### PR TITLE
fix(core): require.resolve(m/package.json) is not guarunteed to work for modern module format

### DIFF
--- a/e2e/cli/src/cli.test.ts
+++ b/e2e/cli/src/cli.test.ts
@@ -166,6 +166,7 @@ describe('migrate', () => {
       `./node_modules/migrate-parent-package/package.json`,
       JSON.stringify({
         version: '1.0.0',
+        name: 'migrate-parent-package',
         'nx-migrations': './migrations.json',
       })
     );
@@ -211,6 +212,7 @@ describe('migrate', () => {
     updateFile(
       `./node_modules/migrate-child-package/package.json`,
       JSON.stringify({
+        name: 'migrate-child-package',
         version: '1.0.0',
       })
     );

--- a/packages/angular/src/executors/file-server/file-server.impl.ts
+++ b/packages/angular/src/executors/file-server/file-server.impl.ts
@@ -11,6 +11,7 @@ import { Schema } from './schema';
 import { watch } from 'chokidar';
 import { platform } from 'os';
 import { resolve } from 'path';
+import { readModulePackageJson } from 'nx/src/utils/package-json';
 
 // platform specific command name
 const pmCmd = platform() === 'win32' ? `npx.cmd` : 'npx';
@@ -153,7 +154,7 @@ export default async function* fileServerExecutor(
   const outputPath = getBuildTargetOutputPath(options, context);
   const args = getHttpServerArgs(options);
 
-  const pathToHttpServerPkgJson = require.resolve('http-server/package.json');
+  const pathToHttpServerPkgJson = readModulePackageJson('http-server').path;
   const pathToHttpServerBin = readJsonFile(pathToHttpServerPkgJson).bin[
     'http-server'
   ];

--- a/packages/angular/src/executors/file-server/file-server.impl.ts
+++ b/packages/angular/src/executors/file-server/file-server.impl.ts
@@ -154,10 +154,9 @@ export default async function* fileServerExecutor(
   const outputPath = getBuildTargetOutputPath(options, context);
   const args = getHttpServerArgs(options);
 
-  const pathToHttpServerPkgJson = readModulePackageJson('http-server').path;
-  const pathToHttpServerBin = readJsonFile(pathToHttpServerPkgJson).bin[
-    'http-server'
-  ];
+  const { path: pathToHttpServerPkgJson, packageJson } =
+    readModulePackageJson('http-server');
+  const pathToHttpServerBin = packageJson.bin['http-server'];
   const pathToHttpServer = resolve(
     pathToHttpServerPkgJson.replace('package.json', ''),
     pathToHttpServerBin

--- a/packages/angular/src/generators/ng-add/utilities/workspace.ts
+++ b/packages/angular/src/generators/ng-add/utilities/workspace.ts
@@ -16,6 +16,7 @@ import { resolveUserExistingPrettierConfig } from '@nrwl/workspace/src/utilities
 import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
 import { prettierVersion } from '@nrwl/workspace/src/utils/versions';
 import { readFileSync } from 'fs';
+import { readModulePackageJson } from 'nx/src/utils/package-json';
 import { dirname, join } from 'path';
 import { angularDevkitVersion, nxVersion } from '../../../utils/versions';
 import { GeneratorOptions } from '../schema';
@@ -82,7 +83,7 @@ export function createNxJson(
 }
 
 export function decorateAngularCli(tree: Tree): void {
-  const nrwlWorkspacePath = require.resolve('@nrwl/workspace/package.json');
+  const nrwlWorkspacePath = readModulePackageJson('@nrwl/workspace').path;
   const decorateCli = readFileSync(
     join(
       dirname(nrwlWorkspacePath),

--- a/packages/angular/src/utils/mfe/mfe-webpack.ts
+++ b/packages/angular/src/utils/mfe/mfe-webpack.ts
@@ -9,6 +9,7 @@ import {
   readTsConfig,
 } from '@nrwl/workspace/src/utilities/typescript';
 import { existsSync, lstatSync, readdirSync } from 'fs';
+import { readModulePackageJson } from 'nx/src/utils/package-json';
 import { dirname, join, normalize, relative } from 'path';
 import { ParsedCommandLine } from 'typescript';
 import { NormalModuleReplacementPlugin } from 'webpack';
@@ -154,9 +155,7 @@ function collectPackageSecondaryEntryPoints(
   let pathToPackage: string;
   let packageJsonPath: string;
   try {
-    packageJsonPath = require.resolve(`${pkgName}/package.json`, {
-      paths: [workspaceRoot],
-    });
+    const packageJsonPath = readModulePackageJson(pkgName).path;
     pathToPackage = dirname(packageJsonPath);
   } catch {
     // the package.json might not resolve if the package has the "exports"

--- a/packages/angular/src/utils/mfe/mfe-webpack.ts
+++ b/packages/angular/src/utils/mfe/mfe-webpack.ts
@@ -9,7 +9,7 @@ import {
   readTsConfig,
 } from '@nrwl/workspace/src/utilities/typescript';
 import { existsSync, lstatSync, readdirSync } from 'fs';
-import { readModulePackageJson } from 'nx/src/utils/package-json';
+import { PackageJson, readModulePackageJson } from 'nx/src/utils/package-json';
 import { dirname, join, normalize, relative } from 'path';
 import { ParsedCommandLine } from 'typescript';
 import { NormalModuleReplacementPlugin } from 'webpack';
@@ -154,8 +154,9 @@ function collectPackageSecondaryEntryPoints(
 ): void {
   let pathToPackage: string;
   let packageJsonPath: string;
+  let packageJson: PackageJson;
   try {
-    const packageJsonPath = readModulePackageJson(pkgName).path;
+    ({ path: packageJsonPath, packageJson } = readModulePackageJson(pkgName));
     pathToPackage = dirname(packageJsonPath);
   } catch {
     // the package.json might not resolve if the package has the "exports"
@@ -167,9 +168,10 @@ function collectPackageSecondaryEntryPoints(
       // might not exist if it's nested in another package, just return here
       return;
     }
+    packageJson = readJsonFile(packageJsonPath);
   }
 
-  const { exports } = readJsonFile(packageJsonPath);
+  const { exports } = packageJson;
   const subDirs = getNonNodeModulesSubDirs(pathToPackage);
   recursivelyCollectSecondaryEntryPointsFromDirectory(
     pkgName,

--- a/packages/make-angular-cli-faster/src/utilities/migration.ts
+++ b/packages/make-angular-cli-faster/src/utilities/migration.ts
@@ -6,6 +6,7 @@ import {
 } from '@nrwl/devkit';
 import { execSync } from 'child_process';
 import { prompt } from 'enquirer';
+import { readModulePackageJson } from 'nx/src/utils/package-json';
 import { lt, lte, major, satisfies } from 'semver';
 import { resolvePackageVersion } from './package-manager';
 import { MigrationDefinition } from './types';
@@ -177,10 +178,7 @@ async function promptForVersion(version: string): Promise<boolean> {
 }
 
 function getInstalledAngularVersion(): string {
-  const packageJsonPath = require.resolve('@angular/core/package.json', {
-    paths: [workspaceRoot],
-  });
-  return readJsonFile(packageJsonPath).version;
+  return readModulePackageJson('@angular/core').packageJson.version;
 }
 
 async function normalizeVersion(version: string): Promise<string> {

--- a/packages/nx/src/adapter/ngcli-adapter.ts
+++ b/packages/nx/src/adapter/ngcli-adapter.ts
@@ -39,7 +39,7 @@ import {
   ProjectsConfigurations,
 } from '../config/workspace-json-project-json';
 import { readNxJson } from '../generators/utils/project-configuration';
-import { readModulePackageJson } from '../utils/package-json';
+import { PackageJson, readModulePackageJson } from '../utils/package-json';
 
 export async function scheduleTarget(
   root: string,
@@ -897,18 +897,10 @@ function resolveMigrationsCollection(name: string): string {
   if (extname(name)) {
     collectionPath = require.resolve(name);
   } else {
-    let packageJsonPath;
-    try {
-      packageJsonPath = readModulePackageJson(name, [process.cwd()]).path;
-    } catch (e) {
-      // workaround for a bug in node 12
-      packageJsonPath = require.resolve(
-        join(process.cwd(), name, 'package.json')
-      );
-    }
+    const { path: packageJsonPath, packageJson } = readModulePackageJson(name, [
+      process.cwd(),
+    ]);
 
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const packageJson = require(packageJsonPath);
     let pkgJsonSchematics =
       packageJson['nx-migrations'] ?? packageJson['ng-update'];
     if (!pkgJsonSchematics) {

--- a/packages/nx/src/adapter/ngcli-adapter.ts
+++ b/packages/nx/src/adapter/ngcli-adapter.ts
@@ -39,6 +39,7 @@ import {
   ProjectsConfigurations,
 } from '../config/workspace-json-project-json';
 import { readNxJson } from '../generators/utils/project-configuration';
+import { readModulePackageJson } from '../utils/package-json';
 
 export async function scheduleTarget(
   root: string,
@@ -898,9 +899,7 @@ function resolveMigrationsCollection(name: string): string {
   } else {
     let packageJsonPath;
     try {
-      packageJsonPath = require.resolve(join(name, 'package.json'), {
-        paths: [process.cwd()],
-      });
+      packageJsonPath = readModulePackageJson(name, [process.cwd()]).path;
     } catch (e) {
       // workaround for a bug in node 12
       packageJsonPath = require.resolve(

--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -21,6 +21,7 @@ import {
   PackageGroup,
   PackageJson,
   readNxMigrateConfig,
+  readModulePackageJson,
 } from '../utils/package-json';
 import {
   createTempNpmDirectory,
@@ -467,10 +468,8 @@ function versions(root: string, from: Record<string, string>) {
       }
 
       if (!cache[packageName]) {
-        const packageJsonPath = require.resolve(`${packageName}/package.json`, {
-          paths: [root],
-        });
-        cache[packageName] = readJsonFile(packageJsonPath).version;
+        const { packageJson } = readModulePackageJson(packageName, [root]);
+        cache[packageName] = packageJson.version;
       }
 
       return cache[packageName];
@@ -687,11 +686,11 @@ function readPackageMigrationConfig(
   packageName: string,
   dir: string
 ): PackageMigrationConfig {
-  const packageJsonPath = require.resolve(`${packageName}/package.json`, {
-    paths: [dir],
-  });
+  const { path: packageJsonPath, packageJson: json } = readModulePackageJson(
+    packageName,
+    [dir]
+  );
 
-  const json = readJsonFile<PackageJson>(packageJsonPath);
   const migrationConfigOrFile = json['nx-migrations'] || json['ng-update'];
 
   if (!migrationConfigOrFile) {

--- a/packages/nx/src/command-line/report.ts
+++ b/packages/nx/src/command-line/report.ts
@@ -7,6 +7,7 @@ import {
   getPackageManagerVersion,
 } from '../utils/package-manager';
 import { readJsonFile } from '../utils/fileutils';
+import { PackageJson, readModulePackageJson } from '../utils/package-json';
 
 export const packagesWeCareAbout = [
   'nx',
@@ -77,19 +78,16 @@ export function reportHandler() {
   });
 }
 
-export function readPackageJson(p: string) {
+export function readPackageJson(p: string): PackageJson | null {
   try {
-    const packageJsonPath = require.resolve(`${p}/package.json`, {
-      paths: [workspaceRoot],
-    });
-    return readJsonFile(packageJsonPath);
+    return readModulePackageJson(p).packageJson;
   } catch {
-    return {};
+    return null;
   }
 }
 
 export function readPackageVersion(p: string): string {
-  return readPackageJson(p).version || 'Not Found';
+  return readPackageJson(p)?.version || 'Not Found';
 }
 
 export function findInstalledCommunityPlugins(): {
@@ -116,7 +114,8 @@ export function findInstalledCommunityPlugins(): {
         return arr;
       }
       try {
-        const depPackageJson = readPackageJson(nextDep);
+        const depPackageJson: Partial<PackageJson> =
+          readPackageJson(nextDep) || {};
         if (
           [
             'ng-update',

--- a/packages/nx/src/utils/nx-plugin.ts
+++ b/packages/nx/src/utils/nx-plugin.ts
@@ -6,7 +6,7 @@ import { Workspaces } from '../config/workspaces';
 
 import { workspaceRoot } from './workspace-root';
 import { readJsonFile } from '../utils/fileutils';
-import { PackageJson } from './package-json';
+import { PackageJson, readModulePackageJson } from './package-json';
 import { registerTsProject } from './register';
 import {
   ProjectConfiguration,
@@ -117,11 +117,12 @@ export function readPluginPackageJson(
   path: string;
   json: PackageJson;
 } {
-  let packageJsonPath: string;
   try {
-    packageJsonPath = require.resolve(`${pluginName}/package.json`, {
-      paths,
-    });
+    const result = readModulePackageJson(pluginName, paths);
+    return {
+      json: result.packageJson,
+      path: result.path,
+    };
   } catch (e) {
     if (e.code === 'MODULE_NOT_FOUND') {
       const localPluginPath = resolveLocalNxPlugin(pluginName);
@@ -138,7 +139,6 @@ export function readPluginPackageJson(
     }
     throw e;
   }
-  return { json: readJsonFile(packageJsonPath), path: packageJsonPath };
 }
 
 /**

--- a/packages/nx/src/utils/package-json.spec.ts
+++ b/packages/nx/src/utils/package-json.spec.ts
@@ -1,6 +1,11 @@
+import { join } from 'path';
+import { workspaceRoot } from './app-root';
+import { readJsonFile } from './fileutils';
 import {
   buildTargetFromScript,
+  PackageJson,
   PackageJsonTargetConfiguration,
+  readModulePackageJson,
 } from './package-json';
 
 describe('buildTargetFromScript', () => {
@@ -36,5 +41,20 @@ describe('buildTargetFromScript', () => {
 
     expect(target.options.script).toEqual('build');
     expect(target.executor).toEqual('nx:run-script');
+  });
+});
+
+const rootPackageJson: PackageJson = readJsonFile(
+  join(workspaceRoot, 'package.json')
+);
+
+const dependencies = [
+  ...Object.keys(rootPackageJson.dependencies),
+  ...Object.keys(rootPackageJson.devDependencies),
+];
+
+describe('readModulePackageJson', () => {
+  it.each(dependencies)(`should be able to find %s`, (s) => {
+    expect(() => readModulePackageJson(s)).not.toThrow();
   });
 });

--- a/packages/nx/src/utils/package-json.spec.ts
+++ b/packages/nx/src/utils/package-json.spec.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { workspaceRoot } from './app-root';
+import { workspaceRoot } from './workspace-root';
 import { readJsonFile } from './fileutils';
 import {
   buildTargetFromScript,

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -1,4 +1,8 @@
+import { existsSync } from 'fs';
+import { dirname, join } from 'path';
 import { TargetConfiguration } from '../config/workspace-json-project-json';
+import { workspaceRoot } from './app-root';
+import { readJsonFile } from './fileutils';
 
 export type PackageJsonTargetConfiguration = Omit<
   TargetConfiguration,
@@ -94,5 +98,44 @@ export function buildTargetFromScript(
       ...(nxTargetConfiguration.options || {}),
       script,
     },
+  };
+}
+
+export function readModulePackageJson(
+  moduleSpecifier: string,
+  requirePaths = [workspaceRoot]
+): {
+  packageJson: PackageJson;
+  path: string;
+} {
+  let packageJsonPath: string;
+  try {
+    packageJsonPath = require.resolve(`${moduleSpecifier}/package.json`, {
+      paths: requirePaths,
+    });
+  } catch {
+    const entryPoint = require.resolve(moduleSpecifier, {
+      paths: requirePaths,
+    });
+    let moduleRootPath = dirname(entryPoint);
+    packageJsonPath = join(moduleRootPath, 'package.json');
+
+    while (!existsSync(packageJsonPath)) {
+      moduleRootPath = dirname(moduleRootPath);
+      packageJsonPath = join(moduleRootPath, 'package.json');
+    }
+  }
+
+  const packageJson = readJsonFile(packageJsonPath);
+
+  if (!(packageJson.name === moduleSpecifier)) {
+    throw new Error(
+      `Found module ${packageJson.name} while trying to locate ${moduleSpecifier}/package.json`
+    );
+  }
+
+  return {
+    packageJson,
+    path: packageJsonPath,
   };
 }

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -1,8 +1,8 @@
 import { existsSync } from 'fs';
 import { dirname, join } from 'path';
 import { TargetConfiguration } from '../config/workspace-json-project-json';
-import { workspaceRoot } from './app-root';
 import { readJsonFile } from './fileutils';
+import { workspaceRoot } from './workspace-root';
 
 export type PackageJsonTargetConfiguration = Omit<
   TargetConfiguration,
@@ -40,6 +40,7 @@ export interface PackageJson {
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
+  bin?: Record<string, string>;
   workspaces?:
     | string[]
     | {
@@ -128,7 +129,7 @@ export function readModulePackageJson(
 
   const packageJson = readJsonFile(packageJsonPath);
 
-  if (!(packageJson.name === moduleSpecifier)) {
+  if (packageJson.name !== moduleSpecifier) {
     throw new Error(
       `Found module ${packageJson.name} while trying to locate ${moduleSpecifier}/package.json`
     );

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -5,7 +5,7 @@ import { dirname, join } from 'path';
 import { dirSync } from 'tmp';
 import { promisify } from 'util';
 import { readJsonFile, writeJsonFile } from './fileutils';
-import { PackageJson } from './package-json';
+import { PackageJson, readModulePackageJson } from './package-json';
 import { gte, lt } from 'semver';
 
 const execAsync = promisify(exec);
@@ -198,11 +198,9 @@ export async function resolvePackageVersionUsingInstallation(
     const pmc = getPackageManagerCommand();
     await execAsync(`${pmc.add} ${packageName}@${version}`, { cwd: dir });
 
-    const packageJsonPath = require.resolve(`${packageName}/package.json`, {
-      paths: [dir],
-    });
+    const { packageJson } = readModulePackageJson(packageName, [dir]);
 
-    return readJsonFile<PackageJson>(packageJsonPath).version;
+    return packageJson.version;
   } finally {
     await cleanup();
   }

--- a/packages/nx/src/utils/plugins/installed-plugins.ts
+++ b/packages/nx/src/utils/plugins/installed-plugins.ts
@@ -4,6 +4,7 @@ import type { CommunityPlugin, CorePlugin, PluginCapabilities } from './models';
 import { getPluginCapabilities } from './plugin-capabilities';
 import { hasElements } from './shared';
 import { readJsonFile } from '../fileutils';
+import { readModulePackageJson } from '../package-json';
 
 export function getInstalledPluginsFromPackageJson(
   workspaceRoot: string,
@@ -25,7 +26,7 @@ export function getInstalledPluginsFromPackageJson(
         try {
           // Check for `package.json` existence instead of requiring the module itself
           // because malformed entries like `main`, may throw false exceptions.
-          require.resolve(`${name}/package.json`, { paths: [workspaceRoot] });
+          readModulePackageJson(name, [workspaceRoot]);
           return true;
         } catch {
           return false;

--- a/packages/nx/src/utils/plugins/plugin-capabilities.ts
+++ b/packages/nx/src/utils/plugins/plugin-capabilities.ts
@@ -6,6 +6,7 @@ import type { PluginCapabilities } from './models';
 import { hasElements } from './shared';
 import { readJsonFile } from '../fileutils';
 import { getPackageManagerCommand } from '../package-manager';
+import { readModulePackageJson } from '../package-json';
 
 function tryGetCollection<T extends object>(
   packageJsonPath: string,
@@ -29,10 +30,8 @@ export function getPluginCapabilities(
   pluginName: string
 ): PluginCapabilities | null {
   try {
-    const packageJsonPath = require.resolve(`${pluginName}/package.json`, {
-      paths: [workspaceRoot],
-    });
-    const packageJson = readJsonFile(packageJsonPath);
+    const { packageJson, path: packageJsonPath } =
+      readModulePackageJson(pluginName);
     return {
       name: pluginName,
       generators:

--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -12,6 +12,7 @@ import { Schema } from './schema';
 import { watch } from 'chokidar';
 import { platform } from 'os';
 import { resolve } from 'path';
+import { readModulePackageJson } from 'nx/src/utils/package-json';
 
 // platform specific command name
 const pmCmd = platform() === 'win32' ? `npx.cmd` : 'npx';
@@ -153,7 +154,7 @@ export default async function* fileServerExecutor(
   const outputPath = getBuildTargetOutputPath(options, context);
   const args = getHttpServerArgs(options);
 
-  const pathToHttpServerPkgJson = require.resolve('http-server/package.json');
+  const pathToHttpServerPkgJson = readModulePackageJson('http-server').path;
   const pathToHttpServerBin = readJsonFile(pathToHttpServerPkgJson).bin[
     'http-server'
   ];

--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -154,10 +154,9 @@ export default async function* fileServerExecutor(
   const outputPath = getBuildTargetOutputPath(options, context);
   const args = getHttpServerArgs(options);
 
-  const pathToHttpServerPkgJson = readModulePackageJson('http-server').path;
-  const pathToHttpServerBin = readJsonFile(pathToHttpServerPkgJson).bin[
-    'http-server'
-  ];
+  const { path: pathToHttpServerPkgJson, packageJson } =
+    readModulePackageJson('http-server');
+  const pathToHttpServerBin = packageJson.bin['http-server'];
   const pathToHttpServer = resolve(
     pathToHttpServerPkgJson.replace('package.json', ''),
     pathToHttpServerBin

--- a/packages/workspace/src/utilities/plugins/installed-plugins.ts
+++ b/packages/workspace/src/utilities/plugins/installed-plugins.ts
@@ -4,6 +4,7 @@ import { output } from '../output';
 import type { CommunityPlugin, CorePlugin, PluginCapabilities } from './models';
 import { getPluginCapabilities } from './plugin-capabilities';
 import { hasElements } from './shared';
+import { readModulePackageJson } from 'nx/src/utils/package-json';
 
 export function getInstalledPluginsFromPackageJson(
   workspaceRoot: string,
@@ -25,7 +26,7 @@ export function getInstalledPluginsFromPackageJson(
         try {
           // Check for `package.json` existence instead of requiring the module itself
           // because malformed entries like `main`, may throw false exceptions.
-          require.resolve(`${name}/package.json`, { paths: [workspaceRoot] });
+          readModulePackageJson(name);
           return true;
         } catch {
           return false;

--- a/packages/workspace/src/utilities/plugins/plugin-capabilities.ts
+++ b/packages/workspace/src/utilities/plugins/plugin-capabilities.ts
@@ -1,6 +1,7 @@
 import { getPackageManagerCommand, readJsonFile } from '@nrwl/devkit';
 import { workspaceRoot } from '@nrwl/devkit';
 import * as chalk from 'chalk';
+import { readModulePackageJson } from 'nx/src/utils/package-json';
 import { dirname, join } from 'path';
 import { output } from '../output';
 import type { PluginCapabilities } from './models';
@@ -28,10 +29,8 @@ export function getPluginCapabilities(
   pluginName: string
 ): PluginCapabilities | null {
   try {
-    const packageJsonPath = require.resolve(`${pluginName}/package.json`, {
-      paths: [workspaceRoot],
-    });
-    const packageJson = readJsonFile(packageJsonPath);
+    const { path: packageJsonPath, packageJson } =
+      readModulePackageJson(pluginName);
     return {
       name: pluginName,
       generators:

--- a/scripts/patched-jest-resolver.js
+++ b/scripts/patched-jest-resolver.js
@@ -62,7 +62,8 @@ module.exports = function (path, options) {
   }
   // Try to use the defaultResolver
   try {
-    if (path.startsWith('@nrwl/')) throw new Error('custom resolution');
+    if (path.startsWith('@nrwl/') && !path.startsWith('@nrwl/nx-cloud'))
+      throw new Error('custom resolution');
     if (path.startsWith('nx/')) throw new Error('custom resolution');
 
     if (path.indexOf('@nrwl/workspace') > -1) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Packages that use `exports` in `package.json` cause errors during migration

## Expected Behavior
We are able to resolve the package.json location regardless of module format

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
