### PR TITLE
chore(repo): update yarn to 1.22.19

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,2 +1,2 @@
 --ignore-engines true
-yarnPath .yarn/releases/yarn-1.22.17.cjs
+yarnPath .yarn/releases/yarn-1.22.19.cjs


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
the repo uses yarn 1.22.17. Every install prints the warning: 
```warning Your current version of Yarn is out of date. The latest version is "1.22.19", while you're on "1.22.17".```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
the repo should use v1.22.19 of yarn. Updated with `yarn policies set-version latest`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
