### PR TITLE
fix(core): handle falsy error in params.ts#handleErrors

### DIFF
--- a/packages/nx/src/utils/params.ts
+++ b/packages/nx/src/utils/params.ts
@@ -72,6 +72,8 @@ export async function handleErrors(isVerbose: boolean, fn: Function) {
   try {
     return await fn();
   } catch (err) {
+    err ??= new Error('Unknown error caught');
+
     if (err.constructor.name === 'UnsuccessfulWorkflowExecution') {
       logger.error('The generator workflow failed. See above.');
     } else if (err.message) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

This happens to me when I run a node application and some error happens. The documented log I have is from when I `Ctrl+C`ed the app, but I've seen this before many times.

```
$ nx serve cli --watch=false

> nx run cli:serve --watch=false

chunk (runtime: main) main.js (main) 65.6 KiB [entry] [rendered]
chunk (runtime: worker) worker.js (worker) 64.2 KiB [entry] [rendered]
webpack compiled successfully (07835d0c74e6b24a)
Starting inspector on localhost:9229 failed: address already in use
[Nest] 51175  - 05/29/2022, 6:43:52 PM     LOG [NestFactory] Starting Nest application...
[Nest] 51175  - 05/29/2022, 6:43:52 PM     LOG [InstanceLoader] MongooseModule dependencies initialized +47ms
[Nest] 51175  - 05/29/2022, 6:44:22 PM   ERROR [MongooseModule] Unable to connect to the database. Retrying (1)...
^C
Unexpected error                                                                                               
TypeError: Cannot read properties of undefined (reading 'constructor')
    at /path/to/project/node_modules/nx/src/utils/params.js:12:21
    at Generator.throw (<anonymous>)
    at rejected (/path/to/project/node_modules/nx/node_modules/tslib/tslib.js:116:69)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

There shouldn't be any uncaught errors within NX's internals
