### PR TITLE
cleanup(misc): speed up add-nx-to-monorepo by removing deps and cleanup

### DIFF
--- a/packages/add-nx-to-monorepo/package.json
+++ b/packages/add-nx-to-monorepo/package.json
@@ -27,8 +27,6 @@
   },
   "homepage": "https://nx.dev",
   "dependencies": {
-    "@nrwl/devkit": "file:../devkit",
-    "@nrwl/workspace": "file:../workspace",
     "enquirer": "~2.3.6",
     "ignore": "^5.0.4",
     "nx": "file:../nx",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`add-nx-to-monorepo` depends on `@nrwl/workspace`, `@nrwl/devkit` and `nx`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
All used functions are from `nx` so the other two packages can be removed. Also a lot of code is duplicated in `add-nx-to-monorepo` and could be used from `nx` instead. Also in the current implementation the check for the package manager gets executed multiple times instead of one time.  

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
