### PR TITLE
fix(core): ensure pnpm v7 install when peer deps are missing

### DIFF
--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -298,7 +298,7 @@ export function newProject({
       if (isCI && packageManager === 'pnpm') {
         updateFile(
           '.npmrc',
-          'prefer-frozen-lockfile=false\nstrict-peer-dependencies=false'
+          'prefer-frozen-lockfile=false\nstrict-peer-dependencies=false\nauto-install-peers=true'
         );
       }
 

--- a/packages/workspace/src/generators/workspace/workspace.ts
+++ b/packages/workspace/src/generators/workspace/workspace.ts
@@ -89,6 +89,14 @@ function createPrettierrc(host: Tree, options: Schema) {
   );
 }
 
+// ensure that pnpm install add all the missing peer deps
+function createNpmrc(host: Tree, options: Schema) {
+  host.write(
+    join(options.directory, '.npmrc'),
+    'strict-peer-dependencies=false\nauto-install-peers=true\n'
+  );
+}
+
 function formatWorkspaceJson(host: Tree, options: Schema) {
   const path = join(
     options.directory,
@@ -145,6 +153,9 @@ export async function workspaceGenerator(host: Tree, options: Schema) {
   createPrettierrc(host, options);
   if (options.cli === 'angular') {
     decorateAngularClI(host, options);
+  }
+  if (options.packageManager === 'pnpm') {
+    createNpmrc(host, options);
   }
   setPresetProperty(host, options);
   addNpmScripts(host, options);


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Create-nx-workspace on pnpm v7 fails on several presets (react) due to string peer dependency check

## Expected Behavior
Create-nx-workspace on pnpm v7 should succeed

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #10434
