### PR TITLE
fix(angular): add missing angular packages to the v14 migration

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -1119,8 +1119,8 @@
         }
       }
     },
-    "14.2.0": {
-      "version": "14.2.0-beta.0",
+    "14.2.0-beta.1": {
+      "version": "14.2.0-beta.1",
       "packages": {
         "@angular-devkit/architect": {
           "version": "~0.1400.0-rc.2",
@@ -1146,7 +1146,67 @@
           "version": "~14.0.0-rc.2",
           "alwaysAddToPackageJson": true
         },
+        "@angular/common": {
+          "version": "~14.0.0-rc.2",
+          "alwaysAddToPackageJson": false
+        },
+        "@angular/forms": {
+          "version": "~14.0.0-rc.2",
+          "alwaysAddToPackageJson": false
+        },
+        "@angular/elements": {
+          "version": "~14.0.0-rc.2",
+          "alwaysAddToPackageJson": false
+        },
+        "@angular/compiler": {
+          "version": "~14.0.0-rc.2",
+          "alwaysAddToPackageJson": false
+        },
+        "@angular/compiler-cli": {
+          "version": "~14.0.0-rc.2",
+          "alwaysAddToPackageJson": false
+        },
+        "@angular/localize": {
+          "version": "~14.0.0-rc.2",
+          "alwaysAddToPackageJson": false
+        },
+        "@angular/platform-browser": {
+          "version": "~14.0.0-rc.2",
+          "alwaysAddToPackageJson": false
+        },
+        "@angular/platform-browser-dynamic": {
+          "version": "~14.0.0-rc.2",
+          "alwaysAddToPackageJson": false
+        },
+        "@angular/platform-server": {
+          "version": "~14.0.0-rc.2",
+          "alwaysAddToPackageJson": false
+        },
+        "@angular/router": {
+          "version": "~14.0.0-rc.2",
+          "alwaysAddToPackageJson": false
+        },
+        "@angular/upgrade": {
+          "version": "~14.0.0-rc.2",
+          "alwaysAddToPackageJson": false
+        },
+        "@angular/language-service": {
+          "version": "~14.0.0-rc.2",
+          "alwaysAddToPackageJson": false
+        },
+        "@angular/animations": {
+          "version": "~14.0.0-rc.2",
+          "alwaysAddToPackageJson": false
+        },
+        "@angular/service-worker": {
+          "version": "~14.0.0-rc.2",
+          "alwaysAddToPackageJson": false
+        },
         "@angular/material": {
+          "version": "~14.0.0-rc.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@angular/cdk": {
           "version": "~14.0.0-rc.1",
           "alwaysAddToPackageJson": false
         },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Workspaces in certain versions of Nx (e.g. `v13.9.6`) won't install the latest `nx` package to run the migrations and therefore, `packageGroup` is not handled. This will also be the case for workspaces in older versions where migrations are run with `NX_MIGRATE_USE_LOCAL=true`.

The migrations file for the `@nrwl/angular` plugin doesn't contain all the Angular packages for v14 because it's relying on the handling of `packageGroup` by the migrator tool. Because of the explained above, this doesn't work well in certain workspaces.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The migration for Angular v14 should work correctly regardless of the migrator tool version being used.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
