### PR TITLE
feat(angular): support tailwind.config.cjs as valid config file in library executors

### DIFF
--- a/packages/angular/src/executors/utilities/tailwindcss.ts
+++ b/packages/angular/src/executors/utilities/tailwindcss.ts
@@ -25,15 +25,7 @@ export function getTailwindSetup(
   let tailwindConfigPath = tailwindConfig;
 
   if (!tailwindConfigPath) {
-    // Try to find TailwindCSS configuration file in the project or workspace root.
-    const tailwindConfigFile = 'tailwind.config.js';
-    for (const path of [basePath, workspaceRoot]) {
-      const fullPath = join(path, tailwindConfigFile);
-      if (existsSync(fullPath)) {
-        tailwindConfigPath = fullPath;
-        break;
-      }
-    }
+    tailwindConfigPath = getTailwindConfigPath(basePath, workspaceRoot);
   }
 
   // Only load Tailwind CSS plugin if configuration file was found.
@@ -63,6 +55,25 @@ export function getTailwindSetup(
   }
 
   return { tailwindConfigPath, tailwindPackagePath };
+}
+
+function getTailwindConfigPath(
+  projectRoot: string,
+  workspaceRoot: string
+): string | undefined {
+  // valid tailwind config files https://github.com/tailwindlabs/tailwindcss/blob/master/src/util/resolveConfigPath.js#L46
+  const tailwindConfigFiles = ['tailwind.config.js', 'tailwind.config.cjs'];
+
+  for (const basePath of [projectRoot, workspaceRoot]) {
+    for (const configFile of tailwindConfigFiles) {
+      const fullPath = join(basePath, configFile);
+      if (existsSync(fullPath)) {
+        return fullPath;
+      }
+    }
+  }
+
+  return undefined;
 }
 
 export function getTailwindPostCssPlugins(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The library executors don't pick up the Tailwind CSS configuration file if named as `tailwind.config.cjs` which is supported by Tailwind CSS (https://github.com/tailwindlabs/tailwindcss/blob/master/src/util/resolveConfigPath.js#L46). 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The library executors should auto-detect a `tailwind.config.cjs` file when used.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
