### PR TITLE
fix(nextjs): update e2e test case to cover env variables exported from libraries

### DIFF
--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -144,9 +144,12 @@ describe('Next.js Applications', () => {
 
   it('should be able to serve with a proxy configuration', async () => {
     const appName = uniq('app');
+    const jsLib = uniq('tslib');
+
     const port = 4201;
 
     runCLI(`generate @nrwl/next:app ${appName}`);
+    runCLI(`generate @nrwl/js:lib ${jsLib} --no-interactive`);
 
     const proxyConf = {
       '/external-api': {
@@ -160,13 +163,23 @@ describe('Next.js Applications', () => {
     updateFile('.env.local', 'NX_CUSTOM_VAR=test value from a file');
 
     updateFile(
+      `libs/${jsLib}/src/lib/${jsLib}.ts`,
+      `
+          export function testFn(): string {
+            return process.env.NX_CUSTOM_VAR;
+          };
+          `
+    );
+
+    updateFile(
       `apps/${appName}/pages/index.tsx`,
       `
         import React from 'react';
+        import { testFn } from '@${proj}/${jsLib}';
 
         export const Index = ({ greeting }: any) => {
           return (
-            <p>{process.env.NX_CUSTOM_VAR}</p>
+            <p>{testFn()}</p>
           );
         };
         export default Index;


### PR DESCRIPTION
Add a test case for libraries which exports `env` vars

ISSUES CLOSED: #9633

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
