### PR TITLE
Improve `@nrwl/next:server` `customServerPath` docs

### DIFF
--- a/packages/next/src/executors/server/schema.json
+++ b/packages/next/src/executors/server/schema.json
@@ -30,7 +30,7 @@
     },
     "customServerPath": {
       "type": "string",
-      "description": "Use a custom server script."
+      "description": "Path to a file that runs a custom server script. It should export a runner function `(nextApp, settings) => Promise<void>` as default"
     },
     "hostname": {
       "type": "string",


### PR DESCRIPTION
This adds more details on what is the `customServerPath` option, and how to use it.

Some of my problems were:
1) I created a server.js, that did not export a function, instead, it was a file that was run: `node server.js`. It showed an error that "customServer is not a function"
2) I changed server.js to export a default function. Now it did run, but it still didn't work as expected
3) I noticed a [specific comment in an specific issue](https://github.com/nrwl/nx/issues/1933#issuecomment-566738495) that showed what was the function signature, and an example on how to use it, which fixed all errors

Because the issue has a public solution but it is not documented, I added it to the documentation