### PR TITLE
feat(storybook): Custom .babelrc in Storybook

### DIFF
--- a/docs/generated/packages/storybook.json
+++ b/docs/generated/packages/storybook.json
@@ -307,6 +307,10 @@
                 "type": "string",
                 "description": "Path to storybook preview.js file."
               },
+              "babelrcPath": {
+                "type": "string",
+                "description": "Path to storybook .babelrc file."
+              },
               "srcRoot": {
                 "type": "string",
                 "description": "Project source path."

--- a/packages/react/plugins/storybook/index.ts
+++ b/packages/react/plugins/storybook/index.ts
@@ -147,31 +147,36 @@ export const webpack = async (
       '11.0.0'
     )
   ) {
-    const babelrc = readJsonFile(
-      joinPathFragments(options.configDir, '../', '.babelrc')
-    );
-    if (babelrc?.plugins?.includes('@emotion/babel-plugin')) {
-      resolvedEmotionAliases = {
-        resolve: {
-          alias: {
-            '@emotion/core': joinPathFragments(
-              workspaceRoot,
-              'node_modules',
-              '@emotion/react'
-            ),
-            '@emotion/styled': joinPathFragments(
-              workspaceRoot,
-              'node_modules',
-              '@emotion/styled'
-            ),
-            'emotion-theming': joinPathFragments(
-              workspaceRoot,
-              'node_modules',
-              '@emotion/react'
-            ),
+    try {
+      const babelrc = readJsonFile(
+        options.babelrcPath ||
+          joinPathFragments(options.configDir, '../', '.babelrc')
+      );
+      if (babelrc?.plugins?.includes('@emotion/babel-plugin')) {
+        resolvedEmotionAliases = {
+          resolve: {
+            alias: {
+              '@emotion/core': joinPathFragments(
+                workspaceRoot,
+                'node_modules',
+                '@emotion/react'
+              ),
+              '@emotion/styled': joinPathFragments(
+                workspaceRoot,
+                'node_modules',
+                '@emotion/styled'
+              ),
+              'emotion-theming': joinPathFragments(
+                workspaceRoot,
+                'node_modules',
+                '@emotion/react'
+              ),
+            },
           },
-        },
-      };
+        };
+      }
+    } catch (error) {
+      // silently ignore if the .babelrc doesn't exist
     }
   }
   return mergeWebpack.merge(

--- a/packages/storybook/src/executors/storybook/schema.json
+++ b/packages/storybook/src/executors/storybook/schema.json
@@ -76,6 +76,10 @@
           "type": "string",
           "description": "Path to storybook preview.js file."
         },
+        "babelrcPath": {
+          "type": "string",
+          "description": "Path to storybook .babelrc file."
+        },
         "srcRoot": {
           "type": "string",
           "description": "Project source path."


### PR DESCRIPTION
## Current Behavior
As of now the `.babelrc` file is mandatory when using `@nrwl/react/plugins/storybook`. This is due to the `.babelrc` path is hardcoded to be on the root of the package. This causes #9010 as well as #8032. Furthermore, it fails if the file is not found even though it is not strictly necessary (the code injects **optionally** some plugins.

## Expected Behavior
The `.babelrc` path is configurable as well as it does not fail if the file is not found

This way we can either avoid having a file or having a file in `<package>/.storybook/.babelrc` to configure only Storybook and make it more explicit. A side effect is that NextJS projects that have Storybook as well, can now run with `swc`.

## Related Issue(s)
#9010 #8032

Fixes #9010 #8032
