### PR TITLE
fix(angular): do not configure e2e test runner when generating a library

### DIFF
--- a/e2e/angular-core/src/ng-add.test.ts
+++ b/e2e/angular-core/src/ng-add.test.ts
@@ -52,7 +52,9 @@ describe('convert Angular CLI workspace to an Nx workspace', () => {
   }
 
   function addCypress() {
-    runNgAdd('@cypress/schematic', '--e2e-update', 'latest');
+    // TODO(leo): @cypress/schematic latest comes with Cypress 10 support
+    // which we don't support yet in our Cypress plugin.
+    runNgAdd('@cypress/schematic', '--e2e-update', '1.7.0');
   }
 
   function addEsLint() {

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -511,6 +511,21 @@ describe('lib', () => {
         ].prefix
       ).toEqual('custom');
     });
+
+    it('should not install any e2e test runners', async () => {
+      // ACT
+      await runLibraryGeneratorWithOpts({
+        publishable: true,
+        importPath: '@myorg/lib',
+      });
+
+      // ASSERT
+      let { dependencies, devDependencies } = readJson(tree, 'package.json');
+      expect(dependencies.cypress).toBeUndefined();
+      expect(devDependencies.cypress).toBeUndefined();
+      expect(dependencies.protractor).toBeUndefined();
+      expect(devDependencies.protractor).toBeUndefined();
+    });
   });
 
   describe('nested', () => {

--- a/packages/angular/src/generators/library/library.ts
+++ b/packages/angular/src/generators/library/library.ts
@@ -11,6 +11,7 @@ import { jestProjectGenerator } from '@nrwl/jest';
 import { Linter } from '@nrwl/linter';
 import { convertToNxProjectGenerator } from '@nrwl/workspace/generators';
 import init from '../../generators/init/init';
+import { E2eTestRunner } from '../../utils/test-runners';
 import { ngPackagrVersion } from '../../utils/versions';
 import addLintingGenerator from '../add-linting/add-linting';
 import karmaProjectGenerator from '../karma-project/karma-project';
@@ -51,6 +52,7 @@ export async function libraryGenerator(host: Tree, schema: Partial<Schema>) {
   await init(host, {
     ...options,
     skipFormat: true,
+    e2eTestRunner: E2eTestRunner.None,
   });
 
   const runAngularLibrarySchematic = wrapAngularDevkitSchematic(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When generating a library in a workspace where Cypress has not been configured, Cypress is being installed.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Generating a library shouldn't configure e2e test runners.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #10525 
