### PR TITLE
docs(misc): update imports to @nrwl/workspace generators to avoid requiring @angular-devkit/schematics

### DIFF
--- a/docs/shared/generators/composing-generators.md
+++ b/docs/shared/generators/composing-generators.md
@@ -7,7 +7,7 @@ Generators are useful individually, but reusing and composing generators allows 
 Nx Devkit generators can be imported and invoked like any javascript function. They often return a `Promise`, so they can be used with the `await` keyword to mimic synchronous code. Because this is standard javascript, control flow logic can be adjusted with `if` blocks and `for` loops as usual.
 
 ```typescript
-import { libraryGenerator } from '@nrwl/workspace';
+import { libraryGenerator } from '@nrwl/workspace/generators';
 
 export default async function (tree: Tree, schema: any) {
   await libraryGenerator(

--- a/docs/shared/generators/creating-files.md
+++ b/docs/shared/generators/creating-files.md
@@ -41,7 +41,7 @@ import {
   joinPathFragments,
   readProjectConfiguration,
 } from '@nrwl/devkit';
-import { libraryGenerator } from '@nrwl/workspace';
+import { libraryGenerator } from '@nrwl/workspace/generators';
 
 export default async function (tree: Tree, schema: any) {
   await libraryGenerator(tree, { name: schema.name });

--- a/docs/shared/generators/generator-options.md
+++ b/docs/shared/generators/generator-options.md
@@ -15,7 +15,7 @@ Import the TypeScript schema into your generator file and replace the any in you
 
 ```typescript
 import { Tree, formatFiles, installPackagesTask } from '@nrwl/devkit';
-import { libraryGenerator } from '@nrwl/workspace';
+import { libraryGenerator } from '@nrwl/workspace/generators';
 
 export default async function (tree: Tree, schema: GeneratorOptions) {
   await libraryGenerator(tree, { name: `${schema.name}-${schema.type || ''}` });

--- a/docs/shared/generators/workspace-generators.md
+++ b/docs/shared/generators/workspace-generators.md
@@ -35,7 +35,7 @@ The initial generator function creates a library.
 
 ```typescript
 import { Tree, formatFiles, installPackagesTask } from '@nrwl/devkit';
-import { libraryGenerator } from '@nrwl/workspace';
+import { libraryGenerator } from '@nrwl/workspace/generators';
 
 export default async function (tree: Tree, schema: any) {
   await libraryGenerator(tree, { name: schema.name });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Some docs show importing generators from `@nrwl/workspace` instead of `@nrwl/workspace/generators`. The former entry point contains some backward-compatible exports which require the `@angular-devkit/schematics` package to be installed.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Docs should show importing generators from `@nrwl/workspace/generators` to avoid requiring the `@angular-devkit/schematics` package.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #10437 
