### PR TITLE
fix(storybook): optional chain includes

### DIFF
--- a/packages/storybook/src/generators/configuration/util-functions.ts
+++ b/packages/storybook/src/generators/configuration/util-functions.ts
@@ -128,8 +128,8 @@ export function configureTsProjectConfig(
   }
 
   if (
-    !tsConfigContent.exclude.includes('**/*.stories.ts') &&
-    !tsConfigContent.exclude.includes('**/*.stories.js')
+    !tsConfigContent?.exclude?.includes('**/*.stories.ts') &&
+    !tsConfigContent?.exclude?.includes('**/*.stories.js')
   ) {
     tsConfigContent.exclude = [
       ...(tsConfigContent.exclude || []),


### PR DESCRIPTION
Just optional chain some `.includes()`

ISSUES CLOSED: #10482

Fixes #10482
