### PR TITLE
fix(storybook): ignore addon-notes from version update

### DIFF
--- a/packages/storybook/src/migrations/update-14-0-0/migrate-defaults-5-to-6/migrate-defaults-5-to-6.spec.ts
+++ b/packages/storybook/src/migrations/update-14-0-0/migrate-defaults-5-to-6/migrate-defaults-5-to-6.spec.ts
@@ -22,6 +22,7 @@ describe('migrate-defaults-5-to-6 Generator', () => {
           '@nrwl/workspace': '10.4.0',
           '@storybook/addon-knobs': '^5.3.8',
           '@storybook/angular': '^5.3.8',
+          '@storybook/addon-notes': '5.3.21',
         },
       };
     });
@@ -60,16 +61,18 @@ describe('migrate-defaults-5-to-6 Generator', () => {
     });
   });
 
-  it('should update Storybook packages to latest version', async () => {
+  it('should update Storybook packages to latest version and ignore the ones to be ignored', async () => {
     migrateDefaultsGenerator(appTree);
 
     const packageJson = readJson(appTree, 'package.json');
-    // general deps
     expect(packageJson.devDependencies['@storybook/angular']).toEqual(
       storybookVersion
     );
     expect(packageJson.devDependencies['@storybook/addon-knobs']).toEqual(
       storybookVersion
+    );
+    expect(packageJson.devDependencies['@storybook/addon-notes']).toEqual(
+      '5.3.21'
     );
   });
 

--- a/packages/storybook/src/migrations/update-14-0-0/migrate-defaults-5-to-6/migrate-defaults-5-to-6.ts
+++ b/packages/storybook/src/migrations/update-14-0-0/migrate-defaults-5-to-6/migrate-defaults-5-to-6.ts
@@ -85,6 +85,7 @@ function maybeUpdateVersion(tree: Tree): GeneratorCallback {
       '@storybook/testing-react',
       '@storybook/testing-vue',
       '@storybook/testing-vue3',
+      '@storybook/addon-notes',
     ];
 
     json.dependencies = json.dependencies || {};


### PR DESCRIPTION
ISSUES CLOSED:  #10484

## Current Behavior
Storybook migration tries to update a [deprecated, unmaintained package](https://storybook.js.org/addons/@storybook/addon-notes).

## Expected Behavior
Storybook migration should ignore that package and not try to update it

## Related Issue(s)
#10484

Fixes #10484
