### PR TITLE
Revert "cleanup(storybook): Refine change Storybook target warn message"

### DIFF
--- a/packages/storybook/src/generators/change-storybook-targets/change-storybook-targets.ts
+++ b/packages/storybook/src/generators/change-storybook-targets/change-storybook-targets.ts
@@ -42,9 +42,7 @@ export async function changeStorybookTargetsGenerator(tree: Tree) {
           storybookBuildTarget
         );
     } else {
-      logger.warn(
-        `Could not find an Angular Storybook target for ${projectName}.`
-      );
+      logger.warn(`Could not find a Storybook target for ${projectName}.`);
     }
     if (changesMade) {
       updateProjectConfiguration(tree, projectName, projectConfiguration);


### PR DESCRIPTION
Reverts nrwl/nx#10495

The suggested message is wrong. It's a `storybook` target inside the `targets` object in `project.json`. There is no "Angular" `storybook` target.