### PR TITLE
fix(core): print normalized generator name instead of alias

### DIFF
--- a/packages/nx/src/command-line/generate.ts
+++ b/packages/nx/src/command-line/generate.ts
@@ -164,8 +164,6 @@ async function convertToGenerateOptions(
     throwInvalidInvocation(['@nrwl/workspace:library']);
   }
 
-  logger.info(`NX Generating ${collectionName}:${generatorName}`);
-
   const res = {
     collectionName,
     generatorName,
@@ -232,6 +230,10 @@ export async function newWorkspace(cwd: string, args: { [k: string]: any }) {
     const { normalizedGeneratorName, schema, implementationFactory } =
       ws.readGenerator(opts.collectionName, opts.generatorName);
 
+    logger.info(
+      `NX Generating ${opts.collectionName}:${normalizedGeneratorName}`
+    );
+
     const combinedOpts = await combineOptionsForGenerator(
       opts.generatorOptions,
       opts.collectionName,
@@ -286,6 +288,10 @@ export async function generate(cwd: string, args: { [k: string]: any }) {
     );
     const { normalizedGeneratorName, schema, implementationFactory, aliases } =
       ws.readGenerator(opts.collectionName, opts.generatorName);
+
+    logger.info(
+      `NX Generating ${opts.collectionName}:${normalizedGeneratorName}`
+    );
 
     if (opts.help) {
       printGenHelp(opts, schema, normalizedGeneratorName, aliases);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When running a generator using an alias, the alias is printed to the terminal output instead of the full normalized generator name.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When running a generator using an alias, the full normalized generator name is printed to the terminal output.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
