### PR TITLE
docs(core): fix typo in ci bitbucket link

### DIFF
--- a/docs/shared/ci-overview.md
+++ b/docs/shared/ci-overview.md
@@ -18,4 +18,4 @@ The following guides cover optimizing your CI/CD environments with affected comm
 - [Setting up CI using CircleCI](/ci/monorepo-ci-circle-ci)
 - [Setting up CI using Azure Pipelines](/ci/monorepo-ci-azure)
 - [Setting up CI using Jenkins](/ci/monorepo-ci-jenkins)
-- [Setting up CI using Bitbucket Pipelines](/ci/monorepo-ci-bitbucket-pipeline)
+- [Setting up CI using Bitbucket Pipelines](/ci/monorepo-ci-bitbucket-pipelines)


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The link to "Setting up CI using Bitbucket Pipelines" is missing an 's' at the end, so clicking the link results in a 404.

## Expected Behavior
The links redirects to the right page.

<!-- ## Related Issue(s) -->
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

<!-- Fixes #-->
