### PR TITLE
fix(core): restore core preset to analyze js sourcecode

### DIFF
--- a/packages/add-nx-to-monorepo/src/add-nx-to-monorepo.ts
+++ b/packages/add-nx-to-monorepo/src/add-nx-to-monorepo.ts
@@ -192,7 +192,7 @@ function createNxJsonFile(repoRoot: string, projects: ProjectDesc[]) {
     );
 
   const res = {
-    extends: 'nx/presets/core.json',
+    extends: 'nx/presets/npm.json',
     tasksRunnerOptions: {
       default: {
         runner: 'nx/tasks-runners/default',

--- a/packages/nx/presets/core.json
+++ b/packages/nx/presets/core.json
@@ -14,13 +14,16 @@
       }
     }
   },
-  "workspaceLayout": {
-    "libsDir": "packages",
-    "appsDir": "packages"
+  "targetDependencies": {
+    "build": [
+      {
+        "target": "build",
+        "projects": "dependencies"
+      }
+    ]
   },
-  "pluginsConfig": {
-    "@nrwl/js": {
-      "analyzeSourceFiles": false
-    }
+  "workspaceLayout": {
+    "appsDir": "packages",
+    "libsDir": "packages"
   }
 }

--- a/packages/nx/src/command-line/init.ts
+++ b/packages/nx/src/command-line/init.ts
@@ -3,7 +3,9 @@ import { join } from 'path';
 import { output } from '../utils/output';
 import { getPackageManagerCommand } from '../utils/package-manager';
 import { fileExists } from '../utils/workspace-root';
-import { readJsonFile, writeJsonFile } from '../utils/fileutils';
+import { writeJsonFile } from '../utils/fileutils';
+
+import * as npmJson from '../../presets/npm.json';
 
 export function initHandler() {
   const nxIsInstalled = !!execSync(getPackageManagerCommand().list)
@@ -28,10 +30,7 @@ export function initHandler() {
   }
 
   if (!fileExists('nx.json')) {
-    writeJsonFile(
-      'nx.json',
-      readJsonFile(join(__dirname, '..', '..', 'presets', 'core.json'))
-    );
+    writeJsonFile('nx.json', npmJson);
 
     output.success({
       title: 'nx.json has been created',

--- a/packages/nx/src/config/workspaces.spec.ts
+++ b/packages/nx/src/config/workspaces.spec.ts
@@ -76,6 +76,7 @@ describe('Workspaces', () => {
           }),
           'libs/domain/lib4/project.json': JSON.stringify(domainLibConfig),
           'libs/domain/lib4/package.json': JSON.stringify({}),
+          'nx.json': JSON.stringify({}),
         },
         '/root'
       );

--- a/packages/nx/src/config/workspaces.ts
+++ b/packages/nx/src/config/workspaces.ts
@@ -10,6 +10,8 @@ import { readJsonFile } from '../utils/fileutils';
 import { logger } from '../utils/logger';
 import { loadNxPlugins, readPluginPackageJson } from '../utils/nx-plugin';
 
+import * as npmPreset from '../../presets/npm.json';
+
 import type { NxJsonConfiguration } from './nx-json';
 import {
   ProjectConfiguration,
@@ -192,13 +194,7 @@ export class Workspaces {
         return nxJsonConfig;
       }
     } else {
-      try {
-        return readJsonFile(
-          join(__dirname, '..', '..', 'presets', 'core.json')
-        );
-      } catch (e) {
-        return {};
-      }
+      return npmPreset as NxJsonConfiguration;
     }
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Running

```
create-nx-workspace --preset core
```

will create a workspace that does not analyze js files for dependencies

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Running
```
create-nx-workspace --preset core
```

will create a workspace that does analyze js files for dependencies

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
