### PR TITLE
fix(js): return empty array if no helper dependencies found

### DIFF
--- a/packages/js/src/utils/compiler-helper-dependency.ts
+++ b/packages/js/src/utils/compiler-helper-dependency.ts
@@ -103,7 +103,7 @@ export function getHelperDependenciesFromProjectGraph(
     !projectGraph.dependencies[sourceProject] ||
     !projectGraph.dependencies[sourceProject].length
   )
-    return;
+    return [];
 
   const sourceDependencies = projectGraph.dependencies[sourceProject];
   const internalDependencies = sourceDependencies.reduce(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
one code path returns undefined instead of `[]`. This results in failing build if a Node application does not have depend on any helper dependency (eg: `tslib`)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
build should pass regardless of the app requiring helper dependency or not

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
