### PR TITLE
feat(linter): use project scoped ESLint cacheLocation

### DIFF
--- a/e2e/linter/src/linter.test.ts
+++ b/e2e/linter/src/linter.test.ts
@@ -73,8 +73,8 @@ describe('Linter', () => {
     runCLI(`lint ${myapp} --cache --cache-location="my-cache"`, {
       silenceError: true,
     });
-    expect(() => checkFilesExist(`my-cache`)).not.toThrow();
-    expect(readCacheFile('my-cache')).toContain(
+    expect(() => checkFilesExist(`my-cache/${myapp}`)).not.toThrow();
+    expect(readCacheFile(`my-cache/${myapp}`)).toContain(
       path.normalize(`${myapp}/src/app/app.spec.tsx`)
     );
   });

--- a/packages/linter/src/executors/eslint/lint.impl.spec.ts
+++ b/packages/linter/src/executors/eslint/lint.impl.spec.ts
@@ -139,7 +139,7 @@ describe('Linter Builder', () => {
       eslintConfig: './.eslintrc.json',
       fix: true,
       cache: true,
-      cacheLocation: 'cacheLocation1',
+      cacheLocation: 'cacheLocation1/proj',
       cacheStrategy: 'content',
       format: 'stylish',
       force: false,

--- a/packages/linter/src/executors/eslint/lint.impl.ts
+++ b/packages/linter/src/executors/eslint/lint.impl.ts
@@ -45,6 +45,10 @@ export default async function run(
     ? resolve(systemRoot, options.eslintConfig)
     : undefined;
 
+  options.cacheLocation = options.cacheLocation
+    ? join(options.cacheLocation, projectName)
+    : undefined;
+
   let lintResults: ESLint.LintResult[] = [];
 
   try {


### PR DESCRIPTION
## Current Behavior
When run in parallel ESLint overrides cache stores in `cacheLocation`.

## Expected Behavior
It should be possible to run linter in parallel and still have full cache written.

Fixes #10589
