### PR TITLE
feat(js): fine-grained dep type support for publishable libs

### DIFF
--- a/packages/workspace/src/utilities/buildable-libs-utils.spec.ts
+++ b/packages/workspace/src/utilities/buildable-libs-utils.spec.ts
@@ -1,9 +1,19 @@
-import { DependencyType, ProjectGraph } from '@nrwl/devkit';
+import {
+  DependencyType,
+  ProjectGraph,
+  ProjectGraphProjectNode,
+  readJsonFile,
+} from '@nrwl/devkit';
+import { join } from 'path';
+import { vol } from 'memfs';
 import {
   calculateProjectDependencies,
   DependentBuildableProjectNode,
+  updateBuildableProjectPackageJsonDependencies,
   updatePaths,
 } from './buildable-libs-utils';
+
+jest.mock('fs', () => require('memfs').fs);
 
 describe('updatePaths', () => {
   const deps: DependentBuildableProjectNode[] = [
@@ -84,3 +94,169 @@ describe('calculateProjectDependencies', () => {
     });
   });
 });
+
+describe('updateBuildableProjectPackageJsonDependencies', () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  it('should add undeclared npm packages to dependencies', () => {
+    vol.fromJSON({
+      './package.json': JSON.stringify({
+        name: '@scope/workspace',
+        version: '0.0.0',
+        dependencies: {
+          foo: '^1.0.0',
+          bar: '~2.0.0',
+          unused: '<= 9.9',
+        },
+        devDependencies: {
+          ignored: '3.3.3',
+        },
+      }),
+      './dist/libs/example/package.json': JSON.stringify({
+        name: '@scope/example',
+        version: '5.0.1',
+      }),
+    });
+
+    const root = '.';
+    const node = libNode('example');
+    const dependencies: DependentBuildableProjectNode[] = [
+      npmDep('foo', '^1.0.0'),
+      npmDep('bar', '~2.0.0'),
+      npmDep('ignored', '3.3.3'),
+    ];
+
+    updateBuildableProjectPackageJsonDependencies(
+      root,
+      'example',
+      'build',
+      undefined,
+      node,
+      dependencies
+    );
+
+    const pkg = readJsonFile(
+      join(root, 'dist', 'libs', 'example', 'package.json')
+    );
+    expect(pkg.dependencies).toMatchObject({
+      foo: '^1.0.0',
+      bar: '~2.0.0',
+    });
+    expect(pkg.peerDependencies).toEqual({});
+    expect(pkg.devDependencies).toBeUndefined();
+  });
+
+  it('should inherit versions for declared dependencies', () => {
+    vol.fromJSON({
+      './package.json': JSON.stringify({
+        name: '@scope/workspace',
+        version: '0.0.0',
+        dependencies: {
+          foo: '^1.0.0',
+          bar: '~2.0.0',
+          zed: '>=4.0.0',
+          unused: '<= 9.9',
+        },
+        devDependencies: {
+          ignored: '3.3.3',
+        },
+      }),
+      './dist/libs/example/package.json': JSON.stringify({
+        name: '@scope/example',
+        version: '5.0.1',
+        dependencies: {
+          foo: '[inherit]',
+        },
+        peerDependencies: {
+          bar: '[inherit]',
+        },
+        devDependencies: {
+          ignored: '[inherit]',
+        },
+      }),
+      './dist/libs/other/package.json': JSON.stringify({
+        name: '@scope/other',
+        version: '5.0.2',
+      }),
+    });
+
+    const root = '.';
+    const node = libNode('example');
+    const dependencies: DependentBuildableProjectNode[] = [
+      npmDep('foo', '^1.0.0'),
+      npmDep('bar', '~2.0.0'),
+      npmDep('zed', '>=4.0.0'),
+      npmDep('ignored', '3.3.3'),
+      libDep('scope', 'other'),
+    ];
+
+    updateBuildableProjectPackageJsonDependencies(
+      root,
+      'example',
+      'build',
+      undefined,
+      node,
+      dependencies,
+      'peerDependencies'
+    );
+
+    const pkg = readJsonFile(
+      join(root, 'dist', 'libs', 'example', 'package.json')
+    );
+    expect(pkg.dependencies).toMatchObject({
+      foo: '^1.0.0',
+    });
+    expect(pkg.peerDependencies).toMatchObject({
+      '@scope/other': '5.0.2',
+      bar: '~2.0.0',
+    });
+    expect(pkg.devDependencies).toMatchObject({
+      // devDependencies are not supported to inherit
+      ignored: '[inherit]',
+    });
+  });
+});
+
+function libDep(scope: string, name: string): DependentBuildableProjectNode {
+  return {
+    name: `@${scope}/${name}`,
+    node: libNode(name),
+    outputs: [`dist/libs/${name}`],
+  };
+}
+
+function libNode(name: string): ProjectGraphProjectNode {
+  return {
+    name,
+    type: 'lib',
+    data: {
+      root: `src/${name}`,
+      files: [],
+      targets: {
+        build: {
+          options: {
+            outputPath: `dist/libs/${name}`,
+          },
+          outputs: ['{options.outputPath}'],
+        },
+      },
+    },
+  };
+}
+
+function npmDep(name: string, version: string): DependentBuildableProjectNode {
+  return {
+    name,
+    node: {
+      name: `npm:${name}`,
+      type: 'npm',
+      data: {
+        packageName: name,
+        version,
+      },
+    },
+    outputs: [],
+  };
+}


### PR DESCRIPTION
Allows lib package.json to define its dependencies appropriately between dependencies and peerDependencies, while providing a way to continue to inherit the workspace's pkg version

e.g. "foo": "[inherit]"

## Current Behavior
If the options to update the package is true and a dependency is declared in the libraries package.json, it would not be updated.

## Expected Behavior
If dependency is declared with "magic" string === `[inherit]`.  The version will be updated from workspace package.json for that dependency.

This allows a library to maintain finer control over whether to use dependencies or peerDependencies for a given package, without giving up the ability to inherit the workspace's package.json version.

## Related Issue(s)
Fixes #10550
