### PR TITLE
fix(angular): apply default eager packages correctly #10496

### DIFF
--- a/packages/angular/src/utils/mfe/with-module-federation.ts
+++ b/packages/angular/src/utils/mfe/with-module-federation.ts
@@ -226,12 +226,10 @@ function applyDefaultEagerPackages(
 ) {
   const DEFAULT_PACKAGES_TO_LOAD_EAGERLY = ['@angular/localize/init'];
   for (const pkg of DEFAULT_PACKAGES_TO_LOAD_EAGERLY) {
-    if (sharedConfig[pkg]) {
-      return {
-        ...sharedConfig,
-        eager: true,
-      };
-    }
+    sharedConfig[pkg] = {
+      ...(sharedConfig[pkg] ?? {}),
+      eager: true,
+    };
   }
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
withModuleFederation is using an immutable approach to updating the shared dependencies when applying default eager packages

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
It should be updating by reference

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #10496
