### PR TITLE
fix(js): resolve shallow dependencies when building package.json

### DIFF
--- a/packages/js/src/utils/check-dependencies.spec.ts
+++ b/packages/js/src/utils/check-dependencies.spec.ts
@@ -1,0 +1,43 @@
+import { calculateProjectDependencies } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+import { checkDependencies } from './check-dependencies';
+
+jest.mock('@nrwl/workspace/src/utilities/buildable-libs-utils');
+
+describe('checkDependencies', () => {
+  test('collects shallow dependencies', () => {
+    const mockedCalculateProjectDependencies = jest.mocked(
+      calculateProjectDependencies
+    );
+    mockedCalculateProjectDependencies.mockReturnValueOnce({
+      target: {
+        name: 'example',
+        type: 'lib',
+        data: {},
+      },
+      dependencies: [],
+      nonBuildableDependencies: [],
+      topLevelDependencies: [],
+    });
+
+    checkDependencies(
+      {
+        root: 'root',
+        projectName: 'example',
+        targetName: 'build',
+        cwd: '?',
+        workspace: null,
+        isVerbose: false,
+      },
+      'pathToTsConfig.json'
+    );
+
+    expect(calculateProjectDependencies).toBeCalledWith(
+      expect.anything(),
+      'root',
+      'example',
+      'build',
+      undefined,
+      true
+    );
+  });
+});

--- a/packages/js/src/utils/check-dependencies.ts
+++ b/packages/js/src/utils/check-dependencies.ts
@@ -23,7 +23,8 @@ export function checkDependencies(
       context.root,
       context.projectName,
       context.targetName,
-      context.configurationName
+      context.configurationName,
+      true
     );
   const projectRoot = target.data.root;
 


### PR DESCRIPTION
For JS builds, the dependencies are now resolved shallow, dependencies will no longer inherit deps
from other buildable libs in the workspace

## Current Behavior
Dependencies are currently resolved "deep".  When the buildable lib has dependencies on other buildable libs in the workspace, the dependencies from those libs would be inherited.

## Expected Behavior
The dependencies should be resolved shallow.

## Related Issue(s)
Fixes #9371