### PR TITLE
feat(dep-graph): introduce NX_DEPS_DIRECTORY env variable

### DIFF
--- a/packages/nx/src/project-graph/nx-deps-cache.ts
+++ b/packages/nx/src/project-graph/nx-deps-cache.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'fs';
 import { ensureDirSync } from 'fs-extra';
 import { join } from 'path';
 import { performance } from 'perf_hooks';
-import { cacheDir } from '../utils/cache-directory';
+import { depsDir } from '../utils/cache-directory';
 import { directoryExists, fileExists } from '../utils/fileutils';
 import {
   FileData,
@@ -29,12 +29,12 @@ export interface ProjectGraphCache {
   dependencies: Record<string, ProjectGraphDependency[]>;
 }
 
-export const nxDepsPath = join(cacheDir, 'nxdeps.json');
+export const nxDepsPath = join(depsDir, 'nxdeps.json');
 
 export function ensureCacheDirectory(): void {
   try {
-    if (!existsSync(cacheDir)) {
-      ensureDirSync(cacheDir);
+    if (!existsSync(depsDir)) {
+      ensureDirSync(depsDir);
     }
   } catch (e) {
     /*
@@ -47,8 +47,8 @@ export function ensureCacheDirectory(): void {
      * In this case, we're creating the directory. If the operation failed, we ensure that the directory
      * exists before continuing (or raise an exception).
      */
-    if (!directoryExists(cacheDir)) {
-      throw new Error(`Failed to create directory: ${cacheDir}`);
+    if (!directoryExists(depsDir)) {
+      throw new Error(`Failed to create directory: ${depsDir}`);
     }
   }
 }

--- a/packages/nx/src/utils/cache-directory.ts
+++ b/packages/nx/src/utils/cache-directory.ts
@@ -3,20 +3,19 @@ import { workspaceRoot } from './workspace-root';
 import { readJsonFile } from './fileutils';
 import { NxJsonConfiguration } from '../config/nx-json';
 
-function readCacheDirectoryProperty(root: string): string | undefined {
+function readTaskRunnerOption(
+  root: string,
+  option: string
+): string | undefined {
   try {
     const nxJson = readJsonFile<NxJsonConfiguration>(join(root, 'nx.json'));
-    return nxJson.tasksRunnerOptions.default.options.cacheDirectory;
+    return nxJson.tasksRunnerOptions.default.options[option];
   } catch {
     return undefined;
   }
 }
 
 function cacheDirectory(root: string, cacheDirectory: string) {
-  const cacheDirFromEnv = process.env.NX_CACHE_DIRECTORY;
-  if (cacheDirFromEnv) {
-    cacheDirectory = cacheDirFromEnv;
-  }
   if (cacheDirectory) {
     if (isAbsolute(cacheDirectory)) {
       return cacheDirectory;
@@ -33,5 +32,16 @@ function cacheDirectory(root: string, cacheDirectory: string) {
  */
 export const cacheDir = cacheDirectory(
   workspaceRoot,
-  readCacheDirectoryProperty(workspaceRoot)
+  process.env.NX_CACHE_DIRECTORY ||
+    readTaskRunnerOption(workspaceRoot, 'cacheDirectory')
+);
+
+/**
+ * Path to the directory where Nx stores its nxdeps.json file
+ */
+export const depsDir = cacheDirectory(
+  workspaceRoot,
+  process.env.NX_DEPS_DIRECTORY ||
+    readTaskRunnerOption(workspaceRoot, 'depsDirectory') ||
+    readTaskRunnerOption(workspaceRoot, 'cacheDirectory')
 );


### PR DESCRIPTION
## Current Behavior
`nxdeps.json` is always stored inside cache directory. This becomes an issues when cache directory is shared/mounted in CI environment. Multiple parallel CI runs start sharing (and updating) same `nxdeps.json` which in turn produces false results/erros.

## Expected Behavior
It should be possible to store `nxdeps.json` outside cache directory, so it could be unique/isolated per workspace in CI environment.

Fixes #10000 
