### PR TITLE
fix(angular): handle paths correctly on windows when migrating angular cli workspaces to nx

### DIFF
--- a/packages/angular/src/generators/ng-add/utilities/app.migrator.ts
+++ b/packages/angular/src/generators/ng-add/utilities/app.migrator.ts
@@ -343,10 +343,13 @@ export class AppMigrator extends ProjectMigrator<SupportedTargets> {
       this.logger.warn(
         `The "${this.targetNames.build}" target does not have the "tsConfig" option configured. Skipping updating the tsConfig file.`
       );
-    } else if (!this.tree.exists(buildDevTsConfig)) {
-      this.logger.warn(
-        `The tsConfig file "${buildDevTsConfig}" specified in the "${this.targetNames.build}" target could not be found. Skipping updating the tsConfig file.`
-      );
+    } else {
+      const newBuildDevTsConfig = this.convertPath(buildDevTsConfig);
+      if (!this.tree.exists(newBuildDevTsConfig)) {
+        this.logger.warn(
+          `The tsConfig file "${buildDevTsConfig}" specified in the "${this.targetNames.build}" target could not be found. Skipping updating the tsConfig file.`
+        );
+      }
     }
 
     this.convertBuildOptions(buildTarget.options ?? {});
@@ -467,10 +470,13 @@ export class AppMigrator extends ProjectMigrator<SupportedTargets> {
       this.logger.warn(
         `The "${this.targetNames.server}" target does not have the "tsConfig" option configured. Skipping updating the tsConfig file.`
       );
-    } else if (!this.tree.exists(serverDevTsConfig)) {
-      this.logger.warn(
-        `The tsConfig file "${serverDevTsConfig}" specified in the "${this.targetNames.server}" target could not be found. Skipping updating the tsConfig file.`
-      );
+    } else {
+      const newServerDevTsConfig = this.convertPath(serverDevTsConfig);
+      if (!this.tree.exists(newServerDevTsConfig)) {
+        this.logger.warn(
+          `The tsConfig file "${serverDevTsConfig}" specified in the "${this.targetNames.server}" target could not be found. Skipping updating the tsConfig file.`
+        );
+      }
     }
 
     this.convertServerOptions(serverTarget.options ?? {});
@@ -534,10 +540,13 @@ export class AppMigrator extends ProjectMigrator<SupportedTargets> {
       this.logger.warn(
         `The "${this.targetNames.test}" target does not have the "tsConfig" option configured. Skipping updating the tsConfig file.`
       );
-    } else if (!this.tree.exists(testOptions.tsConfig)) {
-      this.logger.warn(
-        `The tsConfig file "${testOptions.tsConfig}" specified in the "${this.targetNames.test}" target could not be found. Skipping updating the tsConfig file.`
-      );
+    } else {
+      const newTestTsConfig = this.convertPath(testOptions.tsConfig);
+      if (!this.tree.exists(newTestTsConfig)) {
+        this.logger.warn(
+          `The tsConfig file "${testOptions.tsConfig}" specified in the "${this.targetNames.test}" target could not be found. Skipping updating the tsConfig file.`
+        );
+      }
     }
 
     testOptions.main = testOptions.main && this.convertAsset(testOptions.main);

--- a/packages/angular/src/generators/ng-add/utilities/lib.migrator.ts
+++ b/packages/angular/src/generators/ng-add/utilities/lib.migrator.ts
@@ -50,8 +50,8 @@ export class LibMigrator extends ProjectMigrator<SupportedTargets> {
   }
 
   async migrate(): Promise<void> {
-    this.moveProjectFiles();
     await this.updateProjectConfiguration();
+    this.moveProjectFiles();
     this.updateNgPackageJson();
     this.updateTsConfigs();
     this.updateEsLintConfig();
@@ -259,7 +259,7 @@ export class LibMigrator extends ProjectMigrator<SupportedTargets> {
       return;
     }
 
-    const existEsLintConfigPath = this.tree.exists(this.newEsLintConfigPath);
+    const existEsLintConfigPath = this.tree.exists(this.oldEsLintConfigPath);
     if (!existEsLintConfigPath) {
       this.logger.warn(
         `The ESLint config file "${this.oldEsLintConfigPath}" could not be found. Skipping updating the file.`
@@ -267,11 +267,7 @@ export class LibMigrator extends ProjectMigrator<SupportedTargets> {
     }
 
     lintOptions.eslintConfig =
-      lintOptions.eslintConfig &&
-      joinPathFragments(
-        this.project.newRoot,
-        basename(lintOptions.eslintConfig)
-      );
+      lintOptions.eslintConfig && this.newEsLintConfigPath;
     lintOptions.lintFilePatterns =
       lintOptions.lintFilePatterns &&
       lintOptions.lintFilePatterns.map((pattern) => {
@@ -304,7 +300,7 @@ export class LibMigrator extends ProjectMigrator<SupportedTargets> {
       return;
     }
 
-    const eslintConfig = readJson(this.tree, this.newEsLintConfigPath);
+    const eslintConfig = readJson(this.tree, this.oldEsLintConfigPath);
     if (hasRulesRequiringTypeChecking(eslintConfig)) {
       lintOptions.hasTypeAwareRules = true;
     }

--- a/packages/angular/src/generators/ng-add/utilities/project.migrator.ts
+++ b/packages/angular/src/generators/ng-add/utilities/project.migrator.ts
@@ -1,5 +1,6 @@
 import {
   joinPathFragments,
+  normalizePath,
   offsetFromRoot,
   ProjectConfiguration,
   readWorkspaceConfiguration,
@@ -289,7 +290,7 @@ export abstract class ProjectMigrator<TargetType extends string = any> {
 
   protected moveDir(from: string, to: string): void {
     visitNotIgnoredFiles(this.tree, from, (file) => {
-      this.moveFile(file, file.replace(from, to), true);
+      this.moveFile(file, normalizePath(file).replace(from, to), true);
     });
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When migrating an Angular CLI workspace to Nx in a Windows machine, some paths are not handled correctly causing the migration to not move some files. Also, some wrong warnings are being printed regarding non-existing files that actually exist.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should be able to migrate Angular CLI workspaces to Nx in Windows machines correctly. No invalid warnings should be printed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
