### PR TITLE
chore(angular): fix e2e test for mfe served apps

### DIFF
--- a/e2e/angular-core/src/projects.test.ts
+++ b/e2e/angular-core/src/projects.test.ts
@@ -326,8 +326,6 @@ describe('Angular Projects', () => {
       if (process && process.pid) {
         await promisifiedTreeKill(process.pid, 'SIGKILL');
       }
-      await killPorts(port1);
-      await killPorts(port2);
     } catch (err) {
       expect(err).toBeFalsy();
     }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
e2e test is failing on windows because it can't handle killing a task on a port that's already been killed

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
the kill ports was a fallback to ensure the port was killed correctly, however, the `promisifiedTreeKill` should already handle killing those tasks
