### PR TITLE
fix(nx-plugin): generator and executor generators should work in js libs

### DIFF
--- a/packages/nx-plugin/src/generators/executor/executor.spec.ts
+++ b/packages/nx-plugin/src/generators/executor/executor.spec.ts
@@ -1,7 +1,8 @@
-import { Tree, readJson } from '@nrwl/devkit';
+import { Tree, readJson, readProjectConfiguration } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { executorGenerator } from './executor';
 import { pluginGenerator } from '../plugin/plugin';
+import { libraryGenerator } from '@nrwl/js';
 
 describe('NxPlugin Executor Generator', () => {
   let tree: Tree;
@@ -88,6 +89,25 @@ describe('NxPlugin Executor Generator', () => {
 
     expect(executorsJson.executors['my-executor'].description).toEqual(
       'my-executor custom description'
+    );
+  });
+
+  it('should create executors.json if it is not present', async () => {
+    await libraryGenerator(tree, {
+      name: 'test-js-lib',
+      buildable: true,
+    });
+    const libConfig = readProjectConfiguration(tree, 'test-js-lib');
+    await executorGenerator(tree, {
+      project: 'test-js-lib',
+      includeHasher: false,
+      name: 'test-executor',
+      unitTestRunner: 'jest',
+    });
+
+    expect(() => tree.exists(`${libConfig.root}/executors.json`)).not.toThrow();
+    expect(readJson(tree, `${libConfig.root}/package.json`).executors).toBe(
+      'executors.json'
     );
   });
 

--- a/packages/nx-plugin/src/generators/generator/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/generator/generator.spec.ts
@@ -1,5 +1,6 @@
-import { readJson, Tree } from '@nrwl/devkit';
+import { readJson, readProjectConfiguration, Tree } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { libraryGenerator } from '@nrwl/js';
 import { pluginGenerator } from '../plugin/plugin';
 import { generatorGenerator } from './generator';
 
@@ -56,6 +57,26 @@ describe('NxPlugin Generator Generator', () => {
     );
     expect(generatorJson.generators['my-generator'].description).toEqual(
       'my-generator description'
+    );
+  });
+
+  it('should create generators.json if it is not present', async () => {
+    await libraryGenerator(tree, {
+      name: 'test-js-lib',
+      buildable: true,
+    });
+    const libConfig = readProjectConfiguration(tree, 'test-js-lib');
+    await generatorGenerator(tree, {
+      project: 'test-js-lib',
+      name: 'test-generator',
+      unitTestRunner: 'jest',
+    });
+
+    expect(() =>
+      tree.exists(`${libConfig.root}/generators.json`)
+    ).not.toThrow();
+    expect(readJson(tree, `${libConfig.root}/package.json`).generators).toBe(
+      'generators.json'
     );
   });
 

--- a/packages/nx-plugin/src/generators/migration/migration.ts
+++ b/packages/nx-plugin/src/generators/migration/migration.ts
@@ -14,7 +14,7 @@ import type { Schema } from './schema';
 import * as path from 'path';
 import { addMigrationJsonChecks } from '../lint-checks/generator';
 import type { Linter as EsLint } from 'eslint';
-import { PackageJson } from 'nx/src/utils/package-json';
+import { PackageJson, readNxMigrateConfig } from 'nx/src/utils/package-json';
 interface NormalizedSchema extends Schema {
   projectRoot: string;
   projectSourceRoot: string;
@@ -54,7 +54,16 @@ function addFiles(host: Tree, options: NormalizedSchema) {
 }
 
 function updateMigrationsJson(host: Tree, options: NormalizedSchema) {
-  const migrationsPath = path.join(options.projectRoot, 'migrations.json');
+  const configuredMigrationPath = readNxMigrateConfig(
+    readJson<PackageJson>(
+      host,
+      joinPathFragments(options.projectRoot, 'package.json')
+    )
+  ).migrations;
+  const migrationsPath = joinPathFragments(
+    options.projectRoot,
+    configuredMigrationPath ?? 'migrations.json'
+  );
   const migrations = host.exists(migrationsPath)
     ? readJson(host, migrationsPath)
     : {};


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`nx g @nrwl/nx-plugin:generator` and `nx g @nrwl/nx-plugin:executor` have hardcoded paths for generators.json / executors.json with fallbacks in place for angular-CLI named collections.

They also fail if there is no executors.json or generators.json collection present. This is different from the behavior of `@nrwl/nx-plugin:migration`, so it is corrected in this PR.

## Expected Behavior
`nx g @nrwl/nx-plugin:generator` and `nx g @nrwl/nx-plugin:executor` read paths for collection files from `package.json` and create them if they are not present

## Related Issue(s)
Community slack thread: [https://nrwlcommunity.slack.com/...](https://nrwlcommunity.slack.com/archives/CMFKWPU6Q/p1654627377950329?thread_ts=1654529552.622049&cid=CMFKWPU6Q)

Fixes #
