### PR TITLE
fix(misc): fix printing duplicate generators that are actually extens…

### DIFF
--- a/packages/nx/src/command-line/generate.ts
+++ b/packages/nx/src/command-line/generate.ts
@@ -48,17 +48,18 @@ async function promptForCollection(
       ...Object.keys(packageJson.devDependencies || {}),
     ])
   );
-  const choices = collections
-    .map((collectionName) => {
-      try {
-        const generator = ws.readGenerator(collectionName, generatorName);
+  const choicesMap = new Set<string>();
 
-        return `${collectionName}:${generator.normalizedGeneratorName}`;
-      } catch {
-        return null;
-      }
-    })
-    .filter((c) => !!c);
+  for (const collectionName of collections) {
+    try {
+      const { resolvedCollectionName, normalizedGeneratorName } =
+        ws.readGenerator(collectionName, generatorName);
+
+      choicesMap.add(`${resolvedCollectionName}:${normalizedGeneratorName}`);
+    } catch {}
+  }
+
+  const choices = Array.from(choicesMap);
 
   if (choices.length === 1) {
     return choices[0];

--- a/packages/nx/src/config/workspaces.ts
+++ b/packages/nx/src/config/workspaces.ts
@@ -147,8 +147,12 @@ export class Workspaces {
 
   readGenerator(collectionName: string, generatorName: string) {
     try {
-      const { generatorsFilePath, generatorsJson, normalizedGeneratorName } =
-        this.readGeneratorsJson(collectionName, generatorName);
+      const {
+        generatorsFilePath,
+        generatorsJson,
+        resolvedCollectionName,
+        normalizedGeneratorName,
+      } = this.readGeneratorsJson(collectionName, generatorName);
       const generatorsDir = path.dirname(generatorsFilePath);
       const generatorConfig =
         generatorsJson.generators?.[normalizedGeneratorName] ||
@@ -165,6 +169,7 @@ export class Workspaces {
         generatorsDir
       );
       return {
+        resolvedCollectionName,
         normalizedGeneratorName,
         schema,
         implementationFactory,
@@ -253,6 +258,7 @@ export class Workspaces {
     generatorsFilePath: string;
     generatorsJson: GeneratorsJson;
     normalizedGeneratorName: string;
+    resolvedCollectionName: string;
   } {
     let generatorsFilePath;
     if (collectionName.endsWith('.json')) {
@@ -291,7 +297,12 @@ export class Workspaces {
         `Cannot find generator '${generator}' in ${generatorsFilePath}.`
       );
     }
-    return { generatorsFilePath, generatorsJson, normalizedGeneratorName };
+    return {
+      generatorsFilePath,
+      generatorsJson,
+      normalizedGeneratorName,
+      resolvedCollectionName: collectionName,
+    };
   }
 
   private resolvePaths() {


### PR DESCRIPTION
…ions

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Multiple collections that technically include the generator will be given as choices.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Only collections that actually have an implementation of the generator will be given as choices.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
