### PR TITLE
fix(react-native): replace incorrect ignore paths for pods

### DIFF
--- a/packages/react-native/src/generators/init/lib/gitignore-entries.ts
+++ b/packages/react-native/src/generators/init/lib/gitignore-entries.ts
@@ -56,6 +56,6 @@ buck-out/
 *.jsbundle
 
 # Ruby / CocoaPods
-/ios/Pods/
-/vendor/bundle/
+**/ios/Pods/
+**/vendor/bundle/
 `;


### PR DESCRIPTION
## Related Issue(s)

Fixes #10633
