### PR TITLE
fix(angular): prevent deleting library's root package.json file on windows machines

### DIFF
--- a/packages/angular/src/migrations/update-14-2-0/update-libraries-secondary-entrypoints.ts
+++ b/packages/angular/src/migrations/update-14-2-0/update-libraries-secondary-entrypoints.ts
@@ -2,6 +2,7 @@ import {
   formatFiles,
   getProjects,
   joinPathFragments,
+  normalizePath,
   readJson,
   Tree,
   visitNotIgnoredFiles,
@@ -30,7 +31,8 @@ export default async function (tree: Tree) {
     visitNotIgnoredFiles(tree, project.root, (filePath) => {
       if (
         basename(filePath) !== 'package.json' ||
-        filePath === joinPathFragments(project.root, 'package.json')
+        normalizePath(filePath) ===
+          joinPathFragments(project.root, 'package.json')
       ) {
         return;
       }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The migration to remove library secondary entry points' `package.json` files deletes the `package.json` at the root of the library when using Windows. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The migration to remove library secondary entry points' `package.json` files should not delete the `package.json` at the root of the library.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #10626 
