### PR TITLE
fix(react): set migration to use nx cli

### DIFF
--- a/packages/react/migrations.json
+++ b/packages/react/migrations.json
@@ -55,6 +55,7 @@
       "factory": "./src/migrations/update-14-0-0/add-default-development-configurations"
     },
     "update-external-emotion-jsx-runtime-14.1.0": {
+      "cli": "nx",
       "version": "14.1.0-beta.0",
       "description": "Update external option in projects for Emotion",
       "factory": "./src/migrations/update-14-1-0/update-external-emotion-jsx-runtime"


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The `update-external-emotion-jsx-runtime-14.1.0` migration doesn't have the `cli` set to `nx`. This causes the migration to be run with the Angular CLI which might not be available in workspaces where Angular is not used.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The `update-external-emotion-jsx-runtime-14.1.0` migration should use the Nx CLI.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #10628 
