### PR TITLE
fix(js): check that project's package.json exists before attempting to read its contents

### DIFF
--- a/packages/js/src/executors/tsc/tsc.impl.ts
+++ b/packages/js/src/executors/tsc/tsc.impl.ts
@@ -75,10 +75,6 @@ export async function* tscExecutor(
     dependencies.push(tsLibDependency);
   }
 
-  const packageJsonFileExists = fileExists(
-    join(context.root, projectRoot, 'package.json')
-  );
-
   const assetHandler = new CopyAssetsHandler({
     projectDir: projectRoot,
     rootDir: context.root,
@@ -92,11 +88,7 @@ export async function* tscExecutor(
     const disposePackageJsonChanged = await watchForSingleFileChanges(
       join(context.root, projectRoot),
       'package.json',
-      () => {
-        if (packageJsonFileExists) {
-          updatePackageJson(options, context, target, dependencies);
-        }
-      }
+      () => updatePackageJson(options, context, target, dependencies)
     );
     process.on('exit', async () => {
       await disposeWatchAssetChanges();
@@ -109,6 +101,9 @@ export async function* tscExecutor(
   }
 
   return yield* compileTypeScriptFiles(options, context, async () => {
+    const packageJsonFileExists = fileExists(
+      join(context.root, projectRoot, 'package.json')
+    );
     await assetHandler.processAllAssetsOnce();
     if (packageJsonFileExists) {
       updatePackageJson(options, context, target, dependencies);

--- a/packages/js/src/executors/tsc/tsc.impl.ts
+++ b/packages/js/src/executors/tsc/tsc.impl.ts
@@ -1,4 +1,3 @@
-import { fileExists } from 'nx/src/utils/fileutils';
 import { ExecutorContext } from '@nrwl/devkit';
 import {
   assetGlobsToFiles,
@@ -101,13 +100,8 @@ export async function* tscExecutor(
   }
 
   return yield* compileTypeScriptFiles(options, context, async () => {
-    const packageJsonFileExists = fileExists(
-      join(context.root, projectRoot, 'package.json')
-    );
     await assetHandler.processAllAssetsOnce();
-    if (packageJsonFileExists) {
-      updatePackageJson(options, context, target, dependencies);
-    }
+    updatePackageJson(options, context, target, dependencies);
   });
 }
 

--- a/packages/js/src/utils/update-package-json.ts
+++ b/packages/js/src/utils/update-package-json.ts
@@ -11,6 +11,7 @@ import {
 } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
 import { basename, dirname, join, relative } from 'path';
 import { NormalizedExecutorOptions } from './schema';
+import { fileExists } from 'nx/src/utils/fileutils';
 
 function getMainFileDirRelativeToProjectRoot(
   main: string,
@@ -28,7 +29,15 @@ export function updatePackageJson(
   dependencies: DependentBuildableProjectNode[],
   withTypings = true
 ): void {
-  const packageJson = readJsonFile(join(options.projectRoot, 'package.json'));
+  const pathToPackageJson = join(
+    context.root,
+    options.projectRoot,
+    'package.json'
+  );
+
+  const packageJson = fileExists(pathToPackageJson)
+    ? readJsonFile(pathToPackageJson)
+    : { name: context.projectName };
 
   const mainFile = basename(options.main).replace(/\.[tj]s$/, '');
   const relativeMainFileDir = getMainFileDirRelativeToProjectRoot(


### PR DESCRIPTION
ISSUES CLOSED: #10649

## Current Behavior
Building a node application using `@nrwl/js:tsc` as the executor without a package.json within the applications folder causes an error to be thrown as the executor attempts to read the contents file that does not exist.

## Expected Behavior
An error is not thrown as we now check that the file exists before attempting to update it.

## Related Issue(s)
Fixes #10649
