### PR TITLE
fix(core): prevent "ng completion" command to run through the nx cli

### DIFF
--- a/packages/nx/bin/init-local.ts
+++ b/packages/nx/bin/init-local.ts
@@ -80,7 +80,15 @@ function isKnownCommand() {
 
 function shouldDelegateToAngularCLI() {
   const command = process.argv[2];
-  const commands = ['add', 'analytics', 'deploy', 'config', 'doc', 'update'];
+  const commands = [
+    'add',
+    'analytics',
+    'deploy',
+    'config',
+    'doc',
+    'update',
+    'completion',
+  ];
   return commands.indexOf(command) > -1;
 }
 
@@ -130,6 +138,10 @@ function handleAngularCLIFallbacks(workspace: WorkspaceTypeAndRoot) {
           }
         })
     );
+  } else if (process.argv[2] === 'completion') {
+    console.log(`"ng completion" is not natively supported by Nx.
+Instead, you could try an Nx Editor Plugin for a visual tool to run Nx commands. If you're using VSCode, you can use the Nx Console plugin, or if you're using WebStorm, you could use one of the available community plugins.
+For more information, see https://nx.dev/using-nx/console`);
   } else {
     require('nx/src/adapter/compat');
     try {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Angular 14 has a new `completion` command which adds autocompletion for the Angular CLI in the terminal. This command is not supported by Nx and when run it throws an error.

As a side-effect, if someone did set up the Angular CLI autocompletion in their terminal, when they open the terminal in an Nx workspace an empty `NX` file is being created. This happens because their terminal profile invokes `ng completion` which errors because the Angular CLI is decorated to run the Nx CLI and this one doesn't support the command.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Running `ng completion` should not run through the Nx CLI and instead communicate to the dev that the command is not supported by the Nx CLI.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
