### PR TITLE
feat(core): throw graceful error in runNxMigration() if no collection

### DIFF
--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -1040,12 +1040,8 @@ async function runNxMigration(root: string, packageName: string, name: string) {
 
   const collection = readJsonFile<MigrationsJson>(collectionPath);
   const g = collection.generators || collection.schematics;
-
-  let implRelativePath: string;
-  try {
-    const c = g[name];
-    implRelativePath = c.implementation || c.factory;
-  } catch (e) {
+  const implRelativePath = g[name]?.implementation || g[name]?.factory;
+  if (!implRelativePath) {
     throw new Error(
       `Can not get relative path for migration's implementation as collection not found by name="${name}" for package="${packageName}", collectionPath="${collectionPath}"`
     );

--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -1040,7 +1040,16 @@ async function runNxMigration(root: string, packageName: string, name: string) {
 
   const collection = readJsonFile<MigrationsJson>(collectionPath);
   const g = collection.generators || collection.schematics;
-  const implRelativePath = g[name].implementation || g[name].factory;
+
+  let implRelativePath: string;
+  try {
+    const c = g[name];
+    implRelativePath = c.implementation || c.factory;
+  } catch (e) {
+    throw new Error(
+      `Can not get relative path for migration's implementation as collection not found by name="${name}" for package="${packageName}", collectionPath="${collectionPath}"`
+    );
+  }
 
   let implPath: string;
 

--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -1040,12 +1040,13 @@ async function runNxMigration(root: string, packageName: string, name: string) {
 
   const collection = readJsonFile<MigrationsJson>(collectionPath);
   const g = collection.generators || collection.schematics;
-  const implRelativePath = g[name]?.implementation || g[name]?.factory;
-  if (!implRelativePath) {
+  if (!g[name]) {
+    const source = collection.generators ? 'generators' : 'schematics';
     throw new Error(
-      `Can not get relative path for migration's implementation as collection not found by name="${name}" for package="${packageName}", collectionPath="${collectionPath}"`
+      `Migration not found by name="${name}" for package="${packageName}" in "${source}", collectionPath="${collectionPath}"`
     );
   }
+  const implRelativePath = g[name].implementation || g[name].factory;
 
   let implPath: string;
 

--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -1043,7 +1043,7 @@ async function runNxMigration(root: string, packageName: string, name: string) {
   if (!g[name]) {
     const source = collection.generators ? 'generators' : 'schematics';
     throw new Error(
-      `Migration not found by name="${name}" for package="${packageName}" in "${source}", collectionPath="${collectionPath}"`
+      `Unable to determine implementation path for "${collectionPath}:${name}" using collection.${source}`
     );
   }
   const implRelativePath = g[name].implementation || g[name].factory;


### PR DESCRIPTION
This will give better context to user when getting an error described in "current behaviour".



<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
For some unclear reason getting an error when running `pnpm exec nx migrate --run-migrations`

```
Running migration remove-show-circular-dependencies-option
Cannot read properties of undefined (reading 'implementation')
TypeError: Cannot read properties of undefined (reading 'implementation')
    at /private/var/folders/93/m19tdtfs4j99996mcr4t434c0000gn/T/tmp-41094-b12xESmQUVHD/node_modules/.pnpm/nx@14.2.2/node_modules/nx/src/command-line/migrate.js:706:42
    at Generator.next (<anonymous>)
    at /private/var/folders/93/m19tdtfs4j99996mcr4t434c0000gn/T/tmp-41094-b12xESmQUVHD/node_modules/.pnpm/tslib@2.4.0/node_modules/tslib/tslib.js:118:75
    at new Promise (<anonymous>)
    at Object.__awaiter (/private/var/folders/93/m19tdtfs4j99996mcr4t434c0000gn/T/tmp-41094-b12xESmQUVHD/node_modules/.pnpm/tslib@2.4.0/node_modules/tslib/tslib.js:114:16)
    at runNxMigration (/private/var/folders/93/m19tdtfs4j99996mcr4t434c0000gn/T/tmp-41094-b12xESmQUVHD/node_modules/.pnpm/nx@14.2.2/node_modules/nx/src/command-line/migrate.js:702:20)
    at /private/var/folders/93/m19tdtfs4j99996mcr4t434c0000gn/T/tmp-41094-b12xESmQUVHD/node_modules/.pnpm/nx@14.2.2/node_modules/nx/src/command-line/migrate.js:617:23
    at Generator.next (<anonymous>)
    at fulfilled (/private/var/folders/93/m19tdtfs4j99996mcr4t434c0000gn/T/tmp-41094-b12xESmQUVHD/node_modules/.pnpm/tslib@2.4.0/node_modules/tslib/tslib.js:115:62)
Command failed: /var/folders/93/m19tdtfs4j99996mcr4t434c0000gn/T/tmp-41094-b12xESmQUVHD/node_modules/.bin/nx _migrate --run-migrations --verbose
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Expected to get context on where is the problem so might be able to fix.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
