### PR TITLE
fix(storybook): remove projectBuildConfig from everywhere

### DIFF
--- a/docs/generated/packages/react.json
+++ b/docs/generated/packages/react.json
@@ -639,10 +639,6 @@
             "enum": ["eslint", "tslint"],
             "default": "eslint"
           },
-          "projectBuildConfig": {
-            "description": "Provide a custom projectBuildConfig for the Angular executor. If left blank, Nx will use the default.",
-            "type": "string"
-          },
           "standaloneConfig": {
             "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
             "type": "boolean"

--- a/docs/generated/packages/storybook.json
+++ b/docs/generated/packages/storybook.json
@@ -133,10 +133,6 @@
             "enum": ["eslint", "tslint", "none"],
             "default": "eslint"
           },
-          "projectBuildConfig": {
-            "description": "Provide a custom projectBuildConfig for the Angular executor. If left blank, Nx will use the default.",
-            "type": "string"
-          },
           "js": {
             "type": "boolean",
             "description": "Generate JavaScript story files rather than TypeScript story files.",
@@ -368,10 +364,6 @@
           "outputPath": {
             "type": "string",
             "description": "The output path of the generated files."
-          },
-          "projectBuildConfig": {
-            "type": "string",
-            "description": "Workspace project where Storybook reads the Webpack config from."
           },
           "styles": {
             "type": "array",

--- a/packages/react/src/generators/storybook-configuration/schema.d.ts
+++ b/packages/react/src/generators/storybook-configuration/schema.d.ts
@@ -10,5 +10,4 @@ export interface StorybookConfigureSchema {
   linter?: Linter;
   cypressDirectory?: string;
   standaloneConfig?: boolean;
-  projectBuildConfig?: string;
 }

--- a/packages/react/src/generators/storybook-configuration/schema.json
+++ b/packages/react/src/generators/storybook-configuration/schema.json
@@ -52,10 +52,6 @@
       "enum": ["eslint", "tslint"],
       "default": "eslint"
     },
-    "projectBuildConfig": {
-      "description": "Provide a custom projectBuildConfig for the Angular executor. If left blank, Nx will use the default.",
-      "type": "string"
-    },
     "standaloneConfig": {
       "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
       "type": "boolean"

--- a/packages/storybook/src/executors/build-storybook/schema.json
+++ b/packages/storybook/src/executors/build-storybook/schema.json
@@ -28,10 +28,6 @@
       "type": "string",
       "description": "The output path of the generated files."
     },
-    "projectBuildConfig": {
-      "type": "string",
-      "description": "Workspace project where Storybook reads the Webpack config from."
-    },
     "styles": {
       "type": "array",
       "description": "Global styles to be included in the build.",

--- a/packages/storybook/src/executors/models.ts
+++ b/packages/storybook/src/executors/models.ts
@@ -15,6 +15,5 @@ export interface CommonNxStorybookConfig {
     | '@storybook/vue3'
     | '@storybook/svelte'
     | '@storybook/react-native';
-  projectBuildConfig?: string;
   config: StorybookConfig;
 }

--- a/packages/storybook/src/generators/configuration/schema.d.ts
+++ b/packages/storybook/src/generators/configuration/schema.d.ts
@@ -12,5 +12,4 @@ export interface StorybookConfigureSchema {
   tsConfiguration?: boolean;
   cypressDirectory?: string;
   standaloneConfig?: boolean;
-  projectBuildConfig?: string;
 }

--- a/packages/storybook/src/generators/configuration/schema.json
+++ b/packages/storybook/src/generators/configuration/schema.json
@@ -35,10 +35,6 @@
       "enum": ["eslint", "tslint", "none"],
       "default": "eslint"
     },
-    "projectBuildConfig": {
-      "description": "Provide a custom projectBuildConfig for the Angular executor. If left blank, Nx will use the default.",
-      "type": "string"
-    },
     "js": {
       "type": "boolean",
       "description": "Generate JavaScript story files rather than TypeScript story files.",


### PR DESCRIPTION
## Current Behavior
[The `projectBuildConfig` flag](https://nx.dev/storybook/extra-topics-for-angular-projects#setting-up-projectbuildconfig-for-nx-versions-1418), meant for Nx versions <14.1.8, is no longer used anywhere. It still exists, however, in the executor/generator schemas. It is safe to remove it.

## Expected Behavior

The unused `projectBuildConfig` flag is now removed from the schemas

