### PR TITLE
fix(linter): linter executor should work from other folders than root

### DIFF
--- a/packages/linter/src/executors/eslint/lint.impl.spec.ts
+++ b/packages/linter/src/executors/eslint/lint.impl.spec.ts
@@ -36,6 +36,8 @@ jest.mock('./utility/eslint-utils', () => {
 });
 import lintExecutor from './lint.impl';
 
+let mockChdir = jest.fn().mockImplementation(() => {});
+
 function createValidRunBuilderOptions(
   additionalOptions: Partial<Schema> = {}
 ): Schema {
@@ -64,7 +66,7 @@ function createValidRunBuilderOptions(
 function setupMocks() {
   jest.resetModules();
   jest.clearAllMocks();
-  jest.spyOn(process, 'chdir').mockImplementation(() => {});
+  jest.spyOn(process, 'chdir').mockImplementation(mockChdir);
   console.warn = jest.fn();
   console.error = jest.fn();
   console.info = jest.fn();
@@ -152,6 +154,15 @@ describe('Linter Builder', () => {
       rulesdir: [],
       resolvePluginsRelativeTo: null,
     });
+  });
+
+  it('should execute correctly from another working directory than root', async () => {
+    setupMocks();
+    await lintExecutor(createValidRunBuilderOptions(), {
+      ...mockContext,
+      cwd: 'apps/project/',
+    });
+    expect(mockChdir).toHaveBeenCalledWith('/root');
   });
 
   it('should throw if no reports generated', async () => {

--- a/packages/linter/src/executors/eslint/lint.impl.ts
+++ b/packages/linter/src/executors/eslint/lint.impl.ts
@@ -15,7 +15,11 @@ export default async function run(
   delete options.hasTypeAwareRules;
 
   const systemRoot = context.root;
-  process.chdir(context.cwd);
+
+  // eslint resolves files relative to the current working directory.
+  // We want these paths to always be resolved relative to the workspace
+  // root to be able to run the lint executor from any subfolder.
+  process.chdir(systemRoot);
 
   const projectName = context.projectName || '<???>';
   const printInfo = options.format && !options.silent;


### PR DESCRIPTION
It took me a few hours to figure out why my nx lint script didn't execute the same way in my CI pipeline as locally. It turns out that eslint is dependent on the current working directory. Once I found the problem, I figured to submit a fix this way.

## Related Issue

Fixes #10683 