### PR TITLE
docs(core): update docs for caching to clarify runtime inputs are set by user

### DIFF
--- a/docs/shared/using-nx/caching.md
+++ b/docs/shared/using-nx/caching.md
@@ -13,7 +13,7 @@ By default, the computation hash for say `nx test app1` includes:
 - All the source files of `app1` and its dependencies
 - Relevant global configuration
 - Versions of external dependencies
-- Runtime values provisioned by the user such as the version of Node
+- [Runtime values provisioned by the user](#runtime-hash-inputs)
 - CLI Command flags
 
 ![computation-hashing](/shared/mental-model/computation-hashing.png)


### PR DESCRIPTION
Updates section on runtime inputs to avoid confusion about whether Node version is included by default or not

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
