### PR TITLE
fix(js): preset should use packages folder

### DIFF
--- a/packages/workspace/src/generators/preset/preset.ts
+++ b/packages/workspace/src/generators/preset/preset.ts
@@ -33,11 +33,7 @@ export const presetSchematic = convertNxGenerator(presetGenerator);
 export default presetGenerator;
 
 async function createPreset(tree: Tree, options: Schema) {
-  if (
-    options.preset === Preset.Empty ||
-    options.preset === Preset.Apps ||
-    options.preset === Preset.TS
-  ) {
+  if (options.preset === Preset.Empty || options.preset === Preset.Apps) {
     return;
   } else if (options.preset === Preset.Angular) {
     const {
@@ -178,6 +174,13 @@ async function createPreset(tree: Tree, options: Schema) {
     if (options.preset === Preset.Core) {
       tree.delete('workspace.json');
     }
+  } else if (options.preset === Preset.TS) {
+    const c = readWorkspaceConfiguration(tree);
+    c.workspaceLayout = {
+      appsDir: 'packages',
+      libsDir: 'packages',
+    };
+    updateWorkspaceConfiguration(tree, c);
   } else {
     throw new Error(`Invalid preset ${options.preset}`);
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
TS preset generates a `packages` folder, but first package generated creates it in `libs`

## Expected Behavior
TS preset generates a `packages` folder, and created packages are generated in `packages`

## Context
TS preset used to extend `nx/presets/core.json`, but we don't do that anymore. When we moved away from that, the preset wasn't updated to generate `workspaceLayout`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #10687 
