### PR TITLE
docs(core): correct typo in `ci-workflow` generator description

### DIFF
--- a/docs/generated/packages/workspace.json
+++ b/docs/generated/packages/workspace.json
@@ -701,7 +701,7 @@
         "required": ["ci"],
         "presets": []
       },
-      "description": "Generete a CI workflow.",
+      "description": "Generate a CI workflow.",
       "implementation": "/packages/workspace/src/generators/ci-workflow/ci-workflow#ciWorkflowGenerator.ts",
       "aliases": [],
       "hidden": false,

--- a/packages/workspace/generators.json
+++ b/packages/workspace/generators.json
@@ -146,7 +146,7 @@
     "ci-workflow": {
       "factory": "./src/generators/ci-workflow/ci-workflow#ciWorkflowGenerator",
       "schema": "./src/generators/ci-workflow/schema.json",
-      "description": "Generete a CI workflow."
+      "description": "Generate a CI workflow."
     }
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The description of the `ci-workflow` generator contains the misspelled word *Generete*.

## Expected Behavior
The description of the `ci-workflow` generator contains the properly spelled word *Generate*.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
