### PR TITLE
fix(nextjs): Fixes Next JS Component generator to export component when 'export' flag is provided

### DIFF
--- a/packages/next/src/generators/component/component.ts
+++ b/packages/next/src/generators/component/component.ts
@@ -32,7 +32,6 @@ export async function componentGenerator(host: Tree, options: Schema) {
     ...options,
     directory: getDirectory(host, options),
     pascalCaseFiles: false,
-    export: false,
     classComponent: false,
     routing: false,
   });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Nothing happens to the library `index.ts` when `--export` is provided to the `@nrwl/next:component` generator

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`mylib/src/index.ts` should be updated to export the new component when created with `--export`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
#10322