### PR TITLE
feat(core): support long-running tasks as dependencies

### DIFF
--- a/packages/nx/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/nx/src/tasks-runner/forked-process-task-runner.ts
@@ -99,9 +99,11 @@ export class ForkedProcessTaskRunner {
     {
       streamOutput,
       temporaryOutputPath,
+      prefixRequired,
     }: {
       streamOutput: boolean;
       temporaryOutputPath: string;
+      prefixRequired: boolean;
     }
   ) {
     return new Promise<{ code: number; terminalOutput: string }>((res, rej) => {
@@ -133,8 +135,12 @@ export class ForkedProcessTaskRunner {
         p.stdout.on('data', (chunk) => {
           if (streamOutput) {
             process.stdout.write(
-              addCommandPrefixIfNeeded(task.target.project, chunk, 'utf-8')
-                .content
+              addCommandPrefixIfNeeded(
+                task.target.project,
+                chunk,
+                'utf-8',
+                prefixRequired
+              ).content
             );
           }
           out.push(chunk.toString());
@@ -143,8 +149,12 @@ export class ForkedProcessTaskRunner {
         p.stderr.on('data', (chunk) => {
           if (streamOutput) {
             process.stderr.write(
-              addCommandPrefixIfNeeded(task.target.project, chunk, 'utf-8')
-                .content
+              addCommandPrefixIfNeeded(
+                task.target.project,
+                chunk,
+                'utf-8',
+                prefixRequired
+              ).content
             );
           }
           outWithErr.push(chunk.toString());

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -314,7 +314,7 @@ export function isCacheableTask(
   );
 }
 
-function longRunningTask(task: Task) {
+export function longRunningTask(task: Task) {
   const t = task.target.target;
   return (
     !!task.overrides['watch'] || t === 'serve' || t === 'dev' || t === 'start'

--- a/packages/nx/src/utils/add-command-prefix.ts
+++ b/packages/nx/src/utils/add-command-prefix.ts
@@ -3,9 +3,10 @@ import * as chalk from 'chalk';
 export function addCommandPrefixIfNeeded(
   projectName: string,
   chunk: any,
-  encoding: string
+  encoding: string,
+  forceEnable?: boolean
 ) {
-  if (process.env.NX_PREFIX_OUTPUT === 'true') {
+  if (forceEnable || process.env.NX_PREFIX_OUTPUT === 'true') {
     const lines = (
       typeof chunk === 'string' ? chunk : chunk.toString('utf-8')
     ).split('\n');


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Running a task where dependencies do not exit causes the task to stall on the dependency

## Expected Behavior
If a task is long-running and not the primary task, it will wait until any declared outputs are present, but otherwise it will not block. If any dependencies are noted as long-running, task output will be prefixed with the package name

## Open Questions
* Is there a good way to add automated tests for this?
* Is the output format appropriate?
* Is using the current definition of a "long running task" reasonable?
* Where should this behavior be documented?

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5570
