### PR TITLE
feat(js): add `srcRootForCompilationRoot` option to tsc executor

### DIFF
--- a/docs/generated/packages/js.json
+++ b/docs/generated/packages/js.json
@@ -294,6 +294,10 @@
             "description": "When `updateBuildableProjectDepsInPackageJson` is `true`, this adds dependencies to either `peerDependencies` or `dependencies`.",
             "enum": ["dependencies", "peerDependencies"],
             "default": "peerDependencies"
+          },
+          "srcRootForCompilationRoot": {
+            "type": "string",
+            "description": "Sets the rootDir for TypeScript compilation. When not defined, it uses the project's root property"
           }
         },
         "required": ["main", "outputPath", "tsConfig"],

--- a/packages/js/src/executors/tsc/schema.json
+++ b/packages/js/src/executors/tsc/schema.json
@@ -47,6 +47,10 @@
       "description": "When `updateBuildableProjectDepsInPackageJson` is `true`, this adds dependencies to either `peerDependencies` or `dependencies`.",
       "enum": ["dependencies", "peerDependencies"],
       "default": "peerDependencies"
+    },
+    "srcRootForCompilationRoot": {
+      "type": "string",
+      "description": "Sets the rootDir for TypeScript compilation. When not defined, it uses the project's root property"
     }
   },
   "required": ["main", "outputPath", "tsConfig"],

--- a/packages/js/src/utils/schema.d.ts
+++ b/packages/js/src/utils/schema.d.ts
@@ -41,6 +41,7 @@ export interface ExecutorOptions {
   transformers: TransformerEntry[];
   updateBuildableProjectDepsInPackageJson?: boolean;
   buildableProjectDepsInPackageJsonType?: 'dependencies' | 'peerDependencies';
+  srcRootForCompilationRoot?: string;
 }
 
 export interface NormalizedExecutorOptions extends ExecutorOptions {

--- a/packages/js/src/utils/typescript/compile-typescript-files.ts
+++ b/packages/js/src/utils/typescript/compile-typescript-files.ts
@@ -53,6 +53,7 @@ export async function* compileTypeScriptFiles(
     outputPath: normalizedOptions.outputPath,
     projectName: context.projectName,
     projectRoot: normalizedOptions.projectRoot,
+    rootDir: normalizedOptions.srcRootForCompilationRoot,
     tsConfig: normalizedOptions.tsConfig,
     watch: normalizedOptions.watch,
     getCustomTransformers,


### PR DESCRIPTION
## Current Behavior
Not support `srcRootForCompilationRoot` option in `@nrwl/js:tsc` executor.
This option have been existed on before package(`@nrwl/node:package`).

Now, we can build directory structure like not `dist/libs/<:libName>/<:moduleName>` but only `dist/libs/<:libName>/src/<:moduleName>` by using `@nwrl/js:tsc`.

## Expected Behavior
We should be able to build directory structure like `dist/libs/<:libName>/<:moduleName>` by `srcRootForCompilationRoot` option(`srcRootForCompilationRoot: libs/<:libName>/src`).


## Related Issue(s)
Fixes https://github.com/nrwl/nx/issues/9410
