### PR TITLE
fix(core): Trailing slash in outputs array prevents correct caching

### DIFF
--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -181,6 +181,11 @@ export class Cache {
   }
 
   private async copy(src: string, destination: string): Promise<void> {
+    // 'cp -a /path/dir/ dest/' operates differently to 'cp -a /path/dir dest/'
+    // --> which means actual build works but subsequent populate from cache (using cp -a) does not
+    // --> the fix is to remove trailing slashes to ensure consistent & expected behaviour
+    src = src.replace(/[\/\\]$/, '');
+
     if (this.useFsExtraToCopyAndRemove) {
       return copy(src, destination);
     }


### PR DESCRIPTION
Fix by removing trailing slash when performing `cp -a` into cache.

Add test to confirm fix.

Fixes nrwl/nx#10549