### PR TITLE
feat(web): add named extractCss option in Rollup executor

### DIFF
--- a/docs/generated/packages/web.json
+++ b/docs/generated/packages/web.json
@@ -714,8 +714,8 @@
             "default": []
           },
           "extractCss": {
-            "type": "boolean",
-            "description": "CSS files will be extracted to the output folder.",
+            "type": ["boolean", "string"],
+            "description": "CSS files will be extracted to the output folder. Alternatively custom filename can be provided (e.g. styles.css)",
             "default": true
           },
           "assets": {

--- a/packages/web/src/executors/rollup/schema.d.ts
+++ b/packages/web/src/executors/rollup/schema.d.ts
@@ -10,7 +10,7 @@ export interface WebRollupOptions {
   tsConfig: string;
   project: string;
   entryFile: string;
-  extractCss?: boolean;
+  extractCss?: boolean | string;
   globals?: Globals[];
   external?: string[];
   rollupConfig?: string | string[];

--- a/packages/web/src/executors/rollup/schema.json
+++ b/packages/web/src/executors/rollup/schema.json
@@ -97,8 +97,8 @@
       "default": []
     },
     "extractCss": {
-      "type": "boolean",
-      "description": "CSS files will be extracted to the output folder.",
+      "type": ["boolean", "string"],
+      "description": "CSS files will be extracted to the output folder. Alternatively custom filename can be provided (e.g. styles.css)",
       "default": true
     },
     "assets": {


### PR DESCRIPTION
In Rollup rollup-plugin-postcss has option of 
named extracted css file which can be utilized 
by just passing a string to extractCss option.
This does not affect existing functionality.