### PR TITLE
docs(core): correct grammar in `preset` generator description

### DIFF
--- a/packages/workspace/generators.json
+++ b/packages/workspace/generators.json
@@ -12,7 +12,7 @@
     "preset": {
       "factory": "./src/generators/preset/preset#presetSchematic",
       "schema": "./src/generators/preset/schema.json",
-      "description": "Create application in an empty workspace.",
+      "description": "Create an application in an empty workspace.",
       "hidden": true
     },
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The description of the `preset` generator doesn't include *an* before *application*.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The description of the `preset` generator says *Create **an** application (...)*.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
