### PR TITLE
docs(nxdev): add 13k to github stars counter

### DIFF
--- a/nx-dev/ui-common/src/lib/header.tsx
+++ b/nx-dev/ui-common/src/lib/header.tsx
@@ -152,7 +152,7 @@ export function Header(props: HeaderProps) {
                   >
                     <rect width="10" height="10" />
                   </svg>
-                  12k+
+                  13k+
                 </span>
               </div>
             </a>


### PR DESCRIPTION
It updates the Github stars counter from `12k+` to `13k+` on nx.dev.