### PR TITLE
feat(nx-plugin): add a minimal setup flag to produce an empty nx-plugin

### DIFF
--- a/docs/generated/packages/nx-plugin.json
+++ b/docs/generated/packages/nx-plugin.json
@@ -149,6 +149,11 @@
           "standaloneConfig": {
             "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
             "type": "boolean"
+          },
+          "minimal": {
+            "type": "boolean",
+            "description": "Generate the e2e project with a minimal setup. This would involve not generating tests for a default executor and generator.",
+            "default": false
           }
         },
         "required": ["pluginName", "npmPackageName"],

--- a/docs/generated/packages/nx-plugin.json
+++ b/docs/generated/packages/nx-plugin.json
@@ -93,6 +93,11 @@
             "enum": ["tsc", "swc"],
             "default": "tsc",
             "description": "The compiler used by the build and test targets."
+          },
+          "minimal": {
+            "type": "boolean",
+            "description": "Generate the plugin with a minimal setup. This would involve not generating a default executor and generator.",
+            "default": false
           }
         },
         "required": ["name"],

--- a/packages/nx-plugin/src/generators/e2e-project/e2e.spec.ts
+++ b/packages/nx-plugin/src/generators/e2e-project/e2e.spec.ts
@@ -4,6 +4,7 @@ import {
   readProjectConfiguration,
   readJson,
   getProjects,
+  joinPathFragments,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { e2eProjectGenerator } from './e2e';
@@ -146,5 +147,24 @@ describe('NxPlugin e2e-project Generator', () => {
 
     expect(tree.exists('apps/my-plugin-e2e/tsconfig.spec.json')).toBeTruthy();
     expect(tree.exists('apps/my-plugin-e2e/jest.config.ts')).toBeTruthy();
+  });
+
+  it('should not generate tests when minimal flag is passed', async () => {
+    // ARRANGE & ACT
+    await e2eProjectGenerator(tree, {
+      pluginName: 'my-plugin',
+      pluginOutputPath: `dist/libs/my-plugin`,
+      npmPackageName: '@proj/my-plugin',
+      standaloneConfig: false,
+      minimal: true,
+    });
+
+    const { root } = readProjectConfiguration(tree, 'my-plugin-e2e');
+
+    // ASSERT
+
+    expect(
+      tree.read(joinPathFragments(root, 'tests/my-plugin.spec.ts'), 'utf-8')
+    ).not.toContain("it('should create ");
   });
 });

--- a/packages/nx-plugin/src/generators/e2e-project/e2e.ts
+++ b/packages/nx-plugin/src/generators/e2e-project/e2e.ts
@@ -34,6 +34,7 @@ function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
 
   return {
     ...options,
+    minimal: options.minimal ?? false,
     projectName,
     pluginPropertyName,
     projectRoot,

--- a/packages/nx-plugin/src/generators/e2e-project/files/tests/__pluginName__.spec.ts__tmpl__
+++ b/packages/nx-plugin/src/generators/e2e-project/files/tests/__pluginName__.spec.ts__tmpl__
@@ -23,6 +23,8 @@ describe('<%= pluginName %> e2e', () => {
     runNxCommandAsync('reset');
   });
 
+  <% if(!minimal) { %>
+
   it('should create <%= pluginName %>', async () => {
     const project = uniq('<%= pluginName %>');
     await runNxCommandAsync(
@@ -55,4 +57,5 @@ describe('<%= pluginName %> e2e', () => {
       expect(project.tags).toEqual(['e2etag', 'e2ePackage']);
     }, 120000);
   });
+  <% } %>
 });

--- a/packages/nx-plugin/src/generators/e2e-project/schema.d.ts
+++ b/packages/nx-plugin/src/generators/e2e-project/schema.d.ts
@@ -5,4 +5,5 @@ export interface Schema {
   pluginOutputPath?: string;
   jestConfig?: string;
   standaloneConfig?: boolean;
+  minimal?: boolean;
 }

--- a/packages/nx-plugin/src/generators/e2e-project/schema.json
+++ b/packages/nx-plugin/src/generators/e2e-project/schema.json
@@ -34,6 +34,11 @@
     "standaloneConfig": {
       "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
       "type": "boolean"
+    },
+    "minimal": {
+      "type": "boolean",
+      "description": "Generate the e2e project with a minimal setup. This would involve not generating tests for a default executor and generator.",
+      "default": false
     }
   },
   "required": ["pluginName", "npmPackageName"],

--- a/packages/nx-plugin/src/generators/plugin/plugin.spec.ts
+++ b/packages/nx-plugin/src/generators/plugin/plugin.spec.ts
@@ -128,6 +128,48 @@ describe('NxPlugin Plugin Generator', () => {
     ).toContain('const variable = "<%= projectName %>";');
   });
 
+  it('should not create generator and executor files for minimal setups', async () => {
+    await pluginGenerator(tree, getSchema({ name: 'myPlugin', minimal: true }));
+
+    [
+      'libs/my-plugin/project.json',
+      'libs/my-plugin/generators.json',
+      'libs/my-plugin/executors.json',
+    ].forEach((path) => expect(tree.exists(path)).toBeTruthy());
+
+    [
+      'libs/my-plugin/src/generators/my-plugin/schema.d.ts',
+      'libs/my-plugin/src/generators/my-plugin/generator.ts',
+      'libs/my-plugin/src/generators/my-plugin/generator.spec.ts',
+      'libs/my-plugin/src/generators/my-plugin/schema.json',
+      'libs/my-plugin/src/generators/my-plugin/schema.d.ts',
+      'libs/my-plugin/src/generators/my-plugin/files/src/index.ts__template__',
+      'libs/my-plugin/src/executors/build/executor.ts',
+      'libs/my-plugin/src/executors/build/executor.spec.ts',
+      'libs/my-plugin/src/executors/build/schema.json',
+      'libs/my-plugin/src/executors/build/schema.d.ts',
+    ].forEach((path) => expect(tree.exists(path)).toBeFalsy());
+
+    expect(tree.read('libs/my-plugin/generators.json', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "{
+        \\"$schema\\": \\"http://json-schema.org/schema\\",
+        \\"name\\": \\"my-plugin\\",
+        \\"version\\": \\"0.0.1\\",
+        \\"generators\\": {}
+      }
+      "
+    `);
+    expect(tree.read('libs/my-plugin/executors.json', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "{
+        \\"$schema\\": \\"http://json-schema.org/schema\\",
+        \\"executors\\": {}
+      }
+      "
+    `);
+  });
+
   describe('--unitTestRunner', () => {
     describe('none', () => {
       it('should not generate test files', async () => {

--- a/packages/nx-plugin/src/generators/plugin/plugin.ts
+++ b/packages/nx-plugin/src/generators/plugin/plugin.ts
@@ -37,19 +37,20 @@ async function addFiles(host: Tree, options: NormalizedSchema) {
     }
   );
 
-  if (!options.minimal) {
-    await generatorGenerator(host, {
-      project: options.name,
-      name: options.name,
-      unitTestRunner: options.unitTestRunner,
-    });
-    await executorGenerator(host, {
-      project: options.name,
-      name: 'build',
-      unitTestRunner: options.unitTestRunner,
-      includeHasher: false,
-    });
+  if (options.minimal) {
+    return;
   }
+  await generatorGenerator(host, {
+    project: options.name,
+    name: options.name,
+    unitTestRunner: options.unitTestRunner,
+  });
+  await executorGenerator(host, {
+    project: options.name,
+    name: 'build',
+    unitTestRunner: options.unitTestRunner,
+    includeHasher: false,
+  });
 }
 
 function updateWorkspaceJson(host: Tree, options: NormalizedSchema) {
@@ -120,6 +121,7 @@ export async function pluginGenerator(host: Tree, schema: Schema) {
     pluginOutputPath: `dist/${options.libsDir}/${options.projectDirectory}`,
     npmPackageName: options.npmPackageName,
     standaloneConfig: options.standaloneConfig ?? true,
+    minimal: options.minimal ?? false,
   });
   if (options.linter === Linter.EsLint && !options.skipLintChecks) {
     await pluginLintCheckGenerator(host, { projectName: options.name });

--- a/packages/nx-plugin/src/generators/plugin/plugin.ts
+++ b/packages/nx-plugin/src/generators/plugin/plugin.ts
@@ -37,17 +37,19 @@ async function addFiles(host: Tree, options: NormalizedSchema) {
     }
   );
 
-  await generatorGenerator(host, {
-    project: options.name,
-    name: options.name,
-    unitTestRunner: options.unitTestRunner,
-  });
-  await executorGenerator(host, {
-    project: options.name,
-    name: 'build',
-    unitTestRunner: options.unitTestRunner,
-    includeHasher: false,
-  });
+  if (!options.minimal) {
+    await generatorGenerator(host, {
+      project: options.name,
+      name: options.name,
+      unitTestRunner: options.unitTestRunner,
+    });
+    await executorGenerator(host, {
+      project: options.name,
+      name: 'build',
+      unitTestRunner: options.unitTestRunner,
+      includeHasher: false,
+    });
+  }
 }
 
 function updateWorkspaceJson(host: Tree, options: NormalizedSchema) {

--- a/packages/nx-plugin/src/generators/plugin/schema.d.ts
+++ b/packages/nx-plugin/src/generators/plugin/schema.d.ts
@@ -13,4 +13,5 @@ export interface Schema {
   standaloneConfig?: boolean;
   setParserOptionsProject?: boolean;
   compiler: 'swc' | 'tsc';
+  minimal?: boolean;
 }

--- a/packages/nx-plugin/src/generators/plugin/schema.json
+++ b/packages/nx-plugin/src/generators/plugin/schema.json
@@ -77,6 +77,11 @@
       "enum": ["tsc", "swc"],
       "default": "tsc",
       "description": "The compiler used by the build and test targets."
+    },
+    "minimal": {
+      "type": "boolean",
+      "description": "Generate the plugin with a minimal setup. This would involve not generating a default executor and generator.",
+      "default": false
     }
   },
   "required": ["name"],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Every time we generate an nx-plugin, it comes with a generator and an executor.

For most cases this is fine, however, I've noticed a few times where it would be easier to simply have an empty plugin shell, where the `generator` and `executor` generators can then be used, rather than expecting devs to manually remove this boilerplate generator and executor.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Have a flag to generate an empty Nx Plugin

