### PR TITLE
docs(angular): add note on the import.meta error in mf docs

### DIFF
--- a/docs/shared/guides/module-federation/dynamic-mfe-angular.md
+++ b/docs/shared/guides/module-federation/dynamic-mfe-angular.md
@@ -364,6 +364,14 @@ nx serve dashboard --devRemotes=login
 
 This concludes the setup required for a Micro Frontend approach using Static Module Federation.
 
+> _When serving module federation apps in dev mode locally, there'll be an error output to the console, `import.meta cannot be used outside of a module`, and the script that is coming from is `styles.js`. It's a known error output, but it doesn't actually cause any breakages from as far as our testing has shown. It's because Angular compiler attaches the styles.js file to the index.html in a script tag with defer._
+>
+> _It needs to be attached with `type=module`, but Angular can't make that change because it breaks HMR. They also provide no way of hooking into that process for us to patch it ourselves._
+>
+> _The good news is that the error doesn't propagate to production, because styles are compiled to a CSS file , so there's no erroneous JS to log an error._
+>
+> _It's worth stressing that there's been no actual errors or breakages noted from our tests._
+
 ## Converting the Dashboard application
 
 The Dashboard application is a Host application that loads the Remote applications at runtime based on their deployed locations when the application was built using Static Module Federation.


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
Missing note about the import.meta error in docs

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Add the import.meta error as a note in the docs

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #10711
