### PR TITLE
feat(react): add generateExportsField option to `@nrwl/web:rollup` executor so it is an opt-in feature

### DIFF
--- a/docs/generated/packages/web.json
+++ b/docs/generated/packages/web.json
@@ -757,6 +757,16 @@
             "type": "boolean",
             "description": "Sets `javascriptEnabled` option for less loader",
             "default": false
+          },
+          "generateExportsField": {
+            "type": "boolean",
+            "description": "Generate package.json with 'exports' field. This field defines entry points in the package and is used by Node and the TypeScript compiler.",
+            "default": false
+          },
+          "skipTypeField": {
+            "type": "boolean",
+            "description": "Prevents 'type' field from being added to compiled package.json file. Only use this if you are having an issue with this field.",
+            "default": false
           }
         },
         "required": ["tsConfig", "project", "entryFile", "outputPath"],

--- a/packages/web/src/executors/rollup/lib/update-package-json.spec.ts
+++ b/packages/web/src/executors/rollup/lib/update-package-json.spec.ts
@@ -2,8 +2,6 @@ import { updatePackageJson } from './update-package-json';
 import * as utils from 'nx/src/utils/fileutils';
 import { PackageJson } from 'nx/src/utils/package-json';
 
-jest.mock('fs', () => require('memfs').fs);
-
 describe('updatePackageJson', () => {
   const commonOptions = {
     outputPath: 'dist/index.js',
@@ -23,132 +21,273 @@ describe('updatePackageJson', () => {
     cwd: '',
   };
 
-  it('should support ESM', () => {
-    const spy = jest.spyOn(utils, 'writeJsonFile');
+  // TODO(jack): In Nx 15 we want this field to always generate.
+  describe('generateExportsField: true', () => {
+    it('should support ESM', () => {
+      const spy = jest.spyOn(utils, 'writeJsonFile');
 
-    updatePackageJson(
-      {
-        ...commonOptions,
-        format: ['esm'],
-      },
-      sharedContext,
-      { type: 'app', name: 'test', data: {} },
-      [],
-      {} as unknown as PackageJson
-    );
-
-    expect(utils.writeJsonFile).toHaveBeenCalledWith(expect.anything(), {
-      exports: {
-        '.': {
-          types: './index.d.ts',
-          import: './index.js',
+      updatePackageJson(
+        {
+          ...commonOptions,
+          generateExportsField: true,
+          format: ['esm'],
         },
-      },
-      main: './index.js',
-      module: './index.js',
-      type: 'module',
-      types: './index.d.ts',
-    });
+        sharedContext,
+        { type: 'app', name: 'test', data: {} },
+        [],
+        {} as unknown as PackageJson
+      );
 
-    spy.mockRestore();
-  });
-
-  it('should support CJS', () => {
-    const spy = jest.spyOn(utils, 'writeJsonFile');
-
-    updatePackageJson(
-      {
-        ...commonOptions,
-        format: ['cjs'],
-      },
-      sharedContext,
-      { type: 'app', name: 'test', data: {} },
-      [],
-      {} as unknown as PackageJson
-    );
-
-    expect(utils.writeJsonFile).toHaveBeenCalledWith(expect.anything(), {
-      exports: {
-        '.': {
-          types: './index.d.ts',
-          require: './index.cjs',
-        },
-      },
-      main: './index.cjs',
-      type: 'commonjs',
-      types: './index.d.ts',
-    });
-
-    spy.mockRestore();
-  });
-
-  it('should support ESM + CJS', () => {
-    const spy = jest.spyOn(utils, 'writeJsonFile');
-
-    updatePackageJson(
-      {
-        ...commonOptions,
-        format: ['esm', 'cjs'],
-      },
-      sharedContext,
-      { type: 'app', name: 'test', data: {} },
-      [],
-      {} as unknown as PackageJson
-    );
-
-    expect(utils.writeJsonFile).toHaveBeenCalledWith(expect.anything(), {
-      exports: {
-        '.': {
-          types: './index.d.ts',
-          import: './index.js',
-          require: './index.cjs',
-        },
-      },
-      main: './index.cjs',
-      module: './index.js',
-      type: 'module',
-      types: './index.d.ts',
-    });
-
-    spy.mockRestore();
-  });
-
-  it('should support custom exports field', () => {
-    const spy = jest.spyOn(utils, 'writeJsonFile');
-
-    updatePackageJson(
-      {
-        ...commonOptions,
-        format: ['esm'],
-      },
-      sharedContext,
-      { type: 'app', name: 'test', data: {} },
-      [],
-      {
+      expect(utils.writeJsonFile).toHaveBeenCalledWith(expect.anything(), {
         exports: {
-          foo: {
+          '.': {
+            types: './index.d.ts',
+            import: './index.js',
+          },
+        },
+        main: './index.js',
+        module: './index.js',
+        type: 'module',
+        types: './index.d.ts',
+      });
+
+      spy.mockRestore();
+    });
+
+    it('should support CJS', () => {
+      const spy = jest.spyOn(utils, 'writeJsonFile');
+
+      updatePackageJson(
+        {
+          ...commonOptions,
+          generateExportsField: true,
+          format: ['cjs'],
+        },
+        sharedContext,
+        { type: 'app', name: 'test', data: {} },
+        [],
+        {} as unknown as PackageJson
+      );
+
+      expect(utils.writeJsonFile).toHaveBeenCalledWith(expect.anything(), {
+        exports: {
+          '.': {
+            types: './index.d.ts',
+            require: './index.cjs',
+          },
+        },
+        main: './index.cjs',
+        type: 'commonjs',
+        types: './index.d.ts',
+      });
+
+      spy.mockRestore();
+    });
+
+    it('should support ESM + CJS', () => {
+      const spy = jest.spyOn(utils, 'writeJsonFile');
+
+      updatePackageJson(
+        {
+          ...commonOptions,
+          generateExportsField: true,
+          format: ['esm', 'cjs'],
+        },
+        sharedContext,
+        { type: 'app', name: 'test', data: {} },
+        [],
+        {} as unknown as PackageJson
+      );
+
+      expect(utils.writeJsonFile).toHaveBeenCalledWith(expect.anything(), {
+        exports: {
+          '.': {
+            types: './index.d.ts',
+            import: './index.js',
+            require: './index.cjs',
+          },
+        },
+        main: './index.cjs',
+        module: './index.js',
+        type: 'module',
+        types: './index.d.ts',
+      });
+
+      spy.mockRestore();
+    });
+
+    it('should support custom exports field', () => {
+      const spy = jest.spyOn(utils, 'writeJsonFile');
+
+      updatePackageJson(
+        {
+          ...commonOptions,
+          generateExportsField: true,
+          format: ['esm'],
+        },
+        sharedContext,
+        { type: 'app', name: 'test', data: {} },
+        [],
+        {
+          exports: {
+            './foo': {
+              import: './foo.js',
+            },
+          },
+        } as unknown as PackageJson
+      );
+
+      expect(utils.writeJsonFile).toHaveBeenCalledWith(expect.anything(), {
+        exports: {
+          '.': {
+            types: './index.d.ts',
+            import: './index.js',
+          },
+          './foo': {
             import: './foo.js',
           },
         },
-      } as unknown as PackageJson
-    );
+        main: './index.js',
+        module: './index.js',
+        type: 'module',
+        types: './index.d.ts',
+      });
 
-    expect(utils.writeJsonFile).toHaveBeenCalledWith(expect.anything(), {
-      exports: {
-        '.': {
-          types: './index.d.ts',
-          import: './index.js',
+      spy.mockRestore();
+    });
+  });
+
+  describe('generateExportsField: false', () => {
+    it('should support ESM', () => {
+      const spy = jest.spyOn(utils, 'writeJsonFile');
+
+      updatePackageJson(
+        {
+          ...commonOptions,
+          format: ['esm'],
         },
-        foo: {
-          import: './foo.js',
-        },
-      },
-      main: './index.js',
-      module: './index.js',
-      type: 'module',
-      types: './index.d.ts',
+        sharedContext,
+        { type: 'app', name: 'test', data: {} },
+        [],
+        {} as unknown as PackageJson
+      );
+
+      expect(utils.writeJsonFile).toHaveBeenCalledWith(expect.anything(), {
+        main: './index.js',
+        module: './index.js',
+        type: 'module',
+        types: './index.d.ts',
+      });
+
+      spy.mockRestore();
     });
 
-    spy.mockRestore();
+    it('should support CJS', () => {
+      const spy = jest.spyOn(utils, 'writeJsonFile');
+
+      updatePackageJson(
+        {
+          ...commonOptions,
+          format: ['cjs'],
+        },
+        sharedContext,
+        { type: 'app', name: 'test', data: {} },
+        [],
+        {} as unknown as PackageJson
+      );
+
+      expect(utils.writeJsonFile).toHaveBeenCalledWith(expect.anything(), {
+        main: './index.cjs',
+        type: 'commonjs',
+        types: './index.d.ts',
+      });
+
+      spy.mockRestore();
+    });
+
+    it('should support ESM + CJS', () => {
+      const spy = jest.spyOn(utils, 'writeJsonFile');
+
+      updatePackageJson(
+        {
+          ...commonOptions,
+          format: ['esm', 'cjs'],
+        },
+        sharedContext,
+        { type: 'app', name: 'test', data: {} },
+        [],
+        {} as unknown as PackageJson
+      );
+
+      expect(utils.writeJsonFile).toHaveBeenCalledWith(expect.anything(), {
+        main: './index.cjs',
+        module: './index.js',
+        type: 'module',
+        types: './index.d.ts',
+      });
+
+      spy.mockRestore();
+    });
+
+    it('should support custom exports field', () => {
+      const spy = jest.spyOn(utils, 'writeJsonFile');
+
+      updatePackageJson(
+        {
+          ...commonOptions,
+          format: ['esm'],
+        },
+        sharedContext,
+        { type: 'app', name: 'test', data: {} },
+        [],
+        {
+          exports: {
+            './foo': {
+              import: './foo.js',
+            },
+          },
+        } as unknown as PackageJson
+      );
+
+      expect(utils.writeJsonFile).toHaveBeenCalledWith(expect.anything(), {
+        main: './index.js',
+        module: './index.js',
+        type: 'module',
+        types: './index.d.ts',
+        exports: {
+          './foo': {
+            import: './foo.js',
+          },
+        },
+      });
+
+      spy.mockRestore();
+    });
+  });
+
+  describe('skipTypeField', () => {
+    it('should not add "type" field in package.json', () => {
+      const spy = jest.spyOn(utils, 'writeJsonFile');
+
+      updatePackageJson(
+        {
+          ...commonOptions,
+          format: ['esm'],
+          skipTypeField: true,
+        },
+        sharedContext,
+        { type: 'app', name: 'test', data: {} },
+        [],
+        {} as unknown as PackageJson
+      );
+
+      expect(utils.writeJsonFile).toHaveBeenCalledWith(expect.anything(), {
+        main: './index.js',
+        module: './index.js',
+        types: './index.d.ts',
+      });
+
+      spy.mockRestore();
+    });
   });
 });

--- a/packages/web/src/executors/rollup/lib/update-package-json.ts
+++ b/packages/web/src/executors/rollup/lib/update-package-json.ts
@@ -47,15 +47,20 @@ export function updatePackageJson(
     exports['.']['require'] = './index.cjs';
   }
 
-  packageJson.type = options.format.includes('esm') ? 'module' : 'commonjs';
+  if (!options.skipTypeField) {
+    packageJson.type = options.format.includes('esm') ? 'module' : 'commonjs';
+  }
 
   // Support for older TS versions < 4.5
   packageJson.types = types;
 
-  packageJson.exports = {
-    ...packageJson.exports,
-    ...exports,
-  };
+  // TODO(jack): remove this for Nx 15
+  if (options.generateExportsField) {
+    packageJson.exports = {
+      ...packageJson.exports,
+      ...exports,
+    };
+  }
 
   writeJsonFile(`${options.outputPath}/package.json`, packageJson);
 

--- a/packages/web/src/executors/rollup/schema.d.ts
+++ b/packages/web/src/executors/rollup/schema.d.ts
@@ -23,4 +23,7 @@ export interface WebRollupOptions {
   format: string[];
   compiler?: Compiler;
   javascriptEnabled?: boolean;
+  // TODO(jack): remove this for Nx 15
+  skipTypeField?: boolean;
+  generateExportsField?: boolean;
 }

--- a/packages/web/src/executors/rollup/schema.json
+++ b/packages/web/src/executors/rollup/schema.json
@@ -119,10 +119,19 @@
       "type": "boolean",
       "description": "Sets `javascriptEnabled` option for less loader",
       "default": false
+    },
+    "generateExportsField": {
+      "type": "boolean",
+      "description": "Generate package.json with 'exports' field. This field defines entry points in the package and is used by Node and the TypeScript compiler.",
+      "default": false
+    },
+    "skipTypeField": {
+      "type": "boolean",
+      "description": "Prevents 'type' field from being added to compiled package.json file. Only use this if you are having an issue with this field.",
+      "default": false
     }
   },
   "required": ["tsConfig", "project", "entryFile", "outputPath"],
-
   "definitions": {
     "assetPattern": {
       "oneOf": [


### PR DESCRIPTION
The new `exports` field is a way to specify entry points for packages. Node and TypeScript both support this  field, however it is causing issues with other tooling, so for now it is opt-in via the `generateExportsField` option.

Also adds skipTypeField option in case that is causing issues for users.

## Current Behavior

Building with `@nrwl/web:rollup` generates package.json with `exports` field for the main entry point. This is causing some issues with other tooling/bundlers.

## Expected Behavior

Users must set `generateExportsField: true` in order to generate this field. By default it is off.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #10741
