### PR TITLE
fix(angular): remove unnecessary unused entry module import from new mf remote apps

### DIFF
--- a/packages/angular/src/generators/remote/remote.ts
+++ b/packages/angular/src/generators/remote/remote.ts
@@ -86,17 +86,10 @@ export class AppComponent {}`;
 
   tree.write(
     joinPathFragments(project.sourceRoot, 'app/app.module.ts'),
-    `/*
-* This RemoteEntryModule is imported here to allow TS to find the Module during
-* compilation, allowing it to be included in the built bundle. This is required
-* for the Module Federation Plugin to expose the Module correctly.
-* */
-import { RemoteEntryModule } from './remote-entry/entry.module';
-import { NgModule } from '@angular/core';
+    `import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-
-import { AppComponent } from './app.component';
 import { RouterModule } from '@angular/router';
+import { AppComponent } from './app.component';
 
 @NgModule({
  declarations: [AppComponent],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Newly generated MF remote apps have an unused import to the remote entry module in the `app.module.ts`. This is no longer needed because the `app.module.ts` is set up with a route that lazy loads the remote entry module.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Newly generated MF remote apps should not have an unused import to the remote entry module in the `app.module.ts`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
