### PR TITLE
fix(core): handle optional cli property when writing workspace configuration in the ng cli adapter

### DIFF
--- a/packages/nx/src/adapter/ngcli-adapter.ts
+++ b/packages/nx/src/adapter/ngcli-adapter.ts
@@ -436,7 +436,7 @@ export class NxScopedHost extends virtualFs.ScopedHost<any> {
         if (formatted) {
           const { cli, generators, defaultProject, ...workspaceJson } =
             formatted;
-          delete cli.schematicCollections;
+          delete cli?.schematicCollections;
           return merge(
             this.writeWorkspaceConfigFiles(context, workspaceJson),
             cli || generators || defaultProject
@@ -451,7 +451,7 @@ export class NxScopedHost extends virtualFs.ScopedHost<any> {
             defaultProject,
             ...angularJson
           } = w;
-          delete cli.schematicCollections;
+          delete cli?.schematicCollections;
           return merge(
             this.writeWorkspaceConfigFiles(context, angularJson),
             cli || schematics
@@ -467,7 +467,7 @@ export class NxScopedHost extends virtualFs.ScopedHost<any> {
     }
     const { cli, schematics, generators, defaultProject, ...angularJson } =
       config;
-    delete cli.schematicCollections;
+    delete cli?.schematicCollections;
 
     return merge(
       this.writeWorkspaceConfigFiles(context, angularJson),


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When using an Angular CLI schematic in a workspace where the optional `cli` key is not set in the `nx.json`, the generation fails.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Using an Angular CLI schematic should run successfully in a workspace where the optional `cli` key is not set in the `nx.json`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #10746 
