### PR TITLE
docs(core): fix links to nx tutorials

### DIFF
--- a/nx-dev/ui-common/src/lib/npx-create-nx-workspace.tsx
+++ b/nx-dev/ui-common/src/lib/npx-create-nx-workspace.tsx
@@ -599,12 +599,12 @@ export function NpxCreateNxWorkspaceAnimation({
                     First time using Nx? Check out this interactive Nx tutorial.
                     <br />
                     <a
-                      href="https://nx.dev/react/tutorial/01-create-application"
+                      href="https://nx.dev/react-tutorial/01-create-application"
                       target="_blank"
                       rel="noreferrer"
                       className="cursor-pointer opacity-50 hover:underline hover:opacity-100"
                     >
-                      https://nx.dev/react/tutorial/01-create-application
+                      https://nx.dev/react-tutorial/01-create-application
                     </a>
                     <br />
                     Prefer watching videos? Check out this free Nx course on

--- a/packages/angular/src/generators/application/lib/nrwl-home-tpl.ts
+++ b/packages/angular/src/generators/application/lib/nrwl-home-tpl.ts
@@ -566,7 +566,7 @@ export const nrwlHomeTemplate = {
                 />
               </svg>
             </a>
-            <a href="https://nx.dev/tutorial/01-create-application?utm_source=nx-project" target="_blank" rel="noreferrer" class="list-item-link">
+            <a href="https://nx.dev/angular-tutorial/01-create-application?utm_source=nx-project" target="_blank" rel="noreferrer" class="list-item-link">
               <svg
                 fill="none"
                 stroke="currentColor"

--- a/packages/cra-to-nx/README.md
+++ b/packages/cra-to-nx/README.md
@@ -45,7 +45,7 @@ nx generate lib ui-button
 
 ### Courses, guides, docs
 
-- [Follow the Nx React tutorial](https://nx.dev/react/tutorial/01-create-application)
+- [Follow the Nx React tutorial](https://nx.dev/react-tutorial/01-create-application)
 
 - [Free Nx course on Egghead.io](https://egghead.io/playlists/scale-react-development-with-nx-4038)
 

--- a/packages/cra-to-nx/src/lib/cra-to-nx.ts
+++ b/packages/cra-to-nx/src/lib/cra-to-nx.ts
@@ -167,7 +167,7 @@ export async function createNxWorkspaceForReact(options: Record<string, any>) {
   output.note({
     title: 'First time using Nx? Check out this interactive Nx tutorial.',
     bodyLines: [
-      `https://nx.dev/react/tutorial/01-create-application`,
+      `https://nx.dev/react-tutorial/01-create-application`,
       ` `,
       `Prefer watching videos? Check out this free Nx course on Egghead.io.`,
       `https://egghead.io/playlists/scale-react-development-with-nx-4038`,

--- a/packages/next/src/generators/application/lib/create-application-files.helpers.ts
+++ b/packages/next/src/generators/application/lib/create-application-files.helpers.ts
@@ -152,7 +152,7 @@ export function createAppJsx(name: string) {
               </svg>
             </a>
             <a
-              href="https://nx.dev/tutorial/01-create-application?utm_source=nx-project"
+              href="https://nx.dev/react-tutorial/01-create-application?utm_source=nx-project"
               target="_blank"
               rel="noreferrer"
               className="list-item-link"

--- a/packages/react-native/src/generators/application/files/app/src/app/App.tsx.template
+++ b/packages/react-native/src/generators/application/files/app/src/app/App.tsx.template
@@ -132,7 +132,7 @@ export const App = () => {
                 style={[styles.listItem, styles.learning]}
                 onPress={() =>
                   Linking.openURL(
-                    'https://nx.dev/tutorial/01-create-application?utm_source=nx-project'
+                    'https://nx.dev/react-tutorial/01-create-application?utm_source=nx-project'
                   )
                 }
               >

--- a/packages/react/src/generators/application/files/common/src/app/nx-welcome.tsx
+++ b/packages/react/src/generators/application/files/common/src/app/nx-welcome.tsx
@@ -565,7 +565,7 @@ export function NxWelcome({ title }: { title: string }) {
                 </svg>
               </a>
               <a
-                href="https://nx.dev/tutorial/01-create-application?utm_source=nx-project"
+                href="https://nx.dev/react-tutorial/01-create-application?utm_source=nx-project"
                 target="_blank"
                 rel="noreferrer"
                 className="list-item-link"

--- a/packages/web/src/generators/application/files/app/src/app/app.element.ts__tmpl__
+++ b/packages/web/src/generators/application/files/app/src/app/app.element.ts__tmpl__
@@ -151,7 +151,7 @@ export class AppElement extends HTMLElement {
                 />
               </svg>
             </a>
-            <a href="https://nx.dev/tutorial/01-create-application?utm_source=nx-project" target="_blank" rel="noreferrer" class="list-item-link">
+            <a href="https://nx.dev/react-tutorial/01-create-application?utm_source=nx-project" target="_blank" rel="noreferrer" class="list-item-link">
               <svg
                 fill="none"
                 stroke="currentColor"

--- a/packages/workspace/src/generators/workspace/files/README.md__tmpl__
+++ b/packages/workspace/src/generators/workspace/files/README.md__tmpl__
@@ -14,7 +14,7 @@ This project was generated using [Nx](https://nx.dev).
 
 [10-minute video showing all Nx features](https://nx.dev/getting-started/intro)
 
-[Interactive Tutorial](https://nx.dev/tutorial/01-create-application)
+[Interactive Tutorial](https://nx.dev/react-tutorial/01-create-application)
 
 ## Adding capabilities to your workspace
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Tutorial links lead to a 404.

![image](https://user-images.githubusercontent.com/93159770/173938533-fa861a95-b5f3-4666-add0-a16166914446.png)


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Tutorial links lead to the appropriate tutorial page.

![image](https://user-images.githubusercontent.com/93159770/173938992-2e8e8115-ba30-4f18-8ec1-e6c02b1fddd7.png)


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
