### PR TITLE
fix(angular): ensure @schematics/angular version gets updated when listed in the package.json

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -1148,6 +1148,10 @@
           "version": "~14.0.0",
           "alwaysAddToPackageJson": false
         },
+        "@schematics/angular": {
+          "version": "~14.0.0",
+          "alwaysAddToPackageJson": false
+        },
         "@angular/core": {
           "version": "~14.0.0",
           "alwaysAddToPackageJson": true


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The `@schematics/angular` package version is not updated when it's listed in the `package.json` and migrations are run containing version updates for other Angular CLI packages.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The `@schematics/angular` package version should be updated when it's listed in the `package.json` and other Angular CLI packages are updated.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #10729 
