### PR TITLE
docs(misc): fixed typo in plugin for ci-workflow label

### DIFF
--- a/docs/generated/packages/workspace.json
+++ b/docs/generated/packages/workspace.json
@@ -701,7 +701,7 @@
         "required": ["ci"],
         "presets": []
       },
-      "description": "Generete a CI workflow.",
+      "description": "Generate a CI workflow.",
       "implementation": "/packages/workspace/src/generators/ci-workflow/ci-workflow#ciWorkflowGenerator.ts",
       "aliases": [],
       "hidden": false,

--- a/docs/shared/monorepo-nx-enterprise.md
+++ b/docs/shared/monorepo-nx-enterprise.md
@@ -166,7 +166,7 @@ Read more about workspace generators in the Workspace Generators guide.
 
 ### Workspace Lint Checks
 
-Custom lint checks is another great way to enforce best practices. We can create custom lint checks in the `tools/lint` directory and then register them in `tslint.json`or `.eslintrc.json`.
+Custom lint checks is another great way to enforce best practices. We can create custom lint checks in the `tools/lint` directory and then register them in `tslint.json` or `.eslintrc.json`.
 
 ## Developer Workflow
 

--- a/packages/workspace/generators.json
+++ b/packages/workspace/generators.json
@@ -146,7 +146,7 @@
     "ci-workflow": {
       "factory": "./src/generators/ci-workflow/ci-workflow#ciWorkflowGenerator",
       "schema": "./src/generators/ci-workflow/schema.json",
-      "description": "Generete a CI workflow."
+      "description": "Generate a CI workflow."
     }
   }
 }


### PR DESCRIPTION
Fixed typo in ci-workflow label generete -> generate

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Generete a ci-workflow

## Expected Behavior
Generate a ci-workflow

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
