### PR TITLE
fix(core): update move generator to move multiple projects in eslint parserOptions override

### DIFF
--- a/packages/workspace/src/generators/move/lib/update-eslintrc-json.ts
+++ b/packages/workspace/src/generators/move/lib/update-eslintrc-json.ts
@@ -9,7 +9,7 @@ import { NormalizedSchema } from '../schema';
 
 interface PartialEsLintrcOverride {
   parserOptions?: {
-    project?: [string];
+    project?: string[];
   };
 }
 
@@ -65,9 +65,9 @@ export function updateEslintrcJson(
 
     eslintRcJson.overrides?.forEach((o) => {
       if (o.parserOptions?.project) {
-        o.parserOptions.project = [
-          `${schema.relativeToRootDestination}/tsconfig.*?.json`,
-        ];
+        o.parserOptions.project = o.parserOptions.project.map((p) =>
+          p.replace(project.root, schema.relativeToRootDestination)
+        );
       }
     });
 


### PR DESCRIPTION
move generator now copies over all projects in the parserOptions of the .eslintrc.json rather than
just overriding with the base tsconfigs

ISSUES CLOSED: #10774

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

To move an existing library, we run the following
```sh
nx g @nrwl/workspace:move --project my-feature-lib shared/my-feature-lib
```
In our case, the move does not keep the storybook config file in `.eslintrc.json` after the move. This is under `overrides > parserOptions > projects`. It overrides it with just the base tsconfigs.

Before the move, the `eslintrc.json` looks like like this:
```json
...
"parserOptions": {
  "project": [
    "libs/my-feature-lib/tsconfig.*?.json",
    "libs/my-feature-lib/.storybook/tsconfig.json"
  ]
}
...
```
      
When you run the move command, the new `eslintrc.json` will look like this:
```json
...
"parserOptions": {
  "project": [
    "libs/shared/my-feature-lib/tsconfig.*?.json",
  ]
}
...
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The generator now copies all projects from the existing array, and updates the project root to the new path, no longer dropping any config files. This results in the following output in `.eslintrc.json`
```json
...
"parserOptions": {
  "project": [
    "libs/shared/my-feature-lib/tsconfig.*?.json",
    "libs/shared/my-feature-lib/.storybook/tsconfig.json"
  ]
}
...
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #10774 
