### PR TITLE
fix(angular): set default project if not set when creating an application

### DIFF
--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -5,6 +5,7 @@ import {
   parseJson,
   readJson,
   readProjectConfiguration,
+  readWorkspaceConfiguration,
   updateJson,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
@@ -203,6 +204,29 @@ describe('app', () => {
       // ASSERT
       const appTsConfig = readJson(appTree, 'apps/app/tsconfig.json');
       expect(appTsConfig.extends).toBe('../../tsconfig.json');
+    });
+
+    it('should set default project', async () => {
+      // ACT
+      await generateApp(appTree);
+
+      // ASSERT
+      const { defaultProject } = readWorkspaceConfiguration(appTree);
+      expect(defaultProject).toBe('my-app');
+    });
+
+    it('should not overwrite default project if already set', async () => {
+      // ARRANGE
+      const workspace = readWorkspaceConfiguration(appTree);
+      workspace.defaultProject = 'some-awesome-project';
+      devkit.updateWorkspaceConfiguration(appTree, workspace);
+
+      // ACT
+      await generateApp(appTree);
+
+      // ASSERT
+      const { defaultProject } = readWorkspaceConfiguration(appTree);
+      expect(defaultProject).toBe('some-awesome-project');
     });
   });
 

--- a/packages/angular/src/generators/application/application.ts
+++ b/packages/angular/src/generators/application/application.ts
@@ -20,6 +20,7 @@ import {
   enableStrictTypeChecking,
   normalizeOptions,
   setApplicationStrictDefault,
+  setDefaultProject,
   updateAppComponentTemplate,
   updateComponentSpec,
   updateConfigFiles,
@@ -106,6 +107,7 @@ export async function applicationGenerator(
   await addUnitTestRunner(host, options);
   await addE2e(host, options);
   updateEditorTsConfig(host, options);
+  setDefaultProject(host, options);
 
   if (options.backendProject) {
     addProxyConfig(host, options);

--- a/packages/angular/src/generators/application/lib/index.ts
+++ b/packages/angular/src/generators/application/lib/index.ts
@@ -12,6 +12,7 @@ export * from './nrwl-home-tpl';
 export * from './remove-scaffolded-e2e';
 export * from './root-router-config';
 export * from './set-app-strict-default';
+export * from './set-default-project';
 export * from './update-component-spec';
 export * from './update-app-component-template';
 export * from './update-nx-component-template';

--- a/packages/angular/src/generators/application/lib/set-default-project.ts
+++ b/packages/angular/src/generators/application/lib/set-default-project.ts
@@ -1,0 +1,15 @@
+import type { Tree } from '@nrwl/devkit';
+import {
+  readWorkspaceConfiguration,
+  updateWorkspaceConfiguration,
+} from '@nrwl/devkit';
+import type { NormalizedSchema } from './normalized-schema';
+
+export function setDefaultProject(tree: Tree, options: NormalizedSchema): void {
+  const workspace = readWorkspaceConfiguration(tree);
+
+  if (!workspace.defaultProject) {
+    workspace.defaultProject = options.name;
+    updateWorkspaceConfiguration(tree, workspace);
+  }
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Creating a new workspace with the Angular preset or a new Angular application in a workspace where the default project hasn't been set doesn't set the default project. This used to work because the underlying Angular CLI application schematic was setting it, but that doesn't happen anymore in v14.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Creating a new workspace with the Angular preset, or a new Angular application in a workspace where the default project hasn't been set should set the default project.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #10777 
