### PR TITLE
fix(nextjs): reorder eslint extension so that local eslint loads last

### DIFF
--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -352,51 +352,54 @@ describe('app', () => {
 
         const eslintJson = readJson(tree, '/apps/my-app/.eslintrc.json');
         expect(eslintJson).toMatchInlineSnapshot(`
-Object {
-  "env": Object {
-    "jest": true,
-  },
-  "extends": Array [
-    "plugin:@nrwl/nx/react-typescript",
-    "../../.eslintrc.json",
-    "next",
-    "next/core-web-vitals",
-  ],
-  "ignorePatterns": Array [
-    "!**/*",
-  ],
-  "overrides": Array [
-    Object {
-      "files": Array [
-        "*.ts",
-        "*.tsx",
-        "*.js",
-        "*.jsx",
-      ],
-      "rules": Object {
-        "@next/next/no-html-link-for-pages": Array [
-          "error",
-          "apps/my-app/pages",
-        ],
-      },
-    },
-    Object {
-      "files": Array [
-        "*.ts",
-        "*.tsx",
-      ],
-      "rules": Object {},
-    },
-    Object {
-      "files": Array [
-        "*.js",
-        "*.jsx",
-      ],
-      "rules": Object {},
-    },
-  ],
-}
-`);
+          Object {
+            "env": Object {
+              "jest": true,
+            },
+            "extends": Array [
+              "plugin:@nrwl/nx/react-typescript",
+              "next",
+              "next/core-web-vitals",
+              "../../.eslintrc.json",
+            ],
+            "ignorePatterns": Array [
+              "!**/*",
+            ],
+            "overrides": Array [
+              Object {
+                "files": Array [
+                  "*.ts",
+                  "*.tsx",
+                  "*.js",
+                  "*.jsx",
+                ],
+                "rules": Object {
+                  "@next/next/no-html-link-for-pages": Array [
+                    "error",
+                    "apps/my-app/pages",
+                  ],
+                },
+              },
+              Object {
+                "files": Array [
+                  "*.ts",
+                  "*.tsx",
+                ],
+                "rules": Object {},
+              },
+              Object {
+                "files": Array [
+                  "*.js",
+                  "*.jsx",
+                ],
+                "rules": Object {},
+              },
+            ],
+            "rules": Object {
+              "@next/next/no-html-link-for-pages": "off",
+            },
+          }
+        `);
       });
     });
 

--- a/packages/next/src/generators/application/lib/add-linting.ts
+++ b/packages/next/src/generators/application/lib/add-linting.ts
@@ -33,6 +33,13 @@ export async function addLinting(
       host,
       joinPathFragments(options.appProjectRoot, '.eslintrc.json'),
       () => {
+        // Turn off @next/next/no-html-link-for-pages since there is an issue with nextjs throwing linting errors
+        // TODO(nicholas): remove after Vercel updates nextjs linter to only lint ["*.ts", "*.tsx", "*.js", "*.jsx"]
+
+        reactEslintJson.rules = {
+          '@next/next/no-html-link-for-pages': 'off',
+          ...reactEslintJson.rules,
+        };
         // Find the override that handles both TS and JS files.
         const commonOverride = reactEslintJson.overrides?.find((o) =>
           ['*.ts', '*.tsx', '*.js', '*.jsx'].every((ext) =>
@@ -62,11 +69,12 @@ export async function addLinting(
           reactEslintJson.extends = [reactEslintJson.extends];
         }
         // add next.js configuration
-        reactEslintJson.extends.push(...['next', 'next/core-web-vitals']);
+        reactEslintJson.extends.unshift(...['next', 'next/core-web-vitals']);
         // remove nx/react plugin, as it conflicts with the next.js one
         reactEslintJson.extends = reactEslintJson.extends.filter(
           (name) => name !== 'plugin:@nrwl/nx/react'
         );
+
         reactEslintJson.extends.unshift('plugin:@nrwl/nx/react-typescript');
         if (!reactEslintJson.env) {
           reactEslintJson.env = {};


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9741
