### PR TITLE
fix(storybook): storybook tsconfig - only include stories and .storybook files

### DIFF
--- a/packages/storybook/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/storybook/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -461,7 +461,13 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
     \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
   ],
   \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
-  \\"include\\": [\\"../src/**/*\\", \\"*.js\\" ]
+  \\"include\\": [
+    \\"../src/**/*.stories.ts\\", 
+    \\"../src/**/*.stories.js\\", 
+    \\"../src/**/*.stories.jsx\\", 
+    \\"../src/**/*.stories.tsx\\", 
+    \\"../src/**/*.stories.mdx\\", 
+    \\"*.js\\"]
 }
 "
 `;
@@ -514,7 +520,13 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
     \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
   ],
   \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
-  \\"include\\": [\\"../src/**/*\\", \\"*.js\\" ]
+  \\"include\\": [
+    \\"../src/**/*.stories.ts\\", 
+    \\"../src/**/*.stories.js\\", 
+    \\"../src/**/*.stories.jsx\\", 
+    \\"../src/**/*.stories.tsx\\", 
+    \\"../src/**/*.stories.mdx\\", 
+    \\"*.js\\"]
 }
 "
 `;
@@ -574,7 +586,13 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
     \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
   ],
   \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
-  \\"include\\": [\\"../components/**/*\\", \\"*.js\\" ]
+  \\"include\\": [
+    \\"../components/**/*.stories.ts\\", 
+    \\"../components/**/*.stories.js\\", 
+    \\"../components/**/*.stories.jsx\\", 
+    \\"../components/**/*.stories.tsx\\", 
+    \\"../components/**/*.stories.mdx\\", 
+    \\"*.js\\"]
 }
 "
 `;
@@ -627,7 +645,13 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
     \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
   ],
   \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
-  \\"include\\": [\\"../src/**/*\\", \\"*.js\\" ]
+  \\"include\\": [
+    \\"../src/**/*.stories.ts\\", 
+    \\"../src/**/*.stories.js\\", 
+    \\"../src/**/*.stories.jsx\\", 
+    \\"../src/**/*.stories.tsx\\", 
+    \\"../src/**/*.stories.mdx\\", 
+    \\"*.js\\"]
 }
 "
 `;
@@ -680,7 +704,13 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
     \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
   ],
   \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
-  \\"include\\": [\\"../src/**/*\\", \\"*.js\\" ]
+  \\"include\\": [
+    \\"../src/**/*.stories.ts\\", 
+    \\"../src/**/*.stories.js\\", 
+    \\"../src/**/*.stories.jsx\\", 
+    \\"../src/**/*.stories.tsx\\", 
+    \\"../src/**/*.stories.mdx\\", 
+    \\"*.js\\"]
 }
 "
 `;
@@ -733,7 +763,13 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
     \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
   ],
   \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
-  \\"include\\": [\\"../src/**/*\\", \\"*.js\\" ]
+  \\"include\\": [
+    \\"../src/**/*.stories.ts\\", 
+    \\"../src/**/*.stories.js\\", 
+    \\"../src/**/*.stories.jsx\\", 
+    \\"../src/**/*.stories.tsx\\", 
+    \\"../src/**/*.stories.mdx\\", 
+    \\"*.js\\"]
 }
 "
 `;

--- a/packages/storybook/src/generators/configuration/project-files/.storybook/tsconfig.json__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files/.storybook/tsconfig.json__tmpl__
@@ -10,5 +10,11 @@
     "<%= offsetFromRoot %>../node_modules/@nrwl/react/typings/image.d.ts"
   ],<% } %>
   "exclude": ["../**/*.spec.ts" <% if(uiFramework === '@storybook/react') { %>, "../**/*.spec.js", "../**/*.spec.tsx", "../**/*.spec.jsx"<% } %>],
-  "include": ["../<%= mainDir %>/**/*", "*.js" <% if(uiFramework === '@storybook/react-native') { %>, "*.ts", "*.tsx"<% } %>]
+  "include": [
+    "../<%= mainDir %>/**/*.stories.ts", 
+    "../<%= mainDir %>/**/*.stories.js", 
+    "../<%= mainDir %>/**/*.stories.jsx", 
+    "../<%= mainDir %>/**/*.stories.tsx", 
+    "../<%= mainDir %>/**/*.stories.mdx", 
+    "*.js"<% if(uiFramework === '@storybook/react-native') { %>, "*.ts", "*.tsx"<% } %>]
 }


### PR DESCRIPTION
Updates the default storybook tsconfig file generated when adding a storybook configuration to a library such that only `*.storybook` files within the library are added to the `include` list rather than all files within the library.

ISSUES CLOSED: #9933

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
All files within the a library are included in the `include` list of the default generated storybook `tsconfig.json` file.

## Expected Behavior
Only `*.storybook` files within the a library are included in the `include` list of the default generated storybook `tsconfig.json` file.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9933
