### PR TITLE
fix(react-native): generated .gitignore was causing cache to never be invalidated on macOS (using watchamn)

### DIFF
--- a/packages/react-native/src/generators/init/lib/add-git-ignore-entry.ts
+++ b/packages/react-native/src/generators/init/lib/add-git-ignore-entry.ts
@@ -14,7 +14,7 @@ export function addGitIgnoreEntry(host: Tree) {
   ig.add(host.read('.gitignore', 'utf-8'));
 
   if (!ig.ignores('apps/example/ios/Pods/Folly')) {
-    content = `${content}\n${gitIgnoreEntriesForReactNative}/\n`;
+    content = `${content}\n${gitIgnoreEntriesForReactNative}\n`;
   }
 
   // also ignore nested node_modules folders due to symlink for React Native


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
