### PR TITLE
fix(react-native): generated .gitignore cause cache to never be invalidated on macOS (using watchman)

### DIFF
--- a/packages/react-native/src/generators/init/lib/add-git-ignore-entry.ts
+++ b/packages/react-native/src/generators/init/lib/add-git-ignore-entry.ts
@@ -14,7 +14,7 @@ export function addGitIgnoreEntry(host: Tree) {
   ig.add(host.read('.gitignore', 'utf-8'));
 
   if (!ig.ignores('apps/example/ios/Pods/Folly')) {
-    content = `${content}\n${gitIgnoreEntriesForReactNative}/\n`;
+    content = `${content}\n${gitIgnoreEntriesForReactNative}\n`;
   }
 
   // also ignore nested node_modules folders due to symlink for React Native


### PR DESCRIPTION
## Current Behavior
When creating a new react-native workspace, and running a cacheable command using **Nx**, **Nx** always use the cached output even if project file changes.
This is because [Nx Daemon server](https://nx.dev/guides/nx-daemon#logs) is based on watchman (if available) on macOS, and watchman itself "read" [VCS configurations](https://facebook.github.io/watchman/docs/config.html#ignore_vcs).
And a tiny error in the generated .gitignore file was adding the whole project as "ignored"

_Generated .gitignore_
<img width="360" alt="image" src="https://user-images.githubusercontent.com/9294168/174769066-d6b33907-8aa8-4101-b9b4-c70cf1f907b0.png">

We can verify that error by running the daemon server by hand using the following command, and editing a random project file.
```
nx daemon --start --background false
```
We can see that watchman subscription is not even triggered with the actual `.gitignore` file


## Expected Behavior
Cache should be invalidated when source file has been updated.
"/" should not be added to the `.gitignore` file.

## Steps to reproduce

Run
```
npx create-nx-workspace happynrwl \
--preset=react-native \
--appName=mobile
```

You should see that the generated `.gitignore` file contains the following entry `/`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/10831
