### PR TITLE
fix(storybook): fix support for nextjs and swc

### DIFF
--- a/packages/angular/src/generators/storybook-configuration/__snapshots__/storybook-configuration.spec.ts.snap
+++ b/packages/angular/src/generators/storybook-configuration/__snapshots__/storybook-configuration.spec.ts.snap
@@ -4,6 +4,7 @@ exports[`StorybookConfiguration generator should configure storybook to use webp
 "const rootMain = require('../../../.storybook/main');
 
 
+
 module.exports = {
   ...rootMain,
   
@@ -14,7 +15,10 @@ module.exports = {
     '../src/lib/**/*.stories.mdx',
     '../src/lib/**/*.stories.@(js|jsx|ts|tsx)'
   ],
-  addons: [...rootMain.addons ],
+  addons: [...rootMain.addons 
+    
+    
+  ],
   webpackFinal: async (config, { configType }) => {
     // apply any global webpack configs that might have been specified in .storybook/main.js
     if (rootMain.webpackFinal) {

--- a/packages/react-native/src/generators/stories/stories.ts
+++ b/packages/react-native/src/generators/stories/stories.ts
@@ -19,7 +19,7 @@ export async function createAllStories(tree: Tree, projectName: string) {
   const projectConfiguration = projects.get(projectName);
 
   const { sourceRoot } = projectConfiguration;
-  const projectPath = projectRootPath(tree, projectConfiguration);
+  const projectPath = projectRootPath(projectConfiguration);
 
   let componentPaths: string[] = [];
   visitNotIgnoredFiles(tree, projectPath, (path) => {

--- a/packages/react/src/generators/stories/stories.ts
+++ b/packages/react/src/generators/stories/stories.ts
@@ -16,7 +16,7 @@ import {
 } from '@nrwl/devkit';
 import { basename, join } from 'path';
 import {
-  findStorybookAndBuildTargets,
+  findStorybookAndBuildTargetsAndCompiler,
   isTheFileAStory,
 } from '@nrwl/storybook/src/utils/utilities';
 
@@ -30,7 +30,9 @@ export interface StorybookStoriesSchema {
 export function projectRootPath(config: ProjectConfiguration): string {
   let projectDir: string;
   if (config.projectType === 'application') {
-    const { nextBuildTarget } = findStorybookAndBuildTargets(config.targets);
+    const { nextBuildTarget } = findStorybookAndBuildTargetsAndCompiler(
+      config.targets
+    );
     if (!!nextBuildTarget) {
       // Next.js apps
       projectDir = 'components';

--- a/packages/storybook/src/generators/change-storybook-targets/change-storybook-targets.ts
+++ b/packages/storybook/src/generators/change-storybook-targets/change-storybook-targets.ts
@@ -9,7 +9,7 @@ import {
   Target,
   convertNxGenerator,
 } from '@nrwl/devkit';
-import { findStorybookAndBuildTargets } from '../../utils/utilities';
+import { findStorybookAndBuildTargetsAndCompiler } from '../../utils/utilities';
 
 export async function changeStorybookTargetsGenerator(tree: Tree) {
   let changesMade = false;
@@ -18,7 +18,7 @@ export async function changeStorybookTargetsGenerator(tree: Tree) {
   [...projects.entries()].forEach(([projectName, projectConfiguration]) => {
     changesMade = false;
     const { storybookBuildTarget, storybookTarget, ngBuildTarget } =
-      findStorybookAndBuildTargets(projectConfiguration.targets);
+      findStorybookAndBuildTargetsAndCompiler(projectConfiguration.targets);
     if (
       projectName &&
       storybookTarget &&

--- a/packages/storybook/src/generators/change-storybook-targets/change-storybook-targets.ts
+++ b/packages/storybook/src/generators/change-storybook-targets/change-storybook-targets.ts
@@ -17,7 +17,7 @@ export async function changeStorybookTargetsGenerator(tree: Tree) {
   const projects = getProjects(tree);
   [...projects.entries()].forEach(([projectName, projectConfiguration]) => {
     changesMade = false;
-    const { storybookBuildTarget, storybookTarget, buildTarget } =
+    const { storybookBuildTarget, storybookTarget, ngBuildTarget } =
       findStorybookAndBuildTargets(projectConfiguration.targets);
     if (
       projectName &&
@@ -29,7 +29,7 @@ export async function changeStorybookTargetsGenerator(tree: Tree) {
         projectConfiguration,
         storybookTarget,
         projectName,
-        buildTarget,
+        ngBuildTarget,
         storybookBuildTarget
       );
       changesMade = true;
@@ -38,7 +38,7 @@ export async function changeStorybookTargetsGenerator(tree: Tree) {
         updateStorybookBuildTarget(
           projectConfiguration,
           projectName,
-          buildTarget,
+          ngBuildTarget,
           storybookBuildTarget
         );
     } else {

--- a/packages/storybook/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/storybook/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`@nrwl/storybook:configuration should generate a webpackFinal into the main.js and reference a potential global webpackFinal definition 1`] = `
+exports[`@nrwl/storybook:configuration basic functionalities should generate a webpackFinal into the main.js and reference a potential global webpackFinal definition 1`] = `
 "const rootMain = require('../../../.storybook/main');
+
 
 
 module.exports = {
@@ -14,7 +15,10 @@ module.exports = {
     '../src/lib/**/*.stories.mdx',
     '../src/lib/**/*.stories.@(js|jsx|ts|tsx)'
   ],
-  addons: [...rootMain.addons ],
+  addons: [...rootMain.addons 
+    
+    
+  ],
   webpackFinal: async (config, { configType }) => {
     // apply any global webpack configs that might have been specified in .storybook/main.js
     if (rootMain.webpackFinal) {
@@ -31,7 +35,7 @@ module.exports = {
 "
 `;
 
-exports[`@nrwl/storybook:configuration should have the proper typings 1`] = `
+exports[`@nrwl/storybook:configuration basic functionalities should have the proper typings 1`] = `
 Array [
   "../../../node_modules/@nrwl/react/typings/styled-jsx.d.ts",
   "../../../node_modules/@nrwl/react/typings/cssmodule.d.ts",
@@ -39,9 +43,10 @@ Array [
 ]
 `;
 
-exports[`@nrwl/storybook:configuration should reference the "old" webpack.config.js if there - for backwards compatibility 1`] = `
+exports[`@nrwl/storybook:configuration basic functionalities should reference the "old" webpack.config.js if there - for backwards compatibility 1`] = `
 "const rootMain = require('../../../.storybook/main');
 const rootWebpackConfig = require('../../../.storybook/webpack.config'); 
+
 
 module.exports = {
   ...rootMain,
@@ -53,7 +58,10 @@ module.exports = {
     '../src/lib/**/*.stories.mdx',
     '../src/lib/**/*.stories.@(js|jsx|ts|tsx)'
   ],
-  addons: [...rootMain.addons ],
+  addons: [...rootMain.addons 
+    
+    
+  ],
   webpackFinal: async (config, { configType }) => {
     // apply any global webpack configs that might have been specified in .storybook/main.js
     if (rootMain.webpackFinal) {
@@ -71,5 +79,661 @@ module.exports = {
     return config;
   },
 };
+"
+`;
+
+exports[`@nrwl/storybook:configuration for other types of projects - Next.js and the swc compiler for TypeScript Storybook configurations should create correct main.ts and tsconfig.json for NextJS buildable libs 1`] = `
+"import { rootMain } from '../../../.storybook/main';
+import type { StorybookConfig, Options } from '@storybook/core-common';
+
+
+const config: StorybookConfig = {
+  ...rootMain,
+  
+  core: { ...rootMain.core, builder: 'webpack5' },
+  
+
+  stories: [
+    ...rootMain.stories,
+    '../src/lib/**/*.stories.mdx',
+    '../src/lib/**/*.stories.@(js|jsx|ts|tsx)'
+  ],
+  addons: [...(rootMain.addons || []) , '@nrwl/react/plugins/storybook' 
+    
+    
+  ],
+  webpackFinal: async (config, { configType }: Options) => {
+    // apply any global webpack configs that might have been specified in .storybook/main.ts
+    if (rootMain.webpackFinal) {
+      config = await rootMain.webpackFinal(config, { configType } as Options);
+    }
+
+    // add your own webpack tweaks if needed
+
+    return config;
+  },
+};
+
+module.exports = config;
+"
+`;
+
+exports[`@nrwl/storybook:configuration for other types of projects - Next.js and the swc compiler for TypeScript Storybook configurations should create correct main.ts and tsconfig.json for NextJS buildable libs 2`] = `
+"{
+  \\"extends\\": \\"../tsconfig.json\\",
+  \\"compilerOptions\\": {
+    \\"emitDecoratorMetadata\\": true
+    , \\"outDir\\": \\"\\" 
+  },
+  \\"files\\": [
+    \\"../../../node_modules/@nrwl/react/typings/styled-jsx.d.ts\\",
+    \\"../../../node_modules/@nrwl/react/typings/cssmodule.d.ts\\",
+    \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
+  ],
+  \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
+  \\"include\\": [\\"../src/**/*\\", \\"*.js\\", \\"*.ts\\" ]
+}
+"
+`;
+
+exports[`@nrwl/storybook:configuration for other types of projects - Next.js and the swc compiler for TypeScript Storybook configurations should create correct main.ts and tsconfig.json for NextJS libs 1`] = `
+"import { rootMain } from '../../../.storybook/main';
+import type { StorybookConfig, Options } from '@storybook/core-common';
+
+
+const config: StorybookConfig = {
+  ...rootMain,
+  
+  core: { ...rootMain.core, builder: 'webpack5' },
+  
+
+  stories: [
+    ...rootMain.stories,
+    '../src/lib/**/*.stories.mdx',
+    '../src/lib/**/*.stories.@(js|jsx|ts|tsx)'
+  ],
+  addons: [...(rootMain.addons || []) , '@nrwl/react/plugins/storybook' 
+    
+    
+  ],
+  webpackFinal: async (config, { configType }: Options) => {
+    // apply any global webpack configs that might have been specified in .storybook/main.ts
+    if (rootMain.webpackFinal) {
+      config = await rootMain.webpackFinal(config, { configType } as Options);
+    }
+
+    // add your own webpack tweaks if needed
+
+    return config;
+  },
+};
+
+module.exports = config;
+"
+`;
+
+exports[`@nrwl/storybook:configuration for other types of projects - Next.js and the swc compiler for TypeScript Storybook configurations should create correct main.ts and tsconfig.json for NextJS libs 2`] = `
+"{
+  \\"extends\\": \\"../tsconfig.json\\",
+  \\"compilerOptions\\": {
+    \\"emitDecoratorMetadata\\": true
+    , \\"outDir\\": \\"\\" 
+  },
+  \\"files\\": [
+    \\"../../../node_modules/@nrwl/react/typings/styled-jsx.d.ts\\",
+    \\"../../../node_modules/@nrwl/react/typings/cssmodule.d.ts\\",
+    \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
+  ],
+  \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
+  \\"include\\": [\\"../src/**/*\\", \\"*.js\\", \\"*.ts\\" ]
+}
+"
+`;
+
+exports[`@nrwl/storybook:configuration for other types of projects - Next.js and the swc compiler for TypeScript Storybook configurations should create correct main.ts and tsconfig.json for NextJs apps 1`] = `
+"import { rootMain } from '../../../.storybook/main';
+import type { StorybookConfig, Options } from '@storybook/core-common';
+import path from 'path';
+
+const config: StorybookConfig = {
+  ...rootMain,
+  
+  core: { ...rootMain.core, builder: 'webpack5' },
+  
+
+  stories: [
+    ...rootMain.stories,
+    '../components/**/*.stories.mdx',
+    '../components/**/*.stories.@(js|jsx|ts|tsx)'
+  ],
+  addons: [...(rootMain.addons || []) , '@nrwl/react/plugins/storybook' 
+    
+    , 'storybook-addon-swc', 
+        {
+      name: 'storybook-addon-next',
+      options: {
+        nextConfigPath: path.resolve(__dirname, '../next.config.js'),
+      },
+    }
+     
+  ],
+  webpackFinal: async (config, { configType }: Options) => {
+    // apply any global webpack configs that might have been specified in .storybook/main.ts
+    if (rootMain.webpackFinal) {
+      config = await rootMain.webpackFinal(config, { configType } as Options);
+    }
+
+    // add your own webpack tweaks if needed
+
+    return config;
+  },
+};
+
+module.exports = config;
+"
+`;
+
+exports[`@nrwl/storybook:configuration for other types of projects - Next.js and the swc compiler for TypeScript Storybook configurations should create correct main.ts and tsconfig.json for NextJs apps 2`] = `
+"{
+  \\"extends\\": \\"../tsconfig.json\\",
+  \\"compilerOptions\\": {
+    \\"emitDecoratorMetadata\\": true
+    , \\"outDir\\": \\"\\" 
+  },
+  \\"files\\": [
+    \\"../../../node_modules/@nrwl/react/typings/styled-jsx.d.ts\\",
+    \\"../../../node_modules/@nrwl/react/typings/cssmodule.d.ts\\",
+    \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
+  ],
+  \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
+  \\"include\\": [\\"../components/**/*\\", \\"*.js\\", \\"*.ts\\" ]
+}
+"
+`;
+
+exports[`@nrwl/storybook:configuration for other types of projects - Next.js and the swc compiler for TypeScript Storybook configurations should create correct main.ts and tsconfig.json for React apps 1`] = `
+"import { rootMain } from '../../../.storybook/main';
+import type { StorybookConfig, Options } from '@storybook/core-common';
+
+
+const config: StorybookConfig = {
+  ...rootMain,
+  
+  core: { ...rootMain.core, builder: 'webpack5' },
+  
+
+  stories: [
+    ...rootMain.stories,
+    '../src/app/**/*.stories.mdx',
+    '../src/app/**/*.stories.@(js|jsx|ts|tsx)'
+  ],
+  addons: [...(rootMain.addons || []) , '@nrwl/react/plugins/storybook' 
+    
+    
+  ],
+  webpackFinal: async (config, { configType }: Options) => {
+    // apply any global webpack configs that might have been specified in .storybook/main.ts
+    if (rootMain.webpackFinal) {
+      config = await rootMain.webpackFinal(config, { configType } as Options);
+    }
+
+    // add your own webpack tweaks if needed
+
+    return config;
+  },
+};
+
+module.exports = config;
+"
+`;
+
+exports[`@nrwl/storybook:configuration for other types of projects - Next.js and the swc compiler for TypeScript Storybook configurations should create correct main.ts and tsconfig.json for React apps 2`] = `
+"{
+  \\"extends\\": \\"../tsconfig.json\\",
+  \\"compilerOptions\\": {
+    \\"emitDecoratorMetadata\\": true
+    , \\"outDir\\": \\"\\" 
+  },
+  \\"files\\": [
+    \\"../../../node_modules/@nrwl/react/typings/styled-jsx.d.ts\\",
+    \\"../../../node_modules/@nrwl/react/typings/cssmodule.d.ts\\",
+    \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
+  ],
+  \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
+  \\"include\\": [\\"../src/**/*\\", \\"*.js\\", \\"*.ts\\" ]
+}
+"
+`;
+
+exports[`@nrwl/storybook:configuration for other types of projects - Next.js and the swc compiler for TypeScript Storybook configurations should create correct main.ts and tsconfig.json for React apps using the swc compiler 1`] = `
+"import { rootMain } from '../../../.storybook/main';
+import type { StorybookConfig, Options } from '@storybook/core-common';
+
+
+const config: StorybookConfig = {
+  ...rootMain,
+  
+  core: { ...rootMain.core, builder: 'webpack5' },
+  
+
+  stories: [
+    ...rootMain.stories,
+    '../src/app/**/*.stories.mdx',
+    '../src/app/**/*.stories.@(js|jsx|ts|tsx)'
+  ],
+  addons: [...(rootMain.addons || []) , '@nrwl/react/plugins/storybook' 
+    , 'storybook-addon-swc' 
+    
+  ],
+  webpackFinal: async (config, { configType }: Options) => {
+    // apply any global webpack configs that might have been specified in .storybook/main.ts
+    if (rootMain.webpackFinal) {
+      config = await rootMain.webpackFinal(config, { configType } as Options);
+    }
+
+    // add your own webpack tweaks if needed
+
+    return config;
+  },
+};
+
+module.exports = config;
+"
+`;
+
+exports[`@nrwl/storybook:configuration for other types of projects - Next.js and the swc compiler for TypeScript Storybook configurations should create correct main.ts and tsconfig.json for React apps using the swc compiler 2`] = `
+"{
+  \\"extends\\": \\"../tsconfig.json\\",
+  \\"compilerOptions\\": {
+    \\"emitDecoratorMetadata\\": true
+    , \\"outDir\\": \\"\\" 
+  },
+  \\"files\\": [
+    \\"../../../node_modules/@nrwl/react/typings/styled-jsx.d.ts\\",
+    \\"../../../node_modules/@nrwl/react/typings/cssmodule.d.ts\\",
+    \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
+  ],
+  \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
+  \\"include\\": [\\"../src/**/*\\", \\"*.js\\", \\"*.ts\\" ]
+}
+"
+`;
+
+exports[`@nrwl/storybook:configuration for other types of projects - Next.js and the swc compiler for TypeScript Storybook configurations should create correct main.ts and tsconfig.json for React buildable libs 1`] = `
+"import { rootMain } from '../../../.storybook/main';
+import type { StorybookConfig, Options } from '@storybook/core-common';
+
+
+const config: StorybookConfig = {
+  ...rootMain,
+  
+  core: { ...rootMain.core, builder: 'webpack5' },
+  
+
+  stories: [
+    ...rootMain.stories,
+    '../src/lib/**/*.stories.mdx',
+    '../src/lib/**/*.stories.@(js|jsx|ts|tsx)'
+  ],
+  addons: [...(rootMain.addons || []) , '@nrwl/react/plugins/storybook' 
+    
+    
+  ],
+  webpackFinal: async (config, { configType }: Options) => {
+    // apply any global webpack configs that might have been specified in .storybook/main.ts
+    if (rootMain.webpackFinal) {
+      config = await rootMain.webpackFinal(config, { configType } as Options);
+    }
+
+    // add your own webpack tweaks if needed
+
+    return config;
+  },
+};
+
+module.exports = config;
+"
+`;
+
+exports[`@nrwl/storybook:configuration for other types of projects - Next.js and the swc compiler for TypeScript Storybook configurations should create correct main.ts and tsconfig.json for React buildable libs 2`] = `
+"{
+  \\"extends\\": \\"../tsconfig.json\\",
+  \\"compilerOptions\\": {
+    \\"emitDecoratorMetadata\\": true
+    , \\"outDir\\": \\"\\" 
+  },
+  \\"files\\": [
+    \\"../../../node_modules/@nrwl/react/typings/styled-jsx.d.ts\\",
+    \\"../../../node_modules/@nrwl/react/typings/cssmodule.d.ts\\",
+    \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
+  ],
+  \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
+  \\"include\\": [\\"../src/**/*\\", \\"*.js\\", \\"*.ts\\" ]
+}
+"
+`;
+
+exports[`@nrwl/storybook:configuration for other types of projects - Next.js and the swc compiler for js Storybook configurations should create correct main.js and tsconfig.json for NextJS buildable libs 1`] = `
+"const rootMain = require('../../../.storybook/main');
+
+
+
+module.exports = {
+  ...rootMain,
+  
+  core: { ...rootMain.core, builder: 'webpack5' },
+  
+  stories: [
+    ...rootMain.stories,
+    '../src/lib/**/*.stories.mdx',
+    '../src/lib/**/*.stories.@(js|jsx|ts|tsx)'
+  ],
+  addons: [...rootMain.addons , '@nrwl/react/plugins/storybook' 
+    
+    
+  ],
+  webpackFinal: async (config, { configType }) => {
+    // apply any global webpack configs that might have been specified in .storybook/main.js
+    if (rootMain.webpackFinal) {
+      config = await rootMain.webpackFinal(config, { configType });
+    }
+    
+    
+
+    // add your own webpack tweaks if needed
+
+    return config;
+  },
+};
+"
+`;
+
+exports[`@nrwl/storybook:configuration for other types of projects - Next.js and the swc compiler for js Storybook configurations should create correct main.js and tsconfig.json for NextJS buildable libs 2`] = `
+"{
+  \\"extends\\": \\"../tsconfig.json\\",
+  \\"compilerOptions\\": {
+    \\"emitDecoratorMetadata\\": true
+    , \\"outDir\\": \\"\\" 
+  },
+  \\"files\\": [
+    \\"../../../node_modules/@nrwl/react/typings/styled-jsx.d.ts\\",
+    \\"../../../node_modules/@nrwl/react/typings/cssmodule.d.ts\\",
+    \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
+  ],
+  \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
+  \\"include\\": [\\"../src/**/*\\", \\"*.js\\" ]
+}
+"
+`;
+
+exports[`@nrwl/storybook:configuration for other types of projects - Next.js and the swc compiler for js Storybook configurations should create correct main.js and tsconfig.json for NextJS libs 1`] = `
+"const rootMain = require('../../../.storybook/main');
+
+
+
+module.exports = {
+  ...rootMain,
+  
+  core: { ...rootMain.core, builder: 'webpack5' },
+  
+  stories: [
+    ...rootMain.stories,
+    '../src/lib/**/*.stories.mdx',
+    '../src/lib/**/*.stories.@(js|jsx|ts|tsx)'
+  ],
+  addons: [...rootMain.addons , '@nrwl/react/plugins/storybook' 
+    
+    
+  ],
+  webpackFinal: async (config, { configType }) => {
+    // apply any global webpack configs that might have been specified in .storybook/main.js
+    if (rootMain.webpackFinal) {
+      config = await rootMain.webpackFinal(config, { configType });
+    }
+    
+    
+
+    // add your own webpack tweaks if needed
+
+    return config;
+  },
+};
+"
+`;
+
+exports[`@nrwl/storybook:configuration for other types of projects - Next.js and the swc compiler for js Storybook configurations should create correct main.js and tsconfig.json for NextJS libs 2`] = `
+"{
+  \\"extends\\": \\"../tsconfig.json\\",
+  \\"compilerOptions\\": {
+    \\"emitDecoratorMetadata\\": true
+    , \\"outDir\\": \\"\\" 
+  },
+  \\"files\\": [
+    \\"../../../node_modules/@nrwl/react/typings/styled-jsx.d.ts\\",
+    \\"../../../node_modules/@nrwl/react/typings/cssmodule.d.ts\\",
+    \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
+  ],
+  \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
+  \\"include\\": [\\"../src/**/*\\", \\"*.js\\" ]
+}
+"
+`;
+
+exports[`@nrwl/storybook:configuration for other types of projects - Next.js and the swc compiler for js Storybook configurations should create correct main.js and tsconfig.json for NextJs apps 1`] = `
+"const rootMain = require('../../../.storybook/main');
+
+const path = require('path');
+
+module.exports = {
+  ...rootMain,
+  
+  core: { ...rootMain.core, builder: 'webpack5' },
+  
+  stories: [
+    ...rootMain.stories,
+    '../components/**/*.stories.mdx',
+    '../components/**/*.stories.@(js|jsx|ts|tsx)'
+  ],
+  addons: [...rootMain.addons , '@nrwl/react/plugins/storybook' 
+    
+    , 'storybook-addon-swc', 
+        {
+      name: 'storybook-addon-next',
+      options: {
+        nextConfigPath: path.resolve(__dirname, '../next.config.js'),
+      },
+    }
+     
+  ],
+  webpackFinal: async (config, { configType }) => {
+    // apply any global webpack configs that might have been specified in .storybook/main.js
+    if (rootMain.webpackFinal) {
+      config = await rootMain.webpackFinal(config, { configType });
+    }
+    
+    
+
+    // add your own webpack tweaks if needed
+
+    return config;
+  },
+};
+"
+`;
+
+exports[`@nrwl/storybook:configuration for other types of projects - Next.js and the swc compiler for js Storybook configurations should create correct main.js and tsconfig.json for NextJs apps 2`] = `
+"{
+  \\"extends\\": \\"../tsconfig.json\\",
+  \\"compilerOptions\\": {
+    \\"emitDecoratorMetadata\\": true
+    , \\"outDir\\": \\"\\" 
+  },
+  \\"files\\": [
+    \\"../../../node_modules/@nrwl/react/typings/styled-jsx.d.ts\\",
+    \\"../../../node_modules/@nrwl/react/typings/cssmodule.d.ts\\",
+    \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
+  ],
+  \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
+  \\"include\\": [\\"../components/**/*\\", \\"*.js\\" ]
+}
+"
+`;
+
+exports[`@nrwl/storybook:configuration for other types of projects - Next.js and the swc compiler for js Storybook configurations should create correct main.js and tsconfig.json for React apps 1`] = `
+"const rootMain = require('../../../.storybook/main');
+
+
+
+module.exports = {
+  ...rootMain,
+  
+  core: { ...rootMain.core, builder: 'webpack5' },
+  
+  stories: [
+    ...rootMain.stories,
+    '../src/app/**/*.stories.mdx',
+    '../src/app/**/*.stories.@(js|jsx|ts|tsx)'
+  ],
+  addons: [...rootMain.addons , '@nrwl/react/plugins/storybook' 
+    
+    
+  ],
+  webpackFinal: async (config, { configType }) => {
+    // apply any global webpack configs that might have been specified in .storybook/main.js
+    if (rootMain.webpackFinal) {
+      config = await rootMain.webpackFinal(config, { configType });
+    }
+    
+    
+
+    // add your own webpack tweaks if needed
+
+    return config;
+  },
+};
+"
+`;
+
+exports[`@nrwl/storybook:configuration for other types of projects - Next.js and the swc compiler for js Storybook configurations should create correct main.js and tsconfig.json for React apps 2`] = `
+"{
+  \\"extends\\": \\"../tsconfig.json\\",
+  \\"compilerOptions\\": {
+    \\"emitDecoratorMetadata\\": true
+    , \\"outDir\\": \\"\\" 
+  },
+  \\"files\\": [
+    \\"../../../node_modules/@nrwl/react/typings/styled-jsx.d.ts\\",
+    \\"../../../node_modules/@nrwl/react/typings/cssmodule.d.ts\\",
+    \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
+  ],
+  \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
+  \\"include\\": [\\"../src/**/*\\", \\"*.js\\" ]
+}
+"
+`;
+
+exports[`@nrwl/storybook:configuration for other types of projects - Next.js and the swc compiler for js Storybook configurations should create correct main.js and tsconfig.json for React apps using the swc compiler 1`] = `
+"const rootMain = require('../../../.storybook/main');
+
+
+
+module.exports = {
+  ...rootMain,
+  
+  core: { ...rootMain.core, builder: 'webpack5' },
+  
+  stories: [
+    ...rootMain.stories,
+    '../src/app/**/*.stories.mdx',
+    '../src/app/**/*.stories.@(js|jsx|ts|tsx)'
+  ],
+  addons: [...rootMain.addons , '@nrwl/react/plugins/storybook' 
+    , 'storybook-addon-swc' 
+    
+  ],
+  webpackFinal: async (config, { configType }) => {
+    // apply any global webpack configs that might have been specified in .storybook/main.js
+    if (rootMain.webpackFinal) {
+      config = await rootMain.webpackFinal(config, { configType });
+    }
+    
+    
+
+    // add your own webpack tweaks if needed
+
+    return config;
+  },
+};
+"
+`;
+
+exports[`@nrwl/storybook:configuration for other types of projects - Next.js and the swc compiler for js Storybook configurations should create correct main.js and tsconfig.json for React apps using the swc compiler 2`] = `
+"{
+  \\"extends\\": \\"../tsconfig.json\\",
+  \\"compilerOptions\\": {
+    \\"emitDecoratorMetadata\\": true
+    , \\"outDir\\": \\"\\" 
+  },
+  \\"files\\": [
+    \\"../../../node_modules/@nrwl/react/typings/styled-jsx.d.ts\\",
+    \\"../../../node_modules/@nrwl/react/typings/cssmodule.d.ts\\",
+    \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
+  ],
+  \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
+  \\"include\\": [\\"../src/**/*\\", \\"*.js\\" ]
+}
+"
+`;
+
+exports[`@nrwl/storybook:configuration for other types of projects - Next.js and the swc compiler for js Storybook configurations should create correct main.js and tsconfig.json for React buildable libs 1`] = `
+"const rootMain = require('../../../.storybook/main');
+
+
+
+module.exports = {
+  ...rootMain,
+  
+  core: { ...rootMain.core, builder: 'webpack5' },
+  
+  stories: [
+    ...rootMain.stories,
+    '../src/lib/**/*.stories.mdx',
+    '../src/lib/**/*.stories.@(js|jsx|ts|tsx)'
+  ],
+  addons: [...rootMain.addons , '@nrwl/react/plugins/storybook' 
+    
+    
+  ],
+  webpackFinal: async (config, { configType }) => {
+    // apply any global webpack configs that might have been specified in .storybook/main.js
+    if (rootMain.webpackFinal) {
+      config = await rootMain.webpackFinal(config, { configType });
+    }
+    
+    
+
+    // add your own webpack tweaks if needed
+
+    return config;
+  },
+};
+"
+`;
+
+exports[`@nrwl/storybook:configuration for other types of projects - Next.js and the swc compiler for js Storybook configurations should create correct main.js and tsconfig.json for React buildable libs 2`] = `
+"{
+  \\"extends\\": \\"../tsconfig.json\\",
+  \\"compilerOptions\\": {
+    \\"emitDecoratorMetadata\\": true
+    , \\"outDir\\": \\"\\" 
+  },
+  \\"files\\": [
+    \\"../../../node_modules/@nrwl/react/typings/styled-jsx.d.ts\\",
+    \\"../../../node_modules/@nrwl/react/typings/cssmodule.d.ts\\",
+    \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
+  ],
+  \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
+  \\"include\\": [\\"../src/**/*\\", \\"*.js\\" ]
+}
 "
 `;

--- a/packages/storybook/src/generators/configuration/configuration.spec.ts
+++ b/packages/storybook/src/generators/configuration/configuration.spec.ts
@@ -11,309 +11,315 @@ import { Linter } from '@nrwl/linter';
 import { libraryGenerator } from '@nrwl/workspace/generators';
 import { TsConfig } from '../../utils/utilities';
 import configurationGenerator from './configuration';
+import * as workspaceConfiguration from './test-configs/workspace-conifiguration.json';
 
 describe('@nrwl/storybook:configuration', () => {
-  let tree: Tree;
+  describe('basic functionalities', () => {
+    let tree: Tree;
 
-  beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace();
-    await libraryGenerator(tree, {
-      name: 'test-ui-lib',
-      standaloneConfig: false,
-    });
-    writeJson(tree, 'package.json', {
-      devDependencies: {
-        '@storybook/addon-essentials': '~6.2.9',
-        '@storybook/react': '~6.2.9',
-      },
-    });
-  });
-
-  it('should generate files', async () => {
-    await configurationGenerator(tree, {
-      name: 'test-ui-lib',
-      uiFramework: '@storybook/angular',
-      standaloneConfig: false,
+    beforeEach(async () => {
+      tree = createTreeWithEmptyWorkspace();
+      await libraryGenerator(tree, {
+        name: 'test-ui-lib',
+        standaloneConfig: false,
+      });
+      writeJson(tree, 'package.json', {
+        devDependencies: {
+          '@storybook/addon-essentials': '~6.2.9',
+          '@storybook/react': '~6.2.9',
+        },
+      });
     });
 
-    // Root
-    expect(tree.exists('.storybook/tsconfig.json')).toBeTruthy();
-    expect(tree.exists('.storybook/main.js')).toBeTruthy();
-    const rootStorybookTsconfigJson = readJson<TsConfig>(
-      tree,
-      '.storybook/tsconfig.json'
-    );
-    expect(rootStorybookTsconfigJson.extends).toBe('../tsconfig.base.json');
-    expect(rootStorybookTsconfigJson.exclude).toEqual([
-      '../**/*.spec.js',
-      '../**/*.test.js',
-      '../**/*.spec.ts',
-      '../**/*.test.ts',
-      '../**/*.spec.tsx',
-      '../**/*.test.tsx',
-      '../**/*.spec.jsx',
-      '../**/*.test.jsx',
-    ]);
+    it('should generate files', async () => {
+      await configurationGenerator(tree, {
+        name: 'test-ui-lib',
+        uiFramework: '@storybook/angular',
+        standaloneConfig: false,
+      });
 
-    // Local
-    expect(
-      tree.exists('libs/test-ui-lib/.storybook/tsconfig.json')
-    ).toBeTruthy();
-    expect(tree.exists('libs/test-ui-lib/.storybook/main.js')).toBeTruthy();
-    expect(tree.exists('libs/test-ui-lib/.storybook/preview.js')).toBeTruthy();
+      // Root
+      expect(tree.exists('.storybook/tsconfig.json')).toBeTruthy();
+      expect(tree.exists('.storybook/main.js')).toBeTruthy();
+      const rootStorybookTsconfigJson = readJson<TsConfig>(
+        tree,
+        '.storybook/tsconfig.json'
+      );
+      expect(rootStorybookTsconfigJson.extends).toBe('../tsconfig.base.json');
+      expect(rootStorybookTsconfigJson.exclude).toEqual([
+        '../**/*.spec.js',
+        '../**/*.test.js',
+        '../**/*.spec.ts',
+        '../**/*.test.ts',
+        '../**/*.spec.tsx',
+        '../**/*.test.tsx',
+        '../**/*.spec.jsx',
+        '../**/*.test.jsx',
+      ]);
 
-    const storybookTsconfigJson = readJson<{ exclude: string[] }>(
-      tree,
-      'libs/test-ui-lib/.storybook/tsconfig.json'
-    );
+      // Local
+      expect(
+        tree.exists('libs/test-ui-lib/.storybook/tsconfig.json')
+      ).toBeTruthy();
+      expect(tree.exists('libs/test-ui-lib/.storybook/main.js')).toBeTruthy();
+      expect(
+        tree.exists('libs/test-ui-lib/.storybook/preview.js')
+      ).toBeTruthy();
 
-    expect(
-      storybookTsconfigJson.exclude.includes('../**/*.spec.ts')
-    ).toBeTruthy();
-    expect(
-      storybookTsconfigJson.exclude.includes('../**/*.spec.tsx')
-    ).toBeFalsy();
-    expect(
-      storybookTsconfigJson.exclude.includes('../**/*.spec.js')
-    ).toBeFalsy();
-    expect(
-      storybookTsconfigJson.exclude.includes('../**/*.spec.jsx')
-    ).toBeFalsy();
-  });
+      const storybookTsconfigJson = readJson<{ exclude: string[] }>(
+        tree,
+        'libs/test-ui-lib/.storybook/tsconfig.json'
+      );
 
-  it('should generate TypeScript Configuration files', async () => {
-    await configurationGenerator(tree, {
-      name: 'test-ui-lib',
-      uiFramework: '@storybook/angular',
-      standaloneConfig: false,
-      tsConfiguration: true,
+      expect(
+        storybookTsconfigJson.exclude.includes('../**/*.spec.ts')
+      ).toBeTruthy();
+      expect(
+        storybookTsconfigJson.exclude.includes('../**/*.spec.tsx')
+      ).toBeFalsy();
+      expect(
+        storybookTsconfigJson.exclude.includes('../**/*.spec.js')
+      ).toBeFalsy();
+      expect(
+        storybookTsconfigJson.exclude.includes('../**/*.spec.jsx')
+      ).toBeFalsy();
     });
 
-    // Root
-    expect(tree.exists('.storybook/tsconfig.json')).toBeTruthy();
-    expect(tree.exists('.storybook/main.ts')).toBeTruthy();
-    const rootStorybookTsconfigJson = readJson<TsConfig>(
-      tree,
-      '.storybook/tsconfig.json'
-    );
-    expect(rootStorybookTsconfigJson.extends).toBe('../tsconfig.base.json');
+    it('should generate TypeScript Configuration files', async () => {
+      await configurationGenerator(tree, {
+        name: 'test-ui-lib',
+        uiFramework: '@storybook/angular',
+        standaloneConfig: false,
+        tsConfiguration: true,
+      });
 
-    // Local
-    expect(
-      tree.exists('libs/test-ui-lib/.storybook/tsconfig.json')
-    ).toBeTruthy();
-    expect(tree.exists('libs/test-ui-lib/.storybook/main.ts')).toBeTruthy();
-    expect(tree.exists('libs/test-ui-lib/.storybook/preview.ts')).toBeTruthy();
-  });
+      // Root
+      expect(tree.exists('.storybook/tsconfig.json')).toBeTruthy();
+      expect(tree.exists('.storybook/main.ts')).toBeTruthy();
+      const rootStorybookTsconfigJson = readJson<TsConfig>(
+        tree,
+        '.storybook/tsconfig.json'
+      );
+      expect(rootStorybookTsconfigJson.extends).toBe('../tsconfig.base.json');
 
-  it('should extend from root tsconfig.json when no tsconfig.base.json', async () => {
-    tree.rename('tsconfig.base.json', 'tsconfig.json');
-
-    await configurationGenerator(tree, {
-      name: 'test-ui-lib',
-      uiFramework: '@storybook/angular',
-      standaloneConfig: false,
+      // Local
+      expect(
+        tree.exists('libs/test-ui-lib/.storybook/tsconfig.json')
+      ).toBeTruthy();
+      expect(tree.exists('libs/test-ui-lib/.storybook/main.ts')).toBeTruthy();
+      expect(
+        tree.exists('libs/test-ui-lib/.storybook/preview.ts')
+      ).toBeTruthy();
     });
 
-    const rootStorybookTsconfigJson = readJson<TsConfig>(
-      tree,
-      '.storybook/tsconfig.json'
-    );
-    expect(rootStorybookTsconfigJson.extends).toBe('../tsconfig.json');
-  });
+    it('should extend from root tsconfig.json when no tsconfig.base.json', async () => {
+      tree.rename('tsconfig.base.json', 'tsconfig.json');
 
-  it('should generate a webpackFinal into the main.js and reference a potential global webpackFinal definition', async () => {
-    await configurationGenerator(tree, {
-      name: 'test-ui-lib',
-      uiFramework: '@storybook/angular',
-      standaloneConfig: false,
+      await configurationGenerator(tree, {
+        name: 'test-ui-lib',
+        uiFramework: '@storybook/angular',
+        standaloneConfig: false,
+      });
+
+      const rootStorybookTsconfigJson = readJson<TsConfig>(
+        tree,
+        '.storybook/tsconfig.json'
+      );
+      expect(rootStorybookTsconfigJson.extends).toBe('../tsconfig.json');
     });
 
-    expect(
-      tree.read('libs/test-ui-lib/.storybook/main.js', 'utf-8')
-    ).toMatchSnapshot();
-  });
+    it('should generate a webpackFinal into the main.js and reference a potential global webpackFinal definition', async () => {
+      await configurationGenerator(tree, {
+        name: 'test-ui-lib',
+        uiFramework: '@storybook/angular',
+        standaloneConfig: false,
+      });
 
-  it('should reference the "old" webpack.config.js if there - for backwards compatibility', async () => {
-    // create a root webpack.config.js as in "old" storybook workspaces
-    tree.write('.storybook/webpack.config.js', 'export const test ="hi"');
-
-    await configurationGenerator(tree, {
-      name: 'test-ui-lib',
-      uiFramework: '@storybook/angular',
-      standaloneConfig: false,
+      expect(
+        tree.read('libs/test-ui-lib/.storybook/main.js', 'utf-8')
+      ).toMatchSnapshot();
     });
 
-    expect(
-      tree.read('libs/test-ui-lib/.storybook/main.js', 'utf-8')
-    ).toMatchSnapshot();
-  });
+    it('should reference the "old" webpack.config.js if there - for backwards compatibility', async () => {
+      // create a root webpack.config.js as in "old" storybook workspaces
+      tree.write('.storybook/webpack.config.js', 'export const test ="hi"');
 
-  it('should not update root files after generating them once', async () => {
-    await configurationGenerator(tree, {
-      name: 'test-ui-lib',
-      uiFramework: '@storybook/angular',
-      standaloneConfig: false,
+      await configurationGenerator(tree, {
+        name: 'test-ui-lib',
+        uiFramework: '@storybook/angular',
+        standaloneConfig: false,
+      });
+
+      expect(
+        tree.read('libs/test-ui-lib/.storybook/main.js', 'utf-8')
+      ).toMatchSnapshot();
     });
 
-    const newContents = `module.exports = {
+    it('should not update root files after generating them once', async () => {
+      await configurationGenerator(tree, {
+        name: 'test-ui-lib',
+        uiFramework: '@storybook/angular',
+        standaloneConfig: false,
+      });
+
+      const newContents = `module.exports = {
   stories: [],
   addons: ['@storybook/addon-essentials', 'new-addon'],
 };
 `;
-    // Setup a new lib
-    await libraryGenerator(tree, {
-      name: 'test-ui-lib-2',
-      standaloneConfig: false,
+      // Setup a new lib
+      await libraryGenerator(tree, {
+        name: 'test-ui-lib-2',
+        standaloneConfig: false,
+      });
+
+      tree.write('.storybook/main.js', newContents);
+      await configurationGenerator(tree, {
+        name: 'test-ui-lib-2',
+        uiFramework: '@storybook/angular',
+        standaloneConfig: false,
+      });
+
+      expect(tree.read('.storybook/main.js', 'utf-8')).toEqual(newContents);
     });
 
-    tree.write('.storybook/main.js', newContents);
-    await configurationGenerator(tree, {
-      name: 'test-ui-lib-2',
-      uiFramework: '@storybook/angular',
-      standaloneConfig: false,
-    });
-
-    expect(tree.read('.storybook/main.js', 'utf-8')).toEqual(newContents);
-  });
-
-  it('should update workspace file for react libs', async () => {
-    await configurationGenerator(tree, {
-      name: 'test-ui-lib',
-      uiFramework: '@storybook/react',
-      standaloneConfig: false,
-    });
-    const project = readProjectConfiguration(tree, 'test-ui-lib');
-
-    expect(project.targets.storybook).toEqual({
-      executor: '@nrwl/storybook:storybook',
-      configurations: {
-        ci: {
-          quiet: true,
-        },
-      },
-      options: {
-        port: 4400,
+    it('should update workspace file for react libs', async () => {
+      await configurationGenerator(tree, {
+        name: 'test-ui-lib',
         uiFramework: '@storybook/react',
-        config: {
-          configFolder: 'libs/test-ui-lib/.storybook',
+        standaloneConfig: false,
+      });
+      const project = readProjectConfiguration(tree, 'test-ui-lib');
+
+      expect(project.targets.storybook).toEqual({
+        executor: '@nrwl/storybook:storybook',
+        configurations: {
+          ci: {
+            quiet: true,
+          },
         },
-      },
-    });
-
-    expect(project.targets.lint).toEqual({
-      executor: '@nrwl/linter:eslint',
-      outputs: ['{options.outputFile}'],
-      options: {
-        lintFilePatterns: ['libs/test-ui-lib/**/*.ts'],
-      },
-    });
-  });
-
-  it('should update workspace file for angular libs', async () => {
-    // Setup a new lib
-    await libraryGenerator(tree, {
-      name: 'test-ui-lib-2',
-      standaloneConfig: false,
-    });
-    await configurationGenerator(tree, {
-      name: 'test-ui-lib-2',
-      uiFramework: '@storybook/angular',
-      standaloneConfig: false,
-    });
-    const project = readProjectConfiguration(tree, 'test-ui-lib-2');
-
-    expect(project.targets.storybook).toEqual({
-      executor: '@storybook/angular:start-storybook',
-      configurations: {
-        ci: {
-          quiet: true,
+        options: {
+          port: 4400,
+          uiFramework: '@storybook/react',
+          config: {
+            configFolder: 'libs/test-ui-lib/.storybook',
+          },
         },
-      },
-      options: {
-        port: 4400,
-        browserTarget: 'test-ui-lib-2:build-storybook',
-        compodoc: false,
-        configDir: 'libs/test-ui-lib-2/.storybook',
-      },
-    });
+      });
 
-    expect(project.targets.lint).toEqual({
-      executor: '@nrwl/linter:eslint',
-      outputs: ['{options.outputFile}'],
-      options: {
-        lintFilePatterns: ['libs/test-ui-lib-2/**/*.ts'],
-      },
-    });
-  });
-
-  it('should update workspace file for angular buildable libs', async () => {
-    // Setup a new lib
-    await libraryGenerator(tree, {
-      name: 'test-ui-lib-5',
-      standaloneConfig: false,
-      buildable: true,
-    });
-    await configurationGenerator(tree, {
-      name: 'test-ui-lib-5',
-      uiFramework: '@storybook/angular',
-      standaloneConfig: false,
-    });
-    const project = readProjectConfiguration(tree, 'test-ui-lib-5');
-
-    expect(project.targets.storybook).toEqual({
-      executor: '@storybook/angular:start-storybook',
-      configurations: {
-        ci: {
-          quiet: true,
+      expect(project.targets.lint).toEqual({
+        executor: '@nrwl/linter:eslint',
+        outputs: ['{options.outputFile}'],
+        options: {
+          lintFilePatterns: ['libs/test-ui-lib/**/*.ts'],
         },
-      },
-      options: {
-        port: 4400,
-        browserTarget: 'test-ui-lib-5:build-storybook',
-        compodoc: false,
-        configDir: 'libs/test-ui-lib-5/.storybook',
-      },
+      });
     });
 
-    expect(project.targets.lint).toEqual({
-      executor: '@nrwl/linter:eslint',
-      outputs: ['{options.outputFile}'],
-      options: {
-        lintFilePatterns: ['libs/test-ui-lib-5/**/*.ts'],
-      },
+    it('should update workspace file for angular libs', async () => {
+      // Setup a new lib
+      await libraryGenerator(tree, {
+        name: 'test-ui-lib-2',
+        standaloneConfig: false,
+      });
+      await configurationGenerator(tree, {
+        name: 'test-ui-lib-2',
+        uiFramework: '@storybook/angular',
+        standaloneConfig: false,
+      });
+      const project = readProjectConfiguration(tree, 'test-ui-lib-2');
+
+      expect(project.targets.storybook).toEqual({
+        executor: '@storybook/angular:start-storybook',
+        configurations: {
+          ci: {
+            quiet: true,
+          },
+        },
+        options: {
+          port: 4400,
+          browserTarget: 'test-ui-lib-2:build-storybook',
+          compodoc: false,
+          configDir: 'libs/test-ui-lib-2/.storybook',
+        },
+      });
+
+      expect(project.targets.lint).toEqual({
+        executor: '@nrwl/linter:eslint',
+        outputs: ['{options.outputFile}'],
+        options: {
+          lintFilePatterns: ['libs/test-ui-lib-2/**/*.ts'],
+        },
+      });
     });
-  });
 
-  it('should update `tsconfig.lib.json` file', async () => {
-    await configurationGenerator(tree, {
-      name: 'test-ui-lib',
-      uiFramework: '@storybook/react',
-      standaloneConfig: false,
+    it('should update workspace file for angular buildable libs', async () => {
+      // Setup a new lib
+      await libraryGenerator(tree, {
+        name: 'test-ui-lib-5',
+        standaloneConfig: false,
+        buildable: true,
+      });
+      await configurationGenerator(tree, {
+        name: 'test-ui-lib-5',
+        uiFramework: '@storybook/angular',
+        standaloneConfig: false,
+      });
+      const project = readProjectConfiguration(tree, 'test-ui-lib-5');
+
+      expect(project.targets.storybook).toEqual({
+        executor: '@storybook/angular:start-storybook',
+        configurations: {
+          ci: {
+            quiet: true,
+          },
+        },
+        options: {
+          port: 4400,
+          browserTarget: 'test-ui-lib-5:build-storybook',
+          compodoc: false,
+          configDir: 'libs/test-ui-lib-5/.storybook',
+        },
+      });
+
+      expect(project.targets.lint).toEqual({
+        executor: '@nrwl/linter:eslint',
+        outputs: ['{options.outputFile}'],
+        options: {
+          lintFilePatterns: ['libs/test-ui-lib-5/**/*.ts'],
+        },
+      });
     });
-    const tsconfigJson = readJson<TsConfig>(
-      tree,
-      'libs/test-ui-lib/tsconfig.lib.json'
-    ) as Required<TsConfig>;
 
-    expect(tsconfigJson.exclude).toContain('**/*.stories.ts');
-    expect(tsconfigJson.exclude).toContain('**/*.stories.js');
-    expect(tsconfigJson.exclude).toContain('**/*.stories.jsx');
-    expect(tsconfigJson.exclude).toContain('**/*.stories.tsx');
-  });
+    it('should update `tsconfig.lib.json` file', async () => {
+      await configurationGenerator(tree, {
+        name: 'test-ui-lib',
+        uiFramework: '@storybook/react',
+        standaloneConfig: false,
+      });
+      const tsconfigJson = readJson<TsConfig>(
+        tree,
+        'libs/test-ui-lib/tsconfig.lib.json'
+      ) as Required<TsConfig>;
 
-  it('should update `tsconfig.json` file', async () => {
-    await configurationGenerator(tree, {
-      name: 'test-ui-lib',
-      uiFramework: '@storybook/react',
-      standaloneConfig: false,
+      expect(tsconfigJson.exclude).toContain('**/*.stories.ts');
+      expect(tsconfigJson.exclude).toContain('**/*.stories.js');
+      expect(tsconfigJson.exclude).toContain('**/*.stories.jsx');
+      expect(tsconfigJson.exclude).toContain('**/*.stories.tsx');
     });
-    const tsconfigJson = readJson<TsConfig>(
-      tree,
-      'libs/test-ui-lib/tsconfig.json'
-    );
 
-    expect(tsconfigJson.references).toMatchInlineSnapshot(`
+    it('should update `tsconfig.json` file', async () => {
+      await configurationGenerator(tree, {
+        name: 'test-ui-lib',
+        uiFramework: '@storybook/react',
+        standaloneConfig: false,
+      });
+      const tsconfigJson = readJson<TsConfig>(
+        tree,
+        'libs/test-ui-lib/tsconfig.json'
+      );
+
+      expect(tsconfigJson.references).toMatchInlineSnapshot(`
       Array [
         Object {
           "path": "./tsconfig.lib.json",
@@ -326,88 +332,295 @@ describe('@nrwl/storybook:configuration', () => {
         },
       ]
     `);
-  });
-
-  it("should update the project's .eslintrc.json if config exists", async () => {
-    await libraryGenerator(tree, {
-      name: 'test-ui-lib2',
-      linter: Linter.EsLint,
-      standaloneConfig: false,
     });
 
-    updateJson(tree, 'libs/test-ui-lib2/.eslintrc.json', (json) => {
-      json.parserOptions = {
-        project: [],
-      };
-      return json;
-    });
+    it("should update the project's .eslintrc.json if config exists", async () => {
+      await libraryGenerator(tree, {
+        name: 'test-ui-lib2',
+        linter: Linter.EsLint,
+        standaloneConfig: false,
+      });
 
-    await configurationGenerator(tree, {
-      name: 'test-ui-lib2',
-      uiFramework: '@storybook/react',
-      standaloneConfig: false,
-    });
+      updateJson(tree, 'libs/test-ui-lib2/.eslintrc.json', (json) => {
+        json.parserOptions = {
+          project: [],
+        };
+        return json;
+      });
 
-    expect(readJson(tree, 'libs/test-ui-lib2/.eslintrc.json').parserOptions)
-      .toMatchInlineSnapshot(`
+      await configurationGenerator(tree, {
+        name: 'test-ui-lib2',
+        uiFramework: '@storybook/react',
+        standaloneConfig: false,
+      });
+
+      expect(readJson(tree, 'libs/test-ui-lib2/.eslintrc.json').parserOptions)
+        .toMatchInlineSnapshot(`
       Object {
         "project": Array [
           "libs/test-ui-lib2/.storybook/tsconfig.json",
         ],
       }
     `);
-  });
-
-  it('should have the proper typings', async () => {
-    await libraryGenerator(tree, {
-      name: 'test-ui-lib2',
-      linter: Linter.EsLint,
-      standaloneConfig: false,
     });
 
-    await configurationGenerator(tree, {
-      name: 'test-ui-lib2',
-      uiFramework: '@storybook/react',
-      standaloneConfig: false,
+    it('should have the proper typings', async () => {
+      await libraryGenerator(tree, {
+        name: 'test-ui-lib2',
+        linter: Linter.EsLint,
+        standaloneConfig: false,
+      });
+
+      await configurationGenerator(tree, {
+        name: 'test-ui-lib2',
+        uiFramework: '@storybook/react',
+        standaloneConfig: false,
+      });
+
+      expect(
+        readJson(tree, 'libs/test-ui-lib2/.storybook/tsconfig.json').files
+      ).toMatchSnapshot();
     });
 
-    expect(
-      readJson(tree, 'libs/test-ui-lib2/.storybook/tsconfig.json').files
-    ).toMatchSnapshot();
-  });
+    it('should generate TS config for project if root config is TS', async () => {
+      await configurationGenerator(tree, {
+        name: 'test-ui-lib',
+        uiFramework: '@storybook/angular',
+        standaloneConfig: false,
+        tsConfiguration: true,
+      });
 
-  it('should generate TS config for project if root config is TS', async () => {
-    await configurationGenerator(tree, {
-      name: 'test-ui-lib',
-      uiFramework: '@storybook/angular',
-      standaloneConfig: false,
-      tsConfiguration: true,
-    });
-
-    const newContents = `module.exports = {
+      const newContents = `module.exports = {
   stories: [],
   addons: ['@storybook/addon-essentials', 'new-addon'],
 };
 `;
-    // Setup a new lib
-    await libraryGenerator(tree, {
-      name: 'test-ui-lib-2',
-      standaloneConfig: false,
+      // Setup a new lib
+      await libraryGenerator(tree, {
+        name: 'test-ui-lib-2',
+        standaloneConfig: false,
+      });
+
+      tree.write('.storybook/main.ts', newContents);
+      await configurationGenerator(tree, {
+        name: 'test-ui-lib-2',
+        uiFramework: '@storybook/angular',
+        standaloneConfig: false,
+      });
+
+      expect(tree.read('.storybook/main.ts', 'utf-8')).toEqual(newContents);
+      expect(tree.exists('libs/test-ui-lib-2/.storybook/main.ts')).toBeTruthy();
+      expect(
+        tree.exists('libs/test-ui-lib-2/.storybook/preview.ts')
+      ).toBeTruthy();
+      expect(tree.exists('libs/test-ui-lib-2/.storybook/main.js')).toBeFalsy();
+      expect(
+        tree.exists('libs/test-ui-lib-2/.storybook/preview.js')
+      ).toBeFalsy();
+    });
+  });
+
+  describe('for other types of projects - Next.js and the swc compiler', () => {
+    describe('for js Storybook configurations', () => {
+      let tree: Tree;
+      beforeAll(async () => {
+        tree = createTreeWithEmptyWorkspace();
+        writeJson(tree, 'workspace.json', workspaceConfiguration);
+        writeJson(tree, 'apps/nxapp/tsconfig.json', {});
+        writeJson(tree, 'apps/reapp/tsconfig.json', {});
+        writeJson(tree, 'libs/nxlib/tsconfig.json', {});
+        writeJson(tree, 'libs/nxlib-buildable/tsconfig.json', {});
+        writeJson(tree, 'libs/relib-buildable/tsconfig.json', {});
+        writeJson(tree, 'apps/reapp-swc/tsconfig.json', {});
+        await configurationGenerator(tree, {
+          name: 'nxapp',
+          uiFramework: '@storybook/react',
+        });
+        await configurationGenerator(tree, {
+          name: 'reapp',
+          uiFramework: '@storybook/react',
+        });
+        await configurationGenerator(tree, {
+          name: 'nxlib',
+          uiFramework: '@storybook/react',
+        });
+        await configurationGenerator(tree, {
+          name: 'nxlib-buildable',
+          uiFramework: '@storybook/react',
+        });
+        await configurationGenerator(tree, {
+          name: 'relib-buildable',
+          uiFramework: '@storybook/react',
+        });
+        await configurationGenerator(tree, {
+          name: 'reapp-swc',
+          uiFramework: '@storybook/react',
+        });
+      });
+
+      it(`should create correct main.js and tsconfig.json for NextJs apps`, async () => {
+        expect(
+          tree.read('apps/nxapp/.storybook/main.js', 'utf-8')
+        ).toMatchSnapshot();
+
+        expect(
+          tree.read('apps/nxapp/.storybook/tsconfig.json', 'utf-8')
+        ).toMatchSnapshot();
+      });
+
+      it(`should create correct main.js and tsconfig.json for React apps`, async () => {
+        expect(
+          tree.read('apps/reapp/.storybook/main.js', 'utf-8')
+        ).toMatchSnapshot();
+
+        expect(
+          tree.read('apps/reapp/.storybook/tsconfig.json', 'utf-8')
+        ).toMatchSnapshot();
+      });
+
+      it(`should create correct main.js and tsconfig.json for NextJS libs`, async () => {
+        expect(
+          tree.read('libs/nxlib/.storybook/main.js', 'utf-8')
+        ).toMatchSnapshot();
+
+        expect(
+          tree.read('libs/nxlib/.storybook/tsconfig.json', 'utf-8')
+        ).toMatchSnapshot();
+      });
+
+      it(`should create correct main.js and tsconfig.json for NextJS buildable libs`, async () => {
+        expect(
+          tree.read('libs/nxlib-buildable/.storybook/main.js', 'utf-8')
+        ).toMatchSnapshot();
+
+        expect(
+          tree.read('libs/nxlib-buildable/.storybook/tsconfig.json', 'utf-8')
+        ).toMatchSnapshot();
+      });
+
+      it(`should create correct main.js and tsconfig.json for React buildable libs`, async () => {
+        expect(
+          tree.read('libs/relib-buildable/.storybook/main.js', 'utf-8')
+        ).toMatchSnapshot();
+
+        expect(
+          tree.read('libs/relib-buildable/.storybook/tsconfig.json', 'utf-8')
+        ).toMatchSnapshot();
+      });
+
+      it(`should create correct main.js and tsconfig.json for React apps using the swc compiler`, async () => {
+        expect(
+          tree.read('apps/reapp-swc/.storybook/main.js', 'utf-8')
+        ).toMatchSnapshot();
+
+        expect(
+          tree.read('apps/reapp-swc/.storybook/tsconfig.json', 'utf-8')
+        ).toMatchSnapshot();
+      });
     });
 
-    tree.write('.storybook/main.ts', newContents);
-    await configurationGenerator(tree, {
-      name: 'test-ui-lib-2',
-      uiFramework: '@storybook/angular',
-      standaloneConfig: false,
-    });
+    describe('for TypeScript Storybook configurations', () => {
+      let tree: Tree;
+      beforeAll(async () => {
+        tree = createTreeWithEmptyWorkspace();
+        writeJson(tree, 'workspace.json', workspaceConfiguration);
+        writeJson(tree, 'apps/nxapp/tsconfig.json', {});
+        writeJson(tree, 'apps/reapp/tsconfig.json', {});
+        writeJson(tree, 'libs/nxlib/tsconfig.json', {});
+        writeJson(tree, 'libs/nxlib-buildable/tsconfig.json', {});
+        writeJson(tree, 'libs/relib-buildable/tsconfig.json', {});
+        writeJson(tree, 'apps/reapp-swc/tsconfig.json', {});
+        await configurationGenerator(tree, {
+          name: 'nxapp',
+          uiFramework: '@storybook/react',
+          tsConfiguration: true,
+        });
+        await configurationGenerator(tree, {
+          name: 'reapp',
+          uiFramework: '@storybook/react',
+          tsConfiguration: true,
+        });
+        await configurationGenerator(tree, {
+          name: 'nxlib',
+          uiFramework: '@storybook/react',
+          tsConfiguration: true,
+        });
+        await configurationGenerator(tree, {
+          name: 'nxlib-buildable',
+          uiFramework: '@storybook/react',
+          tsConfiguration: true,
+        });
+        await configurationGenerator(tree, {
+          name: 'relib-buildable',
+          uiFramework: '@storybook/react',
+          tsConfiguration: true,
+        });
+        await configurationGenerator(tree, {
+          name: 'reapp-swc',
+          uiFramework: '@storybook/react',
+          tsConfiguration: true,
+        });
+      });
 
-    expect(tree.read('.storybook/main.ts', 'utf-8')).toEqual(newContents);
-    expect(tree.exists('libs/test-ui-lib-2/.storybook/main.ts')).toBeTruthy();
-    expect(
-      tree.exists('libs/test-ui-lib-2/.storybook/preview.ts')
-    ).toBeTruthy();
-    expect(tree.exists('libs/test-ui-lib-2/.storybook/main.js')).toBeFalsy();
-    expect(tree.exists('libs/test-ui-lib-2/.storybook/preview.js')).toBeFalsy();
+      it(`should create correct main.ts and tsconfig.json for NextJs apps`, async () => {
+        expect(
+          tree.read('apps/nxapp/.storybook/main.ts', 'utf-8')
+        ).toMatchSnapshot();
+
+        expect(
+          tree.read('apps/nxapp/.storybook/tsconfig.json', 'utf-8')
+        ).toMatchSnapshot();
+      });
+
+      it(`should create correct main.ts and tsconfig.json for React apps`, async () => {
+        expect(
+          tree.read('apps/reapp/.storybook/main.ts', 'utf-8')
+        ).toMatchSnapshot();
+
+        expect(
+          tree.read('apps/reapp/.storybook/tsconfig.json', 'utf-8')
+        ).toMatchSnapshot();
+      });
+
+      it(`should create correct main.ts and tsconfig.json for NextJS libs`, async () => {
+        expect(
+          tree.read('libs/nxlib/.storybook/main.ts', 'utf-8')
+        ).toMatchSnapshot();
+
+        expect(
+          tree.read('libs/nxlib/.storybook/tsconfig.json', 'utf-8')
+        ).toMatchSnapshot();
+      });
+
+      it(`should create correct main.ts and tsconfig.json for NextJS buildable libs`, async () => {
+        expect(
+          tree.read('libs/nxlib-buildable/.storybook/main.ts', 'utf-8')
+        ).toMatchSnapshot();
+
+        expect(
+          tree.read('libs/nxlib-buildable/.storybook/tsconfig.json', 'utf-8')
+        ).toMatchSnapshot();
+      });
+
+      it(`should create correct main.ts and tsconfig.json for React buildable libs`, async () => {
+        expect(
+          tree.read('libs/relib-buildable/.storybook/main.ts', 'utf-8')
+        ).toMatchSnapshot();
+
+        expect(
+          tree.read('libs/relib-buildable/.storybook/tsconfig.json', 'utf-8')
+        ).toMatchSnapshot();
+      });
+
+      it(`should create correct main.ts and tsconfig.json for React apps using the swc compiler`, async () => {
+        expect(
+          tree.read('apps/reapp-swc/.storybook/main.ts', 'utf-8')
+        ).toMatchSnapshot();
+
+        expect(
+          tree.read('apps/reapp-swc/.storybook/tsconfig.json', 'utf-8')
+        ).toMatchSnapshot();
+      });
+    });
   });
 });

--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -22,7 +22,6 @@ import {
   updateLintConfig,
 } from './util-functions';
 import { Linter } from '@nrwl/linter';
-import { findStorybookAndBuildTargets } from '../../utils/utilities';
 
 export async function configurationGenerator(
   tree: Tree,
@@ -32,8 +31,7 @@ export async function configurationGenerator(
 
   const tasks: GeneratorCallback[] = [];
 
-  const { projectType, targets } = readProjectConfiguration(tree, schema.name);
-  const { buildTarget } = findStorybookAndBuildTargets(targets);
+  const { projectType } = readProjectConfiguration(tree, schema.name);
   const initTask = await initGenerator(tree, {
     uiFramework: schema.uiFramework,
   });
@@ -52,7 +50,7 @@ export async function configurationGenerator(
   updateLintConfig(tree, schema);
 
   if (schema.uiFramework === '@storybook/angular') {
-    addAngularStorybookTask(tree, schema.name, buildTarget);
+    addAngularStorybookTask(tree, schema.name);
   } else {
     addStorybookTask(tree, schema.name, schema.uiFramework);
   }

--- a/packages/storybook/src/generators/configuration/project-files-ts/.storybook/main.ts__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files-ts/.storybook/main.ts__tmpl__
@@ -9,8 +9,8 @@ const config: StorybookConfig = {
 
   stories: [
     ...rootMain.stories,
-    '../src/app/**/*.stories.mdx',
-    '../src/app/**/*.stories.@(js|jsx|ts|tsx)',
+    '../<%= projectDirectory %>/**/*.stories.mdx',
+    '../<%= projectDirectory %>/**/*.stories.@(js|jsx|ts|tsx)'
   ],
   addons: [...(rootMain.addons || []) <% if(uiFramework === '@storybook/react') { %>, '@nrwl/react/plugins/storybook' <% } %><% if(uiFramework === '@storybook/react-native') { %>, '@storybook/addon-ondevice-actions',  '@storybook/addon-ondevice-backgrounds', '@storybook/addon-ondevice-controls', '@storybook/addon-ondevice-notes'  <% } %>],
   webpackFinal: async (config, { configType }: Options) => {

--- a/packages/storybook/src/generators/configuration/project-files-ts/.storybook/main.ts__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files-ts/.storybook/main.ts__tmpl__
@@ -1,5 +1,6 @@
 import { rootMain } from '<%= offsetFromRoot %>../.storybook/main';
 import type { StorybookConfig, Options } from '@storybook/core-common';
+<% if (isNextJs){ %>import path from 'path';<% } %>
 
 const config: StorybookConfig = {
   ...rootMain,
@@ -12,7 +13,17 @@ const config: StorybookConfig = {
     '../<%= projectDirectory %>/**/*.stories.mdx',
     '../<%= projectDirectory %>/**/*.stories.@(js|jsx|ts|tsx)'
   ],
-  addons: [...(rootMain.addons || []) <% if(uiFramework === '@storybook/react') { %>, '@nrwl/react/plugins/storybook' <% } %><% if(uiFramework === '@storybook/react-native') { %>, '@storybook/addon-ondevice-actions',  '@storybook/addon-ondevice-backgrounds', '@storybook/addon-ondevice-controls', '@storybook/addon-ondevice-notes'  <% } %>],
+  addons: [...(rootMain.addons || []) <% if(uiFramework === '@storybook/react') { %>, '@nrwl/react/plugins/storybook' <% } %><% if(uiFramework === '@storybook/react-native') { %>, '@storybook/addon-ondevice-actions',  '@storybook/addon-ondevice-backgrounds', '@storybook/addon-ondevice-controls', '@storybook/addon-ondevice-notes'  <% } %>
+    <% if(usesSwc && !isNextJs) { %>, 'storybook-addon-swc' <% } %>
+    <% if(isNextJs) { %>, 'storybook-addon-swc', 
+        {
+      name: 'storybook-addon-next',
+      options: {
+        nextConfigPath: path.resolve(__dirname, '../next.config.js'),
+      },
+    }
+     <% } %>
+  ],
   webpackFinal: async (config, { configType }: Options) => {
     // apply any global webpack configs that might have been specified in .storybook/main.ts
     if (rootMain.webpackFinal) {

--- a/packages/storybook/src/generators/configuration/project-files-ts/.storybook/tsconfig.json__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files-ts/.storybook/tsconfig.json__tmpl__
@@ -10,5 +10,5 @@
     "<%= offsetFromRoot %>../node_modules/@nrwl/react/typings/image.d.ts"
   ],<% } %>
   "exclude": ["../**/*.spec.ts" <% if(uiFramework === '@storybook/react') { %>, "../**/*.spec.js", "../**/*.spec.tsx", "../**/*.spec.jsx"<% } %>],
-  "include": ["../src/**/*", "*.js", "*.ts" <% if(uiFramework === '@storybook/react-native') { %>, "*.tsx"<% } %>]
+  "include": ["../<%= mainDir %>/**/*", "*.js", "*.ts" <% if(uiFramework === '@storybook/react-native') { %>, "*.tsx"<% } %>]
 }

--- a/packages/storybook/src/generators/configuration/project-files/.storybook/main.js__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files/.storybook/main.js__tmpl__
@@ -1,5 +1,6 @@
 const rootMain = require('<%= offsetFromRoot %>../.storybook/main');
 <% if (existsRootWebpackConfig){ %>const rootWebpackConfig = require('<%= offsetFromRoot %>../.storybook/webpack.config'); <% } %>
+<% if (isNextJs){ %>const path = require('path');<% } %>
 
 module.exports = {
   ...rootMain,
@@ -11,7 +12,17 @@ module.exports = {
     '../<%= projectDirectory %>/**/*.stories.mdx',
     '../<%= projectDirectory %>/**/*.stories.@(js|jsx|ts|tsx)'
   ],
-  addons: [...rootMain.addons <% if(uiFramework === '@storybook/react') { %>, '@nrwl/react/plugins/storybook' <% } %><% if(uiFramework === '@storybook/react-native') { %>, '@storybook/addon-ondevice-actions',  '@storybook/addon-ondevice-backgrounds', '@storybook/addon-ondevice-controls', '@storybook/addon-ondevice-notes'  <% } %>],
+  addons: [...rootMain.addons <% if(uiFramework === '@storybook/react') { %>, '@nrwl/react/plugins/storybook' <% } %><% if(uiFramework === '@storybook/react-native') { %>, '@storybook/addon-ondevice-actions',  '@storybook/addon-ondevice-backgrounds', '@storybook/addon-ondevice-controls', '@storybook/addon-ondevice-notes'  <% } %>
+    <% if(usesSwc && !isNextJs) { %>, 'storybook-addon-swc' <% } %>
+    <% if(isNextJs) { %>, 'storybook-addon-swc', 
+        {
+      name: 'storybook-addon-next',
+      options: {
+        nextConfigPath: path.resolve(__dirname, '../next.config.js'),
+      },
+    }
+     <% } %>
+  ],
   webpackFinal: async (config, { configType }) => {
     // apply any global webpack configs that might have been specified in .storybook/main.js
     if (rootMain.webpackFinal) {

--- a/packages/storybook/src/generators/configuration/project-files/.storybook/main.js__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files/.storybook/main.js__tmpl__
@@ -8,8 +8,8 @@ module.exports = {
   <% } %>
   stories: [
     ...rootMain.stories,
-    '../src/<%= projectType %>/**/*.stories.mdx',
-    '../src/<%= projectType %>/**/*.stories.@(js|jsx|ts|tsx)'
+    '../<%= projectDirectory %>/**/*.stories.mdx',
+    '../<%= projectDirectory %>/**/*.stories.@(js|jsx|ts|tsx)'
   ],
   addons: [...rootMain.addons <% if(uiFramework === '@storybook/react') { %>, '@nrwl/react/plugins/storybook' <% } %><% if(uiFramework === '@storybook/react-native') { %>, '@storybook/addon-ondevice-actions',  '@storybook/addon-ondevice-backgrounds', '@storybook/addon-ondevice-controls', '@storybook/addon-ondevice-notes'  <% } %>],
   webpackFinal: async (config, { configType }) => {

--- a/packages/storybook/src/generators/configuration/project-files/.storybook/tsconfig.json__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files/.storybook/tsconfig.json__tmpl__
@@ -10,5 +10,5 @@
     "<%= offsetFromRoot %>../node_modules/@nrwl/react/typings/image.d.ts"
   ],<% } %>
   "exclude": ["../**/*.spec.ts" <% if(uiFramework === '@storybook/react') { %>, "../**/*.spec.js", "../**/*.spec.tsx", "../**/*.spec.jsx"<% } %>],
-  "include": ["../src/**/*", "*.js" <% if(uiFramework === '@storybook/react-native') { %>, "*.ts", "*.tsx"<% } %>]
+  "include": ["../<%= mainDir %>/**/*", "*.js" <% if(uiFramework === '@storybook/react-native') { %>, "*.ts", "*.tsx"<% } %>]
 }

--- a/packages/storybook/src/generators/configuration/test-configs/workspace-conifiguration.json
+++ b/packages/storybook/src/generators/configuration/test-configs/workspace-conifiguration.json
@@ -1,0 +1,342 @@
+{
+  "projects": {
+    "nxapp": {
+      "$schema": "../../node_modules/nx/schemas/project-schema.json",
+      "sourceRoot": "apps/nxapp",
+      "root": "apps/nxapp",
+      "projectType": "application",
+      "targets": {
+        "build": {
+          "executor": "@nrwl/next:build",
+          "outputs": ["{options.outputPath}"],
+          "defaultConfiguration": "production",
+          "options": {
+            "root": "apps/nxapp",
+            "outputPath": "dist/apps/nxapp"
+          },
+          "configurations": {
+            "development": {},
+            "production": {}
+          }
+        },
+        "serve": {
+          "executor": "@nrwl/next:server",
+          "defaultConfiguration": "development",
+          "options": {
+            "buildTarget": "nxapp:build",
+            "dev": true
+          },
+          "configurations": {
+            "development": {
+              "buildTarget": "nxapp:build:development",
+              "dev": true
+            },
+            "production": {
+              "buildTarget": "nxapp:build:production",
+              "dev": false
+            }
+          }
+        },
+        "export": {
+          "executor": "@nrwl/next:export",
+          "options": {
+            "buildTarget": "nxapp:build:production"
+          }
+        },
+        "test": {
+          "executor": "@nrwl/jest:jest",
+          "outputs": ["coverage/apps/nxapp"],
+          "options": {
+            "jestConfig": "apps/nxapp/jest.config.ts",
+            "passWithNoTests": true
+          }
+        },
+        "lint": {
+          "executor": "@nrwl/linter:eslint",
+          "outputs": ["{options.outputFile}"],
+          "options": {
+            "lintFilePatterns": ["apps/nxapp/**/*.{ts,tsx,js,jsx}"]
+          }
+        }
+      },
+      "tags": []
+    },
+    "reapp": {
+      "$schema": "../../node_modules/nx/schemas/project-schema.json",
+      "sourceRoot": "apps/reapp/src",
+      "root": "apps/reapp",
+      "projectType": "application",
+      "targets": {
+        "build": {
+          "executor": "@nrwl/web:webpack",
+          "outputs": ["{options.outputPath}"],
+          "defaultConfiguration": "production",
+          "options": {
+            "compiler": "babel",
+            "outputPath": "dist/apps/reapp",
+            "index": "apps/reapp/src/index.html",
+            "baseHref": "/",
+            "main": "apps/reapp/src/main.tsx",
+            "polyfills": "apps/reapp/src/polyfills.ts",
+            "tsConfig": "apps/reapp/tsconfig.app.json",
+            "assets": ["apps/reapp/src/favicon.ico", "apps/reapp/src/assets"],
+            "styles": ["apps/reapp/src/styles.css"],
+            "scripts": [],
+            "webpackConfig": "@nrwl/react/plugins/webpack"
+          },
+          "configurations": {
+            "development": {
+              "extractLicenses": false,
+              "optimization": false,
+              "sourceMap": true,
+              "vendorChunk": true
+            },
+            "production": {
+              "fileReplacements": [
+                {
+                  "replace": "apps/reapp/src/environments/environment.ts",
+                  "with": "apps/reapp/src/environments/environment.prod.ts"
+                }
+              ],
+              "optimization": true,
+              "outputHashing": "all",
+              "sourceMap": false,
+              "namedChunks": false,
+              "extractLicenses": true,
+              "vendorChunk": false
+            }
+          }
+        },
+        "serve": {
+          "executor": "@nrwl/web:dev-server",
+          "defaultConfiguration": "development",
+          "options": {
+            "buildTarget": "reapp:build",
+            "hmr": true
+          },
+          "configurations": {
+            "development": {
+              "buildTarget": "reapp:build:development"
+            },
+            "production": {
+              "buildTarget": "reapp:build:production",
+              "hmr": false
+            }
+          }
+        },
+        "lint": {
+          "executor": "@nrwl/linter:eslint",
+          "outputs": ["{options.outputFile}"],
+          "options": {
+            "lintFilePatterns": ["apps/reapp/**/*.{ts,tsx,js,jsx}"]
+          }
+        },
+        "test": {
+          "executor": "@nrwl/jest:jest",
+          "outputs": ["coverage/apps/reapp"],
+          "options": {
+            "jestConfig": "apps/reapp/jest.config.ts",
+            "passWithNoTests": true
+          }
+        }
+      },
+      "tags": []
+    },
+    "nxlib": {
+      "$schema": "../../node_modules/nx/schemas/project-schema.json",
+      "sourceRoot": "libs/nxlib/src",
+      "root": "libs/nxlib",
+      "projectType": "library",
+      "tags": [],
+      "targets": {
+        "lint": {
+          "executor": "@nrwl/linter:eslint",
+          "outputs": ["{options.outputFile}"],
+          "options": {
+            "lintFilePatterns": ["libs/nxlib/**/*.{ts,tsx,js,jsx}"]
+          }
+        },
+        "test": {
+          "executor": "@nrwl/jest:jest",
+          "outputs": ["coverage/libs/nxlib"],
+          "options": {
+            "jestConfig": "libs/nxlib/jest.config.ts",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "nxlib-buildable": {
+      "$schema": "../../node_modules/nx/schemas/project-schema.json",
+      "sourceRoot": "libs/nxlib-buildable/src",
+      "root": "libs/nxlib-buildable",
+      "projectType": "library",
+      "tags": [],
+      "targets": {
+        "build": {
+          "executor": "@nrwl/web:rollup",
+          "outputs": ["{options.outputPath}"],
+          "options": {
+            "outputPath": "dist/libs/nxlib-buildable",
+            "tsConfig": "libs/nxlib-buildable/tsconfig.lib.json",
+            "project": "libs/nxlib-buildable/package.json",
+            "entryFile": "libs/nxlib-buildable/src/index.ts",
+            "external": ["react/jsx-runtime"],
+            "rollupConfig": "@nrwl/react/plugins/bundle-rollup",
+            "compiler": "babel",
+            "assets": [
+              {
+                "glob": "libs/nxlib-buildable/README.md",
+                "input": ".",
+                "output": "."
+              }
+            ]
+          }
+        },
+        "lint": {
+          "executor": "@nrwl/linter:eslint",
+          "outputs": ["{options.outputFile}"],
+          "options": {
+            "lintFilePatterns": ["libs/nxlib-buildable/**/*.{ts,tsx,js,jsx}"]
+          }
+        },
+        "test": {
+          "executor": "@nrwl/jest:jest",
+          "outputs": ["coverage/libs/nxlib-buildable"],
+          "options": {
+            "jestConfig": "libs/nxlib-buildable/jest.config.ts",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "relib-buildable": {
+      "$schema": "../../node_modules/nx/schemas/project-schema.json",
+      "sourceRoot": "libs/relib-buildable/src",
+      "root": "libs/relib-buildable",
+      "projectType": "library",
+      "tags": [],
+      "targets": {
+        "build": {
+          "executor": "@nrwl/web:rollup",
+          "outputs": ["{options.outputPath}"],
+          "options": {
+            "outputPath": "dist/libs/relib-buildable",
+            "tsConfig": "libs/relib-buildable/tsconfig.lib.json",
+            "project": "libs/relib-buildable/package.json",
+            "entryFile": "libs/relib-buildable/src/index.ts",
+            "external": ["react/jsx-runtime"],
+            "rollupConfig": "@nrwl/react/plugins/bundle-rollup",
+            "compiler": "babel",
+            "assets": [
+              {
+                "glob": "libs/relib-buildable/README.md",
+                "input": ".",
+                "output": "."
+              }
+            ]
+          }
+        },
+        "lint": {
+          "executor": "@nrwl/linter:eslint",
+          "outputs": ["{options.outputFile}"],
+          "options": {
+            "lintFilePatterns": ["libs/relib-buildable/**/*.{ts,tsx,js,jsx}"]
+          }
+        },
+        "test": {
+          "executor": "@nrwl/jest:jest",
+          "outputs": ["coverage/libs/relib-buildable"],
+          "options": {
+            "jestConfig": "libs/relib-buildable/jest.config.ts",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "reapp-swc": {
+      "$schema": "../../node_modules/nx/schemas/project-schema.json",
+      "sourceRoot": "apps/reapp-swc/src",
+      "root": "apps/reapp-swc",
+      "projectType": "application",
+      "targets": {
+        "build": {
+          "executor": "@nrwl/web:webpack",
+          "outputs": ["{options.outputPath}"],
+          "defaultConfiguration": "production",
+          "options": {
+            "compiler": "swc",
+            "outputPath": "dist/apps/reapp-swc",
+            "index": "apps/reapp-swc/src/index.html",
+            "baseHref": "/",
+            "main": "apps/reapp-swc/src/main.tsx",
+            "polyfills": "apps/reapp-swc/src/polyfills.ts",
+            "tsConfig": "apps/reapp-swc/tsconfig.app.json",
+            "assets": [
+              "apps/reapp-swc/src/favicon.ico",
+              "apps/reapp-swc/src/assets"
+            ],
+            "styles": ["apps/reapp-swc/src/styles.css"],
+            "scripts": [],
+            "webpackConfig": "@nrwl/react/plugins/webpack"
+          },
+          "configurations": {
+            "development": {
+              "extractLicenses": false,
+              "optimization": false,
+              "sourceMap": true,
+              "vendorChunk": true
+            },
+            "production": {
+              "fileReplacements": [
+                {
+                  "replace": "apps/reapp-swc/src/environments/environment.ts",
+                  "with": "apps/reapp-swc/src/environments/environment.prod.ts"
+                }
+              ],
+              "optimization": true,
+              "outputHashing": "all",
+              "sourceMap": false,
+              "namedChunks": false,
+              "extractLicenses": true,
+              "vendorChunk": false
+            }
+          }
+        },
+        "serve": {
+          "executor": "@nrwl/web:dev-server",
+          "defaultConfiguration": "development",
+          "options": {
+            "buildTarget": "reapp-swc:build",
+            "hmr": true
+          },
+          "configurations": {
+            "development": {
+              "buildTarget": "reapp-swc:build:development"
+            },
+            "production": {
+              "buildTarget": "reapp-swc:build:production",
+              "hmr": false
+            }
+          }
+        },
+        "lint": {
+          "executor": "@nrwl/linter:eslint",
+          "outputs": ["{options.outputFile}"],
+          "options": {
+            "lintFilePatterns": ["apps/reapp-swc/**/*.{ts,tsx,js,jsx}"]
+          }
+        },
+        "test": {
+          "executor": "@nrwl/jest:jest",
+          "outputs": ["coverage/apps/reapp-swc"],
+          "options": {
+            "jestConfig": "apps/reapp-swc/jest.config.ts",
+            "passWithNoTests": true
+          }
+        }
+      },
+      "tags": []
+    }
+  }
+}

--- a/packages/storybook/src/migrations/update-13-4-6/set-project-build-config.ts
+++ b/packages/storybook/src/migrations/update-13-4-6/set-project-build-config.ts
@@ -14,7 +14,7 @@ export default async function setProjectBuildConfig(tree: Tree) {
     if (!projectConfiguration.targets) {
       return;
     }
-    const { storybookBuildTarget, storybookTarget, buildTarget } =
+    const { storybookBuildTarget, storybookTarget, ngBuildTarget } =
       findStorybookAndBuildTargets(projectConfiguration.targets);
     if (
       projectName &&
@@ -22,7 +22,7 @@ export default async function setProjectBuildConfig(tree: Tree) {
       projectConfiguration?.targets?.[storybookTarget]?.options?.uiFramework ===
         '@storybook/angular'
     ) {
-      if (buildTarget) {
+      if (ngBuildTarget) {
         if (
           !projectConfiguration.targets[storybookTarget].options
             .projectBuildConfig

--- a/packages/storybook/src/migrations/update-13-4-6/set-project-build-config.ts
+++ b/packages/storybook/src/migrations/update-13-4-6/set-project-build-config.ts
@@ -5,7 +5,7 @@ import {
   updateProjectConfiguration,
   getProjects,
 } from '@nrwl/devkit';
-import { findStorybookAndBuildTargets } from '../../utils/utilities';
+import { findStorybookAndBuildTargetsAndCompiler } from '../../utils/utilities';
 
 export default async function setProjectBuildConfig(tree: Tree) {
   let changesMade = false;
@@ -15,7 +15,7 @@ export default async function setProjectBuildConfig(tree: Tree) {
       return;
     }
     const { storybookBuildTarget, storybookTarget, ngBuildTarget } =
-      findStorybookAndBuildTargets(projectConfiguration.targets);
+      findStorybookAndBuildTargetsAndCompiler(projectConfiguration.targets);
     if (
       projectName &&
       storybookTarget &&

--- a/packages/storybook/src/migrations/update-14-0-0/migrate-defaults-5-to-6/migrate-defaults-5-to-6.ts
+++ b/packages/storybook/src/migrations/update-14-0-0/migrate-defaults-5-to-6/migrate-defaults-5-to-6.ts
@@ -4,6 +4,7 @@ import {
   getProjects,
   installPackagesTask,
   logger,
+  readProjectConfiguration,
   Tree,
   updateJson,
   visitNotIgnoredFiles,
@@ -15,6 +16,7 @@ import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescr
 import { storybookVersion } from '../../../utils/versions';
 import { createProjectStorybookDir } from '../../../generators/configuration/util-functions';
 import { StorybookConfigureSchema } from '../../../generators/configuration/schema';
+import { findStorybookAndBuildTargetsAndCompiler } from '../../../utils/utilities';
 
 export function migrateDefaultsGenerator(tree: Tree) {
   migrateAllStorybookInstances(tree);
@@ -179,7 +181,19 @@ function migrateProjectLevelStorybookInstance(
     return;
   }
 
-  createProjectStorybookDir(tree, projectName, uiFramework, false, false);
+  const { targets } = readProjectConfiguration(tree, projectName);
+  const { nextBuildTarget, compiler } =
+    findStorybookAndBuildTargetsAndCompiler(targets);
+
+  createProjectStorybookDir(
+    tree,
+    projectName,
+    uiFramework,
+    false,
+    false,
+    !!nextBuildTarget,
+    compiler === 'swc'
+  );
 }
 
 function migrateRootLevelStorybookInstance(tree: Tree) {

--- a/packages/storybook/src/migrations/update-14-0-0/migrate-defaults-5-to-6/migrate-defaults-5-to-6.ts
+++ b/packages/storybook/src/migrations/update-14-0-0/migrate-defaults-5-to-6/migrate-defaults-5-to-6.ts
@@ -4,17 +4,17 @@ import {
   getProjects,
   installPackagesTask,
   logger,
-  readProjectConfiguration,
   Tree,
   updateJson,
   visitNotIgnoredFiles,
-  offsetFromRoot,
 } from '@nrwl/devkit';
 import { lte } from 'semver';
-import { storybookVersion } from '../../../utils/versions';
 import { join } from 'path';
 import { checkAndCleanWithSemver } from '@nrwl/workspace/src/utilities/version-utils';
 import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
+import { storybookVersion } from '../../../utils/versions';
+import { createProjectStorybookDir } from '../../../generators/configuration/util-functions';
+import { StorybookConfigureSchema } from '../../../generators/configuration/schema';
 
 export function migrateDefaultsGenerator(tree: Tree) {
   migrateAllStorybookInstances(tree);
@@ -28,7 +28,7 @@ export function migrateAllStorybookInstances(tree: Tree) {
   const projects = getProjects(tree);
   const projectsThatHaveStorybookConfiguration: {
     name: string;
-    uiFramework: string;
+    uiFramework: StorybookConfigureSchema['uiFramework'];
     configFolder: string;
   }[] = [...projects.entries()]
     .filter(
@@ -60,7 +60,7 @@ export function migrateAllStorybookInstances(tree: Tree) {
 export function migrateStorybookInstance(
   tree: Tree,
   projectName: string,
-  uiFramework: string,
+  uiFramework: StorybookConfigureSchema['uiFramework'],
   configFolder?: string
 ) {
   migrateProjectLevelStorybookInstance(
@@ -161,11 +161,9 @@ function moveOldFiles(tree: Tree, configFolderDir: string) {
 function migrateProjectLevelStorybookInstance(
   tree: Tree,
   projectName: string,
-  uiFramework: string,
+  uiFramework: StorybookConfigureSchema['uiFramework'],
   configFolder: string
 ) {
-  const { root, projectType } = readProjectConfiguration(tree, projectName);
-  const projectDirectory = projectType === 'application' ? 'app' : 'lib';
   const old_folder_exists_already = tree.exists(
     configFolder?.replace('.storybook', '.old_storybook')
   );
@@ -180,23 +178,8 @@ function migrateProjectLevelStorybookInstance(
   if (tree.exists(configFolder)) {
     return;
   }
-  generateFiles(
-    tree,
-    join(
-      __dirname,
-      '../../../generators/configuration/project-files/.storybook'
-    ),
-    configFolder,
-    {
-      tmpl: '',
-      uiFramework,
-      offsetFromRoot: offsetFromRoot(root),
-      rootTsConfigPath: getRootTsConfigPathInTree(tree),
-      projectType: projectDirectory,
-      useWebpack5: uiFramework === '@storybook/angular',
-      existsRootWebpackConfig: tree.exists('.storybook/webpack.config.js'),
-    }
-  );
+
+  createProjectStorybookDir(tree, projectName, uiFramework, false, false);
 }
 
 function migrateRootLevelStorybookInstance(tree: Tree) {

--- a/packages/storybook/src/utils/test-configs/different-target-variations.json
+++ b/packages/storybook/src/utils/test-configs/different-target-variations.json
@@ -1,0 +1,235 @@
+{
+  "web": {
+    "build": {
+      "executor": "@nrwl/next:build",
+      "options": {
+        "root": "apps/web",
+        "outputPath": "dist/apps/web"
+      }
+    },
+    "serve": {
+      "executor": "@nrwl/next:server",
+      "options": {
+        "buildTarget": "web:build",
+        "dev": true
+      }
+    },
+    "storybook": {
+      "executor": "@nrwl/storybook:storybook",
+      "options": {
+        "uiFramework": "@storybook/react",
+        "port": 4400,
+        "config": {
+          "configFolder": "apps/web/.storybook"
+        }
+      }
+    },
+    "build-storybook": {
+      "executor": "@nrwl/storybook:build",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "uiFramework": "@storybook/react",
+        "outputPath": "dist/storybook/web",
+        "config": {
+          "configFolder": "apps/web/.storybook"
+        }
+      }
+    }
+  },
+  "react": {
+    "build": {
+      "executor": "@nrwl/web:webpack",
+      "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
+      "options": {
+        "compiler": "babel",
+        "outputPath": "dist/apps/reapp"
+      }
+    },
+    "storybook": {
+      "executor": "@nrwl/storybook:storybook",
+      "options": {
+        "uiFramework": "@storybook/react",
+        "port": 4400,
+        "config": {
+          "configFolder": "apps/reapp/.storybook"
+        }
+      }
+    },
+    "build-storybook": {
+      "executor": "@nrwl/storybook:build",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "uiFramework": "@storybook/react",
+        "outputPath": "dist/storybook/reapp",
+        "config": {
+          "configFolder": "apps/reapp/.storybook"
+        }
+      }
+    }
+  },
+  "nextlib": {
+    "build": {
+      "executor": "@nrwl/web:rollup",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/libs/next-lib-buildable",
+        "tsConfig": "libs/next-lib-buildable/tsconfig.lib.json",
+        "project": "libs/next-lib-buildable/package.json",
+        "entryFile": "libs/next-lib-buildable/src/index.ts",
+        "external": ["react/jsx-runtime"],
+        "rollupConfig": "@nrwl/react/plugins/bundle-rollup",
+        "compiler": "babel"
+      }
+    }
+  },
+  "nextapp": {
+    "build": {
+      "executor": "@nrwl/next:build",
+      "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
+      "options": {
+        "root": "apps/nextapp",
+        "outputPath": "dist/apps/nextapp"
+      }
+    },
+    "serve": {
+      "executor": "@nrwl/next:server",
+      "defaultConfiguration": "development",
+      "options": {
+        "buildTarget": "nextapp:build",
+        "dev": true
+      }
+    }
+  },
+  "ngapp": {
+    "build": {
+      "executor": "@angular-devkit/build-angular:browser",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/apps/ngapp",
+        "index": "apps/ngapp/src/index.html",
+        "main": "apps/ngapp/src/main.ts",
+        "polyfills": "apps/ngapp/src/polyfills.ts",
+        "tsConfig": "apps/ngapp/tsconfig.app.json",
+        "assets": ["apps/ngapp/src/favicon.ico", "apps/ngapp/src/assets"],
+        "styles": ["apps/ngapp/src/styles.css"],
+        "scripts": []
+      },
+
+      "defaultConfiguration": "production"
+    },
+    "serve": {
+      "executor": "@angular-devkit/build-angular:dev-server",
+      "configurations": {
+        "production": {
+          "browserTarget": "ngapp:build:production"
+        },
+        "development": {
+          "browserTarget": "ngapp:build:development"
+        }
+      },
+      "defaultConfiguration": "development"
+    },
+
+    "storybook": {
+      "executor": "@storybook/angular:start-storybook",
+      "options": {
+        "port": 4400,
+        "configDir": "apps/ngapp/.storybook",
+        "browserTarget": "ngapp:build",
+        "compodoc": false
+      }
+    },
+    "build-storybook": {
+      "executor": "@storybook/angular:build-storybook",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputDir": "dist/storybook/ngapp",
+        "configDir": "apps/ngapp/.storybook",
+        "browserTarget": "ngapp:build",
+        "compodoc": false
+      }
+    }
+  },
+  "nglib": {
+    "build": {
+      "executor": "@nrwl/angular:ng-packagr-lite",
+      "outputs": ["dist/libs/nglibuild"],
+      "options": {
+        "project": "libs/nglibuild/ng-package.json"
+      },
+      "defaultConfiguration": "production"
+    },
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "options": {
+        "lintFilePatterns": [
+          "libs/nglibuild/**/*.ts",
+          "libs/nglibuild/**/*.html"
+        ]
+      }
+    }
+  },
+  "react-swc": {
+    "build": {
+      "executor": "@nrwl/web:webpack",
+      "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
+      "options": {
+        "compiler": "swc",
+        "outputPath": "dist/apps/reapp"
+      }
+    },
+    "storybook": {
+      "executor": "@nrwl/storybook:storybook",
+      "options": {
+        "uiFramework": "@storybook/react",
+        "port": 4400,
+        "config": {
+          "configFolder": "apps/reapp/.storybook"
+        }
+      }
+    },
+    "build-storybook": {
+      "executor": "@nrwl/storybook:build",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "uiFramework": "@storybook/react",
+        "outputPath": "dist/storybook/reapp",
+        "config": {
+          "configFolder": "apps/reapp/.storybook"
+        }
+      }
+    }
+  },
+  "nextapp-swc": {
+    "build": {
+      "executor": "@nrwl/next:build",
+      "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
+      "options": {
+        "compiler": "swc",
+        "root": "apps/nextapp",
+        "outputPath": "dist/apps/nextapp"
+      }
+    },
+    "serve": {
+      "executor": "@nrwl/next:server",
+      "defaultConfiguration": "development",
+      "options": {
+        "buildTarget": "nextapp:build",
+        "dev": true
+      }
+    }
+  },
+  "other": {
+    "build": {
+      "executor": "@my/custom:build",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "compiler": "swc"
+      }
+    }
+  }
+}

--- a/packages/storybook/src/utils/testing.ts
+++ b/packages/storybook/src/utils/testing.ts
@@ -5,7 +5,6 @@ import { Tree as NrwlTree } from '@nrwl/devkit';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
 
 import { createEmptyWorkspace } from '@nrwl/workspace/testing';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import libraryGenerator from '@nrwl/workspace/src/generators/library/library';
 import { Linter } from '@nrwl/linter';
 

--- a/packages/storybook/src/utils/utilities.spec.ts
+++ b/packages/storybook/src/utils/utilities.spec.ts
@@ -4,8 +4,12 @@ import {
   wrapAngularDevkitSchematic,
 } from '@nrwl/devkit/ngcli-adapter';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import { isTheFileAStory } from './utilities';
+import {
+  findStorybookAndBuildTargetsAndCompiler,
+  isTheFileAStory,
+} from './utilities';
 import { nxVersion, storybookVersion } from './versions';
+import * as targetVariations from './test-configs/different-target-variations.json';
 
 const componentSchematic = wrapAngularDevkitSchematic(
   '@schematics/angular',
@@ -21,44 +25,45 @@ const runAngularStorybookSchematic = wrapAngularDevkitSchematic(
 );
 
 describe('testing utilities', () => {
-  let appTree: Tree;
+  describe('Test functions that need workspace tree', () => {
+    let appTree: Tree;
 
-  beforeEach(async () => {
-    overrideCollectionResolutionForTesting({
-      '@nrwl/storybook': joinPathFragments(
-        __dirname,
-        '../../../../generators.json'
-      ),
-    });
+    beforeEach(async () => {
+      overrideCollectionResolutionForTesting({
+        '@nrwl/storybook': joinPathFragments(
+          __dirname,
+          '../../../../generators.json'
+        ),
+      });
 
-    appTree = createTreeWithEmptyWorkspace();
+      appTree = createTreeWithEmptyWorkspace();
 
-    await runAngularLibrarySchematic(appTree, {
-      name: 'test-ui-lib',
-    });
+      await runAngularLibrarySchematic(appTree, {
+        name: 'test-ui-lib',
+      });
 
-    await componentSchematic(appTree, {
-      name: 'button',
-      project: 'test-ui-lib',
-    });
+      await componentSchematic(appTree, {
+        name: 'button',
+        project: 'test-ui-lib',
+      });
 
-    writeJson(appTree, 'package.json', {
-      devDependencies: {
-        '@nrwl/storybook': nxVersion,
-        '@storybook/addon-knobs': storybookVersion,
-        '@storybook/angular': storybookVersion,
-      },
-    });
-    writeJson(appTree, 'test-ui-lib/tsconfig.json', {});
+      writeJson(appTree, 'package.json', {
+        devDependencies: {
+          '@nrwl/storybook': nxVersion,
+          '@storybook/addon-knobs': storybookVersion,
+          '@storybook/angular': storybookVersion,
+        },
+      });
+      writeJson(appTree, 'test-ui-lib/tsconfig.json', {});
 
-    await runAngularStorybookSchematic(appTree, {
-      name: 'test-ui-lib',
-      configureCypress: true,
-    });
+      await runAngularStorybookSchematic(appTree, {
+        name: 'test-ui-lib',
+        configureCypress: true,
+      });
 
-    appTree.write(
-      `test-ui-lib/src/lib/button/button.component.stories.ts`,
-      `
+      appTree.write(
+        `test-ui-lib/src/lib/button/button.component.stories.ts`,
+        `
       import { Story, Meta } from '@storybook/react';
       import { Button } from './button';
       
@@ -72,128 +77,259 @@ describe('testing utilities', () => {
       export const Primary = Template.bind({});
       Primary.args = {};
     `
-    );
+      );
 
-    appTree.write(
-      `test-ui-lib/src/lib/button/button.component.other.ts`,
-      `
+      appTree.write(
+        `test-ui-lib/src/lib/button/button.component.other.ts`,
+        `
         import { Button } from './button';
         
         // test test
       `
-    );
+      );
 
-    appTree.write(
-      `test-ui-lib/src/lib/button/button.component.react-native.ts`,
-      `
+      appTree.write(
+        `test-ui-lib/src/lib/button/button.component.react-native.ts`,
+        `
        import { storiesOf } from '@storybook/react-native';
         
         // test test
       `
-    );
+      );
 
-    appTree.write(
-      `test-ui-lib/src/lib/button/button.component.new-syntax.ts`,
-      `
+      appTree.write(
+        `test-ui-lib/src/lib/button/button.component.new-syntax.ts`,
+        `
        import { ComponentStory } from '@storybook/react';
         
         // test test
       `
-    );
+      );
 
-    appTree.write(
-      `test-ui-lib/src/lib/button/button.component.stories.jsx`,
-      `
+      appTree.write(
+        `test-ui-lib/src/lib/button/button.component.stories.jsx`,
+        `
        var test = 1;
         // test test
       `
-    );
+      );
 
-    appTree.write(
-      `test-ui-lib/src/lib/button/button.component.stories.js`,
-      `
+      appTree.write(
+        `test-ui-lib/src/lib/button/button.component.stories.js`,
+        `
        var test = 1;
         // test test
       `
-    );
-    appTree.write(
-      `test-ui-lib/src/lib/button/button.component.js`,
-      `
+      );
+      appTree.write(
+        `test-ui-lib/src/lib/button/button.component.js`,
+        `
        var test = 1;
         // test test
       `
-    );
-    appTree.write(
-      `test-ui-lib/src/lib/button/button.component.jsx`,
-      `
+      );
+      appTree.write(
+        `test-ui-lib/src/lib/button/button.component.jsx`,
+        `
        var test = 1;
         // test test
       `
-    );
+      );
+    });
+
+    describe('typescript files', () => {
+      it('should verify it is story', () => {
+        const fileIsStory = isTheFileAStory(
+          appTree,
+          'test-ui-lib/src/lib/button/button.component.stories.ts'
+        );
+        expect(fileIsStory).toBeTruthy();
+      });
+
+      it('should verify it is story for ReactNative', () => {
+        const fileIsStory = isTheFileAStory(
+          appTree,
+          'test-ui-lib/src/lib/button/button.component.react-native.ts'
+        );
+        expect(fileIsStory).toBeTruthy();
+      });
+
+      it('should verify it is story for new Syntax', () => {
+        const fileIsStory = isTheFileAStory(
+          appTree,
+          'test-ui-lib/src/lib/button/button.component.new-syntax.ts'
+        );
+        expect(fileIsStory).toBeTruthy();
+      });
+
+      it('should verify it is not a story', () => {
+        const fileIsStory = isTheFileAStory(
+          appTree,
+          'test-ui-lib/src/lib/button/button.component.other.ts'
+        );
+        expect(fileIsStory).toBeFalsy();
+      });
+    });
+
+    describe('javascript files', () => {
+      it('should verify it is story if it ends in .stories.jsx', () => {
+        const fileIsStory = isTheFileAStory(
+          appTree,
+          'test-ui-lib/src/lib/button/button.component.stories.jsx'
+        );
+        expect(fileIsStory).toBeTruthy();
+      });
+      it('should verify it is story if it ends in .stories.js', () => {
+        const fileIsStory = isTheFileAStory(
+          appTree,
+          'test-ui-lib/src/lib/button/button.component.stories.js'
+        );
+        expect(fileIsStory).toBeTruthy();
+      });
+      it('should verify it is NOT a story if it does NOT end in .stories.jsx', () => {
+        const fileIsStory = isTheFileAStory(
+          appTree,
+          'test-ui-lib/src/lib/button/button.component.jsx'
+        );
+        expect(fileIsStory).toBeFalsy();
+      });
+      it('should verify it is NOT a story if it does NOT end in .stories.js', () => {
+        const fileIsStory = isTheFileAStory(
+          appTree,
+          'test-ui-lib/src/lib/button/button.component.js'
+        );
+        expect(fileIsStory).toBeFalsy();
+      });
+    });
   });
 
-  describe('typescript files', () => {
-    it('should verify it is story', () => {
-      const fileIsStory = isTheFileAStory(
-        appTree,
-        'test-ui-lib/src/lib/button/button.component.stories.ts'
-      );
-      expect(fileIsStory).toBeTruthy();
-    });
+  describe('Test pure utility functions', () => {
+    describe('findStorybookAndBuildTargetsAndCompiler', () => {
+      it('should find correct targets and compiler for the provided next app config', () => {
+        const result = findStorybookAndBuildTargetsAndCompiler(
+          targetVariations.nextapp
+        );
+        expect(result).toEqual({
+          storybookBuildTarget: undefined,
+          storybookTarget: undefined,
+          ngBuildTarget: undefined,
+          nextBuildTarget: 'build',
+          otherBuildTarget: undefined,
+          compiler: undefined,
+        });
+      });
 
-    it('should verify it is story for ReactNative', () => {
-      const fileIsStory = isTheFileAStory(
-        appTree,
-        'test-ui-lib/src/lib/button/button.component.react-native.ts'
-      );
-      expect(fileIsStory).toBeTruthy();
-    });
+      it('should find correct targets and compiler for the provided web app config', () => {
+        const result = findStorybookAndBuildTargetsAndCompiler(
+          targetVariations.web
+        );
+        expect(result).toEqual({
+          storybookBuildTarget: 'build-storybook',
+          storybookTarget: 'storybook',
+          ngBuildTarget: undefined,
+          nextBuildTarget: 'build',
+          otherBuildTarget: undefined,
+          compiler: undefined,
+        });
+      });
 
-    it('should verify it is story for new Syntax', () => {
-      const fileIsStory = isTheFileAStory(
-        appTree,
-        'test-ui-lib/src/lib/button/button.component.new-syntax.ts'
-      );
-      expect(fileIsStory).toBeTruthy();
-    });
+      it('should find correct targets and compiler for the provided react app config', () => {
+        const result = findStorybookAndBuildTargetsAndCompiler(
+          targetVariations.react
+        );
+        expect(result).toEqual({
+          storybookBuildTarget: 'build-storybook',
+          storybookTarget: 'storybook',
+          ngBuildTarget: undefined,
+          nextBuildTarget: undefined,
+          otherBuildTarget: 'build',
+          compiler: 'babel',
+        });
+      });
 
-    it('should verify it is not a story', () => {
-      const fileIsStory = isTheFileAStory(
-        appTree,
-        'test-ui-lib/src/lib/button/button.component.other.ts'
-      );
-      expect(fileIsStory).toBeFalsy();
-    });
-  });
+      it('should find correct targets and compiler for the provided angular app config', () => {
+        const result = findStorybookAndBuildTargetsAndCompiler(
+          targetVariations.ngapp
+        );
+        expect(result).toEqual({
+          storybookBuildTarget: 'build-storybook',
+          storybookTarget: 'storybook',
+          ngBuildTarget: 'build',
+          nextBuildTarget: undefined,
+          otherBuildTarget: undefined,
+          compiler: undefined,
+        });
+      });
 
-  describe('javascript files', () => {
-    it('should verify it is story if it ends in .stories.jsx', () => {
-      const fileIsStory = isTheFileAStory(
-        appTree,
-        'test-ui-lib/src/lib/button/button.component.stories.jsx'
-      );
-      expect(fileIsStory).toBeTruthy();
-    });
-    it('should verify it is story if it ends in .stories.js', () => {
-      const fileIsStory = isTheFileAStory(
-        appTree,
-        'test-ui-lib/src/lib/button/button.component.stories.js'
-      );
-      expect(fileIsStory).toBeTruthy();
-    });
-    it('should verify it is NOT a story if it does NOT end in .stories.jsx', () => {
-      const fileIsStory = isTheFileAStory(
-        appTree,
-        'test-ui-lib/src/lib/button/button.component.jsx'
-      );
-      expect(fileIsStory).toBeFalsy();
-    });
-    it('should verify it is NOT a story if it does NOT end in .stories.js', () => {
-      const fileIsStory = isTheFileAStory(
-        appTree,
-        'test-ui-lib/src/lib/button/button.component.js'
-      );
-      expect(fileIsStory).toBeFalsy();
+      it('should find correct targets and compiler for the provided angular lib config', () => {
+        const result = findStorybookAndBuildTargetsAndCompiler(
+          targetVariations.nglib
+        );
+        expect(result).toEqual({
+          storybookBuildTarget: undefined,
+          storybookTarget: undefined,
+          ngBuildTarget: undefined,
+          nextBuildTarget: undefined,
+          otherBuildTarget: 'build',
+          compiler: undefined,
+        });
+      });
+
+      it('should find correct targets and compiler for the provided next lib config', () => {
+        const result = findStorybookAndBuildTargetsAndCompiler(
+          targetVariations.nextlib
+        );
+        expect(result).toEqual({
+          storybookBuildTarget: undefined,
+          storybookTarget: undefined,
+          ngBuildTarget: undefined,
+          nextBuildTarget: undefined,
+          otherBuildTarget: 'build',
+          compiler: 'babel',
+        });
+      });
+
+      it('should find correct targets and compiler for the provided react app config with swc', () => {
+        const result = findStorybookAndBuildTargetsAndCompiler(
+          targetVariations['react-swc']
+        );
+        expect(result).toEqual({
+          storybookBuildTarget: 'build-storybook',
+          storybookTarget: 'storybook',
+          ngBuildTarget: undefined,
+          nextBuildTarget: undefined,
+          otherBuildTarget: 'build',
+          compiler: 'swc',
+        });
+      });
+
+      it('should find correct targets and compiler for the provided Next.js app config with swc', () => {
+        const result = findStorybookAndBuildTargetsAndCompiler(
+          targetVariations['nextapp-swc']
+        );
+        expect(result).toEqual({
+          storybookBuildTarget: undefined,
+          storybookTarget: undefined,
+          ngBuildTarget: undefined,
+          nextBuildTarget: 'build',
+          otherBuildTarget: undefined,
+          compiler: 'swc',
+        });
+      });
+
+      it('should find compiler for the provided config regardless of what builder', () => {
+        const result = findStorybookAndBuildTargetsAndCompiler(
+          targetVariations.other
+        );
+        expect(result).toEqual({
+          storybookBuildTarget: undefined,
+          storybookTarget: undefined,
+          ngBuildTarget: undefined,
+          nextBuildTarget: undefined,
+          otherBuildTarget: 'build',
+          compiler: 'swc',
+        });
+      });
     });
   });
 });

--- a/packages/storybook/src/utils/utilities.ts
+++ b/packages/storybook/src/utils/utilities.ts
@@ -212,67 +212,31 @@ export function dedupe(arr: string[]) {
 }
 
 /**
- * This function is only used for ANGULAR projects.
+ * This function is mainly used for ANGULAR projects.
  * And it is used for the "old" Storybook/Angular setup,
- * where the Nx executor is used.
- *
- * At the moment, it's used by the migrator to set projectBuildConfig
+ * where the Nx executor is used. It's purpose is to set up
+ * the projectBuildConfig for the Angular project. For that purpose,
+ * it's used ONLY by the migrator to set projectBuildConfig
  * and it is also used by the change-storybook-targets generator/migrator
+ * when migrating to the new, angular-only Storybook schema.
+ *
+ * We are repurposing this function to also return the
+ * build target for Next apps.
  */
+
 export function findStorybookAndBuildTargets(targets: {
   [targetName: string]: TargetConfiguration;
 }): {
   storybookBuildTarget?: string;
   storybookTarget?: string;
-  buildTarget?: string;
+  ngBuildTarget?: string;
+  nextBuildTarget?: string;
 } {
   const returnObject: {
     storybookBuildTarget?: string;
     storybookTarget?: string;
-    buildTarget?: string;
-  } = {};
-  Object.entries(targets).forEach(([target, targetConfig]) => {
-    if (targetConfig.executor === '@nrwl/storybook:storybook') {
-      returnObject.storybookTarget = target;
-    }
-    if (targetConfig.executor === '@nrwl/storybook:build') {
-      returnObject.storybookBuildTarget = target;
-    }
-    /**
-     * Not looking for '@nrwl/angular:ng-packagr-lite', only
-     * looking for '@angular-devkit/build-angular:browser'
-     * because the '@nrwl/angular:ng-packagr-lite' executor
-     * does not support styles and extra options, so the user
-     * will be forced to switch to build-storybook to add extra options.
-     *
-     * So we might as well use the build-storybook by default to
-     * avoid any errors.
-     */
-    if (targetConfig.executor === '@angular-devkit/build-angular:browser') {
-      returnObject.buildTarget = target;
-    }
-  });
-  return returnObject;
-}
-
-/**
- * This function is not used at the moment.
- *
- * However, it may be valuable to create this here, in order to avoid
- * any confusion in the future.
- *
- */
-export function findStorybookAndBuildTargetsForStorybookAngularExecutors(targets: {
-  [targetName: string]: TargetConfiguration;
-}): {
-  storybookBuildTarget?: string;
-  storybookTarget?: string;
-  buildTarget?: string;
-} {
-  const returnObject: {
-    storybookBuildTarget?: string;
-    storybookTarget?: string;
-    buildTarget?: string;
+    ngBuildTarget?: string;
+    nextBuildTarget?: string;
   } = {};
   Object.entries(targets).forEach(([target, targetConfig]) => {
     if (targetConfig.executor === '@storybook/angular:start-storybook') {
@@ -281,6 +245,15 @@ export function findStorybookAndBuildTargetsForStorybookAngularExecutors(targets
     if (targetConfig.executor === '@storybook/angular:build-storybook') {
       returnObject.storybookBuildTarget = target;
     }
+
+    // If it's a non-angular project, these will be the executors
+    if (targetConfig.executor === '@nrwl/storybook:storybook') {
+      returnObject.storybookTarget = target;
+    }
+    if (targetConfig.executor === '@nrwl/storybook:build') {
+      returnObject.storybookBuildTarget = target;
+    }
+
     /**
      * Not looking for '@nrwl/angular:ng-packagr-lite', only
      * looking for '@angular-devkit/build-angular:browser'
@@ -292,7 +265,11 @@ export function findStorybookAndBuildTargetsForStorybookAngularExecutors(targets
      * avoid any errors.
      */
     if (targetConfig.executor === '@angular-devkit/build-angular:browser') {
-      returnObject.buildTarget = target;
+      returnObject.ngBuildTarget = target;
+    }
+
+    if (targetConfig.executor === '@nrwl/next:build') {
+      returnObject.nextBuildTarget = target;
     }
   });
   return returnObject;

--- a/packages/storybook/src/utils/utilities.ts
+++ b/packages/storybook/src/utils/utilities.ts
@@ -1,7 +1,9 @@
 import {
   ExecutorContext,
+  logger,
   readJson,
   readJsonFile,
+  readProjectConfiguration,
   TargetConfiguration,
   Tree,
 } from '@nrwl/devkit';
@@ -212,66 +214,90 @@ export function dedupe(arr: string[]) {
 }
 
 /**
- * This function is mainly used for ANGULAR projects.
- * And it is used for the "old" Storybook/Angular setup,
- * where the Nx executor is used. It's purpose is to set up
- * the projectBuildConfig for the Angular project. For that purpose,
- * it's used ONLY by the migrator to set projectBuildConfig
- * and it is also used by the change-storybook-targets generator/migrator
- * when migrating to the new, angular-only Storybook schema.
+ * This function is used to find the build targets for Storybook
+ * and the project (if it's buildable).
  *
- * We are repurposing this function to also return the
- * build target for Next apps.
+ * The reason this function exists is because we cannot assume
+ * that the user has not created a custom build target for the project,
+ * or that they have not changed the name of the build target
+ * from build to anything else.
+ *
+ * So, in order to find the correct name of the target,
+ * we have to look into all the targets, check the executor
+ * they are using, and infer from the executor that the target
+ * is a build target.
  */
 
-export function findStorybookAndBuildTargets(targets: {
+export function findStorybookAndBuildTargetsAndCompiler(targets: {
   [targetName: string]: TargetConfiguration;
 }): {
   storybookBuildTarget?: string;
   storybookTarget?: string;
   ngBuildTarget?: string;
   nextBuildTarget?: string;
+  otherBuildTarget?: string;
+  compiler?: string;
 } {
   const returnObject: {
     storybookBuildTarget?: string;
     storybookTarget?: string;
     ngBuildTarget?: string;
     nextBuildTarget?: string;
+    otherBuildTarget?: string;
+    compiler?: string;
   } = {};
+
   Object.entries(targets).forEach(([target, targetConfig]) => {
-    if (targetConfig.executor === '@storybook/angular:start-storybook') {
-      returnObject.storybookTarget = target;
-    }
-    if (targetConfig.executor === '@storybook/angular:build-storybook') {
-      returnObject.storybookBuildTarget = target;
-    }
-
-    // If it's a non-angular project, these will be the executors
-    if (targetConfig.executor === '@nrwl/storybook:storybook') {
-      returnObject.storybookTarget = target;
-    }
-    if (targetConfig.executor === '@nrwl/storybook:build') {
-      returnObject.storybookBuildTarget = target;
-    }
-
-    /**
-     * Not looking for '@nrwl/angular:ng-packagr-lite', only
-     * looking for '@angular-devkit/build-angular:browser'
-     * because the '@nrwl/angular:ng-packagr-lite' executor
-     * does not support styles and extra options, so the user
-     * will be forced to switch to build-storybook to add extra options.
-     *
-     * So we might as well use the build-storybook by default to
-     * avoid any errors.
-     */
-    if (targetConfig.executor === '@angular-devkit/build-angular:browser') {
-      returnObject.ngBuildTarget = target;
-    }
-
-    if (targetConfig.executor === '@nrwl/next:build') {
-      returnObject.nextBuildTarget = target;
+    switch (targetConfig.executor) {
+      case '@storybook/angular:start-storybook':
+        returnObject.storybookTarget = target;
+        break;
+      case '@storybook/angular:build-storybook':
+        returnObject.storybookBuildTarget = target;
+        break;
+      // If it's a non-angular project, these will be the executors
+      case '@nrwl/storybook:storybook':
+        returnObject.storybookTarget = target;
+        break;
+      case '@nrwl/storybook:build':
+        returnObject.storybookBuildTarget = target;
+        break;
+      case '@angular-devkit/build-angular:browser':
+        /**
+         * Not looking for '@nrwl/angular:ng-packagr-lite' or any other
+         * angular executors.
+         * Only looking for '@angular-devkit/build-angular:browser'
+         * because the '@nrwl/angular:ng-packagr-lite' executor
+         * (and maybe the other custom exeucutors)
+         * does not support styles and extra options, so the user
+         * will be forced to switch to build-storybook to add extra options.
+         *
+         * So we might as well use the build-storybook by default to
+         * avoid any errors.
+         */
+        returnObject.ngBuildTarget = target;
+        returnObject.compiler = targetConfig?.options?.compiler;
+        break;
+      case '@nrwl/next:build':
+        returnObject.nextBuildTarget = target;
+        returnObject.compiler = targetConfig?.options?.compiler;
+        break;
+      case '@nrwl/web:webpack':
+      case '@nrwl/web:rollup':
+      case '@nrwl/js:tsc':
+      case '@nrwl/angular:ng-packagr-lite':
+        returnObject.otherBuildTarget = target;
+        returnObject.compiler = targetConfig?.options?.compiler;
+        break;
+      default:
+        if (targetConfig.options?.compiler) {
+          returnObject.otherBuildTarget = target;
+          returnObject.compiler = targetConfig?.options?.compiler;
+        }
+        break;
     }
   });
+
   return returnObject;
 }
 

--- a/packages/storybook/src/utils/versions.ts
+++ b/packages/storybook/src/utils/versions.ts
@@ -8,3 +8,5 @@ export const urlLoaderVersion = '^3.0.0';
 export const webpack5Version = '^5.64.0';
 export const storybookReactNativeVersion = '^6.0.1-beta.5';
 export const reactNativeStorybookLoader = '^2.0.5';
+export const storybookSwcAddonVersion = '^1.1.7';
+export const storybookNextAddonVersion = '^1.6.6';


### PR DESCRIPTION
3 birds with one stone, here.

## Current Behavior
1. Nx does not look in the correct directory for Next.js components to create stories
2. Nx/Storybook does not work with nextjs atm, due to bad link for stories (looks into `src/app` instead of `components`
3. Nx/Storybook does not work with nextjs atm, due to the fact that it is not configured to handle swc


## Expected Behavior
1. Look into the correct directory for components to create stories
2. Add correct path for stories in `.storybook`'s `main.js` and `tsconfig.json`
3. Support `swc`

### How will Nx support `swc` for Storybook

Storybook supports `swc` using the `storybook-addon-swc` addon. If you want to use `swc` with Storybook, please read [the documentation](https://storybook.js.org/addons/storybook-addon-swc/).

Nx will generate Storybook configured WITH `swc` if in your `project.json` in your project's configuration you use `swc` as a compiler to your `build` target, or if you use the nextjs `"@nrwl/next:build"` builder.

### How will Nx support `next.js` for Storybook

Next now uses `swc`, so you may have noticed you `next.js` `storybook`s not working. If you're generating Storybook configuration for a Next.js application (one that uses `"@nrwl/next:build"`), then Nx will make sure to add the `storybook-addon-swc` and the `storybook-addon-next` addons to your `main.js` or `main.ts`.


## Related Issue(s)

Fixes #8592 #10619
