### PR TITLE
fix(core): show meaningful error message when unsupported positional arg set

### DIFF
--- a/packages/nx/src/utils/params.spec.ts
+++ b/packages/nx/src/utils/params.spec.ts
@@ -794,6 +794,27 @@ describe('params', () => {
       ).toThrow("'b' is not found in schema");
     });
 
+    it('should throw if found unsupported positional property', () => {
+      expect(() =>
+        validateOptsAgainstSchema(
+          {
+            a: true,
+            _: 'sometext',
+          },
+          {
+            properties: {
+              a: {
+                type: 'boolean',
+              },
+            },
+            additionalProperties: false,
+          }
+        )
+      ).toThrow(
+        "Schema does not support positional arguments. Argument 'sometext' found"
+      );
+    });
+
     describe('primitive types', () => {
       it("should throw if the type doesn't match", () => {
         expect(() =>

--- a/packages/nx/src/utils/params.ts
+++ b/packages/nx/src/utils/params.ts
@@ -4,6 +4,7 @@ import {
   TargetConfiguration,
   ProjectsConfigurations,
 } from '../config/workspace-json-project-json';
+import { execSync } from 'child_process';
 
 type PropertyDescription = {
   type?: string | string[];
@@ -231,7 +232,13 @@ export function validateObject(
   if (additionalProperties === false) {
     Object.keys(opts).find((p) => {
       if (Object.keys(properties).indexOf(p) === -1) {
-        throw new SchemaError(`'${p}' is not found in schema`);
+        if (p === '_') {
+          throw new SchemaError(
+            `Schema does not support positional arguments. Argument '${opts[p]}' found`
+          );
+        } else {
+          throw new SchemaError(`'${p}' is not found in schema`);
+        }
       }
     });
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When schema explicitly disables positional arguments (with `additionalProperties: false`) the error presented is not helpful:

```
'_' is not found in schema
```

## Expected Behavior
Show message explaining that positional argument is not supported and highlight what argument was found that caused this error.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Related to #10768 
