### PR TITLE
docs(nxdev): display minimal header on mobile

### DIFF
--- a/nx-dev/feature-search/src/lib/algolia-search.tsx
+++ b/nx-dev/feature-search/src/lib/algolia-search.tsx
@@ -74,8 +74,8 @@ export function AlgoliaSearch() {
         onClick={handleOpen}
         className="flex w-full items-center rounded-md py-1.5 pl-2 pr-3 text-sm leading-6 text-slate-300 ring-1 ring-slate-600 transition hover:text-slate-200 hover:ring-slate-500"
       >
-        <SearchIcon className="mr-3 h-4 w-4 flex-none" />
-        <span className="mx-3">
+        <SearchIcon className="h-4 w-4 flex-none md:mr-3" />
+        <span className="mx-3 hidden md:inline-flex">
           <span className="hidden lg:inline">Quick </span>search
         </span>
         <span

--- a/nx-dev/ui-common/src/lib/header.tsx
+++ b/nx-dev/ui-common/src/lib/header.tsx
@@ -97,7 +97,7 @@ export function Header(props: HeaderProps) {
             <Link href="/conf">
               <a
                 title="Check Nx conference"
-                className="relative px-3 py-2 leading-tight text-white md:inline-flex"
+                className="relative hidden px-3 py-2 leading-tight text-white md:inline-flex"
               >
                 {/*<span className="absolute top-0 right-0 -mt-1 -mr-1 flex h-3 w-3">*/}
                 {/*  <span className="bg-green-nx-base absolute inline-flex h-full w-full animate-ping rounded-full opacity-75" />*/}


### PR DESCRIPTION
It displays a minimal header on mobile for nx.dev, making all primary header action accessible.