### PR TITLE
docs(misc): fix typo "a executor"

### DIFF
--- a/docs/generated/packages/nx-plugin.json
+++ b/docs/generated/packages/nx-plugin.json
@@ -282,8 +282,8 @@
         "$schema": "http://json-schema.org/schema",
         "cli": "nx",
         "$id": "NxPluginExecutor",
-        "title": "Create a Executor for an Nx Plugin",
-        "description": "Create a Executor for an Nx Plugin.",
+        "title": "Create an Executor for an Nx Plugin",
+        "description": "Create an Executor for an Nx Plugin.",
         "type": "object",
         "examples": [
           {
@@ -326,7 +326,7 @@
         "additionalProperties": false,
         "presets": []
       },
-      "description": "Create a executor for an Nx Plugin.",
+      "description": "Create an executor for an Nx Plugin.",
       "implementation": "/packages/nx-plugin/src/generators/executor/executor.ts",
       "aliases": [],
       "hidden": false,

--- a/e2e/nx-plugin/src/nx-plugin.test.ts
+++ b/e2e/nx-plugin/src/nx-plugin.test.ts
@@ -145,7 +145,7 @@ describe('Nx Plugin', () => {
     });
   }, 90000);
 
-  it('should be able to generate a executor', async () => {
+  it('should be able to generate an executor', async () => {
     const plugin = uniq('plugin');
     const executor = uniq('executor');
 

--- a/packages/nx-plugin/generators.json
+++ b/packages/nx-plugin/generators.json
@@ -27,7 +27,7 @@
     "executor": {
       "factory": "./src/generators/executor/executor",
       "schema": "./src/generators/executor/schema.json",
-      "description": "Create a executor for an Nx Plugin."
+      "description": "Create an executor for an Nx Plugin."
     },
     "plugin-lint-checks": {
       "factory": "./src/generators/lint-checks/generator",
@@ -60,7 +60,7 @@
     "executor": {
       "factory": "./src/generators/executor/executor#executorSchematic",
       "schema": "./src/generators/executor/schema.json",
-      "description": "Create a executor for an Nx Plugin."
+      "description": "Create an executor for an Nx Plugin."
     }
   }
 }

--- a/packages/nx-plugin/src/generators/executor/schema.json
+++ b/packages/nx-plugin/src/generators/executor/schema.json
@@ -2,8 +2,8 @@
   "$schema": "http://json-schema.org/schema",
   "cli": "nx",
   "$id": "NxPluginExecutor",
-  "title": "Create a Executor for an Nx Plugin",
-  "description": "Create a Executor for an Nx Plugin.",
+  "title": "Create an Executor for an Nx Plugin",
+  "description": "Create an Executor for an Nx Plugin.",
   "type": "object",
   "examples": [
     {


### PR DESCRIPTION
## Current Behavior

`"a executor"` and `"a Executor"` appear in the codebase at various places.

## Expected Behavior

`"an executor"` and `"an Executor"` are used consistently.
