### PR TITLE
fix(angular): component generator public interface

### DIFF
--- a/packages/angular/generators.ts
+++ b/packages/angular/generators.ts
@@ -20,6 +20,7 @@ export * from './src/generators/scam/scam';
 export * from './src/generators/scam-directive/scam-directive';
 export * from './src/generators/scam-pipe/scam-pipe';
 export * from './src/generators/add-linting/add-linting';
+export * from './src/generators/component/component';
 export * from './src/generators/component-cypress-spec/component-cypress-spec';
 export * from './src/generators/component-story/component-story';
 export * from './src/generators/web-worker/web-worker';


### PR DESCRIPTION
 + Include @nrwl/angular:component generator in generators.ts public api exports

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

Trying to utilize the angular component generator in a custom `nx workspace-generator` fails during runtime with the error:

```
Package subpath './src/generators/component/component' is not defined by "exports" in ~/app/node_modules/@nrwl/angular/package.json
```

## Expected Behavior

Angular component generator should be included in generators public api, allowing proper import and successful execution at runtime.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #10873
