### PR TITLE
fix(core): return a list of dependents that do not have sourceRoot to…

### DIFF
--- a/packages/next/src/utils/generate-globs.ts
+++ b/packages/next/src/utils/generate-globs.ts
@@ -16,7 +16,16 @@ export function createGlobPatternsOfDependentProjects(
   );
 
   try {
-    const projectDirs = getSourceDirOfDependentProjects(projectName);
+    const [projectDirs, warnings] =
+      getSourceDirOfDependentProjects(projectName);
+
+    if (warnings.length > 0) {
+      logger.warn(`
+[createGlobPatternsForDependencies] Failed to generate glob pattern for the following:
+${warnings.join('\n- ')}\n
+due to missing "sourceRoot" in the dependencies' project configuration
+      `);
+    }
 
     return projectDirs.map((sourceDir) =>
       resolve(workspaceRoot, joinPathFragments(sourceDir, fileGlobPattern))

--- a/packages/nx/src/utils/project-graph-utils.spec.ts
+++ b/packages/nx/src/utils/project-graph-utils.spec.ts
@@ -48,6 +48,11 @@ describe('project graph utils', () => {
             targets: {},
           },
         },
+        'implicit-lib': {
+          name: 'implicit-lib',
+          type: 'lib',
+          data: {},
+        },
       },
       dependencies: {
         'demo-app': [
@@ -70,7 +75,7 @@ describe('project graph utils', () => {
       },
     };
     it('should correctly gather the source root dirs of the dependent projects', () => {
-      const paths = getSourceDirOfDependentProjects('demo-app', projGraph);
+      const [paths] = getSourceDirOfDependentProjects('demo-app', projGraph);
 
       expect(paths.length).toBe(2);
       expect(paths).toContain(projGraph.nodes['ui'].data.sourceRoot);
@@ -85,7 +90,7 @@ describe('project graph utils', () => {
           target: 'demo-app',
         },
       ];
-      const paths = getSourceDirOfDependentProjects('demo-app', projGraph);
+      const [paths] = getSourceDirOfDependentProjects('demo-app', projGraph);
       expect(paths).toContain(projGraph.nodes['ui'].data.sourceRoot);
     });
 
@@ -93,6 +98,22 @@ describe('project graph utils', () => {
       expect(() =>
         getSourceDirOfDependentProjects('non-existent-app', projGraph)
       ).toThrowError();
+    });
+
+    describe('Given there is implicit library with no sourceRoot', () => {
+      it('should return a warnings array with the library with no sourceRoot', () => {
+        projGraph.dependencies['demo-app'].push({
+          type: 'implicit',
+          source: 'demo-app',
+          target: 'implicit-lib',
+        });
+
+        const [_, warnings] = getSourceDirOfDependentProjects(
+          'demo-app',
+          projGraph
+        );
+        expect(warnings).toContain('implicit-lib');
+      });
     });
 
     it('should find the project given a file within its src root', () => {

--- a/packages/nx/src/utils/project-graph-utils.ts
+++ b/packages/nx/src/utils/project-graph-utils.ts
@@ -51,7 +51,7 @@ export function mergeNpmScriptsWithTargets(
 export function getSourceDirOfDependentProjects(
   projectName: string,
   projectGraph = readCachedProjectGraph()
-): string[] {
+): [projectDirs: string[], warnings: string[]] {
   if (!projectGraph.nodes[projectName]) {
     throw new Error(
       `Couldn't find project "${projectName}" in this Nx workspace`
@@ -59,8 +59,16 @@ export function getSourceDirOfDependentProjects(
   }
 
   const nodeNames = findAllProjectNodeDependencies(projectName, projectGraph);
-  return nodeNames.map(
-    (nodeName) => projectGraph.nodes[nodeName].data.sourceRoot
+  return nodeNames.reduce(
+    (result, nodeName) => {
+      if (projectGraph.nodes[nodeName].data.sourceRoot) {
+        result[0].push(projectGraph.nodes[nodeName].data.sourceRoot);
+      } else {
+        result[1].push(nodeName);
+      }
+      return result;
+    },
+    [[], []] as [projectDirs: string[], warnings: string[]]
   );
 }
 

--- a/packages/workspace/src/utilities/generate-globs.ts
+++ b/packages/workspace/src/utilities/generate-globs.ts
@@ -1,4 +1,4 @@
-import { joinPathFragments } from '@nrwl/devkit';
+import { joinPathFragments, logger } from '@nrwl/devkit';
 import { workspaceRoot } from 'nx/src/utils/workspace-root';
 import { relative, resolve } from 'path';
 import { readCachedProjectGraph } from 'nx/src/project-graph/project-graph';
@@ -34,10 +34,18 @@ export function createGlobPatternsForDependencies(
 
   // generate the glob
   try {
-    const projectDirs = getSourceDirOfDependentProjects(
+    const [projectDirs, warnings] = getSourceDirOfDependentProjects(
       projectName,
       projectGraph
     );
+
+    if (warnings.length > 0) {
+      logger.warn(`
+[createGlobPatternsForDependencies] Failed to generate glob pattern for the following:
+${warnings.join('\n- ')}\n
+due to missing "sourceRoot" in the dependencies' project configuration
+      `);
+    }
 
     return projectDirs.map((sourceDir) =>
       resolve(workspaceRoot, joinPathFragments(sourceDir, fileGlobPattern))


### PR DESCRIPTION
… calculate glob patterns

When a library (often an implicit dependency one) does not have `sourceRoot`,
`getSourceDirOfDependentProjects` returns an array with the problematic library path as `[undefined,
libs/some-other-lib]` which causes `createGlobPatternsForDependencies` to throw an error and
ultimately returns an empty `[]` instead of `[libs/some-other-lib]`.

This PR ensures `getSourceDirOfDependentProjects` filters out `undefined` (`sourceRoot`) as well as logs a warning
to let the users know that they have libraries that are missing `sourceRoot` and Nx cannot calculate
their glob patterns

ISSUES CLOSED: #10871

Fixes #10871
