### PR TITLE
chore(dep-graph): refactor tooltips

### DIFF
--- a/dep-graph/client/src/app/machines/graph.service.ts
+++ b/dep-graph/client/src/app/machines/graph.service.ts
@@ -1,14 +1,11 @@
-import { GraphTooltipService } from '../tooltip-service';
+import { getTooltipService } from '../tooltip-service';
 import { GraphService } from './graph';
 
 let graphService: GraphService;
 
 export function getGraphService(): GraphService {
   if (!graphService) {
-    graphService = new GraphService(
-      new GraphTooltipService(),
-      'cytoscape-graph'
-    );
+    graphService = new GraphService(getTooltipService(), 'cytoscape-graph');
   }
 
   return graphService;

--- a/dep-graph/client/src/app/machines/graph.ts
+++ b/dep-graph/client/src/app/machines/graph.ts
@@ -4,12 +4,9 @@ import type {
   ProjectGraphProjectNode,
 } from '@nrwl/devkit';
 import type { VirtualElement } from '@popperjs/core';
-import { default as cy } from 'cytoscape';
-import { default as cytoscapeDagre } from 'cytoscape-dagre';
-import { default as popper } from 'cytoscape-popper';
-import type { Instance } from 'tippy.js';
-import EdgeNodeTooltip from '../edge-tooltip';
-import ProjectNodeToolTip from '../project-node-tooltip';
+import cy from 'cytoscape';
+import cytoscapeDagre from 'cytoscape-dagre';
+import popper from 'cytoscape-popper';
 import { edgeStyles, nodeStyles } from '../styles-graph';
 import { selectValueByThemeStatic } from '../theme-resolver';
 import { GraphTooltipService } from '../tooltip-service';
@@ -25,7 +22,6 @@ export class GraphService {
   private traversalGraph: cy.Core;
   private renderGraph: cy.Core;
 
-  private openTooltip: Instance = null;
   private collapseEdges = false;
 
   constructor(
@@ -441,10 +437,7 @@ export class GraphService {
     }
 
     this.renderGraph.on('zoom', () => {
-      if (this.openTooltip) {
-        this.openTooltip.hide();
-        this.openTooltip = null;
-      }
+      this.tooltipService.hideAll();
     });
 
     this.listenForProjectNodeClicks();
@@ -597,13 +590,11 @@ export class GraphService {
 
       let ref: VirtualElement = node.popperRef(); // used only for positioning
 
-      const content = ProjectNodeToolTip({
+      this.tooltipService.openProjectNodeToolTip(ref, {
         id: node.id(),
         type: node.data('type'),
         tags: node.data('tags'),
       });
-
-      this.openTooltip = this.tooltipService.open(ref, content);
     });
   }
 
@@ -612,7 +603,7 @@ export class GraphService {
       const edge: cy.EdgeSingular = event.target;
       let ref: VirtualElement = edge.popperRef(); // used only for positioning
 
-      const tooltipContent = EdgeNodeTooltip({
+      this.tooltipService.openEdgeToolTip(ref, {
         type: edge.data('type'),
         source: edge.source().id(),
         target: edge.target().id(),
@@ -627,8 +618,6 @@ export class GraphService {
             };
           }),
       });
-
-      this.openTooltip = this.tooltipService.open(ref, tooltipContent);
     });
   }
 

--- a/dep-graph/client/src/app/project-node-tooltip.tsx
+++ b/dep-graph/client/src/app/project-node-tooltip.tsx
@@ -5,6 +5,7 @@ export interface ProjectNodeToolTipProps {
   id: string;
   tags: string[];
 }
+
 function ProjectNodeToolTip({ type, id, tags }: ProjectNodeToolTipProps) {
   const depGraphService = getDepGraphService();
 

--- a/dep-graph/client/src/app/sidebar/sidebar.tsx
+++ b/dep-graph/client/src/app/sidebar/sidebar.tsx
@@ -3,7 +3,6 @@ import { useCallback } from 'react';
 import ExperimentalFeature from '../experimental-feature';
 import { useDepGraphService } from '../hooks/use-dep-graph';
 import { useDepGraphSelector } from '../hooks/use-dep-graph-selector';
-import { useEnvironmentConfig } from '../hooks/use-environment-config';
 import {
   collapseEdgesSelector,
   focusedProjectNameSelector,

--- a/dep-graph/client/src/app/theme-resolver.tsx
+++ b/dep-graph/client/src/app/theme-resolver.tsx
@@ -1,4 +1,3 @@
-import { getEnvironmentConfig } from './hooks/use-environment-config';
 import { getGraphService } from './machines/graph.service';
 
 const htmlEl = document.documentElement;


### PR DESCRIPTION
## Current Behavior
Tooltips for the graph are triggered by a service that statically renders the tooltip component and pass the generated HTML to Tippy. 
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Tooltips for the graph are triggered by a service that passes data to display in the tooltip. The tooltip is rendered in JSX like a typical React component.

This allows us to use hooks inside the tooltip components for more interactions.

