### PR TITLE
fix(devkit): do not duplicate dependencies

### DIFF
--- a/packages/devkit/src/utils/package-json.spec.ts
+++ b/packages/devkit/src/utils/package-json.spec.ts
@@ -75,4 +75,72 @@ describe('addDependenciesToPackageJson', () => {
     });
     expect(installTask).toBeDefined();
   });
+
+  it('should not add dependencies when they exist in devDependencies or vice versa', () => {
+    // ARRANGE
+    writeJson(tree, 'package.json', {
+      dependencies: {
+        '@nrwl/angular': 'latest',
+      },
+      devDependencies: {
+        '@nrwl/next': 'latest',
+      },
+    });
+
+    // ACT
+    const installTask = addDependenciesToPackageJson(
+      tree,
+      {
+        '@nrwl/next': 'next',
+      },
+      {
+        '@nrwl/angular': 'next',
+      }
+    );
+
+    // ASSERT
+    const { dependencies, devDependencies } = readJson(tree, 'package.json');
+    expect(dependencies).toEqual({
+      '@nrwl/angular': 'latest',
+    });
+    expect(devDependencies).toEqual({
+      '@nrwl/next': 'latest',
+    });
+    expect(installTask).toBeDefined();
+  });
+
+  it('should add additional dependencies when they dont exist in devDependencies or vice versa and not update the ones that do exist', () => {
+    // ARRANGE
+    writeJson(tree, 'package.json', {
+      dependencies: {
+        '@nrwl/angular': 'latest',
+      },
+      devDependencies: {
+        '@nrwl/next': 'latest',
+      },
+    });
+
+    // ACT
+    const installTask = addDependenciesToPackageJson(
+      tree,
+      {
+        '@nrwl/next': 'next',
+        '@nrwl/cypress': 'latest',
+      },
+      {
+        '@nrwl/angular': 'next',
+      }
+    );
+
+    // ASSERT
+    const { dependencies, devDependencies } = readJson(tree, 'package.json');
+    expect(dependencies).toEqual({
+      '@nrwl/angular': 'latest',
+      '@nrwl/cypress': 'latest',
+    });
+    expect(devDependencies).toEqual({
+      '@nrwl/next': 'latest',
+    });
+    expect(installTask).toBeDefined();
+  });
 });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Currently, when we use the `addDependenciesToPackageJson` helper, we do not check if the package is already listed in the opposite dependency object (i.e. listed in devDependencies when we try to add it to dependencies).
<!-- This is the behavior we have today -->

## Expected Behavior
We should not duplicate the package in both dependencies and devDependencies when this happens.

@FrozenPandaz  Point of interest: Right now, the direction I've taken with this PR is that the dependency should simply be ignored if it exists in either of the objects already. I feel like there might be an argument to say that if it's in the `devDependencies` we should _move_ it to `dependencies` object. However, I'd err on the side of "the developer put it in one of those objects for a reason, let's not change that behaviour".

<!-- This is the behavior we should expect with the changes in this PR -->
