### PR TITLE
fix(angular): normalize path in ng-package.json when moving a library project

### DIFF
--- a/packages/angular/src/generators/move/lib/update-ng-package.ts
+++ b/packages/angular/src/generators/move/lib/update-ng-package.ts
@@ -1,4 +1,5 @@
 import {
+  normalizePath,
   readProjectConfiguration,
   Tree,
   updateJson,
@@ -21,7 +22,9 @@ export function updateNgPackage(tree: Tree, schema: Schema): void {
     return;
   }
 
-  const rootOffset = relative(join(workspaceRoot, project.root), workspaceRoot);
+  const rootOffset = normalizePath(
+    relative(join(workspaceRoot, project.root), workspaceRoot)
+  );
   let output = `dist/${project.root}`;
   if (project.targets?.build?.outputs?.length > 0) {
     output = project.targets.build.outputs[0];


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When moving an Angular library, the `dest` property in the `ng-package.json` gets updated with OS-specific path delimiters.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When moving an Angular library, the `dest` property in the `ng-package.json` should be updated with Unix-like path delimiters for cross-OS support.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #10892 
