### PR TITLE
fix(angular): ngrx generator support multiple stores in one buildable library #10900

### DIFF
--- a/packages/angular/src/generators/ngrx/__snapshots__/ngrx.classes.spec.ts.snap
+++ b/packages/angular/src/generators/ngrx/__snapshots__/ngrx.classes.spec.ts.snap
@@ -118,13 +118,13 @@ export interface UsersPartialState {
   readonly [USERS_FEATURE_KEY]: UsersState;
 }
 
-export const initialState: UsersState = {
+export const initialUsersState: UsersState = {
   list: [],
   loaded: false
 };
 
-export function reducer(
-  state: UsersState = initialState, 
+export function usersReducer(
+  state: UsersState = initialUsersState,
   action: UsersAction): UsersState
 {
   switch (action.type) {
@@ -339,8 +339,8 @@ import { SuperUsersFacade } from './super-users.facade';
 import {
   SuperUsersState,
   SuperUsersEntity,
-  initialState,
-  reducer
+  initialSuperUsersState,
+  superUsersReducer
 } from './super-users.reducer';
 import { superUsersQuery } from './super-users.selectors';
 
@@ -360,7 +360,7 @@ describe('SuperUsersFacade', () => {
     beforeEach(() => {
       @NgModule({
         imports: [
-          StoreModule.forFeature('superUsers', reducer, { initialState }),
+          StoreModule.forFeature('superUsers', superUsersReducer, { initialState: initialSuperUsersState }),
           EffectsModule.forFeature([SuperUsersEffects])
         ],
         providers: [SuperUsersFacade]
@@ -429,7 +429,7 @@ describe('SuperUsersFacade', () => {
 
 exports[`NgRx generator classes syntax unit tests should generate specs for the ngrx reducer 1`] = `
 "import { SuperUsersLoaded } from './super-users.actions';
-import { SuperUsersState, SuperUsersEntity, initialState, reducer } from './super-users.reducer';
+import { SuperUsersState, SuperUsersEntity, initialSuperUsersState, superUsersReducer } from './super-users.reducer';
 
 describe('SuperUsers Reducer', () => {
   const getSuperUsersId = (it: SuperUsersEntity) => it.id;
@@ -442,7 +442,7 @@ describe('SuperUsers Reducer', () => {
     it('should return the list of known SuperUsers', () => {
       const superUsers = [createSuperUsers('PRODUCT-AAA'), createSuperUsers('PRODUCT-zzz')];
       const action = new SuperUsersLoaded(superUsers);
-      const result: SuperUsersState = reducer(initialState, action);
+      const result: SuperUsersState = superUsersReducer(initialSuperUsersState, action);
       const selId: string = getSuperUsersId(result.list[1]);
 
       expect(result.loaded).toBe(true);
@@ -454,9 +454,9 @@ describe('SuperUsers Reducer', () => {
   describe('unknown action', () => {
     it('should return the previous state', () => {
       const action = {} as any;
-      const result = reducer(initialState, action);
+      const result = superUsersReducer(initialSuperUsersState, action);
 
-      expect(result).toBe(initialState);
+      expect(result).toBe(initialSuperUsersState);
     });
   });
 });

--- a/packages/angular/src/generators/ngrx/__snapshots__/ngrx.creators.spec.ts.snap
+++ b/packages/angular/src/generators/ngrx/__snapshots__/ngrx.creators.spec.ts.snap
@@ -14,7 +14,7 @@ exports[`NgRx generator creators syntax should generate the ngrx actions 1`] = `
 "import { createAction, props } from '@ngrx/store';
 import { UsersEntity } from './users.models';
 
-export const init = createAction(
+export const initUsers = createAction(
   '[Users Page] Init'
 );
 
@@ -41,7 +41,7 @@ import * as UsersFeature from './users.reducer';
 @Injectable()
 export class UsersEffects {
   init$ = createEffect(() => this.actions$.pipe(
-    ofType(UsersActions.init),
+    ofType(UsersActions.initUsers),
     fetch({
       run: action => {
         // Your custom service 'load' logic goes here. For now just return a success action...
@@ -86,7 +86,7 @@ export class UsersFacade {
    * or more tasks in your Effects.
    */
   init() {
-    this.store.dispatch(UsersActions.init());
+    this.store.dispatch(UsersActions.initUsers());
   }
 }
 "
@@ -101,26 +101,26 @@ import { UsersEntity } from './users.models';
 
 export const USERS_FEATURE_KEY = 'users';
 
-export interface State extends EntityState<UsersEntity> {
+export interface UsersState extends EntityState<UsersEntity> {
   selectedId?: string | number; // which Users record has been selected
   loaded: boolean; // has the Users list been loaded
   error?: string | null; // last known error (if any)
 }
 
 export interface UsersPartialState {
-  readonly [USERS_FEATURE_KEY]: State;
+  readonly [USERS_FEATURE_KEY]: UsersState;
 }
 
 export const usersAdapter: EntityAdapter<UsersEntity> = createEntityAdapter<UsersEntity>();
 
-export const initialState: State = usersAdapter.getInitialState({
+export const initialUsersState: UsersState = usersAdapter.getInitialState({
   // set initial required properties
   loaded: false
 });
 
-const usersReducer = createReducer(
-  initialState,
-  on(UsersActions.init,
+const reducer = createReducer(
+  initialUsersState,
+  on(UsersActions.initUsers,
     state => ({ ...state, loaded: false, error: null })
   ),
   on(UsersActions.loadUsersSuccess,
@@ -131,44 +131,44 @@ const usersReducer = createReducer(
   ),
 );
 
-export function reducer(state: State | undefined, action: Action) {
-  return usersReducer(state, action);
+export function usersReducer(state: UsersState | undefined, action: Action) {
+  return reducer(state, action);
 }
 "
 `;
 
 exports[`NgRx generator creators syntax should generate the ngrx selectors 1`] = `
 "import { createFeatureSelector, createSelector } from '@ngrx/store';
-import { USERS_FEATURE_KEY, State, usersAdapter } from './users.reducer';
+import { USERS_FEATURE_KEY, UsersState, usersAdapter } from './users.reducer';
 
 // Lookup the 'Users' feature state managed by NgRx
-export const getUsersState = createFeatureSelector<State>(USERS_FEATURE_KEY);
+export const getUsersState = createFeatureSelector<UsersState>(USERS_FEATURE_KEY);
 
 const { selectAll, selectEntities } = usersAdapter.getSelectors();
 
 export const getUsersLoaded = createSelector(
   getUsersState,
-  (state: State) => state.loaded
+  (state: UsersState) => state.loaded
 );
 
 export const getUsersError = createSelector(
   getUsersState,
-  (state: State) => state.error
+  (state: UsersState) => state.error
 );
 
 export const getAllUsers = createSelector(
   getUsersState,
-  (state: State) => selectAll(state)
+  (state: UsersState) => selectAll(state)
 );
 
 export const getUsersEntities = createSelector(
   getUsersState,
-  (state: State) => selectEntities(state)
+  (state: UsersState) => selectEntities(state)
 );
 
 export const getSelectedId = createSelector(
   getUsersState,
-  (state: State) => state.selectedId
+  (state: UsersState) => state.selectedId
 );
 
 export const getSelected = createSelector(
@@ -227,12 +227,12 @@ import * as UsersFeature from './users.reducer';
 
 @Injectable()
 export class UsersEffects {
-  init$ = createEffect(() => this.dataPersistence.fetch(UsersActions.init, {
-    run: (action: ReturnType<typeof UsersActions.init>, state: UsersFeature.UsersPartialState) => {
+  init$ = createEffect(() => this.dataPersistence.fetch(UsersActions.Usersinit, {
+    run: (action: ReturnType<typeof UsersActions.initUsers>, state: UsersFeature.UsersPartialState) => {
       // Your custom service 'load' logic goes here. For now just return a success action...
       return UsersActions.loadUsersSuccess({ users: [] });
     },
-    onError: (action: ReturnType<typeof UsersActions.init>, error) => {
+    onError: (action: ReturnType<typeof UsersActions.initUsers>, error) => {
       console.error('Error', error);
       return UsersActions.loadUsersFailure({ error });
     }
@@ -279,7 +279,7 @@ describe('SuperUsersEffects', () => {
 
   describe('init$', () => {
     it('should work', () => {
-      actions = hot('-a-|', { a: SuperUsersActions.init() });
+      actions = hot('-a-|', { a: SuperUsersActions.initSuperUsers() });
 
       const expected = hot('-a-|', { a: SuperUsersActions.loadSuperUsersSuccess({ superUsers: [] }) });
 
@@ -324,7 +324,7 @@ describe('SuperUsersEffects', () => {
 
   describe('init$', () => {
     it('should work', () => {
-      actions = hot('-a-|', { a: SuperUsersActions.init() });
+      actions = hot('-a-|', { a: SuperUsersActions.initSuperUsers() });
 
       const expected = hot('-a-|', { a: SuperUsersActions.loadSuperUsersSuccess({ superUsers: [] }) });
 
@@ -349,14 +349,14 @@ import { SuperUsersFacade } from './super-users.facade';
 import { SuperUsersEntity } from './super-users.models';
 import {
   SUPER_USERS_FEATURE_KEY,
-  State,
-  initialState,
-  reducer
+  SuperUsersState,
+  initialSuperUsersState,
+  superUsersReducer
 } from './super-users.reducer';
 import * as SuperUsersSelectors from './super-users.selectors';
 
 interface TestSchema {
-  superUsers: State;
+  superUsers: SuperUsersState;
 }
 
 describe('SuperUsersFacade', () => {
@@ -371,7 +371,7 @@ describe('SuperUsersFacade', () => {
     beforeEach(() => {
       @NgModule({
         imports: [
-          StoreModule.forFeature(SUPER_USERS_FEATURE_KEY, reducer),
+          StoreModule.forFeature(SUPER_USERS_FEATURE_KEY, superUsersReducer),
           EffectsModule.forFeature([SuperUsersEffects])
         ],
         providers: [SuperUsersFacade]
@@ -445,7 +445,7 @@ exports[`NgRx generator creators syntax unit tests should generate specs for the
 
 import * as SuperUsersActions from './super-users.actions';
 import { SuperUsersEntity } from './super-users.models';
-import { State, initialState, reducer } from './super-users.reducer';
+import { SuperUsersState, initialSuperUsersState, superUsersReducer } from './super-users.reducer';
 
 describe('SuperUsers Reducer', () => {
   const createSuperUsersEntity = (id: string, name = ''): SuperUsersEntity => ({
@@ -461,7 +461,7 @@ describe('SuperUsers Reducer', () => {
       ];
       const action = SuperUsersActions.loadSuperUsersSuccess({ superUsers });
 
-      const result: State = reducer(initialState, action);
+      const result: SuperUsersState = superUsersReducer(initialSuperUsersState, action);
 
       expect(result.loaded).toBe(true);
       expect(result.ids.length).toBe(2);
@@ -472,9 +472,9 @@ describe('SuperUsers Reducer', () => {
     it('should return the previous state', () => {
       const action = {} as Action;
 
-      const result = reducer(initialState, action);
+      const result = superUsersReducer(initialSuperUsersState, action);
 
-      expect(result).toBe(initialState);
+      expect(result).toBe(initialSuperUsersState);
     });
   });
 });
@@ -483,7 +483,7 @@ describe('SuperUsers Reducer', () => {
 
 exports[`NgRx generator creators syntax unit tests should generate specs for the ngrx selectors 1`] = `
 "import { SuperUsersEntity } from './super-users.models';
-import { superUsersAdapter, SuperUsersPartialState, initialState } from './super-users.reducer';
+import { superUsersAdapter, SuperUsersPartialState, initialSuperUsersState } from './super-users.reducer';
 import * as SuperUsersSelectors from './super-users.selectors';
 
 describe('SuperUsers Selectors', () => {
@@ -503,7 +503,7 @@ describe('SuperUsers Selectors', () => {
         createSuperUsersEntity('PRODUCT-BBB'),
         createSuperUsersEntity('PRODUCT-CCC')
       ], {
-        ...initialState,
+        ...initialSuperUsersState,
         selectedId : 'PRODUCT-BBB',
         error: ERROR_MSG,
         loaded: true

--- a/packages/angular/src/generators/ngrx/__snapshots__/ngrx.spec.ts.snap
+++ b/packages/angular/src/generators/ngrx/__snapshots__/ngrx.spec.ts.snap
@@ -21,7 +21,7 @@ import { StoreRouterConnectingModule } from '@ngrx/router-store';
         strictActionImmutability: true,
         strictStateImmutability: true
       }
-    }), EffectsModule.forRoot([UsersEffects]), !environment.production ? StoreDevtoolsModule.instrument() : [], StoreRouterConnectingModule.forRoot(), StoreModule.forFeature(fromUsers.USERS_FEATURE_KEY, fromUsers.reducer)],
+    }), EffectsModule.forRoot([UsersEffects]), !environment.production ? StoreDevtoolsModule.instrument() : [], StoreRouterConnectingModule.forRoot(), StoreModule.forFeature(fromUsers.USERS_FEATURE_KEY, fromUsers.usersReducer)],
        declarations: [AppComponent],
        bootstrap: [AppComponent]
      })

--- a/packages/angular/src/generators/ngrx/files/classes-syntax/__directory__/__fileName__.facade.spec.ts__tmpl__
+++ b/packages/angular/src/generators/ngrx/files/classes-syntax/__directory__/__fileName__.facade.spec.ts__tmpl__
@@ -11,8 +11,8 @@ import { <%= className %>Facade } from './<%= fileName %>.facade';
 import {
   <%= className %>State,
   <%= className %>Entity,
-  initialState,
-  reducer
+  initial<%= className %>State,
+  <%= propertyName %>Reducer
 } from './<%= fileName %>.reducer';
 import { <%= propertyName %>Query } from './<%= fileName %>.selectors';
 
@@ -32,7 +32,7 @@ describe('<%= className %>Facade', () => {
     beforeEach(() => {
       @NgModule({
         imports: [
-          StoreModule.forFeature('<%= propertyName %>', reducer, { initialState }),
+          StoreModule.forFeature('<%= propertyName %>', <%= propertyName %>Reducer, { initialState: initial<%= className %>State }),
           EffectsModule.forFeature([<%= className %>Effects])
         ],
         providers: [<%= className %>Facade]

--- a/packages/angular/src/generators/ngrx/files/classes-syntax/__directory__/__fileName__.reducer.spec.ts__tmpl__
+++ b/packages/angular/src/generators/ngrx/files/classes-syntax/__directory__/__fileName__.reducer.spec.ts__tmpl__
@@ -1,5 +1,5 @@
 import { <%= className %>Loaded } from './<%= fileName %>.actions';
-import { <%= className %>State, <%= className %>Entity, initialState, reducer } from './<%= fileName %>.reducer';
+import { <%= className %>State, <%= className %>Entity, initial<%= className %>State, <%= propertyName %>Reducer } from './<%= fileName %>.reducer';
 
 describe('<%= className %> Reducer', () => {
   const get<%= className %>Id = (it: <%= className %>Entity) => it.id;
@@ -12,7 +12,7 @@ describe('<%= className %> Reducer', () => {
     it('should return the list of known <%= className %>', () => {
       const <%= propertyName %> = [create<%= className %>('PRODUCT-AAA'), create<%= className %>('PRODUCT-zzz')];
       const action = new <%= className %>Loaded(<%= propertyName %>);
-      const result: <%= className %>State = reducer(initialState, action);
+      const result: <%= className %>State = <%= propertyName %>Reducer(initial<%= className %>State, action);
       const selId: string = get<%= className %>Id(result.list[1]);
 
       expect(result.loaded).toBe(true);
@@ -24,9 +24,9 @@ describe('<%= className %> Reducer', () => {
   describe('unknown action', () => {
     it('should return the previous state', () => {
       const action = {} as any;
-      const result = reducer(initialState, action);
+      const result = <%= propertyName %>Reducer(initial<%= className %>State, action);
 
-      expect(result).toBe(initialState);
+      expect(result).toBe(initial<%= className %>State);
     });
   });
 });

--- a/packages/angular/src/generators/ngrx/files/classes-syntax/__directory__/__fileName__.reducer.ts__tmpl__
+++ b/packages/angular/src/generators/ngrx/files/classes-syntax/__directory__/__fileName__.reducer.ts__tmpl__
@@ -24,13 +24,13 @@ export interface <%= className %>PartialState {
   readonly [<%= constantName %>_FEATURE_KEY]: <%= className %>State;
 }
 
-export const initialState: <%= className %>State = {
+export const initial<%= className %>State: <%= className %>State = {
   list: [],
   loaded: false
 };
 
-export function reducer(
-  state: <%= className %>State = initialState, 
+export function <%= propertyName %>Reducer(
+  state: <%= className %>State = initial<%= className %>State,
   action: <%= className %>Action): <%= className %>State
 {
   switch (action.type) {

--- a/packages/angular/src/generators/ngrx/files/creator-syntax/__directory__/__fileName__.actions.ts__tmpl__
+++ b/packages/angular/src/generators/ngrx/files/creator-syntax/__directory__/__fileName__.actions.ts__tmpl__
@@ -1,7 +1,7 @@
 import { createAction, props } from '@ngrx/store';
 import { <%= className %>Entity } from './<%= fileName %>.models';
 
-export const init = createAction(
+export const init<%= className %> = createAction(
   '[<%= className %> Page] Init'
 );
 

--- a/packages/angular/src/generators/ngrx/files/creator-syntax/__directory__/__fileName__.effects.spec.ts__tmpl__
+++ b/packages/angular/src/generators/ngrx/files/creator-syntax/__directory__/__fileName__.effects.spec.ts__tmpl__
@@ -31,7 +31,7 @@ describe('<%= className %>Effects', () => {
 
   describe('init$', () => {
     it('should work', () => {
-      actions = hot('-a-|', { a: <%= className %>Actions.init() });
+      actions = hot('-a-|', { a: <%= className %>Actions.init<%= className %>() });
 
       const expected = hot('-a-|', { a: <%= className %>Actions.load<%= className %>Success({ <%= propertyName %>: [] }) });
 

--- a/packages/angular/src/generators/ngrx/files/creator-syntax/__directory__/__fileName__.effects.ts__tmpl__
+++ b/packages/angular/src/generators/ngrx/files/creator-syntax/__directory__/__fileName__.effects.ts__tmpl__
@@ -7,17 +7,17 @@ import * as <%= className %>Feature from './<%= fileName %>.reducer';
 
 @Injectable()
 export class <%= className %>Effects {
-  <% if (useDataPersistence) { %>init$ = createEffect(() => this.dataPersistence.fetch(<%= className %>Actions.init, {
-    run: (action: ReturnType<typeof <%= className %>Actions.init>, state: <%= className %>Feature.<%= className %>PartialState) => {
+  <% if (useDataPersistence) { %>init$ = createEffect(() => this.dataPersistence.fetch(<%= className %>Actions.<%= className %>init, {
+    run: (action: ReturnType<typeof <%= className %>Actions.init<%= className %>>, state: <%= className %>Feature.<%= className %>PartialState) => {
       // Your custom service 'load' logic goes here. For now just return a success action...
       return <%= className %>Actions.load<%= className %>Success({ <%= propertyName %>: [] });
     },
-    onError: (action: ReturnType<typeof <%= className %>Actions.init>, error) => {
+    onError: (action: ReturnType<typeof <%= className %>Actions.init<%= className %>>, error) => {
       console.error('Error', error);
       return <%= className %>Actions.load<%= className %>Failure({ error });
     }
   }));<% } else { %>init$ = createEffect(() => this.actions$.pipe(
-    ofType(<%= className %>Actions.init),
+    ofType(<%= className %>Actions.init<%= className %>),
     fetch({
       run: action => {
         // Your custom service 'load' logic goes here. For now just return a success action...

--- a/packages/angular/src/generators/ngrx/files/creator-syntax/__directory__/__fileName__.facade.spec.ts__tmpl__
+++ b/packages/angular/src/generators/ngrx/files/creator-syntax/__directory__/__fileName__.facade.spec.ts__tmpl__
@@ -11,14 +11,14 @@ import { <%= className %>Facade } from './<%= fileName %>.facade';
 import { <%= className %>Entity } from './<%= fileName %>.models';
 import {
   <%= constantName %>_FEATURE_KEY,
-  State,
-  initialState,
-  reducer
+  <%= className %>State,
+  initial<%= className %>State,
+  <%= propertyName %>Reducer
 } from './<%= fileName %>.reducer';
 import * as <%= className %>Selectors from './<%= fileName %>.selectors';
 
 interface TestSchema {
-  <%= propertyName %>: State;
+  <%= propertyName %>: <%= className %>State;
 }
 
 describe('<%= className %>Facade', () => {
@@ -33,7 +33,7 @@ describe('<%= className %>Facade', () => {
     beforeEach(() => {
       @NgModule({
         imports: [
-          StoreModule.forFeature(<%= constantName %>_FEATURE_KEY, reducer),
+          StoreModule.forFeature(<%= constantName %>_FEATURE_KEY, <%= propertyName %>Reducer),
           EffectsModule.forFeature([<%= className %>Effects])
         ],
         providers: [<%= className %>Facade]

--- a/packages/angular/src/generators/ngrx/files/creator-syntax/__directory__/__fileName__.facade.ts__tmpl__
+++ b/packages/angular/src/generators/ngrx/files/creator-syntax/__directory__/__fileName__.facade.ts__tmpl__
@@ -22,6 +22,6 @@ export class <%= className %>Facade {
    * or more tasks in your Effects.
    */
   init() {
-    this.store.dispatch(<%= className %>Actions.init());
+    this.store.dispatch(<%= className %>Actions.init<%= className %>());
   }
 }

--- a/packages/angular/src/generators/ngrx/files/creator-syntax/__directory__/__fileName__.reducer.spec.ts__tmpl__
+++ b/packages/angular/src/generators/ngrx/files/creator-syntax/__directory__/__fileName__.reducer.spec.ts__tmpl__
@@ -2,7 +2,7 @@ import { Action } from '@ngrx/store';
 
 import * as <%= className %>Actions from './<%= fileName %>.actions';
 import { <%= className %>Entity } from './<%= fileName %>.models';
-import { State, initialState, reducer } from './<%= fileName %>.reducer';
+import { <%= className %>State, initial<%= className %>State, <%= propertyName %>Reducer } from './<%= fileName %>.reducer';
 
 describe('<%= className %> Reducer', () => {
   const create<%= className %>Entity = (id: string, name = ''): <%= className %>Entity => ({
@@ -18,7 +18,7 @@ describe('<%= className %> Reducer', () => {
       ];
       const action = <%= className %>Actions.load<%= className %>Success({ <%= propertyName %> });
 
-      const result: State = reducer(initialState, action);
+      const result: <%= className %>State = <%= propertyName %>Reducer(initial<%= className %>State, action);
 
       expect(result.loaded).toBe(true);
       expect(result.ids.length).toBe(2);
@@ -29,9 +29,9 @@ describe('<%= className %> Reducer', () => {
     it('should return the previous state', () => {
       const action = {} as Action;
 
-      const result = reducer(initialState, action);
+      const result = <%= propertyName %>Reducer(initial<%= className %>State, action);
 
-      expect(result).toBe(initialState);
+      expect(result).toBe(initial<%= className %>State);
     });
   });
 });

--- a/packages/angular/src/generators/ngrx/files/creator-syntax/__directory__/__fileName__.reducer.ts__tmpl__
+++ b/packages/angular/src/generators/ngrx/files/creator-syntax/__directory__/__fileName__.reducer.ts__tmpl__
@@ -6,26 +6,26 @@ import { <%= className %>Entity } from './<%= fileName %>.models';
 
 export const <%= constantName %>_FEATURE_KEY = '<%= propertyName %>';
 
-export interface State extends EntityState<<%= className %>Entity> {
+export interface <%= className %>State extends EntityState<<%= className %>Entity> {
   selectedId?: string | number; // which <%= className %> record has been selected
   loaded: boolean; // has the <%= className %> list been loaded
   error?: string | null; // last known error (if any)
 }
 
 export interface <%= className %>PartialState {
-  readonly [<%= constantName %>_FEATURE_KEY]: State;
+  readonly [<%= constantName %>_FEATURE_KEY]: <%= className %>State;
 }
 
 export const <%= propertyName %>Adapter: EntityAdapter<<%= className %>Entity> = createEntityAdapter<<%= className %>Entity>();
 
-export const initialState: State = <%= propertyName %>Adapter.getInitialState({
+export const initial<%= className %>State: <%= className %>State = <%= propertyName %>Adapter.getInitialState({
   // set initial required properties
   loaded: false
 });
 
-const <%= propertyName %>Reducer = createReducer(
-  initialState,
-  on(<%= className %>Actions.init,
+const reducer = createReducer(
+  initial<%= className %>State,
+  on(<%= className %>Actions.init<%= className %>,
     state => ({ ...state, loaded: false, error: null })
   ),
   on(<%= className %>Actions.load<%= className %>Success,
@@ -36,6 +36,6 @@ const <%= propertyName %>Reducer = createReducer(
   ),
 );
 
-export function reducer(state: State | undefined, action: Action) {
-  return <%= propertyName %>Reducer(state, action);
+export function <%= propertyName %>Reducer(state: <%= className %>State | undefined, action: Action) {
+  return reducer(state, action);
 }

--- a/packages/angular/src/generators/ngrx/files/creator-syntax/__directory__/__fileName__.selectors.spec.ts__tmpl__
+++ b/packages/angular/src/generators/ngrx/files/creator-syntax/__directory__/__fileName__.selectors.spec.ts__tmpl__
@@ -1,5 +1,5 @@
 import { <%= className %>Entity } from './<%= fileName %>.models';
-import { <%= propertyName %>Adapter, <%= className %>PartialState, initialState } from './<%= fileName %>.reducer';
+import { <%= propertyName %>Adapter, <%= className %>PartialState, initial<%= className %>State } from './<%= fileName %>.reducer';
 import * as <%= className %>Selectors from './<%= fileName %>.selectors';
 
 describe('<%= className %> Selectors', () => {
@@ -19,7 +19,7 @@ describe('<%= className %> Selectors', () => {
         create<%= className %>Entity('PRODUCT-BBB'),
         create<%= className %>Entity('PRODUCT-CCC')
       ], {
-        ...initialState,
+        ...initial<%= className %>State,
         selectedId : 'PRODUCT-BBB',
         error: ERROR_MSG,
         loaded: true

--- a/packages/angular/src/generators/ngrx/files/creator-syntax/__directory__/__fileName__.selectors.ts__tmpl__
+++ b/packages/angular/src/generators/ngrx/files/creator-syntax/__directory__/__fileName__.selectors.ts__tmpl__
@@ -1,34 +1,34 @@
 import { createFeatureSelector, createSelector } from '@ngrx/store';
-import { <%= constantName %>_FEATURE_KEY, State, <%= propertyName %>Adapter } from './<%= fileName %>.reducer';
+import { <%= constantName %>_FEATURE_KEY, <%= className %>State, <%= propertyName %>Adapter } from './<%= fileName %>.reducer';
 
 // Lookup the '<%= className %>' feature state managed by NgRx
-export const get<%= className %>State = createFeatureSelector<State>(<%= constantName %>_FEATURE_KEY);
+export const get<%= className %>State = createFeatureSelector<<%= className %>State>(<%= constantName %>_FEATURE_KEY);
 
 const { selectAll, selectEntities } = <%= propertyName %>Adapter.getSelectors();
 
 export const get<%= className %>Loaded = createSelector(
   get<%= className %>State,
-  (state: State) => state.loaded
+  (state: <%= className %>State) => state.loaded
 );
 
 export const get<%= className %>Error = createSelector(
   get<%= className %>State,
-  (state: State) => state.error
+  (state: <%= className %>State) => state.error
 );
 
 export const getAll<%= className %> = createSelector(
   get<%= className %>State,
-  (state: State) => selectAll(state)
+  (state: <%= className %>State) => selectAll(state)
 );
 
 export const get<%= className %>Entities = createSelector(
   get<%= className %>State,
-  (state: State) => selectEntities(state)
+  (state: <%= className %>State) => selectEntities(state)
 );
 
 export const getSelectedId = createSelector(
   get<%= className %>State,
-  (state: State) => state.selectedId
+  (state: <%= className %>State) => state.selectedId
 );
 
 export const getSelected = createSelector(

--- a/packages/angular/src/generators/ngrx/lib/add-imports-to-module.ts
+++ b/packages/angular/src/generators/ngrx/lib/add-imports-to-module.ts
@@ -47,6 +47,7 @@ export function addImportsToModule(
   const effectsName = `${names(options.name).className}Effects`;
   const facadeName = `${names(options.name).className}Facade`;
   const className = `${names(options.name).className}`;
+  const propertyName = `${names(options.name).propertyName}`;
   const reducerImports = `* as from${className}`;
 
   const storeMetaReducers = `metaReducers: !environment.production ? [] : []`;
@@ -61,7 +62,7 @@ export function addImportsToModule(
   const nxModule = 'NxModule.forRoot()';
   const effectsForRoot = `EffectsModule.forRoot([${effectsName}])`;
   const effectsForEmptyRoot = `EffectsModule.forRoot([])`;
-  const storeForFeature = `StoreModule.forFeature(from${className}.${constantName}_FEATURE_KEY, from${className}.reducer)`;
+  const storeForFeature = `StoreModule.forFeature(from${className}.${constantName}_FEATURE_KEY, from${className}.${propertyName}Reducer)`;
   const effectsForFeature = `EffectsModule.forFeature([${effectsName}])`;
   const devTools = `!environment.production ? StoreDevtoolsModule.instrument() : []`;
   const storeRouterModule = 'StoreRouterConnectingModule.forRoot()';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When using buildable libraries, using the NgRx generator currently to add multiple stores to the same library results in conflicting export names.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Names for exported states, reducers, types etc should not by default be conflicting. We should append, prepend and insert the name of the store where possible on exported members to reduce the likelihood of naming conflicts.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #10900
