### PR TITLE
(Proof of Concept/RFC) Task Worker Pools

### DIFF
--- a/packages/nx/bin/run-executor-worker.ts
+++ b/packages/nx/bin/run-executor-worker.ts
@@ -1,0 +1,146 @@
+import { run } from '../src/command-line/run';
+import { Task } from '../src/config/task-graph';
+import { appendFileSync, openSync, writeFileSync, closeSync } from 'fs';
+import { addCommandPrefixIfNeeded } from '../src/utils/add-command-prefix';
+
+setUpOutputWatching();
+
+if (!process.env.NX_WORKSPACE_ROOT) {
+  console.error('Invalid Nx command invocation');
+  process.exit(1);
+}
+
+process.env.NX_CLI_SET = 'true';
+
+interface ExecuteTaskOptions {
+  outputPath?: string;
+  streamOutput?: boolean;
+  captureStderr?: boolean;
+  onStdout?: (chunk: string) => void;
+  onStderr?: (chunk: string) => void;
+}
+
+let state:
+  | {
+      currentTask: Task;
+      onlyStdout: string[];
+      currentOptions: ExecuteTaskOptions;
+      outputPath: string;
+      streamOutput: boolean;
+      captureStderr: boolean;
+      logFileHandle?: number;
+    }
+  | undefined;
+
+export async function executeTask(
+  task: Task,
+  options: ExecuteTaskOptions = {}
+): Promise<{ statusCode: number; error?: string }> {
+  state = {
+    currentTask: task,
+    onlyStdout: [],
+    currentOptions: options,
+    outputPath: options.outputPath,
+    streamOutput: options.streamOutput ?? false,
+    captureStderr: options.captureStderr ?? false,
+  };
+
+  try {
+    const statusCode = await run(
+      process.cwd(),
+      process.env.NX_WORKSPACE_ROOT,
+      task.target,
+      task.overrides,
+      task.overrides['verbose'] === true,
+      false
+    );
+
+    // when the process exits successfully, and we are not asked to capture stderr
+    // override the file with only stdout
+    if (statusCode === 0 && !state.captureStderr && state.outputPath) {
+      writeFileSync(state.outputPath, state.onlyStdout.join(''));
+    }
+
+    return { statusCode };
+  } catch (e) {
+    console.error(e.toString());
+    return { statusCode: 1, error: e.toString() };
+  } finally {
+    if (state.logFileHandle) {
+      closeSync(state.logFileHandle);
+    }
+    state = undefined;
+  }
+}
+
+/**
+ * We need to collect all stdout and stderr and store it, so the caching mechanism
+ * could store it.
+ *
+ * Writing stdout and stderr into different streams is too risky when using TTY.
+ *
+ * So we are simply monkey-patching the Javascript object. In this case the actual output will always be correct.
+ * And the cached output should be correct unless the CLI bypasses process.stdout or console.log and uses some
+ * C-binary to write to stdout.
+ */
+function setUpOutputWatching() {
+  const stdoutWrite = process.stdout._write;
+  const stderrWrite = process.stderr._write;
+
+  process.stdout._write = (
+    chunk: any,
+    encoding: string,
+    callback: Function
+  ) => {
+    state?.onlyStdout.push(chunk);
+    if (state?.outputPath) {
+      if (!state.logFileHandle) {
+        state.logFileHandle = openSync(state.outputPath, 'w');
+      }
+      appendFileSync(state.logFileHandle, chunk);
+    }
+    if (state?.streamOutput) {
+      const updatedChunk = addCommandPrefixIfNeeded(
+        state.currentTask.target.project,
+        chunk,
+        encoding
+      );
+      state.currentOptions?.onStdout?.(chunk);
+      stdoutWrite.apply(process.stdout, [
+        updatedChunk.content,
+        updatedChunk.encoding,
+        callback,
+      ]);
+    } else {
+      callback();
+    }
+  };
+
+  process.stderr._write = (
+    chunk: any,
+    encoding: string,
+    callback: Function
+  ) => {
+    if (state?.outputPath) {
+      if (!state.logFileHandle) {
+        state.logFileHandle = openSync(state.outputPath, 'w');
+      }
+      appendFileSync(state.logFileHandle, chunk);
+    }
+    if (state?.streamOutput) {
+      const updatedChunk = addCommandPrefixIfNeeded(
+        state.currentTask.target.project,
+        chunk,
+        encoding
+      );
+      state.currentOptions?.onStderr?.(chunk);
+      stderrWrite.apply(process.stderr, [
+        updatedChunk.content,
+        updatedChunk.encoding,
+        callback,
+      ]);
+    } else {
+      callback();
+    }
+  };
+}

--- a/packages/nx/bin/run-executor-worker.ts
+++ b/packages/nx/bin/run-executor-worker.ts
@@ -2,6 +2,7 @@ import { run } from '../src/command-line/run';
 import { Task } from '../src/config/task-graph';
 import { appendFileSync, openSync, writeFileSync, closeSync } from 'fs';
 import { addCommandPrefixIfNeeded } from '../src/utils/add-command-prefix';
+import { ProjectGraph } from '../src/config/project-graph';
 
 setUpOutputWatching();
 
@@ -12,6 +13,7 @@ interface ExecuteTaskOptions {
   outputPath?: string;
   streamOutput?: boolean;
   captureStderr?: boolean;
+  projectGraph?: ProjectGraph;
   onStdout?: (chunk: string) => void;
   onStderr?: (chunk: string) => void;
 }
@@ -48,7 +50,8 @@ export async function executeTask(
       task.target,
       task.overrides,
       task.overrides['verbose'] === true,
-      false
+      false,
+      options.projectGraph
     );
 
     // when the process exits successfully, and we are not asked to capture stderr

--- a/packages/nx/bin/run-executor-worker.ts
+++ b/packages/nx/bin/run-executor-worker.ts
@@ -5,14 +5,10 @@ import { addCommandPrefixIfNeeded } from '../src/utils/add-command-prefix';
 
 setUpOutputWatching();
 
-if (!process.env.NX_WORKSPACE_ROOT) {
-  console.error('Invalid Nx command invocation');
-  process.exit(1);
-}
-
 process.env.NX_CLI_SET = 'true';
 
 interface ExecuteTaskOptions {
+  workspaceRoot: string;
   outputPath?: string;
   streamOutput?: boolean;
   captureStderr?: boolean;
@@ -34,7 +30,7 @@ let state:
 
 export async function executeTask(
   task: Task,
-  options: ExecuteTaskOptions = {}
+  options: ExecuteTaskOptions
 ): Promise<{ statusCode: number; error?: string }> {
   state = {
     currentTask: task,
@@ -48,7 +44,7 @@ export async function executeTask(
   try {
     const statusCode = await run(
       process.cwd(),
-      process.env.NX_WORKSPACE_ROOT,
+      options.workspaceRoot,
       task.target,
       task.overrides,
       task.overrides['verbose'] === true,

--- a/packages/nx/bin/run-executor-worker.ts
+++ b/packages/nx/bin/run-executor-worker.ts
@@ -41,6 +41,7 @@ export async function executeTask(
     outputPath: options.outputPath,
     streamOutput: options.streamOutput ?? false,
     captureStderr: options.captureStderr ?? false,
+    logFileHandle: openSync(options.outputPath, 'w'),
   };
 
   try {

--- a/packages/nx/bin/run-executor-worker.ts
+++ b/packages/nx/bin/run-executor-worker.ts
@@ -3,6 +3,7 @@ import { Task } from '../src/config/task-graph';
 import { appendFileSync, openSync, writeFileSync, closeSync } from 'fs';
 import { addCommandPrefixIfNeeded } from '../src/utils/add-command-prefix';
 import { ProjectGraph } from '../src/config/project-graph';
+import { messageParent } from 'jest-worker';
 
 setUpOutputWatching();
 
@@ -14,8 +15,6 @@ interface ExecuteTaskOptions {
   streamOutput?: boolean;
   captureStderr?: boolean;
   projectGraph?: ProjectGraph;
-  onStdout?: (chunk: string) => void;
-  onStderr?: (chunk: string) => void;
 }
 
 let state:
@@ -105,7 +104,7 @@ function setUpOutputWatching() {
         chunk,
         encoding
       );
-      state.currentOptions?.onStdout?.(chunk);
+      messageParent(['stdout', chunk]);
       stdoutWrite.apply(process.stdout, [
         updatedChunk.content,
         updatedChunk.encoding,
@@ -133,7 +132,7 @@ function setUpOutputWatching() {
         chunk,
         encoding
       );
-      state.currentOptions?.onStderr?.(chunk);
+      messageParent(['stderr', chunk]);
       stderrWrite.apply(process.stderr, [
         updatedChunk.content,
         updatedChunk.encoding,

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -46,6 +46,7 @@
     "glob": "7.1.4",
     "ignore": "^5.0.4",
     "jsonc-parser": "3.0.0",
+    "jest-worker": "^28.1.1",
     "minimatch": "3.0.5",
     "npm-run-path": "^4.0.1",
     "open": "^8.4.0",

--- a/packages/nx/src/project-graph/build-project-graph.ts
+++ b/packages/nx/src/project-graph/build-project-graph.ts
@@ -10,7 +10,7 @@ import {
   ProjectGraphCache,
   readCache,
   shouldRecomputeWholeGraph,
-  writeCache,
+  writeCacheIfNecessary,
 } from './nx-deps-cache';
 import { buildImplicitProjectDependencies } from './build-dependencies';
 import {
@@ -119,7 +119,7 @@ export async function buildProjectGraphUsingProjectFileMap(
     rootTsConfig
   );
   if (shouldWriteCache) {
-    writeCache(projectGraphCache);
+    writeCacheIfNecessary(projectGraphCache, cache);
   }
   projectGraph.allWorkspaceFiles = allWorkspaceFiles;
   return {

--- a/packages/nx/src/project-graph/nx-deps-cache.ts
+++ b/packages/nx/src/project-graph/nx-deps-cache.ts
@@ -102,9 +102,9 @@ export function createCache(
 
 export function writeCacheIfNecessary(
   cache: ProjectGraphCache,
-  existingCache: ProjectGraphCache
+  existingCache: ProjectGraphCache | null
 ): void {
-  if (deepEquals(cache, existingCache)) {
+  if (existingCache && deepEquals(cache, existingCache)) {
     return;
   }
   performance.mark('write cache:start');

--- a/packages/nx/src/project-graph/nx-deps-cache.ts
+++ b/packages/nx/src/project-graph/nx-deps-cache.ts
@@ -15,6 +15,7 @@ import {
 import { readJsonFile, writeJsonFile } from '../utils/fileutils';
 import { NxJsonConfiguration } from '../config/nx-json';
 import { ProjectsConfigurations } from '../config/workspace-json-project-json';
+import { deepEquals } from '../utils/json-diff';
 
 export interface ProjectGraphCache {
   version: string;
@@ -99,7 +100,13 @@ export function createCache(
   return newValue;
 }
 
-export function writeCache(cache: ProjectGraphCache): void {
+export function writeCacheIfNecessary(
+  cache: ProjectGraphCache,
+  existingCache: ProjectGraphCache
+): void {
+  if (deepEquals(cache, existingCache)) {
+    return;
+  }
   performance.mark('write cache:start');
   writeJsonFile(nxDepsPath, cache);
   performance.mark('write cache:end');

--- a/packages/nx/src/tasks-runner/jest-worker-task-runner.ts
+++ b/packages/nx/src/tasks-runner/jest-worker-task-runner.ts
@@ -13,7 +13,6 @@ import type * as ExecutorWorker from '../../bin/run-executor-worker';
 import { addCommandPrefixIfNeeded } from '../utils/add-command-prefix';
 import { ProjectGraph } from '../config/project-graph';
 
-// Worker threads slower for me??? 38s fork, 45s worker thread
 const useWorkerThreads =
   process.env.NX_JEST_WORKER_TASK_RUNNER_USE_THREADS === 'true';
 
@@ -37,7 +36,6 @@ export class JestWorkerTaskRunner {
             ...process.env,
             ...this.getNxEnvVariablesForForkedProcess(),
           },
-          execArgv: ['--inspect-brk'],
         },
       })) as Worker & typeof ExecutorWorker;
 

--- a/packages/nx/src/tasks-runner/jest-worker-task-runner.ts
+++ b/packages/nx/src/tasks-runner/jest-worker-task-runner.ts
@@ -11,6 +11,7 @@ import { Worker } from 'jest-worker';
 import { BatchResults } from './batch/batch-messages';
 import type * as ExecutorWorker from '../../bin/run-executor-worker';
 import { addCommandPrefixIfNeeded } from '../utils/add-command-prefix';
+import { ProjectGraph } from '../config/project-graph';
 
 // Worker threads slower for me??? 38s fork, 45s worker thread
 const useWorkerThreads =
@@ -36,11 +37,14 @@ export class JestWorkerTaskRunner {
             ...process.env,
             ...this.getNxEnvVariablesForForkedProcess(),
           },
-          // execArgv: ['--inspect-brk'],
+          execArgv: ['--inspect-brk'],
         },
       })) as Worker & typeof ExecutorWorker;
 
-  constructor(private readonly options: DefaultTasksRunnerOptions) {
+  constructor(
+    private readonly options: DefaultTasksRunnerOptions,
+    private readonly projectGraph: ProjectGraph
+  ) {
     this.setupOnProcessExitListener();
   }
 
@@ -75,6 +79,7 @@ export class JestWorkerTaskRunner {
         outputPath: temporaryOutputPath,
         streamOutput,
         captureStderr: this.options.captureStderr,
+        projectGraph: this.projectGraph,
 
         // Worker threads have trouble serializing these functions but forks don't?
         onStdout: useWorkerThreads

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -247,7 +247,7 @@ function shouldUseDynamicLifeCycle(
   if (isCI()) return false;
   if (outputStyle === 'static' || outputStyle === 'stream') return false;
 
-  const noForwarding = !tasks.find((t) => shouldStreamOutput(t, null, options));
+  const noForwarding = !tasks.find((t) => shouldStreamOutput(t, null));
   return noForwarding;
 }
 

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -27,7 +27,7 @@ export class TaskOrchestrator {
 
   private taskRunner: ForkedProcessTaskRunner | JestWorkerTaskRunner = process
     .env.NX_JEST_WORKER_TASK_RUNNER
-    ? new JestWorkerTaskRunner(this.options)
+    ? new JestWorkerTaskRunner(this.options, this.projectGraph)
     : new ForkedProcessTaskRunner(this.options);
 
   private readonly nxJson = this.workspace.readNxJson();

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -269,11 +269,7 @@ export function getSerializedArgsForTask(task: Task, isVerbose: boolean) {
 
 export function shouldStreamOutput(
   task: Task,
-  initiatingProject: string | null,
-  options: {
-    cacheableOperations?: string[] | null;
-    cacheableTargets?: string[] | null;
-  }
+  initiatingProject: string | null
 ): boolean {
   if (process.env.NX_STREAM_OUTPUT === 'true') return true;
   if (longRunningTask(task)) return true;

--- a/packages/nx/src/utils/json-diff.ts
+++ b/packages/nx/src/utils/json-diff.ts
@@ -103,7 +103,7 @@ function getJsonValue(path: string[], json: any): void | any {
   return curr;
 }
 
-function deepEquals(a: any, b: any): boolean {
+export function deepEquals(a: any, b: any): boolean {
   if (a === b) {
     return true;
   }


### PR DESCRIPTION
### Background

So, we have a large monorepo that I'm trying to get nx working on. The performance of doing a full cold-build was disappointing to me (since I configured each package to use swc), so I investigated a bit. 

Nearly 1/3 of the time per task was spent starting up. It seems that once you get to ~4,300 `node_modules` packages (recursively, `yarn info --all --recursive --name-only`), time spent `require`ing can really add up when each task spins up a brand-new node process. `v8-compiler-cache` helps a bit, but just doing all of the file system `stats` seemed to be a big culprit.

I have some experience writing a custom runner for Jest, so I pulled in `jest-worker` to use a worker pool instead of spinning up a new node process for each task. There's nothing particularly "jest-y" about `jest-worker`, it's mostly just a solid worker pool implementation that can also use node worker threads.

### Results

(edited now that I fixed swc speeds)

These times are with caching on `build` _disabled_ - caching adds (relatively here) significant overhead to each task since it has to `cp` all of the outputs of the task

| Task Runner Implementation                     	| `nx run-many --all --target=build --parallel 8` (130 projects) 	|
|------------------------------------------------	|------------------------------------	|
| `forked-process-task-runner`                   	| 25s                                	|
| `jest-worker-task-runner`                      	| 4.7s                               	|
| `jest-worker-task-runner` using worker threads 	| 3.9s                               	|

Significant increase in the cold build performance! It seems that all the `require` overhead is gone! And worker threads improve the speed a little bit more too!

### Batching

I see that there's undocumented code for batching tasks, which seems to be similar in idea to what I've done here. I think this and batching could still work well together though! Batching will only run one "layer" of tasks at a time, and then compute what can be batched together next - which would still spin up a brand new process and slow things down.

### Caveats

Of course there are a bunch of caveats and this approach probably isn't applicable to some of the task executors:

* Worker memory usage can increase until the workers crash - this has happened plenty in our Jest tests because of memory leaks.
* There's no global require cache cleanup between tests (which is kind of the point), which means that global module-local variables _persist between tasks_. I would hope that most tasks don't rely on global state, but it's definitely something to keep in mind. Could always use require-cache-busting like Jest itself does.
* All tasks are piped instead of direct io because of how the workers work - could possibly make pipe the default and for tasks that need direct (interactive apps?) they would use the fork implementation instead
* Maybe nx would want to roll its own worker pool instead of jest-worker, not sure the precedent there 🤷 

### Thoughts please!

Let me know what you think! I think that 25s -> 4s is a massive speed improvement, and for us it has very little downside (so far). Can just set `NX_JEST_WORKER_TASK_RUNNER` if you'd like to try this.

Obviously the code I have here is totally unfinished 😉 

The nx code was pretty easy to work with and understand! Thanks for keeping it well organized!