### PR TITLE
feat(react): improve babel preset options

### DIFF
--- a/packages/react/babel.ts
+++ b/packages/react/babel.ts
@@ -1,14 +1,15 @@
+import type { NxWebBabelPresetOptions } from '@nrwl/web';
+
 /*
  * Babel preset to provide React support for Nx.
  */
 
-interface ReactBabelOptions {
+interface NxReactBabelOptions extends NxWebBabelPresetOptions {
   runtime?: string;
   importSource?: string;
-  useBuiltIns?: boolean | string;
 }
 
-module.exports = function (api: any, options: ReactBabelOptions) {
+module.exports = function (api: any, options: NxReactBabelOptions) {
   api.assertVersion(7);
   const env = api.env();
   /**
@@ -16,9 +17,7 @@ module.exports = function (api: any, options: ReactBabelOptions) {
    */
   const isNextJs = api.caller((caller) => caller?.pagesDir);
 
-  const presets: any[] = [
-    ['@nrwl/web/babel', { useBuiltIns: options.useBuiltIns }],
-  ];
+  const presets: any[] = [['@nrwl/web/babel', options]];
 
   /**
    * Next.js already includes the preset-react, and including it

--- a/packages/web/babel.ts
+++ b/packages/web/babel.ts
@@ -4,7 +4,7 @@ import { dirname } from 'path';
  * Babel preset to provide TypeScript support and module/nomodule for Nx.
  */
 
-interface NxReactBabelPresetOptions {
+export interface NxWebBabelPresetOptions {
   useBuiltIns?: boolean | string;
   decorators?: {
     decoratorsBeforeExport?: boolean;
@@ -15,7 +15,7 @@ interface NxReactBabelPresetOptions {
   };
 }
 
-module.exports = function (api: any, options: NxReactBabelPresetOptions = {}) {
+module.exports = function (api: any, options: NxWebBabelPresetOptions = {}) {
   api.assertVersion(7);
 
   const isModern = api.caller((caller) => caller?.isModern);

--- a/packages/web/index.ts
+++ b/packages/web/index.ts
@@ -1,2 +1,3 @@
 export { webInitGenerator } from './src/generators/init/init';
 export { applicationGenerator } from './src/generators/application/application';
+export type { NxWebBabelPresetOptions } from './babel';


### PR DESCRIPTION
Improved the `@nrwl/react/babel` preset to allow for customisation of all options provided by
the `@nrwl/web/babel` preset.

## Current Behavior

Only the `useBuiltIns` option of the `@nrwl/web/babel` preset can be configured when using the `@nrwl/react/babel` preset:

```json
{
    "presets": [
        [
            "@nrwl/react/babel",
            {
                "runtime": "automatic",
                "importSource": "react",
                "useBuiltIns": "usage"
            }
        ]
    ],
    "plugins": []
}
```

## Expected Behavior

All options provided by the `@nrwl/web/babel` preset should be configurable when using the `@nrwl/react/babel` preset:

```json
{
    "presets": [
        [
            "@nrwl/react/babel",
            {
                "runtime": "automatic",
                "importSource": "react",
                "useBuiltIns": "usage",
                "decorators": {
                    "decoratorsBeforeExport": true,
                    "legacy": false
                },
                "classProperties": {
                    "loose": false
                }
            }
        ]
    ],
    "plugins": []
}
```

## Related Issue(s)

Fixes #10939
