### PR TITLE
fix(react): fix missing integrity tags in production builds

### DIFF
--- a/packages/web/src/executors/webpack/webpack.impl.ts
+++ b/packages/web/src/executors/webpack/webpack.impl.ts
@@ -238,6 +238,7 @@ export async function* run(
         if (options.generateIndexHtml) {
           await writeIndexHtml({
             crossOrigin: options.crossOrigin,
+            sri: options.subresourceIntegrity,
             outputPath: join(options.outputPath, basename(options.index)),
             indexPath: join(context.root, options.index),
             files: emittedFiles1.filter((x) => x.extension === '.css'),


### PR DESCRIPTION
Subresource Integrity attributes were not generated on production react builds due to a missing option pass through when writing the index file.

## Current Behavior
When building a react production app and generating `index.html`, subresource
integrity tags were not written in to the file, even when enabled in `project.json`.

## Expected Behavior
When enabled, css/jss tags contain the `integrity` attribute

## Related Issue(s)
Fixes #10926
