### PR TITLE
fix(core): make nx init search against a regex instead of indexOf

### DIFF
--- a/packages/nx/src/command-line/init.ts
+++ b/packages/nx/src/command-line/init.ts
@@ -1,14 +1,14 @@
 import { execSync } from 'child_process';
 import { join } from 'path';
+import { fileExists, readJsonFile, writeJsonFile } from '../utils/fileutils';
 import { output } from '../utils/output';
 import { getPackageManagerCommand } from '../utils/package-manager';
-import { readJsonFile, writeJsonFile, fileExists } from '../utils/fileutils';
 
 export function initHandler() {
   const nxIsInstalled = !!execSync(getPackageManagerCommand().list)
     .toString()
     .split('\n')
-    .find((line) => line.indexOf(' nx@') > -1);
+    .find((line) => line.search(/\s?nx(\s|@)\d+.\d+.\d+(-\w+.\d+)?/) > -1);
 
   if (nxIsInstalled) {
     output.log({


### PR DESCRIPTION
## Current Behavior
Running `nx init` in a pnpm workspace fails due to `nxIsInstalled` check doesn't work with `pnpm ls` format

## Expected Behavior
Running `nx init` should work for npm/pnpm/yarn workspace. The following formats are supported:
```
nx 14.0.0
nx@14.0.0
nx 14.0.0-beta.1
nx@14.0.0-beta.1

# with leading white space
 nx 14.0.0
 nx@14.0.0
 nx 14.0.0-beta.1
 nx@14.0.0-beta.1
```