### PR TITLE
fix(react): fix indentation for ejs template for cypress in react package

### DIFF
--- a/packages/react/src/generators/component-cypress-spec/files/__componentName__.spec.__fileExt__
+++ b/packages/react/src/generators/component-cypress-spec/files/__componentName__.spec.__fileExt__
@@ -7,7 +7,7 @@ describe('<%=projectName%>: <%= componentSelector %> component', () => {
       } %>;<%
     }%>'));
     
-    it('should render the component', () => {
-      cy.get('h1').should('contain', 'Welcome to <%=componentSelector%>!');
-    });
+  it('should render the component', () => {
+    cy.get('h1').should('contain', 'Welcome to <%=componentSelector%>!');
+  });
 });


### PR DESCRIPTION
The original ejs template will output the `it` block with 4 spaces indentation. But it should be 2 spaces instead.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The indentation of `it` block is 4 spaces.

```js
describe('store-ui-shared: Header component component', () => {
  beforeEach(() => cy.visit('/iframe.html?id=header component--primary&args=title:BoardGameHoard;'));

    it('should render the component', () => {
      cy.get('h1').should('contain', 'Welcome to Header component!');
    });
});
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Should be 2 spaces.

```js
describe('store-ui-shared: Header component component', () => {
  beforeEach(() => cy.visit('/iframe.html?id=header component--primary&args=title:BoardGameHoard;'));

  it('should render the component', () => {
    cy.get('h1').should('contain', 'Welcome to Header component!');
  });
});
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
