### PR TITLE
fix(core): add -c as an alias for --configuration for `affected` and …

### DIFF
--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -438,6 +438,7 @@ function withAffectedOptions(yargs: yargs.Argv): yargs.Argv {
     .options('configuration', {
       describe:
         'This is the configuration to use when performing tasks on projects',
+      alias: 'c',
       type: 'string',
     })
     .options('only-failed', {
@@ -498,6 +499,7 @@ function withRunManyOptions(yargs: yargs.Argv): yargs.Argv {
     .options('configuration', {
       describe:
         'This is the configuration to use when performing tasks on projects',
+      alias: 'c',
       type: 'string',
     })
     .options('only-failed', {


### PR DESCRIPTION
…`run-many` commands

ISSUES CLOSED: #9488

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`-c` is ignored for `nx affected` and `nx run-many` commands

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`-c` should be an alias for `--configuration`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9488
