### PR TITLE
feat(linter): support transitive hasBannedImport

### DIFF
--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -52,6 +52,7 @@ type Options = [
     enforceBuildableLibDependency: boolean;
     allowCircularSelfDependency: boolean;
     banTransitiveDependencies: boolean;
+    checkNestedExternalImports: boolean;
   }
 ];
 export type MessageIds =
@@ -86,6 +87,7 @@ export default createESLintRule<Options, MessageIds>({
           enforceBuildableLibDependency: { type: 'boolean' },
           allowCircularSelfDependency: { type: 'boolean' },
           banTransitiveDependencies: { type: 'boolean' },
+          checkNestedExternalImports: { type: 'boolean' },
           allow: [{ type: 'string' }],
           depConstraints: [
             {
@@ -127,6 +129,7 @@ export default createESLintRule<Options, MessageIds>({
       enforceBuildableLibDependency: false,
       allowCircularSelfDependency: false,
       banTransitiveDependencies: false,
+      checkNestedExternalImports: false,
     },
   ],
   create(
@@ -138,6 +141,7 @@ export default createESLintRule<Options, MessageIds>({
         enforceBuildableLibDependency,
         allowCircularSelfDependency,
         banTransitiveDependencies,
+        checkNestedExternalImports,
       },
     ]
   ) {
@@ -485,10 +489,9 @@ export default createESLintRule<Options, MessageIds>({
           return;
         }
 
-        const transitiveExternalDeps = findTransitiveExternalDependencies(
-          projectGraph,
-          targetProject
-        );
+        const transitiveExternalDeps = checkNestedExternalImports
+          ? findTransitiveExternalDependencies(projectGraph, targetProject)
+          : [];
 
         for (let constraint of constraints) {
           if (
@@ -537,6 +540,7 @@ export default createESLintRule<Options, MessageIds>({
             }
           }
           if (
+            checkNestedExternalImports &&
             constraint.bannedExternalImports &&
             constraint.bannedExternalImports.length
           ) {

--- a/packages/workspace/src/utils/runtime-lint-utils.spec.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.spec.ts
@@ -1,0 +1,231 @@
+import {
+  ProjectGraph,
+  ProjectGraphExternalNode,
+  ProjectGraphProjectNode,
+} from '@nrwl/devkit';
+import {
+  DepConstraint,
+  dependentsHaveBannedImport,
+  hasBannedImport,
+} from './runtime-lint-utils';
+
+describe('hasBannedImport', () => {
+  const source: ProjectGraphProjectNode = {
+    type: 'lib',
+    name: 'aLib',
+    data: {
+      tags: ['a'],
+    },
+  };
+
+  const target: ProjectGraphExternalNode = {
+    type: 'npm',
+    name: 'npm:react-native',
+    data: {
+      packageName: 'react-native',
+      version: '0.0.1',
+    },
+  };
+
+  it('should return DepConstraint banning given target', () => {
+    const constraints: DepConstraint[] = [
+      {
+        sourceTag: 'a',
+      },
+      {
+        sourceTag: 'a',
+        bannedExternalImports: ['react-native'],
+      },
+      {
+        sourceTag: 'b',
+        bannedExternalImports: ['react-native'],
+      },
+    ];
+
+    expect(hasBannedImport(source, target, constraints)).toBe(constraints[1]);
+  });
+
+  it('should return just first DepConstraint banning given target', () => {
+    const constraints: DepConstraint[] = [
+      {
+        sourceTag: 'a',
+      },
+      {
+        sourceTag: 'a',
+        bannedExternalImports: ['react-native'],
+      },
+      {
+        sourceTag: 'a',
+        bannedExternalImports: ['react-native'],
+      },
+    ];
+
+    expect(hasBannedImport(source, target, constraints)).toBe(constraints[1]);
+  });
+
+  it('should return null if tag does not match', () => {
+    const constraints: DepConstraint[] = [
+      {
+        sourceTag: 'a',
+      },
+      {
+        sourceTag: 'notA',
+        bannedExternalImports: ['react-native'],
+      },
+      {
+        sourceTag: 'b',
+        bannedExternalImports: ['react-native'],
+      },
+    ];
+
+    expect(hasBannedImport(source, target, constraints)).toBe(undefined);
+  });
+
+  it('should return null if packages does not match', () => {
+    const constraints: DepConstraint[] = [
+      {
+        sourceTag: 'a',
+      },
+      {
+        sourceTag: 'a',
+        bannedExternalImports: ['react-native-with-suffix'],
+      },
+    ];
+
+    expect(hasBannedImport(source, target, constraints)).toBe(undefined);
+  });
+});
+
+describe('dependentsHaveBannedImport', () => {
+  const source: ProjectGraphProjectNode = {
+    type: 'lib',
+    name: 'aLib',
+    data: {
+      tags: ['a'],
+    },
+  };
+
+  const target: ProjectGraphProjectNode = {
+    type: 'lib',
+    name: 'bLib',
+    data: {
+      tags: ['b'],
+    },
+  };
+
+  const c: ProjectGraphProjectNode = {
+    type: 'lib',
+    name: 'cLib',
+    data: {
+      tags: ['c'],
+    },
+  };
+
+  const d: ProjectGraphProjectNode = {
+    type: 'lib',
+    name: 'dLib',
+    data: {
+      tags: ['d'],
+    },
+  };
+
+  const bannedTarget: ProjectGraphExternalNode = {
+    type: 'npm',
+    name: 'npm:react-native',
+    data: {
+      packageName: 'react-native',
+      version: '0.0.1',
+    },
+  };
+
+  const nonBannedTarget: ProjectGraphExternalNode = {
+    type: 'npm',
+    name: 'npm:react',
+    data: {
+      packageName: 'react',
+      version: '18.0.1',
+    },
+  };
+
+  const nonBannedTarget2: ProjectGraphExternalNode = {
+    type: 'npm',
+    name: 'npm:react-native-with-suffix',
+    data: {
+      packageName: 'react-native-with-suffix',
+      version: '18.0.1',
+    },
+  };
+
+  const graph: ProjectGraph = {
+    nodes: {
+      aLib: source,
+      bLib: target,
+      cLib: c,
+      dLib: d,
+    },
+    externalNodes: {
+      'npm:react-native': bannedTarget,
+      'npm:react': nonBannedTarget,
+      'npm:react-native-with-suffix': nonBannedTarget2,
+    },
+    dependencies: {
+      aLib: [
+        { type: 'static', target: 'bLib', source: 'aLib' },
+        { type: 'static', target: 'npm:react', source: 'aLib' },
+      ],
+      bLib: [
+        {
+          type: 'static',
+          target: 'npm:react-native-with-suffix',
+          source: 'bLib',
+        },
+        { type: 'static', target: 'npm:react', source: 'bLib' },
+        { type: 'static', target: 'cLib', source: 'bLib' },
+        { type: 'static', target: 'dLib', source: 'bLib' },
+      ],
+      cLib: [{ type: 'static', target: 'npm:react', source: 'cLib' }],
+      dLib: [{ type: 'static', target: 'npm:react-native', source: 'dLib' }],
+    },
+  };
+
+  it('should return target and constraint pair if any dependents have banned import', () => {
+    const constraints: DepConstraint[] = [
+      { sourceTag: 'a', bannedExternalImports: ['angular'] },
+      {
+        sourceTag: 'a',
+        bannedExternalImports: ['react-native'],
+      },
+    ];
+
+    expect(
+      dependentsHaveBannedImport(source, target, graph, constraints)
+    ).toStrictEqual([[bannedTarget, d, constraints[1]]]);
+  });
+
+  it('should return multiple target and constraint pairs if any dependents have banned import', () => {
+    const constraints: DepConstraint[] = [
+      { sourceTag: 'a', bannedExternalImports: ['angular'] },
+      {
+        sourceTag: 'a',
+        bannedExternalImports: ['react'],
+      },
+    ];
+
+    expect(
+      dependentsHaveBannedImport(source, target, graph, constraints)
+    ).toStrictEqual([
+      [nonBannedTarget, target, constraints[1]],
+      [nonBannedTarget, c, constraints[1]],
+    ]);
+  });
+
+  it('should return undefined if no baneed external imports found', () => {
+    const constraints: DepConstraint[] = [
+      { sourceTag: 'a', bannedExternalImports: ['angular'] },
+    ];
+
+    expect(
+      dependentsHaveBannedImport(source, target, graph, constraints).length
+    ).toBe(0);
+  });
+});

--- a/packages/workspace/src/utils/runtime-lint-utils.spec.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.spec.ts
@@ -198,7 +198,7 @@ describe('dependentsHaveBannedImport', () => {
     ];
 
     expect(
-      dependentsHaveBannedImport(source, target, graph, constraints)
+      dependentsHaveBannedImport(target, graph, constraints)
     ).toStrictEqual([[bannedTarget, d, constraints[1]]]);
   });
 
@@ -212,7 +212,7 @@ describe('dependentsHaveBannedImport', () => {
     ];
 
     expect(
-      dependentsHaveBannedImport(source, target, graph, constraints)
+      dependentsHaveBannedImport(target, graph, constraints)
     ).toStrictEqual([
       [nonBannedTarget, target, constraints[1]],
       [nonBannedTarget, c, constraints[1]],
@@ -224,8 +224,8 @@ describe('dependentsHaveBannedImport', () => {
       { sourceTag: 'a', bannedExternalImports: ['angular'] },
     ];
 
-    expect(
-      dependentsHaveBannedImport(source, target, graph, constraints).length
-    ).toBe(0);
+    expect(dependentsHaveBannedImport(target, graph, constraints).length).toBe(
+      0
+    );
   });
 });

--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -254,8 +254,10 @@ export function findTransitiveExternalDependencies(
   graph: ProjectGraph,
   source: ProjectGraphProjectNode
 ): ProjectGraphDependency[] {
-  const allReachableProjects = Object.keys(graph.nodes).filter((projectName) =>
-    pathExists(graph, source.name, projectName)
+  const allReachableProjects = Object.keys(graph.nodes).filter(
+    (projectName) =>
+      pathExists(graph, source.name, projectName) &&
+      graph.dependencies[projectName]
   );
 
   const externalDependencies: Set<ProjectGraphDependency> = new Set(


### PR DESCRIPTION
* [X] Extract constraints check logic
* [X] Implement transitive constraints check
* [X] Update linter rule to check for transitive constraints
* [x] Asses performance impact on larger application

## Current Behavior
The `hasBannedImport` only checks direct dependencies if they are defined as banned imports.

## Expected Behavior
The `hasBannedImport` should also check transitive dependencies if they are defined as banned imports.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

## Impact
~~The performance impact from `findTransitiveExternalDependencies` is above 20%. A better implementation is needed~~
After refactoring, the new function gives only 5% overhead to the entire rule and it's flagged off by default with `checkNestedExternalImports`

Fixes #
