### PR TITLE
fix(linter): escape dollar signs in filepaths

### DIFF
--- a/packages/nx/src/command-line/format.ts
+++ b/packages/nx/src/command-line/format.ts
@@ -44,7 +44,9 @@ export async function format(
     readNxJson()
   );
   const patterns = (await getPatterns({ ...args, ...nxArgs } as any)).map(
-    (p) => `"${p}"`
+    // prettier removes one of the \
+    // prettier-ignore
+    (p) => `"${p.replace("$", "\\\$")}"`
   );
 
   // Chunkify the patterns array to prevent crashing the windows terminal


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
when running `nx format:write` or `nx format:check` file pathnames containing a $ sign result in following error
(original filename is `apps/demo/app/routes/test/$test.tsx`)
```bash
[error] No files matching the pattern were found: "apps/demo/app/routes/test/.tsx".
```
I have a repo with a reproduction here: [riencoertjens/dollar-sign-nx-format](https://github.com/riencoertjens/dollar-sign-nx-format), this is workspace generated with @nrwl/remix (v13 because this doesn't work in v14)

## Expected Behavior
the format script escapes `$` so it's not interpreted as an unassigned variable

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
