### PR TITLE
fix(core): resolve default project correctly when running targets

### DIFF
--- a/packages/nx/src/command-line/run-one.ts
+++ b/packages/nx/src/command-line/run-one.ts
@@ -31,11 +31,10 @@ export async function runOne(
   const nxJson = readNxJson();
   const projectGraph = await createProjectGraphAsync();
 
-  const opts = parseRunOneOptions(
-    cwd,
-    args,
-    readProjectsConfigurationFromProjectGraph(projectGraph)
-  );
+  const opts = parseRunOneOptions(cwd, args, {
+    ...readProjectsConfigurationFromProjectGraph(projectGraph),
+    ...nxJson,
+  });
 
   const { nxArgs, overrides } = splitArgsIntoNxArgsAndOverrides(
     {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Running a target without specifying the project doesn't respect the configured `defaultProject`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Running a target without specifying the project should respect the configured `defaultProject`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #10985 
