### PR TITLE
fix(misc): handle external nodes correctly in module federation additional shared config

### DIFF
--- a/packages/angular/src/utils/mf/with-module-federation.ts
+++ b/packages/angular/src/utils/mf/with-module-federation.ts
@@ -180,7 +180,7 @@ function addStringDependencyToSharedConfig(
 ): void {
   if (projectGraph.nodes[dependency]) {
     sharedConfig[dependency] = { requiredVersion: false };
-  } else if (projectGraph.externalNodes?.[dependency]) {
+  } else if (projectGraph.externalNodes?.[`npm:${dependency}`]) {
     const pkgJson = readRootPackageJson();
     const config = getNpmPackageSharedConfig(
       dependency,

--- a/packages/react/src/module-federation/with-module-federation.ts
+++ b/packages/react/src/module-federation/with-module-federation.ts
@@ -170,7 +170,7 @@ function addStringDependencyToSharedConfig(
 ): void {
   if (projectGraph.nodes[dependency]) {
     sharedConfig[dependency] = { requiredVersion: false };
-  } else if (projectGraph.externalNodes?.[dependency]) {
+  } else if (projectGraph.externalNodes?.[`npm:${dependency}`]) {
     const pkgJson = readRootPackageJson();
     const config = getNpmPackageSharedConfig(
       dependency,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Providing an npm package that is a dependency of a module federation application as an additional shared dependency fails with an error stating that the package doesn't exist in the project graph:

```js
module.exports = {
  name: 'host',
  remotes: ['remote1', 'remote2'],
  additionalShared: ['@some/awesome-package'],
};
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Providing an npm package that is a dependency of a module federation application as an additional shared dependency should work correctly and the npm package should be shared.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
