### PR TITLE
fix(core): adjust add and addDev command for pnpm when it is in a pnp…

### DIFF
--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -65,11 +65,13 @@ export function getPackageManagerCommand(
       const pnpmVersion = getPackageManagerVersion('pnpm');
       const useExec = gte(pnpmVersion, '6.13.0');
       const includeDoubleDashBeforeArgs = lt(pnpmVersion, '7.0.0');
+      const isPnpmWorkspace = existsSync('pnpm-workspace.yaml');
+
       return {
         install: 'pnpm install --no-frozen-lockfile', // explicitly disable in case of CI
         ciInstall: 'pnpm install --frozen-lockfile',
-        add: 'pnpm add',
-        addDev: 'pnpm add -D',
+        add: isPnpmWorkspace ? 'pnpm add -w' : 'pnpm add',
+        addDev: isPnpmWorkspace ? 'pnpm add -Dw' : 'pnpm add -D',
         addGlobal: 'pnpm add -g',
         rm: 'pnpm rm',
         exec: useExec ? 'pnpm exec' : 'pnpx',


### PR DESCRIPTION
…m workspace

## Current Behavior
`npx nx init` in a pnpm workspace fails

## Expected Behavior
`npx nx init` should work

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
