### PR TITLE
cleanup(storybook): remove optional chaining and add warning log for targets

### DIFF
--- a/packages/storybook/src/generators/change-storybook-targets/change-storybook-targets.ts
+++ b/packages/storybook/src/generators/change-storybook-targets/change-storybook-targets.ts
@@ -62,7 +62,8 @@ function updateStorybookTarget(
   storybookBuildTarget: string
 ): TargetConfiguration {
   const oldStorybookTargetConfig: TargetConfiguration =
-    projectConfiguration?.targets?.[storybookTarget];
+    projectConfiguration.targets[storybookTarget];
+
   const newStorybookTargetConfig: TargetConfiguration = {
     executor: '@storybook/angular:start-storybook',
     options: {
@@ -109,7 +110,11 @@ function updateStorybookBuildTarget(
   storybookBuildTarget: string
 ): TargetConfiguration {
   const oldStorybookBuildTargetConfig: TargetConfiguration =
-    projectConfiguration?.targets?.[storybookBuildTarget];
+    projectConfiguration.targets[storybookBuildTarget];
+  if (!oldStorybookBuildTargetConfig?.options) {
+    logger.warn(`Could not find a Storybook build target for ${projectName}.`);
+    return;
+  }
   const newStorybookBuildTargetConfig: TargetConfiguration = {
     executor: '@storybook/angular:build-storybook',
     outputs: oldStorybookBuildTargetConfig.outputs,


### PR DESCRIPTION
Remove optional chaining check because we already check in previous function. Add an extra warning for transparency if storybook build target is missing


