### PR TITLE
fix(storybook): change-storybook-targets should not fail if no build

### DIFF
--- a/packages/storybook/src/generators/change-storybook-targets/__snapshots__/change-storybook-targets.spec.ts.snap
+++ b/packages/storybook/src/generators/change-storybook-targets/__snapshots__/change-storybook-targets.spec.ts.snap
@@ -23,6 +23,28 @@ Object {
 }
 `;
 
+exports[`Change the Storybook targets for Angular projects to use native Storybooke executor for all types of angular projects - non-buildable and buildable libs/apps should not throw an error if no Storybook exists 1`] = `
+Object {
+  "affected": Object {
+    "defaultBase": "main",
+  },
+  "npmScope": "proj",
+  "tasksRunnerOptions": Object {
+    "default": Object {
+      "options": Object {
+        "cacheableOperations": Array [
+          "build",
+          "lint",
+          "test",
+          "e2e",
+        ],
+      },
+      "runner": "nx/tasks-runners/default",
+    },
+  },
+}
+`;
+
 exports[`Change the Storybook targets for Angular projects to use native Storybooke executor for all types of angular projects - non-buildable and buildable libs/apps should set the browserTarget correctly even if target names are not the default 1`] = `
 Object {
   "affected": Object {
@@ -47,6 +69,29 @@ Object {
 `;
 
 exports[`Change the Storybook targets for Angular projects to use native Storybooke executor for all types of angular projects - non-buildable and buildable libs/apps should set the browserTarget correctly in the Storybook config according to the type of project 1`] = `
+Object {
+  "affected": Object {
+    "defaultBase": "main",
+  },
+  "npmScope": "proj",
+  "tasksRunnerOptions": Object {
+    "default": Object {
+      "options": Object {
+        "cacheableOperations": Array [
+          "build",
+          "lint",
+          "test",
+          "e2e",
+        ],
+      },
+      "runner": "nx/tasks-runners/default",
+    },
+  },
+  "version": 1,
+}
+`;
+
+exports[`Change the Storybook targets for Angular projects to use native Storybooke executor for all types of angular projects - non-buildable and buildable libs/apps should work even if build-storybook does not exist 1`] = `
 Object {
   "affected": Object {
     "defaultBase": "main",

--- a/packages/storybook/src/generators/change-storybook-targets/change-storybook-targets.spec.ts
+++ b/packages/storybook/src/generators/change-storybook-targets/change-storybook-targets.spec.ts
@@ -5,6 +5,8 @@ import * as defaultConfig from './test-configs/default-config.json';
 import * as customNames from './test-configs/custom-names-config.json';
 import * as nonAngular from './test-configs/non-angular.json';
 import * as extraOptions from './test-configs/extra-options-for-storybook.json';
+import * as noStorybookBuildTarget from './test-configs/no-build-storybook-target.json';
+import * as noStorybook from './test-configs/no-storybook-targets.json';
 
 describe('Change the Storybook targets for Angular projects to use native Storybooke executor', () => {
   let tree: Tree;
@@ -28,6 +30,17 @@ describe('Change the Storybook targets for Angular projects to use native Storyb
 
     it(`should keep any extra options added in the target`, async () => {
       writeJson(tree, 'workspace.json', extraOptions);
+      await changeStorybookTargetsGenerator(tree);
+      expect(readWorkspaceConfiguration(tree)).toMatchSnapshot();
+    });
+    it(`should work even if build-storybook does not exist`, async () => {
+      writeJson(tree, 'workspace.json', noStorybookBuildTarget);
+      await changeStorybookTargetsGenerator(tree);
+      expect(readWorkspaceConfiguration(tree)).toMatchSnapshot();
+    });
+
+    it(`should not throw an error if no Storybook exists`, async () => {
+      writeJson(tree, 'workspace.json', noStorybook);
       await changeStorybookTargetsGenerator(tree);
       expect(readWorkspaceConfiguration(tree)).toMatchSnapshot();
     });

--- a/packages/storybook/src/generators/change-storybook-targets/change-storybook-targets.ts
+++ b/packages/storybook/src/generators/change-storybook-targets/change-storybook-targets.ts
@@ -34,13 +34,19 @@ export async function changeStorybookTargetsGenerator(tree: Tree) {
       );
       changesMade = true;
       changesMadeToAtLeastOne = true;
-      projectConfiguration.targets[storybookBuildTarget] =
-        updateStorybookBuildTarget(
-          projectConfiguration,
-          projectName,
-          ngBuildTarget,
-          storybookBuildTarget
+      if (storybookBuildTarget) {
+        projectConfiguration.targets[storybookBuildTarget] =
+          updateStorybookBuildTarget(
+            projectConfiguration,
+            projectName,
+            ngBuildTarget,
+            storybookBuildTarget
+          );
+      } else {
+        logger.info(
+          `Project ${projectName} does not have a build target configured for Storybook.`
         );
+      }
     } else {
       logger.warn(`Could not find a Storybook target for ${projectName}.`);
     }
@@ -111,10 +117,6 @@ function updateStorybookBuildTarget(
 ): TargetConfiguration {
   const oldStorybookBuildTargetConfig: TargetConfiguration =
     projectConfiguration.targets[storybookBuildTarget];
-  if (!oldStorybookBuildTargetConfig?.options) {
-    logger.warn(`Could not find a Storybook build target for ${projectName}.`);
-    return;
-  }
   const newStorybookBuildTargetConfig: TargetConfiguration = {
     executor: '@storybook/angular:build-storybook',
     outputs: oldStorybookBuildTargetConfig.outputs,

--- a/packages/storybook/src/generators/change-storybook-targets/test-configs/no-build-storybook-target.json
+++ b/packages/storybook/src/generators/change-storybook-targets/test-configs/no-build-storybook-target.json
@@ -1,0 +1,60 @@
+{
+  "projects": {
+    "main-app": {
+      "projectType": "application",
+      "root": "apps/main-app",
+      "sourceRoot": "apps/main-app/src",
+      "prefix": "katst",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "outputs": ["{options.outputPath}"]
+        },
+        "storybook": {
+          "builder": "@nrwl/storybook:storybook",
+          "options": {
+            "uiFramework": "@storybook/angular",
+            "port": 4400,
+            "config": {
+              "configFolder": "apps/main-app/.storybook"
+            },
+            "projectBuildConfig": "main-app"
+          },
+          "configurations": {
+            "ci": {
+              "quiet": true
+            }
+          }
+        }
+      }
+    },
+    "other-app": {
+      "projectType": "application",
+      "root": "apps/other-app",
+      "sourceRoot": "apps/other-app/src",
+      "prefix": "katst",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "outputs": ["{options.outputPath}"]
+        },
+        "storybook": {
+          "builder": "@nrwl/storybook:storybook",
+          "options": {
+            "uiFramework": "@storybook/angular",
+            "port": 4400,
+            "config": {
+              "configFolder": "apps/other-app/.storybook"
+            },
+            "projectBuildConfig": "other-app"
+          },
+          "configurations": {
+            "ci": {
+              "quiet": true
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/storybook/src/generators/change-storybook-targets/test-configs/no-storybook-targets.json
+++ b/packages/storybook/src/generators/change-storybook-targets/test-configs/no-storybook-targets.json
@@ -1,0 +1,34 @@
+{
+  "projects": {
+    "ui-one": {
+      "projectType": "library",
+      "root": "libs/ui/one",
+      "sourceRoot": "libs/ui/one/src",
+      "targets": {}
+    },
+    "ui-two": {
+      "projectType": "library",
+      "root": "libs/ui/two",
+      "sourceRoot": "libs/ui/two/src",
+      "targets": {}
+    },
+    "ui-three": {
+      "projectType": "library",
+      "root": "libs/ui/three",
+      "sourceRoot": "libs/ui/three/src",
+      "targets": {}
+    },
+    "main-app": {
+      "projectType": "application",
+      "root": "apps/main-app",
+      "sourceRoot": "apps/main-app/src",
+      "prefix": "katst",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "outputs": ["{options.outputPath}"]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Current Behavior
`change-storybook-targets` generator (and migrator - they are the same) throws an error if there is no target configured for building Storybook.

## Expected Behavior
`change-storybook-targets` generator (and migrator - they are the same) should work even if there is no target set for building Storybook.


