### PR TITLE
docs(nxdev): set default shallow link prop to false

### DIFF
--- a/nx-dev/ui-markdoc/src/lib/nodes/link.schema.ts
+++ b/nx-dev/ui-markdoc/src/lib/nodes/link.schema.ts
@@ -37,7 +37,7 @@ export const link = {
       description:
         'Update the path of the current page without rerunning getStaticProps, getServerSideProps or getInitialProps.',
       type: Boolean,
-      default: true,
+      default: false,
     },
     locale: {
       description: 'The active locale is automatically prepended.',


### PR DESCRIPTION
It sets the default `shallow` link property value for the custom markdown to `false` on nx.dev.