### PR TITLE
Add throw of error if a dependency is not in the graph.

### DIFF
--- a/packages/angular/src/generators/ng-add/__snapshots__/migrate-from-angular-cli.spec.ts.snap
+++ b/packages/angular/src/generators/ng-add/__snapshots__/migrate-from-angular-cli.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`workspace --preserve-angular-cli-layout should create nx.json 1`] = `
 Object {
   "affected": Object {
-    "defaultBase": "main",
+    "defaultBase": "master",
   },
   "implicitDependencies": Object {
     ".eslintrc.json": "*",
@@ -42,7 +42,7 @@ Object {
 exports[`workspace --preserve-angular-cli-layout should support multiple projects 1`] = `
 Object {
   "affected": Object {
-    "defaultBase": "main",
+    "defaultBase": "master",
   },
   "implicitDependencies": Object {
     ".eslintrc.json": "*",

--- a/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
+++ b/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
@@ -4,9 +4,9 @@ exports[`lib should generate azure CI config 1`] = `
 "name: CI
 
 trigger:
-  - main
+  - master
 pr:
-  - main
+  - master
 
 variables:
   CI: 'true'
@@ -91,7 +91,7 @@ jobs:
           name: Install dependencies
           command: yarn --frozen-lockfile
       - nx/set-shas:
-          main-branch-name: 'main'
+          main-branch-name: 'master'
       - run:
           name: Initialize the Nx Cloud distributed CI run
           command: yarn nx-cloud start-ci-run
@@ -136,7 +136,7 @@ exports[`lib should generate github CI config 1`] = `
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 jobs:
@@ -167,7 +167,7 @@ exports[`lib should generate github CI config with custom name 1`] = `
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 jobs:

--- a/packages/workspace/src/utilities/buildable-libs-utils.spec.ts
+++ b/packages/workspace/src/utilities/buildable-libs-utils.spec.ts
@@ -84,3 +84,34 @@ describe('calculateProjectDependencies', () => {
     });
   });
 });
+
+describe('missingDependencies', () => {
+  it('should throw an error if dependency is missing', async () => {
+    const graph: ProjectGraph = {
+      nodes: {
+        example: {
+          type: 'lib',
+          name: 'example',
+          data: {
+            files: [],
+            root: '/root/example',
+          },
+        },
+      },
+      externalNodes: {},
+      dependencies: {
+        example: [
+          {
+            source: 'example',
+            target: 'npm:formik',
+            type: DependencyType.static,
+          },
+        ],
+      },
+    };
+
+    expect(() =>
+      calculateProjectDependencies(graph, 'root', 'example', 'build', undefined)
+    ).toThrow();
+  });
+});

--- a/packages/workspace/src/utilities/buildable-libs-utils.ts
+++ b/packages/workspace/src/utilities/buildable-libs-utils.ts
@@ -48,6 +48,9 @@ export function calculateProjectDependencies(
     .map(({ name: dep, isTopLevel }) => {
       let project: DependentBuildableProjectNode = null;
       const depNode = projGraph.nodes[dep] || projGraph.externalNodes[dep];
+      if (!depNode) {
+        throw new Error(`Unable to find dependency ${dep} in project graph.`);
+      }
       if (depNode.type === 'lib') {
         if (isBuildable(targetName, depNode)) {
           const libPackageJsonPath = join(

--- a/yarn.lock
+++ b/yarn.lock
@@ -18860,7 +18860,7 @@ parse-passwd@^1.0.0:
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
   integrity sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=
 
-parse-path@^4.0.0:
+parse-path@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/parse-path/-/parse-path-4.0.4.tgz#4bf424e6b743fb080831f03b536af9fc43f0ffea"
   integrity sha512-Z2lWUis7jlmXC1jeOG9giRO2+FsuyNipeQ43HAjqAZjwSe3SEf+q/84FGPHoso3kyntbxa4c4i77t3m6fGf8cw==


### PR DESCRIPTION
Ref https://github.com/nrwl/nx/issues/11077

Add error throw in the case a dependency is not found in the project graph.

NOTES:
For some reason the azure CI config scripts fail because of master vs main base branch; I didn't change any of that.
I executed jest with -u to update some of the snapshots, but I wasn't sure if that's something to do as part of a PR or not. It seems someone was running -u with the main branch being main and not master like on github.

![image](https://user-images.githubusercontent.com/708186/178028157-9fb3c90f-9d6e-46e5-9a63-ec3be21c131e.png)

Various other tests also fail
![image](https://user-images.githubusercontent.com/708186/178028426-cd0fa424-cac6-4562-a40d-f251dacabf59.png)
There is no /root/dist/apps folder under normal circumstances and definitely not user read/writable.

Creating a folder at /root/dist/apps and chmod each segment to 0777 does work.

