### PR TITLE
fix(storybook): fix schema to read projectName from config

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -1870,7 +1870,8 @@
         "properties": {
           "name": {
             "type": "string",
-            "description": "The name of the project.",
+            "aliases": ["project", "projectName"],
+            "description": "Project for which to generate stories.",
             "$default": { "$source": "argv", "index": 0 },
             "x-prompt": "What's the name of the project for which you want to generate stories?",
             "x-dropdown": "projects"
@@ -1913,8 +1914,10 @@
         "properties": {
           "name": {
             "type": "string",
-            "description": "The name of the project.",
+            "aliases": ["project", "projectName"],
+            "description": "Project for which to generate Storybook configuration.",
             "$default": { "$source": "argv", "index": 0 },
+            "x-prompt": "For which project do you want to generate Storybook configuration?",
             "x-dropdown": "projects"
           },
           "configureCypress": {

--- a/docs/generated/packages/react-native.json
+++ b/docs/generated/packages/react-native.json
@@ -349,8 +349,11 @@
         "properties": {
           "name": {
             "type": "string",
-            "description": "Project name.",
-            "$default": { "$source": "argv", "index": 0 }
+            "aliases": ["project", "projectName"],
+            "description": "Project for which to generate Storybook configuration.",
+            "$default": { "$source": "argv", "index": 0 },
+            "x-prompt": "For which project do you want to generate Storybook configuration?",
+            "x-dropdown": "projects"
           },
           "generateStories": {
             "type": "boolean",
@@ -401,7 +404,8 @@
         "properties": {
           "project": {
             "type": "string",
-            "description": "The project name where to add the components.",
+            "aliases": ["name", "projectName"],
+            "description": "The project where to add the components.",
             "examples": ["shared-ui-component"],
             "$default": { "$source": "projectName", "index": 0 },
             "x-prompt": "What's the name of the project where the component lives?"
@@ -429,15 +433,16 @@
         "$schema": "http://json-schema.org/schema",
         "cli": "nx",
         "$id": "NxReactNativeStorybookStories",
-        "title": "React native Storybook stories",
-        "description": "React native Storybook stories.",
+        "title": "Generate React Native Storybook stories",
+        "description": "Generate stories/specs for all components declared in a React Native project.",
         "type": "object",
         "properties": {
           "project": {
             "type": "string",
-            "description": "Library or application name.",
+            "aliases": ["name", "projectName"],
+            "description": "Project for which to generate stories.",
             "$default": { "$source": "projectName", "index": 0 },
-            "x-prompt": "What's the name of the project for which you want to generate stories?"
+            "x-prompt": "For which project do you want to generate stories?"
           }
         },
         "required": ["project"],

--- a/docs/generated/packages/react.json
+++ b/docs/generated/packages/react.json
@@ -598,8 +598,11 @@
         "properties": {
           "name": {
             "type": "string",
-            "description": "Project name",
-            "$default": { "$source": "argv", "index": 0 }
+            "aliases": ["project", "projectName"],
+            "description": "Project for which to generate Storybook configuration.",
+            "$default": { "$source": "argv", "index": 0 },
+            "x-prompt": "For which project do you want to generate Storybook configuration?",
+            "x-dropdown": "projects"
           },
           "configureCypress": {
             "type": "boolean",
@@ -666,7 +669,8 @@
         "properties": {
           "project": {
             "type": "string",
-            "description": "The project name where to add the components.",
+            "aliases": ["name", "projectName"],
+            "description": "The project where to add the components.",
             "examples": ["shared-ui-component"],
             "$default": { "$source": "projectName", "index": 0 },
             "x-prompt": "What's name of the project where the component lives?"
@@ -694,15 +698,16 @@
         "$schema": "http://json-schema.org/schema",
         "cli": "nx",
         "$id": "NxReactStorybookStories",
-        "title": "Create React Storybook stories",
-        "description": "Create stories/specs for all components declared in an app or a library.",
+        "title": "Generate React Storybook stories",
+        "description": "Generate stories/specs for all components declared in a project.",
         "type": "object",
         "properties": {
           "project": {
             "type": "string",
-            "description": "Library or application name.",
+            "aliases": ["name", "projectName"],
+            "description": "Project for which to generate stories.",
             "$default": { "$source": "projectName", "index": 0 },
-            "x-prompt": "What's name of the project for which you want to generate stories?"
+            "x-prompt": "For which project do you want to generate stories?"
           },
           "generateCypressSpecs": {
             "type": "boolean",

--- a/docs/generated/packages/storybook.json
+++ b/docs/generated/packages/storybook.json
@@ -109,8 +109,11 @@
         "properties": {
           "name": {
             "type": "string",
-            "description": "Library or application name.",
-            "$default": { "$source": "argv", "index": 0 }
+            "aliases": ["project", "projectName"],
+            "description": "Project for which to generate Storybook configuration.",
+            "$default": { "$source": "argv", "index": 0 },
+            "x-prompt": "For which project do you want to generate Storybook configuration?",
+            "x-dropdown": "projects"
           },
           "uiFramework": {
             "type": "string",
@@ -170,8 +173,11 @@
         "properties": {
           "name": {
             "type": "string",
-            "description": "Library or application name.",
-            "$default": { "$source": "argv", "index": 0 }
+            "aliases": ["project", "projectName"],
+            "description": "Project for which to generate the cypress E2E app.",
+            "$default": { "$source": "argv", "index": 0 },
+            "x-prompt": "For which project do you want to generate the Cypress E2E app?",
+            "x-dropdown": "projects"
           },
           "js": {
             "type": "boolean",

--- a/packages/angular/src/generators/stories/schema.json
+++ b/packages/angular/src/generators/stories/schema.json
@@ -8,7 +8,8 @@
   "properties": {
     "name": {
       "type": "string",
-      "description": "The name of the project.",
+      "aliases": ["project", "projectName"],
+      "description": "Project for which to generate stories.",
       "$default": {
         "$source": "argv",
         "index": 0

--- a/packages/angular/src/generators/storybook-configuration/schema.json
+++ b/packages/angular/src/generators/storybook-configuration/schema.json
@@ -8,11 +8,13 @@
   "properties": {
     "name": {
       "type": "string",
-      "description": "The name of the project.",
+      "aliases": ["project", "projectName"],
+      "description": "Project for which to generate Storybook configuration.",
       "$default": {
         "$source": "argv",
         "index": 0
       },
+      "x-prompt": "For which project do you want to generate Storybook configuration?",
       "x-dropdown": "projects"
     },
     "configureCypress": {

--- a/packages/react-native/src/generators/component-story/schema.json
+++ b/packages/react-native/src/generators/component-story/schema.json
@@ -8,7 +8,8 @@
   "properties": {
     "project": {
       "type": "string",
-      "description": "The project name where to add the components.",
+      "aliases": ["name", "projectName"],
+      "description": "The project where to add the components.",
       "examples": ["shared-ui-component"],
       "$default": {
         "$source": "projectName",

--- a/packages/react-native/src/generators/stories/schema.json
+++ b/packages/react-native/src/generators/stories/schema.json
@@ -2,18 +2,19 @@
   "$schema": "http://json-schema.org/schema",
   "cli": "nx",
   "$id": "NxReactNativeStorybookStories",
-  "title": "React native Storybook stories",
-  "description": "React native Storybook stories.",
+  "title": "Generate React Native Storybook stories",
+  "description": "Generate stories/specs for all components declared in a React Native project.",
   "type": "object",
   "properties": {
     "project": {
       "type": "string",
-      "description": "Library or application name.",
+      "aliases": ["name", "projectName"],
+      "description": "Project for which to generate stories.",
       "$default": {
         "$source": "projectName",
         "index": 0
       },
-      "x-prompt": "What's the name of the project for which you want to generate stories?"
+      "x-prompt": "For which project do you want to generate stories?"
     }
   },
   "required": ["project"]

--- a/packages/react-native/src/generators/storybook-configuration/schema.json
+++ b/packages/react-native/src/generators/storybook-configuration/schema.json
@@ -8,11 +8,14 @@
   "properties": {
     "name": {
       "type": "string",
-      "description": "Project name.",
+      "aliases": ["project", "projectName"],
+      "description": "Project for which to generate Storybook configuration.",
       "$default": {
         "$source": "argv",
         "index": 0
-      }
+      },
+      "x-prompt": "For which project do you want to generate Storybook configuration?",
+      "x-dropdown": "projects"
     },
     "generateStories": {
       "type": "boolean",

--- a/packages/react/src/generators/component-story/schema.json
+++ b/packages/react/src/generators/component-story/schema.json
@@ -8,7 +8,8 @@
   "properties": {
     "project": {
       "type": "string",
-      "description": "The project name where to add the components.",
+      "aliases": ["name", "projectName"],
+      "description": "The project where to add the components.",
       "examples": ["shared-ui-component"],
       "$default": {
         "$source": "projectName",

--- a/packages/react/src/generators/stories/schema.json
+++ b/packages/react/src/generators/stories/schema.json
@@ -2,18 +2,19 @@
   "$schema": "http://json-schema.org/schema",
   "cli": "nx",
   "$id": "NxReactStorybookStories",
-  "title": "Create React Storybook stories",
-  "description": "Create stories/specs for all components declared in an app or a library.",
+  "title": "Generate React Storybook stories",
+  "description": "Generate stories/specs for all components declared in a project.",
   "type": "object",
   "properties": {
     "project": {
       "type": "string",
-      "description": "Library or application name.",
+      "aliases": ["name", "projectName"],
+      "description": "Project for which to generate stories.",
       "$default": {
         "$source": "projectName",
         "index": 0
       },
-      "x-prompt": "What's name of the project for which you want to generate stories?"
+      "x-prompt": "For which project do you want to generate stories?"
     },
     "generateCypressSpecs": {
       "type": "boolean",

--- a/packages/react/src/generators/storybook-configuration/schema.json
+++ b/packages/react/src/generators/storybook-configuration/schema.json
@@ -8,11 +8,14 @@
   "properties": {
     "name": {
       "type": "string",
-      "description": "Project name",
+      "aliases": ["project", "projectName"],
+      "description": "Project for which to generate Storybook configuration.",
       "$default": {
         "$source": "argv",
         "index": 0
-      }
+      },
+      "x-prompt": "For which project do you want to generate Storybook configuration?",
+      "x-dropdown": "projects"
     },
     "configureCypress": {
       "type": "boolean",

--- a/packages/storybook/src/generators/configuration/schema.json
+++ b/packages/storybook/src/generators/configuration/schema.json
@@ -8,11 +8,14 @@
   "properties": {
     "name": {
       "type": "string",
-      "description": "Library or application name.",
+      "aliases": ["project", "projectName"],
+      "description": "Project for which to generate Storybook configuration.",
       "$default": {
         "$source": "argv",
         "index": 0
-      }
+      },
+      "x-prompt": "For which project do you want to generate Storybook configuration?",
+      "x-dropdown": "projects"
     },
     "uiFramework": {
       "type": "string",

--- a/packages/storybook/src/generators/cypress-project/schema.json
+++ b/packages/storybook/src/generators/cypress-project/schema.json
@@ -8,11 +8,14 @@
   "properties": {
     "name": {
       "type": "string",
-      "description": "Library or application name.",
+      "aliases": ["project", "projectName"],
+      "description": "Project for which to generate the cypress E2E app.",
       "$default": {
         "$source": "argv",
         "index": 0
-      }
+      },
+      "x-prompt": "For which project do you want to generate the Cypress E2E app?",
+      "x-dropdown": "projects"
     },
     "js": {
       "type": "boolean",


### PR DESCRIPTION
## Current Behavior
The storybook-related generators do not provide a dropdown for project names, at the moment. This is due to the fact that the parameter that is used to submit the project is named `name`, and the default is not provided correctly.


## Expected Behavior
There should be a drop down of project names.
I changed the `default` source to be `projectName`. I also added prompts where there were not.
