### PR TITLE
chore(repo): re-enable graph e2e tests on win

### DIFF
--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -30,7 +30,7 @@ jobs:
           - e2e-storybook,e2e-storybook-angular
           - e2e-workspace-create
           - e2e-add-nx-to-monorepo
-          # - e2e-dep-graph-client
+          - e2e-dep-graph-client
       fail-fast: false
 
     name: ${{ matrix.packages }}


### PR DESCRIPTION
## Current Behavior
`e2e-dep-graph` is disabled for Windows nightly

## Expected Behavior
`e2e-dep-graph` is enabled for Windows nightly

## Related Issue(s)
Previously disabled by #10906 
I wasn't able to replicate the failure in Windows locally, but I did some work to add better clean-up after test cases. As part of this, I discovered failing tests if certain actions were performed too quickly, like they are during e2e tests. These changes were merged in #10986 
