### PR TITLE
feat(storybook): ignore paths when generating stories

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -1896,6 +1896,18 @@
             "description": "Skip formatting files.",
             "type": "boolean",
             "default": false
+          },
+          "ignorePaths": {
+            "type": "array",
+            "description": "Paths to ignore when looking for components.",
+            "items": { "type": "string", "description": "Path to ignore." },
+            "examples": [
+              "apps/my-app/src/not-stories/**",
+              "**/**/src/**/not-stories/**",
+              "libs/my-lib/**/*.something.ts",
+              "**/**/src/**/*.other.*",
+              "libs/my-lib/src/not-stories/**,**/**/src/**/*.other.*,apps/my-app/**/*.something.ts"
+            ]
           }
         },
         "additionalProperties": false,
@@ -1964,6 +1976,18 @@
             "description": "Skip formatting files.",
             "type": "boolean",
             "default": false
+          },
+          "ignorePaths": {
+            "type": "array",
+            "description": "Paths to ignore when looking for components.",
+            "items": { "type": "string", "description": "Path to ignore." },
+            "examples": [
+              "apps/my-app/src/not-stories/**",
+              "**/**/src/**/not-stories/**",
+              "libs/my-lib/**/*.something.ts",
+              "**/**/src/**/*.other.*",
+              "libs/my-lib/src/not-stories/**,**/**/src/**/*.other.*,apps/my-app/**/*.something.ts"
+            ]
           }
         },
         "additionalProperties": false,

--- a/docs/generated/packages/react-native.json
+++ b/docs/generated/packages/react-native.json
@@ -380,6 +380,18 @@
           "standaloneConfig": {
             "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
             "type": "boolean"
+          },
+          "ignorePaths": {
+            "type": "array",
+            "description": "Paths to ignore when looking for components.",
+            "items": { "type": "string", "description": "Path to ignore." },
+            "examples": [
+              "apps/my-app/src/not-stories/**",
+              "**/**/src/**/not-stories/**",
+              "libs/my-lib/**/*.something.ts",
+              "**/**/src/**/*.other.*",
+              "libs/my-lib/src/not-stories/**,**/**/src/**/*.other.*,apps/my-app/**/*.something.ts"
+            ]
           }
         },
         "required": ["name"],
@@ -443,6 +455,18 @@
             "description": "Project for which to generate stories.",
             "$default": { "$source": "projectName", "index": 0 },
             "x-prompt": "For which project do you want to generate stories?"
+          },
+          "ignorePaths": {
+            "type": "array",
+            "description": "Paths to ignore when looking for components.",
+            "items": { "type": "string", "description": "Path to ignore." },
+            "examples": [
+              "apps/my-app/src/not-stories/**",
+              "**/**/src/**/not-stories/**",
+              "libs/my-lib/**/*.something.ts",
+              "**/**/src/**/*.other.*",
+              "libs/my-lib/src/not-stories/**,**/**/src/**/*.other.*,apps/my-app/**/*.something.ts"
+            ]
           }
         },
         "required": ["project"],

--- a/docs/generated/packages/react.json
+++ b/docs/generated/packages/react.json
@@ -650,6 +650,18 @@
           "standaloneConfig": {
             "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
             "type": "boolean"
+          },
+          "ignorePaths": {
+            "type": "array",
+            "description": "Paths to ignore when looking for components.",
+            "items": { "type": "string", "description": "Path to ignore." },
+            "examples": [
+              "apps/my-app/src/not-stories/**",
+              "**/**/src/**/not-stories/**",
+              "libs/my-lib/**/*.something.ts",
+              "**/**/src/**/*.other.*",
+              "libs/my-lib/src/not-stories/**,**/**/src/**/*.other.*,apps/my-app/**/*.something.ts"
+            ]
           }
         },
         "required": ["name"],
@@ -727,6 +739,18 @@
             "type": "boolean",
             "description": "Generate JavaScript files rather than TypeScript files.",
             "default": false
+          },
+          "ignorePaths": {
+            "type": "array",
+            "description": "Paths to ignore when looking for components.",
+            "items": { "type": "string", "description": "Path to ignore." },
+            "examples": [
+              "apps/my-app/src/not-stories/**",
+              "**/**/src/**/not-stories/**",
+              "libs/my-lib/**/*.something.ts",
+              "**/**/src/**/*.other.*",
+              "libs/my-lib/src/not-stories/**,**/**/src/**/*.other.*,apps/my-app/**/*.something.ts"
+            ]
           }
         },
         "required": ["project"],

--- a/packages/angular/ng-package.json
+++ b/packages/angular/ng-package.json
@@ -13,6 +13,7 @@
     "chokidar",
     "ignore",
     "jasmine-marbles",
+    "minimatch",
     "rxjs-for-await",
     "webpack-merge",
     "ts-node",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -53,6 +53,7 @@
     "ignore": "^5.0.4",
     "jasmine-marbles": "~0.8.4",
     "magic-string": "~0.26.2",
+    "minimatch": "3.0.5",
     "semver": "7.3.4",
     "ts-node": "~10.8.0",
     "tsconfig-paths": "^3.9.0",

--- a/packages/angular/src/generators/stories/__snapshots__/stories-lib.spec.ts.snap
+++ b/packages/angular/src/generators/stories/__snapshots__/stories-lib.spec.ts.snap
@@ -84,3 +84,31 @@ Primary.args = {
     isOn:  false,
 }"
 `;
+
+exports[`angularStories generator: libraries Stories for non-empty Angular library should ignore paths 1`] = `
+"import { moduleMetadata, Story, Meta } from '@storybook/angular';
+import { TestButtonComponent } from './test-button.component';
+
+export default {
+  title: 'TestButtonComponent',
+  component: TestButtonComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [],
+    })
+  ],
+} as Meta<TestButtonComponent>;
+
+const Template: Story<TestButtonComponent> = (args: TestButtonComponent) => ({
+  props: args,
+});
+
+
+export const Primary = Template.bind({});
+Primary.args = {
+    buttonType:  'button',
+    style:  'default',
+    age:  0,
+    isOn:  false,
+}"
+`;

--- a/packages/angular/src/generators/stories/schema.d.ts
+++ b/packages/angular/src/generators/stories/schema.d.ts
@@ -3,4 +3,5 @@ export interface StoriesGeneratorOptions {
   cypressProject?: string;
   generateCypressSpecs?: boolean;
   skipFormat?: boolean;
+  ignorePaths?: string[];
 }

--- a/packages/angular/src/generators/stories/schema.json
+++ b/packages/angular/src/generators/stories/schema.json
@@ -30,6 +30,21 @@
       "description": "Skip formatting files.",
       "type": "boolean",
       "default": false
+    },
+    "ignorePaths": {
+      "type": "array",
+      "description": "Paths to ignore when looking for components.",
+      "items": {
+        "type": "string",
+        "description": "Path to ignore."
+      },
+      "examples": [
+        "apps/my-app/src/not-stories/**",
+        "**/**/src/**/not-stories/**",
+        "libs/my-lib/**/*.something.ts",
+        "**/**/src/**/*.other.*",
+        "libs/my-lib/src/not-stories/**,**/**/src/**/*.other.*,apps/my-app/**/*.something.ts"
+      ]
     }
   },
   "additionalProperties": false,

--- a/packages/angular/src/generators/stories/stories-app.spec.ts
+++ b/packages/angular/src/generators/stories/stories-app.spec.ts
@@ -3,7 +3,9 @@ import type { Tree } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { applicationGenerator } from '../application/application';
 import { scamGenerator } from '../scam/scam';
+import { componentGenerator } from '../component/component';
 import { angularStoriesGenerator } from './stories';
+
 // need to mock cypress otherwise it'll use the nx installed version from package.json
 //  which is v9 while we are testing for the new v10 version
 jest.mock('@nrwl/cypress/src/utils/cypress-version');
@@ -53,6 +55,34 @@ describe('angularStories generator: applications', () => {
     expect(
       tree.exists(
         `apps/${appName}/src/app/my-scam/my-scam.component.stories.ts`
+      )
+    ).toBeFalsy();
+  });
+
+  it('should ignore a path that has a nested component, but still generate nested component stories', async () => {
+    await componentGenerator(tree, { name: 'component-a', project: appName });
+    await componentGenerator(tree, {
+      name: 'component-a/component-b',
+      project: appName,
+    });
+
+    console.log(tree.listChanges());
+
+    angularStoriesGenerator(tree, {
+      name: appName,
+      ignorePaths: [
+        `apps/${appName}/src/app/component-a/component-a.component.ts`,
+      ],
+    });
+
+    expect(
+      tree.exists(
+        `apps/${appName}/src/app/component-a/component-b/component-b.component.stories.ts`
+      )
+    ).toBeTruthy();
+    expect(
+      tree.exists(
+        `apps/${appName}/src/app/component-a/component-a.component.stories.ts`
       )
     ).toBeFalsy();
   });

--- a/packages/angular/src/generators/stories/stories-app.spec.ts
+++ b/packages/angular/src/generators/stories/stories-app.spec.ts
@@ -42,6 +42,21 @@ describe('angularStories generator: applications', () => {
     ).toBeTruthy();
   });
 
+  it('should ignore paths', async () => {
+    await scamGenerator(tree, { name: 'my-scam', project: appName });
+
+    angularStoriesGenerator(tree, {
+      name: appName,
+      ignorePaths: [`apps/${appName}/src/app/my-scam/**`],
+    });
+
+    expect(
+      tree.exists(
+        `apps/${appName}/src/app/my-scam/my-scam.component.stories.ts`
+      )
+    ).toBeFalsy();
+  });
+
   it('should generate stories file for inline scam component', async () => {
     await scamGenerator(tree, {
       name: 'my-scam',

--- a/packages/angular/src/generators/stories/stories-app.spec.ts
+++ b/packages/angular/src/generators/stories/stories-app.spec.ts
@@ -59,14 +59,27 @@ describe('angularStories generator: applications', () => {
     ).toBeFalsy();
   });
 
+  it('should ignore paths when full path to component is provided', async () => {
+    await scamGenerator(tree, { name: 'my-scam', project: appName });
+
+    angularStoriesGenerator(tree, {
+      name: appName,
+      ignorePaths: [`apps/${appName}/src/app/my-scam/my-scam.component.ts`],
+    });
+
+    expect(
+      tree.exists(
+        `apps/${appName}/src/app/my-scam/my-scam.component.stories.ts`
+      )
+    ).toBeFalsy();
+  });
+
   it('should ignore a path that has a nested component, but still generate nested component stories', async () => {
     await componentGenerator(tree, { name: 'component-a', project: appName });
     await componentGenerator(tree, {
       name: 'component-a/component-b',
       project: appName,
     });
-
-    console.log(tree.listChanges());
 
     angularStoriesGenerator(tree, {
       name: appName,

--- a/packages/angular/src/generators/stories/stories-lib.spec.ts
+++ b/packages/angular/src/generators/stories/stories-lib.spec.ts
@@ -333,5 +333,60 @@ describe('angularStories generator: libraries', () => {
         )
       ).toMatchSnapshot();
     });
+
+    it('should ignore paths', async () => {
+      // add secondary entrypoint
+      writeJson(tree, `libs/${libName}/package.json`, { name: libName });
+      await librarySecondaryEntryPointGenerator(tree, {
+        library: libName,
+        name: 'secondary-entry-point',
+      });
+      // add a standalone component to the secondary entrypoint
+      await componentGenerator(tree, {
+        name: 'secondary-button',
+        project: libName,
+        path: `libs/${libName}/secondary-entry-point/src/lib`,
+      });
+
+      angularStoriesGenerator(tree, {
+        name: libName,
+        ignorePaths: [
+          `libs/${libName}/src/lib/barrel/**`,
+          `libs/${libName}/secondary-entry-point/**`,
+        ],
+      });
+
+      expect(
+        tree.exists(
+          `libs/${libName}/src/lib/barrel/barrel-button/barrel-button.component.stories.ts`
+        )
+      ).toBeFalsy();
+      expect(
+        tree.exists(
+          `libs/${libName}/src/lib/nested/nested-button/nested-button.component.stories.ts`
+        )
+      ).toBeTruthy();
+      expect(
+        tree.exists(
+          `libs/${libName}/src/lib/test-button/test-button.component.stories.ts`
+        )
+      ).toBeTruthy();
+      expect(
+        tree.exists(
+          `libs/${libName}/src/lib/test-other/test-other.component.stories.ts`
+        )
+      ).toBeTruthy();
+      expect(
+        tree.read(
+          `libs/${libName}/src/lib/test-button/test-button.component.stories.ts`,
+          'utf-8'
+        )
+      ).toMatchSnapshot();
+      expect(
+        tree.exists(
+          `libs/${libName}/secondary-entry-point/src/lib/secondary-button/secondary-button.component.stories.ts`
+        )
+      ).toBeFalsy();
+    });
   });
 });

--- a/packages/angular/src/generators/stories/stories.ts
+++ b/packages/angular/src/generators/stories/stories.ts
@@ -1,5 +1,10 @@
-import type { Tree } from '@nrwl/devkit';
-import { formatFiles, joinPathFragments, logger } from '@nrwl/devkit';
+import {
+  formatFiles,
+  joinPathFragments,
+  logger,
+  readProjectConfiguration,
+  Tree,
+} from '@nrwl/devkit';
 import componentCypressSpecGenerator from '../component-cypress-spec/component-cypress-spec';
 import componentStoryGenerator from '../component-story/component-story';
 import type { ComponentInfo } from './lib/component-info';
@@ -11,6 +16,7 @@ import { getProjectEntryPoints } from './lib/entry-point';
 import { getE2EProject } from './lib/get-e2e-project';
 import { getModuleFilePaths } from './lib/module-info';
 import type { StoriesGeneratorOptions } from './schema';
+import minimatch = require('minimatch');
 
 export function angularStoriesGenerator(
   tree: Tree,
@@ -19,7 +25,7 @@ export function angularStoriesGenerator(
   const e2eProjectName = options.cypressProject ?? `${options.name}-e2e`;
   const e2eProject = getE2EProject(tree, e2eProjectName);
   const entryPoints = getProjectEntryPoints(tree, options.name);
-
+  const { root } = readProjectConfiguration(tree, options.name);
   const componentsInfo: ComponentInfo[] = [];
   for (const entryPoint of entryPoints) {
     const moduleFilePaths = getModuleFilePaths(tree, entryPoint);
@@ -35,32 +41,42 @@ export function angularStoriesGenerator(
     );
   }
 
-  componentsInfo.forEach((info) => {
-    if (info === undefined) {
-      return;
-    }
+  componentsInfo
+    .filter(
+      (f) =>
+        !options.ignorePaths?.some((pattern) =>
+          minimatch(
+            joinPathFragments(f.moduleFolderPath, f.path, f.componentFileName),
+            pattern
+          )
+        )
+    )
+    ?.forEach((info) => {
+      if (info === undefined) {
+        return;
+      }
 
-    componentStoryGenerator(tree, {
-      projectPath: info.moduleFolderPath,
-      componentName: info.name,
-      componentPath: info.path,
-      componentFileName: info.componentFileName,
-      skipFormat: false,
-    });
-
-    if (options.generateCypressSpecs && e2eProject) {
-      componentCypressSpecGenerator(tree, {
-        projectName: options.name,
+      componentStoryGenerator(tree, {
         projectPath: info.moduleFolderPath,
-        cypressProject: options.cypressProject,
         componentName: info.name,
         componentPath: info.path,
         componentFileName: info.componentFileName,
-        specDirectory: joinPathFragments(info.entryPointName, info.path),
         skipFormat: false,
       });
-    }
-  });
+
+      if (options.generateCypressSpecs && e2eProject) {
+        componentCypressSpecGenerator(tree, {
+          projectName: options.name,
+          projectPath: info.moduleFolderPath,
+          cypressProject: options.cypressProject,
+          componentName: info.name,
+          componentPath: info.path,
+          componentFileName: info.componentFileName,
+          specDirectory: joinPathFragments(info.entryPointName, info.path),
+          skipFormat: false,
+        });
+      }
+    });
 
   if (!options.skipFormat) {
     formatFiles(tree);

--- a/packages/angular/src/generators/stories/stories.ts
+++ b/packages/angular/src/generators/stories/stories.ts
@@ -44,12 +44,17 @@ export function angularStoriesGenerator(
   componentsInfo
     .filter(
       (f) =>
-        !options.ignorePaths?.some((pattern) =>
-          minimatch(
-            joinPathFragments(f.moduleFolderPath, f.path, f.componentFileName),
+        !options.ignorePaths?.some((pattern) => {
+          const shouldIgnorePath = minimatch(
+            joinPathFragments(
+              f.moduleFolderPath,
+              f.path,
+              `${f.componentFileName}.ts`
+            ),
             pattern
-          )
-        )
+          );
+          return shouldIgnorePath;
+        })
     )
     ?.forEach((info) => {
       if (info === undefined) {

--- a/packages/angular/src/generators/storybook-configuration/lib/generate-stories.ts
+++ b/packages/angular/src/generators/storybook-configuration/lib/generate-stories.ts
@@ -20,5 +20,6 @@ export function generateStories(
     generateCypressSpecs:
       options.configureCypress && options.generateCypressSpecs,
     cypressProject: e2eProjectName,
+    ignorePaths: options.ignorePaths,
   });
 }

--- a/packages/angular/src/generators/storybook-configuration/schema.d.ts
+++ b/packages/angular/src/generators/storybook-configuration/schema.d.ts
@@ -9,4 +9,5 @@ export interface StorybookConfigurationOptions {
   cypressDirectory?: string;
   tsConfiguration?: boolean;
   skipFormat?: boolean;
+  ignorePaths?: string[];
 }

--- a/packages/angular/src/generators/storybook-configuration/schema.json
+++ b/packages/angular/src/generators/storybook-configuration/schema.json
@@ -54,6 +54,21 @@
       "description": "Skip formatting files.",
       "type": "boolean",
       "default": false
+    },
+    "ignorePaths": {
+      "type": "array",
+      "description": "Paths to ignore when looking for components.",
+      "items": {
+        "type": "string",
+        "description": "Path to ignore."
+      },
+      "examples": [
+        "apps/my-app/src/not-stories/**",
+        "**/**/src/**/not-stories/**",
+        "libs/my-lib/**/*.something.ts",
+        "**/**/src/**/*.other.*",
+        "libs/my-lib/src/not-stories/**,**/**/src/**/*.other.*,apps/my-app/**/*.something.ts"
+      ]
     }
   },
   "additionalProperties": false,

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -36,6 +36,7 @@
     "fs-extra": "^10.1.0",
     "ignore": "^5.0.4",
     "metro-resolver": "^0.71.3",
+    "minimatch": "3.0.5",
     "node-fetch": "^2.6.7",
     "tsconfig-paths": "^3.9.0"
   },

--- a/packages/react-native/src/generators/stories/schema.d.ts
+++ b/packages/react-native/src/generators/stories/schema.d.ts
@@ -1,3 +1,4 @@
 export interface StorybookStoriesSchema {
   project: string;
+  ignorePaths?: string[];
 }

--- a/packages/react-native/src/generators/stories/schema.json
+++ b/packages/react-native/src/generators/stories/schema.json
@@ -15,6 +15,21 @@
         "index": 0
       },
       "x-prompt": "For which project do you want to generate stories?"
+    },
+    "ignorePaths": {
+      "type": "array",
+      "description": "Paths to ignore when looking for components.",
+      "items": {
+        "type": "string",
+        "description": "Path to ignore."
+      },
+      "examples": [
+        "apps/my-app/src/not-stories/**",
+        "**/**/src/**/not-stories/**",
+        "libs/my-lib/**/*.something.ts",
+        "**/**/src/**/*.other.*",
+        "libs/my-lib/src/not-stories/**,**/**/src/**/*.other.*,apps/my-app/**/*.something.ts"
+      ]
     }
   },
   "required": ["project"]

--- a/packages/react-native/src/generators/stories/stories-app.spec.ts
+++ b/packages/react-native/src/generators/stories/stories-app.spec.ts
@@ -32,6 +32,27 @@ describe('react:stories for applications', () => {
     ).toBeTruthy();
   });
 
+  it('should ignore paths', async () => {
+    await reactNativeComponentGenerator(appTree, {
+      name: 'another-cmp',
+      project: 'test-ui-app',
+    });
+    await storiesGenerator(appTree, {
+      project: 'test-ui-app',
+      ignorePaths: ['apps/test-ui-app/src/app/**'],
+    });
+
+    expect(appTree.exists('apps/test-ui-app/src/app/App.tsx')).toBeTruthy();
+    expect(
+      appTree.exists('apps/test-ui-app/src/app/App.stories.tsx')
+    ).toBeFalsy();
+    expect(
+      appTree.exists(
+        'apps/test-ui-app/src/app/another-cmp/another-cmp.stories.tsx'
+      )
+    ).toBeFalsy();
+  });
+
   it('should ignore files that do not contain components', async () => {
     // create another component
     appTree.write(

--- a/packages/react-native/src/generators/stories/stories-app.spec.ts
+++ b/packages/react-native/src/generators/stories/stories-app.spec.ts
@@ -53,6 +53,63 @@ describe('react:stories for applications', () => {
     ).toBeFalsy();
   });
 
+  it('should ignore paths with a direct path to a component', async () => {
+    await reactNativeComponentGenerator(appTree, {
+      name: 'another-new-cmp',
+      project: 'test-ui-app',
+    });
+
+    await storiesGenerator(appTree, {
+      project: 'test-ui-app',
+      ignorePaths: [
+        'apps/test-ui-app/src/app/another-new-cmp/another-new-cmp.tsx',
+      ],
+    });
+
+    expect(appTree.exists('apps/test-ui-app/src/app/App.tsx')).toBeTruthy();
+    expect(
+      appTree.exists('apps/test-ui-app/src/app/App.stories.tsx')
+    ).toBeTruthy();
+    expect(
+      appTree.exists(
+        'apps/test-ui-app/src/app/another-new-cmp/another-new-cmp.stories.tsx'
+      )
+    ).toBeFalsy();
+  });
+
+  it('should ignore a path that has a nested component, but still generate nested component stories', async () => {
+    await reactNativeComponentGenerator(appTree, {
+      name: 'another-new-cmp',
+      project: 'test-ui-app',
+    });
+    await reactNativeComponentGenerator(appTree, {
+      name: 'comp-a',
+      directory: 'app/another-new-cmp',
+      project: 'test-ui-app',
+    });
+    await storiesGenerator(appTree, {
+      project: 'test-ui-app',
+      ignorePaths: [
+        'apps/test-ui-app/src/app/another-new-cmp/another-new-cmp.tsx',
+      ],
+    });
+
+    expect(appTree.exists('apps/test-ui-app/src/app/App.tsx')).toBeTruthy();
+    expect(
+      appTree.exists('apps/test-ui-app/src/app/App.stories.tsx')
+    ).toBeTruthy();
+    expect(
+      appTree.exists(
+        'apps/test-ui-app/src/app/another-new-cmp/comp-a/comp-a.stories.tsx'
+      )
+    ).toBeTruthy();
+    expect(
+      appTree.exists(
+        'apps/test-ui-app/src/app/another-new-cmp/another-new-cmp.stories.tsx'
+      )
+    ).toBeFalsy();
+  });
+
   it('should ignore files that do not contain components', async () => {
     // create another component
     appTree.write(

--- a/packages/react-native/src/generators/stories/stories-lib.spec.ts
+++ b/packages/react-native/src/generators/stories/stories-lib.spec.ts
@@ -38,6 +38,32 @@ describe('react-native:stories for libraries', () => {
     ).toBeTruthy();
   });
 
+  it('should ignore paths', async () => {
+    await reactNativeComponentGenerator(appTree, {
+      name: 'test-ui-lib',
+      project: 'test-ui-lib',
+    });
+    await reactNativeComponentGenerator(appTree, {
+      name: 'another-cmp',
+      project: 'test-ui-lib',
+    });
+    await storiesGenerator(appTree, {
+      project: 'test-ui-lib',
+      ignorePaths: ['libs/test-ui-lib/src/lib/another-cmp/**'],
+    });
+
+    expect(
+      appTree.exists(
+        'libs/test-ui-lib/src/lib/test-ui-lib/test-ui-lib.stories.tsx'
+      )
+    ).toBeTruthy();
+    expect(
+      appTree.exists(
+        'libs/test-ui-lib/src/lib/another-cmp/another-cmp.stories.tsx'
+      )
+    ).toBeFalsy();
+  });
+
   it('should ignore files that do not contain components', async () => {
     await reactNativeComponentGenerator(appTree, {
       name: 'test-ui-lib',

--- a/packages/react-native/src/generators/stories/stories.ts
+++ b/packages/react-native/src/generators/stories/stories.ts
@@ -5,7 +5,6 @@ import {
   visitNotIgnoredFiles,
 } from '@nrwl/devkit';
 import { join } from 'path';
-
 import componentStoryGenerator from '../component-story/component-story';
 import { StorybookStoriesSchema } from './schema';
 import {
@@ -13,16 +12,23 @@ import {
   projectRootPath,
 } from '@nrwl/react/src/generators/stories/stories';
 import { isTheFileAStory } from '@nrwl/storybook/src/utils/utilities';
+import minimatch = require('minimatch');
 
-export async function createAllStories(tree: Tree, projectName: string) {
+export async function createAllStories(
+  tree: Tree,
+  projectName: string,
+  ignorePaths?: string[]
+) {
   const projects = getProjects(tree);
   const projectConfiguration = projects.get(projectName);
 
-  const { sourceRoot } = projectConfiguration;
+  const { sourceRoot, root } = projectConfiguration;
   const projectPath = projectRootPath(projectConfiguration);
 
   let componentPaths: string[] = [];
   visitNotIgnoredFiles(tree, projectPath, (path) => {
+    if (ignorePaths?.some((pattern) => minimatch(path, pattern))) return;
+
     if (
       (path.endsWith('.tsx') && !path.endsWith('.spec.tsx')) ||
       (path.endsWith('.js') && !path.endsWith('.spec.js')) ||
@@ -62,7 +68,7 @@ export async function storiesGenerator(
   host: Tree,
   schema: StorybookStoriesSchema
 ) {
-  await createAllStories(host, schema.project);
+  await createAllStories(host, schema.project, schema.ignorePaths);
 }
 
 export default storiesGenerator;

--- a/packages/react-native/src/generators/storybook-configuration/configuration.ts
+++ b/packages/react-native/src/generators/storybook-configuration/configuration.ts
@@ -18,6 +18,7 @@ import { StorybookConfigureSchema } from './schema';
 async function generateStories(host: Tree, schema: StorybookConfigureSchema) {
   await storiesGenerator(host, {
     project: schema.name,
+    ignorePaths: schema.ignorePaths,
   });
 }
 

--- a/packages/react-native/src/generators/storybook-configuration/schema.d.ts
+++ b/packages/react-native/src/generators/storybook-configuration/schema.d.ts
@@ -7,4 +7,5 @@ export interface StorybookConfigureSchema {
   tsConfiguration?: boolean;
   linter?: Linter;
   standaloneConfig?: boolean;
+  ignorePaths?: string[];
 }

--- a/packages/react-native/src/generators/storybook-configuration/schema.json
+++ b/packages/react-native/src/generators/storybook-configuration/schema.json
@@ -42,6 +42,21 @@
     "standaloneConfig": {
       "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
       "type": "boolean"
+    },
+    "ignorePaths": {
+      "type": "array",
+      "description": "Paths to ignore when looking for components.",
+      "items": {
+        "type": "string",
+        "description": "Path to ignore."
+      },
+      "examples": [
+        "apps/my-app/src/not-stories/**",
+        "**/**/src/**/not-stories/**",
+        "libs/my-lib/**/*.something.ts",
+        "**/**/src/**/*.other.*",
+        "libs/my-lib/src/not-stories/**,**/**/src/**/*.other.*,apps/my-app/**/*.something.ts"
+      ]
     }
   },
   "required": ["name"]

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-react": "7.30.0",
     "eslint-plugin-react-hooks": "^4.3.0",
+    "minimatch": "3.0.5",
     "react-refresh": "^0.10.0",
     "semver": "7.3.4",
     "url-loader": "^4.1.1",

--- a/packages/react/src/generators/stories/schema.json
+++ b/packages/react/src/generators/stories/schema.json
@@ -29,6 +29,21 @@
       "type": "boolean",
       "description": "Generate JavaScript files rather than TypeScript files.",
       "default": false
+    },
+    "ignorePaths": {
+      "type": "array",
+      "description": "Paths to ignore when looking for components.",
+      "items": {
+        "type": "string",
+        "description": "Path to ignore."
+      },
+      "examples": [
+        "apps/my-app/src/not-stories/**",
+        "**/**/src/**/not-stories/**",
+        "libs/my-lib/**/*.something.ts",
+        "**/**/src/**/*.other.*",
+        "libs/my-lib/src/not-stories/**,**/**/src/**/*.other.*,apps/my-app/**/*.something.ts"
+      ]
     }
   },
   "required": ["project"]

--- a/packages/react/src/generators/stories/stories.app.spec.ts
+++ b/packages/react/src/generators/stories/stories.app.spec.ts
@@ -112,6 +112,147 @@ describe('react:stories for applications', () => {
       `import { ComponentStory, ComponentMeta } from '@storybook/react'`
     );
   });
+
+  describe('ignore paths', () => {
+    beforeEach(() => {
+      appTree.write(
+        'apps/test-ui-app/src/app/test-path/ignore-it/another-one.tsx',
+        `import React from 'react';
+  
+    import './test.scss';
+  
+    export interface TestProps {
+      name: string;
+      displayAge: boolean;
+    }
+  
+    export const Test = (props: TestProps) => {
+      return (
+        <div>
+          <h1>Welcome to test component, {props.name}</h1>
+        </div>
+      );
+    };
+  
+    export default Test;
+    `
+      );
+
+      appTree.write(
+        'apps/test-ui-app/src/app/anothercmp/another-cmp-test.skip.tsx',
+        `import React from 'react';
+  
+    import './test.scss';
+  
+    export interface TestProps {
+      name: string;
+      displayAge: boolean;
+    }
+  
+    export const Test = (props: TestProps) => {
+      return (
+        <div>
+          <h1>Welcome to test component, {props.name}</h1>
+        </div>
+      );
+    };
+  
+    export default Test;
+    `
+      );
+    });
+    it('should generate stories for all if no ignorePaths', async () => {
+      await storiesGenerator(appTree, {
+        project: 'test-ui-app',
+        generateCypressSpecs: false,
+      });
+
+      expect(
+        appTree.exists('apps/test-ui-app/src/app/nx-welcome.stories.tsx')
+      ).toBeTruthy();
+      expect(
+        appTree.exists(
+          'apps/test-ui-app/src/app/anothercmp/another-cmp.stories.tsx'
+        )
+      ).toBeTruthy();
+
+      expect(
+        appTree.exists(
+          'apps/test-ui-app/src/app/test-path/ignore-it/another-one.stories.tsx'
+        )
+      ).toBeTruthy();
+
+      expect(
+        appTree.exists(
+          'apps/test-ui-app/src/app/anothercmp/another-cmp-test.skip.stories.tsx'
+        )
+      ).toBeTruthy();
+    });
+
+    it('should ignore entire paths', async () => {
+      await storiesGenerator(appTree, {
+        project: 'test-ui-app',
+        generateCypressSpecs: false,
+        ignorePaths: [
+          `apps/test-ui-app/src/app/anothercmp/**`,
+          `**/**/src/**/test-path/ignore-it/**`,
+        ],
+      });
+
+      expect(
+        appTree.exists('apps/test-ui-app/src/app/nx-welcome.stories.tsx')
+      ).toBeTruthy();
+      expect(
+        appTree.exists(
+          'apps/test-ui-app/src/app/anothercmp/another-cmp.stories.tsx'
+        )
+      ).toBeFalsy();
+
+      expect(
+        appTree.exists(
+          'apps/test-ui-app/src/app/test-path/ignore-it/another-one.stories.tsx'
+        )
+      ).toBeFalsy();
+
+      expect(
+        appTree.exists(
+          'apps/test-ui-app/src/app/anothercmp/another-cmp-test.skip.stories.tsx'
+        )
+      ).toBeFalsy();
+    });
+
+    it('should ignore path or a pattern', async () => {
+      await storiesGenerator(appTree, {
+        project: 'test-ui-app',
+        generateCypressSpecs: false,
+        ignorePaths: [
+          'apps/test-ui-app/src/app/anothercmp/**/*.skip.*',
+          '**/**/src/**/test-path/**',
+        ],
+      });
+
+      expect(
+        appTree.exists('apps/test-ui-app/src/app/nx-welcome.stories.tsx')
+      ).toBeTruthy();
+      expect(
+        appTree.exists(
+          'apps/test-ui-app/src/app/anothercmp/another-cmp.stories.tsx'
+        )
+      ).toBeTruthy();
+
+      expect(
+        appTree.exists(
+          'apps/test-ui-app/src/app/test-path/ignore-it/another-one.stories.tsx'
+        )
+      ).toBeFalsy();
+
+      expect(
+        appTree.exists(
+          'apps/test-ui-app/src/app/anothercmp/another-cmp-test.skip.stories.tsx'
+        )
+      ).toBeFalsy();
+    });
+  });
 });
 
 export async function createTestUIApp(

--- a/packages/react/src/generators/stories/stories.app.spec.ts
+++ b/packages/react/src/generators/stories/stories.app.spec.ts
@@ -252,6 +252,89 @@ describe('react:stories for applications', () => {
         )
       ).toBeFalsy();
     });
+
+    it('should ignore direct path to component', async () => {
+      await storiesGenerator(appTree, {
+        project: 'test-ui-app',
+        generateCypressSpecs: false,
+        ignorePaths: ['apps/test-ui-app/src/app/anothercmp/**/*.skip.tsx'],
+      });
+
+      expect(
+        appTree.exists('apps/test-ui-app/src/app/nx-welcome.stories.tsx')
+      ).toBeTruthy();
+      expect(
+        appTree.exists(
+          'apps/test-ui-app/src/app/anothercmp/another-cmp.stories.tsx'
+        )
+      ).toBeTruthy();
+
+      expect(
+        appTree.exists(
+          'apps/test-ui-app/src/app/test-path/ignore-it/another-one.stories.tsx'
+        )
+      ).toBeTruthy();
+
+      expect(
+        appTree.exists(
+          'apps/test-ui-app/src/app/anothercmp/another-cmp-test.skip.stories.tsx'
+        )
+      ).toBeFalsy();
+    });
+
+    it('should ignore a path that has a nested component, but still generate nested component stories', async () => {
+      appTree.write(
+        'apps/test-ui-app/src/app/anothercmp/comp-a/comp-a.tsx',
+        `import React from 'react';
+  
+    import './test.scss';
+  
+    export interface TestProps {
+      name: string;
+      displayAge: boolean;
+    }
+  
+    export const Test = (props: TestProps) => {
+      return (
+        <div>
+          <h1>Welcome to test component, {props.name}</h1>
+        </div>
+      );
+    };
+  
+    export default Test;
+    `
+      );
+
+      await storiesGenerator(appTree, {
+        project: 'test-ui-app',
+        generateCypressSpecs: false,
+        ignorePaths: [
+          'apps/test-ui-app/src/app/anothercmp/another-cmp-test.skip.tsx',
+        ],
+      });
+
+      expect(
+        appTree.exists('apps/test-ui-app/src/app/nx-welcome.stories.tsx')
+      ).toBeTruthy();
+      expect(
+        appTree.exists(
+          'apps/test-ui-app/src/app/anothercmp/another-cmp.stories.tsx'
+        )
+      ).toBeTruthy();
+
+      expect(
+        appTree.exists(
+          'apps/test-ui-app/src/app/anothercmp/comp-a/comp-a.stories.tsx'
+        )
+      ).toBeTruthy();
+
+      expect(
+        appTree.exists(
+          'apps/test-ui-app/src/app/anothercmp/another-cmp-test.skip.stories.tsx'
+        )
+      ).toBeFalsy();
+    });
   });
 });
 

--- a/packages/react/src/generators/stories/stories.nextjs.spec.ts
+++ b/packages/react/src/generators/stories/stories.nextjs.spec.ts
@@ -42,6 +42,18 @@ describe('nextjs:stories for applications', () => {
       tree.exists('apps/test-ui-app/components/test.stories.tsx')
     ).toBeTruthy();
   });
+
+  it('should ignore paths', async () => {
+    await storiesGenerator(tree, {
+      project: 'test-ui-app',
+      generateCypressSpecs: false,
+      ignorePaths: ['apps/test-ui-app/components/**'],
+    });
+
+    expect(
+      tree.exists('apps/test-ui-app/components/test.stories.tsx')
+    ).toBeFalsy();
+  });
 });
 
 export async function createTestUIApp(name: string): Promise<Tree> {

--- a/packages/react/src/generators/stories/stories.ts
+++ b/packages/react/src/generators/stories/stories.ts
@@ -19,12 +19,14 @@ import {
   findStorybookAndBuildTargetsAndCompiler,
   isTheFileAStory,
 } from '@nrwl/storybook/src/utils/utilities';
+import minimatch = require('minimatch');
 
 export interface StorybookStoriesSchema {
   project: string;
   generateCypressSpecs: boolean;
   js?: boolean;
   cypressProject?: string;
+  ignorePaths?: string[];
 }
 
 export function projectRootPath(config: ProjectConfiguration): string {
@@ -74,16 +76,19 @@ export async function createAllStories(
   projectName: string,
   generateCypressSpecs: boolean,
   js: boolean,
-  cypressProject?: string
+  cypressProject?: string,
+  ignorePaths?: string[]
 ) {
   const projects = getProjects(tree);
   const projectConfiguration = projects.get(projectName);
-  const { sourceRoot } = projectConfiguration;
+  const { sourceRoot, root } = projectConfiguration;
   let componentPaths: string[] = [];
 
   visitNotIgnoredFiles(tree, projectRootPath(projectConfiguration), (path) => {
     // Ignore private files starting with "_".
     if (basename(path).startsWith('_')) return;
+
+    if (ignorePaths?.some((pattern) => minimatch(path, pattern))) return;
 
     if (
       (path.endsWith('.tsx') && !path.endsWith('.spec.tsx')) ||
@@ -147,7 +152,8 @@ export async function storiesGenerator(
     schema.project,
     schema.generateCypressSpecs,
     schema.js,
-    schema.cypressProject
+    schema.cypressProject,
+    schema.ignorePaths
   );
 }
 

--- a/packages/react/src/generators/storybook-configuration/configuration.ts
+++ b/packages/react/src/generators/storybook-configuration/configuration.ts
@@ -22,6 +22,7 @@ async function generateStories(host: Tree, schema: StorybookConfigureSchema) {
       schema.configureCypress && schema.generateCypressSpecs,
     js: schema.js,
     cypressProject,
+    ignorePaths: schema.ignorePaths,
   });
 }
 

--- a/packages/react/src/generators/storybook-configuration/schema.d.ts
+++ b/packages/react/src/generators/storybook-configuration/schema.d.ts
@@ -10,4 +10,5 @@ export interface StorybookConfigureSchema {
   linter?: Linter;
   cypressDirectory?: string;
   standaloneConfig?: boolean;
+  ignorePaths?: string[];
 }

--- a/packages/react/src/generators/storybook-configuration/schema.json
+++ b/packages/react/src/generators/storybook-configuration/schema.json
@@ -58,6 +58,21 @@
     "standaloneConfig": {
       "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
       "type": "boolean"
+    },
+    "ignorePaths": {
+      "type": "array",
+      "description": "Paths to ignore when looking for components.",
+      "items": {
+        "type": "string",
+        "description": "Path to ignore."
+      },
+      "examples": [
+        "apps/my-app/src/not-stories/**",
+        "**/**/src/**/not-stories/**",
+        "libs/my-lib/**/*.something.ts",
+        "**/**/src/**/*.other.*",
+        "libs/my-lib/src/not-stories/**,**/**/src/**/*.other.*,apps/my-app/**/*.something.ts"
+      ]
     }
   },
   "required": ["name"]


### PR DESCRIPTION
ISSUES CLOSED: #10211

## Current Behavior
User cannot ignore paths/directories when generating stories. They can only ignore individual files (by prepending them with `_`).

## Expected Behavior
Users will now be able to specify paths/directories that will be ignored when generating stories.

```
    "ignorePaths": {
      "type": "array",
      "description": "Paths to ignore when looking for components.",
      "items": {
        "type": "string",
        "description": "Path to ignore."
      },
      "examples": [
        "apps/my-app/src/not-stories/**",
        "**/**/src/**/not-stories/**",
        "libs/my-lib/**/*.something.ts",
        "**/**/src/**/*.other.*",
        "libs/my-lib/src/not-stories/**,**/**/src/**/*.other.*,apps/my-app/**/*.something.ts"
      ]
    }
```

## Related Issue(s)

Fixes #10211
