### PR TITLE
fix(repo): explicitly stop all agents on failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,6 +203,7 @@ jobs:
       - run:
           name: Stop All Running Agents for This CI Run
           command: npx nx-cloud stop-all-agents
+          when: always
 
   # -------------------------
   #     JOBS: Main-MacOS
@@ -243,6 +244,7 @@ jobs:
       - run:
           name: Stop All Running Agents for This CI Run
           command: npx nx-cloud stop-all-agents
+          when: always
 
 # -------------------------
 #        WORKFLOWS(JOBS)


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We don't explicitly start CI runs on our CI. If an error happens before the distributed run was initiated, the agents will keep on spinning until they timeout (60min).

## Expected Behavior
Agents should be killed immediately when CI run fails

## Related Issue(s)
Issue discovered by @rarmatei on https://github.com/nrwl/nx/pull/11113

Fixes #
