### PR TITLE
fix(react): do not set a module federation remote project as the default project

### DIFF
--- a/docs/generated/packages/react.json
+++ b/docs/generated/packages/react.json
@@ -212,6 +212,11 @@
             "description": "The compiler to use.",
             "enum": ["babel", "swc"],
             "default": "babel"
+          },
+          "skipDefaultProject": {
+            "description": "Skip setting the project as the default project. When `false` (the default), the project is set as the default project only if there is no default project already set.",
+            "type": "boolean",
+            "default": false
           }
         },
         "required": [],

--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -4,6 +4,7 @@ import {
   readJson,
   readWorkspaceConfiguration,
   Tree,
+  updateWorkspaceConfiguration,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
@@ -43,6 +44,28 @@ describe('app', () => {
       expect(projects.get('my-app').root).toEqual('apps/my-app');
       expect(projects.get('my-app-e2e').root).toEqual('apps/my-app-e2e');
       expect(workspaceJson.defaultProject).toEqual('my-app');
+    });
+
+    it('should not overwrite default project if already set', async () => {
+      const workspace = readWorkspaceConfiguration(appTree);
+      workspace.defaultProject = 'some-awesome-project';
+      updateWorkspaceConfiguration(appTree, workspace);
+
+      await applicationGenerator(appTree, schema);
+
+      const { defaultProject } = readWorkspaceConfiguration(appTree);
+      expect(defaultProject).toBe('some-awesome-project');
+    });
+
+    it('should not set defaultProject when "--skip-default-project=true"', async () => {
+      await applicationGenerator(appTree, {
+        ...schema,
+        skipDefaultProject: true,
+      });
+
+      const { defaultProject } = readWorkspaceConfiguration(appTree);
+
+      expect(defaultProject).toBeUndefined();
     });
 
     it('should update tags and implicit dependencies', async () => {

--- a/packages/react/src/generators/application/lib/set-defaults.ts
+++ b/packages/react/src/generators/application/lib/set-defaults.ts
@@ -12,7 +12,7 @@ export function setDefaults(host: Tree, options: NormalizedSchema) {
 
   const workspace = readWorkspaceConfiguration(host);
 
-  if (!workspace.defaultProject) {
+  if (!options.skipDefaultProject && !workspace.defaultProject) {
     workspace.defaultProject = options.projectName;
   }
 

--- a/packages/react/src/generators/application/schema.d.ts
+++ b/packages/react/src/generators/application/schema.d.ts
@@ -26,6 +26,7 @@ export interface Schema {
   compiler?: 'babel' | 'swc';
   remotes?: string[];
   devServerPort?: number;
+  skipDefaultProject?: boolean;
 }
 
 export interface NormalizedSchema extends Schema {

--- a/packages/react/src/generators/application/schema.json
+++ b/packages/react/src/generators/application/schema.json
@@ -159,6 +159,11 @@
       "description": "The compiler to use.",
       "enum": ["babel", "swc"],
       "default": "babel"
+    },
+    "skipDefaultProject": {
+      "description": "Skip setting the project as the default project. When `false` (the default), the project is set as the default project only if there is no default project already set.",
+      "type": "boolean",
+      "default": false
     }
   },
   "required": []

--- a/packages/react/src/generators/remote/remote.spec.ts
+++ b/packages/react/src/generators/remote/remote.spec.ts
@@ -1,0 +1,23 @@
+import { readWorkspaceConfiguration } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { Linter } from '@nrwl/linter';
+import remote from './remote';
+
+describe('remote generator', () => {
+  it('should not set the remote as the default project', async () => {
+    const tree = createTreeWithEmptyWorkspace(2);
+
+    await remote(tree, {
+      name: 'test',
+      devServerPort: 4201,
+      e2eTestRunner: 'cypress',
+      linter: Linter.EsLint,
+      skipFormat: false,
+      style: 'css',
+      unitTestRunner: 'jest',
+    });
+
+    const { defaultProject } = readWorkspaceConfiguration(tree);
+    expect(defaultProject).toBeUndefined();
+  });
+});

--- a/packages/react/src/generators/remote/remote.ts
+++ b/packages/react/src/generators/remote/remote.ts
@@ -29,7 +29,10 @@ export function addModuleFederationFiles(
 
 export async function remoteGenerator(host: Tree, schema: Schema) {
   const options = normalizeOptions(host, schema);
-  const initApp = await applicationGenerator(host, options);
+  const initApp = await applicationGenerator(host, {
+    ...options,
+    skipDefaultProject: true,
+  });
 
   if (schema.host) {
     updateHostWithRemote(host, schema.host, options.name);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When creating a Module Federation remote application in a workspace where the default project is not set, the remote is set as the default project.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
A Module Federation remote application is not set as the default project when generated. It doesn't make much sense to have a remote as a default project.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
