### PR TITLE
fix(core): handle specifying a prerelease version without a package when migrating

### DIFF
--- a/packages/nx/src/command-line/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate.spec.ts
@@ -769,6 +769,12 @@ describe('Migration', () => {
         }
       );
       expect(
+        parseMigrationsOptions({ packageAndVersion: '8.12.0-beta.0' })
+      ).toMatchObject({
+        targetPackage: '@nrwl/workspace',
+        targetVersion: '8.12.0-beta.0',
+      });
+      expect(
         parseMigrationsOptions({ packageAndVersion: 'next' })
       ).toMatchObject({
         targetPackage: 'nx',

--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -394,14 +394,14 @@ function parseTargetPackageAndVersion(args: string) {
     }
   } else {
     if (
-      args.match(/^\d+(?:\.\d+)?(?:\.\d+)?$/) ||
       args === 'latest' ||
-      args === 'next'
+      args === 'next' ||
+      valid(args) ||
+      args.match(/^\d+(?:\.\d+)?(?:\.\d+)?$/)
     ) {
       const targetVersion = normalizeVersionWithTagCheck(args);
       const targetPackage =
-        args.match(/^\d+(?:\.\d+)?(?:\.\d+)?$/) &&
-        lt(targetVersion, '14.0.0-beta.0')
+        !['latest', 'next'].includes(args) && lt(targetVersion, '14.0.0-beta.0')
           ? '@nrwl/workspace'
           : 'nx';
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Running `nx migrate` specifying a prerelease version and no package causes the migration to not generate any changes. It wrongly parses the prerelease version as a package name to update to `latest`.

This issue is a regression that was introduced in https://github.com/nrwl/nx/pull/8598 while solving another issue.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Running `nx migrate` specifying a prerelease version and no package should work as expected. The package should be correctly inferred and the prerelease version should be used.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
