### PR TITLE
fix(nx): Ignore the debugger attached message in node

### DIFF
--- a/packages/js/src/utils/swc/compile-swc.ts
+++ b/packages/js/src/utils/swc/compile-swc.ts
@@ -148,10 +148,10 @@ export async function* compileSwcWatch(
       };
 
       stderrOnData = (err?: any) => {
+        process.stderr.write(err);
         if(err.includes("Debugger attached.")) {
           return;
         }
-        process.stderr.write(err);
         next(getResult(false));
       };
 

--- a/packages/js/src/utils/swc/compile-swc.ts
+++ b/packages/js/src/utils/swc/compile-swc.ts
@@ -148,6 +148,9 @@ export async function* compileSwcWatch(
       };
 
       stderrOnData = (err?: any) => {
+        if(err.includes("Debugger attached.")) {
+          return;
+        }
         process.stderr.write(err);
         next(getResult(false));
       };

--- a/packages/js/src/utils/swc/compile-swc.ts
+++ b/packages/js/src/utils/swc/compile-swc.ts
@@ -149,7 +149,7 @@ export async function* compileSwcWatch(
 
       stderrOnData = (err?: any) => {
         process.stderr.write(err);
-        if(err.includes("Debugger attached.")) {
+        if (err.includes('Debugger attached.')) {
           return;
         }
         next(getResult(false));


### PR DESCRIPTION
## Current Behavior
Node will print out `Debugger attached.` to stderr when a debugger is attached, thus marking the build as failed.

## Expected Behavior
The message should be ignored.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #11130
