### PR TITLE
docs(nxdev): add press kit link in footer

### DIFF
--- a/nx-dev/ui-common/src/lib/footer.tsx
+++ b/nx-dev/ui-common/src/lib/footer.tsx
@@ -22,6 +22,10 @@ export function Footer({ useDarkBackground }: FooterProps) {
         href: 'https://nxplaybook.com/?utm_source=nx.dev',
       },
       { name: 'Nrwl', href: 'https://nrwl.io/?utm_source=nx.dev' },
+      {
+        name: 'Press kit',
+        href: 'https://nrwl.io/pages/brands?utm_source=nx.dev',
+      },
     ],
     community: [
       { name: 'Twitter', href: 'https://twitter.com/NXdevtools' },


### PR DESCRIPTION
It adds a link to the press kit on nrwl.io/pages/brands to the footer on nx.dev.