### PR TITLE
fix(storybook): include polyfills in Storybook tsconfig for ngapps

### DIFF
--- a/packages/storybook/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/storybook/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -130,8 +130,17 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
     \\"../../../node_modules/@nrwl/react/typings/cssmodule.d.ts\\",
     \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
   ],
+  
+  
   \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
-  \\"include\\": [\\"../src/**/*\\", \\"*.js\\", \\"*.ts\\" ]
+  \\"include\\": [
+    \\"../src/**/*.stories.ts\\", 
+    \\"../src/**/*.stories.js\\", 
+    \\"../src/**/*.stories.jsx\\", 
+    \\"../src/**/*.stories.tsx\\", 
+    \\"../src/**/*.stories.mdx\\", 
+    \\"*.ts\\",
+    \\"*.js\\"]
 }
 "
 `;
@@ -184,8 +193,17 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
     \\"../../../node_modules/@nrwl/react/typings/cssmodule.d.ts\\",
     \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
   ],
+  
+  
   \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
-  \\"include\\": [\\"../src/**/*\\", \\"*.js\\", \\"*.ts\\" ]
+  \\"include\\": [
+    \\"../src/**/*.stories.ts\\", 
+    \\"../src/**/*.stories.js\\", 
+    \\"../src/**/*.stories.jsx\\", 
+    \\"../src/**/*.stories.tsx\\", 
+    \\"../src/**/*.stories.mdx\\", 
+    \\"*.ts\\",
+    \\"*.js\\"]
 }
 "
 `;
@@ -245,8 +263,17 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
     \\"../../../node_modules/@nrwl/react/typings/cssmodule.d.ts\\",
     \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
   ],
+  
+  
   \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
-  \\"include\\": [\\"../components/**/*\\", \\"*.js\\", \\"*.ts\\" ]
+  \\"include\\": [
+    \\"../components/**/*.stories.ts\\", 
+    \\"../components/**/*.stories.js\\", 
+    \\"../components/**/*.stories.jsx\\", 
+    \\"../components/**/*.stories.tsx\\", 
+    \\"../components/**/*.stories.mdx\\", 
+    \\"*.ts\\",
+    \\"*.js\\"]
 }
 "
 `;
@@ -299,8 +326,17 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
     \\"../../../node_modules/@nrwl/react/typings/cssmodule.d.ts\\",
     \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
   ],
+  
+  
   \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
-  \\"include\\": [\\"../src/**/*\\", \\"*.js\\", \\"*.ts\\" ]
+  \\"include\\": [
+    \\"../src/**/*.stories.ts\\", 
+    \\"../src/**/*.stories.js\\", 
+    \\"../src/**/*.stories.jsx\\", 
+    \\"../src/**/*.stories.tsx\\", 
+    \\"../src/**/*.stories.mdx\\", 
+    \\"*.ts\\",
+    \\"*.js\\"]
 }
 "
 `;
@@ -353,8 +389,17 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
     \\"../../../node_modules/@nrwl/react/typings/cssmodule.d.ts\\",
     \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
   ],
+  
+  
   \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
-  \\"include\\": [\\"../src/**/*\\", \\"*.js\\", \\"*.ts\\" ]
+  \\"include\\": [
+    \\"../src/**/*.stories.ts\\", 
+    \\"../src/**/*.stories.js\\", 
+    \\"../src/**/*.stories.jsx\\", 
+    \\"../src/**/*.stories.tsx\\", 
+    \\"../src/**/*.stories.mdx\\", 
+    \\"*.ts\\",
+    \\"*.js\\"]
 }
 "
 `;
@@ -407,8 +452,17 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
     \\"../../../node_modules/@nrwl/react/typings/cssmodule.d.ts\\",
     \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
   ],
+  
+  
   \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
-  \\"include\\": [\\"../src/**/*\\", \\"*.js\\", \\"*.ts\\" ]
+  \\"include\\": [
+    \\"../src/**/*.stories.ts\\", 
+    \\"../src/**/*.stories.js\\", 
+    \\"../src/**/*.stories.jsx\\", 
+    \\"../src/**/*.stories.tsx\\", 
+    \\"../src/**/*.stories.mdx\\", 
+    \\"*.ts\\",
+    \\"*.js\\"]
 }
 "
 `;
@@ -460,6 +514,7 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
     \\"../../../node_modules/@nrwl/react/typings/cssmodule.d.ts\\",
     \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
   ],
+  
   \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
   \\"include\\": [
     \\"../src/**/*.stories.ts\\", 
@@ -519,6 +574,7 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
     \\"../../../node_modules/@nrwl/react/typings/cssmodule.d.ts\\",
     \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
   ],
+  
   \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
   \\"include\\": [
     \\"../src/**/*.stories.ts\\", 
@@ -585,6 +641,7 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
     \\"../../../node_modules/@nrwl/react/typings/cssmodule.d.ts\\",
     \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
   ],
+  
   \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
   \\"include\\": [
     \\"../components/**/*.stories.ts\\", 
@@ -644,6 +701,7 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
     \\"../../../node_modules/@nrwl/react/typings/cssmodule.d.ts\\",
     \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
   ],
+  
   \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
   \\"include\\": [
     \\"../src/**/*.stories.ts\\", 
@@ -703,6 +761,7 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
     \\"../../../node_modules/@nrwl/react/typings/cssmodule.d.ts\\",
     \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
   ],
+  
   \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
   \\"include\\": [
     \\"../src/**/*.stories.ts\\", 
@@ -762,6 +821,7 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
     \\"../../../node_modules/@nrwl/react/typings/cssmodule.d.ts\\",
     \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
   ],
+  
   \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
   \\"include\\": [
     \\"../src/**/*.stories.ts\\", 

--- a/packages/storybook/src/generators/configuration/project-files-ts/.storybook/tsconfig.json__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files-ts/.storybook/tsconfig.json__tmpl__
@@ -9,6 +9,19 @@
     "<%= offsetFromRoot %>../node_modules/@nrwl/react/typings/cssmodule.d.ts",
     "<%= offsetFromRoot %>../node_modules/@nrwl/react/typings/image.d.ts"
   ],<% } %>
+  <% if(uiFramework === '@storybook/angular') { %>"files": [
+    "<%= offsetFromRoot %>../node_modules/@nrwl/react/typings/styled-jsx.d.ts",
+    "<%= offsetFromRoot %>../node_modules/@nrwl/react/typings/cssmodule.d.ts",
+    "<%= offsetFromRoot %>../node_modules/@nrwl/react/typings/image.d.ts"
+  ],<% } %>
+  <% if(uiFramework === '@storybook/angular' && projectType === 'application') { %>"files": ["../src/polyfills.ts"],<% } %>
   "exclude": ["../**/*.spec.ts" <% if(uiFramework === '@storybook/react') { %>, "../**/*.spec.js", "../**/*.spec.tsx", "../**/*.spec.jsx"<% } %>],
-  "include": ["../<%= mainDir %>/**/*", "*.js", "*.ts" <% if(uiFramework === '@storybook/react-native') { %>, "*.tsx"<% } %>]
+  "include": [
+    "../<%= mainDir %>/**/*.stories.ts", 
+    "../<%= mainDir %>/**/*.stories.js", 
+    "../<%= mainDir %>/**/*.stories.jsx", 
+    "../<%= mainDir %>/**/*.stories.tsx", 
+    "../<%= mainDir %>/**/*.stories.mdx", 
+    "*.ts",
+    "*.js"<% if(uiFramework === '@storybook/react-native') { %>, "*.tsx"<% } %>]
 }

--- a/packages/storybook/src/generators/configuration/project-files/.storybook/tsconfig.json__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files/.storybook/tsconfig.json__tmpl__
@@ -9,6 +9,7 @@
     "<%= offsetFromRoot %>../node_modules/@nrwl/react/typings/cssmodule.d.ts",
     "<%= offsetFromRoot %>../node_modules/@nrwl/react/typings/image.d.ts"
   ],<% } %>
+  <% if(uiFramework === '@storybook/angular' && projectType === 'application') { %>"files": ["../src/polyfills.ts"],<% } %>
   "exclude": ["../**/*.spec.ts" <% if(uiFramework === '@storybook/react') { %>, "../**/*.spec.js", "../**/*.spec.tsx", "../**/*.spec.jsx"<% } %>],
   "include": [
     "../<%= mainDir %>/**/*.stories.ts", 

--- a/packages/storybook/src/generators/configuration/util-functions.ts
+++ b/packages/storybook/src/generators/configuration/util-functions.ts
@@ -330,6 +330,7 @@ export function createProjectStorybookDir(
       uiFramework === '@storybook/angular' ||
       uiFramework === '@storybook/react',
     existsRootWebpackConfig: tree.exists('.storybook/webpack.config.js'),
+    projectType,
     mainDir: isNextJs && projectType === 'application' ? 'components' : 'src',
     isNextJs: isNextJs && projectType === 'application',
     usesSwc,


### PR DESCRIPTION
## Current Behavior
Recent changes to the project-level `.storybook/tsconfig.json` leave out `polyfills.ts` which is by default added in the compliation of an Angular app.


## Expected Behavior
The template for `.storybook/tsconfig.json` should include `polyfills.ts` if it's for an Angular app, so that it works out of the box.

## Related Issue(s)
Fixes #11124
