### PR TITLE
docs(devkit): fix link break in the docs

### DIFF
--- a/docs/shared/generators/modifying-files.md
+++ b/docs/shared/generators/modifying-files.md
@@ -4,7 +4,7 @@ Modifying existing files is an order of magnitude harder than creating new files
 
 ## Compose Existing Generators
 
-If you can compose together existing generators to modify the files you need, you should take that approach. See [Composing Generators](./composing-generators) for more information.
+If you can compose together existing generators to modify the files you need, you should take that approach. See [Composing Generators](/generators/composing-generators) for more information.
 
 ## Modify JSON Files
 


### PR DESCRIPTION
fix the link from generator/modifying-files pages to /generators/composing-generators

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
the link from generator/modifying-files pages to /generators/composing-generators is break

## Expected Behavior
fix the link from generator/modifying-files pages to /generators/composing-generators

## Related Issue(s)
Don't exist issue open

Fixes #
