### PR TITLE
docs(nxdev): remove gray-matter dependency

### DIFF
--- a/nx-dev/feature-doc-viewer/src/lib/content.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/content.tsx
@@ -1,12 +1,11 @@
 import { DocumentData } from '@nrwl/nx-dev/models-document';
 import { renderMarkdown } from '@nrwl/nx-dev/ui-markdoc';
-import { ReactNode } from 'react';
 
 export interface ContentProps {
   document: DocumentData;
 }
 
-export const Content = (props: ContentProps): ReactNode => (
+export const Content = (props: ContentProps): JSX.Element => (
   <div className="min-w-0 flex-auto px-4 pt-8 pb-24 sm:px-6 lg:pb-16 xl:px-8">
     <div className="prose max-w-none">{renderMarkdown(props.document)}</div>
   </div>

--- a/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
@@ -25,10 +25,15 @@ export function DocViewer({
     <>
       <NextSeo
         title={document.data.title + ' | Nx'}
+        description={
+          document.data.description ??
+          'Next generation build system with first class monorepo support and powerful integrations.'
+        }
         openGraph={{
           url: 'https://nx.dev' + router.asPath,
           title: document.data.title,
           description:
+            document.data.description ??
             'Next generation build system with first class monorepo support and powerful integrations.',
           images: [
             {

--- a/nx-dev/models-document/src/lib/documents.models.ts
+++ b/nx-dev/models-document/src/lib/documents.models.ts
@@ -2,7 +2,6 @@ export interface DocumentData {
   filePath: string;
   data: { [key: string]: any };
   content: string;
-  excerpt?: string;
 }
 
 export interface DocumentMetadata {

--- a/nx-dev/ui-markdoc/src/index.ts
+++ b/nx-dev/ui-markdoc/src/index.ts
@@ -1,4 +1,4 @@
-import Markdoc from '@markdoc/markdoc';
+import { parse, renderers, transform, Node } from '@markdoc/markdoc';
 import { DocumentData } from '@nrwl/nx-dev/models-document';
 import React, { ReactNode } from 'react';
 import { Fence } from './lib/nodes/fence.component';
@@ -55,16 +55,15 @@ export const getMarkdocCustomConfig = (
   },
 });
 
+export const parseMarkdown: (markdown: string) => Node = (markdown) =>
+  parse(markdown);
+
 export const renderMarkdown: (document: DocumentData) => ReactNode = (
   document: DocumentData
 ): ReactNode => {
+  const ast = parseMarkdown(document.content.toString());
   const configuration = getMarkdocCustomConfig(document);
-  const ast = Markdoc.parse(document.content.toString());
-  return Markdoc.renderers.react(
-    Markdoc.transform(ast, configuration.config),
-    React,
-    {
-      components: configuration.components,
-    }
-  );
+  return renderers.react(transform(ast, configuration.config), React, {
+    components: configuration.components,
+  });
 };

--- a/nx-dev/ui-markdoc/src/lib/nodes/heading.schema.ts
+++ b/nx-dev/ui-markdoc/src/lib/nodes/heading.schema.ts
@@ -4,8 +4,8 @@ function generateID(
   children: RenderableTreeNode[],
   attributes: Record<string, any>
 ) {
-  if (attributes.id && typeof attributes.id === 'string') {
-    return attributes.id;
+  if (attributes['id'] && typeof attributes['id'] === 'string') {
+    return attributes['id'];
   }
   return children
     .filter((child) => typeof child === 'string')

--- a/nx-dev/ui-markdoc/src/lib/nodes/image.schema.ts
+++ b/nx-dev/ui-markdoc/src/lib/nodes/image.schema.ts
@@ -21,7 +21,6 @@ export const getImageSchema = (document: DocumentData): Schema => ({
 
     return new Tag(
       this.render,
-      // `h${node.attributes['level']}`,
       { ...attributes, src, loading: 'lazy' },
       children
     );

--- a/package.json
+++ b/package.json
@@ -284,7 +284,6 @@
     "fast-glob": "3.2.7",
     "framer-motion": "^4.1.17",
     "glob": "7.1.4",
-    "gray-matter": "^4.0.3",
     "json-schema-to-typescript": "^10.1.5",
     "jsonpointer": "^5.0.0",
     "next": "12.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13693,16 +13693,6 @@ graphlib@^2.1.8:
   dependencies:
     lodash "^4.17.15"
 
-gray-matter@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/gray-matter/-/gray-matter-4.0.3.tgz#e893c064825de73ea1f5f7d88c7a9f7274288798"
-  integrity sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==
-  dependencies:
-    js-yaml "^3.13.1"
-    kind-of "^6.0.2"
-    section-matter "^1.0.0"
-    strip-bom-string "^1.0.0"
-
 handle-thing@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.1.tgz#857f79ce359580c340d43081cc648970d0bb234e"
@@ -21558,14 +21548,6 @@ scss-parser@^1.0.4:
   dependencies:
     invariant "2.2.4"
 
-section-matter@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/section-matter/-/section-matter-1.0.0.tgz#e9041953506780ec01d59f292a19c7b850b84167"
-  integrity sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==
-  dependencies:
-    extend-shallow "^2.0.1"
-    kind-of "^6.0.0"
-
 secure-compare@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/secure-compare/-/secure-compare-3.0.1.tgz#f1a0329b308b221fae37b9974f3d578d0ca999e3"
@@ -22541,11 +22523,6 @@ strip-ansi@^7.0.0:
   integrity sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==
   dependencies:
     ansi-regex "^6.0.1"
-
-strip-bom-string@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/strip-bom-string/-/strip-bom-string-1.0.0.tgz#e5211e9224369fbb81d633a2f00044dc8cedad92"
-  integrity sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==
 
 strip-bom@4.0.0, strip-bom@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
It removes the `gray-matter` dependency previously used to render markdown.