### PR TITLE
chore(core): add dotenv as dependencies for plugins that import it

### DIFF
--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -42,6 +42,7 @@
     "@phenomnomnominal/tsquery": "4.1.1",
     "babel-loader": "^8.0.2",
     "chalk": "4.1.0",
+    "dotenv": "~10.0.0",
     "enhanced-resolve": "^5.8.3",
     "fork-ts-checker-webpack-plugin": "6.2.10",
     "rxjs": "^6.5.4",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -38,6 +38,7 @@
     "@nrwl/devkit": "file:../devkit",
     "@phenomnomnominal/tsquery": "4.1.1",
     "chalk": "4.1.0",
+    "dotenv": "~10.0.0",
     "identity-obj-proxy": "3.0.0",
     "jest-config": "27.5.1",
     "jest-resolve": "27.5.1",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -43,6 +43,7 @@
     "@nrwl/workspace": "file:../workspace",
     "@svgr/webpack": "^6.1.2",
     "chalk": "4.1.0",
+    "dotenv": "~10.0.0",
     "eslint-config-next": "^12.1.0",
     "fs-extra": "^10.1.0",
     "ts-node": "~10.8.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -37,6 +37,7 @@
     "@nrwl/workspace": "file:../workspace",
     "chalk": "4.1.0",
     "copy-webpack-plugin": "^9.0.1",
+    "dotenv": "~10.0.0",
     "enhanced-resolve": "^5.8.3",
     "fork-ts-checker-webpack-plugin": "6.2.10",
     "fs-extra": "^10.1.0",

--- a/packages/nx-plugin/package.json
+++ b/packages/nx-plugin/package.json
@@ -31,6 +31,7 @@
     "@nrwl/jest": "file:../jest",
     "@nrwl/js": "file:../js",
     "@nrwl/linter": "file:../linter",
+    "dotenv": "~10.0.0",
     "fs-extra": "^10.1.0",
     "rxjs": "^6.5.4",
     "semver": "7.3.4",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -34,6 +34,7 @@
     "@nrwl/linter": "file:../linter",
     "@nrwl/workspace": "file:../workspace",
     "core-js": "^3.6.5",
+    "dotenv": "~10.0.0",
     "semver": "7.3.4",
     "ts-loader": "^9.2.6",
     "tsconfig-paths-webpack-plugin": "3.5.2"

--- a/scripts/depcheck/missing.ts
+++ b/scripts/depcheck/missing.ts
@@ -2,15 +2,7 @@ import * as depcheck from 'depcheck';
 
 // Ignore packages that are defined here per package
 const IGNORE_MATCHES = {
-  '*': [
-    'nx',
-    '@nrwl/cli',
-    '@nrwl/workspace',
-    'prettier',
-    'typescript',
-    'dotenv',
-    'rxjs',
-  ],
+  '*': ['nx', '@nrwl/cli', '@nrwl/workspace', 'prettier', 'typescript', 'rxjs'],
   angular: [
     '@angular-devkit/architect',
     '@angular-devkit/build-angular',


### PR DESCRIPTION
We are importing `dotenv` in our plugins, but the dependency is missing from `package.json` files. This may lead errors due to how packages are hoisted.

Unlike packages such as `typescript` and `rxjs`, which rely on the workspace having those dependencies in their `pacakge.json` file, we never install `dotenv` to the workspace, thus it is required in the plugin's `package.json` files.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
