### PR TITLE
fix(nextjs): set development outputPath to a different one from production build

### DIFF
--- a/packages/next/migrations.json
+++ b/packages/next/migrations.json
@@ -84,6 +84,12 @@
       "version": "14.0.0-beta.0",
       "description": "Add a default development configuration for build and serve targets.",
       "factory": "./src/migrations/update-14-0-0/add-default-development-configurations"
+    },
+    "add-dev-output-path": {
+      "cli": "nx",
+      "version": "14.4.3-beta.0",
+      "description": "Add a development outputPath to avoid conflict with the production build.",
+      "factory": "./src/migrations/update-14-4-3/add-dev-output-path"
     }
   },
   "packageJsonUpdates": {

--- a/packages/next/src/generators/application/lib/add-project.ts
+++ b/packages/next/src/generators/application/lib/add-project.ts
@@ -18,7 +18,9 @@ export function addProject(host: Tree, options: NormalizedSchema) {
       outputPath: joinPathFragments('dist', options.appProjectRoot),
     },
     configurations: {
-      development: {},
+      development: {
+        outputPath: joinPathFragments('tmp', options.appProjectRoot),
+      },
       production: {},
     },
   };

--- a/packages/next/src/migrations/update-14-4-3/add-dev-output-path.spec.ts
+++ b/packages/next/src/migrations/update-14-4-3/add-dev-output-path.spec.ts
@@ -1,0 +1,68 @@
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import {
+  addProjectConfiguration,
+  readProjectConfiguration,
+} from '@nrwl/devkit';
+import update from './add-dev-output-path';
+
+describe('React default development configuration', () => {
+  it('should add output path if it does not alreayd exist', async () => {
+    const tree = createTreeWithEmptyWorkspace(2);
+    addProjectConfiguration(
+      tree,
+      'example',
+      {
+        root: 'apps/example',
+        sourceRoot: 'apps/example',
+        projectType: 'application',
+        targets: {
+          build: {
+            executor: '@nrwl/next:build',
+            configurations: {
+              development: {},
+            },
+          },
+        },
+      },
+      true
+    );
+
+    await update(tree);
+
+    const config = readProjectConfiguration(tree, 'example');
+
+    expect(config.targets.build.configurations.development.outputPath).toEqual(
+      'tmp/apps/example'
+    );
+  });
+
+  it('should skip update if outputPath already exists for development', async () => {
+    const tree = createTreeWithEmptyWorkspace(2);
+    addProjectConfiguration(
+      tree,
+      'example',
+      {
+        root: 'apps/example',
+        sourceRoot: 'apps/example',
+        projectType: 'application',
+        targets: {
+          build: {
+            executor: '@nrwl/next:build',
+            configurations: {
+              development: { outputPath: '/tmp/some/custom/path' },
+            },
+          },
+        },
+      },
+      true
+    );
+
+    await update(tree);
+
+    const config = readProjectConfiguration(tree, 'example');
+
+    expect(config.targets.build.configurations.development.outputPath).toEqual(
+      '/tmp/some/custom/path'
+    );
+  });
+});

--- a/packages/next/src/migrations/update-14-4-3/add-dev-output-path.ts
+++ b/packages/next/src/migrations/update-14-4-3/add-dev-output-path.ts
@@ -1,0 +1,25 @@
+import {
+  formatFiles,
+  getProjects,
+  joinPathFragments,
+  Tree,
+  updateProjectConfiguration,
+} from '@nrwl/devkit';
+
+export async function update(tree: Tree) {
+  const projects = getProjects(tree);
+
+  projects.forEach((config, name) => {
+    if (config.targets?.build?.executor === '@nrwl/next:build') {
+      config.targets.build.configurations ??= {};
+      config.targets.build.configurations.development ??= {};
+      config.targets.build.configurations.development.outputPath ??=
+        joinPathFragments('tmp', config.sourceRoot);
+      updateProjectConfiguration(tree, name, config);
+    }
+  });
+
+  await formatFiles(tree);
+}
+
+export default update;


### PR DESCRIPTION
This PR makes it so the development `outputPath` is different from production. This allows the production cache to remain correct even after dev server is run.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

Running

```
nx  build demo
nx  serve demo
nx build demo
```

results in wrong cache content in outputPath due to the dev server writing to the same location,  and Nx thinks nothing has changed.

## Expected Behavior
Running the above commands should result in correct prod build so users can run `nx serve --prod demo`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #10312
