### PR TITLE
fix(storybook): adjusted STORYBOOK_

### DIFF
--- a/packages/react/plugins/storybook/index.ts
+++ b/packages/react/plugins/storybook/index.ts
@@ -18,7 +18,7 @@ function getClientEnvironment(mode) {
   // Grab NODE_ENV and NX_* and STORYBOOK_* environment variables and prepare them to be
   // injected into the application via DefinePlugin in webpack configuration.
   const NX_PREFIX = /^NX_/i;
-  const STORYBOOK_PREFIX = /^STORYBOOK__/i;
+  const STORYBOOK_PREFIX = /^STORYBOOK_/i;
 
   const raw = Object.keys(process.env)
     .filter((key) => NX_PREFIX.test(key) || STORYBOOK_PREFIX.test(key))


### PR DESCRIPTION
Corrected the `STORYBOOK_` RegExp to match documentation
https://storybook.js.org/docs/react/configure/environment-variable

## Current Behavior
All `STORYBOOK_` environment variables are not being passed unless they have double underscores.

## Expected Behavior
All `STORYBOOK_` environment variables should be available due to the Storybook documentation.
