### PR TITLE
feat(angular): deprecate syntax option from the ngrx generator

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -1467,7 +1467,8 @@
             "type": "string",
             "enum": ["classes", "creators"],
             "default": "creators",
-            "description": "Specifies whether to use class-based or creator functions for actions, reducers, and effects."
+            "description": "Specifies whether to use class-based or creator functions for actions, reducers, and effects.",
+            "x-deprecated": "Classes syntax is deprecated and this option will be removed in v15. Creators syntax will be the default in v15 and this option will be removed."
           },
           "useDataPersistence": {
             "type": "boolean",

--- a/docs/shared/guides/misc-ngrx.md
+++ b/docs/shared/guides/misc-ngrx.md
@@ -36,7 +36,6 @@ The `name` and the `--module=` arguments are required. The `no-interactive` opti
 The most common additional options are:
 
 - `root` - Set up the initial NgModule imports for NgRx Store, Effects, Router-Store, and Store DevTools.
-- `syntax` - NgRx introduced new creator functions for actions, reducers, and effects that provide the same type-safety with less code than action classes.
 - `facade` - Optional. If you prefer to further encapsulate NgRx from your components, add an injectable facade. See the blog [Better State Management with Facades](https://blog.nrwl.io/nrwl-nx-6-2-angular-6-1-and-better-state-management-e139da2cd074#cb93) for details.
 
 See the [API Docs](/packages/angular/generators/ngrx) for detailed descriptions of all the available options. Also visit the [NgRx](https://ngrx.io) website for more guides and documentation about the libraries.

--- a/packages/angular/src/generators/ngrx/schema.d.ts
+++ b/packages/angular/src/generators/ngrx/schema.d.ts
@@ -3,12 +3,20 @@ export interface NgRxGeneratorOptions {
   minimal: boolean;
   module: string;
   name: string;
-  useDataPersistence: boolean;
   barrels?: boolean;
   facade?: boolean;
   root?: boolean;
   skipFormat?: boolean;
   skipImport?: boolean;
   skipPackageJson?: boolean;
+  /**
+   * @deprecated This option is deprecated and will be removed in v15.
+   * Using the individual operators is recommended.
+   */
+  useDataPersistence?: boolean;
+  /**
+   * @deprecated Always use the `creators` value. The `classes` syntax is
+   * deprecated and this option will be removed in v15.
+   */
   syntax?: 'classes' | 'creators';
 }

--- a/packages/angular/src/generators/ngrx/schema.json
+++ b/packages/angular/src/generators/ngrx/schema.json
@@ -61,7 +61,8 @@
       "type": "string",
       "enum": ["classes", "creators"],
       "default": "creators",
-      "description": "Specifies whether to use class-based or creator functions for actions, reducers, and effects."
+      "description": "Specifies whether to use class-based or creator functions for actions, reducers, and effects.",
+      "x-deprecated": "Classes syntax is deprecated and this option will be removed in v15. Creators syntax will be the default in v15 and this option will be removed."
     },
     "useDataPersistence": {
       "type": "boolean",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The `@nrwl/angular:ngrx` generator allows to select the desired syntax (classes, creators) for creating actions, effects, etc. The NgRx classes syntax [has been deprecated](https://ngrx.io/guide/migration/v11#the-effect-decorator) for a while now.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Deprecate the `syntax` option.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
