### PR TITLE
cleanup(misc): consolidate tslib version in generated projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -239,7 +239,6 @@
     "ts-node": "10.8.1",
     "tsconfig-paths": "^3.9.0",
     "tsconfig-paths-webpack-plugin": "3.5.2",
-    "tslib": "^2.3.0",
     "tslint": "6.1.3",
     "tslint-to-eslint-config": "^2.13.0",
     "typedoc": "0.22.9",

--- a/packages/angular/src/generators/init/init.ts
+++ b/packages/angular/src/generators/init/init.ts
@@ -17,6 +17,7 @@ import {
   jestPresetAngularVersion,
   rxjsVersion,
   tsNodeVersion,
+  tsLibVersion,
 } from '../../utils/versions';
 import { karmaGenerator } from '../karma/karma';
 import { Schema } from './schema';
@@ -109,7 +110,7 @@ function updateDependencies(host: Tree): GeneratorCallback {
       '@angular/platform-browser-dynamic': angularVersion,
       '@angular/router': angularVersion,
       rxjs: rxjsVersion,
-      tslib: '^2.0.0',
+      tslib: tsLibVersion,
       'zone.js': '~0.11.4',
     },
     {

--- a/packages/angular/src/utils/versions.ts
+++ b/packages/angular/src/utils/versions.ts
@@ -10,4 +10,5 @@ export const angularEslintVersion = '~14.0.0';
 export const tailwindVersion = '^3.0.2';
 export const postcssVersion = '^8.4.5';
 export const autoprefixerVersion = '^10.4.0';
+export const tsLibVersion = '^2.3.0';
 export const tsNodeVersion = '~10.8.0';

--- a/packages/nest/src/generators/init/lib/add-dependencies.ts
+++ b/packages/nest/src/generators/init/lib/add-dependencies.ts
@@ -9,6 +9,7 @@ import {
   reflectMetadataVersion,
   rxjsVersion6,
   rxjsVersion7,
+  tsLibVersion,
 } from '../../../utils/versions';
 
 export function addDependencies(tree: Tree): GeneratorCallback {
@@ -42,7 +43,7 @@ export function addDependencies(tree: Tree): GeneratorCallback {
       '@nestjs/platform-express': NEST_VERSION,
       'reflect-metadata': reflectMetadataVersion,
       rxjs: RXJS,
-      tslib: '^2.0.0',
+      tslib: tsLibVersion,
     },
     {
       '@nestjs/schematics': nestJsSchematicsVersion,

--- a/packages/nest/src/utils/versions.ts
+++ b/packages/nest/src/utils/versions.ts
@@ -9,3 +9,5 @@ export const rxjsVersion6 = '~6.6.3';
 export const rxjsVersion7 = '^7.0.0';
 
 export const reflectMetadataVersion = '^0.1.13';
+
+export const tsLibVersion = '^2.3.0';

--- a/packages/next/src/generators/init/init.ts
+++ b/packages/next/src/generators/init/init.ts
@@ -14,6 +14,7 @@ import {
   eslintConfigNextVersion,
   nextVersion,
   nxVersion,
+  tsLibVersion,
 } from '../../utils/versions';
 import { InitSchema } from './schema';
 
@@ -25,7 +26,7 @@ function updateDependencies(host: Tree) {
       next: nextVersion,
       react: reactVersion,
       'react-dom': reactDomVersion,
-      tslib: '^2.0.0',
+      tslib: tsLibVersion,
     },
     {
       'eslint-config-next': eslintConfigNextVersion,

--- a/packages/next/src/utils/versions.ts
+++ b/packages/next/src/utils/versions.ts
@@ -7,3 +7,4 @@ export const lessLoader = '11.0.0';
 export const stylusLoader = '7.0.0';
 export const emotionServerVersion = '11.4.0';
 export const babelPluginStyledComponentsVersion = '1.10.7';
+export const tsLibVersion = '^2.3.0';

--- a/packages/node/src/utils/versions.ts
+++ b/packages/node/src/utils/versions.ts
@@ -1,5 +1,5 @@
 export const nxVersion = require('../../package.json').version;
 
-export const tslibVersion = '^2.0.0';
+export const tslibVersion = '^2.3.0';
 
 export const typesNodeVersion = '18.0.0';

--- a/packages/nx-plugin/src/generators/plugin/plugin.ts
+++ b/packages/nx-plugin/src/generators/plugin/plugin.ts
@@ -15,7 +15,7 @@ import { addSwcDependencies } from '@nrwl/js/src/utils/swc/add-swc-dependencies'
 import { swcNodeVersion } from 'nx/src/utils/versions';
 import * as path from 'path';
 
-import { nxVersion } from '../../utils/versions';
+import { nxVersion, tsLibVersion } from '../../utils/versions';
 import { e2eProjectGenerator } from '../e2e-project/e2e';
 import { executorGenerator } from '../executor/executor';
 import { generatorGenerator } from '../generator/generator';
@@ -105,7 +105,7 @@ export async function pluginGenerator(host: Tree, schema: Schema) {
       '@nrwl/jest': nxVersion,
       '@nrwl/js': nxVersion,
       '@swc-node/register': swcNodeVersion,
-      tslib: '^2.0.0',
+      tslib: tsLibVersion,
     }
   );
 

--- a/packages/nx-plugin/src/utils/versions.ts
+++ b/packages/nx-plugin/src/utils/versions.ts
@@ -1,2 +1,3 @@
 export const nxVersion = require('../../package.json').version;
 export const jsoncEslintParserVersion = '^2.1.0';
+export const tsLibVersion = '^2.3.0';

--- a/packages/react/src/generators/init/init.ts
+++ b/packages/react/src/generators/init/init.ts
@@ -17,6 +17,7 @@ import {
   reactTestRendererVersion,
   reactVersion,
   testingLibraryReactVersion,
+  tsLibVersion,
   typesNodeVersion,
   typesReactDomVersion,
   typesReactVersion,
@@ -52,7 +53,7 @@ function updateDependencies(host: Tree) {
       react: reactVersion,
       'react-dom': reactDomVersion,
       'regenerator-runtime': '0.13.7',
-      tslib: '^2.0.0',
+      tslib: tsLibVersion,
     },
     {
       '@nrwl/react': nxVersion,

--- a/packages/react/src/utils/versions.ts
+++ b/packages/react/src/utils/versions.ts
@@ -34,3 +34,5 @@ export const eslintPluginReactVersion = '7.30.1';
 export const eslintPluginReactHooksVersion = '4.6.0';
 
 export const babelPluginStyledComponentsVersion = '1.10.7';
+
+export const tsLibVersion = '^2.3.0';

--- a/packages/web/src/generators/init/init.ts
+++ b/packages/web/src/generators/init/init.ts
@@ -10,7 +10,11 @@ import {
 } from '@nrwl/devkit';
 import { jestInitGenerator } from '@nrwl/jest';
 import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
-import { nxVersion, typesNodeVersion } from '../../utils/versions';
+import {
+  nxVersion,
+  tsLibVersion,
+  typesNodeVersion,
+} from '../../utils/versions';
 import { Schema } from './schema';
 
 function updateDependencies(tree: Tree) {
@@ -21,7 +25,7 @@ function updateDependencies(tree: Tree) {
     {
       'core-js': '^3.6.5',
       'regenerator-runtime': '0.13.7',
-      tslib: '^2.0.0',
+      tslib: tsLibVersion,
     },
     {
       '@nrwl/web': nxVersion,

--- a/packages/web/src/utils/versions.ts
+++ b/packages/web/src/utils/versions.ts
@@ -2,3 +2,4 @@ export const nxVersion = require('../../package.json').version;
 
 export const swcLoaderVersion = '0.1.15';
 export const typesNodeVersion = '18.0.0';
+export const tsLibVersion = '^2.3.0';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When generating projects, some official plugins add the `tslib` package to the `package.json` with a version `^2.0.0`, while others do it with `^2.3.0`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When generating projects, all official plugins should add the `tslib` package to the `package.json` with the version `^2.3.0`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
