### PR TITLE
cleanup(devkit): use `Mode` type from `fs` for `Tree` permissions

### DIFF
--- a/packages/devkit/src/utils/invoke-nx-generator.ts
+++ b/packages/devkit/src/utils/invoke-nx-generator.ts
@@ -7,7 +7,8 @@ import type {
 import { toNewFormat, toOldFormatOrNull } from 'nx/src/config/workspaces';
 import { Generator, GeneratorCallback } from 'nx/src/config/misc-interfaces';
 import { parseJson, serializeJson } from 'nx/src/utils/json';
-import { join, relative, dirname } from 'path';
+import { join, relative } from 'path';
+import type { Mode } from 'fs';
 
 class RunCallbackTask {
   constructor(private callback: GeneratorCallback) {}
@@ -214,14 +215,11 @@ class DevkitTreeFromAngularDevkitTree implements Tree {
     }
   }
 
-  changePermissions(filePath: string, mode: string | number): void {
+  changePermissions(filePath: string, mode: Mode): void {
     this.warnUnsupportedFilePermissionsChange(filePath, mode);
   }
 
-  private warnUnsupportedFilePermissionsChange(
-    filePath: string,
-    mode: string | number
-  ) {
+  private warnUnsupportedFilePermissionsChange(filePath: string, mode: Mode) {
     logger.warn(
       stripIndent(`The Angular DevKit tree does not support changing a file permissions.
                   Ignoring changing ${filePath} permissions to ${mode}.`)

--- a/packages/nx/src/generators/tree.spec.ts
+++ b/packages/nx/src/generators/tree.spec.ts
@@ -1,4 +1,4 @@
-import { lstatSync, readFileSync, writeFileSync } from 'fs';
+import { lstatSync, Mode, readFileSync, writeFileSync } from 'fs';
 import { removeSync, ensureDirSync } from 'fs-extra';
 import { dirSync } from 'tmp';
 import * as path from 'path';
@@ -473,7 +473,7 @@ describe('tree', () => {
     });
   }
 
-  function octal(value: string | number): number {
+  function octal(value: Mode): number {
     if (typeof value === 'string') return parseInt(value, 8);
     return value;
   }

--- a/packages/nx/src/generators/tree.ts
+++ b/packages/nx/src/generators/tree.ts
@@ -7,6 +7,7 @@ import {
   removeSync,
   chmodSync,
 } from 'fs-extra';
+import type { Mode } from 'fs';
 import { logger } from '../utils/logger';
 import { dirname, join, relative, sep } from 'path';
 import * as chalk from 'chalk';
@@ -20,7 +21,7 @@ export interface TreeWriteOptions {
    * The logical OR operator can be used to separate multiple permissions.
    * See https://nodejs.org/api/fs.html#fs_file_modes
    */
-  mode?: string | number;
+  mode?: Mode;
 }
 
 /**
@@ -90,7 +91,7 @@ export interface Tree {
    * @param mode The permission to be granted on the file, given as a string (e.g `755`) or octal integer (e.g `0o755`).
    * See https://nodejs.org/api/fs.html#fs_file_modes.
    */
-  changePermissions(filePath: string, mode: string | number): void;
+  changePermissions(filePath: string, mode: Mode): void;
 }
 
 /**
@@ -280,7 +281,7 @@ export class FsTree implements Tree {
     return res;
   }
 
-  changePermissions(filePath: string, mode: string | number): void {
+  changePermissions(filePath: string, mode: Mode): void {
     filePath = this.normalize(filePath);
     const filePathChangeKey = this.rp(filePath);
     if (this.recordedChanges[filePathChangeKey]) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
