### PR TITLE
fix(angular): add @angular/localize to list of default packages to be eagerly loaded in mf apps

### DIFF
--- a/packages/angular/src/utils/mf/with-module-federation.ts
+++ b/packages/angular/src/utils/mf/with-module-federation.ts
@@ -224,7 +224,10 @@ function applyAdditionalShared(
 function applyDefaultEagerPackages(
   sharedConfig: Record<string, SharedLibraryConfig>
 ) {
-  const DEFAULT_PACKAGES_TO_LOAD_EAGERLY = ['@angular/localize/init'];
+  const DEFAULT_PACKAGES_TO_LOAD_EAGERLY = [
+    '@angular/localize',
+    '@angular/localize/init',
+  ];
   for (const pkg of DEFAULT_PACKAGES_TO_LOAD_EAGERLY) {
     sharedConfig[pkg] = {
       ...(sharedConfig[pkg] ?? {}),


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
A Module Federation application using `@angular/localize` fails with a runtime error about the shared module not being available for eager consumption.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Add `@angular/localize` to the list of default packages to be loaded eagerly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #11121 
