### PR TITLE
fix(testing): correctly migrate plugins file if present

### DIFF
--- a/packages/cypress/src/generators/migrate-to-cypress-ten/__snapshots__/migrate-to-cypress-ten.spec.ts.snap
+++ b/packages/cypress/src/generators/migrate-to-cypress-ten/__snapshots__/migrate-to-cypress-ten.spec.ts.snap
@@ -202,7 +202,7 @@ Object {
 exports[`convertToCypressTen convertCypressProject should update project w/customized config 1`] = `
 "import { defineConfig } from 'cypress'
 import { nxE2EPreset } from '@nrwl/cypress/plugins/cypress-preset';
-import setupNodeEvents from './src/plugins/index.js';
+import setupNodeEvents from './src/plugins/index';
 
 const cypressJsonConfig = {
 \\"fileServerFolder\\": \\".\\",

--- a/packages/cypress/src/generators/migrate-to-cypress-ten/migrate-to-cypress-ten.ts
+++ b/packages/cypress/src/generators/migrate-to-cypress-ten/migrate-to-cypress-ten.ts
@@ -4,6 +4,7 @@ import {
   installPackagesTask,
   joinPathFragments,
   logger,
+  ProjectConfiguration,
   readProjectConfiguration,
   stripIndents,
   Tree,
@@ -11,12 +12,15 @@ import {
   updateProjectConfiguration,
 } from '@nrwl/devkit';
 import { forEachExecutorOptions } from '@nrwl/workspace/src/utilities/executor-options-utils';
+import { tsquery } from '@phenomnomnominal/tsquery';
+import { extname } from 'path';
 import { CypressExecutorOptions } from '../../executors/cypress/cypress.impl';
 import { cypressVersion } from '../../utils/versions';
 import {
   addConfigToTsConfig,
   createNewCypressConfig,
   findCypressConfigs,
+  updatePluginFile,
   updateProjectPaths,
   writeNewConfig,
 } from './conversion.util';
@@ -39,13 +43,18 @@ export async function migrateCypressProject(tree: Tree) {
           tree.exists(cypressConfigPathJson) &&
           !tree.exists(cypressConfigPathTs)
         ) {
-          const cypressConfigs = createNewCypressConfig(
+          let cypressConfigs = createNewCypressConfig(
             tree,
             projectConfig,
             cypressConfigPathJson
           );
 
           updateProjectPaths(tree, projectConfig, cypressConfigs);
+          cypressConfigs = updatePluginFile(
+            tree,
+            projectConfig,
+            cypressConfigs
+          );
           writeNewConfig(tree, cypressConfigPathTs, cypressConfigs);
           addConfigToTsConfig(
             tree,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
when a plugin file is being migrated it's imported as `./src/plugins/index.ts` (with extension) and a when it's a ts file, there is an editor error about no default export

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
imported plugin file without file extension and update ts `module.exports` to ts export if a ts file
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
