### PR TITLE
fix(core): use proper package manager when installing package for migration

### DIFF
--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -25,6 +25,7 @@ import {
 } from '../utils/package-json';
 import {
   createTempNpmDirectory,
+  detectPackageManager,
   getPackageManagerCommand,
   packageRegistryPack,
   packageRegistryView,
@@ -653,7 +654,7 @@ async function getPackageMigrationsUsingInstall(
   let result: ResolvedMigrationConfiguration;
 
   try {
-    const pmc = getPackageManagerCommand();
+    const pmc = getPackageManagerCommand(detectPackageManager(dir));
 
     await execAsync(`${pmc.add} ${packageName}@${packageVersion}`, {
       cwd: dir,


### PR DESCRIPTION
## Current Behavior
`nx migrate latest` fails in pnpm workspace

```l
Fetching meta data about packages.
It may take a few minutes.
Fetching nx@14.4.3
Fetching nx@latest

 ERROR  The migrate command failed.


 >  NX   Command failed: pnpm add -w nx@latest

   
   Pass --verbose to see the stacktrace.
```

## Expected Behavior
`nx migrate latest` should works fine

## Related Issue(s)
by detecting pnpm workspace in https://github.com/nrwl/nx/pull/11025 migrations are not working in pnpm workspaces
