### PR TITLE
fix(node): add flag to skip calculate resolve mappings for yarn works…

### DIFF
--- a/docs/generated/packages/node.json
+++ b/docs/generated/packages/node.json
@@ -580,6 +580,11 @@
             "type": "boolean",
             "description": "Enable re-building when files change.",
             "default": true
+          },
+          "skipCalculateMappings": {
+            "type": "boolean",
+            "description": "Skip logic of resolving mappings for Nx workspaces. Yarn/NPM/PNPM workspaces where packages are installed as node_modules can disable this",
+            "default": false
           }
         },
         "additionalProperties": false,

--- a/packages/node/src/executors/node/node.impl.ts
+++ b/packages/node/src/executors/node/node.impl.ts
@@ -50,7 +50,9 @@ export async function* nodeExecutor(
     }
   }
 
-  const mappings = calculateResolveMappings(context, options);
+  const mappings = options.skipCalculateMappings
+    ? {}
+    : calculateResolveMappings(context, options);
   for await (const event of startBuild(options, context)) {
     if (!event.success) {
       logger.error('There was an error with the build. See above.');

--- a/packages/node/src/executors/node/schema.d.ts
+++ b/packages/node/src/executors/node/schema.d.ts
@@ -13,4 +13,5 @@ export interface NodeExecutorOptions {
   host: string;
   port: number;
   watch?: boolean;
+  skipCalculateMappings?: boolean;
 }

--- a/packages/node/src/executors/node/schema.json
+++ b/packages/node/src/executors/node/schema.json
@@ -65,6 +65,11 @@
       "type": "boolean",
       "description": "Enable re-building when files change.",
       "default": true
+    },
+    "skipCalculateMappings": {
+      "type": "boolean",
+      "description": "Skip logic of resolving mappings for Nx workspaces. Yarn/NPM/PNPM workspaces where packages are installed as node_modules can disable this",
+      "default": false
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
…paces and the likes

ISSUES CLOSED: #11221

## Current Behavior
For workspaces that add libraries by linking in `node_modules` (yarn workspaces etc...) with specific versions rather than the latest, `calculateResolveMappings` in `nrwl/node:node` does not respect this

## Expected Behavior
Add a flag `skipCalculateMappings` for `nrwl/node:node` executor so users of these types of workspaces can skip this logic

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #11221 
