### PR TITLE
feat(core): add support for non-destructive renames in `tree.rename`

### DIFF
--- a/packages/nx/src/generators/tree.spec.ts
+++ b/packages/nx/src/generators/tree.spec.ts
@@ -269,14 +269,14 @@ describe('tree', () => {
           type: 'RENAME',
           content: null,
           origin: 'parent/new-child/new-child-file.txt',
-          options: { mode: 'fs' }
+          options: { mode: 'fs' },
         },
         {
           path: 'renamed-root-file.txt',
           type: 'RENAME',
           content: null,
           origin: 'root-file.txt',
-          options: { mode: 'fs' }
+          options: { mode: 'fs' },
         },
       ]);
 
@@ -399,12 +399,14 @@ describe('tree', () => {
       tree.rename('parent/child', 'parent/new-child');
 
       expect(tree.children('parent')).toEqual([
-        "parent-file-with-write-options.txt",
-        "parent-file.txt",
+        'parent-file-with-write-options.txt',
+        'parent-file.txt',
         'new-child',
       ]);
       expect(tree.children('parent/new-child')).toEqual(['child-file.txt']);
-      expect(tree.read('parent/new-child/child-file.txt', 'utf-8')).toEqual('The child content');
+      expect(tree.read('parent/new-child/child-file.txt', 'utf-8')).toEqual(
+        'The child content'
+      );
 
       expect(s(tree.listChanges())).toEqual([
         {
@@ -447,15 +449,17 @@ describe('tree', () => {
         execSync('git add parent/child/child-file.txt');
 
         tree.rename('parent/child', 'parent/new-child');
-  
+
         expect(tree.children('parent')).toEqual([
-          "parent-file-with-write-options.txt",
-          "parent-file.txt",
-          "new-child",
+          'parent-file-with-write-options.txt',
+          'parent-file.txt',
+          'new-child',
         ]);
         expect(tree.children('parent/new-child')).toEqual(['child-file.txt']);
-        expect(tree.read('parent/new-child/child-file.txt', 'utf-8')).toEqual('The child content');
-  
+        expect(tree.read('parent/new-child/child-file.txt', 'utf-8')).toEqual(
+          'The child content'
+        );
+
         const changes = tree.listChanges();
 
         expect(s(changes)).toEqual([
@@ -478,16 +482,18 @@ describe('tree', () => {
             origin: 'parent/child/child-file.txt',
           },
         ]);
-  
+
         flushChanges(dir, changes);
 
         expect(tree.children('parent')).toEqual([
-          "new-child",
-          "parent-file-with-write-options.txt",
-          "parent-file.txt",
+          'new-child',
+          'parent-file-with-write-options.txt',
+          'parent-file.txt',
         ]);
 
-        expect(tree.read('parent/new-child/child-file.txt', 'utf-8')).toEqual('The child content');
+        expect(tree.read('parent/new-child/child-file.txt', 'utf-8')).toEqual(
+          'The child content'
+        );
         expect(tree.read('parent/child/child-file.txt')).toEqual(null);
       });
     });

--- a/packages/nx/src/generators/tree.ts
+++ b/packages/nx/src/generators/tree.ts
@@ -29,7 +29,7 @@ export interface TreeWriteOptions {
 /**
  * Options to set when renaming a file/folder in the Virtual file system tree.
  */
- export interface TreeRenameOptions {
+export interface TreeRenameOptions {
   /**
    * This should correspond to the type of rename action to perform
    */
@@ -169,17 +169,22 @@ export class FsTree implements Tree {
       } else if (this.recordedChanges[this.rp(filePath)]) {
         // If renamed file
         if (this.recordedChanges[this.rp(filePath)].origin) {
-
           // Use the content of recordedChange for the origin file, if exists
-          if (this.recordedChanges[this.recordedChanges[this.rp(filePath)].origin]) {
-            content = this.recordedChanges[this.recordedChanges[this.rp(filePath)].origin].content;
+          if (
+            this.recordedChanges[this.recordedChanges[this.rp(filePath)].origin]
+          ) {
+            content =
+              this.recordedChanges[
+                this.recordedChanges[this.rp(filePath)].origin
+              ].content;
           }
 
           // Or, read the origin file from fs, if content is null or undefined
-          if (content === null || content === void(0)) {
-            content = this.fsReadFile(this.recordedChanges[this.rp(filePath)].origin);
+          if (content === null || content === void 0) {
+            content = this.fsReadFile(
+              this.recordedChanges[this.rp(filePath)].origin
+            );
           }
-
         } else {
           content = this.recordedChanges[this.rp(filePath)].content;
         }
@@ -278,20 +283,20 @@ export class FsTree implements Tree {
         content: null,
         origin: from,
         isDeleted: false,
-        options: { mode } as TreeRenameOptions
+        options: { mode } as TreeRenameOptions,
       };
 
       this.renameChanges[from] = to;
 
       this.filesForDir(from).forEach((f) => {
-        this.renameChanges[f] = this.rp(f.replace(dirname(f) , to));
+        this.renameChanges[f] = this.rp(f.replace(dirname(f), to));
 
         this.recordedChanges[this.renameChanges[f]] = {
           content: null,
           origin: this.rp(f),
           isDeleted: false,
           noop: true,
-        };   
+        };
       });
 
       // Delete directories when empty
@@ -329,7 +334,7 @@ export class FsTree implements Tree {
 
   listChanges(): FileChange[] {
     const res = [] as FileChange[];
-    Object.keys(this.recordedChanges).forEach((f) => {      
+    Object.keys(this.recordedChanges).forEach((f) => {
       if (this.recordedChanges[f].isDeleted) {
         if (this.fsExists(f)) {
           res.push({ path: f, type: 'DELETE', content: null });
@@ -426,14 +431,17 @@ export class FsTree implements Tree {
     try {
       // TODO: consider nodegit?
       return !!execSync(`git ls-files ${filePath}`).toString();
-    } catch(e) {
+    } catch (e) {
       return false;
     }
   }
 
   private filesForDir(path: string): string[] {
     return Object.keys(this.recordedChanges).filter(
-      (f) => f.startsWith(`${path}/`) && !this.recordedChanges[f].isDeleted && !this.renameChanges[f]
+      (f) =>
+        f.startsWith(`${path}/`) &&
+        !this.recordedChanges[f].isDeleted &&
+        !this.renameChanges[f]
     );
   }
 


### PR DESCRIPTION
This commit makes possible native file/folder renaming with the ability.  It is git-aware and will perform a `git mv` on the file/folder in the event that the object is in the git index.  It adds a new FileChange type of "RENAME".

## Current Behavior
`tree.rename` reads the file, deletes it, and then writes a new file at the desired path with the original content.  This behavior destroys commit history for any files/folders renamed that tracked by git.

## Expected Behavior
`tree.rename` should handle git-tracked files properly and `git mv` them to their new path, preserving commit history.

## Related Issue(s)
https://github.com/nrwl/nx/discussions/11219

Fixes #11219 