### PR TITLE
fix(core): improve performance of enforce-module-boundaries linting rule on Windows

### DIFF
--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -374,9 +374,8 @@ export function mapProjectGraphFiles<T>(
   };
 }
 
-const ESLINT_REGEX = /node_modules.*\/eslint$/;
-const NRWL_CLI_REGEX = /nx\/bin\/run-executor\.js$/;
-
+const ESLINT_REGEX = /node_modules.*[\/\\]eslint$/;
+const NRWL_CLI_REGEX = /nx[\/\\]bin[\/\\]run-executor\.js$/;
 export function isTerminalRun(): boolean {
   return (
     process.argv.length > 1 &&


### PR DESCRIPTION
The @nrwl/nx/enforce-module-boundaries linting rule is extremely slow on Windows

The eslint nx-enforce-module-boundaries rule caches the NX graph during a full eslint run. Based on how the eslint rule is started (ea is het started by the user from a terminal or is het started for 1 file by the IDE), the cache will|be rebuilt or not.|To determine if eslint is started via a terminal, NX looks into the process argv to find out. On Windows the path in process argv is with backslashes instead of forward slashes. The regex did not take into account back slashes.

ISSUES CLOSED: #11250

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Running `npx nx lint houston-demo-app --skip-nx-cache --quiet` on a Windows machine on a large NX workspace is very slow.

## Expected Behavior
running `npx nx lint houston-demo-app --skip-nx-cache --quiet` on a Windows machine on a large NX workspace performs more or less the same on Windows and Mac

## Related Issue(s)
Fixes #11250
