### PR TITLE
feat(angular): add spa option to file-server executor to support reloading client-side routes

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -3233,6 +3233,11 @@
             "type": "boolean",
             "description": "Watch for file changes.",
             "default": false
+          },
+          "spa": {
+            "type": "boolean",
+            "description": "Redirect 404 errors to index.html (useful for SPA's).",
+            "default": false
           }
         },
         "additionalProperties": false,

--- a/packages/angular/src/executors/file-server/schema.d.ts
+++ b/packages/angular/src/executors/file-server/schema.d.ts
@@ -11,4 +11,5 @@ export interface Schema {
   withDeps: boolean;
   proxyOptions?: object;
   watch?: boolean;
+  spa?: boolean;
 }

--- a/packages/angular/src/executors/file-server/schema.json
+++ b/packages/angular/src/executors/file-server/schema.json
@@ -60,6 +60,11 @@
       "type": "boolean",
       "description": "Watch for file changes.",
       "default": false
+    },
+    "spa": {
+      "type": "boolean",
+      "description": "Redirect 404 errors to index.html (useful for SPA's).",
+      "default": false
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Reloading a route that is not the root, returns a 404 error.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Reloading routes other than the root works correctly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
