### PR TITLE
feat(angular): deprecate generating e2e tests with protractor

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -170,7 +170,7 @@
           "e2eTestRunner": {
             "type": "string",
             "enum": ["protractor", "cypress", "none"],
-            "description": "Test runner to use for end to end (E2E) tests.",
+            "description": "Test runner to use for end to end (E2E) tests. The `protractor` option is deprecated and it will be removed in v15.",
             "default": "cypress"
           },
           "tags": {

--- a/packages/angular/src/generators/application/schema.json
+++ b/packages/angular/src/generators/application/schema.json
@@ -107,7 +107,7 @@
     "e2eTestRunner": {
       "type": "string",
       "enum": ["protractor", "cypress", "none"],
-      "description": "Test runner to use for end to end (E2E) tests.",
+      "description": "Test runner to use for end to end (E2E) tests. The `protractor` option is deprecated and it will be removed in v15.",
       "default": "cypress"
     },
     "tags": {

--- a/packages/angular/src/utils/test-runners.ts
+++ b/packages/angular/src/utils/test-runners.ts
@@ -4,6 +4,10 @@ export const enum UnitTestRunner {
   None = 'none',
 }
 export const enum E2eTestRunner {
+  /**
+   * @deprecated Protractor is no longer maintained. Support for generating
+   * E2E tests with it will be removed in v15.
+   */
   Protractor = 'protractor',
   Cypress = 'cypress',
   None = 'none',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When creating an angular application we can choose to create the E2E test project with the unmaintained Protractor. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Deprecate the `protractor` value in the `e2eTestRunner` option.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
