### PR TITLE
docs(nxdev): add github example callout

### DIFF
--- a/nx-dev/ui-markdoc/src/index.ts
+++ b/nx-dev/ui-markdoc/src/index.ts
@@ -1,4 +1,4 @@
-import { parse, renderers, transform, Node } from '@markdoc/markdoc';
+import { Node, parse, renderers, transform } from '@markdoc/markdoc';
 import { DocumentData } from '@nrwl/nx-dev/models-document';
 import React, { ReactNode } from 'react';
 import { Fence } from './lib/nodes/fence.component';
@@ -10,10 +10,12 @@ import { CustomLink } from './lib/nodes/link.component';
 import { link } from './lib/nodes/link.schema';
 import { Callout } from './lib/tags/callout.component';
 import { callout } from './lib/tags/callout.schema';
+import { GithubRepository } from './lib/tags/github-repository.component';
+import { githubRepository } from './lib/tags/github-repository.schema';
 import { Iframe } from './lib/tags/iframe.component';
 import { iframe } from './lib/tags/iframe.schema';
-import { nxCloudSection } from './lib/tags/nx-cloud-section.schema';
 import { NxCloudSection } from './lib/tags/nx-cloud-section.component';
+import { nxCloudSection } from './lib/tags/nx-cloud-section.schema';
 import { SideBySide } from './lib/tags/side-by-side.component';
 import { sideBySide } from './lib/tags/side-by-side.schema';
 import { Tab, Tabs } from './lib/tags/tabs.component';
@@ -33,6 +35,7 @@ export const getMarkdocCustomConfig = (
     },
     tags: {
       callout,
+      'github-repository': githubRepository,
       iframe,
       'nx-cloud-section': nxCloudSection,
       'side-by-side': sideBySide,
@@ -45,6 +48,7 @@ export const getMarkdocCustomConfig = (
     Callout,
     CustomLink,
     Fence,
+    GithubRepository,
     Heading,
     Iframe,
     NxCloudSection,

--- a/nx-dev/ui-markdoc/src/lib/tags/github-repository.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/github-repository.component.tsx
@@ -1,0 +1,39 @@
+import { ChevronRightIcon } from '@heroicons/react/outline';
+
+export function GithubRepository({ url }: { url: string }): JSX.Element {
+  return (
+    <div className="not-prose group relative my-12 mx-auto flex w-full max-w-md items-center gap-3 overflow-hidden rounded-lg bg-white shadow-md transition hover:text-white">
+      <div className="bg-blue-nx-base absolute inset-0 z-0 w-2 transition-all duration-150 group-hover:w-full"></div>
+      <div className="bg-blue-nx-base w-2"></div>
+
+      <div className="z-10 flex flex-grow items-center py-3">
+        <svg
+          className="h-10 w-10 rounded-full object-cover"
+          viewBox="0 0 16 16"
+          fill="currentColor"
+        >
+          <path
+            fillRule="evenodd"
+            d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
+          ></path>
+        </svg>
+
+        <div className="mx-3">
+          <p>
+            Check the example:
+            <a
+              href={url}
+              target="_blank"
+              rel="noreferrer"
+              className="block text-sm font-medium opacity-80"
+            >
+              <span className="absolute inset-0" aria-hidden="true"></span>
+              {url.replace(/^.*\/\/[^\/]+/, '')}
+            </a>
+          </p>
+        </div>
+      </div>
+      <ChevronRightIcon className="mr-4 h-6 w-6 transition-all group-hover:translate-x-3" />
+    </div>
+  );
+}

--- a/nx-dev/ui-markdoc/src/lib/tags/github-repository.schema.ts
+++ b/nx-dev/ui-markdoc/src/lib/tags/github-repository.schema.ts
@@ -1,0 +1,13 @@
+import { Schema } from '@markdoc/markdoc';
+
+export const githubRepository: Schema = {
+  render: 'GithubRepository',
+  description: 'Display the provided repository link into a clickable button.',
+  attributes: {
+    url: {
+      type: 'String',
+      required: true,
+      description: 'The url of the Github repository',
+    },
+  },
+};

--- a/nx-dev/ui-markdoc/src/lib/tags/youtube.components.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/youtube.components.tsx
@@ -1,5 +1,5 @@
 // TODO@ben: add tailwindcss classes
-export function YouTube(props: any) {
+export function YouTube(props: any): JSX.Element {
   return (
     <iframe
       {...props}


### PR DESCRIPTION
It introduces a new component to use in the documentation when sharing a Github repository link as example on nx.dev.

Syntax:
```markdown
{% github-repository url="https://github.com/nrwl/nx-recipes" /%}
```