### PR TITLE
fix(angular): update module federation logic to correctly identify workspace libs secondary entry points

### DIFF
--- a/packages/angular/src/utils/mf/typescript.spec.ts
+++ b/packages/angular/src/utils/mf/typescript.spec.ts
@@ -1,0 +1,24 @@
+import * as tsUtils from '@nrwl/workspace/src/utilities/typescript';
+import * as fs from 'fs';
+import { readTsPathMappings } from './typescript';
+
+describe('readTsPathMappings', () => {
+  it('should normalize paths', () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(tsUtils, 'readTsConfig').mockReturnValue({
+      options: {
+        paths: {
+          '@myorg/lib1': ['./libs/lib1/src/index.ts'],
+          '@myorg/lib2': ['libs/lib2/src/index.ts'],
+        },
+      },
+    } as any);
+
+    const paths = readTsPathMappings('/path/to/tsconfig.json');
+
+    expect(paths).toEqual({
+      '@myorg/lib1': ['libs/lib1/src/index.ts'],
+      '@myorg/lib2': ['libs/lib2/src/index.ts'],
+    });
+  });
+});

--- a/packages/angular/src/utils/mf/typescript.ts
+++ b/packages/angular/src/utils/mf/typescript.ts
@@ -1,0 +1,34 @@
+import {
+  getRootTsConfigPath,
+  readTsConfig,
+} from '@nrwl/workspace/src/utilities/typescript';
+import { existsSync } from 'fs';
+import { ParsedCommandLine } from 'typescript';
+
+let tsConfig: ParsedCommandLine;
+let tsPathMappings: ParsedCommandLine['options']['paths'];
+export function readTsPathMappings(
+  tsConfigPath: string = process.env.NX_TSCONFIG_PATH ?? getRootTsConfigPath()
+): ParsedCommandLine['options']['paths'] {
+  if (tsPathMappings) {
+    return tsPathMappings;
+  }
+
+  tsConfig ??= readTsConfiguration(tsConfigPath);
+  tsPathMappings = {};
+  Object.entries(tsConfig.options?.paths ?? {}).forEach(([alias, paths]) => {
+    tsPathMappings[alias] = paths.map((path) => path.replace(/^\.\//, ''));
+  });
+
+  return tsPathMappings;
+}
+
+function readTsConfiguration(tsConfigPath: string): ParsedCommandLine {
+  if (!existsSync(tsConfigPath)) {
+    throw new Error(
+      `NX MF: TsConfig Path for workspace libraries does not exist! (${tsConfigPath}).`
+    );
+  }
+
+  return readTsConfig(tsConfigPath);
+}

--- a/packages/angular/src/utils/mf/utils.spec.ts
+++ b/packages/angular/src/utils/mf/utils.spec.ts
@@ -1,0 +1,158 @@
+import * as tsUtils from './typescript';
+import { getDependentPackagesForProject } from './utils';
+
+describe('getDependentPackagesForProject', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should collect npm packages and workspaces libraries without duplicates', () => {
+    jest.spyOn(tsUtils, 'readTsPathMappings').mockReturnValue({
+      '@myorg/lib1': ['libs/lib1/src/index.ts'],
+      '@myorg/lib2': ['libs/lib2/src/index.ts'],
+    });
+
+    const dependencies = getDependentPackagesForProject(
+      {
+        dependencies: {
+          shell: [
+            { source: 'shell', target: 'lib1', type: 'static' },
+            { source: 'shell', target: 'lib2', type: 'static' },
+            { source: 'shell', target: 'npm:lodash', type: 'static' },
+          ],
+          lib1: [{ source: 'lib1', target: 'lib2', type: 'static' }],
+          lib2: [{ source: 'lib2', target: 'npm:lodash', type: 'static' }],
+        },
+        nodes: {
+          shell: {
+            name: 'shell',
+            data: { root: 'apps/shell', sourceRoot: 'apps/shell/src' },
+            type: 'app',
+          },
+          lib1: {
+            name: 'lib1',
+            data: { root: 'libs/lib1', sourceRoot: 'libs/lib1/src' },
+            type: 'lib',
+          },
+          lib2: {
+            name: 'lib2',
+            data: { root: 'libs/lib2', sourceRoot: 'libs/lib2/src' },
+            type: 'lib',
+          },
+        },
+      },
+      'shell'
+    );
+
+    expect(dependencies).toEqual({
+      workspaceLibraries: [
+        { name: 'lib1', root: 'libs/lib1', importKey: '@myorg/lib1' },
+        { name: 'lib2', root: 'libs/lib2', importKey: '@myorg/lib2' },
+      ],
+      npmPackages: ['lodash'],
+    });
+  });
+
+  it('should collect workspaces libraries recursively', () => {
+    jest.spyOn(tsUtils, 'readTsPathMappings').mockReturnValue({
+      '@myorg/lib1': ['libs/lib1/src/index.ts'],
+      '@myorg/lib2': ['libs/lib2/src/index.ts'],
+      '@myorg/lib3': ['libs/lib3/src/index.ts'],
+    });
+
+    const dependencies = getDependentPackagesForProject(
+      {
+        dependencies: {
+          shell: [{ source: 'shell', target: 'lib1', type: 'static' }],
+          lib1: [{ source: 'lib1', target: 'lib2', type: 'static' }],
+          lib2: [{ source: 'lib2', target: 'lib3', type: 'static' }],
+        },
+        nodes: {
+          shell: {
+            name: 'shell',
+            data: { root: 'apps/shell', sourceRoot: 'apps/shell/src' },
+            type: 'app',
+          },
+          lib1: {
+            name: 'lib1',
+            data: { root: 'libs/lib1', sourceRoot: 'libs/lib1/src' },
+            type: 'lib',
+          },
+          lib2: {
+            name: 'lib2',
+            data: { root: 'libs/lib2', sourceRoot: 'libs/lib2/src' },
+            type: 'lib',
+          },
+          lib3: {
+            name: 'lib3',
+            data: { root: 'libs/lib3', sourceRoot: 'libs/lib3/src' },
+            type: 'lib',
+          },
+        },
+      },
+      'shell'
+    );
+
+    expect(dependencies).toEqual({
+      workspaceLibraries: [
+        { name: 'lib1', root: 'libs/lib1', importKey: '@myorg/lib1' },
+        { name: 'lib2', root: 'libs/lib2', importKey: '@myorg/lib2' },
+        { name: 'lib3', root: 'libs/lib3', importKey: '@myorg/lib3' },
+      ],
+      npmPackages: [],
+    });
+  });
+
+  it('should ignore TS path mappings with wildcards', () => {
+    jest.spyOn(tsUtils, 'readTsPathMappings').mockReturnValue({
+      '@myorg/lib1': ['libs/lib1/src/index.ts'],
+      '@myorg/lib1/*': ['libs/lib1/src/lib/*'],
+      '@myorg/lib2': ['libs/lib2/src/index.ts'],
+      '@myorg/lib2/*': ['libs/lib2/src/lib/*'],
+      '@myorg/lib3': ['libs/lib3/src/index.ts'],
+      '@myorg/lib3/*': ['libs/lib3/src/lib/*'],
+    });
+
+    const dependencies = getDependentPackagesForProject(
+      {
+        dependencies: {
+          shell: [{ source: 'shell', target: 'lib1', type: 'static' }],
+          lib1: [{ source: 'lib1', target: 'lib2', type: 'static' }],
+          lib2: [{ source: 'lib2', target: 'lib3', type: 'static' }],
+        },
+        nodes: {
+          shell: {
+            name: 'shell',
+            data: { root: 'apps/shell', sourceRoot: 'apps/shell/src' },
+            type: 'app',
+          },
+          lib1: {
+            name: 'lib1',
+            data: { root: 'libs/lib1', sourceRoot: 'libs/lib1/src' },
+            type: 'lib',
+          },
+          lib2: {
+            name: 'lib2',
+            data: { root: 'libs/lib2', sourceRoot: 'libs/lib2/src' },
+            type: 'lib',
+          },
+          lib3: {
+            name: 'lib3',
+            data: { root: 'libs/lib3', sourceRoot: 'libs/lib3/src' },
+            type: 'lib',
+          },
+        },
+      },
+      'shell'
+    );
+
+    expect(dependencies).toEqual({
+      workspaceLibraries: [
+        { name: 'lib1', root: 'libs/lib1', importKey: '@myorg/lib1' },
+        { name: 'lib2', root: 'libs/lib2', importKey: '@myorg/lib2' },
+        { name: 'lib3', root: 'libs/lib3', importKey: '@myorg/lib3' },
+      ],
+      npmPackages: [],
+    });
+  });
+});

--- a/packages/angular/src/utils/mf/utils.ts
+++ b/packages/angular/src/utils/mf/utils.ts
@@ -1,5 +1,17 @@
-import { joinPathFragments, readJsonFile, workspaceRoot } from '@nrwl/devkit';
+import {
+  joinPathFragments,
+  ProjectGraph,
+  readJsonFile,
+  workspaceRoot,
+} from '@nrwl/devkit';
 import { existsSync } from 'fs';
+import { readTsPathMappings } from './typescript';
+
+export type WorkspaceLibrary = {
+  name: string;
+  root: string;
+  importKey: string | undefined;
+};
 
 export function readRootPackageJson(): {
   dependencies?: { [key: string]: string };
@@ -13,4 +25,71 @@ export function readRootPackageJson(): {
   }
 
   return readJsonFile(pkgJsonPath);
+}
+
+export function getDependentPackagesForProject(
+  projectGraph: ProjectGraph,
+  name: string
+): {
+  workspaceLibraries: WorkspaceLibrary[];
+  npmPackages: string[];
+} {
+  const { npmPackages, workspaceLibraries } = collectDependencies(
+    projectGraph,
+    name
+  );
+
+  return {
+    workspaceLibraries: [...workspaceLibraries.values()],
+    npmPackages: [...npmPackages],
+  };
+}
+
+function collectDependencies(
+  projectGraph: ProjectGraph,
+  name: string,
+  dependencies = {
+    workspaceLibraries: new Map<string, WorkspaceLibrary>(),
+    npmPackages: new Set<string>(),
+  },
+  seen: Set<string> = new Set()
+): {
+  workspaceLibraries: Map<string, WorkspaceLibrary>;
+  npmPackages: Set<string>;
+} {
+  if (seen.has(name)) {
+    return dependencies;
+  }
+  seen.add(name);
+
+  (projectGraph.dependencies[name] ?? []).forEach((dependency) => {
+    if (dependency.target.startsWith('npm:')) {
+      dependencies.npmPackages.add(dependency.target.replace('npm:', ''));
+    } else {
+      dependencies.workspaceLibraries.set(dependency.target, {
+        name: dependency.target,
+        root: projectGraph.nodes[dependency.target].data.root,
+        importKey: getLibraryImportPath(dependency.target, projectGraph),
+      });
+      collectDependencies(projectGraph, dependency.target, dependencies, seen);
+    }
+  });
+
+  return dependencies;
+}
+
+function getLibraryImportPath(
+  library: string,
+  projectGraph: ProjectGraph
+): string | undefined {
+  const tsConfigPathMappings = readTsPathMappings();
+
+  const sourceRoot = projectGraph.nodes[library].data.sourceRoot;
+  for (const [key, value] of Object.entries(tsConfigPathMappings)) {
+    if (value.find((path) => path.startsWith(sourceRoot))) {
+      return key;
+    }
+  }
+
+  return undefined;
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
In an Angular Module Federation app, the current approach to identifying workspace 'libraries'' secondary entry points determines a library's root path by trying to find a `package.json` file starting from a TS path mapping for the library and going up through the filesystem. This approach has an issue when it finds TS path mappings using wildcards and causes an infinite loop. Also, the information about the project root is already contained in the project graph, so we can use that instead which is more reliable.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
A Module Federation application should build and be served correctly regardless of having some TS path mappings using wildcards or not.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #11174 
