### PR TITLE
fix(react): buildable library sets NODE_ENV correctly

### DIFF
--- a/e2e/react/src/react-package.test.ts
+++ b/e2e/react/src/react-package.test.ts
@@ -136,6 +136,13 @@ describe('Build React libraries and apps', () => {
       checkFilesExist(`dist/libs/${parentLib}/index.js`);
       checkFilesExist(`dist/libs/${childLib}/index.js`);
       checkFilesExist(`dist/libs/${childLib2}/index.js`);
+
+      expect(readFile(`dist/libs/${childLib}/index.js`)).not.toContain(
+        'react/jsx-dev-runtime'
+      );
+      expect(readFile(`dist/libs/${childLib}/index.js`)).toContain(
+        'react/jsx-runtime'
+      );
     });
 
     it('should support --format option', () => {

--- a/packages/web/src/executors/rollup/rollup.impl.ts
+++ b/packages/web/src/executors/rollup/rollup.impl.ts
@@ -36,16 +36,18 @@ import { updatePackageJson } from './lib/update-package-json';
 // These use require because the ES import isn't correct.
 const commonjs = require('@rollup/plugin-commonjs');
 const image = require('@rollup/plugin-image');
+
 const json = require('@rollup/plugin-json');
 const copy = require('rollup-plugin-copy');
 const postcss = require('rollup-plugin-postcss');
 
 const fileExtensions = ['.js', '.jsx', '.ts', '.tsx'];
-
 export default async function* rollupExecutor(
   rawOptions: WebRollupOptions,
   context: ExecutorContext
 ) {
+  process.env.NODE_ENV ??= 'production';
+
   const project = context.workspace.projects[context.projectName];
   const projectGraph = readCachedProjectGraph();
   const sourceRoot = project.sourceRoot;


### PR DESCRIPTION
Currently, building libraries using `.js` files rather than `.ts` files is transpiling with `react/jsx-dev-runtime` instead of `react/jsx-runtime`.  This is fixed by specifying the correct `NODE_ENV` before building the library.

## Current Behavior
Built React library uses dev runtime.

## Expected Behavior
Built React library should not use dev runtime.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #11281 
