### PR TITLE
fix(core): use globbing also for workspace file patterns without '*'

### DIFF
--- a/packages/nx/src/hasher/hasher.ts
+++ b/packages/nx/src/hasher/hasher.ts
@@ -384,20 +384,12 @@ class TaskHasher {
     if (!this.filesetHashes[mapKey]) {
       this.filesetHashes[mapKey] = new Promise(async (res) => {
         const parts = [];
-        if (fileset.indexOf('*') > -1) {
-          this.projectGraph.allWorkspaceFiles
-            .filter((f) => minimatch(f.file, withoutWorkspaceRoot))
-            .forEach((f) => {
-              parts.push(f.hash);
-            });
-        } else {
-          const matchingFile = this.projectGraph.allWorkspaceFiles.find(
-            (t) => t.file === withoutWorkspaceRoot
-          );
-          if (matchingFile) {
-            parts.push(matchingFile.hash);
-          }
-        }
+        this.projectGraph.allWorkspaceFiles
+          .filter((f) => minimatch(f.file, withoutWorkspaceRoot))
+          .forEach((f) => {
+            parts.push(f.hash);
+          });
+
         const value = this.hashing.hashArray(parts);
         res({
           value,


### PR DESCRIPTION
This change allows cache input strings for`{workspaceRoot}` filesets to be parsed as glob patterns even if they don't contain asterisk `*` inside.

Few examples: 
```jsonc
// nx.json 
{
  "targetDefaults": {
    "build": {
      "inputs": [
        "{workspaceRoot}/.babelrc?(.json)", 
        "{workspaceRoot}/tsconfig.{e2e-base,ts-node}.json"
      ]
    }
}
// or project.json
{
  "targets": {
    "build": {
      "inputs": [
        "{workspaceRoot}/.babelrc?(.json)", 
        "{workspaceRoot}/tsconfig.{e2e-base,ts-node}.json"
      ]
    }
  }
}
```

Making perf optimizations by skipping minimatch for a few static files might not be worth the tradeoff. (related commit: https://github.com/nrwl/nx/commit/15ccae0b5833c2e46cd3f8b0ba02ae6db57f8ba2)

Note: this is a behaviour related to ["cache inputs" feature introduced in Nx 14.4](https://blog.nrwl.io/nx-14-4-inputs-optional-npm-scope-project-graph-cache-directory-and-more-2f92e3437ae0#05eb).

## Current Behavior

Rerunning a target with above defined inputs with one of `.babelrc` or `tsconfig.{e2e-base,ts-node}.json` files updated will not invalidate a cache for the target.

## Expected Behavior

Those files would get matched by `Hasher` and the Nx cache for the target would get invalidated.
