### PR TITLE
chore(react): remove storybook logger dependency

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -41,7 +41,6 @@
     "@nrwl/web": "file:../web",
     "@nrwl/workspace": "file:../workspace",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",
-    "@storybook/node-logger": "6.1.20",
     "@svgr/webpack": "^6.1.2",
     "chalk": "4.1.0",
     "eslint-plugin-import": "^2.25.2",

--- a/packages/react/plugins/storybook/index.ts
+++ b/packages/react/plugins/storybook/index.ts
@@ -1,9 +1,12 @@
-import { joinPathFragments, readJsonFile } from '@nrwl/devkit';
-import { workspaceRoot } from '@nrwl/devkit';
+import {
+  joinPathFragments,
+  readJsonFile,
+  logger,
+  workspaceRoot,
+} from '@nrwl/devkit';
 import { getBaseWebpackPartial } from '@nrwl/web/src/utils/config';
 import { getStylesPartial } from '@nrwl/web/src/utils/web.config';
 import { checkAndCleanWithSemver } from '@nrwl/workspace/src/utilities/version-utils';
-import { logger } from '@storybook/node-logger';
 import { join } from 'path';
 import { gte } from 'semver';
 import { Configuration, WebpackPluginInstance, DefinePlugin } from 'webpack';


### PR DESCRIPTION
## Current Behavior
React imports `logger` from `"@storybook/node-logger"`.

## Expected Behavior
React should import `logger` from ` '@nrwl/devkit'`.

Remove completely the `"@storybook/node-logger"` dependency from `@nrwl/react`.

## Related Issue(s)

Fixes #11300
