### PR TITLE
docs(nxdev): apply github repository callout cmp

### DIFF
--- a/docs/shared/distributed-builds.md
+++ b/docs/shared/distributed-builds.md
@@ -10,10 +10,8 @@ The easiest way is to use Nx Cloud. Learn more about [configuring your CI](/nx-c
 
 But you can also set up distribution manually using the `print-affected` and `run-many` commands.
 
-Please look at the following two examples:
-
-- [Example of setting up distributed Azure build for Nx workspace](https://github.com/nrwl/nx-azure-build)
-- [Example of setting up distributed Jenkins build for Nx workspace](https://github.com/nrwl/nx-jenkins-build)
+{% github-repository url="https://github.com/nrwl/nx-azure-build" /%}
+{% github-repository url="https://github.com/nrwl/nx-jenkins-build" /%}
 
 The Azure example is very easy to port to other CI providers (e.g., CircleCI, GitLab).
 

--- a/docs/shared/examples/apollo-react.md
+++ b/docs/shared/examples/apollo-react.md
@@ -9,4 +9,4 @@ In this article, you’ll learn how to:
 
 **Blog Post:** [Using Apollo GraphQL with React in an Nx Workspace](https://blog.nrwl.io/using-apollo-graphql-with-react-in-an-nx-workspace-99db8d69cebe)
 
-**Repository:** [nx-apollo-react-example](https://github.com/nrwl/nx-apollo-react-example)
+{% github-repository url="https://github.com/nrwl/nx-apollo-react-example" /%}

--- a/docs/shared/examples/caching.md
+++ b/docs/shared/examples/caching.md
@@ -7,4 +7,4 @@ Repo contains:
 
 The repo shows how Nx works in a large workspace. It also benchmarks Nx and explains the optimisations Nx uses to be fast.
 
-**Repository:** [vsavkin/large-monorepo](https://github.com/vsavkin/large-monorepo)
+{% github-repository url="https://github.com/vsavkin/large-monorepo" /%}

--- a/docs/shared/examples/dte.md
+++ b/docs/shared/examples/dte.md
@@ -7,4 +7,4 @@ Repo contains:
 
 The repo shows how Nx distributed task execution can make the CI 16 times faster with a small configuration change.
 
-**Repository:** [vsavkin/interstellar](https://github.com/vsavkin/interstellar)
+{% github-repository url="https://github.com/vsavkin/interstellar" /%}

--- a/docs/shared/examples/nx-examples.md
+++ b/docs/shared/examples/nx-examples.md
@@ -4,6 +4,6 @@ This repository contains a single book store website that serves a React app for
 
 The repository is kept up to date with the latest version of Nx and is used as a smoke test for migrations to new versions of Nx.
 
-**Repository:** [nx-examples](https://github.com/nrwl/nx-examples)
-
 **Live Demo:** [Nx Store](https://nrwl-nx-examples-cart.netlify.app/cart)
+
+{% github-repository url="https://github.com/nrwl/nx-examples" /%}

--- a/docs/shared/examples/react-nx.md
+++ b/docs/shared/examples/react-nx.md
@@ -9,4 +9,4 @@ Learn to:
 
 **Blog post:** [Powering Up React Development With Nx](https://blog.nrwl.io/powering-up-react-development-with-nx-cf0a9385dbec)
 
-**Repository:** [nrwl/react-nx-example](https://github.com/nrwl/react-nx-example)
+{% github-repository url="https://github.com/nrwl/react-nx-example" /%}

--- a/docs/shared/extending-nx/project-graph-plugins.md
+++ b/docs/shared/extending-nx/project-graph-plugins.md
@@ -127,3 +127,5 @@ It might also be a good idea to ensure that the dep graph is not running on the 
 ## Example Project Graph Plugin
 
 The [nrwl/nx-go-project-graph-plugin](https://github.com/nrwl/nx-go-project-graph-plugin) repo contains an example project graph plugin which adds [Go](https://golang.org/) dependencies to the Nx Project Graph! A similar approach can be used for other languages.
+
+{% github-repository url="https://github.com/nrwl/nx-go-project-graph-plugin" /%}

--- a/docs/shared/guides/module-federation/faster-builds.md
+++ b/docs/shared/guides/module-federation/faster-builds.md
@@ -39,10 +39,11 @@ The best way to understand the setup is through an example. In this section, we 
 1. `/cart`
 1. `/about`
 
-But before we begin, we've put together a couple of example repos for you to inspect if you want to skip ahead.
+But before we begin, we've put together a couple of example repos (React and Angular) for you to inspect if you want to skip ahead.
 
-- Angular: https://github.com/nrwl/ng-module-federation
-- React: https://github.com/nrwl/react-module-federation
+{% github-repository url="https://github.com/nrwl/ng-module-federation" /%}
+
+{% github-repository url="https://github.com/nrwl/react-module-federation" /%}
 
 These examples have fully functioning [CI](https://github.com/nrwl/react-module-federation/blob/main/.github/workflows/ci.yml) [workflows](https://github.com/nrwl/ng-module-federation/blob/main/.github/workflows/ci.yml) that are simple to set up. You can see what the CI does by viewing the sample pull requests in each repo. Also notice the [Nx Cloud](https://nx.app) integration, which gives you insight into each pipeline. We'll touch on this [later in this guide](#distributed-computation-caching-with-nx-cloud).
 
@@ -328,6 +329,10 @@ The above command is just an example. You'll need to use what make sense for you
 
 For examples of how CI/CD pipelines can be configured using Nx Cloud and GitHub, see our [React](https://github.com/nrwl/react-module-federation)
 and [Angular](https://github.com/nrwl/ng-module-federation) examples.
+
+{% github-repository url="https://github.com/nrwl/ng-module-federation" /%}
+
+{% github-repository url="https://github.com/nrwl/react-module-federation" /%}
 
 ## Using buildable libs
 

--- a/docs/shared/guides/setup-incremental-builds-angular.md
+++ b/docs/shared/guides/setup-incremental-builds-angular.md
@@ -274,3 +274,5 @@ depends on must also be `build-base`:
 ## Example repository
 
 Check out the [nx-incremental-large-repo](https://github.com/nrwl/nx-incremental-large-repo) for a live example.
+
+{% github-repository url="https://github.com/nrwl/nx-incremental-large-repo" /%}

--- a/docs/shared/incremental-builds.md
+++ b/docs/shared/incremental-builds.md
@@ -37,6 +37,8 @@ It is costly to rebuild all the buildable libraries from scratch every time you 
 
 If we can share the cache with our teammates, we can get a much better dev experience. For instance, [this repo](https://github.com/nrwl/nx-incremental-large-repo) has a large application, where `nx serve` takes just a few seconds.
 
+{% github-repository url="https://github.com/nrwl/nx-incremental-large-repo" /%}
+
 ![comparison: webpack vs incremental build](/shared/incremental-build-webpack-vs-incremental.png)
 
 The above chart has three different test runs:

--- a/docs/shared/migration/migration-angularjs.md
+++ b/docs/shared/migration/migration-angularjs.md
@@ -14,6 +14,8 @@ For this example, you’ll be migrating the [Real World AngularJS](https://githu
 
 There is also a [repo](https://github.com/nrwl/nx-migrate-angularjs-example) that shows a completed example of this guide.
 
+{% github-repository url="https://github.com/nrwl/nx-migrate-angularjs-example" /%}
+
 {% callout type="note" title="RealWorld app vs reality" %}
 The RealWorld app is a great example of an AngularJS app, but it probably doesn’t have the complexity of your own codebase. As you go along, I’ll include some recommendations on how you might apply this example to your larger, more complex application.
 {% /callout %}

--- a/docs/shared/migration/migration-cra.md
+++ b/docs/shared/migration/migration-cra.md
@@ -47,6 +47,8 @@ For this example, you’ll be migrating the default CRA typescript template app 
 
 There is also a [repo](https://github.com/nrwl/cra-to-nx-migration) that shows the finished result of this guide and for each step a [diff](https://github.com/nrwl/cra-to-nx-migration/commits/main) will be provided to see the exact code changes that occur for that step.
 
+{% github-repository url="https://github.com/nrwl/cra-to-nx-migration" /%}
+
 ### 1. Create your workspace
 
 To start migrating your app, create an Nx workspace:

--- a/docs/shared/tools-workspace-builders.md
+++ b/docs/shared/tools-workspace-builders.md
@@ -214,7 +214,7 @@ export default async function multipleExecutor(
 
 For other ideas on how to create your own executors, you can always check out Nx's own open-source executors as well!
 
-(For example, our [cypress executor](https://github.com/nrwl/nx/blob/master/packages/cypress/src/executors/cypress/cypress.impl.ts))
+{% github-repository url="https://github.com/nrwl/nx/blob/master/packages/cypress/src/executors/cypress/cypress.impl.ts" %}
 
 ## Using Custom Hashers
 


### PR DESCRIPTION
It uses the new GitHub repository example component call-out into the documentation for nx.dev.