### PR TITLE
fix(nx): git-hasher should fetch files from git submodules

### DIFF
--- a/packages/nx/src/hasher/git-hasher.ts
+++ b/packages/nx/src/hasher/git-hasher.ts
@@ -146,7 +146,7 @@ async function getUntrackedFiles(path: string) {
   const lines = untracked.split('\0').filter((f) => !!f);
   const additionalLines = untrackedInSubModules.split('\0').filter((f) => !!f);
 
-  return getGitHashForFiles([...lines,...additionalLines], path);
+  return getGitHashForFiles([...lines, ...additionalLines], path);
 }
 
 export async function getFileHashes(path: string): Promise<{

--- a/packages/nx/src/hasher/git-hasher.ts
+++ b/packages/nx/src/hasher/git-hasher.ts
@@ -133,7 +133,14 @@ async function getUnstagedFiles(path: string) {
 async function getUntrackedFiles(path: string) {
   const { stdout: untracked } = await spawnProcess(
     'git',
-    ['ls-files', '--recurse-submodules', '--other', '-z', '--exclude-standard', '.'],
+    [
+      'ls-files',
+      '--recurse-submodules',
+      '--other',
+      '-z',
+      '--exclude-standard',
+      '.',
+    ],
     path
   );
   const lines = untracked.split('\0').filter((f) => !!f);

--- a/packages/nx/src/hasher/git-hasher.ts
+++ b/packages/nx/src/hasher/git-hasher.ts
@@ -131,7 +131,8 @@ async function getUnstagedFiles(path: string) {
 }
 
 async function getUntrackedFiles(path: string) {
-  const { stdout: untracked } = await spawnProcess(
+  const { stdout: untracked } = await spawnProcess('git', ['ls-files', '--other', '-z', '--exclude-standard', '.'], path);
+  const { stdout: untrackedInSubModules } = await spawnProcess(
     'git',
     [
       'submodule',
@@ -143,7 +144,9 @@ async function getUntrackedFiles(path: string) {
     path
   );
   const lines = untracked.split('\0').filter((f) => !!f);
-  return getGitHashForFiles(lines, path);
+  const additionalLines = untrackedInSubModules.split('\0').filter((f) => !!f);
+
+  return getGitHashForFiles([...lines,...additionalLines], path);
 }
 
 export async function getFileHashes(path: string): Promise<{

--- a/packages/nx/src/hasher/git-hasher.ts
+++ b/packages/nx/src/hasher/git-hasher.ts
@@ -105,7 +105,7 @@ async function spawnProcess(
 async function getStagedFiles(path: string) {
   const { stdout: staged } = await spawnProcess(
     'git',
-    ['ls-files', '-s', '-z', '--exclude-standard', '.'],
+    ['ls-files', '--recurse-submodules', '-s', '-z', '--exclude-standard', '.'],
     path
   );
   const res = new Map();
@@ -123,7 +123,7 @@ async function getStagedFiles(path: string) {
 async function getUnstagedFiles(path: string) {
   const { stdout: unstaged } = await spawnProcess(
     'git',
-    ['ls-files', '-m', '-z', '--exclude-standard', '.'],
+    ['ls-files', '--recurse-submodules', '-m', '-z', '--exclude-standard', '.'],
     path
   );
   const lines = unstaged.split('\0').filter((f) => !!f);
@@ -133,7 +133,7 @@ async function getUnstagedFiles(path: string) {
 async function getUntrackedFiles(path: string) {
   const { stdout: untracked } = await spawnProcess(
     'git',
-    ['ls-files', '--other', '-z', '--exclude-standard', '.'],
+    ['ls-files', '--recurse-submodules', '--other', '-z', '--exclude-standard', '.'],
     path
   );
   const lines = untracked.split('\0').filter((f) => !!f);

--- a/packages/nx/src/hasher/git-hasher.ts
+++ b/packages/nx/src/hasher/git-hasher.ts
@@ -131,11 +131,13 @@ async function getUnstagedFiles(path: string) {
 }
 
 async function getUntrackedFiles(path: string) {
+  //this command will list all parent repo's untracked files
   const { stdout: untracked } = await spawnProcess(
     'git',
     ['ls-files', '--other', '-z', '--exclude-standard', '.'],
     path
   );
+  //and this command will only list nested submodules untracked files
   const { stdout: untrackedInSubModules } = await spawnProcess(
     'git',
     [

--- a/packages/nx/src/hasher/git-hasher.ts
+++ b/packages/nx/src/hasher/git-hasher.ts
@@ -131,7 +131,11 @@ async function getUnstagedFiles(path: string) {
 }
 
 async function getUntrackedFiles(path: string) {
-  const { stdout: untracked } = await spawnProcess('git', ['ls-files', '--other', '-z', '--exclude-standard', '.'], path);
+  const { stdout: untracked } = await spawnProcess(
+    'git',
+    ['ls-files', '--other', '-z', '--exclude-standard', '.'],
+    path
+  );
   const { stdout: untrackedInSubModules } = await spawnProcess(
     'git',
     [
@@ -139,7 +143,7 @@ async function getUntrackedFiles(path: string) {
       'foreach',
       '--recursive',
       '--quiet',
-      'git ls-files --other -z --exclude-standard .'
+      'git ls-files --other -z --exclude-standard .',
     ],
     path
   );

--- a/packages/nx/src/hasher/git-hasher.ts
+++ b/packages/nx/src/hasher/git-hasher.ts
@@ -134,12 +134,11 @@ async function getUntrackedFiles(path: string) {
   const { stdout: untracked } = await spawnProcess(
     'git',
     [
-      'ls-files',
-      '--recurse-submodules',
-      '--other',
-      '-z',
-      '--exclude-standard',
-      '.',
+      'submodule',
+      'foreach',
+      '--recursive',
+      '--quiet',
+      'git ls-files --other -z --exclude-standard .'
     ],
     path
   );


### PR DESCRIPTION

## Current Behavior
Not recognizing files and their changes if they are inside a git submodule.

## Expected Behavior
git submodules should be supported and project dependencies should be discovered from files within submodules

## Related Issue(s)
https://github.com/nrwl/nx/issues/10903

## Fixes
Add `--recurse-submodules` flag for the `git ls-files` class 