### PR TITLE
chore(storybook): fix outputs for build-storybook configuration

### DIFF
--- a/packages/storybook/src/generators/configuration/util-functions.ts
+++ b/packages/storybook/src/generators/configuration/util-functions.ts
@@ -89,7 +89,7 @@ export function addAngularStorybookTask(tree: Tree, projectName: string) {
   };
   projectConfig.targets['build-storybook'] = {
     executor: '@storybook/angular:build-storybook',
-    outputs: ['{options.outputPath}'],
+    outputs: ['{options.outputDir}'],
     options: {
       outputDir: joinPathFragments('dist/storybook', projectName),
       configDir: `${projectConfig.root}/.storybook`,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

With `build-storybook` in `cacheableOperations`, output files are not generated on cache hit.

## Expected Behavior

When `build-storybook` is cached, the output files should be restored from cache.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #11342
