### PR TITLE
fix(nest): update nestjs versions for init generators

### DIFF
--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -1,15 +1,6 @@
-import { applicationGenerator as angularApplicationGenerator } from '@nrwl/angular/src/generators/application/application';
 import type { Tree } from '@nrwl/devkit';
 import * as devkit from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import * as semver from 'semver';
-import {
-  nestJsSchematicsVersion,
-  nestJsVersion7,
-  nestJsVersion8,
-  rxjsVersion6,
-  rxjsVersion7,
-} from '../../utils/versions';
 import { applicationGenerator } from './application';
 
 describe('application generator', () => {
@@ -74,75 +65,6 @@ describe('application generator', () => {
       await applicationGenerator(tree, { name: appName, skipFormat: true });
 
       expect(devkit.formatFiles).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('NestJS versions', () => {
-    it('should use NestJs 8 for empty workspace', async () => {
-      await applicationGenerator(tree, { name: appName });
-      const pkg = devkit.readJson(tree, `package.json`);
-
-      expect(pkg.dependencies['rxjs']).toBe(rxjsVersion7);
-      expect(pkg.dependencies['@nestjs/common']).toBe(nestJsVersion8);
-      expect(pkg.devDependencies['@nestjs/schematics']).toBe(
-        nestJsSchematicsVersion
-      );
-    });
-
-    it(`should use NestJs 8 for Angular + RxJS 7 (${rxjsVersion7}) workspace`, async () => {
-      await angularApplicationGenerator(tree, { name: 'angular-app' });
-
-      let pkg = devkit.readJson(tree, 'package.json');
-      pkg.dependencies['rxjs'] = rxjsVersion7;
-      tree.write('package.json', JSON.stringify(pkg));
-
-      await applicationGenerator(tree, { name: appName });
-
-      pkg = devkit.readJson(tree, 'package.json');
-
-      expect(pkg.dependencies['rxjs']).toBe(rxjsVersion7);
-      expect(pkg.dependencies['@nestjs/common']).toBe(nestJsVersion8);
-      expect(pkg.devDependencies['@nestjs/schematics']).toBe(
-        nestJsSchematicsVersion
-      );
-    });
-
-    it('should use NestJs 8 for Angular + RxJS 7 (7.4.0) workspace', async () => {
-      await angularApplicationGenerator(tree, { name: 'angular-app' });
-
-      let pkg = devkit.readJson(tree, 'package.json');
-      pkg.dependencies['rxjs'] = '~7.4.0';
-      tree.write('package.json', JSON.stringify(pkg));
-
-      await applicationGenerator(tree, { name: appName });
-
-      pkg = devkit.readJson(tree, 'package.json');
-
-      expect(pkg.dependencies['rxjs']).toBe('~7.4.0');
-      expect(pkg.dependencies['@nestjs/common']).toBe(nestJsVersion8);
-      expect(pkg.devDependencies['@nestjs/schematics']).toBe(
-        nestJsSchematicsVersion
-      );
-    });
-
-    it('should use NestJs 7 for Angular + RxJS 6 workspace', async () => {
-      await angularApplicationGenerator(tree, { name: 'angular-app' });
-      devkit.updateJson(tree, 'package.json', (json) => {
-        json.dependencies.rxjs = rxjsVersion6;
-        return json;
-      });
-
-      await applicationGenerator(tree, { name: appName });
-
-      const pkg = devkit.readJson(tree, `package.json`);
-
-      expect(semver.minVersion(pkg.dependencies['rxjs']).major).toBe(
-        semver.minVersion(rxjsVersion6).major
-      );
-      expect(pkg.dependencies['@nestjs/common']).toBe(nestJsVersion7);
-      expect(pkg.devDependencies['@nestjs/schematics']).toBe(
-        nestJsSchematicsVersion
-      );
     });
   });
 });

--- a/packages/nest/src/generators/init/init.spec.ts
+++ b/packages/nest/src/generators/init/init.spec.ts
@@ -1,11 +1,7 @@
 import type { Tree } from '@nrwl/devkit';
 import * as devkit from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import {
-  nestJsSchematicsVersion,
-  nestJsVersion8,
-  nxVersion,
-} from '../../utils/versions';
+import { nestJsVersion, nxVersion } from '../../utils/versions';
 import { initGenerator } from './init';
 
 describe('init generator', () => {
@@ -20,19 +16,19 @@ describe('init generator', () => {
     await initGenerator(tree, {});
 
     const packageJson = devkit.readJson(tree, 'package.json');
-    expect(packageJson.dependencies['@nestjs/common']).toBe(nestJsVersion8);
-    expect(packageJson.dependencies['@nestjs/core']).toBe(nestJsVersion8);
+    expect(packageJson.dependencies['@nestjs/common']).toBe(nestJsVersion);
+    expect(packageJson.dependencies['@nestjs/core']).toBe(nestJsVersion);
     expect(packageJson.dependencies['@nestjs/platform-express']).toBe(
-      nestJsVersion8
+      nestJsVersion
     );
     expect(packageJson.dependencies['reflect-metadata']).toBeDefined();
     expect(packageJson.dependencies['rxjs']).toBeDefined();
     expect(packageJson.dependencies['tslib']).toBeDefined();
     expect(packageJson.dependencies['@nrwl/nest']).toBeUndefined();
     expect(packageJson.devDependencies['@nestjs/schematics']).toBe(
-      nestJsSchematicsVersion
+      nestJsVersion
     );
-    expect(packageJson.devDependencies['@nestjs/testing']).toBe(nestJsVersion8);
+    expect(packageJson.devDependencies['@nestjs/testing']).toBe(nestJsVersion);
     expect(packageJson.devDependencies['@nrwl/nest']).toBe(nxVersion);
   });
 

--- a/packages/nest/src/generators/init/lib/add-dependencies.ts
+++ b/packages/nest/src/generators/init/lib/add-dependencies.ts
@@ -1,53 +1,27 @@
 import type { GeneratorCallback, Tree } from '@nrwl/devkit';
-import { addDependenciesToPackageJson, readJson } from '@nrwl/devkit';
-import { satisfies } from 'semver';
+import { addDependenciesToPackageJson } from '@nrwl/devkit';
 import {
-  nestJsSchematicsVersion,
-  nestJsVersion7,
-  nestJsVersion8,
+  nestJsVersion,
   nxVersion,
   reflectMetadataVersion,
-  rxjsVersion6,
-  rxjsVersion7,
+  rxjsVersion,
   tsLibVersion,
 } from '../../../utils/versions';
 
 export function addDependencies(tree: Tree): GeneratorCallback {
-  // Old nest 7 and rxjs 6 by default
-  let NEST_VERSION = nestJsVersion7;
-  let RXJS = rxjsVersion6;
-
-  const packageJson = readJson(tree, 'package.json');
-
-  if (packageJson.dependencies['@angular/core']) {
-    let rxjs = packageJson.dependencies['rxjs'];
-
-    if (rxjs.startsWith('~') || rxjs.startsWith('^')) {
-      rxjs = rxjs.substring(1);
-    }
-
-    if (satisfies(rxjs, rxjsVersion7)) {
-      NEST_VERSION = nestJsVersion8;
-      RXJS = packageJson.dependencies['rxjs'];
-    }
-  } else {
-    NEST_VERSION = nestJsVersion8;
-    RXJS = rxjsVersion7;
-  }
-
   return addDependenciesToPackageJson(
     tree,
     {
-      '@nestjs/common': NEST_VERSION,
-      '@nestjs/core': NEST_VERSION,
-      '@nestjs/platform-express': NEST_VERSION,
+      '@nestjs/common': nestJsVersion,
+      '@nestjs/core': nestJsVersion,
+      '@nestjs/platform-express': nestJsVersion,
       'reflect-metadata': reflectMetadataVersion,
-      rxjs: RXJS,
+      rxjs: rxjsVersion,
       tslib: tsLibVersion,
     },
     {
-      '@nestjs/schematics': nestJsSchematicsVersion,
-      '@nestjs/testing': NEST_VERSION,
+      '@nestjs/schematics': nestJsVersion,
+      '@nestjs/testing': nestJsVersion,
       '@nrwl/nest': nxVersion,
     }
   );

--- a/packages/nest/src/migrations/update-13-2-0/update-to-nest-8.ts
+++ b/packages/nest/src/migrations/update-13-2-0/update-to-nest-8.ts
@@ -1,12 +1,11 @@
 import { formatFiles, logger, readJson, Tree, updateJson } from '@nrwl/devkit';
 import { checkAndCleanWithSemver } from '@nrwl/workspace';
 import { satisfies } from 'semver';
-import {
-  nestJsSchematicsVersion,
-  nestJsVersion8,
-  rxjsVersion7,
-} from '../../utils/versions';
 import { sortObjectByKeys } from '@nrwl/workspace/src/utils/ast-utils';
+
+const nestJsSchematicsVersion = '^9.0.0';
+const nestJsVersion8 = '^8.0.0';
+const rxjsVersion7 = '^7.0.0';
 
 export default async function update(tree: Tree) {
   const shouldUpdate = await isUpdatable(tree);

--- a/packages/nest/src/utils/versions.ts
+++ b/packages/nest/src/utils/versions.ts
@@ -1,13 +1,6 @@
 export const nxVersion = require('../../package.json').version;
 
-export const nestJsVersion7 = '^7.0.0';
-export const nestJsVersion8 = '^8.0.0';
-
-export const nestJsSchematicsVersion = '^8.0.0';
-
-export const rxjsVersion6 = '~6.6.3';
-export const rxjsVersion7 = '^7.0.0';
-
+export const nestJsVersion = '^9.0.0';
+export const rxjsVersion = '^7.0.0';
 export const reflectMetadataVersion = '^0.1.13';
-
 export const tsLibVersion = '^2.3.0';


### PR DESCRIPTION
ISSUES CLOSED: #11344

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`versions.ts` in `nrwl/nest` was not updated leading to init a new Nest project didn't have v9

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Initializing a new NestJS project should have v9

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #11344
