### PR TITLE
feat(misc): autocomplete prompts

### DIFF
--- a/packages/add-nx-to-monorepo/src/add-nx-to-monorepo.ts
+++ b/packages/add-nx-to-monorepo/src/add-nx-to-monorepo.ts
@@ -63,7 +63,7 @@ async function askAboutNxCloud(parsedArgs: any) {
         {
           name: 'NxCloud',
           message: `Set up distributed caching using Nx Cloud (It's free and doesn't require registration.)`,
-          type: 'select',
+          type: 'autocomplete',
           choices: [
             {
               name: 'Yes',

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -359,7 +359,7 @@ async function determinePackageManager(
           name: 'PackageManager',
           message: `Which package manager to use       `,
           initial: 'npm' as any,
-          type: 'select',
+          type: 'autocomplete',
           choices: [
             { name: 'npm', message: 'NPM' },
             { name: 'yarn', message: 'Yarn' },
@@ -457,7 +457,7 @@ async function determinePreset(parsedArgs: any): Promise<Preset> {
         name: 'Preset',
         message: `What to create in the new workspace`,
         initial: 'empty' as any,
-        type: 'select',
+        type: 'autocomplete',
         choices: presetOptions,
       },
     ])
@@ -598,7 +598,7 @@ async function determineStyle(
           name: 'style',
           message: `Default stylesheet format          `,
           initial: 'css' as any,
-          type: 'select',
+          type: 'autocomplete',
           choices: choices,
         },
       ])
@@ -632,7 +632,7 @@ async function determineNxCloud(
         {
           name: 'NxCloud',
           message: `Set up distributed caching using Nx Cloud (It's free and doesn't require registration.)`,
-          type: 'select',
+          type: 'autocomplete',
           choices: [
             {
               name: 'Yes',
@@ -680,7 +680,7 @@ async function determineCI(
           {
             name: 'CI',
             message: `CI workflow file to generate?      `,
-            type: 'select',
+            type: 'autocomplete',
             initial: '' as any,
             choices: [
               { message: 'none', name: '' },

--- a/packages/make-angular-cli-faster/src/utilities/nx-cloud.ts
+++ b/packages/make-angular-cli-faster/src/utilities/nx-cloud.ts
@@ -7,7 +7,7 @@ export async function promptForNxCloud(): Promise<boolean> {
     {
       name: 'useNxCloud',
       message: `Set up distributed caching using Nx Cloud (It's free and doesn't require registration.)`,
-      type: 'select',
+      type: 'autocomplete',
       choices: [
         {
           name: 'Yes',

--- a/packages/nx/src/command-line/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/connect-to-nx-cloud.ts
@@ -62,7 +62,7 @@ async function connectToNxCloudPrompt(prompt?: string) {
         message:
           prompt ??
           `Set up distributed caching using Nx Cloud (It's free and doesn't require registration.)`,
-        type: 'select',
+        type: 'autocomplete',
         choices: [
           {
             name: 'Yes',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Prompts that have enumerable choices are selected via using the UP and DOWN arrow keys.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Prompts that have enumerable choices can be autocompleted. Users can start to type the choice they want and select the value that is highlighted by pressing ENTER. 
Selection via using the UP and DOWN arrow keys still works.

For example, when creating a workspace, you can type the preset you want.

![create-autocomplete](https://user-images.githubusercontent.com/8104246/181831170-c44753a9-e217-47a0-a650-bae8f91523cf.gif)

This also works for `$default.$source: 'projectName'` when the `defaultProject` is not set. :wink:

![project-autocomplete](https://user-images.githubusercontent.com/8104246/181828623-572ab245-47a9-4a5e-b80c-1ae161cd9e5a.gif)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
