### PR TITLE
fix(web): fix http-server proxyOptions arg converter (#11309)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,5 @@
 {
-  "packages": [
-    "build/packages/*"
-  ],
+  "packages": ["build/packages/*"],
   "version": "14.1.10",
   "granularPathspec": false,
   "command": {

--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -39,7 +39,7 @@ function getHttpServerArgs(options: Schema) {
 
   if (options.proxyOptions) {
     Object.keys(options.proxyOptions).forEach((key) => {
-      args.push(`--proxy-options.${key}=options.proxyOptions[key]`);
+      args.push(`--proxy-options.${key}=${options.proxyOptions[key]}`);
     });
   }
   return args;


### PR DESCRIPTION
Fix the string interpolation in the http-server command arg converter for proxyOptions.

ISSUES CLOSED: #11302

Co-authored-by: Szabolcs Grünwald <sgruenwald@eurofunk.com>
(cherry picked from commit 5614307ca2c7b24e463e2e99a130d7f3ddd02692)

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
