### PR TITLE
fix(react): allow positional params for setup-tailwind generator

### DIFF
--- a/docs/generated/packages/react.json
+++ b/docs/generated/packages/react.json
@@ -1284,7 +1284,8 @@
             "type": "string",
             "description": "The name of the project to add the Tailwind CSS setup for.",
             "alias": "p",
-            "$default": { "$source": "projectName" },
+            "$default": { "$source": "argv", "index": 0 },
+            "x-dropdown": "project",
             "x-prompt": "What project would you like to add the Tailwind CSS setup?"
           },
           "buildTarget": {

--- a/packages/react/src/generators/setup-tailwind/schema.json
+++ b/packages/react/src/generators/setup-tailwind/schema.json
@@ -16,7 +16,11 @@
       "type": "string",
       "description": "The name of the project to add the Tailwind CSS setup for.",
       "alias": "p",
-      "$default": { "$source": "projectName" },
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-dropdown": "project",
       "x-prompt": "What project would you like to add the Tailwind CSS setup?"
     },
     "buildTarget": {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

We can just pass the project using `--project` and not using positional args

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

It should be possible to invoke the generator like

```
nx g @nrwl/react:setup-tailwind <project-name>
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
