### PR TITLE
fix(node): add implicit dep on the e2e project to nest

### DIFF
--- a/e2e/node/project.json
+++ b/e2e/node/project.json
@@ -30,5 +30,5 @@
       "outputs": ["coverage/e2e/node"]
     }
   },
-  "implicitDependencies": ["node"]
+  "implicitDependencies": ["node", "nest"]
 }

--- a/e2e/node/src/node.test.ts
+++ b/e2e/node/src/node.test.ts
@@ -1,8 +1,8 @@
 import { stripIndents } from '@angular-devkit/core/src/utils/literals';
 import {
-  createFile,
   checkFilesDoNotExist,
   checkFilesExist,
+  createFile,
   expectJestTestsToPass,
   killPorts,
   newProject,
@@ -274,9 +274,9 @@ describe('Build Node apps', () => {
     expect(packageJson).toEqual(
       expect.objectContaining({
         dependencies: {
-          '@nestjs/common': '^8.0.0',
-          '@nestjs/core': '^8.0.0',
-          '@nestjs/platform-express': '^8.0.0',
+          '@nestjs/common': '^9.0.0',
+          '@nestjs/core': '^9.0.0',
+          '@nestjs/platform-express': '^9.0.0',
           'reflect-metadata': '^0.1.13',
           rxjs: '^7.0.0',
         },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
E2E tests were failing for `e2e-node` because versions were updated in `nest`. The `e2e-node` project has tests for `nest` but there was not an implicit dependency on `nest`. Therefore updates to `nest` did not mark `e2e-node` as affected.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`e2e-node` should have an implicit dependency on `nest` and it should pass correctly.
