### PR TITLE
fix(core): list local plugins

### DIFF
--- a/packages/nx/src/command-line/list.ts
+++ b/packages/nx/src/command-line/list.ts
@@ -9,6 +9,14 @@ import {
   listInstalledPlugins,
   listPluginCapabilities,
 } from '../utils/plugins';
+import {
+  getLocalWorkspacePlugins,
+  listLocalWorkspacePlugins,
+} from '../utils/plugins/local-plugins';
+import {
+  createProjectGraphAsync,
+  readProjectsConfigurationFromProjectGraph,
+} from '../project-graph/project-graph';
 
 export interface ListArgs {
   /** The name of an installed plugin to query  */
@@ -36,12 +44,18 @@ export async function listHandler(args: ListArgs): Promise<void> {
 
       return [];
     });
+    const projectGraph = await createProjectGraphAsync();
 
+    const localPlugins = getLocalWorkspacePlugins(
+      readProjectsConfigurationFromProjectGraph(projectGraph)
+    );
     const installedPlugins = getInstalledPluginsFromPackageJson(
       workspaceRoot,
       corePlugins,
       communityPlugins
     );
+
+    listLocalWorkspacePlugins(localPlugins);
     listInstalledPlugins(installedPlugins);
     listCorePlugins(installedPlugins, corePlugins);
     listCommunityPlugins(installedPlugins, communityPlugins);

--- a/packages/nx/src/utils/nx-plugin.ts
+++ b/packages/nx/src/utils/nx-plugin.ts
@@ -6,7 +6,11 @@ import { Workspaces } from '../config/workspaces';
 
 import { workspaceRoot } from './workspace-root';
 import { readJsonFile } from '../utils/fileutils';
-import { PackageJson, readModulePackageJson } from './package-json';
+import {
+  PackageJson,
+  readModulePackageJson,
+  readModulePackageJsonWithoutFallbacks,
+} from './package-json';
 import { registerTsProject } from './register';
 import {
   ProjectConfiguration,
@@ -118,7 +122,7 @@ export function readPluginPackageJson(
   json: PackageJson;
 } {
   try {
-    const result = readModulePackageJson(pluginName, paths);
+    const result = readModulePackageJsonWithoutFallbacks(pluginName, paths);
     return {
       json: result.packageJson,
       path: result.path,

--- a/packages/nx/src/utils/plugins/local-plugins.ts
+++ b/packages/nx/src/utils/plugins/local-plugins.ts
@@ -1,0 +1,70 @@
+import * as chalk from 'chalk';
+import { output } from '../output';
+import type { CommunityPlugin, CorePlugin, PluginCapabilities } from './models';
+import { getPluginCapabilities } from './plugin-capabilities';
+import { hasElements } from './shared';
+import { readJsonFile } from '../fileutils';
+import { PackageJson, readModulePackageJson } from '../package-json';
+import { ProjectsConfigurations } from 'nx/src/config/workspace-json-project-json';
+import { join } from 'path';
+import { workspaceRoot } from '../workspace-root';
+import { existsSync } from 'fs';
+import { ExecutorsJson, GeneratorsJson } from 'nx/src/config/misc-interfaces';
+
+export function getLocalWorkspacePlugins(
+  projectsConfiguration: ProjectsConfigurations
+): Map<string, PluginCapabilities> {
+  const plugins: Map<string, PluginCapabilities> = new Map();
+  for (const project of Object.values(projectsConfiguration.projects)) {
+    const packageJsonPath = join(workspaceRoot, project.root, 'package.json');
+    if (existsSync(packageJsonPath)) {
+      const packageJson: PackageJson = readJsonFile(packageJsonPath);
+      const capabilities: Partial<PluginCapabilities> = {};
+      const generatorsPath = packageJson.generators ?? packageJson.schematics;
+      const executorsPath = packageJson.executors ?? packageJson.builders;
+      if (generatorsPath) {
+        const file = readJsonFile<GeneratorsJson>(
+          join(workspaceRoot, project.root, generatorsPath)
+        );
+        capabilities.generators = file.generators ?? file.schematics;
+      }
+      if (executorsPath) {
+        const file = readJsonFile<ExecutorsJson>(
+          join(workspaceRoot, project.root, executorsPath)
+        );
+        capabilities.executors = file.executors ?? file.builders;
+      }
+      if (capabilities.executors || capabilities.generators) {
+        plugins.set(packageJson.name, {
+          executors: capabilities.executors ?? {},
+          generators: capabilities.generators ?? {},
+          name: packageJson.name,
+        });
+      }
+    }
+  }
+
+  return plugins;
+}
+
+export function listLocalWorkspacePlugins(
+  installedPlugins: Map<string, PluginCapabilities>
+) {
+  const bodyLines: string[] = [];
+
+  for (const [, p] of installedPlugins) {
+    const capabilities = [];
+    if (hasElements(p.executors)) {
+      capabilities.push('executors');
+    }
+    if (hasElements(p.generators)) {
+      capabilities.push('generators');
+    }
+    bodyLines.push(`${chalk.bold(p.name)} (${capabilities.join()})`);
+  }
+
+  output.log({
+    title: `Local workspace plugins:`,
+    bodyLines: bodyLines,
+  });
+}

--- a/packages/nx/src/utils/plugins/plugin-capabilities.ts
+++ b/packages/nx/src/utils/plugins/plugin-capabilities.ts
@@ -6,7 +6,7 @@ import type { PluginCapabilities } from './models';
 import { hasElements } from './shared';
 import { readJsonFile } from '../fileutils';
 import { getPackageManagerCommand } from '../package-manager';
-import { readModulePackageJson } from '../package-json';
+import { readPluginPackageJson } from '../nx-plugin';
 
 function tryGetCollection<T extends object>(
   packageJsonPath: string,
@@ -30,8 +30,8 @@ export function getPluginCapabilities(
   pluginName: string
 ): PluginCapabilities | null {
   try {
-    const { packageJson, path: packageJsonPath } =
-      readModulePackageJson(pluginName);
+    const { json: packageJson, path: packageJsonPath } =
+      readPluginPackageJson(pluginName);
     return {
       name: pluginName,
       generators:


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Generators from local plugins are not included in the prompt when running `nx g` without a default collection or specified collection. They are also not present in `nx report` or `nx list`

## Expected Behavior
Generators from local plugins are present in each expected location. They are separated from installed generators during prompting, s.t. they are more readily available to the user.


![image](https://user-images.githubusercontent.com/6933928/183219555-51bea872-59fa-4cce-9a36-4e780cbff581.png)


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
