### PR TITLE
fix(dep-graph): Fixed graph calculation when there are mixed targets

### DIFF
--- a/packages/nx/src/tasks-runner/create-task-graph.ts
+++ b/packages/nx/src/tasks-runner/create-task-graph.ts
@@ -139,12 +139,7 @@ export class ProcessTasks {
               );
             }
           } else {
-            this.processTask(
-              task,
-              depProject.name,
-              configuration,
-              taskOverrides
-            );
+            this.processTask(task, depProject.name, configuration, overrides);
           }
         }
       } else {

--- a/packages/nx/src/tasks-runner/create-task-graph.ts
+++ b/packages/nx/src/tasks-runner/create-task-graph.ts
@@ -135,7 +135,7 @@ export class ProcessTasks {
                 newTask,
                 newTask.target.project,
                 configuration,
-                taskOverrides
+                overrides
               );
             }
           } else {
@@ -175,7 +175,7 @@ export class ProcessTasks {
               newTask,
               newTask.target.project,
               configuration,
-              taskOverrides
+              overrides
             );
           }
         }


### PR DESCRIPTION
## Current Behavior

If there is a default target configuration with `params: 'forward'` and a different target which doesn't have that option you can end up with tasks which do not have the param forwarded.

## Expected Behavior

If there is configuration to forward params, they should be forwarded

## Related Issue(s)

Extends fix of #11103
