### PR TITLE
fix(express): tslib should be included if importHelpers is true

### DIFF
--- a/e2e/node/src/node.test.ts
+++ b/e2e/node/src/node.test.ts
@@ -279,6 +279,7 @@ describe('Build Node apps', () => {
           '@nestjs/platform-express': '^9.0.0',
           'reflect-metadata': '^0.1.13',
           rxjs: '^7.0.0',
+          tslib: '^2.3.0',
         },
         main: 'main.js',
         name: expect.any(String),

--- a/packages/express/src/generators/init/init.spec.ts
+++ b/packages/express/src/generators/init/init.spec.ts
@@ -27,6 +27,8 @@ describe('init', () => {
     const packageJson = readJson(tree, 'package.json');
     // add express
     expect(packageJson.dependencies['express']).toBeDefined();
+    // add tslib
+    expect(packageJson.dependencies['tslib']).toBeDefined();
     // move `@nrwl/express` to dev
     expect(packageJson.dependencies['@nrwl/express']).toBeUndefined();
     expect(packageJson.devDependencies['@nrwl/express']).toBeDefined();

--- a/packages/express/src/generators/init/init.ts
+++ b/packages/express/src/generators/init/init.ts
@@ -6,6 +6,7 @@ import {
   Tree,
 } from '@nrwl/devkit';
 import { initGenerator as nodeInitGenerator } from '@nrwl/node';
+import { tslibVersion } from '@nrwl/node/src/utils/versions';
 import {
   expressTypingsVersion,
   expressVersion,
@@ -20,6 +21,7 @@ function updateDependencies(tree: Tree) {
     tree,
     {
       express: expressVersion,
+      tslib: tslibVersion,
     },
     {
       '@types/express': expressTypingsVersion,


### PR DESCRIPTION
ISSUES CLOSED: #11012

## Current Behavior
`GeneratePackageJsonPlugin` does not respect `importHelpers` property in `tsconfig` used to compile typescript

## Expected Behavior
- `GeneratePackageJsonPlugin` respects `importHelpers` property
- `nrwl/express:init` also has `tslib` added to `dependencies` along with `express`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #11012
