### PR TITLE
fix(core): resolve project files correctly in project graph creation for empty root

### DIFF
--- a/e2e/nx-init/src/nx-project-graph.test.ts
+++ b/e2e/nx-init/src/nx-project-graph.test.ts
@@ -49,7 +49,7 @@ describe('project graph creation', () => {
     expect(graphJson.nodes[libName].data.files.length).toBeGreaterThan(0);
   });
 
-  it("should correctly build the nxdeps.json containing files for the project when root is '' and for project that do not have root as ''", () => {
+  it("should correctly build the graph.json containing files for the project when root is '' and for project that do not have root as ''", () => {
     // ARRANGE
     const libName = uniq('mylib');
     const secondLibName = uniq('mysecondlib');

--- a/e2e/nx-init/src/nx-project-graph.test.ts
+++ b/e2e/nx-init/src/nx-project-graph.test.ts
@@ -1,0 +1,74 @@
+import {
+  cleanupProject,
+  newProject,
+  readJson,
+  runCLI,
+  uniq,
+  updateJson,
+} from '@nrwl/e2e/utils';
+
+describe('project graph creation', () => {
+  let proj;
+
+  beforeAll(() => newProject());
+  afterAll(() => cleanupProject());
+
+  it('should correctly build the nxdeps.json containing files for the project', () => {
+    // ARRANGE
+    const libName = uniq('mylib');
+
+    runCLI(`generate @nrwl/workspace:lib ${libName}`);
+
+    // ACT
+
+    runCLI(`graph --file=graph.json`);
+
+    // ASSERT
+    const { graph: graphJson } = readJson('graph.json');
+
+    expect(graphJson.nodes[libName].data.files.length).toBeGreaterThan(0);
+  });
+
+  it("should correctly build the nxdeps.json containing files for the project when root is ''", () => {
+    // ARRANGE
+    const libName = uniq('mylib');
+
+    runCLI(`generate @nrwl/workspace:lib ${libName}`);
+    updateJson(`libs/${libName}/project.json`, (json) => ({
+      ...json,
+      root: '',
+    }));
+
+    // ACT
+
+    runCLI(`graph --file=graph.json`);
+
+    // ASSERT
+
+    const { graph: graphJson } = readJson('graph.json');
+    expect(graphJson.nodes[libName].data.files.length).toBeGreaterThan(0);
+  });
+
+  it("should correctly build the nxdeps.json containing files for the project when root is '' and for project that do not have root as ''", () => {
+    // ARRANGE
+    const libName = uniq('mylib');
+    const secondLibName = uniq('mysecondlib');
+
+    runCLI(`generate @nrwl/workspace:lib ${libName}`);
+    runCLI(`generate @nrwl/workspace:lib ${secondLibName}`);
+    updateJson(`libs/${libName}/project.json`, (json) => ({
+      ...json,
+      root: '',
+    }));
+
+    // ACT
+
+    runCLI(`graph --file=graph.json`);
+
+    // ASSERT
+
+    const { graph: graphJson } = readJson('graph.json');
+    expect(graphJson.nodes[libName].data.files.length).toBeGreaterThan(0);
+    expect(graphJson.nodes[secondLibName].data.files.length).toBeGreaterThan(0);
+  });
+});

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -2,8 +2,8 @@ import {
   joinPathFragments,
   parseJson,
   ProjectConfiguration,
-  readJsonFile,
   ProjectsConfigurations,
+  readJsonFile,
 } from '@nrwl/devkit';
 import { angularCliVersion } from '@nrwl/workspace/src/utils/versions';
 import { ChildProcess, exec, execSync, ExecSyncOptions } from 'child_process';
@@ -329,7 +329,7 @@ export function newProject({
     }
 
     if (process.env.NX_VERBOSE_LOGGING == 'true') {
-      console.log(`E2E test is creating a project: ${tmpProjPath()}`);
+      logInfo(`NX`, `E2E test is creating a project: ${tmpProjPath()}`);
     }
     return projScope;
   } catch (e) {

--- a/packages/nx/src/project-graph/file-map-utils.ts
+++ b/packages/nx/src/project-graph/file-map-utils.ts
@@ -10,7 +10,10 @@ function createProjectRootMappings(
     if (!projectFileMap[projectName]) {
       projectFileMap[projectName] = [];
     }
-    const root = workspaceJson.projects[projectName].root;
+    const root =
+      workspaceJson.projects[projectName].root === ''
+        ? '.'
+        : workspaceJson.projects[projectName].root;
     projectRootMappings.set(
       root.endsWith('/') ? root.substring(0, root.length - 1) : root,
       projectFileMap[projectName]
@@ -23,16 +26,15 @@ function findMatchingProjectFiles(
   projectRootMappings: Map<string, FileData[]>,
   file: string
 ) {
-  for (
-    let currentPath = dirname(file);
-    currentPath != dirname(currentPath);
-    currentPath = dirname(currentPath)
-  ) {
+  let currentPath = file;
+  do {
+    currentPath = dirname(currentPath);
     const p = projectRootMappings.get(currentPath);
     if (p) {
       return p;
     }
-  }
+  } while (currentPath != dirname(currentPath));
+
   return null;
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently, the project graph does not correctly find files for projects that have `root: ''` in their configuration.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The project graph should find the files correctly, regardless of the project's `root` property in its configuration.

## Notes
This _does_ mean that projects with a `root: ''` in their configuration will take into consideration files that _may_ not be related to the project (e.g. `.gitignore`, `.editorconfig` etc). This could impact hashing, however, it is schematically correct given `root: ''` encompasses these files. 

Users can improve their hashing performance by setting up `inputs` and `namedInputs` that apply to the project.