### PR TITLE
fix(testing): install ts-node when migrating to ts jest config files

### DIFF
--- a/packages/jest/src/migrations/update-14-1-5/update-exports-jest-config.spec.ts
+++ b/packages/jest/src/migrations/update-14-1-5/update-exports-jest-config.spec.ts
@@ -3,6 +3,8 @@ import {
   stripIndents,
   Tree,
   updateProjectConfiguration,
+  updateJson,
+  readJson,
 } from '@nrwl/devkit';
 import { createTree, createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { libraryGenerator as workspaceLib } from '@nrwl/workspace';
@@ -86,9 +88,19 @@ module.exports = {
 };
 `
     );
+    updateJson(tree, 'package.json', (json) => {
+      delete json.devDependencies['ts-node'];
+      return json;
+    });
+    expect(
+      readJson(tree, 'package.json').devDependencies['ts-node']
+    ).toBeUndefined();
     updateExportsJestConfig(tree);
 
     const config = tree.read('libs/lib-one/jest.config.ts', 'utf-8');
+    expect(readJson(tree, 'package.json').devDependencies['ts-node']).toEqual(
+      '10.9.1'
+    );
     expect(config).toMatchSnapshot();
   });
 

--- a/packages/jest/src/migrations/update-14-1-5/update-exports-jest-config.ts
+++ b/packages/jest/src/migrations/update-14-1-5/update-exports-jest-config.ts
@@ -1,4 +1,6 @@
+import { addDependenciesToPackageJson, GeneratorCallback } from '@nrwl/devkit';
 import type { Tree } from '@nrwl/devkit';
+import { tsNodeVersion } from '../../utils/versions';
 import { forEachExecutorOptions } from '@nrwl/workspace/src/utilities/executor-options-utils';
 import { tsquery } from '@phenomnomnominal/tsquery';
 import type { BinaryExpression } from 'typescript';
@@ -6,6 +8,7 @@ import type { JestExecutorOptions } from '../../executors/jest/schema';
 
 export function updateExportsJestConfig(tree: Tree) {
   const { didUpdateRootPreset } = updateRootFiles(tree);
+  let shouldInstallTsNode = false;
   forEachExecutorOptions<JestExecutorOptions>(
     tree,
     '@nrwl/jest:jest',
@@ -13,6 +16,7 @@ export function updateExportsJestConfig(tree: Tree) {
       if (options.jestConfig && tree.exists(options.jestConfig)) {
         if (options.jestConfig.endsWith('.ts')) {
           updateToDefaultExport(tree, options.jestConfig);
+          shouldInstallTsNode = true;
         }
 
         const updatedImport = updateNxPresetImport(
@@ -32,6 +36,10 @@ export function updateExportsJestConfig(tree: Tree) {
       }
     }
   );
+
+  return shouldInstallTsNode
+    ? addDependenciesToPackageJson(tree, {}, { 'ts-node': tsNodeVersion })
+    : () => {};
 }
 
 export function updateRootFiles(tree: Tree): { didUpdateRootPreset: boolean } {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
jest throws error about needing ts-node after migration to ts jest config files

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
ts-node is installed when migrating to jest ts config files
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #10846
should go in after #11429 