### PR TITLE
fix(angular): adds missing types in the schemes of `remote` and `host` generators

### DIFF
--- a/packages/angular/src/generators/host/schema.d.ts
+++ b/packages/angular/src/generators/host/schema.d.ts
@@ -1,3 +1,9 @@
+import { Linter } from '@nrwl/linter';
+import { E2eTestRunner, UnitTestRunner } from '../../utils/test-runners';
+import type { Styles } from '../utils/types';
+
+type AngularLinter = Exclude<Linter, Linter.TsLint>;
+
 export interface Schema {
   name: string;
   remotes?: string[];

--- a/packages/angular/src/generators/remote/schema.d.ts
+++ b/packages/angular/src/generators/remote/schema.d.ts
@@ -1,3 +1,9 @@
+import { Linter } from '@nrwl/linter';
+import { E2eTestRunner, UnitTestRunner } from '../../utils/test-runners';
+import type { Styles } from '../utils/types';
+
+type AngularLinter = Exclude<Linter, Linter.TsLint>;
+
 export interface Schema {
   name: string;
   host?: string;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

I have created a new workspace generator:
```ts
import { formatFiles, installPackagesTask, Tree } from '@nrwl/devkit';
import { libraryGenerator } from '@nrwl/angular/generators';

export default async function (tree: Tree, schema: any) {
  await libraryGenerator(tree, {
    name: schema.name,
  });
  await formatFiles(tree);
  return () => {
    installPackagesTask(tree);
  };
}
```
When I run it I get an error:
```
❯ nx workspace-generator web-page
node_modules/@nrwl/angular/src/generators/host/schema.d.ts:10:11 - error TS2304: Cannot find name 'Styles'.

10   style?: Styles;
             ~~~~~~

node_modules/@nrwl/angular/src/generators/host/schema.d.ts:14:12 - error TS2304: Cannot find name 'AngularLinter'.

14   linter?: AngularLinter;
              ~~~~~~~~~~~~~

node_modules/@nrwl/angular/src/generators/host/schema.d.ts:15:20 - error TS2304: Cannot find name 'UnitTestRunner'.

15   unitTestRunner?: UnitTestRunner;
                      ~~~~~~~~~~~~~~

node_modules/@nrwl/angular/src/generators/host/schema.d.ts:16:19 - error TS2304: Cannot find name 'E2eTestRunner'.

16   e2eTestRunner?: E2eTestRunner;
                     ~~~~~~~~~~~~~

node_modules/@nrwl/angular/src/generators/remote/schema.d.ts:9:11 - error TS2304: Cannot find name 'Styles'.

9   style?: Styles;
            ~~~~~~

node_modules/@nrwl/angular/src/generators/remote/schema.d.ts:13:12 - error TS2304: Cannot find name 'AngularLinter'.

13   linter?: AngularLinter;
              ~~~~~~~~~~~~~

node_modules/@nrwl/angular/src/generators/remote/schema.d.ts:14:20 - error TS2304: Cannot find name 'UnitTestRunner'.

14   unitTestRunner?: UnitTestRunner;
                      ~~~~~~~~~~~~~~

node_modules/@nrwl/angular/src/generators/remote/schema.d.ts:15:19 - error TS2304: Cannot find name 'E2eTestRunner'.

15   e2eTestRunner?: E2eTestRunner;
                     ~~~~~~~~~~~~~


Found 8 errors in 2 files.

Errors  Files
     4  node_modules/@nrwl/angular/src/generators/host/schema.d.ts:10
     4  node_modules/@nrwl/angular/src/generators/remote/schema.d.ts:9
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

New generator works fine.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
