### PR TITLE
fix(core): correctly handle overrides of watch flag for caching

### DIFF
--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -297,7 +297,10 @@ export function isCacheableTask(
 function longRunningTask(task: Task) {
   const t = task.target.target;
   return (
-    !!task.overrides['watch'] || t === 'serve' || t === 'dev' || t === 'start'
+    (!!task.overrides['watch'] && task.overrides['watch'] !== 'false') ||
+    t === 'serve' ||
+    t === 'dev' ||
+    t === 'start'
   );
 }
 


### PR DESCRIPTION
Previously if the --watch flag were being overridden, when attempting to determine if a given task is long-running, we would perform a !!value check against the override. Since overrides are passed through as strings, if a --watch override was provided at all, the task would be marked as long running -- even if the override was disabling watch mode.

This has a side effect of the Nx Cloud runner not persisting task outputs to the remote cache, causing any task with a --watch override running in DTE to fail.
