### PR TITLE
fix(web): fix json imports in rollup with swc

### DIFF
--- a/packages/web/src/executors/rollup/rollup.impl.ts
+++ b/packages/web/src/executors/rollup/rollup.impl.ts
@@ -205,6 +205,7 @@ export function createRollupOptions(
         ),
       }),
       image(),
+      json(),
       useBabel &&
         require('rollup-plugin-typescript2')({
           check: true,
@@ -258,7 +259,6 @@ export function createRollupOptions(
         }),
       commonjs(),
       analyze(),
-      json(),
     ];
 
     const globals = options.globals


### PR DESCRIPTION
moved the json plugin to be before the swc plugin in the rollup executor

ISSUES CLOSED: 11435

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When importing a JSON file in a lib generated with `@nrwl/react:library` and `compiler=swc` (`"resolveJsonModule": true` set in `tsconfig.json`), I get an error and the build fails.

## Expected Behavior
After creating a react lib using `@nrwl/react:library` and `compiler=swc`, and setting "resolveJsonModule": true in `tsconfig.json`, I expect to be able to import the contents of JSON files inside of .ts files.

## Related Issue(s)
https://github.com/nrwl/nx/issues/11435

Fixes #11435 
