### PR TITLE
fix(core): fix backwards compatibility with Nx 14.1.0

### DIFF
--- a/packages/devkit/index.ts
+++ b/packages/devkit/index.ts
@@ -10,6 +10,16 @@
  */
 
 /**
+ * Note to developers: This is the Public API of @nrwl/devkit.
+ * @nrwl/devkit should be compatible with versions of Nx 1 major version prior.
+ * This is so that plugins can use the latest @nrwl/devkit while their users may use versions +/- 1 of Nx.
+ *
+ * 1. Try hard to not add to this API to reduce the surface area we need to maintain.
+ * 2. Do not add newly created paths from the nx package to this file as they will not be available in older versions of Nx.
+ *   a. We might need to duplicate code instead of importing from nx until all supported versions of nx contain the file.
+ */
+
+/**
  * @category Tree
  */
 export type { Tree, FileChange } from 'nx/src/generators/tree';
@@ -48,11 +58,12 @@ export type {
  */
 export { Workspaces } from 'nx/src/config/workspaces';
 
+// TODO (v16): Change this to export from 'nx/src/config/configuration'
 export {
   readNxJson,
   readAllWorkspaceConfiguration,
   workspaceLayout,
-} from 'nx/src/config/configuration';
+} from 'nx/src/project-graph/file-utils';
 
 export type {
   NxPlugin,
@@ -284,10 +295,11 @@ export {
  */
 export { moveFilesToNewDirectory } from './src/utils/move-dir';
 
+// TODO(v16): Change this to export from 'nx/src/utils/workspace-root'
 /**
  * @category Utils
  */
-export { workspaceRoot, appRootPath } from 'nx/src/utils/workspace-root';
+export { workspaceRoot, appRootPath } from 'nx/src/utils/app-root';
 
 /**
  * @category Utils

--- a/packages/nx/src/config/configuration.ts
+++ b/packages/nx/src/config/configuration.ts
@@ -7,6 +7,7 @@ export function readNxJson(): NxJsonConfiguration {
   return new Workspaces(workspaceRoot).readNxJson();
 }
 
+// TODO(v16): Remove this
 /**
  * @deprecated Use readProjectsConfigurationFromProjectGraph(await createProjectGraphAsync())
  */

--- a/packages/nx/src/project-graph/file-utils.ts
+++ b/packages/nx/src/project-graph/file-utils.ts
@@ -157,3 +157,10 @@ export function readPackageJson(): any {
 }
 // Original Exports
 export { FileData };
+
+// TODO(v16): Remove these exports
+export {
+  readNxJson,
+  readAllWorkspaceConfiguration,
+  workspaceLayout,
+} from '../config/configuration';

--- a/packages/nx/src/utils/app-root.ts
+++ b/packages/nx/src/utils/app-root.ts
@@ -1,0 +1,10 @@
+// TODO(v16): Remove this file
+import { workspaceRoot } from 'nx/src/utils/workspace-root';
+
+/**
+ * The root of the workspace.
+ *
+ * @deprecated use workspaceRoot instead
+ */
+export const appRootPath = workspaceRoot;
+export { workspaceRoot };

--- a/packages/nx/src/utils/workspace-root.ts
+++ b/packages/nx/src/utils/workspace-root.ts
@@ -6,13 +6,6 @@ import { fileExists } from './fileutils';
  */
 export const workspaceRoot = workspaceRootInner(process.cwd(), process.cwd());
 
-/**
- * The root of the workspace.
- *
- * @deprecated use workspaceRoot instead
- */
-export const appRootPath = workspaceRoot;
-
 export function workspaceRootInner(
   dir: string,
   candidateRoot: string | null

--- a/packages/workspace/src/utils/app-root.ts
+++ b/packages/workspace/src/utils/app-root.ts
@@ -1,1 +1,2 @@
-export { appRootPath, workspaceRoot } from 'nx/src/utils/workspace-root';
+// TODO(v15): Remove this file
+export { appRootPath, workspaceRoot } from '@nrwl/devkit';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Plugins that use `@nrwl/devkit@>=14.2.0` are not compatible with Nx workspaces that use `nx@<=14.2.0`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Plugins that use `@nrwl/devkit` are compatible with Nx workspaces 1 major version it.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/11423
