### PR TITLE
feat(node): expose webpack watchOptions to executor

### DIFF
--- a/docs/generated/packages/node.json
+++ b/docs/generated/packages/node.json
@@ -301,6 +301,22 @@
             "description": "Run build when files change.",
             "default": false
           },
+          "watchOptions": {
+            "type": "object",
+            "description": "A set of options used to customize watch mode.",
+            "properties": {
+              "aggregateTimeout": { "type": "integer" },
+              "ignored": {
+                "oneOf": [
+                  { "type": "array", "items": { "type": "string" } },
+                  { "type": "string" }
+                ]
+              },
+              "poll": { "type": "integer" },
+              "followSymlinks": { "type": "boolean" },
+              "stdin": { "type": "boolean" }
+            }
+          },
           "poll": {
             "type": "number",
             "description": "Frequency of file watcher in ms."

--- a/packages/node/src/executors/webpack/schema.json
+++ b/packages/node/src/executors/webpack/schema.json
@@ -26,6 +26,37 @@
       "description": "Run build when files change.",
       "default": false
     },
+    "watchOptions": {
+      "type": "object",
+      "description": "A set of options used to customize watch mode.",
+      "properties": {
+        "aggregateTimeout": {
+          "type": "integer"
+        },
+        "ignored": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "poll": {
+          "type": "integer"
+        },
+        "followSymlinks": {
+          "type": "boolean"
+        },
+        "stdin": {
+          "type": "boolean"
+        }
+      }
+    },
     "poll": {
       "type": "number",
       "description": "Frequency of file watcher in ms."

--- a/packages/node/src/executors/webpack/webpack.impl.spec.ts
+++ b/packages/node/src/executors/webpack/webpack.impl.spec.ts
@@ -84,6 +84,27 @@ describe('Node Build Executor', () => {
     );
   });
 
+  it('should use watchOptions if passed in', async () => {
+    await webpackExecutor(
+      {
+        ...options,
+        watchOptions: {
+          ignored: ['path1'],
+        },
+      },
+      context
+    ).next();
+
+    expect(runWebpack).toHaveBeenCalledWith(
+      expect.objectContaining({
+        watchOptions: {
+          ignored: ['path1'],
+          aggregateTimeout: 200,
+        },
+      })
+    );
+  });
+
   describe('webpackConfig', () => {
     it('should handle custom path', async () => {
       jest.mock(

--- a/packages/node/src/utils/config.ts
+++ b/packages/node/src/utils/config.ts
@@ -113,6 +113,7 @@ export function getBaseWebpackPartial(
       // two builds on a single file change.
       aggregateTimeout: 200,
       poll: options.poll,
+      ...options.watchOptions,
     },
     stats: getStatsConfig(options),
     experiments: {

--- a/packages/node/src/utils/types.ts
+++ b/packages/node/src/utils/types.ts
@@ -59,11 +59,20 @@ export interface AdditionalEntryPoint {
   entryPath: string;
 }
 
+export interface WebpackWatchOptions {
+  aggregateTimeout?: number;
+  ignored?: Array<string> | string;
+  poll?: number;
+  followSymlinks?: boolean;
+  stdin?: boolean;
+}
+
 export interface BuildBuilderOptions {
   main: string;
   outputPath: string;
   tsConfig: string;
   watch?: boolean;
+  watchOptions?: WebpackWatchOptions;
   sourceMap?: boolean | SourceMapOptions;
   optimization?: boolean | OptimizationOptions;
   maxWorkers?: number;


### PR DESCRIPTION
Add watchOptions to node executor

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
@nrwl/node didn't accept any `watchOptions` which provided to webpack

## Expected Behavior
expose `watchOptions` to @nrwl/node to support dynamic webpack config

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
https://github.com/nrwl/nx/issues/11450

Fixes #
