### PR TITLE
fix(angular): building all projects in webpack-server #11349

### DIFF
--- a/packages/angular/src/builders/webpack-server/webpack-server.impl.ts
+++ b/packages/angular/src/builders/webpack-server/webpack-server.impl.ts
@@ -112,13 +112,19 @@ export function executeWebpackServerBuilder(
         const workspaceDependencies = dependencies
           .filter((dep) => !isNpmProject(dep.node))
           .map((dep) => dep.node.name);
-        baseWebpackConfig.plugins.push(
-          new WebpackNxBuildCoordinationPlugin(
-            `nx run-many --target=${
-              parsedBrowserTarget.target
-            } --projects=${workspaceDependencies.join(',')}`
-          )
-        );
+        // default for `nx run-many` is --all projects
+        // by passing an empty string for --projects, run-many will default to
+        // run the target for all projects.
+        // This will occur when workspaceDependencies = []
+        if (workspaceDependencies.length > 0) {
+          baseWebpackConfig.plugins.push(
+            new WebpackNxBuildCoordinationPlugin(
+              `nx run-many --target=${
+                parsedBrowserTarget.target
+              } --projects=${workspaceDependencies.join(',')}`
+            )
+          );
+        }
       }
 
       if (!pathToWebpackConfig) {


### PR DESCRIPTION
## Current Behavior
Having `buildLibsFromSource` set to false for the build target is forcing `webpack-server` to also assume that value. Then, if a project has no dependents we run `nx run-many --target=build --projects=''`.

The default for `run-many` is `--all` projects, so it falls back to this.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should only attempt to run builds for dependent projects when there are some.

## Related Issues

Fixes #11349