### PR TITLE
fix(testing): restore path in update-jestconfig

### DIFF
--- a/packages/jest/src/generators/jest-project/lib/update-jestconfig.ts
+++ b/packages/jest/src/generators/jest-project/lib/update-jestconfig.ts
@@ -19,6 +19,6 @@ export function updateJestConfig(host: Tree, options: JestProjectSchema) {
     host,
     findRootJestConfig(host),
     'projects',
-    `<rootDir>/$"14.4.0-beta.5"root}`
+    `<rootDir>/${project.root}`
   );
 }


### PR DESCRIPTION
Reverts what looks like a search and replace gone awry.

## Current Behavior
Sets a Jest project path to `<rootDir>/$"14.4.0-beta.5"root}`

## Expected Behavior
Reverts to the original path, `<rootDir>/${project.root}`
