### PR TITLE
Revert "fix(core): add -c as an alias for --configuration for `affect…

### DIFF
--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -438,7 +438,6 @@ function withAffectedOptions(yargs: yargs.Argv): yargs.Argv {
     .options('configuration', {
       describe:
         'This is the configuration to use when performing tasks on projects',
-      alias: 'c',
       type: 'string',
     })
     .options('only-failed', {
@@ -499,7 +498,6 @@ function withRunManyOptions(yargs: yargs.Argv): yargs.Argv {
     .options('configuration', {
       describe:
         'This is the configuration to use when performing tasks on projects',
-      alias: 'c',
       type: 'string',
     })
     .options('only-failed', {


### PR DESCRIPTION
…ed` and … (#10993)"

This reverts commit 355dc54d8f6ac05e806fb4e36dc2c29d1c448aee.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The command `nx affected:build --configuration production` fails on github.com/nrwl/nx-examples.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The command `nx affected:build --configuration production` passes.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
