### PR TITLE
cleanup(angular): add e2e test for make-angular-cli-faster on nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,7 @@ jobs:
       - run:
           name: Run E2E Tests
           command: |
-            npx nx affected --target=e2e --base=$NX_BASE --head=$NX_HEAD --exclude=e2e-storybook,e2e-storybook-angular,e2e-react-native,e2e-detox --parallel=1
+            npx nx affected --target=e2e --base=$NX_BASE --head=$NX_HEAD --exclude=e2e-storybook,e2e-storybook-angular,e2e-react-native,e2e-detox,e2e-make-angular-cli-faster --parallel=1
           no_output_timeout: 45m
       - run:
           name: Stop All Running Agents for This CI Run
@@ -236,7 +236,7 @@ jobs:
           name: Run E2E Tests
           command: |
             if $E2E_AFFECTED; then
-              npx nx affected --target=e2e --base=$NX_BASE --head=$NX_HEAD --exclude=e2e-detox,e2e-js,e2e-next,e2e-workspace-create,e2e-nx-run,e2e-nx-misc,e2e-react,e2e-web,e2e-angular-extensions,e2e-angular-core,e2e-nx-plugin,e2e-cypress,e2e-node,e2e-linter,e2e-jest,e2e-add-nx-to-monorepo,nx-dev-e2e,e2e-nx-init,e2e-dep-graph-client --parallel=1;
+              npx nx affected --target=e2e --base=$NX_BASE --head=$NX_HEAD --exclude=e2e-make-angular-cli-faster,e2e-detox,e2e-js,e2e-next,e2e-workspace-create,e2e-nx-run,e2e-nx-misc,e2e-react,e2e-web,e2e-angular-extensions,e2e-angular-core,e2e-nx-plugin,e2e-cypress,e2e-node,e2e-linter,e2e-jest,e2e-add-nx-to-monorepo,nx-dev-e2e,e2e-nx-init,e2e-dep-graph-client --parallel=1;
             else
               echo "Skipping E2E tests";
             fi

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -35,6 +35,7 @@ jobs:
           - e2e-angular-core
           - e2e-angular-extensions
           - e2e-nx-run,e2e-nx-misc,e2e-nx-plugin
+          - e2e-make-angular-cli-faster
           - e2e-jest
           - e2e-linter
           - e2e-cypress
@@ -82,6 +83,8 @@ jobs:
             packages: e2e-add-nx-to-monorepo
           - os: macos-latest
             packages: e2e-dep-graph-client
+          - os: macos-latest
+            packages: e2e-make-angular-cli-faster
       fail-fast: false
 
     name: ${{ matrix.os-name }}/${{ matrix.package_manager }} - ${{ matrix.packages }}

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -23,6 +23,7 @@ jobs:
           - e2e-angular-core
           - e2e-angular-extensions
           - e2e-nx-run,e2e-nx-misc,e2e-nx-plugin
+          - e2e-make-angular-cli-faster
           - e2e-jest
           - e2e-linter
           - e2e-cypress

--- a/e2e/make-angular-cli-faster/jest.config.ts
+++ b/e2e/make-angular-cli-faster/jest.config.ts
@@ -1,0 +1,10 @@
+export default {
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
+  maxWorkers: 1,
+  globals: { 'ts-jest': { tsconfig: '<rootDir>/tsconfig.spec.json' } },
+  displayName: 'e2e-make-angular-cli-faster',
+  preset: '../../jest.preset.js',
+};

--- a/e2e/make-angular-cli-faster/project.json
+++ b/e2e/make-angular-cli-faster/project.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "e2e/make-angular-cli-faster",
+  "projectType": "application",
+  "targets": {
+    "e2e": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          {
+            "command": "yarn e2e-start-local-registry"
+          },
+          {
+            "command": "yarn e2e-build-package-publish"
+          },
+          {
+            "command": "nx run-e2e-tests e2e-make-angular-cli-faster"
+          }
+        ],
+        "parallel": false
+      }
+    },
+    "run-e2e-tests": {
+      "executor": "@nrwl/jest:jest",
+      "options": {
+        "jestConfig": "e2e/make-angular-cli-faster/jest.config.ts",
+        "passWithNoTests": true,
+        "runInBand": true
+      },
+      "outputs": ["coverage/e2e/make-angular-cli-faster"]
+    }
+  },
+  "implicitDependencies": ["make-angular-cli-faster"]
+}

--- a/e2e/make-angular-cli-faster/src/make-angular-cli-faster.test.ts
+++ b/e2e/make-angular-cli-faster/src/make-angular-cli-faster.test.ts
@@ -1,0 +1,42 @@
+import {
+  cleanupProject,
+  getSelectedPackageManager,
+  runNgNew,
+  tmpProjPath,
+  uniq,
+} from '../../utils';
+import { PackageManager } from 'nx/src/utils/package-manager';
+import { execSync } from 'child_process';
+
+describe('make-angular-cli-faster', () => {
+  let project: string;
+  let packageManager: PackageManager;
+
+  beforeEach(() => {
+    project = uniq('proj');
+    packageManager = getSelectedPackageManager();
+    // TODO: solve issues with pnpm and remove this fallback
+    packageManager = packageManager === 'pnpm' ? 'yarn' : packageManager;
+  });
+
+  afterEach(() => {
+    cleanupProject();
+  });
+
+  it('should successfully install make-angular-cli-faster with nx cloud', () => {
+    // ARRANGE
+    runNgNew(project, packageManager);
+
+    expect(() =>
+      execSync(
+        `NPM_CONFIG_REGISTRY=https://registry.npmjs.org npx --yes make-angular-cli-faster@latest --useNxCloud=true`,
+        {
+          cwd: tmpProjPath(),
+          env: process.env,
+          encoding: 'utf-8',
+          stdio: ['pipe', 'pipe', 'pipe'],
+        }
+      )
+    ).not.toThrow();
+  });
+});

--- a/e2e/make-angular-cli-faster/tsconfig.json
+++ b/e2e/make-angular-cli-faster/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node", "jest"]
+  },
+  "include": [],
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/e2e/make-angular-cli-faster/tsconfig.spec.json
+++ b/e2e/make-angular-cli-faster/tsconfig.spec.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.test.tsx",
+    "**/*.spec.js",
+    "**/*.test.js",
+    "**/*.spec.jsx",
+    "**/*.test.jsx",
+    "**/*.d.ts",
+    "jest.config.ts"
+  ]
+}

--- a/packages/make-angular-cli-faster/src/index.ts
+++ b/packages/make-angular-cli-faster/src/index.ts
@@ -8,7 +8,7 @@ import {
 
 const args = yargsParser(process.argv, {
   string: ['version'],
-  boolean: ['verbose'],
+  boolean: ['verbose', 'useNxCloud'],
 });
 
 makeAngularCliFaster(args as Args)

--- a/packages/make-angular-cli-faster/src/utilities/make-angular-cli-faster.ts
+++ b/packages/make-angular-cli-faster/src/utilities/make-angular-cli-faster.ts
@@ -6,6 +6,7 @@ import { installDependencies } from './package-manager';
 export interface Args {
   version?: string;
   verbose?: boolean;
+  useNxCloud?: boolean;
 }
 
 export async function makeAngularCliFaster(args: Args) {
@@ -14,7 +15,10 @@ export async function makeAngularCliFaster(args: Args) {
   output.log({ title: '🧐 Checking versions compatibility' });
   const migration = await determineMigration(args.version);
 
-  const useNxCloud = await promptForNxCloud();
+  const useNxCloud =
+    args.useNxCloud !== null && args.useNxCloud !== undefined
+      ? args.useNxCloud
+      : await promptForNxCloud();
 
   output.log({ title: '📦 Installing dependencies' });
   await installDependencies(migration, useNxCloud);

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -4,8 +4,8 @@ import { remove } from 'fs-extra';
 import { dirname, join } from 'path';
 import { dirSync } from 'tmp';
 import { promisify } from 'util';
-import { readJsonFile, writeJsonFile } from './fileutils';
-import { PackageJson, readModulePackageJson } from './package-json';
+import { writeJsonFile } from './fileutils';
+import { readModulePackageJson } from './package-json';
 import { gte, lt } from 'semver';
 
 const execAsync = promisify(exec);

--- a/workspace.json
+++ b/workspace.json
@@ -21,6 +21,7 @@
     "e2e-jest": "e2e/jest",
     "e2e-js": "e2e/js",
     "e2e-linter": "e2e/linter",
+    "e2e-make-angular-cli-faster": "e2e/make-angular-cli-faster",
     "e2e-next": "e2e/next",
     "e2e-node": "e2e/node",
     "e2e-nx-init": "e2e/nx-init",


### PR DESCRIPTION
This is a bit of a misnomer, hence it running on the nightly tests.

It uses _only_ the published versions of `@nrwl/*` packages on npmjs registry, due to a limitation with verdaccio, where it only looks at the local registry for `@nrwl/*` packages.

That said, it should give us at least some feedback on whether `make-angular-cli-faster` has broken at all, rather than no feedback.