### PR TITLE
fix(react): allow async functions to work with custom webpack config

### DIFF
--- a/packages/web/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/web/src/executors/dev-server/dev-server.impl.ts
@@ -85,7 +85,7 @@ export default async function* devServerExecutor(
       customWebpack = await customWebpack;
     }
 
-    webpackConfig = customWebpack(webpackConfig, {
+    webpackConfig = await customWebpack(webpackConfig, {
       buildOptions,
       configuration: serveOptions.buildTarget.split(':')[2],
     });

--- a/packages/web/src/executors/webpack/webpack.impl.ts
+++ b/packages/web/src/executors/webpack/webpack.impl.ts
@@ -101,41 +101,43 @@ async function getWebpackConfigs(
     }
   }
 
-  return [
-    // ESM build for modern browsers.
-    getWebConfig(
-      context.root,
-      projectRoot,
-      sourceRoot,
-      options,
-      true,
-      isScriptOptimizeOn,
-      context.configurationName
-    ),
-    // ES5 build for legacy browsers.
-    isScriptOptimizeOn && buildBrowserFeatures.isDifferentialLoadingNeeded()
-      ? getWebConfig(
-          context.root,
-          projectRoot,
-          sourceRoot,
-          options,
-          false,
-          isScriptOptimizeOn,
-          context.configurationName
-        )
-      : undefined,
-  ]
-    .filter(Boolean)
-    .map((config) => {
-      if (customWebpack) {
-        return customWebpack(config, {
-          options,
-          configuration: context.configurationName,
-        });
-      } else {
-        return config;
-      }
-    });
+  return await Promise.all(
+    [
+      // ESM build for modern browsers.
+      getWebConfig(
+        context.root,
+        projectRoot,
+        sourceRoot,
+        options,
+        true,
+        isScriptOptimizeOn,
+        context.configurationName
+      ),
+      // ES5 build for legacy browsers.
+      isScriptOptimizeOn && buildBrowserFeatures.isDifferentialLoadingNeeded()
+        ? getWebConfig(
+            context.root,
+            projectRoot,
+            sourceRoot,
+            options,
+            false,
+            isScriptOptimizeOn,
+            context.configurationName
+          )
+        : undefined,
+    ]
+      .filter(Boolean)
+      .map(async (config) => {
+        if (customWebpack) {
+          return await customWebpack(config, {
+            options,
+            configuration: context.configurationName,
+          });
+        } else {
+          return config;
+        }
+      })
+  );
 }
 
 export async function* run(


### PR DESCRIPTION
This PR allows an async function to be returned from the custom webpack file.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

This fails:

```
module.exports = async (config) => {
  return config;
}
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
It should work.
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Closes #10485
