### PR TITLE
fix(testing): exclude jest.config.ts in angular project tsconfigs

### DIFF
--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -103,7 +103,11 @@ describe('app', () => {
       );
       expect(tsconfigApp.compilerOptions.outDir).toEqual('../../dist/out-tsc');
       expect(tsconfigApp.extends).toEqual('./tsconfig.json');
-      expect(tsconfigApp.exclude).toEqual(['**/*.test.ts', '**/*.spec.ts']);
+      expect(tsconfigApp.exclude).toEqual([
+        'jest.config.ts',
+        '**/*.test.ts',
+        '**/*.spec.ts',
+      ]);
 
       const eslintrcJson = parseJson(
         appTree.read('apps/my-app/.eslintrc.json', 'utf-8')
@@ -307,7 +311,7 @@ describe('app', () => {
         {
           path: 'apps/my-dir/my-app/tsconfig.app.json',
           lookupFn: (json) => json.exclude,
-          expectedValue: ['**/*.test.ts', '**/*.spec.ts'],
+          expectedValue: ['jest.config.ts', '**/*.test.ts', '**/*.spec.ts'],
         },
         {
           path: 'apps/my-dir/my-app/.eslintrc.json',
@@ -390,7 +394,7 @@ describe('app', () => {
         {
           path: 'my-dir/my-app/tsconfig.app.json',
           lookupFn: (json) => json.exclude,
-          expectedValue: ['**/*.test.ts', '**/*.spec.ts'],
+          expectedValue: ['jest.config.ts', '**/*.test.ts', '**/*.spec.ts'],
         },
         {
           path: 'my-dir/my-app/.eslintrc.json',

--- a/packages/angular/src/generators/application/lib/update-config-files.ts
+++ b/packages/angular/src/generators/application/lib/update-config-files.ts
@@ -27,7 +27,12 @@ function updateTsConfigOptions(host: Tree, options: NormalizedSchema) {
       outDir: `${offsetFromRoot(options.appProjectRoot)}dist/out-tsc`,
     },
     exclude: [
-      ...new Set([...(json.exclude || []), '**/*.test.ts', '**/*.spec.ts']),
+      ...new Set([
+        ...(json.exclude || []),
+        'jest.config.ts',
+        '**/*.test.ts',
+        '**/*.spec.ts',
+      ]),
     ],
   }));
 

--- a/packages/angular/src/generators/library/lib/update-tsconfig.ts
+++ b/packages/angular/src/generators/library/lib/update-tsconfig.ts
@@ -35,7 +35,12 @@ function updateProjectConfig(host: Tree, options: NormalizedSchema) {
   updateJson(host, `${options.projectRoot}/tsconfig.lib.json`, (json) => {
     json.include = ['**/*.ts'];
     json.exclude = [
-      ...new Set([...(json.exclude || []), '**/*.test.ts', '**/*.spec.ts']),
+      ...new Set([
+        ...(json.exclude || []),
+        'jest.config.ts',
+        '**/*.test.ts',
+        '**/*.spec.ts',
+      ]),
     ];
     return json;
   });

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -394,6 +394,7 @@ describe('lib', () => {
         expect(tsconfigJson.exclude).toEqual([
           'src/test-setup.ts',
           '**/*.spec.ts',
+          'jest.config.ts',
           '**/*.test.ts',
         ]);
       });
@@ -409,6 +410,7 @@ describe('lib', () => {
         expect(tsconfigJson.exclude).toEqual([
           'src/test.ts',
           '**/*.spec.ts',
+          'jest.config.ts',
           '**/*.test.ts',
         ]);
       });
@@ -421,7 +423,11 @@ describe('lib', () => {
 
         // ASSERT
         const tsconfigJson = readJson(tree, 'libs/my-lib/tsconfig.lib.json');
-        expect(tsconfigJson.exclude).toEqual(['**/*.test.ts', '**/*.spec.ts']);
+        expect(tsconfigJson.exclude).toEqual([
+          'jest.config.ts',
+          '**/*.test.ts',
+          '**/*.spec.ts',
+        ]);
       });
     });
 
@@ -902,6 +908,7 @@ describe('lib', () => {
         expect(tsConfigLibJson.exclude).toEqual([
           'src/test-setup.ts',
           '**/*.spec.ts',
+          'jest.config.ts',
           '**/*.test.ts',
         ]);
 
@@ -916,6 +923,7 @@ describe('lib', () => {
         expect(tsConfigLibJson2.exclude).toEqual([
           'src/test-setup.ts',
           '**/*.spec.ts',
+          'jest.config.ts',
           '**/*.test.ts',
         ]);
 
@@ -933,6 +941,7 @@ describe('lib', () => {
         expect(tsConfigLibJson3.exclude).toEqual([
           'src/test-setup.ts',
           '**/*.spec.ts',
+          'jest.config.ts',
           '**/*.test.ts',
         ]);
       });

--- a/packages/jest/migrations.json
+++ b/packages/jest/migrations.json
@@ -53,6 +53,12 @@
       "cli": "nx",
       "description": "Update to export default in jest config and revert jest.preset.ts to jest.preset.js",
       "factory": "./src/migrations/update-14-1-5/update-exports-jest-config"
+    },
+    "exclude-jest-config-from-ts-config": {
+      "version": "14.5.5-beta.0",
+      "cli": "nx",
+      "description": "Exclude jest.config.ts from tsconfig where missing.",
+      "factory": "./src/migrations/update-14-0-0/update-jest-config-ext"
     }
   },
   "packageJsonUpdates": {

--- a/packages/jest/src/migrations/update-14-0-0/__snapshots__/update-jest-config-ext.spec.ts.snap
+++ b/packages/jest/src/migrations/update-14-0-0/__snapshots__/update-jest-config-ext.spec.ts.snap
@@ -20,6 +20,43 @@ module.exports = {
 "
 `;
 
+exports[`Jest Migration (v14.0.0) should produce the same results when running multiple times 1`] = `
+Object {
+  "files": Array [
+    "*.ts",
+    "*.tsx",
+    "*.js",
+    "*.jsx",
+  ],
+  "parserOptions": Object {
+    "project": Array [
+      "libs/my-next-proj/tsconfig.*?.json",
+    ],
+  },
+  "rules": Object {},
+}
+`;
+
+exports[`Jest Migration (v14.0.0) should produce the same results when running multiple times 2`] = `
+"/* eslint-disable */
+
+module.exports = {
+  displayName: 'lib-one',
+  preset: '../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    }
+  },
+  transform: {
+    '^.+\\\\\\\\.[tj]sx?$': 'ts-jest'
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../coverage/libs/lib-one'
+};
+"
+`;
+
 exports[`Jest Migration (v14.0.0) should rename project jest.config.js to jest.config.ts 1`] = `
 "/* eslint-disable */
 

--- a/packages/jest/src/migrations/update-14-0-0/update-jest-config-ext.ts
+++ b/packages/jest/src/migrations/update-14-0-0/update-jest-config-ext.ts
@@ -42,11 +42,13 @@ function updateTsConfig(tree: Tree, tsConfigPath: string) {
 function addEsLintIgnoreComments(tree: Tree, filePath: string) {
   if (tree.exists(filePath)) {
     const contents = tree.read(filePath, 'utf-8');
-    tree.write(
-      filePath,
-      `/* eslint-disable */
+    if (!contents.startsWith('/* eslint-disable */')) {
+      tree.write(
+        filePath,
+        `/* eslint-disable */
 ${contents}`
-    );
+      );
+    }
   }
 }
 
@@ -133,6 +135,11 @@ export async function updateJestConfigExt(tree: Tree) {
 
           if (tsConfig.references) {
             for (const { path } of tsConfig.references) {
+              // skip as editor.json should include everything anyway.
+              if (path.endsWith('tsconfig.editor.json')) {
+                continue;
+              }
+
               if (path.endsWith('tsconfig.spec.json')) {
                 const eslintPath = joinPathFragments(
                   projectConfig.root,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
ng projects don't exclude jest.config.ts
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
ng projects should exclude jest.config.ts
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #10526
