### PR TITLE
fix(angular): add check before attempting to collect secondary entrypoints #11437

### DIFF
--- a/packages/angular/src/utils/mf/mf-webpack.ts
+++ b/packages/angular/src/utils/mf/mf-webpack.ts
@@ -65,16 +65,22 @@ export function shareWorkspaceLibraries(
       continue;
     }
 
-    collectWorkspaceLibrarySecondaryEntryPoints(
-      key,
-      join(workspaceRoot, library.root),
-      tsconfigPathAliases
-    ).forEach(({ name, path }) =>
-      pathMappings.push({
-        name,
-        path,
-      })
+    const needsSecondaryEntryPointsCollected = existsSync(
+      join(workspaceRoot, library.root, 'ng-package.json')
     );
+
+    if (needsSecondaryEntryPointsCollected) {
+      collectWorkspaceLibrarySecondaryEntryPoints(
+        key,
+        join(workspaceRoot, library.root),
+        tsconfigPathAliases
+      ).forEach(({ name, path }) =>
+        pathMappings.push({
+          name,
+          path,
+        })
+      );
+    }
 
     pathMappings.push({
       name: key,

--- a/packages/angular/src/utils/mf/mf-webpack.ts
+++ b/packages/angular/src/utils/mf/mf-webpack.ts
@@ -20,25 +20,44 @@ export interface SharedLibraryConfig {
 }
 
 function collectWorkspaceLibrarySecondaryEntryPoints(
-  library: string,
-  libraryRoot: string,
+  library: WorkspaceLibrary,
   tsconfigPathAliases: Record<string, string[]>
 ) {
-  const aliasesUnderLibrary = Object.keys(tsconfigPathAliases).filter(
-    (libName) => libName.startsWith(library) && libName !== library
+  const libraryRoot = join(workspaceRoot, library.root);
+  const needsSecondaryEntryPointsCollected = existsSync(
+    join(libraryRoot, 'ng-package.json')
   );
+
   const secondaryEntryPoints = [];
-  for (const alias of aliasesUnderLibrary) {
-    const pathToLib = dirname(
-      join(workspaceRoot, tsconfigPathAliases[alias][0])
-    );
-    let searchDir = pathToLib;
-    while (searchDir !== libraryRoot) {
-      if (existsSync(join(searchDir, 'ng-package.json'))) {
-        secondaryEntryPoints.push({ name: alias, path: pathToLib });
-        break;
+  if (needsSecondaryEntryPointsCollected) {
+    const tsConfigAliasesForLibWithSecondaryEntryPoints = Object.entries(
+      tsconfigPathAliases
+    ).reduce((acc, [tsKey, tsPaths]) => {
+      if (!tsKey.startsWith(library.importKey)) {
+        return { ...acc };
       }
-      searchDir = dirname(searchDir);
+
+      if (tsPaths.some((path) => path.startsWith(`${library.root}/`))) {
+        acc = { ...acc, [tsKey]: tsPaths };
+      }
+
+      return acc;
+    }, {});
+
+    for (const [alias] of Object.entries(
+      tsConfigAliasesForLibWithSecondaryEntryPoints
+    )) {
+      const pathToLib = dirname(
+        join(workspaceRoot, tsconfigPathAliases[alias][0])
+      );
+      let searchDir = pathToLib;
+      while (searchDir !== libraryRoot) {
+        if (existsSync(join(searchDir, 'ng-package.json'))) {
+          secondaryEntryPoints.push({ name: alias, path: pathToLib });
+          break;
+        }
+        searchDir = dirname(searchDir);
+      }
     }
   }
 
@@ -65,22 +84,15 @@ export function shareWorkspaceLibraries(
       continue;
     }
 
-    const needsSecondaryEntryPointsCollected = existsSync(
-      join(workspaceRoot, library.root, 'ng-package.json')
+    collectWorkspaceLibrarySecondaryEntryPoints(
+      library,
+      tsconfigPathAliases
+    ).forEach(({ name, path }) =>
+      pathMappings.push({
+        name,
+        path,
+      })
     );
-
-    if (needsSecondaryEntryPointsCollected) {
-      collectWorkspaceLibrarySecondaryEntryPoints(
-        key,
-        join(workspaceRoot, library.root),
-        tsconfigPathAliases
-      ).forEach(({ name, path }) =>
-        pathMappings.push({
-          name,
-          path,
-        })
-      );
-    }
 
     pathMappings.push({
       name: key,

--- a/scripts/e2e-build-package-publish.ts
+++ b/scripts/e2e-build-package-publish.ts
@@ -42,7 +42,7 @@ async function buildPackagePublishAndCleanPorts() {
 }
 
 async function updateVersionsAndPublishPackages() {
-  execSync(`yarn nx-release --local`, {
+  execSync(`yarn nx-release --local --canary`, {
     stdio: 'inherit',
   });
 }

--- a/scripts/e2e-build-package-publish.ts
+++ b/scripts/e2e-build-package-publish.ts
@@ -42,7 +42,7 @@ async function buildPackagePublishAndCleanPorts() {
 }
 
 async function updateVersionsAndPublishPackages() {
-  execSync(`yarn nx-release --local --canary`, {
+  execSync(`yarn nx-release --local`, {
     stdio: 'inherit',
   });
 }


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
A lib that has the same starting name as another library forces an infinite loop when checking for secondary entry points

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We're checking all libraries for secondary entry points, when we should only check those that might contain it.

This should also have a minor performance gain

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #11437
