### PR TITLE
fix(web): run swc after other plugins in rollup

### DIFF
--- a/packages/web/src/executors/rollup/rollup.impl.ts
+++ b/packages/web/src/executors/rollup/rollup.impl.ts
@@ -214,7 +214,6 @@ export function createRollupOptions(
             compilerOptions: createCompilerOptions(options, dependencies),
           },
         }),
-      useSwc && swc(),
       peerDepsExternal({
         packageJsonPath: options.project,
       }),
@@ -233,6 +232,7 @@ export function createRollupOptions(
         preferBuiltins: true,
         extensions: fileExtensions,
       }),
+      useSwc && swc(),
       useBabel &&
         getBabelInputPlugin({
           // Let's `@nrwl/web/babel` preset know that we are packaging.


### PR DESCRIPTION
ISSUES CLOSED: #11500

## Current Behavior
When I make a buildable React lib and choose to use SWC as the compiler, it throws an error if any CSS files are imported in .ts files.

## Expected Behavior
Importing CSS should not cause a build failure and should include CSS in the build artifacts as appropriate.

## Related Issue(s)
Fixes #11500
