### PR TITLE
fix(nxdev): preserve generated sitemap in cache

### DIFF
--- a/nx-dev/nx-dev/project.json
+++ b/nx-dev/nx-dev/project.json
@@ -22,8 +22,9 @@
     },
     "sitemap": {
       "executor": "nx:run-commands",
-      "outputs": [],
+      "outputs": ["{options.outputPath}"],
       "options": {
+        "outputPath": "dist/nx-dev/nx-dev/public",
         "command": "yarn next-sitemap --config ./nx-dev/nx-dev/next-sitemap.js"
       }
     },

--- a/scripts/documentation/internal-link-checker.ts
+++ b/scripts/documentation/internal-link-checker.ts
@@ -82,7 +82,7 @@ const sitemapLinks = readSiteMapIndex(
   join(workspaceRoot, 'dist/nx-dev/nx-dev/public/'),
   'sitemap.xml'
 ).flatMap((path) => readSiteMapLinks(path));
-const errors = [];
+const errors: Array<{ file: string; link: string }> = [];
 for (let file in documentLinks) {
   for (let link of documentLinks[file]) {
     if (!sitemapLinks.includes(['https://nx.dev', link].join('')))


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
NxDev's `sitemap` target is added to `cacheableOperations` but its artifacts (sitemaps, robot) are not cached. This causes the subsequent link checker to fail if the result of the sitemap generation is loaded from the cache.

## Expected Behavior
The `sitemap` target should store its artifacts in the cache.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
