### PR TITLE
docs(misc): updates Step 11 to use print-affected rather than affected

### DIFF
--- a/docs/shared/angular-tutorial/11-test-affected-projects.md
+++ b/docs/shared/angular-tutorial/11-test-affected-projects.md
@@ -26,15 +26,15 @@ git checkout -b testbranch
 Run the command to see affected apps.
 
 ```sh
-npx nx affected:apps
+npx nx print-affected --type=app --select=projects
 ```
 
-You should see `todos` printed out. The `affected:apps` looks at what you have changed and uses the project graph to figure out which apps can be affected by this change.
+You should see `todos` printed out. The `print-affected` looks at what you have changed and uses the project graph to figure out which apps can be affected by this change.
 
 Run the command to see affected libraries
 
 ```sh
-npx nx affected:libs
+npx nx print-affected --type=lib --select=projects
 ```
 
 You should see `ui` printed out. This command works similarly, but instead of printing the affected apps, it prints the affected libs.

--- a/docs/shared/react-tutorial/11-test-affected-projects.md
+++ b/docs/shared/react-tutorial/11-test-affected-projects.md
@@ -38,9 +38,9 @@ export function Todos(props: TodosProps) {
 export default Todos;
 ```
 
-**Run `npx nx affected:apps`**, and you should see `todos` printed out. The `affected:apps` looks at what you have changed and uses the project graph to figure out which apps can be affected by this change.
+**Run `npx nx print-affected --type=app --select=projects`**, and you should see `todos` printed out. The `print-affected` looks at what you have changed and uses the project graph to figure out which apps can be affected by this change.
 
-**Run `npx nx affected:libs`**, and you should see `ui` printed out. This command works similarly, but instead of printing the affected apps, it prints the affected libs.
+**Run `npx nx print-affected --type=lib --select=projects`**, and you should see `ui` printed out. This command works similarly, but instead of printing the affected apps, it prints the affected libs.
 
 ## Test Affected Projects
 


### PR DESCRIPTION
docs(misc): updates Step 11 to use `print-affected` rather than the soon to be depreciated `affected:apps|libs` command

## Current Behavior
Currently the react and angular tutorials ask the user to run `npx nx affected:apps` which displays the following:

![image](https://user-images.githubusercontent.com/22569730/184261065-53ae3558-f5e3-4b44-89bd-1fe727f81599.png)


## Expected Behavior
The user will no longer be presented with a depreciation warning

## Related Issue(s)
None
