### PR TITLE
feat(core): format additional flags values for logging

### DIFF
--- a/packages/nx/src/tasks-runner/life-cycles/formatting-utils.spec.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/formatting-utils.spec.ts
@@ -1,0 +1,44 @@
+import { formatFlags } from './formatting-utils';
+
+describe('formatFlags', () => {
+  it('should properly show string values', () => {
+    expect(formatFlags('', 'myflag', 'myvalue')).toBe('  --myflag=myvalue');
+  });
+  it('should properly show number values', () => {
+    expect(formatFlags('', 'myflag', 123)).toBe('  --myflag=123');
+  });
+  it('should properly show boolean values', () => {
+    expect(formatFlags('', 'myflag', true)).toBe('  --myflag=true');
+  });
+  it('should properly show array values', () => {
+    expect(formatFlags('', 'myflag', [1, 23, 'abc'])).toBe(
+      '  --myflag=[1,23,abc]'
+    );
+  });
+  it('should properly show object values', () => {
+    expect(formatFlags('', 'myflag', { abc: 'def', ghi: { jkl: 42 } })).toBe(
+      '  --myflag={"abc":"def","ghi":{"jkl":42}}'
+    );
+  });
+  it('should not break on invalid inputs', () => {
+    expect(formatFlags('', 'myflag', (abc) => abc)).toBe(
+      '  --myflag=(abc) => abc'
+    );
+    expect(formatFlags('', 'myflag', NaN)).toBe('  --myflag=NaN');
+  });
+  it('should decompose positional values', () => {
+    expect(formatFlags('', '_', ['foo', 'bar', 42, 'baz'])).toBe(
+      '  foo bar 42 baz'
+    );
+  });
+  it('should handle indentation', () => {
+    expect(formatFlags('_____', 'myflag', 'myvalue')).toBe(
+      '_____  --myflag=myvalue'
+    );
+  });
+  it('should handle indentation with positionals', () => {
+    expect(formatFlags('_____', '_', ['foo', 'bar', 42, 'baz'])).toBe(
+      '_____  foo bar 42 baz'
+    );
+  });
+});

--- a/packages/nx/src/tasks-runner/life-cycles/formatting-utils.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/formatting-utils.ts
@@ -9,9 +9,7 @@ export function formatFlags(
 }
 
 function formatValue(value: any) {
-  if (typeof value === 'string' || typeof value === 'number') {
-    return value;
-  } else if (Array.isArray(value)) {
+  if (Array.isArray(value)) {
     return `[${value.join(',')}]`;
   } else if (typeof value === 'object') {
     return JSON.stringify(value);

--- a/packages/nx/src/tasks-runner/life-cycles/formatting-utils.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/formatting-utils.ts
@@ -5,5 +5,17 @@ export function formatFlags(
 ): string {
   return flag == '_'
     ? `${leftPadding}  ${(value as string[]).join(' ')}`
-    : `${leftPadding}  --${flag}=${value}`;
+    : `${leftPadding}  --${flag}=${formatValue(value)}`;
+}
+
+function formatValue(value: any) {
+  if (typeof value === 'string' || typeof value === 'number') {
+    return value;
+  } else if (Array.isArray(value)) {
+    return `[${value.join(',')}]`;
+  } else if (typeof value === 'object') {
+    return JSON.stringify(value);
+  } else {
+    return value;
+  }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
If we pass flags as object, the logger prints it as `[object Object]`

## Expected Behavior
We should see the contents of the object being printed out

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Related to #10808
