### PR TITLE
fix(react): fix webpack node api config error serving a react app

### DIFF
--- a/packages/react/plugins/webpack.ts
+++ b/packages/react/plugins/webpack.ts
@@ -65,6 +65,12 @@ export function getWebpackConfig(config: Configuration) {
     config.plugins.push(new ReactRefreshPlugin());
   }
 
+  // enable webpack node api
+  config.node = {
+    __dirname: true,
+    __filename: true,
+  };
+
   return config;
 }
 


### PR DESCRIPTION
Webpack compiles a react app and the main.js file created contains __dirname variable. This crash
the application when it is served. The webpack node api config has been enabled.

ISSUES CLOSED: #11571