### PR TITLE
fix(repo): change e2e tests to publish 9999.0.2

### DIFF
--- a/scripts/e2e-build-package-publish.ts
+++ b/scripts/e2e-build-package-publish.ts
@@ -42,7 +42,7 @@ async function buildPackagePublishAndCleanPorts() {
 }
 
 async function updateVersionsAndPublishPackages() {
-  execSync(`yarn nx-release --local --canary`, {
+  execSync(`yarn nx-release 9999.0.2 --local`, {
     stdio: 'inherit',
   });
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The e2e tests publish the next version based on the `lerna.json` but this becomes out of date.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The e2e tests publish v `9999.0.2` which... will be a later version for the foreseeable future.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
