### PR TITLE
feat(core): add workspace integrity check for package alignment

### DIFF
--- a/packages/nx/src/command-line/lint.ts
+++ b/packages/nx/src/command-line/lint.ts
@@ -11,13 +11,17 @@ export async function workspaceLint(): Promise<void> {
   const allWorkspaceFiles = graph.allWorkspaceFiles;
   const projectGraph = pruneExternalNodes(graph);
 
-  const cliErrorOutputConfigs = new WorkspaceIntegrityChecks(
+  const integrityMessages = new WorkspaceIntegrityChecks(
     projectGraph,
     readAllFilesFromAppsAndLibs(allWorkspaceFiles)
   ).run();
 
-  if (cliErrorOutputConfigs.length > 0) {
-    cliErrorOutputConfigs.forEach((errorConfig) => {
+  for (const message of integrityMessages.warn) {
+    output.warn(message);
+  }
+
+  if (integrityMessages.error?.length > 0) {
+    integrityMessages.error.forEach((errorConfig) => {
       output.error(errorConfig);
     });
     process.exit(1);

--- a/packages/nx/src/command-line/workspace-integrity-checks.ts
+++ b/packages/nx/src/command-line/workspace-integrity-checks.ts
@@ -1,13 +1,38 @@
-import { output } from '../utils/output';
+import { CLIWarnMessageConfig, output } from '../utils/output';
 import type { CLIErrorMessageConfig } from '../utils/output';
 import { workspaceFileName } from '../project-graph/file-utils';
 import { ProjectGraph } from '../config/project-graph';
+import { readJsonFile } from '../utils/fileutils';
+import { PackageJson } from '../utils/package-json';
+import { joinPathFragments } from '../utils/path';
+import { workspaceRoot } from '../utils/workspace-root';
+import { gt, gte, valid } from 'semver';
 
 export class WorkspaceIntegrityChecks {
+  nxPackageJson = readJsonFile<typeof import('../../package.json')>(
+    joinPathFragments(__dirname, '../../package.json')
+  );
+
   constructor(private projectGraph: ProjectGraph, private files: string[]) {}
 
-  run(): CLIErrorMessageConfig[] {
-    return [...this.projectWithoutFilesCheck(), ...this.filesWithoutProjects()];
+  run(): { error: CLIErrorMessageConfig[]; warn: CLIWarnMessageConfig[] } {
+    const errors = [
+      ...this.projectWithoutFilesCheck(),
+      ...this.filesWithoutProjects(),
+    ];
+    const warnings = [];
+
+    // @todo(AgentEnder) - Remove this check after v15
+    if (gte(this.nxPackageJson.version, '15.0.0')) {
+      errors.push(...this.misalignedPackages());
+    } else {
+      warnings.push(...this.misalignedPackages());
+    }
+
+    return {
+      error: errors,
+      warn: warnings,
+    };
   }
 
   private projectWithoutFilesCheck(): CLIErrorMessageConfig[] {
@@ -55,6 +80,49 @@ export class WorkspaceIntegrityChecks {
             // slug: 'file-does-not-belong-to-project'
           },
         ];
+  }
+
+  misalignedPackages(): CLIErrorMessageConfig[] {
+    const bodyLines: CLIErrorMessageConfig['bodyLines'] = [];
+    const packageJson = readJsonFile<PackageJson>(
+      joinPathFragments(workspaceRoot, 'package.json')
+    );
+
+    let migrateTarget = this.nxPackageJson.version;
+
+    for (const pkg of this.nxPackageJson['nx-migrations'].packageGroup) {
+      const packageName = typeof pkg === 'string' ? pkg : pkg.package;
+      if (typeof pkg === 'string' || pkg.version === '*') {
+        // should be aligned
+        const installedVersion =
+          packageJson.dependencies?.[packageName] ??
+          packageJson.devDependencies?.[packageName];
+        if (
+          installedVersion &&
+          installedVersion !== this.nxPackageJson.version
+        ) {
+          if (valid(installedVersion) && gt(installedVersion, migrateTarget)) {
+            migrateTarget = installedVersion;
+          }
+          bodyLines.push(`- ${packageName}@${installedVersion}`);
+        }
+      }
+    }
+
+    return bodyLines.length
+      ? [
+          {
+            title: 'Some packages have misaligned versions!',
+            bodyLines: [
+              'These packages should match your installed version of Nx.',
+              ...bodyLines,
+              '',
+              `You should be able to fix this by running \`nx migrate ${migrateTarget}\``,
+            ],
+            // slug: 'nx-misaligned-versions',
+          },
+        ]
+      : [];
   }
 
   private allProjectFiles() {


### PR DESCRIPTION
## Expected behavior

workspace-lint throws if package-version mismatch is found.

<img width="666" alt="image" src="https://user-images.githubusercontent.com/6933928/185677283-8d3a0cad-c831-4a1f-bdb1-7e4aed0f5fd5.png">



## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
