### PR TITLE
fix(core): project graph should be read from executor context

### DIFF
--- a/packages/angular/src/executors/delegate-build/delegate-build.impl.ts
+++ b/packages/angular/src/executors/delegate-build/delegate-build.impl.ts
@@ -4,7 +4,6 @@ import {
   parseTargetString,
   runExecutor,
 } from '@nrwl/devkit';
-import { readCachedProjectGraph } from '@nrwl/devkit';
 import {
   calculateProjectDependencies,
   checkDependentProjectsHaveBeenBuilt,
@@ -17,7 +16,7 @@ export async function* delegateBuildExecutor(
   context: ExecutorContext
 ) {
   const { target, dependencies } = calculateProjectDependencies(
-    readCachedProjectGraph(),
+    context.projectGraph,
     context.root,
     context.projectName,
     context.targetName,

--- a/packages/angular/src/executors/package/package.impl.ts
+++ b/packages/angular/src/executors/package/package.impl.ts
@@ -1,5 +1,4 @@
 import type { ExecutorContext } from '@nrwl/devkit';
-import { readCachedProjectGraph } from '@nrwl/devkit';
 import { eachValueFrom } from '@nrwl/devkit/src/utils/rxjs-for-await';
 import {
   calculateProjectDependencies,
@@ -68,7 +67,7 @@ export function createLibraryExecutor(
   ) {
     const { target, dependencies, topLevelDependencies } =
       calculateProjectDependencies(
-        readCachedProjectGraph(),
+        context.projectGraph,
         context.root,
         context.projectName,
         context.targetName,

--- a/packages/devkit/src/utils/convert-nx-executor.ts
+++ b/packages/devkit/src/utils/convert-nx-executor.ts
@@ -1,6 +1,11 @@
 import type { Observable } from 'rxjs';
 import { Workspaces } from 'nx/src/config/workspaces';
 import { Executor, ExecutorContext } from 'nx/src/config/misc-interfaces';
+import {
+  createProjectGraphAsync,
+  readCachedProjectGraph,
+} from 'nx/src/project-graph/project-graph';
+import { ProjectGraph } from 'nx/src/config/project-graph';
 
 /**
  * Convert an Nx Executor into an Angular Devkit Builder
@@ -12,63 +17,70 @@ export function convertNxExecutor(executor: Executor) {
   const builderFunction = (options, builderContext) => {
     const workspaces = new Workspaces(builderContext.workspaceRoot);
     const workspaceConfig = workspaces.readWorkspaceConfiguration();
-    const context: ExecutorContext = {
-      root: builderContext.workspaceRoot,
-      projectName: builderContext.target.project,
-      targetName: builderContext.target.target,
-      configurationName: builderContext.target.configuration,
-      workspace: workspaceConfig,
-      cwd: process.cwd(),
-      isVerbose: false,
+
+    const promise = async () => {
+      let projectGraph: ProjectGraph;
+      try {
+        projectGraph = readCachedProjectGraph();
+      } catch {
+        projectGraph = await createProjectGraphAsync();
+      }
+      const context: ExecutorContext = {
+        root: builderContext.workspaceRoot,
+        projectName: builderContext.target.project,
+        targetName: builderContext.target.target,
+        target: builderContext.target.target,
+        configurationName: builderContext.target.configuration,
+        workspace: workspaceConfig,
+        cwd: process.cwd(),
+        projectGraph,
+        isVerbose: false,
+      };
+      return executor(options, context);
     };
-    if (
-      builderContext.target &&
-      builderContext.target.project &&
-      builderContext.target.target
-    ) {
-      context.target =
-        workspaceConfig.projects[builderContext.target.project].targets[
-          builderContext.target.target
-        ];
-    }
-    return toObservable(executor(options, context));
+    return toObservable(promise());
   };
   return require('@angular-devkit/architect').createBuilder(builderFunction);
 }
 
 function toObservable<T extends { success: boolean }>(
-  promiseOrAsyncIterator: Promise<T> | AsyncIterableIterator<T>
+  promiseOrAsyncIterator: Promise<T | AsyncIterableIterator<T>>
 ): Observable<T> {
-  if (typeof (promiseOrAsyncIterator as any).then === 'function') {
-    return require('rxjs').from(promiseOrAsyncIterator as Promise<T>);
-  } else {
-    return new (require('rxjs').Observable)((subscriber) => {
-      let asyncIterator = promiseOrAsyncIterator as AsyncIterableIterator<T>;
+  return new (require('rxjs') as typeof import('rxjs')).Observable(
+    (subscriber) => {
+      promiseOrAsyncIterator.then((value) => {
+        if ((!value as any).next) {
+          subscriber.next(value as T);
+          subscriber.complete();
+        } else {
+          let asyncIterator = value as AsyncIterableIterator<T>;
 
-      function recurse(iterator: AsyncIterableIterator<T>) {
-        iterator
-          .next()
-          .then((result) => {
-            if (!result.done) {
-              subscriber.next(result.value);
-              recurse(iterator);
-            } else {
-              if (result.value) {
-                subscriber.next(result.value);
-              }
-              subscriber.complete();
-            }
-          })
-          .catch((e) => {
-            subscriber.error(e);
-          });
-      }
+          function recurse(iterator: AsyncIterableIterator<T>) {
+            iterator
+              .next()
+              .then((result) => {
+                if (!result.done) {
+                  subscriber.next(result.value);
+                  recurse(iterator);
+                } else {
+                  if (result.value) {
+                    subscriber.next(result.value);
+                  }
+                  subscriber.complete();
+                }
+              })
+              .catch((e) => {
+                subscriber.error(e);
+              });
+          }
 
-      recurse(asyncIterator);
+          recurse(asyncIterator);
 
-      return () => {
-        asyncIterator.return();
-      };
-    });
-  }
+          return () => {
+            asyncIterator.return();
+          };
+        }
+      });
+    }
+  );
 }

--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -3,7 +3,6 @@ import {
   joinPathFragments,
   logger,
   parseTargetString,
-  readCachedProjectGraph,
   runExecutor,
 } from '@nrwl/devkit';
 import { calculateProjectDependencies } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
@@ -65,10 +64,9 @@ function calculateResolveMappings(
   context: ExecutorContext,
   options: NodeExecutorOptions
 ) {
-  const projectGraph = readCachedProjectGraph();
   const parsed = parseTargetString(options.buildTarget);
   const { dependencies } = calculateProjectDependencies(
-    projectGraph,
+    context.projectGraph,
     context.root,
     parsed.project,
     parsed.target,

--- a/packages/js/src/executors/swc/swc.impl.ts
+++ b/packages/js/src/executors/swc/swc.impl.ts
@@ -112,7 +112,8 @@ export async function* swcExecutor(
   const swcHelperDependency = getHelperDependency(
     HelperDependency.swc,
     options.swcCliOptions.swcrcPath,
-    dependencies
+    dependencies,
+    context.projectGraph
   );
 
   if (swcHelperDependency) {

--- a/packages/js/src/executors/tsc/tsc.impl.ts
+++ b/packages/js/src/executors/tsc/tsc.impl.ts
@@ -67,7 +67,8 @@ export async function* tscExecutor(
   const tsLibDependency = getHelperDependency(
     HelperDependency.tsc,
     options.tsConfig,
-    dependencies
+    dependencies,
+    context.projectGraph
   );
 
   if (tsLibDependency) {

--- a/packages/js/src/utils/check-dependencies.ts
+++ b/packages/js/src/utils/check-dependencies.ts
@@ -1,8 +1,4 @@
-import {
-  ExecutorContext,
-  ProjectGraphProjectNode,
-  readCachedProjectGraph,
-} from '@nrwl/devkit';
+import { ExecutorContext, ProjectGraphProjectNode } from '@nrwl/devkit';
 import {
   calculateProjectDependencies,
   createTmpTsConfig,
@@ -18,10 +14,9 @@ export function checkDependencies(
   target: ProjectGraphProjectNode<any>;
   dependencies: DependentBuildableProjectNode[];
 } {
-  const projectGraph = readCachedProjectGraph();
   const { target, dependencies, nonBuildableDependencies } =
     calculateProjectDependencies(
-      projectGraph,
+      context.projectGraph,
       context.root,
       context.projectName,
       context.targetName,

--- a/packages/js/src/utils/compiler-helper-dependency.ts
+++ b/packages/js/src/utils/compiler-helper-dependency.ts
@@ -1,7 +1,7 @@
 import {
   logger,
+  ProjectGraph,
   ProjectGraphDependency,
-  readCachedProjectGraph,
   readJsonFile,
 } from '@nrwl/devkit';
 import { DependentBuildableProjectNode } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
@@ -44,6 +44,7 @@ export function getHelperDependency(
   helperDependency: HelperDependency,
   configPath: string,
   dependencies: DependentBuildableProjectNode[],
+  projectGraph: ProjectGraph,
   returnDependencyIfFound = false
 ): DependentBuildableProjectNode | null {
   const dependency = dependencies.find((dep) => dep.name === helperDependency);
@@ -70,7 +71,6 @@ export function getHelperDependency(
 
   if (!isHelperNeeded) return null;
 
-  const projectGraph = readCachedProjectGraph();
   const libNode = projectGraph.externalNodes[helperDependency];
 
   if (!libNode) {
@@ -91,10 +91,9 @@ export function getHelperDependency(
 
 export function getHelperDependenciesFromProjectGraph(
   contextRoot: string,
-  sourceProject: string
+  sourceProject: string,
+  projectGraph: ProjectGraph
 ): ProjectGraphDependency[] {
-  const projectGraph = readCachedProjectGraph();
-
   // if the source project isn't part of the projectGraph nodes; skip
   if (!projectGraph.nodes[sourceProject]) return [];
 
@@ -153,6 +152,7 @@ export function getHelperDependenciesFromProjectGraph(
         helperDependency,
         configPath,
         dependencies,
+        projectGraph,
         true
       );
 

--- a/packages/next/src/executors/build/build.impl.ts
+++ b/packages/next/src/executors/build/build.impl.ts
@@ -4,7 +4,6 @@ import build from 'next/dist/build';
 import { join, resolve } from 'path';
 import { copySync, mkdir } from 'fs-extra';
 import { directoryExists } from '@nrwl/workspace/src/utilities/fileutils';
-import { readCachedProjectGraph } from '@nrwl/devkit';
 import {
   calculateProjectDependencies,
   DependentBuildableProjectNode,
@@ -34,7 +33,7 @@ export default async function buildExecutor(
 
   if (!options.buildLibsFromSource && context.targetName) {
     const result = calculateProjectDependencies(
-      readCachedProjectGraph(),
+      context.projectGraph,
       context.root,
       context.projectName,
       context.targetName,

--- a/packages/next/src/executors/build/lib/create-package-json.ts
+++ b/packages/next/src/executors/build/lib/create-package-json.ts
@@ -1,6 +1,5 @@
 import type { ExecutorContext } from '@nrwl/devkit';
 import { writeJsonFile } from '@nrwl/devkit';
-import { readCachedProjectGraph } from '@nrwl/devkit';
 import { createPackageJson as generatePackageJson } from '@nrwl/workspace/src/utilities/create-package-json';
 import type { NextBuildBuilderOptions } from '../../../utils/types';
 
@@ -8,11 +7,14 @@ export async function createPackageJson(
   options: NextBuildBuilderOptions,
   context: ExecutorContext
 ) {
-  const depGraph = readCachedProjectGraph();
-  const packageJson = generatePackageJson(context.projectName, depGraph, {
-    root: context.root,
-    projectRoot: context.workspace.projects[context.projectName].sourceRoot,
-  });
+  const packageJson = generatePackageJson(
+    context.projectName,
+    context.projectGraph,
+    {
+      root: context.root,
+      projectRoot: context.workspace.projects[context.projectName].sourceRoot,
+    }
+  );
   if (!packageJson.scripts) {
     packageJson.scripts = {};
   }
@@ -20,14 +22,15 @@ export async function createPackageJson(
   if (!packageJson.devDependencies) {
     packageJson.devDependencies = {};
   }
-  const nrwlWorkspaceNode = depGraph.externalNodes['npm:@nrwl/workspace'];
+  const nrwlWorkspaceNode =
+    context.projectGraph.externalNodes['npm:@nrwl/workspace'];
 
   if (nrwlWorkspaceNode) {
     packageJson.dependencies['@nrwl/workspace'] =
       nrwlWorkspaceNode.data.version;
   }
 
-  const typescriptNode = depGraph.externalNodes['npm:typescript'];
+  const typescriptNode = context.projectGraph.externalNodes['npm:typescript'];
   if (typescriptNode) {
     packageJson.dependencies['typescript'] = typescriptNode.data.version;
   }

--- a/packages/next/src/executors/export/export.impl.ts
+++ b/packages/next/src/executors/export/export.impl.ts
@@ -7,7 +7,6 @@ import {
 } from '@nrwl/devkit';
 import exportApp from 'next/dist/export';
 import { join, resolve } from 'path';
-import { readCachedProjectGraph } from '@nrwl/devkit';
 import {
   calculateProjectDependencies,
   DependentBuildableProjectNode,
@@ -29,7 +28,7 @@ export default async function exportExecutor(
   let dependencies: DependentBuildableProjectNode[] = [];
   if (!options.buildLibsFromSource) {
     const result = calculateProjectDependencies(
-      readCachedProjectGraph(),
+      context.projectGraph,
       context.root,
       context.projectName,
       'build', // this should be generalized

--- a/packages/next/src/executors/server/server.impl.ts
+++ b/packages/next/src/executors/server/server.impl.ts
@@ -3,7 +3,6 @@ import {
   ExecutorContext,
   logger,
   parseTargetString,
-  readCachedProjectGraph,
   readTargetOptions,
   runExecutor,
   workspaceLayout,
@@ -72,7 +71,7 @@ function getDependencies(
     return [];
   } else {
     const result = calculateProjectDependencies(
-      readCachedProjectGraph(),
+      context.projectGraph,
       context.root,
       context.projectName,
       'build', // should be generalized

--- a/packages/node/src/executors/webpack/webpack.impl.spec.ts
+++ b/packages/node/src/executors/webpack/webpack.impl.spec.ts
@@ -16,10 +16,6 @@ describe('Node Build Executor', () => {
   let options: BuildNodeBuilderOptions;
 
   beforeEach(async () => {
-    jest
-      .spyOn(projectGraph, 'readCachedProjectGraph')
-      .mockReturnValue({} as ProjectGraph);
-
     (<any>runWebpack).mockReturnValue(of({ hasErrors: () => false }));
     context = {
       root: '/root',
@@ -36,6 +32,7 @@ describe('Node Build Executor', () => {
         },
         npmScope: 'test',
       },
+      projectGraph: {} as ProjectGraph,
       isVerbose: false,
     };
     options = {

--- a/packages/node/src/executors/webpack/webpack.impl.ts
+++ b/packages/node/src/executors/webpack/webpack.impl.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import { ExecutorContext, readCachedProjectGraph } from '@nrwl/devkit';
+import { ExecutorContext } from '@nrwl/devkit';
 import { eachValueFrom } from '@nrwl/devkit/src/utils/rxjs-for-await';
 import {
   calculateProjectDependencies,
@@ -47,10 +47,9 @@ export async function* webpackExecutor(
     registerTsNode();
   }
 
-  const projGraph = readCachedProjectGraph();
   if (!options.buildLibsFromSource) {
     const { target, dependencies } = calculateProjectDependencies(
-      projGraph,
+      context.projectGraph,
       context.root,
       context.projectName,
       context.targetName,
@@ -76,7 +75,9 @@ export async function* webpackExecutor(
         configuration: context.configurationName,
       });
     },
-    Promise.resolve(getNodeWebpackConfig(context, projGraph, options))
+    Promise.resolve(
+      getNodeWebpackConfig(context, context.projectGraph, options)
+    )
   );
 
   return yield* eachValueFrom(

--- a/packages/node/src/utils/generate-package-json-webpack-plugin.ts
+++ b/packages/node/src/utils/generate-package-json-webpack-plugin.ts
@@ -32,7 +32,8 @@ export class GeneratePackageJsonWebpackPlugin implements WebpackPluginInstance {
         () => {
           const helperDependencies = getHelperDependenciesFromProjectGraph(
             this.context.root,
-            this.context.projectName
+            this.context.projectName,
+            this.projectGraph
           );
 
           const importHelpers = !!readTsConfig(this.options.tsConfig).options

--- a/packages/nx/src/command-line/run-one.ts
+++ b/packages/nx/src/command-line/run-one.ts
@@ -50,7 +50,7 @@ export async function runOne(
   if (nxArgs.help) {
     await (
       await import('./run')
-    ).run(cwd, workspaceRoot, opts, {}, false, true, projectGraph);
+    ).run(cwd, workspaceRoot, opts, {}, false, true);
     process.exit(0);
   }
 

--- a/packages/nx/src/config/misc-interfaces.ts
+++ b/packages/nx/src/config/misc-interfaces.ts
@@ -177,4 +177,12 @@ export interface ExecutorContext {
    * Enable verbose logging
    */
   isVerbose: boolean;
+
+  /**
+   * A snapshot of the project graph as
+   * it existed when the Nx command was kicked off
+   *
+   * @todo(AgentEnder) mark this required for v15
+   */
+  projectGraph?: ProjectGraph;
 }

--- a/packages/nx/src/tasks-runner/batch/run-batch.ts
+++ b/packages/nx/src/tasks-runner/batch/run-batch.ts
@@ -31,6 +31,7 @@ async function runTasks(executorName: string, taskGraph: TaskGraph) {
     cwd: process.cwd(),
     workspace: workspaceConfig,
     isVerbose: false,
+    projectGraph,
   };
   for (const task of tasks) {
     const projectConfiguration = workspaceConfig.projects[task.target.project];

--- a/packages/react-native/src/executors/run-android/run-android.impl.ts
+++ b/packages/react-native/src/executors/run-android/run-android.impl.ts
@@ -29,7 +29,12 @@ export default async function* runAndroidExecutor(
   if (options.sync) {
     displayNewlyAddedDepsMessage(
       context.projectName,
-      await syncDeps(context.projectName, projectRoot, context.root)
+      await syncDeps(
+        context.projectName,
+        projectRoot,
+        context.root,
+        context.projectGraph
+      )
     );
   }
 

--- a/packages/react-native/src/executors/run-ios/run-ios.impl.ts
+++ b/packages/react-native/src/executors/run-ios/run-ios.impl.ts
@@ -30,7 +30,12 @@ export default async function* runIosExecutor(
   if (options.sync) {
     displayNewlyAddedDepsMessage(
       context.projectName,
-      await syncDeps(context.projectName, projectRoot, context.root)
+      await syncDeps(
+        context.projectName,
+        projectRoot,
+        context.root,
+        context.projectGraph
+      )
     );
   }
   if (options.install) {

--- a/packages/react-native/src/executors/storybook/storybook.impl.ts
+++ b/packages/react-native/src/executors/storybook/storybook.impl.ts
@@ -28,12 +28,18 @@ export default async function* reactNatievStorybookExecutor(
   if (fileExists(packageJsonPath))
     displayNewlyAddedDepsMessage(
       context.projectName,
-      await syncDeps(context.projectName, projectRoot, context.root, [
-        '@storybook/addon-ondevice-actions',
-        '@storybook/addon-ondevice-backgrounds',
-        '@storybook/addon-ondevice-controls',
-        '@storybook/addon-ondevice-notes',
-      ])
+      await syncDeps(
+        context.projectName,
+        projectRoot,
+        context.root,
+        context.projectGraph,
+        [
+          '@storybook/addon-ondevice-actions',
+          '@storybook/addon-ondevice-backgrounds',
+          '@storybook/addon-ondevice-controls',
+          '@storybook/addon-ondevice-notes',
+        ]
+      )
     );
 
   try {

--- a/packages/react-native/src/executors/sync-deps/sync-deps.impl.ts
+++ b/packages/react-native/src/executors/sync-deps/sync-deps.impl.ts
@@ -3,9 +3,9 @@ import * as chalk from 'chalk';
 import {
   ExecutorContext,
   logger,
+  ProjectGraph,
   readJsonFile,
   writeJsonFile,
-  createProjectGraphAsync,
 } from '@nrwl/devkit';
 
 import { findAllNpmDependencies } from '../../utils/find-all-npm-dependencies';
@@ -27,6 +27,7 @@ export default async function* syncDepsExecutor(
       context.projectName,
       projectRoot,
       context.root,
+      context.projectGraph,
       typeof options.include === 'string'
         ? options.include.split(',')
         : options.include,
@@ -43,11 +44,11 @@ export async function syncDeps(
   projectName: string,
   projectRoot: string,
   workspaceRoot: string,
+  projectGraph: ProjectGraph,
   include: string[] = [],
   exclude: string[] = []
 ): Promise<string[]> {
-  const graph = await createProjectGraphAsync();
-  let npmDeps = findAllNpmDependencies(graph, projectName);
+  let npmDeps = findAllNpmDependencies(projectGraph, projectName);
   const packageJsonPath = join(workspaceRoot, projectRoot, 'package.json');
   const packageJson = readJsonFile(packageJsonPath);
   const newDeps = [];

--- a/packages/web/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/web/src/executors/dev-server/dev-server.impl.ts
@@ -16,7 +16,6 @@ import {
   calculateProjectDependencies,
   createTmpTsConfig,
 } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
-import { readCachedProjectGraph } from '@nrwl/devkit';
 import { getEmittedFiles, runWebpackDevServer } from '../../utils/run-webpack';
 import { resolveCustomWebpackConfig } from '../../utils/webpack/custom-webpack';
 
@@ -53,7 +52,7 @@ export default async function* devServerExecutor(
 
   if (!buildOptions.buildLibsFromSource) {
     const { target, dependencies } = calculateProjectDependencies(
-      readCachedProjectGraph(),
+      context.projectGraph,
       context.root,
       context.projectName,
       'build', // should be generalized

--- a/packages/web/src/executors/rollup/rollup.impl.ts
+++ b/packages/web/src/executors/rollup/rollup.impl.ts
@@ -7,12 +7,7 @@ import { catchError, concatMap, last, scan, tap } from 'rxjs/operators';
 import { eachValueFrom } from '@nrwl/devkit/src/utils/rxjs-for-await';
 import * as autoprefixer from 'autoprefixer';
 import type { ExecutorContext } from '@nrwl/devkit';
-import {
-  logger,
-  names,
-  readCachedProjectGraph,
-  readJsonFile,
-} from '@nrwl/devkit';
+import { logger, names, readJsonFile } from '@nrwl/devkit';
 import {
   calculateProjectDependencies,
   computeCompilerOptionsPaths,
@@ -49,10 +44,9 @@ export default async function* rollupExecutor(
   process.env.NODE_ENV ??= 'production';
 
   const project = context.workspace.projects[context.projectName];
-  const projectGraph = readCachedProjectGraph();
   const sourceRoot = project.sourceRoot;
   const { target, dependencies } = calculateProjectDependencies(
-    projectGraph,
+    context.projectGraph,
     context.root,
     context.projectName,
     context.targetName,
@@ -78,7 +72,7 @@ export default async function* rollupExecutor(
   }
   const packageJson = readJsonFile(options.project);
 
-  const npmDeps = (projectGraph.dependencies[context.projectName] ?? [])
+  const npmDeps = (context.projectGraph.dependencies[context.projectName] ?? [])
     .filter((d) => d.target.startsWith('npm:'))
     .map((d) => d.target.slice(4));
 

--- a/packages/web/src/executors/webpack/webpack.impl.ts
+++ b/packages/web/src/executors/webpack/webpack.impl.ts
@@ -1,4 +1,4 @@
-import { ExecutorContext, logger, readCachedProjectGraph } from '@nrwl/devkit';
+import { ExecutorContext, logger } from '@nrwl/devkit';
 import { eachValueFrom } from '@nrwl/devkit/src/utils/rxjs-for-await';
 import type { Configuration, Stats } from 'webpack';
 import { from, of } from 'rxjs';
@@ -179,7 +179,7 @@ export async function* run(
 
   if (!options.buildLibsFromSource && context.targetName) {
     const { dependencies } = calculateProjectDependencies(
-      readCachedProjectGraph(),
+      context.projectGraph,
       context.root,
       context.projectName,
       context.targetName,


### PR DESCRIPTION
## Current Behavior
Several executors use a mish-mash  of `createProjectGraphAsync `as well as `readCachedProjectGraph `to access project graph data. This is not necessarily incorrect, but combined with the call to `createProjectGraphAsync` in `run`, some places may attempt to read the cache while it is actively being written. This results in malformed JSON and presents as a crash.

This currently surfaces most frequently in @nrwl/js:tsc and @nrwl/angular:package, but its possible that other executors would be affected as well.
## Expected Behavior
Executors only use `readCachedProjectGraph`, but also make use of the project graph as provided in the executor context when possible.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #11210 
