### PR TITLE
fix(linter): normalize rule context file name for cross OS

### DIFF
--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -149,6 +149,7 @@ export default createESLintRule<Options, MessageIds>({
     const projectPath = normalizePath(
       (global as any).projectPath || workspaceRoot
     );
+    const fileName = normalizePath(context.getFilename());
 
     const projectGraph = readProjectGraph(RULE_NAME);
 
@@ -192,10 +193,7 @@ export default createESLintRule<Options, MessageIds>({
         return;
       }
 
-      const sourceFilePath = getSourceFilePath(
-        context.getFilename(),
-        projectPath
-      );
+      const sourceFilePath = getSourceFilePath(fileName, projectPath);
 
       const sourceProject = findSourceProject(projectGraph, sourceFilePath);
       // If source is not part of an nx workspace, return.
@@ -327,7 +325,7 @@ export default createESLintRule<Options, MessageIds>({
                     if (importPath) {
                       // resolve the import path
                       const relativePath = relative(
-                        dirname(context.getFilename()),
+                        dirname(fileName),
                         dirname(importPath)
                       );
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #11577
