### PR TITLE
feat(nextjs): add --custom-server option to app generator

### DIFF
--- a/docs/generated/packages/next.json
+++ b/docs/generated/packages/next.json
@@ -179,6 +179,11 @@
             "description": "Enable the Rust-based compiler SWC to compile JS/TS files.",
             "type": "boolean",
             "default": true
+          },
+          "customServer": {
+            "description": "Use a custom Express server for the Next.js application.",
+            "type": "boolean",
+            "default": false
           }
         },
         "required": [],

--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -148,7 +148,7 @@ describe('Next.js Applications', () => {
       `dist/apps/${appName}/public/a/b.txt`,
       `dist/apps/${appName}/public/shared/ui/hello.txt`
     );
-  }, 300000);
+  }, 300_000);
 
   it('should be able to serve with a proxy configuration', async () => {
     const appName = uniq('app');
@@ -222,7 +222,7 @@ describe('Next.js Applications', () => {
     } catch (err) {
       expect(err).toBeFalsy();
     }
-  }, 300000);
+  }, 300_000);
 
   it('should build with a next.config.js file in the dist folder', async () => {
     const appName = uniq('app');
@@ -248,7 +248,7 @@ describe('Next.js Applications', () => {
 
     checkFilesExist(`dist/apps/${appName}/next.config.js`);
     expect(result).toContain('NODE_ENV is production');
-  }, 300000);
+  }, 300_000);
 
   it('should support --js flag', async () => {
     const appName = uniq('app');
@@ -300,7 +300,7 @@ describe('Next.js Applications', () => {
       checkE2E: false,
       checkExport: false,
     });
-  }, 300000);
+  }, 300_000);
 
   it('should support --no-swc flag', async () => {
     const appName = uniq('app');
@@ -316,13 +316,14 @@ describe('Next.js Applications', () => {
       checkE2E: false,
       checkExport: true,
     });
-  }, 300000);
+  }, 300_000);
 
   it('should allow using a custom server implementation', async () => {
     const appName = uniq('app');
 
-    runCLI(`generate @nrwl/next:app ${appName} --style=css --no-interactive`);
-    runCLI(`generate @nrwl/next:custom-server ${appName} --no-interactive`);
+    runCLI(
+      `generate @nrwl/next:app ${appName} --style=css --no-interactive --custom-server`
+    );
 
     checkFilesExist(`apps/${appName}/server/main.ts`);
 
@@ -332,7 +333,7 @@ describe('Next.js Applications', () => {
       checkE2E: true,
       checkExport: false,
     });
-  }, 300000);
+  }, 300_000);
 
   it('should support different --style options', async () => {
     const lessApp = uniq('app');
@@ -384,10 +385,10 @@ describe('Next.js Applications', () => {
       checkE2E: false,
       checkExport: false,
     });
-  }, 300000);
+  }, 300_000);
   it('should run default jest tests', async () => {
     await expectJestTestsToPass('@nrwl/next:app');
-  }, 100000);
+  }, 100_000);
 });
 
 function getData(port: number, path = ''): Promise<any> {

--- a/packages/next/src/generators/application/application.ts
+++ b/packages/next/src/generators/application/application.ts
@@ -1,4 +1,5 @@
 import { convertNxGenerator, formatFiles, Tree } from '@nrwl/devkit';
+import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 
 import { normalizeOptions } from './lib/normalize-options';
 import { Schema } from './schema';
@@ -12,7 +13,7 @@ import { updateJestConfig } from './lib/update-jest-config';
 import { nextInitGenerator } from '../init/init';
 import { addStyleDependencies } from '../../utils/styles';
 import { addLinting } from './lib/add-linting';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+import { customServerGenerator } from '../custom-server/custom-server';
 
 export async function applicationGenerator(host: Tree, schema: Schema) {
   const options = normalizeOptions(host, schema);
@@ -30,6 +31,13 @@ export async function applicationGenerator(host: Tree, schema: Schema) {
   updateJestConfig(host, options);
   const styledTask = addStyleDependencies(host, options.style);
   setDefaults(host, options);
+
+  if (options.customServer) {
+    await customServerGenerator(host, {
+      project: options.name,
+      compiler: options.swc ? 'swc' : 'tsc',
+    });
+  }
 
   if (!options.skipFormat) {
     await formatFiles(host);

--- a/packages/next/src/generators/application/schema.d.ts
+++ b/packages/next/src/generators/application/schema.d.ts
@@ -16,4 +16,5 @@ export interface Schema {
   setParserOptionsProject?: boolean;
   standaloneConfig?: boolean;
   swc?: boolean;
+  customServer?: boolean;
 }

--- a/packages/next/src/generators/application/schema.json
+++ b/packages/next/src/generators/application/schema.json
@@ -119,6 +119,11 @@
       "description": "Enable the Rust-based compiler SWC to compile JS/TS files.",
       "type": "boolean",
       "default": true
+    },
+    "customServer": {
+      "description": "Use a custom Express server for the Next.js application.",
+      "type": "boolean",
+      "default": false
     }
   },
   "required": []

--- a/packages/next/src/generators/custom-server/custom-server.ts
+++ b/packages/next/src/generators/custom-server/custom-server.ts
@@ -14,7 +14,7 @@ import { CustomServerSchema } from './schema';
 export async function customServerGenerator(
   host: Tree,
   options: CustomServerSchema
-) {
+): Promise<void> {
   const project = readProjectConfiguration(host, options.project);
 
   if (project.targets?.build?.executor !== '@nrwl/next:build') {

--- a/packages/next/src/generators/custom-server/files/server/main.ts__tmpl__
+++ b/packages/next/src/generators/custom-server/files/server/main.ts__tmpl__
@@ -1,8 +1,13 @@
 /*
  * This is only a minimal custom server to get started.
- * You should customize this server with CORS and other security features.
+ * You may want to consider using Express or another server framework, and enable security features such as CORS.
+ *
+ * For more examples, see the Next.js repo:
+ * - Express: https://github.com/vercel/next.js/tree/canary/examples/custom-server-express
+ * - Hapi: https://github.com/vercel/next.js/tree/canary/examples/custom-server-hapi
  */
-import express from 'express';
+import { createServer } from 'http';
+import { parse } from 'url';
 import * as path from 'path';
 import next from 'next';
 
@@ -11,10 +16,9 @@ import next from 'next';
 // - The fallback `__dirname` is for production builds.
 // - Feel free to change this to suit your needs.
 const dir = process.env.NX_NEXT_DIR || path.join(__dirname, '..');
-const publicDir = process.env.NX_NEXT_PUBLIC_DIR || path.join(__dirname, '../public');
 const dev = process.env.NODE_ENV === 'development';
 
-// Express server options:
+// HTTP Server options:
 // - Feel free to change this to suit your needs.
 const hostname = process.env.HOST || 'localhost';
 const port = process.env.PORT ? parseInt(process.env.PORT) : 4200;
@@ -25,28 +29,14 @@ async function main() {
 
   await nextApp.prepare();
 
-  const expressApp = express();
-
-  expressApp.get('/api', (req, res) => {
-    res.send({ message: 'Welcome!' });
+  const server = createServer((req, res) => {
+    const parsedUrl = parse(req.url, true);
+    handle(req, res, parsedUrl);
   });
 
-  // Serve static files from public folder.
-  expressApp.use(express.static(publicDir));
+  server.listen(port, hostname);
 
-  // Redirect requests to Next.js app.
-  expressApp.all('*', (req, res) => {
-    console.log('Forwarding request to Next.js: ', req.url);
-    handle(req, res)
-  });
-
-  return new Promise<void>((resolve, reject) => {
-    expressApp.on('error', (err) => reject(err));
-    expressApp.listen(port, () => {
-      console.log(`[ ready ] on http://${hostname}:${port}`)
-      resolve();
-    });
-  });
+  console.log(`[ ready ] on http://${hostname}:${port}`)
 }
 
 main().catch((err) => {


### PR DESCRIPTION
Next.js app can now be generated with `--custom-server` option that adds a custom express server instead of the default Next.js server.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
