### PR TITLE
feat(angular): support standalone component library generation

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -884,6 +884,11 @@
             "type": "boolean",
             "description": "Whether to skip the creation of a default module when generating the library.",
             "default": false
+          },
+          "standalone": {
+            "type": "boolean",
+            "description": "Generate a library that uses a standalone component instead of a module as the entry point.",
+            "default": false
           }
         },
         "additionalProperties": false,

--- a/packages/angular/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/angular/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -1,0 +1,192 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`lib --standalone should generate a library with a standalone component as entry point 1`] = `"export * from \\"./lib/my-lib/my-lib.component\\";"`;
+
+exports[`lib --standalone should generate a library with a standalone component as entry point 2`] = `
+"import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'proj-my-lib',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './my-lib.component.html',
+  styleUrls: ['./my-lib.component.css']
+})
+export class MyLibComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}
+"
+`;
+
+exports[`lib --standalone should generate a library with a standalone component as entry point 3`] = `
+"import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MyLibComponent } from './my-lib.component';
+
+describe('MyLibComponent', () => {
+  let component: MyLibComponent;
+  let fixture: ComponentFixture<MyLibComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ MyLibComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(MyLibComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});
+"
+`;
+
+exports[`lib --standalone should generate a library with a standalone component as entry point with routing setup 1`] = `
+"export * from \\"./lib/my-lib/my-lib.component\\";
+        export * from './lib/routes'"
+`;
+
+exports[`lib --standalone should generate a library with a standalone component as entry point with routing setup 2`] = `
+"import { Route } from '@angular/router';
+    import { MyLibComponent } from './my-lib/my-lib.component';
+    
+        export const MYLIB_ROUTES: Route[] = [
+          {path: '', component: MyLibComponent}
+        ];"
+`;
+
+exports[`lib --standalone should generate a library with a standalone component as entry point with routing setup 3`] = `
+"import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'proj-my-lib',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './my-lib.component.html',
+  styleUrls: ['./my-lib.component.css']
+})
+export class MyLibComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}
+"
+`;
+
+exports[`lib --standalone should generate a library with a standalone component as entry point with routing setup 4`] = `
+"import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MyLibComponent } from './my-lib.component';
+
+describe('MyLibComponent', () => {
+  let component: MyLibComponent;
+  let fixture: ComponentFixture<MyLibComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ MyLibComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(MyLibComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});
+"
+`;
+
+exports[`lib --standalone should generate a library with a standalone component as entry point with routing setup and attach it to parent module as a lazy child 1`] = `
+"export * from \\"./lib/my-lib/my-lib.component\\";
+        export * from './lib/routes'"
+`;
+
+exports[`lib --standalone should generate a library with a standalone component as entry point with routing setup and attach it to parent module as a lazy child 2`] = `
+"import { Route } from '@angular/router';
+    import { MyLibComponent } from './my-lib/my-lib.component';
+    
+        export const MYLIB_ROUTES: Route[] = [
+          {path: '', component: MyLibComponent}
+        ];"
+`;
+
+exports[`lib --standalone should generate a library with a standalone component as entry point with routing setup and attach it to parent module as a lazy child 3`] = `
+"import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+
+import { AppComponent } from './app.component';
+import { NxWelcomeComponent } from './nx-welcome.component';
+import { RouterModule } from '@angular/router';
+
+@NgModule({
+  declarations: [
+    AppComponent,
+    NxWelcomeComponent
+  ],
+  imports: [
+    BrowserModule,
+    RouterModule.forRoot([{path: 'my-lib', loadChildren: () => import('@proj/my-lib').then(module => module.MYLIB_ROUTES)}], {initialNavigation: 'enabledBlocking'})
+  ],
+  providers: [],
+  bootstrap: [AppComponent]
+})
+export class AppModule { }
+"
+`;
+
+exports[`lib --standalone should generate a library with a standalone component as entry point with routing setup and attach it to parent module as direct child 1`] = `
+"export * from \\"./lib/my-lib/my-lib.component\\";
+        export * from './lib/routes'"
+`;
+
+exports[`lib --standalone should generate a library with a standalone component as entry point with routing setup and attach it to parent module as direct child 2`] = `
+"import { Route } from '@angular/router';
+    import { MyLibComponent } from './my-lib/my-lib.component';
+    
+        export const MYLIB_ROUTES: Route[] = [
+          {path: '', component: MyLibComponent}
+        ];"
+`;
+
+exports[`lib --standalone should generate a library with a standalone component as entry point with routing setup and attach it to parent module as direct child 3`] = `
+"import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+
+import { AppComponent } from './app.component';
+import { NxWelcomeComponent } from './nx-welcome.component';
+import { RouterModule } from '@angular/router';
+import { MYLIB_ROUTES } from '@proj/my-lib';
+
+@NgModule({
+  declarations: [
+    AppComponent,
+    NxWelcomeComponent
+  ],
+  imports: [
+    BrowserModule,
+    RouterModule.forRoot([{ path: 'my-lib', children: MYLIB_ROUTES }], {initialNavigation: 'enabledBlocking'})
+  ],
+  providers: [],
+  bootstrap: [AppComponent]
+})
+export class AppModule { }
+"
+`;

--- a/packages/angular/src/generators/library/lib/add-children.ts
+++ b/packages/angular/src/generators/library/lib/add-children.ts
@@ -1,4 +1,4 @@
-import { Tree, names, getWorkspaceLayout } from '@nrwl/devkit';
+import { names, Tree } from '@nrwl/devkit';
 import { insertImport } from '@nrwl/workspace/src/utilities/ast-utils';
 import * as ts from 'typescript';
 import {
@@ -13,7 +13,9 @@ export function addChildren(host: Tree, options: NormalizedSchema) {
   }
 
   const moduleSource = host.read(options.parentModule, 'utf-8');
-  const constName = `${names(options.fileName).propertyName}Routes`;
+  const constName = options.standalone
+    ? `${names(options.name).className.toUpperCase()}_ROUTES`
+    : `${names(options.fileName).propertyName}Routes`;
   const importPath = options.importPath;
   let sourceFile = ts.createSourceFile(
     options.parentModule,
@@ -22,12 +24,15 @@ export function addChildren(host: Tree, options: NormalizedSchema) {
     true
   );
 
-  sourceFile = addImportToModule(
-    host,
-    sourceFile,
-    options.parentModule,
-    options.moduleName
-  );
+  if (!options.standalone) {
+    sourceFile = addImportToModule(
+      host,
+      sourceFile,
+      options.parentModule,
+      options.moduleName
+    );
+  }
+
   sourceFile = addRoute(
     host,
     options.parentModule,
@@ -38,7 +43,7 @@ export function addChildren(host: Tree, options: NormalizedSchema) {
     host,
     sourceFile,
     options.parentModule,
-    `${options.moduleName}, ${constName}`,
+    options.standalone ? constName : `${options.moduleName}, ${constName}`,
     importPath
   );
 }

--- a/packages/angular/src/generators/library/lib/add-load-children.ts
+++ b/packages/angular/src/generators/library/lib/add-load-children.ts
@@ -24,6 +24,10 @@ export function addLoadChildren(host: Tree, options: NormalizedSchema) {
       names(options.fileName).fileName
     }', loadChildren: () => import('${
       options.importPath
-    }').then(module => module.${options.moduleName})}`
+    }').then(module => module.${
+      options.standalone
+        ? `${names(options.name).className.toUpperCase()}_ROUTES`
+        : options.moduleName
+    })}`
   );
 }

--- a/packages/angular/src/generators/library/lib/add-standalone-component.ts
+++ b/packages/angular/src/generators/library/lib/add-standalone-component.ts
@@ -1,0 +1,60 @@
+import { Tree } from 'nx/src/generators/tree';
+import { NormalizedSchema } from './normalized-schema';
+import componentGenerator from '../../component/component';
+import { joinPathFragments } from 'nx/src/utils/path';
+import { names } from '@nrwl/devkit';
+import { addLoadChildren } from './add-load-children';
+import { addChildren } from './add-children';
+import { normalizeProjectName } from '../../utils/project';
+
+export async function addStandaloneComponent(
+  tree: Tree,
+  options: NormalizedSchema
+) {
+  await componentGenerator(tree, {
+    name: options.name,
+    standalone: true,
+    export: true,
+    project: normalizeProjectName(options.name, options.directory),
+  });
+
+  if (options.routing) {
+    const pathToRoutes = joinPathFragments(
+      options.projectRoot,
+      'src/lib/routes.ts'
+    );
+
+    const routesContents = `import { Route } from '@angular/router';
+    import { ${options.standaloneComponentName} } from './${joinPathFragments(
+      options.fileName,
+      `${options.fileName}.component`
+    )}';
+    
+        export const ${names(
+          options.name
+        ).className.toUpperCase()}_ROUTES: Route[] = [
+          {path: '', component: ${options.standaloneComponentName}}
+        ];`;
+    tree.write(pathToRoutes, routesContents);
+
+    const pathToEntryFile = joinPathFragments(
+      options.projectRoot,
+      'src',
+      `${options.entryFile}.ts`
+    );
+    const entryFileContents = tree.read(pathToEntryFile, 'utf-8');
+    tree.write(
+      pathToEntryFile,
+      `${entryFileContents}
+        export * from './lib/routes'`
+    );
+
+    if (options.parentModule) {
+      if (options.lazy) {
+        addLoadChildren(tree, options);
+      } else {
+        addChildren(tree, options);
+      }
+    }
+  }
+}

--- a/packages/angular/src/generators/library/lib/normalize-options.ts
+++ b/packages/angular/src/generators/library/lib/normalize-options.ts
@@ -2,13 +2,13 @@ import {
   getWorkspaceLayout,
   getWorkspacePath,
   joinPathFragments,
+  names,
   readJson,
   Tree,
 } from '@nrwl/devkit';
 import { getImportPath } from 'nx/src/utils/path';
 import { Schema } from '../schema';
 import { NormalizedSchema } from './normalized-schema';
-import { names } from '@nrwl/devkit';
 import { Linter } from '@nrwl/linter';
 import { UnitTestRunner } from '../../../utils/test-runners';
 import { normalizePrefix } from '../../utils/project';
@@ -30,7 +30,7 @@ export function normalizeOptions(
     compilationMode: schema.publishable
       ? 'partial'
       : schema.compilationMode ?? 'full',
-    skipModule: schema.skipModule ?? false,
+    skipModule: schema.skipModule || schema.standalone,
     ...schema,
   };
 
@@ -85,5 +85,6 @@ export function normalizeOptions(
     fileName,
     importPath,
     ngCliSchematicLibRoot,
+    standaloneComponentName: `${names(name).className}Component`,
   };
 }

--- a/packages/angular/src/generators/library/lib/normalized-schema.ts
+++ b/packages/angular/src/generators/library/lib/normalized-schema.ts
@@ -13,4 +13,5 @@ export interface NormalizedSchema extends Schema {
   projectDirectory: string;
   parsedTags: string[];
   ngCliSchematicLibRoot: string;
+  standaloneComponentName: string;
 }

--- a/packages/angular/src/generators/library/lib/update-project.ts
+++ b/packages/angular/src/generators/library/lib/update-project.ts
@@ -56,7 +56,7 @@ function updateFiles(host: Tree, options: NormalizedSchema) {
   if (options.name !== options.fileName) {
     host.delete(path.join(libRoot, `${options.name}.module.ts`));
   }
-  if (!options.skipModule) {
+  if (!options.skipModule && !options.standalone) {
     host.write(
       path.join(libRoot, `${options.fileName}.module.ts`),
       `
@@ -104,7 +104,7 @@ function updateFiles(host: Tree, options: NormalizedSchema) {
 
   host.write(
     `${options.projectRoot}/src/index.ts`,
-    options.skipModule
+    options.skipModule || options.standalone
       ? ``
       : `
         export * from './lib/${options.fileName}.module';

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -22,6 +22,7 @@ import {
 } from '../../utils/versions';
 import libraryGenerator from './library';
 import { Schema } from './schema';
+import applicationGenerator from '../application/application';
 
 describe('lib', () => {
   let tree: Tree;
@@ -1459,6 +1460,90 @@ describe('lib', () => {
       expect(devDependencies['tailwindcss']).toBe(tailwindVersion);
       expect(devDependencies['postcss']).toBe(postcssVersion);
       expect(devDependencies['autoprefixer']).toBe(autoprefixerVersion);
+    });
+  });
+
+  describe('--standalone', () => {
+    it('should generate a library with a standalone component as entry point', async () => {
+      await runLibraryGeneratorWithOpts({ standalone: true });
+
+      expect(tree.read('libs/my-lib/src/index.ts', 'utf-8')).toMatchSnapshot();
+      expect(
+        tree.read('libs/my-lib/src/lib/my-lib/my-lib.component.ts', 'utf-8')
+      ).toMatchSnapshot();
+      expect(
+        tree.read(
+          'libs/my-lib/src/lib/my-lib/my-lib.component.spec.ts',
+          'utf-8'
+        )
+      ).toMatchSnapshot();
+    });
+
+    it('should generate a library with a standalone component as entry point with routing setup', async () => {
+      await runLibraryGeneratorWithOpts({ standalone: true, routing: true });
+
+      expect(tree.read('libs/my-lib/src/index.ts', 'utf-8')).toMatchSnapshot();
+      expect(
+        tree.read('libs/my-lib/src/lib/routes.ts', 'utf-8')
+      ).toMatchSnapshot();
+      expect(
+        tree.read('libs/my-lib/src/lib/my-lib/my-lib.component.ts', 'utf-8')
+      ).toMatchSnapshot();
+      expect(
+        tree.read(
+          'libs/my-lib/src/lib/my-lib/my-lib.component.spec.ts',
+          'utf-8'
+        )
+      ).toMatchSnapshot();
+    });
+
+    it('should generate a library with a standalone component as entry point with routing setup and attach it to parent module as direct child', async () => {
+      // ARRANGE
+      await applicationGenerator(tree, {
+        name: 'app1',
+        routing: true,
+      });
+
+      // ACT
+      await runLibraryGeneratorWithOpts({
+        standalone: true,
+        routing: true,
+        parentModule: 'apps/app1/src/app/app.module.ts',
+      });
+
+      // ASSERT
+      expect(tree.read('libs/my-lib/src/index.ts', 'utf-8')).toMatchSnapshot();
+      expect(
+        tree.read('libs/my-lib/src/lib/routes.ts', 'utf-8')
+      ).toMatchSnapshot();
+      expect(
+        tree.read('apps/app1/src/app/app.module.ts', 'utf-8')
+      ).toMatchSnapshot();
+    });
+
+    it('should generate a library with a standalone component as entry point with routing setup and attach it to parent module as a lazy child', async () => {
+      // ARRANGE
+      await applicationGenerator(tree, {
+        name: 'app1',
+        routing: true,
+      });
+
+      // ACT
+      await runLibraryGeneratorWithOpts({
+        standalone: true,
+        routing: true,
+        lazy: true,
+        parentModule: 'apps/app1/src/app/app.module.ts',
+      });
+
+      // ASSERT
+      expect(tree.read('libs/my-lib/src/index.ts', 'utf-8')).toMatchSnapshot();
+      expect(
+        tree.read('libs/my-lib/src/lib/routes.ts', 'utf-8')
+      ).toMatchSnapshot();
+      expect(
+        tree.read('apps/app1/src/app/app.module.ts', 'utf-8')
+      ).toMatchSnapshot();
     });
   });
 });

--- a/packages/angular/src/generators/library/schema.d.ts
+++ b/packages/angular/src/generators/library/schema.d.ts
@@ -31,4 +31,5 @@ export interface Schema {
   skipModule?: boolean;
   skipPackageJson?: boolean;
   skipPostInstall?: boolean;
+  standalone?: boolean;
 }

--- a/packages/angular/src/generators/library/schema.json
+++ b/packages/angular/src/generators/library/schema.json
@@ -128,6 +128,11 @@
       "type": "boolean",
       "description": "Whether to skip the creation of a default module when generating the library.",
       "default": false
+    },
+    "standalone": {
+      "type": "boolean",
+      "description": "Generate a library that uses a standalone component instead of a module as the entry point.",
+      "default": false
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
We currently do not have a way to generate an angular library that uses standalone components

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Allow libraries to be generated following the standalone components flow

