### PR TITLE
fix(nx-plugin): fix the file paths for newly created generators in generators.json

### DIFF
--- a/packages/nx-plugin/src/generators/generator/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/generator/generator.spec.ts
@@ -60,6 +60,36 @@ describe('NxPlugin Generator Generator', () => {
     );
   });
 
+  it('should update generators.json with the same path as where the generator files folder is located', async () => {
+    const generatorName = 'myGenerator';
+    const generatorFileName = 'my-generator';
+
+    await generatorGenerator(tree, {
+      project: projectName,
+      name: generatorName,
+      description: 'my-generator description',
+      unitTestRunner: 'jest',
+    });
+
+    const generatorJson = readJson(tree, 'libs/my-plugin/generators.json');
+
+    expect(
+      tree.exists(
+        `libs/my-plugin/src/generators/${generatorFileName}/schema.d.ts`
+      )
+    ).toBeTruthy();
+
+    expect(generatorJson.generators[generatorName].factory).toEqual(
+      `./src/generators/${generatorFileName}/generator`
+    );
+    expect(generatorJson.generators[generatorName].schema).toEqual(
+      `./src/generators/${generatorFileName}/schema.json`
+    );
+    expect(generatorJson.generators[generatorName].description).toEqual(
+      `${generatorFileName} description`
+    );
+  });
+
   it('should create generators.json if it is not present', async () => {
     await libraryGenerator(tree, {
       name: 'test-js-lib',

--- a/packages/nx-plugin/src/generators/generator/generator.ts
+++ b/packages/nx-plugin/src/generators/generator/generator.ts
@@ -126,8 +126,8 @@ function updateGeneratorJson(host: Tree, options: NormalizedSchema) {
     let generators = json.generators ?? json.schematics;
     generators = generators || {};
     generators[options.name] = {
-      factory: `./src/generators/${options.name}/generator`,
-      schema: `./src/generators/${options.name}/schema.json`,
+      factory: `./src/generators/${options.fileName}/generator`,
+      schema: `./src/generators/${options.fileName}/schema.json`,
       description: options.description,
     };
     json.generators = generators;


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
nx-plugin generator does not use the `fileName` property for updating `generators.json` and leads to invalid paths in `generators.json` when using camelCase for a generator name.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`generators.json` is updated with the correct paths for the newly created generator. 
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #11610 

*Note*: 
The executor generator uses `options.fileName` and is not affected by the same issue when updating `executors.json`
`packages/nx-plugin/src/generators/executor/executor.ts`