### PR TITLE
fix(linter): escape all `$` chars in path; not only the first

### DIFF
--- a/packages/nx/src/command-line/format.ts
+++ b/packages/nx/src/command-line/format.ts
@@ -46,7 +46,7 @@ export async function format(
   const patterns = (await getPatterns({ ...args, ...nxArgs } as any)).map(
     // prettier removes one of the \
     // prettier-ignore
-    (p) => `"${p.replace("$", "\\\$")}"`
+    (p) => `"${p.replace(/\$/g, "\\\$")}"`
   );
 
   // Chunkify the patterns array to prevent crashing the windows terminal


### PR DESCRIPTION
## Current Behavior
`nx format` fails if a path has more than one dollar sign (`$`) in it. See https://github.com/nrwl/nx/issues/11493

I believe #11009 intended to fix this, but it only escapes the first `$` it finds.

## Expected Behavior
`nx format` should properly escape the paths

## This PR
This PR escapes all `$` characters. 

It uses a regular expression with the global flag
```diff
-    (p) => `"${p.replace("$", "\\\$")}"`
+    (p) => `"${p.replace(/\$/g, "\\\$")}"`
```

Another option would be use use `replaceAll`
```diff
-    (p) => `"${p.replace("$", "\\\$")}"`
+    (p) => `"${p.replaceAll("$", "\\\$")}"`
```

## Related Issue(s)
#11009

Fixes #11493
