### PR TITLE
chore(repo): increase memory allocation to agents

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ executors:
     <<: *defaults
     docker:
       - image: cimg/node:lts-browsers
+    resource_class: medium+
 
   macos:
     <<: *defaults


### PR DESCRIPTION
increase memory allocation to agents.

Agents being killed due to RAM usage as can be seen here: https://app.circleci.com/pipelines/github/nrwl/nx/19882/workflows/f4e0a188-8860-47a8-8cee-f5c7a66e49a1/jobs/200706/resources

Increasing the memory allocation produces successful agent execution: https://app.circleci.com/pipelines/github/nrwl/nx/19881/workflows/7016b2fd-1da6-4781-b285-eba39f5bee46/jobs/200698/resources