### PR TITLE
chore(angular): add standalone router helper

### DIFF
--- a/packages/angular/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/angular/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -143,7 +143,7 @@ import { RouterModule } from '@angular/router';
   ],
   imports: [
     BrowserModule,
-    RouterModule.forRoot([{path: 'my-lib', loadChildren: () => import('@proj/my-lib').then(module => module.MYLIB_ROUTES)}], {initialNavigation: 'enabledBlocking'})
+    RouterModule.forRoot([{path: 'my-lib', loadChildren: () => import('@proj/my-lib').then(m => m.MYLIB_ROUTES)}], {initialNavigation: 'enabledBlocking'})
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/packages/angular/src/generators/library/lib/add-load-children.ts
+++ b/packages/angular/src/generators/library/lib/add-load-children.ts
@@ -22,9 +22,7 @@ export function addLoadChildren(host: Tree, options: NormalizedSchema) {
     sourceFile,
     `{path: '${
       names(options.fileName).fileName
-    }', loadChildren: () => import('${
-      options.importPath
-    }').then(module => module.${
+    }', loadChildren: () => import('${options.importPath}').then(m => m.${
       options.standalone
         ? `${names(options.name).className.toUpperCase()}_ROUTES`
         : options.moduleName

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -906,7 +906,7 @@ describe('lib', () => {
         // ASSERT
         expect(moduleContents).toContain('RouterModule.forRoot([');
         expect(moduleContents).toContain(
-          `{path: 'my-dir-my-lib', loadChildren: () => import('@proj/my-dir/my-lib').then(module => module.MyDirMyLibModule)}`
+          `{path: 'my-dir-my-lib', loadChildren: () => import('@proj/my-dir/my-lib').then(m => m.MyDirMyLibModule)}`
         );
 
         expect(tsConfigLibJson.exclude).toEqual([
@@ -918,10 +918,10 @@ describe('lib', () => {
 
         expect(moduleContents2).toContain('RouterModule.forRoot([');
         expect(moduleContents2).toContain(
-          `{path: 'my-dir-my-lib', loadChildren: () => import('@proj/my-dir/my-lib').then(module => module.MyDirMyLibModule)}`
+          `{path: 'my-dir-my-lib', loadChildren: () => import('@proj/my-dir/my-lib').then(m => m.MyDirMyLibModule)}`
         );
         expect(moduleContents2).toContain(
-          `{path: 'my-lib2', loadChildren: () => import('@proj/my-dir/my-lib2').then(module => module.MyLib2Module)}`
+          `{path: 'my-lib2', loadChildren: () => import('@proj/my-dir/my-lib2').then(m => m.MyLib2Module)}`
         );
 
         expect(tsConfigLibJson2.exclude).toEqual([
@@ -933,13 +933,13 @@ describe('lib', () => {
 
         expect(moduleContents3).toContain('RouterModule.forRoot([');
         expect(moduleContents3).toContain(
-          `{path: 'my-dir-my-lib', loadChildren: () => import('@proj/my-dir/my-lib').then(module => module.MyDirMyLibModule)}`
+          `{path: 'my-dir-my-lib', loadChildren: () => import('@proj/my-dir/my-lib').then(m => m.MyDirMyLibModule)}`
         );
         expect(moduleContents3).toContain(
-          `{path: 'my-lib2', loadChildren: () => import('@proj/my-dir/my-lib2').then(module => module.MyLib2Module)}`
+          `{path: 'my-lib2', loadChildren: () => import('@proj/my-dir/my-lib2').then(m => m.MyLib2Module)}`
         );
         expect(moduleContents3).toContain(
-          `{path: 'my-lib3', loadChildren: () => import('@proj/my-dir/my-lib3').then(module => module.MyLib3Module)}`
+          `{path: 'my-lib3', loadChildren: () => import('@proj/my-dir/my-lib3').then(m => m.MyLib3Module)}`
         );
 
         expect(tsConfigLibJson3.exclude).toEqual([
@@ -987,7 +987,7 @@ describe('lib', () => {
 
         expect(moduleContents).toContain('RouterModule.forRoot(routes)');
         expect(moduleContents).toContain(
-          `const routes = [{path: 'my-dir-my-lib', loadChildren: () => import('@proj/my-dir/my-lib').then(module => module.MyDirMyLibModule)}];`
+          `const routes = [{path: 'my-dir-my-lib', loadChildren: () => import('@proj/my-dir/my-lib').then(m => m.MyDirMyLibModule)}];`
         );
       });
     });

--- a/packages/angular/src/utils/nx-devkit/standalone-utils.spec.ts
+++ b/packages/angular/src/utils/nx-devkit/standalone-utils.spec.ts
@@ -1,0 +1,144 @@
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { addStandaloneRoute } from './standalone-utils';
+
+describe('standalone component utils', () => {
+  it('should add a lazy route correctly to parent with router module', () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    tree.write(
+      'parent-file.ts',
+      `import { RouterModule } from '@angular/router';
+      import { AppComponent } from './app/app.component';
+      
+    bootstrapApplication(AppComponent, {
+      providers: [
+        importProvidersFrom(
+          RouterModule.forRoot([], { initialNavigation: 'enabledBlocking' }),
+          SomeOtherModule
+        ),
+      ],
+    })`
+    );
+
+    // ACT
+    addStandaloneRoute(
+      tree,
+      'parent-file.ts',
+      "{path: 'test', loadChildren: () => import('@proj/lib').then(m => m.ROUTES) }"
+    );
+
+    // ASSERT
+    expect(tree.read('parent-file.ts', 'utf-8')).toMatchInlineSnapshot(`
+      "import { RouterModule } from '@angular/router';
+            import { AppComponent } from './app/app.component';
+            
+          bootstrapApplication(AppComponent, {
+            providers: [
+              importProvidersFrom(
+                RouterModule.forRoot([
+          {path: 'test', loadChildren: () => import('@proj/lib').then(m => m.ROUTES) },], { initialNavigation: 'enabledBlocking' }),
+                SomeOtherModule
+              ),
+            ],
+          }"
+    `);
+  });
+
+  it('should add a route correctly to parent with router module', () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    tree.write(
+      'parent-file.ts',
+      `import { RouterModule } from '@angular/router';
+      import { AppComponent } from './app/app.component';
+      
+    bootstrapApplication(AppComponent, {
+      providers: [
+        importProvidersFrom(
+          RouterModule.forRoot([], { initialNavigation: 'enabledBlocking' }),
+          SomeOtherModule
+        ),
+      ],
+    })`
+    );
+
+    // ACT
+    addStandaloneRoute(
+      tree,
+      'parent-file.ts',
+      "{path: 'test', children: ROUTES }",
+      false,
+      'ROUTES',
+      '@proj/lib'
+    );
+
+    // ASSERT
+    expect(tree.read('parent-file.ts', 'utf-8')).toMatchInlineSnapshot(`
+      "import { RouterModule } from '@angular/router';
+            import { AppComponent } from './app/app.component';
+      import { ROUTES } from '@proj/lib';
+            
+          bootstrapApplication(AppComponent, {
+            providers: [
+              importProvidersFrom(
+                RouterModule.forRoot([
+          {path: 'test', children: ROUTES },], { initialNavigation: 'enabledBlocking' }),
+                SomeOtherModule
+              ),
+            ],
+          }"
+    `);
+  });
+
+  it('should add a lazy route correctly to parent with route config', () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    tree.write(
+      'parent-file.ts',
+      `import { Route } from '@angular/router';
+      export const ROUTES: Route[] = [];`
+    );
+
+    // ACT
+    addStandaloneRoute(
+      tree,
+      'parent-file.ts',
+      "{path: 'test', loadChildren: () => import('@proj/lib').then(m => m.ROUTES) }"
+    );
+
+    // ASSERT
+    expect(tree.read('parent-file.ts', 'utf-8')).toMatchInlineSnapshot(`
+      "import { Route } from '@angular/router';
+            export const ROUTES: Route[] = [
+          {path: 'test', loadChildren: () => import('@proj/lib').then(m => m.ROUTES) },]"
+    `);
+  });
+
+  it('should add a route correctly to parent with router module', () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    tree.write(
+      'parent-file.ts',
+      `import { Route } from '@angular/router';
+      export const ROUTES: Route[] = [];`
+    );
+
+    // ACT
+    addStandaloneRoute(
+      tree,
+      'parent-file.ts',
+      "{path: 'test', children: ROUTES }",
+      false,
+      'ROUTES',
+      '@proj/lib'
+    );
+
+    // ASSERT
+    expect(tree.read('parent-file.ts', 'utf-8')).toMatchInlineSnapshot(`
+      "import { Route } from '@angular/router';
+      import { ROUTES } from '@proj/lib';
+            export const ROUTES: Route[] = [
+          {path: 'test', children: ROUTES },]"
+    `);
+  });
+});

--- a/packages/angular/src/utils/nx-devkit/standalone-utils.ts
+++ b/packages/angular/src/utils/nx-devkit/standalone-utils.ts
@@ -1,0 +1,75 @@
+import { Tree } from '@nrwl/devkit';
+import { tsquery } from '@phenomnomnominal/tsquery';
+import * as ts from 'typescript';
+import { insertImport } from '@nrwl/workspace/src/utilities/ast-utils';
+
+export function addStandaloneRoute(
+  tree: Tree,
+  parentPath: string,
+  route: string,
+  lazy: boolean = true,
+  routesConst?: string,
+  importPath?: string
+) {
+  if (!tree.exists(parentPath)) {
+    throw new Error(
+      `Path to parent routing declaration (${parentPath}) does not exist. Please ensure path is correct.`
+    );
+  }
+
+  let parentContents = tree.read(parentPath, 'utf-8');
+
+  if (!lazy) {
+    let parentSourceFile = ts.createSourceFile(
+      parentPath,
+      parentContents,
+      ts.ScriptTarget.Latest,
+      true
+    );
+
+    parentSourceFile = insertImport(
+      tree,
+      parentSourceFile,
+      parentPath,
+      routesConst,
+      importPath
+    );
+
+    parentContents = tree.read(parentPath, 'utf-8');
+  }
+
+  const ast = tsquery.ast(parentContents);
+
+  const IMPORT_PROVIDERS_FROM_ROUTER_MODULE_SELECTOR =
+    'CallExpression:has(Identifier[name=importProvidersFrom]) CallExpression:has(PropertyAccessExpression:has(Identifier[name=RouterModule])) > ArrayLiteralExpression';
+
+  const ROUTES_ARRAY_SELECTOR =
+    'VariableDeclaration:has(ArrayType > TypeReference > Identifier[name=Route]) > ArrayLiteralExpression';
+
+  const routerModuleNodes = tsquery(
+    ast,
+    IMPORT_PROVIDERS_FROM_ROUTER_MODULE_SELECTOR,
+    { visitAllChildren: true }
+  );
+  const isImportProvidersFromRouterSetup = routerModuleNodes.length > 0;
+
+  const routesArrayNodes = tsquery(ast, ROUTES_ARRAY_SELECTOR, {
+    visitAllChildren: true,
+  });
+  const isRoutesArray = routesArrayNodes.length > 0;
+
+  if (!isImportProvidersFromRouterSetup && !isRoutesArray) {
+    throw new Error(
+      'Parent routing declaration does not contain a routing configuration. Please ensure the parent contains a routing configuration.'
+    );
+  }
+
+  const nodes = isImportProvidersFromRouterSetup
+    ? routerModuleNodes
+    : routesArrayNodes;
+
+  const newParentContents = `${parentContents.slice(0, nodes[0].getStart() + 1)}
+    ${route},${parentContents.slice(nodes[0].getStart() + 1, -1)}`;
+
+  tree.write(parentPath, newParentContents);
+}


### PR DESCRIPTION
Add a `addStandaloneRoute` helper to make it easier to add standalone routes to router module or route configuration
