### PR TITLE
feat(angular): support library routing setup for standalone routes

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -839,7 +839,8 @@
           },
           "parentModule": {
             "type": "string",
-            "description": "Update the router configuration of the parent module using `loadChildren` or `children`, depending on what `lazy` is set to."
+            "description": "Update the router configuration of the parent module using `loadChildren` or `children`, depending on what `lazy` is set to.",
+            "alias": "parent"
           },
           "tags": {
             "type": "string",

--- a/packages/angular/src/generators/library/schema.json
+++ b/packages/angular/src/generators/library/schema.json
@@ -78,7 +78,8 @@
     },
     "parentModule": {
       "type": "string",
-      "description": "Update the router configuration of the parent module using `loadChildren` or `children`, depending on what `lazy` is set to."
+      "description": "Update the router configuration of the parent module using `loadChildren` or `children`, depending on what `lazy` is set to.",
+      "alias": "parent"
     },
     "tags": {
       "type": "string",


### PR DESCRIPTION
Standalone libraries should be able to insert routes into other standalone-based routing configurations