### PR TITLE
docs(nxdev): add transformer for code fence

### DIFF
--- a/docs/shared/core-tutorial/01-create-blog.md
+++ b/docs/shared/core-tutorial/01-create-blog.md
@@ -118,7 +118,7 @@ To actually create a blog, we'll have to change a few more files. This is all El
 
 Update `index.html`:
 
-```html
+```html {% process=false %}
 ---
 layout: layout.liquid
 pageTitle: Welcome to my blog

--- a/nx-dev/ui-markdoc/src/lib/nodes/fence.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/nodes/fence.component.tsx
@@ -14,6 +14,14 @@ function resolveLanguage(lang: string) {
   }
 }
 
+function showLineNumber(lang: string, content: string) {
+  if (['bash', 'text', 'treeview'].includes(lang)) {
+    return false;
+  }
+
+  return content.split(/\r\n|\r|\n/).length > 2;
+}
+
 export function Fence({
   children,
   language,
@@ -33,6 +41,7 @@ export function Fence({
       t && clearTimeout(t);
     };
   }, [copied]);
+
   return (
     <div className="code-block group relative">
       <CopyToClipboard
@@ -63,7 +72,7 @@ export function Fence({
         </button>
       </CopyToClipboard>
       <SyntaxHighlighter
-        showLineNumbers={!['bash', 'text', 'treeview'].includes(language)}
+        showLineNumbers={showLineNumber(language, children)}
         useInlineStyles={false}
         language={resolveLanguage(language)}
         children={children}

--- a/nx-dev/ui-markdoc/src/lib/nodes/fence.schema.ts
+++ b/nx-dev/ui-markdoc/src/lib/nodes/fence.schema.ts
@@ -1,9 +1,17 @@
-import { Schema } from '@markdoc/markdoc';
+import { Schema, Tag } from '@markdoc/markdoc';
 
 export const fence: Schema = {
   render: 'Fence',
   attributes: {
-    text: { type: 'String', required: true },
+    content: { type: 'String', render: false, required: true },
     language: { type: 'String' },
+    process: { type: 'Boolean', render: false, default: true },
+  },
+  transform(node, config) {
+    const attributes = node.transformAttributes(config);
+    const children = node.children.length
+      ? node.transformChildren(config)
+      : [node.attributes['content']];
+    return new Tag('Fence', attributes, children);
   },
 };

--- a/package.json
+++ b/package.json
@@ -271,7 +271,7 @@
     "@docsearch/react": "3.0.0",
     "@headlessui/react": "^1.1.1",
     "@heroicons/react": "^1.0.1",
-    "@markdoc/markdoc": "^0.1.3",
+    "@markdoc/markdoc": "0.1.6",
     "@monaco-editor/react": "^4.3.1",
     "@napi-rs/canvas": "^0.1.19",
     "@tailwindcss/aspect-ratio": "^0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3259,10 +3259,10 @@
     npmlog "^4.1.2"
     write-file-atomic "^3.0.3"
 
-"@markdoc/markdoc@^0.1.3":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@markdoc/markdoc/-/markdoc-0.1.4.tgz#2f229ce3feb80aa781c0d8f453f7a7a614e1248a"
-  integrity sha512-WOm+jwCeDyWtshIc5tjZ/AD+rFpqL9b1YAUiC975VlZISxRXt2G6Df5G3RwH420Jbavtik50r2tDInnEWIS8nQ==
+"@markdoc/markdoc@0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@markdoc/markdoc/-/markdoc-0.1.6.tgz#3ac13e8d135378231e83dc7faf3a4c73fb0fad0a"
+  integrity sha512-I+QvtEjeZpl8H8uRbSuILwlUw/8ngogQnHeXKmxigJcvLXqZ8BJSldCPXjiVKpQ5vZOpjrblwAAkTI4JeEN3ZA==
 
 "@mdx-js/mdx@^1.6.22":
   version "1.6.22"


### PR DESCRIPTION
It adds a transformer function to the code fense in order to filter out configuration and attributes for markdoc on nx.dev.
Allows the `{% process=false %}` usage as code fence's attribute to escape all content parsing.