### PR TITLE
fix(core): Add throw of error if a dependency is not in the graph

### DIFF
--- a/packages/workspace/src/utilities/buildable-libs-utils.spec.ts
+++ b/packages/workspace/src/utilities/buildable-libs-utils.spec.ts
@@ -84,3 +84,34 @@ describe('calculateProjectDependencies', () => {
     });
   });
 });
+
+describe('missingDependencies', () => {
+  it('should throw an error if dependency is missing', async () => {
+    const graph: ProjectGraph = {
+      nodes: {
+        example: {
+          type: 'lib',
+          name: 'example',
+          data: {
+            files: [],
+            root: '/root/example',
+          },
+        },
+      },
+      externalNodes: {},
+      dependencies: {
+        example: [
+          {
+            source: 'example',
+            target: 'npm:formik',
+            type: DependencyType.static,
+          },
+        ],
+      },
+    };
+
+    expect(() =>
+      calculateProjectDependencies(graph, 'root', 'example', 'build', undefined)
+    ).toThrow();
+  });
+});

--- a/packages/workspace/src/utilities/buildable-libs-utils.ts
+++ b/packages/workspace/src/utilities/buildable-libs-utils.ts
@@ -44,7 +44,27 @@ export function calculateProjectDependencies(
   // gather the library dependencies
   const nonBuildableDependencies = [];
   const topLevelDependencies: DependentBuildableProjectNode[] = [];
-  const dependencies = collectDependencies(projectName, projGraph, [], shallow)
+  const collectedDeps = collectDependencies(
+    projectName,
+    projGraph,
+    [],
+    shallow
+  );
+  const missing = collectedDeps.reduce(
+    (missing: string[] | undefined, { name: dep }) => {
+      const depNode = projGraph.nodes[dep] || projGraph.externalNodes[dep];
+      if (!depNode) {
+        missing = missing || [];
+        missing.push(dep);
+      }
+      return missing;
+    },
+    null
+  );
+  if (missing) {
+    throw new Error(`Unable to find ${missing.join(', ')} in project graph.`);
+  }
+  const dependencies = collectedDeps
     .map(({ name: dep, isTopLevel }) => {
       let project: DependentBuildableProjectNode = null;
       const depNode = projGraph.nodes[dep] || projGraph.externalNodes[dep];


### PR DESCRIPTION
Applies #11080 

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
