### PR TITLE
fix(nextjs): fix React 18 detection

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -47,6 +47,7 @@
     "eslint-config-next": "^12.1.0",
     "fs-extra": "^10.1.0",
     "ignore": "^5.0.4",
+    "semver": "7.3.4",
     "ts-node": "10.9.1",
     "tsconfig-paths": "^3.9.0",
     "url-loader": "^4.1.1",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`@nrwl/next@14.5.5` does not work with Next.js v12.2.1 or higher because of the changes introduced in https://github.com/nrwl/nx/commit/50afd2b6648ce967ed76437598315df016278a35 .

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`__NEXT_REACT_ROOT` should be set based on the version of installed `react-dom`.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #11609
