### PR TITLE
cleanup(angular): deprecate mf signature from app generator

### DIFF
--- a/packages/angular/src/generators/application/schema.d.ts
+++ b/packages/angular/src/generators/application/schema.d.ts
@@ -23,14 +23,29 @@ export interface Schema {
   backendProject?: string;
   strict?: boolean;
   standaloneConfig?: boolean;
+  /**
+   * @deprecated Use the `host` or `remote` generators instead. Support for generating Module Federation applications using the application generator will be removed in an upcoming version.
+   */
   mf?: boolean;
+  /**
+   * @deprecated Use the `host` or `remote` generators instead. Support for generating Module Federation applications using the application generator will be removed in an upcoming version.
+   */
   mfType?: 'host' | 'remote';
+  /**
+   * @deprecated Use the `host` or `remote` generators instead. Support for generating Module Federation applications using the application generator will be removed in an upcoming version.
+   */
   remotes?: string[];
   port?: number;
+  /**
+   * @deprecated Use the `host` or `remote` generators instead. Support for generating Module Federation applications using the application generator will be removed in an upcoming version.
+   */
   host?: string;
   setParserOptionsProject?: boolean;
   skipPackageJson?: boolean;
   skipPostInstall?: boolean;
+  /**
+   * @deprecated Use the `host` or `remote` generators instead. Support for generating Module Federation applications using the application generator will be removed in an upcoming version.
+   */
   federationType?: 'static' | 'dynamic';
   skipDefaultProject?: boolean;
   standalone?: boolean;


### PR DESCRIPTION
When deprecating the Module Federation schema options for the Application generator, we did not also deprecate the TS interface. Anyone using the application generator programmatically may not have been informed about the deprecated nature of those options.
