### PR TITLE
cleanup(angular): use app generator and setup-mf for host and remote

### DIFF
--- a/packages/angular/src/generators/host/host.spec.ts
+++ b/packages/angular/src/generators/host/host.spec.ts
@@ -1,6 +1,5 @@
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import host from './host';
-import applicationGenerator from '../application/application';
 import remote from '../remote/remote';
 
 describe('Host App Generator', () => {
@@ -21,12 +20,8 @@ describe('Host App Generator', () => {
     // ARRANGE
     const tree = createTreeWithEmptyWorkspace();
 
-    await applicationGenerator(tree, {
+    await remote(tree, {
       name: 'remote',
-      mf: true,
-      mfType: 'remote',
-      routing: true,
-      port: 4201,
     });
 
     // ACT

--- a/packages/angular/src/generators/host/host.ts
+++ b/packages/angular/src/generators/host/host.ts
@@ -12,6 +12,7 @@ import remoteGenerator from '../remote/remote';
 import { normalizeProjectName } from '../utils/project';
 import * as ts from 'typescript';
 import { addRoute } from '../../utils/nx-devkit/ast-utils';
+import { setupMf } from '../setup-mf/setup-mf';
 
 export default async function host(tree: Tree, options: Schema) {
   const projects = getProjects(tree);
@@ -29,22 +30,32 @@ export default async function host(tree: Tree, options: Schema) {
     });
   }
 
+  const appName = normalizeProjectName(options.name, options.directory);
+
   const installTask = await applicationGenerator(tree, {
     ...options,
-    mf: true,
+    routing: true,
+    port: 4200,
+    skipFormat: true,
+  });
+
+  await setupMf(tree, {
+    appName,
     mfType: 'host',
     routing: true,
-    remotes: remotesToIntegrate ?? [],
     port: 4200,
+    remotes: remotesToIntegrate ?? [],
     federationType: options.dynamic ? 'dynamic' : 'static',
+    skipPackageJson: options.skipPackageJson,
     skipFormat: true,
+    e2eProjectName: `${appName}-e2e`,
   });
 
   for (const remote of remotesToGenerate) {
     await remoteGenerator(tree, {
       ...options,
       name: remote,
-      host: normalizeProjectName(options.name, options.directory),
+      host: appName,
       skipFormat: true,
     });
   }

--- a/packages/angular/src/generators/remote/remote.spec.ts
+++ b/packages/angular/src/generators/remote/remote.spec.ts
@@ -3,7 +3,7 @@ import {
   readWorkspaceConfiguration,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import applicationGenerator from '../application/application';
+import host from '../host/host';
 import remote from './remote';
 
 describe('MF Remote App Generator', () => {
@@ -25,18 +25,14 @@ describe('MF Remote App Generator', () => {
     // ARRANGE
     const tree = createTreeWithEmptyWorkspace();
 
-    await applicationGenerator(tree, {
+    await host(tree, {
       name: 'host',
-      mf: true,
-      mfType: 'host',
-      routing: true,
     });
 
     // ACT
     await remote(tree, {
       name: 'test',
       host: 'host',
-      port: 4201,
     });
 
     // ASSERT
@@ -53,7 +49,6 @@ describe('MF Remote App Generator', () => {
       await remote(tree, {
         name: 'test',
         host: 'host',
-        port: 4201,
       });
     } catch (error) {
       // ASSERT

--- a/packages/angular/src/generators/setup-mf/lib/add-cypress-workaround.ts
+++ b/packages/angular/src/generators/setup-mf/lib/add-cypress-workaround.ts
@@ -3,23 +3,29 @@
 // is attached to the index.html with type=module
 
 import type { ProjectConfiguration, Tree } from '@nrwl/devkit';
-import type { Schema } from '../schema';
-
 import {
   joinPathFragments,
-  readProjectConfiguration,
   logger,
+  readProjectConfiguration,
 } from '@nrwl/devkit';
+import type { Schema } from '../schema';
 
 export function addCypressOnErrorWorkaround(tree: Tree, schema: Schema) {
-  const e2eProjectName = schema.e2eProjectName ?? `${schema.appName}-e2e`;
+  if (!schema.e2eProjectName) {
+    return;
+  }
+
+  const e2eProjectName = schema.e2eProjectName;
   let e2eProject: ProjectConfiguration;
 
   try {
     e2eProject = readProjectConfiguration(tree, e2eProjectName);
   } catch {
-    logger.warn(`Could not find an associated e2e project for ${schema.appName} with name ${e2eProjectName}. 
-    If the app does have an associated Cypress e2e project, you can pass the name of it to the generator using --e2eProjectName.`);
+    logger.warn(`Could not find an associated e2e project for ${schema.appName} with name ${e2eProjectName}.
+    If there is an associated e2e project for this application, and it uses Cypress, you will need to add a workaround to allow Cypress to test correctly.
+    An error will be thrown in the console when you serve the application, coming from styles.js. It is an error that can be safely ignored and will not reach production due to how production builds of Angular are created.
+    You can find how to implement that workaround here: https://docs.cypress.io/api/events/catalog-of-events#Uncaught-Exceptions
+    `);
     return;
   }
 

--- a/packages/angular/src/generators/setup-mf/setup-mf.spec.ts
+++ b/packages/angular/src/generators/setup-mf/setup-mf.spec.ts
@@ -278,6 +278,7 @@ describe('Init MF', () => {
       appName: 'test-app',
       mfType: 'host',
       routing: true,
+      e2eProjectName: 'test-app-e2e',
     });
 
     // ASSERT


### PR DESCRIPTION
Change host and remote generator to use app generator without Module Federation options and rely on `setup-mf` generator to do those integrations.
