### PR TITLE
fix(core): include config name in the cached fileset for main task

### DIFF
--- a/packages/linter/src/executors/eslint/hasher.spec.ts
+++ b/packages/linter/src/executors/eslint/hasher.spec.ts
@@ -1,0 +1,80 @@
+import type { Task, Hasher, Hash } from '@nrwl/devkit';
+
+import run from './hasher';
+
+describe('Eslint Hasher', () => {
+  const mockHasher: Partial<Hasher> = {
+    async hashTask(task: Task): Promise<Hash> {
+      return {
+        details: {
+          command: 'test-command',
+          nodes: {
+            [`${task.target.project}:$filesets:${task.target.target}`]:
+              'test-files-hash',
+          },
+          runtime: {},
+          implicitDeps: {},
+        },
+        value: '',
+      };
+    },
+    hashArray(values: string[]): string {
+      return values.join('-');
+    },
+  };
+
+  it('should fetch filesets from target', async () => {
+    expect(
+      await run(
+        {
+          target: { project: 'project', target: 'build' },
+          id: 'test-proj',
+          overrides: {},
+        },
+        {
+          hasher: mockHasher as Hasher,
+          projectGraph: {
+            nodes: {
+              project: {
+                name: 'project',
+                type: 'lib',
+                data: {
+                  root: 'libs/project',
+                  targets: {
+                    build: {
+                      inputs: [
+                        'default',
+                        '^default',
+                        { runtime: 'echo runtime123' },
+                        { env: 'TESTENV' },
+                        { env: 'NONEXISTENTENV' },
+                      ],
+                    },
+                  },
+                  files: [{ file: '/file', ext: '.ts', hash: 'file.hash' }],
+                },
+              },
+            },
+            dependencies: {
+              project: [],
+            },
+            allWorkspaceFiles: [],
+          },
+          workspaceConfig: {
+            projects: {},
+            version: 2,
+          },
+        }
+      )
+    ).toEqual({
+      details: {
+        command: 'test-command',
+        nodes: {
+          project: 'test-files-hash',
+          tags: '',
+        },
+      },
+      value: 'test-command-test-files-hash-',
+    });
+  });
+});


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Targets share the same fileset cache for main task.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Targets should not share same filesets if different are defined.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
