### PR TITLE
fix(next): add default hostname value to @nrwl/next:server

### DIFF
--- a/packages/next/src/executors/server/server.impl.ts
+++ b/packages/next/src/executors/server/server.impl.ts
@@ -97,7 +97,7 @@ async function* runNextDevServer(
     conf: config,
     port: options.port,
     customServer: !!options.customServerTarget,
-    hostname: options.hostname,
+    hostname: options.hostname || 'localhost',
 
     // TOOD(jack): Remove in Nx 15
     path: options.customServerPath,


### PR DESCRIPTION


## Current Behavior
If we don't set hostname option in next.js app, when running `nx serve <next-app>`, `<next-app>` will get `hostname`with value `undefined` in middleware `req.nextUrl` object, which will cause bugs. When running `<next-app>` with `next dev`, this will not be a problem

## Expected Behavior
`hostname` option should be optional with default value `localhost`

## Related Issue(s)

Fixes #11582
