### PR TITLE
fix(angular): remote generator should not assume a default host

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -974,7 +974,7 @@
           "host": {
             "type": "string",
             "description": "The name of the host app to attach this remote app to.",
-            "$default": { "$source": "projectName" }
+            "x-dropdown": "projects"
           },
           "port": {
             "type": "number",

--- a/packages/angular/src/generators/remote/schema.json
+++ b/packages/angular/src/generators/remote/schema.json
@@ -23,9 +23,7 @@
     "host": {
       "type": "string",
       "description": "The name of the host app to attach this remote app to.",
-      "$default": {
-        "$source": "projectName"
-      }
+      "x-dropdown": "projects"
     },
     "port": {
       "type": "number",


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
`host` property was fetching the default app when `--host` was not provided

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`host` should not be set, but Nx Console should still provide a hint

