### PR TITLE
fix(angular): remote entry component template typo

### DIFF
--- a/packages/angular/src/generators/setup-mf/__snapshots__/setup-mf.spec.ts.snap
+++ b/packages/angular/src/generators/setup-mf/__snapshots__/setup-mf.spec.ts.snap
@@ -114,7 +114,7 @@ exports[`Init MF should generate the remote entry component correctly when prefi
 
 @Component({
   selector: 'remote1-entry',
-  template: \`nx-welcome></nx-welcome>\`
+  template: \`<nx-welcome></nx-welcome>\`
 })
 export class RemoteEntryComponent {}
 "

--- a/packages/angular/src/generators/setup-mf/files/entry-module-files/entry.component.ts__tmpl__
+++ b/packages/angular/src/generators/setup-mf/files/entry-module-files/entry.component.ts__tmpl__
@@ -4,6 +4,6 @@ import { Component } from '@angular/core';
   selector: '<%= prefix %>-<%= appName %>-entry',
   template: `<<%= prefix %>-nx-welcome></<%= prefix %>-nx-welcome>`<% } else { %>
   selector: '<%= appName %>-entry',
-  template: `nx-welcome></nx-welcome>`<% } %>
+  template: `<nx-welcome></nx-welcome>`<% } %>
 })
 export class RemoteEntryComponent {}


### PR DESCRIPTION
Minor typo in component template that gets generated
