### PR TITLE
feat(core): support reading cli args from env

### DIFF
--- a/packages/nx/src/command-line/nx-commands.spec.ts
+++ b/packages/nx/src/command-line/nx-commands.spec.ts
@@ -1,6 +1,16 @@
 import { commandsObject } from 'nx/src/command-line/nx-commands';
 
 describe('nx-commands', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
   it('should parse dot notion cli args', () => {
     const actual = commandsObject.parse(
       'nx e2e project-e2e --env.NX_API_URL=http://localhost:4200 --abc.123.xyx=false --a.b=3'
@@ -18,6 +28,28 @@ describe('nx-commands', () => {
         env: {
           NX_API_URL: 'http://localhost:4200',
         },
+      })
+    );
+  });
+
+  it('should support args from the environment', () => {
+    process.env.NX_DRY_RUN = 'true';
+    process.env.NX_SKIP_NX_CACHE = 'false';
+    const actual = commandsObject.parse('nx run project-e2e');
+    expect(actual).toEqual(
+      expect.objectContaining({
+        dryRun: 'true',
+        skipNxCache: 'false',
+      })
+    );
+  });
+
+  it('CLI args should take precedence over args from the environment', () => {
+    process.env.NX_DRY_RUN = 'true';
+    const actual = commandsObject.parse('nx run project-e2e --dryRun=false');
+    expect(actual).toEqual(
+      expect.objectContaining({
+        dryRun: 'false',
       })
     );
   });

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -25,6 +25,7 @@ export const parserConfiguration: Partial<yargs.ParserConfigurationOptions> = {
 export const commandsObject = yargs
   .parserConfiguration(parserConfiguration)
   .usage(chalk.bold('Smart, Fast and Extensible Build System'))
+  .env('NX')
   .demandCommand(1, '')
   .command({
     command: 'generate <generator> [_..]',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
CLI options cannot be set via environment variables

## Expected Behavior
CLI options can be set via environment variables. 

This is easily accomplished via the `yargs` [.env](http://yargs.js.org/docs/#api-reference-envprefix) method.

## Related Issue(s)
Fixes https://github.com/nrwl/nx/issues/11713