### PR TITLE
fix(js): close typescript watch program on SIGINT/SIGTERM

### DIFF
--- a/packages/js/src/utils/typescript/compile-typescript-files.ts
+++ b/packages/js/src/utils/typescript/compile-typescript-files.ts
@@ -16,33 +16,58 @@ function getErrorCountFromMessage(messageText: string) {
   return Number.parseInt(ERROR_COUNT_REGEX.exec(messageText)[1]);
 }
 
-export async function* compileTypeScriptFiles(
+export interface TypescriptCompilationResult {
+  success: boolean;
+  outfile: string;
+}
+
+export function compileTypeScriptFiles(
   normalizedOptions: NormalizedExecutorOptions,
   tscOptions: TypeScriptCompilationOptions,
   postCompilationCallback: () => void | Promise<void>
-) {
+): {
+  iterator: AsyncIterable<TypescriptCompilationResult>;
+  close: () => void | Promise<void>;
+} {
   const getResult = (success: boolean) => ({
     success,
     outfile: normalizedOptions.mainOutputPath,
   });
 
-  return yield* createAsyncIterable<{ success: boolean; outfile: string }>(
-    async ({ next, done }) => {
-      if (normalizedOptions.watch) {
-        compileTypeScriptWatcher(tscOptions, async (d: Diagnostic) => {
-          if (d.code === TYPESCRIPT_FOUND_N_ERRORS_WATCHING_FOR_FILE_CHANGES) {
-            await postCompilationCallback();
-            next(
-              getResult(getErrorCountFromMessage(d.messageText as string) === 0)
-            );
-          }
-        });
-      } else {
-        const { success } = compileTypeScript(tscOptions);
-        await postCompilationCallback();
-        next(getResult(success));
-        done();
+  let tearDown: (() => void) | undefined;
+
+  return {
+    iterator: createAsyncIterable<TypescriptCompilationResult>(
+      async ({ next, done }) => {
+        if (normalizedOptions.watch) {
+          const host = compileTypeScriptWatcher(
+            tscOptions,
+            async (d: Diagnostic) => {
+              if (
+                d.code === TYPESCRIPT_FOUND_N_ERRORS_WATCHING_FOR_FILE_CHANGES
+              ) {
+                await postCompilationCallback();
+                next(
+                  getResult(
+                    getErrorCountFromMessage(d.messageText as string) === 0
+                  )
+                );
+              }
+            }
+          );
+
+          tearDown = () => {
+            host.close();
+            done();
+          };
+        } else {
+          const { success } = compileTypeScript(tscOptions);
+          await postCompilationCallback();
+          next(getResult(success));
+          done();
+        }
       }
-    }
-  );
+    ),
+    close: () => tearDown?.(),
+  };
 }


### PR DESCRIPTION
Close typescript watch program and complete iterator to ensure program can exit.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Runnig @nrwl/js:tsc compiler with the --watch=true option, causes underlying process to run forewer.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

TSC process should terminate as soon as executor is terminated. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
