### PR TITLE
fix(misc): run-commands executor should not pass its own options to commands

### DIFF
--- a/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
@@ -150,7 +150,7 @@ describe('Run Commands', () => {
   });
 
   describe('interpolateArgsIntoCommand', () => {
-    it('should add all unparsed args when forwardAllArgs is true', () => {
+    it('should add all unknown unparsed args when forwardAllArgs is true', () => {
       expect(
         interpolateArgsIntoCommand(
           'echo',
@@ -158,6 +158,26 @@ describe('Run Commands', () => {
           true
         )
       ).toEqual('echo one -a=b');
+    });
+
+    it('should not add unparsed args, that are executor options when forwardAllArgs is true', () => {
+      expect(
+        interpolateArgsIntoCommand(
+          'echo',
+          { __unparsed__: ['--command=abc', '--parallel=false'] } as any,
+          true
+        )
+      ).toEqual('echo');
+    });
+
+    it('should not add "--__unparsed__=.." as argument', () => {
+      expect(
+        interpolateArgsIntoCommand(
+          'echo',
+          { __unparsed__: ['--__unparsed__='] } as any,
+          true
+        )
+      ).toEqual('echo');
     });
   });
 

--- a/packages/nx/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.ts
@@ -292,12 +292,22 @@ export function interpolateArgsIntoCommand(
     const regex = /{args\.([^}]+)}/g;
     return command.replace(regex, (_, group: string) => opts.parsedArgs[group]);
   } else if (forwardAllArgs) {
+    const filteredUnparsed = filterUnparsed(opts.__unparsed__);
     return `${command}${
-      opts.__unparsed__.length > 0 ? ' ' + opts.__unparsed__.join(' ') : ''
+      filteredUnparsed.length > 0 ? ' ' + filteredUnparsed.join(' ') : ''
     }`;
   } else {
     return command;
   }
+}
+
+function filterUnparsed(unparsed: string[]) {
+  return unparsed.filter(
+    (_unparsedKV) =>
+      ![...propKeys, '__unparsed__'].some((_propKey) =>
+        _unparsedKV.startsWith(`--${_propKey}=`)
+      )
+  );
 }
 
 function parseArgs(options: RunCommandsOptions) {


### PR DESCRIPTION
## Current Behavior
As described in #11382, the run-commands executor passes all __unparsed__ args to its commands, even those, which should be consumed by the run-commands executor itself.
This leads to problems, when invoking runExecutor via @nrwl/devkit and passing customized options as "overrides" (e.g. postTargets of @jscuterly/semver, as described in the issue )

## Expected Behavior
run-commands executor should only forward args to its defined command(s), that are not consumable by itself.

## Related Issue(s)
Fixes #11382
