### PR TITLE
fix(devkit): split-create-tree should use nx cli

### DIFF
--- a/packages/devkit/migrations.json
+++ b/packages/devkit/migrations.json
@@ -1,6 +1,7 @@
 {
-  "schematics": {
+  "generators": {
     "split-create-tree": {
+      "cli": "nx",
       "version": "14.2.0-beta.0",
       "description": "Adjusts calls to createTreeWithEmptyWorkspace to reflect new API",
       "factory": "./src/migrations/update-14-2-0/split-create-empty-tree"

--- a/packages/devkit/migrations.spec.ts
+++ b/packages/devkit/migrations.spec.ts
@@ -1,7 +1,7 @@
 import path = require('path');
 import json = require('./migrations.json');
 
-const migrations = Object.entries(json.schematics);
+const migrations = Object.entries(json.generators);
 
 describe('devkit migrations', () => {
   it.each(migrations)('should have valid path: %s', (key, m) => {


### PR DESCRIPTION
fixes: #11710

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
