### PR TITLE
docs(nxdev): add external paths

### DIFF
--- a/nx-dev/data-access-documents/src/lib/documents.api.ts
+++ b/nx-dev/data-access-documents/src/lib/documents.api.ts
@@ -76,6 +76,7 @@ export class DocumentsApi {
     const paths: StaticDocumentPaths[] = [];
 
     function recur(curr, acc) {
+      if (curr.isExternal) return;
       if (curr.itemList) {
         curr.itemList.forEach((ii) => {
           recur(ii, [...acc, curr.id]);

--- a/nx-dev/models-document/src/lib/documents.models.ts
+++ b/nx-dev/models-document/src/lib/documents.models.ts
@@ -10,5 +10,6 @@ export interface DocumentMetadata {
   packageName?: string;
   file?: string;
   path?: string;
+  isExternal?: boolean;
   itemList?: DocumentMetadata[];
 }

--- a/scripts/documentation/map-link-checker.ts
+++ b/scripts/documentation/map-link-checker.ts
@@ -22,6 +22,7 @@ function filePathExtractor(file: any): string[] {
   const paths: string[] = [];
 
   function recur(curr): void {
+    if (curr.isExternal) return; // Removing external links
     if (curr.itemList) {
       curr.itemList.forEach((ii) => {
         recur(ii);


### PR DESCRIPTION
It adds the capability to reference external resources in the `map.json` that will not be handled by the documentation website.

Use `isExternal: true` in combination with a `path` and the item will behave link a standard link.