### PR TITLE
fix(misc): skip projects configured in package.json for adding schemas

### DIFF
--- a/packages/nx/src/migrations/update-14-2-0/add-json-schema.ts
+++ b/packages/nx/src/migrations/update-14-2-0/add-json-schema.ts
@@ -7,6 +7,8 @@ import {
   getRelativeProjectJsonSchemaPath,
   updateProjectConfiguration,
 } from '../../generators/utils/project-configuration';
+import { logger } from '../../utils/logger';
+import { join } from 'path';
 
 export default async function (tree: Tree) {
   // update nx.json $schema
@@ -33,16 +35,24 @@ export default async function (tree: Tree) {
 
   // update projects $schema
   for (const [projName, projConfig] of getProjects(tree)) {
-    if (projConfig['$schema']) continue;
+    if (
+      projConfig['$schema'] ||
+      !tree.exists(join(projConfig.root, 'project.json'))
+    )
+      continue;
 
-    const relativeProjectJsonSchemaPath = getRelativeProjectJsonSchemaPath(
-      tree,
-      projConfig
-    );
-    updateProjectConfiguration(tree, projName, {
-      $schema: relativeProjectJsonSchemaPath,
-      ...projConfig,
-    } as ProjectConfiguration);
+    try {
+      const relativeProjectJsonSchemaPath = getRelativeProjectJsonSchemaPath(
+        tree,
+        projConfig
+      );
+      updateProjectConfiguration(tree, projName, {
+        $schema: relativeProjectJsonSchemaPath,
+        ...projConfig,
+      } as ProjectConfiguration);
+    } catch (e) {
+      logger.warn(`Could not add schema for "${projName}": ${e.message}`);
+    }
   }
 
   await formatChangedFilesWithPrettierIfAvailable(tree);


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

Having projects configured with something that is not `project.json` will cause the migration to fail. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Projects configured with something that is not `project.json` will be skipped during the migration.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
