### PR TITLE
fix(nextjs): set `__NEXT_REACT_ROOT` only when the version of `react-dom` is 18 or above

### DIFF
--- a/packages/next/src/executors/build/build.impl.ts
+++ b/packages/next/src/executors/build/build.impl.ts
@@ -31,7 +31,9 @@ export default async function buildExecutor(
   const hasReact18 =
     reactDomVersion &&
     gte(checkAndCleanWithSemver('react-dom', reactDomVersion), '18.0.0');
-  (process.env as any).__NEXT_REACT_ROOT ||= hasReact18 ? 'true' : undefined;
+  if (hasReact18) {
+    (process.env as any).__NEXT_REACT_ROOT ||= 'true';
+  }
 
   let dependencies: DependentBuildableProjectNode[] = [];
   const root = resolve(context.root, options.root);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
According to https://github.com/nrwl/nx/issues/11717#issuecomment-1229127200, `__NEXT_REACT_ROOT` is set to `'undefined'` (as string) with `react-dom@17`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`__NEXT_REACT_ROOT` should be removed from `process.env.*`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #11717
