### PR TITLE
docs(nxdev): add new sitemap index pointer

### DIFF
--- a/scripts/documentation/internal-link-checker.ts
+++ b/scripts/documentation/internal-link-checker.ts
@@ -80,7 +80,7 @@ function readSiteMapLinks(filePath: string): string[] {
 const documentLinks = extractAllLinks(join(workspaceRoot, 'docs'));
 const sitemapLinks = readSiteMapIndex(
   join(workspaceRoot, 'dist/nx-dev/nx-dev/public/'),
-  'sitemap.xml'
+  'sitemap-0.xml'
 ).flatMap((path) => readSiteMapLinks(path));
 const errors: Array<{ file: string; link: string }> = [];
 for (let file in documentLinks) {


### PR DESCRIPTION
Since the sitemap has grown, the pointer for nx.dev's sitemap needs to be updated.