### PR TITLE
chore(nxdev): clean up api imports

### DIFF
--- a/docs/nx-cloud/intro/nx-cloud.md
+++ b/docs/nx-cloud/intro/nx-cloud.md
@@ -10,7 +10,7 @@ And it takes five minutes to set up.
 
 ## Clean User Interface
 
-Most developers will benefit from Nx Cloud without ever changing any of their workflow. Commands will just execute faster. For those developers that are tasked with making the most of Nx Cloud or those that want to get more insight into the different commands executed in the repository, Nx Cloud has a clean, informative user interface.
+Most developers will benefit from Nx Cloud without ever-changing any of their workflow. Commands will just execute faster. For those developers that are tasked with making the most of Nx Cloud or those that want to get more insight into the different commands executed in the repository, Nx Cloud has a clean, informative user interface.
 
 The [top level organization page](https://nx.app/orgs/5e38af6de037b5000598b2d6/workspaces/5edaf12087863a0005781f17) displays recent runs and a helpful dashboard of information about commands run in the repository.
 

--- a/nx-dev/nx-dev/lib/api.ts
+++ b/nx-dev/nx-dev/lib/api.ts
@@ -6,7 +6,6 @@ import {
   getBasicNxCloudSection,
   getBasicSection,
   getDeepDiveNxCloudSection,
-  getDeepDiveSection,
 } from '../../data-access-menu/src/lib/menu.utils';
 
 // Imports JSON directly, so they can be bundled into the app and functions.

--- a/scripts/documentation/internal-link-checker.ts
+++ b/scripts/documentation/internal-link-checker.ts
@@ -80,7 +80,7 @@ function readSiteMapLinks(filePath: string): string[] {
 const documentLinks = extractAllLinks(join(workspaceRoot, 'docs'));
 const sitemapLinks = readSiteMapIndex(
   join(workspaceRoot, 'dist/nx-dev/nx-dev/public/'),
-  'sitemap-0.xml'
+  'sitemap.xml'
 ).flatMap((path) => readSiteMapLinks(path));
 const errors: Array<{ file: string; link: string }> = [];
 for (let file in documentLinks) {


### PR DESCRIPTION
It cleans up the `api.ts` imports on the Next.js application for nx.dev.