### PR TITLE
feat(testing): add test retries option to cypress executor

### DIFF
--- a/docs/generated/packages/cypress.json
+++ b/docs/generated/packages/cypress.json
@@ -299,6 +299,10 @@
             "type": "string",
             "description": "A comma delimited list to identify a run with.",
             "aliases": ["t"]
+          },
+          "retries": {
+            "type": "number",
+            "description": "Retry failed tests the specified number of times."
           }
         },
         "additionalProperties": true,

--- a/packages/cypress/src/executors/cypress/cypress.impl.ts
+++ b/packages/cypress/src/executors/cypress/cypress.impl.ts
@@ -38,6 +38,7 @@ export interface CypressExecutorOptions extends Json {
   skipServe?: boolean;
   testingType?: 'component' | 'e2e';
   tag?: string;
+  retries?: number;
 }
 
 export default async function cypressExecutor(
@@ -180,10 +181,15 @@ async function runCypress(baseUrl: string, opts: CypressExecutorOptions) {
   const options: any = {
     project: projectFolderPath,
     configFile: basename(opts.cypressConfig),
+    config: {},
   };
   // If not, will use the `baseUrl` normally from `cypress.json`
   if (baseUrl) {
-    options.config = { baseUrl };
+    options.config.baseUrl = baseUrl;
+  }
+
+  if (opts.retries !== undefined) {
+    options.config.retries = opts.retries;
   }
 
   if (opts.browser) {

--- a/packages/cypress/src/executors/cypress/schema.json
+++ b/packages/cypress/src/executors/cypress/schema.json
@@ -119,6 +119,10 @@
       "type": "string",
       "description": "A comma delimited list to identify a run with.",
       "aliases": ["t"]
+    },
+    "retries": {
+      "type": "number",
+      "description": "Retry failed tests the specified number of times."
     }
   },
   "additionalProperties": true,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Test retries can only be specified in the Cypress config file.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Test retries can be specified as an executor option. This is convenient for enabling test retries for CI only.