### PR TITLE
docs(nxdev): add a custom 500 page

### DIFF
--- a/nx-dev/nx-dev/pages/500.tsx
+++ b/nx-dev/nx-dev/pages/500.tsx
@@ -1,0 +1,53 @@
+import { Footer, Header } from '@nrwl/nx-dev/ui-common';
+import { NextSeo } from 'next-seo';
+import Link from 'next/link';
+
+export default function FiveOhOh(): JSX.Element {
+  return (
+    <>
+      <NextSeo title="Internal Server Error" noindex={true} />
+      <Header useDarkBackground={false} />
+      <main id="main" role="main">
+        <div className="w-full">
+          <article
+            id="getting-started"
+            className="relative py-16 sm:pt-24 lg:py-32"
+          >
+            <div className="mx-auto px-4 sm:px-6 lg:px-8 xl:max-w-7xl">
+              <h1 className="mt-2 text-4xl font-extrabold tracking-tight text-gray-800 sm:text-6xl">
+                500 - Internal Server Error!
+              </h1>
+              <p className="mt-8 text-lg">
+                Sorry, an error occurred while we were loading this page.
+              </p>
+              <p className="mt-2 text-lg">
+                You can return to{' '}
+                <Link href="/">
+                  <a
+                    title="Go to the home page"
+                    className="font-semibold underline"
+                  >
+                    our front page
+                  </a>
+                </Link>
+                , or{' '}
+                <Link href="https://github.com/nrwl/nx/issues/new?assignees=&labels=type%3A+docs&template=3-documentation.md">
+                  <a
+                    target="_blank"
+                    rel="noreferrer"
+                    className="font-semibold underline"
+                    title="Create a Github issue"
+                  >
+                    drop us a line
+                  </a>
+                </Link>{' '}
+                if you can't find what you're looking for.
+              </p>
+            </div>
+          </article>
+        </div>
+      </main>
+      <Footer useDarkBackground={false} />
+    </>
+  );
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

- Pages that error are going to the default Next.JS page (https://nx.dev/plugins/overview), without any header of footer

## Expected Behavior

- A custom 500 page is loaded in these cases so that the user can clearly see what has happened and navigate back around the site.
- Built example: https://nx-dev-git-fork-nicholasgriffintn-500-nrwl.vercel.app/plugins/overview

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

NA
