### PR TITLE
fix(angular): change rxjs migration to conditional migration

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -161,6 +161,12 @@
       "description": "Update the @angular/cli package version to ~14.1.0.",
       "factory": "./src/migrations/update-14-5-2/update-angular-cli"
     },
+    "update-rxjs-7-5-0": {
+      "cli": "nx",
+      "version": "14.5.7-beta.0",
+      "description": "Update the rxjs package version to ~7.5.0 if RxJS 7 is used in workspace.",
+      "factory": "./src/migrations/update-14-5-7/update-rxjs"
+    },
     "update-angular-cli-version-14-2-0": {
       "cli": "nx",
       "version": "14.6.0-beta.0",
@@ -1456,15 +1462,6 @@
       "packages": {
         "ts-node": {
           "version": "10.9.1",
-          "alwaysAddToPackageJson": false
-        }
-      }
-    },
-    "14.5.7": {
-      "version": "14.5.7-beta.0",
-      "packages": {
-        "rxjs": {
-          "version": "~7.5.0",
           "alwaysAddToPackageJson": false
         }
       }

--- a/packages/angular/src/migrations/update-14-5-7/update-rxjs.spec.ts
+++ b/packages/angular/src/migrations/update-14-5-7/update-rxjs.spec.ts
@@ -1,0 +1,55 @@
+import { readJson, Tree, writeJson } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import updateRxjs from './update-rxjs';
+
+describe('update-rxjs migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should update rxjs version when defined as a dev dependency and greater than 7.0.0', async () => {
+    writeJson(tree, 'package.json', {
+      devDependencies: { rxjs: '~7.0.0' },
+    });
+
+    await updateRxjs(tree);
+
+    const { devDependencies } = readJson(tree, 'package.json');
+    expect(devDependencies['rxjs']).toEqual('~7.5.0');
+  });
+
+  it('should update rxjs version when defined as a dependency and greater than 7.0.0', async () => {
+    writeJson(tree, 'package.json', {
+      dependencies: { rxjs: '~7.0.0' },
+    });
+
+    await updateRxjs(tree);
+
+    const { dependencies } = readJson(tree, 'package.json');
+    expect(dependencies['rxjs']).toEqual('~7.5.0');
+  });
+
+  it('should not update rxjs when it is less than 7.0.0', async () => {
+    writeJson(tree, 'package.json', {
+      dependencies: { rxjs: '~6.5.0' },
+    });
+
+    await updateRxjs(tree);
+
+    const { dependencies } = readJson(tree, 'package.json');
+    expect(dependencies['rxjs']).toEqual('~6.5.0');
+  });
+
+  it('should not update rxjs when it is less than 7.0.0', async () => {
+    writeJson(tree, 'package.json', {
+      devDependencies: { rxjs: '~6.5.0' },
+    });
+
+    await updateRxjs(tree);
+
+    const { devDependencies } = readJson(tree, 'package.json');
+    expect(devDependencies['rxjs']).toEqual('~6.5.0');
+  });
+});

--- a/packages/angular/src/migrations/update-14-5-7/update-rxjs.ts
+++ b/packages/angular/src/migrations/update-14-5-7/update-rxjs.ts
@@ -1,0 +1,30 @@
+import { formatFiles, Tree, updateJson } from '@nrwl/devkit';
+import { gte, minVersion } from 'semver';
+
+const rxjsVersion = '~7.5.0';
+
+export default async function (tree: Tree) {
+  let shouldFormat = false;
+
+  updateJson(tree, 'package.json', (json) => {
+    if (
+      json.devDependencies?.['rxjs'] &&
+      gte(minVersion(json.devDependencies?.['rxjs']), '7.0.0')
+    ) {
+      json.devDependencies['rxjs'] = rxjsVersion;
+      shouldFormat = true;
+    } else if (
+      json.dependencies?.['rxjs'] &&
+      gte(minVersion(json.dependencies?.['rxjs']), '7.0.0')
+    ) {
+      json.dependencies['rxjs'] = rxjsVersion;
+      shouldFormat = true;
+    }
+
+    return json;
+  });
+
+  if (shouldFormat) {
+    await formatFiles(tree);
+  }
+}


### PR DESCRIPTION
we were forcing all workspaces to rxjs 7.5.0 despite rxjs 7 still being opt in