### PR TITLE
docs(core): show 404 content instead of redirecting to intro

### DIFF
--- a/nx-dev/nx-dev/pages/404.tsx
+++ b/nx-dev/nx-dev/pages/404.tsx
@@ -2,7 +2,7 @@ import { Footer, Header } from '@nrwl/nx-dev/ui-common';
 import { NextSeo } from 'next-seo';
 import Link from 'next/link';
 
-export default function FourOhFour(): JSX.Element {
+export function FourOhFour(): JSX.Element {
   return (
     <>
       <NextSeo title="Page not found" noindex={true} />
@@ -51,3 +51,5 @@ export default function FourOhFour(): JSX.Element {
     </>
   );
 }
+
+export default FourOhFour;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->
Shows a 404 message and keep URL intact, instead of redirecting to the intro page. This way we can track them better.

<img width="2672" alt="Screen Shot 2022-08-30 at 1 48 35 PM" src="https://user-images.githubusercontent.com/53559/187507799-eb0c7351-d853-4739-9288-3a186a82906f.png">

Example: https://nx-dev-git-fork-jaysoo-docs-show-404-nrwl.vercel.app/four-oh-four

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
