### PR TITLE
fix(testing): update cypress argument name

### DIFF
--- a/e2e/angular-core/src/ng-add.test.ts
+++ b/e2e/angular-core/src/ng-add.test.ts
@@ -57,7 +57,7 @@ describe('convert Angular CLI workspace to an Nx workspace', () => {
     packageInstall('cypress', null, '^9.0.0');
   }
   function addCypress10() {
-    runNgAdd('@cypress/schematic', '--e2e-update', 'latest');
+    runNgAdd('@cypress/schematic', '--e2e', 'latest');
   }
 
   function addEsLint() {


### PR DESCRIPTION


## Current Behavior
Angular core e2e tests fail because cypress argument is outdated - [it changed](https://github.com/cypress-io/cypress/commit/99562af65a10abb0fab211fd97b13f98e2b0f959#diff-093f7452cc38cbcd7bb1fd43be3dcbecea4e6c76b0ae1028b15af0978721d137R7).

## Expected Behavior
Pass correct argument to cypress.

