### PR TITLE
fix(storybook): support secondary entry points for angular #11446

### DIFF
--- a/packages/angular/src/generators/storybook-configuration/__snapshots__/storybook-configuration.spec.ts.snap
+++ b/packages/angular/src/generators/storybook-configuration/__snapshots__/storybook-configuration.spec.ts.snap
@@ -12,9 +12,8 @@ module.exports = {
   
   stories: [
     ...rootMain.stories,
-    '../src/lib/**/*.stories.mdx',
-    '../src/lib/**/*.stories.@(js|jsx|ts|tsx)'
-  ],
+    '../**/*.stories.mdx',
+    '../**/*.stories.@(js|jsx|ts|tsx)' ],
   addons: [...rootMain.addons 
     
     

--- a/packages/storybook/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/storybook/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -12,9 +12,8 @@ module.exports = {
   
   stories: [
     ...rootMain.stories,
-    '../src/lib/**/*.stories.mdx',
-    '../src/lib/**/*.stories.@(js|jsx|ts|tsx)'
-  ],
+    '../**/*.stories.mdx',
+    '../**/*.stories.@(js|jsx|ts|tsx)' ],
   addons: [...rootMain.addons 
     
     
@@ -78,9 +77,8 @@ module.exports = {
   
   stories: [
     ...rootMain.stories,
-    '../src/lib/**/*.stories.mdx',
-    '../src/lib/**/*.stories.@(js|jsx|ts|tsx)'
-  ],
+    '../**/*.stories.mdx',
+    '../**/*.stories.@(js|jsx|ts|tsx)' ],
   addons: [...rootMain.addons 
     
     
@@ -156,11 +154,11 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
   
   \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
   \\"include\\": [
-    \\"../src/**/*.stories.ts\\", 
-    \\"../src/**/*.stories.js\\", 
-    \\"../src/**/*.stories.jsx\\", 
-    \\"../src/**/*.stories.tsx\\", 
-    \\"../src/**/*.stories.mdx\\", 
+    \\"../src/**/*.stories.ts\\",
+    \\"../src/**/*.stories.js\\",
+    \\"../src/**/*.stories.jsx\\",
+    \\"../src/**/*.stories.tsx\\",
+    \\"../src/**/*.stories.mdx\\",
     \\"*.ts\\",
     \\"*.js\\"]
 }
@@ -218,11 +216,11 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
   
   \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
   \\"include\\": [
-    \\"../src/**/*.stories.ts\\", 
-    \\"../src/**/*.stories.js\\", 
-    \\"../src/**/*.stories.jsx\\", 
-    \\"../src/**/*.stories.tsx\\", 
-    \\"../src/**/*.stories.mdx\\", 
+    \\"../src/**/*.stories.ts\\",
+    \\"../src/**/*.stories.js\\",
+    \\"../src/**/*.stories.jsx\\",
+    \\"../src/**/*.stories.tsx\\",
+    \\"../src/**/*.stories.mdx\\",
     \\"*.ts\\",
     \\"*.js\\"]
 }
@@ -287,11 +285,11 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
   
   \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
   \\"include\\": [
-    \\"../components/**/*.stories.ts\\", 
-    \\"../components/**/*.stories.js\\", 
-    \\"../components/**/*.stories.jsx\\", 
-    \\"../components/**/*.stories.tsx\\", 
-    \\"../components/**/*.stories.mdx\\", 
+    \\"../components/**/*.stories.ts\\",
+    \\"../components/**/*.stories.js\\",
+    \\"../components/**/*.stories.jsx\\",
+    \\"../components/**/*.stories.tsx\\",
+    \\"../components/**/*.stories.mdx\\",
     \\"*.ts\\",
     \\"*.js\\"]
 }
@@ -349,11 +347,11 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
   
   \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
   \\"include\\": [
-    \\"../src/**/*.stories.ts\\", 
-    \\"../src/**/*.stories.js\\", 
-    \\"../src/**/*.stories.jsx\\", 
-    \\"../src/**/*.stories.tsx\\", 
-    \\"../src/**/*.stories.mdx\\", 
+    \\"../src/**/*.stories.ts\\",
+    \\"../src/**/*.stories.js\\",
+    \\"../src/**/*.stories.jsx\\",
+    \\"../src/**/*.stories.tsx\\",
+    \\"../src/**/*.stories.mdx\\",
     \\"*.ts\\",
     \\"*.js\\"]
 }
@@ -411,11 +409,11 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
   
   \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
   \\"include\\": [
-    \\"../src/**/*.stories.ts\\", 
-    \\"../src/**/*.stories.js\\", 
-    \\"../src/**/*.stories.jsx\\", 
-    \\"../src/**/*.stories.tsx\\", 
-    \\"../src/**/*.stories.mdx\\", 
+    \\"../src/**/*.stories.ts\\",
+    \\"../src/**/*.stories.js\\",
+    \\"../src/**/*.stories.jsx\\",
+    \\"../src/**/*.stories.tsx\\",
+    \\"../src/**/*.stories.mdx\\",
     \\"*.ts\\",
     \\"*.js\\"]
 }
@@ -473,11 +471,11 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
   
   \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
   \\"include\\": [
-    \\"../src/**/*.stories.ts\\", 
-    \\"../src/**/*.stories.js\\", 
-    \\"../src/**/*.stories.jsx\\", 
-    \\"../src/**/*.stories.tsx\\", 
-    \\"../src/**/*.stories.mdx\\", 
+    \\"../src/**/*.stories.ts\\",
+    \\"../src/**/*.stories.js\\",
+    \\"../src/**/*.stories.jsx\\",
+    \\"../src/**/*.stories.tsx\\",
+    \\"../src/**/*.stories.mdx\\",
     \\"*.ts\\",
     \\"*.js\\"]
 }
@@ -538,7 +536,7 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
     \\"../src/**/*.stories.js\\", 
     \\"../src/**/*.stories.jsx\\", 
     \\"../src/**/*.stories.tsx\\", 
-    \\"../src/**/*.stories.mdx\\", 
+    \\"../src/**/*.stories.mdx\\",
     \\"*.js\\"]
 }
 "
@@ -598,7 +596,7 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
     \\"../src/**/*.stories.js\\", 
     \\"../src/**/*.stories.jsx\\", 
     \\"../src/**/*.stories.tsx\\", 
-    \\"../src/**/*.stories.mdx\\", 
+    \\"../src/**/*.stories.mdx\\",
     \\"*.js\\"]
 }
 "
@@ -665,7 +663,7 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
     \\"../components/**/*.stories.js\\", 
     \\"../components/**/*.stories.jsx\\", 
     \\"../components/**/*.stories.tsx\\", 
-    \\"../components/**/*.stories.mdx\\", 
+    \\"../components/**/*.stories.mdx\\",
     \\"*.js\\"]
 }
 "
@@ -725,7 +723,7 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
     \\"../src/**/*.stories.js\\", 
     \\"../src/**/*.stories.jsx\\", 
     \\"../src/**/*.stories.tsx\\", 
-    \\"../src/**/*.stories.mdx\\", 
+    \\"../src/**/*.stories.mdx\\",
     \\"*.js\\"]
 }
 "
@@ -785,7 +783,7 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
     \\"../src/**/*.stories.js\\", 
     \\"../src/**/*.stories.jsx\\", 
     \\"../src/**/*.stories.tsx\\", 
-    \\"../src/**/*.stories.mdx\\", 
+    \\"../src/**/*.stories.mdx\\",
     \\"*.js\\"]
 }
 "
@@ -845,7 +843,7 @@ exports[`@nrwl/storybook:configuration for other types of projects - Next.js and
     \\"../src/**/*.stories.js\\", 
     \\"../src/**/*.stories.jsx\\", 
     \\"../src/**/*.stories.tsx\\", 
-    \\"../src/**/*.stories.mdx\\", 
+    \\"../src/**/*.stories.mdx\\",
     \\"*.js\\"]
 }
 "

--- a/packages/storybook/src/generators/configuration/project-files-ts/.storybook/main.ts__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files-ts/.storybook/main.ts__tmpl__
@@ -9,10 +9,12 @@ const config: StorybookConfig = {
   <% } %>
 
   stories: [
-    ...rootMain.stories,
+    ...rootMain.stories,<% if(uiFramework === '@storybook/angular' && projectType === 'library') { %>
+    '../**/*.stories.mdx',
+    '../**/*.stories.@(js|jsx|ts|tsx)' <% } else { %>
     '../<%= projectDirectory %>/**/*.stories.mdx',
     '../<%= projectDirectory %>/**/*.stories.@(js|jsx|ts|tsx)'
-  ],
+  <% } %>],
   addons: [...(rootMain.addons || []) <% if(uiFramework === '@storybook/react') { %>, '@nrwl/react/plugins/storybook' <% } %><% if(uiFramework === '@storybook/react-native') { %>, '@storybook/addon-ondevice-actions',  '@storybook/addon-ondevice-backgrounds', '@storybook/addon-ondevice-controls', '@storybook/addon-ondevice-notes'  <% } %>
     <% if(usesSwc && !isNextJs) { %>, 'storybook-addon-swc' <% } %>
     <% if(isNextJs) { %>, 'storybook-addon-swc', 

--- a/packages/storybook/src/generators/configuration/project-files-ts/.storybook/tsconfig.json__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files-ts/.storybook/tsconfig.json__tmpl__
@@ -11,12 +11,19 @@
   ],<% } %>
   <% if(uiFramework === '@storybook/angular' && projectType === 'application') { %>"files": ["../src/polyfills.ts"],<% } %>
   "exclude": ["../**/*.spec.ts" <% if(uiFramework === '@storybook/react') { %>, "../**/*.spec.js", "../**/*.spec.tsx", "../**/*.spec.jsx"<% } %>],
-  "include": [
-    "../<%= mainDir %>/**/*.stories.ts", 
-    "../<%= mainDir %>/**/*.stories.js", 
-    "../<%= mainDir %>/**/*.stories.jsx", 
-    "../<%= mainDir %>/**/*.stories.tsx", 
-    "../<%= mainDir %>/**/*.stories.mdx", 
+  "include": [<% if(uiFramework === '@storybook/angular' && projectType === 'library') { %>
+    "../**/*.stories.ts",
+    "../**/*.stories.js",
+    "../**/*.stories.jsx",
+    "../**/*.stories.tsx",
+    "../**/*.stories.mdx",
     "*.ts",
-    "*.js"<% if(uiFramework === '@storybook/react-native') { %>, "*.tsx"<% } %>]
+    "*.js"<% } else { %>
+    "../<%= mainDir %>/**/*.stories.ts",
+    "../<%= mainDir %>/**/*.stories.js",
+    "../<%= mainDir %>/**/*.stories.jsx",
+    "../<%= mainDir %>/**/*.stories.tsx",
+    "../<%= mainDir %>/**/*.stories.mdx",
+    "*.ts",
+    "*.js"<% if(uiFramework === '@storybook/react-native') { %>, *.tsx"<% } %><% } %>]
 }

--- a/packages/storybook/src/generators/configuration/project-files/.storybook/main.js__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files/.storybook/main.js__tmpl__
@@ -8,10 +8,12 @@ module.exports = {
   core: { ...rootMain.core, builder: 'webpack5' },
   <% } %>
   stories: [
-    ...rootMain.stories,
+    ...rootMain.stories,<% if(uiFramework === '@storybook/angular' && projectType === 'library') { %>
+    '../**/*.stories.mdx',
+    '../**/*.stories.@(js|jsx|ts|tsx)' <% } else { %>
     '../<%= projectDirectory %>/**/*.stories.mdx',
     '../<%= projectDirectory %>/**/*.stories.@(js|jsx|ts|tsx)'
-  ],
+  <% } %>],
   addons: [...rootMain.addons <% if(uiFramework === '@storybook/react') { %>, '@nrwl/react/plugins/storybook' <% } %><% if(uiFramework === '@storybook/react-native') { %>, '@storybook/addon-ondevice-actions',  '@storybook/addon-ondevice-backgrounds', '@storybook/addon-ondevice-controls', '@storybook/addon-ondevice-notes'  <% } %>
     <% if(usesSwc && !isNextJs) { %>, 'storybook-addon-swc' <% } %>
     <% if(isNextJs) { %>, 'storybook-addon-swc', 

--- a/packages/storybook/src/generators/configuration/project-files/.storybook/tsconfig.json__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files/.storybook/tsconfig.json__tmpl__
@@ -11,11 +11,17 @@
   ],<% } %>
   <% if(uiFramework === '@storybook/angular' && projectType === 'application') { %>"files": ["../src/polyfills.ts"],<% } %>
   "exclude": ["../**/*.spec.ts" <% if(uiFramework === '@storybook/react') { %>, "../**/*.spec.js", "../**/*.spec.tsx", "../**/*.spec.jsx"<% } %>],
-  "include": [
+  "include": [<% if(uiFramework === '@storybook/angular' && projectType === 'library') { %>
+    "../**/*.stories.ts",
+    "../**/*.stories.js",
+    "../**/*.stories.jsx",
+    "../**/*.stories.tsx",
+    "../**/*.stories.mdx",
+    "*.js"<% } else { %>
     "../<%= mainDir %>/**/*.stories.ts", 
     "../<%= mainDir %>/**/*.stories.js", 
     "../<%= mainDir %>/**/*.stories.jsx", 
     "../<%= mainDir %>/**/*.stories.tsx", 
-    "../<%= mainDir %>/**/*.stories.mdx", 
-    "*.js"<% if(uiFramework === '@storybook/react-native') { %>, "*.ts", "*.tsx"<% } %>]
+    "../<%= mainDir %>/**/*.stories.mdx",
+    "*.js"<% if(uiFramework === '@storybook/react-native') { %>, "*.ts", "*.tsx"<% } %><% } %>]
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The storybook configuration that is generated for angular projects does not support secondary entry points in libraries.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The storybook configuration that is generated for angular projects should support secondary entry points in libraries.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #11446
