### PR TITLE
fix(angular): e2e test using removed argument for cypress schematic

### DIFF
--- a/e2e/angular-core/src/ng-add.test.ts
+++ b/e2e/angular-core/src/ng-add.test.ts
@@ -53,7 +53,7 @@ describe('convert Angular CLI workspace to an Nx workspace', () => {
   }
 
   function addCypress9() {
-    runNgAdd('@cypress/schematic', '--e2e-update', '1.7.0');
+    runNgAdd('@cypress/schematic', '--e2e', '1.7.0');
     packageInstall('cypress', null, '^9.0.0');
   }
   function addCypress10() {


### PR DESCRIPTION

## Current Behavior
<!-- This is the behavior we have today -->
We use `--e2e-update` argument when running the ng-add e2e test. this argument got renamed to `e2e`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
E2Es should pass

