### PR TITLE
fix(angular): collect secondary folders correctly for tailwind #11747

### DIFF
--- a/packages/workspace/src/utilities/generate-globs.ts
+++ b/packages/workspace/src/utilities/generate-globs.ts
@@ -1,11 +1,23 @@
 import { joinPathFragments, logger } from '@nrwl/devkit';
 import { workspaceRoot } from 'nx/src/utils/workspace-root';
-import { relative, resolve } from 'path';
+import { dirname, join, relative, resolve } from 'path';
 import { readCachedProjectGraph } from 'nx/src/project-graph/project-graph';
 import {
   getProjectNameFromDirPath,
   getSourceDirOfDependentProjects,
 } from 'nx/src/utils/project-graph-utils';
+import { existsSync, lstatSync, readdirSync, readFileSync } from 'fs';
+import ignore, { Ignore } from 'ignore';
+
+function configureIgnore() {
+  let ig: Ignore;
+  const pathToGitIgnore = join(workspaceRoot, '.gitignore');
+  if (existsSync(pathToGitIgnore)) {
+    ig = ignore();
+    ig.add(readFileSync(pathToGitIgnore, { encoding: 'utf-8' }));
+  }
+  return ig;
+}
 
 /**
  * Generates a set of glob patterns based off the source root of the app and its dependencies
@@ -16,6 +28,7 @@ export function createGlobPatternsForDependencies(
   dirPath: string,
   fileGlobPattern: string
 ): string[] {
+  let ig = configureIgnore();
   const filenameRelativeToWorkspaceRoot = relative(workspaceRoot, dirPath);
   const projectGraph = readCachedProjectGraph();
 
@@ -39,6 +52,28 @@ export function createGlobPatternsForDependencies(
       projectGraph
     );
 
+    const dirsToUse = [];
+    const recursiveScanDirs = (dirPath) => {
+      const children = readdirSync(dirPath);
+      for (const child of children) {
+        const childPath = join(dirPath, child);
+        if (ig?.ignores(childPath) || !lstatSync(childPath).isDirectory()) {
+          continue;
+        }
+        if (existsSync(join(childPath, 'ng-package.json'))) {
+          dirsToUse.push(childPath);
+        } else {
+          recursiveScanDirs(childPath);
+        }
+      }
+    };
+
+    for (const srcDir of projectDirs) {
+      dirsToUse.push(srcDir);
+      const root = dirname(srcDir);
+      recursiveScanDirs(root);
+    }
+
     if (warnings.length > 0) {
       logger.warn(`
 [createGlobPatternsForDependencies] Failed to generate glob pattern for the following:
@@ -47,7 +82,7 @@ due to missing "sourceRoot" in the dependencies' project configuration
       `);
     }
 
-    return projectDirs.map((sourceDir) =>
+    return dirsToUse.map((sourceDir) =>
       resolve(workspaceRoot, joinPathFragments(sourceDir, fileGlobPattern))
     );
   } catch (e) {


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
For libraries, our glob creation function only checks under `src` for classes for tailwind.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should also check alternate folders for secondary entry points

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #11747
