### PR TITLE
fix(linter): consider the default public API filename when checking for secondary entrypoints

### DIFF
--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -431,7 +431,9 @@ export function isAngularSecondaryEntrypoint(
     targetFiles &&
     targetFiles.some(
       (file) =>
-        file.endsWith('src/index.ts') &&
+        // The `ng-packagr` defaults to the `src/public_api.ts` entry file to
+        // the public API if the `lib.entryFile` is not specified explicitly.
+        (file.endsWith('src/public_api.ts') || file.endsWith('src/index.ts')) &&
         existsSync(joinPathFragments(file, '../../', 'ng-package.json'))
     )
   );


### PR DESCRIPTION
## Current Behavior

The linter is not able to determine the secondary entry-point correctly since we may have entry-points with default public API filenames, which are `src/public_api.ts` (this is the default filename in `ng-packagr` schema).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
