### PR TITLE
fix(angular): remove double normalize of project name #11819

### DIFF
--- a/packages/angular/src/generators/library/lib/add-standalone-component.ts
+++ b/packages/angular/src/generators/library/lib/add-standalone-component.ts
@@ -5,7 +5,6 @@ import { joinPathFragments } from 'nx/src/utils/path';
 import { names } from '@nrwl/devkit';
 import { addLoadChildren } from './add-load-children';
 import { addChildren } from './add-children';
-import { normalizeProjectName } from '../../utils/project';
 
 export async function addStandaloneComponent(
   tree: Tree,
@@ -15,7 +14,7 @@ export async function addStandaloneComponent(
     name: options.name,
     standalone: true,
     export: true,
-    project: normalizeProjectName(options.name, options.directory),
+    project: options.name,
   });
 
   if (options.routing) {


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
We were adding a secondary normalization of the project name when generating a standalone component for a standalone library when a directory was passed. This caused an unexpected error by adding the directory name again.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Should generate a standalone library with component with no errors when a directory is passed

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #11819
