### PR TITLE
fix(js): remove check for non-buildable libs being used when packaging.

### DIFF
--- a/packages/js/src/utils/check-dependencies.ts
+++ b/packages/js/src/utils/check-dependencies.ts
@@ -14,25 +14,14 @@ export function checkDependencies(
   target: ProjectGraphProjectNode<any>;
   dependencies: DependentBuildableProjectNode[];
 } {
-  const { target, dependencies, nonBuildableDependencies } =
-    calculateProjectDependencies(
-      context.projectGraph,
-      context.root,
-      context.projectName,
-      context.targetName,
-      context.configurationName
-    );
+  const { target, dependencies } = calculateProjectDependencies(
+    context.projectGraph,
+    context.root,
+    context.projectName,
+    context.targetName,
+    context.configurationName
+  );
   const projectRoot = target.data.root;
-
-  if (nonBuildableDependencies.length > 0) {
-    throw new Error(
-      `Buildable libraries can only depend on other buildable libraries. You must define the ${
-        context.targetName
-      } target for the following libraries: ${nonBuildableDependencies
-        .map((t) => `"${t}"`)
-        .join(', ')}`
-    );
-  }
 
   if (dependencies.length > 0) {
     return {


### PR DESCRIPTION
- unblocks custom server in next.js
- builds are guaranteed to happen if nx.json is configured correctly
- if a package isn't buildable it will be included in the package in the
  near-future

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #11675
