### PR TITLE
fix(nextjs): fix resolving dependencies

### DIFF
--- a/packages/next/src/executors/build/build.impl.ts
+++ b/packages/next/src/executors/build/build.impl.ts
@@ -1,8 +1,13 @@
 import 'dotenv/config';
-import { ExecutorContext, readJsonFile, workspaceLayout } from '@nrwl/devkit';
+import {
+  ExecutorContext,
+  readJsonFile,
+  workspaceLayout,
+  workspaceRoot,
+} from '@nrwl/devkit';
 import build from 'next/dist/build';
 import { join, resolve } from 'path';
-import { copySync, mkdir } from 'fs-extra';
+import { copySync, existsSync, mkdir } from 'fs-extra';
 import { gte } from 'semver';
 import { directoryExists } from '@nrwl/workspace/src/utilities/fileutils';
 import {
@@ -25,16 +30,6 @@ export default async function buildExecutor(
   // Cast to any to overwrite NODE_ENV
   (process.env as any).NODE_ENV ||= 'production';
 
-  // Set `__NEXT_REACT_ROOT` based on installed ReactDOM version
-  const packageJson = readJsonFile(join(context.root, 'package.json'));
-  const reactDomVersion = packageJson.dependencies['react-dom'];
-  const hasReact18 =
-    reactDomVersion &&
-    gte(checkAndCleanWithSemver('react-dom', reactDomVersion), '18.0.0');
-  if (hasReact18) {
-    (process.env as any).__NEXT_REACT_ROOT ||= 'true';
-  }
-
   let dependencies: DependentBuildableProjectNode[] = [];
   const root = resolve(context.root, options.root);
   const libsDir = join(context.root, workspaceLayout().libsDir);
@@ -50,6 +45,22 @@ export default async function buildExecutor(
       context.configurationName
     );
     dependencies = result.dependencies;
+  }
+
+  // Set `__NEXT_REACT_ROOT` based on installed ReactDOM version
+  const packageJsonPath = join(root, 'package.json');
+  const packageJson = existsSync(packageJsonPath)
+    ? readJsonFile(packageJsonPath)
+    : undefined;
+  const rootPackageJson = readJsonFile(join(workspaceRoot, 'package.json'));
+  const reactDomVersion =
+    packageJson?.dependencies?.['react-dom'] ??
+    rootPackageJson.dependencies?.['react-dom'];
+  const hasReact18 =
+    reactDomVersion &&
+    gte(checkAndCleanWithSemver('react-dom', reactDomVersion), '18.0.0');
+  if (hasReact18) {
+    (process.env as any).__NEXT_REACT_ROOT ||= 'true';
   }
 
   const config = await prepareConfig(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Resolveing the version of `react-dom` does not work  as expected when `dependencies` is not in the root `package.json`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`@nrwl/next` should resolve `dependencies` correctly.
- If `<project>/package.json` exists, read the version of `react-dom` from its `dependencies`.
- If neither `<project>/package.json` nor `dependencies` in the file are available, use `package.json` in workspace root.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #11814
