### PR TITLE
fix(misc): print new workspace directory and fix issues when creating…

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -822,13 +822,17 @@ async function createApp(
       nxWorkspaceRoot = `\\"${nxWorkspaceRoot.slice(1, -1)}\\"`;
     }
   }
-  let workspaceSetupSpinner = ora('Creating your workspace').start();
+  let workspaceSetupSpinner = ora(
+    `Creating your workspace in ${getFileName(name)}`
+  ).start();
 
   try {
     const fullCommand = `${pmc.exec} nx ${command} --nxWorkspaceRoot=${nxWorkspaceRoot}`;
     await execAndWait(fullCommand, tmpDir);
 
-    workspaceSetupSpinner.succeed('Nx has successfully created the workspace.');
+    workspaceSetupSpinner.succeed(
+      `Nx has successfully created the workspace: ${getFileName(name)}.`
+    );
   } catch (e) {
     workspaceSetupSpinner.fail();
     output.error({
@@ -839,7 +843,7 @@ async function createApp(
   } finally {
     workspaceSetupSpinner.stop();
   }
-  return join(workingDir, name);
+  return join(workingDir, getFileName(name));
 }
 
 async function setupNxCloud(name: string, packageManager: PackageManager) {

--- a/packages/create-nx-workspace/bin/utils.spec.ts
+++ b/packages/create-nx-workspace/bin/utils.spec.ts
@@ -1,0 +1,11 @@
+import { getFileName } from './utils';
+
+describe('utils', () => {
+  describe('getFileName', () => {
+    it('should return nrwl-org given NrwlORG', () => {
+      let name = 'NrwlORG';
+      expect(getFileName(name)).toEqual('nrwl-org');
+      expect(name).toEqual('NrwlORG');
+    });
+  });
+});


### PR DESCRIPTION
… workspaces with non-normalized name

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When creating a new workspace with a non-normalized name, users may get confused when it doesn't appear in the name they passed because we normalized it.

Also, the git commands are being spawned in the wrong directory because.. it was normalized:

```
events.js:377
      throw er; // Unhandled 'error' event
      ^

Error: spawn /bin/sh ENOENT
    at Process.ChildProcess._handle.onexit (internal/child_process.js:277:19)
    at onErrorNT (internal/child_process.js:472:16)
    at processTicksAndRejections (internal/process/task_queues.js:82:21)
Emitted 'error' event on ChildProcess instance at:
    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:12)
    at onErrorNT (internal/child_process.js:472:16)
    at processTicksAndRejections (internal/process/task_queues.js:82:21) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'spawn /bin/sh',
  path: '/bin/sh',
  spawnargs: [ '-c', 'git rev-parse --is-inside-work-tree' ]
}
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The name of the directory is printed and the git commands are spawned in the right place.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/11772
