### PR TITLE
docs(core): fix the problem of render txt file in tutorial

### DIFF
--- a/docs/shared/core-tutorial/03-share-assets.md
+++ b/docs/shared/core-tutorial/03-share-assets.md
@@ -64,7 +64,7 @@ Then you can reference that shared asset file in a blog post.
 
 `packages/blog/src/posts/ascii.md`:
 
-```markdown
+```markdown {% process=false %}
 ---
 pageTitle: Some ASCII Art
 ---
@@ -72,7 +72,7 @@ pageTitle: Some ASCII Art
 Welcome to [The Restaurant at the End of the Universe](https://hitchhikers.fandom.com/wiki/Ameglian_Major_Cow)
 
 <pre>
-&#123;% renderFile "../ascii/assets/cow.txt" %&#125;
+{% renderFile "../ascii/assets/cow.txt" %}
 </pre>
 
 Art courtesy of [cowsay](https://www.npmjs.com/package/cowsay).


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Does not render text files correctly in the [tutorial](http://localhost:4200/core-tutorial/03-share-assets).

## Expected Behavior
The text file renders correctly.

Like this.
<img width="534" alt="スクリーンショット 2022-09-04 17 09 19" src="https://user-images.githubusercontent.com/15213369/188303960-0a9a6b7f-93bb-4ced-8050-de1cc4b5eef6.png">



## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #11843
