### PR TITLE
Added an option to show final tsconfig during compilation for debug purpose

### DIFF
--- a/packages/workspace/src/utilities/typescript/compilation.ts
+++ b/packages/workspace/src/utilities/typescript/compilation.ts
@@ -13,6 +13,7 @@ export interface TypeScriptCompilationOptions {
   rootDir?: string;
   watch?: boolean;
   getCustomTransformers?(program: Program): CustomTransformers;
+  showTsConfig?: boolean;
 }
 
 export interface TypescriptWatchChangeEvent {
@@ -30,6 +31,10 @@ export function compileTypeScript(options: TypeScriptCompilationOptions): {
 
   if (normalizedOptions.deleteOutputPath) {
     removeSync(normalizedOptions.outputPath);
+  }
+  
+  if(options.showTsConfig) {
+    console.log(`tsConfig: ${JSON.stringify(tsConfig)}`);
   }
 
   return createProgram(tsConfig, normalizedOptions);


### PR DESCRIPTION
Added an option to show final tsconfig during compilation for debug purpose

## Current Behavior
We have to set breakpoint to check the tsconfig used during typescript compilation.

## Expected Behavior
We now can set showTsConfig to true to show such config.

## Related Issue(s)
