### PR TITLE
fix(misc): move library without given importPath default to contain slashes

### DIFF
--- a/packages/angular/src/generators/move/lib/update-module-name.spec.ts
+++ b/packages/angular/src/generators/move/lib/update-module-name.spec.ts
@@ -1,11 +1,11 @@
 import { Tree } from '@nrwl/devkit';
 import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
+import { Linter } from '@nrwl/linter';
 import { moveGenerator } from '@nrwl/workspace/generators';
+import { UnitTestRunner } from '../../../utils/test-runners';
+import libraryGenerator from '../../library/library';
 import { Schema } from '../schema';
 import { updateModuleName } from './update-module-name';
-import libraryGenerator from '../../library/library';
-import { Linter } from '@nrwl/linter';
-import { UnitTestRunner } from '../../../utils/test-runners';
 
 describe('updateModuleName Rule', () => {
   let tree: Tree;
@@ -132,7 +132,7 @@ describe('updateModuleName Rule', () => {
 
       const importerFile = tree.read(secondModulePath).toString('utf-8');
       expect(importerFile).toContain(
-        `import { SharedMyFirstModule } from '@proj/shared-my-first';`
+        `import { SharedMyFirstModule } from '@proj/shared/my-first';`
       );
       expect(importerFile).toContain(
         `export class MySecondModule extends SharedMyFirstModule {}`

--- a/packages/workspace/src/generators/move/lib/normalize-schema.spec.ts
+++ b/packages/workspace/src/generators/move/lib/normalize-schema.spec.ts
@@ -34,7 +34,7 @@ describe('normalizeSchema', () => {
   it('should calculate importPath, projectName and relativeToRootDestination correctly', () => {
     const expected: NormalizedSchema = {
       destination: 'my/library',
-      importPath: '@proj/my-library',
+      importPath: '@proj/my/library',
       newProjectName: 'my-library',
       projectName: 'my-library',
       relativeToRootDestination: 'libs/my/library',

--- a/packages/workspace/src/generators/move/lib/normalize-schema.ts
+++ b/packages/workspace/src/generators/move/lib/normalize-schema.ts
@@ -1,4 +1,4 @@
-import { ProjectConfiguration, Tree, getWorkspaceLayout } from '@nrwl/devkit';
+import { getWorkspaceLayout, ProjectConfiguration, Tree } from '@nrwl/devkit';
 import { getImportPath } from 'nx/src/utils/path';
 import type { NormalizedSchema, Schema } from '../schema';
 import { getDestination, getNewProjectName, normalizeSlashes } from './utils';
@@ -19,7 +19,7 @@ export function normalizeSchema(
     destination,
     importPath:
       schema.importPath ??
-      normalizeSlashes(getImportPath(npmScope, newProjectName)),
+      normalizeSlashes(getImportPath(npmScope, destination)),
     newProjectName,
     relativeToRootDestination: getDestination(
       tree,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Performing:
`nx g mv --projectName lib/child-1 --destination lib/child-2`

would result in the ts-config and import paths of files being `@<project>/lib-child-2` 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

It is expected to be `@<project>/lib/child-2`. 
As that is how the `nx g` creation works when creating a library.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #9281
