### PR TITLE
adds example schema.json to generator guide.

### DIFF
--- a/docs/shared/generators/creating-files.md
+++ b/docs/shared/generators/creating-files.md
@@ -30,6 +30,39 @@ Example NOTES.md:
 Hello, my name is <%= name %>!
 ```
 
+Next, update the `schema.json` file for the generator.
+```json
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "$id": "MyPlugin",
+  "title": "",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "What name would you like to use?"
+    },
+    "tags": {
+      "type": "string",
+      "description": "Add tags to the project (used for linting)",
+      "alias": "t"
+    },
+    "directory": {
+      "type": "string",
+      "description": "A directory where the project is placed",
+      "alias": "d"
+    }
+  },
+  "required": ["name"]
+}
+```
+
 Next, update the `index.ts` file for the generator, and generate the new files.
 
 ```typescript


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
- the custom generator guide for a local generator did not include an example for the generators `schema.json` file.
- https://nx.dev/recipe/creating-files#creating-files-with-a-generator

## Expected Behavior
- this PR adds an example `schema.json` file that follows the existing example, and helps unblock the reader so that they can complete the guide.

## Related Issue(s)
N/A

Fixes #
