### PR TITLE
fix(next): fix withNx with nx property doesn't exist

### DIFF
--- a/packages/next/plugins/with-nx.spec.ts
+++ b/packages/next/plugins/with-nx.spec.ts
@@ -1,0 +1,51 @@
+import { withNx } from './with-nx';
+
+describe('withNx', () => {
+  describe('svgr', () => {
+    it('should be used by default', () => {
+      const config = withNx({});
+
+      const result = config.webpack(
+        {
+          module: { rules: [{ oneOf: [] }] },
+        },
+        {
+          defaultLoaders: {
+            babel: {
+              options: {},
+            },
+          },
+        }
+      );
+
+      expect(
+        result.module.rules.some((rule) => rule.test?.test('cat.svg'))
+      ).toBe(true);
+    });
+
+    it('should not be used when disabled', () => {
+      const config = withNx({
+        nx: {
+          svgr: false,
+        },
+      });
+
+      const result = config.webpack(
+        {
+          module: { rules: [{ oneOf: [] }] },
+        },
+        {
+          defaultLoaders: {
+            babel: {
+              options: {},
+            },
+          },
+        }
+      );
+
+      expect(
+        result.module.rules.some((rule) => rule.test?.test('cat.svg'))
+      ).toBe(false);
+    });
+  });
+});

--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -128,7 +128,7 @@ export function withNx(nextConfig = {} as WithNxOptions) {
        */
 
       // Default SVGR support to be on for projects.
-      if (nx.svgr !== false) {
+      if (nx?.svgr !== false) {
         config.module.rules.push({
           test: /\.svg$/,
           oneOf: [
@@ -180,7 +180,7 @@ function getNxEnvironmentVariables() {
 }
 
 function addNxEnvVariables(config: any) {
-  const maybeDefinePlugin = config.plugins.find((plugin) => {
+  const maybeDefinePlugin = config.plugins?.find((plugin) => {
     return plugin.definitions?.['process.env.NODE_ENV'];
   });
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

If the `nx` property is not passed into `withNx`, the following error will occur:
https://cloud.nx.app/runs/n6p7SAFQqyV/task/nx-dev:build-base

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

If the `nx` property is not passed into `withNx`, svgr should be used as it is used by default unless explicitly disabled.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
