### PR TITLE
fix(core): fix process.send will crash the nx runner without check if it is undefined

### DIFF
--- a/packages/nx/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/nx/src/tasks-runner/forked-process-task-runner.ts
@@ -86,7 +86,9 @@ export class ForkedProcessTaskRunner {
             }
             default: {
               // Re-emit any non-batch messages from the task process
-              process.send(message);
+              if (process.send) {
+                process.send(message);
+              }
             }
           }
         });
@@ -137,7 +139,9 @@ export class ForkedProcessTaskRunner {
 
         // Re-emit any messages from the task process
         p.on('message', (message) => {
-          process.send(message);
+          if (process.send) {
+            process.send(message);
+          }
         });
 
         let out = [];
@@ -216,7 +220,9 @@ export class ForkedProcessTaskRunner {
 
         // Re-emit any messages from the task process
         p.on('message', (message) => {
-          process.send(message);
+          if (process.send) {
+            process.send(message);
+          }
         });
 
         p.on('exit', (code, signal) => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
If i use nodemon in my custom executor, Nx will crash

## Expected Behavior
Nx custom executor with nodemon will continue to be working

## Related Issue(s)

Fixes #11903 
