### PR TITLE
add workspace config section

### DIFF
--- a/docs/shared/core-tutorial/01-create-blog.md
+++ b/docs/shared/core-tutorial/01-create-blog.md
@@ -101,6 +101,24 @@ Next, add `packages/blog/src/index.html`:
 <p>Hello, Eleventy</p>
 ```
 
+## Adding the project to the workspace configuration
+
+Before running our project, we have to make sure nx knows where is our project located.
+
+So, your `workspace.json` should look like this:
+
+```json 
+{
+  "$schema": "./node_modules/nx/schemas/workspace-schema.json",
+  "version": 2,
+  "projects": {
+    "blog": {
+      "root": "packages/blog"
+    }
+  }
+}
+```
+
 ## Running Eleventy with Nx
 
 Now that we have the bare minimum set up for Eleventy, you can run:


### PR DESCRIPTION
I am just doing the Core Nx Tutorial, and got a `Cannot find project 'blog'` once I tried to run `nx serve blog`, I solved the issue in a couple minutes after looking at this [Fireship video](https://www.youtube.com/watch?v=9iU_IE6vnJ8), however I feel like it would be nice to have it directly in the page.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
