### PR TITLE
fix(angular): warning logged when generating MF app with no e2e

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -1864,6 +1864,11 @@
             "default": false,
             "description": "Do not add dependencies to `package.json`."
           },
+          "skipE2E": {
+            "type": "boolean",
+            "default": false,
+            "description": "Do not set up E2E related config."
+          },
           "e2eProjectName": {
             "type": "string",
             "description": "The project name of the associated E2E project for the application. This is only required for Cypress E2E projects that do not follow the naming convention `<appName>-e2e`."

--- a/packages/angular/src/generators/host/host.spec.ts
+++ b/packages/angular/src/generators/host/host.spec.ts
@@ -1,6 +1,8 @@
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import host from './host';
 import remote from '../remote/remote';
+import { E2eTestRunner } from '../../utils/test-runners';
+import { getProjects } from 'nx/src/generators/utils/project-configuration';
 
 describe('Host App Generator', () => {
   it('should generate a host app with no remotes', async () => {
@@ -165,5 +167,22 @@ describe('Host App Generator', () => {
     expect(
       tree.read(`apps/test/dashboard/src/app/app.component.spec.ts`, 'utf-8')
     ).toMatchSnapshot();
+  });
+
+  it('should not generate an e2e project when e2eTestRunner is none', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+
+    // ACT
+    await host(tree, {
+      name: 'dashboard',
+      remotes: ['remote1'],
+      e2eTestRunner: E2eTestRunner.None,
+    });
+
+    // ASSERT
+    const projects = getProjects(tree);
+    expect(projects.has('dashboard-e2e')).toBeFalsy();
+    expect(projects.has('remote1-e2e')).toBeFalsy();
   });
 });

--- a/packages/angular/src/generators/host/host.ts
+++ b/packages/angular/src/generators/host/host.ts
@@ -15,6 +15,7 @@ import * as ts from 'typescript';
 import { addRoute } from '../../utils/nx-devkit/ast-utils';
 import { addStandaloneRoute } from '../../utils/nx-devkit/standalone-utils';
 import { setupMf } from '../setup-mf/setup-mf';
+import { E2eTestRunner } from '../../utils/test-runners';
 
 export default async function host(tree: Tree, options: Schema) {
   const projects = getProjects(tree);
@@ -41,6 +42,8 @@ export default async function host(tree: Tree, options: Schema) {
     skipFormat: true,
   });
 
+  const skipE2E =
+    !options.e2eTestRunner || options.e2eTestRunner === E2eTestRunner.None;
   await setupMf(tree, {
     appName,
     mfType: 'host',
@@ -50,7 +53,8 @@ export default async function host(tree: Tree, options: Schema) {
     federationType: options.dynamic ? 'dynamic' : 'static',
     skipPackageJson: options.skipPackageJson,
     skipFormat: true,
-    e2eProjectName: `${appName}-e2e`,
+    skipE2E,
+    e2eProjectName: skipE2E ? undefined : `${appName}-e2e`,
   });
 
   for (const remote of remotesToGenerate) {

--- a/packages/angular/src/generators/remote/remote.spec.ts
+++ b/packages/angular/src/generators/remote/remote.spec.ts
@@ -1,10 +1,12 @@
 import {
+  getProjects,
   readProjectConfiguration,
   readWorkspaceConfiguration,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import host from '../host/host';
 import remote from './remote';
+import { E2eTestRunner } from '@nrwl/angular/src/utils/test-runners';
 
 describe('MF Remote App Generator', () => {
   it('should generate a remote mf app with no host', async () => {
@@ -131,5 +133,20 @@ describe('MF Remote App Generator', () => {
     expect(
       tree.read(`apps/test/src/app/remote-entry/routes.ts`, 'utf-8')
     ).toMatchSnapshot();
+  });
+
+  it('should not generate an e2e project when e2eTestRunner is none', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+
+    // ACT
+    await remote(tree, {
+      name: 'remote1',
+      e2eTestRunner: E2eTestRunner.None,
+    });
+
+    // ASSERT
+    const projects = getProjects(tree);
+    expect(projects.has('remote1-e2e')).toBeFalsy();
   });
 });

--- a/packages/angular/src/generators/remote/remote.ts
+++ b/packages/angular/src/generators/remote/remote.ts
@@ -10,6 +10,7 @@ import applicationGenerator from '../application/application';
 import { getMFProjects } from '../../utils/get-mf-projects';
 import { normalizeProjectName } from '../utils/project';
 import { setupMf } from '../setup-mf/setup-mf';
+import { E2eTestRunner } from '../../utils/test-runners';
 
 function findNextAvailablePort(tree: Tree) {
   const mfProjects = getMFProjects(tree);
@@ -44,6 +45,9 @@ export default async function remote(tree: Tree, options: Schema) {
     port,
   });
 
+  const skipE2E =
+    !options.e2eTestRunner || options.e2eTestRunner === E2eTestRunner.None;
+
   await setupMf(tree, {
     appName,
     mfType: 'remote',
@@ -52,7 +56,8 @@ export default async function remote(tree: Tree, options: Schema) {
     port,
     skipPackageJson: options.skipPackageJson,
     skipFormat: true,
-    e2eProjectName: `${appName}-e2e`,
+    skipE2E,
+    e2eProjectName: skipE2E ? undefined : `${appName}-e2e`,
     standalone: options.standalone,
   });
 

--- a/packages/angular/src/generators/setup-mf/lib/add-cypress-workaround.ts
+++ b/packages/angular/src/generators/setup-mf/lib/add-cypress-workaround.ts
@@ -7,6 +7,7 @@ import {
   joinPathFragments,
   logger,
   readProjectConfiguration,
+  stripIndents,
 } from '@nrwl/devkit';
 import type { Schema } from '../schema';
 
@@ -21,7 +22,7 @@ export function addCypressOnErrorWorkaround(tree: Tree, schema: Schema) {
   try {
     e2eProject = readProjectConfiguration(tree, e2eProjectName);
   } catch {
-    logger.warn(`Could not find an associated e2e project for ${schema.appName} with name ${e2eProjectName}.
+    logger.warn(stripIndents`Could not find an associated e2e project for ${schema.appName} with name ${e2eProjectName}.
     If there is an associated e2e project for this application, and it uses Cypress, you will need to add a workaround to allow Cypress to test correctly.
     An error will be thrown in the console when you serve the application, coming from styles.js. It is an error that can be safely ignored and will not reach production due to how production builds of Angular are created.
     You can find how to implement that workaround here: https://docs.cypress.io/api/events/catalog-of-events#Uncaught-Exceptions

--- a/packages/angular/src/generators/setup-mf/schema.d.ts
+++ b/packages/angular/src/generators/setup-mf/schema.d.ts
@@ -11,4 +11,5 @@ export interface Schema {
   e2eProjectName?: string;
   prefix?: string;
   standalone?: boolean;
+  skipE2E?: boolean;
 }

--- a/packages/angular/src/generators/setup-mf/schema.json
+++ b/packages/angular/src/generators/setup-mf/schema.json
@@ -53,6 +53,11 @@
       "default": false,
       "description": "Do not add dependencies to `package.json`."
     },
+    "skipE2E": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not set up E2E related config."
+    },
     "e2eProjectName": {
       "type": "string",
       "description": "The project name of the associated E2E project for the application. This is only required for Cypress E2E projects that do not follow the naming convention `<appName>-e2e`."

--- a/packages/angular/src/generators/setup-mf/setup-mf.ts
+++ b/packages/angular/src/generators/setup-mf/setup-mf.ts
@@ -35,7 +35,9 @@ export async function setupMf(tree: Tree, options: Schema) {
 
   fixBootstrap(tree, projectConfig.root, options);
 
-  addCypressOnErrorWorkaround(tree, options);
+  if (!options.skipE2E) {
+    addCypressOnErrorWorkaround(tree, options);
+  }
 
   // format files
   if (!options.skipFormat) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We log an incorrect warning when setting up MF for an app that intentionally has no e2e

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Do not log warning

