### PR TITLE
docs(nxdev): url hash filter for packages

### DIFF
--- a/nx-dev/nx-dev-e2e/src/integration/packages.spec.ts
+++ b/nx-dev/nx-dev-e2e/src/integration/packages.spec.ts
@@ -494,3 +494,28 @@ describe('nx-dev: Packages Section', () => {
     },
   ]).forEach((page) => assertTextOnPage(page.path, page.title));
 });
+
+/**
+ * Asserting that URL applied filters are working as expected
+ */
+describe('nx-dev: Packages Section - URL hash as filter', () => {
+  it('should filter packages by the URL hash', () => {
+    cy.visit('/packages#storybook');
+    cy.get('section#storybook').should('exist');
+    cy.get('section#cypress').should('not.exist');
+    cy.get('section#angular').should('not.exist');
+    cy.get('section#detox').should('not.exist');
+    cy.get('section#react').should('not.exist');
+    cy.get('section#workspace').should('not.exist');
+  });
+
+  it('should show all packages if the hash does not correspond to a package', () => {
+    cy.visit('/packages#asdfg');
+    cy.get('section#storybook').should('exist');
+    cy.get('section#cypress').should('exist');
+    cy.get('section#angular').should('exist');
+    cy.get('section#detox').should('exist');
+    cy.get('section#react').should('exist');
+    cy.get('section#workspace').should('exist');
+  });
+});

--- a/nx-dev/ui-references/src/index.ts
+++ b/nx-dev/ui-references/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/references-nav-list';
 export * from './lib/references-index-item';
+export * from './lib/references-section';


### PR DESCRIPTION
## Current Behavior

This is for the [Reference](https://nx.dev/packages) page in docs. On that page, you can filter the results by clicking on the buttons.

## Expected Behavior

As you filter the results on that page, the name of the package gets added in the URL as a hash, so that we can link straight to the filtered results.

eg:

`https://nx.dev/packages#storybook` will now return this: 

![Screenshot 2022-09-08 at 6 36 33 PM](https://user-images.githubusercontent.com/6603745/189164861-5a86b0af-4444-4a12-9152-c009b10c4827.png)


