### PR TITLE
fix(core): add back target defaults for all new workspaces

### DIFF
--- a/e2e/nx-run/src/cache.test.ts
+++ b/e2e/nx-run/src/cache.test.ts
@@ -64,9 +64,9 @@ describe('cache', () => {
 
     // touch package.json
     // --------------------------------------------
-    updateFile(`package.json`, (c) => {
+    updateFile(`nx.json`, (c) => {
       const r = JSON.parse(c);
-      r.description = 'different';
+      r.affected.defaultBase = 'different';
       return JSON.stringify(r);
     });
     const outputWithNoBuildCached = runCLI(`affected:build ${files}`);

--- a/packages/workspace/src/generators/workspace/workspace.spec.ts
+++ b/packages/workspace/src/generators/workspace/workspace.spec.ts
@@ -53,6 +53,11 @@ describe('@nrwl/workspace:workspace', () => {
           },
         },
       },
+      targetDefaults: {
+        build: {
+          dependsOn: ['^build'],
+        },
+      },
     });
     const validateNxJson = ajv.compile(nxSchema);
     expect(validateNxJson(nxJson)).toEqual(true);

--- a/packages/workspace/src/generators/workspace/workspace.ts
+++ b/packages/workspace/src/generators/workspace/workspace.ts
@@ -80,6 +80,12 @@ function createNxJson(
     },
   };
 
+  nxJson.targetDefaults = {
+    build: {
+      dependsOn: ['^build'],
+    },
+  };
+
   if (
     preset !== Preset.Core &&
     preset !== Preset.NPM &&
@@ -90,12 +96,7 @@ function createNxJson(
       production: ['default'],
       sharedGlobals: [],
     };
-    nxJson.targetDefaults = {
-      build: {
-        dependsOn: ['^build'],
-        inputs: ['production', '^production'],
-      },
-    };
+    nxJson.targetDefaults.build.inputs = ['production', '^production'];
   }
 
   if (packageManager && cli === 'angular') {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

TS, Core, and NPM workspaces lost their `targetDefaults` for build.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

TS, Core, and NPM workspaces have `targetDefaults` for build.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
