### PR TITLE
fix(testing): do not add cypress inputs if namedInputs is not defined

### DIFF
--- a/packages/cypress/src/generators/init/init.ts
+++ b/packages/cypress/src/generators/init/init.ts
@@ -16,6 +16,10 @@ import { Schema } from './schema';
 function setupE2ETargetDefaults(tree: Tree) {
   const workspaceConfiguration = readWorkspaceConfiguration(tree);
 
+  if (!workspaceConfiguration.namedInputs) {
+    return;
+  }
+
   // E2e targets depend on all their project's sources + production sources of dependencies
   workspaceConfiguration.targetDefaults ??= {};
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Setting up cypress for the first time in an existing workspace will add namedInputs configuration.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Setting up cypress for the first time in an existing workspace will not add namedInputs configuration just yet.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
