### PR TITLE
docs(nxdev): graph links from package.json

### DIFF
--- a/docs/map.json
+++ b/docs/map.json
@@ -453,6 +453,11 @@
         "id": "recipe",
         "itemList": [
           {
+            "name": "Disable Graph Links Created from Analyzing Source Files",
+            "id": "analyze-source-files",
+            "file": "shared/recipes/analyze-source-files"
+          },
+          {
             "name": "Nx Console Generate Command",
             "id": "console-generate-command",
             "file": "shared/recipes/console-generate-command"

--- a/docs/shared/concepts/how-project-graph-is-built.md
+++ b/docs/shared/concepts/how-project-graph-is-built.md
@@ -2,7 +2,23 @@
 
 Nx creates a graph of all the dependencies between projects in your workspace using two sources of information:
 
-1. Typescript `import` statements referencing a particular project's path alias
+1. Package dependencies defined in the `package.json` file for each project.
+
+   If the `myapp/package.json` file has this dependency:
+
+   ```jsonc
+   {
+     "dependencies": {
+       "@myorg/awesome-library": "*"
+     }
+   }
+   ```
+
+   Then `my-app` depends on `awesome-library`.
+
+   Note: We typically use `*` for the dependency instead of a specific version because we want to depend on the version of the library as it currently exists in the repo.
+
+2. Typescript `import` statements referencing a particular project's path alias
 
    For instance, if a file in `my-app` has this code:
 
@@ -12,7 +28,7 @@ Nx creates a graph of all the dependencies between projects in your workspace us
 
    Then `my-app` depends on `awesome-library`
 
-2. Manually created `implicitDependencies` in the project configuration file.
+3. Manually created `implicitDependencies` in the project configuration file.
 
    If your project configuration has this content:
 

--- a/docs/shared/concepts/how-project-graph-is-built.md
+++ b/docs/shared/concepts/how-project-graph-is-built.md
@@ -28,6 +28,8 @@ Nx creates a graph of all the dependencies between projects in your workspace us
 
    Then `my-app` depends on `awesome-library`
 
+   This can be [turned on or off with the `analyzeSourceFiles` flag](../../recipe/analyze-source-files).
+
 3. Manually created `implicitDependencies` in the project configuration file.
 
    If your project configuration has this content:
@@ -58,3 +60,10 @@ Nx creates a graph of all the dependencies between projects in your workspace us
 {% /tabs %}
 
 Then `my-app` depends on `some-api`
+
+## Related Documentation
+
+### Recipes
+
+- [Disable Graph Links Created from Analyzing Source Files](/recipe/analyze-source-files)
+- [Modify the Project Graph with a Plugin](recipe/project-graph-plugins)

--- a/docs/shared/recipes/analyze-source-files.md
+++ b/docs/shared/recipes/analyze-source-files.md
@@ -1,0 +1,17 @@
+# Disable Graph Links Created from Analyzing Source Files
+
+If you want to disable detecting dependencies from source code and want to only use the dependencies as defined in `package.json` (the same way yarn does), you can add the following configuration to your `nx.json` file:
+
+```json
+{
+  "pluginsConfig": {
+    "@nrwl/js": {
+      "analyzeSourceFiles": false
+    }
+  }
+}
+```
+
+## Default
+
+The default setting for Nx repos is `"analyzeSourceFiles": true`. The assumption is that if there is a real link in the code between projects, you want to know about it. For Lerna repos, the default value is `false` in order to maintain backward compatibility with the way Lerna has always calculated dependencies.

--- a/docs/shared/recipes/recipe-list.md
+++ b/docs/shared/recipes/recipe-list.md
@@ -87,3 +87,4 @@
 - [Tag in Multiple Dimensions](/recipe/tag-multiple-dimensions)
 - [Ban External Imports](/recipe/ban-external-imports)
 - [Tags Allow List](/recipe/tags-allow-list)
+- [Disable Graph Links Created from Analyzing Source Files](/recipe/analyze-source-files)


### PR DESCRIPTION
Updates the `How the Project Graph is Built` guide.  And adds a related recipe