### PR TITLE
fix(testing): change import to not include angular

### DIFF
--- a/packages/cypress/src/migrations/update-14-7-0/update-cypress-version-if-10.ts
+++ b/packages/cypress/src/migrations/update-14-7-0/update-cypress-version-if-10.ts
@@ -5,7 +5,8 @@ import {
   Tree,
   updateJson,
 } from '@nrwl/devkit';
-import { checkAndCleanWithSemver } from '@nrwl/workspace';
+// don't import from root level to prevent issue where angular isn't installed.
+import { checkAndCleanWithSemver } from '@nrwl/workspace/src/utilities/version-utils';
 import { gte, lt } from 'semver';
 
 export function updateCypressVersionIf10(tree: Tree): GeneratorCallback {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
```
 >  NX   Running migrations from 'migrations.json'


 >  NX   Failed to run update-cypress-if-v10 from @nrwl/cypress. This workspace is NOT up to date!


 >  NX   Cannot find module '@angular-devkit/schematics'

   Require stack:
   - <project-folder>node_modules/@nrwl/workspace/src/utils/ast-utils.js
```
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

not requiring angular to be in the workspace

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
