### PR TITLE
docs(nxdev): added unique key in list item

### DIFF
--- a/nx-dev/feature-package-schema-viewer/src/lib/ui/package-reference.tsx
+++ b/nx-dev/feature-package-schema-viewer/src/lib/ui/package-reference.tsx
@@ -31,6 +31,7 @@ export function PackageReference({
       <ul className="divide-y divide-gray-200">
         {executors.map((executor) => (
           <SchemaListItem
+            key={executor.name}
             schema={executor}
             packageName={name}
             type="executors"
@@ -44,6 +45,7 @@ export function PackageReference({
       <ul className="divide-y divide-gray-200">
         {generators.map((generator) => (
           <SchemaListItem
+            key={generator.name}
             schema={generator}
             packageName={name}
             type="generators"


### PR DESCRIPTION
## Current Behavior

On https://nx.dev/packages page, getting error when running locally that list item does not have unique key (for generators and executors)

## Expected Behavior

Added unique key to the list items, so now error does not appear.

