### PR TITLE
docs(nxdev): redirect executors and generators to current package

### DIFF
--- a/nx-dev/ui-common/src/lib/breadcrumbs.tsx
+++ b/nx-dev/ui-common/src/lib/breadcrumbs.tsx
@@ -10,10 +10,12 @@ export function Breadcrumbs({ path }: { path: string }): JSX.Element {
       .split('/')
       .filter(Boolean)
       .map((segment, index, segments) => ({
-        name: segment,
+        name: segment.includes('#')
+          ? segment.slice(0, segment.indexOf('#'))
+          : segment,
         // We do not have dedicated page view for executors & generators
         href: ['executors', 'generators'].includes(segment)
-          ? '#'
+          ? '/' + segments.slice(0, index).join('/') + '#' + segment
           : '/' + segments.slice(0, index + 1).join('/'),
         current: '/' + segments.slice(0, index + 1).join('/') === cleanedPath,
       })),


### PR DESCRIPTION
It improves the breadcrumbs' behaviour to redirect the visitor to the package main page on the right section for nx.dev.