### PR TITLE
fix(testing): use webpack defined in executor options for react ct

### DIFF
--- a/e2e/react/src/cypress-component-tests.test.ts
+++ b/e2e/react/src/cypress-component-tests.test.ts
@@ -124,7 +124,7 @@ export default Input;
     expect(runCLI(`component-test ${appName} --no-watch`)).toContain(
       'All specs passed!'
     );
-  }, 1000000);
+  }, 300_000);
 
   it('should successfully component test lib being used in app', () => {
     runCLI(
@@ -133,7 +133,7 @@ export default Input;
     expect(runCLI(`component-test ${usedInAppLibName} --no-watch`)).toContain(
       'All specs passed!'
     );
-  }, 1000000);
+  }, 300_000);
 
   it('should test buildable lib not being used in app', () => {
     createFile(
@@ -192,5 +192,5 @@ ${content}`;
     expect(runCLI(`component-test ${buildableLibName} --no-watch`)).toContain(
       'All specs passed!'
     );
-  }, 1000000);
+  }, 300_000);
 });

--- a/e2e/react/src/cypress-component-tests.test.ts
+++ b/e2e/react/src/cypress-component-tests.test.ts
@@ -1,14 +1,123 @@
-import { createFile, newProject, runCLI, uniq, updateFile } from '../../utils';
+import {
+  createFile,
+  newProject,
+  runCLI,
+  uniq,
+  updateFile,
+  updateProjectConfig,
+} from '../../utils';
 
 describe('React Cypress Component Tests', () => {
-  beforeAll(() => newProject());
-
-  it('should successfully test react app', () => {
-    const appName = uniq('cy-react-app');
+  let projectName;
+  const appName = uniq('cy-react-app');
+  const usedInAppLibName = uniq('cy-react-lib');
+  const buildableLibName = uniq('cy-react-buildable-lib');
+  beforeAll(() => {
+    projectName = newProject({ name: uniq('cy-react') });
     runCLI(`generate @nrwl/react:app ${appName} --no-interactive`);
     runCLI(
-      `generate @nrwl/react:component fancy-component --project=${appName} --no-interactive`
+      `generate @nrwl/react:component fancy-cmp --project=${appName} --no-interactive`
     );
+    runCLI(`generate @nrwl/react:lib ${usedInAppLibName} --no-interactive`);
+    runCLI(
+      `generate @nrwl/react:component btn --project=${usedInAppLibName} --export --no-interactive`
+    );
+    // makes sure custom webpack is loading
+    createFile(
+      `apps/${appName}/src/assets/demo.svg`,
+      `
+<svg version="1.1"
+     width="300" height="200"
+     xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="aliceblue" />
+  <circle cx="150" cy="100" r="80" fill="blue" />
+  <text x="150" y="125" font-size="60" text-anchor="middle" fill="white">nrwl</text>
+</svg>
+`
+    );
+    updateFile(
+      `libs/${usedInAppLibName}/src/lib/btn/btn.tsx`,
+      `
+import styles from './btn.module.css';
+
+/* eslint-disable-next-line */
+export interface BtnProps {
+    text: string
+}
+
+export function Btn(props: BtnProps) {
+  return (
+    <div className={styles['container']}>
+      <h1>Welcome to Btn!</h1>
+      <button className="text-green-500">{props.text}</button>
+    </div>
+  );
+}
+
+export default Btn;
+`
+    );
+
+    updateFile(
+      `apps/${appName}/src/app/app.tsx`,
+      `
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import styles from './app.module.css';
+import logo from '../assets/demo.svg';
+import { Btn } from '@${projectName}/${usedInAppLibName}';
+
+export function App() {
+  return (
+    <>
+      <Btn  text={'I am the app'}/>
+      <img src={logo} alt="logo" />
+    </>
+  );
+}
+
+export default App;`
+    );
+
+    runCLI(
+      `generate @nrwl/react:lib ${buildableLibName} --buildable --no-interactive`
+    );
+    runCLI(
+      `generate @nrwl/react:component input --project=${buildableLibName} --export --no-interactive`
+    );
+
+    updateFile(
+      `libs/${buildableLibName}/src/lib/input/input.tsx`,
+      `
+    import styles from './input.module.css';
+
+/* eslint-disable-next-line */
+export interface InputProps {
+    readOnly: boolean
+}
+
+export function Input(props: InputProps) {
+  return ( 
+      <label className="text-green-500">Email: 
+        <input className="border-blue-500" type="email" readOnly={props.readOnly}/>
+      </label>
+  );
+}
+
+export default Input;
+`
+    );
+    createFile('libs/assets/data.json', JSON.stringify({ data: 'data' }));
+    updateProjectConfig(appName, (config) => {
+      config.targets['build'].options.assets.push({
+        glob: '**/*',
+        input: 'libs/assets',
+        output: 'assets',
+      });
+      return config;
+    });
+  });
+
+  it('should test app', () => {
     runCLI(
       `generate @nrwl/react:cypress-component-configuration --project=${appName} --generate-tests`
     );
@@ -17,19 +126,48 @@ describe('React Cypress Component Tests', () => {
     );
   }, 1000000);
 
-  it('should successfully test react lib', () => {
-    const libName = uniq('cy-react-lib');
-    const appName = uniq('cy-react-app-target');
-    runCLI(`generate @nrwl/react:app ${appName} --no-interactive`);
-    runCLI(`generate @nrwl/react:lib ${libName} --component --no-interactive`);
+  it('should successfully component test lib being used in app', () => {
     runCLI(
-      `generate @nrwl/react:setup-tailwind --project=${libName} --no-interactive`
+      `generate @nrwl/react:cypress-component-configuration --project=${usedInAppLibName} --generate-tests`
     );
-    runCLI(
-      `generate @nrwl/react:component fancy-component --project=${libName} --no-interactive`
+    expect(runCLI(`component-test ${usedInAppLibName} --no-watch`)).toContain(
+      'All specs passed!'
     );
+  }, 1000000);
+
+  it('should test buildable lib not being used in app', () => {
     createFile(
-      `libs/${libName}/src/styles.css`,
+      `libs/${buildableLibName}/src/lib/input/input.cy.tsx`,
+      `
+import * as React from 'react'
+import { mount } from 'cypress/react'
+import Input from './input'
+
+
+describe(Input.name, () => {
+  it('renders', () => {
+    mount(<Input readOnly={false} />)
+    cy.get('label').should('have.css', 'color', 'rgb(0, 0, 0)');
+  })
+  it('should be read only', () => {
+    mount(<Input readOnly={true}/>)
+    cy.get('input').should('have.attr', 'readonly');
+  })
+});
+`
+    );
+
+    runCLI(
+      `generate @nrwl/react:cypress-component-configuration --project=${buildableLibName} --generate-tests --build-target=${appName}:build`
+    );
+    expect(runCLI(`component-test ${buildableLibName} --no-watch`)).toContain(
+      'All specs passed!'
+    );
+
+    // add tailwind
+    runCLI(`generate @nrwl/react:setup-tailwind --project=${buildableLibName}`);
+    updateFile(
+      `libs/${buildableLibName}/src/styles.css`,
       `
 @tailwind components;
 @tailwind base;
@@ -37,17 +175,21 @@ describe('React Cypress Component Tests', () => {
 `
     );
     updateFile(
-      `libs/${libName}/src/lib/fancy-component/fancy-component.tsx`,
+      `libs/${buildableLibName}/src/lib/input/input.cy.tsx`,
       (content) => {
-        return `
-import '../../styles.css';
+        // text-green-500 should now apply
+        return content.replace('rgb(0, 0, 0)', 'rgb(34, 197, 94)');
+      }
+    );
+    updateFile(
+      `libs/${buildableLibName}/src/lib/input/input.tsx`,
+      (content) => {
+        return `import '../../styles.css';
 ${content}`;
       }
     );
-    runCLI(
-      `generate @nrwl/react:cypress-component-configuration --project=${libName} --build-target=${appName}:build --generate-tests`
-    );
-    expect(runCLI(`component-test ${libName} --no-watch`)).toContain(
+
+    expect(runCLI(`component-test ${buildableLibName} --no-watch`)).toContain(
       'All specs passed!'
     );
   }, 1000000);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
svg images don't load with react component testing.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
component testing preset should load the defined webpack config if present in the executor options of the build target.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
