### PR TITLE
docs(nxdev): added redirect rule for removed storybook page

### DIFF
--- a/nx-dev/nx-dev/redirect-rules.config.js
+++ b/nx-dev/nx-dev/redirect-rules.config.js
@@ -81,6 +81,8 @@ const schemaUrls = {
     '/packages/storybook/generators/migrate-stories-to-6-2',
   '/storybook/executors-build': '/packages/storybook/executors/build',
   '/storybook/executors-storybook': '/packages/storybook/executors/storybook',
+  '/storybook/extra-topics-for-angular-projects':
+    '/storybook/overview-angular#more-documentation',
   '/linter/eslint': '/packages/linter/executors/eslint',
   '/linter/lint': '/packages/linter/executors/lint',
   '/linter/workspace-rule': '/packages/linter/generators/workspace-rule',


### PR DESCRIPTION
## Current Behavior

After I removed the [Extra Topics for Angular](https://nx.dev/storybook/extra-topics-for-angular-projects) page, I forgot to write a redirect rule. So the page returns a 404.

## Expected Behavior

[Extra Topics for Angular](https://nx.dev/storybook/extra-topics-for-angular-projects) redirects to the "More Documentation" section of the main "Set up Storybook for Angular" page.

