### PR TITLE
feat(angular): use provideRouter for standalone apps

### DIFF
--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`app --standalone should generate a standalone app correctly with routing 1`] = `
-"import { enableProdMode, importProvidersFrom } from '@angular/core';
+"import { enableProdMode } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { RouterModule } from '@angular/router';
+import { provideRouter, withNonEnabledBlockingInitialNavigation } from '@angular/router';
 import { AppComponent } from './app/app.component';
 import { environment } from './environments/environment';
 import { appRoutes } from './app/app.routes';
@@ -13,7 +13,7 @@ if (environment.production) {
 }
 
 bootstrapApplication(AppComponent, {
-  providers: [importProvidersFrom(RouterModule.forRoot(appRoutes, {initialNavigation: 'enabledBlocking'}))],
+  providers: [provideRouter(appRoutes, withEnabledBlockingInitialNavigation())],
 }).catch((err) => console.error(err));"
 `;
 

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -5,6 +5,7 @@ import {
   NxJsonConfiguration,
   parseJson,
   readJson,
+  readProjectConfiguration,
   readWorkspaceConfiguration,
   updateJson,
 } from '@nrwl/devkit';

--- a/packages/angular/src/generators/application/lib/convert-to-standalone-app.ts
+++ b/packages/angular/src/generators/application/lib/convert-to-standalone-app.ts
@@ -45,13 +45,11 @@ function updateMainEntrypoint(
 
 const standaloneComponentMainContents = (
   routerModuleSetup
-) => `import { enableProdMode${
-  routerModuleSetup ? `, importProvidersFrom` : ``
-} } from '@angular/core';
+) => `import { enableProdMode } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';${
   routerModuleSetup
     ? `
-import { RouterModule } from '@angular/router'`
+import { provideRouter, withNonEnabledBlockingInitialNavigation } from '@angular/router'`
     : ``
 };
 import { AppComponent } from './app/app.component';
@@ -65,7 +63,7 @@ if (environment.production) {
 bootstrapApplication(AppComponent${
   routerModuleSetup
     ? `, {
-  providers: [importProvidersFrom(${routerModuleSetup})],
+  providers: [provideRouter(appRoutes, withEnabledBlockingInitialNavigation())],
 }`
     : ''
 }).catch((err) => console.error(err));`;

--- a/packages/angular/src/generators/host/__snapshots__/host.spec.ts.snap
+++ b/packages/angular/src/generators/host/__snapshots__/host.spec.ts.snap
@@ -19,9 +19,9 @@ module.exports = withModuleFederation(config);"
 `;
 
 exports[`Host App Generator should generate a host with remotes using standalone components 1`] = `
-"import { enableProdMode, importProvidersFrom } from '@angular/core';
+"import { enableProdMode } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { RouterModule } from '@angular/router';
+import { provideRouter, withNonEnabledBlockingInitialNavigation } from '@angular/router';
 import { AppComponent } from './app/app.component';
 import { environment } from './environments/environment';
 import { appRoutes } from './app/app.routes';
@@ -31,7 +31,7 @@ if (environment.production) {
 }
 
 bootstrapApplication(AppComponent, {
-  providers: [importProvidersFrom(RouterModule.forRoot(appRoutes, {initialNavigation: 'enabledBlocking'}))],
+  providers: [provideRouter(appRoutes, withEnabledBlockingInitialNavigation())],
 }).catch((err) => console.error(err));"
 `;
 


### PR DESCRIPTION
Switch from `importProvidersFrom` to `provideRouter` for standalone apps