### PR TITLE
fix(testing): use cypress generated tsconfig for angular ct

### DIFF
--- a/e2e/angular-extensions/src/cypress-component-tests.test.ts
+++ b/e2e/angular-extensions/src/cypress-component-tests.test.ts
@@ -146,27 +146,27 @@ import {CommonModule} from '@angular/common';
 
   it('should test app', () => {
     runCLI(
-      `generate @nrwl/angular:cypress-component-configuration --project=${appName} --generate-tests`
+      `generate @nrwl/angular:cypress-component-configuration --project=${appName} --generate-tests --no-interactive`
     );
     expect(runCLI(`component-test ${appName} --no-watch`)).toContain(
       'All specs passed!'
     );
-  }, 1000000);
+  }, 300_000);
 
   it('should successfully component test lib being used in app', () => {
     runCLI(
-      `generate @nrwl/angular:cypress-component-configuration --project=${usedInAppLibName} --generate-tests`
+      `generate @nrwl/angular:cypress-component-configuration --project=${usedInAppLibName} --generate-tests --no-interactive`
     );
     expect(runCLI(`component-test ${usedInAppLibName} --no-watch`)).toContain(
       'All specs passed!'
     );
-  }, 1000000);
+  }, 300_000);
 
   it('should test buildable lib not being used in app', () => {
     expect(() => {
       // should error since no edge in graph between lib and app
       runCLI(
-        `generate @nrwl/angular:cypress-component-configuration --project=${buildableLibName} --generate-tests`
+        `generate @nrwl/angular:cypress-component-configuration --project=${buildableLibName} --generate-tests --no-interactive`
       );
     }).toThrow();
     createFile(
@@ -232,7 +232,7 @@ describe(InputStandaloneComponent.name, () => {
     );
 
     runCLI(
-      `generate @nrwl/angular:cypress-component-configuration --project=${buildableLibName} --generate-tests --build-target=${appName}:build`
+      `generate @nrwl/angular:cypress-component-configuration --project=${buildableLibName} --generate-tests --build-target=${appName}:build --no-interactive`
     );
     expect(runCLI(`component-test ${buildableLibName} --no-watch`)).toContain(
       'All specs passed!'
@@ -261,5 +261,5 @@ describe(InputStandaloneComponent.name, () => {
       'All specs passed!'
     );
     checkFilesDoNotExist(`tmp/libs/${buildableLibName}/ct-styles.css`);
-  }, 1000000);
+  }, 300_000);
 });

--- a/packages/angular/plugins/component-testing.ts
+++ b/packages/angular/plugins/component-testing.ts
@@ -172,11 +172,14 @@ function normalizeBuildTargetOptions(
   buildOptions.index =
     typeof buildOptions.index === 'string'
       ? joinPathFragments(offset, buildOptions.index)
-      : (buildOptions.index.input = joinPathFragments(
-          offset,
-          buildOptions.index.input
-        ));
-  buildOptions.tsConfig = joinPathFragments(offset, buildOptions.tsConfig);
+      : {
+          ...buildOptions.index,
+          input: joinPathFragments(offset, buildOptions.index.input),
+        };
+  // cypress creates a tsconfig if one isn't preset
+  // that contains all the support required for angular and component tests
+  delete buildOptions.tsConfig;
+
   buildOptions.fileReplacements = buildOptions.fileReplacements.map((fr) => {
     fr.replace = joinPathFragments(offset, fr.replace);
     fr.with = joinPathFragments(offset, fr.with);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
angular ct fail with typescript errors. 
```
ERROR in ./cypress/support/component.ts
Module build failed (from ../../node _modules/@ngtools/webpack/src/ivy/index.js):
Error: /support/component.ts is missing
from the TypeScript compilation. Please make sure it is in your tsconfig via the 'files' or include
property.
// etc
```

<!-- This is the behavior we should expect with the changes in this PR -->
angular ct works out of the box. 

## Contexts
in v10.8.0 of Cypress, angular component testing would use the tsConfig option if preset. this breaks when in an nx workspace because of issues with pathing in an nx workspace vs angular cli project. (root vs project root)

Now nx preset will delete the tsConfig option to fallback to cypress generated one, which was the behavior prior to v10.8.0
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
