### PR TITLE
feat(angular): add types to the generated tailwind configuration

### DIFF
--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -1056,6 +1056,7 @@ describe('app', () => {
         "const { createGlobPatternsForDependencies } = require('@nrwl/angular/tailwind');
         const { join } = require('path');
 
+        /** @type {import('tailwindcss').Config} */
         module.exports = {
           content: [
             join(__dirname, 'src/**/!(*.stories|*.spec).{ts,html}'),

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -1440,6 +1440,7 @@ describe('lib', () => {
         "const { createGlobPatternsForDependencies } = require('@nrwl/angular/tailwind');
         const { join } = require('path');
 
+        /** @type {import('tailwindcss').Config} */
         module.exports = {
           content: [
             join(__dirname, 'src/**/!(*.stories|*.spec).{ts,html}'),

--- a/packages/angular/src/generators/setup-tailwind/files/v3/tailwind.config.js__tmpl__
+++ b/packages/angular/src/generators/setup-tailwind/files/v3/tailwind.config.js__tmpl__
@@ -1,6 +1,7 @@
 const { createGlobPatternsForDependencies } = require('@nrwl/angular/tailwind');
 const { join } = require('path');
 
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
     join(__dirname, '<%= relativeSourceRoot %>/**/!(*.stories|*.spec).{ts,html}'),

--- a/packages/angular/src/generators/setup-tailwind/setup-tailwind.application.spec.ts
+++ b/packages/angular/src/generators/setup-tailwind/setup-tailwind.application.spec.ts
@@ -331,6 +331,7 @@ describe('setupTailwind generator', () => {
         "const { createGlobPatternsForDependencies } = require('@nrwl/angular/tailwind');
         const { join } = require('path');
 
+        /** @type {import('tailwindcss').Config} */
         module.exports = {
           content: [
             join(__dirname, 'src/**/!(*.stories|*.spec).{ts,html}'),
@@ -360,6 +361,7 @@ describe('setupTailwind generator', () => {
         "const { createGlobPatternsForDependencies } = require('@nrwl/angular/tailwind');
         const { join } = require('path');
 
+        /** @type {import('tailwindcss').Config} */
         module.exports = {
           content: [
             join(__dirname, 'src/**/!(*.stories|*.spec).{ts,html}'),

--- a/packages/angular/src/generators/setup-tailwind/setup-tailwind.library.spec.ts
+++ b/packages/angular/src/generators/setup-tailwind/setup-tailwind.library.spec.ts
@@ -200,6 +200,7 @@ describe('setupTailwind generator', () => {
         "const { createGlobPatternsForDependencies } = require('@nrwl/angular/tailwind');
         const { join } = require('path');
 
+        /** @type {import('tailwindcss').Config} */
         module.exports = {
           content: [
             join(__dirname, 'src/**/!(*.stories|*.spec).{ts,html}'),
@@ -232,6 +233,7 @@ describe('setupTailwind generator', () => {
         "const { createGlobPatternsForDependencies } = require('@nrwl/angular/tailwind');
         const { join } = require('path');
 
+        /** @type {import('tailwindcss').Config} */
         module.exports = {
           content: [
             join(__dirname, 'src/**/!(*.stories|*.spec).{ts,html}'),


### PR DESCRIPTION
Adding JSDoc to Angular Tailwind configuration to improve editor autocompletion. This now matches the React setup.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Generates a config with no JSDoc.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Should have JSDoc to match React setup

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
