### PR TITLE
fix(angular): add $schema property to generated project configs

### DIFF
--- a/packages/angular/src/generators/library/lib/update-project.ts
+++ b/packages/angular/src/generators/library/lib/update-project.ts
@@ -1,15 +1,16 @@
 import {
+  addProjectConfiguration,
   generateFiles,
   getWorkspaceLayout,
   joinPathFragments,
   offsetFromRoot,
   readProjectConfiguration,
+  removeProjectConfiguration,
   Tree,
   updateJson,
-  updateProjectConfiguration,
 } from '@nrwl/devkit';
-import { replaceAppNameWithPath } from '@nrwl/workspace/src/utils/cli-config-utils';
 import { getRelativePathToRootTsConfig } from '@nrwl/workspace/src/utilities/typescript';
+import { replaceAppNameWithPath } from '@nrwl/workspace/src/utils/cli-config-utils';
 import * as path from 'path';
 import { NormalizedSchema } from './normalized-schema';
 import { updateNgPackage } from './update-ng-package';
@@ -173,7 +174,23 @@ function fixProjectWorkspaceConfig(
 
   delete project.targets.test;
 
-  updateProjectConfiguration(host, options.name, project);
+  /**
+   * The "$schema" property on our configuration files is only added when the
+   * project configuration is added and not when updating it. It's done this
+   * way to avoid re-adding "$schema" when updating a project configuration
+   * and that property was intentionally removed by the devs.
+   *
+   * Since the project gets created by the Angular application schematic,
+   * the "$schema" property is not added, so we remove the project and add
+   * it back to workaround that.
+   */
+  removeProjectConfiguration(host, options.name);
+  addProjectConfiguration(
+    host,
+    options.name,
+    project,
+    options.standaloneConfig
+  );
 }
 
 function updateProjectTsConfig(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Generated Angular projects don't have the `$schema` property set in the project configuration file.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Generated Angular projects have the `$schema` property set in the project configuration file.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #11350 
