### PR TITLE
fix(testing): improve return type of getJestProjects

### DIFF
--- a/packages/jest/src/utils/config/get-jest-projects.ts
+++ b/packages/jest/src/utils/config/get-jest-projects.ts
@@ -12,7 +12,7 @@ export function getJestProjects() {
   const ws = readWorkspaceConfig({
     format: 'nx',
   }) as ProjectsConfigurations;
-  const jestConfigurationSet = new Set();
+  const jestConfigurationSet = new Set<string>();
   for (const projectConfig of Object.values(ws.projects)) {
     if (!projectConfig.targets) {
       continue;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

By default `Set` uses type of `unknown` for it's values which results in return type of `getJestProjects` being `unknown[]`

## Expected Behavior

With correct generic specified the return type is now `string[]`

## Related Issue(s)

\-
