### PR TITLE
chore(testing): update migration to read all project configuration at once

### DIFF
--- a/packages/jest/src/migrations/update-14-0-0/update-jest-config-ext.ts
+++ b/packages/jest/src/migrations/update-14-0-0/update-jest-config-ext.ts
@@ -1,10 +1,10 @@
 import {
   formatFiles,
+  getProjects,
   joinPathFragments,
   logger,
   ProjectConfiguration,
   readJson,
-  readProjectConfiguration,
   stripIndents,
   Tree,
   updateJson,
@@ -112,11 +112,13 @@ export async function updateJestConfigExt(tree: Tree) {
     tree.rename('jest.config.js', 'jest.config.ts');
   }
 
+  const projects = getProjects(tree);
+
   forEachExecutorOptions<JestExecutorOptions>(
     tree,
     '@nrwl/jest:jest',
     (options, projectName, target, configuration) => {
-      const projectConfig = readProjectConfiguration(tree, projectName);
+      const projectConfig = projects.get(projectName);
 
       if (!options.jestConfig || !isJestConfigValid(tree, options)) {
         return;


### PR DESCRIPTION
readProjectConfiguration inside a foreach is slow in a large repo with many projects 
using getProjects before the loop and read it within performance much better

ISSUES CLOSED: #12051

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
