### PR TITLE
fix(bundling): default outputFileName to "main.js" when called from "…

### DIFF
--- a/packages/webpack/src/executors/webpack/lib/normalize-options.ts
+++ b/packages/webpack/src/executors/webpack/lib/normalize-options.ts
@@ -21,6 +21,7 @@ export function normalizeOptions(
     target: options.target ?? 'web',
     main: resolve(root, options.main),
     outputPath: resolve(root, options.outputPath),
+    outputFileName: options.outputFileName ?? 'main.js',
     tsConfig: resolve(root, options.tsConfig),
     fileReplacements: normalizeFileReplacements(root, options.fileReplacements),
     assets: normalizeAssets(options.assets, root, sourceRoot),


### PR DESCRIPTION
…@nrwl/web:webpack"

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
