### PR TITLE
feat(nx-plugin): pass env vars to asynccommand testing util

### DIFF
--- a/packages/nx-plugin/src/utils/testing-utils/async-commands.ts
+++ b/packages/nx-plugin/src/utils/testing-utils/async-commands.ts
@@ -20,7 +20,7 @@ export function runCommandAsync(
       command,
       {
         cwd: tmpProjPath(),
-        env: { ...process.env, ...(opts.env ? opts.env : {}) },
+        env: { ...process.env, ...opts.env},
       },
       (err, stdout, stderr) => {
         if (!opts.silenceError && err) {

--- a/packages/nx-plugin/src/utils/testing-utils/async-commands.ts
+++ b/packages/nx-plugin/src/utils/testing-utils/async-commands.ts
@@ -8,10 +8,11 @@ import { getPackageManagerCommand } from '@nrwl/devkit';
  * @param command
  * @param opts
  */
-export function runCommandAsync(
+ export function runCommandAsync(
   command: string,
-  opts = {
+  opts: { silenceError?: boolean; env?: NodeJS.ProcessEnv } = {
     silenceError: false,
+    env: {},
   }
 ): Promise<{ stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
@@ -19,6 +20,7 @@ export function runCommandAsync(
       command,
       {
         cwd: tmpProjPath(),
+        env: { ...process.env, ...(opts.env ? opts.env : {}) },
       },
       (err, stdout, stderr) => {
         if (!opts.silenceError && err) {
@@ -37,8 +39,9 @@ export function runCommandAsync(
  */
 export function runNxCommandAsync(
   command: string,
-  opts = {
+  opts: { silenceError?: boolean; env?: NodeJS.ProcessEnv } = {
     silenceError: false,
+    env: {},
   }
 ): Promise<{ stdout: string; stderr: string }> {
   const pmc = getPackageManagerCommand();

--- a/packages/nx-plugin/src/utils/testing-utils/async-commands.ts
+++ b/packages/nx-plugin/src/utils/testing-utils/async-commands.ts
@@ -20,7 +20,7 @@ export function runCommandAsync(
       command,
       {
         cwd: tmpProjPath(),
-        env: { ...process.env, ...opts.env},
+        env: { ...process.env, ...opts.env },
       },
       (err, stdout, stderr) => {
         if (!opts.silenceError && err) {

--- a/packages/nx-plugin/src/utils/testing-utils/async-commands.ts
+++ b/packages/nx-plugin/src/utils/testing-utils/async-commands.ts
@@ -8,7 +8,7 @@ import { getPackageManagerCommand } from '@nrwl/devkit';
  * @param command
  * @param opts
  */
- export function runCommandAsync(
+export function runCommandAsync(
   command: string,
   opts: { silenceError?: boolean; env?: NodeJS.ProcessEnv } = {
     silenceError: false,

--- a/packages/nx-plugin/src/utils/testing-utils/async-commands.ts
+++ b/packages/nx-plugin/src/utils/testing-utils/async-commands.ts
@@ -12,7 +12,6 @@ export function runCommandAsync(
   command: string,
   opts: { silenceError?: boolean; env?: NodeJS.ProcessEnv } = {
     silenceError: false,
-    env: {},
   }
 ): Promise<{ stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
@@ -41,7 +40,6 @@ export function runNxCommandAsync(
   command: string,
   opts: { silenceError?: boolean; env?: NodeJS.ProcessEnv } = {
     silenceError: false,
-    env: {},
   }
 ): Promise<{ stdout: string; stderr: string }> {
   const pmc = getPackageManagerCommand();

--- a/packages/nx-plugin/src/utils/testing-utils/commands.ts
+++ b/packages/nx-plugin/src/utils/testing-utils/commands.ts
@@ -13,7 +13,6 @@ export function runNxCommand(
   command?: string,
   opts: { silenceError?: boolean; env?: NodeJS.ProcessEnv } = {
     silenceError: false,
-    env: {},
   }
 ): string {
   try {
@@ -39,15 +38,13 @@ export function runNxCommand(
 
 export function runCommand(
   command: string,
-  opts: { env?: NodeJS.ProcessEnv } = {
-    env: {},
-  }
+  opts?: { env?: NodeJS.ProcessEnv }
 ): string {
   try {
     return execSync(command, {
       cwd: tmpProjPath(),
       stdio: ['pipe', 'pipe', 'pipe'],
-      env: { ...process.env, ...opts.env },
+      env: { ...process.env, ...opts?.env },
     }).toString();
   } catch (e) {
     return e.stdout.toString() + e.stderr.toString();

--- a/packages/nx-plugin/src/utils/testing-utils/commands.ts
+++ b/packages/nx-plugin/src/utils/testing-utils/commands.ts
@@ -11,14 +11,16 @@ import { getPackageManagerCommand } from '@nrwl/devkit';
  */
 export function runNxCommand(
   command?: string,
-  opts = {
+  opts: { silenceError?: boolean; env?: NodeJS.ProcessEnv } = {
     silenceError: false,
+    env: {},
   }
 ): string {
   try {
     const pmc = getPackageManagerCommand();
     return execSync(`${pmc.exec} nx ${command}`, {
       cwd: tmpProjPath(),
+      env: { ...process.env, ...opts.env },
     })
       .toString()
       .replace(
@@ -35,11 +37,17 @@ export function runNxCommand(
   }
 }
 
-export function runCommand(command: string): string {
+export function runCommand(
+  command: string,
+  opts: { env?: NodeJS.ProcessEnv } = {
+    env: {},
+  }
+): string {
   try {
     return execSync(command, {
       cwd: tmpProjPath(),
       stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, ...opts.env },
     }).toString();
   } catch (e) {
     return e.stdout.toString() + e.stderr.toString();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `runNxCommandAsync` function from `@nxkit/utils/testing` does not provide an easy option to define environment variables for that specific command run.

Using the `runCommandAsync` from the same package could be an alternative to this by prepending the desired variable in the command string

```typescript
await runCommandAsync('MY_ENV_VAR=1 npx nx myexecutor ${project}');
```
however, it will break consistency with the API used when invoking Nx commands across tests. Additionally, this alternative does not provide a good code readability unless using a utility to build that command prefix.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Being able to pass a key-value object with the environment variables that should be used for that Nx command execution. Example:

```typescript
// ...plugin e2e tests code
const result = await runNxCommandAsync(`myexecutor ${project}`, {
  env: {
    ONE_ENV_VAR: '1',
    OTHER_ENV_VAR: undefined,
    ANOTHER_ENV_VAR: 'other_value',
    YET_ANOTHER_ENV_VAR: 'other_value_x2',
  },
});
expect(result.stdout).toContain('Executor ran');
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #12076
