### PR TITLE
chore(graph): change ports for serving graph configs

### DIFF
--- a/graph/client-e2e/project.json
+++ b/graph/client-e2e/project.json
@@ -6,21 +6,23 @@
     "e2e-base": {
       "executor": "@nrwl/cypress:cypress",
       "options": {
-        "tsConfig": "graph/client-e2e/tsconfig.e2e.json",
-        "baseUrl": "http://localhost:4200"
+        "tsConfig": "graph/client-e2e/tsconfig.e2e.json"
       },
       "configurations": {
         "dev": {
           "cypressConfig": "graph/client-e2e/cypress.json",
-          "devServerTarget": "graph-client:serve"
+          "devServerTarget": "graph-client:serve",
+          "baseUrl": "http://localhost:4201"
         },
         "watch": {
           "cypressConfig": "graph/client-e2e/cypress-watch-mode.json",
-          "devServerTarget": "graph-client:serve:watch"
+          "devServerTarget": "graph-client:serve:watch",
+          "baseUrl": "http://localhost:4204"
         },
         "release": {
           "cypressConfig": "graph/client-e2e/cypress-release.json",
-          "devServerTarget": "graph-client:serve:release"
+          "devServerTarget": "graph-client:serve:release",
+          "baseUrl": "http://localhost:4203"
         }
       },
       "defaultConfiguration": "dev"

--- a/graph/client/project.json
+++ b/graph/client/project.json
@@ -104,16 +104,20 @@
       "executor": "@nrwl/webpack:dev-server",
       "configurations": {
         "dev": {
-          "buildTarget": "graph-client:build-base:dev"
+          "buildTarget": "graph-client:build-base:dev",
+          "port": 4201
         },
         "nx-console": {
-          "buildTarget": "graph-client:build-base:nx-console"
+          "buildTarget": "graph-client:build-base:nx-console",
+          "port": 4202
         },
         "release": {
-          "buildTarget": "graph-client:build-base:release"
+          "buildTarget": "graph-client:build-base:release",
+          "port": 4203
         },
         "watch": {
-          "buildTarget": "graph-client:build-base:watch"
+          "buildTarget": "graph-client:build-base:watch",
+          "port": 4204
         }
       },
       "defaultConfiguration": "dev"


### PR DESCRIPTION
## Current Behavior
* `e2e-graph-client` runs tests while serving on port 4200, which can conflict with some of the other e2e suites for Nx.

## Expected Behavior
* `e2e-graph-client` runs tests on ports other than 4200.
