### PR TITLE
fix(webpack): add check if scripts exist or fallback to empty array

### DIFF
--- a/packages/webpack/src/utils/webpack/partials/common.ts
+++ b/packages/webpack/src/utils/webpack/partials/common.ts
@@ -92,7 +92,7 @@ export function getCommonConfig(
 
   // process global scripts
   const globalScriptsByBundleName = normalizeExtraEntryPoints(
-    buildOptions.scripts,
+    buildOptions.scripts || [],
     'scripts'
   ).reduce(
     (


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When I use `@nrwl/node:webpack` as executor, the build fails because of undefined `buildOptions.scripts`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The build can be built using the `@nrwl/node:webpack` executor.
