### PR TITLE
fix(js): use path to `rootDir` when update package.json

### DIFF
--- a/packages/js/src/executors/tsc/tsc.impl.spec.ts
+++ b/packages/js/src/executors/tsc/tsc.impl.spec.ts
@@ -23,9 +23,9 @@ describe('tscExecutor', () => {
       targetName: 'build',
     };
     testOptions = {
-      main: 'libs/ui/src/index.ts',
-      outputPath: 'dist/libs/ui',
-      tsConfig: 'libs/ui/tsconfig.json',
+      main: 'libs/example/src/index.ts',
+      outputPath: 'dist/libs/example',
+      tsConfig: 'libs/example/tsconfig.json',
       assets: [],
       transformers: [],
       watch: false,
@@ -39,18 +39,18 @@ describe('tscExecutor', () => {
         normalizeOptions(
           testOptions,
           '/root',
-          '/root/libs/ui/src',
-          '/root/libs/ui'
+          '/root/libs/example/src',
+          '/root/libs/example'
         ),
         context
       );
 
       expect(result).toMatchObject({
-        outputPath: '/root/dist/libs/ui',
+        outputPath: '/root/dist/libs/example',
         projectName: 'example',
-        projectRoot: '/root/libs/ui',
-        rootDir: '/root/libs/ui',
-        tsConfig: '/root/libs/ui/tsconfig.json',
+        projectRoot: '/root/libs/example',
+        rootDir: '/root/libs/example',
+        tsConfig: '/root/libs/example/tsconfig.json',
         watch: false,
         deleteOutputPath: true,
       });
@@ -59,16 +59,16 @@ describe('tscExecutor', () => {
     it('should handle custom rootDir', () => {
       const result = createTypeScriptCompilationOptions(
         normalizeOptions(
-          { ...testOptions, rootDir: 'libs/ui/src' },
+          { ...testOptions, rootDir: 'libs/example/src' },
           '/root',
-          '/root/libs/ui/src',
-          '/root/libs/ui'
+          '/root/libs/example/src',
+          '/root/libs/example'
         ),
         context
       );
 
       expect(result).toMatchObject({
-        rootDir: '/root/libs/ui/src',
+        rootDir: '/root/libs/example/src',
       });
     });
   });

--- a/packages/js/src/utils/package-json/index.ts
+++ b/packages/js/src/utils/package-json/index.ts
@@ -8,7 +8,7 @@ import { updatePackageJson } from './update-package-json';
 import { checkDependencies } from '../check-dependencies';
 
 export interface CopyPackageJsonOptions
-  extends Omit<UpdatePackageJsonOption, 'projectRoot'> {
+  extends Omit<UpdatePackageJsonOption, 'projectRoot' | 'rootDir'> {
   watch?: boolean;
   extraDependencies?: DependentBuildableProjectNode[];
 }
@@ -32,7 +32,7 @@ export async function copyPackageJson(
     context,
     context.target.options.tsConfig
   );
-  const options = { ..._options, projectRoot };
+  const options = { ..._options, projectRoot, rootDir: projectRoot };
   if (options.extraDependencies?.length) {
     dependencies.push(...options.extraDependencies);
   }

--- a/packages/js/src/utils/package-json/update-package-json.spec.ts
+++ b/packages/js/src/utils/package-json/update-package-json.spec.ts
@@ -1,18 +1,28 @@
-import { getUpdatedPackageJsonContent } from './update-package-json';
+import {
+  getUpdatedPackageJsonContent,
+  UpdatePackageJsonOption,
+} from './update-package-json';
+import type { PackageJson } from 'nx/src/utils/package-json';
 
 describe('getUpdatedPackageJsonContent', () => {
+  let packageJson: PackageJson;
+  let testOptions: UpdatePackageJsonOption;
+
+  beforeEach(async () => {
+    packageJson = {
+      name: 'test',
+      version: '0.0.1',
+    };
+    testOptions = {
+      main: 'proj/src/index.ts',
+      outputPath: 'dist/proj',
+      projectRoot: 'proj',
+      rootDir: 'proj',
+    };
+  });
+
   it('should update fields for commonjs only (default)', () => {
-    const json = getUpdatedPackageJsonContent(
-      {
-        name: 'test',
-        version: '0.0.1',
-      },
-      {
-        main: 'proj/src/index.ts',
-        outputPath: 'dist/proj',
-        projectRoot: 'proj',
-      }
-    );
+    const json = getUpdatedPackageJsonContent(packageJson, testOptions);
 
     expect(json).toEqual({
       name: 'test',
@@ -22,21 +32,27 @@ describe('getUpdatedPackageJsonContent', () => {
     });
   });
 
-  it('should update fields for esm only', () => {
-    const json = getUpdatedPackageJsonContent(
-      {
-        name: 'test',
-        version: '0.0.1',
-      },
-      {
-        main: 'proj/src/index.ts',
-        outputPath: 'dist/proj',
-        projectRoot: 'proj',
-        format: ['esm'],
-      }
-    );
+  it('should support custom rootDir', () => {
+    const json = getUpdatedPackageJsonContent(packageJson, {
+      ...testOptions,
+      rootDir: 'proj/src',
+    });
 
     expect(json).toEqual({
+      name: 'test',
+      main: './index.js',
+      types: './index.d.ts',
+      version: '0.0.1',
+    });
+  });
+
+  it('should update fields for esm only', () => {
+    const json = getUpdatedPackageJsonContent(packageJson, {
+      ...testOptions,
+      format: ['esm'],
+    });
+
+    expect(json).toMatchObject({
       name: 'test',
       type: 'module',
       module: './src/index.js',
@@ -47,18 +63,10 @@ describe('getUpdatedPackageJsonContent', () => {
   });
 
   it('should update fields for commonjs + esm', () => {
-    const json = getUpdatedPackageJsonContent(
-      {
-        name: 'test',
-        version: '0.0.1',
-      },
-      {
-        main: 'proj/src/index.ts',
-        outputPath: 'dist/proj',
-        projectRoot: 'proj',
-        format: ['esm', 'cjs'],
-      }
-    );
+    const json = getUpdatedPackageJsonContent(packageJson, {
+      ...testOptions,
+      format: ['esm', 'cjs'],
+    });
 
     expect(json).toEqual({
       name: 'test',
@@ -70,18 +78,10 @@ describe('getUpdatedPackageJsonContent', () => {
   });
 
   it('should support skipping types', () => {
-    const json = getUpdatedPackageJsonContent(
-      {
-        name: 'test',
-        version: '0.0.1',
-      },
-      {
-        main: 'proj/src/index.ts',
-        outputPath: 'dist/proj',
-        projectRoot: 'proj',
-        skipTypings: true,
-      }
-    );
+    const json = getUpdatedPackageJsonContent(packageJson, {
+      ...testOptions,
+      skipTypings: true,
+    });
 
     expect(json).toEqual({
       name: 'test',
@@ -91,19 +91,11 @@ describe('getUpdatedPackageJsonContent', () => {
   });
 
   it('should support generated exports field', () => {
-    const json = getUpdatedPackageJsonContent(
-      {
-        name: 'test',
-        version: '0.0.1',
-      },
-      {
-        main: 'proj/src/index.ts',
-        outputPath: 'dist/proj',
-        projectRoot: 'proj',
-        format: ['esm'],
-        generateExportsField: true,
-      }
-    );
+    const json = getUpdatedPackageJsonContent(packageJson, {
+      ...testOptions,
+      format: ['esm'],
+      generateExportsField: true,
+    });
 
     expect(json).toEqual({
       name: 'test',
@@ -119,20 +111,12 @@ describe('getUpdatedPackageJsonContent', () => {
   });
 
   it('should support different CJS file extension', () => {
-    const json = getUpdatedPackageJsonContent(
-      {
-        name: 'test',
-        version: '0.0.1',
-      },
-      {
-        main: 'proj/src/index.ts',
-        outputPath: 'dist/proj',
-        projectRoot: 'proj',
-        format: ['esm', 'cjs'],
-        outputFileExtensionForCjs: '.cjs',
-        generateExportsField: true,
-      }
-    );
+    const json = getUpdatedPackageJsonContent(packageJson, {
+      ...testOptions,
+      format: ['esm', 'cjs'],
+      outputFileExtensionForCjs: '.cjs',
+      generateExportsField: true,
+    });
 
     expect(json).toEqual({
       name: 'test',
@@ -147,18 +131,10 @@ describe('getUpdatedPackageJsonContent', () => {
   });
 
   it('should not set types when { skipTypings: true }', () => {
-    const json = getUpdatedPackageJsonContent(
-      {
-        name: 'test',
-        version: '0.0.1',
-      },
-      {
-        main: 'proj/src/index.ts',
-        outputPath: 'dist/proj',
-        projectRoot: 'proj',
-        skipTypings: true,
-      }
-    );
+    const json = getUpdatedPackageJsonContent(packageJson, {
+      ...testOptions,
+      skipTypings: true,
+    });
 
     expect(json).toEqual({
       name: 'test',

--- a/packages/js/src/utils/package-json/update-package-json.ts
+++ b/packages/js/src/utils/package-json/update-package-json.ts
@@ -13,12 +13,12 @@ import { basename, dirname, join, parse, relative } from 'path';
 import { fileExists } from 'nx/src/utils/fileutils';
 import type { PackageJson } from 'nx/src/utils/package-json';
 
-function getMainFileDirRelativeToProjectRoot(
+function getMainFileDirRelativeToRootDir(
   main: string,
-  projectRoot: string
+  rootDir: string
 ): string {
   const mainFileDir = dirname(main);
-  const relativeDir = normalizePath(relative(projectRoot, mainFileDir));
+  const relativeDir = normalizePath(relative(rootDir, mainFileDir));
   return relativeDir === '' ? `./` : `./${relativeDir}/`;
 }
 
@@ -26,6 +26,7 @@ export type SupportedFormat = 'cjs' | 'esm';
 
 export interface UpdatePackageJsonOption {
   projectRoot: string;
+  rootDir: string;
   main: string;
   format?: SupportedFormat[];
   outputPath: string;
@@ -83,9 +84,9 @@ export function getUpdatedPackageJsonContent(
   const hasEsmFormat = options.format?.includes('esm');
 
   const mainFile = basename(options.main).replace(/\.[tj]s$/, '');
-  const relativeMainFileDir = getMainFileDirRelativeToProjectRoot(
+  const relativeMainFileDir = getMainFileDirRelativeToRootDir(
     options.main,
-    options.projectRoot
+    options.rootDir
   );
   const typingsFile = `${relativeMainFileDir}${mainFile}.d.ts`;
   const exports = {

--- a/packages/js/src/utils/schema.d.ts
+++ b/packages/js/src/utils/schema.d.ts
@@ -53,6 +53,7 @@ export interface NormalizedExecutorOptions extends ExecutorOptions {
   root?: string;
   sourceRoot?: string;
   projectRoot: string;
+  rootDir: string;
   mainOutputPath: string;
   files: Array<FileInputOutput>;
 }


### PR DESCRIPTION
fix path when set rootDir
![image](https://user-images.githubusercontent.com/64340763/191190654-475e8e79-9d55-4921-9fe7-62a4e301c9a8.png)
