### PR TITLE
docs(nx-cloud): update no-helm repository link

### DIFF
--- a/docs/nx-cloud/private/get-started.md
+++ b/docs/nx-cloud/private/get-started.md
@@ -15,7 +15,7 @@ documented.
 ## Resources
 
 - [Nx Cloud K8s Example + All Config Options](https://github.com/nrwl/nx-cloud-helm)
-- [Nx Cloud K8s Example + All Config Options (no Helm)](https://github.com/nrwl/nx-cloud-helm/no-helm)
+- [Nx Cloud K8s Example + All Config Options (no Helm)](https://github.com/nrwl/nx-cloud-helm/tree/main/no-helm)
 - [Standalone Container](/nx-cloud/private-cloud/standalone)
 - [GitHub PR Integration](/nx-cloud/private-cloud/github)
 - [Auth (Basic)](/nx-cloud/private-cloud/auth-single-admin)


### PR DESCRIPTION
It changes the no-heml repository link installation for nx-cloud on nx.dev.