### PR TITLE
feat(nx-plugin): allow skipping the creation of an e2e project

### DIFF
--- a/docs/generated/packages/nx-plugin.json
+++ b/docs/generated/packages/nx-plugin.json
@@ -80,6 +80,11 @@
             "default": false,
             "description": "Do not eslint configuration for plugin json files."
           },
+          "skipE2eProject": {
+            "type": "boolean",
+            "default": false,
+            "description": "Do not add an e2e test project."
+          },
           "standaloneConfig": {
             "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
             "type": "boolean"

--- a/docs/generated/packages/nx-plugin.json
+++ b/docs/generated/packages/nx-plugin.json
@@ -80,10 +80,11 @@
             "default": false,
             "description": "Do not eslint configuration for plugin json files."
           },
-          "skipE2eProject": {
-            "type": "boolean",
-            "default": false,
-            "description": "Do not add an e2e test project."
+          "e2eTestRunner": {
+            "type": "string",
+            "enum": ["jest", "none"],
+            "description": "Test runner to use for end to end (E2E) tests.",
+            "default": "jest"
           },
           "standaloneConfig": {
             "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",

--- a/packages/nx-plugin/src/generators/executor/files/executor/__fileName__/executor.ts__tmpl__
+++ b/packages/nx-plugin/src/generators/executor/files/executor/__fileName__/executor.ts__tmpl__
@@ -3,9 +3,9 @@ import { <%= className %>ExecutorSchema } from './schema';
 export default async function runExecutor(
   options: <%= className %>ExecutorSchema,
 ) {
-  console.log('Executor ran for <%= className %>', options)
+  console.log('Executor ran for <%= className %>', options);
   return {
     success: true
-  }
+  };
 }
 

--- a/packages/nx-plugin/src/generators/generator/files/generator/__fileName__/generator.spec.ts__tmpl__
+++ b/packages/nx-plugin/src/generators/generator/files/generator/__fileName__/generator.spec.ts__tmpl__
@@ -16,5 +16,5 @@ describe('<%= name %> generator', () => {
     await generator(appTree, options);
     const config = readProjectConfiguration(appTree, 'test');
     expect(config).toBeDefined();
-  })
+  });
 });

--- a/packages/nx-plugin/src/generators/generator/files/generator/__fileName__/generator.ts__tmpl__
+++ b/packages/nx-plugin/src/generators/generator/files/generator/__fileName__/generator.ts__tmpl__
@@ -14,7 +14,7 @@ interface NormalizedSchema extends <%= className %>GeneratorSchema {
   projectName: string;
   projectRoot: string;
   projectDirectory: string;
-  parsedTags: string[]
+  parsedTags: string[];
 }
 
 function normalizeOptions(tree: Tree, options: <%= className %>GeneratorSchema): NormalizedSchema {

--- a/packages/nx-plugin/src/generators/plugin/plugin.spec.ts
+++ b/packages/nx-plugin/src/generators/plugin/plugin.spec.ts
@@ -1,13 +1,14 @@
-import { pluginGenerator } from './plugin';
 import {
-  Tree,
-  readProjectConfiguration,
-  readJson,
+  getProjects,
   joinPathFragments,
+  readJson,
+  readProjectConfiguration,
+  Tree,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import { Schema } from './schema';
 import { Linter } from '@nrwl/linter';
+import { pluginGenerator } from './plugin';
+import { Schema } from './schema';
 
 const getSchema: (overrides?: Partial<Schema>) => Schema = (
   overrides = {}
@@ -265,6 +266,14 @@ describe('NxPlugin Plugin Generator', () => {
       );
 
       expect(name).toEqual('@my-company/my-plugin');
+    });
+  });
+
+  describe('--skipE2eProject', () => {
+    it('should allow the e2e project to be skipped', async () => {
+      await pluginGenerator(tree, getSchema({ skipE2eProject: true }));
+      const projects = getProjects(tree);
+      expect(projects.has('plugins-my-plugin-e2e')).toBe(false);
     });
   });
 });

--- a/packages/nx-plugin/src/generators/plugin/plugin.spec.ts
+++ b/packages/nx-plugin/src/generators/plugin/plugin.spec.ts
@@ -1,4 +1,3 @@
-import { pluginGenerator } from './plugin';
 import {
   getProjects,
   joinPathFragments,
@@ -7,8 +6,9 @@ import {
   Tree,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import { Schema } from './schema';
 import { Linter } from '@nrwl/linter';
+import { pluginGenerator } from './plugin';
+import { Schema } from './schema';
 
 const getSchema: (overrides?: Partial<Schema>) => Schema = (
   overrides = {}
@@ -269,9 +269,9 @@ describe('NxPlugin Plugin Generator', () => {
     });
   });
 
-  describe('--skipE2eProject', () => {
+  describe('--e2eTestRunner', () => {
     it('should allow the e2e project to be skipped', async () => {
-      await pluginGenerator(tree, getSchema({ skipE2eProject: true }));
+      await pluginGenerator(tree, getSchema({ e2eTestRunner: 'none' }));
       const projects = getProjects(tree);
       expect(projects.has('plugins-my-plugin-e2e')).toBe(false);
     });

--- a/packages/nx-plugin/src/generators/plugin/plugin.spec.ts
+++ b/packages/nx-plugin/src/generators/plugin/plugin.spec.ts
@@ -1,3 +1,4 @@
+import { pluginGenerator } from './plugin';
 import {
   getProjects,
   joinPathFragments,
@@ -6,9 +7,8 @@ import {
   Tree,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import { Linter } from '@nrwl/linter';
-import { pluginGenerator } from './plugin';
 import { Schema } from './schema';
+import { Linter } from '@nrwl/linter';
 
 const getSchema: (overrides?: Partial<Schema>) => Schema = (
   overrides = {}

--- a/packages/nx-plugin/src/generators/plugin/plugin.ts
+++ b/packages/nx-plugin/src/generators/plugin/plugin.ts
@@ -116,7 +116,7 @@ export async function pluginGenerator(host: Tree, schema: Schema) {
   await addFiles(host, options);
   updateWorkspaceJson(host, options);
 
-  if (options.skipE2eProject !== true) {
+  if (options.e2eTestRunner !== 'none') {
     await e2eProjectGenerator(host, {
       pluginName: options.name,
       projectDirectory: options.projectDirectory,

--- a/packages/nx-plugin/src/generators/plugin/plugin.ts
+++ b/packages/nx-plugin/src/generators/plugin/plugin.ts
@@ -10,8 +10,8 @@ import {
   updateProjectConfiguration,
 } from '@nrwl/devkit';
 import { libraryGenerator } from '@nrwl/js';
-import { Linter } from '@nrwl/linter';
 import { addSwcDependencies } from '@nrwl/js/src/utils/swc/add-swc-dependencies';
+import { Linter } from '@nrwl/linter';
 import { swcNodeVersion } from 'nx/src/utils/versions';
 import * as path from 'path';
 
@@ -115,14 +115,18 @@ export async function pluginGenerator(host: Tree, schema: Schema) {
 
   await addFiles(host, options);
   updateWorkspaceJson(host, options);
-  await e2eProjectGenerator(host, {
-    pluginName: options.name,
-    projectDirectory: options.projectDirectory,
-    pluginOutputPath: `dist/${options.libsDir}/${options.projectDirectory}`,
-    npmPackageName: options.npmPackageName,
-    standaloneConfig: options.standaloneConfig ?? true,
-    minimal: options.minimal ?? false,
-  });
+
+  if (options.skipE2eProject !== true) {
+    await e2eProjectGenerator(host, {
+      pluginName: options.name,
+      projectDirectory: options.projectDirectory,
+      pluginOutputPath: `dist/${options.libsDir}/${options.projectDirectory}`,
+      npmPackageName: options.npmPackageName,
+      standaloneConfig: options.standaloneConfig ?? true,
+      minimal: options.minimal ?? false,
+    });
+  }
+
   if (options.linter === Linter.EsLint && !options.skipLintChecks) {
     await pluginLintCheckGenerator(host, { projectName: options.name });
   }

--- a/packages/nx-plugin/src/generators/plugin/schema.d.ts
+++ b/packages/nx-plugin/src/generators/plugin/schema.d.ts
@@ -7,6 +7,7 @@ export interface Schema {
   skipTsConfig: boolean;
   skipFormat: boolean;
   skipLintChecks: boolean;
+  skipE2eProject?: boolean;
   tags?: string;
   unitTestRunner: 'jest' | 'none';
   linter: Linter;

--- a/packages/nx-plugin/src/generators/plugin/schema.d.ts
+++ b/packages/nx-plugin/src/generators/plugin/schema.d.ts
@@ -7,7 +7,7 @@ export interface Schema {
   skipTsConfig: boolean;
   skipFormat: boolean;
   skipLintChecks: boolean;
-  skipE2eProject?: boolean;
+  e2eTestRunner?: 'jest' | 'none';
   tags?: string;
   unitTestRunner: 'jest' | 'none';
   linter: Linter;

--- a/packages/nx-plugin/src/generators/plugin/schema.json
+++ b/packages/nx-plugin/src/generators/plugin/schema.json
@@ -63,6 +63,11 @@
       "default": false,
       "description": "Do not eslint configuration for plugin json files."
     },
+    "skipE2eProject": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not add an e2e test project."
+    },
     "standaloneConfig": {
       "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
       "type": "boolean"

--- a/packages/nx-plugin/src/generators/plugin/schema.json
+++ b/packages/nx-plugin/src/generators/plugin/schema.json
@@ -63,10 +63,11 @@
       "default": false,
       "description": "Do not eslint configuration for plugin json files."
     },
-    "skipE2eProject": {
-      "type": "boolean",
-      "default": false,
-      "description": "Do not add an e2e test project."
+    "e2eTestRunner": {
+      "type": "string",
+      "enum": ["jest", "none"],
+      "description": "Test runner to use for end to end (E2E) tests.",
+      "default": "jest"
     },
     "standaloneConfig": {
       "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently there is no option to skip the creation of an E2E project when generating an Nx Plugin.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Ideally the creation of an e2e project should be optional.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

N/A
