### PR TITLE
feat(js): inline non-buildbale

### DIFF
--- a/docs/generated/packages/js.json
+++ b/docs/generated/packages/js.json
@@ -314,6 +314,18 @@
             "description": "When `updateBuildableProjectDepsInPackageJson` is `true`, this adds dependencies to either `peerDependencies` or `dependencies`.",
             "enum": ["dependencies", "peerDependencies"],
             "default": "peerDependencies"
+          },
+          "external": {
+            "type": "string",
+            "description": "A list projects to be treated as external.",
+            "enum": ["all", "none"],
+            "default": "all"
+          },
+          "externalBuildTargets": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "List of target names that annotate a build target for a project",
+            "default": ["build"]
           }
         },
         "required": ["main", "outputPath", "tsConfig"],

--- a/e2e/js/src/js.test.ts
+++ b/e2e/js/src/js.test.ts
@@ -303,6 +303,42 @@ export function ${lib}Wildcard() {
     );
   }, 120000);
 
+  it.only('should inline non-buildable libraries with --external=all', async () => {
+    const parent = uniq('parent');
+    runCLI(`generate @nrwl/js:lib ${parent}`);
+
+    const buildable = uniq('buildable');
+    runCLI(`generate @nrwl/js:lib ${buildable}`);
+
+    const nonBuildable = uniq('nonbuildable');
+    runCLI(`generate @nrwl/js:lib ${nonBuildable} --buildable=false`);
+
+    updateFile(`libs/${parent}/src/lib/${parent}.ts`, () => {
+      return `
+import { ${buildable} } from '@${scope}/${buildable}';
+import { ${nonBuildable} } from '@${scope}/${nonBuildable}';
+
+export function ${parent}() {
+  ${buildable}();
+  ${nonBuildable}();
+}
+        `;
+    });
+
+    expect(runCLI(`build ${parent}`)).toContain(
+      'Done compiling TypeScript files'
+    );
+
+    checkFilesExist(
+      `dist/libs/${buildable}/src/index.js`, // buildable
+      `dist/libs/${parent}/src/index.js`, // parent
+      `dist/libs/${parent}/${nonBuildable}/src/index.js` // non buildable
+    );
+
+    const fileContent = readFile(`dist/libs/${parent}/src/lib/${parent}.js`);
+    expect(fileContent).toContain(`${nonBuildable}/src`);
+  }, 120000);
+
   it('should not create a `.babelrc` file when creating libs with js executors (--compiler=tsc)', () => {
     const lib = uniq('lib');
     runCLI(

--- a/e2e/node/src/node.test.ts
+++ b/e2e/node/src/node.test.ts
@@ -481,11 +481,10 @@ describe('nest libraries', function () {
   }, 200000);
 
   it('should have plugin output if specified in `transformers`', async () => {
-    newProject();
     const nestlib = uniq('nestlib');
     runCLI(`generate @nrwl/nest:lib ${nestlib} --buildable`);
 
-    packageInstall('@nestjs/swagger', undefined, '~5.0.0');
+    packageInstall('@nestjs/swagger', undefined, '^6.0.0');
 
     updateProjectConfig(nestlib, (config) => {
       config.targets.build.options.transformers = [
@@ -508,7 +507,7 @@ export class FooModel {
 }`
     );
 
-    await runCLIAsync(`build ${nestlib}`);
+    runCLI(`build ${nestlib}`);
 
     const fooModelJs = readFile(`dist/libs/${nestlib}/src/lib/foo.model.js`);
     expect(stripIndents`${fooModelJs}`).toContain(
@@ -518,13 +517,13 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.FooModel = void 0;
 const openapi = require("@nestjs/swagger");
 class FooModel {
-    static _OPENAPI_METADATA_FACTORY() {
-        return { foo: { required: true, type: () => String }, bar: { required: true, type: () => Number } };
-    }
+  static _OPENAPI_METADATA_FACTORY() {
+      return { foo: { required: true, type: () => String }, bar: { required: true, type: () => Number } };
+  }
 }
 exports.FooModel = FooModel;
 //# sourceMappingURL=foo.model.js.map
-        `
+            `
     );
   }, 300000);
 

--- a/packages/js/src/executors/tsc/schema.json
+++ b/packages/js/src/executors/tsc/schema.json
@@ -61,6 +61,20 @@
       "description": "When `updateBuildableProjectDepsInPackageJson` is `true`, this adds dependencies to either `peerDependencies` or `dependencies`.",
       "enum": ["dependencies", "peerDependencies"],
       "default": "peerDependencies"
+    },
+    "external": {
+      "type": "string",
+      "description": "A list projects to be treated as external.",
+      "enum": ["all", "none"],
+      "default": "all"
+    },
+    "externalBuildTargets": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "List of target names that annotate a build target for a project",
+      "default": ["build"]
     }
   },
   "required": ["main", "outputPath", "tsConfig"],

--- a/packages/js/src/executors/tsc/tsc.impl.spec.ts
+++ b/packages/js/src/executors/tsc/tsc.impl.spec.ts
@@ -1,8 +1,8 @@
 import { ExecutorContext } from '@nrwl/devkit';
 import { ExecutorOptions } from '../../utils/schema';
 import {
-  normalizeOptions,
   createTypeScriptCompilationOptions,
+  normalizeOptions,
 } from './tsc.impl';
 
 describe('tscExecutor', () => {

--- a/packages/js/src/utils/inline.ts
+++ b/packages/js/src/utils/inline.ts
@@ -1,0 +1,179 @@
+import type { ExecutorContext, ProjectGraphProjectNode } from '@nrwl/devkit';
+import { logger, readJsonFile } from '@nrwl/devkit';
+import type { TypeScriptCompilationOptions } from '@nrwl/workspace/src/utilities/typescript/compilation';
+import {
+  copySync,
+  readdirSync,
+  readFileSync,
+  removeSync,
+  writeFileSync,
+} from 'fs-extra';
+import { join, relative } from 'path';
+import type { NormalizedExecutorOptions } from './schema';
+
+export function handleInliningBuild(
+  context: ExecutorContext,
+  options: NormalizedExecutorOptions,
+  tsConfigPath: string
+): Array<ProjectGraphProjectNode & { pathAlias: string }> {
+  const projectDependencies =
+    context.projectGraph.dependencies[context.projectName];
+  const dependencies: Array<{ name: string; path: string }> = [];
+
+  if (projectDependencies && projectDependencies.length) {
+    const tsConfigJson = readJsonFile(tsConfigPath);
+
+    // handle inlining
+    // 1. figure out a list of dependencies that need to be inlined
+    for (const projectDependency of projectDependencies) {
+      // skip npm packages
+      if (projectDependency.target.startsWith('npm')) {
+        continue;
+      }
+
+      let shouldInline = false;
+      if (options.external === 'all') {
+        /**
+         * if all buildable libraries are marked as external,
+         * then push the project dependency that doesn't have a build target
+         */
+        if (!hasBuildTarget(projectDependency.target, context, options)) {
+          shouldInline = true;
+        }
+      } else if (options.external === 'none') {
+        /**
+         * if all buildable libraries are marked as internal,
+         * then push every project dependency to be inlined
+         */
+        shouldInline = true;
+      }
+
+      if (shouldInline) {
+        dependencies.push({
+          name: projectDependency.target,
+          path: getPathAliasForPackage(
+            context.projectGraph.nodes[projectDependency.target],
+            tsConfigJson['compilerOptions']['paths']
+          ),
+        });
+      }
+    }
+
+    // 2. adjust rootDir of tmp tsConfig if we have dependencies to inline
+    if (dependencies.length > 0) {
+      logger.log(
+        'List of dependencies to be inlined:',
+        JSON.stringify(dependencies, null, 2)
+      );
+    }
+  }
+  return dependencies.map((dependency) => ({
+    ...context.projectGraph.nodes[dependency.name],
+    pathAlias: dependency.path,
+  }));
+}
+
+export function postProcessInlinedDependencies(
+  tsCompilationOptions: TypeScriptCompilationOptions,
+  inlinedDependencies: Array<ProjectGraphProjectNode & { pathAlias: string }>
+) {
+  if (inlinedDependencies.length === 0) {
+    return;
+  }
+
+  const destOutputPath = tsCompilationOptions.outputPath;
+  const parentLibDir = tsCompilationOptions.projectRoot;
+
+  const parentOutputPath = join(destOutputPath, parentLibDir);
+
+  // move parentOutput
+  movePackage(parentOutputPath, destOutputPath);
+
+  const inlinedDepsDestOutputRecord: Record<string, string> = {};
+  // move inlined outputs
+  for (const inlinedDependency of inlinedDependencies) {
+    const depOutputPath = join(destOutputPath, inlinedDependency.data.root);
+    const destDepOutputPath = join(destOutputPath, inlinedDependency.name);
+    movePackage(depOutputPath, destDepOutputPath);
+
+    // TODO: hard-coded "src"
+    inlinedDepsDestOutputRecord[inlinedDependency.pathAlias] =
+      destDepOutputPath + '/src';
+  }
+
+  updateImports(destOutputPath, inlinedDepsDestOutputRecord);
+}
+
+function movePackage(from: string, to: string) {
+  copySync(from, to, { overwrite: true, recursive: true });
+  removeSync(from);
+}
+
+function updateImports(
+  destOutputPath: string,
+  inlinedDepsDestOutputRecord: Record<string, string>
+) {
+  const importRegex = new RegExp(
+    Object.keys(inlinedDepsDestOutputRecord).join('|'),
+    'g'
+  );
+  recursiveUpdateImport(
+    destOutputPath + '/src',
+    importRegex,
+    inlinedDepsDestOutputRecord
+  );
+}
+
+function recursiveUpdateImport(
+  dirPath: string,
+  importRegex: RegExp,
+  inlinedDepsDestOutputRecord: Record<string, string>
+) {
+  const files = readdirSync(dirPath, { withFileTypes: true });
+  for (const file of files) {
+    // only check .js and .d.ts files
+    if (
+      file.isFile() &&
+      (file.name.endsWith('.js') || file.name.endsWith('.d.ts'))
+    ) {
+      const filePath = join(dirPath, file.name);
+      const fileContent = readFileSync(filePath, 'utf-8');
+      const updatedContent = fileContent.replace(importRegex, (matched) =>
+        relative(dirPath, inlinedDepsDestOutputRecord[matched])
+      );
+      writeFileSync(filePath, updatedContent);
+    } else if (file.isDirectory()) {
+      recursiveUpdateImport(
+        join(dirPath, file.name),
+        importRegex,
+        inlinedDepsDestOutputRecord
+      );
+    }
+  }
+}
+
+function getPathAliasForPackage(
+  packageNode: ProjectGraphProjectNode,
+  pathAliases: Record<string, string[]>
+): string {
+  if (!packageNode) return '';
+
+  for (const [alias, paths] of Object.entries(pathAliases)) {
+    if (paths.some((path) => path.includes(packageNode.data.root))) {
+      return alias;
+    }
+  }
+
+  return '';
+}
+
+function hasBuildTarget(
+  projectName: string,
+  context: ExecutorContext,
+  options: NormalizedExecutorOptions
+): boolean {
+  return options.externalBuildTargets.some(
+    (buildTarget) =>
+      context.projectGraph.nodes[projectName]?.data?.targets?.[buildTarget]
+  );
+}

--- a/packages/js/src/utils/schema.d.ts
+++ b/packages/js/src/utils/schema.d.ts
@@ -45,6 +45,8 @@ export interface ExecutorOptions {
   transformers: TransformerEntry[];
   updateBuildableProjectDepsInPackageJson?: boolean;
   buildableProjectDepsInPackageJsonType?: 'dependencies' | 'peerDependencies';
+  external?: 'all' | 'none';
+  externalBuildTargets?: string[];
 }
 
 export interface NormalizedExecutorOptions extends ExecutorOptions {


### PR DESCRIPTION
## Current Behavior
`nrwl/js:lib` cannot utilize non-buildable libraries in the workspace (aka workspace libraries) without them being published/built properly

## Expected Behavior
`nrwl/js:lib` can utilize non-buildable workspace libraries