### PR TITLE
fix(react-native): fix xcode shell script used for release builds

### DIFF
--- a/packages/react-native/src/generators/application/files/app/ios/.xcode.env.template
+++ b/packages/react-native/src/generators/application/files/app/ios/.xcode.env.template
@@ -9,4 +9,4 @@
 # For example, to use nvm with brew, add the following line
 # . "$(brew --prefix nvm)/nvm.sh" --no-use
 export NODE_BINARY=$(command -v node)
-export ENTRY_FILE="$(PROJECT_DIR)/../<%= entryFile %>"
+export ENTRY_FILE="${PROJECT_DIR}/../<%= entryFile %>"


### PR DESCRIPTION
ISSUES CLOSED: #12166

## Current Behavior
Xcode release configuration fails to run and the product fails to archive. The fatal error reads:

>  ...main.jsbundle does not exist...

The important clue is earlier in the output:

> apps/mobile/ios/Pods/../.xcode.env: line 12: PROJECT_DIR: command not found


## Expected Behavior
The release configuration works and the product archives.
 
## Related Issue(s)
Fixes #12166
