### PR TITLE
fix(esbuild): remove explicit root dir from typecheck

### DIFF
--- a/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
+++ b/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
@@ -164,7 +164,6 @@ function getTypeCheckOptions(
     tsConfigPath: tsConfig,
     outDir: outputPath,
     workspaceRoot: root,
-    rootDir: projectRoot,
   };
 
   if (watch) {


### PR DESCRIPTION
Setting `projectRoot` explicitly causes the annoying TS6059 error. Without it things work perfectly.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Cannot use workspace packages in a package built by esbuild, get TS6059 errors.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Should be able to use other packages in workspace easily.
