### PR TITLE
docs(storybook): update storybook host library config step

### DIFF
--- a/docs/shared/recipes/one-storybook-for-all.md
+++ b/docs/shared/recipes/one-storybook-for-all.md
@@ -26,7 +26,7 @@ Now, you have a new library, which will act as a shell/host for all your stories
 Now let’s configure our new library to use Storybook, using the [`@nrwl/storybook:configuration` generator](/packages/storybook/generators/configuration). Run:
 
 ```bash
-nx g @nrwl/storybook:configuration –-name:storybook-host
+nx g @nrwl/storybook:configuration storybook-host
 ```
 
 and choose the framework you want to use (in our case, choose `@storybook/react`).


### PR DESCRIPTION
Using the command previously specified throws a warning: `Cannot find configuration for '–-name:storybook-host' in /workspace.json.`.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Following the command provided in the **Configure the new library to use Storybook** step leads to the following warning:

```bash
Cannot find configuration for '–-name:storybook-host' in /workspace.json.
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Following the command provided in the **Configure the new library to use Storybook** step, it generates:
- the lib's `libs/storybook-host/.storybook` folder;
- the `storybook` and `build-storybook` targets in the `storybook-host` library's `project.json`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
N/A
