### PR TITLE
feat(core): map lock file data to external dependencies

### DIFF
--- a/e2e/js/src/js.test.ts
+++ b/e2e/js/src/js.test.ts
@@ -240,6 +240,10 @@ describe('js e2e', () => {
     runCLI(`build ${lib}`);
 
     expect(
+      readJson(`dist/libs/${lib}/package.json`).peerDependencies['@swc/helpers']
+    ).toEqual(swcHelpersVersion);
+
+    expect(
       satisfies(
         readJson(`dist/libs/${lib}/package.json`).peerDependencies[
           '@swc/helpers'

--- a/e2e/js/src/js.test.ts
+++ b/e2e/js/src/js.test.ts
@@ -17,10 +17,6 @@ import {
   waitUntil,
 } from '../../utils';
 
-// copy from packages/nx/src/utils/version.ts
-// TODO(meeroslav) this should be in sync with the version in the package.json
-const swcHelpersVersion = '~0.3.3';
-
 describe('js e2e', () => {
   let scope: string;
 
@@ -239,16 +235,14 @@ describe('js e2e', () => {
 
     runCLI(`build ${lib}`);
 
-    expect(
-      readJson(`dist/libs/${lib}/package.json`).peerDependencies['@swc/helpers']
-    ).toEqual(swcHelpersVersion);
+    const rootPackageJson = readJson(`package.json`);
 
     expect(
       satisfies(
         readJson(`dist/libs/${lib}/package.json`).peerDependencies[
           '@swc/helpers'
         ],
-        swcHelpersVersion
+        rootPackageJson.dependencies['@swc/helpers']
       )
     ).toBeTruthy();
 

--- a/e2e/js/src/js.test.ts
+++ b/e2e/js/src/js.test.ts
@@ -235,16 +235,12 @@ describe('js e2e', () => {
 
     runCLI(`build ${lib}`);
 
-    const rootPackageJson = readJson(`package.json`);
+    const swcHelpersFromRoot =
+      readJson(`package.json`).dependencies['@swc/helpers'];
+    const swcHelpersFromDist = readJson(`dist/libs/${lib}/package.json`)
+      .peerDependencies['@swc/helpers'];
 
-    expect(
-      satisfies(
-        readJson(`dist/libs/${lib}/package.json`).peerDependencies[
-          '@swc/helpers'
-        ],
-        rootPackageJson.dependencies['@swc/helpers']
-      )
-    ).toBeTruthy();
+    expect(satisfies(swcHelpersFromDist, swcHelpersFromRoot)).toBeTruthy();
 
     updateJson(`libs/${lib}/.lib.swcrc`, (json) => {
       json.jsc.externalHelpers = false;

--- a/e2e/js/src/js.test.ts
+++ b/e2e/js/src/js.test.ts
@@ -17,6 +17,10 @@ import {
   waitUntil,
 } from '../../utils';
 
+// copy from packages/nx/src/utils/version.ts
+// TODO(meeroslav) this should be in sync with the version in the package.json
+const swcHelpersVersion = '~0.3.3';
+
 describe('js e2e', () => {
   let scope: string;
 
@@ -235,14 +239,12 @@ describe('js e2e', () => {
 
     runCLI(`build ${lib}`);
 
-    const rootPackageJson = readJson(`package.json`);
-
     expect(
       satisfies(
         readJson(`dist/libs/${lib}/package.json`).peerDependencies[
           '@swc/helpers'
         ],
-        rootPackageJson.dependencies['@swc/helpers']
+        swcHelpersVersion
       )
     ).toBeTruthy();
 

--- a/e2e/js/src/js.test.ts
+++ b/e2e/js/src/js.test.ts
@@ -1,3 +1,4 @@
+import { satisfies } from 'semver';
 import {
   checkFilesDoNotExist,
   checkFilesExist,
@@ -150,10 +151,12 @@ describe('js e2e', () => {
 
     const rootPackageJson = readJson(`package.json`);
 
-    expect(readJson(`dist/libs/${lib}/package.json`)).toHaveProperty(
-      'peerDependencies.tslib',
-      rootPackageJson.dependencies.tslib
-    );
+    expect(
+      satisfies(
+        readJson(`dist/libs/${lib}/package.json`).peerDependencies.tslib,
+        rootPackageJson.dependencies.tslib
+      )
+    ).toBeTruthy();
 
     updateJson(`libs/${lib}/tsconfig.json`, (json) => {
       json.compilerOptions = { ...json.compilerOptions, importHelpers: false };
@@ -234,10 +237,14 @@ describe('js e2e', () => {
 
     const rootPackageJson = readJson(`package.json`);
 
-    expect(readJson(`dist/libs/${lib}/package.json`)).toHaveProperty(
-      'peerDependencies.@swc/helpers',
-      rootPackageJson.dependencies['@swc/helpers']
-    );
+    expect(
+      satisfies(
+        readJson(`dist/libs/${lib}/package.json`).peerDependencies[
+          '@swc/helpers'
+        ],
+        rootPackageJson.dependencies['@swc/helpers']
+      )
+    ).toBeTruthy();
 
     updateJson(`libs/${lib}/.lib.swcrc`, (json) => {
       json.jsc.externalHelpers = false;

--- a/e2e/node/src/node.test.ts
+++ b/e2e/node/src/node.test.ts
@@ -10,7 +10,6 @@ import {
   packageInstall,
   promisifiedTreeKill,
   readFile,
-  removeFile,
   runCLI,
   runCLIAsync,
   runCommandUntil,
@@ -21,6 +20,7 @@ import {
 } from '@nrwl/e2e/utils';
 import { exec, execSync } from 'child_process';
 import * as http from 'http';
+import { satisfies } from 'semver';
 
 function getData(port): Promise<any> {
   return new Promise((resolve) => {
@@ -276,19 +276,25 @@ describe('Build Node apps', () => {
     );
     expect(packageJson).toEqual(
       expect.objectContaining({
-        dependencies: {
-          '@nestjs/common': '^9.0.0',
-          '@nestjs/core': '^9.0.0',
-          '@nestjs/platform-express': '^9.0.0',
-          'reflect-metadata': '^0.1.13',
-          rxjs: '^7.0.0',
-          tslib: '^2.3.0',
-        },
         main: 'main.js',
         name: expect.any(String),
         version: '0.0.1',
       })
     );
+    expect(
+      satisfies(packageJson.dependencies['@nestjs/common'], '^9.0.0')
+    ).toBeTruthy();
+    expect(
+      satisfies(packageJson.dependencies['@nestjs/core'], '^9.0.0')
+    ).toBeTruthy();
+    expect(
+      satisfies(packageJson.dependencies['@nestjs/platform-express'], '^9.0.0')
+    ).toBeTruthy();
+    expect(
+      satisfies(packageJson.dependencies['reflect-metadata'], '^0.1.13')
+    ).toBeTruthy();
+    expect(satisfies(packageJson.dependencies['rxjs'], '^7.0.0')).toBeTruthy();
+    expect(satisfies(packageJson.dependencies['tslib'], '^2.3.0')).toBeTruthy();
 
     const nodeapp = uniq('nodeapp');
     runCLI(`generate @nrwl/node:app ${nodeapp}`);

--- a/packages/js/src/utils/versions.ts
+++ b/packages/js/src/utils/versions.ts
@@ -4,5 +4,5 @@ export const nxVersion = require('../../package.json').version;
 
 export const esbuildVersion = '^0.15.7';
 export const swcCliVersion = '~0.1.55';
-export const swcHelpersVersion = '~0.3.3';
+export const swcHelpersVersion = '~0.4.11';
 export const typesNodeVersion = '18.7.1';

--- a/packages/nx/src/command-line/print-affected.ts
+++ b/packages/nx/src/command-line/print-affected.ts
@@ -87,6 +87,8 @@ async function createTasks(
 function serializeProjectGraph(projectGraph: ProjectGraph) {
   const nodes = Object.values(projectGraph.nodes).map((n) => n.name);
   const dependencies = {};
+  // we don't need external dependencies' dependencies for print-affected
+  // having them included makes the output unreadable
   Object.keys(projectGraph.dependencies).forEach((key) => {
     if (!key.startsWith('npm:')) {
       dependencies[key] = projectGraph.dependencies[key];

--- a/packages/nx/src/command-line/print-affected.ts
+++ b/packages/nx/src/command-line/print-affected.ts
@@ -86,7 +86,13 @@ async function createTasks(
 
 function serializeProjectGraph(projectGraph: ProjectGraph) {
   const nodes = Object.values(projectGraph.nodes).map((n) => n.name);
-  return { nodes, dependencies: projectGraph.dependencies };
+  const dependencies = {};
+  Object.keys(projectGraph.dependencies).forEach((key) => {
+    if (!key.startsWith('npm:')) {
+      dependencies[key] = projectGraph.dependencies[key];
+    }
+  });
+  return { nodes, dependencies };
 }
 
 export function selectPrintAffected(wholeJson: any, wholeSelect: string) {

--- a/packages/nx/src/config/project-graph.ts
+++ b/packages/nx/src/config/project-graph.ts
@@ -107,7 +107,13 @@ export interface ProjectGraphProjectNode<T = any> {
 
 /**
  * A node describing an external dependency
- * `name` has as form of `npm:packageName` for primary dependencies or `npm:packageName@version` for hoisted ones
+ * `name` has as form of:
+ * - `npm:packageName` for root dependencies or
+ * - `npm:packageName@version` for nested transitive dependencies
+ *
+ * This is vital for our node discovery to always point to root dependencies,
+ * while allowing tracking of the full tree of different nested versions
+ *
  */
 export interface ProjectGraphExternalNode {
   type: 'npm';
@@ -115,6 +121,7 @@ export interface ProjectGraphExternalNode {
   data: {
     version: string;
     packageName: string;
+    hash?: string;
   };
 }
 

--- a/packages/nx/src/config/project-graph.ts
+++ b/packages/nx/src/config/project-graph.ts
@@ -107,6 +107,7 @@ export interface ProjectGraphProjectNode<T = any> {
 
 /**
  * A node describing an external dependency
+ * `name` has as form of `npm:packageName` for primary dependencies or `npm:packageName@version` for hoisted ones
  */
 export interface ProjectGraphExternalNode {
   type: 'npm';
@@ -114,6 +115,8 @@ export interface ProjectGraphExternalNode {
   data: {
     version: string;
     packageName: string;
+    dependencies?: Record<string, [string, string]>; // dependencies of this version { [packageName]: [versionRange, actualVersion] }
+    peerDependencies?: Record<string, [string, string]>; // dependencies of this version { [packageName]: [versionRange, actualVersion] }
   };
 }
 

--- a/packages/nx/src/config/project-graph.ts
+++ b/packages/nx/src/config/project-graph.ts
@@ -115,8 +115,6 @@ export interface ProjectGraphExternalNode {
   data: {
     version: string;
     packageName: string;
-    dependencies?: Record<string, [string, string]>; // dependencies of this version { [packageName]: [versionRange, actualVersion] }
-    peerDependencies?: Record<string, [string, string]>; // dependencies of this version { [packageName]: [versionRange, actualVersion] }
   };
 }
 

--- a/packages/nx/src/hasher/hasher.spec.ts
+++ b/packages/nx/src/hasher/hasher.spec.ts
@@ -79,6 +79,7 @@ describe('Hasher', () => {
               root: 'libs/parent',
               targets: {
                 build: {
+                  executor: 'unknown',
                   inputs: [
                     'default',
                     '^default',
@@ -95,6 +96,7 @@ describe('Hasher', () => {
         dependencies: {
           parent: [],
         },
+        externalNodes: {},
         allWorkspaceFiles,
       },
       {} as any,
@@ -121,7 +123,8 @@ describe('Hasher', () => {
     expect(hash.details.command).toEqual('parent|build||{"prop":"prop-value"}');
     expect(hash.details.nodes).toEqual({
       'parent:{projectRoot}/**/*':
-        '/file|file.hash|{"root":"libs/parent","targets":{"build":{"inputs":["default","^default",{"runtime":"echo runtime123"},{"env":"TESTENV"},{"env":"NONEXISTENTENV"}]}}}|{"compilerOptions":{"paths":{"@nrwl/parent":["libs/parent/src/index.ts"],"@nrwl/child":["libs/child/src/index.ts"]}}}',
+        '/file|file.hash|{"root":"libs/parent","targets":{"build":{"executor":"unknown","inputs":["default","^default",{"runtime":"echo runtime123"},{"env":"TESTENV"},{"env":"NONEXISTENTENV"}]}}}|{"compilerOptions":{"paths":{"@nrwl/parent":["libs/parent/src/index.ts"],"@nrwl/child":["libs/child/src/index.ts"]}}}',
+      parent: 'unknown',
       '{workspaceRoot}/nx.json': 'nx.json.hash',
       '{workspaceRoot}/.gitignore': '',
       '{workspaceRoot}/.nxignore': '',
@@ -141,7 +144,7 @@ describe('Hasher', () => {
             type: 'lib',
             data: {
               root: 'libs/parent',
-              targets: { build: {} },
+              targets: { build: { executor: 'unknown' } },
               files: [
                 { file: '/filea.ts', hash: 'a.hash' },
                 { file: '/filea.spec.ts', hash: 'a.spec.hash' },
@@ -201,6 +204,7 @@ describe('Hasher', () => {
               targets: {
                 build: {
                   inputs: ['prod', '^prod'],
+                  executor: 'unknown',
                 },
               },
               files: [
@@ -217,7 +221,7 @@ describe('Hasher', () => {
               namedInputs: {
                 prod: ['default'],
               },
-              targets: { build: {} },
+              targets: { build: { executor: 'unknown' } },
               files: [
                 { file: 'libs/child/fileb.ts', hash: 'b.hash' },
                 { file: 'libs/child/fileb.spec.ts', hash: 'b.spec.hash' },
@@ -269,10 +273,12 @@ describe('Hasher', () => {
               targets: {
                 build: {
                   inputs: ['prod'],
+                  executor: 'unknown',
                 },
                 test: {
                   inputs: ['default'],
                   dependsOn: ['build'],
+                  executor: 'unknown',
                 },
               },
               files: [
@@ -335,6 +341,7 @@ describe('Hasher', () => {
               targets: {
                 test: {
                   inputs: ['default', '^prod'],
+                  executor: 'unknown',
                 },
               },
               files: [
@@ -358,6 +365,7 @@ describe('Hasher', () => {
               targets: {
                 test: {
                   inputs: ['default'],
+                  executor: 'unknown',
                 },
               },
               files: [
@@ -436,7 +444,7 @@ describe('Hasher', () => {
             data: {
               root: 'libs/parent',
               targets: {
-                build: {},
+                build: { executor: '@nrwl/workspace:run-commands' },
               },
               files: [
                 { file: 'libs/parent/filea.ts', hash: 'a.hash' },
@@ -449,7 +457,7 @@ describe('Hasher', () => {
             type: 'lib',
             data: {
               root: 'libs/child',
-              targets: { build: {} },
+              targets: { build: { executor: '@nrwl/workspace:run-commands' } },
               files: [
                 { file: 'libs/child/fileb.ts', hash: 'b.hash' },
                 { file: 'libs/child/fileb.spec.ts', hash: 'b.spec.hash' },
@@ -503,7 +511,7 @@ describe('Hasher', () => {
             type: 'lib',
             data: {
               root: 'libs/parent',
-              targets: { build: {} },
+              targets: { build: { executor: '@nrwl/workspace:run-commands' } },
               files: [{ file: '/file', hash: 'file.hash' }],
             },
           },
@@ -552,7 +560,7 @@ describe('Hasher', () => {
             type: 'lib',
             data: {
               root: 'libs/parent',
-              targets: { build: {} },
+              targets: { build: { executor: '@nrwl/workspace:run-commands' } },
               files: [{ file: '/filea.ts', hash: 'a.hash' }],
             },
           },
@@ -561,7 +569,7 @@ describe('Hasher', () => {
             type: 'lib',
             data: {
               root: 'libs/child',
-              targets: { build: {} },
+              targets: { build: { executor: '@nrwl/workspace:run-commands' } },
               files: [{ file: '/fileb.ts', hash: 'b.hash' }],
             },
           },
@@ -633,7 +641,7 @@ describe('Hasher', () => {
             type: 'lib',
             data: {
               root: 'libs/parent',
-              targets: { build: {} },
+              targets: { build: { executor: '@nrwl/workspace:run-commands' } },
               files: [{ file: '/file', hash: 'some-hash' }],
             },
           },
@@ -675,7 +683,7 @@ describe('Hasher', () => {
             type: 'lib',
             data: {
               root: 'libs/parents',
-              targets: { build: {} },
+              targets: { build: { executor: '@nrwl/workspace:run-commands' } },
               files: [],
             },
           },
@@ -711,7 +719,7 @@ describe('Hasher', () => {
             type: 'app',
             data: {
               root: 'apps/app',
-              targets: { build: {} },
+              targets: { build: { executor: '@nrwl/workspace:run-commands' } },
               files: [{ file: '/filea.ts', hash: 'a.hash' }],
             },
           },
@@ -760,7 +768,7 @@ describe('Hasher', () => {
             type: 'app',
             data: {
               root: 'apps/app',
-              targets: { build: {} },
+              targets: { build: { executor: '@nrwl/workspace:run-commands' } },
               files: [{ file: '/filea.ts', hash: 'a.hash' }],
             },
           },

--- a/packages/nx/src/hasher/hasher.spec.ts
+++ b/packages/nx/src/hasher/hasher.spec.ts
@@ -110,7 +110,6 @@ describe('Hasher', () => {
       overrides: { prop: 'prop-value' },
     });
 
-    expect(hash.value).toContain('yarn.lock.hash'); //implicits
     expect(hash.value).toContain('file.hash'); //project files
     expect(hash.value).toContain('prop-value'); //overrides
     expect(hash.value).toContain('parent'); //project
@@ -123,9 +122,6 @@ describe('Hasher', () => {
     expect(hash.details.nodes).toEqual({
       'parent:{projectRoot}/**/*':
         '/file|file.hash|{"root":"libs/parent","targets":{"build":{"inputs":["default","^default",{"runtime":"echo runtime123"},{"env":"TESTENV"},{"env":"NONEXISTENTENV"}]}}}|{"compilerOptions":{"paths":{"@nrwl/parent":["libs/parent/src/index.ts"],"@nrwl/child":["libs/child/src/index.ts"]}}}',
-      '{workspaceRoot}/yarn.lock': 'yarn.lock.hash',
-      '{workspaceRoot}/package-lock.json': 'package-lock.json.hash',
-      '{workspaceRoot}/pnpm-lock.yaml': 'pnpm-lock.yaml.hash',
       '{workspaceRoot}/nx.json': 'nx.json.hash',
       '{workspaceRoot}/.gitignore': '',
       '{workspaceRoot}/.nxignore': '',
@@ -531,7 +527,6 @@ describe('Hasher', () => {
       overrides: { prop: 'prop-value' },
     });
 
-    expect(hash.value).toContain('yarn.lock.hash'); //implicits
     expect(hash.value).toContain('file.hash'); //project files
     expect(hash.value).toContain('prop-value'); //overrides
     expect(hash.value).toContain('parent'); //project
@@ -588,7 +583,6 @@ describe('Hasher', () => {
       overrides: { prop: 'prop-value' },
     });
 
-    expect(tasksHash.value).toContain('yarn.lock.hash'); //implicits
     expect(tasksHash.value).toContain('a.hash'); //project files
     expect(tasksHash.value).toContain('b.hash'); //project files
     expect(tasksHash.value).toContain('prop-value'); //overrides
@@ -612,7 +606,6 @@ describe('Hasher', () => {
       overrides: { prop: 'prop-value' },
     });
 
-    expect(hashb.value).toContain('yarn.lock.hash'); //implicits
     expect(hashb.value).toContain('a.hash'); //project files
     expect(hashb.value).toContain('b.hash'); //project files
     expect(hashb.value).toContain('prop-value'); //overrides

--- a/packages/nx/src/hasher/hasher.ts
+++ b/packages/nx/src/hasher/hasher.ts
@@ -337,16 +337,9 @@ class TaskHasher {
       hash = this.hashing.hashArray([version]);
     } else {
       // unknown dependency
-      // this may occur if a file has a dependency to a npm package
-      // which is not directly registestered in package.json
-      // but only indirectly through dependencies of registered
-      // npm packages
-      // when it is at a later stage registered in package.json
-      // the cache project graph will not know this module but
-      // the new project graph will know it
-      // The actual checksum added here is of no importance as
-      // the version is unknown and may only change when some
-      // other change occurs in package.json and/or package-lock.json
+      // this may occur dependency is not an npm package
+      // but rather symlinked in node_modules or it's pointing to a remote git repo
+      // in this case we have no information about the versioning of the given package
       hash = `__${projectName}__`;
     }
     return {

--- a/packages/nx/src/hasher/hasher.ts
+++ b/packages/nx/src/hasher/hasher.ts
@@ -345,12 +345,6 @@ class TaskHasher {
     if (n?.data?.hash) {
       // we already know the hash of this dependency
       hash = n.data.hash;
-    } else if (version) {
-      const deps = [`${projectName}@${version}`];
-      this.traverseExternalNodesDependencies(projectName, deps);
-      hash = this.hashing.hashArray(deps.sort());
-      // store hash of given dependency for later use
-      n.data.hash = hash;
     } else {
       // unknown dependency
       // this may occur dependency is not an npm package
@@ -364,19 +358,6 @@ class TaskHasher {
         [projectName]: version || hash,
       },
     };
-  }
-
-  private traverseExternalNodesDependencies(
-    projectName: string,
-    visited: string[]
-  ) {
-    const dependencies = this.projectGraph.dependencies[projectName] ?? [];
-    dependencies.forEach((d) => {
-      if (visited.indexOf(d.target) === -1) {
-        visited.push(d.target);
-        this.traverseExternalNodesDependencies(d.target, visited);
-      }
-    });
   }
 
   private hashTarget(projectName: string, targetName: string): PartialHash {

--- a/packages/nx/src/hasher/hasher.ts
+++ b/packages/nx/src/hasher/hasher.ts
@@ -84,10 +84,6 @@ export class Hasher {
     const legacyFilesetInputs = [
       ...Object.keys(this.nxJson.implicitDependencies ?? {}),
       'nx.json',
-      //TODO: vsavkin move the special cases into explicit ts support
-      'package-lock.json',
-      'yarn.lock',
-      'pnpm-lock.yaml',
 
       // ignore files will change the set of inputs to the hasher
       '.gitignore',

--- a/packages/nx/src/hasher/hasher.ts
+++ b/packages/nx/src/hasher/hasher.ts
@@ -342,10 +342,15 @@ class TaskHasher {
     const n = this.projectGraph.externalNodes[projectName];
     const version = n?.data?.version;
     let hash: string;
-    if (version) {
+    if (n?.data?.hash) {
+      // we already know the hash of this dependency
+      hash = n.data.hash;
+    } else if (version) {
       const deps = [`${projectName}@${version}`];
       this.traverseExternalNodesDependencies(projectName, deps);
       hash = this.hashing.hashArray(deps.sort());
+      // store hash of given dependency for later use
+      n.data.hash = hash;
     } else {
       // unknown dependency
       // this may occur dependency is not an npm package

--- a/packages/nx/src/hasher/hasher.ts
+++ b/packages/nx/src/hasher/hasher.ts
@@ -382,9 +382,13 @@ class TaskHasher {
       return;
     }
 
-    // if it's run commands we skip traversing since we have no info
-    // what this command depends on
-    if (target.executor !== `@nrwl/workspace:run-commands`) {
+    // we can only vouch for @nrwl packages's executors
+    // if it's "run commands" we skip traversing since we have no info what this command depends on
+    // for everything else we take the hash of the @nrwl package dependency tree
+    if (
+      target.executor.startsWith(`@nrwl/`) &&
+      target.executor !== `@nrwl/workspace:run-commands`
+    ) {
       const executorPackage = target.executor.split(':')[0];
       const executorNode = `npm:${executorPackage}`;
       if (this.projectGraph.externalNodes?.[executorNode]) {

--- a/packages/nx/src/project-graph/affected/affected-project-graph.spec.ts
+++ b/packages/nx/src/project-graph/affected/affected-project-graph.spec.ts
@@ -15,6 +15,7 @@ jest.mock('nx/src/utils/workspace-root', () => ({
 
 describe('project graph', () => {
   let packageJson: any;
+  let packageLockJson: any;
   let workspaceJson: WorkspaceJsonConfiguration;
   let tsConfigJson: any;
   let nxJson: NxJsonConfiguration;
@@ -24,6 +25,7 @@ describe('project graph', () => {
     process.env.NX_CACHE_PROJECT_GRAPH = 'false';
     packageJson = {
       name: '@nrwl/workspace-src',
+      version: '0.0.0',
       scripts: {
         deploy: 'echo deploy',
       },
@@ -32,6 +34,43 @@ describe('project graph', () => {
       },
       devDependencies: {
         '@nrwl/workspace': '8.0.0',
+      },
+    };
+    packageLockJson = {
+      name: '@nrwl/workspace-src',
+      version: '0.0.0',
+      lockfileVersion: 2,
+      requires: true,
+      packages: {
+        '': packageJson,
+        'node_modules/@nrwl/workspace': {
+          version: '15.0.0',
+          resolved:
+            'https://registry.npmjs.org/@nrwl/workspace/-/@nrwl/workspace-15.0.0.tgz',
+          integrity: 'sha512-12345678==',
+          dev: true,
+        },
+        'node_modules/happy-nrwl': {
+          version: '4.0.0',
+          resolved:
+            'https://registry.npmjs.org/happy-nrwl/-/happy-nrwl-1.0.0.tgz',
+          integrity: 'sha512-12345678==',
+        },
+      },
+      dependencies: {
+        '@nrwl/workspace': {
+          version: '15.0.0',
+          resolved:
+            'https://registry.npmjs.org/@nrwl/workspace/-/@nrwl/workspace-15.0.0.tgz',
+          integrity: 'sha512-12345678==',
+          dev: true,
+        },
+        'happy-nrwl': {
+          version: '1.0.0',
+          resolved:
+            'https://registry.npmjs.org/happy-nrwl/-/happy-nrwl-1.0.0.tgz',
+          integrity: 'sha512-12345678==',
+        },
       },
     };
     workspaceJson = {
@@ -110,6 +149,7 @@ describe('project graph', () => {
         import * as happyNrwl from 'happy-nrwl';
       `,
       './package.json': JSON.stringify(packageJson),
+      './package-lock.json': JSON.stringify(packageLockJson),
       './nx.json': JSON.stringify(nxJson),
       './workspace.json': JSON.stringify(workspaceJson),
       './tsconfig.base.json': JSON.stringify(tsConfigJson),

--- a/packages/nx/src/project-graph/affected/locators/workspace-projects.ts
+++ b/packages/nx/src/project-graph/affected/locators/workspace-projects.ts
@@ -35,7 +35,6 @@ export const getImplicitlyTouchedProjects: TouchedProjectLocator = (
   const globalFiles = [
     ...extractGlobalFilesFromInputs(nxJson, projectGraphNodes),
     'nx.json',
-    'package.json',
   ];
   globalFiles.forEach((file) => {
     implicits[file] = '*' as any;

--- a/packages/nx/src/project-graph/build-project-graph.spec.ts
+++ b/packages/nx/src/project-graph/build-project-graph.spec.ts
@@ -13,6 +13,7 @@ import { DependencyType } from '../config/project-graph';
 
 describe('project graph', () => {
   let packageJson: any;
+  let packageLockJson: any;
   let workspaceJson: WorkspaceJsonConfiguration;
   let nxJson: NxJsonConfiguration;
   let tsConfigJson: any;
@@ -22,12 +23,63 @@ describe('project graph', () => {
     defaultFileHasher.ensureInitialized();
     packageJson = {
       name: '@nrwl/workspace-src',
+      version: '0.0.0',
       dependencies: {
         express: '4.0.0',
         'happy-nrwl': '1.0.0',
       },
       devDependencies: {
         '@nrwl/workspace': '*',
+      },
+    };
+    packageLockJson = {
+      name: '@nrwl/workspace-src',
+      version: '0.0.0',
+      lockfileVersion: 2,
+      requires: true,
+      packages: {
+        '': packageJson,
+        'node_modules/@nrwl/workspace': {
+          version: '15.0.0',
+          resolved:
+            'https://registry.npmjs.org/@nrwl/workspace/-/@nrwl/workspace-15.0.0.tgz',
+          integrity: 'sha512-12345678==',
+          dev: true,
+        },
+        'node_modules/express': {
+          version: '4.0.0',
+          resolved: 'https://registry.npmjs.org/express/-/express-4.0.0.tgz',
+          integrity: 'sha512-12345678==',
+          engines: {
+            node: '>=4.2.0',
+          },
+        },
+        'node_modules/happy-nrwl': {
+          version: '4.0.0',
+          resolved:
+            'https://registry.npmjs.org/happy-nrwl/-/happy-nrwl-1.0.0.tgz',
+          integrity: 'sha512-12345678==',
+        },
+      },
+      dependencies: {
+        '@nrwl/workspace': {
+          version: '15.0.0',
+          resolved:
+            'https://registry.npmjs.org/@nrwl/workspace/-/@nrwl/workspace-15.0.0.tgz',
+          integrity: 'sha512-12345678==',
+          dev: true,
+        },
+        express: {
+          version: '4.0.0',
+          resolved: 'https://registry.npmjs.org/express/-/express-4.0.0.tgz',
+          integrity: 'sha512-12345678==',
+        },
+        'happy-nrwl': {
+          version: '1.0.0',
+          resolved:
+            'https://registry.npmjs.org/happy-nrwl/-/happy-nrwl-1.0.0.tgz',
+          integrity: 'sha512-12345678==',
+        },
       },
     };
     workspaceJson = {
@@ -125,6 +177,7 @@ describe('project graph', () => {
         export const LAZY = 'lazy lib';
       `,
       './package.json': JSON.stringify(packageJson),
+      './package-lock.json': JSON.stringify(packageLockJson),
       './nx.json': JSON.stringify(nxJson),
       './workspace.json': JSON.stringify(workspaceJson),
       './tsconfig.base.json': JSON.stringify(tsConfigJson),

--- a/packages/nx/src/project-graph/build-project-graph.ts
+++ b/packages/nx/src/project-graph/build-project-graph.ts
@@ -40,6 +40,7 @@ import {
   readNxJson,
 } from '../config/configuration';
 import {
+  lockFileExists,
   lockFileHash,
   mapLockFileDataToExternalNodes,
   parseLockFile,
@@ -101,11 +102,15 @@ export async function buildProjectGraphUsingProjectFileMap(
     cachedFileData = {};
   }
   let externalNodes;
-  const lockHash = lockFileHash();
-  if (cache && cache.lockFileHash === lockHash) {
-    externalNodes = cache.externalNodes;
-  } else {
-    externalNodes = mapLockFileDataToExternalNodes(parseLockFile());
+  let lockHash = 'n/a';
+  // during the create-nx-workspace lock file might not exists yet
+  if (lockFileExists()) {
+    lockHash = lockFileHash();
+    if (cache && cache.lockFileHash === lockHash) {
+      externalNodes = cache.externalNodes;
+    } else {
+      externalNodes = mapLockFileDataToExternalNodes(parseLockFile());
+    }
   }
   const context = createContext(
     projectsConfigurations,

--- a/packages/nx/src/project-graph/build-project-graph.ts
+++ b/packages/nx/src/project-graph/build-project-graph.ts
@@ -39,6 +39,11 @@ import {
   readAllWorkspaceConfiguration,
   readNxJson,
 } from '../config/configuration';
+import {
+  lockFileHash,
+  mapLockFileDataToExternalNodes,
+  parseLockFile,
+} from '../utils/lock-file/lock-file';
 
 export async function buildProjectGraph() {
   const projectConfigurations = readAllWorkspaceConfiguration();
@@ -95,6 +100,13 @@ export async function buildProjectGraphUsingProjectFileMap(
     filesToProcess = projectFileMap;
     cachedFileData = {};
   }
+  let externalNodes;
+  const lockHash = lockFileHash();
+  if (cache && cache.lockFileHash === lockHash) {
+    externalNodes = cache.externalNodes;
+  } else {
+    externalNodes = mapLockFileDataToExternalNodes(parseLockFile());
+  }
   const context = createContext(
     projectsConfigurations,
     nxJson,
@@ -112,7 +124,8 @@ export async function buildProjectGraphUsingProjectFileMap(
     nxJson,
     packageJsonDeps,
     projectGraph,
-    rootTsConfig
+    rootTsConfig,
+    lockHash
   );
   if (shouldWriteCache) {
     writeCache(projectGraphCache);

--- a/packages/nx/src/project-graph/nx-deps-cache.spec.ts
+++ b/packages/nx/src/project-graph/nx-deps-cache.spec.ts
@@ -4,7 +4,6 @@ import {
   ProjectGraphCache,
   shouldRecomputeWholeGraph,
 } from './nx-deps-cache';
-import { createCache } from './nx-deps-cache';
 import { ProjectGraph } from '../config/project-graph';
 import { WorkspaceJsonConfiguration } from '../config/workspace-json-project-json';
 import { NxJsonConfiguration } from '../config/nx-json';
@@ -299,7 +298,8 @@ describe('nx deps utils', () => {
         createNxJson({}),
         createPackageJsonDeps({}),
         createCache({}) as ProjectGraph,
-        {}
+        {},
+        'abcd1234'
       );
     });
 
@@ -308,7 +308,8 @@ describe('nx deps utils', () => {
         createNxJson({}),
         createPackageJsonDeps({}),
         createCache({}) as ProjectGraph,
-        undefined
+        undefined,
+        'abcd1234'
       );
 
       expect(result).toBeDefined();
@@ -322,6 +323,7 @@ describe('nx deps utils', () => {
         '@nrwl/workspace': '12.0.0',
         plugin: '1.0.0',
       },
+      lockFileHash: 'abcd1234',
       pathMappings: {
         mylib: ['libs/mylib/index.ts'],
       },

--- a/packages/nx/src/project-graph/nx-deps-cache.ts
+++ b/packages/nx/src/project-graph/nx-deps-cache.ts
@@ -19,6 +19,7 @@ import { ProjectsConfigurations } from '../config/workspace-json-project-json';
 export interface ProjectGraphCache {
   version: string;
   deps: Record<string, string>;
+  lockFileHash: string;
   pathMappings: Record<string, any>;
   nxJsonPlugins: { name: string; version: string }[];
   pluginsConfig?: any;
@@ -81,7 +82,8 @@ export function createCache(
   nxJson: NxJsonConfiguration<'*' | string[]>,
   packageJsonDeps: Record<string, string>,
   projectGraph: ProjectGraph,
-  tsConfig: { compilerOptions?: { paths?: { [p: string]: any } } }
+  tsConfig: { compilerOptions?: { paths?: { [p: string]: any } } },
+  lockFileHash: string
 ) {
   const nxJsonPlugins = (nxJson.plugins || []).map((p) => ({
     name: p,
@@ -90,6 +92,7 @@ export function createCache(
   const newValue: ProjectGraphCache = {
     version: projectGraph.version || '5.0',
     deps: packageJsonDeps,
+    lockFileHash,
     // compilerOptions may not exist, especially for repos converted through add-nx-to-monorepo
     pathMappings: tsConfig?.compilerOptions?.paths || {},
     nxJsonPlugins,

--- a/packages/nx/src/project-graph/project-graph.ts
+++ b/packages/nx/src/project-graph/project-graph.ts
@@ -182,7 +182,7 @@ export function projectGraphAdapter(
   if (sourceVersion === targetVersion) {
     return projectGraph;
   }
-  if (sourceVersion === '5.0' && targetVersion === '4.0') {
+  if (+sourceVersion >= 5 && targetVersion === '4.0') {
     return projectGraphCompat5to4(projectGraph as ProjectGraph);
   }
   throw new Error(

--- a/packages/nx/src/utils/lock-file/__snapshots__/lock-file.spec.ts.snap
+++ b/packages/nx/src/utils/lock-file/__snapshots__/lock-file.spec.ts.snap
@@ -3,77 +3,57 @@
 exports[`lock-file mapLockFileDataToExternalNodes should map npm lock file data to external nodes 1`] = `
 Object {
   "data": Object {
-    "dependencies": Object {
-      "cliui": Array [
-        "^7.0.2",
-        "7.0.4",
-      ],
-      "escalade": Array [
-        "^3.1.1",
-        "3.1.1",
-      ],
-      "get-caller-file": Array [
-        "^2.0.5",
-        "2.0.5",
-      ],
-      "require-directory": Array [
-        "^2.1.1",
-        "2.1.1",
-      ],
-      "string-width": Array [
-        "^4.2.3",
-        "4.2.3",
-      ],
-      "y18n": Array [
-        "^5.0.5",
-        "5.0.8",
-      ],
-      "yargs-parser": Array [
-        "^21.0.0",
-        "21.0.1",
-      ],
-    },
     "packageName": "yargs",
     "version": "17.5.1",
   },
   "name": "npm:yargs",
   "type": "npm",
 }
+`;
+
+exports[`lock-file mapLockFileDataToExternalNodes should map npm lock file data to external nodes 2`] = `
+Array [
+  Object {
+    "source": "npm:yargs",
+    "target": "npm:cliui@7.0.4",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:yargs",
+    "target": "npm:escalade@3.1.1",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:yargs",
+    "target": "npm:get-caller-file@2.0.5",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:yargs",
+    "target": "npm:require-directory@2.1.1",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:yargs",
+    "target": "npm:string-width@4.2.3",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:yargs",
+    "target": "npm:y18n@5.0.8",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:yargs",
+    "target": "npm:yargs-parser@21.0.1",
+    "type": "static",
+  },
+]
 `;
 
 exports[`lock-file mapLockFileDataToExternalNodes should map pnpm lock file data to external nodes 1`] = `
 Object {
   "data": Object {
-    "dependencies": Object {
-      "cliui": Array [
-        "7.0.4",
-        "7.0.4",
-      ],
-      "escalade": Array [
-        "3.1.1",
-        "3.1.1",
-      ],
-      "get-caller-file": Array [
-        "2.0.5",
-        "2.0.5",
-      ],
-      "require-directory": Array [
-        "2.1.1",
-        "2.1.1",
-      ],
-      "string-width": Array [
-        "4.2.3",
-        "4.2.3",
-      ],
-      "y18n": Array [
-        "5.0.8",
-        "5.0.8",
-      ],
-      "yargs-parser": Array [
-        "21.1.1",
-        "21.1.1",
-      ],
-    },
     "packageName": "yargs",
     "version": "17.5.1",
   },
@@ -82,142 +62,50 @@ Object {
 }
 `;
 
+exports[`lock-file mapLockFileDataToExternalNodes should map pnpm lock file data to external nodes 2`] = `
+Array [
+  Object {
+    "source": "npm:yargs",
+    "target": "npm:cliui@7.0.4",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:yargs",
+    "target": "npm:escalade@3.1.1",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:yargs",
+    "target": "npm:get-caller-file@2.0.5",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:yargs",
+    "target": "npm:require-directory@2.1.1",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:yargs",
+    "target": "npm:string-width@4.2.3",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:yargs",
+    "target": "npm:y18n@5.0.8",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:yargs",
+    "target": "npm:yargs-parser@21.1.1",
+    "type": "static",
+  },
+]
+`;
+
 exports[`lock-file mapLockFileDataToExternalNodes should map successfully complex npm lock file 1`] = `
 Object {
   "data": Object {
-    "dependencies": Object {
-      "@nrwl/cli": Array [
-        "14.7.5",
-        "14.7.5",
-      ],
-      "@nrwl/tao": Array [
-        "14.7.5",
-        "14.7.5",
-      ],
-      "@parcel/watcher": Array [
-        "2.0.4",
-        "2.0.4",
-      ],
-      "chalk": Array [
-        "4.1.0",
-        "4.1.0",
-      ],
-      "chokidar": Array [
-        "^3.5.1",
-        "3.5.3",
-      ],
-      "cli-cursor": Array [
-        "3.1.0",
-        "3.1.0",
-      ],
-      "cli-spinners": Array [
-        "2.6.1",
-        "2.6.1",
-      ],
-      "cliui": Array [
-        "^7.0.2",
-        "7.0.4",
-      ],
-      "dotenv": Array [
-        "~10.0.0",
-        "10.0.0",
-      ],
-      "enquirer": Array [
-        "~2.3.6",
-        "2.3.6",
-      ],
-      "fast-glob": Array [
-        "3.2.7",
-        "3.2.7",
-      ],
-      "figures": Array [
-        "3.2.0",
-        "3.2.0",
-      ],
-      "flat": Array [
-        "^5.0.2",
-        "5.0.2",
-      ],
-      "fs-extra": Array [
-        "^10.1.0",
-        "10.1.0",
-      ],
-      "glob": Array [
-        "7.1.4",
-        "7.1.4",
-      ],
-      "ignore": Array [
-        "^5.0.4",
-        "5.2.0",
-      ],
-      "js-yaml": Array [
-        "4.1.0",
-        "4.1.0",
-      ],
-      "jsonc-parser": Array [
-        "3.0.0",
-        "3.0.0",
-      ],
-      "minimatch": Array [
-        "3.0.5",
-        "3.0.5",
-      ],
-      "npm-run-path": Array [
-        "^4.0.1",
-        "4.0.1",
-      ],
-      "open": Array [
-        "^8.4.0",
-        "8.4.0",
-      ],
-      "semver": Array [
-        "7.3.4",
-        "7.3.4",
-      ],
-      "string-width": Array [
-        "^4.2.3",
-        "4.2.3",
-      ],
-      "tar-stream": Array [
-        "~2.2.0",
-        "2.2.0",
-      ],
-      "tmp": Array [
-        "~0.2.1",
-        "0.2.1",
-      ],
-      "tsconfig-paths": Array [
-        "^3.9.0",
-        "3.14.1",
-      ],
-      "tslib": Array [
-        "^2.3.0",
-        "2.4.0",
-      ],
-      "v8-compile-cache": Array [
-        "2.3.0",
-        "2.3.0",
-      ],
-      "yargs": Array [
-        "^17.4.0",
-        "17.5.1",
-      ],
-      "yargs-parser": Array [
-        "21.0.1",
-        "21.0.1",
-      ],
-    },
     "packageName": "nx",
-    "peerDependencies": Object {
-      "@swc-node/register": Array [
-        "^1.4.2",
-        undefined,
-      ],
-      "@swc/core": Array [
-        "^1.2.173",
-        undefined,
-      ],
-    },
     "version": "14.7.5",
   },
   "name": "npm:nx",
@@ -225,142 +113,165 @@ Object {
 }
 `;
 
+exports[`lock-file mapLockFileDataToExternalNodes should map successfully complex npm lock file 2`] = `
+Array [
+  Object {
+    "source": "npm:nx",
+    "target": "npm:@nrwl/cli@14.7.5",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:@nrwl/tao@14.7.5",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:@parcel/watcher@2.0.4",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:chalk@4.1.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:chokidar@3.5.3",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:cli-cursor@3.1.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:cli-spinners@2.6.1",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:cliui@7.0.4",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:dotenv@10.0.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:enquirer@2.3.6",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:fast-glob@3.2.7",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:figures@3.2.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:flat@5.0.2",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:fs-extra@10.1.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:glob@7.1.4",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:ignore@5.2.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:js-yaml@4.1.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:jsonc-parser@3.0.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:minimatch@3.0.5",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:npm-run-path@4.0.1",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:open@8.4.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:semver@7.3.4",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:string-width@4.2.3",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:tar-stream@2.2.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:tmp@0.2.1",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:tsconfig-paths@3.14.1",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:tslib@2.4.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:v8-compile-cache@2.3.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:yargs@17.5.1",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:yargs-parser@21.0.1",
+    "type": "static",
+  },
+]
+`;
+
 exports[`lock-file mapLockFileDataToExternalNodes should map successfully complex pnpm lock file 1`] = `
 Object {
   "data": Object {
-    "dependencies": Object {
-      "@nrwl/cli": Array [
-        "14.7.5",
-        "14.7.5",
-      ],
-      "@nrwl/tao": Array [
-        "14.7.5",
-        "14.7.5",
-      ],
-      "@parcel/watcher": Array [
-        "2.0.4",
-        "2.0.4",
-      ],
-      "chalk": Array [
-        "4.1.0",
-        "4.1.0",
-      ],
-      "chokidar": Array [
-        "3.5.3",
-        "3.5.3",
-      ],
-      "cli-cursor": Array [
-        "3.1.0",
-        "3.1.0",
-      ],
-      "cli-spinners": Array [
-        "2.6.1",
-        "2.6.1",
-      ],
-      "cliui": Array [
-        "7.0.4",
-        "7.0.4",
-      ],
-      "dotenv": Array [
-        "10.0.0",
-        "10.0.0",
-      ],
-      "enquirer": Array [
-        "2.3.6",
-        "2.3.6",
-      ],
-      "fast-glob": Array [
-        "3.2.7",
-        "3.2.7",
-      ],
-      "figures": Array [
-        "3.2.0",
-        "3.2.0",
-      ],
-      "flat": Array [
-        "5.0.2",
-        "5.0.2",
-      ],
-      "fs-extra": Array [
-        "10.1.0",
-        "10.1.0",
-      ],
-      "glob": Array [
-        "7.1.4",
-        "7.1.4",
-      ],
-      "ignore": Array [
-        "5.2.0",
-        "5.2.0",
-      ],
-      "js-yaml": Array [
-        "4.1.0",
-        "4.1.0",
-      ],
-      "jsonc-parser": Array [
-        "3.0.0",
-        "3.0.0",
-      ],
-      "minimatch": Array [
-        "3.0.5",
-        "3.0.5",
-      ],
-      "npm-run-path": Array [
-        "4.0.1",
-        "4.0.1",
-      ],
-      "open": Array [
-        "8.4.0",
-        "8.4.0",
-      ],
-      "semver": Array [
-        "7.3.4",
-        "7.3.4",
-      ],
-      "string-width": Array [
-        "4.2.3",
-        "4.2.3",
-      ],
-      "tar-stream": Array [
-        "2.2.0",
-        "2.2.0",
-      ],
-      "tmp": Array [
-        "0.2.1",
-        "0.2.1",
-      ],
-      "tsconfig-paths": Array [
-        "3.14.1",
-        "3.14.1",
-      ],
-      "tslib": Array [
-        "2.4.0",
-        "2.4.0",
-      ],
-      "v8-compile-cache": Array [
-        "2.3.0",
-        "2.3.0",
-      ],
-      "yargs": Array [
-        "17.5.1",
-        "17.5.1",
-      ],
-      "yargs-parser": Array [
-        "21.0.1",
-        "21.0.1",
-      ],
-    },
     "packageName": "nx",
-    "peerDependencies": Object {
-      "@swc-node/register": Array [
-        "^1.4.2",
-        undefined,
-      ],
-      "@swc/core": Array [
-        "^1.2.173",
-        undefined,
-      ],
-    },
     "version": "14.7.5",
   },
   "name": "npm:nx",
@@ -369,25 +280,164 @@ Object {
 `;
 
 exports[`lock-file mapLockFileDataToExternalNodes should map successfully complex pnpm lock file 2`] = `
+Array [
+  Object {
+    "source": "npm:nx",
+    "target": "npm:@nrwl/cli@14.7.5",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:@nrwl/tao@14.7.5",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:@parcel/watcher@2.0.4",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:chalk@4.1.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:chokidar@3.5.3",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:cli-cursor@3.1.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:cli-spinners@2.6.1",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:cliui@7.0.4",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:dotenv@10.0.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:enquirer@2.3.6",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:fast-glob@3.2.7",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:figures@3.2.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:flat@5.0.2",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:fs-extra@10.1.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:glob@7.1.4",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:ignore@5.2.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:js-yaml@4.1.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:jsonc-parser@3.0.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:minimatch@3.0.5",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:npm-run-path@4.0.1",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:open@8.4.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:semver@7.3.4",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:string-width@4.2.3",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:tar-stream@2.2.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:tmp@0.2.1",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:tsconfig-paths@3.14.1",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:tslib@2.4.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:v8-compile-cache@2.3.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:yargs@17.5.1",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:yargs-parser@21.0.1",
+    "type": "static",
+  },
+]
+`;
+
+exports[`lock-file mapLockFileDataToExternalNodes should map successfully complex pnpm lock file 3`] = `
 Object {
   "data": Object {
-    "dependencies": Object {
-      "esquery": Array [
-        "1.4.0",
-        "1.4.0",
-      ],
-      "typescript": Array [
-        "4.8.3",
-        "4.8.3",
-      ],
-    },
     "packageName": "@phenomnomnominal/tsquery",
-    "peerDependencies": Object {
-      "typescript": Array [
-        "^3 || ^4",
-        "4.8.3",
-      ],
-    },
     "version": "4.1.1",
   },
   "name": "npm:@phenomnomnominal/tsquery",
@@ -395,131 +445,24 @@ Object {
 }
 `;
 
+exports[`lock-file mapLockFileDataToExternalNodes should map successfully complex pnpm lock file 4`] = `
+Array [
+  Object {
+    "source": "npm:@phenomnomnominal/tsquery",
+    "target": "npm:esquery@1.4.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:@phenomnomnominal/tsquery",
+    "target": "npm:typescript@4.8.3",
+    "type": "static",
+  },
+]
+`;
+
 exports[`lock-file mapLockFileDataToExternalNodes should map successfully complex yarn lock file 1`] = `
 Object {
   "data": Object {
-    "dependencies": Object {
-      "@nrwl/cli": Array [
-        "14.7.5",
-        "14.7.5",
-      ],
-      "@nrwl/tao": Array [
-        "14.7.5",
-        "14.7.5",
-      ],
-      "@parcel/watcher": Array [
-        "2.0.4",
-        "2.0.4",
-      ],
-      "chalk": Array [
-        "4.1.0",
-        "4.1.0",
-      ],
-      "chokidar": Array [
-        "^3.5.1",
-        "3.5.3",
-      ],
-      "cli-cursor": Array [
-        "3.1.0",
-        "3.1.0",
-      ],
-      "cli-spinners": Array [
-        "2.6.1",
-        "2.6.1",
-      ],
-      "cliui": Array [
-        "^7.0.2",
-        "7.0.4",
-      ],
-      "dotenv": Array [
-        "~10.0.0",
-        "10.0.0",
-      ],
-      "enquirer": Array [
-        "~2.3.6",
-        "2.3.6",
-      ],
-      "fast-glob": Array [
-        "3.2.7",
-        "3.2.7",
-      ],
-      "figures": Array [
-        "3.2.0",
-        "3.2.0",
-      ],
-      "flat": Array [
-        "^5.0.2",
-        "5.0.2",
-      ],
-      "fs-extra": Array [
-        "^10.1.0",
-        "10.1.0",
-      ],
-      "glob": Array [
-        "7.1.4",
-        "7.1.4",
-      ],
-      "ignore": Array [
-        "^5.0.4",
-        "5.2.0",
-      ],
-      "js-yaml": Array [
-        "4.1.0",
-        "4.1.0",
-      ],
-      "jsonc-parser": Array [
-        "3.0.0",
-        "3.0.0",
-      ],
-      "minimatch": Array [
-        "3.0.5",
-        "3.0.5",
-      ],
-      "npm-run-path": Array [
-        "^4.0.1",
-        "4.0.1",
-      ],
-      "open": Array [
-        "^8.4.0",
-        "8.4.0",
-      ],
-      "semver": Array [
-        "7.3.4",
-        "7.3.4",
-      ],
-      "string-width": Array [
-        "^4.2.3",
-        "4.2.3",
-      ],
-      "tar-stream": Array [
-        "~2.2.0",
-        "2.2.0",
-      ],
-      "tmp": Array [
-        "~0.2.1",
-        "0.2.1",
-      ],
-      "tsconfig-paths": Array [
-        "^3.9.0",
-        "3.14.1",
-      ],
-      "tslib": Array [
-        "^2.3.0",
-        "2.4.0",
-      ],
-      "v8-compile-cache": Array [
-        "2.3.0",
-        "2.3.0",
-      ],
-      "yargs": Array [
-        "^17.4.0",
-        "17.5.1",
-      ],
-      "yargs-parser": Array [
-        "21.0.1",
-        "21.0.1",
-      ],
-    },
     "packageName": "nx",
     "version": "14.7.5",
   },
@@ -528,43 +471,208 @@ Object {
 }
 `;
 
+exports[`lock-file mapLockFileDataToExternalNodes should map successfully complex yarn lock file 2`] = `
+Array [
+  Object {
+    "source": "npm:nx",
+    "target": "npm:@nrwl/cli@14.7.5",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:@nrwl/tao@14.7.5",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:@parcel/watcher@2.0.4",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:chalk@4.1.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:chokidar@3.5.3",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:cli-cursor@3.1.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:cli-spinners@2.6.1",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:cliui@7.0.4",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:dotenv@10.0.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:enquirer@2.3.6",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:fast-glob@3.2.7",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:figures@3.2.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:flat@5.0.2",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:fs-extra@10.1.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:glob@7.1.4",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:ignore@5.2.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:js-yaml@4.1.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:jsonc-parser@3.0.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:minimatch@3.0.5",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:npm-run-path@4.0.1",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:open@8.4.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:semver@7.3.4",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:string-width@4.2.3",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:tar-stream@2.2.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:tmp@0.2.1",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:tsconfig-paths@3.14.1",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:tslib@2.4.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:v8-compile-cache@2.3.0",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:yargs@17.5.1",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:nx",
+    "target": "npm:yargs-parser@21.0.1",
+    "type": "static",
+  },
+]
+`;
+
 exports[`lock-file mapLockFileDataToExternalNodes should map yarn lock file data to external nodes 1`] = `
 Object {
   "data": Object {
-    "dependencies": Object {
-      "cliui": Array [
-        "^7.0.2",
-        "7.0.4",
-      ],
-      "escalade": Array [
-        "^3.1.1",
-        "3.1.1",
-      ],
-      "get-caller-file": Array [
-        "^2.0.5",
-        "2.0.5",
-      ],
-      "require-directory": Array [
-        "^2.1.1",
-        "2.1.1",
-      ],
-      "string-width": Array [
-        "^4.2.3",
-        "4.2.3",
-      ],
-      "y18n": Array [
-        "^5.0.5",
-        "5.0.8",
-      ],
-      "yargs-parser": Array [
-        "^21.0.0",
-        "21.1.1",
-      ],
-    },
     "packageName": "yargs",
     "version": "17.5.1",
   },
   "name": "npm:yargs",
   "type": "npm",
 }
+`;
+
+exports[`lock-file mapLockFileDataToExternalNodes should map yarn lock file data to external nodes 2`] = `
+Array [
+  Object {
+    "source": "npm:yargs",
+    "target": "npm:cliui@7.0.4",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:yargs",
+    "target": "npm:escalade@3.1.1",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:yargs",
+    "target": "npm:get-caller-file@2.0.5",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:yargs",
+    "target": "npm:require-directory@2.1.1",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:yargs",
+    "target": "npm:string-width@4.2.3",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:yargs",
+    "target": "npm:y18n@5.0.8",
+    "type": "static",
+  },
+  Object {
+    "source": "npm:yargs",
+    "target": "npm:yargs-parser@21.1.1",
+    "type": "static",
+  },
+]
 `;

--- a/packages/nx/src/utils/lock-file/__snapshots__/lock-file.spec.ts.snap
+++ b/packages/nx/src/utils/lock-file/__snapshots__/lock-file.spec.ts.snap
@@ -3,6 +3,7 @@
 exports[`lock-file mapLockFileDataToExternalNodes should map npm lock file data to external nodes 1`] = `
 Object {
   "data": Object {
+    "hash": "54342be9f4609650eba8e995881c5eb98c29b9d7bb95b9a699d9e9df68d6428e",
     "packageName": "yargs",
     "version": "17.5.1",
   },
@@ -15,37 +16,37 @@ exports[`lock-file mapLockFileDataToExternalNodes should map npm lock file data 
 Array [
   Object {
     "source": "npm:yargs",
-    "target": "npm:cliui@7.0.4",
+    "target": "npm:cliui",
     "type": "static",
   },
   Object {
     "source": "npm:yargs",
-    "target": "npm:escalade@3.1.1",
+    "target": "npm:escalade",
     "type": "static",
   },
   Object {
     "source": "npm:yargs",
-    "target": "npm:get-caller-file@2.0.5",
+    "target": "npm:get-caller-file",
     "type": "static",
   },
   Object {
     "source": "npm:yargs",
-    "target": "npm:require-directory@2.1.1",
+    "target": "npm:require-directory",
     "type": "static",
   },
   Object {
     "source": "npm:yargs",
-    "target": "npm:string-width@4.2.3",
+    "target": "npm:string-width",
     "type": "static",
   },
   Object {
     "source": "npm:yargs",
-    "target": "npm:y18n@5.0.8",
+    "target": "npm:y18n",
     "type": "static",
   },
   Object {
     "source": "npm:yargs",
-    "target": "npm:yargs-parser@21.0.1",
+    "target": "npm:yargs-parser",
     "type": "static",
   },
 ]
@@ -54,6 +55,7 @@ Array [
 exports[`lock-file mapLockFileDataToExternalNodes should map pnpm lock file data to external nodes 1`] = `
 Object {
   "data": Object {
+    "hash": "c22918aa52c9fdce78bf82451d8114e00b6d4375a8e5b1d1d96c6cf4755dbe1a",
     "packageName": "yargs",
     "version": "17.5.1",
   },
@@ -66,37 +68,37 @@ exports[`lock-file mapLockFileDataToExternalNodes should map pnpm lock file data
 Array [
   Object {
     "source": "npm:yargs",
-    "target": "npm:cliui@7.0.4",
+    "target": "npm:cliui",
     "type": "static",
   },
   Object {
     "source": "npm:yargs",
-    "target": "npm:escalade@3.1.1",
+    "target": "npm:escalade",
     "type": "static",
   },
   Object {
     "source": "npm:yargs",
-    "target": "npm:get-caller-file@2.0.5",
+    "target": "npm:get-caller-file",
     "type": "static",
   },
   Object {
     "source": "npm:yargs",
-    "target": "npm:require-directory@2.1.1",
+    "target": "npm:require-directory",
     "type": "static",
   },
   Object {
     "source": "npm:yargs",
-    "target": "npm:string-width@4.2.3",
+    "target": "npm:string-width",
     "type": "static",
   },
   Object {
     "source": "npm:yargs",
-    "target": "npm:y18n@5.0.8",
+    "target": "npm:y18n",
     "type": "static",
   },
   Object {
     "source": "npm:yargs",
-    "target": "npm:yargs-parser@21.1.1",
+    "target": "npm:yargs-parser",
     "type": "static",
   },
 ]
@@ -105,6 +107,7 @@ Array [
 exports[`lock-file mapLockFileDataToExternalNodes should map successfully complex npm lock file 1`] = `
 Object {
   "data": Object {
+    "hash": "1e61b9db38c17534ce427d40ce84f9c03b4c439253f659e9a48513a10a52b465",
     "packageName": "nx",
     "version": "14.7.5",
   },
@@ -117,82 +120,82 @@ exports[`lock-file mapLockFileDataToExternalNodes should map successfully comple
 Array [
   Object {
     "source": "npm:nx",
-    "target": "npm:@nrwl/cli@14.7.5",
+    "target": "npm:@nrwl/cli",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:@nrwl/tao@14.7.5",
+    "target": "npm:@nrwl/tao",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:@parcel/watcher@2.0.4",
+    "target": "npm:@parcel/watcher",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:chalk@4.1.0",
+    "target": "npm:chalk",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:chokidar@3.5.3",
+    "target": "npm:chokidar",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:cli-cursor@3.1.0",
+    "target": "npm:cli-cursor",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:cli-spinners@2.6.1",
+    "target": "npm:cli-spinners",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:cliui@7.0.4",
+    "target": "npm:cliui",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:dotenv@10.0.0",
+    "target": "npm:dotenv",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:enquirer@2.3.6",
+    "target": "npm:enquirer",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:fast-glob@3.2.7",
+    "target": "npm:fast-glob",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:figures@3.2.0",
+    "target": "npm:figures",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:flat@5.0.2",
+    "target": "npm:flat",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:fs-extra@10.1.0",
+    "target": "npm:fs-extra",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:glob@7.1.4",
+    "target": "npm:glob",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:ignore@5.2.0",
+    "target": "npm:ignore",
     "type": "static",
   },
   Object {
@@ -202,67 +205,67 @@ Array [
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:jsonc-parser@3.0.0",
+    "target": "npm:jsonc-parser",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:minimatch@3.0.5",
+    "target": "npm:minimatch",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:npm-run-path@4.0.1",
+    "target": "npm:npm-run-path",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:open@8.4.0",
+    "target": "npm:open",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:semver@7.3.4",
+    "target": "npm:semver",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:string-width@4.2.3",
+    "target": "npm:string-width",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:tar-stream@2.2.0",
+    "target": "npm:tar-stream",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:tmp@0.2.1",
+    "target": "npm:tmp",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:tsconfig-paths@3.14.1",
+    "target": "npm:tsconfig-paths",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:tslib@2.4.0",
+    "target": "npm:tslib",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:v8-compile-cache@2.3.0",
+    "target": "npm:v8-compile-cache",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:yargs@17.5.1",
+    "target": "npm:yargs",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:yargs-parser@21.0.1",
+    "target": "npm:yargs-parser",
     "type": "static",
   },
 ]
@@ -271,6 +274,7 @@ Array [
 exports[`lock-file mapLockFileDataToExternalNodes should map successfully complex pnpm lock file 1`] = `
 Object {
   "data": Object {
+    "hash": "1e61b9db38c17534ce427d40ce84f9c03b4c439253f659e9a48513a10a52b465",
     "packageName": "nx",
     "version": "14.7.5",
   },
@@ -283,152 +287,152 @@ exports[`lock-file mapLockFileDataToExternalNodes should map successfully comple
 Array [
   Object {
     "source": "npm:nx",
-    "target": "npm:@nrwl/cli@14.7.5",
+    "target": "npm:@nrwl/cli",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:@nrwl/tao@14.7.5",
+    "target": "npm:@nrwl/tao",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:@parcel/watcher@2.0.4",
+    "target": "npm:@parcel/watcher",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:chalk@4.1.0",
+    "target": "npm:chalk",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:chokidar@3.5.3",
+    "target": "npm:chokidar",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:cli-cursor@3.1.0",
+    "target": "npm:cli-cursor",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:cli-spinners@2.6.1",
+    "target": "npm:cli-spinners",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:cliui@7.0.4",
+    "target": "npm:cliui",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:dotenv@10.0.0",
+    "target": "npm:dotenv",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:enquirer@2.3.6",
+    "target": "npm:enquirer",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:fast-glob@3.2.7",
+    "target": "npm:fast-glob",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:figures@3.2.0",
+    "target": "npm:figures",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:flat@5.0.2",
+    "target": "npm:flat",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:fs-extra@10.1.0",
+    "target": "npm:fs-extra",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:glob@7.1.4",
+    "target": "npm:glob",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:ignore@5.2.0",
+    "target": "npm:ignore",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:js-yaml@4.1.0",
+    "target": "npm:js-yaml",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:jsonc-parser@3.0.0",
+    "target": "npm:jsonc-parser",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:minimatch@3.0.5",
+    "target": "npm:minimatch",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:npm-run-path@4.0.1",
+    "target": "npm:npm-run-path",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:open@8.4.0",
+    "target": "npm:open",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:semver@7.3.4",
+    "target": "npm:semver",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:string-width@4.2.3",
+    "target": "npm:string-width",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:tar-stream@2.2.0",
+    "target": "npm:tar-stream",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:tmp@0.2.1",
+    "target": "npm:tmp",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:tsconfig-paths@3.14.1",
+    "target": "npm:tsconfig-paths",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:tslib@2.4.0",
+    "target": "npm:tslib",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:v8-compile-cache@2.3.0",
+    "target": "npm:v8-compile-cache",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:yargs@17.5.1",
+    "target": "npm:yargs",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:yargs-parser@21.0.1",
+    "target": "npm:yargs-parser",
     "type": "static",
   },
 ]
@@ -437,6 +441,7 @@ Array [
 exports[`lock-file mapLockFileDataToExternalNodes should map successfully complex pnpm lock file 3`] = `
 Object {
   "data": Object {
+    "hash": "6c5961e1a6ab89174727587860e480508f945407ce4c2cc7c9f1e46f181e6468",
     "packageName": "@phenomnomnominal/tsquery",
     "version": "4.1.1",
   },
@@ -449,12 +454,12 @@ exports[`lock-file mapLockFileDataToExternalNodes should map successfully comple
 Array [
   Object {
     "source": "npm:@phenomnomnominal/tsquery",
-    "target": "npm:esquery@1.4.0",
+    "target": "npm:esquery",
     "type": "static",
   },
   Object {
     "source": "npm:@phenomnomnominal/tsquery",
-    "target": "npm:typescript@4.8.3",
+    "target": "npm:typescript",
     "type": "static",
   },
 ]
@@ -463,6 +468,7 @@ Array [
 exports[`lock-file mapLockFileDataToExternalNodes should map successfully complex yarn lock file 1`] = `
 Object {
   "data": Object {
+    "hash": "1e61b9db38c17534ce427d40ce84f9c03b4c439253f659e9a48513a10a52b465",
     "packageName": "nx",
     "version": "14.7.5",
   },
@@ -475,152 +481,152 @@ exports[`lock-file mapLockFileDataToExternalNodes should map successfully comple
 Array [
   Object {
     "source": "npm:nx",
-    "target": "npm:@nrwl/cli@14.7.5",
+    "target": "npm:@nrwl/cli",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:@nrwl/tao@14.7.5",
+    "target": "npm:@nrwl/tao",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:@parcel/watcher@2.0.4",
+    "target": "npm:@parcel/watcher",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:chalk@4.1.0",
+    "target": "npm:chalk",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:chokidar@3.5.3",
+    "target": "npm:chokidar",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:cli-cursor@3.1.0",
+    "target": "npm:cli-cursor",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:cli-spinners@2.6.1",
+    "target": "npm:cli-spinners",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:cliui@7.0.4",
+    "target": "npm:cliui",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:dotenv@10.0.0",
+    "target": "npm:dotenv",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:enquirer@2.3.6",
+    "target": "npm:enquirer",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:fast-glob@3.2.7",
+    "target": "npm:fast-glob",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:figures@3.2.0",
+    "target": "npm:figures",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:flat@5.0.2",
+    "target": "npm:flat",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:fs-extra@10.1.0",
+    "target": "npm:fs-extra",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:glob@7.1.4",
+    "target": "npm:glob",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:ignore@5.2.0",
+    "target": "npm:ignore",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:js-yaml@4.1.0",
+    "target": "npm:js-yaml",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:jsonc-parser@3.0.0",
+    "target": "npm:jsonc-parser",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:minimatch@3.0.5",
+    "target": "npm:minimatch",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:npm-run-path@4.0.1",
+    "target": "npm:npm-run-path",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:open@8.4.0",
+    "target": "npm:open",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:semver@7.3.4",
+    "target": "npm:semver",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:string-width@4.2.3",
+    "target": "npm:string-width",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:tar-stream@2.2.0",
+    "target": "npm:tar-stream",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:tmp@0.2.1",
+    "target": "npm:tmp",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:tsconfig-paths@3.14.1",
+    "target": "npm:tsconfig-paths",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:tslib@2.4.0",
+    "target": "npm:tslib",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:v8-compile-cache@2.3.0",
+    "target": "npm:v8-compile-cache",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:yargs@17.5.1",
+    "target": "npm:yargs",
     "type": "static",
   },
   Object {
     "source": "npm:nx",
-    "target": "npm:yargs-parser@21.0.1",
+    "target": "npm:yargs-parser",
     "type": "static",
   },
 ]
@@ -629,6 +635,7 @@ Array [
 exports[`lock-file mapLockFileDataToExternalNodes should map yarn lock file data to external nodes 1`] = `
 Object {
   "data": Object {
+    "hash": "c22918aa52c9fdce78bf82451d8114e00b6d4375a8e5b1d1d96c6cf4755dbe1a",
     "packageName": "yargs",
     "version": "17.5.1",
   },
@@ -641,37 +648,37 @@ exports[`lock-file mapLockFileDataToExternalNodes should map yarn lock file data
 Array [
   Object {
     "source": "npm:yargs",
-    "target": "npm:cliui@7.0.4",
+    "target": "npm:cliui",
     "type": "static",
   },
   Object {
     "source": "npm:yargs",
-    "target": "npm:escalade@3.1.1",
+    "target": "npm:escalade",
     "type": "static",
   },
   Object {
     "source": "npm:yargs",
-    "target": "npm:get-caller-file@2.0.5",
+    "target": "npm:get-caller-file",
     "type": "static",
   },
   Object {
     "source": "npm:yargs",
-    "target": "npm:require-directory@2.1.1",
+    "target": "npm:require-directory",
     "type": "static",
   },
   Object {
     "source": "npm:yargs",
-    "target": "npm:string-width@4.2.3",
+    "target": "npm:string-width",
     "type": "static",
   },
   Object {
     "source": "npm:yargs",
-    "target": "npm:y18n@5.0.8",
+    "target": "npm:y18n",
     "type": "static",
   },
   Object {
     "source": "npm:yargs",
-    "target": "npm:yargs-parser@21.1.1",
+    "target": "npm:yargs-parser",
     "type": "static",
   },
 ]

--- a/packages/nx/src/utils/lock-file/__snapshots__/lock-file.spec.ts.snap
+++ b/packages/nx/src/utils/lock-file/__snapshots__/lock-file.spec.ts.snap
@@ -477,7 +477,7 @@ Object {
       ],
       "npm-run-path": Array [
         "^4.0.1",
-        "4.0.2",
+        "4.0.1",
       ],
       "open": Array [
         "^8.4.0",

--- a/packages/nx/src/utils/lock-file/__snapshots__/lock-file.spec.ts.snap
+++ b/packages/nx/src/utils/lock-file/__snapshots__/lock-file.spec.ts.snap
@@ -82,6 +82,452 @@ Object {
 }
 `;
 
+exports[`lock-file mapLockFileDataToExternalNodes should map successfully complex npm lock file 1`] = `
+Object {
+  "data": Object {
+    "dependencies": Object {
+      "@nrwl/cli": Array [
+        "14.7.5",
+        "14.7.5",
+      ],
+      "@nrwl/tao": Array [
+        "14.7.5",
+        "14.7.5",
+      ],
+      "@parcel/watcher": Array [
+        "2.0.4",
+        "2.0.4",
+      ],
+      "chalk": Array [
+        "4.1.0",
+        "4.1.0",
+      ],
+      "chokidar": Array [
+        "^3.5.1",
+        "3.5.3",
+      ],
+      "cli-cursor": Array [
+        "3.1.0",
+        "3.1.0",
+      ],
+      "cli-spinners": Array [
+        "2.6.1",
+        "2.6.1",
+      ],
+      "cliui": Array [
+        "^7.0.2",
+        "7.0.4",
+      ],
+      "dotenv": Array [
+        "~10.0.0",
+        "10.0.0",
+      ],
+      "enquirer": Array [
+        "~2.3.6",
+        "2.3.6",
+      ],
+      "fast-glob": Array [
+        "3.2.7",
+        "3.2.7",
+      ],
+      "figures": Array [
+        "3.2.0",
+        "3.2.0",
+      ],
+      "flat": Array [
+        "^5.0.2",
+        "5.0.2",
+      ],
+      "fs-extra": Array [
+        "^10.1.0",
+        "10.1.0",
+      ],
+      "glob": Array [
+        "7.1.4",
+        "7.1.4",
+      ],
+      "ignore": Array [
+        "^5.0.4",
+        "5.2.0",
+      ],
+      "js-yaml": Array [
+        "4.1.0",
+        "4.1.0",
+      ],
+      "jsonc-parser": Array [
+        "3.0.0",
+        "3.0.0",
+      ],
+      "minimatch": Array [
+        "3.0.5",
+        "3.0.5",
+      ],
+      "npm-run-path": Array [
+        "^4.0.1",
+        "4.0.1",
+      ],
+      "open": Array [
+        "^8.4.0",
+        "8.4.0",
+      ],
+      "semver": Array [
+        "7.3.4",
+        "7.3.4",
+      ],
+      "string-width": Array [
+        "^4.2.3",
+        "4.2.3",
+      ],
+      "tar-stream": Array [
+        "~2.2.0",
+        "2.2.0",
+      ],
+      "tmp": Array [
+        "~0.2.1",
+        "0.2.1",
+      ],
+      "tsconfig-paths": Array [
+        "^3.9.0",
+        "3.14.1",
+      ],
+      "tslib": Array [
+        "^2.3.0",
+        "2.4.0",
+      ],
+      "v8-compile-cache": Array [
+        "2.3.0",
+        "2.3.0",
+      ],
+      "yargs": Array [
+        "^17.4.0",
+        "17.5.1",
+      ],
+      "yargs-parser": Array [
+        "21.0.1",
+        "21.0.1",
+      ],
+    },
+    "packageName": "nx",
+    "peerDependencies": Object {
+      "@swc-node/register": Array [
+        "^1.4.2",
+        undefined,
+      ],
+      "@swc/core": Array [
+        "^1.2.173",
+        undefined,
+      ],
+    },
+    "version": "14.7.5",
+  },
+  "name": "npm:nx",
+  "type": "npm",
+}
+`;
+
+exports[`lock-file mapLockFileDataToExternalNodes should map successfully complex pnpm lock file 1`] = `
+Object {
+  "data": Object {
+    "dependencies": Object {
+      "@nrwl/cli": Array [
+        "14.7.5",
+        "14.7.5",
+      ],
+      "@nrwl/tao": Array [
+        "14.7.5",
+        "14.7.5",
+      ],
+      "@parcel/watcher": Array [
+        "2.0.4",
+        "2.0.4",
+      ],
+      "chalk": Array [
+        "4.1.0",
+        "4.1.0",
+      ],
+      "chokidar": Array [
+        "3.5.3",
+        "3.5.3",
+      ],
+      "cli-cursor": Array [
+        "3.1.0",
+        "3.1.0",
+      ],
+      "cli-spinners": Array [
+        "2.6.1",
+        "2.6.1",
+      ],
+      "cliui": Array [
+        "7.0.4",
+        "7.0.4",
+      ],
+      "dotenv": Array [
+        "10.0.0",
+        "10.0.0",
+      ],
+      "enquirer": Array [
+        "2.3.6",
+        "2.3.6",
+      ],
+      "fast-glob": Array [
+        "3.2.7",
+        "3.2.7",
+      ],
+      "figures": Array [
+        "3.2.0",
+        "3.2.0",
+      ],
+      "flat": Array [
+        "5.0.2",
+        "5.0.2",
+      ],
+      "fs-extra": Array [
+        "10.1.0",
+        "10.1.0",
+      ],
+      "glob": Array [
+        "7.1.4",
+        "7.1.4",
+      ],
+      "ignore": Array [
+        "5.2.0",
+        "5.2.0",
+      ],
+      "js-yaml": Array [
+        "4.1.0",
+        "4.1.0",
+      ],
+      "jsonc-parser": Array [
+        "3.0.0",
+        "3.0.0",
+      ],
+      "minimatch": Array [
+        "3.0.5",
+        "3.0.5",
+      ],
+      "npm-run-path": Array [
+        "4.0.1",
+        "4.0.1",
+      ],
+      "open": Array [
+        "8.4.0",
+        "8.4.0",
+      ],
+      "semver": Array [
+        "7.3.4",
+        "7.3.4",
+      ],
+      "string-width": Array [
+        "4.2.3",
+        "4.2.3",
+      ],
+      "tar-stream": Array [
+        "2.2.0",
+        "2.2.0",
+      ],
+      "tmp": Array [
+        "0.2.1",
+        "0.2.1",
+      ],
+      "tsconfig-paths": Array [
+        "3.14.1",
+        "3.14.1",
+      ],
+      "tslib": Array [
+        "2.4.0",
+        "2.4.0",
+      ],
+      "v8-compile-cache": Array [
+        "2.3.0",
+        "2.3.0",
+      ],
+      "yargs": Array [
+        "17.5.1",
+        "17.5.1",
+      ],
+      "yargs-parser": Array [
+        "21.0.1",
+        "21.0.1",
+      ],
+    },
+    "packageName": "nx",
+    "peerDependencies": Object {
+      "@swc-node/register": Array [
+        "^1.4.2",
+        undefined,
+      ],
+      "@swc/core": Array [
+        "^1.2.173",
+        undefined,
+      ],
+    },
+    "version": "14.7.5",
+  },
+  "name": "npm:nx",
+  "type": "npm",
+}
+`;
+
+exports[`lock-file mapLockFileDataToExternalNodes should map successfully complex pnpm lock file 2`] = `
+Object {
+  "data": Object {
+    "dependencies": Object {
+      "esquery": Array [
+        "1.4.0",
+        "1.4.0",
+      ],
+      "typescript": Array [
+        "4.8.3",
+        "4.8.3",
+      ],
+    },
+    "packageName": "@phenomnomnominal/tsquery",
+    "peerDependencies": Object {
+      "typescript": Array [
+        "^3 || ^4",
+        "4.8.3",
+      ],
+    },
+    "version": "4.1.1",
+  },
+  "name": "npm:@phenomnomnominal/tsquery",
+  "type": "npm",
+}
+`;
+
+exports[`lock-file mapLockFileDataToExternalNodes should map successfully complex yarn lock file 1`] = `
+Object {
+  "data": Object {
+    "dependencies": Object {
+      "@nrwl/cli": Array [
+        "14.7.5",
+        "14.7.5",
+      ],
+      "@nrwl/tao": Array [
+        "14.7.5",
+        "14.7.5",
+      ],
+      "@parcel/watcher": Array [
+        "2.0.4",
+        "2.0.4",
+      ],
+      "chalk": Array [
+        "4.1.0",
+        "4.1.0",
+      ],
+      "chokidar": Array [
+        "^3.5.1",
+        "3.5.3",
+      ],
+      "cli-cursor": Array [
+        "3.1.0",
+        "3.1.0",
+      ],
+      "cli-spinners": Array [
+        "2.6.1",
+        "2.6.1",
+      ],
+      "cliui": Array [
+        "^7.0.2",
+        "7.0.4",
+      ],
+      "dotenv": Array [
+        "~10.0.0",
+        "10.0.0",
+      ],
+      "enquirer": Array [
+        "~2.3.6",
+        "2.3.6",
+      ],
+      "fast-glob": Array [
+        "3.2.7",
+        "3.2.7",
+      ],
+      "figures": Array [
+        "3.2.0",
+        "3.2.0",
+      ],
+      "flat": Array [
+        "^5.0.2",
+        "5.0.2",
+      ],
+      "fs-extra": Array [
+        "^10.1.0",
+        "10.1.0",
+      ],
+      "glob": Array [
+        "7.1.4",
+        "7.1.4",
+      ],
+      "ignore": Array [
+        "^5.0.4",
+        "5.2.0",
+      ],
+      "js-yaml": Array [
+        "4.1.0",
+        "4.1.0",
+      ],
+      "jsonc-parser": Array [
+        "3.0.0",
+        "3.0.0",
+      ],
+      "minimatch": Array [
+        "3.0.5",
+        "3.0.5",
+      ],
+      "npm-run-path": Array [
+        "^4.0.1",
+        "4.0.2",
+      ],
+      "open": Array [
+        "^8.4.0",
+        "8.4.0",
+      ],
+      "semver": Array [
+        "7.3.4",
+        "7.3.4",
+      ],
+      "string-width": Array [
+        "^4.2.3",
+        "4.2.3",
+      ],
+      "tar-stream": Array [
+        "~2.2.0",
+        "2.2.0",
+      ],
+      "tmp": Array [
+        "~0.2.1",
+        "0.2.1",
+      ],
+      "tsconfig-paths": Array [
+        "^3.9.0",
+        "3.14.1",
+      ],
+      "tslib": Array [
+        "^2.3.0",
+        "2.4.0",
+      ],
+      "v8-compile-cache": Array [
+        "2.3.0",
+        "2.3.0",
+      ],
+      "yargs": Array [
+        "^17.4.0",
+        "17.5.1",
+      ],
+      "yargs-parser": Array [
+        "21.0.1",
+        "21.0.1",
+      ],
+    },
+    "packageName": "nx",
+    "version": "14.7.5",
+  },
+  "name": "npm:nx",
+  "type": "npm",
+}
+`;
+
 exports[`lock-file mapLockFileDataToExternalNodes should map yarn lock file data to external nodes 1`] = `
 Object {
   "data": Object {

--- a/packages/nx/src/utils/lock-file/__snapshots__/lock-file.spec.ts.snap
+++ b/packages/nx/src/utils/lock-file/__snapshots__/lock-file.spec.ts.snap
@@ -1,0 +1,124 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`lock-file mapLockFileDataToExternalNodes should map npm lock file data to external nodes 1`] = `
+Object {
+  "data": Object {
+    "dependencies": Object {
+      "cliui": Array [
+        "^7.0.2",
+        "7.0.4",
+      ],
+      "escalade": Array [
+        "^3.1.1",
+        "3.1.1",
+      ],
+      "get-caller-file": Array [
+        "^2.0.5",
+        "2.0.5",
+      ],
+      "require-directory": Array [
+        "^2.1.1",
+        "2.1.1",
+      ],
+      "string-width": Array [
+        "^4.2.3",
+        "4.2.3",
+      ],
+      "y18n": Array [
+        "^5.0.5",
+        "5.0.8",
+      ],
+      "yargs-parser": Array [
+        "^21.0.0",
+        "21.0.1",
+      ],
+    },
+    "packageName": "yargs",
+    "version": "17.5.1",
+  },
+  "name": "npm:yargs",
+  "type": "npm",
+}
+`;
+
+exports[`lock-file mapLockFileDataToExternalNodes should map pnpm lock file data to external nodes 1`] = `
+Object {
+  "data": Object {
+    "dependencies": Object {
+      "cliui": Array [
+        "7.0.4",
+        "7.0.4",
+      ],
+      "escalade": Array [
+        "3.1.1",
+        "3.1.1",
+      ],
+      "get-caller-file": Array [
+        "2.0.5",
+        "2.0.5",
+      ],
+      "require-directory": Array [
+        "2.1.1",
+        "2.1.1",
+      ],
+      "string-width": Array [
+        "4.2.3",
+        "4.2.3",
+      ],
+      "y18n": Array [
+        "5.0.8",
+        "5.0.8",
+      ],
+      "yargs-parser": Array [
+        "21.1.1",
+        "21.1.1",
+      ],
+    },
+    "packageName": "yargs",
+    "version": "17.5.1",
+  },
+  "name": "npm:yargs",
+  "type": "npm",
+}
+`;
+
+exports[`lock-file mapLockFileDataToExternalNodes should map yarn lock file data to external nodes 1`] = `
+Object {
+  "data": Object {
+    "dependencies": Object {
+      "cliui": Array [
+        "^7.0.2",
+        "7.0.4",
+      ],
+      "escalade": Array [
+        "^3.1.1",
+        "3.1.1",
+      ],
+      "get-caller-file": Array [
+        "^2.0.5",
+        "2.0.5",
+      ],
+      "require-directory": Array [
+        "^2.1.1",
+        "2.1.1",
+      ],
+      "string-width": Array [
+        "^4.2.3",
+        "4.2.3",
+      ],
+      "y18n": Array [
+        "^5.0.5",
+        "5.0.8",
+      ],
+      "yargs-parser": Array [
+        "^21.0.0",
+        "21.1.1",
+      ],
+    },
+    "packageName": "yargs",
+    "version": "17.5.1",
+  },
+  "name": "npm:yargs",
+  "type": "npm",
+}
+`;

--- a/packages/nx/src/utils/lock-file/__snapshots__/npm.spec.ts.snap
+++ b/packages/nx/src/utils/lock-file/__snapshots__/npm.spec.ts.snap
@@ -19,6 +19,7 @@ Object {
       },
     ],
     "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+    "rootVersion": true,
     "version": "2.2.0",
   },
 }
@@ -43,6 +44,7 @@ Object {
       },
     ],
     "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+    "rootVersion": true,
     "version": "4.8.3",
   },
 }

--- a/packages/nx/src/utils/lock-file/__snapshots__/pnpm.spec.ts.snap
+++ b/packages/nx/src/utils/lock-file/__snapshots__/pnpm.spec.ts.snap
@@ -3,6 +3,11 @@
 exports[`pnpm LockFile utility lock file with inline specifiers should parse lockfile (IS) 1`] = `
 Object {
   "@ampproject/remapping@2.2.0": Object {
+    "dependencies": Object {
+      "@jridgewell/gen-mapping": "0.1.1",
+      "@jridgewell/trace-mapping": "0.3.15",
+    },
+    "dev": true,
     "engines": Object {
       "node": ">=6.0.0",
     },
@@ -13,7 +18,6 @@ Object {
             "@jridgewell/gen-mapping": "0.1.1",
             "@jridgewell/trace-mapping": "0.3.15",
           },
-          "dev": true,
         },
         "isDependency": false,
         "isDevDependency": false,
@@ -32,15 +36,14 @@ Object {
 exports[`pnpm LockFile utility lock file with inline specifiers should parse lockfile (IS) 2`] = `
 Object {
   "typescript@4.8.3": Object {
+    "dev": true,
     "engines": Object {
       "node": ">=4.2.0",
     },
+    "hasBin": true,
     "packageMeta": Array [
       Object {
-        "dependencyDetails": Object {
-          "dev": true,
-          "hasBin": true,
-        },
+        "dependencyDetails": Object {},
         "isDependency": false,
         "isDevDependency": true,
         "key": "/typescript/4.8.3",
@@ -58,6 +61,11 @@ Object {
 exports[`pnpm LockFile utility standard lock file should parse lockfile correctly 1`] = `
 Object {
   "@ampproject/remapping@2.2.0": Object {
+    "dependencies": Object {
+      "@jridgewell/gen-mapping": "0.1.1",
+      "@jridgewell/trace-mapping": "0.3.15",
+    },
+    "dev": true,
     "engines": Object {
       "node": ">=6.0.0",
     },
@@ -68,7 +76,6 @@ Object {
             "@jridgewell/gen-mapping": "0.1.1",
             "@jridgewell/trace-mapping": "0.3.15",
           },
-          "dev": true,
         },
         "isDependency": false,
         "isDevDependency": false,
@@ -87,15 +94,14 @@ Object {
 exports[`pnpm LockFile utility standard lock file should parse lockfile correctly 2`] = `
 Object {
   "typescript@4.8.3": Object {
+    "dev": true,
     "engines": Object {
       "node": ">=4.2.0",
     },
+    "hasBin": true,
     "packageMeta": Array [
       Object {
-        "dependencyDetails": Object {
-          "dev": true,
-          "hasBin": true,
-        },
+        "dependencyDetails": Object {},
         "isDependency": false,
         "isDevDependency": true,
         "key": "/typescript/4.8.3",

--- a/packages/nx/src/utils/lock-file/__snapshots__/pnpm.spec.ts.snap
+++ b/packages/nx/src/utils/lock-file/__snapshots__/pnpm.spec.ts.snap
@@ -28,6 +28,7 @@ Object {
     "resolution": Object {
       "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
     },
+    "rootVersion": true,
     "version": "2.2.0",
   },
 }
@@ -53,6 +54,7 @@ Object {
     "resolution": Object {
       "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
     },
+    "rootVersion": true,
     "version": "4.8.3",
   },
 }
@@ -86,6 +88,7 @@ Object {
     "resolution": Object {
       "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
     },
+    "rootVersion": true,
     "version": "2.2.0",
   },
 }
@@ -111,6 +114,7 @@ Object {
     "resolution": Object {
       "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
     },
+    "rootVersion": true,
     "version": "4.8.3",
   },
 }

--- a/packages/nx/src/utils/lock-file/__snapshots__/yarn.spec.ts.snap
+++ b/packages/nx/src/utils/lock-file/__snapshots__/yarn.spec.ts.snap
@@ -14,6 +14,7 @@ Object {
       "@ampproject/remapping@npm:^2.1.0",
     ],
     "resolution": "@ampproject/remapping@npm:2.2.0",
+    "rootVersion": true,
     "version": "2.2.0",
   },
 }
@@ -33,6 +34,7 @@ Object {
       "typescript@npm:~4.8.2",
     ],
     "resolution": "typescript@npm:4.8.3",
+    "rootVersion": true,
     "version": "4.8.3",
   },
 }
@@ -50,6 +52,7 @@ Object {
       "@ampproject/remapping@^2.1.0",
     ],
     "resolved": "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d",
+    "rootVersion": true,
     "version": "2.2.0",
   },
 }
@@ -63,6 +66,7 @@ Object {
       "typescript@~4.8.2",
     ],
     "resolved": "https://registry.yarnpkg.com/typescript/-/typescript-4.8.3.tgz#d59344522c4bc464a65a730ac695007fdb66dd88",
+    "rootVersion": true,
     "version": "4.8.3",
   },
 }

--- a/packages/nx/src/utils/lock-file/lock-file-type.ts
+++ b/packages/nx/src/utils/lock-file/lock-file-type.ts
@@ -1,5 +1,6 @@
 export interface PackageDependency {
   version?: string;
+  rootVersion?: boolean;
   packageMeta: any[];
   dependencies?: Record<string, string>;
   [key: string]: any;

--- a/packages/nx/src/utils/lock-file/lock-file.spec.ts
+++ b/packages/nx/src/utils/lock-file/lock-file.spec.ts
@@ -1,4 +1,4 @@
-import { mapLockFileDataToExternalNodes } from './lock-file';
+import { mapLockFileDataToPartialGraph } from './lock-file';
 import { parseNpmLockFile } from './npm';
 import { parsePnpmLockFile } from './pnpm';
 import { parseYarnLockFile } from './yarn';
@@ -20,51 +20,60 @@ describe('lock-file', () => {
     it('should map yarn lock file data to external nodes', () => {
       const lockFileData = parseYarnLockFile(lockFileDevkitAndYargs);
 
-      const mappedExernalNodes = mapLockFileDataToExternalNodes(lockFileData);
+      const partialGraph = mapLockFileDataToPartialGraph(lockFileData);
 
-      expect(mappedExernalNodes['npm:yargs']).toMatchSnapshot();
+      expect(partialGraph.externalNodes['npm:yargs']).toMatchSnapshot();
+      expect(partialGraph.dependencies['npm:yargs']).toMatchSnapshot();
     });
 
     it('should map successfully complex yarn lock file', () => {
       const lockFileData = parseYarnLockFile(yarnLockFile);
 
-      const mappedExernalNodes = mapLockFileDataToExternalNodes(lockFileData);
+      const partialGraph = mapLockFileDataToPartialGraph(lockFileData);
 
-      expect(mappedExernalNodes['npm:nx']).toMatchSnapshot();
+      expect(partialGraph.externalNodes['npm:nx']).toMatchSnapshot();
+      expect(partialGraph.dependencies['npm:nx']).toMatchSnapshot();
     });
 
     it('should map npm lock file data to external nodes', () => {
       const lockFileData = parseNpmLockFile(npmLockFileYargsOnly);
 
-      const mappedExernalNodes = mapLockFileDataToExternalNodes(lockFileData);
+      const partialGraph = mapLockFileDataToPartialGraph(lockFileData);
 
-      expect(mappedExernalNodes['npm:yargs']).toMatchSnapshot();
+      expect(partialGraph.externalNodes['npm:yargs']).toMatchSnapshot();
+      expect(partialGraph.dependencies['npm:yargs']).toMatchSnapshot();
     });
 
     it('should map successfully complex npm lock file', () => {
       const lockFileData = parseNpmLockFile(npmLockFile);
 
-      const mappedExernalNodes = mapLockFileDataToExternalNodes(lockFileData);
+      const partialGraph = mapLockFileDataToPartialGraph(lockFileData);
 
-      expect(mappedExernalNodes['npm:nx']).toMatchSnapshot();
+      expect(partialGraph.externalNodes['npm:nx']).toMatchSnapshot();
+      expect(partialGraph.dependencies['npm:nx']).toMatchSnapshot();
     });
 
     it('should map pnpm lock file data to external nodes', () => {
       const lockFileData = parsePnpmLockFile(pnpmLockFileYargsOnly);
 
-      const mappedExernalNodes = mapLockFileDataToExternalNodes(lockFileData);
+      const partialGraph = mapLockFileDataToPartialGraph(lockFileData);
 
-      expect(mappedExernalNodes['npm:yargs']).toMatchSnapshot();
+      expect(partialGraph.externalNodes['npm:yargs']).toMatchSnapshot();
+      expect(partialGraph.dependencies['npm:yargs']).toMatchSnapshot();
     });
 
     it('should map successfully complex pnpm lock file', () => {
       const lockFileData = parsePnpmLockFile(pnpmLockFile);
 
-      const mappedExernalNodes = mapLockFileDataToExternalNodes(lockFileData);
+      const partialGraph = mapLockFileDataToPartialGraph(lockFileData);
 
-      expect(mappedExernalNodes['npm:nx']).toMatchSnapshot();
+      expect(partialGraph.externalNodes['npm:nx']).toMatchSnapshot();
+      expect(partialGraph.dependencies['npm:nx']).toMatchSnapshot();
       expect(
-        mappedExernalNodes['npm:@phenomnomnominal/tsquery']
+        partialGraph.externalNodes['npm:@phenomnomnominal/tsquery']
+      ).toMatchSnapshot();
+      expect(
+        partialGraph.dependencies['npm:@phenomnomnominal/tsquery']
       ).toMatchSnapshot();
     });
   });

--- a/packages/nx/src/utils/lock-file/lock-file.spec.ts
+++ b/packages/nx/src/utils/lock-file/lock-file.spec.ts
@@ -1,54 +1,40 @@
 import { mapLockFileDataToExternalNodes } from './lock-file';
 import { LockFileData } from './lock-file-type';
+import { parseNpmLockFile } from './npm';
+import { parsePnpmLockFile } from './pnpm';
+import { parseYarnLockFile } from './yarn';
+import { lockFileYargsOnly } from './__fixtures__/npm.lock';
+import { lockFileYargsOnly as pnpmLockFileYargsOnly } from './__fixtures__/pnpm.lock';
+import { lockFileDevkitAndYargs } from './__fixtures__/yarn.lock';
 
 describe('lock-file', () => {
   describe('mapLockFileDataToExternalNodes', () => {
-    it('should map lock file data to external nodes', () => {
-      const lockFileData: LockFileData = {
-        dependencies: {
-          'happy-nrwl': {
-            'happy-nrwl@1.0.0': {
-              version: '1.0.0',
-              resolved:
-                'https://registry.npmjs.org/happy-nrwl/-/happy-nrwl-1.0.0.tgz',
-              integrity: 'sha512-1',
-              packageMeta: ['happy-nrwl@1.0.0'],
-            },
-          },
-          'happy-nrwl2': {
-            'happy-nrwl2@^1.0.0': {
-              version: '1.2.0',
-              resolved:
-                'https://registry.npmjs.org/happy-nrwl2/-/happy-nrwl2-1.2.0.tgz',
-              integrity: 'sha512-2',
-              packageMeta: ['happy-nrwl@^1.0.0'],
-            },
-          },
-        },
-      };
-      const externalNodes = mapLockFileDataToExternalNodes(lockFileData);
-      expect(externalNodes).toEqual({
-        'npm:happy-nrwl': {
-          type: 'npm',
-          name: 'npm:happy-nrwl',
-          data: {
-            version: '1.0.0',
-            resolved:
-              'https://registry.npmjs.org/happy-nrwl/-/happy-nrwl-1.0.0.tgz',
-            integrity: 'sha512-1',
-          },
-        },
-        'npm:happy-nrwl2': {
-          type: 'npm',
-          name: 'npm:happy-nrwl2',
-          data: {
-            version: '1.2.0',
-            resolved:
-              'https://registry.npmjs.org/happy-nrwl2/-/happy-nrwl2-1.2.0.tgz',
-            integrity: 'sha512-2',
-          },
-        },
-      });
+    it('should map yarn lock file data to external nodes', () => {
+      const lockFileData = parseYarnLockFile(lockFileDevkitAndYargs);
+
+      const mappedExernalNodes = mapLockFileDataToExternalNodes(lockFileData);
+
+      expect(mappedExernalNodes['npm:yargs']).toMatchSnapshot();
+    });
+
+    it('should map npm lock file data to external nodes', () => {
+      const lockFileData = parseNpmLockFile(lockFileYargsOnly);
+
+      const mappedExernalNodes = mapLockFileDataToExternalNodes(lockFileData);
+
+      expect(mappedExernalNodes['npm:yargs']).toMatchSnapshot();
+    });
+
+    it('should map pnpm lock file data to external nodes', () => {
+      const lockFileData = parsePnpmLockFile(pnpmLockFileYargsOnly);
+
+      const mappedExernalNodes = mapLockFileDataToExternalNodes(lockFileData);
+
+      console.log(JSON.stringify(lockFileData.dependencies['yargs'], null, 2));
+
+      console.log(JSON.stringify(mappedExernalNodes['npm:yargs'], null, 2));
+
+      expect(mappedExernalNodes['npm:yargs']).toMatchSnapshot();
     });
   });
 });

--- a/packages/nx/src/utils/lock-file/lock-file.spec.ts
+++ b/packages/nx/src/utils/lock-file/lock-file.spec.ts
@@ -1,11 +1,19 @@
 import { mapLockFileDataToExternalNodes } from './lock-file';
-import { LockFileData } from './lock-file-type';
 import { parseNpmLockFile } from './npm';
 import { parsePnpmLockFile } from './pnpm';
 import { parseYarnLockFile } from './yarn';
-import { lockFileYargsOnly } from './__fixtures__/npm.lock';
-import { lockFileYargsOnly as pnpmLockFileYargsOnly } from './__fixtures__/pnpm.lock';
-import { lockFileDevkitAndYargs } from './__fixtures__/yarn.lock';
+import {
+  lockFileYargsOnly as npmLockFileYargsOnly,
+  lockFile as npmLockFile,
+} from './__fixtures__/npm.lock';
+import {
+  lockFileYargsOnly as pnpmLockFileYargsOnly,
+  lockFile as pnpmLockFile,
+} from './__fixtures__/pnpm.lock';
+import {
+  lockFileDevkitAndYargs,
+  lockFile as yarnLockFile,
+} from './__fixtures__/yarn.lock';
 
 describe('lock-file', () => {
   describe('mapLockFileDataToExternalNodes', () => {
@@ -17,12 +25,30 @@ describe('lock-file', () => {
       expect(mappedExernalNodes['npm:yargs']).toMatchSnapshot();
     });
 
+    it('should map successfully complex yarn lock file', () => {
+      const lockFileData = parseYarnLockFile(yarnLockFile);
+
+      const mappedExernalNodes = mapLockFileDataToExternalNodes(lockFileData);
+
+      expect(mappedExernalNodes['npm:nx']).toMatchSnapshot();
+    });
+
     it('should map npm lock file data to external nodes', () => {
-      const lockFileData = parseNpmLockFile(lockFileYargsOnly);
+      const lockFileData = parseNpmLockFile(npmLockFileYargsOnly);
 
       const mappedExernalNodes = mapLockFileDataToExternalNodes(lockFileData);
 
       expect(mappedExernalNodes['npm:yargs']).toMatchSnapshot();
+    });
+
+    it('should map successfully complex npm lock file', () => {
+      const lockFileData = parseNpmLockFile(npmLockFile);
+
+      const mappedExernalNodes = mapLockFileDataToExternalNodes(lockFileData);
+
+      console.log(mappedExernalNodes, lockFileData);
+
+      expect(mappedExernalNodes['npm:nx']).toMatchSnapshot();
     });
 
     it('should map pnpm lock file data to external nodes', () => {
@@ -30,11 +56,18 @@ describe('lock-file', () => {
 
       const mappedExernalNodes = mapLockFileDataToExternalNodes(lockFileData);
 
-      console.log(JSON.stringify(lockFileData.dependencies['yargs'], null, 2));
-
-      console.log(JSON.stringify(mappedExernalNodes['npm:yargs'], null, 2));
-
       expect(mappedExernalNodes['npm:yargs']).toMatchSnapshot();
+    });
+
+    it('should map successfully complex pnpm lock file', () => {
+      const lockFileData = parsePnpmLockFile(pnpmLockFile);
+
+      const mappedExernalNodes = mapLockFileDataToExternalNodes(lockFileData);
+
+      expect(mappedExernalNodes['npm:nx']).toMatchSnapshot();
+      expect(
+        mappedExernalNodes['npm:@phenomnomnominal/tsquery']
+      ).toMatchSnapshot();
     });
   });
 });

--- a/packages/nx/src/utils/lock-file/lock-file.spec.ts
+++ b/packages/nx/src/utils/lock-file/lock-file.spec.ts
@@ -1,0 +1,54 @@
+import { mapLockFileDataToExternalNodes } from './lock-file';
+import { LockFileData } from './lock-file-type';
+
+describe('lock-file', () => {
+  describe('mapLockFileDataToExternalNodes', () => {
+    it('should map lock file data to external nodes', () => {
+      const lockFileData: LockFileData = {
+        dependencies: {
+          'happy-nrwl': {
+            'happy-nrwl@1.0.0': {
+              version: '1.0.0',
+              resolved:
+                'https://registry.npmjs.org/happy-nrwl/-/happy-nrwl-1.0.0.tgz',
+              integrity: 'sha512-1',
+              packageMeta: ['happy-nrwl@1.0.0'],
+            },
+          },
+          'happy-nrwl2': {
+            'happy-nrwl2@^1.0.0': {
+              version: '1.2.0',
+              resolved:
+                'https://registry.npmjs.org/happy-nrwl2/-/happy-nrwl2-1.2.0.tgz',
+              integrity: 'sha512-2',
+              packageMeta: ['happy-nrwl@^1.0.0'],
+            },
+          },
+        },
+      };
+      const externalNodes = mapLockFileDataToExternalNodes(lockFileData);
+      expect(externalNodes).toEqual({
+        'npm:happy-nrwl': {
+          type: 'npm',
+          name: 'npm:happy-nrwl',
+          data: {
+            version: '1.0.0',
+            resolved:
+              'https://registry.npmjs.org/happy-nrwl/-/happy-nrwl-1.0.0.tgz',
+            integrity: 'sha512-1',
+          },
+        },
+        'npm:happy-nrwl2': {
+          type: 'npm',
+          name: 'npm:happy-nrwl2',
+          data: {
+            version: '1.2.0',
+            resolved:
+              'https://registry.npmjs.org/happy-nrwl2/-/happy-nrwl2-1.2.0.tgz',
+            integrity: 'sha512-2',
+          },
+        },
+      });
+    });
+  });
+});

--- a/packages/nx/src/utils/lock-file/lock-file.spec.ts
+++ b/packages/nx/src/utils/lock-file/lock-file.spec.ts
@@ -46,8 +46,6 @@ describe('lock-file', () => {
 
       const mappedExernalNodes = mapLockFileDataToExternalNodes(lockFileData);
 
-      console.log(mappedExernalNodes, lockFileData);
-
       expect(mappedExernalNodes['npm:nx']).toMatchSnapshot();
     });
 

--- a/packages/nx/src/utils/lock-file/lock-file.ts
+++ b/packages/nx/src/utils/lock-file/lock-file.ts
@@ -19,6 +19,7 @@ import { LockFileData } from './lock-file-type';
 import { workspaceRoot } from '../workspace-root';
 import { join } from 'path';
 import { hashString } from './utils';
+import { ProjectGraphExternalNode } from 'nx/src/config/project-graph';
 
 /**
  * Hashes lock file content
@@ -64,6 +65,12 @@ export function parseLockFile(
     return parseNpmLockFile(file);
   }
   throw Error(`Unknown package manager: ${packageManager}`);
+}
+
+export function mapLockFileDataToExternalNodes(
+  lockFileData: LockFileData
+): Record<string, ProjectGraphExternalNode> {
+  return {};
 }
 
 /**

--- a/packages/nx/src/utils/lock-file/lock-file.ts
+++ b/packages/nx/src/utils/lock-file/lock-file.ts
@@ -20,6 +20,29 @@ import { workspaceRoot } from '../workspace-root';
 import { join } from 'path';
 import { findMatchingVersion, hashString } from './utils';
 import { ProjectGraphExternalNode } from '../../config/project-graph';
+import { existsSync } from 'fs';
+
+const YARN_LOCK_PATH = join(workspaceRoot, 'yarn.lock');
+const NPM_LOCK_PATH = join(workspaceRoot, 'package-lock.json');
+const PNPM_LOCK_PATH = join(workspaceRoot, 'pnpm-lock.yaml');
+
+/**
+ * Check if lock file exists
+ */
+export function lockFileExists(
+  packageManager: PackageManager = detectPackageManager(workspaceRoot)
+): boolean {
+  if (packageManager === 'yarn') {
+    return existsSync(YARN_LOCK_PATH);
+  }
+  if (packageManager === 'pnpm') {
+    return existsSync(PNPM_LOCK_PATH);
+  }
+  if (packageManager === 'npm') {
+    return existsSync(NPM_LOCK_PATH);
+  }
+  throw Error(`Unknown package manager ${packageManager} or lock file missing`);
+}
 
 /**
  * Hashes lock file content
@@ -29,13 +52,13 @@ export function lockFileHash(
 ): string {
   let file: string;
   if (packageManager === 'yarn') {
-    file = readFileSync(join(workspaceRoot, 'yarn.lock'), 'utf8');
+    file = readFileSync(YARN_LOCK_PATH, 'utf8');
   }
   if (packageManager === 'pnpm') {
-    file = readFileSync(join(workspaceRoot, 'pnpm-lock.yaml'), 'utf8');
+    file = readFileSync(PNPM_LOCK_PATH, 'utf8');
   }
   if (packageManager === 'npm') {
-    file = readFileSync(join(workspaceRoot, 'package-lock.json'), 'utf8');
+    file = readFileSync(NPM_LOCK_PATH, 'utf8');
   }
   if (file) {
     return hashString(file);
@@ -53,15 +76,15 @@ export function parseLockFile(
   packageManager: PackageManager = detectPackageManager(workspaceRoot)
 ): LockFileData {
   if (packageManager === 'yarn') {
-    const file = readFileSync(join(workspaceRoot, 'yarn.lock'), 'utf8');
+    const file = readFileSync(YARN_LOCK_PATH, 'utf8');
     return parseYarnLockFile(file);
   }
   if (packageManager === 'pnpm') {
-    const file = readFileSync(join(workspaceRoot, 'pnpm-lock.yaml'), 'utf8');
+    const file = readFileSync(PNPM_LOCK_PATH, 'utf8');
     return parsePnpmLockFile(file);
   }
   if (packageManager === 'npm') {
-    const file = readFileSync(join(workspaceRoot, 'package-lock.json'), 'utf8');
+    const file = readFileSync(NPM_LOCK_PATH, 'utf8');
     return parseNpmLockFile(file);
   }
   throw Error(`Unknown package manager: ${packageManager}`);
@@ -160,17 +183,17 @@ export function writeLockFile(
 ): void {
   if (packageManager === 'yarn') {
     const content = stringifyYarnLockFile(lockFile);
-    writeFileSync(join(workspaceRoot, 'yarn.lock'), content);
+    writeFileSync(YARN_LOCK_PATH, content);
     return;
   }
   if (packageManager === 'pnpm') {
     const content = stringifyPnpmLockFile(lockFile);
-    writeFileSync(join(workspaceRoot, 'pnpm-lock.yaml'), content);
+    writeFileSync(PNPM_LOCK_PATH, content);
     return;
   }
   if (packageManager === 'npm') {
     const content = stringifyNpmLockFile(lockFile);
-    writeFileSync(join(workspaceRoot, 'package-lock.json'), content);
+    writeFileSync(NPM_LOCK_PATH, content);
     return;
   }
   throw Error(`Unknown package manager: ${packageManager}`);

--- a/packages/nx/src/utils/lock-file/lock-file.ts
+++ b/packages/nx/src/utils/lock-file/lock-file.ts
@@ -154,7 +154,15 @@ function mapTransitiveDependencies(
   const result: Record<string, [string, string]> = {};
 
   Object.keys(dependencies).forEach((packageName) => {
-    const key = `${packages[packageName]}@${dependencies[packageName]}`;
+    const key = `${packageName}@${dependencies[packageName]}`;
+
+    // some of the peer dependencies might not be installed,
+    // we don't need them as nodes in externalNodes
+    if (!packages[packageName]) {
+      result[packageName] = [dependencies[packageName], undefined];
+      versionCache[key] = undefined;
+      return;
+    }
 
     // if we already processed this dependency, use the version from the cache
     if (versionCache[key]) {

--- a/packages/nx/src/utils/lock-file/lock-file.ts
+++ b/packages/nx/src/utils/lock-file/lock-file.ts
@@ -15,12 +15,12 @@ import {
   prunePnpmLockFile,
   stringifyPnpmLockFile,
 } from './pnpm';
-import { LockFileData, PackageVersions } from './lock-file-type';
+import { LockFileData } from './lock-file-type';
 import { workspaceRoot } from '../workspace-root';
 import { join } from 'path';
 import {
-  findMatchingVersion,
   getNodeName,
+  hashExternalNodes,
   hashString,
   mapExternalNodeDependencies,
 } from './utils';
@@ -144,6 +144,7 @@ export function mapLockFileDataToPartialGraph(
       }
     });
   });
+  hashExternalNodes(result);
   return result;
 }
 

--- a/packages/nx/src/utils/lock-file/npm.spec.ts
+++ b/packages/nx/src/utils/lock-file/npm.spec.ts
@@ -41,11 +41,22 @@ describe('npm LockFile utility', () => {
         '@jridgewell/gen-mapping@0.1.1'
       ]
     ).toBeDefined();
+    // This is opposite from yarn and pnpm
+    expect(
+      parsedLockFile.dependencies['@jridgewell/gen-mapping'][
+        '@jridgewell/gen-mapping@0.1.1'
+      ].rootVersion
+    ).toBeTruthy();
     expect(
       parsedLockFile.dependencies['@jridgewell/gen-mapping'][
         '@jridgewell/gen-mapping@0.3.2'
       ]
     ).toBeDefined();
+    expect(
+      parsedLockFile.dependencies['@jridgewell/gen-mapping'][
+        '@jridgewell/gen-mapping@0.3.2'
+      ].rootVersion
+    ).toBeFalsy();
   });
 
   it('should map various instances of the same version', () => {

--- a/packages/nx/src/utils/lock-file/npm.ts
+++ b/packages/nx/src/utils/lock-file/npm.ts
@@ -75,6 +75,14 @@ function mapPackages(packages: Dependencies): LockFileData['dependencies'] {
       };
     }
   });
+  // sort the version in descending order
+  Object.keys(mappedPackages).forEach((packageName) => {
+    mappedPackages[packageName] = sortObject(
+      mappedPackages[packageName],
+      undefined,
+      true
+    );
+  });
   return mappedPackages;
 }
 

--- a/packages/nx/src/utils/lock-file/npm.ts
+++ b/packages/nx/src/utils/lock-file/npm.ts
@@ -69,19 +69,13 @@ function mapPackages(packages: Dependencies): LockFileData['dependencies'] {
     if (mappedPackages[packageName][newKey]) {
       mappedPackages[packageName][newKey].packageMeta.push(packageMeta);
     } else {
+      const rootVersion = key.split('/node_modules/').length === 1;
       mappedPackages[packageName][newKey] = {
         ...value,
         packageMeta: [packageMeta],
+        rootVersion,
       };
     }
-  });
-  // sort the version in descending order
-  Object.keys(mappedPackages).forEach((packageName) => {
-    mappedPackages[packageName] = sortObject(
-      mappedPackages[packageName],
-      undefined,
-      true
-    );
   });
   return mappedPackages;
 }
@@ -123,7 +117,7 @@ export function stringifyNpmLockFile(lockFileData: LockFileData): string {
 // remapping the package back to package-lock format
 function unmapPackage(
   packages: Dependencies,
-  { packageMeta, ...value }: PackageDependency
+  { packageMeta, rootVersion, ...value }: PackageDependency
 ) {
   // we need to decompose value, to achieve particular field ordering
   const {

--- a/packages/nx/src/utils/lock-file/pnpm.spec.ts
+++ b/packages/nx/src/utils/lock-file/pnpm.spec.ts
@@ -29,9 +29,19 @@ describe('pnpm LockFile utility', () => {
       ).toBeDefined();
       expect(
         parsedLockFile.dependencies['@jridgewell/gen-mapping'][
+          '@jridgewell/gen-mapping@0.1.1'
+        ].rootVersion
+      ).toBeFalsy();
+      expect(
+        parsedLockFile.dependencies['@jridgewell/gen-mapping'][
           '@jridgewell/gen-mapping@0.3.2'
         ]
       ).toBeDefined();
+      expect(
+        parsedLockFile.dependencies['@jridgewell/gen-mapping'][
+          '@jridgewell/gen-mapping@0.3.2'
+        ].rootVersion
+      ).toBeTruthy();
     });
 
     it('should map various instances of the same version', () => {

--- a/packages/nx/src/utils/lock-file/pnpm.ts
+++ b/packages/nx/src/utils/lock-file/pnpm.ts
@@ -99,6 +99,14 @@ function mapPackages(
       };
     }
   });
+  // sort the version in descending order
+  Object.keys(mappedPackages).forEach((packageName) => {
+    mappedPackages[packageName] = sortObject(
+      mappedPackages[packageName],
+      undefined,
+      true
+    );
+  });
   return mappedPackages;
 }
 

--- a/packages/nx/src/utils/lock-file/utils.ts
+++ b/packages/nx/src/utils/lock-file/utils.ts
@@ -9,15 +9,19 @@ import { PackageVersions } from './lock-file-type';
  */
 export function sortObject<T = string>(
   obj: Record<string, T>,
-  valueTransformator: (value: T) => any = (value) => value
+  valueTransformator: (value: T) => any = (value) => value,
+  descending = false
 ): Record<string, T> | undefined {
   const keys = Object.keys(obj);
   if (keys.length === 0) {
     return;
   }
-
+  keys.sort();
+  if (descending) {
+    keys.reverse();
+  }
   const result: Record<string, T> = {};
-  keys.sort().forEach((key) => {
+  keys.forEach((key) => {
     result[key] = valueTransformator(obj[key]);
   });
   return result;

--- a/packages/nx/src/utils/lock-file/utils.ts
+++ b/packages/nx/src/utils/lock-file/utils.ts
@@ -1,4 +1,6 @@
+import { satisfies } from 'semver';
 import { defaultHashing } from '../../hasher/hashing-impl';
+import { PackageVersions } from './lock-file-type';
 
 /**
  * Simple sort function to ensure keys are ordered alphabetically
@@ -28,4 +30,12 @@ export function sortObject<T = string>(
  */
 export function hashString(fileContent: string): string {
   return defaultHashing.hashArray([fileContent]);
+}
+
+export function findMatchingVersion(
+  packageVersions: PackageVersions,
+  version: string
+) {
+  const versions = Object.values(packageVersions).map((v) => v.version);
+  return versions.find((v) => satisfies(v, version));
 }

--- a/packages/nx/src/utils/lock-file/utils.ts
+++ b/packages/nx/src/utils/lock-file/utils.ts
@@ -1,6 +1,8 @@
 import { satisfies } from 'semver';
 import { defaultHashing } from '../../hasher/hashing-impl';
 import { PackageVersions } from './lock-file-type';
+import { workspaceRoot } from '../workspace-root';
+import { existsSync, readFileSync } from 'fs';
 
 /**
  * Simple sort function to ensure keys are ordered alphabetically
@@ -49,4 +51,15 @@ export function findMatchingVersion(
   return Object.values(packageVersions).find((v) =>
     satisfies(v.version, version)
   )?.version;
+}
+
+export function isRootVersion(packageName: string, version: string): boolean {
+  const fullPath = `${workspaceRoot}/node_modules/${packageName}/package.json`;
+  if (existsSync(fullPath)) {
+    const content = readFileSync(fullPath, 'utf-8');
+    return JSON.parse(content).version === version;
+  } else {
+    return false;
+  }
+  return true;
 }

--- a/packages/nx/src/utils/lock-file/utils.ts
+++ b/packages/nx/src/utils/lock-file/utils.ts
@@ -33,9 +33,16 @@ export function hashString(fileContent: string): string {
 }
 
 export function findMatchingVersion(
+  packageName: string,
   packageVersions: PackageVersions,
   version: string
-) {
-  const versions = Object.values(packageVersions).map((v) => v.version);
-  return versions.find((v) => satisfies(v, version));
+): string {
+  // if it's fixed version, just return it
+  if (packageVersions[`${packageName}@${version}`]) {
+    return version;
+  }
+  // otherwise search for the matching version
+  return Object.values(packageVersions).find((v) =>
+    satisfies(v.version, version)
+  )?.version;
 }

--- a/packages/nx/src/utils/lock-file/yarn.spec.ts
+++ b/packages/nx/src/utils/lock-file/yarn.spec.ts
@@ -13,7 +13,9 @@ import {
 
 describe('yarn LockFile utility', () => {
   describe('classic', () => {
+    console.time('before');
     const parsedLockFile = parseYarnLockFile(lockFile);
+    console.timeEnd('before');
 
     it('should parse lockfile correctly', () => {
       expect(parsedLockFile.lockFileMetadata).toBeUndefined();
@@ -36,9 +38,19 @@ describe('yarn LockFile utility', () => {
       ).toBeDefined();
       expect(
         parsedLockFile.dependencies['@jridgewell/gen-mapping'][
+          '@jridgewell/gen-mapping@0.1.1'
+        ].rootVersion
+      ).toBeFalsy();
+      expect(
+        parsedLockFile.dependencies['@jridgewell/gen-mapping'][
           '@jridgewell/gen-mapping@0.3.2'
         ]
       ).toBeDefined();
+      expect(
+        parsedLockFile.dependencies['@jridgewell/gen-mapping'][
+          '@jridgewell/gen-mapping@0.3.2'
+        ].rootVersion
+      ).toBeTruthy();
     });
 
     it('should map various instances of the same version', () => {

--- a/packages/nx/src/utils/lock-file/yarn.ts
+++ b/packages/nx/src/utils/lock-file/yarn.ts
@@ -70,6 +70,14 @@ function mapPackages(
       }
     }
   });
+  // sort the version in descending order
+  Object.keys(mappedPackages).forEach((packageName) => {
+    mappedPackages[packageName] = sortObject(
+      mappedPackages[packageName],
+      undefined,
+      true
+    );
+  });
   return [mappedPackages, workspacePackages];
 }
 

--- a/packages/webpack/src/utils/versions.ts
+++ b/packages/webpack/src/utils/versions.ts
@@ -1,5 +1,5 @@
 export const nxVersion = require('../../package.json').version;
 
 export const swcLoaderVersion = '0.1.15';
-export const swcHelpersVersion = '~0.3.3';
+export const swcHelpersVersion = '~0.4.11';
 export const tsLibVersion = '^2.3.0';


### PR DESCRIPTION
This PR brings accurate external dependencies mapping to the project graph. 

## Implementation details
- Parses lock file to `LockFileData` structure when a lock file is changed
- Stores lock file hash in the `nxdeps.json` cache for later comparison (add an additional field to nx deps cache object)
- Maps `LockFileData` to partial `ProjectGraph` (graph with only `externalNodes` and their dependencies populated)
- Modifies project graph building to re-use the partial ProjectGraph while building the graph
- Changes `print-affected` to ignore `externalNodes`'s dependencies
- Modifies the hasher to exclude lockfile file-based hashing and includes hashing of the task target
- Extends hasher's external nodes hashing to traverse nested dependencies
- Fixes several rigid tests

## Benefits
- Project Graph contains accurate information about packages and versions used
- Hasher uses an accurate dependency tree
- The package json generator uses a fixed version instead of ranges
- Opens the possibility to fix several issues (e.g. https://github.com/nrwl/nx/issues/11178)
- Fixes issues that were blocked by missing dependencies

## Performance (calculated on Nx repo) with Yarn:
- Compare with cached lock file: 0.039ms
- Full lock file parsing: ~150ms (due to cache miss)
    - Parse Syml (original function from yarn): ~124ms (**point for replacement**)
       > This is **should** run in the background daemon so practically it shouldn't be noticeable, but nevertheless should still be improved
    - Hash Lock: 0.7ms
    - Map Packages: 25ms (**point for improvement**)
    - Detect root packages after mapping: 2-3ms (Yarn and Pnpm only, Npm has clean differentiation built in)

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

Fixes #12033
Fixes #11874
