### PR TITLE
fix(core): properly invalidate outputs when output is removed

### DIFF
--- a/packages/nx/src/daemon/server/output-watcher.ts
+++ b/packages/nx/src/daemon/server/output-watcher.ts
@@ -42,17 +42,20 @@ export async function recordOutputsHash(_outputs: string[], hash: string) {
 export async function outputsHashesMatch(_outputs: string[], hash: string) {
   const outputs = await normalizeOutputs(_outputs);
   let invalidated = [];
+  let matches = true;
   if (outputs.length !== numberOfExpandedOutputs[hash]) {
+    matches = false;
     invalidated = outputs;
   } else {
     for (const output of outputs) {
       if (recordedHashes[output] !== hash) {
+        matches = false;
         invalidated.push(output);
       }
     }
   }
   await removeSubscriptionsForOutputs(invalidated);
-  return invalidated.length === 0;
+  return matches;
 }
 
 function anyErrorsAssociatedWithOutputs(outputs: string[]) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When removing the outputs entirely (`rm -rf dist`), commands improperly return that outputs match. They don't because.. they're not there anymore.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When removing the outputs entirely (`rm -rf dist`), commands properly invalidate outputs. Commands should restore from local cache.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
