### PR TITLE
fix(misc): do not exit after running graph

### DIFF
--- a/packages/nx/src/command-line/dep-graph.ts
+++ b/packages/nx/src/command-line/dep-graph.ts
@@ -272,6 +272,7 @@ export async function generateGraph(
       });
       process.exit(1);
     }
+    process.exit(0);
   } else {
     const environmentJs = buildEnvironmentJs(
       args.exclude || [],

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -178,14 +178,12 @@ export const commandsObject = yargs
         withAffectedOptions(withDepGraphOptions(yargs)),
         'affected:graph'
       ),
-    handler: async (args) => {
+    handler: async (args) =>
       await (
         await import('./affected')
       ).affected('graph', {
         ...args,
-      });
-      process.exit(0);
-    },
+      }),
   })
   .command({
     command: 'print-affected',
@@ -218,10 +216,8 @@ export const commandsObject = yargs
     aliases: ['dep-graph'],
     builder: (yargs) =>
       linkToNxDevAndExamples(withDepGraphOptions(yargs), 'dep-graph'),
-    handler: async (args) => {
-      await (await import('./dep-graph')).generateGraph(args as any, []);
-      process.exit(0);
-    },
+    handler: async (args) =>
+      await (await import('./dep-graph')).generateGraph(args as any, []),
   })
 
   .command({


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Running `nx graph`, `nx affected:graph`, and `nx dep-graph` will instantly close the process even when the server is running.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Running `nx graph`, `nx affected:graph`, and `nx dep-graph` will have a long running process when the server is running.

When a file is written, it will exit afterwards

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #12134 
