### PR TITLE
feat(core): add migration and deprecation warning for @nrwl/workspace…

### DIFF
--- a/packages/nx/executors.json
+++ b/packages/nx/executors.json
@@ -1,4 +1,16 @@
 {
+  "builders": {
+    "run-commands": {
+      "implementation": "./src/executors/run-commands/compat",
+      "schema": "./src/executors/run-commands/schema.json",
+      "description": "Run any custom commands with Nx."
+    },
+    "run-script": {
+      "implementation": "./src/executors/run-script/compat",
+      "schema": "./src/executors/run-script/schema.json",
+      "description": "Run an NPM script using Nx."
+    }
+  },
   "executors": {
     "noop": {
       "implementation": "./src/executors/noop/noop.impl",

--- a/packages/nx/src/executors/run-commands/compat.ts
+++ b/packages/nx/src/executors/run-commands/compat.ts
@@ -1,0 +1,4 @@
+import { convertNxExecutor } from '../utils/convert-nx-executor';
+import { default as runCommandsExecutor } from './run-commands.impl';
+
+export default convertNxExecutor(runCommandsExecutor);

--- a/packages/nx/src/executors/run-script/compat.ts
+++ b/packages/nx/src/executors/run-script/compat.ts
@@ -1,0 +1,5 @@
+import { convertNxExecutor } from '../utils/convert-nx-executor';
+
+import { default as runScriptExecutor } from './run-script.impl';
+
+export default convertNxExecutor(runScriptExecutor);

--- a/packages/nx/src/executors/utils/convert-nx-executor.ts
+++ b/packages/nx/src/executors/utils/convert-nx-executor.ts
@@ -1,0 +1,89 @@
+/**
+ * This is a copy of the @nrwl/devkit utility but this should not be used outside of the nx package
+ */
+
+import type { Observable } from 'rxjs';
+import { Workspaces } from '../../config/workspaces';
+import { Executor, ExecutorContext } from '../../config/misc-interfaces';
+import {
+  createProjectGraphAsync,
+  readCachedProjectGraph,
+} from '../../project-graph/project-graph';
+import { ProjectGraph } from '../../config/project-graph';
+
+/**
+ * Convert an Nx Executor into an Angular Devkit Builder
+ *
+ * Use this to expose a compatible Angular Builder
+ */
+export function convertNxExecutor(executor: Executor) {
+  const builderFunction = (options, builderContext) => {
+    const workspaces = new Workspaces(builderContext.workspaceRoot);
+    const workspaceConfig = workspaces.readWorkspaceConfiguration();
+
+    const promise = async () => {
+      let projectGraph: ProjectGraph;
+      try {
+        projectGraph = readCachedProjectGraph();
+      } catch {
+        projectGraph = await createProjectGraphAsync();
+      }
+      const context: ExecutorContext = {
+        root: builderContext.workspaceRoot,
+        projectName: builderContext.target.project,
+        targetName: builderContext.target.target,
+        target: builderContext.target.target,
+        configurationName: builderContext.target.configuration,
+        workspace: workspaceConfig,
+        cwd: process.cwd(),
+        projectGraph,
+        isVerbose: false,
+      };
+      return executor(options, context);
+    };
+    return toObservable(promise());
+  };
+  return require('@angular-devkit/architect').createBuilder(builderFunction);
+}
+
+function toObservable<T extends { success: boolean }>(
+  promiseOrAsyncIterator: Promise<T | AsyncIterableIterator<T>>
+): Observable<T> {
+  return new (require('rxjs') as typeof import('rxjs')).Observable(
+    (subscriber) => {
+      promiseOrAsyncIterator.then((value) => {
+        if (!(value as any).next) {
+          subscriber.next(value as T);
+          subscriber.complete();
+        } else {
+          let asyncIterator = value as AsyncIterableIterator<T>;
+
+          function recurse(iterator: AsyncIterableIterator<T>) {
+            iterator
+              .next()
+              .then((result) => {
+                if (!result.done) {
+                  subscriber.next(result.value);
+                  recurse(iterator);
+                } else {
+                  if (result.value) {
+                    subscriber.next(result.value);
+                  }
+                  subscriber.complete();
+                }
+              })
+              .catch((e) => {
+                subscriber.error(e);
+              });
+          }
+
+          recurse(asyncIterator);
+
+          return () => {
+            asyncIterator.return();
+          };
+        }
+      });
+    }
+  );
+}

--- a/packages/workspace/migrations.json
+++ b/packages/workspace/migrations.json
@@ -71,6 +71,12 @@
       "description": "Explicitly enable sourceAnalysis for all workspaces extending from npm.json or core.json (this was default behavior prior to 14.2)",
       "cli": "nx",
       "implementation": "./src/migrations/update-14-2-0/enable-source-analysis"
+    },
+    "14-8-0-change-run-commands-executor": {
+      "version": "14.8.0-beta.0",
+      "description": "Migrates from @nrwl/workspace:run-commands to nx:run-commands",
+      "cli": "nx",
+      "implementation": "./src/migrations/update-14-8-0/change-run-commands-executor"
     }
   },
   "packageJsonUpdates": {

--- a/packages/workspace/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/workspace/src/executors/run-commands/run-commands.impl.ts
@@ -1,4 +1,9 @@
+import { logger } from '@nrwl/devkit';
 import runCommands from 'nx/src/executors/run-commands/run-commands.impl';
+
+logger.warn(
+  '@nrwl/workspace:run-commands is deprecated and will be removed in Nx 16. Please switch to nx:run-commands'
+);
 
 export { RunCommandsOptions } from 'nx/src/executors/run-commands/run-commands.impl';
 

--- a/packages/workspace/src/executors/run-script/run-script.impl.ts
+++ b/packages/workspace/src/executors/run-script/run-script.impl.ts
@@ -1,4 +1,9 @@
+import { logger } from '@nrwl/devkit';
 import runScript from 'nx/src/executors/run-script/run-script.impl';
+
+logger.warn(
+  '@nrwl/workspace:run-script is deprecated and will be removed in Nx 16. Please switch to nx:run-script'
+);
 
 export { RunScriptOptions } from 'nx/src/executors/run-script/run-script.impl';
 

--- a/packages/workspace/src/migrations/update-14-8-0/change-run-commands-executor.spec.ts
+++ b/packages/workspace/src/migrations/update-14-8-0/change-run-commands-executor.spec.ts
@@ -1,0 +1,50 @@
+import {
+  addProjectConfiguration,
+  readProjectConfiguration,
+  Tree,
+} from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import changeRunCommandsExecutor from './change-run-commands-executor';
+
+describe('changeRunCommandsExecutor', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+
+    addProjectConfiguration(tree, 'proj1', {
+      root: 'proj1',
+      targets: {
+        scriptTarget: {
+          executor: '@nrwl/workspace:run-commands',
+          options: {},
+        },
+        notScriptTarget: {
+          executor: '@nrwl/workspace:something',
+          options: {},
+        },
+      },
+    });
+  });
+
+  it('should change the npm script executor to nx:npm-script', async () => {
+    await changeRunCommandsExecutor(tree);
+
+    expect(readProjectConfiguration(tree, 'proj1')).toMatchInlineSnapshot(`
+      Object {
+        "$schema": "../node_modules/nx/schemas/project-schema.json",
+        "root": "proj1",
+        "targets": Object {
+          "notScriptTarget": Object {
+            "executor": "@nrwl/workspace:something",
+            "options": Object {},
+          },
+          "scriptTarget": Object {
+            "executor": "nx:run-commands",
+            "options": Object {},
+          },
+        },
+      }
+    `);
+  });
+});

--- a/packages/workspace/src/migrations/update-14-8-0/change-run-commands-executor.ts
+++ b/packages/workspace/src/migrations/update-14-8-0/change-run-commands-executor.ts
@@ -1,0 +1,26 @@
+import {
+  formatFiles,
+  readProjectConfiguration,
+  Tree,
+  updateProjectConfiguration,
+} from '@nrwl/devkit';
+import { forEachExecutorOptions } from '@nrwl/workspace/src/utilities/executor-options-utils';
+
+export async function changeRunCommandsExecutor(tree: Tree) {
+  forEachExecutorOptions(
+    tree,
+    '@nrwl/workspace:run-commands',
+    (currentValue, project, target) => {
+      const projectConfig = readProjectConfiguration(tree, project);
+      const targetConfig = projectConfig.targets[target];
+
+      targetConfig.executor = 'nx:run-commands';
+
+      updateProjectConfiguration(tree, project, projectConfig);
+    }
+  );
+
+  await formatFiles(tree);
+}
+
+export default changeRunCommandsExecutor;


### PR DESCRIPTION
…:run-commands

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`nx:run-commands` is pretty much the same as `@nrwl/workspace:run-commands` but it isn't compatible running through the angular devkit.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`nx:run-commands` is the same as `@nrwl/workspace:run-comands` (compatible with angular devkit) and also `@nrwl/workspace:run-commands` is migrated to `nx:run-commands`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
