### PR TITLE
docs(nxdev) adding --present=core to generate packages approach

### DIFF
--- a/docs/shared/core-tutorial/01-create-blog.md
+++ b/docs/shared/core-tutorial/01-create-blog.md
@@ -20,7 +20,7 @@ This tutorial sets up a [package-based repo](/concepts/integrated-vs-package-bas
 **Start by creating a new workspace.**
 
 ```bash
-npx create-nx-workspace@latest
+npx create-nx-workspace@latest --preset=core
 ```
 
 You then receive the following prompts in your command line:


### PR DESCRIPTION
@latest seems to generate the integrated approach by default.. I believe we need to pass --preset=core to generate the packages approach.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
