### PR TITLE
fix(angular): add error handling for cypress mf to correct file #12118

### DIFF
--- a/packages/angular/src/generators/setup-mf/lib/add-cypress-workaround.ts
+++ b/packages/angular/src/generators/setup-mf/lib/add-cypress-workaround.ts
@@ -44,7 +44,7 @@ export function addCypressOnErrorWorkaround(tree: Tree, schema: Schema) {
 
   const pathToCommandsFile = joinPathFragments(
     e2eProject.sourceRoot,
-    'support/index.ts'
+    'support/e2e.ts'
   );
 
   const commandsContent = tree.exists(pathToCommandsFile)

--- a/packages/angular/src/generators/setup-mf/setup-mf.spec.ts
+++ b/packages/angular/src/generators/setup-mf/setup-mf.spec.ts
@@ -283,7 +283,7 @@ describe('Init MF', () => {
 
     // ASSERT
     const cypressCommands = tree.read(
-      'apps/test-app-e2e/src/support/index.ts',
+      'apps/test-app-e2e/src/support/e2e.ts',
       'utf-8'
     );
     expect(cypressCommands).toContain(


### PR DESCRIPTION

## Current Behavior
<!-- This is the behavior we have today -->
MF throws an error when attaching styles.js in dev mode. we had a workaround to allow cypress tests to not fail instantly if this error appeared. but with updates to cypress, the location of where this workaround needed to go changed.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
add workaround to correct file

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #12118
