### PR TITLE
feat(nextjs): remove dependency on "@nrwl/next" for the production build

### DIFF
--- a/docs/generated/packages/next.json
+++ b/docs/generated/packages/next.json
@@ -664,6 +664,11 @@
             "type": "boolean",
             "description": "Read buildable libraries from source instead of building them separately.",
             "default": true
+          },
+          "includeDevDependenciesInPackageJson": {
+            "type": "boolean",
+            "description": "Include `devDependencies` in the generated package.json file. By default only production `dependencies` are included.",
+            "default": false
           }
         },
         "required": ["root", "outputPath"],

--- a/packages/next/src/executors/build/lib/create-next-config-file.ts
+++ b/packages/next/src/executors/build/lib/create-next-config-file.ts
@@ -1,9 +1,17 @@
-import { ExecutorContext } from '@nrwl/devkit';
-
-import { copyFileSync, existsSync } from 'fs';
+import type { ExecutorContext } from '@nrwl/devkit';
+import {
+  applyChangesToString,
+  ChangeType,
+  workspaceLayout,
+  workspaceRoot,
+  stripIndents,
+} from '@nrwl/devkit';
+import * as ts from 'typescript';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 
-import { NextBuildBuilderOptions } from '../../../utils/types';
+import type { NextBuildBuilderOptions } from '../../../utils/types';
+import { findNodes } from '@nrwl/workspace/src/utilities/typescript';
 
 export function createNextConfigFile(
   options: NextBuildBuilderOptions,
@@ -13,7 +21,53 @@ export function createNextConfigFile(
     ? join(context.root, options.nextConfig)
     : join(context.root, options.root, 'next.config.js');
 
+  // Copy config file and our `with-nx.js` file to remove dependency on @nrwl/next for production build.
   if (existsSync(nextConfigPath)) {
-    copyFileSync(nextConfigPath, join(options.outputPath, 'next.config.js'));
+    writeFileSync(join(options.outputPath, 'with-nx.js'), getWithNxContent());
+    writeFileSync(
+      join(options.outputPath, 'next.config.js'),
+      readFileSync(nextConfigPath)
+        .toString()
+        .replace('@nrwl/next/plugins/with-nx', './with-nx.js')
+    );
   }
+}
+
+function getWithNxContent() {
+  const withNxFile = join(__dirname, '../../../../plugins/with-nx.js');
+  let withNxContent = readFileSync(withNxFile).toString();
+  const withNxSource = ts.createSourceFile(
+    withNxFile,
+    withNxContent,
+    ts.ScriptTarget.Latest,
+    true
+  );
+  const getWithNxContextDeclaration = findNodes(
+    withNxSource,
+    ts.SyntaxKind.FunctionDeclaration
+  )?.find(
+    (node: ts.FunctionDeclaration) => node.name?.text === 'getWithNxContext'
+  );
+
+  if (getWithNxContextDeclaration) {
+    withNxContent = applyChangesToString(withNxContent, [
+      {
+        type: ChangeType.Delete,
+        start: getWithNxContextDeclaration.getStart(withNxSource),
+        length: getWithNxContextDeclaration.getWidth(withNxSource),
+      },
+      {
+        type: ChangeType.Insert,
+        index: getWithNxContextDeclaration.getStart(withNxSource),
+        text: stripIndents`function getWithNxContext() {
+          return {
+            workspaceRoot: '${workspaceRoot}',
+            libsDir: '${workspaceLayout().libsDir}'
+          }
+        }`,
+      },
+    ]);
+  }
+
+  return withNxContent;
 }

--- a/packages/next/src/executors/build/lib/create-package-json.ts
+++ b/packages/next/src/executors/build/lib/create-package-json.ts
@@ -15,20 +15,16 @@ export async function createPackageJson(
       projectRoot: context.workspace.projects[context.projectName].sourceRoot,
     }
   );
+
+  // By default we remove devDependencies since this is a production build.
+  if (!options.includeDevDependenciesInPackageJson) {
+    delete packageJson.devDependencies;
+  }
+
   if (!packageJson.scripts) {
     packageJson.scripts = {};
   }
   packageJson.scripts.start = 'next start';
-  if (!packageJson.devDependencies) {
-    packageJson.devDependencies = {};
-  }
-  const nrwlWorkspaceNode =
-    context.projectGraph.externalNodes['npm:@nrwl/workspace'];
-
-  if (nrwlWorkspaceNode) {
-    packageJson.dependencies['@nrwl/workspace'] =
-      nrwlWorkspaceNode.data.version;
-  }
 
   const typescriptNode = context.projectGraph.externalNodes['npm:typescript'];
   if (typescriptNode) {

--- a/packages/next/src/executors/build/schema.json
+++ b/packages/next/src/executors/build/schema.json
@@ -47,6 +47,11 @@
       "type": "boolean",
       "description": "Read buildable libraries from source instead of building them separately.",
       "default": true
+    },
+    "includeDevDependenciesInPackageJson": {
+      "type": "boolean",
+      "description": "Include `devDependencies` in the generated package.json file. By default only production `dependencies` are included.",
+      "default": false
     }
   },
   "required": ["root", "outputPath"]

--- a/packages/next/src/utils/types.ts
+++ b/packages/next/src/utils/types.ts
@@ -36,6 +36,7 @@ export interface NextBuildBuilderOptions {
   assets?: any[];
   nextConfig?: string;
   buildLibsFromSource?: boolean;
+  includeDevDependenciesInPackageJson?: boolean;
   watch?: boolean;
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

This PR adds a step to inline `with-nx.js` into the production build, which avoids the need for `@nrwl/next` to be present in the production app.

## Current Behavior
`@nrwl/next` is needed as a dependency in the dist `package.json` file, which bloats the artifact.

## Expected Behavior
`@nrwl/next` is not needed in production app.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #12150 
