### PR TITLE
fix(run-ios): ensure broken symlinks get recreated

### DIFF
--- a/packages/react-native/src/utils/ensure-node-modules-symlink.ts
+++ b/packages/react-native/src/utils/ensure-node-modules-symlink.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { platform } from 'os';
-import { removeSync, existsSync, symlinkSync } from 'fs-extra';
+import { removeSync, existsSync, symlinkSync, lstatSync } from 'fs-extra';
 
 /**
  * This function symlink workspace node_modules folder with app project's node_mdules folder.
@@ -14,9 +14,10 @@ export function ensureNodeModulesSymlink(
   workspaceRoot: string,
   projectRoot: string
 ): void {
-  const worksapceNodeModulesPath = join(workspaceRoot, 'node_modules');
-  if (!existsSync(worksapceNodeModulesPath)) {
-    throw new Error(`Cannot find ${worksapceNodeModulesPath}`);
+  const workspaceNodeModulesPath = join(workspaceRoot, 'node_modules');
+  // Not using `existsSync` because it will return `true` it always follows symlinks, and will return `true` if the symlink is broken
+  if (!lstatSync(workspaceNodeModulesPath, { throwIfNoEntry: false })) {
+    throw new Error(`Cannot find ${workspaceNodeModulesPath}`);
   }
 
   const appNodeModulesPath = join(workspaceRoot, projectRoot, 'node_modules');
@@ -26,5 +27,5 @@ export function ensureNodeModulesSymlink(
   if (existsSync(appNodeModulesPath)) {
     removeSync(appNodeModulesPath);
   }
-  symlinkSync(worksapceNodeModulesPath, appNodeModulesPath, symlinkType);
+  symlinkSync(workspaceNodeModulesPath, appNodeModulesPath, symlinkType);
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
In a react-native application, if `node_modules` symlink for some reason is invalid, running `@nrwl/react-native:run-ios` will fail, since it will try to create a file that already exists.

This happens due to the fact that `fs.exists` [always follows symlinks](https://github.com/nodejs/node/issues/14025).

I ran into this scenario when my colleague has accidentally committed `node_modules` symlink into the codebase, but I'd imagine there might be other scenarios causing this.

## Expected Behavior
The broken symlink should be removed, and a new one created in its place.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

None.
