### PR TITLE
fix(angular): fix root selector in index.html for standalone remotes

### DIFF
--- a/packages/angular/src/generators/remote/remote.spec.ts
+++ b/packages/angular/src/generators/remote/remote.spec.ts
@@ -149,4 +149,23 @@ describe('MF Remote App Generator', () => {
     const projects = getProjects(tree);
     expect(projects.has('remote1-e2e')).toBeFalsy();
   });
+
+  it('should update the index.html to use the remote entry component selector for root when standalone', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+
+    // ACT
+    await remote(tree, {
+      name: 'test',
+      standalone: true,
+    });
+
+    // ASSERT
+    expect(tree.read('apps/test/src/index.html', 'utf-8')).not.toContain(
+      'proj-root'
+    );
+    expect(tree.read('apps/test/src/index.html', 'utf-8')).toContain(
+      'proj-test-entry'
+    );
+  });
 });

--- a/packages/angular/src/generators/remote/remote.ts
+++ b/packages/angular/src/generators/remote/remote.ts
@@ -3,6 +3,7 @@ import {
   getProjects,
   joinPathFragments,
   readProjectConfiguration,
+  readWorkspaceConfiguration,
   Tree,
 } from '@nrwl/devkit';
 import type { Schema } from './schema';
@@ -132,5 +133,19 @@ export class AppModule {}`
     );
   } else {
     tree.delete(pathToAppComponent);
+
+    const prefix = options.prefix ?? readWorkspaceConfiguration(tree).npmScope;
+    const remoteEntrySelector = `${prefix}-${projectName}-entry`;
+
+    const pathToIndexHtml = project.targets.build.options.index;
+    const indexContents = tree.read(pathToIndexHtml, 'utf-8');
+
+    const rootSelectorRegex = new RegExp(`${prefix}-root`, 'ig');
+    const newIndexContents = indexContents.replace(
+      rootSelectorRegex,
+      remoteEntrySelector
+    );
+
+    tree.write(pathToIndexHtml, newIndexContents);
   }
 }


### PR DESCRIPTION

## Current Behavior
<!-- This is the behavior we have today -->
When generating a standalone remote we delete the unneeded app component but do not change the root selector in the index.html
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
make sure to change the root selector being used

