### PR TITLE
fix(angular): update component correctly when remote uses inlineTemplate

### DIFF
--- a/packages/angular/src/generators/remote/remote.spec.ts
+++ b/packages/angular/src/generators/remote/remote.spec.ts
@@ -150,6 +150,30 @@ describe('MF Remote App Generator', () => {
     expect(projects.has('remote1-e2e')).toBeFalsy();
   });
 
+  it('should generate a correct app component when inline template is used', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+
+    // ACT
+    await remote(tree, {
+      name: 'test',
+      inlineTemplate: true,
+    });
+
+    // ASSERT
+    expect(tree.read('apps/test/src/app/app.component.ts', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "import { Component } from '@angular/core';
+
+      @Component({
+        selector: 'proj-root',
+        template: '<router-outlet></router-outlet>'
+
+      })
+      export class AppComponent {}"
+    `);
+  });
+
   it('should update the index.html to use the remote entry component selector for root when standalone', async () => {
     // ARRANGE
     const tree = createTreeWithEmptyWorkspace();

--- a/packages/angular/src/generators/remote/remote.ts
+++ b/packages/angular/src/generators/remote/remote.ts
@@ -103,8 +103,11 @@ function removeDeadCode(tree: Tree, options: Schema) {
   );
   if (!options.standalone) {
     const component =
-      tree.read(pathToAppComponent, 'utf-8').split('templateUrl')[0] +
+      tree
+        .read(pathToAppComponent, 'utf-8')
+        .split(options.inlineTemplate ? 'template' : 'templateUrl')[0] +
       `template: '<router-outlet></router-outlet>'
+
 })
 export class AppComponent {}`;
 


### PR DESCRIPTION

## Current Behavior
<!-- This is the behavior we have today -->

removeDeadCode function was not handling inline templates

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

it should handle inlineTemplates
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
