### PR TITLE
fix(core): custom generators help should print relevant information

### DIFF
--- a/e2e/nx-misc/src/workspace.test.ts
+++ b/e2e/nx-misc/src/workspace.test.ts
@@ -213,7 +213,7 @@ describe('Workspace Tests', () => {
 
       const helpOutput = runCLI(`workspace-generator ${custom} --help`);
       expect(helpOutput).toContain(
-        `nx workspace-generator ${custom} [inlineprop] [options]`
+        `workspace-generator ${custom} [inlineprop] (options)`
       );
       expect(helpOutput).toContain(`--directory`);
       expect(helpOutput).toContain(`--skipTsConfig`);

--- a/e2e/nx-misc/src/workspace.test.ts
+++ b/e2e/nx-misc/src/workspace.test.ts
@@ -24,9 +24,7 @@ describe('Workspace Tests', () => {
     proj = newProject();
   });
 
-  afterAll(() => {
-    cleanupProject();
-  });
+  afterAll(() => cleanupProject());
 
   describe('@nrwl/workspace:library', () => {
     it('should create a library that can be tested and linted', async () => {
@@ -196,6 +194,7 @@ describe('Workspace Tests', () => {
         description: 'skip changes to tsconfig',
       };
       json.properties['inlineprop'] = json.properties['name'];
+      json.required = ['inlineprop'];
       delete json.properties['name'];
 
       updateFile(
@@ -208,7 +207,7 @@ describe('Workspace Tests', () => {
         `tools/generators/${custom}/index.ts`,
         indexFile.replace(
           'name: schema.name',
-          'inlineprop: schema.inlineprop, directory: schema.directory, skipTsConfig: schema.skipTsConfig'
+          'name: schema.inlineprop, directory: schema.directory, skipTsConfig: schema.skipTsConfig'
         )
       );
 
@@ -228,11 +227,10 @@ describe('Workspace Tests', () => {
         `CREATE libs/dir/${workspace}/src/index.ts`
       );
 
-      const output = runCLI(
+      runCLI(
         `workspace-generator ${custom} ${workspace} --no-interactive --directory=dir`
       );
       checkFilesExist(`libs/dir/${workspace}/src/index.ts`);
-      expect(output).not.toContain('UPDATE nx.json');
 
       const jsonFailing = readJson(`tools/generators/${failing}/schema.json`);
       jsonFailing.properties = {};

--- a/e2e/nx-misc/src/workspace.test.ts
+++ b/e2e/nx-misc/src/workspace.test.ts
@@ -195,6 +195,9 @@ describe('Workspace Tests', () => {
         type: 'boolean',
         description: 'skip changes to tsconfig',
       };
+      json.properties['inlineprop'] = json.properties['name'];
+      delete json.properties['name'];
+
       updateFile(
         `tools/generators/${custom}/schema.json`,
         JSON.stringify(json)
@@ -205,9 +208,16 @@ describe('Workspace Tests', () => {
         `tools/generators/${custom}/index.ts`,
         indexFile.replace(
           'name: schema.name',
-          'name: schema.name, directory: schema.directory, skipTsConfig: schema.skipTsConfig'
+          'inlineprop: schema.inlineprop, directory: schema.directory, skipTsConfig: schema.skipTsConfig'
         )
       );
+
+      const helpOutput = runCLI(`workspace-generator ${custom} --help`);
+      expect(helpOutput).toContain(
+        `nx workspace-generator ${custom} [inlineprop] [options]`
+      );
+      expect(helpOutput).toContain(`--directory`);
+      expect(helpOutput).toContain(`--skipTsConfig`);
 
       const workspace = uniq('workspace');
       const dryRunOutput = runCLI(

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -839,7 +839,7 @@ async function withCustomGeneratorOptions(
     command += ` [${name}]`;
   });
   if (options.length) {
-    command += ' [options]';
+    command += ' (options)';
   }
 
   yargs.command({

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -259,12 +259,7 @@ export const commandsObject = yargs
         await withWorkspaceGeneratorOptions(yargs, process.argv.slice(3)),
         'workspace-generator'
       ),
-    handler: async () => {
-      await (
-        await import('./workspace-generators')
-      ).workspaceGenerators(process.argv.slice(3));
-      process.exit(0);
-    },
+    handler: workspaceGeneratorHandler,
   })
   .command({
     command: 'migrate [packageAndVersion]',
@@ -847,21 +842,30 @@ async function withCustomGeneratorOptions(
     command += ' [options]';
   }
 
-  yargs.wrap(yargs.terminalWidth()).command(
+  yargs.command({
     // this is the default and only command
     command,
-    schema.description || '',
-    (yargs) => {
+    describe: schema.description || '',
+    builder: (y) => {
       options.forEach(({ name, definition }) => {
-        yargs.option(name, definition);
+        y.option(name, definition);
       });
       positionals.forEach(({ name, definition }) => {
-        yargs.positional(name, definition);
+        y.positional(name, definition);
       });
-    }
-  );
+      return linkToNxDevAndExamples(y, 'workspace-generator');
+    },
+    handler: workspaceGeneratorHandler,
+  });
 
   return yargs;
+}
+
+async function workspaceGeneratorHandler() {
+  await (
+    await import('./workspace-generators')
+  ).workspaceGenerators(process.argv.slice(3));
+  process.exit(0);
 }
 
 function withMigrationOptions(yargs: yargs.Argv) {

--- a/packages/nx/src/command-line/workspace-generators.ts
+++ b/packages/nx/src/command-line/workspace-generators.ts
@@ -40,6 +40,17 @@ export async function workspaceGenerators(args: string[]) {
   }
 }
 
+export function workspaceGeneratorSchema(name: string) {
+  const schemaFile = path.join(generatorsDir, name, 'schema.json');
+
+  if (fileExists(schemaFile)) {
+    return readJsonFile(schemaFile);
+  } else {
+    logger.error(`Cannot find schema for ${name}. Does the generator exist?`);
+    process.exit(1);
+  }
+}
+
 // compile tools
 function compileTools() {
   const toolsOutDir = getToolsOutDir();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Running `nx workspace-generator custom-name --help` prints out the default help for root `nx workspace-generator` command

## Expected Behavior
Running `nx workspace-generator custom-name --help` should print custom generator specific CLI help

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #12253

cc @rarmatei 
