### PR TITLE
chore(core): add hints to readModulePackageJson function for non-hoisted modules

### DIFF
--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -139,6 +139,13 @@ export function readModulePackageJsonWithoutFallbacks(
  *
  * Includes a fallback that accounts for modules that don't export package.json
  *
+ * @param {string} moduleSpecifier The module to look up
+ * @param {string[]} requirePaths List of paths look in. Pass `module.paths` to ensure non-hoisted dependencies are found.
+ *
+ * @example
+ * // Use the caller's lookup paths for non-hoisted dependencies
+ * readModulePackageJson('http-server', module.paths);
+ *
  * @returns package json contents and path
  */
 export function readModulePackageJson(


### PR DESCRIPTION
This PR just adds some jsdoc hints so consumers of `readModulePackageJson` can avoid potential errors.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
