### PR TITLE
fix(react): fix builder options for storybook plugin

### DIFF
--- a/packages/react/plugins/storybook/index.ts
+++ b/packages/react/plugins/storybook/index.ts
@@ -9,6 +9,7 @@ import {
   workspaceRoot,
 } from '@nrwl/devkit';
 import { getBaseWebpackPartial } from '@nrwl/webpack/src/utils/config';
+import { NormalizedWebpackExecutorOptions } from '@nrwl/webpack/src/executors/webpack/schema';
 import { getStylesPartial } from '@nrwl/webpack/src/executors/webpack/lib/get-webpack-config';
 import { checkAndCleanWithSemver } from '@nrwl/workspace/src/utilities/version-utils';
 import { join } from 'path';
@@ -100,7 +101,7 @@ export const webpack = async (
 
   const tsconfigPath = join(options.configDir, 'tsconfig.json');
 
-  const builderOptions: any = {
+  const builderOptions: NormalizedWebpackExecutorOptions = {
     ...options,
     root: options.configDir,
     sourceRoot: '',
@@ -115,6 +116,7 @@ export const webpack = async (
     optimization: {},
     tsConfig: tsconfigPath,
     extractCss: storybookWebpackConfig.mode === 'production',
+    target: 'web',
   };
 
   const esm = true;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Nx + Next.js + SVGR + Storybook (storybook-addon-next) with Nx's SB plugin fails to handle assets because `@nrwl/react/plugins/storybook` does not pass `target` which is needed for `@nrwl/webpack:webpack` executor.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
It should work with no build errors.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
