### PR TITLE
feat(js): inline non-buildable libs for tsc and swc

### DIFF
--- a/docs/generated/packages/js.json
+++ b/docs/generated/packages/js.json
@@ -314,6 +314,19 @@
             "description": "When `updateBuildableProjectDepsInPackageJson` is `true`, this adds dependencies to either `peerDependencies` or `dependencies`.",
             "enum": ["dependencies", "peerDependencies"],
             "default": "peerDependencies"
+          },
+          "external": {
+            "description": "A list projects to be treated as external. This feature is experimental",
+            "oneOf": [
+              { "type": "string", "enum": ["all", "none"] },
+              { "type": "array", "items": { "type": "string" } }
+            ]
+          },
+          "externalBuildTargets": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "List of target names that annotate a build target for a project",
+            "default": ["build"]
           }
         },
         "required": ["main", "outputPath", "tsConfig"],
@@ -472,6 +485,19 @@
             "description": "When `updateBuildableProjectDepsInPackageJson` is `true`, this adds dependencies to either `peerDependencies` or `dependencies`.",
             "enum": ["dependencies", "peerDependencies"],
             "default": "peerDependencies"
+          },
+          "external": {
+            "description": "A list projects to be treated as external. This feature is experimental",
+            "oneOf": [
+              { "type": "string", "enum": ["all", "none"] },
+              { "type": "array", "items": { "type": "string" } }
+            ]
+          },
+          "externalBuildTargets": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "List of target names that annotate a build target for a project",
+            "default": ["build"]
           }
         },
         "required": ["main", "outputPath", "tsConfig"],

--- a/e2e/node/src/node.test.ts
+++ b/e2e/node/src/node.test.ts
@@ -455,7 +455,7 @@ describe('nest libraries', function () {
     const nestlib = uniq('nestlib');
     runCLI(`generate @nrwl/nest:lib ${nestlib} --buildable`);
 
-    packageInstall('@nestjs/swagger', undefined, '~5.0.0');
+    packageInstall('@nestjs/swagger', undefined, '~6.0.0');
 
     updateProjectConfig(nestlib, (config) => {
       config.targets.build.options.transformers = [

--- a/packages/js/src/executors/swc/schema.json
+++ b/packages/js/src/executors/swc/schema.json
@@ -72,6 +72,29 @@
       "description": "When `updateBuildableProjectDepsInPackageJson` is `true`, this adds dependencies to either `peerDependencies` or `dependencies`.",
       "enum": ["dependencies", "peerDependencies"],
       "default": "peerDependencies"
+    },
+    "external": {
+      "description": "A list projects to be treated as external. This feature is experimental",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["all", "none"]
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "externalBuildTargets": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "List of target names that annotate a build target for a project",
+      "default": ["build"]
     }
   },
   "required": ["main", "outputPath", "tsConfig"],

--- a/packages/js/src/executors/tsc/schema.json
+++ b/packages/js/src/executors/tsc/schema.json
@@ -61,6 +61,29 @@
       "description": "When `updateBuildableProjectDepsInPackageJson` is `true`, this adds dependencies to either `peerDependencies` or `dependencies`.",
       "enum": ["dependencies", "peerDependencies"],
       "default": "peerDependencies"
+    },
+    "external": {
+      "description": "A list projects to be treated as external. This feature is experimental",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["all", "none"]
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "externalBuildTargets": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "List of target names that annotate a build target for a project",
+      "default": ["build"]
     }
   },
   "required": ["main", "outputPath", "tsConfig"],

--- a/packages/js/src/executors/tsc/tsc.impl.spec.ts
+++ b/packages/js/src/executors/tsc/tsc.impl.spec.ts
@@ -1,8 +1,8 @@
 import { ExecutorContext } from '@nrwl/devkit';
 import { ExecutorOptions } from '../../utils/schema';
 import {
-  normalizeOptions,
   createTypeScriptCompilationOptions,
+  normalizeOptions,
 } from './tsc.impl';
 
 describe('tscExecutor', () => {

--- a/packages/js/src/executors/tsc/tsc.impl.ts
+++ b/packages/js/src/executors/tsc/tsc.impl.ts
@@ -3,7 +3,7 @@ import {
   assetGlobsToFiles,
   FileInputOutput,
 } from '@nrwl/workspace/src/utilities/assets';
-import { TypeScriptCompilationOptions } from '@nrwl/workspace/src/utilities/typescript/compilation';
+import type { TypeScriptCompilationOptions } from '@nrwl/workspace/src/utilities/typescript/compilation';
 import { join, resolve } from 'path';
 import {
   CustomTransformers,
@@ -11,16 +11,21 @@ import {
   SourceFile,
   TransformerFactory,
 } from 'typescript';
+import { CopyAssetsHandler } from '../../utils/assets/copy-assets-handler';
 import { checkDependencies } from '../../utils/check-dependencies';
 import {
   getHelperDependency,
   HelperDependency,
 } from '../../utils/compiler-helper-dependency';
-import { CopyAssetsHandler } from '../../utils/assets/copy-assets-handler';
+import {
+  handleInliningBuild,
+  isInlineGraphEmpty,
+  postProcessInlinedDependencies,
+} from '../../utils/inline';
+import { updatePackageJson } from '../../utils/package-json/update-package-json';
 import { ExecutorOptions, NormalizedExecutorOptions } from '../../utils/schema';
 import { compileTypeScriptFiles } from '../../utils/typescript/compile-typescript-files';
 import { loadTsTransformers } from '../../utils/typescript/load-ts-transformers';
-import { updatePackageJson } from '../../utils/package-json/update-package-json';
 import { watchForSingleFileChanges } from '../../utils/watch-for-single-file-changes';
 
 export function normalizeOptions(
@@ -36,6 +41,20 @@ export function normalizeOptions(
 
   if (options.watch == null) {
     options.watch = false;
+  }
+
+  // TODO: put back when inlining story is more stable
+  // if (options.external == null) {
+  //   options.external = 'all';
+  // } else if (Array.isArray(options.external) && options.external.length === 0) {
+  //   options.external = 'none';
+  // }
+
+  if (Array.isArray(options.external) && options.external.length > 0) {
+    const firstItem = options.external[0];
+    if (firstItem === 'all' || firstItem === 'none') {
+      options.external = firstItem;
+    }
   }
 
   const files: FileInputOutput[] = assetGlobsToFiles(
@@ -141,12 +160,32 @@ export async function* tscExecutor(
     process.on('SIGTERM', () => handleTermination());
   }
 
+  const tsCompilationOptions = createTypeScriptCompilationOptions(
+    options,
+    context
+  );
+
+  const inlineProjectGraph = handleInliningBuild(
+    context,
+    options,
+    tsCompilationOptions.tsConfig
+  );
+
+  if (!isInlineGraphEmpty(inlineProjectGraph)) {
+    tsCompilationOptions.rootDir = '.';
+  }
+
   return yield* compileTypeScriptFiles(
     options,
-    createTypeScriptCompilationOptions(options, context),
+    tsCompilationOptions,
     async () => {
       await assetHandler.processAllAssetsOnce();
       updatePackageJson(options, context, target, dependencies);
+      postProcessInlinedDependencies(
+        tsCompilationOptions.outputPath,
+        tsCompilationOptions.projectRoot,
+        inlineProjectGraph
+      );
     }
   );
 }

--- a/packages/js/src/utils/inline.ts
+++ b/packages/js/src/utils/inline.ts
@@ -1,0 +1,321 @@
+import type { ExecutorContext, ProjectGraphProjectNode } from '@nrwl/devkit';
+import { readJsonFile } from '@nrwl/devkit';
+import {
+  copySync,
+  readdirSync,
+  readFileSync,
+  removeSync,
+  writeFileSync,
+} from 'fs-extra';
+import { join, relative } from 'path';
+import type { NormalizedExecutorOptions } from './schema';
+
+interface InlineProjectNode {
+  name: string;
+  root: string;
+  sourceRoot: string;
+  pathAlias: string;
+  buildOutputPath?: string;
+}
+
+export interface InlineProjectGraph {
+  nodes: Record<string, InlineProjectNode>;
+  externals: Record<string, InlineProjectNode>;
+  dependencies: Record<string, string[]>;
+}
+
+export function isInlineGraphEmpty(inlineGraph: InlineProjectGraph): boolean {
+  return Object.keys(inlineGraph.nodes).length === 0;
+}
+
+export function handleInliningBuild(
+  context: ExecutorContext,
+  options: NormalizedExecutorOptions,
+  tsConfigPath: string
+): InlineProjectGraph {
+  const tsConfigJson = readJsonFile(tsConfigPath);
+  const pathAliases =
+    tsConfigJson['compilerOptions']['paths'] || readBasePathAliases(context);
+  const inlineGraph = createInlineGraph(context, options, pathAliases);
+
+  if (isInlineGraphEmpty(inlineGraph)) {
+    return inlineGraph;
+  }
+
+  buildInlineGraphExternals(context, inlineGraph, pathAliases);
+
+  return inlineGraph;
+}
+
+export function postProcessInlinedDependencies(
+  outputPath: string,
+  parentOutputPath: string,
+  inlineGraph: InlineProjectGraph
+) {
+  if (isInlineGraphEmpty(inlineGraph)) {
+    return;
+  }
+
+  const parentDistPath = join(outputPath, parentOutputPath);
+
+  // move parentOutput
+  movePackage(parentDistPath, outputPath);
+
+  const inlinedDepsDestOutputRecord: Record<string, string> = {};
+  // move inlined outputs
+
+  for (const inlineDependenciesNames of Object.values(
+    inlineGraph.dependencies
+  )) {
+    for (const inlineDependenciesName of inlineDependenciesNames) {
+      const inlineDependency = inlineGraph.nodes[inlineDependenciesName];
+      const depOutputPath =
+        inlineDependency.buildOutputPath ||
+        join(outputPath, inlineDependency.root);
+      const destDepOutputPath = join(outputPath, inlineDependency.name);
+      movePackage(depOutputPath, destDepOutputPath);
+
+      // TODO: hard-coded "src"
+      inlinedDepsDestOutputRecord[inlineDependency.pathAlias] =
+        destDepOutputPath + '/src';
+    }
+  }
+
+  updateImports(outputPath, inlinedDepsDestOutputRecord);
+}
+
+function readBasePathAliases(context: ExecutorContext) {
+  const tsConfigPath = join(context.root, 'tsconfig.base.json');
+  return readJsonFile(tsConfigPath)?.['compilerOptions']['paths'] || {};
+}
+
+function emptyInlineGraph(): InlineProjectGraph {
+  return { nodes: {}, externals: {}, dependencies: {} };
+}
+
+function projectNodeToInlineProjectNode(
+  projectNode: ProjectGraphProjectNode,
+  pathAlias = '',
+  buildOutputPath = ''
+): InlineProjectNode {
+  return {
+    name: projectNode.name,
+    root: projectNode.data.root,
+    sourceRoot: projectNode.data.sourceRoot,
+    pathAlias,
+    buildOutputPath,
+  };
+}
+
+function createInlineGraph(
+  context: ExecutorContext,
+  options: NormalizedExecutorOptions,
+  pathAliases: Record<string, string[]>,
+  projectName: string = context.projectName,
+  inlineGraph: InlineProjectGraph = emptyInlineGraph()
+) {
+  if (options.external == null) return inlineGraph;
+
+  const projectDependencies =
+    context.projectGraph.dependencies[projectName] || [];
+  if (projectDependencies.length === 0) return inlineGraph;
+
+  if (!inlineGraph.nodes[projectName]) {
+    inlineGraph.nodes[projectName] = projectNodeToInlineProjectNode(
+      context.projectGraph.nodes[projectName]
+    );
+  }
+
+  const implicitDependencies =
+    context.projectGraph.nodes[projectName].data.implicitDependencies || [];
+
+  for (const projectDependency of projectDependencies) {
+    // skip npm packages
+    if (projectDependency.target.startsWith('npm')) {
+      continue;
+    }
+
+    // skip implicitDependencies
+    if (implicitDependencies.includes(projectDependency.target)) {
+      continue;
+    }
+
+    const pathAlias = getPathAliasForPackage(
+      context.projectGraph.nodes[projectDependency.target],
+      pathAliases
+    );
+
+    const buildOutputPath = getBuildOutputPath(
+      projectDependency.target,
+      context,
+      options
+    );
+
+    const shouldInline =
+      /**
+       * if all buildable libraries are marked as external,
+       * then push the project dependency that doesn't have a build target
+       */
+      (options.external === 'all' && !buildOutputPath) ||
+      /**
+       * if all buildable libraries are marked as internal,
+       * then push every project dependency to be inlined
+       */
+      options.external === 'none' ||
+      /**
+       * if some buildable libraries are marked as external,
+       * then push the project dependency that IS NOT marked as external OR doesn't have a build target
+       */
+      (Array.isArray(options.external) &&
+        options.external.length > 0 &&
+        !options.external.includes(projectDependency.target)) ||
+      !buildOutputPath;
+
+    if (shouldInline) {
+      inlineGraph.dependencies[projectName] ??= [];
+      inlineGraph.dependencies[projectName].push(projectDependency.target);
+    }
+
+    inlineGraph.nodes[projectDependency.target] =
+      projectNodeToInlineProjectNode(
+        context.projectGraph.nodes[projectDependency.target],
+        pathAlias,
+        buildOutputPath
+      );
+
+    if (
+      context.projectGraph.dependencies[projectDependency.target].length > 0
+    ) {
+      inlineGraph = createInlineGraph(
+        context,
+        options,
+        pathAliases,
+        projectDependency.target,
+        inlineGraph
+      );
+    }
+  }
+
+  return inlineGraph;
+}
+
+function buildInlineGraphExternals(
+  context: ExecutorContext,
+  inlineProjectGraph: InlineProjectGraph,
+  pathAliases: Record<string, string[]>
+) {
+  const allNodes = { ...context.projectGraph.nodes };
+
+  for (const [parent, dependencies] of Object.entries(
+    inlineProjectGraph.dependencies
+  )) {
+    if (allNodes[parent]) {
+      delete allNodes[parent];
+    }
+
+    for (const dependencyName of dependencies) {
+      const dependencyNode = inlineProjectGraph.nodes[dependencyName];
+
+      // buildable is still external even if it is a dependency
+      if (dependencyNode.buildOutputPath) {
+        continue;
+      }
+
+      if (allNodes[dependencyName]) {
+        delete allNodes[dependencyName];
+      }
+    }
+  }
+
+  for (const [projectName, projectNode] of Object.entries(allNodes)) {
+    if (!inlineProjectGraph.externals[projectName]) {
+      inlineProjectGraph.externals[projectName] =
+        projectNodeToInlineProjectNode(
+          projectNode,
+          getPathAliasForPackage(projectNode, pathAliases)
+        );
+    }
+  }
+}
+
+export function movePackage(from: string, to: string) {
+  copySync(from, to, { overwrite: true, recursive: true });
+  removeSync(from);
+}
+
+function updateImports(
+  destOutputPath: string,
+  inlinedDepsDestOutputRecord: Record<string, string>
+) {
+  const importRegex = new RegExp(
+    Object.keys(inlinedDepsDestOutputRecord)
+      .map((pathAlias) => `["'](${pathAlias})["']`)
+      .join('|'),
+    'g'
+  );
+  recursiveUpdateImport(
+    destOutputPath,
+    importRegex,
+    inlinedDepsDestOutputRecord
+  );
+}
+
+function recursiveUpdateImport(
+  dirPath: string,
+  importRegex: RegExp,
+  inlinedDepsDestOutputRecord: Record<string, string>
+) {
+  const files = readdirSync(dirPath, { withFileTypes: true });
+  for (const file of files) {
+    // only check .js and .d.ts files
+    if (
+      file.isFile() &&
+      (file.name.endsWith('.js') || file.name.endsWith('.d.ts'))
+    ) {
+      const filePath = join(dirPath, file.name);
+      const fileContent = readFileSync(filePath, 'utf-8');
+      const updatedContent = fileContent.replace(importRegex, (matched) => {
+        const result = matched.replace(/['"]/g, '');
+        return `"${relative(dirPath, inlinedDepsDestOutputRecord[result])}"`;
+      });
+      writeFileSync(filePath, updatedContent);
+    } else if (file.isDirectory()) {
+      recursiveUpdateImport(
+        join(dirPath, file.name),
+        importRegex,
+        inlinedDepsDestOutputRecord
+      );
+    }
+  }
+}
+
+function getPathAliasForPackage(
+  packageNode: ProjectGraphProjectNode,
+  pathAliases: Record<string, string[]>
+): string {
+  if (!packageNode) return '';
+
+  for (const [alias, paths] of Object.entries(pathAliases)) {
+    if (paths.some((path) => path.includes(packageNode.data.root))) {
+      return alias;
+    }
+  }
+
+  return '';
+}
+
+function getBuildOutputPath(
+  projectName: string,
+  context: ExecutorContext,
+  options: NormalizedExecutorOptions
+): string {
+  const buildTarget = options.externalBuildTargets.find(
+    (buildTarget) =>
+      context.projectGraph.nodes[projectName]?.data?.targets?.[buildTarget]
+  );
+
+  if (buildTarget)
+    return context.projectGraph.nodes[projectName].data.targets?.[buildTarget]
+      .options['outputPath'];
+  return '';
+}

--- a/packages/js/src/utils/schema.d.ts
+++ b/packages/js/src/utils/schema.d.ts
@@ -45,6 +45,8 @@ export interface ExecutorOptions {
   transformers: TransformerEntry[];
   updateBuildableProjectDepsInPackageJson?: boolean;
   buildableProjectDepsInPackageJsonType?: 'dependencies' | 'peerDependencies';
+  external?: 'all' | 'none' | string[];
+  externalBuildTargets?: string[];
 }
 
 export interface NormalizedExecutorOptions extends ExecutorOptions {
@@ -72,6 +74,7 @@ export interface SwcCliOptions {
 
 export interface NormalizedSwcExecutorOptions
   extends NormalizedExecutorOptions {
+  originalProjectRoot: string;
   swcExclude: string[];
   skipTypeCheck: boolean;
   swcCliOptions: SwcCliOptions;

--- a/packages/js/src/utils/swc/compile-swc.ts
+++ b/packages/js/src/utils/swc/compile-swc.ts
@@ -1,11 +1,10 @@
-import { ExecutorContext, logger } from '@nrwl/devkit';
+import { cacheDir, ExecutorContext, logger } from '@nrwl/devkit';
 import { exec, execSync } from 'child_process';
-import { cacheDir } from '@nrwl/devkit';
+import { removeSync } from 'fs-extra';
 import { createAsyncIterable } from '../create-async-iterable/create-async-iteratable';
 import { NormalizedSwcExecutorOptions, SwcCliOptions } from '../schema';
 import { printDiagnostics } from '../typescript/print-diagnostics';
 import { runTypeCheck, TypeCheckOptions } from '../typescript/run-type-check';
-import { removeSync } from 'fs-extra';
 
 function getSwcCmd(
   { swcrcPath, srcPath, destPath }: SwcCliOptions,
@@ -51,9 +50,8 @@ export async function compileSwc(
   logger.log(swcCmdLog.replace(/\n/, ''));
   const isCompileSuccess = swcCmdLog.includes('Successfully compiled');
 
-  await postCompilationCallback();
-
   if (normalizedOptions.skipTypeCheck) {
+    await postCompilationCallback();
     return { success: isCompileSuccess };
   }
 
@@ -67,6 +65,7 @@ export async function compileSwc(
     await printDiagnostics(errors, warnings);
   }
 
+  await postCompilationCallback();
   return { success: !hasErrors && isCompileSuccess };
 }
 

--- a/packages/js/src/utils/swc/inline.ts
+++ b/packages/js/src/utils/swc/inline.ts
@@ -1,0 +1,21 @@
+import { readJsonFile, writeJsonFile } from '@nrwl/devkit';
+import type { InlineProjectGraph } from '../inline';
+
+export function generateTmpSwcrc(
+  inlineProjectGraph: InlineProjectGraph,
+  swcrcPath: string
+) {
+  const swcrc = readJsonFile(swcrcPath);
+
+  swcrc['exclude'] = swcrc['exclude'].concat(
+    Object.values(inlineProjectGraph.externals).map(
+      (external) => `${external.root}/**/.*.ts$`
+    ),
+    'node_modules/**/*.ts$'
+  );
+
+  const tmpSwcrcPath = `tmp${swcrcPath}`;
+  writeJsonFile(tmpSwcrcPath, swcrc);
+
+  return tmpSwcrcPath;
+}


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
`nrwl/js:tsc` and `nrwl/js:swc` do not work with non-buildable libraries

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
- `nrwl/js:tsc` and `nrwl/js:swc` works with non-buildable libraries by inlining them.
- This PR includes code from the reverted `chore(js): inline non-buildablie libs`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
