### PR TITLE
fix(devkit): ensure that getProjects works properly without a nx.json

### DIFF
--- a/packages/nx/src/config/workspaces.ts
+++ b/packages/nx/src/config/workspaces.ts
@@ -725,22 +725,23 @@ function buildProjectConfigurationFromPackageJson(
 ): ProjectConfiguration & { name: string } {
   const directory = dirname(path).split('\\').join('/');
   let name = packageJson.name ?? toProjectName(directory, nxJson);
-  if (nxJson.npmScope) {
+  if (nxJson?.npmScope) {
     const npmPrefix = `@${nxJson.npmScope}/`;
     if (name.startsWith(npmPrefix)) {
       name = name.replace(npmPrefix, '');
     }
   }
+  const projectType =
+    nxJson?.workspaceLayout?.appsDir != nxJson?.workspaceLayout?.libsDir &&
+    nxJson?.workspaceLayout?.appsDir &&
+    directory.startsWith(nxJson.workspaceLayout.appsDir)
+      ? 'application'
+      : 'library';
   return {
     root: directory,
     sourceRoot: directory,
     name,
-    projectType:
-      nxJson.workspaceLayout?.appsDir != nxJson.workspaceLayout?.libsDir &&
-      nxJson.workspaceLayout?.appsDir &&
-      directory.startsWith(nxJson.workspaceLayout.appsDir)
-        ? 'application'
-        : 'library',
+    projectType,
   };
 }
 

--- a/packages/nx/src/generators/utils/project-configuration.spec.ts
+++ b/packages/nx/src/generators/utils/project-configuration.spec.ts
@@ -2,6 +2,7 @@ import Ajv from 'ajv';
 import { Tree } from '../tree';
 import { ProjectConfiguration } from '../../config/workspace-json-project-json';
 
+import { createTree } from '../testing-utils/create-tree';
 import {
   createTreeWithEmptyWorkspace,
   createTreeWithEmptyV1Workspace,
@@ -432,6 +433,23 @@ describe('project configuration', () => {
       });
     });
 
+    describe('getProjects', () => {
+      it('should get a map of projects', () => {
+        addProjectConfiguration(tree, 'proj', {
+          root: 'proj',
+        });
+
+        const projects = getProjects(tree);
+
+        expect(projects.size).toEqual(1);
+        expect(projects.get('proj')).toEqual({
+          $schema: '../node_modules/nx/schemas/project-schema.json',
+          name: 'proj',
+          root: 'proj',
+        });
+      });
+    });
+
     describe('without nx.json', () => {
       beforeEach(() => tree.delete('nx.json'));
 
@@ -567,6 +585,64 @@ describe('project configuration', () => {
             joinPathFragments(baseTestProjectConfigV2.root, 'project.json')
           )
         ).toBeFalsy();
+      });
+
+      describe('getProjects', () => {
+        it('should get a map of projects', () => {
+          addProjectConfiguration(tree, 'proj', {
+            root: 'proj',
+          });
+
+          const projects = getProjects(tree);
+
+          expect(projects.size).toEqual(1);
+          expect(projects.get('proj')).toEqual({
+            $schema: '../node_modules/nx/schemas/project-schema.json',
+            name: 'proj',
+            root: 'proj',
+          });
+        });
+      });
+    });
+  });
+
+  describe('for npm workspaces', () => {
+    beforeEach(() => {
+      tree = createTree();
+    });
+
+    describe('readProjectConfiguration', () => {
+      it('should read project configuration from package.json files', () => {
+        writeJson(tree, 'proj/package.json', {
+          name: 'proj',
+        });
+
+        const proj = readProjectConfiguration(tree, 'proj');
+
+        expect(proj).toEqual({
+          root: 'proj',
+          sourceRoot: 'proj',
+          projectType: 'library',
+        });
+      });
+    });
+
+    describe('getProjects', () => {
+      beforeEach(() => {
+        writeJson(tree, 'proj/package.json', {
+          name: 'proj',
+        });
+      });
+
+      it('should get a map of projects', () => {
+        const projects = getProjects(tree);
+
+        expect(projects.size).toEqual(1);
+        expect(projects.get('proj')).toEqual({
+          root: 'proj',
+          sourceRoot: 'proj',
+          projectType: 'library',
+        });
       });
     });
   });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The following error is thrown when using `getProjects` in a repo without `nx.json`:

```
jason@pop-os ~/p/lerna (main)> npx nx repair --verbose

 >  NX   Failed to run 14-0-6-remove-root from nx. This workspace is NOT up to date!


 >  NX   Cannot read property 'npmScope' of null
 ```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`getProjects` properly returns the map of projects when used in a workspace with no `nx.json`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
