### PR TITLE
fix(webpack): regression from #10432 to allow `//` prefix

### DIFF
--- a/packages/angular/src/utils/mf/with-module-federation.ts
+++ b/packages/angular/src/utils/mf/with-module-federation.ts
@@ -4,7 +4,7 @@ import {
   readCachedProjectGraph,
 } from '@nrwl/devkit';
 import { readCachedProjectConfiguration } from 'nx/src/project-graph/project-graph';
-import { extname, join } from 'path';
+import { extname } from 'path';
 import {
   getNpmPackageSharedConfig,
   SharedLibraryConfig,
@@ -59,7 +59,11 @@ function mapRemotes(remotes: MFRemotes) {
       const remoteLocationExt = extname(remoteLocation);
       mappedRemotes[remoteName] = ['.js', '.mjs'].includes(remoteLocationExt)
         ? remoteLocation
-        : join(remoteLocation, 'remoteEntry.mjs');
+        : `${
+            remoteLocation.endsWith('/')
+              ? remoteLocation.slice(0, -1)
+              : remoteLocation
+          }/remoteEntry.mjs`;
     } else if (typeof remote === 'string') {
       mappedRemotes[remote] = determineRemoteUrl(remote);
     }

--- a/packages/react/src/module-federation/with-module-federation.ts
+++ b/packages/react/src/module-federation/with-module-federation.ts
@@ -22,7 +22,7 @@ import {
   SharedLibraryConfig,
 } from './models';
 import { readRootPackageJson } from './package-json';
-import { extname, join } from 'path';
+import { extname } from 'path';
 import ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
 
 function collectDependencies(
@@ -133,7 +133,11 @@ function mapRemotes(remotes: Remotes, projectGraph: ProjectGraph) {
       const remoteLocationExt = extname(remoteLocation);
       mappedRemotes[remoteName] = ['.js', '.mjs'].includes(remoteLocationExt)
         ? remoteLocation
-        : join(remoteLocation, 'remoteEntry.js');
+        : `${
+            remoteLocation.endsWith('/')
+              ? remoteLocation.slice(0, -1)
+              : remoteLocation
+          }/remoteEntry.js`;
     } else if (typeof remote === 'string') {
       mappedRemotes[remote] = determineRemoteUrl(remote, projectGraph);
     }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Provided `ModuleFederationConfig` of the following:

```js
  remotes: [
    ['about', '//localhost:4201/'],
    ['cart', '//localhost:4202/'],
    ['shop', '//localhost:4203/'],
  ],
```

It ends up requesting `http://localhost:4200/localhost:4201/remoteEntry.js`

![image](https://user-images.githubusercontent.com/9028430/192933295-e3b021a5-eaa6-4c98-bc16-8ee059ecb229.png)

And I think we shouldn't use `path.join` because it would normalize the double slash to become single:
```sh
$ node -e "console.log(require('path').join('//localhost:4201/', 'remoteEntry.js'))"
> /localhost:4201/remoteEntry.js
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

It should assemble the URL correctly and request `http://localhost:4201/remoteEntry.js` instead.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

I believe it's a regression introduced by #10432 when trying to fix #10206.
