### PR TITLE
fix(storybook): check root mainjs for builder

### DIFF
--- a/packages/storybook/src/executors/utils.spec.ts
+++ b/packages/storybook/src/executors/utils.spec.ts
@@ -1,15 +1,11 @@
 import * as ts from 'typescript';
 import { stripIndents } from '@nrwl/devkit';
-import { findBuilderInMainJsTs } from './utils';
-import { logger } from '@nrwl/devkit';
+import { builderIsWebpackButNotWebpack5 } from './utils';
 
 describe('testing utilities', () => {
-  beforeEach(() => {
-    jest.spyOn(logger, 'warn');
-  });
-
-  it('should not log the webpack5 warning if builder is webpack5', () => {
-    const sourceCode = stripIndents`
+  describe('builderIsWebpackButNotWebpack5', () => {
+    it('should return false if builder is webpack5', () => {
+      const sourceCode = stripIndents`
     const rootMain = require('../../../.storybook/main');
 
     module.exports = {
@@ -18,19 +14,18 @@ describe('testing utilities', () => {
     };    
     `;
 
-    const source = ts.createSourceFile(
-      '.storybook/main.js',
-      sourceCode,
-      ts.ScriptTarget.Latest,
-      true
-    );
+      const source = ts.createSourceFile(
+        '.storybook/main.js',
+        sourceCode,
+        ts.ScriptTarget.Latest,
+        true
+      );
 
-    findBuilderInMainJsTs(source);
-    expect(logger.warn).not.toHaveBeenCalled();
-  });
+      expect(builderIsWebpackButNotWebpack5(source)).toBeFalsy();
+    });
 
-  it('should not log the webpack5 warning if builder is @storybook/webpack5', () => {
-    const sourceCode = stripIndents`
+    it('should return false if builder is @storybook/webpack5', () => {
+      const sourceCode = stripIndents`
     const rootMain = require('../../../.storybook/main');
 
     module.exports = {
@@ -39,19 +34,18 @@ describe('testing utilities', () => {
     };    
     `;
 
-    const source = ts.createSourceFile(
-      '.storybook/main.js',
-      sourceCode,
-      ts.ScriptTarget.Latest,
-      true
-    );
+      const source = ts.createSourceFile(
+        '.storybook/main.js',
+        sourceCode,
+        ts.ScriptTarget.Latest,
+        true
+      );
 
-    findBuilderInMainJsTs(source);
-    expect(logger.warn).not.toHaveBeenCalled();
-  });
+      expect(builderIsWebpackButNotWebpack5(source)).toBeFalsy();
+    });
 
-  it('should not log the webpack5 warning if builder exists but does not contain webpack', () => {
-    const sourceCode = stripIndents`
+    it('should return false if builder exists but does not contain webpack', () => {
+      const sourceCode = stripIndents`
     const rootMain = require('../../../.storybook/main');
 
     module.exports = {
@@ -60,19 +54,18 @@ describe('testing utilities', () => {
     };    
     `;
 
-    const source = ts.createSourceFile(
-      '.storybook/main.js',
-      sourceCode,
-      ts.ScriptTarget.Latest,
-      true
-    );
+      const source = ts.createSourceFile(
+        '.storybook/main.js',
+        sourceCode,
+        ts.ScriptTarget.Latest,
+        true
+      );
 
-    findBuilderInMainJsTs(source);
-    expect(logger.warn).not.toHaveBeenCalled();
-  });
+      expect(builderIsWebpackButNotWebpack5(source)).toBeFalsy();
+    });
 
-  it('should log the webpack5 warning if builder is webpack4', () => {
-    const sourceCode = stripIndents`
+    it('should return true if builder is webpack4', () => {
+      const sourceCode = stripIndents`
     const rootMain = require('../../../.storybook/main');
 
     module.exports = {
@@ -81,19 +74,18 @@ describe('testing utilities', () => {
     };    
     `;
 
-    const source = ts.createSourceFile(
-      '.storybook/main.js',
-      sourceCode,
-      ts.ScriptTarget.Latest,
-      true
-    );
+      const source = ts.createSourceFile(
+        '.storybook/main.js',
+        sourceCode,
+        ts.ScriptTarget.Latest,
+        true
+      );
 
-    findBuilderInMainJsTs(source);
-    expect(logger.warn).toHaveBeenCalled();
-  });
+      expect(builderIsWebpackButNotWebpack5(source)).toBeTruthy();
+    });
 
-  it('should log the webpack5 warning if builder does not exist', () => {
-    const sourceCode = stripIndents`
+    it('should return true if builder does not exist because default is webpack', () => {
+      const sourceCode = stripIndents`
     const rootMain = require('../../../.storybook/main');
 
     module.exports = {
@@ -101,14 +93,14 @@ describe('testing utilities', () => {
     };    
     `;
 
-    const source = ts.createSourceFile(
-      '.storybook/main.js',
-      sourceCode,
-      ts.ScriptTarget.Latest,
-      true
-    );
+      const source = ts.createSourceFile(
+        '.storybook/main.js',
+        sourceCode,
+        ts.ScriptTarget.Latest,
+        true
+      );
 
-    findBuilderInMainJsTs(source);
-    expect(logger.warn).toHaveBeenCalled();
+      expect(builderIsWebpackButNotWebpack5(source)).toBeFalsy();
+    });
   });
 });

--- a/packages/storybook/src/executors/utils.ts
+++ b/packages/storybook/src/executors/utils.ts
@@ -47,37 +47,47 @@ export function runStorybookSetupCheck(options: CommonNxStorybookConfig) {
 
 function reactWebpack5Check(options: CommonNxStorybookConfig) {
   if (options.uiFramework === '@storybook/react') {
-    let storybookConfigFilePath = joinPathFragments(
-      options.config.configFolder,
-      'main.js'
-    );
-
-    if (!existsSync(storybookConfigFilePath)) {
-      storybookConfigFilePath = joinPathFragments(
-        options.config.configFolder,
-        'main.ts'
-      );
-    }
-
-    if (!existsSync(storybookConfigFilePath)) {
-      // looks like there's no main config file, so skip
-      return;
-    }
-
+    const source = mainJsTsFileContent(options.config.configFolder);
+    const rootSource = mainJsTsFileContent('.storybook');
     // check whether the current Storybook configuration has the webpack 5 builder enabled
-    const storybookConfig = readFileSync(storybookConfigFilePath, {
-      encoding: 'utf8',
-    });
-
-    const source = ts.createSourceFile(
-      storybookConfigFilePath,
-      storybookConfig,
-      ts.ScriptTarget.Latest,
-      true
-    );
-
-    findBuilderInMainJsTs(source);
+    if (
+      builderIsWebpackButNotWebpack5(source) &&
+      builderIsWebpackButNotWebpack5(rootSource)
+    ) {
+      logger.warn(`
+      It looks like you use Webpack 5 but your Storybook setup is not configured to leverage that
+      and thus falls back to Webpack 4.
+      Make sure you upgrade your Storybook config to use Webpack 5.
+      
+        - https://gist.github.com/shilman/8856ea1786dcd247139b47b270912324#upgrade
+            
+      `);
+    }
   }
+}
+
+function mainJsTsFileContent(configFolder: string): ts.SourceFile {
+  let storybookConfigFilePath = joinPathFragments(configFolder, 'main.js');
+
+  if (!existsSync(storybookConfigFilePath)) {
+    storybookConfigFilePath = joinPathFragments(configFolder, 'main.ts');
+  }
+
+  if (!existsSync(storybookConfigFilePath)) {
+    // looks like there's no main config file, so skip
+    return;
+  }
+
+  const storybookConfig = readFileSync(storybookConfigFilePath, {
+    encoding: 'utf8',
+  });
+
+  return ts.createSourceFile(
+    storybookConfigFilePath,
+    storybookConfig,
+    ts.ScriptTarget.Latest,
+    true
+  );
 }
 
 function webpackFinalPropertyCheck(options: CommonNxStorybookConfig) {
@@ -135,33 +145,25 @@ export function resolveCommonStorybookOptionMapper(
   return storybookOptions;
 }
 
-export function findBuilderInMainJsTs(storybookConfig: ts.SourceFile) {
+export function builderIsWebpackButNotWebpack5(
+  storybookConfig: ts.SourceFile
+): boolean {
   const importArray = findNodes(storybookConfig, [
     ts.SyntaxKind.PropertyAssignment,
   ]);
-  let builderIsSpecified = false;
+  let builderIsWebpackNot5 = false;
   importArray.forEach((parent) => {
     const identifier = findNodes(parent, ts.SyntaxKind.Identifier);
     const sbBuilder = findNodes(parent, ts.SyntaxKind.StringLiteral);
     const builderText = sbBuilder?.[0]?.getText() ?? '';
-    if (identifier[0].getText() === 'builder') {
-      builderIsSpecified = true;
-      if (
-        builderText.includes('webpack') &&
-        !builderText.includes('webpack5')
-      ) {
-        builderIsSpecified = false;
-      }
+    if (
+      identifier?.[0]?.getText() === 'builder' &&
+      builderText.includes('webpack') &&
+      !builderText.includes('webpack5')
+    ) {
+      builderIsWebpackNot5 = true;
     }
   });
-  if (!builderIsSpecified) {
-    logger.warn(`
-    It looks like you use Webpack 5 but your Storybook setup is not configured to leverage that
-    and thus falls back to Webpack 4.
-    Make sure you upgrade your Storybook config to use Webpack 5.
-    
-      - https://gist.github.com/shilman/8856ea1786dcd247139b47b270912324#upgrade
-          
-    `);
-  }
+
+  return builderIsWebpackNot5;
 }


### PR DESCRIPTION
## Current Behavior
If Storybook builder is specified in root `.storybook/main.js` and not in the project-level `main.js`, the warning about not using webpack5 shows up erroneously.

## Expected Behavior
Check root `.storybook/main.js` to see if builder is specified there. If builder is not specified in either of the two (root level and project level `.storybook/main.js`) then and only then show the warning

## Related Issue(s)

Fixes #12219
