### PR TITLE
fix(bundling): correct main field in package.json when using esbuild

### DIFF
--- a/e2e/esbuild/src/esbuild.test.ts
+++ b/e2e/esbuild/src/esbuild.test.ts
@@ -13,7 +13,9 @@ import {
 
 describe('EsBuild Plugin', () => {
   let proj: string;
+
   beforeEach(() => (proj = newProject()));
+
   afterEach(() => cleanupProject());
 
   it('should setup and build projects using build', async () => {
@@ -30,8 +32,10 @@ describe('EsBuild Plugin', () => {
     runCLI(`build ${myPkg}`);
 
     expect(runCommand(`node dist/libs/${myPkg}/index.js`)).toMatch(/Hello/);
-
+    // main field should be set correctly in package.json
     checkFilesExist(`dist/libs/${myPkg}/package.json`);
+    expect(runCommand(`node dist/libs/${myPkg}`)).toMatch(/Hello/);
+
     expect(readFile(`dist/libs/${myPkg}/assets/a.md`)).toMatch(/file a/);
     expect(readFile(`dist/libs/${myPkg}/assets/b.md`)).toMatch(/file b/);
 

--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.spec.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.spec.ts
@@ -1,0 +1,154 @@
+import { buildEsbuildOptions } from './build-esbuild-options';
+import { ExecutorContext } from 'nx/src/config/misc-interfaces';
+
+describe('buildEsbuildOptions', () => {
+  const context: ExecutorContext = {
+    workspace: {
+      version: 2,
+      projects: {
+        myapp: {
+          root: 'apps/myapp',
+        },
+      },
+    },
+    isVerbose: false,
+    root: '/',
+    cwd: '/',
+    target: {
+      executor: '@nrwl/esbuild:esbuild',
+      options: {
+        outputPath: 'dist/apps/myapp',
+      },
+    },
+  };
+
+  it('should include environment variables for platform === browser', () => {
+    expect(
+      buildEsbuildOptions(
+        'esm',
+        {
+          platform: 'browser',
+          main: 'apps/myapp/src/index.ts',
+          outputPath: 'dist/apps/myapp',
+          tsConfig: 'apps/myapp/tsconfig.app.json',
+          project: 'apps/myapp/package.json',
+          assets: [],
+          outputFileName: 'index.js',
+          singleEntry: true,
+        },
+        context
+      )
+    ).toEqual({
+      bundle: true,
+      define: expect.objectContaining({
+        'process.env.NODE_ENV': '"test"',
+      }),
+      entryNames: '[dir]/[name]',
+      entryPoints: ['apps/myapp/src/index.ts'],
+      format: 'esm',
+      platform: 'browser',
+      outfile: 'dist/apps/myapp/index.js',
+      tsconfig: 'apps/myapp/tsconfig.app.json',
+      outExtension: {
+        '.js': '.js',
+      },
+    });
+  });
+
+  it('should support multiple entry points', () => {
+    expect(
+      buildEsbuildOptions(
+        'esm',
+        {
+          platform: 'browser',
+          main: 'apps/myapp/src/index.ts',
+          additionalEntryPoints: ['apps/myapp/src/extra-entry.ts'],
+          outputPath: 'dist/apps/myapp',
+          tsConfig: 'apps/myapp/tsconfig.app.json',
+          project: 'apps/myapp/package.json',
+          assets: [],
+          outputFileName: 'index.js',
+          singleEntry: false,
+        },
+        context
+      )
+    ).toEqual({
+      bundle: true,
+      define: expect.objectContaining({
+        'process.env.NODE_ENV': '"test"',
+      }),
+      entryNames: '[dir]/[name]',
+      entryPoints: ['apps/myapp/src/index.ts', 'apps/myapp/src/extra-entry.ts'],
+      format: 'esm',
+      platform: 'browser',
+      outdir: 'dist/apps/myapp',
+      tsconfig: 'apps/myapp/tsconfig.app.json',
+      outExtension: {
+        '.js': '.js',
+      },
+    });
+  });
+
+  it('should support cjs format', () => {
+    expect(
+      buildEsbuildOptions(
+        'cjs',
+        {
+          platform: 'browser',
+          main: 'apps/myapp/src/index.ts',
+          outputPath: 'dist/apps/myapp',
+          tsConfig: 'apps/myapp/tsconfig.app.json',
+          project: 'apps/myapp/package.json',
+          assets: [],
+          outputFileName: 'index.js',
+          singleEntry: true,
+        },
+        context
+      )
+    ).toEqual({
+      bundle: true,
+      define: expect.objectContaining({
+        'process.env.NODE_ENV': '"test"',
+      }),
+      entryNames: '[dir]/[name]',
+      entryPoints: ['apps/myapp/src/index.ts'],
+      format: 'cjs',
+      platform: 'browser',
+      outfile: 'dist/apps/myapp/index.cjs',
+      tsconfig: 'apps/myapp/tsconfig.app.json',
+      outExtension: {
+        '.js': '.cjs',
+      },
+    });
+  });
+
+  it('should not define environment variables for node', () => {
+    expect(
+      buildEsbuildOptions(
+        'cjs',
+        {
+          platform: 'node',
+          main: 'apps/myapp/src/index.ts',
+          outputPath: 'dist/apps/myapp',
+          tsConfig: 'apps/myapp/tsconfig.app.json',
+          project: 'apps/myapp/package.json',
+          assets: [],
+          outputFileName: 'index.js',
+          singleEntry: true,
+        },
+        context
+      )
+    ).toEqual({
+      bundle: true,
+      entryNames: '[dir]/[name]',
+      entryPoints: ['apps/myapp/src/index.ts'],
+      format: 'cjs',
+      platform: 'node',
+      outfile: 'dist/apps/myapp/index.cjs',
+      tsconfig: 'apps/myapp/tsconfig.app.json',
+      outExtension: {
+        '.js': '.cjs',
+      },
+    });
+  });
+});

--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
@@ -1,0 +1,66 @@
+import * as esbuild from 'esbuild';
+import { getClientEnvironment } from '../../../utils/environment-variables';
+import {
+  EsBuildExecutorOptions,
+  NormalizedEsBuildExecutorOptions,
+} from '../schema';
+import { ExecutorContext } from 'nx/src/config/misc-interfaces';
+import { joinPathFragments } from 'nx/src/utils/path';
+import { parse } from 'path';
+
+const ESM_FILE_EXTENSION = '.js';
+const CJS_FILE_EXTENSION = '.cjs';
+
+export function buildEsbuildOptions(
+  format: 'cjs' | 'esm',
+  options: NormalizedEsBuildExecutorOptions,
+  context: ExecutorContext
+): esbuild.BuildOptions {
+  const esbuildOptions: esbuild.BuildOptions = {
+    ...options.esbuildOptions,
+    entryPoints: options.additionalEntryPoints
+      ? [options.main, ...options.additionalEntryPoints]
+      : [options.main],
+    entryNames:
+      options.outputHashing === 'all' ? '[dir]/[name].[hash]' : '[dir]/[name]',
+    bundle: true, // TODO(jack): support non-bundled builds
+    external: options.external,
+    minify: options.minify,
+    platform: options.platform,
+    target: options.target,
+    metafile: options.metafile,
+    tsconfig: options.tsConfig,
+    format,
+    outExtension: { '.js': getOutExtension(format) },
+  };
+
+  if (options.platform === 'browser') {
+    esbuildOptions.define = getClientEnvironment();
+  }
+
+  if (options.singleEntry) {
+    esbuildOptions.outfile = getOutfile(format, options, context);
+  } else {
+    esbuildOptions.outdir = options.outputPath;
+  }
+
+  return esbuildOptions;
+}
+
+function getOutExtension(format: 'cjs' | 'esm') {
+  return format === 'esm' ? ESM_FILE_EXTENSION : CJS_FILE_EXTENSION;
+}
+
+function getOutfile(
+  format: 'cjs' | 'esm',
+  options: EsBuildExecutorOptions,
+  context: ExecutorContext
+) {
+  const candidate = joinPathFragments(
+    context.target.options.outputPath,
+    options.outputFileName
+  );
+  const ext = getOutExtension(format);
+  const { dir, name } = parse(candidate);
+  return `${dir}/${name}${ext}`;
+}

--- a/packages/esbuild/src/executors/esbuild/lib/normalize.spec.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/normalize.spec.ts
@@ -1,0 +1,79 @@
+import { normalizeOptions } from './normalize';
+
+describe('normalizeOptions', () => {
+  it('should handle single entry point options', () => {
+    expect(
+      normalizeOptions({
+        main: 'apps/myapp/src/index.ts',
+        outputPath: 'dist/apps/myapp',
+        tsConfig: 'apps/myapp/tsconfig.app.json',
+        project: 'apps/myapp/package.json',
+        assets: [],
+      })
+    ).toEqual({
+      main: 'apps/myapp/src/index.ts',
+      outputPath: 'dist/apps/myapp',
+      tsConfig: 'apps/myapp/tsconfig.app.json',
+      project: 'apps/myapp/package.json',
+      assets: [],
+      outputFileName: 'index.js',
+      singleEntry: true,
+    });
+  });
+
+  it('should handle multiple entry point options', () => {
+    expect(
+      normalizeOptions({
+        main: 'apps/myapp/src/index.ts',
+        outputPath: 'dist/apps/myapp',
+        tsConfig: 'apps/myapp/tsconfig.app.json',
+        project: 'apps/myapp/package.json',
+        assets: [],
+        additionalEntryPoints: ['apps/myapp/src/extra-entry.ts'],
+      })
+    ).toEqual({
+      main: 'apps/myapp/src/index.ts',
+      outputPath: 'dist/apps/myapp',
+      tsConfig: 'apps/myapp/tsconfig.app.json',
+      project: 'apps/myapp/package.json',
+      assets: [],
+      additionalEntryPoints: ['apps/myapp/src/extra-entry.ts'],
+      singleEntry: false,
+    });
+  });
+
+  it('should support custom output file name', () => {
+    expect(
+      normalizeOptions({
+        main: 'apps/myapp/src/index.ts',
+        outputPath: 'dist/apps/myapp',
+        tsConfig: 'apps/myapp/tsconfig.app.json',
+        project: 'apps/myapp/package.json',
+        assets: [],
+        outputFileName: 'test.js',
+      })
+    ).toEqual({
+      main: 'apps/myapp/src/index.ts',
+      outputPath: 'dist/apps/myapp',
+      tsConfig: 'apps/myapp/tsconfig.app.json',
+      project: 'apps/myapp/package.json',
+      assets: [],
+      outputFileName: 'test.js',
+      singleEntry: true,
+    });
+  });
+
+  it('should validate against multiple entry points + outputFileName', () => {
+    expect(() =>
+      normalizeOptions({
+        main: 'apps/myapp/src/index.ts',
+        outputPath: 'dist/apps/myapp',
+        tsConfig: 'apps/myapp/tsconfig.app.json',
+        project: 'apps/myapp/package.json',
+        assets: [],
+        additionalEntryPoints: ['apps/myapp/src/extra-entry.ts'],
+        outputFileName: 'test.js',
+      })
+    ).toThrow(/Cannot use/);
+  });
+});

--- a/packages/esbuild/src/executors/esbuild/lib/normalize.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/normalize.ts
@@ -1,9 +1,29 @@
-import { EsBuildExecutorOptions } from '../schema';
+import { parse } from 'path';
+import {
+  EsBuildExecutorOptions,
+  NormalizedEsBuildExecutorOptions,
+} from '../schema';
+
 export function normalizeOptions(
   options: EsBuildExecutorOptions
-): EsBuildExecutorOptions {
-  return {
-    ...options,
-    outputFileName: options.outputFileName ?? 'main.js',
-  };
+): NormalizedEsBuildExecutorOptions {
+  if (options.additionalEntryPoints?.length > 0) {
+    const { outputFileName, ...rest } = options;
+    if (outputFileName) {
+      throw new Error(
+        `Cannot use outputFileName and additionalEntry points together. Please remove outputFileName and try again.`
+      );
+    }
+    return {
+      ...rest,
+      singleEntry: false,
+    };
+  } else {
+    return {
+      ...options,
+      singleEntry: true,
+      outputFileName:
+        options.outputFileName ?? `${parse(options.main).name}.js`,
+    };
+  }
 }

--- a/packages/esbuild/src/executors/esbuild/schema.d.ts
+++ b/packages/esbuild/src/executors/esbuild/schema.d.ts
@@ -24,3 +24,8 @@ export interface EsBuildExecutorOptions {
   updateBuildableProjectDepsInPackageJson?: boolean;
   watch?: boolean;
 }
+
+export interface NormalizedEsBuildExecutorOptions
+  extends EsBuildExecutorOptions {
+  singleEntry: boolean;
+}


### PR DESCRIPTION
This PR fixes and issue where the `main` field in `package.json` may be incorrect unless manually set.