### PR TITLE
docs(core): fix package.json code snippet typo

### DIFF
--- a/docs/shared/core-tutorial/03-share-assets.md
+++ b/docs/shared/core-tutorial/03-share-assets.md
@@ -113,7 +113,7 @@ For the blog project, you'll need to add `ascii` as a `dependency` (or `devDepen
   "name": "blog",
   "description": "eleventy blog",
   "version": "1.0.0",
-  "dependency": {
+  "dependencies": {
     "ascii": "*"
   },
   "scripts": {


### PR DESCRIPTION
\"dependency\" changed to \"dependencies\" to align with package.json requirements

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
There is a typo in one of the `package.json` code snippets (`"dependency"` instead of `"dependencies"`) in the tutorial docs "Core Nx Tutorial - Step 3: Share Assets". Someone following the tutorial may copy the snippet into their local project and wonder why their project isn't working as expected.

## Expected Behavior
An accurate `package.json` code snippet that enables tutorial users to copy the snippet without introducing a sneaky bug

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
