### PR TITLE
fix(graph): filter print-affected results by target

### DIFF
--- a/e2e/nx-run/src/affected-graph.test.ts
+++ b/e2e/nx-run/src/affected-graph.test.ts
@@ -260,7 +260,7 @@ describe('Nx Affected and Graph Tests', () => {
     });
   });
 
-  describe('print-affected', () => {
+  fdescribe('print-affected', () => {
     it('should print information about affected projects', async () => {
       const myapp = uniq('myapp-a');
       const myapp2 = uniq('myapp-b');
@@ -274,18 +274,18 @@ describe('Nx Affected and Graph Tests', () => {
       runCLI(`generate @nrwl/js:lib ${mylib2}`);
       runCLI(`generate @nrwl/js:lib ${mypublishablelib}`);
 
-      const app1ElementSpec = readFile(
-        `apps/${myapp}/src/app/app.element.spec.ts`
-      );
-
-      updateFile(
-        `apps/${myapp}/src/app/app.element.spec.ts`,
-        `
-          import "@${proj}/${mylib}";
-          import "@${proj}/${mypublishablelib}";
-          ${app1ElementSpec}
-          `
-      );
+      // const app1ElementSpec = readFile(
+      //   `apps/${myapp}/src/app/app.element.spec.ts`
+      // );
+      //
+      // updateFile(
+      //   `apps/${myapp}/src/app/app.element.spec.ts`,
+      //   `
+      //     import "@${proj}/${mylib}";
+      //     import "@${proj}/${mypublishablelib}";
+      //     ${app1ElementSpec}
+      //     `
+      // );
 
       const app2ElementSpec = readFile(
         `apps/${myapp2}/src/app/app.element.spec.ts`
@@ -334,6 +334,19 @@ describe('Nx Affected and Graph Tests', () => {
         outputs: [`coverage/apps/${myapp}`],
       });
       compareTwoArrays(resWithTarget.projects, [`${myapp}-e2e`, myapp]);
+
+      const app1ElementSpec = readFile(
+        `apps/${myapp}/src/app/app.element.spec.ts`
+      );
+
+      updateFile(
+        `apps/${myapp}/src/app/app.element.spec.ts`,
+        `
+          import "@${proj}/${mylib}";
+          import "@${proj}/${mypublishablelib}";
+          ${app1ElementSpec}
+          `
+      );
 
       const resWithTargetWithSelect1 = (
         await runCLIAsync(

--- a/packages/nx/src/command-line/affected.ts
+++ b/packages/nx/src/command-line/affected.ts
@@ -97,7 +97,6 @@ export async function affected(
           const projectsWithTarget = allProjectsWithTarget(projects, nxArgs);
           await printAffected(
             projectsWithTarget,
-            projects,
             projectGraph,
             { nxJson },
             nxArgs,
@@ -105,7 +104,6 @@ export async function affected(
           );
         } else {
           await printAffected(
-            [],
             projects,
             projectGraph,
             { nxJson },

--- a/packages/nx/src/command-line/print-affected.ts
+++ b/packages/nx/src/command-line/print-affected.ts
@@ -12,19 +12,17 @@ import { workspaceRoot } from '../utils/workspace-root';
 
 export async function printAffected(
   affectedProjectsWithTargetAndConfig: ProjectGraphProjectNode[],
-  affectedProjects: ProjectGraphProjectNode[],
   projectGraph: ProjectGraph,
   { nxJson }: { nxJson: NxJsonConfiguration },
   nxArgs: NxArgs,
   overrides: yargs.Arguments
 ) {
-  const projectNames = affectedProjects
-    .filter((p) => (nxArgs.type ? p.type === nxArgs.type : true))
-    .map((p) => p.name);
+  const projectsForType = affectedProjectsWithTargetAndConfig.filter((p) =>
+    nxArgs.type ? p.type === nxArgs.type : true
+  );
+  const projectNames = projectsForType.map((p) => p.name);
   const tasksJson = await createTasks(
-    affectedProjectsWithTargetAndConfig.filter((p) =>
-      nxArgs.type ? p.type === nxArgs.type : true
-    ),
+    projectsForType,
     projectGraph,
     nxArgs,
     nxJson,


### PR DESCRIPTION
When invoked with a --target=x argument, print-affected was not filtering the results shown to only projects with that target

ISSUES CLOSED: #11645

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
