### PR TITLE
fix(js): add outfile to swc compiler in non-watch mode

### DIFF
--- a/packages/js/src/utils/swc/compile-swc.ts
+++ b/packages/js/src/utils/swc/compile-swc.ts
@@ -66,7 +66,10 @@ export async function compileSwc(
   }
 
   await postCompilationCallback();
-  return { success: !hasErrors && isCompileSuccess };
+  return {
+    success: !hasErrors && isCompileSuccess,
+    outfile: normalizedOptions.mainOutputPath,
+  };
 }
 
 export async function* compileSwcWatch(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When using the node executor with a buildTarget using `@nrwl/js:swc` and turning off watch mode, the following error is produced: 

```bash
TypeError: The "id" argument must be of type string. Received undefined
    at new NodeError (node:internal/errors:371:5)
    at validateString (node:internal/validators:120:11)
    at Module.require (node:internal/modules/cjs/loader:998:3)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/foo/node_modules/@nrwl/js/src/executors/node/node-with-require-overrides.js:23:1)
    at Module._compile (node:internal/modules/cjs/loader:1103:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1157:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:77:12)
```


## Expected Behavior
The error will not show up

## Related Issue(s)
#12344 

Fixes #12344 
