### PR TITLE
fix(core): fix print-affected not filtering on target

### DIFF
--- a/e2e/nx-run/src/affected-graph.test.ts
+++ b/e2e/nx-run/src/affected-graph.test.ts
@@ -333,7 +333,7 @@ describe('Nx Affected and Graph Tests', () => {
         command: `${runNx} run ${myapp}:test`,
         outputs: [`coverage/apps/${myapp}`],
       });
-      compareTwoArrays(resWithTarget.projects, [`${myapp}-e2e`, myapp]);
+      compareTwoArrays(resWithTarget.projects, [myapp]);
 
       const resWithTargetWithSelect1 = (
         await runCLIAsync(
@@ -341,10 +341,7 @@ describe('Nx Affected and Graph Tests', () => {
           { silent: true }
         )
       ).stdout.trim();
-      compareTwoSerializedArrays(
-        resWithTargetWithSelect1,
-        `${myapp}-e2e, ${myapp}`
-      );
+      compareTwoSerializedArrays(resWithTargetWithSelect1, myapp);
 
       const resWithTargetWithSelect2 = (
         await runCLIAsync(
@@ -352,7 +349,7 @@ describe('Nx Affected and Graph Tests', () => {
           { silent: true }
         )
       ).stdout.trim();
-      compareTwoSerializedArrays(resWithTargetWithSelect2, `${myapp}`);
+      compareTwoSerializedArrays(resWithTargetWithSelect2, myapp);
     }, 120000);
 
     function compareTwoSerializedArrays(a: string, b: string) {

--- a/packages/nx/src/command-line/affected.ts
+++ b/packages/nx/src/command-line/affected.ts
@@ -94,10 +94,8 @@ export async function affected(
 
       case 'print-affected':
         if (nxArgs.target) {
-          const projectsWithTarget = allProjectsWithTarget(projects, nxArgs);
           await printAffected(
-            projectsWithTarget,
-            projects,
+            allProjectsWithTarget(projects, nxArgs),
             projectGraph,
             { nxJson },
             nxArgs,
@@ -105,7 +103,6 @@ export async function affected(
           );
         } else {
           await printAffected(
-            [],
             projects,
             projectGraph,
             { nxJson },

--- a/packages/nx/src/command-line/print-affected.ts
+++ b/packages/nx/src/command-line/print-affected.ts
@@ -21,13 +21,15 @@ export async function printAffected(
     nxArgs.type ? p.type === nxArgs.type : true
   );
   const projectNames = projectsForType.map((p) => p.name);
-  const tasksJson = await createTasks(
-    projectsForType,
-    projectGraph,
-    nxArgs,
-    nxJson,
-    overrides
-  );
+  const tasksJson = nxArgs.target
+    ? await createTasks(
+        projectsForType,
+        projectGraph,
+        nxArgs,
+        nxJson,
+        overrides
+      )
+    : [];
   const result = {
     tasks: tasksJson,
     projects: projectNames,

--- a/packages/nx/src/command-line/print-affected.ts
+++ b/packages/nx/src/command-line/print-affected.ts
@@ -10,22 +10,17 @@ import { Hasher } from '../hasher/hasher';
 import { hashTask } from '../hasher/hash-task';
 import { workspaceRoot } from '../utils/workspace-root';
 
-// dont need both collections
 export async function printAffected(
-  affectedProjectsWithTargetAndConfig: ProjectGraphProjectNode[],
   affectedProjects: ProjectGraphProjectNode[],
   projectGraph: ProjectGraph,
   { nxJson }: { nxJson: NxJsonConfiguration },
   nxArgs: NxArgs,
   overrides: yargs.Arguments
 ) {
-  const projectNames = affectedProjects
-    .filter((p) => (nxArgs.type ? p.type === nxArgs.type : true))
-    .map((p) => p.name);
+  const projectsForType = affectedProjects.filter((p) => (nxArgs.type ? p.type === nxArgs.type : true));
+  const projectNames = projectsForType.map((p) => p.name);
   const tasksJson = await createTasks(
-    affectedProjectsWithTargetAndConfig.filter((p) =>
-      nxArgs.type ? p.type === nxArgs.type : true
-    ),
+    projectsForType,
     projectGraph,
     nxArgs,
     nxJson,

--- a/packages/nx/src/command-line/print-affected.ts
+++ b/packages/nx/src/command-line/print-affected.ts
@@ -10,6 +10,7 @@ import { Hasher } from '../hasher/hasher';
 import { hashTask } from '../hasher/hash-task';
 import { workspaceRoot } from '../utils/workspace-root';
 
+// dont need both collections
 export async function printAffected(
   affectedProjectsWithTargetAndConfig: ProjectGraphProjectNode[],
   affectedProjects: ProjectGraphProjectNode[],

--- a/packages/nx/src/command-line/print-affected.ts
+++ b/packages/nx/src/command-line/print-affected.ts
@@ -17,7 +17,9 @@ export async function printAffected(
   nxArgs: NxArgs,
   overrides: yargs.Arguments
 ) {
-  const projectsForType = affectedProjects.filter((p) => (nxArgs.type ? p.type === nxArgs.type : true));
+  const projectsForType = affectedProjects.filter((p) =>
+    nxArgs.type ? p.type === nxArgs.type : true
+  );
   const projectNames = projectsForType.map((p) => p.name);
   const tasksJson = await createTasks(
     projectsForType,


### PR DESCRIPTION
When invoked with a --target=x argument, print-affected was not filtering the results shown to only
projects with that target
ISSUES CLOSED: #11645

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
