### PR TITLE
docs(nxdev): add /docs redirect rule

### DIFF
--- a/nx-dev/nx-dev/next.config.js
+++ b/nx-dev/nx-dev/next.config.js
@@ -178,6 +178,13 @@ module.exports = withNx({
       destination: '/',
       permanent: true,
     });
+
+    // Docs
+    rules.push({
+      source: '/docs',
+      destination: '/getting-started/intro',
+      permanent: true,
+    });
     return rules;
   },
 });


### PR DESCRIPTION
It adds a redirect rule for `/docs` to `/getting-started/intro` on nx.dev.