### PR TITLE
docs(nxdev): add missing link in nxconsole section

### DIFF
--- a/nx-dev/ui-home/src/lib/extensible-and-integrated/vscode-integration-tab.tsx
+++ b/nx-dev/ui-home/src/lib/extensible-and-integrated/vscode-integration-tab.tsx
@@ -33,7 +33,7 @@ export function VscodeIntegrationTab(): JSX.Element {
       icon: <SparklesIcon className="h-5 w-5" />,
       description:
         'The Nx team is obsessed with providing the best possible DX. Nx Console is the culmination of that. Carefully crafted, in constant evolution, always in search of making the life of developers easier.',
-      link: '#',
+      link: '/core-features/integrate-with-editors',
     },
   ];
   return (


### PR DESCRIPTION
third nx console hightlight currently leads to `#`
