### PR TITLE
fix(angular): fix import breaking jasmine-marbles migration

### DIFF
--- a/packages/angular/src/migrations/update-15-0-0/switch-to-jasmine-marbles.ts
+++ b/packages/angular/src/migrations/update-15-0-0/switch-to-jasmine-marbles.ts
@@ -9,7 +9,7 @@ import {
 } from '@nrwl/devkit';
 import { extname } from 'path';
 import { tsquery } from '@phenomnomnominal/tsquery';
-import { jasmineMarblesVersion } from '@nrwl/angular/src/utils/versions';
+import { jasmineMarblesVersion } from '../../utils/versions';
 
 export default async function switchToJasmineMarbles(tree: Tree) {
   const usesJasmineMarbles = await replaceJasmineMarbleUsagesInFiles(tree);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The switch-to-jasmine-marbles migration breaks on because it can't import @nrwl/angular/src/utils/versions 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The switch-to-jasmine-marbles migration works because the import is from ../../utils/versions

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
