### PR TITLE
feat(bundling): remove deprecated UMD format support for rollup

### DIFF
--- a/docs/generated/packages/rollup.json
+++ b/docs/generated/packages/rollup.json
@@ -117,7 +117,7 @@
       "implementation": "/packages/rollup/src/executors/rollup/rollup.impl.ts",
       "schema": {
         "title": "Web Library Rollup Target (Experimental)",
-        "description": "Packages a library for different web usages (`UMD`, `ESM`, `CJS`).",
+        "description": "Packages a library for different web usages (ESM, CommonJS).",
         "cli": "nx",
         "type": "object",
         "properties": {
@@ -156,7 +156,7 @@
             "type": "array",
             "description": "List of module formats to output. Defaults to matching format from tsconfig (e.g. CJS for CommonJS, and ESM otherwise).",
             "alias": "f",
-            "items": { "type": "string", "enum": ["esm", "umd", "cjs"] }
+            "items": { "type": "string", "enum": ["esm", "cjs"] }
           },
           "external": {
             "type": "array",
@@ -196,30 +196,6 @@
               }
             ],
             "description": "Path to a function which takes a rollup config and returns an updated rollup config."
-          },
-          "umdName": {
-            "type": "string",
-            "description": "The name of your module in `UMD` format. Defaulted to your project name."
-          },
-          "globals": {
-            "description": "A mapping of node modules to their `UMD` global names. Used by the `UMD` bundle.",
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "moduleId": {
-                  "type": "string",
-                  "description": "The node module to map from (e.g. `react-dom`)."
-                },
-                "global": {
-                  "type": "string",
-                  "description": "The global name to map to (e.g. `ReactDOM`)."
-                }
-              },
-              "additionalProperties": false,
-              "required": ["moduleId", "global"]
-            },
-            "default": []
           },
           "extractCss": {
             "type": ["boolean", "string"],

--- a/docs/generated/packages/web.json
+++ b/docs/generated/packages/web.json
@@ -752,30 +752,6 @@
             ],
             "description": "Path to a function which takes a rollup config and returns an updated rollup config."
           },
-          "umdName": {
-            "type": "string",
-            "description": "The name of your module in `UMD` format. Defaulted to your project name."
-          },
-          "globals": {
-            "description": "A mapping of node modules to their `UMD` global names. Used by the `UMD` bundle.",
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "moduleId": {
-                  "type": "string",
-                  "description": "The node module to map from (e.g. `react-dom`)."
-                },
-                "global": {
-                  "type": "string",
-                  "description": "The global name to map to (e.g. `ReactDOM`)."
-                }
-              },
-              "additionalProperties": false,
-              "required": ["moduleId", "global"]
-            },
-            "default": []
-          },
           "extractCss": {
             "type": ["boolean", "string"],
             "description": "CSS files will be extracted to the output folder. Alternatively custom filename can be provided (e.g. styles.css)",

--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -192,9 +192,6 @@ async function* startBuild(
 ) {
   const buildTarget = parseTargetString(options.buildTarget);
 
-  // TODO(jack): [Nx 14] Remove this line once we generate `development` configuration by default + add migration for it if missing
-  buildTarget.configuration ??= '';
-
   yield* await runExecutor<ExecutorEvent>(
     buildTarget,
     {

--- a/packages/rollup/src/executors/rollup/lib/update-package-json.ts
+++ b/packages/rollup/src/executors/rollup/lib/update-package-json.ts
@@ -17,8 +17,7 @@ export function updatePackageJson(
   packageJson: PackageJson
 ) {
   const hasEsmFormat = options.format.includes('esm');
-  const hasCjsFormat =
-    options.format.includes('umd') || options.format.includes('cjs');
+  const hasCjsFormat = options.format.includes('cjs');
 
   const types = `./${relative(options.entryRoot, options.main).replace(
     /\.[jt]sx?$/,
@@ -54,7 +53,7 @@ export function updatePackageJson(
   // Support for older TS versions < 4.5
   packageJson.types = types;
 
-  // TODO(jack): remove this for Nx 15
+  // TODO(jack): remove this for Nx 16
   if (options.generateExportsField) {
     packageJson.exports = {
       ...packageJson.exports,

--- a/packages/rollup/src/executors/rollup/rollup.impl.spec.ts
+++ b/packages/rollup/src/executors/rollup/rollup.impl.spec.ts
@@ -49,18 +49,14 @@ describe('rollupExecutor', () => {
         {
           dir: '/root/dist/ui',
           format: 'esm',
-          globals: { 'react/jsx-runtime': 'jsxRuntime' },
           name: 'Example',
-          inlineDynamicImports: false,
           chunkFileNames: '[name].js',
           entryFileNames: '[name].js',
         },
         {
           dir: '/root/dist/ui',
           format: 'cjs',
-          globals: { 'react/jsx-runtime': 'jsxRuntime' },
           name: 'Example',
-          inlineDynamicImports: false,
           chunkFileNames: '[name].cjs',
           entryFileNames: '[name].cjs',
         },

--- a/packages/rollup/src/executors/rollup/schema.d.ts
+++ b/packages/rollup/src/executors/rollup/schema.d.ts
@@ -19,19 +19,17 @@ export interface RollupExecutorOptions {
   main: string;
   outputFileName?: string;
   extractCss?: boolean | string;
-  globals?: Globals[];
   external?: string[];
   rollupConfig?: string | string[];
   watch?: boolean;
   assets?: any[];
   updateBuildableProjectDepsInPackageJson?: boolean;
   buildableProjectDepsInPackageJsonType?: 'dependencies' | 'peerDependencies';
-  umdName?: string;
   deleteOutputPath?: boolean;
   format?: string[];
   compiler?: 'babel' | 'tsc' | 'swc';
   javascriptEnabled?: boolean;
-  // TODO(jack): remove this for Nx 15
+  // TODO(jack): remove this for Nx 16
   skipTypeField?: boolean;
   generateExportsField?: boolean;
 }

--- a/packages/rollup/src/executors/rollup/schema.json
+++ b/packages/rollup/src/executors/rollup/schema.json
@@ -1,6 +1,6 @@
 {
   "title": "Web Library Rollup Target (Experimental)",
-  "description": "Packages a library for different web usages (`UMD`, `ESM`, `CJS`).",
+  "description": "Packages a library for different web usages (ESM, CommonJS).",
   "cli": "nx",
   "type": "object",
   "properties": {
@@ -41,7 +41,7 @@
       "alias": "f",
       "items": {
         "type": "string",
-        "enum": ["esm", "umd", "cjs"]
+        "enum": ["esm", "cjs"]
       }
     },
     "external": {
@@ -84,30 +84,6 @@
         }
       ],
       "description": "Path to a function which takes a rollup config and returns an updated rollup config."
-    },
-    "umdName": {
-      "type": "string",
-      "description": "The name of your module in `UMD` format. Defaulted to your project name."
-    },
-    "globals": {
-      "description": "A mapping of node modules to their `UMD` global names. Used by the `UMD` bundle.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "moduleId": {
-            "type": "string",
-            "description": "The node module to map from (e.g. `react-dom`)."
-          },
-          "global": {
-            "type": "string",
-            "description": "The global name to map to (e.g. `ReactDOM`)."
-          }
-        },
-        "additionalProperties": false,
-        "required": ["moduleId", "global"]
-      },
-      "default": []
     },
     "extractCss": {
       "type": ["boolean", "string"],

--- a/packages/web/migrations.json
+++ b/packages/web/migrations.json
@@ -74,6 +74,12 @@
       "version": "15.0.0-beta.0",
       "description": "Adds babel.config.json to the hash of all tasks",
       "factory": "./src/migrations/update-15-0-0/add-babel-inputs"
+    },
+    "update-rollup-executor": {
+      "cli": "nx",
+      "version": "15.0.0-beta.1",
+      "description": "Update usages of rollup executors to @nrwl/rollup",
+      "factory": "./src/migrations/update-15-0-0/update-rollup-executor"
     }
   },
   "packageJsonUpdates": {

--- a/packages/web/src/executors/rollup/schema.d.ts
+++ b/packages/web/src/executors/rollup/schema.d.ts
@@ -23,7 +23,7 @@ export interface WebRollupOptions {
   format: string[];
   compiler?: Compiler;
   javascriptEnabled?: boolean;
-  // TODO(jack): remove this for Nx 15
+  // TODO(jack): remove this for Nx 16
   skipTypeField?: boolean;
   generateExportsField?: boolean;
 }

--- a/packages/web/src/executors/rollup/schema.json
+++ b/packages/web/src/executors/rollup/schema.json
@@ -81,30 +81,6 @@
       ],
       "description": "Path to a function which takes a rollup config and returns an updated rollup config."
     },
-    "umdName": {
-      "type": "string",
-      "description": "The name of your module in `UMD` format. Defaulted to your project name."
-    },
-    "globals": {
-      "description": "A mapping of node modules to their `UMD` global names. Used by the `UMD` bundle.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "moduleId": {
-            "type": "string",
-            "description": "The node module to map from (e.g. `react-dom`)."
-          },
-          "global": {
-            "type": "string",
-            "description": "The global name to map to (e.g. `ReactDOM`)."
-          }
-        },
-        "additionalProperties": false,
-        "required": ["moduleId", "global"]
-      },
-      "default": []
-    },
     "extractCss": {
       "type": ["boolean", "string"],
       "description": "CSS files will be extracted to the output folder. Alternatively custom filename can be provided (e.g. styles.css)",

--- a/packages/web/src/migrations/update-15-0-0/update-rollup-executor.spec.ts
+++ b/packages/web/src/migrations/update-15-0-0/update-rollup-executor.spec.ts
@@ -1,0 +1,104 @@
+import {
+  addProjectConfiguration,
+  readProjectConfiguration,
+} from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+
+import update from './update-rollup-executor';
+
+describe('Migration: @nrwl/rollup', () => {
+  it(`should update usage of rollup executor`, async () => {
+    let tree = createTreeWithEmptyWorkspace();
+
+    addProjectConfiguration(tree, 'mylib', {
+      root: 'libs/mylib',
+      sourceRoot: 'libs/mylib/src',
+      projectType: 'library',
+      targets: {
+        build: {
+          executor: '@nrwl/web:rollup',
+          options: {},
+        },
+      },
+    });
+    await update(tree);
+
+    expect(readProjectConfiguration(tree, 'mylib')).toEqual({
+      $schema: '../../node_modules/nx/schemas/project-schema.json',
+      name: 'mylib',
+      root: 'libs/mylib',
+      sourceRoot: 'libs/mylib/src',
+      projectType: 'library',
+      targets: {
+        build: {
+          executor: '@nrwl/rollup:rollup',
+          options: {},
+        },
+      },
+    });
+  });
+
+  it(`should replace umd with cjs`, async () => {
+    let tree = createTreeWithEmptyWorkspace();
+
+    addProjectConfiguration(tree, 'lib1', {
+      root: 'libs/lib1',
+      sourceRoot: 'libs/lib1/src',
+      projectType: 'library',
+      targets: {
+        build: {
+          executor: '@nrwl/web:rollup',
+          options: {
+            formats: ['umd'],
+          },
+        },
+      },
+    });
+    addProjectConfiguration(tree, 'lib2', {
+      root: 'libs/lib2',
+      sourceRoot: 'libs/lib2/src',
+      projectType: 'library',
+      targets: {
+        build: {
+          executor: '@nrwl/rollup:rollup',
+          options: {
+            formats: ['esm', 'cjs', 'umd'],
+          },
+        },
+      },
+    });
+
+    await update(tree);
+
+    expect(readProjectConfiguration(tree, 'lib1')).toEqual({
+      $schema: '../../node_modules/nx/schemas/project-schema.json',
+      name: 'lib1',
+      root: 'libs/lib1',
+      sourceRoot: 'libs/lib1/src',
+      projectType: 'library',
+      targets: {
+        build: {
+          executor: '@nrwl/rollup:rollup',
+          options: {
+            formats: ['cjs'],
+          },
+        },
+      },
+    });
+    expect(readProjectConfiguration(tree, 'lib2')).toEqual({
+      $schema: '../../node_modules/nx/schemas/project-schema.json',
+      name: 'lib2',
+      root: 'libs/lib2',
+      sourceRoot: 'libs/lib2/src',
+      projectType: 'library',
+      targets: {
+        build: {
+          executor: '@nrwl/rollup:rollup',
+          options: {
+            formats: ['esm', 'cjs'],
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/web/src/migrations/update-15-0-0/update-rollup-executor.ts
+++ b/packages/web/src/migrations/update-15-0-0/update-rollup-executor.ts
@@ -1,0 +1,42 @@
+import {
+  formatFiles,
+  getProjects,
+  Tree,
+  updateProjectConfiguration,
+} from '@nrwl/devkit';
+
+export default async function update(host: Tree) {
+  const projects = getProjects(host);
+
+  for (const [name, config] of projects.entries()) {
+    let updated = false;
+
+    if (config?.targets?.build?.executor === '@nrwl/web:rollup') {
+      config.targets.build.executor = '@nrwl/rollup:rollup';
+      updated = true;
+    }
+
+    if (config?.targets?.build?.options?.formats?.includes('umd')) {
+      config.targets.build.options.formats =
+        config.targets.build.options.formats.reduce((acc, x) => {
+          const format = x === 'umd' ? 'cjs' : x;
+
+          if (format === 'cjs') {
+            if (!acc.includes('cjs')) acc.push(format);
+          } else {
+            acc.push(format);
+          }
+
+          return acc;
+        }, []);
+
+      updated = true;
+    }
+
+    if (updated) {
+      updateProjectConfiguration(host, name, config);
+    }
+  }
+
+  await formatFiles(host);
+}


### PR DESCRIPTION
This PR removes the UMD format from `@nrwl/rollup:rollup`, which has been deprecated with a warning since Nx 13.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
