### PR TITLE
chore(graph): enable dark mode for scrollbars

### DIFF
--- a/graph/client/src/styles.scss
+++ b/graph/client/src/styles.scss
@@ -4,6 +4,11 @@
 @tailwind base;
 @tailwind utilities;
 
+/** Scrollbars **/
+.dark {
+  color-scheme: dark;
+}
+
 $gray: rgb(100, 116, 139, 1);
 
 #app,


### PR DESCRIPTION
It enables dark mode for scrollbars especially on windows, preventing light backgrounds to show up.