### PR TITLE
feat(core): merge more target options from targetDefaults

### DIFF
--- a/docs/shared/reference/nx-json.md
+++ b/docs/shared/reference/nx-json.md
@@ -115,7 +115,6 @@ In this case Nx will use the right `production` input for each project.
 
 Target defaults provide ways to set common options for a particular target in your workspace. When building your project's configuration, we merge it with up to 1 default from this map. For a given target, we look at its name and its executor. We then check target defaults for any of the following combinations:
 
-- `` `${targetName}#${executor}` ``
 - `` `${executor}` ``
 - `` `${targetName}` ``
 
@@ -156,6 +155,35 @@ Another target default you can configure is `outputs`:
   }
 }
 ```
+
+When defining any options or configurations inside of a target default, you may use the `{workspaceRoot}` and `{projectRoot}` tokens. This is useful for defining things like the outputPath or tsconfig for many build targets.
+
+```json {% fileName="nx.json" %}
+{
+  "targetDefaults": {
+    "@nrwl/js:tsc": {
+      "options": {
+        "main": "{projectRoot}/src/index.ts"
+      },
+      "configurations": {
+        "prod": {
+          "tsconfig": "{projectRoot}/tsconfig.prod.json"
+        }
+      },
+      "inputs": ["prod"],
+      "outputs": ["{workspaceRoot}/{projectRoot}"]
+    },
+    "build": {
+      "inputs": ["prod"],
+      "outputs": ["{workspaceRoot}/{projectRoot}"]
+    }
+  }
+}
+```
+
+{% callout type="note" title="Target Default Priority" %}
+Note that the inputs and outputs are respecified on the @nrwl/js:tsc default configuration. This is **required**, as when reading target defaults Nx will only ever look at one key. If there is a default configuration based on the executor used, it will be read first. If not, Nx will fall back to looking at the configuration based on target name. For instance, running `nx build project` will read the options from `targetDefaults[@nrwl/js:tsc]` if the target configuration for build uses the @nrwl/js:tsc executor. It **would not** read any of the configuration from the `build` target default configuration unless the executor does not match.
+{% /callout %}
 
 ### Generators
 

--- a/docs/shared/reference/nx-json.md
+++ b/docs/shared/reference/nx-json.md
@@ -113,6 +113,14 @@ In this case Nx will use the right `production` input for each project.
 
 ### Target Defaults
 
+Target defaults provide ways to set common options for a particular target in your workspace. When building your project's configuration, we merge it with up to 1 default from this map. For a given target, we look at its name and its executor. We then check target defaults for any of the following combinations:
+
+- `` `${targetName}|${executor}` ``
+- `` `*|${executor}` ``
+- `` `${targetName}` ``
+
+Whichever of these we find first, we use as the base for that target's configuration. Some common scenarios for this follow.
+
 Targets can depend on other targets. A common scenario is having to build dependencies of a project first before
 building the project. The `dependsOn` property in `project.json` can be used to define the list of dependencies of an
 individual target.
@@ -174,7 +182,7 @@ named "default" is used by default. Specify a different one like this `nx run-ma
 Tasks runners can accept different options. The following are the options supported
 by `"nx/tasks-runners/default"` and `"@nrwl/nx-cloud"`.
 
-| Property                | Descrtipion                                                                                                                                                                                                                                                                                                                                   |
+| Property                | Description                                                                                                                                                                                                                                                                                                                                   |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | cacheableOperations     | defines the list of targets/operations that are cached by Nx                                                                                                                                                                                                                                                                                  |
 | parallel                | defines the max number of targets ran in parallel (in older versions of Nx you had to pass `--parallel --maxParallel=3` instead of `--parallel=3`)                                                                                                                                                                                            |

--- a/docs/shared/reference/nx-json.md
+++ b/docs/shared/reference/nx-json.md
@@ -115,8 +115,8 @@ In this case Nx will use the right `production` input for each project.
 
 Target defaults provide ways to set common options for a particular target in your workspace. When building your project's configuration, we merge it with up to 1 default from this map. For a given target, we look at its name and its executor. We then check target defaults for any of the following combinations:
 
-- `` `${targetName}|${executor}` ``
-- `` `*|${executor}` ``
+- `` `${targetName}#${executor}` ``
+- `` `${executor}` ``
 - `` `${targetName}` ``
 
 Whichever of these we find first, we use as the base for that target's configuration. Some common scenarios for this follow.

--- a/e2e/nx-run/src/run.test.ts
+++ b/e2e/nx-run/src/run.test.ts
@@ -275,12 +275,14 @@ describe('Nx Running Tests', () => {
           JSON.stringify({
             name: lib,
             targets: {
-              target: {},
+              [target]: {},
             },
           })
         );
 
-        expect(runCLI(`${target} ${lib}`)).toContain(`Hello from ${target}`);
+        expect(runCLI(`${target} ${lib} --verbose`)).toContain(
+          `Hello from ${target}`
+        );
       });
 
       it('should be able to pull options from targetDefaults based on executor', () => {
@@ -289,7 +291,7 @@ describe('Nx Running Tests', () => {
 
         updateJson('nx.json', (nxJson) => {
           nxJson.targetDefaults ??= {};
-          nxJson.targetDefaults[`*|nx:run-commands}`] = {
+          nxJson.targetDefaults[`nx:run-commands`] = {
             options: {
               command: `echo Hello from ${target}`,
             },
@@ -302,14 +304,16 @@ describe('Nx Running Tests', () => {
           JSON.stringify({
             name: lib,
             targets: {
-              target: {
+              [target]: {
                 executor: 'nx:run-commands',
               },
             },
           })
         );
 
-        expect(runCLI(`${target} ${lib}`)).toContain(`Hello from ${target}`);
+        expect(runCLI(`${target} ${lib} --verbose`)).toContain(
+          `Hello from ${target}`
+        );
       });
     });
 

--- a/e2e/nx-run/src/run.test.ts
+++ b/e2e/nx-run/src/run.test.ts
@@ -254,6 +254,65 @@ describe('Nx Running Tests', () => {
       );
     }, 10000);
 
+    describe('target defaults + executor specifications', () => {
+      it('should be able to run targets with unspecified executor given an appropriate targetDefaults entry', () => {
+        const target = uniq('target');
+        const lib = uniq('lib');
+
+        updateJson('nx.json', (nxJson) => {
+          nxJson.targetDefaults ??= {};
+          nxJson.targetDefaults[target] = {
+            executor: 'nx:run-commands',
+            options: {
+              command: `echo Hello from ${target}`,
+            },
+          };
+          return nxJson;
+        });
+
+        updateFile(
+          `libs/${lib}/project.json`,
+          JSON.stringify({
+            name: lib,
+            targets: {
+              target: {},
+            },
+          })
+        );
+
+        expect(runCLI(`${target} ${lib}`)).toContain(`Hello from ${target}`);
+      });
+
+      it('should be able to pull options from targetDefaults based on executor', () => {
+        const target = uniq('target');
+        const lib = uniq('lib');
+
+        updateJson('nx.json', (nxJson) => {
+          nxJson.targetDefaults ??= {};
+          nxJson.targetDefaults[`*|nx:run-commands}`] = {
+            options: {
+              command: `echo Hello from ${target}`,
+            },
+          };
+          return nxJson;
+        });
+
+        updateFile(
+          `libs/${lib}/project.json`,
+          JSON.stringify({
+            name: lib,
+            targets: {
+              target: {
+                executor: 'nx:run-commands',
+              },
+            },
+          })
+        );
+
+        expect(runCLI(`${target} ${lib}`)).toContain(`Hello from ${target}`);
+      });
+    });
+
     describe('target dependencies', () => {
       let myapp;
       let mylib1;

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -249,7 +249,25 @@
           "items": {
             "type": "string"
           }
+        },
+        "executor": {
+          "description": "The function that Nx will invoke when you run this target",
+          "type": "string"
+        },
+        "options": {
+          "type": "object"
+        },
+        "configurations": {
+          "type": "object",
+          "description": "provides extra sets of values that will be merged into the options map",
+          "additionalProperties": {
+            "type": "object"
+          }
         }
+      },
+      "dependentRequired": {
+        "configurations": ["executor"],
+        "options": ["executor"]
       },
       "additionalProperties": false
     }

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -209,6 +209,26 @@
       "type": "object",
       "description": "Target defaults",
       "properties": {
+        "executor": {
+          "description": "The function that Nx will invoke when you run this target",
+          "type": "string"
+        },
+        "options": {
+          "type": "object"
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "configurations": {
+          "type": "object",
+          "description": "provides extra sets of values that will be merged into the options map",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
         "inputs": {
           "$ref": "#/definitions/inputs"
         },
@@ -243,31 +263,7 @@
               }
             ]
           }
-        },
-        "outputs": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "executor": {
-          "description": "The function that Nx will invoke when you run this target",
-          "type": "string"
-        },
-        "options": {
-          "type": "object"
-        },
-        "configurations": {
-          "type": "object",
-          "description": "provides extra sets of values that will be merged into the options map",
-          "additionalProperties": {
-            "type": "object"
-          }
         }
-      },
-      "dependentRequired": {
-        "configurations": ["executor"],
-        "options": ["executor"]
       },
       "additionalProperties": false
     }

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -1,6 +1,7 @@
 import { PackageManager } from '../utils/package-manager';
 import {
   InputDefinition,
+  TargetConfiguration,
   TargetDependencyConfig,
 } from './workspace-json-project-json';
 
@@ -19,14 +20,7 @@ export interface NxAffectedConfig {
   defaultBase?: string;
 }
 
-export type TargetDefaults = Record<
-  string,
-  {
-    outputs?: string[];
-    dependsOn?: (TargetDependencyConfig | string)[];
-    inputs?: (InputDefinition | string)[];
-  }
->;
+export type TargetDefaults = Record<string, Partial<TargetConfiguration>>;
 
 export type TargetDependencies = Record<
   string,

--- a/packages/nx/src/config/workspaces.spec.ts
+++ b/packages/nx/src/config/workspaces.spec.ts
@@ -145,52 +145,55 @@ describe('Workspaces', () => {
   });
 
   describe('target defaults', () => {
-    const nxJson = {
-      targetDefaults: {
-        'build|nx:run-commands': {
-          options: {
-            key: 't:e',
-          },
+    const targetDefaults = {
+      'build#nx:run-commands': {
+        options: {
+          key: 't:e',
         },
-        '*|nx:run-commands': {
-          options: {
-            key: '*:e',
-          },
+      },
+      'nx:run-commands': {
+        options: {
+          key: '*:e',
         },
-        build: {
-          options: {
-            key: 't',
-          },
+      },
+      build: {
+        options: {
+          key: 't',
         },
       },
     };
 
-    it('should prefer target|executor key', () => {
+    it('should prefer target#executor key', () => {
       expect(
-        readTargetDefaultsForTarget('build', nxJson, 'run-commands').options[
-          'key'
-        ]
+        readTargetDefaultsForTarget('build', targetDefaults, 'nx:run-commands')
+          .options['key']
       ).toEqual('t:e');
     });
 
-    it('should prefer *|executor key', () => {
+    it('should prefer executor key', () => {
       expect(
-        readTargetDefaultsForTarget('other-target', nxJson, 'run-commands')
-          .options['key']
+        readTargetDefaultsForTarget(
+          'other-target',
+          targetDefaults,
+          'nx:run-commands'
+        ).options['key']
       ).toEqual('*:e');
     });
 
     it('should fallback to target key', () => {
       expect(
-        readTargetDefaultsForTarget('build', nxJson, 'other-executor').options[
-          'key'
-        ]
+        readTargetDefaultsForTarget('build', targetDefaults, 'other-executor')
+          .options['key']
       ).toEqual('t');
     });
 
     it('should return undefined if not found', () => {
       expect(
-        readTargetDefaultsForTarget('other-target', nxJson, 'other-executor')
+        readTargetDefaultsForTarget(
+          'other-target',
+          targetDefaults,
+          'other-executor'
+        )
       ).toBeNull();
     });
 
@@ -200,11 +203,17 @@ describe('Workspaces', () => {
         expect(
           mergeTargetConfigurations(
             {
-              executor: 'target',
-              [property]: {
-                a: {},
+              root: '.',
+              targets: {
+                build: {
+                  executor: 'target',
+                  [property]: {
+                    a: {},
+                  },
+                },
               },
             },
+            'build',
             {
               executor: 'target',
               [property]: {
@@ -223,11 +232,17 @@ describe('Workspaces', () => {
         expect(
           mergeTargetConfigurations(
             {
-              executor: 'target',
-              [property]: {
-                a: {},
+              root: '',
+              targets: {
+                build: {
+                  executor: 'target',
+                  [property]: {
+                    a: {},
+                  },
+                },
               },
             },
+            'build',
             {
               [property]: {
                 b: {},
@@ -244,10 +259,16 @@ describe('Workspaces', () => {
         expect(
           mergeTargetConfigurations(
             {
-              [property]: {
-                a: {},
+              root: '',
+              targets: {
+                build: {
+                  [property]: {
+                    a: {},
+                  },
+                },
               },
             },
+            'build',
             {
               executor: 'target',
               [property]: {
@@ -265,10 +286,16 @@ describe('Workspaces', () => {
         expect(
           mergeTargetConfigurations(
             {
-              [property]: {
-                a: {},
+              root: '',
+              targets: {
+                build: {
+                  [property]: {
+                    a: {},
+                  },
+                },
               },
             },
+            'build',
             {
               executor: 'target',
               [property]: {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Target defaults may only contain dependsOn, inputs, outputs etc and can only be applied based on the name of the target.

## New Behavior
Target defaults may contain **_any_** property inside `TargetConfiguration`, and can be applied based on targetName, executorName, or both.

Keys in the mapping can be any of the following:
- `` `${executor}` ``
- `` `${targetName}` ``

A `#` symbol is used as a separator between `targetName` and `executorName`. This is analogous to how we can specify an export in a module when writing a generator's implementation path. `build#nx:run-commands` would indicate any target named build that uses `nx:run-commands` as the executor.

When merging defaults, options are merged 1 layer deep. Additionally, `{projectRoot}` and `{workspaceRoot}` are valid within `targetDefaults`. As an example, merging the defaults
```
{
  path: "{workspaceRoot}/{projectRoot}
  other: "hello"
  optimization: {
    "a": true
  }
}
```
with the provided options:
```
{
  optimization: {
    "b": true
  }
}
```
would result in:
```
{
  path: "libs/my-lib"
  other: "hello"
  optimization: {
    "b": true
  }
}
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #12433
