### PR TITLE
fix(core): fix slashes in inputs migrations

### DIFF
--- a/packages/linter/src/migrations/update-15-0-0/add-eslint-inputs.ts
+++ b/packages/linter/src/migrations/update-15-0-0/add-eslint-inputs.ts
@@ -1,11 +1,11 @@
 import {
   formatFiles,
+  joinPathFragments,
   readWorkspaceConfiguration,
   Tree,
   updateWorkspaceConfiguration,
 } from '@nrwl/devkit';
 import { forEachExecutorOptions } from '@nrwl/workspace/src/utilities/executor-options-utils';
-import { join } from 'path';
 
 export default async function (tree: Tree) {
   const workspaceConfiguration = readWorkspaceConfiguration(tree);
@@ -31,7 +31,9 @@ export default async function (tree: Tree) {
 
     lintTargetDefaults.inputs ??= [
       'default',
-      ...(globalEslintFile ? [join('{workspaceRoot}', globalEslintFile)] : []),
+      ...(globalEslintFile
+        ? [joinPathFragments('{workspaceRoot}', globalEslintFile)]
+        : []),
     ];
   }
 

--- a/packages/nx/src/migrations/update-15-0-0/migrate-to-inputs.ts
+++ b/packages/nx/src/migrations/update-15-0-0/migrate-to-inputs.ts
@@ -6,7 +6,7 @@ import {
   updateProjectConfiguration,
   updateWorkspaceConfiguration,
 } from '../../generators/utils/project-configuration';
-import { join } from 'path';
+import { joinPathFragments } from '../../utils/path';
 
 const skippedFiles = [
   'package.json', // Not to be added to filesets
@@ -73,7 +73,9 @@ export default async function (tree: Tree) {
           const projectSpecificFileset = new Set(
             project.namedInputs.projectSpecificFiles ?? []
           );
-          projectSpecificFileset.add(join('{workspaceRoot}', files));
+          projectSpecificFileset.add(
+            joinPathFragments('{workspaceRoot}', files)
+          );
           project.namedInputs.projectSpecificFiles = Array.from(
             projectSpecificFileset
           );
@@ -81,7 +83,7 @@ export default async function (tree: Tree) {
         }
       } else {
         workspaceConfiguration.namedInputs.sharedGlobals.push(
-          join('{workspaceRoot}', files)
+          joinPathFragments('{workspaceRoot}', files)
         );
       }
     }

--- a/packages/react-native/src/migrations/update-15-0-0/add-babel-inputs.ts
+++ b/packages/react-native/src/migrations/update-15-0-0/add-babel-inputs.ts
@@ -1,10 +1,10 @@
 import {
   formatFiles,
+  joinPathFragments,
   readWorkspaceConfiguration,
   Tree,
   updateWorkspaceConfiguration,
 } from '@nrwl/devkit';
-import { join } from 'path';
 
 export default async function (tree: Tree) {
   const workspaceConfiguration = readWorkspaceConfiguration(tree);
@@ -17,7 +17,9 @@ export default async function (tree: Tree) {
     const sharedGlobalFileset = new Set(
       workspaceConfiguration.namedInputs.sharedGlobals
     );
-    sharedGlobalFileset.add(join('{workspaceRoot}', globalBabelFile));
+    sharedGlobalFileset.add(
+      joinPathFragments('{workspaceRoot}', globalBabelFile)
+    );
     workspaceConfiguration.namedInputs.sharedGlobals =
       Array.from(sharedGlobalFileset);
   }

--- a/packages/rollup/src/migrations/update-15-0-0/add-babel-inputs.ts
+++ b/packages/rollup/src/migrations/update-15-0-0/add-babel-inputs.ts
@@ -1,10 +1,10 @@
 import {
   formatFiles,
+  joinPathFragments,
   readWorkspaceConfiguration,
   Tree,
   updateWorkspaceConfiguration,
 } from '@nrwl/devkit';
-import { join } from 'path';
 
 export default async function (tree: Tree) {
   const workspaceConfiguration = readWorkspaceConfiguration(tree);
@@ -17,7 +17,9 @@ export default async function (tree: Tree) {
     const sharedGlobalFileset = new Set(
       workspaceConfiguration.namedInputs.sharedGlobals
     );
-    sharedGlobalFileset.add(join('{workspaceRoot}', globalBabelFile));
+    sharedGlobalFileset.add(
+      joinPathFragments('{workspaceRoot}', globalBabelFile)
+    );
     workspaceConfiguration.namedInputs.sharedGlobals =
       Array.from(sharedGlobalFileset);
   }

--- a/packages/web/src/migrations/update-15-0-0/add-babel-inputs.ts
+++ b/packages/web/src/migrations/update-15-0-0/add-babel-inputs.ts
@@ -1,10 +1,10 @@
 import {
   formatFiles,
+  joinPathFragments,
   readWorkspaceConfiguration,
   Tree,
   updateWorkspaceConfiguration,
 } from '@nrwl/devkit';
-import { join } from 'path';
 
 export default async function (tree: Tree) {
   const workspaceConfiguration = readWorkspaceConfiguration(tree);
@@ -17,7 +17,9 @@ export default async function (tree: Tree) {
     const sharedGlobalFileset = new Set(
       workspaceConfiguration.namedInputs.sharedGlobals
     );
-    sharedGlobalFileset.add(join('{workspaceRoot}', globalBabelFile));
+    sharedGlobalFileset.add(
+      joinPathFragments('{workspaceRoot}', globalBabelFile)
+    );
     workspaceConfiguration.namedInputs.sharedGlobals =
       Array.from(sharedGlobalFileset);
   }

--- a/packages/webpack/src/migrations/update-15-0-0/add-babel-inputs.ts
+++ b/packages/webpack/src/migrations/update-15-0-0/add-babel-inputs.ts
@@ -1,10 +1,10 @@
 import {
   formatFiles,
+  joinPathFragments,
   readWorkspaceConfiguration,
   Tree,
   updateWorkspaceConfiguration,
 } from '@nrwl/devkit';
-import { join } from 'path';
 
 export default async function (tree: Tree) {
   const workspaceConfiguration = readWorkspaceConfiguration(tree);
@@ -17,7 +17,9 @@ export default async function (tree: Tree) {
     const sharedGlobalFileset = new Set(
       workspaceConfiguration.namedInputs.sharedGlobals
     );
-    sharedGlobalFileset.add(join('{workspaceRoot}', globalBabelFile));
+    sharedGlobalFileset.add(
+      joinPathFragments('{workspaceRoot}', globalBabelFile)
+    );
     workspaceConfiguration.namedInputs.sharedGlobals =
       Array.from(sharedGlobalFileset);
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Paths during the `inputs` migration are written with the OS's path separators.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Paths during the `inputs` migration are written with `/`
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
