### PR TITLE
fix(angular): export generators correctly #12434

### DIFF
--- a/packages/angular/src/generators/convert-to-with-mf/convert-to-with-mf.ts
+++ b/packages/angular/src/generators/convert-to-with-mf/convert-to-with-mf.ts
@@ -1,7 +1,11 @@
-import { joinPathFragments, logger, Tree } from '@nrwl/devkit';
+import {
+  formatFiles,
+  joinPathFragments,
+  logger,
+  readProjectConfiguration,
+  Tree,
+} from '@nrwl/devkit';
 import type { Schema } from './schema';
-
-import { readProjectConfiguration, formatFiles } from '@nrwl/devkit';
 import { getMFProjects } from '../../utils/get-mf-projects';
 import {
   checkOutputNameMatchesProjectName,
@@ -12,7 +16,7 @@ import {
   writeNewWebpackConfig,
 } from './lib';
 
-export default async function convertToWithMF(tree: Tree, schema: Schema) {
+export async function convertToWithMF(tree: Tree, schema: Schema) {
   const projects = new Set(getMFProjects(tree, { legacy: true }));
 
   if (!projects.has(schema.project)) {
@@ -56,3 +60,5 @@ export default async function convertToWithMF(tree: Tree, schema: Schema) {
 
   await formatFiles(tree);
 }
+
+export default convertToWithMF;

--- a/packages/angular/src/generators/host/host.ts
+++ b/packages/angular/src/generators/host/host.ts
@@ -16,7 +16,7 @@ import { addRoute } from '../../utils/nx-devkit/route-utils';
 import { setupMf } from '../setup-mf/setup-mf';
 import { E2eTestRunner } from '../../utils/test-runners';
 
-export default async function host(tree: Tree, options: Schema) {
+export async function host(tree: Tree, options: Schema) {
   const projects = getProjects(tree);
 
   const remotesToGenerate: string[] = [];
@@ -142,3 +142,5 @@ ${remoteRoutes}
     }
   );
 }
+
+export default host;

--- a/packages/angular/src/generators/remote/remote.ts
+++ b/packages/angular/src/generators/remote/remote.ts
@@ -28,7 +28,7 @@ function findNextAvailablePort(tree: Tree) {
   return nextAvailablePort;
 }
 
-export default async function remote(tree: Tree, options: Schema) {
+export async function remote(tree: Tree, options: Schema) {
   const projects = getProjects(tree);
   if (options.host && !projects.has(options.host)) {
     throw new Error(
@@ -152,3 +152,5 @@ export class AppModule {}`
     tree.write(pathToIndexHtml, newIndexContents);
   }
 }
+
+export default remote;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Exporting generators only as default prevents them from being reused by consumers programatically.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should use named and default exports

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #12434
