### PR TITLE
fix(graph): close tooltips when panning graph

### DIFF
--- a/graph/client/src/app/machines/graph.ts
+++ b/graph/client/src/app/machines/graph.ts
@@ -449,7 +449,7 @@ export class GraphService {
       this.renderGraph.$id(currentFocusedProjectName).addClass('focused');
     }
 
-    this.renderGraph.on('zoom', () => {
+    this.renderGraph.on('zoom pan', () => {
       this.tooltipService.hideAll();
     });
 


### PR DESCRIPTION
## Current Behavior
When panning the graph, tooltips stay open and wind up disconnected from the original node.

## Expected Behavior
When panning the graph, tooltips close
