### PR TITLE
fix(nextjs): specify return type in withNx plugin

### DIFF
--- a/packages/next/plugins/with-nx.spec.ts
+++ b/packages/next/plugins/with-nx.spec.ts
@@ -1,3 +1,4 @@
+import { NextConfigComplete } from 'next/dist/server/config-shared';
 import { withNx } from './with-nx';
 
 describe('withNx', () => {
@@ -10,6 +11,13 @@ describe('withNx', () => {
           module: { rules: [{ oneOf: [] }] },
         },
         {
+          buildId: 'build-id',
+          config: config as NextConfigComplete,
+          dev: true,
+          dir: 'dir',
+          isServer: false,
+          totalPages: 0,
+          webpack: undefined,
           defaultLoaders: {
             babel: {
               options: {},
@@ -35,6 +43,13 @@ describe('withNx', () => {
           module: { rules: [{ oneOf: [] }] },
         },
         {
+          buildId: 'build-id',
+          config: config as NextConfigComplete,
+          dev: true,
+          dir: 'dir',
+          isServer: false,
+          totalPages: 0,
+          webpack: undefined,
           defaultLoaders: {
             babel: {
               options: {},

--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -37,7 +37,7 @@ function getWithNxContext(): WithNxContext {
 export function withNx(
   nextConfig = {} as WithNxOptions,
   context: WithNxContext = getWithNxContext()
-) {
+): NextConfig {
   const userWebpack = nextConfig.webpack || ((x) => x);
   const { nx, ...validNextConfig } = nextConfig;
   return {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Inherited type doesn't exactly match NextConfig causing type-errors when used in combination with other plugins

## Expected Behavior

`withNx` returns valid `NextConfig`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
None
