### PR TITLE
fix(angular): do not use ngcc for new workspaces and projects #12386

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -170,11 +170,6 @@
             "default": false,
             "description": "Do not add dependencies to `package.json`."
           },
-          "skipPostInstall": {
-            "type": "boolean",
-            "default": false,
-            "description": "Do not add or append `ngcc` to the `postinstall` script in `package.json`."
-          },
           "unitTestRunner": {
             "type": "string",
             "enum": ["karma", "jest", "none"],
@@ -718,11 +713,6 @@
             "type": "boolean",
             "default": false,
             "description": "Do not add dependencies to `package.json`."
-          },
-          "skipPostInstall": {
-            "type": "boolean",
-            "default": false,
-            "description": "Do not add or append `ngcc` to the `postinstall` script in `package.json`."
           }
         },
         "additionalProperties": false,
@@ -862,11 +852,6 @@
             "type": "boolean",
             "default": false,
             "description": "Do not add dependencies to `package.json`."
-          },
-          "skipPostInstall": {
-            "type": "boolean",
-            "default": false,
-            "description": "Do not add or append `ngcc` to the `postinstall` script in `package.json`."
           },
           "skipTsConfig": {
             "type": "boolean",

--- a/packages/angular/src/generators/application/schema.d.ts
+++ b/packages/angular/src/generators/application/schema.d.ts
@@ -24,7 +24,6 @@ export interface Schema {
   port?: number;
   setParserOptionsProject?: boolean;
   skipPackageJson?: boolean;
-  skipPostInstall?: boolean;
   skipDefaultProject?: boolean;
   standalone?: boolean;
 }

--- a/packages/angular/src/generators/application/schema.json
+++ b/packages/angular/src/generators/application/schema.json
@@ -93,11 +93,6 @@
       "default": false,
       "description": "Do not add dependencies to `package.json`."
     },
-    "skipPostInstall": {
-      "type": "boolean",
-      "default": false,
-      "description": "Do not add or append `ngcc` to the `postinstall` script in `package.json`."
-    },
     "unitTestRunner": {
       "type": "string",
       "enum": ["karma", "jest", "none"],

--- a/packages/angular/src/generators/init/init.spec.ts
+++ b/packages/angular/src/generators/init/init.spec.ts
@@ -4,7 +4,6 @@ import { Linter } from '@nrwl/linter';
 
 import init from './init';
 import { E2eTestRunner, UnitTestRunner } from '../../utils/test-runners';
-import { Styles } from '../utils/types';
 
 describe('init', () => {
   let host: Tree;
@@ -40,37 +39,6 @@ describe('init', () => {
 
     // codelyzer should no longer be there by default
     expect(devDependencies['codelyzer']).toBeUndefined();
-  });
-
-  it('should add a postinstall script for ngcc by default', async () => {
-    // ACT
-    await init(host, {
-      unitTestRunner: UnitTestRunner.Karma,
-      linter: Linter.EsLint,
-      skipFormat: false,
-    });
-
-    const packageJson = readJson(host, 'package.json');
-
-    // ASSERT
-    expect(packageJson.scripts.postinstall).toEqual(
-      'ngcc --properties es2020 browser module main'
-    );
-  });
-
-  it('should not add a postinstall script for ngcc if skipPostInstall=true', async () => {
-    // ACT
-    await init(host, {
-      unitTestRunner: UnitTestRunner.Karma,
-      linter: Linter.EsLint,
-      skipFormat: false,
-      skipPostInstall: true,
-    });
-
-    const packageJson = readJson(host, 'package.json');
-
-    // ASSERT
-    expect(packageJson?.scripts?.postinstall).toBeFalsy();
   });
 
   describe('--unit-test-runner', () => {

--- a/packages/angular/src/generators/init/init.ts
+++ b/packages/angular/src/generators/init/init.ts
@@ -1,10 +1,11 @@
 import { cypressInitGenerator } from '@nrwl/cypress';
-import { GeneratorCallback, logger, Tree } from '@nrwl/devkit';
 import {
   addDependenciesToPackageJson,
   formatFiles,
+  GeneratorCallback,
+  logger,
   readWorkspaceConfiguration,
-  updateJson,
+  Tree,
   updateWorkspaceConfiguration,
 } from '@nrwl/devkit';
 import { jestInitGenerator } from '@nrwl/jest';
@@ -12,18 +13,18 @@ import { Linter } from '@nrwl/linter';
 import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 import { E2eTestRunner, UnitTestRunner } from '../../utils/test-runners';
 import {
-  angularVersion,
   angularDevkitVersion,
-  jestPresetAngularVersion,
-  rxjsVersion,
-  tsNodeVersion,
-  tsLibVersion,
-  zoneJsVersion,
-  protractorVersion,
+  angularVersion,
   jasmineCoreVersion,
   jasmineSpecReporterVersion,
+  jestPresetAngularVersion,
+  protractorVersion,
+  rxjsVersion,
+  tsLibVersion,
+  tsNodeVersion,
   typesJasmineVersion,
   typesJasminewd2Version,
+  zoneJsVersion,
 } from '../../utils/versions';
 import { karmaGenerator } from '../karma/karma';
 import { Schema } from './schema';
@@ -34,10 +35,6 @@ export async function angularInitGenerator(
 ): Promise<GeneratorCallback> {
   const options = normalizeOptions(rawOptions);
   setDefaults(host, options);
-
-  if (!options.skipPostInstall) {
-    addPostInstall(host);
-  }
 
   const depsTask = !options.skipPackageJson
     ? updateDependencies(host)
@@ -59,7 +56,6 @@ function normalizeOptions(options: Schema): Required<Schema> {
     linter: options.linter ?? Linter.EsLint,
     skipFormat: options.skipFormat ?? false,
     skipInstall: options.skipInstall ?? false,
-    skipPostInstall: options.skipPostInstall ?? false,
     skipPackageJson: options.skipPackageJson ?? false,
     style: options.style ?? 'css',
     unitTestRunner: options.unitTestRunner ?? UnitTestRunner.Jest,
@@ -88,19 +84,6 @@ function setDefaults(host: Tree, options: Schema) {
   };
 
   updateWorkspaceConfiguration(host, workspace);
-}
-
-function addPostInstall(host: Tree) {
-  updateJson(host, 'package.json', (pkgJson) => {
-    pkgJson.scripts = pkgJson.scripts ?? {};
-    const command = 'ngcc --properties es2020 browser module main';
-    if (!pkgJson.scripts.postinstall) {
-      pkgJson.scripts.postinstall = command;
-    } else if (!pkgJson.scripts.postinstall.includes('ngcc')) {
-      pkgJson.scripts.postinstall = `${pkgJson.scripts.postinstall} && ${command}`;
-    }
-    return pkgJson;
-  });
 }
 
 function updateDependencies(host: Tree): GeneratorCallback {

--- a/packages/angular/src/generators/init/schema.d.ts
+++ b/packages/angular/src/generators/init/schema.d.ts
@@ -10,5 +10,4 @@ export interface Schema {
   style?: Styles;
   linter?: Linter;
   skipPackageJson?: boolean;
-  skipPostInstall?: boolean;
 }

--- a/packages/angular/src/generators/init/schema.json
+++ b/packages/angular/src/generators/init/schema.json
@@ -72,11 +72,6 @@
       "type": "boolean",
       "default": false,
       "description": "Do not add dependencies to `package.json`."
-    },
-    "skipPostInstall": {
-      "type": "boolean",
-      "default": false,
-      "description": "Do not add or append `ngcc` to the `postinstall` script in `package.json`."
     }
   },
   "additionalProperties": false

--- a/packages/angular/src/generators/library/schema.d.ts
+++ b/packages/angular/src/generators/library/schema.d.ts
@@ -28,7 +28,6 @@ export interface Schema {
   setParserOptionsProject?: boolean;
   skipModule?: boolean;
   skipPackageJson?: boolean;
-  skipPostInstall?: boolean;
   standalone?: boolean;
   displayBlock?: boolean;
   inlineStyle?: boolean;

--- a/packages/angular/src/generators/library/schema.json
+++ b/packages/angular/src/generators/library/schema.json
@@ -57,11 +57,6 @@
       "default": false,
       "description": "Do not add dependencies to `package.json`."
     },
-    "skipPostInstall": {
-      "type": "boolean",
-      "default": false,
-      "description": "Do not add or append `ngcc` to the `postinstall` script in `package.json`."
-    },
     "skipTsConfig": {
       "type": "boolean",
       "default": false,


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
We add a post install script to run `ngcc` to all new workspaces and to existing workspaces that are not using it when the `angular init` generator is called.

With Ivy being around for a while now, and most packages having migrated to use `partial compilation`, it makes more sense for people to intentionally add this themselves.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #12386
