### PR TITLE
fix(angular): ng-add migration should set default project

### DIFF
--- a/e2e/angular-core/src/ng-add.test.ts
+++ b/e2e/angular-core/src/ng-add.test.ts
@@ -148,6 +148,7 @@ describe('convert Angular CLI workspace to an Nx workspace', () => {
       cli: {
         packageManager: packageManager,
       },
+      defaultProject: project,
       implicitDependencies: {
         '.eslintrc.json': '*',
         'package.json': {

--- a/packages/angular/src/generators/ng-add/__snapshots__/migrate-from-angular-cli.spec.ts.snap
+++ b/packages/angular/src/generators/ng-add/__snapshots__/migrate-from-angular-cli.spec.ts.snap
@@ -44,6 +44,7 @@ Object {
   "affected": Object {
     "defaultBase": "main",
   },
+  "defaultProject": "app1",
   "implicitDependencies": Object {
     ".eslintrc.json": "*",
     "package.json": Object {

--- a/packages/angular/src/generators/ng-add/migrate-from-angular-cli.spec.ts
+++ b/packages/angular/src/generators/ng-add/migrate-from-angular-cli.spec.ts
@@ -243,9 +243,7 @@ describe('workspace', () => {
 
     it('should set the default project correctly', async () => {
       await migrateFromAngularCli(tree, {});
-      expect(readJson(tree, 'nx.json').defaultProject).toMatchInlineSnapshot(
-        `"myApp"`
-      );
+      expect(readJson(tree, 'nx.json').defaultProject).toBe('myApp');
     });
 
     it('should create nx.json', async () => {

--- a/packages/angular/src/generators/ng-add/migrate-from-angular-cli.spec.ts
+++ b/packages/angular/src/generators/ng-add/migrate-from-angular-cli.spec.ts
@@ -241,6 +241,13 @@ describe('workspace', () => {
       ).not.toBeDefined();
     });
 
+    it('should set the default project correctly', async () => {
+      await migrateFromAngularCli(tree, {});
+      expect(readJson(tree, 'nx.json').defaultProject).toMatchInlineSnapshot(
+        `"myApp"`
+      );
+    });
+
     it('should create nx.json', async () => {
       await migrateFromAngularCli(tree, { defaultBase: 'main' });
       expect(readJson(tree, 'nx.json')).toMatchSnapshot();

--- a/packages/angular/src/generators/ng-add/migrate-from-angular-cli.ts
+++ b/packages/angular/src/generators/ng-add/migrate-from-angular-cli.ts
@@ -3,8 +3,10 @@ import {
   formatFiles,
   installPackagesTask,
   readJson,
+  readWorkspaceConfiguration,
   Tree,
   updateJson,
+  updateWorkspaceConfiguration,
 } from '@nrwl/devkit';
 import { nxVersion } from '../../utils/versions';
 import type { GeneratorOptions } from './schema';
@@ -35,6 +37,10 @@ export async function migrateFromAngularCli(
   validateWorkspace(tree);
   const projects = getAllProjects(tree);
   const options = normalizeOptions(tree, rawOptions, projects);
+
+  const defaultProject = projects.apps.find((app) =>
+    app.config.sourceRoot?.startsWith('src')
+  );
 
   if (options.preserveAngularCliLayout) {
     addDependenciesToPackageJson(
@@ -101,6 +107,14 @@ export async function migrateFromAngularCli(
     }
 
     await formatFiles(tree);
+  }
+
+  if (defaultProject) {
+    const workspaceConfig = readWorkspaceConfiguration(tree);
+    updateWorkspaceConfiguration(tree, {
+      ...workspaceConfig,
+      defaultProject: defaultProject.name,
+    });
   }
 
   if (!options.skipInstall) {

--- a/packages/angular/src/generators/ng-add/migrate-from-angular-cli.ts
+++ b/packages/angular/src/generators/ng-add/migrate-from-angular-cli.ts
@@ -38,9 +38,7 @@ export async function migrateFromAngularCli(
   const projects = getAllProjects(tree);
   const options = normalizeOptions(tree, rawOptions, projects);
 
-  const defaultProject = projects.apps.find((app) =>
-    app.config.sourceRoot?.startsWith('src')
-  );
+  const defaultProject = projects.apps.find((app) => app.config.root === '');
 
   if (options.preserveAngularCliLayout) {
     addDependenciesToPackageJson(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Migration doesn't set the default project

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Migration should set the default project

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #12332
