### PR TITLE
fix(linter): check for all .eslintrc.* files when generating a package

### DIFF
--- a/packages/linter/src/generators/utils/eslint-file.spec.ts
+++ b/packages/linter/src/generators/utils/eslint-file.spec.ts
@@ -1,4 +1,4 @@
-import { findEslintFile } from './eslint-file';
+import {eslintFileList, findEslintFile} from './eslint-file'
 
 import { Tree } from '@nrwl/devkit';
 import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
@@ -15,20 +15,9 @@ describe('@nrwl/linter:eslint-file', () => {
       expect(findEslintFile(tree)).toBe(null);
     });
 
-    it('should return the name of the eslint config when calling findEslintFile', () => {
-      tree.write('.eslintrc.json', '{}');
-      expect(findEslintFile(tree)).toBe('.eslintrc.json');
-    });
-
-    it('should return the name of the eslint config when calling findEslintFile', () => {
-      tree.write('.eslintrc.js', '{}');
-      expect(findEslintFile(tree)).toBe('.eslintrc.js');
-    });
-
-    it('should return default name when calling findEslintFile when no eslint is found', () => {
-      tree.write('.eslintrc.yaml', '{}');
-
-      expect(findEslintFile(tree)).toBe(null);
-    });
+    test.each(eslintFileList)('should return %p when calling findEslintFile', (eslintFileName) => {
+      tree.write(eslintFileName, '{}');
+      expect(findEslintFile(tree)).toBe(eslintFileName);
+    })
   });
 });

--- a/packages/linter/src/generators/utils/eslint-file.spec.ts
+++ b/packages/linter/src/generators/utils/eslint-file.spec.ts
@@ -1,4 +1,4 @@
-import {eslintFileList, findEslintFile} from './eslint-file'
+import { eslintConfigFileWhitelist, findEslintFile } from './eslint-file';
 
 import { Tree } from '@nrwl/devkit';
 import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
@@ -15,9 +15,12 @@ describe('@nrwl/linter:eslint-file', () => {
       expect(findEslintFile(tree)).toBe(null);
     });
 
-    test.each(eslintFileList)('should return %p when calling findEslintFile', (eslintFileName) => {
-      tree.write(eslintFileName, '{}');
-      expect(findEslintFile(tree)).toBe(eslintFileName);
-    })
+    test.each(eslintConfigFileWhitelist)(
+      'should return %p when calling findEslintFile',
+      (eslintFileName) => {
+        tree.write(eslintFileName, '{}');
+        expect(findEslintFile(tree)).toBe(eslintFileName);
+      }
+    );
   });
 });

--- a/packages/linter/src/generators/utils/eslint-file.ts
+++ b/packages/linter/src/generators/utils/eslint-file.ts
@@ -1,6 +1,6 @@
 import type { Tree } from '@nrwl/devkit';
 
-export const eslintFileList = [
+export const eslintConfigFileWhitelist = [
   '.eslintrc',
   '.eslintrc.js',
   '.eslintrc.cjs',
@@ -10,7 +10,7 @@ export const eslintFileList = [
 ];
 
 export function findEslintFile(tree: Tree): string | null {
-  for (const file of eslintFileList) {
+  for (const file of eslintConfigFileWhitelist) {
     if (tree.exists(file)) {
       return file;
     }

--- a/packages/linter/src/generators/utils/eslint-file.ts
+++ b/packages/linter/src/generators/utils/eslint-file.ts
@@ -1,6 +1,13 @@
 import type { Tree } from '@nrwl/devkit';
 
-const eslintFileList = ['.eslintrc.json', '.eslintrc.js'];
+export const eslintFileList = [
+  '.eslintrc',
+  '.eslintrc.js',
+  '.eslintrc.cjs',
+  '.eslintrc.yaml',
+  '.eslintrc.yml',
+  '.eslintrc.json',
+];
 
 export function findEslintFile(tree: Tree): string | null {
   for (const file of eslintFileList) {
@@ -8,5 +15,6 @@ export function findEslintFile(tree: Tree): string | null {
       return file;
     }
   }
+
   return null;
 }

--- a/packages/linter/src/migrations/update-15-0-0/add-eslint-inputs.ts
+++ b/packages/linter/src/migrations/update-15-0-0/add-eslint-inputs.ts
@@ -6,11 +6,12 @@ import {
   updateWorkspaceConfiguration,
 } from '@nrwl/devkit';
 import { forEachExecutorOptions } from '@nrwl/workspace/src/utilities/executor-options-utils';
+import { eslintConfigFileWhitelist } from '../../generators/utils/eslint-file';
 
-export default async function (tree: Tree) {
+export default async function addEslintInputs(tree: Tree) {
   const workspaceConfiguration = readWorkspaceConfiguration(tree);
 
-  const globalEslintFile = ['.eslintrc.js', '.eslintrc.json'].find((file) =>
+  const globalEslintFile = eslintConfigFileWhitelist.find((file) =>
     tree.exists(file)
   );
 
@@ -18,13 +19,16 @@ export default async function (tree: Tree) {
     const productionFileset = new Set(
       workspaceConfiguration.namedInputs.production
     );
-    productionFileset.add('!{projectRoot}/.eslintrc.json');
+
+    productionFileset.add(`!{projectRoot}/${globalEslintFile}`);
+
     workspaceConfiguration.namedInputs.production =
       Array.from(productionFileset);
   }
 
   for (const targetName of getEslintTargets(tree)) {
     workspaceConfiguration.targetDefaults ??= {};
+
     const lintTargetDefaults = (workspaceConfiguration.targetDefaults[
       targetName
     ] ??= {});


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
- When generating new applications or packages, a `.eslintrc.json` file is still generated if we are using other eslint config file  formats, for example `.eslintrc`.

## Expected Behavior
- If a `.eslintrc.*` file that matches any of the possible `.eslintrc.*` formats listed [here](https://eslint.org/docs/latest/user-guide/configuring/configuration-files#configuration-file-formats), in the root of the monorepo. We should not generate a new `.eslintrc.json` file.

## Related Issue(s)
Enhances https://github.com/nrwl/nx/pull/10080
