### PR TITLE
fix(repo): bump node version of macos agents

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,8 @@ commands:
           steps:
             - run:
                 command: sudo apt-get install -y ca-certificates
+      - node/install:
+          node-version: 'latest'
       - run-yarn-install:
           os: << parameters.os >>
       - when:


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Mac OS agents in circleci are using npm v6

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Mac OS agents in circleci are using npm v8 (same as linux)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
