### PR TITLE
fix(core): readRawWorkspaceJson should keep workspace cache up to date

### DIFF
--- a/packages/nx/src/generators/utils/project-configuration.ts
+++ b/packages/nx/src/generators/utils/project-configuration.ts
@@ -464,7 +464,6 @@ function findDeletedProjects(tree: Tree) {
   });
 }
 
-let staticFSWorkspace: RawProjectsConfigurations;
 function readRawWorkspaceJson(tree: Tree): RawProjectsConfigurations {
   const path = getWorkspacePath(tree);
   if (path && tree.exists(path)) {
@@ -478,13 +477,13 @@ function readRawWorkspaceJson(tree: Tree): RawProjectsConfigurations {
       (file) => readJson(tree, file)
     ).projects;
     // We already have built a cache
-    if (!staticFSWorkspace) {
-      staticFSWorkspace = buildWorkspaceConfigurationFromGlobs(
-        nxJson,
-        [...globForProjectFiles(tree.root, nxJson)],
-        (file) => readJson(tree, file)
-      );
-    }
+    // if (!staticFSWorkspace) {
+    const staticFSWorkspace = buildWorkspaceConfigurationFromGlobs(
+      nxJson,
+      [...globForProjectFiles(tree.root, nxJson)],
+      (file) => readJson(tree, file)
+    );
+    // }
     const projects = { ...staticFSWorkspace.projects, ...createdProjects };
     findDeletedProjects(tree).forEach((file) => {
       const matchingStaticProject = Object.entries(projects).find(
@@ -498,11 +497,10 @@ function readRawWorkspaceJson(tree: Tree): RawProjectsConfigurations {
         delete projects[matchingStaticProject[0]];
       }
     });
-    staticFSWorkspace = {
+    return {
       ...staticFSWorkspace,
       projects,
     };
-    return staticFSWorkspace;
   }
 }
 

--- a/packages/nx/src/generators/utils/project-configuration.ts
+++ b/packages/nx/src/generators/utils/project-configuration.ts
@@ -498,10 +498,11 @@ function readRawWorkspaceJson(tree: Tree): RawProjectsConfigurations {
         delete projects[matchingStaticProject[0]];
       }
     });
-    return {
+    staticFSWorkspace = {
       ...staticFSWorkspace,
       projects,
     };
+    return staticFSWorkspace;
   }
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Running migrations that use workspace configuration (using `readRawWorkspaceJson`) on the clean repo (with no files changed) returns no projects.

## Expected Behavior
Workspace configuration (using `readRawWorkspaceJson`) from devkit should return all projects regardless of the state of the git.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
