### PR TITLE
fix(core): swap default method for output capture

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -2374,6 +2374,8 @@
       "name": "delegate-build",
       "implementation": "/packages/angular/src/executors/delegate-build/delegate-build.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "$schema": "http://json-schema.org/draft-07/schema",
         "title": "Schema for an executor which delegates a build.",
         "description": "Options for delegating a build to a different target.",
@@ -2415,6 +2417,8 @@
       "name": "ng-packagr-lite",
       "implementation": "/packages/angular/src/executors/ng-packagr-lite/ng-packagr-lite.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "$schema": "http://json-schema.org/schema",
         "title": "ng-packagr Target",
         "description": "ng-packagr target options for Build Architect. Use to build library projects.",
@@ -2478,6 +2482,8 @@
       "name": "package",
       "implementation": "/packages/angular/src/executors/package/package.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "$schema": "http://json-schema.org/schema",
         "title": "ng-packagr Target",
         "description": "ng-packagr target options for Build Architect. Use to build and package library projects for publishing.",
@@ -2543,6 +2549,8 @@
       "name": "webpack-browser",
       "implementation": "/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "$schema": "http://json-schema.org/draft-07/schema",
         "title": "Schema for Webpack Browser",
         "description": "The webpack-browser executor is very similar to the standard browser builder provided by the Angular Devkit. It allows you to build your Angular application to a build artifact that can be hosted online. There are some key differences:   \n- Supports Custom Webpack Configurations  \n- Supports Incremental Building",
@@ -3220,6 +3228,8 @@
       "name": "webpack-dev-server",
       "implementation": "/packages/angular/src/builders/webpack-dev-server/webpack-dev-server.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "$schema": "http://json-schema.org/draft-07/schema",
         "title": "Schema for Webpack Dev Server",
         "description": "The webpack-dev-server executor is very similar to the standard dev server builder provided by the Angular Devkit. It is usually used in tandem with `@nrwl/angular:webpack-browser` when your Angular application uses a custom webpack configuration.",
@@ -3335,6 +3345,8 @@
       "name": "module-federation-dev-server",
       "implementation": "/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "$schema": "http://json-schema.org/draft-07/schema",
         "title": "Schema for Module Federation Dev Server",
         "description": "The module-federation-dev-server executor is reserved exclusively for use with host Module Federation applications. It allows the user to specify which remote applications should be served with the host.",
@@ -3451,6 +3463,8 @@
       "name": "file-server",
       "implementation": "/packages/angular/src/executors/file-server/file-server.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "title": "File Server",
         "description": "Serve a web application from a folder.",
         "type": "object",

--- a/docs/generated/packages/cypress.json
+++ b/docs/generated/packages/cypress.json
@@ -188,6 +188,7 @@
       "name": "cypress",
       "implementation": "/packages/cypress/src/executors/cypress/cypress.impl.ts",
       "schema": {
+        "version": 2,
         "title": "Cypress Target",
         "description": "Run Cypress for e2e, integration and component testing.",
         "type": "object",

--- a/docs/generated/packages/detox.json
+++ b/docs/generated/packages/detox.json
@@ -108,6 +108,8 @@
       "name": "build",
       "implementation": "/packages/detox/src/executors/build/build.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "title": "Run detox build",
         "description": "Run detox build options.",
         "type": "object",
@@ -138,6 +140,8 @@
       "name": "test",
       "implementation": "/packages/detox/src/executors/test/test.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "title": "Run detox test",
         "description": "Run detox test options.",
         "type": "object",

--- a/docs/generated/packages/esbuild.json
+++ b/docs/generated/packages/esbuild.json
@@ -116,6 +116,8 @@
       "name": "esbuild",
       "implementation": "/packages/esbuild/src/executors/esbuild/esbuild.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "title": "esbuild (experimental)",
         "description": "Bundle a package for different platforms. Note: declaration (*.d.ts) file are not currently generated.",
         "cli": "nx",
@@ -155,7 +157,7 @@
           },
           "format": {
             "type": "array",
-            "description": "Set the output format(s).",
+            "description": "List of module formats to output. Defaults to matching format from tsconfig (e.g. CJS for CommonJS, and ESM otherwise).",
             "alias": "f",
             "items": { "type": "string", "enum": ["esm", "cjs"] },
             "default": ["esm"]

--- a/docs/generated/packages/expo.json
+++ b/docs/generated/packages/expo.json
@@ -330,6 +330,8 @@
       "name": "update",
       "implementation": "/packages/expo/src/executors/update/update.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "$schema": "http://json-schema.org/schema",
         "$id": "NxExpoEasUpdate",
         "cli": "nx",
@@ -401,6 +403,8 @@
       "name": "build",
       "implementation": "/packages/expo/src/executors/build/build.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "$schema": "http://json-schema.org/schema",
         "$id": "NxExpoEasBuild",
         "cli": "nx",
@@ -466,6 +470,8 @@
       "name": "build-list",
       "implementation": "/packages/expo/src/executors/build-list/build-list.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "$schema": "http://json-schema.org/schema",
         "$id": "NxExpoEasBuildList",
         "cli": "nx",
@@ -546,6 +552,8 @@
       "name": "download",
       "implementation": "/packages/expo/src/executors/download/download.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "$schema": "http://json-schema.org/schema",
         "$id": "NxExpoDownloadEasBuild",
         "cli": "nx",
@@ -611,6 +619,8 @@
       "name": "build-ios",
       "implementation": "/packages/expo/src/executors/build-ios/build-ios.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "$schema": "http://json-schema.org/schema",
         "$id": "NxExpoBuildIOS",
         "cli": "nx",
@@ -708,6 +718,8 @@
       "name": "build-android",
       "implementation": "/packages/expo/src/executors/build-android/build-android.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "$schema": "http://json-schema.org/schema",
         "$id": "NxExpoBuildAndroid",
         "cli": "nx",
@@ -771,6 +783,8 @@
       "name": "build-web",
       "implementation": "/packages/expo/src/executors/build-web/build-web.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "$schema": "http://json-schema.org/schema",
         "$id": "NxExpoBuildWeb",
         "cli": "nx",
@@ -804,6 +818,8 @@
       "name": "build-status",
       "implementation": "/packages/expo/src/executors/build-status/build-status.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "$schema": "http://json-schema.org/schema",
         "$id": "NxExpoBuildStatus",
         "cli": "nx",
@@ -828,6 +844,8 @@
       "name": "publish",
       "implementation": "/packages/expo/src/executors/publish/publish.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "cli": "nx",
         "$id": "NxExpoPublish",
         "$schema": "http://json-schema.org/schema",
@@ -879,6 +897,8 @@
       "name": "publish-set",
       "implementation": "/packages/expo/src/executors/publish-set/publish-set.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "cli": "nx",
         "$id": "NxExpoPublishSet",
         "$schema": "http://json-schema.org/schema",
@@ -907,6 +927,8 @@
       "name": "rollback",
       "implementation": "/packages/expo/src/executors/rollback/rollback.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "cli": "nx",
         "$id": "NxExpoRollback",
         "$schema": "http://json-schema.org/schema",
@@ -939,6 +961,8 @@
       "name": "run",
       "implementation": "/packages/expo/src/executors/run/run.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "cli": "nx",
         "$id": "NxExpoRun",
         "$schema": "http://json-schema.org/schema",
@@ -999,6 +1023,8 @@
       "name": "start",
       "implementation": "/packages/expo/src/executors/start/start.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "cli": "nx",
         "$id": "NxExpoStart",
         "$schema": "http://json-schema.org/schema",
@@ -1090,6 +1116,8 @@
       "name": "sync-deps",
       "implementation": "/packages/expo/src/executors/sync-deps/sync-deps.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "cli": "nx",
         "$id": "NxExpoSyncDeps",
         "$schema": "http://json-schema.org/schema",
@@ -1113,6 +1141,8 @@
       "name": "ensure-symlink",
       "implementation": "/packages/expo/src/executors/ensure-symlink/ensure-symlink.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "cli": "nx",
         "$id": "NxExpoEnsureSymlink",
         "$schema": "http://json-schema.org/schema",
@@ -1131,6 +1161,8 @@
       "name": "eject",
       "implementation": "/packages/expo/src/executors/eject/eject.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "cli": "nx",
         "$id": "NxExpoEject",
         "$schema": "http://json-schema.org/schema",

--- a/docs/generated/packages/jest.json
+++ b/docs/generated/packages/jest.json
@@ -141,6 +141,8 @@
       "implementation": "/packages/jest/src/executors/jest/jest.impl.ts",
       "batchImplementation": "./src/executors/jest/jest.impl#batchJest",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "title": "Jest Builder",
         "description": "Jest target options for Build Facade.",
         "cli": "nx",

--- a/docs/generated/packages/js.json
+++ b/docs/generated/packages/js.json
@@ -212,6 +212,8 @@
       "name": "tsc",
       "implementation": "/packages/js/src/executors/tsc/tsc.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "title": "Typescript Build Target",
         "description": "Builds using TypeScript.",
         "cli": "nx",
@@ -386,6 +388,8 @@
       "name": "swc",
       "implementation": "/packages/js/src/executors/swc/swc.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "$schema": "http://json-schema.org/schema",
         "cli": "nx",
         "title": "Typescript Build Target",
@@ -543,6 +547,8 @@
       "name": "node",
       "implementation": "/packages/js/src/executors/node/node.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "$schema": "http://json-schema.org/schema",
         "cli": "nx",
         "title": "Node executor",

--- a/docs/generated/packages/linter.json
+++ b/docs/generated/packages/linter.json
@@ -95,6 +95,8 @@
       "name": "lint",
       "implementation": "/packages/linter/src/executors/lint/lint.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "$schema": "http://json-schema.org/schema",
         "title": "Lint Target",
         "description": "Linter.",
@@ -222,6 +224,8 @@
       "name": "eslint",
       "implementation": "/packages/linter/src/executors/eslint/lint.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "$schema": "http://json-schema.org/schema",
         "title": "ESLint Lint Target",
         "description": "ESLint Lint Target.",

--- a/docs/generated/packages/next.json
+++ b/docs/generated/packages/next.json
@@ -620,6 +620,8 @@
       "name": "build",
       "implementation": "/packages/next/src/executors/build/build.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "$schema": "http://json-schema.org/schema",
         "cli": "nx",
         "title": "Next Build",
@@ -683,6 +685,8 @@
       "name": "server",
       "implementation": "/packages/next/src/executors/server/server.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "cli": "nx",
         "title": "Next Serve",
         "description": "Serve a Next.js app.",
@@ -748,6 +752,8 @@
       "name": "export",
       "implementation": "/packages/next/src/executors/export/export.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "cli": "nx",
         "title": "Next Export",
         "description": "Export a Next.js application. The exported application is located at `dist/$outputPath/exported`.",

--- a/docs/generated/packages/node.json
+++ b/docs/generated/packages/node.json
@@ -275,6 +275,8 @@
       "name": "webpack",
       "implementation": "/packages/node/src/executors/webpack/webpack.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "title": "Node Application Build Target",
         "description": "Node application build target options for Build Facade.",
         "cli": "nx",
@@ -562,6 +564,8 @@
       "name": "node",
       "implementation": "/packages/node/src/executors/node/node.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "$schema": "http://json-schema.org/schema",
         "cli": "nx",
         "title": "Node executor",

--- a/docs/generated/packages/nx-plugin.json
+++ b/docs/generated/packages/nx-plugin.json
@@ -370,6 +370,8 @@
       "name": "e2e",
       "implementation": "/packages/nx-plugin/src/executors/e2e/e2e.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "title": "Nx Plugin Playground Target",
         "description": "Creates a playground for a Nx Plugin.",
         "cli": "nx",

--- a/docs/generated/packages/nx.json
+++ b/docs/generated/packages/nx.json
@@ -156,6 +156,7 @@
       "name": "noop",
       "implementation": "/packages/nx/src/executors/noop/noop.impl.ts",
       "schema": {
+        "version": 2,
         "title": "Noop",
         "description": "An executor that does nothing",
         "type": "object",
@@ -174,6 +175,7 @@
       "name": "run-commands",
       "implementation": "/packages/nx/src/executors/run-commands/run-commands.impl.ts",
       "schema": {
+        "version": 2,
         "title": "Run Commands",
         "description": "Run any custom commands with Nx.",
         "type": "object",
@@ -305,6 +307,7 @@
       "name": "run-script",
       "implementation": "/packages/nx/src/executors/run-script/run-script.impl.ts",
       "schema": {
+        "version": 2,
         "title": "Run Script",
         "description": "Run any NPM script of a project in the project's root directory.",
         "type": "object",

--- a/docs/generated/packages/react-native.json
+++ b/docs/generated/packages/react-native.json
@@ -532,6 +532,8 @@
       "name": "run-android",
       "implementation": "/packages/react-native/src/executors/run-android/run-android.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "cli": "nx",
         "$id": "NxReactNativeRunAndroid",
         "$schema": "http://json-schema.org/schema",
@@ -617,6 +619,8 @@
       "name": "run-ios",
       "implementation": "/packages/react-native/src/executors/run-ios/run-ios.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "cli": "nx",
         "$id": "NxReactNativeRunIos",
         "$schema": "http://json-schema.org/schema",
@@ -702,6 +706,8 @@
       "name": "bundle",
       "implementation": "/packages/react-native/src/executors/bundle/bundle.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "cli": "nx",
         "$id": "NxReactNativeBundle",
         "$schema": "http://json-schema.org/schema",
@@ -781,6 +787,8 @@
       "name": "build-android",
       "implementation": "/packages/react-native/src/executors/build-android/build-android.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "cli": "nx",
         "$id": "NxReactNativeBuildAndroid",
         "$schema": "http://json-schema.org/schema",
@@ -813,6 +821,8 @@
       "name": "start",
       "implementation": "/packages/react-native/src/executors/start/start.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "cli": "nx",
         "$id": "NxReactNativeStart",
         "$schema": "http://json-schema.org/schema",
@@ -847,6 +857,8 @@
       "name": "sync-deps",
       "implementation": "/packages/react-native/src/executors/sync-deps/sync-deps.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "cli": "nx",
         "$id": "NxReactNativeSyncDeps",
         "$schema": "http://json-schema.org/schema",
@@ -878,6 +890,8 @@
       "name": "ensure-symlink",
       "implementation": "/packages/react-native/src/executors/ensure-symlink/ensure-symlink.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "cli": "nx",
         "$id": "NxReactNativeEnsureSymlink",
         "$schema": "http://json-schema.org/schema",
@@ -896,6 +910,8 @@
       "name": "storybook",
       "implementation": "/packages/react-native/src/executors/storybook/storybook.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "title": "React Native Storybook Load Stories",
         "cli": "nx",
         "description": "Load stories for react native.",

--- a/docs/generated/packages/react.json
+++ b/docs/generated/packages/react.json
@@ -1357,6 +1357,8 @@
       "name": "module-federation-dev-server",
       "implementation": "/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "title": "Module Federation Dev Server",
         "description": "Serve a web application.",
         "cli": "nx",

--- a/docs/generated/packages/rollup.json
+++ b/docs/generated/packages/rollup.json
@@ -116,6 +116,8 @@
       "name": "rollup",
       "implementation": "/packages/rollup/src/executors/rollup/rollup.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "title": "Web Library Rollup Target (Experimental)",
         "description": "Packages a library for different web usages (ESM, CommonJS).",
         "cli": "nx",

--- a/docs/generated/packages/storybook.json
+++ b/docs/generated/packages/storybook.json
@@ -274,6 +274,8 @@
       "name": "storybook",
       "implementation": "/packages/storybook/src/executors/storybook/storybook.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "title": "Storybook Dev Builder",
         "cli": "nx",
         "description": "Serve up storybook in development mode.",
@@ -383,6 +385,8 @@
       "name": "build",
       "implementation": "/packages/storybook/src/executors/build-storybook/build-storybook.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "title": "Storybook Builder",
         "cli": "nx",
         "description": "Build storybook in production mode.",

--- a/docs/generated/packages/web.json
+++ b/docs/generated/packages/web.json
@@ -170,6 +170,8 @@
       "name": "webpack",
       "implementation": "/packages/web/src/executors/webpack/webpack.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "title": "Webpack Executor",
         "description": "Builds web applications using webpack.",
         "cli": "nx",
@@ -675,6 +677,8 @@
       "name": "rollup",
       "implementation": "/packages/web/src/executors/rollup/rollup.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "title": "Web Library Rollup Target (Experimental)",
         "description": "Packages a library for different web usages (`UMD`, `ESM`, `CJS`).",
         "cli": "nx",
@@ -846,6 +850,8 @@
       "name": "dev-server",
       "implementation": "/packages/web/src/executors/dev-server/dev-server.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "title": "Web Dev Server",
         "description": "Serve a web application.",
         "cli": "nx",
@@ -930,6 +936,8 @@
       "name": "file-server",
       "implementation": "/packages/web/src/executors/file-server/file-server.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "title": "File Server",
         "description": "Serve a web application from a folder.",
         "type": "object",

--- a/docs/generated/packages/webpack.json
+++ b/docs/generated/packages/webpack.json
@@ -117,6 +117,8 @@
       "name": "webpack",
       "implementation": "/packages/webpack/src/executors/webpack/webpack.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "title": "Webpack Executor",
         "description": "Builds web applications using webpack.",
         "cli": "nx",
@@ -702,6 +704,8 @@
       "name": "dev-server",
       "implementation": "/packages/webpack/src/executors/dev-server/dev-server.impl.ts",
       "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
         "title": "Web Dev Server",
         "description": "Serve a web application.",
         "cli": "nx",

--- a/docs/generated/packages/workspace.json
+++ b/docs/generated/packages/workspace.json
@@ -677,6 +677,7 @@
       "name": "run-commands",
       "implementation": "/packages/workspace/src/executors/run-commands/run-commands.impl.ts",
       "schema": {
+        "version": 2,
         "title": "Run Commands",
         "description": "Run any custom commands with Nx.",
         "type": "object",
@@ -809,6 +810,7 @@
       "implementation": "/packages/workspace/src/executors/counter/counter.impl.ts",
       "batchImplementation": "./src/executors/counter/counter.impl#batchCounter",
       "schema": {
+        "version": 2,
         "title": "Counter",
         "description": "A dummy executor useful for E2E tests.",
         "type": "object",
@@ -831,6 +833,7 @@
       "name": "run-script",
       "implementation": "/packages/workspace/src/executors/run-script/run-script.impl.ts",
       "schema": {
+        "version": 2,
         "title": "Run Script",
         "description": "Run any NPM script of a project in the project's root directory.",
         "type": "object",

--- a/packages/angular/src/builders/module-federation-dev-server/schema.json
+++ b/packages/angular/src/builders/module-federation-dev-server/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "$schema": "http://json-schema.org/draft-07/schema",
   "title": "Schema for Module Federation Dev Server",
   "description": "The module-federation-dev-server executor is reserved exclusively for use with host Module Federation applications. It allows the user to specify which remote applications should be served with the host.",

--- a/packages/angular/src/builders/webpack-browser/schema.json
+++ b/packages/angular/src/builders/webpack-browser/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "$schema": "http://json-schema.org/draft-07/schema",
   "title": "Schema for Webpack Browser",
   "description": "The webpack-browser executor is very similar to the standard browser builder provided by the Angular Devkit. It allows you to build your Angular application to a build artifact that can be hosted online. There are some key differences:   \n- Supports Custom Webpack Configurations  \n- Supports Incremental Building",

--- a/packages/angular/src/builders/webpack-dev-server/schema.json
+++ b/packages/angular/src/builders/webpack-dev-server/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "$schema": "http://json-schema.org/draft-07/schema",
   "title": "Schema for Webpack Dev Server",
   "description": "The webpack-dev-server executor is very similar to the standard dev server builder provided by the Angular Devkit. It is usually used in tandem with `@nrwl/angular:webpack-browser` when your Angular application uses a custom webpack configuration.",

--- a/packages/angular/src/executors/delegate-build/schema.json
+++ b/packages/angular/src/executors/delegate-build/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "$schema": "http://json-schema.org/draft-07/schema",
   "title": "Schema for an executor which delegates a build.",
   "description": "Options for delegating a build to a different target.",

--- a/packages/angular/src/executors/file-server/schema.json
+++ b/packages/angular/src/executors/file-server/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "title": "File Server",
   "description": "Serve a web application from a folder.",
   "type": "object",

--- a/packages/angular/src/executors/ng-packagr-lite/schema.json
+++ b/packages/angular/src/executors/ng-packagr-lite/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "$schema": "http://json-schema.org/schema",
   "title": "ng-packagr Target",
   "description": "ng-packagr target options for Build Architect. Use to build library projects.",

--- a/packages/angular/src/executors/package/schema.json
+++ b/packages/angular/src/executors/package/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "$schema": "http://json-schema.org/schema",
   "title": "ng-packagr Target",
   "description": "ng-packagr target options for Build Architect. Use to build and package library projects for publishing.",

--- a/packages/cypress/src/executors/cypress/schema.json
+++ b/packages/cypress/src/executors/cypress/schema.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "title": "Cypress Target",
   "description": "Run Cypress for e2e, integration and component testing.",
   "type": "object",

--- a/packages/detox/src/executors/build/schema.json
+++ b/packages/detox/src/executors/build/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "title": "Run detox build",
   "description": "Run detox build options.",
   "type": "object",

--- a/packages/detox/src/executors/test/schema.json
+++ b/packages/detox/src/executors/test/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "title": "Run detox test",
   "description": "Run detox test options.",
   "type": "object",

--- a/packages/esbuild/src/executors/esbuild/schema.json
+++ b/packages/esbuild/src/executors/esbuild/schema.json
@@ -42,7 +42,7 @@
     },
     "format": {
       "type": "array",
-      "description": "Set the output format(s).",
+      "description": "List of module formats to output. Defaults to matching format from tsconfig (e.g. CJS for CommonJS, and ESM otherwise).",
       "alias": "f",
       "items": {
         "type": "string",

--- a/packages/esbuild/src/executors/esbuild/schema.json
+++ b/packages/esbuild/src/executors/esbuild/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "title": "esbuild (experimental)",
   "description": "Bundle a package for different platforms. Note: declaration (*.d.ts) file are not currently generated.",
   "cli": "nx",
@@ -33,14 +35,20 @@
     "additionalEntryPoints": {
       "type": "array",
       "description": "List of additional entry points.",
-      "items": { "type": "string" },
+      "items": {
+        "type": "string"
+      },
       "default": []
     },
     "format": {
       "type": "array",
-      "description": "List of module formats to output. Defaults to matching format from tsconfig (e.g. CJS for CommonJS, and ESM otherwise).",
+      "description": "Set the output format(s).",
       "alias": "f",
-      "items": { "type": "string", "enum": ["esm", "cjs"] }
+      "items": {
+        "type": "string",
+        "enum": ["esm", "cjs"]
+      },
+      "default": ["esm"]
     },
     "watch": {
       "type": "boolean",
@@ -67,16 +75,6 @@
       "items": {
         "type": "string"
       }
-    },
-    "format": {
-      "type": "array",
-      "description": "Set the output format(s).",
-      "alias": "f",
-      "items": {
-        "type": "string",
-        "enum": ["esm", "cjs"]
-      },
-      "default": ["esm"]
     },
     "outputHashing": {
       "type": "string",

--- a/packages/expo/src/executors/build-android/schema.json
+++ b/packages/expo/src/executors/build-android/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "$schema": "http://json-schema.org/schema",
   "$id": "NxExpoBuildAndroid",
   "cli": "nx",

--- a/packages/expo/src/executors/build-ios/schema.json
+++ b/packages/expo/src/executors/build-ios/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "$schema": "http://json-schema.org/schema",
   "$id": "NxExpoBuildIOS",
   "cli": "nx",

--- a/packages/expo/src/executors/build-list/schema.json
+++ b/packages/expo/src/executors/build-list/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "$schema": "http://json-schema.org/schema",
   "$id": "NxExpoEasBuildList",
   "cli": "nx",

--- a/packages/expo/src/executors/build-status/schema.json
+++ b/packages/expo/src/executors/build-status/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "$schema": "http://json-schema.org/schema",
   "$id": "NxExpoBuildStatus",
   "cli": "nx",

--- a/packages/expo/src/executors/build-web/schema.json
+++ b/packages/expo/src/executors/build-web/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "$schema": "http://json-schema.org/schema",
   "$id": "NxExpoBuildWeb",
   "cli": "nx",

--- a/packages/expo/src/executors/build/schema.json
+++ b/packages/expo/src/executors/build/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "$schema": "http://json-schema.org/schema",
   "$id": "NxExpoEasBuild",
   "cli": "nx",

--- a/packages/expo/src/executors/download/schema.json
+++ b/packages/expo/src/executors/download/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "$schema": "http://json-schema.org/schema",
   "$id": "NxExpoDownloadEasBuild",
   "cli": "nx",

--- a/packages/expo/src/executors/eject/schema.json
+++ b/packages/expo/src/executors/eject/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "cli": "nx",
   "$id": "NxExpoEject",
   "$schema": "http://json-schema.org/schema",

--- a/packages/expo/src/executors/ensure-symlink/schema.json
+++ b/packages/expo/src/executors/ensure-symlink/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "cli": "nx",
   "$id": "NxExpoEnsureSymlink",
   "$schema": "http://json-schema.org/schema",

--- a/packages/expo/src/executors/publish-set/schema.json
+++ b/packages/expo/src/executors/publish-set/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "cli": "nx",
   "$id": "NxExpoPublishSet",
   "$schema": "http://json-schema.org/schema",

--- a/packages/expo/src/executors/publish/schema.json
+++ b/packages/expo/src/executors/publish/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "cli": "nx",
   "$id": "NxExpoPublish",
   "$schema": "http://json-schema.org/schema",

--- a/packages/expo/src/executors/rollback/schema.json
+++ b/packages/expo/src/executors/rollback/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "cli": "nx",
   "$id": "NxExpoRollback",
   "$schema": "http://json-schema.org/schema",

--- a/packages/expo/src/executors/run/schema.json
+++ b/packages/expo/src/executors/run/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "cli": "nx",
   "$id": "NxExpoRun",
   "$schema": "http://json-schema.org/schema",

--- a/packages/expo/src/executors/start/schema.json
+++ b/packages/expo/src/executors/start/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "cli": "nx",
   "$id": "NxExpoStart",
   "$schema": "http://json-schema.org/schema",

--- a/packages/expo/src/executors/sync-deps/schema.json
+++ b/packages/expo/src/executors/sync-deps/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "cli": "nx",
   "$id": "NxExpoSyncDeps",
   "$schema": "http://json-schema.org/schema",

--- a/packages/expo/src/executors/update/schema.json
+++ b/packages/expo/src/executors/update/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "$schema": "http://json-schema.org/schema",
   "$id": "NxExpoEasUpdate",
   "cli": "nx",

--- a/packages/jest/src/executors/jest/schema.json
+++ b/packages/jest/src/executors/jest/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "title": "Jest Builder",
   "description": "Jest target options for Build Facade.",
   "cli": "nx",
@@ -66,7 +68,14 @@
     "bail": {
       "alias": "b",
       "description": "Exit the test suite immediately after `n` number of failing tests. (https://jestjs.io/docs/cli#--bail)",
-      "oneOf": [{ "type": "number" }, { "type": "boolean" }]
+      "oneOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
     },
     "ci": {
       "description": "Whether to run Jest in continuous integration (CI) mode. This option is on by default in most popular CI environments. It will prevent snapshots from being written unless explicitly requested. (https://jestjs.io/docs/cli#--ci)",
@@ -88,7 +97,14 @@
     "maxWorkers": {
       "alias": "w",
       "description": "Specifies the maximum number of workers the worker-pool will spawn for running tests. This defaults to the number of the cores available on your machine. Useful for CI. (its usually best not to override this default) (https://jestjs.io/docs/cli#--maxworkersnumstring)",
-      "oneOf": [{ "type": "number" }, { "type": "string" }]
+      "oneOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "onlyChanged": {
       "alias": "o",

--- a/packages/js/src/executors/node/schema.json
+++ b/packages/js/src/executors/node/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "$schema": "http://json-schema.org/schema",
   "cli": "nx",
   "title": "Node executor",

--- a/packages/js/src/executors/swc/schema.json
+++ b/packages/js/src/executors/swc/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "$schema": "http://json-schema.org/schema",
   "cli": "nx",
   "title": "Typescript Build Target",

--- a/packages/js/src/executors/tsc/schema.json
+++ b/packages/js/src/executors/tsc/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "title": "Typescript Build Target",
   "description": "Builds using TypeScript.",
   "cli": "nx",

--- a/packages/linter/src/executors/eslint/schema.json
+++ b/packages/linter/src/executors/eslint/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "$schema": "http://json-schema.org/schema",
   "title": "ESLint Lint Target",
   "description": "ESLint Lint Target.",

--- a/packages/linter/src/executors/lint/schema.json
+++ b/packages/linter/src/executors/lint/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "$schema": "http://json-schema.org/schema",
   "title": "Lint Target",
   "description": "Linter.",

--- a/packages/next/src/executors/build/schema.json
+++ b/packages/next/src/executors/build/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "$schema": "http://json-schema.org/schema",
   "cli": "nx",
   "title": "Next Build",
@@ -23,7 +25,6 @@
           "replace": {
             "type": "string",
             "description": "The file to be replaced.",
-
             "x-completion-type": "file"
           },
           "with": {

--- a/packages/next/src/executors/export/schema.json
+++ b/packages/next/src/executors/export/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "cli": "nx",
   "title": "Next Export",
   "description": "Export a Next.js application. The exported application is located at `dist/$outputPath/exported`.",

--- a/packages/next/src/executors/server/schema.json
+++ b/packages/next/src/executors/server/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "cli": "nx",
   "title": "Next Serve",
   "description": "Serve a Next.js app.",

--- a/packages/node/src/executors/node/schema.json
+++ b/packages/node/src/executors/node/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "$schema": "http://json-schema.org/schema",
   "cli": "nx",
   "title": "Node executor",

--- a/packages/node/src/executors/webpack/schema.json
+++ b/packages/node/src/executors/webpack/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "title": "Node Application Build Target",
   "description": "Node application build target options for Build Facade.",
   "cli": "nx",

--- a/packages/nx-plugin/migrations.json
+++ b/packages/nx-plugin/migrations.json
@@ -26,6 +26,12 @@
       "version": "14.2.3-beta.0",
       "description": "Adds @swc/core and @swc-node as a dev dep if you are using them (repeated due to bad version on earlier migration)",
       "factory": "./src/migrations/update-14-1-9/add-swc-deps-if-needed"
+    },
+    "update-15-0-0": {
+      "cli": "nx",
+      "version": "15.0.0-beta.0",
+      "description": "Migrates executor schema files to v2",
+      "factory": "./src/migrations/update-15-0-0/specify-output-capture"
     }
   }
 }

--- a/packages/nx-plugin/src/executors/e2e/schema.json
+++ b/packages/nx-plugin/src/executors/e2e/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "title": "Nx Plugin Playground Target",
   "description": "Creates a playground for a Nx Plugin.",
   "cli": "nx",
@@ -21,7 +23,6 @@
       "x-completion-type": "file",
       "x-completion-glob": "tsconfig.*.json"
     },
-
     "codeCoverage": {
       "description": "Indicates that test coverage information should be collected and reported in the output. (https://jestjs.io/docs/cli#--coverageboolean)",
       "type": "boolean",
@@ -66,7 +67,14 @@
     "bail": {
       "alias": "b",
       "description": "Exit the test suite immediately after `n` number of failing tests. (https://jestjs.io/docs/cli#--bail)",
-      "oneOf": [{ "type": "number" }, { "type": "boolean" }]
+      "oneOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
     },
     "ci": {
       "description": "Whether to run Jest in continuous integration (CI) mode. This option is on by default in most popular CI environments. It will prevent snapshots from being written unless explicitly requested. (https://jestjs.io/docs/cli#--ci)",
@@ -88,7 +96,14 @@
     "maxWorkers": {
       "alias": "w",
       "description": "Specifies the maximum number of workers the worker-pool will spawn for running tests. This defaults to the number of the cores available on your machine. Useful for CI. (its usually best not to override this default) (https://jestjs.io/docs/cli#--maxworkersnumstring)",
-      "oneOf": [{ "type": "number" }, { "type": "string" }]
+      "oneOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "onlyChanged": {
       "alias": "o",

--- a/packages/nx-plugin/src/generators/executor/files/executor/__fileName__/schema.json__tmpl__
+++ b/packages/nx-plugin/src/generators/executor/files/executor/__fileName__/schema.json__tmpl__
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema",
+  "version": 2,
   "cli": "nx",
   "title": "<%= className %> executor",
   "description": "",

--- a/packages/nx-plugin/src/migrations/update-15-0-0/specify-output-capture.spec.ts
+++ b/packages/nx-plugin/src/migrations/update-15-0-0/specify-output-capture.spec.ts
@@ -1,0 +1,66 @@
+import { readJson, updateJson } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { Linter } from '@nrwl/linter';
+import { ExecutorConfig } from 'nx/src/config/misc-interfaces';
+import pluginGenerator from '../../generators/plugin/plugin';
+import update from './specify-output-capture';
+
+const schemaPath = `libs/plugin/src/executors/build/schema.json`;
+
+describe('update-14-2-0-split-create-empty-tree', () => {
+  it('should not change outputCapture if already present', async () => {
+    const { tree } = await createTreeWithBoilerplate();
+    updateJson(tree, schemaPath, (json) => {
+      delete json.version;
+      json.outputCapture = 'pipe';
+      return json;
+    });
+    await update(tree);
+    expect(
+      readJson<ExecutorConfig['schema']>(tree, schemaPath).version
+    ).toEqual(2);
+    expect(
+      readJson<ExecutorConfig['schema']>(tree, schemaPath).outputCapture
+    ).toEqual('pipe');
+  });
+
+  it('should not set outputCapture if version is 2', async () => {
+    const { tree } = await createTreeWithBoilerplate();
+    await update(tree);
+    expect(
+      readJson<ExecutorConfig['schema']>(tree, schemaPath).version
+    ).toEqual(2);
+    expect(
+      readJson<ExecutorConfig['schema']>(tree, schemaPath).outputCapture
+    ).toBeUndefined();
+  });
+
+  it('should set outputCapture if version is null', async () => {
+    const { tree } = await createTreeWithBoilerplate();
+    updateJson(tree, schemaPath, (json) => {
+      delete json.version;
+      return json;
+    });
+    await update(tree);
+    expect(
+      readJson<ExecutorConfig['schema']>(tree, schemaPath).version
+    ).toEqual(2);
+    expect(
+      readJson<ExecutorConfig['schema']>(tree, schemaPath).outputCapture
+    ).toEqual('direct-nodejs');
+  });
+});
+
+async function createTreeWithBoilerplate() {
+  const tree = createTreeWithEmptyWorkspace();
+  await pluginGenerator(tree, {
+    name: 'plugin',
+    compiler: 'tsc',
+    linter: Linter.EsLint,
+    skipFormat: false,
+    skipLintChecks: false,
+    skipTsConfig: false,
+    unitTestRunner: 'jest',
+  });
+  return { tree };
+}

--- a/packages/nx-plugin/src/migrations/update-15-0-0/specify-output-capture.ts
+++ b/packages/nx-plugin/src/migrations/update-15-0-0/specify-output-capture.ts
@@ -40,16 +40,17 @@ export default async function update(tree: Tree): Promise<void> {
           const schemaPath = joinPathFragments(root, entry.schema);
           if (tree.exists(schemaPath)) {
             updateJson(tree, schemaPath, (json: ExecutorConfig['schema']) => {
-              console.log(json);
-              return json.version
-                ? json
-                : {
-                    version: 2,
-                    outputCapture: json.outputCapture
-                      ? json.outputCapture
-                      : 'direct-nodejs',
-                    ...json,
-                  };
+              if (json.version) {
+                return json;
+              } else {
+                const newProperties: Partial<ExecutorConfig['schema']> = {
+                  version: 2,
+                };
+                if (!json.outputCapture) {
+                  newProperties.outputCapture = 'direct-nodejs';
+                }
+                return { ...newProperties, ...json };
+              }
             });
           }
         }

--- a/packages/nx-plugin/src/migrations/update-15-0-0/specify-output-capture.ts
+++ b/packages/nx-plugin/src/migrations/update-15-0-0/specify-output-capture.ts
@@ -1,0 +1,60 @@
+import {
+  Tree,
+  getProjects,
+  joinPathFragments,
+  ExecutorsJson,
+  updateJson,
+  formatFiles,
+  readJson,
+} from '@nrwl/devkit';
+import { ExecutorConfig } from 'nx/src/config/misc-interfaces';
+import { PackageJson } from 'nx/src/utils/package-json';
+
+export default async function update(tree: Tree): Promise<void> {
+  for (const [project, { root }] of getProjects(tree)) {
+    const packageJsonPath = joinPathFragments(root, 'package.json');
+    if (!tree.exists(packageJsonPath)) {
+      continue;
+    }
+    const packageJson = readJson<PackageJson>(tree, packageJsonPath);
+    if (!packageJson.executors && !packageJson.builders) {
+      continue;
+    }
+    const paths = [packageJson.executors, packageJson.builders].filter(Boolean);
+    for (const collectionPathSegment of paths) {
+      const collectionPath = joinPathFragments(root, collectionPathSegment);
+      if (!tree.exists(collectionPath)) {
+        continue;
+      }
+      const collectionFile: ExecutorsJson = readJson(tree, collectionPath);
+
+      const collections = [
+        collectionFile.builders,
+        collectionFile.executors,
+      ].filter(Boolean);
+      for (const collection of collections) {
+        if (!collection) {
+          continue;
+        }
+        for (const entry of Object.values(collection)) {
+          const schemaPath = joinPathFragments(root, entry.schema);
+          if (tree.exists(schemaPath)) {
+            updateJson(tree, schemaPath, (json: ExecutorConfig['schema']) => {
+              console.log(json);
+              return json.version
+                ? json
+                : {
+                    version: 2,
+                    outputCapture: json.outputCapture
+                      ? json.outputCapture
+                      : 'direct-nodejs',
+                    ...json,
+                  };
+            });
+          }
+        }
+      }
+    }
+  }
+  await formatFiles(tree);
+}

--- a/packages/nx/src/config/misc-interfaces.ts
+++ b/packages/nx/src/config/misc-interfaces.ts
@@ -7,6 +7,7 @@ import {
 } from './workspace-json-project-json';
 
 import type { NxJsonConfiguration } from './nx-json';
+import { Schema } from '../utils/params';
 /**
  * A callback function that is executed after changes are made to the file system
  */
@@ -89,8 +90,7 @@ export interface ExecutorConfig {
   schema: {
     version?: number;
     outputCapture?: OutputCaptureMethod;
-    properties: any;
-  };
+  } & Schema;
   hasherFactory?: () => CustomHasher;
   implementationFactory: () => Executor;
   batchImplementationFactory?: () => TaskGraphExecutor;

--- a/packages/nx/src/config/misc-interfaces.ts
+++ b/packages/nx/src/config/misc-interfaces.ts
@@ -30,6 +30,8 @@ export interface GeneratorsJsonEntry {
   'x-type'?: 'library' | 'application';
 }
 
+export type OutputCaptureMethod = 'direct-nodejs' | 'pipe';
+
 export interface ExecutorsJsonEntry {
   schema: string;
   implementation: string;
@@ -84,7 +86,11 @@ export interface ExecutorsJson {
 }
 
 export interface ExecutorConfig {
-  schema: any;
+  schema: {
+    version?: number;
+    outputCapture?: OutputCaptureMethod;
+    properties: any;
+  };
   hasherFactory?: () => CustomHasher;
   implementationFactory: () => Executor;
   batchImplementationFactory?: () => TaskGraphExecutor;

--- a/packages/nx/src/config/workspaces.ts
+++ b/packages/nx/src/config/workspaces.ts
@@ -144,10 +144,8 @@ export class Workspaces {
       );
       const executorsDir = path.dirname(executorsFilePath);
       const schemaPath = path.join(executorsDir, executorConfig.schema || '');
-      const schema = readJsonFile(schemaPath);
-      if (!schema.properties || typeof schema.properties !== 'object') {
-        schema.properties = {};
-      }
+      const schema = normalizeExecutorSchema(readJsonFile(schemaPath));
+
       const implementationFactory = this.getImplementationFactory<Executor>(
         executorConfig.implementation,
         executorsDir
@@ -383,6 +381,16 @@ export class Workspaces {
     );
     return resolveNewFormatWithInlineProjects(rawWorkspace, this.root);
   }
+}
+
+function normalizeExecutorSchema(schema: any): ExecutorConfig['schema'] {
+  const version = (schema.version ??= 1);
+  return {
+    properties:
+      (!schema.properties || typeof schema.properties !== 'object') ?? {},
+    version,
+    outputCapture: version < 2 ? 'direct-nodejs' : 'pipe',
+  };
 }
 
 function assertValidWorkspaceConfiguration(

--- a/packages/nx/src/config/workspaces.ts
+++ b/packages/nx/src/config/workspaces.ts
@@ -383,13 +383,19 @@ export class Workspaces {
   }
 }
 
-function normalizeExecutorSchema(schema: any): ExecutorConfig['schema'] {
+function normalizeExecutorSchema(
+  schema: Partial<ExecutorConfig['schema']>
+): ExecutorConfig['schema'] {
   const version = (schema.version ??= 1);
   return {
-    properties:
-      (!schema.properties || typeof schema.properties !== 'object') ?? {},
     version,
-    outputCapture: version < 2 ? 'direct-nodejs' : 'pipe',
+    outputCapture:
+      schema.outputCapture ?? version < 2 ? 'direct-nodejs' : 'pipe',
+    properties:
+      !schema.properties || typeof schema.properties !== 'object'
+        ? {}
+        : schema.properties,
+    ...schema,
   };
 }
 

--- a/packages/nx/src/executors/noop/schema.json
+++ b/packages/nx/src/executors/noop/schema.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "title": "Noop",
   "description": "An executor that does nothing",
   "type": "object",

--- a/packages/nx/src/executors/run-commands/schema.json
+++ b/packages/nx/src/executors/run-commands/schema.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "title": "Run Commands",
   "description": "Run any custom commands with Nx.",
   "type": "object",

--- a/packages/nx/src/executors/run-script/schema.json
+++ b/packages/nx/src/executors/run-script/schema.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "title": "Run Script",
   "description": "Run any NPM script of a project in the project's root directory.",
   "type": "object",

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -432,9 +432,15 @@ export class TaskOrchestrator {
 
   private pipeOutputCapture(task: Task) {
     try {
+      const { schema } = getExecutorForTask(
+        task,
+        this.workspace,
+        this.projectGraph,
+        this.nxJson
+      );
+
       return (
-        getExecutorForTask(task, this.workspace, this.projectGraph, this.nxJson)
-          .schema.outputCapture === 'pipe' ||
+        schema.outputCapture === 'pipe' ||
         process.env.NX_STREAM_OUTPUT === 'true'
       );
     } catch (e) {

--- a/packages/nx/src/tasks-runner/tasks-schedule.spec.ts
+++ b/packages/nx/src/tasks-runner/tasks-schedule.spec.ts
@@ -3,6 +3,7 @@ import { Workspaces } from '../config/workspaces';
 import { removeTasksFromTaskGraph } from './utils';
 import { Task, TaskGraph } from '../config/task-graph';
 import { ProjectGraph } from '../config/project-graph';
+import { ExecutorConfig } from '../config/misc-interfaces';
 
 function createMockTask(id: string): Task {
   const [project, target] = id.split(':');
@@ -44,10 +45,13 @@ describe('TasksSchedule', () => {
     const workspace: Partial<Workspaces> = {
       readExecutor() {
         return {
-          schema: {},
+          schema: {
+            version: 2,
+            properties: {},
+          },
           implementationFactory: jest.fn(),
           batchImplementationFactory: jest.fn(),
-        };
+        } as ExecutorConfig;
       },
       readNxJson() {
         return {};

--- a/packages/react-native/src/executors/build-android/schema.json
+++ b/packages/react-native/src/executors/build-android/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "cli": "nx",
   "$id": "NxReactNativeBuildAndroid",
   "$schema": "http://json-schema.org/schema",

--- a/packages/react-native/src/executors/bundle/schema.json
+++ b/packages/react-native/src/executors/bundle/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "cli": "nx",
   "$id": "NxReactNativeBundle",
   "$schema": "http://json-schema.org/schema",

--- a/packages/react-native/src/executors/ensure-symlink/schema.json
+++ b/packages/react-native/src/executors/ensure-symlink/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "cli": "nx",
   "$id": "NxReactNativeEnsureSymlink",
   "$schema": "http://json-schema.org/schema",

--- a/packages/react-native/src/executors/run-android/schema.json
+++ b/packages/react-native/src/executors/run-android/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "cli": "nx",
   "$id": "NxReactNativeRunAndroid",
   "$schema": "http://json-schema.org/schema",

--- a/packages/react-native/src/executors/run-ios/schema.json
+++ b/packages/react-native/src/executors/run-ios/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "cli": "nx",
   "$id": "NxReactNativeRunIos",
   "$schema": "http://json-schema.org/schema",

--- a/packages/react-native/src/executors/start/schema.json
+++ b/packages/react-native/src/executors/start/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "cli": "nx",
   "$id": "NxReactNativeStart",
   "$schema": "http://json-schema.org/schema",

--- a/packages/react-native/src/executors/storybook/schema.json
+++ b/packages/react-native/src/executors/storybook/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "title": "React Native Storybook Load Stories",
   "cli": "nx",
   "description": "Load stories for react native.",

--- a/packages/react-native/src/executors/sync-deps/schema.json
+++ b/packages/react-native/src/executors/sync-deps/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "cli": "nx",
   "$id": "NxReactNativeSyncDeps",
   "$schema": "http://json-schema.org/schema",

--- a/packages/react/src/executors/module-federation-dev-server/schema.json
+++ b/packages/react/src/executors/module-federation-dev-server/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "title": "Module Federation Dev Server",
   "description": "Serve a web application.",
   "cli": "nx",

--- a/packages/rollup/src/executors/rollup/schema.json
+++ b/packages/rollup/src/executors/rollup/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "title": "Web Library Rollup Target (Experimental)",
   "description": "Packages a library for different web usages (ESM, CommonJS).",
   "cli": "nx",

--- a/packages/storybook/src/executors/build-storybook/schema.json
+++ b/packages/storybook/src/executors/build-storybook/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "title": "Storybook Builder",
   "cli": "nx",
   "description": "Build storybook in production mode.",

--- a/packages/storybook/src/executors/storybook/schema.json
+++ b/packages/storybook/src/executors/storybook/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "title": "Storybook Dev Builder",
   "cli": "nx",
   "description": "Serve up storybook in development mode.",

--- a/packages/web/src/executors/dev-server/schema.json
+++ b/packages/web/src/executors/dev-server/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "title": "Web Dev Server",
   "description": "Serve a web application.",
   "cli": "nx",

--- a/packages/web/src/executors/file-server/schema.json
+++ b/packages/web/src/executors/file-server/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "title": "File Server",
   "description": "Serve a web application from a folder.",
   "type": "object",

--- a/packages/web/src/executors/rollup/schema.json
+++ b/packages/web/src/executors/rollup/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "title": "Web Library Rollup Target (Experimental)",
   "description": "Packages a library for different web usages (`UMD`, `ESM`, `CJS`).",
   "cli": "nx",

--- a/packages/web/src/executors/webpack/schema.json
+++ b/packages/web/src/executors/webpack/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "title": "Webpack Executor",
   "description": "Builds web applications using webpack.",
   "cli": "nx",

--- a/packages/webpack/src/executors/dev-server/schema.json
+++ b/packages/webpack/src/executors/dev-server/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "title": "Web Dev Server",
   "description": "Serve a web application.",
   "cli": "nx",

--- a/packages/webpack/src/executors/webpack/schema.json
+++ b/packages/webpack/src/executors/webpack/schema.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "outputCapture": "direct-nodejs",
   "title": "Webpack Executor",
   "description": "Builds web applications using webpack.",
   "cli": "nx",

--- a/packages/workspace/src/executors/counter/schema.json
+++ b/packages/workspace/src/executors/counter/schema.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "title": "Counter",
   "description": "A dummy executor useful for E2E tests.",
   "type": "object",

--- a/packages/workspace/src/executors/run-commands/schema.json
+++ b/packages/workspace/src/executors/run-commands/schema.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "title": "Run Commands",
   "description": "Run any custom commands with Nx.",
   "type": "object",

--- a/packages/workspace/src/executors/run-script/schema.json
+++ b/packages/workspace/src/executors/run-script/schema.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "title": "Run Script",
   "description": "Run any NPM script of a project in the project's root directory.",
   "type": "object",


### PR DESCRIPTION
BREAKING CHANGE: Swaps from direct-nodejs to pipe for default output capture mechanism. Less accurate for executors that don't use child process, but still works for generic case. Previous behaviour still available through opt-in
