### PR TITLE
fix(core): drain stdout before exit in print-affected

### DIFF
--- a/packages/nx/src/command-line/affected.ts
+++ b/packages/nx/src/command-line/affected.ts
@@ -130,6 +130,7 @@ export async function affected(
         break;
       }
     }
+    await output.drain();
   } catch (e) {
     printError(e, args.verbose);
     process.exit(1);

--- a/packages/nx/src/utils/output.ts
+++ b/packages/nx/src/utils/output.ts
@@ -267,6 +267,16 @@ class CLIOutput {
 
     this.addNewline();
   }
+
+  drain(): Promise<void> {
+    return new Promise((resolve) => {
+      if (process.stdout.writableNeedDrain) {
+        process.stdout.once('drain', resolve);
+      } else {
+        resolve();
+      }
+    });
+  }
 }
 
 export const output = new CLIOutput();


### PR DESCRIPTION
Piping a large print-affected output to another command, such as cat or jq, resulted in broken json output as the node process can exit before the output is fully written. The process.stdout stream needs to wait to drain before process.exit.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Sometimes, when I pipe `nx print-affected --all` to another command, such as `cat` or `jq`, the output will be truncated. For example:
```
~pubrepos/nx forivall/print-affected-stdout-drain ≡
» nx print-affected --all | cat
{
  "tasks": [],
  "projects": [
    "nx-dev-feature-package-schema-viewer",
    "make-angular-cli-faster",
...
          "type": "static"
        }
      ],
      "nest": [
        {
          "source": "nest",
          "target": "node",
          "type": "impli
~pubrepos/nx forivall/print-affected-stdout-drain ≡
» nx print-affected --all | jq .
parse error: Unfinished JSON term at EOF at line 3479, column 3
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
```
» nx print-affected --all | jq .
{
  "tasks": [],
  "projects": [
    "nx-dev-feature-package-schema-viewer",
    "make-angular-cli-faster",
    "create-nx-workspace",
...
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
I don't think this issue has been reported yet.

Fixes #
