### PR TITLE
fix(react): Export remoteGenerator

### DIFF
--- a/packages/react/index.ts
+++ b/packages/react/index.ts
@@ -16,6 +16,7 @@ export { reduxGenerator } from './src/generators/redux/redux';
 export { storiesGenerator } from './src/generators/stories/stories';
 export { storybookConfigurationGenerator } from './src/generators/storybook-configuration/configuration';
 export { hostGenerator } from './src/generators/host/host';
+export { remoteGenerator } from './src/generators/remote/remote';
 export { cypressComponentConfigGenerator } from './src/generators/cypress-component-configuration/cypress-component-configuration';
 export { componentTestGenerator } from './src/generators/component-test/component-test';
 export type { SupportedStyles } from './typings/style';


### PR DESCRIPTION
hostGenerator is all ready exported and is part for same context as remoteGenerator. Need remoteGenerator for customizing and testing remotes in workspace. This is allready done in the angular plugin, but not in react.


