### PR TITLE
feat(angular): add flat for standalone library #12420

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -979,6 +979,11 @@
             "type": "boolean",
             "default": false,
             "description": "Specifies if the component should have a selector or not. Disclaimer: This option is only valid when `--standalone` is set to `true`."
+          },
+          "flat": {
+            "type": "boolean",
+            "default": false,
+            "description": "Ensure the generated standalone component is not placed in a subdirectory. Disclaimer: This option is only valid when `--standalone` is set to `true`."
           }
         },
         "additionalProperties": false,

--- a/packages/angular/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/angular/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -1,5 +1,119 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`lib --standalone should generate a library with a standalone component and have it flat 1`] = `"export * from \\"./lib/my-lib.component\\";"`;
+
+exports[`lib --standalone should generate a library with a standalone component and have it flat 2`] = `
+"import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'proj-my-lib',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './my-lib.component.html',
+  styleUrls: ['./my-lib.component.css']
+})
+export class MyLibComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}
+"
+`;
+
+exports[`lib --standalone should generate a library with a standalone component and have it flat 3`] = `
+"import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MyLibComponent } from './my-lib.component';
+
+describe('MyLibComponent', () => {
+  let component: MyLibComponent;
+  let fixture: ComponentFixture<MyLibComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ MyLibComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(MyLibComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});
+"
+`;
+
+exports[`lib --standalone should generate a library with a standalone component and have it flat with routing setup 1`] = `
+"export * from \\"./lib/my-lib.component\\";
+        export * from './lib/lib.routes'"
+`;
+
+exports[`lib --standalone should generate a library with a standalone component and have it flat with routing setup 2`] = `
+"import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'proj-my-lib',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './my-lib.component.html',
+  styleUrls: ['./my-lib.component.css']
+})
+export class MyLibComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}
+"
+`;
+
+exports[`lib --standalone should generate a library with a standalone component and have it flat with routing setup 3`] = `
+"import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MyLibComponent } from './my-lib.component';
+
+describe('MyLibComponent', () => {
+  let component: MyLibComponent;
+  let fixture: ComponentFixture<MyLibComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ MyLibComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(MyLibComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});
+"
+`;
+
+exports[`lib --standalone should generate a library with a standalone component and have it flat with routing setup 4`] = `
+"import { Route } from '@angular/router';
+    import { MyLibComponent } from './my-lib.component';
+    
+        export const myLibRoutes: Route[] = [
+          {path: '', component: MyLibComponent}
+        ];"
+`;
+
 exports[`lib --standalone should generate a library with a standalone component as entry point 1`] = `"export * from \\"./lib/my-lib/my-lib.component\\";"`;
 
 exports[`lib --standalone should generate a library with a standalone component as entry point 2`] = `

--- a/packages/angular/src/generators/library/lib/add-standalone-component.ts
+++ b/packages/angular/src/generators/library/lib/add-standalone-component.ts
@@ -16,6 +16,7 @@ export async function addStandaloneComponent(
     standalone: true,
     export: true,
     project: libraryOptions.name,
+    flat: componentOptions.flat,
   });
 
   if (libraryOptions.routing) {
@@ -28,7 +29,7 @@ export async function addStandaloneComponent(
     import { ${
       libraryOptions.standaloneComponentName
     } } from './${joinPathFragments(
-      libraryOptions.fileName,
+      componentOptions.flat ? '' : libraryOptions.fileName,
       `${libraryOptions.fileName}.component`
     )}';
     

--- a/packages/angular/src/generators/library/lib/normalize-options.ts
+++ b/packages/angular/src/generators/library/lib/normalize-options.ts
@@ -98,6 +98,7 @@ export function normalizeOptions(
     skipTests,
     selector,
     skipSelector,
+    flat,
     ...libraryOptions
   } = allNormalizedOptions;
 
@@ -115,6 +116,7 @@ export function normalizeOptions(
       skipTests,
       selector,
       skipSelector,
+      flat,
     },
   };
 }

--- a/packages/angular/src/generators/library/lib/normalized-schema.ts
+++ b/packages/angular/src/generators/library/lib/normalized-schema.ts
@@ -15,7 +15,6 @@ export interface NormalizedSchema {
     importPath?: string;
     standaloneConfig?: boolean;
     spec?: boolean;
-    flat?: boolean;
     commonModule?: boolean;
     routing?: boolean;
     lazy?: boolean;
@@ -53,5 +52,6 @@ export interface NormalizedSchema {
     skipTests?: boolean;
     selector?: string;
     skipSelector?: boolean;
+    flat?: boolean;
   };
 }

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -1456,6 +1456,52 @@ describe('lib', () => {
       ).toMatchSnapshot();
     });
 
+    it('should generate a library with a standalone component and have it flat', async () => {
+      await runLibraryGeneratorWithOpts({ standalone: true, flat: true });
+
+      expect(tree.read('libs/my-lib/src/index.ts', 'utf-8')).toMatchSnapshot();
+      expect(
+        tree.read('libs/my-lib/src/lib/my-lib.component.ts', 'utf-8')
+      ).toMatchSnapshot();
+      expect(
+        tree.read('libs/my-lib/src/lib/my-lib.component.spec.ts', 'utf-8')
+      ).toMatchSnapshot();
+    });
+
+    it('should generate a library with a standalone component and have it flat with routing setup', async () => {
+      await runLibraryGeneratorWithOpts({
+        standalone: true,
+        flat: true,
+        routing: true,
+      });
+
+      expect(tree.read('libs/my-lib/src/index.ts', 'utf-8')).toMatchSnapshot();
+      expect(
+        tree.read('libs/my-lib/src/lib/my-lib.component.ts', 'utf-8')
+      ).toMatchSnapshot();
+      expect(
+        tree.read('libs/my-lib/src/lib/my-lib.component.spec.ts', 'utf-8')
+      ).toMatchSnapshot();
+      expect(
+        tree.read('libs/my-lib/src/lib/lib.routes.ts', 'utf-8')
+      ).toMatchSnapshot();
+      expect(tree.children('libs/my-lib/src/lib')).toMatchInlineSnapshot(`
+        Array [
+          "my-lib.component.spec.ts",
+          "my-lib.component.ts",
+          "my-lib.component.css",
+          "my-lib.component.html",
+          "lib.routes.ts",
+        ]
+      `);
+      expect(tree.children('libs/my-lib/src')).toMatchInlineSnapshot(`
+        Array [
+          "index.ts",
+          "test-setup.ts",
+        ]
+      `);
+    });
+
     it('should generate a library with a standalone component as entry point with routing setup', async () => {
       await runLibraryGeneratorWithOpts({ standalone: true, routing: true });
 

--- a/packages/angular/src/generators/library/schema.json
+++ b/packages/angular/src/generators/library/schema.json
@@ -181,6 +181,11 @@
       "type": "boolean",
       "default": false,
       "description": "Specifies if the component should have a selector or not. Disclaimer: This option is only valid when `--standalone` is set to `true`."
+    },
+    "flat": {
+      "type": "boolean",
+      "default": false,
+      "description": "Ensure the generated standalone component is not placed in a subdirectory. Disclaimer: This option is only valid when `--standalone` is set to `true`."
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
When generating a standalone library the component will be placed in a subdirectory with no option to make it flat.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Allow standalone library to have a flat component

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #12420
