### PR TITLE
fix(bundling): wrong main entry path for cjs in ouput package.json

### DIFF
--- a/packages/js/src/utils/package-json/update-package-json.ts
+++ b/packages/js/src/utils/package-json/update-package-json.ts
@@ -123,7 +123,7 @@ export function getUpdatedPackageJsonContent(
   // Bundlers/Compilers like webpack, tsc, swc do not have different file extensions.
   if (hasCjsFormat) {
     const { dir, name } = parse(mainJsFile);
-    const cjsMain = `${dir}/${name}${
+    const cjsMain = `${dir ? dir : '.'}/${name}${
       options.outputFileExtensionForCjs ?? '.js'
     }`;
     packageJson.main ??= cjsMain;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When you build the project for CommonJs format, the generated `package.json` in the `dist` folder sets the `main` attribute with a leading slash when the `main.cjs` is at the root of the project folder. 

```json
{
  "name": "...",
  "version": "...",
  "main": "/main.cjs",
  "types": "./src/index.d.ts",
  "dependencies": {},
  "peerDependencies": {
    ...
  }
}
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

It should set the `main` attribute to `./main.cjs` or `main.cjs`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
