### PR TITLE
docs(nxdev): add more contrast to light mode for fences

### DIFF
--- a/nx-dev/ui-markdoc/src/lib/nodes/fence.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/nodes/fence.component.tsx
@@ -19,9 +19,9 @@ function CodeWrapper(
   fileName: string
 ): ({ children }: { children: ReactNode }) => JSX.Element {
   return ({ children }: { children: ReactNode }) => (
-    <div className="hljs not-prose my-4 w-full overflow-x-auto rounded-lg border border-slate-100 bg-slate-50/20 font-mono text-sm dark:border-slate-700 dark:bg-slate-800/60">
+    <div className="hljs not-prose my-4 w-full overflow-x-auto rounded-lg border border-slate-200 bg-slate-50/50 font-mono text-sm dark:border-slate-700 dark:bg-slate-800/60">
       {!!fileName && (
-        <div className="flex border-b border-slate-100 bg-slate-50/50 px-4 py-2 italic text-slate-400 dark:border-slate-700 dark:bg-slate-800/80 dark:text-slate-500">
+        <div className="flex border-b border-slate-100 bg-slate-50/60 px-4 py-2 italic text-slate-400 dark:border-slate-700 dark:bg-slate-800/80 dark:text-slate-500">
           {fileName}
         </div>
       )}


### PR DESCRIPTION
It adds a little bit more contrast to the code fences in light mode for nx.dev.