### PR TITLE
docs(nxdev): add terminal output option on fence

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -48,11 +48,21 @@ Cards allow to show content in a grid system with a title, a description, a type
 
 #### Code
 
-You can add specific languages, a filename and allow or not to process interpolation _(default is `false`)_ on the code snippet displayed.
+You can add specific languages and a filename on the code snippet displayed.
 
 ````
 ‎```javascript {% fileName="main.js" %}
 ‎ const code = "goes here";
+‎```
+````
+
+#### Terminal Output
+
+You can display your terminal output with a dedicated component the same way you would show code.
+
+````
+‎``` {% command="node index.js" %}
+‎ My terminal ouptput here!
 ‎```
 ````
 

--- a/nx-dev/nx-dev/styles/syntax-highlight.css
+++ b/nx-dev/nx-dev/styles/syntax-highlight.css
@@ -5,67 +5,67 @@ html {
   --interactive-muted: #64748b;
 }
 
-.hljs-comment,
-.hljs-quote {
+.hljs .hljs-comment,
+.hljs .hljs-quote {
   color: var(--interactive-muted);
 }
 
-.hljs-addition,
-.hljs-keyword,
-.hljs-selector-tag {
+.hljs .hljs-addition,
+.hljs .hljs-keyword,
+.hljs .hljs-selector-tag {
   color: #859900;
 }
 
-.hljs-doctag,
-.hljs-literal,
-.hljs-meta .hljs-meta-string,
-.hljs-number,
-.hljs-regexp,
-.hljs-string {
+.hljs .hljs-doctag,
+.hljs .hljs-literal,
+.hljs .hljs-meta .hljs .hljs-meta-string,
+.hljs .hljs-number,
+.hljs .hljs-regexp,
+.hljs .hljs-string {
   color: #2aa198;
 }
 
-.hljs-name,
-.hljs-section,
-.hljs-selector-class,
-.hljs-selector-id,
-.hljs-title {
+.hljs .hljs-name,
+.hljs .hljs-section,
+.hljs .hljs-selector-class,
+.hljs .hljs-selector-id,
+.hljs .hljs-title {
   color: #268bd2;
 }
 
-.hljs-attr,
-.hljs-attribute,
-.hljs-class .hljs-title,
-.hljs-template-variable,
-.hljs-type,
-.hljs-variable {
+.hljs .hljs-attr,
+.hljs .hljs-attribute,
+.hljs .hljs-class .hljs .hljs-title,
+.hljs .hljs-template-variable,
+.hljs .hljs-type,
+.hljs .hljs-variable {
   color: #b58900;
 }
 
-.hljs-bullet,
-.hljs-link,
-.hljs-meta,
-.hljs-meta .hljs-keyword,
-.hljs-selector-attr,
-.hljs-selector-pseudo,
-.hljs-subst,
-.hljs-symbol {
+.hljs .hljs-bullet,
+.hljs .hljs-link,
+.hljs .hljs-meta,
+.hljs .hljs-meta .hljs .hljs-keyword,
+.hljs .hljs-selector-attr,
+.hljs .hljs-selector-pseudo,
+.hljs .hljs-subst,
+.hljs .hljs-symbol {
   color: #cb4b16;
 }
 
-.hljs-built_in,
-.hljs-deletion {
+.hljs .hljs-built_in,
+.hljs .hljs-deletion {
   color: #dc322f;
 }
 
-.hljs-formula {
+.hljs .hljs-formula {
   background: #073642;
 }
 
-.hljs-emphasis {
+.hljs .hljs-emphasis {
   font-style: italic;
 }
 
-.hljs-strong {
+.hljs .hljs-strong {
   font-weight: 700;
 }

--- a/nx-dev/ui-markdoc/src/lib/nodes/fence.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/nodes/fence.component.tsx
@@ -4,6 +4,8 @@ import React, { ReactNode, useEffect, useState } from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 // @ts-ignore
 import SyntaxHighlighter from 'react-syntax-highlighter';
+import { CodeOutput } from './fences/codeOutput.component';
+import { TerminalOutput } from './fences/terminal-output.component';
 
 function resolveLanguage(lang: string) {
   switch (lang) {
@@ -15,27 +17,27 @@ function resolveLanguage(lang: string) {
       return lang;
   }
 }
-function CodeWrapper(
-  fileName: string
-): ({ children }: { children: ReactNode }) => JSX.Element {
-  return ({ children }: { children: ReactNode }) => (
-    <div className="hljs not-prose my-4 w-full overflow-x-auto rounded-lg border border-slate-200 bg-slate-50/50 font-mono text-sm dark:border-slate-700 dark:bg-slate-800/60">
-      {!!fileName && (
-        <div className="flex border-b border-slate-100 bg-slate-50/60 px-4 py-2 italic text-slate-400 dark:border-slate-700 dark:bg-slate-800/80 dark:text-slate-500">
-          {fileName}
-        </div>
-      )}
-      <div className="p-4">{children}</div>
-    </div>
-  );
+
+function CodeWrapper(options: {
+  fileName: string;
+  command: string;
+}): ({ children }: { children: ReactNode }) => JSX.Element {
+  return ({ children }: { children: ReactNode }) =>
+    options.command ? (
+      <TerminalOutput content={children} command={options.command} />
+    ) : (
+      <CodeOutput content={children} fileName={options.fileName} />
+    );
 }
 
 export function Fence({
   children,
+  command,
   fileName,
   language,
 }: {
   children: string;
+  command: string;
   fileName: string;
   language: string;
 }) {
@@ -51,7 +53,6 @@ export function Fence({
       t && clearTimeout(t);
     };
   }, [copied]);
-
   return (
     <div className="w-full">
       <div className="code-block group relative inline-flex w-auto min-w-[50%] max-w-full">
@@ -63,7 +64,7 @@ export function Fence({
         >
           <button
             type="button"
-            className="not-prose absolute top-7 right-2 flex opacity-0 transition-opacity group-hover:opacity-100"
+            className="not-prose absolute top-7 right-2 z-10 flex opacity-0 transition-opacity group-hover:opacity-100"
           >
             <ClipboardDocumentIcon className="h-4 w-4" />
             <span className="ml-1 text-xs">{copied ? 'Copied!' : 'Copy'}</span>
@@ -73,7 +74,7 @@ export function Fence({
           useInlineStyles={false}
           language={resolveLanguage(language)}
           children={children}
-          PreTag={CodeWrapper(fileName)}
+          PreTag={CodeWrapper({ fileName, command })}
         />
       </div>
     </div>

--- a/nx-dev/ui-markdoc/src/lib/nodes/fence.schema.ts
+++ b/nx-dev/ui-markdoc/src/lib/nodes/fence.schema.ts
@@ -6,6 +6,7 @@ export const fence: Schema = {
     content: { type: 'String', render: false, required: true },
     language: { type: 'String' },
     fileName: { type: 'String', default: '' },
+    command: { type: 'String', default: '' },
     process: { type: 'Boolean', render: false, default: true },
   },
   transform(node, config) {

--- a/nx-dev/ui-markdoc/src/lib/nodes/fences/codeOutput.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/nodes/fences/codeOutput.component.tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from 'react';
+
+export function CodeOutput({
+  content,
+  fileName,
+}: {
+  content: ReactNode;
+  fileName: string;
+}): JSX.Element {
+  return (
+    <div className="hljs not-prose my-4 w-full overflow-x-auto rounded-lg border border-slate-200 bg-slate-50/50 font-mono text-sm dark:border-slate-700 dark:bg-slate-800/60">
+      {!!fileName && (
+        <div className="flex border-b border-slate-200 bg-slate-50 px-4 py-2 italic text-slate-400 dark:border-slate-700 dark:bg-slate-800/80 dark:text-slate-500">
+          {fileName}
+        </div>
+      )}
+      <div className="p-4">{content}</div>
+    </div>
+  );
+}

--- a/nx-dev/ui-markdoc/src/lib/nodes/fences/terminal-output.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/nodes/fences/terminal-output.component.tsx
@@ -1,0 +1,38 @@
+import { ReactNode } from 'react';
+
+export function TerminalOutput({
+  content,
+  command,
+}: {
+  content: ReactNode;
+  command: string;
+}): JSX.Element {
+  return (
+    <div className="coding not-prose overflow-hidden rounded-lg border border-slate-200 bg-slate-50 font-mono text-xs leading-normal subpixel-antialiased dark:border-slate-700 dark:bg-slate-800">
+      <div className="relative flex justify-center border-b border-slate-200 bg-slate-100/50 p-2 text-slate-400 dark:border-slate-700 dark:bg-slate-700/50 dark:text-slate-500">
+        <div className="absolute left-2 top-3 flex items-center gap-2">
+          <span className="h-2 w-2 rounded-full bg-red-400 dark:bg-red-600" />
+          <span className="h-2 w-2 rounded-full bg-yellow-400 dark:bg-yellow-600" />
+          <span className="h-2 w-2 rounded-full bg-green-400 dark:bg-green-600" />
+        </div>
+        <span>Terminal</span>
+      </div>
+      <div className="p-4 pt-2">
+        <div className="flex items-center">
+          <p>
+            <span className="text-base text-purple-600 dark:text-fuchsia-500">
+              →
+            </span>
+            <span className="mx-1 text-green-600 dark:text-green-400">
+              {' '}
+              ~/workspace{' '}
+            </span>
+            <span>$</span>
+          </p>
+          <p className="typing mt-0.5 flex-1 pl-2">{command}</p>
+        </div>
+        <div className="not-prose mt-2 flex">{content}</div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
It adds a terminal output option on fence (code block) for nx.dev. The usage is similar than the `fileName` option.

````
‎‎``` {% command="node index.js" %}
‎ My terminal ouptput here!
‎```
````