### PR TITLE
docs(nxdev): add redirect rule for add-to-monorepo recipe

### DIFF
--- a/nx-dev/nx-dev/next.config.js
+++ b/nx-dev/nx-dev/next.config.js
@@ -171,6 +171,14 @@ module.exports = withNx({
         permanent: true,
       });
     }
+    // Recipes doc restructure
+    for (let s of Object.keys(redirectRules.recipesUrls)) {
+      rules.push({
+        source: s,
+        destination: redirectRules.recipesUrls[s],
+        permanent: true,
+      });
+    }
 
     // Landing pages
     rules.push({

--- a/nx-dev/nx-dev/redirect-rules.config.js
+++ b/nx-dev/nx-dev/redirect-rules.config.js
@@ -314,6 +314,12 @@ const cliUrls = {
   '/cli/connect-to-nx-cloud': '/nx/connect-to-nx-cloud',
   '/cli/reset': '/nx/reset',
 };
+/**
+ * Recipes
+ */
+const recipesUrls = {
+  '/recipe/adding-to-monorepo': '/recipes/adopting-nx/adding-to-monorepo',
+};
 
 /**
  * Public export API
@@ -323,5 +329,6 @@ module.exports = {
   diataxis,
   guideUrls,
   overviewUrls,
+  recipesUrls,
   schemaUrls,
 };


### PR DESCRIPTION
It adds a redirect rule to handle `/recipe/add-to-monorep` to `/recipes/adopting-nx/add-to-monorepo` on nx.dev.