### PR TITLE
docs(core): integrate terminal frame in tutorial

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -62,7 +62,15 @@ You can display your terminal output with a dedicated component the same way you
 
 ````
 ‎``` {% command="node index.js" %}
-‎ My terminal ouptput here!
+‎ My terminal output here!
+‎```
+````
+
+You can optionally also pass a `path` like
+
+````
+‎``` {% command="node index.js" path="~/myorg" %}
+‎ My terminal output here!
 ‎```
 ````
 

--- a/docs/shared/npm-tutorial/integrated.md
+++ b/docs/shared/npm-tutorial/integrated.md
@@ -168,9 +168,7 @@ npx nx build is-even
 
 Run the same command a second time and you'll see the build cache is being used:
 
-```bash
-> nx build is-even
-
+```{% command="npx nx build is-even" %}
 > nx run is-even:build
 
 Compiling TypeScript files for project "is-even"...
@@ -191,9 +189,7 @@ npx nx run-many --target=build
 
 What you would get is the following:
 
-```bash
-> npx nx run-many --target=build
-
+```{% command="npx nx run-many --target=build" %}
     ✔  nx run is-even:build  [existing outputs match the cache, left as is]
     ✔  nx run is-odd:build (906ms)
 

--- a/docs/shared/npm-tutorial/package-based.md
+++ b/docs/shared/npm-tutorial/package-based.md
@@ -165,17 +165,16 @@ npx nx build is-even
 
 Run the same command a second time and you'll see the build cache is being used:
 
-```bash
-> nx build is-even
-
+```{% command="npx nx build is-even" %}
 > nx run is-even:build
 
 > @package-based/is-even@0.0.0 build
 > tsc index.ts --outDir dist
 
- —————————————————————————————————————————————————————————————————
+—————————————————————————————————————————————————————————————————
 
- >  NX   Successfully ran target build for project is-even (1s)
+> NX Successfully ran target build for project is-even (1s)
+
 ```
 
 ## Running Multiple Tasks
@@ -188,9 +187,7 @@ npx nx run-many --target=build
 
 What you would get is the following:
 
-```bash
-> npx nx run-many --target=build
-
+```{% command="npx nx run-many --target=build" %}
     ✔  nx run is-even:build  [existing outputs match the cache, left as is]
     ✔  nx run is-odd:build (906ms)
 

--- a/nx-dev/ui-markdoc/src/lib/nodes/fence.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/nodes/fence.component.tsx
@@ -21,10 +21,15 @@ function resolveLanguage(lang: string) {
 function CodeWrapper(options: {
   fileName: string;
   command: string;
+  path: string;
 }): ({ children }: { children: ReactNode }) => JSX.Element {
   return ({ children }: { children: ReactNode }) =>
     options.command ? (
-      <TerminalOutput content={children} command={options.command} />
+      <TerminalOutput
+        content={children}
+        command={options.command}
+        path={options.path}
+      />
     ) : (
       <CodeOutput content={children} fileName={options.fileName} />
     );
@@ -33,11 +38,13 @@ function CodeWrapper(options: {
 export function Fence({
   children,
   command,
+  path,
   fileName,
   language,
 }: {
   children: string;
   command: string;
+  path: string;
   fileName: string;
   language: string;
 }) {
@@ -74,7 +81,7 @@ export function Fence({
           useInlineStyles={false}
           language={resolveLanguage(language)}
           children={children}
-          PreTag={CodeWrapper({ fileName, command })}
+          PreTag={CodeWrapper({ fileName, command, path })}
         />
       </div>
     </div>

--- a/nx-dev/ui-markdoc/src/lib/nodes/fence.schema.ts
+++ b/nx-dev/ui-markdoc/src/lib/nodes/fence.schema.ts
@@ -7,6 +7,7 @@ export const fence: Schema = {
     language: { type: 'String' },
     fileName: { type: 'String', default: '' },
     command: { type: 'String', default: '' },
+    path: { type: 'String', default: '~/workspace' },
     process: { type: 'Boolean', render: false, default: true },
   },
   transform(node, config) {

--- a/nx-dev/ui-markdoc/src/lib/nodes/fences/terminal-output.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/nodes/fences/terminal-output.component.tsx
@@ -3,12 +3,14 @@ import { ReactNode } from 'react';
 export function TerminalOutput({
   content,
   command,
+  path,
 }: {
   content: ReactNode;
   command: string;
+  path: string;
 }): JSX.Element {
   return (
-    <div className="coding not-prose overflow-hidden rounded-lg border border-slate-200 bg-slate-50 font-mono text-xs leading-normal subpixel-antialiased dark:border-slate-700 dark:bg-slate-800">
+    <div className="coding not-prose overflow-hidden rounded-lg border border-slate-200 bg-slate-50 font-mono text-sm leading-normal subpixel-antialiased dark:border-slate-700 dark:bg-slate-800">
       <div className="relative flex justify-center border-b border-slate-200 bg-slate-100/50 p-2 text-slate-400 dark:border-slate-700 dark:bg-slate-700/50 dark:text-slate-500">
         <div className="absolute left-2 top-3 flex items-center gap-2">
           <span className="h-2 w-2 rounded-full bg-red-400 dark:bg-red-600" />
@@ -19,15 +21,11 @@ export function TerminalOutput({
       </div>
       <div className="p-4 pt-2">
         <div className="flex items-center">
-          <p>
-            <span className="text-base text-purple-600 dark:text-fuchsia-500">
-              →
+          <p className="mt-0.5">
+            <span className="text-purple-600 dark:text-fuchsia-500">
+              {path}
             </span>
-            <span className="mx-1 text-green-600 dark:text-green-400">
-              {' '}
-              ~/workspace{' '}
-            </span>
-            <span>$</span>
+            <span className="mx-1 text-green-600 dark:text-green-400">❯</span>
           </p>
           <p className="typing mt-0.5 flex-1 pl-2">{command}</p>
         </div>


### PR DESCRIPTION
- adds the ability to pass a `path` to the terminal frame (default is `~/workspace`)
- removes arrow (as it is not needed, given the path)
- fixes minor misalignment between the path and command

![image](https://user-images.githubusercontent.com/542458/195695414-68802238-59ee-4725-b441-3c96713393e4.png)

- integrates the terminal into the package-based & integrated terminal