### PR TITLE
fix(core): remove warning for invalid outputs

### DIFF
--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -145,7 +145,7 @@ export function getOutputsForTargetAndConfiguration(
       validateOutputs(targetConfiguration.outputs);
     } catch (error) {
       if (error instanceof InvalidOutputsError) {
-        logger.warn(error.message);
+        // TODO(v16): start warning for invalid outputs
         targetConfiguration.outputs = transformLegacyOutputs(
           node.data.root,
           error


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

There is a warning for the old version of outputs without `{workspaceRoot}`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

There is no warning for the old version of outputs without `{workspaceRoot}`. This warning will be added later.

### Rationale
For plugins, there's no easy way to pick between the old output paths vs the new output paths with the `{workspaceRoot}`.

On older versions of Nx, adding {workspaceRoot} would be broken. On newer versions.. if I left the warning in... the old paths would trigger warnings...

Plugins can continue to generate the old paths.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
