### PR TITLE
chore(core): remove @nrwl/workspace/src/utils/app-root

### DIFF
--- a/packages/workspace/src/utils/app-root.ts
+++ b/packages/workspace/src/utils/app-root.ts
@@ -1,2 +1,0 @@
-// TODO(v15): Remove this file
-export { appRootPath, workspaceRoot } from '@nrwl/devkit';

--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -8,9 +8,9 @@ import {
   parseJson,
   ProjectGraphExternalNode,
   joinPathFragments,
+  workspaceRoot,
 } from '@nrwl/devkit';
 import { join } from 'path';
-import { workspaceRoot } from './app-root';
 import { getPath, pathExists } from './graph-utils';
 import { existsSync } from 'fs';
 import { readFileIfExisting } from 'nx/src/project-graph/file-utils';

--- a/scripts/documentation/internal-link-checker.ts
+++ b/scripts/documentation/internal-link-checker.ts
@@ -1,4 +1,4 @@
-import { workspaceRoot } from '@nrwl/workspace/src/utils/app-root';
+import { workspaceRoot } from '@nrwl/devkit';
 import { XMLParser } from 'fast-xml-parser';
 import * as glob from 'glob';
 import { readFileSync } from 'node:fs';


### PR DESCRIPTION
BREAKING CHANGES: importing @nrwl/workspace/src/utils/app-root will break. It has been deprecated since v13

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`@nrwl/workspace/src/utils/app-root` has been deprecated since v13.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`@nrwl/workspace/src/utils/app-root` is removed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
