### PR TITLE
fix(core): do not run postinstall unless it is the main nx package

### DIFF
--- a/packages/nx/bin/compute-project-graph.ts
+++ b/packages/nx/bin/compute-project-graph.ts
@@ -6,7 +6,7 @@ import { daemonClient } from '../src/daemon/client/client';
 
 (async () => {
   try {
-    if (fileExists(join(workspaceRoot, 'nx.json'))) {
+    if (isMainNxPackage() && fileExists(join(workspaceRoot, 'nx.json'))) {
       try {
         await daemonClient.stop();
       } catch (e) {}
@@ -27,3 +27,11 @@ import { daemonClient } from '../src/daemon/client/client';
     }
   }
 })();
+
+function isMainNxPackage() {
+  const mainNxPath = require.resolve('nx', {
+    paths: [workspaceRoot],
+  });
+  const thisNxPath = require.resolve('nx');
+  return mainNxPath === thisNxPath;
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The postinstall script runs for all instances of Nx in a workspace.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The postinstall script only runs for the main instance of nx in a workspace, not the instances of nx that are a dependency of other packages.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
