### PR TITLE
docs(nx-cloud): resolves grammar error in get-started.md

### DIFF
--- a/docs/nx-cloud/private/get-started.md
+++ b/docs/nx-cloud/private/get-started.md
@@ -2,7 +2,7 @@
 
 Nx Cloud can be deployed to your cloud, which gives you full control of your data, with no external API calls.
 
-You can learn more about it as [nx.app/enterprise](https://nx.app/enterprise).
+You can learn more about it at [nx.app/enterprise](https://nx.app/enterprise).
 
 Nx Cloud can be deployed in two ways:
 


### PR DESCRIPTION
## Current Behavior
Incorrect grammar in statement directing users to https://nx.app/enterprise

## Expected Behavior
Correct grammar in statement directing users to https://nx.app/enterprise

## Related Issue(s)

Fixes #
