### PR TITLE
chore(repo): update monaco-editor dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -264,7 +264,7 @@
     "@headlessui/react": "^1.6.6",
     "@heroicons/react": "^2.0.10",
     "@markdoc/markdoc": "0.1.12",
-    "@monaco-editor/react": "^4.3.1",
+    "@monaco-editor/react": "^4.4.6",
     "@napi-rs/canvas": "^0.1.19",
     "@swc/helpers": "~0.4.11",
     "@tailwindcss/aspect-ratio": "^0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3045,10 +3045,10 @@
   dependencies:
     state-local "^1.0.6"
 
-"@monaco-editor/react@^4.3.1":
-  version "4.4.5"
-  resolved "https://registry.yarnpkg.com/@monaco-editor/react/-/react-4.4.5.tgz#beabe491efeb2457441a00d1c7651c653697f65b"
-  integrity sha512-IImtzU7sRc66OOaQVCG+5PFHkSWnnhrUWGBuH6zNmH2h0YgmAhcjHZQc/6MY9JWEbUtVF1WPBMJ9u1XuFbRrVA==
+"@monaco-editor/react@^4.4.6":
+  version "4.4.6"
+  resolved "https://registry.yarnpkg.com/@monaco-editor/react/-/react-4.4.6.tgz#8ae500b0edf85276d860ed702e7056c316548218"
+  integrity sha512-Gr3uz3LYf33wlFE3eRnta4RxP5FSNxiIV9ENn2D2/rN8KgGAD8ecvcITRtsbbyuOuNkwbuHYxfeaz2Vr+CtyFA==
   dependencies:
     "@monaco-editor/loader" "^1.3.2"
     prop-types "^15.7.2"


### PR DESCRIPTION
It updates `@monaco-editor/react` dependency to `4.4.6`.