### PR TITLE
chore(core): update url for updating nx

### DIFF
--- a/nx-dev/ui-home/src/lib/migrations-and-code-generation.tsx
+++ b/nx-dev/ui-home/src/lib/migrations-and-code-generation.tsx
@@ -111,7 +111,7 @@ export function MigrationsAndCodeGeneration(): JSX.Element {
                     href="https://nx.dev/core-features/automate-updating-dependencies"
                     className="ml-2 underline"
                   >
-                    https://nx.dev/using-nx/updating-nx
+                    https://nx.dev/core-features/automate-updating-dependencies
                   </a>
                 </p>
               </div>

--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -873,7 +873,7 @@ async function generateMigrationsJsonAndUpdatePackageJson(
         ...(migrations.length > 0
           ? [`- Run '${pmc.exec} nx migrate --run-migrations'`]
           : []),
-        `- To learn more go to https://nx.dev/using-nx/updating-nx`,
+        `- To learn more go to https://nx.dev/core-features/automate-updating-dependencies`,
         ...(showConnectToCloudMessage()
           ? [
               `- You may run '${pmc.run(


### PR DESCRIPTION
When running migrations, we link to https://nx.dev/using-nx/updating-nx which is redirected to https://nx.dev/core-features/automate-updating-dependencies now. This PR updates the url directly so the redirection is not hit anymore.