### PR TITLE
chore(devkit): extend devkit peer dependency on nx to v16

### DIFF
--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -35,7 +35,7 @@
     "semver": "7.3.4"
   },
   "peerDependencies": {
-    "nx": ">= 13.10 <= 15"
+    "nx": ">= 14 <= 16"
   },
   "nx-migrations": {
     "migrations": "./migrations.json"


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The peer dependency of nx in @nrwl/devkit is from 13.10 - 15

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The peer dependency of nx in @nrwl/devkit is from 14 - 16

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
