### PR TITLE
fix(js): handle different exports field shapes

### DIFF
--- a/packages/js/src/utils/package-json/update-package-json.spec.ts
+++ b/packages/js/src/utils/package-json/update-package-json.spec.ts
@@ -166,4 +166,96 @@ describe('getUpdatedPackageJsonContent', () => {
       version: '0.0.1',
     });
   });
+
+  it('should support different exports field shape', () => {
+    // exports: string
+    expect(
+      getUpdatedPackageJsonContent(
+        {
+          name: 'test',
+          version: '0.0.1',
+          exports: './custom.js',
+        },
+        {
+          main: 'proj/src/index.ts',
+          outputPath: 'dist/proj',
+          projectRoot: 'proj',
+          format: ['esm', 'cjs'],
+          outputFileExtensionForCjs: '.cjs',
+          generateExportsField: true,
+        }
+      )
+    ).toEqual({
+      name: 'test',
+      main: './src/index.cjs',
+      module: './src/index.js',
+      types: './src/index.d.ts',
+      version: '0.0.1',
+      exports: './custom.js',
+    });
+
+    // exports: { '.': string }
+    expect(
+      getUpdatedPackageJsonContent(
+        {
+          name: 'test',
+          version: '0.0.1',
+          exports: {
+            '.': './custom.js',
+          },
+        },
+        {
+          main: 'proj/src/index.ts',
+          outputPath: 'dist/proj',
+          projectRoot: 'proj',
+          format: ['esm', 'cjs'],
+          outputFileExtensionForCjs: '.cjs',
+          generateExportsField: true,
+        }
+      )
+    ).toEqual({
+      name: 'test',
+      main: './src/index.cjs',
+      module: './src/index.js',
+      types: './src/index.d.ts',
+      version: '0.0.1',
+      exports: {
+        '.': './custom.js',
+      },
+    });
+
+    // exports: { './custom': string }
+    expect(
+      getUpdatedPackageJsonContent(
+        {
+          name: 'test',
+          version: '0.0.1',
+          exports: {
+            './custom': './custom.js',
+          },
+        },
+        {
+          main: 'proj/src/index.ts',
+          outputPath: 'dist/proj',
+          projectRoot: 'proj',
+          format: ['esm', 'cjs'],
+          outputFileExtensionForCjs: '.cjs',
+          generateExportsField: true,
+        }
+      )
+    ).toEqual({
+      name: 'test',
+      main: './src/index.cjs',
+      module: './src/index.js',
+      types: './src/index.d.ts',
+      version: '0.0.1',
+      exports: {
+        '.': {
+          import: './src/index.js',
+          require: './src/index.cjs',
+        },
+        './custom': './custom.js',
+      },
+    });
+  });
 });

--- a/packages/js/src/utils/package-json/update-package-json.ts
+++ b/packages/js/src/utils/package-json/update-package-json.ts
@@ -88,10 +88,14 @@ export function getUpdatedPackageJsonContent(
     options.projectRoot
   );
   const typingsFile = `${relativeMainFileDir}${mainFile}.d.ts`;
-  const exports = {
-    '.': {},
-    ...packageJson.exports,
-  };
+
+  const exports =
+    typeof packageJson.exports === 'string'
+      ? packageJson.exports
+      : {
+          '.': {},
+          ...packageJson.exports,
+        };
 
   const mainJsFile =
     options.outputFileName ?? `${relativeMainFileDir}${mainFile}.js`;
@@ -105,7 +109,13 @@ export function getUpdatedPackageJsonContent(
       packageJson.main ??= mainJsFile;
     }
 
-    exports['.']['import'] = mainJsFile;
+    if (typeof exports !== 'string') {
+      if (typeof exports['.'] !== 'string') {
+        exports['.']['import'] ??= mainJsFile;
+      } else if (!hasCjsFormat) {
+        exports['.'] ??= mainJsFile;
+      }
+    }
   }
 
   // CJS output may have .cjs or .js file extensions.
@@ -117,7 +127,13 @@ export function getUpdatedPackageJsonContent(
       options.outputFileExtensionForCjs ?? '.js'
     }`;
     packageJson.main ??= cjsMain;
-    exports['.']['require'] = cjsMain;
+    if (typeof exports !== 'string') {
+      if (typeof exports['.'] !== 'string') {
+        exports['.']['require'] ??= cjsMain;
+      } else if (!hasEsmFormat) {
+        exports['.'] ??= cjsMain;
+      }
+    }
   }
 
   if (options.generateExportsField) {

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -37,10 +37,12 @@ export interface PackageJson {
   main?: string;
   types?: string;
   module?: string;
-  exports?: Record<
-    string,
-    { types?: string; require?: string; import?: string }
-  >;
+  exports?:
+    | string
+    | Record<
+        string,
+        string | { types?: string; require?: string; import?: string }
+      >;
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;

--- a/packages/rollup/src/executors/rollup/lib/update-package-json.ts
+++ b/packages/rollup/src/executors/rollup/lib/update-package-json.ts
@@ -54,7 +54,7 @@ export function updatePackageJson(
   packageJson.types = types;
 
   // TODO(jack): remove this for Nx 16
-  if (options.generateExportsField) {
+  if (options.generateExportsField && typeof packageJson.exports !== 'string') {
     packageJson.exports = {
       ...packageJson.exports,
       ...exports,


### PR DESCRIPTION
The `exports` field in `package.json` can have string values instead of objects, this will break if the user sets this for the `.` export.

## Current Behavior
If user has a string in exports like `exports: './index.js'` then our JS build fails.

## Expected Behavior
Custom `exports` with string should work, same with `exports: { '.': './index.js' }`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
