### PR TITLE
fix(testing): use @swc/jest if being used as transformer

### DIFF
--- a/packages/react/plugins/jest.ts
+++ b/packages/react/plugins/jest.ts
@@ -33,7 +33,7 @@ module.exports = {
     }
 
     if (JS_SOURCE_EXTENSIONS.includes(path.extname(filename))) {
-      const transformer = getJsTransform();
+      const transformer = getJsTransform(options.config?.transform ?? []);
       if (transformer) return transformer.process(src, filename, options);
     }
 
@@ -44,15 +44,17 @@ module.exports = {
   },
 };
 
-function getJsTransform() {
+function getJsTransform(transformers?: [string, string, string?]) {
   try {
-    return require('babel-jest').default;
+    if (transformers?.[1]?.includes('@swc/jest')) {
+      return require('@swc/jest').createTransformer();
+    }
   } catch {
     // ignored
   }
 
   try {
-    return require('@swc/jest').createTransformer();
+    return require('babel-jest').default.createTransformer();
   } catch {
     // ignored
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
always using babel-jest then swc/jest even if tests where using babel-jest.
babel-jest not calling `createTransformer()`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
use swc/jest when the tests are configured for swc/jest
when using babel-jest correctly call the transformer

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #11836 
Fixes #12723 
