### PR TITLE
fix(core): catch rejected promises in convertNxExecutor

### DIFF
--- a/packages/devkit/src/utils/convert-nx-executor.ts
+++ b/packages/devkit/src/utils/convert-nx-executor.ts
@@ -48,39 +48,43 @@ function toObservable<T extends { success: boolean }>(
 ): Observable<T> {
   return new (require('rxjs') as typeof import('rxjs')).Observable(
     (subscriber) => {
-      promiseOrAsyncIterator.then((value) => {
-        if (!(value as any).next) {
-          subscriber.next(value as T);
-          subscriber.complete();
-        } else {
-          let asyncIterator = value as AsyncIterableIterator<T>;
+      promiseOrAsyncIterator
+        .then((value) => {
+          if (!(value as any).next) {
+            subscriber.next(value as T);
+            subscriber.complete();
+          } else {
+            let asyncIterator = value as AsyncIterableIterator<T>;
 
-          function recurse(iterator: AsyncIterableIterator<T>) {
-            iterator
-              .next()
-              .then((result) => {
-                if (!result.done) {
-                  subscriber.next(result.value);
-                  recurse(iterator);
-                } else {
-                  if (result.value) {
+            function recurse(iterator: AsyncIterableIterator<T>) {
+              iterator
+                .next()
+                .then((result) => {
+                  if (!result.done) {
                     subscriber.next(result.value);
+                    recurse(iterator);
+                  } else {
+                    if (result.value) {
+                      subscriber.next(result.value);
+                    }
+                    subscriber.complete();
                   }
-                  subscriber.complete();
-                }
-              })
-              .catch((e) => {
-                subscriber.error(e);
-              });
+                })
+                .catch((e) => {
+                  subscriber.error(e);
+                });
+            }
+
+            recurse(asyncIterator);
+
+            return () => {
+              asyncIterator.return();
+            };
           }
-
-          recurse(asyncIterator);
-
-          return () => {
-            asyncIterator.return();
-          };
-        }
-      });
+        })
+        .catch((err) => {
+          subscriber.error(err);
+        });
     }
   );
 }

--- a/packages/nx/src/executors/utils/convert-nx-executor.ts
+++ b/packages/nx/src/executors/utils/convert-nx-executor.ts
@@ -51,39 +51,43 @@ function toObservable<T extends { success: boolean }>(
 ): Observable<T> {
   return new (require('rxjs') as typeof import('rxjs')).Observable(
     (subscriber) => {
-      promiseOrAsyncIterator.then((value) => {
-        if (!(value as any).next) {
-          subscriber.next(value as T);
-          subscriber.complete();
-        } else {
-          let asyncIterator = value as AsyncIterableIterator<T>;
+      promiseOrAsyncIterator
+        .then((value) => {
+          if (!(value as any).next) {
+            subscriber.next(value as T);
+            subscriber.complete();
+          } else {
+            let asyncIterator = value as AsyncIterableIterator<T>;
 
-          function recurse(iterator: AsyncIterableIterator<T>) {
-            iterator
-              .next()
-              .then((result) => {
-                if (!result.done) {
-                  subscriber.next(result.value);
-                  recurse(iterator);
-                } else {
-                  if (result.value) {
+            function recurse(iterator: AsyncIterableIterator<T>) {
+              iterator
+                .next()
+                .then((result) => {
+                  if (!result.done) {
                     subscriber.next(result.value);
+                    recurse(iterator);
+                  } else {
+                    if (result.value) {
+                      subscriber.next(result.value);
+                    }
+                    subscriber.complete();
                   }
-                  subscriber.complete();
-                }
-              })
-              .catch((e) => {
-                subscriber.error(e);
-              });
+                })
+                .catch((e) => {
+                  subscriber.error(e);
+                });
+            }
+
+            recurse(asyncIterator);
+
+            return () => {
+              asyncIterator.return();
+            };
           }
-
-          recurse(asyncIterator);
-
-          return () => {
-            asyncIterator.return();
-          };
-        }
-      });
+        })
+        .catch((err) => {
+          subscriber.error(err);
+        });
     }
   );
 }


### PR DESCRIPTION
## Current Behavior
If an Nx executor when wrapped as an Angular builder, errors are not caught causing the builder to hang.

This is demonstrated in this repo: https://github.com/philipjfulcher/angular-builder-uncaught-rejection

After cloning and running `npm i`, try `npx nx allof-run-commands-fails app` to see the uncaught promise rejection error. The process will not close on its own.

## Expected Behavior
If an Nx executor when wrapped as an Angular builder, errors are caught and report failure successfully.

