### PR TITLE
fix(angular): rename withEnabledBlockingInitialNavigation to withNonE…

### DIFF
--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -13,7 +13,7 @@ if (environment.production) {
 }
 
 bootstrapApplication(AppComponent, {
-  providers: [provideRouter(appRoutes, withEnabledBlockingInitialNavigation())],
+  providers: [provideRouter(appRoutes, withNonEnabledBlockingInitialNavigation())],
 }).catch((err) => console.error(err));"
 `;
 

--- a/packages/angular/src/generators/application/lib/convert-to-standalone-app.ts
+++ b/packages/angular/src/generators/application/lib/convert-to-standalone-app.ts
@@ -63,7 +63,7 @@ if (environment.production) {
 bootstrapApplication(AppComponent${
   routerModuleSetup
     ? `, {
-  providers: [provideRouter(appRoutes, withEnabledBlockingInitialNavigation())],
+  providers: [provideRouter(appRoutes, withNonEnabledBlockingInitialNavigation())],
 }`
     : ''
 }).catch((err) => console.error(err));`;

--- a/packages/angular/src/generators/host/__snapshots__/host.spec.ts.snap
+++ b/packages/angular/src/generators/host/__snapshots__/host.spec.ts.snap
@@ -31,7 +31,7 @@ if (environment.production) {
 }
 
 bootstrapApplication(AppComponent, {
-  providers: [provideRouter(appRoutes, withEnabledBlockingInitialNavigation())],
+  providers: [provideRouter(appRoutes, withNonEnabledBlockingInitialNavigation())],
 }).catch((err) => console.error(err));"
 `;
 


### PR DESCRIPTION
…nabledBlockingInitialNavigation

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Got an error when generating a new Angular application in v15:

```
'"@angular/router"' has no exported member named 'withNonEnabledBlockingInitialNavigation'. Did you mean 'withEnabledBlockingInitialNavigation'?
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
https://github.com/nrwl/nx/issues/12631

Fixes #
