### PR TITLE
fix(angular): rename withNonEnabledBlockingInitialNavigation to withEnabledBlockingInitialNavigation

### DIFF
--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`app --standalone should generate a standalone app correctly with routing 1`] = `
 "import { enableProdMode } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideRouter, withNonEnabledBlockingInitialNavigation } from '@angular/router';
+import { provideRouter, withEnabledBlockingInitialNavigation } from '@angular/router';
 import { AppComponent } from './app/app.component';
 import { environment } from './environments/environment';
 import { appRoutes } from './app/app.routes';

--- a/packages/angular/src/generators/application/lib/convert-to-standalone-app.ts
+++ b/packages/angular/src/generators/application/lib/convert-to-standalone-app.ts
@@ -49,7 +49,7 @@ const standaloneComponentMainContents = (
 import { bootstrapApplication } from '@angular/platform-browser';${
   routerModuleSetup
     ? `
-import { provideRouter, withNonEnabledBlockingInitialNavigation } from '@angular/router'`
+import { provideRouter, withEnabledBlockingInitialNavigation } from '@angular/router'`
     : ``
 };
 import { AppComponent } from './app/app.component';

--- a/packages/angular/src/generators/host/__snapshots__/host.spec.ts.snap
+++ b/packages/angular/src/generators/host/__snapshots__/host.spec.ts.snap
@@ -21,7 +21,7 @@ module.exports = withModuleFederation(config);"
 exports[`Host App Generator should generate a host with remotes using standalone components 1`] = `
 "import { enableProdMode } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideRouter, withNonEnabledBlockingInitialNavigation } from '@angular/router';
+import { provideRouter, withEnabledBlockingInitialNavigation } from '@angular/router';
 import { AppComponent } from './app/app.component';
 import { environment } from './environments/environment';
 import { appRoutes } from './app/app.routes';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
nx generates angular application with `withNonEnabledBlockingInitialNavigation` (which not exist) instead of `withEnabledBlockingInitialNavigation`.
See https://github.com/nrwl/nx/issues/12631

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
#12631 

Fixes #
#12631 