### PR TITLE
fix(react): fix minification for prod builds in with-module-federation

### DIFF
--- a/packages/react/src/module-federation/with-module-federation.ts
+++ b/packages/react/src/module-federation/with-module-federation.ts
@@ -261,7 +261,6 @@ export async function withModuleFederation(options: ModuleFederationConfig) {
 
     config.optimization = {
       runtimeChunk: false,
-      minimize: false,
     };
 
     config.experiments = {


### PR DESCRIPTION
ISSUES CLOSED: #12679

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When using the `withModuleFederation` webpack config, minification for prod builds are not happening 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Minification should remain intact from the default react webpack config for production builds.



## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
#12679