### PR TITLE
fix(angular): support serving static remotes using tuple API #12658

### DIFF
--- a/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -12,6 +12,7 @@ import { join } from 'path';
 import { executeWebpackDevServerBuilder } from '../webpack-dev-server/webpack-dev-server.impl';
 import { existsSync, readFileSync } from 'fs';
 import { readProjectsConfigurationFromProjectGraph } from 'nx/src/project-graph/project-graph';
+import { MFRemotes } from '../../utils/mf/with-module-federation';
 
 function getDynamicRemotes(
   project: ProjectConfiguration,
@@ -84,7 +85,7 @@ function getStaticRemotes(
     'module-federation.config.js'
   );
 
-  let mfeConfig: { remotes: string[] };
+  let mfeConfig: { remotes: MFRemotes };
   try {
     mfeConfig = require(mfConfigPath);
   } catch {
@@ -93,7 +94,11 @@ function getStaticRemotes(
     );
   }
 
-  const staticRemotes = mfeConfig.remotes.length > 0 ? mfeConfig.remotes : [];
+  const remotesConfig = mfeConfig.remotes.length > 0 ? mfeConfig.remotes : [];
+  const staticRemotes = remotesConfig.map((remoteDefinition) =>
+    Array.isArray(remoteDefinition) ? remoteDefinition[0] : remoteDefinition
+  );
+
   const invalidStaticRemotes = staticRemotes.filter(
     (remote) => !workspaceProjects[remote]
   );


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Tuple API is supported as an option for providing URL of the remote app, however, the static remotes in the builder does not support that api.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
module-federation-dev-server should support tuple API. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #12658
