### PR TITLE
fix(react): fixes broken links to 01-create-application

### DIFF
--- a/nx-dev/ui-common/src/lib/npx-create-nx-workspace.tsx
+++ b/nx-dev/ui-common/src/lib/npx-create-nx-workspace.tsx
@@ -600,12 +600,12 @@ export function NpxCreateNxWorkspaceAnimation({
                     First time using Nx? Check out this interactive Nx tutorial.
                     <br />
                     <a
-                      href="https://nx.dev/react-tutorial/01-create-application"
+                      href="https://nx.dev/react-tutorial/1-code-generation"
                       target="_blank"
                       rel="noreferrer"
                       className="cursor-pointer opacity-50 hover:underline hover:opacity-100"
                     >
-                      https://nx.dev/react-tutorial/01-create-application
+                      https://nx.dev/react-tutorial/1-code-generation
                     </a>
                     <br />
                     Prefer watching videos? Check out this free Nx course on

--- a/packages/cra-to-nx/README.md
+++ b/packages/cra-to-nx/README.md
@@ -45,7 +45,7 @@ nx generate lib ui-button
 
 ### Courses, guides, docs
 
-- [Follow the Nx React tutorial](https://nx.dev/react-tutorial/01-create-application)
+- [Follow the Nx React tutorial](https://nx.dev/react-tutorial/1-code-generation)
 
 - [Free Nx course on Egghead.io](https://egghead.io/playlists/scale-react-development-with-nx-4038)
 

--- a/packages/cra-to-nx/src/lib/cra-to-nx.ts
+++ b/packages/cra-to-nx/src/lib/cra-to-nx.ts
@@ -172,7 +172,7 @@ export async function createNxWorkspaceForReact(options: Record<string, any>) {
   output.note({
     title: 'First time using Nx? Check out this interactive Nx tutorial.',
     bodyLines: [
-      `https://nx.dev/react-tutorial/01-create-application`,
+      `https://nx.dev/react-tutorial/1-code-generation`,
       ` `,
       `Prefer watching videos? Check out this free Nx course on Egghead.io.`,
       `https://egghead.io/playlists/scale-react-development-with-nx-4038`,

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -1035,7 +1035,7 @@ function pointToTutorialAndCourse(preset: Preset) {
       output.addVerticalSeparator();
       output.note({
         title,
-        bodyLines: [`https://nx.dev/react-tutorial/01-create-application`],
+        bodyLines: [`https://nx.dev/react-tutorial/1-code-generation`],
       });
       break;
     case Preset.Angular:

--- a/packages/next/src/generators/application/lib/create-application-files.helpers.ts
+++ b/packages/next/src/generators/application/lib/create-application-files.helpers.ts
@@ -152,7 +152,7 @@ export function createAppJsx(name: string) {
               </svg>
             </a>
             <a
-              href="https://nx.dev/react-tutorial/01-create-application?utm_source=nx-project"
+              href="https://nx.dev/react-tutorial/1-code-generation?utm_source=nx-project"
               target="_blank"
               rel="noreferrer"
               className="list-item-link"

--- a/packages/react-native/src/generators/application/files/app/src/app/App.tsx.template
+++ b/packages/react-native/src/generators/application/files/app/src/app/App.tsx.template
@@ -132,7 +132,7 @@ export const App = () => {
                 style={[styles.listItem, styles.learning]}
                 onPress={() =>
                   Linking.openURL(
-                    'https://nx.dev/react-tutorial/01-create-application?utm_source=nx-project'
+                    'https://nx.dev/react-tutorial/1-code-generation?utm_source=nx-project'
                   )
                 }
               >

--- a/packages/react/src/generators/application/files/common/src/app/nx-welcome.tsx
+++ b/packages/react/src/generators/application/files/common/src/app/nx-welcome.tsx
@@ -565,7 +565,7 @@ export function NxWelcome({ title }: { title: string }) {
                 </svg>
               </a>
               <a
-                href="https://nx.dev/react-tutorial/01-create-application?utm_source=nx-project"
+                href="https://nx.dev/react-tutorial/1-code-generation?utm_source=nx-project"
                 target="_blank"
                 rel="noreferrer"
                 className="list-item-link"

--- a/packages/web/src/generators/application/files/app/src/app/app.element.ts__tmpl__
+++ b/packages/web/src/generators/application/files/app/src/app/app.element.ts__tmpl__
@@ -151,7 +151,7 @@ export class AppElement extends HTMLElement {
                 />
               </svg>
             </a>
-            <a href="https://nx.dev/react-tutorial/01-create-application?utm_source=nx-project" target="_blank" rel="noreferrer" class="list-item-link">
+            <a href="https://nx.dev/react-tutorial/1-code-generation?utm_source=nx-project" target="_blank" rel="noreferrer" class="list-item-link">
               <svg
                 fill="none"
                 stroke="currentColor"


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Several links to: https://nx.dev/react-tutorial/01-create-application - which is now broken

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The url for the first react lesson is now: https://nx.dev/react-tutorial/1-code-generation

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
