### PR TITLE
feat(storybook): generate typed import from storybook/react

### DIFF
--- a/packages/react/src/generators/component-story/component-story.spec.ts
+++ b/packages/react/src/generators/component-story/component-story.spec.ts
@@ -64,7 +64,6 @@ describe('react:component-story', () => {
           const Template: ComponentStory<typeof TestUiLib> = (args) => <TestUiLib {...args} />;
           
           export const Primary = Template.bind({});
-
           Primary.args = {};
           `);
       });

--- a/packages/react/src/generators/component-story/component-story.spec.ts
+++ b/packages/react/src/generators/component-story/component-story.spec.ts
@@ -52,7 +52,7 @@ describe('react:component-story', () => {
       it('should properly set up the story', () => {
         expect(formatFile`${appTree.read(storyFilePath, 'utf-8')}`)
           .toContain(formatFile`
-          import { ComponentStory, ComponentMeta } from '@storybook/react';
+          import type { ComponentStory, ComponentMeta } from '@storybook/react';
           import { TestUiLib } from './test-ui-lib';
           
           const Story: ComponentMeta<typeof TestUiLib> = {
@@ -150,7 +150,7 @@ describe('react:component-story', () => {
       it('should create a story without controls', () => {
         expect(formatFile`${appTree.read(storyFilePath, 'utf-8')}`)
           .toContain(formatFile`
-          import { ComponentStory, ComponentMeta } from '@storybook/react';
+          import type { ComponentStory, ComponentMeta } from '@storybook/react';
           import { Test } from './test-ui-lib';
           
           const Story: ComponentMeta<typeof Test> = {
@@ -201,7 +201,7 @@ describe('react:component-story', () => {
       it('should setup controls based on the component props', () => {
         expect(formatFile`${appTree.read(storyFilePath, 'utf-8')}`)
           .toContain(formatFile`
-            import { ComponentStory, ComponentMeta } from '@storybook/react';
+            import type { ComponentStory, ComponentMeta } from '@storybook/react';
             import { Test } from './test-ui-lib';
 
             const Story: ComponentMeta<typeof Test> = {
@@ -260,7 +260,7 @@ describe('react:component-story', () => {
       it('should setup controls based on the component props', () => {
         expect(formatFile`${appTree.read(storyFilePath, 'utf-8')}`)
           .toContain(formatFile`
-            import { ComponentStory, ComponentMeta } from '@storybook/react';
+            import type { ComponentStory, ComponentMeta } from '@storybook/react';
             import { Test } from './test-ui-lib';
 
             const Story: ComponentMeta<typeof Test> = {
@@ -424,7 +424,7 @@ describe('react:component-story', () => {
             it('should properly setup the controls based on the component props', () => {
               expect(formatFile`${appTree.read(storyFilePath, 'utf-8')}`)
                 .toContain(formatFile`
-            import { ComponentStory, ComponentMeta } from '@storybook/react';
+            import type { ComponentStory, ComponentMeta } from '@storybook/react';
             import { Test } from './test-ui-lib';
 
             const Story: ComponentMeta<typeof Test> = {
@@ -557,7 +557,7 @@ describe('react:component-story', () => {
             it('should properly setup the controls based on the component props', () => {
               expect(formatFile`${appTree.read(storyFilePath, 'utf-8')}`)
                 .toContain(formatFile`
-              import { ComponentStory, ComponentMeta } from '@storybook/react';
+              import type { ComponentStory, ComponentMeta } from '@storybook/react';
               import { Test } from './test-ui-lib';
   
               const Story: ComponentMeta<typeof Test> = {
@@ -621,7 +621,7 @@ describe('react:component-story', () => {
 
           expect(formatFile`${appTree.read(storyFilePathOne, 'utf-8')}`)
             .toContain(formatFile`
-            import { ComponentStory, ComponentMeta } from '@storybook/react';
+            import type { ComponentStory, ComponentMeta } from '@storybook/react';
             import { One } from './test-ui-lib';
             
             const Story: ComponentMeta<typeof One> = {
@@ -638,7 +638,7 @@ describe('react:component-story', () => {
 
           expect(formatFile`${appTree.read(storyFilePathTwo, 'utf-8')}`)
             .toContain(formatFile`
-            import { ComponentStory, ComponentMeta } from '@storybook/react';
+            import type { ComponentStory, ComponentMeta } from '@storybook/react';
             import { Two } from './test-ui-lib';
             
             const Story: ComponentMeta<typeof Two> = {
@@ -655,7 +655,7 @@ describe('react:component-story', () => {
 
           expect(formatFile`${appTree.read(storyFilePathThree, 'utf-8')}`)
             .toContain(formatFile`
-            import { ComponentStory, ComponentMeta } from '@storybook/react';
+            import type { ComponentStory, ComponentMeta } from '@storybook/react';
             import { Three } from './test-ui-lib';
             
             const Story: ComponentMeta<typeof Three> = {

--- a/packages/react/src/generators/component-story/component-story.spec.ts
+++ b/packages/react/src/generators/component-story/component-story.spec.ts
@@ -64,6 +64,7 @@ describe('react:component-story', () => {
           const Template: ComponentStory<typeof TestUiLib> = (args) => <TestUiLib {...args} />;
           
           export const Primary = Template.bind({});
+
           Primary.args = {};
           `);
       });

--- a/packages/react/src/generators/component-story/component-story.spec.ts
+++ b/packages/react/src/generators/component-story/component-story.spec.ts
@@ -687,7 +687,7 @@ describe('react:component-story', () => {
     it('should properly set up the story', () => {
       expect(formatFile`${appTree.read(storyFilePath, 'utf-8')}`)
         .toContain(formatFile`
-        import { ComponentStory, ComponentMeta } from '@storybook/react';
+        import type { ComponentStory, ComponentMeta } from '@storybook/react';
         import { TestUiLib } from './test-ui-lib';
         
         const Story: ComponentMeta<typeof TestUiLib> = {

--- a/packages/react/src/generators/component-story/files/__componentFileName__.stories.__fileExt__
+++ b/packages/react/src/generators/component-story/files/__componentFileName__.stories.__fileExt__
@@ -1,4 +1,4 @@
-<% if ( !isPlainJs ) { %>import { ComponentStory, ComponentMeta } from '@storybook/react';<% } %>
+<% if ( !isPlainJs ) { %>import type { ComponentStory, ComponentMeta } from '@storybook/react';<% } %>
 import<% if ( !isPlainJs ) { %> { <% } %> <%= componentName %> <% if ( !isPlainJs ) { %> } <% } %> from './<%= componentImportFileName %>';
 
 <% if ( isPlainJs ) { %>

--- a/packages/react/src/utils/ast-utils.ts
+++ b/packages/react/src/utils/ast-utils.ts
@@ -125,6 +125,7 @@ export function findDefaultExportDeclaration(
   }
 }
 
+// this is broken somehow, it is finding not exported stff
 export function findExportDeclarationsForJsx(
   source: ts.SourceFile
 ): Array<

--- a/packages/react/src/utils/ast-utils.ts
+++ b/packages/react/src/utils/ast-utils.ts
@@ -125,7 +125,6 @@ export function findDefaultExportDeclaration(
   }
 }
 
-// this is broken somehow, it is finding not exported stff
 export function findExportDeclarationsForJsx(
   source: ts.SourceFile
 ): Array<


### PR DESCRIPTION
Use [type-only imports](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export) for the storybook types, as they import only types.

## Current Behavior

```
ComponentStory not found in '@storybook/react'eslint[import/named](https://github.com/import-js/eslint-plugin-import/blob/v2.25.3/docs/rules/named.md)
```

## Expected Behavior
No ts warnings

## Fixes 

\# (no issue yet)
