### PR TITLE
feat(nxdev): redirects to send legacy tutorial links to new locations

### DIFF
--- a/nx-dev/nx-dev/next.config.js
+++ b/nx-dev/nx-dev/next.config.js
@@ -45,7 +45,17 @@ module.exports = withNx({
     // Tutorials
     rules.push({
       source: '/(l|latest)/(r|react)/tutorial/01-create-application',
-      destination: '/react-tutorial/01-create-application',
+      destination: '/react-tutorial/1-code-generation',
+      permanent: true,
+    });
+    rules.push({
+      source: '/react-tutorial/:slug(0.*)', // 0.* is regex for "anything starting with 0"
+      destination: '/react-tutorial/1-code-generation',
+      permanent: true,
+    });
+    rules.push({
+      source: '/react-tutorial/:slug(1[0|1|2]-.*)', // 1[0|1|2]-.* is regex for "anything starting with '10-', '11-', or '12-'"
+      destination: '/react-tutorial/1-code-generation',
       permanent: true,
     });
     rules.push({
@@ -56,6 +66,16 @@ module.exports = withNx({
     rules.push({
       source: '/(l|latest)/(n|node)/tutorial/1-code-generation',
       destination: '/node-tutorial/1-code-generation',
+      permanent: true,
+    });
+    rules.push({
+      source: '/node-tutorial/:slug(0.*)', // 0.* is regex for "anything starting with 0"
+      destination: '/node-tutorial/1-code-generation', // 1[0|1|2]-.* is regex for "anything starting with '10-', '11-', or '12-'"
+      permanent: true,
+    });
+    rules.push({
+      source: '/node-tutorial/:slug(1[0|1|2]-.*)', // 1[0|1|2].* is regex for "
+      destination: '/node-tutorial/1-code-generation', // 1[0|1|2]-.* is regex for "anything starting with '10-', '11-', or '12-'"
       permanent: true,
     });
 

--- a/nx-dev/nx-dev/next.config.js
+++ b/nx-dev/nx-dev/next.config.js
@@ -44,7 +44,7 @@ module.exports = withNx({
 
     // Tutorials
     rules.push({
-      source: '/(l|latest)/(r|react)/tutorial/01-create-application',
+      source: '/(l|latest)/(r|react)/tutorial/1-code-generation',
       destination: '/react-tutorial/1-code-generation',
       permanent: true,
     });

--- a/nx-dev/nx-dev/next.config.js
+++ b/nx-dev/nx-dev/next.config.js
@@ -49,16 +49,6 @@ module.exports = withNx({
       permanent: true,
     });
     rules.push({
-      source: '/react-tutorial/:slug(0.*)', // 0.* is regex for "anything starting with 0"
-      destination: '/react-tutorial/1-code-generation',
-      permanent: true,
-    });
-    rules.push({
-      source: '/react-tutorial/:slug(1[0|1|2]-.*)', // 1[0|1|2]-.* is regex for "anything starting with '10-', '11-', or '12-'"
-      destination: '/react-tutorial/1-code-generation',
-      permanent: true,
-    });
-    rules.push({
       source: '/(l|latest)/(a|angular)/tutorial/01-create-application',
       destination: '/angular-tutorial/01-create-application',
       permanent: true,
@@ -68,16 +58,15 @@ module.exports = withNx({
       destination: '/node-tutorial/1-code-generation',
       permanent: true,
     });
-    rules.push({
-      source: '/node-tutorial/:slug(0.*)', // 0.* is regex for "anything starting with 0"
-      destination: '/node-tutorial/1-code-generation', // 1[0|1|2]-.* is regex for "anything starting with '10-', '11-', or '12-'"
-      permanent: true,
-    });
-    rules.push({
-      source: '/node-tutorial/:slug(1[0|1|2]-.*)', // 1[0|1|2].* is regex for "
-      destination: '/node-tutorial/1-code-generation', // 1[0|1|2]-.* is regex for "anything starting with '10-', '11-', or '12-'"
-      permanent: true,
-    });
+    for (const [source, destination] of Object.entries(
+      redirectRules.tutorialRedirects
+    )) {
+      rules.push({
+        source,
+        destination,
+        permanent: true,
+      });
+    }
 
     // Storybook
     rules.push({

--- a/nx-dev/nx-dev/redirect-rules.config.js
+++ b/nx-dev/nx-dev/redirect-rules.config.js
@@ -322,6 +322,48 @@ const recipesUrls = {
 };
 
 /**
+ * Tutorial Updates
+ */
+const oldReactTutorialPaths = [
+  '/react-tutori23al/01-create-application',
+  '/react-tutorial/02-add-e2e-test',
+  '/react-tutorial/03-display-todos',
+  '/react-tutorial/04-connect-to-api',
+  '/react-tutorial/05-add-node-app',
+  '/react-tutorial/06-proxy',
+  '/react-tutorial/07-share-code',
+  '/react-tutorial/08-create-libs',
+  '/react-tutorial/09-dep-graph',
+  '/react-tutorial/10-computation-caching',
+  '/react-tutorial/11-test-affected-projects',
+  '/react-tutorial/12-summary',
+];
+const reactRedirectDestination = '/react-tutorial/1-code-generation';
+const reactTutorialRedirects = oldReactTutorialPaths.reduce((acc, path) => {
+  acc[path] = reactRedirectDestination;
+  return acc;
+}, {});
+const oldNodeTutorialPaths = [
+  '/node-tutorial/01-create-application',
+  '/node-tutorial/02-display-todos',
+  '/node-tutorial/03-share-code',
+  '/node-tutorial/04-create-libs',
+  '/node-tutorial/05-dep-graph',
+  '/node-tutorial/06-computation-caching',
+  '/node-tutorial/07-test-affected-projects',
+  '/node-tutorial/08-summary',
+];
+const nodeRedirectDestination = '/node-tutorial/1-code-generation';
+const nodeTutorialRedirects = oldNodeTutorialPaths.reduce((acc, path) => {
+  acc[path] = nodeRedirectDestination;
+  return acc;
+}, {});
+const tutorialRedirects = Object.assign(
+  reactTutorialRedirects,
+  nodeTutorialRedirects
+);
+
+/**
  * Public export API
  */
 module.exports = {
@@ -331,4 +373,5 @@ module.exports = {
   overviewUrls,
   recipesUrls,
   schemaUrls,
+  tutorialRedirects,
 };

--- a/nx-dev/nx-dev/redirect-rules.config.js
+++ b/nx-dev/nx-dev/redirect-rules.config.js
@@ -325,7 +325,7 @@ const recipesUrls = {
  * Tutorial Updates
  */
 const oldReactTutorialPaths = [
-  '/react-tutori23al/01-create-application',
+  '/react-tutorial/01-create-application',
   '/react-tutorial/02-add-e2e-test',
   '/react-tutorial/03-display-todos',
   '/react-tutorial/04-connect-to-api',

--- a/nx-dev/nx-dev/redirect-rules.config.spec.js
+++ b/nx-dev/nx-dev/redirect-rules.config.spec.js
@@ -9,10 +9,55 @@ describe('Redirect rules configuration', () => {
         ...redirectRules.guideUrls,
         ...redirectRules.overviewUrls,
         ...redirectRules.schemaUrls,
+        ...redirectRules.tutorialRedirects,
       };
 
       for (let k of Object.keys(rules)) {
         expect(k).not.toEqual(rules[k]);
+      }
+    });
+  });
+
+  describe('Tutorial redirects', () => {
+    test('old react tutorial links', () => {
+      const oldReactUrls = [
+        '/react-tutori23al/01-create-application',
+        '/react-tutorial/02-add-e2e-test',
+        '/react-tutorial/03-display-todos',
+        '/react-tutorial/04-connect-to-api',
+        '/react-tutorial/05-add-node-app',
+        '/react-tutorial/06-proxy',
+        '/react-tutorial/07-share-code',
+        '/react-tutorial/08-create-libs',
+        '/react-tutorial/09-dep-graph',
+        '/react-tutorial/10-computation-caching',
+        '/react-tutorial/11-test-affected-projects',
+        '/react-tutorial/12-summary',
+      ];
+
+      for (const url of oldReactUrls) {
+        expect(redirectRules.tutorialRedirects[url]).toEqual(
+          '/react-tutorial/1-code-generation'
+        );
+      }
+    });
+
+    test('old node tutorial links', () => {
+      const oldNodeTutorialPaths = [
+        '/node-tutorial/01-create-application',
+        '/node-tutorial/02-display-todos',
+        '/node-tutorial/03-share-code',
+        '/node-tutorial/04-create-libs',
+        '/node-tutorial/05-dep-graph',
+        '/node-tutorial/06-computation-caching',
+        '/node-tutorial/07-test-affected-projects',
+        '/node-tutorial/08-summary',
+      ];
+
+      for (const url of oldNodeTutorialPaths) {
+        expect(redirectRules.tutorialRedirects[url]).toEqual(
+          '/node-tutorial/1-code-generation'
+        );
       }
     });
   });

--- a/nx-dev/nx-dev/redirect-rules.config.spec.js
+++ b/nx-dev/nx-dev/redirect-rules.config.spec.js
@@ -21,7 +21,7 @@ describe('Redirect rules configuration', () => {
   describe('Tutorial redirects', () => {
     test('old react tutorial links', () => {
       const oldReactUrls = [
-        '/react-tutori23al/01-create-application',
+        '/react-tutorial/01-create-application',
         '/react-tutorial/02-add-e2e-test',
         '/react-tutorial/03-display-todos',
         '/react-tutorial/04-connect-to-api',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Links to legacy docs (e.g. https://nx.dev/react-tutorial/01-create-application) lead to a 404 page.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
User navigating to any old link get redirected to step 1 of the new tutorial (https://nx.dev/react-tutorial/1-code-generation).

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
