### PR TITLE
fix(expo): fixing broken tutorial link

### DIFF
--- a/packages/expo/src/generators/application/files/src/app/App.tsx.template
+++ b/packages/expo/src/generators/application/files/src/app/App.tsx.template
@@ -132,7 +132,7 @@ const App = () => {
                 style={[styles.listItem, styles.learning]}
                 onPress={() =>
                   Linking.openURL(
-                    'https://nx.dev/tutorial/01-create-application?utm_source=nx-project'
+                    'https://nx.dev/react-tutorial/1-code-generation?utm_source=nx-project'
                   )
                 }
               >


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The welcome page (when serving after initially creating an application) for expo links to an incorrect link for the docs

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The welcome page has the correct link.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
