### PR TITLE
docs(nxdev): remove nx conf banner

### DIFF
--- a/nx-dev/nx-dev/pages/index.tsx
+++ b/nx-dev/nx-dev/pages/index.tsx
@@ -1,4 +1,4 @@
-import { AnnouncementBanner, Footer, Header } from '@nrwl/nx-dev/ui-common';
+import { Footer, Header } from '@nrwl/nx-dev/ui-common';
 import {
   ExtensibleAndIntegrated,
   GettingStarted,
@@ -39,7 +39,6 @@ export default function Index(): JSX.Element {
         }}
       />
       <h1 className="sr-only">Next generation monorepo tool</h1>
-      <AnnouncementBanner />
       <Header />
       <main id="main" role="main">
         <div className="w-full">

--- a/nx-dev/ui-common/src/lib/header.tsx
+++ b/nx-dev/ui-common/src/lib/header.tsx
@@ -187,10 +187,10 @@ export function Header(): JSX.Element {
                 title="Check Nx conference"
                 className="relative hidden px-3 py-2 font-medium leading-tight hover:text-blue-500 dark:text-slate-200 dark:hover:text-sky-500 md:inline-flex"
               >
-                <span className="absolute top-0 right-0 -mt-1 -mr-1 flex h-3 w-3">
-                  <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-blue-500 opacity-75 dark:bg-sky-500" />
-                  <span className="relative inline-flex h-3 w-3 rounded-full bg-blue-500 dark:bg-sky-500" />
-                </span>
+                {/*<span className="absolute top-0 right-0 -mt-1 -mr-1 flex h-3 w-3">*/}
+                {/*  <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-blue-500 opacity-75 dark:bg-sky-500" />*/}
+                {/*  <span className="relative inline-flex h-3 w-3 rounded-full bg-blue-500 dark:bg-sky-500" />*/}
+                {/*</span>*/}
                 Nx Conf
               </a>
             </Link>


### PR DESCRIPTION
It removed the temporary announcement banner on top of nx.dev for the Nx Conf 2022.