### PR TITLE
fix(testing): update jest batch mode

### DIFF
--- a/packages/jest/src/executors/jest/jest.impl.ts
+++ b/packages/jest/src/executors/jest/jest.impl.ts
@@ -182,17 +182,17 @@ export async function batchJest(
       .map((value) => value.substring(1, value.length - 1))[0];
     selectedProjects.push(displayName);
   }
-
-  throw new Error(
-    stripIndents`Some projects do not have a "displayName" property. Jest Batch Mode requires this to be set. Please ensure this value is set. 
+  if (projectsWithNoName.length > 0) {
+    throw new Error(
+      stripIndents`Some projects do not have a "displayName" property. Jest Batch Mode requires this to be set. Please ensure this value is set. 
 
       Projects missing "displayName":
       ${projectsWithNoName.map(
         ([project, configPath]) => ` - ${project} - ${configPath}\r\n`
       )}
       You can learn more about this requirement from Jest here: https://jestjs.io/docs/cli#--selectprojects-project1--projectn`
-  );
-
+    );
+  }
   const parsedConfigs = await jestConfigParser(overrides, context, true);
 
   const { globalConfig, results } = await runCLI(


### PR DESCRIPTION
jest go burrrr now

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
jest tests are slower in Nx than the jest CLI

(shout out @Coly010 for finding the config changes)

Note:
- requires using the `NX_BATCH_MODE=true` env var to be set.
- using `--output-style=stream` looks best/is easier to see what is going on (this should be the default for batch mode)
- ISSUE: if one project fails all projects are marked as failure. this is a bug that needs to be fixed in a follow up PR)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

test are the same speed as jest cli

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

TODO
- [ ] add tests for basic usage of `batchJest`
Fixes #
