### PR TITLE
fix(core): disable ts-node warning when its using a fast transpiler

### DIFF
--- a/packages/nx/src/utils/register.ts
+++ b/packages/nx/src/utils/register.ts
@@ -36,18 +36,21 @@ export const registerTsProject = (
     // We can fall back on ts-node if its available
     const tsNodeInstalled = packageIsInstalled('ts-node/register');
     if (tsNodeInstalled) {
-      warnTsNodeUsage();
       const { register } = require('ts-node') as typeof import('ts-node');
 
       // ts-node doesn't provide a cleanup method
       registerTranspiler = () => {
-        register({
+        const service = register({
           project: tsConfigPath,
           transpileOnly: true,
           compilerOptions: {
             module: 'commonjs',
           },
         });
+        // Don't warn if a faster transpiler is enabled
+        if (!service.options.transpiler && !service.options.swc) {
+          warnTsNodeUsage();
+        }
         return () => {};
       };
     }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
If I dont have `@swc-node/register` installed, but use the [ts-node `swc`](https://typestrong.org/ts-node/docs/swc) or [`transpiler` option](https://typestrong.org/ts-node/docs/transpilers) instead, I always see a warning message.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When an alternative transpiler, such as swc is configured for ts-node, the warning should not appear.

The following tsconfig.json sections should disable the warning:
```json
  "ts-node": {
    "transpileOnly": true,
    "transpiler": "ts-node/transpilers/swc"
  }
```

```json
  "ts-node": {
    "swc": true
  }
```

```json
  "ts-node": {
    "transpileOnly": true,
    "transpiler": "sucrase/ts-node-plugin"
  }
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
