### PR TITLE
fix(misc): fix broken link on npm page

### DIFF
--- a/scripts/readme-fragments/resources.md
+++ b/scripts/readme-fragments/resources.md
@@ -3,7 +3,7 @@
 A few links to help you get started:
 
 - [Nx.Dev: Documentation, Guides, Interactive Tutorials](https://nx.dev)
-- [Tutorial: Adding Nx to an Existing Monorepo](/recipes/adopting-nx/adding-to-monorepo)
+- [Tutorial: Adding Nx to an Existing Monorepo](https://nx.dev/recipes/adopting-nx/adding-to-monorepo)
 - [Official Nx YouTube Channel](https://www.youtube.com/c/Nrwl_io)
 - [Blog Posts About Nx](https://blog.nrwl.io/nx/home)
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The page link to `Tutorial: Adding Nx to an Existing Monorepo` is broken.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The page link to `Tutorial: Adding Nx to an Existing Monorepo` works correctly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/12750
