### PR TITLE
fix(nx): checking npmPackage before accessing it

### DIFF
--- a/packages/nx/src/project-graph/affected/locators/npm-packages.ts
+++ b/packages/nx/src/project-graph/affected/locators/npm-packages.ts
@@ -31,11 +31,11 @@ export const getTouchedNpmPackages: TouchedProjectLocator<
         const npmPackage = npmPackages.find(
           (pkg) => pkg.data.packageName === c.path[1]
         );
-        
+
         if (!npmPackage) {
           continue;
         }
-        
+
         touched.push(npmPackage.name);
         // If it was a type declarations package then also mark its corresponding implementation package as affected
         if (npmPackage.name.startsWith('npm:@types/')) {

--- a/packages/nx/src/project-graph/affected/locators/npm-packages.ts
+++ b/packages/nx/src/project-graph/affected/locators/npm-packages.ts
@@ -31,6 +31,11 @@ export const getTouchedNpmPackages: TouchedProjectLocator<
         const npmPackage = npmPackages.find(
           (pkg) => pkg.data.packageName === c.path[1]
         );
+        
+        if (!npmPackage) {
+          continue;
+        }
+        
         touched.push(npmPackage.name);
         // If it was a type declarations package then also mark its corresponding implementation package as affected
         if (npmPackage.name.startsWith('npm:@types/')) {


### PR DESCRIPTION
## Current Behavior
I was trying to run the `build` script using `nx affected` command but got an `undefined` error accessing `name` property. Inspecting the stack trace I've found that the `find` result wasn't checked and when `undefined` it breaks.
You can see my error here: https://github.com/matteobruni/tsparticles/actions/runs/3310723320/jobs/5465299557#step:21:62
I've tried editing the `node_modules/nx` code directly and it works, I don't know if it's the best solution

## Expected Behavior
`nx affected` should work without errors

## Related Issue(s)
Fixes #12775 
