### PR TITLE
fix(core): add globPatternforDependencies support nx:run-commands wi…

### DIFF
--- a/packages/workspace/src/utilities/generate-globs.ts
+++ b/packages/workspace/src/utilities/generate-globs.ts
@@ -54,13 +54,16 @@ export function createGlobPatternsForDependencies(
 
     const dirsToUse = [];
     const recursiveScanDirs = (dirPath) => {
-      const children = readdirSync(dirPath);
+      const children = readdirSync(resolve(workspaceRoot, dirPath));
       for (const child of children) {
         const childPath = join(dirPath, child);
-        if (ig?.ignores(childPath) || !lstatSync(childPath).isDirectory()) {
+        if (
+          ig?.ignores(childPath) ||
+          !lstatSync(resolve(workspaceRoot, childPath)).isDirectory()
+        ) {
           continue;
         }
-        if (existsSync(join(childPath, 'ng-package.json'))) {
+        if (existsSync(join(workspaceRoot, childPath, 'ng-package.json'))) {
           dirsToUse.push(childPath);
         } else {
           recursiveScanDirs(childPath);


### PR DESCRIPTION
…th cwd option

As globPatternforDependencies expects cwd to be in workspaceRoot, it will fail if it's used in a script that is called via `nx:run-commands` with `cwd` option pointing to project. This \"fix\" resolves paths to allow the script to run even from project dir.

Closes issues: #12721

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When running a script that utilises `globPatternforDependencies` from workspace package in a target that uses `nx:run-commands` executor together with `cwd` option pointing to project root then that script will fail because it can not resolve the paths correctly.
An example would be a migrated CRA application that should run `craco start` from project root and contains a tailwind config per documentation.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Running target with `nx:run-commands` with `cwd` option should not break `globPatternforDependencies`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
Fixes #12721


EDIT(26/10/2022): Edited due to changed fix implementation
