### PR TITLE
fix(misc): resolve the esbuild outfile path to the root context

### DIFF
--- a/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
+++ b/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
@@ -1,5 +1,6 @@
 import 'dotenv/config';
 import * as chalk from 'chalk';
+import { resolve } from 'node:path';
 import type { ExecutorContext } from '@nrwl/devkit';
 import { cacheDir, joinPathFragments, logger } from '@nrwl/devkit';
 import {
@@ -89,7 +90,7 @@ export async function* esbuildExecutor(
 
               next({
                 success: true,
-                outfile: esbuildOptions.outfile,
+                outfile: resolve(context.root, esbuildOptions.outfile),
               });
 
               return result;


### PR DESCRIPTION
When running esbuild in watch mode (typically through the serve command), the output file should be resolved against the root location before returning.

BREAKING CHANGE:
The esbuild watchmode output file path is now absolute.

ISSUES CLOSED: #12687

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The outfile path of the esbuild executor is relative when running in watch mode which causes it to break when consumed by the @nrwl/js:node executor.

## Expected Behavior
The outfile path of the esbuild executor is absolute when running in watch mode which is more in line with other bundling executors (cfr. webpack). The absolute path can now be consumed by the @nrwl/js:node executor to run the produced bundle.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #12687
