### PR TITLE
fix(misc): improve print-affected perf

### DIFF
--- a/packages/nx/src/command-line/print-affected.ts
+++ b/packages/nx/src/command-line/print-affected.ts
@@ -9,6 +9,7 @@ import { Workspaces } from '../config/workspaces';
 import { Hasher } from '../hasher/hasher';
 import { hashTask } from '../hasher/hash-task';
 import { workspaceRoot } from '../utils/workspace-root';
+import { getPackageManagerCommand } from 'nx/src/utils/package-manager';
 
 export async function printAffected(
   affectedProjectsWithTargetAndConfig: ProjectGraphProjectNode[],
@@ -51,6 +52,7 @@ async function createTasks(
 ) {
   const workspaces = new Workspaces(workspaceRoot);
   const hasher = new Hasher(projectGraph, nxJson, {});
+  const execCommand = getPackageManagerCommand().exec;
 
   const tasks: Task[] = affectedProjectsWithTargetAndConfig.map(
     (affectedProject) => {
@@ -79,7 +81,7 @@ async function createTasks(
     overrides,
     target: task.target,
     hash: task.hash,
-    command: getCommandAsString(task),
+    command: getCommandAsString(execCommand, task),
     outputs: getOutputs(projectGraph.nodes, task),
   }));
 }

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -9,17 +9,14 @@ import {
   mergePluginTargetsWithNxTargets,
 } from '../utils/nx-plugin';
 import { Task, TaskGraph } from '../config/task-graph';
-import { getPackageManagerCommand } from '../utils/package-manager';
 import { ProjectGraph, ProjectGraphProjectNode } from '../config/project-graph';
 import { TargetDependencyConfig } from '../config/workspace-json-project-json';
 import { workspaceRoot } from '../utils/workspace-root';
 import { NxJsonConfiguration } from '../config/nx-json';
 import { joinPathFragments } from '../utils/path';
-import { logger } from '../utils/logger';
 import { isRelativePath } from 'nx/src/utils/fileutils';
 
-export function getCommandAsString(task: Task) {
-  const execCommand = getPackageManagerCommand().exec;
+export function getCommandAsString(execCommand: string, task: Task) {
   const args = getPrintableCommandArgsForTask(task);
   return [execCommand, 'nx', ...args].join(' ').trim();
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`nx print-affected` takes a long time getting executable commands for tasks. This was due to every single task detecting the package manager and checking the version of said package manager.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`nx print-affected` does not take a long time getting executable commands for tasks.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
