### PR TITLE
fix(core): ensure project configuration is saved as standalone when workspace.json isn't present

### DIFF
--- a/packages/nx/src/adapter/ngcli-adapter.ts
+++ b/packages/nx/src/adapter/ngcli-adapter.ts
@@ -508,7 +508,7 @@ export class NxScopedHost extends virtualFs.ScopedHost<any> {
     const projects: [string, any][] = Object.entries(configToWrite.projects);
     for (const [project, projectConfig] of projects) {
       if (!workspaceFileName) {
-        projectConfig.configFilePath ??= `${projectConfig.root}/project.json`
+        projectConfig.configFilePath ??= `${projectConfig.root}/project.json`;
       }
       if (projectConfig.configFilePath) {
         if (workspaceFileName && !isNewFormat) {

--- a/packages/nx/src/adapter/ngcli-adapter.ts
+++ b/packages/nx/src/adapter/ngcli-adapter.ts
@@ -507,6 +507,9 @@ export class NxScopedHost extends virtualFs.ScopedHost<any> {
     };
     const projects: [string, any][] = Object.entries(configToWrite.projects);
     for (const [project, projectConfig] of projects) {
+      if (!workspaceFileName) {
+        projectConfig.configFilePath ??= `${projectConfig.root}/project.json`
+      }
       if (projectConfig.configFilePath) {
         if (workspaceFileName && !isNewFormat) {
           throw new Error(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

When a `workspace.json` is absent, the ng cli adapter may fail with `Cannot find configuration`.

## Expected Behavior

The ng cli adapter will now succeed in this case.

cc/ @AgentEnder 
