### PR TITLE
feat(nextjs): bump next.js to v13.0.0

### DIFF
--- a/packages/next/migrations.json
+++ b/packages/next/migrations.json
@@ -267,6 +267,19 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "15.0.4": {
+      "version": "15.0.4-beta.1",
+      "packages": {
+        "next": {
+          "version": "13.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "eslint-config-next": {
+          "version": "13.0.0",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/next/src/utils/versions.ts
+++ b/packages/next/src/utils/versions.ts
@@ -1,7 +1,7 @@
 export const nxVersion = require('../../package.json').version;
 
-export const nextVersion = '12.3.1';
-export const eslintConfigNextVersion = '12.3.1';
+export const nextVersion = '13.0.0';
+export const eslintConfigNextVersion = '13.0.0';
 export const sassVersion = '1.55.0';
 export const lessLoader = '11.0.0';
 export const stylusLoader = '7.0.0';


### PR DESCRIPTION
bump up next.js and eslint-config-next to v13.0.0

BREAKING CHANGE:
https://nextjs.org/blog/next-13#breaking-changes

`next/image` and `next/link` have breaking changes.
Next.js community made codemod for this changes.
In Nx, had better create this patch?
Please advice

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Using Next.js v12.3.1

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Using Next.js v13.0.0

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
