### PR TITLE
fix(angular): support routes as route array type for ast parsing #12707

### DIFF
--- a/packages/angular/src/utils/nx-devkit/route-utils.spec.ts
+++ b/packages/angular/src/utils/nx-devkit/route-utils.spec.ts
@@ -1,14 +1,17 @@
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { addRoute } from './route-utils';
 
-describe('standalone component utils', () => {
+describe.each([
+  ['Route[]', 'Route'],
+  ['Routes', 'Routes'],
+])('standalone component utils - %s', (routes, routeType) => {
   it('should add a static route to the routes file', () => {
     // ARRANGE
     const tree = createTreeWithEmptyWorkspace();
     tree.write(
       'routes-file.ts',
-      `import { Route } from '@angular/router';
-      export const ROUTES: Route[] = [];`
+      `import { ${routeType} } from '@angular/router';
+      export const ROUTES: ${routes} = [];`
     );
 
     // ACT
@@ -23,9 +26,9 @@ describe('standalone component utils', () => {
 
     // ASSERT
     expect(tree.read('routes-file.ts', 'utf-8')).toMatchInlineSnapshot(`
-      "import { Route } from '@angular/router';
+      "import { ${routeType} } from '@angular/router';
       import { ROUTES } from '@proj/lib';
-            export const ROUTES: Route[] = [
+            export const ROUTES: ${routes} = [
           {path: 'test', children: ROUTES },]"
     `);
   });
@@ -35,8 +38,8 @@ describe('standalone component utils', () => {
     const tree = createTreeWithEmptyWorkspace();
     tree.write(
       'routes-file.ts',
-      `import { Route } from '@angular/router';
-      export const ROUTES: Route[] = [];`
+      `import { ${routeType} } from '@angular/router';
+      export const ROUTES: ${routes} = [];`
     );
 
     // ACT
@@ -48,8 +51,8 @@ describe('standalone component utils', () => {
 
     // ASSERT
     expect(tree.read('routes-file.ts', 'utf-8')).toMatchInlineSnapshot(`
-      "import { Route } from '@angular/router';
-            export const ROUTES: Route[] = [
+      "import { ${routeType} } from '@angular/router';
+            export const ROUTES: ${routes} = [
           {path: 'test', , loadChildren: () => import('@proj/lib').then(m => m.ROUTES) },]"
     `);
   });

--- a/packages/angular/src/utils/nx-devkit/route-utils.ts
+++ b/packages/angular/src/utils/nx-devkit/route-utils.ts
@@ -42,7 +42,7 @@ export function addRoute(
   const ast = tsquery.ast(routesFileContents);
 
   const ROUTES_ARRAY_SELECTOR =
-    'VariableDeclaration:has(ArrayType > TypeReference > Identifier[name=Route]) > ArrayLiteralExpression';
+    'VariableDeclaration:has(ArrayType > TypeReference > Identifier[name=Route], Identifier[name=Routes]) > ArrayLiteralExpression';
 
   const routesArrayNodes = tsquery(ast, ROUTES_ARRAY_SELECTOR, {
     visitAllChildren: true,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When adding routes to a route constant, we only look for `Route[]` but `Routes` is also a valid type

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Support `Routes` in AST parsing.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #12707
