### PR TITLE
fix(testing): handle trailing commas in 14.0.0 migration

### DIFF
--- a/packages/jest/src/migrations/update-14-0-0/update-jest-config-ext.ts
+++ b/packages/jest/src/migrations/update-14-0-0/update-jest-config-ext.ts
@@ -133,7 +133,10 @@ export async function updateJestConfigExt(tree: Tree) {
       for (const fileName of rootFiles) {
         if (fileName === 'tsconfig.json') {
           const filePath = joinPathFragments(projectConfig.root, fileName);
-          const tsConfig = readJson(tree, filePath);
+          const tsConfig = readJson(tree, filePath, {
+            allowTrailingComma: true,
+            disallowComments: false,
+          });
 
           if (tsConfig.references) {
             for (const { path } of tsConfig.references) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Trailing comma in tsconfig causes migrations to fail

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Trailing comma in tsconfig does not cause migrations to fail

Fixes https://github.com/nrwl/nx/issues/12736
