### PR TITLE
fix(cra-to-nx): use cross-env to ensure Windows compatibility with CRA build script

### DIFF
--- a/packages/cra-to-nx/src/lib/add-cra-commands-to-nx.ts
+++ b/packages/cra-to-nx/src/lib/add-cra-commands-to-nx.ts
@@ -6,7 +6,7 @@ export function addCRAcracoScriptsToPackageJson(appName: string) {
     ...packageJson.scripts,
     start: 'craco start',
     serve: 'npm start',
-    build: `BUILD_PATH=../../dist/apps/${appName} craco build`,
+    build: `cross-env BUILD_PATH=../../dist/apps/${appName} craco build`,
     test: 'craco test',
   };
   writeJsonSync(`apps/${appName}/package.json`, packageJson, { spaces: 2 });

--- a/packages/cra-to-nx/src/lib/cra-to-nx.ts
+++ b/packages/cra-to-nx/src/lib/cra-to-nx.ts
@@ -165,6 +165,7 @@ export async function createNxWorkspaceForReact(options: Record<string, any>) {
   addDependency('@craco/craco', true);
   addDependency('web-vitals', true);
   addDependency('jest-watch-typeahead', true); // Only for ts apps?
+  addDependency('cross-env', true);
 
   output.log({
     title: '🎉 Done!',


### PR DESCRIPTION
## Current Behavior
When using cra-to-nx, the tool generates the following build script :

`"build": "BUILD_PATH=../../dist/apps/my-react-app craco build"`

Setting environment variables this way is not supported on Windows. This PR suggests to use [cross-env](https://github.com/kentcdodds/cross-env) so that the aftermath of cra-to-nx works on Windows out of the box.