### PR TITLE
fix(testing): update tsconfig.cy.json template file for generator

### DIFF
--- a/packages/cypress/src/generators/cypress-component-project/cypress-component-project.spec.ts
+++ b/packages/cypress/src/generators/cypress-component-project/cypress-component-project.spec.ts
@@ -129,6 +129,7 @@ describe('Cypress Component Project', () => {
       '../**/*.cy.jsx',
       '../**/*.d.ts',
     ]);
+    expect(cyTsConfig.compilerOptions.outDir).toEqual('../../../dist/out-tsc');
     const libTsConfig = readJson(tree, 'libs/cool-lib/tsconfig.lib.json');
     expect(libTsConfig.exclude).toEqual(
       expect.arrayContaining([

--- a/packages/cypress/src/generators/cypress-component-project/files/cypress/tsconfig.cy.json
+++ b/packages/cypress/src/generators/cypress-component-project/files/cypress/tsconfig.cy.json
@@ -1,7 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
+    "outDir": "<%= offsetFromRoot %>../dist/out-tsc",
     "module": "commonjs",
     "types": ["cypress", "node"]
   },


### PR DESCRIPTION
## Summary
This updates the cypress component project generator to properly use the offset from root to generate the outDir field in the tsconfig.cy.json file that is created rather than a potentially incorrect static offset value.

## Current Behavior
`outDir` always outputs as `"outDir": "../../../dist/out-tsc",`

## Expected Behavior
`outDir` should use a template variable to offset from the root relative to the project you are running the generator for

## Related Issue(s)
Fixes #12846
