### PR TITLE
feat(bundling): add support only bundling in workspace libs, not npm packages

### DIFF
--- a/docs/generated/packages/esbuild.json
+++ b/docs/generated/packages/esbuild.json
@@ -250,16 +250,16 @@
             "description": "Skip type-checking via TypeScript. Skipping type-checking speeds up the build but type errors are not caught.",
             "default": false
           },
-          "updateBuildableProjectDepsInPackageJson": {
+          "thirdParty": {
             "type": "boolean",
-            "description": "Update buildable project dependencies in `package.json`.",
+            "description": "Includes third-party packages in the bundle (i.e. npm packages).",
             "default": true
           },
-          "buildableProjectDepsInPackageJsonType": {
+          "dependenciesFieldType": {
             "type": "string",
-            "description": "When `updateBuildableProjectDepsInPackageJson` is `true`, this adds dependencies to either `peerDependencies` or `dependencies`.",
+            "description": "When `bundleInternalProjectsOnly` is true, this option determines whether external packages should be in 'dependencies' or 'peerDependencies' field in the generated package.json file.",
             "enum": ["dependencies", "peerDependencies"],
-            "default": "peerDependencies"
+            "default": "dependencies"
           },
           "esbuildOptions": {
             "type": "object",

--- a/e2e/esbuild/src/esbuild.test.ts
+++ b/e2e/esbuild/src/esbuild.test.ts
@@ -4,11 +4,13 @@ import {
   cleanupProject,
   newProject,
   readFile,
+  readJson,
   runCLI,
   runCommand,
   uniq,
   updateFile,
   updateProjectConfig,
+  packageInstall,
 } from '@nrwl/e2e/utils';
 
 describe('EsBuild Plugin', () => {
@@ -65,24 +67,54 @@ describe('EsBuild Plugin', () => {
     expect(runCommand(`node dist/libs/${myPkg}/index.js`)).toMatch(/Bye/);
   }, 300_000);
 
-  it('should bundle in workspace libs', async () => {
+  it('should support bundling everything or only workspace libs', async () => {
+    packageInstall('rambda', undefined, '~7.3.0', 'prod');
+    packageInstall('lodash', undefined, '~4.14.0', 'prod');
     const parentLib = uniq('parent-lib');
     const childLib = uniq('child-lib');
     runCLI(`generate @nrwl/js:lib ${parentLib} --bundler=esbuild`);
     runCLI(`generate @nrwl/js:lib ${childLib} --buildable=false`);
     updateFile(
       `libs/${parentLib}/src/index.ts`,
-      `import '@${proj}/${childLib}';`
+      `
+        // @ts-ignore
+        import _ from 'lodash';
+        import { greet } from '@${proj}/${childLib}';
+
+        console.log(_.upperFirst('hello world'));
+        console.log(greet());
+      `
     );
     updateFile(
       `libs/${childLib}/src/index.ts`,
-      `console.log('Hello from lib');\n`
+      `
+        import { always } from 'rambda';
+        export const greet = always('Hello from child lib');
+      `
     );
 
+    // Bundle child lib and third-party packages
     runCLI(`build ${parentLib}`);
 
-    expect(runCommand(`node dist/libs/${parentLib}/index.js`)).toMatch(
-      /Hello from lib/
-    );
+    expect(
+      readJson(`dist/libs/${parentLib}/package.json`).dependencies?.['dayjs']
+    ).not.toBeDefined();
+    let runResult = runCommand(`node dist/libs/${parentLib}/index.js`);
+    expect(runResult).toMatch(/Hello world/);
+    expect(runResult).toMatch(/Hello from child lib/);
+
+    // Bundle only child lib
+    runCLI(`build ${parentLib} --third-party=false`);
+
+    expect(
+      readJson(`dist/libs/${parentLib}/package.json`).dependencies
+    ).toEqual({
+      // Don't care about the versions, just that they exist
+      rambda: expect.any(String),
+      lodash: expect.any(String),
+    });
+    runResult = runCommand(`node dist/libs/${parentLib}/index.js`);
+    expect(runResult).toMatch(/Hello world/);
+    expect(runResult).toMatch(/Hello from child lib/);
   }, 300_000);
 });

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -244,7 +244,8 @@ export function runCreatePlugin(
 export function packageInstall(
   pkg: string,
   projName?: string,
-  version = getPublishedVersion()
+  version = getPublishedVersion(),
+  mode: 'dev' | 'prod' = 'dev'
 ) {
   const cwd = projName ? `${e2eCwd}/${projName}` : tmpProjPath();
   const pm = getPackageManagerCommand({ path: cwd });
@@ -252,13 +253,16 @@ export function packageInstall(
     .split(' ')
     .map((pgk) => `${pgk}@${version}`)
     .join(' ');
-  const install = execSync(`${pm.addDev} ${pkgsWithVersions}`, {
-    cwd,
-    // stdio: [0, 1, 2],
-    stdio: ['pipe', 'pipe', 'pipe'],
-    env: process.env,
-    encoding: 'utf-8',
-  });
+  const install = execSync(
+    `${mode === 'dev' ? pm.addDev : pm.addProd} ${pkgsWithVersions}`,
+    {
+      cwd,
+      // stdio: [0, 1, 2],
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: process.env,
+      encoding: 'utf-8',
+    }
+  );
   return install ? install.toString() : '';
 }
 
@@ -853,6 +857,7 @@ export function getPackageManagerCommand({
   runNx: string;
   runNxSilent: string;
   runUninstalledPackage: string;
+  addProd: string;
   addDev: string;
   list: string;
 } {
@@ -868,6 +873,7 @@ export function getPackageManagerCommand({
       runNx: `npx nx`,
       runNxSilent: `npx nx`,
       runUninstalledPackage: `npx --yes`,
+      addProd: `npm install --legacy-peer-deps`,
       addDev: `npm install --legacy-peer-deps -D`,
       list: 'npm ls --depth 10',
     },
@@ -878,6 +884,7 @@ export function getPackageManagerCommand({
       runNx: `yarn nx`,
       runNxSilent: `yarn --silent nx`,
       runUninstalledPackage: 'npx --yes',
+      addProd: `yarn add`,
       addDev: `yarn add -D`,
       list: 'npm ls --depth 10',
     },
@@ -888,6 +895,7 @@ export function getPackageManagerCommand({
       runNx: `pnpm exec nx`,
       runNxSilent: `pnpm exec nx`,
       runUninstalledPackage: 'pnpm dlx',
+      addProd: `pnpm add`,
       addDev: `pnpm add -D`,
       list: 'npm ls --depth 10',
     },

--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.spec.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.spec.ts
@@ -35,6 +35,7 @@ describe('buildEsbuildOptions', () => {
           assets: [],
           outputFileName: 'index.js',
           singleEntry: true,
+          external: [],
         },
         context
       )
@@ -49,6 +50,7 @@ describe('buildEsbuildOptions', () => {
       platform: 'browser',
       outfile: 'dist/apps/myapp/index.js',
       tsconfig: 'apps/myapp/tsconfig.app.json',
+      external: [],
       outExtension: {
         '.js': '.js',
       },
@@ -69,6 +71,7 @@ describe('buildEsbuildOptions', () => {
           assets: [],
           outputFileName: 'index.js',
           singleEntry: false,
+          external: [],
         },
         context
       )
@@ -83,6 +86,7 @@ describe('buildEsbuildOptions', () => {
       platform: 'browser',
       outdir: 'dist/apps/myapp',
       tsconfig: 'apps/myapp/tsconfig.app.json',
+      external: [],
       outExtension: {
         '.js': '.js',
       },
@@ -102,6 +106,7 @@ describe('buildEsbuildOptions', () => {
           assets: [],
           outputFileName: 'index.js',
           singleEntry: true,
+          external: [],
         },
         context
       )
@@ -116,6 +121,7 @@ describe('buildEsbuildOptions', () => {
       platform: 'browser',
       outfile: 'dist/apps/myapp/index.cjs',
       tsconfig: 'apps/myapp/tsconfig.app.json',
+      external: [],
       outExtension: {
         '.js': '.cjs',
       },
@@ -135,6 +141,7 @@ describe('buildEsbuildOptions', () => {
           assets: [],
           outputFileName: 'index.js',
           singleEntry: true,
+          external: [],
         },
         context
       )
@@ -146,6 +153,7 @@ describe('buildEsbuildOptions', () => {
       platform: 'node',
       outfile: 'dist/apps/myapp/index.cjs',
       tsconfig: 'apps/myapp/tsconfig.app.json',
+      external: [],
       outExtension: {
         '.js': '.cjs',
       },

--- a/packages/esbuild/src/executors/esbuild/lib/get-extra-dependencies.spec.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/get-extra-dependencies.spec.ts
@@ -1,0 +1,83 @@
+import { getExtraDependencies } from './get-extra-dependencies';
+
+describe('getExtraDependencies', () => {
+  it('should include npm dependencies of child libs', () => {
+    const result = getExtraDependencies('parent', {
+      nodes: {
+        parent: {
+          type: 'app',
+          name: 'parent',
+          data: {},
+        },
+        child1: {
+          type: 'lib',
+          name: 'child1',
+          data: {},
+        },
+        child2: {
+          type: 'lib',
+          name: 'child2',
+          data: {},
+        },
+      },
+      externalNodes: {
+        'npm:react': {
+          type: 'npm',
+          name: 'npm:react',
+          data: { packageName: 'react', version: '18.0.0' },
+        },
+        'npm:axios': {
+          type: 'npm',
+          name: 'npm:axios',
+          data: { packageName: 'axios', version: '1.0.0' },
+        },
+        'npm:dayjs': {
+          type: 'npm',
+          name: 'npm:dayjs',
+          data: { packageName: 'dayjs', version: '1.11.0' },
+        },
+      },
+      dependencies: {
+        parent: [
+          { source: 'parent', target: 'child1', type: 'static' },
+          { source: 'parent', target: 'npm:react', type: 'static' },
+        ],
+        child1: [
+          { source: 'child1', target: 'child2', type: 'static' },
+          { source: 'child1', target: 'npm:axios', type: 'static' },
+        ],
+        child2: [{ source: 'child2', target: 'npm:dayjs', type: 'static' }],
+      },
+    });
+
+    expect(result).toEqual([
+      {
+        name: 'npm:react',
+        outputs: [],
+        node: {
+          type: 'npm',
+          name: 'npm:react',
+          data: { packageName: 'react', version: '18.0.0' },
+        },
+      },
+      {
+        name: 'npm:axios',
+        outputs: [],
+        node: {
+          type: 'npm',
+          name: 'npm:axios',
+          data: { packageName: 'axios', version: '1.0.0' },
+        },
+      },
+      {
+        name: 'npm:dayjs',
+        outputs: [],
+        node: {
+          type: 'npm',
+          name: 'npm:dayjs',
+          data: { packageName: 'dayjs', version: '1.11.0' },
+        },
+      },
+    ]);
+  });
+});

--- a/packages/esbuild/src/executors/esbuild/lib/get-extra-dependencies.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/get-extra-dependencies.ts
@@ -1,0 +1,38 @@
+import { ProjectGraph } from '@nrwl/devkit';
+import { DependentBuildableProjectNode } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+
+export function getExtraDependencies(
+  projectName: string,
+  graph: ProjectGraph
+): DependentBuildableProjectNode[] {
+  const deps = new Map<string, DependentBuildableProjectNode>();
+  recur(projectName);
+
+  function recur(currProjectName) {
+    const allDeps = graph.dependencies[currProjectName];
+    const externalDeps = allDeps.reduce((acc, node) => {
+      const found = graph.externalNodes[node.target];
+      if (found) acc.push(found);
+      return acc;
+    }, []);
+    const internalDeps = allDeps.reduce((acc, node) => {
+      const found = graph.nodes[node.target];
+      if (found) acc.push(found);
+      return acc;
+    }, []);
+
+    for (const externalDep of externalDeps) {
+      deps.set(externalDep.name, {
+        name: externalDep.name,
+        outputs: [],
+        node: externalDep,
+      });
+    }
+
+    for (const internalDep of internalDeps) {
+      recur(internalDep.name);
+    }
+  }
+
+  return Array.from(deps.values());
+}

--- a/packages/esbuild/src/executors/esbuild/lib/normalize.spec.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/normalize.spec.ts
@@ -18,6 +18,7 @@ describe('normalizeOptions', () => {
       assets: [],
       outputFileName: 'index.js',
       singleEntry: true,
+      external: [],
     });
   });
 
@@ -39,6 +40,7 @@ describe('normalizeOptions', () => {
       assets: [],
       additionalEntryPoints: ['apps/myapp/src/extra-entry.ts'],
       singleEntry: false,
+      external: [],
     });
   });
 
@@ -60,6 +62,7 @@ describe('normalizeOptions', () => {
       assets: [],
       outputFileName: 'test.js',
       singleEntry: true,
+      external: [],
     });
   });
 

--- a/packages/esbuild/src/executors/esbuild/lib/normalize.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/normalize.ts
@@ -16,11 +16,13 @@ export function normalizeOptions(
     }
     return {
       ...rest,
+      external: options.external ?? [],
       singleEntry: false,
     };
   } else {
     return {
       ...options,
+      external: options.external ?? [],
       singleEntry: true,
       outputFileName:
         options.outputFileName ?? `${parse(options.main).name}.js`,

--- a/packages/esbuild/src/executors/esbuild/schema.d.ts
+++ b/packages/esbuild/src/executors/esbuild/schema.d.ts
@@ -7,6 +7,7 @@ export interface EsBuildExecutorOptions {
   assets: AssetGlob[];
   buildableProjectDepsInPackageJsonType?: 'dependencies' | 'peerDependencies';
   deleteOutputPath?: boolean;
+  dependenciesFieldType?: boolean;
   esbuildOptions?: Record<string, any>;
   external?: string[];
   format?: Array<'esm' | 'cjs'>;
@@ -20,12 +21,13 @@ export interface EsBuildExecutorOptions {
   project: string;
   skipTypeCheck?: boolean;
   target?: string;
+  thirdParty?: boolean;
   tsConfig: string;
-  updateBuildableProjectDepsInPackageJson?: boolean;
   watch?: boolean;
 }
 
 export interface NormalizedEsBuildExecutorOptions
   extends EsBuildExecutorOptions {
   singleEntry: boolean;
+  external: string[];
 }

--- a/packages/esbuild/src/executors/esbuild/schema.json
+++ b/packages/esbuild/src/executors/esbuild/schema.json
@@ -114,16 +114,16 @@
       "description": "Skip type-checking via TypeScript. Skipping type-checking speeds up the build but type errors are not caught.",
       "default": false
     },
-    "updateBuildableProjectDepsInPackageJson": {
+    "thirdParty": {
       "type": "boolean",
-      "description": "Update buildable project dependencies in `package.json`.",
+      "description": "Includes third-party packages in the bundle (i.e. npm packages).",
       "default": true
     },
-    "buildableProjectDepsInPackageJsonType": {
+    "dependenciesFieldType": {
       "type": "string",
-      "description": "When `updateBuildableProjectDepsInPackageJson` is `true`, this adds dependencies to either `peerDependencies` or `dependencies`.",
+      "description": "When `bundleInternalProjectsOnly` is true, this option determines whether external packages should be in 'dependencies' or 'peerDependencies' field in the generated package.json file.",
       "enum": ["dependencies", "peerDependencies"],
-      "default": "peerDependencies"
+      "default": "dependencies"
     },
     "esbuildOptions": {
       "type": "object",

--- a/packages/js/src/utils/package-json/index.ts
+++ b/packages/js/src/utils/package-json/index.ts
@@ -11,6 +11,7 @@ export interface CopyPackageJsonOptions
   extends Omit<UpdatePackageJsonOption, 'projectRoot'> {
   watch?: boolean;
   extraDependencies?: DependentBuildableProjectNode[];
+  overrideDependencies?: DependentBuildableProjectNode[];
 }
 
 export interface CopyPackageJsonResult {
@@ -28,14 +29,19 @@ export async function copyPackageJson(
       `Could not find tsConfig option for "${context.targetName}" target of "${context.projectName}" project. Check that your project configuration is correct.`
     );
   }
-  const { target, dependencies, projectRoot } = checkDependencies(
+  let { target, dependencies, projectRoot } = checkDependencies(
     context,
     context.target.options.tsConfig
   );
   const options = { ..._options, projectRoot };
-  if (options.extraDependencies?.length) {
+
+  if (options.extraDependencies) {
     dependencies.push(...options.extraDependencies);
   }
+  if (options.overrideDependencies) {
+    dependencies = options.overrideDependencies;
+  }
+
   if (options.watch) {
     const dispose = await watchForSingleFileChanges(
       join(context.root, projectRoot),

--- a/packages/js/src/utils/package-json/update-package-json.ts
+++ b/packages/js/src/utils/package-json/update-package-json.ts
@@ -33,6 +33,7 @@ export interface UpdatePackageJsonOption {
   outputFileExtensionForCjs?: `.${string}`;
   skipTypings?: boolean;
   generateExportsField?: boolean;
+  excludeLibsInPackageJson?: boolean;
   updateBuildableProjectDepsInPackageJson?: boolean;
   buildableProjectDepsInPackageJsonType?: 'dependencies' | 'peerDependencies';
 }
@@ -52,6 +53,10 @@ export function updatePackageJson(
   const packageJson = fileExists(pathToPackageJson)
     ? readJsonFile(pathToPackageJson)
     : { name: context.projectName };
+
+  if (options.excludeLibsInPackageJson) {
+    dependencies = dependencies.filter((dep) => dep.node.type !== 'lib');
+  }
 
   writeJsonFile(
     `${options.outputPath}/package.json`,


### PR DESCRIPTION
This PR allows users to pass the `--no-third-party` option (or `--third-party=no`), so the generated bundled will include all workspace libs but exclude third-party packages.


## Why?

This is useful for Docker images, publishing to npm, etc. where you expect third-party packages to be installed via `npm i` (or `yarn` or `pnpm i`).

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Alternatives

The workaround currently is to pass a fixed `--external` list (e.g. `--external=rambda,dayjs,chalk,uuid`), which will exclude those packages in the bundle. The `--no-third-party` option will automatically mark these as external, and include them in the generated `package.json` file.

## Current Behavior
Bundle includes everything -- unless in `--external` list.

## Expected Behavior
Bundle only includes libs/packages in the workspace.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
