### PR TITLE
docs(core): clearer update nx guide

### DIFF
--- a/docs/shared/core-features/automate-updating-dependencies.md
+++ b/docs/shared/core-features/automate-updating-dependencies.md
@@ -4,9 +4,9 @@ The Nx CLI provides the `migrate` command to help you stay up to date with the l
 
 Not only does `nx migrate` update you to the latest version of Nx, but it also updates the versions of dependencies that we support and test such as Jest and Cypress. You can also use the `migrate` command to update any Nx plugin.
 
-## Migrating to the latest Nx version
+## Update to the latest Nx version
 
-Migration happens in three steps:
+Updating happens in three steps:
 
 - The installed dependencies are updated including the `package.json` (and `node_modules`).
 - The source code in the repo is updated to match the new versions of packages in `package.json`.

--- a/docs/shared/recipes/advanced-update.md
+++ b/docs/shared/recipes/advanced-update.md
@@ -1,5 +1,7 @@
 # Advanced update process
 
+This is an advanced version of the [standard update process](/core-features/automate-updating-dependencies).
+
 When you run into problems running the `nx migrate --run-migrations` command, here are some solutions to break the process down into manageable steps.
 
 ## Make changes easier to review by committing after each migration runs


### PR DESCRIPTION
Tweaks the update Nx instructions.  Cross-linking the advanced update guide back to the main update guide.

Fixes #12832 
