### PR TITLE
fix(js): only generate shallow dependencies when building with tsc and swc

### DIFF
--- a/packages/js/src/utils/check-dependencies.ts
+++ b/packages/js/src/utils/check-dependencies.ts
@@ -19,7 +19,8 @@ export function checkDependencies(
     context.root,
     context.projectName,
     context.targetName,
-    context.configurationName
+    context.configurationName,
+    true
   );
   const projectRoot = target.data.root;
 


### PR DESCRIPTION
This PR fixes an issue where `peerDependencies` of the generated package.json contains a huge list of nested deps.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
