### PR TITLE
docs(node): update tutorial documentation for working examples

### DIFF
--- a/docs/shared/npm-tutorial/package-based.md
+++ b/docs/shared/npm-tutorial/package-based.md
@@ -66,7 +66,7 @@ Update the `.gitignore` file to make sure you have a `dist` entry (without a lea
 Note, the `build` uses TypeScript to compile the `index.ts` file into a project-level `./dist` folder. To run it use:
 
 ```shell
-npx nx build is-even
+npx nx build @package-based/is-even
 ```
 
 ## Local Linking of Packages
@@ -150,7 +150,7 @@ This tells Nx to run the `build` target of all the dependent projects first, bef
 Remove any existing `dist` folder and run:
 
 ```shell
-npx nx build is-odd
+npx nx build @package-based/is-odd
 ```
 
 It will automatically first run `npx nx build is-even` and then the build for `is-odd`. Note that if `is-even` has been built before, it would just be restored out of the cache.
@@ -160,7 +160,7 @@ It will automatically first run `npx nx build is-even` and then the build for `i
 To build the `is-even` package run:
 
 ```shell
-npx nx build is-even
+npx nx build @package-based/is-even
 ```
 
 Run the same command a second time and you'll see the build cache is being used:


### PR DESCRIPTION
## Current Behavior
The docs for the package based tutorial do not have the prefix of `@package-based` for the example packages of `is-odd` or `is-even` leading to broken examples being run.

## Expected Behavior
The docs should have the `@package-based` prefix for the example docs for things like `is-even` or `is-odd` to avoid confusion.

## Related Issue(s)
Fixes #12689 
