### PR TITLE
fix(linter): improve wildcard import parsing to allow full regex

### DIFF
--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -333,7 +333,8 @@ export function isDirectDependency(target: ProjectGraphExternalNode): boolean {
  * @returns
  */
 function parseImportWildcards(importDefinition: string): RegExp {
-  const mappedWildcards = importDefinition.split('*').join('.*');
+  // we replace all instances of `*`, `**..*` and `.*` with `.*`
+  const mappedWildcards = importDefinition.split(/(?:\.\*)|\*+/).join('.*');
   return new RegExp(`^${new RegExp(mappedWildcards).source}$`);
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We map every `*` to `.*` which might turn a valid regex (e.g. `react.*`) into an invalid one.

## Expected Behavior
Replace function should not destroy valid `any` char expression.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
