### PR TITLE
chore(linter): allow cache override for manual jest runs

### DIFF
--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -375,11 +375,13 @@ export function mapProjectGraphFiles<T>(
 }
 
 const ESLINT_REGEX = /node_modules.*[\/\\]eslint$/;
+const JEST_REGEX = /node_modules\/.bin\/jest$/; // when we run unit tests in jest
 const NRWL_CLI_REGEX = /nx[\/\\]bin[\/\\]run-executor\.js$/;
 export function isTerminalRun(): boolean {
   return (
     process.argv.length > 1 &&
     (!!process.argv[1].match(NRWL_CLI_REGEX) ||
+      !!process.argv[1].match(JEST_REGEX) ||
       !!process.argv[1].match(ESLINT_REGEX))
   );
 }


### PR DESCRIPTION
This PR allows us to run jest tests from IDE directly without hitting the `WARNING No cached ProjectGraph is available. The rule will be skipped.` issue.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
