### PR TITLE
fix(js): correctly build library with workspace dependencies

### DIFF
--- a/packages/js/src/utils/check-dependencies.ts
+++ b/packages/js/src/utils/check-dependencies.ts
@@ -19,8 +19,7 @@ export function checkDependencies(
     context.root,
     context.projectName,
     context.targetName,
-    context.configurationName,
-    true
+    context.configurationName
   );
   const projectRoot = target.data.root;
 

--- a/packages/workspace/src/utilities/buildable-libs-utils.ts
+++ b/packages/workspace/src/utilities/buildable-libs-utils.ts
@@ -137,7 +137,8 @@ function collectDependencies(
         return;
 
       acc.push({ name: dependency.target, isTopLevel: areTopLevelDeps });
-      if (!shallow) {
+      const isInternalTarget = projGraph.nodes[dependency.target];
+      if (!shallow && isInternalTarget) {
         collectDependencies(dependency.target, projGraph, acc, shallow, false);
       }
     }


### PR DESCRIPTION
Fixes #12874

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

Importing workspace libs into a lib results in TS error for the file not being under `rootDir`.

## Expected Behavior
Building should work with workspace lib dependencies.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
