### PR TITLE
fix(misc): remove -d as alias in generator schema

### DIFF
--- a/docs/generated/packages/expo.json
+++ b/docs/generated/packages/expo.json
@@ -76,8 +76,7 @@
           },
           "directory": {
             "description": "The directory of the new application.",
-            "type": "string",
-            "alias": "d"
+            "type": "string"
           },
           "skipFormat": {
             "description": "Skip formatting files",
@@ -157,8 +156,7 @@
           },
           "directory": {
             "type": "string",
-            "description": "A directory where the lib is placed.",
-            "alias": "d"
+            "description": "A directory where the lib is placed."
           },
           "linter": {
             "description": "The tool to use for running lint checks.",
@@ -287,8 +285,7 @@
           },
           "directory": {
             "type": "string",
-            "description": "Create the component under this directory (can be nested).",
-            "alias": "d"
+            "description": "Create the component under this directory (can be nested)."
           },
           "flat": {
             "type": "boolean",

--- a/docs/generated/packages/nx-plugin.json
+++ b/docs/generated/packages/nx-plugin.json
@@ -40,8 +40,7 @@
           },
           "directory": {
             "type": "string",
-            "description": "A directory where the plugin is placed.",
-            "alias": "d"
+            "description": "A directory where the plugin is placed."
           },
           "importPath": {
             "type": "string",
@@ -203,8 +202,7 @@
           },
           "description": {
             "type": "string",
-            "description": "Migration description.",
-            "alias": "d"
+            "description": "Migration description."
           },
           "packageVersion": {
             "type": "string",
@@ -313,8 +311,7 @@
           },
           "description": {
             "type": "string",
-            "description": "Executor description.",
-            "alias": "d"
+            "description": "Executor description."
           },
           "unitTestRunner": {
             "type": "string",

--- a/docs/generated/packages/react-native.json
+++ b/docs/generated/packages/react-native.json
@@ -91,8 +91,7 @@
           },
           "directory": {
             "description": "The directory of the new application.",
-            "type": "string",
-            "alias": "d"
+            "type": "string"
           },
           "skipFormat": {
             "description": "Skip formatting files",
@@ -174,8 +173,7 @@
           },
           "directory": {
             "type": "string",
-            "description": "A directory where the lib is placed.",
-            "alias": "d"
+            "description": "A directory where the lib is placed."
           },
           "linter": {
             "description": "The tool to use for running lint checks.",
@@ -300,8 +298,7 @@
           },
           "directory": {
             "type": "string",
-            "description": "Create the component under this directory (can be nested).",
-            "alias": "d"
+            "description": "Create the component under this directory (can be nested)."
           },
           "flat": {
             "type": "boolean",

--- a/docs/generated/packages/react.json
+++ b/docs/generated/packages/react.json
@@ -855,8 +855,7 @@
           },
           "directory": {
             "type": "string",
-            "description": "Create the hook under this directory (can be nested).",
-            "alias": "d"
+            "description": "Create the hook under this directory (can be nested)."
           },
           "flat": {
             "type": "boolean",

--- a/packages/expo/src/generators/application/schema.json
+++ b/packages/expo/src/generators/application/schema.json
@@ -30,8 +30,7 @@
     },
     "directory": {
       "description": "The directory of the new application.",
-      "type": "string",
-      "alias": "d"
+      "type": "string"
     },
     "skipFormat": {
       "description": "Skip formatting files",

--- a/packages/expo/src/generators/component/schema.json
+++ b/packages/expo/src/generators/component/schema.json
@@ -50,8 +50,7 @@
     },
     "directory": {
       "type": "string",
-      "description": "Create the component under this directory (can be nested).",
-      "alias": "d"
+      "description": "Create the component under this directory (can be nested)."
     },
     "flat": {
       "type": "boolean",

--- a/packages/expo/src/generators/library/schema.json
+++ b/packages/expo/src/generators/library/schema.json
@@ -23,8 +23,7 @@
     },
     "directory": {
       "type": "string",
-      "description": "A directory where the lib is placed.",
-      "alias": "d"
+      "description": "A directory where the lib is placed."
     },
     "linter": {
       "description": "The tool to use for running lint checks.",

--- a/packages/nx-plugin/src/generators/executor/schema.json
+++ b/packages/nx-plugin/src/generators/executor/schema.json
@@ -32,8 +32,7 @@
     },
     "description": {
       "type": "string",
-      "description": "Executor description.",
-      "alias": "d"
+      "description": "Executor description."
     },
     "unitTestRunner": {
       "type": "string",

--- a/packages/nx-plugin/src/generators/generator/files/generator/__fileName__/schema.json__tmpl__
+++ b/packages/nx-plugin/src/generators/generator/files/generator/__fileName__/schema.json__tmpl__
@@ -21,8 +21,7 @@
     }, 
     "directory": {
       "type": "string",
-      "description": "A directory where the project is placed",
-      "alias": "d"
+      "description": "A directory where the project is placed"
     }
   },
   "required": ["name"]

--- a/packages/nx-plugin/src/generators/migration/schema.json
+++ b/packages/nx-plugin/src/generators/migration/schema.json
@@ -31,8 +31,7 @@
     },
     "description": {
       "type": "string",
-      "description": "Migration description.",
-      "alias": "d"
+      "description": "Migration description."
     },
     "packageVersion": {
       "type": "string",

--- a/packages/nx-plugin/src/generators/plugin/schema.json
+++ b/packages/nx-plugin/src/generators/plugin/schema.json
@@ -23,8 +23,7 @@
     },
     "directory": {
       "type": "string",
-      "description": "A directory where the plugin is placed.",
-      "alias": "d"
+      "description": "A directory where the plugin is placed."
     },
     "importPath": {
       "type": "string",

--- a/packages/react-native/src/generators/application/schema.json
+++ b/packages/react-native/src/generators/application/schema.json
@@ -31,8 +31,7 @@
     },
     "directory": {
       "description": "The directory of the new application.",
-      "type": "string",
-      "alias": "d"
+      "type": "string"
     },
     "skipFormat": {
       "description": "Skip formatting files",

--- a/packages/react-native/src/generators/component/schema.json
+++ b/packages/react-native/src/generators/component/schema.json
@@ -46,8 +46,7 @@
     },
     "directory": {
       "type": "string",
-      "description": "Create the component under this directory (can be nested).",
-      "alias": "d"
+      "description": "Create the component under this directory (can be nested)."
     },
     "flat": {
       "type": "boolean",

--- a/packages/react-native/src/generators/library/schema.json
+++ b/packages/react-native/src/generators/library/schema.json
@@ -24,8 +24,7 @@
     },
     "directory": {
       "type": "string",
-      "description": "A directory where the lib is placed.",
-      "alias": "d"
+      "description": "A directory where the lib is placed."
     },
     "linter": {
       "description": "The tool to use for running lint checks.",

--- a/packages/react/src/generators/hook/schema.json
+++ b/packages/react/src/generators/hook/schema.json
@@ -42,8 +42,7 @@
     },
     "directory": {
       "type": "string",
-      "description": "Create the hook under this directory (can be nested).",
-      "alias": "d"
+      "description": "Create the hook under this directory (can be nested)."
     },
     "flat": {
       "type": "boolean",


### PR DESCRIPTION
-d is an alias for --dry-run, so it never reaches the generator parameter parsing

Fixes: #12596

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
