### PR TITLE
fix(testing): provide better error messages around component test --build-target

### DIFF
--- a/packages/angular/src/generators/cypress-component-configuration/cypress-component-configuration.spec.ts
+++ b/packages/angular/src/generators/cypress-component-configuration/cypress-component-configuration.spec.ts
@@ -5,6 +5,7 @@ import {
   ProjectGraph,
   readProjectConfiguration,
   Tree,
+  updateProjectConfiguration,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { applicationGenerator } from '../application/application';
@@ -158,21 +159,60 @@ describe('Cypress Component Testing Configuration', () => {
       });
     });
 
-    it('should throw if --build-target is invalid', async () => {
+    it('should throw with invalid --build-target', async () => {
+      await applicationGenerator(tree, {
+        name: 'fancy-app',
+      });
       await libraryGenerator(tree, {
         name: 'fancy-lib',
       });
-      await expect(
-        cypressComponentConfiguration(tree, {
+      await componentGenerator(tree, {
+        name: 'fancy-cmp',
+        project: 'fancy-lib',
+        export: true,
+      });
+      const appConfig = readProjectConfiguration(tree, 'fancy-app');
+      appConfig.targets['build'].executor = 'something/else';
+      updateProjectConfiguration(tree, 'fancy-app', appConfig);
+      projectGraph = {
+        nodes: {
+          'fancy-app': {
+            name: 'fancy-app',
+            type: 'app',
+            data: {
+              ...appConfig,
+            },
+          },
+          'fancy-lib': {
+            name: 'fancy-lib',
+            type: 'lib',
+            data: {
+              ...readProjectConfiguration(tree, 'fancy-lib'),
+            },
+          },
+        },
+        dependencies: {
+          'fancy-app': [
+            {
+              type: DependencyType.static,
+              source: 'fancy-app',
+              target: 'fancy-lib',
+            },
+          ],
+        },
+      };
+      await expect(async () => {
+        await cypressComponentConfiguration(tree, {
           project: 'fancy-lib',
-          buildTarget: 'fancy-app:build:development',
+          buildTarget: 'fancy-app:build',
           generateTests: false,
-        })
-      ).rejects
-        .toThrow(`Error trying to find build configuration. Try manually specifying the build target with the --build-target flag.
-Provided project? fancy-lib
-Provided build target? fancy-app:build:development
-Provided Executors? @nrwl/angular:webpack-browser, @angular-devkit/build-angular:browser`);
+        });
+      }).rejects.toThrowErrorMatchingInlineSnapshot(`
+        "Error trying to find build configuration. Try manually specifying the build target with the --build-target flag.
+        Provided project? fancy-lib
+        Provided build target? fancy-app:build
+        Provided Executors? @nrwl/angular:webpack-browser, @angular-devkit/build-angular:browser"
+      `);
     });
     it('should use own project config', async () => {
       await applicationGenerator(tree, {
@@ -273,6 +313,7 @@ Provided Executors? @nrwl/angular:webpack-browser, @angular-devkit/build-angular
     });
   });
 
+  it('should throw if an invalid --build-target', async () => {});
   it('should work with simple components', async () => {
     await libraryGenerator(tree, {
       name: 'my-lib',

--- a/packages/react/src/generators/cypress-component-configuration/lib/update-configs.ts
+++ b/packages/react/src/generators/cypress-component-configuration/lib/update-configs.ts
@@ -19,7 +19,7 @@ export async function updateProjectConfig(
     validExecutorNames: new Set<string>(['@nrwl/webpack:webpack']),
   });
 
-  assetValidConfig(found.config);
+  assetValidConfig(found?.config);
 
   const projectConfig = readProjectConfiguration(tree, options.project);
   projectConfig.targets['component-test'].options = {


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
when error happens in finding the build target for component testing they aren't helpful into why a build target won't work or why the generator didn't find a build target

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
More helpful errors when providing a build target that's invalid
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #12844
