### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -10,8 +10,11 @@ on:
         required: false
         default: false
 
+permissions: {}
 jobs:
   e2e:
+    permissions:
+      contents: read  #  to fetch code (actions/checkout)
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -10,8 +10,12 @@ on:
         required: false
         default: false
 
+permissions: {}
 jobs:
   e2e:
+    permissions:
+      contents: read  #  to fetch code (actions/checkout)
+
     runs-on: windows-latest
     strategy:
       matrix:

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -5,8 +5,12 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions: {}
 jobs:
   audit:
+    permissions:
+      contents: read  #  to fetch code (actions/checkout)
+
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/schedule-stale.yml
+++ b/.github/workflows/schedule-stale.yml
@@ -2,8 +2,13 @@ on:
   schedule:
     - cron: "0 0 * * *"
 name: Stale Bot workflow
+permissions: {}
 jobs:
   build:
+    permissions:
+      issues: write  #  to close stale issues (actions/stale)
+      pull-requests: write  #  to close stale PRs (actions/stale)
+
     name: stale
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
All workflows except triggered on pull_request, run with read-write permissions to contents, issues, pull-requests, discussions, actions, checks, etc.

## Expected Behavior

This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

N/A