### PR TITLE
feat(react): add skipPackageJson flag

### DIFF
--- a/docs/generated/packages/react.json
+++ b/docs/generated/packages/react.json
@@ -43,6 +43,11 @@
             "type": "boolean",
             "default": false
           },
+          "skipPackageJson": {
+            "description": "Do not add dependencies to `package.json`.",
+            "type": "boolean",
+            "default": false
+          },
           "js": {
             "type": "boolean",
             "default": false,
@@ -390,6 +395,11 @@
             "enum": ["babel", "swc"],
             "default": "babel",
             "description": "Which compiler to use."
+          },
+          "skipPackageJson": {
+            "description": "Do not add dependencies to `package.json`.",
+            "type": "boolean",
+            "default": false
           }
         },
         "required": ["name"],

--- a/docs/generated/packages/web.json
+++ b/docs/generated/packages/web.json
@@ -48,6 +48,11 @@
             "description": "Skip formatting files",
             "type": "boolean",
             "default": false
+          },
+          "skipPackageJson": {
+            "description": "Do not add dependencies to `package.json`.",
+            "type": "boolean",
+            "default": false
           }
         },
         "required": [],

--- a/packages/react/src/generators/init/init.ts
+++ b/packages/react/src/generators/init/init.ts
@@ -82,8 +82,10 @@ export async function reactInitGenerator(host: Tree, schema: InitSchema) {
 
   const initTask = await webInitGenerator(host, schema);
   tasks.push(initTask);
-  const installTask = updateDependencies(host);
-  tasks.push(installTask);
+  if (!schema.skipPackageJson) {
+    const installTask = updateDependencies(host);
+    tasks.push(installTask);
+  }
 
   return runTasksInSerial(...tasks);
 }

--- a/packages/react/src/generators/init/schema.d.ts
+++ b/packages/react/src/generators/init/schema.d.ts
@@ -2,5 +2,6 @@ export interface InitSchema {
   unitTestRunner?: 'jest' | 'none';
   e2eTestRunner?: 'cypress' | 'none';
   skipFormat?: boolean;
+  skipPackageJson?: boolean;
   js?: boolean;
 }

--- a/packages/react/src/generators/init/schema.json
+++ b/packages/react/src/generators/init/schema.json
@@ -23,6 +23,11 @@
       "type": "boolean",
       "default": false
     },
+    "skipPackageJson": {
+      "description": "Do not add dependencies to `package.json`.",
+      "type": "boolean",
+      "default": false
+    },
     "js": {
       "type": "boolean",
       "default": false,

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -6,7 +6,10 @@ import {
   Tree,
   updateJson,
 } from '@nrwl/devkit';
-import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
+import {
+  createTreeWithEmptyV1Workspace,
+  createTreeWithEmptyWorkspace,
+} from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import applicationGenerator from '../application/application';
 import libraryGenerator from './library';
@@ -710,6 +713,24 @@ describe('lib', () => {
 
       expect(packageJson.devDependencies['@swc/core']).toEqual(
         expect.any(String)
+      );
+    });
+  });
+
+  describe('--skipPackageJson', () => {
+    it('should not add dependencies to package.json when true', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      const packageJsonBeforeGenerator = tree.read('package.json', 'utf-8');
+      // ACT
+      await libraryGenerator(tree, {
+        ...defaultSchema,
+        skipPackageJson: true,
+      });
+
+      // ASSERT
+      expect(tree.read('package.json', 'utf-8')).toEqual(
+        packageJsonBeforeGenerator
       );
     });
   });

--- a/packages/react/src/generators/library/schema.d.ts
+++ b/packages/react/src/generators/library/schema.d.ts
@@ -23,4 +23,5 @@ export interface Schema {
   setParserOptionsProject?: boolean;
   standaloneConfig?: boolean;
   compiler?: 'babel' | 'swc';
+  skipPackageJson?: boolean;
 }

--- a/packages/react/src/generators/library/schema.json
+++ b/packages/react/src/generators/library/schema.json
@@ -161,6 +161,11 @@
       "enum": ["babel", "swc"],
       "default": "babel",
       "description": "Which compiler to use."
+    },
+    "skipPackageJson": {
+      "description": "Do not add dependencies to `package.json`.",
+      "type": "boolean",
+      "default": false
     }
   },
   "required": ["name"]

--- a/packages/web/src/generators/init/init.ts
+++ b/packages/web/src/generators/init/init.ts
@@ -65,15 +65,21 @@ export async function webInitGenerator(tree: Tree, schema: Schema) {
   let tasks: GeneratorCallback[] = [];
 
   if (!schema.unitTestRunner || schema.unitTestRunner === 'jest') {
-    const jestTask = jestInitGenerator(tree, {});
+    const jestTask = jestInitGenerator(tree, {
+      skipPackageJson: schema.skipPackageJson,
+    });
     tasks.push(jestTask);
   }
   if (!schema.e2eTestRunner || schema.e2eTestRunner === 'cypress') {
-    const cypressTask = cypressInitGenerator(tree, {});
+    const cypressTask = cypressInitGenerator(tree, {
+      skipPackageJson: schema.skipPackageJson,
+    });
     tasks.push(cypressTask);
   }
-  const installTask = updateDependencies(tree, schema);
-  tasks.push(installTask);
+  if (!schema.skipPackageJson) {
+    const installTask = updateDependencies(tree, schema);
+    tasks.push(installTask);
+  }
   initRootBabelConfig(tree);
   if (!schema.skipFormat) {
     await formatFiles(tree);

--- a/packages/web/src/generators/init/schema.d.ts
+++ b/packages/web/src/generators/init/schema.d.ts
@@ -3,4 +3,5 @@ export interface Schema {
   unitTestRunner?: 'jest' | 'none';
   e2eTestRunner?: 'cypress' | 'none';
   skipFormat?: boolean;
+  skipPackageJson?: boolean;
 }

--- a/packages/web/src/generators/init/schema.json
+++ b/packages/web/src/generators/init/schema.json
@@ -28,6 +28,11 @@
       "description": "Skip formatting files",
       "type": "boolean",
       "default": false
+    },
+    "skipPackageJson": {
+      "description": "Do not add dependencies to `package.json`.",
+      "type": "boolean",
+      "default": false
     }
   },
   "required": []


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
Adding a new library may always update package.json when it is unnecessary or when it is unwanted behaviour (if the developer has specific versions of packages for a reason).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Add the `skipPackageJson` flag that to the library generator (and subsequent generators that require it) to allow the developer to specifically state if they want the dependencies modified. 
This follows the pattern seen in other `@nrwl/*` packages.
