### PR TITLE
cleanup(angular): add utilities for shared builder logic

### DIFF
--- a/packages/angular/src/builders/utilities/buildable-libs.ts
+++ b/packages/angular/src/builders/utilities/buildable-libs.ts
@@ -1,0 +1,33 @@
+import { BuilderContext } from '@angular-devkit/architect';
+import {
+  calculateProjectDependencies,
+  createTmpTsConfig,
+  DependentBuildableProjectNode,
+} from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+import { readCachedProjectGraph } from '@nrwl/devkit';
+import { join } from 'path';
+
+export function createTmpTsConfigForBuildableLibs(
+  tsConfigPath: string,
+  context: BuilderContext
+) {
+  let dependencies: DependentBuildableProjectNode[];
+  const result = calculateProjectDependencies(
+    readCachedProjectGraph(),
+    context.workspaceRoot,
+    context.target.project,
+    context.target.target,
+    context.target.configuration
+  );
+  dependencies = result.dependencies;
+
+  const tmpTsConfigPath = createTmpTsConfig(
+    join(context.workspaceRoot, tsConfigPath),
+    context.workspaceRoot,
+    result.target.data.root,
+    dependencies
+  );
+  process.env.NX_TSCONFIG_PATH = tmpTsConfigPath;
+
+  return { tsConfigPath: tmpTsConfigPath, dependencies };
+}

--- a/packages/angular/src/builders/utilities/webpack.ts
+++ b/packages/angular/src/builders/utilities/webpack.ts
@@ -1,3 +1,30 @@
+import type { Target } from '@angular-devkit/architect';
+import { merge } from 'webpack-merge';
+
+export async function mergeCustomWebpackConfig(
+  baseWebpackConfig: any,
+  pathToWebpackConfig: string,
+  options: { tsConfig: string; [k: string]: any },
+  target: Target
+) {
+  const customWebpackConfiguration = resolveCustomWebpackConfig(
+    pathToWebpackConfig,
+    options.tsConfig
+  );
+  // The extra Webpack configuration file can also export a Promise, for instance:
+  // `module.exports = new Promise(...)`. If it exports a single object, but not a Promise,
+  // then await will just resolve that object.
+  const config = await customWebpackConfiguration;
+
+  // The extra Webpack configuration file can export a synchronous or asynchronous function,
+  // for instance: `module.exports = async config => { ... }`.
+  if (typeof config === 'function') {
+    return config(baseWebpackConfig, options, target);
+  } else {
+    return merge(baseWebpackConfig, config);
+  }
+}
+
 export function resolveCustomWebpackConfig(path: string, tsConfig: string) {
   tsNodeRegister(path, tsConfig);
 

--- a/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
+++ b/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
@@ -6,17 +6,11 @@ import {
 import { executeBrowserBuilder } from '@angular-devkit/build-angular';
 import { Schema } from '@angular-devkit/build-angular/src/builders/browser/schema';
 import { JsonObject } from '@angular-devkit/core';
-import { joinPathFragments, readCachedProjectGraph } from '@nrwl/devkit';
-import {
-  calculateProjectDependencies,
-  createTmpTsConfig,
-  DependentBuildableProjectNode,
-} from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+import { joinPathFragments } from '@nrwl/devkit';
 import { existsSync } from 'fs';
-import { join } from 'path';
 import { Observable } from 'rxjs';
-import { merge } from 'webpack-merge';
-import { resolveCustomWebpackConfig } from '../utilities/webpack';
+import { mergeCustomWebpackConfig } from '../utilities/webpack';
+import { createTmpTsConfigForBuildableLibs } from '../utilities/buildable-libs';
 
 export type BrowserBuilderSchema = Schema & {
   customWebpackConfig?: {
@@ -61,24 +55,13 @@ function buildAppWithCustomWebpackConfiguration(
   pathToWebpackConfig: string
 ) {
   return executeBrowserBuilder(options, context as any, {
-    webpackConfiguration: async (baseWebpackConfig) => {
-      const customWebpackConfiguration = resolveCustomWebpackConfig(
+    webpackConfiguration: (baseWebpackConfig) =>
+      mergeCustomWebpackConfig(
+        baseWebpackConfig,
         pathToWebpackConfig,
-        options.tsConfig
-      );
-      // The extra Webpack configuration file can also export a Promise, for instance:
-      // `module.exports = new Promise(...)`. If it exports a single object, but not a Promise,
-      // then await will just resolve that object.
-      const config = await customWebpackConfiguration;
-
-      // The extra Webpack configuration file can export a synchronous or asynchronous function,
-      // for instance: `module.exports = async config => { ... }`.
-      if (typeof config === 'function') {
-        return config(baseWebpackConfig, options, context.target);
-      } else {
-        return merge(baseWebpackConfig, config);
-      }
-    },
+        options,
+        context.target
+      ),
   });
 }
 
@@ -87,25 +70,13 @@ export function executeWebpackBrowserBuilder(
   context: BuilderContext
 ): Observable<BuilderOutput> {
   options.buildLibsFromSource ??= true;
-  let dependencies: DependentBuildableProjectNode[];
 
   if (!options.buildLibsFromSource) {
-    const result = calculateProjectDependencies(
-      readCachedProjectGraph(),
-      context.workspaceRoot,
-      context.target.project,
-      context.target.target,
-      context.target.configuration
+    const { tsConfigPath } = createTmpTsConfigForBuildableLibs(
+      options.tsConfig,
+      context
     );
-    dependencies = result.dependencies;
-
-    options.tsConfig = createTmpTsConfig(
-      join(context.workspaceRoot, options.tsConfig),
-      context.workspaceRoot,
-      result.target.data.root,
-      dependencies
-    );
-    process.env.NX_TSCONFIG_PATH = options.tsConfig;
+    options.tsConfig = tsConfigPath;
   }
 
   return buildApp(options, context);


### PR DESCRIPTION
Cleanup shared logic for builders into utilities for:
 - buildable libs
 - custom webpack config merges