### PR TITLE
fix(web): add option to override outputPath for file-server

### DIFF
--- a/docs/generated/packages/web.json
+++ b/docs/generated/packages/web.json
@@ -999,6 +999,10 @@
             "type": "boolean",
             "description": "Redirect 404 errors to index.html (useful for SPA's)",
             "default": false
+          },
+          "staticFilePath": {
+            "type": "string",
+            "description": "Path where the build artifacts are located. If not provided then it will be infered from the buildTarget executor options as outputPath"
           }
         },
         "additionalProperties": false,

--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -3,6 +3,8 @@ import * as chalk from 'chalk';
 import {
   ExecutorContext,
   joinPathFragments,
+  parseTargetString,
+  readTargetOptions,
   workspaceLayout,
 } from '@nrwl/devkit';
 import ignore from 'ignore';
@@ -57,14 +59,14 @@ function getBuildTargetCommand(options: Schema) {
 }
 
 function getBuildTargetOutputPath(options: Schema, context: ExecutorContext) {
+  if (options.staticFilePath) {
+    return options.staticFilePath;
+  }
+
   let buildOptions;
   try {
-    const [project, target, config] = options.buildTarget.split(':');
-
-    const buildTarget = context.workspace.projects[project].targets[target];
-    buildOptions = config
-      ? { ...buildTarget.options, ...buildTarget.configurations[config] }
-      : buildTarget.options;
+    const target = parseTargetString(options.buildTarget);
+    buildOptions = readTargetOptions(target, context);
   } catch (e) {
     throw new Error(`Invalid buildTarget: ${options.buildTarget}`);
   }
@@ -73,7 +75,7 @@ function getBuildTargetOutputPath(options: Schema, context: ExecutorContext) {
   const outputPath = buildOptions.outputPath;
   if (!outputPath) {
     throw new Error(
-      `Invalid buildTarget: ${options.buildTarget}. The target must contain outputPath property.`
+      `Unable to get the outputPath from buildTarget ${options.buildTarget}. Make sure ${options.buildTarget} has an outputPath property or manually provide an staticFilePath property`
     );
   }
 

--- a/packages/web/src/executors/file-server/schema.d.ts
+++ b/packages/web/src/executors/file-server/schema.d.ts
@@ -12,4 +12,5 @@ export interface Schema {
   proxyOptions?: object;
   watch?: boolean;
   spa: boolean;
+  staticFilePath?: string;
 }

--- a/packages/web/src/executors/file-server/schema.json
+++ b/packages/web/src/executors/file-server/schema.json
@@ -67,6 +67,10 @@
       "type": "boolean",
       "description": "Redirect 404 errors to index.html (useful for SPA's)",
       "default": false
+    },
+    "staticFilePath": {
+      "type": "string",
+      "description": "Path where the build artifacts are located. If not provided then it will be infered from the buildTarget executor options as outputPath"
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

when trying to use file-server with an executor that does not have an outputPath property (i.e. storybook) you are unable to serve the artifacts with file-server

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
be able to manually override the outputPath to allow other executors to use file server

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
