### PR TITLE
fix(linter): ensure fs operations run on full path

### DIFF
--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -248,7 +248,7 @@ export default createESLintRule<Options, MessageIds>({
                   for (const importMember of imports) {
                     const importPath = getRelativeImportPath(
                       importMember,
-                      entryPointPath.path,
+                      joinPathFragments(workspaceRoot, entryPointPath.path),
                       sourceProject.data.sourceRoot
                     );
                     // we cannot remap, so leave it as is
@@ -322,7 +322,7 @@ export default createESLintRule<Options, MessageIds>({
                   for (const importMember of imports) {
                     const importPath = getRelativeImportPath(
                       importMember,
-                      entryPointPath,
+                      joinPathFragments(workspaceRoot, entryPointPath),
                       sourceProject.data.sourceRoot
                     );
                     if (importPath) {

--- a/packages/eslint-plugin-nx/src/utils/ast-utils.ts
+++ b/packages/eslint-plugin-nx/src/utils/ast-utils.ts
@@ -7,8 +7,7 @@ import { findNodes } from '@nrwl/workspace/src/utilities/typescript';
 import { existsSync, readFileSync } from 'fs';
 import { dirname } from 'path';
 import ts = require('typescript');
-import { logger } from '@nrwl/devkit';
-import { workspaceRoot } from '@nrwl/devkit';
+import { logger, workspaceRoot } from '@nrwl/devkit';
 
 function tryReadBaseJson() {
   try {
@@ -200,14 +199,12 @@ export function getRelativeImportPath(exportedMember, filePath, basePath) {
       const modulePath = (exportDeclaration as any).moduleSpecifier.text;
 
       let moduleFilePath = joinPathFragments(
-        './',
         dirname(filePath),
         `${modulePath}.ts`
       );
       if (!existsSync(moduleFilePath)) {
         // might be a index.ts
         moduleFilePath = joinPathFragments(
-          './',
           dirname(filePath),
           `${modulePath}/index.ts`
         );

--- a/packages/workspace/src/utils/runtime-lint-utils.ts
+++ b/packages/workspace/src/utils/runtime-lint-utils.ts
@@ -437,7 +437,9 @@ export function isAngularSecondaryEntrypoint(
         // The `ng-packagr` defaults to the `src/public_api.ts` entry file to
         // the public API if the `lib.entryFile` is not specified explicitly.
         (file.endsWith('src/public_api.ts') || file.endsWith('src/index.ts')) &&
-        existsSync(joinPathFragments(file, '../../', 'ng-package.json'))
+        existsSync(
+          joinPathFragments(workspaceRoot, file, '../../', 'ng-package.json')
+        )
     )
   );
 }


### PR DESCRIPTION
WebStorm's eslint process runs on a different CWD than the workspace root, resulting in files not being found when using e.g. `existsSync`. This leads to invalid messages being presented to the user, despite terminal runs working as expected.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #12067
