### PR TITLE
fix(linter): do not remap namespace import specifiers as import specifiers

### DIFF
--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -239,7 +239,9 @@ export default createESLintRule<Options, MessageIds>({
                   return;
                 }
 
-                const imports = specifiers.map((s) => s.imported.name);
+                const imports = specifiers
+                  .filter((s) => s.type === 'ImportSpecifier')
+                  .map((s) => s.imported.name);
 
                 // process each potential entry point and try to find the imports
                 const importsToRemap = [];
@@ -313,7 +315,9 @@ export default createESLintRule<Options, MessageIds>({
                   return;
                 }
                 // imported JS functions to remap
-                const imports = specifiers.map((s) => s.imported.name);
+                const imports = specifiers
+                  .filter((s) => s.type === 'ImportSpecifier')
+                  .map((s) => s.imported.name);
 
                 // process each potential entry point and try to find the imports
                 const importsToRemap = [];


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #12316
