### PR TITLE
fix(core): workspace-generator errors should be propagated to nx

### DIFF
--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -771,6 +771,14 @@ function withRunOneOptions(yargs: yargs.Argv) {
   }
 }
 
+type OptionArgumentDefinition = {
+  type: yargs.Options['type'];
+  describe?: string;
+  default?: any;
+  choices?: yargs.Options['type'][];
+  demandOption?: boolean;
+};
+
 type WorkspaceGeneratorProperties = {
   [name: string]:
     | {
@@ -778,6 +786,7 @@ type WorkspaceGeneratorProperties = {
         description?: string;
         default?: any;
         enum?: yargs.Options['type'][];
+        demandOption?: boolean;
       }
     | {
         type: yargs.PositionalOptionsType;
@@ -839,7 +848,7 @@ async function withCustomGeneratorOptions(
 
   Object.entries(schema.properties as WorkspaceGeneratorProperties).forEach(
     ([name, prop]) => {
-      options.push({
+      const option: { name: string; definition: OptionArgumentDefinition } = {
         name,
         definition: {
           describe: prop.description,
@@ -847,7 +856,11 @@ async function withCustomGeneratorOptions(
           default: prop.default,
           choices: prop.enum,
         },
-      });
+      };
+      if (schema.required && schema.required.includes(name)) {
+        option.definition.demandOption = true;
+      }
+      options.push(option);
       if (isPositionalProperty(prop)) {
         positionals.push({
           name,
@@ -869,21 +882,23 @@ async function withCustomGeneratorOptions(
     command += ' (options)';
   }
 
-  yargs.command({
-    // this is the default and only command
-    command,
-    describe: schema.description || '',
-    builder: (y) => {
-      options.forEach(({ name, definition }) => {
-        y.option(name, definition);
-      });
-      positionals.forEach(({ name, definition }) => {
-        y.positional(name, definition);
-      });
-      return linkToNxDevAndExamples(y, 'workspace-generator');
-    },
-    handler: workspaceGeneratorHandler,
-  });
+  yargs
+    .command({
+      // this is the default and only command
+      command,
+      describe: schema.description || '',
+      builder: (y) => {
+        options.forEach(({ name, definition }) => {
+          y.option(name, definition);
+        });
+        positionals.forEach(({ name, definition }) => {
+          y.positional(name, definition);
+        });
+        return linkToNxDevAndExamples(y, 'workspace-generator');
+      },
+      handler: workspaceGeneratorHandler,
+    })
+    .fail(() => void 0); // no action is needed on failure as Nx will handle it based on schema validation
 
   return yargs;
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The `workspace-generator` uses `yargs` to handle help and argument parsing which results in the following errors:
- positional arguments are causing the command to break even if the argument as passed as optional one

    ```shell
    nx workspace-generator some-name # this succeeds
    nx workspace-generator --name=some-name # this fails
    ```
 - error reported in the default one from `yargs` and it's not very helpful
   ```
   Not enough non-option arguments: got 0, need at least 1
   ```

## Expected Behavior
- Mandatory fields are marked as `[required]`
- Options can be passed as both flags and positionals (if defined as such)
- Useful errors should be reported
![Screenshot 2022-11-03 at 00 11 47](https://user-images.githubusercontent.com/881612/199619461-c9c9931a-a010-4209-8e65-adcb93f3a0d0.png)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #12677
