### PR TITLE
fix(core): schedule tasks with the most tasks that depend on it first

### DIFF
--- a/packages/nx/src/tasks-runner/tasks-schedule.ts
+++ b/packages/nx/src/tasks-runner/tasks-schedule.ts
@@ -99,7 +99,14 @@ export class TasksSchedule {
       [taskId]
     );
     this.options.lifeCycle.scheduleTask(task);
-    this.scheduledTasks.push(taskId);
+    this.scheduledTasks = this.scheduledTasks
+      .concat(taskId)
+      // NOTE: sort task by most dependent on first
+      .sort(
+        (taskId1, taskId2) =>
+          this.reverseTaskDeps[taskId2].length -
+          this.reverseTaskDeps[taskId1].length
+      );
   }
 
   private scheduleBatches() {


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Tasks are scheduled by its dependency  order.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Tasks should be scheduled by how many other tasks depend on it, to avoid bottlenecks.

For our use case it produces 2-5% faster builds. depending on the dependency order and parallel count.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
