### PR TITLE
docs(misc): fix whitespaces for EmptyList component

### DIFF
--- a/nx-dev/feature-package-schema-viewer/src/lib/ui/package-reference.tsx
+++ b/nx-dev/feature-package-schema-viewer/src/lib/ui/package-reference.tsx
@@ -165,8 +165,8 @@ function EmptyList({
             rel="noreferrer"
             target="_blank"
           >
-            <span className="absolute inset-0" aria-hidden="true"></span>No
-            {type}available for this package yet!
+            <span className="absolute inset-0" aria-hidden="true"></span>No{' '}
+            {type} available for this package yet!
           </Link>
         </p>
         <div className="prose prose-slate dark:prose-invert prose-sm">


### PR DESCRIPTION
This PR fixes a small whitespace issue on the package overview pages when generators/executors are missing.

<img width="698" alt="Screenshot 2022-11-03 at 1 55 33 PM" src="https://user-images.githubusercontent.com/53559/199798570-cf2b344b-c7c9-49ff-b9f5-2c87e8fb11fe.png">

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
