### PR TITLE
feat(angular): use share helpers from module federation package

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -47,6 +47,7 @@
     "@nrwl/storybook": "file:../storybook",
     "@nrwl/webpack": "file:../webpack",
     "@nrwl/workspace": "file:../workspace",
+    "@nrwl/module-federation": "file:../module-federation",
     "@phenomnomnominal/tsquery": "4.1.1",
     "@schematics/angular": "~14.2.0",
     "chalk": "4.1.0",

--- a/packages/angular/src/utils/mf/with-module-federation.ts
+++ b/packages/angular/src/utils/mf/with-module-federation.ts
@@ -6,12 +6,13 @@ import {
 import { readCachedProjectConfiguration } from 'nx/src/project-graph/project-graph';
 import { extname } from 'path';
 import {
+  getDependentPackagesForProject,
   getNpmPackageSharedConfig,
+  readRootPackageJson,
   SharedLibraryConfig,
   sharePackages,
   shareWorkspaceLibraries,
-} from './mf-webpack';
-import { getDependentPackagesForProject, readRootPackageJson } from './utils';
+} from '@nrwl/module-federation';
 import ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
 
 export type MFRemotes = string[] | [remoteName: string, remoteUrl: string][];


### PR DESCRIPTION
Switch the angular package to use the nrwl/module-federation package for the share helperes