### PR TITLE
fix(graph): improve performance of showing/hiding directories of projects

### DIFF
--- a/graph/client/src/app/machines/dep-graph.machine.ts
+++ b/graph/client/src/app/machines/dep-graph.machine.ts
@@ -92,7 +92,11 @@ export const depGraphMachine = Machine<
       },
       selectProject: {
         target: 'customSelected',
-        actions: ['notifyGraphShowProject'],
+        actions: ['notifyGraphShowProjects'],
+      },
+      selectProjects: {
+        target: 'customSelected',
+        actions: ['notifyGraphShowProjects'],
       },
       selectAll: {
         target: 'customSelected',
@@ -112,7 +116,17 @@ export const depGraphMachine = Machine<
         },
         {
           target: 'customSelected',
-          actions: ['notifyGraphHideProject'],
+          actions: ['notifyGraphHideProjects'],
+        },
+      ],
+      deselectProjects: [
+        {
+          target: 'unselected',
+          cond: 'deselectLastProject',
+        },
+        {
+          target: 'customSelected',
+          actions: ['notifyGraphHideProjects'],
         },
       ],
       deselectAll: {
@@ -298,27 +312,46 @@ export const depGraphMachine = Machine<
         }
       ),
 
-      notifyGraphShowProject: send(
+      notifyGraphShowProjects: send(
         (context, event) => {
-          if (event.type !== 'selectProject') return;
+          if (event.type !== 'selectProject' && event.type !== 'selectProjects')
+            return;
 
-          return {
-            type: 'notifyGraphShowProject',
-            projectName: event.projectName,
-          };
+          if (event.type === 'selectProject') {
+            return {
+              type: 'notifyGraphShowProjects',
+              projectNames: [event.projectName],
+            };
+          } else {
+            return {
+              type: 'notifyGraphShowProjects',
+              projectNames: event.projectNames,
+            };
+          }
         },
         {
           to: (context) => context.graphActor,
         }
       ),
-      notifyGraphHideProject: send(
+      notifyGraphHideProjects: send(
         (context, event) => {
-          if (event.type !== 'deselectProject') return;
+          if (
+            event.type !== 'deselectProject' &&
+            event.type !== 'deselectProjects'
+          )
+            return;
 
-          return {
-            type: 'notifyGraphHideProject',
-            projectName: event.projectName,
-          };
+          if (event.type === 'deselectProject') {
+            return {
+              type: 'notifyGraphHideProjects',
+              projectNames: [event.projectName],
+            };
+          } else {
+            return {
+              type: 'notifyGraphHideProjects',
+              projectNames: event.projectNames,
+            };
+          }
         },
         {
           to: (context) => context.graphActor,

--- a/graph/client/src/app/machines/interfaces.ts
+++ b/graph/client/src/app/machines/interfaces.ts
@@ -34,6 +34,8 @@ export type DepGraphUIEvents =
     }
   | { type: 'selectProject'; projectName: string }
   | { type: 'deselectProject'; projectName: string }
+  | { type: 'selectProjects'; projectNames: string[] }
+  | { type: 'deselectProjects'; projectNames: string[] }
   | { type: 'selectAll' }
   | { type: 'deselectAll' }
   | { type: 'selectAffected' }

--- a/graph/ui-graph/src/lib/graph.ts
+++ b/graph/ui-graph/src/lib/graph.ts
@@ -157,12 +157,12 @@ export class GraphService {
         );
         break;
 
-      case 'notifyGraphShowProject':
-        this.showProjects([event.projectName]);
+      case 'notifyGraphShowProjects':
+        this.showProjects(event.projectNames);
         break;
 
-      case 'notifyGraphHideProject':
-        this.hideProject(event.projectName);
+      case 'notifyGraphHideProjects':
+        this.hideProjects(event.projectNames);
         break;
 
       case 'notifyGraphShowAllProjects':
@@ -349,14 +349,18 @@ export class GraphService {
     this.transferToRenderGraph(nodesToRender.union(edgesToRender));
   }
 
-  hideProject(projectName: string) {
+  hideProjects(projectNames: string[]) {
     const currentNodes =
       this.renderGraph?.nodes() ?? this.traversalGraph.collection();
-    const nodeToHide = this.renderGraph.$id(projectName);
+    let nodesToHide = this.renderGraph.collection();
+
+    projectNames.forEach((projectName) => {
+      nodesToHide = nodesToHide.union(this.renderGraph.$id(projectName));
+    });
 
     const nodesToAdd = currentNodes
-      .difference(nodeToHide)
-      .difference(nodeToHide.ancestors());
+      .difference(nodesToHide)
+      .difference(nodesToHide.ancestors());
     const ancestorsToAdd = nodesToAdd.ancestors();
 
     let nodesToRender = nodesToAdd.union(ancestorsToAdd);

--- a/graph/ui-graph/src/lib/interfaces.ts
+++ b/graph/ui-graph/src/lib/interfaces.ts
@@ -34,6 +34,8 @@ export type DepGraphUIEvents =
     }
   | { type: 'selectProject'; projectName: string }
   | { type: 'deselectProject'; projectName: string }
+  | { type: 'selectProjects'; projectNames: string[] }
+  | { type: 'deselectProjects'; projectNames: string[] }
   | { type: 'selectAll' }
   | { type: 'deselectAll' }
   | { type: 'selectAffected' }
@@ -103,12 +105,12 @@ export type GraphRenderEvents =
       searchDepth: number;
     }
   | {
-      type: 'notifyGraphShowProject';
-      projectName: string;
+      type: 'notifyGraphShowProjects';
+      projectNames: string[];
     }
   | {
-      type: 'notifyGraphHideProject';
-      projectName: string;
+      type: 'notifyGraphHideProjects';
+      projectNames: string[];
     }
   | {
       type: 'notifyGraphShowAllProjects';


### PR DESCRIPTION
## Current Behavior
* Showing or hiding a directory of projects sends an individual event for each project added or hidden, resulting in a graph re-render for each one.

## Expected Behavior
* Showing or hiding a directory of projects sends a single events which causes a single graph re-render
