### PR TITLE
fix(js): patch migration from @nrwl/node:package to @nrwl/js:tsc to rename srcRootForCompilationRoot option to rootDir

### DIFF
--- a/packages/node/src/migrations/update-13-8-5/update-package-to-tsc.spec.ts
+++ b/packages/node/src/migrations/update-13-8-5/update-package-to-tsc.spec.ts
@@ -67,4 +67,52 @@ describe('Migration: rename package to tsc', () => {
 
     expect(tasks).toBeUndefined();
   });
+
+  it('should migrate srcRootForCompilationRoot option to rootDir', async () => {
+    let tree = createTreeWithEmptyV1Workspace();
+
+    tree.write(
+      'workspace.json',
+      JSON.stringify({
+        version: 2,
+        projects: {
+          mylib: {
+            root: 'libs/mylib',
+            sourceRoot: 'libs/mylib/src',
+            projectType: 'library',
+            targets: {
+              build: {
+                executor: '@nrwl/node:package',
+                options: {
+                  srcRootForCompilationRoot: '.',
+                },
+              },
+            },
+          },
+        },
+      })
+    );
+
+    const tasks = await update(tree);
+
+    expect(tasks).toBeDefined();
+    expect(readJson(tree, 'workspace.json')).toEqual({
+      version: 2,
+      projects: {
+        mylib: {
+          root: 'libs/mylib',
+          sourceRoot: 'libs/mylib/src',
+          projectType: 'library',
+          targets: {
+            build: {
+              executor: '@nrwl/js:tsc',
+              options: {
+                rootDir: '.',
+              },
+            },
+          },
+        },
+      },
+    });
+  });
 });

--- a/packages/node/src/migrations/update-13-8-5/update-package-to-tsc.ts
+++ b/packages/node/src/migrations/update-13-8-5/update-package-to-tsc.ts
@@ -29,6 +29,18 @@ export default async function update(host: Tree) {
           transformers;
       }
 
+      if (
+        projectConfiguration.targets[targetName].options
+          ?.srcRootForCompilationRoot
+      ) {
+        projectConfiguration.targets[targetName].options.rootDir =
+          projectConfiguration.targets[
+            targetName
+          ].options.srcRootForCompilationRoot;
+        delete projectConfiguration.targets[targetName].options
+          .srcRootForCompilationRoot;
+      }
+
       updateProjectConfiguration(host, projectName, projectConfiguration);
     }
   );


### PR DESCRIPTION
This fixes an issue with the previous migration where `srcRootForCompilationRoot` was not renamed to `rootDir`. Should also be cherry-picked to 14.x version.


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Users run into errors after migration and have to manually update options per-project.

## Expected Behavior
Nx migration automatically update options.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
