### PR TITLE
fix(nextjs): guard against missing webpack-loader 'issuer' field

### DIFF
--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -79,7 +79,7 @@ export function withNx(
           rule.sideEffects === false && regexEqual(rule.test, /\.module\.css$/)
       );
       // Might not be found if Next.js webpack config changes in the future
-      if (nextCssLoader) {
+      if (nextCssLoader && nextCssLoader.issuer) {
         nextCssLoader.issuer.or = nextCssLoader.issuer.and
           ? nextCssLoader.issuer.and.concat(includes)
           : includes;
@@ -95,7 +95,7 @@ export function withNx(
           regexEqual(rule.test, /\.module\.(scss|sass)$/)
       );
       // Might not be found if Next.js webpack config changes in the future
-      if (nextSassLoader) {
+      if (nextSassLoader && nextSassLoader.issuer) {
         nextSassLoader.issuer.or = nextSassLoader.issuer.and
           ? nextSassLoader.issuer.and.concat(includes)
           : includes;


### PR DESCRIPTION
Next.js v13+ removed the 'issuer' field from their css/sass loaders. This breaks the nx-next plugin 'withNx'. This PR just adds a check to ensure the 'issuer' field is still there. Not the most robust fix but it should at least maintain backwards-compatibility w/ folks using next.js < 13.

ISSUES CLOSED: #12916, #12912

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
