### PR TITLE
feat(testing): Add multi devServerTargets support.

### DIFF
--- a/docs/generated/packages/cypress.json
+++ b/docs/generated/packages/cypress.json
@@ -230,7 +230,7 @@
           },
           "devServerTarget": {
             "type": "string",
-            "description": "Dev server target to run tests against."
+            "description": "Dev server target(s) to run tests against. Multiple dev server targets can be specified with comma separated values, e.g: 'app1:target1:config1, app2:target2:config2', of which last dev server target yielded baseUrl will be passed over to Cypress."
           },
           "headed": {
             "type": "boolean",

--- a/packages/cypress/src/executors/cypress/schema.json
+++ b/packages/cypress/src/executors/cypress/schema.json
@@ -39,7 +39,7 @@
     },
     "devServerTarget": {
       "type": "string",
-      "description": "Dev server target to run tests against."
+      "description": "Dev server target(s) to run tests against. Multiple dev server targets can be specified with comma separated values, e.g: 'app1:target1:config1, app2:target2:config2', of which last dev server target yielded baseUrl will be passed over to Cypress."
     },
     "headed": {
       "type": "boolean",


### PR DESCRIPTION
This adds optional multi `devServerTarget` support, should be backwards compatible with existing single `devServerTarget`. 

Fixes #3748 

This is my first PR. Please let me know if there's any issues. Thanks.