### PR TITLE
feat(bundling): vite plugin executors

### DIFF
--- a/docs/generated/packages/vite.json
+++ b/docs/generated/packages/vite.json
@@ -11,7 +11,7 @@
       "id": "overview",
       "path": "/packages/vite",
       "file": "shared/vite-plugin",
-      "content": "The Nx plugin for [Vite](https://vitejs.dev/) and [Vitest](https://vitest.dev/).\n\n{% callout type=\"warning\" title=\"Early release plugin\" %}\nThis Nx plugin is in active development and may not be ready for real-world use. The planned release date for the stable plugin is December, 2022.\n{% /callout %}\n\nWhy should you use this plugin?\n\n- Instant dev server start\n- Lightning fast Hot-Module Reloading\n- _Fast_ builds using Vite.\n- Vite-powered tests with smart and instant watch mode\n\n## Setting up Vite\n\nTo create a new workspace, run `npx create-nx-workspace@latest --preset=npm`.\n\nTo add the Vite plugin to an existing workspace, run the following:\n\n{% tabs %}\n{% tab label=\"npm\" %}\n\n```shell\nnpm install -D @nrwl/vite\n```\n\n{% /tab %}\n{% tab label=\"yarn\" %}\n\n```shell\nyarn add -D @nrwl/vite\n```\n\n{% /tab %}\n{% tab label=\"pnpm\" %}\n\n```shell\npnpm install -D @nrwl/vite\n```\n\n{% /tab %}\n{% /tabs %}\n"
+      "content": "The Nx plugin for [Vite](https://vitejs.dev/) and [Vitest](https://vitest.dev/).\n\n{% callout type=\"warning\" title=\"Early release plugin\" %}\nThis Nx plugin is in active development and may not be ready for real-world use. The planned release date for the stable plugin is December, 2022.\n{% /callout %}\n\n[Vite.js](https://vitejs.dev/) is a build tool that aims to provide a faster and leaner development experience for modern web projects.\n\nWhy should you use this plugin?\n\n- Instant dev server start\n- Lightning fast Hot-Module Reloading\n- _Fast_ builds using Vite.\n- Vite-powered tests with smart and instant watch mode\n\nRead more about Vite and Vitest in the [Vite documentation](https://vitejs.dev/).\n\n## Setting up Vite\n\nTo create a new workspace, run `npx create-nx-workspace@latest --preset=vite`.\n\n### Add Vite to an existing workspace\n\nTo add the Vite plugin to an existing workspace, run the following:\n\n{% tabs %}\n{% tab label=\"npm\" %}\n\n```shell\nnpm install -D @nrwl/vite\n```\n\n{% /tab %}\n{% tab label=\"yarn\" %}\n\n```shell\nyarn add -D @nrwl/vite\n```\n\n{% /tab %}\n{% tab label=\"pnpm\" %}\n\n```shell\npnpm install -D @nrwl/vite\n```\n\n{% /tab %}\n{% /tabs %}\n\n### Initialize Vite.js\n\nAfter you install the plugin, you need to initialize Vite.js. You can do this by running the `init` executor. This executor will make sure to install all the necessary dependencies.\n\n```bash\nnx g @nrwl/vite:init\n```\n\n{% callout type=\"note\" title=\"Choosing a framework\" %}\nYou will notice that the executor will ask you of the framework you are planning to use. This is just to make sure that the right dependencies are installed. You can always install manually any other dependencies you need.\n{% /callout %}\n\n## Using Vite.js in a React application\n\nYou can use the `@nrwl/vite:dev-server` and the `@nrwl/vite:build` executors to serve and build your React applications using Vite.js. To do this, you need to make a few adjustments to your application.\n\n{% github-repository url=\"https://github.com/mandarini/nx-recipes/tree/feat/react-vite-recipe/react-vite\" /%}\n\n### 1. Change the executors in your `project.json`\n\n#### The `serve` target\n\nIn your app's `project.json` file, change the executor of your `serve` target to use `@nrwl/vite:dev-server` and set it up with the following options:\n\n```json\n//...\n\"my-app\": {\n    \"targets\": {\n        //...\n        \"serve\": {\n            \"executor\": \"@nrwl/vite:dev-server\",\n            \"defaultConfiguration\": \"development\",\n            \"options\": {\n                \"buildTarget\": \"my-app:build\",\n                \"port\": 4200,\n            },\n            \"configurations\": {\n                ...\n            }\n        },\n    }\n}\n```\n\n{% callout type=\"note\" title=\"Other options\" %}\nYou do not have to set the `port` here, necessarily. You can also specify the port in the `vite.config.ts` file (see **Step 2** below).\nThe same goes for all other Vite.js options that you can find the [Vite.js documentation](https://vitejs.dev/config/). All these can be added in your `vite.config.ts` file.\n{% /callout %}\n\n#### The `build` target\n\nIn your app's `project.json` file, change the executor of your `build` target to use `@nrwl/vite:build` and set it up with the following options:\n\n```json\n//...\n\"my-app\": {\n    \"targets\": {\n        //...\n        \"build\": {\n        \"executor\": \"@nrwl/vite:build\",\n        ...\n        \"options\": {\n            \"outputPath\": \"dist/apps/my-app\"\n        },\n        \"configurations\": {\n                ...\n            }\n        },\n    }\n}\n```\n\n{% callout type=\"note\" title=\"Other options\" %}\nYou can specify more options in the `vite.config.ts` file (see **Step 2** below).\n{% /callout %}\n\n### 2. Configure Vite.js\n\nAdd a `vite.config.ts` file to the root of your app, and add the `'@vitejs/plugin-react'` plugin to it:\n\n```ts\n// eg. apps/my-app/vite.config.ts\nimport { defineConfig } from 'vite';\nimport react from '@vitejs/plugin-react';\nimport ViteTsConfigPathsPlugin from 'vite-tsconfig-paths';\n\nexport default defineConfig({\n  plugins: [\n    react(),\n    ViteTsConfigPathsPlugin({\n      root: '../../',\n      projects: ['tsconfig.base.json'],\n    }),\n  ],\n});\n```\n\n{% callout type=\"note\" title=\"The `root` path\" %}\nMake sure the `root` path in the `ViteTsConfigPathsPlugin` options is correct. It should be the path to the root of your workspace.\n{% /callout %}\n\nIn that config file, you can configure Vite.js as you would normally do. For more information, see the [Vite.js documentation](https://vitejs.dev/config/).\n\n### 3. Move `index.html` and point it to your app's entrypoint\n\nFirst of all, move your `index.html` file to the root of your app (eg. from `apps/my-app/src/index.html` to `apps/my-app/index.html`).\n\nThen, add a module `script` tag pointing to the `main.tsx` file of your app:\n\n```html\n...\n  <body>\n    <div id=\"root\"></div>\n    <script type=\"module\" src=\"src/main.tsx\"></script>\n  </body>\n</html>\n```\n\n### 4. Add a `public` folder\n\nYou can add a `public` folder to the root of your app. You can read more about the public folder in the [Vite.js documentation](https://vitejs.dev/guide/assets.html#the-public-directory). Use that folder as you would normally do.\n\n```treeview\nmyorg/\n├── apps/\n│   ├── my-app/\n│   │   ├── src/\n│   │   │   ├── app/\n│   │   │   ├── assets/\n│   │   │   ├── ...\n│   │   │   └── main.tsx\n│   │   ├── index.html\n│   │   ├── public/\n│   │   │   └── my-page.md\n│   │   ├── project.json\n│   │   ├── ...\n│   │   ├── tsconfig.app.json\n│   │   ├── tsconfig.json\n│   │   └── tsconfig.spec.json\n```\n\n### 5. Adjust your app's tsconfig.json\n\nChange your app's `tsconfig.json` (eg. `apps/my-app/tsconfig.json`) `compilerOptions` to the following:\n\n```json\n...\n  \"compilerOptions\": {\n    \"jsx\": \"react-jsx\",\n    \"allowJs\": false,\n    \"esModuleInterop\": false,\n    \"allowSyntheticDefaultImports\": true,\n    \"forceConsistentCasingInFileNames\": true,\n    \"isolatedModules\": true,\n    \"lib\": [\"DOM\", \"DOM.Iterable\", \"ESNext\"],\n    \"module\": \"ESNext\",\n    \"moduleResolution\": \"Node\",\n    \"noEmit\": true,\n    \"resolveJsonModule\": true,\n    \"skipLibCheck\": true,\n    \"strict\": true,\n    \"target\": \"ESNext\",\n    \"types\": [\"vite/client\"],\n    \"useDefineForClassFields\": true\n  },\n...\n```\n\nYou can read more about the TypeScript compiler options in the [Vite.js documentation](https://vitejs.dev/guide/features.html#typescript-compiler-options).\n\n### 6. Use Vite.js!\n\nNow you can finally serve and build your app using Vite.js:\n\n#### Serve the app\n\n```\nnx serve my-app\n```\n\nor\n\n```\nnx run my-app:serve\n```\n\nNow, visit [http://localhost:4200](http://localhost:4200) to see your app running!\n\n#### Build the app\n\n```\nnx build my-app\n```\n\nor\n\n```\nnx run my-app:build\n```\n"
     }
   ],
   "generators": [
@@ -42,5 +42,226 @@
       "path": "/packages/vite/src/generators/init/schema.json"
     }
   ],
-  "executors": []
+  "executors": [
+    {
+      "name": "dev-server",
+      "implementation": "/packages/vite/src/executors/dev-server/dev-server.impl.ts",
+      "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
+        "title": "Vite Dev Server",
+        "cli": "nx",
+        "description": "Dev server for Vite.",
+        "type": "object",
+        "presets": [{ "name": "Default minimum setup", "keys": [] }],
+        "properties": {
+          "buildTarget": {
+            "type": "string",
+            "description": "Target which builds the application."
+          },
+          "baseHref": {
+            "type": "string",
+            "description": "Base url for the application being built."
+          },
+          "proxyConfig": {
+            "type": "string",
+            "description": "Path to the proxy configuration file.",
+            "x-completion-type": "file"
+          },
+          "fileReplacements": {
+            "description": "Replace files with other files in the build.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "replace": {
+                  "type": "string",
+                  "description": "The file to be replaced.",
+                  "x-completion-type": "file"
+                },
+                "with": {
+                  "type": "string",
+                  "description": "The file to replace with.",
+                  "x-completion-type": "file"
+                }
+              },
+              "additionalProperties": false,
+              "required": ["replace", "with"]
+            },
+            "default": []
+          },
+          "port": {
+            "type": "number",
+            "description": "Port to listen on.",
+            "default": 4200
+          },
+          "host": {
+            "description": "Specify which IP addresses the server should listen on.",
+            "default": "localhost",
+            "oneOf": [{ "type": "boolean" }, { "type": "string" }]
+          },
+          "https": {
+            "type": "boolean",
+            "description": "Serve using HTTPS.",
+            "default": false
+          },
+          "hmr": {
+            "description": "Enable hot module replacement. For more options, use the 'hmr' option in the Vite configuration file.",
+            "default": false,
+            "type": "boolean"
+          }
+        },
+        "definitions": {},
+        "required": [],
+        "examplesFile": "`project.json`:\n\n```json\n//...\n\"my-app\": {\n    \"targets\": {\n        //...\n        \"serve\": {\n            \"executor\": \"@nrwl/vite:dev-server\",\n            \"defaultConfiguration\": \"development\",\n            \"options\": {\n                \"buildTarget\": \"my-app:build\",\n            },\n            \"configurations\": {\n                ...\n            }\n        },\n    }\n}\n```\n\n```bash\nnx serve my-app\n```\n\n## Examples\n\n{% tabs %}\n{% tab label=\"Set up a custom port\" %}\n\nYou can always set the port in your `vite.config.ts` file. However, you can also set it directly in your `project.json` file, in the `serve` target options:\n\n```json\n//...\n\"my-app\": {\n    \"targets\": {\n        //...\n        \"serve\": {\n            \"executor\": \"@nrwl/vite:dev-server\",\n            \"defaultConfiguration\": \"development\",\n            \"options\": {\n                \"buildTarget\": \"my-app:build\",\n                \"port\": 4200,\n            },\n            \"configurations\": {\n                ...\n            }\n        },\n    }\n}\n```\n\n{% /tab %}\n{% tab label=\"Set a custom path for vite.config.ts\" %}\n\nNx will automatically look in the root of your application for a `vite.config.ts` (or a `vite.config.js`) file. If you want to use a different path, you can set it in your `project.json` file, in the `serve` target options:\n\n```json\n//...\n\"my-app\": {\n    \"targets\": {\n        //...\n        \"serve\": {\n            \"executor\": \"@nrwl/vite:dev-server\",\n            \"defaultConfiguration\": \"development\",\n            \"options\": {\n                \"buildTarget\": \"my-app:build\",\n                \"configFile\": \"apps/my-app/vite.config.other-path.ts\"\n            },\n            \"configurations\": {\n                ...\n            }\n        },\n    }\n}\n```\n\nor even\n\n```json\n//...\n\"my-app\": {\n    \"targets\": {\n        //...\n        \"serve\": {\n            \"executor\": \"@nrwl/vite:dev-server\",\n            \"defaultConfiguration\": \"development\",\n            \"options\": {\n                \"buildTarget\": \"my-app:build\",\n                \"configFile\": \"vite.config.base.ts\"\n            },\n            \"configurations\": {\n                ...\n            }\n        },\n    }\n}\n```\n\n{% /tab %}\n\n{% tab label=\"Specify a proxyConfig\" %}\n\nYou can specify a proxy config by pointing to the path of your proxy configuration file:\n\n```json\n//...\n\"my-app\": {\n    \"targets\": {\n        //...\n        \"serve\": {\n            \"executor\": \"@nrwl/vite:dev-server\",\n            \"defaultConfiguration\": \"development\",\n            \"options\": {\n                \"buildTarget\": \"my-app:build\",\n                \"proxyConfig\": \"apps/my-app/proxy.conf.json\"\n            },\n            \"configurations\": {\n                ...\n            }\n        },\n    }\n}\n```\n\n{% /tab %}\n\n{% /tabs %}\n"
+      },
+      "description": "Vite dev server.",
+      "aliases": [],
+      "hidden": false,
+      "path": "/packages/vite/src/executors/dev-server/schema.json"
+    },
+    {
+      "name": "build",
+      "implementation": "/packages/vite/src/executors/build/build.impl.ts",
+      "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
+        "title": "Vite Prod Builder",
+        "cli": "nx",
+        "description": "Build using Vite.",
+        "type": "object",
+        "presets": [{ "name": "Default minimum setup", "keys": [] }],
+        "properties": {
+          "outputPath": {
+            "type": "string",
+            "description": "The output path of the generated files.",
+            "x-completion-type": "directory"
+          },
+          "baseHref": {
+            "type": "string",
+            "description": "Base url for the application being built."
+          },
+          "proxyConfig": {
+            "type": "string",
+            "description": "Path to the proxy configuration file.",
+            "x-completion-type": "file"
+          },
+          "tsConfig": {
+            "type": "string",
+            "description": "The name of the Typescript configuration file.",
+            "x-completion-type": "file",
+            "x-completion-glob": "tsconfig.*.json"
+          },
+          "configFile": {
+            "type": "string",
+            "description": "The name of the Vite.js configuration file.",
+            "x-completion-type": "file"
+          },
+          "assets": {
+            "type": "array",
+            "description": "List of static application assets.",
+            "default": [],
+            "items": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "glob": {
+                      "type": "string",
+                      "description": "The pattern to match."
+                    },
+                    "input": {
+                      "type": "string",
+                      "description": "The input directory path in which to apply 'glob'. Defaults to the project root."
+                    },
+                    "ignore": {
+                      "description": "An array of globs to ignore.",
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "output": {
+                      "type": "string",
+                      "description": "Absolute path within the output."
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": ["glob", "input", "output"]
+                },
+                { "type": "string" }
+              ]
+            }
+          },
+          "fileReplacements": {
+            "description": "Replace files with other files in the build.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "replace": {
+                  "type": "string",
+                  "description": "The file to be replaced.",
+                  "x-completion-type": "file"
+                },
+                "with": {
+                  "type": "string",
+                  "description": "The file to replace with.",
+                  "x-completion-type": "file"
+                }
+              },
+              "additionalProperties": false,
+              "required": ["replace", "with"]
+            },
+            "default": []
+          },
+          "sourcemap": {
+            "description": "Output sourcemaps. Use 'hidden' for use with error reporting tools without generating sourcemap comment.",
+            "default": true,
+            "oneOf": [{ "type": "boolean" }, { "type": "string" }]
+          },
+          "hmr": {
+            "description": "Enable hot module replacement. For more options, use the 'hmr' option in the Vite configuration file.",
+            "default": false,
+            "type": "boolean"
+          }
+        },
+        "definitions": {
+          "assetPattern": {
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "glob": {
+                    "type": "string",
+                    "description": "The pattern to match."
+                  },
+                  "input": {
+                    "type": "string",
+                    "description": "The input directory path in which to apply 'glob'. Defaults to the project root."
+                  },
+                  "ignore": {
+                    "description": "An array of globs to ignore.",
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "output": {
+                    "type": "string",
+                    "description": "Absolute path within the output."
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["glob", "input", "output"]
+              },
+              { "type": "string" }
+            ]
+          }
+        },
+        "required": [],
+        "examplesFile": "`project.json`:\n\n```json\n//...\n\"my-app\": {\n    \"targets\": {\n        //...\n        \"build\": {\n            \"executor\": \"@nrwl/vite:build\",\n            //...\n            //...\n            \"options\": {\n                \"outputPath\": \"dist/apps/my-app\"\n            },\n                //...\n            }\n        },\n    }\n}\n```\n\n```bash\nnx serve my-app\n```\n\n## Examples\n\n{% tabs %}\n{% tab label=\"Set a custom path for vite.config.ts\" %}\n\nNx will automatically look in the root of your application for a `vite.config.ts` (or a `vite.config.js`) file. If you want to use a different path, you can set it in your `project.json` file, in the `build` target options:\n\n```json\n//...\n\"my-app\": {\n    \"targets\": {\n        //...\n        \"build\": {\n            \"executor\": \"@nrwl/vite:build\",\n            //...\n            \"options\": {\n                \"outputPath\": \"dist/apps/my-app\",\n                \"configFile\": \"apps/my-app/vite.config.other-path.ts\"\n            },\n            \"configurations\": {\n                ...\n            }\n        },\n    }\n}\n```\n\nor even\n\n```json\n//...\n\"my-app\": {\n    \"targets\": {\n        //...\n        \"build\": {\n            \"executor\": \"@nrwl/vite:build\",\n            //...\n            \"options\": {\n                \"outputPath\": \"dist/apps/my-app\",\n                \"configFile\": \"vite.config.base.ts\"\n            },\n            \"configurations\": {\n                ...\n            }\n        },\n    }\n}\n```\n\n{% /tab %}\n\n{% tab label=\"Adding assets\" %}\n\nAssets are non-JS and non-TS files, such as images, CSS, etc. You can add them to the project configuration as follows.\n\n```jsonc\n\"serve\": {\n \"executor\": \"@nrwl/vite:build\",\n  \"options\": {\n    //...\n    \"assets\": [\n      { \"input\": \"apps/my-app\", \"glob\": \"README.md\", \"output\": \"/\" },\n      { \"input\": \"apps/my-app\", \"glob\": \"logo.png\", \"output\": \"/\" },\n      { \"input\": \"apps/my-app\", \"glob\": \"docs/**/*.md\", \"output\": \"/docs\" },\n      //...\n    ]\n }\n}\n```\n\nRunning `nx build my-app` outputs something like this.\n\n```text\ndist/apps/my-app/\n├── README.md\n├── docs\n│   ├── CONTRIBUTING.md\n│   └── TESTING.md\n├── index.js\n├── logo.png\n└── package.json\n```\n\n{% /tab %}\n\n{% /tabs %}\n"
+      },
+      "description": "Build with Vite.",
+      "aliases": [],
+      "hidden": false,
+      "path": "/packages/vite/src/executors/build/schema.json"
+    }
+  ]
 }

--- a/docs/packages.json
+++ b/docs/packages.json
@@ -373,7 +373,7 @@
     "packageName": "vite",
     "description": "The Nx Plugin for building and testing applications using Vite (Early Release)",
     "path": "generated/packages/vite.json",
-    "schemas": { "executors": [], "generators": ["init"] }
+    "schemas": { "executors": ["dev-server", "build"], "generators": ["init"] }
   },
   {
     "name": "web",

--- a/docs/shared/vite-plugin.md
+++ b/docs/shared/vite-plugin.md
@@ -4,6 +4,8 @@ The Nx plugin for [Vite](https://vitejs.dev/) and [Vitest](https://vitest.dev/).
 This Nx plugin is in active development and may not be ready for real-world use. The planned release date for the stable plugin is December, 2022.
 {% /callout %}
 
+[Vite.js](https://vitejs.dev/) is a build tool that aims to provide a faster and leaner development experience for modern web projects.
+
 Why should you use this plugin?
 
 - Instant dev server start
@@ -11,9 +13,13 @@ Why should you use this plugin?
 - _Fast_ builds using Vite.
 - Vite-powered tests with smart and instant watch mode
 
+Read more about Vite and Vitest in the [Vite documentation](https://vitejs.dev/).
+
 ## Setting up Vite
 
-To create a new workspace, run `npx create-nx-workspace@latest --preset=npm`.
+To create a new workspace, run `npx create-nx-workspace@latest --preset=vite`.
+
+### Add Vite to an existing workspace
 
 To add the Vite plugin to an existing workspace, run the following:
 
@@ -40,3 +46,203 @@ pnpm install -D @nrwl/vite
 
 {% /tab %}
 {% /tabs %}
+
+### Initialize Vite.js
+
+After you install the plugin, you need to initialize Vite.js. You can do this by running the `init` executor. This executor will make sure to install all the necessary dependencies.
+
+```bash
+nx g @nrwl/vite:init
+```
+
+{% callout type="note" title="Choosing a framework" %}
+You will notice that the executor will ask you of the framework you are planning to use. This is just to make sure that the right dependencies are installed. You can always install manually any other dependencies you need.
+{% /callout %}
+
+## Using Vite.js in a React application
+
+You can use the `@nrwl/vite:dev-server` and the `@nrwl/vite:build` executors to serve and build your React applications using Vite.js. To do this, you need to make a few adjustments to your application.
+
+{% github-repository url="https://github.com/mandarini/nx-recipes/tree/feat/react-vite-recipe/react-vite" /%}
+
+### 1. Change the executors in your `project.json`
+
+#### The `serve` target
+
+In your app's `project.json` file, change the executor of your `serve` target to use `@nrwl/vite:dev-server` and set it up with the following options:
+
+```json
+//...
+"my-app": {
+    "targets": {
+        //...
+        "serve": {
+            "executor": "@nrwl/vite:dev-server",
+            "defaultConfiguration": "development",
+            "options": {
+                "buildTarget": "my-app:build",
+                "port": 4200,
+            },
+            "configurations": {
+                ...
+            }
+        },
+    }
+}
+```
+
+{% callout type="note" title="Other options" %}
+You do not have to set the `port` here, necessarily. You can also specify the port in the `vite.config.ts` file (see **Step 2** below).
+The same goes for all other Vite.js options that you can find the [Vite.js documentation](https://vitejs.dev/config/). All these can be added in your `vite.config.ts` file.
+{% /callout %}
+
+#### The `build` target
+
+In your app's `project.json` file, change the executor of your `build` target to use `@nrwl/vite:build` and set it up with the following options:
+
+```json
+//...
+"my-app": {
+    "targets": {
+        //...
+        "build": {
+        "executor": "@nrwl/vite:build",
+        ...
+        "options": {
+            "outputPath": "dist/apps/my-app"
+        },
+        "configurations": {
+                ...
+            }
+        },
+    }
+}
+```
+
+{% callout type="note" title="Other options" %}
+You can specify more options in the `vite.config.ts` file (see **Step 2** below).
+{% /callout %}
+
+### 2. Configure Vite.js
+
+Add a `vite.config.ts` file to the root of your app, and add the `'@vitejs/plugin-react'` plugin to it:
+
+```ts
+// eg. apps/my-app/vite.config.ts
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import ViteTsConfigPathsPlugin from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [
+    react(),
+    ViteTsConfigPathsPlugin({
+      root: '../../',
+      projects: ['tsconfig.base.json'],
+    }),
+  ],
+});
+```
+
+{% callout type="note" title="The `root` path" %}
+Make sure the `root` path in the `ViteTsConfigPathsPlugin` options is correct. It should be the path to the root of your workspace.
+{% /callout %}
+
+In that config file, you can configure Vite.js as you would normally do. For more information, see the [Vite.js documentation](https://vitejs.dev/config/).
+
+### 3. Move `index.html` and point it to your app's entrypoint
+
+First of all, move your `index.html` file to the root of your app (eg. from `apps/my-app/src/index.html` to `apps/my-app/index.html`).
+
+Then, add a module `script` tag pointing to the `main.tsx` file of your app:
+
+```html
+...
+  <body>
+    <div id="root"></div>
+    <script type="module" src="src/main.tsx"></script>
+  </body>
+</html>
+```
+
+### 4. Add a `public` folder
+
+You can add a `public` folder to the root of your app. You can read more about the public folder in the [Vite.js documentation](https://vitejs.dev/guide/assets.html#the-public-directory). Use that folder as you would normally do.
+
+```treeview
+myorg/
+├── apps/
+│   ├── my-app/
+│   │   ├── src/
+│   │   │   ├── app/
+│   │   │   ├── assets/
+│   │   │   ├── ...
+│   │   │   └── main.tsx
+│   │   ├── index.html
+│   │   ├── public/
+│   │   │   └── my-page.md
+│   │   ├── project.json
+│   │   ├── ...
+│   │   ├── tsconfig.app.json
+│   │   ├── tsconfig.json
+│   │   └── tsconfig.spec.json
+```
+
+### 5. Adjust your app's tsconfig.json
+
+Change your app's `tsconfig.json` (eg. `apps/my-app/tsconfig.json`) `compilerOptions` to the following:
+
+```json
+...
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "allowJs": false,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ESNext",
+    "types": ["vite/client"],
+    "useDefineForClassFields": true
+  },
+...
+```
+
+You can read more about the TypeScript compiler options in the [Vite.js documentation](https://vitejs.dev/guide/features.html#typescript-compiler-options).
+
+### 6. Use Vite.js!
+
+Now you can finally serve and build your app using Vite.js:
+
+#### Serve the app
+
+```
+nx serve my-app
+```
+
+or
+
+```
+nx run my-app:serve
+```
+
+Now, visit [http://localhost:4200](http://localhost:4200) to see your app running!
+
+#### Build the app
+
+```
+nx build my-app
+```
+
+or
+
+```
+nx run my-app:build
+```

--- a/e2e/vite/src/vite.test.ts
+++ b/e2e/vite/src/vite.test.ts
@@ -1,15 +1,135 @@
-import { cleanupProject, newProject } from '@nrwl/e2e/utils';
+import {
+  cleanupProject,
+  createFile,
+  killPorts,
+  newProject,
+  readFile,
+  rmDist,
+  runCLI,
+  runCommandUntil,
+  uniq,
+  updateFile,
+  updateProjectConfig,
+} from '@nrwl/e2e/utils';
+
+const myApp = uniq('my-app');
 
 describe('Vite Plugin', () => {
   let proj: string;
 
-  beforeEach(() => (proj = newProject()));
+  beforeEach(() => {
+    proj = newProject();
+    runCLI(`generate @nrwl/react:app ${myApp}`);
+    runCLI(`generate @nrwl/vite:init`);
+    updateFile(
+      `apps/${myApp}/index.html`,
+      `
+    <!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>My App</title>
+    <base href="/" />
 
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="src/main.tsx"></script>
+  </body>
+</html>
+    `
+    );
+
+    createFile(
+      `apps/${myApp}/vite.config.ts`,
+      `
+    import { defineConfig } from 'vite';
+    import react from '@vitejs/plugin-react';
+    import plugin from 'vite-tsconfig-paths';
+
+    export default defineConfig({
+      plugins: [
+        react(),
+        plugin({
+          root: '../../',
+          projects: ['tsconfig.base.json'],
+        }),
+      ],
+    });`
+    );
+
+    updateFile(
+      `apps/${myApp}/tsconfig.json`,
+      `
+      {
+        "extends": "../../tsconfig.base.json",
+        "compilerOptions": {
+          "jsx": "react-jsx",
+          "allowJs": false,
+          "esModuleInterop": false,
+          "allowSyntheticDefaultImports": true,
+          "forceConsistentCasingInFileNames": true,
+          "isolatedModules": true,
+          "lib": ["DOM", "DOM.Iterable", "ESNext"],
+          "module": "ESNext",
+          "moduleResolution": "Node",
+          "noEmit": true,
+          "resolveJsonModule": true,
+          "skipLibCheck": true,
+          "strict": true,
+          "target": "ESNext",
+          "types": ["vite/client"],
+          "useDefineForClassFields": true
+        },
+        "files": [],
+        "include": [],
+        "references": [
+          {
+            "path": "./tsconfig.app.json"
+          },
+          {
+            "path": "./tsconfig.spec.json"
+          }
+        ]
+      }
+    `
+    );
+
+    updateProjectConfig(myApp, (config) => {
+      config.targets.build.executor = '@nrwl/vite:build';
+      config.targets.serve.executor = '@nrwl/vite:dev-server';
+
+      config.targets.build.options = {
+        outputPath: `dist/apps/${myApp}`,
+      };
+
+      config.targets.serve.options = {
+        buildTarget: `${myApp}:build`,
+      };
+
+      return config;
+    });
+  });
   afterEach(() => cleanupProject());
 
-  xit('should build applications', () => {});
+  it('should build applications', async () => {
+    runCLI(`build ${myApp}`);
+    expect(readFile(`dist/apps/${myApp}/index.html`)).toBeDefined();
+    rmDist();
+  }, 200000);
 
-  xit('should serve applications in dev mode', () => {});
+  describe('serve using Vite', () => {
+    afterEach(() => killPorts());
+
+    it('should serve applications in dev mode', async () => {
+      const p = await runCommandUntil(`run ${myApp}:serve`, (output) => {
+        return output.includes('Local:');
+      });
+      p.kill();
+    }, 200000);
+  });
 
   xit('should test applications', () => {});
 });

--- a/package.json
+++ b/package.json
@@ -240,6 +240,7 @@
     "unzipper": "^0.10.11",
     "url-loader": "^4.1.1",
     "verdaccio": "^5.0.4",
+    "vite": "^3.2.3",
     "webpack": "^5.58.1",
     "webpack-dev-server": "^4.9.3",
     "webpack-merge": "^5.8.0",

--- a/packages/vite/docs/build-examples.md
+++ b/packages/vite/docs/build-examples.md
@@ -1,0 +1,111 @@
+`project.json`:
+
+```json
+//...
+"my-app": {
+    "targets": {
+        //...
+        "build": {
+            "executor": "@nrwl/vite:build",
+            //...
+            //...
+            "options": {
+                "outputPath": "dist/apps/my-app"
+            },
+                //...
+            }
+        },
+    }
+}
+```
+
+```bash
+nx serve my-app
+```
+
+## Examples
+
+{% tabs %}
+{% tab label="Set a custom path for vite.config.ts" %}
+
+Nx will automatically look in the root of your application for a `vite.config.ts` (or a `vite.config.js`) file. If you want to use a different path, you can set it in your `project.json` file, in the `build` target options:
+
+```json
+//...
+"my-app": {
+    "targets": {
+        //...
+        "build": {
+            "executor": "@nrwl/vite:build",
+            //...
+            "options": {
+                "outputPath": "dist/apps/my-app",
+                "configFile": "apps/my-app/vite.config.other-path.ts"
+            },
+            "configurations": {
+                ...
+            }
+        },
+    }
+}
+```
+
+or even
+
+```json
+//...
+"my-app": {
+    "targets": {
+        //...
+        "build": {
+            "executor": "@nrwl/vite:build",
+            //...
+            "options": {
+                "outputPath": "dist/apps/my-app",
+                "configFile": "vite.config.base.ts"
+            },
+            "configurations": {
+                ...
+            }
+        },
+    }
+}
+```
+
+{% /tab %}
+
+{% tab label="Adding assets" %}
+
+Assets are non-JS and non-TS files, such as images, CSS, etc. You can add them to the project configuration as follows.
+
+```jsonc
+"serve": {
+ "executor": "@nrwl/vite:build",
+  "options": {
+    //...
+    "assets": [
+      { "input": "apps/my-app", "glob": "README.md", "output": "/" },
+      { "input": "apps/my-app", "glob": "logo.png", "output": "/" },
+      { "input": "apps/my-app", "glob": "docs/**/*.md", "output": "/docs" },
+      //...
+    ]
+ }
+}
+```
+
+Running `nx build my-app` outputs something like this.
+
+```text
+dist/apps/my-app/
+├── README.md
+├── docs
+│   ├── CONTRIBUTING.md
+│   └── TESTING.md
+├── index.js
+├── logo.png
+└── package.json
+```
+
+{% /tab %}
+
+{% /tabs %}

--- a/packages/vite/docs/dev-server-examples.md
+++ b/packages/vite/docs/dev-server-examples.md
@@ -1,0 +1,128 @@
+`project.json`:
+
+```json
+//...
+"my-app": {
+    "targets": {
+        //...
+        "serve": {
+            "executor": "@nrwl/vite:dev-server",
+            "defaultConfiguration": "development",
+            "options": {
+                "buildTarget": "my-app:build",
+            },
+            "configurations": {
+                ...
+            }
+        },
+    }
+}
+```
+
+```bash
+nx serve my-app
+```
+
+## Examples
+
+{% tabs %}
+{% tab label="Set up a custom port" %}
+
+You can always set the port in your `vite.config.ts` file. However, you can also set it directly in your `project.json` file, in the `serve` target options:
+
+```json
+//...
+"my-app": {
+    "targets": {
+        //...
+        "serve": {
+            "executor": "@nrwl/vite:dev-server",
+            "defaultConfiguration": "development",
+            "options": {
+                "buildTarget": "my-app:build",
+                "port": 4200,
+            },
+            "configurations": {
+                ...
+            }
+        },
+    }
+}
+```
+
+{% /tab %}
+{% tab label="Set a custom path for vite.config.ts" %}
+
+Nx will automatically look in the root of your application for a `vite.config.ts` (or a `vite.config.js`) file. If you want to use a different path, you can set it in your `project.json` file, in the `serve` target options:
+
+```json
+//...
+"my-app": {
+    "targets": {
+        //...
+        "serve": {
+            "executor": "@nrwl/vite:dev-server",
+            "defaultConfiguration": "development",
+            "options": {
+                "buildTarget": "my-app:build",
+                "configFile": "apps/my-app/vite.config.other-path.ts"
+            },
+            "configurations": {
+                ...
+            }
+        },
+    }
+}
+```
+
+or even
+
+```json
+//...
+"my-app": {
+    "targets": {
+        //...
+        "serve": {
+            "executor": "@nrwl/vite:dev-server",
+            "defaultConfiguration": "development",
+            "options": {
+                "buildTarget": "my-app:build",
+                "configFile": "vite.config.base.ts"
+            },
+            "configurations": {
+                ...
+            }
+        },
+    }
+}
+```
+
+{% /tab %}
+
+{% tab label="Specify a proxyConfig" %}
+
+You can specify a proxy config by pointing to the path of your proxy configuration file:
+
+```json
+//...
+"my-app": {
+    "targets": {
+        //...
+        "serve": {
+            "executor": "@nrwl/vite:dev-server",
+            "defaultConfiguration": "development",
+            "options": {
+                "buildTarget": "my-app:build",
+                "proxyConfig": "apps/my-app/proxy.conf.json"
+            },
+            "configurations": {
+                ...
+            }
+        },
+    }
+}
+```
+
+{% /tab %}
+
+{% /tabs %}

--- a/packages/vite/executors.json
+++ b/packages/vite/executors.json
@@ -1,4 +1,26 @@
 {
-  "builders": {},
-  "executors": {}
+  "builders": {
+    "dev-server": {
+      "implementation": "./src/executors/dev-server/compat",
+      "schema": "./src/executors/dev-server/schema.json",
+      "description": "Vite dev server."
+    },
+    "build": {
+      "implementation": "./src/executors/build/compat",
+      "schema": "./src/executors/build/schema.json",
+      "description": "Build with Vite."
+    }
+  },
+  "executors": {
+    "dev-server": {
+      "implementation": "./src/executors/dev-server/dev-server.impl",
+      "schema": "./src/executors/dev-server/schema.json",
+      "description": "Vite dev server."
+    },
+    "build": {
+      "implementation": "./src/executors/build/build.impl",
+      "schema": "./src/executors/build/schema.json",
+      "description": "Build with Vite."
+    }
+  }
 }

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -28,11 +28,16 @@
     "requirements": {},
     "migrations": "./migrations.json"
   },
+  "peerDependencies": {
+    "vite": "^3.2.3"
+  },
   "dependencies": {
     "@nrwl/devkit": "file:../devkit",
     "@nrwl/workspace": "file:../workspace",
+    "@nrwl/js": "file:../js",
     "@swc/helpers": "^0.4.11",
-    "chalk": "4.1.0"
+    "chalk": "4.1.0",
+    "dotenv": "~10.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/vite/plugins/rollup-replace-files.plugin.ts
+++ b/packages/vite/plugins/rollup-replace-files.plugin.ts
@@ -1,0 +1,42 @@
+// source: https://github.com/Myrmod/vitejs-theming/blob/master/build-plugins/rollup/replace-files.js
+
+/**
+ * @function replaceFiles
+ * @param {FileReplacement[]} replacements
+ * @return {({name: "rollup-plugin-replace-files", enforce: "pre", Promise<resolveId>})}
+ */
+export default function replaceFiles(replacements: FileReplacement[]) {
+  if (!replacements?.length) {
+    return null;
+  }
+  return {
+    name: 'rollup-plugin-replace-files',
+    enforce: 'pre',
+    async resolveId(source, importer) {
+      const resolved = await this.resolve(source, importer, { skipSelf: true });
+      const foundReplace = replacements.find(
+        (replacement) => replacement.replace === resolved?.id
+      );
+      if (foundReplace) {
+        console.info(
+          `replace "${foundReplace.replace}" with "${foundReplace.with}"`
+        );
+        try {
+          // return new file content
+          return {
+            id: foundReplace.with,
+          };
+        } catch (err) {
+          console.error(err);
+          return null;
+        }
+      }
+      return null;
+    },
+  };
+}
+
+export interface FileReplacement {
+  replace: string;
+  with: string;
+}

--- a/packages/vite/src/executors/build/build.impl.ts
+++ b/packages/vite/src/executors/build/build.impl.ts
@@ -1,0 +1,33 @@
+import { ExecutorContext, logger } from '@nrwl/devkit';
+import { build, InlineConfig } from 'vite';
+import 'dotenv/config';
+import { getBuildConfig } from '../../utils/helper-functions';
+import { ViteBuildExecutorOptions } from './schema';
+import { copyAssets } from '@nrwl/js';
+
+export default async function viteBuildExecutor(
+  options: ViteBuildExecutorOptions,
+  context: ExecutorContext
+) {
+  if (options.assets) {
+    await copyAssets(
+      {
+        outputPath: options.outputPath,
+        assets: options.assets,
+      },
+      context
+    );
+  }
+
+  logger.info(`NX Vite builder starting ...`);
+  await runInstance(await getBuildConfig(options, context));
+  logger.info(`NX Vite builder finished ...`);
+  logger.info(`NX Vite files available in ${options.outputPath}`);
+  return { success: true };
+}
+
+function runInstance(options: InlineConfig) {
+  return build({
+    ...options,
+  });
+}

--- a/packages/vite/src/executors/build/compat.ts
+++ b/packages/vite/src/executors/build/compat.ts
@@ -1,0 +1,4 @@
+import { convertNxExecutor } from '@nrwl/devkit';
+import viteBuildExecutor from './build.impl';
+
+export default convertNxExecutor(viteBuildExecutor);

--- a/packages/vite/src/executors/build/schema.d.ts
+++ b/packages/vite/src/executors/build/schema.d.ts
@@ -1,0 +1,13 @@
+import type { AssetGlob } from '@nrwl/workspace/src/utilities/assets';
+import type { FileReplacement } from '../../plugins/rollup-replace-files.plugin';
+export interface ViteBuildExecutorOptions {
+  outputPath?: string;
+  baseHref?: string;
+  proxyConfig?: string;
+  tsConfig?: string;
+  configFile?: string;
+  assets: AssetGlob[];
+  fileReplacements: FileReplacement[];
+  sourcemap?: boolean | 'inline' | 'hidden';
+  hmr?: boolean;
+}

--- a/packages/vite/src/executors/build/schema.json
+++ b/packages/vite/src/executors/build/schema.json
@@ -1,0 +1,125 @@
+{
+  "version": 2,
+  "outputCapture": "direct-nodejs",
+  "title": "Vite Prod Builder",
+  "cli": "nx",
+  "description": "Build using Vite.",
+  "type": "object",
+  "presets": [
+    {
+      "name": "Default minimum setup",
+      "keys": []
+    }
+  ],
+  "properties": {
+    "outputPath": {
+      "type": "string",
+      "description": "The output path of the generated files.",
+      "x-completion-type": "directory"
+    },
+    "baseHref": {
+      "type": "string",
+      "description": "Base url for the application being built."
+    },
+    "proxyConfig": {
+      "type": "string",
+      "description": "Path to the proxy configuration file.",
+      "x-completion-type": "file"
+    },
+    "tsConfig": {
+      "type": "string",
+      "description": "The name of the Typescript configuration file.",
+      "x-completion-type": "file",
+      "x-completion-glob": "tsconfig.*.json"
+    },
+    "configFile": {
+      "type": "string",
+      "description": "The name of the Vite.js configuration file.",
+      "x-completion-type": "file"
+    },
+    "assets": {
+      "type": "array",
+      "description": "List of static application assets.",
+      "default": [],
+      "items": {
+        "$ref": "#/definitions/assetPattern"
+      }
+    },
+    "fileReplacements": {
+      "description": "Replace files with other files in the build.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "replace": {
+            "type": "string",
+            "description": "The file to be replaced.",
+            "x-completion-type": "file"
+          },
+          "with": {
+            "type": "string",
+            "description": "The file to replace with.",
+            "x-completion-type": "file"
+          }
+        },
+        "additionalProperties": false,
+        "required": ["replace", "with"]
+      },
+      "default": []
+    },
+    "sourcemap": {
+      "description": "Output sourcemaps. Use 'hidden' for use with error reporting tools without generating sourcemap comment.",
+      "default": true,
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "hmr": {
+      "description": "Enable hot module replacement. For more options, use the 'hmr' option in the Vite configuration file.",
+      "default": false,
+      "type": "boolean"
+    }
+  },
+  "definitions": {
+    "assetPattern": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "glob": {
+              "type": "string",
+              "description": "The pattern to match."
+            },
+            "input": {
+              "type": "string",
+              "description": "The input directory path in which to apply 'glob'. Defaults to the project root."
+            },
+            "ignore": {
+              "description": "An array of globs to ignore.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "output": {
+              "type": "string",
+              "description": "Absolute path within the output."
+            }
+          },
+          "additionalProperties": false,
+          "required": ["glob", "input", "output"]
+        },
+        {
+          "type": "string"
+        }
+      ]
+    }
+  },
+  "required": [],
+  "examplesFile": "../../../docs/build-examples.md"
+}

--- a/packages/vite/src/executors/dev-server/compat.ts
+++ b/packages/vite/src/executors/dev-server/compat.ts
@@ -1,0 +1,4 @@
+import { convertNxExecutor } from '@nrwl/devkit';
+import viteDevServerExecutor from './dev-server.impl';
+
+export default convertNxExecutor(viteDevServerExecutor);

--- a/packages/vite/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/vite/src/executors/dev-server/dev-server.impl.ts
@@ -1,0 +1,81 @@
+import { ExecutorContext } from '@nrwl/devkit';
+
+import 'dotenv/config';
+import { InlineConfig, createServer, mergeConfig, ViteDevServer } from 'vite';
+
+import {
+  getBuildConfig,
+  getBuildTargetOptions,
+  getServerOptions,
+} from '../../utils/helper-functions';
+
+import { copyAssets, CopyAssetsResult } from '@nrwl/js';
+
+import { ViteDevServerExecutorOptions } from './schema';
+import { ViteBuildExecutorOptions } from '../build/schema';
+
+export default async function* viteDevServerExecutor(
+  options: ViteDevServerExecutorOptions,
+  context: ExecutorContext
+): AsyncGenerator<{ success: boolean; baseUrl: string }> {
+  const mergedOptions = {
+    ...getBuildTargetOptions(options, context),
+    ...options,
+  } as ViteDevServerExecutorOptions & ViteBuildExecutorOptions;
+
+  let assetsResult: CopyAssetsResult;
+  if (mergedOptions.assets) {
+    assetsResult = await copyAssets(
+      {
+        outputPath: mergedOptions.outputPath,
+        assets: mergedOptions.assets ?? [],
+        watch: true,
+      },
+      context
+    );
+  }
+
+  const serverConfig: InlineConfig = mergeConfig(
+    await getBuildConfig(mergedOptions, context),
+    {
+      server: getServerOptions(mergedOptions, context),
+    } as InlineConfig
+  );
+
+  const server = await createServer(serverConfig);
+
+  await runViteDevServer(server, assetsResult);
+
+  yield {
+    success: true,
+    baseUrl: `${mergedOptions.https ? 'https' : 'http'}://${
+      mergedOptions.host ?? 'localhost'
+    }:${mergedOptions.port ?? 4200}`,
+  };
+
+  // This Promise intentionally never resolves, leaving the process running
+  await new Promise<{ success: boolean }>(() => {});
+}
+
+async function runViteDevServer(
+  server: ViteDevServer,
+  assetsResult: CopyAssetsResult
+) {
+  try {
+    await server.listen();
+    server.printUrls();
+
+    const processOnExit = () => {
+      assetsResult?.stop();
+      process.off('SIGINT', processOnExit);
+      process.off('SIGTERM', processOnExit);
+      process.off('exit', processOnExit);
+    };
+
+    process.on('SIGINT', processOnExit);
+    process.on('SIGTERM', processOnExit);
+    process.on('exit', processOnExit);
+  } catch (err) {
+    console.log(err);
+  }
+}

--- a/packages/vite/src/executors/dev-server/schema.d.ts
+++ b/packages/vite/src/executors/dev-server/schema.d.ts
@@ -1,0 +1,11 @@
+import type { FileReplacement } from '../../plugins/rollup-replace-files.plugin';
+export interface ViteDevServerExecutorOptions {
+  buildTarget: string;
+  baseHref?: string;
+  proxyConfig?: string;
+  fileReplacements: FileReplacement[];
+  port?: number;
+  host?: string | boolean;
+  https?: boolean;
+  hmr?: boolean;
+}

--- a/packages/vite/src/executors/dev-server/schema.json
+++ b/packages/vite/src/executors/dev-server/schema.json
@@ -1,0 +1,82 @@
+{
+  "version": 2,
+  "outputCapture": "direct-nodejs",
+  "title": "Vite Dev Server",
+  "cli": "nx",
+  "description": "Dev server for Vite.",
+  "type": "object",
+  "presets": [
+    {
+      "name": "Default minimum setup",
+      "keys": []
+    }
+  ],
+  "properties": {
+    "buildTarget": {
+      "type": "string",
+      "description": "Target which builds the application."
+    },
+    "baseHref": {
+      "type": "string",
+      "description": "Base url for the application being built."
+    },
+    "proxyConfig": {
+      "type": "string",
+      "description": "Path to the proxy configuration file.",
+      "x-completion-type": "file"
+    },
+    "fileReplacements": {
+      "description": "Replace files with other files in the build.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "replace": {
+            "type": "string",
+            "description": "The file to be replaced.",
+            "x-completion-type": "file"
+          },
+          "with": {
+            "type": "string",
+            "description": "The file to replace with.",
+            "x-completion-type": "file"
+          }
+        },
+        "additionalProperties": false,
+        "required": ["replace", "with"]
+      },
+      "default": []
+    },
+
+    "port": {
+      "type": "number",
+      "description": "Port to listen on.",
+      "default": 4200
+    },
+    "host": {
+      "description": "Specify which IP addresses the server should listen on.",
+      "default": "localhost",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "https": {
+      "type": "boolean",
+      "description": "Serve using HTTPS.",
+      "default": false
+    },
+    "hmr": {
+      "description": "Enable hot module replacement. For more options, use the 'hmr' option in the Vite configuration file.",
+      "default": false,
+      "type": "boolean"
+    }
+  },
+  "definitions": {},
+  "required": [],
+  "examplesFile": "../../../docs/dev-server-examples.md"
+}

--- a/packages/vite/src/generators/init/__snapshots__/init.spec.ts.snap
+++ b/packages/vite/src/generators/init/__snapshots__/init.spec.ts.snap
@@ -12,6 +12,7 @@ Object {
     "existing": "1.0.0",
     "vite": "^3.0.5",
     "vite-plugin-eslint": "^1.6.0",
+    "vite-tsconfig-paths": "^3.5.2",
     "vitest": "^0.19.1",
   },
   "name": "test-name",

--- a/packages/vite/src/generators/init/init.ts
+++ b/packages/vite/src/generators/init/init.ts
@@ -13,6 +13,7 @@ import {
   viteVersion,
   vitestUiVersion,
   vitestVersion,
+  viteTsConfigPathsVersion,
 } from '../../utils/versions';
 import { Schema } from './schema';
 
@@ -27,6 +28,7 @@ function checkDependenciesInstalled(host: Tree, schema: Schema) {
   devDependencies['@nrwl/vite'] = nxVersion;
   devDependencies['vite'] = viteVersion;
   devDependencies['vite-plugin-eslint'] = vitePluginEslintVersion;
+  devDependencies['vite-tsconfig-paths'] = viteTsConfigPathsVersion;
   devDependencies['vitest'] = vitestVersion;
   devDependencies['@vitest/ui'] = vitestUiVersion;
 

--- a/packages/vite/src/utils/helper-functions.ts
+++ b/packages/vite/src/utils/helper-functions.ts
@@ -1,0 +1,158 @@
+import {
+  ExecutorContext,
+  joinPathFragments,
+  logger,
+  parseTargetString,
+  readTargetOptions,
+} from '@nrwl/devkit';
+import { existsSync } from 'fs';
+import { join, relative } from 'path';
+import {
+  BuildOptions,
+  defineConfig,
+  InlineConfig,
+  mergeConfig,
+  searchForWorkspaceRoot,
+  ServerOptions,
+  UserConfig,
+  UserConfigFn,
+} from 'vite';
+import { ViteDevServerExecutorOptions } from '../executors/dev-server/schema';
+import replaceFiles from '../../plugins/rollup-replace-files.plugin';
+import { ViteBuildExecutorOptions } from '../executors/build/schema';
+
+export async function getBuildConfig(
+  options:
+    | (ViteDevServerExecutorOptions & ViteBuildExecutorOptions)
+    | ViteBuildExecutorOptions,
+  context: ExecutorContext
+): Promise<InlineConfig> {
+  const projectRoot = context.workspace.projects[context.projectName].root;
+
+  const userConfig: UserConfig = await getUserConfig(
+    options as ViteDevServerExecutorOptions & ViteBuildExecutorOptions,
+    context,
+    projectRoot
+  );
+
+  return mergeConfig(userConfig, {
+    configFile: normalizeConfigFilePath(
+      options.configFile,
+      context.root,
+      projectRoot
+    ),
+    build: getViteBuildOptions(
+      options as ViteDevServerExecutorOptions & ViteBuildExecutorOptions,
+      projectRoot
+    ),
+  } as InlineConfig);
+}
+
+export function normalizeConfigFilePath(
+  configFile: string,
+  workspaceRoot: string,
+  projectRoot: string
+): string {
+  return configFile
+    ? joinPathFragments(`${workspaceRoot}/${configFile}`)
+    : existsSync(joinPathFragments(`${projectRoot}/vite.config.ts`))
+    ? joinPathFragments(`${projectRoot}/vite.config.ts`)
+    : existsSync(joinPathFragments(`${projectRoot}/vite.config.js`))
+    ? joinPathFragments(`${projectRoot}/vite.config.js`)
+    : undefined;
+}
+
+export function normalizeTsConfigPath(
+  tsConfig: string,
+  workspaceRoot: string
+): string {
+  return tsConfig
+    ? joinPathFragments(`${workspaceRoot}/${tsConfig}`)
+    : undefined;
+}
+
+export async function getUserConfig(
+  options: ViteDevServerExecutorOptions & ViteBuildExecutorOptions,
+  context: ExecutorContext,
+  projectRoot: string
+): Promise<UserConfig> {
+  const baseUserConfig: UserConfigFn = (await defineConfig(() => {
+    return {
+      base: options.baseHref ?? '/',
+      root: projectRoot,
+      tsConfig: normalizeTsConfigPath(options.tsConfig, context.root),
+    };
+  })) as UserConfigFn;
+  return baseUserConfig({
+    command: 'build',
+    mode: options['configurationName'],
+  });
+}
+
+export function getServerOptions(
+  options: ViteDevServerExecutorOptions,
+  context: ExecutorContext
+): ServerOptions {
+  const projectRoot = context.workspace.projects[context.projectName].root;
+  let serverOptions: ServerOptions = {};
+  if (options.proxyConfig) {
+    const proxyConfigPath = options.proxyConfig
+      ? join(context.root, options.proxyConfig)
+      : join(projectRoot, 'proxy.conf.json');
+
+    if (existsSync(proxyConfigPath)) {
+      logger.info(`Loading proxy configuration from: ${proxyConfigPath}`);
+      serverOptions.proxy = require(proxyConfigPath);
+      serverOptions.fs = {
+        allow: [
+          searchForWorkspaceRoot(joinPathFragments(projectRoot)),
+          joinPathFragments(context.root, 'node_modules/vite'),
+        ],
+      };
+    }
+  }
+
+  serverOptions = {
+    ...serverOptions,
+    host: options.host,
+    port: options.port,
+    https: options.https,
+    hmr: options.hmr,
+  };
+
+  return serverOptions;
+}
+
+export function getBuildTargetOptions(
+  options: ViteDevServerExecutorOptions,
+  context: ExecutorContext
+) {
+  const target = parseTargetString(options.buildTarget);
+  return readTargetOptions(target, context);
+}
+
+export function getViteBuildOptions(
+  options: ViteDevServerExecutorOptions & ViteBuildExecutorOptions,
+  projectRoot: string
+): BuildOptions {
+  let buildOptions: BuildOptions = {
+    outDir: relative(projectRoot, options.outputPath),
+    emptyOutDir: true,
+    reportCompressedSize: true,
+    cssCodeSplit: true,
+    target: 'esnext',
+    commonjsOptions: {
+      transformMixedEsModules: true,
+    },
+    rollupOptions: {
+      plugins: [replaceFiles(options.fileReplacements)],
+    },
+  };
+
+  buildOptions = {
+    ...buildOptions,
+    sourcemap: options.sourcemap,
+  };
+
+  return buildOptions;
+}

--- a/packages/vite/src/utils/versions.ts
+++ b/packages/vite/src/utils/versions.ts
@@ -6,3 +6,4 @@ export const vitestUiVersion = '^0.9.3';
 export const vitePluginReactVersion = '^2.2.0';
 export const vitePluginVueVersion = '^3.2.0';
 export const vitePluginVueJsxVersion = '^2.1.1';
+export const viteTsConfigPathsVersion = '^3.5.2';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2233,10 +2233,20 @@
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.15.12.tgz#e548b10a5e55b9e10537a049ebf0bc72c453b769"
   integrity sha512-IC7TqIqiyE0MmvAhWkl/8AEzpOtbhRNDo7aph47We1NbE5w2bt/Q+giAhe0YYeVpYnIhGMcuZY92qDK6dQauvA==
 
+"@esbuild/android-arm@0.15.13":
+  version "0.15.13"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.15.13.tgz#ce11237a13ee76d5eae3908e47ba4ddd380af86a"
+  integrity sha512-RY2fVI8O0iFUNvZirXaQ1vMvK0xhCcl0gqRj74Z6yEiO1zAUa7hbsdwZM1kzqbxHK7LFyMizipfXT3JME+12Hw==
+
 "@esbuild/linux-loong64@0.15.12":
   version "0.15.12"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.15.12.tgz#475b33a2631a3d8ca8aa95ee127f9a61d95bf9c1"
   integrity sha512-tZEowDjvU7O7I04GYvWQOS4yyP9E/7YlsB0jjw1Ycukgr2ycEzKyIk5tms5WnLBymaewc6VmRKnn5IJWgK4eFw==
+
+"@esbuild/linux-loong64@0.15.13":
+  version "0.15.13"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.15.13.tgz#64e8825bf0ce769dac94ee39d92ebe6272020dfc"
+  integrity sha512-+BoyIm4I8uJmH/QDIH0fu7MG0AEx9OXEDXnqptXCwKOlOqZiS4iraH1Nr7/ObLMokW3sOCeBNyD68ATcV9b9Ag==
 
 "@esbuild/linux-loong64@0.15.5":
   version "0.15.5"
@@ -11034,6 +11044,11 @@ esbuild-android-64@0.15.12:
   resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.15.12.tgz#5e8151d5f0a748c71a7fbea8cee844ccf008e6fc"
   integrity sha512-MJKXwvPY9g0rGps0+U65HlTsM1wUs9lbjt5CU19RESqycGFDRijMDQsh68MtbzkqWSRdEtiKS1mtPzKneaAI0Q==
 
+esbuild-android-64@0.15.13:
+  version "0.15.13"
+  resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.15.13.tgz#5f25864055dbd62e250f360b38b4c382224063af"
+  integrity sha512-yRorukXBlokwTip+Sy4MYskLhJsO0Kn0/Fj43s1krVblfwP+hMD37a4Wmg139GEsMLl+vh8WXp2mq/cTA9J97g==
+
 esbuild-android-64@0.15.5:
   version "0.15.5"
   resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.15.5.tgz#3c7b2f2a59017dab3f2c0356188a8dd9cbdc91c8"
@@ -11043,6 +11058,11 @@ esbuild-android-arm64@0.15.12:
   version "0.15.12"
   resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.15.12.tgz#5ee72a6baa444bc96ffcb472a3ba4aba2cc80666"
   integrity sha512-Hc9SEcZbIMhhLcvhr1DH+lrrec9SFTiRzfJ7EGSBZiiw994gfkVV6vG0sLWqQQ6DD7V4+OggB+Hn0IRUdDUqvA==
+
+esbuild-android-arm64@0.15.13:
+  version "0.15.13"
+  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.15.13.tgz#d8820f999314efbe8e0f050653a99ff2da632b0f"
+  integrity sha512-TKzyymLD6PiVeyYa4c5wdPw87BeAiTXNtK6amWUcXZxkV51gOk5u5qzmDaYSwiWeecSNHamFsaFjLoi32QR5/w==
 
 esbuild-android-arm64@0.15.5:
   version "0.15.5"
@@ -11054,6 +11074,11 @@ esbuild-darwin-64@0.15.12:
   resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.15.12.tgz#70047007e093fa1b3ba7ef86f9b3fa63db51fe25"
   integrity sha512-qkmqrTVYPFiePt5qFjP8w/S+GIUMbt6k8qmiPraECUWfPptaPJUGkCKrWEfYFRWB7bY23FV95rhvPyh/KARP8Q==
 
+esbuild-darwin-64@0.15.13:
+  version "0.15.13"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.15.13.tgz#99ae7fdaa43947b06cd9d1a1c3c2c9f245d81fd0"
+  integrity sha512-WAx7c2DaOS6CrRcoYCgXgkXDliLnFv3pQLV6GeW1YcGEZq2Gnl8s9Pg7ahValZkpOa0iE/ojRVQ87sbUhF1Cbg==
+
 esbuild-darwin-64@0.15.5:
   version "0.15.5"
   resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.15.5.tgz#11726de5d0bf5960b92421ef433e35871c091f8d"
@@ -11063,6 +11088,11 @@ esbuild-darwin-arm64@0.15.12:
   version "0.15.12"
   resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.12.tgz#41c951f23d9a70539bcca552bae6e5196696ae04"
   integrity sha512-z4zPX02tQ41kcXMyN3c/GfZpIjKoI/BzHrdKUwhC/Ki5BAhWv59A9M8H+iqaRbwpzYrYidTybBwiZAIWCLJAkw==
+
+esbuild-darwin-arm64@0.15.13:
+  version "0.15.13"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.13.tgz#bafa1814354ad1a47adcad73de416130ef7f55e3"
+  integrity sha512-U6jFsPfSSxC3V1CLiQqwvDuj3GGrtQNB3P3nNC3+q99EKf94UGpsG9l4CQ83zBs1NHrk1rtCSYT0+KfK5LsD8A==
 
 esbuild-darwin-arm64@0.15.5:
   version "0.15.5"
@@ -11074,6 +11104,11 @@ esbuild-freebsd-64@0.15.12:
   resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.12.tgz#a761b5afd12bbedb7d56c612e9cfa4d2711f33f0"
   integrity sha512-XFL7gKMCKXLDiAiBjhLG0XECliXaRLTZh6hsyzqUqPUf/PY4C6EJDTKIeqqPKXaVJ8+fzNek88285krSz1QECw==
 
+esbuild-freebsd-64@0.15.13:
+  version "0.15.13"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.13.tgz#84ef85535c5cc38b627d1c5115623b088d1de161"
+  integrity sha512-whItJgDiOXaDG/idy75qqevIpZjnReZkMGCgQaBWZuKHoElDJC1rh7MpoUgupMcdfOd+PgdEwNQW9DAE6i8wyA==
+
 esbuild-freebsd-64@0.15.5:
   version "0.15.5"
   resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.5.tgz#6bfb52b4a0d29c965aa833e04126e95173289c8a"
@@ -11083,6 +11118,11 @@ esbuild-freebsd-arm64@0.15.12:
   version "0.15.12"
   resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.12.tgz#6b0839d4d58deabc6cbd96276eb8cbf94f7f335e"
   integrity sha512-jwEIu5UCUk6TjiG1X+KQnCGISI+ILnXzIzt9yDVrhjug2fkYzlLbl0K43q96Q3KB66v6N1UFF0r5Ks4Xo7i72g==
+
+esbuild-freebsd-arm64@0.15.13:
+  version "0.15.13"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.13.tgz#033f21de434ec8e0c478054b119af8056763c2d8"
+  integrity sha512-6pCSWt8mLUbPtygv7cufV0sZLeylaMwS5Fznj6Rsx9G2AJJsAjQ9ifA+0rQEIg7DwJmi9it+WjzNTEAzzdoM3Q==
 
 esbuild-freebsd-arm64@0.15.5:
   version "0.15.5"
@@ -11094,6 +11134,11 @@ esbuild-linux-32@0.15.12:
   resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.15.12.tgz#bd50bfe22514d434d97d5150977496e2631345b4"
   integrity sha512-uSQuSEyF1kVzGzuIr4XM+v7TPKxHjBnLcwv2yPyCz8riV8VUCnO/C4BF3w5dHiVpCd5Z1cebBtZJNlC4anWpwA==
 
+esbuild-linux-32@0.15.13:
+  version "0.15.13"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.15.13.tgz#54290ea8035cba0faf1791ce9ae6693005512535"
+  integrity sha512-VbZdWOEdrJiYApm2kkxoTOgsoCO1krBZ3quHdYk3g3ivWaMwNIVPIfEE0f0XQQ0u5pJtBsnk2/7OPiCFIPOe/w==
+
 esbuild-linux-32@0.15.5:
   version "0.15.5"
   resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.15.5.tgz#942dc70127f0c0a7ea91111baf2806e61fc81b32"
@@ -11103,6 +11148,11 @@ esbuild-linux-64@0.15.12:
   version "0.15.12"
   resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.15.12.tgz#074bb2b194bf658245f8490f29c01ffcdfa8c931"
   integrity sha512-QcgCKb7zfJxqT9o5z9ZUeGH1k8N6iX1Y7VNsEi5F9+HzN1OIx7ESxtQXDN9jbeUSPiRH1n9cw6gFT3H4qbdvcA==
+
+esbuild-linux-64@0.15.13:
+  version "0.15.13"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.15.13.tgz#4264249281ea388ead948614b57fb1ddf7779a2c"
+  integrity sha512-rXmnArVNio6yANSqDQlIO4WiP+Cv7+9EuAHNnag7rByAqFVuRusLbGi2697A5dFPNXoO//IiogVwi3AdcfPC6A==
 
 esbuild-linux-64@0.15.5:
   version "0.15.5"
@@ -11114,6 +11164,11 @@ esbuild-linux-arm64@0.15.12:
   resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.12.tgz#3bf789c4396dc032875a122988efd6f3733f28f5"
   integrity sha512-HtNq5xm8fUpZKwWKS2/YGwSfTF+339L4aIA8yphNKYJckd5hVdhfdl6GM2P3HwLSCORS++++7++//ApEwXEuAQ==
 
+esbuild-linux-arm64@0.15.13:
+  version "0.15.13"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.13.tgz#9323c333924f97a02bdd2ae8912b36298acb312d"
+  integrity sha512-alEMGU4Z+d17U7KQQw2IV8tQycO6T+rOrgW8OS22Ua25x6kHxoG6Ngry6Aq6uranC+pNWNMB6aHFPh7aTQdORQ==
+
 esbuild-linux-arm64@0.15.5:
   version "0.15.5"
   resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.5.tgz#28cd899beb2d2b0a3870fd44f4526835089a318d"
@@ -11123,6 +11178,11 @@ esbuild-linux-arm@0.15.12:
   version "0.15.12"
   resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.15.12.tgz#b91b5a8d470053f6c2c9c8a5e67ec10a71fe4a67"
   integrity sha512-Wf7T0aNylGcLu7hBnzMvsTfEXdEdJY/hY3u36Vla21aY66xR0MS5I1Hw8nVquXjTN0A6fk/vnr32tkC/C2lb0A==
+
+esbuild-linux-arm@0.15.13:
+  version "0.15.13"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.15.13.tgz#b407f47b3ae721fe4e00e19e9f19289bef87a111"
+  integrity sha512-Ac6LpfmJO8WhCMQmO253xX2IU2B3wPDbl4IvR0hnqcPrdfCaUa2j/lLMGTjmQ4W5JsJIdHEdW12dG8lFS0MbxQ==
 
 esbuild-linux-arm@0.15.5:
   version "0.15.5"
@@ -11134,6 +11194,11 @@ esbuild-linux-mips64le@0.15.12:
   resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.12.tgz#2fb54099ada3c950a7536dfcba46172c61e580e2"
   integrity sha512-Qol3+AvivngUZkTVFgLpb0H6DT+N5/zM3V1YgTkryPYFeUvuT5JFNDR3ZiS6LxhyF8EE+fiNtzwlPqMDqVcc6A==
 
+esbuild-linux-mips64le@0.15.13:
+  version "0.15.13"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.13.tgz#bdf905aae5c0bcaa8f83567fe4c4c1bdc1f14447"
+  integrity sha512-47PgmyYEu+yN5rD/MbwS6DxP2FSGPo4Uxg5LwIdxTiyGC2XKwHhHyW7YYEDlSuXLQXEdTO7mYe8zQ74czP7W8A==
+
 esbuild-linux-mips64le@0.15.5:
   version "0.15.5"
   resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.5.tgz#d4927f817290eaffc062446896b2a553f0e11981"
@@ -11143,6 +11208,11 @@ esbuild-linux-ppc64le@0.15.12:
   version "0.15.12"
   resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.12.tgz#9e3b8c09825fb27886249dfb3142a750df29a1b7"
   integrity sha512-4D8qUCo+CFKaR0cGXtGyVsOI7w7k93Qxb3KFXWr75An0DHamYzq8lt7TNZKoOq/Gh8c40/aKaxvcZnTgQ0TJNg==
+
+esbuild-linux-ppc64le@0.15.13:
+  version "0.15.13"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.13.tgz#2911eae1c90ff58a3bd3259cb557235df25aa3b4"
+  integrity sha512-z6n28h2+PC1Ayle9DjKoBRcx/4cxHoOa2e689e2aDJSaKug3jXcQw7mM+GLg+9ydYoNzj8QxNL8ihOv/OnezhA==
 
 esbuild-linux-ppc64le@0.15.5:
   version "0.15.5"
@@ -11154,6 +11224,11 @@ esbuild-linux-riscv64@0.15.12:
   resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.12.tgz#923d0f5b6e12ee0d1fe116b08e4ae4478fe40693"
   integrity sha512-G9w6NcuuCI6TUUxe6ka0enjZHDnSVK8bO+1qDhMOCtl7Tr78CcZilJj8SGLN00zO5iIlwNRZKHjdMpfFgNn1VA==
 
+esbuild-linux-riscv64@0.15.13:
+  version "0.15.13"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.13.tgz#1837c660be12b1d20d2a29c7189ea703f93e9265"
+  integrity sha512-+Lu4zuuXuQhgLUGyZloWCqTslcCAjMZH1k3Xc9MSEJEpEFdpsSU0sRDXAnk18FKOfEjhu4YMGaykx9xjtpA6ow==
+
 esbuild-linux-riscv64@0.15.5:
   version "0.15.5"
   resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.5.tgz#2801bf18414dc3d3ad58d1ea83084f00d9d84896"
@@ -11163,6 +11238,11 @@ esbuild-linux-s390x@0.15.12:
   version "0.15.12"
   resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.12.tgz#3b1620220482b96266a0c6d9d471d451a1eab86f"
   integrity sha512-Lt6BDnuXbXeqSlVuuUM5z18GkJAZf3ERskGZbAWjrQoi9xbEIsj/hEzVnSAFLtkfLuy2DE4RwTcX02tZFunXww==
+
+esbuild-linux-s390x@0.15.13:
+  version "0.15.13"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.13.tgz#d52880ece229d1bd10b2d936b792914ffb07c7fc"
+  integrity sha512-BMeXRljruf7J0TMxD5CIXS65y7puiZkAh+s4XFV9qy16SxOuMhxhVIXYLnbdfLrsYGFzx7U9mcdpFWkkvy/Uag==
 
 esbuild-linux-s390x@0.15.5:
   version "0.15.5"
@@ -11174,6 +11254,11 @@ esbuild-netbsd-64@0.15.12:
   resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.12.tgz#276730f80da646859b1af5a740e7802d8cd73e42"
   integrity sha512-jlUxCiHO1dsqoURZDQts+HK100o0hXfi4t54MNRMCAqKGAV33JCVvMplLAa2FwviSojT/5ZG5HUfG3gstwAG8w==
 
+esbuild-netbsd-64@0.15.13:
+  version "0.15.13"
+  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.13.tgz#de14da46f1d20352b43e15d97a80a8788275e6ed"
+  integrity sha512-EHj9QZOTel581JPj7UO3xYbltFTYnHy+SIqJVq6yd3KkCrsHRbapiPb0Lx3EOOtybBEE9EyqbmfW1NlSDsSzvQ==
+
 esbuild-netbsd-64@0.15.5:
   version "0.15.5"
   resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.5.tgz#951bbf87600512dfcfbe3b8d9d117d684d26c1b8"
@@ -11184,6 +11269,11 @@ esbuild-openbsd-64@0.15.12:
   resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.12.tgz#bd0eea1dd2ca0722ed489d88c26714034429f8ae"
   integrity sha512-1o1uAfRTMIWNOmpf8v7iudND0L6zRBYSH45sofCZywrcf7NcZA+c7aFsS1YryU+yN7aRppTqdUK1PgbZVaB1Dw==
 
+esbuild-openbsd-64@0.15.13:
+  version "0.15.13"
+  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.13.tgz#45e8a5fd74d92ad8f732c43582369c7990f5a0ac"
+  integrity sha512-nkuDlIjF/sfUhfx8SKq0+U+Fgx5K9JcPq1mUodnxI0x4kBdCv46rOGWbuJ6eof2n3wdoCLccOoJAbg9ba/bT2w==
+
 esbuild-openbsd-64@0.15.5:
   version "0.15.5"
   resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.5.tgz#26705b61961d525d79a772232e8b8f211fdbb035"
@@ -11193,6 +11283,11 @@ esbuild-sunos-64@0.15.12:
   version "0.15.12"
   resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.15.12.tgz#5e56bf9eef3b2d92360d6d29dcde7722acbecc9e"
   integrity sha512-nkl251DpoWoBO9Eq9aFdoIt2yYmp4I3kvQjba3jFKlMXuqQ9A4q+JaqdkCouG3DHgAGnzshzaGu6xofGcXyPXg==
+
+esbuild-sunos-64@0.15.13:
+  version "0.15.13"
+  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.15.13.tgz#f646ac3da7aac521ee0fdbc192750c87da697806"
+  integrity sha512-jVeu2GfxZQ++6lRdY43CS0Tm/r4WuQQ0Pdsrxbw+aOrHQPHV0+LNOLnvbN28M7BSUGnJnHkHm2HozGgNGyeIRw==
 
 esbuild-sunos-64@0.15.5:
   version "0.15.5"
@@ -11214,6 +11309,11 @@ esbuild-windows-32@0.15.12:
   resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.15.12.tgz#a4f1a301c1a2fa7701fcd4b91ef9d2620cf293d0"
   integrity sha512-WlGeBZHgPC00O08luIp5B2SP4cNCp/PcS+3Pcg31kdcJPopHxLkdCXtadLU9J82LCfw4TVls21A6lilQ9mzHrw==
 
+esbuild-windows-32@0.15.13:
+  version "0.15.13"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.15.13.tgz#fb4fe77c7591418880b3c9b5900adc4c094f2401"
+  integrity sha512-XoF2iBf0wnqo16SDq+aDGi/+QbaLFpkiRarPVssMh9KYbFNCqPLlGAWwDvxEVz+ywX6Si37J2AKm+AXq1kC0JA==
+
 esbuild-windows-32@0.15.5:
   version "0.15.5"
   resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.15.5.tgz#0670326903f421424be86bc03b7f7b3ff86a9db7"
@@ -11224,6 +11324,11 @@ esbuild-windows-64@0.15.12:
   resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.15.12.tgz#bc2b467541744d653be4fe64eaa9b0dbbf8e07f6"
   integrity sha512-VActO3WnWZSN//xjSfbiGOSyC+wkZtI8I4KlgrTo5oHJM6z3MZZBCuFaZHd8hzf/W9KPhF0lY8OqlmWC9HO5AA==
 
+esbuild-windows-64@0.15.13:
+  version "0.15.13"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.15.13.tgz#1fca8c654392c0c31bdaaed168becfea80e20660"
+  integrity sha512-Et6htEfGycjDrtqb2ng6nT+baesZPYQIW+HUEHK4D1ncggNrDNk3yoboYQ5KtiVrw/JaDMNttz8rrPubV/fvPQ==
+
 esbuild-windows-64@0.15.5:
   version "0.15.5"
   resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.15.5.tgz#64f32acb7341f3f0a4d10e8ff1998c2d1ebfc0a9"
@@ -11233,6 +11338,11 @@ esbuild-windows-arm64@0.15.12:
   version "0.15.12"
   resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.12.tgz#9a7266404334a86be800957eaee9aef94c3df328"
   integrity sha512-Of3MIacva1OK/m4zCNIvBfz8VVROBmQT+gRX6pFTLPngFYcj6TFH/12VveAqq1k9VB2l28EoVMNMUCcmsfwyuA==
+
+esbuild-windows-arm64@0.15.13:
+  version "0.15.13"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.13.tgz#4ffd01b6b2888603f1584a2fe96b1f6a6f2b3dd8"
+  integrity sha512-3bv7tqntThQC9SWLRouMDmZnlOukBhOCTlkzNqzGCmrkCJI7io5LLjwJBOVY6kOUlIvdxbooNZwjtBvj+7uuVg==
 
 esbuild-windows-arm64@0.15.5:
   version "0.15.5"
@@ -11293,6 +11403,34 @@ esbuild@^0.15.0:
     esbuild-windows-32 "0.15.12"
     esbuild-windows-64 "0.15.12"
     esbuild-windows-arm64 "0.15.12"
+
+esbuild@^0.15.9:
+  version "0.15.13"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.15.13.tgz#7293480038feb2bafa91d3f6a20edab3ba6c108a"
+  integrity sha512-Cu3SC84oyzzhrK/YyN4iEVy2jZu5t2fz66HEOShHURcjSkOSAVL8C/gfUT+lDJxkVHpg8GZ10DD0rMHRPqMFaQ==
+  optionalDependencies:
+    "@esbuild/android-arm" "0.15.13"
+    "@esbuild/linux-loong64" "0.15.13"
+    esbuild-android-64 "0.15.13"
+    esbuild-android-arm64 "0.15.13"
+    esbuild-darwin-64 "0.15.13"
+    esbuild-darwin-arm64 "0.15.13"
+    esbuild-freebsd-64 "0.15.13"
+    esbuild-freebsd-arm64 "0.15.13"
+    esbuild-linux-32 "0.15.13"
+    esbuild-linux-64 "0.15.13"
+    esbuild-linux-arm "0.15.13"
+    esbuild-linux-arm64 "0.15.13"
+    esbuild-linux-mips64le "0.15.13"
+    esbuild-linux-ppc64le "0.15.13"
+    esbuild-linux-riscv64 "0.15.13"
+    esbuild-linux-s390x "0.15.13"
+    esbuild-netbsd-64 "0.15.13"
+    esbuild-openbsd-64 "0.15.13"
+    esbuild-sunos-64 "0.15.13"
+    esbuild-windows-32 "0.15.13"
+    esbuild-windows-64 "0.15.13"
+    esbuild-windows-arm64 "0.15.13"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -18861,7 +18999,7 @@ postcss@^8.1.10, postcss@^8.2.14, postcss@^8.3.5, postcss@^8.3.7, postcss@^8.4.1
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-postcss@^8.2.15:
+postcss@^8.2.15, postcss@^8.4.18:
   version "8.4.19"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.19.tgz#61178e2add236b17351897c8bcc0b4c8ecab56fc"
   integrity sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==
@@ -20161,7 +20299,7 @@ rollup-pluginutils@^2.8.2:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^2.56.2, rollup@^2.70.0:
+rollup@^2.56.2, rollup@^2.70.0, rollup@^2.79.1:
   version "2.79.1"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.79.1.tgz#bedee8faef7c9f93a2647ac0108748f497f081c7"
   integrity sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==
@@ -22813,6 +22951,18 @@ vfile@^4.0.0:
     is-buffer "^2.0.0"
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
+
+vite@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-3.2.3.tgz#7a68d9ef73eff7ee6dc0718ad3507adfc86944a7"
+  integrity sha512-h8jl1TZ76eGs3o2dIBSsvXDLb1m/Ec1iej8ZMdz+PsaFUsftZeWe2CZOI3qogEsMNaywc17gu0q6cQDzh/weCQ==
+  dependencies:
+    esbuild "^0.15.9"
+    postcss "^8.4.18"
+    resolve "^1.22.1"
+    rollup "^2.79.1"
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 vm-browserify@^1.0.1:
   version "1.1.2"


### PR DESCRIPTION
## Vite support

This contains the `@nrwl/vite` executors for Nx, for the dev server and the prod builder. 

Things still to do:
- [x] forward options (like storybook does)
- [x] Add and read vite config file 
- [x] add proxy support
- [x] expose more options: `tsconfig` path, `port`
- [x] add tests
- [x] make sure all works as expected (asses, styles, imports)
