### PR TITLE
fix(js): call normalizePath on generated importPath

### DIFF
--- a/packages/js/src/utils/inline.ts
+++ b/packages/js/src/utils/inline.ts
@@ -1,5 +1,5 @@
 import type { ExecutorContext, ProjectGraphProjectNode } from '@nrwl/devkit';
-import { readJsonFile } from '@nrwl/devkit';
+import { readJsonFile, normalizePath } from '@nrwl/devkit';
 import {
   copySync,
   readdirSync,
@@ -285,7 +285,11 @@ function recursiveUpdateImport(
       const fileContent = readFileSync(filePath, 'utf-8');
       const updatedContent = fileContent.replace(importRegex, (matched) => {
         const result = matched.replace(/['"]/g, '');
-        return `"${relative(dirPath, inlinedDepsDestOutputRecord[result])}"`;
+        const importPath = `"${relative(
+          dirPath,
+          inlinedDepsDestOutputRecord[result]
+        )}"`;
+        return normalizePath(importPath);
       });
       writeFileSync(filePath, updatedContent);
     } else if (file.isDirectory()) {


### PR DESCRIPTION
Used normalizePath to replace the windows style path with a unix style path.

## Current Behavior
When running nx build on a project that has a dependency to another project the paths are generated like this: import { child } from "..\..\child\src";

## Expected Behavior
I expect that the paths are generated like: import { child } from "../../child/src"; or import { child } from "..\\..\\child\\src";

## Related Issue(s)
#13011 

Fixes #13011 
