### PR TITLE
cleanup(misc): refactor cra-to-nx to be faster and smaller

### DIFF
--- a/packages/cra-to-nx/package.json
+++ b/packages/cra-to-nx/package.json
@@ -23,8 +23,6 @@
   },
   "homepage": "https://nx.dev",
   "dependencies": {
-    "@nrwl/devkit": "file:../devkit",
-    "@nrwl/workspace": "file:../workspace",
     "fs-extra": "^10.1.0",
     "nx": "file:../nx",
     "tslib": "^2.3.0",

--- a/packages/cra-to-nx/src/index.ts
+++ b/packages/cra-to-nx/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 import { createNxWorkspaceForReact } from './lib/cra-to-nx';
 import * as yargsParser from 'yargs-parser';
 
@@ -6,11 +7,7 @@ export * from './lib/cra-to-nx';
 
 const args = yargsParser(process.argv);
 
-createNxWorkspaceForReact(args)
-  .then(() => {
-    process.exit(0);
-  })
-  .catch((e) => {
-    console.log(e);
-    process.exit(1);
-  });
+createNxWorkspaceForReact(args).catch((e) => {
+  console.log(e);
+  process.exit(1);
+});

--- a/packages/cra-to-nx/src/lib/add-cra-commands-to-nx.ts
+++ b/packages/cra-to-nx/src/lib/add-cra-commands-to-nx.ts
@@ -1,7 +1,7 @@
-import { readJsonSync, writeJsonSync } from 'fs-extra';
+import { readJsonFile, writeJsonFile } from 'nx/src/utils/fileutils';
 
 export function addCRAcracoScriptsToPackageJson(appName: string) {
-  const packageJson = readJsonSync(`apps/${appName}/package.json`);
+  const packageJson = readJsonFile(`apps/${appName}/package.json`);
   packageJson.scripts = {
     ...packageJson.scripts,
     start: 'craco start',
@@ -9,5 +9,5 @@ export function addCRAcracoScriptsToPackageJson(appName: string) {
     build: `cross-env BUILD_PATH=../../dist/apps/${appName} craco build`,
     test: 'craco test',
   };
-  writeJsonSync(`apps/${appName}/package.json`, packageJson, { spaces: 2 });
+  writeJsonFile(`apps/${appName}/package.json`, packageJson);
 }

--- a/packages/cra-to-nx/src/lib/clean-up-files.ts
+++ b/packages/cra-to-nx/src/lib/clean-up-files.ts
@@ -1,15 +1,11 @@
 import { removeSync } from 'fs-extra';
-import * as fs from 'fs';
+import { readJsonFile, writeJsonFile } from 'nx/src/utils/fileutils';
 
 export function cleanUpFiles(appName: string) {
   // Delete targets from project since we delegate to npm scripts.
-  const data = fs.readFileSync(`apps/${appName}/project.json`);
-  const json = JSON.parse(data.toString());
+  const json = readJsonFile(`apps/${appName}/project.json`);
   delete json.targets;
-  fs.writeFileSync(
-    `apps/${appName}/project.json`,
-    JSON.stringify(json, null, 2)
-  );
+  writeJsonFile(`apps/${appName}/project.json`, json);
 
   removeSync('temp-workspace');
 }

--- a/packages/cra-to-nx/src/lib/read-name-from-package-json.ts
+++ b/packages/cra-to-nx/src/lib/read-name-from-package-json.ts
@@ -1,11 +1,9 @@
-import { fileExists } from '@nrwl/workspace/src/utilities/fileutils';
-import * as fs from 'fs';
+import { fileExists, readJsonFile } from 'nx/src/utils/fileutils';
 
 export function readNameFromPackageJson(): string {
   let appName = 'webapp';
   if (fileExists('package.json')) {
-    const data = fs.readFileSync('package.json');
-    const json = JSON.parse(data.toString());
+    const json = readJsonFile('package.json');
     if (
       json['name'] &&
       json['name'].length &&

--- a/packages/cra-to-nx/src/lib/setup-e2e-project.ts
+++ b/packages/cra-to-nx/src/lib/setup-e2e-project.ts
@@ -1,9 +1,12 @@
-import { fileExists } from '@nrwl/workspace/src/utilities/fileutils';
-import * as fs from 'fs';
+import {
+  fileExists,
+  readJsonFile,
+  writeJsonFile,
+} from 'nx/src/utils/fileutils';
+import { writeFileSync } from 'fs';
 
 export function setupE2eProject(appName: string) {
-  const data = fs.readFileSync(`apps/${appName}-e2e/project.json`);
-  const json = JSON.parse(data.toString());
+  const json = readJsonFile(`apps/${appName}-e2e/project.json`);
   json.targets.e2e = {
     executor: 'nx:run-commands',
     options: {
@@ -25,10 +28,7 @@ export function setupE2eProject(appName: string) {
       readyWhen: 'can now view',
     },
   };
-  fs.writeFileSync(
-    `apps/${appName}-e2e/project.json`,
-    JSON.stringify(json, null, 2)
-  );
+  writeJsonFile(`apps/${appName}-e2e/project.json`, json);
 
   if (fileExists(`apps/${appName}-e2e/src/integration/app.spec.ts`)) {
     const integrationE2eTest = `
@@ -38,7 +38,7 @@ export function setupE2eProject(appName: string) {
           cy.get('body').should('exist');
         });
       });`;
-    fs.writeFileSync(
+    writeFileSync(
       `apps/${appName}-e2e/src/integration/app.spec.ts`,
       integrationE2eTest
     );

--- a/packages/cra-to-nx/src/lib/tsconfig-setup.ts
+++ b/packages/cra-to-nx/src/lib/tsconfig-setup.ts
@@ -1,5 +1,8 @@
-import { fileExists } from '@nrwl/workspace/src/utilities/fileutils';
-import * as fs from 'fs';
+import {
+  fileExists,
+  readJsonFile,
+  writeJsonFile,
+} from 'nx/src/utils/fileutils';
 
 const defaultTsConfig = {
   extends: '../../tsconfig.base.json',
@@ -57,8 +60,7 @@ const defaultTsConfigSpec = {
 
 export function setupTsConfig(appName: string) {
   if (fileExists(`apps/${appName}/tsconfig.json`)) {
-    const data = fs.readFileSync(`apps/${appName}/tsconfig.json`);
-    const json = JSON.parse(data.toString());
+    const json = readJsonFile(`apps/${appName}/tsconfig.json`);
     json.extends = '../../tsconfig.base.json';
     if (json.compilerOptions) {
       json.compilerOptions.jsx = 'react';
@@ -70,44 +72,24 @@ export function setupTsConfig(appName: string) {
         allowSyntheticDefaultImports: true,
       };
     }
-    fs.writeFileSync(
-      `apps/${appName}/tsconfig.json`,
-      JSON.stringify(json, null, 2)
-    );
+    writeJsonFile(`apps/${appName}/tsconfig.json`, json);
   } else {
-    fs.writeFileSync(
-      `apps/${appName}/tsconfig.json`,
-      JSON.stringify(defaultTsConfig, null, 2)
-    );
+    writeJsonFile(`apps/${appName}/tsconfig.json`, defaultTsConfig);
   }
 
   if (fileExists(`apps/${appName}/tsconfig.app.json`)) {
-    const data = fs.readFileSync(`apps/${appName}/tsconfig.app.json`);
-    const json = JSON.parse(data.toString());
+    const json = readJsonFile(`apps/${appName}/tsconfig.app.json`);
     json.extends = './tsconfig.json';
-    fs.writeFileSync(
-      `apps/${appName}/tsconfig.app.json`,
-      JSON.stringify(json, null, 2)
-    );
+    writeJsonFile(`apps/${appName}/tsconfig.app.json`, json);
   } else {
-    fs.writeFileSync(
-      `apps/${appName}/tsconfig.app.json`,
-      JSON.stringify(defaultTsConfigApp, null, 2)
-    );
+    writeJsonFile(`apps/${appName}/tsconfig.app.json`, defaultTsConfigApp);
   }
 
   if (fileExists(`apps/${appName}/tsconfig.spec.json`)) {
-    const data = fs.readFileSync(`apps/${appName}/tsconfig.spec.json`);
-    const json = JSON.parse(data.toString());
+    const json = readJsonFile(`apps/${appName}/tsconfig.spec.json`);
     json.extends = './tsconfig.json';
-    fs.writeFileSync(
-      `apps/${appName}/tsconfig.spec.json`,
-      JSON.stringify(json, null, 2)
-    );
+    writeJsonFile(`apps/${appName}/tsconfig.spec.json`, json);
   } else {
-    fs.writeFileSync(
-      `apps/${appName}/tsconfig.spec.json`,
-      JSON.stringify(defaultTsConfigSpec, null, 2)
-    );
+    writeJsonFile(`apps/${appName}/tsconfig.spec.json`, defaultTsConfigSpec);
   }
 }

--- a/packages/cra-to-nx/src/lib/write-craco-config.ts
+++ b/packages/cra-to-nx/src/lib/write-craco-config.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import { writeFileSync } from 'fs';
 
 export function writeCracoConfig(appName: string, isCRA5: boolean) {
   const configOverride = `
@@ -57,5 +57,5 @@ export function writeCracoConfig(appName: string, isCRA5: boolean) {
     },
   };
   `;
-  fs.writeFileSync(`apps/${appName}/craco.config.js`, configOverride);
+  writeFileSync(`apps/${appName}/craco.config.js`, configOverride);
 }

--- a/packages/cra-to-nx/tsconfig.lib.json
+++ b/packages/cra-to-nx/tsconfig.lib.json
@@ -3,8 +3,9 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "../../dist/out-tsc",
-    "declaration": true,
-    "types": ["node"]
+    "declaration": false,
+    "types": ["node"],
+    "sourceMap": false
   },
   "exclude": ["**/*.spec.ts", "jest.config.ts"],
   "include": ["**/*.ts"]


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

- `cra-to-nx` depends on @nrwl/devkit and @nrwl/workspace but both packages are not needed and add extra install time
- `cra-to-nx` npm package contains typescript declarations and sourceMaps but is just a CLI tool and should not be imported
- `cra-to-nx` contains custom package manager helper functions that can be replaced by already implemented functionality from `nx/src/utils/package-manager` which also reduces the install size

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
