### PR TITLE
cleanup(misc): refactor `make-angular-cli-faster` to reduce install size and make it faster

### DIFF
--- a/packages/make-angular-cli-faster/package.json
+++ b/packages/make-angular-cli-faster/package.json
@@ -28,13 +28,9 @@
   },
   "homepage": "https://nx.dev",
   "dependencies": {
-    "@nrwl/devkit": "file:../devkit",
-    "@nrwl/workspace": "file:../workspace",
     "enquirer": "^2.3.6",
     "nx": "file:../nx",
     "semver": "7.3.4",
-    "tmp": "~0.2.1",
-    "yargs": "^17.6.2",
     "yargs-parser": "21.1.1"
   },
   "publishConfig": {

--- a/packages/make-angular-cli-faster/src/index.ts
+++ b/packages/make-angular-cli-faster/src/index.ts
@@ -11,11 +11,7 @@ const args = yargsParser(process.argv, {
   boolean: ['verbose', 'useNxCloud'],
 });
 
-makeAngularCliFaster(args as Args)
-  .then(() => {
-    process.exit(0);
-  })
-  .catch((e) => {
-    console.log(e);
-    process.exit(1);
-  });
+makeAngularCliFaster(args as Args).catch((e) => {
+  console.log(e);
+  process.exit(1);
+});

--- a/packages/make-angular-cli-faster/src/utilities/make-angular-cli-faster.ts
+++ b/packages/make-angular-cli-faster/src/utilities/make-angular-cli-faster.ts
@@ -1,4 +1,5 @@
-import { output } from '@nrwl/devkit';
+import { output } from 'nx/src/utils/output';
+import { getPackageManagerCommand } from 'nx/src/utils/package-manager';
 import { determineMigration, migrateWorkspace } from './migration';
 import { initNxCloud, promptForNxCloud } from './nx-cloud';
 import { installDependencies } from './package-manager';
@@ -10,6 +11,8 @@ export interface Args {
 }
 
 export async function makeAngularCliFaster(args: Args) {
+  const pmc = getPackageManagerCommand();
+
   output.log({ title: '🐳 Nx initialization' });
 
   output.log({ title: '🧐 Checking versions compatibility' });
@@ -21,22 +24,22 @@ export async function makeAngularCliFaster(args: Args) {
       : await promptForNxCloud();
 
   output.log({ title: '📦 Installing dependencies' });
-  await installDependencies(migration, useNxCloud);
+  await installDependencies(migration, useNxCloud, pmc);
 
   output.log({ title: '📝 Setting up workspace for faster computation' });
-  migrateWorkspace(migration);
+  migrateWorkspace(migration, pmc);
 
   if (useNxCloud) {
     output.log({ title: '🛠️ Setting up Nx Cloud' });
-    initNxCloud();
+    initNxCloud(pmc);
   }
 
   output.success({
     title: '🎉 Angular CLI is faster now!',
     bodyLines: [
       `Execute 'npx ng build' twice to see the computation caching in action.`,
-      'Learn more about computation caching, how it is shared with your teammates,' +
-        ' and how it can speed up your CI by up to 10 times at https://nx.dev/getting-started/nx-and-angular',
+      'Learn more about computation caching, how it is shared with your teammates,',
+      'and how it can speed up your CI by up to 10 times at https://nx.dev/getting-started/nx-and-angular',
     ],
   });
 }

--- a/packages/make-angular-cli-faster/src/utilities/migration.ts
+++ b/packages/make-angular-cli-faster/src/utilities/migration.ts
@@ -1,8 +1,9 @@
-import { getPackageManagerCommand, output } from '@nrwl/devkit';
 import { execSync } from 'child_process';
 import { prompt } from 'enquirer';
-import { readModulePackageJson } from 'nx/src/utils/package-json';
 import { lt, lte, major, satisfies } from 'semver';
+import { output } from 'nx/src/utils/output';
+import { readModulePackageJson } from 'nx/src/utils/package-json';
+import { PackageManagerCommands } from 'nx/src/utils/package-manager';
 import { resolvePackageVersion } from './package-manager';
 import { MigrationDefinition } from './types';
 
@@ -83,7 +84,10 @@ export async function determineMigration(
   };
 }
 
-export function migrateWorkspace(migration: MigrationDefinition): void {
+export function migrateWorkspace(
+  migration: MigrationDefinition,
+  pmc: PackageManagerCommands
+): void {
   const preserveAngularCliLayoutFlag = lte(
     migration.version,
     latestVersionWithOldFlag
@@ -91,9 +95,7 @@ export function migrateWorkspace(migration: MigrationDefinition): void {
     ? '--preserveAngularCLILayout'
     : '--preserve-angular-cli-layout';
   execSync(
-    `${getPackageManagerCommand().exec} nx g ${
-      migration.packageName
-    }:ng-add ${preserveAngularCliLayoutFlag}`,
+    `${pmc.exec} nx g ${migration.packageName}:ng-add ${preserveAngularCliLayoutFlag}`,
     { stdio: [0, 1, 2] }
   );
 }

--- a/packages/make-angular-cli-faster/src/utilities/nx-cloud.ts
+++ b/packages/make-angular-cli-faster/src/utilities/nx-cloud.ts
@@ -1,9 +1,9 @@
-import { getPackageManagerCommand } from '@nrwl/devkit';
 import { execSync } from 'child_process';
 import { prompt } from 'enquirer';
+import { PackageManagerCommands } from 'nx/src/utils/package-manager';
 
-export async function promptForNxCloud(): Promise<boolean> {
-  const { useNxCloud } = await prompt<{ useNxCloud: 'Yes' | 'No' }>([
+export function promptForNxCloud(): Promise<boolean> {
+  return prompt([
     {
       name: 'useNxCloud',
       message: `Enable distributed caching to make your CI faster`,
@@ -17,16 +17,12 @@ export async function promptForNxCloud(): Promise<boolean> {
       ],
       initial: 'Yes' as any,
     },
-  ]);
-
-  return useNxCloud === 'Yes';
+  ]).then((a: { useNxCloud: 'Yes' | 'No' }) => a.useNxCloud === 'Yes');
 }
 
-export function initNxCloud(): void {
+export function initNxCloud(pmc: PackageManagerCommands): void {
   execSync(
-    `${
-      getPackageManagerCommand().exec
-    } nx g @nrwl/nx-cloud:init --installationSource=make-angular-cli-faster`,
+    `${pmc.exec} nx g @nrwl/nx-cloud:init --installationSource=make-angular-cli-faster`,
     {
       stdio: [0, 1, 2],
     }

--- a/packages/make-angular-cli-faster/src/utilities/package-manager.ts
+++ b/packages/make-angular-cli-faster/src/utilities/package-manager.ts
@@ -1,17 +1,14 @@
-import {
-  getPackageManagerCommand,
-  readJsonFile,
-  workspaceRoot,
-} from '@nrwl/devkit';
+import { join } from 'path';
 import { execSync } from 'child_process';
-import { writeFileSync } from 'fs';
+import { gte, major } from 'semver';
+import { readJsonFile, writeJsonFile } from 'nx/src/utils/fileutils';
+import { workspaceRoot } from 'nx/src/utils/workspace-root';
 import { sortObjectByKeys } from 'nx/src/utils/object-sort';
 import {
   resolvePackageVersionUsingInstallation,
   resolvePackageVersionUsingRegistry,
+  PackageManagerCommands,
 } from 'nx/src/utils/package-manager';
-import { join } from 'path';
-import { gte, major } from 'semver';
 import { MigrationDefinition } from './types';
 
 // version when the Nx CLI changed from @nrwl/tao & @nrwl/cli to nx
@@ -19,7 +16,8 @@ const versionWithConsolidatedPackages = '13.9.0';
 
 export async function installDependencies(
   { packageName, version }: MigrationDefinition,
-  useNxCloud: boolean
+  useNxCloud: boolean,
+  pmc: PackageManagerCommands
 ): Promise<void> {
   const json = readJsonFile(join(workspaceRoot, 'package.json'));
 
@@ -48,11 +46,9 @@ export async function installDependencies(
     json.dependencies['@nrwl/angular'] = version;
     json.dependencies = sortObjectByKeys(json.dependencies);
   }
-  writeFileSync(`package.json`, JSON.stringify(json, null, 2));
+  writeJsonFile(`package.json`, json);
 
-  execSync(getPackageManagerCommand().install, {
-    stdio: [0, 1, 2],
-  });
+  execSync(pmc.install, { stdio: [0, 1, 2] });
 }
 
 export async function resolvePackageVersion(

--- a/packages/make-angular-cli-faster/tsconfig.lib.json
+++ b/packages/make-angular-cli-faster/tsconfig.lib.json
@@ -3,8 +3,9 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "../../dist/out-tsc",
-    "declaration": true,
-    "types": ["node"]
+    "declaration": false,
+    "types": ["node"],
+    "sourceMap": false
   },
   "exclude": ["**/*.spec.ts"],
   "include": ["**/*.ts"]


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
- `make-angular-cli-faster` depends on `@nrwl/devkit`, `@nrwl/workspace`, `tmp` and `yargs` but all these packages are not needed and add extra install time
- npm package contains typescript declarations and sourceMaps but is just a CLI tool and should not be imported
- `getPackageManagerCommands()` is executed mutliple times

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
- unused dependencies are removed
- `getPackageManagerCommands()` is executed only one time
