### PR TITLE
feat(repo): added a script to add engines to package.json files of npm packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "description": "Smart, Fast and Extensible Build System",
   "homepage": "https://nx.dev",
   "private": true,
+  "engines": {
+    "node": "^14.15.0 || ^16.10.0 || ^18.12.0 || >= 19.0.0"
+  },
   "scripts": {
     "build": "nx run-many --target build --all --parallel 8 --exclude nx-dev,typedoc-theme",
     "commit": "git-cz",

--- a/packages/add-nx-to-monorepo/project.json
+++ b/packages/add-nx-to-monorepo/project.json
@@ -46,6 +46,9 @@
           },
           {
             "command": "node ./scripts/copy-readme.js add-nx-to-monorepo"
+          },
+          {
+            "command": "node ./scripts/add-engines.js add-nx-to-monorepo"
           }
         ],
         "parallel": false

--- a/packages/angular/project.json
+++ b/packages/angular/project.json
@@ -70,6 +70,9 @@
           },
           {
             "command": "node ./scripts/copy-readme.js angular"
+          },
+          {
+            "command": "node ./scripts/add-engines.js angular"
           }
         ],
         "parallel": false

--- a/packages/cli/project.json
+++ b/packages/cli/project.json
@@ -65,6 +65,9 @@
           },
           {
             "command": "node ./scripts/copy-readme.js cli"
+          },
+          {
+            "command": "node ./scripts/add-engines.js cli"
           }
         ],
         "parallel": false

--- a/packages/cra-to-nx/project.json
+++ b/packages/cra-to-nx/project.json
@@ -47,6 +47,9 @@
           },
           {
             "command": "node ./scripts/copy-readme.js cra-to-nx"
+          },
+          {
+            "command": "node ./scripts/add-engines.js cra-to-nx"
           }
         ],
         "parallel": false

--- a/packages/create-nx-plugin/project.json
+++ b/packages/create-nx-plugin/project.json
@@ -68,6 +68,9 @@
           },
           {
             "command": "node ./scripts/replace-versions.js build/packages/create-nx-plugin/bin/create-nx-plugin.js"
+          },
+          {
+            "command": "node ./scripts/add-engines.js create-nx-plugin"
           }
         ],
         "parallel": false

--- a/packages/create-nx-workspace/project.json
+++ b/packages/create-nx-workspace/project.json
@@ -68,6 +68,9 @@
           },
           {
             "command": "node ./scripts/replace-versions.js build/packages/create-nx-workspace/bin/create-nx-workspace.js"
+          },
+          {
+            "command": "node ./scripts/add-engines.js create-nx-workspace"
           }
         ],
         "parallel": false

--- a/packages/cypress/project.json
+++ b/packages/cypress/project.json
@@ -59,7 +59,14 @@
       "executor": "nx:run-commands",
       "outputs": ["{workspaceRoot}/build/packages/cypress"],
       "options": {
-        "command": "node ./scripts/copy-readme.js cypress"
+        "commands": [
+          {
+            "command": "node ./scripts/copy-readme.js cypress"
+          },
+          {
+            "command": "node ./scripts/add-engines.js cypress"
+          }
+        ]
       }
     },
     "lint": {

--- a/packages/detox/project.json
+++ b/packages/detox/project.json
@@ -78,7 +78,14 @@
       "executor": "nx:run-commands",
       "outputs": ["{workspaceRoot}/build/packages/detox"],
       "options": {
-        "command": "node ./scripts/copy-readme.js detox"
+        "commands": [
+          {
+            "command": "node ./scripts/copy-readme.js detox"
+          },
+          {
+            "command": "node ./scripts/add-engines.js detox"
+          }
+        ]
       }
     }
   }

--- a/packages/devkit/project.json
+++ b/packages/devkit/project.json
@@ -59,7 +59,14 @@
       "executor": "nx:run-commands",
       "outputs": ["{workspaceRoot}/build/packages/devkit"],
       "options": {
-        "command": "node ./scripts/copy-readme.js devkit"
+        "commands": [
+          {
+            "command": "node ./scripts/copy-readme.js devkit"
+          },
+          {
+            "command": "node ./scripts/add-engines.js devkit"
+          }
+        ]
       }
     },
     "lint": {

--- a/packages/esbuild/project.json
+++ b/packages/esbuild/project.json
@@ -59,7 +59,14 @@
       "executor": "nx:run-commands",
       "outputs": ["{workspaceRoot}/build/packages/esbuild"],
       "options": {
-        "command": "node ./scripts/copy-readme.js esbuild"
+        "commands": [
+          {
+            "command": "node ./scripts/copy-readme.js esbuild"
+          },
+          {
+            "command": "node ./scripts/add-engines.js esbuild"
+          }
+        ]
       }
     },
     "lint": {

--- a/packages/eslint-plugin-nx/project.json
+++ b/packages/eslint-plugin-nx/project.json
@@ -59,7 +59,14 @@
       "executor": "nx:run-commands",
       "outputs": ["{workspaceRoot}/build/packages/eslint-plugin-nx"],
       "options": {
-        "command": "node ./scripts/copy-readme.js eslint-plugin-nx"
+        "commands": [
+          {
+            "command": "node ./scripts/copy-readme.js eslint-plugin-nx"
+          },
+          {
+            "command": "node ./scripts/add-engines.js eslint-plugin-nx"
+          }
+        ]
       }
     },
     "lint": {

--- a/packages/expo/project.json
+++ b/packages/expo/project.json
@@ -75,7 +75,14 @@
       "executor": "nx:run-commands",
       "outputs": ["{workspaceRoot}/build/packages/expo"],
       "options": {
-        "command": "node ./scripts/copy-readme.js expo"
+        "commands": [
+          {
+            "command": "node ./scripts/copy-readme.js expo"
+          },
+          {
+            "command": "node ./scripts/add-engines.js expo"
+          }
+        ]
       }
     }
   },

--- a/packages/express/project.json
+++ b/packages/express/project.json
@@ -59,7 +59,14 @@
       "executor": "nx:run-commands",
       "outputs": ["{workspaceRoot}/build/packages/express"],
       "options": {
-        "command": "node ./scripts/copy-readme.js express"
+        "commands": [
+          {
+            "command": "node ./scripts/copy-readme.js express"
+          },
+          {
+            "command": "node ./scripts/add-engines.js express"
+          }
+        ]
       }
     },
     "lint": {

--- a/packages/jest/project.json
+++ b/packages/jest/project.json
@@ -59,7 +59,14 @@
       "executor": "nx:run-commands",
       "outputs": ["{workspaceRoot}/build/packages/jest"],
       "options": {
-        "command": "node ./scripts/copy-readme.js jest"
+        "commands": [
+          {
+            "command": "node ./scripts/copy-readme.js jest"
+          },
+          {
+            "command": "node ./scripts/add-engines.js jest"
+          }
+        ]
       }
     },
     "lint": {

--- a/packages/js/project.json
+++ b/packages/js/project.json
@@ -74,7 +74,14 @@
       "executor": "nx:run-commands",
       "outputs": ["{workspaceRoot}/build/packages/js"],
       "options": {
-        "command": "node ./scripts/copy-readme.js js"
+        "commands": [
+          {
+            "command": "node ./scripts/copy-readme.js js"
+          },
+          {
+            "command": "node ./scripts/add-engines.js js"
+          }
+        ]
       }
     }
   },

--- a/packages/linter/project.json
+++ b/packages/linter/project.json
@@ -59,7 +59,14 @@
       "executor": "nx:run-commands",
       "outputs": ["{workspaceRoot}/build/packages/linter"],
       "options": {
-        "command": "node ./scripts/copy-readme.js linter"
+        "commands": [
+          {
+            "command": "node ./scripts/copy-readme.js linter"
+          },
+          {
+            "command": "node ./scripts/add-engines.js linter"
+          }
+        ]
       }
     },
     "lint": {

--- a/packages/make-angular-cli-faster/project.json
+++ b/packages/make-angular-cli-faster/project.json
@@ -34,6 +34,9 @@
           },
           {
             "command": "node ./scripts/copy-readme.js make-angular-cli-faster"
+          },
+          {
+            "command": "node ./scripts/add-engines.js make-angular-cli-faster"
           }
         ],
         "parallel": false

--- a/packages/module-federation/project.json
+++ b/packages/module-federation/project.json
@@ -70,7 +70,14 @@
       "executor": "nx:run-commands",
       "outputs": ["{workspaceRoot}/build/packages/module-federation"],
       "options": {
-        "command": "node ./scripts/copy-readme.js module-federation"
+        "commands": [
+          {
+            "command": "node ./scripts/copy-readme.js module-federation"
+          },
+          {
+            "command": "node ./scripts/add-engines.js module-federation"
+          }
+        ]
       }
     }
   },

--- a/packages/nest/project.json
+++ b/packages/nest/project.json
@@ -59,7 +59,14 @@
       "executor": "nx:run-commands",
       "outputs": ["{workspaceRoot}/build/packages/nest"],
       "options": {
-        "command": "node ./scripts/copy-readme.js nest"
+        "commands": [
+          {
+            "command": "node ./scripts/copy-readme.js nest"
+          },
+          {
+            "command": "node ./scripts/add-engines.js nest"
+          }
+        ]
       }
     },
     "lint": {

--- a/packages/next/project.json
+++ b/packages/next/project.json
@@ -64,7 +64,14 @@
       "executor": "nx:run-commands",
       "outputs": ["{workspaceRoot}/build/packages/next"],
       "options": {
-        "command": "node ./scripts/copy-readme.js next"
+        "commands": [
+          {
+            "command": "node ./scripts/copy-readme.js next"
+          },
+          {
+            "command": "node ./scripts/add-engines.js next"
+          }
+        ]
       }
     },
     "lint": {

--- a/packages/node/project.json
+++ b/packages/node/project.json
@@ -59,7 +59,14 @@
       "executor": "nx:run-commands",
       "outputs": ["{workspaceRoot}/build/packages/node"],
       "options": {
-        "command": "node ./scripts/copy-readme.js node"
+        "commands": [
+          {
+            "command": "node ./scripts/copy-readme.js node"
+          },
+          {
+            "command": "node ./scripts/add-engines.js node"
+          }
+        ]
       }
     },
     "lint": {

--- a/packages/nx-plugin/project.json
+++ b/packages/nx-plugin/project.json
@@ -59,7 +59,14 @@
       "executor": "nx:run-commands",
       "outputs": ["{workspaceRoot}/build/packages/nx-plugin"],
       "options": {
-        "command": "node ./scripts/copy-readme.js nx-plugin"
+        "commands": [
+          {
+            "command": "node ./scripts/copy-readme.js nx-plugin"
+          },
+          {
+            "command": "node ./scripts/add-engines.js nx-plugin"
+          }
+        ]
       }
     },
     "lint": {

--- a/packages/nx/project.json
+++ b/packages/nx/project.json
@@ -74,6 +74,9 @@
           },
           {
             "command": "node ./scripts/add-dependency-to-build.js nx @nrwl/tao"
+          },
+          {
+            "command": "node ./scripts/add-engines.js nx"
           }
         ],
         "parallel": false

--- a/packages/react-native/project.json
+++ b/packages/react-native/project.json
@@ -84,7 +84,14 @@
       "executor": "nx:run-commands",
       "outputs": ["{workspaceRoot}/build/packages/react-native"],
       "options": {
-        "command": "node ./scripts/copy-readme.js react-native"
+        "commands": [
+          {
+            "command": "node ./scripts/copy-readme.js react-native"
+          },
+          {
+            "command": "node ./scripts/add-engines.js react-native"
+          }
+        ]
       }
     }
   }

--- a/packages/react/project.json
+++ b/packages/react/project.json
@@ -69,7 +69,14 @@
       "executor": "nx:run-commands",
       "outputs": ["{workspaceRoot}/build/packages/react"],
       "options": {
-        "command": "node ./scripts/copy-readme.js react"
+        "commands": [
+          {
+            "command": "node ./scripts/copy-readme.js react"
+          },
+          {
+            "command": "node ./scripts/add-engines.js react"
+          }
+        ]
       }
     },
     "lint": {

--- a/packages/rollup/project.json
+++ b/packages/rollup/project.json
@@ -59,7 +59,14 @@
       "executor": "nx:run-commands",
       "outputs": ["{workspaceRoot}/build/packages/rollup"],
       "options": {
-        "command": "node ./scripts/copy-readme.js rollup"
+        "commands": [
+          {
+            "command": "node ./scripts/copy-readme.js rollup"
+          },
+          {
+            "command": "node ./scripts/add-engines.js rollup"
+          }
+        ]
       }
     },
     "lint": {

--- a/packages/storybook/project.json
+++ b/packages/storybook/project.json
@@ -74,7 +74,14 @@
       "executor": "nx:run-commands",
       "outputs": ["{workspaceRoot}/build/packages/storybook"],
       "options": {
-        "command": "node ./scripts/copy-readme.js storybook"
+        "commands": [
+          {
+            "command": "node ./scripts/copy-readme.js storybook"
+          },
+          {
+            "command": "node ./scripts/add-engines.js storybook"
+          }
+        ]
       }
     },
     "lint": {

--- a/packages/tao/project.json
+++ b/packages/tao/project.json
@@ -65,6 +65,9 @@
           },
           {
             "command": "node ./scripts/copy-readme.js tao"
+          },
+          {
+            "command": "node ./scripts/add-engines.js tao"
           }
         ],
         "parallel": false

--- a/packages/vite/project.json
+++ b/packages/vite/project.json
@@ -59,7 +59,14 @@
       "executor": "nx:run-commands",
       "outputs": ["{workspaceRoot}/build/packages/vite"],
       "options": {
-        "command": "node ./scripts/copy-readme.js vite"
+        "commands": [
+          {
+            "command": "node ./scripts/copy-readme.js vite"
+          },
+          {
+            "command": "node ./scripts/add-engines.js vite"
+          }
+        ]
       }
     },
     "lint": {

--- a/packages/web/project.json
+++ b/packages/web/project.json
@@ -64,7 +64,14 @@
       "executor": "nx:run-commands",
       "outputs": ["{workspaceRoot}/build/packages/web"],
       "options": {
-        "command": "node ./scripts/copy-readme.js web"
+        "commands": [
+          {
+            "command": "node ./scripts/copy-readme.js web"
+          },
+          {
+            "command": "node ./scripts/add-engines.js web"
+          }
+        ]
       }
     },
     "lint": {

--- a/packages/webpack/project.json
+++ b/packages/webpack/project.json
@@ -59,7 +59,14 @@
       "executor": "nx:run-commands",
       "outputs": ["{workspaceRoot}/build/packages/webpack"],
       "options": {
-        "command": "node ./scripts/copy-readme.js webpack"
+        "commands": [
+          {
+            "command": "node ./scripts/copy-readme.js webpack"
+          },
+          {
+            "command": "node ./scripts/add-engines.js webpack"
+          }
+        ]
       }
     },
     "lint": {

--- a/packages/workspace/project.json
+++ b/packages/workspace/project.json
@@ -93,6 +93,9 @@
           },
           {
             "command": "node ./scripts/add-dependency-to-build.js workspace @nrwl/linter"
+          },
+          {
+            "command": "node ./scripts/add-engines.js workspace"
           }
         ],
         "parallel": false

--- a/scripts/add-engines.js
+++ b/scripts/add-engines.js
@@ -1,0 +1,11 @@
+const { readJsonSync, writeJsonSync } = require('fs-extra');
+const { join } = require('path');
+
+const package = process.argv[2];
+
+const engines = readJsonSync(`package.json`).engines;
+
+const path = join(__dirname, '../build/packages', package, 'package.json');
+const packageJson = readJsonSync(path);
+packageJson.engines = engines;
+writeJsonSync(path, packageJson, { spaces: 2 });


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
Nx does not define which node.js versions are supported. See #5896

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Nx should clearly define which node.js versions are supported. The supported versions should also be specified in the package.json files of the packages. Only LTS and Current Releases of Node.js should be supported.

For the release and end of life dates see: https://github.com/nodejs/Release/blob/main/schedule.json

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #5896
