### PR TITLE
fix(core): fix undefined projectName in tasks runner

### DIFF
--- a/packages/nx/src/tasks-runner/utils.spec.ts
+++ b/packages/nx/src/tasks-runner/utils.spec.ts
@@ -40,15 +40,20 @@ describe('utils', () => {
         )
       ).toEqual([]);
     });
-    it('should interpolate {workspaceRoot} and {projectRoot}', () => {
+
+    it('should interpolate {workspaceRoot}, {projectRoot} and {projectName}', () => {
       expect(
         getOutputsForTargetAndConfiguration(
           task,
           getNode({
-            outputs: ['{workspaceRoot}/one', '{projectRoot}/two'],
+            outputs: [
+              '{workspaceRoot}/one',
+              '{projectRoot}/two',
+              '{projectName}/three',
+            ],
           })
         )
-      ).toEqual(['one', 'myapp/two']);
+      ).toEqual(['one', 'myapp/two', 'myapp/three']);
     });
 
     it('should interpolate {projectRoot} when it is not in front', () => {

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -157,8 +157,8 @@ export function getOutputsForTargetAndConfiguration(
       .map((output: string) => {
         return interpolate(output, {
           projectRoot: node.data.root,
-          projectName: node.data.name,
-          project: { ...node.data, name: node.data.name }, // this is legacy
+          projectName: node.name,
+          project: { ...node.data, name: node.name }, // this is legacy
           options,
         });
       })


### PR DESCRIPTION
ISSUES CLOSED: #13018

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The keyword `{projectName}` has been interpolated to `undefined`.

## Expected Behavior
It's supposes to be interpolated to expecting project name.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #13018
