### PR TITLE
chore(repo): hide publishing logs unless verbose is set

### DIFF
--- a/scripts/e2e-build-package-publish.ts
+++ b/scripts/e2e-build-package-publish.ts
@@ -1,7 +1,7 @@
 import { execSync } from 'child_process';
 import { remove } from 'fs-extra';
 import { existsSync } from 'fs';
-import { stripIndent } from 'nx/src/utils/logger';
+import { stripIndent, NX_PREFIX } from 'nx/src/utils/logger';
 
 process.env.npm_config_registry = `http://localhost:4872`;
 process.env.YARN_REGISTRY = process.env.npm_config_registry;
@@ -42,9 +42,19 @@ async function buildPackagePublishAndCleanPorts() {
 }
 
 async function updateVersionsAndPublishPackages() {
-  execSync(`yarn nx-release major --local`, {
-    stdio: 'inherit',
+  console.log(`\n${NX_PREFIX} 📦 Publishing packages\n`);
+  const isVerbose =
+    process.env.NX_VERBOSE_LOGGING === 'true' ||
+    process.argv.includes('--verbose');
+  const response = execSync(`yarn nx-release major --local`, {
+    stdio: isVerbose ? 'inherit' : 'pipe',
+    encoding: 'utf8',
   });
+  // extract published version
+  if (!isVerbose) {
+    const value = response.match(/Successfully published:\s+ - .+@(.*)/);
+    console.log(`${NX_PREFIX} ✅ Published local version: ${value?.[1]}\n`);
+  }
 }
 
 (async () => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Full logs of local package publishing is always shown in the terminal

## Expected Behavior
The detailed logs should be toggleable via `--verbose` and `NX_VERBOSE_LOGGING`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
