### PR TITLE
chore(repo): hide vite from being pubished publically

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nrwl/vite",
   "version": "0.0.1",
-  "private": false,
+  "private": true,
   "description": "The Nx Plugin for building and testing applications using Vite (Early Release)",
   "repository": {
     "type": "git",

--- a/scripts/nx-release.ts
+++ b/scripts/nx-release.ts
@@ -36,6 +36,24 @@ function hideFromGitIndex(uncommittedFiles: string[]) {
     stdio: [0, 1, 2],
   });
 
+  if (options.local) {
+    // Force all projects to be not private
+    const projects = JSON.parse(
+      execSync('npx lerna list --json --all').toString()
+    );
+    for (const proj of projects) {
+      if (proj.private) {
+        console.log('Publishing private package locally:', proj.name);
+        const packageJsonPath = join(proj.location, 'package.json');
+        const original = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+        writeFileSync(
+          packageJsonPath,
+          JSON.stringify({ ...original, private: false })
+        );
+      }
+    }
+  }
+
   const versionOptions = {
     bump: options.version ? options.version : undefined,
     conventionalCommits: true,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

vite is still under development but may be accidentally published.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

vite is still under development so its marked as private for now. During the local release script, it will still publish private projects.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
