### PR TITLE
feat(react): use shared helpers from devkit

### DIFF
--- a/packages/react/src/module-federation/with-module-federation.ts
+++ b/packages/react/src/module-federation/with-module-federation.ts
@@ -1,110 +1,21 @@
 import {
-  getNpmPackageSharedConfig,
-  sharePackages,
-  shareWorkspaceLibraries,
-} from './webpack-utils';
-import {
+  AdditionalSharedConfig,
   createProjectGraphAsync,
+  getDependentPackagesForProject,
+  getNpmPackageSharedConfig,
+  ModuleFederationConfig,
   ProjectConfiguration,
   ProjectGraph,
   readCachedProjectGraph,
-} from '@nrwl/devkit';
-import {
-  getRootTsConfigPath,
-  readTsConfig,
-} from '@nrwl/workspace/src/utilities/typescript';
-import { ParsedCommandLine } from 'typescript';
-import {
-  AdditionalSharedConfig,
-  ModuleFederationConfig,
+  readRootPackageJson,
   Remotes,
   SharedFunction,
   SharedLibraryConfig,
-} from './models';
-import { readRootPackageJson } from './package-json';
+  sharePackages,
+  shareWorkspaceLibraries,
+} from '@nrwl/devkit';
 import { extname } from 'path';
 import ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
-
-function collectDependencies(
-  projectGraph: ProjectGraph,
-  name: string,
-  dependencies = {
-    workspaceLibraries: new Set<string>(),
-    npmPackages: new Set<string>(),
-  },
-  seen: Set<string> = new Set()
-): {
-  workspaceLibraries: Set<string>;
-  npmPackages: Set<string>;
-} {
-  if (seen.has(name)) {
-    return dependencies;
-  }
-  seen.add(name);
-
-  (projectGraph.dependencies[name] ?? []).forEach((dependency) => {
-    if (dependency.target.startsWith('npm:')) {
-      dependencies.npmPackages.add(dependency.target.replace('npm:', ''));
-    } else {
-      dependencies.workspaceLibraries.add(dependency.target);
-      collectDependencies(projectGraph, dependency.target, dependencies, seen);
-    }
-  });
-
-  return dependencies;
-}
-
-function mapWorkspaceLibrariesToTsConfigImport(
-  workspaceLibraries: string[],
-  { nodes }: ProjectGraph
-) {
-  const tsConfigPath = process.env.NX_TSCONFIG_PATH ?? getRootTsConfigPath();
-  const tsConfig: ParsedCommandLine = readTsConfig(tsConfigPath);
-
-  const tsconfigPathAliases: Record<string, string[]> = tsConfig.options?.paths;
-
-  if (!tsconfigPathAliases) {
-    return workspaceLibraries;
-  }
-
-  const mappedLibraries = [];
-  for (const lib of workspaceLibraries) {
-    const sourceRoot = nodes[lib].data.sourceRoot;
-    let found = false;
-
-    for (const [key, value] of Object.entries(tsconfigPathAliases)) {
-      if (value.find((p) => p.startsWith(sourceRoot))) {
-        mappedLibraries.push(key);
-        found = true;
-        break;
-      }
-    }
-
-    if (!found) {
-      mappedLibraries.push(lib);
-    }
-  }
-
-  return mappedLibraries;
-}
-
-async function getDependentPackagesForProject(
-  projectGraph: ProjectGraph,
-  name: string
-) {
-  const { npmPackages, workspaceLibraries } = collectDependencies(
-    projectGraph,
-    name
-  );
-
-  return {
-    workspaceLibraries: mapWorkspaceLibrariesToTsConfigImport(
-      [...workspaceLibraries],
-      projectGraph
-    ),
-    npmPackages: [...npmPackages],
-  };
-}
 
 function determineRemoteUrl(remote: string, projectGraph: ProjectGraph) {
   const remoteConfiguration = projectGraph.nodes[remote].data;
@@ -232,7 +143,7 @@ export async function withModuleFederation(options: ModuleFederationConfig) {
     );
   }
 
-  const dependencies = await getDependentPackagesForProject(
+  const dependencies = getDependentPackagesForProject(
     projectGraph,
     options.name
   );


### PR DESCRIPTION
## Current Behavior
React is currently using webpack module federation helpers from its own package.

Since we moved these helpers to Devkit, they are redundant.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Use the helpers from Devkit
