### PR TITLE
fix(core): provide a plugin which to allow users to opt into package.…

### DIFF
--- a/packages/nx/plugins/package-json.ts
+++ b/packages/nx/plugins/package-json.ts
@@ -1,0 +1,1 @@
+export const projectFilePatterns = ['package.json'];


### PR DESCRIPTION
…json projects without npm workspaces

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Nx used to find all `package.json` files when `workspace.json` and npm workspaces were setup but no longer does that. There is no easy way to get this behavior back.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

There is a `nx/plugins/package-json` plugin which will find all `package.json` projects even without npm workspaces setup.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/13063
