### PR TITLE
feat(cra-to-nx): add option to use vite instead of craco

### DIFF
--- a/packages/cra-to-nx/package.json
+++ b/packages/cra-to-nx/package.json
@@ -24,9 +24,10 @@
   "homepage": "https://nx.dev",
   "dependencies": {
     "fs-extra": "^10.1.0",
+    "glob": "7.1.4",
     "nx": "file:../nx",
     "tslib": "^2.3.0",
-    "yargs-parser": "21.1.1"
+    "yargs": "^17.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cra-to-nx/src/index.ts
+++ b/packages/cra-to-nx/src/index.ts
@@ -1,13 +1,25 @@
 #!/usr/bin/env node
 
+import * as yargs from 'yargs';
 import { createNxWorkspaceForReact } from './lib/cra-to-nx';
-import * as yargsParser from 'yargs-parser';
 
 export * from './lib/cra-to-nx';
 
-const args = yargsParser(process.argv);
+export const commandsObject = yargs
+  .parserConfiguration({ 'strip-dashed': true })
+  .option('e2e', {
+    type: 'boolean',
+    describe: 'Generate end-to-end tests with Cypress',
+    default: false,
+  })
+  .option('vite', {
+    type: 'boolean',
+    describe: 'Use Vite and Vitest (instead of Webpack and Jest)',
+    default: false,
+  })
+  .help();
 
-createNxWorkspaceForReact(args).catch((e) => {
+createNxWorkspaceForReact(commandsObject.argv).catch((e) => {
   console.log(e);
   process.exit(1);
 });

--- a/packages/cra-to-nx/src/lib/add-craco-commands-to-package-scripts.ts
+++ b/packages/cra-to-nx/src/lib/add-craco-commands-to-package-scripts.ts
@@ -1,6 +1,6 @@
 import { readJsonFile, writeJsonFile } from 'nx/src/utils/fileutils';
 
-export function addCRAcracoScriptsToPackageJson(appName: string) {
+export function addCracoCommandsToPackageScripts(appName: string) {
   const packageJson = readJsonFile(`apps/${appName}/package.json`);
   packageJson.scripts = {
     ...packageJson.scripts,

--- a/packages/cra-to-nx/src/lib/add-vite-commands-to-package-scripts.ts
+++ b/packages/cra-to-nx/src/lib/add-vite-commands-to-package-scripts.ts
@@ -1,0 +1,13 @@
+import { readJsonFile, writeJsonFile } from 'nx/src/utils/fileutils';
+
+export function addViteCommandsToPackageScripts(appName: string) {
+  const packageJson = readJsonFile(`apps/${appName}/package.json`);
+  packageJson.scripts = {
+    ...packageJson.scripts,
+    start: 'vite',
+    serve: 'vite',
+    build: `vite build`,
+    test: 'vitest',
+  };
+  writeJsonFile(`apps/${appName}/package.json`, packageJson, { spaces: 2 });
+}

--- a/packages/cra-to-nx/src/lib/rename-js-to-jsx.ts
+++ b/packages/cra-to-nx/src/lib/rename-js-to-jsx.ts
@@ -1,0 +1,17 @@
+import { sync } from 'glob';
+import { renameSync, readFileSync } from 'fs-extra';
+import { performance } from 'perf_hooks';
+
+// Vite cannot process JSX like <div> or <Header> unless the file is named .jsx or .tsx
+export function renameJsToJsx(appName: string) {
+  const files = sync(`apps/${appName}/src/**/*.js`);
+
+  files.forEach((file) => {
+    const content = readFileSync(file).toString();
+    // Try to detect JSX before renaming to .jsx
+    // Files like setupTests.js from CRA should not be renamed
+    if (/<[a-zA-Z0-9]+/.test(content)) {
+      renameSync(file, `${file}x`);
+    }
+  });
+}

--- a/packages/cra-to-nx/src/lib/write-vite-config.ts
+++ b/packages/cra-to-nx/src/lib/write-vite-config.ts
@@ -1,0 +1,27 @@
+import * as fs from 'fs';
+
+export function writeViteConfig(appName: string) {
+  fs.writeFileSync(
+    `apps/${appName}/vite.config.js`,
+    `import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  build: {
+    outDir: '../../dist/apps/cra-app'
+  },
+  server: {
+    open: true,
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: 'src/setupTests.js',
+    css: true,
+  },
+  plugins: [react()],
+});
+`
+  );
+}

--- a/packages/cra-to-nx/src/lib/write-vite-index-html.ts
+++ b/packages/cra-to-nx/src/lib/write-vite-index-html.ts
@@ -1,0 +1,20 @@
+import * as fs from 'fs';
+
+export function writeViteIndexHtml(appName: string) {
+  fs.writeFileSync(
+    `apps/${appName}/index.html`,
+    `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite + React + Nx</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.jsx"></script>
+  </body>
+</html>`
+  );
+}


### PR DESCRIPTION
This PR adds a `--vite` option to the `cra-to-nx` migration tool.

```
npx cra-to-nx --vite
```

Once the nested project feature has landed, we can make this even better by not having to move files around to apps/libs.