### PR TITLE
fix(core): prevent incorrect regex replacement of app name

### DIFF
--- a/packages/workspace/src/utils/cli-config-utils.ts
+++ b/packages/workspace/src/utils/cli-config-utils.ts
@@ -65,6 +65,8 @@ export function replaceAppNameWithPath(
       'defaultConfiguration',
       'maximumError',
       'name',
+      'type',
+      'outputHashing',
     ]; // Some of the properties should not be renamed
     return Object.keys(node).reduce(
       (m, c) => (


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
Generating an app with name `a` will match certain options in `project.json` causing issues.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Generating an app with name `a` should be fine