### PR TITLE
feat(angular): add skipRemotes option to module-federation-dev-server

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -3821,6 +3821,11 @@
             "type": "array",
             "items": { "type": "string" },
             "description": "List of remote applications to run in development mode (i.e. using serve target)."
+          },
+          "skipRemotes": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "List of remote applications to not automatically serve, either statically or in development mode. This can be useful for multi-repository module federation setups where the host application uses a remote application from an external repository."
           }
         },
         "additionalProperties": false,

--- a/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -147,7 +147,10 @@ export function executeModuleFederationDevServerBuilder(
 
   const staticRemotes = getStaticRemotes(project, context, workspaceProjects);
   const dynamicRemotes = getDynamicRemotes(project, context, workspaceProjects);
-  const remotes = [...staticRemotes, ...dynamicRemotes];
+  const remotesToSkip = new Set(options.skipRemotes ?? []);
+  const remotes = [...staticRemotes, ...dynamicRemotes].filter(
+    (r) => !remotesToSkip.has(r)
+  );
 
   const devServeRemotes = !options.devRemotes
     ? []

--- a/packages/angular/src/builders/module-federation-dev-server/schema.d.ts
+++ b/packages/angular/src/builders/module-federation-dev-server/schema.d.ts
@@ -18,4 +18,5 @@ export interface Schema {
   watch?: boolean;
   poll?: number;
   devRemotes?: string[];
+  skipRemotes?: string[];
 }

--- a/packages/angular/src/builders/module-federation-dev-server/schema.json
+++ b/packages/angular/src/builders/module-federation-dev-server/schema.json
@@ -110,6 +110,13 @@
         "type": "string"
       },
       "description": "List of remote applications to run in development mode (i.e. using serve target)."
+    },
+    "skipRemotes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "List of remote applications to not automatically serve, either statically or in development mode. This can be useful for multi-repository module federation setups where the host application uses a remote application from an external repository."
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently, if a remote lives outside the Nx repo of the host, it can be troublesome to take advantage of `module-federation-dev-server`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Allow option to skip remotes that do not live in the monorepo.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #13064
