### PR TITLE
feat(react): add skipRemotes option to module-federation-dev-server

### DIFF
--- a/docs/generated/packages/react.json
+++ b/docs/generated/packages/react.json
@@ -1380,6 +1380,11 @@
             "items": { "type": "string" },
             "description": "List of remote applications to run in development mode (i.e. using serve target)."
           },
+          "skipRemotes": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "List of remote applications to not automatically serve, either statically or in development mode. This can be useful for multi-repository module federation setups where the host application uses a remote application from an external repository."
+          },
           "buildTarget": {
             "type": "string",
             "description": "Target which builds the application."

--- a/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -10,6 +10,7 @@ import {
 
 type ModuleFederationDevServerOptions = WebDevServerOptions & {
   devRemotes?: string | string[];
+  skipRemotes?: string[];
 };
 
 export default async function* moduleFederationDevServer(
@@ -35,7 +36,10 @@ export default async function* moduleFederationDevServer(
     );
   }
 
-  const knownRemotes = moduleFederationConfig.remotes ?? [];
+  const remotesToSkip = new Set(options.skipRemotes ?? []);
+  const knownRemotes = (moduleFederationConfig.remotes ?? []).filter(
+    (r) => !remotesToSkip.has(r)
+  );
 
   const devServeApps = !options.devRemotes
     ? []

--- a/packages/react/src/executors/module-federation-dev-server/schema.json
+++ b/packages/react/src/executors/module-federation-dev-server/schema.json
@@ -13,6 +13,13 @@
       },
       "description": "List of remote applications to run in development mode (i.e. using serve target)."
     },
+    "skipRemotes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "List of remote applications to not automatically serve, either statically or in development mode. This can be useful for multi-repository module federation setups where the host application uses a remote application from an external repository."
+    },
     "buildTarget": {
       "type": "string",
       "description": "Target which builds the application."


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently, if a remote lives outside the Nx repo of the host, it can be troublesome to take advantage of `module-federation-dev-server`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Allow option to skip remotes that do not live in the monorepo.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #13064
