### PR TITLE
cleanup(angular): add @angular-devkit/build-angular:karma builder migrator

### DIFF
--- a/packages/angular/src/generators/ng-add/migrate-from-angular-cli.ts
+++ b/packages/angular/src/generators/ng-add/migrate-from-angular-cli.ts
@@ -19,7 +19,7 @@ import {
   createWorkspaceFiles,
   decorateAngularCli,
   getAllProjects,
-  getWorkspaceCapabilities,
+  getWorkspaceRootFileTypesInfo,
   normalizeOptions,
   updatePackageJson,
   updateRootEsLintConfig,
@@ -59,7 +59,10 @@ export async function migrateFromAngularCli(
     // validate all projects
     validateProjects(migrators);
 
-    const workspaceCapabilities = getWorkspaceCapabilities(tree, projects);
+    const workspaceRootFileTypesInfo = getWorkspaceRootFileTypesInfo(
+      tree,
+      migrators
+    );
 
     /**
      * Keep a copy of the root eslint config to restore it later. We need to
@@ -68,7 +71,7 @@ export async function migrateFromAngularCli(
      * the app migration.
      */
     let eslintConfig =
-      workspaceCapabilities.eslint && tree.exists('.eslintrc.json')
+      workspaceRootFileTypesInfo.eslint && tree.exists('.eslintrc.json')
         ? readJson(tree, '.eslintrc.json')
         : undefined;
 
@@ -95,10 +98,10 @@ export async function migrateFromAngularCli(
      * these files in the root for the root application, so we wait until
      * those root config files are moved when the projects are migrated.
      */
-    if (workspaceCapabilities.karma) {
+    if (workspaceRootFileTypesInfo.karma) {
       createRootKarmaConfig(tree);
     }
-    if (workspaceCapabilities.eslint) {
+    if (workspaceRootFileTypesInfo.eslint) {
       updateRootEsLintConfig(tree, eslintConfig, options.unitTestRunner);
       cleanupEsLintPackages(tree);
     }

--- a/packages/angular/src/generators/ng-add/migrators/builders/angular-devkit-karma.migrator.ts
+++ b/packages/angular/src/generators/ng-add/migrators/builders/angular-devkit-karma.migrator.ts
@@ -1,0 +1,145 @@
+import {
+  joinPathFragments,
+  ProjectConfiguration,
+  TargetConfiguration,
+  Tree,
+  updateProjectConfiguration,
+} from '@nrwl/devkit';
+import { offsetFromRoot } from '@nrwl/devkit';
+import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
+import { basename } from 'path';
+import type {
+  Logger,
+  ProjectMigrationInfo,
+  ValidationError,
+  ValidationResult,
+} from '../../utilities';
+import { arrayToString } from '../../utilities';
+import { BuilderMigrator } from './builder.migrator';
+
+export class AngularDevkitKarmaMigrator extends BuilderMigrator {
+  constructor(
+    tree: Tree,
+    project: ProjectMigrationInfo,
+    projectConfig: ProjectConfiguration,
+    logger: Logger
+  ) {
+    super(
+      tree,
+      '@angular-devkit/build-angular:karma',
+      'karma',
+      project,
+      projectConfig,
+      logger
+    );
+  }
+
+  override migrate(): void {
+    for (const [name, target] of this.targets) {
+      this.moveFilePathsFromTargetToProjectRoot(target, [
+        'karmaConfig',
+        'tsConfig',
+        'webWorkerTsConfig',
+      ]);
+      this.updateTargetConfiguration(name, target);
+      this.updateTsConfigFileUsedByTestTarget(name, target);
+      this.updateCacheableOperations([name]);
+    }
+
+    if (!this.targets.size && this.projectConfig.root === '') {
+      // there could still be a karma.conf.js file in the root
+      // so move to new location
+      const karmaConfig = 'karma.conf.js';
+      if (this.tree.exists(karmaConfig)) {
+        this.logger.info(
+          'No "test" target was found, but a root Karma config file was found in the project root. The file will be moved to the new location.'
+        );
+        this.moveProjectRootFile(karmaConfig);
+      }
+    }
+  }
+
+  override validate(): ValidationResult {
+    const errors: ValidationError[] = [];
+    // TODO(leo): keeping restriction until the full refactor is done and we start
+    // expanding what's supported.
+    if (this.targets.size > 1) {
+      errors.push({
+        message: `There is more than one target using a builder that is used to build the project (${arrayToString(
+          [...this.targets.keys()]
+        )}).`,
+        hint: `Make sure the project only has one target with a builder that is used to build the project.`,
+      });
+    }
+
+    return errors.length ? errors : null;
+  }
+
+  private updateTargetConfiguration(
+    targetName: string,
+    target: TargetConfiguration
+  ): void {
+    if (!target.options) {
+      this.logger.warn(
+        `The target "${targetName}" is not specifying any options. Skipping updating the target configuration.`
+      );
+      return;
+    }
+
+    target.options.main =
+      target.options.main && this.convertAsset(target.options.main);
+    target.options.polyfills =
+      target.options.polyfills && this.convertAsset(target.options.polyfills);
+    target.options.tsConfig =
+      target.options.tsConfig &&
+      joinPathFragments(
+        this.project.newRoot,
+        basename(target.options.tsConfig)
+      );
+    target.options.karmaConfig =
+      target.options.karmaConfig &&
+      joinPathFragments(
+        this.project.newRoot,
+        basename(target.options.karmaConfig)
+      );
+    target.options.assets =
+      target.options.assets &&
+      target.options.assets.map((asset) => this.convertAsset(asset));
+    target.options.styles =
+      target.options.styles &&
+      target.options.styles.map((style) => this.convertAsset(style));
+    target.options.scripts =
+      target.options.scripts &&
+      target.options.scripts.map((script) => this.convertAsset(script));
+
+    updateProjectConfiguration(this.tree, this.project.name, {
+      ...this.projectConfig,
+    });
+  }
+
+  private updateTsConfigFileUsedByTestTarget(
+    targetName: string,
+    target: TargetConfiguration
+  ): void {
+    if (!target.options?.tsConfig) {
+      this.logger.warn(
+        `The "${targetName}" target does not have the "tsConfig" option configured. Skipping updating the tsConfig file.`
+      );
+      return;
+    }
+    if (!this.tree.exists(target.options.tsConfig)) {
+      const originalTsConfigPath =
+        this.originalProjectConfig.targets[targetName].options.tsConfig;
+      this.logger.warn(
+        `The tsConfig file "${originalTsConfigPath}" specified in the "${targetName}" target could not be found. Skipping updating the tsConfig file.`
+      );
+      return;
+    }
+
+    this.updateTsConfigFile(
+      target.options.tsConfig,
+      getRootTsConfigPathInTree(this.tree),
+      offsetFromRoot(this.projectConfig.root)
+    );
+  }
+}

--- a/packages/angular/src/generators/ng-add/migrators/builders/angular-devkit-ng-packagr.migrator.ts
+++ b/packages/angular/src/generators/ng-add/migrators/builders/angular-devkit-ng-packagr.migrator.ts
@@ -31,6 +31,7 @@ export class AngularDevkitNgPackagrMigrator extends BuilderMigrator {
     super(
       tree,
       '@angular-devkit/build-angular:ng-packagr',
+      undefined,
       project,
       projectConfig,
       logger

--- a/packages/angular/src/generators/ng-add/migrators/builders/builder.migrator.ts
+++ b/packages/angular/src/generators/ng-add/migrators/builders/builder.migrator.ts
@@ -3,7 +3,11 @@ import type {
   TargetConfiguration,
   Tree,
 } from '@nrwl/devkit';
-import type { Logger, ProjectMigrationInfo } from '../../utilities';
+import type {
+  Logger,
+  ProjectMigrationInfo,
+  WorkspaceRootFileType,
+} from '../../utilities';
 import { Migrator } from '../migrator';
 
 export abstract class BuilderMigrator extends Migrator {
@@ -12,6 +16,7 @@ export abstract class BuilderMigrator extends Migrator {
   constructor(
     tree: Tree,
     public readonly builderName: string,
+    public readonly rootFileType: WorkspaceRootFileType | undefined,
     project: ProjectMigrationInfo,
     projectConfig: ProjectConfiguration,
     logger: Logger
@@ -22,6 +27,10 @@ export abstract class BuilderMigrator extends Migrator {
     this.projectConfig = projectConfig;
 
     this.collectBuilderTargets();
+  }
+
+  isBuilderUsed(): boolean {
+    return this.targets.size > 0;
   }
 
   protected collectBuilderTargets(): void {

--- a/packages/angular/src/generators/ng-add/migrators/builders/index.ts
+++ b/packages/angular/src/generators/ng-add/migrators/builders/index.ts
@@ -1,3 +1,4 @@
+export * from './angular-devkit-karma.migrator';
 export * from './angular-devkit-ng-packagr.migrator';
 export * from './builder-migrator-class.type';
 export * from './builder.migrator';

--- a/packages/angular/src/generators/ng-add/migrators/projects/app.migrator.spec.ts
+++ b/packages/angular/src/generators/ng-add/migrators/projects/app.migrator.spec.ts
@@ -1577,9 +1577,9 @@ describe('app migrator', () => {
         'lint',
         'test',
         'e2e',
+        'myCustomTest',
         'myCustomBuild',
         'myCustomLint',
-        'myCustomTest',
       ]);
     });
 

--- a/packages/angular/src/generators/ng-add/migrators/projects/lib.migrator.spec.ts
+++ b/packages/angular/src/generators/ng-add/migrators/projects/lib.migrator.spec.ts
@@ -129,7 +129,7 @@ describe('lib migrator', () => {
         'The "build" target is using an unsupported builder "@not/supported:builder".',
       ]);
       expect(result[0].hint).toMatchInlineSnapshot(
-        `"The supported builders for libraries are: \\"@angular-devkit/build-angular:karma\\", \\"@angular-eslint/builder:lint\\" and \\"@angular-devkit/build-angular:ng-packagr\\"."`
+        `"The supported builders for libraries are: \\"@angular-eslint/builder:lint\\", \\"@angular-devkit/build-angular:ng-packagr\\" and \\"@angular-devkit/build-angular:karma\\"."`
       );
     });
 
@@ -152,7 +152,7 @@ describe('lib migrator', () => {
         'The "test" target is using an unsupported builder "@other/not-supported:builder".',
       ]);
       expect(result[0].hint).toMatchInlineSnapshot(
-        `"The supported builders for libraries are: \\"@angular-devkit/build-angular:karma\\", \\"@angular-eslint/builder:lint\\" and \\"@angular-devkit/build-angular:ng-packagr\\"."`
+        `"The supported builders for libraries are: \\"@angular-eslint/builder:lint\\", \\"@angular-devkit/build-angular:ng-packagr\\" and \\"@angular-devkit/build-angular:karma\\"."`
       );
     });
 
@@ -171,7 +171,7 @@ describe('lib migrator', () => {
         'The "my-build" target is using an unsupported builder "@not/supported:builder".',
       ]);
       expect(result[0].hint).toMatchInlineSnapshot(
-        `"The supported builders for libraries are: \\"@angular-devkit/build-angular:karma\\", \\"@angular-eslint/builder:lint\\" and \\"@angular-devkit/build-angular:ng-packagr\\"."`
+        `"The supported builders for libraries are: \\"@angular-eslint/builder:lint\\", \\"@angular-devkit/build-angular:ng-packagr\\" and \\"@angular-devkit/build-angular:karma\\"."`
       );
     });
 
@@ -1284,8 +1284,8 @@ describe('lib migrator', () => {
         'test',
         'e2e',
         'myCustomBuild',
-        'myCustomLint',
         'myCustomTest',
+        'myCustomLint',
       ]);
     });
 

--- a/packages/angular/src/generators/ng-add/utilities/types.ts
+++ b/packages/angular/src/generators/ng-add/utilities/types.ts
@@ -18,10 +18,8 @@ export type ProjectMigrationInfo = {
   newSourceRoot: string;
 };
 
-export type WorkspaceCapabilities = {
-  karma: boolean;
-  eslint: boolean;
-};
+export type WorkspaceRootFileType = 'karma' | 'eslint';
+export type WorkspaceRootFileTypesInfo = Record<WorkspaceRootFileType, boolean>;
 
 export type ValidationError = {
   message?: string;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The Angular CLI migrator generator is split per project migrators which contain all the logic to do the migration in them.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `@angular-devkit/build-angular:karma` builder now has its own dedicated migrator, and its associated logic was removed from the application and library migrators.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
