### PR TITLE
fix(angular): passthrough skip package json option to generators

### DIFF
--- a/packages/angular/src/generators/library/library.ts
+++ b/packages/angular/src/generators/library/library.ts
@@ -139,6 +139,7 @@ async function addUnitTestRunner(
       supportTsx: false,
       skipSerializers: false,
       skipFormat: true,
+      skipPackageJson: options.skipPackageJson,
     });
   } else if (options.unitTestRunner === 'karma') {
     await karmaProjectGenerator(host, {
@@ -182,6 +183,7 @@ async function addLinting(
     unitTestRunner: options.unitTestRunner,
     setParserOptionsProject: options.setParserOptionsProject,
     skipFormat: true,
+    skipPackageJson: options.skipPackageJson,
   });
 }
 


### PR DESCRIPTION
ISSUES CLOSED: #13108

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When generating a @nrwl/angular:library it changes the package.json file even if I set skipPackageJson to true.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
I would expect that the skipPackageJson flag would be passed around to prevent any changes to the package.json

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #13108
