### PR TITLE
fix(angular): migration should ignore external deps

### DIFF
--- a/packages/angular/src/migrations/update-14-2-0/update-router-initial-navigation.ts
+++ b/packages/angular/src/migrations/update-14-2-0/update-router-initial-navigation.ts
@@ -93,8 +93,12 @@ async function getProjectsWithAngularRouter(
   const projectGraph = await createProjectGraphAsync();
 
   return Object.entries(projectGraph.dependencies)
-    .filter(([, dep]) =>
-      dep.some(({ target }) => target === 'npm:@angular/router')
+    .filter(([node, dep]) =>
+      dep.some(
+        ({ target }) =>
+          target === 'npm:@angular/router' &&
+          !projectGraph.externalNodes?.[node]
+      )
     )
     .map(([projectName]) => readProjectConfiguration(tree, projectName));
 }

--- a/packages/angular/src/migrations/update-14-2-0/update-tsconfig-target.ts
+++ b/packages/angular/src/migrations/update-14-2-0/update-tsconfig-target.ts
@@ -61,8 +61,11 @@ async function collectTsConfigPaths(tree: Tree): Promise<string[]> {
 
   const projectGraph = await createProjectGraphAsync();
   const angularProjects = Object.entries(projectGraph.dependencies)
-    .filter(([, dep]) =>
-      dep.some(({ target }) => target === 'npm:@angular/core')
+    .filter(([node, dep]) =>
+      dep.some(
+        ({ target }) =>
+          target === 'npm:@angular/core' && !projectGraph.externalNodes?.[node]
+      )
     )
     .map(([projectName]) => ({
       projectName,

--- a/packages/angular/src/migrations/update-15-0-0/switch-to-jasmine-marbles.ts
+++ b/packages/angular/src/migrations/update-15-0-0/switch-to-jasmine-marbles.ts
@@ -28,8 +28,11 @@ async function replaceJasmineMarbleUsagesInFiles(tree: Tree) {
   })();
 
   const dirsToTraverse = Object.entries(projectGraph.dependencies)
-    .filter(([, dep]) =>
-      dep.some(({ target }) => target === 'npm:@nrwl/angular')
+    .filter(([node, dep]) =>
+      dep.some(
+        ({ target }) =>
+          target === 'npm:@nrwl/angular' && !projectGraph.externalNodes?.[node]
+      )
     )
     .map(([projectName]) => readProjectConfiguration(tree, projectName).root);
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Migrations try to read projects based on dependencies in the graph, which include keys that refer to external deps

## Expected Behavior
Migrations ignore keys that refer to external deps

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
