### PR TITLE
fix(misc): read the version of nrwl packages from project graph

### DIFF
--- a/packages/nx/src/command-line/lint.ts
+++ b/packages/nx/src/command-line/lint.ts
@@ -4,15 +4,12 @@ import { workspaceLayout } from '../config/configuration';
 import { output } from '../utils/output';
 import * as path from 'path';
 import { createProjectGraphAsync } from '../project-graph/project-graph';
-import { pruneExternalNodes } from '../project-graph/operators';
 
 export async function workspaceLint(): Promise<void> {
   const graph = await createProjectGraphAsync({ exitOnError: true });
   const allWorkspaceFiles = graph.allWorkspaceFiles;
-  const projectGraph = pruneExternalNodes(graph);
-
   const integrityMessages = new WorkspaceIntegrityChecks(
-    projectGraph,
+    graph,
     readAllFilesFromAppsAndLibs(allWorkspaceFiles)
   ).run();
 

--- a/packages/nx/src/command-line/workspace-integrity-checks.spec.ts
+++ b/packages/nx/src/command-line/workspace-integrity-checks.spec.ts
@@ -18,10 +18,6 @@ describe('WorkspaceIntegrityChecks', () => {
             packageGroup: [],
           },
         } as PackageJson),
-        [joinPathFragments(workspaceRoot, 'package.json')]: JSON.stringify({
-          name: 'nx-workspace',
-          version: '0.0.1',
-        } as PackageJson),
       });
     });
 
@@ -38,6 +34,16 @@ describe('WorkspaceIntegrityChecks', () => {
                 implicitDependencies: [],
                 architect: {},
                 files: [createFile('libs/project1/src/index.ts')],
+              },
+            },
+          },
+          externalNodes: {
+            'npm:@nrwl/workspace': {
+              type: 'npm',
+              name: 'npm:@nrwl/worrkspace',
+              data: {
+                packageName: '@nrwl/workspace',
+                version: '1.0.0',
               },
             },
           },
@@ -141,26 +147,67 @@ describe('WorkspaceIntegrityChecks', () => {
             ],
           },
         } as PackageJson),
-        [joinPathFragments(workspaceRoot, 'package.json')]: JSON.stringify({
-          name: 'nx-workspace',
-          version: '0.0.1',
-          dependencies: {
-            '@nrwl/dependency': '1.0.1',
-          },
-          devDependencies: {
-            '@nrwl/dev-dependency': '0.9.1',
-            '@nrwl/may-not-be-aligned': '1.0.15',
-            '@nrwl/correct': '1.0.0',
-            '@nrwl/not-in-pkg-group': '0.9.1',
-            '@nrwl/installed-higher': '2.0.0',
-            nx: '1.0.0',
-          },
-        } as PackageJson),
       });
     });
 
     it('should pick up expected errors', () => {
-      const integrity = new WorkspaceIntegrityChecks(null, null);
+      const integrity = new WorkspaceIntegrityChecks(
+        {
+          nodes: {},
+          dependencies: {},
+          externalNodes: {
+            'npm:@nrwl/dependency': {
+              type: 'npm',
+              name: 'npm:@nrwl/dev-dependency',
+              data: {
+                packageName: '@nrwl/dev-dependency',
+                version: '1.0.1',
+              },
+            },
+            'npm:@nrwl/dev-dependency': {
+              type: 'npm',
+              name: 'npm:@nrwl/dev-dependency',
+              data: {
+                packageName: '@nrwl/dev-dependency',
+                version: '0.9.1',
+              },
+            },
+            'npm:@nrwl/may-not-be-aligned': {
+              type: 'npm',
+              name: 'npm:@nrwl/may-not-be-aligned',
+              data: {
+                packageName: '@nrwl/may-not-be-aligned',
+                version: '1.0.15',
+              },
+            },
+            'npm:@nrwl/correct': {
+              type: 'npm',
+              name: 'npm:@nrwl/correct',
+              data: {
+                packageName: '@nrwl/correct',
+                version: '1.0.0',
+              },
+            },
+            'npm:@nrwl/not-in-pkg-group': {
+              type: 'npm',
+              name: 'npm:@nrwl/not-in-pkg-group',
+              data: {
+                packageName: '@nrwl/not-in-pkg-group',
+                version: '1.0.0',
+              },
+            },
+            'npm:@nrwl/installed-higher': {
+              type: 'npm',
+              name: 'npm:@nrwl/installed-higher',
+              data: {
+                packageName: '@nrwl/installed-higher',
+                version: '2.0.0',
+              },
+            },
+          },
+        },
+        null
+      );
       const errors = integrity.misalignedPackages();
       // All errors are in 1 message
       expect(errors.length).toEqual(1);

--- a/packages/nx/src/command-line/workspace-integrity-checks.ts
+++ b/packages/nx/src/command-line/workspace-integrity-checks.ts
@@ -84,9 +84,6 @@ export class WorkspaceIntegrityChecks {
 
   misalignedPackages(): CLIErrorMessageConfig[] {
     const bodyLines: CLIErrorMessageConfig['bodyLines'] = [];
-    const packageJson = readJsonFile<PackageJson>(
-      joinPathFragments(workspaceRoot, 'package.json')
-    );
 
     let migrateTarget = this.nxPackageJson.version;
 
@@ -95,8 +92,8 @@ export class WorkspaceIntegrityChecks {
       if (typeof pkg === 'string' || pkg.version === '*') {
         // should be aligned
         const installedVersion =
-          packageJson.dependencies?.[packageName] ??
-          packageJson.devDependencies?.[packageName];
+          this.projectGraph.externalNodes['npm:' + packageName]?.data?.version;
+
         if (
           installedVersion &&
           installedVersion !== this.nxPackageJson.version


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When `package.json` has `"@nrwl/angular": "^15.0.13", "nx": "15.0.13"` there's an error in `nx workspace-lint` even though the installed version of `@nrwl/angular` is the same as `nx`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`nx workspace-lint` will look at the installed version from the project graph (the one that's in the lockfile) and compare the actually installed versions. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
