### PR TITLE
feat(core): add glob support for project-level implicit dependencies

### DIFF
--- a/docs/shared/reference/project-configuration.md
+++ b/docs/shared/reference/project-configuration.md
@@ -336,8 +336,7 @@ belonging to `myteam` are not depended on by libraries belong to `theirteam`.
 
 ### implicitDependencies
 
-Nx uses powerful source-code analysis to figure out your workspace's project graph. Some dependencies cannot be deduced
-statically, so you can set them manually like this:
+Nx uses powerful source-code analysis to figure out your workspace's project graph. Some dependencies cannot be deduced statically, so you can set them manually like this:
 
 {% tabs %}
 {% tab label="package.json" %}
@@ -390,6 +389,35 @@ You can also remove a dependency as follows:
 
 {% /tab %}
 {% /tabs %}
+
+An implicit dependency could also be a glob pattern:
+
+{% tabs %}
+{% tab label="package.json" %}
+
+```jsonc {% fileName="package.json" %}
+{
+  "name": "mylib",
+  "nx": {
+    "implicitDependencies": ["shop-*"] # regardless of what Nx thinks, "mylib" doesn't depend on "anotherlib"
+  }
+}
+```
+
+{% /tab %}
+{% tab label="project.json" %}
+
+```jsonc {% fileName="project.json" %}
+{
+  "root": "/libs/mylib",
+  "implicitDependencies": ["shop-*"] # regardless of what Nx thinks, "mylib" doesn't depend on "anotherlib"
+}
+```
+
+{% /tab %}
+{% /tabs %}
+
+In this example, mylib would implicitly depend on any project that's name started with `shop-`.
 
 ### Including package.json files as projects in the graph
 

--- a/packages/nx/src/command-line/run-many.spec.ts
+++ b/packages/nx/src/command-line/run-many.spec.ts
@@ -80,7 +80,7 @@ describe('run-many', () => {
           },
           projectGraph
         ).map(({ name }) => name);
-      }).toThrowError('nomatch*');
+      }).toThrow();
     });
 
     it('should exclude projects', () => {

--- a/packages/nx/src/command-line/run-many.spec.ts
+++ b/packages/nx/src/command-line/run-many.spec.ts
@@ -139,7 +139,7 @@ describe('run-many', () => {
         );
         performance.mark('end');
         const measure = performance.measure('projects', 'start', 'end');
-        expect(measure.duration).toBeLessThan(2500);
+        expect(measure.duration).toBeLessThan(3000);
       });
     });
   });

--- a/packages/nx/src/command-line/run-many.ts
+++ b/packages/nx/src/command-line/run-many.ts
@@ -58,7 +58,6 @@ export function projectsToRun(
 ): ProjectGraphProjectNode[] {
   const selectedProjects = new Map<string, ProjectGraphProjectNode>();
   const validProjects = runnableForTarget(projectGraph.nodes, nxArgs.targets);
-  const validProjectNames = Array.from(validProjects.keys());
   const invalidProjects: string[] = [];
 
   // --all is default now, if --projects is provided, it'll override the --all
@@ -67,9 +66,11 @@ export function projectsToRun(
       selectedProjects.set(projectName, projectGraph.nodes[projectName]);
     }
   } else {
+    const allProjectNames = Object.keys(projectGraph.nodes);
     const matchingProjects = findMatchingProjects(
       nxArgs.projects,
-      Object.keys(projectGraph.nodes)
+      allProjectNames,
+      new Set(allProjectNames)
     );
     for (const project of matchingProjects) {
       if (!validProjects.has(project)) {
@@ -93,7 +94,8 @@ export function projectsToRun(
 
   const excludedProjects = findMatchingProjects(
     nxArgs.exclude ?? [],
-    Array.from(selectedProjects.keys())
+    Array.from(selectedProjects.keys()),
+    new Set(selectedProjects.keys())
   );
 
   for (const excludedProject of excludedProjects) {

--- a/packages/nx/src/project-graph/affected/affected-project-graph.spec.ts
+++ b/packages/nx/src/project-graph/affected/affected-project-graph.spec.ts
@@ -4,7 +4,7 @@ import { filterAffected } from './affected-project-graph';
 import { WholeFileChange } from '../file-utils';
 import { buildProjectGraph } from '../build-project-graph';
 import { defaultFileHasher } from '../../hasher/file-hasher';
-import { WorkspaceJsonConfiguration } from '../../config/workspace-json-project-json';
+import { ProjectsConfigurations } from '../../config/workspace-json-project-json';
 import { NxJsonConfiguration } from '../../config/nx-json';
 import { stripIndents } from '../../utils/strip-indents';
 
@@ -16,7 +16,7 @@ jest.mock('nx/src/utils/workspace-root', () => ({
 describe('project graph', () => {
   let packageJson: any;
   let packageLockJson: any;
-  let workspaceJson: WorkspaceJsonConfiguration;
+  let workspaceJson: ProjectsConfigurations;
   let tsConfigJson: any;
   let nxJson: NxJsonConfiguration;
   let filesJson: any;

--- a/packages/nx/src/project-graph/build-nodes/workspace-projects.spec.ts
+++ b/packages/nx/src/project-graph/build-nodes/workspace-projects.spec.ts
@@ -1,70 +1,46 @@
-import { ProjectConfiguration } from 'nx/src/config/workspace-json-project-json';
 import { normalizeImplicitDependencies } from './workspace-projects';
 
 describe('workspace-projects', () => {
+  let projectsSet: Set<string>;
+
+  beforeEach(() => {
+    projectsSet = new Set(['test-project', 'a', 'b', 'c']);
+  });
+
   describe('normalizeImplicitDependencies', () => {
     it('should expand "*" implicit dependencies', () => {
       expect(
-        normalizeImplicitDependencies('test-project', ['*'], {
-          fileMap: {},
-          filesToProcess: {},
-          workspace: {
-            version: 2,
-            projects: {
-              ...makeProject('test-project'),
-              ...makeProject('a'),
-              ...makeProject('b'),
-              ...makeProject('c'),
-            },
-          },
-        })
+        normalizeImplicitDependencies(
+          'test-project',
+          ['*'],
+          Array.from(projectsSet),
+          projectsSet
+        )
       ).toEqual(['a', 'b', 'c']);
     });
 
     it('should return [] for null implicit dependencies', () => {
       expect(
-        normalizeImplicitDependencies('test-project', null, {
-          fileMap: {},
-          filesToProcess: {},
-          workspace: {
-            version: 2,
-            projects: {
-              ...makeProject('test-project'),
-              ...makeProject('a'),
-              ...makeProject('b'),
-              ...makeProject('c'),
-            },
-          },
-        })
+        normalizeImplicitDependencies(
+          'test-project',
+          null,
+          Array.from(projectsSet),
+          projectsSet
+        )
       ).toEqual([]);
     });
 
     it('should expand glob based implicit dependencies', () => {
+      projectsSet.add('b-1');
+      projectsSet.add('b-2');
       expect(
-        normalizeImplicitDependencies('test-project', ['b*'], {
-          fileMap: {},
-          filesToProcess: {},
-          workspace: {
-            version: 2,
-            projects: {
-              ...makeProject('test-project'),
-              ...makeProject('a'),
-              ...makeProject('b'),
-              ...makeProject('b-1'),
-              ...makeProject('b-2'),
-              ...makeProject('c'),
-            },
-          },
-        })
+        normalizeImplicitDependencies(
+          'test-project',
+          ['b*'],
+          Array.from(projectsSet),
+          projectsSet
+        )
       ).toEqual(['b', 'b-1', 'b-2']);
     });
   });
 });
-
-function makeProject(name: string): Record<string, ProjectConfiguration> {
-  return {
-    [name]: {
-      root: `packages/${name}`,
-    },
-  };
-}

--- a/packages/nx/src/project-graph/build-nodes/workspace-projects.spec.ts
+++ b/packages/nx/src/project-graph/build-nodes/workspace-projects.spec.ts
@@ -20,6 +20,44 @@ describe('workspace-projects', () => {
         })
       ).toEqual(['a', 'b', 'c']);
     });
+
+    it('should return [] for null implicit dependencies', () => {
+      expect(
+        normalizeImplicitDependencies('test-project', null, {
+          fileMap: {},
+          filesToProcess: {},
+          workspace: {
+            version: 2,
+            projects: {
+              ...makeProject('test-project'),
+              ...makeProject('a'),
+              ...makeProject('b'),
+              ...makeProject('c'),
+            },
+          },
+        })
+      ).toEqual([]);
+    });
+
+    it('should expand glob based implicit dependencies', () => {
+      expect(
+        normalizeImplicitDependencies('test-project', ['b*'], {
+          fileMap: {},
+          filesToProcess: {},
+          workspace: {
+            version: 2,
+            projects: {
+              ...makeProject('test-project'),
+              ...makeProject('a'),
+              ...makeProject('b'),
+              ...makeProject('b-1'),
+              ...makeProject('b-2'),
+              ...makeProject('c'),
+            },
+          },
+        })
+      ).toEqual(['b', 'b-1', 'b-2']);
+    });
   });
 });
 

--- a/packages/nx/src/project-graph/build-nodes/workspace-projects.spec.ts
+++ b/packages/nx/src/project-graph/build-nodes/workspace-projects.spec.ts
@@ -1,0 +1,32 @@
+import { ProjectConfiguration } from 'nx/src/config/workspace-json-project-json';
+import { normalizeImplicitDependencies } from './workspace-projects';
+
+describe('workspace-projects', () => {
+  describe('normalizeImplicitDependencies', () => {
+    it('should expand "*" implicit dependencies', () => {
+      expect(
+        normalizeImplicitDependencies('test-project', ['*'], {
+          fileMap: {},
+          filesToProcess: {},
+          workspace: {
+            version: 2,
+            projects: {
+              ...makeProject('test-project'),
+              ...makeProject('a'),
+              ...makeProject('b'),
+              ...makeProject('c'),
+            },
+          },
+        })
+      ).toEqual(['a', 'b', 'c']);
+    });
+  });
+});
+
+function makeProject(name: string): Record<string, ProjectConfiguration> {
+  return {
+    [name]: {
+      root: `packages/${name}`,
+    },
+  };
+}

--- a/packages/nx/src/project-graph/build-nodes/workspace-projects.ts
+++ b/packages/nx/src/project-graph/build-nodes/workspace-projects.ts
@@ -11,7 +11,11 @@ import { ProjectGraphBuilder } from '../project-graph-builder';
 import { PackageJson } from '../../utils/package-json';
 import { readJsonFile } from '../../utils/fileutils';
 import { NxJsonConfiguration } from '../../config/nx-json';
-import { ProjectConfiguration, TargetConfiguration } from '../../config/workspace-json-project-json';
+import {
+  ProjectConfiguration,
+  TargetConfiguration,
+} from '../../config/workspace-json-project-json';
+import { findMatchingProjects } from '../../utils/find-matching-projects';
 import { NX_PREFIX } from '../../utils/logger';
 
 export function buildWorkspaceProjectNodes(
@@ -147,12 +151,10 @@ export function normalizeImplicitDependencies(
   implicitDependencies: ProjectConfiguration['implicitDependencies'],
   context: ProjectGraphProcessorContext
 ) {
-  return implicitDependencies?.flatMap((target) => {
-    if (target === '*') {
-      return Object.keys(context.workspace.projects).filter(
-        (projectName) => projectName !== source
-      );
-    }
-    return target;
-  });
+  return findMatchingProjects(
+    implicitDependencies || [],
+    Object.keys(context.workspace.projects).filter(
+      (projectName) => projectName !== source
+    )
+  );
 }

--- a/packages/nx/src/project-graph/build-project-graph.spec.ts
+++ b/packages/nx/src/project-graph/build-project-graph.spec.ts
@@ -6,7 +6,7 @@ jest.mock('nx/src/utils/workspace-root', () => ({
 }));
 import { buildProjectGraph } from './build-project-graph';
 import { defaultFileHasher } from '../hasher/file-hasher';
-import { WorkspaceJsonConfiguration } from '../config/workspace-json-project-json';
+import { ProjectsConfigurations } from '../config/workspace-json-project-json';
 import { NxJsonConfiguration } from '../config/nx-json';
 import { stripIndents } from '../utils/strip-indents';
 import { DependencyType } from '../config/project-graph';
@@ -14,7 +14,7 @@ import { DependencyType } from '../config/project-graph';
 describe('project graph', () => {
   let packageJson: any;
   let packageLockJson: any;
-  let workspaceJson: WorkspaceJsonConfiguration;
+  let workspaceJson: ProjectsConfigurations;
   let nxJson: NxJsonConfiguration;
   let tsConfigJson: any;
   let filesJson: any;

--- a/packages/nx/src/project-graph/build-project-graph.ts
+++ b/packages/nx/src/project-graph/build-project-graph.ts
@@ -414,14 +414,15 @@ function createContext(
   fileMap: ProjectFileMap,
   filesToProcess: ProjectFileMap
 ): ProjectGraphProcessorContext {
-  const projects: Record<string, ProjectConfiguration> = Object.keys(
-    projectsConfigurations.projects
-  ).reduce((map, projectName) => {
-    map[projectName] = {
-      ...projectsConfigurations.projects[projectName],
-    };
-    return map;
-  }, {});
+  const projects = Object.keys(projectsConfigurations.projects).reduce(
+    (map, projectName) => {
+      map[projectName] = {
+        ...projectsConfigurations.projects[projectName],
+      };
+      return map;
+    },
+    {} as Record<string, ProjectConfiguration>
+  );
   return {
     workspace: {
       ...projectsConfigurations,

--- a/packages/nx/src/utils/assert-workspace-validity.spec.ts
+++ b/packages/nx/src/utils/assert-workspace-validity.spec.ts
@@ -43,6 +43,14 @@ describe('assertWorkspaceValidity', () => {
     }
   });
 
+  it('should not throw for a project-level implicit dependency with a glob', () => {
+    mockWorkspaceJson.projects.app2.implicitDependencies = ['lib*'];
+
+    expect(() => {
+      assertWorkspaceValidity(mockWorkspaceJson, mockNxJson);
+    }).not.toThrow();
+  });
+
   it('should throw for an invalid project-level implicit dependency', () => {
     mockWorkspaceJson.projects.app2.implicitDependencies = ['invalidproj'];
 
@@ -55,6 +63,21 @@ describe('assertWorkspaceValidity', () => {
       );
       expect(e.message).toContain('invalidproj');
       expect(e.message).toContain('invalidproj');
+    }
+  });
+
+  it('should throw for an invalid project-level implicit dependency with glob', () => {
+    mockWorkspaceJson.projects.app2.implicitDependencies = ['invalid*'];
+
+    try {
+      assertWorkspaceValidity(mockWorkspaceJson, mockNxJson);
+      fail('should not reach');
+    } catch (e) {
+      expect(e.message).toContain(
+        'The following implicitDependencies specified in project configurations are invalid'
+      );
+      expect(e.message).toContain('invalid*');
+      expect(e.message).toContain('invalid*');
     }
   });
 

--- a/packages/nx/src/utils/assert-workspace-validity.ts
+++ b/packages/nx/src/utils/assert-workspace-validity.ts
@@ -10,7 +10,8 @@ export function assertWorkspaceValidity(
   workspaceJson,
   nxJson: NxJsonConfiguration
 ) {
-  const workspaceJsonProjects = Object.keys(workspaceJson.projects);
+  const projectNames = Object.keys(workspaceJson.projects);
+  const projectNameSet = new Set(projectNames);
 
   const projects = {
     ...workspaceJson.projects,
@@ -50,12 +51,14 @@ export function assertWorkspaceValidity(
         map,
         filename,
         projectNames,
-        projects
+        projects,
+        projectNames,
+        projectNameSet
       );
       return map;
     }, invalidImplicitDependencies);
 
-  workspaceJsonProjects
+  projectNames
     .filter((projectName) => {
       const project = projects[projectName];
       return !!project.implicitDependencies;
@@ -66,7 +69,9 @@ export function assertWorkspaceValidity(
         map,
         projectName,
         project.implicitDependencies,
-        projects
+        projects,
+        projectNames,
+        projectNameSet
       );
       return map;
     }, invalidImplicitDependencies);
@@ -91,17 +96,18 @@ function detectAndSetInvalidProjectGlobValues(
   map: Map<string, string[]>,
   sourceName: string,
   desiredImplicitDeps: string[],
-  validProjects: ProjectsConfigurations['projects']
+  projectConfigurations: ProjectsConfigurations['projects'],
+  projectNames: string[],
+  projectNameSet: Set<string>
 ) {
-  const validProjectNames = Object.keys(validProjects);
   const invalidProjectsOrGlobs = desiredImplicitDeps.filter((implicit) => {
     const projectName = implicit.startsWith('!')
       ? implicit.substring(1)
       : implicit;
 
     return !(
-      validProjects[projectName] ||
-      findMatchingProjects([implicit], validProjectNames).length
+      projectConfigurations[projectName] ||
+      findMatchingProjects([implicit], projectNames, projectNameSet).length
     );
   });
 

--- a/packages/nx/src/utils/find-matching-projects.spec.ts
+++ b/packages/nx/src/utils/find-matching-projects.spec.ts
@@ -1,0 +1,30 @@
+import { findMatchingProjects } from './find-matching-projects';
+
+describe('findMatchingProjects', () => {
+  let projectsSet: Set<string>;
+
+  beforeEach(() => {
+    projectsSet = new Set(['test-project', 'a', 'b', 'c']);
+  });
+
+  it('should expand "*"', () => {
+    expect(
+      findMatchingProjects(['*'], Array.from(projectsSet), projectsSet)
+    ).toEqual(['test-project', 'a', 'b', 'c']);
+  });
+
+  it('should expand generic glob patterns', () => {
+    projectsSet.add('b-1');
+    projectsSet.add('b-2');
+
+    expect(
+      findMatchingProjects(['b*'], Array.from(projectsSet), projectsSet)
+    ).toEqual(['b', 'b-1', 'b-2']);
+  });
+
+  it('should support projectNames', () => {
+    expect(
+      findMatchingProjects(['a', 'b'], Array.from(projectsSet), projectsSet)
+    ).toEqual(['a', 'b']);
+  });
+});

--- a/packages/nx/src/utils/find-matching-projects.ts
+++ b/packages/nx/src/utils/find-matching-projects.ts
@@ -1,15 +1,30 @@
 import minimatch = require('minimatch');
 
+const globCharacters = ['*', '|', '{', '}', '(', ')'];
+
+/**
+ * Find matching project names given a list of potential project names or globs.
+ *
+ * @param patterns A list of project names or globs to match against.
+ * @param projectNames An array containing the list of project names.
+ * @param projectNamesSet A set containing the list of project names.
+ * @returns
+ */
 export function findMatchingProjects(
   patterns: string[],
-  projectNames: string[]
+  projectNames: string[],
+  projectNamesSet: Set<string>
 ): string[] {
   const selectedProjects: Set<string> = new Set();
   const excludedProjects: Set<string> = new Set();
 
   for (const nameOrGlob of patterns) {
-    if (projectNames.includes(nameOrGlob)) {
+    if (projectNamesSet.has(nameOrGlob)) {
       selectedProjects.add(nameOrGlob);
+      continue;
+    }
+
+    if (!globCharacters.some((c) => nameOrGlob.includes(c))) {
       continue;
     }
 

--- a/packages/nx/src/utils/find-matching-projects.ts
+++ b/packages/nx/src/utils/find-matching-projects.ts
@@ -1,0 +1,35 @@
+import minimatch = require('minimatch');
+
+export function findMatchingProjects(
+  patterns: string[],
+  projectNames: string[]
+): string[] {
+  const selectedProjects: Set<string> = new Set();
+  const excludedProjects: Set<string> = new Set();
+
+  for (const nameOrGlob of patterns) {
+    if (projectNames.includes(nameOrGlob)) {
+      selectedProjects.add(nameOrGlob);
+      continue;
+    }
+
+    const exclude = nameOrGlob.startsWith('!');
+    const pattern = exclude ? nameOrGlob.substring(1) : nameOrGlob;
+
+    const matchedProjectNames = minimatch.match(projectNames, pattern);
+
+    matchedProjectNames.forEach((matchedProjectName) => {
+      if (exclude) {
+        excludedProjects.add(matchedProjectName);
+      } else {
+        selectedProjects.add(matchedProjectName);
+      }
+    });
+  }
+
+  for (const project of excludedProjects) {
+    selectedProjects.delete(project);
+  }
+
+  return Array.from(selectedProjects);
+}


### PR DESCRIPTION
## Current Behavior
There is no way to specify all other projects as an implicit dependency of project {x}.

## Expected Behavior
You can specify "*" in implicit dependencies to specify all other projects as a dependency. This is especially useful in the case of the root project, which may depend on all other projects.

Additionally, if you wanted to specify all other projects, except {x} as a dependency of {y}, then in {y}'s project configuration you could specify:

```
implicitDependencies: ['*', '!x']
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
