### PR TITLE
fix(devkit): use target inference from plugins in readTargetOptions

### DIFF
--- a/packages/devkit/src/executors/read-target-options.ts
+++ b/packages/devkit/src/executors/read-target-options.ts
@@ -12,7 +12,7 @@ export function readTargetOptions<T = any>(
   { project, target, configuration }: Target,
   context: ExecutorContext
 ): T {
-  const projectConfiguration = context.workspace.projects[project];
+  const projectConfiguration = context.projectGraph.nodes[project].data;
   const targetConfiguration = projectConfiguration.targets[target];
 
   const ws = new Workspaces(context.root);


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

`readTargetOptions` won't take in account targets defined from plugins.

This causes executors that depend on it to fail when the target is not explicit in the project.json file. 

As an example, you could define a target with executor `@nrwl/web:dev-server` for your project, but leave the `build` target to be defined from a plugin. When `@nrwl/web:dev-server` tries to get the options from `build`, it will fail due to this target not being explicit in `project.json`.

See more information in the fixed issue #10972

## Expected Behavior

Targets defined using inference from plugins should be available when using `readTargetOptions`.

## Related Issue(s)

I believe this was left unchanged by mistake when target inference was first introduced in #8210. The fix applied here uses the same approach as seen in the original PR.

Fixes #10972
