### PR TITLE
fix(webpack): ssl dev server logs wrong protocol

### DIFF
--- a/packages/webpack/src/executors/dev-server/lib/get-dev-server-config.ts
+++ b/packages/webpack/src/executors/dev-server/lib/get-dev-server-config.ts
@@ -90,7 +90,7 @@ function getDevServerPartial(
     onListening(server: any) {
       logger.info(
         `NX Web Development Server is listening at ${
-          server.options.https ? 'https' : 'http'
+          server.options.server.type === 'http' ? 'http' : 'https'
         }://${server.options.host}:${server.options.port}${buildServePath(
           buildOptions
         )}`


### PR DESCRIPTION
When running dev server with `{ ssl: true }`, NX logs address with `http`, eg:
`NX  Web Development Server is listening at http://localhost:4200/`

Fix is based on the webpack's sources:
https://github.com/webpack/webpack-dev-server/blob/efb2cec3f8acbbe5113aad20529e268c01ac29c2/lib/Server.js#L2782