### PR TITLE
fix(angular): local imports in webpack-dev-server custom config

### DIFF
--- a/packages/angular/src/builders/webpack-dev-server/webpack-dev-server.impl.ts
+++ b/packages/angular/src/builders/webpack-dev-server/webpack-dev-server.impl.ts
@@ -84,6 +84,12 @@ export function executeWebpackDevServerBuilder(
       options.tsConfig = tsConfigPath;
       return options;
     };
+
+    // The buildTargetConfiguration also needs to use the generated tsconfig path
+    // otherwise the build will fail if customWebpack function/file is referencing
+    // local libs. This synchronize the behavior with webpack-browser and
+    // webpack-server implementation.
+    buildTargetConfiguration.tsConfig = tsConfigPath;
   }
 
   return executeDevServerBuilder(options as DevServerBuilderOptions, context, {


### PR DESCRIPTION
Fixes the implementation of webpack-dev-server to allow imports of local libraries in custom webpack config typescript files. This aligns the behavior with the webpack-browser and webpack-server builders.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
After the cleanup story #12924 ([this change](https://github.com/nrwl/nx/pull/12924/files#diff-39a45d5a12bd4b48ebc0871fab97966eab51e70137d4e1d48df18ee5171b5da2R114-R118)), custom webpack files lost the possibility to import local libraries. Each `serve` command ends up with error being thrown regarding unresolved dependencies while `build` works fine.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The `serve` command works in the same way as `build` and allow referencing local libraries.

## Related Issue(s)
Fixes #13233
