### PR TITLE
fix(nxdev): related docs recipes not listed

### DIFF
--- a/nx-dev/nx-dev/lib/api.ts
+++ b/nx-dev/nx-dev/lib/api.ts
@@ -30,6 +30,21 @@ export const nxDocumentsApi = new DocumentsApi({
     documents.content.find(
       (x) => x.id === 'additional-api-references'
     ) as Partial<DocumentMetadata>,
+    {
+      id: 'nx-recipes',
+      name: 'wrapper',
+      itemList: [
+        {
+          id: 'recipes',
+          name: 'Recipes',
+          itemList: (
+            documents.content.find(
+              (x) => x.id === 'nx-recipes'
+            ) as Partial<DocumentMetadata>
+          ).itemList,
+        },
+      ],
+    },
   ]
     .filter((x) => !!x)
     .map((x) => convertToDocumentMetadata(x)),


### PR DESCRIPTION
Related Documentation recipes were not showing up because the recipes were in a different section from the rest of the Nx docs.

I first noticed it on this page:
https://nx.dev/reference/environment-variables

After the PR it looks like this:
![Screen Shot 2022-11-14 at 3 30 58 PM](https://user-images.githubusercontent.com/861504/201760178-11320571-acc2-4867-b4cc-87fde16abd0c.png)
