### PR TITLE
feat(core): add prune lock file hashing based on the input

### DIFF
--- a/packages/nx/src/utils/lock-file/npm.ts
+++ b/packages/nx/src/utils/lock-file/npm.ts
@@ -1,6 +1,11 @@
 import { satisfies } from 'semver';
 import { LockFileData, PackageDependency } from './lock-file-type';
-import { sortObject, hashString, TransitiveLookupFunctionInput } from './utils';
+import {
+  sortObject,
+  hashString,
+  TransitiveLookupFunctionInput,
+  generatePrunnedHash,
+} from './utils';
 
 type PackageMeta = {
   path: string;
@@ -460,7 +465,11 @@ Returning entire lock file.`
     ...pruneRootPackage(lockFileData, packages, projectName),
   };
   let prunedLockFileData: LockFileData;
-  prunedLockFileData = { dependencies, lockFileMetadata, hash: '' };
+  prunedLockFileData = {
+    dependencies,
+    lockFileMetadata,
+    hash: generatePrunnedHash(lockFileData.hash, packages, projectName),
+  };
   return prunedLockFileData;
 }
 

--- a/packages/nx/src/utils/lock-file/pnpm.ts
+++ b/packages/nx/src/utils/lock-file/pnpm.ts
@@ -5,6 +5,7 @@ import {
   hashString,
   isRootVersion,
   TransitiveLookupFunctionInput,
+  generatePrunnedHash,
 } from './utils';
 import { satisfies } from 'semver';
 
@@ -345,7 +346,7 @@ export function prunePnpmLockFile(
   const prunedLockFileData = {
     lockFileMetadata: lockFileData.lockFileMetadata,
     dependencies,
-    hash: '',
+    hash: generatePrunnedHash(lockFileData.hash, packages, projectName),
   };
   return prunedLockFileData;
 }

--- a/packages/nx/src/utils/lock-file/utils.ts
+++ b/packages/nx/src/utils/lock-file/utils.ts
@@ -246,6 +246,13 @@ function traverseExternalNodesDependencies(
   });
 }
 
+/**
+ * Generate new hash based on the original hash and pruning input parameters - packages and project name
+ * @param originalHash
+ * @param packages
+ * @param projectName
+ * @returns
+ */
 export function generatePrunnedHash(
   originalHash: string,
   packages: string[],

--- a/packages/nx/src/utils/lock-file/utils.ts
+++ b/packages/nx/src/utils/lock-file/utils.ts
@@ -245,3 +245,15 @@ function traverseExternalNodesDependencies(
     }
   });
 }
+
+export function generatePrunnedHash(
+  originalHash: string,
+  packages: string[],
+  projectName?: string
+) {
+  const hashingInput = [originalHash, ...packages];
+  if (projectName) {
+    hashingInput.push(projectName);
+  }
+  return defaultHashing.hashArray(hashingInput);
+}

--- a/packages/nx/src/utils/lock-file/yarn.ts
+++ b/packages/nx/src/utils/lock-file/yarn.ts
@@ -10,6 +10,7 @@ import {
   hashString,
   isRootVersion,
   TransitiveLookupFunctionInput,
+  generatePrunnedHash,
 } from './utils';
 
 type LockFileDependencies = Record<
@@ -204,10 +205,13 @@ export function pruneYarnLockFile(
         ),
       },
       dependencies: prunedDependencies,
-      hash: '',
+      hash: generatePrunnedHash(lockFileData.hash, packages, projectName),
     };
   } else {
-    prunedLockFileData = { dependencies: prunedDependencies, hash: '' };
+    prunedLockFileData = {
+      dependencies: prunedDependencies,
+      hash: generatePrunnedHash(lockFileData.hash, packages, projectName),
+    };
   }
 
   prunedLockFileData.hash = hashString(JSON.stringify(prunedLockFileData));


### PR DESCRIPTION
Add missing pruning functionality:
- [ ] Prune NPM
  - [ ] Pruning V1 (workaround in place)
  - [X] Pruning V2 [Done in the previous PR]
  - [X] Pruning V3 [Done in the previous PR] 
  - [X] Root project name pruning [Done in the previous PR]   
  - [X] Handle peer dependencies [Done in the previous PR]
- [ ] Prune Yarn
  - [X] Pruning Classic [Done in the previous PR]
  - [X] Pruning Berry [Done in the previous PR]  
  - [ ] Workspace projects pruning  
- [ ] Prune Pnpm
  - [X] Pruning Pnpm [Done in the previous PR]
  - [ ] Workspace projects pruning    
- [X] **Solve hashing**

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Related to https://github.com/nrwl/nx/issues/9761
