### PR TITLE
feat(core): handle yarn workspace packages when pruning

### DIFF
--- a/packages/nx/src/utils/lock-file/yarn.spec.ts
+++ b/packages/nx/src/utils/lock-file/yarn.spec.ts
@@ -182,6 +182,29 @@ describe('yarn LockFile utility', () => {
         removeComment(berryLockFileDevkitAndYargs)
       );
     });
+
+    it('shold correctly prune lockfile with multiple packages and custom name', () => {
+      const result = pruneYarnLockFile(
+        parsedLockFile,
+        ['yargs', '@nrwl/devkit', 'typescript'],
+        'custom-name'
+      );
+      expect(result.lockFileMetadata.workspacePackages).toMatchInlineSnapshot(`
+        Object {
+          "custom-name@workspace:^": Object {
+            "dependencies": Object {
+              "@nrwl/devkit": "14.7.5",
+              "typescript": "~4.8.2",
+              "yargs": "^17.4.0",
+            },
+            "languageName": "unknown",
+            "linkType": "soft",
+            "resolution": "custom-name@workspace:^",
+            "version": "0.0.0-use.local",
+          },
+        }
+      `);
+    });
   });
 });
 


### PR DESCRIPTION
Add missing pruning functionality:
- [ ] Prune NPM
  - [ ] Pruning V1 (workaround in place)
  - [X] Pruning V2 [Done in the previous PR]
  - [X] Pruning V3 [Done in the previous PR] 
  - [X] Root project name pruning [Done in the previous PR]   
  - [X] Handle peer dependencies [Done in the previous PR]
- [x] Prune Yarn
  - [X] Pruning Classic [Done in the previous PR]
  - [X] Pruning Berry [Done in the previous PR]  
  - [x] **Workspace projects pruning**
- [ ] Prune Pnpm
  - [X] Pruning Pnpm [Done in the previous PR]
  - [ ] Lock file meta pruning
- [X] Solve hashing [Done in the previous PR]

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Related to https://github.com/nrwl/nx/issues/9761
