### PR TITLE
docs(nx-plugin): typo correction in local generators docs

### DIFF
--- a/docs/shared/recipes/local-generators.md
+++ b/docs/shared/recipes/local-generators.md
@@ -44,7 +44,7 @@ happynrwl/
 └── tsconfig.base.json
 ```
 
-The `index.ts` provides an entry point to the generator. The file contains a function that is called to perform manipulations on a tree that represents the file system.
+The `generator.ts` provides an entry point to the generator. The file contains a function that is called to perform manipulations on a tree that represents the file system.
 The `schema.json` provides a description of the generator, available options, validation information, and default values.
 
 The initial generator function creates a library.


### PR DESCRIPTION
The documentation still refers to the `index.ts` file as the entry point, while the current implementation uses the `generator.ts` file instead.

## Current Behavior
The current documentation (docs/shared/recipes/local-generators.md) displays the following snippet and description:

```text
happynrwl/
├── apps/
├── libs/
│   ├── my-plugin
│   │   ├── src
│   │   │   ├── generators
│   │   │   |   └── my-generator/
│   │   │   |   |    ├── generator.spec.ts
│   │   │   |   |    ├── generator.ts
│   │   │   |   |    ├── schema.d.ts
│   │   │   |   |    └── schema.json
├── nx.json
├── package.json
└── tsconfig.base.json
```

The `index.ts` provides an entry point to the generator. (following text is omitted)

## Expected Behavior

`index.ts` should be replaced with `generator.ts` to be aligned with the new generator's structure.

