### PR TITLE
fix(testing): add babel-jest transform options for react libraries

### DIFF
--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -311,6 +311,14 @@ describe('app', () => {
     );
   });
 
+  it('should setup jest with babel-jest support', async () => {
+    await applicationGenerator(appTree, { ...schema, name: 'my-app' });
+
+    expect(appTree.read('apps/my-app/jest.config.ts').toString()).toContain(
+      "['babel-jest', { presets: ['@nrwl/react/babel'] }]"
+    );
+  });
+
   it('should setup jest without serializers', async () => {
     await applicationGenerator(appTree, { ...schema, name: 'my-app' });
 

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -224,6 +224,12 @@ describe('lib', () => {
         }
       `);
     });
+    it('should update jest.config.ts for babel', async () => {
+      await libraryGenerator(appTree, { ...defaultSchema, compiler: 'babel' });
+      expect(appTree.read('libs/my-lib/jest.config.ts', 'utf-8')).toContain(
+        "['babel-jest', { presets: ['@nrwl/react/babel'] }]"
+      );
+    });
   });
 
   describe('nested', () => {
@@ -270,6 +276,16 @@ describe('lib', () => {
       ).toBeTruthy();
     });
 
+    it('should update jest.config.ts for babel', async () => {
+      await libraryGenerator(appTree, {
+        ...defaultSchema,
+        directory: 'myDir',
+        compiler: 'babel',
+      });
+      expect(
+        appTree.read('libs/my-dir/my-lib/jest.config.ts', 'utf-8')
+      ).toContain("['babel-jest', { presets: ['@nrwl/react/babel'] }]");
+    });
     it('should update workspace.json', async () => {
       await libraryGenerator(appTree, { ...defaultSchema, directory: 'myDir' });
       const workspaceJson = readJson(appTree, '/workspace.json');

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -46,7 +46,7 @@ import {
 import componentGenerator from '../component/component';
 import init from '../init/init';
 import { Schema } from './schema';
-
+import { updateJestConfigContent } from '../../utils/jest-utils';
 export interface NormalizedSchema extends Schema {
   name: string;
   fileName: string;
@@ -99,6 +99,16 @@ export async function libraryGenerator(host: Tree, schema: Schema) {
       compiler: options.compiler,
     });
     tasks.push(jestTask);
+    const jestConfigPath = joinPathFragments(
+      options.projectRoot,
+      options.js ? 'jest.config.js' : 'jest.config.ts'
+    );
+    if (options.compiler === 'babel' && host.exists(jestConfigPath)) {
+      const updatedContent = updateJestConfigContent(
+        host.read(jestConfigPath, 'utf-8')
+      );
+      host.write(jestConfigPath, updatedContent);
+    }
   }
 
   if (options.component) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
when creating a react library the transform options are not set like they are in a react app causing issues where babel transforms won't be applied as expected; therefore, looking like it doesn't work when there just aren't presets for the transform to apply.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
preset is set when making a new react lib

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
