### PR TITLE
feat(core): add includedScripts to allow filtering package json scripts

### DIFF
--- a/e2e/nx-run/src/run.test.ts
+++ b/e2e/nx-run/src/run.test.ts
@@ -14,6 +14,7 @@ import {
   updateFile,
   updateProjectConfig,
 } from '@nrwl/e2e/utils';
+import { PackageJson } from 'nx/src/utils/package-json';
 
 describe('Nx Running Tests', () => {
   let proj: string;
@@ -85,9 +86,13 @@ describe('Nx Running Tests', () => {
 
       updateFile(
         `libs/${mylib}/package.json`,
-        JSON.stringify({
+        JSON.stringify(<PackageJson>{
           name: 'mylib1',
-          scripts: { 'echo:dev': `echo ECHOED` },
+          version: '1.0.0',
+          scripts: { 'echo:dev': `echo ECHOED`, 'echo:fail': 'should not run' },
+          nx: {
+            includedScripts: ['echo:dev'],
+          },
         })
       );
 
@@ -102,6 +107,10 @@ describe('Nx Running Tests', () => {
       } else {
         expect(stdout).toMatch(/ECHOED positional --a=123 --no-b/);
       }
+
+      expect(runCLI(`echo:fail ${mylib}`, { silenceError: true })).toContain(
+        `Cannot find configuration for task ${mylib}:echo:fail`
+      );
 
       updateProjectConfig(mylib, (c) => original);
     }, 1000000);

--- a/packages/nx/src/command-line/run.ts
+++ b/packages/nx/src/command-line/run.ts
@@ -114,7 +114,10 @@ function createImplicitTargetConfig(
     return null;
   }
   const { scripts, nx } = readJsonFile<PackageJson>(packageJsonPath);
-  if (!(targetName in (scripts || {}))) {
+  if (
+    !(targetName in (scripts || {})) ||
+    !(nx.includedScripts && nx.includedScripts.includes(targetName))
+  ) {
     return null;
   }
   return buildTargetFromScript(targetName, nx);

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -17,6 +17,7 @@ export interface NxProjectPackageJsonConfiguration {
   tags?: string[];
   namedInputs?: { [inputName: string]: (string | InputDefinition)[] };
   targets?: Record<string, PackageJsonTargetConfiguration>;
+  includedScripts?: string[];
 }
 
 export type PackageGroup =
@@ -95,7 +96,7 @@ export function readNxMigrateConfig(
 export function buildTargetFromScript(
   script: string,
   nx: NxProjectPackageJsonConfiguration
-) {
+): TargetConfiguration {
   const nxTargetConfiguration = nx?.targets?.[script] || {};
 
   return {

--- a/packages/nx/src/utils/project-graph-utils.spec.ts
+++ b/packages/nx/src/utils/project-graph-utils.spec.ts
@@ -259,5 +259,36 @@ describe('project graph utils', () => {
         },
       });
     });
+
+    it('should ignore scripts that are not in includedScripts', () => {
+      jsonFileOverrides['includedScriptsTest/package.json'] = {
+        name: 'included-scripts-test',
+        scripts: {
+          test: 'echo testing',
+          fail: 'exit 1',
+        },
+        nx: {
+          includedScripts: ['test'],
+        },
+      };
+
+      const result = mergeNpmScriptsWithTargets('includedScriptsTest', {
+        build: {
+          executor: 'nx:run-commands',
+          options: { command: 'echo hi' },
+        },
+      });
+
+      expect(result).toEqual({
+        build: {
+          executor: 'nx:run-commands',
+          options: { command: 'echo hi' },
+        },
+        test: {
+          executor: 'nx:run-script',
+          options: { script: 'test' },
+        },
+      });
+    });
   });
 });

--- a/packages/nx/src/utils/project-graph-utils.ts
+++ b/packages/nx/src/utils/project-graph-utils.ts
@@ -40,7 +40,9 @@ export function mergeNpmScriptsWithTargets(
     const res: Record<string, TargetConfiguration> = {};
     // handle no scripts
     Object.keys(scripts || {}).forEach((script) => {
-      res[script] = buildTargetFromScript(script, nx);
+      if (!nx?.includedScripts || nx?.includedScripts.includes(script)) {
+        res[script] = buildTargetFromScript(script, nx);
+      }
     });
     return { ...res, ...(targets || {}) };
   } catch (e) {


### PR DESCRIPTION
## Current Behavior
All package.json scripts are inferred as targets

## Expected Behavior
`package.json` scripts can be limited by specifying an allowlist

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
