### PR TITLE
fix(bundling): fix webpack `publicPath: 'auto'` behavior for `esm` builds

### DIFF
--- a/packages/webpack/src/utils/config.ts
+++ b/packages/webpack/src/utils/config.ts
@@ -90,6 +90,7 @@ export function getBaseWebpackPartial(
       hashFunction: 'xxhash64',
       // Disabled for performance
       pathinfo: false,
+      scriptType: internalOptions.esm ? 'module' : undefined,
     },
     module: {
       // Enabled for performance


### PR DESCRIPTION
There's a lot more detail in the issue I opened, but I'll summarize the output changes here.

When building with webpack and:
- `output.publicPath` is set to `auto` or omitted (it defaults to `auto`)
- There's an async loaded chunk (for example using a dynamic import)
- Scripts are of type `module` when injected in the html markup (i.e. `esm: true`)

The wrong snippet from the webpack [AutoPublicPathRuntimeModule](https://github.com/webpack/webpack/blob/main/lib/runtime/AutoPublicPathRuntimeModule.js#L38) template is injected

## Current Behavior

Current output uses `document.currentScript` which is not supported for `type="module"` scripts

Minified (note the `currentScript` usage):
```
(()=>{var e;n.g.importScripts&&(e=n.g.location+"");var r=n.g.document;if(!e&&r&&(r.currentScript&&(e=r.currentScript.src),!e)){var t=r.getElementsByTagName("script");t.length&&(e=t[t.length-1].src)}if(!e)throw new Error("Automatic publicPath is not supported in this browser");e=e.replace(/#.*$/,"").replace(/\?.*$/,"").replace(/\/[^\/]+$/,"/"),n.p=e})()
```

With minification manually disabled:
```
/******/ 	/* webpack/runtime/publicPath */
/******/ 	(() => {
/******/ 		var scriptUrl;
/******/ 		if (__webpack_require__.g.importScripts) scriptUrl = __webpack_require__.g.location + "";
/******/ 		var document = __webpack_require__.g.document;
/******/ 		if (!scriptUrl && document) {
/******/ 			if (document.currentScript)
/******/ 				scriptUrl = document.currentScript.src
/******/ 			if (!scriptUrl) {
/******/ 				var scripts = document.getElementsByTagName("script");
/******/ 				if(scripts.length) scriptUrl = scripts[scripts.length - 1].src
/******/ 			}
/******/ 		}
/******/ 		// When supporting browsers where an automatic publicPath is not supported you must specify an output.publicPath manually via configuration
/******/ 		// or pass an empty string ("") and set the __webpack_public_path__ variable from your code to use your own logic.
/******/ 		if (!scriptUrl) throw new Error("Automatic publicPath is not supported in this browser");
/******/ 		scriptUrl = scriptUrl.replace(/#.*$/, "").replace(/\?.*$/, "").replace(/\/[^\/]+$/, "/");
/******/ 		__webpack_require__.p = scriptUrl;
/******/ 	})();
```

## Expected Behavior

After this change:

Minified (not `import.meta.url` usage):
```
(()=>{var e;if("string"==typeof import.meta.url&&(e=import.meta.url),!e)throw new Error("Automatic publicPath is not supported in this browser");e=e.replace(/#.*$/,"").replace(/\?.*$/,"").replace(/\/[^\/]+$/,"/"),n.p=e})()
```

With minification manually disabled:
```
/******/ 	/* webpack/runtime/publicPath */
/******/ 	(() => {
/******/ 		var scriptUrl;
/******/ 		if (typeof import.meta.url === "string") scriptUrl = import.meta.url
/******/ 		// When supporting browsers where an automatic publicPath is not supported you must specify an output.publicPath manually via configuration
/******/ 		// or pass an empty string ("") and set the __webpack_public_path__ variable from your code to use your own logic.
/******/ 		if (!scriptUrl) throw new Error("Automatic publicPath is not supported in this browser");
/******/ 		scriptUrl = scriptUrl.replace(/#.*$/, "").replace(/\?.*$/, "").replace(/\/[^\/]+$/, "/");
/******/ 		__webpack_require__.p = scriptUrl;
/******/ 	})();
```


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #13185
