### PR TITLE
fix(core): fix parsing of npm workspace patterns

### DIFF
--- a/packages/nx/src/config/workspaces.ts
+++ b/packages/nx/src/config/workspaces.ts
@@ -28,6 +28,7 @@ import {
 import { PackageJson } from '../utils/package-json';
 import { sortObjectByKeys } from '../utils/object-sort';
 import { output } from '../utils/output';
+import { joinPathFragments } from '../utils/path';
 
 export function workspaceConfigName(
   root: string
@@ -655,7 +656,9 @@ export function getGlobPatternsFromPackageManagerWorkspaces(
 function normalizePatterns(patterns: string[]): string[] {
   return patterns.map((pattern) =>
     removeRelativePath(
-      pattern.endsWith('/package.json') ? pattern : `${pattern}/package.json`
+      pattern.endsWith('/package.json')
+        ? pattern
+        : joinPathFragments(pattern, 'package.json')
     )
   );
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Patterns such as these will be parsed incorrectly and the projects will not be located.

```
"packages": [
    "packages/my-project1/",
    "packages/my-project2/"
  ],
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The above pattern should be parsed correctly and they will work as expected.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/13153
