### PR TITLE
fix(angular): setup-ssr environments file replacements should be removed

### DIFF
--- a/packages/angular/src/generators/setup-ssr/__snapshots__/setup-ssr.spec.ts.snap
+++ b/packages/angular/src/generators/setup-ssr/__snapshots__/setup-ssr.spec.ts.snap
@@ -9,12 +9,6 @@ Object {
       "sourceMap": true,
     },
     "production": Object {
-      "fileReplacements": Array [
-        Object {
-          "replace": "apps/app1/src/environments/environment.ts",
-          "with": "apps/app1/src/environments/environment.prod.ts",
-        },
-      ],
       "outputHashing": "media",
     },
   },

--- a/packages/angular/src/generators/setup-ssr/files/src/__main__
+++ b/packages/angular/src/generators/setup-ssr/files/src/__main__
@@ -7,13 +7,5 @@
  */
 import '@angular/platform-server/init';
 
-import { enableProdMode } from '@angular/core';
-
-import { environment } from './environments/environment';
-
-if (environment.production) {
-  enableProdMode();
-}
-
 export { <%= rootModuleClassName %> } from './app/<%= rootModuleFileName.slice(0, -3) %>';
 export { renderModule } from '@angular/platform-server';

--- a/packages/angular/src/generators/setup-ssr/files/src/main.ts__tpl__
+++ b/packages/angular/src/generators/setup-ssr/files/src/main.ts__tpl__
@@ -1,12 +1,6 @@
-import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
 import { AppModule } from './app/app.module';
-import { environment } from './environments/environment';
-
-if (environment.production) {
-  enableProdMode();
-}
 
 function bootstrap() {
   platformBrowserDynamic()

--- a/packages/angular/src/generators/setup-ssr/lib/update-project-config.ts
+++ b/packages/angular/src/generators/setup-ssr/lib/update-project-config.ts
@@ -21,18 +21,6 @@ export function updateProjectConfig(tree: Tree, schema: Schema) {
     configurations: {
       production: {
         outputHashing: 'media',
-        fileReplacements: [
-          {
-            replace: joinPathFragments(
-              projectConfig.sourceRoot,
-              'environments/environment.ts'
-            ),
-            with: joinPathFragments(
-              projectConfig.sourceRoot,
-              'environments/environment.prod.ts'
-            ),
-          },
-        ],
       },
       development: {
         optimization: false,

--- a/packages/angular/src/generators/setup-ssr/setup-ssr.spec.ts
+++ b/packages/angular/src/generators/setup-ssr/setup-ssr.spec.ts
@@ -34,27 +34,13 @@ describe('setupSSR', () => {
        */
       import '@angular/platform-server/init';
 
-      import { enableProdMode } from '@angular/core';
-
-      import { environment } from './environments/environment';
-
-      if (environment.production) {
-        enableProdMode();
-      }
-
       export { AppServerModule } from './app/app.server.module';
       export { renderModule } from '@angular/platform-server';"
     `);
     expect(tree.read('apps/app1/src/main.ts', 'utf-8')).toMatchInlineSnapshot(`
-      "import { enableProdMode } from '@angular/core';
-      import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+      "import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
       import { AppModule } from './app/app.module';
-      import { environment } from './environments/environment';
-
-      if (environment.production) {
-        enableProdMode();
-      }
 
       function bootstrap() {
         platformBrowserDynamic()


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
FileReplacements and environment files are no longer used in Angular 15, but we still generate them

## Expected Behavior
Do not generate config relating to environment files
<!-- This is the behavior we should expect with the changes in this PR -->
