### PR TITLE
fix(angular): should support filereplacements for apps that already have them

### DIFF
--- a/packages/angular/src/generators/setup-ssr/__snapshots__/setup-ssr.spec.ts.snap
+++ b/packages/angular/src/generators/setup-ssr/__snapshots__/setup-ssr.spec.ts.snap
@@ -84,3 +84,31 @@ if (moduleFilename === __filename || moduleFilename.includes('iisnode')) {
 
 export * from './src/main.server';"
 `;
+
+exports[`setupSSR should use fileReplacements if they already exist 1`] = `
+Object {
+  "configurations": Object {
+    "development": Object {
+      "extractLicenses": false,
+      "optimization": false,
+      "sourceMap": true,
+    },
+    "production": Object {
+      "fileReplacements": Array [
+        Object {
+          "replace": "apps/app1/src/environments/environment.ts",
+          "with": "apps/app1/src/environments/environment.prod.ts",
+        },
+      ],
+      "outputHashing": "media",
+    },
+  },
+  "defaultConfiguration": "production",
+  "executor": "@angular-devkit/build-angular:server",
+  "options": Object {
+    "main": "apps/app1/server.ts",
+    "outputPath": "dist/apps/app1/server",
+    "tsConfig": "apps/app1/tsconfig.server.json",
+  },
+}
+`;

--- a/packages/angular/src/generators/setup-ssr/lib/update-project-config.ts
+++ b/packages/angular/src/generators/setup-ssr/lib/update-project-config.ts
@@ -11,6 +11,9 @@ export function updateProjectConfig(tree: Tree, schema: Schema) {
 
   projectConfig.targets.build.options.outputPath = `dist/apps/${schema.project}/browser`;
 
+  const buildTargetFileReplacements =
+    projectConfig.targets.build.configurations?.production?.fileReplacements;
+
   projectConfig.targets.server = {
     executor: '@angular-devkit/build-angular:server',
     options: {
@@ -21,6 +24,9 @@ export function updateProjectConfig(tree: Tree, schema: Schema) {
     configurations: {
       production: {
         outputHashing: 'media',
+        ...(buildTargetFileReplacements
+          ? { fileReplacements: buildTargetFileReplacements }
+          : {}),
       },
       development: {
         optimization: false,


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
People may need to run setup-ssr on an app they have migrated along older versions of angular which still has fileReplacments

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should support this use case
