### PR TITLE
feat(core): optimize project graph file mapping

### DIFF
--- a/packages/angular/plugins/component-testing.ts
+++ b/packages/angular/plugins/component-testing.ts
@@ -21,7 +21,7 @@ import {
   stripIndents,
   workspaceRoot,
 } from '@nrwl/devkit';
-import { mapProjectGraphFiles } from 'nx/src/utils/target-project-locator';
+import { createProjectFileMappings } from 'nx/src/utils/target-project-locator';
 import { lstatSync, mkdirSync, writeFileSync } from 'fs';
 import { dirname, join, relative } from 'path';
 import type { BrowserBuilderSchema } from '../src/builders/webpack-browser/webpack-browser.impl';
@@ -279,14 +279,16 @@ function withSchemaDefaults(options: any): BrowserBuilderSchema {
  * this file should get cleaned up via the cypress executor
  */
 function getTempStylesForTailwind(ctExecutorContext: ExecutorContext) {
-  const mappedGraph = mapProjectGraphFiles(ctExecutorContext.projectGraph);
+  const mappedGraphFiles = createProjectFileMappings(
+    ctExecutorContext.projectGraph
+  );
   const ctProjectConfig = ctExecutorContext.projectGraph.nodes[
     ctExecutorContext.projectName
   ].data as ProjectConfiguration;
   // angular only supports `tailwind.config.{js,cjs}`
   const ctProjectTailwindConfig = join(ctProjectConfig.root, 'tailwind.config');
-  const isTailWindInCtProject = !!mappedGraph.allFiles[ctProjectTailwindConfig];
-  const isTailWindInRoot = !!mappedGraph.allFiles['tailwind.config'];
+  const isTailWindInCtProject = !!mappedGraphFiles[ctProjectTailwindConfig];
+  const isTailWindInRoot = !!mappedGraphFiles['tailwind.config'];
 
   if (isTailWindInRoot || isTailWindInCtProject) {
     const pathToStyle = getTempTailwindPath(ctExecutorContext);

--- a/packages/cypress/plugins/cypress-preset.ts
+++ b/packages/cypress/plugins/cypress-preset.ts
@@ -9,7 +9,7 @@ import {
   workspaceRoot,
 } from '@nrwl/devkit';
 import { readProjectsConfigurationFromProjectGraph } from 'nx/src/project-graph/project-graph';
-import { mapProjectGraphFiles } from 'nx/src/utils/target-project-locator';
+import { createProjectFileMappings } from 'nx/src/utils/target-project-locator';
 import { dirname, extname, join, relative } from 'path';
 import { lstatSync } from 'fs';
 
@@ -90,9 +90,9 @@ export function getProjectConfigByPath(
       : configFileFromWorkspaceRoot
   );
 
-  const mappedGraph = mapProjectGraphFiles(graph);
+  const mappedGraphFiles = createProjectFileMappings(graph);
   const componentTestingProjectName =
-    mappedGraph.allFiles[normalizedPathFromWorkspaceRoot];
+    mappedGraphFiles[normalizedPathFromWorkspaceRoot];
   if (
     !componentTestingProjectName ||
     !graph.nodes[componentTestingProjectName]?.data

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.spec.ts
@@ -5,7 +5,7 @@ import { TSESLint } from '@typescript-eslint/utils';
 import { vol } from 'memfs';
 import {
   TargetProjectLocator,
-  mapProjectGraphFiles,
+  createProjectFileMappings,
 } from 'nx/src/utils/target-project-locator';
 import enforceModuleBoundaries, {
   RULE_NAME as enforceModuleBoundariesRuleName,
@@ -1885,7 +1885,9 @@ function runRule(
   projectGraph: ProjectGraph
 ): TSESLint.Linter.LintMessage[] {
   (global as any).projectPath = `${process.cwd()}/proj`;
-  (global as any).projectGraph = mapProjectGraphFiles(projectGraph);
+  (global as any).projectGraph = projectGraph;
+  (global as any).projectGraphFileMappings =
+    createProjectFileMappings(projectGraph);
   (global as any).targetProjectLocator = new TargetProjectLocator(
     projectGraph.nodes,
     projectGraph.externalNodes

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -154,7 +154,8 @@ export default createESLintRule<Options, MessageIds>({
     );
     const fileName = normalizePath(context.getFilename());
 
-    const projectGraph = readProjectGraph(RULE_NAME);
+    const { projectGraph, projectGraphFileMappings } =
+      readProjectGraph(RULE_NAME);
 
     if (!projectGraph) {
       return {};
@@ -198,7 +199,11 @@ export default createESLintRule<Options, MessageIds>({
 
       const sourceFilePath = getSourceFilePath(fileName, projectPath);
 
-      const sourceProject = findSourceProject(projectGraph, sourceFilePath);
+      const sourceProject = findSourceProject(
+        projectGraph,
+        projectGraphFileMappings,
+        sourceFilePath
+      );
       // If source is not part of an nx workspace, return.
       if (!sourceProject) {
         return;
@@ -210,12 +215,17 @@ export default createESLintRule<Options, MessageIds>({
       let targetProject: ProjectGraphProjectNode | ProjectGraphExternalNode;
 
       if (isAbsoluteImportIntoAnotherProj) {
-        targetProject = findTargetProject(projectGraph, imp);
+        targetProject = findTargetProject(
+          projectGraph,
+          projectGraphFileMappings,
+          imp
+        );
       } else {
         targetProject = getTargetProjectBasedOnRelativeImport(
           imp,
           projectPath,
           projectGraph,
+          projectGraphFileMappings,
           sourceFilePath
         );
       }

--- a/packages/eslint-plugin-nx/src/rules/nx-plugin-checks.ts
+++ b/packages/eslint-plugin-nx/src/rules/nx-plugin-checks.ts
@@ -87,14 +87,19 @@ export default createESLintRule<Options, MessageIds>({
       return {};
     }
 
-    const projectGraph = readProjectGraph(RULE_NAME);
+    const { projectGraph, projectGraphFileMappings } =
+      readProjectGraph(RULE_NAME);
 
     const sourceFilePath = getSourceFilePath(
       context.getFilename(),
       workspaceRoot
     );
 
-    const sourceProject = findSourceProject(projectGraph, sourceFilePath);
+    const sourceProject = findSourceProject(
+      projectGraph,
+      projectGraphFileMappings,
+      sourceFilePath
+    );
     // If source is not part of an nx workspace, return.
     if (!sourceProject) {
       return {};

--- a/packages/nx/src/utils/target-project-locator.ts
+++ b/packages/nx/src/utils/target-project-locator.ts
@@ -206,7 +206,7 @@ function filterRootExternalDependencies(
  */
 export function createProjectRootMappings(
   nodes: Record<string, ProjectGraphProjectNode>
-) {
+): Map<string, string> {
   const projectRootMappings = new Map<string, string>();
   for (const projectName of Object.keys(nodes)) {
     const root = nodes[projectName].data.root;
@@ -217,10 +217,6 @@ export function createProjectRootMappings(
   }
   return projectRootMappings;
 }
-
-export type MappedProjectGraph<T = any> = ProjectGraph<T> & {
-  allFiles: Record<string, string>;
-};
 
 /**
  * Strips the file extension from the file path
@@ -237,26 +233,20 @@ export function removeExt(file: string): string {
  * @param projectGraph
  * @returns
  */
-export function mapProjectGraphFiles<T>(
-  projectGraph: ProjectGraph<T>
-): MappedProjectGraph | null {
-  if (!projectGraph) {
-    return null;
-  }
-  const allFiles: Record<string, string> = {};
+export function createProjectFileMappings(
+  projectGraph: ProjectGraph
+): Record<string, string> {
+  const result: Record<string, string> = {};
   Object.entries(
     projectGraph.nodes as Record<string, ProjectGraphProjectNode>
   ).forEach(([name, node]) => {
     node.data.files.forEach(({ file }) => {
       const fileName = removeExt(file);
-      allFiles[fileName] = name;
+      result[fileName] = name;
     });
   });
 
-  return {
-    ...projectGraph,
-    allFiles,
-  };
+  return result;
 }
 
 /**


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The `mapProjectGraphFiles` creates an extended `ProjectGraph` structure that includes the `allFiles` lookup map.

## Expected Behavior
- Rename `mapProjectGraphFiles` to `createProjectFileMappings` to match existing logic in `TargetProjectLocator`
- Extract the file lookup map to keep it separate from the project graph.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Followup to #13222
