### PR TITLE
fix(bundling): Fix vite `fileReplacements` not working

### DIFF
--- a/packages/vite/plugins/rollup-replace-files.plugin.ts
+++ b/packages/vite/plugins/rollup-replace-files.plugin.ts
@@ -13,38 +13,40 @@ export default function replaceFiles(replacements: FileReplacement[]) {
   }
   return {
     name: 'rollup-plugin-replace-files',
-    enforce: 'pre',
-    async resolveId(source, importer, options) {
-      const resolved = await this.resolve(source, importer, {
-        ...options,
-        skipSelf: true,
-      });
+    resolveId: {
+      order: 'pre',
+      async handler(source, importer, options) {
+        const resolved = await this.resolve(source, importer, {
+          ...options,
+          skipSelf: true,
+        });
 
-      /**
-       * The reason we're using endsWith here is because the resolved id
-       * will be the absolute path to the file. We want to check if the
-       * file ends with the file we're trying to replace, which will be essentially
-       * the path from the root of our workspace.
-       */
+        /**
+         * The reason we're using endsWith here is because the resolved id
+         * will be the absolute path to the file. We want to check if the
+         * file ends with the file we're trying to replace, which will be essentially
+         * the path from the root of our workspace.
+         */
 
-      const foundReplace = replacements.find((replacement) =>
-        resolved?.id?.endsWith(replacement.replace)
-      );
-      if (foundReplace) {
-        console.info(
-          `replace "${foundReplace.replace}" with "${foundReplace.with}"`
+        const foundReplace = replacements.find((replacement) =>
+          resolved?.id?.endsWith(replacement.replace)
         );
-        try {
-          // return new file content
-          return {
-            id: foundReplace.with,
-          };
-        } catch (err) {
-          console.error(err);
-          return null;
+        if (foundReplace) {
+          console.info(
+            `replace "${foundReplace.replace}" with "${foundReplace.with}"`
+          );
+          try {
+            // return new file content
+            return {
+              id: foundReplace.with,
+            };
+          } catch (err) {
+            console.error(err);
+            return null;
+          }
         }
-      }
-      return null;
+        return null;
+      },
     },
   };
 }


### PR DESCRIPTION
Fixes `fileReplacements` not working correctly by correcting the rollup plugin usage

According to https://rollupjs.org/guide/en/#build-hooks

<img width="806" alt="image" src="https://user-images.githubusercontent.com/8536244/202764298-a1b4b1d2-aa91-4b8a-a6c8-d495586a707e.png">

The correct plugin structure seem to be like the image above

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

There's a `enforce` property and the `resolveId` is a function

## Expected Behavior

The resolveId should be an object containing `order` and `handler`

## Related Issue(s)

Fixes #13246