### PR TITLE
fix(vite): Fix `fileReplacements` not working with devServer

### DIFF
--- a/packages/vite/plugins/rollup-replace-files.plugin.ts
+++ b/packages/vite/plugins/rollup-replace-files.plugin.ts
@@ -1,5 +1,6 @@
 // source: https://github.com/Myrmod/vitejs-theming/blob/master/build-plugins/rollup/replace-files.js
 
+import fs from 'fs';
 import { resolve } from 'path';
 
 /**
@@ -28,15 +29,13 @@ export default function replaceFiles(replacements: FileReplacement[]) {
         console.info(
           `replace "${foundReplace.replace}" with "${foundReplace.with}"`
         );
-        const { body } = this.parse(code)
-        const newCode = [];
-        if (body.find(({ type }) => type === 'ExportNamedDeclaration')) {
-            newCode.push(`export * from "${foundReplace.with}";`);
+        const foundReplace = replacements.find((replacement)=>{
+          return id.endsWith(replacement.replace)
+        });
+        if (foundReplace) {
+          return fs.readFileSync(id.replace(foundReplace.replace, foundReplace.with)).toString();
         }
-        if (body.find(({ type }) => type === 'ExportDefaultDeclaration')) {
-            newCode.push(`export { default } from "${foundReplace.with}";`);
-        }
-        return newCode.join('\n');
+        return code
       }
       return code;
     },

--- a/packages/vite/plugins/rollup-replace-files.plugin.ts
+++ b/packages/vite/plugins/rollup-replace-files.plugin.ts
@@ -36,7 +36,6 @@ export default function replaceFiles(replacements: FileReplacement[]) {
         if (body.find(({ type }) => type === 'ExportDefaultDeclaration')) {
             newCode.push(`export { default } from "${foundReplace.with}";`);
         }
-        console.log(newCode.join('\n'));
         return newCode.join('\n');
       }
       return code;

--- a/packages/vite/plugins/rollup-replace-files.plugin.ts
+++ b/packages/vite/plugins/rollup-replace-files.plugin.ts
@@ -15,10 +15,19 @@ export default function replaceFiles(replacements: FileReplacement[]) {
     name: 'rollup-plugin-replace-files',
     enforce: 'pre',
     async load(id) {
+      /**
+       * The reason we're using endsWith here is because the resolved id
+       * will be the absolute path to the file. We want to check if the
+       * file ends with the file we're trying to replace, which will be essentially
+       * the path from the root of our workspace.
+       */
       const foundReplace = replacements.find((replacement)=>{
         return id.endsWith(replacement.replace)
       });
       if (foundReplace) {
+        console.info(
+          `replace "${foundReplace.replace}" with "${foundReplace.with}"`
+        );
         return `export * from "${foundReplace.with}"; export { default } from "${foundReplace.with}";`;
       }
       return null

--- a/packages/vite/plugins/rollup-replace-files.plugin.ts
+++ b/packages/vite/plugins/rollup-replace-files.plugin.ts
@@ -14,37 +14,14 @@ export default function replaceFiles(replacements: FileReplacement[]) {
   return {
     name: 'rollup-plugin-replace-files',
     enforce: 'pre',
-    async resolveId(source, importer, options) {
-      const resolved = await this.resolve(source, importer, {
-        ...options,
-        skipSelf: true,
+    async load(id) {
+      const foundReplace = replacements.find((replacement)=>{
+        return id.endsWith(replacement.replace)
       });
-
-      /**
-       * The reason we're using endsWith here is because the resolved id
-       * will be the absolute path to the file. We want to check if the
-       * file ends with the file we're trying to replace, which will be essentially
-       * the path from the root of our workspace.
-       */
-
-      const foundReplace = replacements.find((replacement) =>
-        resolved?.id?.endsWith(replacement.replace)
-      );
       if (foundReplace) {
-        console.info(
-          `replace "${foundReplace.replace}" with "${foundReplace.with}"`
-        );
-        try {
-          // return new file content
-          return {
-            id: foundReplace.with,
-          };
-        } catch (err) {
-          console.error(err);
-          return null;
-        }
+        return `export * from "${foundReplace.with}"; export { default } from "${foundReplace.with}";`;
       }
-      return null;
+      return null
     },
   };
 }


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

The `fileReplacements` option does not work with `@nrwl/vite:dev-server` executor

Existing solution using `resolveId` only works when building but not local dev

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When also passing `fileReplacements` in the "serve" section for the dev server,

It should also do the replacement
