### PR TITLE
fix(core): use multiselect prompts for array properties

### DIFF
--- a/packages/nx/src/utils/params.spec.ts
+++ b/packages/nx/src/utils/params.spec.ts
@@ -1460,7 +1460,7 @@ describe('params', () => {
       ]);
     });
 
-    it('should use an multiselect prompt for x-prompts with items', () => {
+    it('should use a multiselect prompt for x-prompts with items', () => {
       const prompts = getPromptsForSchema(
         {},
         {
@@ -1492,7 +1492,46 @@ describe('params', () => {
       ]);
     });
 
-    it('should use an multiselect prompt for x-prompts with items', () => {
+    it('should use a multiselect prompt for array properties', () => {
+      const prompts = getPromptsForSchema(
+        {},
+        {
+          properties: {
+            pets: {
+              type: 'array',
+              'x-prompt': {
+                type: 'list',
+                message: 'What kind of pets do you have?',
+                items: [
+                  { label: 'Cat', value: 'cat' },
+                  { label: 'Dog', value: 'dog' },
+                  { label: 'Fish', value: 'fish' },
+                ],
+              },
+            },
+          },
+        },
+        {
+          version: 2,
+          projects: {},
+        }
+      );
+
+      expect(prompts).toEqual([
+        {
+          type: 'multiselect',
+          name: 'pets',
+          message: 'What kind of pets do you have?',
+          choices: [
+            { message: 'Cat', name: 'cat' },
+            { message: 'Dog', name: 'dog' },
+            { message: 'Fish', name: 'fish' },
+          ],
+        },
+      ]);
+    });
+
+    it('should use a multiselect prompt for x-prompts with items', () => {
       const prompts = getPromptsForSchema(
         {},
         {

--- a/packages/nx/src/utils/params.ts
+++ b/packages/nx/src/utils/params.ts
@@ -770,9 +770,10 @@ export function getPromptsForSchema(
         question.type = 'confirm';
       } else if (v['x-prompt'].items) {
         question.message = v['x-prompt'].message;
-        question.type = v['x-prompt'].multiselect
-          ? 'multiselect'
-          : 'autocomplete';
+        question.type =
+          v['x-prompt'].multiselect || v.type === 'array'
+            ? 'multiselect'
+            : 'autocomplete';
         question.choices =
           v['x-prompt'].items &&
           v['x-prompt'].items.map((item) => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`ng g @angular/material:mdc-migration` does not show a multi select prompt and is broken.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`ng g @angular/material:mdc-migration` does show a multi select prompt and works.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
