### PR TITLE
fix(angular): use the browserTarget to calculate project deps for buildable libs support in the dev server

### DIFF
--- a/packages/angular/src/builders/utilities/buildable-libs.ts
+++ b/packages/angular/src/builders/utilities/buildable-libs.ts
@@ -9,14 +9,15 @@ import { join } from 'path';
 
 export function createTmpTsConfigForBuildableLibs(
   tsConfigPath: string,
-  context: BuilderContext
+  context: BuilderContext,
+  target?: string
 ) {
   let dependencies: DependentBuildableProjectNode[];
   const result = calculateProjectDependencies(
     readCachedProjectGraph(),
     context.workspaceRoot,
     context.target.project,
-    context.target.target,
+    target ?? context.target.target,
     context.target.configuration
   );
   dependencies = result.dependencies;

--- a/packages/angular/src/builders/webpack-dev-server/webpack-dev-server.impl.ts
+++ b/packages/angular/src/builders/webpack-dev-server/webpack-dev-server.impl.ts
@@ -69,7 +69,11 @@ export function executeWebpackDevServerBuilder(
     const buildTargetTsConfigPath =
       buildTargetConfiguration?.tsConfig ?? buildTarget.options.tsConfig;
     const { tsConfigPath, dependencies: foundDependencies } =
-      createTmpTsConfigForBuildableLibs(buildTargetTsConfigPath, context);
+      createTmpTsConfigForBuildableLibs(
+        buildTargetTsConfigPath,
+        context,
+        parsedBrowserTarget.target
+      );
     dependencies = foundDependencies;
 
     // We can't just pass the tsconfig path in memory to the angular builder


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `webpack-dev-server` builder, when handling the incremental build scenario, is not using the `browserTarget` name to calculate the buildable project dependencies. This causes the builder to not collect any buildable libraries and build them from the source even when the `buildLibsFromSource` option is set to `false`.

This is a regression introduced in https://github.com/nrwl/nx/pull/12924 where the following was missed https://github.com/nrwl/nx/pull/12924/files#diff-39a45d5a12bd4b48ebc0871fab97966eab51e70137d4e1d48df18ee5171b5da2L83.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `webpack-dev-server` builder when handling the incremental build scenario, should use the `browserTarget` name to calculate the buildable project dependencies.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
