### PR TITLE
chore(misc): bump minimatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
     "metro-resolver": "^0.70.3",
     "mime": "2.4.4",
     "mini-css-extract-plugin": "~2.4.7",
-    "minimatch": "3.0.4",
+    "minimatch": "3.0.5",
     "next-sitemap": "^1.6.108",
     "ng-packagr": "~13.3.0",
     "ngrx-store-freeze": "0.2.4",

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -41,7 +41,7 @@
     "fs-extra": "^10.1.0",
     "ignore": "^5.0.4",
     "js-tokens": "^4.0.0",
-    "minimatch": "3.0.4",
+    "minimatch": "3.0.5",
     "source-map-support": "0.5.19",
     "tree-kill": "1.2.2"
   }

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -48,7 +48,7 @@
     "glob": "7.1.4",
     "ignore": "^5.0.4",
     "jsonc-parser": "3.0.0",
-    "minimatch": "3.0.4",
+    "minimatch": "3.0.5",
     "npm-run-path": "^4.0.1",
     "open": "^8.4.0",
     "semver": "7.3.4",

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -77,7 +77,7 @@
     "fs-extra": "^10.1.0",
     "glob": "7.1.4",
     "ignore": "^5.0.4",
-    "minimatch": "3.0.4",
+    "minimatch": "3.0.5",
     "npm-run-path": "^4.0.1",
     "open": "^8.4.0",
     "rxjs": "^6.5.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16706,6 +16706,13 @@ minimatch@3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.5.tgz#4da8f1290ee0f0f8e83d60ca69f8f134068604a3"
+  integrity sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimatch@5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.0.1.tgz#fb9022f7528125187c92bd9e9b6366be1cf3415b"


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Current NX uses a minimatch version with vulnerability: `3.0.4`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Updated minimatch version to `3.0.5`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
Vulnerability issue https://github.com/advisories/GHSA-f8q6-p94x-37v3
