### PR TITLE
feat(core): allow interactivity for run-commands #8269

### DIFF
--- a/docs/generated/packages/nx.json
+++ b/docs/generated/packages/nx.json
@@ -180,7 +180,7 @@
         "description": "Run any custom commands with Nx.",
         "type": "object",
         "cli": "nx",
-        "outputCapture": "pipe",
+        "outputCapture": "direct-nodejs",
         "presets": [
           { "name": "Arguments forwarding", "keys": ["commands"] },
           {

--- a/packages/nx/src/executors/run-commands/schema.json
+++ b/packages/nx/src/executors/run-commands/schema.json
@@ -4,7 +4,7 @@
   "description": "Run any custom commands with Nx.",
   "type": "object",
   "cli": "nx",
-  "outputCapture": "pipe",
+  "outputCapture": "direct-nodejs",
   "presets": [
     {
       "name": "Arguments forwarding",


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
running any command via the `nx:run-commands` executor that expects user input is impossible. The output is hidden, and the terminal is not interactive to allow the user to input anything to the stdin stream.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Running commands via the `nx:run-commands` executor should allow for the output of the underlying command to be streamed to the terminal, as it is most likely running a third-party tool, and it should also allow interactivity from the user to support maximum compatibility with the commands that can be run from it.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8269
