### PR TITLE
fix(linter): align reportUnusedDisableDirectives default value

### DIFF
--- a/docs/generated/packages/linter.json
+++ b/docs/generated/packages/linter.json
@@ -206,7 +206,6 @@
           },
           "reportUnusedDisableDirectives": {
             "type": "string",
-            "default": "off",
             "enum": ["off", "warn", "error"],
             "description": "The equivalent of the `--report-unused-disable-directives` flag on the ESLint CLI."
           }

--- a/packages/linter/src/executors/eslint/schema.json
+++ b/packages/linter/src/executors/eslint/schema.json
@@ -126,7 +126,6 @@
     },
     "reportUnusedDisableDirectives": {
       "type": "string",
-      "default": "off",
       "enum": ["off", "warn", "error"],
       "description": "The equivalent of the `--report-unused-disable-directives` flag on the ESLint CLI."
     }

--- a/packages/linter/src/executors/eslint/utility/eslint-utils.spec.ts
+++ b/packages/linter/src/executors/eslint/utility/eslint-utils.spec.ts
@@ -156,5 +156,15 @@ describe('eslint-utils', () => {
         useEslintrc: true,
       });
     });
+
+    it('should create a ESLint instance with no "reportUnusedDisableDirectives" if it is undefined', async () => {
+      await lint(undefined, {});
+
+      expect(ESLint).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reportUnusedDisableDirectives: undefined,
+        })
+      );
+    });
   });
 });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The NX linter:eslint executor currently runs ESLint with `reportUnusedDisableDirectives` set as `"off"` by default when  the property is not defined in executor options. This is not aligned with the default ESLint behaviour which defines this property as `undefined`.

This lack of alignment with the current ESLint default can be problematic for some plugins, such as [eslint-plugin-eslint-comments](https://www.npmjs.com/package/eslint-plugin-eslint-comments) which will try to [cast this option to boolean](https://github.com/mysticatea/eslint-plugin-eslint-comments/blob/v3.2.0/lib/utils/patch.js#L178), and can cause results from running lint with ESLint CLI and the NX ESLint executor to be different.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The `reportUnusedDisableDirectives` is undefined by default when this options if not defined in the executor options.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
https://github.com/nrwl/nx/issues/13241

Fixes #13241
