### PR TITLE
fix(angular): checks for targets existence before attempting to iterate them

### DIFF
--- a/packages/angular/src/migrations/update-15-2-0/update-typescript-target.ts
+++ b/packages/angular/src/migrations/update-15-2-0/update-typescript-target.ts
@@ -16,6 +16,8 @@ function updateTarget(tree: Tree, tsconfigPath: string) {
 export default async function updateTypescriptTarget(tree: Tree) {
   const projects = getProjects(tree);
   for (const [, project] of projects) {
+    if (!project.targets) continue;
+
     for (const [, target] of Object.entries(project.targets)) {
       // Update all other known CLI builders that use a tsconfig
       const tsConfigs = [


### PR DESCRIPTION
## Current Behavior
Migration fails for projects that don't have a target section defined. (e.g.: an assets library which only holds static files and does not need to build/test/lint/etc. anything)

## Expected Behavior
Projects without a target section should be omitted from running the migration, not throw an error.

Fixes #13286
