### PR TITLE
fix(angular): update make-angular-cli-faster version map with angular 15

### DIFF
--- a/packages/make-angular-cli-faster/src/utilities/migration.ts
+++ b/packages/make-angular-cli-faster/src/utilities/migration.ts
@@ -17,8 +17,8 @@ const latestVersionWithOldFlag = '13.8.3';
 // is already supported
 const nxAngularVersionMap: Record<number, { range: string; max?: string }> = {
   13: { range: '>= 13.2.0 < 14.2.0', max: '~14.1.0' },
-  14: { range: '>= 14.2.0' },
-  15: { range: '>= 15.0.0' },
+  14: { range: '>= 14.2.0 < 15.2.0', max: '~15.1.0' },
+  15: { range: '>= 15.2.0' },
 };
 // latest major version of Angular that is compatible with Nx, based on the map above
 const latestCompatibleAngularMajorVersion = Math.max(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The internal version map used to determine the specific migration and package version to use when running `make-angular-cli-faster`, does not have accurate information for Angular 15.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The internal version map used to determine the specific migration and package version to use when running `make-angular-cli-faster`, has accurate information for Angular 15.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
