### PR TITLE
feat(bundling): add more options to vite executors

### DIFF
--- a/docs/generated/packages/vite.json
+++ b/docs/generated/packages/vite.json
@@ -127,6 +127,29 @@
             "description": "Enable hot module replacement. For more options, use the 'hmr' option in the Vite configuration file.",
             "default": false,
             "type": "boolean"
+          },
+          "open": {
+            "description": "Automatically open the app in the browser on server start. When the value is a string, it will be used as the URL's pathname.",
+            "default": false,
+            "oneOf": [{ "type": "boolean" }, { "type": "string" }]
+          },
+          "cors": {
+            "description": "Configure CORS for the dev server.",
+            "type": "boolean"
+          },
+          "logLevel": {
+            "type": "string",
+            "description": "Adjust console output verbosity.",
+            "enum": ["info", "warn", "error", "silent"]
+          },
+          "mode": {
+            "type": "string",
+            "description": "Specifying this in config will override the default mode for both serve and build."
+          },
+          "clearScreen": {
+            "description": "Set to false to prevent Vite from clearing the terminal screen when logging certain messages.",
+            "default": true,
+            "type": "boolean"
           }
         },
         "definitions": {},
@@ -237,10 +260,27 @@
             "default": true,
             "oneOf": [{ "type": "boolean" }, { "type": "string" }]
           },
-          "hmr": {
-            "description": "Enable hot module replacement. For more options, use the 'hmr' option in the Vite configuration file.",
-            "default": false,
-            "type": "boolean"
+          "minify": {
+            "description": "Output sourcemaps. Use 'hidden' for use with error reporting tools without generating sourcemap comment.",
+            "default": "esbuild",
+            "oneOf": [{ "type": "boolean" }, { "type": "string" }]
+          },
+          "manifest": {
+            "description": "Output sourcemaps. Use 'hidden' for use with error reporting tools without generating sourcemap comment.",
+            "oneOf": [{ "type": "boolean" }, { "type": "string" }]
+          },
+          "ssrManifest": {
+            "description": "When set to true, the build will also generate an SSR manifest for determining style links and asset preload directives in production. When the value is a string, it will be used as the manifest file name.",
+            "oneOf": [{ "type": "boolean" }, { "type": "string" }]
+          },
+          "logLevel": {
+            "type": "string",
+            "description": "Adjust console output verbosity.",
+            "enum": ["info", "warn", "error", "silent"]
+          },
+          "mode": {
+            "type": "string",
+            "description": "Specifying this in config will override the default mode for both serve and build."
           }
         },
         "definitions": {

--- a/packages/vite/src/executors/build/schema.d.ts
+++ b/packages/vite/src/executors/build/schema.d.ts
@@ -9,5 +9,9 @@ export interface ViteBuildExecutorOptions {
   assets?: AssetGlob[];
   fileReplacements?: FileReplacement[];
   sourcemap?: boolean | 'inline' | 'hidden';
-  hmr?: boolean;
+  minify?: boolean | 'esbuild' | 'terser';
+  manifest?: boolean | string;
+  ssrManifest?: boolean | string;
+  logLevel?: 'info' | 'warn' | 'error' | 'silent';
+  mode?: string;
 }

--- a/packages/vite/src/executors/build/schema.json
+++ b/packages/vite/src/executors/build/schema.json
@@ -80,10 +80,48 @@
         }
       ]
     },
-    "hmr": {
-      "description": "Enable hot module replacement. For more options, use the 'hmr' option in the Vite configuration file.",
-      "default": false,
-      "type": "boolean"
+    "minify": {
+      "description": "Output sourcemaps. Use 'hidden' for use with error reporting tools without generating sourcemap comment.",
+      "default": "esbuild",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "manifest": {
+      "description": "Output sourcemaps. Use 'hidden' for use with error reporting tools without generating sourcemap comment.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "ssrManifest": {
+      "description": "When set to true, the build will also generate an SSR manifest for determining style links and asset preload directives in production. When the value is a string, it will be used as the manifest file name.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "logLevel": {
+      "type": "string",
+      "description": "Adjust console output verbosity.",
+      "enum": ["info", "warn", "error", "silent"]
+    },
+    "mode": {
+      "type": "string",
+      "description": "Specifying this in config will override the default mode for both serve and build."
     }
   },
   "definitions": {

--- a/packages/vite/src/executors/dev-server/schema.d.ts
+++ b/packages/vite/src/executors/dev-server/schema.d.ts
@@ -6,4 +6,9 @@ export interface ViteDevServerExecutorOptions {
   host?: string | boolean;
   https?: boolean;
   hmr?: boolean;
+  open?: string | boolean;
+  cors?: boolean;
+  logLevel?: info | warn | error | silent;
+  mode?: string;
+  clearScreen?: boolean;
 }

--- a/packages/vite/src/executors/dev-server/schema.json
+++ b/packages/vite/src/executors/dev-server/schema.json
@@ -51,6 +51,36 @@
       "description": "Enable hot module replacement. For more options, use the 'hmr' option in the Vite configuration file.",
       "default": false,
       "type": "boolean"
+    },
+    "open": {
+      "description": "Automatically open the app in the browser on server start. When the value is a string, it will be used as the URL's pathname.",
+      "default": false,
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "cors": {
+      "description": "Configure CORS for the dev server.",
+      "type": "boolean"
+    },
+    "logLevel": {
+      "type": "string",
+      "description": "Adjust console output verbosity.",
+      "enum": ["info", "warn", "error", "silent"]
+    },
+    "mode": {
+      "type": "string",
+      "description": "Specifying this in config will override the default mode for both serve and build."
+    },
+    "clearScreen": {
+      "description": "Set to false to prevent Vite from clearing the terminal screen when logging certain messages.",
+      "default": true,
+      "type": "boolean"
     }
   },
   "definitions": {},

--- a/packages/vite/src/utils/options-utils.ts
+++ b/packages/vite/src/utils/options-utils.ts
@@ -95,7 +95,7 @@ export function getServerOptions(
   context: ExecutorContext
 ): ServerOptions {
   const projectRoot = context.workspace.projects[context.projectName].root;
-  let serverOptions: ServerOptions = {};
+  let serverOptions: ServerOptions & UserConfig = {};
   if (options.proxyConfig) {
     const proxyConfigPath = options.proxyConfig
       ? join(context.root, options.proxyConfig)
@@ -119,6 +119,11 @@ export function getServerOptions(
     port: options.port,
     https: options.https,
     hmr: options.hmr,
+    open: options.open,
+    cors: options.cors,
+    logLevel: options.logLevel,
+    mode: options.mode,
+    clearScreen: options.clearScreen,
   };
 
   return serverOptions;
@@ -136,7 +141,7 @@ export function getViteBuildOptions(
   options: ViteDevServerExecutorOptions & ViteBuildExecutorOptions,
   projectRoot: string
 ): BuildOptions {
-  let buildOptions: BuildOptions = {
+  let buildOptions: BuildOptions & UserConfig = {
     outDir: relative(projectRoot, options.outputPath),
     emptyOutDir: true,
     reportCompressedSize: true,
@@ -150,6 +155,11 @@ export function getViteBuildOptions(
   buildOptions = {
     ...buildOptions,
     sourcemap: options.sourcemap,
+    minify: options.minify,
+    manifest: options.manifest,
+    ssrManifest: options.ssrManifest,
+    logLevel: options.logLevel,
+    mode: options.mode,
   };
 
   return buildOptions;


### PR DESCRIPTION
Allowing user to set more vite options through project.json build/serve targets.
