### PR TITLE
feat(core): move createPackageJson to nx

### DIFF
--- a/packages/next/src/executors/build/lib/create-package-json.ts
+++ b/packages/next/src/executors/build/lib/create-package-json.ts
@@ -1,6 +1,6 @@
 import type { ExecutorContext } from '@nrwl/devkit';
 import { writeJsonFile } from '@nrwl/devkit';
-import { createPackageJson as generatePackageJson } from '@nrwl/workspace/src/utilities/create-package-json';
+import { createPackageJson as generatePackageJson } from 'nx/src/utils/create-package-json';
 import type { NextBuildBuilderOptions } from '../../../utils/types';
 
 export async function createPackageJson(
@@ -12,7 +12,6 @@ export async function createPackageJson(
     context.projectGraph,
     {
       root: context.root,
-      projectRoot: context.workspace.projects[context.projectName].sourceRoot,
     }
   );
 

--- a/packages/nx/src/utils/create-package-json.ts
+++ b/packages/nx/src/utils/create-package-json.ts
@@ -11,7 +11,6 @@ export function createPackageJson(
   projectName: string,
   graph: ProjectGraph,
   options: {
-    projectRoot?: string;
     root?: string;
   }
 ): any {
@@ -24,7 +23,9 @@ export function createPackageJson(
     devDependencies: {},
   };
   try {
-    packageJson = readJsonFile(`${options.projectRoot}/package.json`);
+    packageJson = readJsonFile(
+      `${graph.nodes[projectName].data.root}/package.json`
+    );
     if (!packageJson.dependencies) {
       packageJson.dependencies = {};
     }

--- a/packages/nx/src/utils/create-package-json.ts
+++ b/packages/nx/src/utils/create-package-json.ts
@@ -1,6 +1,6 @@
-import type { ProjectGraph } from '@nrwl/devkit';
-import { readJsonFile } from '@nrwl/devkit';
+import { readJsonFile } from './fileutils';
 import { sortObjectByKeys } from 'nx/src/utils/object-sort';
+import { ProjectGraph } from '../config/project-graph';
 
 /**
  * Creates a package.json in the output directory for support to install dependencies within containers.

--- a/packages/webpack/src/utils/generate-package-json-webpack-plugin.ts
+++ b/packages/webpack/src/utils/generate-package-json-webpack-plugin.ts
@@ -5,7 +5,7 @@ import {
   type ProjectGraph,
   serializeJson,
 } from '@nrwl/devkit';
-import { createPackageJson } from '@nrwl/workspace/src/utilities/create-package-json';
+import { createPackageJson } from 'nx/src/utils/create-package-json';
 import {
   getHelperDependenciesFromProjectGraph,
   HelperDependency,
@@ -15,14 +15,12 @@ import { readTsConfig } from '@nrwl/workspace/src/utilities/typescript';
 import { NormalizedWebpackExecutorOptions } from '../executors/webpack/schema';
 
 export class GeneratePackageJsonWebpackPlugin implements WebpackPluginInstance {
-  private readonly projectConfig: ProjectConfiguration;
   private readonly projectGraph: ProjectGraph;
 
   constructor(
     private readonly context: ExecutorContext,
     private readonly options: NormalizedWebpackExecutorOptions
   ) {
-    this.projectConfig = context.workspace.projects[context.projectName];
     this.projectGraph = context.projectGraph;
   }
 
@@ -68,7 +66,7 @@ export class GeneratePackageJsonWebpackPlugin implements WebpackPluginInstance {
           const packageJson = createPackageJson(
             this.context.projectName,
             this.projectGraph,
-            { root: this.context.root, projectRoot: this.projectConfig.root }
+            { root: this.context.root }
           );
           packageJson.main = packageJson.main ?? this.options.outputFileName;
 


### PR DESCRIPTION
Move `createPackageJson` to `nx` so that dependency detection functionality can be shared with lock file pruning. 

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
