### PR TITLE
fix(bundling): fix exclude entries for .lib.swcrc file to exclude spe…

### DIFF
--- a/packages/js/src/migrations/update-13-10-1/__snapshots__/update-lib-swcrc-exclude.spec.ts.snap
+++ b/packages/js/src/migrations/update-13-10-1/__snapshots__/update-lib-swcrc-exclude.spec.ts.snap
@@ -25,8 +25,8 @@ exports[`Update .lib.swcrc exclude should update the exclude pattern 1`] = `
   \\"sourceMaps\\": true,
   \\"exclude\\": [
     \\"jest.config.ts\\",
-    \\".*.spec.tsx?$\\",
-    \\".*.test.tsx?$\\",
+    \\".*\\\\\\\\.spec.tsx?$\\",
+    \\".*\\\\\\\\.test.tsx?$\\",
     \\"./src/jest-setup.ts$\\",
     \\"./**/jest-setup.ts$\\",
     \\".*.js$\\"

--- a/packages/js/src/utils/swc/add-swc-config.ts
+++ b/packages/js/src/utils/swc/add-swc-config.ts
@@ -5,8 +5,8 @@ import { join } from 'path';
 
 export const defaultExclude = [
   'jest.config.ts',
-  '.*.spec.tsx?$',
-  '.*.test.tsx?$',
+  '.*\\.spec.tsx?$',
+  '.*\\.test.tsx?$',
   './src/jest-setup.ts$',
   './**/jest-setup.ts$',
   '.*.js$',


### PR DESCRIPTION
…c files correctly

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior


if you have a file ending with `test.ts` or `spec.ts`, it'll be ignored by SWC because the `.*.spec.tsx?$` or `.*.test.tsx?$` pattern matched it.

## Expected Behavior
Files should not be ignored unless it is a spec file.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
