### PR TITLE
feat(core): set appsDir and libsDir to "." when using nested projects preset

### DIFF
--- a/packages/workspace/src/generators/new/generate-workspace-files.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.ts
@@ -136,6 +136,16 @@ function createNxJson(
     nxJson.targetDefaults.build.inputs = ['production', '^production'];
   }
 
+  if (
+    preset === Preset.AngularExperimental ||
+    preset === Preset.ReactExperimental
+  ) {
+    nxJson.workspaceLayout = {
+      appsDir: '.',
+      libsDir: '.',
+    };
+  }
+
   writeJson<NxJsonConfiguration>(host, join(directory, 'nx.json'), nxJson);
 }
 


### PR DESCRIPTION
The existing workspace layout doesn't make sense for nested projects since users should dictate exactly where things are generated.

This PR changes apps and libs to default to the root directory, and users can pass `--directory=<whatever>` to the app/lib generators if needed.