### PR TITLE
fix(nx-plugin): ensure project has eslint available before adding lint checks for migrations.json

### DIFF
--- a/packages/nx-plugin/src/generators/lint-checks/generator.ts
+++ b/packages/nx-plugin/src/generators/lint-checks/generator.ts
@@ -73,6 +73,10 @@ export function addMigrationJsonChecks(
     options.projectName
   );
 
+  if (!projectIsEsLintEnabled(projectConfiguration)) {
+    return;
+  }
+
   const [eslintTarget, eslintTargetConfiguration] =
     getEsLintOptions(projectConfiguration);
 


### PR DESCRIPTION

## Current Behavior
When generating a migration in a repository/project that don't have eslint target, it give this error:

```
>  NX   getEsLintOptions is not a function or its return value is not iterable
```

## Expected Behavior
The migration is generated without adding lint check to migrations.json file

Fixes https://github.com/nrwl/nx/issues/13326
