### PR TITLE
fix(storybook): pin enhanced-resolve to ~5.10.0 until 5.11.0 is fixed for webpack to resolve paths correctly

### DIFF
--- a/e2e/storybook/src/storybook.test.ts
+++ b/e2e/storybook/src/storybook.test.ts
@@ -17,7 +17,7 @@ describe('Storybook schematics', () => {
   let proj: string;
 
   beforeAll(() => {
-    process.env.SELECTED_PM = 'yarn';
+    process.env.SELECTED_PM = 'npm';
 
     proj = newProject();
     reactStorybookLib = uniq('test-ui-lib-react');

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "depcheck": "^1.3.1",
     "dotenv": "~10.0.0",
     "ejs": "^3.1.7",
-    "enhanced-resolve": "^5.8.3",
+    "enhanced-resolve": "~5.10.0",
     "eslint": "8.15.0",
     "eslint-config-next": "13.0.0",
     "eslint-config-prettier": "^8.1.0",

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -44,6 +44,7 @@
     "babel-loader": "^8.0.2",
     "chalk": "4.1.0",
     "dotenv": "~10.0.0",
+    "enhanced-resolve": "~5.10.0",
     "fork-ts-checker-webpack-plugin": "7.2.13",
     "semver": "7.3.4",
     "ts-loader": "^9.3.1",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -35,7 +35,7 @@
     "@nrwl/workspace": "file:../workspace",
     "@svgr/webpack": "^6.1.2",
     "chalk": "^4.1.0",
-    "enhanced-resolve": "^5.8.3",
+    "enhanced-resolve": "~5.10.0",
     "fs-extra": "^10.1.0",
     "metro-resolver": "^0.73.3",
     "node-fetch": "^2.6.7",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -33,7 +33,7 @@
     "@nrwl/storybook": "file:../storybook",
     "@nrwl/workspace": "file:../workspace",
     "chalk": "^4.1.0",
-    "enhanced-resolve": "^5.8.3",
+    "enhanced-resolve": "~5.10.0",
     "fs-extra": "^10.1.0",
     "ignore": "^5.0.4",
     "metro-resolver": "^0.73.3",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -48,6 +48,7 @@
     "@svgr/webpack": "^6.1.2",
     "chalk": "4.1.0",
     "css-loader": "^6.4.0",
+    "enhanced-resolve": "~5.10.0",
     "minimatch": "3.0.5",
     "react-refresh": "^0.10.0",
     "semver": "7.3.4",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -34,6 +34,7 @@
     "@nrwl/devkit": "file:../devkit",
     "@nrwl/linter": "file:../linter",
     "@nrwl/workspace": "file:../workspace",
+    "enhanced-resolve": "~5.10.0",
     "dotenv": "~10.0.0",
     "semver": "7.3.4"
   },

--- a/scripts/depcheck/unused.ts
+++ b/scripts/depcheck/unused.ts
@@ -6,7 +6,10 @@ const IGNORE_MATCHES = {
   '*': ['@nrwl/devkit', '@nrwl/workspace', 'chalk', 'tslib', '@swc/helpers'],
   angular: ['@angular-devkit/schematics', '@schematics/angular', 'http-server'],
   cli: [],
-  cypress: [],
+  cypress: [
+    // TODO(jack): We added enhanced resolve to help with an issue introduced in 5.11.0.
+    'enhanced-resolve',
+  ],
   devkit: [],
   'eslint-plugin-nx': [],
   jest: [
@@ -18,9 +21,17 @@ const IGNORE_MATCHES = {
   next: [],
   node: [],
   'nx-plugin': [],
-  react: [],
+  react: [
+    // TODO(jack): We added enhanced resolve to help with an issue introduced in 5.11.0.
+    'enhanced-resolve',
+  ],
   rollup: [],
-  storybook: [],
+  storybook: [
+    // TODO(jack): We added enhanced resolve to help with an issue introduced in 5.11.0.
+    // See: https://github.com/webpack/enhanced-resolve/issues/362
+    // When that issue is resolved we can remove this dep again.
+    'enhanced-resolve',
+  ],
   nx: ['glob'],
   vite: [],
   web: ['http-server'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -11104,7 +11104,7 @@ enhanced-resolve@^4.0.0, enhanced-resolve@^4.5.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
-enhanced-resolve@^5.0.0, enhanced-resolve@^5.10.0, enhanced-resolve@^5.7.0, enhanced-resolve@^5.8.3:
+enhanced-resolve@^5.0.0, enhanced-resolve@^5.10.0, enhanced-resolve@^5.7.0, enhanced-resolve@~5.10.0:
   version "5.10.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz#0dc579c3bb2a1032e357ac45b8f3a6f3ad4fb1e6"
   integrity sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==


### PR DESCRIPTION
`enhanced-resolve@5.11.0` has an issue as covered here https://github.com/webpack/enhanced-resolve/issues/362.

This PR patches the issue temporarily until the package is fixed.


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
