### PR TITLE
fix(graph): project edge tooltips should appear

### DIFF
--- a/graph/ui-graph/src/lib/util-cytoscape/project-edge.ts
+++ b/graph/ui-graph/src/lib/util-cytoscape/project-edge.ts
@@ -26,7 +26,7 @@ export class ProjectEdge {
         type: this.dep.type,
       },
     };
-    edge.classes = this.dep.type ?? '';
+    edge.classes += ` ${this.dep.type}` ?? '';
     if (this.affected) {
       edge.classes += ' affected';
     }


### PR DESCRIPTION
## Current Behavior
Tooltips do not appear when project edges are clicked

## Expected Behavior
Tooltips appear when project edges are clicked
