### PR TITLE
feat(core): support nested projects when deriving the project name from a given path

### DIFF
--- a/packages/nx/src/utils/project-graph-utils.spec.ts
+++ b/packages/nx/src/utils/project-graph-utils.spec.ts
@@ -116,25 +116,72 @@ describe('project graph utils', () => {
         expect(warnings).toContain('implicit-lib');
       });
     });
+  });
 
-    it('should find the project given a file within its src root', () => {
-      expect(getProjectNameFromDirPath('apps/demo-app', projGraph)).toEqual(
-        'demo-app'
-      );
+  describe('getProjectNameFromDirPath', () => {
+    describe('root project', () => {
+      const projGraph: ProjectGraph = {
+        nodes: {
+          'demo-app': {
+            name: 'demo-app',
+            type: 'app',
+            data: { root: '.' },
+          },
+          'demo-lib': {
+            name: 'demo-lib',
+            type: 'lib',
+            data: { root: 'demo-lib' },
+          },
+        },
+        dependencies: { 'demo-app': [] },
+      };
 
-      expect(getProjectNameFromDirPath('apps/demo-app/src', projGraph)).toEqual(
-        'demo-app'
-      );
+      it('should find the project given a file within its src root', () => {
+        expect(getProjectNameFromDirPath('', projGraph)).toEqual('demo-app');
+        expect(getProjectNameFromDirPath('src', projGraph)).toEqual('demo-app');
+        expect(getProjectNameFromDirPath('src/subdir/bla', projGraph)).toEqual(
+          'demo-app'
+        );
+      });
 
-      expect(
-        getProjectNameFromDirPath('apps/demo-app/src/subdir/bla', projGraph)
-      ).toEqual('demo-app');
+      it('should find the nested project correctly', () => {
+        expect(getProjectNameFromDirPath('demo-lib', projGraph)).toEqual(
+          'demo-lib'
+        );
+      });
     });
 
-    it('should throw an error if the project name has not been found', () => {
-      expect(() => {
-        getProjectNameFromDirPath('apps/demo-app-unknown');
-      }).toThrowError();
+    describe('non root project', () => {
+      const projGraph: ProjectGraph = {
+        nodes: {
+          'demo-app': {
+            name: 'demo-app',
+            type: 'app',
+            data: { root: 'apps/demo-app' },
+          },
+        },
+        dependencies: { 'demo-app': [] },
+      };
+
+      it('should find the project given a file within its src root', () => {
+        expect(getProjectNameFromDirPath('apps/demo-app', projGraph)).toEqual(
+          'demo-app'
+        );
+
+        expect(
+          getProjectNameFromDirPath('apps/demo-app/src', projGraph)
+        ).toEqual('demo-app');
+
+        expect(
+          getProjectNameFromDirPath('apps/demo-app/src/subdir/bla', projGraph)
+        ).toEqual('demo-app');
+      });
+
+      it('should throw an error if the project name has not been found', () => {
+        expect(() => {
+          getProjectNameFromDirPath('apps/demo-app-unknown');
+        }).toThrowError();
+      });
     });
   });
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `getProjectNameFromDirPath` utility to derive a project name from a given path doesn't support a workspace with a project at the root and/or nested projects. This causes things like the Tailwind CSS utility to get the glob patterns for a project's dependencies (used by the Angular and React plugins) to fail and not return any glob pattern.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `getProjectNameFromDirPath` utility to derive a project name from a given path supports a workspace with a project at the root and/or nested projects.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
