### PR TITLE
feat(testing): support root project generation for jest

### DIFF
--- a/docs/generated/packages/jest.json
+++ b/docs/generated/packages/jest.json
@@ -41,6 +41,12 @@
             "type": "boolean",
             "default": false,
             "description": "Use JavaScript instead of TypeScript for config files"
+          },
+          "rootProject": {
+            "description": "initialize Jest for an application at the root of the workspace",
+            "type": "boolean",
+            "default": false,
+            "hidden": true
           }
         },
         "required": [],
@@ -123,6 +129,12 @@
             "type": "boolean",
             "default": false,
             "description": "Use JavaScript instead of TypeScript for config files"
+          },
+          "rootProject": {
+            "description": "Add Jest to an application at the root of the workspace",
+            "type": "boolean",
+            "default": false,
+            "hidden": true
           }
         },
         "required": [],

--- a/e2e/jest/src/jest-root.test.ts
+++ b/e2e/jest/src/jest-root.test.ts
@@ -1,0 +1,73 @@
+import { newProject, runCLI, uniq, runCLIAsync } from '@nrwl/e2e/utils';
+
+describe('Jest root projects', () => {
+  const myapp = uniq('myapp');
+  const mylib = uniq('mylib');
+
+  describe('angular', () => {
+    beforeAll(() => {
+      newProject();
+    });
+
+    it('should test root level app projects', async () => {
+      runCLI(`generate @nrwl/angular:app ${myapp} --rootProject=true`);
+
+      const rootProjectTestResults = await runCLIAsync(`test ${myapp}`);
+
+      expect(rootProjectTestResults.combinedOutput).toContain(
+        'Test Suites: 1 passed, 1 total'
+      );
+    }, 300_000);
+
+    it('should add lib project and tests should still work', async () => {
+      runCLI(`generate @nrwl/angular:lib ${mylib}`);
+      runCLI(
+        `generate @nrwl/angular:component ${mylib} --export --standalone --project=${mylib} --no-interactive`
+      );
+
+      const libProjectTestResults = await runCLIAsync(`test ${mylib}`);
+
+      expect(libProjectTestResults.combinedOutput).toContain(
+        'Test Suites: 1 passed, 1 total'
+      );
+
+      const rootProjectTestResults = await runCLIAsync(`test ${myapp}`);
+
+      expect(rootProjectTestResults.combinedOutput).toContain(
+        'Test Suites: 1 passed, 1 total'
+      );
+    }, 300_000);
+  });
+
+  describe('react', () => {
+    beforeAll(() => {
+      newProject();
+    });
+
+    it('should test root level app projects', async () => {
+      runCLI(`generate @nrwl/react:app ${myapp} --rootProject=true`);
+
+      const rootProjectTestResults = await runCLIAsync(`test ${myapp}`);
+
+      expect(rootProjectTestResults.combinedOutput).toContain(
+        'Test Suites: 1 passed, 1 total'
+      );
+    }, 300_000);
+
+    it('should add lib project and tests should still work', async () => {
+      runCLI(`generate @nrwl/react:lib ${mylib}`);
+
+      const libProjectTestResults = await runCLIAsync(`test ${mylib}`);
+
+      expect(libProjectTestResults.combinedOutput).toContain(
+        'Test Suites: 1 passed, 1 total'
+      );
+
+      const rootProjectTestResults = await runCLIAsync(`test ${myapp}`);
+
+      expect(rootProjectTestResults.combinedOutput).toContain(
+        'Test Suites: 1 passed, 1 total'
+      );
+    }, 300_000);
+  });
+});

--- a/e2e/jest/src/jest.test.ts
+++ b/e2e/jest/src/jest.test.ts
@@ -153,7 +153,7 @@ describe('Jest', () => {
   }, 90000);
 });
 
-describe('Jest root projects MMM', () => {
+describe('Jest root projects', () => {
   afterEach(() => cleanupProject());
 
   it('should set root project config to app and migrate when another lib is added', () => {

--- a/e2e/jest/src/jest.test.ts
+++ b/e2e/jest/src/jest.test.ts
@@ -152,36 +152,3 @@ describe('Jest', () => {
     );
   }, 90000);
 });
-
-describe('Jest root projects', () => {
-  afterEach(() => cleanupProject());
-
-  it('should set root project config to app and migrate when another lib is added', () => {
-    const myapp = uniq('myapp');
-    const mylib = uniq('mylib');
-
-    newProject();
-    runCLI(`generate @nrwl/react:app ${myapp} --rootProject=true`);
-
-    expect(() => checkFilesExist('jest.config.ts')).not.toThrow();
-    expect(() => checkFilesExist('jest.preset.js')).not.toThrow();
-    const rootConfig = readFile('jest.config.ts');
-    expect(rootConfig).not.toContain(`getJestProjects`);
-
-    let rootProjectConfig = readJson('project.json');
-    expect(rootProjectConfig.targets.test.options.jestConfig).toEqual(
-      'jest.config.ts'
-    );
-
-    runCLI(`generate @nrwl/react:lib ${mylib}`);
-
-    const newName = `jest.config.${myapp}.ts`;
-    expect(() => checkFilesExist(newName)).not.toThrow();
-    const newRootConfig = readFile('jest.config.ts');
-    expect(newRootConfig).toContain(`getJestProjects`);
-    const projectConfig = readFile(newName);
-    expect(projectConfig).toEqual(rootConfig);
-    rootProjectConfig = readJson('project.json');
-    expect(rootProjectConfig.targets.test.options.jestConfig).toEqual(newName);
-  });
-});

--- a/e2e/linter/src/linter.test.ts
+++ b/e2e/linter/src/linter.test.ts
@@ -473,9 +473,6 @@ export function tslibC(): string {
         'plugin:@nrwl/nx/javascript',
       ]);
 
-      console.log(JSON.stringify(rootEslint, null, 2));
-      console.log(JSON.stringify(e2eEslint, null, 2));
-
       runCLI(`generate @nrwl/react:lib ${mylib}`);
       // should add new tslint
       expect(() => checkFilesExist(`.eslintrc.base.json`)).not.toThrow();

--- a/packages/angular/src/generators/application/lib/add-unit-test-runner.ts
+++ b/packages/angular/src/generators/application/lib/add-unit-test-runner.ts
@@ -14,6 +14,7 @@ export async function addUnitTestRunner(host: Tree, options: NormalizedSchema) {
       supportTsx: false,
       skipSerializers: false,
       skipPackageJson: options.skipPackageJson,
+      rootProject: options.rootProject,
     });
   } else if (options.unitTestRunner === UnitTestRunner.Karma) {
     await karmaProjectGenerator(host, {

--- a/packages/jest/index.ts
+++ b/packages/jest/index.ts
@@ -5,4 +5,7 @@ export {
 export { jestConfigObjectAst } from './src/utils/config/functions';
 export { jestProjectGenerator } from './src/generators/jest-project/jest-project';
 export { jestInitGenerator } from './src/generators/init/init';
-export { getJestProjects } from './src/utils/config/get-jest-projects';
+export {
+  getJestProjects,
+  getNestedJestProjects,
+} from './src/utils/config/get-jest-projects';

--- a/packages/jest/src/generators/init/init.spec.ts
+++ b/packages/jest/src/generators/init/init.spec.ts
@@ -160,9 +160,8 @@ export default {
     });
 
     it('should rename the project jest.config.ts to project jest config', () => {
-      tree.write('nx.json', JSON.stringify({ defaultProject: 'my-project' }));
       addProjectConfiguration(tree, 'my-project', {
-        root: '',
+        root: '.',
         name: 'my-project',
         sourceRoot: 'src',
         targets: {
@@ -186,12 +185,12 @@ export default {
   globals: { 'ts-jest': { tsconfig: '<rootDir>/tsconfig.spec.json' } },
   displayName: 'my-project',
   testEnvironment: 'node',
-  preset: '../../jest.preset.js',
+  preset: './jest.preset.js',
 };
 `
       );
       jestInitGenerator(tree, { rootProject: false });
-      expect(tree.exists('jest.my-project.config.ts')).toBeTruthy();
+      expect(tree.exists('jest.config.my-project.ts')).toBeTruthy();
       expect(tree.read('jest.config.ts', 'utf-8'))
         .toEqual(`import { getJestProjects } from '@nrwl/jest';
 
@@ -203,13 +202,26 @@ projects: getJestProjects()
         Object {
           "executor": "@nrwl/jest:jest",
           "options": Object {
-            "jestConfig": "jest.my-project.config.ts",
+            "jestConfig": "jest.config.my-project.ts",
           },
         }
       `);
     });
 
     it('should work with --js', () => {
+      addProjectConfiguration(tree, 'my-project', {
+        root: '.',
+        name: 'my-project',
+        sourceRoot: 'src',
+        targets: {
+          test: {
+            executor: '@nrwl/jest:jest',
+            options: {
+              jestConfig: 'jest.config.js',
+            },
+          },
+        },
+      });
       tree.write(
         'jest.config.js',
         `
@@ -222,12 +234,12 @@ module.exports = {
   globals: { 'ts-jest': { tsconfig: '<rootDir>/tsconfig.spec.json' } },
   displayName: 'my-project',
   testEnvironment: 'node',
-  preset: '../../jest.preset.js',
+  preset: './jest.preset.js',
 };
 `
       );
       jestInitGenerator(tree, { js: true, rootProject: false });
-      expect(tree.exists('jest.project-config.js')).toBeTruthy();
+      expect(tree.exists('jest.config.my-project.js')).toBeTruthy();
       expect(tree.read('jest.config.js', 'utf-8'))
         .toEqual(`const { getJestProjects } = require('@nrwl/jest');
 

--- a/packages/jest/src/generators/init/init.spec.ts
+++ b/packages/jest/src/generators/init/init.spec.ts
@@ -1,6 +1,8 @@
 import {
+  addProjectConfiguration,
   NxJsonConfiguration,
   readJson,
+  readProjectConfiguration,
   stripIndents,
   Tree,
   updateJson,
@@ -41,9 +43,16 @@ describe('jest', () => {
   });
 
   it('should not override existing files', async () => {
-    tree.write('jest.config.ts', `test`);
+    const expected = stripIndents`
+import { getJestProjects } from '@nrwl/jest';
+export default {
+  projects: getJestProjects(),
+  extraThing: "Goes Here"
+}
+`;
+    tree.write('jest.config.ts', expected);
     jestInitGenerator(tree, {});
-    expect(tree.read('jest.config.ts', 'utf-8')).toEqual('test');
+    expect(tree.read('jest.config.ts', 'utf-8')).toEqual(expected);
   });
 
   it('should add target defaults for test', async () => {
@@ -141,6 +150,90 @@ describe('jest', () => {
       jestInitGenerator(tree, { compiler: 'swc' });
       const packageJson = readJson(tree, 'package.json');
       expect(packageJson.devDependencies['@swc/jest']).toBeDefined();
+    });
+  });
+
+  describe('root project', () => {
+    it('should not add a monorepo jest.config.ts  to the project', () => {
+      jestInitGenerator(tree, { rootProject: true });
+      expect(tree.exists('jest.config.ts')).toBeFalsy();
+    });
+
+    it('should rename the project jest.config.ts to project jest config', () => {
+      tree.write('nx.json', JSON.stringify({ defaultProject: 'my-project' }));
+      addProjectConfiguration(tree, 'my-project', {
+        root: '',
+        name: 'my-project',
+        sourceRoot: 'src',
+        targets: {
+          test: {
+            executor: '@nrwl/jest:jest',
+            options: {
+              jestConfig: 'jest.config.ts',
+            },
+          },
+        },
+      });
+      tree.write(
+        'jest.config.ts',
+        `
+/* eslint-disable */
+export default {
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
+  globals: { 'ts-jest': { tsconfig: '<rootDir>/tsconfig.spec.json' } },
+  displayName: 'my-project',
+  testEnvironment: 'node',
+  preset: '../../jest.preset.js',
+};
+`
+      );
+      jestInitGenerator(tree, { rootProject: false });
+      expect(tree.exists('jest.my-project.config.ts')).toBeTruthy();
+      expect(tree.read('jest.config.ts', 'utf-8'))
+        .toEqual(`import { getJestProjects } from '@nrwl/jest';
+
+export default {
+projects: getJestProjects()
+};`);
+      expect(readProjectConfiguration(tree, 'my-project').targets.test)
+        .toMatchInlineSnapshot(`
+        Object {
+          "executor": "@nrwl/jest:jest",
+          "options": Object {
+            "jestConfig": "jest.my-project.config.ts",
+          },
+        }
+      `);
+    });
+
+    it('should work with --js', () => {
+      tree.write(
+        'jest.config.js',
+        `
+/* eslint-disable */
+module.exports = {
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
+  globals: { 'ts-jest': { tsconfig: '<rootDir>/tsconfig.spec.json' } },
+  displayName: 'my-project',
+  testEnvironment: 'node',
+  preset: '../../jest.preset.js',
+};
+`
+      );
+      jestInitGenerator(tree, { js: true, rootProject: false });
+      expect(tree.exists('jest.project-config.js')).toBeTruthy();
+      expect(tree.read('jest.config.js', 'utf-8'))
+        .toEqual(`const { getJestProjects } = require('@nrwl/jest');
+
+module.exports = {
+projects: getJestProjects()
+};`);
     });
   });
 

--- a/packages/jest/src/generators/init/init.spec.ts
+++ b/packages/jest/src/generators/init/init.spec.ts
@@ -43,6 +43,19 @@ describe('jest', () => {
   });
 
   it('should not override existing files', async () => {
+    addProjectConfiguration(tree, 'my-project', {
+      root: 'apps/my-app',
+      name: 'my-app',
+      sourceRoot: 'apps/my-app/src',
+      targets: {
+        test: {
+          executor: '@nrwl/jest:jest',
+          options: {
+            jestConfig: 'apps/my-app/jest.config.ts',
+          },
+        },
+      },
+    });
     const expected = stripIndents`
 import { getJestProjects } from '@nrwl/jest';
 export default {
@@ -190,7 +203,7 @@ export default {
 `
       );
       jestInitGenerator(tree, { rootProject: false });
-      expect(tree.exists('jest.config.my-project.ts')).toBeTruthy();
+      expect(tree.exists('jest.config.app.ts')).toBeTruthy();
       expect(tree.read('jest.config.ts', 'utf-8'))
         .toEqual(`import { getJestProjects } from '@nrwl/jest';
 
@@ -202,7 +215,7 @@ projects: getJestProjects()
         Object {
           "executor": "@nrwl/jest:jest",
           "options": Object {
-            "jestConfig": "jest.config.my-project.ts",
+            "jestConfig": "jest.config.app.ts",
           },
         }
       `);
@@ -239,7 +252,7 @@ module.exports = {
 `
       );
       jestInitGenerator(tree, { js: true, rootProject: false });
-      expect(tree.exists('jest.config.my-project.js')).toBeTruthy();
+      expect(tree.exists('jest.config.app.js')).toBeTruthy();
       expect(tree.read('jest.config.js', 'utf-8'))
         .toEqual(`const { getJestProjects } = require('@nrwl/jest');
 

--- a/packages/jest/src/generators/init/init.ts
+++ b/packages/jest/src/generators/init/init.ts
@@ -8,8 +8,6 @@ import {
   Tree,
   updateJson,
   updateWorkspaceConfiguration,
-  readProjectConfiguration,
-  readJson,
   updateProjectConfiguration,
 } from '@nrwl/devkit';
 import { findRootJestConfig } from '../../utils/config/find-root-jest-files';
@@ -24,7 +22,6 @@ import {
   tsNodeVersion,
 } from '../../utils/versions';
 import { JestInitSchema } from './schema';
-import { extname } from 'path';
 import { readWorkspace } from 'nx/src/generators/utils/project-configuration';
 
 interface NormalizedSchema extends ReturnType<typeof normalizeOptions> {}
@@ -84,7 +81,6 @@ function createJestConfig(tree: Tree, options: NormalizedSchema) {
 
   const isProjectConfig =
     rootJestPath &&
-    // TODO: (meeroslav) is this condition enough?
     !tree.read(rootJestPath, 'utf-8').includes('getJestProjects()');
 
   if (isProjectConfig) {

--- a/packages/jest/src/generators/init/schema.d.ts
+++ b/packages/jest/src/generators/init/schema.d.ts
@@ -6,4 +6,5 @@ export interface JestInitSchema {
    * @deprecated
    */
   babelJest?: boolean;
+  rootProject?: boolean;
 }

--- a/packages/jest/src/generators/init/schema.json
+++ b/packages/jest/src/generators/init/schema.json
@@ -21,6 +21,12 @@
       "type": "boolean",
       "default": false,
       "description": "Use JavaScript instead of TypeScript for config files"
+    },
+    "rootProject": {
+      "description": "initialize Jest for an application at the root of the workspace",
+      "type": "boolean",
+      "default": false,
+      "hidden": true
     }
   },
   "required": []

--- a/packages/jest/src/generators/jest-project/files-angular/jest.config.ts__tmpl__
+++ b/packages/jest/src/generators/jest-project/files-angular/jest.config.ts__tmpl__
@@ -19,5 +19,9 @@
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',
     'jest-preset-angular/build/serializers/html-comment',
-  ]<% } %>
+  ]<% } %><% if(rootProject){ %>,
+  testMatch: [
+    '<rootDir>/src/**/__tests__/**/*.[jt]s?(x)',
+    '<rootDir>/src/**/?(*.)+(spec|test).[jt]s?(x)',
+  ],<% } %>
 };

--- a/packages/jest/src/generators/jest-project/files/jest.config.ts__tmpl__
+++ b/packages/jest/src/generators/jest-project/files/jest.config.ts__tmpl__
@@ -13,5 +13,9 @@
     <% if (supportTsx){ %>'^.+\\.[tj]sx?$'<% } else { %>'^.+\\.[tj]s$'<% } %>: <% if (supportTsx && transformer === '@swc/jest') { %>['<%= transformer %>', { jsc: { transform: { react: { runtime: 'automatic' } } } }]<% } else { %>'<%= transformer %>'<% } %>
   },
   <% if (supportTsx) { %>moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],<% } else { %>moduleFileExtensions: ['ts', 'js', 'html'],<% } %><% } %>
-  coverageDirectory: '<%= offsetFromRoot %>coverage/<%= projectRoot %>'
+  coverageDirectory: '<%= offsetFromRoot %>coverage/<%= projectRoot %>'<% if(rootProject){ %>,
+  testMatch: [
+    '<rootDir>/src/**/__tests__/**/*.[jt]s?(x)',
+    '<rootDir>/src/**/?(*.)+(spec|test).[jt]s?(x)',
+  ],<% } %>
 };

--- a/packages/jest/src/generators/jest-project/jest-project.spec.ts
+++ b/packages/jest/src/generators/jest-project/jest-project.spec.ts
@@ -362,4 +362,73 @@ describe('jestProject', () => {
       expect(tree.read('libs/lib1/jest.config.ts', 'utf-8')).toMatchSnapshot();
     });
   });
+
+  describe('root project', () => {
+    it('root jest.config.ts should be project config', async () => {
+      writeJson(tree, 'tsconfig.json', {
+        files: [],
+        include: [],
+        references: [],
+      });
+      addProjectConfiguration(tree, 'my-project', {
+        root: '',
+        sourceRoot: 'src',
+        name: 'my-project',
+        targets: {},
+      });
+      await jestProjectGenerator(tree, {
+        ...defaultOptions,
+        project: 'my-project',
+        rootProject: true,
+      });
+      expect(tree.read('jest.config.ts', 'utf-8')).toMatchInlineSnapshot(`
+        "/* eslint-disable */
+        export default {
+          displayName: 'my-project',
+          preset: '../jest.preset.js',
+          globals: {
+            'ts-jest': {
+              tsconfig: '<rootDir>/tsconfig.spec.json',
+            }
+          },
+          coverageDirectory: '../coverage/my-project'
+        };
+        "
+      `);
+    });
+
+    it('root jest.config.js should be project config', async () => {
+      writeJson(tree, 'tsconfig.json', {
+        files: [],
+        include: [],
+        references: [],
+      });
+      addProjectConfiguration(tree, 'my-project', {
+        root: '',
+        sourceRoot: 'src',
+        name: 'my-project',
+        targets: {},
+      });
+      await jestProjectGenerator(tree, {
+        ...defaultOptions,
+        project: 'my-project',
+        rootProject: true,
+        js: true,
+      });
+      expect(tree.read('jest.config.js', 'utf-8')).toMatchInlineSnapshot(`
+        "/* eslint-disable */
+        module.exports = {
+          displayName: 'my-project',
+          preset: '../jest.preset.js',
+          globals: {
+            'ts-jest': {
+              tsconfig: '<rootDir>/tsconfig.spec.json',
+            }
+          },
+          coverageDirectory: '../coverage/my-project'
+        };
+        "
+      `);
+    });
+  });
 });

--- a/packages/jest/src/generators/jest-project/jest-project.spec.ts
+++ b/packages/jest/src/generators/jest-project/jest-project.spec.ts
@@ -391,7 +391,11 @@ describe('jestProject', () => {
               tsconfig: '<rootDir>/tsconfig.spec.json',
             }
           },
-          coverageDirectory: '../coverage/my-project'
+          coverageDirectory: '../coverage/my-project',
+          testMatch: [
+            '<rootDir>/src/**/__tests__/**/*.[jt]s?(x)',
+            '<rootDir>/src/**/?(*.)+(spec|test).[jt]s?(x)',
+          ],
         };
         "
       `);
@@ -425,7 +429,11 @@ describe('jestProject', () => {
               tsconfig: '<rootDir>/tsconfig.spec.json',
             }
           },
-          coverageDirectory: '../coverage/my-project'
+          coverageDirectory: '../coverage/my-project',
+          testMatch: [
+            '<rootDir>/src/**/__tests__/**/*.[jt]s?(x)',
+            '<rootDir>/src/**/?(*.)+(spec|test).[jt]s?(x)',
+          ],
         };
         "
       `);

--- a/packages/jest/src/generators/jest-project/jest-project.ts
+++ b/packages/jest/src/generators/jest-project/jest-project.ts
@@ -13,6 +13,7 @@ const schemaDefaults = {
   supportTsx: false,
   skipSetupFile: false,
   skipSerializers: false,
+  rootProject: false,
 } as const;
 
 function normalizeOptions(options: JestProjectSchema) {
@@ -42,7 +43,7 @@ function normalizeOptions(options: JestProjectSchema) {
 
   // setupFile is always 'none'
   options.setupFile = schemaDefaults.setupFile;
-
+  options.rootProject = options.rootProject;
   return {
     ...schemaDefaults,
     ...options,
@@ -59,7 +60,11 @@ export async function jestProjectGenerator(
   createFiles(tree, options);
   updateTsConfig(tree, options);
   updateWorkspace(tree, options);
-  updateJestConfig(tree, options);
+  // TODO(caleb): is this really needed anymore?
+  // surely everyone is on the getJestProjects() fn usage already?
+  // should remove it and provide a migration (just in case) so we can remove it
+  // which makes the root project work simpler
+  // updateJestConfig(tree, options);
   if (!schema.skipFormat) {
     await formatFiles(tree);
   }

--- a/packages/jest/src/generators/jest-project/jest-project.ts
+++ b/packages/jest/src/generators/jest-project/jest-project.ts
@@ -43,7 +43,6 @@ function normalizeOptions(options: JestProjectSchema) {
 
   // setupFile is always 'none'
   options.setupFile = schemaDefaults.setupFile;
-  options.rootProject = options.rootProject;
   return {
     ...schemaDefaults,
     ...options,

--- a/packages/jest/src/generators/jest-project/jest-project.ts
+++ b/packages/jest/src/generators/jest-project/jest-project.ts
@@ -55,15 +55,12 @@ export async function jestProjectGenerator(
 ) {
   const options = normalizeOptions(schema);
   const installTask = init(tree, options);
+
   checkForTestTarget(tree, options);
   createFiles(tree, options);
   updateTsConfig(tree, options);
   updateWorkspace(tree, options);
-  // TODO(caleb): is this really needed anymore?
-  // surely everyone is on the getJestProjects() fn usage already?
-  // should remove it and provide a migration (just in case) so we can remove it
-  // which makes the root project work simpler
-  // updateJestConfig(tree, options);
+
   if (!schema.skipFormat) {
     await formatFiles(tree);
   }

--- a/packages/jest/src/generators/jest-project/lib/check-for-test-target.ts
+++ b/packages/jest/src/generators/jest-project/lib/check-for-test-target.ts
@@ -3,7 +3,7 @@ import { JestProjectSchema } from '../schema';
 
 export function checkForTestTarget(tree: Tree, options: JestProjectSchema) {
   const projectConfig = readProjectConfiguration(tree, options.project);
-  if (projectConfig.targets.test) {
-    throw new Error(`${options.project}: already has a test architect option.`);
+  if (projectConfig?.targets?.test) {
+    throw new Error(`${options.project}: already has a test target set.`);
   }
 }

--- a/packages/jest/src/generators/jest-project/lib/create-files.ts
+++ b/packages/jest/src/generators/jest-project/lib/create-files.ts
@@ -27,10 +27,15 @@ export function createFiles(tree: Tree, options: JestProjectSchema) {
     ...options,
     transformer,
     js: !!options.js,
-    projectRoot: projectConfig.root,
+    projectRoot: options.rootProject ? options.project : projectConfig.root,
     offsetFromRoot: offsetFromRoot(projectConfig.root),
   });
 
+  if (options.rootProject) {
+    // if the project is a root project,
+    // then we need to set the root jest.config.ts to be what would normally be in the project level instead of the root one
+    // if it's not a root project we need to make sure that the root jest.config.ts correctly has the monorepo setup support
+  }
   if (options.setupFile === 'none') {
     tree.delete(join(projectConfig.root, './src/test-setup.ts'));
   }

--- a/packages/jest/src/generators/jest-project/lib/create-files.ts
+++ b/packages/jest/src/generators/jest-project/lib/create-files.ts
@@ -27,15 +27,11 @@ export function createFiles(tree: Tree, options: JestProjectSchema) {
     ...options,
     transformer,
     js: !!options.js,
+    rootProject: options.rootProject,
     projectRoot: options.rootProject ? options.project : projectConfig.root,
     offsetFromRoot: offsetFromRoot(projectConfig.root),
   });
 
-  if (options.rootProject) {
-    // if the project is a root project,
-    // then we need to set the root jest.config.ts to be what would normally be in the project level instead of the root one
-    // if it's not a root project we need to make sure that the root jest.config.ts correctly has the monorepo setup support
-  }
   if (options.setupFile === 'none') {
     tree.delete(join(projectConfig.root, './src/test-setup.ts'));
   }

--- a/packages/jest/src/generators/jest-project/lib/update-jestconfig.ts
+++ b/packages/jest/src/generators/jest-project/lib/update-jestconfig.ts
@@ -4,21 +4,25 @@ import { addPropertyToJestConfig } from '../../../utils/config/update-config';
 import { readProjectConfiguration, Tree } from '@nrwl/devkit';
 
 function isUsingUtilityFunction(host: Tree) {
-  return host
-    .read(findRootJestConfig(host))
-    .toString()
-    .includes('getJestProjects()');
+  const rootConfig = findRootJestConfig(host);
+  return (
+    rootConfig && host.read(rootConfig).toString().includes('getJestProjects()')
+  );
 }
 
 export function updateJestConfig(host: Tree, options: JestProjectSchema) {
   if (isUsingUtilityFunction(host)) {
+    console.log('is not using util function');
     return;
   }
   const project = readProjectConfiguration(host, options.project);
-  addPropertyToJestConfig(
-    host,
-    findRootJestConfig(host),
-    'projects',
-    `<rootDir>/${project.root}`
-  );
+  const rootConfig = findRootJestConfig(host);
+  if (rootConfig) {
+    addPropertyToJestConfig(
+      host,
+      findRootJestConfig(host),
+      'projects',
+      `<rootDir>/${project.root}`
+    );
+  }
 }

--- a/packages/jest/src/generators/jest-project/lib/update-jestconfig.ts
+++ b/packages/jest/src/generators/jest-project/lib/update-jestconfig.ts
@@ -12,7 +12,6 @@ function isUsingUtilityFunction(host: Tree) {
 
 export function updateJestConfig(host: Tree, options: JestProjectSchema) {
   if (isUsingUtilityFunction(host)) {
-    console.log('is not using util function');
     return;
   }
   const project = readProjectConfiguration(host, options.project);

--- a/packages/jest/src/generators/jest-project/schema.d.ts
+++ b/packages/jest/src/generators/jest-project/schema.d.ts
@@ -16,4 +16,5 @@ export interface JestProjectSchema {
   compiler?: 'tsc' | 'babel' | 'swc';
   skipPackageJson?: boolean;
   js?: boolean;
+  rootProject?: boolean;
 }

--- a/packages/jest/src/generators/jest-project/schema.json
+++ b/packages/jest/src/generators/jest-project/schema.json
@@ -68,6 +68,12 @@
       "type": "boolean",
       "default": false,
       "description": "Use JavaScript instead of TypeScript for config files"
+    },
+    "rootProject": {
+      "description": "Add Jest to an application at the root of the workspace",
+      "type": "boolean",
+      "default": false,
+      "hidden": true
     }
   },
   "required": []

--- a/packages/jest/src/utils/config/get-jest-projects.ts
+++ b/packages/jest/src/utils/config/get-jest-projects.ts
@@ -41,3 +41,17 @@ export function getJestProjects() {
   }
   return Array.from(jestConfigurationSet);
 }
+
+/**
+ * a list of nested projects that have jest configured
+ * to be used in the testPathIgnorePatterns property of a given jest config
+ * https://jestjs.io/docs/configuration#testpathignorepatterns-arraystring
+ * */
+export function getNestedJestProjects() {
+  // TODO(caleb): get current project path and list of all projects and their rootDir
+  // return a list of all projects that are nested in the current projects path
+  // always include node_modules as that's the default
+
+  const allProjects = getJestProjects();
+  return ['/node_modules/'];
+}

--- a/packages/react/src/generators/application/lib/add-jest.ts
+++ b/packages/react/src/generators/application/lib/add-jest.ts
@@ -14,5 +14,6 @@ export async function addJest(host: Tree, options: NormalizedSchema) {
     skipSerializers: true,
     setupFile: 'none',
     compiler: options.compiler,
+    rootProject: options.rootProject,
   });
 }

--- a/packages/react/src/generators/init/init.ts
+++ b/packages/react/src/generators/init/init.ts
@@ -8,7 +8,6 @@ import {
   Tree,
   updateWorkspaceConfiguration,
 } from '@nrwl/devkit';
-import { jestInitGenerator } from '@nrwl/jest';
 import { webInitGenerator } from '@nrwl/web';
 import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 import {
@@ -71,10 +70,6 @@ export async function reactInitGenerator(host: Tree, schema: InitSchema) {
 
   setDefault(host);
 
-  if (!schema.unitTestRunner || schema.unitTestRunner === 'jest') {
-    const jestTask = jestInitGenerator(host, schema);
-    tasks.push(jestTask);
-  }
   if (!schema.e2eTestRunner || schema.e2eTestRunner === 'cypress') {
     const cypressTask = cypressInitGenerator(host, {});
     tasks.push(cypressTask);

--- a/packages/workspace/src/generators/preset/preset.ts
+++ b/packages/workspace/src/generators/preset/preset.ts
@@ -68,7 +68,6 @@ async function createPreset(tree: Tree, options: Schema) {
       name: options.name,
       style: options.style,
       linter: options.linter,
-      unitTestRunner: 'jest',
       standaloneConfig: options.standaloneConfig,
       rootProject: true,
       bundler: 'vite',

--- a/packages/workspace/src/generators/preset/preset.ts
+++ b/packages/workspace/src/generators/preset/preset.ts
@@ -68,7 +68,7 @@ async function createPreset(tree: Tree, options: Schema) {
       name: options.name,
       style: options.style,
       linter: options.linter,
-      unitTestRunner: 'none',
+      unitTestRunner: 'jest',
       standaloneConfig: options.standaloneConfig,
       rootProject: true,
       bundler: 'vite',

--- a/packages/workspace/src/generators/preset/preset.ts
+++ b/packages/workspace/src/generators/preset/preset.ts
@@ -44,7 +44,6 @@ async function createPreset(tree: Tree, options: Schema) {
       name: options.name,
       style: options.style,
       linter: options.linter,
-      unitTestRunner: 'none',
       standaloneConfig: options.standaloneConfig,
       rootProject: true,
     });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
@nrwl/jest does not work with experimental root projects

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Enable jest to run in the experimental single root project setup and update configurations to support multi project jest projects when adding new projects with nx

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
TODO
- [x] e2e tests
- [x] migration to ensuring `getJestProjects()` is used
- [x] more robust project config update detection when switching project types
