### PR TITLE
fix(nextjs): check validity of Nx context in withNx plugin

### DIFF
--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -38,6 +38,10 @@ export function withNx(
   nextConfig = {} as WithNxOptions,
   context: WithNxContext = getWithNxContext()
 ): NextConfig {
+  // If `next-compose-plugins` is used, the context argument is invalid.
+  if (!context.libsDir || !context.workspaceRoot) {
+    context = getWithNxContext();
+  }
   const userWebpack = nextConfig.webpack || ((x) => x);
   const { nx, ...validNextConfig } = nextConfig;
   return {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
If users use `next-compose-plugins` then `withNx` gets the wrong context object and errors out.

## Expected Behavior
Using `next-compose-plugins` should work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
