### PR TITLE
fix(core): disallow edges to the root project

### DIFF
--- a/packages/nx/src/project-graph/build-dependencies/explicit-project-dependencies.ts
+++ b/packages/nx/src/project-graph/build-dependencies/explicit-project-dependencies.ts
@@ -12,6 +12,10 @@ export function buildExplicitTypeScriptDependencies(
   graph: ProjectGraph,
   filesToProcess: ProjectFileMap
 ) {
+  function isRoot(projectName: string) {
+    return graph.nodes[projectName]?.data?.root === '.';
+  }
+
   const importLocator = new TypeScriptImportLocator();
   const targetProjectLocator = new TargetProjectLocator(
     graph.nodes as any,
@@ -28,6 +32,11 @@ export function buildExplicitTypeScriptDependencies(
             f.file
           );
           if (target) {
+            if (!isRoot(source) && isRoot(target)) {
+              // TODO: These edges technically should be allowed but we need to figure out how to separate config files out from root
+              return;
+            }
+
             res.push({
               sourceProjectName: source,
               targetProjectName: target,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

There are some config files in the root of the workspace such as `/.storybook/main.js` which are imported from configs within libraries within the workspace (`libs/ui/.storybook/main.js`) which will cause an edge. Many times, this will create a circular dependency because the root app will depend on that same lib.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Though it is within the root app's directory, `.storybook/main.js` isn't really part of the app that lives at the root. If it were to be moved into its own directory, `.storybook/main.js` would not be moved with it. This change ignores these edges until we have a better way of indicating that `.storybook/main.js` is not part of the root app.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
