### PR TITLE
chore(core): introduce getProjectForPath util

### DIFF
--- a/packages/angular/plugins/component-testing.ts
+++ b/packages/angular/plugins/component-testing.ts
@@ -21,10 +21,10 @@ import {
   stripIndents,
   workspaceRoot,
 } from '@nrwl/devkit';
-import { createProjectFileMappings } from 'nx/src/utils/target-project-locator';
 import { lstatSync, mkdirSync, writeFileSync } from 'fs';
 import { dirname, join, relative } from 'path';
 import type { BrowserBuilderSchema } from '../src/builders/webpack-browser/webpack-browser.impl';
+import { createProjectPathMappings } from 'nx/src/project-graph/utils/get-project';
 
 /**
  * Angular nx preset for Cypress Component Testing
@@ -279,7 +279,7 @@ function withSchemaDefaults(options: any): BrowserBuilderSchema {
  * this file should get cleaned up via the cypress executor
  */
 function getTempStylesForTailwind(ctExecutorContext: ExecutorContext) {
-  const mappedGraphFiles = createProjectFileMappings(
+  const mappedGraphFiles = createProjectPathMappings(
     ctExecutorContext.projectGraph.nodes
   );
   const ctProjectConfig = ctExecutorContext.projectGraph.nodes[

--- a/packages/angular/src/generators/component/lib/normalize-options.ts
+++ b/packages/angular/src/generators/component/lib/normalize-options.ts
@@ -1,27 +1,25 @@
 import type { Tree } from '@nrwl/devkit';
 import {
   joinPathFragments,
+  readCachedProjectGraph,
   readProjectConfiguration,
   readWorkspaceConfiguration,
 } from '@nrwl/devkit';
 import type { NormalizedSchema, Schema } from '../schema';
-import { getProjectNameFromDirPath } from 'nx/src/utils/project-graph-utils';
-
-function getProjectFromPath(path: string) {
-  try {
-    return getProjectNameFromDirPath(path);
-  } catch {
-    return null;
-  }
-}
+import {
+  createProjectPathMappings,
+  getProjectForPath,
+} from 'nx/src/project-graph/utils/get-project';
 
 export function normalizeOptions(
   tree: Tree,
   options: Schema
 ): NormalizedSchema {
+  const projectGraph = readCachedProjectGraph();
+  const projectPathMappings = createProjectPathMappings(projectGraph.nodes);
   const project =
     options.project ??
-    getProjectFromPath(options.path) ??
+    getProjectForPath(options.path, projectPathMappings) ??
     readWorkspaceConfiguration(tree).defaultProject;
   const { projectType, root, sourceRoot } = readProjectConfiguration(
     tree,

--- a/packages/cypress/plugins/cypress-preset.ts
+++ b/packages/cypress/plugins/cypress-preset.ts
@@ -9,9 +9,12 @@ import {
   workspaceRoot,
 } from '@nrwl/devkit';
 import { readProjectsConfigurationFromProjectGraph } from 'nx/src/project-graph/project-graph';
-import { createProjectFileMappings } from 'nx/src/utils/target-project-locator';
 import { dirname, extname, join, relative } from 'path';
 import { lstatSync } from 'fs';
+import {
+  createProjectPathMappings,
+  getProjectForPath,
+} from 'nx/src/project-graph/utils/get-project';
 
 interface BaseCypressPreset {
   videosFolder: string;
@@ -90,9 +93,11 @@ export function getProjectConfigByPath(
       : configFileFromWorkspaceRoot
   );
 
-  const mappedGraphFiles = createProjectFileMappings(graph.nodes);
-  const componentTestingProjectName =
-    mappedGraphFiles[normalizedPathFromWorkspaceRoot];
+  const mappedGraphFiles = createProjectPathMappings(graph.nodes);
+  const componentTestingProjectName = getProjectForPath(
+    normalizedPathFromWorkspaceRoot,
+    mappedGraphFiles
+  );
   if (
     !componentTestingProjectName ||
     !graph.nodes[componentTestingProjectName]?.data

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.spec.ts
@@ -3,13 +3,11 @@ import { DependencyType } from '@nrwl/devkit';
 import * as parser from '@typescript-eslint/parser';
 import { TSESLint } from '@typescript-eslint/utils';
 import { vol } from 'memfs';
-import {
-  TargetProjectLocator,
-  createProjectFileMappings,
-} from 'nx/src/utils/target-project-locator';
+import { TargetProjectLocator } from 'nx/src/utils/target-project-locator';
 import enforceModuleBoundaries, {
   RULE_NAME as enforceModuleBoundariesRuleName,
 } from './enforce-module-boundaries';
+import { createProjectPathMappings } from 'nx/src/project-graph/utils/get-project';
 
 jest.mock('fs', () => require('memfs').fs);
 
@@ -1894,7 +1892,7 @@ function runRule(
 ): TSESLint.Linter.LintMessage[] {
   (global as any).projectPath = `${process.cwd()}/proj`;
   (global as any).projectGraph = projectGraph;
-  (global as any).projectGraphFileMappings = createProjectFileMappings(
+  (global as any).projectGraphFileMappings = createProjectPathMappings(
     projectGraph.nodes
   );
   (global as any).targetProjectLocator = new TargetProjectLocator(

--- a/packages/eslint-plugin-nx/src/utils/project-graph-utils.ts
+++ b/packages/eslint-plugin-nx/src/utils/project-graph-utils.ts
@@ -1,7 +1,7 @@
 import { ProjectGraph, readCachedProjectGraph, readNxJson } from '@nrwl/devkit';
-import { createProjectFileMappings } from 'nx/src/utils/target-project-locator';
 import { isTerminalRun } from './runtime-lint-utils';
 import * as chalk from 'chalk';
+import { createProjectPathMappings } from 'nx/src/project-graph/utils/get-project';
 
 export function ensureGlobalProjectGraph(ruleName: string) {
   /**
@@ -22,7 +22,7 @@ export function ensureGlobalProjectGraph(ruleName: string) {
      */
     try {
       (global as any).projectGraph = readCachedProjectGraph();
-      (global as any).projectGraphFileMappings = createProjectFileMappings(
+      (global as any).projectGraphFileMappings = createProjectPathMappings(
         (global as any).projectGraph.nodes
       );
     } catch {

--- a/packages/eslint-plugin-nx/src/utils/runtime-lint-utils.ts
+++ b/packages/eslint-plugin-nx/src/utils/runtime-lint-utils.ts
@@ -14,10 +14,8 @@ import { join } from 'path';
 import { getPath, pathExists } from './graph-utils';
 import { existsSync } from 'fs';
 import { readFileIfExisting } from 'nx/src/project-graph/file-utils';
-import {
-  TargetProjectLocator,
-  removeExt,
-} from 'nx/src/utils/target-project-locator';
+import { TargetProjectLocator } from 'nx/src/utils/target-project-locator';
+import { removeExt } from 'nx/src/utils/fileutils';
 
 export type Deps = { [projectName: string]: ProjectGraphDependency[] };
 export type DepConstraint = {

--- a/packages/nx/src/nx-init/add-nx-to-npm-repo.ts
+++ b/packages/nx/src/nx-init/add-nx-to-npm-repo.ts
@@ -10,7 +10,7 @@ import {
   initCloud,
   runInstall,
 } from './utils';
-import { joinPathFragments } from 'nx/src/utils/path';
+import { joinPathFragments } from '../utils/path';
 
 const parsedArgs = yargsParser(process.argv, {
   boolean: ['yes'],

--- a/packages/nx/src/project-graph/affected/locators/workspace-projects.ts
+++ b/packages/nx/src/project-graph/affected/locators/workspace-projects.ts
@@ -2,13 +2,13 @@ import * as minimatch from 'minimatch';
 import { TouchedProjectLocator } from '../affected-project-graph-models';
 import { NxJsonConfiguration } from '../../../config/nx-json';
 import { ProjectGraphProjectNode } from '../../../config/project-graph';
-import { createProjectFileMappings } from '../../../utils/target-project-locator';
+import { createProjectPathMappings } from '../../utils/get-project';
 
 export const getTouchedProjects: TouchedProjectLocator = (
   touchedFiles,
   projectGraphNodes
 ): string[] => {
-  const allProjectFiles = createProjectFileMappings(projectGraphNodes);
+  const allProjectFiles = createProjectPathMappings(projectGraphNodes);
   const affected = [];
 
   touchedFiles.forEach((f) => {

--- a/packages/nx/src/project-graph/utils/get-project.spec.ts
+++ b/packages/nx/src/project-graph/utils/get-project.spec.ts
@@ -1,0 +1,88 @@
+import { createProjectPathMappings, getProjectForPath } from './get-project';
+import { ProjectGraph } from '../../config/project-graph';
+
+describe('get project utils', () => {
+  let projGraph: ProjectGraph;
+  beforeEach(() => {
+    projGraph = {
+      nodes: {
+        'demo-app': {
+          name: 'demo-app',
+          type: 'app',
+          data: {
+            root: 'apps/demo-app',
+            files: [],
+          },
+        },
+        ui: {
+          name: 'ui',
+          type: 'lib',
+          data: {
+            root: 'libs/ui',
+            sourceRoot: 'libs/ui/src',
+            projectType: 'library',
+            targets: {},
+            files: [],
+          },
+        },
+        core: {
+          name: 'core',
+          type: 'lib',
+          data: {
+            root: 'libs/core',
+            sourceRoot: 'libs/core/src',
+            projectType: 'library',
+            targets: {},
+            files: [],
+          },
+        },
+        'implicit-lib': {
+          name: 'implicit-lib',
+          type: 'lib',
+          data: {
+            files: [],
+          },
+        },
+      },
+      dependencies: {
+        'demo-app': [
+          {
+            type: 'static',
+            source: 'demo-app',
+            target: 'ui',
+          },
+          {
+            type: 'static',
+            source: 'demo-app',
+            target: 'npm:chalk',
+          },
+          {
+            type: 'static',
+            source: 'demo-app',
+            target: 'core',
+          },
+        ],
+      },
+    };
+  });
+
+  describe('getProjectForPath', () => {
+    let projectPathMapping;
+    beforeEach(() => {
+      projectPathMapping = createProjectPathMappings(projGraph.nodes);
+    });
+    it('should find the project given a file within its src root', () => {
+      expect(getProjectForPath('apps/demo-app', projectPathMapping)).toEqual(
+        'demo-app'
+      );
+
+      expect(
+        getProjectForPath('apps/demo-app/src', projectPathMapping)
+      ).toEqual('demo-app');
+
+      expect(
+        getProjectForPath('apps/demo-app/src/subdir/bla', projectPathMapping)
+      ).toEqual('demo-app');
+    });
+  });
+});

--- a/packages/nx/src/project-graph/utils/get-project.ts
+++ b/packages/nx/src/project-graph/utils/get-project.ts
@@ -1,0 +1,49 @@
+import type { ProjectGraphProjectNode } from '../../config/project-graph';
+import { removeExt } from '../../utils/fileutils';
+import { dirname } from 'path';
+
+/**
+ * Maps the file paths to the project name, both with and without the file extension
+ * apps/myapp/src/main.ts -> { 'apps/myapp/src/main': 'myapp', 'apps/myapp/src/main.ts': 'myapp' }
+ * @param projectGraph nodes
+ * @returns
+ */
+export function createProjectPathMappings(
+  nodes: Record<string, ProjectGraphProjectNode>
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  Object.entries(nodes).forEach(([name, node]) => {
+    if (node?.data?.root) {
+      result[node.data.root] = name;
+    }
+    node.data.files.forEach(({ file }) => {
+      const fileName = removeExt(file);
+      result[fileName] = name;
+      result[file] = name;
+    });
+  });
+
+  return result;
+}
+
+/**
+ * Locates a project in projectRootMap based on a file within it
+ * @param filePath path that is inside of projectName
+ * @param projectPathMappings Map<projectRoot, projectName> Use {@link #createProjectPathMappings} to create this
+ */
+export function getProjectForPath(
+  filePath: string,
+  projectPathMappings: Record<string, string>
+): string | null {
+  for (
+    let currentPath = filePath;
+    currentPath != dirname(currentPath);
+    currentPath = dirname(currentPath)
+  ) {
+    const p = projectPathMappings[currentPath];
+    if (p) {
+      return p;
+    }
+  }
+  return null;
+}

--- a/packages/nx/src/utils/create-package-json.ts
+++ b/packages/nx/src/utils/create-package-json.ts
@@ -1,5 +1,5 @@
 import { readJsonFile } from './fileutils';
-import { sortObjectByKeys } from 'nx/src/utils/object-sort';
+import { sortObjectByKeys } from './object-sort';
 import { ProjectGraph } from '../config/project-graph';
 
 /**

--- a/packages/nx/src/utils/fileutils.ts
+++ b/packages/nx/src/utils/fileutils.ts
@@ -1,13 +1,13 @@
-import { parseJson, serializeJson } from './json';
 import type { JsonParseOptions, JsonSerializeOptions } from './json';
+import { parseJson, serializeJson } from './json';
 import {
   createReadStream,
   createWriteStream,
+  mkdirSync,
   PathLike,
   readFileSync,
-  writeFileSync,
-  mkdirSync,
   statSync,
+  writeFileSync,
 } from 'fs';
 import { dirname } from 'path';
 import * as tar from 'tar-stream';
@@ -153,4 +153,13 @@ export async function extractFileFromTarball(
 
     createReadStream(tarballPath).pipe(createGunzip()).pipe(tarExtractStream);
   });
+}
+
+/**
+ * Strips the file extension from the file path
+ * @param file
+ * @returns
+ */
+export function removeExt(file: string): string {
+  return file.replace(/(?<!(^|\/))\.[^/.]+$/, '');
 }

--- a/packages/nx/src/utils/nx-plugin.ts
+++ b/packages/nx/src/utils/nx-plugin.ts
@@ -16,8 +16,8 @@ import {
   TargetConfiguration,
   ProjectsConfigurations,
 } from '../config/workspace-json-project-json';
-import { findMatchingProjectForPath } from './target-project-locator';
 import { logger } from './logger';
+import { getProjectForPath } from '../project-graph/utils/get-project';
 
 export type ProjectTargetConfigurator = (
   file: string
@@ -197,10 +197,7 @@ function findNxProjectForImportPath(
   if (possiblePaths?.length) {
     const projectRootMappings = buildProjectRootMap(workspace.projects, root);
     for (const tsConfigPath of possiblePaths) {
-      const nxProject = findMatchingProjectForPath(
-        tsConfigPath,
-        projectRootMappings
-      );
+      const nxProject = getProjectForPath(tsConfigPath, projectRootMappings);
       if (nxProject) {
         return nxProject;
       }
@@ -223,9 +220,9 @@ function buildProjectRootMap(
   root: string
 ) {
   return Object.entries(projects).reduce((m, [project, config]) => {
-    m.set(path.resolve(root, config.root), project);
+    m[path.resolve(root, config.root)] = project;
     return m;
-  }, new Map<string, string>());
+  }, {});
 }
 
 let tsconfigPaths: Record<string, string[]>;

--- a/packages/nx/src/utils/project-graph-utils.spec.ts
+++ b/packages/nx/src/utils/project-graph-utils.spec.ts
@@ -13,7 +13,6 @@ jest.mock('nx/src/utils/fileutils', () => ({
 import { PackageJson } from './package-json';
 import { ProjectGraph } from '../config/project-graph';
 import {
-  getProjectNameFromDirPath,
   getSourceDirOfDependentProjects,
   mergeNpmScriptsWithTargets,
 } from './project-graph-utils';
@@ -115,26 +114,6 @@ describe('project graph utils', () => {
         );
         expect(warnings).toContain('implicit-lib');
       });
-    });
-
-    it('should find the project given a file within its src root', () => {
-      expect(getProjectNameFromDirPath('apps/demo-app', projGraph)).toEqual(
-        'demo-app'
-      );
-
-      expect(getProjectNameFromDirPath('apps/demo-app/src', projGraph)).toEqual(
-        'demo-app'
-      );
-
-      expect(
-        getProjectNameFromDirPath('apps/demo-app/src/subdir/bla', projGraph)
-      ).toEqual('demo-app');
-    });
-
-    it('should throw an error if the project name has not been found', () => {
-      expect(() => {
-        getProjectNameFromDirPath('apps/demo-app-unknown');
-      }).toThrowError();
     });
   });
 

--- a/packages/nx/src/utils/project-graph-utils.ts
+++ b/packages/nx/src/utils/project-graph-utils.ts
@@ -1,8 +1,7 @@
 import { buildTargetFromScript, PackageJson } from './package-json';
-import { join, relative } from 'path';
+import { join } from 'path';
 import { ProjectGraph, ProjectGraphProjectNode } from '../config/project-graph';
 import { readJsonFile } from './fileutils';
-import { normalizePath } from './path';
 import { readCachedProjectGraph } from '../project-graph/project-graph';
 import { TargetConfiguration } from '../config/workspace-json-project-json';
 
@@ -72,38 +71,6 @@ export function getSourceDirOfDependentProjects(
     },
     [[], []] as [projectDirs: string[], warnings: string[]]
   );
-}
-
-/**
- * Finds the project node name by a file that lives within it's src root
- * @param projRelativeDirPath directory path relative to the workspace root
- * @param projectGraph
- */
-export function getProjectNameFromDirPath(
-  projRelativeDirPath: string,
-  projectGraph = readCachedProjectGraph()
-) {
-  let parentNodeName = null;
-  for (const [nodeName, node] of Object.entries(projectGraph.nodes)) {
-    const normalizedRootPath = normalizePath(node.data.root);
-    const normalizedProjRelPath = normalizePath(projRelativeDirPath);
-
-    const relativePath = relative(normalizedRootPath, normalizedProjRelPath);
-    const isMatch = relativePath && !relativePath.startsWith('..');
-
-    if (isMatch || normalizedRootPath === normalizedProjRelPath) {
-      parentNodeName = nodeName;
-      break;
-    }
-  }
-
-  if (!parentNodeName) {
-    throw new Error(
-      `Could not find any project containing the file "${projRelativeDirPath}" among it's project files`
-    );
-  }
-
-  return parentNodeName;
 }
 
 /**

--- a/packages/workspace/src/utilities/generate-globs.ts
+++ b/packages/workspace/src/utilities/generate-globs.ts
@@ -2,12 +2,13 @@ import { joinPathFragments, logger } from '@nrwl/devkit';
 import { workspaceRoot } from 'nx/src/utils/workspace-root';
 import { dirname, join, relative, resolve } from 'path';
 import { readCachedProjectGraph } from 'nx/src/project-graph/project-graph';
-import {
-  getProjectNameFromDirPath,
-  getSourceDirOfDependentProjects,
-} from 'nx/src/utils/project-graph-utils';
+import { getSourceDirOfDependentProjects } from 'nx/src/utils/project-graph-utils';
 import { existsSync, lstatSync, readdirSync, readFileSync } from 'fs';
 import ignore, { Ignore } from 'ignore';
+import {
+  createProjectPathMappings,
+  getProjectForPath,
+} from 'nx/src/project-graph/utils/get-project';
 
 function configureIgnore() {
   let ig: Ignore;
@@ -31,14 +32,21 @@ export function createGlobPatternsForDependencies(
   let ig = configureIgnore();
   const filenameRelativeToWorkspaceRoot = relative(workspaceRoot, dirPath);
   const projectGraph = readCachedProjectGraph();
+  const projectPathMappings = createProjectPathMappings(projectGraph.nodes);
 
   // find the project
   let projectName;
   try {
-    projectName = getProjectNameFromDirPath(
+    projectName = getProjectForPath(
       filenameRelativeToWorkspaceRoot,
-      projectGraph
+      projectPathMappings
     );
+
+    if (!projectName) {
+      throw new Error(
+        `Could not find any project containing the file "${filenameRelativeToWorkspaceRoot}" among it's project files`
+      );
+    }
   } catch (e) {
     throw new Error(
       `createGlobPatternsForDependencies: Error when trying to determine main project.\n${e?.message}`


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

There are many versions of functions that get the project which a file or path pertains to.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

There is 1 function used to get the project which a file or path pertains to: `getProjectForPath`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Closes #13349 
