### PR TITLE
fix(bundling): add type for bundler option to enable autocomplete prompt

### DIFF
--- a/docs/generated/packages/js.json
+++ b/docs/generated/packages/js.json
@@ -122,6 +122,7 @@
           },
           "bundler": {
             "description": "The bundler to use.",
+            "type": "string",
             "enum": ["none", "esbuild", "rollup", "webpack"],
             "default": "none"
           },

--- a/docs/generated/packages/react.json
+++ b/docs/generated/packages/react.json
@@ -242,6 +242,7 @@
           },
           "bundler": {
             "description": "The bundler to use.",
+            "type": "string",
             "enum": ["vite", "webpack"],
             "x-prompt": "Which bundler do you want to use?",
             "default": "webpack"

--- a/packages/js/src/generators/library/schema.json
+++ b/packages/js/src/generators/library/schema.json
@@ -105,6 +105,7 @@
     },
     "bundler": {
       "description": "The bundler to use.",
+      "type": "string",
       "enum": ["none", "esbuild", "rollup", "webpack"],
       "default": "none"
     },

--- a/packages/react/src/generators/application/schema.json
+++ b/packages/react/src/generators/application/schema.json
@@ -183,6 +183,7 @@
     },
     "bundler": {
       "description": "The bundler to use.",
+      "type": "string",
       "enum": ["vite", "webpack"],
       "x-prompt": "Which bundler do you want to use?",
       "default": "webpack"


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Users have to type out vite for the prompt for the bundler

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Users have a autocomplete prompt for the prompt for bundler

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
