### PR TITLE
fix(angular): port should be added to serve-ssr for remote

### DIFF
--- a/packages/angular/src/generators/remote/lib/add-ssr.ts
+++ b/packages/angular/src/generators/remote/lib/add-ssr.ts
@@ -6,7 +6,6 @@ import {
   readProjectConfiguration,
   updateProjectConfiguration,
 } from '@nrwl/devkit';
-import type { Schema } from '../schema';
 
 import setupSsr from '../../setup-ssr/setup-ssr';
 import {
@@ -15,7 +14,10 @@ import {
   moduleFederationNodeVersion,
 } from '../../../utils/versions';
 
-export async function addSsr(tree: Tree, options: Schema, appName: string) {
+export async function addSsr(
+  tree: Tree,
+  { appName, port }: { appName: string; port: number }
+) {
   let project = readProjectConfiguration(tree, appName);
 
   await setupSsr(tree, {
@@ -43,6 +45,10 @@ export async function addSsr(tree: Tree, options: Schema, appName: string) {
   project.targets.server.executor = '@nrwl/angular:webpack-server';
   project.targets.server.options.customWebpackConfig = {
     path: joinPathFragments(project.root, 'webpack.server.config.js'),
+  };
+  project.targets['serve-ssr'].options = {
+    ...(project.targets['serve-ssr'].options ?? {}),
+    port,
   };
 
   updateProjectConfiguration(tree, appName, project);

--- a/packages/angular/src/generators/remote/remote.ts
+++ b/packages/angular/src/generators/remote/remote.ts
@@ -43,7 +43,7 @@ export async function remote(tree: Tree, options: Schema) {
 
   let installTasks = [appInstallTask];
   if (options.ssr) {
-    let ssrInstallTask = await addSsr(tree, options, appName);
+    let ssrInstallTask = await addSsr(tree, { appName, port });
     installTasks.push(ssrInstallTask);
   }
 


### PR DESCRIPTION
# Current Behavior
<!-- This is the behavior we have today -->
The port is not being added to `serve-ssr` options when generating a remote.
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The port should be added to serve-ssr to ensure it gets served correctly and can be found by the host.
