### PR TITLE
cleanup(angular): amend invalid comment in decorate-angular-cli.js script

### DIFF
--- a/packages/workspace/src/generators/utils/decorate-angular-cli.js__tmpl__
+++ b/packages/workspace/src/generators/utils/decorate-angular-cli.js__tmpl__
@@ -12,8 +12,7 @@
  * Every command you run should work the same when using the Nx CLI, except faster.
  *
  * Because of symlinking you can still type `ng build/test/lint` in the terminal. The ng command, in this case,
- * will point to nx, which will perform optimizations before invoking ng. So the Angular CLI is always invoked.
- * The Nx CLI simply does some optimizations before invoking the Angular CLI.
+ * will point to nx, which will perform optimizations before running your task.
  *
  * To opt out of this patch:
  * - Replace occurrences of nx with ng in your package.json


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The description in a comment on the `decorate-angular-cli.js` script wrongly states that the Angular CLI is always invoked.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The description in a comment on the `decorate-angular-cli.js` script should not state that the Angular CLI is invoked at all. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
