### PR TITLE
fix(bundling): set rootDir to the project root when bundling with rollup

### DIFF
--- a/packages/rollup/src/executors/rollup/lib/update-package-json.ts
+++ b/packages/rollup/src/executors/rollup/lib/update-package-json.ts
@@ -8,6 +8,7 @@ import {
 import { writeJsonFile } from 'nx/src/utils/fileutils';
 import { PackageJson } from 'nx/src/utils/package-json';
 import { NormalizedRollupExecutorOptions } from './normalize';
+import { joinPathFragments } from 'nx/src/utils/path';
 
 export function updatePackageJson(
   options: NormalizedRollupExecutorOptions,
@@ -19,7 +20,7 @@ export function updatePackageJson(
   const hasEsmFormat = options.format.includes('esm');
   const hasCjsFormat = options.format.includes('cjs');
 
-  const types = `./${relative(options.entryRoot, options.main).replace(
+  const types = `./${relative(options.projectRoot, options.main).replace(
     /\.[jt]sx?$/,
     '.d.ts'
   )}`;

--- a/packages/rollup/src/executors/rollup/rollup.impl.ts
+++ b/packages/rollup/src/executors/rollup/rollup.impl.ts
@@ -302,7 +302,7 @@ function createTsCompilerOptions(
 ) {
   const compilerOptionPaths = computeCompilerOptionsPaths(config, dependencies);
   const compilerOptions = {
-    rootDir: options.entryRoot,
+    rootDir: options.projectRoot,
     allowJs: false,
     declaration: true,
     paths: compilerOptionPaths,


### PR DESCRIPTION
- Fixes errors when *.ts files exist outside of source root

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
