### PR TITLE
fix(core): change name schema order in project.json

### DIFF
--- a/packages/nx/src/generators/utils/project-configuration.ts
+++ b/packages/nx/src/generators/utils/project-configuration.ts
@@ -375,8 +375,8 @@ function addProjectToWorkspaceJson(
 
       // update the project.json file
       writeJson(tree, projectConfigFile, {
-        ...jsonSchema,
         name: mode === 'create' ? projectName : project.name ?? projectName,
+        ...jsonSchema,
         ...project,
         root: undefined,
       });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The addProjectToWorkspaceJson generator utility is creating a project.json with first the schema property and afterwards the name and rest of the projectConfiguration. This works ok, but has unexpected behavior when you use another generator (for example @nrwl/angular:application) that does a formatting on the project configuration files. The 'wrongly' sorted project.json files will show as updated in the changed files list. Which is something we like to prevent in a large monorepo with multiple codeowners.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Expected behavior is that every schematic/generator and utility is generating the project.json in the same way so that generated files are formatted correctly and not show up as unrelated changes when you create a new app or lib.

## Steps to Reproduce
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
I created a small reproduction path on nx-examples: https://github.com/nrwl/nx-examples/pull/250
If you checkout this code and run `nx g @nrwl/angular:app test-app --dry-run` you will see that the output shows:
UPDATE libs/cart/cart-page/project.json
which isn't expected when you generate a new app called test-app.

![Screenshot 2022-11-25 at 13 18 38](https://user-images.githubusercontent.com/4587734/204006993-197c5509-0c50-4da8-8ff6-112ad96a9281.png)
![Screenshot 2022-11-25 at 13 19 28](https://user-images.githubusercontent.com/4587734/204007019-31bee4a0-7e2c-4992-ac36-d5bb14f124c7.png)

## Solution
The solution to this issue is as simple as changing the order of the properties in the project configuration in the addProjectToWorkspaceJson utility