### PR TITLE
fix(core): set the right project graph node type for e2e project with name e2e

### DIFF
--- a/packages/nx/src/project-graph/build-nodes/workspace-projects.ts
+++ b/packages/nx/src/project-graph/build-nodes/workspace-projects.ts
@@ -51,9 +51,10 @@ export function buildWorkspaceProjectNodes(
       loadNxPlugins(ctx.workspace.plugins)
     );
 
+    // TODO: remove in v16
     const projectType =
       p.projectType === 'application'
-        ? key.endsWith('-e2e')
+        ? key.endsWith('-e2e') || key === 'e2e'
           ? 'e2e'
           : 'app'
         : 'lib';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

An e2e project with the name "e2e" is getting classified with a node type "app" and therefore, it shows up in the project graph as an app and not as an e2e project. This can be seen with the Angular and React experimental presets where the initial app is at the root of the workspace and the associated e2e project is named "e2e".

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

An e2e project with the name "e2e" should have a node type of "e2e" and appear in the project graph as an e2e project.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
