### PR TITLE
feat(angular): rename default ngrx-selector names to match ngrx-standard

### DIFF
--- a/packages/angular/src/generators/ngrx/__snapshots__/ngrx.spec.ts.snap
+++ b/packages/angular/src/generators/ngrx/__snapshots__/ngrx.spec.ts.snap
@@ -216,29 +216,29 @@ describe('SuperUsers Selectors', () => {
   });
 
   describe('SuperUsers Selectors', () => {
-    it('getAllSuperUsers() should return the list of SuperUsers', () => {
-      const results = SuperUsersSelectors.getAllSuperUsers(state);
+    it('selectAllSuperUsers() should return the list of SuperUsers', () => {
+      const results = SuperUsersSelectors.selectAllSuperUsers(state);
       const selId = getSuperUsersId(results[1]);
 
       expect(results.length).toBe(3);
       expect(selId).toBe('PRODUCT-BBB');
     });
 
-    it('getSelected() should return the selected Entity', () => {
-      const result = SuperUsersSelectors.getSelected(state) as SuperUsersEntity;
+    it('selectEntity() should return the selected Entity', () => {
+      const result = SuperUsersSelectors.selectEntity(state) as SuperUsersEntity;
       const selId = getSuperUsersId(result);
 
       expect(selId).toBe('PRODUCT-BBB');
     });
 
-    it('getSuperUsersLoaded() should return the current \\"loaded\\" status', () => {
-      const result = SuperUsersSelectors.getSuperUsersLoaded(state);
+    it('selectSuperUsersLoaded() should return the current \\"loaded\\" status', () => {
+      const result = SuperUsersSelectors.selectSuperUsersLoaded(state);
 
       expect(result).toBe(true);
     });
 
-    it('getSuperUsersError() should return the current \\"error\\" state', () => {
-      const result = SuperUsersSelectors.getSuperUsersError(state);
+    it('selectSuperUsersError() should return the current \\"error\\" state', () => {
+      const result = SuperUsersSelectors.selectSuperUsersError(state);
 
       expect(result).toBe(ERROR_MSG);
     });
@@ -372,9 +372,9 @@ export class UsersFacade {
    * Combine pieces of state using createSelector, 
    * and expose them as observables through the facade.
    */
-  loaded$ = this.store.pipe(select(UsersSelectors.getUsersLoaded));
-  allUsers$ = this.store.pipe(select(UsersSelectors.getAllUsers));
-  selectedUsers$ = this.store.pipe(select(UsersSelectors.getSelected));
+  loaded$ = this.store.pipe(select(UsersSelectors.selectUsersLoaded));
+  allUsers$ = this.store.pipe(select(UsersSelectors.selectAllUsers));
+  selectedUsers$ = this.store.pipe(select(UsersSelectors.selectEntity));
 
   /**
    * Use the initialization action to perform one 
@@ -437,38 +437,38 @@ exports[`ngrx should generate the ngrx selectors 1`] = `
 import { USERS_FEATURE_KEY, UsersState, usersAdapter } from './users.reducer';
 
 // Lookup the 'Users' feature state managed by NgRx
-export const getUsersState = createFeatureSelector<UsersState>(USERS_FEATURE_KEY);
+export const selectUsersState = createFeatureSelector<UsersState>(USERS_FEATURE_KEY);
 
 const { selectAll, selectEntities } = usersAdapter.getSelectors();
 
-export const getUsersLoaded = createSelector(
-  getUsersState,
+export const selectUsersLoaded = createSelector(
+  selectUsersState,
   (state: UsersState) => state.loaded
 );
 
-export const getUsersError = createSelector(
-  getUsersState,
+export const selectUsersError = createSelector(
+  selectUsersState,
   (state: UsersState) => state.error
 );
 
-export const getAllUsers = createSelector(
-  getUsersState,
+export const selectAllUsers = createSelector(
+  selectUsersState,
   (state: UsersState) => selectAll(state)
 );
 
-export const getUsersEntities = createSelector(
-  getUsersState,
+export const selectUsersEntities = createSelector(
+  selectUsersState,
   (state: UsersState) => selectEntities(state)
 );
 
-export const getSelectedId = createSelector(
-  getUsersState,
+export const selectSelectedId = createSelector(
+  selectUsersState,
   (state: UsersState) => state.selectedId
 );
 
-export const getSelected = createSelector(
-  getUsersEntities,
-  getSelectedId,
+export const selectEntity = createSelector(
+  selectUsersEntities,
+  selectSelectedId,
   (entities, selectedId) => (selectedId ? entities[selectedId] : undefined)
 );
 "

--- a/packages/angular/src/generators/ngrx/files/__directory__/__fileName__.facade.ts__tmpl__
+++ b/packages/angular/src/generators/ngrx/files/__directory__/__fileName__.facade.ts__tmpl__
@@ -13,9 +13,9 @@ export class <%= className %>Facade {
    * Combine pieces of state using createSelector, 
    * and expose them as observables through the facade.
    */
-  loaded$ = this.store.pipe(select(<%= className %>Selectors.get<%= className %>Loaded));
-  all<%= className %>$ = this.store.pipe(select(<%= className %>Selectors.getAll<%= className %>));
-  selected<%= className %>$ = this.store.pipe(select(<%= className %>Selectors.getSelected));
+  loaded$ = this.store.pipe(select(<%= className %>Selectors.select<%= className %>Loaded));
+  all<%= className %>$ = this.store.pipe(select(<%= className %>Selectors.selectAll<%= className %>));
+  selected<%= className %>$ = this.store.pipe(select(<%= className %>Selectors.selectEntity));
 
   /**
    * Use the initialization action to perform one 

--- a/packages/angular/src/generators/ngrx/files/__directory__/__fileName__.selectors.spec.ts__tmpl__
+++ b/packages/angular/src/generators/ngrx/files/__directory__/__fileName__.selectors.spec.ts__tmpl__
@@ -28,29 +28,29 @@ describe('<%= className %> Selectors', () => {
   });
 
   describe('<%= className %> Selectors', () => {
-    it('getAll<%= className %>() should return the list of <%= className %>', () => {
-      const results = <%= className %>Selectors.getAll<%= className %>(state);
+    it('selectAll<%= className %>() should return the list of <%= className %>', () => {
+      const results = <%= className %>Selectors.selectAll<%= className %>(state);
       const selId = get<%= className %>Id(results[1]);
 
       expect(results.length).toBe(3);
       expect(selId).toBe('PRODUCT-BBB');
     });
 
-    it('getSelected() should return the selected Entity', () => {
-      const result = <%= className %>Selectors.getSelected(state) as <%= className %>Entity;
+    it('selectEntity() should return the selected Entity', () => {
+      const result = <%= className %>Selectors.selectEntity(state) as <%= className %>Entity;
       const selId = get<%= className %>Id(result);
 
       expect(selId).toBe('PRODUCT-BBB');
     });
 
-    it('get<%= className %>Loaded() should return the current "loaded" status', () => {
-      const result = <%= className %>Selectors.get<%= className %>Loaded(state);
+    it('select<%= className %>Loaded() should return the current "loaded" status', () => {
+      const result = <%= className %>Selectors.select<%= className %>Loaded(state);
 
       expect(result).toBe(true);
     });
 
-    it('get<%= className %>Error() should return the current "error" state', () => {
-      const result = <%= className %>Selectors.get<%= className %>Error(state);
+    it('select<%= className %>Error() should return the current "error" state', () => {
+      const result = <%= className %>Selectors.select<%= className %>Error(state);
 
       expect(result).toBe(ERROR_MSG);
     });

--- a/packages/angular/src/generators/ngrx/files/__directory__/__fileName__.selectors.ts__tmpl__
+++ b/packages/angular/src/generators/ngrx/files/__directory__/__fileName__.selectors.ts__tmpl__
@@ -2,37 +2,37 @@ import { createFeatureSelector, createSelector } from '@ngrx/store';
 import { <%= constantName %>_FEATURE_KEY, <%= className %>State, <%= propertyName %>Adapter } from './<%= fileName %>.reducer';
 
 // Lookup the '<%= className %>' feature state managed by NgRx
-export const get<%= className %>State = createFeatureSelector<<%= className %>State>(<%= constantName %>_FEATURE_KEY);
+export const select<%= className %>State = createFeatureSelector<<%= className %>State>(<%= constantName %>_FEATURE_KEY);
 
 const { selectAll, selectEntities } = <%= propertyName %>Adapter.getSelectors();
 
-export const get<%= className %>Loaded = createSelector(
-  get<%= className %>State,
+export const select<%= className %>Loaded = createSelector(
+  select<%= className %>State,
   (state: <%= className %>State) => state.loaded
 );
 
-export const get<%= className %>Error = createSelector(
-  get<%= className %>State,
+export const select<%= className %>Error = createSelector(
+  select<%= className %>State,
   (state: <%= className %>State) => state.error
 );
 
-export const getAll<%= className %> = createSelector(
-  get<%= className %>State,
+export const selectAll<%= className %> = createSelector(
+  select<%= className %>State,
   (state: <%= className %>State) => selectAll(state)
 );
 
-export const get<%= className %>Entities = createSelector(
-  get<%= className %>State,
+export const select<%= className %>Entities = createSelector(
+  select<%= className %>State,
   (state: <%= className %>State) => selectEntities(state)
 );
 
-export const getSelectedId = createSelector(
-  get<%= className %>State,
+export const selectSelectedId = createSelector(
+  select<%= className %>State,
   (state: <%= className %>State) => state.selectedId
 );
 
-export const getSelected = createSelector(
-  get<%= className %>Entities,
-  getSelectedId,
+export const selectEntity = createSelector(
+  select<%= className %>Entities,
+  selectSelectedId,
   (entities, selectedId) => (selectedId ? entities[selectedId] : undefined)
 );


### PR DESCRIPTION


## Current Behavior
Currently the generated ngrx selectors are prefixed with `get`.

## Expected Behavior
The generated selectors should match the default naming convention and be prefixed with `select`

## Related Issue(s)
-
Fixes #
-