### PR TITLE
fix(nextjs): update order of @tailwind directives in @nrwl/react:setup-tailwind

### DIFF
--- a/docs/shared/guides/using-tailwind-css-in-react.md
+++ b/docs/shared/guides/using-tailwind-css-in-react.md
@@ -110,8 +110,8 @@ In the above, you are invoking the `createGlobPatternsForDependencies` utility f
 Next, import tailwind styles to the application's base `styles.css` or `styles.scss` file. This can be done by adding the following lines:
 
 ```css
-@tailwind components;
 @tailwind base;
+@tailwind components;
 @tailwind utilities;
 ```
 

--- a/packages/react/src/generators/setup-tailwind/lib/add-tailwind-style-imports.ts
+++ b/packages/react/src/generators/setup-tailwind/lib/add-tailwind-style-imports.ts
@@ -37,15 +37,15 @@ export function addTailwindStyleImports(
     const content = tree.read(stylesPath).toString();
     tree.write(
       stylesPath,
-      `@tailwind components;\n@tailwind base;\n@tailwind utilities;\n${content}`
+      `@tailwind base;\n@tailwind components;\n@tailwind utilities;\n${content}`
     );
   } else {
     logger.warn(
       stripIndents`
         Could not find stylesheet to update. Add the following imports to your stylesheet (e.g. styles.css):
         
-          @tailwind components;
           @tailwind base;
+          @tailwind components;
           @tailwind utilities;
           
         See our guide for more details: https://nx.dev/guides/using-tailwind-css-in-react`

--- a/packages/react/src/generators/setup-tailwind/setup-tailwind.spec.ts
+++ b/packages/react/src/generators/setup-tailwind/setup-tailwind.spec.ts
@@ -34,8 +34,8 @@ describe('setup-tailwind', () => {
 
     expect(tree.read(`apps/example/${stylesPath}`).toString()).toEqual(
       stripIndents`
-        @tailwind components;
         @tailwind base;
+        @tailwind components;
         @tailwind utilities;
         /* existing content */
       `


### PR DESCRIPTION
The previous order didn't match the tailwind instructions: https://tailwindcss.com/docs/installation
and causes an issue with daisyUI: https://github.com/saadeghi/daisyui/issues/1387

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The generator inserts the directives in the following order:
```css
@tailwind components;
@tailwind base;
@tailwind utilities;
```


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
While the order should be the following one (wrong order causes issues with css specificity):
```css
@tailwind base;
@tailwind components;
@tailwind utilities;
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

There is no nx issue but this daisyui one: https://github.com/saadeghi/daisyui/issues/1387
