### PR TITLE
feat(linter): replace createReactEslintJson with extendReactEslintJson

### DIFF
--- a/e2e/react-native/src/react-native.test.ts
+++ b/e2e/react-native/src/react-native.test.ts
@@ -122,7 +122,7 @@ describe('react native', () => {
     expect(() => {
       runCLI(`build ${libName}`);
       checkFilesExist(`dist/libs/${libName}/index.js`);
-      checkFilesExist(`dist/libs/${libName}/index.d.ts`);
+      checkFilesExist(`dist/libs/${libName}/src/index.d.ts`);
     }).not.toThrow();
   });
 

--- a/packages/detox/src/generators/application/lib/add-linting.ts
+++ b/packages/detox/src/generators/application/lib/add-linting.ts
@@ -6,7 +6,7 @@ import {
   Tree,
   updateJson,
 } from '@nrwl/devkit';
-import { createReactEslintJson, extraEslintDependencies } from '@nrwl/react';
+import { extendReactEslintJson, extraEslintDependencies } from '@nrwl/react';
 import { NormalizedSchema } from './normalize-options';
 
 export async function addLinting(host: Tree, options: NormalizedSchema) {
@@ -24,15 +24,10 @@ export async function addLinting(host: Tree, options: NormalizedSchema) {
     skipFormat: true,
   });
 
-  const reactEslintJson = createReactEslintJson(
-    options.e2eProjectRoot,
-    options.setParserOptionsProject
-  );
-
   updateJson(
     host,
     joinPathFragments(options.e2eProjectRoot, '.eslintrc.json'),
-    () => reactEslintJson
+    extendReactEslintJson
   );
 
   const installTask = addDependenciesToPackageJson(

--- a/packages/expo/src/utils/add-linting.ts
+++ b/packages/expo/src/utils/add-linting.ts
@@ -6,7 +6,7 @@ import {
   Tree,
   updateJson,
 } from '@nrwl/devkit';
-import { createReactEslintJson, extraEslintDependencies } from '@nrwl/react';
+import { extendReactEslintJson, extraEslintDependencies } from '@nrwl/react';
 import type { Linter as ESLintLinter } from 'eslint';
 
 export async function addLinting(
@@ -29,16 +29,12 @@ export async function addLinting(
     skipFormat: true,
   });
 
-  const reactEslintJson = createReactEslintJson(
-    appProjectRoot,
-    setParserOptionsProject
-  );
-
   updateJson(
     host,
     joinPathFragments(appProjectRoot, '.eslintrc.json'),
     (json: ESLintLinter.Config) => {
-      json = reactEslintJson;
+      json = extendReactEslintJson(json);
+
       json.ignorePatterns = ['!**/*', '.expo', 'node_modules', 'web-build'];
 
       // Find the override that handles both TS and JS files.

--- a/packages/react-native/src/utils/add-linting.ts
+++ b/packages/react-native/src/utils/add-linting.ts
@@ -6,7 +6,7 @@ import {
   Tree,
   updateJson,
 } from '@nrwl/devkit';
-import { createReactEslintJson, extraEslintDependencies } from '@nrwl/react';
+import { extendReactEslintJson, extraEslintDependencies } from '@nrwl/react';
 import type { Linter as ESLintLinter } from 'eslint';
 
 interface NormalizedSchema {
@@ -30,16 +30,12 @@ export async function addLinting(host: Tree, options: NormalizedSchema) {
     skipFormat: true,
   });
 
-  const reactEslintJson = createReactEslintJson(
-    options.projectRoot,
-    options.setParserOptionsProject
-  );
-
   updateJson(
     host,
     joinPathFragments(options.projectRoot, '.eslintrc.json'),
     (json: ESLintLinter.Config) => {
-      json = reactEslintJson;
+      json = extendReactEslintJson(json);
+
       json.ignorePatterns = ['!**/*', 'public', '.cache', 'node_modules'];
 
       // Find the override that handles both TS and JS files.

--- a/packages/react/index.ts
+++ b/packages/react/index.ts
@@ -1,6 +1,7 @@
 export {
   extraEslintDependencies,
   createReactEslintJson,
+  extendReactEslintJson,
 } from './src/utils/lint';
 export { CSS_IN_JS_DEPENDENCIES } from './src/utils/styled';
 export { assertValidStyle } from './src/utils/assertion';

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -34,7 +34,7 @@ import {
   findComponentImportPath,
 } from '../../utils/ast-utils';
 import {
-  createReactEslintJson,
+  extendReactEslintJson,
   extraEslintDependencies,
 } from '../../utils/lint';
 import {
@@ -195,15 +195,10 @@ async function addLinting(host: Tree, options: NormalizedSchema) {
       skipPackageJson: options.skipPackageJson,
     });
 
-    const reactEslintJson = createReactEslintJson(
-      options.projectRoot,
-      options.setParserOptionsProject
-    );
-
     updateJson(
       host,
       joinPathFragments(options.projectRoot, '.eslintrc.json'),
-      () => reactEslintJson
+      extendReactEslintJson
     );
 
     let installTask = () => {};

--- a/packages/react/src/utils/lint.ts
+++ b/packages/react/src/utils/lint.ts
@@ -26,6 +26,9 @@ export const extendReactEslintJson = (json: Linter.Config) => {
   };
 };
 
+/**
+ * @deprecated Use {@link extendReactEslintJson} instead.
+ */
 export const createReactEslintJson = (
   projectRoot: string,
   setParserOptionsProject: boolean


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
For all react-driven project scaffolding, we use `createReactEslintJson` that re-generates the eslint config.
This new config overrides the auto-generated eslint config and gets in the way of standalone/root functionality.

## Expected Behavior
The react-project should only extend the existing eslint config with necessary `extends` + any other specific configs,  instead of replacing the entire config.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
