### PR TITLE
fix(linter): ensure projectRootMappings exist when running eslint directly

### DIFF
--- a/packages/eslint-plugin-nx/src/utils/project-graph-utils.ts
+++ b/packages/eslint-plugin-nx/src/utils/project-graph-utils.ts
@@ -11,7 +11,11 @@ export function ensureGlobalProjectGraph(ruleName: string) {
    * Only reuse graph when running from terminal
    * Enforce every IDE change to get a fresh nxdeps.json
    */
-  if (!(global as any).projectGraph || !isTerminalRun()) {
+  if (
+    !(global as any).projectGraph ||
+    !(global as any).projectRootMappings ||
+    !isTerminalRun()
+  ) {
     const nxJson = readNxJson();
     (global as any).workspaceLayout = nxJson.workspaceLayout;
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When running eslint directly via `npx eslint .` the `projectRootMappings` may not be available in the global JS object causing linter to fail on project discovery.

## Expected Behavior
The `ensureGlobalProjectGraph` needs to confirm both graph and mapping exists before moving on.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
