### PR TITLE
fix(bundling): if bundler is vite unitTestRunner is vitest

### DIFF
--- a/packages/react/src/generators/application/application.ts
+++ b/packages/react/src/generators/application/application.ts
@@ -116,6 +116,7 @@ export async function applicationGenerator(host: Tree, schema: Schema) {
 
   const cypressTask = await addCypress(host, options);
   tasks.push(cypressTask);
+
   if (options.unitTestRunner === 'jest') {
     const jestTask = await addJest(host, options);
     tasks.push(jestTask);

--- a/packages/react/src/generators/application/lib/normalize-options.ts
+++ b/packages/react/src/generators/application/lib/normalize-options.ts
@@ -40,6 +40,10 @@ export function normalizeOptions(
 
   assertValidStyle(options.style);
 
+  if (options.bundler === 'vite') {
+    options.unitTestRunner = 'vitest';
+  }
+
   const normalized = {
     ...options,
     name: names(options.name).fileName,


### PR DESCRIPTION
If `bundler: 'vite'` for React make sure to set `unitTestRunner` to `vitest` (as is done in the `nrwl/web:app` generator). If `unitTestRunner` is not set to `vitest`, it's set to `jest` by default, and the `nrwl/react:app` generator will attempt to generate `jest` files, but it will not be able to do so, since the `test` target will already be set to `vite` and the generator will exit with error `already has a test architect option`.
