### PR TITLE
fix(angular): use correct ready state for ssr bootstrap

### DIFF
--- a/packages/angular/src/generators/host/__snapshots__/host.spec.ts.snap
+++ b/packages/angular/src/generators/host/__snapshots__/host.spec.ts.snap
@@ -37,7 +37,7 @@ function bootstrap() {
 };
 
 
- if (document.readyState === 'complete') {
+ if (document.readyState !== 'loading') {
    bootstrap();
  } else {
    document.addEventListener('DOMContentLoaded', bootstrap);

--- a/packages/angular/src/generators/setup-ssr/files/src/main.ts__tpl__
+++ b/packages/angular/src/generators/setup-ssr/files/src/main.ts__tpl__
@@ -9,7 +9,7 @@ function bootstrap() {
 };
 
 
- if (document.readyState === 'complete') {
+ if (document.readyState !== 'loading') {
    bootstrap();
  } else {
    document.addEventListener('DOMContentLoaded', bootstrap);

--- a/packages/angular/src/generators/setup-ssr/setup-ssr.spec.ts
+++ b/packages/angular/src/generators/setup-ssr/setup-ssr.spec.ts
@@ -53,7 +53,7 @@ describe('setupSSR', () => {
       };
 
 
-       if (document.readyState === 'complete') {
+       if (document.readyState !== 'loading') {
          bootstrap();
        } else {
          document.addEventListener('DOMContentLoaded', bootstrap);


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

Angular CSR was never bootstrapping after initial SSR Render

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Angular CSR should bootstrap after SSR render

