### PR TITLE
fix(web): removes duplicated nx in the example command

### DIFF
--- a/docs/generated/cli/run-many.md
+++ b/docs/generated/cli/run-many.md
@@ -38,7 +38,7 @@ Test proj1 and proj2 in parallel:
 Test all projects ending with `*-app` except `excluded-app`:
 
 ```terminal
- nx nx run-many --target=test --projects=*-app --exclude excluded-app
+ nx run-many --target=test --projects=*-app --exclude excluded-app
 ```
 
 ## Options


### PR DESCRIPTION
Removes the extra `nx` in the `run-many` example to test all projects

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The example has an extra `nx` in there which gives you an error if you copy/paste without properly reading.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
There is only one `nx` command in the example code.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
