### PR TITLE
feat(angular): add static-server target to ssr mf remote

### DIFF
--- a/packages/angular/src/generators/remote/__snapshots__/remote.spec.ts.snap
+++ b/packages/angular/src/generators/remote/__snapshots__/remote.spec.ts.snap
@@ -182,6 +182,26 @@ Object {
 }
 `;
 
+exports[`MF Remote App Generator --ssr should generate the correct files 12`] = `
+"import { Route } from '@angular/router';
+import { RemoteEntryComponent } from './entry.component';
+
+export const remoteRoutes: Route[] = [{ path: '', component: RemoteEntryComponent }];"
+`;
+
+exports[`MF Remote App Generator --ssr should generate the correct files 13`] = `
+Object {
+  "dependsOn": Array [
+    "build",
+    "server",
+  ],
+  "executor": "nx:run-commands",
+  "options": Object {
+    "command": "PORT=4201 node dist/apps/test/server/main.js",
+  },
+}
+`;
+
 exports[`MF Remote App Generator should generate a remote mf app with a host 1`] = `
 "const { withModuleFederation } = require('@nrwl/angular/module-federation');
 const config = require('./module-federation.config');

--- a/packages/angular/src/generators/remote/lib/add-ssr.ts
+++ b/packages/angular/src/generators/remote/lib/add-ssr.ts
@@ -50,6 +50,17 @@ export async function addSsr(
     port,
   };
 
+  project.targets['static-server'] = {
+    dependsOn: ['build', 'server'],
+    executor: 'nx:run-commands',
+    options: {
+      command: `PORT=${port} node ${joinPathFragments(
+        project.targets.server.options.outputPath,
+        'main.js'
+      )}`,
+    },
+  };
+
   updateProjectConfiguration(tree, appName, project);
 
   const installTask = addDependenciesToPackageJson(

--- a/packages/angular/src/generators/remote/remote.spec.ts
+++ b/packages/angular/src/generators/remote/remote.spec.ts
@@ -241,6 +241,10 @@ describe('MF Remote App Generator', () => {
         tree.read(`apps/test/src/app/remote-entry/entry.routes.ts`, 'utf-8')
       ).toMatchSnapshot();
       expect(project.targets.server).toMatchSnapshot();
+      expect(
+        tree.read(`apps/test/src/app/remote-entry/entry.routes.ts`, 'utf-8')
+      ).toMatchSnapshot();
+      expect(project.targets['static-server']).toMatchSnapshot();
     });
   });
 });


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
We currently have no target to simply serve, via node, the built output of an Angular SSR Module Federated Remote application.

This is useful when serving many remotes but only caring about having file watchers attached to some remotes.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Add `static-server` target to perform this functionality.
