### PR TITLE
fix(bundling): remove default values from executors

### DIFF
--- a/docs/generated/packages/vite.json
+++ b/docs/generated/packages/vite.json
@@ -161,29 +161,18 @@
             "description": "Path to the proxy configuration file.",
             "x-completion-type": "file"
           },
-          "port": {
-            "type": "number",
-            "description": "Port to listen on.",
-            "default": 4200
-          },
+          "port": { "type": "number", "description": "Port to listen on." },
           "host": {
             "description": "Specify which IP addresses the server should listen on.",
-            "default": "localhost",
             "oneOf": [{ "type": "boolean" }, { "type": "string" }]
           },
-          "https": {
-            "type": "boolean",
-            "description": "Serve using HTTPS.",
-            "default": false
-          },
+          "https": { "type": "boolean", "description": "Serve using HTTPS." },
           "hmr": {
             "description": "Enable hot module replacement. For more options, use the 'hmr' option in the Vite configuration file.",
-            "type": "boolean",
-            "default": true
+            "type": "boolean"
           },
           "open": {
             "description": "Automatically open the app in the browser on server start. When the value is a string, it will be used as the URL's pathname.",
-            "default": false,
             "oneOf": [{ "type": "boolean" }, { "type": "string" }]
           },
           "cors": {
@@ -198,12 +187,10 @@
           "mode": {
             "type": "string",
             "description": "Mode to run the server in.",
-            "enum": ["production", "development"],
-            "default": "development"
+            "enum": ["production", "development"]
           },
           "clearScreen": {
             "description": "Set to false to prevent Vite from clearing the terminal screen when logging certain messages.",
-            "default": true,
             "type": "boolean"
           }
         },
@@ -235,18 +222,13 @@
           },
           "baseHref": {
             "type": "string",
-            "description": "Base url for the application being built."
+            "description": "Base public path when served in development or production.",
+            "alias": "base"
           },
           "proxyConfig": {
             "type": "string",
             "description": "Path to the proxy configuration file.",
             "x-completion-type": "file"
-          },
-          "tsConfig": {
-            "type": "string",
-            "description": "The name of the Typescript configuration file.",
-            "x-completion-type": "file",
-            "x-completion-glob": "tsconfig.*.json"
           },
           "configFile": {
             "type": "string",
@@ -278,12 +260,10 @@
           },
           "sourcemap": {
             "description": "Output sourcemaps. Use 'hidden' for use with error reporting tools without generating sourcemap comment.",
-            "default": true,
             "oneOf": [{ "type": "boolean" }, { "type": "string" }]
           },
           "minify": {
             "description": "Output sourcemaps. Use 'hidden' for use with error reporting tools without generating sourcemap comment.",
-            "default": "esbuild",
             "oneOf": [{ "type": "boolean" }, { "type": "string" }]
           },
           "manifest": {
@@ -302,8 +282,7 @@
           "mode": {
             "type": "string",
             "description": "Mode to run the build in.",
-            "enum": ["production", "development"],
-            "default": "production"
+            "enum": ["production", "development"]
           }
         },
         "definitions": {

--- a/packages/vite/src/executors/build/build.impl.ts
+++ b/packages/vite/src/executors/build/build.impl.ts
@@ -1,7 +1,7 @@
 import 'dotenv/config';
 import { ExecutorContext, logger } from '@nrwl/devkit';
 import { build, InlineConfig } from 'vite';
-import { getBuildConfig } from '../../utils/options-utils';
+import { getBuildAndSharedConfig } from '../../utils/options-utils';
 import { ViteBuildExecutorOptions } from './schema';
 import { copyAssets } from '@nrwl/js';
 import { existsSync } from 'fs';
@@ -14,7 +14,9 @@ export default async function viteBuildExecutor(
   const projectRoot = context.workspace.projects[context.projectName].root;
 
   logger.info(`NX Vite build starting ...`);
-  const buildResult = await runInstance(await getBuildConfig(options, context));
+  const buildResult = await runInstance(
+    await getBuildAndSharedConfig(options, context)
+  );
   logger.info(`NX Vite build finished ...`);
   logger.info(`NX Vite files available in ${options.outputPath}`);
 

--- a/packages/vite/src/executors/build/schema.d.ts
+++ b/packages/vite/src/executors/build/schema.d.ts
@@ -3,7 +3,6 @@ export interface ViteBuildExecutorOptions {
   outputPath: string;
   baseHref?: string;
   proxyConfig?: string;
-  tsConfig?: string;
   configFile?: string;
   fileReplacements?: FileReplacement[];
   sourcemap?: boolean | 'inline' | 'hidden';

--- a/packages/vite/src/executors/build/schema.json
+++ b/packages/vite/src/executors/build/schema.json
@@ -19,18 +19,13 @@
     },
     "baseHref": {
       "type": "string",
-      "description": "Base url for the application being built."
+      "description": "Base public path when served in development or production.",
+      "alias": "base"
     },
     "proxyConfig": {
       "type": "string",
       "description": "Path to the proxy configuration file.",
       "x-completion-type": "file"
-    },
-    "tsConfig": {
-      "type": "string",
-      "description": "The name of the Typescript configuration file.",
-      "x-completion-type": "file",
-      "x-completion-glob": "tsconfig.*.json"
     },
     "configFile": {
       "type": "string",
@@ -62,7 +57,6 @@
     },
     "sourcemap": {
       "description": "Output sourcemaps. Use 'hidden' for use with error reporting tools without generating sourcemap comment.",
-      "default": true,
       "oneOf": [
         {
           "type": "boolean"
@@ -74,7 +68,6 @@
     },
     "minify": {
       "description": "Output sourcemaps. Use 'hidden' for use with error reporting tools without generating sourcemap comment.",
-      "default": "esbuild",
       "oneOf": [
         {
           "type": "boolean"
@@ -114,8 +107,7 @@
     "mode": {
       "type": "string",
       "description": "Mode to run the build in.",
-      "enum": ["production", "development"],
-      "default": "production"
+      "enum": ["production", "development"]
     }
   },
   "definitions": {

--- a/packages/vite/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/vite/src/executors/dev-server/dev-server.impl.ts
@@ -3,7 +3,7 @@ import { ExecutorContext } from '@nrwl/devkit';
 import { createServer, InlineConfig, mergeConfig, ViteDevServer } from 'vite';
 
 import {
-  getBuildConfig,
+  getBuildAndSharedConfig,
   getBuildTargetOptions,
   getServerOptions,
 } from '../../utils/options-utils';
@@ -21,7 +21,7 @@ export default async function* viteDevServerExecutor(
   } as ViteDevServerExecutorOptions & ViteBuildExecutorOptions;
 
   const serverConfig: InlineConfig = mergeConfig(
-    await getBuildConfig(mergedOptions, context),
+    await getBuildAndSharedConfig(mergedOptions, context),
     {
       server: getServerOptions(mergedOptions, context),
     } as InlineConfig

--- a/packages/vite/src/executors/dev-server/schema.json
+++ b/packages/vite/src/executors/dev-server/schema.json
@@ -27,12 +27,10 @@
     },
     "port": {
       "type": "number",
-      "description": "Port to listen on.",
-      "default": 4200
+      "description": "Port to listen on."
     },
     "host": {
       "description": "Specify which IP addresses the server should listen on.",
-      "default": "localhost",
       "oneOf": [
         {
           "type": "boolean"
@@ -44,17 +42,14 @@
     },
     "https": {
       "type": "boolean",
-      "description": "Serve using HTTPS.",
-      "default": false
+      "description": "Serve using HTTPS."
     },
     "hmr": {
       "description": "Enable hot module replacement. For more options, use the 'hmr' option in the Vite configuration file.",
-      "type": "boolean",
-      "default": true
+      "type": "boolean"
     },
     "open": {
       "description": "Automatically open the app in the browser on server start. When the value is a string, it will be used as the URL's pathname.",
-      "default": false,
       "oneOf": [
         {
           "type": "boolean"
@@ -76,12 +71,10 @@
     "mode": {
       "type": "string",
       "description": "Mode to run the server in.",
-      "enum": ["production", "development"],
-      "default": "development"
+      "enum": ["production", "development"]
     },
     "clearScreen": {
       "description": "Set to false to prevent Vite from clearing the terminal screen when logging certain messages.",
-      "default": true,
       "type": "boolean"
     }
   },

--- a/packages/vite/src/generators/vitest/vitest.spec.ts
+++ b/packages/vite/src/generators/vitest/vitest.spec.ts
@@ -109,6 +109,11 @@ describe('vitest generator', () => {
               
               
               export default defineConfig({
+                
+            server:{
+              port: 4200,
+              host: 'localhost',
+            },
                 plugins: [
                   
                   react(),
@@ -145,6 +150,11 @@ describe('vitest generator', () => {
               
               
               export default defineConfig({
+                
+            server:{
+              port: 4200,
+              host: 'localhost',
+            },
                 plugins: [
                   
                   react(),

--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -406,7 +406,13 @@ export function writeViteConfig(tree: Tree, options: Schema) {
             }]
           }
         },`
-    : '';
+    : ``;
+
+  const serverOption = `
+    server:{
+      port: 4200,
+      host: 'localhost',
+    },`;
 
   switch (options.uiFramework) {
     case 'react':
@@ -422,6 +428,7 @@ ${options.includeVitest ? '/// <reference types="vitest" />' : ''}
       }
       
       export default defineConfig({
+        ${serverOption}
         plugins: [
           ${options.includeLib ? dtsPlugin : ''}
           react(),
@@ -447,6 +454,7 @@ ${options.includeVitest ? '/// <reference types="vitest" />' : ''}
       }
       
       export default defineConfig({
+        ${serverOption}
         plugins: [
           ${options.includeLib ? dtsPlugin : ''}
           tsconfigPaths({

--- a/packages/vite/src/utils/options-utils.ts
+++ b/packages/vite/src/utils/options-utils.ts
@@ -9,19 +9,17 @@ import { existsSync } from 'fs';
 import { join, relative } from 'path';
 import {
   BuildOptions,
-  defineConfig,
   InlineConfig,
   mergeConfig,
   searchForWorkspaceRoot,
   ServerOptions,
   UserConfig,
-  UserConfigFn,
 } from 'vite';
 import { ViteDevServerExecutorOptions } from '../executors/dev-server/schema';
 import replaceFiles from '../../plugins/rollup-replace-files.plugin';
 import { ViteBuildExecutorOptions } from '../executors/build/schema';
 
-export async function getBuildConfig(
+export async function getBuildAndSharedConfig(
   options:
     | (ViteDevServerExecutorOptions & ViteBuildExecutorOptions)
     | ViteBuildExecutorOptions,
@@ -29,13 +27,10 @@ export async function getBuildConfig(
 ): Promise<InlineConfig> {
   const projectRoot = context.workspace.projects[context.projectName].root;
 
-  const userConfig: UserConfig = await getUserConfig(
-    options as ViteDevServerExecutorOptions & ViteBuildExecutorOptions,
-    context,
-    projectRoot
-  );
-
-  return mergeConfig(userConfig, {
+  return mergeConfig({}, {
+    mode: options.mode,
+    root: projectRoot,
+    base: options.baseHref,
     configFile: normalizeConfigFilePath(
       options.configFile,
       context.root,
@@ -61,33 +56,6 @@ export function normalizeConfigFilePath(
     : existsSync(joinPathFragments(`${projectRoot}/vite.config.js`))
     ? joinPathFragments(`${projectRoot}/vite.config.js`)
     : undefined;
-}
-
-export function normalizeTsConfigPath(
-  tsConfig: string,
-  workspaceRoot: string
-): string {
-  return tsConfig
-    ? joinPathFragments(`${workspaceRoot}/${tsConfig}`)
-    : undefined;
-}
-
-export async function getUserConfig(
-  options: ViteDevServerExecutorOptions & ViteBuildExecutorOptions,
-  context: ExecutorContext,
-  projectRoot: string
-): Promise<UserConfig> {
-  const baseUserConfig: UserConfigFn = (await defineConfig(() => {
-    return {
-      base: options.baseHref ?? '/',
-      root: projectRoot,
-      tsConfig: normalizeTsConfigPath(options.tsConfig, context.root),
-    };
-  })) as UserConfigFn;
-  return baseUserConfig({
-    command: 'build',
-    mode: options['configurationName'],
-  });
 }
 
 export function getServerOptions(
@@ -122,7 +90,6 @@ export function getServerOptions(
     open: options.open,
     cors: options.cors,
     logLevel: options.logLevel,
-    mode: options.mode,
     clearScreen: options.clearScreen,
   };
 
@@ -159,7 +126,6 @@ export function getViteBuildOptions(
     manifest: options.manifest,
     ssrManifest: options.ssrManifest,
     logLevel: options.logLevel,
-    mode: options.mode,
   };
 
   return buildOptions;


### PR DESCRIPTION
Fixes #13350

* removed default values from executors
* cleaned up unnecessary things that the executor was taking into account as options
* use `baseHref` correctly
* removed `tsConfig` option from schema, since it was not used/needed
