### PR TITLE
docs(nxdev): change connect-to-nx-cloud command

### DIFF
--- a/docs/shared/core-features/distribute-task-execution.md
+++ b/docs/shared/core-features/distribute-task-execution.md
@@ -21,7 +21,7 @@ Find more information in this [detailed guide to improve your worst case CI time
 To distribute your task execution, you need to (1) connect to Nx Cloud and (2) enable DTE in your CI workflow. Each of these steps can be enabled with a single command:
 
 ```shell title="1. Connect to Nx Cloud"
-nx connect-to-nx-cloud
+nx connect
 ```
 
 {% callout type="note" title="Use the latest version of Nx Cloud" %}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
- docs specify `nx-connect-to-nx-cloud` to setup nx cloud integration here:
https://nx.dev/core-features/distribute-task-execution#set-up

Except this doesn't seem to be a command anymore.

## Expected Behavior
- `nx connect` seems to be the command now.

## Related Issue(s)

Fixes #13385
