### PR TITLE
fix(core): escape scripts with delimiters for nx exec

### DIFF
--- a/e2e/nx-run/src/run.test.ts
+++ b/e2e/nx-run/src/run.test.ts
@@ -1,7 +1,6 @@
 import {
   checkFilesExist,
   cleanupProject,
-  e2eCwd,
   fileExists,
   isWindows,
   newProject,
@@ -466,6 +465,7 @@ describe('Nx Running Tests', () => {
           version: '0.0.1',
           scripts: {
             build: 'nx exec -- echo HELLO',
+            'build:option': 'nx exec -- echo HELLO WITH OPTION',
           },
         })
       );
@@ -481,6 +481,12 @@ describe('Nx Running Tests', () => {
       });
       expect(output).toContain('HELLO');
       expect(output).toContain(`nx run ${pkg}:build`);
+    });
+
+    it('should work for npm scripts with delimiter', () => {
+      const output = runCommand('npm run build:option', { cwd: pkgRoot });
+      expect(output).toContain('HELLO WITH OPTION');
+      expect(output).toContain(`nx run ${pkg}:"build:option"`);
     });
 
     it('should pass overrides', () => {

--- a/packages/nx/src/command-line/exec.ts
+++ b/packages/nx/src/command-line/exec.ts
@@ -52,9 +52,10 @@ async function runScriptAsNxTarget(argv: string[]) {
     providedArgs.length === argv.length ? [] : argv.slice(providedArgs.length);
 
   const pm = getPackageManagerCommand();
+  // `targetName` might be an npm script with `:` like: `start:dev`, `start:debug`.
   let command = `${
     pm.exec
-  } nx run ${projectName}:\"${targetName}\" ${extraArgs.join(' ')}`;
+  } nx run ${projectName}:\\\"${targetName}\\\" ${extraArgs.join(' ')}`;
   return execSync(command, { stdio: 'inherit' });
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
If a script in `package.json` contains delimiters like `:`, `nx exec` doesn't work correctly
```json
"scripts": {
   "start": "nest start",
   "start:dev": "nx exec -- nest start --watch"
}
```

Running `npm run start:dev` invokes `nx exec` then `nx run myapp:start` (`start:dev` is stripped down to `start`)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Running `npm run start:dev` should invoke `nx exec` which invokes `nx run myapp:"start:dev"`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
