### PR TITLE
fix(core): nx exec should work with compound commands

### DIFF
--- a/e2e/nx-run/src/run.test.ts
+++ b/e2e/nx-run/src/run.test.ts
@@ -466,6 +466,7 @@ describe('Nx Running Tests', () => {
           scripts: {
             build: 'nx exec -- echo HELLO',
             'build:option': 'nx exec -- echo HELLO WITH OPTION',
+            compound: 'nx exec -- echo HELLO && echo COMPOUND',
           },
         })
       );
@@ -487,6 +488,13 @@ describe('Nx Running Tests', () => {
       const output = runCommand('npm run build:option', { cwd: pkgRoot });
       expect(output).toContain('HELLO WITH OPTION');
       expect(output).toContain(`nx run ${pkg}:"build:option"`);
+    });
+
+    it('should support compound scripts', () => {
+      const output = runCommand('npm run compound test', { cwd: pkgRoot });
+      expect(output).toContain('HELLO\n');
+      expect(output).toContain('COMPOUND TEST');
+      expect(output).not.toContain('HELLO COMPOUND');
     });
 
     it('should pass overrides', () => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The command to feed to `execSync` is rebuilt from scriptArgV at runtime. This means that anything that didn't get fed to Nx is missed. Most notably, compound commands (i.e. ones which contain `&&`, `||`, or other special shell things) are frequently missed entirely with only the first portion ran via Nx

## Expected Behavior
Compound commands run as expected under Nx.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
