### PR TITLE
docs(angular): update incremental builds requirements docs and ng-packagr-lite description

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -2509,7 +2509,7 @@
         "outputCapture": "direct-nodejs",
         "$schema": "http://json-schema.org/schema",
         "title": "ng-packagr Target",
-        "description": "ng-packagr target options for Build Architect. Use to build library projects.",
+        "description": "Builds a library with support for incremental builds.\nThis executor is meant to be used with buildable libraries in an incremental build scenario. It is similar to the `@nrwl/angular:package` executor but with some key differences:\n- It doesn't run `ngcc` automatically (`ngcc` needs to be run separately beforehand if needed, this can be done in a `postinstall` hook on `package.json`).\n- It only produces ESM2020 bundles.\n- It doesn't generate package exports in the `package.json`.",
         "cli": "nx",
         "type": "object",
         "presets": [
@@ -2561,7 +2561,7 @@
         "additionalProperties": false,
         "required": ["project"]
       },
-      "description": "Builds a library with support for incremental builds.",
+      "description": "Builds a library with support for incremental builds.\nThis executor is meant to be used with buildable libraries in an incremental build scenario. It is similar to the `@nrwl/angular:package` executor but with some key differences:\n- It doesn't run `ngcc` automatically (`ngcc` needs to be run separately beforehand if needed, this can be done in a `postinstall` hook on `package.json`).\n- It only produces ESM2020 bundles.\n- It doesn't generate package exports in the `package.json`.",
       "aliases": [],
       "hidden": false,
       "path": "/packages/angular/src/executors/ng-packagr-lite/schema.json"

--- a/docs/shared/guides/setup-incremental-builds-angular.md
+++ b/docs/shared/guides/setup-incremental-builds-angular.md
@@ -9,9 +9,10 @@ Incremental builds requires Nx version 10.4.0 or later.
 
 ## Requirements
 
-It’s required that you run the Angular compatibility compiler (`ngcc`) after every package installation if you have Ivy
-enabled. This comes configured by default in every Nx workspace. The incremental build relies on the fact that `ngcc`
-must have already been run. You can check your `package.json` and make sure you have the following:
+If your library consumes any Angular package that has not been compiled with Ivy, you must ensure the
+Angular compatibility compiler (`ngcc`) has run before building the library. The incremental build relies
+on the fact that `ngcc` must have already been run. One way to do this is to run `ngcc` after every package
+installation. You can check your `package.json` and make sure you have the following:
 
 ```jsonc {% fileName="package.json" %}
 {

--- a/packages/angular/executors.json
+++ b/packages/angular/executors.json
@@ -8,7 +8,7 @@
     "ng-packagr-lite": {
       "implementation": "./src/executors/ng-packagr-lite/ng-packagr-lite.impl",
       "schema": "./src/executors/ng-packagr-lite/schema.json",
-      "description": "Builds a library with support for incremental builds."
+      "description": "Builds a library with support for incremental builds.\nThis executor is meant to be used with buildable libraries in an incremental build scenario. It is similar to the `@nrwl/angular:package` executor but with some key differences:\n- It doesn't run `ngcc` automatically (`ngcc` needs to be run separately beforehand if needed, this can be done in a `postinstall` hook on `package.json`).\n- It only produces ESM2020 bundles.\n- It doesn't generate package exports in the `package.json`."
     },
     "package": {
       "implementation": "./src/executors/package/package.impl",
@@ -30,7 +30,7 @@
     "ng-packagr-lite": {
       "implementation": "./src/executors/ng-packagr-lite/compat",
       "schema": "./src/executors/ng-packagr-lite/schema.json",
-      "description": "Builds a library with support for incremental builds."
+      "description": "Builds a library with support for incremental builds.\nThis executor is meant to be used with buildable libraries in an incremental build scenario. It is similar to the `@nrwl/angular:package` executor but with some key differences:\n- It doesn't run `ngcc` automatically (`ngcc` needs to be run separately beforehand if needed, this can be done in a `postinstall` hook on `package.json`)\n- It only produces ESM2020 bundles\n- It doesn't generate package exports in the `package.json`"
     },
     "package": {
       "implementation": "./src/executors/package/compat",

--- a/packages/angular/src/executors/ng-packagr-lite/schema.json
+++ b/packages/angular/src/executors/ng-packagr-lite/schema.json
@@ -3,7 +3,7 @@
   "outputCapture": "direct-nodejs",
   "$schema": "http://json-schema.org/schema",
   "title": "ng-packagr Target",
-  "description": "ng-packagr target options for Build Architect. Use to build library projects.",
+  "description": "Builds a library with support for incremental builds.\nThis executor is meant to be used with buildable libraries in an incremental build scenario. It is similar to the `@nrwl/angular:package` executor but with some key differences:\n- It doesn't run `ngcc` automatically (`ngcc` needs to be run separately beforehand if needed, this can be done in a `postinstall` hook on `package.json`).\n- It only produces ESM2020 bundles.\n- It doesn't generate package exports in the `package.json`.",
   "cli": "nx",
   "type": "object",
   "presets": [


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The incremental builds requirements section mentions that the `postinstall` script with the `ngcc` command is generated with the workspace, which is no longer the case. Also, the `ng-packagr-lite` executor docs don't mention the differences compared to a "full" `ng-packagr` executor.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The incremental builds requirements section should mention that `ngcc` should be run if needed and advise how to do so. The `ng-packagr-lite` executor docs should better describe the executor and the differences compared to a "full" `ng-packagr` executor.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #13421 
