### PR TITLE
fix(angular): make server build depend on browser build

### DIFF
--- a/packages/angular/src/generators/host/__snapshots__/host.spec.ts.snap
+++ b/packages/angular/src/generators/host/__snapshots__/host.spec.ts.snap
@@ -166,6 +166,9 @@ Object {
     },
   },
   "defaultConfiguration": "production",
+  "dependsOn": Array [
+    "build",
+  ],
   "executor": "@nrwl/angular:webpack-server",
   "options": Object {
     "customWebpackConfig": Object {

--- a/packages/angular/src/generators/remote/__snapshots__/remote.spec.ts.snap
+++ b/packages/angular/src/generators/remote/__snapshots__/remote.spec.ts.snap
@@ -170,6 +170,9 @@ Object {
     },
   },
   "defaultConfiguration": "production",
+  "dependsOn": Array [
+    "build",
+  ],
   "executor": "@nrwl/angular:webpack-server",
   "options": Object {
     "customWebpackConfig": Object {

--- a/packages/angular/src/generators/setup-ssr/__snapshots__/setup-ssr.spec.ts.snap
+++ b/packages/angular/src/generators/setup-ssr/__snapshots__/setup-ssr.spec.ts.snap
@@ -13,6 +13,9 @@ Object {
     },
   },
   "defaultConfiguration": "production",
+  "dependsOn": Array [
+    "build",
+  ],
   "executor": "@angular-devkit/build-angular:server",
   "options": Object {
     "main": "apps/app1/server.ts",
@@ -104,6 +107,9 @@ Object {
     },
   },
   "defaultConfiguration": "production",
+  "dependsOn": Array [
+    "build",
+  ],
   "executor": "@angular-devkit/build-angular:server",
   "options": Object {
     "main": "apps/app1/server.ts",

--- a/packages/angular/src/generators/setup-ssr/lib/update-project-config.ts
+++ b/packages/angular/src/generators/setup-ssr/lib/update-project-config.ts
@@ -15,6 +15,7 @@ export function updateProjectConfig(tree: Tree, schema: Schema) {
     projectConfig.targets.build.configurations?.production?.fileReplacements;
 
   projectConfig.targets.server = {
+    dependsOn: ['build'],
     executor: '@angular-devkit/build-angular:server',
     options: {
       outputPath: `dist/${projectConfig.root}/server`,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Server _does_ depend on a browser build existing but it doesn't depend on it via Nx

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
server build should depend on browser build
