### PR TITLE
docs(angular): update docs generation to account for builders

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -2711,6 +2711,1236 @@
       "aliases": [],
       "hidden": false,
       "path": "/packages/angular/src/executors/file-server/schema.json"
+    },
+    {
+      "name": "webpack-browser",
+      "implementation": "/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts",
+      "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
+        "$schema": "http://json-schema.org/draft-07/schema",
+        "title": "Schema for Webpack Browser",
+        "description": "The webpack-browser executor is very similar to the standard browser builder provided by the Angular Devkit. It allows you to build your Angular application to a build artifact that can be hosted online. There are some key differences:   \n- Supports Custom Webpack Configurations  \n- Supports Incremental Building",
+        "examplesFile": "##### Using a custom webpack configuration\n\nThe executor supports providing a path to a custom webpack configuration. This allows you to customize how your Angular application is built. It currently supports the following types of webpack configurations:\n\n- `object`\n- `Function`\n- `Promise<object|Function>`\n\nThe executor will merge the provided configuration with the webpack configuration that Angular Devkit uses. The merge order is:\n\n- Angular Devkit Configuration\n- Provided Configuration\n\nTo use a custom webpack configuration when building your Angular application, change the `build` target in your `project.json` to match the following:\n\n```typescript\n\"build\": {\n    \"executor\": \"@nrwl/angular:webpack-browser\",\n    \"options\": {\n        ...\n        \"customWebpackConfig\": {\n          \"path\": \"apps/appName/webpack.config.js\"\n        }\n    }\n}\n```\n\n##### Incrementally Building your Application\n\nThe executor supports incrementally building your Angular application by building the workspace libraries it depends on _(that have been marked as buildable)_ and then building your application using the built source of the libraries.\n\nThis can improve build time as the building of the workspace libraries can be cached, meaning they only have to be rebuilt if they have changed.\n\n> Note: There may be some additional overhead in the linking of the built libraries' sources which may reduce the overall improvement in build time. Therefore this approach only benefits large applications and would likely have a negative impact on small and medium applications.  \n> You can read more about when to use incremental builds [here](/more-concepts/incremental-builds#when-should-i-use-incremental-builds).\n\nTo allow your Angular application to take advantage of incremental building, change the `build` target in your `project.json` to match the following:\n\n```typescript\n\"build\": {\n    \"executor\": \"@nrwl/angular:webpack-browser\",\n    \"options\": {\n        ...\n        \"buildLibsFromSource\": false\n    }\n}\n```\n",
+        "type": "object",
+        "presets": [
+          {
+            "name": "Custom Webpack Configuration",
+            "keys": [
+              "outputs",
+              "outputPath",
+              "index",
+              "main",
+              "polyfills",
+              "tsConfig",
+              "assets",
+              "styles",
+              "scripts",
+              "customWebpackConfig"
+            ]
+          }
+        ],
+        "properties": {
+          "assets": {
+            "type": "array",
+            "description": "List of static application assets.",
+            "default": [],
+            "items": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "followSymlinks": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Allow glob patterns to follow symlink directories. This allows subdirectories of the symlink to be searched."
+                    },
+                    "glob": {
+                      "type": "string",
+                      "description": "The pattern to match."
+                    },
+                    "input": {
+                      "type": "string",
+                      "description": "The input directory path in which to apply 'glob'. Defaults to the project root."
+                    },
+                    "ignore": {
+                      "description": "An array of globs to ignore.",
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "output": {
+                      "type": "string",
+                      "description": "Absolute path within the output."
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": ["glob", "input", "output"]
+                },
+                { "type": "string" }
+              ]
+            }
+          },
+          "main": {
+            "type": "string",
+            "description": "The full path for the main entry point to the app, relative to the current workspace."
+          },
+          "polyfills": {
+            "description": "Polyfills to be included in the build.",
+            "oneOf": [
+              {
+                "type": "array",
+                "description": "A list of polyfills to include in the build. Can be a full path for a file, relative to the current workspace or module specifier. Example: 'zone.js'.",
+                "items": { "type": "string", "uniqueItems": true },
+                "default": []
+              },
+              {
+                "type": "string",
+                "description": "The full path for the polyfills file, relative to the current workspace or a module specifier. Example: 'zone.js'."
+              }
+            ]
+          },
+          "tsConfig": {
+            "type": "string",
+            "description": "The full path for the TypeScript configuration file, relative to the current workspace."
+          },
+          "scripts": {
+            "description": "Global scripts to be included in the build.",
+            "type": "array",
+            "default": [],
+            "items": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "input": {
+                      "type": "string",
+                      "description": "The file to include.",
+                      "pattern": "\\.[cm]?jsx?$"
+                    },
+                    "bundleName": {
+                      "type": "string",
+                      "pattern": "^[\\w\\-.]*$",
+                      "description": "The bundle name for this extra entry point."
+                    },
+                    "inject": {
+                      "type": "boolean",
+                      "description": "If the bundle will be referenced in the HTML file.",
+                      "default": true
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": ["input"]
+                },
+                {
+                  "type": "string",
+                  "description": "The file to include.",
+                  "pattern": "\\.[cm]?jsx?$"
+                }
+              ]
+            }
+          },
+          "styles": {
+            "description": "Global styles to be included in the build.",
+            "type": "array",
+            "default": [],
+            "items": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "input": {
+                      "type": "string",
+                      "description": "The file to include.",
+                      "pattern": "\\.(?:css|scss|sass|less|styl)$"
+                    },
+                    "bundleName": {
+                      "type": "string",
+                      "pattern": "^[\\w\\-.]*$",
+                      "description": "The bundle name for this extra entry point."
+                    },
+                    "inject": {
+                      "type": "boolean",
+                      "description": "If the bundle will be referenced in the HTML file.",
+                      "default": true
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": ["input"]
+                },
+                {
+                  "type": "string",
+                  "description": "The file to include.",
+                  "pattern": "\\.(?:css|scss|sass|less|styl)$"
+                }
+              ]
+            }
+          },
+          "inlineStyleLanguage": {
+            "description": "The stylesheet language to use for the application's inline component styles.",
+            "type": "string",
+            "default": "css",
+            "enum": ["css", "less", "sass", "scss"]
+          },
+          "stylePreprocessorOptions": {
+            "description": "Options to pass to style preprocessors.",
+            "type": "object",
+            "properties": {
+              "includePaths": {
+                "description": "Paths to include. Paths will be resolved to project root.",
+                "type": "array",
+                "items": { "type": "string" },
+                "default": []
+              }
+            },
+            "additionalProperties": false
+          },
+          "optimization": {
+            "description": "Enables optimization of the build output. Including minification of scripts and styles, tree-shaking, dead-code elimination, inlining of critical CSS and fonts inlining. For more information, see https://angular.io/guide/workspace-config#optimization-configuration.",
+            "x-user-analytics": 16,
+            "default": true,
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "scripts": {
+                    "type": "boolean",
+                    "description": "Enables optimization of the scripts output.",
+                    "default": true
+                  },
+                  "styles": {
+                    "description": "Enables optimization of the styles output.",
+                    "default": true,
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "minify": {
+                            "type": "boolean",
+                            "description": "Minify CSS definitions by removing extraneous whitespace and comments, merging identifiers and minimizing values.",
+                            "default": true
+                          },
+                          "inlineCritical": {
+                            "type": "boolean",
+                            "description": "Extract and inline critical CSS definitions to improve first paint time.",
+                            "default": true
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      { "type": "boolean" }
+                    ]
+                  },
+                  "fonts": {
+                    "description": "Enables optimization for fonts. This option requires internet access. `HTTPS_PROXY` environment variable can be used to specify a proxy server.",
+                    "default": true,
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "inline": {
+                            "type": "boolean",
+                            "description": "Reduce render blocking requests by inlining external Google Fonts and Adobe Fonts CSS definitions in the application's HTML index file. This option requires internet access. `HTTPS_PROXY` environment variable can be used to specify a proxy server.",
+                            "default": true
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      { "type": "boolean" }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              },
+              { "type": "boolean" }
+            ]
+          },
+          "fileReplacements": {
+            "description": "Replace compilation source files with other compilation source files in the build.",
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "src": {
+                      "type": "string",
+                      "pattern": "\\.(([cm]?j|t)sx?|json)$"
+                    },
+                    "replaceWith": {
+                      "type": "string",
+                      "pattern": "\\.(([cm]?j|t)sx?|json)$"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": ["src", "replaceWith"]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "replace": {
+                      "type": "string",
+                      "pattern": "\\.(([cm]?j|t)sx?|json)$"
+                    },
+                    "with": {
+                      "type": "string",
+                      "pattern": "\\.(([cm]?j|t)sx?|json)$"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": ["replace", "with"]
+                }
+              ]
+            },
+            "default": []
+          },
+          "outputPath": {
+            "type": "string",
+            "description": "The full path for the new output directory, relative to the current workspace.\n\nBy default, writes output to a folder named dist/ in the current project."
+          },
+          "resourcesOutputPath": {
+            "type": "string",
+            "description": "The path where style resources will be placed, relative to outputPath.",
+            "default": ""
+          },
+          "aot": {
+            "type": "boolean",
+            "description": "Build using Ahead of Time compilation.",
+            "x-user-analytics": 13,
+            "default": true
+          },
+          "sourceMap": {
+            "description": "Output source maps for scripts and styles. For more information, see https://angular.io/guide/workspace-config#source-map-configuration.",
+            "default": false,
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "scripts": {
+                    "type": "boolean",
+                    "description": "Output source maps for all scripts.",
+                    "default": true
+                  },
+                  "styles": {
+                    "type": "boolean",
+                    "description": "Output source maps for all styles.",
+                    "default": true
+                  },
+                  "hidden": {
+                    "type": "boolean",
+                    "description": "Output source maps used for error reporting tools.",
+                    "default": false
+                  },
+                  "vendor": {
+                    "type": "boolean",
+                    "description": "Resolve vendor packages source maps.",
+                    "default": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              { "type": "boolean" }
+            ]
+          },
+          "vendorChunk": {
+            "type": "boolean",
+            "description": "Generate a seperate bundle containing only vendor libraries. This option should only used for development.",
+            "default": false
+          },
+          "commonChunk": {
+            "type": "boolean",
+            "description": "Generate a seperate bundle containing code used across multiple bundles.",
+            "default": true
+          },
+          "baseHref": {
+            "type": "string",
+            "description": "Base url for the application being built."
+          },
+          "deployUrl": {
+            "type": "string",
+            "description": "URL where files will be deployed.",
+            "x-deprecated": "Use `baseHref` option, `APP_BASE_HREF` DI token or a combination of both instead. For more information, see https://angular.io/guide/deployment#the-deploy-url."
+          },
+          "verbose": {
+            "type": "boolean",
+            "description": "Adds more details to output logging.",
+            "default": false
+          },
+          "progress": {
+            "type": "boolean",
+            "description": "Log progress to the console while building.",
+            "default": true
+          },
+          "i18nMissingTranslation": {
+            "type": "string",
+            "description": "How to handle missing translations for i18n.",
+            "enum": ["warning", "error", "ignore"],
+            "default": "warning"
+          },
+          "i18nDuplicateTranslation": {
+            "type": "string",
+            "description": "How to handle duplicate translations for i18n.",
+            "enum": ["warning", "error", "ignore"],
+            "default": "warning"
+          },
+          "localize": {
+            "description": "Translate the bundles in one or more locales.",
+            "oneOf": [
+              { "type": "boolean", "description": "Translate all locales." },
+              {
+                "type": "array",
+                "description": "List of locales ID's to translate.",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "pattern": "^[a-zA-Z]{2,3}(-[a-zA-Z]{4})?(-([a-zA-Z]{2}|[0-9]{3}))?(-[a-zA-Z]{5,8})?(-x(-[a-zA-Z0-9]{1,8})+)?$"
+                }
+              }
+            ]
+          },
+          "watch": {
+            "type": "boolean",
+            "description": "Run build when files change.",
+            "default": false
+          },
+          "outputHashing": {
+            "type": "string",
+            "description": "Define the output filename cache-busting hashing mode.",
+            "default": "none",
+            "enum": ["none", "all", "media", "bundles"]
+          },
+          "poll": {
+            "type": "number",
+            "description": "Enable and define the file watching poll time period in milliseconds."
+          },
+          "deleteOutputPath": {
+            "type": "boolean",
+            "description": "Delete the output path before building.",
+            "default": true
+          },
+          "preserveSymlinks": {
+            "type": "boolean",
+            "description": "Do not use the real path when resolving modules. If unset then will default to `true` if NodeJS option --preserve-symlinks is set."
+          },
+          "extractLicenses": {
+            "type": "boolean",
+            "description": "Extract all licenses in a separate file.",
+            "default": true
+          },
+          "buildOptimizer": {
+            "type": "boolean",
+            "description": "Enables advanced build optimizations when using the 'aot' option.",
+            "default": true
+          },
+          "namedChunks": {
+            "type": "boolean",
+            "description": "Use file name for lazy loaded chunks.",
+            "default": false
+          },
+          "subresourceIntegrity": {
+            "type": "boolean",
+            "description": "Enables the use of subresource integrity validation.",
+            "default": false
+          },
+          "serviceWorker": {
+            "type": "boolean",
+            "description": "Generates a service worker config for production builds.",
+            "default": false
+          },
+          "ngswConfigPath": {
+            "type": "string",
+            "description": "Path to ngsw-config.json."
+          },
+          "index": {
+            "description": "Configures the generation of the application's HTML index.",
+            "oneOf": [
+              {
+                "type": "string",
+                "description": "The path of a file to use for the application's HTML index. The filename of the specified path will be used for the generated file and will be created in the root of the application's configured output path."
+              },
+              {
+                "type": "object",
+                "description": "",
+                "properties": {
+                  "input": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The path of a file to use for the application's generated HTML index."
+                  },
+                  "output": {
+                    "type": "string",
+                    "minLength": 1,
+                    "default": "index.html",
+                    "description": "The output path of the application's generated HTML index file. The full provided path will be used and will be considered relative to the application's configured output path."
+                  }
+                },
+                "required": ["input"]
+              }
+            ]
+          },
+          "statsJson": {
+            "type": "boolean",
+            "description": "Generates a 'stats.json' file which can be analyzed using tools such as 'webpack-bundle-analyzer'.",
+            "default": false
+          },
+          "budgets": {
+            "description": "Budget thresholds to ensure parts of your application stay within boundaries which you set.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "The type of budget.",
+                  "enum": [
+                    "all",
+                    "allScript",
+                    "any",
+                    "anyScript",
+                    "anyComponentStyle",
+                    "bundle",
+                    "initial"
+                  ]
+                },
+                "name": {
+                  "type": "string",
+                  "description": "The name of the bundle."
+                },
+                "baseline": {
+                  "type": "string",
+                  "description": "The baseline size for comparison."
+                },
+                "maximumWarning": {
+                  "type": "string",
+                  "description": "The maximum threshold for warning relative to the baseline."
+                },
+                "maximumError": {
+                  "type": "string",
+                  "description": "The maximum threshold for error relative to the baseline."
+                },
+                "minimumWarning": {
+                  "type": "string",
+                  "description": "The minimum threshold for warning relative to the baseline."
+                },
+                "minimumError": {
+                  "type": "string",
+                  "description": "The minimum threshold for error relative to the baseline."
+                },
+                "warning": {
+                  "type": "string",
+                  "description": "The threshold for warning relative to the baseline (min & max)."
+                },
+                "error": {
+                  "type": "string",
+                  "description": "The threshold for error relative to the baseline (min & max)."
+                }
+              },
+              "additionalProperties": false,
+              "required": ["type"]
+            },
+            "default": []
+          },
+          "webWorkerTsConfig": {
+            "type": "string",
+            "description": "TypeScript configuration for Web Worker modules."
+          },
+          "crossOrigin": {
+            "type": "string",
+            "description": "Define the crossorigin attribute setting of elements that provide CORS support.",
+            "default": "none",
+            "enum": ["none", "anonymous", "use-credentials"]
+          },
+          "allowedCommonJsDependencies": {
+            "description": "A list of CommonJS packages that are allowed to be used without a build time warning.",
+            "type": "array",
+            "items": { "type": "string" },
+            "default": []
+          },
+          "customWebpackConfig": {
+            "description": "Options for additional webpack configurations.",
+            "type": "object",
+            "properties": {
+              "path": {
+                "description": "Path to additional webpack configuration, relative to the workspace root.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "buildLibsFromSource": {
+            "type": "boolean",
+            "description": "Read buildable libraries from source instead of building them separately.",
+            "default": true
+          }
+        },
+        "additionalProperties": false,
+        "required": ["outputPath", "index", "main", "tsConfig"],
+        "definitions": {
+          "assetPattern": {
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "followSymlinks": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Allow glob patterns to follow symlink directories. This allows subdirectories of the symlink to be searched."
+                  },
+                  "glob": {
+                    "type": "string",
+                    "description": "The pattern to match."
+                  },
+                  "input": {
+                    "type": "string",
+                    "description": "The input directory path in which to apply 'glob'. Defaults to the project root."
+                  },
+                  "ignore": {
+                    "description": "An array of globs to ignore.",
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "output": {
+                    "type": "string",
+                    "description": "Absolute path within the output."
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["glob", "input", "output"]
+              },
+              { "type": "string" }
+            ]
+          },
+          "fileReplacement": {
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "src": {
+                    "type": "string",
+                    "pattern": "\\.(([cm]?j|t)sx?|json)$"
+                  },
+                  "replaceWith": {
+                    "type": "string",
+                    "pattern": "\\.(([cm]?j|t)sx?|json)$"
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["src", "replaceWith"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "replace": {
+                    "type": "string",
+                    "pattern": "\\.(([cm]?j|t)sx?|json)$"
+                  },
+                  "with": {
+                    "type": "string",
+                    "pattern": "\\.(([cm]?j|t)sx?|json)$"
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["replace", "with"]
+              }
+            ]
+          },
+          "budget": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "The type of budget.",
+                "enum": [
+                  "all",
+                  "allScript",
+                  "any",
+                  "anyScript",
+                  "anyComponentStyle",
+                  "bundle",
+                  "initial"
+                ]
+              },
+              "name": {
+                "type": "string",
+                "description": "The name of the bundle."
+              },
+              "baseline": {
+                "type": "string",
+                "description": "The baseline size for comparison."
+              },
+              "maximumWarning": {
+                "type": "string",
+                "description": "The maximum threshold for warning relative to the baseline."
+              },
+              "maximumError": {
+                "type": "string",
+                "description": "The maximum threshold for error relative to the baseline."
+              },
+              "minimumWarning": {
+                "type": "string",
+                "description": "The minimum threshold for warning relative to the baseline."
+              },
+              "minimumError": {
+                "type": "string",
+                "description": "The minimum threshold for error relative to the baseline."
+              },
+              "warning": {
+                "type": "string",
+                "description": "The threshold for warning relative to the baseline (min & max)."
+              },
+              "error": {
+                "type": "string",
+                "description": "The threshold for error relative to the baseline (min & max)."
+              }
+            },
+            "additionalProperties": false,
+            "required": ["type"]
+          }
+        }
+      },
+      "description": "The `webpack-browser` executor is very similar to the standard `browser` builder provided by the Angular Devkit. It allows you to build your Angular application to a build artifact that can be hosted online. There are some key differences:   \n- Supports Custom Webpack Configurations  \n- Supports Incremental Building",
+      "aliases": [],
+      "hidden": false,
+      "path": "/packages/angular/src/builders/webpack-browser/schema.json"
+    },
+    {
+      "name": "webpack-dev-server",
+      "implementation": "/packages/angular/src/builders/webpack-dev-server/webpack-dev-server.impl.ts",
+      "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
+        "$schema": "http://json-schema.org/draft-07/schema",
+        "title": "Schema for Webpack Dev Server",
+        "description": "The webpack-dev-server executor is very similar to the standard dev server builder provided by the Angular Devkit. It is usually used in tandem with `@nrwl/angular:webpack-browser` when your Angular application uses a custom webpack configuration.",
+        "examplesFile": "##### Seving an application with a custom webpack configuration\n\nThis executor should be used along with `@nrwl/angular:webpack-browser` to serve an application using a custom webpack configuration.\n\nYour `project.json` file should contain a `build` and `serve` target that matches the following:\n\n```json\n\"build\": {\n    \"executor\": \"@nrwl/angular:webpack-browser\",\n    \"options\": {\n        ...\n        \"customWebpackConfig\": {\n          \"path\": \"apps/appName/webpack.config.js\"\n        }\n    }\n},\n\"serve\": {\n    \"executor\": \"@nrwl/angular:webpack-dev-server\",\n    \"configurations\": {\n        \"production\": {\n            \"browserTarget\": \"appName:build:production\"\n        },\n        \"development\": {\n            \"browserTarget\": \"appName:build:development\"\n        }\n    },\n    \"defaultConfiguration\": \"development\",\n}\n```\n",
+        "type": "object",
+        "presets": [
+          {
+            "name": "Using a Different Port",
+            "keys": ["browserTarget", "port"]
+          }
+        ],
+        "properties": {
+          "browserTarget": {
+            "type": "string",
+            "description": "A browser builder target to serve in the format of `project:target[:configuration]`. You can also pass in more than one configuration name as a comma-separated list. Example: `project:target:production,staging`.",
+            "pattern": "^[^:\\s]+:[^:\\s]+(:[^\\s]+)?$"
+          },
+          "port": {
+            "type": "number",
+            "description": "Port to listen on.",
+            "default": 4200
+          },
+          "host": {
+            "type": "string",
+            "description": "Host to listen on.",
+            "default": "localhost"
+          },
+          "proxyConfig": {
+            "type": "string",
+            "description": "Proxy configuration file. For more information, see https://angular.io/guide/build#proxying-to-a-backend-server."
+          },
+          "ssl": {
+            "type": "boolean",
+            "description": "Serve using HTTPS.",
+            "default": false
+          },
+          "sslKey": {
+            "type": "string",
+            "description": "SSL key to use for serving HTTPS."
+          },
+          "sslCert": {
+            "type": "string",
+            "description": "SSL certificate to use for serving HTTPS."
+          },
+          "headers": {
+            "type": "object",
+            "description": "Custom HTTP headers to be added to all responses.",
+            "propertyNames": { "pattern": "^[-_A-Za-z0-9]+$" },
+            "additionalProperties": { "type": "string" }
+          },
+          "open": {
+            "type": "boolean",
+            "description": "Opens the url in default browser.",
+            "default": false,
+            "alias": "o"
+          },
+          "verbose": {
+            "type": "boolean",
+            "description": "Adds more details to output logging."
+          },
+          "liveReload": {
+            "type": "boolean",
+            "description": "Whether to reload the page on change, using live-reload.",
+            "default": true
+          },
+          "publicHost": {
+            "type": "string",
+            "description": "The URL that the browser client (or live-reload client, if enabled) should use to connect to the development server. Use for a complex dev server setup, such as one with reverse proxies."
+          },
+          "allowedHosts": {
+            "type": "array",
+            "description": "List of hosts that are allowed to access the dev server.",
+            "default": [],
+            "items": { "type": "string" }
+          },
+          "servePath": {
+            "type": "string",
+            "description": "The pathname where the app will be served."
+          },
+          "disableHostCheck": {
+            "type": "boolean",
+            "description": "Don't verify connected clients are part of allowed hosts.",
+            "default": false
+          },
+          "hmr": {
+            "type": "boolean",
+            "description": "Enable hot module replacement.",
+            "default": false
+          },
+          "watch": {
+            "type": "boolean",
+            "description": "Rebuild on change.",
+            "default": true
+          },
+          "poll": {
+            "type": "number",
+            "description": "Enable and define the file watching poll time period in milliseconds."
+          },
+          "buildLibsFromSource": {
+            "type": "boolean",
+            "description": "Read buildable libraries from source instead of building them separately. If not set, it will take the value specified in the `browserTarget` options, or it will default to `true` if it's also not set in the `browserTarget` options."
+          }
+        },
+        "additionalProperties": false,
+        "required": ["browserTarget"]
+      },
+      "description": "The `webpack-dev-server` executor is very similar to the standard `dev-server` builder provided by the Angular Devkit. It is usually used in tandem with `@nrwl/angular:webpack-browser` when your Angular application uses a custom webpack configuration.",
+      "aliases": [],
+      "hidden": false,
+      "path": "/packages/angular/src/builders/webpack-dev-server/schema.json"
+    },
+    {
+      "name": "webpack-server",
+      "implementation": "/packages/angular/src/builders/webpack-server/webpack-server.impl.ts",
+      "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
+        "$schema": "http://json-schema.org/draft-07/schema",
+        "title": "Schema for Webpack Server",
+        "description": "The webpack-dev-server executor is very similar to the standard server builder provided by the Angular Devkit. It is usually used in tandem with `@nrwl/angular:webpack-browser` when your Angular application uses a custom webpack configuration and NgUniversal for SSR.",
+        "type": "object",
+        "properties": {
+          "main": {
+            "type": "string",
+            "description": "The full path for the main entry point to the server app, relative to the current workspace."
+          },
+          "tsConfig": {
+            "type": "string",
+            "default": "tsconfig.app.json",
+            "description": "The full path for the TypeScript configuration file, relative to the current workspace."
+          },
+          "inlineStyleLanguage": {
+            "description": "The stylesheet language to use for the application's inline component styles.",
+            "type": "string",
+            "default": "css",
+            "enum": ["css", "less", "sass", "scss"]
+          },
+          "stylePreprocessorOptions": {
+            "description": "Options to pass to style preprocessors",
+            "type": "object",
+            "properties": {
+              "includePaths": {
+                "description": "Paths to include. Paths will be resolved to project root.",
+                "type": "array",
+                "items": { "type": "string" },
+                "default": []
+              }
+            },
+            "additionalProperties": false
+          },
+          "optimization": {
+            "description": "Enables optimization of the build output. Including minification of scripts and styles, tree-shaking and dead-code elimination. For more information, see https://angular.io/guide/workspace-config#optimization-configuration.",
+            "default": true,
+            "x-user-analytics": "ep.ng_optimization",
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "scripts": {
+                    "type": "boolean",
+                    "description": "Enables optimization of the scripts output.",
+                    "default": true
+                  },
+                  "styles": {
+                    "type": "boolean",
+                    "description": "Enables optimization of the styles output.",
+                    "default": true
+                  }
+                },
+                "additionalProperties": false
+              },
+              { "type": "boolean" }
+            ]
+          },
+          "fileReplacements": {
+            "description": "Replace compilation source files with other compilation source files in the build.",
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "src": {
+                      "type": "string",
+                      "pattern": "\\.(([cm]?j|t)sx?|json)$"
+                    },
+                    "replaceWith": {
+                      "type": "string",
+                      "pattern": "\\.(([cm]?j|t)sx?|json)$"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": ["src", "replaceWith"]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "replace": {
+                      "type": "string",
+                      "pattern": "\\.(([cm]?j|t)sx?|json)$"
+                    },
+                    "with": {
+                      "type": "string",
+                      "pattern": "\\.(([cm]?j|t)sx?|json)$"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": ["replace", "with"]
+                }
+              ]
+            },
+            "default": []
+          },
+          "outputPath": {
+            "type": "string",
+            "description": "The full path for the new output directory, relative to the current workspace.\n\nBy default, writes output to a folder named dist/ in the current project."
+          },
+          "resourcesOutputPath": {
+            "type": "string",
+            "description": "The path where style resources will be placed, relative to outputPath."
+          },
+          "sourceMap": {
+            "description": "Output source maps for scripts and styles. For more information, see https://angular.io/guide/workspace-config#source-map-configuration.",
+            "default": false,
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "scripts": {
+                    "type": "boolean",
+                    "description": "Output source maps for all scripts.",
+                    "default": true
+                  },
+                  "styles": {
+                    "type": "boolean",
+                    "description": "Output source maps for all styles.",
+                    "default": true
+                  },
+                  "hidden": {
+                    "type": "boolean",
+                    "description": "Output source maps used for error reporting tools.",
+                    "default": false
+                  },
+                  "vendor": {
+                    "type": "boolean",
+                    "description": "Resolve vendor packages source maps.",
+                    "default": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              { "type": "boolean" }
+            ]
+          },
+          "deployUrl": {
+            "type": "string",
+            "description": "URL where files will be deployed.",
+            "x-deprecated": "Use \"baseHref\" browser builder option, \"APP_BASE_HREF\" DI token or a combination of both instead. For more information, see https://angular.io/guide/deployment#the-deploy-url."
+          },
+          "verbose": {
+            "type": "boolean",
+            "description": "Adds more details to output logging.",
+            "default": false
+          },
+          "progress": {
+            "type": "boolean",
+            "description": "Log progress to the console while building.",
+            "default": true
+          },
+          "i18nMissingTranslation": {
+            "type": "string",
+            "description": "How to handle missing translations for i18n.",
+            "enum": ["warning", "error", "ignore"],
+            "default": "warning"
+          },
+          "i18nDuplicateTranslation": {
+            "type": "string",
+            "description": "How to handle duplicate translations for i18n.",
+            "enum": ["warning", "error", "ignore"],
+            "default": "warning"
+          },
+          "localize": {
+            "description": "Translate the bundles in one or more locales.",
+            "oneOf": [
+              { "type": "boolean", "description": "Translate all locales." },
+              {
+                "type": "array",
+                "description": "List of locales ID's to translate.",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "pattern": "^[a-zA-Z]{2,3}(-[a-zA-Z]{4})?(-([a-zA-Z]{2}|[0-9]{3}))?(-[a-zA-Z]{5,8})?(-x(-[a-zA-Z0-9]{1,8})+)?$"
+                }
+              }
+            ]
+          },
+          "outputHashing": {
+            "type": "string",
+            "description": "Define the output filename cache-busting hashing mode.",
+            "default": "none",
+            "enum": ["none", "all", "media", "bundles"]
+          },
+          "deleteOutputPath": {
+            "type": "boolean",
+            "description": "Delete the output path before building.",
+            "default": true
+          },
+          "preserveSymlinks": {
+            "type": "boolean",
+            "description": "Do not use the real path when resolving modules. If unset then will default to `true` if NodeJS option --preserve-symlinks is set."
+          },
+          "extractLicenses": {
+            "type": "boolean",
+            "description": "Extract all licenses in a separate file, in the case of production builds only.",
+            "default": true
+          },
+          "namedChunks": {
+            "type": "boolean",
+            "description": "Use file name for lazy loaded chunks.",
+            "default": false
+          },
+          "externalDependencies": {
+            "description": "Exclude the listed external dependencies from being bundled into the bundle. Instead, the created bundle relies on these dependencies to be available during runtime.",
+            "type": "array",
+            "items": { "type": "string" },
+            "default": []
+          },
+          "bundleDependencies": {
+            "description": "Which external dependencies to bundle into the bundle. By default, all of node_modules will be bundled.",
+            "default": true,
+            "oneOf": [
+              { "type": "boolean" },
+              { "type": "string", "enum": ["none", "all"] }
+            ]
+          },
+          "statsJson": {
+            "type": "boolean",
+            "description": "Generates a 'stats.json' file which can be analyzed using tools such as 'webpack-bundle-analyzer'.",
+            "default": false
+          },
+          "watch": {
+            "type": "boolean",
+            "description": "Run build when files change.",
+            "default": false
+          },
+          "poll": {
+            "type": "number",
+            "description": "Enable and define the file watching poll time period in milliseconds."
+          },
+          "customWebpackConfig": {
+            "description": "Options for additional webpack configurations.",
+            "type": "object",
+            "properties": {
+              "path": {
+                "description": "Path to additional webpack configuration, relative to the workspace root.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "buildLibsFromSource": {
+            "type": "boolean",
+            "description": "Read buildable libraries from source instead of building them separately.",
+            "default": true
+          }
+        },
+        "additionalProperties": false,
+        "required": ["outputPath", "main", "tsConfig"],
+        "definitions": {
+          "fileReplacement": {
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "src": {
+                    "type": "string",
+                    "pattern": "\\.(([cm]?j|t)sx?|json)$"
+                  },
+                  "replaceWith": {
+                    "type": "string",
+                    "pattern": "\\.(([cm]?j|t)sx?|json)$"
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["src", "replaceWith"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "replace": {
+                    "type": "string",
+                    "pattern": "\\.(([cm]?j|t)sx?|json)$"
+                  },
+                  "with": {
+                    "type": "string",
+                    "pattern": "\\.(([cm]?j|t)sx?|json)$"
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["replace", "with"]
+              }
+            ]
+          }
+        },
+        "presets": []
+      },
+      "description": "The `webpack-server` executor is very similar to the standard `server` builder provided by the Angular Devkit. It is usually used in tandem with `@nrwl/angular:webpack-browser` when your Angular application uses a custom webpack configuration and NgUniversal for SSR.",
+      "aliases": [],
+      "hidden": false,
+      "path": "/packages/angular/src/builders/webpack-server/schema.json"
+    },
+    {
+      "name": "module-federation-dev-server",
+      "implementation": "/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts",
+      "schema": {
+        "version": 2,
+        "outputCapture": "direct-nodejs",
+        "$schema": "http://json-schema.org/draft-07/schema",
+        "title": "Schema for Module Federation Dev Server",
+        "description": "The module-federation-dev-server executor is reserved exclusively for use with host Module Federation applications. It allows the user to specify which remote applications should be served with the host.",
+        "type": "object",
+        "presets": [
+          {
+            "name": "Using a Different Port",
+            "keys": ["browserTarget", "port"]
+          }
+        ],
+        "properties": {
+          "browserTarget": {
+            "type": "string",
+            "description": "A browser builder target to serve in the format of `project:target[:configuration]`. You can also pass in more than one configuration name as a comma-separated list. Example: `project:target:production,staging`.",
+            "pattern": "^[^:\\s]+:[^:\\s]+(:[^\\s]+)?$"
+          },
+          "port": {
+            "type": "number",
+            "description": "Port to listen on.",
+            "default": 4200
+          },
+          "host": {
+            "type": "string",
+            "description": "Host to listen on.",
+            "default": "localhost"
+          },
+          "proxyConfig": {
+            "type": "string",
+            "description": "Proxy configuration file. For more information, see https://angular.io/guide/build#proxying-to-a-backend-server."
+          },
+          "ssl": {
+            "type": "boolean",
+            "description": "Serve using HTTPS.",
+            "default": false
+          },
+          "sslKey": {
+            "type": "string",
+            "description": "SSL key to use for serving HTTPS."
+          },
+          "sslCert": {
+            "type": "string",
+            "description": "SSL certificate to use for serving HTTPS."
+          },
+          "headers": {
+            "type": "object",
+            "description": "Custom HTTP headers to be added to all responses.",
+            "propertyNames": { "pattern": "^[-_A-Za-z0-9]+$" },
+            "additionalProperties": { "type": "string" }
+          },
+          "open": {
+            "type": "boolean",
+            "description": "Opens the url in default browser.",
+            "default": false,
+            "alias": "o"
+          },
+          "verbose": {
+            "type": "boolean",
+            "description": "Adds more details to output logging."
+          },
+          "liveReload": {
+            "type": "boolean",
+            "description": "Whether to reload the page on change, using live-reload.",
+            "default": true
+          },
+          "publicHost": {
+            "type": "string",
+            "description": "The URL that the browser client (or live-reload client, if enabled) should use to connect to the development server. Use for a complex dev server setup, such as one with reverse proxies."
+          },
+          "allowedHosts": {
+            "type": "array",
+            "description": "List of hosts that are allowed to access the dev server.",
+            "default": [],
+            "items": { "type": "string" }
+          },
+          "servePath": {
+            "type": "string",
+            "description": "The pathname where the app will be served."
+          },
+          "disableHostCheck": {
+            "type": "boolean",
+            "description": "Don't verify connected clients are part of allowed hosts.",
+            "default": false
+          },
+          "hmr": {
+            "type": "boolean",
+            "description": "Enable hot module replacement.",
+            "default": false
+          },
+          "watch": {
+            "type": "boolean",
+            "description": "Rebuild on change.",
+            "default": true
+          },
+          "poll": {
+            "type": "number",
+            "description": "Enable and define the file watching poll time period in milliseconds."
+          },
+          "devRemotes": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "List of remote applications to run in development mode (i.e. using serve target)."
+          },
+          "skipRemotes": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "List of remote applications to not automatically serve, either statically or in development mode. This can be useful for multi-repository module federation setups where the host application uses a remote application from an external repository."
+          }
+        },
+        "additionalProperties": false,
+        "required": ["browserTarget"],
+        "examplesFile": "## Examples\n\n{% tabs %}\n\n{% tab label=\"Basic Usage\" %}\nThe Module Federation Dev Server will serve a host application and find the remote applications associated with the host and serve them statically also.  \nSee an example set up of it below:\n\n```json\n{\n  \"serve\": {\n    \"executor\": \"@nrwl/angular:module-federation-dev-server\",\n    \"configurations\": {\n      \"production\": {\n        \"browserTarget\": \"host:build:production\"\n      },\n      \"development\": {\n        \"browserTarget\": \"host:build:development\"\n      }\n    },\n    \"defaultConfiguration\": \"development\",\n    \"options\": {\n      \"port\": 4200,\n      \"publicHost\": \"http://localhost:4200\"\n    }\n  }\n}\n```\n\n{% /tab %}\n\n{% tab label=\"Serve host with remotes that can be live reloaded\" %}\nThe Module Federation Dev Server will serve a host application and find the remote applications associated with the host and serve a set selection with live reloading enabled also.  \nSee an example set up of it below:\n\n```json\n{\n  \"serve-with-hmr-remotes\": {\n    \"executor\": \"@nrwl/angular:module-federation-dev-server\",\n    \"configurations\": {\n      \"production\": {\n        \"browserTarget\": \"host:build:production\"\n      },\n      \"development\": {\n        \"browserTarget\": \"host:build:development\"\n      }\n    },\n    \"defaultConfiguration\": \"development\",\n    \"options\": {\n      \"port\": 4200,\n      \"publicHost\": \"http://localhost:4200\",\n      \"devRemotes\": [\"remote1\", \"remote2\"]\n    }\n  }\n}\n```\n\n{% /tab %}\n\n{% /tabs %}\n"
+      },
+      "description": "The module-federation-dev-server executor is reserved exclusively for use with host Module Federation applications. It allows the user to specify which remote applications should be served with the host.",
+      "aliases": [],
+      "hidden": false,
+      "path": "/packages/angular/src/builders/module-federation-dev-server/schema.json"
     }
   ]
 }

--- a/docs/packages.json
+++ b/docs/packages.json
@@ -16,7 +16,11 @@
         "delegate-build",
         "ng-packagr-lite",
         "package",
-        "file-server"
+        "file-server",
+        "webpack-browser",
+        "webpack-dev-server",
+        "webpack-server",
+        "module-federation-dev-server"
       ],
       "generators": [
         "add-linting",

--- a/scripts/documentation/package-schemas/package-metadata.ts
+++ b/scripts/documentation/package-schemas/package-metadata.ts
@@ -50,14 +50,28 @@ function getSchemaList(
     folderName: string;
     root: string;
   },
-  type: 'generators' | 'executors'
+  collectionFileName: string,
+  collectionEntries: string[]
 ): SchemaMetadata[] {
-  const targetPath = join(paths.absoluteRoot, paths.root, type + '.json');
+  const targetPath = join(paths.absoluteRoot, paths.root, collectionFileName);
   try {
-    return Object.entries(readJsonSync(targetPath, 'utf8')[type]).map(
-      ([name, schema]: [string, JsonSchema1]) =>
-        createSchemaMetadata(name, schema, paths)
-    );
+    const metadata: SchemaMetadata[] = [];
+    const collectionFile = readJsonSync(targetPath, 'utf8');
+    for (const entry of collectionEntries) {
+      if (!collectionFile[entry]) {
+        continue;
+      }
+
+      metadata.push(
+        ...Object.entries<JsonSchema1>(collectionFile[entry])
+          .filter(([name]) => !metadata.find((x) => x.name === name))
+          .map(([name, schema]: [string, JsonSchema1]) =>
+            createSchemaMetadata(name, schema, paths)
+          )
+      );
+    }
+
+    return metadata;
   } catch (e) {
     console.log(
       `SchemaMetadata "${paths.root
@@ -87,7 +101,7 @@ export function getPackageMetadataList(
    */
   const additionalApiReferences: any = DocumentationMap.content.find(
     (data) => data.id === 'additional-api-references'
-  ).itemList;
+  )!.itemList;
 
   // Do not use map.json, but add a documentation property on the package.json directly that can be easily resolved
   return sync(`${packagesDir}/*`, { ignore: [`${packagesDir}/cli`] }).map(
@@ -123,7 +137,8 @@ export function getPackageMetadataList(
             folderName,
             root: relativeFolderPath,
           },
-          'generators'
+          'generators.json',
+          ['generators']
         ),
         executors: getSchemaList(
           {
@@ -131,7 +146,8 @@ export function getPackageMetadataList(
             folderName,
             root: relativeFolderPath,
           },
-          'executors'
+          'executors.json',
+          ['executors', 'builders']
         ),
       };
     }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The docs generation script only fetches the executors defined in the `executors` entry of the `executors.json` file of each plugin. It doesn't fetch unique builders that are defined in the `builders` entry of that file. The Angular plugin in particular, contains some builders that are not showing up in the docs because of that.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Unique builders defined in the `builders` entry of the `executors.json` file should appear in the docs.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
