### PR TITLE
feat(core): use node_modules/.cache/nx as default for projectGraphCac…

### DIFF
--- a/packages/nx/src/utils/cache-directory.ts
+++ b/packages/nx/src/utils/cache-directory.ts
@@ -1,7 +1,7 @@
-import { join, isAbsolute } from 'path';
-import { workspaceRoot } from './workspace-root';
-import { readJsonFile } from './fileutils';
+import { isAbsolute, join } from 'path';
 import { NxJsonConfiguration } from '../config/nx-json';
+import { readJsonFile } from './fileutils';
+import { workspaceRoot } from './workspace-root';
 
 function readCacheDirectoryProperty(root: string): string | undefined {
   try {
@@ -12,17 +12,21 @@ function readCacheDirectoryProperty(root: string): string | undefined {
   }
 }
 
+function absolutePath(root: string, path: string): string {
+  if (isAbsolute(path)) {
+    return path;
+  } else {
+    return join(root, path);
+  }
+}
+
 function cacheDirectory(root: string, cacheDirectory: string) {
   const cacheDirFromEnv = process.env.NX_CACHE_DIRECTORY;
   if (cacheDirFromEnv) {
     cacheDirectory = cacheDirFromEnv;
   }
   if (cacheDirectory) {
-    if (isAbsolute(cacheDirectory)) {
-      return cacheDirectory;
-    } else {
-      return join(root, cacheDirectory);
-    }
+    return absolutePath(root, cacheDirectory);
   } else {
     return join(root, 'node_modules', '.cache', 'nx');
   }
@@ -36,5 +40,8 @@ export const cacheDir = cacheDirectory(
   readCacheDirectoryProperty(workspaceRoot)
 );
 
-export const projectGraphCacheDirectory =
-  process.env.NX_PROJECT_GRAPH_CACHE_DIRECTORY ?? cacheDir;
+export const projectGraphCacheDirectory = absolutePath(
+  workspaceRoot,
+  process.env.NX_PROJECT_GRAPH_CACHE_DIRECTORY ??
+    join(workspaceRoot, 'node_modules', '.cache', 'nx')
+);


### PR DESCRIPTION
## Current Behavior
When changing the location of the nx cache directory away from default `node_modules/.cache/nx`
   - using `.cacheDirectory` option in `nx.json` or `NX_CACHE_DIRECTORY` environment variable - 
the location of `projectGraphCacheDirectory` follows the nx cache directory 
unless environment `NX_PROJECT_GRAPH_CACHE_DIRECTORY` is set.

## Expected Behavior
The location of `projectGraphCacheDirectory` should stay in `node_modules/.cache/nx`
unless environment `NX_PROJECT_GRAPH_CACHE_DIRECTORY` is set.
The rationale is that changing the normal cache directory to some directory shared by
multiple worktrees/repos will result in error if the `projectGraphCacheDirectory` is also shared.

## BREAKING CHANGE:
The default of projectGraphCacheDirectory no longer follows the location of cacheDirectory

## Related Issue(s)
This is one of two Pull Requests fixing the same problem
This one does the minimal changes
Only one of the PRs should be merged
Closes https://github.com/nrwl/nx/pull/13471

Fixes #
