### PR TITLE
fix(bundling): remove extraneous logs from @nrwl/vite:build executor

### DIFF
--- a/packages/vite/src/executors/build/build.impl.ts
+++ b/packages/vite/src/executors/build/build.impl.ts
@@ -13,12 +13,7 @@ export default async function viteBuildExecutor(
 ) {
   const projectRoot = context.workspace.projects[context.projectName].root;
 
-  logger.info(`NX Vite build starting ...`);
-  const buildResult = await runInstance(
-    await getBuildAndSharedConfig(options, context)
-  );
-  logger.info(`NX Vite build finished ...`);
-  logger.info(`NX Vite files available in ${options.outputPath}`);
+  await runInstance(await getBuildAndSharedConfig(options, context));
 
   // For buildable libs, copy package.json if it exists.
   if (existsSync(join(projectRoot, 'package.json'))) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

There are extraneous logs when building vite apps and libs.

```terminal
~/p/t/node-ipc-test (main|✚4…) $ nx build app1

> nx run app1:build:production  [local cache]


>  NX  Vite build starting ...

vite v3.2.4 building for production...
✓ 36 modules transformed.
../../dist/apps/app1/index.html                  0.46 KiB
../../dist/apps/app1/assets/index.ccdffbe4.js    179.19 KiB / gzip: 56.61 KiB

>  NX  Vite build finished ...


>  NX  Vite files available in dist/apps/app1


 ——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 >  NX   Successfully ran target build for project app1 (25ms)
 ```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The output is pretty much the same as `vite`

```terminal
~/p/t/node-ipc-test (main|✚4…) $ nx build app1

> nx run app1:build:production

vite v3.2.4 building for production...
✓ 36 modules transformed.
../../dist/apps/app1/index.html                  0.46 KiB
../../dist/apps/app1/assets/index.ccdffbe4.js    179.19 KiB / gzip: 56.61 KiB

 ——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 >  NX   Successfully ran target build for project app1 (2s)
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
