### PR TITLE
docs(nxdev): externalize related documentation links into its own section

### DIFF
--- a/nx-dev/data-access-documents/src/lib/documents.api.ts
+++ b/nx-dev/data-access-documents/src/lib/documents.api.ts
@@ -98,6 +98,8 @@ export class DocumentsApi {
         cardsTemplate,
         '{% /cards %}\n\n',
       ].join(''),
+      relatedContent: '',
+      tags: [],
     };
   }
 
@@ -123,8 +125,9 @@ export class DocumentsApi {
     return {
       filePath,
       data: frontmatter,
-      content:
-        originalContent + '\n\n' + this.getRelatedDocumentsSection(tags, path),
+      content: originalContent,
+      relatedContent: this.getRelatedDocumentsSection(tags, path),
+      tags: tags,
     };
   }
 

--- a/nx-dev/feature-doc-viewer/src/lib/content.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/content.tsx
@@ -8,8 +8,21 @@ export interface ContentProps {
 export function Content(props: ContentProps): JSX.Element {
   return (
     <div className="min-w-0 flex-auto pb-24 lg:pb-16">
-      <div className="prose prose-slate dark:prose-invert max-w-none">
-        {renderMarkdown(props.document)}
+      <div
+        id="document-data"
+        className="prose prose-slate dark:prose-invert max-w-none"
+      >
+        {renderMarkdown(props.document.content.toString(), {
+          filePath: props.document.filePath,
+        })}
+      </div>
+      <div
+        id="related-document-data"
+        className="prose prose-slate dark:prose-invert max-w-none"
+      >
+        {renderMarkdown(props.document.relatedContent.toString(), {
+          filePath: '',
+        })}
       </div>
     </div>
   );

--- a/nx-dev/feature-package-schema-viewer/src/lib/content.tsx
+++ b/nx-dev/feature-package-schema-viewer/src/lib/content.tsx
@@ -78,17 +78,18 @@ export function Content({
       );
     },
     get markdown(): ReactNode {
-      return renderMarkdown({
-        content: getMarkdown({
+      return renderMarkdown(
+        getMarkdown({
           type: schemaViewModel.type,
           packageName: schemaViewModel.packageName,
           schemaName: schemaViewModel.schemaMetadata.name,
           schemaAlias: schemaViewModel.schemaMetadata.aliases[0] ?? '',
           schema: schemaViewModel.currentSchema as NxSchema,
         }),
-        filePath: '',
-        data: {},
-      });
+        {
+          filePath: '',
+        }
+      );
     },
   };
 

--- a/nx-dev/feature-package-schema-viewer/src/lib/package-schema-list.tsx
+++ b/nx-dev/feature-package-schema-viewer/src/lib/package-schema-list.tsx
@@ -65,11 +65,10 @@ export function PackageSchemaList({
       url: 'https://nx.dev' + router.asPath,
     },
     get markdown(): ReactNode {
-      return renderMarkdown({
-        content: this.package.readme.content || this.package.description,
-        filePath: this.package.readme.filePath,
-        data: {},
-      });
+      return renderMarkdown(
+        this.package.readme.content || this.package.description,
+        { filePath: this.package.readme.filePath }
+      );
     },
   };
 

--- a/nx-dev/feature-package-schema-viewer/src/lib/parameter-view.tsx
+++ b/nx-dev/feature-package-schema-viewer/src/lib/parameter-view.tsx
@@ -61,18 +61,14 @@ export const ParameterView = (props: {
     </div>
 
     <div className="prose prose-slate dark:prose-invert">
-      {renderMarkdown({
-        content: props.description,
-        data: {},
+      {renderMarkdown(props.description, {
         filePath: '',
       })}
     </div>
 
     {props.deprecated && !!props.schema['x-deprecated'] && (
       <div className="prose prose-slate dark:prose-invert mt-2 rounded-md bg-red-100 px-4 text-red-800 dark:bg-red-800 dark:text-red-100">
-        {renderMarkdown({
-          content: props.schema['x-deprecated'] as string,
-          data: {},
+        {renderMarkdown((props.schema as any)['x-deprecated'].toString(), {
           filePath: '',
         })}
       </div>

--- a/nx-dev/feature-package-schema-viewer/src/lib/ui/package-reference.tsx
+++ b/nx-dev/feature-package-schema-viewer/src/lib/ui/package-reference.tsx
@@ -133,9 +133,7 @@ function SchemaListItem({
           )}
         </p>
         <div className="prose prose-slate dark:prose-invert prose-sm">
-          {renderMarkdown({
-            content: schema.description,
-            data: {},
+          {renderMarkdown(schema.description, {
             filePath: '',
           })}
         </div>

--- a/nx-dev/models-document/src/lib/documents.models.ts
+++ b/nx-dev/models-document/src/lib/documents.models.ts
@@ -2,6 +2,8 @@ export interface DocumentData {
   filePath: string;
   data: { [key: string]: any };
   content: string;
+  relatedContent: string;
+  tags: string[];
 }
 
 export interface DocumentMetadata {

--- a/nx-dev/ui-markdoc/src/index.ts
+++ b/nx-dev/ui-markdoc/src/index.ts
@@ -32,13 +32,13 @@ import { YouTube } from './lib/tags/youtube.components';
 import { youtube } from './lib/tags/youtube.schema';
 
 export const getMarkdocCustomConfig = (
-  document: DocumentData
+  documentFilePath: string
 ): { config: any; components: any } => ({
   config: {
     nodes: {
       fence,
       heading,
-      image: getImageSchema(document),
+      image: getImageSchema(documentFilePath),
       link,
     },
     tags: {
@@ -82,11 +82,15 @@ export const getMarkdocCustomConfig = (
 export const parseMarkdown: (markdown: string) => Node = (markdown) =>
   parse(markdown);
 
-export const renderMarkdown: (document: DocumentData) => ReactNode = (
-  document: DocumentData
+export const renderMarkdown: (
+  documentContent: string,
+  options: { filePath: string }
+) => ReactNode = (
+  documentContent: string,
+  options: { filePath: string } = { filePath: '' }
 ): ReactNode => {
-  const ast = parseMarkdown(document.content.toString());
-  const configuration = getMarkdocCustomConfig(document);
+  const ast = parseMarkdown(documentContent);
+  const configuration = getMarkdocCustomConfig(options.filePath);
   return renderers.react(transform(ast, configuration.config), React, {
     components: configuration.components,
   });

--- a/nx-dev/ui-markdoc/src/lib/nodes/helpers/transform-image-path.spec.ts
+++ b/nx-dev/ui-markdoc/src/lib/nodes/helpers/transform-image-path.spec.ts
@@ -2,13 +2,9 @@ import { transformImagePath } from './transform-image-path';
 
 describe('transformImagePath', () => {
   it('should transform relative paths', () => {
-    const opts = {
-      content: '',
-      excerpt: '',
-      filePath: 'nx-dev/nx-dev/public/documentation/shared/using-nx/dte.md',
-      data: {},
-    };
-    const transform = transformImagePath(opts);
+    const transform = transformImagePath(
+      'nx-dev/nx-dev/public/documentation/shared/using-nx/dte.md'
+    );
 
     expect(transform('./test.png')).toEqual(
       '/documentation/shared/using-nx/test.png'
@@ -18,14 +14,9 @@ describe('transformImagePath', () => {
   });
 
   it('should transform absolute paths', () => {
-    const opts = {
-      content: '',
-      excerpt: '',
-      filePath:
-        'nx-dev/nx-dev/public/documentation/angular/generators/workspace-generators.md',
-      data: {},
-    };
-    const transform = transformImagePath(opts);
+    const transform = transformImagePath(
+      'nx-dev/nx-dev/public/documentation/angular/generators/workspace-generators.md'
+    );
 
     expect(transform('/shared/test.png')).toEqual(
       '/documentation/shared/test.png'

--- a/nx-dev/ui-markdoc/src/lib/nodes/helpers/transform-image-path.ts
+++ b/nx-dev/ui-markdoc/src/lib/nodes/helpers/transform-image-path.ts
@@ -3,7 +3,7 @@ import { join } from 'path';
 import { uriTransformer } from './uri-transformer';
 
 export function transformImagePath(
-  document: DocumentData
+  documentFilePath: string
 ): (src: string) => string {
   return (src) => {
     const isRelative = src.startsWith('.');
@@ -14,7 +14,7 @@ export function transformImagePath(
 
     if (isRelative) {
       return uriTransformer(
-        join('/', document.filePath.split('/').splice(3).join('/'), '..', src)
+        join('/', documentFilePath.split('/').splice(3).join('/'), '..', src)
       );
     }
 

--- a/nx-dev/ui-markdoc/src/lib/nodes/image.schema.ts
+++ b/nx-dev/ui-markdoc/src/lib/nodes/image.schema.ts
@@ -8,7 +8,7 @@ import {
 import { DocumentData } from '@nrwl/nx-dev/models-document';
 import { transformImagePath } from './helpers/transform-image-path';
 
-export const getImageSchema = (document: DocumentData): Schema => ({
+export const getImageSchema = (documentFilePath: string): Schema => ({
   render: 'img',
   attributes: {
     src: { type: 'String', required: true },
@@ -17,7 +17,7 @@ export const getImageSchema = (document: DocumentData): Schema => ({
   transform(node: Node, config: Config): RenderableTreeNodes {
     const attributes = node.transformAttributes(config);
     const children = node.transformChildren(config);
-    const src = transformImagePath(document)(attributes['src']);
+    const src = transformImagePath(documentFilePath)(attributes['src']);
 
     return new Tag(
       this.render,


### PR DESCRIPTION
It moves the "related documentation links" section into its own `DocumentData` property and enables us to have distinct markup for its wrapper.
It adds the `tags` property to `DocumentData` object to exposes tags in the template for future usage.

This allows us:
- to have dedicated markup for this section
- to precisely tell Algolia to not reference this section (which is a link duplication) so we should come with better results;
- to possibly move section in the template _(if needed)_