### PR TITLE
fix(core): fix configuration option for affected:build|test|e2e

### DIFF
--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -86,7 +86,9 @@ export const commandsObject = yargs
     describe: false,
     builder: (yargs) =>
       linkToNxDevAndExamples(
-        withAffectedOptions(withRunOptions(withOutputStyleOption(yargs))),
+        withAffectedOptions(
+          withRunOptions(withOutputStyleOption(withConfiguration(yargs)))
+        ),
         'affected'
       ),
     handler: async (args) =>
@@ -100,7 +102,9 @@ export const commandsObject = yargs
     describe: false,
     builder: (yargs) =>
       linkToNxDevAndExamples(
-        withAffectedOptions(withRunOptions(withOutputStyleOption(yargs))),
+        withAffectedOptions(
+          withRunOptions(withOutputStyleOption(withConfiguration(yargs)))
+        ),
         'affected'
       ),
     handler: async (args) =>
@@ -114,7 +118,9 @@ export const commandsObject = yargs
     describe: false,
     builder: (yargs) =>
       linkToNxDevAndExamples(
-        withAffectedOptions(withRunOptions(withOutputStyleOption(yargs))),
+        withAffectedOptions(
+          withRunOptions(withOutputStyleOption(withConfiguration(yargs)))
+        ),
         'affected'
       ),
     handler: async (args) =>
@@ -128,7 +134,9 @@ export const commandsObject = yargs
     describe: false,
     builder: (yargs) =>
       linkToNxDevAndExamples(
-        withAffectedOptions(withRunOptions(withOutputStyleOption(yargs))),
+        withAffectedOptions(
+          withRunOptions(withOutputStyleOption(withConfiguration(yargs)))
+        ),
         'affected'
       ),
     handler: async (args) =>
@@ -631,20 +639,22 @@ function withTargetAndConfigurationOption(
   yargs: yargs.Argv,
   demandOption = true
 ): yargs.Argv {
-  return yargs
-    .option('target', {
-      describe: 'Task to run for affected projects',
-      type: 'string',
-      requiresArg: true,
-      demandOption,
-      global: false,
-    })
-    .options('configuration', {
-      describe:
-        'This is the configuration to use when performing tasks on projects',
-      type: 'string',
-      alias: 'c',
-    });
+  return withConfiguration(yargs).option('target', {
+    describe: 'Task to run for affected projects',
+    type: 'string',
+    requiresArg: true,
+    demandOption,
+    global: false,
+  });
+}
+
+function withConfiguration(yargs: yargs.Argv) {
+  return yargs.options('configuration', {
+    describe:
+      'This is the configuration to use when performing tasks on projects',
+    type: 'string',
+    alias: 'c',
+  });
 }
 
 function withNewOptions(yargs: yargs.Argv) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`nx affected:build` doesn't have a `--configuration` option.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`nx affected:build` has a `--configuration` option.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
