### PR TITLE
fix(storybook): inform user vite is used if project uses vite

### DIFF
--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -49,7 +49,13 @@ export async function configurationGenerator(
   const { nextBuildTarget, compiler, viteBuildTarget } =
     findStorybookAndBuildTargetsAndCompiler(targets);
 
-  console.log(findStorybookAndBuildTargetsAndCompiler(targets));
+  if (viteBuildTarget && schema.bundler !== 'vite') {
+    logger.info(
+      `Your project ${schema.name} uses Vite as a bundler. 
+      Nx will configure Storybook for this project to use Vite as well.`
+    );
+    schema.bundler = 'vite';
+  }
 
   const initTask = await initGenerator(tree, {
     uiFramework: schema.uiFramework,
@@ -68,7 +74,7 @@ export async function configurationGenerator(
       projectType,
       !!nextBuildTarget,
       compiler === 'swc',
-      schema.bundler === 'vite' || !!viteBuildTarget
+      schema.bundler === 'vite'
     );
   } else {
     createRootStorybookDir(tree, schema.js, schema.tsConfiguration);
@@ -80,7 +86,7 @@ export async function configurationGenerator(
       schema.tsConfiguration,
       !!nextBuildTarget,
       compiler === 'swc',
-      schema.bundler === 'vite' || !!viteBuildTarget
+      schema.bundler === 'vite'
     );
   }
 


### PR DESCRIPTION
If a project is using vite, then Storybook will generate with vite configuration, as well, no matter the bundler the user passed. 

Also, Storybook generator does not install the vite dependency if bundler is not set as vite by the user.

* inform user that if project uses vite storybook will be configured for vite, too
* install vite if project is configured using vite even if user provided different builder