### PR TITLE
fix(core): prevent peer deps from ending up as dev deps in create package json

### DIFF
--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -444,7 +444,7 @@ async function checkApp(
 
   const packageJson = readJson(`dist/apps/${appName}/package.json`);
   expect(packageJson.dependencies.react).toBeDefined();
-  expect(packageJson.peerDependencies['react-dom']).toBeDefined();
+  expect(packageJson.dependencies['react-dom']).toBeDefined();
   expect(packageJson.dependencies.next).toBeDefined();
 
   if (opts.checkLint) {

--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -242,11 +242,11 @@ describe('Next.js Applications', () => {
             if (found) throw new Error('Found SVGR plugin');
 
             console.log('NODE_ENV is', process.env.NODE_ENV);
-            
+
             return config;
           }
         };
-        
+
         module.exports = withNx(nextConfig);
       `
     );
@@ -265,7 +265,7 @@ describe('Next.js Applications', () => {
         const { withNx } = require('@nrwl/next/plugins/with-nx');
         // Not including "nx" entry should still work.
         const nextConfig = {};
-        
+
         module.exports = withNx(nextConfig);
       `
     );
@@ -444,7 +444,7 @@ async function checkApp(
 
   const packageJson = readJson(`dist/apps/${appName}/package.json`);
   expect(packageJson.dependencies.react).toBeDefined();
-  expect(packageJson.dependencies['react-dom']).toBeDefined();
+  expect(packageJson.peerDependencies['react-dom']).toBeDefined();
   expect(packageJson.dependencies.next).toBeDefined();
 
   if (opts.checkLint) {

--- a/e2e/node/src/node.test.ts
+++ b/e2e/node/src/node.test.ts
@@ -229,7 +229,7 @@ describe('Build Node apps', () => {
 
   afterEach(() => cleanupProject());
 
-  it('should generate a package.json with the `--generatePackageJson` flag MMM', async () => {
+  it('should generate a package.json with the `--generatePackageJson` flag', async () => {
     const scope = newProject();
     const nestapp = uniq('nestapp');
     runCLI(`generate @nrwl/nest:app ${nestapp} --linter=eslint`);

--- a/packages/next/src/executors/build/lib/create-package-json.ts
+++ b/packages/next/src/executors/build/lib/create-package-json.ts
@@ -27,6 +27,7 @@ export async function createPackageJson(
 
   const typescriptNode = context.projectGraph.externalNodes['npm:typescript'];
   if (typescriptNode) {
+    packageJson.dependencies = packageJson.dependencies || {};
     packageJson.dependencies['typescript'] = typescriptNode.data.version;
   }
 

--- a/packages/nx/src/utils/create-package-json.ts
+++ b/packages/nx/src/utils/create-package-json.ts
@@ -1,5 +1,5 @@
 import { readJsonFile } from './fileutils';
-import { sortObjectByKeys } from 'nx/src/utils/object-sort';
+import { sortObjectByKeys } from './object-sort';
 import { ProjectGraph } from '../config/project-graph';
 import { PackageJson } from './package-json';
 import { existsSync } from 'fs';

--- a/packages/nx/src/utils/create-package-json.ts
+++ b/packages/nx/src/utils/create-package-json.ts
@@ -71,13 +71,19 @@ function findAllNpmDeps(
   } = { dependencies: {}, peerDependencies: {} },
   seen = new Set<string>()
 ) {
+  const node = graph.externalNodes[projectName];
+
   if (seen.has(projectName)) {
+    // if it's in peerDependencies, move it to regular dependencies
+    // since this is a direct dependency of the project
+    if (node && list.peerDependencies[node.data.packageName]) {
+      list.dependencies[node.data.packageName] = node.data.version;
+      delete list.peerDependencies[node.data.packageName];
+    }
     return list;
   }
 
   seen.add(projectName);
-
-  const node = graph.externalNodes[projectName];
 
   if (node) {
     list.dependencies[node.data.packageName] = node.data.version;

--- a/packages/nx/src/utils/create-package-json.ts
+++ b/packages/nx/src/utils/create-package-json.ts
@@ -50,14 +50,16 @@ export function createPackageJson(
     }
   });
   Object.entries(npmDeps.peerDependencies).forEach(([packageName, version]) => {
-    packageJson.peerDependencies = packageJson.peerDependencies || {};
-    if (!packageJson.peerDependencies[packageName]) {
-      packageJson.peerDependencies[packageName] = version;
+    if (!packageJson.peerDependencies?.[packageName]) {
+      packageJson.dependencies[packageName] = version;
     }
   });
 
   packageJson.devDependencies &&= sortObjectByKeys(packageJson.devDependencies);
   packageJson.dependencies &&= sortObjectByKeys(packageJson.dependencies);
+  packageJson.peerDependencies &&= sortObjectByKeys(
+    packageJson.peerDependencies
+  );
 
   return packageJson;
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When generating package.json for the project, we treat peer dependencies as direct dependencies, and if already defined in the `peerDependencies` we make a duplicate. 

## Expected Behavior
The peer dependencies nature should be respected in the generated package.json and there should not be duplicates.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
