### PR TITLE
docs(nxdev): set document-data type on doc pages

### DIFF
--- a/nx-dev/feature-doc-viewer/src/lib/content.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/content.tsx
@@ -9,7 +9,7 @@ export function Content(props: ContentProps): JSX.Element {
   return (
     <div className="min-w-0 flex-auto pb-24 lg:pb-16">
       <div
-        id="document-data"
+        data-document="main"
         className="prose prose-slate dark:prose-invert max-w-none"
       >
         {renderMarkdown(props.document.content.toString(), {
@@ -17,7 +17,7 @@ export function Content(props: ContentProps): JSX.Element {
         })}
       </div>
       <div
-        id="related-document-data"
+        data-document="related"
         className="prose prose-slate dark:prose-invert max-w-none"
       >
         {renderMarkdown(props.document.relatedContent.toString(), {

--- a/nx-dev/feature-package-schema-viewer/src/lib/content.tsx
+++ b/nx-dev/feature-package-schema-viewer/src/lib/content.tsx
@@ -94,7 +94,7 @@ export function Content({
   };
 
   return (
-    <div className="min-w-0 flex-auto pt-8 pb-24 lg:pb-16">
+    <div data-document="main" className="min-w-0 flex-auto pt-8 pb-24 lg:pb-16">
       <div className="mb-8 flex w-full items-center space-x-2">
         <div className="w-full flex-grow space-x-4">
           <div
@@ -208,7 +208,7 @@ export function Content({
                   <button
                     onClick={() => setPresets([])}
                     type="button"
-                    className="relative inline-flex items-center rounded-md border border-slate-200 bg-white px-4 px-4 py-2 py-2 text-xs font-medium text-slate-600 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-400 dark:hover:bg-slate-800"
+                    className="relative inline-flex items-center rounded-md border border-slate-200 bg-white px-4 py-2 py-2 text-xs font-medium text-slate-600 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-400 dark:hover:bg-slate-800"
                   >
                     Reset <XCircleIcon className="ml-1.5 h-4 w-4" />
                   </button>

--- a/nx-dev/feature-package-schema-viewer/src/lib/package-schema-list.tsx
+++ b/nx-dev/feature-package-schema-viewer/src/lib/package-schema-list.tsx
@@ -98,7 +98,10 @@ export function PackageSchemaList({
           <div className="mb-6 pt-8">
             <Breadcrumbs path={router.asPath} />
           </div>
-          <div className="mb-8 flex w-full items-center space-x-2">
+          <div
+            data-document="main"
+            className="mb-8 flex w-full items-center space-x-2"
+          >
             <div className="w-full flex-grow">
               <div
                 className="relative inline-flex rounded-md border border-slate-200 bg-slate-50 px-4 py-2 text-xs font-medium uppercase dark:border-slate-700 dark:bg-slate-800/60"


### PR DESCRIPTION
It sets a `data-document` attribute on the documentation layout for nx.dev with the type of document shown in the layout section so we can precisely guide the Algolia Crawler.