### PR TITLE
fix(misc): use given name for creating standalone workspaces

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -333,8 +333,9 @@ async function getConfiguration(
         preset === Preset.ReactStandalone ||
         preset === Preset.AngularStandalone
       ) {
-        appName = await determineAppName(preset, argv);
-        name = appName;
+        appName =
+          argv.appName ?? argv.name ?? (await determineAppName(preset, argv));
+        name = argv.name ?? appName;
       } else {
         name = await determineRepoName(argv);
         appName = await determineAppName(preset, argv);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

```
~/p/t/tests $ npx create-nx-workspace@latest ng-test
Need to install the following packages:
  create-nx-workspace@15.3.0
Ok to proceed? (y) y

 >  NX   Let's create a new workspace [https://nx.dev/getting-started/intro]

✔ Choose what to create                 · angular
✔ Application name                      · app1
✔ Default stylesheet format             · css
✔ Enable distributed caching to make your CI faster · Yes

 >  NX   Nx is creating your v15.3.0 workspace.

   To make sure the command works reliably in all environments, and that the preset is applied correctly,
   Nx will run "npm install" several times. Please wait.

✔ Installing dependencies with npm
✔ Nx has successfully created the workspace: ng-test.
✔ NxCloud has been set up successfully

 >  NX   Successfully initialized git.
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The repo name passed in the command should be used if available instead of the app name.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
