### PR TITLE
docs(core): update angular to nx guide

### DIFF
--- a/docs/shared/migration/migration-angular.md
+++ b/docs/shared/migration/migration-angular.md
@@ -130,7 +130,6 @@ After the changes are applied, your workspace file structure should look similar
 ├── .gitignore
 ├── .prettierignore
 ├── .prettierrc
-├── angular.json
 ├── decorate-angular-cli.js
 ├── karma.conf.js
 ├── nx.json
@@ -205,49 +204,41 @@ yarn create nx-workspace myorg --preset=angular
 
 When prompted for the `application name`, enter the _project name_ from your current `angular.json` file.
 
-A new Nx workspace with your `org name` as the folder name, and your `application name` as the first application is generated.
+A new Nx workspace with your `org name` as the folder name, and your `application name` as the root-level application is generated.
 
 ```text
 <workspace name>/
-├── apps/
-│   ├── <app name>/
-│   │   ├── src/
-│   │   │   ├── app/
-│   │   │   ├── assets/
-│   │   │   ├── environments/
-│   │   │   ├── favicon.ico
-│   │   │   ├── index.html
-│   │   │   ├── main.ts
-│   │   │   ├── polyfills.ts
-│   │   │   ├── styles.css
-│   │   │   └── test.ts
-│   │   ├── browserslist
-│   │   ├── jest.conf.js
-│   │   ├── tsconfig.app.json
-│   │   ├── tsconfig.json
-│   │   ├── tslint.json
-│   │   └── tsconfig.spec.json
-│   └── <app name>-e2e/
-│       ├── src/
-│       ├── cypress.json
-│       ├── tsconfig.e2e.json
-│       ├── tslint.json
-│       └── tsconfig.json
-├── libs/
-├── tools/
-├── .editorconfig
+├── e2e/
+│   ├── src/
+│   ├── .eslintrc.json
+│   ├── cypress.config.ts
+│   ├── project.json
+│   └── tsconfig.json
+├── src/
+│   ├── app/
+│   ├── assets/
+│   ├── favicon.ico
+│   ├── index.html
+│   ├── main.ts
+│   ├── styles.css
+│   └── test-setup.ts
 ├── .eslintrc.json
+├── .eslintrc.<app name>.json
 ├── .gitignore
 ├── .prettierignore
 ├── .prettierrc
-├── angular.json
-├── decorate-angular-cli.js
-├── jest.config.js
+├── jest.config.app.ts
+├── jest.config.ts
 ├── jest.preset.js
 ├── nx.json
 ├── package.json
+├── project.json
 ├── README.md
-└── tsconfig.base.json
+├── tsconfig.app.json
+├── tsconfig.base.json
+├── tsconfig.editor.json
+├── tsconfig.json
+└── tsconfig.spec.json
 ```
 
 ### Copying over application files
@@ -255,8 +246,8 @@ A new Nx workspace with your `org name` as the folder name, and your `applicatio
 Your application code is self-contained within the `src` folder of your Angular CLI workspace.
 
 - Copy the `src` folder from your Angular CLI project to the `apps/<app name>` folder, overwriting the existing `src` folder.
-- Copy any project-specific configuration files, such as `browserslist`, or service worker configuration files into their relative path under the `apps/<app name>` folder.
-- Transfer the `assets`, `scripts`, `styles`, and build-specific configuration, such as service worker configuration, from your Angular CLI `angular.json` to the `apps/<app name>/project.json` file.
+- Copy any project-specific configuration files, such as `browserslist`, or service worker configuration files into their relative path in the root of the repo.
+- Transfer the `assets`, `scripts`, `styles`, and build-specific configuration, such as service worker configuration, from your Angular CLI `angular.json` to the root-level `project.json` file.
 
 Verify your application runs correctly by running:
 
@@ -276,29 +267,29 @@ ng test <app name>
 
 If you are using `Karma` for unit testing:
 
-- Copy the `karma.conf.js` file to your `apps/<app name>` folder.
-- Copy the `test.ts` file to your `apps/<app name>/src` folder.
-- Copy the `test` target in your `architect` configuration from your Angular CLI `angular.json` file into the `targets` configuration in the `apps/<app name>/project.json` file in your Nx workspace.
+- Copy the `karma.conf.js` file to the root folder.
+- Copy the `test.ts` file to your `src` folder.
+- Copy the `test` target in your `architect` configuration from your Angular CLI `angular.json` file into the `targets` configuration in the `project.json` file in your Nx workspace.
 - Update the `test` target file paths to be relative to `apps/<app name>`.
 
-```jsonc {% fileName="apps/<app name>/project.json" %}
+```jsonc {% fileName="project.json" %}
 {
   "projectType": "application",
-  "sourceRoot": "apps/<app name>/src",
+  "sourceRoot": "src",
   "prefix": "myapp",
   "targets": {
     "test": {
       "executor": "@angular-devkit/build-angular:karma",
       "options": {
-        "main": "apps/<app name>/src/test.ts",
-        "polyfills": "apps/<app name>/src/polyfills.ts",
-        "tsConfig": "apps/<app name>/tsconfig.spec.json",
-        "karmaConfig": "apps/<app name>/karma.conf.js",
+        "main": "src/test.ts",
+        "polyfills": "src/polyfills.ts",
+        "tsConfig": "tsconfig.spec.json",
+        "karmaConfig": "karma.conf.js",
         "assets": [
-          "apps/<app name>/src/favicon.ico",
-          "apps/<app name>/src/assets"
+          "src/favicon.ico",
+          "src/assets"
         ],
-        "styles": ["apps/<app name>/src/styles.css"],
+        "styles": ["src/styles.css"],
         "scripts": []
       }
     }
@@ -309,9 +300,9 @@ If you are using `Karma` for unit testing:
 
 > Jest will be used by default when generating new applications. If you want to continue using `Karma`, set the `unitTestRunner` to `karma` in the `generators` section of the `nx.json` file.
 
-- Update `test-setup.ts` to `test.ts` in the `files` array of the `apps/<app name>/tsconfig.spec.json` file.
+- Update `test-setup.ts` to `test.ts` in the `files` array of the `tsconfig.spec.json` file.
 
-```json {% fileName="apps/<app name>/tsconfig.spec.json" %}
+```json {% fileName="tsconfig.spec.json" %}
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
@@ -339,20 +330,20 @@ ng e2e <app name>-e2e
 
 If you are using `Protractor` for E2E testing:
 
-- Delete the `apps/<app name>-e2e` folder that was generated to use Cypress.
-- Copy the `e2e` folder from your Angular CLI workspace into the `apps` folder.
+- Delete the `e2e` folder that was generated to use Cypress.
+- Copy the `e2e` folder from your Angular CLI workspace into the root folder.
 - Rename the `e2e` folder to `<app name>-e2e`.
-- Create the project configuration file at `apps/<app name>-e2e/project.json`.
-- Copy the project configuration for `app name` from the Angular CLI workspace `angular.json` file to `apps/<app name>-e2e/project.json` and adjust the file paths to be relative to `apps/<app name>-e2e`.
+- Create the project configuration file at `e2e/project.json`.
+- Copy the project configuration for `app name` from the Angular CLI workspace `angular.json` file to `e2e/project.json` and adjust the file paths to be relative to `e2e`.
 
-```json {% fileName="apps/<app name>-e2e/project.json" %}
+```json {% fileName="e2e/project.json" %}
 {
   "projectType": "application",
   "targets": {
     "e2e": {
       "executor": "@angular-devkit/build-angular:protractor",
       "options": {
-        "protractorConfig": "apps/<app name>-e2e/protractor.conf.js"
+        "protractorConfig": "e2e/protractor.conf.js"
       },
       "configurations": {
         "production": {
@@ -367,8 +358,8 @@ If you are using `Protractor` for E2E testing:
     "lint": {
       "executor": "@angular-devkit/build-angular:tslint",
       "options": {
-        "tsConfig": "apps/<app name>-e2e/tsconfig.e2e.json",
-        "exclude": ["**/node_modules/**", "!apps/<app name>-e2e/**/*"]
+        "tsConfig": "e2e/tsconfig.e2e.json",
+        "exclude": ["**/node_modules/**", "!e2e/**/*"]
       }
     }
   },
@@ -377,9 +368,9 @@ If you are using `Protractor` for E2E testing:
 }
 ```
 
-Create a `tsconfig.e2e.json` file under `apps/<app name>-e2e` folder:
+Create a `tsconfig.e2e.json` file under `e2e` folder:
 
-```json {% fileName="apps/<app name>-e2e/tsconfig.e2e.json" %}
+```json {% fileName="e2e/tsconfig.e2e.json" %}
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
@@ -388,13 +379,13 @@ Create a `tsconfig.e2e.json` file under `apps/<app name>-e2e` folder:
 }
 ```
 
-Update the `apps/<app name>/tsconfig.json` to extend the root `tsconfig.json`:
+Update the `tsconfig.app.json` to extend the root `tsconfig.json`:
 
-```json {% fileName="apps/<app name>/tsconfig.json" %}
+```json {% fileName="tsconfig.app.json" %}
 {
-  "extends": "../../tsconfig.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../out-tsc/<app name>-e2e",
+    "outDir": "./dist/out-tsc",
     "module": "commonjs",
     "target": "es5",
     "types": ["jasmine", "jasminewd2", "node"]
@@ -405,7 +396,7 @@ Update the `apps/<app name>/tsconfig.json` to extend the root `tsconfig.json`:
 Verify your E2E tests run correctly by running:
 
 ```shell
-ng e2e <app name>-e2e
+ng e2e e2e
 ```
 
 > Cypress will be used by default when generating new applications. If you want to continue using `Protractor`, set the `e2eTestRunner` to `protractor` in the `generators` section of the `nx.json` file.

--- a/docs/shared/migration/migration-angular.md
+++ b/docs/shared/migration/migration-angular.md
@@ -14,12 +14,14 @@ This command will install the correct version of Nx based on your Angular versio
 
 This will enable you to use the Nx CLI in your existing Angular CLI workspace while keeping your existing file structure in place. The following changes will be made in your repo to enable Nx:
 
-- The `nx` and `@nrwl/workspace` packages will be installed.
+- The `nx`, `@nrwl/workspace` and `prettier` packages will be installed.
 - An `nx.json` file will be created in the root of your workspace.
 - A `decorate-angular-cli.js` file will be added to the root of your workspace, and a `postinstall` script will be added to your `package.json` to run this script when your dependencies are updated. (The script forwards the `ng` commands to the Nx CLI (`nx`) to enable features such as [Computation Caching](/concepts/how-caching-works).)
 - For an Angular 15+ repo, the `angular.json` file is split into separate `project.json` files for each project.
 
 After the process completes, you can continue using the same `serve/build/lint/test` commands you are used to.
+
+**Note:** The changes will be slightly different for Angular 14 and lower.
 
 ## Transforming an Angular CLI workspace to an Integrated Nx Monorepo
 

--- a/docs/shared/migration/migration-angular.md
+++ b/docs/shared/migration/migration-angular.md
@@ -7,19 +7,15 @@ src="https://www.youtube.com/embed/dJG9zH30c-o"
 title="Nx in 100 seconds: Migrate an Angular CLI app to Nx"
 width="100%" /%}
 
-## Prerequisites
+## Migrating to a Standalone Angular App with Nx
 
-**The major version of your `Angular CLI` must align with the version of `Nx` you are upgrading to**. You can check the [Nx and Angular Version Compatibility Matrix](/angular-nx-version-matrix) for more information.
-
-## Using the Nx CLI while preserving the existing structure
-
-To use the Nx CLI in an existing Angular CLI workspace while keeping your existing file structure in place, use the `ng add` command with the `--preserve-angular-cli-layout` option:
+You can migrate to a [Standalone Angular App](/angular-standalone-tutorial/1-code-generation) with the command:
 
 ```shell
-ng add @nrwl/angular --preserve-angular-cli-layout
+nx init
 ```
 
-**Note**: If you specify a version of Nx (e.g. `ng add @nrwl/angular@13.10.0`), please make sure to use the appropriate command as shown in the compatibility table below:
+**Note**: To migrate to legacy versions of Nx, you'll need to refer to the following compatibility table below:
 
 | Nx version          | Collection to use | Flag to use                     | Example                                                       |
 | ------------------- | ----------------- | ------------------------------- | ------------------------------------------------------------- |
@@ -27,17 +23,31 @@ ng add @nrwl/angular --preserve-angular-cli-layout
 | >= 13.8.4 < 13.10.0 | `@nrwl/workspace` | `--preserve-angular-cli-layout` | `ng add @nrwl/workspace@13.8.4 --preserve-angular-cli-layout` |
 | < 13.8.4            | `@nrwl/workspace` | `--preserveAngularCLILayout`    | `ng add @nrwl/workspace@13.5.0 --preserveAngularCLILayout`    |
 
-This installs the `@nrwl/angular` (or `@nrwl/workspace`) package into your workspace and runs a generator (or schematic) to make following changes:
+This will enable you to use the Nx CLI in your existing Angular CLI workspace while keeping your existing file structure in place. The following changes will be made in your repo to enable Nx:
 
-- Installs the `nx` and `@nrwl/workspace` packages.
-- Creates an `nx.json` file in the root of your workspace.
-- Adds a `decorate-angular-cli.js` to the root of your workspace, and a `postinstall` script in your `package.json` to run the script when your dependencies are updated. The script forwards the `ng` commands to the Nx CLI (`nx`) to enable features such as [Computation Caching](/concepts/how-caching-works).
+- The `nx` and `@nrwl/workspace` packages will be installed.
+- An `nx.json` file will be created in the root of your workspace.
+- A `decorate-angular-cli.js` file will be added to the root of your workspace, and a `postinstall` script will be added to your `package.json` to run this script when your dependencies are updated. (The script forwards the `ng` commands to the Nx CLI (`nx`) to enable features such as [Computation Caching](/concepts/how-caching-works).)
 
 After the process completes, you can continue using the same `serve/build/lint/test` commands you are used to.
 
-## Transforming an Angular CLI workspace to an Nx workspace
+## Transforming an Angular CLI workspace to an Integrated Nx Monorepo
 
-To fully take advantage of all the features provided by Nx and the Nx Angular plugin, you can do a full migration from an Angular CLI to an Nx workspace.
+To take advantage of Nx's monorepo features provided by Nx and the Nx Angular plugin, you can also perform a migration from an Angular CLI to an Integrated Nx Monorepo with the command:
+
+```shell
+ng add @nrwl/angular
+```
+
+**Note**: To migrate to legacy versions of Nx prior to Nx 13.10, run the command:
+
+```shell
+ng add @nrwl/workspace@<version_number>
+```
+
+**Note**: Refer to the [Nx and Angular Version Compatibility Matrix](/angular-nx-version-matrix) for matching Angular and Nx versions.
+
+**Note**: Support for workspaces with multiple applications and libraries was added in Nx v14.1.0. If you are migrating using an older version of Nx, your workspace can only contain one application and no libraries in order to use the automated migration, otherwise, you can still [migrate manually](#transitioning-manually).
 
 > The automated migration supports Angular CLI workspaces with a standard structure, configurations and features. If your workspace has deviated from what the Angular CLI generates, you might not be able to use the automated migration and you will need to [manually migrate your workspace](#transitioning-manually).
 >
@@ -57,21 +67,6 @@ To fully take advantage of all the features provided by Nx and the Nx Angular pl
 >
 > Support for other executors may be added in the future.
 
-To transform an Angular CLI workspace to an Nx workspace, run the following command:
-
-```shell
-ng add @nrwl/angular
-```
-
-**Note**: If you specify a version of Nx (e.g. `ng add @nrwl/angular@13.10.0`), please make sure to use the appropriate command as shown in the compatibility table below:
-
-| Nx version | Command to run           |
-| ---------- | ------------------------ |
-| >= 13.10.0 | `ng add @nrwl/angular`   |
-| < 13.10.0  | `ng add @nrwl/workspace` |
-
-> **Note**: Support for workspaces with multiple applications and libraries was added in Nx v14.1.0. If you are migrating using an older version of Nx, your workspace can only contain one application and no libraries in order to use the automated migration, otherwise, you can still [migrate manually](#transitioning-manually).
-
 This installs the `@nrwl/angular` (or `@nrwl/workspace`) package into your workspace and runs a generator (or schematic) to transform your workspace. The generator applies the following changes to your workspace:
 
 - Installs the `nx` and `@nrwl/workspace` packages.
@@ -85,7 +80,6 @@ This installs the `@nrwl/angular` (or `@nrwl/workspace`) package into your works
 - Moves your libraries into the `libs` folder, and updates the relevant file paths in your configuration files.
 - Updates your `package.json` scripts to use `nx` instead of `ng`.
 - Splits your `angular.json` into `project.json` files for each project with updated paths.
-- Updates the `angular.json` configuration to reflect the changes made.
 
 After the changes are applied, your workspace file structure should look similar to the one below:
 
@@ -146,7 +140,7 @@ Your workspace is now powered by Nx! You can verify out that your application st
 - To run e2e tests, run `ng e2e` (or `nx e2e`).
 - To see your project graph, run `nx graph`.
 
-> Your project graph will grow as you add, and use more applications and libraries. You can add the `--watch` flag to `nx graph` to see this changes in-browser as you add them.
+> Your project graph will grow as you add, and use more applications and libraries. You can add the `--watch` flag to `nx graph` to see the changes in-browser as you add them.
 
 Learn more about the advantages of Nx in the following guides:
 

--- a/docs/shared/migration/migration-angular.md
+++ b/docs/shared/migration/migration-angular.md
@@ -187,19 +187,19 @@ To start, run the command to generate an Nx workspace with an Angular applicatio
 **Using `npx`**
 
 ```shell
-npx create-nx-workspace myorg --preset=angular
+npx create-nx-workspace myorg --preset=angular-standalone
 ```
 
 **Using `npm init`**
 
 ```shell
-npm init nx-workspace myorg --preset=angular
+npm init nx-workspace myorg --preset=angular-standalone
 ```
 
 **Using `yarn create`**
 
 ```shell
-yarn create nx-workspace myorg --preset=angular
+yarn create nx-workspace myorg --preset=angular-standalone
 ```
 
 When prompted for the `application name`, enter the _project name_ from your current `angular.json` file.
@@ -223,7 +223,7 @@ A new Nx workspace with your `org name` as the folder name, and your `applicatio
 │   ├── styles.css
 │   └── test-setup.ts
 ├── .eslintrc.json
-├── .eslintrc.<app name>.json
+├── .eslintrc.base.json
 ├── .gitignore
 ├── .prettierignore
 ├── .prettierrc
@@ -356,12 +356,11 @@ If you are using `Protractor` for E2E testing:
       "defaultConfiguration": "development"
     },
     "lint": {
-      "executor": "@angular-devkit/build-angular:tslint",
+      "executor": "@nrwl/linter:eslint",
       "options": {
-        "tsConfig": "e2e/tsconfig.e2e.json",
-        "exclude": ["**/node_modules/**", "!e2e/**/*"]
+        "lintFilePatterns": ["apps/myapp/**/*.ts", "apps/myapp/**/*.html"]
       }
-    }
+    },
   },
   "implicitDependencies": ["<app name>"],
   "tags": []
@@ -403,7 +402,7 @@ ng e2e e2e
 
 ### Updating your linting configuration
 
-For lint rules, migrate your existing rules into the root `tslint.json` file.
+For lint rules, migrate your existing rules into the root `.eslintrc.base.json` file.
 
 Verify your lint checks run correctly by running:
 

--- a/docs/shared/migration/migration-angular.md
+++ b/docs/shared/migration/migration-angular.md
@@ -2,11 +2,6 @@
 
 Within an Nx workspace, you gain many capabilities that help you build applications and libraries using a monorepo approach. If you are currently using an Angular CLI workspace, you can transform it into an Nx workspace.
 
-{% youtube
-src="https://www.youtube.com/embed/dJG9zH30c-o"
-title="Nx in 100 seconds: Migrate an Angular CLI app to Nx"
-width="100%" /%}
-
 ## Migrating to a Standalone Angular App with Nx
 
 You can migrate to a [Standalone Angular App](/angular-standalone-tutorial/1-code-generation) with the command:

--- a/docs/shared/migration/migration-angular.md
+++ b/docs/shared/migration/migration-angular.md
@@ -246,7 +246,7 @@ A new Nx workspace with your `org name` as the folder name, and your `applicatio
 Your application code is self-contained within the `src` folder of your Angular CLI workspace.
 
 - Copy the `src` folder from your Angular CLI project to the `apps/<app name>` folder, overwriting the existing `src` folder.
-- Copy any project-specific configuration files, such as `browserslist`, or service worker configuration files into their relative path in the root of the repo.
+- Copy any project-specific configuration files, such as `browserslist`, or service worker configuration files into their relative path under `src` in the root of the repo.
 - Transfer the `assets`, `scripts`, `styles`, and build-specific configuration, such as service worker configuration, from your Angular CLI `angular.json` to the root-level `project.json` file.
 
 Verify your application runs correctly by running:
@@ -270,33 +270,7 @@ If you are using `Karma` for unit testing:
 - Copy the `karma.conf.js` file to the root folder.
 - Copy the `test.ts` file to your `src` folder.
 - Copy the `test` target in your `architect` configuration from your Angular CLI `angular.json` file into the `targets` configuration in the `project.json` file in your Nx workspace.
-- Update the `test` target file paths to be relative to `apps/<app name>`.
-
-```jsonc {% fileName="project.json" %}
-{
-  "projectType": "application",
-  "sourceRoot": "src",
-  "prefix": "myapp",
-  "targets": {
-    "test": {
-      "executor": "@angular-devkit/build-angular:karma",
-      "options": {
-        "main": "src/test.ts",
-        "polyfills": "src/polyfills.ts",
-        "tsConfig": "tsconfig.spec.json",
-        "karmaConfig": "karma.conf.js",
-        "assets": [
-          "src/favicon.ico",
-          "src/assets"
-        ],
-        "styles": ["src/styles.css"],
-        "scripts": []
-      }
-    }
-    ...
-  }
-}
-```
+- Run `nx format` to change `architect` to `targets` and `builder` to `executor`.
 
 > Jest will be used by default when generating new applications. If you want to continue using `Karma`, set the `unitTestRunner` to `karma` in the `generators` section of the `nx.json` file.
 
@@ -332,48 +306,17 @@ If you are using `Protractor` for E2E testing:
 
 - Delete the `e2e` folder that was generated to use Cypress.
 - Copy the `e2e` folder from your Angular CLI workspace into the root folder.
-- Rename the `e2e` folder to `<app name>-e2e`.
 - Create the project configuration file at `e2e/project.json`.
-- Copy the project configuration for `app name` from the Angular CLI workspace `angular.json` file to `e2e/project.json` and adjust the file paths to be relative to `e2e`.
+- Copy the project configuration for `e2e` from the Angular CLI workspace `angular.json` file to `e2e/project.json` and adjust the file paths to be relative to `e2e`.
+- Run `nx format` to change `architect` to `targets` and `builder` to `executor`.
 
-```json {% fileName="e2e/project.json" %}
+Create a `tsconfig.json` file under `e2e` folder:
+
+```json {% fileName="e2e/tsconfig.json" %}
 {
-  "projectType": "application",
-  "targets": {
-    "e2e": {
-      "executor": "@angular-devkit/build-angular:protractor",
-      "options": {
-        "protractorConfig": "e2e/protractor.conf.js"
-      },
-      "configurations": {
-        "production": {
-          "devServerTarget": "<app name>:serve:production"
-        },
-        "development": {
-          "devServerTarget": "<app name>:serve:development"
-        }
-      }
-      "defaultConfiguration": "development"
-    },
-    "lint": {
-      "executor": "@nrwl/linter:eslint",
-      "options": {
-        "lintFilePatterns": ["apps/myapp/**/*.ts", "apps/myapp/**/*.html"]
-      }
-    },
-  },
-  "implicitDependencies": ["<app name>"],
-  "tags": []
-}
-```
-
-Create a `tsconfig.e2e.json` file under `e2e` folder:
-
-```json {% fileName="e2e/tsconfig.e2e.json" %}
-{
-  "extends": "./tsconfig.json",
+  "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "../../dist/out-tsc"
+    "outDir": "../dist/out-tsc"
   }
 }
 ```

--- a/docs/shared/migration/migration-angular.md
+++ b/docs/shared/migration/migration-angular.md
@@ -7,22 +7,17 @@ Within an Nx workspace, you gain many capabilities that help you build applicati
 You can migrate to a [Standalone Angular App](/angular-standalone-tutorial/1-code-generation) with the command:
 
 ```shell
-nx init
+npx nx init
 ```
 
-**Note**: To migrate to legacy versions of Nx, you'll need to refer to the following compatibility table below:
-
-| Nx version          | Collection to use | Flag to use                     | Example                                                       |
-| ------------------- | ----------------- | ------------------------------- | ------------------------------------------------------------- |
-| >= 13.10.0          | `@nrwl/angular`   | `--preserve-angular-cli-layout` | `ng add @nrwl/angular@13.10.0 --preserve-angular-cli-layout`  |
-| >= 13.8.4 < 13.10.0 | `@nrwl/workspace` | `--preserve-angular-cli-layout` | `ng add @nrwl/workspace@13.8.4 --preserve-angular-cli-layout` |
-| < 13.8.4            | `@nrwl/workspace` | `--preserveAngularCLILayout`    | `ng add @nrwl/workspace@13.5.0 --preserveAngularCLILayout`    |
+This command will install the correct version of Nx based on your Angular version.
 
 This will enable you to use the Nx CLI in your existing Angular CLI workspace while keeping your existing file structure in place. The following changes will be made in your repo to enable Nx:
 
 - The `nx` and `@nrwl/workspace` packages will be installed.
 - An `nx.json` file will be created in the root of your workspace.
 - A `decorate-angular-cli.js` file will be added to the root of your workspace, and a `postinstall` script will be added to your `package.json` to run this script when your dependencies are updated. (The script forwards the `ng` commands to the Nx CLI (`nx`) to enable features such as [Computation Caching](/concepts/how-caching-works).)
+- For an Angular 15+ repo, the `angular.json` file is split into separate `project.json` files for each project.
 
 After the process completes, you can continue using the same `serve/build/lint/test` commands you are used to.
 
@@ -31,7 +26,7 @@ After the process completes, you can continue using the same `serve/build/lint/t
 To take advantage of Nx's monorepo features provided by Nx and the Nx Angular plugin, you can also perform a migration from an Angular CLI to an Integrated Nx Monorepo with the command:
 
 ```shell
-ng add @nrwl/angular
+ng add @nrwl/angular@<version_number>
 ```
 
 **Note**: To migrate to legacy versions of Nx prior to Nx 13.10, run the command:

--- a/docs/shared/migration/migration-angular.md
+++ b/docs/shared/migration/migration-angular.md
@@ -92,32 +92,20 @@ After the changes are applied, your workspace file structure should look similar
 ```text
 <workspace name>/
 ├── apps/
-│   ├── <app name>/
-│   │   ├── src/
-│   │   │   ├── app/
-│   │   │   ├── assets/
-│   │   │   ├── environments/
-│   │   │   ├── favicon.ico
-│   │   │   ├── index.html
-│   │   │   ├── main.ts
-│   │   │   ├── polyfills.ts
-│   │   │   ├── styles.css
-│   │   │   └── test.ts
-│   │   ├── .browserslistrc
-│   │   ├── karma.conf.js
-│   │   ├── project.json
-│   │   ├── tsconfig.app.json
-│   │   └── tsconfig.spec.json
-│   └── <app name>-e2e/
+│   └─ <app name>/
 │       ├── src/
-│       ├── protractor.conf.js | cypress.json
+│       │   ├── app/
+│       │   ├── assets/
+│       │   ├── favicon.ico
+│       │   ├── index.html
+│       │   ├── main.ts
+│       │   └── styles.css
 │       ├── project.json
-│       └── tsconfig.json
+│       ├── tsconfig.app.json
+│       └── tsconfig.spec.json
 ├── libs/
 │   └── <lib name>/
 │       ├── src/
-│       ├── .browserslistrc
-│       ├── karma.conf.js
 │       ├── ng-package.json
 │       ├── package.json
 │       ├── project.json
@@ -140,10 +128,9 @@ After the changes are applied, your workspace file structure should look similar
 
 Your workspace is now powered by Nx! You can verify out that your application still runs as intended:
 
-- To serve, run `ng serve` (or `nx serve`).
-- To build, run `ng build` (or `nx build`).
-- To run unit tests, run `ng test` (or `nx test`).
-- To run e2e tests, run `ng e2e` (or `nx e2e`).
+- To serve, run `ng serve <app name>` (or `nx serve <app name>`).
+- To build, run `ng build <app name>` (or `nx build <app name>`).
+- To run unit tests, run `ng test <app name>` (or `nx test <app name>`).
 - To see your project graph, run `nx graph`.
 
 > Your project graph will grow as you add, and use more applications and libraries. You can add the `--watch` flag to `nx graph` to see this changes in-browser as you add them.


### PR DESCRIPTION
Updates the angular cli to Nx guide

It accurately describes how to use `ng add @nrwl/angular`.  But should we direct people to use `nx init` instead?  I think people coming from Angular will be more comfortable with the `ng add` syntax, so I left the guide using that syntax.