### PR TITLE
fix(testing): fix jest paths for root directory

### DIFF
--- a/packages/jest/src/utils/config/get-jest-projects.spec.ts
+++ b/packages/jest/src/utils/config/get-jest-projects.spec.ts
@@ -23,7 +23,9 @@ describe('getJestProjects', () => {
     jest
       .spyOn(Workspace, 'readWorkspaceConfig')
       .mockImplementation(() => mockedWorkspaceConfig);
-    const expectedResults = ['<rootDir>/test/jest/config/location'];
+    const expectedResults = [
+      '<rootDir>/test/jest/config/location/jest.config.js',
+    ];
     expect(getJestProjects()).toEqual(expectedResults);
   });
 
@@ -47,7 +49,33 @@ describe('getJestProjects', () => {
     jest
       .spyOn(Workspace, 'readWorkspaceConfig')
       .mockImplementation(() => mockedWorkspaceConfig);
-    const expectedResults = ['<rootDir>/test/jest/config/location'];
+    const expectedResults = [
+      '<rootDir>/test/jest/config/location/jest.config.js',
+    ];
+    expect(getJestProjects()).toEqual(expectedResults);
+  });
+
+  test('root project', () => {
+    const mockedWorkspaceConfig: WorkspaceJsonConfiguration = {
+      projects: {
+        'test-1': {
+          root: '.',
+          targets: {
+            test: {
+              executor: '@nrwl/jest:jest',
+              options: {
+                jestConfig: 'jest.config.app.js',
+              },
+            },
+          },
+        },
+      },
+      version: 1,
+    };
+    jest
+      .spyOn(Workspace, 'readWorkspaceConfig')
+      .mockImplementation(() => mockedWorkspaceConfig);
+    const expectedResults = ['<rootDir>/jest.config.app.js'];
     expect(getJestProjects()).toEqual(expectedResults);
   });
 
@@ -77,8 +105,8 @@ describe('getJestProjects', () => {
       .spyOn(Workspace, 'readWorkspaceConfig')
       .mockImplementation(() => mockedWorkspaceConfig);
     const expectedResults = [
-      '<rootDir>/test/jest/config/location',
-      '<rootDir>/configuration-specific',
+      '<rootDir>/test/jest/config/location/jest.config.js',
+      '<rootDir>/configuration-specific/jest.config.js',
     ];
     expect(getJestProjects()).toEqual(expectedResults);
   });
@@ -108,7 +136,9 @@ describe('getJestProjects', () => {
     jest
       .spyOn(Workspace, 'readWorkspaceConfig')
       .mockImplementation(() => mockedWorkspaceConfig);
-    const expectedResults = ['<rootDir>/test/jest/config/location'];
+    const expectedResults = [
+      '<rootDir>/test/jest/config/location/jest.config.js',
+    ];
     expect(getJestProjects()).toEqual(expectedResults);
   });
 

--- a/packages/jest/src/utils/config/get-jest-projects.ts
+++ b/packages/jest/src/utils/config/get-jest-projects.ts
@@ -1,11 +1,11 @@
-import { dirname, join } from 'path';
+import { join } from 'path';
 import type { ProjectsConfigurations } from '@nrwl/devkit';
 import { readWorkspaceConfig } from 'nx/src/project-graph/file-utils';
 
 const JEST_RUNNER_TOKEN = '@nrwl/jest:jest';
 
 function getJestConfigProjectPath(projectJestConfigPath: string): string {
-  return join('<rootDir>', dirname(projectJestConfigPath));
+  return join('<rootDir>', projectJestConfigPath);
 }
 
 export function getJestProjects() {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`getJestProjects()` returns `[<rootDir>]` for a root project with `jest.config.app.ts` which is incorrect.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`getJestProjects()` returns `[<rootDir>/jest.config.app.ts]` for a root project with `jest.config.app.ts`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
