### PR TITLE
cleanup(angular): add util for finding the directory name based on angular version

### DIFF
--- a/packages/angular/src/utils/get-generator-directory-for-ng-version.spec.ts
+++ b/packages/angular/src/utils/get-generator-directory-for-ng-version.spec.ts
@@ -1,0 +1,47 @@
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { updateJson } from '@nrwl/devkit';
+import { getGeneratorDirectoryForInstalledAngularVersion } from './get-generator-directory-for-ng-version';
+
+describe('getGeneratorDirectoryForAngularVersion', () => {
+  test.each(['14.0.0', '~14.1.0', '^14.2.0', '~14.3.0-beta.0'])(
+    'should return correct directory name for v14',
+    (ngVersion) => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      updateJson(tree, 'package.json', (json) => ({
+        ...json,
+        dependencies: {
+          '@angular/core': ngVersion,
+        },
+      }));
+
+      // ACT
+      const directoryName =
+        getGeneratorDirectoryForInstalledAngularVersion(tree);
+
+      // ASSERT
+      expect(directoryName).toEqual('angular-v14');
+    }
+  );
+
+  test.each(['15.0.0', '~15.1.0', '^13.2.0', '~15.3.0-beta.0'])(
+    'should return null for anything other than v14',
+    (ngVersion) => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      updateJson(tree, 'package.json', (json) => ({
+        ...json,
+        dependencies: {
+          '@angular/core': ngVersion,
+        },
+      }));
+
+      // ACT
+      const directoryName =
+        getGeneratorDirectoryForInstalledAngularVersion(tree);
+
+      // ASSERT
+      expect(directoryName).toBe(null);
+    }
+  );
+});

--- a/packages/angular/src/utils/get-generator-directory-for-ng-version.ts
+++ b/packages/angular/src/utils/get-generator-directory-for-ng-version.ts
@@ -1,0 +1,16 @@
+import type { Tree } from '@nrwl/devkit';
+import { readJson } from '@nrwl/devkit';
+import { coerce, major } from 'semver';
+
+export function getGeneratorDirectoryForInstalledAngularVersion(tree: Tree) {
+  const pkgJson = readJson(tree, 'package.json');
+  const angularVersion = pkgJson.dependencies['@angular/core'];
+
+  const majorAngularVersion = major(coerce(angularVersion));
+
+  const directoryDictionary = {
+    14: 'angular-v14',
+  };
+
+  return directoryDictionary[majorAngularVersion] ?? null;
+}


### PR DESCRIPTION
We need a method for determining the major version of angular installed and the directory name that contains the generator logic for that version.

Add a util to handle this.
