### PR TITLE
fix(angular): don't set the workspaceLayout when migrating an angular cli workspace to nx

### DIFF
--- a/packages/angular/src/generators/ng-add/__snapshots__/migrate-from-angular-cli.spec.ts.snap
+++ b/packages/angular/src/generators/ng-add/__snapshots__/migrate-from-angular-cli.spec.ts.snap
@@ -36,10 +36,6 @@ Object {
       "runner": "nx/tasks-runners/default",
     },
   },
-  "workspaceLayout": Object {
-    "appsDir": "",
-    "libsDir": "",
-  },
 }
 `;
 
@@ -96,10 +92,6 @@ Object {
       },
       "runner": "nx/tasks-runners/default",
     },
-  },
-  "workspaceLayout": Object {
-    "appsDir": "projects",
-    "libsDir": "projects",
   },
 }
 `;

--- a/packages/angular/src/generators/ng-add/migrate-from-angular-cli.ts
+++ b/packages/angular/src/generators/ng-add/migrate-from-angular-cli.ts
@@ -52,7 +52,7 @@ export async function migrateFromAngularCli(
         prettier: prettierVersion,
       }
     );
-    createNxJson(tree, options, true);
+    createNxJson(tree, options);
     decorateAngularCli(tree);
     updateVsCodeRecommendedExtensions(tree);
     await updatePrettierConfig(tree);

--- a/packages/angular/src/generators/ng-add/utilities/workspace.ts
+++ b/packages/angular/src/generators/ng-add/utilities/workspace.ts
@@ -43,12 +43,7 @@ export function validateWorkspace(tree: Tree): void {
   - ${errors.join('\n  ')}`);
 }
 
-export function createNxJson(
-  tree: Tree,
-  options: GeneratorOptions,
-  setWorkspaceLayoutAsNewProjectRoot: boolean = false
-): void {
-  const { newProjectRoot = '' } = readJson(tree, 'angular.json');
+export function createNxJson(tree: Tree, options: GeneratorOptions): void {
   const { npmScope } = options;
 
   const targets = getWorkspaceCommonTargets(tree);
@@ -107,9 +102,6 @@ export function createNxJson(
           }
         : undefined,
     },
-    workspaceLayout: setWorkspaceLayoutAsNewProjectRoot
-      ? { appsDir: newProjectRoot, libsDir: newProjectRoot }
-      : undefined,
   });
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When migrating an Angular CLI workspace to Nx using the `preserve-angular-cli-layout` flag, the `workspaceLayout` option is set.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `workspaceLayout` option should not be set when migrating an Angular CLI workspace to Nx.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
