### PR TITLE
fix(core): always set root version of npm packages

### DIFF
--- a/packages/nx/src/lock-file/npm.ts
+++ b/packages/nx/src/lock-file/npm.ts
@@ -157,10 +157,11 @@ function mapPackageDependency(
     peer,
     optional,
   };
-  if (!mappedPackages[packageName][key]) {
+  const rootVersion =
+    isRootVersion ?? packagePath.split('/node_modules/').length === 1;
+
+  if (!mappedPackages[packageName][key] || rootVersion) {
     // const packageDependencies = lockfileVersion === 1 ? requires : dependencies;
-    const rootVersion =
-      isRootVersion ?? packagePath.split('/node_modules/').length === 1;
 
     if (lockfileVersion === 1) {
       const { requires, ...rest } = value;


### PR DESCRIPTION
## Current Behavior
Root level depednencies are being missed when versions match submodules

## Expected Behavior
Root level dependencies should always match the package.json

