### PR TITLE
fix(vite): apps packagejson copy

### DIFF
--- a/e2e/vite/src/vite.test.ts
+++ b/e2e/vite/src/vite.test.ts
@@ -3,6 +3,7 @@ import {
   cleanupProject,
   createFile,
   exists,
+  fileExists,
   killPorts,
   listFiles,
   newProject,
@@ -242,6 +243,7 @@ describe('Vite Plugin', () => {
         expect(
           readFile(`dist/apps/${myApp}/assets/${mainBundle}`)
         ).toBeDefined();
+        expect(fileExists(`dist/apps/${myApp}/package.json`)).toBeFalsy();
         rmDist();
       }, 200_000);
     });

--- a/packages/vite/src/executors/build/build.impl.ts
+++ b/packages/vite/src/executors/build/build.impl.ts
@@ -5,7 +5,7 @@ import { getBuildAndSharedConfig } from '../../utils/options-utils';
 import { ViteBuildExecutorOptions } from './schema';
 import { copyAssets } from '@nrwl/js';
 import { existsSync } from 'fs';
-import { join } from 'path';
+import { resolve } from 'path';
 
 export default async function viteBuildExecutor(
   options: ViteBuildExecutorOptions,
@@ -15,8 +15,14 @@ export default async function viteBuildExecutor(
 
   await runInstance(await getBuildAndSharedConfig(options, context));
 
+  const libraryPackageJson = resolve(projectRoot, 'package.json');
+  const rootPackageJson = resolve(context.root, 'package.json');
+
   // For buildable libs, copy package.json if it exists.
-  if (existsSync(join(projectRoot, 'package.json'))) {
+  if (
+    existsSync(libraryPackageJson) &&
+    rootPackageJson !== libraryPackageJson
+  ) {
     await copyAssets(
       {
         outputPath: options.outputPath,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently when you build a vite app the app artifact contains `package.json`.
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Only lib artifacts should contain `packagae.json`
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
