### PR TITLE
feat(js): added a minimal option to the library generator

### DIFF
--- a/docs/generated/packages/js/generators/library.json
+++ b/docs/generated/packages/js/generators/library.json
@@ -122,6 +122,11 @@
         "type": "boolean",
         "description": "Whether to skip TypeScript type checking for SWC compiler.",
         "default": false
+      },
+      "minimal": {
+        "type": "boolean",
+        "description": "Generate a library with a minimal setup. No README.md generated.",
+        "default": false
       }
     },
     "required": ["name"],

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -1100,4 +1100,56 @@ describe('lib', () => {
       }
     );
   });
+
+  describe('--minimal', () => {
+    it('should generate a README.md when minimal is set to false', async () => {
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        name: 'myLib',
+        minimal: false,
+      });
+
+      expect(tree.exists('libs/my-lib/README.md')).toBeTruthy();
+    });
+
+    it('should not generate a README.md when minimal is set to true', async () => {
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        name: 'myLib',
+        minimal: true,
+      });
+
+      expect(tree.exists('libs/my-lib/README.md')).toBeFalsy();
+    });
+
+    it('should generate a README.md and add it to the build assets when buildable is true and minimal is false', async () => {
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        name: 'myLib',
+        bundler: 'tsc',
+        minimal: false,
+      });
+
+      expect(tree.exists('libs/my-lib/README.md')).toBeTruthy();
+
+      const project = readProjectConfiguration(tree, 'my-lib');
+      expect(project.targets.build.options.assets).toStrictEqual([
+        'libs/my-lib/*.md',
+      ]);
+    });
+
+    it('should not generate a README.md when both bundler and minimal are set', async () => {
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        name: 'myLib',
+        bundler: 'tsc',
+        minimal: true,
+      });
+
+      expect(tree.exists('libs/my-lib/README.md')).toBeFalsy();
+
+      const project = readProjectConfiguration(tree, 'my-lib');
+      expect(project.targets.build.options.assets).toEqual([]);
+    });
+  });
 });

--- a/packages/js/src/generators/library/schema.json
+++ b/packages/js/src/generators/library/schema.json
@@ -122,6 +122,11 @@
       "type": "boolean",
       "description": "Whether to skip TypeScript type checking for SWC compiler.",
       "default": false
+    },
+    "minimal": {
+      "type": "boolean",
+      "description": "Generate a library with a minimal setup. No README.md generated.",
+      "default": false
     }
   },
   "required": ["name"],

--- a/packages/js/src/utils/schema.d.ts
+++ b/packages/js/src/utils/schema.d.ts
@@ -31,6 +31,7 @@ export interface LibraryGeneratorSchema {
   compiler?: Compiler;
   bundler?: Bundler;
   skipTypeCheck?: boolean;
+  minimal?: boolean;
 }
 
 export interface ExecutorOptions {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When generating libraries i have no option to skip the generation of the `README.md` file. I have to delete the file by hand if I don't want it.

When generating buildable libraries a entry is added to the `assets` array of the build target. I have to delete that manually to if I want a clean `project.json`/`workspace.json` without unnecessary entries.

These often unnecessary generated READMEs add extra vertical space to a opened lib.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
I set the `includeReadme` flag to `false` when generating libs and end up with a lib without a `README.md` and without a `assets` property in the build targets options when generating a buildable lib.

`includeReadme` defaults to `true` so nothing has changed when not specifing this option.

I just implemented it for the `@nrwl/js:library` generator but I am willing to submit follow-up PRs if this gets merged.