### PR TITLE
feat(angular): add backwards compat support to setup-tailwind generator

### DIFF
--- a/packages/angular/src/generators/setup-tailwind/angular-v14/files/v2/tailwind.config.js__tmpl__
+++ b/packages/angular/src/generators/setup-tailwind/angular-v14/files/v2/tailwind.config.js__tmpl__
@@ -1,0 +1,18 @@
+const { createGlobPatternsForDependencies } = require('@nrwl/angular/tailwind');
+const { join } = require('path');
+
+module.exports = {
+  mode: 'jit',
+  purge: [
+    join(__dirname, '<%= relativeSourceRoot %>/**/!(*.stories|*.spec).{ts,html}'),
+    ...createGlobPatternsForDependencies(__dirname),
+  ],
+  darkMode: false, // or 'media' or 'class'
+  theme: {
+    extend: {},
+  },
+  variants: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/packages/angular/src/generators/setup-tailwind/angular-v14/files/v3/tailwind.config.js__tmpl__
+++ b/packages/angular/src/generators/setup-tailwind/angular-v14/files/v3/tailwind.config.js__tmpl__
@@ -1,0 +1,14 @@
+const { createGlobPatternsForDependencies } = require('@nrwl/angular/tailwind');
+const { join } = require('path');
+
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    join(__dirname, '<%= relativeSourceRoot %>/**/!(*.stories|*.spec).{ts,html}'),
+    ...createGlobPatternsForDependencies(__dirname),
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/packages/angular/src/generators/setup-tailwind/angular-v14/lib/add-tailwind-config-path-to-project.ts
+++ b/packages/angular/src/generators/setup-tailwind/angular-v14/lib/add-tailwind-config-path-to-project.ts
@@ -1,0 +1,56 @@
+import {
+  joinPathFragments,
+  ProjectConfiguration,
+  stripIndents,
+  Tree,
+  updateProjectConfiguration,
+} from '@nrwl/devkit';
+import { NormalizedGeneratorOptions } from '../schema';
+
+export function addTailwindConfigPathToProject(
+  tree: Tree,
+  options: NormalizedGeneratorOptions,
+  project: ProjectConfiguration
+): void {
+  const buildTarget = project.targets?.[options.buildTarget];
+
+  if (!buildTarget) {
+    throw new Error(
+      stripIndents`The target "${options.buildTarget}" was not found for project "${options.project}".
+      If you are using a different build target, please provide it using the "--buildTarget" option.
+      If the project is not a buildable or publishable library, you don't need to setup TailwindCSS for it.`
+    );
+  }
+
+  const supportedLibraryExecutors = [
+    '@nrwl/angular:ng-packagr-lite',
+    '@nrwl/angular:package',
+  ];
+  if (!supportedLibraryExecutors.includes(buildTarget.executor)) {
+    throw new Error(
+      stripIndents`The build target for project "${
+        options.project
+      }" is using an unsupported executor "${buildTarget.executor}".
+      Supported executors are ${supportedLibraryExecutors
+        .map((e) => `"${e}"`)
+        .join(', ')}.`
+    );
+  }
+
+  if (
+    buildTarget.options?.tailwindConfig &&
+    tree.exists(buildTarget.options.tailwindConfig)
+  ) {
+    throw new Error(
+      stripIndents`The "${buildTarget.options.tailwindConfig}" file is already configured for the project "${options.project}". Are you sure this is the right project to set up Tailwind?
+      If you are sure, you can remove the configuration and re-run the generator.`
+    );
+  }
+
+  buildTarget.options = {
+    ...buildTarget.options,
+    tailwindConfig: joinPathFragments(project.root, 'tailwind.config.js'),
+  };
+
+  updateProjectConfiguration(tree, options.project, project);
+}

--- a/packages/angular/src/generators/setup-tailwind/angular-v14/lib/add-tailwind-config.ts
+++ b/packages/angular/src/generators/setup-tailwind/angular-v14/lib/add-tailwind-config.ts
@@ -1,0 +1,35 @@
+import {
+  generateFiles,
+  joinPathFragments,
+  ProjectConfiguration,
+  stripIndents,
+  Tree,
+} from '@nrwl/devkit';
+import { relative } from 'path';
+import { GeneratorOptions } from '../schema';
+
+export function addTailwindConfig(
+  tree: Tree,
+  options: GeneratorOptions,
+  project: ProjectConfiguration,
+  tailwindVersion: '2' | '3'
+): void {
+  if (tree.exists(joinPathFragments(project.root, 'tailwind.config.js'))) {
+    throw new Error(
+      stripIndents`The "tailwind.config.js" file already exists in the project "${options.project}". Are you sure this is the right project to set up Tailwind?
+      If you are sure, you can remove the existing file and re-run the generator.`
+    );
+  }
+
+  const filesDir = tailwindVersion === '3' ? 'files/v3' : 'files/v2';
+
+  generateFiles(
+    tree,
+    joinPathFragments(__dirname, '..', filesDir),
+    project.root,
+    {
+      relativeSourceRoot: relative(project.root, project.sourceRoot),
+      tmpl: '',
+    }
+  );
+}

--- a/packages/angular/src/generators/setup-tailwind/angular-v14/lib/add-tailwind-required-packages.ts
+++ b/packages/angular/src/generators/setup-tailwind/angular-v14/lib/add-tailwind-required-packages.ts
@@ -1,0 +1,18 @@
+import {
+  addDependenciesToPackageJson,
+  GeneratorCallback,
+  Tree,
+} from '@nrwl/devkit';
+import { versions } from '../../../../utils/versions';
+
+export function addTailwindRequiredPackages(tree: Tree): GeneratorCallback {
+  return addDependenciesToPackageJson(
+    tree,
+    {},
+    {
+      autoprefixer: versions.angularV14.autoprefixerVersion,
+      postcss: versions.angularV14.postcssVersion,
+      tailwindcss: versions.angularV14.tailwindVersion,
+    }
+  );
+}

--- a/packages/angular/src/generators/setup-tailwind/angular-v14/lib/detect-tailwind-installed-version.ts
+++ b/packages/angular/src/generators/setup-tailwind/angular-v14/lib/detect-tailwind-installed-version.ts
@@ -1,0 +1,24 @@
+import { readJson, Tree } from '@nrwl/devkit';
+import { checkAndCleanWithSemver } from '@nrwl/workspace/src/utilities/version-utils';
+import { lt } from 'semver';
+
+export function detectTailwindInstalledVersion(
+  tree: Tree
+): '2' | '3' | undefined {
+  const { dependencies, devDependencies } = readJson(tree, 'package.json');
+  const tailwindVersion =
+    dependencies?.tailwindcss ?? devDependencies?.tailwindcss;
+
+  if (!tailwindVersion) {
+    return undefined;
+  }
+
+  const version = checkAndCleanWithSemver('tailwindcss', tailwindVersion);
+  if (lt(version, '2.0.0')) {
+    throw new Error(
+      `The Tailwind CSS version "${tailwindVersion}" is not supported. Please upgrade to v2.0.0 or higher.`
+    );
+  }
+
+  return lt(version, '3.0.0') ? '2' : '3';
+}

--- a/packages/angular/src/generators/setup-tailwind/angular-v14/lib/index.ts
+++ b/packages/angular/src/generators/setup-tailwind/angular-v14/lib/index.ts
@@ -1,0 +1,6 @@
+export * from './add-tailwind-config-path-to-project';
+export * from './add-tailwind-config';
+export * from './add-tailwind-required-packages';
+export * from './detect-tailwind-installed-version';
+export * from './normalize-options';
+export * from './update-application-styles';

--- a/packages/angular/src/generators/setup-tailwind/angular-v14/lib/normalize-options.ts
+++ b/packages/angular/src/generators/setup-tailwind/angular-v14/lib/normalize-options.ts
@@ -1,0 +1,10 @@
+import type { GeneratorOptions, NormalizedGeneratorOptions } from '../schema';
+
+export function normalizeOptions(
+  options: GeneratorOptions
+): NormalizedGeneratorOptions {
+  return {
+    ...options,
+    buildTarget: options.buildTarget || 'build',
+  };
+}

--- a/packages/angular/src/generators/setup-tailwind/angular-v14/lib/update-application-styles.ts
+++ b/packages/angular/src/generators/setup-tailwind/angular-v14/lib/update-application-styles.ts
@@ -1,0 +1,84 @@
+import {
+  joinPathFragments,
+  ProjectConfiguration,
+  stripIndents,
+  Tree,
+} from '@nrwl/devkit';
+import { NormalizedGeneratorOptions } from '../schema';
+
+export function updateApplicationStyles(
+  tree: Tree,
+  options: NormalizedGeneratorOptions,
+  project: ProjectConfiguration
+): void {
+  let stylesEntryPoint = options.stylesEntryPoint;
+
+  if (stylesEntryPoint && !tree.exists(stylesEntryPoint)) {
+    throw new Error(
+      `The provided styles entry point "${stylesEntryPoint}" could not be found.`
+    );
+  }
+
+  if (!stylesEntryPoint) {
+    stylesEntryPoint = findStylesEntryPoint(tree, options, project);
+
+    if (!stylesEntryPoint) {
+      throw new Error(
+        stripIndents`Could not find a styles entry point for project "${options.project}".
+        Please specify a styles entry point using the "--stylesEntryPoint" option.`
+      );
+    }
+  }
+
+  const stylesEntryPointContent = tree.read(stylesEntryPoint, 'utf-8');
+  tree.write(
+    stylesEntryPoint,
+    stripIndents`@tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+
+    ${stylesEntryPointContent}`
+  );
+}
+
+function findStylesEntryPoint(
+  tree: Tree,
+  options: NormalizedGeneratorOptions,
+  project: ProjectConfiguration
+): string | undefined {
+  // first check for common names
+  const possibleStylesEntryPoints = [
+    joinPathFragments(project.sourceRoot ?? project.root, 'styles.css'),
+    joinPathFragments(project.sourceRoot ?? project.root, 'styles.scss'),
+    joinPathFragments(project.sourceRoot ?? project.root, 'styles.sass'),
+    joinPathFragments(project.sourceRoot ?? project.root, 'styles.less'),
+  ];
+
+  let stylesEntryPoint = possibleStylesEntryPoints.find((s) => tree.exists(s));
+  if (stylesEntryPoint) {
+    return stylesEntryPoint;
+  }
+
+  // then check for the specified styles in the build configuration if it exists
+  const styles: Array<string | { input: string; inject: boolean }> =
+    project.targets?.[options.buildTarget].options?.styles;
+
+  if (!styles) {
+    return undefined;
+  }
+
+  // find the first style that belongs to the project source
+  const style = styles.find((s) =>
+    typeof s === 'string'
+      ? s.startsWith(project.root) && tree.exists(s)
+      : s.input.startsWith(project.root) &&
+        s.inject !== false &&
+        tree.exists(s.input)
+  );
+
+  if (!style) {
+    return undefined;
+  }
+
+  return typeof style === 'string' ? style : style.input;
+}

--- a/packages/angular/src/generators/setup-tailwind/angular-v14/schema.d.ts
+++ b/packages/angular/src/generators/setup-tailwind/angular-v14/schema.d.ts
@@ -1,0 +1,11 @@
+export interface GeneratorOptions {
+  project: string;
+  buildTarget?: string;
+  skipFormat?: boolean;
+  stylesEntryPoint?: string;
+  skipPackageJson?: boolean;
+}
+
+export interface NormalizedGeneratorOptions extends GeneratorOptions {
+  buildTarget: string;
+}

--- a/packages/angular/src/generators/setup-tailwind/angular-v14/setup-tailwind.ts
+++ b/packages/angular/src/generators/setup-tailwind/angular-v14/setup-tailwind.ts
@@ -13,23 +13,11 @@ import {
   updateApplicationStyles,
 } from './lib';
 import { GeneratorOptions } from './schema';
-import { getGeneratorDirectoryForInstalledAngularVersion } from '../../utils/get-generator-directory-for-ng-version';
-import { join } from 'path';
 
 export async function setupTailwindGenerator(
   tree: Tree,
   rawOptions: GeneratorOptions
 ): Promise<GeneratorCallback> {
-  const generatorDirectory =
-    getGeneratorDirectoryForInstalledAngularVersion(tree);
-  if (generatorDirectory) {
-    let previousGenerator = await import(
-      join(__dirname, generatorDirectory, 'setup-tailwind')
-    );
-    await previousGenerator.default(tree, rawOptions);
-    return;
-  }
-
   const options = normalizeOptions(rawOptions);
   const project = readProjectConfiguration(tree, options.project);
 

--- a/packages/angular/src/generators/setup-tailwind/setup-tailwind.application.spec.ts
+++ b/packages/angular/src/generators/setup-tailwind/setup-tailwind.application.spec.ts
@@ -1,11 +1,12 @@
+import * as devkit from '@nrwl/devkit';
 import {
   addProjectConfiguration,
   readJson,
   readProjectConfiguration,
   Tree,
+  updateJson,
   updateProjectConfiguration,
 } from '@nrwl/devkit';
-import * as devkit from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { setupTailwindGenerator } from './setup-tailwind';
 import {
@@ -432,6 +433,425 @@ describe('setupTailwind generator', () => {
       });
 
       expect(devkit.formatFiles).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('support angular v14', () => {
+    beforeEach(() => {
+      updateJson(tree, 'package.json', (json) => ({
+        ...json,
+        dependencies: {
+          ...json.dependencies,
+          '@angular/core': '14.1.0',
+        },
+      }));
+    });
+
+    describe('application', () => {
+      const project = 'app1';
+
+      beforeEach(() => {
+        addProjectConfiguration(tree, project, {
+          name: project,
+          projectType: 'application',
+          root: `apps/${project}`,
+          sourceRoot: `apps/${project}/src`,
+        });
+      });
+
+      it('should throw when tailwind is installed as a dependency with a version lower than 2.0.0', async () => {
+        tree.write(
+          'package.json',
+          JSON.stringify({ dependencies: { tailwindcss: '^1.99.99' } })
+        );
+
+        await expect(setupTailwindGenerator(tree, { project })).rejects.toThrow(
+          `Tailwind CSS version "^1.99.99" is not supported. Please upgrade to v2.0.0 or higher.`
+        );
+      });
+
+      it('should throw when tailwind is installed as a devDependency with a version lower than 2.0.0', async () => {
+        tree.write(
+          'package.json',
+          JSON.stringify({ devDependencies: { tailwindcss: '^1.99.99' } })
+        );
+
+        await expect(setupTailwindGenerator(tree, { project })).rejects.toThrow(
+          `Tailwind CSS version "^1.99.99" is not supported. Please upgrade to v2.0.0 or higher.`
+        );
+      });
+
+      it('should throw when there is a tailwind.config.js file in the project', async () => {
+        tree.write(`apps/${project}/tailwind.config.js`, '');
+
+        await expect(setupTailwindGenerator(tree, { project })).rejects.toThrow(
+          expect.objectContaining({
+            message: expect.stringContaining(
+              `The "tailwind.config.js" file already exists in the project "${project}". Are you sure this is the right project to set up Tailwind?`
+            ),
+          })
+        );
+      });
+
+      it('should throw when the provided styles entry point is not found', async () => {
+        const stylesEntryPoint = `apps/${project}/src/foo.scss`;
+
+        await expect(
+          setupTailwindGenerator(tree, { project, stylesEntryPoint })
+        ).rejects.toThrow(
+          `The provided styles entry point "${stylesEntryPoint}" could not be found.`
+        );
+      });
+
+      it('should throw when the styles entry point is not provided and it is not found', async () => {
+        await expect(setupTailwindGenerator(tree, { project })).rejects.toThrow(
+          expect.objectContaining({
+            message: expect.stringContaining(
+              `Could not find a styles entry point for project "${project}"`
+            ),
+          })
+        );
+      });
+
+      it('should throw when styles is not configured in the build config', async () => {
+        const projectConfig = readProjectConfiguration(tree, project);
+        projectConfig.targets = {
+          build: {
+            executor: '@nrwl/angular:webpack-browser',
+            options: {},
+          },
+        };
+
+        await expect(setupTailwindGenerator(tree, { project })).rejects.toThrow(
+          expect.objectContaining({
+            message: expect.stringContaining(
+              `Could not find a styles entry point for project "${project}"`
+            ),
+          })
+        );
+      });
+
+      it('should throw when the styles configured in the build config do not exist', async () => {
+        const stylesEntryPoint = `apps/${project}/src/custom-styles-entry-point.scss`;
+        const projectConfig = readProjectConfiguration(tree, project);
+        projectConfig.targets = {
+          build: {
+            executor: '@nrwl/angular:webpack-browser',
+            options: {
+              styles: ['node_modules/awesome-ds/styles.css', stylesEntryPoint],
+            },
+          },
+        };
+
+        await expect(setupTailwindGenerator(tree, { project })).rejects.toThrow(
+          expect.objectContaining({
+            message: expect.stringContaining(
+              `Could not find a styles entry point for project "${project}"`
+            ),
+          })
+        );
+      });
+
+      it('should throw when no styles within the project root are configured in the build config', async () => {
+        const projectConfig = readProjectConfiguration(tree, project);
+        projectConfig.targets = {
+          build: {
+            executor: '@nrwl/angular:webpack-browser',
+            options: {
+              styles: ['node_modules/awesome-ds/styles.css'],
+            },
+          },
+        };
+
+        await expect(setupTailwindGenerator(tree, { project })).rejects.toThrow(
+          expect.objectContaining({
+            message: expect.stringContaining(
+              `Could not find a styles entry point for project "${project}"`
+            ),
+          })
+        );
+      });
+
+      it('should throw when the style inside the project root specified in the build config as an object has "inject: false"', async () => {
+        const stylesEntryPoint = `apps/${project}/src/custom-styles-entry-point.scss`;
+        tree.write(stylesEntryPoint, 'p { margin: 0; }');
+        const projectConfig = readProjectConfiguration(tree, project);
+        projectConfig.targets = {
+          build: {
+            executor: '@nrwl/angular:webpack-browser',
+            options: {
+              styles: [
+                'node_modules/awesome-ds/styles.css',
+                {
+                  bundleName: 'styles.css',
+                  input: stylesEntryPoint,
+                  inject: false,
+                },
+              ],
+            },
+          },
+        };
+        updateProjectConfiguration(tree, project, projectConfig);
+
+        await expect(setupTailwindGenerator(tree, { project })).rejects.toThrow(
+          expect.objectContaining({
+            message: expect.stringContaining(
+              `Could not find a styles entry point for project "${project}"`
+            ),
+          })
+        );
+      });
+
+      it('should add tailwind styles to provided styles entry point', async () => {
+        const stylesEntryPoint = `apps/${project}/src/custom-styles-entry-point.scss`;
+        tree.write(stylesEntryPoint, 'p { margin: 0; }');
+
+        await setupTailwindGenerator(tree, { project, stylesEntryPoint });
+
+        expect(tree.read(stylesEntryPoint, 'utf-8')).toMatchInlineSnapshot(`
+        "@tailwind base;
+        @tailwind components;
+        @tailwind utilities;
+
+        p { margin: 0; }"
+      `);
+      });
+
+      it.each([
+        `apps/${project}/src/styles.css`,
+        `apps/${project}/src/styles.scss`,
+        `apps/${project}/src/styles.sass`,
+        `apps/${project}/src/styles.less`,
+      ])(
+        'should add tailwind styles to "%s" when not provided',
+        async (stylesEntryPoint) => {
+          tree.write(stylesEntryPoint, 'p { margin: 0; }');
+
+          await setupTailwindGenerator(tree, { project });
+
+          expect(tree.read(stylesEntryPoint, 'utf-8')).toMatchInlineSnapshot(`
+                  "@tailwind base;
+                  @tailwind components;
+                  @tailwind utilities;
+
+                  p { margin: 0; }"
+              `);
+        }
+      );
+
+      it('should add tailwind styles to the first style inside the project root specified in the build config as a string', async () => {
+        const stylesEntryPoint = `apps/${project}/src/custom-styles-entry-point.scss`;
+        tree.write(stylesEntryPoint, 'p { margin: 0; }');
+        const projectConfig = readProjectConfiguration(tree, project);
+        projectConfig.targets = {
+          build: {
+            executor: '@nrwl/angular:webpack-browser',
+            options: {
+              styles: ['node_modules/awesome-ds/styles.css', stylesEntryPoint],
+            },
+          },
+        };
+        updateProjectConfiguration(tree, project, projectConfig);
+
+        await setupTailwindGenerator(tree, { project });
+
+        expect(tree.read(stylesEntryPoint, 'utf-8')).toMatchInlineSnapshot(`
+        "@tailwind base;
+        @tailwind components;
+        @tailwind utilities;
+
+        p { margin: 0; }"
+      `);
+      });
+
+      it('should add tailwind styles to the first style inside the project root specified in the build config as an object when inject is not specified', async () => {
+        const stylesEntryPoint = `apps/${project}/src/custom-styles-entry-point.scss`;
+        tree.write(stylesEntryPoint, 'p { margin: 0; }');
+        const projectConfig = readProjectConfiguration(tree, project);
+        projectConfig.targets = {
+          build: {
+            executor: '@nrwl/angular:webpack-browser',
+            options: {
+              styles: [
+                'node_modules/awesome-ds/styles.css',
+                {
+                  bundleName: 'styles.css',
+                  input: stylesEntryPoint,
+                },
+              ],
+            },
+          },
+        };
+        updateProjectConfiguration(tree, project, projectConfig);
+
+        await setupTailwindGenerator(tree, { project });
+
+        expect(tree.read(stylesEntryPoint, 'utf-8')).toMatchInlineSnapshot(`
+        "@tailwind base;
+        @tailwind components;
+        @tailwind utilities;
+
+        p { margin: 0; }"
+      `);
+      });
+
+      it('should add tailwind styles to the first style inside the project root specified in the build config as an object when "inject: true"', async () => {
+        const stylesEntryPoint = `apps/${project}/src/custom-styles-entry-point.scss`;
+        tree.write(stylesEntryPoint, 'p { margin: 0; }');
+        const projectConfig = readProjectConfiguration(tree, project);
+        projectConfig.targets = {
+          build: {
+            executor: '@nrwl/angular:webpack-browser',
+            options: {
+              styles: [
+                'node_modules/awesome-ds/styles.css',
+                {
+                  bundleName: 'styles.css',
+                  input: stylesEntryPoint,
+                  inject: true,
+                },
+              ],
+            },
+          },
+        };
+        updateProjectConfiguration(tree, project, projectConfig);
+
+        await setupTailwindGenerator(tree, { project });
+
+        expect(tree.read(stylesEntryPoint, 'utf-8')).toMatchInlineSnapshot(`
+        "@tailwind base;
+        @tailwind components;
+        @tailwind utilities;
+
+        p { margin: 0; }"
+      `);
+      });
+
+      it('should add required packages', async () => {
+        const stylesEntryPoint = `apps/${project}/src/styles.scss`;
+        tree.write(stylesEntryPoint, 'p { margin: 0; }');
+
+        await setupTailwindGenerator(tree, { project, stylesEntryPoint });
+
+        const { devDependencies } = readJson(tree, 'package.json');
+        expect(devDependencies.tailwindcss).toBe(tailwindVersion);
+        expect(devDependencies.autoprefixer).toBe(autoprefixerVersion);
+        expect(devDependencies.postcss).toBe(postcssVersion);
+      });
+
+      it('should generate the tailwind.config.js file in the project root with the config for v3 by default', async () => {
+        const stylesEntryPoint = `apps/${project}/src/styles.scss`;
+        tree.write(stylesEntryPoint, 'p { margin: 0; }');
+
+        await setupTailwindGenerator(tree, { project, stylesEntryPoint });
+
+        expect(tree.read(`apps/${project}/tailwind.config.js`, 'utf-8'))
+          .toMatchInlineSnapshot(`
+        "const { createGlobPatternsForDependencies } = require('@nrwl/angular/tailwind');
+        const { join } = require('path');
+
+        /** @type {import('tailwindcss').Config} */
+        module.exports = {
+          content: [
+            join(__dirname, 'src/**/!(*.stories|*.spec).{ts,html}'),
+            ...createGlobPatternsForDependencies(__dirname),
+          ],
+          theme: {
+            extend: {},
+          },
+          plugins: [],
+        };
+        "
+      `);
+      });
+
+      it('should generate the tailwind.config.js file in the project root with the config for v3 when a version greater than 3 is installed', async () => {
+        const stylesEntryPoint = `apps/${project}/src/styles.scss`;
+        tree.write(stylesEntryPoint, 'p { margin: 0; }');
+        tree.write(
+          'package.json',
+          JSON.stringify({ devDependencies: { tailwindcss: '^3.0.1' } })
+        );
+
+        await setupTailwindGenerator(tree, { project, stylesEntryPoint });
+
+        expect(tree.read(`apps/${project}/tailwind.config.js`, 'utf-8'))
+          .toMatchInlineSnapshot(`
+        "const { createGlobPatternsForDependencies } = require('@nrwl/angular/tailwind');
+        const { join } = require('path');
+
+        /** @type {import('tailwindcss').Config} */
+        module.exports = {
+          content: [
+            join(__dirname, 'src/**/!(*.stories|*.spec).{ts,html}'),
+            ...createGlobPatternsForDependencies(__dirname),
+          ],
+          theme: {
+            extend: {},
+          },
+          plugins: [],
+        };
+        "
+      `);
+      });
+
+      it('should generate the tailwind.config.js file in the project root with the config for v2 when a version greater than 2 and lower than 3 is installed', async () => {
+        const stylesEntryPoint = `apps/${project}/src/styles.scss`;
+        tree.write(stylesEntryPoint, 'p { margin: 0; }');
+        tree.write(
+          'package.json',
+          JSON.stringify({ devDependencies: { tailwindcss: '~2.0.0' } })
+        );
+
+        await setupTailwindGenerator(tree, { project, stylesEntryPoint });
+
+        expect(tree.read(`apps/${project}/tailwind.config.js`, 'utf-8'))
+          .toMatchInlineSnapshot(`
+        "const { createGlobPatternsForDependencies } = require('@nrwl/angular/tailwind');
+        const { join } = require('path');
+
+        module.exports = {
+          mode: 'jit',
+          purge: [
+            join(__dirname, 'src/**/!(*.stories|*.spec).{ts,html}'),
+            ...createGlobPatternsForDependencies(__dirname),
+          ],
+          darkMode: false, // or 'media' or 'class'
+          theme: {
+            extend: {},
+          },
+          variants: {
+            extend: {},
+          },
+          plugins: [],
+        };
+        "
+      `);
+      });
+
+      it('should format files', async () => {
+        const stylesEntryPoint = `apps/${project}/src/styles.scss`;
+        tree.write(stylesEntryPoint, 'p { margin: 0; }');
+        jest.spyOn(devkit, 'formatFiles');
+
+        await setupTailwindGenerator(tree, { project, stylesEntryPoint });
+
+        expect(devkit.formatFiles).toHaveBeenCalled();
+      });
+
+      it('should not format files when "skipFormat: true"', async () => {
+        const stylesEntryPoint = `apps/${project}/src/styles.scss`;
+        tree.write(stylesEntryPoint, 'p { margin: 0; }');
+        jest.spyOn(devkit, 'formatFiles');
+
+        await setupTailwindGenerator(tree, {
+          project,
+          stylesEntryPoint,
+          skipFormat: true,
+        });
+
+        expect(devkit.formatFiles).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/packages/angular/src/generators/setup-tailwind/setup-tailwind.library.spec.ts
+++ b/packages/angular/src/generators/setup-tailwind/setup-tailwind.library.spec.ts
@@ -1,11 +1,12 @@
+import * as devkit from '@nrwl/devkit';
 import {
   addProjectConfiguration,
   readJson,
   readProjectConfiguration,
   Tree,
+  updateJson,
   updateProjectConfiguration,
 } from '@nrwl/devkit';
-import * as devkit from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { setupTailwindGenerator } from './setup-tailwind';
 import {
@@ -309,6 +310,302 @@ describe('setupTailwind generator', () => {
       await setupTailwindGenerator(tree, { project, skipFormat: true });
 
       expect(devkit.formatFiles).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('support angular v14', () => {
+    beforeEach(() => {
+      updateJson(tree, 'package.json', (json) => ({
+        ...json,
+        dependencies: {
+          ...json.dependencies,
+          '@angular/core': '14.1.0',
+        },
+      }));
+    });
+
+    describe('libraries', () => {
+      const project = 'lib1';
+
+      beforeEach(() => {
+        addProjectConfiguration(tree, project, {
+          name: project,
+          projectType: 'library',
+          root: `libs/${project}`,
+          sourceRoot: `libs/${project}/src`,
+        });
+      });
+
+      it('should throw when tailwind is installed as a dependency with a version lower than 2.0.0', async () => {
+        tree.write(
+          'package.json',
+          JSON.stringify({ dependencies: { tailwindcss: '^1.99.99' } })
+        );
+
+        await expect(setupTailwindGenerator(tree, { project })).rejects.toThrow(
+          `Tailwind CSS version "^1.99.99" is not supported. Please upgrade to v2.0.0 or higher.`
+        );
+      });
+
+      it('should throw when tailwind is installed as a devDependency with a version lower than 2.0.0', async () => {
+        tree.write(
+          'package.json',
+          JSON.stringify({ devDependencies: { tailwindcss: '^1.99.99' } })
+        );
+
+        await expect(setupTailwindGenerator(tree, { project })).rejects.toThrow(
+          `Tailwind CSS version "^1.99.99" is not supported. Please upgrade to v2.0.0 or higher.`
+        );
+      });
+
+      it('should throw when the build target is not found', async () => {
+        await expect(setupTailwindGenerator(tree, { project })).rejects.toThrow(
+          expect.objectContaining({
+            message: expect.stringContaining(
+              `The target "build" was not found for project "${project}".`
+            ),
+          })
+        );
+      });
+
+      it('should throw when the specified build target is not found', async () => {
+        await expect(
+          setupTailwindGenerator(tree, { project, buildTarget: 'custom-build' })
+        ).rejects.toThrow(
+          expect.objectContaining({
+            message: expect.stringContaining(
+              `The target "custom-build" was not found for project "${project}".`
+            ),
+          })
+        );
+      });
+
+      it('should throw when the build target is using an unsupported executor', async () => {
+        const projectConfig = readProjectConfiguration(tree, project);
+        projectConfig.targets = {
+          build: {
+            executor: '@angular/build-angular:browser',
+            options: {},
+          },
+        };
+        updateProjectConfiguration(tree, project, projectConfig);
+
+        await expect(setupTailwindGenerator(tree, { project })).rejects.toThrow(
+          expect.objectContaining({
+            message: expect.stringContaining(
+              `The build target for project "${project}" is using an unsupported executor "@angular/build-angular:browser".`
+            ),
+          })
+        );
+      });
+
+      it('should throw when the tailwind config is configured in the build target and the file it points to exists', async () => {
+        const tailwindConfig = `libs/${project}/my-tailwind.config.js`;
+        let projectConfig = readProjectConfiguration(tree, project);
+        projectConfig.targets = {
+          build: {
+            executor: '@nrwl/angular:package',
+            options: { tailwindConfig },
+          },
+        };
+        updateProjectConfiguration(tree, project, projectConfig);
+        tree.write(tailwindConfig, '');
+
+        await expect(setupTailwindGenerator(tree, { project })).rejects.toThrow(
+          expect.objectContaining({
+            message: expect.stringContaining(
+              `The "${tailwindConfig}" file is already configured for the project "${project}". Are you sure this is the right project to set up Tailwind?`
+            ),
+          })
+        );
+      });
+
+      it('should add the tailwind config path to the "build" target by default when no build target is specified', async () => {
+        let projectConfig = readProjectConfiguration(tree, project);
+        projectConfig.targets = {
+          build: { executor: '@nrwl/angular:package', options: {} },
+        };
+        updateProjectConfiguration(tree, project, projectConfig);
+
+        await setupTailwindGenerator(tree, { project });
+
+        projectConfig = readProjectConfiguration(tree, project);
+        expect(projectConfig.targets.build.options.tailwindConfig).toBe(
+          `libs/${project}/tailwind.config.js`
+        );
+      });
+
+      it('should add the tailwind config path to the specified buildTarget', async () => {
+        const buildTarget = 'custom-build';
+        let projectConfig = readProjectConfiguration(tree, project);
+        projectConfig.targets = {
+          [buildTarget]: { executor: '@nrwl/angular:package', options: {} },
+        };
+        updateProjectConfiguration(tree, project, projectConfig);
+
+        await setupTailwindGenerator(tree, { project, buildTarget });
+
+        projectConfig = readProjectConfiguration(tree, project);
+        expect(projectConfig.targets[buildTarget].options.tailwindConfig).toBe(
+          `libs/${project}/tailwind.config.js`
+        );
+      });
+
+      it.each(['@nrwl/angular:ng-packagr-lite', '@nrwl/angular:package'])(
+        'should add the tailwind config path when using the "%s" executor',
+        async (executor) => {
+          let projectConfig = readProjectConfiguration(tree, project);
+          projectConfig.targets = { build: { executor, options: {} } };
+          updateProjectConfiguration(tree, project, projectConfig);
+
+          await setupTailwindGenerator(tree, { project });
+
+          projectConfig = readProjectConfiguration(tree, project);
+          expect(projectConfig.targets.build.options.tailwindConfig).toBe(
+            `libs/${project}/tailwind.config.js`
+          );
+        }
+      );
+
+      it('should add required packages', async () => {
+        const projectConfig = readProjectConfiguration(tree, project);
+        projectConfig.targets = {
+          build: { executor: '@nrwl/angular:package', options: {} },
+        };
+        updateProjectConfiguration(tree, project, projectConfig);
+
+        await setupTailwindGenerator(tree, { project });
+
+        const { devDependencies } = readJson(tree, 'package.json');
+        expect(devDependencies.tailwindcss).toBe(tailwindVersion);
+        expect(devDependencies.autoprefixer).toBe(autoprefixerVersion);
+        expect(devDependencies.postcss).toBe(postcssVersion);
+      });
+
+      it('should generate the tailwind.config.js file in the project root for v3 by default', async () => {
+        const projectConfig = readProjectConfiguration(tree, project);
+        projectConfig.targets = {
+          build: { executor: '@nrwl/angular:package', options: {} },
+        };
+        updateProjectConfiguration(tree, project, projectConfig);
+
+        await setupTailwindGenerator(tree, { project });
+
+        expect(tree.read(`libs/${project}/tailwind.config.js`, 'utf-8'))
+          .toMatchInlineSnapshot(`
+        "const { createGlobPatternsForDependencies } = require('@nrwl/angular/tailwind');
+        const { join } = require('path');
+
+        /** @type {import('tailwindcss').Config} */
+        module.exports = {
+          content: [
+            join(__dirname, 'src/**/!(*.stories|*.spec).{ts,html}'),
+            ...createGlobPatternsForDependencies(__dirname),
+          ],
+          theme: {
+            extend: {},
+          },
+          plugins: [],
+        };
+        "
+      `);
+      });
+
+      it('should generate the tailwind.config.js file in the project root with the config for v3 when a version greater than 3 is installed', async () => {
+        const projectConfig = readProjectConfiguration(tree, project);
+        projectConfig.targets = {
+          build: { executor: '@nrwl/angular:package', options: {} },
+        };
+        updateProjectConfiguration(tree, project, projectConfig);
+        tree.write(
+          'package.json',
+          JSON.stringify({ devDependencies: { tailwindcss: '^3.0.1' } })
+        );
+
+        await setupTailwindGenerator(tree, { project });
+
+        expect(tree.read(`libs/${project}/tailwind.config.js`, 'utf-8'))
+          .toMatchInlineSnapshot(`
+        "const { createGlobPatternsForDependencies } = require('@nrwl/angular/tailwind');
+        const { join } = require('path');
+
+        /** @type {import('tailwindcss').Config} */
+        module.exports = {
+          content: [
+            join(__dirname, 'src/**/!(*.stories|*.spec).{ts,html}'),
+            ...createGlobPatternsForDependencies(__dirname),
+          ],
+          theme: {
+            extend: {},
+          },
+          plugins: [],
+        };
+        "
+      `);
+      });
+
+      it('should generate the tailwind.config.js file in the project root with the config for v2 when a version greater than 2 and lower than 3 is installed', async () => {
+        const projectConfig = readProjectConfiguration(tree, project);
+        projectConfig.targets = {
+          build: { executor: '@nrwl/angular:package', options: {} },
+        };
+        updateProjectConfiguration(tree, project, projectConfig);
+        tree.write(
+          'package.json',
+          JSON.stringify({ devDependencies: { tailwindcss: '~2.0.0' } })
+        );
+
+        await setupTailwindGenerator(tree, { project });
+
+        expect(tree.read(`libs/${project}/tailwind.config.js`, 'utf-8'))
+          .toMatchInlineSnapshot(`
+        "const { createGlobPatternsForDependencies } = require('@nrwl/angular/tailwind');
+        const { join } = require('path');
+
+        module.exports = {
+          mode: 'jit',
+          purge: [
+            join(__dirname, 'src/**/!(*.stories|*.spec).{ts,html}'),
+            ...createGlobPatternsForDependencies(__dirname),
+          ],
+          darkMode: false, // or 'media' or 'class'
+          theme: {
+            extend: {},
+          },
+          variants: {
+            extend: {},
+          },
+          plugins: [],
+        };
+        "
+      `);
+      });
+
+      it('should format files', async () => {
+        const projectConfig = readProjectConfiguration(tree, project);
+        projectConfig.targets = {
+          build: { executor: '@nrwl/angular:package', options: {} },
+        };
+        updateProjectConfiguration(tree, project, projectConfig);
+        jest.spyOn(devkit, 'formatFiles');
+
+        await setupTailwindGenerator(tree, { project });
+
+        expect(devkit.formatFiles).toHaveBeenCalled();
+      });
+
+      it('should not format files when "skipFormat: true"', async () => {
+        const projectConfig = readProjectConfiguration(tree, project);
+        projectConfig.targets = {
+          build: { executor: '@nrwl/angular:package', options: {} },
+        };
+        updateProjectConfiguration(tree, project, projectConfig);
+        jest.spyOn(devkit, 'formatFiles');
+
+        await setupTailwindGenerator(tree, { project, skipFormat: true });
+
+        expect(devkit.formatFiles).not.toHaveBeenCalled();
+      });
     });
   });
 });


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

Our `setup-tailwind` generator only supports Angular 15

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Our `setup-tailwind` generator only supports Angular 14 and 15

