### PR TITLE
feat(angular): add backwards compat support to add-linting

### DIFF
--- a/packages/angular/src/generators/add-linting/__snapshots__/add-linting.spec.ts.snap
+++ b/packages/angular/src/generators/add-linting/__snapshots__/add-linting.spec.ts.snap
@@ -48,3 +48,52 @@ Object {
   ],
 }
 `;
+
+exports[`addLinting generator support angular v14 should correctly generate the .eslintrc.json file 1`] = `
+Object {
+  "extends": Array [
+    "../../.eslintrc.json",
+  ],
+  "ignorePatterns": Array [
+    "!**/*",
+  ],
+  "overrides": Array [
+    Object {
+      "extends": Array [
+        "plugin:@nrwl/nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates",
+      ],
+      "files": Array [
+        "*.ts",
+      ],
+      "rules": Object {
+        "@angular-eslint/component-selector": Array [
+          "error",
+          Object {
+            "prefix": "my-org",
+            "style": "kebab-case",
+            "type": "element",
+          },
+        ],
+        "@angular-eslint/directive-selector": Array [
+          "error",
+          Object {
+            "prefix": "myOrg",
+            "style": "camelCase",
+            "type": "attribute",
+          },
+        ],
+      },
+    },
+    Object {
+      "extends": Array [
+        "plugin:@nrwl/nx/angular-template",
+      ],
+      "files": Array [
+        "*.html",
+      ],
+      "rules": Object {},
+    },
+  ],
+}
+`;

--- a/packages/angular/src/generators/add-linting/add-linting.spec.ts
+++ b/packages/angular/src/generators/add-linting/add-linting.spec.ts
@@ -3,11 +3,11 @@ import {
   addProjectConfiguration,
   readJson,
   readProjectConfiguration,
+  updateJson,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import * as linter from '@nrwl/linter';
 import { addLintingGenerator } from './add-linting';
-import * as devkit from '@nrwl/devkit';
 
 describe('addLinting generator', () => {
   let tree: Tree;
@@ -80,6 +80,85 @@ describe('addLinting generator', () => {
         ],
       },
       outputs: ['{options.outputFile}'],
+    });
+  });
+
+  describe('support angular v14', () => {
+    beforeEach(() => {
+      tree = createTreeWithEmptyV1Workspace();
+      updateJson(tree, 'package.json', (json) => ({
+        ...json,
+        dependencies: {
+          ...json.dependencies,
+          '@angular/core': '14.1.0',
+        },
+      }));
+
+      addProjectConfiguration(tree, appProjectName, {
+        root: appProjectRoot,
+        prefix: 'myOrg',
+        projectType: 'application',
+        targets: {},
+      } as ProjectConfiguration);
+    });
+
+    it('should invoke the lintProjectGenerator', async () => {
+      jest.spyOn(linter, 'lintProjectGenerator');
+
+      await addLintingGenerator(tree, {
+        prefix: 'myOrg',
+        projectName: appProjectName,
+        projectRoot: appProjectRoot,
+      });
+
+      expect(linter.lintProjectGenerator).toHaveBeenCalled();
+    });
+
+    it('should add the Angular specific EsLint devDependencies', async () => {
+      await addLintingGenerator(tree, {
+        prefix: 'myOrg',
+        projectName: appProjectName,
+        projectRoot: appProjectRoot,
+      });
+
+      const { dependencies, devDependencies } = readJson(tree, 'package.json');
+      expect(dependencies['@angular/core']).toEqual('14.1.0');
+      expect(devDependencies['@angular-eslint/eslint-plugin']).toBeDefined();
+      expect(
+        devDependencies['@angular-eslint/eslint-plugin-template']
+      ).toBeDefined();
+      expect(devDependencies['@angular-eslint/template-parser']).toBeDefined();
+    });
+
+    it('should correctly generate the .eslintrc.json file', async () => {
+      await addLintingGenerator(tree, {
+        prefix: 'myOrg',
+        projectName: appProjectName,
+        projectRoot: appProjectRoot,
+      });
+
+      const eslintConfig = readJson(tree, `${appProjectRoot}/.eslintrc.json`);
+      expect(eslintConfig).toMatchSnapshot();
+    });
+
+    it('should update the project with the right lint target configuration', async () => {
+      await addLintingGenerator(tree, {
+        prefix: 'myOrg',
+        projectName: appProjectName,
+        projectRoot: appProjectRoot,
+      });
+
+      const project = readProjectConfiguration(tree, appProjectName);
+      expect(project.targets.lint).toEqual({
+        executor: '@nrwl/linter:eslint',
+        options: {
+          lintFilePatterns: [
+            `${appProjectRoot}/**/*.ts`,
+            `${appProjectRoot}/**/*.html`,
+          ],
+        },
+        outputs: ['{options.outputFile}'],
+      });
     });
   });
 });

--- a/packages/angular/src/generators/add-linting/angular-v14/add-linting.ts
+++ b/packages/angular/src/generators/add-linting/angular-v14/add-linting.ts
@@ -10,23 +10,11 @@ import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-ser
 import { addAngularEsLintDependencies } from './lib/add-angular-eslint-dependencies';
 import { extendAngularEslintJson } from './lib/create-eslint-configuration';
 import type { AddLintingGeneratorSchema } from './schema';
-import { getGeneratorDirectoryForInstalledAngularVersion } from '../../utils/get-generator-directory-for-ng-version';
-import { join } from 'path';
 
 export async function addLintingGenerator(
   tree: Tree,
   options: AddLintingGeneratorSchema
 ): Promise<GeneratorCallback> {
-  const generatorDirectory =
-    getGeneratorDirectoryForInstalledAngularVersion(tree);
-  if (generatorDirectory) {
-    let previousGenerator = await import(
-      join(__dirname, generatorDirectory, 'add-linting')
-    );
-    await previousGenerator.default(tree, options);
-    return;
-  }
-
   const tasks: GeneratorCallback[] = [];
   const rootProject = options.projectRoot === '.' || options.projectRoot === '';
   const lintTask = await lintProjectGenerator(tree, {

--- a/packages/angular/src/generators/add-linting/angular-v14/lib/add-angular-eslint-dependencies.ts
+++ b/packages/angular/src/generators/add-linting/angular-v14/lib/add-angular-eslint-dependencies.ts
@@ -1,0 +1,17 @@
+import type { GeneratorCallback, Tree } from '@nrwl/devkit';
+import { addDependenciesToPackageJson } from '@nrwl/devkit';
+import { versions } from '../../../../utils/versions';
+
+export function addAngularEsLintDependencies(tree: Tree): GeneratorCallback {
+  return addDependenciesToPackageJson(
+    tree,
+    {},
+    {
+      '@angular-eslint/eslint-plugin': versions.angularV14.angularEslintVersion,
+      '@angular-eslint/eslint-plugin-template':
+        versions.angularV14.angularEslintVersion,
+      '@angular-eslint/template-parser':
+        versions.angularV14.angularEslintVersion,
+    }
+  );
+}

--- a/packages/angular/src/generators/add-linting/angular-v14/lib/add-project-lint-target.ts
+++ b/packages/angular/src/generators/add-linting/angular-v14/lib/add-project-lint-target.ts
@@ -1,0 +1,25 @@
+import type { Tree } from '@nrwl/devkit';
+import {
+  readProjectConfiguration,
+  updateProjectConfiguration,
+} from '@nrwl/devkit';
+import { mapLintPattern } from '@nrwl/linter/src/generators/lint-project/lint-project';
+import type { AddLintingGeneratorSchema } from '../schema';
+
+export function addProjectLintTarget(
+  tree: Tree,
+  options: AddLintingGeneratorSchema
+): void {
+  const project = readProjectConfiguration(tree, options.projectName);
+  const rootProject = options.projectRoot === '.' || options.projectRoot === '';
+  project.targets.lint = {
+    executor: '@nrwl/linter:eslint',
+    options: {
+      lintFilePatterns: [
+        mapLintPattern(options.projectRoot, 'ts', rootProject),
+        mapLintPattern(options.projectRoot, 'html', rootProject),
+      ],
+    },
+  };
+  updateProjectConfiguration(tree, options.projectName, project);
+}

--- a/packages/angular/src/generators/add-linting/angular-v14/lib/create-eslint-configuration.ts
+++ b/packages/angular/src/generators/add-linting/angular-v14/lib/create-eslint-configuration.ts
@@ -1,0 +1,135 @@
+import type { Tree } from '@nrwl/devkit';
+import { joinPathFragments, offsetFromRoot, writeJson } from '@nrwl/devkit';
+import { camelize, dasherize } from '@nrwl/workspace/src/utils/strings';
+import type { Linter } from 'eslint';
+import type { AddLintingGeneratorSchema } from '../schema';
+
+type EslintExtensionSchema = {
+  prefix: string;
+};
+
+export const extendAngularEslintJson = (
+  json: Linter.Config,
+  options: EslintExtensionSchema
+) => {
+  const overrides = [
+    {
+      ...json.overrides[0],
+      files: ['*.ts'],
+      extends: [
+        ...(json.overrides[0].extends || []),
+        'plugin:@nrwl/nx/angular',
+        'plugin:@angular-eslint/template/process-inline-templates',
+      ],
+      rules: {
+        '@angular-eslint/directive-selector': [
+          'error',
+          {
+            type: 'attribute',
+            prefix: camelize(options.prefix),
+            style: 'camelCase',
+          },
+        ],
+        '@angular-eslint/component-selector': [
+          'error',
+          {
+            type: 'element',
+            prefix: dasherize(options.prefix),
+            style: 'kebab-case',
+          },
+        ],
+      },
+    },
+    {
+      files: ['*.html'],
+      extends: ['plugin:@nrwl/nx/angular-template'],
+      /**
+       * Having an empty rules object present makes it more obvious to the user where they would
+       * extend things from if they needed to
+       */
+      rules: {},
+    },
+  ];
+
+  return {
+    ...json,
+    overrides,
+  };
+};
+
+/**
+ * @deprecated Use {@link extendAngularEslintJson} instead
+ */
+export function createEsLintConfiguration(
+  tree: Tree,
+  options: AddLintingGeneratorSchema
+): void {
+  const rootConfig = `${offsetFromRoot(options.projectRoot)}.eslintrc.json`;
+  // Include all project files to be linted (since they are turned off in the root eslintrc file).
+  const ignorePatterns = ['!**/*'];
+
+  const configJson = {
+    extends: [rootConfig],
+    ignorePatterns,
+    overrides: [
+      {
+        files: ['*.ts'],
+        extends: [
+          'plugin:@nrwl/nx/angular',
+          'plugin:@angular-eslint/template/process-inline-templates',
+        ],
+        /**
+         * NOTE: We no longer set parserOptions.project by default when creating new projects.
+         *
+         * We have observed that users rarely add rules requiring type-checking to their Nx workspaces, and therefore
+         * do not actually need the capabilites which parserOptions.project provides. When specifying parserOptions.project,
+         * typescript-eslint needs to create full TypeScript Programs for you. When omitting it, it can perform a simple
+         * parse (and AST tranformation) of the source files it encounters during a lint run, which is much faster and much
+         * less memory intensive.
+         *
+         * In the rare case that users attempt to add rules requiring type-checking to their setup later on (and haven't set
+         * parserOptions.project), the executor will attempt to look for the particular error typescript-eslint gives you
+         * and provide feedback to the user.
+         */
+        parserOptions: !options.setParserOptionsProject
+          ? undefined
+          : {
+              project: [`${options.projectRoot}/tsconfig.*?.json`],
+            },
+        rules: {
+          '@angular-eslint/directive-selector': [
+            'error',
+            {
+              type: 'attribute',
+              prefix: camelize(options.prefix),
+              style: 'camelCase',
+            },
+          ],
+          '@angular-eslint/component-selector': [
+            'error',
+            {
+              type: 'element',
+              prefix: dasherize(options.prefix),
+              style: 'kebab-case',
+            },
+          ],
+        },
+      },
+      {
+        files: ['*.html'],
+        extends: ['plugin:@nrwl/nx/angular-template'],
+        /**
+         * Having an empty rules object present makes it more obvious to the user where they would
+         * extend things from if they needed to
+         */
+        rules: {},
+      },
+    ],
+  };
+
+  writeJson(
+    tree,
+    joinPathFragments(options.projectRoot, '.eslintrc.json'),
+    configJson
+  );
+}

--- a/packages/angular/src/generators/add-linting/angular-v14/schema.d.ts
+++ b/packages/angular/src/generators/add-linting/angular-v14/schema.d.ts
@@ -1,0 +1,9 @@
+export interface AddLintingGeneratorSchema {
+  projectName: string;
+  projectRoot: string;
+  prefix: string;
+  setParserOptionsProject?: boolean;
+  skipFormat?: boolean;
+  skipPackageJson?: boolean;
+  unitTestRunner?: string;
+}


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

Our `add-linting` generator only supports Angular 15

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Our `add-linting` generator only supports Angular 14 and 15

