### PR TITLE
fix(core): detect angular cli workspace correctly

### DIFF
--- a/packages/nx/src/utils/find-workspace-root.ts
+++ b/packages/nx/src/utils/find-workspace-root.ts
@@ -1,5 +1,3 @@
-import { existsSync } from 'fs';
-import * as path from 'path';
 import { workspaceRootInner } from './workspace-root';
 
 /**
@@ -13,7 +11,7 @@ export function findWorkspaceRoot(dir: string): WorkspaceTypeAndRoot | null {
 
   if (r === null) return null;
 
-  if (existsSync(path.join(r, 'angular.json'))) {
+  if (isAngularCliInstalled(r)) {
     return { type: 'angular', dir: r };
   } else {
     return { type: 'nx', dir: r };
@@ -23,4 +21,15 @@ export function findWorkspaceRoot(dir: string): WorkspaceTypeAndRoot | null {
 export interface WorkspaceTypeAndRoot {
   type: 'nx' | 'angular';
   dir: string;
+}
+
+function isAngularCliInstalled(root: string): boolean {
+  try {
+    require.resolve('@angular/cli', {
+      paths: [root],
+    });
+    return true;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The Nx CLI no longer detects whether a workspace uses Angular or not. The current detection logic relies on the existence of the `angular.json` file which is no longer generated in new workspaces with Angular presets.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The Nx CLI should correctly detect whether a workspace uses Angular or not.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
