### PR TITLE
fix(angular): show the correct link to the docs when running nx init

### DIFF
--- a/packages/make-angular-cli-faster/src/utilities/make-angular-cli-faster.ts
+++ b/packages/make-angular-cli-faster/src/utilities/make-angular-cli-faster.ts
@@ -39,8 +39,7 @@ export async function makeAngularCliFaster(args: Args) {
     title: '🎉 Angular CLI is faster now!',
     bodyLines: [
       `Execute 'npx ng build' twice to see the computation caching in action.`,
-      'Learn more about computation caching, how it is shared with your teammates,',
-      'and how it can speed up your CI by up to 10 times at https://nx.dev/getting-started/nx-and-angular',
+      'Learn more about the changes done to your workspace at https://nx.dev/recipes/adopting-nx/migration-angular.',
     ],
   });
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

After running `nx init`, an invalid link to the docs is being shown.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

After running `nx init`, a link to the Angular CLI to Nx migration docs should be shown to learn more about the changes made.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
