### PR TITLE
fix(angular): ensure apps/libs layout is created when migrating from angular cli to nx monorepo layout

### DIFF
--- a/e2e/angular-core/src/ng-add.test.ts
+++ b/e2e/angular-core/src/ng-add.test.ts
@@ -284,19 +284,17 @@ describe('convert Angular CLI workspace to an Nx workspace', () => {
     // Restore e2e directory
     runCommand('mv e2e-bak e2e');
 
-    // TODO: this functionality is currently broken, this validation doesn't exist
-    // // Remove src
-    // runCommand('mv src src-bak');
-    // expect(() => runNgAdd('@nrwl/angular', '--npm-scope projscope --skip-install')).toThrow(
-    //   'Path: src does not exist'
-    // );
+    // Remove src
+    runCommand('mv src src-bak');
+    expect(() =>
+      runNgAdd('@nrwl/angular', '--npm-scope projscope --skip-install')
+    ).toThrow('The project source root "src" could not be found.');
 
-    // // Put src back
-    // runCommand('mv src-bak src');
+    // Put src back
+    runCommand('mv src-bak src');
   });
 
-  //TODO: reenable
-  xit('should handle a workspace with cypress v9', () => {
+  it('should handle a workspace with cypress v9', () => {
     addCypress9();
 
     // Remove cypress.json
@@ -383,8 +381,7 @@ describe('convert Angular CLI workspace to an Nx workspace', () => {
     });
   });
 
-  //TODO: reenable
-  xit('should handle a workspace with cypress v10', () => {
+  it('should handle a workspace with cypress v10', () => {
     addCypress10();
 
     // Remove cypress.config.ts

--- a/packages/angular/src/generators/ng-add/migrate-from-angular-cli.spec.ts
+++ b/packages/angular/src/generators/ng-add/migrate-from-angular-cli.spec.ts
@@ -269,6 +269,101 @@ describe('workspace', () => {
       expect(prettierIgnore).toBe('# existing ignore rules');
     });
 
+    it('should generate .gitkeep file in apps directory when there are no applications', async () => {
+      tree.write('projects/lib1/README.md', '');
+      tree.write('projects/lib1/src/public-api.ts', '');
+      writeJson(tree, 'angular.json', {
+        $schema: './node_modules/@angular/cli/lib/config/schema.json',
+        version: 1,
+        defaultProject: 'lib1',
+        newProjectRoot: 'projects',
+        projects: {
+          lib1: {
+            root: 'projects/lib1',
+            sourceRoot: 'projects/lib1/src',
+            projectType: 'library',
+            architect: {
+              build: {
+                builder: '@angular-devkit/build-angular:ng-packagr',
+                options: { tsConfig: 'projects/lib1/tsconfig.lib.json' },
+              },
+              test: {
+                builder: '@angular-devkit/build-angular:karma',
+                options: { tsConfig: 'projects/lib1/tsconfig.spec.json' },
+              },
+            },
+          },
+        },
+      });
+
+      await migrateFromAngularCli(tree, {});
+
+      expect(tree.exists('apps/.gitkeep')).toBe(true);
+    });
+
+    it('should not generate .gitkeep file in apps directory when there is at least one application', async () => {
+      await migrateFromAngularCli(tree, {});
+
+      expect(tree.exists('apps/.gitkeep')).toBe(false);
+    });
+
+    it('should generate .gitkeep file in libs directory when there are no libraries', async () => {
+      await migrateFromAngularCli(tree, {});
+
+      expect(tree.exists('libs/.gitkeep')).toBe(true);
+    });
+
+    it('should not generate .gitkeep file in libs directory when there is at least one library', async () => {
+      tree.write('projects/lib1/README.md', '');
+      tree.write('projects/lib1/src/public-api.ts', '');
+      writeJson(tree, 'angular.json', {
+        $schema: './node_modules/@angular/cli/lib/config/schema.json',
+        version: 1,
+        defaultProject: 'app1',
+        newProjectRoot: 'projects',
+        projects: {
+          app1: {
+            root: '',
+            sourceRoot: 'src',
+            projectType: 'application',
+            architect: {
+              build: {
+                builder: '@angular-devkit/build-angular:browser',
+                options: { tsConfig: 'tsconfig.app.json' },
+              },
+              test: {
+                builder: '@angular-devkit/build-angular:karma',
+                options: { tsConfig: 'tsconfig.spec.json' },
+              },
+              e2e: {
+                builder: '@angular-devkit/build-angular:protractor',
+                options: { protractorConfig: 'e2e/protractor.conf.js' },
+              },
+            },
+          },
+          lib1: {
+            root: 'projects/lib1',
+            sourceRoot: 'projects/lib1/src',
+            projectType: 'library',
+            architect: {
+              build: {
+                builder: '@angular-devkit/build-angular:ng-packagr',
+                options: { tsConfig: 'projects/lib1/tsconfig.lib.json' },
+              },
+              test: {
+                builder: '@angular-devkit/build-angular:karma',
+                options: { tsConfig: 'projects/lib1/tsconfig.spec.json' },
+              },
+            },
+          },
+        },
+      });
+
+      await migrateFromAngularCli(tree, {});
+
+      expect(tree.exists('libs/.gitkeep')).toBe(false);
+    });
+
     it('should create a root eslint config', async () => {
       await migrateFromAngularCli(tree, {});
 

--- a/packages/angular/src/generators/ng-add/migrate-from-angular-cli.ts
+++ b/packages/angular/src/generators/ng-add/migrate-from-angular-cli.ts
@@ -3,9 +3,7 @@ import {
   addDependenciesToPackageJson,
   installPackagesTask,
   readJson,
-  readWorkspaceConfiguration,
   updateJson,
-  updateWorkspaceConfiguration,
 } from '@nrwl/devkit';
 import { convertToNxProjectGenerator } from '@nrwl/workspace/generators';
 import { prettierVersion } from '@nrwl/workspace/src/utils/versions';
@@ -20,6 +18,7 @@ import {
   createWorkspaceFiles,
   decorateAngularCli,
   deleteAngularJson,
+  deleteGitKeepFilesIfNotNeeded,
   formatFilesTask,
   getAllProjects,
   getWorkspaceRootFileTypesInfo,
@@ -119,6 +118,8 @@ export async function migrateFromAngularCli(
       updateRootEsLintConfig(tree, eslintConfig, options.unitTestRunner);
       cleanupEsLintPackages(tree);
     }
+
+    deleteGitKeepFilesIfNotNeeded(tree);
   }
 
   deleteAngularJson(tree);

--- a/packages/angular/src/generators/ng-add/utilities/workspace.ts
+++ b/packages/angular/src/generators/ng-add/utilities/workspace.ts
@@ -400,3 +400,12 @@ export function deleteAngularJson(tree: Tree): void {
   }
   tree.delete('angular.json');
 }
+
+export function deleteGitKeepFilesIfNotNeeded(tree: Tree): void {
+  if (tree.children('apps').length > 1 && tree.exists('apps/.gitkeep')) {
+    tree.delete('apps/.gitkeep');
+  }
+  if (tree.children('libs').length > 1 && tree.exists('libs/.gitkeep')) {
+    tree.delete('libs/.gitkeep');
+  }
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Migrating from an Angular CLI workspace to an Nx workspace with a monorepo layout breaks for e2e projects due to changes in the workspace layout handling.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Migrating from an Angular CLI workspace to an Nx workspace with a monorepo layout should work correctly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
