### PR TITLE
cleanup(bundling): change baseHref to base for vite builder

### DIFF
--- a/docs/generated/packages/vite.json
+++ b/docs/generated/packages/vite.json
@@ -219,10 +219,10 @@
             "description": "The output path of the generated files.",
             "x-completion-type": "directory"
           },
-          "baseHref": {
+          "base": {
             "type": "string",
             "description": "Base public path when served in development or production.",
-            "alias": "base"
+            "alias": "baseHref"
           },
           "proxyConfig": {
             "type": "string",

--- a/packages/vite/src/executors/build/schema.d.ts
+++ b/packages/vite/src/executors/build/schema.d.ts
@@ -1,7 +1,7 @@
 import type { FileReplacement } from '../../plugins/rollup-replace-files.plugin';
 export interface ViteBuildExecutorOptions {
   outputPath: string;
-  baseHref?: string;
+  base?: string;
   proxyConfig?: string;
   configFile?: string;
   fileReplacements?: FileReplacement[];

--- a/packages/vite/src/executors/build/schema.json
+++ b/packages/vite/src/executors/build/schema.json
@@ -17,10 +17,10 @@
       "description": "The output path of the generated files.",
       "x-completion-type": "directory"
     },
-    "baseHref": {
+    "base": {
       "type": "string",
       "description": "Base public path when served in development or production.",
-      "alias": "base"
+      "alias": "baseHref"
     },
     "proxyConfig": {
       "type": "string",

--- a/packages/vite/src/utils/options-utils.ts
+++ b/packages/vite/src/utils/options-utils.ts
@@ -30,7 +30,7 @@ export async function getBuildAndSharedConfig(
   return mergeConfig({}, {
     mode: options.mode,
     root: projectRoot,
-    base: options.baseHref,
+    base: options.base,
     configFile: normalizeConfigFilePath(
       options.configFile,
       context.root,


### PR DESCRIPTION
 I changed the property name to be `base`, and added as alias the `baseHref`. The reason we used `baseHref` initially, instead of `base`, is because we wanted to keep compatibility with the `nxext/vite` package. But I can see that it will create confusion. So, default name is `base`, alias `baseHref`. 

Fixes #13535
