### PR TITLE
fix(bundling): pass nxext options to our executor

### DIFF
--- a/docs/generated/packages/vite.json
+++ b/docs/generated/packages/vite.json
@@ -224,11 +224,6 @@
             "description": "Base public path when served in development or production.",
             "alias": "baseHref"
           },
-          "proxyConfig": {
-            "type": "string",
-            "description": "Path to the proxy configuration file.",
-            "x-completion-type": "file"
-          },
           "configFile": {
             "type": "string",
             "description": "The name of the Vite.js configuration file.",

--- a/packages/vite/src/executors/build/schema.d.ts
+++ b/packages/vite/src/executors/build/schema.d.ts
@@ -2,7 +2,6 @@ import type { FileReplacement } from '../../plugins/rollup-replace-files.plugin'
 export interface ViteBuildExecutorOptions {
   outputPath: string;
   base?: string;
-  proxyConfig?: string;
   configFile?: string;
   fileReplacements?: FileReplacement[];
   sourcemap?: boolean | 'inline' | 'hidden';

--- a/packages/vite/src/executors/build/schema.json
+++ b/packages/vite/src/executors/build/schema.json
@@ -22,11 +22,6 @@
       "description": "Base public path when served in development or production.",
       "alias": "baseHref"
     },
-    "proxyConfig": {
-      "type": "string",
-      "description": "Path to the proxy configuration file.",
-      "x-completion-type": "file"
-    },
     "configFile": {
       "type": "string",
       "description": "The name of the Vite.js configuration file.",

--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -138,6 +138,12 @@ export function addOrChangeBuildTarget(
   };
 
   if (targets[target]) {
+    buildOptions.fileReplacements = targets[target].options.fileReplacements;
+
+    if (target === '@nxext/vite:build') {
+      buildOptions.base = targets[target].options.baseHref;
+      buildOptions.sourcemap = targets[target].options.sourcemaps;
+    }
     targets[target].options = {
       ...buildOptions,
     };
@@ -179,6 +185,9 @@ export function addOrChangeServeTarget(
   };
 
   if (targets[target]) {
+    if (target === '@nxext/vite:dev') {
+      serveOptions.proxyConfig = targets[target].options.proxyConfig;
+    }
     targets[target].options = {
       ...serveOptions,
     };


### PR DESCRIPTION
If some options are set to the executor for a nxext/vite, pass them to ours with the generator!
