### PR TITLE
docs(nxdev): remove redirect rules for landing pages

### DIFF
--- a/nx-dev/nx-dev/next.config.js
+++ b/nx-dev/nx-dev/next.config.js
@@ -197,13 +197,6 @@ module.exports = withNx({
       });
     }
 
-    // Landing pages
-    rules.push({
-      source: '/(angular|react|node)',
-      destination: '/',
-      permanent: true,
-    });
-
     // Packages Indexes
     for (let s of Object.keys(redirectRules.packagesIndexes)) {
       rules.push({


### PR DESCRIPTION
It removes the old redirect rules about the landing pages (`angular`/`node`/`react`) since #13555. Auto generated indexes are now available for each packages.