### PR TITLE
feat(angular): log a warning when running make-angular-cli-faster with older or incompatible versions

### DIFF
--- a/packages/make-angular-cli-faster/src/utilities/make-angular-cli-faster.ts
+++ b/packages/make-angular-cli-faster/src/utilities/make-angular-cli-faster.ts
@@ -1,5 +1,6 @@
 import { output } from 'nx/src/utils/output';
 import { getPackageManagerCommand } from 'nx/src/utils/package-manager';
+import { lt } from 'semver';
 import { determineMigration, migrateWorkspace } from './migration';
 import { initNxCloud, promptForNxCloud } from './nx-cloud';
 import { installDependencies } from './package-manager';
@@ -42,4 +43,25 @@ export async function makeAngularCliFaster(args: Args) {
       'and how it can speed up your CI by up to 10 times at https://nx.dev/getting-started/nx-and-angular',
     ],
   });
+
+  if (migration.incompatibleWithAngularVersion) {
+    output.warn({
+      title: `The provided version of Nx (${args.version}) is not compatible with the currently installed version of Angular (${migration.angularVersion}).`,
+      bodyLines: [
+        'The workspace was still migrated, but you might find unexpected issues or behaviors using this version.',
+        'To know which versions are compatible, please refer to https://nx.dev/angular-nx-version-matrix.',
+      ],
+    });
+  }
+
+  // if migrated to an older version than root project is supported, log a warning
+  if (lt(migration.version, '15.3.0-beta.5')) {
+    output.warn({
+      title: 'You are not on the latest version of Nx yet.',
+      bodyLines: [
+        `You might find some differences compared to the documentation which reflects the latest state of Nx.`,
+        'To update to the latest version of Nx, visit https://nx.dev/core-features/automate-updating-dependencies.',
+      ],
+    });
+  }
 }

--- a/packages/make-angular-cli-faster/src/utilities/types.ts
+++ b/packages/make-angular-cli-faster/src/utilities/types.ts
@@ -1,4 +1,6 @@
 export interface MigrationDefinition {
   packageName: string;
   version: string;
+  angularVersion?: string;
+  incompatibleWithAngularVersion?: boolean;
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Running `make-angular-cli-faster` with an incompatible or an older version (a version that doesn't supports root project) doesn't provide any feedback about it.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Running `make-angular-cli-faster` with an incompatible or an older version a warning is logged providing feedback.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
