### PR TITLE
fix(testing): generate appropriate files when unitTestRunner is vitest without specifying vite as the bundler

### DIFF
--- a/packages/react/src/generators/library/lib/create-files.ts
+++ b/packages/react/src/generators/library/lib/create-files.ts
@@ -27,7 +27,7 @@ export function createFiles(host: Tree, options: NormalizedSchema) {
     substitutions
   );
 
-  if (options.bundler === 'vite') {
+  if (options.bundler === 'vite' || options.unitTestRunner === 'vitest') {
     generateFiles(
       host,
       joinPathFragments(__dirname, '../files/vite'),


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
