### PR TITLE
fix(misc): adjust prompt for standalone react to not include cypress

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -447,8 +447,7 @@ function determineMonorepoStyle(): Promise<string> {
           },
           {
             name: 'react',
-            message:
-              'Standalone React app:   Nx configures Vite, ESLint and Cypress.',
+            message: 'Standalone React app:   Nx configures Vite and ESLint.',
           },
           {
             name: 'angular',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Creating a new workspace claims that we will create a workspace with react, eslint, and cypress.. but then doesn't create cypress.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Creating a new workspce will not claim to create a workspace that includes cypress.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
