### PR TITLE
fix(testing): handle cypress-project generation for standalone projects

### DIFF
--- a/docs/generated/packages/cypress.json
+++ b/docs/generated/packages/cypress.json
@@ -111,12 +111,6 @@
             "type": "boolean",
             "default": false,
             "description": "Do not add dependencies to `package.json`."
-          },
-          "rootProject": {
-            "description": "Create a application at the root of the workspace",
-            "type": "boolean",
-            "default": false,
-            "hidden": true
           }
         },
         "required": ["name"],

--- a/packages/cypress/src/generators/cypress-project/cypress-project.spec.ts
+++ b/packages/cypress/src/generators/cypress-project/cypress-project.spec.ts
@@ -245,6 +245,32 @@ describe('Cypress Project', () => {
         const tsConfig = readJson(tree, 'apps/my-dir/my-app-e2e/tsconfig.json');
         expect(tsConfig.extends).toBe('../../../tsconfig.json');
       });
+
+      describe('root project', () => {
+        it('should generate in option.name when root project detected', async () => {
+          addProjectConfiguration(tree, 'root', {
+            root: '.',
+          });
+          await cypressProjectGenerator(tree, {
+            ...defaultOptions,
+            name: 'e2e-tests',
+            baseUrl: 'http://localhost:1234',
+            project: 'root',
+            rootProject: true,
+          });
+          expect(tree.listChanges().map((c) => c.path)).toEqual(
+            expect.arrayContaining([
+              'e2e-tests/cypress.config.ts',
+              'e2e-tests/src/e2e/app.cy.ts',
+              'e2e-tests/src/fixtures/example.json',
+              'e2e-tests/src/support/app.po.ts',
+              'e2e-tests/src/support/commands.ts',
+              'e2e-tests/src/support/e2e.ts',
+              'e2e-tests/tsconfig.json',
+            ])
+          );
+        });
+      });
     });
 
     describe('--project', () => {

--- a/packages/cypress/src/generators/cypress-project/schema.json
+++ b/packages/cypress/src/generators/cypress-project/schema.json
@@ -59,12 +59,6 @@
       "type": "boolean",
       "default": false,
       "description": "Do not add dependencies to `package.json`."
-    },
-    "rootProject": {
-      "description": "Create a application at the root of the workspace",
-      "type": "boolean",
-      "default": false,
-      "hidden": true
     }
   },
   "required": ["name"],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
when a common named directory exists in the workspace cypress-projects would be generated nested in the directory which is an issue in standalone workspaces. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
standalone projects should always generate project as it's name. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
