### PR TITLE
fix(testing): only target files in src/* directory for component testing

### DIFF
--- a/packages/angular/plugins/component-testing.ts
+++ b/packages/angular/plugins/component-testing.ts
@@ -100,7 +100,7 @@ ${e.stack ? e.stack : e}`
   return {
     ...nxBaseCypressPreset(pathToConfig),
     // NOTE: cannot use a glob pattern since it will break cypress generated tsconfig.
-    specPattern: ['**/*.cy.ts', '**/*.cy.js'],
+    specPattern: ['src/**/*.cy.ts', 'src/**/*.cy.js'],
     devServer: {
       // cypress uses string union type,
       // need to use const to prevent typing to string

--- a/packages/react/plugins/component-testing/index.ts
+++ b/packages/react/plugins/component-testing/index.ts
@@ -93,6 +93,7 @@ export function nxComponentTestingPreset(
   }
   return {
     ...nxBaseCypressPreset(pathToConfig),
+    specPattern: 'src/**/*.cy.{js,jsx,ts,tsx}',
     devServer: {
       // cypress uses string union type,
       // need to use const to prevent typing to string


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
when using standalone CT config would pick up on e2e cypress files and try to run them

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
using CT in standalone app does not try to run e2e cypress tests

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
