### PR TITLE
fix(angular): standalone angular projects with karma should function

### DIFF
--- a/packages/angular/src/generators/karma-project/files/workspace-with-root-project/karma.conf.js__tmpl__
+++ b/packages/angular/src/generators/karma-project/files/workspace-with-root-project/karma.conf.js__tmpl__
@@ -2,13 +2,14 @@
 // https://karma-runner.github.io/6.4/config/configuration-file.html
 
 const { join } = require('path');
-const setBaseKarmaConfig = require('<%= offsetFromRoot %>karma.conf');
+const getBaseKarmaConfig = require('<%= offsetFromRoot %>karma.conf');
 
 module.exports = function (config) {
-  setBaseKarmaConfig(config);
-
+  const baseConfig = getBaseKarmaConfig();
   config.set({
+    ...baseConfig,
     coverageReporter: {
+      ...baseConfig.coverageReporter,
       dir: join(__dirname, '<%= offsetFromRoot %>coverage/<%= projectRoot %>')
     }
   });


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
The `karma.conf.js` config we create for nested projects in standalone workspaces is failing to launch correctly.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Fix the generated `karma.conf.js` to function as expected
