### PR TITLE
fix(misc): only warn about ng completion not supported when trying to set up the completion

### DIFF
--- a/packages/nx/bin/init-local.ts
+++ b/packages/nx/bin/init-local.ts
@@ -139,9 +139,11 @@ function handleAngularCLIFallbacks(workspace: WorkspaceTypeAndRoot) {
         })
     );
   } else if (process.argv[2] === 'completion') {
-    console.log(`"ng completion" is not natively supported by Nx.
-Instead, you could try an Nx Editor Plugin for a visual tool to run Nx commands. If you're using VSCode, you can use the Nx Console plugin, or if you're using WebStorm, you could use one of the available community plugins.
-For more information, see https://nx.dev/using-nx/console`);
+    if (!process.argv[3]) {
+      console.log(`"ng completion" is not natively supported by Nx.
+  Instead, you could try an Nx Editor Plugin for a visual tool to run Nx commands. If you're using VSCode, you can use the Nx Console plugin, or if you're using WebStorm, you could use one of the available community plugins.
+  For more information, see https://nx.dev/core-features/integrate-with-editors`);
+    }
   } else {
     require('nx/src/adapter/compat');
     try {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The Angular CLI completion adds `source <(ng completion script)` to the shell profile. When an Angular CLI workspace is migrated to Nx, the result of `ng completion script` is not a script, but rather a message is logged out, which is not correct and breaks it.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The unsupported log message for `ng completion` should only be shown when trying to set up the completion with Nx. Otherwise, it should do nothing.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
