### PR TITLE
cleanup(nextjs): remove workaround for enhanced-resolve bug in e2e test

### DIFF
--- a/e2e/next/src/next-storybook.test.ts
+++ b/e2e/next/src/next-storybook.test.ts
@@ -24,16 +24,6 @@ describe('Next.js Applications', () => {
   it('should run a Next.js based Storybook setup', async () => {
     const appName = uniq('app');
 
-    // TODO(jack): Overriding enhanced-resolve to 5.10.0 now until the package is fixed.
-    // See: https://github.com/webpack/enhanced-resolve/issues/362
-    updateJson('package.json', (json) => {
-      json['overrides'] = {
-        'enhanced-resolve': '5.10.0',
-      };
-      return json;
-    });
-    runCommand(getPackageManagerCommand().install);
-
     runCLI(`generate @nrwl/next:app ${appName} --no-interactive`);
     runCLI(
       `generate @nrwl/next:component Foo --project=${appName} --no-interactive`


### PR DESCRIPTION
Previously, we had to put a workaround in our e2e tests to make sure npm installs `enhanced-resolve` at version `5.10.0` since `5.11.0` was breaking all projects using Storybook (outside of our control).

This PR removes that workaround since `5.12.0` reverted the breaking change in `enhanced-resolve`.