### PR TITLE
React Native PNPM resolver can't resolve `require` export condition name

### DIFF
--- a/packages/react-native/plugins/metro-resolver.ts
+++ b/packages/react-native/plugins/metro-resolver.ts
@@ -86,13 +86,15 @@ function pnpmResolver(
     if (filePath) {
       return { type: 'sourceFile', filePath };
     }
-  } catch {
-    if (debug)
+  } catch (error) {
+    if (debug) {
       console.log(
         chalk.cyan(
           `[Nx] Unable to resolve with default PNPM resolver: ${realModuleName}`
         )
       );
+      console.log(error);
+    }
   }
 }
 
@@ -177,6 +179,7 @@ function getPnpmResolver(extensions: string[]) {
       extensions: extensions.map((extension) => '.' + extension),
       useSyncFileSystemCalls: true,
       modules: [join(workspaceRoot, 'node_modules'), 'node_modules'],
+      conditionNames: ["node", "require"]
     });
   }
   return resolver;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Any package with `exports` field in the description file which declare `require` can't be resolved by pnpm, including [css-select](https://www.npmjs.com/package/css-select), [nth-check](https://www.npmjs.com/package/nth-check), [domhandler](https://www.npmjs.com/package/domhandler), [domelementtype](https://www.npmjs.com/package/domelementtype), etc...

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

These package should resolve...
