### PR TITLE
docs(core): deprecate global implicit dependencies

### DIFF
--- a/docs/map.json
+++ b/docs/map.json
@@ -573,6 +573,11 @@
               "name": "runtimeCacheInputs",
               "id": "runtime-cache-inputs",
               "file": "shared/deprecated/runtime-cache-inputs"
+            },
+            {
+              "name": "globalImplicitDependencies",
+              "id": "global-implicit-dependencies",
+              "file": "shared/deprecated/global-implicit-dependencies"
             }
           ]
         },

--- a/docs/shared/deprecated/global-implicit-dependencies.md
+++ b/docs/shared/deprecated/global-implicit-dependencies.md
@@ -15,34 +15,30 @@ The old way to have the `myapp` project depend on specific files in the root of 
 }
 ```
 
-To express the same dependencies with `inputs` and `namedInputs`, do this:
+To express the same dependencies with `inputs` and `namedInputs`, modify the default `sharedGlobals` named input:
 
 ```json {% fileName="nx.json" %}
 {
   "namedInputs": {
-    "globalFiles": [
+    "sharedGlobals": [
       "{workspaceRoot}/globalConfig.js",
       "{workspaceRoot}/styles/**/*.css"
+    ],
+    "default": [
+      "sharedGlobals"
+      // etc
     ]
   }
 }
 ```
 
-```json {% fileName="project.json" %}
-{
-  "targets": {
-    "build": {
-      "inputs": ["globalFiles" /* etc */]
-    }
-  }
-}
-```
+The `sharedGlobals` are included in the `default` named input, so most targets will be set up to depend on them.
 
 For a more detailed explanation, read the [Customizing Inputs and Named Inputs guide](/more-concepts/customizing-inputs)
 
 ### Dependencies on Sections of the Root `package.json` File
 
-You used to be able to set up dependencies on specific sections of the `package.json` file, like this:
+You used to be able to set up dependencies on specific packages in the `dependenceis` and `devDependencies` sections of the `package.json` file, like this:
 
 ```json
 {
@@ -51,15 +47,10 @@ You used to be able to set up dependencies on specific sections of the `package.
       "dependencies": "*",
       "devDependencies": {
         "mypackage": ["mylib"]
-      },
-      "scripts": {
-        "check:*": "*"
       }
     }
   }
 }
 ```
 
-This never worked correctly with the caching mechanism and is not possible to specify using `inputs` and `namedInputs`.
-
-As of Nx 15.3, you can create a root-level project and treat the root-level `package.json` scripts as targets like any other project and then set up the `dependsOn` property for those individual targets. Depending on your use case, this might be a sufficient replacement.
+As of Nx 15, this is inferred automatically by Nx based on the `import` statements in your code. These `implicitDependencies` can be safely deleted.

--- a/docs/shared/deprecated/global-implicit-dependencies.md
+++ b/docs/shared/deprecated/global-implicit-dependencies.md
@@ -1,0 +1,65 @@
+# Global Implicit Dependencies
+
+As of Nx 14.4, it is better to use [`inputs` and `namedInputs`](/more-concepts/customizing-inputs) instead of the `implicitDependencies` previously defined in `nx.json`. [`implicitDependencies` in the project configuration](/reference/project-configuration#implicitdependencies) are still the best way to manually set up a dependency between two projects that Nx is not able to detect automatically.
+
+## Projects Depending on Global Files
+
+The old way to have the `myapp` project depend on specific files in the root of the workspace was to use `implicitDependencies`, like this:
+
+```json
+{
+  "implicitDependencies": {
+    "globalConfig.js": ["myapp"],
+    "styles/**/*.css": ["myapp"]
+  }
+}
+```
+
+To express the same dependencies with `inputs` and `namedInputs`, do this:
+
+```json {% fileName="nx.json" %}
+{
+  "namedInputs": {
+    "globalFiles": [
+      "{workspaceRoot}/globalConfig.js",
+      "{workspaceRoot}/styles/**/*.css"
+    ]
+  }
+}
+```
+
+```json {% fileName="project.json" %}
+{
+  "targets": {
+    "build": {
+      "inputs": ["globalFiles" /* etc */]
+    }
+  }
+}
+```
+
+For a more detailed explanation, read the [Customizing Inputs and Named Inputs guide](/more-concepts/customizing-inputs)
+
+### Dependencies on Sections of the Root `package.json` File
+
+You used to be able to set up dependencies on specific sections of the `package.json` file, like this:
+
+```json
+{
+  "implicitDependencies": {
+    "package.json": {
+      "dependencies": "*",
+      "devDependencies": {
+        "mypackage": ["mylib"]
+      },
+      "scripts": {
+        "check:*": "*"
+      }
+    }
+  }
+}
+```
+
+This never worked correctly with the caching mechanism and is not possible to specify using `inputs` and `namedInputs`.
+
+As of Nx 15.3, you can create a root-level project and treat the root-level `package.json` scripts as targets like any other project and then set up the `dependsOn` property for those individual targets. Depending on your use case, this might be a sufficient replacement.

--- a/docs/shared/reference/nx-json.md
+++ b/docs/shared/reference/nx-json.md
@@ -74,38 +74,6 @@ You can add a `workspaceLayout` property to modify where libraries and apps are 
 These settings would store apps in `/demos/` and libraries in `/packages/`. The paths specified are relative to the
 workspace root.
 
-### Files & Implicit Dependencies
-
-Nx performs advanced source-code analysis to figure out the project graph of the workspace. So when you make a change,
-Nx can deduce what can be broken by this change. Some dependencies between projects and shared files cannot be inferred
-statically. You can configure those using `implicitDependencies`.
-
-```json
-{
-  "implicitDependencies": {
-    "package.json": {
-      "dependencies": "*",
-      "devDependencies": {
-        "mypackage": ["mylib"]
-      },
-      "scripts": {
-        "check:*": "*"
-      }
-    },
-    "globalFile": ["myapp"],
-    "styles/**/*.css": ["myapp"]
-  }
-}
-```
-
-In the example above:
-
-- Changing the `dependencies` property in `package.json` affects every project.
-- Changing the `mypackage` property in `package.json` only affects `mylib`.
-- Changing any of the custom check `scripts` in `package.json` affects every project.
-- Changing `globalFile` only affects `myapp`.
-- Changing any CSS file inside the `styles` directory only affects `myapp`.
-
 ### inputs & namedInputs
 
 Named inputs defined in `nx.json` are merged with the named inputs defined in each project's project.json.


### PR DESCRIPTION
Deprecate the nx.json implicit dependencies section