### PR TITLE
chore(devkit): adding missing peer dep in devkit on typescript

### DIFF
--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -35,7 +35,8 @@
     "semver": "7.3.4"
   },
   "peerDependencies": {
-    "nx": ">= 14 <= 16"
+    "nx": ">= 14 <= 16",
+    "typescript": "^3 || ^4"
   },
   "nx-migrations": {
     "migrations": "./migrations.json"


### PR DESCRIPTION
## Current Behavior
Installing the latest version of lerna results in `@nrwl/devkit@npm:15.2.4 [bd3f7] doesn't provide typescript (pdfcb0), requested by @phenomnomnominal/tsquery`

## Expected Behavior
Don't do that

## Related Issue(s)
Didn't make one - felt like clutter. LMK if you want me to.

Fixes #

Note: I couldn't find `@phenomnomnominal/tsquery@4.1.1` in that repo's commit history...:shrug:
