### PR TITLE
fix(vite): remove default for hmr from schema.json

### DIFF
--- a/docs/generated/packages/vite.json
+++ b/docs/generated/packages/vite.json
@@ -175,8 +175,7 @@
           "https": { "type": "boolean", "description": "Serve using HTTPS." },
           "hmr": {
             "description": "Enable hot module replacement. For more options, use the 'hmr' option in the Vite configuration file.",
-            "type": "boolean",
-            "default": true
+            "type": "boolean"
           },
           "open": {
             "description": "Automatically open the app in the browser on server start. When the value is a string, it will be used as the URL's pathname.",

--- a/packages/vite/src/executors/dev-server/schema.json
+++ b/packages/vite/src/executors/dev-server/schema.json
@@ -46,8 +46,7 @@
     },
     "hmr": {
       "description": "Enable hot module replacement. For more options, use the 'hmr' option in the Vite configuration file.",
-      "type": "boolean",
-      "default": true
+      "type": "boolean"
     },
     "open": {
       "description": "Automatically open the app in the browser on server start. When the value is a string, it will be used as the URL's pathname.",

--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -202,6 +202,7 @@ export function addOrChangeServeTarget(
       configurations: {
         development: {
           buildTarget: `${options.project}:build:development`,
+          hmr: true,
         },
         production: {
           buildTarget: `${options.project}:build:production`,


### PR DESCRIPTION
The reason for this change is the following:

If there's a default set in `schema.json`, then the default can ONLY be overwritten in `project.json` or if the user passes the option through a flag (eg: `nx serve my-app --hmr=false`). It cannot be overwritten in `vite.config.ts`. I think it's best to allow the user to be able to set all options in `vite.config.ts` if they want to. So it's best to not impose any defaults.

In this PR, I am adding the `hmr: true` in `project.json`, so a user can either change it there, or remove it completely, and set it in `vite.config.ts`.
