### PR TITLE
fix(vite): take into account configuration for build mode

### DIFF
--- a/packages/vite/src/executors/build/schema.d.ts
+++ b/packages/vite/src/executors/build/schema.d.ts
@@ -9,5 +9,5 @@ export interface ViteBuildExecutorOptions {
   manifest?: boolean | string;
   ssrManifest?: boolean | string;
   logLevel?: 'info' | 'warn' | 'error' | 'silent';
-  mode?: string;
+  mode?: 'production' | 'development';
 }

--- a/packages/vite/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/vite/src/executors/dev-server/dev-server.impl.ts
@@ -16,7 +16,7 @@ export default async function* viteDevServerExecutor(
   context: ExecutorContext
 ): AsyncGenerator<{ success: boolean; baseUrl: string }> {
   const mergedOptions = {
-    ...getBuildTargetOptions(options, context),
+    ...getBuildTargetOptions(options.buildTarget, context),
     ...options,
   } as ViteDevServerExecutorOptions & ViteBuildExecutorOptions;
 

--- a/packages/vite/src/executors/dev-server/schema.d.ts
+++ b/packages/vite/src/executors/dev-server/schema.d.ts
@@ -9,6 +9,6 @@ export interface ViteDevServerExecutorOptions {
   open?: string | boolean;
   cors?: boolean;
   logLevel?: info | warn | error | silent;
-  mode?: string;
+  mode?: 'production' | 'development';
   clearScreen?: boolean;
 }

--- a/packages/vite/src/utils/options-utils.ts
+++ b/packages/vite/src/utils/options-utils.ts
@@ -28,7 +28,7 @@ export async function getBuildAndSharedConfig(
   const projectRoot = context.workspace.projects[context.projectName].root;
 
   return mergeConfig({}, {
-    mode: options.mode,
+    mode: options.mode ?? context.configurationName,
     root: projectRoot,
     base: options.base,
     configFile: normalizeConfigFilePath(
@@ -97,10 +97,10 @@ export function getServerOptions(
 }
 
 export function getBuildTargetOptions(
-  options: ViteDevServerExecutorOptions,
+  buildTarget: string,
   context: ExecutorContext
 ) {
-  const target = parseTargetString(options.buildTarget);
+  const target = parseTargetString(buildTarget);
   return readTargetOptions(target, context);
 }
 


### PR DESCRIPTION
Take into account `--configuration` or `my-app:build:production` configuration for vite builder (don't just use the options). It was only using `mode` to set configuration for builder.

Explanation:

This means, Vite is taking into account the `configurationName` from Nx, to set the [Vite builder mode](https://vitejs.dev/config/shared-options.html#mode). 

The `--configuration` flag/option cannot be used interchangeably with [`mode`](https://vitejs.dev/config/shared-options.html#mode):

* `mode` **will** set the Vite builder mode **and** the configurationName (if you do `--mode=production` it will build for `production` and use the `production` configuration in `project.json`. 
* However, if your `configuration` is set to `development` and you pass `--mode=production`, the Vite builder will build for `production`, but Nx will use the `development` configuration options from `project.json`