### PR TITLE
fix(core): throw a better error when running a target doesn't have an…

### DIFF
--- a/packages/nx/src/tasks-runner/create-task-graph.spec.ts
+++ b/packages/nx/src/tasks-runner/create-task-graph.spec.ts
@@ -274,7 +274,14 @@ describe('createTaskGraph', () => {
           data: {
             root: 'lib2-root',
             files: [],
-            targets: { build: {}, test: {} },
+            targets: {
+              build: {
+                executor: 'nx:run-commands',
+              },
+              test: {
+                executor: 'nx:run-commands',
+              },
+            },
           },
         },
       },
@@ -976,7 +983,9 @@ describe('createTaskGraph', () => {
                   { target: 'build', projects: 'dependencies' },
                 ],
               },
-              prebuild: {},
+              prebuild: {
+                executor: 'nx:run-commands',
+              },
             },
           },
         },

--- a/packages/nx/src/tasks-runner/create-task-graph.spec.ts
+++ b/packages/nx/src/tasks-runner/create-task-graph.spec.ts
@@ -14,8 +14,11 @@ describe('createTaskGraph', () => {
             root: 'app1-root',
             files: [],
             targets: {
-              prebuild: {},
+              prebuild: {
+                executor: 'nx:run-commands',
+              },
               build: {
+                executor: 'nx:run-commands',
                 dependsOn: [
                   {
                     projects: 'dependencies',
@@ -27,8 +30,12 @@ describe('createTaskGraph', () => {
                   },
                 ],
               },
-              test: {},
-              serve: {},
+              test: {
+                executor: 'nx:run-commands',
+              },
+              serve: {
+                executor: 'nx:run-commands',
+              },
             },
           },
         },
@@ -39,8 +46,12 @@ describe('createTaskGraph', () => {
             root: 'lib1-root',
             files: [],
             targets: {
-              build: {},
-              test: {},
+              build: {
+                executor: 'nx:run-commands',
+              },
+              test: {
+                executor: 'nx:run-commands',
+              },
             },
           },
         },
@@ -208,9 +219,14 @@ describe('createTaskGraph', () => {
             root: 'app1-root',
             files: [],
             targets: {
-              'prebuild-base': {},
-              prebuild: {},
+              'prebuild-base': {
+                executor: 'nx:run-commands',
+              },
+              prebuild: {
+                executor: 'nx:run-commands',
+              },
               build: {
+                executor: 'nx:run-commands',
                 dependsOn: [
                   {
                     projects: 'dependencies',
@@ -220,8 +236,12 @@ describe('createTaskGraph', () => {
                   { projects: 'self', target: 'prebuild', params: 'forward' },
                 ],
               },
-              test: {},
-              serve: {},
+              test: {
+                executor: 'nx:run-commands',
+              },
+              serve: {
+                executor: 'nx:run-commands',
+              },
             },
           },
         },
@@ -233,6 +253,7 @@ describe('createTaskGraph', () => {
             files: [],
             targets: {
               build: {
+                executor: 'nx:run-commands',
                 dependsOn: [
                   {
                     projects: 'dependencies',
@@ -241,7 +262,9 @@ describe('createTaskGraph', () => {
                   },
                 ],
               },
-              test: {},
+              test: {
+                executor: 'nx:run-commands',
+              },
             },
           },
         },
@@ -392,7 +415,9 @@ describe('createTaskGraph', () => {
             root: 'app1-root',
             files: [],
             targets: {
-              build: {},
+              build: {
+                executor: 'nx:run-commands',
+              },
             },
           },
         },
@@ -403,7 +428,9 @@ describe('createTaskGraph', () => {
             root: 'lib1-root',
             files: [],
             targets: {
-              build: {},
+              build: {
+                executor: 'nx:run-commands',
+              },
             },
           },
         },
@@ -414,7 +441,9 @@ describe('createTaskGraph', () => {
             root: 'lib2-root',
             files: [],
             targets: {
-              build: {},
+              build: {
+                executor: 'nx:run-commands',
+              },
             },
           },
         },
@@ -425,7 +454,9 @@ describe('createTaskGraph', () => {
             root: 'lib3-root',
             files: [],
             targets: {
-              build: {},
+              build: {
+                executor: 'nx:run-commands',
+              },
             },
           },
         },
@@ -526,7 +557,9 @@ describe('createTaskGraph', () => {
             root: 'app1-root',
             files: [],
             targets: {
-              build: {},
+              build: {
+                executor: 'nx:run-commands',
+              },
             },
           },
         },
@@ -537,7 +570,9 @@ describe('createTaskGraph', () => {
             root: 'app2-root',
             files: [],
             targets: {
-              build: {},
+              build: {
+                executor: 'nx:run-commands',
+              },
             },
           },
         },
@@ -548,7 +583,9 @@ describe('createTaskGraph', () => {
             root: 'infra1-root',
             files: [],
             targets: {
-              apply: {},
+              apply: {
+                executor: 'nx:run-commands',
+              },
             },
           },
         },
@@ -559,7 +596,9 @@ describe('createTaskGraph', () => {
             root: 'infra2-root',
             files: [],
             targets: {
-              apply: {},
+              apply: {
+                executor: 'nx:run-commands',
+              },
             },
           },
         },
@@ -570,7 +609,9 @@ describe('createTaskGraph', () => {
             root: 'infra3-root',
             files: [],
             targets: {
-              apply: {},
+              apply: {
+                executor: 'nx:run-commands',
+              },
             },
           },
         },
@@ -675,9 +716,11 @@ describe('createTaskGraph', () => {
             files: [],
             targets: {
               build: {
+                executor: 'nx:run-commands',
                 dependsOn: [{ target: 'test', projects: 'self' }],
               },
               test: {
+                executor: 'nx:run-commands',
                 dependsOn: [{ target: 'build', projects: 'self' }],
               },
             },
@@ -741,7 +784,9 @@ describe('createTaskGraph', () => {
             root: 'app1-root',
             files: [],
             targets: {
-              build: {},
+              build: {
+                executor: 'nx:run-commands',
+              },
             },
           },
         },
@@ -761,7 +806,9 @@ describe('createTaskGraph', () => {
             root: 'app3-root',
             files: [],
             targets: {
-              build: {},
+              build: {
+                executor: 'nx:run-commands',
+              },
             },
           },
         },
@@ -831,7 +878,9 @@ describe('createTaskGraph', () => {
             root: 'app1-root',
             files: [],
             targets: {
-              build: {},
+              build: {
+                executor: 'nx:run-commands',
+              },
             },
           },
         },
@@ -851,7 +900,9 @@ describe('createTaskGraph', () => {
             root: 'app3-root',
             files: [],
             targets: {
-              build: {},
+              build: {
+                executor: 'nx:run-commands',
+              },
             },
           },
         },
@@ -919,6 +970,7 @@ describe('createTaskGraph', () => {
             files: [],
             targets: {
               build: {
+                executor: 'nx:run-commands',
                 dependsOn: [
                   { target: 'prebuild', projects: 'self' },
                   { target: 'build', projects: 'dependencies' },
@@ -935,7 +987,9 @@ describe('createTaskGraph', () => {
             root: 'app2-root',
             files: [],
             targets: {
-              build: {},
+              build: {
+                executor: 'nx:run-commands',
+              },
             },
           },
         },

--- a/packages/nx/src/tasks-runner/create-task-graph.ts
+++ b/packages/nx/src/tasks-runner/create-task-graph.ts
@@ -26,6 +26,14 @@ export class ProcessTasks {
   ) {
     for (const projectName of projectNames) {
       for (const target of targets) {
+        if (
+          !this.projectGraph.nodes[projectName].data.targets[target].executor
+        ) {
+          throw new Error(
+            `Target "${projectName}:${target}" does not have an executor configured`
+          );
+        }
+
         const resolvedConfiguration = this.resolveConfiguration(
           this.projectGraph.nodes[projectName],
           target,

--- a/packages/nx/src/tasks-runner/create-task-graph.ts
+++ b/packages/nx/src/tasks-runner/create-task-graph.ts
@@ -26,14 +26,6 @@ export class ProcessTasks {
   ) {
     for (const projectName of projectNames) {
       for (const target of targets) {
-        if (
-          !this.projectGraph.nodes[projectName].data.targets[target].executor
-        ) {
-          throw new Error(
-            `Target "${projectName}:${target}" does not have an executor configured`
-          );
-        }
-
         const resolvedConfiguration = this.resolveConfiguration(
           this.projectGraph.nodes[projectName],
           target,
@@ -198,6 +190,18 @@ export class ProcessTasks {
     resolvedConfiguration: string | undefined,
     overrides: Object
   ): Task {
+    if (!project.data.targets[target]) {
+      throw new Error(
+        `Cannot find configuration for task ${project.name}:${target}`
+      );
+    }
+
+    if (!project.data.targets[target].executor) {
+      throw new Error(
+        `Target "${project.name}:${target}" does not have an executor configured`
+      );
+    }
+
     const qualifiedTarget = {
       project: project.name,
       target,

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -215,12 +215,6 @@ export function getExecutorNameForTask(
     loadNxPlugins(nxJson.plugins)
   );
 
-  if (!project.targets[task.target.target]) {
-    throw new Error(
-      `Cannot find configuration for task ${task.target.project}:${task.target.target}`
-    );
-  }
-
   return project.targets[task.target.target].executor;
 }
 


### PR DESCRIPTION
… executor

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When running a target which does not have an executor defined, there is  a strange error:

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Running a target which does not have a executor defined should throw an error that says so.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/13556
