### PR TITLE
fix(angular): handle next and latest npm tags when resolving generator directory

### DIFF
--- a/packages/angular/src/utils/get-generator-directory-for-ng-version.spec.ts
+++ b/packages/angular/src/utils/get-generator-directory-for-ng-version.spec.ts
@@ -24,24 +24,27 @@ describe('getGeneratorDirectoryForAngularVersion', () => {
     }
   );
 
-  test.each(['15.0.0', '~15.1.0', '^13.2.0', '~15.3.0-beta.0'])(
-    'should return null for anything other than v14',
-    (ngVersion) => {
-      // ARRANGE
-      const tree = createTreeWithEmptyWorkspace();
-      updateJson(tree, 'package.json', (json) => ({
-        ...json,
-        dependencies: {
-          '@angular/core': ngVersion,
-        },
-      }));
+  test.each([
+    '15.0.0',
+    '~15.1.0',
+    '^13.2.0',
+    '~15.3.0-beta.0',
+    'latest',
+    'next',
+  ])('should return null for anything other than v14', (ngVersion) => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: {
+        '@angular/core': ngVersion,
+      },
+    }));
 
-      // ACT
-      const directoryName =
-        getGeneratorDirectoryForInstalledAngularVersion(tree);
+    // ACT
+    const directoryName = getGeneratorDirectoryForInstalledAngularVersion(tree);
 
-      // ASSERT
-      expect(directoryName).toBe(null);
-    }
-  );
+    // ASSERT
+    expect(directoryName).toBe(null);
+  });
 });

--- a/packages/angular/src/utils/get-generator-directory-for-ng-version.ts
+++ b/packages/angular/src/utils/get-generator-directory-for-ng-version.ts
@@ -7,7 +7,11 @@ export function getGeneratorDirectoryForInstalledAngularVersion(tree: Tree) {
   const angularVersion =
     pkgJson.dependencies && pkgJson.dependencies['@angular/core'];
 
-  if (!angularVersion) {
+  if (
+    !angularVersion ||
+    angularVersion === 'latest' ||
+    angularVersion === 'next'
+  ) {
     return null;
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Resolving a generator directory for an Angular version using the `next` or `latest` npm tag breaks the generator.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Resolving a generator directory for an Angular version using the `next` or `latest` npm tag should work correctly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #13673 
