### PR TITLE
fix(angular): ensure migration for ngrx 15 targets a future patch version

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -1672,8 +1672,8 @@
         }
       }
     },
-    "15.2.4": {
-      "version": "15.2.4-beta.0",
+    "15.3.1": {
+      "version": "15.3.1-beta.0",
       "packages": {
         "packages": {
           "@ngrx/store": {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The migration to bump ngrx to v15 targets a version lower than the version the migration was released. Therefore, workspaces on Nx v15.2.4 migrating to latest don't get the migration to run.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The migration to bump ngrx to v15 targets the next version that is not yet released, so it runs for every workspace regardless of its version.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #13689 
