### PR TITLE
fix(js): inlining duplicate dependencies

### DIFF
--- a/packages/js/src/utils/inline.ts
+++ b/packages/js/src/utils/inline.ts
@@ -64,30 +64,31 @@ export function postProcessInlinedDependencies(
   const inlinedDepsDestOutputRecord: Record<string, string> = {};
   // move inlined outputs
 
-  for (const inlineDependenciesNames of Object.values(
-    inlineGraph.dependencies
-  )) {
-    for (const inlineDependenciesName of inlineDependenciesNames) {
-      const inlineDependency = inlineGraph.nodes[inlineDependenciesName];
-      const depOutputPath =
-        inlineDependency.buildOutputPath ||
-        join(outputPath, inlineDependency.root);
-      const destDepOutputPath = join(outputPath, inlineDependency.name);
-      const isBuildable = !!inlineDependency.buildOutputPath;
+  //get deduplicated inlineDependencies
+  const inlineDependenciesNames = Object.values(inlineGraph.dependencies)
+    .flat()
+    .filter((v, idx, arr) => arr.indexOf(v) === idx);
 
-      if (isBuildable) {
-        copySync(depOutputPath, destDepOutputPath, {
-          overwrite: true,
-          recursive: true,
-        });
-      } else {
-        movePackage(depOutputPath, destDepOutputPath);
-      }
+  for (const inlineDependenciesName of inlineDependenciesNames) {
+    const inlineDependency = inlineGraph.nodes[inlineDependenciesName];
+    const depOutputPath =
+      inlineDependency.buildOutputPath ||
+      join(outputPath, inlineDependency.root);
+    const destDepOutputPath = join(outputPath, inlineDependency.name);
+    const isBuildable = !!inlineDependency.buildOutputPath;
 
-      // TODO: hard-coded "src"
-      inlinedDepsDestOutputRecord[inlineDependency.pathAlias] =
-        destDepOutputPath + '/src';
+    if (isBuildable) {
+      copySync(depOutputPath, destDepOutputPath, {
+        overwrite: true,
+        recursive: true,
+      });
+    } else {
+      movePackage(depOutputPath, destDepOutputPath);
     }
+
+    // TODO: hard-coded "src"
+    inlinedDepsDestOutputRecord[inlineDependency.pathAlias] =
+      destDepOutputPath + '/src';
   }
 
   updateImports(outputPath, inlinedDepsDestOutputRecord);


### PR DESCRIPTION
De-duplicates dependencies before looping through them

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

Given we have three libs:
- `lib-a` (buildable)
- `lib-b`
- `lib-c`

And:
 - `lib-a` depends on `lib-b` & `lib-c`
 - `lib-b` depends on `lib-c`

When we run `nx run lib-a:build`

Then it will try and call `movePackage` twice on `lib-c`, the second time failing because it has already been handled.

The error is :
```
Error: ENOENT: no such file or directory, lstat '/home/user/example-project/dist/libs/lib-a/libs/lib-c'
    at Object.lstatSync (node:fs:1529:3)
    at Object.lstatSync (/home/user/example-project/node_modules/graceful-fs/polyfills.js:318:34)
    at statFunc (/home/user/example-project/node_modules/fs-extra/lib/util/stat.js:24:20)
    at getStatsSync (/home/user/example-project/node_modules/fs-extra/lib/util/stat.js:25:19)
    at Object.checkPathsSync (/home/user/example-project/node_modules/fs-extra/lib/util/stat.js:67:33)
    at copySync (/home/user/example-project/node_modules/fs-extra/lib/copy/copy-sync.js:27:38)
    at movePackage (/home/user/example-project/node_modules/@nrwl/js/src/utils/inline.js:157:29)
    at postProcessInlinedDependencies (/home/user/example-project/node_modules/@nrwl/js/src/utils/inline.js:45:17)
    at /home/user/example-project/node_modules/@nrwl/js/src/executors/tsc/tsc.impl.js:87:57
    at Generator.next (<anonymous>) {
  errno: -2,
  syscall: 'lstat',
  code: 'ENOENT',
  path: '/home/user/example-project/dist/libs/lib-a/libs/lib-c'
}
```

## Expected Behavior

Build command completes successfully, and dependencies are inlined

## Related Issue(s)
_No issue created for this as I found the fix - I can created if more details/reproduction is needed_
