### PR TITLE
fix(angular): remove invalid nested packages key from migration

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -1675,34 +1675,32 @@
     "15.3.1": {
       "version": "15.3.1-beta.0",
       "packages": {
-        "packages": {
-          "@ngrx/store": {
-            "version": "~15.0.0",
-            "alwaysAddToPackageJson": false
-          },
-          "@ngrx/effects": {
-            "version": "~15.0.0",
-            "alwaysAddToPackageJson": false
-          },
-          "@ngrx/entity": {
-            "version": "~15.0.0",
-            "alwaysAddToPackageJson": false
-          },
-          "@ngrx/router-store": {
-            "version": "~15.0.0",
-            "alwaysAddToPackageJson": false
-          },
-          "@ngrx/schematics": {
-            "version": "~15.0.0",
-            "alwaysAddToPackageJson": false
-          },
-          "@ngrx/store-devtools": {
-            "version": "~15.0.0",
-            "alwaysAddToPackageJson": false
-          },
-          "@ngrx/component-store": {
-            "version": "~15.0.0"
-          }
+        "@ngrx/store": {
+          "version": "~15.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@ngrx/effects": {
+          "version": "~15.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@ngrx/entity": {
+          "version": "~15.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@ngrx/router-store": {
+          "version": "~15.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@ngrx/schematics": {
+          "version": "~15.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@ngrx/store-devtools": {
+          "version": "~15.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@ngrx/component-store": {
+          "version": "~15.0.0"
         }
       }
     }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The package update definition for ngrx 15 has a wrong nested `packages` entry that causes the packages not to be updated.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The package update definition for ngrx 15 is correct.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #13689 
