### PR TITLE
fix(react): fix target to use for serve-ssr remote detection

### DIFF
--- a/packages/react/src/module-federation/with-module-federation-ssr.ts
+++ b/packages/react/src/module-federation/with-module-federation-ssr.ts
@@ -4,11 +4,11 @@ import { getModuleFederationConfig } from './utils';
 
 function determineRemoteUrl(remote: string) {
   const remoteConfiguration = readCachedProjectConfiguration(remote);
-  const serveTarget = remoteConfiguration?.targets?.serve;
+  const serveTarget = remoteConfiguration?.targets?.['serve-server'];
 
   if (!serveTarget) {
     throw new Error(
-      `Cannot automatically determine URL of remote (${remote}). Looked for property "host" in the project's "serve" target.\n
+      `Cannot automatically determine URL of remote (${remote}). Looked for property "host" in the project's "serve-server" target.\n
       You can also use the tuple syntax in your webpack config to configure your remotes. e.g. \`remotes: [['remote1', '//localhost:4201']]\``
     );
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`withModuleFederationSSR` was not correctly finding remote locations

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

it should correctly find remote locations
