### PR TITLE
feat(js): add --bundler=vite support for JS libs

### DIFF
--- a/docs/generated/packages/js.json
+++ b/docs/generated/packages/js.json
@@ -45,9 +45,9 @@
           },
           "unitTestRunner": {
             "type": "string",
-            "enum": ["jest", "none"],
+            "enum": ["jest", "vitest", "none"],
             "description": "Test runner to use for unit tests.",
-            "default": "jest"
+            "x-prompt": "Which unit test runner would you like to use?"
           },
           "tags": {
             "type": "string",
@@ -123,7 +123,7 @@
           "bundler": {
             "description": "The bundler to use.",
             "type": "string",
-            "enum": ["none", "esbuild", "rollup", "webpack"],
+            "enum": ["none", "esbuild", "rollup", "vite", "webpack"],
             "default": "none"
           },
           "skipTypeCheck": {

--- a/e2e/js/src/js.test.ts
+++ b/e2e/js/src/js.test.ts
@@ -432,6 +432,26 @@ export function ${child}() {
     }, 120000);
   });
 
+  describe('bundling libs', () => {
+    it('should support esbuild and vite bundlers for building libs', () => {
+      const esbuildLib = uniq('esbuildlib');
+      const viteLib = uniq('vitelib');
+
+      runCLI(
+        `generate @nrwl/js:lib ${esbuildLib} --bundler=esbuild --no-interactive`
+      );
+      runCLI(
+        `generate @nrwl/js:lib ${viteLib} --bundler=vite --no-interactive`
+      );
+
+      runCLI(`build ${esbuildLib}`);
+      runCLI(`build ${viteLib}`);
+
+      checkFilesExist(`dist/libs/${esbuildLib}/index.js`);
+      checkFilesExist(`dist/libs/${viteLib}/index.js`);
+    });
+  });
+
   it('should not create a `.babelrc` file when creating libs with js executors (--compiler=tsc)', () => {
     const lib = uniq('lib');
     runCLI(

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -978,4 +978,43 @@ describe('lib', () => {
       });
     });
   });
+
+  describe('--bundler=vite', () => {
+    it('should add build and test targets with vite and vitest', async () => {
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        name: 'myLib',
+        bundler: 'vite',
+        unitTestRunner: undefined,
+      });
+
+      const project = readProjectConfiguration(tree, 'my-lib');
+      expect(project.targets.build).toMatchObject({
+        executor: '@nrwl/vite:build',
+      });
+      expect(project.targets.test).toMatchObject({
+        executor: '@nrwl/vite:test',
+      });
+      expect(tree.exists('libs/my-lib/vite.config.ts')).toBeTruthy();
+    });
+
+    it.each`
+      unitTestRunner | executor
+      ${'none'}      | ${undefined}
+      ${'jest'}      | ${'@nrwl/jest:jest'}
+    `(
+      'should respect unitTestRunner if passed',
+      async ({ unitTestRunner, executor }) => {
+        await libraryGenerator(tree, {
+          ...defaultOptions,
+          name: 'myLib',
+          bundler: 'vite',
+          unitTestRunner,
+        });
+
+        const project = readProjectConfiguration(tree, 'my-lib');
+        expect(project.targets.test?.executor).toEqual(executor);
+      }
+    );
+  });
 });

--- a/packages/js/src/generators/library/schema.json
+++ b/packages/js/src/generators/library/schema.json
@@ -28,9 +28,9 @@
     },
     "unitTestRunner": {
       "type": "string",
-      "enum": ["jest", "none"],
+      "enum": ["jest", "vitest", "none"],
       "description": "Test runner to use for unit tests.",
-      "default": "jest"
+      "x-prompt": "Which unit test runner would you like to use?"
     },
     "tags": {
       "type": "string",
@@ -106,7 +106,7 @@
     "bundler": {
       "description": "The bundler to use.",
       "type": "string",
-      "enum": ["none", "esbuild", "rollup", "webpack"],
+      "enum": ["none", "esbuild", "rollup", "vite", "webpack"],
       "default": "none"
     },
     "skipTypeCheck": {

--- a/packages/js/src/utils/schema.d.ts
+++ b/packages/js/src/utils/schema.d.ts
@@ -7,7 +7,7 @@ import type {
 import { TransformerEntry } from './typescript/types';
 
 export type Compiler = 'tsc' | 'swc';
-export type Bundler = 'none' | 'rollup' | 'esbuild' | 'webpack';
+export type Bundler = 'none' | 'rollup' | 'esbuild' | 'vite' | 'webpack';
 
 export interface LibraryGeneratorSchema {
   name: string;
@@ -17,7 +17,7 @@ export interface LibraryGeneratorSchema {
   simpleModuleName?: boolean;
   skipTsConfig?: boolean;
   includeBabelRc?: boolean;
-  unitTestRunner?: 'jest' | 'none';
+  unitTestRunner?: 'jest' | 'vitest' | 'none';
   linter?: Linter;
   testEnvironment?: 'jsdom' | 'node';
   importPath?: string;


### PR DESCRIPTION
This adds the option to use Vite for JS libs.

```
# Use Vite for build, Vitest for test
nx g @nrwl/lib:js --bundler=vite

# Use Vite for build, Jest for test
nx g @nrwl/lib:js --bundler=vite --unitTestRunner=jest

# Use Vite for build, no tests
nx g @nrwl/lib:js --bundler=vite --unitTestRunner=none
```

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
