### PR TITLE
feat(graph): support `excludeFromProjectGraph` option in `nx.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -284,7 +284,6 @@
     "fast-glob": "3.2.7",
     "framer-motion": "^4.1.17",
     "glob": "7.1.4",
-    "glob-to-regexp": "^0.4.1",
     "history": "^5.3.0",
     "json-schema-to-typescript": "^10.1.5",
     "jsonpointer": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -284,6 +284,7 @@
     "fast-glob": "3.2.7",
     "framer-motion": "^4.1.17",
     "glob": "7.1.4",
+    "glob-to-regexp": "^0.4.1",
     "history": "^5.3.0",
     "json-schema-to-typescript": "^10.1.5",
     "jsonpointer": "^5.0.0",

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -49,6 +49,7 @@
     "flat": "^5.0.2",
     "fs-extra": "^10.1.0",
     "glob": "7.1.4",
+    "glob-to-regexp": "^0.4.1",
     "ignore": "^5.0.4",
     "js-yaml": "4.1.0",
     "jsonc-parser": "3.2.0",

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -136,4 +136,14 @@ export interface NxJsonConfiguration<T = '*' | string[]> {
    * will be used. Convenient for small workspaces with one main application.
    */
   defaultProject?: string;
+
+  /**
+   * Glob pattern of files to be excluded from project graph calculation.
+   *
+   * Can be useful to exclude imports in test files from affecting the project dependency
+   * graph which then affects the deep import checks.
+   *
+   * Example: `['*.spec.ts', '*.spec.tsx']`
+   */
+  excludeFromProjectGraph?: string[];
 }

--- a/packages/nx/src/generators/utils/project-configuration.ts
+++ b/packages/nx/src/generators/utils/project-configuration.ts
@@ -138,6 +138,7 @@ export function updateWorkspaceConfiguration(
     workspaceLayout,
     tasksRunnerOptions,
     affected,
+    excludeFromProjectGraph,
     extends: ext,
   } = workspaceConfig;
 
@@ -155,6 +156,7 @@ export function updateWorkspaceConfiguration(
     cli,
     generators,
     defaultProject,
+    excludeFromProjectGraph,
     extends: ext,
   };
 

--- a/packages/nx/src/project-graph/build-project-graph.ts
+++ b/packages/nx/src/project-graph/build-project-graph.ts
@@ -175,6 +175,9 @@ async function buildProjectGraphUsingContext(
   performance.mark('build project graph:start');
 
   const builder = new ProjectGraphBuilder(partialGraph);
+  if (nxJson.excludeFromProjectGraph) {
+    builder.setExclusionGlob(nxJson.excludeFromProjectGraph);
+  }
 
   buildWorkspaceProjectNodes(ctx, builder, nxJson);
   if (!partialGraph) {

--- a/packages/nx/src/project-graph/project-graph-builder.spec.ts
+++ b/packages/nx/src/project-graph/project-graph-builder.spec.ts
@@ -138,4 +138,24 @@ describe('ProjectGraphBuilder', () => {
       target2: [],
     });
   });
+
+  it(`should allow excluding via glob pattern`, () => {
+    builder.addNode({ name: 'target2', type: 'lib', data: {} });
+    builder.addExplicitDependency('source', 'source/index.ts', 'target');
+    builder.addExplicitDependency('source', 'source/second.ts', 'target2');
+    builder.setExclusionGlob(['*second.ts']);
+
+    const graph = builder.getUpdatedProjectGraph();
+    expect(graph.dependencies).toEqual({
+      source: [
+        {
+          source: 'source',
+          target: 'target',
+          type: 'static',
+        },
+      ],
+      target: [],
+      target2: [],
+    });
+  });
 });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
All imports in all files of a project counts in dependency graph, regardless whether these files are implementation or test files.

## Expected Behavior
Having control whether imports in test files should deeply impact the dependency graph or not.

Example:

```
- lib1/src/index.ts // exports from file1.ts **but not from file1.spec.ts**
- lib1/src/file1.ts
- lib1/src/file1.spec.ts // imports util1 from lib-test-utils

- lib-test-utils/src/index.ts // exports util1
- lib-test-utils/src/util1.ts // imports file2 from lib2

- lib2/src/index.ts // exports file2
- lib2/src/file2.ts
```

The current behavior of the above example is considering lib2 as a dependency for lib1, even though there is no path from lib1 entrypoint to lib2.

Such deep dependency check including files that are not exported from the library entrypoint, can cause the dependency graph to be faulty. As in the above example, lib1 does not depend on lib2, but because of the test file, lib1 was counted as depending on lib2.

This impacts also the `@nrwl/nx/enforce-module-boundaries` checks as well, in a larger-scale workspace.

## Related Issue(s)
https://github.com/nrwl/nx/issues/8606
https://github.com/nrwl/nx/issues/1018

Fixes #1018
