### PR TITLE
fix(angular): deprecate simpleModuleName in library generator in favor of simpleName

### DIFF
--- a/docs/generated/packages/angular.json
+++ b/docs/generated/packages/angular.json
@@ -850,6 +850,12 @@
           "simpleModuleName": {
             "description": "Keep the module name simple (when using `--directory`).",
             "type": "boolean",
+            "default": false,
+            "x-deprecated": "Use `simpleName` instead. It will be removed in v16."
+          },
+          "simpleName": {
+            "description": "Don't include the directory in the name of the module or standalone component entry of the library.",
+            "type": "boolean",
             "default": false
           },
           "addModuleSpec": {

--- a/packages/angular/src/generators/karma-project/karma-project.spec.ts
+++ b/packages/angular/src/generators/karma-project/karma-project.spec.ts
@@ -22,7 +22,7 @@ describe('karmaProject', () => {
       buildable: false,
       linter: Linter.EsLint,
       publishable: false,
-      simpleModuleName: false,
+      simpleName: false,
       skipFormat: false,
       unitTestRunner: UnitTestRunner.None,
     });

--- a/packages/angular/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/angular/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -372,3 +372,95 @@ import { secondRoutes } from '@proj/second';
           {path: '', component: MyLibComponent}
         ]"
 `;
+
+exports[`lib --standalone should generate a library with a standalone component in a directory 1`] = `"export * from \\"./lib/my-dir-my-lib/my-dir-my-lib.component\\";"`;
+
+exports[`lib --standalone should generate a library with a standalone component in a directory 2`] = `
+"import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'proj-my-dir-my-lib',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './my-dir-my-lib.component.html',
+  styleUrls: ['./my-dir-my-lib.component.css']
+})
+export class MyDirMyLibComponent {
+
+}
+"
+`;
+
+exports[`lib --standalone should generate a library with a standalone component in a directory 3`] = `
+"import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MyDirMyLibComponent } from './my-dir-my-lib.component';
+
+describe('MyDirMyLibComponent', () => {
+  let component: MyDirMyLibComponent;
+  let fixture: ComponentFixture<MyDirMyLibComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ MyDirMyLibComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(MyDirMyLibComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});
+"
+`;
+
+exports[`lib --standalone should generate a library with a standalone component in a directory with a simple name 1`] = `"export * from \\"./lib/my-lib/my-lib.component\\";"`;
+
+exports[`lib --standalone should generate a library with a standalone component in a directory with a simple name 2`] = `
+"import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'proj-my-lib',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './my-lib.component.html',
+  styleUrls: ['./my-lib.component.css']
+})
+export class MyLibComponent {
+
+}
+"
+`;
+
+exports[`lib --standalone should generate a library with a standalone component in a directory with a simple name 3`] = `
+"import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MyLibComponent } from './my-lib.component';
+
+describe('MyLibComponent', () => {
+  let component: MyLibComponent;
+  let fixture: ComponentFixture<MyLibComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ MyLibComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(MyLibComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});
+"
+`;

--- a/packages/angular/src/generators/library/lib/normalize-options.ts
+++ b/packages/angular/src/generators/library/lib/normalize-options.ts
@@ -14,17 +14,13 @@ import { Linter } from '@nrwl/linter';
 import { UnitTestRunner } from '../../../utils/test-runners';
 import { normalizePrefix } from '../../utils/project';
 
-export function normalizeOptions(
-  host: Tree,
-  schema: Partial<Schema>
-): NormalizedSchema {
+export function normalizeOptions(host: Tree, schema: Schema): NormalizedSchema {
   // Create a schema with populated default values
   const options: Schema = {
     buildable: false,
     linter: Linter.EsLint,
-    name: '', // JSON validation will ensure this is set
     publishable: false,
-    simpleModuleName: false,
+    simpleName: false,
     skipFormat: false,
     unitTestRunner: UnitTestRunner.Jest,
     // Publishable libs cannot use `full` yet, so if its false then use the passed value or default to `full`
@@ -53,7 +49,8 @@ export function normalizeOptions(
   const projectName = fullProjectDirectory
     .replace(new RegExp('/', 'g'), '-')
     .replace(/-\d+/g, '');
-  const fileName = options.simpleModuleName ? name : projectName;
+  const fileName =
+    options.simpleName || options.simpleModuleName ? name : projectName;
   const projectRoot = joinPathFragments(libsDir, fullProjectDirectory);
 
   const moduleName = `${names(fileName).className}Module`;
@@ -114,7 +111,7 @@ export function normalizeOptions(
   return {
     libraryOptions,
     componentOptions: {
-      name: libraryOptions.name,
+      name: fileName,
       standalone: libraryOptions.standalone,
       displayBlock,
       inlineStyle,

--- a/packages/angular/src/generators/library/lib/normalized-schema.ts
+++ b/packages/angular/src/generators/library/lib/normalized-schema.ts
@@ -6,7 +6,7 @@ export interface NormalizedSchema {
     name: string;
     addTailwind?: boolean;
     skipFormat?: boolean;
-    simpleModuleName?: boolean;
+    simpleName?: boolean;
     addModuleSpec?: boolean;
     directory?: string;
     sourceDir?: string;

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -44,7 +44,7 @@ describe('lib', () => {
       linter: Linter.EsLint,
       skipFormat: false,
       unitTestRunner: UnitTestRunner.Jest,
-      simpleModuleName: false,
+      simpleName: false,
       strict: true,
       ...opts,
     });
@@ -558,7 +558,7 @@ describe('lib', () => {
       await runLibraryGeneratorWithOpts({
         name: 'myLib2',
         directory: 'myDir',
-        simpleModuleName: true,
+        simpleName: true,
       });
 
       // ASSERT
@@ -693,7 +693,7 @@ describe('lib', () => {
       };
       await runLibraryGeneratorWithOpts({
         directory: 'myDir',
-        simpleModuleName: true,
+        simpleName: true,
         publishable: true,
         importPath: '@myorg/lib',
       });
@@ -766,7 +766,7 @@ describe('lib', () => {
           directory: 'myDir',
           routing: true,
           lazy: true,
-          simpleModuleName: true,
+          simpleName: true,
         });
 
         // ASSERT
@@ -811,7 +811,7 @@ describe('lib', () => {
           directory: 'myDir',
           routing: true,
           lazy: true,
-          simpleModuleName: true,
+          simpleName: true,
           parent: 'apps/myapp/src/app/app.module.ts',
         });
 
@@ -827,7 +827,7 @@ describe('lib', () => {
           directory: 'myDir',
           routing: true,
           lazy: true,
-          simpleModuleName: true,
+          simpleName: true,
           parent: 'apps/myapp/src/app/app.module.ts',
         });
 
@@ -938,7 +938,7 @@ describe('lib', () => {
         await runLibraryGeneratorWithOpts({
           name: 'myLib2',
           directory: 'myDir',
-          simpleModuleName: true,
+          simpleName: true,
           routing: true,
         });
         // ASSERT
@@ -984,7 +984,7 @@ describe('lib', () => {
         await runLibraryGeneratorWithOpts({
           name: 'myLib2',
           directory: 'myDir',
-          simpleModuleName: true,
+          simpleName: true,
           routing: true,
           parent: 'apps/myapp/src/app/app.module.ts',
         });
@@ -998,7 +998,7 @@ describe('lib', () => {
           directory: 'myDir',
           routing: true,
           parent: 'apps/myapp/src/app/app.module.ts',
-          simpleModuleName: true,
+          simpleName: true,
         });
 
         const moduleContents3 = tree
@@ -1439,6 +1439,53 @@ describe('lib', () => {
       ).toMatchSnapshot();
       expect(
         tree.read('libs/my-lib/src/lib/my-lib.component.spec.ts', 'utf-8')
+      ).toMatchSnapshot();
+    });
+
+    it('should generate a library with a standalone component in a directory', async () => {
+      await runLibraryGeneratorWithOpts({
+        standalone: true,
+        directory: 'my-dir',
+      });
+
+      expect(
+        tree.read('libs/my-dir/my-lib/src/index.ts', 'utf-8')
+      ).toMatchSnapshot();
+      expect(
+        tree.read(
+          'libs/my-dir/my-lib/src/lib/my-dir-my-lib/my-dir-my-lib.component.ts',
+          'utf-8'
+        )
+      ).toMatchSnapshot();
+      expect(
+        tree.read(
+          'libs/my-dir/my-lib/src/lib/my-dir-my-lib/my-dir-my-lib.component.spec.ts',
+          'utf-8'
+        )
+      ).toMatchSnapshot();
+    });
+
+    it('should generate a library with a standalone component in a directory with a simple name', async () => {
+      await runLibraryGeneratorWithOpts({
+        standalone: true,
+        directory: 'my-dir',
+        simpleName: true,
+      });
+
+      expect(
+        tree.read('libs/my-dir/my-lib/src/index.ts', 'utf-8')
+      ).toMatchSnapshot();
+      expect(
+        tree.read(
+          'libs/my-dir/my-lib/src/lib/my-lib/my-lib.component.ts',
+          'utf-8'
+        )
+      ).toMatchSnapshot();
+      expect(
+        tree.read(
+          'libs/my-dir/my-lib/src/lib/my-lib/my-lib.component.spec.ts',
+          'utf-8'
+        )
       ).toMatchSnapshot();
     });
 

--- a/packages/angular/src/generators/library/library.ts
+++ b/packages/angular/src/generators/library/library.ts
@@ -30,7 +30,7 @@ import { updateTsConfig } from './lib/update-tsconfig';
 import { addStandaloneComponent } from './lib/add-standalone-component';
 import { Schema } from './schema';
 
-export async function libraryGenerator(tree: Tree, schema: Partial<Schema>) {
+export async function libraryGenerator(tree: Tree, schema: Schema) {
   // Do some validation checks
   if (!schema.routing && schema.lazy) {
     throw new Error(`To use "--lazy" option, "--routing" must also be set.`);

--- a/packages/angular/src/generators/library/schema.d.ts
+++ b/packages/angular/src/generators/library/schema.d.ts
@@ -5,7 +5,11 @@ export interface Schema {
   name: string;
   addTailwind?: boolean;
   skipFormat?: boolean;
+  /**
+   * @deprecated Use `simpleName` instead. It will be removed in v16.
+   */
   simpleModuleName?: boolean;
+  simpleName?: boolean;
   addModuleSpec?: boolean;
   directory?: string;
   sourceDir?: string;

--- a/packages/angular/src/generators/library/schema.json
+++ b/packages/angular/src/generators/library/schema.json
@@ -45,6 +45,12 @@
     "simpleModuleName": {
       "description": "Keep the module name simple (when using `--directory`).",
       "type": "boolean",
+      "default": false,
+      "x-deprecated": "Use `simpleName` instead. It will be removed in v16."
+    },
+    "simpleName": {
+      "description": "Don't include the directory in the name of the module or standalone component entry of the library.",
+      "type": "boolean",
       "default": false
     },
     "addModuleSpec": {

--- a/packages/angular/src/generators/move/lib/update-module-name.spec.ts
+++ b/packages/angular/src/generators/move/lib/update-module-name.spec.ts
@@ -18,7 +18,7 @@ describe('updateModuleName Rule', () => {
     const updatedModulePath = '/libs/my/first/src/lib/my-first.module.ts';
     await libraryGenerator(tree, {
       name: 'my-first',
-      simpleModuleName: true,
+      simpleName: true,
     });
     const schema: Schema = {
       projectName: 'my-first',
@@ -54,7 +54,7 @@ describe('updateModuleName Rule', () => {
         buildable: false,
         linter: Linter.EsLint,
         publishable: false,
-        simpleModuleName: true,
+        simpleName: true,
         skipFormat: false,
         unitTestRunner: UnitTestRunner.Jest,
       });
@@ -63,7 +63,7 @@ describe('updateModuleName Rule', () => {
         buildable: false,
         linter: Linter.EsLint,
         publishable: false,
-        simpleModuleName: true,
+        simpleName: true,
         skipFormat: false,
         unitTestRunner: UnitTestRunner.Jest,
       });
@@ -169,7 +169,7 @@ describe('updateModuleName Rule', () => {
         buildable: false,
         linter: Linter.EsLint,
         publishable: false,
-        simpleModuleName: true,
+        simpleName: true,
         skipFormat: false,
         unitTestRunner: UnitTestRunner.Jest,
       });
@@ -214,7 +214,7 @@ describe('updateModuleName Rule', () => {
         buildable: false,
         linter: Linter.EsLint,
         publishable: false,
-        simpleModuleName: true,
+        simpleName: true,
         skipFormat: false,
         unitTestRunner: UnitTestRunner.Jest,
       });

--- a/packages/angular/src/generators/move/move.spec.ts
+++ b/packages/angular/src/generators/move/move.spec.ts
@@ -17,7 +17,7 @@ describe('@nrwl/angular:move', () => {
       buildable: false,
       linter: Linter.EsLint,
       publishable: false,
-      simpleModuleName: true,
+      simpleName: true,
       skipFormat: false,
       unitTestRunner: UnitTestRunner.Jest,
     });

--- a/packages/angular/src/generators/utils/testing.ts
+++ b/packages/angular/src/generators/utils/testing.ts
@@ -24,7 +24,7 @@ export async function createStorybookTestWorkspaceForLib(
     buildable: false,
     linter: Linter.EsLint,
     publishable: false,
-    simpleModuleName: false,
+    simpleName: false,
     skipFormat: false,
     unitTestRunner: UnitTestRunner.Jest,
   });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `simpleModuleName` option of the `@nrwl/angular:library` generator only works for a generated module and not for libraries generated with the `--standalone` flag.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

A new option `simpleName` is available to support module and standalone component use cases. The `simpleModuleName` also supports both but it's now deprecated in favor of the new option.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #13198 
