### PR TITLE
cleanup(graph): add e2e tests to externalAPI

### DIFF
--- a/graph/client-e2e/src/e2e/release-static-app.cy.ts
+++ b/graph/client-e2e/src/e2e/release-static-app.cy.ts
@@ -1,4 +1,10 @@
 import { testProjectsRoutes, testTaskRoutes } from '../support/routing-tests';
+import {
+  getCheckedProjectItems,
+  getFocusButtonForProject,
+  getUnfocusProjectButton,
+} from '../support/app.po';
+import * as nxExamplesJson from '../fixtures/nx-examples-project-graph.json';
 
 describe('release static-mode app', () => {
   describe('smoke tests', () => {
@@ -21,5 +27,29 @@ describe('release static-mode app', () => {
 
   describe('routing', () => {
     testProjectsRoutes('hash', ['/projects']);
+  });
+
+  describe('api tests', () => {
+    describe('focusProject', () => {
+      it('should focus project', () => {
+        cy.window().then((window) => {
+          window.externalApi.focusProject('cart');
+
+          const dependencies = nxExamplesJson.dependencies.cart;
+          const dependents = Object.keys(nxExamplesJson.dependencies).filter(
+            (key) =>
+              nxExamplesJson.dependencies[key]
+                .map((dependencies) => dependencies.target)
+                .includes('cart')
+          );
+          getUnfocusProjectButton().should('exist');
+          getCheckedProjectItems().should(
+            'have.length',
+            ['cart', ...dependencies, ...dependents].length
+          );
+          cy.url().should('contain', '/projects/cart');
+        });
+      });
+    });
   });
 });

--- a/graph/client-e2e/src/e2e/release-static-app.cy.ts
+++ b/graph/client-e2e/src/e2e/release-static-app.cy.ts
@@ -1,7 +1,9 @@
 import { testProjectsRoutes, testTaskRoutes } from '../support/routing-tests';
 import {
   getCheckedProjectItems,
+  getDeselectAllButton,
   getFocusButtonForProject,
+  getTextFilterInput,
   getUnfocusProjectButton,
 } from '../support/app.po';
 import * as nxExamplesJson from '../fixtures/nx-examples-project-graph.json';
@@ -30,26 +32,115 @@ describe('release static-mode app', () => {
   });
 
   describe('api tests', () => {
-    describe('focusProject', () => {
+    before(() => {
+      cy.visit('/#/projects/');
+    });
+
+    afterEach(() => {
+      // clean up by hiding all projects and clearing text input
+      getDeselectAllButton().click();
+      getTextFilterInput().clear();
+      getCheckedProjectItems().should('have.length', 0);
+    });
+
+    describe('externalApi public api', () => {
       it('should focus project', () => {
         cy.window().then((window) => {
           window.externalApi.focusProject('cart');
+          checkFocusedProject(nxExamplesJson, 'cart');
+        });
+      });
 
-          const dependencies = nxExamplesJson.dependencies.cart;
-          const dependents = Object.keys(nxExamplesJson.dependencies).filter(
-            (key) =>
-              nxExamplesJson.dependencies[key]
-                .map((dependencies) => dependencies.target)
-                .includes('cart')
-          );
-          getUnfocusProjectButton().should('exist');
-          getCheckedProjectItems().should(
-            'have.length',
-            ['cart', ...dependencies, ...dependents].length
-          );
-          cy.url().should('contain', '/projects/cart');
+      it('should select all projects', () => {
+        cy.window().then((window) => {
+          window.externalApi.selectAllProjects();
+          checkSelectAll(nxExamplesJson);
+        });
+      });
+    });
+
+    ['depGraphService', 'projectGraphService'].forEach((serviceName) => {
+      describe(`deprecated api - ${serviceName}`, () => {
+        it('should focus project', () => {
+          cy.window().then((window) => {
+            window.externalApi[serviceName].send({
+              type: 'focusProject',
+              projectName: 'cart',
+            });
+            checkFocusedProject(nxExamplesJson, 'cart');
+          });
+        });
+
+        it('should select all projects', () => {
+          cy.window().then((window) => {
+            window.externalApi[serviceName].send({ type: 'selectAll' });
+            checkSelectAll(nxExamplesJson);
+          });
+        });
+
+        it('should select a project', () => {
+          cy.window().then((window) => {
+            window.externalApi[serviceName].send({
+              type: 'selectProject',
+              projectName: 'cart',
+            });
+            checkSelectedProject('cart');
+          });
+        });
+
+        it('should deselect a project', () => {
+          cy.window().then((window) => {
+            window.externalApi[serviceName].send({
+              type: 'selectProject',
+              projectName: 'cart',
+            });
+            window.externalApi[serviceName].send({
+              type: 'selectProject',
+              projectName: 'cart-e2e',
+            });
+            window.externalApi[serviceName].send({
+              type: 'deselectProject',
+              projectName: 'cart',
+            });
+
+            checkSelectedProject('cart-e2e');
+            checkDeselectedProject('cart');
+          });
         });
       });
     });
   });
 });
+
+function checkFocusedProject(projectGraphJson: any, projectName: string) {
+  const dependencies = projectGraphJson.dependencies.cart;
+  const dependents = Object.keys(nxExamplesJson.dependencies).filter((key) =>
+    nxExamplesJson.dependencies[key]
+      .map((dependencies) => dependencies.target)
+      .includes(projectName)
+  );
+  getUnfocusProjectButton().should('exist');
+  getCheckedProjectItems().should(
+    'have.length',
+    [projectName, ...dependencies, ...dependents].length
+  );
+  cy.url().should('contain', `/projects/${projectName}`);
+}
+
+function checkSelectAll(projectGraphJson: any) {
+  getCheckedProjectItems().should(
+    'have.length',
+    projectGraphJson.projects.length
+  );
+  cy.url().should('contain', `/projects/all`);
+}
+
+function checkSelectedProject(projectName: string) {
+  cy.get(`[data-project="${projectName}"][data-active="true"]`).should('exist');
+}
+
+function checkDeselectedProject(projectName: string) {
+  cy.get(`[data-project="${projectName}"][data-active="true"]`).should(
+    'not.exist'
+  );
+}

--- a/graph/client-e2e/src/globals.d.ts
+++ b/graph/client-e2e/src/globals.d.ts
@@ -1,0 +1,2 @@
+// ensure we have the types for the externalApi on window
+export type { global } from 'graph/client/src/globals';

--- a/graph/client/src/app/app.tsx
+++ b/graph/client/src/app/app.tsx
@@ -5,23 +5,13 @@ import {
   createHashRouter,
   RouterProvider,
 } from 'react-router-dom';
-import { getRoutesForEnvironment } from './routes';
-import { getEnvironmentConfig } from './hooks/use-environment-config';
+import { getRouter } from './get-router';
 
 themeInit();
 rankDirInit();
 
-const environmentConfig = getEnvironmentConfig();
-
-let routerCreate = createBrowserRouter;
-if (environmentConfig.localMode === 'build') {
-  routerCreate = createHashRouter;
-}
-
-const router = routerCreate(getRoutesForEnvironment());
-
 export function App() {
-  return <RouterProvider router={router} />;
+  return <RouterProvider router={getRouter()} />;
 }
 
 export default App;

--- a/graph/client/src/app/external-api.ts
+++ b/graph/client/src/app/external-api.ts
@@ -1,10 +1,10 @@
-import { getProjectGraphService } from './machines/get-services';
+import { getRouter } from './get-router';
 
 export class ExternalApi {
-  projectGraphService = getProjectGraphService();
+  router = getRouter();
 
   focusProject(projectName: string) {
-    this.projectGraphService.send({ type: 'focusProject', projectName });
+    this.router.navigate(`/projects/${projectName}`);
   }
 
   enableExperimentalFeatures() {

--- a/graph/client/src/app/external-api.ts
+++ b/graph/client/src/app/external-api.ts
@@ -1,10 +1,35 @@
 import { getRouter } from './get-router';
+import { getProjectGraphService } from './machines/get-services';
+import { ProjectGraphMachineEvents } from './feature-projects/machines/interfaces';
 
 export class ExternalApi {
+  _projectGraphService = getProjectGraphService();
+  _graphIsReady = new Promise<void>((resolve) => {
+    this._projectGraphService.subscribe((state) => {
+      if (!state.matches('idle')) {
+        resolve();
+      }
+    });
+  });
+
   router = getRouter();
+
+  projectGraphService = {
+    send: (event: ProjectGraphMachineEvents) => {
+      this.handleLegacyProjectGraphEvent(event);
+    },
+  };
+
+  get depGraphService() {
+    return this.projectGraphService;
+  }
 
   focusProject(projectName: string) {
     this.router.navigate(`/projects/${projectName}`);
+  }
+
+  selectAllProjects() {
+    this.router.navigate(`/projects/all`);
   }
 
   enableExperimentalFeatures() {
@@ -15,5 +40,19 @@ export class ExternalApi {
   disableExperimentalFeatures() {
     localStorage.setItem('showExperimentalFeatures', 'false');
     window.appConfig.showExperimentalFeatures = false;
+  }
+
+  private handleLegacyProjectGraphEvent(event: ProjectGraphMachineEvents) {
+    switch (event.type) {
+      case 'focusProject':
+        this.focusProject(event.projectName);
+        break;
+      case 'selectAll':
+        this.selectAllProjects();
+        break;
+      default:
+        this._graphIsReady.then(() => this._projectGraphService.send(event));
+        break;
+    }
   }
 }

--- a/graph/client/src/app/get-router.ts
+++ b/graph/client/src/app/get-router.ts
@@ -1,0 +1,20 @@
+import { createBrowserRouter, createHashRouter } from 'react-router-dom';
+import { getRoutesForEnvironment } from './routes';
+import { getEnvironmentConfig } from './hooks/use-environment-config';
+
+let router;
+
+export function getRouter() {
+  if (!router) {
+    const environmentConfig = getEnvironmentConfig();
+
+    let routerCreate = createBrowserRouter;
+    if (environmentConfig.localMode === 'build') {
+      routerCreate = createHashRouter;
+    }
+
+    router = routerCreate(getRoutesForEnvironment());
+  }
+
+  return router;
+}

--- a/graph/client/src/app/util.ts
+++ b/graph/client/src/app/util.ts
@@ -5,7 +5,7 @@ import { To, useParams, useSearchParams } from 'react-router-dom';
 
 export const useRouteConstructor = (): ((
   to: To,
-  retainSearchParams: true
+  retainSearchParams: boolean
 ) => To) => {
   const { environment } = getEnvironmentConfig();
   const { selectedWorkspaceId } = useParams();


### PR DESCRIPTION
## Current Behavior
* The `externalApi` for Nx Console to interact with the graph client is not covered by any tests.

## Expected Behavior
* The `externalApi` for Nx Console to interact with the graph client is covered by e2e tests.
