### PR TITLE
fix(core): ignore angular.json when nx.json is missing

### DIFF
--- a/packages/nx/src/config/workspaces.spec.ts
+++ b/packages/nx/src/config/workspaces.spec.ts
@@ -1,6 +1,6 @@
-import { toProjectName, Workspaces } from './workspaces';
-import { NxJsonConfiguration } from './nx-json';
 import { vol } from 'memfs';
+import { NxJsonConfiguration } from './nx-json';
+import { toProjectName, workspaceConfigName, Workspaces } from './workspaces';
 
 import * as fastGlob from 'fast-glob';
 
@@ -135,6 +135,76 @@ describe('Workspaces', () => {
         root: 'packages/my-package',
         sourceRoot: 'packages/my-package',
         projectType: 'library',
+      });
+    });
+  });
+
+  describe('workspace config name', () => {
+    describe('when nx.json exists', () => {
+      it('should return angular.json', () => {
+        vol.fromJSON(
+          {
+            'nx.json': '{}',
+            'workspace.json': '{}',
+            'angular.json': '{}',
+          },
+          '/root'
+        );
+
+        const workspaceFileName = workspaceConfigName('/root');
+        expect(workspaceFileName).toBe('angular.json');
+      });
+
+      it('should return workspace.json', () => {
+        vol.fromJSON(
+          {
+            'nx.json': '{}',
+            'workspace.json': '{}',
+          },
+          '/root'
+        );
+
+        const workspaceFileName = workspaceConfigName('/root');
+        expect(workspaceFileName).toBe('workspace.json');
+      });
+
+      it('should return null if no config exists', () => {
+        vol.fromJSON(
+          {
+            'nx.json': '{}',
+          },
+          '/root'
+        );
+
+        const workspaceFileName = workspaceConfigName('/root');
+        expect(workspaceFileName).toBeNull();
+      });
+    });
+
+    describe('when nx.json does not exist', () => {
+      it('should ignore angular.json and return workspace.json', () => {
+        vol.fromJSON(
+          {
+            'workspace.json': '{}',
+            'angular.json': '{}',
+          },
+          '/root'
+        );
+
+        const workspaceFileName = workspaceConfigName('/root');
+        expect(workspaceFileName).toBe('workspace.json');
+      });
+
+      it('should ignore angular.json and return null if no workspace.json exists', () => {
+        vol.fromJSON(
+          {
+            'angular.json': '{}',
+          },
+          '/root'
+        );
+
+        const workspaceFileName = workspaceConfigName('/root');
+        expect(workspaceFileName).toBeNull();
       });
     });
   });

--- a/packages/nx/src/config/workspaces.ts
+++ b/packages/nx/src/config/workspaces.ts
@@ -33,7 +33,10 @@ import { joinPathFragments } from '../utils/path';
 export function workspaceConfigName(
   root: string
 ): 'angular.json' | 'workspace.json' | null {
-  if (existsSync(path.join(root, 'angular.json'))) {
+  if (
+    existsSync(path.join(root, 'angular.json')) &&
+    existsSync(path.join(root, 'nx.json'))
+  ) {
     return 'angular.json';
   } else if (existsSync(path.join(root, 'workspace.json'))) {
     return 'workspace.json';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Nx will prefer angular.json projects in Lerna projects that do not have nx.json. This causes an issue when running Nx via Lerna (https://github.com/lerna/lerna/issues/3379). 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Nx will ignore angular.json when creating the project graph when Nx.json does not exist. 
