### PR TITLE
fix(react-native): Package path . is not exported from package

### DIFF
--- a/packages/expo/plugins/metro-resolver.ts
+++ b/packages/expo/plugins/metro-resolver.ts
@@ -177,6 +177,7 @@ function getPnpmResolver(extensions: string[]) {
       extensions: extensions.map((extension) => '.' + extension),
       useSyncFileSystemCalls: true,
       modules: [join(workspaceRoot, 'node_modules'), 'node_modules'],
+      conditionNames: ['native', 'browser', 'require', 'default'],
     });
   }
   return resolver;

--- a/packages/react-native/plugins/metro-resolver.ts
+++ b/packages/react-native/plugins/metro-resolver.ts
@@ -177,6 +177,7 @@ function getPnpmResolver(extensions: string[]) {
       extensions: extensions.map((extension) => '.' + extension),
       useSyncFileSystemCalls: true,
       modules: [join(workspaceRoot, 'node_modules'), 'node_modules'],
+      conditionNames: ['native', 'browser', 'require', 'default'],
     });
   }
   return resolver;


### PR DESCRIPTION
## Current Behavior

When using pnpm and using packages like `decimal.js` it will fail to load because the `exports` does not include a `default`.

```
  "exports": {
    ".": {
      "types": "./decimal.d.ts",
      "import": "./decimal.mjs",
      "require": "./decimal.js"
    },
    "./decimal.mjs": "./decimal.mjs",
    "./decimal.js": "./decimal.js",
    "./package.json": "./package.json",
    "./decimal": {
      "types": "./decimal.d.ts",
      "import": "./decimal.mjs",
      "require": "./decimal.js"
    }
  },
```

## Expected Behavior

It should resolve using `require` (possibly `import` in the future if esm becomes better supported)

## Related Issue(s)
