### PR TITLE
fix(expo): update peerDep to match expo version 47

### DIFF
--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -44,7 +44,7 @@
     "tsconfig-paths-webpack-plugin": "^3.5.2"
   },
   "peerDependencies": {
-    "expo": "^46.0.16"
+    "expo": "^47.0.8"
   },
   "builders": "./executors.json",
   "ng-update": {


### PR DESCRIPTION
Small fixup to this [recent change](https://github.com/nrwl/nx/pull/13609/files#diff-6f3291778f5daec4c46c903a2c0bfdac02a8e19658dfdae03961b000ff635b7fR506)

## Current Behavior

![image](https://user-images.githubusercontent.com/2213636/206831234-00cea79c-3f9f-4ad6-a386-7bb793f30084.png)