### PR TITLE
fix(vite): Support fileReplacements for devServer

### DIFF
--- a/packages/vite/plugins/rollup-replace-files.plugin.ts
+++ b/packages/vite/plugins/rollup-replace-files.plugin.ts
@@ -1,5 +1,6 @@
 // source: https://github.com/Myrmod/vitejs-theming/blob/master/build-plugins/rollup/replace-files.js
 
+import fs from 'fs';
 import { resolve } from 'path';
 
 /**
@@ -14,11 +15,7 @@ export default function replaceFiles(replacements: FileReplacement[]) {
   return {
     name: 'rollup-plugin-replace-files',
     enforce: 'pre',
-    async resolveId(source, importer, options) {
-      const resolved = await this.resolve(source, importer, {
-        ...options,
-        skipSelf: true,
-      });
+    async transform (code, id) {
       /**
        * The reason we're using endsWith here is because the resolved id
        * will be the absolute path to the file. We want to check if the
@@ -27,7 +24,7 @@ export default function replaceFiles(replacements: FileReplacement[]) {
        */
 
       const foundReplace = replacements.find((replacement) =>
-        resolved?.id?.endsWith(replacement.replace)
+        id.endsWith(replacement.replace)
       );
       if (foundReplace) {
         console.info(
@@ -35,15 +32,13 @@ export default function replaceFiles(replacements: FileReplacement[]) {
         );
         try {
           // return new file content
-          return {
-            id: foundReplace.with,
-          };
+          return fs.readFileSync(id.replace(foundReplace.replace, foundReplace.with)).toString();
         } catch (err) {
           console.error(err);
-          return null;
+          return code;
         }
       }
-      return null;
+      return code;
     },
   };
 }

--- a/packages/vite/plugins/rollup-replace-files.plugin.ts
+++ b/packages/vite/plugins/rollup-replace-files.plugin.ts
@@ -15,7 +15,7 @@ export default function replaceFiles(replacements: FileReplacement[]) {
   return {
     name: 'rollup-plugin-replace-files',
     enforce: 'pre',
-    async transform (code, id) {
+    async transform(code, id) {
       /**
        * The reason we're using endsWith here is because the resolved id
        * will be the absolute path to the file. We want to check if the
@@ -32,7 +32,9 @@ export default function replaceFiles(replacements: FileReplacement[]) {
         );
         try {
           // return new file content
-          return fs.readFileSync(id.replace(foundReplace.replace, foundReplace.with)).toString();
+          return fs
+            .readFileSync(id.replace(foundReplace.replace, foundReplace.with))
+            .toString();
         } catch (err) {
           console.error(err);
           return code;

--- a/packages/vite/plugins/rollup-replace-files.plugin.ts
+++ b/packages/vite/plugins/rollup-replace-files.plugin.ts
@@ -1,6 +1,6 @@
 // source: https://github.com/Myrmod/vitejs-theming/blob/master/build-plugins/rollup/replace-files.js
 
-import fs from 'fs';
+import * as fs from 'fs';
 import { resolve } from 'path';
 
 /**


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->

The `fileReplacements` option does not work with `@nrwl/vite:dev-server` executor

Existing solution using `resolveId` only works when building but not local dev

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When also passing `fileReplacements` in the "serve" section for the dev server,

It should also do the replacement

## Related Issue(s)

Fixes #13758
