### PR TITLE
Fix/remove libs tools folders for standalone

### DIFF
--- a/e2e/cra-to-nx/src/cra-to-nx.test.ts
+++ b/e2e/cra-to-nx/src/cra-to-nx.test.ts
@@ -1,9 +1,11 @@
 import {
+  checkFilesDoNotExist,
   checkFilesExist,
   getPackageManagerCommand,
   getPublishedVersion,
   getSelectedPackageManager,
   readFile,
+  readJson,
   runCLI,
   runCommand,
   updateFile,
@@ -71,7 +73,7 @@ describe('nx init (for CRA)', () => {
     expect(unitTestsOutput).toContain('Successfully ran target test');
   });
 
-  it('should convert to a nested workspace with craco (webpack)', () => {
+  it('should convert to a standalone workspace with craco (webpack)', () => {
     const appName = 'my-app';
     createReactApp(appName);
 
@@ -87,7 +89,7 @@ describe('nx init (for CRA)', () => {
     checkFilesExist(`dist/${appName}/index.html`);
   });
 
-  it('should convert to an nested workspace with Vite', () => {
+  it('should convert to an standalone workspace with Vite', () => {
     const appName = 'my-app';
     createReactApp(appName);
 
@@ -98,6 +100,17 @@ describe('nx init (for CRA)', () => {
     );
 
     expect(craToNxOutput).toContain('🎉 Done!');
+
+    checkFilesDoNotExist(
+      'libs/.gitkeep',
+      'tools/tsconfig.tools.json',
+      'babel.config.json',
+      'jest.preset.js',
+      'jest.config.ts'
+    );
+
+    const packageJson = readJson('package.json');
+    expect(packageJson.devDependencies['@nrwl/jest']).toBeUndefined();
 
     const viteConfig = readFile(`vite.config.js`);
     expect(viteConfig).toContain('port: 4200'); // default port

--- a/packages/cra-to-nx/src/lib/add-craco-commands-to-package-scripts.ts
+++ b/packages/cra-to-nx/src/lib/add-craco-commands-to-package-scripts.ts
@@ -2,12 +2,14 @@ import { readJsonFile, writeJsonFile } from 'nx/src/utils/fileutils';
 
 export function addCracoCommandsToPackageScripts(
   appName: string,
-  isNested: boolean
+  isStandalone: boolean
 ) {
-  const packageJsonPath = isNested
+  const packageJsonPath = isStandalone
     ? 'package.json'
     : `apps/${appName}/package.json`;
-  const distPath = isNested ? `dist/${appName}` : `../../dist/apps/${appName}`;
+  const distPath = isStandalone
+    ? `dist/${appName}`
+    : `../../dist/apps/${appName}`;
   const packageJson = readJsonFile(packageJsonPath);
   packageJson.scripts = {
     ...packageJson.scripts,

--- a/packages/cra-to-nx/src/lib/add-vite-commands-to-package-scripts.ts
+++ b/packages/cra-to-nx/src/lib/add-vite-commands-to-package-scripts.ts
@@ -2,9 +2,9 @@ import { readJsonFile, writeJsonFile } from 'nx/src/utils/fileutils';
 
 export function addViteCommandsToPackageScripts(
   appName: string,
-  isNested: boolean
+  isStandalone: boolean
 ) {
-  const packageJsonPath = isNested
+  const packageJsonPath = isStandalone
     ? 'package.json'
     : `apps/${appName}/package.json`;
   const packageJson = readJsonFile(packageJsonPath);

--- a/packages/cra-to-nx/src/lib/clean-up-files.ts
+++ b/packages/cra-to-nx/src/lib/clean-up-files.ts
@@ -1,14 +1,14 @@
 import { removeSync } from 'fs-extra';
 import { readJsonFile, writeJsonFile } from 'nx/src/utils/fileutils';
 
-export function cleanUpFiles(appName: string, isNested: boolean) {
+export function cleanUpFiles(appName: string, isStandalone: boolean) {
   // Delete targets from project since we delegate to npm scripts.
-  const projectJsonPath = isNested
+  const projectJsonPath = isStandalone
     ? 'project.json'
     : `apps/${appName}/project.json`;
   const json = readJsonFile(projectJsonPath);
   delete json.targets;
-  if (isNested) {
+  if (isStandalone) {
     if (json.sourceRoot) {
       json.sourceRoot = json.sourceRoot.replace(`apps/${appName}/`, '');
     }
@@ -22,4 +22,12 @@ export function cleanUpFiles(appName: string, isNested: boolean) {
   writeJsonFile(projectJsonPath, json);
 
   removeSync('temp-workspace');
+
+  if (isStandalone) {
+    removeSync('babel.config.json');
+    removeSync('jest.preset.js');
+    removeSync('jest.config.ts');
+    removeSync('libs');
+    removeSync('tools');
+  }
 }

--- a/packages/cra-to-nx/src/lib/rename-js-to-jsx.ts
+++ b/packages/cra-to-nx/src/lib/rename-js-to-jsx.ts
@@ -2,8 +2,10 @@ import { sync } from 'glob';
 import { renameSync, readFileSync } from 'fs-extra';
 
 // Vite cannot process JSX like <div> or <Header> unless the file is named .jsx or .tsx
-export function renameJsToJsx(appName: string, isNested: boolean) {
-  const files = sync(isNested ? 'src/**/*.js' : `apps/${appName}/src/**/*.js`);
+export function renameJsToJsx(appName: string, isStandalone: boolean) {
+  const files = sync(
+    isStandalone ? 'src/**/*.js' : `apps/${appName}/src/**/*.js`
+  );
 
   files.forEach((file) => {
     const content = readFileSync(file).toString();

--- a/packages/cra-to-nx/src/lib/tsconfig-setup.ts
+++ b/packages/cra-to-nx/src/lib/tsconfig-setup.ts
@@ -61,20 +61,20 @@ const defaultTsConfigSpec = (relativePathToRoot: string) => ({
   ],
 });
 
-export function setupTsConfig(appName: string, isNested: boolean) {
-  const tsconfigPath = isNested
+export function setupTsConfig(appName: string, isStandalone: boolean) {
+  const tsconfigPath = isStandalone
     ? 'tsconfig.json'
     : `apps/${appName}/tsconfig.json`;
-  const tsconfigAppPath = isNested
+  const tsconfigAppPath = isStandalone
     ? 'tsconfig.app.json'
     : `apps/${appName}/tsconfig.app.json`;
-  const tsconfiSpecPath = isNested
+  const tsconfiSpecPath = isStandalone
     ? 'tsconfig.spec.json'
     : `apps/${appName}/tsconfig.spec.json`;
-  const tsconfigBasePath = isNested
+  const tsconfigBasePath = isStandalone
     ? './tsconfig.base.json'
     : '../../tsconfig.base.json';
-  const relativePathToRoot = isNested ? '' : '../../';
+  const relativePathToRoot = isStandalone ? '' : '../../';
   if (fileExists(tsconfigPath)) {
     const json = readJsonFile(tsconfigPath);
     json.extends = tsconfigBasePath;

--- a/packages/cra-to-nx/src/lib/write-craco-config.ts
+++ b/packages/cra-to-nx/src/lib/write-craco-config.ts
@@ -3,7 +3,7 @@ import { writeFileSync } from 'fs';
 export function writeCracoConfig(
   appName: string,
   isCRA5: boolean,
-  isNested: boolean
+  isStandalone: boolean
 ) {
   const configOverride = `
   const path = require('path');
@@ -62,7 +62,7 @@ export function writeCracoConfig(
   };
   `;
   writeFileSync(
-    isNested ? 'craco.config.js' : `apps/${appName}/craco.config.js`,
+    isStandalone ? 'craco.config.js' : `apps/${appName}/craco.config.js`,
     configOverride
   );
 }

--- a/packages/cra-to-nx/src/lib/write-vite-config.ts
+++ b/packages/cra-to-nx/src/lib/write-vite-config.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 
 export function writeViteConfig(
   appName: string,
-  isNested: boolean,
+  isStandalone: boolean,
   isJs: boolean
 ) {
   let port = 4200;
@@ -18,14 +18,16 @@ export function writeViteConfig(
   }
 
   fs.writeFileSync(
-    isNested ? 'vite.config.js' : `apps/${appName}/vite.config.js`,
+    isStandalone ? 'vite.config.js' : `apps/${appName}/vite.config.js`,
     `import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   build: {
-    outDir: ${isNested ? `'./dist/${appName}'` : `'../../dist/apps/${appName}'`}
+    outDir: ${
+      isStandalone ? `'./dist/${appName}'` : `'../../dist/apps/${appName}'`
+    }
   },
   server: {
     port: ${port},

--- a/packages/cra-to-nx/src/lib/write-vite-index-html.ts
+++ b/packages/cra-to-nx/src/lib/write-vite-index-html.ts
@@ -2,10 +2,10 @@ import * as fs from 'fs';
 
 export function writeViteIndexHtml(
   appName: string,
-  isNested: boolean,
+  isStandalone: boolean,
   isJs: boolean
 ) {
-  const indexPath = isNested ? 'index.html' : `apps/${appName}/index.html`;
+  const indexPath = isStandalone ? 'index.html' : `apps/${appName}/index.html`;
   if (fs.existsSync(indexPath)) {
     fs.copyFileSync(indexPath, indexPath + '.old');
   }


### PR DESCRIPTION
Standalone React projects should not have libs or tools folders, nor babel/jest files.

## Current Behavior
Migrating CRA to standalone setup creates:

```
├── babel.config.json
├── index.html
├── jest.config.ts
├── jest.preset.js
├── nx.json
├── package-lock.json
├── package.json
├── project.json
├── public
├── src
├── tsconfig.app.json
├── tsconfig.base.json
├── tsconfig.json
├── tsconfig.spec.json
└── vite.config.js
```

## Expected Behavior

Files should be:

```├── index.html
├── nx.json
├── package-lock.json
├── package.json
├── project.json
├── public
├── src
├── tsconfig.app.json
├── tsconfig.base.json
├── tsconfig.json
├── tsconfig.spec.json
└── vite.config.js
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
