### PR TITLE
fix(react): host should use module-federation-ssr-dev-server

### DIFF
--- a/packages/react/src/generators/host/lib/setup-ssr-for-host.ts
+++ b/packages/react/src/generators/host/lib/setup-ssr-for-host.ts
@@ -5,6 +5,7 @@ import {
   joinPathFragments,
   names,
   readProjectConfiguration,
+  updateProjectConfiguration,
 } from '@nrwl/devkit';
 import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 
@@ -19,7 +20,10 @@ export async function setupSsrForHost(
   defaultRemoteManifest: { name: string; port: number }[]
 ) {
   const tasks: GeneratorCallback[] = [];
-  const project = readProjectConfiguration(tree, appName);
+  let project = readProjectConfiguration(tree, appName);
+  project.targets.serve.executor =
+    '@nrwl/react:module-federation-ssr-dev-server';
+  updateProjectConfiguration(tree, appName, project);
 
   generateFiles(
     tree,


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
Host currently uses webpack ssr dev server for serving with SSR. This means it does not start up the remotes it depends on.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The host should the use module-federation-ssr-dev-server to serve the remotes and then the host

