### PR TITLE
feat(vite): configuration updates

### DIFF
--- a/docs/generated/packages/vite.json
+++ b/docs/generated/packages/vite.json
@@ -192,8 +192,7 @@
           },
           "mode": {
             "type": "string",
-            "description": "Mode to run the server in.",
-            "enum": ["production", "development"]
+            "description": "Mode to run the server in."
           },
           "clearScreen": {
             "description": "Set to false to prevent Vite from clearing the terminal screen when logging certain messages.",
@@ -286,8 +285,7 @@
           },
           "mode": {
             "type": "string",
-            "description": "Mode to run the build in.",
-            "enum": ["production", "development"]
+            "description": "Mode to run the build in."
           }
         },
         "definitions": {},

--- a/docs/generated/packages/vite.json
+++ b/docs/generated/packages/vite.json
@@ -275,6 +275,10 @@
             "description": "When set to true, the build will also generate an SSR manifest for determining style links and asset preload directives in production. When the value is a string, it will be used as the manifest file name.",
             "oneOf": [{ "type": "boolean" }, { "type": "string" }]
           },
+          "ssr": {
+            "description": "Produce SSR-oriented build. The value can be a string to directly specify the SSR entry, or true, which requires specifying the SSR entry via rollupOptions.input.",
+            "oneOf": [{ "type": "boolean" }, { "type": "string" }]
+          },
           "logLevel": {
             "type": "string",
             "description": "Adjust console output verbosity.",

--- a/packages/vite/src/executors/build/schema.d.ts
+++ b/packages/vite/src/executors/build/schema.d.ts
@@ -9,6 +9,6 @@ export interface ViteBuildExecutorOptions {
   manifest?: boolean | string;
   ssrManifest?: boolean | string;
   logLevel?: 'info' | 'warn' | 'error' | 'silent';
-  mode?: 'production' | 'development';
+  mode?: string;
   ssr?: boolean | string;
 }

--- a/packages/vite/src/executors/build/schema.d.ts
+++ b/packages/vite/src/executors/build/schema.d.ts
@@ -10,4 +10,5 @@ export interface ViteBuildExecutorOptions {
   ssrManifest?: boolean | string;
   logLevel?: 'info' | 'warn' | 'error' | 'silent';
   mode?: 'production' | 'development';
+  ssr?: boolean | string;
 }

--- a/packages/vite/src/executors/build/schema.json
+++ b/packages/vite/src/executors/build/schema.json
@@ -94,6 +94,17 @@
         }
       ]
     },
+    "ssr": {
+      "description": "Produce SSR-oriented build. The value can be a string to directly specify the SSR entry, or true, which requires specifying the SSR entry via rollupOptions.input.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
     "logLevel": {
       "type": "string",
       "description": "Adjust console output verbosity.",

--- a/packages/vite/src/executors/build/schema.json
+++ b/packages/vite/src/executors/build/schema.json
@@ -112,8 +112,7 @@
     },
     "mode": {
       "type": "string",
-      "description": "Mode to run the build in.",
-      "enum": ["production", "development"]
+      "description": "Mode to run the build in."
     }
   },
   "definitions": {},

--- a/packages/vite/src/executors/dev-server/schema.d.ts
+++ b/packages/vite/src/executors/dev-server/schema.d.ts
@@ -9,6 +9,6 @@ export interface ViteDevServerExecutorOptions {
   open?: string | boolean;
   cors?: boolean;
   logLevel?: info | warn | error | silent;
-  mode?: 'production' | 'development';
+  mode?: string;
   clearScreen?: boolean;
 }

--- a/packages/vite/src/executors/dev-server/schema.json
+++ b/packages/vite/src/executors/dev-server/schema.json
@@ -70,8 +70,7 @@
     },
     "mode": {
       "type": "string",
-      "description": "Mode to run the server in.",
-      "enum": ["production", "development"]
+      "description": "Mode to run the server in."
     },
     "clearScreen": {
       "description": "Set to false to prevent Vite from clearing the terminal screen when logging certain messages.",

--- a/packages/vite/src/utils/options-utils.ts
+++ b/packages/vite/src/utils/options-utils.ts
@@ -121,6 +121,7 @@ export function getViteBuildOptions(
     minify: options.minify,
     manifest: options.manifest,
     ssrManifest: options.ssrManifest,
+    ssr: options.ssr,
     logLevel: options.logLevel,
   };
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
- there's no `ssr` option exposed https://vitejs.dev/config/build-options.html#build-ssr
- the `mode` option is limited to `development` or `production`. Although these 2 values are default for serve/build actions, the option itself is not limited to them https://vitejs.dev/guide/env-and-mode.html#modes
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
These properties are used by `qwik` in order to run/build the app. Here's an sample of their usage with a plain qwik app
```
"build.client": "vite build",
"build.preview": "vite build --ssr src/entry.preview.tsx",
"dev": "vite --mode ssr"
```
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
