### PR TITLE
feat(linter): add support for combo source tags

### DIFF
--- a/docs/shared/recipes/tag-multiple-dimensions.md
+++ b/docs/shared/recipes/tag-multiple-dimensions.md
@@ -122,8 +122,44 @@ We can now restrict projects within the same group to depend on each other based
 }
 ```
 
-There are no limits to number of tags, but as you add more tags the complexity of your dependency constraints rises exponentially. It's always good to draw a diagram and carefully plan the boundaries.
+There are no limits to the number of tags, but as you add more tags the complexity of your dependency constraints rises exponentially. It's always good to draw a diagram and carefully plan the boundaries.
+
+## Matching multiple source tags
+
+Matching just a single source tag is sometimes not enough for solving complex restrictions. To avoid creating ad-hoc tags that are only meant for specific constraints, you can also combine multiple tags with `allSourceTags`. Each tag in the array must be matched for a constraint to be applied:
+
+```jsonc
+{
+  // ... more ESLint config here
+
+  // nx-enforce-module-boundaries should already exist at the top-level of your config
+  "nx-enforce-module-boundaries": [
+    "error",
+    {
+      "allow": [],
+      // update depConstraints based on your tags
+      "depConstraints": [
+        { // this constraint applies to all "admin" projects
+          "sourceTag": "scope:admin",
+          "onlyDependOnLibsWithTags": ["scope:shared", "scope:admin"]
+        },
+        {
+          "sourceTag": "type:ui",
+          "onlyDependOnLibsWithTags": ["type:ui", "type:util"]
+        },
+        { // we don't want our admin ui components to depend on router or other ui libraries
+          "allSourceTags": ["scope:admin", "type:ui"],
+          "onlyDependOnLibsWithTags": ["type:util"],
+          "bannedExternalImports": ["*router*"]
+        }
+      ]
+    }
+  ]
+
+  // ... more ESLint config here
+}
 
 ## Further reading
 
 - [Article: Taming Code Organization with Module Boundaries in Nx](https://blog.nrwl.io/mastering-the-project-boundaries-in-nx-f095852f5bf4)
+```

--- a/docs/shared/recipes/tag-multiple-dimensions.md
+++ b/docs/shared/recipes/tag-multiple-dimensions.md
@@ -147,7 +147,7 @@ Matching just a single source tag is sometimes not enough for solving complex re
           "sourceTag": "type:ui",
           "onlyDependOnLibsWithTags": ["type:ui", "type:util"]
         },
-        { // we don't want our admin ui components to depend on router or other ui libraries
+        { // we don't want our admin ui components to depend on anything except utilities, and we also want to ban router imports
           "allSourceTags": ["scope:admin", "type:ui"],
           "onlyDependOnLibsWithTags": ["type:util"],
           "bannedExternalImports": ["*router*"]

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.spec.ts
@@ -749,6 +749,59 @@ Violation detected in:
 
       expect(failures.length).toEqual(0);
     });
+
+    it('should report errors for combo source tags', () => {
+      const failures = runRule(
+        {
+          depConstraints: [
+            {
+              sourceTagCombo: ['impl', 'domain1'],
+              onlyDependOnLibsWithTags: ['impl'],
+            },
+            { sourceTag: 'impl', onlyDependOnLibsWithTags: ['api'] },
+          ],
+        },
+        // ['impl', 'domain1']
+        `${process.cwd()}/proj/libs/impl/src/index.ts`,
+        // ['impl', 'domain1', 'domain2']
+        `
+          import '@mycompany/api';
+          import('@mycompany/api');
+        `,
+        graph
+      );
+
+      expect(failures.length).toEqual(2);
+      expect(failures[0].message).toEqual(
+        'A project tagged with "impl" and "domain1" can only depend on libs tagged with "impl"'
+      );
+      expect(failures[1].message).toEqual(
+        'A project tagged with "impl" and "domain1" can only depend on libs tagged with "impl"'
+      );
+    });
+
+    it('should properly map combo source tags', () => {
+      const failures = runRule(
+        {
+          depConstraints: [
+            {
+              sourceTagCombo: ['impl', 'domain1'],
+              onlyDependOnLibsWithTags: ['api'],
+            },
+          ],
+        },
+        // ['impl', 'domain1']
+        `${process.cwd()}/proj/libs/impl/src/index.ts`,
+        // ['impl', 'domain1', 'domain2']
+        `
+          import '@mycompany/api';
+          import('@mycompany/api');
+        `,
+        graph
+      );
+
+      expect(failures.length).toEqual(0);
+    });
   });
 
   describe('relative imports', () => {

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.spec.ts
@@ -755,7 +755,7 @@ Violation detected in:
         {
           depConstraints: [
             {
-              sourceTagCombo: ['impl', 'domain1'],
+              allSourceTags: ['impl', 'domain1'],
               onlyDependOnLibsWithTags: ['impl'],
             },
             { sourceTag: 'impl', onlyDependOnLibsWithTags: ['api'] },
@@ -785,7 +785,7 @@ Violation detected in:
         {
           depConstraints: [
             {
-              sourceTagCombo: ['impl', 'domain1'],
+              allSourceTags: ['impl', 'domain1'],
               onlyDependOnLibsWithTags: ['api'],
             },
           ],

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -30,6 +30,7 @@ import {
   matchImportWithWildcard,
   onlyLoadChildren,
   stringifyTags,
+  isComboDepConstraint,
 } from '../utils/runtime-lint-utils';
 import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
 import { TargetProjectLocator } from 'nx/src/utils/target-project-locator';
@@ -91,7 +92,16 @@ export default createESLintRule<Options, MessageIds>({
             {
               type: 'object',
               properties: {
-                sourceTag: { type: 'string' },
+                oneOf: [
+                  { sourceTag: { type: 'string' } },
+                  {
+                    sourceTagCombo: {
+                      type: 'array',
+                      items: { type: 'string' },
+                      minItems: 2,
+                    },
+                  },
+                ],
                 onlyDependOnLibsWithTags: [{ type: 'string' }],
                 bannedExternalImports: [{ type: 'string' }],
                 notDependOnLibsWithTags: [{ type: 'string' }],
@@ -389,7 +399,9 @@ export default createESLintRule<Options, MessageIds>({
             node,
             messageId: 'bannedExternalImportsViolation',
             data: {
-              sourceTag: constraint.sourceTag,
+              sourceTag: isComboDepConstraint(constraint)
+                ? constraint.sourceTagCombo.join('" and "')
+                : constraint.sourceTag,
               package: targetProject.data.packageName,
             },
           });
@@ -521,7 +533,9 @@ export default createESLintRule<Options, MessageIds>({
               node,
               messageId: 'onlyTagsConstraintViolation',
               data: {
-                sourceTag: constraint.sourceTag,
+                sourceTag: isComboDepConstraint(constraint)
+                  ? constraint.sourceTagCombo.join('" and "')
+                  : constraint.sourceTag,
                 tags: stringifyTags(constraint.onlyDependOnLibsWithTags),
               },
             });
@@ -536,7 +550,9 @@ export default createESLintRule<Options, MessageIds>({
               node,
               messageId: 'emptyOnlyTagsConstraintViolation',
               data: {
-                sourceTag: constraint.sourceTag,
+                sourceTag: isComboDepConstraint(constraint)
+                  ? constraint.sourceTagCombo.join('" and "')
+                  : constraint.sourceTag,
               },
             });
             return;
@@ -555,7 +571,9 @@ export default createESLintRule<Options, MessageIds>({
                 node,
                 messageId: 'notTagsConstraintViolation',
                 data: {
-                  sourceTag: constraint.sourceTag,
+                  sourceTag: isComboDepConstraint(constraint)
+                    ? constraint.sourceTagCombo.join('" and "')
+                    : constraint.sourceTag,
                   tags: stringifyTags(constraint.notDependOnLibsWithTags),
                   projects: projectPaths
                     .map(
@@ -584,7 +602,9 @@ export default createESLintRule<Options, MessageIds>({
                   node,
                   messageId: 'bannedExternalImportsViolation',
                   data: {
-                    sourceTag: constraint.sourceTag,
+                    sourceTag: isComboDepConstraint(constraint)
+                      ? constraint.sourceTagCombo.join('" and "')
+                      : constraint.sourceTag,
                     childProjectName: violatingSource.name,
                     package: target.data.packageName,
                   },

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -95,7 +95,7 @@ export default createESLintRule<Options, MessageIds>({
                 oneOf: [
                   { sourceTag: { type: 'string' } },
                   {
-                    sourceTagCombo: {
+                    allSourceTags: {
                       type: 'array',
                       items: { type: 'string' },
                       minItems: 2,
@@ -400,7 +400,7 @@ export default createESLintRule<Options, MessageIds>({
             messageId: 'bannedExternalImportsViolation',
             data: {
               sourceTag: isComboDepConstraint(constraint)
-                ? constraint.sourceTagCombo.join('" and "')
+                ? constraint.allSourceTags.join('" and "')
                 : constraint.sourceTag,
               package: targetProject.data.packageName,
             },
@@ -534,7 +534,7 @@ export default createESLintRule<Options, MessageIds>({
               messageId: 'onlyTagsConstraintViolation',
               data: {
                 sourceTag: isComboDepConstraint(constraint)
-                  ? constraint.sourceTagCombo.join('" and "')
+                  ? constraint.allSourceTags.join('" and "')
                   : constraint.sourceTag,
                 tags: stringifyTags(constraint.onlyDependOnLibsWithTags),
               },
@@ -551,7 +551,7 @@ export default createESLintRule<Options, MessageIds>({
               messageId: 'emptyOnlyTagsConstraintViolation',
               data: {
                 sourceTag: isComboDepConstraint(constraint)
-                  ? constraint.sourceTagCombo.join('" and "')
+                  ? constraint.allSourceTags.join('" and "')
                   : constraint.sourceTag,
               },
             });
@@ -572,7 +572,7 @@ export default createESLintRule<Options, MessageIds>({
                 messageId: 'notTagsConstraintViolation',
                 data: {
                   sourceTag: isComboDepConstraint(constraint)
-                    ? constraint.sourceTagCombo.join('" and "')
+                    ? constraint.allSourceTags.join('" and "')
                     : constraint.sourceTag,
                   tags: stringifyTags(constraint.notDependOnLibsWithTags),
                   projects: projectPaths
@@ -603,7 +603,7 @@ export default createESLintRule<Options, MessageIds>({
                   messageId: 'bannedExternalImportsViolation',
                   data: {
                     sourceTag: isComboDepConstraint(constraint)
-                      ? constraint.sourceTagCombo.join('" and "')
+                      ? constraint.allSourceTags.join('" and "')
                       : constraint.sourceTag,
                     childProjectName: violatingSource.name,
                     package: target.data.packageName,

--- a/packages/eslint-plugin-nx/src/utils/runtime-lint-utils.ts
+++ b/packages/eslint-plugin-nx/src/utils/runtime-lint-utils.ts
@@ -28,7 +28,7 @@ type SingleSourceTagConstraint = {
   bannedExternalImports?: string[];
 };
 type ComboSourceTagConstraint = {
-  sourceTagCombo: string[];
+  allSourceTags: string[];
   onlyDependOnLibsWithTags?: string[];
   notDependOnLibsWithTags?: string[];
   bannedExternalImports?: string[];
@@ -51,7 +51,7 @@ export function hasNoneOfTheseTags(
 export function isComboDepConstraint(
   depConstraint: DepConstraint
 ): depConstraint is ComboSourceTagConstraint {
-  return !!(depConstraint as ComboSourceTagConstraint).sourceTagCombo;
+  return !!(depConstraint as ComboSourceTagConstraint).allSourceTags;
 }
 
 /**
@@ -168,7 +168,7 @@ export function findConstraintsFor(
 ) {
   return depConstraints.filter((f) => {
     if (isComboDepConstraint(f)) {
-      return f.sourceTagCombo.every((tag) => hasTag(sourceProject, tag));
+      return f.allSourceTags.every((tag) => hasTag(sourceProject, tag));
     } else {
       return hasTag(sourceProject, f.sourceTag);
     }
@@ -225,7 +225,7 @@ export function hasBannedImport(
   depConstraints = depConstraints.filter((c) => {
     let tags = [];
     if (isComboDepConstraint(c)) {
-      tags = c.sourceTagCombo;
+      tags = c.allSourceTags;
     } else {
       tags = [c.sourceTag];
     }


### PR DESCRIPTION
This PR introduces ~~sourceTagCombo~~ `allSourceTags` property for `enforce-module-boundaries`' dependency constraints.
The combo has priority over `sourceTag` when both are defined.

- [X] Implement logic
- [X] Add unit test
- [x] Document new feature

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #12871
