### PR TITLE
fix(devkit): do not move properties when nx.json doesn't exist

### DIFF
--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -2,12 +2,7 @@ import type { Tree } from 'nx/src/generators/tree';
 import * as path from 'path';
 import type * as Prettier from 'prettier';
 import { readJson, updateJson, writeJson } from 'nx/src/generators/utils/json';
-import {
-  getWorkspacePath,
-  readWorkspaceConfiguration,
-  updateWorkspaceConfiguration,
-  WorkspaceConfiguration,
-} from 'nx/src/generators/utils/project-configuration';
+import { getWorkspacePath } from 'nx/src/generators/utils/project-configuration';
 import { sortObjectByKeys } from 'nx/src/utils/object-sort';
 
 /**
@@ -20,7 +15,6 @@ export async function formatFiles(tree: Tree): Promise<void> {
     prettier = await import('prettier');
   } catch {}
 
-  ensurePropertiesAreInNewLocations(tree);
   sortWorkspaceJson(tree);
   sortTsConfig(tree);
 
@@ -86,41 +80,6 @@ function sortWorkspaceJson(tree: Tree) {
   } catch (e) {
     // catch noop
   }
-}
-
-/**
- * `updateWorkspaceConfiguration` already handles
- * placing properties in their new locations, so
- * reading + updating it ensures that props are placed
- * correctly.
- */
-function ensurePropertiesAreInNewLocations(tree: Tree) {
-  // If nx.json doesn't exist then there is no where to move these properties to
-  if (!tree.exists('nx.json')) {
-    return;
-  }
-
-  const workspacePath = getWorkspacePath(tree);
-  if (!workspacePath) {
-    return;
-  }
-  const wc = readWorkspaceConfiguration(tree);
-  updateJson<WorkspaceConfiguration>(tree, workspacePath, (json) => {
-    wc.generators ??= json.generators ?? (json as any).schematics;
-    if (wc.cli) {
-      wc.cli.defaultCollection ??= json.cli?.defaultCollection;
-      wc.cli.packageManager ??= json.cli?.packageManager;
-    } else if (json.cli) {
-      wc.cli ??= json.cli;
-    }
-    wc.defaultProject ??= json.defaultProject;
-    delete json.cli;
-    delete json.defaultProject;
-    delete (json as any).schematics;
-    delete json.generators;
-    return json;
-  });
-  updateWorkspaceConfiguration(tree, wc);
 }
 
 function sortTsConfig(tree: Tree) {

--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -95,6 +95,11 @@ function sortWorkspaceJson(tree: Tree) {
  * correctly.
  */
 function ensurePropertiesAreInNewLocations(tree: Tree) {
+  // If nx.json doesn't exist then there is no where to move these properties to
+  if (!tree.exists('nx.json')) {
+    return;
+  }
+
   const workspacePath = getWorkspacePath(tree);
   if (!workspacePath) {
     return;

--- a/packages/workspace/src/generators/new/generate-preset.ts
+++ b/packages/workspace/src/generators/new/generate-preset.ts
@@ -35,6 +35,9 @@ export function addPresetDependencies(host: Tree, options: NormalizedSchema) {
 export function generatePreset(host: Tree, opts: NormalizedSchema) {
   const parsedArgs = yargsParser(process.argv, {
     boolean: ['interactive'],
+    default: {
+      interactive: true,
+    },
   });
   const spawnOptions = {
     stdio: [process.stdin, process.stdout, process.stderr],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`formatFiles` removes properties from `angular.json` from workspaces that don't use Nx.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`formatFiles` does not remove properties from `angular.json` if there is no `nx.json` to move the properties to.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
