### PR TITLE
fix(core): ignore angular.json projects if @nrwl/angular is not insta…

### DIFF
--- a/packages/nx/src/config/workspaces.ts
+++ b/packages/nx/src/config/workspaces.ts
@@ -33,7 +33,8 @@ import { joinPathFragments } from '../utils/path';
 export function workspaceConfigName(
   root: string
 ): 'angular.json' | 'workspace.json' | null {
-  if (existsSync(path.join(root, 'angular.json'))) {
+  // If a workspace doesn't have `@nrwl/angular` it's likely they do not want projects from `angular.json` to be considered by Nx.
+  if (existsSync(path.join(root, 'angular.json')) && isNrwlAngularInstalled()) {
     return 'angular.json';
   } else if (existsSync(path.join(root, 'workspace.json'))) {
     return 'workspace.json';
@@ -428,6 +429,15 @@ function assertValidWorkspaceConfiguration(
     logger.warn(
       'NX As of Nx 13, project configuration should be moved from nx.json to workspace.json/project.json. Please run "nx format" to fix this.'
     );
+  }
+}
+
+function isNrwlAngularInstalled() {
+  try {
+    require.resolve('@nrwl/angular');
+    return true;
+  } catch {
+    return false;
   }
 }
 

--- a/scripts/depcheck/missing.ts
+++ b/scripts/depcheck/missing.ts
@@ -124,6 +124,7 @@ const IGNORE_MATCHES_IN_PACKAGE = {
     '@angular-devkit/core',
     '@angular-devkit/architect',
     '@angular/cli',
+    '@nrwl/angular',
     'ts-node', // We *may* fall back on ts-node, but we want to encourage the use of @swc-node instead so we don't explicitly list ts-node as an optional dep
   ],
   web: [


### PR DESCRIPTION
…lled

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Most workspaces use Nx and Angular together. However, workspaces which use Nx and Angular CLI entirely independently have a conflict in some package names.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Projects that use Nx and Angular entirely independently do not have `@nrwl/angular` installed and should not read projects from `angular.json`  

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
