### PR TITLE
fix(core): fix parallel cli argument not default to 3 when not specified

### DIFF
--- a/packages/nx/src/utils/command-line-utils.spec.ts
+++ b/packages/nx/src/utils/command-line-utils.spec.ts
@@ -20,6 +20,7 @@ describe('splitArgs', () => {
       base: 'sha1',
       head: 'sha2',
       skipNxCache: false,
+      parallel: 3
     });
   });
 
@@ -51,6 +52,7 @@ describe('splitArgs', () => {
     ).toEqual({
       base: 'main',
       skipNxCache: false,
+      parallel: 3
     });
   });
 
@@ -68,6 +70,7 @@ describe('splitArgs', () => {
     ).toEqual({
       base: 'develop',
       skipNxCache: false,
+      parallel: 3
     });
   });
 
@@ -85,6 +88,7 @@ describe('splitArgs', () => {
     ).toEqual({
       base: 'main',
       skipNxCache: false,
+      parallel: 3
     });
   });
 
@@ -181,6 +185,7 @@ describe('splitArgs', () => {
       base: 'envVarSha1',
       head: 'envVarSha2',
       skipNxCache: false,
+      parallel: 3
     });
 
     expect(
@@ -198,6 +203,7 @@ describe('splitArgs', () => {
       base: 'envVarSha1',
       head: 'directlyOnCommandSha1',
       skipNxCache: false,
+      parallel: 3
     });
 
     expect(
@@ -215,6 +221,7 @@ describe('splitArgs', () => {
       base: 'directlyOnCommandSha2',
       head: 'envVarSha2',
       skipNxCache: false,
+      parallel: 3
     });
 
     // Reset process data

--- a/packages/nx/src/utils/command-line-utils.spec.ts
+++ b/packages/nx/src/utils/command-line-utils.spec.ts
@@ -238,7 +238,21 @@ describe('splitArgs', () => {
       expect(parallel).toEqual(5);
     });
 
-    it('should default to 3', () => {
+    it('should default to 3 when not specified', () => {
+      const parallel = splitArgsIntoNxArgsAndOverrides(
+        {
+          $0: '',
+          __overrides_unparsed__: [],
+        },
+        'affected',
+        {} as any,
+        {} as any
+      ).nxArgs.parallel;
+
+      expect(parallel).toEqual(3);
+    });
+
+    it('should default to 3 when used with no value specified', () => {
       const parallel = splitArgsIntoNxArgsAndOverrides(
         {
           $0: '',

--- a/packages/nx/src/utils/command-line-utils.spec.ts
+++ b/packages/nx/src/utils/command-line-utils.spec.ts
@@ -20,7 +20,7 @@ describe('splitArgs', () => {
       base: 'sha1',
       head: 'sha2',
       skipNxCache: false,
-      parallel: 3
+      parallel: 3,
     });
   });
 
@@ -52,7 +52,7 @@ describe('splitArgs', () => {
     ).toEqual({
       base: 'main',
       skipNxCache: false,
-      parallel: 3
+      parallel: 3,
     });
   });
 
@@ -70,7 +70,7 @@ describe('splitArgs', () => {
     ).toEqual({
       base: 'develop',
       skipNxCache: false,
-      parallel: 3
+      parallel: 3,
     });
   });
 
@@ -88,7 +88,7 @@ describe('splitArgs', () => {
     ).toEqual({
       base: 'main',
       skipNxCache: false,
-      parallel: 3
+      parallel: 3,
     });
   });
 
@@ -185,7 +185,7 @@ describe('splitArgs', () => {
       base: 'envVarSha1',
       head: 'envVarSha2',
       skipNxCache: false,
-      parallel: 3
+      parallel: 3,
     });
 
     expect(
@@ -203,7 +203,7 @@ describe('splitArgs', () => {
       base: 'envVarSha1',
       head: 'directlyOnCommandSha1',
       skipNxCache: false,
-      parallel: 3
+      parallel: 3,
     });
 
     expect(
@@ -221,7 +221,7 @@ describe('splitArgs', () => {
       base: 'directlyOnCommandSha2',
       head: 'envVarSha2',
       skipNxCache: false,
-      parallel: 3
+      parallel: 3,
     });
 
     // Reset process data

--- a/packages/nx/src/utils/command-line-utils.ts
+++ b/packages/nx/src/utils/command-line-utils.ts
@@ -170,7 +170,8 @@ export function splitArgsIntoNxArgsAndOverrides(
   } else if (
     args['parallel'] === 'true' ||
     args['parallel'] === true ||
-    args['parallel'] === ''
+    args['parallel'] === '' ||
+    args['parallel'] === undefined
   ) {
     nxArgs['parallel'] = Number(
       nxArgs['maxParallel'] || nxArgs['max-parallel'] || 3


### PR DESCRIPTION
## Current Behavior
When the `--parallel` flag is not specified, nx commands run the targets sequentially.

## Expected Behavior
According to the docs, when the `--parallel` flag is not specified, it should default to 3.

## Related Issue(s)
Fixes #13782
BREAKING CHANGE: Default for --parallel is 3
