### PR TITLE
docs(vite): reorder compilerOptions for Vite to be comparable to each other

### DIFF
--- a/docs/shared/vite-plugin.md
+++ b/docs/shared/vite-plugin.md
@@ -277,8 +277,8 @@ Change your app's `tsconfig.json` (eg. `apps/my-app/tsconfig.json`) `compilerOpt
   "compilerOptions": {
     "jsx": "react-jsx",
     "allowJs": false,
-    "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
+    "esModuleInterop": false,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
@@ -300,21 +300,21 @@ Change your app's `tsconfig.json` (eg. `apps/my-app/tsconfig.json`) `compilerOpt
 ```json
 ...
   "compilerOptions": {
-    "target": "ESNext",
-    "useDefineForClassFields": true,
-    "module": "ESNext",
-    "lib": ["ESNext", "DOM"],
-    "moduleResolution": "Node",
-    "strict": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "esModuleInterop": true,
+    "isolatedModules": true,
+    "lib": ["DOM". "ESNext"],
+    "module": "ESNext",
+    "moduleResolution": "Node",
     "noEmit": true,
+    "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noImplicitReturns": true,
+    "resolveJsonModule": true,
     "skipLibCheck": true,
-    "types": ["vite/client"]
+    "strict": true,
+    "target": "ESNext",
+    "types": ["vite/client"],
+    "useDefineForClassFields": true
   },
   "include": ["src"],
 ...


### PR DESCRIPTION
It is much easier to compare different configs if their properties are ordered in the same way (preferable alphabetically).

The original rendered docs can be seen here: https://nx.dev/packages/vite#5.-adjust-your-app's-tsconfig.json