### PR TITLE
feat(react): add cypress e2e for react standalone preset

### DIFF
--- a/e2e/react/src/react.test.ts
+++ b/e2e/react/src/react.test.ts
@@ -121,6 +121,10 @@ describe('React Applications', () => {
     runCLI(`build ${appName}`);
 
     checkFilesExist(`dist/apps/${appName}/index.html`);
+
+    const e2eResults = runCLI(`e2e ${appName}-e2e --no-watch`);
+    expect(e2eResults).toContain('All specs passed!');
+    expect(await killPorts()).toBeTruthy();
   }, 250_000);
 
   async function testGeneratedApp(

--- a/packages/react/src/generators/application/lib/add-cypress.ts
+++ b/packages/react/src/generators/application/lib/add-cypress.ts
@@ -15,5 +15,6 @@ export async function addCypress(host: Tree, options: NormalizedSchema) {
     directory: options.directory,
     project: options.projectName,
     rootProject: options.rootProject,
+    bundler: options.bundler,
   });
 }

--- a/packages/workspace/src/generators/preset/preset.ts
+++ b/packages/workspace/src/generators/preset/preset.ts
@@ -70,7 +70,7 @@ async function createPreset(tree: Tree, options: Schema) {
       standaloneConfig: options.standaloneConfig,
       rootProject: true,
       bundler: 'vite',
-      e2eTestRunner: 'none',
+      e2eTestRunner: 'cypress',
       unitTestRunner: 'vitest',
     });
   } else if (options.preset === Preset.NextJs) {


### PR DESCRIPTION
Since `@nrwl/cypress` no longer pulls in webpack, babel, and other packages, we can enable e2e tests for standalone projects again.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
