### PR TITLE
fix(core): reduce likelihood of ENAMETOOLONG error on windows

### DIFF
--- a/packages/nx/src/hasher/git-hasher.ts
+++ b/packages/nx/src/hasher/git-hasher.ts
@@ -18,7 +18,7 @@ export async function getGitHashForFiles(
     // the overall comand, rather than the number of individual
     // arguments. Since file paths are large and rather variable,
     // we use a smaller batchSize.
-    const batchSize = process.platform === 'win32' ? 500 : 4000;
+    const batchSize = process.platform === 'win32' ? 250 : 4000;
     for (
       let startIndex = 0;
       startIndex < filesToHash.length;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We use a smaller batch size when many files are being passed to git for hashing on windows. This batch size is evidently still too big though, and some users report further ENAMETOOLONG errors that are resolved by committing changes.

## Expected Behavior
We use an even smaller batch size when many files are being passed to git for hashing on windows

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #13712
Fixes #10929
