### PR TITLE
fix(vite): set mode in configuration

### DIFF
--- a/packages/vite/migrations.json
+++ b/packages/vite/migrations.json
@@ -5,6 +5,12 @@
       "version": "15.3.1-beta.0",
       "description": "Remove projects property from vite-tsconfig-paths plugin in vite.config.ts files.",
       "factory": "./src/migrations/update-15-3-1/update-vite-tsconfig-paths"
+    },
+    "set-mode-in-configurations": {
+      "cli": "nx",
+      "version": "15.3.4-beta.0",
+      "description": "Set the mode in configurations to match the configurationName.",
+      "factory": "./src/migrations/update-15-3-4/set-mode-in-configuration"
     }
   },
   "packageJsonUpdates": {

--- a/packages/vite/src/migrations/update-15-3-4/set-mode-in-configuration.spec.ts
+++ b/packages/vite/src/migrations/update-15-3-4/set-mode-in-configuration.spec.ts
@@ -1,0 +1,32 @@
+import { readProjectConfiguration, Tree } from '@nrwl/devkit';
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
+import { mockViteReactAppGenerator } from '../../utils/test-utils';
+import { setModeInConfiguration } from './set-mode-in-configuration';
+
+describe('set mode in configuration object', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyV1Workspace();
+    mockViteReactAppGenerator(tree);
+  });
+
+  it('should set the mode to be the configuration name and preserve other settings', async () => {
+    await setModeInConfiguration(tree);
+
+    const projectConfig = readProjectConfiguration(
+      tree,
+      'my-test-react-vite-app'
+    );
+
+    expect(projectConfig.targets.build.configurations.production.mode).toEqual(
+      'production'
+    );
+
+    expect(projectConfig.targets.build.configurations.ssr.mode).toEqual('ssr');
+    expect(projectConfig.targets.build.configurations.ssr.ssr).toBeTruthy();
+    expect(
+      projectConfig.targets.build.configurations.ssr['my-other-setting']
+    ).toBe('my-other-value');
+  });
+});

--- a/packages/vite/src/migrations/update-15-3-4/set-mode-in-configuration.ts
+++ b/packages/vite/src/migrations/update-15-3-4/set-mode-in-configuration.ts
@@ -1,0 +1,36 @@
+import {
+  formatFiles,
+  readProjectConfiguration,
+  Tree,
+  updateProjectConfiguration,
+} from '@nrwl/devkit';
+
+import { forEachExecutorOptions } from '@nrwl/workspace/src/utilities/executor-options-utils';
+
+export async function setModeInConfiguration(tree: Tree) {
+  forAllProjectsUsingViteAddMode(tree);
+  await formatFiles(tree);
+}
+
+export default setModeInConfiguration;
+
+function forAllProjectsUsingViteAddMode(tree: Tree): void {
+  forEachExecutorOptions(
+    tree,
+    '@nrwl/vite:build',
+    (_options, projectName, targetName, configuration) => {
+      if (!configuration) {
+        return;
+      }
+
+      const projectConfiguration = readProjectConfiguration(tree, projectName);
+      projectConfiguration.targets[targetName].configurations[
+        configuration
+      ].mode ??= configuration;
+
+      updateProjectConfiguration(tree, projectName, {
+        ...projectConfiguration,
+      });
+    }
+  );
+}

--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -130,11 +130,11 @@ export function addOrChangeBuildTarget(
   };
 
   if (targets[target]) {
-    buildOptions.fileReplacements = targets[target].options.fileReplacements;
+    buildOptions.fileReplacements = targets[target].options?.fileReplacements;
 
-    if (target === '@nxext/vite:build') {
-      buildOptions.base = targets[target].options.baseHref;
-      buildOptions.sourcemap = targets[target].options.sourcemaps;
+    if (targets[target].executor === '@nxext/vite:build') {
+      buildOptions.base = targets[target].options?.baseHref;
+      buildOptions.sourcemap = targets[target].options?.sourcemaps;
     }
     targets[target].options = {
       ...buildOptions,
@@ -147,8 +147,12 @@ export function addOrChangeBuildTarget(
       defaultConfiguration: 'production',
       options: buildOptions,
       configurations: {
-        development: {},
-        production: {},
+        development: {
+          mode: 'development',
+        },
+        production: {
+          mode: 'production',
+        },
       },
     };
   }

--- a/packages/vite/src/utils/options-utils.ts
+++ b/packages/vite/src/utils/options-utils.ts
@@ -29,7 +29,7 @@ export async function getBuildAndSharedConfig(
   const projectRoot = context.workspace.projects[context.projectName].root;
 
   return mergeConfig({}, {
-    mode: options.mode ?? context.configurationName,
+    mode: options.mode,
     root: projectRoot,
     base: options.base,
     configFile: normalizeViteConfigFilePath(projectRoot, options.configFile),

--- a/packages/vite/src/utils/test-files/react-vite-project.config.json
+++ b/packages/vite/src/utils/test-files/react-vite-project.config.json
@@ -14,7 +14,11 @@
       },
       "configurations": {
         "development": {},
-        "production": {}
+        "production": {},
+        "ssr": {
+          "ssr": true,
+          "my-other-setting": "my-other-value"
+        }
       }
     },
     "serve": {

--- a/packages/vite/src/utils/test-utils.ts
+++ b/packages/vite/src/utils/test-utils.ts
@@ -1,4 +1,4 @@
-import { Tree, writeJson } from '@nrwl/devkit';
+import { parseJson, Tree, writeJson } from '@nrwl/devkit';
 import * as reactAppConfig from './test-files/react-project.config.json';
 import * as reactViteConfig from './test-files/react-vite-project.config.json';
 import * as webAppConfig from './test-files/web-project.config.json';


### PR DESCRIPTION
Set the mode under the configuration settings for `vite` projects, so that when someone passes the configuration through Nx, then we will also pass the vite mode.

eg. `nx build --prod` or `nx build --configuration=development` will also set the `mode` for the Vite builder.

as a continuation of: https://github.com/nrwl/nx/pull/13816