### PR TITLE
fix(react): default bundler to vite when deprecated buildable option is used

### DIFF
--- a/packages/react/src/generators/library/lib/normalize-options.spec.ts
+++ b/packages/react/src/generators/library/lib/normalize-options.spec.ts
@@ -85,4 +85,37 @@ describe('normalizeOptions', () => {
       unitTestRunner: 'jest',
     });
   });
+
+  it('should set bundler to rollup if buildable is true not no bundler is passed', () => {
+    const options = normalizeOptions(tree, {
+      name: 'test',
+      style: 'css',
+      linter: Linter.None,
+      buildable: true,
+      unitTestRunner: 'jest',
+    });
+
+    expect(options).toMatchObject({
+      buildable: true,
+      bundler: 'rollup',
+      unitTestRunner: 'jest',
+    });
+  });
+
+  it('should set bundler to rollup if buildable is true and bundler is none ', () => {
+    const options = normalizeOptions(tree, {
+      name: 'test',
+      style: 'css',
+      linter: Linter.None,
+      buildable: true,
+      bundler: 'none',
+      unitTestRunner: 'jest',
+    });
+
+    expect(options).toMatchObject({
+      buildable: true,
+      bundler: 'rollup',
+      unitTestRunner: 'jest',
+    });
+  });
 });

--- a/packages/react/src/generators/library/lib/normalize-options.ts
+++ b/packages/react/src/generators/library/lib/normalize-options.ts
@@ -4,6 +4,7 @@ import {
   getProjects,
   getWorkspaceLayout,
   joinPathFragments,
+  logger,
   names,
   normalizePath,
   Tree,
@@ -36,12 +37,27 @@ export function normalizeOptions(
   const importPath =
     options.importPath || getImportPath(npmScope, fullProjectDirectory);
 
+  let bundler = options.bundler ?? 'none';
+
+  if (bundler === 'none') {
+    if (options.publishable) {
+      logger.warn(
+        `Publishable libraries cannot be used with bundler: 'none'. Defaulting to 'rollup'.`
+      );
+      bundler = 'rollup';
+    }
+    if (options.buildable) {
+      logger.warn(
+        `Buildable libraries cannot be used with bundler: 'none'. Defaulting to 'rollup'.`
+      );
+      bundler = 'rollup';
+    }
+  }
+
   const normalized = {
     ...options,
     compiler: options.compiler ?? 'babel',
-    bundler:
-      options.bundler ??
-      (options.buildable || options.publishable ? 'rollup' : 'none'),
+    bundler,
     fileName,
     routePath: `/${name}`,
     name: projectName,


### PR DESCRIPTION
If user use the deprecated `--buildable` option, and chooses `bundler: none` at the prompt, then the library is not buildable.

We should warn them and pick a default. For now the default should be `rollup` for any existing workspaces passing `--buildable`. In Nx 16 we can change this to be vite.

## Current Behavior

Generated library is not buildable even though `--buildable` is passed.

## Expected Behavior
Generated library should be buildable.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
