### PR TITLE
docs(devkit): fix typo `same same`

### DIFF
--- a/docs/shared/guides/nx-devkit-angular-devkit.md
+++ b/docs/shared/guides/nx-devkit-angular-devkit.md
@@ -86,7 +86,7 @@ The Nx CLI can invoke Nx Generator or Angular Schematics directly. When the user
 
 ```shell
 nx g mygenerator params
-nx g mygenerator params  # will work exactly the same same as the line above
+nx g mygenerator params  # will work exactly the same as the line above
 ```
 
 The Nx CLI will see what type of generator `mygenerator` is and will invoke it using the right machinery. The user doesn't have to know how the generator is implemented.


### PR DESCRIPTION
Just a simple typo (correct me if not), for `same` instead of `same same`

Reference: https://nx.dev/more-concepts/nx-devkit-angular-devkit#conversions

![image](https://user-images.githubusercontent.com/30556071/207978263-94e7299e-766f-420b-a77a-53328b02a7d9.png)
