### PR TITLE
fix(core): move generator should work if there are comments in tsconfig #13740

### DIFF
--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -82,6 +82,7 @@
     "fs-extra": "^10.1.0",
     "glob": "7.1.4",
     "ignore": "^5.0.4",
+    "jsonc-parser": "3.2.0",
     "minimatch": "3.0.5",
     "npm-run-path": "^4.0.1",
     "open": "^8.4.0",

--- a/packages/workspace/src/generators/move/lib/update-imports.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-imports.spec.ts
@@ -340,6 +340,30 @@ export MyExtendedClass extends MyClass {};`
     });
   });
 
+  it('should update project ref in the root tsconfig.json when there is a comment', async () => {
+    tree.rename('tsconfig.base.json', 'tsconfig.json');
+    tree.write(
+      'tsconfig.json',
+      `// A comment\n${tree.read('tsconfig.json', 'utf-8')}`
+    );
+    await libraryGenerator(tree, {
+      name: 'my-source',
+      standaloneConfig: false,
+    });
+    const projectConfig = readProjectConfiguration(tree, 'my-source');
+
+    updateImports(
+      tree,
+      normalizeSchema(tree, schema, projectConfig),
+      projectConfig
+    );
+
+    const tsConfig = readJson(tree, '/tsconfig.json');
+    expect(tsConfig.compilerOptions.paths).toEqual({
+      '@proj/my-destination': ['libs/my-destination/src/index.ts'],
+    });
+  });
+
   it('should only update the project ref paths in the tsconfig file when --updateImportPath=false', async () => {
     await libraryGenerator(tree, {
       name: 'my-source',

--- a/packages/workspace/src/generators/move/lib/update-imports.ts
+++ b/packages/workspace/src/generators/move/lib/update-imports.ts
@@ -17,6 +17,7 @@ import { findNodes } from 'nx/src/utils/typescript';
 import { NormalizedSchema } from '../schema';
 import { normalizeSlashes } from './utils';
 import { relative } from 'path';
+import { parse } from 'jsonc-parser';
 
 /**
  * Updates all the imports in the workspace and modifies the tsconfig appropriately.
@@ -42,7 +43,15 @@ export function updateImports(
   let tsConfig: any;
   let fromPath: string;
   if (tree.exists(tsConfigPath)) {
-    tsConfig = JSON.parse(tree.read(tsConfigPath).toString('utf-8'));
+    const tsConfigRawContents = tree.read(tsConfigPath).toString('utf-8');
+    tsConfig = (() => {
+      try {
+        return JSON.parse(tsConfigRawContents);
+      } catch {
+        return parse(tsConfigRawContents);
+      }
+    })();
+
     fromPath = Object.keys(tsConfig.compilerOptions.paths).find((path) =>
       tsConfig.compilerOptions.paths[path].some((x) =>
         x.startsWith(project.sourceRoot)


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
If there are comments in the tsconfig, the move generator will fall over right away.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
It shouldn't fall over if there are comments in the base tsconfig

## Notes

Comments will be removed from the tsconfig file, but there is no good way to keep them there.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #13740
