### PR TITLE
fixed tsconfig template for next app generator

### DIFF
--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -422,8 +422,8 @@ describe('app', () => {
       expect(tsConfig.compilerOptions.allowJs).toEqual(true);
 
       const tsConfigApp = readJson(tree, 'apps/my-app/tsconfig.json');
-      expect(tsConfigApp.include).toContain('src/**/*.js');
-      expect(tsConfigApp.exclude).not.toContain('src/**/*.spec.js');
+      expect(tsConfigApp.include).toContain('**/*.js');
+      expect(tsConfigApp.exclude).not.toContain('**/*.spec.js');
     });
   });
 

--- a/packages/next/src/generators/application/files/tsconfig.json__tmpl__
+++ b/packages/next/src/generators/application/files/tsconfig.json__tmpl__
@@ -14,5 +14,5 @@
     "incremental": true
   },
   "include": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "next-env.d.ts"],
-  "exclude": ["node_modules", "jest.config.ts"]
+  "exclude": ["node_modules", "jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/packages/next/src/generators/application/files/tsconfig.json__tmpl__
+++ b/packages/next/src/generators/application/files/tsconfig.json__tmpl__
@@ -13,6 +13,6 @@
     "isolatedModules": true,
     "incremental": true
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.js", "src/**/*.jsx", "next-env.d.ts"],
+  "include": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "next-env.d.ts"],
   "exclude": ["node_modules", "jest.config.ts"]
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
```json
 "include": [
    "src/**/*.ts",
    "src/**/*.tsx",
    "src/**/*.js",
    "src/**/*.jsx",
    "next-env.d.ts"
  ],
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

tsconfig.json generated by `nrwl/next:application` should have 
```json
 "include": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "next-env.d.ts"],
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #13754
