### PR TITLE
fix(vite): inform user to add build config

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -32,6 +32,7 @@
     "@nrwl/devkit": "file:../devkit",
     "@nrwl/workspace": "file:../workspace",
     "@nrwl/js": "file:../js",
+    "@phenomnomnominal/tsquery": "4.1.1",
     "@swc/helpers": "^0.4.11",
     "chalk": "4.1.0",
     "dotenv": "~10.0.0",

--- a/packages/vite/src/generators/configuration/configuration.ts
+++ b/packages/vite/src/generators/configuration/configuration.ts
@@ -12,7 +12,7 @@ import {
   addOrChangeServeTarget,
   editTsConfig,
   moveAndEditIndexHtml,
-  writeViteConfig,
+  createOrEditViteConfig,
   handleUnsupportedUserProvidedTargets,
   handleUnknownExecutors,
   UserProvidedTargetName,
@@ -133,7 +133,7 @@ export async function viteConfigurationGenerator(tree: Tree, schema: Schema) {
     addOrChangeServeTarget(tree, schema, serveTargetName);
   }
 
-  writeViteConfig(tree, schema);
+  createOrEditViteConfig(tree, schema);
 
   if (schema.includeVitest) {
     const vitestTask = await vitestGenerator(tree, {

--- a/packages/vite/src/generators/vitest/vitest-generator.ts
+++ b/packages/vite/src/generators/vitest/vitest-generator.ts
@@ -13,7 +13,7 @@ import {
 import {
   addOrChangeTestTarget,
   findExistingTargetsInProject,
-  writeViteConfig,
+  createOrEditViteConfig,
 } from '../../utils/generator-utils';
 import { VitestGeneratorSchema } from './schema';
 
@@ -44,7 +44,7 @@ export async function vitestGenerator(
   tasks.push(initTask);
 
   if (!schema.skipViteConfig) {
-    writeViteConfig(tree, {
+    createOrEditViteConfig(tree, {
       ...schema,
       includeVitest: true,
     });

--- a/packages/vite/src/migrations/update-15-3-1/update-vite-tsconfig-paths.spec.ts
+++ b/packages/vite/src/migrations/update-15-3-1/update-vite-tsconfig-paths.spec.ts
@@ -1,10 +1,8 @@
 import { addDependenciesToPackageJson, Tree } from '@nrwl/devkit';
 import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
+import { tsquery } from '@phenomnomnominal/tsquery';
 import { mockViteReactAppGenerator } from '../../utils/test-utils';
-import {
-  getTsSourceFile,
-  removeProjectsFromViteTsConfigPaths,
-} from './update-vite-tsconfig-paths';
+import { removeProjectsFromViteTsConfigPaths } from './update-vite-tsconfig-paths';
 
 describe('remove projects from vite-tsconfig-paths', () => {
   let tree: Tree;
@@ -23,11 +21,11 @@ describe('remove projects from vite-tsconfig-paths', () => {
 
   it('should remove the projects attribute from vite-tsconfig-paths', async () => {
     await removeProjectsFromViteTsConfigPaths(tree);
-
-    const file = getTsSourceFile(
-      tree,
-      'apps/my-test-react-vite-app/vite.config.ts'
+    const appFileContent = tree.read(
+      'apps/my-test-react-vite-app/vite.config.ts',
+      'utf-8'
     );
+    const file = tsquery.ast(appFileContent);
 
     expect(file.getText().includes('tsconfig.base.json')).toBeFalsy();
     expect(file.getText().includes('projects')).toBeFalsy();

--- a/packages/vite/src/utils/__snapshots__/generator-util.spec.ts.snap
+++ b/packages/vite/src/utils/__snapshots__/generator-util.spec.ts.snap
@@ -1,0 +1,175 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generator utils ensureBuildOptionsInViteConfig should add build options if build options don't exist 1`] = `
+"
+    import { defineConfig } from 'vite';
+    import react from '@vitejs/plugin-react';
+    import viteTsConfigPaths from 'vite-tsconfig-paths';
+
+    export default defineConfig({
+      
+    // Configuration for building your library.
+    // See: https://vitejs.dev/guide/build.html#library-mode
+    build: {
+      lib: {
+        // Could also be a dictionary or array of multiple entry points.
+        entry: 'src/index.ts',
+        name: 'my-app',
+        fileName: 'index',
+        // Change this to the formats you want to support.
+        // Don't forgot to update your package.json as well.
+        formats: ['es', 'cjs']
+      },
+      rollupOptions: {
+        // External packages that should not be bundled into your library.
+        external: [\\"'react', 'react-dom', 'react/jsx-runtime'\\"]
+      }
+    },server: {
+        port: 4200,
+        host: 'localhost',
+      },
+      plugins: [
+        react(),
+        viteTsConfigPaths({
+          root: '../../',
+        }),
+      ],
+
+      test: {
+        globals: true,
+        cache: {
+          dir: '../../node_modules/.vitest',
+        },
+        environment: 'jsdom',
+        include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+      },
+
+    });
+    "
+`;
+
+exports[`generator utils ensureBuildOptionsInViteConfig should add build options if defineConfig is empty 1`] = `
+"
+    import { defineConfig } from 'vite';
+    import react from '@vitejs/plugin-react';
+    import viteTsConfigPaths from 'vite-tsconfig-paths';
+
+    export default defineConfig({
+    // Configuration for building your library.
+    // See: https://vitejs.dev/guide/build.html#library-mode
+    build: {
+      lib: {
+        // Could also be a dictionary or array of multiple entry points.
+        entry: 'src/index.ts',
+        name: 'my-app',
+        fileName: 'index',
+        // Change this to the formats you want to support.
+        // Don't forgot to update your package.json as well.
+        formats: ['es', 'cjs']
+      },
+      rollupOptions: {
+        // External packages that should not be bundled into your library.
+        external: [\\"'react', 'react-dom', 'react/jsx-runtime'\\"]
+      }
+    },});
+    "
+`;
+
+exports[`generator utils ensureBuildOptionsInViteConfig should add build options if defineConfig is not used 1`] = `
+"
+    import { defineConfig } from 'vite';
+    import react from '@vitejs/plugin-react';
+    import viteTsConfigPaths from 'vite-tsconfig-paths';
+
+    export default {
+    // Configuration for building your library.
+    // See: https://vitejs.dev/guide/build.html#library-mode
+    build: {
+      lib: {
+        // Could also be a dictionary or array of multiple entry points.
+        entry: 'src/index.ts',
+        name: 'my-app',
+        fileName: 'index',
+        // Change this to the formats you want to support.
+        // Don't forgot to update your package.json as well.
+        formats: ['es', 'cjs']
+      },
+      rollupOptions: {
+        // External packages that should not be bundled into your library.
+        external: [\\"'react', 'react-dom', 'react/jsx-runtime'\\"]
+      }
+    },
+      server: {
+        port: 4200,
+        host: 'localhost',
+      },
+      plugins: [
+        react(),
+        viteTsConfigPaths({
+          root: '../../',
+        }),
+      ],
+    };
+    "
+`;
+
+exports[`generator utils ensureBuildOptionsInViteConfig should add build options if it is using conditional config 1`] = `
+"
+    import { defineConfig } from 'vite';
+    export default defineConfig(({ command, mode, ssrBuild }) => {
+      if (command === 'serve') {
+        return {
+          port: 4200,
+          host: 'localhost',
+        }
+      } else {
+        // command === 'build'
+        return {
+      ...{
+          my: 'option',
+        },
+      ...\\"\\\\n    // Configuration for building your library.\\\\n    // See: https://vitejs.dev/guide/build.html#library-mode\\\\n    build: {\\\\n      lib: {\\\\n        // Could also be a dictionary or array of multiple entry points.\\\\n        entry: 'src/index.ts',\\\\n        name: 'my-app',\\\\n        fileName: 'index',\\\\n        // Change this to the formats you want to support.\\\\n        // Don't forgot to update your package.json as well.\\\\n        formats: ['es', 'cjs']\\\\n      },\\\\n      rollupOptions: {\\\\n        // External packages that should not be bundled into your library.\\\\n        external: [\\\\\\"'react', 'react-dom', 'react/jsx-runtime'\\\\\\"]\\\\n      }\\\\n    },\\"
+   }
+      }
+    })
+    "
+`;
+
+exports[`generator utils ensureBuildOptionsInViteConfig should add new build options if some build options already exist 1`] = `
+"import { defineConfig } from 'vite';
+    import react from '@vitejs/plugin-react';
+    import viteTsConfigPaths from 'vite-tsconfig-paths';
+
+    export default defineConfig({
+      server: {
+        port: 4200,
+        host: 'localhost',
+      },
+      plugins: [
+        react(),
+        viteTsConfigPaths({
+          root: '../../',
+        }),
+      ],
+
+      test: {
+        globals: true,
+        cache: {
+          dir: '../../node_modules/.vitest',
+        },
+        environment: 'jsdom',
+        include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+      },
+
+      build: {
+          ...{
+        my: 'option',
+      },
+          ...{\\"lib\\":{\\"entry\\":\\"src/index.ts\\",\\"name\\":\\"my-app\\",\\"fileName\\":\\"index\\",\\"formats\\":[\\"es\\",\\"cjs\\"]},\\"rollupOptions\\":{\\"external\\":[\\"'react', 'react-dom', 'react/jsx-runtime'\\"]}}
+       }
+
+    });
+    "
+`;
+
+exports[`generator utils ensureBuildOptionsInViteConfig should not do anything if cannot understand syntax of vite config 1`] = `"console.log('Unknown syntax')"`;

--- a/packages/vite/src/utils/generator-util.spec.ts
+++ b/packages/vite/src/utils/generator-util.spec.ts
@@ -4,7 +4,9 @@ import {
   updateProjectConfiguration,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
+import { tsquery } from '@phenomnomnominal/tsquery';
 import {
+  ensureBuildOptionsInViteConfig,
   findExistingTargetsInProject,
   getViteConfigPathForProject,
   handleUnsupportedUserProvidedTargets,
@@ -213,6 +215,253 @@ describe('generator utils', () => {
         object.targets
       );
       expect(response).toBeUndefined();
+    });
+  });
+
+  describe('ensureBuildOptionsInViteConfig', () => {
+    let tree: Tree;
+
+    const buildOption = `
+    // Configuration for building your library.
+    // See: https://vitejs.dev/guide/build.html#library-mode
+    build: {
+      lib: {
+        // Could also be a dictionary or array of multiple entry points.
+        entry: 'src/index.ts',
+        name: 'my-app',
+        fileName: 'index',
+        // Change this to the formats you want to support.
+        // Don't forgot to update your package.json as well.
+        formats: ['es', 'cjs']
+      },
+      rollupOptions: {
+        // External packages that should not be bundled into your library.
+        external: ["'react', 'react-dom', 'react/jsx-runtime'"]
+      }
+    },`;
+
+    const buildOptionObject = {
+      lib: {
+        entry: 'src/index.ts',
+        name: 'my-app',
+        fileName: 'index',
+        formats: ['es', 'cjs'],
+      },
+      rollupOptions: {
+        external: ["'react', 'react-dom', 'react/jsx-runtime'"],
+      },
+    };
+
+    const noBuildOptions = `
+    import { defineConfig } from 'vite';
+    import react from '@vitejs/plugin-react';
+    import viteTsConfigPaths from 'vite-tsconfig-paths';
+
+    export default defineConfig({
+      server: {
+        port: 4200,
+        host: 'localhost',
+      },
+      plugins: [
+        react(),
+        viteTsConfigPaths({
+          root: '../../',
+        }),
+      ],
+
+      test: {
+        globals: true,
+        cache: {
+          dir: '../../node_modules/.vitest',
+        },
+        environment: 'jsdom',
+        include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+      },
+
+    });
+    `;
+
+    const someBuildOptions = `
+    import { defineConfig } from 'vite';
+    import react from '@vitejs/plugin-react';
+    import viteTsConfigPaths from 'vite-tsconfig-paths';
+
+    export default defineConfig({
+      server: {
+        port: 4200,
+        host: 'localhost',
+      },
+      plugins: [
+        react(),
+        viteTsConfigPaths({
+          root: '../../',
+        }),
+      ],
+
+      test: {
+        globals: true,
+        cache: {
+          dir: '../../node_modules/.vitest',
+        },
+        environment: 'jsdom',
+        include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+      },
+
+      build: {
+        my: 'option',
+      }
+
+    });
+    `;
+
+    const noContentDefineConfig = `
+    import { defineConfig } from 'vite';
+    import react from '@vitejs/plugin-react';
+    import viteTsConfigPaths from 'vite-tsconfig-paths';
+
+    export default defineConfig({});
+    `;
+
+    const conditionalConfig = `
+    import { defineConfig } from 'vite';
+    export default defineConfig(({ command, mode, ssrBuild }) => {
+      if (command === 'serve') {
+        return {
+          port: 4200,
+          host: 'localhost',
+        }
+      } else {
+        // command === 'build'
+        return {
+          my: 'option',
+        }
+      }
+    })
+    `;
+
+    const configNoDefineConfig = `
+    import { defineConfig } from 'vite';
+    import react from '@vitejs/plugin-react';
+    import viteTsConfigPaths from 'vite-tsconfig-paths';
+
+    export default {
+      server: {
+        port: 4200,
+        host: 'localhost',
+      },
+      plugins: [
+        react(),
+        viteTsConfigPaths({
+          root: '../../',
+        }),
+      ],
+    };
+    `;
+
+    beforeEach(() => {
+      tree = createTreeWithEmptyV1Workspace();
+    });
+
+    it("should add build options if build options don't exist", () => {
+      tree.write('apps/my-app/vite.config.ts', noBuildOptions);
+      ensureBuildOptionsInViteConfig(
+        tree,
+        'apps/my-app/vite.config.ts',
+        buildOption,
+        buildOptionObject
+      );
+      const appFileContent = tree.read('apps/my-app/vite.config.ts', 'utf-8');
+      const file = tsquery.ast(appFileContent);
+      const buildNode = tsquery.query(
+        file,
+        'PropertyAssignment:has(Identifier[name="build"])'
+      );
+      expect(buildNode).toBeDefined();
+      expect(appFileContent).toMatchSnapshot();
+    });
+
+    it('should add new build options if some build options already exist', () => {
+      tree.write('apps/my-app/vite.config.ts', someBuildOptions);
+      ensureBuildOptionsInViteConfig(
+        tree,
+        'apps/my-app/vite.config.ts',
+        buildOption,
+        buildOptionObject
+      );
+      const appFileContent = tree.read('apps/my-app/vite.config.ts', 'utf-8');
+      const file = tsquery.ast(appFileContent);
+      const buildNode = tsquery.query(
+        file,
+        'PropertyAssignment:has(Identifier[name="build"])'
+      );
+      expect(buildNode).toBeDefined();
+      expect(appFileContent).toMatchSnapshot();
+    });
+
+    it('should add build options if defineConfig is empty', () => {
+      tree.write('apps/my-app/vite.config.ts', noContentDefineConfig);
+      ensureBuildOptionsInViteConfig(
+        tree,
+        'apps/my-app/vite.config.ts',
+        buildOption,
+        buildOptionObject
+      );
+      const appFileContent = tree.read('apps/my-app/vite.config.ts', 'utf-8');
+      const file = tsquery.ast(appFileContent);
+      const buildNode = tsquery.query(
+        file,
+        'PropertyAssignment:has(Identifier[name="build"])'
+      );
+      expect(buildNode).toBeDefined();
+      expect(appFileContent).toMatchSnapshot();
+    });
+
+    it('should add build options if it is using conditional config', () => {
+      tree.write('apps/my-app/vite.config.ts', conditionalConfig);
+      ensureBuildOptionsInViteConfig(
+        tree,
+        'apps/my-app/vite.config.ts',
+        buildOption,
+        buildOptionObject
+      );
+      const appFileContent = tree.read('apps/my-app/vite.config.ts', 'utf-8');
+      const file = tsquery.ast(appFileContent);
+      const buildNode = tsquery.query(
+        file,
+        'PropertyAssignment:has(Identifier[name="build"])'
+      );
+      expect(buildNode).toBeDefined();
+      expect(appFileContent).toMatchSnapshot();
+    });
+
+    it('should add build options if defineConfig is not used', () => {
+      tree.write('apps/my-app/vite.config.ts', configNoDefineConfig);
+      ensureBuildOptionsInViteConfig(
+        tree,
+        'apps/my-app/vite.config.ts',
+        buildOption,
+        buildOptionObject
+      );
+      const appFileContent = tree.read('apps/my-app/vite.config.ts', 'utf-8');
+      const file = tsquery.ast(appFileContent);
+      const buildNode = tsquery.query(
+        file,
+        'PropertyAssignment:has(Identifier[name="build"])'
+      );
+      expect(buildNode).toBeDefined();
+      expect(appFileContent).toMatchSnapshot();
+    });
+
+    it('should not do anything if cannot understand syntax of vite config', () => {
+      tree.write('apps/my-app/vite.config.ts', `console.log('Unknown syntax')`);
+      ensureBuildOptionsInViteConfig(
+        tree,
+        'apps/my-app/vite.config.ts',
+        buildOption,
+        buildOptionObject
+      );
+      const appFileContent = tree.read('apps/my-app/vite.config.ts', 'utf-8');
+      expect(appFileContent).toMatchSnapshot();
     });
   });
 });


### PR DESCRIPTION
If a `vite.config.ts` file already exists when we are converting an existing project to use vite, make sure to edit that file to add the build settings, or modify the existing build settings.
