### PR TITLE
fix(angular): handle not provided path when generating a component without the project option

### DIFF
--- a/packages/angular/src/generators/component/__snapshots__/component.spec.ts.snap
+++ b/packages/angular/src/generators/component/__snapshots__/component.spec.ts.snap
@@ -42,6 +42,20 @@ export class ExampleComponent {
 "
 `;
 
+exports[`component Generator --path should infer project from path and generate component correctly 1`] = `
+"import { Component } from '@angular/core';
+
+@Component({
+  selector: 'example',
+  templateUrl: './example.component.html',
+  styleUrls: ['./example.component.css']
+})
+export class ExampleComponent {
+
+}
+"
+`;
+
 exports[`component Generator secondary entry points should create the component correctly and export it in the entry point 1`] = `
 "import { Component } from '@angular/core';
 

--- a/packages/angular/src/generators/component/angular-v14/lib/normalize-options.ts
+++ b/packages/angular/src/generators/component/angular-v14/lib/normalize-options.ts
@@ -2,7 +2,6 @@ import type { Tree } from '@nrwl/devkit';
 import {
   createProjectGraphAsync,
   joinPathFragments,
-  readCachedProjectGraph,
   readProjectConfiguration,
   readWorkspaceConfiguration,
 } from '@nrwl/devkit';
@@ -15,7 +14,10 @@ import {
 async function findProjectFromOptions(options: Schema) {
   const projectGraph = await createProjectGraphAsync();
   const projectRootMappings = createProjectRootMappings(projectGraph.nodes);
-  return findProjectForPath(options.path, projectRootMappings);
+
+  // path can be undefined when running on the root of the workspace, we default to the root
+  // to handle standalone layouts
+  return findProjectForPath(options.path || '', projectRootMappings);
 }
 
 export async function normalizeOptions(
@@ -26,6 +28,22 @@ export async function normalizeOptions(
     options.project ??
     (await findProjectFromOptions(options)) ??
     readWorkspaceConfiguration(tree).defaultProject;
+
+  if (!project) {
+    // path is hidden, so if not provided we don't suggest setting it
+    if (!options.path) {
+      throw new Error(
+        'No "project" was specified and "defaultProject" is not set in the workspace configuration. Please provide the "project" option and try again.'
+      );
+    }
+
+    // path was provided, so it's wrong and we should mention it
+    throw new Error(
+      'The provided "path" is wrong and no "project" was specified and "defaultProject" is not set in the workspace configuration. ' +
+        'Please provide a correct "path" or provide the "project" option instead and try again.'
+    );
+  }
+
   const { projectType, root, sourceRoot } = readProjectConfiguration(
     tree,
     project

--- a/packages/angular/src/generators/component/lib/normalize-options.ts
+++ b/packages/angular/src/generators/component/lib/normalize-options.ts
@@ -2,7 +2,6 @@ import type { Tree } from '@nrwl/devkit';
 import {
   createProjectGraphAsync,
   joinPathFragments,
-  readCachedProjectGraph,
   readProjectConfiguration,
   readWorkspaceConfiguration,
 } from '@nrwl/devkit';
@@ -15,7 +14,10 @@ import {
 async function findProjectFromOptions(options: Schema) {
   const projectGraph = await createProjectGraphAsync();
   const projectRootMappings = createProjectRootMappings(projectGraph.nodes);
-  return findProjectForPath(options.path, projectRootMappings);
+
+  // path can be undefined when running on the root of the workspace, we default to the root
+  // to handle standalone layouts
+  return findProjectForPath(options.path || '', projectRootMappings);
 }
 
 export async function normalizeOptions(
@@ -26,6 +28,22 @@ export async function normalizeOptions(
     options.project ??
     (await findProjectFromOptions(options)) ??
     readWorkspaceConfiguration(tree).defaultProject;
+
+  if (!project) {
+    // path is hidden, so if not provided we don't suggest setting it
+    if (!options.path) {
+      throw new Error(
+        'No "project" was specified and "defaultProject" is not set in the workspace configuration. Please provide the "project" option and try again.'
+      );
+    }
+
+    // path was provided, so it's wrong and we should mention it
+    throw new Error(
+      'The provided "path" is wrong and no "project" was specified and "defaultProject" is not set in the workspace configuration. ' +
+        'Please provide a correct "path" or provide the "project" option instead and try again.'
+    );
+  }
+
   const { projectType, root, sourceRoot } = readProjectConfiguration(
     tree,
     project


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Generating a component from the workspace root without providing the `project` and `path` options throws an error.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Generating a component from the workspace root without providing the `project` and `path` options should not throw and fallback to use the set `defaultProject`. Only if `defaultProject` is not set we throw a meaningful error to the user.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #13874 
