### PR TITLE
fix(misc): set schema when converting a project to standalone configuration

### DIFF
--- a/packages/angular/src/generators/ng-add/__snapshots__/migrate-from-angular-cli.spec.ts.snap
+++ b/packages/angular/src/generators/ng-add/__snapshots__/migrate-from-angular-cli.spec.ts.snap
@@ -98,6 +98,7 @@ Object {
 
 exports[`workspace --preserve-angular-cli-layout should support multiple projects 2`] = `
 Object {
+  "$schema": "node_modules/nx/schemas/project-schema.json",
   "name": "app1",
   "sourceRoot": "src",
   "targets": Object {
@@ -125,6 +126,7 @@ Object {
 
 exports[`workspace --preserve-angular-cli-layout should support multiple projects 3`] = `
 Object {
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "name": "app2",
   "sourceRoot": "projects/app2/src",
   "targets": Object {
@@ -152,6 +154,7 @@ Object {
 
 exports[`workspace --preserve-angular-cli-layout should support multiple projects 4`] = `
 Object {
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "name": "lib1",
   "sourceRoot": "projects/lib1/src",
   "targets": Object {

--- a/packages/workspace/src/generators/convert-to-nx-project/convert-to-nx-project.spec.ts
+++ b/packages/workspace/src/generators/convert-to-nx-project/convert-to-nx-project.spec.ts
@@ -1,20 +1,17 @@
+import * as devkit from '@nrwl/devkit';
 import {
   ProjectConfiguration,
   readJson,
   readProjectConfiguration,
 } from '@nrwl/devkit';
-import {
-  createTreeWithEmptyV1Workspace,
-  createTreeWithEmptyWorkspace,
-} from '@nrwl/devkit/testing';
-import enquirer = require('enquirer');
+import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
+import { getRelativeProjectJsonSchemaPath } from 'nx/src/generators/utils/project-configuration';
 import { libraryGenerator } from '../library/library';
-import * as devkit from '@nrwl/devkit';
-
 import convertToNxProject, {
   SCHEMA_OPTIONS_ARE_MUTUALLY_EXCLUSIVE,
 } from './convert-to-nx-project';
 import { getProjectConfigurationPath } from './utils/get-project-configuration-path';
+import enquirer = require('enquirer');
 
 jest.mock('fs-extra', () => ({
   ...jest.requireActual<any>('fs-extra'),
@@ -88,7 +85,11 @@ describe('convert-to-nx-project', () => {
       getProjectConfigurationPath(config)
     );
 
+    expect(newConfigFile.$schema).toBe(
+      getRelativeProjectJsonSchemaPath(tree, config)
+    );
     delete config.root;
+    delete newConfigFile.$schema;
     expect(config).toEqual(newConfigFile);
   });
 
@@ -116,7 +117,11 @@ describe('convert-to-nx-project', () => {
         tree,
         getProjectConfigurationPath(config)
       );
+      expect(newConfigFile.$schema).toBe(
+        getRelativeProjectJsonSchemaPath(tree, config)
+      );
       delete config.root;
+      delete newConfigFile.$schema;
       expect(config).toEqual(newConfigFile);
     }
   });

--- a/packages/workspace/src/generators/convert-to-nx-project/convert-to-nx-project.ts
+++ b/packages/workspace/src/generators/convert-to-nx-project/convert-to-nx-project.ts
@@ -1,6 +1,3 @@
-import { dirname } from 'path';
-import { prompt } from 'enquirer';
-
 import {
   convertNxGenerator,
   formatFiles,
@@ -15,7 +12,9 @@ import {
   updateJson,
   writeJson,
 } from '@nrwl/devkit';
-
+import { prompt } from 'enquirer';
+import { getRelativeProjectJsonSchemaPath } from 'nx/src/generators/utils/project-configuration';
+import { dirname } from 'path';
 import { Schema } from './schema';
 import { getProjectConfigurationPath } from './utils/get-project-configuration-path';
 
@@ -68,9 +67,11 @@ To upgrade change the version number at the top of ${getWorkspacePath(
       continue;
     }
 
-    delete configuration.root;
-
-    writeJson(host, configPath, configuration);
+    writeJson(host, configPath, {
+      $schema: getRelativeProjectJsonSchemaPath(host, configuration),
+      ...configuration,
+      root: undefined,
+    });
 
     updateJson(host, getWorkspacePath(host), (value) => {
       value.projects[project] = normalizePath(dirname(configPath));


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When converting a project to a standalone project the `$schema` property is not set in the generated `project.json` file. This is not in line with newly generated standalone projects whIch do have the property set.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `$schema` property should be set in the converted standalone projects' `project.json` file.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
