### PR TITLE
feat(testing): allow updating jest config nested keys with dots

### DIFF
--- a/packages/jest/src/utils/config/update-config.spec.ts
+++ b/packages/jest/src/utils/config/update-config.spec.ts
@@ -150,6 +150,20 @@ describe('Update jest.config.js', () => {
       );
     });
 
+    it('should be able to update an existing value in a nested object with a dot delimited key', () => {
+      const newPropertyValue = 'value';
+      addPropertyToJestConfig(
+        host,
+        'jest.config.js',
+        ['alreadyExistingObject', 'nestedProperty', 'key.with.dot'],
+        newPropertyValue
+      );
+      const json = jestConfigObject(host, 'jest.config.js');
+      expect(json.alreadyExistingObject.nestedProperty['key.with.dot']).toEqual(
+        newPropertyValue
+      );
+    });
+
     it('should be able to modify an object with a string identifier', () => {
       addPropertyToJestConfig(
         host,
@@ -258,6 +272,33 @@ describe('Update jest.config.js', () => {
       const json = jestConfigObject(host, 'jest.config.js');
       expect(
         json['alreadyExistingObject']['nested-object']['childArray']
+      ).toEqual(undefined);
+    });
+    it('should remove single nested properties in the jest config, with a dot delimited key', () => {
+      host.write(
+        'jest.config.js',
+        String.raw`
+       const { nxPreset } = require('@nrwl/jest/preset');
+        
+      module.exports = {
+        ...nxPreset,
+        name: 'test',
+        alreadyExistingObject: {
+          'nested-object': {
+            'child.dotted.value': ['value1', 'value2']
+          }
+        },
+      }
+    `
+      );
+      removePropertyFromJestConfig(host, 'jest.config.js', [
+        'alreadyExistingObject',
+        'nested-object',
+        'child.dotted.value',
+      ]);
+      const json = jestConfigObject(host, 'jest.config.js');
+      expect(
+        json['alreadyExistingObject']['nested-object']['child.dotted.value']
       ).toEqual(undefined);
     });
     it('should remove single properties', () => {

--- a/packages/jest/src/utils/config/update-config.ts
+++ b/packages/jest/src/utils/config/update-config.ts
@@ -9,23 +9,23 @@ import {
  * Add a property to the jest config
  * @param host
  * @param path - path to the jest config file
- * @param propertyName - Property to update. Can be dot delimited to access deeply nested properties
+ * @param propertyName - Property to update. Can be dot delimited or an array to access deeply nested properties
  * @param value
  * @param options - set `valueAsString` option to true if the `value` being passed represents a string of the code that should be associated with the `propertyName`
  */
 export function addPropertyToJestConfig(
   host: Tree,
   path: string,
-  propertyName: string,
+  propertyName: string | string[],
   value: unknown,
   options: { valueAsString: boolean } = { valueAsString: false }
 ) {
   if (!host.exists(path)) {
     throw new Error(`Cannot find '${path}' in your workspace.`);
   }
+  const { propertyString, properties } = parsePropertyName(propertyName);
   try {
     const configObject = jestConfigObjectAst(host.read(path, 'utf-8'));
-    const properties = propertyName.split('.');
     addOrUpdateProperty(
       host,
       configObject,
@@ -38,7 +38,7 @@ export function addPropertyToJestConfig(
     logger.warn(
       `Could not automatically add the following property to ${path}:`
     );
-    logger.warn(`${propertyName}: ${JSON.stringify(value)}`);
+    logger.warn(`${propertyString}: ${JSON.stringify(value)}`);
     logger.warn(`Error: ${e.message}`);
   }
 }
@@ -47,22 +47,22 @@ export function addPropertyToJestConfig(
  * Remove a property value from the jest config
  * @param host
  * @param path
- * @param propertyName - Property to remove. Can be dot delimited to access deeply nested properties
+ * @param propertyName - Property to remove. Can be dot delimited or an array to access deeply nested properties
  */
 export function removePropertyFromJestConfig(
   host: Tree,
   path: string,
-  propertyName: string
+  propertyName: string | string[]
 ) {
   if (!host.exists(path)) {
     throw new Error(`Cannot find '${path}' in your workspace.`);
   }
+
+  const { propertyString, properties } = parsePropertyName(propertyName);
+
   try {
     const configObject = jestConfigObjectAst(host.read(path, 'utf-8'));
-    const propertyAssignment = removeProperty(
-      configObject,
-      propertyName.split('.')
-    );
+    const propertyAssignment = removeProperty(configObject, properties);
 
     if (propertyAssignment) {
       const file = host.read(path, 'utf-8');
@@ -81,9 +81,20 @@ export function removePropertyFromJestConfig(
   } catch (e) {
     logger.info(`NX Please manually update ${path}`);
     logger.warn(
-      `Could not automatically remove the '${propertyName}' property from ${path}:`
+      `Could not automatically remove the '${propertyString}' property from ${path}:`
     );
   }
+}
+
+function parsePropertyName(propertyName: string | string[]) {
+  return {
+    properties: Array.isArray(propertyName)
+      ? propertyName
+      : propertyName.split('.'),
+    propertyString: Array.isArray(propertyName)
+      ? propertyName.join('.')
+      : propertyName,
+  };
 }
 
 export function addImportStatementToJestConfig(


### PR DESCRIPTION
Some keys in jest.config.ts may contain dots
For example, transform has regular expressions as its child keys

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
```typescript
  addPropertyToJestConfig(tree, 'jest.config.ts', 'transform.your.regex.here', 'new value')
```
The code above will add the following property:
```typscript
{
  ...
  transform: {
    your: 'new value'
  }
}
```

## Expected Behavior
```typescript
  addPropertyToJestConfig(tree, 'jest.config.ts', ['transform', 'your.regex.here'], 'new value')
```
The code above will allow adding the property as intended:
```typscript
{
  ...
  transform: {
    'your.regex.here': 'new value'
  }
}
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
