### PR TITLE
feat(angular): support alternate remoteEntry name in dynamic federation #13688

### DIFF
--- a/packages/angular/mf/mf.ts
+++ b/packages/angular/mf/mf.ts
@@ -58,9 +58,14 @@ async function loadRemoteContainer(remoteName: string) {
     ? remoteUrlDefinitions[remoteName]
     : await resolveRemoteUrl(remoteName);
 
-  const containerUrl = `${remoteUrl}${
-    remoteUrl.endsWith('/') ? '' : '/'
-  }remoteEntry.mjs`;
+  const remoteEntryFileName =
+    remoteUrl.endsWith('.mjs') || remoteUrl.endsWith('.js')
+      ? remoteUrl.split('/').pop()
+      : undefined;
+
+  const containerUrl = `${remoteUrl}${remoteUrl.endsWith('/') ? '' : '/'}${
+    remoteEntryFileName ?? 'remoteEntry.mjs'
+  }`;
 
   const container = await loadModule(containerUrl);
   await container.init(__webpack_share_scopes__.default);

--- a/packages/angular/mf/mf.ts
+++ b/packages/angular/mf/mf.ts
@@ -58,14 +58,12 @@ async function loadRemoteContainer(remoteName: string) {
     ? remoteUrlDefinitions[remoteName]
     : await resolveRemoteUrl(remoteName);
 
-  const remoteEntryFileName =
-    remoteUrl.endsWith('.mjs') || remoteUrl.endsWith('.js')
-      ? remoteUrl.split('/').pop()
-      : undefined;
-
-  const containerUrl = `${remoteUrl}${remoteUrl.endsWith('/') ? '' : '/'}${
-    remoteEntryFileName ?? 'remoteEntry.mjs'
-  }`;
+  let containerUrl = remoteUrl;
+  if (!remoteUrl.endsWith('.mjs') && !remoteUrl.endsWith('.js')) {
+    containerUrl = `${remoteUrl}${
+      remoteUrl.endsWith('/') ? '' : '/'
+    }remoteEntry.mjs`;
+  }
 
   const container = await loadModule(containerUrl);
   await container.init(__webpack_share_scopes__.default);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Dynamic federation can encounter issues with webpack caching with the same file name used across remotes.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
 Allow the name to be configurable by setting it within the `module-federation.manifest.json`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #13688
