### PR TITLE
fix(angular): missing remotes form mf config should not break mf server

### DIFF
--- a/packages/angular/src/builders/utilities/module-federation.ts
+++ b/packages/angular/src/builders/utilities/module-federation.ts
@@ -86,7 +86,10 @@ export function getStaticRemotes(
     );
   }
 
-  const remotesConfig = mfeConfig.remotes.length > 0 ? mfeConfig.remotes : [];
+  const remotesConfig =
+    Array.isArray(mfeConfig.remotes) && mfeConfig.remotes.length > 0
+      ? mfeConfig.remotes
+      : [];
   const staticRemotes = remotesConfig
     .map((remoteDefinition) =>
       Array.isArray(remoteDefinition) ? remoteDefinition[0] : remoteDefinition


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
When using dynamic module federation the `remotes` key could be missing from the `module-federation.config.js`. Currently, this will cause the `module-federation-dev-server` to error.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
This scenario should not cause an error
