### PR TITLE
fix(js): node executor failing to kill processes

### DIFF
--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -92,7 +92,7 @@ async function runProcess(
 ) {
   const execArgv = getExecArgv(options);
 
-  const hashed = hasher.hashArray(execArgv.concat(options.args));
+  const hashed = hasher.hashArray(execArgv.concat(hashedKey));
   hashedMap.set(hashedKey, hashed);
 
   const subProcess = fork(


### PR DESCRIPTION
## Current Behavior
In a recent change a unique key was added to keep each call of nodeExuector isolated, however this broke the array references in the map since new arrays were creeated on each call meaning there was never a match and processes were never killed.

## Expected Behavior
This fixes the bug that was introduced while keeping the node executors isolated by declaring the hashedKey in a place where it will only be declared once

