### PR TITLE
docs(nxdev): extract meta tags from document to app

### DIFF
--- a/nx-dev/nx-dev/pages/_app.tsx
+++ b/nx-dev/nx-dev/pages/_app.tsx
@@ -1,6 +1,7 @@
 import { sendPageViewEvent } from '@nrwl/nx-dev/feature-analytics';
 import { DefaultSeo } from 'next-seo';
 import { AppProps } from 'next/app';
+import Head from 'next/head';
 import { useRouter } from 'next/router';
 import Script from 'next/script';
 import { useEffect } from 'react';
@@ -45,6 +46,17 @@ export default function CustomApp({
           cardType: 'summary_large_image',
         }}
       />
+      <Head>
+        <meta name="apple-mobile-web-app-title" content="Nx" />
+        <meta name="application-name" content="Nx" />
+        <meta
+          name="msapplication-TileColor"
+          content="#DA532C"
+          key="windows-tile-color"
+        />
+        <meta name="theme-color" content="#FFFFFF" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
       <a
         id="skip-to-content-link"
         href="#main"

--- a/nx-dev/nx-dev/pages/_document.tsx
+++ b/nx-dev/nx-dev/pages/_document.tsx
@@ -28,15 +28,6 @@ export default function Document(): JSX.Element {
           href="/favicon/safari-pinned-tab.svg"
           color="#5bbad5"
         />
-        <meta name="apple-mobile-web-app-title" content="Nx" />
-        <meta name="application-name" content="Nx" />
-        <meta
-          name="msapplication-TileColor"
-          content="#DA532C"
-          key="windows-tile-color"
-        />
-        <meta name="theme-color" content="#FFFFFF" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <script
           dangerouslySetInnerHTML={{
             __html: `


### PR DESCRIPTION
It removes the tag declarations from the `_document.tsx` to `_app.tsx` dor nx.dev because `_documents.tsx` should not declare `meta` tags in its template.