### PR TITLE
feat(core): ability to use targets with colons without quotations in `nx run`

### DIFF
--- a/e2e/nx-run/src/run.test.ts
+++ b/e2e/nx-run/src/run.test.ts
@@ -190,11 +190,18 @@ describe('Nx Running Tests', () => {
           name: myapp,
           scripts: {
             [target]: `echo ${expectedOutput}`,
+            [`${target}:test`]: `echo ${expectedOutput}:test`,
           },
         })
       );
 
       expect(runCLI(`${target} ${myapp}`)).toContain(expectedOutput);
+      expect(runCLI(`${target}:test ${myapp}`)).toContain(
+        expectedOutput + ':test'
+      );
+      expect(runCLI(`run ${myapp}:${target}:test`)).toContain(
+        expectedOutput + ':test'
+      );
     }, 10000);
 
     it('should run targets inferred from plugin-specified project files', () => {

--- a/packages/nx/src/command-line/run.ts
+++ b/packages/nx/src/command-line/run.ts
@@ -6,19 +6,8 @@ import {
 import { printHelp } from '../utils/print-help';
 import { Workspaces } from '../config/workspaces';
 import { NxJsonConfiguration } from '../config/nx-json';
-import { readJsonFile } from '../utils/fileutils';
-import { buildTargetFromScript, PackageJson } from '../utils/package-json';
-import { join } from 'path';
-import { existsSync } from 'fs';
-import {
-  loadNxPlugins,
-  mergePluginTargetsWithNxTargets,
-} from '../utils/nx-plugin';
-import {
-  ProjectConfiguration,
-  TargetConfiguration,
-  ProjectsConfigurations,
-} from '../config/workspace-json-project-json';
+
+import { ProjectsConfigurations } from '../config/workspace-json-project-json';
 import { Executor, ExecutorContext } from '../config/misc-interfaces';
 import { serializeOverridesIntoCommandLine } from '../utils/serialize-overrides-into-command-line';
 import {
@@ -103,25 +92,6 @@ async function iteratorToProcessStatusCode(
   }
 }
 
-function createImplicitTargetConfig(
-  root: string,
-  proj: ProjectConfiguration,
-  targetName: string
-): TargetConfiguration | null {
-  const packageJsonPath = join(root, proj.root, 'package.json');
-  if (!existsSync(packageJsonPath)) {
-    return null;
-  }
-  const { scripts, nx } = readJsonFile<PackageJson>(packageJsonPath);
-  if (
-    !(targetName in (scripts || {})) ||
-    !(nx.includedScripts && nx.includedScripts.includes(targetName))
-  ) {
-    return null;
-  }
-  return buildTargetFromScript(targetName, nx);
-}
-
 async function runExecutorInternal<T extends { success: boolean }>(
   {
     project,
@@ -143,15 +113,8 @@ async function runExecutorInternal<T extends { success: boolean }>(
   validateProject(workspace, project);
 
   const ws = new Workspaces(root);
-  const proj = workspace.projects[project];
-  const targetConfig =
-    proj.targets?.[target] ||
-    createImplicitTargetConfig(root, proj, target) ||
-    mergePluginTargetsWithNxTargets(
-      proj.root,
-      proj.targets,
-      loadNxPlugins(workspace.plugins, [root], root)
-    )[target];
+  const proj = projectGraph.nodes[project].data;
+  const targetConfig = proj.targets?.[target];
 
   if (!targetConfig) {
     throw new Error(`Cannot find target '${target}' for project '${project}'`);

--- a/packages/nx/src/utils/project-graph-utils.spec.ts
+++ b/packages/nx/src/utils/project-graph-utils.spec.ts
@@ -123,13 +123,8 @@ describe('project graph utils', () => {
       version: '0.0.0',
       scripts: {
         build: 'echo 1',
-      },
-    };
-
-    const packageJsonBuildTarget = {
-      executor: 'nx:run-script',
-      options: {
-        script: 'build',
+        'test:web': 'jest -c jest.config.web.js',
+        'test:models': 'jest -c jest.config.models.js',
       },
     };
 
@@ -172,10 +167,7 @@ describe('project graph utils', () => {
         'apps/my-app',
         projectJsonTargets
       );
-      expect(result).toEqual({
-        ...projectJsonTargets,
-        build: packageJsonBuildTarget,
-      });
+      expect(result).toMatchInlineSnapshot();
     });
 
     it('should contain extended options from nx property in package.json', () => {
@@ -194,8 +186,10 @@ describe('project graph utils', () => {
       };
 
       const result = mergeNpmScriptsWithTargets('apps/my-other-app', null);
-      expect(result).toEqual({
-        build: { ...packageJsonBuildTarget, outputs: ['custom'] },
+      expect(result.build).toEqual({
+        executor: 'nx:run-script',
+        options: { script: 'build' },
+        outputs: ['custom'],
       });
     });
 
@@ -266,6 +260,46 @@ describe('project graph utils', () => {
         test: {
           executor: 'nx:run-script',
           options: { script: 'test' },
+        },
+      });
+    });
+
+    it('should add scripts with colons as configurations', () => {
+      const result = mergeNpmScriptsWithTargets('apps/my-app', {});
+      expect(result).toEqual({
+        build: {
+          executor: 'nx:run-script',
+          options: {
+            script: 'build',
+          },
+        },
+        test: {
+          executor: 'nx:run-script',
+          options: {},
+          configurations: {
+            models: {
+              options: {
+                script: 'test:models',
+              },
+            },
+            web: {
+              options: {
+                script: 'test:web',
+              },
+            },
+          },
+        },
+        'test:models': {
+          executor: 'nx:run-script',
+          options: {
+            script: 'test:models',
+          },
+        },
+        'test:web': {
+          executor: 'nx:run-script',
+          options: {
+            script: 'test:web',
+          },
         },
       });
     });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We support targets that contain a colon in them, but when using `nx run` they must be delimited with quotation marks. This comes off as unexpected at times.

Consider the following setup, which is not unusual for package-based repos:

> package.json
```json
{
  "name": "project",
  "scripts": {
    "build": "tsc -p tsconfig.json",
    "build:prod": "tsc -p tsconfig.prod.json"
  }
}
```

<table>
<thead><td>Command</td><td>Status</td></thead>
<tr>
	<td>nx build:prod project</td>
    <td>✅ works as expected</td>
<tr>
	<td>nx run project:build:prod</td>
    <td>❌Cannot find configuration for task build...</td>
<tr>
	<td>nx run project:"build:prod"</td>
    <td>⚠️requires escaping quotes, differs by shell env</td>
</tr>
</table>

The current implementation works in some cases by splitting the target string on a colon, and allowing for it to be wrapped by quotes. In the infix run syntax (nx target project), we know the target is the argv[1], so we don't require the quotation marks.

Quotations are currently required with `nx run project:target`, as the string gets split mistakenly thinking that its a configuration.



## Expected Behavior
<table>
<tr>
	<td>nx build:prod project</td>
    <td>✅ works as expected</td>
</tr>
<tr>
	<td>nx build project -c prod</td>
    <td>✅ works as expected</td>
</tr>
<tr>
	<td>nx run project:build:prod</td>
    <td>✅ works as expected</td>
</tr>
<tr>
	<td>nx run project:"build:prod"</td>
    <td>✅ works as expected</td>
</tr>
<tr>
	<td>nx run project:\"build:prod\"</td>
    <td>✅ works as expected</td>
</tr>
</table>

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
