### PR TITLE
fix(core): find imports in `export type` statements

### DIFF
--- a/packages/nx/src/utils/strip-source-code.spec.ts
+++ b/packages/nx/src/utils/strip-source-code.spec.ts
@@ -47,6 +47,7 @@ import('./module.ts')`;
       } from './a';
 
       export { B } from './b';
+      export type { B } from './b';
 
       export { C as D } from './c';
 
@@ -58,6 +59,7 @@ export {
         A
       } from './a'
 export { B } from './b'
+export type { B } from './b'
 export { C as D } from './c'`;
 
     expect(stripSourceCode(scanner, input)).toEqual(expected);

--- a/packages/nx/src/utils/strip-source-code.ts
+++ b/packages/nx/src/utils/strip-source-code.ts
@@ -1,6 +1,6 @@
 import type { Scanner } from 'typescript';
 
-let SyntaxKind;
+let SyntaxKind: typeof import('typescript').SyntaxKind;
 export function stripSourceCode(scanner: Scanner, contents: string): string {
   if (!SyntaxKind) {
     SyntaxKind = require('typescript').SyntaxKind;
@@ -68,7 +68,8 @@ export function stripSourceCode(scanner: Scanner, contents: string): string {
         }
         if (
           token === SyntaxKind.OpenBraceToken ||
-          token === SyntaxKind.AsteriskToken
+          token === SyntaxKind.AsteriskToken ||
+          token === SyntaxKind.TypeKeyword
         ) {
           start = potentialStart;
         }


### PR DESCRIPTION
The "analyzeSourceFiles" functionality which automatically detects deps does not currently file "import" requests in statements using the relatively new `export type ... from "..."` syntax. This is happening because the scanner does not find an asterick or curly-bracket after the `export` keyword, so it strips that export statement from the code.

## Current Behavior
Today, "import" statements using the relatively new `export type ... from "..."` syntax are stripped from the code before analysis occurs. This fixes the scanner to not drop these statements.

## Expected Behavior
Analysis should identify that a package which includes nothing but `export * from 'some-other-package'` has a dependency on `some-other-package`, but today no dependency is discovered.

## Related Issue(s)
I didn't file an issue, if I need to I'd be happy to.
