### PR TITLE
fix(core): find imports after template literals with vars

### DIFF
--- a/packages/nx/src/utils/strip-source-code.spec.ts
+++ b/packages/nx/src/utils/strip-source-code.spec.ts
@@ -242,4 +242,42 @@ require('./c')`;
 
     expect(stripSourceCode(scanner, input)).toEqual(expected);
   });
+
+  it('should find an import after a template literal with a variable in it', () => {
+    const input = `
+      const a = 1;
+      const b = \`a: $\{a}\`
+      const c = await import('./c')
+      const d = require('./d')
+    `;
+    const expected = `import('./c')
+require('./d')`;
+
+    expect(stripSourceCode(scanner, input)).toEqual(expected);
+  });
+
+  it('finds imports after an escaped character', () => {
+    const input = `
+      const b = unquotedLiteral.replace(/"/g, '\\\\"')
+      const c = await import('./c')
+      const d = require('./d')
+    `;
+    const expected = `import('./c')
+require('./d')`;
+
+    expect(stripSourceCode(scanner, input)).toEqual(expected);
+  });
+
+  it('finds imports after template literals with a regex inside', () => {
+    const input = `
+      const a = 1;
+      const b = \`"$\{unquotedLiteral.replace(/"/g, '\\\\"')}"\`
+      const c = await import('./c')
+      const d = require('./d')
+    `;
+    const expected = `import('./c')
+require('./d')`;
+
+    expect(stripSourceCode(scanner, input)).toEqual(expected);
+  });
 });

--- a/packages/nx/src/utils/strip-source-code.ts
+++ b/packages/nx/src/utils/strip-source-code.ts
@@ -58,6 +58,28 @@ export function stripSourceCode(scanner: Scanner, contents: string): string {
         break;
       }
 
+      case SyntaxKind.TemplateHead: {
+        while (true) {
+          token = scanner.scan();
+
+          if (token === SyntaxKind.SlashToken) {
+            token = scanner.reScanSlashToken();
+          }
+
+          if (token === SyntaxKind.EndOfFileToken) {
+            // either the template is unterminated, or there
+            // is some other edge case we haven't compensated for
+            break;
+          }
+
+          if (token === SyntaxKind.CloseBraceToken) {
+            token = scanner.reScanTemplateToken(false);
+            break;
+          }
+        }
+        break;
+      }
+
       case SyntaxKind.ExportKeyword: {
         token = scanner.scan();
         while (


### PR DESCRIPTION
## Current Behavior
If you have a template literal in your code all the code between the closing backtick of your template literal, to either the end of the file or the next template literal, will be treated as a `SyntaxKind.TemplateHead` and therefore not scanned for imports.

## Expected Behavior
All import statements in a file, regardless of the other expressions in that file, should be found.

## Related Issue(s)
No issue created.