### PR TITLE
fix(vite): dont add server config for libs

### DIFF
--- a/docs/generated/packages/vite/generators/configuration.json
+++ b/docs/generated/packages/vite/generators/configuration.json
@@ -21,6 +21,11 @@
         "description": "Add a library build option and skip the server option.",
         "hidden": true
       },
+      "includeVitest": {
+        "type": "boolean",
+        "description": "Use vitest for the test suite.",
+        "hidden": true
+      },
       "uiFramework": {
         "type": "string",
         "description": "UI Framework to use for Vite.",

--- a/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -1,5 +1,159 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`@nrwl/vite:configuration library mode should add config for building library 1`] = `
+"
+
+      import { defineConfig } from 'vite';
+      import react from '@vitejs/plugin-react';
+      import viteTsConfigPaths from 'vite-tsconfig-paths';
+      import dts from 'vite-plugin-dts';
+import { join } from 'path';
+      
+      export default defineConfig({
+        
+        plugins: [
+          dts({
+      tsConfigFilePath: join(__dirname, 'tsconfig.lib.json'),
+      // Faster builds by skipping tests. Set this to false to enable type checking.
+      skipDiagnostics: true,
+    }),
+          react(),
+          viteTsConfigPaths({
+            root: '../',
+          }),
+        ],
+        
+      // Configuration for building your library.
+      // See: https://vitejs.dev/guide/build.html#library-mode
+      build: {
+        lib: {
+          // Could also be a dictionary or array of multiple entry points.
+          entry: 'src/index.ts',
+          name: 'my-lib',
+          fileName: 'index',
+          // Change this to the formats you want to support.
+          // Don't forgot to update your package.json as well.
+          formats: ['es', 'cjs']
+        },
+        rollupOptions: {
+          // External packages that should not be bundled into your library.
+          external: ['react', 'react-dom', 'react/jsx-runtime']
+        }
+      },
+        
+        
+      });"
+`;
+
+exports[`@nrwl/vite:configuration library mode should set up non buildable library correctly 1`] = `
+"
+/// <reference types=\\"vitest\\" />
+      import { defineConfig } from 'vite';
+      import react from '@vitejs/plugin-react';
+      import viteTsConfigPaths from 'vite-tsconfig-paths';
+      import dts from 'vite-plugin-dts';
+import { join } from 'path';
+      
+      export default defineConfig({
+        
+        plugins: [
+          dts({
+      tsConfigFilePath: join(__dirname, 'tsconfig.lib.json'),
+      // Faster builds by skipping tests. Set this to false to enable type checking.
+      skipDiagnostics: true,
+    }),
+          react(),
+          viteTsConfigPaths({
+            root: '../../',
+          }),
+        ],
+        
+      // Configuration for building your library.
+      // See: https://vitejs.dev/guide/build.html#library-mode
+      build: {
+        lib: {
+          // Could also be a dictionary or array of multiple entry points.
+          entry: 'src/index.ts',
+          name: 'react-lib-nonb-jest',
+          fileName: 'index',
+          // Change this to the formats you want to support.
+          // Don't forgot to update your package.json as well.
+          formats: ['es', 'cjs']
+        },
+        rollupOptions: {
+          // External packages that should not be bundled into your library.
+          external: ['react', 'react-dom', 'react/jsx-runtime']
+        }
+      },
+        
+        test: {
+    globals: true,
+    cache: {
+      dir: '../../node_modules/.vitest'
+    },
+    environment: 'jsdom',
+    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    
+  },
+      });"
+`;
+
+exports[`@nrwl/vite:configuration library mode should set up non buildable library correctly 2`] = `
+"{
+  \\"projects\\": {
+    \\"react-lib-nonb-jest\\": {
+      \\"$schema\\": \\"../../node_modules/nx/schemas/project-schema.json\\",
+      \\"root\\": \\"libs/react-lib-nonb-jest\\",
+      \\"sourceRoot\\": \\"libs/react-lib-nonb-jest/src\\",
+      \\"projectType\\": \\"library\\",
+      \\"architect\\": {
+        \\"lint\\": {
+          \\"builder\\": \\"@nrwl/linter:eslint\\",
+          \\"outputs\\": [
+            \\"{options.outputFile}\\"
+          ],
+          \\"options\\": {
+            \\"lintFilePatterns\\": [
+              \\"libs/react-lib-nonb-jest/**/*.{ts,tsx,js,jsx}\\"
+            ]
+          }
+        },
+        \\"test\\": {
+          \\"builder\\": \\"@nrwl/vite:test\\",
+          \\"outputs\\": [
+            \\"{workspaceRoot}/coverage/{projectRoot}\\"
+          ],
+          \\"options\\": {
+            \\"passWithNoTests\\": true
+          }
+        },
+        \\"build\\": {
+          \\"builder\\": \\"@nrwl/vite:build\\",
+          \\"outputs\\": [
+            \\"{options.outputPath}\\"
+          ],
+          \\"defaultConfiguration\\": \\"production\\",
+          \\"options\\": {
+            \\"outputPath\\": \\"dist/libs/react-lib-nonb-jest\\"
+          },
+          \\"configurations\\": {
+            \\"development\\": {
+              \\"mode\\": \\"development\\"
+            },
+            \\"production\\": {
+              \\"mode\\": \\"production\\"
+            }
+          }
+        }
+      },
+      \\"tags\\": []
+    }
+  },
+  \\"version\\": 1
+}
+"
+`;
+
 exports[`@nrwl/vite:configuration transform React app to use Vite by providing custom targets transform React app if supported executor is provided should transform workspace.json project config 1`] = `
 "{
   \\"projects\\": {
@@ -68,6 +222,51 @@ exports[`@nrwl/vite:configuration transform React app to use Vite by providing c
   \\"version\\": 1
 }
 "
+`;
+
+exports[`@nrwl/vite:configuration transform React app to use Vite should create vite.config file at the root of the app 1`] = `
+"
+
+      import { defineConfig } from 'vite';
+      import react from '@vitejs/plugin-react';
+      import viteTsConfigPaths from 'vite-tsconfig-paths';
+      
+      
+      export default defineConfig({
+        
+    server:{
+      port: 4200,
+      host: 'localhost',
+    },
+        plugins: [
+          
+          react(),
+          viteTsConfigPaths({
+            root: '../../',
+          }),
+        ],
+        
+        
+        
+      });"
+`;
+
+exports[`@nrwl/vite:configuration transform React app to use Vite should move index.html to the root of the project 1`] = `
+"<!DOCTYPE html>
+    <html lang=\\"en\\">
+      <head>
+        <meta charset=\\"utf-8\\" />
+        <title>My Test React App</title>
+        <base href=\\"/\\" />
+    
+        <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\" />
+        <link rel=\\"icon\\" type=\\"image/x-icon\\" href=\\"favicon.ico\\" />
+      </head>
+      <body>
+        <div id=\\"root\\"></div>
+      <script type=\\"module\\" src=\\"/src/main.tsx\\"></script>
+          </body>
+    </html>"
 `;
 
 exports[`@nrwl/vite:configuration transform React app to use Vite should transform workspace.json project config 1`] = `
@@ -157,6 +356,50 @@ exports[`@nrwl/vite:configuration transform React app to use Vite should transfo
 "
 `;
 
+exports[`@nrwl/vite:configuration transform Web app to use Vite should create vite.config file at the root of the app 1`] = `
+"
+      
+      import { defineConfig } from 'vite';
+      import viteTsConfigPaths from 'vite-tsconfig-paths';
+      
+      
+      export default defineConfig({
+        
+    server:{
+      port: 4200,
+      host: 'localhost',
+    },
+        plugins: [
+          
+          viteTsConfigPaths({
+            root: '../../',
+          }),
+        ],
+        
+        
+        
+      });"
+`;
+
+exports[`@nrwl/vite:configuration transform Web app to use Vite should move index.html to the root of the project 1`] = `
+"<!DOCTYPE html>
+    <html lang=\\"en\\">
+      <head>
+        <meta charset=\\"utf-8\\" />
+        <title>WebappPure</title>
+        <base href=\\"/\\" />
+    
+        <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\" />
+        <link rel=\\"icon\\" type=\\"image/x-icon\\" href=\\"favicon.ico\\" />
+      </head>
+      <body>
+        <workspace-root></workspace-root>
+      <script type=\\"module\\" src=\\"/src/main.ts\\"></script>
+          </body>
+    </html>
+    "
+`;
+
 exports[`@nrwl/vite:configuration transform Web app to use Vite should transform workspace.json project config 1`] = `
 "{
   \\"projects\\": {
@@ -231,4 +474,39 @@ exports[`@nrwl/vite:configuration transform Web app to use Vite should transform
   \\"version\\": 1
 }
 "
+`;
+
+exports[`@nrwl/vite:configuration vitest should create a vitest configuration if "includeVitest" is true 1`] = `
+"
+/// <reference types=\\"vitest\\" />
+      import { defineConfig } from 'vite';
+      import react from '@vitejs/plugin-react';
+      import viteTsConfigPaths from 'vite-tsconfig-paths';
+      
+      
+      export default defineConfig({
+        
+    server:{
+      port: 4200,
+      host: 'localhost',
+    },
+        plugins: [
+          
+          react(),
+          viteTsConfigPaths({
+            root: '../../',
+          }),
+        ],
+        
+        
+        test: {
+    globals: true,
+    cache: {
+      dir: '../../node_modules/.vitest'
+    },
+    environment: 'jsdom',
+    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    
+  },
+      });"
 `;

--- a/packages/vite/src/generators/configuration/configuration.spec.ts
+++ b/packages/vite/src/generators/configuration/configuration.spec.ts
@@ -11,6 +11,7 @@ import { viteConfigurationGenerator } from './configuration';
 import {
   mockAngularAppGenerator,
   mockReactAppGenerator,
+  mockReactLibNonBuildableJestTestRunnerGenerator,
   mockReactMixedAppGenerator,
   mockUnknownAppGenerator,
   mockWebAppGenerator,
@@ -46,6 +47,9 @@ describe('@nrwl/vite:configuration', () => {
     it('should move index.html to the root of the project', () => {
       expect(tree.exists('apps/my-test-react-app/src/index.html')).toBeFalsy();
       expect(tree.exists('apps/my-test-react-app/index.html')).toBeTruthy();
+      expect(
+        tree.read('apps/my-test-react-app/index.html', 'utf-8')
+      ).toMatchSnapshot();
     });
 
     it('should create correct tsconfig compilerOptions', () => {
@@ -58,6 +62,9 @@ describe('@nrwl/vite:configuration', () => {
 
     it('should create vite.config file at the root of the app', () => {
       expect(tree.exists('apps/my-test-react-app/vite.config.ts')).toBe(true);
+      expect(
+        tree.read('apps/my-test-react-app/vite.config.ts', 'utf-8')
+      ).toMatchSnapshot();
     });
 
     it('should transform workspace.json project config', () => {
@@ -92,6 +99,9 @@ describe('@nrwl/vite:configuration', () => {
     it('should move index.html to the root of the project', () => {
       expect(tree.exists('apps/my-test-web-app/src/index.html')).toBeFalsy();
       expect(tree.exists('apps/my-test-web-app/index.html')).toBeTruthy();
+      expect(
+        tree.read('apps/my-test-web-app/index.html', 'utf-8')
+      ).toMatchSnapshot();
     });
 
     it('should create correct tsconfig compilerOptions', () => {
@@ -101,6 +111,9 @@ describe('@nrwl/vite:configuration', () => {
 
     it('should create vite.config file at the root of the app', () => {
       expect(tree.exists('apps/my-test-web-app/vite.config.ts')).toBe(true);
+      expect(
+        tree.read('apps/my-test-web-app/vite.config.ts', 'utf-8')
+      ).toMatchSnapshot();
     });
 
     it('should transform workspace.json project config', () => {
@@ -289,18 +302,21 @@ describe('@nrwl/vite:configuration', () => {
         .read('apps/my-test-react-app/vite.config.ts')
         .toString();
       expect(viteConfig).toContain('test');
+      expect(
+        tree.read('apps/my-test-react-app/vite.config.ts', 'utf-8')
+      ).toMatchSnapshot();
     });
   });
 
   describe('library mode', () => {
     beforeEach(async () => {
       tree = createTreeWithEmptyV1Workspace();
-      addProjectConfiguration(tree, 'my-lib', {
-        root: 'my-lib',
-      });
     });
 
     it('should add config for building library', async () => {
+      addProjectConfiguration(tree, 'my-lib', {
+        root: 'my-lib',
+      });
       await viteConfigurationGenerator(tree, {
         uiFramework: 'react',
         includeLib: true,
@@ -312,6 +328,21 @@ describe('@nrwl/vite:configuration', () => {
 
       expect(viteConfig).toMatch('build: {');
       expect(viteConfig).toMatch("external: ['react'");
+      expect(tree.read('my-lib/vite.config.ts', 'utf-8')).toMatchSnapshot();
+    });
+
+    it('should set up non buildable library correctly', async () => {
+      mockReactLibNonBuildableJestTestRunnerGenerator(tree);
+      await viteConfigurationGenerator(tree, {
+        uiFramework: 'react',
+        project: 'react-lib-nonb-jest',
+        includeVitest: true,
+      });
+      expect(
+        tree.read('libs/react-lib-nonb-jest/vite.config.ts', 'utf-8')
+      ).toMatchSnapshot();
+
+      expect(tree.read('workspace.json', 'utf-8')).toMatchSnapshot();
     });
   });
 });

--- a/packages/vite/src/generators/configuration/schema.json
+++ b/packages/vite/src/generators/configuration/schema.json
@@ -21,6 +21,11 @@
       "description": "Add a library build option and skip the server option.",
       "hidden": true
     },
+    "includeVitest": {
+      "type": "boolean",
+      "description": "Use vitest for the test suite.",
+      "hidden": true
+    },
     "uiFramework": {
       "type": "string",
       "description": "UI Framework to use for Vite.",

--- a/packages/vite/src/generators/vitest/__snapshots__/vitest.spec.ts.snap
+++ b/packages/vite/src/generators/vitest/__snapshots__/vitest.spec.ts.snap
@@ -1,0 +1,96 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`vitest generator insourceTests should add the insourceSource option in the vite config 1`] = `
+"
+/// <reference types=\\"vitest\\" />
+      import { defineConfig } from 'vite';
+      import react from '@vitejs/plugin-react';
+      import viteTsConfigPaths from 'vite-tsconfig-paths';
+      
+      
+      export default defineConfig({
+        
+        plugins: [
+          
+          react(),
+          viteTsConfigPaths({
+            root: '../../',
+          }),
+        ],
+        
+        define: {
+    'import.meta.vitest': undefined
+  },
+        test: {
+    globals: true,
+    cache: {
+      dir: '../../node_modules/.vitest'
+    },
+    environment: 'jsdom',
+    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    includeSource: ['src/**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}']
+  },
+      });"
+`;
+
+exports[`vitest generator vite.config should create correct vite.config.ts file for apps 1`] = `
+"
+/// <reference types=\\"vitest\\" />
+      import { defineConfig } from 'vite';
+      import react from '@vitejs/plugin-react';
+      import viteTsConfigPaths from 'vite-tsconfig-paths';
+      
+      
+      export default defineConfig({
+        
+        plugins: [
+          
+          react(),
+          viteTsConfigPaths({
+            root: '../../',
+          }),
+        ],
+        
+        
+        test: {
+    globals: true,
+    cache: {
+      dir: '../../node_modules/.vitest'
+    },
+    environment: 'jsdom',
+    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    
+  },
+      });"
+`;
+
+exports[`vitest generator vite.config should create correct vite.config.ts file for non buildable libs 1`] = `
+"
+/// <reference types=\\"vitest\\" />
+      import { defineConfig } from 'vite';
+      import react from '@vitejs/plugin-react';
+      import viteTsConfigPaths from 'vite-tsconfig-paths';
+      
+      
+      export default defineConfig({
+        
+        plugins: [
+          
+          react(),
+          viteTsConfigPaths({
+            root: '../../',
+          }),
+        ],
+        
+        
+        test: {
+    globals: true,
+    cache: {
+      dir: '../../node_modules/.vitest'
+    },
+    environment: 'jsdom',
+    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    
+  },
+      });"
+`;

--- a/packages/vite/src/generators/vitest/vitest-generator.ts
+++ b/packages/vite/src/generators/vitest/vitest-generator.ts
@@ -30,7 +30,10 @@ export async function vitestGenerator(
 ) {
   const tasks: GeneratorCallback[] = [];
 
-  const { targets, root } = readProjectConfiguration(tree, schema.project);
+  const { targets, root, projectType } = readProjectConfiguration(
+    tree,
+    schema.project
+  );
   let testTarget =
     schema.testTarget ??
     findExistingTargetsInProject(targets)?.validFoundTargetName?.test ??
@@ -44,10 +47,15 @@ export async function vitestGenerator(
   tasks.push(initTask);
 
   if (!schema.skipViteConfig) {
-    createOrEditViteConfig(tree, {
-      ...schema,
-      includeVitest: true,
-    });
+    createOrEditViteConfig(
+      tree,
+      {
+        ...schema,
+        includeVitest: true,
+        includeLib: projectType === 'library',
+      },
+      true
+    );
   }
 
   createFiles(tree, schema, root);

--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -220,14 +220,12 @@ export function addOrChangeBuildTarget(
   target: string
 ) {
   const project = readProjectConfiguration(tree, options.project);
-
   const buildOptions: ViteBuildExecutorOptions = {
     outputPath: joinPathFragments(
       'dist',
       project.root != '.' ? project.root : options.project
     ),
   };
-
   const targets = {
     ...project.targets,
   };
@@ -436,12 +434,18 @@ export function moveAndEditIndexHtml(
   }
 }
 
-export function createOrEditViteConfig(tree: Tree, options: Schema) {
+export function createOrEditViteConfig(
+  tree: Tree,
+  options: Schema,
+  onlyVitest?: boolean
+) {
   const projectConfig = readProjectConfiguration(tree, options.project);
 
   const viteConfigPath = `${projectConfig.root}/vite.config.ts`;
 
-  const buildOption = options.includeLib
+  const buildOption = onlyVitest
+    ? ''
+    : options.includeLib
     ? `
       // Configuration for building your library.
       // See: https://vitejs.dev/guide/build.html#library-mode
@@ -532,13 +536,17 @@ export function createOrEditViteConfig(tree: Tree, options: Schema) {
   },`
     : '';
 
-  const dtsPlugin = `dts({
+  const dtsPlugin = onlyVitest
+    ? ''
+    : `dts({
       tsConfigFilePath: join(__dirname, 'tsconfig.lib.json'),
       // Faster builds by skipping tests. Set this to false to enable type checking.
       skipDiagnostics: true,
     }),`;
 
-  const serverOption = options.includeLib
+  const serverOption = onlyVitest
+    ? ''
+    : options.includeLib
     ? ''
     : `
     server:{
@@ -554,7 +562,9 @@ ${options.includeVitest ? '/// <reference types="vitest" />' : ''}
       import react from '@vitejs/plugin-react';
       import viteTsConfigPaths from 'vite-tsconfig-paths';
       ${
-        options.includeLib
+        onlyVitest
+          ? ''
+          : options.includeLib
           ? `import dts from 'vite-plugin-dts';\nimport { join } from 'path';`
           : ''
       }
@@ -579,7 +589,9 @@ ${options.includeVitest ? '/// <reference types="vitest" />' : ''}
       import { defineConfig } from 'vite';
       import viteTsConfigPaths from 'vite-tsconfig-paths';
       ${
-        options.includeLib
+        onlyVitest
+          ? ''
+          : options.includeLib
           ? `import dts from 'vite-plugin-dts';\nimport { join } from 'path';`
           : ''
       }

--- a/packages/vite/src/utils/test-files/react-lib-non-buildable.json
+++ b/packages/vite/src/utils/test-files/react-lib-non-buildable.json
@@ -1,0 +1,25 @@
+{
+  "name": "react-lib-nonb-jest",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "root": "libs/react-lib-nonb-jest",
+  "sourceRoot": "libs/react-lib-nonb-jest/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/react-lib-nonb-jest/**/*.{ts,tsx,js,jsx}"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/react-lib-nonb-jest/jest.config.ts",
+        "passWithNoTests": true
+      }
+    }
+  },
+  "tags": []
+}

--- a/packages/vite/src/utils/test-utils.ts
+++ b/packages/vite/src/utils/test-utils.ts
@@ -5,6 +5,7 @@ import * as webAppConfig from './test-files/web-project.config.json';
 import * as angularAppConfig from './test-files/angular-project.config.json';
 import * as randomAppConfig from './test-files/unknown-project.config.json';
 import * as mixedAppConfig from './test-files/react-mixed-project.config.json';
+import * as reactLibNBJest from './test-files/react-lib-non-buildable.json';
 
 export function mockViteReactAppGenerator(tree: Tree): Tree {
   const appName = 'my-test-react-vite-app';
@@ -442,6 +443,82 @@ export function mockUnknownAppGenerator(tree: Tree): Tree {
     ...randomAppConfig,
     root: `apps/${appName}`,
     projectType: 'application',
+  });
+
+  return tree;
+}
+
+export function mockReactLibNonBuildableJestTestRunnerGenerator(
+  tree: Tree
+): Tree {
+  const libName = 'react-lib-nonb-jest';
+
+  tree.write(`libs/${libName}/src/index.ts`, ``);
+
+  tree.write(
+    `libs/${libName}/tsconfig.json`,
+    `{
+      "compilerOptions": {
+        "jsx": "react-jsx",
+        "allowJs": false,
+        "esModuleInterop": false,
+        "allowSyntheticDefaultImports": true,
+        "strict": true
+      },
+      "files": [],
+      "include": [],
+      "references": [
+        {
+          "path": "./tsconfig.lib.json"
+        },
+        {
+          "path": "./tsconfig.spec.json"
+        }
+      ],
+      "extends": "../../tsconfig.base.json"
+    }`
+  );
+  tree.write(
+    `libs/${libName}/tsconfig.lib.json`,
+    `{
+      "extends": "./tsconfig.json",
+      "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "types": ["node"]
+      },
+      "files": [
+        "../../node_modules/@nrwl/react/typings/cssmodule.d.ts",
+        "../../node_modules/@nrwl/react/typings/image.d.ts"
+      ],
+      "exclude": [
+        "jest.config.ts",
+        "src/**/*.spec.ts",
+        "src/**/*.test.ts",
+        "src/**/*.spec.tsx",
+        "src/**/*.test.tsx",
+        "src/**/*.spec.js",
+        "src/**/*.test.js",
+        "src/**/*.spec.jsx",
+        "src/**/*.test.jsx"
+      ],
+      "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"]
+    }`
+  );
+
+  writeJson(tree, 'workspace.json', {
+    projects: {
+      [`${libName}`]: {
+        ...reactLibNBJest,
+        root: `libs/${libName}`,
+        projectType: 'library',
+      },
+    },
+  });
+
+  writeJson(tree, `libs/${libName}/project.json`, {
+    ...reactLibNBJest,
+    root: `libs/${libName}`,
+    projectType: 'library',
   });
 
   return tree;


### PR DESCRIPTION
Sometimes libs were generated with `server` config. Removing that. Also writing tests around that.