### PR TITLE
fix(angular): cache server build

### DIFF
--- a/packages/angular/src/generators/setup-ssr/lib/update-project-config.ts
+++ b/packages/angular/src/generators/setup-ssr/lib/update-project-config.ts
@@ -2,7 +2,9 @@ import type { Tree } from '@nrwl/devkit';
 import {
   joinPathFragments,
   readProjectConfiguration,
+  readWorkspaceConfiguration,
   updateProjectConfiguration,
+  updateWorkspaceConfiguration,
 } from '@nrwl/devkit';
 import type { Schema } from '../schema';
 
@@ -72,4 +74,18 @@ export function updateProjectConfig(tree: Tree, schema: Schema) {
   };
 
   updateProjectConfiguration(tree, schema.project, projectConfig);
+
+  const workspaceConfig = readWorkspaceConfiguration(tree);
+  if (
+    workspaceConfig.tasksRunnerOptions?.default &&
+    !workspaceConfig.tasksRunnerOptions.default.options.cacheableOperations.includes(
+      'server'
+    )
+  ) {
+    workspaceConfig.tasksRunnerOptions.default.options.cacheableOperations = [
+      ...workspaceConfig.tasksRunnerOptions.default.options.cacheableOperations,
+      'server',
+    ];
+    updateWorkspaceConfiguration(tree, workspaceConfig);
+  }
 }

--- a/packages/angular/src/generators/setup-ssr/setup-ssr.spec.ts
+++ b/packages/angular/src/generators/setup-ssr/setup-ssr.spec.ts
@@ -1,4 +1,5 @@
 import {
+  NxJsonConfiguration,
   readJson,
   readProjectConfiguration,
   updateProjectConfiguration,
@@ -130,6 +131,23 @@ describe('setupSSR', () => {
     for (const [dep, version] of Object.entries(devDeps)) {
       expect(packageJson.devDependencies[dep]).toEqual(version);
     }
+    const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+    expect(nxJson.tasksRunnerOptions).toMatchInlineSnapshot(`
+      Object {
+        "default": Object {
+          "options": Object {
+            "cacheableOperations": Array [
+              "build",
+              "lint",
+              "test",
+              "e2e",
+              "server",
+            ],
+          },
+          "runner": "nx/tasks-runners/default",
+        },
+      }
+    `);
   });
 
   it('should use fileReplacements if they already exist', async () => {

--- a/packages/react/src/generators/setup-ssr/setup-ssr.ts
+++ b/packages/react/src/generators/setup-ssr/setup-ssr.ts
@@ -168,7 +168,9 @@ export async function setupSsrGenerator(tree: Tree, options: Schema) {
   const workspace = readWorkspaceConfiguration(tree);
   if (
     workspace.tasksRunnerOptions?.default &&
-    !workspace.tasksRunnerOptions.default.options.cacheableOperations['server']
+    !workspace.tasksRunnerOptions.default.options.cacheableOperations.includes(
+      'server'
+    )
   ) {
     workspace.tasksRunnerOptions.default.options.cacheableOperations = [
       ...workspace.tasksRunnerOptions.default.options.cacheableOperations,


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
setup-ssr generator does not add server to cacheable targets

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
it should add server to cacheable targets

