### PR TITLE
fix(misc): using `normalizePath` for tailwindcss config generation

### DIFF
--- a/packages/workspace/src/utilities/generate-globs.ts
+++ b/packages/workspace/src/utilities/generate-globs.ts
@@ -1,4 +1,4 @@
-import { joinPathFragments, logger } from '@nrwl/devkit';
+import { joinPathFragments, logger, normalizePath } from '@nrwl/devkit';
 import { workspaceRoot } from 'nx/src/utils/workspace-root';
 import { dirname, join, relative, resolve } from 'path';
 import { readCachedProjectGraph } from 'nx/src/project-graph/project-graph';
@@ -30,7 +30,9 @@ export function createGlobPatternsForDependencies(
   fileGlobPattern: string
 ): string[] {
   let ig = configureIgnore();
-  const filenameRelativeToWorkspaceRoot = relative(workspaceRoot, dirPath);
+  const filenameRelativeToWorkspaceRoot = normalizePath(
+    relative(workspaceRoot, dirPath)
+  );
   const projectGraph = readCachedProjectGraph();
   const projectRootMappings = createProjectRootMappings(projectGraph.nodes);
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

Windows users get an error when running `nx serve` or `nx build` for projects with TailwindCSS, because `createGlobPatternsForDependencies` uses the `path.relative` method without normalizing the paths first.

## Expected Behavior

Windows users should be able to run `nx serve` or `nx build` for projects with TailwindCSS.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #13713
