### PR TITLE
fix(testing): warn and default if sourceRoot isn't set for ng CT

### DIFF
--- a/packages/angular/plugins/component-testing.ts
+++ b/packages/angular/plugins/component-testing.ts
@@ -231,11 +231,20 @@ function normalizeBuildTargetOptions(
     buildOptions.scripts = [];
     buildOptions.stylePreprocessorOptions = { includePaths: [] };
   }
-  const { root, sourceRoot } =
+
+  const config =
     buildContext.projectGraph.nodes[buildContext.projectName]?.data;
+
+  if (!config.sourceRoot) {
+    logger.warn(stripIndents`Unable to find the 'sourceRoot' in the project configuration.
+Will set 'sourceRoot' to '${config.root}/src'
+Note: this may fail, setting the correct 'sourceRoot' for ${buildContext.projectName} in the project.json file will ensure the correct value is used.`);
+    config.sourceRoot = joinPathFragments(config.root, 'src');
+  }
+
   return {
-    root: joinPathFragments(offset, root),
-    sourceRoot: joinPathFragments(offset, sourceRoot),
+    root: joinPathFragments(offset, config.root),
+    sourceRoot: joinPathFragments(offset, config.sourceRoot),
     buildOptions,
   };
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
when sourceRoot is missing in the project.json angular CT errors out trying to join the paths

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
does not error or provides helpful error

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #13883
