### PR TITLE
fix(testing): change ignoreTestFiles to excludeSpecPattern for cy10+

### DIFF
--- a/docs/generated/packages/cypress/executors/cypress.json
+++ b/docs/generated/packages/cypress/executors/cypress.json
@@ -101,6 +101,7 @@
         "description": "A named group for recorded runs in the Cypress dashboard."
       },
       "ignoreTestFiles": {
+        "aliases": ["excludeSpecPattern"],
         "type": "string",
         "description": "A String or Array of glob patterns used to ignore test files that would otherwise be shown in your list of tests. Cypress uses minimatch with the options: `{dot: true, matchBase: true}`. We suggest using https://globster.xyz to test what files would match."
       },

--- a/packages/cypress/src/executors/cypress/cypress.impl.ts
+++ b/packages/cypress/src/executors/cypress/cypress.impl.ts
@@ -190,6 +190,7 @@ async function runCypress(
   baseUrl: string,
   opts: NormalizedCypressExecutorOptions
 ) {
+  const cypressVersion = installedCypressVersion();
   // Cypress expects the folder where a cypress config is present
   const projectFolderPath = dirname(opts.cypressConfig);
   const options: any = {
@@ -225,7 +226,15 @@ async function runCypress(
   options.parallel = opts.parallel;
   options.ciBuildId = opts.ciBuildId?.toString();
   options.group = opts.group;
-  options.ignoreTestFiles = opts.ignoreTestFiles;
+  // renamed in cy 10
+  if (cypressVersion >= 10) {
+    options.config ??= {};
+    options.config[opts.testingType] = {
+      excludeSpecPattern: opts.ignoreTestFiles,
+    };
+  } else {
+    options.ignoreTestFiles = opts.ignoreTestFiles;
+  }
 
   if (opts.reporter) {
     options.reporter = opts.reporter;

--- a/packages/cypress/src/executors/cypress/schema.json
+++ b/packages/cypress/src/executors/cypress/schema.json
@@ -108,6 +108,7 @@
       "description": "A named group for recorded runs in the Cypress dashboard."
     },
     "ignoreTestFiles": {
+      "aliases": ["excludeSpecPattern"],
       "type": "string",
       "description": "A String or Array of glob patterns used to ignore test files that would otherwise be shown in your list of tests. Cypress uses minimatch with the options: `{dot: true, matchBase: true}`. We suggest using https://globster.xyz to test what files would match."
     },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
when using > Cypress 10 the option ignoreTestFiles was renamed to excludeSpecPattern

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
when using > Cypress 10 should use excludeSpecPattern instead of ignoreTestFiles

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->


the option has to be passed via the testingType level of config instead of the root level option since the excludeSpecPattern has move from the root level to the e2e/component level.


Fixes #13860
