### PR TITLE
feat(nextjs): Switch custom server's watch option by environment

### DIFF
--- a/packages/next/src/executors/server/server.impl.ts
+++ b/packages/next/src/executors/server/server.impl.ts
@@ -157,7 +157,7 @@ async function* runCustomServer(
   const customServerBuild = await runExecutor(
     parseTargetString(options.customServerTarget),
     {
-      watch: true,
+      watch: options.dev ? true : false,
     },
     context
   );


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When using Next.js custom server with `@nrwl/next:server`'s `customServerTarget`, the `watch: true` option is always passed (Please see the following link).
https://github.com/nrwl/nx/blob/3afb6bf/packages/next/src/executors/server/server.impl.ts#L157-L163

This behavior does not change when passing the `dev: false` option in `@nrwl/next:server`. Therefore, it runs rebuilds that are not needed in the production environment as well.

<details>
<summary>Details</summary>
Unnecessary processes being executed in the production environment is a problem by itself, but in our case, it consumed a lot of `inotify` watched files and exceeded `inotify.max_user_watches` limit, which caused a side issue of not being able to start Docker container.
</details>


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Rebuilds are run only in the development environment.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/13192
Related PR: https://github.com/nrwl/nx/pull/11325