### PR TITLE
fix(storybook): optional-chain typeName

### DIFF
--- a/packages/react/src/utils/ast-utils.ts
+++ b/packages/react/src/utils/ast-utils.ts
@@ -629,7 +629,7 @@ export function getComponentPropsInterface(
       (x) => ts.isParameter(x) && (x.name as ts.Identifier).text === 'props'
     );
 
-    if (propsParam && propsParam.type) {
+    if (propsParam?.type?.['typeName']) {
       propsTypeName = (
         (propsParam.type as ts.TypeReferenceNode).typeName as ts.Identifier
       ).text;
@@ -666,10 +666,10 @@ export function getComponentPropsInterface(
         return name === 'Component' || name === 'PureComponent';
       });
 
-      if (propsTypeExpression && propsTypeExpression.typeArguments) {
+      if (propsTypeExpression?.typeArguments?.[0]?.['typeName']) {
         propsTypeName = (
           propsTypeExpression.typeArguments[0] as ts.TypeReferenceNode
-        ).typeName?.getText();
+        ).typeName.getText();
       }
     }
   } else {


### PR DESCRIPTION
## Current Behavior
`TypeError: Cannot read properties of undefined (reading 'text')`

## Expected Behavior
Don't throw if `typeName` is `undefined`

## Related Issue(s)

Fixes https://github.com/nrwl/nx/issues/12155