### PR TITLE
fix(js): revert change to use new lockfile utils

### DIFF
--- a/packages/js/src/utils/package-json/update-package-json.spec.ts
+++ b/packages/js/src/utils/package-json/update-package-json.spec.ts
@@ -1,8 +1,8 @@
-import { updatePackageJsonContent } from './update-package-json';
+import { getUpdatedPackageJsonContent } from './update-package-json';
 
 describe('getUpdatedPackageJsonContent', () => {
   it('should update fields for commonjs only (default)', () => {
-    const json = updatePackageJsonContent(
+    const json = getUpdatedPackageJsonContent(
       {
         name: 'test',
         version: '0.0.1',
@@ -23,7 +23,7 @@ describe('getUpdatedPackageJsonContent', () => {
   });
 
   it('should update fields for esm only', () => {
-    const json = updatePackageJsonContent(
+    const json = getUpdatedPackageJsonContent(
       {
         name: 'test',
         version: '0.0.1',
@@ -47,7 +47,7 @@ describe('getUpdatedPackageJsonContent', () => {
   });
 
   it('should update fields for commonjs + esm', () => {
-    const json = updatePackageJsonContent(
+    const json = getUpdatedPackageJsonContent(
       {
         name: 'test',
         version: '0.0.1',
@@ -70,7 +70,7 @@ describe('getUpdatedPackageJsonContent', () => {
   });
 
   it('should support skipping types', () => {
-    const json = updatePackageJsonContent(
+    const json = getUpdatedPackageJsonContent(
       {
         name: 'test',
         version: '0.0.1',
@@ -91,7 +91,7 @@ describe('getUpdatedPackageJsonContent', () => {
   });
 
   it('should support generated exports field', () => {
-    const json = updatePackageJsonContent(
+    const json = getUpdatedPackageJsonContent(
       {
         name: 'test',
         version: '0.0.1',
@@ -119,7 +119,7 @@ describe('getUpdatedPackageJsonContent', () => {
   });
 
   it('should support different CJS file extension', () => {
-    const json = updatePackageJsonContent(
+    const json = getUpdatedPackageJsonContent(
       {
         name: 'test',
         version: '0.0.1',
@@ -147,7 +147,7 @@ describe('getUpdatedPackageJsonContent', () => {
   });
 
   it('should not set types when { skipTypings: true }', () => {
-    const json = updatePackageJsonContent(
+    const json = getUpdatedPackageJsonContent(
       {
         name: 'test',
         version: '0.0.1',
@@ -170,7 +170,7 @@ describe('getUpdatedPackageJsonContent', () => {
   it('should support different exports field shape', () => {
     // exports: string
     expect(
-      updatePackageJsonContent(
+      getUpdatedPackageJsonContent(
         {
           name: 'test',
           version: '0.0.1',
@@ -196,7 +196,7 @@ describe('getUpdatedPackageJsonContent', () => {
 
     // exports: { '.': string }
     expect(
-      updatePackageJsonContent(
+      getUpdatedPackageJsonContent(
         {
           name: 'test',
           version: '0.0.1',
@@ -226,7 +226,7 @@ describe('getUpdatedPackageJsonContent', () => {
 
     // exports: { './custom': string }
     expect(
-      updatePackageJsonContent(
+      getUpdatedPackageJsonContent(
         {
           name: 'test',
           version: '0.0.1',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The changes in [this commit](https://github.com/nrwl/nx/commit/3149b66036dd26b42db0990ab4153141d6a63464) add a ton of extra dependencies to published packages even though there is a flag which asks not to alter the `package.json`.

This caused issues in our own e2e tests as `@nrwl/*` packages had a lot of additional dependencies:

[Before](https://unpkg.com/@nrwl/webpack@15.3.3/package.json)
[After](https://unpkg.com/@nrwl/webpack@15.4.0-rc.0/package.json)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

This reverts the changes to `@nrwl/js:tsc` made in the above commit and restores the `package.json` behavior during `@nrwl/js:tsc`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
