### PR TITLE
feat(core): use inputs to determine package dependencies

### DIFF
--- a/docs/generated/devkit/nrwl_devkit.md
+++ b/docs/generated/devkit/nrwl_devkit.md
@@ -1070,13 +1070,15 @@ Convert an Nx Generator into an Angular Devkit Schematic.
 
 #### Parameters
 
-| Name                    | Type                                                              |
-| :---------------------- | :---------------------------------------------------------------- |
-| `projectName`           | `string`                                                          |
-| `graph`                 | [`ProjectGraph`](../../devkit/documents/nrwl_devkit#projectgraph) |
-| `options`               | `Object`                                                          |
-| `options.isProduction?` | `boolean`                                                         |
-| `options.root?`         | `string`                                                          |
+| Name                          | Type                                                              |
+| :---------------------------- | :---------------------------------------------------------------- |
+| `projectName`                 | `string`                                                          |
+| `graph`                       | [`ProjectGraph`](../../devkit/documents/nrwl_devkit#projectgraph) |
+| `options`                     | `Object`                                                          |
+| `options.helperDependencies?` | `string`[]                                                        |
+| `options.isProduction?`       | `boolean`                                                         |
+| `options.root?`               | `string`                                                          |
+| `options.target?`             | `string`                                                          |
 
 #### Returns
 

--- a/docs/generated/packages/devkit/documents/nrwl_devkit.md
+++ b/docs/generated/packages/devkit/documents/nrwl_devkit.md
@@ -1070,13 +1070,15 @@ Convert an Nx Generator into an Angular Devkit Schematic.
 
 #### Parameters
 
-| Name                    | Type                                                              |
-| :---------------------- | :---------------------------------------------------------------- |
-| `projectName`           | `string`                                                          |
-| `graph`                 | [`ProjectGraph`](../../devkit/documents/nrwl_devkit#projectgraph) |
-| `options`               | `Object`                                                          |
-| `options.isProduction?` | `boolean`                                                         |
-| `options.root?`         | `string`                                                          |
+| Name                          | Type                                                              |
+| :---------------------------- | :---------------------------------------------------------------- |
+| `projectName`                 | `string`                                                          |
+| `graph`                       | [`ProjectGraph`](../../devkit/documents/nrwl_devkit#projectgraph) |
+| `options`                     | `Object`                                                          |
+| `options.helperDependencies?` | `string`[]                                                        |
+| `options.isProduction?`       | `boolean`                                                         |
+| `options.root?`               | `string`                                                          |
+| `options.target?`             | `string`                                                          |
 
 #### Returns
 

--- a/packages/js/src/utils/package-json/update-package-json.spec.ts
+++ b/packages/js/src/utils/package-json/update-package-json.spec.ts
@@ -6,7 +6,7 @@ import {
   UpdatePackageJsonOption,
 } from './update-package-json';
 import { vol } from 'memfs';
-import { ExecutorContext, ProjectGraph } from '@nrwl/devkit';
+import { DependencyType, ExecutorContext, ProjectGraph } from '@nrwl/devkit';
 import { DependentBuildableProjectNode } from '../buildable-libs-utils';
 
 jest.mock('nx/src/utils/workspace-root', () => ({
@@ -298,7 +298,24 @@ describe('updatePackageJson', () => {
               outputs: ['{workspaceRoot}/dist/libs/lib1'],
             },
           },
-          files: [],
+          files: [
+            {
+              file: 'test.ts',
+              hash: '',
+              dependencies: [
+                {
+                  type: DependencyType.static,
+                  target: 'npm:external1',
+                  source: '@org/lib1',
+                },
+                {
+                  type: DependencyType.static,
+                  target: 'npm:external2',
+                  source: '@org/lib1',
+                },
+              ],
+            },
+          ],
         },
       },
     },
@@ -330,8 +347,16 @@ describe('updatePackageJson', () => {
     },
     dependencies: {
       '@org/lib1': [
-        { source: '@org/lib1', target: 'npm:external1', type: 'static' },
-        { source: '@org/lib1', target: 'npm:external2', type: 'static' },
+        {
+          source: '@org/lib1',
+          target: 'npm:external1',
+          type: DependencyType.static,
+        },
+        {
+          source: '@org/lib1',
+          target: 'npm:external2',
+          type: DependencyType.static,
+        },
       ],
     },
   };

--- a/packages/js/src/utils/package-json/update-package-json.ts
+++ b/packages/js/src/utils/package-json/update-package-json.ts
@@ -54,6 +54,7 @@ export function updatePackageJson(
 
   if (options.updateBuildableProjectDepsInPackageJson) {
     packageJson = createPackageJson(context.projectName, context.projectGraph, {
+      target: context.targetName,
       root: context.root,
       // By default we remove devDependencies since this is a production build.
       isProduction: true,

--- a/packages/next/src/executors/build/build.impl.ts
+++ b/packages/next/src/executors/build/build.impl.ts
@@ -84,6 +84,7 @@ export default async function buildExecutor(
     context.projectName,
     context.projectGraph,
     {
+      target: context.targetName,
       root: context.root,
       isProduction: !options.includeDevDependenciesInPackageJson, // By default we remove devDependencies since this is a production build.
     }

--- a/packages/nx/src/utils/create-package-json.spec.ts
+++ b/packages/nx/src/utils/create-package-json.spec.ts
@@ -1,0 +1,502 @@
+import * as fs from 'fs';
+
+import * as configModule from '../config/configuration';
+import { DependencyType } from '../config/project-graph';
+import * as hashModule from '../hasher/hasher';
+import { createPackageJson } from './create-package-json';
+import * as fileutilsModule from './fileutils';
+
+describe('createPackageJson', () => {
+  it('should add additional dependencies', () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+    jest.spyOn(fileutilsModule, 'readJsonFile').mockReturnValue({
+      dependencies: {
+        typescript: '4.8.4',
+        tslib: '2.4.0',
+      },
+    });
+
+    expect(
+      createPackageJson(
+        'lib1',
+        {
+          nodes: {
+            lib1: {
+              type: 'lib',
+              name: 'lib1',
+              data: { files: [], targets: {}, root: '' },
+            },
+          },
+          externalNodes: {
+            'npm:tslib': {
+              type: 'npm',
+              name: 'npm:tslib',
+              data: { version: '2.4.0', hash: '', packageName: 'tslib' },
+            },
+          },
+          dependencies: {},
+        },
+        { helperDependencies: ['npm:tslib'] }
+      )
+    ).toEqual({
+      dependencies: {
+        tslib: '2.4.0',
+      },
+      name: 'lib1',
+      version: '0.0.1',
+    });
+  });
+
+  it('should only add file dependencies if target is specified', () => {
+    jest.spyOn(configModule, 'readNxJson').mockReturnValueOnce({
+      namedInputs: {
+        default: ['{projectRoot}/**/*'],
+        production: ['!{projectRoot}/**/*.spec.ts'],
+      },
+      targetDefaults: {
+        build: {
+          inputs: ['default', 'production', '^production'],
+        },
+      },
+    });
+
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+    jest.spyOn(fileutilsModule, 'readJsonFile').mockReturnValue({
+      dependencies: {
+        axios: '1.0.0',
+        tslib: '2.4.0',
+        jest: '29.0.0',
+        typescript: '4.8.4',
+      },
+    });
+
+    expect(
+      createPackageJson(
+        'lib1',
+        {
+          nodes: {
+            lib1: {
+              type: 'lib',
+              name: 'lib1',
+              data: {
+                root: 'libs/lib1',
+                targets: {
+                  build: {},
+                },
+                files: [
+                  {
+                    file: 'libs/lib1/src/main.ts',
+                    dependencies: [
+                      {
+                        type: DependencyType.static,
+                        target: 'npm:typescript',
+                        source: 'lib1',
+                      },
+                    ],
+                    hash: '',
+                  },
+                  {
+                    file: 'libs/lib1/src/main2.ts',
+                    dependencies: [
+                      {
+                        type: DependencyType.static,
+                        target: 'lib2',
+                        source: 'lib1',
+                      },
+                    ],
+                    hash: '',
+                  },
+                  {
+                    file: 'libs/lib1/src/main.spec.ts',
+                    dependencies: [
+                      {
+                        type: DependencyType.static,
+                        target: 'npm:jest',
+                        source: 'lib1',
+                      },
+                    ],
+                    hash: '',
+                  },
+                ],
+              },
+            },
+            lib2: {
+              type: 'lib',
+              name: 'lib2',
+              data: {
+                root: 'libs/lib2',
+                targets: {
+                  build: {},
+                },
+                files: [
+                  {
+                    file: 'libs/lib2/src/main.ts',
+                    dependencies: [
+                      {
+                        type: DependencyType.static,
+                        target: 'npm:axios',
+                        source: 'lib2',
+                      },
+                    ],
+                    hash: '',
+                  },
+                  {
+                    file: 'libs/lib2/src/main.spec.ts',
+                    dependencies: [
+                      {
+                        type: DependencyType.static,
+                        target: 'npm:jest',
+                        source: 'lib2',
+                      },
+                    ],
+                    hash: '',
+                  },
+                ],
+              },
+            },
+          },
+          externalNodes: {
+            'npm:tslib': {
+              type: 'npm',
+              name: 'npm:tslib',
+              data: { version: '2.4.0', hash: '', packageName: 'tslib' },
+            },
+            'npm:typescript': {
+              type: 'npm',
+              name: 'npm:typescript',
+              data: { version: '4.8.4', hash: '', packageName: 'typescript' },
+            },
+            'npm:jest': {
+              type: 'npm',
+              name: 'npm:jest',
+              data: { version: '29.0.0', hash: '', packageName: 'jest' },
+            },
+            'npm:axios': {
+              type: 'npm',
+              name: 'npm:jest',
+              data: { version: '1.0.0', hash: '', packageName: 'axios' },
+            },
+          },
+          dependencies: {},
+        },
+        {
+          target: 'build',
+          isProduction: true,
+          helperDependencies: ['npm:tslib'],
+        }
+      )
+    ).toEqual({
+      dependencies: {
+        axios: '1.0.0',
+        tslib: '2.4.0',
+        typescript: '4.8.4',
+      },
+      name: 'lib1',
+      version: '0.0.1',
+    });
+  });
+
+  it('should only add all dependencies if target is not specified', () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+    jest.spyOn(fileutilsModule, 'readJsonFile').mockReturnValue({
+      dependencies: {
+        axios: '1.0.0',
+        tslib: '2.4.0',
+        jest: '29.0.0',
+        typescript: '4.8.4',
+      },
+    });
+
+    expect(
+      createPackageJson(
+        'lib1',
+        {
+          nodes: {
+            lib1: {
+              type: 'lib',
+              name: 'lib1',
+              data: {
+                root: 'libs/lib1',
+                targets: {
+                  build: {},
+                },
+                files: [
+                  {
+                    file: 'libs/lib1/src/main.ts',
+                    dependencies: [
+                      {
+                        type: DependencyType.static,
+                        target: 'npm:typescript',
+                        source: 'lib1',
+                      },
+                    ],
+                    hash: '',
+                  },
+                  {
+                    file: 'libs/lib1/src/main2.ts',
+                    dependencies: [
+                      {
+                        type: DependencyType.static,
+                        target: 'lib2',
+                        source: 'lib1',
+                      },
+                    ],
+                    hash: '',
+                  },
+                  {
+                    file: 'libs/lib1/src/main.spec.ts',
+                    dependencies: [
+                      {
+                        type: DependencyType.static,
+                        target: 'npm:jest',
+                        source: 'lib1',
+                      },
+                    ],
+                    hash: '',
+                  },
+                ],
+              },
+            },
+            lib2: {
+              type: 'lib',
+              name: 'lib2',
+              data: {
+                root: 'libs/lib2',
+                targets: {
+                  build: {},
+                },
+                files: [
+                  {
+                    file: 'libs/lib2/src/main.ts',
+                    dependencies: [
+                      {
+                        type: DependencyType.static,
+                        target: 'npm:axios',
+                        source: 'lib2',
+                      },
+                    ],
+                    hash: '',
+                  },
+                  {
+                    file: 'libs/lib2/src/main.spec.ts',
+                    dependencies: [
+                      {
+                        type: DependencyType.static,
+                        target: 'npm:jest',
+                        source: 'lib2',
+                      },
+                    ],
+                    hash: '',
+                  },
+                ],
+              },
+            },
+          },
+          externalNodes: {
+            'npm:tslib': {
+              type: 'npm',
+              name: 'npm:tslib',
+              data: { version: '2.4.0', hash: '', packageName: 'tslib' },
+            },
+            'npm:typescript': {
+              type: 'npm',
+              name: 'npm:typescript',
+              data: { version: '4.8.4', hash: '', packageName: 'typescript' },
+            },
+            'npm:jest': {
+              type: 'npm',
+              name: 'npm:jest',
+              data: { version: '29.0.0', hash: '', packageName: 'jest' },
+            },
+            'npm:axios': {
+              type: 'npm',
+              name: 'npm:axios',
+              data: { version: '1.0.0', hash: '', packageName: 'axios' },
+            },
+          },
+          dependencies: {},
+        },
+        { isProduction: true, helperDependencies: ['npm:tslib'] }
+      )
+    ).toEqual({
+      dependencies: {
+        axios: '1.0.0',
+        jest: '29.0.0',
+        tslib: '2.4.0',
+        typescript: '4.8.4',
+      },
+      name: 'lib1',
+      version: '0.0.1',
+    });
+  });
+
+  it('should cache filterUsingGlobPatterns', () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+    jest.spyOn(fileutilsModule, 'readJsonFile').mockReturnValue({
+      dependencies: {
+        axios: '1.0.0',
+        tslib: '2.4.0',
+        jest: '29.0.0',
+        typescript: '4.8.4',
+      },
+    });
+    const filterUsingGlobPatternsSpy = jest.spyOn(
+      hashModule,
+      'filterUsingGlobPatterns'
+    );
+
+    expect(
+      createPackageJson(
+        'lib1',
+        {
+          nodes: {
+            lib1: {
+              type: 'lib',
+              name: 'lib1',
+              data: {
+                root: 'libs/lib1',
+                targets: {
+                  build: {},
+                },
+                files: [
+                  {
+                    file: 'libs/lib1/src/main.ts',
+                    dependencies: [
+                      {
+                        type: DependencyType.static,
+                        target: 'lib3',
+                        source: 'lib1',
+                      },
+                    ],
+                    hash: '',
+                  },
+                  {
+                    file: 'libs/lib1/src/main2.ts',
+                    dependencies: [
+                      {
+                        type: DependencyType.static,
+                        target: 'lib2',
+                        source: 'lib1',
+                      },
+                    ],
+                    hash: '',
+                  },
+                ],
+              },
+            },
+            lib2: {
+              type: 'lib',
+              name: 'lib2',
+              data: {
+                root: 'libs/lib2',
+                targets: {
+                  build: {},
+                },
+                files: [
+                  {
+                    file: 'libs/lib2/src/main.ts',
+                    dependencies: [
+                      {
+                        type: DependencyType.static,
+                        target: 'lib4',
+                        source: 'lib2',
+                      },
+                    ],
+                    hash: '',
+                  },
+                ],
+              },
+            },
+            lib3: {
+              type: 'lib',
+              name: 'lib3',
+              data: {
+                root: 'libs/lib3',
+                targets: {
+                  build: {},
+                },
+                files: [
+                  {
+                    file: 'libs/lib3/src/main.ts',
+                    dependencies: [
+                      {
+                        type: DependencyType.static,
+                        target: 'lib4',
+                        source: 'lib3',
+                      },
+                    ],
+                    hash: '',
+                  },
+                ],
+              },
+            },
+            lib4: {
+              type: 'lib',
+              name: 'lib4',
+              data: {
+                root: 'libs/lib4',
+                targets: {
+                  build: {},
+                },
+                files: [
+                  {
+                    file: 'libs/lib2/src/main.ts',
+                    dependencies: [
+                      {
+                        type: DependencyType.static,
+                        target: 'npm:axios',
+                        source: 'lib2',
+                      },
+                    ],
+                    hash: '',
+                  },
+                ],
+              },
+            },
+          },
+          externalNodes: {
+            'npm:axios': {
+              type: 'npm',
+              name: 'npm:axios',
+              data: { version: '1.0.0', hash: '', packageName: 'axios' },
+            },
+          },
+          dependencies: {},
+        },
+        { isProduction: true }
+      )
+    ).toEqual({
+      dependencies: {
+        axios: '1.0.0',
+      },
+      name: 'lib1',
+      version: '0.0.1',
+    });
+
+    expect(filterUsingGlobPatternsSpy).toHaveBeenNthCalledWith(
+      1,
+      'libs/lib1',
+      expect.anything(),
+      expect.anything()
+    );
+    expect(filterUsingGlobPatternsSpy).toHaveBeenNthCalledWith(
+      2,
+      'libs/lib3',
+      expect.anything(),
+      expect.anything()
+    );
+    expect(filterUsingGlobPatternsSpy).toHaveBeenNthCalledWith(
+      3,
+      'libs/lib4',
+      expect.anything(),
+      expect.anything()
+    );
+    expect(filterUsingGlobPatternsSpy).toHaveBeenNthCalledWith(
+      4,
+      'libs/lib2',
+      expect.anything(),
+      expect.anything()
+    );
+    expect(filterUsingGlobPatternsSpy).toHaveBeenCalledTimes(4);
+  });
+});

--- a/packages/webpack/src/plugins/generate-package-json-plugin.ts
+++ b/packages/webpack/src/plugins/generate-package-json-plugin.ts
@@ -54,17 +54,15 @@ export class GeneratePackageJsonPlugin implements WebpackPluginInstance {
             });
           }
 
-          if (helperDependencies.length > 0) {
-            this.projectGraph.dependencies[this.context.projectName] =
-              this.projectGraph.dependencies[this.context.projectName].concat(
-                helperDependencies
-              );
-          }
-
           const packageJson = createPackageJson(
             this.context.projectName,
             this.projectGraph,
-            { root: this.context.root, isProduction: true }
+            {
+              target: this.context.targetName,
+              root: this.context.root,
+              isProduction: true,
+              helperDependencies: helperDependencies.map((dep) => dep.target),
+            }
           );
           packageJson.main = packageJson.main ?? this.options.outputFileName;
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Nx uses `all` project files to determine the dependencies that should be included in the output `package.json` ( generated by setting the [generatePackageJson](https://nx.dev/packages/webpack/executors/webpack#generatepackagejson) flag to true ).
This is not very practical, since it will include dependencies used in `*.spec.ts` files, which are not required in the production environment.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Nx should only include dependencies that are required in the production environment.
An alterntive would be to rely on webpack and use the [generate-package-json-webpack-plugin](https://github.com/lostpebble/generate-package-json-webpack-plugin).

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
Related #13462
Fixes #14981 
