### PR TITLE
chore(graph): enforce chrome on e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,8 @@ commands:
           steps:
             - run:
                 command: sudo apt-get install -y ca-certificates
+            - browser-tools/install-chrome
+            - browser-tools/install-chromedriver
       - node/install:
           # Use LTS version
           node-version: ''
@@ -174,8 +176,6 @@ jobs:
           os: linux
       - nx/set-shas:
           main-branch-name: 'master'
-      - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
       - run: npx nx-cloud start-ci-run --stop-agents-after="e2e"
       - run:
           name: Check Documentation

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ version: 2.1
 orbs:
   nx: nrwl/nx@1.6.1
   node: circleci/node@5.0.2
+  browser-tools: circleci/browser-tools@1.4.0
 
 # -------------------------
 #        DEFAULTS
@@ -173,6 +174,8 @@ jobs:
           os: linux
       - nx/set-shas:
           main-branch-name: 'master'
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - run: npx nx-cloud start-ci-run --stop-agents-after="e2e"
       - run:
           name: Check Documentation

--- a/graph/client-e2e/project.json
+++ b/graph/client-e2e/project.json
@@ -8,7 +8,8 @@
       "executor": "@nrwl/cypress:cypress",
       "options": {
         "tsConfig": "graph/client-e2e/tsconfig.e2e.json",
-        "testingType": "e2e"
+        "testingType": "e2e",
+        "browser": "chrome"
       },
       "configurations": {
         "dev": {


### PR DESCRIPTION
## Current Behavior
* No browser is set for Cypress, so it defaults to Electron

## Expected Behavior
* Browser is set to Chrome, hopefully reducing e2e flakiness