### PR TITLE
feat(js): add lockfile generator to js plugin

### DIFF
--- a/docs/generated/packages/js/executors/swc.json
+++ b/docs/generated/packages/js/executors/swc.json
@@ -116,6 +116,12 @@
         "items": { "type": "string" },
         "description": "List of target names that annotate a build target for a project",
         "default": ["build"]
+      },
+      "generateLockfile": {
+        "type": "boolean",
+        "description": "Generate a lockfile (e.g. yarn.lock) that matches the workspace lockfile to ensure package versions match.",
+        "default": false,
+        "x-priority": "internal"
       }
     },
     "required": ["main", "outputPath", "tsConfig"],

--- a/docs/generated/packages/js/executors/tsc.json
+++ b/docs/generated/packages/js/executors/tsc.json
@@ -116,6 +116,12 @@
         "items": { "type": "string" },
         "description": "List of target names that annotate a build target for a project",
         "default": ["build"]
+      },
+      "generateLockfile": {
+        "type": "boolean",
+        "description": "Generate a lockfile (e.g. yarn.lock) that matches the workspace lockfile to ensure package versions match.",
+        "default": false,
+        "x-priority": "internal"
       }
     },
     "required": ["main", "outputPath", "tsConfig"],

--- a/e2e/js/src/js-swc.test.ts
+++ b/e2e/js/src/js-swc.test.ts
@@ -3,10 +3,13 @@ import {
   checkFilesDoNotExist,
   checkFilesExist,
   cleanupProject,
+  detectPackageManager,
   newProject,
+  packageManagerLockFile,
   readJson,
   runCLI,
   runCLIAsync,
+  tmpProjPath,
   uniq,
   updateFile,
   updateJson,
@@ -79,6 +82,14 @@ describe('js e2e', () => {
     const output = runCLI(`build ${parentLib}`);
     expect(output).toContain('1 task it depends on');
     expect(output).toContain('Successfully compiled: 2 files with swc');
+
+    runCLI(`build ${parentLib} --generateLockfile=true`);
+    checkFilesExist(
+      `dist/libs/${parentLib}/package.json`,
+      `dist/libs/${parentLib}/${
+        packageManagerLockFile[detectPackageManager(tmpProjPath())]
+      }`
+    );
 
     updateJson(`libs/${lib}/.lib.swcrc`, (json) => {
       json.jsc.externalHelpers = true;

--- a/e2e/js/src/js-tsc.test.ts
+++ b/e2e/js/src/js-tsc.test.ts
@@ -3,6 +3,7 @@ import {
   checkFilesDoNotExist,
   checkFilesExist,
   cleanupProject,
+  detectPackageManager,
   getPackageManagerCommand,
   newProject,
   packageManagerLockFile,
@@ -12,6 +13,7 @@ import {
   runCLIAsync,
   runCommand,
   runCommandUntil,
+  tmpProjPath,
   uniq,
   updateFile,
   updateJson,
@@ -47,6 +49,14 @@ describe('js e2e', () => {
       `dist/libs/${lib}/src/lib/${lib}.js`,
       `dist/libs/${lib}/src/index.d.ts`,
       `dist/libs/${lib}/src/lib/${lib}.d.ts`
+    );
+
+    runCLI(`build ${lib} --generateLockfile=true`);
+    checkFilesExist(
+      `dist/libs/${lib}/package.json`,
+      `dist/libs/${lib}/${
+        packageManagerLockFile[detectPackageManager(tmpProjPath())]
+      }`
     );
 
     updateJson(`libs/${lib}/project.json`, (json) => {

--- a/e2e/js/src/js-tsc.test.ts
+++ b/e2e/js/src/js-tsc.test.ts
@@ -197,9 +197,10 @@ describe('package.json updates', () => {
     runCLI(`build ${lib}`);
 
     // Check that only 'react' exists, don't care about version
-    expect(readJson(`dist/libs/${lib}/package.json`).dependencies).toEqual({});
-    expect(readJson(`dist/libs/${lib}/package.json`).peerDependencies).toEqual({
+    expect(readJson(`dist/libs/${lib}/package.json`).dependencies).toEqual({
       react: expect.any(String),
+    });
+    expect(readJson(`dist/libs/${lib}/package.json`).peerDependencies).toEqual({
       tslib: expect.any(String),
     });
     checkFilesDoNotExist(`dist/libs/${lib}/${packageManagerLockFile['npm']}`);

--- a/packages/js/src/executors/swc/schema.json
+++ b/packages/js/src/executors/swc/schema.json
@@ -97,6 +97,12 @@
       },
       "description": "List of target names that annotate a build target for a project",
       "default": ["build"]
+    },
+    "generateLockfile": {
+      "type": "boolean",
+      "description": "Generate a lockfile (e.g. yarn.lock) that matches the workspace lockfile to ensure package versions match.",
+      "default": false,
+      "x-priority": "internal"
     }
   },
   "required": ["main", "outputPath", "tsConfig"],

--- a/packages/js/src/executors/tsc/schema.json
+++ b/packages/js/src/executors/tsc/schema.json
@@ -86,6 +86,12 @@
       },
       "description": "List of target names that annotate a build target for a project",
       "default": ["build"]
+    },
+    "generateLockfile": {
+      "type": "boolean",
+      "description": "Generate a lockfile (e.g. yarn.lock) that matches the workspace lockfile to ensure package versions match.",
+      "default": false,
+      "x-priority": "internal"
     }
   },
   "required": ["main", "outputPath", "tsConfig"],

--- a/packages/js/src/utils/package-json/update-package-json.ts
+++ b/packages/js/src/utils/package-json/update-package-json.ts
@@ -41,6 +41,7 @@ export interface UpdatePackageJsonOption {
   excludeLibsInPackageJson?: boolean;
   updateBuildableProjectDepsInPackageJson?: boolean;
   buildableProjectDepsInPackageJsonType?: 'dependencies' | 'peerDependencies';
+  generateLockfile?: boolean;
 }
 
 export function updatePackageJson(
@@ -84,10 +85,13 @@ export function updatePackageJson(
 
   // save files
   writeJsonFile(`${options.outputPath}/package.json`, packageJson);
-  const lockFile = createLockFile(packageJson);
-  writeFileSync(`${options.outputPath}/${getLockFileName()}`, lockFile, {
-    encoding: 'utf-8',
-  });
+
+  if (options.generateLockfile) {
+    const lockFile = createLockFile(packageJson);
+    writeFileSync(`${options.outputPath}/${getLockFileName()}`, lockFile, {
+      encoding: 'utf-8',
+    });
+  }
 }
 
 function addMissingDependencies(

--- a/packages/js/src/utils/package-json/update-package-json.ts
+++ b/packages/js/src/utils/package-json/update-package-json.ts
@@ -1,15 +1,20 @@
 import {
+  createLockFile,
+  createPackageJson,
   ExecutorContext,
+  getOutputsForTargetAndConfiguration,
+  joinPathFragments,
   normalizePath,
   ProjectGraphProjectNode,
   readJsonFile,
+  workspaceRoot,
   writeJsonFile,
 } from '@nrwl/devkit';
-import {
-  DependentBuildableProjectNode,
-  updateBuildableProjectPackageJsonDependencies,
-} from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+import { DependentBuildableProjectNode } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
 import { basename, dirname, join, parse, relative } from 'path';
+import { getLockFileName } from 'nx/src/lock-file/lock-file';
+import { writeFileSync } from 'fs-extra';
+import { isNpmProject } from 'nx/src/project-graph/operators';
 import { fileExists } from 'nx/src/utils/fileutils';
 import type { PackageJson } from 'nx/src/utils/package-json';
 
@@ -44,45 +49,104 @@ export function updatePackageJson(
   target: ProjectGraphProjectNode,
   dependencies: DependentBuildableProjectNode[]
 ): void {
-  const pathToPackageJson = join(
-    context.root,
-    options.projectRoot,
-    'package.json'
-  );
+  let packageJson: PackageJson;
 
-  const packageJson = fileExists(pathToPackageJson)
-    ? readJsonFile(pathToPackageJson)
-    : { name: context.projectName };
+  if (options.updateBuildableProjectDepsInPackageJson) {
+    packageJson = createPackageJson(context.projectName, context.projectGraph, {
+      root: context.root,
+      // By default we remove devDependencies since this is a production build.
+      isProduction: true,
+    });
 
-  if (options.excludeLibsInPackageJson) {
-    dependencies = dependencies.filter((dep) => dep.node.type !== 'lib');
-  }
+    if (options.excludeLibsInPackageJson) {
+      dependencies = dependencies.filter((dep) => dep.node.type !== 'lib');
+    }
 
-  writeJsonFile(
-    `${options.outputPath}/package.json`,
-    getUpdatedPackageJsonContent(packageJson, options)
-  );
-
-  if (
-    dependencies.length > 0 &&
-    options.updateBuildableProjectDepsInPackageJson
-  ) {
-    updateBuildableProjectPackageJsonDependencies(
-      context.root,
-      context.projectName,
-      context.targetName,
-      context.configurationName,
-      target,
+    addMissingDependencies(
+      packageJson,
+      context,
       dependencies,
       options.buildableProjectDepsInPackageJsonType
     );
+  } else {
+    const pathToPackageJson = join(
+      context.root,
+      options.projectRoot,
+      'package.json'
+    );
+    packageJson = fileExists(pathToPackageJson)
+      ? readJsonFile(pathToPackageJson)
+      : { name: context.projectName, version: '0.0.1' };
   }
+
+  // update package specific settings
+  packageJson = getUpdatedPackageJsonContent(packageJson, options);
+
+  // save files
+  writeJsonFile(`${options.outputPath}/package.json`, packageJson);
+  const lockFile = createLockFile(packageJson);
+  writeFileSync(`${options.outputPath}/${getLockFileName()}`, lockFile, {
+    encoding: 'utf-8',
+  });
+}
+
+function addMissingDependencies(
+  packageJson: PackageJson,
+  { projectName, targetName, configurationName, root }: ExecutorContext,
+  dependencies: DependentBuildableProjectNode[],
+  propType: 'dependencies' | 'peerDependencies' = 'dependencies'
+) {
+  const workspacePackageJson = readJsonFile(
+    joinPathFragments(workspaceRoot, 'package.json')
+  );
+  dependencies.forEach((entry) => {
+    if (isNpmProject(entry.node)) {
+      const { packageName, version } = entry.node.data;
+      if (
+        packageJson.dependencies?.[packageName] ||
+        packageJson.devDependencies?.[packageName] ||
+        packageJson.peerDependencies?.[packageName]
+      ) {
+        return;
+      }
+      if (workspacePackageJson.devDependencies?.[packageName]) {
+        return;
+      }
+
+      packageJson[propType] ??= {};
+      packageJson[propType][packageName] = version;
+    } else {
+      const packageName = entry.name;
+      if (
+        !packageJson.dependencies?.[packageName] &&
+        !packageJson.peerDependencies?.[packageName]
+      ) {
+        const outputs = getOutputsForTargetAndConfiguration(
+          {
+            overrides: {},
+            target: {
+              project: projectName,
+              target: targetName,
+              configuration: configurationName,
+            },
+          },
+          entry.node
+        );
+
+        const depPackageJsonPath = join(root, outputs[0], 'package.json');
+        const version = readJsonFile(depPackageJsonPath).version;
+
+        packageJson[propType] ??= {};
+        packageJson[propType][packageName] = version;
+      }
+    }
+  });
 }
 
 export function getUpdatedPackageJsonContent(
   packageJson: PackageJson,
   options: UpdatePackageJsonOption
-) {
+): PackageJson {
   // Default is CJS unless esm is explicitly passed.
   const hasCjsFormat = !options.format || options.format?.includes('cjs');
   const hasEsmFormat = options.format?.includes('esm');

--- a/packages/js/src/utils/schema.d.ts
+++ b/packages/js/src/utils/schema.d.ts
@@ -47,6 +47,7 @@ export interface ExecutorOptions {
   buildableProjectDepsInPackageJsonType?: 'dependencies' | 'peerDependencies';
   external?: 'all' | 'none' | string[];
   externalBuildTargets?: string[];
+  generateLockfile?: boolean;
 }
 
 export interface NormalizedExecutorOptions extends ExecutorOptions {


### PR DESCRIPTION
This is a rework of the functionality that was reverted in the https://github.com/nrwl/nx/pull/13962.

The check for `updateBuildableProjectDepsInPackageJson` is now pushed earlier to ensure we don't override the existing `package.json` with `createPackageJson`.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
