### PR TITLE
fix(vite): improve vite configuration

### DIFF
--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -941,7 +941,10 @@ describe('app', () => {
 
     it('should create correct tsconfig compilerOptions', () => {
       const tsconfigJson = readJson(viteAppTree, '/apps/my-app/tsconfig.json');
-      expect(tsconfigJson.compilerOptions.types).toMatchObject(['vite/client']);
+      expect(tsconfigJson.compilerOptions.types).toMatchObject([
+        'vite/client',
+        'vitest',
+      ]);
     });
 
     it('should create index.html and vite.config file at the root of the app', () => {

--- a/packages/react/src/utils/create-ts-config.ts
+++ b/packages/react/src/utils/create-ts-config.ts
@@ -11,6 +11,7 @@ export function createTsConfig(
     style?: string;
     bundler?: string;
     rootProject?: boolean;
+    unitTestRunner?: string;
   },
   relativePathToRootTsConfig: string
 ) {
@@ -36,7 +37,10 @@ export function createTsConfig(
   }
 
   if (options.bundler === 'vite') {
-    json.compilerOptions.types = ['vite/client'];
+    json.compilerOptions.types =
+      options.unitTestRunner === 'vitest'
+        ? ['vite/client', 'vitest']
+        : ['vite/client'];
   }
 
   // inline tsconfig.base.json into the project

--- a/packages/storybook/src/generators/configuration/configuration-nested.spec.ts
+++ b/packages/storybook/src/generators/configuration/configuration-nested.spec.ts
@@ -36,7 +36,7 @@ describe('@nrwl/storybook:configuration for workspaces with Root project', () =>
           skipLibCheck: true,
           strict: true,
           target: 'ESNext',
-          types: ['vite/client'],
+          types: ['vite/client', 'vitest'],
           useDefineForClassFields: true,
           noImplicitOverride: true,
           noPropertyAccessFromIndexSignature: true,

--- a/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`@nrwl/vite:configuration library mode should add config for building library 1`] = `
 "
-      
       import { defineConfig } from 'vite';
       import react from '@vitejs/plugin-react';
       import viteTsConfigPaths from 'vite-tsconfig-paths';
@@ -49,7 +48,6 @@ import { join } from 'path';
 
 exports[`@nrwl/vite:configuration library mode should set up non buildable library correctly 1`] = `
 "
-      /// <reference types=\\"vitest\\" />
       import { defineConfig } from 'vite';
       import react from '@vitejs/plugin-react';
       import viteTsConfigPaths from 'vite-tsconfig-paths';
@@ -295,7 +293,8 @@ exports[`@nrwl/vite:configuration transform React app to use Vite by providing c
           \\"builder\\": \\"@nrwl/vite:dev-server\\",
           \\"defaultConfiguration\\": \\"development\\",
           \\"options\\": {
-            \\"buildTarget\\": \\"my-test-mixed-react-app:build\\"
+            \\"buildTarget\\": \\"my-test-mixed-react-app:build\\",
+            \\"hmr\\": true
           },
           \\"configurations\\": {
             \\"development\\": {
@@ -339,7 +338,6 @@ exports[`@nrwl/vite:configuration transform React app to use Vite by providing c
 
 exports[`@nrwl/vite:configuration transform React app to use Vite should create vite.config file at the root of the app 1`] = `
 "
-      
       import { defineConfig } from 'vite';
       import react from '@vitejs/plugin-react';
       import viteTsConfigPaths from 'vite-tsconfig-paths';
@@ -429,7 +427,8 @@ exports[`@nrwl/vite:configuration transform React app to use Vite should transfo
           \\"builder\\": \\"@nrwl/vite:dev-server\\",
           \\"defaultConfiguration\\": \\"development\\",
           \\"options\\": {
-            \\"buildTarget\\": \\"my-test-react-app:build\\"
+            \\"buildTarget\\": \\"my-test-react-app:build\\",
+            \\"hmr\\": true
           },
           \\"configurations\\": {
             \\"development\\": {
@@ -473,7 +472,6 @@ exports[`@nrwl/vite:configuration transform React app to use Vite should transfo
 
 exports[`@nrwl/vite:configuration transform Web app to use Vite should create vite.config file at the root of the app 1`] = `
 "
-      
       import { defineConfig } from 'vite';
       
       import viteTsConfigPaths from 'vite-tsconfig-paths';
@@ -597,7 +595,6 @@ exports[`@nrwl/vite:configuration transform Web app to use Vite should transform
 
 exports[`@nrwl/vite:configuration vitest should create a vitest configuration if "includeVitest" is true 1`] = `
 "
-      /// <reference types=\\"vitest\\" />
       import { defineConfig } from 'vite';
       import react from '@vitejs/plugin-react';
       import viteTsConfigPaths from 'vite-tsconfig-paths';

--- a/packages/vite/src/generators/vitest/__snapshots__/vitest.spec.ts.snap
+++ b/packages/vite/src/generators/vitest/__snapshots__/vitest.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`vitest generator insourceTests should add the insourceSource option in the vite config 1`] = `
 "
-      /// <reference types=\\"vitest\\" />
       import { defineConfig } from 'vite';
       import react from '@vitejs/plugin-react';
       import viteTsConfigPaths from 'vite-tsconfig-paths';
@@ -37,7 +36,6 @@ exports[`vitest generator insourceTests should add the insourceSource option in 
 
 exports[`vitest generator vite.config should create correct vite.config.ts file for apps 1`] = `
 "
-      /// <reference types=\\"vitest\\" />
       import { defineConfig } from 'vite';
       import react from '@vitejs/plugin-react';
       import viteTsConfigPaths from 'vite-tsconfig-paths';
@@ -70,7 +68,6 @@ exports[`vitest generator vite.config should create correct vite.config.ts file 
 
 exports[`vitest generator vite.config should create correct vite.config.ts file for non buildable libs 1`] = `
 "
-      /// <reference types=\\"vitest\\" />
       import { defineConfig } from 'vite';
       import react from '@vitejs/plugin-react';
       import viteTsConfigPaths from 'vite-tsconfig-paths';

--- a/packages/vite/src/generators/vitest/vitest-generator.ts
+++ b/packages/vite/src/generators/vitest/vitest-generator.ts
@@ -96,6 +96,17 @@ function updateTsConfig(
         path: './tsconfig.spec.json',
       });
     }
+
+    if (!json.compilerOptions?.types?.includes('vitest')) {
+      if (json.compilerOptions?.types) {
+        json.compilerOptions.types.push('vitest');
+      } else {
+        if (!json.compilerOptions) {
+          json.compilerOptions = {};
+        }
+        json.compilerOptions.types = ['vitest'];
+      }
+    }
     return json;
   });
 

--- a/packages/vite/src/utils/__snapshots__/vite-config-edit-utils.spec.ts.snap
+++ b/packages/vite/src/utils/__snapshots__/vite-config-edit-utils.spec.ts.snap
@@ -1,6 +1,54 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`generator utils ensureBuildOptionsInViteConfig should add build options if build options don't exist 1`] = `
+exports[`ensureBuildOptionsInViteConfig should add build and test options if defineConfig is empty 1`] = `
+"import dts from 'vite-plugin-dts';
+import { join } from 'path';
+
+    import { defineConfig } from 'vite';
+    import react from '@vitejs/plugin-react';
+    import viteTsConfigPaths from 'vite-tsconfig-paths';
+
+    export default defineConfig({
+    
+    // Configuration for building your library.
+    // See: https://vitejs.dev/guide/build.html#library-mode
+    build: {
+      lib: {
+        // Could also be a dictionary or array of multiple entry points.
+        entry: 'src/index.ts',
+        name: 'my-app',
+        fileName: 'index',
+        // Change this to the formats you want to support.
+        // Don't forgot to update your package.json as well.
+        formats: ['es', 'cjs']
+      },
+      rollupOptions: {
+        // External packages that should not be bundled into your library.
+        external: [\\"'react', 'react-dom', 'react/jsx-runtime'\\"]
+      }
+    },plugins: [
+      dts({
+      tsConfigFilePath: join(__dirname, 'tsconfig.lib.json'),
+      // Faster builds by skipping tests. Set this to false to enable type checking.
+      skipDiagnostics: true,
+    }),
+      react(),
+      viteTsConfigPaths({
+        root: '../../',
+      }),
+    ],
+    test: {
+        globals: true,
+        cache: {
+          dir: '../node_modules/.vitest'
+        },
+        environment: 'jsdom',
+        include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    },});
+    "
+`;
+
+exports[`ensureBuildOptionsInViteConfig should add build option but not update test option if test already setup 1`] = `
 "import dts from 'vite-plugin-dts';
 import { join } from 'path';
 import { defineConfig } from 'vite';
@@ -52,16 +100,15 @@ import { defineConfig } from 'vite';
     "
 `;
 
-exports[`generator utils ensureBuildOptionsInViteConfig should add build options if defineConfig is empty 1`] = `
+exports[`ensureBuildOptionsInViteConfig should add build options if build options don't exist 1`] = `
 "import dts from 'vite-plugin-dts';
 import { join } from 'path';
-
-    import { defineConfig } from 'vite';
+import { defineConfig } from 'vite';
     import react from '@vitejs/plugin-react';
     import viteTsConfigPaths from 'vite-tsconfig-paths';
 
     export default defineConfig({
-    
+      
     // Configuration for building your library.
     // See: https://vitejs.dev/guide/build.html#library-mode
     build: {
@@ -79,21 +126,33 @@ import { join } from 'path';
         external: [\\"'react', 'react-dom', 'react/jsx-runtime'\\"]
       }
     },plugins: [
-      dts({
+                    ...[
+        react(),
+        viteTsConfigPaths({
+          root: '../../',
+        }),
+      ],
+                    dts({
       tsConfigFilePath: join(__dirname, 'tsconfig.lib.json'),
       // Faster builds by skipping tests. Set this to false to enable type checking.
       skipDiagnostics: true,
     }),
-      react(),
-      viteTsConfigPaths({
-        root: '../../',
-      }),
-    ],
+                ],
+
+      test: {
+        globals: true,
+        cache: {
+          dir: '../../node_modules/.vitest',
+        },
+        environment: 'jsdom',
+        include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+      },
+
     });
     "
 `;
 
-exports[`generator utils ensureBuildOptionsInViteConfig should add build options if defineConfig is not used 1`] = `
+exports[`ensureBuildOptionsInViteConfig should add build options if defineConfig is not used 1`] = `
 "import dts from 'vite-plugin-dts';
 import { join } from 'path';
 import { defineConfig } from 'vite';
@@ -117,6 +176,13 @@ import { defineConfig } from 'vite';
         // External packages that should not be bundled into your library.
         external: [\\"'react', 'react-dom', 'react/jsx-runtime'\\"]
       }
+    },test: {
+        globals: true,
+        cache: {
+          dir: '../node_modules/.vitest'
+        },
+        environment: 'jsdom',
+        include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     },
       plugins: [
                     ...[
@@ -135,7 +201,7 @@ import { defineConfig } from 'vite';
     "
 `;
 
-exports[`generator utils ensureBuildOptionsInViteConfig should add build options if it is using conditional config 1`] = `
+exports[`ensureBuildOptionsInViteConfig should add build options if it is using conditional config - do nothing for test 1`] = `
 "
     import { defineConfig } from 'vite';
     export default defineConfig(({ command, mode, ssrBuild }) => {
@@ -157,7 +223,7 @@ exports[`generator utils ensureBuildOptionsInViteConfig should add build options
     "
 `;
 
-exports[`generator utils ensureBuildOptionsInViteConfig should add new build options if some build options already exist 1`] = `
+exports[`ensureBuildOptionsInViteConfig should add new build options if some build options already exist 1`] = `
 "import dts from 'vite-plugin-dts';
 import { join } from 'path';
 import { defineConfig } from 'vite';
@@ -199,4 +265,93 @@ import { defineConfig } from 'vite';
     "
 `;
 
-exports[`generator utils ensureBuildOptionsInViteConfig should not do anything if cannot understand syntax of vite config 1`] = `"console.log('Unknown syntax')"`;
+exports[`ensureBuildOptionsInViteConfig should not do anything if cannot understand syntax of vite config 1`] = `"console.log('Unknown syntax')"`;
+
+exports[`ensureBuildOptionsInViteConfig should not do anything if project has everything setup already 1`] = `
+"
+    import { defineConfig } from 'vite';
+    import react from '@vitejs/plugin-react';
+    import viteTsConfigPaths from 'vite-tsconfig-paths';
+
+    export default defineConfig({
+      plugins: [
+        dts({
+          tsConfigFilePath: join(__dirname, 'tsconfig.lib.json'),
+          // Faster builds by skipping tests. Set this to false to enable type checking.
+          skipDiagnostics: true,
+        }),
+        react(),
+        viteTsConfigPaths({
+          root: '../../../',
+        }),
+      ],
+    
+      // Configuration for building your library.
+      // See: https://vitejs.dev/guide/build.html#library-mode
+      build: {
+        lib: {
+          // Could also be a dictionary or array of multiple entry points.
+          entry: 'src/index.ts',
+          name: 'pure-libs-react-vite',
+          fileName: 'index',
+          // Change this to the formats you want to support.
+          // Don't forgot to update your package.json as well.
+          formats: ['es', 'cjs'],
+        },
+        rollupOptions: {
+          // External packages that should not be bundled into your library.
+          external: ['react', 'react-dom', 'react/jsx-runtime'],
+        },
+      },
+    
+      test: {
+        globals: true,
+        cache: {
+          dir: '../../../node_modules/.vitest',
+        },
+        environment: 'jsdom',
+        include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+      },
+    });
+    "
+`;
+
+exports[`ensureBuildOptionsInViteConfig should update both test and build options - keep existing settings 1`] = `
+"import dts from 'vite-plugin-dts';
+import { join } from 'path';
+import { defineConfig } from 'vite';
+    import react from '@vitejs/plugin-react';
+    import viteTsConfigPaths from 'vite-tsconfig-paths';
+
+    export default defineConfig({
+      plugins: [
+                    ...[
+        react(),
+        viteTsConfigPaths({
+          root: '../../',
+        }),
+      ],
+                    dts({
+      tsConfigFilePath: join(__dirname, 'tsconfig.lib.json'),
+      // Faster builds by skipping tests. Set this to false to enable type checking.
+      skipDiagnostics: true,
+    }),
+                ],
+
+      test: {
+                  ...{
+        my: 'option',
+      },
+                  ...{\\"globals\\":true,\\"cache\\":{\\"dir\\":\\"../node_modules/.vitest\\"},\\"environment\\":\\"jsdom\\",\\"include\\":[\\"src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}\\"]}
+               },
+
+      build: {
+                  ...{
+        my: 'option',
+      },
+                  ...{\\"lib\\":{\\"entry\\":\\"src/index.ts\\",\\"name\\":\\"my-app\\",\\"fileName\\":\\"index\\",\\"formats\\":[\\"es\\",\\"cjs\\"]},\\"rollupOptions\\":{\\"external\\":[\\"'react', 'react-dom', 'react/jsx-runtime'\\"]}}
+               }
+
+    });
+    "
+`;

--- a/packages/vite/src/utils/test-files/test-vite-configs.ts
+++ b/packages/vite/src/utils/test-files/test-vite-configs.ts
@@ -1,0 +1,254 @@
+export const noBuildOptions = `
+    import { defineConfig } from 'vite';
+    import react from '@vitejs/plugin-react';
+    import viteTsConfigPaths from 'vite-tsconfig-paths';
+
+    export default defineConfig({
+      plugins: [
+        react(),
+        viteTsConfigPaths({
+          root: '../../',
+        }),
+      ],
+
+      test: {
+        globals: true,
+        cache: {
+          dir: '../../node_modules/.vitest',
+        },
+        environment: 'jsdom',
+        include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+      },
+
+    });
+    `;
+
+export const someBuildOptions = `
+    import { defineConfig } from 'vite';
+    import react from '@vitejs/plugin-react';
+    import viteTsConfigPaths from 'vite-tsconfig-paths';
+
+    export default defineConfig({
+      plugins: [
+        react(),
+        viteTsConfigPaths({
+          root: '../../',
+        }),
+      ],
+
+      test: {
+        globals: true,
+        cache: {
+          dir: '../../node_modules/.vitest',
+        },
+        environment: 'jsdom',
+        include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+      },
+
+      build: {
+        my: 'option',
+      }
+
+    });
+    `;
+
+export const noContentDefineConfig = `
+    import { defineConfig } from 'vite';
+    import react from '@vitejs/plugin-react';
+    import viteTsConfigPaths from 'vite-tsconfig-paths';
+
+    export default defineConfig({});
+    `;
+
+export const conditionalConfig = `
+    import { defineConfig } from 'vite';
+    export default defineConfig(({ command, mode, ssrBuild }) => {
+      if (command === 'serve') {
+        return {
+          port: 4200,
+          host: 'localhost',
+        }
+      } else {
+        // command === 'build'
+        return {
+          my: 'option',
+        }
+      }
+    })
+    `;
+
+export const configNoDefineConfig = `
+    import { defineConfig } from 'vite';
+    import react from '@vitejs/plugin-react';
+    import viteTsConfigPaths from 'vite-tsconfig-paths';
+
+    export default {
+      plugins: [
+        react(),
+        viteTsConfigPaths({
+          root: '../../',
+        }),
+      ],
+    };
+    `;
+
+export const noBuildOptionsHasTestOption = `
+    import { defineConfig } from 'vite';
+    import react from '@vitejs/plugin-react';
+    import viteTsConfigPaths from 'vite-tsconfig-paths';
+
+    export default defineConfig({
+      plugins: [
+        react(),
+        viteTsConfigPaths({
+          root: '../../',
+        }),
+      ],
+
+      test: {
+        globals: true,
+        cache: {
+          dir: '../../node_modules/.vitest',
+        },
+        environment: 'jsdom',
+        include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+      },
+
+    });
+    `;
+
+export const someBuildOptionsSomeTestOption = `
+    import { defineConfig } from 'vite';
+    import react from '@vitejs/plugin-react';
+    import viteTsConfigPaths from 'vite-tsconfig-paths';
+
+    export default defineConfig({
+      plugins: [
+        react(),
+        viteTsConfigPaths({
+          root: '../../',
+        }),
+      ],
+
+      test: {
+        my: 'option',
+      },
+
+      build: {
+        my: 'option',
+      }
+
+    });
+    `;
+
+export const hasEverything = `
+    import { defineConfig } from 'vite';
+    import react from '@vitejs/plugin-react';
+    import viteTsConfigPaths from 'vite-tsconfig-paths';
+
+    export default defineConfig({
+      plugins: [
+        dts({
+          tsConfigFilePath: join(__dirname, 'tsconfig.lib.json'),
+          // Faster builds by skipping tests. Set this to false to enable type checking.
+          skipDiagnostics: true,
+        }),
+        react(),
+        viteTsConfigPaths({
+          root: '../../../',
+        }),
+      ],
+    
+      // Configuration for building your library.
+      // See: https://vitejs.dev/guide/build.html#library-mode
+      build: {
+        lib: {
+          // Could also be a dictionary or array of multiple entry points.
+          entry: 'src/index.ts',
+          name: 'pure-libs-react-vite',
+          fileName: 'index',
+          // Change this to the formats you want to support.
+          // Don't forgot to update your package.json as well.
+          formats: ['es', 'cjs'],
+        },
+        rollupOptions: {
+          // External packages that should not be bundled into your library.
+          external: ['react', 'react-dom', 'react/jsx-runtime'],
+        },
+      },
+    
+      test: {
+        globals: true,
+        cache: {
+          dir: '../../../node_modules/.vitest',
+        },
+        environment: 'jsdom',
+        include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+      },
+    });
+    `;
+
+export const buildOption = `
+    // Configuration for building your library.
+    // See: https://vitejs.dev/guide/build.html#library-mode
+    build: {
+      lib: {
+        // Could also be a dictionary or array of multiple entry points.
+        entry: 'src/index.ts',
+        name: 'my-app',
+        fileName: 'index',
+        // Change this to the formats you want to support.
+        // Don't forgot to update your package.json as well.
+        formats: ['es', 'cjs']
+      },
+      rollupOptions: {
+        // External packages that should not be bundled into your library.
+        external: ["'react', 'react-dom', 'react/jsx-runtime'"]
+      }
+    },`;
+export const buildOptionObject = {
+  lib: {
+    entry: 'src/index.ts',
+    name: 'my-app',
+    fileName: 'index',
+    formats: ['es', 'cjs'],
+  },
+  rollupOptions: {
+    external: ["'react', 'react-dom', 'react/jsx-runtime'"],
+  },
+};
+
+export const testOption = `test: {
+        globals: true,
+        cache: {
+          dir: '../node_modules/.vitest'
+        },
+        environment: 'jsdom',
+        include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    },`;
+
+export const testOptionObject = {
+  globals: true,
+  cache: {
+    dir: `../node_modules/.vitest`,
+  },
+  environment: 'jsdom',
+  include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+};
+
+export const dtsPlugin = `dts({
+      tsConfigFilePath: join(__dirname, 'tsconfig.lib.json'),
+      // Faster builds by skipping tests. Set this to false to enable type checking.
+      skipDiagnostics: true,
+    }),`;
+export const dtsImportLine = `import dts from 'vite-plugin-dts';\nimport { join } from 'path';`;
+
+export const pluginOption = `
+    plugins: [
+      ${dtsPlugin}
+      react(),
+      viteTsConfigPaths({
+        root: '../../',
+      }),
+    ],
+    `;

--- a/packages/vite/src/utils/test-utils.ts
+++ b/packages/vite/src/utils/test-utils.ts
@@ -1,4 +1,4 @@
-import { parseJson, Tree, writeJson } from '@nrwl/devkit';
+import { Tree, writeJson } from '@nrwl/devkit';
 import * as reactAppConfig from './test-files/react-project.config.json';
 import * as reactViteConfig from './test-files/react-vite-project.config.json';
 import * as webAppConfig from './test-files/web-project.config.json';
@@ -90,8 +90,7 @@ export function mockViteReactAppGenerator(tree: Tree): Tree {
 
   tree.write(
     `apps/${appName}/vite.config.ts`,
-    `/// <reference types="vitest" />
-    import { defineConfig } from 'vite';
+    `import { defineConfig } from 'vite';
     import react from '@vitejs/plugin-react';
     import tsconfigPaths from 'vite-tsconfig-paths';
     
@@ -534,9 +533,7 @@ export function mockReactLibNonBuildableVitestRunnerGenerator(
 
   tree.write(
     `libs/${libName}/vite.config.ts`,
-    `
-    /// <reference types="vitest" />
-    import { defineConfig } from 'vite';
+    `import { defineConfig } from 'vite';
     import react from '@vitejs/plugin-react';
     import viteTsConfigPaths from 'vite-tsconfig-paths';
 

--- a/packages/vite/src/utils/vite-config-edit-utils.spec.ts
+++ b/packages/vite/src/utils/vite-config-edit-utils.spec.ts
@@ -1,281 +1,221 @@
 import { Tree } from '@nrwl/devkit';
 import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { tsquery } from '@phenomnomnominal/tsquery';
-
+import {
+  buildOption,
+  buildOptionObject,
+  conditionalConfig,
+  configNoDefineConfig,
+  dtsImportLine,
+  dtsPlugin,
+  hasEverything,
+  noBuildOptions,
+  noBuildOptionsHasTestOption,
+  noContentDefineConfig,
+  pluginOption,
+  someBuildOptions,
+  someBuildOptionsSomeTestOption,
+  testOption,
+  testOptionObject,
+} from './test-files/test-vite-configs';
 import { ensureBuildOptionsInViteConfig } from './vite-config-edit-utils';
 
-describe('generator utils', () => {
+describe('ensureBuildOptionsInViteConfig', () => {
   let tree: Tree;
 
   beforeEach(() => {
     tree = createTreeWithEmptyV1Workspace();
   });
 
-  describe('ensureBuildOptionsInViteConfig', () => {
-    let tree: Tree;
+  it("should add build options if build options don't exist", () => {
+    tree.write('apps/my-app/vite.config.ts', noBuildOptions);
+    ensureBuildOptionsInViteConfig(
+      tree,
+      'apps/my-app/vite.config.ts',
+      buildOption,
+      buildOptionObject,
+      dtsPlugin,
+      dtsImportLine,
+      pluginOption,
+      testOption,
+      testOptionObject,
+      { build: false, test: true, serve: false }
+    );
+    const appFileContent = tree.read('apps/my-app/vite.config.ts', 'utf-8');
+    const file = tsquery.ast(appFileContent);
+    const buildNode = tsquery.query(
+      file,
+      'PropertyAssignment:has(Identifier[name="build"])'
+    );
+    expect(buildNode).toBeDefined();
+    expect(appFileContent).toMatchSnapshot();
+  });
 
-    const buildOption = `
-    // Configuration for building your library.
-    // See: https://vitejs.dev/guide/build.html#library-mode
-    build: {
-      lib: {
-        // Could also be a dictionary or array of multiple entry points.
-        entry: 'src/index.ts',
-        name: 'my-app',
-        fileName: 'index',
-        // Change this to the formats you want to support.
-        // Don't forgot to update your package.json as well.
-        formats: ['es', 'cjs']
-      },
-      rollupOptions: {
-        // External packages that should not be bundled into your library.
-        external: ["'react', 'react-dom', 'react/jsx-runtime'"]
-      }
-    },`;
-    const buildOptionObject = {
-      lib: {
-        entry: 'src/index.ts',
-        name: 'my-app',
-        fileName: 'index',
-        formats: ['es', 'cjs'],
-      },
-      rollupOptions: {
-        external: ["'react', 'react-dom', 'react/jsx-runtime'"],
-      },
-    };
-    const dtsPlugin = `dts({
-      tsConfigFilePath: join(__dirname, 'tsconfig.lib.json'),
-      // Faster builds by skipping tests. Set this to false to enable type checking.
-      skipDiagnostics: true,
-    }),`;
-    const dtsImportLine = `import dts from 'vite-plugin-dts';\nimport { join } from 'path';`;
+  it('should add new build options if some build options already exist', () => {
+    tree.write('apps/my-app/vite.config.ts', someBuildOptions);
+    ensureBuildOptionsInViteConfig(
+      tree,
+      'apps/my-app/vite.config.ts',
+      buildOption,
+      buildOptionObject,
+      dtsPlugin,
+      dtsImportLine,
+      pluginOption,
+      testOption,
+      testOptionObject,
+      { build: false, test: true, serve: false }
+    );
+    const appFileContent = tree.read('apps/my-app/vite.config.ts', 'utf-8');
+    const file = tsquery.ast(appFileContent);
+    const buildNode = tsquery.query(
+      file,
+      'PropertyAssignment:has(Identifier[name="build"])'
+    );
+    expect(buildNode).toBeDefined();
+    expect(appFileContent).toMatchSnapshot();
+  });
 
-    const pluginOption = `
-    plugins: [
-      ${dtsPlugin}
-      react(),
-      viteTsConfigPaths({
-        root: '../../',
-      }),
-    ],
-    `;
+  it('should add build and test options if defineConfig is empty', () => {
+    tree.write('apps/my-app/vite.config.ts', noContentDefineConfig);
+    ensureBuildOptionsInViteConfig(
+      tree,
+      'apps/my-app/vite.config.ts',
+      buildOption,
+      buildOptionObject,
+      dtsPlugin,
+      dtsImportLine,
+      pluginOption,
+      testOption,
+      testOptionObject,
+      { build: false, test: false, serve: false }
+    );
+    const appFileContent = tree.read('apps/my-app/vite.config.ts', 'utf-8');
+    const file = tsquery.ast(appFileContent);
+    const buildNode = tsquery.query(
+      file,
+      'PropertyAssignment:has(Identifier[name="build"])'
+    );
+    expect(buildNode).toBeDefined();
+    expect(appFileContent).toMatchSnapshot();
+  });
 
-    const noBuildOptions = `
-    import { defineConfig } from 'vite';
-    import react from '@vitejs/plugin-react';
-    import viteTsConfigPaths from 'vite-tsconfig-paths';
+  it('should add build options if it is using conditional config - do nothing for test', () => {
+    tree.write('apps/my-app/vite.config.ts', conditionalConfig);
+    ensureBuildOptionsInViteConfig(
+      tree,
+      'apps/my-app/vite.config.ts',
+      buildOption,
+      buildOptionObject,
+      dtsPlugin,
+      dtsImportLine,
+      pluginOption,
+      testOption,
+      testOptionObject,
+      { build: false, test: false, serve: false }
+    );
+    const appFileContent = tree.read('apps/my-app/vite.config.ts', 'utf-8');
+    const file = tsquery.ast(appFileContent);
+    const buildNode = tsquery.query(
+      file,
+      'PropertyAssignment:has(Identifier[name="build"])'
+    );
+    expect(buildNode).toBeDefined();
+    expect(appFileContent).toMatchSnapshot();
+  });
 
-    export default defineConfig({
-      plugins: [
-        react(),
-        viteTsConfigPaths({
-          root: '../../',
-        }),
-      ],
+  it('should add build options if defineConfig is not used', () => {
+    tree.write('apps/my-app/vite.config.ts', configNoDefineConfig);
+    ensureBuildOptionsInViteConfig(
+      tree,
+      'apps/my-app/vite.config.ts',
+      buildOption,
+      buildOptionObject,
+      dtsPlugin,
+      dtsImportLine,
+      pluginOption,
+      testOption,
+      testOptionObject,
+      { build: false, test: false, serve: false }
+    );
+    const appFileContent = tree.read('apps/my-app/vite.config.ts', 'utf-8');
+    const file = tsquery.ast(appFileContent);
+    const buildNode = tsquery.query(
+      file,
+      'PropertyAssignment:has(Identifier[name="build"])'
+    );
+    expect(buildNode).toBeDefined();
+    expect(appFileContent).toMatchSnapshot();
+  });
 
-      test: {
-        globals: true,
-        cache: {
-          dir: '../../node_modules/.vitest',
-        },
-        environment: 'jsdom',
-        include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
-      },
+  it('should not do anything if cannot understand syntax of vite config', () => {
+    tree.write('apps/my-app/vite.config.ts', `console.log('Unknown syntax')`);
+    ensureBuildOptionsInViteConfig(
+      tree,
+      'apps/my-app/vite.config.ts',
+      buildOption,
+      buildOptionObject,
+      dtsPlugin,
+      dtsImportLine,
+      pluginOption,
+      testOption,
+      testOptionObject,
+      { build: false, test: false, serve: false }
+    );
+    const appFileContent = tree.read('apps/my-app/vite.config.ts', 'utf-8');
+    expect(appFileContent).toMatchSnapshot();
+  });
 
-    });
-    `;
+  it('should not do anything if project has everything setup already', () => {
+    tree.write('apps/my-app/vite.config.ts', hasEverything);
+    ensureBuildOptionsInViteConfig(
+      tree,
+      'apps/my-app/vite.config.ts',
+      buildOption,
+      buildOptionObject,
+      dtsPlugin,
+      dtsImportLine,
+      pluginOption,
+      testOption,
+      testOptionObject,
+      { build: true, test: true, serve: true }
+    );
+    const appFileContent = tree.read('apps/my-app/vite.config.ts', 'utf-8');
+    expect(appFileContent).toMatchSnapshot();
+  });
 
-    const someBuildOptions = `
-    import { defineConfig } from 'vite';
-    import react from '@vitejs/plugin-react';
-    import viteTsConfigPaths from 'vite-tsconfig-paths';
+  it('should add build option but not update test option if test already setup', () => {
+    tree.write('apps/my-app/vite.config.ts', noBuildOptionsHasTestOption);
+    ensureBuildOptionsInViteConfig(
+      tree,
+      'apps/my-app/vite.config.ts',
+      buildOption,
+      buildOptionObject,
+      dtsPlugin,
+      dtsImportLine,
+      pluginOption,
+      testOption,
+      testOptionObject,
+      { build: false, test: true, serve: true }
+    );
+    const appFileContent = tree.read('apps/my-app/vite.config.ts', 'utf-8');
+    expect(appFileContent).toMatchSnapshot();
+  });
 
-    export default defineConfig({
-      plugins: [
-        react(),
-        viteTsConfigPaths({
-          root: '../../',
-        }),
-      ],
-
-      test: {
-        globals: true,
-        cache: {
-          dir: '../../node_modules/.vitest',
-        },
-        environment: 'jsdom',
-        include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
-      },
-
-      build: {
-        my: 'option',
-      }
-
-    });
-    `;
-
-    const noContentDefineConfig = `
-    import { defineConfig } from 'vite';
-    import react from '@vitejs/plugin-react';
-    import viteTsConfigPaths from 'vite-tsconfig-paths';
-
-    export default defineConfig({});
-    `;
-
-    const conditionalConfig = `
-    import { defineConfig } from 'vite';
-    export default defineConfig(({ command, mode, ssrBuild }) => {
-      if (command === 'serve') {
-        return {
-          port: 4200,
-          host: 'localhost',
-        }
-      } else {
-        // command === 'build'
-        return {
-          my: 'option',
-        }
-      }
-    })
-    `;
-
-    const configNoDefineConfig = `
-    import { defineConfig } from 'vite';
-    import react from '@vitejs/plugin-react';
-    import viteTsConfigPaths from 'vite-tsconfig-paths';
-
-    export default {
-      plugins: [
-        react(),
-        viteTsConfigPaths({
-          root: '../../',
-        }),
-      ],
-    };
-    `;
-
-    beforeEach(() => {
-      tree = createTreeWithEmptyV1Workspace();
-    });
-
-    it("should add build options if build options don't exist", () => {
-      tree.write('apps/my-app/vite.config.ts', noBuildOptions);
-      ensureBuildOptionsInViteConfig(
-        tree,
-        'apps/my-app/vite.config.ts',
-        buildOption,
-        buildOptionObject,
-        dtsPlugin,
-        dtsImportLine,
-        pluginOption
-      );
-      const appFileContent = tree.read('apps/my-app/vite.config.ts', 'utf-8');
-      const file = tsquery.ast(appFileContent);
-      const buildNode = tsquery.query(
-        file,
-        'PropertyAssignment:has(Identifier[name="build"])'
-      );
-      expect(buildNode).toBeDefined();
-      expect(appFileContent).toMatchSnapshot();
-    });
-
-    it('should add new build options if some build options already exist', () => {
-      tree.write('apps/my-app/vite.config.ts', someBuildOptions);
-      ensureBuildOptionsInViteConfig(
-        tree,
-        'apps/my-app/vite.config.ts',
-        buildOption,
-        buildOptionObject,
-        dtsPlugin,
-        dtsImportLine,
-        pluginOption
-      );
-      const appFileContent = tree.read('apps/my-app/vite.config.ts', 'utf-8');
-      const file = tsquery.ast(appFileContent);
-      const buildNode = tsquery.query(
-        file,
-        'PropertyAssignment:has(Identifier[name="build"])'
-      );
-      expect(buildNode).toBeDefined();
-      expect(appFileContent).toMatchSnapshot();
-    });
-
-    it('should add build options if defineConfig is empty', () => {
-      tree.write('apps/my-app/vite.config.ts', noContentDefineConfig);
-      ensureBuildOptionsInViteConfig(
-        tree,
-        'apps/my-app/vite.config.ts',
-        buildOption,
-        buildOptionObject,
-        dtsPlugin,
-        dtsImportLine,
-        pluginOption
-      );
-      const appFileContent = tree.read('apps/my-app/vite.config.ts', 'utf-8');
-      const file = tsquery.ast(appFileContent);
-      const buildNode = tsquery.query(
-        file,
-        'PropertyAssignment:has(Identifier[name="build"])'
-      );
-      expect(buildNode).toBeDefined();
-      expect(appFileContent).toMatchSnapshot();
-    });
-
-    it('should add build options if it is using conditional config', () => {
-      tree.write('apps/my-app/vite.config.ts', conditionalConfig);
-      ensureBuildOptionsInViteConfig(
-        tree,
-        'apps/my-app/vite.config.ts',
-        buildOption,
-        buildOptionObject,
-        dtsPlugin,
-        dtsImportLine,
-        pluginOption
-      );
-      const appFileContent = tree.read('apps/my-app/vite.config.ts', 'utf-8');
-      const file = tsquery.ast(appFileContent);
-      const buildNode = tsquery.query(
-        file,
-        'PropertyAssignment:has(Identifier[name="build"])'
-      );
-      expect(buildNode).toBeDefined();
-      expect(appFileContent).toMatchSnapshot();
-    });
-
-    it('should add build options if defineConfig is not used', () => {
-      tree.write('apps/my-app/vite.config.ts', configNoDefineConfig);
-      ensureBuildOptionsInViteConfig(
-        tree,
-        'apps/my-app/vite.config.ts',
-        buildOption,
-        buildOptionObject,
-        dtsPlugin,
-        dtsImportLine,
-        pluginOption
-      );
-      const appFileContent = tree.read('apps/my-app/vite.config.ts', 'utf-8');
-      const file = tsquery.ast(appFileContent);
-      const buildNode = tsquery.query(
-        file,
-        'PropertyAssignment:has(Identifier[name="build"])'
-      );
-      expect(buildNode).toBeDefined();
-      expect(appFileContent).toMatchSnapshot();
-    });
-
-    it('should not do anything if cannot understand syntax of vite config', () => {
-      tree.write('apps/my-app/vite.config.ts', `console.log('Unknown syntax')`);
-      ensureBuildOptionsInViteConfig(
-        tree,
-        'apps/my-app/vite.config.ts',
-        buildOption,
-        buildOptionObject,
-        dtsPlugin,
-        dtsImportLine,
-        pluginOption
-      );
-      const appFileContent = tree.read('apps/my-app/vite.config.ts', 'utf-8');
-      expect(appFileContent).toMatchSnapshot();
-    });
+  it('should update both test and build options - keep existing settings', () => {
+    tree.write('apps/my-app/vite.config.ts', someBuildOptionsSomeTestOption);
+    ensureBuildOptionsInViteConfig(
+      tree,
+      'apps/my-app/vite.config.ts',
+      buildOption,
+      buildOptionObject,
+      dtsPlugin,
+      dtsImportLine,
+      pluginOption,
+      testOption,
+      testOptionObject,
+      { build: false, test: false, serve: true }
+    );
+    const appFileContent = tree.read('apps/my-app/vite.config.ts', 'utf-8');
+    expect(appFileContent).toMatchSnapshot();
   });
 });

--- a/packages/web/src/generators/application/application.spec.ts
+++ b/packages/web/src/generators/application/application.spec.ts
@@ -160,7 +160,10 @@ describe('app', () => {
           path: './tsconfig.spec.json',
         },
       ]);
-      expect(tsconfig.compilerOptions.types).toMatchObject(['vite/client']);
+      expect(tsconfig.compilerOptions.types).toMatchObject([
+        'vite/client',
+        'vitest',
+      ]);
 
       expect(tree.exists('apps/my-app-e2e/cypress.config.ts')).toBeTruthy();
       expect(tree.exists('apps/my-app/index.html')).toBeTruthy();
@@ -563,7 +566,10 @@ describe('app', () => {
 
     it('should create correct tsconfig compilerOptions', () => {
       const tsconfigJson = readJson(viteAppTree, '/apps/my-app/tsconfig.json');
-      expect(tsconfigJson.compilerOptions.types).toMatchObject(['vite/client']);
+      expect(tsconfigJson.compilerOptions.types).toMatchObject([
+        'vite/client',
+        'vitest',
+      ]);
     });
 
     it('should create index.html and vite.config file at the root of the app', () => {


### PR DESCRIPTION
Make improvements in `@nrwl/vite:configuration` generator, for converting apps and libs:

Improvements include:

* Don't edit `vite.config.ts` file if no changes are made to `targets`
* Copy compatible `server` options (eg. `hmr`)
* Move `vitest` types in `tsconfig.json`
* Only update `vite.config.ts` options that correspond to changed targets (only update `build` if we changed `build` target, only edit `test` if we changed `test` target)
* Add `test` option in `vite.config.ts` if `vite.config.ts` already exists (when converting application that is set up to not use `vitest` test runner, but is set up to use `vite` as builder)