### PR TITLE
docs(nxdev): improve related documentation link matcher

### DIFF
--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -1333,7 +1333,7 @@
           },
           {
             "name": "Nx Devkit",
-            "path": "/packages#devkit",
+            "path": "/packages/devkit/index",
             "id": "packages-devkit",
             "isExternal": true,
             "children": [],
@@ -1400,7 +1400,7 @@
       },
       {
         "name": "Nx Devkit",
-        "path": "/packages#devkit",
+        "path": "/packages/devkit/index",
         "id": "packages-devkit",
         "isExternal": true,
         "children": [],
@@ -1543,7 +1543,7 @@
           },
           {
             "name": "--skip-nx-cache flag",
-            "path": "/nx/affected#skip-nx-cache",
+            "path": "/packages/nx/documents/affected#skip-nx-cache",
             "id": "skip-nx-cache-flag",
             "isExternal": true,
             "children": [],
@@ -1602,7 +1602,7 @@
       },
       {
         "name": "--skip-nx-cache flag",
-        "path": "/nx/affected#skip-nx-cache",
+        "path": "/packages/nx/documents/affected#skip-nx-cache",
         "id": "skip-nx-cache-flag",
         "isExternal": true,
         "children": [],

--- a/docs/generated/manifests/nx.json
+++ b/docs/generated/manifests/nx.json
@@ -1663,7 +1663,7 @@
         "file": "",
         "itemList": [],
         "isExternal": true,
-        "path": "/packages#devkit",
+        "path": "/packages/devkit/index",
         "tags": ["create-your-own-plugin"]
       },
       {
@@ -1741,14 +1741,14 @@
     "path": "/packages",
     "tags": []
   },
-  "/packages#devkit": {
+  "/packages/devkit/index": {
     "id": "packages-devkit",
     "name": "Nx Devkit",
     "description": "",
     "file": "",
     "itemList": [],
     "isExternal": true,
-    "path": "/packages#devkit",
+    "path": "/packages/devkit/index",
     "tags": ["create-your-own-plugin"]
   },
   "/reference/glossary": {
@@ -1925,7 +1925,7 @@
         "file": "",
         "itemList": [],
         "isExternal": true,
-        "path": "/nx/affected#skip-nx-cache",
+        "path": "/packages/nx/documents/affected#skip-nx-cache",
         "tags": ["cache-task-results"]
       },
       {
@@ -1993,14 +1993,14 @@
     "path": "/nx-cloud/intro/what-is-nx-cloud",
     "tags": ["cache-task-results", "distribute-task-execution"]
   },
-  "/nx/affected#skip-nx-cache": {
+  "/packages/nx/documents/affected#skip-nx-cache": {
     "id": "skip-nx-cache-flag",
     "name": "--skip-nx-cache flag",
     "description": "",
     "file": "",
     "itemList": [],
     "isExternal": true,
-    "path": "/nx/affected#skip-nx-cache",
+    "path": "/packages/nx/documents/affected#skip-nx-cache",
     "tags": ["cache-task-results"]
   },
   "/reference/nx-json#tasks-runner-options": {

--- a/docs/generated/manifests/tags.json
+++ b/docs/generated/manifests/tags.json
@@ -91,7 +91,7 @@
       "file": "",
       "id": "skip-nx-cache-flag",
       "name": "--skip-nx-cache flag",
-      "path": "/nx/affected#skip-nx-cache"
+      "path": "/packages/nx/documents/affected#skip-nx-cache"
     },
     {
       "description": "",
@@ -620,7 +620,7 @@
       "file": "",
       "id": "packages-devkit",
       "name": "Nx Devkit",
-      "path": "/packages#devkit"
+      "path": "/packages/devkit/index"
     },
     {
       "description": "",

--- a/docs/map.json
+++ b/docs/map.json
@@ -539,7 +539,7 @@
               "id": "packages-devkit",
               "tags": ["create-your-own-plugin"],
               "file": "",
-              "path": "/packages#devkit",
+              "path": "/packages/devkit/index",
               "isExternal": true
             },
             {
@@ -613,7 +613,7 @@
               "id": "skip-nx-cache-flag",
               "file": "",
               "tags": ["cache-task-results"],
-              "path": "/nx/affected#skip-nx-cache",
+              "path": "/packages/nx/documents/affected#skip-nx-cache",
               "isExternal": true
             },
             {

--- a/nx-dev/models-document/src/lib/related-documents.utils.ts
+++ b/nx-dev/models-document/src/lib/related-documents.utils.ts
@@ -2,10 +2,14 @@ import { RelatedDocument } from './documents.models';
 
 interface RelatedDocumentsCategory {
   id: string;
-  name: string;
+  /**
+   * Matcher that will be evaluated against a path.
+   */
   matchers: string[];
+  name: string;
   relatedDocuments: RelatedDocument[];
 }
+
 export function categorizeRelatedDocuments(
   items: RelatedDocument[]
 ): RelatedDocumentsCategory[] {
@@ -13,25 +17,25 @@ export function categorizeRelatedDocuments(
     {
       id: 'concepts',
       name: 'Concepts',
-      matchers: ['concepts', 'more-concepts'],
+      matchers: ['/concepts/', '/more-concepts/'],
       relatedDocuments: [],
     },
     {
       id: 'recipes',
       name: 'Recipes',
-      matchers: ['recipes'],
+      matchers: ['/recipes/'],
       relatedDocuments: [],
     },
     {
       id: 'reference',
       name: 'Reference',
-      matchers: ['nx', 'workspace'],
+      matchers: ['/workspace/', '/packages/'],
       relatedDocuments: [],
     },
     {
       id: 'see-also',
       name: 'See also',
-      matchers: ['see-also'],
+      matchers: ['/see-also/'],
       relatedDocuments: [],
     },
   ];


### PR DESCRIPTION
It improves the related documentations matching mechanism by replacing the `nx` matcher by `packages` since all references documents and informations are now in the `/pacakges/{pacakge-name}` path.

It also fix few URLs that were supporting the old paths scheme.