### PR TITLE
fix(bundling): support custom outExtension for ESM and CJS (e.g. .mjs)

### DIFF
--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.spec.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.spec.ts
@@ -159,4 +159,112 @@ describe('buildEsbuildOptions', () => {
       },
     });
   });
+
+  it('should respect user defined outExtension', () => {
+    expect(
+      buildEsbuildOptions(
+        'esm',
+        {
+          platform: 'node',
+          main: 'apps/myapp/src/index.ts',
+          outputPath: 'dist/apps/myapp',
+          tsConfig: 'apps/myapp/tsconfig.app.json',
+          project: 'apps/myapp/package.json',
+          outputFileName: 'index.js',
+          assets: [],
+          singleEntry: true,
+          external: [],
+          esbuildOptions: {
+            outExtension: {
+              '.js': '.mjs',
+            },
+          },
+        },
+        context
+      )
+    ).toEqual({
+      bundle: true,
+      entryNames: '[dir]/[name]',
+      entryPoints: ['apps/myapp/src/index.ts'],
+      format: 'esm',
+      platform: 'node',
+      outfile: 'dist/apps/myapp/index.mjs',
+      tsconfig: 'apps/myapp/tsconfig.app.json',
+      external: [],
+      outExtension: {
+        '.js': '.mjs',
+      },
+    });
+
+    expect(
+      buildEsbuildOptions(
+        'cjs',
+        {
+          platform: 'node',
+          main: 'apps/myapp/src/index.ts',
+          outputPath: 'dist/apps/myapp',
+          tsConfig: 'apps/myapp/tsconfig.app.json',
+          project: 'apps/myapp/package.json',
+          outputFileName: 'index.js',
+          assets: [],
+          singleEntry: true,
+          external: [],
+          esbuildOptions: {
+            outExtension: {
+              '.js': '.js',
+            },
+          },
+        },
+        context
+      )
+    ).toEqual({
+      bundle: true,
+      entryNames: '[dir]/[name]',
+      entryPoints: ['apps/myapp/src/index.ts'],
+      format: 'cjs',
+      platform: 'node',
+      outfile: 'dist/apps/myapp/index.js',
+      tsconfig: 'apps/myapp/tsconfig.app.json',
+      external: [],
+      outExtension: {
+        '.js': '.js',
+      },
+    });
+
+    // ESM cannot be mapped to .cjs so ignore
+    expect(
+      buildEsbuildOptions(
+        'esm',
+        {
+          platform: 'node',
+          main: 'apps/myapp/src/index.ts',
+          outputPath: 'dist/apps/myapp',
+          tsConfig: 'apps/myapp/tsconfig.app.json',
+          project: 'apps/myapp/package.json',
+          outputFileName: 'index.js',
+          assets: [],
+          singleEntry: true,
+          external: [],
+          esbuildOptions: {
+            outExtension: {
+              '.js': '.cjs',
+            },
+          },
+        },
+        context
+      )
+    ).toEqual({
+      bundle: true,
+      entryNames: '[dir]/[name]',
+      entryPoints: ['apps/myapp/src/index.ts'],
+      format: 'esm',
+      platform: 'node',
+      outfile: 'dist/apps/myapp/index.js',
+      tsconfig: 'apps/myapp/tsconfig.app.json',
+      external: [],
+      outExtension: {
+        '.js': '.js',
+      },
+    });
+  });
 });


### PR DESCRIPTION
This PR adds a check for user-defined `outExtension` before providing our own.

This allows `.mjs` to be used for ESM, and `.js` to be used for CJS. The executor will check to make sure the extensions are valid (e.g. `.cjs` cannot be used for ESM, and `.mjs` cannot be used for CJS).

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #13890
