### PR TITLE
docs(nxdev): take into account custom description

### DIFF
--- a/nx-dev/models-package/src/lib/package.models.ts
+++ b/nx-dev/models-package/src/lib/package.models.ts
@@ -24,13 +24,14 @@ export interface FileMetadata {
 export interface PackageData {
   description: string;
   documents: {
-    tags: string[];
-    id: string;
-    name: string;
-    itemList: any[];
     content: string;
+    description: string;
     file: string;
+    id: string;
+    itemList: any[];
+    name: string;
     path: string;
+    tags: string[];
   }[];
   executors: SchemaMetadata[];
   generators: SchemaMetadata[];

--- a/scripts/documentation/package-schemas/generatePackageSchemas.ts
+++ b/scripts/documentation/package-schemas/generatePackageSchemas.ts
@@ -66,7 +66,7 @@ export function generatePackageSchemas(): Promise<void[]> {
       description: p.description,
       documents: p.documents.map((d) => ({
         ...createDocumentMetadata({
-          description: p.description,
+          description: d.description || p.description,
           file: ['generated', 'packages', p.name, 'documents', d.id].join('/'),
           id: d.id,
           itemList: d.itemList,


### PR DESCRIPTION
It updates the package metadata generation to take into account the custom description of a document item instead of taking directly the description of its related package.
