### PR TITLE
chore(repo): support npm 9 in local-registry

### DIFF
--- a/scripts/local-registry.sh
+++ b/scripts/local-registry.sh
@@ -5,14 +5,14 @@ COMMAND=$1
 if [[ $COMMAND == "enable" ]]; then
 	echo "Setting registry to local registry"
 	echo "To Disable: yarn local-registry disable"
-	npm config set registry http://localhost:4873/
+	npm config set registry http://localhost:4873/ --location user
 	yarn config set registry http://localhost:4873/
 fi
 
 if [[ $COMMAND == "disable" ]]; then
-	npm config delete registry
+	npm config delete registry --location user
 	yarn config delete registry
-	CURRENT_NPM_REGISTRY=$(npm config get registry)
+	CURRENT_NPM_REGISTRY=$(npm config get registry --location user)
 	CURRENT_YARN_REGISTRY=$(yarn config get registry)
 
 	echo "Reverting registries"


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

npm 9 defaults to setting config in the local repo so it doesn't work as intended with `yarn local-registry`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

We pass `--location user` to restore the behavior of setting the local-registry active for your OS user.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
