### PR TITLE
fix(node): use strings as keys for node executor hashedMap

### DIFF
--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -15,7 +15,7 @@ import { InspectType, NodeExecutorOptions } from './schema';
 
 const hasher = new HashingImpl();
 const processMap = new Map<string, ChildProcess>();
-const hashedMap = new Map<string[], string>();
+const hashedMap = new Map<string, string>();
 
 export interface ExecutorEvent {
   outfile: string;
@@ -92,7 +92,7 @@ async function runProcess(
 
   const hashed = hasher.hashArray(execArgv.concat(options.args));
 
-  const hashedKey = [uniqueKey, ...options.args];
+  const hashedKey = JSON.stringify([uniqueKey, ...options.args]);
   hashedMap.set(hashedKey, hashed);
 
   const subProcess = fork(
@@ -166,7 +166,7 @@ async function killCurrentProcess(
   options: NodeExecutorOptions,
   signal: string = 'SIGTERM'
 ) {
-  const hashedKey = [uniqueKey, ...options.args];
+  const hashedKey = JSON.stringify([uniqueKey, ...options.args]);
   const currentProcessKey = hashedMap.get(hashedKey);
   if (!currentProcessKey) return;
 


### PR DESCRIPTION
This PR fixes issue with node executor restarts caused by not waiting for previous process to exit before forking another.

This PR changes the `hashedMap` to use `string` as keys instead of `string[]`.  The array-valued key used to set the value on `hashedMap` is not the same instance as the one used to retrieve the value

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14006
