### PR TITLE
fix(testing): correctly set task status for failed coverage reports

### DIFF
--- a/packages/vite/migrations.json
+++ b/packages/vite/migrations.json
@@ -11,6 +11,12 @@
       "version": "15.3.4-beta.0",
       "description": "Set the mode in configurations to match the configurationName.",
       "factory": "./src/migrations/update-15-3-4/set-mode-in-configuration"
+    },
+    "update-test-path-placeholder-vars": {
+      "cli": "nx",
+      "version": "15.4.3-beta.0",
+      "description": "Update @nrwl/vite:test reportsDirectory and outputs properties to point to correct paths.",
+      "factory": "./src/migrations/update-15-4-3/update-report-directory"
     }
   },
   "packageJsonUpdates": {

--- a/packages/vite/src/executors/test/vitest.impl.ts
+++ b/packages/vite/src/executors/test/vitest.impl.ts
@@ -75,7 +75,9 @@ export default async function* runExecutor(
   }
 
   for await (const report of nxReporter) {
-    hasErrors = report.hasErrors;
+    // vitest sets the exitCode = 1 when code coverage isn't met
+    hasErrors =
+      report.hasErrors || (process.exitCode && process.exitCode !== 0);
   }
 
   return {

--- a/packages/vite/src/generators/vitest/vitest-generator.ts
+++ b/packages/vite/src/generators/vitest/vitest-generator.ts
@@ -16,7 +16,6 @@ import {
   createOrEditViteConfig,
 } from '../../utils/generator-utils';
 import { VitestGeneratorSchema } from './schema';
-
 import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 import initGenerator from '../init/init';
 import {
@@ -41,7 +40,7 @@ export async function vitestGenerator(
 
   addOrChangeTestTarget(tree, schema, testTarget);
 
-  const initTask = await initGenerator(tree, {
+  const initTask = initGenerator(tree, {
     uiFramework: schema.uiFramework,
   });
   tasks.push(initTask);

--- a/packages/vite/src/generators/vitest/vitest.spec.ts
+++ b/packages/vite/src/generators/vitest/vitest.spec.ts
@@ -1,5 +1,9 @@
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import { Tree, readProjectConfiguration } from '@nrwl/devkit';
+import {
+  Tree,
+  readProjectConfiguration,
+  updateProjectConfiguration,
+} from '@nrwl/devkit';
 
 import generator from './vitest-generator';
 import { VitestGeneratorSchema } from './schema';
@@ -20,7 +24,7 @@ describe('vitest generator', () => {
     appTree = createTreeWithEmptyWorkspace();
   });
 
-  it('Should add the test target', async () => {
+  it('Should add the test target to existing test target', async () => {
     mockReactAppGenerator(appTree);
     await generator(appTree, options);
     const config = readProjectConfiguration(appTree, 'my-test-react-app');
@@ -32,6 +36,30 @@ describe('vitest generator', () => {
         },
         "outputs": Array [
           "{workspaceRoot}/coverage/{projectRoot}",
+        ],
+      }
+    `);
+  });
+
+  it('should add the test target if its missing', async () => {
+    mockReactAppGenerator(appTree);
+    const projectConfig = readProjectConfiguration(
+      appTree,
+      'my-test-react-app'
+    );
+    delete projectConfig.targets.test;
+    updateProjectConfiguration(appTree, 'my-test-react-app', projectConfig);
+    await generator(appTree, options);
+    const config = readProjectConfiguration(appTree, 'my-test-react-app');
+    expect(config.targets['test']).toMatchInlineSnapshot(`
+      Object {
+        "executor": "@nrwl/vite:test",
+        "options": Object {
+          "passWithNoTests": true,
+          "reportsDirectory": "../../coverage/apps/my-test-react-app",
+        },
+        "outputs": Array [
+          "coverage/apps/my-test-react-app",
         ],
       }
     `);

--- a/packages/vite/src/migrations/update-15-4-3/update-report-directory.spec.ts
+++ b/packages/vite/src/migrations/update-15-4-3/update-report-directory.spec.ts
@@ -1,0 +1,148 @@
+import {
+  addProjectConfiguration,
+  readProjectConfiguration,
+  Tree,
+} from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { updateReportDirectoryPlaceholders } from './update-report-directory';
+
+describe('Update Report Directory Vitest Migration', () => {
+  let tree: Tree;
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should migrate', () => {
+    addVitestProjects(tree, { name: 'project' });
+
+    updateReportDirectoryPlaceholders(tree);
+    expect(readProjectConfiguration(tree, 'project-one').targets)
+      .toMatchInlineSnapshot(`
+      Object {
+        "test": Object {
+          "executor": "@nrwl/vite:test",
+          "options": Object {
+            "passWithNoTests": true,
+            "reportsDirectory": "../../coverge/packages/project-one",
+          },
+          "outputs": Array [
+            "coverage/packages/project-one",
+          ],
+        },
+      }
+    `);
+    expect(readProjectConfiguration(tree, 'project-two').targets)
+      .toMatchInlineSnapshot(`
+      Object {
+        "custom-test": Object {
+          "configurations": Object {
+            "ci": Object {
+              "reportsDirectory": "coverge/project-two",
+            },
+          },
+          "executor": "@nrwl/vite:test",
+          "options": Object {
+            "passWithNoTests": true,
+          },
+          "outputs": Array [
+            "coverage/project-two",
+            "dist/coverage/else.txt",
+          ],
+        },
+        "test": Object {
+          "executor": "@nrwl/vite:test",
+          "options": Object {
+            "passWithNoTests": true,
+            "reportsDirectory": "coverge/project-two",
+          },
+        },
+      }
+    `);
+  });
+  it('should be idempotent', () => {
+    addVitestProjects(tree, { name: 'project' });
+
+    const expectedProjectOneConfig = {
+      test: {
+        outputs: ['coverage/packages/project-one'],
+        executor: '@nrwl/vite:test',
+        options: {
+          reportsDirectory: '../../coverge/packages/project-one',
+          passWithNoTests: true,
+        },
+      },
+    };
+
+    const expectedProjectTwoConfig = {
+      'custom-test': {
+        executor: '@nrwl/vite:test',
+        outputs: ['coverage/project-two', 'dist/coverage/else.txt'],
+        options: {
+          passWithNoTests: true,
+        },
+        configurations: {
+          ci: {
+            reportsDirectory: 'coverge/project-two',
+          },
+        },
+      },
+      test: {
+        executor: '@nrwl/vite:test',
+        options: {
+          reportsDirectory: 'coverge/project-two',
+          passWithNoTests: true,
+        },
+      },
+    };
+
+    updateReportDirectoryPlaceholders(tree);
+    const projOneConfig = readProjectConfiguration(tree, 'project-one');
+    expect(projOneConfig.targets).toEqual(expectedProjectOneConfig);
+    const projTwoConfig = readProjectConfiguration(tree, 'project-two');
+    expect(projTwoConfig.targets).toEqual(expectedProjectTwoConfig);
+  });
+});
+
+function addVitestProjects(tree: Tree, options: { name: string }) {
+  addProjectConfiguration(tree, options.name + '-one', {
+    name: options.name + '-one',
+    sourceRoot: `packages/${options.name}-one/src`,
+    root: `packages/${options.name}-one`,
+    targets: {
+      test: {
+        outputs: ['{projectRoot}/coverage'],
+        executor: '@nrwl/vite:test',
+        options: {
+          reportsDirectory: '{workspaceRoot}/coverge/{projectRoot}',
+          passWithNoTests: true,
+        },
+      },
+    },
+  });
+  addProjectConfiguration(tree, options.name + '-two', {
+    name: options.name + '-two',
+    sourceRoot: 'src',
+    root: '.',
+    targets: {
+      'custom-test': {
+        executor: '@nrwl/vite:test',
+        outputs: ['{projectRoot}/coverage', 'dist/coverage/else.txt'],
+        options: {
+          passWithNoTests: true,
+        },
+        configurations: {
+          ci: {
+            reportsDirectory: '{workspaceRoot}/coverge/{projectRoot}',
+          },
+        },
+      },
+      test: {
+        executor: '@nrwl/vite:test',
+        options: {
+          reportsDirectory: '{workspaceRoot}/coverge/{projectRoot}',
+          passWithNoTests: true,
+        },
+      },
+    },
+  });
+}

--- a/packages/vite/src/migrations/update-15-4-3/update-report-directory.ts
+++ b/packages/vite/src/migrations/update-15-4-3/update-report-directory.ts
@@ -1,0 +1,49 @@
+import {
+  getProjects,
+  offsetFromRoot,
+  Tree,
+  updateProjectConfiguration,
+} from '@nrwl/devkit';
+import { forEachExecutorOptions } from '@nrwl/workspace/src/utilities/executor-options-utils';
+import { VitestExecutorOptions } from '../../executors/test/schema';
+
+export function updateReportDirectoryPlaceholders(tree: Tree) {
+  const projects = getProjects(tree);
+  forEachExecutorOptions<VitestExecutorOptions>(
+    tree,
+    '@nrwl/vite:test',
+    (options, projectName, targetName, configName) => {
+      const projectConfig = projects.get(projectName);
+      const coverageOutput =
+        projectConfig.root === '.' ? projectName : projectConfig.root;
+
+      if (options.reportsDirectory) {
+        options.reportsDirectory = options.reportsDirectory
+          .replace(
+            '{workspaceRoot}/',
+            projectConfig.root === '.' ? '' : offsetFromRoot(projectConfig.root)
+          )
+          .replace('{projectRoot}', coverageOutput);
+        if (configName) {
+          projectConfig.targets[targetName].configurations[configName] =
+            options;
+        } else {
+          projectConfig.targets[targetName].options = options;
+        }
+        if (projectConfig.targets[targetName].outputs) {
+          projectConfig.targets[targetName].outputs = projectConfig.targets[
+            targetName
+          ].outputs.map((output) =>
+            output.replace(
+              '{projectRoot}/coverage',
+              `coverage/${coverageOutput}`
+            )
+          );
+        }
+        updateProjectConfiguration(tree, projectName, projectConfig);
+      }
+    }
+  );
+}
+
+export default updateReportDirectoryPlaceholders;

--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -208,12 +208,16 @@ export function addOrChangeTestTarget(
 ) {
   const project = readProjectConfiguration(tree, options.project);
 
+  const coveragePath = joinPathFragments(
+    'coverage',
+    project.root === '.' ? options.project : project.root
+  );
   const testOptions: VitestExecutorOptions = {
     passWithNoTests: true,
+    // vitest runs in the project root so we have to offset to the workspaceRoot
     reportsDirectory: joinPathFragments(
-      '{workspaceRoot}',
-      'coverage',
-      '{projectRoot}'
+      offsetFromRoot(project.root),
+      coveragePath
     ),
   };
 
@@ -226,7 +230,7 @@ export function addOrChangeTestTarget(
     }
     project.targets[target] = {
       executor: '@nrwl/vite:test',
-      outputs: ['{projectRoot}/coverage'],
+      outputs: [coveragePath],
       options: testOptions,
     };
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
when coverage isn't met vitest shows error but nx says it was successful

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
not met coverage limits should cause tasks to fail

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Also noticed an incosistency with the coverage paths set by the vitest generator. 

basically using the `{workspaceRoot}` and `{projectRoot}` variables in the executor options which are not currently expanded so the folder structure results in the actual test `{workspaceRoot}` as the folder names. 

Also by default coverage reports are placed in the project root (where vitest runs). Should this line up with jest and be in the root /coverage/<projectRootPath> directory?

I initially thought so based on the standalone project (since project root is also the workspace root) but noticed in integrated repo it's actually the project root. Open to whatever makes sense just wanted to fix the paths but need to know where they should be for the generator and migration

Fixes #13676
