### PR TITLE
fix(bundling): update rollup-plugin-typescript2 to fix typechecking ...

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-postcss": "^4.0.1",
-    "rollup-plugin-typescript2": "^0.31.1",
+    "rollup-plugin-typescript2": "0.34.1",
     "rxjs": "6.6.7",
     "rxjs-for-await": "0.0.2",
     "sass": "1.55.0",

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -47,7 +47,7 @@
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-postcss": "^4.0.1",
-    "rollup-plugin-typescript2": "^0.31.1",
+    "rollup-plugin-typescript2": "0.34.1",
     "rxjs": "^6.5.4",
     "tslib": "^2.3.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -21121,6 +21121,17 @@ rollup-plugin-sourcemaps@^0.6.3:
     "@rollup/pluginutils" "^3.0.9"
     source-map-resolve "^0.6.0"
 
+rollup-plugin-typescript2@0.34.1:
+  version "0.34.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.34.1.tgz#c457f155a71d133c142689213fce78694e30d0be"
+  integrity sha512-P4cHLtGikESmqi1CA+tdMDUv8WbQV48mzPYt77TSTOPJpERyZ9TXdDgjSDix8Fkqce6soYz3+fa4lrC93IEkcw==
+  dependencies:
+    "@rollup/pluginutils" "^4.1.2"
+    find-cache-dir "^3.3.2"
+    fs-extra "^10.0.0"
+    semver "^7.3.7"
+    tslib "^2.4.0"
+
 rollup-plugin-typescript2@^0.31.1:
   version "0.31.2"
   resolved "https://registry.yarnpkg.com/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.31.2.tgz#463aa713a7e2bf85b92860094b9f7fb274c5a4d8"


### PR DESCRIPTION
…in rollup bundle

This commit fixes typechecking in rollup bundle while using pnpm as package manager. 

## Related Issue(s)
https://github.com/ezolenko/rollup-plugin-typescript2/issues/330

