### PR TITLE
fix(js): node executor address already in use

### DIFF
--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -15,7 +15,7 @@ import { InspectType, NodeExecutorOptions } from './schema';
 
 const hasher = new HashingImpl();
 const processMap = new Map<string, ChildProcess>();
-const hashedMap = new Map<string[], string>();
+const hashedMap = new Map<string, string>();
 
 export interface ExecutorEvent {
   outfile: string;
@@ -92,7 +92,7 @@ async function runProcess(
 
   const hashed = hasher.hashArray(execArgv.concat(options.args));
 
-  const hashedKey = [uniqueKey, ...options.args];
+  const hashedKey = JSON.stringify([uniqueKey, ...options.args]);
   hashedMap.set(hashedKey, hashed);
 
   const subProcess = fork(
@@ -166,7 +166,7 @@ async function killCurrentProcess(
   options: NodeExecutorOptions,
   signal: string = 'SIGTERM'
 ) {
-  const hashedKey = [uniqueKey, ...options.args];
+  const hashedKey = JSON.stringify([uniqueKey, ...options.args]);
   const currentProcessKey = hashedMap.get(hashedKey);
   if (!currentProcessKey) return;
 


### PR DESCRIPTION
Due to this https://github.com/nrwl/nx/pull/13813 PR, frameworks like express and nest are throwing the EADDRINUSE error after file changes.
The issue is caused by using array as key in new Map(key, value) function. I corrected it by wrapping JSON.strigify function around Map key.

BREAKING CHANGE:
NA

ISSUES CLOSED: #14017

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Wherever we have @nrwl/js:node executor (express, nest etc.) after each file changes, we are getting EADDRINUSE error.

## Expected Behavior
Every file changes should be seamlessly watched by @nrwl/js:node executor and changes should be instantly available while serving the application locally.

## Related Issue(s)
#14024
#14023