### PR TITLE
feat(react): expose setupTailwindGenerator from @nrwl/react

### DIFF
--- a/packages/react/index.ts
+++ b/packages/react/index.ts
@@ -20,4 +20,5 @@ export { hostGenerator } from './src/generators/host/host';
 export { remoteGenerator } from './src/generators/remote/remote';
 export { cypressComponentConfigGenerator } from './src/generators/cypress-component-configuration/cypress-component-configuration';
 export { componentTestGenerator } from './src/generators/component-test/component-test';
+export { setupTailwindGenerator } from './src/generators/setup-tailwind/setup-tailwind';
 export type { SupportedStyles } from './typings/style';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`setupTailwindGenerator` is not exposed in @nrwl/react, and can't be used to compose plugins

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`setupTailwindGenerator` should be exposed like the rest of the generators

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14028 