### PR TITLE
docs(testing): redirect cy 10 generator to cy 11

### DIFF
--- a/docs/generated/packages/cypress/documents/v11-migration-guide.md
+++ b/docs/generated/packages/cypress/documents/v11-migration-guide.md
@@ -6,6 +6,14 @@ Before continuing, make sure you have all your changes committed and have a clea
 
 You can migrate an E2E project to v11 by running the following command:
 
+{% callout type="note" title="Generator Naming Changes" %}
+If your nx version is below v15.3.0, this migration is called `migrate-to-cypress-10`.
+
+From v15.3.0+ this generator is called `migrate-to-cypress-11`.
+
+As of nx v15.1.0, if your project was already using Cypress v10, then your project will be migrated to Cypress v11 via the [standard nx migration process](/core-features/automate-updating-dependencies)
+{% /callout %}
+
 ```shell
 nx g @nrwl/cypress:migrate-to-cypress-11
 ```

--- a/docs/shared/packages/cypress/cypress-v11-migration.md
+++ b/docs/shared/packages/cypress/cypress-v11-migration.md
@@ -6,6 +6,14 @@ Before continuing, make sure you have all your changes committed and have a clea
 
 You can migrate an E2E project to v11 by running the following command:
 
+{% callout type="note" title="Generator Naming Changes" %}
+If your nx version is below v15.3.0, this migration is called `migrate-to-cypress-10`.
+
+From v15.3.0+ this generator is called `migrate-to-cypress-11`.
+
+As of nx v15.1.0, if your project was already using Cypress v10, then your project will be migrated to Cypress v11 via the [standard nx migration process](/core-features/automate-updating-dependencies)
+{% /callout %}
+
 ```shell
 nx g @nrwl/cypress:migrate-to-cypress-11
 ```

--- a/nx-dev/nx-dev/redirect-rules.config.js
+++ b/nx-dev/nx-dev/redirect-rules.config.js
@@ -163,6 +163,8 @@ const guideUrls = {
   '/structure/project-graph-plugins': '/extending-nx/project-graph-plugins',
   '/guides/lerna-and-nx': '/migration/lerna-and-nx',
   '/cypress/v10-migration-guide': '/cypress/v11-migration-guide',
+  '/cypress/generators/migrate-to-cypress-10':
+    '/cypress/generators/migrate-to-cypress-11',
 };
 
 /**


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
cy 10 page didn't redirect to cy 11

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
no broken links

add extra info about what the generator is named depending on nx version

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14000
