### PR TITLE
Honour browserslist on libraries using babel

### DIFF
--- a/packages/web/babel.ts
+++ b/packages/web/babel.ts
@@ -48,7 +48,7 @@ module.exports = function (api: any, options: NxWebBabelPresetOptions = {}) {
               corejs: 3,
               // Do not transform modules to CJS
               modules: false,
-              targets: isModern ? { esmodules: true } : undefined,
+              targets: isModern ? { esmodules: 'intersect' } : undefined,
               bugfixes: true,
               // Exclude transforms that make all code slower
               exclude: ['transform-typeof-symbol'],


### PR DESCRIPTION
## Current Behavior
Libraries include unnecessary polyfills, even when configured for modern browsers on browserslist.

## Expected Behavior
Respect the browserslist and only generate necessary polyfills.

## Related Issue(s)

Fixes #10304

---

`du -sh dist/libs/**/index.js`

`esmodules: true`:

```
136K    dist/libs/redacted/index.js
 48K    dist/libs/redacted/index.js
4.0K    dist/libs/redacted/index.js
 84K    dist/libs/redacted/index.js
4.0K    dist/libs/redacted/index.js <-- this one was using swc instead, which respects browserslistrc
 36K    dist/libs/redacted/index.js
108K    dist/libs/redacted/index.js
 48K    dist/libs/redacted/index.js
 88K    dist/libs/redacted/index.js
 48K    dist/libs/redacted/index.js
 20K    dist/libs/redacted/index.js
```

`esmodules: "intersect"` + browserslistrc:

```
8.0K    dist/libs/redacted/index.js
4.0K    dist/libs/redacted/index.js
4.0K    dist/libs/redacted/index.js
8.0K    dist/libs/redacted/index.js
4.0K    dist/libs/redacted/index.js
4.0K    dist/libs/redacted/index.js
4.0K    dist/libs/redacted/index.js
4.0K    dist/libs/redacted/index.js
4.0K    dist/libs/redacted/index.js
4.0K    dist/libs/redacted/index.js
4.0K    dist/libs/redacted/index.js
```