### PR TITLE
fix(core): schemas should not require executor due to negative config work

### DIFF
--- a/packages/nx/schemas/project-schema.json
+++ b/packages/nx/schemas/project-schema.json
@@ -80,17 +80,7 @@
             "type": "string",
             "description": "A shorthand for using the nx:run-commands executor"
           }
-        },
-        "oneOf": [
-          {
-            "type": "object",
-            "required": ["executor"]
-          },
-          {
-            "type": "object",
-            "required": ["command"]
-          }
-        ]
+        }
       }
     },
     "tags": {

--- a/packages/nx/schemas/workspace-schema.json
+++ b/packages/nx/schemas/workspace-schema.json
@@ -90,17 +90,7 @@
                             "type": "string",
                             "description": "A shorthand for using the nx:run-commands executor"
                           }
-                        },
-                        "oneOf": [
-                          {
-                            "type": "object",
-                            "required": ["executor"]
-                          },
-                          {
-                            "type": "object",
-                            "required": ["command"]
-                          }
-                        ]
+                        }
                       }
                     },
                     "tags": {

--- a/packages/nx/src/config/workspaces.ts
+++ b/packages/nx/src/config/workspaces.ts
@@ -1009,11 +1009,12 @@ function mergeConfigurations<T extends Object>(
   return configurations;
 }
 
-function resolvePathTokensInOptions<T extends Object>(
+function resolvePathTokensInOptions<T extends Object | Array<unknown>>(
   object: T,
   projectRoot: string,
   key: string
 ): T {
+  const result: T = Array.isArray(object) ? ([...object] as T) : { ...object };
   for (let [opt, value] of Object.entries(object ?? {})) {
     if (typeof value === 'string') {
       if (value.startsWith('{workspaceRoot}/')) {
@@ -1024,12 +1025,16 @@ function resolvePathTokensInOptions<T extends Object>(
           `${NX_PREFIX} The {workspaceRoot} token is only valid at the beginning of an option. (${key})`
         );
       }
-      object[opt] = value.replace('{projectRoot}', projectRoot);
+      result[opt] = value.replace('{projectRoot}', projectRoot);
     } else if (typeof value === 'object' && value) {
-      resolvePathTokensInOptions(value, projectRoot, [key, opt].join('.'));
+      result[opt] = resolvePathTokensInOptions(
+        value,
+        projectRoot,
+        [key, opt].join('.')
+      );
     }
   }
-  return object;
+  return result;
 }
 
 export function readTargetDefaultsForTarget(


### PR DESCRIPTION
> **Note** This PR contains 2 distinct fixes and 1 new addition. It should be rebased and merged s.t. the changelogs are accurate. 
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
- Target defaults supports `projectRoot` token, but not `projectName`.
- Merging target defaults that use the `projectRoot` token results in issues due to mutation of in-memory objects.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
- Target defaults supports a {projectName} token. This is super useful for targets that make use of run-commands. Once released, we can use this for the e2e target in our repo.
- Resolving tokens doens't mutate the in-memory target defaults object.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
