### PR TITLE
fix(expo): address deprecation warning seen upon using `@nrwl/expo:start`

### DIFF
--- a/packages/expo/src/utils/ensure-node-modules-symlink.spec.ts
+++ b/packages/expo/src/utils/ensure-node-modules-symlink.spec.ts
@@ -1,6 +1,6 @@
 import { tmpdir } from 'os';
 import { join } from 'path';
-import * as fs from 'fs';
+import * as fs from 'fs-extra';
 import { ensureNodeModulesSymlink } from './ensure-node-modules-symlink';
 
 const workspaceDir = join(tmpdir(), 'nx-react-native-test');
@@ -10,7 +10,7 @@ const appDirAbsolutePath = join(workspaceDir, appDir);
 describe('ensureNodeModulesSymlink', () => {
   beforeEach(() => {
     if (fs.existsSync(workspaceDir))
-      fs.rmdirSync(workspaceDir, { recursive: true });
+      fs.removeSync(workspaceDir);
     fs.mkdirSync(workspaceDir);
     fs.mkdirSync(appDirAbsolutePath, { recursive: true });
     fs.mkdirSync(appDirAbsolutePath, { recursive: true });
@@ -36,8 +36,7 @@ describe('ensureNodeModulesSymlink', () => {
   });
 
   afterEach(() => {
-    if (fs.existsSync(workspaceDir))
-      fs.rmdirSync(workspaceDir, { recursive: true });
+    if (fs.existsSync(workspaceDir)) fs.removeSync(workspaceDir);
   });
 
   it('should create symlinks', () => {

--- a/packages/expo/src/utils/ensure-node-modules-symlink.spec.ts
+++ b/packages/expo/src/utils/ensure-node-modules-symlink.spec.ts
@@ -9,8 +9,7 @@ const appDirAbsolutePath = join(workspaceDir, appDir);
 
 describe('ensureNodeModulesSymlink', () => {
   beforeEach(() => {
-    if (fs.existsSync(workspaceDir))
-      fs.removeSync(workspaceDir);
+    if (fs.existsSync(workspaceDir)) fs.removeSync(workspaceDir);
     fs.mkdirSync(workspaceDir);
     fs.mkdirSync(appDirAbsolutePath, { recursive: true });
     fs.mkdirSync(appDirAbsolutePath, { recursive: true });

--- a/packages/expo/src/utils/ensure-node-modules-symlink.spec.ts
+++ b/packages/expo/src/utils/ensure-node-modules-symlink.spec.ts
@@ -1,6 +1,6 @@
 import { tmpdir } from 'os';
 import { join } from 'path';
-import * as fs from 'fs-extra';
+import { existsSync, mkdirSync, removeSync, writeFileSync } from 'fs-extra';
 import { ensureNodeModulesSymlink } from './ensure-node-modules-symlink';
 
 const workspaceDir = join(tmpdir(), 'nx-react-native-test');
@@ -9,18 +9,18 @@ const appDirAbsolutePath = join(workspaceDir, appDir);
 
 describe('ensureNodeModulesSymlink', () => {
   beforeEach(() => {
-    if (fs.existsSync(workspaceDir)) fs.removeSync(workspaceDir);
-    fs.mkdirSync(workspaceDir);
-    fs.mkdirSync(appDirAbsolutePath, { recursive: true });
-    fs.mkdirSync(appDirAbsolutePath, { recursive: true });
-    fs.writeFileSync(
+    if (existsSync(workspaceDir)) removeSync(workspaceDir);
+    mkdirSync(workspaceDir);
+    mkdirSync(appDirAbsolutePath, { recursive: true });
+    mkdirSync(appDirAbsolutePath, { recursive: true });
+    writeFileSync(
       join(appDirAbsolutePath, 'package.json'),
       JSON.stringify({
         name: 'myapp',
         dependencies: { 'react-native': '*' },
       })
     );
-    fs.writeFileSync(
+    writeFileSync(
       join(workspaceDir, 'package.json'),
       JSON.stringify({
         name: 'workspace',
@@ -35,7 +35,7 @@ describe('ensureNodeModulesSymlink', () => {
   });
 
   afterEach(() => {
-    if (fs.existsSync(workspaceDir)) fs.removeSync(workspaceDir);
+    if (existsSync(workspaceDir)) removeSync(workspaceDir);
   });
 
   it('should create symlinks', () => {
@@ -62,7 +62,7 @@ describe('ensureNodeModulesSymlink', () => {
   });
 
   it('should add packages listed in workspace package.json', () => {
-    fs.writeFileSync(
+    writeFileSync(
       join(workspaceDir, 'package.json'),
       JSON.stringify({
         name: 'workspace',
@@ -90,8 +90,8 @@ describe('ensureNodeModulesSymlink', () => {
 
   function createNpmDirectory(packageName, version) {
     const dir = join(workspaceDir, `node_modules/${packageName}`);
-    fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
       join(dir, 'package.json'),
       JSON.stringify({ name: packageName, version: version })
     );
@@ -100,7 +100,7 @@ describe('ensureNodeModulesSymlink', () => {
 
   function expectSymlinkToExist(packageName) {
     expect(
-      fs.existsSync(
+      existsSync(
         join(appDirAbsolutePath, `node_modules/${packageName}/package.json`)
       )
     ).toBe(true);

--- a/packages/expo/src/utils/ensure-node-modules-symlink.ts
+++ b/packages/expo/src/utils/ensure-node-modules-symlink.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { platform } from 'os';
-import * as fs from 'fs';
+import * as fs from 'fs-extra';
 
 /**
  * This function symlink workspace node_modules folder with app project's node_mdules folder.
@@ -24,7 +24,7 @@ export function ensureNodeModulesSymlink(
   const symlinkType = platform() === 'win32' ? 'junction' : 'dir';
 
   if (fs.existsSync(appNodeModulesPath)) {
-    fs.rmdirSync(appNodeModulesPath, { recursive: true });
+    fs.removeSync(appNodeModulesPath);
   }
   fs.symlinkSync(worksapceNodeModulesPath, appNodeModulesPath, symlinkType);
 }

--- a/packages/expo/src/utils/ensure-node-modules-symlink.ts
+++ b/packages/expo/src/utils/ensure-node-modules-symlink.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { platform } from 'os';
-import * as fs from 'fs-extra';
+import { existsSync, removeSync, symlinkSync } from 'fs-extra';
 
 /**
  * This function symlink workspace node_modules folder with app project's node_mdules folder.
@@ -15,7 +15,7 @@ export function ensureNodeModulesSymlink(
   projectRoot: string
 ): void {
   const worksapceNodeModulesPath = join(workspaceRoot, 'node_modules');
-  if (!fs.existsSync(worksapceNodeModulesPath)) {
+  if (!existsSync(worksapceNodeModulesPath)) {
     throw new Error(`Cannot find ${worksapceNodeModulesPath}`);
   }
 
@@ -23,8 +23,8 @@ export function ensureNodeModulesSymlink(
   // `mklink /D` requires admin privilege in Windows so we need to use junction
   const symlinkType = platform() === 'win32' ? 'junction' : 'dir';
 
-  if (fs.existsSync(appNodeModulesPath)) {
-    fs.removeSync(appNodeModulesPath);
+  if (existsSync(appNodeModulesPath)) {
+    removeSync(appNodeModulesPath);
   }
-  fs.symlinkSync(worksapceNodeModulesPath, appNodeModulesPath, symlinkType);
+  symlinkSync(worksapceNodeModulesPath, appNodeModulesPath, symlinkType);
 }


### PR DESCRIPTION
## Note

The same fix was applied a while ago in `@nrwl/react-native`: https://github.com/nrwl/nx/pull/7772

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Upon running: 
```sh
# uses `@nrwl/expo:start` executor
npx nx start my-app
```

I see: 

```sh
Packager is ready at http://localhost:8081
(node:33501) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)
```
![deprecation](https://user-images.githubusercontent.com/5302071/210272599-c62d5f58-bbb3-4ca8-9493-943bd36ad35d.jpg)



## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Upon replacing the function.

![Screenshot 2023-01-02 at 20 28 14](https://user-images.githubusercontent.com/5302071/210271971-92e5ed44-c832-4b9c-b836-2526b0daf984.png)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
https://github.com/nrwl/nx/issues/14094

Fixes #
https://github.com/nrwl/nx/issues/14094
