### PR TITLE
fix(react): skip exports field in generated package.json when using rollup to bundle library

### DIFF
--- a/packages/react/src/generators/library/files/common/package.json__tmpl__
+++ b/packages/react/src/generators/library/files/common/package.json__tmpl__
@@ -1,12 +1,4 @@
 {
   "name": "<%= name %>",
-  "version": "0.0.1",
-  "main": "./index.js",
-  "module": "./index.mjs",
-  "exports": {
-    ".": {
-      "import": "./index.mjs",
-      "require": "./index.js"
-    }
-  }
+  "version": "0.0.1"
 }

--- a/packages/rollup/src/generators/init/init.spec.ts
+++ b/packages/rollup/src/generators/init/init.spec.ts
@@ -1,5 +1,6 @@
 import { Tree, readJson, NxJsonConfiguration, updateJson } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { nxVersion } from '../../utils/versions';
 
 import { rollupInitGenerator } from './init';
 
@@ -35,6 +36,7 @@ describe('rollupInitGenerator', () => {
       name: expect.any(String),
       dependencies: {},
       devDependencies: {
+        '@nrwl/rollup': nxVersion,
         '@swc/helpers': expect.any(String),
         '@swc/core': expect.any(String),
         'swc-loader': expect.any(String),

--- a/packages/rollup/src/generators/init/init.ts
+++ b/packages/rollup/src/generators/init/init.ts
@@ -7,7 +7,11 @@ import {
 } from '@nrwl/devkit';
 import { Schema } from './schema';
 import { swcCoreVersion, swcHelpersVersion } from '@nrwl/js/src/utils/versions';
-import { swcLoaderVersion, tsLibVersion } from '../../utils/versions';
+import {
+  nxVersion,
+  swcLoaderVersion,
+  tsLibVersion,
+} from '../../utils/versions';
 import { addBabelInputs } from '@nrwl/js/src/utils/add-babel-inputs';
 
 export async function rollupInitGenerator(tree: Tree, schema: Schema) {
@@ -22,6 +26,7 @@ export async function rollupInitGenerator(tree: Tree, schema: Schema) {
       tree,
       {},
       {
+        '@nrwl/rollup': nxVersion,
         '@swc/helpers': swcHelpersVersion,
         '@swc/core': swcCoreVersion,
         'swc-loader': swcLoaderVersion,


### PR DESCRIPTION
This PR reverts generated `package.json` to not include `exports`, `module`, and `main` fields since these are generated dynamically by `@nrwl/rollup:rollup` executor.

Also adds `@nrwl/rollup` install to `@nrwl/rollup:init` generator which was missing previously.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14063

