### PR TITLE
fix(storybook): restore babelrc for storybook webpack

### DIFF
--- a/packages/react/src/generators/library/lib/create-files.ts
+++ b/packages/react/src/generators/library/lib/create-files.ts
@@ -5,7 +5,6 @@ import {
   names,
   offsetFromRoot,
   toJS,
-  updateJson,
 } from '@nrwl/devkit';
 import { getRelativePathToRootTsConfig } from '@nrwl/workspace/src/utilities/typescript';
 

--- a/packages/react/src/generators/storybook-configuration/configuration.ts
+++ b/packages/react/src/generators/storybook-configuration/configuration.ts
@@ -3,6 +3,7 @@ import storiesGenerator from '../stories/stories';
 import {
   convertNxGenerator,
   ensurePackage,
+  joinPathFragments,
   logger,
   readProjectConfiguration,
   Tree,
@@ -51,6 +52,42 @@ export async function storybookConfigurationGenerator(
       Storybook will be configured to use Vite as well.`
       );
     }
+  }
+
+  /**
+   * If it's library and there's no .babelrc file,
+   * we need to generate one if it's not using vite.
+   *
+   * The reason is that it will be using webpack for Storybook,
+   * and webpack needs the babelrc file to be present.
+   *
+   * The reason the babelrc file is not there in the first place,
+   * is because the vitest generator deletes it, since it
+   * does not need it.
+   * See:
+   * packages/react/src/generators/library/lib/create-files.ts#L42
+   */
+
+  if (
+    bundler !== 'vite' &&
+    projectConfig.projectType === 'library' &&
+    !host.exists(joinPathFragments(projectConfig.root, '.babelrc'))
+  ) {
+    host.write(
+      joinPathFragments(projectConfig.root, '.babelrc'),
+      JSON.stringify({
+        presets: [
+          [
+            '@nrwl/react/babel',
+            {
+              runtime: 'automatic',
+              useBuiltIns: 'usage',
+            },
+          ],
+        ],
+        plugins: [],
+      })
+    );
   }
 
   const installTask = await configurationGenerator(host, {


### PR DESCRIPTION
When generating Storybook configuration, if the bundler is `webpack` and there is no `babelrc`, then create one.

https://github.com/nrwl/nx/issues/14093

https://github.com/nrwl/nx/issues/14055

https://github.com/nrwl/nx/pull/14110