### PR TITLE
fix(testing): vitest deleting project root with coverage enabled

### DIFF
--- a/packages/vite/src/executors/test/vitest.impl.ts
+++ b/packages/vite/src/executors/test/vitest.impl.ts
@@ -48,14 +48,22 @@ export default async function* runExecutor(
   const projectRoot = context.projectGraph.nodes[context.projectName].data.root;
 
   const nxReporter = new NxReporter(options.watch);
-  const ctx = await startVitest(options.mode, [], {
+  const settings = {
     ...options,
     root: projectRoot,
     reporters: [...(options.reporters ?? []), 'default', nxReporter],
-    coverage: {
-      reportsDirectory: options.reportsDirectory,
-    },
-  });
+    // if reportsDirectory is not provides vitest will remove all files in the project root
+    // when coverage is enabled in the vite.config.ts
+    ...(options.reportsDirectory
+      ? {
+          coverage: {
+            reportsDirectory: options.reportsDirectory,
+          },
+        }
+      : {}),
+  };
+
+  const ctx = await startVitest(options.mode, [], settings);
 
   let hasErrors = false;
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
project root directory is deleted when coverage is enabled in the vite.config.ts file and reportsDirectory is removed from the project.json @nrwl/vite:test executor options

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

project root directory isn't deleted when reportsDirectory option isn't specified

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14099
