### PR TITLE
docs(nxdev): remove survey banners

### DIFF
--- a/nx-dev/nx-dev/pages/index.tsx
+++ b/nx-dev/nx-dev/pages/index.tsx
@@ -1,4 +1,4 @@
-import { AnnouncementBanner, Footer, Header } from '@nrwl/nx-dev/ui-common';
+import { Footer, Header } from '@nrwl/nx-dev/ui-common';
 import {
   ExtensibleAndIntegrated,
   GettingStarted,
@@ -39,7 +39,6 @@ export default function Index(): JSX.Element {
         }}
       />
       <h1 className="sr-only">Next generation monorepo tool</h1>
-      <AnnouncementBanner />
       <Header />
       <main id="main" role="main">
         <div className="w-full">

--- a/nx-dev/ui-common/src/lib/documentation-header.tsx
+++ b/nx-dev/ui-common/src/lib/documentation-header.tsx
@@ -192,21 +192,6 @@ export function DocumentationHeader({
         </div>
         {/*NAVIGATION*/}
         <div className="hidden flex-grow lg:flex">{/* SPACER */}</div>
-        <div className="hidden flex-grow text-xs italic lg:flex">
-          <div className="relative">
-            <span className="mr-2">State of JS survey is online!</span>
-            <Link
-              href="https://stateofjs.com/en-us/"
-              rel="noreferrer"
-              target="_blank"
-              className="text-blue-500 underline dark:text-sky-500"
-            >
-              <span className="absolute inset-0" aria-hidden="true" />
-              Give Nx a thumbs up
-              <span aria-hidden="true">&rarr;</span>
-            </Link>
-          </div>
-        </div>
         <div className="hidden flex-shrink-0 lg:flex">
           <nav
             role="accessory-nav"


### PR DESCRIPTION
It removes the two survey banners placed for the State of Javascript since the survey is now closed.