### PR TITLE
fix(storybook): pass down configureTestRunner option

### DIFF
--- a/packages/angular/src/generators/storybook-configuration/lib/generate-storybook-configuration.ts
+++ b/packages/angular/src/generators/storybook-configuration/lib/generate-storybook-configuration.ts
@@ -15,5 +15,6 @@ export async function generateStorybookConfiguration(
     linter: options.linter,
     cypressDirectory: options.cypressDirectory,
     tsConfiguration: options.tsConfiguration,
+    configureTestRunner: options.configureTestRunner,
   });
 }

--- a/packages/react/src/generators/storybook-configuration/configuration.ts
+++ b/packages/react/src/generators/storybook-configuration/configuration.ts
@@ -99,6 +99,7 @@ export async function storybookConfigurationGenerator(
     cypressDirectory: schema.cypressDirectory,
     standaloneConfig: schema.standaloneConfig,
     tsConfiguration: schema.tsConfiguration,
+    configureTestRunner: schema.configureTestRunner,
     bundler,
   });
 


### PR DESCRIPTION
For some reason, the `configureTestRunner` option was not getting passed down to the Storybook generator.
