### PR TITLE
docs(nxdev): check type of x-deprecated value

### DIFF
--- a/nx-dev/feature-package-schema-viewer/src/lib/parameter-view.tsx
+++ b/nx-dev/feature-package-schema-viewer/src/lib/parameter-view.tsx
@@ -68,7 +68,8 @@ export const ParameterView = (props: {
       }
     </div>
 
-    {props.deprecated && !!(props.schema as any)['x-deprecated'] && (
+    {props.deprecated &&
+    typeof (props.schema as any)['x-deprecated'] === 'string' ? (
       <div className="prose prose-slate dark:prose-invert mt-2 rounded-md bg-red-100 px-4 text-red-800 dark:bg-red-800 dark:text-red-100">
         {
           renderMarkdown(String((props.schema as any)['x-deprecated']), {
@@ -76,7 +77,7 @@ export const ParameterView = (props: {
           }).node
         }
       </div>
-    )}
+    ) : null}
   </div>
 );
 


### PR DESCRIPTION
It now checks the type of `x-deprecated`'s value in order to show a message only when its type is `string`.