### PR TITLE
feat(angular): add ast util to add a provider to bootstrapApplication

### DIFF
--- a/packages/angular/src/utils/nx-devkit/route-utils.ts
+++ b/packages/angular/src/utils/nx-devkit/route-utils.ts
@@ -131,12 +131,18 @@ export function addProviderToRoute(
       }
     );
 
-    const routeText = selectedRouteNode.getText();
     if (routeProivdersNodes.length === 0) {
       const newFileContents = `${routesFileContents.slice(
         0,
         selectedRouteNode.getEnd() - 1
-      )}, providers: [${providerToAdd}]${routesFileContents.slice(
+      )}${
+        routesFileContents
+          .slice(0, selectedRouteNode.getEnd() - 1)
+          .trim()
+          .endsWith(',')
+          ? ''
+          : ', '
+      }providers: [${providerToAdd}]${routesFileContents.slice(
         selectedRouteNode.getEnd() - 1,
         routesFileContents.length
       )}`;


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
Some providers with standalone applications must be attached to the bootstrapApplication call. We currently have no convenient way of handling this.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Add an ast util to do this.

