### PR TITLE
feat(bundling): add option to esbuild to not bundle

### DIFF
--- a/docs/generated/packages/esbuild/executors/esbuild.json
+++ b/docs/generated/packages/esbuild/executors/esbuild.json
@@ -41,6 +41,11 @@
         "items": { "type": "string" },
         "default": []
       },
+      "bundle": {
+        "type": "boolean",
+        "description": "Whether to bundle the main entry point and additional entry points. Set to false to keep individual output files.",
+        "default": true
+      },
       "format": {
         "type": "array",
         "description": "List of module formats to output. Defaults to matching format from tsconfig (e.g. CJS for CommonJS, and ESM otherwise).",

--- a/e2e/esbuild/src/esbuild.test.ts
+++ b/e2e/esbuild/src/esbuild.test.ts
@@ -117,4 +117,22 @@ describe('EsBuild Plugin', () => {
     expect(runResult).toMatch(/Hello world/);
     expect(runResult).toMatch(/Hello from child lib/);
   }, 300_000);
+
+  it('should support non-bundle builds', () => {
+    const myPkg = uniq('my-pkg');
+    runCLI(`generate @nrwl/js:lib ${myPkg} --bundler=esbuild`);
+    updateFile(`libs/${myPkg}/src/lib/${myPkg}.ts`, `console.log('Hello');\n`);
+    updateFile(`libs/${myPkg}/src/index.ts`, `import './lib/${myPkg}.js';\n`);
+
+    runCLI(`build ${myPkg} --bundle=false`);
+
+    checkFilesExist(
+      `dist/libs/${myPkg}/lib/${myPkg}.js`,
+      `dist/libs/${myPkg}/index.js`
+    );
+    // Test files are excluded in tsconfig (e.g. tsconfig.lib.json)
+    checkFilesDoNotExist(`dist/libs/${myPkg}/lib/${myPkg}.spec.js`);
+    // Can run package (package.json fields are correctly generated)
+    expect(runCommand(`node dist/libs/${myPkg}`)).toMatch(/Hello/);
+  }, 300_000);
 });

--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -34,6 +34,7 @@
     "@nrwl/workspace": "file:../workspace",
     "chalk": "4.1.0",
     "dotenv": "~10.0.0",
+    "fast-glob": "3.2.7",
     "fs-extra": "^10.1.0",
     "tslib": "^2.3.0"
   },

--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.spec.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.spec.ts
@@ -3,6 +3,7 @@ import { ExecutorContext } from 'nx/src/config/misc-interfaces';
 
 describe('buildEsbuildOptions', () => {
   const context: ExecutorContext = {
+    projectName: 'myapp',
     workspace: {
       version: 2,
       projects: {
@@ -27,6 +28,7 @@ describe('buildEsbuildOptions', () => {
       buildEsbuildOptions(
         'esm',
         {
+          bundle: true,
           platform: 'browser',
           main: 'apps/myapp/src/index.ts',
           outputPath: 'dist/apps/myapp',
@@ -62,6 +64,7 @@ describe('buildEsbuildOptions', () => {
       buildEsbuildOptions(
         'esm',
         {
+          bundle: true,
           platform: 'browser',
           main: 'apps/myapp/src/index.ts',
           additionalEntryPoints: ['apps/myapp/src/extra-entry.ts'],
@@ -98,6 +101,7 @@ describe('buildEsbuildOptions', () => {
       buildEsbuildOptions(
         'cjs',
         {
+          bundle: true,
           platform: 'browser',
           main: 'apps/myapp/src/index.ts',
           outputPath: 'dist/apps/myapp',
@@ -133,6 +137,7 @@ describe('buildEsbuildOptions', () => {
       buildEsbuildOptions(
         'cjs',
         {
+          bundle: true,
           platform: 'node',
           main: 'apps/myapp/src/index.ts',
           outputPath: 'dist/apps/myapp',
@@ -165,6 +170,7 @@ describe('buildEsbuildOptions', () => {
       buildEsbuildOptions(
         'esm',
         {
+          bundle: true,
           platform: 'node',
           main: 'apps/myapp/src/index.ts',
           outputPath: 'dist/apps/myapp',
@@ -200,6 +206,7 @@ describe('buildEsbuildOptions', () => {
       buildEsbuildOptions(
         'cjs',
         {
+          bundle: true,
           platform: 'node',
           main: 'apps/myapp/src/index.ts',
           outputPath: 'dist/apps/myapp',
@@ -236,6 +243,7 @@ describe('buildEsbuildOptions', () => {
       buildEsbuildOptions(
         'esm',
         {
+          bundle: true,
           platform: 'node',
           main: 'apps/myapp/src/index.ts',
           outputPath: 'dist/apps/myapp',

--- a/packages/esbuild/src/executors/esbuild/schema.d.ts
+++ b/packages/esbuild/src/executors/esbuild/schema.d.ts
@@ -6,6 +6,7 @@ export interface EsBuildExecutorOptions {
   additionalEntryPoints?: string[];
   assets: AssetGlob[];
   buildableProjectDepsInPackageJsonType?: 'dependencies' | 'peerDependencies';
+  bundle?: boolean;
   deleteOutputPath?: boolean;
   dependenciesFieldType?: boolean;
   esbuildOptions?: Record<string, any>;

--- a/packages/esbuild/src/executors/esbuild/schema.json
+++ b/packages/esbuild/src/executors/esbuild/schema.json
@@ -40,6 +40,11 @@
       },
       "default": []
     },
+    "bundle": {
+      "type": "boolean",
+      "description": "Whether to bundle the main entry point and additional entry points. Set to false to keep individual output files.",
+      "default": true
+    },
     "format": {
       "type": "array",
       "description": "List of module formats to output. Defaults to matching format from tsconfig (e.g. CJS for CommonJS, and ESM otherwise).",


### PR DESCRIPTION
This PR adds `bundle: false` support for esbuild. When bundle is off, the behavior is the same as tsc and swc, where `include` and `exclude` from corresponding tsconfig file determines what files are transpiled.

## Current Behavior
`nx build --bundle=false` does not work

## Expected Behavior
`nx build --bundle=false` results in multiple transpiled files

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #13997 
