### PR TITLE
fix(testing): only check provided project is root for cypress-project…

### DIFF
--- a/packages/cypress/src/generators/cypress-project/cypress-project.spec.ts
+++ b/packages/cypress/src/generators/cypress-project/cypress-project.spec.ts
@@ -286,6 +286,32 @@ describe('Cypress Project', () => {
             ])
           );
         });
+
+        it('should not generate a root project when the passed in project is not the root project', async () => {
+          addProjectConfiguration(tree, 'root', {
+            root: '.',
+          });
+          addProjectConfiguration(tree, 'my-cool-app', {
+            root: 'apps/my-app',
+          });
+          await cypressProjectGenerator(tree, {
+            ...defaultOptions,
+            name: 'e2e-tests',
+            baseUrl: 'http://localhost:1234',
+            project: 'my-app',
+          });
+          expect(tree.listChanges().map((c) => c.path)).toEqual(
+            expect.arrayContaining([
+              'apps/e2e-tests/cypress.config.ts',
+              'apps/e2e-tests/src/e2e/app.cy.ts',
+              'apps/e2e-tests/src/fixtures/example.json',
+              'apps/e2e-tests/src/support/app.po.ts',
+              'apps/e2e-tests/src/support/commands.ts',
+              'apps/e2e-tests/src/support/e2e.ts',
+              'apps/e2e-tests/tsconfig.json',
+            ])
+          );
+        });
       });
     });
 

--- a/packages/cypress/src/generators/cypress-project/cypress-project.ts
+++ b/packages/cypress/src/generators/cypress-project/cypress-project.ts
@@ -316,7 +316,8 @@ function normalizeOptions(host: Tree, options: Schema): CypressProjectSchema {
   if (
     maybeRootProject?.root === '.' ||
     // should still check to see if we are in a standalone based workspace
-    Array.from(projects.values()).some((config) => config.root === '.')
+    (!maybeRootProject &&
+      Array.from(projects.values()).some((config) => config.root === '.'))
   ) {
     projectName = options.name;
     projectRoot = options.name;


### PR DESCRIPTION
… generator

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

cypress generating projects in the root directory when provided project is not the root project

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

cypress uses the provided project to determine the if it's the root project

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14138
