### PR TITLE
cleanup(webpack): remove previously deprecated options

### DIFF
--- a/docs/generated/packages/webpack/executors/dev-server.json
+++ b/docs/generated/packages/webpack/executors/dev-server.json
@@ -68,10 +68,6 @@
         "type": "number",
         "description": "Memory limit for type checking service process in `MB`."
       },
-      "maxWorkers": {
-        "type": "number",
-        "description": "Number of workers to use for type checking."
-      },
       "baseHref": {
         "type": "string",
         "description": "Base url for the application being built."

--- a/docs/generated/packages/webpack/executors/webpack.json
+++ b/docs/generated/packages/webpack/executors/webpack.json
@@ -200,62 +200,6 @@
         },
         "default": []
       },
-      "budgets": {
-        "description": "Budget thresholds to ensure parts of your application stay within boundaries which you set.",
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "description": "The type of budget.",
-              "enum": [
-                "all",
-                "allScript",
-                "any",
-                "anyScript",
-                "bundle",
-                "initial"
-              ]
-            },
-            "name": {
-              "type": "string",
-              "description": "The name of the bundle."
-            },
-            "baseline": {
-              "type": "string",
-              "description": "The baseline size for comparison."
-            },
-            "maximumWarning": {
-              "type": "string",
-              "description": "The maximum threshold for warning relative to the baseline."
-            },
-            "maximumError": {
-              "type": "string",
-              "description": "The maximum threshold for error relative to the baseline."
-            },
-            "minimumWarning": {
-              "type": "string",
-              "description": "The minimum threshold for warning relative to the baseline."
-            },
-            "minimumError": {
-              "type": "string",
-              "description": "The minimum threshold for error relative to the baseline."
-            },
-            "warning": {
-              "type": "string",
-              "description": "The threshold for warning relative to the baseline (min & max)."
-            },
-            "error": {
-              "type": "string",
-              "description": "The threshold for error relative to the baseline (min & max)."
-            }
-          },
-          "additionalProperties": false,
-          "required": ["type"]
-        },
-        "default": []
-      },
       "namedChunks": {
         "type": "boolean",
         "description": "Names the produced bundles according to their entry file.",
@@ -398,11 +342,6 @@
         "description": "Memory limit for type checking service process in `MB`.",
         "default": 2048
       },
-      "maxWorkers": {
-        "type": "number",
-        "description": "Number of workers to use for type checking.",
-        "default": 2
-      },
       "fileReplacements": {
         "description": "Replace files with other files in the build.",
         "type": "array",
@@ -476,57 +415,6 @@
           },
           { "type": "string" }
         ]
-      },
-      "budget": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "description": "The type of budget.",
-            "enum": [
-              "all",
-              "allScript",
-              "any",
-              "anyScript",
-              "bundle",
-              "initial"
-            ]
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the bundle."
-          },
-          "baseline": {
-            "type": "string",
-            "description": "The baseline size for comparison."
-          },
-          "maximumWarning": {
-            "type": "string",
-            "description": "The maximum threshold for warning relative to the baseline."
-          },
-          "maximumError": {
-            "type": "string",
-            "description": "The maximum threshold for error relative to the baseline."
-          },
-          "minimumWarning": {
-            "type": "string",
-            "description": "The minimum threshold for warning relative to the baseline."
-          },
-          "minimumError": {
-            "type": "string",
-            "description": "The minimum threshold for error relative to the baseline."
-          },
-          "warning": {
-            "type": "string",
-            "description": "The threshold for warning relative to the baseline (min & max)."
-          },
-          "error": {
-            "type": "string",
-            "description": "The threshold for error relative to the baseline (min & max)."
-          }
-        },
-        "additionalProperties": false,
-        "required": ["type"]
       },
       "extraEntryPoint": {
         "oneOf": [

--- a/packages/webpack/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/webpack/src/executors/dev-server/dev-server.impl.ts
@@ -98,9 +98,6 @@ function getBuildOptions(
   const overrides: Partial<WebpackExecutorOptions> = {
     watch: false,
   };
-  if (options.maxWorkers) {
-    overrides.maxWorkers = options.maxWorkers;
-  }
   if (options.memoryLimit) {
     overrides.memoryLimit = options.memoryLimit;
   }

--- a/packages/webpack/src/executors/dev-server/schema.d.ts
+++ b/packages/webpack/src/executors/dev-server/schema.d.ts
@@ -12,7 +12,6 @@ export interface WebDevServerOptions {
   hmr: boolean;
   watch: boolean;
   allowedHosts: string;
-  maxWorkers?: number;
   memoryLimit?: number;
   baseHref?: string;
 }

--- a/packages/webpack/src/executors/dev-server/schema.json
+++ b/packages/webpack/src/executors/dev-server/schema.json
@@ -65,10 +65,6 @@
       "type": "number",
       "description": "Memory limit for type checking service process in `MB`."
     },
-    "maxWorkers": {
-      "type": "number",
-      "description": "Number of workers to use for type checking."
-    },
     "baseHref": {
       "type": "string",
       "description": "Base url for the application being built."

--- a/packages/webpack/src/executors/webpack/schema.d.ts
+++ b/packages/webpack/src/executors/webpack/schema.d.ts
@@ -41,7 +41,6 @@ export interface WebpackExecutorOptions {
   additionalEntryPoints?: AdditionalEntryPoint[];
   assets?: Array<AssetGlob | string>;
   baseHref?: string;
-  budgets?: any[];
   buildLibsFromSource?: boolean;
   commonChunk?: boolean;
   compiler?: 'babel' | 'swc' | 'tsc';
@@ -57,7 +56,6 @@ export interface WebpackExecutorOptions {
   generatePackageJson?: boolean;
   index?: string;
   main: string;
-  maxWorkers?: number;
   memoryLimit?: number;
   namedChunks?: boolean;
   optimization?: boolean | OptimizationOptions;

--- a/packages/webpack/src/executors/webpack/schema.json
+++ b/packages/webpack/src/executors/webpack/schema.json
@@ -120,14 +120,6 @@
       },
       "default": []
     },
-    "budgets": {
-      "description": "Budget thresholds to ensure parts of your application stay within boundaries which you set.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/budget"
-      },
-      "default": []
-    },
     "namedChunks": {
       "type": "boolean",
       "description": "Names the produced bundles according to their entry file.",
@@ -271,11 +263,6 @@
       "description": "Memory limit for type checking service process in `MB`.",
       "default": 2048
     },
-    "maxWorkers": {
-      "type": "number",
-      "description": "Number of workers to use for type checking.",
-      "default": 2
-    },
     "fileReplacements": {
       "description": "Replace files with other files in the build.",
       "type": "array",
@@ -353,50 +340,6 @@
           "type": "string"
         }
       ]
-    },
-    "budget": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "description": "The type of budget.",
-          "enum": ["all", "allScript", "any", "anyScript", "bundle", "initial"]
-        },
-        "name": {
-          "type": "string",
-          "description": "The name of the bundle."
-        },
-        "baseline": {
-          "type": "string",
-          "description": "The baseline size for comparison."
-        },
-        "maximumWarning": {
-          "type": "string",
-          "description": "The maximum threshold for warning relative to the baseline."
-        },
-        "maximumError": {
-          "type": "string",
-          "description": "The maximum threshold for error relative to the baseline."
-        },
-        "minimumWarning": {
-          "type": "string",
-          "description": "The minimum threshold for warning relative to the baseline."
-        },
-        "minimumError": {
-          "type": "string",
-          "description": "The minimum threshold for error relative to the baseline."
-        },
-        "warning": {
-          "type": "string",
-          "description": "The threshold for warning relative to the baseline (min & max)."
-        },
-        "error": {
-          "type": "string",
-          "description": "The threshold for error relative to the baseline (min & max)."
-        }
-      },
-      "additionalProperties": false,
-      "required": ["type"]
     },
     "extraEntryPoint": {
       "oneOf": [


### PR DESCRIPTION
This PR removes `@nrwl/webpack:webpack` options that were previously deprecated and haven't supported in a long time.

* `maxWorkers` - This was passed to `fork-ts-checker-webpack-plugin` previously, but it was removed over a year ago since that plugin removed support for it.
* `budgets` - This support was removed a few major versions ago in Nx but we never removed it from the schema. It does nothing.

Does not have any impact on users.