### PR TITLE
chore(js): add tslib dependency

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -42,7 +42,8 @@
     "js-tokens": "^4.0.0",
     "minimatch": "3.0.5",
     "source-map-support": "0.5.19",
-    "tree-kill": "1.2.2"
+    "tree-kill": "1.2.2",
+    "tslib": "^2.3.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
tslib dependency required due to importHelpers tsconfig setting

ISSUES CLOSED: #14152

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Due to the "importHelpers": true, and "target": "es2015", in the tsconfig.base.json,
`const tslib_1 = require("tslib");` is added to js/src/utils/add-babel-inputs.js because of the async/await code in that file.

Therefore, tslib needs to be added as a dependency to @nrwl/js.

This came up for me because I'm using yarn pnp which is a strict environment.
Here is the error:

@nrwl/js tried to access tslib, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: tslib
Require stack:

/node_modules/@nrwl/js/src/utils/add-babel-inputs.js

## Expected Behavior
tslib should be added as a dependency to resolve the issue

## Related Issue(s)
Fixes #14152
