### PR TITLE
fix(react): fix skipRemotes in moduleFederationDevServer

### DIFF
--- a/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -37,9 +37,10 @@ export default async function* moduleFederationDevServer(
   }
 
   const remotesToSkip = new Set(options.skipRemotes ?? []);
-  const knownRemotes = (moduleFederationConfig.remotes ?? []).filter(
-    (r) => !remotesToSkip.has(r)
-  );
+  const knownRemotes = (moduleFederationConfig.remotes ?? []).filter((r) => {
+    const validRemote = Array.isArray(r) ? r[0] : r;
+    return !remotesToSkip.has(validRemote);
+  });
 
   const devServeApps = !options.devRemotes
     ? []


### PR DESCRIPTION
option skipRemotes isn't working when use array multidimensional in moduleFederationConfig

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When using multidimensional array in the remotes option in module-federation-config.js it makes the skipRemotes option not work when putting the names of the applications to be ignored.

Example:
```js
// module-federation.config.js
 const moduleFederationConfig = {
  name: 'admin',
  remotes: [
    ['gallery-admin', 'http://localhost:8000/v1/static/galleries/remoteEntry.js'],
    ['other-admin', 'http://localhost:8000/v1/static/ola/remoteEntry.js'],
  ],
}
```

```json
// project.json
{ "skipRemotes": ["other-admin"] }
```
When run the command `yarn nx run admin:serve` the application in the skip config continues to be triggered

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When run the command `yarn nx run admin:serve` the application in the skip config should not be triggered
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
