### PR TITLE
feat(angular): add backwards compatibility to module-federation-dev-server

### DIFF
--- a/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -5,8 +5,6 @@ import {
   Workspaces,
 } from '@nrwl/devkit';
 import { scheduleTarget } from 'nx/src/adapter/ngcli-adapter';
-import { BuilderContext, createBuilder } from '@angular-devkit/architect';
-import { JsonObject } from '@angular-devkit/core';
 import { executeWebpackDevServerBuilder } from '../webpack-dev-server/webpack-dev-server.impl';
 import { readProjectsConfigurationFromProjectGraph } from 'nx/src/project-graph/project-graph';
 import {
@@ -17,7 +15,7 @@ import {
 
 export function executeModuleFederationDevServerBuilder(
   schema: Schema,
-  context: BuilderContext
+  context: import('@angular-devkit/architect').BuilderContext
 ) {
   const { ...options } = schema;
   const projectGraph = readCachedProjectGraph();
@@ -95,6 +93,6 @@ export function executeModuleFederationDevServerBuilder(
   return executeWebpackDevServerBuilder(options, context);
 }
 
-export default createBuilder<JsonObject & Schema>(
+export default require('@angular-devkit/architect').createBuilder(
   executeModuleFederationDevServerBuilder
 );

--- a/packages/angular/src/builders/utilities/buildable-libs.ts
+++ b/packages/angular/src/builders/utilities/buildable-libs.ts
@@ -1,4 +1,3 @@
-import { BuilderContext } from '@angular-devkit/architect';
 import {
   calculateProjectDependencies,
   createTmpTsConfig,
@@ -9,7 +8,7 @@ import { join } from 'path';
 
 export function createTmpTsConfigForBuildableLibs(
   tsConfigPath: string,
-  context: BuilderContext,
+  context: import('@angular-devkit/architect').BuilderContext,
   target?: string
 ) {
   let dependencies: DependentBuildableProjectNode[];

--- a/packages/angular/src/builders/utilities/module-federation.ts
+++ b/packages/angular/src/builders/utilities/module-federation.ts
@@ -1,12 +1,11 @@
 import { ProjectConfiguration } from 'nx/src/config/workspace-json-project-json';
-import { BuilderContext } from '@angular-devkit/architect';
 import { join } from 'path';
 import { existsSync, readFileSync } from 'fs';
 import { Remotes } from '@nrwl/devkit';
 
 export function getDynamicRemotes(
   project: ProjectConfiguration,
-  context: BuilderContext,
+  context: import('@angular-devkit/architect').BuilderContext,
   workspaceProjects: Record<string, ProjectConfiguration>,
   remotesToSkip: Set<string>
 ): string[] {
@@ -67,7 +66,7 @@ export function getDynamicRemotes(
 
 export function getStaticRemotes(
   project: ProjectConfiguration,
-  context: BuilderContext,
+  context: import('@angular-devkit/architect').BuilderContext,
   workspaceProjects: Record<string, ProjectConfiguration>,
   remotesToSkip: Set<string>
 ): string[] {

--- a/packages/angular/src/builders/utilities/webpack.ts
+++ b/packages/angular/src/builders/utilities/webpack.ts
@@ -1,11 +1,10 @@
-import type { Target } from '@angular-devkit/architect';
 import { merge } from 'webpack-merge';
 
 export async function mergeCustomWebpackConfig(
   baseWebpackConfig: any,
   pathToWebpackConfig: string,
   options: { tsConfig: string; [k: string]: any },
-  target: Target
+  target: import('@angular-devkit/architect').Target
 ) {
   const customWebpackConfiguration = resolveCustomWebpackConfig(
     pathToWebpackConfig,


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
`@nrwl/angular:module-federation-dev-server` on Nx 15+ does not work for Angular 14 applications. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should ensure backwards compatibility by using the angular-devkit that is installed in the users' workspaces. 

This has been tested with Angular 14 and Angular 15.

Tested:
 - Serving host with static remote
 - Serving host with dev remote

Note: To test in Angular 14, you'll need to delete the `@angular-devkit` folder from `node_modules/@nrwl/angular/node_modules` to allow the executor to find the repo's top-level angular-devkit. 

This will be resolved when backwards compat support is complete and we move `@nrwl/angular` to use `peerDependencies` rather than direct dependency.
