### PR TITLE
feat(angular): add backwards compatibility to module-federation-dev-ssr

### DIFF
--- a/packages/angular/src/builders/module-federation-dev-ssr/module-federation-dev-ssr.impl.ts
+++ b/packages/angular/src/builders/module-federation-dev-ssr/module-federation-dev-ssr.impl.ts
@@ -1,8 +1,4 @@
 import type { Schema } from './schema';
-import type { BuilderContext } from '@angular-devkit/architect';
-import { createBuilder } from '@angular-devkit/architect';
-import type { JsonObject } from '@angular-devkit/core';
-import { executeSSRDevServerBuilder } from '@nguniversal/builders';
 import { readProjectsConfigurationFromProjectGraph } from 'nx/src/project-graph/project-graph';
 import {
   readCachedProjectGraph,
@@ -22,7 +18,7 @@ import { scheduleTarget } from 'nx/src/adapter/ngcli-adapter';
 
 export function executeModuleFederationDevSSRBuilder(
   schema: Schema,
-  context: BuilderContext
+  context: import('@angular-devkit/architect').BuilderContext
 ) {
   const { ...options } = schema;
   const projectGraph = readCachedProjectGraph();
@@ -132,10 +128,13 @@ export function executeModuleFederationDevSSRBuilder(
   }
 
   return from(Promise.all(remoteProcessPromises)).pipe(
-    switchMap(() => executeSSRDevServerBuilder(options, context))
+    switchMap(() => from(import('@nguniversal/builders'))),
+    switchMap(({ executeSSRDevServerBuilder }) =>
+      executeSSRDevServerBuilder(options, context)
+    )
   );
 }
 
-export default createBuilder<JsonObject & Schema>(
+export default require('@angular-devkit/architect').createBuilder(
   executeModuleFederationDevSSRBuilder
 );


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
`@nrwl/angular:module-federation-dev-ssr` on Nx 15+ does not work for Angular 14 applications. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should ensure backwards compatibility by using the angular-devkit that is installed in the users' workspaces. 

This has been tested with Angular 14 and Angular 15.

Tested:
 - Serving host with static remote
 - Serving host with dev remote

Note: To test in Angular 14, you'll need to delete the `@angular-devkit` folder from `node_modules/@nrwl/angular/node_modules` to allow the executor to find the repo's top-level angular-devkit. 

This will be resolved when backwards compat support is complete and we move `@nrwl/angular` to use `peerDependencies` rather than direct dependency.
