### PR TITLE
fix(web): dynamic default unitTestRunner based on bundler for @nrwl/web:app

### DIFF
--- a/docs/generated/packages/web/generators/application.json
+++ b/docs/generated/packages/web/generators/application.json
@@ -71,8 +71,7 @@
       "unitTestRunner": {
         "type": "string",
         "enum": ["jest", "vitest", "none"],
-        "description": "Test runner to use for unit tests",
-        "default": "jest"
+        "description": "Test runner to use for unit tests. Default value is 'jest' when using 'webpack' or 'none' as the bundler and 'vitest' when using 'vite' as the bundler"
       },
       "inSourceTests": {
         "type": "boolean",

--- a/packages/web/src/generators/application/application.ts
+++ b/packages/web/src/generators/application/application.ts
@@ -202,7 +202,7 @@ export async function applicationGenerator(host: Tree, schema: Schema) {
       uiFramework: 'none',
       project: options.projectName,
       newProject: true,
-      includeVitest: true,
+      includeVitest: options.unitTestRunner === 'vitest',
       inSourceTests: options.inSourceTests,
     });
     tasks.push(viteTask);
@@ -298,7 +298,7 @@ function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
     ? options.tags.split(',').map((s) => s.trim())
     : [];
 
-  if (options.bundler === 'vite') {
+  if (options.bundler === 'vite' && !options.unitTestRunner) {
     options.unitTestRunner = 'vitest';
   }
 

--- a/packages/web/src/generators/application/schema.json
+++ b/packages/web/src/generators/application/schema.json
@@ -74,8 +74,7 @@
     "unitTestRunner": {
       "type": "string",
       "enum": ["jest", "vitest", "none"],
-      "description": "Test runner to use for unit tests",
-      "default": "jest"
+      "description": "Test runner to use for unit tests. Default value is 'jest' when using 'webpack' or 'none' as the bundler and 'vitest' when using 'vite' as the bundler"
     },
     "inSourceTests": {
       "type": "boolean",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

--bundler=vite --unitTestRunner=jest does not add jest. only vitest

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
--unitTestRunner should be respected
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14167 
