### PR TITLE
feat(webpack): use webpack.sources instead of webpack-sources package

### DIFF
--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -74,7 +74,6 @@
     "webpack-dev-server": "^4.9.3",
     "webpack-merge": "^5.8.0",
     "webpack-node-externals": "^3.0.0",
-    "webpack-sources": "^3.2.3",
     "webpack-subresource-integrity": "^5.1.0"
   },
   "publishConfig": {

--- a/packages/webpack/src/utils/webpack/write-index-html.ts
+++ b/packages/webpack/src/utils/webpack/write-index-html.ts
@@ -3,7 +3,7 @@ import { readFileSync, writeFileSync } from 'fs';
 import { interpolateEnvironmentVariablesToIndex } from './interpolate-env-variables-to-index';
 import { generateEntryPoints } from './package-chunk-sort';
 import { createHash } from 'crypto';
-import { RawSource, ReplaceSource } from 'webpack-sources';
+import * as webpack from 'webpack';
 
 import type { EmittedFile, ExtraEntryPoint } from '../models';
 
@@ -138,8 +138,8 @@ export function augmentIndexHtml(params: AugmentIndexHtmlOptions): string {
   }
 
   // Inject into the html
-  const indexSource = new ReplaceSource(
-    new RawSource(params.inputContent),
+  const indexSource = new webpack.sources.ReplaceSource(
+    new webpack.sources.RawSource(params.inputContent),
     params.input
   );
 
@@ -260,7 +260,7 @@ export function augmentIndexHtml(params: AugmentIndexHtmlOptions): string {
     parse5.serialize(styleElements, { treeAdapter })
   );
 
-  return indexSource.source();
+  return indexSource.source().toString();
 }
 
 function _generateSriAttributes(content: string) {


### PR DESCRIPTION
webpack.sources is an re-export of webpack-sources and this change keeps the versions in sync. This reduces install size slightly.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
