### PR TITLE
fix(bundling): update esbuild executor to emit correct events

### DIFF
--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
@@ -84,7 +84,7 @@ function getOutExtension(
     : CJS_FILE_EXTENSION;
 }
 
-function getOutfile(
+export function getOutfile(
   format: 'cjs' | 'esm',
   options: EsBuildExecutorOptions,
   context: ExecutorContext


### PR DESCRIPTION
The esbuild executor is not emitting the correct `outfile` when watching, and when not watching it does not emit events.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
