### PR TITLE
fix(vite): do not include vitest types in tsconfig.json

### DIFF
--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -342,49 +342,42 @@ export function editTsConfig(tree: Tree, options: Schema) {
 
   const config = readJson(tree, `${projectConfig.root}/tsconfig.json`);
 
+  const commonCompilerOptions = {
+    target: 'ESNext',
+    useDefineForClassFields: true,
+    module: 'ESNext',
+    strict: true,
+    moduleResolution: 'Node',
+    resolveJsonModule: true,
+    isolatedModules: true,
+    types: ['vite/client'],
+    noEmit: true,
+  };
+
   switch (options.uiFramework) {
     case 'react':
       config.compilerOptions = {
-        target: 'ESNext',
-        useDefineForClassFields: true,
-        module: 'ESNext',
+        ...commonCompilerOptions,
         lib: ['DOM', 'DOM.Iterable', 'ESNext'],
         allowJs: false,
-        skipLibCheck: true,
         esModuleInterop: false,
+        skipLibCheck: true,
         allowSyntheticDefaultImports: true,
-        strict: true,
         forceConsistentCasingInFileNames: true,
-        moduleResolution: 'Node',
-        resolveJsonModule: true,
-        isolatedModules: true,
-        noEmit: true,
         jsx: 'react-jsx',
-        types: options.includeVitest
-          ? ['vite/client', 'vitest']
-          : ['vite/client'],
       };
       config.include = [...config.include, 'src'];
       break;
     case 'none':
       config.compilerOptions = {
-        target: 'ESNext',
-        useDefineForClassFields: true,
-        module: 'ESNext',
+        ...commonCompilerOptions,
         lib: ['ESNext', 'DOM'],
         skipLibCheck: true,
         esModuleInterop: true,
         strict: true,
-        moduleResolution: 'Node',
-        resolveJsonModule: true,
-        isolatedModules: true,
-        noEmit: true,
         noUnusedLocals: true,
         noUnusedParameters: true,
         noImplicitReturns: true,
-        types: options.includeVitest
-          ? ['vite/client', 'vitest']
-          : ['vite/client'],
       };
       config.include = [...config.include, 'src'];
       break;


### PR DESCRIPTION
The vitest types are already included in tsconfig.spec.json

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`vitest` types are added to tsconfig.json

They are already in [`tsconfig.spec.json`](https://github.com/nrwl/nx/blob/e8b2731a479c365a7191b610f983fcc3f863f9dd/packages/vite/src/generators/vitest/vitest-generator.ts#L106)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`vitest` types are added to tsconfig.json

## Related Issue(s)

https://github.com/nrwl/nx/issues/14167#issuecomment-1372701181
