### PR TITLE
fix(testing): do not add a duplicate tsconfig.spec.json ref

### DIFF
--- a/packages/jest/src/generators/jest-project/lib/update-tsconfig.ts
+++ b/packages/jest/src/generators/jest-project/lib/update-tsconfig.ts
@@ -13,7 +13,10 @@ export function updateTsConfig(host: Tree, options: JestProjectSchema) {
     );
   }
   updateJson(host, join(projectConfig.root, 'tsconfig.json'), (json) => {
-    if (json.references) {
+    if (
+      json.references &&
+      !json.references.some((r) => r.path === './tsconfig.spec.json')
+    ) {
       json.references.push({
         path: './tsconfig.spec.json',
       });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Jest could add a duplicate ref to the spec file in tsconfig.json

See https://github.com/nrwl/nx/issues/14167#issuecomment-1372701181

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Jest could **not** add a duplicate ref to the spec file in tsconfig.json

