### PR TITLE
fix(nextjs): hide lockfile generation behind a flag so it can be toggled on and off

### DIFF
--- a/docs/generated/packages/next/executors/build.json
+++ b/docs/generated/packages/next/executors/build.json
@@ -53,6 +53,11 @@
         "type": "boolean",
         "description": "Include `devDependencies` in the generated package.json file. By default only production `dependencies` are included.",
         "default": false
+      },
+      "generateLockfile": {
+        "type": "boolean",
+        "description": "Generate a lockfile (e.g. yarn.lock) that matches the workspace lockfile to ensure package versions match.",
+        "default": false
       }
     },
     "required": ["root", "outputPath"],

--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -12,9 +12,9 @@ import {
   updateFile,
   updateProjectConfig,
 } from '@nrwl/e2e/utils';
-import { checkApp } from './utils';
 import { stringUtils } from '@nrwl/workspace';
 import * as http from 'http';
+import { checkApp } from './utils';
 
 describe('Next.js Applications', () => {
   let proj: string;

--- a/e2e/next/src/utils.ts
+++ b/e2e/next/src/utils.ts
@@ -1,14 +1,11 @@
 import {
   checkFilesExist,
-  detectPackageManager,
   killPorts,
   readJson,
   runCLI,
   runCLIAsync,
   runCypressTests,
-  tmpProjPath,
 } from '../../utils';
-import { getLockFileName } from '../../../packages/nx/src/lock-file/lock-file';
 
 export async function checkApp(
   appName: string,
@@ -27,12 +24,6 @@ export async function checkApp(
   expect(packageJson.dependencies.react).toBeDefined();
   expect(packageJson.dependencies['react-dom']).toBeDefined();
   expect(packageJson.dependencies.next).toBeDefined();
-
-  checkFilesExist(
-    `dist/apps/${appName}/${getLockFileName(
-      detectPackageManager(tmpProjPath())
-    )}`
-  );
 
   if (opts.checkLint) {
     const lintResults = runCLI(`lint ${appName}`);

--- a/packages/next/src/executors/build/build.impl.ts
+++ b/packages/next/src/executors/build/build.impl.ts
@@ -90,11 +90,14 @@ export default async function buildExecutor(
     }
   );
   updatePackageJson(builtPackageJson, context);
-  const lockFile = createLockFile(builtPackageJson);
   writeJsonFile(`${options.outputPath}/package.json`, builtPackageJson);
-  writeFileSync(`${options.outputPath}/${getLockFileName()}`, lockFile, {
-    encoding: 'utf-8',
-  });
+
+  if (options.generateLockfile) {
+    const lockFile = createLockFile(builtPackageJson);
+    writeFileSync(`${options.outputPath}/${getLockFileName()}`, lockFile, {
+      encoding: 'utf-8',
+    });
+  }
 
   createNextConfigFile(options, context);
 

--- a/packages/next/src/executors/build/schema.json
+++ b/packages/next/src/executors/build/schema.json
@@ -53,6 +53,11 @@
       "type": "boolean",
       "description": "Include `devDependencies` in the generated package.json file. By default only production `dependencies` are included.",
       "default": false
+    },
+    "generateLockfile": {
+      "type": "boolean",
+      "description": "Generate a lockfile (e.g. yarn.lock) that matches the workspace lockfile to ensure package versions match.",
+      "default": false
     }
   },
   "required": ["root", "outputPath"]

--- a/packages/next/src/utils/types.ts
+++ b/packages/next/src/utils/types.ts
@@ -37,6 +37,7 @@ export interface NextBuildBuilderOptions {
   nextConfig?: string;
   buildLibsFromSource?: boolean;
   includeDevDependenciesInPackageJson?: boolean;
+  generateLockfile?: boolean;
   watch?: boolean;
 }
 


### PR DESCRIPTION
There are some issues with yarn and lockfile handling. This PR hides it behind a flag so it is opt-in rather than on at all times.

## Current Behavior
Some users are unable to build their app due to lockfile handling erroring out.

## Expected Behavior
Users should be able to build.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14106
