### PR TITLE
docs(testing): add info about --spec and link to storybook

### DIFF
--- a/docs/generated/packages/cypress/documents/overview.md
+++ b/docs/generated/packages/cypress/documents/overview.md
@@ -10,6 +10,8 @@ Cypress is a test runner built for the modern web. It has a lot of great feature
 ## Setting Up Cypress
 
 > Info about [Cypress Component Testing can be found here](/packages/cypress/documents/cypress-component-testing)
+>
+> Info about [using Cypress and Storybook can be found here](/packages/storybook/documents/overview-react#cypress-tests-for-storiesbook)
 
 If the `@nrwl/cypress` package is not installed, install the version that matches your `nx` package version.
 
@@ -54,6 +56,20 @@ You can run your e2e test against a production build by using the `production` [
 ```shell
 nx e2e frontend-e2e --configuration=production
 ```
+
+{% callout type="note" title="Selecting Specific Specs" %}
+
+You can use the `--spec` flag to glob for test files
+
+```bash
+# run the tests in the smoke/ directory
+nx e2e frontend-e2e --spec=**smoke/**
+
+# run the tests in smoke/ directory and with dashboard in the file name
+nx e2e frontend-e2e --spec=**smoke/**,**dashboard.cy**
+```
+
+{% /callout %}
 
 By default, Cypress will run in headless mode. You will have the result of all the tests and errors (if any) in your
 terminal. Screenshots and videos will be accessible in `dist/cypress/apps/frontend/screenshots` and `dist/cypress/apps/frontend/videos`.

--- a/docs/shared/packages/cypress/cypress-plugin.md
+++ b/docs/shared/packages/cypress/cypress-plugin.md
@@ -10,6 +10,8 @@ Cypress is a test runner built for the modern web. It has a lot of great feature
 ## Setting Up Cypress
 
 > Info about [Cypress Component Testing can be found here](/packages/cypress/documents/cypress-component-testing)
+>
+> Info about [using Cypress and Storybook can be found here](/packages/storybook/documents/overview-react#cypress-tests-for-storiesbook)
 
 If the `@nrwl/cypress` package is not installed, install the version that matches your `nx` package version.
 
@@ -54,6 +56,20 @@ You can run your e2e test against a production build by using the `production` [
 ```shell
 nx e2e frontend-e2e --configuration=production
 ```
+
+{% callout type="note" title="Selecting Specific Specs" %}
+
+You can use the `--spec` flag to glob for test files
+
+```bash
+# run the tests in the smoke/ directory
+nx e2e frontend-e2e --spec=**smoke/**
+
+# run the tests in smoke/ directory and with dashboard in the file name
+nx e2e frontend-e2e --spec=**smoke/**,**dashboard.cy**
+```
+
+{% /callout %}
 
 By default, Cypress will run in headless mode. You will have the result of all the tests and errors (if any) in your
 terminal. Screenshots and videos will be accessible in `dist/cypress/apps/frontend/screenshots` and `dist/cypress/apps/frontend/videos`.


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Cypress overview doesn't talk about integrating with storybook. 
Cypress overview doesn't talk about how to run a single or group of spec files

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

docs about storybook + cypress and how to use --spec

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
