### PR TITLE
feat(expo): add clean option to prebuild executor

### DIFF
--- a/docs/generated/packages/expo/executors/prebuild.json
+++ b/docs/generated/packages/expo/executors/prebuild.json
@@ -11,6 +11,11 @@
     "description": "Create native iOS and Android project files for building natively.",
     "type": "object",
     "properties": {
+      "clean": {
+        "type": "boolean",
+        "description": "Delete the native folders and regenerate them before applying changes",
+        "default": false
+      },
       "install": {
         "type": "boolean",
         "description": "Installing npm packages and CocoaPods.",

--- a/packages/expo/src/executors/prebuild/schema.d.ts
+++ b/packages/expo/src/executors/prebuild/schema.d.ts
@@ -3,6 +3,7 @@
 import { string } from 'yargs';
 
 export interface ExpoPrebuildOptions {
+  clean: boolean; // default is false
   install: boolean; // default is true
   platform: 'all' | 'android' | 'ios'; // default is all
   template?: string;

--- a/packages/expo/src/executors/prebuild/schema.json
+++ b/packages/expo/src/executors/prebuild/schema.json
@@ -8,6 +8,11 @@
   "description": "Create native iOS and Android project files for building natively.",
   "type": "object",
   "properties": {
+    "clean": {
+      "type": "boolean",
+      "description": "Delete the native folders and regenerate them before applying changes",
+      "default": false
+    },
     "install": {
       "type": "boolean",
       "description": "Installing npm packages and CocoaPods.",


### PR DESCRIPTION
## Current Behavior
**clean** param is missing on expo's **prebuild** executor

See prebuild param [here](https://github.com/expo/expo/blob/main/packages/%40expo/cli/src/prebuild/index.ts)

## Expected Behavior

"clean" should be available

## Related Issue(s)
/
Fixes #
