### PR TITLE
feat(misc): move ci options to configuration

### DIFF
--- a/docs/shared/monorepo-ci-azure.md
+++ b/docs/shared/monorepo-ci-azure.md
@@ -34,7 +34,7 @@ jobs:
       - script: npx nx format:check
 
       - script: npx nx affected --base=$(BASE_SHA) --target=lint --parallel=3
-      - script: npx nx affected --base=$(BASE_SHA) --target=test --parallel=3 --ci --code-coverage
+      - script: npx nx affected --base=$(BASE_SHA) --target=test --parallel=3 --configuration=ci
       - script: npx nx affected --base=$(BASE_SHA) --target=build --parallel=3
 ```
 
@@ -86,7 +86,7 @@ jobs:
 
       - script: npx nx-cloud record -- npx nx workspace-lint
       - script: npx nx-cloud record -- npx nx format:check --base=$(BASE_SHA) --head=$(HEAD_SHA)
-      - script: npx nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) --target=lint --parallel=3 & npx nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) --target=test --parallel=3 --ci --code-coverage & npx nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) --target=build --parallel=3
+      - script: npx nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) --target=lint --parallel=3 & npx nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) --target=test --parallel=3 --configuration=ci & npx nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) --target=build --parallel=3
 ```
 
 You can also use our [ci-workflow generator](/packages/workspace/generators/ci-workflow) to generate the pipeline file.

--- a/docs/shared/monorepo-ci-bitbucket-pipelines.md
+++ b/docs/shared/monorepo-ci-bitbucket-pipelines.md
@@ -16,7 +16,7 @@ pipelines:
             - npx nx workspace-lint
             - npx nx format:check
             - npx nx affected --target=lint --base=origin/master --parallel --max-parallel=3
-            - npx nx affected --target=test --base=origin/master --parallel --max-parallel=3 --ci --code-coverage
+            - npx nx affected --target=test --base=origin/master --parallel --max-parallel=3 --configuration=ci
             - npx nx affected --target=build --base=origin/master --head=HEAD --parallel  --max-parallel=3
 
   branches:
@@ -29,7 +29,7 @@ pipelines:
             - npm ci
             - npx nx workspace-lint
             - npx nx format:check
-            - npx nx affected --target=lint --base=origin/master --parallel --max-parallel=3 & npx nx affected --target=test --base=HEAD~1 --parallel --max-parallel=3 --ci --code-coverage & npx nx affected --target=build --base=HEAD~1 --parallel  --max-parallel=3
+            - npx nx affected --target=lint --base=origin/master --parallel --max-parallel=3 & npx nx affected --target=test --base=HEAD~1 --parallel --max-parallel=3 --configuration=ci & npx nx affected --target=build --base=HEAD~1 --parallel  --max-parallel=3
 ```
 
 The `pull-requests` and `main` jobs implement the CI workflow.

--- a/docs/shared/monorepo-ci-circle-ci.md
+++ b/docs/shared/monorepo-ci-circle-ci.md
@@ -21,7 +21,7 @@ jobs:
       - run: npx nx workspace-lint
       - run: npx nx format:check
       - run: npx nx affected --base=$NX_BASE --head=$NX_HEAD --target=lint --parallel=3
-      - run: npx nx affected --base=$NX_BASE --head=$NX_HEAD --target=test --parallel=3 --ci --code-coverage
+      - run: npx nx affected --base=$NX_BASE --head=$NX_HEAD --target=test --parallel=3 --configuration=ci
       - run: npx nx affected --base=$NX_BASE --head=$NX_HEAD --target=build --parallel=3
 workflows:
   build:
@@ -75,7 +75,7 @@ jobs:
 
       - run: npx nx-cloud record -- npx nx workspace-lint
       - run: npx nx-cloud record -- npx nx format:check
-      - run: npx nx affected --base=$NX_BASE --head=$NX_HEAD --target=lint --parallel=3 & npx nx affected --base=$NX_BASE --head=$NX_HEAD --target=test --parallel=3 --ci --code-coverage & npx nx affected --base=$NX_BASE --head=$NX_HEAD --target=build --parallel=3
+      - run: npx nx affected --base=$NX_BASE --head=$NX_HEAD --target=lint --parallel=3 & npx nx affected --base=$NX_BASE --head=$NX_HEAD --target=test --parallel=3 --configuration=ci & npx nx affected --base=$NX_BASE --head=$NX_HEAD --target=build --parallel=3
 workflows:
   build:
     jobs:

--- a/docs/shared/monorepo-ci-github-actions.md
+++ b/docs/shared/monorepo-ci-github-actions.md
@@ -26,7 +26,7 @@ jobs:
       - run: npx nx workspace-lint
       - run: npx nx format:check
       - run: npx nx affected --target=lint --parallel=3
-      - run: npx nx affected --target=test --parallel=3 --ci --code-coverage
+      - run: npx nx affected --target=test --parallel=3 --configuration=ci
       - run: npx nx affected --target=build --parallel=3
 ```
 
@@ -64,7 +64,7 @@ jobs:
         npx nx-cloud record -- npx nx workspace-lint
         npx nx-cloud record -- npx nx format:check
       parallel-commands-on-agents: |
-        npx nx affected --target=lint --parallel=3 & npx nx affected --target=test --parallel=3 --ci --code-coverage & npx nx affected --target=build --parallel=3
+        npx nx affected --target=lint --parallel=3 & npx nx affected --target=test --parallel=3 --configuration=ci & npx nx affected --target=build --parallel=3
 
   agents:
     name: Nx Cloud - Agents

--- a/docs/shared/monorepo-ci-gitlab.md
+++ b/docs/shared/monorepo-ci-gitlab.md
@@ -50,7 +50,7 @@ test:
   stage: test
   extends: .distributed
   script:
-    - npx nx affected --base=$NX_BASE --head=$NX_HEAD --target=test --parallel=3 --ci --code-coverage
+    - npx nx affected --base=$NX_BASE --head=$NX_HEAD --target=test --parallel=3 --configuration=ci
 
 build:
   stage: build
@@ -120,7 +120,7 @@ nx-dte:
     - yarn nx-cloud start-ci-run --stop-agents-after="build"
     - yarn nx-cloud record -- yarn nx workspace-lint --base=$NX_BASE --head=$NX_HEAD
     - yarn nx-cloud record -- yarn nx format:check --base=$NX_BASE --head=$NX_HEAD
-    - yarn nx affected --base=$NX_BASE --head=$NX_HEAD --target=lint --parallel=3 & yarn nx affected --base=$NX_BASE --head=$NX_HEAD --target=test --parallel=3 --ci --code-coverage & yarn nx affected --base=$NX_BASE --head=$NX_HEAD --target=e2e --parallel=3 --ci --code-coverage & yarn nx affected --base=$NX_BASE --head=$NX_HEAD --target=build --parallel=3
+    - yarn nx affected --base=$NX_BASE --head=$NX_HEAD --target=lint --parallel=3 & yarn nx affected --base=$NX_BASE --head=$NX_HEAD --target=test --parallel=3 --configuration=ci & yarn nx affected --base=$NX_BASE --head=$NX_HEAD --target=e2e --parallel=3 & yarn nx affected --base=$NX_BASE --head=$NX_HEAD --target=build --parallel=3
 
 # Create as many agents as you want
 nx-dte-agent1:

--- a/docs/shared/monorepo-ci-jenkins.md
+++ b/docs/shared/monorepo-ci-jenkins.md
@@ -39,7 +39,7 @@ pipeline {
                         sh "npx nx workspace-lint"
                         sh "npx nx format:check"
                         sh "npx nx affected --base origin/${env.CHANGE_TARGET} --target=lint --parallel=3"
-                        sh "npx nx affected --base origin/${env.CHANGE_TARGET} --target=test --parallel=3 --ci  --code-coverage"
+                        sh "npx nx affected --base origin/${env.CHANGE_TARGET} --target=test --parallel=3 --configuration=ci"
                         sh "npx nx affected --base origin/${env.CHANGE_TARGET} --target=build --parallel=3"
                     }
                 }
@@ -78,7 +78,7 @@ pipeline {
                         sh "npx nx-cloud start-ci-run --stop-agents-after='build'"
                         sh "npx nx workspace-lint"
                         sh "npx nx format:check"
-                        sh "npx nx affected --base=HEAD~1 --target=lint --parallel=3 & npx nx affected --base=HEAD~1 --target=test --parallel=3 --ci --code-coverage & npx nx affected --base=HEAD~1 --target=build --parallel=3"
+                        sh "npx nx affected --base=HEAD~1 --target=lint --parallel=3 & npx nx affected --base=HEAD~1 --target=test --parallel=3 --configuration=ci & npx nx affected --base=HEAD~1 --target=build --parallel=3"
                     }
                 }
                 stage('PR') {
@@ -91,7 +91,7 @@ pipeline {
                         sh "npx nx-cloud start-ci-run --stop-agents-after='build'"
                         sh "npx nx workspace-lint"
                         sh "npx nx format:check"
-                        sh "npx nx affected --base origin/${env.CHANGE_TARGET} --target=lint --parallel=3 & npx nx affected --base origin/${env.CHANGE_TARGET} --target=test --parallel=3 --ci --code-coverage & npx nx affected --base origin/${env.CHANGE_TARGET} --target=build --parallel=3"
+                        sh "npx nx affected --base origin/${env.CHANGE_TARGET} --target=lint --parallel=3 & npx nx affected --base origin/${env.CHANGE_TARGET} --target=test --parallel=3 --configuration=ci & npx nx affected --base origin/${env.CHANGE_TARGET} --target=build --parallel=3"
                     }
                 }
 

--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -209,6 +209,12 @@ Object {
     },
     "test": Object {
       "builder": "@nrwl/jest:jest",
+      "configurations": Object {
+        "ci": Object {
+          "ci": true,
+          "codeCoverage": true,
+        },
+      },
       "options": Object {
         "jestConfig": "apps/my-dir/my-app/jest.config.ts",
         "passWithNoTests": true,
@@ -380,6 +386,12 @@ Object {
     },
     "test": Object {
       "builder": "@nrwl/jest:jest",
+      "configurations": Object {
+        "ci": Object {
+          "ci": true,
+          "codeCoverage": true,
+        },
+      },
       "options": Object {
         "jestConfig": "apps/my-app/jest.config.ts",
         "passWithNoTests": true,

--- a/packages/angular/src/generators/application/__snapshots__/application.v14.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.v14.spec.ts.snap
@@ -217,6 +217,12 @@ Object {
     },
     "test": Object {
       "builder": "@nrwl/jest:jest",
+      "configurations": Object {
+        "ci": Object {
+          "ci": true,
+          "codeCoverage": true,
+        },
+      },
       "options": Object {
         "jestConfig": "apps/my-dir/my-app/jest.config.ts",
         "passWithNoTests": true,
@@ -388,6 +394,12 @@ Object {
     },
     "test": Object {
       "builder": "@nrwl/jest:jest",
+      "configurations": Object {
+        "ci": Object {
+          "ci": true,
+          "codeCoverage": true,
+        },
+      },
       "options": Object {
         "jestConfig": "apps/my-app/jest.config.ts",
         "passWithNoTests": true,

--- a/packages/jest/src/generators/jest-project/__snapshots__/jest-project.spec.ts.snap
+++ b/packages/jest/src/generators/jest-project/__snapshots__/jest-project.spec.ts.snap
@@ -111,6 +111,12 @@ export default {
 
 exports[`jestProject should use jest.config.js in project config with --js flag 1`] = `
 Object {
+  "configurations": Object {
+    "ci": Object {
+      "ci": true,
+      "codeCoverage": true,
+    },
+  },
   "executor": "@nrwl/jest:jest",
   "options": Object {
     "jestConfig": "libs/lib1/jest.config.js",

--- a/packages/jest/src/generators/jest-project/jest-project.spec.ts
+++ b/packages/jest/src/generators/jest-project/jest-project.spec.ts
@@ -79,6 +79,12 @@ describe('jestProject', () => {
         jestConfig: 'libs/lib1/jest.config.ts',
         passWithNoTests: true,
       },
+      configurations: {
+        ci: {
+          ci: true,
+          codeCoverage: true,
+        },
+      },
     });
     expect(lib1.targets.lint.options.tsConfig).toContain(
       'libs/lib1/tsconfig.spec.json'

--- a/packages/jest/src/generators/jest-project/lib/update-workspace.ts
+++ b/packages/jest/src/generators/jest-project/lib/update-workspace.ts
@@ -23,6 +23,12 @@ export function updateWorkspace(tree: Tree, options: JestProjectSchema) {
       ),
       passWithNoTests: true,
     },
+    configurations: {
+      ci: {
+        ci: true,
+        codeCoverage: true,
+      },
+    },
   };
 
   const isUsingTSLint =

--- a/packages/linter/src/generators/workspace-rules-project/workspace-rules-project.spec.ts
+++ b/packages/linter/src/generators/workspace-rules-project/workspace-rules-project.spec.ts
@@ -81,6 +81,12 @@ describe('@nrwl/linter:workspace-rules-project', () => {
         "sourceRoot": "tools/eslint-rules",
         "targets": Object {
           "test": Object {
+            "configurations": Object {
+              "ci": Object {
+                "ci": true,
+                "codeCoverage": true,
+              },
+            },
             "executor": "@nrwl/jest:jest",
             "options": Object {
               "jestConfig": "tools/eslint-rules/jest.config.ts",

--- a/packages/nest/src/generators/library/library.spec.ts
+++ b/packages/nest/src/generators/library/library.spec.ts
@@ -39,6 +39,12 @@ describe('lib', () => {
           jestConfig: `libs/${libFileName}/jest.config.ts`,
           passWithNoTests: true,
         },
+        configurations: {
+          ci: {
+            ci: true,
+            codeCoverage: true,
+          },
+        },
       });
     });
 

--- a/packages/node/src/generators/library/library.spec.ts
+++ b/packages/node/src/generators/library/library.spec.ts
@@ -43,6 +43,12 @@ describe('lib', () => {
           jestConfig: 'libs/my-lib/jest.config.ts',
           passWithNoTests: true,
         },
+        configurations: {
+          ci: {
+            ci: true,
+            codeCoverage: true,
+          },
+        },
       });
     });
 

--- a/packages/nx-plugin/src/generators/plugin/plugin.spec.ts
+++ b/packages/nx-plugin/src/generators/plugin/plugin.spec.ts
@@ -85,6 +85,12 @@ describe('NxPlugin Plugin Generator', () => {
         jestConfig: 'libs/my-plugin/jest.config.ts',
         passWithNoTests: true,
       },
+      configurations: {
+        ci: {
+          ci: true,
+          codeCoverage: true,
+        },
+      },
     });
   });
 

--- a/packages/storybook/src/generators/configuration/__snapshots__/configuration-v7.spec.ts.snap
+++ b/packages/storybook/src/generators/configuration/__snapshots__/configuration-v7.spec.ts.snap
@@ -83,6 +83,12 @@ Object {
       },
     },
     "test": Object {
+      "configurations": Object {
+        "ci": Object {
+          "ci": true,
+          "codeCoverage": true,
+        },
+      },
       "executor": "@nrwl/jest:jest",
       "options": Object {
         "jestConfig": "libs/test-ui-lib/jest.config.ts",


### PR DESCRIPTION
make test task depend less on jest specific options and use configuration instead to be more inclusive

ISSUES CLOSED: #12045

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Documentation suggests to add flags --ci and --code-coverage to tasks. This is specific for jest and might break with other tests.

## Expected Behavior
To have a jest independent approach we might start with using configurations instead of specific flags.

## Related Issue(s)
This would also allow preventing issues like #12045 and allow to run karma and jest test within one target.

Fixes #12045
