### PR TITLE
fix(angular): do not rename dts file since it is already done

### DIFF
--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ts/cache-compiler-host.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ts/cache-compiler-host.ts
@@ -104,9 +104,6 @@ export function cacheCompilerHost(
           }
         }
 
-        // Rename file to index.d.ts so that TypeScript can resolve types without
-        // them needing to be referenced in the package.json manifest.
-        fileName = fileName.replace(flatModuleFileDtsFilename, 'index.d.ts');
         sourceFiles.forEach((source) => {
           const cache = sourcesFileCache.getOrCreate(source.fileName);
           if (!cache.declarationFileName) {

--- a/packages/angular/src/executors/package/ng-packagr-adjustments/ts/cache-compiler-host.ts
+++ b/packages/angular/src/executors/package/ng-packagr-adjustments/ts/cache-compiler-host.ts
@@ -104,9 +104,6 @@ export function cacheCompilerHost(
           }
         }
 
-        // Rename file to index.d.ts so that TypeScript can resolve types without
-        // them needing to be referenced in the package.json manifest.
-        fileName = fileName.replace(flatModuleFileDtsFilename, 'index.d.ts');
         sourceFiles.forEach((source) => {
           const cache = sourcesFileCache.getOrCreate(source.fileName);
           if (!cache.declarationFileName) {


### PR DESCRIPTION
This is a follow up of this PR: https://github.com/nrwl/nx/pull/11032.

The `fileName.replace` is already being done within the code previously in the `else` block.

Closes #14216 