### PR TITLE
docs(nxdev): remove current items from related documents

### DIFF
--- a/nx-dev/nx-dev/pages/[...segments].tsx
+++ b/nx-dev/nx-dev/pages/[...segments].tsx
@@ -103,7 +103,9 @@ export const getStaticProps: GetStaticProps = async ({
     return {
       props: {
         document,
-        relatedDocuments: tagsApi.getAssociatedItemsFromTags(document.tags),
+        relatedDocuments: tagsApi
+          .getAssociatedItemsFromTags(document.tags)
+          .filter((item) => item.path !== '/' + params.segments.join('/')), // Remove currently displayed item
         menu: menusApi.getMenu('nx', ''),
       },
     };

--- a/nx-dev/nx-dev/pages/nx-cloud/[...segments].tsx
+++ b/nx-dev/nx-dev/pages/nx-cloud/[...segments].tsx
@@ -97,11 +97,14 @@ export const getStaticProps: GetStaticProps = async ({
   params: { segments: string[] };
 }) => {
   try {
-    const document = nxCloudApi.getDocument(['nx-cloud', ...params.segments]);
+    const segments = ['nx-cloud', ...params.segments];
+    const document = nxCloudApi.getDocument(segments);
     return {
       props: {
         document,
-        relatedDocuments: tagsApi.getAssociatedItemsFromTags(document.tags),
+        relatedDocuments: tagsApi
+          .getAssociatedItemsFromTags(document.tags)
+          .filter((item) => item.path !== '/' + segments.join('/')), // Remove currently displayed item
         menu: menusApi.getMenu('cloud', ''),
       },
     };

--- a/nx-dev/nx-dev/pages/packages/[name]/documents/[...segments].tsx
+++ b/nx-dev/nx-dev/pages/packages/[name]/documents/[...segments].tsx
@@ -109,6 +109,7 @@ export async function getStaticProps({
   params: { name: string; segments: string[] };
 }) {
   try {
+    const segments = ['packages', params.name, 'documents', ...params.segments];
     const documents = new DocumentsApi({
       id: [params.name, 'documents'].join('-'),
       manifest: nxPackagesApi.getPackageDocuments(params.name),
@@ -116,18 +117,15 @@ export async function getStaticProps({
       publicDocsRoot: 'nx-dev/nx-dev/public/documentation',
       tagsApi,
     });
-    const document = documents.getDocument([
-      'packages',
-      params.name,
-      'documents',
-      ...params.segments,
-    ]);
+    const document = documents.getDocument(segments);
 
     return {
       props: {
         pkg: nxPackagesApi.getPackage([params.name]),
         document,
-        relatedDocuments: tagsApi.getAssociatedItemsFromTags(document.tags),
+        relatedDocuments: tagsApi
+          .getAssociatedItemsFromTags(document.tags)
+          .filter((item) => item.path !== '/' + segments.join('/')), // Remove currently displayed item
         menu: menusApi.getMenu('packages', ''),
       },
     };

--- a/nx-dev/nx-dev/pages/recipes/[...segments].tsx
+++ b/nx-dev/nx-dev/pages/recipes/[...segments].tsx
@@ -94,11 +94,14 @@ export const getStaticProps: GetStaticProps = async ({
   params: { segments: string[] };
 }) => {
   try {
-    const document = nxRecipesApi.getDocument(['recipes', ...params.segments]);
+    const segments = ['recipes', ...params.segments];
+    const document = nxRecipesApi.getDocument(segments);
     return {
       props: {
         document,
-        relatedDocuments: tagsApi.getAssociatedItemsFromTags(document.tags),
+        relatedDocuments: tagsApi
+          .getAssociatedItemsFromTags(document.tags)
+          .filter((item) => item.path !== '/' + segments.join('/')), // Remove currently displayed item
         menu: menusApi.getMenu('recipes', ''),
       },
     };


### PR DESCRIPTION
It removes the link to itself in the related documents list when consulting a document on nx.dev.