### PR TITLE
fix(core): `exec` should not log usage info when inner command fails

### DIFF
--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -378,8 +378,12 @@ export const commandsObject = yargs
     describe: 'Executes any command as if it was a target on the project',
     builder: (yargs) => withRunOneOptions(yargs),
     handler: async (args) => {
-      await (await import('./exec')).nxExecCommand(withOverrides(args));
-      process.exit(0);
+      try {
+        await (await import('./exec')).nxExecCommand(withOverrides(args));
+        process.exit(0);
+      } catch (e) {
+        process.exit(1);
+      }
     },
   })
   .command({


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When a command ran through `nx exec` fails, the output of `nx exec --help` is logged out twice.

## Expected Behavior
Failing inner commands from `nx exec` should not log usage text.


```terminal
agentender@DESKTOP-RFT62G1:~/nx$ npm run check-commit

> check-commit
> nx exec -- echo 'oh no'; exit 1

yarn run v1.22.19
$ /home/agentender/nx/node_modules/.bin/nx run '@nrwl/nx-source:"check-commit"'

> nx run @nrwl/nx-source:check-commit

$ nx exec -- echo 'oh no'; exit 1
oh no
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

 —————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 >  NX   Ran target undefined for project @nrwl/nx-source (781ms)
 
    ✖    1/1 failed
    ✔    0/1 succeeded [0 read from cache]
 
   View structured, searchable error logs at https://staging.nx.app/runs/hjUZVmJiFD

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14202
