### PR TITLE
fix(core): run-one should not log undefined as target name on failure

### DIFF
--- a/packages/nx/src/command-line/run-many.spec.ts
+++ b/packages/nx/src/command-line/run-many.spec.ts
@@ -71,18 +71,6 @@ describe('run-many', () => {
       expect(projects).toContain('proj2');
     });
 
-    it('should throw for invalid patterns', () => {
-      expect(() => {
-        projectsToRun(
-          {
-            targets: ['test'],
-            projects: ['nomatch*'],
-          },
-          projectGraph
-        ).map(({ name }) => name);
-      }).toThrow();
-    });
-
     it('should exclude projects', () => {
       const projects = projectsToRun(
         {

--- a/packages/nx/src/command-line/run-many.ts
+++ b/packages/nx/src/command-line/run-many.ts
@@ -82,14 +82,12 @@ export function projectsToRun(
 
     if (invalidProjects.length > 0) {
       output.warn({
-        title: `the following do not have configuration for "${nxArgs.target}"`,
+        title: `The following projects do not have a configuration for any of the provided targets ("${nxArgs.targets.join(
+          ', '
+        )}")`,
         bodyLines: invalidProjects.map((name) => `- ${name}`),
       });
     }
-  }
-
-  if (selectedProjects.size === 0) {
-    throw new Error(`No projects found for project patterns`);
   }
 
   const excludedProjects = findMatchingProjects(

--- a/packages/nx/src/tasks-runner/life-cycles/dynamic-run-one-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/dynamic-run-one-terminal-output-life-cycle.ts
@@ -39,7 +39,7 @@ export async function createRunOneDynamicOutputRenderer({
 }: {
   initiatingProject: string;
   tasks: Task[];
-  args: { target?: string; configuration?: string; parallel?: number };
+  args: { configuration?: string; parallel?: number };
   overrides: Record<string, unknown>;
 }): Promise<{ lifeCycle: LifeCycle; renderIsDone: Promise<void> }> {
   cliCursor.hide();
@@ -79,7 +79,7 @@ export async function createRunOneDynamicOutputRenderer({
   const totalDependentTasksNotFromInitiatingProject =
     totalTasks - totalTasksFromInitiatingProject;
 
-  const targetName = args.target;
+  const targetName = tasks[0].target.target;
 
   let dependentTargetsNumLines = 0;
   let totalCompletedTasks = 0;
@@ -274,7 +274,7 @@ export async function createRunOneDynamicOutputRenderer({
 
       const text = `Successfully ran ${formatTargetsAndProjects(
         [initiatingProject],
-        [tasks[0].target.target],
+        [targetName],
         tasks
       )}`;
 

--- a/packages/nx/src/utils/command-line-utils.ts
+++ b/packages/nx/src/utils/command-line-utils.ts
@@ -11,7 +11,6 @@ export interface RawNxArgs extends NxArgs {
 }
 
 export interface NxArgs {
-  target?: string;
   targets?: string[];
   configuration?: string;
   runner?: string;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14158
