### PR TITLE
feat(nest): nx init nest

### DIFF
--- a/e2e/nx-init/src/nx-init-nest.test.ts
+++ b/e2e/nx-init/src/nx-init-nest.test.ts
@@ -1,0 +1,65 @@
+import {
+  e2eCwd,
+  exists,
+  getPackageManagerCommand,
+  getPublishedVersion,
+  runCLI,
+} from '@nrwl/e2e/utils';
+import { execSync } from 'child_process';
+import { removeSync } from 'fs-extra';
+
+describe('nx init (for NestCLI)', () => {
+  const pmc = getPackageManagerCommand({
+    packageManager: 'npm',
+  });
+  const projectName = 'nest-app';
+  const projectRoot = `${e2eCwd}/${projectName}`;
+  const cliOptions = { cwd: projectRoot };
+
+  afterEach(() => {
+    removeSync(projectRoot);
+  });
+
+  it('should convert NestCLI application to Nx standalone', () => {
+    execSync(
+      `${pmc.runUninstalledPackage} @nestjs/cli new ${projectName} --package-manager=npm`,
+      {
+        cwd: e2eCwd,
+        encoding: 'utf-8',
+        env: process.env,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }
+    );
+
+    const output = execSync(
+      `${
+        pmc.runUninstalledPackage
+      } nx@${getPublishedVersion()} init -y --cacheable=format`,
+      {
+        cwd: projectRoot,
+        encoding: 'utf-8',
+        env: process.env,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }
+    );
+
+    expect(output).toContain('Enabled computation caching');
+
+    // nest-cli.json is removed
+    expect(exists(`${projectRoot}/nest-cli.json`)).toBeFalsy();
+
+    // root nx.json exists
+    expect(exists(`${projectRoot}/nx.json`)).toBeTruthy();
+    // root project.json exists
+    expect(exists(`${projectRoot}/project.json`)).toBeTruthy();
+
+    runCLI('build', cliOptions);
+    expect(
+      exists(`${projectRoot}/dist/${projectName}/src/main.js`)
+    ).toBeTruthy();
+
+    // run build again for cache
+    const buildOutput = runCLI('build', cliOptions);
+    expect(buildOutput).toContain('Nx read the output from the cache');
+  }, 10000);
+});

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@floating-ui/react-dom": "^1.0.1",
     "@nestjs/common": "^9.0.0",
     "@nestjs/core": "^9.0.0",
+    "@nestjs/cli": "^9.0.0",
     "@nestjs/platform-express": "^9.0.0",
     "@nestjs/schematics": "^9.0.0",
     "@nestjs/swagger": "^6.0.0",

--- a/packages/js/src/utils/inline.ts
+++ b/packages/js/src/utils/inline.ts
@@ -245,6 +245,7 @@ function buildInlineGraphExternals(
 }
 
 function movePackage(from: string, to: string) {
+  if (from === to) return;
   copySync(from, to, { overwrite: true });
   removeSync(from);
 }
@@ -269,7 +270,8 @@ function updateImports(
 function recursiveUpdateImport(
   dirPath: string,
   importRegex: RegExp,
-  inlinedDepsDestOutputRecord: Record<string, string>
+  inlinedDepsDestOutputRecord: Record<string, string>,
+  rootParentDir?: string
 ) {
   const files = readdirSync(dirPath, { withFileTypes: true });
   for (const file of files) {
@@ -282,6 +284,8 @@ function recursiveUpdateImport(
       const fileContent = readFileSync(filePath, 'utf-8');
       const updatedContent = fileContent.replace(importRegex, (matched) => {
         const result = matched.replace(/['"]/g, '');
+        // If a match is the same as the rootParentDir, we're checking its own files so we return the matched as in no changes.
+        if (result === rootParentDir) return matched;
         const importPath = `"${relative(
           dirPath,
           inlinedDepsDestOutputRecord[result]
@@ -293,7 +297,8 @@ function recursiveUpdateImport(
       recursiveUpdateImport(
         join(dirPath, file.name),
         importRegex,
-        inlinedDepsDestOutputRecord
+        inlinedDepsDestOutputRecord,
+        rootParentDir || file.name
       );
     }
   }

--- a/packages/nest/src/generators/library/lib/add-project.ts
+++ b/packages/nest/src/generators/library/lib/add-project.ts
@@ -15,9 +15,10 @@ export function addProject(tree: Tree, options: NormalizedOptions): void {
     executor: '@nrwl/js:tsc',
     outputs: ['{options.outputPath}'],
     options: {
-      outputPath: options.libsDir
-        ? `dist/${options.libsDir}/${options.projectDirectory}`
-        : `dist/${options.projectDirectory}`,
+      outputPath:
+        options.libsDir && options.libsDir !== '.'
+          ? `dist/${options.libsDir}/${options.projectDirectory}`
+          : `dist/${options.projectDirectory}`,
       tsConfig: `${options.projectRoot}/tsconfig.lib.json`,
       packageJson: `${options.projectRoot}/package.json`,
       main: `${options.projectRoot}/src/index.ts`,

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -27,6 +27,11 @@ export type TargetDependencies = Record<
   (TargetDependencyConfig | string)[]
 >;
 
+export interface NrwlJsPluginConfig {
+  analyzeSourceFiles?: boolean;
+  analyzePackageJson?: boolean;
+}
+
 /**
  * Nx.json configuration
  *

--- a/packages/nx/src/nx-init/add-nx-to-nest.ts
+++ b/packages/nx/src/nx-init/add-nx-to-nest.ts
@@ -1,0 +1,478 @@
+import { unlinkSync, writeFileSync } from 'fs-extra';
+import * as yargsParser from 'yargs-parser';
+import * as enquirer from 'enquirer';
+import { join } from 'path';
+import { output } from '../utils/output';
+import { PackageJson } from '../utils/package-json';
+import { fileExists, readJsonFile, writeJsonFile } from '../utils/fileutils';
+import {
+  addDepsToPackageJson,
+  askAboutNxCloud,
+  createNxJsonFile,
+  initCloud,
+  runInstall,
+} from './utils';
+import { getPackageManagerCommand } from '../utils/package-manager';
+import { markRootPackageJsonAsNxProject } from './add-nx-to-npm-repo';
+import { ProjectConfiguration } from '../config/workspace-json-project-json';
+import { NrwlJsPluginConfig, NxJsonConfiguration } from '../config/nx-json';
+
+type NestCLIConfiguration =
+  import('@nestjs/cli/lib/configuration').Configuration;
+
+const parsedArgs = yargsParser(process.argv, {
+  boolean: ['yes'],
+  string: ['cacheable'], // only used for testing
+  alias: {
+    yes: ['y'],
+  },
+});
+
+export async function addNxToNest(packageJson: PackageJson) {
+  const repoRoot = process.cwd();
+
+  output.log({ title: `🐳 Nx initialization` });
+
+  // we check upstream that nest-cli.json exists before it reaches this function
+  // so it is guaranteed to be here
+  const nestCliJson = readJsonFile(
+    join(repoRoot, 'nest-cli.json')
+  ) as NestCLIConfiguration;
+  const nestCLIConfiguration = mergeWithDefaultConfig(nestCliJson);
+
+  // For NestJS CLI Monorepo, this property is always "true"
+  if (nestCLIConfiguration.monorepo) {
+    // TODO: update message for NestJS CLI Monorepo support
+    output.log({ title: 'NestCLI Monorepo support is coming soon' });
+    return;
+  }
+
+  const isJS = nestCLIConfiguration.language === 'js';
+
+  const nestCacheableScripts = ['build', 'lint', 'test'];
+  const nestIgnoreScripts = [
+    'start',
+    'start:dev',
+    'start:debug',
+    'test:cov',
+    'test:watch',
+  ];
+
+  const scripts = Object.keys(packageJson.scripts).filter((s) => {
+    if (nestCacheableScripts.includes(s) || nestIgnoreScripts.includes(s)) {
+      return false;
+    }
+
+    return !s.startsWith('pre') && !s.startsWith('post');
+  });
+
+  let cacheableOperations: string[];
+  let scriptOutputs = {};
+  let useCloud: boolean;
+
+  if (parsedArgs.yes !== true) {
+    output.log({
+      title: `🧑‍🔧 Please answer the following questions about the scripts found in your package.json in order to generate task runner configuration`,
+    });
+    cacheableOperations = (
+      (await enquirer.prompt([
+        {
+          type: 'multiselect',
+          name: 'cacheableOperations',
+          message:
+            'Which of the following scripts are cacheable? (Produce the same output given the same input, e.g. build, test and lint usually are, serve and start are not)',
+          choices: scripts,
+        },
+      ])) as any
+    ).cacheableOperations;
+
+    for (const scriptName of cacheableOperations) {
+      scriptOutputs[scriptName] = (
+        await enquirer.prompt([
+          {
+            type: 'input',
+            name: scriptName,
+            message: `Does the "${scriptName}" script create any outputs? If not, leave blank, otherwise provide a path (e.g. dist, lib, build, coverage)`,
+          },
+        ])
+      )[scriptName];
+    }
+
+    useCloud = await askAboutNxCloud();
+  } else {
+    cacheableOperations = parsedArgs.cacheable
+      ? parsedArgs.cacheable.split(',')
+      : [];
+    useCloud = false;
+  }
+
+  createNxJsonFile(
+    repoRoot,
+    [],
+    [...cacheableOperations, ...nestCacheableScripts],
+    {},
+    packageJson.name
+  );
+
+  const pmc = getPackageManagerCommand();
+
+  addDepsToPackageJson(repoRoot, useCloud);
+  addNestPluginToPackageJson(repoRoot);
+  markRootPackageJsonAsNxProject(
+    repoRoot,
+    cacheableOperations,
+    scriptOutputs,
+    pmc
+  );
+
+  createProjectJson(repoRoot, packageJson, nestCLIConfiguration);
+  removeFile(repoRoot, 'nest-cli.json');
+
+  updatePackageJsonScripts(repoRoot, isJS);
+  if (!isJS) {
+    updateTsConfig(repoRoot, nestCLIConfiguration.sourceRoot);
+  }
+
+  output.log({ title: `📦 Installing dependencies` });
+
+  runInstall(repoRoot);
+
+  if (useCloud) {
+    initCloud(repoRoot);
+  }
+
+  printFinalMessage();
+}
+
+function printFinalMessage() {
+  output.success({
+    title: `🎉 Done!`,
+    bodyLines: [
+      `- Enabled computation caching!`,
+      `- Learn more at https://nx.dev/recipes/adopting-nx/adding-to-monorepo`,
+    ],
+  });
+}
+
+function addNestPluginToPackageJson(repoRoot: string) {
+  const path = join(repoRoot, `package.json`);
+  const json: PackageJson = readJsonFile(path);
+  json.devDependencies['@nrwl/nest'] = require('../../package.json').version;
+  json.devDependencies['@nrwl/jest'] = require('../../package.json').version;
+  writeJsonFile(path, json);
+}
+
+function createProjectJson(
+  repoRoot: string,
+  packageJson: PackageJson,
+  nestCLIOptions: NestCLIConfiguration
+) {
+  const packageName = packageJson.name;
+  const path = join(repoRoot, 'project.json');
+  const json: ProjectConfiguration = {
+    name: packageName,
+    root: '.',
+    sourceRoot: nestCLIOptions.sourceRoot,
+    projectType: 'application',
+    targets: {},
+    tags: [],
+  };
+  json['$schema'] = 'node_modules/nx/schemas/project-schema.json';
+
+  if (nestCLIOptions.language !== 'js') {
+    json.targets['serve'] = {
+      executor: '@nrwl/js:node',
+      options: {
+        buildTarget: `${packageName}:build`,
+      },
+    };
+
+    console.log(nestCLIOptions);
+
+    if (nestCLIOptions.webpackOptions) {
+      json.targets['build'] = {
+        executor: '@nrwl/webpack:webpack',
+        outputs: ['{options.outputPath}'],
+        options: {
+          target: 'node',
+          compiler: 'tsc',
+          outputPath: `dist/${packageName}`,
+          main: join(nestCLIOptions.sourceRoot, nestCLIOptions.entryFile),
+          tsConfig: 'tsconfig.build.json',
+        },
+        configurations: {
+          production: {
+            optimization: true,
+            extractLicenses: true,
+            inspect: false,
+          },
+        },
+      };
+      json.targets['serve'] = {
+        ...json.targets['serve'],
+        configurations: {
+          production: {
+            buildTarget: `${packageName}:build:production`,
+          },
+        },
+      };
+    } else {
+      json.targets['build'] = {
+        executor: '@nrwl/js:tsc',
+        outputs: ['{options.outputPath}'],
+        options: {
+          outputPath: `dist/${packageName}`,
+          main: join(nestCLIOptions.sourceRoot, nestCLIOptions.entryFile),
+          tsConfig: 'tsconfig.build.json',
+        },
+      };
+      json.targets['serve'] = {
+        ...json.targets['serve'],
+        configurations: {
+          debug: {
+            inspect: 'inspect',
+          },
+        },
+      };
+
+      // if we're using nrwl/js, then we add nrwl/js analyzeSourceFiles to nx.json
+      addNrwlJsPluginsConfig(repoRoot);
+    }
+
+    // lint
+    json.targets['lint'] = {
+      executor: '@nrwl/linter:eslint',
+      outputs: ['{options.outputFile}'],
+      options: {
+        lintFilePatterns: ['src/**/*.ts', 'test/**/*.ts'],
+      },
+    };
+
+    // test and e2e
+    addJestTargets(repoRoot, packageName, json, packageJson);
+  }
+
+  writeJsonFile(path, json);
+}
+
+function getJestOptions(
+  isE2E: boolean,
+  repoRoot: string,
+  packageName: string,
+  existingOptions?: Record<string, unknown>
+) {
+  // try get the e2e json if we find it
+  if (isE2E && !existingOptions) {
+    try {
+      existingOptions = readJsonFile(join(repoRoot, 'test/jest-e2e.json'));
+      removeFile(repoRoot, 'test/jest-e2e.json');
+    } catch (e) {}
+  }
+
+  const jestOptions = existingOptions || {
+    moduleFileExtensions: ['js', 'json', 'ts'],
+    testEnvironment: 'node',
+    transform: { '^.+\\.(t|j)s$': 'ts-jest' },
+  };
+
+  jestOptions['displayName'] = isE2E ? `${packageName}-e2e` : packageName;
+
+  // remove rootDir and testRegex, we'll use testMatch instead since we'll have the
+  // root jest.preset.js in the root instead of 'src'
+  delete jestOptions['rootDir'];
+  delete jestOptions['testRegex'];
+  jestOptions['testMatch'] = isE2E
+    ? ['<rootDir>/test/**/?(*.)+(e2e-spec|e2e-test).[jt]s?(x)']
+    : ['<rootDir>/src/**/?(*.)+(spec|test).[jt]s?(x)'];
+
+  // set coverage directory for unit test
+  if (!isE2E) {
+    jestOptions['coverageDirectory'] = `./coverage/${packageName}`;
+  }
+
+  return jestOptions;
+}
+
+function tryCreateJestPreset(repoRoot: string) {
+  const jestPresetPath = join(repoRoot, 'jest.preset.js');
+  if (!fileExists(jestPresetPath)) {
+    writeFileSync(
+      jestPresetPath,
+      `
+const nxPreset = require('@nrwl/jest/preset').default;
+module.exports = {...nxPreset};
+`,
+      'utf8'
+    );
+    return true;
+  }
+
+  return false;
+}
+
+function addJestTargets(
+  repoRoot: string,
+  packageName: string,
+  projectJson: ProjectConfiguration,
+  packageJson: PackageJson
+) {
+  const unitTestOptions = getJestOptions(
+    false,
+    repoRoot,
+    packageName,
+    packageJson['jest']
+  );
+  const unitTestConfigPath = 'jest.config.ts';
+
+  const e2eTestOptions = getJestOptions(true, repoRoot, packageName);
+  const e2eTestConfigPath = 'jest.e2e-config.ts';
+
+  const isPresetCreated = tryCreateJestPreset(repoRoot);
+
+  if (isPresetCreated) {
+    unitTestOptions['preset'] = e2eTestOptions['preset'] = './jest.preset.js';
+  }
+
+  writeFileSync(
+    unitTestConfigPath,
+    `export default ${JSON.stringify(unitTestOptions, null, 2)}`,
+    'utf8'
+  );
+  writeFileSync(
+    e2eTestConfigPath,
+    `export default ${JSON.stringify(e2eTestOptions, null, 2)}`,
+    'utf8'
+  );
+
+  projectJson.targets['test'] = {
+    executor: '@nrwl/jest:jest',
+    outputs: [`{workspaceRoot}/coverage/${packageName}`],
+    options: {
+      passWithNoTests: true,
+      jestConfig: unitTestConfigPath,
+    },
+  };
+
+  projectJson.targets['e2e'] = {
+    executor: '@nrwl/jest:jest',
+    options: {
+      passWithNoTests: true,
+      jestConfig: e2eTestConfigPath,
+    },
+  };
+
+  // remove jest options from package.json
+  delete packageJson['jest'];
+}
+
+function addNrwlJsPluginsConfig(repoRoot: string) {
+  const path = join(repoRoot, 'nx.json');
+  const json: NxJsonConfiguration = readJsonFile(path);
+
+  if (!json.pluginsConfig) {
+    json.pluginsConfig = {
+      '@nrwl/js': {
+        analyzeSourceFiles: true,
+      } as NrwlJsPluginConfig,
+    };
+  }
+
+  writeJsonFile(path, json);
+}
+
+function updatePackageJsonScripts(repoRoot: string, isJS: boolean) {
+  const path = join(repoRoot, `package.json`);
+  const json: PackageJson = readJsonFile(path);
+
+  if (json.scripts['build']) {
+    json.scripts['build'] = 'nx build';
+  }
+
+  if (json.scripts['lint']) {
+    json.scripts['lint'] = 'nx lint';
+  }
+
+  if (json.scripts['start:debug']) {
+    json.scripts['start:debug'] = 'nx serve --configuration=debug';
+  }
+
+  if (json.scripts['test']) {
+    json.scripts['test'] = 'nx test';
+  }
+
+  if (json.scripts['test:cov']) {
+    delete json.scripts['test:cov'];
+  }
+
+  if (json.scripts['test:watch']) {
+    delete json.scripts['test:watch'];
+  }
+
+  if (json.scripts['test:e2e']) {
+    delete json.scripts['test:e2e'];
+    json.scripts['e2e'] = 'nx e2e';
+  }
+
+  if (!isJS) {
+    if (json.scripts['start']) {
+      json.scripts['start'] = 'nx serve';
+    }
+
+    if (json.scripts['start:dev']) {
+      // same as nx serve
+      delete json.scripts['start:dev'];
+    }
+  }
+
+  writeJsonFile(path, json);
+}
+
+function updateTsConfig(repoRoot: string, sourceRoot: string) {
+  const path = join(repoRoot, `tsconfig.build.json`);
+  const json = readJsonFile(path);
+
+  // we add include to the tsconfig.build because our executor runs tsc with
+  // generated tsconfig which is in `tmp/**.generated.json`. By default, tsc
+  // cannot find the default source files anymore.
+  if (!json.include) json.include = [];
+  json.include.push(`${sourceRoot}/**/*.ts`);
+
+  writeJsonFile(path, json);
+}
+
+function removeFile(repoRoot: string, file: string) {
+  const path = join(repoRoot, file);
+  unlinkSync(path);
+}
+
+function mergeWithDefaultConfig(config: NestCLIConfiguration) {
+  const defaultNestCliConfigurations = {
+    language: 'ts',
+    sourceRoot: 'src',
+    collection: '@nestjs/schematics',
+    entryFile: 'main',
+    projects: {},
+    monorepo: false,
+    compilerOptions: {
+      tsConfigPath: 'tsconfig.build.json',
+      webpack: false,
+      webpackConfigPath: 'webpack.config.js',
+      plugins: [],
+      assets: [],
+    },
+    generateOptions: {},
+  } as NestCLIConfiguration;
+
+  if (config.compilerOptions) {
+    return {
+      ...defaultNestCliConfigurations,
+      ...config,
+      compilerOptions: {
+        ...defaultNestCliConfigurations.compilerOptions,
+        ...config.compilerOptions,
+      },
+    };
+  }
+
+  return { ...defaultNestCliConfigurations, ...config };
+}

--- a/packages/nx/src/project-graph/build-project-graph.ts
+++ b/packages/nx/src/project-graph/build-project-graph.ts
@@ -28,7 +28,7 @@ import {
   ProjectGraphProcessorContext,
 } from '../config/project-graph';
 import { readJsonFile } from '../utils/fileutils';
-import { NxJsonConfiguration } from '../config/nx-json';
+import { NrwlJsPluginConfig, NxJsonConfiguration } from '../config/nx-json';
 import { logger } from '../utils/logger';
 import { ProjectGraphBuilder } from './project-graph-builder';
 import {
@@ -209,11 +209,6 @@ async function buildProjectGraphUsingContext(
   );
 
   return r;
-}
-
-interface NrwlJsPluginConfig {
-  analyzeSourceFiles?: boolean;
-  analyzePackageJson?: boolean;
 }
 
 function jsPluginConfig(

--- a/packages/workspace/src/utilities/typescript/compilation.ts
+++ b/packages/workspace/src/utilities/typescript/compilation.ts
@@ -1,4 +1,4 @@
-import { logger } from '@nrwl/devkit';
+import { joinPathFragments, logger } from '@nrwl/devkit';
 import { removeSync } from 'fs-extra';
 import * as ts from 'typescript';
 import type { CustomTransformers, Diagnostic, Program } from 'typescript';
@@ -140,6 +140,12 @@ function getNormalizedTsConfig(options: TypeScriptCompilationOptions) {
   tsConfig.options.outDir = options.outputPath;
   tsConfig.options.noEmitOnError = true;
   tsConfig.options.rootDir = options.rootDir;
+  if (tsConfig.options.incremental && !tsConfig.options.tsBuildInfoFile) {
+    tsConfig.options.tsBuildInfoFile = joinPathFragments(
+      options.outputPath,
+      'tsconfig.tsbuildinfo'
+    );
+  }
   return tsConfig;
 }
 

--- a/scripts/depcheck/missing.ts
+++ b/scripts/depcheck/missing.ts
@@ -129,6 +129,7 @@ const IGNORE_MATCHES_IN_PACKAGE = {
     '@angular-devkit/architect',
     '@angular/cli',
     '@nrwl/angular',
+    '@nestjs/cli', // nx init nest makes use of nestjs cli (which should be available in NestJS CLI app) to parse the nest-cli.json file
     'ts-node', // We *may* fall back on ts-node, but we want to encourage the use of @swc-node instead so we don't explicitly list ts-node as an optional dep
   ],
   web: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -249,6 +249,18 @@
     rxjs "6.6.7"
     source-map "0.7.4"
 
+"@angular-devkit/schematics-cli@15.0.4":
+  version "15.0.4"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/schematics-cli/-/schematics-cli-15.0.4.tgz#8c11e4994fcdcb44b35db626e2b2e1679fdb7b4b"
+  integrity sha512-rEzkpjiQcJqCgbZ1Ns8jn1BL4724jcj+YFS7Qw5d4v6yQYA8iSLz12HDTH0TiNEv7u5S55fYuRz2QreI0QUT8A==
+  dependencies:
+    "@angular-devkit/core" "15.0.4"
+    "@angular-devkit/schematics" "15.0.4"
+    ansi-colors "4.1.3"
+    inquirer "8.2.4"
+    symbol-observable "4.0.0"
+    yargs-parser "21.1.1"
+
 "@angular-devkit/schematics@14.2.1":
   version "14.2.1"
   resolved "https://registry.yarnpkg.com/@angular-devkit/schematics/-/schematics-14.2.1.tgz#9d66080e60ab32d1b44c854cabc8f5cbb421d877"
@@ -4108,6 +4120,34 @@
     "@napi-rs/canvas-linux-x64-gnu" "0.1.30"
     "@napi-rs/canvas-linux-x64-musl" "0.1.30"
     "@napi-rs/canvas-win32-x64-msvc" "0.1.30"
+
+"@nestjs/cli@^9.0.0":
+  version "9.1.8"
+  resolved "https://registry.yarnpkg.com/@nestjs/cli/-/cli-9.1.8.tgz#e4cb06c0cb628bf08ae143c2c6278a7beb38044b"
+  integrity sha512-53laCMoPLAkjyz3405FlMSrHnbr3DGeoaQjY963bEroezLlm/qfQhwj6oGJwtgA28eNFgx68mvQV2f1VZNUJtw==
+  dependencies:
+    "@angular-devkit/core" "15.0.4"
+    "@angular-devkit/schematics" "15.0.4"
+    "@angular-devkit/schematics-cli" "15.0.4"
+    "@nestjs/schematics" "^9.0.0"
+    chalk "3.0.0"
+    chokidar "3.5.3"
+    cli-table3 "0.6.3"
+    commander "4.1.1"
+    fork-ts-checker-webpack-plugin "7.2.14"
+    inquirer "7.3.3"
+    node-emoji "1.11.0"
+    ora "5.4.1"
+    os-name "4.0.1"
+    rimraf "3.0.2"
+    shelljs "0.8.5"
+    source-map-support "0.5.21"
+    tree-kill "1.2.2"
+    tsconfig-paths "4.1.1"
+    tsconfig-paths-webpack-plugin "4.0.0"
+    typescript "4.9.4"
+    webpack "5.75.0"
+    webpack-node-externals "3.0.0"
 
 "@nestjs/common@^9.0.0":
   version "9.1.6"
@@ -10042,6 +10082,14 @@ chainsaw@~0.1.0:
   dependencies:
     traverse ">=0.3.0 <0.4"
 
+chalk@3.0.0, chalk@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
+  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
@@ -10077,14 +10125,6 @@ chalk@^2.0.0, chalk@^2.3.0, chalk@^2.4.1:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-chalk@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
-  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
 
 char-regex@^1.0.2:
   version "1.0.2"
@@ -10260,7 +10300,7 @@ cli-spinners@^2.5.0:
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.7.0.tgz#f815fd30b5f9eaac02db604c7a231ed7cb2f797a"
   integrity sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==
 
-cli-table3@^0.6.1, cli-table3@~0.6.1:
+cli-table3@0.6.3, cli-table3@^0.6.1, cli-table3@~0.6.1:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.3.tgz#61ab765aac156b52f222954ffc607a6f01dbeeb2"
   integrity sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==
@@ -10430,6 +10470,11 @@ comma-separated-tokens@^1.0.0:
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
   integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
 
+commander@4.1.1, commander@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
+  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
+
 commander@9.4.0, commander@^9.4.0:
   version "9.4.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.0.tgz#bc4a40918fefe52e22450c111ecd6b7acce6f11c"
@@ -10439,11 +10484,6 @@ commander@^2.12.1, commander@^2.19.0, commander@^2.2.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
-
-commander@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
-  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
 commander@^5.1.0:
   version "5.1.0"
@@ -12804,7 +12844,7 @@ exec-sh@^0.3.2:
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.6.tgz#ff264f9e325519a60cb5e273692943483cca63bc"
   integrity sha512-nQn+hI3yp+oD0huYhKwvYI32+JFeq+XkNcD1GAo3Y/MjxsfVGmrrzrnzjWiNY6f+pUCP440fThsFh5gZrRAU/w==
 
-execa@4.1.0, execa@^4.0.0:
+execa@4.1.0, execa@^4.0.0, execa@^4.0.2:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a"
   integrity sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==
@@ -13386,6 +13426,24 @@ fork-ts-checker-webpack-plugin@7.2.13:
     semver "^7.3.5"
     tapable "^2.2.1"
 
+fork-ts-checker-webpack-plugin@7.2.14:
+  version "7.2.14"
+  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-7.2.14.tgz#746eb15b4d643aafccd3c729995f9c9281eabd22"
+  integrity sha512-Tg2feh/n8k486KX0EbXVUfJj3j0xnnbKYTJw0fnIb2QdV0+lblOYZSal5ed9hARoWVwKeOC7sYE2EakSRLo5ZA==
+  dependencies:
+    "@babel/code-frame" "^7.16.7"
+    chalk "^4.1.2"
+    chokidar "^3.5.3"
+    cosmiconfig "^7.0.1"
+    deepmerge "^4.2.2"
+    fs-extra "^10.0.0"
+    memfs "^3.4.1"
+    minimatch "^3.0.4"
+    node-abort-controller "^3.0.1"
+    schema-utils "^3.1.1"
+    semver "^7.3.5"
+    tapable "^2.2.1"
+
 fork-ts-checker-webpack-plugin@^4.1.6:
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-4.1.6.tgz#5055c703febcf37fa06405d400c122b905167fc5"
@@ -13930,7 +13988,7 @@ glob@^6.0.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.3, glob@^7.0.6, glob@^7.1.1, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.2.0:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.6, glob@^7.1.1, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.2.0:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -14897,6 +14955,25 @@ inline-style-parser@0.1.1:
   resolved "https://registry.yarnpkg.com/inline-style-parser/-/inline-style-parser-0.1.1.tgz#ec8a3b429274e9c0a1f1c4ffa9453a7fef72cea1"
   integrity sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==
 
+inquirer@7.3.3:
+  version "7.3.3"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.3.3.tgz#04d176b2af04afc157a83fd7c100e98ee0aad003"
+  integrity sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.19"
+    mute-stream "0.0.8"
+    run-async "^2.4.0"
+    rxjs "^6.6.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
+
 inquirer@8.2.4:
   version "8.2.4"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.4.tgz#ddbfe86ca2f67649a67daa6f1051c128f684f0b4"
@@ -14947,6 +15024,11 @@ internal-slot@^1.0.3:
     get-intrinsic "^1.1.0"
     has "^1.0.3"
     side-channel "^1.0.4"
+
+interpret@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
+  integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
 interpret@^2.2.0:
   version "2.2.0"
@@ -17129,6 +17211,11 @@ lz-string@^1.4.4:
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
   integrity sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==
 
+macos-release@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.5.0.tgz#067c2c88b5f3fb3c56a375b2ec93826220fa1ff2"
+  integrity sha512-EIgv+QZ9r+814gjJj0Bt5vSLJLzswGmSUbUpbi9AIr/fsN2IWFBl2NucV9PAiek+U1STK468tEkxmVYUtuAN3g==
+
 magic-string@0.26.2:
   version "0.26.2"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.26.2.tgz#5331700e4158cd6befda738bb6b0c7b93c0d4432"
@@ -18057,6 +18144,13 @@ node-dir@^0.1.10:
   dependencies:
     minimatch "^3.0.2"
 
+node-emoji@1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.11.0.tgz#69a0150e6946e2f115e9d7ea4df7971e2628301c"
+  integrity sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==
+  dependencies:
+    lodash "^4.17.21"
+
 node-fetch@2.6.7, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
@@ -18779,6 +18873,14 @@ os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
   integrity sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==
+
+os-name@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/os-name/-/os-name-4.0.1.tgz#32cee7823de85a8897647ba4d76db46bf845e555"
+  integrity sha512-xl9MAoU97MH1Xt5K9ERft2YfCAoaO6msy1OBA0ozxEC0x0TmIoE6K3QvgJMMZA9yKGLmHXNY/YZoDbiGDj4zYw==
+  dependencies:
+    macos-release "^2.5.0"
+    windows-release "^4.0.0"
 
 os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
@@ -20886,6 +20988,13 @@ readdirp@^3.5.0, readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  integrity sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==
+  dependencies:
+    resolve "^1.1.6"
+
 redent@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
@@ -21260,7 +21369,7 @@ resolve.exports@1.1.0, resolve.exports@^1.1.0:
   resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-1.1.0.tgz#5ce842b94b05146c0e03076985d1d0e7e48c90c9"
   integrity sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==
 
-resolve@1.22.1, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.22.0, resolve@^1.22.1, resolve@^1.3.2:
+resolve@1.22.1, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.22.0, resolve@^1.22.1, resolve@^1.3.2:
   version "1.22.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
   integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
@@ -21326,7 +21435,7 @@ rimraf@2, rimraf@^2.2.8, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.0, rimraf@^3.0.2:
+rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -21456,7 +21565,7 @@ rxjs-for-await@0.0.2:
   resolved "https://registry.yarnpkg.com/rxjs-for-await/-/rxjs-for-await-0.0.2.tgz#26598a1d6167147cc192172970e7eed4e620384b"
   integrity sha512-IJ8R/ZCFMHOcDIqoABs82jal00VrZx8Xkgfe7TOKoaRPAW5nH/VFlG23bXpeGdrmtqI9UobFPgUKgCuFc7Lncw==
 
-rxjs@6.6.7, rxjs@^6.5.4, rxjs@^6.5.5:
+rxjs@6.6.7, rxjs@^6.5.4, rxjs@^6.5.5, rxjs@^6.6.0:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
@@ -21962,6 +22071,15 @@ shell-exec@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/shell-exec/-/shell-exec-1.0.2.tgz#2e9361b0fde1d73f476c4b6671fa17785f696756"
   integrity sha512-jyVd+kU2X+mWKMmGhx4fpWbPsjvD53k9ivqetutVW/BQ+WIZoDoP4d8vUMGezV6saZsiNoW2f9GIhg9Dondohg==
+
+shelljs@0.8.5:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
+  integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
 
 shiki@^0.9.12:
   version "0.9.15"
@@ -23452,6 +23570,15 @@ tsconfig-paths-webpack-plugin@^3.3.0:
     enhanced-resolve "^5.7.0"
     tsconfig-paths "^3.9.0"
 
+tsconfig-paths@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-4.1.1.tgz#7f23094ce897fcf4a93f67c4776e813003e48b75"
+  integrity sha512-VgPrtLKpRgEAJsMj5Q/I/mXouC6A/7eJ/X4Nuk6o0cRPwBtznYxTCU4FodbexbzH9somBPEXYi0ZkUViUpJ21Q==
+  dependencies:
+    json5 "^2.2.1"
+    minimist "^1.2.6"
+    strip-bom "^3.0.0"
+
 tsconfig-paths@^3.14.1, tsconfig-paths@^3.9.0:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz#ba0734599e8ea36c862798e920bcf163277b137a"
@@ -23668,6 +23795,11 @@ typescript@4.8.2:
   version "4.8.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.2.tgz#e3b33d5ccfb5914e4eeab6699cf208adee3fd790"
   integrity sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==
+
+typescript@4.9.4:
+  version "4.9.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
+  integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
 
 "typescript@^3 || ^4", typescript@~4.8.2:
   version "4.8.4"
@@ -24520,7 +24652,7 @@ webpack-merge@5.8.0, webpack-merge@^5.8.0:
     clone-deep "^4.0.1"
     wildcard "^2.0.0"
 
-webpack-node-externals@^3.0.0:
+webpack-node-externals@3.0.0, webpack-node-externals@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-3.0.0.tgz#1a3407c158d547a9feb4229a9e3385b7b60c9917"
   integrity sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==
@@ -24759,6 +24891,13 @@ wildcard@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.0.tgz#a77d20e5200c6faaac979e4b3aadc7b3dd7f8fec"
   integrity sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==
+
+windows-release@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/windows-release/-/windows-release-4.0.0.tgz#4725ec70217d1bf6e02c7772413b29cdde9ec377"
+  integrity sha512-OxmV4wzDKB1x7AZaZgXMVsdJ1qER1ed83ZrTYd5Bwq2HfJVg3DJS8nqlAG4sMoJ7mu8cuRmLEYyU13BKwctRAg==
+  dependencies:
+    execa "^4.0.2"
 
 word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`nx init` does not recognize NestCLI application

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`nx init` inside of a NestCLI application will turn that application into a Nx Standalone setup with `@nrwl/nest`
- NestJS monorepo mode support is coming after this initial feature
- `--language=js` support is coming after this initial feature