### PR TITLE
fix(core): Adding a yarn berry version of isRootVersion utility

### DIFF
--- a/packages/nx/src/lock-file/yarn.ts
+++ b/packages/nx/src/lock-file/yarn.ts
@@ -540,7 +540,6 @@ function ensureMetaVersion(
  * A function equivalent to isRootVersion, but for yarn berry
  * @param packageName name of the package
  * @param version version of the package to check
- * @returns a boolean indicating if the package of given version is installed in the root of the project
  */
 function isRootVersionBerry(packageName: string, version: string): boolean {
   const pmc = getPackageManagerCommand();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Building a publishable package fails when
1. Yarn berry or higher is used as the package manager
2. More than one version of a package is found in dependencies.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Building publishable packages in above-mentioned scenarios must not fail by default.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14106 in yarn berry environments
