### PR TITLE
fix(core): keep decorate-cli script for existing workspace usages

### DIFF
--- a/packages/cli/lib/decorate-cli.ts
+++ b/packages/cli/lib/decorate-cli.ts
@@ -1,0 +1,1 @@
+export * from 'nx/src/adapter/decorate-cli';

--- a/packages/nx/src/adapter/decorate-cli.ts
+++ b/packages/nx/src/adapter/decorate-cli.ts
@@ -1,12 +1,13 @@
 import { readFileSync, writeFileSync } from 'fs';
+import { output } from '../utils/output';
 
 export function decorateCli() {
-  console.warn(
-    `Decoration of the Angular CLI is deprecated and will be removed in a future version.`
-  );
-  console.warn(
-    `Please replace usage of "ng <command>" in any scripts, particularly for CI, with "nx <command>".`
-  );
+  output.warn({
+    title: `Decoration of the Angular CLI is deprecated and will be removed in a future version`,
+    bodyLines: [
+      `Please replace usage of "ng <command>" in any scripts, particularly for CI, with "nx <command>"`,
+    ],
+  });
   const path = 'node_modules/@angular/cli/lib/cli/index.js';
   const angularCLIInit = readFileSync(path, 'utf-8');
   const start = angularCLIInit.indexOf(`(options) {`) + 11;

--- a/packages/nx/src/adapter/decorate-cli.ts
+++ b/packages/nx/src/adapter/decorate-cli.ts
@@ -1,0 +1,22 @@
+import { readFileSync, writeFileSync } from 'fs';
+
+export function decorateCli() {
+  console.warn(
+    `Decoration of the Angular CLI is deprecated and will be removed in a future version.`
+  );
+  console.warn(
+    `Please replace usage of "ng <command>" in any scripts, particularly for CI, with "nx <command>".`
+  );
+  const path = 'node_modules/@angular/cli/lib/cli/index.js';
+  const angularCLIInit = readFileSync(path, 'utf-8');
+  const start = angularCLIInit.indexOf(`(options) {`) + 11;
+
+  const newContent = `${angularCLIInit.slice(0, start)}
+  if (!process.env['NX_CLI_SET']) {
+    require('nx/bin/nx');
+    return new Promise(function(res, rej) {});
+  }
+  ${angularCLIInit.substring(start)}
+`;
+  writeFileSync(path, newContent);
+}


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
Existing workspaces will fail when trying to decorate angular cli as the script was removed

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Reinstate the script but log a warning
