### PR TITLE
feat(angular): throw error when --standalone used for setup-mf w/ invalid Ng version

### DIFF
--- a/packages/angular/src/generators/setup-mf/setup-mf.spec.ts
+++ b/packages/angular/src/generators/setup-mf/setup-mf.spec.ts
@@ -1,4 +1,9 @@
-import { readJson, readProjectConfiguration, Tree } from '@nrwl/devkit';
+import {
+  readJson,
+  readProjectConfiguration,
+  Tree,
+  updateJson,
+} from '@nrwl/devkit';
 import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 
 import { setupMf } from './setup-mf';
@@ -342,5 +347,27 @@ describe('Init MF', () => {
     expect(
       tree.read('apps/app1/src/app/app.routes.ts', 'utf-8')
     ).toMatchSnapshot();
+  });
+
+  it('should throw an error when installed version of angular < 14.1.0 and --standalone is used', async () => {
+    // ARRANGE
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: {
+        ...json.dependencies,
+        '@angular/core': '14.0.0',
+      },
+    }));
+
+    // ACT & ASSERT
+    await expect(
+      setupMf(tree, {
+        appName: 'app1',
+        mfType: 'host',
+        standalone: true,
+      })
+    ).rejects.toThrow(
+      'The --standalone flag is not supported in your current version of Angular (14.0.0). Please update to a version of Angular that supports Standalone Components (>= 14.1.0).'
+    );
   });
 });

--- a/packages/angular/src/generators/setup-mf/setup-mf.ts
+++ b/packages/angular/src/generators/setup-mf/setup-mf.ts
@@ -16,8 +16,17 @@ import {
   updateHostAppRoutes,
   updateTsConfigTarget,
 } from './lib';
+import { getInstalledAngularVersionInfo } from '../utils/angular-version-utils';
+import { lt } from 'semver';
 
 export async function setupMf(tree: Tree, options: Schema) {
+  const installedAngularInfo = getInstalledAngularVersionInfo(tree);
+
+  if (lt(installedAngularInfo.version, '14.1.0') && options.standalone) {
+    throw new Error(
+      `The --standalone flag is not supported in your current version of Angular (${installedAngularInfo.version}). Please update to a version of Angular that supports Standalone Components (>= 14.1.0).`
+    );
+  }
   const projectConfig = readProjectConfiguration(tree, options.appName);
 
   options.federationType = options.federationType ?? 'static';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We don't support --standalone for versions of angular < 14.1, but we do not error when generating

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Error when generating to inform users that --standalone is not supported for their version
