### PR TITLE
fix(misc): loosen chalk version

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "babel-jest": "28.1.3",
     "babel-loader": "^8.2.2",
     "browserslist": "^4.21.4",
-    "chalk": "4.1.0",
+    "chalk": "^4.1.0",
     "chokidar": "^3.5.1",
     "confusing-browser-globals": "^1.0.9",
     "conventional-changelog-cli": "^2.0.23",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -49,7 +49,7 @@
     "@nrwl/workspace": "file:../workspace",
     "@phenomnomnominal/tsquery": "4.1.1",
     "@schematics/angular": "~15.1.0",
-    "chalk": "4.1.0",
+    "chalk": "^4.1.0",
     "chokidar": "^3.5.1",
     "http-server": "^14.1.0",
     "ignore": "^5.0.4",

--- a/packages/create-nx-workspace/package.json
+++ b/packages/create-nx-workspace/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://nx.dev",
   "dependencies": {
-    "chalk": "4.1.0",
+    "chalk": "^4.1.0",
     "enquirer": "~2.3.6",
     "flat": "^5.0.2",
     "ora": "5.3.0",

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -38,7 +38,6 @@
     "@nrwl/linter": "file:../linter",
     "@nrwl/workspace": "file:../workspace",
     "@phenomnomnominal/tsquery": "4.1.1",
-    "chalk": "4.1.0",
     "dotenv": "~10.0.0",
     "semver": "7.3.4"
   },

--- a/packages/detox/package.json
+++ b/packages/detox/package.json
@@ -29,8 +29,7 @@
     "@nrwl/jest": "file:../jest",
     "@nrwl/linter": "file:../linter",
     "@nrwl/react": "file:../react",
-    "@nrwl/workspace": "file:../workspace",
-    "chalk": "^4.1.0"
+    "@nrwl/workspace": "file:../workspace"
   },
   "peerDependencies": {
     "detox": "^20.0.3"

--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -32,7 +32,7 @@
     "@nrwl/devkit": "file:../devkit",
     "@nrwl/js": "file:../js",
     "@nrwl/workspace": "file:../workspace",
-    "chalk": "4.1.0",
+    "chalk": "^4.1.0",
     "dotenv": "~10.0.0",
     "fast-glob": "3.2.7",
     "fs-extra": "^11.1.0",

--- a/packages/eslint-plugin-nx/package.json
+++ b/packages/eslint-plugin-nx/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@nrwl/devkit": "file:../devkit",
     "@typescript-eslint/utils": "^5.36.1",
-    "chalk": "4.1.0",
+    "chalk": "^4.1.0",
     "confusing-browser-globals": "^1.0.9",
     "semver": "7.3.4"
   },

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -38,7 +38,7 @@
     "@jest/test-result": "28.1.1",
     "@nrwl/devkit": "file:../devkit",
     "@phenomnomnominal/tsquery": "4.1.1",
-    "chalk": "4.1.0",
+    "chalk": "^4.1.0",
     "dotenv": "~10.0.0",
     "identity-obj-proxy": "3.0.0",
     "jest-config": "28.1.1",

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -35,7 +35,7 @@
     "@nrwl/devkit": "file:../devkit",
     "@nrwl/linter": "file:../linter",
     "@nrwl/workspace": "file:../workspace",
-    "chalk": "4.1.0",
+    "chalk": "^4.1.0",
     "fast-glob": "3.2.7",
     "fs-extra": "^11.1.0",
     "ignore": "^5.0.4",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -43,7 +43,7 @@
     "@nrwl/webpack": "file:../webpack",
     "@nrwl/workspace": "file:../workspace",
     "@svgr/webpack": "^6.1.2",
-    "chalk": "4.1.0",
+    "chalk": "^4.1.0",
     "dotenv": "~10.0.0",
     "fs-extra": "^11.1.0",
     "ignore": "^5.0.4",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -37,7 +37,6 @@
     "@nrwl/linter": "file:../linter",
     "@nrwl/webpack": "file:../webpack",
     "@nrwl/workspace": "file:../workspace",
-    "chalk": "4.1.0",
     "enquirer": "~2.3.6",
     "tslib": "^2.3.0"
   },

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -37,7 +37,7 @@
     "@yarnpkg/parsers": "^3.0.0-rc.18",
     "@zkochan/js-yaml": "0.0.6",
     "axios": "^1.0.0",
-    "chalk": "4.1.0",
+    "chalk": "^4.1.0",
     "cli-cursor": "3.1.0",
     "cli-spinners": "2.6.1",
     "cliui": "^7.0.2",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -35,7 +35,7 @@
     "@nrwl/linter": "file:../linter",
     "@nrwl/workspace": "file:../workspace",
     "@phenomnomnominal/tsquery": "4.1.1",
-    "chalk": "4.1.0",
+    "chalk": "^4.1.0",
     "enquirer": "~2.3.6",
     "minimatch": "3.0.5",
     "semver": "7.3.4"

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -39,7 +39,7 @@
     "@rollup/plugin-node-resolve": "^13.0.4",
     "autoprefixer": "^10.4.9",
     "babel-plugin-transform-async-to-promises": "^0.8.15",
-    "chalk": "4.1.0",
+    "chalk": "^4.1.0",
     "dotenv": "~10.0.0",
     "fs-extra": "^11.1.0",
     "postcss": "^8.4.14",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -34,7 +34,6 @@
     "@nrwl/js": "file:../js",
     "@phenomnomnominal/tsquery": "4.1.1",
     "@swc/helpers": "^0.4.11",
-    "chalk": "4.1.0",
     "dotenv": "~10.0.0",
     "enquirer": "~2.3.6"
   },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -49,7 +49,7 @@
     "babel-plugin-const-enum": "^1.0.1",
     "babel-plugin-macros": "^2.8.0",
     "babel-plugin-transform-typescript-metadata": "^0.3.1",
-    "chalk": "4.1.0",
+    "chalk": "^4.1.0",
     "chokidar": "^3.5.1",
     "http-server": "^14.1.0",
     "ignore": "^5.0.4",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -34,7 +34,7 @@
     "@nrwl/workspace": "file:../workspace",
     "autoprefixer": "^10.4.9",
     "babel-loader": "^8.2.2",
-    "chalk": "4.1.0",
+    "chalk": "^4.1.0",
     "chokidar": "^3.5.1",
     "copy-webpack-plugin": "^10.2.4",
     "css-loader": "^6.4.0",

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -72,7 +72,7 @@
   "dependencies": {
     "@nrwl/devkit": "file:../devkit",
     "@parcel/watcher": "2.0.4",
-    "chalk": "4.1.0",
+    "chalk": "^4.1.0",
     "chokidar": "^3.5.1",
     "cli-cursor": "3.1.0",
     "cli-spinners": "2.6.1",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`chalk` version is locked to 4.1.0

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`chalk` version is ^4.1.0 to support minor and patch level releases of chalk. 

I also removed `chalk` from the dependencies of packages not using it. 

Note: I know that the releases 4.1.1 and 4.1.2 of chalk only contained readme updates, but most packages updated to 4.1.2 or use the ^4.1.0 semver range while Nx locks the version to 4.1.0. This leads to npm not hoisting the package. 