### PR TITLE
cleanup(core): move js graph creation its own folder

### DIFF
--- a/e2e/js/src/js-swc.test.ts
+++ b/e2e/js/src/js-swc.test.ts
@@ -103,7 +103,7 @@ describe('js e2e', () => {
     const swcHelpersFromDist = readJson(`dist/libs/${lib}/package.json`)
       .peerDependencies['@swc/helpers'];
 
-    expect(satisfies(swcHelpersFromDist, swcHelpersFromRoot)).toBeTruthy();
+    expect(swcHelpersFromDist).toEqual(swcHelpersFromRoot);
 
     updateJson(`libs/${lib}/.lib.swcrc`, (json) => {
       json.jsc.externalHelpers = false;

--- a/e2e/js/src/js-tsc.test.ts
+++ b/e2e/js/src/js-tsc.test.ts
@@ -144,11 +144,8 @@ describe('js e2e', () => {
     const rootPackageJson = readJson(`package.json`);
 
     expect(
-      satisfies(
-        readJson(`dist/libs/${lib}/package.json`).peerDependencies.tslib,
-        rootPackageJson.dependencies.tslib
-      )
-    ).toBeTruthy();
+      readJson(`dist/libs/${lib}/package.json`).peerDependencies.tslib
+    ).toEqual(rootPackageJson.dependencies.tslib);
 
     updateJson(`libs/${lib}/tsconfig.json`, (json) => {
       json.compilerOptions = { ...json.compilerOptions, importHelpers: false };

--- a/e2e/node/src/node.test.ts
+++ b/e2e/node/src/node.test.ts
@@ -11,6 +11,7 @@ import {
   packageInstall,
   promisifiedTreeKill,
   readFile,
+  readJson,
   runCLI,
   runCLIAsync,
   runCommandUntil,
@@ -22,7 +23,6 @@ import {
 import { exec, execSync } from 'child_process';
 import * as http from 'http';
 import { getLockFileName } from 'nx/src/lock-file/lock-file';
-import { satisfies } from 'semver';
 
 function getData(port, path = '/api'): Promise<any> {
   return new Promise((resolve) => {
@@ -246,6 +246,7 @@ describe('Build Node apps', () => {
         detectPackageManager(tmpProjPath())
       )}`
     );
+    const rootPackageJson = JSON.parse(readFile(`package.json`));
     const packageJson = JSON.parse(
       readFile(`dist/apps/${nestapp}/package.json`)
     );
@@ -256,17 +257,22 @@ describe('Build Node apps', () => {
         version: '0.0.1',
       })
     );
-    expect(
-      satisfies(packageJson.dependencies['@nestjs/common'], '^9.0.0')
-    ).toBeTruthy();
-    expect(
-      satisfies(packageJson.dependencies['@nestjs/core'], '^9.0.0')
-    ).toBeTruthy();
-    expect(
-      satisfies(packageJson.dependencies['reflect-metadata'], '^0.1.13')
-    ).toBeTruthy();
-    expect(satisfies(packageJson.dependencies['rxjs'], '^7.0.0')).toBeTruthy();
-    expect(satisfies(packageJson.dependencies['tslib'], '^2.3.0')).toBeTruthy();
+
+    expect(packageJson.dependencies['@nestjs/common']).toEqual(
+      rootPackageJson.dependencies['@nestjs/common']
+    );
+    expect(packageJson.dependencies['@nestjs/core']).toEqual(
+      rootPackageJson.dependencies['@nestjs/core']
+    );
+    expect(packageJson.dependencies['reflect-metadata']).toEqual(
+      rootPackageJson.dependencies['reflect-metadata']
+    );
+    expect(packageJson.dependencies['rxjs']).toEqual(
+      rootPackageJson.dependencies['rxjs']
+    );
+    expect(packageJson.dependencies['tslib']).toEqual(
+      rootPackageJson.dependencies['tslib']
+    );
 
     const nodeapp = uniq('nodeapp');
     runCLI(`generate @nrwl/node:app ${nodeapp} --bundler=webpack`);

--- a/packages/nx/src/plugins/js/index.ts
+++ b/packages/nx/src/plugins/js/index.ts
@@ -1,0 +1,11 @@
+import { ProjectGraphProcessor } from '../../config/project-graph';
+import { ProjectGraphBuilder } from '../../project-graph/project-graph-builder';
+import { buildNpmPackageNodes } from './project-graph/build-nodes/build-npm-package-nodes';
+
+export const processProjectGraph: ProjectGraphProcessor = (graph) => {
+  const builder = new ProjectGraphBuilder(graph);
+
+  buildNpmPackageNodes(builder);
+
+  return builder.getUpdatedProjectGraph();
+};

--- a/packages/nx/src/plugins/js/project-graph/build-nodes/build-npm-package-nodes.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-nodes/build-npm-package-nodes.ts
@@ -1,7 +1,7 @@
+import { ProjectGraphBuilder } from '../../../../project-graph/project-graph-builder';
+import { readJsonFile } from '../../../../utils/fileutils';
 import { join } from 'path';
-import { workspaceRoot } from '../../utils/workspace-root';
-import { readJsonFile } from '../../utils/fileutils';
-import { ProjectGraphBuilder } from '../project-graph-builder';
+import { workspaceRoot } from '../../../../utils/workspace-root';
 
 export function buildNpmPackageNodes(builder: ProjectGraphBuilder) {
   const packageJson = readJsonFile(join(workspaceRoot, 'package.json'));

--- a/packages/nx/src/project-graph/build-nodes/index.ts
+++ b/packages/nx/src/project-graph/build-nodes/index.ts
@@ -1,2 +1,1 @@
 export * from './workspace-projects';
-export * from './npm-packages';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Js project graph calculation is intertwined with the core of Nx which doesn't actually need to work on JS at all.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Js project graph calculation is moved into its own folder and also uses the Nx Plugin API so it can later on be extracted into an optional plugin.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
