### PR TITLE
feat(web): use daemon file-watcher for file-server executors

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -31,10 +31,8 @@
   },
   "dependencies": {
     "chalk": "^4.1.0",
-    "chokidar": "^3.5.1",
     "detect-port": "^1.5.1",
     "http-server": "^14.1.0",
-    "ignore": "^5.0.4",
     "tslib": "^2.3.0",
     "@nx/devkit": "file:../devkit",
     "@nx/js": "file:../js"


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

# TODO
- [ ] ~Check if daemon is available and fallback to `@parcel/watcher` or `chokidar` when not available.~

## Current Behavior
<!-- This is the behavior we have today -->
`file-server` executors of the angular and web package use chokidar to watch the app and lib directory

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`file-server` executors use the daemon file-watcher

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
