### PR TITLE
feat(nx): add type to tasks list result for the `print-affected` command

### DIFF
--- a/packages/nx/src/config/task-graph.ts
+++ b/packages/nx/src/config/task-graph.ts
@@ -19,6 +19,10 @@ export interface Task {
      */
     target: string;
     /**
+     * The type (i.e., 'app', 'lib', or 'e2e') the project belongs to
+     */
+    type: string;
+    /**
      * The configuration of the target which the task invokes
      */
     configuration?: string;

--- a/packages/nx/src/tasks-runner/create-task-graph.ts
+++ b/packages/nx/src/tasks-runner/create-task-graph.ts
@@ -209,6 +209,7 @@ export class ProcessTasks {
       project: project.name,
       target,
       configuration: resolvedConfiguration,
+      type: project.type,
     };
 
     return {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->


<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Currently, when running the "print-affected" command with a target option, the affected tasks list does not include which type (i.e., 'app', 'lib', 'e2e') the project belongs to.  This information is valuable in cases where you have to perform further action based on the project's type.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The outcome should look like this: 
![image](https://user-images.githubusercontent.com/70804363/212031935-d6f16769-12fd-476e-8207-a1e3ad35db49.png)

(the target object now also includes the "type")

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

--> The unit tests are failing, and there are a bunch of them to fix. I am willing to do so, if the change I did in this PR is acceptable 😅 
