### PR TITLE
fix(core): add default configuration to nx schema

### DIFF
--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -222,6 +222,10 @@
             "type": "string"
           }
         },
+        "defaultConfiguration": {
+          "type": "string",
+          "description": "The name of a configuration to use as the default if a configuration is not provided"
+        },
         "configurations": {
           "type": "object",
           "description": "provides extra sets of values that will be merged into the options map",

--- a/packages/nx/src/config/workspaces.spec.ts
+++ b/packages/nx/src/config/workspaces.spec.ts
@@ -455,5 +455,97 @@ describe('Workspaces', () => {
         });
       });
     });
+
+    describe('defaultConfiguration', () => {
+      const projectDefaultConfiguration: TargetConfiguration['defaultConfiguration'] =
+        'dev';
+      const defaultDefaultConfiguration: TargetConfiguration['defaultConfiguration'] =
+        'prod';
+
+      const merged: TargetConfiguration['defaultConfiguration'] =
+        projectDefaultConfiguration;
+
+      it('should merge defaultConfiguration if executor matches', () => {
+        expect(
+          mergeTargetConfigurations(
+            {
+              root: '.',
+              targets: {
+                build: {
+                  executor: 'target',
+                  defaultConfiguration: projectDefaultConfiguration,
+                },
+              },
+            },
+            'build',
+            {
+              executor: 'target',
+              defaultConfiguration: defaultDefaultConfiguration,
+            }
+          ).defaultConfiguration
+        ).toEqual(merged);
+      });
+
+      it('should merge if executor is only provided on the project', () => {
+        expect(
+          mergeTargetConfigurations(
+            {
+              root: '.',
+              targets: {
+                build: {
+                  executor: 'target',
+                  defaultConfiguration: projectDefaultConfiguration,
+                },
+              },
+            },
+            'build',
+            {
+              defaultConfiguration: defaultDefaultConfiguration,
+            }
+          ).defaultConfiguration
+        ).toEqual(merged);
+      });
+
+      it('should merge if executor is only provided in the defaults', () => {
+        expect(
+          mergeTargetConfigurations(
+            {
+              root: '.',
+              targets: {
+                build: {
+                  defaultConfiguration: projectDefaultConfiguration,
+                },
+              },
+            },
+            'build',
+            {
+              executor: 'target',
+              defaultConfiguration: defaultDefaultConfiguration,
+            }
+          ).defaultConfiguration
+        ).toEqual(merged);
+      });
+
+      it('should not merge if executor doesnt match', () => {
+        expect(
+          mergeTargetConfigurations(
+            {
+              root: '',
+              targets: {
+                build: {
+                  executor: 'other',
+                  defaultConfiguration: projectDefaultConfiguration,
+                },
+              },
+            },
+            'build',
+            {
+              executor: 'target',
+              defaultConfiguration: defaultDefaultConfiguration,
+            }
+          ).defaultConfiguration
+        ).toEqual(projectDefaultConfiguration);
+      });
+    });
   });
 });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The `defaultConfiguration` property for an executor is missing from [nx-schema.json properties](https://github.com/nrwl/nx/blob/16aa1b5af2bb296fb91c6b30cec5f9418a42ac51/packages/nx/schemas/nx-schema.json#L211).

**Setting the `defaultConfiguration` property in `nx.json` for an executor does work though.**

## Expected Behavior
The `defaultConfiguration` property exists in the [nx-schema.json properties](https://github.com/nrwl/nx/blob/16aa1b5af2bb296fb91c6b30cec5f9418a42ac51/packages/nx/schemas/nx-schema.json#L211) you don't get an `Property 'defaultConfiguration' is not allowed ` warning.

[core: merge more target options from targetDefaults](https://github.com/nrwl/nx/pull/12435/files#diff-60e9fd49c694ec24c2e25e3201eeb2f4be115039b4c78218d74d8b73c7b38490) in release 15.4.3 should have included this change.

## Related Issue(s)


Fixes #14214