### PR TITLE
fix(storybook): return baseUrl from storybook and use in cypress

### DIFF
--- a/packages/cypress/src/executors/cypress/cypress.impl.ts
+++ b/packages/cypress/src/executors/cypress/cypress.impl.ts
@@ -173,6 +173,7 @@ async function* startDevServer(
   for await (const output of await runExecutor<{
     success: boolean;
     baseUrl?: string;
+    info?: { port: number; baseUrl?: string };
   }>(
     { project, target, configuration },
     // @NOTE: Do not forward watch option if not supported by the target dev server,
@@ -183,7 +184,15 @@ async function* startDevServer(
   )) {
     if (!output.success && !opts.watch)
       throw new Error('Could not compile application files');
-    yield opts.baseUrl || (output.baseUrl as string);
+    if (
+      !opts.baseUrl &&
+      !output.baseUrl &&
+      !output.info.baseUrl &&
+      output.info.port
+    ) {
+      output.baseUrl = `http://localhost:${output.info.port}`;
+    }
+    yield opts.baseUrl || output.baseUrl || output.info.baseUrl;
   }
 }
 

--- a/packages/storybook/src/executors/storybook/storybook.impl.ts
+++ b/packages/storybook/src/executors/storybook/storybook.impl.ts
@@ -13,7 +13,10 @@ import { CommonNxStorybookConfig } from '../models';
 export default async function* storybookExecutor(
   options: CLIOptions & CommonNxStorybookConfig,
   context: ExecutorContext
-): AsyncGenerator<{ success: boolean; info?: { port: number } }> {
+): AsyncGenerator<{
+  success: boolean;
+  info?: { port: number; baseUrl?: string };
+}> {
   const storybook7 = isStorybookV7();
   storybookConfigExistsCheck(options.configDir, context.projectName);
   if (storybook7) {
@@ -22,7 +25,15 @@ export default async function* storybookExecutor(
       buildOptions,
       storybook7
     );
-    yield { success: true, info: { port: result.port } };
+    yield {
+      success: true,
+      info: {
+        port: result.port,
+        baseUrl: `${options.https ? 'https' : 'http'}://${
+          options.host ?? 'localhost'
+        }:${result.port}`,
+      },
+    };
     await new Promise<{ success: boolean }>(() => {});
   } else {
     // TODO (katerina): Remove when Storybook 7


### PR DESCRIPTION
Pass the `port` and the `baseUrl` from the Storybook `devServer` to the cypress executor.

## Why this schema?

**Reason why we are using the `info?: { port: number; baseUrl?: string };` schema:**

The [`@storybook/angular:start-storybook` executor returns](https://github.com/storybookjs/storybook/blob/next/code/frameworks/angular/src/builders/start-storybook/index.ts#L110):

```
return { success: true, info: { port } };
```

So we want to keep a consistent schema to our `@nrwl/storybook:storybook` executor.

Now, since we are in control of what the `@nrwl/storybook:storybook` executor returns and what the options passed to it are, we can generate/infer the whole `baseUrl` that it ends up with. So, we are passing that to cypress.

