### PR TITLE
feat(nx-cloud): display current token for connect-to-nx-cloud

### DIFF
--- a/packages/nx/src/command-line/connect.ts
+++ b/packages/nx/src/command-line/connect.ts
@@ -2,7 +2,11 @@ import { output } from '../utils/output';
 import { getPackageManagerCommand } from '../utils/package-manager';
 import { execSync } from 'child_process';
 import { readNxJson } from '../config/configuration';
-import { isNxCloudUsed } from '../utils/nx-cloud-utils';
+import {
+  getNxCloudToken,
+  getNxCloudUrl,
+  isNxCloudUsed,
+} from '../utils/nx-cloud-utils';
 
 export async function connectToNxCloudIfExplicitlyAsked(opts: {
   [k: string]: any;
@@ -33,7 +37,14 @@ export async function connectToNxCloudCommand(
 ): Promise<boolean> {
   if (isNxCloudUsed()) {
     output.log({
-      title: 'This workspace is already connected to Nx Cloud.',
+      title: '✅ This workspace is already connected to Nx Cloud.',
+      bodyLines: [
+        'This means your workspace can use computation caching, distributed task execution, and show you run analytics.',
+        'Go to https://nx.app to learn more.',
+        ' ',
+        'If you have not done so already, please claim this workspace:',
+        `${getNxCloudUrl()}'/orgs/workspace-setup?accessToken=${getNxCloudToken()}`,
+      ],
     });
     return false;
   }

--- a/packages/nx/src/utils/nx-cloud-utils.ts
+++ b/packages/nx/src/utils/nx-cloud-utils.ts
@@ -6,3 +6,14 @@ export function isNxCloudUsed() {
     (r) => r.runner == '@nrwl/nx-cloud'
   );
 }
+
+export function getNxCloudUrl(): string {
+  const taskRunner = isNxCloudUsed();
+  if (!taskRunner) throw new Error('@nrwl/nx-cloud runner not find in nx.json');
+  return taskRunner.options.url || 'https://nx.app';
+}
+export function getNxCloudToken(): string {
+  const taskRunner = isNxCloudUsed();
+  if (!taskRunner) throw new Error('@nrwl/nx-cloud runner not find in nx.json');
+  return taskRunner.options.accessToken;
+}


### PR DESCRIPTION
It displays the current token the runner uses when a workspace is already connected to Nx Cloud.

This will allow developers not to have to look for the access token themselves when they manually want to claim a workspace.
