### PR TITLE
fix(vite): expose "init" generator

### DIFF
--- a/packages/vite/index.ts
+++ b/packages/vite/index.ts
@@ -2,3 +2,4 @@ export * from './src/utils/versions';
 export * from './src/utils/generator-utils';
 export { viteConfigurationGenerator } from './src/generators/configuration/configuration';
 export { vitestGenerator } from './src/generators/vitest/vitest-generator';
+export { initGenerator } from './src/generators/init/init';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`@nrwl/vite:init` generator is mentioned in the docs and available via console, but is not exported from the package. And since this package has `exports` field in `package.json`, there's an error when trying to import it like `import { initGenerator } from '@nrwl/vite/src/generators/init/init';`  
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Should be able to import `init` generator without any issues.
