### PR TITLE
chore(core): make the JSON parser accepts trailing commas by default

### DIFF
--- a/docs/generated/devkit/index.md
+++ b/docs/generated/devkit/index.md
@@ -1705,7 +1705,7 @@ offsetFromRoot('apps/mydir/myapp/'); // returns "../../../"
 ▸ **parseJson**<`T`\>(`input`, `options?`): `T`
 
 Parses the given JSON string and returns the object the JSON content represents.
-By default javascript-style comments are allowed.
+By default javascript-style comments and trailing commas are allowed.
 
 #### Type parameters
 

--- a/docs/generated/packages/devkit/documents/index.md
+++ b/docs/generated/packages/devkit/documents/index.md
@@ -1705,7 +1705,7 @@ offsetFromRoot('apps/mydir/myapp/'); // returns "../../../"
 ▸ **parseJson**<`T`\>(`input`, `options?`): `T`
 
 Parses the given JSON string and returns the object the JSON content represents.
-By default javascript-style comments are allowed.
+By default javascript-style comments and trailing commas are allowed.
 
 #### Type parameters
 

--- a/packages/nx/src/utils/json.spec.ts
+++ b/packages/nx/src/utils/json.spec.ts
@@ -100,7 +100,22 @@ describe('parseJson', () => {
     `);
   });
 
-  it('should throw when JSON has trailing commas', () => {
+  it('should allow trailing commas by default', () => {
+    expect(() =>
+      parseJson(
+        `{
+      "test": 123,
+      "nested": {
+          "test": 123,
+          "more": 456,
+     },
+      "array": [1, 2, 3,]
+  }`
+      )
+    ).not.toThrow();
+  });
+
+  it('should throw when JSON has trailing commas if disabled', () => {
     expect(() =>
       parseJson(
         `{
@@ -111,7 +126,7 @@ describe('parseJson', () => {
      },
       "array": [1, 2, 3,]
   }`,
-        { disallowComments: true, expectComments: true }
+        { allowTrailingComma: false }
       )
     ).toThrowErrorMatchingInlineSnapshot(`
       "PropertyNameExpected in JSON at 6:6

--- a/packages/nx/src/utils/json.ts
+++ b/packages/nx/src/utils/json.ts
@@ -32,7 +32,7 @@ export interface JsonSerializeOptions {
 
 /**
  * Parses the given JSON string and returns the object the JSON content represents.
- * By default javascript-style comments are allowed.
+ * By default javascript-style comments and trailing commas are allowed.
  *
  * @param input JSON content as string
  * @param options JSON parse options
@@ -45,6 +45,8 @@ export function parseJson<T extends object = any>(
   try {
     return JSON.parse(input);
   } catch {}
+
+  options = { allowTrailingComma: true, ...options };
 
   const errors: ParseError[] = [];
   const result: T = parse(input, errors, options);


### PR DESCRIPTION
This PR makes the JSON parser allow trailing commas by default.

I have had generators failed because of trailing commas in tsconfig.json files - see https://github.com/nrwl/nx/issues/14167#issuecomment-1372701181 for details.

It is kind of a pain because typescript is happy with trailing commas but still Nx would complain.

With this change trailing commas would be allowed by default making the parser more lenient. 

Fixes #14203
