### PR TITLE
fix(core): Adding a yarn berry version of isRootVersion utility

### DIFF
--- a/packages/nx/src/lock-file/yarn.ts
+++ b/packages/nx/src/lock-file/yarn.ts
@@ -9,7 +9,6 @@ import { isRootVersion, TransitiveLookupFunctionInput } from './utils/mapping';
 import { generatePrunnedHash, hashString } from './utils/hashing';
 import { PackageJsonDeps } from './utils/pruning';
 import { sortObjectByKeys } from '../utils/object-sort';
-import { getPackageManagerCommand } from '@nrwl/devkit';
 import { execSync } from 'child_process';
 
 type LockFileDependencies = Record<

--- a/packages/nx/src/lock-file/yarn.ts
+++ b/packages/nx/src/lock-file/yarn.ts
@@ -9,7 +9,6 @@ import { isRootVersion, TransitiveLookupFunctionInput } from './utils/mapping';
 import { generatePrunnedHash, hashString } from './utils/hashing';
 import { PackageJsonDeps } from './utils/pruning';
 import { sortObjectByKeys } from '../utils/object-sort';
-import { execSync } from 'child_process';
 
 type LockFileDependencies = Record<
   string,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->
This is a rewritten version of the fix in #14260 with a better approach. Also, to retrigger Circle CI which was not triggering for some reason.

## Current Behavior
<!-- This is the behavior we have today -->

Building a publishable package fails when
1. Yarn berry or higher is used as the package manager
2. More than one version of a package is found in dependencies.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Building publishable packages in above-mentioned scenarios must not fail by default.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14106 in yarn berry environments
