### PR TITLE
chore(nx): remove pnx tip

### DIFF
--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -64,24 +64,6 @@ if (
   if (localNx === resolveNx(null)) {
     initLocal(workspace);
   } else {
-    const packageManager = detectPackageManager();
-    if (packageManager === 'pnpm') {
-      const tip =
-        process.platform === 'win32'
-          ? 'doskey pnx=pnpm nx -- $*'
-          : `alias pnx="pnpm nx --"`;
-      output.warn({
-        title: `Running global Nx CLI with PNPM may have issues.`,
-        bodyLines: [
-          `Prefer to use "pnpm" (https://pnpm.io/cli/exec) to execute commands in this workspace.`,
-          `${chalk.reset.inverse.bold.cyan(
-            ' TIP '
-          )} create a shortcut such as: ${chalk.bold.white(tip)}`,
-          ``,
-        ],
-      });
-    }
-
     // Nx is being run from globally installed CLI - hand off to the local
     require(localNx);
   }


### PR DESCRIPTION
## Current Behavior

When using `pnpm` and invoking `nx` globally a warning is showing instructing users to create a `pnx` alias to run `pnpm` through `pnpm nx`

## Expected Behavior

This tip appears to no longer be necessary so it should not be shown

## Related Issue(s)

Fixes #14220
