### PR TITLE
fix(angular): correctly error when assets are used in Angular < 15.1.0

### DIFF
--- a/docs/generated/packages/angular/executors/webpack-server.json
+++ b/docs/generated/packages/angular/executors/webpack-server.json
@@ -11,7 +11,7 @@
     "properties": {
       "assets": {
         "type": "array",
-        "description": "List of static application assets.",
+        "description": "List of static application assets. _Note: only supported in Angular versions >= 15.1.0_",
         "default": [],
         "items": {
           "oneOf": [

--- a/packages/angular/src/builders/webpack-server/schema.json
+++ b/packages/angular/src/builders/webpack-server/schema.json
@@ -8,7 +8,7 @@
   "properties": {
     "assets": {
       "type": "array",
-      "description": "List of static application assets.",
+      "description": "List of static application assets. _Note: only supported in Angular versions >= 15.1.0_",
       "default": [],
       "items": {
         "$ref": "#/definitions/assetPattern"

--- a/packages/angular/src/builders/webpack-server/webpack-server.impl.ts
+++ b/packages/angular/src/builders/webpack-server/webpack-server.impl.ts
@@ -1,10 +1,12 @@
-import { joinPathFragments } from '@nrwl/devkit';
+import { joinPathFragments, stripIndents } from '@nrwl/devkit';
 import { existsSync } from 'fs';
 import { from, Observable } from 'rxjs';
 import { mergeCustomWebpackConfig } from '../utilities/webpack';
 import { Schema } from './schema';
 import { createTmpTsConfigForBuildableLibs } from '../utilities/buildable-libs';
 import { switchMap } from 'rxjs/operators';
+import { getInstalledAngularVersionInfo } from '../../executors/utilities/angular-version-utils';
+import { lt } from 'semver';
 
 function buildServerApp(
   options: Schema,
@@ -90,6 +92,17 @@ export function executeWebpackServerBuilder(
   options: Schema,
   context: import('@angular-devkit/architect').BuilderContext
 ): Observable<import('@angular-devkit/build-angular').ServerBuilderOutput> {
+  const installedAngularVersionInfo = getInstalledAngularVersionInfo();
+
+  if (
+    lt(installedAngularVersionInfo.version, '15.1.0') &&
+    Array.isArray(options.assets) &&
+    options.assets.length > 0
+  ) {
+    throw new Error(stripIndents`The "assets" option is only supported in Angular >= 15.1.0. You are currently using ${installedAngularVersionInfo.version}.
+    You can resolve this error by removing the "assets" option or by migrating to Angular 15.1.0.`);
+  }
+
   options.buildLibsFromSource ??= true;
 
   if (!options.buildLibsFromSource) {


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
assets option for webpack-server is only supported in angular versions >= 15.1.0

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
error correctly when webpack-server + assets are used with lower versions of angular

