### PR TITLE
fix(angular): correctly error application when standalone is used in Angular < 14.1.0

### DIFF
--- a/docs/generated/packages/angular/generators/application.json
+++ b/docs/generated/packages/angular/generators/application.json
@@ -140,7 +140,7 @@
         "default": false
       },
       "standalone": {
-        "description": "Generate an application that is setup to use standalone components.",
+        "description": "Generate an application that is setup to use standalone components. _Note: This is only supported in Angular versions >= 14.1.0_",
         "type": "boolean",
         "default": false
       },

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -7,6 +7,7 @@ import {
   readJson,
   readNxJson,
   readProjectConfiguration,
+  stripIndents,
   updateJson,
 } from '@nrwl/devkit';
 import {
@@ -1068,6 +1069,26 @@ describe('app', () => {
       const project = readProjectConfiguration(appTree, 'my-app');
       expect(project.targets.build.options['outputPath']).toBe('dist/my-app');
     });
+  });
+
+  it('should error correctly when Angular version does not support standalone', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: {
+        '@angular/core': '14.0.0',
+      },
+    }));
+
+    // ACT & ASSERT
+    await expect(
+      generateApp(tree, 'my-app', {
+        standalone: true,
+      })
+    ).rejects
+      .toThrow(stripIndents`The "standalone" option is only supported in Angular >= 14.1.0. You are currently using 14.0.0.
+    You can resolve this error by removing the "standalone" option or by migrating to Angular 14.1.0.`);
   });
 });
 

--- a/packages/angular/src/generators/application/application.ts
+++ b/packages/angular/src/generators/application/application.ts
@@ -3,6 +3,7 @@ import {
   installPackagesTask,
   moveFilesToNewDirectory,
   readNxJson,
+  stripIndents,
   Tree,
   updateNxJson,
 } from '@nrwl/devkit';
@@ -12,7 +13,10 @@ import { join } from 'path';
 import { UnitTestRunner } from '../../utils/test-runners';
 import { angularInitGenerator } from '../init/init';
 import { setupTailwindGenerator } from '../setup-tailwind/setup-tailwind';
-import { getGeneratorDirectoryForInstalledAngularVersion } from '../utils/angular-version-utils';
+import {
+  getGeneratorDirectoryForInstalledAngularVersion,
+  getInstalledAngularVersionInfo,
+} from '../utils/angular-version-utils';
 import {
   addE2e,
   addLinting,
@@ -31,11 +35,19 @@ import {
   updateNxComponentTemplate,
 } from './lib';
 import type { Schema } from './schema';
+import { lt } from 'semver';
 
 export async function applicationGenerator(
   tree: Tree,
   schema: Partial<Schema>
 ) {
+  const installedAngularVersionInfo = getInstalledAngularVersionInfo(tree);
+
+  if (lt(installedAngularVersionInfo.version, '14.1.0') && schema.standalone) {
+    throw new Error(stripIndents`The "standalone" option is only supported in Angular >= 14.1.0. You are currently using ${installedAngularVersionInfo.version}.
+    You can resolve this error by removing the "standalone" option or by migrating to Angular 14.1.0.`);
+  }
+
   const generatorDirectory =
     getGeneratorDirectoryForInstalledAngularVersion(tree);
   if (generatorDirectory) {

--- a/packages/angular/src/generators/application/schema.json
+++ b/packages/angular/src/generators/application/schema.json
@@ -143,7 +143,7 @@
       "default": false
     },
     "standalone": {
-      "description": "Generate an application that is setup to use standalone components.",
+      "description": "Generate an application that is setup to use standalone components. _Note: This is only supported in Angular versions >= 14.1.0_",
       "type": "boolean",
       "default": false
     },


### PR DESCRIPTION
Correctly error for unsupported standalone option on angular < 14.1.0 