### PR TITLE
fix(angular): correctly error host when standalone is used in Angular < 14.1.0

### DIFF
--- a/docs/generated/packages/angular/generators/host.json
+++ b/docs/generated/packages/angular/generators/host.json
@@ -149,7 +149,7 @@
       },
       "standalone": {
         "type": "boolean",
-        "description": "Whether to generate a host application that uses standalone components.",
+        "description": "Whether to generate a host application that uses standalone components. _Note: This is only supported in Angular versions >= 14.1.0_",
         "default": false
       },
       "ssr": {

--- a/packages/angular/src/generators/host/host.spec.ts
+++ b/packages/angular/src/generators/host/host.spec.ts
@@ -6,6 +6,7 @@ import {
   getProjects,
   readProjectConfiguration,
 } from 'nx/src/generators/utils/project-configuration';
+import { stripIndents, updateJson } from '@nrwl/devkit';
 
 describe('Host App Generator', () => {
   it('should generate a host app with no remotes', async () => {
@@ -227,5 +228,26 @@ describe('Host App Generator', () => {
       expect(project.targets.server).toMatchSnapshot();
       expect(project.targets['serve-ssr']).toMatchSnapshot();
     });
+  });
+
+  it('should error correctly when Angular version does not support standalone', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: {
+        '@angular/core': '14.0.0',
+      },
+    }));
+
+    // ACT & ASSERT
+    await expect(
+      host(tree, {
+        name: 'test',
+        standalone: true,
+      })
+    ).rejects
+      .toThrow(stripIndents`The "standalone" option is only supported in Angular >= 14.1.0. You are currently using 14.0.0.
+    You can resolve this error by removing the "standalone" option or by migrating to Angular 14.1.0.`);
   });
 });

--- a/packages/angular/src/generators/host/host.ts
+++ b/packages/angular/src/generators/host/host.ts
@@ -1,4 +1,4 @@
-import { formatFiles, getProjects, Tree } from '@nrwl/devkit';
+import { formatFiles, getProjects, stripIndents, Tree } from '@nrwl/devkit';
 import type { Schema } from './schema';
 import applicationGenerator from '../application/application';
 import remoteGenerator from '../remote/remote';
@@ -7,8 +7,17 @@ import { setupMf } from '../setup-mf/setup-mf';
 import { E2eTestRunner } from '../../utils/test-runners';
 import { addSsr } from './lib';
 import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+import { getInstalledAngularVersionInfo } from '../utils/angular-version-utils';
+import { lt } from 'semver';
 
 export async function host(tree: Tree, options: Schema) {
+  const installedAngularVersionInfo = getInstalledAngularVersionInfo(tree);
+
+  if (lt(installedAngularVersionInfo.version, '14.1.0') && options.standalone) {
+    throw new Error(stripIndents`The "standalone" option is only supported in Angular >= 14.1.0. You are currently using ${installedAngularVersionInfo.version}.
+    You can resolve this error by removing the "standalone" option or by migrating to Angular 14.1.0.`);
+  }
+
   const projects = getProjects(tree);
 
   const remotesToGenerate: string[] = [];

--- a/packages/angular/src/generators/host/schema.json
+++ b/packages/angular/src/generators/host/schema.json
@@ -152,7 +152,7 @@
     },
     "standalone": {
       "type": "boolean",
-      "description": "Whether to generate a host application that uses standalone components.",
+      "description": "Whether to generate a host application that uses standalone components. _Note: This is only supported in Angular versions >= 14.1.0_",
       "default": false
     },
     "ssr": {


### PR DESCRIPTION
 correctly error host generator when standalone is used in Angular < 14.1.0