### PR TITLE
fix(angular): correctly error scam-to-standalone when used in Angular < 14.1.0

### DIFF
--- a/docs/generated/packages/angular/generators/scam-to-standalone.json
+++ b/docs/generated/packages/angular/generators/scam-to-standalone.json
@@ -6,7 +6,7 @@
     "$id": "GeneratorAngularScamToStandalone",
     "cli": "nx",
     "title": "Convert an Inline SCAM to Standalone Component",
-    "description": "Convert an Inline SCAM to a Standalone Component.",
+    "description": "Convert an Inline SCAM to a Standalone Component. _Note: This generator is only supported with Angular versions >= 14.1.0_.",
     "type": "object",
     "properties": {
       "component": {

--- a/packages/angular/src/generators/scam-to-standalone/scam-to-standalone.spec.ts
+++ b/packages/angular/src/generators/scam-to-standalone/scam-to-standalone.spec.ts
@@ -2,6 +2,7 @@ import { scamToStandalone } from './scam-to-standalone';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import applicationGenerator from '../application/application';
 import scamGenerator from '../scam/scam';
+import { stripIndents, updateJson } from '@nrwl/devkit';
 
 describe('scam-to-standalone', () => {
   it('should convert an inline scam to standalone', async () => {
@@ -79,5 +80,26 @@ describe('scam-to-standalone', () => {
       });
       "
     `);
+  });
+
+  it('should error correctly when Angular version does not support standalone', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: {
+        '@angular/core': '14.0.0',
+      },
+    }));
+
+    // ACT & ASSERT
+    await expect(
+      scamToStandalone(tree, {
+        component: 'src/app/bar/bar.component.ts',
+        project: 'foo',
+      })
+    ).rejects
+      .toThrow(stripIndents`This generator is only supported with Angular >= 14.1.0. You are currently using 14.0.0.
+    You can resolve this error by migrating to Angular 14.1.0.`);
   });
 });

--- a/packages/angular/src/generators/scam-to-standalone/scam-to-standalone.ts
+++ b/packages/angular/src/generators/scam-to-standalone/scam-to-standalone.ts
@@ -1,5 +1,10 @@
 import type { Tree } from '@nrwl/devkit';
-import { formatFiles, getProjects, joinPathFragments } from '@nrwl/devkit';
+import {
+  formatFiles,
+  getProjects,
+  joinPathFragments,
+  stripIndents,
+} from '@nrwl/devkit';
 import type { Schema } from './schema';
 import {
   convertScamToStandalone,
@@ -10,11 +15,20 @@ import {
   verifyIsInlineScam,
   verifyModuleIsScam,
 } from './lib';
+import { getInstalledAngularVersionInfo } from '../utils/angular-version-utils';
+import { lt } from 'semver';
 
 export async function scamToStandalone(
   tree: Tree,
   { component, project: projectName, skipFormat }: Schema
 ) {
+  const installedAngularVersionInfo = getInstalledAngularVersionInfo(tree);
+
+  if (lt(installedAngularVersionInfo.version, '14.1.0')) {
+    throw new Error(stripIndents`This generator is only supported with Angular >= 14.1.0. You are currently using ${installedAngularVersionInfo.version}.
+    You can resolve this error by migrating to Angular 14.1.0.`);
+  }
+
   const projects = getProjects(tree);
   let project = getTargetProject(projectName, projects);
 

--- a/packages/angular/src/generators/scam-to-standalone/schema.json
+++ b/packages/angular/src/generators/scam-to-standalone/schema.json
@@ -3,7 +3,7 @@
   "$id": "GeneratorAngularScamToStandalone",
   "cli": "nx",
   "title": "Convert an Inline SCAM to Standalone Component",
-  "description": "Convert an Inline SCAM to a Standalone Component.",
+  "description": "Convert an Inline SCAM to a Standalone Component. _Note: This generator is only supported with Angular versions >= 14.1.0_.",
   "type": "object",
   "properties": {
     "component": {


### PR DESCRIPTION
correctly error scam-to-standalone when used in Angular < 14.1.0