### PR TITLE
fix(angular): fix executor conversion to angular builder

### DIFF
--- a/e2e/angular-core/src/ng-cli.test.ts
+++ b/e2e/angular-core/src/ng-cli.test.ts
@@ -1,0 +1,77 @@
+import * as isCI from 'is-ci';
+import {
+  checkFilesExist,
+  getSelectedPackageManager,
+  packageInstall,
+  readJson,
+  runCommand,
+  runNgNew,
+  tmpProjPath,
+  uniq,
+  updateFile,
+} from '@nrwl/e2e/utils';
+import { PackageManager } from 'nx/src/utils/package-manager';
+import { removeSync } from 'fs-extra';
+
+process.env.SELECTED_CLI = 'angular';
+
+describe('using Nx executors and generators with Angular CLI', () => {
+  let project: string;
+  let packageManager: PackageManager;
+
+  beforeEach(() => {
+    project = uniq('proj');
+    packageManager = getSelectedPackageManager();
+    runNgNew(project, packageManager);
+  });
+
+  afterEach(() => {
+    if (isCI) {
+      try {
+        removeSync(tmpProjPath());
+      } catch (e) {}
+    }
+  });
+
+  it('should convert Nx executors into Angular CLI compatible builders', () => {
+    // update package.json
+    const packageJson = readJson('package.json');
+    packageJson.description = 'some description';
+    updateFile('package.json', JSON.stringify(packageJson, null, 2));
+
+    // use vite to build a library
+    packageInstall('vite', undefined, 'latest');
+    packageInstall('@nrwl/vite');
+    const angularJson = readJson('angular.json');
+    angularJson.projects[project].architect.build = {
+      builder: '@nrwl/vite:build',
+      options: {
+        configFile: 'vite.config.ts',
+        outputPath: 'dist',
+      },
+    };
+    updateFile('angular.json', JSON.stringify(angularJson, null, 2));
+    updateFile(
+      'vite.config.ts',
+      `
+      import { defineConfig } from 'vite';
+      export default defineConfig({
+        build: {
+          lib: {
+            entry: 'src/main.ts',
+            name: 'my-app',
+            fileName: 'main',
+            formats: ['cjs']
+          }
+        }
+      });
+    `
+    );
+    updateFile(`src/main.ts`, `console.log('Hello World');`);
+
+    runCommand(`npx ng build ${project}`);
+
+    checkFilesExist(`dist/main.js`);
+    expect(runCommand(`node dist/main.js`)).toMatch(/Hello World/);
+  });
+});

--- a/packages/nx/src/config/workspaces.ts
+++ b/packages/nx/src/config/workspaces.ts
@@ -34,14 +34,14 @@ import { joinPathFragments } from '../utils/path';
 export function workspaceConfigName(
   root: string,
   opts?: {
-    includeProjectsFromAngularJson;
+    _includeProjectsFromAngularJson?: boolean;
   }
 ): 'angular.json' | 'workspace.json' | null {
   if (
     existsSync(path.join(root, 'angular.json')) &&
     // Include projects from angular.json if explicitly required.
     // e.g. when invoked from `packages/devkit/src/utils/convert-nx-executor.ts`
-    (opts?.includeProjectsFromAngularJson ||
+    (opts?._includeProjectsFromAngularJson ||
       // Or if a workspace has `@nrwl/angular` installed then projects from `angular.json` to be considered by Nx.
       isNrwlAngularInstalled())
   ) {
@@ -98,13 +98,11 @@ export class Workspaces {
       (path) => readJsonFile(join(this.root, path))
     );
 
-    const workspaceFile = workspaceConfigName(this.root, {
-      includeProjectsFromAngularJson: opts?._includeProjectsFromAngularJson,
-    });
+    const workspaceFile = workspaceConfigName(this.root, opts);
 
     if (workspaceFile) {
       workspace.projects = this.mergeWorkspaceJsonAndGlobProjects(
-        this.readFromWorkspaceJson().projects,
+        this.readFromWorkspaceJson(opts).projects,
         workspace.projects
       );
     }
@@ -430,9 +428,11 @@ export class Workspaces {
     return this.root ? [this.root, __dirname] : [__dirname];
   }
 
-  private readFromWorkspaceJson() {
+  private readFromWorkspaceJson(opts?: {
+    _includeProjectsFromAngularJson?: boolean;
+  }) {
     const rawWorkspace = readJsonFile(
-      path.join(this.root, workspaceConfigName(this.root))
+      path.join(this.root, workspaceConfigName(this.root, opts))
     );
     return resolveNewFormatWithInlineProjects(rawWorkspace, this.root);
   }


### PR DESCRIPTION
There is an issue with using our executors as Angular builders through Angular CLI. This PR fixes the compatibility layer.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
