### PR TITLE
fix(core): check for nx.json before applying migrations

### DIFF
--- a/packages/nx/src/migrations/update-14-2-0/remove-default-collection.spec.ts
+++ b/packages/nx/src/migrations/update-14-2-0/remove-default-collection.spec.ts
@@ -1,10 +1,10 @@
 import { createTreeWithEmptyWorkspace } from '../../generators/testing-utils/create-tree-with-empty-workspace';
 import type { Tree } from '../../generators/tree';
-import removeDefaultCollection from './remove-default-collection';
 import {
   readNxJson,
   updateNxJson,
 } from '../../generators/utils/project-configuration';
+import removeDefaultCollection from './remove-default-collection';
 
 describe('remove-default-collection', () => {
   let tree: Tree;
@@ -45,6 +45,11 @@ describe('remove-default-collection', () => {
     delete config.cli;
     updateNxJson(tree, config);
 
+    await expect(removeDefaultCollection(tree)).resolves.not.toThrow();
+  });
+
+  it('should not error when nxJson does not exist', async () => {
+    tree.delete('nx.json');
     await expect(removeDefaultCollection(tree)).resolves.not.toThrow();
   });
 });

--- a/packages/nx/src/migrations/update-14-2-0/remove-default-collection.ts
+++ b/packages/nx/src/migrations/update-14-2-0/remove-default-collection.ts
@@ -1,11 +1,16 @@
+import { formatChangedFilesWithPrettierIfAvailable } from '../../generators/internal-utils/format-changed-files-with-prettier-if-available';
 import { Tree } from '../../generators/tree';
 import {
   readNxJson,
   updateNxJson,
 } from '../../generators/utils/project-configuration';
-import { formatChangedFilesWithPrettierIfAvailable } from '../../generators/internal-utils/format-changed-files-with-prettier-if-available';
 
 export default async function (tree: Tree) {
+  // If the workspace doesn't have a nx.json, don't make any changes
+  if (!tree.exists('nx.json')) {
+    return;
+  }
+
   const nxJson = readNxJson(tree);
 
   delete nxJson.cli?.defaultCollection;

--- a/packages/nx/src/migrations/update-14-3-4/create-target-defaults.spec.ts
+++ b/packages/nx/src/migrations/update-14-3-4/create-target-defaults.spec.ts
@@ -35,4 +35,9 @@ describe('createTargetDefaults', () => {
     });
     expect(updated.targetDependencies).toBeUndefined();
   });
+
+  it('should not error when nxJson does not exist', async () => {
+    tree.delete('nx.json');
+    await expect(createTargetDefaults(tree)).resolves.not.toThrow();
+  });
 });

--- a/packages/nx/src/migrations/update-14-3-4/create-target-defaults.ts
+++ b/packages/nx/src/migrations/update-14-3-4/create-target-defaults.ts
@@ -1,11 +1,16 @@
+import { formatChangedFilesWithPrettierIfAvailable } from '../../generators/internal-utils/format-changed-files-with-prettier-if-available';
 import { Tree } from '../../generators/tree';
 import {
   readNxJson,
   updateNxJson,
 } from '../../generators/utils/project-configuration';
-import { formatChangedFilesWithPrettierIfAvailable } from '../../generators/internal-utils/format-changed-files-with-prettier-if-available';
 
 export default async function (tree: Tree) {
+  // If the workspace doesn't have a nx.json, don't make any changes
+  if (!tree.exists('nx.json')) {
+    return;
+  }
+
   const nxJson = readNxJson(tree);
 
   if (nxJson.targetDependencies) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Some migrations error when nx.json does not exist.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
All migrations should pass if nx.json does not exist. This allows `repair` to be run on workspaces without a nx.json, which is the majority of `lerna` repositories.
