### PR TITLE
docs(nxdev): fix react monorepo tutorial link

### DIFF
--- a/docs/shared/npm-tutorial/integrated.md
+++ b/docs/shared/npm-tutorial/integrated.md
@@ -227,7 +227,7 @@ npx nx affected --target=build
 
 {% card title="Integrated Repos vs Package-Based Repos" description="Learn about two styles of monorepos." url="/concepts/integrated-vs-package-based" /%}
 
-{% card title="React Tutorial" description="A step-by-step tutorial showing how to build an integrated monorepo with React applications sharing code." url="/getting-started/react-tutorial" /%}
+{% card title="React Tutorial" description="A step-by-step tutorial showing how to build an integrated monorepo with React applications sharing code." url="/react-tutorial/1-code-generation" /%}
 
 {% card title="Node.js Tutorial" description="A step-by-step tutorial showing how to build an integrated monorepo with Node.js applications sharing code." url="/getting-started/node-tutorial" /%}
 


### PR DESCRIPTION
closes #14134
