### PR TITLE
fix(bundling): fix esbuild watch yields success=false when no error

### DIFF
--- a/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
+++ b/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
@@ -115,7 +115,7 @@ export async function* esbuildExecutor(
                       }
 
                       next({
-                        success: !!error && !hasTypeErrors,
+                        success,
                         // Need to call getOutfile directly in the case of bundle=false and outfile is not set for esbuild.
                         outfile: join(
                           context.root,


### PR DESCRIPTION
## Current Behavior
When using esbuild with watch=true, the onRebuild function returns success=false when there is no error.

## Expected Behavior
When using esbuild with watch=true, the onRebuild function should return success=true when there is no error.

## Related Issue(s)


Fixes #
