### PR TITLE
cleanup(angular): reduce sourcemap loading and decoding in ng-packagr-lite executor

### DIFF
--- a/packages/angular/src/executors/package/ng-packagr-adjustments/ts/cache-compiler-host.ts
+++ b/packages/angular/src/executors/package/ng-packagr-adjustments/ts/cache-compiler-host.ts
@@ -14,7 +14,9 @@ import { EntryPointNode, fileUrl } from 'ng-packagr/lib/ng-package/nodes';
 import { ensureUnixPath } from 'ng-packagr/lib/utils/path';
 import { NgPackageConfig } from 'ng-packagr/ng-package.schema';
 import * as path from 'path';
+import { gte } from 'semver';
 import * as ts from 'typescript';
+import { getInstalledPackageVersionInfo } from '../../../utilities/angular-version-utils';
 import { StylesheetProcessor } from '../styles/stylesheet-processor';
 
 export function cacheCompilerHost(
@@ -27,6 +29,8 @@ export function cacheCompilerHost(
   sourcesFileCache: FileCache = entryPoint.cache.sourcesFileCache
 ): CompilerHost {
   const compilerHost = ts.createIncrementalCompilerHost(compilerOptions);
+  const { version: ngPackagrVersion } =
+    getInstalledPackageVersionInfo('ng-packagr');
 
   const getNode = (fileName: string) => {
     const nodeUri = fileUrl(ensureUnixPath(fileName));
@@ -114,10 +118,30 @@ export function cacheCompilerHost(
         fileName = fileName.replace(/\.js(\.map)?$/, '.mjs$1');
         const outputCache = entryPoint.cache.outputCache;
 
-        outputCache.set(fileName, {
-          content: data,
-          version: createHash('sha256').update(data).digest('hex'),
-        });
+        // added in https://github.com/ng-packagr/ng-packagr/pull/2502, first released in 15.0.2
+        if (gte(ngPackagrVersion, '15.0.2')) {
+          // Extract inline sourcemap which will later be used by rollup.
+          const version = createHash('sha256').update(data).digest('hex');
+          let map = undefined;
+          if (fileName.endsWith('.mjs')) {
+            const cachedData = outputCache.get(fileName);
+            map =
+              cachedData?.version === version
+                ? cachedData.map
+                : require('convert-source-map').fromComment(data).toJSON();
+          }
+
+          outputCache.set(fileName, {
+            content: data,
+            version,
+            map,
+          });
+        } else {
+          outputCache.set(fileName, {
+            content: data,
+            version: createHash('sha256').update(data).digest('hex'),
+          });
+        }
       }
 
       compilerHost.writeFile.call(

--- a/packages/angular/src/executors/utilities/angular-version-utils.ts
+++ b/packages/angular/src/executors/utilities/angular-version-utils.ts
@@ -1,13 +1,19 @@
 import { readModulePackageJson } from 'nx/src/utils/package-json';
 import { major } from 'semver';
 
-type AngularVersionInfo = { major: number; version: string };
+type VersionInfo = { major: number; version: string };
 
-export function getInstalledAngularVersionInfo(): AngularVersionInfo | null {
+export function getInstalledAngularVersionInfo(): VersionInfo | null {
+  return getInstalledPackageVersionInfo('@angular/core');
+}
+
+export function getInstalledPackageVersionInfo(
+  pkgName: string
+): VersionInfo | null {
   try {
     const {
       packageJson: { version },
-    } = readModulePackageJson('@angular/core');
+    } = readModulePackageJson(pkgName);
 
     return { major: major(version), version };
   } catch {

--- a/scripts/depcheck/missing.ts
+++ b/scripts/depcheck/missing.ts
@@ -44,6 +44,7 @@ const IGNORE_MATCHES_IN_PACKAGE = {
     'node-sass',
     'node-sass-tilde-importer',
     'ora',
+    'convert-source-map',
     'postcss',
     'postcss-import',
     'postcss-preset-env',


### PR DESCRIPTION
Syncs the `ng-packagr-lite` executor with a change made in `ng-packagr` that reduces sourcemap loading and decoding.