### PR TITLE
fix(testing): do not set vitest root when not in workspaceRoot

### DIFF
--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -592,7 +592,7 @@ export function runCommandAsync(
     exec(
       command,
       {
-        cwd: tmpProjPath(),
+        cwd: opts.cwd || tmpProjPath(),
         env: {
           CI: 'true',
           ...(opts.env || getStrippedEnvironmentVariables()),

--- a/e2e/vite/src/vite.test.ts
+++ b/e2e/vite/src/vite.test.ts
@@ -205,6 +205,14 @@ describe('Vite Plugin', () => {
       expect(result.combinedOutput).toContain(
         `Successfully ran target test for project ${lib}`
       );
+
+      // TODO(caleb): run tests from project root and make sure they still work
+      const nestedResults = await runCLIAsync(`test ${lib} --skip-nx-cache`, {
+        cwd: `${tmpProjPath()}/libs/${lib}`,
+      });
+      expect(nestedResults.combinedOutput).toContain(
+        `Successfully ran target test for project ${lib}`
+      );
     }, 100_000);
 
     it('should collect coverage', () => {

--- a/packages/vite/src/executors/test/vitest.impl.ts
+++ b/packages/vite/src/executors/test/vitest.impl.ts
@@ -1,6 +1,7 @@
-import { ExecutorContext } from '@nrwl/devkit';
+import { ExecutorContext, workspaceRoot } from '@nrwl/devkit';
 import { File, Reporter } from 'vitest';
 import { VitestExecutorOptions } from './schema';
+import { relative } from 'path';
 
 class NxReporter implements Reporter {
   deferred: {
@@ -46,11 +47,15 @@ export default async function* runExecutor(
   )() as Promise<typeof import('vitest/node')>);
 
   const projectRoot = context.projectGraph.nodes[context.projectName].data.root;
+  const offset = relative(workspaceRoot, context.cwd);
 
   const nxReporter = new NxReporter(options.watch);
   const settings = {
     ...options,
-    root: projectRoot,
+    // when running nx from the project root, the root will get appended to the cwd.
+    // creating an invalid path and no tests will be found.
+    // instead if we are not at the root, let the cwd be root.
+    root: offset === '' ? projectRoot : '',
     reporters: [...(options.reporters ?? []), 'default', nxReporter],
     // if reportsDirectory is not provides vitest will remove all files in the project root
     // when coverage is enabled in the vite.config.ts


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
when running vitest in the project root no tests are found as it's looks in an invalid path. {workspaceRoot}/{projectRoot}/{projectRoot}

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
vitest does not search in an invalid path (extra {projectRoot} appended to the path).

The change will set the vitest root to the project root being tested if the ExecutorContext#cwd is the `workspaceRoot` otherwise it will be set to an empty string letting vitest set the root to the current process.cwd

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14208
