### PR TITLE
fix(core): cap inferred max workers count at 8

### DIFF
--- a/packages/nx/src/project-graph/build-project-graph.ts
+++ b/packages/nx/src/project-graph/build-project-graph.ts
@@ -400,7 +400,7 @@ function buildExplicitDependenciesUsingWorkers(
 function getNumberOfWorkers(): number {
   return process.env.NX_PROJECT_GRAPH_MAX_WORKERS
     ? +process.env.NX_PROJECT_GRAPH_MAX_WORKERS
-    : os.cpus().length - 1;
+    : Math.min(os.cpus().length - 1, 8); // This is capped for cases in CI where `os.cpus()` returns way more CPUs than the resources that are allocated
 }
 
 function createContext(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

In CI (within Docker containers) the `os.cpus()` returns the number of cpus the real OS has which is generally much more than the actual resources that the docker container has. This will then spawn many workers to calculate the project graph which will overwhelm the resources on the docker container and fail to calculate the graph.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

There's a cap of 8 on the inferred number of workers that we spawn to calculate the graph. This should prevent the container from getting overwhelmed

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
