### PR TITLE
docs(nxdev): remove partytown usage

### DIFF
--- a/nx-dev/nx-dev/next.config.js
+++ b/nx-dev/nx-dev/next.config.js
@@ -14,9 +14,6 @@ copySync(
 );
 
 module.exports = withNx({
-  experimental: {
-    nextScriptWorkers: true, // Enable PartyTown offloading script strategy
-  },
   // For both client and server
   env: {
     VERCEL: process.env.VERCEL,

--- a/nx-dev/nx-dev/pages/_app.tsx
+++ b/nx-dev/nx-dev/pages/_app.tsx
@@ -89,7 +89,7 @@ export default function CustomApp({
       {/* HubSpot Analytics */}
       <Script
         id="hs-script-loader"
-        strategy="worker"
+        strategy="afterInteractive"
         src="https://js.hs-scripts.com/2757427.js"
       />
       {/* Hotjar Analytics */}

--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
     "@babel/preset-typescript": "^7.15.0",
     "@cypress/react": "^6.0.0",
     "@floating-ui/react-dom": "^1.0.1",
+    "@nestjs/cli": "^9.0.0",
     "@nestjs/common": "^9.0.0",
     "@nestjs/core": "^9.0.0",
-    "@nestjs/cli": "^9.0.0",
     "@nestjs/platform-express": "^9.0.0",
     "@nestjs/schematics": "^9.0.0",
     "@nestjs/swagger": "^6.0.0",
@@ -264,7 +264,6 @@
     }
   },
   "dependencies": {
-    "@builder.io/partytown": "^0.6.1",
     "@docsearch/react": "^3.3.0",
     "@headlessui/react": "^1.7.3",
     "@heroicons/react": "^2.0.12",
@@ -327,4 +326,3 @@
     ]
   }
 }
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -2339,11 +2339,6 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@builder.io/partytown@^0.6.1":
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/@builder.io/partytown/-/partytown-0.6.4.tgz#8610c9e73cc52a95b963c1878760ebe628eee048"
-  integrity sha512-W6C7O0eSg6YNujHYZozXK5iJ+V69QVLLLRv+NlmYh1vFe0PUJ3kmAhRCx7rUqI3XAA/KpdyfdxLoopBg3GlfVA==
-
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"


### PR DESCRIPTION
It removes Partytown canary implementation usage from Nextjs project settings.