### PR TITLE
Vite: preview generator

### DIFF
--- a/docs/generated/packages/vite/generators/configuration.json
+++ b/docs/generated/packages/vite/generators/configuration.json
@@ -44,7 +44,7 @@
       },
       "serveTarget": {
         "type": "string",
-        "description": "The serve target of the project to be transformed to use the @nrwl/vite:dev-server executor."
+        "description": "The serve target of the project to be transformed to use the @nrwl/vite:dev-server and @nrwl/vite:preview-server executors."
       },
       "testTarget": {
         "type": "string",

--- a/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -11,6 +11,7 @@ import { join } from 'path';
       export default defineConfig({
         
         
+        
     plugins: [
       dts({
       tsConfigFilePath: join(__dirname, 'tsconfig.lib.json'),
@@ -64,6 +65,7 @@ exports[`@nrwl/vite:configuration library mode should set up non buildable libra
 import { join } from 'path';
       
       export default defineConfig({
+        
         
         
     plugins: [
@@ -344,6 +346,21 @@ exports[`@nrwl/vite:configuration transform React app to use Vite by providing c
             \\"jestConfig\\": \\"apps/my-test-mixed-react-app/jest.config.ts\\",
             \\"passWithNoTests\\": true
           }
+        },
+        \\"preview\\": {
+          \\"builder\\": \\"@nrwl/vite:preview-server\\",
+          \\"defaultConfiguration\\": \\"development\\",
+          \\"options\\": {
+            \\"buildTarget\\": \\"my-test-mixed-react-app:build\\"
+          },
+          \\"configurations\\": {
+            \\"development\\": {
+              \\"buildTarget\\": \\"my-test-mixed-react-app:build:development\\"
+            },
+            \\"production\\": {
+              \\"buildTarget\\": \\"my-test-mixed-react-app:build:production\\"
+            }
+          }
         }
       },
       \\"tags\\": []
@@ -365,6 +382,11 @@ exports[`@nrwl/vite:configuration transform React app to use Vite should create 
         
     server:{
       port: 4200,
+      host: 'localhost',
+    },
+        
+    preview:{
+      port: 4300,
       host: 'localhost',
     },
         
@@ -487,6 +509,21 @@ exports[`@nrwl/vite:configuration transform React app to use Vite should transfo
             \\"jestConfig\\": \\"apps/my-test-react-app/jest.config.ts\\",
             \\"passWithNoTests\\": true
           }
+        },
+        \\"preview\\": {
+          \\"builder\\": \\"@nrwl/vite:preview-server\\",
+          \\"defaultConfiguration\\": \\"development\\",
+          \\"options\\": {
+            \\"buildTarget\\": \\"my-test-react-app:build\\"
+          },
+          \\"configurations\\": {
+            \\"development\\": {
+              \\"buildTarget\\": \\"my-test-react-app:build:development\\"
+            },
+            \\"production\\": {
+              \\"buildTarget\\": \\"my-test-react-app:build:production\\"
+            }
+          }
         }
       },
       \\"tags\\": []
@@ -508,6 +545,11 @@ exports[`@nrwl/vite:configuration transform Web app to use Vite should create vi
         
     server:{
       port: 4200,
+      host: 'localhost',
+    },
+        
+    preview:{
+      port: 4300,
       host: 'localhost',
     },
         
@@ -620,6 +662,21 @@ exports[`@nrwl/vite:configuration transform Web app to use Vite should transform
             \\"jestConfig\\": \\"apps/my-test-web-app/jest.config.ts\\",
             \\"passWithNoTests\\": true
           }
+        },
+        \\"preview\\": {
+          \\"builder\\": \\"@nrwl/vite:preview-server\\",
+          \\"defaultConfiguration\\": \\"development\\",
+          \\"options\\": {
+            \\"buildTarget\\": \\"my-test-web-app:build\\"
+          },
+          \\"configurations\\": {
+            \\"development\\": {
+              \\"buildTarget\\": \\"my-test-web-app:build:development\\"
+            },
+            \\"production\\": {
+              \\"buildTarget\\": \\"my-test-web-app:build:production\\"
+            }
+          }
         }
       }
     }
@@ -640,6 +697,11 @@ exports[`@nrwl/vite:configuration vitest should create a vitest configuration if
         
     server:{
       port: 4200,
+      host: 'localhost',
+    },
+        
+    preview:{
+      port: 4300,
       host: 'localhost',
     },
         

--- a/packages/vite/src/generators/configuration/configuration.ts
+++ b/packages/vite/src/generators/configuration/configuration.ts
@@ -37,10 +37,10 @@ export async function viteConfigurationGenerator(tree: Tree, schema: Schema) {
   schema.includeLib ??= projectType === 'library';
 
   /**
-   * This is for when we are convering an existing project
+   * This is for when we are converting an existing project
    * to use the vite executors.
-   *  */
-  let projectAlreadyHasViteTargets: TargetFlags;
+   */
+  let projectAlreadyHasViteTargets: TargetFlags = {};
   if (!schema.newProject) {
     const userProvidedTargetName: UserProvidedTargetName = {
       build: schema.buildTarget,
@@ -63,8 +63,7 @@ export async function viteConfigurationGenerator(tree: Tree, schema: Schema) {
      * a build target at all, so we can create a new one.
      *
      * So we only throw if we found a target, but it is unsupported.
-     *
-     * */
+     */
     if (!validFoundTargetName.build && projectContainsUnsupportedExecutor) {
       throw new Error(
         `The project ${schema.project} cannot be converted to use the @nrwl/vite executors.`
@@ -144,11 +143,11 @@ export async function viteConfigurationGenerator(tree: Tree, schema: Schema) {
   });
   tasks.push(initTask);
 
-  if (!projectAlreadyHasViteTargets?.build) {
+  if (!projectAlreadyHasViteTargets.build) {
     addOrChangeBuildTarget(tree, schema, buildTargetName);
   }
 
-  if (!schema.includeLib && !projectAlreadyHasViteTargets?.serve) {
+  if (!schema.includeLib && !projectAlreadyHasViteTargets.serve) {
     addOrChangeServeTarget(tree, schema, serveTargetName);
   }
 

--- a/packages/vite/src/generators/configuration/configuration.ts
+++ b/packages/vite/src/generators/configuration/configuration.ts
@@ -17,6 +17,7 @@ import {
   handleUnknownExecutors,
   UserProvidedTargetName,
   TargetFlags,
+  addPreviewTarget,
 } from '../../utils/generator-utils';
 
 import initGenerator from '../init/init';
@@ -41,7 +42,7 @@ export async function viteConfigurationGenerator(tree: Tree, schema: Schema) {
    * to use the vite executors.
    */
   let projectAlreadyHasViteTargets: TargetFlags = {};
-  
+
   if (!schema.newProject) {
     const userProvidedTargetName: UserProvidedTargetName = {
       build: schema.buildTarget,
@@ -146,8 +147,13 @@ export async function viteConfigurationGenerator(tree: Tree, schema: Schema) {
     addOrChangeBuildTarget(tree, schema, buildTargetName);
   }
 
-  if (!schema.includeLib && !projectAlreadyHasViteTargets.serve) {
-    addOrChangeServeTarget(tree, schema, serveTargetName);
+  if (!schema.includeLib) {
+    if (!projectAlreadyHasViteTargets.serve) {
+      addOrChangeServeTarget(tree, schema, serveTargetName);
+    }
+    if (!projectAlreadyHasViteTargets.preview) {
+      addPreviewTarget(tree, schema, serveTargetName);
+    }
   }
 
   createOrEditViteConfig(tree, schema, false, projectAlreadyHasViteTargets);

--- a/packages/vite/src/generators/configuration/configuration.ts
+++ b/packages/vite/src/generators/configuration/configuration.ts
@@ -41,6 +41,7 @@ export async function viteConfigurationGenerator(tree: Tree, schema: Schema) {
    * to use the vite executors.
    */
   let projectAlreadyHasViteTargets: TargetFlags = {};
+  
   if (!schema.newProject) {
     const userProvidedTargetName: UserProvidedTargetName = {
       build: schema.buildTarget,
@@ -72,12 +73,11 @@ export async function viteConfigurationGenerator(tree: Tree, schema: Schema) {
 
     if (
       alreadyHasNxViteTargets.build &&
-      (alreadyHasNxViteTargets.serve ||
-        (!alreadyHasNxViteTargets.serve && projectType === 'library')) &&
+      (alreadyHasNxViteTargets.serve || projectType === 'library') &&
       alreadyHasNxViteTargets.test
     ) {
       throw new Error(
-        `The project ${schema.project} is aready configured to use the @nrwl/vite executors.
+        `The project ${schema.project} is already configured to use the @nrwl/vite executors.
         Please try a different project, or remove the existing targets 
         and re-run this generator to reset the existing Vite Configuration.
         `
@@ -114,9 +114,8 @@ export async function viteConfigurationGenerator(tree: Tree, schema: Schema) {
      * We also keep track of the targets that we found in the project,
      * through the findExistingTargetsInProject function, which returns
      * targets for build/serve/test that use supported executors, and
-     * can be coverted to use the vite executors. These are the
+     * can be converted to use the vite executors. These are the
      * kept in the validFoundTargetName object.
-     *
      */
     await handleUnsupportedUserProvidedTargets(
       userProvidedTargetIsUnsupported,

--- a/packages/vite/src/generators/configuration/schema.json
+++ b/packages/vite/src/generators/configuration/schema.json
@@ -44,7 +44,7 @@
     },
     "serveTarget": {
       "type": "string",
-      "description": "The serve target of the project to be transformed to use the @nrwl/vite:dev-server executor."
+      "description": "The serve target of the project to be transformed to use the @nrwl/vite:dev-server and @nrwl/vite:preview-server executors."
     },
     "testTarget": {
       "type": "string",

--- a/packages/vite/src/generators/vitest/__snapshots__/vitest.spec.ts.snap
+++ b/packages/vite/src/generators/vitest/__snapshots__/vitest.spec.ts.snap
@@ -10,6 +10,7 @@ exports[`vitest generator insourceTests should add the insourceSource option in 
       export default defineConfig({
         
         
+        
     plugins: [
       
       react(),
@@ -53,6 +54,7 @@ exports[`vitest generator vite.config should create correct vite.config.ts file 
       export default defineConfig({
         
         
+        
     plugins: [
       
       react(),
@@ -92,6 +94,7 @@ exports[`vitest generator vite.config should create correct vite.config.ts file 
       
       
       export default defineConfig({
+        
         
         
     plugins: [

--- a/packages/vite/src/generators/vitest/vitest-generator.ts
+++ b/packages/vite/src/generators/vitest/vitest-generator.ts
@@ -35,7 +35,7 @@ export async function vitestGenerator(
   );
   let testTarget =
     schema.testTarget ??
-    findExistingTargetsInProject(targets)?.validFoundTargetName?.test ??
+    findExistingTargetsInProject(targets).validFoundTargetName.test ??
     'test';
 
   addOrChangeTestTarget(tree, schema, testTarget);
@@ -73,9 +73,6 @@ export async function vitestGenerator(
   );
   tasks.push(installCoverageProviderTask);
 
-  if (schema.coverageProvider === 'istanbul') {
-  }
-
   await formatFiles(tree);
 
   return runTasksInSerial(...tasks);
@@ -100,9 +97,7 @@ function updateTsConfig(
       if (json.compilerOptions?.types) {
         json.compilerOptions.types.push('vitest');
       } else {
-        if (!json.compilerOptions) {
-          json.compilerOptions = {};
-        }
+        json.compilerOptions ??= {};
         json.compilerOptions.types = ['vitest'];
       }
     }

--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -225,7 +225,7 @@ export function addOrChangeServeTarget(
   };
 
   if (project.targets?.[target]) {
-    if (target === '@nxext/vite:dev') {
+    if (project.targets[target].executor === '@nxext/vite:dev') {
       serveOptions.proxyConfig = project.targets[target].options.proxyConfig;
     }
     project.targets[target].options = {
@@ -240,9 +240,7 @@ export function addOrChangeServeTarget(
     project.targets[target] = {
       executor: '@nrwl/vite:dev-server',
       defaultConfiguration: 'development',
-      options: {
-        buildTarget: `${options.project}:build`,
-      },
+      options: serveOptions,
       configurations: {
         development: {
           buildTarget: `${options.project}:build:development`,

--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -38,18 +38,18 @@ export function findExistingTargetsInProject(
     alreadyHasNxViteTargets: {},
   };
 
-  const supportedBuilders = [
-    '@nxext/vite:build',
-    '@nrwl/js:babel',
-    '@nrwl/js:swc',
-    '@nrwl/webpack:webpack',
-    '@nrwl/rollup:rollup',
-    '@nrwl/web:rollup',
-  ];
-
-  const supportedServers = ['@nxext/vite:dev', '@nrwl/webpack:dev-server'];
-
-  const supportedTesters = ['@nrwl/jest:jest', '@nxext/vitest:vitest'];
+  const supportedExecutors = {
+    build: [
+      '@nxext/vite:build',
+      '@nrwl/js:babel',
+      '@nrwl/js:swc',
+      '@nrwl/webpack:webpack',
+      '@nrwl/rollup:rollup',
+      '@nrwl/web:rollup',
+    ],
+    serve: ['@nxext/vite:dev', '@nrwl/webpack:dev-server'],
+    test: ['@nrwl/jest:jest', '@nxext/vitest:vitest'],
+  };
 
   const unsupportedExecutors = [
     '@nrwl/angular:ng-packagr-lite',
@@ -73,9 +73,13 @@ export function findExistingTargetsInProject(
   // If they have, we check if the executor the target is using is supported
   // If it's not supported, then we set the unsupported flag to true for that target
 
-  function checkUserProvidedTarget(target: string, executors: string[]) {
+  function checkUserProvidedTarget(target: Target) {
     if (userProvidedTargets?.[target]) {
-      if (executors.includes(targets[userProvidedTargets[target]]?.executor)) {
+      if (
+        supportedExecutors[target].includes(
+          targets[userProvidedTargets[target]]?.executor
+        )
+      ) {
         output.validFoundTargetName[target] = userProvidedTargets[target];
       } else {
         output.userProvidedTargetIsUnsupported[target] = true;
@@ -83,9 +87,9 @@ export function findExistingTargetsInProject(
     }
   }
 
-  checkUserProvidedTarget('build', supportedBuilders);
-  checkUserProvidedTarget('serve', supportedServers);
-  checkUserProvidedTarget('test', supportedTesters);
+  checkUserProvidedTarget('build');
+  checkUserProvidedTarget('serve');
+  checkUserProvidedTarget('test');
 
   // Returns early when we have a build, serve, and test targets.
   if (
@@ -107,13 +111,19 @@ export function findExistingTargetsInProject(
     hasViteTargets.test ||= executorName === '@nrwl/vite:test';
 
     const foundTargets = output.validFoundTargetName;
-    if (!foundTargets.build && supportedBuilders.includes(executorName)) {
+    if (
+      !foundTargets.build &&
+      supportedExecutors.build.includes(executorName)
+    ) {
       foundTargets.build = target;
     }
-    if (!foundTargets.serve && supportedServers.includes(executorName)) {
+    if (
+      !foundTargets.serve &&
+      supportedExecutors.serve.includes(executorName)
+    ) {
       foundTargets.serve = target;
     }
-    if (!foundTargets.test && supportedTesters.includes(executorName)) {
+    if (!foundTargets.test && supportedExecutors.test.includes(executorName)) {
       foundTargets.test = target;
     }
 

--- a/packages/vite/src/utils/vite-config-edit-utils.ts
+++ b/packages/vite/src/utils/vite-config-edit-utils.ts
@@ -131,7 +131,7 @@ function handleBuildOrTestNode(
           updatedFileContent,
           'ExportAssignment'
         );
-        const found = tsquery?.query(
+        const found = tsquery.query(
           defaultExport?.[0],
           'ObjectLiteralExpression'
         );


### PR DESCRIPTION
This PR is the second part of #14125

I have created multiple commits to make the review easier.

Commits (older first):

- [cleaning(vite): minor cleanup/refactoring](https://github.com/nrwl/nx/pull/14375/commits/6c06134c39e51e171c78005a0ad0e67046c7b61e)

A couple fixes (see inline comments) and some refactoring/simplification of the vite generators. The behavior remains unchanged.

- [fix(vite): fix addOrChangeServeTarget](https://github.com/nrwl/nx/pull/14375/commits/d3becb8ff193b151993c183e0812054667d0c6c9)

A small fix

- [feat(vite): generate a preview target](https://github.com/nrwl/nx/pull/14375/commits/865e7d0f625f27f3b03e5da5d3e0647c63bc48ab)

Update the generator to generate a preview target.

I tested the PR locally and it works fine.

The next and last step will be to add support for watch mode in the build and preview executors.

/cc @mandarini 
