### PR TITLE
docs(vite): add x-priority flag for the preview executor

### DIFF
--- a/docs/generated/packages/vite/executors/preview-server.json
+++ b/docs/generated/packages/vite/executors/preview-server.json
@@ -15,14 +15,19 @@
     "properties": {
       "buildTarget": {
         "type": "string",
-        "description": "Target which builds the application."
+        "description": "Target which builds the application.",
+        "x-priority": "important"
       },
       "proxyConfig": {
         "type": "string",
         "description": "Path to the proxy configuration file.",
         "x-completion-type": "file"
       },
-      "port": { "type": "number", "description": "Port to listen on." },
+      "port": {
+        "type": "number",
+        "description": "Port to listen on.",
+        "x-priority": "important"
+      },
       "host": {
         "description": "Specify which IP addresses the server should listen on.",
         "oneOf": [{ "type": "boolean" }, { "type": "string" }]

--- a/packages/vite/src/executors/preview-server/schema.json
+++ b/packages/vite/src/executors/preview-server/schema.json
@@ -18,7 +18,8 @@
   "properties": {
     "buildTarget": {
       "type": "string",
-      "description": "Target which builds the application."
+      "description": "Target which builds the application.",
+      "x-priority": "important"
     },
     "proxyConfig": {
       "type": "string",
@@ -27,7 +28,8 @@
     },
     "port": {
       "type": "number",
-      "description": "Port to listen on."
+      "description": "Port to listen on.",
+      "x-priority": "important"
     },
     "host": {
       "description": "Specify which IP addresses the server should listen on.",


### PR DESCRIPTION
Seems like #14336 was created before the preview executor was submitted.

Added the same `x-important` keys as for the `dev-server`.

/cc @mandarini 
