### PR TITLE
fix(js): fix reading tsconfig.json on TypeScript 4.9

### DIFF
--- a/packages/nx/src/utils/typescript.ts
+++ b/packages/nx/src/utils/typescript.ts
@@ -34,6 +34,7 @@ function readTsConfigOptions(tsConfigPath: string) {
   // we don't need to scan the files, we only care about options
   const host = {
     readDirectory: () => [],
+    readFile: () => '',
     fileExists: tsModule.sys.fileExists,
   };
   return tsModule.parseJsonConfigFileContent(

--- a/packages/workspace/src/utilities/typescript.ts
+++ b/packages/workspace/src/utilities/typescript.ts
@@ -40,6 +40,7 @@ function readTsConfigOptions(tsConfigPath: string) {
   // we don't need to scan the files, we only care about options
   const host: Partial<ts.ParseConfigHost> = {
     readDirectory: () => [],
+    readFile: () => '',
     fileExists: tsModule.sys.fileExists,
   };
 


### PR DESCRIPTION
## Current Behavior
Crashes when reading (certain) `tsconfig.json` files with TypeScript 4.9. For more information see #14223.

## Expected Behavior
Does not crash when reading (certain) `tsconfig.json` files with TypeScript 4.9.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14223
