### PR TITLE
docs(nxdev): deploy sequence sync

### DIFF
--- a/nx-dev/nx-dev/project.json
+++ b/nx-dev/nx-dev/project.json
@@ -90,7 +90,7 @@
           }
         ],
         "color": true,
-        "parallel": true
+        "parallel": false
       }
     },
     "export": {


### PR DESCRIPTION
It sets the deploy sequence on Vercel to be synchronous, focusing resources on one task at the time.