### PR TITLE
fix(core): fix broken lines and columns import

### DIFF
--- a/packages/nx/src/utils/json.ts
+++ b/packages/nx/src/utils/json.ts
@@ -1,6 +1,6 @@
 import { parse, printParseErrorCode, stripComments } from 'jsonc-parser';
 import type { ParseError, ParseOptions } from 'jsonc-parser';
-import LinesAndColumn from 'lines-and-columns';
+import { LinesAndColumns } from 'lines-and-columns';
 
 export { stripComments as stripJsonComments };
 
@@ -72,7 +72,7 @@ function formatParseError(
   numContextLine: number
 ) {
   const { error, offset, length } = parseError;
-  const { line, column } = new LinesAndColumn(input).locationForIndex(offset);
+  const { line, column } = new LinesAndColumns(input).locationForIndex(offset);
 
   const errorLines = [
     `${printParseErrorCode(error)} in JSON at ${line + 1}:${column + 1}`,


### PR DESCRIPTION
This fixes the issue introduced in the https://github.com/nrwl/nx/pull/14293

## Current Behavior
`Lines and columns` has an invalid import (https://www.npmjs.com/package/lines-and-columns) which is causing the docs generator to crash.

## Expected Behavior
We should use names import as per library documentation.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
