### PR TITLE
fix(core): project locator should use nodes when tsconfig is missing

### DIFF
--- a/packages/nx/src/utils/target-project-locator.spec.ts
+++ b/packages/nx/src/utils/target-project-locator.spec.ts
@@ -12,7 +12,6 @@ jest.mock('nx/src/utils/workspace-root', () => ({
 jest.mock('fs', () => require('memfs').fs);
 
 describe('findTargetProjectWithImport', () => {
-  let ctx: ProjectGraphProcessorContext;
   let projects: Record<string, ProjectGraphProjectNode>;
   let npmProjects: Record<string, ProjectGraphExternalNode>;
   let fsJson;
@@ -69,7 +68,7 @@ describe('findTargetProjectWithImport', () => {
     };
     vol.fromJSON(fsJson, '/root');
 
-    ctx = {
+    const ctx = {
       workspace: {
         ...workspaceJson,
         ...nxJson,
@@ -594,6 +593,14 @@ describe('findTargetProjectWithImport (without tsconfig.json)', () => {
     } as any;
 
     projects = {
+      '@org/proj1': {
+        name: '@org/proj1',
+        type: 'lib',
+        data: {
+          root: 'libs/proj1',
+          files: [],
+        },
+      },
       proj3a: {
         name: 'proj3a',
         type: 'lib',
@@ -771,6 +778,20 @@ describe('findTargetProjectWithImport (without tsconfig.json)', () => {
     expect(res2).toEqual('proj');
     expect(res3).toEqual('proj2');
     expect(res4).toEqual('proj');
+  });
+
+  it('should be able to resolve local project', () => {
+    const result1 = targetProjectLocator.findProjectWithImport(
+      '@org/proj1',
+      'libs/proj1/index.ts'
+    );
+    const result2 = targetProjectLocator.findProjectWithImport(
+      '@org/proj1/some/nested/path',
+      'libs/proj1/index.ts'
+    );
+
+    expect(result1).toEqual('@org/proj1');
+    expect(result2).toEqual('@org/proj1');
   });
 
   it('should be able to npm dependencies', () => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #13099
