### PR TITLE
feat(core): add prompts and requirements to nx migrations

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -123,6 +123,9 @@
     "update-angular-cli-version-14-1-0": {
       "cli": "nx",
       "version": "14.5.2-beta.0",
+      "requires": {
+        "@angular/core": ">=14.1.0"
+      },
       "description": "Update the @angular/cli package version to ~14.1.0.",
       "factory": "./src/migrations/update-14-5-2/update-angular-cli"
     },
@@ -135,6 +138,9 @@
     "update-angular-cli-version-14-2-0": {
       "cli": "nx",
       "version": "14.6.0-beta.0",
+      "requires": {
+        "@angular/core": ">=14.2.0"
+      },
       "description": "Update the @angular/cli package version to ~14.2.0.",
       "factory": "./src/migrations/update-14-6-0/update-angular-cli"
     },
@@ -159,42 +165,63 @@
     "update-angular-cli-version-15-0-0": {
       "cli": "nx",
       "version": "15.2.0-beta.0",
+      "requires": {
+        "@angular/core": ">=15.0.0"
+      },
       "description": "Update the @angular/cli package version to ~15.0.0.",
       "factory": "./src/migrations/update-15-2-0/update-angular-cli"
     },
     "remove-browserlist-config": {
       "cli": "nx",
       "version": "15.2.0-beta.0",
+      "requires": {
+        "@angular/core": ">=15.0.0"
+      },
       "description": "Remove browserlist config as it's handled by build-angular",
       "factory": "./src/migrations/update-15-2-0/remove-browserlist-config"
     },
     "update-typescript-target": {
       "cli": "nx",
       "version": "15.2.0-beta.0",
+      "requires": {
+        "@angular/core": ">=15.0.0"
+      },
       "description": "Update typescript target to ES2022",
       "factory": "./src/migrations/update-15-2-0/update-typescript-target"
     },
     "update-workspace-config": {
       "cli": "nx",
       "version": "15.2.0-beta.0",
+      "requires": {
+        "@angular/core": ">=15.0.0"
+      },
       "description": "Remove bundleDependencies from server targets",
       "factory": "./src/migrations/update-15-2-0/update-workspace-config"
     },
     "update-platform-server-exports": {
       "cli": "ng",
       "version": "15.2.0-beta.0",
+      "requires": {
+        "@angular/core": ">=15.0.0"
+      },
       "description": "Remove exported `@angular/platform-server` `renderModule` method. The `renderModule` method is now exported by the Angular CLI.",
       "factory": "./src/migrations/update-15-2-0/remove-platform-server-exports"
     },
     "update-karma-main-file": {
       "cli": "ng",
       "version": "15.2.0-beta.0",
+      "requires": {
+        "@angular/core": ">=15.0.0"
+      },
       "description": "Remove no longer needed require calls in Karma builder main file.",
       "factory": "./src/migrations/update-15-2-0/update-karma-main-file"
     },
     "update-angular-cli-version-15-1-0": {
       "cli": "nx",
       "version": "15.5.0-beta.0",
+      "requires": {
+        "@angular/core": ">=15.1.0"
+      },
       "description": "Update the @angular/cli package version to ~15.1.0.",
       "factory": "./src/migrations/update-15-5-0/update-angular-cli"
     },
@@ -1346,6 +1373,9 @@
     },
     "14.3.7": {
       "version": "14.3.7-beta.0",
+      "requires": {
+        "@angular/core": "^14.0.0"
+      },
       "packages": {
         "@ngrx/store": {
           "version": "~14.0.0",
@@ -1378,6 +1408,9 @@
     },
     "14.4.0": {
       "version": "14.4.0-beta.1",
+      "requires": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
       "packages": {
         "@angular-eslint/eslint-plugin": {
           "version": "~14.0.0",
@@ -1395,6 +1428,10 @@
     },
     "14.5.2": {
       "version": "14.5.2-beta.0",
+      "x-prompt": "Do you want to update the Angular version to v14.1?",
+      "requires": {
+        "@angular/core": ">=14.0.0 <14.1.0"
+      },
       "packages": {
         "@angular-devkit/architect": {
           "version": "~0.1401.0",
@@ -1417,7 +1454,7 @@
           "alwaysAddToPackageJson": false
         },
         "@schematics/angular": {
-          "version": "~14.0.0",
+          "version": "~14.1.0",
           "alwaysAddToPackageJson": false
         },
         "@angular/core": {
@@ -1500,13 +1537,13 @@
         }
       }
     },
-    "14.6.0": {
+    "14.6.0-angular": {
       "version": "14.6.0-beta.0",
+      "x-prompt": "Do you want to update the Angular version to v14.2?",
+      "requires": {
+        "@angular/core": ">=14.1.0 <14.2.0"
+      },
       "packages": {
-        "jest-preset-angular": {
-          "version": "~12.2.0",
-          "alwaysAddToPackageJson": false
-        },
         "@angular-devkit/architect": {
           "version": "~0.1402.0",
           "alwaysAddToPackageJson": false
@@ -1549,17 +1586,25 @@
         }
       }
     },
-    "14.8.0": {
-      "version": "14.8.0-beta.0",
+    "14.6.0-jest-preset-angular": {
+      "version": "14.6.0-beta.0",
+      "requires": {
+        "@angular-devkit/build-angular": ">=0.1102.19 <15.0.0",
+        "@angular/compiler-cli": ">=11.2.14 <15.0.0",
+        "@angular/core": ">=11.2.14 <15.0.0",
+        "@angular/platform-browser-dynamic": ">=11.2.14 <15.0.0",
+        "jest": "^28.0.0"
+      },
       "packages": {
         "jest-preset-angular": {
-          "version": "~12.2.2",
+          "version": "12.2.0",
           "alwaysAddToPackageJson": false
-        },
-        "typescript": {
-          "version": "~4.8.2",
-          "alwaysAddToPackageJson": false
-        },
+        }
+      }
+    },
+    "14.8.0-angular-eslint": {
+      "version": "14.8.0-beta.0",
+      "packages": {
         "@angular-eslint/eslint-plugin": {
           "version": "~14.0.4",
           "alwaysAddToPackageJson": false
@@ -1574,8 +1619,28 @@
         }
       }
     },
+    "14.8.0-jest-preset-angular": {
+      "version": "14.8.0-beta.0",
+      "requires": {
+        "@angular-devkit/build-angular": ">=0.1102.19 <15.0.0",
+        "@angular/compiler-cli": ">=11.2.14 <15.0.0",
+        "@angular/core": ">=11.2.14 <15.0.0",
+        "@angular/platform-browser-dynamic": ">=11.2.14 <15.0.0",
+        "jest": "^28.0.0"
+      },
+      "packages": {
+        "jest-preset-angular": {
+          "version": "12.2.2",
+          "alwaysAddToPackageJson": false
+        }
+      }
+    },
     "15.2.0": {
       "version": "15.2.0-beta.0",
+      "x-prompt": "Do you want to update the Angular version to v15?",
+      "requires": {
+        "@angular/core": "^14.0.0"
+      },
       "packages": {
         "@angular-devkit/architect": {
           "version": "~0.1500.0",
@@ -1631,8 +1696,11 @@
         }
       }
     },
-    "15.2.2": {
+    "15.2.2-angular-eslint": {
       "version": "15.2.2-beta.0",
+      "requires": {
+        "eslint": "^7.20.0 || ^8.0.0"
+      },
       "packages": {
         "@angular-eslint/eslint-plugin": {
           "version": "~15.0.0",
@@ -1645,7 +1713,19 @@
         "@angular-eslint/template-parser": {
           "version": "~15.0.0",
           "alwaysAddToPackageJson": false
-        },
+        }
+      }
+    },
+    "15.2.2-jest": {
+      "version": "15.2.2-beta.0",
+      "requires": {
+        "@angular-devkit/build-angular": ">=12.2.18 <16.0.0",
+        "@angular/compiler-cli": ">=12.2.16 <16.0.0",
+        "@angular/core": ">=12.2.16 <16.0.0",
+        "@angular/platform-browser-dynamic": ">=12.2.16 <16.0.0",
+        "jest": "^28.0.0"
+      },
+      "packages": {
         "jest-preset-angular": {
           "version": "12.2.3",
           "alwaysAddToPackageJson": false
@@ -1654,6 +1734,9 @@
     },
     "15.3.1": {
       "version": "15.3.1-beta.0",
+      "requires": {
+        "@angular/core": "^15.0.0"
+      },
       "packages": {
         "@ngrx/store": {
           "version": "~15.0.0",
@@ -1686,6 +1769,10 @@
     },
     "15.5.0": {
       "version": "15.5.0-beta.0",
+      "x-prompt": "Do you want to update the Angular version to v15.1?",
+      "requires": {
+        "@angular/core": ">=15.0.0 <15.1.0"
+      },
       "packages": {
         "@angular-devkit/architect": {
           "version": "~0.1501.0",
@@ -1731,6 +1818,9 @@
     },
     "15.5.2": {
       "version": "15.5.2-beta.0",
+      "requires": {
+        "@angular-devkit/build-angular": ">=15.0.0 <16.0.0"
+      },
       "packages": {
         "@nguniversal/builders": {
           "version": "~15.1.0",

--- a/packages/jest/migrations.json
+++ b/packages/jest/migrations.json
@@ -63,12 +63,18 @@
     "update-configs-jest-28": {
       "version": "14.6.0-beta.0",
       "cli": "nx",
+      "requires": {
+        "jest": "^28.0.0"
+      },
       "description": "Update jest configs to support jest 28 changes (https://jestjs.io/docs/upgrading-to-jest28#configuration-options)",
       "factory": "./src/migrations/update-14-6-0/update-configs-jest-28"
     },
     "update-tests-jest-28": {
       "version": "14.6.0-beta.0",
       "cli": "nx",
+      "requires": {
+        "jest": "^28.0.0"
+      },
       "description": "Update jest test files to support jest 28 changes (https://jestjs.io/docs/upgrading-to-jest28)",
       "factory": "./src/migrations/update-14-6-0/update-tests-jest-28"
     },
@@ -172,6 +178,10 @@
     },
     "14.6.0": {
       "version": "14.6.0-beta.0",
+      "x-prompt": "Do you want to update the Jest version to v28?",
+      "requires": {
+        "jest": "^27.0.0"
+      },
       "packages": {
         "jest": {
           "version": "~28.1.1",
@@ -205,11 +215,17 @@
           "version": "~28.1.1",
           "alwaysAddToPackageJson": false
         }
+      }
+    },
+    "15.0.1-beta.3": {
+      "version": "15.0.1-beta.3",
+      "requires": {
+        "jest": "^28.0.0"
       },
-      "15.0.1-beta.3": {
+      "packages": {
         "jest-environment-jsdom": {
           "version": "~28.1.1",
-          "alwaysAddToPackageJson": true
+          "addToPackageJson": "devDependencies"
         }
       }
     }

--- a/packages/jest/migrations.json
+++ b/packages/jest/migrations.json
@@ -63,18 +63,12 @@
     "update-configs-jest-28": {
       "version": "14.6.0-beta.0",
       "cli": "nx",
-      "requires": {
-        "jest": "^28.0.0"
-      },
       "description": "Update jest configs to support jest 28 changes (https://jestjs.io/docs/upgrading-to-jest28#configuration-options)",
       "factory": "./src/migrations/update-14-6-0/update-configs-jest-28"
     },
     "update-tests-jest-28": {
       "version": "14.6.0-beta.0",
       "cli": "nx",
-      "requires": {
-        "jest": "^28.0.0"
-      },
       "description": "Update jest test files to support jest 28 changes (https://jestjs.io/docs/upgrading-to-jest28)",
       "factory": "./src/migrations/update-14-6-0/update-tests-jest-28"
     },
@@ -178,10 +172,6 @@
     },
     "14.6.0": {
       "version": "14.6.0-beta.0",
-      "x-prompt": "Do you want to update the Jest version to v28?",
-      "requires": {
-        "jest": "^27.0.0"
-      },
       "packages": {
         "jest": {
           "version": "~28.1.1",
@@ -219,9 +209,6 @@
     },
     "15.0.1-beta.3": {
       "version": "15.0.1-beta.3",
-      "requires": {
-        "jest": "^28.0.0"
-      },
       "packages": {
         "jest-environment-jsdom": {
           "version": "~28.1.1",

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -92,6 +92,8 @@
   "nx-migrations": {
     "migrations": "./migrations.json",
     "packageGroup": [
+      "@nrwl/jest",
+      "@nrwl/linter",
       "@nrwl/angular",
       "@nrwl/cli",
       "@nrwl/cypress",
@@ -101,9 +103,7 @@
       "@nrwl/eslint-plugin-nx",
       "@nrwl/expo",
       "@nrwl/express",
-      "@nrwl/jest",
       "@nrwl/js",
-      "@nrwl/linter",
       "@nrwl/nest",
       "@nrwl/next",
       "@nrwl/node",

--- a/packages/nx/src/command-line/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate.spec.ts
@@ -551,6 +551,8 @@ describe('Migration', () => {
         jest
           .spyOn(enquirer, 'prompt')
           .mockReturnValue(Promise.resolve({ shouldMigrate: true }));
+        const customPromptMessage =
+          'Do you want to update the packages related to <some fwk name>?';
         const migrator = new Migrator({
           packageJson: createPackageJson({
             dependencies: { child1: '1.0.0', child2: '1.0.0', child3: '1.0.0' },
@@ -569,7 +571,7 @@ describe('Migration', () => {
                   },
                   'version2-prompt-group': {
                     version: '2.0.0',
-                    confirmationPrompt: true,
+                    confirmationPrompt: customPromptMessage,
                     packages: {
                       child2: { version: '3.0.0' },
                       child3: { version: '3.0.0' },
@@ -598,7 +600,11 @@ describe('Migration', () => {
             child3: { version: '3.0.0', addToPackageJson: false },
           },
         });
-        expect(enquirer.prompt).toHaveBeenCalled();
+        expect(enquirer.prompt).toHaveBeenCalledWith(
+          expect.arrayContaining([
+            expect.objectContaining({ message: customPromptMessage }),
+          ])
+        );
       });
 
       it('should filter out updates when prompt answer is false', async () => {
@@ -623,7 +629,8 @@ describe('Migration', () => {
                   },
                   'version2-prompt-group': {
                     version: '2.0.0',
-                    confirmationPrompt: true,
+                    confirmationPrompt:
+                      'Do you want to update the packages related to <some fwk name>?',
                     packages: {
                       child2: { version: '3.0.0' },
                       child3: { version: '3.0.0' },
@@ -675,7 +682,8 @@ describe('Migration', () => {
                   },
                   'version2-prompt-group': {
                     version: '2.0.0',
-                    confirmationPrompt: true,
+                    confirmationPrompt:
+                      'Do you want to update the packages related to <some fwk name>?',
                     packages: {
                       child2: { version: '3.0.0' },
                       child3: { version: '3.0.0' },
@@ -705,46 +713,6 @@ describe('Migration', () => {
           },
         });
         expect(enquirer.prompt).not.toHaveBeenCalled();
-      });
-
-      it('should support a custom prompt message', async () => {
-        jest
-          .spyOn(enquirer, 'prompt')
-          .mockReturnValue(Promise.resolve({ shouldMigrate: true }));
-        const customPromptMessage =
-          'Do you want to update the packages related to <some fwk name>?';
-        const migrator = new Migrator({
-          packageJson: createPackageJson({ dependencies: { child1: '1.0.0' } }),
-          versions: () => '1.0.0',
-          fetch: (p, _v) => {
-            if (p === 'mypackage') {
-              return Promise.resolve({
-                version: '2.0.0',
-                packageJsonUpdates: {
-                  'version2-prompt-group': {
-                    version: '2.0.0',
-                    confirmationPrompt: customPromptMessage,
-                    packages: { child1: { version: '3.0.0' } },
-                  },
-                },
-              });
-            } else if (p === 'child1') {
-              return Promise.resolve({ version: '3.0.0' });
-            } else {
-              return Promise.resolve(null);
-            }
-          },
-          to: {},
-          interactive: true,
-        });
-
-        await migrator.updatePackageJson('mypackage', '2.0.0');
-
-        expect(enquirer.prompt).toHaveBeenCalledWith(
-          expect.arrayContaining([
-            expect.objectContaining({ message: customPromptMessage }),
-          ])
-        );
       });
     });
   });
@@ -931,7 +899,8 @@ describe('Migration', () => {
                     child1: { version: '2.0.0' },
                     child2: { version: '3.0.0' },
                   },
-                  confirmationPrompt: true,
+                  confirmationPrompt:
+                    'Do you want to update the packages related to <some fwk name>?',
                 },
               },
               generators: {

--- a/packages/nx/src/command-line/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate.spec.ts
@@ -550,15 +550,15 @@ describe('Migration', () => {
       it('should prompt when --interactive and there is a package updates group with confirmation prompts', async () => {
         jest
           .spyOn(enquirer, 'prompt')
-          .mockReturnValue(Promise.resolve({ shouldMigrate: true }));
-        const customPromptMessage =
+          .mockReturnValue(Promise.resolve({ shouldApply: true }));
+        const promptMessage =
           'Do you want to update the packages related to <some fwk name>?';
         const migrator = new Migrator({
           packageJson: createPackageJson({
             dependencies: { child1: '1.0.0', child2: '1.0.0', child3: '1.0.0' },
           }),
           versions: () => '1.0.0',
-          fetch: (p, _v) => {
+          fetch: (p) => {
             if (p === 'mypackage') {
               return Promise.resolve({
                 version: '2.0.0',
@@ -571,7 +571,7 @@ describe('Migration', () => {
                   },
                   'version2-prompt-group': {
                     version: '2.0.0',
-                    confirmationPrompt: customPromptMessage,
+                    'x-prompt': promptMessage,
                     packages: {
                       child2: { version: '3.0.0' },
                       child3: { version: '3.0.0' },
@@ -602,7 +602,7 @@ describe('Migration', () => {
         });
         expect(enquirer.prompt).toHaveBeenCalledWith(
           expect.arrayContaining([
-            expect.objectContaining({ message: customPromptMessage }),
+            expect.objectContaining({ message: promptMessage }),
           ])
         );
       });
@@ -610,13 +610,13 @@ describe('Migration', () => {
       it('should filter out updates when prompt answer is false', async () => {
         jest
           .spyOn(enquirer, 'prompt')
-          .mockReturnValue(Promise.resolve({ shouldMigrate: false }));
+          .mockReturnValue(Promise.resolve({ shouldApply: false }));
         const migrator = new Migrator({
           packageJson: createPackageJson({
             dependencies: { child1: '1.0.0', child2: '1.0.0', child3: '1.0.0' },
           }),
           versions: () => '1.0.0',
-          fetch: (p, _v) => {
+          fetch: (p) => {
             if (p === 'mypackage') {
               return Promise.resolve({
                 version: '2.0.0',
@@ -629,7 +629,7 @@ describe('Migration', () => {
                   },
                   'version2-prompt-group': {
                     version: '2.0.0',
-                    confirmationPrompt:
+                    'x-prompt':
                       'Do you want to update the packages related to <some fwk name>?',
                     packages: {
                       child2: { version: '3.0.0' },
@@ -663,13 +663,13 @@ describe('Migration', () => {
       it('should not prompt and get all updates when --interactive=false', async () => {
         jest
           .spyOn(enquirer, 'prompt')
-          .mockReturnValue(Promise.resolve({ shouldMigrate: false }));
+          .mockReturnValue(Promise.resolve({ shouldApply: false }));
         const migrator = new Migrator({
           packageJson: createPackageJson({
             dependencies: { child1: '1.0.0', child2: '1.0.0', child3: '1.0.0' },
           }),
           versions: () => '1.0.0',
-          fetch: (p, _v) => {
+          fetch: (p) => {
             if (p === 'mypackage') {
               return Promise.resolve({
                 version: '2.0.0',
@@ -682,7 +682,7 @@ describe('Migration', () => {
                   },
                   'version2-prompt-group': {
                     version: '2.0.0',
-                    confirmationPrompt:
+                    'x-prompt':
                       'Do you want to update the packages related to <some fwk name>?',
                     packages: {
                       child2: { version: '3.0.0' },
@@ -710,6 +710,263 @@ describe('Migration', () => {
             child1: { version: '3.0.0', addToPackageJson: false },
             child2: { version: '3.0.0', addToPackageJson: false },
             child3: { version: '3.0.0', addToPackageJson: false },
+          },
+        });
+        expect(enquirer.prompt).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('requirements', () => {
+      beforeEach(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should collect updates that meet requirements and leave out those that do not meet them', async () => {
+        const migrator = new Migrator({
+          packageJson: createPackageJson({
+            dependencies: {
+              child1: '1.0.0',
+              child2: '1.0.0',
+              child3: '1.0.0',
+              child4: '1.0.0',
+              child5: '1.0.0',
+              pkg1: '1.0.0',
+              pkg2: '2.0.0',
+            },
+          }),
+          versions: (p) => (p === 'pkg2' ? '2.0.0' : '1.0.0'),
+          fetch: (p) => {
+            if (p === 'mypackage') {
+              return Promise.resolve({
+                version: '2.0.0',
+                packageJsonUpdates: {
+                  group1: {
+                    version: '2.0.0',
+                    packages: { child1: { version: '3.0.0' } },
+                    requires: {
+                      // exist on a lower version
+                      pkg1: '^2.0.0',
+                    },
+                  },
+                  group2: {
+                    version: '2.0.0',
+                    packages: {
+                      child2: { version: '3.0.0' },
+                      child3: { version: '3.0.0' },
+                    },
+                    requires: {
+                      // exists on a version satisfying the range
+                      pkg2: '^2.0.0',
+                    },
+                  },
+                  group3: {
+                    version: '2.0.0',
+                    packages: {
+                      child4: { version: '3.0.0' },
+                      child5: { version: '3.0.0' },
+                    },
+                    requires: {
+                      // non existent
+                      pkg3: '^2.0.0',
+                    },
+                  },
+                },
+              });
+            } else if (
+              ['child1', 'child2', 'child3', 'child4', 'child5'].includes(p)
+            ) {
+              return Promise.resolve({ version: '3.0.0' });
+            } else {
+              return Promise.resolve(null);
+            }
+          },
+          to: {},
+        });
+
+        const result = await migrator.updatePackageJson('mypackage', '2.0.0');
+
+        expect(result).toStrictEqual({
+          migrations: [],
+          packageJson: {
+            mypackage: { version: '2.0.0', addToPackageJson: false },
+            child2: { version: '3.0.0', addToPackageJson: false },
+            child3: { version: '3.0.0', addToPackageJson: false },
+          },
+        });
+      });
+
+      it('should meet requirements with versions set by dependent package updates in package groups', async () => {
+        const migrator = new Migrator({
+          packageJson: createPackageJson({
+            dependencies: {
+              child1: '1.0.0',
+              child2: '1.0.0',
+              child3: '1.0.0',
+              pkg1: '1.0.0',
+              pkg2: '1.0.0',
+            },
+          }),
+          versions: () => '1.0.0',
+          fetch: (p) => {
+            if (p === 'mypackage') {
+              return Promise.resolve({
+                version: '2.0.0',
+                packageJsonUpdates: {
+                  group1: {
+                    version: '2.0.0',
+                    packages: { child1: { version: '3.0.0' } },
+                  },
+                },
+                packageGroup: ['pkg1', 'pkg2'],
+              });
+            } else if (p === 'pkg1') {
+              // add a delay to showcase the dependent requirement will wait for it
+              return new Promise((resolve) => {
+                setTimeout(() => {
+                  resolve({
+                    version: '2.0.0',
+                    packageJsonUpdates: {
+                      group1: {
+                        version: '2.0.0',
+                        packages: { child2: { version: '3.0.0' } },
+                        requires: { child1: '^3.0.0' },
+                      },
+                    },
+                  });
+                }, 100);
+              });
+            } else if (p === 'pkg2') {
+              return Promise.resolve({
+                version: '2.0.0',
+                packageJsonUpdates: {
+                  group1: {
+                    version: '2.0.0',
+                    packages: { child3: { version: '3.0.0' } },
+                    // installed version doesn't satisfy the requirements, but
+                    // a package update from "pkg1" fulfills it, it waits for it
+                    // because of the packageGroup order
+                    requires: { child2: '^3.0.0' },
+                  },
+                },
+              });
+            } else if (['child1', 'child2', 'child3'].includes(p)) {
+              return Promise.resolve({ version: '3.0.0' });
+            } else {
+              return Promise.resolve(null);
+            }
+          },
+          to: {},
+        });
+
+        const result = await migrator.updatePackageJson('mypackage', '2.0.0');
+
+        expect(result).toStrictEqual({
+          migrations: [],
+          packageJson: {
+            mypackage: { version: '2.0.0', addToPackageJson: false },
+            child1: { version: '3.0.0', addToPackageJson: false },
+            child2: { version: '3.0.0', addToPackageJson: false },
+            child3: { version: '3.0.0', addToPackageJson: false },
+            pkg1: { version: '2.0.0', addToPackageJson: false },
+            pkg2: { version: '2.0.0', addToPackageJson: false },
+          },
+        });
+      });
+
+      it('should prompt when requirements are met', async () => {
+        jest
+          .spyOn(enquirer, 'prompt')
+          .mockReturnValue(Promise.resolve({ shouldApply: true }));
+        const promptMessage =
+          'Do you want to update the packages related to <some fwk name>?';
+        const migrator = new Migrator({
+          packageJson: createPackageJson({
+            dependencies: { child1: '1.0.0', pkg1: '2.0.0' },
+          }),
+          versions: (p) => (p === 'pkg1' ? '2.0.0' : '1.0.0'),
+          fetch: (p) => {
+            if (p === 'mypackage') {
+              return Promise.resolve({
+                version: '2.0.0',
+                packageJsonUpdates: {
+                  version2: {
+                    version: '2.0.0',
+                    'x-prompt': promptMessage,
+                    requires: { pkg1: '^2.0.0' },
+                    packages: {
+                      child1: { version: '3.0.0' },
+                    },
+                  },
+                },
+              });
+            } else if (p === 'child1') {
+              return Promise.resolve({ version: '3.0.0' });
+            } else {
+              return Promise.resolve(null);
+            }
+          },
+          to: {},
+          interactive: true,
+        });
+
+        const result = await migrator.updatePackageJson('mypackage', '2.0.0');
+
+        expect(result).toStrictEqual({
+          migrations: [],
+          packageJson: {
+            mypackage: { version: '2.0.0', addToPackageJson: false },
+            child1: { version: '3.0.0', addToPackageJson: false },
+          },
+        });
+        expect(enquirer.prompt).toHaveBeenCalledWith(
+          expect.arrayContaining([
+            expect.objectContaining({ message: promptMessage }),
+          ])
+        );
+      });
+
+      it('should not prompt when requirements are not met', async () => {
+        jest
+          .spyOn(enquirer, 'prompt')
+          .mockReturnValue(Promise.resolve({ shouldApply: true }));
+        const promptMessage =
+          'Do you want to update the packages related to <some fwk name>?';
+        const migrator = new Migrator({
+          packageJson: createPackageJson({
+            dependencies: { child1: '1.0.0', pkg1: '1.0.0' },
+          }),
+          versions: () => '1.0.0',
+          fetch: (p) => {
+            if (p === 'mypackage') {
+              return Promise.resolve({
+                version: '2.0.0',
+                packageJsonUpdates: {
+                  version2: {
+                    version: '2.0.0',
+                    'x-prompt': promptMessage,
+                    requires: { pkg1: '^2.0.0' },
+                    packages: {
+                      child1: { version: '3.0.0' },
+                    },
+                  },
+                },
+              });
+            } else if (p === 'child1') {
+              return Promise.resolve({ version: '3.0.0' });
+            } else {
+              return Promise.resolve(null);
+            }
+          },
+          to: {},
+          interactive: true,
+        });
+
+        const result = await migrator.updatePackageJson('mypackage', '2.0.0');
+
+        expect(result).toStrictEqual({
+          migrations: [],
+          packageJson: {
+            mypackage: { version: '2.0.0', addToPackageJson: false },
           },
         });
         expect(enquirer.prompt).not.toHaveBeenCalled();
@@ -882,13 +1139,13 @@ describe('Migration', () => {
     it('should not generate migrations for packages which confirmation prompt answer was false', async () => {
       jest
         .spyOn(enquirer, 'prompt')
-        .mockReturnValue(Promise.resolve({ shouldMigrate: false }));
+        .mockReturnValue(Promise.resolve({ shouldApply: false }));
       const migrator = new Migrator({
         packageJson: createPackageJson({
           dependencies: { child: '1.0.0', child2: '1.0.0' },
         }),
-        versions: (p) => '1.0.0',
-        fetch: (p, _v) => {
+        versions: () => '1.0.0',
+        fetch: (p) => {
           if (p === 'parent') {
             return Promise.resolve({
               version: '2.0.0',
@@ -899,7 +1156,7 @@ describe('Migration', () => {
                     child1: { version: '2.0.0' },
                     child2: { version: '3.0.0' },
                   },
-                  confirmationPrompt:
+                  'x-prompt':
                     'Do you want to update the packages related to <some fwk name>?',
                 },
               },
@@ -954,6 +1211,112 @@ describe('Migration', () => {
         },
       });
       expect(enquirer.prompt).toHaveBeenCalled();
+    });
+
+    it('should generate migrations that meet requirements and leave out those that do not meet them', async () => {
+      const migrator = new Migrator({
+        packageJson: createPackageJson({
+          dependencies: {
+            child1: '1.0.0',
+            child2: '1.0.0',
+            pkg1: '1.0.0',
+            pkg2: '2.0.0',
+            pkg3: '2.0.0',
+          },
+        }),
+        versions: (p) => (p === 'pkg2' || p === 'pkg3' ? '2.0.0' : '1.0.0'),
+        fetch: (p) => {
+          if (p === 'parent') {
+            return Promise.resolve({
+              version: '2.0.0',
+              packageJsonUpdates: {
+                version2: {
+                  version: '2.0.0',
+                  packages: {
+                    child1: { version: '2.0.0' },
+                    child2: { version: '3.0.0' },
+                  },
+                },
+              },
+              generators: {
+                migration1: {
+                  version: '2.0.0',
+                  description: 'migration1 desc',
+                  requires: {
+                    // exist on a lower version
+                    pkg1: '^2.0.0',
+                  },
+                },
+                migration2: {
+                  version: '2.0.0',
+                  description: 'migration2 desc',
+                  requires: {
+                    // exists on a version satisfying the range
+                    pkg2: '^2.0.0',
+                  },
+                },
+              },
+            });
+          } else if (p === 'child1') {
+            return Promise.resolve({
+              version: '2.0.0',
+              generators: {
+                migration1: {
+                  version: '2.0.0',
+                  description: 'child1 - migration 1 desc',
+                  requires: {
+                    // exists on a version satisfying the range
+                    pkg3: '^2.0.0',
+                  },
+                },
+              },
+            });
+          } else if (p === 'child2') {
+            return Promise.resolve({
+              version: '3.0.0',
+              generators: {
+                migration1: {
+                  version: '3.0.0',
+                  description: 'child2 - migration1 desc',
+                  requires: {
+                    // non existent
+                    pkg4: '^2.0.0',
+                  },
+                },
+              },
+            });
+          } else {
+            return Promise.resolve(null);
+          }
+        },
+        to: {},
+      });
+
+      const result = await migrator.updatePackageJson('parent', '2.0.0');
+
+      expect(result).toEqual({
+        migrations: [
+          {
+            version: '2.0.0',
+            name: 'migration2',
+            package: 'parent',
+            description: 'migration2 desc',
+            requires: { pkg2: '^2.0.0' },
+          },
+          {
+            version: '2.0.0',
+            name: 'migration1',
+            package: 'child1',
+            description: 'child1 - migration 1 desc',
+            requires: { pkg3: '^2.0.0' },
+          },
+        ],
+        packageJson: {
+          child1: { version: '2.0.0', addToPackageJson: false },
+          child2: { version: '3.0.0', addToPackageJson: false },
+          parent: { version: '2.0.0', addToPackageJson: false },
+        },
+      });
     });
   });
 

--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -296,14 +296,14 @@ export class Migrator {
     for (const packageJsonUpdate of Object.values(
       migration.packageJsonUpdates
     )) {
-      const { packages, version } = packageJsonUpdate;
+      const { confirmationPrompt, packages, version } = packageJsonUpdate;
       if (
         packages &&
         this.gt(version, this.versions(packageName)) &&
         this.lte(version, targetVersion) &&
         (!this.interactive ||
           (await this.runPackageJsonUpdatesConfirmationPrompt(
-            packageJsonUpdate
+            confirmationPrompt
           )))
       ) {
         filteredPackageJsonUpdates.push(packageJsonUpdate);
@@ -341,10 +341,9 @@ export class Migrator {
       .reduce((m, c) => ({ ...m, ...c }), {});
   }
 
-  private async runPackageJsonUpdatesConfirmationPrompt({
-    confirmationPrompt,
-    packages,
-  }: PackageJsonUpdates[number]): Promise<boolean> {
+  private async runPackageJsonUpdatesConfirmationPrompt(
+    confirmationPrompt: string
+  ): Promise<boolean> {
     if (!confirmationPrompt) {
       return Promise.resolve(true);
     }
@@ -353,16 +352,8 @@ export class Migrator {
       {
         name: 'shouldMigrate',
         type: 'confirm',
-        message:
-          typeof confirmationPrompt === 'string'
-            ? confirmationPrompt
-            : `Do you want to run the migration for the packages ${Object.entries(
-                packages
-              )
-                .map(
-                  ([packageName, { version }]) => `${packageName}@${version}`
-                )
-                .join(', ')}?`,
+        message: confirmationPrompt,
+        initial: true,
       },
     ]).then((a: { shouldMigrate: boolean }) => a.shouldMigrate);
   }

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -953,6 +953,14 @@ function withMigrationOptions(yargs: yargs.Argv) {
       type: 'string',
       default: defaultCommitPrefix,
     })
+    .option('interactive', {
+      describe:
+        'Enable prompts to confirm whether to collect migrations for packages that allow being skipped',
+      type: 'boolean',
+      default: false,
+      // TODO(leo): make it visible when we publish the docs about it
+      hidden: true,
+    })
     .check(({ createCommits, commitPrefix }) => {
       if (!createCommits && commitPrefix !== defaultCommitPrefix) {
         throw new Error(

--- a/packages/nx/src/config/misc-interfaces.ts
+++ b/packages/nx/src/config/misc-interfaces.ts
@@ -58,7 +58,7 @@ export type PackageJsonUpdates = {
     packages: {
       [packageName: string]: PackageJsonUpdateForPackage;
     };
-    confirmationPrompt?: string | boolean;
+    confirmationPrompt?: string;
   };
 };
 

--- a/packages/nx/src/config/misc-interfaces.ts
+++ b/packages/nx/src/config/misc-interfaces.ts
@@ -58,6 +58,7 @@ export type PackageJsonUpdates = {
     packages: {
       [packageName: string]: PackageJsonUpdateForPackage;
     };
+    confirmationPrompt?: string | boolean;
   };
 };
 

--- a/packages/nx/src/config/misc-interfaces.ts
+++ b/packages/nx/src/config/misc-interfaces.ts
@@ -58,7 +58,8 @@ export type PackageJsonUpdates = {
     packages: {
       [packageName: string]: PackageJsonUpdateForPackage;
     };
-    confirmationPrompt?: string;
+    'x-prompt'?: string;
+    requires?: Record<string, string>;
   };
 };
 
@@ -68,6 +69,7 @@ export interface MigrationsJsonEntry {
   cli?: string;
   implementation?: string;
   factory?: string;
+  requires?: Record<string, string>;
 }
 
 export interface MigrationsJson {

--- a/packages/nx/src/utils/params.ts
+++ b/packages/nx/src/utils/params.ts
@@ -80,7 +80,7 @@ export async function handleErrors(isVerbose: boolean, fn: Function) {
   try {
     return await fn();
   } catch (err) {
-    err ??= new Error('Unknown error caught');
+    err ||= new Error('Unknown error caught');
     if (err.constructor.name === 'UnsuccessfulWorkflowExecution') {
       logger.error('The generator workflow failed. See above.');
     } else {

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -33,6 +33,8 @@
     "requirements": {},
     "migrations": "./migrations.json",
     "packageGroup": {
+      "@nrwl/jest": "*",
+      "@nrwl/linter": "*",
       "@nrwl/angular": "*",
       "@nrwl/cli": "*",
       "@nrwl/cypress": "*",
@@ -42,9 +44,7 @@
       "@nrwl/eslint-plugin-nx": "*",
       "@nrwl/expo": "*",
       "@nrwl/express": "*",
-      "@nrwl/jest": "*",
       "@nrwl/js": "*",
-      "@nrwl/linter": "*",
       "@nrwl/nest": "*",
       "@nrwl/next": "*",
       "@nrwl/node": "*",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Nx migrations authors don't have a way to configure prompts to ask the user whether certain package updates should be applied.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The migrator tool should support migrations authors to configure prompts for package updates they want the users to decide whether to apply them or not. By default, no prompt is asked, so the existing behavior of the migrations doesn't change, but it can be enabled with the `--interactive` flag.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
