### PR TITLE
fix(linter): use ng-packager for checking secondary entry points in linter

### DIFF
--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -313,7 +313,7 @@ export default createESLintRule<Options, MessageIds>({
         if (
           !allowCircularSelfDependency &&
           !isRelativePath(imp) &&
-          !isAngularSecondaryEntrypoint(targetProjectLocator, imp)
+          !isAngularSecondaryEntrypoint(imp, sourceFilePath)
         ) {
           context.report({
             node,

--- a/packages/eslint-plugin-nx/src/utils/runtime-lint-utils.spec.ts
+++ b/packages/eslint-plugin-nx/src/utils/runtime-lint-utils.spec.ts
@@ -3,7 +3,6 @@ import {
   ProjectGraphExternalNode,
   ProjectGraphProjectNode,
 } from '@nrwl/devkit';
-import { TargetProjectLocator } from 'nx/src/utils/target-project-locator';
 import {
   DepConstraint,
   findTransitiveExternalDependencies,
@@ -343,75 +342,43 @@ describe('isAngularSecondaryEntrypoint', () => {
     };
     const fsJson = {
       'tsconfig.base.json': JSON.stringify(tsConfig),
+      'apps/app.ts': '',
       'libs/standard/package.json': '{ "version": "0.0.0" }',
       'libs/standard/secondary/ng-package.json': JSON.stringify({
         version: '0.0.0',
         ngPackage: { lib: { entryFile: 'src/index.ts' } },
       }),
+      'libs/standard/secondary/src/index.ts': 'const bla = "foo"',
       'libs/standard/tertiary/ng-package.json': JSON.stringify({
         version: '0.0.0',
         ngPackage: { lib: { entryFile: 'src/public_api.ts' } },
       }),
+      'libs/standard/tertiary/src/public_api.ts': 'const bla = "foo"',
       'libs/features/package.json': '{ "version": "0.0.0" }',
       'libs/features/secondary/ng-package.json': JSON.stringify({
         version: '0.0.0',
         ngPackage: { lib: { entryFile: 'random/folder/api.ts' } },
       }),
+      'libs/features/secondary/random/folder/api.ts': 'const bla = "foo"',
     };
     vol.fromJSON(fsJson, '/root');
   });
 
   it('should return true for secondary entrypoints', () => {
-    const targetLocator = new TargetProjectLocator(
-      {
-        standard: {
-          name: 'standard',
-          type: 'lib',
-          data: {
-            root: '/root/libs/standard',
-            files: [
-              { file: 'libs/standard/package.json', hash: 'hsh' },
-              { file: 'libs/standard/src/index.ts', hash: 'hsh' },
-              { file: 'libs/standard/secondary/ng-package.json', hash: 'hsh' },
-              { file: 'libs/standard/secondary/src/index.ts', hash: 'hsh' },
-              { file: 'libs/standard/tertiary/ng-package.json', hash: 'hsh' },
-              { file: 'libs/standard/tertiary/src/public_api.ts', hash: 'hsh' },
-            ],
-          },
-        },
-        features: {
-          name: 'features',
-          type: 'lib',
-          data: {
-            root: '/root/libs/features',
-            files: [
-              { file: 'libs/features/package.json', hash: 'hsh' },
-              { file: 'libs/features/src/index.ts', hash: 'hsh' },
-              { file: 'libs/features/secondary/ng-package.json', hash: 'hsh' },
-              {
-                file: 'libs/features/secondary/random/folder/api.ts',
-                hash: 'hsh',
-              },
-            ],
-          },
-        },
-      },
-      {}
-    );
     expect(
-      isAngularSecondaryEntrypoint(targetLocator, '@project/standard')
+      isAngularSecondaryEntrypoint('@project/standard', 'apps/app.ts')
     ).toBe(false);
     expect(
-      isAngularSecondaryEntrypoint(targetLocator, '@project/standard/secondary')
+      isAngularSecondaryEntrypoint('@project/standard/secondary', 'apps/app.ts')
     ).toBe(true);
     expect(
-      isAngularSecondaryEntrypoint(targetLocator, '@project/standard/tertiary')
+      isAngularSecondaryEntrypoint('@project/standard/tertiary', 'apps/app.ts')
     ).toBe(true);
     expect(
-      isAngularSecondaryEntrypoint(targetLocator, '@project/features')
+      isAngularSecondaryEntrypoint('@project/features', 'apps/app.ts')
     ).toBe(false);
     expect(
-      isAngularSecondaryEntrypoint(targetLocator, '@project/features/secondary')
+      isAngularSecondaryEntrypoint('@project/features/secondary', 'apps/app.ts')
     ).toBe(true);
   });
 });

--- a/packages/eslint-plugin-nx/src/utils/runtime-lint-utils.ts
+++ b/packages/eslint-plugin-nx/src/utils/runtime-lint-utils.ts
@@ -12,13 +12,16 @@ import {
   workspaceRoot,
 } from '@nrwl/devkit';
 import { getPath, pathExists } from './graph-utils';
-import { existsSync } from 'fs';
 import { readFileIfExisting } from 'nx/src/project-graph/file-utils';
 import { TargetProjectLocator } from 'nx/src/utils/target-project-locator';
 import {
   findProjectForPath,
   ProjectRootMappings,
 } from 'nx/src/project-graph/utils/find-project-for-path';
+import {
+  getRootTsConfigFileName,
+  resolveModuleByImport,
+} from 'nx/src/utils/typescript';
 
 export type Deps = { [projectName: string]: ProjectGraphDependency[] };
 type SingleSourceTagConstraint = {
@@ -415,11 +418,16 @@ export function groupImports(
  * @returns
  */
 export function isAngularSecondaryEntrypoint(
-  targetProjectLocator: TargetProjectLocator,
-  importExpr: string
+  importExpr: string,
+  filePath: string
 ): boolean {
-  const targetFiles = targetProjectLocator.findPaths(importExpr);
-  return targetFiles && targetFiles.some(fileIsSecondaryEntryPoint);
+  const resolvedModule = resolveModuleByImport(
+    importExpr,
+    filePath,
+    join(workspaceRoot, getRootTsConfigFileName())
+  );
+
+  return !!resolvedModule && fileIsSecondaryEntryPoint(resolvedModule);
 }
 
 function fileIsSecondaryEntryPoint(file: string): boolean {

--- a/packages/nx/src/utils/target-project-locator.ts
+++ b/packages/nx/src/utils/target-project-locator.ts
@@ -93,7 +93,16 @@ export class TargetProjectLocator {
           normalizedImportExpr === path.replace(/\/\*$/, ''))
     );
     if (wildcardPath) {
-      return this.paths[wildcardPath];
+      // we need to map wildcards to actual path segments
+      const keySegments = wildcardPath.split('/');
+      const importSegments = normalizedImportExpr.split('/');
+      while (keySegments.length && keySegments[0] === importSegments[0]) {
+        keySegments.shift();
+        importSegments.shift();
+      }
+      return this.paths[wildcardPath].map((path) =>
+        path.replace('*', importSegments.join('/'))
+      );
     }
     return undefined;
   }

--- a/packages/nx/src/utils/target-project-locator.ts
+++ b/packages/nx/src/utils/target-project-locator.ts
@@ -93,16 +93,7 @@ export class TargetProjectLocator {
           normalizedImportExpr === path.replace(/\/\*$/, ''))
     );
     if (wildcardPath) {
-      // we need to map wildcards to actual path segments
-      const keySegments = wildcardPath.split('/');
-      const importSegments = normalizedImportExpr.split('/');
-      while (keySegments.length && keySegments[0] === importSegments[0]) {
-        keySegments.shift();
-        importSegments.shift();
-      }
-      return this.paths[wildcardPath].map((path) =>
-        path.replace('*', importSegments.join('/'))
-      );
+      return this.paths[wildcardPath];
     }
     return undefined;
   }


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
- We ignore secondary entry points with wildcards
- We naively expect the entry point always to be `src/index.ts` or `src/public_api.ts`

## Expected Behavior
- Wildcard ts paths should be mapped upon import expression to get full file path
- We should check if the file path matches the entry file as specified in the `ng-package.json`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #13085
