### PR TITLE
fix(webpack): allow optimization to be turned off via CLI

### DIFF
--- a/packages/webpack/src/utils/with-nx.ts
+++ b/packages/webpack/src/utils/with-nx.ts
@@ -185,7 +185,10 @@ export function withNx(opts?: { skipTypeChecking?: boolean }) {
       optimization: {
         ...config.optimization,
         sideEffects: true,
-        minimize: !!options.optimization,
+        minimize:
+          typeof options.optimization === 'object'
+            ? !!options.optimization.scripts
+            : !!options.optimization,
         minimizer: [
           options.compiler !== 'swc'
             ? new TerserPlugin({


### PR DESCRIPTION
This PR fixes the optimization config so that by default Node apps are not optimized through Terser, and users can pass `--optimization` to the build command to optimize it.

## Current Behavior
Cannot turn on/off optimization through CLI.

## Expected Behavior
Can turn on/off optimization through CLI.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #12782
