### PR TITLE
chore(core): nx plugin submission nx-mesh

### DIFF
--- a/community/approved-plugins.json
+++ b/community/approved-plugins.json
@@ -393,5 +393,10 @@
     "name": "@monodon/rust",
     "description": "Adds Cargo and Rust support",
     "url": "https://github.com/cammisuli/monodon/tree/main/packages/rust"
+  },
+  {
+    "name": "nx-mesh",
+    "description": "GraphQL Mesh support for Nx",
+    "url": "https://github.com/domjtalbot/nx-mesh"
   }
 ]


### PR DESCRIPTION
# Community Plugin Submission

## nx-mesh

### Features

- Use [GraphQL Mesh](https://the-guild.dev/graphql/mesh) to combine multiple APIs into a single GraphQL API.
- Create a new Nx workspace with a GraphQL Mesh preset.
- Generate a GraphQL Mesh API Gateway
  - A standalone application for running GraphQL Mesh.
  - Choose from multiple starter templates.
- Generate a GraphQL Mesh SDK
  - Supports deploying to Vercel as a NextJS route.
  - Choose from multiple starter templates.
- Supports all GraphQL CLI commands (`build`, `dev`, `start`, `validate`)
- Use [SWC](https://swc.rs/) to compile a GraphQL Mesh SDK
- Use [`graphql-codegen`](https://the-guild.dev/graphql/codegen) to build custom SDKs from GraphQL Mesh.
- Automatically use the first available port when running `dev`, `start`, or `serve`.
- Supports NX Cypress plugin