### PR TITLE
chore(express): add deprecation message for express app generator

### DIFF
--- a/packages/express/src/generators/application/application.ts
+++ b/packages/express/src/generators/application/application.ts
@@ -60,8 +60,13 @@ server.on('error', console.error);
     toJS(tree);
   }
 }
-
+// TODO (nicholas): Remove After Nx 16
+// @deprecated Use `nx g @nrwl/node:app --framework=express instead.
 export async function applicationGenerator(tree: Tree, schema: Schema) {
+  console.warn(
+    'As of Nx 16 using `nx g @nrwl/express:app` has been deprecated! Use `nx g @nrwl/node:app --framework=express instead.'
+  );
+
   const options = normalizeOptions(tree, schema);
   const initTask = await initGenerator(tree, { ...options, skipFormat: true });
   const applicationTask = await nodeApplicationGenerator(tree, {


### PR DESCRIPTION
Express has been collapsed into the node generator.

This adds a deprecation message/warning to communicate this change


<img width="1502" alt="Screenshot 2023-01-17 at 2 20 28 PM" src="https://user-images.githubusercontent.com/338948/213014786-8340c4e8-71ba-4ffa-82f1-544138c84439.png">
