### PR TITLE
fix(node): update generated spec file to work better for standalone projects

### DIFF
--- a/packages/node/src/generators/e2e-project/e2e-project.spec.ts
+++ b/packages/node/src/generators/e2e-project/e2e-project.spec.ts
@@ -1,0 +1,41 @@
+import { Tree } from '@nrwl/devkit/';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { applicationGenerator } from '../application/application';
+import { e2eProjectGenerator } from './e2e-project';
+
+describe('e2eProjectGenerator', () => {
+  let tree: Tree;
+  beforeEach(async () => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should generate default spec for server app (integrated)', async () => {
+    await applicationGenerator(tree, {
+      name: 'api',
+      framework: 'express',
+      e2eTestRunner: 'none',
+    });
+    await e2eProjectGenerator(tree, {
+      projectType: 'server',
+      project: 'api',
+    });
+
+    expect(tree.exists(`api-e2e/src/api/api.spec.ts`)).toBeTruthy();
+  });
+
+  it('should generate default spec for server app (standalone)', async () => {
+    await applicationGenerator(tree, {
+      name: 'api',
+      framework: 'express',
+      e2eTestRunner: 'none',
+      rootProject: true,
+    });
+    await e2eProjectGenerator(tree, {
+      projectType: 'server',
+      project: 'api',
+      rootProject: true,
+    });
+
+    expect(tree.exists(`e2e/src/server/server.spec.ts`)).toBeTruthy();
+  });
+});

--- a/packages/node/src/generators/e2e-project/e2e-project.ts
+++ b/packages/node/src/generators/e2e-project/e2e-project.ts
@@ -46,7 +46,7 @@ export async function e2eProjectGenerator(host: Tree, _options: Schema) {
       options.projectRoot,
       {
         ...options,
-        ...names(options.projectName),
+        ...names(options.rootProject ? 'server' : options.project),
         offsetFromRoot: offsetFromRoot(options.projectRoot),
         tmpl: '',
       }
@@ -59,7 +59,7 @@ export async function e2eProjectGenerator(host: Tree, _options: Schema) {
       options.projectRoot,
       {
         ...options,
-        ...names(options.projectName),
+        ...names(options.rootProject ? 'server' : options.project),
         mainFile,
         offsetFromRoot: offsetFromRoot(options.projectRoot),
         tmpl: '',
@@ -116,7 +116,13 @@ function normalizeOptions(
     ? 'e2e'
     : joinPathFragments(appsDir, appDirectory);
 
-  return { ...options, projectRoot, projectName, port: options.port ?? 3000 };
+  return {
+    ...options,
+    projectRoot,
+    projectName,
+    port: options.port ?? 3000,
+    rootProject: !!options.rootProject,
+  };
 }
 
 export default e2eProjectGenerator;


### PR DESCRIPTION
This PR improves the default spec for Node server standalone projects.

## Current Behavior
Default spec is `e2e/src/e2e/e2e.spec.ts` since the name `e2e` is used for standalone projects.

## Expected Behavior
Default spec is `e2e/src/server/server.spec.ts` to make it more clear what the test is for.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
