### PR TITLE
feat(core): react standalone bundler prompt

### DIFF
--- a/docs/generated/cli/create-nx-workspace.md
+++ b/docs/generated/cli/create-nx-workspace.md
@@ -31,6 +31,12 @@ Type: `string`
 
 The name of the application when a preset with pregenerated app is selected
 
+### bundler
+
+Type: `string`
+
+Bundler to be used to build the application
+
 ### ci
 
 Type: `string`

--- a/docs/generated/packages/nx/documents/create-nx-workspace.md
+++ b/docs/generated/packages/nx/documents/create-nx-workspace.md
@@ -31,6 +31,12 @@ Type: `string`
 
 The name of the application when a preset with pregenerated app is selected
 
+### bundler
+
+Type: `string`
+
+Bundler to be used to build the application
+
 ### ci
 
 Type: `string`

--- a/docs/generated/packages/workspace/generators/preset.json
+++ b/docs/generated/packages/workspace/generators/preset.json
@@ -62,6 +62,12 @@
         "description": "The framework which the application is using",
         "type": "string",
         "enum": ["express", "koa", "fastify", "connect"]
+      },
+      "bundler": {
+        "description": "The bundler to use for building the application.",
+        "type": "string",
+        "enum": ["webpack", "vite"],
+        "default": "vite"
       }
     },
     "presets": []

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -160,6 +160,7 @@ export function runCreateWorkspace(
     ci,
     useDetectedPm = false,
     cwd = e2eCwd,
+    bundler,
   }: {
     preset: string;
     appName?: string;
@@ -171,6 +172,7 @@ export function runCreateWorkspace(
     ci?: 'azure' | 'github' | 'circleci';
     useDetectedPm?: boolean;
     cwd?: string;
+    bundler?: 'webpack' | 'vite';
   }
 ) {
   projName = name;
@@ -188,6 +190,10 @@ export function runCreateWorkspace(
   }
   if (ci) {
     command += ` --ci=${ci}`;
+  }
+
+  if (bundler) {
+    command += ` --bundler=${bundler}`;
   }
 
   if (base) {

--- a/e2e/workspace-create/src/create-nx-workspace.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace.test.ts
@@ -39,6 +39,7 @@ describe('create-nx-workspace', () => {
       appName: wsName,
       style: 'css',
       packageManager,
+      bundler: 'vite',
     });
 
     checkFilesExist('package.json');

--- a/packages/workspace/src/generators/preset/__snapshots__/preset.spec.ts.snap
+++ b/packages/workspace/src/generators/preset/__snapshots__/preset.spec.ts.snap
@@ -34,3 +34,43 @@ Array [
   "nx-welcome.component.ts",
 ]
 `;
+
+exports[`preset should create files (preset = react-standalone bundler = vite) 1`] = `
+Object {
+  "configurations": Object {
+    "development": Object {
+      "buildTarget": "proj:build:development",
+      "hmr": true,
+    },
+    "production": Object {
+      "buildTarget": "proj:build:production",
+      "hmr": false,
+    },
+  },
+  "defaultConfiguration": "development",
+  "executor": "@nrwl/vite:dev-server",
+  "options": Object {
+    "buildTarget": "proj:build",
+  },
+}
+`;
+
+exports[`preset should create files (preset = react-standalone bundler = webpack) 1`] = `
+Object {
+  "configurations": Object {
+    "development": Object {
+      "buildTarget": "proj:build:development",
+    },
+    "production": Object {
+      "buildTarget": "proj:build:production",
+      "hmr": false,
+    },
+  },
+  "defaultConfiguration": "development",
+  "executor": "@nrwl/webpack:dev-server",
+  "options": Object {
+    "buildTarget": "proj:build",
+    "hmr": true,
+  },
+}
+`;

--- a/packages/workspace/src/generators/preset/preset.spec.ts
+++ b/packages/workspace/src/generators/preset/preset.spec.ts
@@ -1,4 +1,4 @@
-import { Tree, readJson, readProjectConfiguration } from '@nrwl/devkit';
+import { Tree, readProjectConfiguration } from '@nrwl/devkit';
 import { createTreeWithEmptyV1Workspace } from '@nrwl/devkit/testing';
 import { overrideCollectionResolutionForTesting } from '@nrwl/devkit/ngcli-adapter';
 import { presetGenerator } from './preset';
@@ -113,5 +113,37 @@ describe('preset', () => {
     });
 
     expect(tree.exists('/apps/proj/src/app/App.tsx')).toBe(true);
+  });
+
+  it(`should create files (preset = ${Preset.ReactStandalone} bundler = webpack)`, async () => {
+    await presetGenerator(tree, {
+      name: 'proj',
+      preset: Preset.ReactStandalone,
+      style: 'css',
+      linter: 'eslint',
+      cli: 'nx',
+      standaloneConfig: false,
+      bundler: 'webpack',
+    });
+    expect(tree.exists('webpack.config.js')).toBe(true);
+    expect(
+      readProjectConfiguration(tree, 'proj').targets.serve
+    ).toMatchSnapshot();
+  });
+
+  it(`should create files (preset = ${Preset.ReactStandalone} bundler = vite)`, async () => {
+    await presetGenerator(tree, {
+      name: 'proj',
+      preset: Preset.ReactStandalone,
+      style: 'css',
+      linter: 'eslint',
+      cli: 'nx',
+      standaloneConfig: false,
+      bundler: 'vite',
+    });
+    expect(tree.exists('vite.config.ts')).toBe(true);
+    expect(
+      readProjectConfiguration(tree, 'proj').targets.serve
+    ).toMatchSnapshot();
   });
 });

--- a/packages/workspace/src/generators/preset/preset.ts
+++ b/packages/workspace/src/generators/preset/preset.ts
@@ -68,7 +68,7 @@ async function createPreset(tree: Tree, options: Schema) {
       linter: options.linter,
       standaloneConfig: options.standaloneConfig,
       rootProject: true,
-      bundler: 'vite',
+      bundler: options.bundler ?? 'vite',
       e2eTestRunner: 'cypress',
       unitTestRunner: 'vitest',
     });

--- a/packages/workspace/src/generators/preset/schema.d.ts
+++ b/packages/workspace/src/generators/preset/schema.d.ts
@@ -11,4 +11,5 @@ export interface Schema {
   standaloneConfig?: boolean;
   framework?: string;
   packageManager?: PackageManager;
+  bundler?: 'vite' | 'webpack';
 }

--- a/packages/workspace/src/generators/preset/schema.json
+++ b/packages/workspace/src/generators/preset/schema.json
@@ -68,6 +68,12 @@
       "description": "The framework which the application is using",
       "type": "string",
       "enum": ["express", "koa", "fastify", "connect"]
+    },
+    "bundler": {
+      "description": "The bundler to use for building the application.",
+      "type": "string",
+      "enum": ["webpack", "vite"],
+      "default": "vite"
     }
   }
 }


### PR DESCRIPTION
If user chooses react-standalone on `create-nx-workspace`, prompt them choose the bundler, too. Available options `vite` and `webpack`. Default is `vite`.
