### PR TITLE
feat(node): add docker as a build target

### DIFF
--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -5015,6 +5015,14 @@
                 "children": [],
                 "isExternal": false,
                 "disableCollapsible": false
+              },
+              {
+                "id": "setup-docker",
+                "path": "/packages/node/generators/setup-docker",
+                "name": "setup-docker",
+                "children": [],
+                "isExternal": false,
+                "disableCollapsible": false
               }
             ],
             "isExternal": false,

--- a/docs/generated/manifests/packages.json
+++ b/docs/generated/manifests/packages.json
@@ -1554,6 +1554,15 @@
         "originalFilePath": "/packages/node/src/generators/library/schema.json",
         "path": "/packages/node/generators/library",
         "type": "generator"
+      },
+      "/packages/node/generators/setup-docker": {
+        "description": "Set up Docker configuration for a project.",
+        "file": "generated/packages/node/generators/setup-docker.json",
+        "hidden": false,
+        "name": "setup-docker",
+        "originalFilePath": "/packages/node/src/generators/setup-docker/schema.json",
+        "path": "/packages/node/generators/setup-docker",
+        "type": "generator"
       }
     },
     "path": "/packages/node"

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -1531,6 +1531,15 @@
         "originalFilePath": "/packages/node/src/generators/library/schema.json",
         "path": "node/generators/library",
         "type": "generator"
+      },
+      {
+        "description": "Set up Docker configuration for a project.",
+        "file": "generated/packages/node/generators/setup-docker.json",
+        "hidden": false,
+        "name": "setup-docker",
+        "originalFilePath": "/packages/node/src/generators/setup-docker/schema.json",
+        "path": "node/generators/setup-docker",
+        "type": "generator"
       }
     ],
     "githubRoot": "https://github.com/nrwl/nx/blob/master",

--- a/docs/generated/packages/node/generators/application.json
+++ b/docs/generated/packages/node/generators/application.json
@@ -110,6 +110,10 @@
         "enum": ["jest", "none"],
         "description": "Test runner to use for end to end (e2e) tests",
         "default": "jest"
+      },
+      "docker": {
+        "type": "boolean",
+        "description": "Add a docker build target"
       }
     },
     "required": [],

--- a/docs/generated/packages/node/generators/setup-docker.json
+++ b/docs/generated/packages/node/generators/setup-docker.json
@@ -1,0 +1,36 @@
+{
+  "name": "setup-docker",
+  "factory": "./src/generators/setup-docker/setup-docker",
+  "schema": {
+    "$schema": "http://json-schema.org/schema",
+    "cli": "nx",
+    "$id": "SchematicsNxSetupDocker",
+    "title": "Nx Node Docker Options Schema",
+    "description": "Nx Node Docker Options Schema.",
+    "type": "object",
+    "properties": {
+      "projectName": {
+        "description": "The name of the project",
+        "$default": { "$source": "argv", "index": 0 },
+        "type": "string"
+      },
+      "targetName": {
+        "description": "The name of the target to create",
+        "type": "string",
+        "default": "docker-build"
+      },
+      "buildTargetName": {
+        "description": "The name of the build target",
+        "type": "string",
+        "default": "build"
+      }
+    },
+    "presets": []
+  },
+  "description": "Set up Docker configuration for a project.",
+  "hidden": false,
+  "implementation": "/packages/node/src/generators/setup-docker/setup-docker.ts",
+  "aliases": [],
+  "path": "/packages/node/src/generators/setup-docker/schema.json",
+  "type": "generator"
+}

--- a/packages/node/generators.json
+++ b/packages/node/generators.json
@@ -23,6 +23,12 @@
       "aliases": ["lib"],
       "x-type": "library",
       "description": "Create a node library."
+    },
+    "setup-docker": {
+      "factory": "./src/generators/setup-docker/setup-docker",
+      "schema": "./src/generators/setup-docker/schema.json",
+      "description": "Set up Docker configuration for a project.",
+      "hidden": false
     }
   },
   "schematics": {
@@ -46,6 +52,11 @@
       "aliases": ["lib"],
       "x-type": "library",
       "description": "Create a node library."
+    },
+    "setup-docker": {
+      "factory": "./src/generators/setup-docker/setup-docker#setupDockerGenerator",
+      "schema": "./src/generators/setup-docker/schema.json",
+      "description": "Set up Docker configuration for a project."
     }
   }
 }

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -44,6 +44,7 @@ import {
 
 import * as shared from '@nrwl/workspace/src/utils/create-ts-config';
 import { e2eProjectGenerator } from '../e2e-project/e2e-project';
+import { setupDockerGenerator } from '../setup-docker/setup-docker';
 
 export interface NormalizedSchema extends Schema {
   appProjectRoot: string;
@@ -372,6 +373,15 @@ export async function applicationGenerator(tree: Tree, schema: Schema) {
 
   if (options.frontendProject) {
     addProxy(tree, options);
+  }
+
+  if (options.docker) {
+    const dockerTask = await setupDockerGenerator(tree, {
+      ...options,
+      projectName: options.name,
+    });
+
+    tasks.push(dockerTask);
   }
 
   if (!options.skipFormat) {

--- a/packages/node/src/generators/application/schema.d.ts
+++ b/packages/node/src/generators/application/schema.d.ts
@@ -19,6 +19,7 @@ export interface Schema {
   framework?: NodeJsFrameWorks;
   port?: number;
   rootProject?: boolean;
+  docker?: boolean;
 }
 
 export type NodeJsFrameWorks =

--- a/packages/node/src/generators/application/schema.json
+++ b/packages/node/src/generators/application/schema.json
@@ -110,6 +110,10 @@
       "enum": ["jest", "none"],
       "description": "Test runner to use for end to end (e2e) tests",
       "default": "jest"
+    },
+    "docker": {
+      "type": "boolean",
+      "description": "Add a docker build target"
     }
   },
   "required": []

--- a/packages/node/src/generators/setup-docker/files/Dockerfile__tmpl__
+++ b/packages/node/src/generators/setup-docker/files/Dockerfile__tmpl__
@@ -1,0 +1,11 @@
+FROM docker.io/node:lts-alpine
+
+WORKDIR /app
+
+RUN addgroup --system <%= projectName %> && \
+          adduser --system -G <%= projectName %> <%= projectName %>
+
+COPY <%= buildLocation %> dist
+RUN chown -R <%= projectName %>:<%= projectName %> .
+
+CMD [ "node", "dist" ]

--- a/packages/node/src/generators/setup-docker/schema.d.ts
+++ b/packages/node/src/generators/setup-docker/schema.d.ts
@@ -1,0 +1,6 @@
+export interface SetUpDockerOptions {
+  projectName?: string;
+  targetName?: string;
+  buildTarget?: string;
+  skipFormat?: boolean;
+}

--- a/packages/node/src/generators/setup-docker/schema.json
+++ b/packages/node/src/generators/setup-docker/schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "$id": "SchematicsNxSetupDocker",
+  "title": "Nx Node Docker Options Schema",
+  "description": "Nx Node Docker Options Schema.",
+  "type": "object",
+  "properties": {
+    "projectName": {
+      "description": "The name of the project",
+      "$default": { "$source": "argv", "index": 0 },
+      "type": "string"
+    },
+    "targetName": {
+      "description": "The name of the target to create",
+      "type": "string",
+      "default": "docker-build"
+    },
+    "buildTargetName": {
+      "description": "The name of the build target",
+      "type": "string",
+      "default": "build"
+    }
+  }
+}

--- a/packages/node/src/generators/setup-docker/setup-docker.spec.ts
+++ b/packages/node/src/generators/setup-docker/setup-docker.spec.ts
@@ -1,0 +1,60 @@
+import { readProjectConfiguration, Tree } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { applicationGenerator } from '../application/application';
+describe('setupDockerGenerator', () => {
+  let tree: Tree;
+  beforeEach(async () => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('integrated', () => {
+    it('should create docker assets when --docker is passed', async () => {
+      await applicationGenerator(tree, {
+        name: 'api',
+        framework: 'express',
+        e2eTestRunner: 'none',
+        docker: true,
+      });
+
+      const project = readProjectConfiguration(tree, 'api');
+
+      expect(tree.exists('api/Dockerfile')).toBeTruthy();
+      expect(project.targets).toEqual(
+        expect.objectContaining({
+          'docker-build': {
+            dependsOn: ['build'],
+            executor: 'nx:run-commands',
+            options: {
+              commands: ['docker build -f api/Dockerfile .'],
+            },
+          },
+        })
+      );
+    });
+  });
+
+  describe('standalone', () => {
+    it('should create docker assets when --docker is passed', async () => {
+      await applicationGenerator(tree, {
+        name: 'api',
+        framework: 'fastify',
+        rootProject: true,
+        docker: true,
+      });
+
+      const project = readProjectConfiguration(tree, 'api');
+      expect(tree.exists('Dockerfile')).toBeTruthy();
+      expect(project.targets).toEqual(
+        expect.objectContaining({
+          'docker-build': {
+            dependsOn: ['build'],
+            executor: 'nx:run-commands',
+            options: {
+              commands: ['docker build -f Dockerfile .'],
+            },
+          },
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
## 
This adds a docker configuration to a current node project (standalone / integrated)

It should create a Dockerfile which builds an image based off the output path for your node project
Running the command
```
npx nx g @nrwl/node:app --framework=fastify api --docker
```

Should create a folder structure similar to 

<img width="463" alt="Screenshot 2023-01-19 at 2 55 28 PM" src="https://user-images.githubusercontent.com/338948/213571171-51c1e4b9-9e8e-4c8c-a1d9-d2e67e914e2c.png">

