### PR TITLE
docs(core): mention outputs defaults in project-configuration

### DIFF
--- a/docs/shared/reference/project-configuration.md
+++ b/docs/shared/reference/project-configuration.md
@@ -194,6 +194,13 @@ Targets may define outputs to tell Nx where the target is going to create file a
 
 This configuration is usually not needed. Nx comes with reasonable defaults (imported in `nx.json`) which implement the configuration above.
 
+Specifically, by default, the following locations are cached for builds:
+
+- `{workspaceRoot}/dist/{projectRoot}`,
+- `{projectRoot}/build`,
+- `{projectRoot}/dist`,
+- `{projectRoot}/public`
+
 #### Basic Example
 
 Usually, a target writes to a specific directory or a file. The following instructs Nx to cache `dist/libs/mylib` and `build/libs/mylib/main.js`:


### PR DESCRIPTION
## Current Behavior
The docs don't yet mention `outputs` default values.

## Expected Behavior

Mentioned default value for outputs: both for running from a project root and within packages. 

Note: I'm not confident in my Nx phrasing. Is this how you'd refer to the things?

## Related Issue(s)

Fixes #14472

cc @AgentEnder as requested