### PR TITLE
cleanup(angular): disable ng-add and ng-cli e2e tests temporarily

### DIFF
--- a/e2e/angular-core/src/ng-add.test.ts
+++ b/e2e/angular-core/src/ng-add.test.ts
@@ -16,7 +16,8 @@ import {
 } from '@nrwl/e2e/utils';
 import { PackageManager } from 'nx/src/utils/package-manager';
 
-describe('convert Angular CLI workspace to an Nx workspace', () => {
+// TODO(leo): temporarily disabled until a bug in the Angular CLI is solved
+xdescribe('convert Angular CLI workspace to an Nx workspace', () => {
   let project: string;
   let packageManager: PackageManager;
 

--- a/e2e/angular-core/src/ng-cli.test.ts
+++ b/e2e/angular-core/src/ng-cli.test.ts
@@ -15,7 +15,8 @@ import { removeSync } from 'fs-extra';
 
 process.env.SELECTED_CLI = 'angular';
 
-describe('using Nx executors and generators with Angular CLI', () => {
+// TODO(leo): temporarily disabled until figure out why is causing the tests to hang
+xdescribe('using Nx executors and generators with Angular CLI', () => {
   let project: string;
   let packageManager: PackageManager;
 


### PR DESCRIPTION
Temporarily disable the `ng add` e2e tests until an issue introduced by https://github.com/angular/angular-cli/commit/387472a956b71eaca89e210e64f4d75969abc9d3#diff-48c50415b0bf774d5ebd436d8e23dbbdf10ee121a24b2612d2798891e84dd53bR208 is solved.

Also temporarily disable the `ng-cli.test.ts` e2e tests until we can figure out why is hanging.