### PR TITLE
fix(react): storybook plugin fixes

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,8 +36,7 @@
     "@nrwl/workspace": "file:../workspace",
     "@phenomnomnominal/tsquery": "4.1.1",
     "chalk": "^4.1.0",
-    "minimatch": "3.0.5",
-    "semver": "7.3.4"
+    "minimatch": "3.0.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react/plugins/storybook/merge-plugins.ts
+++ b/packages/react/plugins/storybook/merge-plugins.ts
@@ -1,4 +1,8 @@
-import { RuleSetRule, WebpackPluginInstance } from 'webpack';
+import {
+  ResolvePluginInstance,
+  RuleSetRule,
+  WebpackPluginInstance,
+} from 'webpack';
 
 export const mergeRules = (...args: RuleSetRule[]) =>
   args.reduce((rules, rule) => {
@@ -14,8 +18,8 @@ export const mergeRules = (...args: RuleSetRule[]) =>
   }, [] as WebpackPluginInstance[]);
 
 export const mergePlugins = (
-  ...args: WebpackPluginInstance[]
-): WebpackPluginInstance[] =>
+  ...args: (WebpackPluginInstance | ResolvePluginInstance)[]
+): (WebpackPluginInstance | ResolvePluginInstance)[] =>
   args.reduce((plugins, plugin) => {
     if (
       plugins.some(
@@ -26,4 +30,4 @@ export const mergePlugins = (
       return plugins;
     }
     return [...plugins, plugin];
-  }, [] as WebpackPluginInstance[]);
+  }, [] as (WebpackPluginInstance | ResolvePluginInstance)[]);


### PR DESCRIPTION
Remove extra handling for `emotion` and `styled-components` for Storybook, since they are now both supported natively.

Fixes #13699
