### PR TITLE
fix(core): prevent duplicate lookups for packages when migrating

### DIFF
--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -166,6 +166,13 @@ export class Migrator {
     try {
       migrationsJson = await this.fetch(targetPackage, targetVersion);
       targetVersion = migrationsJson.version;
+      if (
+        this.collectedVersions[targetPackage] &&
+        gte(this.collectedVersions[targetPackage], targetVersion)
+      ) {
+        return {};
+      }
+
       this.collectedVersions[targetPackage] = targetVersion;
     } catch (e) {
       if (e?.message?.includes('No matching version')) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `migrate` command executes some processing and lookups multiple times for some packages that are common dependencies of several packages. Due to the concurrent nature of the lookups, the number of times a package is processed varies randomly depending on when things execute and when we run certain checks to prevent them.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `migrate` command prevents processing the same packages as much as possible by running an additional early check to determine if it has already been processed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
