### PR TITLE
chore(repo): update CI config to mitigate memory failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,15 +187,18 @@ jobs:
           no_output_timeout: 60m
           command: |
             pids=()
+
             npx nx-cloud record -- nx format:check --base=$NX_BASE --head=$NX_HEAD &
             pids+=($!)
 
-            npx nx run-many -t check-imports check-commit check-lock-files root-lint depcheck documentation --parallel=1 --no-dte &
+            (npx nx lint --no-dte &&
+            npx nx run-many -t check-imports check-commit check-lock-files depcheck documentation --parallel=1 --no-dte) &
             pids+=($!)
 
-            yarn nx affected -t test lint --base=$NX_BASE --head=$NX_HEAD --parallel=1 &
+            yarn nx affected --target=lint --base=$NX_BASE --head=$NX_HEAD --parallel=3 &
             pids+=($!)
-
+            yarn nx affected --target=test --base=$NX_BASE --head=$NX_HEAD --parallel=1 &
+            pids+=($!)
             (yarn nx affected --target=build --base=$NX_BASE --head=$NX_HEAD --parallel=3 &&
             npx nx affected --target=e2e --base=$NX_BASE --head=$NX_HEAD --exclude=e2e-storybook,e2e-storybook-angular --parallel=1) &
             pids+=($!)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "submit-plugin": "node ./scripts/submit-plugin.js",
     "prepare": "is-ci || husky install",
     "echo": "echo 123458",
-    "root-lint": "nx workspace-lint"
+    "lint": "nx workspace-lint"
   },
   "devDependencies": {
     "@angular-devkit/architect": "~0.1501.0",


### PR DESCRIPTION
This PR splits some of the `run-many` targets back to separate commands. We're noticing some 137 exit codes (OOM errors).

Also noticed that `root-lint` is not found on the root project, so running `nx run-many -t root-lint` does nothing.

The React Native and Detox e2e tests require MacOS, so removed them from Linux tests.