### PR TITLE
cleanup(angular): enable the ng-cli e2e test

### DIFF
--- a/e2e/angular-core/src/ng-cli.test.ts
+++ b/e2e/angular-core/src/ng-cli.test.ts
@@ -15,8 +15,7 @@ import { removeSync } from 'fs-extra';
 
 process.env.SELECTED_CLI = 'angular';
 
-// TODO(leo): temporarily disabled until figure out why is causing the tests to hang
-xdescribe('using Nx executors and generators with Angular CLI', () => {
+describe('using Nx executors and generators with Angular CLI', () => {
   let project: string;
   let packageManager: PackageManager;
 
@@ -35,44 +34,14 @@ xdescribe('using Nx executors and generators with Angular CLI', () => {
   });
 
   it('should convert Nx executors into Angular CLI compatible builders', () => {
-    // update package.json
-    const packageJson = readJson('package.json');
-    packageJson.description = 'some description';
-    updateFile('package.json', JSON.stringify(packageJson, null, 2));
-
-    // use vite to build a library
-    packageInstall('vite', undefined, 'latest');
-    packageInstall('@nrwl/vite');
+    packageInstall('@nrwl/angular');
     const angularJson = readJson('angular.json');
-    angularJson.projects[project].architect.build = {
-      builder: '@nrwl/vite:build',
-      options: {
-        configFile: 'vite.config.ts',
-        outputPath: 'dist',
-      },
-    };
+    angularJson.projects[project].architect.build.builder =
+      '@nrwl/angular:webpack-browser';
     updateFile('angular.json', JSON.stringify(angularJson, null, 2));
-    updateFile(
-      'vite.config.ts',
-      `
-      import { defineConfig } from 'vite';
-      export default defineConfig({
-        build: {
-          lib: {
-            entry: 'src/main.ts',
-            name: 'my-app',
-            fileName: 'main',
-            formats: ['cjs']
-          }
-        }
-      });
-    `
-    );
-    updateFile(`src/main.ts`, `console.log('Hello World');`);
 
-    runCommand(`npx ng build ${project}`);
+    runCommand(`npx ng build ${project} --configuration=development`);
 
-    checkFilesExist(`dist/main.js`);
-    expect(runCommand(`node dist/main.js`)).toMatch(/Hello World/);
+    checkFilesExist(`dist/${project}/main.js`);
   });
 });


### PR DESCRIPTION
Enables back the previously disabled `ng-cli.test.ts` e2e tests. It's updated to use an executor from the Angular plugin and avoid the additional dependency on the Vite plugin.