### PR TITLE
fix(react): typo on webpack templates with redundant parenthesis

### DIFF
--- a/packages/react/src/generators/host/files/module-federation/webpack.config.prod.js__tmpl__
+++ b/packages/react/src/generators/host/files/module-federation/webpack.config.prod.js__tmpl__
@@ -1,6 +1,6 @@
 const { composePlugins, withNx } = require('@nrwl/webpack');
 const { withReact } = require('@nrwl/react');
-const { withModuleFederation } = require('@nrwl/react/module-federation'));
+const { withModuleFederation } = require('@nrwl/react/module-federation');
 
 const baseConfig = require('./module-federation.config');
 

--- a/packages/react/src/generators/remote/files/module-federation/webpack.config.js__tmpl__
+++ b/packages/react/src/generators/remote/files/module-federation/webpack.config.js__tmpl__
@@ -1,6 +1,6 @@
 const { composePlugins, withNx } = require('@nrwl/webpack');
 const { withReact } = require('@nrwl/react');
-const { withModuleFederation } = require('@nrwl/react/module-federation'));
+const { withModuleFederation } = require('@nrwl/react/module-federation');
 
 const baseConfig = require('./module-federation.config');
 


### PR DESCRIPTION
## Current Behavior
@nrwl/react generator adds a typo on the generated react apps

## Expected Behavior
`const { withModuleFederation } = require('@nrwl/react/module-federation');
`
