### PR TITLE
fix(angular): should find the tsconfig at root of project #14379

### DIFF
--- a/packages/angular/src/builders/webpack-dev-server/webpack-dev-server.impl.ts
+++ b/packages/angular/src/builders/webpack-dev-server/webpack-dev-server.impl.ts
@@ -14,15 +14,13 @@ import type { Schema } from './schema';
 import { createTmpTsConfigForBuildableLibs } from '../utilities/buildable-libs';
 import { from } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
+import { getRootTsConfigPath } from 'nx/src/utils/typescript';
 
 export function executeWebpackDevServerBuilder(
   rawOptions: Schema,
   context: import('@angular-devkit/architect').BuilderContext
 ) {
-  process.env.NX_TSCONFIG_PATH = joinPathFragments(
-    context.workspaceRoot,
-    'tsconfig.base.json'
-  );
+  process.env.NX_TSCONFIG_PATH = getRootTsConfigPath();
 
   const options = normalizeOptions(rawOptions);
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We only set tsconfig.base.json as the tsconfig file to look for in the builder.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We only get the root tsconfig file to look for in the builder.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14379
