### PR TITLE
chore(repo): rename root lint target from "lint" to "root-lint"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,8 +191,7 @@ jobs:
             npx nx-cloud record -- nx format:check --base=$NX_BASE --head=$NX_HEAD &
             pids+=($!)
 
-            (npx nx lint --no-dte &&
-            npx nx run-many -t check-imports check-commit check-lock-files depcheck documentation --parallel=1 --no-dte) &
+            npx nx run-many -t root-lint check-imports check-commit check-lock-files depcheck documentation --parallel=1 --no-dte &
             pids+=($!)
 
             yarn nx affected --target=lint --base=$NX_BASE --head=$NX_HEAD --parallel=3 &

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "submit-plugin": "node ./scripts/submit-plugin.js",
     "prepare": "is-ci || husky install",
     "echo": "echo 123458",
-    "lint": "nx workspace-lint"
+    "root-lint": "nx workspace-lint"
   },
   "devDependencies": {
     "@angular-devkit/architect": "~0.1501.0",
@@ -322,7 +322,7 @@
       "check-lock-files",
       "depcheck",
       "documentation",
-      "lint"
+      "root-lint"
     ]
   }
 }


### PR DESCRIPTION
Rename `lint` to `root-lint` for the root project so it can be combined with other targets.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
