### PR TITLE
feat(nx-dev): display deprecated schema options last

### DIFF
--- a/nx-dev/feature-package-schema-viewer/src/lib/schema-viewer.tsx
+++ b/nx-dev/feature-package-schema-viewer/src/lib/schema-viewer.tsx
@@ -58,25 +58,28 @@ function getViewModel(
 }
 
 function extractPropertiesByImportance(properties: PropertyModel[]): {
-  required: PropertyModel[];
+  deprecated: PropertyModel[];
   important: PropertyModel[];
   internal: PropertyModel[];
+  required: PropertyModel[];
   rest: PropertyModel[];
 } {
   const result: {
-    required: PropertyModel[];
+    deprecated: PropertyModel[];
     important: PropertyModel[];
     internal: PropertyModel[];
+    required: PropertyModel[];
     rest: PropertyModel[];
   } = {
-    required: [],
+    deprecated: [],
     important: [],
     internal: [],
+    required: [],
     rest: [],
   };
   for (const property of properties) {
-    if (property.isRequired) {
-      result.required.push(property);
+    if (isPropertyDeprecated(property.initialSchema)) {
+      result.deprecated.push(property);
       continue;
     }
     if (
@@ -158,6 +161,7 @@ export function SchemaViewer({
     ...categorizedProperties.important,
     ...categorizedProperties.rest,
     ...categorizedProperties.internal,
+    ...categorizedProperties.deprecated,
   ]);
 
   const additionalProperties = new Array<JSX.Element>();


### PR DESCRIPTION
It updates the display of schema options rendering functions to show them in last position in the list, since they are should be rarely used and shown only for information.