### PR TITLE
fix(webpack): handle new https options in webpack-dev-server

### DIFF
--- a/e2e/web/src/web-webpack.test.ts
+++ b/e2e/web/src/web-webpack.test.ts
@@ -1,0 +1,23 @@
+import {
+  cleanupProject,
+  newProject,
+  runCLI,
+  runCommandUntil,
+  uniq,
+} from '@nrwl/e2e/utils';
+
+describe('Web Components Applications with bundler set as webpack', () => {
+  beforeEach(() => newProject());
+  afterEach(() => cleanupProject());
+
+  it('should support https for dev-server', async () => {
+    const appName = uniq('app');
+    runCLI(
+      `generate @nrwl/web:app ${appName} --bundler=webpack --no-interactive`
+    );
+
+    await runCommandUntil(`serve ${appName} --port=5000 --ssl`, (output) => {
+      return output.includes('listening at https://localhost:5000');
+    });
+  }, 300_000);
+});

--- a/packages/webpack/src/executors/dev-server/lib/get-dev-server-config.ts
+++ b/packages/webpack/src/executors/dev-server/lib/get-dev-server-config.ts
@@ -80,9 +80,11 @@ function getDevServerPartial(
       htmlAcceptHeaders: ['text/html', 'application/xhtml+xml'],
     },
     onListening(server: any) {
+      const isHttps =
+        server.options.https || server.options.server?.type === 'https';
       logger.info(
         `NX Web Development Server is listening at ${
-          server.options.https ? 'https' : 'http'
+          isHttps ? 'https' : 'http'
         }://${server.options.host}:${server.options.port}${buildServePath(
           buildOptions
         )}`


### PR DESCRIPTION
Support new `https` option in webpack-dev-server when logging out `started at https://localhost:<port>` message.

## Current Behavior
Nx logs out the wrong URL.

## Expected Behavior
Nx logs out correct URL.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14424
