### PR TITLE
fix(core): use require.resolve instead of randomly matching from our …

### DIFF
--- a/packages/nx/src/utils/target-project-locator.spec.ts
+++ b/packages/nx/src/utils/target-project-locator.spec.ts
@@ -781,16 +781,23 @@ describe('findTargetProjectWithImport (without tsconfig.json)', () => {
   });
 
   it('should be able to resolve local project', () => {
+    jest
+      .spyOn(targetProjectLocator as any, 'resolveImportWithRequire')
+      .mockReturnValue('libs/proj1/index.ts');
+
     const result1 = targetProjectLocator.findProjectWithImport(
       '@org/proj1',
       'libs/proj1/index.ts'
     );
+    expect(result1).toEqual('@org/proj1');
+
+    jest
+      .spyOn(targetProjectLocator as any, 'resolveImportWithRequire')
+      .mockReturnValue('libs/proj1/some/nested/file.ts');
     const result2 = targetProjectLocator.findProjectWithImport(
       '@org/proj1/some/nested/path',
       'libs/proj1/index.ts'
     );
-
-    expect(result1).toEqual('@org/proj1');
     expect(result2).toEqual('@org/proj1');
   });
 


### PR DESCRIPTION
…project graph

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

We resolve any imports which match the name of one of the projects in our project graph.

This is kind of arbitrary because this dependency would only exist in Nx and wouldn't stem from any underlying tool.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

We use `require.resolve` to resolve those dependencies. This is more valid because the dependency would exist natively in JS.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
