### PR TITLE
fix(graph): encode id in project node tooltip

### DIFF
--- a/graph/client/src/app/ui-tooltips/project-node-actions.tsx
+++ b/graph/client/src/app/ui-tooltips/project-node-actions.tsx
@@ -11,6 +11,7 @@ export function ProjectNodeActions({ id }: ProjectNodeToolTipProps) {
     projectGraphService.getSnapshot().context.tracing;
   const routeConstructor = useRouteConstructor();
   const navigate = useNavigate();
+  const encodedId = encodeURIComponent(id);
 
   function onExclude() {
     projectGraphService.send({
@@ -21,17 +22,13 @@ export function ProjectNodeActions({ id }: ProjectNodeToolTipProps) {
   }
 
   function onStartTrace() {
-    navigate(
-      routeConstructor(`/projects/trace/${encodeURIComponent(id)}`, true)
-    );
+    navigate(routeConstructor(`/projects/trace/${encodedId}`, true));
   }
 
   function onEndTrace() {
     navigate(
       routeConstructor(
-        `/projects/trace/${encodeURIComponent(start)}/${encodeURIComponent(
-          id
-        )}`,
+        `/projects/trace/${encodeURIComponent(start)}/${encodedId}`,
         true
       )
     );
@@ -39,7 +36,7 @@ export function ProjectNodeActions({ id }: ProjectNodeToolTipProps) {
 
   return (
     <div className="grid grid-cols-3 gap-4">
-      <TooltipLinkButton to={routeConstructor(`/projects/${id}`, true)}>
+      <TooltipLinkButton to={routeConstructor(`/projects/${encodedId}`, true)}>
         Focus
       </TooltipLinkButton>
       <TooltipButton onClick={onExclude}>Exclude</TooltipButton>


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
If lib has scope (eg `@example/lib`), then clicking on the focus button of graph project tooltip causes 404 error. Thats because the name of a lib (id in terms of graph) are not encoded.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Graph focuses on selected node.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
