### PR TITLE
fix(nx): fix broking workspace claim link

### DIFF
--- a/packages/nx/src/command-line/connect.ts
+++ b/packages/nx/src/command-line/connect.ts
@@ -43,7 +43,7 @@ export async function connectToNxCloudCommand(
         'Go to https://nx.app to learn more.',
         ' ',
         'If you have not done so already, please claim this workspace:',
-        `${getNxCloudUrl()}'/orgs/workspace-setup?accessToken=${getNxCloudToken()}`,
+        `${getNxCloudUrl()}/orgs/workspace-setup?accessToken=${getNxCloudToken()}`,
       ],
     });
     return false;


### PR DESCRIPTION
## Current Behavior
Nx Cloud workspace claim link is broken

## Expected Behavior
Nx Cloud workspace claim link works

## Related Issue(s)

Fixes #14535