### PR TITLE
fix(nextjs): incorrect path when serving production builds

### DIFF
--- a/packages/next/src/executors/server/server.impl.ts
+++ b/packages/next/src/executors/server/server.impl.ts
@@ -47,7 +47,10 @@ export default async function* serveExecutor(
     parseTargetString(options.buildTarget, context.projectGraph),
     context
   );
-  const root = resolve(context.root, buildOptions.root);
+  const root = resolve(
+    context.root,
+    options.dev ? buildOptions.root : buildOptions.outputPath
+  );
   const config = await prepareConfig(
     options.dev ? PHASE_DEVELOPMENT_SERVER : PHASE_PRODUCTION_SERVER,
     buildOptions,


### PR DESCRIPTION
closed #14507

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently when serving a prod build locally you will get the error similar to 
```
Error: Could not find a production build in the '/nx-bug/apps/nx-bug/.next' directory. 
```
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
With this change there should be no errors.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
