### PR TITLE
Revert "chore(storybook): re-enable storybook e2e tests"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,7 @@ jobs:
             yarn nx affected --target=test --base=$NX_BASE --head=$NX_HEAD --parallel=1 &
             pids+=($!)
             (yarn nx affected --target=build --base=$NX_BASE --head=$NX_HEAD --parallel=3 &&
-            npx nx affected --target=e2e --base=$NX_BASE --head=$NX_HEAD --parallel=1) &
+            npx nx affected --target=e2e --base=$NX_BASE --head=$NX_HEAD --exclude=e2e-storybook,e2e-storybook-angular --parallel=1) &
             pids+=($!)
 
             for pid in "${pids[@]}"; do


### PR DESCRIPTION
Reverts nrwl/nx#14549

Well, turns out the [tests were not fixed after all](https://github.com/nrwl/nx/pull/14552).

They fail on Linux on CI.