### PR TITLE
fix(devkit): splitTarget should fall back to old behavior if not passed project graph

### DIFF
--- a/packages/nx/src/utils/split-target.spec.ts
+++ b/packages/nx/src/utils/split-target.spec.ts
@@ -53,4 +53,12 @@ describe('splitTarget', () => {
       splitTarget('project:"other:other":configuration', projectGraph)
     ).toEqual(['project', 'other:other', 'configuration']);
   });
+
+  it('should targets that contain colons when not provided graph but surrounded by quotes', () => {
+    expect(splitTarget('project:"other:other":configuration')).toEqual([
+      'project',
+      'other:other',
+      'configuration',
+    ]);
+  });
 });

--- a/packages/nx/src/utils/split-target.ts
+++ b/packages/nx/src/utils/split-target.ts
@@ -3,10 +3,10 @@ import { ProjectConfiguration } from '../config/workspace-json-project-json';
 
 export function splitTarget(
   s: string,
-  projectGraph: ProjectGraph
+  projectGraph?: ProjectGraph
 ): [project: string, target?: string, configuration?: string] {
   let [project, ...segments] = splitByColons(s);
-  const validTargets = projectGraph.nodes[project]?.data?.targets;
+  const validTargets = projectGraph?.nodes?.[project]?.data?.targets;
   const validTargetNames = new Set(Object.keys(validTargets ?? {}));
 
   return [project, ...groupJointSegments(segments, validTargetNames)] as [


### PR DESCRIPTION
…sed project graph

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14555
