### PR TITLE
feat(core): hide hidden and deprecated generators from prompts

### DIFF
--- a/docs/generated/packages/workspace/generators/library.json
+++ b/docs/generated/packages/workspace/generators/library.json
@@ -114,6 +114,7 @@
   "aliases": ["lib"],
   "x-type": "library",
   "description": "Create a library.",
+  "x-deprecated": "@nrwl/workspace:library is deprecated. Consider using @nrwl/js:lib instead.",
   "implementation": "/packages/workspace/src/generators/library/library#libraryGenerator.ts",
   "hidden": false,
   "path": "/packages/workspace/src/generators/library/schema.json",

--- a/docs/generated/packages/workspace/generators/library.json
+++ b/docs/generated/packages/workspace/generators/library.json
@@ -114,7 +114,7 @@
   "aliases": ["lib"],
   "x-type": "library",
   "description": "Create a library.",
-  "x-deprecated": "@nrwl/workspace:library is deprecated. Consider using @nrwl/js:lib instead.",
+  "x-deprecated": "Use @nrwl/js:lib instead. This will be removed in Nx v16.",
   "implementation": "/packages/workspace/src/generators/library/library#libraryGenerator.ts",
   "hidden": false,
   "path": "/packages/workspace/src/generators/library/schema.json",

--- a/docs/generated/packages/workspace/generators/workspace-generator.json
+++ b/docs/generated/packages/workspace/generators/workspace-generator.json
@@ -26,7 +26,6 @@
   },
   "aliases": ["workspace-schematic"],
   "description": "Generates a workspace generator.",
-  "x-deprecated": "workspace-generators are deprecated. Consider using a local plugin instead. https://nx.dev/recipes/generators/local-generators",
   "implementation": "/packages/workspace/src/generators/workspace-generator/workspace-generator.ts",
   "hidden": false,
   "path": "/packages/workspace/src/generators/workspace-generator/schema.json",

--- a/docs/generated/packages/workspace/generators/workspace-generator.json
+++ b/docs/generated/packages/workspace/generators/workspace-generator.json
@@ -26,6 +26,7 @@
   },
   "aliases": ["workspace-schematic"],
   "description": "Generates a workspace generator.",
+  "x-deprecated": "workspace-generators are deprecated. Consider using a local plugin instead. https://nx.dev/recipes/generators/local-generators",
   "implementation": "/packages/workspace/src/generators/workspace-generator/workspace-generator.ts",
   "hidden": false,
   "path": "/packages/workspace/src/generators/workspace-generator/schema.json",

--- a/packages/nx/src/command-line/generate.ts
+++ b/packages/nx/src/command-line/generate.ts
@@ -69,8 +69,7 @@ async function promptForCollection(
       const {
         resolvedCollectionName,
         normalizedGeneratorName,
-        deprecated,
-        hidden,
+        generatorConfiguration: { ['x-deprecated']: deprecated, hidden },
       } = ws.readGenerator(collectionName, generatorName);
       if (hidden) {
         continue;
@@ -95,8 +94,7 @@ async function promptForCollection(
       const {
         resolvedCollectionName,
         normalizedGeneratorName,
-        deprecated,
-        hidden,
+        generatorConfiguration: { ['x-deprecated']: deprecated, hidden },
       } = ws.readGenerator(name, generatorName);
       if (hidden) {
         continue;
@@ -326,8 +324,7 @@ export async function generate(cwd: string, args: { [k: string]: any }) {
       normalizedGeneratorName,
       schema,
       implementationFactory,
-      aliases,
-      deprecated,
+      generatorConfiguration: { aliases, hidden, ['x-deprecated']: deprecated },
     } = ws.readGenerator(opts.collectionName, opts.generatorName);
 
     if (deprecated) {

--- a/packages/nx/src/config/misc-interfaces.ts
+++ b/packages/nx/src/config/misc-interfaces.ts
@@ -22,6 +22,7 @@ export type Generator<T = unknown> = (
 ) => void | GeneratorCallback | Promise<void | GeneratorCallback>;
 
 export interface GeneratorsJsonEntry {
+  hidden?: boolean;
   schema: string;
   implementation?: string;
   factory?: string;

--- a/packages/nx/src/config/misc-interfaces.ts
+++ b/packages/nx/src/config/misc-interfaces.ts
@@ -30,6 +30,7 @@ export interface GeneratorsJsonEntry {
   aliases?: string[];
   cli?: 'nx';
   'x-type'?: 'library' | 'application';
+  'x-deprecated'?: string;
 }
 
 export type OutputCaptureMethod = 'direct-nodejs' | 'pipe';

--- a/packages/nx/src/config/workspaces.ts
+++ b/packages/nx/src/config/workspaces.ts
@@ -185,7 +185,19 @@ export class Workspaces {
     }
   }
 
-  readGenerator(collectionName: string, generatorName: string) {
+  readGenerator(
+    collectionName: string,
+    generatorName: string
+  ): {
+    resolvedCollectionName: string;
+    normalizedGeneratorName: string;
+    schema: any;
+    implementationFactory: () => Generator<unknown>;
+    isNgCompat: boolean;
+    aliases: string[];
+    deprecated?: string;
+    hidden: boolean;
+  } {
     try {
       const {
         generatorsFilePath,
@@ -216,6 +228,8 @@ export class Workspaces {
         implementationFactory,
         isNgCompat,
         aliases: generatorConfig.aliases || [],
+        deprecated: generatorConfig['x-deprecated'],
+        hidden: generatorConfig.hidden,
       };
     } catch (e) {
       throw new Error(

--- a/packages/nx/src/config/workspaces.ts
+++ b/packages/nx/src/config/workspaces.ts
@@ -24,6 +24,7 @@ import {
   ExecutorsJson,
   Generator,
   GeneratorsJson,
+  GeneratorsJsonEntry,
   TaskGraphExecutor,
 } from './misc-interfaces';
 import { PackageJson } from '../utils/package-json';
@@ -194,9 +195,11 @@ export class Workspaces {
     schema: any;
     implementationFactory: () => Generator<unknown>;
     isNgCompat: boolean;
+    /**
+     * @deprecated(v16): This will be removed in v16, use generatorConfiguration.aliases
+     */
     aliases: string[];
-    deprecated?: string;
-    hidden: boolean;
+    generatorConfiguration: GeneratorsJsonEntry;
   } {
     try {
       const {
@@ -221,6 +224,11 @@ export class Workspaces {
         generatorConfig.implementation,
         generatorsDir
       );
+      const normalizedGeneratorConfiguration: GeneratorsJsonEntry = {
+        ...generatorConfig,
+        aliases: generatorConfig.aliases ?? [],
+        hidden: !!generatorConfig.hidden,
+      };
       return {
         resolvedCollectionName,
         normalizedGeneratorName,
@@ -228,8 +236,7 @@ export class Workspaces {
         implementationFactory,
         isNgCompat,
         aliases: generatorConfig.aliases || [],
-        deprecated: generatorConfig['x-deprecated'],
-        hidden: generatorConfig.hidden,
+        generatorConfiguration: normalizedGeneratorConfiguration,
       };
     } catch (e) {
       throw new Error(

--- a/packages/workspace/generators.json
+++ b/packages/workspace/generators.json
@@ -19,13 +19,15 @@
       "schema": "./src/generators/library/schema.json",
       "aliases": ["lib"],
       "x-type": "library",
-      "description": "Create a library."
+      "description": "Create a library.",
+      "x-deprecated": "@nrwl/workspace:library is deprecated. Consider using @nrwl/js:lib instead."
     },
     "workspace-generator": {
       "factory": "./src/generators/workspace-generator/workspace-generator",
       "schema": "./src/generators/workspace-generator/schema.json",
       "aliases": ["workspace-schematic"],
-      "description": "Generates a workspace generator."
+      "description": "Generates a workspace generator.",
+      "x-deprecated": "workspace-generators are deprecated. Consider using a local plugin instead. https://nx.dev/recipes/generators/local-generators"
     },
     "run-commands": {
       "factory": "./src/generators/run-commands/run-commands#runCommandsSchematic",
@@ -70,13 +72,15 @@
       "schema": "./src/generators/library/schema.json",
       "aliases": ["lib"],
       "x-type": "library",
-      "description": "Create a library."
+      "description": "Create a library.",
+      "x-deprecated": "@nrwl/workspace:library is deprecated. Consider using @nrwl/js:lib instead."
     },
     "workspace-generator": {
       "factory": "./src/generators/workspace-generator/workspace-generator",
       "schema": "./src/generators/workspace-generator/schema.json",
       "aliases": ["workspace-schematic"],
-      "description": "Generates a workspace generator."
+      "description": "Generates a workspace generator.",
+      "x-deprecated": "workspace-generators are deprecated. Consider using a local plugin instead. https://nx.dev/recipes/generators/local-generators"
     },
     "run-commands": {
       "factory": "./src/generators/run-commands/run-commands#runCommandsGenerator",

--- a/packages/workspace/generators.json
+++ b/packages/workspace/generators.json
@@ -20,14 +20,13 @@
       "aliases": ["lib"],
       "x-type": "library",
       "description": "Create a library.",
-      "x-deprecated": "@nrwl/workspace:library is deprecated. Consider using @nrwl/js:lib instead."
+      "x-deprecated": "Use @nrwl/js:lib instead. This will be removed in Nx v16"
     },
     "workspace-generator": {
       "factory": "./src/generators/workspace-generator/workspace-generator",
       "schema": "./src/generators/workspace-generator/schema.json",
       "aliases": ["workspace-schematic"],
-      "description": "Generates a workspace generator.",
-      "x-deprecated": "workspace-generators are deprecated. Consider using a local plugin instead. https://nx.dev/recipes/generators/local-generators"
+      "description": "Generates a workspace generator."
     },
     "run-commands": {
       "factory": "./src/generators/run-commands/run-commands#runCommandsSchematic",
@@ -73,14 +72,13 @@
       "aliases": ["lib"],
       "x-type": "library",
       "description": "Create a library.",
-      "x-deprecated": "@nrwl/workspace:library is deprecated. Consider using @nrwl/js:lib instead."
+      "x-deprecated": "Use @nrwl/js:lib instead. This will be removed in Nx v16."
     },
     "workspace-generator": {
       "factory": "./src/generators/workspace-generator/workspace-generator",
       "schema": "./src/generators/workspace-generator/schema.json",
       "aliases": ["workspace-schematic"],
-      "description": "Generates a workspace generator.",
-      "x-deprecated": "workspace-generators are deprecated. Consider using a local plugin instead. https://nx.dev/recipes/generators/local-generators"
+      "description": "Generates a workspace generator."
     },
     "run-commands": {
       "factory": "./src/generators/run-commands/run-commands#runCommandsGenerator",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Plugin authors have no way to mark existing generators as deprecated, and provide information to help folks transition to newer means.

## Expected Behavior
![image](https://user-images.githubusercontent.com/6933928/214150691-3896f2ca-5486-49c1-b714-eff6dce6bf2a.png)

![image](https://user-images.githubusercontent.com/6933928/214150757-5cb696c8-ee52-4f70-8a64-70ef7d68d083.png)


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
