### PR TITLE
Revert "fix(nextjs): incorrect path when serving production builds (#…

### DIFF
--- a/packages/next/src/executors/server/server.impl.ts
+++ b/packages/next/src/executors/server/server.impl.ts
@@ -47,10 +47,7 @@ export default async function* serveExecutor(
     parseTargetString(options.buildTarget, context.projectGraph),
     context
   );
-  const root = resolve(
-    context.root,
-    options.dev ? buildOptions.root : buildOptions.outputPath
-  );
+  const root = resolve(context.root, buildOptions.root);
   const config = await prepareConfig(
     options.dev ? PHASE_DEVELOPMENT_SERVER : PHASE_PRODUCTION_SERVER,
     buildOptions,


### PR DESCRIPTION
…14553)"

This reverts commit 578f5c03e04d946b22f53dc39d4251e8bc67debc.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

This change caused a regression.

```
~/p/nx2 (upnx15.6.0-beta.0↑4↓1|✔) [1]$ nx serve nx-dev --prod --verbose

> nx run nx-dev:serve:production

{ root: '/home/jason/projects/nx2/dist/nx-dev/nx-dev' }
Error: Could not find a production build in the '/home/jason/projects/nx2/dist/dist/nx-dev/nx-dev/.next' directory. Try building your app with 'next build' before starting the production server. https://nextjs.org/docs/messages/production-start-no-build-id
    at NextNodeServer.getBuildId (/home/jason/projects/nx2/node_modules/next/dist/server/next-server.js:171:23)
    at new Server (/home/jason/projects/nx2/node_modules/next/dist/server/base-server.js:58:29)
    at new NextNodeServer (/home/jason/projects/nx2/node_modules/next/dist/server/next-server.js:68:9)
    at NextServer.createServer (/home/jason/projects/nx2/node_modules/next/dist/server/next.js:143:16)
    at async /home/jason/projects/nx2/node_modules/next/dist/server/next.js:155:31
    at async NextServer.prepare (/home/jason/projects/nx2/node_modules/next/dist/server/next.js:130:24)

 >  NX   Could not start production server. Try building your app with `nx build nx-dev`.


Error: Could not start production server. Try building your app with `nx build nx-dev`.
    at runNextDevServer_1 (/home/jason/projects/nx2/node_modules/@nrwl/next/src/executors/server/server.impl.js:91:23)
    at runNextDevServer_1.throw (<anonymous>)
    at resume (/home/jason/projects/nx2/node_modules/tslib/tslib.js:230:48)
    at reject (/home/jason/projects/nx2/node_modules/tslib/tslib.js:233:34)

 ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 >  NX   Running target serve for project nx-dev failed

   Failed tasks:
   
   - nx-dev:serve:production
   
   Hint: run the command with --verbose for more details.

   View structured, searchable error logs at https://staging.nx.app/runs/172Mf8Jp4e


```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The behavior will return to the way it was before.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
