### PR TITLE
feat(expo): add option for skipPackageJson for expo generators

### DIFF
--- a/docs/generated/packages/expo/generators/application.json
+++ b/docs/generated/packages/expo/generators/application.json
@@ -77,6 +77,11 @@
         "type": "boolean",
         "default": true,
         "x-deprecated": "Nx only supports standaloneConfig"
+      },
+      "skipPackageJson": {
+        "type": "boolean",
+        "description": "Do not add dependencies to `package.json`.",
+        "default": false
       }
     },
     "required": ["name"],

--- a/docs/generated/packages/expo/generators/init.json
+++ b/docs/generated/packages/expo/generators/init.json
@@ -25,6 +25,11 @@
         "type": "string",
         "enum": ["detox", "none"],
         "default": "detox"
+      },
+      "skipPackageJson": {
+        "type": "boolean",
+        "description": "Do not add dependencies to `package.json`.",
+        "default": false
       }
     },
     "required": [],

--- a/docs/generated/packages/expo/generators/library.json
+++ b/docs/generated/packages/expo/generators/library.json
@@ -88,6 +88,11 @@
         "type": "boolean",
         "description": "Whether or not to configure the ESLint \"parserOptions.project\" option. We do not do this by default for lint performance reasons.",
         "default": false
+      },
+      "skipPackageJson": {
+        "type": "boolean",
+        "description": "Do not add dependencies to `package.json`.",
+        "default": false
       }
     },
     "required": ["name"],

--- a/packages/expo/src/generators/application/schema.d.ts
+++ b/packages/expo/src/generators/application/schema.d.ts
@@ -15,4 +15,5 @@ export interface Schema {
   setParserOptionsProject?: boolean; // default is false
   e2eTestRunner: 'detox' | 'none'; // default is detox
   standaloneConfig?: boolean;
+  skipPackageJson?: boolean; // default is false
 }

--- a/packages/expo/src/generators/application/schema.json
+++ b/packages/expo/src/generators/application/schema.json
@@ -77,6 +77,11 @@
       "type": "boolean",
       "default": true,
       "x-deprecated": "Nx only supports standaloneConfig"
+    },
+    "skipPackageJson": {
+      "type": "boolean",
+      "description": "Do not add dependencies to `package.json`.",
+      "default": false
     }
   },
   "required": ["name"]

--- a/packages/expo/src/generators/init/init.ts
+++ b/packages/expo/src/generators/init/init.ts
@@ -42,7 +42,12 @@ export async function expoInitGenerator(host: Tree, schema: Schema) {
   addGitIgnoreEntry(host);
   initRootBabelConfig(host);
 
-  const tasks = [moveDependency(host), updateDependencies(host)];
+  const tasks = [];
+
+  if (!schema.skipPackageJson) {
+    tasks.push(moveDependency(host));
+    tasks.push(updateDependencies(host));
+  }
 
   if (!schema.unitTestRunner || schema.unitTestRunner === 'jest') {
     const jestTask = jestInitGenerator(host, {});

--- a/packages/expo/src/generators/init/schema.d.ts
+++ b/packages/expo/src/generators/init/schema.d.ts
@@ -2,4 +2,5 @@ export interface Schema {
   unitTestRunner?: 'jest' | 'none';
   skipFormat?: boolean;
   e2eTestRunner?: 'detox' | 'none';
+  skipPackageJson?: boolean; // default is false
 }

--- a/packages/expo/src/generators/init/schema.json
+++ b/packages/expo/src/generators/init/schema.json
@@ -22,6 +22,11 @@
       "type": "string",
       "enum": ["detox", "none"],
       "default": "detox"
+    },
+    "skipPackageJson": {
+      "type": "boolean",
+      "description": "Do not add dependencies to `package.json`.",
+      "default": false
     }
   },
   "required": []

--- a/packages/expo/src/generators/library/schema.d.ts
+++ b/packages/expo/src/generators/library/schema.d.ts
@@ -18,4 +18,5 @@ export interface Schema {
   js: boolean; // default is false
   strict: boolean; // default is true
   setParserOptionsProject?: boolean;
+  skipPackageJson?: boolean; // default is false
 }

--- a/packages/expo/src/generators/library/schema.json
+++ b/packages/expo/src/generators/library/schema.json
@@ -88,6 +88,11 @@
       "type": "boolean",
       "description": "Whether or not to configure the ESLint \"parserOptions.project\" option. We do not do this by default for lint performance reasons.",
       "default": false
+    },
+    "skipPackageJson": {
+      "type": "boolean",
+      "description": "Do not add dependencies to `package.json`.",
+      "default": false
     }
   },
   "required": ["name"]


### PR DESCRIPTION
## Current Behavior
When using expo generator to create a library, it modifies npm dependencies

## Expected Behavior
Have an option to skip modifications to package.json when adding an expo library
