### PR TITLE
fix(vite): proper path for main.tsx for standalone

### DIFF
--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -372,12 +372,15 @@ export function moveAndEditIndexHtml(
   let indexHtmlPath =
     projectConfig.targets[buildTarget].options?.index ??
     `${projectConfig.root}/src/index.html`;
-  const mainPath = (
+  let mainPath =
     projectConfig.targets[buildTarget].options?.main ??
     `${projectConfig.root}/src/main.ts${
       options.uiFramework === 'react' ? 'x' : ''
-    }`
-  ).replace(projectConfig.root, '');
+    }`;
+
+  if (projectConfig.root !== '.') {
+    mainPath = mainPath.replace(projectConfig.root, '');
+  }
 
   if (
     !tree.exists(indexHtmlPath) &&


### PR DESCRIPTION
When converting Standalone Project to `vite`, the project root path is `.`, so when replacing it in the `index.html` it would end up with `maintsx` instead of `main.tsx`