### PR TITLE
fix(storybook): @nrwl/react plugin for storybook `sourceMap` should set a boolean

### DIFF
--- a/packages/react/plugins/storybook/index.ts
+++ b/packages/react/plugins/storybook/index.ts
@@ -85,12 +85,7 @@ export const webpack = async (
     projectRoot: '',
     sourceRoot: '',
     fileReplacements: [],
-    sourceMap: {
-      hidden: false,
-      scripts: true,
-      styles: true,
-      vendors: false,
-    },
+    sourceMap: true,
     styles: options.styles ?? [],
     optimization: {},
     tsConfig: tsconfigPath,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When attempting to run `nx run [project]:storybook`

```
ValidationError: Invalid options object. Sass Loader has been initialized using an options object that does not match the API schema.
 - options.sourceMap should be a boolean.
   -> Enables/Disables generation of source maps.
   -> Read more at https://github.com/webpack-contrib/sass-loader#sourcemap
    at validate (~/node_modules/schema-utils/dist/validate.js:105:11)
    at Object.getOptions (~/node_modules/webpack/lib/NormalModule.js:585:19)
    at Object.loader (~/node_modules/sass-loader/dist/index.js:27:24)
    at processResult (~/node_modules/webpack/lib/NormalModule.js:758:19)
    at ~/node_modules/webpack/lib/NormalModule.js:860:5
    at ~/node_modules/loader-runner/lib/LoaderRunner.js:399:11
    at ~/node_modules/loader-runner/lib/LoaderRunner.js:251:18
```

Last known working version (without PR changes):

```
  "devDependencies": {
    "@nrwl/storybook": "15.4.5", 
    "@storybook/addon-a11y": "~6.5.15",
    "@storybook/addon-essentials": "6.5.15",
    "@storybook/builder-webpack5": "6.5.15",
    "@storybook/core-server": "6.5.15",
    "@storybook/manager-webpack5": "6.5.15",
    "@storybook/react": "6.5.15",
  }
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Storybook should work using the plugin provided by `@nx/react`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

<!-- Fixes # -->
This removes the functionality provided by using this value as an object (although I'm not sure how that functionality was implemented) - mainly because my priority is to unblock my upgrade of nx. If you require a ticket to identify that this needs to be reverted back to an object, let me know. However, I set it as such to follow the guidelines provided by @nrwl/storybook.

