### PR TITLE
feat(core): migrate command can succeed if no migrations.json using flag --if-exists

### DIFF
--- a/docs/generated/cli/migrate.md
+++ b/docs/generated/cli/migrate.md
@@ -3,7 +3,7 @@ title: 'migrate - CLI command'
 description:
   'Creates a migrations file or runs migrations from the migrations file.
   - Migrate packages and create migrations.json (e.g., nx migrate @nrwl/workspace@latest)
-  - Run migrations (e.g., nx migrate --run-migrations=migrations.json)'
+  - Run migrations (e.g., nx migrate --run-migrations=migrations.json). Use flag --if-exists to run migrations only if the migrations file exists.'
 ---
 
 # migrate
@@ -11,7 +11,7 @@ description:
 Creates a migrations file or runs migrations from the migrations file.
 
 - Migrate packages and create migrations.json (e.g., nx migrate @nrwl/workspace@latest)
-- Run migrations (e.g., nx migrate --run-migrations=migrations.json)
+- Run migrations (e.g., nx migrate --run-migrations=migrations.json). Use flag --if-exists to run migrations only if the migrations file exists.
 
 ## Usage
 

--- a/docs/generated/cli/migrate.md
+++ b/docs/generated/cli/migrate.md
@@ -101,6 +101,14 @@ Type: `boolean`
 
 Show help
 
+### ifExists
+
+Type: `boolean`
+
+Default: `false`
+
+Run migrations only if the migrations file exists, if not continues successfully
+
 ### interactive
 
 Type: `boolean`

--- a/docs/generated/packages/nx/documents/migrate.md
+++ b/docs/generated/packages/nx/documents/migrate.md
@@ -3,7 +3,7 @@ title: 'migrate - CLI command'
 description:
   'Creates a migrations file or runs migrations from the migrations file.
   - Migrate packages and create migrations.json (e.g., nx migrate @nrwl/workspace@latest)
-  - Run migrations (e.g., nx migrate --run-migrations=migrations.json)'
+  - Run migrations (e.g., nx migrate --run-migrations=migrations.json). Use flag --if-exists to run migrations only if the migrations file exists.'
 ---
 
 # migrate
@@ -11,7 +11,7 @@ description:
 Creates a migrations file or runs migrations from the migrations file.
 
 - Migrate packages and create migrations.json (e.g., nx migrate @nrwl/workspace@latest)
-- Run migrations (e.g., nx migrate --run-migrations=migrations.json)
+- Run migrations (e.g., nx migrate --run-migrations=migrations.json). Use flag --if-exists to run migrations only if the migrations file exists.
 
 ## Usage
 

--- a/docs/generated/packages/nx/documents/migrate.md
+++ b/docs/generated/packages/nx/documents/migrate.md
@@ -101,6 +101,14 @@ Type: `boolean`
 
 Show help
 
+### ifExists
+
+Type: `boolean`
+
+Default: `false`
+
+Run migrations only if the migrations file exists, if not continues successfully
+
 ### interactive
 
 Type: `boolean`

--- a/e2e/nx-misc/src/misc.test.ts
+++ b/e2e/nx-misc/src/misc.test.ts
@@ -548,7 +548,7 @@ describe('migrate', () => {
     });
 
     expect(output).toContain(
-      `Error: File 'migrations.json' doesn't exist, can't run migrations. Use flag --if-present to run migrations only if the file exists`
+      `File 'migrations.json' doesn't exist, can't run migrations. Use flag --if-exists to run migrations only if the file exists`
     );
   });
 

--- a/e2e/nx-misc/src/misc.test.ts
+++ b/e2e/nx-misc/src/misc.test.ts
@@ -6,6 +6,7 @@ import {
   newProject,
   readFile,
   readJson,
+  removeFile,
   runCLI,
   runCLIAsync,
   runCommand,
@@ -531,5 +532,39 @@ describe('migrate', () => {
     expect(output).toContain(
       `Error: Providing a custom commit prefix requires --create-commits to be enabled`
     );
+  });
+
+  it('should fail if no migrations are present', () => {
+    removeFile(`./node_modules/migrate-parent-package/migrations.json`);
+
+    // Invalid: runs migrations with a custom commit-prefix but without enabling --create-commits
+    const output = runCLI(`migrate --run-migrations`, {
+      env: {
+        ...process.env,
+        NX_MIGRATE_SKIP_INSTALL: 'true',
+        NX_MIGRATE_USE_LOCAL: 'true',
+      },
+      silenceError: true,
+    });
+
+    expect(output).toContain(
+      `Error: File 'migrations.json' doesn't exist, can't run migrations. Use flag --if-present to run migrations only if the file exists`
+    );
+  });
+
+  it('should not run migrations if no migrations are present and flag --if-exists is used', () => {
+    removeFile(`./node_modules/migrate-parent-package/migrations.json`);
+
+    // Invalid: runs migrations with a custom commit-prefix but without enabling --create-commits
+    const output = runCLI(`migrate --run-migrations --if-exists`, {
+      env: {
+        ...process.env,
+        NX_MIGRATE_SKIP_INSTALL: 'true',
+        NX_MIGRATE_USE_LOCAL: 'true',
+      },
+      silenceError: true,
+    });
+
+    expect(output).toContain(`Migrations file 'migrations.json' doesn't exist`);
   });
 });

--- a/e2e/nx-misc/src/misc.test.ts
+++ b/e2e/nx-misc/src/misc.test.ts
@@ -535,7 +535,7 @@ describe('migrate', () => {
   });
 
   it('should fail if no migrations are present', () => {
-    removeFile(`./node_modules/migrate-parent-package/migrations.json`);
+    removeFile(`./migrations.json`);
 
     // Invalid: runs migrations with a custom commit-prefix but without enabling --create-commits
     const output = runCLI(`migrate --run-migrations`, {
@@ -553,7 +553,7 @@ describe('migrate', () => {
   });
 
   it('should not run migrations if no migrations are present and flag --if-exists is used', () => {
-    removeFile(`./node_modules/migrate-parent-package/migrations.json`);
+    removeFile(`./migrations.json`);
 
     // Invalid: runs migrations with a custom commit-prefix but without enabling --create-commits
     const output = runCLI(`migrate --run-migrations --if-exists`, {

--- a/packages/nx/src/command-line/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate.spec.ts
@@ -1387,7 +1387,7 @@ describe('Migration', () => {
   });
 
   describe('parseMigrationsOptions', () => {
-    it('should work', () => {
+    it('should work for generating migrations', () => {
       const r = parseMigrationsOptions({
         packageAndVersion: '8.12.0',
         from: '@myscope/a@12.3,@myscope/b@1.1.1',
@@ -1404,6 +1404,18 @@ describe('Migration', () => {
         to: {
           '@myscope/c': '12.3.1',
         },
+      });
+    });
+
+    it('should work for running migrations', () => {
+      const r = parseMigrationsOptions({
+        runMigrations: '',
+        ifExists: '',
+      });
+      expect(r).toEqual({
+        type: 'runMigrations',
+        runMigrations: 'migrations.json',
+        ifExists: true,
       });
     });
 

--- a/packages/nx/src/command-line/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate.spec.ts
@@ -1410,7 +1410,7 @@ describe('Migration', () => {
     it('should work for running migrations', () => {
       const r = parseMigrationsOptions({
         runMigrations: '',
-        ifExists: '',
+        ifExists: true,
       });
       expect(r).toEqual({
         type: 'runMigrations',

--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -641,7 +641,7 @@ export function parseMigrationsOptions(options: {
     return {
       type: 'runMigrations',
       runMigrations: options.runMigrations as string,
-      ifExists: options.ifExists === '',
+      ifExists: options.ifExists as boolean,
     };
   }
 }

--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -23,6 +23,7 @@ import { NxJsonConfiguration } from '../config/nx-json';
 import { flushChanges, FsTree, printChanges } from '../generators/tree';
 import {
   extractFileFromTarball,
+  fileExists,
   JsonReadOptions,
   readJsonFile,
   writeJsonFile,
@@ -606,7 +607,11 @@ type GenerateMigrations = {
   interactive?: boolean;
 };
 
-type RunMigrations = { type: 'runMigrations'; runMigrations: string };
+type RunMigrations = {
+  type: 'runMigrations';
+  runMigrations: string;
+  ifExists: boolean;
+};
 
 export function parseMigrationsOptions(options: {
   [k: string]: any;
@@ -636,6 +641,7 @@ export function parseMigrationsOptions(options: {
     return {
       type: 'runMigrations',
       runMigrations: options.runMigrations as string,
+      ifExists: options.ifExists === '',
     };
   }
 }
@@ -1249,13 +1255,26 @@ export async function executeMigrations(
 
 async function runMigrations(
   root: string,
-  opts: { runMigrations: string },
+  opts: { runMigrations: string; ifExists: boolean },
   isVerbose: boolean,
   shouldCreateCommits = false,
   commitPrefix: string
 ) {
   if (!process.env.NX_MIGRATE_SKIP_INSTALL) {
     runInstall();
+  }
+
+  const migrationsExists: boolean = fileExists(opts.runMigrations);
+
+  if (opts.ifExists && !migrationsExists) {
+    output.log({
+      title: `Migrations file '${opts.runMigrations}' doesn't exist`,
+    });
+    return;
+  } else if (!opts.ifExists && !migrationsExists) {
+    throw new Error(
+      `File '${opts.runMigrations}' doesn't exist, can't run migrations. Use flag --if-present to run migrations only if the file exists`
+    );
   }
 
   output.log({

--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -1273,7 +1273,7 @@ async function runMigrations(
     return;
   } else if (!opts.ifExists && !migrationsExists) {
     throw new Error(
-      `File '${opts.runMigrations}' doesn't exist, can't run migrations. Use flag --if-present to run migrations only if the file exists`
+      `File '${opts.runMigrations}' doesn't exist, can't run migrations. Use flag --if-exists to run migrations only if the file exists`
     );
   }
 

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -282,7 +282,7 @@ export const commandsObject = yargs
     command: 'migrate [packageAndVersion]',
     describe: `Creates a migrations file or runs migrations from the migrations file.
   - Migrate packages and create migrations.json (e.g., nx migrate @nrwl/workspace@latest)
-  - Run migrations (e.g., nx migrate --run-migrations=migrations.json). Use flag --if-present to run migrations only if the migrations file exists.`,
+  - Run migrations (e.g., nx migrate --run-migrations=migrations.json). Use flag --if-exists to run migrations only if the migrations file exists.`,
     builder: (yargs) =>
       linkToNxDevAndExamples(withMigrationOptions(yargs), 'migrate'),
     handler: () => {

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -944,6 +944,11 @@ function withMigrationOptions(yargs: yargs.Argv) {
       describe: `Execute migrations from a file (when the file isn't provided, execute migrations from migrations.json)`,
       type: 'string',
     })
+    .option('ifExists', {
+      describe: `Run migrations only if the migrations file exists, if not continues successfully`,
+      type: 'boolean',
+      default: false,
+    })
     .option('from', {
       describe:
         'Use the provided versions for packages instead of the ones installed in node_modules (e.g., --from="@nrwl/react@12.0.0,@nrwl/js@12.0.0")',

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -282,7 +282,7 @@ export const commandsObject = yargs
     command: 'migrate [packageAndVersion]',
     describe: `Creates a migrations file or runs migrations from the migrations file.
   - Migrate packages and create migrations.json (e.g., nx migrate @nrwl/workspace@latest)
-  - Run migrations (e.g., nx migrate --run-migrations=migrations.json)`,
+  - Run migrations (e.g., nx migrate --run-migrations=migrations.json). Use flag --if-present to run migrations only if the migrations file exists.`,
     builder: (yargs) =>
       linkToNxDevAndExamples(withMigrationOptions(yargs), 'migrate'),
     handler: () => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Running `nx migrate --run-migrations` fails if `migrations.json` does not exist. This is not suitable for CI environment as Renovate

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

With a new flag `--if-present`, the command can succeed if the file doesn't exist.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14131