### PR TITLE
fix(vite): delete webpack config when converting

### DIFF
--- a/packages/vite/src/generators/configuration/configuration.ts
+++ b/packages/vite/src/generators/configuration/configuration.ts
@@ -18,6 +18,7 @@ import {
   UserProvidedTargetName,
   TargetFlags,
   addPreviewTarget,
+  deleteWebpackConfig,
 } from '../../utils/generator-utils';
 
 import initGenerator from '../init/init';
@@ -27,7 +28,7 @@ import { Schema } from './schema';
 export async function viteConfigurationGenerator(tree: Tree, schema: Schema) {
   const tasks: GeneratorCallback[] = [];
 
-  const { targets, projectType } = readProjectConfiguration(
+  const { targets, projectType, root } = readProjectConfiguration(
     tree,
     schema.project
   );
@@ -134,6 +135,13 @@ export async function viteConfigurationGenerator(tree: Tree, schema: Schema) {
     if (projectType === 'application') {
       moveAndEditIndexHtml(tree, schema, buildTargetName);
     }
+
+    deleteWebpackConfig(
+      tree,
+      root,
+      targets[buildTargetName]?.options?.webpackConfig
+    );
+
     editTsConfig(tree, schema);
   }
 

--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -362,6 +362,24 @@ export function editTsConfig(tree: Tree, options: Schema) {
   writeJson(tree, `${projectConfig.root}/tsconfig.json`, config);
 }
 
+export function deleteWebpackConfig(
+  tree: Tree,
+  projectRoot: string,
+  webpackConfigFilePath?: string
+) {
+  const webpackConfigPath =
+    webpackConfigFilePath && tree.exists(webpackConfigFilePath)
+      ? webpackConfigFilePath
+      : tree.exists(`${projectRoot}/webpack.config.js`)
+      ? `${projectRoot}/webpack.config.js`
+      : tree.exists(`${projectRoot}/webpack.config.ts`)
+      ? `${projectRoot}/webpack.config.ts`
+      : null;
+  if (webpackConfigPath) {
+    tree.delete(webpackConfigPath);
+  }
+}
+
 export function moveAndEditIndexHtml(
   tree: Tree,
   options: Schema,


### PR DESCRIPTION
If webpack config file exists, delete it after converting to vite.