### PR TITLE
feat(angular): add index html transformer for builder #13368

### DIFF
--- a/docs/generated/packages/angular/executors/webpack-browser.json
+++ b/docs/generated/packages/angular/executors/webpack-browser.json
@@ -554,6 +554,10 @@
         "x-priority": "important",
         "additionalProperties": false
       },
+      "indexFileTransformer": {
+        "description": "Path to transformer function to transform the index.html",
+        "type": "string"
+      },
       "buildLibsFromSource": {
         "type": "boolean",
         "description": "Read buildable libraries from source instead of building them separately.",

--- a/packages/angular/src/builders/utilities/webpack.ts
+++ b/packages/angular/src/builders/utilities/webpack.ts
@@ -36,6 +36,19 @@ export function resolveCustomWebpackConfig(path: string, tsConfig: string) {
   return customWebpackConfig.default ?? customWebpackConfig;
 }
 
+export function resolveIndexHtmlTransformer(
+  path: string,
+  tsConfig: string,
+  target: import('@angular-devkit/architect').Target
+) {
+  tsNodeRegister(path, tsConfig);
+
+  const indexTransformer = require(path);
+  const transform = indexTransformer.default ?? indexTransformer;
+
+  return (indexHtml) => transform(target, indexHtml);
+}
+
 function tsNodeRegister(file: string, tsConfig?: string) {
   if (!file?.endsWith('.ts')) return;
   // Register TS compiler lazily

--- a/packages/angular/src/builders/webpack-browser/schema.json
+++ b/packages/angular/src/builders/webpack-browser/schema.json
@@ -458,6 +458,10 @@
       "x-priority": "important",
       "additionalProperties": false
     },
+    "indexFileTransformer": {
+      "description": "Path to transformer function to transform the index.html",
+      "type": "string"
+    },
     "buildLibsFromSource": {
       "type": "boolean",
       "description": "Read buildable libraries from source instead of building them separately.",


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
Third party builders allow for the index.html to be transformed which can be useful for post build additions such as web components etc.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Support index HTML transformer

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #13368
