### PR TITLE
fix(nextjs): custom server root points to output path for production builds

### DIFF
--- a/packages/next/src/executors/server/server.impl.ts
+++ b/packages/next/src/executors/server/server.impl.ts
@@ -57,7 +57,11 @@ export default async function* serveExecutor(
   );
 
   if (options.customServerTarget) {
-    yield* runCustomServer(root, config, options, buildOptions, context);
+    // Custom Server and Nx Dev Server roots are handled differently
+    const customRoot = options.dev
+      ? root
+      : resolve(context.root, buildOptions.outputPath);
+    yield* runCustomServer(customRoot, config, options, buildOptions, context);
   } else {
     yield* runNextDevServer(root, config, options, buildOptions, context);
   }


### PR DESCRIPTION
closed #14507

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently when serving a prod build locally you will get the error similar to 
```
Error: Could not find a production build in the '/nx-bug/apps/nx-bug/.next' directory. 
```

The [previous change](https://github.com/nrwl/nx/pull/14569) made it so that both *Nx Dev Server* and *Custom Server* would receive the same root path for the nextjs artifacts which was incorrect
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
With this change there should be no errors.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
