### PR TITLE
cleanup(misc): disable cypress component tests e2e tests

### DIFF
--- a/e2e/angular-extensions/src/cypress-component-tests.test.ts
+++ b/e2e/angular-extensions/src/cypress-component-tests.test.ts
@@ -9,7 +9,9 @@ import {
   updateProjectConfig,
 } from '../../utils';
 import { names } from '@nrwl/devkit';
-describe('Angular Cypress Component Tests', () => {
+
+// TODO(leo): reenable once https://github.com/cypress-io/cypress/issues/25568 is addressed
+xdescribe('Angular Cypress Component Tests', () => {
   let projectName: string;
   const appName = uniq('cy-angular-app');
   const usedInAppLibName = uniq('cy-angular-lib');

--- a/e2e/react/src/cypress-component-tests.test.ts
+++ b/e2e/react/src/cypress-component-tests.test.ts
@@ -9,7 +9,8 @@ import {
   updateProjectConfig,
 } from '../../utils';
 
-describe('React Cypress Component Tests', () => {
+// TODO(leo): reenable once https://github.com/cypress-io/cypress/issues/25568 is addressed
+xdescribe('React Cypress Component Tests', () => {
   let projectName;
   const appName = uniq('cy-react-app');
   const usedInAppLibName = uniq('cy-react-lib');


### PR DESCRIPTION
Disabled until https://github.com/cypress-io/cypress/issues/25568 is addressed.