### PR TITLE
fix(core): tsconfig.base.json module setting should not break local plugins

### DIFF
--- a/docs/generated/packages/nx-plugin/documents/overview.md
+++ b/docs/generated/packages/nx-plugin/documents/overview.md
@@ -155,3 +155,9 @@ To make sure that assets are copied to the dist folder, open the plugin's `proje
 ## Using your Nx Plugin
 
 To use your plugin, simply list it in `nx.json` or use its generators and executors as you would for any other plugin. This could look like `nx g @my-org/my-plugin:lib` for generators or `"executor": "@my-org/my-plugin:build"` for executors. It should be usable in all of the same ways as published plugins in your local workspace immediately after generating it. This includes setting it up as the default collection in `nx.json`, which would allow you to run `nx g lib` and hit your plugin's generator.
+
+{% callout type="warning" title="string" %}
+
+Nx uses the paths from tsconfig.base.json when running plugins locally, but uses the recommended tsconfig for node 16 for other compiler options. See https://github.com/tsconfig/bases/blob/main/bases/node16.json
+
+{% /callout %}

--- a/docs/shared/packages/nx-plugin/nx-plugin.md
+++ b/docs/shared/packages/nx-plugin/nx-plugin.md
@@ -155,3 +155,9 @@ To make sure that assets are copied to the dist folder, open the plugin's `proje
 ## Using your Nx Plugin
 
 To use your plugin, simply list it in `nx.json` or use its generators and executors as you would for any other plugin. This could look like `nx g @my-org/my-plugin:lib` for generators or `"executor": "@my-org/my-plugin:build"` for executors. It should be usable in all of the same ways as published plugins in your local workspace immediately after generating it. This includes setting it up as the default collection in `nx.json`, which would allow you to run `nx g lib` and hit your plugin's generator.
+
+{% callout type="warning" title="string" %}
+
+Nx uses the paths from tsconfig.base.json when running plugins locally, but uses the recommended tsconfig for node 16 for other compiler options. See https://github.com/tsconfig/bases/blob/main/bases/node16.json
+
+{% /callout %}

--- a/docs/shared/recipes/generators/local-generators.md
+++ b/docs/shared/recipes/generators/local-generators.md
@@ -97,7 +97,7 @@ nx generate @myorg/my-plugin:my-generator mylib
 
 {% callout type="warning" title="string" %}
 
-Nx uses the paths from tsconfig.base.json when running plugins locally, but uses the recommended tsconfig for node 16 for other compiler options. See https://github.com/tsconfig/bases/blob/main/bases/node16.json
+Nx uses the paths from `tsconfig.base.json` when running plugins locally, but uses the recommended tsconfig for node 16 for other compiler options. See https://github.com/tsconfig/bases/blob/main/bases/node16.json
 
 {% /callout %}
 

--- a/docs/shared/recipes/generators/local-generators.md
+++ b/docs/shared/recipes/generators/local-generators.md
@@ -95,6 +95,12 @@ To run a generator, invoke the `nx generate` command with the name of the genera
 nx generate @myorg/my-plugin:my-generator mylib
 ```
 
+{% callout type="warning" title="string" %}
+
+Nx uses the paths from tsconfig.base.json when running plugins locally, but uses the recommended tsconfig for node 16 for other compiler options. See https://github.com/tsconfig/bases/blob/main/bases/node16.json
+
+{% /callout %}
+
 ## Debugging generators
 
 ### With Visual Studio Code

--- a/docs/shared/recipes/plugins/local-executors.md
+++ b/docs/shared/recipes/plugins/local-executors.md
@@ -136,7 +136,7 @@ Hello World
 
 {% callout type="warning" title="string" %}
 
-Nx uses the paths from tsconfig.base.json when running plugins locally, but uses the recommended tsconfig for node 16 for other compiler options. See https://github.com/tsconfig/bases/blob/main/bases/node16.json
+Nx uses the paths from `tsconfig.base.json` when running plugins locally, but uses the recommended tsconfig for node 16 for other compiler options. See https://github.com/tsconfig/bases/blob/main/bases/node16.json
 
 {% /callout %}
 

--- a/docs/shared/recipes/plugins/local-executors.md
+++ b/docs/shared/recipes/plugins/local-executors.md
@@ -134,6 +134,12 @@ Options: {
 Hello World
 ```
 
+{% callout type="warning" title="string" %}
+
+Nx uses the paths from tsconfig.base.json when running plugins locally, but uses the recommended tsconfig for node 16 for other compiler options. See https://github.com/tsconfig/bases/blob/main/bases/node16.json
+
+{% /callout %}
+
 ## Using Node Child Process
 
 [Node’s `childProcess`](https://nodejs.org/api/child_process.html) is often useful in executors.

--- a/e2e/nx-plugin/src/nx-plugin.test.ts
+++ b/e2e/nx-plugin/src/nx-plugin.test.ts
@@ -70,10 +70,9 @@ describe('Nx Plugin', () => {
   // we should change it to point to the right collection using relative path
   // TODO: Re-enable this to work with pnpm
   xit(`should run the plugin's e2e tests`, async () => {
-    const plugin = uniq('plugin-name');
-    runCLI(`generate @nrwl/nx-plugin:plugin ${plugin} --linter=eslint`);
-
     if (isNotWindows()) {
+      const plugin = uniq('plugin-name');
+      runCLI(`generate @nrwl/nx-plugin:plugin ${plugin} --linter=eslint`);
       const e2eResults = runCLI(`e2e ${plugin}-e2e`);
       expect(e2eResults).toContain('Successfully ran target e2e');
       expect(await killPorts()).toBeTruthy();
@@ -281,7 +280,7 @@ describe('Nx Plugin', () => {
   /**
    * @todo(@AgentEnder): reenable after figuring out @swc-node
    */
-  xdescribe('local plugins', () => {
+  describe('local plugins', () => {
     let plugin: string;
     beforeEach(() => {
       plugin = uniq('plugin');

--- a/packages/nx/src/utils/nx-plugin.ts
+++ b/packages/nx/src/utils/nx-plugin.ts
@@ -189,17 +189,16 @@ let tsNodeAndPathsRegistered = false;
 
 function registerTSTranspiler() {
   if (!tsNodeAndPathsRegistered) {
+    // nx-ignore-next-line
+    const ts: typeof import('typescript') = require('typescript');
+
     registerTsConfigPaths(join(workspaceRoot, 'tsconfig.base.json'));
     registerTranspiler({
       lib: ['es2021'],
-      module: 1 as ModuleKind,
-      target: 8 as ScriptTarget,
-
-      strict: true,
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2021,
       esModuleInterop: true,
       skipLibCheck: true,
-      forceConsistentCasingInFileNames: true,
-      moduleResolution: 3 as ModuleResolutionKind,
     });
   }
   tsNodeAndPathsRegistered = true;

--- a/packages/nx/src/utils/nx-plugin.ts
+++ b/packages/nx/src/utils/nx-plugin.ts
@@ -10,7 +10,7 @@ import {
   PackageJson,
   readModulePackageJsonWithoutFallbacks,
 } from './package-json';
-import { registerTsProject } from './register';
+import { registerTranspiler, registerTsConfigPaths } from './register';
 import {
   ProjectConfiguration,
   ProjectsConfigurations,
@@ -22,6 +22,13 @@ import {
   findProjectForPath,
 } from '../project-graph/utils/find-project-for-path';
 import { normalizePath } from './path';
+import { join } from 'path';
+
+import type {
+  ModuleKind,
+  ModuleResolutionKind,
+  ScriptTarget,
+} from 'typescript';
 
 export type ProjectTargetConfigurator = (
   file: string
@@ -179,9 +186,21 @@ export function resolveLocalNxPlugin(
 }
 
 let tsNodeAndPathsRegistered = false;
+
 function registerTSTranspiler() {
   if (!tsNodeAndPathsRegistered) {
-    registerTsProject(workspaceRoot, 'tsconfig.base.json');
+    registerTsConfigPaths(join(workspaceRoot, 'tsconfig.base.json'));
+    registerTranspiler({
+      lib: ['es2021'],
+      module: 1 as ModuleKind,
+      target: 8 as ScriptTarget,
+
+      strict: true,
+      esModuleInterop: true,
+      skipLibCheck: true,
+      forceConsistentCasingInFileNames: true,
+      moduleResolution: 3 as ModuleResolutionKind,
+    });
   }
   tsNodeAndPathsRegistered = true;
 }

--- a/packages/nx/src/utils/nx-plugin.ts
+++ b/packages/nx/src/utils/nx-plugin.ts
@@ -24,12 +24,6 @@ import {
 import { normalizePath } from './path';
 import { join } from 'path';
 
-import type {
-  ModuleKind,
-  ModuleResolutionKind,
-  ScriptTarget,
-} from 'typescript';
-
 export type ProjectTargetConfigurator = (
   file: string
 ) => Record<string, TargetConfiguration>;

--- a/packages/nx/src/utils/register.ts
+++ b/packages/nx/src/utils/register.ts
@@ -1,5 +1,9 @@
-import { join } from 'path';
+import { dirname, join } from 'path';
+import type { CompilerOptions } from 'typescript';
 import { logger, NX_PREFIX, stripIndent } from './logger';
+
+const swcNodeInstalled = packageIsInstalled('@swc-node/register');
+const tsNodeInstalled = packageIsInstalled('ts-node/register');
 
 /**
  * Optionally, if swc-node and tsconfig-paths are available in the current workspace, apply the require
@@ -15,37 +19,51 @@ export const registerTsProject = (
   path: string,
   configFilename = 'tsconfig.json'
 ): (() => void) => {
+  const tsConfigPath = join(path, configFilename);
+
+  const compilerOptions: CompilerOptions = readCompilerOptions(tsConfigPath);
+  const cleanupFunctions = [
+    registerTsConfigPaths(tsConfigPath),
+    registerTranspiler(compilerOptions),
+  ];
+
+  return () => {
+    for (const fn of cleanupFunctions) {
+      fn();
+    }
+  };
+};
+
+/**
+ * Register ts-node or swc-node given a set of compiler options.
+ *
+ * Note: Several options require enums from typescript. To avoid importing typescript,
+ * use import type + raw values
+ *
+ * @returns cleanup method
+ */
+export function registerTranspiler(
+  compilerOptions: CompilerOptions
+): () => void {
   // Function to register transpiler that returns cleanup function
   let registerTranspiler: () => () => void;
 
-  const tsConfigPath = join(path, configFilename);
-  const cleanupFunctions = [registerTsConfigPaths(tsConfigPath)];
-
-  const swcNodeInstalled = packageIsInstalled('@swc-node/register');
   if (swcNodeInstalled) {
     // These are requires to prevent it from registering when it shouldn't
     const { register } =
       require('@swc-node/register/register') as typeof import('@swc-node/register/register');
-    const {
-      readDefaultTsConfig,
-    } = require('@swc-node/register/read-default-tsconfig');
 
-    const tsConfig = readDefaultTsConfig(tsConfigPath);
-    registerTranspiler = () => register(tsConfig);
+    registerTranspiler = () => register(compilerOptions);
   } else {
     // We can fall back on ts-node if its available
-    const tsNodeInstalled = packageIsInstalled('ts-node/register');
+
     if (tsNodeInstalled) {
       const { register } = require('ts-node') as typeof import('ts-node');
-
       // ts-node doesn't provide a cleanup method
       registerTranspiler = () => {
         const service = register({
-          project: tsConfigPath,
           transpileOnly: true,
-          compilerOptions: {
-            module: 'commonjs',
-          },
+          compilerOptions,
         });
         // Don't warn if a faster transpiler is enabled
         if (!service.options.transpiler && !service.options.swc) {
@@ -57,19 +75,12 @@ export const registerTsProject = (
   }
 
   if (registerTranspiler) {
-    cleanupFunctions.push(registerTranspiler());
+    return registerTranspiler();
   } else {
     warnNoTranspiler();
+    return () => {};
   }
-
-  // Overall cleanup method cleans up tsconfig path resolution
-  // as well as ts transpiler
-  return () => {
-    for (const f of cleanupFunctions) {
-      f();
-    }
-  };
-};
+}
 
 /**
  * @param tsConfigPath Adds the paths from a tsconfig file into node resolutions
@@ -96,6 +107,24 @@ export function registerTsConfigPaths(tsConfigPath): () => void {
     warnNoTsconfigPaths();
   }
   return () => {};
+}
+
+function readCompilerOptions(tsConfigPath): CompilerOptions {
+  if (swcNodeInstalled) {
+    const {
+      readDefaultTsConfig,
+    }: typeof import('@swc-node/register/read-default-tsconfig') = require('@swc-node/register/read-default-tsconfig');
+    return readDefaultTsConfig(tsConfigPath);
+  }
+  return readCompilerOptionsWithTypescript(tsConfigPath);
+}
+
+function readCompilerOptionsWithTypescript(tsConfigPath) {
+  const { readConfigFile, parseJsonConfigFileContent, sys } =
+    require('typescript') as typeof import('typescript');
+  const jsonContent = readConfigFile(tsConfigPath, sys.readFile);
+  return parseJsonConfigFileContent(jsonContent, sys, dirname(tsConfigPath))
+    .options;
 }
 
 function warnTsNodeUsage() {

--- a/packages/nx/src/utils/register.ts
+++ b/packages/nx/src/utils/register.ts
@@ -115,16 +115,24 @@ function readCompilerOptions(tsConfigPath): CompilerOptions {
       readDefaultTsConfig,
     }: typeof import('@swc-node/register/read-default-tsconfig') = require('@swc-node/register/read-default-tsconfig');
     return readDefaultTsConfig(tsConfigPath);
+  } else {
+    return readCompilerOptionsWithTypescript(tsConfigPath);
   }
-  return readCompilerOptionsWithTypescript(tsConfigPath);
 }
 
 function readCompilerOptionsWithTypescript(tsConfigPath) {
   const { readConfigFile, parseJsonConfigFileContent, sys } =
     require('typescript') as typeof import('typescript');
   const jsonContent = readConfigFile(tsConfigPath, sys.readFile);
-  return parseJsonConfigFileContent(jsonContent, sys, dirname(tsConfigPath))
-    .options;
+  const { options } = parseJsonConfigFileContent(
+    jsonContent,
+    sys,
+    dirname(tsConfigPath)
+  );
+  // This property is returned in compiler options for some reason, but not part of the typings.
+  // ts-node fails on unknown props, so we have to remove it.
+  delete options.configFilePath;
+  return options;
 }
 
 function warnTsNodeUsage() {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`tsconfig.base.json` influences local plugin runtime as it is read for all compiler options which are then fed into ts-node or swc-node. 

When setting module to `ESNEXT` or similar, this can break plugin usage.

## Expected Behavior
Plugins run in a known environment. They will always run under node or a similar runtime, so we can provide an appropriate tsconfig. Only the paths from tsconfig.base.json should really matter.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
There's a community slack thread here: https://nrwlcommunity.slack.com/archives/CMFKWPU6Q/p1674653626198069
