### PR TITLE
fix(core): react monorepo account for bundler

### DIFF
--- a/e2e/workspace-create/src/create-nx-workspace.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace.test.ts
@@ -133,7 +133,7 @@ describe('create-nx-workspace', () => {
     }
   });
 
-  it('should be able to create an react workspace', () => {
+  it('should be able to create a react workspace with webpack', () => {
     const wsName = uniq('react');
     const appName = uniq('app');
 
@@ -149,6 +149,24 @@ describe('create-nx-workspace', () => {
     expectNoTsJestInJestConfig(appName);
     const packageJson = readJson('package.json');
     expect(packageJson.devDependencies['@nrwl/webpack']).toBeDefined();
+  });
+
+  it('should be able to create a react workspace with vite', () => {
+    const wsName = uniq('react');
+    const appName = uniq('app');
+
+    runCreateWorkspace(wsName, {
+      preset: 'react-monorepo',
+      style: 'css',
+      appName,
+      packageManager,
+      bundler: 'vite',
+    });
+
+    expectNoAngularDevkit();
+    const packageJson = readJson('package.json');
+    expect(packageJson.devDependencies['@nrwl/webpack']).not.toBeDefined();
+    expect(packageJson.devDependencies['@nrwl/vite']).toBeDefined();
   });
 
   it('should be able to create an next workspace', () => {

--- a/packages/workspace/src/generators/preset/preset.ts
+++ b/packages/workspace/src/generators/preset/preset.ts
@@ -53,7 +53,7 @@ async function createPreset(tree: Tree, options: Schema) {
       name: options.name,
       style: options.style,
       linter: options.linter,
-      bundler: 'webpack',
+      bundler: options.bundler ?? 'webpack',
     });
   } else if (options.preset === Preset.ReactStandalone) {
     const {


### PR DESCRIPTION
closed #14614

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`bundler` is ignored in `react-monorepo` cases. It's hard-coded to be `webpack`.

## Expected Behavior
Take into account `bundler` option when generating `react-monorepo`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14614
