### PR TITLE
fix(storybook): react-native tsconfig templates

### DIFF
--- a/packages/storybook/src/generators/configuration/project-files-7-ts/.storybook/tsconfig.json__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files-7-ts/.storybook/tsconfig.json__tmpl__
@@ -24,5 +24,5 @@
     "../<%= mainDir %>/**/*.stories.tsx",
     "../<%= mainDir %>/**/*.stories.mdx",
     "*.ts",
-    "*.js"<% if(uiFramework === '@storybook/react-native') { %>, *.tsx"<% } %><% } %>]
+    "*.js"<% if(uiFramework === '@storybook/react-native') { %>, "*.tsx"<% } %><% } %>]
 }

--- a/packages/storybook/src/generators/configuration/project-files-ts/.storybook/tsconfig.json__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files-ts/.storybook/tsconfig.json__tmpl__
@@ -24,5 +24,5 @@
     "../<%= mainDir %>/**/*.stories.tsx",
     "../<%= mainDir %>/**/*.stories.mdx",
     "*.ts",
-    "*.js"<% if(uiFramework === '@storybook/react-native') { %>, *.tsx"<% } %><% } %>]
+    "*.js"<% if(uiFramework === '@storybook/react-native') { %>, "*.tsx"<% } %><% } %>]
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Running `nx g @nrwl/storybook:configuration <project> --tsConfiguration=true` fails when targeting `react-native`.
The generated file `.storybook/tsconfig.json` is invalid due to a missing quote.
Issue impacts both current and beta (v7) version of the generator

## Expected Behavior
A valid `tsconfig.json` file should be generated.

