### PR TITLE
fix(webpack): sourceMap option must be a boolean if/when passed to loaders

### DIFF
--- a/packages/webpack/src/utils/with-web.ts
+++ b/packages/webpack/src/utils/with-web.ts
@@ -176,7 +176,7 @@ export function withWeb() {
             loader: require.resolve('sass-loader'),
             options: {
               implementation: require('sass'),
-              sourceMap: options.sourceMap,
+              sourceMap: !!options.sourceMap,
               sassOptions: {
                 fiber: false,
                 // bootstrap-sass requires a minimum precision of 8
@@ -195,7 +195,7 @@ export function withWeb() {
           {
             loader: require.resolve('less-loader'),
             options: {
-              sourceMap: options.sourceMap,
+              sourceMap: !!options.sourceMap,
               lessOptions: {
                 javascriptEnabled: true,
                 ...lessPathOptions,
@@ -212,7 +212,7 @@ export function withWeb() {
           {
             loader: require.resolve('stylus-loader'),
             options: {
-              sourceMap: options.sourceMap,
+              sourceMap: !!options.sourceMap,
               stylusOptions: {
                 include: includePaths,
               },
@@ -237,7 +237,7 @@ export function withWeb() {
             loader: require.resolve('sass-loader'),
             options: {
               implementation: require('sass'),
-              sourceMap: options.sourceMap,
+              sourceMap: !!options.sourceMap,
               sassOptions: {
                 fiber: false,
                 // bootstrap-sass requires a minimum precision of 8
@@ -256,7 +256,7 @@ export function withWeb() {
           {
             loader: require.resolve('less-loader'),
             options: {
-              sourceMap: options.sourceMap,
+              sourceMap: !!options.sourceMap,
               lessOptions: {
                 javascriptEnabled: true,
                 ...lessPathOptions,
@@ -273,7 +273,7 @@ export function withWeb() {
           {
             loader: require.resolve('stylus-loader'),
             options: {
-              sourceMap: options.sourceMap,
+              sourceMap: !!options.sourceMap,
               stylusOptions: {
                 include: includePaths,
               },


### PR DESCRIPTION
## Current Behavior

When using `sourceMap: 'hidden'` as an **nx** webpack config option you see errors from loaders

eg.

```
Error: Module build failed (from ./node_modules/sass-loader/dist/cjs.js):
ValidationError: Invalid options object. Sass Loader has been initialized using an options object that does not match the API schema.
 - options.sourceMap should be a boolean.
   -> Enables/Disables generation of source maps.
   -> Read more at https://github.com/webpack-contrib/sass-loader#sourcemap
```

## Expected Behavior

No errors when specifying `'hidden'` as the `sourceMap` config.

Note, all modified loader configs expect a boolean:
- https://www.npmjs.com/package/sass-loader#sourcemap
- https://www.npmjs.com/package/less-loader#sourcemap
- https://www.npmjs.com/package/stylus-loader#sourcemap

