### PR TITLE
fix(devkit): always read package version from the actual package in e…

### DIFF
--- a/packages/devkit/src/utils/package-json.spec.ts
+++ b/packages/devkit/src/utils/package-json.spec.ts
@@ -318,20 +318,6 @@ describe('ensurePackage', () => {
     tree = createTree();
   });
 
-  it('should return without error when dependency is satisfied', async () => {
-    writeJson(tree, 'package.json', {
-      devDependencies: {
-        '@nrwl/vite': '15.0.0',
-      },
-    });
-
-    await expect(
-      ensurePackage(tree, '@nrwl/vite', '>=15.0.0', {
-        throwOnMissing: true,
-      })
-    ).resolves.toBeUndefined();
-  });
-
   it('should throw when dependencies are missing', async () => {
     writeJson(tree, 'package.json', {});
 

--- a/packages/devkit/src/utils/package-json.ts
+++ b/packages/devkit/src/utils/package-json.ts
@@ -5,6 +5,7 @@ import { GeneratorCallback } from 'nx/src/config/misc-interfaces';
 import { clean, coerce, gt, satisfies } from 'semver';
 import { getPackageManagerCommand } from 'nx/src/utils/package-manager';
 import { execSync } from 'child_process';
+import { readModulePackageJson } from 'nx/src/utils/package-json';
 
 const NON_SEMVER_TAGS = {
   '*': 2,
@@ -317,21 +318,22 @@ export async function ensurePackage(
   let version: string;
 
   // Read package and version from root package.json file.
-  const packageJson = readJson(tree, 'package.json');
   const dev = options.dev ?? true;
   const throwOnMissing = options.throwOnMissing ?? !!process.env.NX_DRY_RUN; // NX_DRY_RUN is set in `packages/nx/src/command-line/generate.ts`
   const pmc = getPackageManagerCommand();
-  const field = dev ? 'devDependencies' : 'dependencies';
 
-  version = packageJson[field]?.[pkg];
+  // Try to resolve the actual version from resolved module.
+  try {
+    version = readModulePackageJson(pkg).packageJson.version;
+  } catch {
+    // ignore
+  }
 
-  // If package not found, try to resolve it using Node and get its version.
+  // Otherwise try to read in from package.json. This is needed for E2E tests to pass.
   if (!version) {
-    try {
-      version = require(`${pkg}/package.json`).version;
-    } catch {
-      // ignore
-    }
+    const packageJson = readJson(tree, 'package.json');
+    const field = dev ? 'devDependencies' : 'dependencies';
+    version = packageJson[field]?.[pkg];
   }
 
   if (!satisfies(version, requiredVersion)) {


### PR DESCRIPTION
…nsurePackage function


Currently, if there is a range in the root `package.json` file, the `ensurePackage` function does not work, since comparing something like `^1.0.0` to `1.0.0` will not work. This PR fixes this by looking at the actual version installed rather than a range.


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
