### PR TITLE
feat(node): add --docker for CNW

### DIFF
--- a/docs/generated/cli/create-nx-workspace.md
+++ b/docs/generated/cli/create-nx-workspace.md
@@ -81,6 +81,12 @@ Default: `main`
 
 Default base to use for new projects
 
+### docker
+
+Type: `boolean`
+
+Generate a Dockerfile with your node-server
+
 ### framework
 
 Type: `string`

--- a/docs/generated/packages/nx/documents/create-nx-workspace.md
+++ b/docs/generated/packages/nx/documents/create-nx-workspace.md
@@ -81,6 +81,12 @@ Default: `main`
 
 Default base to use for new projects
 
+### docker
+
+Type: `boolean`
+
+Generate a Dockerfile with your node-server
+
 ### framework
 
 Type: `string`

--- a/docs/generated/packages/workspace/generators/preset.json
+++ b/docs/generated/packages/workspace/generators/preset.json
@@ -70,6 +70,11 @@
         "type": "string",
         "enum": ["webpack", "vite"],
         "default": "vite"
+      },
+      "docker": {
+        "description": "Generate a Dockerfile",
+        "type": "boolean",
+        "default": false
       }
     },
     "presets": []

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -32,6 +32,7 @@ type Arguments = {
   cli: string;
   style: string;
   framework: string;
+  docker: boolean;
   nxCloud: boolean;
   allPrompts: boolean;
   packageManager: PackageManager;
@@ -161,6 +162,10 @@ export const commandsObject: yargs.Argv<Arguments> = yargs
           describe: chalk.dim`Framework option to be used when the node-server preset is selected`,
           type: 'string',
         })
+        .option('docker', {
+          describe: chalk.dim`Generate a Dockerfile with your node-server`,
+          type: 'boolean',
+        })
         .option('nxCloud', {
           describe: chalk.dim(messages.getPromptMessage('nxCloudCreation')),
           type: 'boolean',
@@ -241,6 +246,7 @@ async function main(parsedArgs: yargs.Arguments<Arguments>) {
     skipGit,
     commit,
     framework,
+    docker,
     bundler,
   } = parsedArgs;
 
@@ -267,6 +273,7 @@ async function main(parsedArgs: yargs.Arguments<Arguments>) {
       nxCloud,
       defaultBase,
       framework,
+      docker,
       bundler,
     }
   );
@@ -320,7 +327,7 @@ async function getConfiguration(
   argv: yargs.Arguments<Arguments>
 ): Promise<void> {
   try {
-    let name, appName, style, preset, framework, bundler;
+    let name, appName, style, preset, framework, bundler, docker;
 
     output.log({
       title:
@@ -365,7 +372,8 @@ async function getConfiguration(
         name = argv.name ?? appName;
 
         if (preset === Preset.NodeServer) {
-          framework = await determineFramework(preset, argv);
+          framework = await determineFramework(argv);
+          docker = await determineDockerfile(argv);
         }
 
         if (preset === Preset.ReactStandalone) {
@@ -399,6 +407,7 @@ async function getConfiguration(
       defaultBase,
       ci,
       bundler,
+      docker,
     });
   } catch (e) {
     console.error(e);
@@ -685,13 +694,8 @@ async function determineAppName(
 }
 
 async function determineFramework(
-  preset: Preset,
   parsedArgs: yargs.Arguments<Arguments>
 ): Promise<string> {
-  if (preset !== Preset.NodeServer) {
-    return Promise.resolve('');
-  }
-
   const frameworkChoices = [
     {
       name: 'express',
@@ -738,6 +742,35 @@ async function determineFramework(
   }
 
   return Promise.resolve(parsedArgs.framework);
+}
+
+async function determineDockerfile(
+  parsedArgs: yargs.Arguments<Arguments>
+): Promise<boolean> {
+  if (parsedArgs.docker === undefined) {
+    return enquirer
+      .prompt([
+        {
+          name: 'docker',
+          message:
+            'Would you like to generate a Dockerfile? [https://docs.docker.com/]',
+          type: 'autocomplete',
+          choices: [
+            {
+              name: 'Yes',
+              hint: 'I want to generate a Dockerfile',
+            },
+            {
+              name: 'No',
+            },
+          ],
+          initial: 'No' as any,
+        },
+      ])
+      .then((a: { docker: 'Yes' | 'No' }) => a.docker === 'Yes');
+  } else {
+    return Promise.resolve(parsedArgs.docker);
+  }
 }
 
 function isValidCli(cli: string): cli is 'angular' | 'nx' {

--- a/packages/workspace/src/generators/new/generate-preset.ts
+++ b/packages/workspace/src/generators/new/generate-preset.ts
@@ -75,6 +75,7 @@ export function generatePreset(host: Tree, opts: NormalizedSchema) {
       opts.preset ? `--preset=${opts.preset}` : null,
       opts.bundler ? `--bundler=${opts.bundler}` : null,
       opts.framework ? `--framework=${opts.framework}` : null,
+      opts.docker ? `--docker=${opts.docker}` : null,
       opts.packageManager ? `--packageManager=${opts.packageManager}` : null,
       parsedArgs.interactive ? '--interactive=true' : '--interactive=false',
     ].filter((e) => !!e);

--- a/packages/workspace/src/generators/new/new.ts
+++ b/packages/workspace/src/generators/new/new.ts
@@ -24,6 +24,7 @@ interface Schema {
   preset: string;
   defaultBase: string;
   framework?: string;
+  docker?: boolean;
   linter?: Linter;
   bundler?: 'vite' | 'webpack';
   packageManager?: PackageManager;

--- a/packages/workspace/src/generators/preset/preset.ts
+++ b/packages/workspace/src/generators/preset/preset.ts
@@ -134,6 +134,7 @@ async function createPreset(tree: Tree, options: Schema) {
       linter: options.linter,
       standaloneConfig: options.standaloneConfig,
       framework: options.framework,
+      docker: options.docker,
       rootProject: true,
     });
   } else {

--- a/packages/workspace/src/generators/preset/schema.d.ts
+++ b/packages/workspace/src/generators/preset/schema.d.ts
@@ -12,4 +12,5 @@ export interface Schema {
   framework?: string;
   packageManager?: PackageManager;
   bundler?: 'vite' | 'webpack';
+  docker?: boolean;
 }

--- a/packages/workspace/src/generators/preset/schema.json
+++ b/packages/workspace/src/generators/preset/schema.json
@@ -76,6 +76,11 @@
       "type": "string",
       "enum": ["webpack", "vite"],
       "default": "vite"
+    },
+    "docker": {
+      "description": "Generate a Dockerfile",
+      "type": "boolean",
+      "default": false
     }
   }
 }


### PR DESCRIPTION
You can now create a Dockerfile through CNW when generating a node server by passing the `--docker` flag
If it is not passed you will get a prompt similar to:

<img width="941" alt="Screenshot 2023-01-25 at 11 58 05 AM" src="https://user-images.githubusercontent.com/338948/214657642-9ae04682-bdf7-457f-955b-72787d97a68c.png">
