### PR TITLE
cleanup(angular): reenable ng add e2e tests

### DIFF
--- a/e2e/angular-core/src/ng-add.test.ts
+++ b/e2e/angular-core/src/ng-add.test.ts
@@ -16,8 +16,7 @@ import {
 } from '@nrwl/e2e/utils';
 import { PackageManager } from 'nx/src/utils/package-manager';
 
-// TODO(leo): temporarily disabled until a bug in the Angular CLI is solved
-xdescribe('convert Angular CLI workspace to an Nx workspace', () => {
+describe('convert Angular CLI workspace to an Nx workspace', () => {
   let project: string;
   let packageManager: PackageManager;
 


### PR DESCRIPTION
Reenable the ng add e2e tests previously disabled in https://github.com/nrwl/nx/pull/14487 due to an Angular CLI bug. The issue was resolved in https://github.com/angular/angular-cli/commit/de15ec5763afe231439c3f1ace35cbacefad2ca7 and released on Angular CLI [v15.1.3](https://github.com/angular/angular-cli/releases/tag/15.1.3).