### PR TITLE
fix(esbuild): don't set outfile or outdir if already defined

### DIFF
--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
@@ -40,10 +40,12 @@ export function buildEsbuildOptions(
     esbuildOptions.define = getClientEnvironment();
   }
 
-  if (options.singleEntry && options.bundle) {
-    esbuildOptions.outfile = getOutfile(format, options, context);
-  } else {
-    esbuildOptions.outdir = options.outputPath;
+  if (!esbuildOptions.outfile && !esbuildOptions.outdir) {
+    if (options.singleEntry && options.bundle && !esbuildOptions.splitting) {
+      esbuildOptions.outfile = getOutfile(format, options, context);
+    } else {
+      esbuildOptions.outdir = options.outputPath;
+    }
   }
 
   const entryPoints = options.additionalEntryPoints


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

outdir/outfile defined in esbuildOptions either conflicts or is overwritten with options set by executor

knock on effect is that esbuild executor cannot be run with splitting=true

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When setting outdir or outfile for esbuilld executor, it will not get overwritten by executor.

Also, when splitting is set to true, outdir is defined instead of outfile

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14635
