### PR TITLE
fix(nx-dev): test additional property for boolean and object

### DIFF
--- a/nx-dev/feature-package-schema-viewer/src/lib/types/type.tsx
+++ b/nx-dev/feature-package-schema-viewer/src/lib/types/type.tsx
@@ -60,8 +60,9 @@ function hasPatternProperties(s: JsonSchema1): boolean {
 }
 
 function hasAdditionalProperties(s: JsonSchema1): boolean {
-  return !(
-    typeof s.additionalProperties === 'boolean' && !s.additionalProperties
+  return (
+    typeof s.additionalProperties === 'boolean' ||
+    typeof s.additionalProperties === 'object'
   );
 }
 


### PR DESCRIPTION
It fixes the wrong test condition when attempting to look for additional properties for parameter type. It now explicitly looks for a boolean or and object.

closes #12773
