### PR TITLE
fix(core): reintroduce misaligned packages check

### DIFF
--- a/e2e/nx-misc/src/misc.test.ts
+++ b/e2e/nx-misc/src/misc.test.ts
@@ -1,5 +1,6 @@
 import {
   cleanupProject,
+  getPublishedVersion,
   isNotWindows,
   newProject,
   readFile,
@@ -12,7 +13,6 @@ import {
   updateFile,
 } from '@nrwl/e2e/utils';
 import { renameSync } from 'fs';
-import { packagesWeCareAbout } from 'nx/src/command-line/report';
 import * as path from 'path';
 
 describe('Nx Commands', () => {
@@ -44,9 +44,12 @@ describe('Nx Commands', () => {
     it(`should report package versions`, async () => {
       const reportOutput = runCLI('report');
 
-      packagesWeCareAbout.forEach((p) => {
-        expect(reportOutput).toContain(p);
-      });
+      expect(reportOutput).toEqual(
+        expect.stringMatching(
+          new RegExp(`\@nrwl\/workspace.*:.*${getPublishedVersion()}`)
+        )
+      );
+      expect(reportOutput).toContain('@nrwl/workspace');
     }, 120000);
 
     it(`should list plugins`, async () => {

--- a/packages/nx/src/command-line/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate.spec.ts
@@ -1,6 +1,11 @@
 import * as enquirer from 'enquirer';
 import { PackageJson } from '../utils/package-json';
-import { Migrator, normalizeVersion, parseMigrationsOptions } from './migrate';
+import {
+  Migrator,
+  normalizeVersion,
+  parseMigrationsOptions,
+  ResolvedMigrationConfiguration,
+} from './migrate';
 
 const createPackageJson = (
   overrides: Partial<PackageJson> = {}
@@ -366,9 +371,9 @@ describe('Migration', () => {
             return {
               version: '2.0.0',
               packageGroup: [
-                '@my-company/lib-1',
-                '@my-company/lib-2',
-                '@my-company/lib-3',
+                { package: '@my-company/lib-1', version: '*' },
+                { package: '@my-company/lib-2', version: '*' },
+                { package: '@my-company/lib-3', version: '*' },
                 { package: '@my-company/lib-4', version: 'latest' },
               ],
             };
@@ -376,13 +381,17 @@ describe('Migration', () => {
           if (pkg === '@my-company/lib-6') {
             return {
               version: '2.0.0',
-              packageGroup: ['@my-company/nx-workspace'],
+              packageGroup: [
+                { version: '*', package: '@my-company/nx-workspace' },
+              ],
             };
           }
           if (pkg === '@my-company/lib-3') {
             return {
               version: '2.0.0',
-              packageGroup: ['@my-company/lib-3-child'],
+              packageGroup: [
+                { version: '*', package: '@my-company/lib-3-child' },
+              ],
             };
           }
           if (version === 'latest') {
@@ -440,19 +449,26 @@ describe('Migration', () => {
           if (pkg === '@my-company/nx-workspace' && version === '3.0.0') {
             return {
               version: '3.0.0',
-              packageGroup: ['@my-company/lib-1', '@my-company/lib-2'],
+              packageGroup: [
+                { package: '@my-company/lib-1', version: '*' },
+                { package: '@my-company/lib-2', version: '*' },
+              ],
             };
           }
           if (pkg === '@my-company/lib-1' && version === 'latest') {
             return {
               version: '3.0.0',
-              packageGroup: ['@my-company/nx-workspace'],
+              packageGroup: [
+                { package: '@my-company/nx-workspace', version: '*' },
+              ],
             };
           }
           if (pkg === '@my-company/lib-1' && version === '3.0.0') {
             return {
               version: '3.0.0',
-              packageGroup: ['@my-company/nx-workspace'],
+              packageGroup: [
+                { package: '@my-company/nx-workspace', version: '*' },
+              ],
             };
           }
           if (pkg === '@my-company/lib-2' && version === '3.0.0') {
@@ -827,7 +843,7 @@ describe('Migration', () => {
             },
           }),
           getInstalledPackageVersion: () => '1.0.0',
-          fetch: (p) => {
+          fetch: (p): Promise<ResolvedMigrationConfiguration> => {
             if (p === 'mypackage') {
               return Promise.resolve({
                 version: '2.0.0',
@@ -837,7 +853,10 @@ describe('Migration', () => {
                     packages: { child1: { version: '3.0.0' } },
                   },
                 },
-                packageGroup: ['pkg1', 'pkg2'],
+                packageGroup: [
+                  { package: 'pkg1', version: '*' },
+                  { package: 'pkg2', version: '*' },
+                ],
               });
             } else if (p === 'pkg1') {
               // add a delay to showcase the dependent requirement will wait for it
@@ -1008,7 +1027,7 @@ describe('Migration', () => {
           if (p === 'child') return '1.0.0';
           return null;
         },
-        fetch: (p, _v) => {
+        fetch: (p: string): Promise<ResolvedMigrationConfiguration> => {
           if (p === 'parent') {
             return Promise.resolve({
               version: '2.0.0',
@@ -1089,7 +1108,7 @@ describe('Migration', () => {
           if (p === 'newChild') return '1.0.0'; // installed as a transitive dep, not a top-level dep
           return null;
         },
-        fetch: (p, _v) => {
+        fetch: (p: string): Promise<ResolvedMigrationConfiguration> => {
           if (p === 'parent') {
             return Promise.resolve({
               version: '2.0.0',

--- a/packages/nx/src/command-line/report.spec.ts
+++ b/packages/nx/src/command-line/report.spec.ts
@@ -1,5 +1,11 @@
-// import * as devkit from '@nrwl/devkit';
 import * as fileUtils from '../utils/fileutils';
+import * as packageJsonUtils from '../utils/package-json';
+import {
+  findInstalledCommunityPlugins,
+  findInstalledPackagesWeCareAbout,
+  findMisalignedPackagesForPackage,
+  packagesWeCareAbout,
+} from './report';
 
 jest.mock('nx/src/utils/workspace-root', () => ({
   workspaceRoot: '',
@@ -10,141 +16,276 @@ jest.mock('../utils/fileutils', () => ({
   resolve: (file) => `node_modules/${file}`,
 }));
 
-describe('reenable spec', () => {
-  it('empty', () => {
-    expect(1).toEqual(1);
+describe('report', () => {
+  describe('findInstalledCommunityPlugins', () => {
+    afterEach(() => jest.resetAllMocks());
+
+    it('should read angular-devkit plugins', () => {
+      jest.spyOn(fileUtils, 'readJsonFile').mockImplementation((path) => {
+        console.log(path);
+        if (path === 'package.json') {
+          return {
+            dependencies: {
+              'plugin-one': '1.0.0',
+            },
+            devDependencies: {
+              'plugin-two': '2.0.0',
+            },
+          };
+        }
+      });
+      jest.spyOn(packageJsonUtils, 'readModulePackageJson').mockImplementation(
+        provideMockPackages({
+          'plugin-one': {
+            'ng-update': {},
+            version: '1.0.0',
+          },
+          'plugin-two': {
+            schematics: '',
+            version: '2.0.0',
+          },
+        })
+      );
+      const plugins = findInstalledCommunityPlugins();
+      expect(plugins).toEqual([
+        expect.objectContaining({ name: 'plugin-one', version: '1.0.0' }),
+        expect.objectContaining({ name: 'plugin-two', version: '2.0.0' }),
+      ]);
+    });
+
+    it('should exclude misc @angluar packages', () => {
+      jest.spyOn(fileUtils, 'readJsonFile').mockImplementation((path) => {
+        if (path === 'package.json') {
+          return {
+            dependencies: {
+              '@angular/cdk': '1.0.0',
+            },
+            devDependencies: {
+              'plugin-two': '2.0.0',
+            },
+          };
+        }
+      });
+      jest.spyOn(packageJsonUtils, 'readModulePackageJson').mockImplementation(
+        provideMockPackages({
+          'plugin-two': {
+            schematics: '',
+            version: '2.0.0',
+          },
+        })
+      );
+      const plugins = findInstalledCommunityPlugins();
+      expect(plugins).toEqual([
+        expect.objectContaining({ package: 'plugin-two', version: '2.0.0' }),
+      ]);
+    });
+
+    it('should read nx devkit plugins', () => {
+      jest.spyOn(fileUtils, 'readJsonFile').mockImplementation((path) => {
+        if (path === 'package.json') {
+          return {
+            dependencies: {
+              'plugin-one': '1.0.0',
+            },
+            devDependencies: {
+              'plugin-two': '2.0.0',
+            },
+          };
+        }
+      });
+      jest.spyOn(packageJsonUtils, 'readModulePackageJson').mockImplementation(
+        provideMockPackages({
+          'plugin-one': {
+            'nx-migrations': {},
+            version: '1.0.0',
+          },
+          'plugin-two': {
+            generators: '',
+            version: '2.0.0',
+          },
+        })
+      );
+      const plugins = findInstalledCommunityPlugins();
+      expect(plugins).toEqual([
+        expect.objectContaining({ package: 'plugin-one', version: '1.0.0' }),
+        expect.objectContaining({ package: 'plugin-two', version: '2.0.0' }),
+      ]);
+    });
+
+    it('should not include non-plugins', () => {
+      jest.spyOn(fileUtils, 'readJsonFile').mockImplementation((path) => {
+        if (path === 'package.json') {
+          return {
+            dependencies: {
+              'plugin-one': '1.0.0',
+            },
+            devDependencies: {
+              'plugin-two': '2.0.0',
+              'other-package': '1.44.0',
+            },
+          };
+        }
+      });
+      jest.spyOn(packageJsonUtils, 'readModulePackageJson').mockImplementation(
+        provideMockPackages({
+          'plugin-one': {
+            'nx-migrations': {},
+            version: '1.0.0',
+          },
+          'plugin-two': {
+            generators: '',
+            version: '2.0.0',
+          },
+          'other-package': {
+            version: '1.44.0',
+          },
+        })
+      );
+      const plugins = findInstalledCommunityPlugins().map((x) => x.package);
+      expect(plugins).not.toContain('other-package');
+    });
+  });
+
+  describe('findInstalledPackagesWeCareAbout', () => {
+    it('should not list packages that are not installed', () => {
+      const installed: [string, packageJsonUtils.PackageJson][] =
+        packagesWeCareAbout.map((x) => [
+          x,
+          {
+            name: x,
+            version: '1.0.0',
+          },
+        ]);
+      const uninstalled: [string, packageJsonUtils.PackageJson][] = [
+        installed.pop(),
+        installed.pop(),
+        installed.pop(),
+        installed.pop(),
+      ].map((x) => [x[0], null]);
+
+      jest
+        .spyOn(packageJsonUtils, 'readModulePackageJson')
+        .mockImplementation(
+          provideMockPackages(Object.fromEntries(installed.concat(uninstalled)))
+        );
+
+      const result = findInstalledPackagesWeCareAbout().map((x) => x.package);
+      for (const [pkg] of uninstalled) {
+        expect(result).not.toContain(pkg);
+      }
+      for (const [pkg] of installed) {
+        expect(result).toContain(pkg);
+      }
+    });
+  });
+
+  describe('findMisalignedPackagesForPackage', () => {
+    it('should identify misaligned packages for array specified package groups', () => {
+      jest.spyOn(packageJsonUtils, 'readModulePackageJson').mockImplementation(
+        provideMockPackages({
+          'plugin-one': {
+            'ng-update': {},
+            version: '1.0.0',
+          },
+          'plugin-two': {
+            schematics: '',
+            version: '2.0.0',
+          },
+        })
+      );
+      const results = findMisalignedPackagesForPackage({
+        name: 'my-package',
+        version: '1.0.0',
+        'nx-migrations': {
+          packageGroup: ['plugin-one', 'plugin-two'],
+        },
+      });
+      expect(results.misalignedPackages).toEqual([
+        {
+          name: 'plugin-two',
+          version: '2.0.0',
+        },
+      ]);
+      expect(results.migrateTarget).toEqual('my-package@2.0.0');
+    });
+
+    it('should identify misaligned packages for expanded array specified package groups', () => {
+      jest.spyOn(packageJsonUtils, 'readModulePackageJson').mockImplementation(
+        provideMockPackages({
+          'plugin-one': {
+            'ng-update': {},
+            version: '0.5.0',
+          },
+          'plugin-two': {
+            schematics: '',
+            version: '2.0.0',
+          },
+        })
+      );
+      const results = findMisalignedPackagesForPackage({
+        name: 'my-package',
+        version: '1.0.0',
+        'nx-migrations': {
+          packageGroup: [
+            { package: 'plugin-one', version: '*' },
+            { package: 'plugin-two', version: 'latest' },
+          ],
+        },
+      });
+      expect(results.misalignedPackages).toEqual([
+        {
+          name: 'plugin-one',
+          version: '0.5.0',
+        },
+      ]);
+      expect(results.migrateTarget).toEqual('my-package@1.0.0');
+    });
+
+    it('should identify misaligned packages for object specified package groups', () => {
+      jest.spyOn(packageJsonUtils, 'readModulePackageJson').mockImplementation(
+        provideMockPackages({
+          'plugin-one': {
+            'ng-update': {},
+            version: '0.5.0',
+          },
+          'plugin-two': {
+            schematics: '',
+            version: '2.0.0',
+          },
+        })
+      );
+      const results = findMisalignedPackagesForPackage({
+        name: 'my-package',
+        version: '1.0.0',
+        'nx-migrations': {
+          packageGroup: {
+            'plugin-one': '*',
+            'plugin-two': 'latest',
+          },
+        },
+      });
+      expect(results.misalignedPackages).toEqual([
+        {
+          name: 'plugin-one',
+          version: '0.5.0',
+        },
+      ]);
+      expect(results.migrateTarget).toEqual('my-package@1.0.0');
+    });
   });
 });
 
-// describe('report', () => {
-//   describe('findInstalledCommunityPlugins', () => {
-//     afterEach(() => jest.resetAllMocks());
-//
-//     it('should read angular-devkit plugins', () => {
-//       jest.spyOn(devkit, 'readJsonFile').mockImplementation((path) => {
-//         console.log(path);
-//         if (path === 'package.json') {
-//           return {
-//             dependencies: {
-//               'plugin-one': '1.0.0',
-//             },
-//             devDependencies: {
-//               'plugin-two': '2.0.0',
-//             },
-//           };
-//         } else if (
-//           path.includes(join('node_modules', 'plugin-one', 'package.json'))
-//         ) {
-//           return {
-//             'ng-update': {},
-//             version: '1.0.0',
-//           };
-//         } else if (
-//           path.includes(join('node_modules', 'plugin-two', 'package.json'))
-//         ) {
-//           return {
-//             schematics: {},
-//             version: '2.0.0',
-//           };
-//         }
-//       });
-//       const plugins = findInstalledCommunityPlugins();
-//       expect(plugins).toEqual([
-//         { package: 'plugin-one', version: '1.0.0' },
-//         { package: 'plugin-two', version: '2.0.0' },
-//       ]);
-//     });
-//
-//     it('should exclude misc @angluar packages', () => {
-//       jest.spyOn(devkit, 'readJsonFile').mockImplementation((path) => {
-//         if (path === 'package.json') {
-//           return {
-//             dependencies: {
-//               '@angular/cdk': '1.0.0',
-//             },
-//             devDependencies: {
-//               'plugin-two': '2.0.0',
-//             },
-//           };
-//         } else if (
-//           path.includes(join('node_modules', 'plugin-two', 'package.json'))
-//         ) {
-//           return {
-//             schematics: {},
-//             version: '1.0.0',
-//           };
-//         }
-//       });
-//       const plugins = findInstalledCommunityPlugins();
-//       expect(plugins).toEqual([{ package: 'plugin-two', version: '1.0.0' }]);
-//     });
-//
-//     it('should read nx devkit plugins', () => {
-//       jest.spyOn(devkit, 'readJsonFile').mockImplementation((path) => {
-//         if (path === 'package.json') {
-//           return {
-//             dependencies: {
-//               'plugin-one': '1.0.0',
-//             },
-//             devDependencies: {
-//               'plugin-two': '2.0.0',
-//             },
-//           };
-//         } else if (
-//           path.includes(join('node_modules', 'plugin-one', 'package.json'))
-//         ) {
-//           return {
-//             'nx-migrations': {},
-//             version: '1.0.0',
-//           };
-//         } else if (
-//           path.includes(join('node_modules', 'plugin-two', 'package.json'))
-//         ) {
-//           return {
-//             generators: {},
-//             version: '2.0.0',
-//           };
-//         }
-//       });
-//       const plugins = findInstalledCommunityPlugins();
-//       expect(plugins).toEqual([
-//         { package: 'plugin-one', version: '1.0.0' },
-//         { package: 'plugin-two', version: '2.0.0' },
-//       ]);
-//     });
-//
-//     it('should not include non-plugins', () => {
-//       jest.spyOn(devkit, 'readJsonFile').mockImplementation((path) => {
-//         if (path === 'package.json') {
-//           return {
-//             dependencies: {
-//               'plugin-one': '1.0.0',
-//             },
-//             devDependencies: {
-//               'plugin-two': '2.0.0',
-//               'other-package': '1.44.0',
-//             },
-//           };
-//         } else if (
-//           path.includes(join('node_modules', 'plugin-one', 'package.json'))
-//         ) {
-//           return {
-//             'nx-migrations': {},
-//           };
-//         } else if (
-//           path.includes(join('node_modules', 'plugin-two', 'package.json'))
-//         ) {
-//           return {
-//             generators: {},
-//           };
-//         } else {
-//           return {
-//             version: '',
-//           };
-//         }
-//       });
-//       const plugins = findInstalledCommunityPlugins().map((x) => x.package);
-//       expect(plugins).not.toContain('other-package');
-//     });
-//   });
-// });
+function provideMockPackages(
+  packages: Record<string, Omit<packageJsonUtils.PackageJson, 'name'>>
+): (m: string) => ReturnType<typeof packageJsonUtils.readModulePackageJson> {
+  return (m) => {
+    if (m in packages) {
+      return {
+        path: `node_modules/${m}/package.json`,
+        packageJson: { name: m, ...packages[m] },
+      };
+    } else {
+      throw new Error(`Attempted to read unmocked package ${m}`);
+    }
+  };
+}

--- a/packages/nx/src/command-line/report.ts
+++ b/packages/nx/src/command-line/report.ts
@@ -5,42 +5,32 @@ import { join } from 'path';
 import {
   detectPackageManager,
   getPackageManagerVersion,
+  PackageManager,
 } from '../utils/package-manager';
 import { readJsonFile } from '../utils/fileutils';
-import { PackageJson, readModulePackageJson } from '../utils/package-json';
+import {
+  PackageJson,
+  readModulePackageJson,
+  readNxMigrateConfig,
+} from '../utils/package-json';
 import { getLocalWorkspacePlugins } from '../utils/plugins/local-plugins';
 import {
   createProjectGraphAsync,
   readProjectsConfigurationFromProjectGraph,
 } from '../project-graph/project-graph';
+import { gt, valid } from 'semver';
+
+const nxPackageJson = readJsonFile<typeof import('../../package.json')>(
+  join(__dirname, '../../package.json')
+);
 
 export const packagesWeCareAbout = [
   'nx',
-  '@nrwl/angular',
-  '@nrwl/cypress',
-  '@nrwl/detox',
-  '@nrwl/devkit',
-  '@nrwl/esbuild',
-  '@nrwl/eslint-plugin-nx',
-  '@nrwl/expo',
-  '@nrwl/express',
-  '@nrwl/jest',
-  '@nrwl/js',
-  '@nrwl/linter',
-  '@nrwl/nest',
-  '@nrwl/next',
-  '@nrwl/node',
-  '@nrwl/nx-cloud',
-  '@nrwl/nx-plugin',
-  '@nrwl/react',
-  '@nrwl/react-native',
-  '@nrwl/rollup',
-  '@nrwl/schematics',
-  '@nrwl/storybook',
-  '@nrwl/web',
-  '@nrwl/webpack',
-  '@nrwl/workspace',
-  '@nrwl/vite',
+  'lerna',
+  ...nxPackageJson['nx-migrations'].packageGroup.map((x) =>
+    typeof x === 'string' ? x : x.package
+  ),
+  '@nrwl/schematics', // manually added since we don't publish it anymore.
   'typescript',
 ];
 
@@ -51,6 +41,7 @@ export const patternsWeIgnoreInCommunityReport: Array<string | RegExp> = [
   '@nestjs/schematics',
 ];
 
+const LINE_SEPARATOR = '---------------------------------------';
 /**
  * Reports relevant version numbers for adding to an Nx issue report
  *
@@ -60,8 +51,15 @@ export const patternsWeIgnoreInCommunityReport: Array<string | RegExp> = [
  *
  */
 export async function reportHandler() {
-  const pm = detectPackageManager();
-  const pmVersion = getPackageManagerVersion(pm);
+  const {
+    pm,
+    pmVersion,
+    localPlugins,
+    communityPlugins,
+    packageVersionsWeCareAbout,
+    outOfSyncPackageGroup,
+    projectGraphError,
+  } = await getReportData();
 
   const bodyLines = [
     `Node : ${process.versions.node}`,
@@ -70,33 +68,55 @@ export async function reportHandler() {
     ``,
   ];
 
-  packagesWeCareAbout.forEach((p) => {
-    bodyLines.push(`${chalk.green(p)} : ${chalk.bold(readPackageVersion(p))}`);
+  let padding =
+    Math.max(...packageVersionsWeCareAbout.map((x) => x.package.length)) + 1;
+  packageVersionsWeCareAbout.forEach((p) => {
+    bodyLines.push(
+      `${chalk.green(p.package.padEnd(padding))} : ${chalk.bold(p.version)}`
+    );
   });
 
-  bodyLines.push('---------------------------------------');
-
-  try {
-    const projectGraph = await createProjectGraphAsync({ exitOnError: true });
-    bodyLines.push('Local workspace plugins:');
-    const plugins = getLocalWorkspacePlugins(
-      readProjectsConfigurationFromProjectGraph(projectGraph)
-    ).keys();
-    for (const plugin of plugins) {
-      bodyLines.push(`\t ${chalk.green(plugin)}`);
-    }
-    bodyLines.push(...plugins);
-  } catch {
-    bodyLines.push('Unable to construct project graph');
+  if (communityPlugins.length) {
+    bodyLines.push(LINE_SEPARATOR);
+    padding = Math.max(...communityPlugins.map((x) => x.package.length)) + 1;
+    bodyLines.push('Community plugins:');
+    communityPlugins.forEach((p) => {
+      bodyLines.push(
+        `${chalk.green(p.package.padEnd(padding))}: ${chalk.bold(p.version)}`
+      );
+    });
   }
 
-  bodyLines.push('---------------------------------------');
+  if (localPlugins.length) {
+    bodyLines.push(LINE_SEPARATOR);
 
-  const communityPlugins = findInstalledCommunityPlugins();
-  bodyLines.push('Community plugins:');
-  communityPlugins.forEach((p) => {
-    bodyLines.push(`\t ${chalk.green(p.package)}: ${chalk.bold(p.version)}`);
-  });
+    bodyLines.push('Local workspace plugins:');
+
+    for (const plugin of localPlugins) {
+      bodyLines.push(`\t ${chalk.green(plugin)}`);
+    }
+  }
+
+  if (outOfSyncPackageGroup) {
+    bodyLines.push(LINE_SEPARATOR);
+    bodyLines.push(
+      `The following packages should match the installed version of ${outOfSyncPackageGroup.basePackage}`
+    );
+    for (const pkg of outOfSyncPackageGroup.misalignedPackages) {
+      bodyLines.push(`  - ${pkg.name}@${pkg.version}`);
+    }
+    bodyLines.push('');
+    bodyLines.push(
+      `To fix this, run \`nx migrate ${outOfSyncPackageGroup.migrateTarget}\``
+    );
+  }
+
+  if (projectGraphError) {
+    bodyLines.push(LINE_SEPARATOR);
+    bodyLines.push('⚠️ Unable to construct project graph.');
+    bodyLines.push(projectGraphError.message);
+    bodyLines.push(projectGraphError.stack);
+  }
 
   output.log({
     title: 'Report complete - copy this into the issue template',
@@ -104,7 +124,71 @@ export async function reportHandler() {
   });
 }
 
-export function readPackageJson(p: string): PackageJson | null {
+export interface ReportData {
+  pm: PackageManager;
+  pmVersion: string;
+  localPlugins: string[];
+  communityPlugins: (PackageJson & {
+    package: string;
+  })[];
+  packageVersionsWeCareAbout: {
+    package: string;
+    version: string;
+  }[];
+  outOfSyncPackageGroup?: {
+    basePackage: string;
+    misalignedPackages: {
+      name: string;
+      version: string;
+    }[];
+    migrateTarget: string;
+  };
+  projectGraphError?: Error | null;
+}
+
+export async function getReportData(): Promise<ReportData> {
+  const pm = detectPackageManager();
+  const pmVersion = getPackageManagerVersion(pm);
+
+  const localPlugins = await findLocalPlugins();
+  const communityPlugins = findInstalledCommunityPlugins();
+
+  let projectGraphError: Error | null = null;
+  try {
+    await createProjectGraphAsync();
+  } catch (e) {
+    projectGraphError = e;
+  }
+
+  const packageVersionsWeCareAbout = findInstalledPackagesWeCareAbout();
+
+  const outOfSyncPackageGroup = findMisalignedPackagesForPackage(nxPackageJson);
+
+  return {
+    pm,
+    pmVersion,
+    localPlugins,
+    communityPlugins,
+    packageVersionsWeCareAbout,
+    outOfSyncPackageGroup,
+    projectGraphError,
+  };
+}
+
+async function findLocalPlugins() {
+  try {
+    const projectGraph = await createProjectGraphAsync({ exitOnError: true });
+    return Array.from(
+      getLocalWorkspacePlugins(
+        readProjectsConfigurationFromProjectGraph(projectGraph)
+      ).keys()
+    );
+  } catch {
+    return [];
+  }
+}
+
+function readPackageJson(p: string): PackageJson | null {
   try {
     return readModulePackageJson(p).packageJson;
   } catch {
@@ -112,14 +196,58 @@ export function readPackageJson(p: string): PackageJson | null {
   }
 }
 
-export function readPackageVersion(p: string): string {
-  return readPackageJson(p)?.version || 'Not Found';
+function readPackageVersion(p: string): string | null {
+  return readPackageJson(p)?.version;
 }
 
-export function findInstalledCommunityPlugins(): {
+interface OutOfSyncPackageGroup {
+  basePackage: string;
+  misalignedPackages: {
+    name: string;
+    version: string;
+  }[];
+  migrateTarget: string;
+}
+
+export function findMisalignedPackagesForPackage(
+  base: PackageJson
+): undefined | OutOfSyncPackageGroup {
+  const misalignedPackages: { name: string; version: string }[] = [];
+
+  let migrateTarget = base.version;
+
+  const { packageGroup } = readNxMigrateConfig(base);
+
+  for (const entry of packageGroup ?? []) {
+    const { package: packageName, version } = entry;
+    // should be aligned
+    if (version === '*') {
+      const installedVersion = readPackageVersion(packageName);
+
+      if (installedVersion && installedVersion !== base.version) {
+        if (valid(installedVersion) && gt(installedVersion, migrateTarget)) {
+          migrateTarget = installedVersion;
+        }
+        misalignedPackages.push({
+          name: packageName,
+          version: installedVersion,
+        });
+      }
+    }
+  }
+
+  return misalignedPackages.length
+    ? {
+        basePackage: base.name,
+        misalignedPackages,
+        migrateTarget: `${base.name}@${migrateTarget}`,
+      }
+    : undefined;
+}
+
+export function findInstalledCommunityPlugins(): (PackageJson & {
   package: string;
-  version: string;
-}[] {
+})[] {
   const { dependencies, devDependencies } = readJsonFile(
     join(workspaceRoot, 'package.json')
   );
@@ -152,7 +280,7 @@ export function findInstalledCommunityPlugins(): {
             'executors',
           ].some((field) => field in depPackageJson)
         ) {
-          arr.push({ package: nextDep, version: depPackageJson.version });
+          arr.push({ package: nextDep, ...depPackageJson });
           return arr;
         } else {
           return arr;
@@ -164,4 +292,13 @@ export function findInstalledCommunityPlugins(): {
     },
     []
   );
+}
+export function findInstalledPackagesWeCareAbout() {
+  return packagesWeCareAbout.reduce((acc, next) => {
+    const v = readPackageVersion(next);
+    if (v) {
+      acc.push({ package: next, version: v });
+    }
+    return acc;
+  }, [] as { package: string; version: string }[]);
 }


### PR DESCRIPTION
## Current Behavior
This PR addresses the following behavior's:

1. Prior to version 15.6, `nx workspace-lint` would list packages that were misaligned. Since `workspace-lint` has now been deprecated, this would no longer be the case.
2. `nx report` contained empty sections for community plugins and local plugins if there were none present
3. `nx report`'s output was growing quite a bit as we add more first party plugins and more folks use community plugins


## Expected Behavior
The corresponding new behavior's: 


1. `nx report` shows any misalignment in new sections at the bottom, with remediation instructions
2. `nx report` hides empty sections for community plugins and local plugins if there were none present
3. `nx report`' hides uninstalled plugins, even if we care about them

## Sample Output

```shell
> nx report

 >  NX   Report complete - copy this into the issue template

   Node : 18.12.1
   OS   : linux x64
   yarn : 1.22.19
   
   nx            : 0.0.1
   lerna         : 6.0.0
   @nrwl/cli     : 15.6.0-beta.1
   @nrwl/cypress : 15.6.0-beta.1
   @nrwl/devkit  : 15.6.0-beta.1
   @nrwl/eslint-plugin-nx : 15.6.0-beta.1
   @nrwl/jest    : 15.6.0-beta.1
   @nrwl/js      : 15.6.0-beta.1
   @nrwl/linter  : 15.6.0-beta.1
   @nrwl/next    : 15.6.0-beta.1
   @nrwl/react   : 15.6.0-beta.1
   @nrwl/rollup  : 15.6.0-beta.1
   @nrwl/storybook : 15.6.0-beta.1
   @nrwl/tao     : 15.6.0-beta.1
   @nrwl/web     : 15.6.0-beta.1
   @nrwl/webpack : 15.6.0-beta.1
   @nrwl/workspace : 15.6.0-beta.1
   @nrwl/nx-cloud : 15.0.2
   typescript    : 4.8.4
   ---------------------------------------
   Community plugins:
   @ngrx/effects: 15.0.0
   @ngrx/router-store: 15.0.0
   @ngrx/store : 15.0.0
   @nguniversal/builders: 15.1.0
   @storybook/angular: 6.5.15
   rxjs        : 6.6.7
   ---------------------------------------
   Local workspace plugins:
         @nrwl/react-native
         @nrwl/nx-plugin
         @nrwl/storybook
         @nrwl/workspace
         @nrwl/angular
         @nrwl/cypress
         @nrwl/esbuild
         @nrwl/express
         @nrwl/webpack
         @nrwl/linter
         @nrwl/rollup
         @nrwl/detox
         @nrwl/react
         @nrwl/expo
         @nrwl/jest
         @nrwl/nest
         @nrwl/next
         @nrwl/node
         @nrwl/vite
         @nrwl/web
         @nrwl/js
         nx
   ---------------------------------------
   The following packages should match the installed version of nx
   - @nrwl/cli@15.6.0-beta.1
   - @nrwl/cypress@15.6.0-beta.1
   - @nrwl/devkit@15.6.0-beta.1
   - @nrwl/eslint-plugin-nx@15.6.0-beta.1
   
   To fix this, run `nx migrate nx@15.6.0-beta.1`
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
