### PR TITLE
fix(core): gitlab should be included in ci-workflow ci schema

### DIFF
--- a/docs/generated/packages/workspace/generators/ci-workflow.json
+++ b/docs/generated/packages/workspace/generators/ci-workflow.json
@@ -12,7 +12,13 @@
       "ci": {
         "type": "string",
         "description": "CI provider.",
-        "enum": ["github", "circleci", "azure", "bitbucket-pipelines"],
+        "enum": [
+          "github",
+          "circleci",
+          "azure",
+          "bitbucket-pipelines",
+          "gitlab"
+        ],
         "x-prompt": {
           "message": "What is your target CI provider?",
           "type": "list",

--- a/packages/workspace/src/generators/ci-workflow/schema.json
+++ b/packages/workspace/src/generators/ci-workflow/schema.json
@@ -9,7 +9,7 @@
     "ci": {
       "type": "string",
       "description": "CI provider.",
-      "enum": ["github", "circleci", "azure", "bitbucket-pipelines"],
+      "enum": ["github", "circleci", "azure", "bitbucket-pipelines", "gitlab"],
       "x-prompt": {
         "message": "What is your target CI provider?",
         "type": "list",


### PR DESCRIPTION
## Current Behavior
Passing --ci=gitlab fails due to gitlab not existing in the generator schema

## Expected Behavior
Gitlab CI should be generated


Fixes #14632 
