### PR TITLE
feat(angular): support nx init for Angular 14+

### DIFF
--- a/packages/make-angular-cli-faster/src/utilities/make-angular-cli-faster.ts
+++ b/packages/make-angular-cli-faster/src/utilities/make-angular-cli-faster.ts
@@ -36,9 +36,9 @@ export async function makeAngularCliFaster(args: Args) {
   }
 
   output.success({
-    title: '🎉 Angular CLI is faster now!',
+    title: '🎉 Nx is now enabled in your workspace!',
     bodyLines: [
-      `Execute 'npx ng build' twice to see the computation caching in action.`,
+      `Execute 'npx nx build' twice to see the computation caching in action.`,
       'Learn more about the changes done to your workspace at https://nx.dev/recipes/adopting-nx/migration-angular.',
     ],
   });

--- a/packages/make-angular-cli-faster/src/utilities/migration.ts
+++ b/packages/make-angular-cli-faster/src/utilities/migration.ts
@@ -15,7 +15,7 @@ const latestVersionWithOldFlag = '13.8.3';
 // versions
 const nxAngularVersionMap: Record<number, { min: string; max?: string }> = {
   13: { min: '13.2.0', max: '~14.1.0' },
-  14: { min: '14.2.0', max: '~15.1.0' },
+  14: { min: '14.2.0' },
   15: { min: '15.2.0' },
 };
 // latest major version of Angular that is compatible with Nx, based on the map above


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
Currently Nx Init will not install latest Nx for Angular 14 workspaces.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
It should install latest nx for Angular 14+ workspaces

