### PR TITLE
fix(react): install @nrwl/web when module federation is used

### DIFF
--- a/packages/react/src/generators/host/host.spec.ts
+++ b/packages/react/src/generators/host/host.spec.ts
@@ -28,6 +28,20 @@ describe('hostGenerator', () => {
     expect(tree.exists('apps/test/src/remotes.d.ts'));
   });
 
+  it('should install @nrwl/web for the file-server executor', async () => {
+    const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    await hostGenerator(tree, {
+      name: 'test',
+      style: 'css',
+      linter: Linter.None,
+      unitTestRunner: 'none',
+      e2eTestRunner: 'none',
+    });
+
+    const packageJson = readJson(tree, 'package.json');
+    expect(packageJson.devDependencies['@nrwl/web']).toBeDefined();
+  });
+
   it('should generate host files and configs for SSR', async () => {
     await hostGenerator(tree, {
       name: 'test',

--- a/packages/react/src/generators/remote/remote.spec.ts
+++ b/packages/react/src/generators/remote/remote.spec.ts
@@ -1,12 +1,27 @@
-import { readNxJson } from '@nrwl/devkit';
+import { readJson, readNxJson } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import remote from './remote';
 
 describe('remote generator', () => {
+  it('should install @nrwl/web for the file-server executor', async () => {
+    const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    await remote(tree, {
+      name: 'test',
+      devServerPort: 4201,
+      e2eTestRunner: 'cypress',
+      linter: Linter.EsLint,
+      skipFormat: false,
+      style: 'css',
+      unitTestRunner: 'jest',
+    });
+
+    const packageJson = readJson(tree, 'package.json');
+    expect(packageJson.devDependencies['@nrwl/web']).toBeDefined();
+  });
+
   it('should not set the remote as the default project', async () => {
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-
     await remote(tree, {
       name: 'test',
       devServerPort: 4201,

--- a/packages/react/src/rules/update-module-federation-project.ts
+++ b/packages/react/src/rules/update-module-federation-project.ts
@@ -1,8 +1,11 @@
 import {
+  addDependenciesToPackageJson,
+  GeneratorCallback,
   readProjectConfiguration,
   Tree,
   updateProjectConfiguration,
 } from '@nrwl/devkit';
+import { nxVersion } from '../utils/versions';
 
 export function updateModuleFederationProject(
   host: Tree,
@@ -11,7 +14,7 @@ export function updateModuleFederationProject(
     appProjectRoot: string;
     devServerPort?: number;
   }
-) {
+): GeneratorCallback {
   const projectConfig = readProjectConfiguration(host, options.projectName);
 
   projectConfig.targets.build.options = {
@@ -48,4 +51,6 @@ export function updateModuleFederationProject(
   };
 
   updateProjectConfiguration(host, options.projectName, projectConfig);
+
+  return addDependenciesToPackageJson(host, {}, { '@nrwl/web': nxVersion });
 }


### PR DESCRIPTION
Module federation for React uses `@nrwl/web:file-server` to statically serve remote apps. Now that `@nrwl/react` no longer has a hard dependency on the web plugin, we need to install it when using `@nrwl/react:host` or `@nrwl/react:remote` generators.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Related #14629
