### PR TITLE
feat(node): update app generator for fastify to be more inline with fastify cli

### DIFF
--- a/packages/node/src/generators/application/files/fastify/src/app/app.ts__tmpl__
+++ b/packages/node/src/generators/application/files/fastify/src/app/app.ts__tmpl__
@@ -1,0 +1,11 @@
+import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+
+/* eslint-disable-next-line */
+export interface AppOptions {
+}
+
+export async function app(fastify: FastifyInstance, opts: AppOptions) {
+  fastify.get('/', async function(request: FastifyRequest, reply: FastifyReply) {
+    return { message: 'Hello API' };
+  });
+}

--- a/packages/node/src/generators/application/files/fastify/src/main.ts__tmpl__
+++ b/packages/node/src/generators/application/files/fastify/src/main.ts__tmpl__
@@ -1,22 +1,23 @@
-import fastify from 'fastify';
+import Fastify from 'fastify';
+import { app } from './app/app';
 
 const host = process.env.HOST ?? 'localhost';
 const port = process.env.PORT ? Number(process.env.PORT) : <%= port %>;
 
-const app = fastify();
-
-app.get('/', async (req, res) => {
-    return { 'message': 'Hello API'};
+// Instantiate Fastify with some config
+const server = Fastify({
+  logger: true,
 });
 
-const start = async() => {
-    try {
-        await app.listen({ host, port });
-        console.log(`[ ready ] http://${host}:${port}`);
-    } catch (err) {
-        // Errors are logged here
-        process.exit(1);
-    }
-}
+// Register your application as a normal plugin.
+server.register(app);
 
-start();
+// Start listening.
+server.listen({ port, host }, (err) => {
+  if (err) {
+    server.log.error(err);
+    process.exit(1);
+  } else {
+    console.log(`[ ready ] http://${host}:${port}`);
+  }
+});


### PR DESCRIPTION
This PR extracts the app (with `/` route) into its own plugin. The `main.ts` file now registers the app plugin.