### PR TITLE
cleanup(misc): reenable cypress component tests e2e tests

### DIFF
--- a/e2e/angular-extensions/src/cypress-component-tests.test.ts
+++ b/e2e/angular-extensions/src/cypress-component-tests.test.ts
@@ -10,8 +10,7 @@ import {
 } from '../../utils';
 import { names } from '@nrwl/devkit';
 
-// TODO(leo): reenable once https://github.com/cypress-io/cypress/issues/25568 is addressed
-xdescribe('Angular Cypress Component Tests', () => {
+describe('Angular Cypress Component Tests', () => {
   let projectName: string;
   const appName = uniq('cy-angular-app');
   const usedInAppLibName = uniq('cy-angular-lib');

--- a/e2e/react/src/cypress-component-tests.test.ts
+++ b/e2e/react/src/cypress-component-tests.test.ts
@@ -9,8 +9,7 @@ import {
   updateProjectConfig,
 } from '../../utils';
 
-// TODO(leo): reenable once https://github.com/cypress-io/cypress/issues/25568 is addressed
-xdescribe('React Cypress Component Tests', () => {
+describe('React Cypress Component Tests', () => {
   let projectName;
   const appName = uniq('cy-react-app');
   const usedInAppLibName = uniq('cy-react-lib');
@@ -222,16 +221,24 @@ ${content}`;
     // are they overriding some option on top of each other causing cypress to not see it's running?
     createFile(
       `apps/${appName}/webpack.config.js`,
-      `module.exports = async function (configuration) {
-  await new Promise((res) => {
-    setTimeout(() => {
-      console.log('I am from the custom async Webpack config')
-      res()
-    }, 1000)
-  })
-  const defaultConfig = require("@nrwl/react/plugins/webpack")
-  return defaultConfig(configuration);
-};`
+      `
+        const { composePlugins, withNx } = require('@nrwl/webpack');
+        const { withReact } = require('@nrwl/react');
+        
+        module.exports = composePlugins(
+          withNx(),
+          withReact(),
+          async function (configuration) {
+            await new Promise((res) => {
+              setTimeout(() => {
+                console.log('I am from the custom async Webpack config');
+                res();
+              }, 1000);
+            });
+            return configuration;
+          }
+        );
+      `
     );
     updateProjectConfig(appName, (config) => {
       config.targets[


### PR DESCRIPTION
Reenable the cypress component tests e2e tests that were previously disabled in https://github.com/nrwl/nx/pull/14608. The fix for Cypress was released in [v12.4.1](https://docs.cypress.io/guides/references/changelog#12-4-1).