### PR TITLE
feat(devkit): add method to read installed Nx version

### DIFF
--- a/docs/generated/devkit/nrwl_devkit.md
+++ b/docs/generated/devkit/nrwl_devkit.md
@@ -128,6 +128,7 @@ It only uses language primitives and immutable objects
 
 ### Utils Variables
 
+- [NX_VERSION](../../devkit/documents/nrwl_devkit#nx_version)
 - [appRootPath](../../devkit/documents/nrwl_devkit#approotpath)
 - [cacheDir](../../devkit/documents/nrwl_devkit#cachedir)
 - [output](../../devkit/documents/nrwl_devkit#output)
@@ -793,6 +794,12 @@ Implementation of a target of a project that handles multiple projects to be bat
 ---
 
 ## Utils Variables
+
+### NX_VERSION
+
+• **NX_VERSION**: `string`
+
+---
 
 ### appRootPath
 

--- a/docs/generated/packages/devkit/documents/nrwl_devkit.md
+++ b/docs/generated/packages/devkit/documents/nrwl_devkit.md
@@ -128,6 +128,7 @@ It only uses language primitives and immutable objects
 
 ### Utils Variables
 
+- [NX_VERSION](../../devkit/documents/nrwl_devkit#nx_version)
 - [appRootPath](../../devkit/documents/nrwl_devkit#approotpath)
 - [cacheDir](../../devkit/documents/nrwl_devkit#cachedir)
 - [output](../../devkit/documents/nrwl_devkit#output)
@@ -793,6 +794,12 @@ Implementation of a target of a project that handles multiple projects to be bat
 ---
 
 ## Utils Variables
+
+### NX_VERSION
+
+• **NX_VERSION**: `string`
+
+---
 
 ### appRootPath
 

--- a/packages/devkit/public-api.ts
+++ b/packages/devkit/public-api.ts
@@ -50,6 +50,7 @@ export {
   addDependenciesToPackageJson,
   ensurePackage,
   removeDependenciesFromPackageJson,
+  NX_VERSION,
 } from './src/utils/package-json';
 
 /**

--- a/packages/devkit/src/utils/package-json.ts
+++ b/packages/devkit/src/utils/package-json.ts
@@ -454,3 +454,8 @@ function getPackageVersion(pkg: string): undefined | string {
     return undefined;
   }
 }
+
+/**
+ * @description The version of Nx used by the workspace. Returns null if no version is found.
+ */
+export const NX_VERSION = getPackageVersion('nx');


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
- There is no common way to read the installed Nx version
- There is no standard way for community plugin authors to check the versions of installed packages

## Expected Behavior
- There are utils within `nx` that we use frequently throughout our own plugins for this, and they have existed for 14 months (as of 1/27/2023), which would be helpful for plugin authors. This PR exposes them, but wrapped with small functions s.t. we still have the option to decouple it from `nx` as needed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
