### PR TITLE
fix(webpack): config migrations should account for different configurations

### DIFF
--- a/packages/react/src/migrations/update-15-6-3/__snapshots__/webpack-config-setup.spec.ts.snap
+++ b/packages/react/src/migrations/update-15-6-3/__snapshots__/webpack-config-setup.spec.ts.snap
@@ -9,6 +9,8 @@ exports[`15.6.3 migration (setup webpack.config file for React apps) should crea
           module.exports = composePlugins(withNx(), withReact(), (config, { options, context }) => {
             // Update the webpack config as needed here.
             // e.g. config.plugins.push(new MyPlugin())
+            // For more information on webpack config and Nx see:
+            // https://nx.dev/packages/webpack/documents/webpack-config-setup
             return config;
           });
         "
@@ -23,6 +25,8 @@ exports[`15.6.3 migration (setup webpack.config file for React apps) should crea
           module.exports = composePlugins(withNx(), withReact(), (config, { options, context }) => {
             // Update the webpack config as needed here.
             // e.g. config.plugins.push(new MyPlugin())
+            // For more information on webpack config and Nx see:
+            // https://nx.dev/packages/webpack/documents/webpack-config-setup
             return config;
           });
         "
@@ -37,6 +41,8 @@ exports[`15.6.3 migration (setup webpack.config file for React apps) should crea
           module.exports = composePlugins(withNx(), withReact(), (config, { options, context }) => {
             // Update the webpack config as needed here.
             // e.g. config.plugins.push(new MyPlugin())
+            // For more information on webpack config and Nx see:
+            // https://nx.dev/packages/webpack/documents/webpack-config-setup
             return config;
           });
         "
@@ -51,6 +57,8 @@ exports[`15.6.3 migration (setup webpack.config file for React apps) should crea
             module.exports = composePlugins(withNx(), withReact(), (config, { options, context }) => {
               // Note: This was added by an Nx migration.
               // You should consider inlining the logic into this file.
+              // For more information on webpack config and Nx see:
+              // https://nx.dev/packages/webpack/documents/webpack-config-setup
               return require('./webpack.something.old.ts')(config, context);
             });
             "

--- a/packages/webpack/src/migrations/update-15-6-3/__snapshots__/webpack-config-setup.spec.ts.snap
+++ b/packages/webpack/src/migrations/update-15-6-3/__snapshots__/webpack-config-setup.spec.ts.snap
@@ -8,6 +8,8 @@ exports[`15.6.3 migration (setup webpack.config file) should create webpack.conf
         module.exports = composePlugins(withNx(), (config) => {
           // Update the webpack config as needed here.
           // e.g. config.plugins.push(new MyPlugin())
+          // For more information on webpack config and Nx see:
+          // https://nx.dev/packages/webpack/documents/webpack-config-setup
           return config;
         });
         "
@@ -21,6 +23,8 @@ exports[`15.6.3 migration (setup webpack.config file) should create webpack.conf
         module.exports = composePlugins(withNx(), (config) => {
           // Update the webpack config as needed here.
           // e.g. config.plugins.push(new MyPlugin())
+          // For more information on webpack config and Nx see:
+          // https://nx.dev/packages/webpack/documents/webpack-config-setup
           return config;
         });
         "
@@ -34,6 +38,8 @@ exports[`15.6.3 migration (setup webpack.config file) should rename existing web
         module.exports = composePlugins(withNx(), (config, { options, context }) => {
           // Note: This was added by an Nx migration.
           // You should consider inlining the logic into this file.
+          // For more information on webpack config and Nx see:
+          // https://nx.dev/packages/webpack/documents/webpack-config-setup
           return require('./webpack.config.old.js')(config, context);
         });
         "
@@ -47,6 +53,8 @@ exports[`15.6.3 migration (setup webpack.config file) should rename existing web
         module.exports = composePlugins(withNx(), (config, { options, context }) => {
           // Note: This was added by an Nx migration.
           // You should consider inlining the logic into this file.
+          // For more information on webpack config and Nx see:
+          // https://nx.dev/packages/webpack/documents/webpack-config-setup
           return require('./webpack.something.old.ts')(config, context);
         });
         "

--- a/packages/webpack/src/migrations/update-15-6-3/webpack-config-setup.spec.ts
+++ b/packages/webpack/src/migrations/update-15-6-3/webpack-config-setup.spec.ts
@@ -11,7 +11,78 @@ describe('15.6.3 migration (setup webpack.config file)', () => {
 
   beforeEach(async () => {
     tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  });
 
+  it('should create webpack.config.js for projects that do not have one', async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      targets: {
+        build: {
+          executor: '@nrwl/webpack:webpack',
+          options: {},
+        },
+      },
+    });
+    addProjectConfiguration(tree, 'app2', {
+      root: 'apps/app2',
+      targets: {
+        custom: {
+          executor: '@nrwl/webpack:webpack',
+          options: {},
+        },
+      },
+    });
+
+    await webpackConfigSetup(tree);
+
+    expect(tree.read('apps/app1/webpack.config.js', 'utf-8')).toMatchSnapshot();
+    expect(tree.read('apps/app2/webpack.config.js', 'utf-8')).toMatchSnapshot();
+  });
+
+  it('should rename existing webpack.config file and create new one that requires it', async () => {
+    addProjectConfiguration(tree, 'app3', {
+      root: 'apps/app3',
+      targets: {
+        custom: {
+          executor: '@nrwl/webpack:webpack',
+          options: {
+            webpackConfig: 'apps/app3/webpack.config.js',
+          },
+        },
+      },
+    });
+    tree.write('apps/app3/webpack.config.js', 'some content');
+
+    addProjectConfiguration(tree, 'app4', {
+      root: 'apps/app4',
+      targets: {
+        custom: {
+          executor: '@nrwl/webpack:webpack',
+          options: {
+            webpackConfig: 'some/random/path/webpack.something.ts',
+          },
+        },
+      },
+    });
+    tree.write('some/random/path/webpack.something.ts', 'some content');
+
+    await webpackConfigSetup(tree);
+
+    expect(tree.read('apps/app3/webpack.config.js', 'utf-8')).toMatchSnapshot();
+    expect(
+      tree.read('apps/app3/webpack.config.old.js', 'utf-8')
+    ).toMatchInlineSnapshot(`"some content"`);
+
+    expect(
+      tree.read('some/random/path/webpack.something.ts', 'utf-8')
+    ).toMatchSnapshot();
+
+    expect(
+      tree.read('some/random/path/webpack.something.old.ts', 'utf-8')
+    ).toMatchInlineSnapshot(`"some content"`);
+  });
+
+  it('should update the project configuration - executor options', async () => {
     addProjectConfiguration(tree, 'app1', {
       root: 'apps/app1',
       targets: {
@@ -56,69 +127,10 @@ describe('15.6.3 migration (setup webpack.config file)', () => {
         },
       },
     });
-
     tree.write('some/random/path/webpack.something.ts', 'some content');
 
-    addProjectConfiguration(tree, 'app5', {
-      root: 'apps/app5',
-      targets: {
-        custom: {
-          executor: '@nrwl/webpack:webpack',
-          options: {
-            isolatedConfig: true,
-          },
-        },
-      },
-    });
-
-    addProjectConfiguration(tree, 'app6', {
-      root: 'apps/app6',
-      targets: {
-        custom: {
-          executor: '@nrwl/webpack:webpack',
-          options: {
-            webpackConfig: '@nrwl/react/plugins/webpack',
-          },
-        },
-      },
-    });
-
-    addProjectConfiguration(tree, 'app7', {
-      root: 'apps/app7',
-      targets: {
-        custom: {
-          executor: '@nrwl/webpack:webpack',
-          options: {
-            main: 'apps/app7/src/main.tsx',
-          },
-        },
-      },
-    });
-
     await webpackConfigSetup(tree);
-  });
 
-  it('should create webpack.config.js for projects that do not have one', () => {
-    expect(tree.read('apps/app1/webpack.config.js', 'utf-8')).toMatchSnapshot();
-    expect(tree.read('apps/app2/webpack.config.js', 'utf-8')).toMatchSnapshot();
-  });
-
-  it('should rename existing webpack.config file and create new one that requires it', () => {
-    expect(tree.read('apps/app3/webpack.config.js', 'utf-8')).toMatchSnapshot();
-    expect(
-      tree.read('apps/app3/webpack.config.old.js', 'utf-8')
-    ).toMatchInlineSnapshot(`"some content"`);
-
-    expect(
-      tree.read('some/random/path/webpack.something.ts', 'utf-8')
-    ).toMatchSnapshot();
-
-    expect(
-      tree.read('some/random/path/webpack.something.old.ts', 'utf-8')
-    ).toMatchInlineSnapshot(`"some content"`);
-  });
-
-  it('should update the project configuration - executor options', () => {
     expect(
       readProjectConfiguration(tree, 'app1').targets.build.options.webpackConfig
     ).toBe('apps/app1/webpack.config.js');
@@ -157,12 +169,119 @@ describe('15.6.3 migration (setup webpack.config file)', () => {
     ).toBeTruthy();
   });
 
-  it('should not do anything if isolatedConfig is true', () => {
+  it('should not do anything if isolatedConfig is true', async () => {
+    addProjectConfiguration(tree, 'app5', {
+      root: 'apps/app5',
+      targets: {
+        custom: {
+          executor: '@nrwl/webpack:webpack',
+          options: {
+            isolatedConfig: true,
+          },
+        },
+      },
+    });
+
+    await webpackConfigSetup(tree);
+
     expect(tree.exists('apps/app5/webpack.config.js')).toBeFalsy();
   });
 
-  it('should not do anything if project is react', () => {
+  it('should not do anything if project is react', async () => {
+    addProjectConfiguration(tree, 'app6', {
+      root: 'apps/app6',
+      targets: {
+        custom: {
+          executor: '@nrwl/webpack:webpack',
+          options: {
+            webpackConfig: '@nrwl/react/plugins/webpack',
+          },
+        },
+      },
+    });
+
+    addProjectConfiguration(tree, 'app7', {
+      root: 'apps/app7',
+      targets: {
+        custom: {
+          executor: '@nrwl/webpack:webpack',
+          options: {
+            main: 'apps/app7/src/main.tsx',
+          },
+        },
+      },
+    });
+
+    await webpackConfigSetup(tree);
+
     expect(tree.exists('apps/app6/webpack.config.js')).toBeFalsy();
     expect(tree.exists('apps/app7/webpack.config.js')).toBeFalsy();
+  });
+
+  it('should migrate configurations (dev, prod, etc.) with webpackConfig but ignore ones without it', async () => {
+    addProjectConfiguration(tree, 'myapp', {
+      root: 'apps/myapp',
+      targets: {
+        build: {
+          executor: '@nrwl/webpack:webpack',
+          options: {
+            main: 'apps/myapp/src/main.ts',
+            webpackConfig: 'apps/myapp/webpack.config.js',
+          },
+          configurations: {
+            foo: {},
+            bar: {
+              webpackConfig: 'apps/myapp/webpack.config.bar.js',
+            },
+          },
+        },
+      },
+    });
+    tree.write('apps/myapp/webpack.config.js', 'default');
+    tree.write('apps/myapp/webpack.config.bar.js', 'bar');
+
+    addProjectConfiguration(tree, 'alreadymigrated', {
+      root: 'apps/alreadymigrated',
+      targets: {
+        build: {
+          executor: '@nrwl/webpack:webpack',
+          options: {
+            isolatedConfig: true,
+            main: 'apps/alreadymigrated/src/main.ts',
+            webpackConfig: 'apps/alreadymigrated/webpack.config.js',
+          },
+          configurations: {
+            foo: {},
+            bar: {
+              webpackConfig: 'apps/alreadymigrated/webpack.config.bar.js',
+            },
+          },
+        },
+      },
+    });
+    tree.write('apps/alreadymigrated/webpack.config.js', 'default');
+    tree.write('apps/alreadymigrated/webpack.config.bar.js', 'bar');
+
+    await webpackConfigSetup(tree);
+
+    expect(tree.read('apps/myapp/webpack.config.old.js', 'utf-8')).toContain(
+      'default'
+    );
+    expect(
+      tree.read('apps/myapp/webpack.config.bar.old.js', 'utf-8')
+    ).toContain('bar');
+
+    expect(
+      tree.read('apps/alreadymigrated/webpack.config.js', 'utf-8')
+    ).toContain('default');
+    expect(
+      tree.read('apps/alreadymigrated/webpack.config.bar.js', 'utf-8')
+    ).toContain('bar');
+    expect(
+      tree.exists('apps/alreadymigrated/webpack.config.old.js')
+    ).toBeFalsy();
+    expect(
+      tree.exists('apps/alreadymigrated/webpack.config.bar.old.js')
+    ).toBeFalsy();
   });
 });


### PR DESCRIPTION
This PR fixes an issue where different configurations (e.g. `deveopment` and `production`) can mess up migrations between `@nrwl/webpack` and `@nrwl/react`.

For example, `@nrwl/react` migrates a custom `webpack.config.js` correctly, but now `@nrwl/webpack` looks at the options, which is like this:

```
build: {
  ...
  "options": {
     "isolatedConfig": true,
     "main": "myapp/main.tsx",
    "webpackConfig": "myapp/webpack.alreadymigrated.config.js"
  },
  "configurations": {
     "production": {
        "webpackConfig": "myapp/webpack.alreadymigrated.prod.config.js"
      }
  }
```

And for `production` configuration, the new `isolatedConfig` flag is not set, and there is a custom `webpackConfig` so `@nrwl/webpack` performs a migration that isn't needed.

The fix is make sure we keep track of the default options, and if the default options need to be migrated, then other configurations may also need to be migrated. If the default options do not need a migration, then skip the rest of the configurations.

## Notes

- The check for `main.tsx` needs to be on default options, because each configuration will likely not provide a different `main` option.
- Updating project configuration should update the `options` field for default options, or `<configurationName>` for things like `development` and `production`.
- Isolated each test case to set up required projects, rather than having everything shared in `beforeEach`.
- Two new test cases were added to check the configuration case (one in webpack, one in React).
