### PR TITLE
(fix) Temp workaround for supporting virtual modules

### DIFF
--- a/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
+++ b/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
@@ -41,11 +41,19 @@ export async function* esbuildExecutor(
 
   const externalDependencies: DependentBuildableProjectNode[] =
     options.external.map((name) => {
-      const externalNode = context.projectGraph.externalNodes[`npm:${name}`];
-      if (!externalNode)
-        throw new Error(
-          `Cannot find external dependency ${name}. Check your package.json file.`
-        );
+      let externalNode = context.projectGraph.externalNodes[`npm:${name}`];
+      
+      if (!externalNode) {
+          externalNode = {
+             type: '',
+             name: '',
+            data: {
+            version: '',
+            packageName: `${name}`,
+            hash: ''
+          }
+        } 
+      }
       return {
         name,
         outputs: [],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When I try to exclude a virtual dependency into the bundler it gives me out
**Cannot find external dependency "dependency". Check your package.json file.**

## Expected Behavior
To just exclude that dependency from being bundled

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
It's just a temp work around i mocked externalNode and I get the expected behaviour

My output as proof of concept
```js
var r=(o,l)=>()=>(l||o((l={exports:{}}).exports,l),l.exports);import m from"alt-client";var t=r(()=>{m.log("Hello World!")});export default t();
```