### PR TITLE
fix(devkit): adjust behavior of the "addDependenciesToPackageJson" function

### DIFF
--- a/packages/devkit/src/utils/package-json.spec.ts
+++ b/packages/devkit/src/utils/package-json.spec.ts
@@ -209,6 +209,80 @@ describe('addDependenciesToPackageJson', () => {
     expect(installTask).toBeDefined();
   });
 
+  it('should not overwrite dependencies when they exist in "dependencies" and one of the versions is lesser', () => {
+    // ARRANGE
+    writeJson(tree, 'package.json', {
+      dependencies: {
+        '@nrwl/angular': '14.2.0',
+        '@nrwl/cypress': '14.1.1',
+      },
+      devDependencies: {
+        '@nrwl/next': '14.0.0',
+        '@nrwl/vite': '14.1.0',
+      },
+    });
+
+    // ACT
+    const installTask = addDependenciesToPackageJson(
+      tree,
+      {
+        '@nrwl/angular': '14.1.0',
+      },
+      {
+        '@nrwl/next': '14.1.0',
+      }
+    );
+
+    // ASSERT
+    const { dependencies, devDependencies } = readJson(tree, 'package.json');
+    expect(dependencies).toEqual({
+      '@nrwl/angular': '14.2.0',
+      '@nrwl/cypress': '14.1.1',
+    });
+    expect(devDependencies).toEqual({
+      '@nrwl/next': '14.1.0',
+      '@nrwl/vite': '14.1.0',
+    });
+    expect(installTask).toBeDefined();
+  });
+
+  it('should not overwrite dependencies when they exist in "devDependencies" and one of the versions is lesser', () => {
+    // ARRANGE
+    writeJson(tree, 'package.json', {
+      dependencies: {
+        '@nrwl/angular': '14.0.0',
+        '@nrwl/cypress': '14.1.1',
+      },
+      devDependencies: {
+        '@nrwl/next': '14.2.0',
+        '@nrwl/vite': '14.1.0',
+      },
+    });
+
+    // ACT
+    const installTask = addDependenciesToPackageJson(
+      tree,
+      {
+        '@nrwl/angular': '14.1.0',
+      },
+      {
+        '@nrwl/next': '14.1.0',
+      }
+    );
+
+    // ASSERT
+    const { dependencies, devDependencies } = readJson(tree, 'package.json');
+    expect(dependencies).toEqual({
+      '@nrwl/angular': '14.1.0',
+      '@nrwl/cypress': '14.1.1',
+    });
+    expect(devDependencies).toEqual({
+      '@nrwl/next': '14.2.0',
+      '@nrwl/vite': '14.1.0',
+    });
+    expect(installTask).toBeDefined();
+  });
+
   it('should only overwrite dependencies when their version is greater', () => {
     // ARRANGE
     writeJson(tree, 'package.json', {
@@ -247,7 +321,7 @@ describe('addDependenciesToPackageJson', () => {
     writeJson(tree, 'package.json', {
       dependencies: {
         '@nrwl/angular': 'github:reponame/packageNameOne',
-        // '@nrwl/vite': 'git://github.com/npm/cli.git#v14.2.0' // this format is parsable
+        '@nrwl/vite': 'git://github.com/npm/cli.git#v14.2.0', // this format is parsable
       },
       devDependencies: {
         '@nrwl/next': '14.1.0',
@@ -261,7 +335,7 @@ describe('addDependenciesToPackageJson', () => {
         '@nrwl/next': 'github:reponame/packageNameTwo',
         '@nrwl/cypress':
           'git+https://username@github.com/reponame/packagename.git',
-        // '@nrwl/vite': '14.0.1'
+        '@nrwl/vite': '14.0.1',
       },
       {
         '@nrwl/angular': '14.1.0',
@@ -274,7 +348,7 @@ describe('addDependenciesToPackageJson', () => {
       '@nrwl/angular': '14.1.0',
       '@nrwl/cypress':
         'git+https://username@github.com/reponame/packagename.git',
-      // '@nrwl/vite': 'git://github.com/npm/cli.git#v14.2.0'
+      '@nrwl/vite': 'git://github.com/npm/cli.git#v14.2.0',
     });
     expect(devDependencies).toEqual({
       '@nrwl/next': 'github:reponame/packageNameTwo',

--- a/packages/devkit/src/utils/package-json.spec.ts
+++ b/packages/devkit/src/utils/package-json.spec.ts
@@ -242,6 +242,46 @@ describe('addDependenciesToPackageJson', () => {
     expect(installTask).toBeDefined();
   });
 
+  it('should overwrite dependencies when their version is not in a semver format', () => {
+    // ARRANGE
+    writeJson(tree, 'package.json', {
+      dependencies: {
+        '@nrwl/angular': 'github:reponame/packageNameOne',
+        // '@nrwl/vite': 'git://github.com/npm/cli.git#v14.2.0' // this format is parsable
+      },
+      devDependencies: {
+        '@nrwl/next': '14.1.0',
+      },
+    });
+
+    // ACT
+    const installTask = addDependenciesToPackageJson(
+      tree,
+      {
+        '@nrwl/next': 'github:reponame/packageNameTwo',
+        '@nrwl/cypress':
+          'git+https://username@github.com/reponame/packagename.git',
+        // '@nrwl/vite': '14.0.1'
+      },
+      {
+        '@nrwl/angular': '14.1.0',
+      }
+    );
+
+    // ASSERT
+    const { dependencies, devDependencies } = readJson(tree, 'package.json');
+    expect(dependencies).toEqual({
+      '@nrwl/angular': '14.1.0',
+      '@nrwl/cypress':
+        'git+https://username@github.com/reponame/packagename.git',
+      // '@nrwl/vite': 'git://github.com/npm/cli.git#v14.2.0'
+    });
+    expect(devDependencies).toEqual({
+      '@nrwl/next': 'github:reponame/packageNameTwo',
+    });
+    expect(installTask).toBeDefined();
+  });
+
   it('should add additional dependencies when they dont exist in devDependencies or vice versa and not update the ones that do exist', () => {
     // ARRANGE
     writeJson(tree, 'package.json', {

--- a/packages/devkit/src/utils/package-json.ts
+++ b/packages/devkit/src/utils/package-json.ts
@@ -6,9 +6,10 @@ import { clean, coerce, gt, satisfies } from 'semver';
 import { getPackageManagerCommand } from 'nx/src/utils/package-manager';
 import { execSync } from 'child_process';
 
+const UNIDENTIFIED_VERSION = 'UNIDENTIFIED_VERSION';
 const NON_SEMVER_TAGS = {
   '*': 2,
-  unidentified: 2,
+  [UNIDENTIFIED_VERSION]: 2,
   next: 1,
   latest: 0,
   previous: -1,
@@ -40,11 +41,11 @@ function isIncomingVersionGreater(
   const incomingVersionCompareBy =
     incomingVersion in NON_SEMVER_TAGS
       ? incomingVersion
-      : cleanSemver(incomingVersion)?.toString() ?? 'unidentified';
+      : cleanSemver(incomingVersion)?.toString() ?? UNIDENTIFIED_VERSION;
   const existingVersionCompareBy =
     existingVersion in NON_SEMVER_TAGS
       ? existingVersion
-      : cleanSemver(existingVersion)?.toString() ?? 'unidentified';
+      : cleanSemver(existingVersion)?.toString() ?? UNIDENTIFIED_VERSION;
 
   if (
     incomingVersionCompareBy in NON_SEMVER_TAGS &&
@@ -66,7 +67,7 @@ function isIncomingVersionGreater(
   return gt(cleanSemver(incomingVersion), cleanSemver(existingVersion));
 }
 
-function updateExistingDependenciesVersion(
+function updateExistingAltDependenciesVersion(
   dependencies: Record<string, string>,
   existingAltDependencies: Record<string, string>
 ) {
@@ -78,6 +79,24 @@ function updateExistingDependenciesVersion(
 
       const incomingVersion = dependencies[d];
       const existingVersion = existingAltDependencies[d];
+
+      return isIncomingVersionGreater(incomingVersion, existingVersion);
+    })
+    .reduce((acc, d) => ({ ...acc, [d]: dependencies[d] }), {});
+}
+
+function updateExistingDependenciesVersion(
+  dependencies: Record<string, string>,
+  existingDependencies: Record<string, string> = {}
+) {
+  return Object.keys(dependencies)
+    .filter((d) => {
+      if (!existingDependencies[d]) {
+        return true;
+      }
+
+      const incomingVersion = dependencies[d];
+      const existingVersion = existingDependencies[d];
 
       return isIncomingVersionGreater(incomingVersion, existingVersion);
     })
@@ -107,25 +126,37 @@ export function addDependenciesToPackageJson(
 ): GeneratorCallback {
   const currentPackageJson = readJson(tree, packageJsonPath);
 
+  /** Dependencies to install that are not met in dev dependencies */
   let filteredDependencies = filterExistingDependencies(
     dependencies,
     currentPackageJson.devDependencies
   );
+  /** Dev dependencies to install that are not met in dependencies */
   let filteredDevDependencies = filterExistingDependencies(
     devDependencies,
     currentPackageJson.dependencies
   );
 
+  // filtered dependencies should consist of:
+  // - dependencies of the same type that are not present
+  // - dependencies of the same type that have greater version
+  // - specified dependencies of the other type that have greater version and are already installed as current type
   filteredDependencies = {
-    ...filteredDependencies,
     ...updateExistingDependenciesVersion(
+      filteredDependencies,
+      currentPackageJson.dependencies
+    ),
+    ...updateExistingAltDependenciesVersion(
       devDependencies,
       currentPackageJson.dependencies
     ),
   };
   filteredDevDependencies = {
-    ...filteredDevDependencies,
     ...updateExistingDependenciesVersion(
+      filteredDevDependencies,
+      currentPackageJson.devDependencies
+    ),
+    ...updateExistingAltDependenciesVersion(
       dependencies,
       currentPackageJson.devDependencies
     ),

--- a/packages/devkit/src/utils/package-json.ts
+++ b/packages/devkit/src/utils/package-json.ts
@@ -8,6 +8,7 @@ import { execSync } from 'child_process';
 
 const NON_SEMVER_TAGS = {
   '*': 2,
+  unidentified: 2,
   next: 1,
   latest: 0,
   previous: -1,
@@ -35,16 +36,29 @@ function isIncomingVersionGreater(
   incomingVersion: string,
   existingVersion: string
 ) {
-  if (
-    incomingVersion in NON_SEMVER_TAGS &&
+  // if version is in the format of "latest", "next" or similar - keep it, otherwise try to parse it
+  const incomingVersionCompareBy =
+    incomingVersion in NON_SEMVER_TAGS
+      ? incomingVersion
+      : cleanSemver(incomingVersion)?.toString() ?? 'unidentified';
+  const existingVersionCompareBy =
     existingVersion in NON_SEMVER_TAGS
+      ? existingVersion
+      : cleanSemver(existingVersion)?.toString() ?? 'unidentified';
+
+  if (
+    incomingVersionCompareBy in NON_SEMVER_TAGS &&
+    existingVersionCompareBy in NON_SEMVER_TAGS
   ) {
-    return NON_SEMVER_TAGS[incomingVersion] > NON_SEMVER_TAGS[existingVersion];
+    return (
+      NON_SEMVER_TAGS[incomingVersionCompareBy] >
+      NON_SEMVER_TAGS[existingVersionCompareBy]
+    );
   }
 
   if (
-    incomingVersion in NON_SEMVER_TAGS ||
-    existingVersion in NON_SEMVER_TAGS
+    incomingVersionCompareBy in NON_SEMVER_TAGS ||
+    existingVersionCompareBy in NON_SEMVER_TAGS
   ) {
     return true;
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
1. Right now `addDependenciesToPackageJson` will fail if in package.json there're packages with not semantic version (e.g. `git://github.com/npm/cli.git#v1.0.27` or `github:builderio/qwik-build`
2. Packages with lower version than specified in package.json may get installed if provided dependencies are all of the same type (dependencies or devDependencies). This was a bit weird, but is perfectly demonstrated with unit tests added in the second commit
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Issues above should not exist

