### PR TITLE
fix(angular): deprecate the testing utils

### DIFF
--- a/packages/angular/testing/src/testing-utils.ts
+++ b/packages/angular/testing/src/testing-utils.ts
@@ -2,6 +2,8 @@ import type { Observable } from 'rxjs';
 import { first, toArray } from 'rxjs/operators';
 
 /**
+ * @deprecated This will be removed in a later version of Nx. Since RxJS 7, use firstValueFrom(obs$.pipe(toArray())) or lastValueFrom(obs$.pipe(toArray())).
+ *
  * @whatItDoes reads all the values from an observable and returns a promise
  * with an array of all values. This should be used in combination with async/await.
  *
@@ -18,6 +20,8 @@ export function readAll<T>(o: Observable<T>): Promise<T[]> {
 }
 
 /**
+ * @deprecated This will be removed in a later version of Nx. Since RxJS 7, use firstValueFrom(obs$)
+ *
  * @whatItDoes reads the first value from an observable and returns a promise
  * with it. This should be used in combination with async/await.
  *


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The testing utils are expected to be used at runtime, but the @nrwl/angular package is intended to be a dev tool. 
Since RxJS 7, there are better ways to achieve what what the testing utils provide.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Deprecate the testing utils in preparation for removal.

