### PR TITLE
chore(nx-dev): use structuredClone for cloning objects

### DIFF
--- a/nx-dev/data-access-documents/src/lib/documents.api.ts
+++ b/nx-dev/data-access-documents/src/lib/documents.api.ts
@@ -36,7 +36,7 @@ export class DocumentsApi {
       throw new Error('public document sources cannot be undefined');
     }
 
-    this.manifest = Object.assign({}, this.options.manifest);
+    this.manifest = structuredClone(this.options.manifest);
   }
   private getManifestKey(path: string): string {
     return '/' + path;

--- a/nx-dev/data-access-documents/src/lib/tags.api.ts
+++ b/nx-dev/data-access-documents/src/lib/tags.api.ts
@@ -7,7 +7,7 @@ export class TagsApi {
       throw new Error('tags property cannot be undefined');
     }
 
-    this.manifest = Object.assign({}, this.tags);
+    this.manifest = structuredClone(this.tags);
   }
 
   getAssociatedItems(tag: string): RelatedDocument[] {

--- a/nx-dev/data-access-packages/src/lib/packages.api.ts
+++ b/nx-dev/data-access-packages/src/lib/packages.api.ts
@@ -38,7 +38,7 @@ export class PackagesApi {
       throw new Error('public document sources cannot be undefined');
     }
 
-    this.manifest = Object.assign({}, this.options.manifest);
+    this.manifest = structuredClone(this.options.manifest);
   }
 
   getFilePath(path: string): string {

--- a/nx-dev/feature-package-schema-viewer/src/lib/examples.ts
+++ b/nx-dev/feature-package-schema-viewer/src/lib/examples.ts
@@ -466,7 +466,7 @@ function generateJsonExampleForHelper(
       }
 
       if (matchedType === 'object') {
-        const example = Object.assign({}, ...examples);
+        const example = structuredClone(examples);
         return Example.of(example);
       } else if (
         matchedType === 'string' ||

--- a/scripts/documentation/generators/generate-manifests.ts
+++ b/scripts/documentation/generators/generate-manifests.ts
@@ -393,7 +393,7 @@ function documentRecurseOperations(
   target: DocumentMetadata,
   parent: DocumentMetadata
 ): DocumentMetadata {
-  const document: DocumentMetadata = Object.assign({}, target);
+  const document: DocumentMetadata = structuredClone(target);
 
   /**
    * Calculate `path`

--- a/scripts/documentation/package-schemas/schema.resolver.ts
+++ b/scripts/documentation/package-schemas/schema.resolver.ts
@@ -72,7 +72,7 @@ export function schemaResolver(
   resolveExamplesFile: () => void;
   getSchema: () => NxSchema;
 } {
-  const updatedSchema: NxSchema = Object.assign({}, schema);
+  const updatedSchema: NxSchema = structuredClone(schema);
   return {
     resolveReferences: () => {
       traverseAndReplaceReferences(updatedSchema, '$ref', lookup);


### PR DESCRIPTION
It refactors the `Object.assign()` syntax used to clone objects by a simpler and more performant `structuredCloned` native function.