### PR TITLE
docs(angular): use an actual schematic in example of converting it to an nx generator

### DIFF
--- a/docs/shared/guides/nx-devkit-angular-devkit.md
+++ b/docs/shared/guides/nx-devkit-angular-devkit.md
@@ -130,7 +130,7 @@ Then, you might need to register it in the `collections.json`:
 
 ```typescript
 export const libraryGenerator = wrapAngularDevkitSchematic(
-  '@nrwl/angular',
+  '@schematics/angular',
   'library'
 );
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The example shown to convert an Angular CLI schematic to an Nx DevKit generator uses an Nx generator converted to an Angular CLI schematic, instead of an actual Angular CLI schematic. This is misleading and folks might see it as the way to consume Nx generators.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The example shown to convert an Angular CLI schematic to an Nx DevKit generator uses an Angular CLI schematic.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
