### PR TITLE
fix(core): update CSV handling to account for the the value already being an array

### DIFF
--- a/e2e/nx-run/src/run.test.ts
+++ b/e2e/nx-run/src/run.test.ts
@@ -512,7 +512,8 @@ describe('Nx Running Tests', () => {
       runCLI(`generate @nrwl/web:app ${myapp2}`);
 
       let outputs = runCLI(
-        `run-many -t build test -p ${myapp1} ${myapp2} --ci`
+        // Options with lists can be specified using multiple args or with a delimiter (comma or space).
+        `run-many -t build -t test -p ${myapp1} ${myapp2} --ci`
       );
       expect(outputs).toContain('Running targets build, test for 2 projects:');
 

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -1017,8 +1017,11 @@ function withWatchOptions(yargs: yargs.Argv) {
     }, true);
 }
 
-function parseCSV(args: string) {
+function parseCSV(args: string[] | string) {
   if (!args) {
+    return args;
+  }
+  if (Array.isArray(args)) {
     return args;
   }
   return args.split(',');


### PR DESCRIPTION
This PR updates our CSV handling to be compatible with latest `yargs-parser`.

Previously it seems `-t a -t b` results in a `string` from yargs, but now it is returning `string[]`, which when being processed as a `string` results in an error.

e.g. `nx run-many -t test -build`

## Current Behavior
Passing multiple args results in weird error: `args.split is not a function`.

## Expected Behavior
Passing multiple args should work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
