### PR TITLE
feat(core): happy message when all targets build from cache

### DIFF
--- a/e2e/nx-init/src/nx-init-nest.test.ts
+++ b/e2e/nx-init/src/nx-init-nest.test.ts
@@ -60,6 +60,6 @@ describe('nx init (for NestCLI)', () => {
 
     // run build again for cache
     const buildOutput = runCLI('build', cliOptions);
-    expect(buildOutput).toContain('Nx read the output from the cache');
+    expect(buildOutput).toContain('All -23 commands built from cache!');
   }, 10000);
 });

--- a/e2e/nx-run/src/run.test.ts
+++ b/e2e/nx-run/src/run.test.ts
@@ -582,7 +582,7 @@ describe('Nx Running Tests', () => {
         const output = runCommand('npm run build', {
           cwd: pkgRoot,
         });
-        expect(output).toContain('Nx read the output from the cache');
+        expect(output).toContain('All -1 commands built from cache!');
       });
 
       it('should read outputs', () => {

--- a/packages/nx/src/tasks-runner/life-cycles/dynamic-run-many-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/dynamic-run-many-terminal-output-life-cycle.ts
@@ -9,6 +9,7 @@ import { Task } from '../../config/task-graph';
 import { prettyTime } from './pretty-time';
 import { formatFlags, formatTargetsAndProjects } from './formatting-utils';
 import { viewLogsFooterRows } from './view-logs-utils';
+import { getReadFromCacheLines } from './get-read-from-cache-lines';
 
 /**
  * The following function is responsible for creating a life cycle with dynamic
@@ -333,21 +334,17 @@ export async function createRunManyDynamicOutputRenderer({
           .forEach((arg) => taskOverridesRows.push(arg));
       }
 
-      const pinnedFooterLines = [
-        output.applyNxPrefix(
-          'green',
-          output.colors.green(text) + output.dim.white(` (${timeTakenText})`)
-        ),
-        ...taskOverridesRows,
-      ];
-      if (totalCachedTasks > 0) {
-        pinnedFooterLines.push(
-          output.dim(
-            `${EOL}   Nx read the output from the cache instead of running the command for ${totalCachedTasks} out of ${totalTasks} tasks.`
-          )
-        );
-      }
-      renderPinnedFooter(pinnedFooterLines, 'green');
+      renderPinnedFooter(
+        [
+          output.applyNxPrefix(
+            'green',
+            output.colors.green(text) + output.dim.white(` (${timeTakenText})`)
+          ),
+          ...taskOverridesRows,
+          ...getReadFromCacheLines(totalCachedTasks, totalTasks),
+        ],
+        'green'
+      );
     } else {
       const text = `Ran ${formatTargetsAndProjects(
         projectNames,

--- a/packages/nx/src/tasks-runner/life-cycles/dynamic-run-one-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/dynamic-run-one-terminal-output-life-cycle.ts
@@ -8,6 +8,7 @@ import { prettyTime } from './pretty-time';
 import { Task } from '../../config/task-graph';
 import { formatFlags, formatTargetsAndProjects } from './formatting-utils';
 import { viewLogsFooterRows } from './view-logs-utils';
+import { getReadFromCacheLines } from './get-read-from-cache-lines';
 
 /**
  * As tasks are completed the overall state moves from:
@@ -292,21 +293,17 @@ export async function createRunOneDynamicOutputRenderer({
           .forEach((arg) => taskOverridesLines.push(arg));
       }
 
-      const pinnedFooterLines = [
-        output.applyNxPrefix(
-          'green',
-          output.colors.green(text) + output.dim(` (${timeTakenText})`)
-        ),
-        ...taskOverridesLines,
-      ];
-      if (totalCachedTasks > 0) {
-        pinnedFooterLines.push(
-          output.dim(
-            `${EOL}   Nx read the output from the cache instead of running the command for ${totalCachedTasks} out of ${totalTasks} tasks.`
-          )
-        );
-      }
-      renderLines(pinnedFooterLines, 'green');
+      renderLines(
+        [
+          output.applyNxPrefix(
+            'green',
+            output.colors.green(text) + output.dim(` (${timeTakenText})`)
+          ),
+          ...taskOverridesLines,
+          ...getReadFromCacheLines(totalCachedTasks, totalTasks),
+        ],
+        'green'
+      );
     } else {
       state = 'COMPLETED_WITH_ERRORS';
 

--- a/packages/nx/src/tasks-runner/life-cycles/get-read-from-cache-lines.spec.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/get-read-from-cache-lines.spec.ts
@@ -1,0 +1,44 @@
+import { EOL } from 'os';
+
+import { output } from '../../utils/output';
+import { getReadFromCacheLines } from './get-read-from-cache-lines';
+
+describe('getReadFromCacheLines', () => {
+  it.each([
+    ['no lines when nothing was cached', 0, 1, []],
+    [
+      'a happy line when 1 of 1 task was cached',
+      1,
+      1,
+      [
+        output.colors.cyan(
+          `${EOL}  ✨⚡️ All 1 command built from cache! ⚡️✨`
+        ),
+      ],
+    ],
+    [
+      'happy lines when 2 of 2 tasks were cached',
+      2,
+      2,
+      [
+        output.colors.cyan(
+          `${EOL}  ✨⚡️ All 2 commands built from cache! ⚡️✨`
+        ),
+      ],
+    ],
+    [
+      'dim lines when 2 of 2 tasks were cached',
+      1,
+      2,
+      [
+        output.dim(
+          `${EOL}  Nx read the output from the cache instead of running the command for 1 out of 2 tasks.`
+        ),
+      ],
+    ],
+  ] as const)('returns %s', (_, totalCachedTasks, totalTasks, expected) => {
+    const actual = getReadFromCacheLines(totalCachedTasks, totalTasks);
+
+    expect(actual).toEqual(expected);
+  });
+});

--- a/packages/nx/src/tasks-runner/life-cycles/get-read-from-cache-lines.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/get-read-from-cache-lines.ts
@@ -1,0 +1,29 @@
+import { EOL } from 'os';
+
+import { output } from '../../utils/output';
+
+export function getReadFromCacheLines(
+  totalCachedTasks: number,
+  totalTasks: number
+) {
+  switch (totalCachedTasks) {
+    case 0:
+      return [];
+
+    case totalTasks:
+      return [
+        output.colors.cyan(
+          `${EOL}  ✨⚡️ All ${totalTasks} command${
+            totalTasks === 1 ? '' : 's'
+          } built from cache! ⚡️✨`
+        ),
+      ];
+
+    default:
+      return [
+        output.dim(
+          `${EOL}  Nx read the output from the cache instead of running the command for ${totalCachedTasks} out of ${totalTasks} tasks.`
+        ),
+      ];
+  }
+}

--- a/packages/nx/src/tasks-runner/life-cycles/static-run-many-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/static-run-many-terminal-output-life-cycle.ts
@@ -4,6 +4,7 @@ import { getPrintableCommandArgsForTask } from '../utils';
 import type { LifeCycle } from '../life-cycle';
 import { Task } from '../../config/task-graph';
 import { formatFlags, formatTargetsAndProjects } from './formatting-utils';
+import { getReadFromCacheLines } from './get-read-from-cache-lines';
 
 /**
  * The following life cycle's outputs are static, meaning no previous content
@@ -72,14 +73,10 @@ export class StaticRunManyTerminalOutputLifeCycle implements LifeCycle {
     if (this.failedTasks.length === 0) {
       output.addVerticalSeparatorWithoutNewLines('green');
 
-      const bodyLines =
-        this.cachedTasks.length > 0
-          ? [
-              output.dim(
-                `Nx read the output from the cache instead of running the command for ${this.cachedTasks.length} out of ${this.tasks.length} tasks.`
-              ),
-            ]
-          : [];
+      const bodyLines = getReadFromCacheLines(
+        this.cachedTasks.length,
+        this.tasks.length
+      );
 
       output.success({
         title: `Successfully ran ${formatTargetsAndProjects(

--- a/packages/nx/src/tasks-runner/life-cycles/static-run-one-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/static-run-one-terminal-output-life-cycle.ts
@@ -4,6 +4,7 @@ import { getPrintableCommandArgsForTask } from '../utils';
 import type { LifeCycle } from '../life-cycle';
 import { Task } from '../../config/task-graph';
 import { formatTargetsAndProjects } from './formatting-utils';
+import { getReadFromCacheLines } from './get-read-from-cache-lines';
 
 /**
  * The following life cycle's outputs are static, meaning no previous content
@@ -49,14 +50,10 @@ export class StaticRunOneTerminalOutputLifeCycle implements LifeCycle {
     if (this.failedTasks.length === 0) {
       output.addVerticalSeparatorWithoutNewLines('green');
 
-      const bodyLines =
-        this.cachedTasks.length > 0
-          ? [
-              output.dim(
-                `Nx read the output from the cache instead of running the command for ${this.cachedTasks.length} out of ${this.tasks.length} tasks.`
-              ),
-            ]
-          : [];
+      const bodyLines = getReadFromCacheLines(
+        this.cachedTasks.length,
+        this.tasks.length
+      );
 
       output.success({
         title: `Successfully ran ${formatTargetsAndProjects(


### PR DESCRIPTION
## Current Behavior

In dim text:

```plaintext
Nx read the output from the cache instead of running the command for 2 out of 2 tasks.
```

## Expected Behavior

Something... snazzy!

In cyan text:

```plaintext
✨⚡️ All 2 commands built from cache! ⚡️✨
```

## Related Issue(s)

Fixes #14471
