### PR TITLE
fix(repo): fix lerna tests to successfully run for yarn

### DIFF
--- a/e2e/lerna-smoke-tests/src/lerna-smoke-tests.test.ts
+++ b/e2e/lerna-smoke-tests/src/lerna-smoke-tests.test.ts
@@ -38,7 +38,9 @@ describe('Lerna Smoke Tests', () => {
   describe('lerna repair', () => {
     // If this snapshot fails it means that nx repair generators are making assumptions which don't hold true for lerna workspaces
     it('should complete successfully on a new lerna workspace', async () => {
-      expect(runLernaCLI(`repair`)).toMatchInlineSnapshot(`
+      let result = runLernaCLI(`repair`);
+      result = result.replace(/.*\/node_modules\/.*\n/, ''); // yarn adds "$ /node_modules/.bin/lerna repair" to the output
+      expect(result).toMatchInlineSnapshot(`
 
         >  Lerna   No changes were necessary. This workspace is up to date!
 
@@ -59,11 +61,15 @@ describe('Lerna Smoke Tests', () => {
         },
       }));
 
-      expect(runLernaCLI(`run print-name`)).toMatchInlineSnapshot(`
+      let result = runLernaCLI(`run print-name`);
+      result = result
+        .replace(/.*\/node_modules\/.*\n/, '') // yarn adds "$ /node_modules/.bin/lerna run print-name" to the output
+        .replace(/.*package-1@0.*\n/, '') // yarn output doesn't contain "> package-1@0.0.0 print-name"
+        .replace('$ echo test-package-1', '> echo test-package-1');
+      expect(result).toMatchInlineSnapshot(`
 
         > package-1:print-name
 
-        > package-1@0.0.0 print-name
         > echo test-package-1
         test-package-1
 


### PR DESCRIPTION
Lerna E2E smoke tests fail on Yarn due to differences in the output.

This PR maps the response to match all package managers.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
