### PR TITLE
fix(angular): throw when polyfills is provided with an array for webpack-browser and angular 14

### DIFF
--- a/docs/generated/packages/angular/executors/webpack-browser.json
+++ b/docs/generated/packages/angular/executors/webpack-browser.json
@@ -75,7 +75,7 @@
         "oneOf": [
           {
             "type": "array",
-            "description": "A list of polyfills to include in the build. Can be a full path for a file, relative to the current workspace or module specifier. Example: 'zone.js'.",
+            "description": "A list of polyfills to include in the build. Can be a full path for a file, relative to the current workspace or module specifier. Example: 'zone.js'. _Note: supported in Angular versions >= 15.0.0_.",
             "items": { "type": "string", "uniqueItems": true },
             "default": []
           },

--- a/packages/angular/src/builders/webpack-browser/schema.json
+++ b/packages/angular/src/builders/webpack-browser/schema.json
@@ -41,7 +41,7 @@
       "oneOf": [
         {
           "type": "array",
-          "description": "A list of polyfills to include in the build. Can be a full path for a file, relative to the current workspace or module specifier. Example: 'zone.js'.",
+          "description": "A list of polyfills to include in the build. Can be a full path for a file, relative to the current workspace or module specifier. Example: 'zone.js'. _Note: supported in Angular versions >= 15.0.0_.",
           "items": {
             "type": "string",
             "uniqueItems": true


### PR DESCRIPTION
Throws a meaningful error when the `polyfills` option is provided with an array value in a workspace with Angular 14.