### PR TITLE
fix(misc): identify workspace schematics correctly using isSchematic option in schema

### DIFF
--- a/packages/nx/src/command-line/workspace-generators.ts
+++ b/packages/nx/src/command-line/workspace-generators.ts
@@ -98,21 +98,29 @@ function compileToolsDir(outDir: string) {
 
 function constructCollection() {
   const generators = {};
+  const schematics = {};
   readdirSync(generatorsDir).forEach((c) => {
     const childDir = path.join(generatorsDir, c);
     if (existsSync(path.join(childDir, 'schema.json'))) {
-      generators[c] = {
+      const generatorOrSchematic = {
         factory: `./${c}`,
         schema: `./${normalizePath(path.join(c, 'schema.json'))}`,
         description: `Schematic ${c}`,
       };
+
+      const { isSchematic } = readJsonFile(path.join(childDir, 'schema.json'));
+      if (isSchematic) {
+        schematics[c] = generatorOrSchematic;
+      } else {
+        generators[c] = generatorOrSchematic;
+      }
     }
   });
   return {
     name: 'workspace-generators',
     version: '1.0',
     generators,
-    schematics: generators,
+    schematics,
   };
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Workspace schematics are not being identified as such after some workspace configuration cleanup and rework. Therefore, they are being run as generators.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Workspace schematics are identified correctly by setting `"isSchematic": true` in their `schema.json`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14641 
