### PR TITLE
feat(bundling): update esbuild to 0.17.5

### DIFF
--- a/e2e/esbuild/src/esbuild.test.ts
+++ b/e2e/esbuild/src/esbuild.test.ts
@@ -11,6 +11,8 @@ import {
   updateFile,
   updateProjectConfig,
   packageInstall,
+  rmDist,
+  runCommandUntil,
 } from '@nrwl/e2e/utils';
 
 describe('EsBuild Plugin', () => {
@@ -135,4 +137,39 @@ describe('EsBuild Plugin', () => {
     // Can run package (package.json fields are correctly generated)
     expect(runCommand(`node dist/libs/${myPkg}`)).toMatch(/Hello/);
   }, 300_000);
+
+  it('should support new watch API in >= 0.17.0 and old watch API in < 0.17.0', async () => {
+    const myPkg = uniq('my-pkg');
+    runCLI(`generate @nrwl/js:lib ${myPkg} --bundler=esbuild`);
+    updateFile(`libs/${myPkg}/src/index.ts`, `console.log('new API');\n`);
+
+    let watchProcess = await runCommandUntil(
+      `build ${myPkg} --bundle=false --watch`,
+      (output) => {
+        return output.includes('build succeeded');
+      }
+    );
+
+    watchProcess.kill();
+
+    // Check that the build is correct
+    expect(runCommand(`node dist/libs/${myPkg}`)).toMatch(/new API/);
+
+    // Now install legacy esbuild and do a build watch
+    packageInstall('esbuild', undefined, '0.16.17');
+
+    rmDist();
+
+    watchProcess = await runCommandUntil(
+      `build ${myPkg} --bundle=false --watch`,
+      (output) => {
+        return output.includes('build succeeded');
+      }
+    );
+
+    watchProcess.kill();
+
+    // Check that the build is correct
+    expect(runCommand(`node dist/libs/${myPkg}`)).toMatch(/new API/);
+  }, 120_000);
 });

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "dotenv": "~10.0.0",
     "ejs": "^3.1.7",
     "enhanced-resolve": "^5.8.3",
+    "esbuild": "^0.17.5",
     "eslint": "8.15.0",
     "eslint-config-next": "13.1.1",
     "eslint-config-prettier": "^8.1.0",

--- a/packages/esbuild/migrations.json
+++ b/packages/esbuild/migrations.json
@@ -1,0 +1,14 @@
+{
+  "generators": {},
+  "packageJsonUpdates": {
+    "15.7.0": {
+      "version": "15.7.0-beta.0",
+      "packages": {
+        "esbuild": {
+          "version": "0.17.5",
+          "alwaysAddToPackageJson": false
+        }
+      }
+    }
+  }
+}

--- a/packages/esbuild/migrations.spec.ts
+++ b/packages/esbuild/migrations.spec.ts
@@ -1,0 +1,12 @@
+import path = require('path');
+import json = require('./migrations.json');
+
+describe('esbuild migrations', () => {
+  it('should have valid paths', () => {
+    Object.values(json.generators).forEach((m: any) => {
+      expect(() =>
+        require.resolve(path.join(__dirname, `${m.factory}.ts`))
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -39,7 +39,7 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "esbuild": "~0.15.9"
+    "esbuild": "~0.17.5"
   },
   "peerDependenciesMeta": {
     "esbuild": {

--- a/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
+++ b/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
@@ -82,128 +82,235 @@ export async function* esbuildExecutor(
 
   const packageJsonResult = await copyPackageJson(cpjOptions, context);
 
-  if (options.watch) {
-    return yield* createAsyncIterable<{ success: boolean; outfile?: string }>(
-      async ({ next, done }) => {
-        let hasTypeErrors = false;
+  if ('context' in esbuild) {
+    // 0.17.0+ adds esbuild.context and context.watch()
+    if (options.watch) {
+      return yield* createAsyncIterable<{ success: boolean; outfile?: string }>(
+        async ({ next, done }) => {
+          let hasTypeErrors = false;
+          const disposeFns = await Promise.all(
+            options.format.map(async (format, idx) => {
+              const esbuildOptions = buildEsbuildOptions(
+                format,
+                options,
+                context
+              );
+              const ctx = await esbuild.context({
+                ...esbuildOptions,
+                plugins: [
+                  ...(esbuildOptions.plugins ?? []),
+                  // Only emit info on one of the watch processes.
+                  idx === 0
+                    ? {
+                        name: 'nx-watch-plugin',
+                        setup(build: esbuild.PluginBuild) {
+                          build.onEnd(async (result: esbuild.BuildResult) => {
+                            if (!options.skipTypeCheck) {
+                              const { errors } = await runTypeCheck(
+                                options,
+                                context
+                              );
+                              hasTypeErrors = errors.length > 0;
+                            }
+                            const success =
+                              result.errors.length === 0 && !hasTypeErrors;
 
-        const results = await Promise.all(
-          options.format.map(async (format, idx) => {
-            const esbuildOptions = buildEsbuildOptions(
-              format,
-              options,
-              context
-            );
-            const watch =
-              // Only emit info on one of the watch processes.
-              idx === 0
-                ? {
-                    onRebuild: async (
-                      error: esbuild.BuildFailure,
-                      result: esbuild.BuildResult
-                    ) => {
-                      if (!options.skipTypeCheck) {
-                        const { errors } = await runTypeCheck(options, context);
-                        hasTypeErrors = errors.length > 0;
+                            if (!success) {
+                              logger.info(BUILD_WATCH_FAILED);
+                            } else {
+                              logger.info(BUILD_WATCH_SUCCEEDED);
+                            }
+
+                            next({
+                              success,
+                              // Need to call getOutfile directly in the case of bundle=false and outfile is not set for esbuild.
+                              outfile: join(
+                                context.root,
+                                getOutfile(format, options, context)
+                              ),
+                            });
+                          });
+                        },
                       }
-                      const success = !error && !hasTypeErrors;
-
-                      if (!success) {
-                        logger.info(BUILD_WATCH_FAILED);
-                      } else {
-                        logger.info(BUILD_WATCH_SUCCEEDED);
-                      }
-
-                      next({
-                        success,
-                        // Need to call getOutfile directly in the case of bundle=false and outfile is not set for esbuild.
-                        outfile: join(
-                          context.root,
-                          getOutfile(format, options, context)
-                        ),
-                      });
-                    },
-                  }
-                : true;
-            try {
-              const result = await esbuild.build({ ...esbuildOptions, watch });
-
-              next({
-                success: true,
-                // Need to call getOutfile directly in the case of bundle=false and outfile is not set for esbuild.
-                outfile: join(
-                  context.root,
-                  getOutfile(format, options, context)
-                ),
+                    : null,
+                ].filter(Boolean),
               });
 
-              return result;
-            } catch {
-              next({ success: false });
-            }
-          })
-        );
-        const processOnExit = () => {
-          assetsResult?.stop();
-          packageJsonResult?.stop();
-          results.forEach((r) => r?.stop());
-          done();
-          process.off('SIGINT', processOnExit);
-          process.off('SIGTERM', processOnExit);
-          process.off('exit', processOnExit);
-        };
+              await ctx.watch();
+              return () => ctx.dispose();
+            })
+          );
 
-        process.on('SIGINT', processOnExit);
-        process.on('SIGTERM', processOnExit);
-        process.on('exit', processOnExit);
-
-        if (!options.skipTypeCheck) {
-          const { errors } = await runTypeCheck(options, context);
-          hasTypeErrors = errors.length > 0;
+          registerCleanupCallback(() => {
+            assetsResult?.stop();
+            packageJsonResult?.stop();
+            disposeFns.forEach((fn) => fn());
+            done(); // return from async iterable
+          });
         }
-
-        const success =
-          results.every((r) => r.errors?.length === 0) && !hasTypeErrors;
-
-        if (!success) {
-          logger.info(BUILD_WATCH_FAILED);
-        } else {
-          logger.info(BUILD_WATCH_SUCCEEDED);
+      );
+    } else {
+      // Run type-checks first and bail if they don't pass.
+      if (!options.skipTypeCheck) {
+        const { errors } = await runTypeCheck(options, context);
+        if (errors.length > 0) {
+          yield { success: false };
+          return;
         }
       }
-    );
-  } else {
-    // Run type-checks first and bail if they don't pass.
-    if (!options.skipTypeCheck) {
-      const { errors } = await runTypeCheck(options, context);
-      if (errors.length > 0) {
-        yield { success: false };
-        return;
+
+      // Emit a build event for each file format.
+      for (let i = 0; i < options.format.length; i++) {
+        const format = options.format[i];
+        const esbuildOptions = buildEsbuildOptions(format, options, context);
+        const buildResult = await esbuild.build(esbuildOptions);
+
+        if (options.metafile) {
+          const filename =
+            options.format.length === 1
+              ? 'meta.json'
+              : `meta.${options.format[i]}.json`;
+          writeJsonSync(
+            joinPathFragments(options.outputPath, filename),
+            buildResult.metafile
+          );
+        }
+
+        yield {
+          success: buildResult.errors.length === 0,
+          // Need to call getOutfile directly in the case of bundle=false and outfile is not set for esbuild.
+          outfile: join(context.root, getOutfile(format, options, context)),
+        };
       }
     }
+  } else {
+    // TODO(jack): Remove in Nx 16
+    // < 0.17.0 takes watch as an argument to build()
+    if (options.watch) {
+      return yield* createAsyncIterable<{ success: boolean; outfile?: string }>(
+        async ({ next, done }) => {
+          let hasTypeErrors = false;
+          const results = await Promise.all(
+            options.format.map(async (format, idx) => {
+              const esbuildOptions = buildEsbuildOptions(
+                format,
+                options,
+                context
+              );
+              const watch =
+                // Only emit info on one of the watch processes.
+                idx === 0
+                  ? {
+                      onRebuild: async (
+                        error: esbuild.BuildFailure,
+                        result: esbuild.BuildResult
+                      ) => {
+                        if (!options.skipTypeCheck) {
+                          const { errors } = await runTypeCheck(
+                            options,
+                            context
+                          );
+                          hasTypeErrors = errors.length > 0;
+                        }
+                        const success = !error && !hasTypeErrors;
 
-    // Emit a build event for each file format.
-    for (let i = 0; i < options.format.length; i++) {
-      const format = options.format[i];
-      const esbuildOptions = buildEsbuildOptions(format, options, context);
-      const buildResult = await esbuild.build(esbuildOptions);
+                        if (!success) {
+                          logger.info(BUILD_WATCH_FAILED);
+                        } else {
+                          logger.info(BUILD_WATCH_SUCCEEDED);
+                        }
 
-      if (options.metafile) {
-        const filename =
-          options.format.length === 1
-            ? 'meta.json'
-            : `meta.${options.format[i]}.json`;
-        writeJsonSync(
-          joinPathFragments(options.outputPath, filename),
-          buildResult.metafile
-        );
+                        next({
+                          success,
+                          // Need to call getOutfile directly in the case of bundle=false and outfile is not set for esbuild.
+                          outfile: join(
+                            context.root,
+                            getOutfile(format, options, context)
+                          ),
+                        });
+                      },
+                    }
+                  : true;
+              try {
+                const result = await esbuild.build({
+                  ...esbuildOptions,
+                  watch,
+                });
+
+                next({
+                  success: true,
+                  // Need to call getOutfile directly in the case of bundle=false and outfile is not set for esbuild.
+                  outfile: join(
+                    context.root,
+                    getOutfile(format, options, context)
+                  ),
+                });
+
+                return result;
+              } catch {
+                next({ success: false });
+              }
+            })
+          );
+
+          registerCleanupCallback(() => {
+            assetsResult?.stop();
+            packageJsonResult?.stop();
+            results.forEach((r) =>
+              // result.stop() is no in esbuild 0.17.0+ but it exists in earlier versions
+              r?.['stop']?.()
+            );
+            done();
+          });
+
+          if (!options.skipTypeCheck) {
+            const { errors } = await runTypeCheck(options, context);
+            hasTypeErrors = errors.length > 0;
+          }
+
+          const success =
+            results.every((r) => r.errors?.length === 0) && !hasTypeErrors;
+
+          if (!success) {
+            logger.info(BUILD_WATCH_FAILED);
+          } else {
+            logger.info(BUILD_WATCH_SUCCEEDED);
+          }
+        }
+      );
+    } else {
+      // Run type-checks first and bail if they don't pass.
+      if (!options.skipTypeCheck) {
+        const { errors } = await runTypeCheck(options, context);
+        if (errors.length > 0) {
+          yield { success: false };
+          return;
+        }
       }
 
-      yield {
-        success: buildResult.errors.length === 0,
-        // Need to call getOutfile directly in the case of bundle=false and outfile is not set for esbuild.
-        outfile: join(context.root, getOutfile(format, options, context)),
-      };
+      // Emit a build event for each file format.
+      for (let i = 0; i < options.format.length; i++) {
+        const format = options.format[i];
+        const esbuildOptions = buildEsbuildOptions(format, options, context);
+        const buildResult = await esbuild.build(esbuildOptions);
+
+        if (options.metafile) {
+          const filename =
+            options.format.length === 1
+              ? 'meta.json'
+              : `meta.${options.format[i]}.json`;
+          writeJsonSync(
+            joinPathFragments(options.outputPath, filename),
+            buildResult.metafile
+          );
+        }
+
+        yield {
+          success: buildResult.errors.length === 0,
+          // Need to call getOutfile directly in the case of bundle=false and outfile is not set for esbuild.
+          outfile: join(context.root, getOutfile(format, options, context)),
+        };
+      }
     }
   }
 }
@@ -246,6 +353,19 @@ async function runTypeCheck(
   }
 
   return { errors, warnings };
+}
+
+function registerCleanupCallback(callback: () => void) {
+  const wrapped = () => {
+    callback();
+    process.off('SIGINT', wrapped);
+    process.off('SIGTERM', wrapped);
+    process.off('exit', wrapped);
+  };
+
+  process.on('SIGINT', wrapped);
+  process.on('SIGTERM', wrapped);
+  process.on('exit', wrapped);
 }
 
 export default esbuildExecutor;

--- a/packages/js/src/utils/versions.ts
+++ b/packages/js/src/utils/versions.ts
@@ -2,7 +2,7 @@ export { swcCoreVersion } from 'nx/src/utils/versions';
 
 export const nxVersion = require('../../package.json').version;
 
-export const esbuildVersion = '^0.15.7';
+export const esbuildVersion = '^0.17.5';
 export const swcCliVersion = '~0.1.55';
 export const swcHelpersVersion = '~0.4.11';
 export const typesNodeVersion = '18.7.1';

--- a/packages/node/src/utils/versions.ts
+++ b/packages/node/src/utils/versions.ts
@@ -4,7 +4,7 @@ export const tslibVersion = '^2.3.0';
 
 export const typesNodeVersion = '18.7.1';
 
-export const esbuildVersion = '^0.15.7';
+export const esbuildVersion = '^0.17.5';
 
 export const expressVersion = '^4.18.1';
 export const expressTypingsVersion = '4.17.13';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2547,6 +2547,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.16.4.tgz#4b31b9e3da2e4c12a8170bd682f713c775f68ab1"
   integrity sha512-VPuTzXFm/m2fcGfN6CiwZTlLzxrKsWbPkG7ArRFpuxyaHUm/XFHQPD4xNwZT6uUmpIHhnSjcaCmcla8COzmZ5Q==
 
+"@esbuild/android-arm64@0.17.5":
+  version "0.17.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.17.5.tgz#a145f43018e639bed94ed637369e2dcdd6bf9ea2"
+  integrity sha512-KHWkDqYAMmKZjY4RAN1PR96q6UOtfkWlTS8uEwWxdLtkRt/0F/csUhXIrVfaSIFxnscIBMPynGfhsMwQDRIBQw==
+
 "@esbuild/android-arm@0.16.13":
   version "0.16.13"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.16.13.tgz#df3317286eed68c727daf39c2d585625f9c2f170"
@@ -2561,6 +2566,11 @@
   version "0.16.4"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.16.4.tgz#057d3e8b0ee41ff59386c33ba6dcf20f4bedd1f7"
   integrity sha512-rZzb7r22m20S1S7ufIc6DC6W659yxoOrl7sKP1nCYhuvUlnCFHVSbATG4keGUtV8rDz11sRRDbWkvQZpzPaHiw==
+
+"@esbuild/android-arm@0.17.5":
+  version "0.17.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.17.5.tgz#9fa2deff7fc5d180bb4ecff70beea3a95ac44251"
+  integrity sha512-crmPUzgCmF+qZXfl1YkiFoUta2XAfixR1tEnr/gXIixE+WL8Z0BGqfydP5oox0EUOgQMMRgtATtakyAcClQVqQ==
 
 "@esbuild/android-x64@0.16.13":
   version "0.16.13"
@@ -2577,6 +2587,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.16.4.tgz#62ccab8ac1d3e6ef1df3fa2e1974bc2b8528d74a"
   integrity sha512-MW+B2O++BkcOfMWmuHXB15/l1i7wXhJFqbJhp82IBOais8RBEQv2vQz/jHrDEHaY2X0QY7Wfw86SBL2PbVOr0g==
 
+"@esbuild/android-x64@0.17.5":
+  version "0.17.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.17.5.tgz#145fc61f810400e65a56b275280d1422a102c2ef"
+  integrity sha512-8fI/AnIdmWz/+1iza2WrCw8kwXK9wZp/yZY/iS8ioC+U37yJCeppi9EHY05ewJKN64ASoBIseufZROtcFnX5GA==
+
 "@esbuild/darwin-arm64@0.16.13":
   version "0.16.13"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.16.13.tgz#0b80c8580c262ccfb1203053201cf19c6f7b4cdb"
@@ -2591,6 +2606,11 @@
   version "0.16.4"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.16.4.tgz#c19a6489d626c36fc611c85ccd8a3333c1f2a930"
   integrity sha512-a28X1O//aOfxwJVZVs7ZfM8Tyih2Za4nKJrBwW5Wm4yKsnwBy9aiS/xwpxiiTRttw3EaTg4Srerhcm6z0bu9Wg==
+
+"@esbuild/darwin-arm64@0.17.5":
+  version "0.17.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.17.5.tgz#61fb0546aa4bae0850817d6e0d008b1cb3f64b49"
+  integrity sha512-EAvaoyIySV6Iif3NQCglUNpnMfHSUgC5ugt2efl3+QDntucJe5spn0udNZjTgNi6tKVqSceOw9tQ32liNZc1Xw==
 
 "@esbuild/darwin-x64@0.16.13":
   version "0.16.13"
@@ -2607,6 +2627,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.16.4.tgz#b726bbc84a1e277f6ec2509d10b8ee03f242b776"
   integrity sha512-e3doCr6Ecfwd7VzlaQqEPrnbvvPjE9uoTpxG5pyLzr2rI2NMjDHmvY1E5EO81O/e9TUOLLkXA5m6T8lfjK9yAA==
 
+"@esbuild/darwin-x64@0.17.5":
+  version "0.17.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.17.5.tgz#54b770f0c49f524ae9ba24c85d6dea8b521f610d"
+  integrity sha512-ha7QCJh1fuSwwCgoegfdaljowwWozwTDjBgjD3++WAy/qwee5uUi1gvOg2WENJC6EUyHBOkcd3YmLDYSZ2TPPA==
+
 "@esbuild/freebsd-arm64@0.16.13":
   version "0.16.13"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.13.tgz#d1a45ac5c4a1be566c4eefbadbe5a967288ad338"
@@ -2621,6 +2646,11 @@
   version "0.16.4"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.4.tgz#364568e6ca2901297f247de0681c9b14bbe658c8"
   integrity sha512-Oup3G/QxBgvvqnXWrBed7xxkFNwAwJVHZcklWyQt7YCAL5bfUkaa6FVWnR78rNQiM8MqqLiT6ZTZSdUFuVIg1w==
+
+"@esbuild/freebsd-arm64@0.17.5":
+  version "0.17.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.5.tgz#be1dd18b7b9411f10bdc362ba8bff16386175367"
+  integrity sha512-VbdXJkn2aI2pQ/wxNEjEcnEDwPpxt3CWWMFYmO7CcdFBoOsABRy2W8F3kjbF9F/pecEUDcI3b5i2w+By4VQFPg==
 
 "@esbuild/freebsd-x64@0.16.13":
   version "0.16.13"
@@ -2637,6 +2667,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.16.4.tgz#44701ba4a5497ba64eec0a6c9e221d8f46a25e72"
   integrity sha512-vAP+eYOxlN/Bpo/TZmzEQapNS8W1njECrqkTpNgvXskkkJC2AwOXwZWai/Kc2vEFZUXQttx6UJbj9grqjD/+9Q==
 
+"@esbuild/freebsd-x64@0.17.5":
+  version "0.17.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.17.5.tgz#c9c1960fa3e1eada4e5d4be2a11a2f04ce14198f"
+  integrity sha512-olgGYND1/XnnWxwhjtY3/ryjOG/M4WfcA6XH8dBTH1cxMeBemMODXSFhkw71Kf4TeZFFTN25YOomaNh0vq2iXg==
+
 "@esbuild/linux-arm64@0.16.13":
   version "0.16.13"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.16.13.tgz#e8db3c3751b32ecf801751424eae43f6863a2ee7"
@@ -2651,6 +2686,11 @@
   version "0.16.4"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.16.4.tgz#b58fb418ec9ac714d8dbb38c787ff2441eb1d9db"
   integrity sha512-2zXoBhv4r5pZiyjBKrOdFP4CXOChxXiYD50LRUU+65DkdS5niPFHbboKZd/c81l0ezpw7AQnHeoCy5hFrzzs4g==
+
+"@esbuild/linux-arm64@0.17.5":
+  version "0.17.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.17.5.tgz#34d96d11c6899017ecae42fb97de8e0c3282902f"
+  integrity sha512-8a0bqSwu3OlLCfu2FBbDNgQyBYdPJh1B9PvNX7jMaKGC9/KopgHs37t+pQqeMLzcyRqG6z55IGNQAMSlCpBuqg==
 
 "@esbuild/linux-arm@0.16.13":
   version "0.16.13"
@@ -2667,6 +2707,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.16.4.tgz#b37f15ecddb53eeea466e5960e31a58f33e0e87e"
   integrity sha512-A47ZmtpIPyERxkSvIv+zLd6kNIOtJH03XA0Hy7jaceRDdQaQVGSDt4mZqpWqJYgDk9rg96aglbF6kCRvPGDSUA==
 
+"@esbuild/linux-arm@0.17.5":
+  version "0.17.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.17.5.tgz#86332e6293fd713a54ab299a5e2ed7c60c9e1c07"
+  integrity sha512-YBdCyQwA3OQupi6W2/WO4FnI+NWFWe79cZEtlbqSESOHEg7a73htBIRiE6uHPQe7Yp5E4aALv+JxkRLGEUL7tw==
+
 "@esbuild/linux-ia32@0.16.13":
   version "0.16.13"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.16.13.tgz#41ee9bd3b7161ab681fab6cb3990a3f5c08a9940"
@@ -2681,6 +2726,11 @@
   version "0.16.4"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.16.4.tgz#117e32a9680b5deac184ebee122f8575369fad1b"
   integrity sha512-uxdSrpe9wFhz4yBwt2kl2TxS/NWEINYBUFIxQtaEVtglm1eECvsj1vEKI0KX2k2wCe17zDdQ3v+jVxfwVfvvjw==
+
+"@esbuild/linux-ia32@0.17.5":
+  version "0.17.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.17.5.tgz#7bd9185c844e7dfce6a01dfdec584e115602a8c4"
+  integrity sha512-uCwm1r/+NdP7vndctgq3PoZrnmhmnecWAr114GWMRwg2QMFFX+kIWnp7IO220/JLgnXK/jP7VKAFBGmeOYBQYQ==
 
 "@esbuild/linux-loong64@0.16.13":
   version "0.16.13"
@@ -2697,6 +2747,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.16.4.tgz#dd504fb83c280752d4b485d9acb3cf391cb7bf5b"
   integrity sha512-peDrrUuxbZ9Jw+DwLCh/9xmZAk0p0K1iY5d2IcwmnN+B87xw7kujOkig6ZRcZqgrXgeRGurRHn0ENMAjjD5DEg==
 
+"@esbuild/linux-loong64@0.17.5":
+  version "0.17.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.17.5.tgz#2907d4120c7b3642b96be6014f77e7624c378eea"
+  integrity sha512-3YxhSBl5Sb6TtBjJu+HP93poBruFzgXmf3PVfIe4xOXMj1XpxboYZyw3W8BhoX/uwxzZz4K1I99jTE/5cgDT1g==
+
 "@esbuild/linux-mips64el@0.16.13":
   version "0.16.13"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.16.13.tgz#30d8571b71e0b8bf25fc5ef11422221ed23cdacc"
@@ -2711,6 +2766,11 @@
   version "0.16.4"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.16.4.tgz#9ab77e31cf3be1e35572afff94b51df8149d15bd"
   integrity sha512-sD9EEUoGtVhFjjsauWjflZklTNr57KdQ6xfloO4yH1u7vNQlOfAlhEzbyBKfgbJlW7rwXYBdl5/NcZ+Mg2XhQA==
+
+"@esbuild/linux-mips64el@0.17.5":
+  version "0.17.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.17.5.tgz#fc98be741e8080ecd13b404d5fca5302d3835bf4"
+  integrity sha512-Hy5Z0YVWyYHdtQ5mfmfp8LdhVwGbwVuq8mHzLqrG16BaMgEmit2xKO+iDakHs+OetEx0EN/2mUzDdfdktI+Nmg==
 
 "@esbuild/linux-ppc64@0.16.13":
   version "0.16.13"
@@ -2727,6 +2787,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.16.4.tgz#69d56c2a960808bee1c7b9b84a115220ec9ce05c"
   integrity sha512-X1HSqHUX9D+d0l6/nIh4ZZJ94eQky8d8z6yxAptpZE3FxCWYWvTDd9X9ST84MGZEJx04VYUD/AGgciddwO0b8g==
 
+"@esbuild/linux-ppc64@0.17.5":
+  version "0.17.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.17.5.tgz#ea12e8f6b290a613ac4903c9e00835c69ced065c"
+  integrity sha512-5dbQvBLbU/Y3Q4ABc9gi23hww1mQcM7KZ9KBqabB7qhJswYMf8WrDDOSw3gdf3p+ffmijMd28mfVMvFucuECyg==
+
 "@esbuild/linux-riscv64@0.16.13":
   version "0.16.13"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.16.13.tgz#6139202858da8202724d7079102614c269524f34"
@@ -2741,6 +2806,11 @@
   version "0.16.4"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.16.4.tgz#9fc23583f4a1508a8d352bd376340e42217e8a90"
   integrity sha512-97ANpzyNp0GTXCt6SRdIx1ngwncpkV/z453ZuxbnBROCJ5p/55UjhbaG23UdHj88fGWLKPFtMoU4CBacz4j9FA==
+
+"@esbuild/linux-riscv64@0.17.5":
+  version "0.17.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.17.5.tgz#ce47b15fd4227eeb0590826e41bdc430c5bfd06c"
+  integrity sha512-fp/KUB/ZPzEWGTEUgz9wIAKCqu7CjH1GqXUO2WJdik1UNBQ7Xzw7myIajpxztE4Csb9504ERiFMxZg5KZ6HlZQ==
 
 "@esbuild/linux-s390x@0.16.13":
   version "0.16.13"
@@ -2757,6 +2827,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.16.4.tgz#4cae1f70ac2943f076dd130c3c80d28f57bf75d1"
   integrity sha512-pUvPQLPmbEeJRPjP0DYTC1vjHyhrnCklQmCGYbipkep+oyfTn7GTBJXoPodR7ZS5upmEyc8lzAkn2o29wD786A==
 
+"@esbuild/linux-s390x@0.17.5":
+  version "0.17.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.17.5.tgz#962fa540d7498967270eb1d4b9ac6c4a4f339735"
+  integrity sha512-kRV3yw19YDqHTp8SfHXfObUFXlaiiw4o2lvT1XjsPZ++22GqZwSsYWJLjMi1Sl7j9qDlDUduWDze/nQx0d6Lzw==
+
 "@esbuild/linux-x64@0.16.13":
   version "0.16.13"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.16.13.tgz#deb7951829ea5930e0d88440aeb5df0756ebb2d0"
@@ -2771,6 +2846,11 @@
   version "0.16.4"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.16.4.tgz#fdf494de07cda23a2dc4b71ff1e0848e4ee6539c"
   integrity sha512-N55Q0mJs3Sl8+utPRPBrL6NLYZKBCLLx0bme/+RbjvMforTGGzFvsRl4xLTZMUBFC1poDzBEPTEu5nxizQ9Nlw==
+
+"@esbuild/linux-x64@0.17.5":
+  version "0.17.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.17.5.tgz#9fa52884c3d876593a522aa1d4df43b717907050"
+  integrity sha512-vnxuhh9e4pbtABNLbT2ANW4uwQ/zvcHRCm1JxaYkzSehugoFd5iXyC4ci1nhXU13mxEwCnrnTIiiSGwa/uAF1g==
 
 "@esbuild/netbsd-x64@0.16.13":
   version "0.16.13"
@@ -2787,6 +2867,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.16.4.tgz#b59ecb49087119c575c0f64d7e66001d52799e24"
   integrity sha512-LHSJLit8jCObEQNYkgsDYBh2JrJT53oJO2HVdkSYLa6+zuLJh0lAr06brXIkljrlI+N7NNW1IAXGn/6IZPi3YQ==
 
+"@esbuild/netbsd-x64@0.17.5":
+  version "0.17.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.17.5.tgz#47bb187b86aad9622051cb80c27e439b7d9e3a9a"
+  integrity sha512-cigBpdiSx/vPy7doUyImsQQBnBjV5f1M99ZUlaJckDAJjgXWl6y9W17FIfJTy8TxosEF6MXq+fpLsitMGts2nA==
+
 "@esbuild/openbsd-x64@0.16.13":
   version "0.16.13"
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.16.13.tgz#4ae19ac63c665424d248ba5c577618dd7bbcebd5"
@@ -2801,6 +2886,11 @@
   version "0.16.4"
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.16.4.tgz#c51e36db875948b7b11d08bafa355605a1aa289c"
   integrity sha512-nLgdc6tWEhcCFg/WVFaUxHcPK3AP/bh+KEwKtl69Ay5IBqUwKDaq/6Xk0E+fh/FGjnLwqFSsarsbPHeKM8t8Sw==
+
+"@esbuild/openbsd-x64@0.17.5":
+  version "0.17.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.17.5.tgz#abc55c35a1ed2bc3c5ede2ef50a3b2f87395009a"
+  integrity sha512-VdqRqPVIjjZfkf40LrqOaVuhw9EQiAZ/GNCSM2UplDkaIzYVsSnycxcFfAnHdWI8Gyt6dO15KHikbpxwx+xHbw==
 
 "@esbuild/sunos-x64@0.16.13":
   version "0.16.13"
@@ -2817,6 +2907,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.16.4.tgz#0b50e941cd44f069e9f2573321aec984244ec228"
   integrity sha512-08SluG24GjPO3tXKk95/85n9kpyZtXCVwURR2i4myhrOfi3jspClV0xQQ0W0PYWHioJj+LejFMt41q+PG3mlAQ==
 
+"@esbuild/sunos-x64@0.17.5":
+  version "0.17.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.17.5.tgz#b83c080a2147662599a5d18b2ff47f07c93e03a0"
+  integrity sha512-ItxPaJ3MBLtI4nK+mALLEoUs6amxsx+J1ibnfcYMkqaCqHST1AkF4aENpBehty3czqw64r/XqL+W9WqU6kc2Qw==
+
 "@esbuild/win32-arm64@0.16.13":
   version "0.16.13"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.16.13.tgz#965ebbe889e4221962250c55facaa1e48130c162"
@@ -2831,6 +2926,11 @@
   version "0.16.4"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.16.4.tgz#d1c93b20f17355ab2221cd18e13ae2f1b68013e3"
   integrity sha512-yYiRDQcqLYQSvNQcBKN7XogbrSvBE45FEQdH8fuXPl7cngzkCvpsG2H9Uey39IjQ6gqqc+Q4VXYHsQcKW0OMjQ==
+
+"@esbuild/win32-arm64@0.17.5":
+  version "0.17.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.17.5.tgz#2a4c41f427d9cf25b75f9d61493711a482106850"
+  integrity sha512-4u2Q6qsJTYNFdS9zHoAi80spzf78C16m2wla4eJPh4kSbRv+BpXIfl6TmBSWupD8e47B1NrTfrOlEuco7mYQtg==
 
 "@esbuild/win32-ia32@0.16.13":
   version "0.16.13"
@@ -2847,6 +2947,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.16.4.tgz#df5910e76660e0acbbdceb8d4ae6bf1efeade6ae"
   integrity sha512-5rabnGIqexekYkh9zXG5waotq8mrdlRoBqAktjx2W3kb0zsI83mdCwrcAeKYirnUaTGztR5TxXcXmQrEzny83w==
 
+"@esbuild/win32-ia32@0.17.5":
+  version "0.17.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.17.5.tgz#7c14e3250725d0e2c21f89c98eb6abb520cba0e0"
+  integrity sha512-KYlm+Xu9TXsfTWAcocLuISRtqxKp/Y9ZBVg6CEEj0O5J9mn7YvBKzAszo2j1ndyzUPk+op+Tie2PJeN+BnXGqQ==
+
 "@esbuild/win32-x64@0.16.13":
   version "0.16.13"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.16.13.tgz#0b0989cf0e7887cb0f3124e705cee68a694b96dd"
@@ -2861,6 +2966,11 @@
   version "0.16.4"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.16.4.tgz#6ec594468610c176933da1387c609558371d37e0"
   integrity sha512-sN/I8FMPtmtT2Yw+Dly8Ur5vQ5a/RmC8hW7jO9PtPSQUPkowxWpcUZnqOggU7VwyT3Xkj6vcXWd3V/qTXwultQ==
+
+"@esbuild/win32-x64@0.17.5":
+  version "0.17.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.17.5.tgz#a8f3d26d8afc5186eccda265ceb1820b8e8830be"
+  integrity sha512-XgA9qWRqby7xdYXuF6KALsn37QGBMHsdhmnpjfZtYxKxbTOwfnDM6MYi2WuUku5poNaX2n9XGVr20zgT/2QwCw==
 
 "@eslint/eslintrc@^1.2.3":
   version "1.3.3"
@@ -12449,6 +12559,34 @@ esbuild@^0.16.3:
     "@esbuild/win32-arm64" "0.16.4"
     "@esbuild/win32-ia32" "0.16.4"
     "@esbuild/win32-x64" "0.16.4"
+
+esbuild@^0.17.5:
+  version "0.17.5"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.17.5.tgz#cd76d75700d49ac050ad9eedfbed777bd6a9d930"
+  integrity sha512-Bu6WLCc9NMsNoMJUjGl3yBzTjVLXdysMltxQWiLAypP+/vQrf+3L1Xe8fCXzxaECus2cEJ9M7pk4yKatEwQMqQ==
+  optionalDependencies:
+    "@esbuild/android-arm" "0.17.5"
+    "@esbuild/android-arm64" "0.17.5"
+    "@esbuild/android-x64" "0.17.5"
+    "@esbuild/darwin-arm64" "0.17.5"
+    "@esbuild/darwin-x64" "0.17.5"
+    "@esbuild/freebsd-arm64" "0.17.5"
+    "@esbuild/freebsd-x64" "0.17.5"
+    "@esbuild/linux-arm" "0.17.5"
+    "@esbuild/linux-arm64" "0.17.5"
+    "@esbuild/linux-ia32" "0.17.5"
+    "@esbuild/linux-loong64" "0.17.5"
+    "@esbuild/linux-mips64el" "0.17.5"
+    "@esbuild/linux-ppc64" "0.17.5"
+    "@esbuild/linux-riscv64" "0.17.5"
+    "@esbuild/linux-s390x" "0.17.5"
+    "@esbuild/linux-x64" "0.17.5"
+    "@esbuild/netbsd-x64" "0.17.5"
+    "@esbuild/openbsd-x64" "0.17.5"
+    "@esbuild/sunos-x64" "0.17.5"
+    "@esbuild/win32-arm64" "0.17.5"
+    "@esbuild/win32-ia32" "0.17.5"
+    "@esbuild/win32-x64" "0.17.5"
 
 escalade@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
This PR upgrades esbuild version to latest (0.17.5), which comes with a breaking API change.

## Notes

- Both 0.17.0+ and older versions are supported (until Nx 16) <-- covered in e2e tests
- Migration will automatically upgrade users to esbuild@0.17.5
- Since we're using `onEnd` now instead of the removed `onRebuild`, we no longer need to handle first build vs rebuild separately (a lot cleaner) -- old code still needs this obviously

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14484
