### PR TITLE
fix(bundling): combine user-defined external esbuild options with ours

### DIFF
--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.spec.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.spec.ts
@@ -1,5 +1,6 @@
 import { buildEsbuildOptions } from './build-esbuild-options';
 import { ExecutorContext } from 'nx/src/config/misc-interfaces';
+import path = require('path');
 
 describe('buildEsbuildOptions', () => {
   const context: ExecutorContext = {
@@ -14,8 +15,8 @@ describe('buildEsbuildOptions', () => {
     },
     nxJsonConfiguration: {},
     isVerbose: false,
-    root: '/',
-    cwd: '/',
+    root: path.join(__dirname, 'fixtures'),
+    cwd: path.join(__dirname, 'fixtures'),
     target: {
       executor: '@nrwl/esbuild:esbuild',
       options: {
@@ -271,6 +272,75 @@ describe('buildEsbuildOptions', () => {
       outfile: 'dist/apps/myapp/index.js',
       tsconfig: 'apps/myapp/tsconfig.app.json',
       external: [],
+      outExtension: {
+        '.js': '.js',
+      },
+    });
+  });
+
+  it('should respect user defined external', () => {
+    expect(
+      buildEsbuildOptions(
+        'esm',
+        {
+          bundle: true,
+          platform: 'node',
+          main: 'apps/myapp/src/index.ts',
+          outputPath: 'dist/apps/myapp',
+          tsConfig: 'apps/myapp/tsconfig.app.json',
+          project: 'apps/myapp/package.json',
+          outputFileName: 'index.js',
+          assets: [],
+          singleEntry: true,
+          external: ['foo'],
+          esbuildOptions: {
+            external: ['bar'],
+          },
+        },
+        context
+      )
+    ).toEqual({
+      bundle: true,
+      entryNames: '[dir]/[name]',
+      entryPoints: ['apps/myapp/src/index.ts'],
+      format: 'esm',
+      platform: 'node',
+      outfile: 'dist/apps/myapp/index.js',
+      tsconfig: 'apps/myapp/tsconfig.app.json',
+      external: ['bar', 'foo'],
+      outExtension: {
+        '.js': '.js',
+      },
+    });
+  });
+
+  it('should not set external if --bundle=false', () => {
+    expect(
+      buildEsbuildOptions(
+        'esm',
+        {
+          bundle: false,
+          platform: 'node',
+          main: 'apps/myapp/src/index.ts',
+          outputPath: 'dist/apps/myapp',
+          tsConfig: 'apps/myapp/tsconfig.app.json',
+          project: 'apps/myapp/package.json',
+          outputFileName: 'index.js',
+          assets: [],
+          singleEntry: true,
+          external: ['foo'],
+        },
+        context
+      )
+    ).toEqual({
+      bundle: false,
+      entryNames: '[dir]/[name]',
+      entryPoints: ['apps/myapp/src/index.ts'],
+      format: 'esm',
+      platform: 'node',
+      outdir: 'dist/apps/myapp',
+      tsconfig: 'apps/myapp/tsconfig.app.json',
+      external: undefined,
       outExtension: {
         '.js': '.js',
       },

--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
@@ -24,7 +24,10 @@ export function buildEsbuildOptions(
     entryNames:
       options.outputHashing === 'all' ? '[dir]/[name].[hash]' : '[dir]/[name]',
     bundle: options.bundle,
-    external: options.external,
+    // Cannot use external with bundle option
+    external: options.bundle
+      ? [...(options.esbuildOptions?.external ?? []), ...options.external]
+      : undefined,
     minify: options.minify,
     platform: options.platform,
     target: options.target,

--- a/packages/esbuild/src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json
+++ b/packages/esbuild/src/executors/esbuild/lib/fixtures/apps/myapp/tsconfig.app.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "paths": {}
+  }
+}


### PR DESCRIPTION
If users define their own 'esbuildOptions.external`, Nx should combine that with its own.

## Notes

- If `bundle: false` then `external` should be set to `undefined`, otherwise esbuild will error.
