### PR TITLE
fix(vite): fix watch schema for build executor to object or boolean i…

### DIFF
--- a/docs/generated/packages/vite/executors/build.json
+++ b/docs/generated/packages/vite/executors/build.json
@@ -81,8 +81,8 @@
       },
       "watch": {
         "description": "Enable re-building when files change.",
-        "type": "object",
-        "default": null
+        "oneOf": [{ "type": "boolean" }, { "type": "object" }],
+        "default": false
       }
     },
     "definitions": {},

--- a/packages/vite/src/executors/build/build.impl.ts
+++ b/packages/vite/src/executors/build/build.impl.ts
@@ -15,13 +15,14 @@ export default async function* viteBuildExecutor(
   options: ViteBuildExecutorOptions,
   context: ExecutorContext
 ) {
+  const normalizedOptions = normalizeOptions(options);
   const projectRoot =
     context.projectsConfigurations.projects[context.projectName].root;
 
   const buildConfig = mergeConfig(
-    getViteSharedConfig(options, false, context),
+    getViteSharedConfig(normalizedOptions, false, context),
     {
-      build: getViteBuildOptions(options, context),
+      build: getViteBuildOptions(normalizedOptions, context),
     }
   );
 
@@ -37,7 +38,7 @@ export default async function* viteBuildExecutor(
   ) {
     await copyAssets(
       {
-        outputPath: options.outputPath,
+        outputPath: normalizedOptions.outputPath,
         assets: [
           {
             input: projectRoot,
@@ -78,4 +79,17 @@ function runInstance(options: InlineConfig) {
   return build({
     ...options,
   });
+}
+
+function normalizeOptions(options: ViteBuildExecutorOptions) {
+  const normalizedOptions = { ...options };
+
+  // coerce watch to null or {} to match with Vite's watch config
+  if (options.watch === false) {
+    normalizedOptions.watch = null;
+  } else if (options.watch === true) {
+    normalizedOptions.watch = {};
+  }
+
+  return normalizedOptions;
 }

--- a/packages/vite/src/executors/build/schema.d.ts
+++ b/packages/vite/src/executors/build/schema.d.ts
@@ -12,5 +12,5 @@ export interface ViteBuildExecutorOptions {
   logLevel?: 'info' | 'warn' | 'error' | 'silent';
   mode?: string;
   ssr?: boolean | string;
-  watch?: object | null;
+  watch?: object | boolean;
 }

--- a/packages/vite/src/executors/build/schema.json
+++ b/packages/vite/src/executors/build/schema.json
@@ -121,8 +121,15 @@
     },
     "watch": {
       "description": "Enable re-building when files change.",
-      "type": "object",
-      "default": null
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object"
+        }
+      ],
+      "default": false
     }
   },
   "definitions": {},

--- a/packages/vite/src/utils/options-utils.ts
+++ b/packages/vite/src/utils/options-utils.ts
@@ -142,7 +142,7 @@ export function getViteBuildOptions(
     manifest: options.manifest,
     ssrManifest: options.ssrManifest,
     ssr: options.ssr,
-    watch: options.watch,
+    watch: options.watch as BuildOptions['watch'],
   };
 }
 


### PR DESCRIPTION
…nstead of null

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
__only happens if we run the executor via `ng`__
A schema property with `type: object, default: null` or `type: object` without default value is always coerced to `{}`. This is due to Angular CLI using `ajv` as their schema validation. 

For Vite's watch configuration, `{}` is a valid value to turn on the watcher which means our default value for `watch` (as `null`) ends up turning on the watcher

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`watch` value should control the watcher correctly.

`watch` is now an `object | boolean` instead, and the default value is `false`. If `false`, we turn it to `null` (to disable the watcher), if `true`, then we turn it into an `{}`, if it is an `object`, we leave it alone

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
