### PR TITLE
chore(repo): do not use tsconfig paths for release

### DIFF
--- a/nx-dev/nx-dev/project.json
+++ b/nx-dev/nx-dev/project.json
@@ -16,7 +16,7 @@
         "outputPath": "dist/nx-dev/nx-dev",
         "commands": [
           "nx run nx-dev:sitemap",
-          "ts-node -P ./scripts/tsconfig.scripts.json ./scripts/documentation/internal-link-checker.ts"
+          "ts-node -P ./scripts/tsconfig.release.json ./scripts/documentation/internal-link-checker.ts"
         ],
         "parallel": false
       }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "check-documentation-map": "ts-node -P ./scripts/tsconfig.scripts.json ./scripts/documentation/map-link-checker.ts",
     "e2e-start-local-registry": "node ./scripts/e2e-start-local-registry.js",
     "e2e-build-package-publish": "ts-node -P ./scripts/tsconfig.e2e.json ./scripts/e2e-build-package-publish.ts",
-    "nx-release": "ts-node -P ./scripts/tsconfig.scripts.json ./scripts/nx-release",
+    "nx-release": "ts-node -P ./scripts/tsconfig.release.json ./scripts/nx-release",
     "prepublishOnly": "node ./scripts/update-package-group.js",
     "version": "npx prettier lerna.json --write",
     "depcheck": "ts-node -P ./scripts/tsconfig.scripts.json ./scripts/depcheck",

--- a/scripts/tsconfig.release.json
+++ b/scripts/tsconfig.release.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../scripts/tools-out",
+    "module": "commonjs",
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The scripts tsconfig brings in paths and it messes with the lerna import in nx-release.ts

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The release script uses tsconfig.release.json brings in paths and it messes with the lerna import in nx-release.ts

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
