### PR TITLE
fix(angular): ensure required peer deps are installed when migrating from angular cli workspaces

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -56,7 +56,6 @@
     "webpack-merge": "5.7.3"
   },
   "peerDependencies": {
-    "@angular-devkit/architect": ">= 0.1400.0 < 0.1600.0",
     "@angular-devkit/build-angular": ">= 14.0.0 < 16.0.0",
     "@angular-devkit/schematics": ">= 14.0.0 < 16.0.0",
     "@schematics/angular": ">= 14.0.0 < 16.0.0",

--- a/packages/angular/src/generators/ng-add/migrate-from-angular-cli.ts
+++ b/packages/angular/src/generators/ng-add/migrate-from-angular-cli.ts
@@ -18,6 +18,7 @@ import {
   createWorkspaceFiles,
   deleteAngularJson,
   deleteGitKeepFilesIfNotNeeded,
+  ensureAngularDevKitPeerDependenciesAreInstalled,
   formatFilesTask,
   getAllProjects,
   getWorkspaceRootFileTypesInfo,
@@ -40,6 +41,7 @@ export async function migrateFromAngularCli(
   const options = normalizeOptions(tree, rawOptions, projects);
 
   const angularJson = readJson(tree, 'angular.json') as any;
+  ensureAngularDevKitPeerDependenciesAreInstalled(tree);
 
   if (options.preserveAngularCliLayout) {
     addDependenciesToPackageJson(

--- a/packages/angular/src/generators/ng-add/utilities/dependencies.ts
+++ b/packages/angular/src/generators/ng-add/utilities/dependencies.ts
@@ -1,0 +1,35 @@
+import { addDependenciesToPackageJson, readJson, Tree } from '@nrwl/devkit';
+import { getPkgVersionForAngularMajorVersion } from '../../../utils/version-utils';
+import { getInstalledAngularMajorVersion } from '../../utils/version-utils';
+
+export function ensureAngularDevKitPeerDependenciesAreInstalled(
+  tree: Tree
+): void {
+  const packagesToInstall = [
+    '@angular-devkit/core',
+    '@angular-devkit/schematics',
+    '@schematics/angular',
+  ];
+
+  const { devDependencies, dependencies } = readJson(tree, 'package.json');
+  let angularCliVersion =
+    devDependencies?.['@angular/cli'] ?? dependencies?.['@angular/cli'];
+
+  if (!angularCliVersion) {
+    const angularMajorVersion = getInstalledAngularMajorVersion(tree);
+    const angularDevkitVersion = getPkgVersionForAngularMajorVersion(
+      'angularDevkitVersion',
+      angularMajorVersion
+    );
+    angularCliVersion = angularDevkitVersion;
+  }
+
+  const filteredPackages = packagesToInstall
+    .filter((pkg) => !devDependencies?.[pkg] && !dependencies?.[pkg])
+    .reduce((allPkgs, pkg) => {
+      allPkgs[pkg] = angularCliVersion;
+      return allPkgs;
+    }, {} as Record<string, string>);
+
+  addDependenciesToPackageJson(tree, {}, filteredPackages);
+}

--- a/packages/angular/src/generators/ng-add/utilities/index.ts
+++ b/packages/angular/src/generators/ng-add/utilities/index.ts
@@ -1,3 +1,4 @@
+export * from './dependencies';
 export * from './file-change-recorder';
 export * from './format-files-task';
 export * from './logger';

--- a/packages/angular/src/migrations/update-15-7-0/install-required-packages.ts
+++ b/packages/angular/src/migrations/update-15-7-0/install-required-packages.ts
@@ -18,13 +18,13 @@ export default async function (tree: Tree) {
   );
 
   const angularCliVersion =
-    pkgJson.devDependencies['@angular/cli'] ??
-    pkgJson.dependencies['@angular/cli'] ??
+    pkgJson.devDependencies?.['@angular/cli'] ??
+    pkgJson.dependencies?.['@angular/cli'] ??
     angularDevkitVersion;
 
   const filteredPackages: Record<string, string> = packagesToInstall
     .filter(
-      (pkg) => !pkgJson.devDependencies[pkg] && !pkgJson.dependencies[pkg]
+      (pkg) => !pkgJson.devDependencies?.[pkg] && !pkgJson.dependencies?.[pkg]
     )
     .reduce((allPkgs, pkg) => ({ ...allPkgs, [pkg]: angularCliVersion }), {});
 


### PR DESCRIPTION
Install required peerDependencies of the `@nrwl/angular` plugin when migrating from an Angular CLI workspace to an Nx workspace.