### PR TITLE
cleanup(core): add x-priority to properties

### DIFF
--- a/packages/nx/src/utils/params.ts
+++ b/packages/nx/src/utils/params.ts
@@ -37,6 +37,7 @@ type PropertyDescription = {
     | { message: string; type: string; items?: any[]; multiselect?: boolean };
   'x-deprecated'?: boolean | string;
   'x-dropdown'?: 'projects';
+  'x-priority'?: 'important' | 'internal';
 
   // Numbers Only
   multipleOf?: number;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We've been using `x-priority` to sort flags but the fact that this property exists isn't reflected in any types.

## Expected Behavior
Folks using Nx should know about this property (for example in Nx Console, we consume the type updated here).

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
