### PR TITLE
fix(core): `anyOf` should validate if at least 1 condition passes

### DIFF
--- a/packages/nx/src/utils/params.spec.ts
+++ b/packages/nx/src/utils/params.spec.ts
@@ -877,6 +877,38 @@ describe('params', () => {
       `);
     });
 
+    it('should not throw if one of the anyOf conditions is met', () => {
+      expect(() =>
+        validateOptsAgainstSchema(
+          {
+            a: true
+          },
+
+          {
+            properties: {
+              a: {
+                type: 'boolean',
+              },
+
+              b: {
+                type: 'boolean',
+              },
+            },
+
+            anyOf: [
+              {
+                required: ['a'],
+              },
+
+              {
+                required: ['b'],
+              },
+            ],
+          }
+        )
+      ).not.toThrow();
+    });
+
     it('should throw if found an unknown property', () => {
       expect(() =>
         validateOptsAgainstSchema(

--- a/packages/nx/src/utils/params.spec.ts
+++ b/packages/nx/src/utils/params.spec.ts
@@ -881,7 +881,7 @@ describe('params', () => {
       expect(() =>
         validateOptsAgainstSchema(
           {
-            a: true
+            a: true,
           },
 
           {

--- a/packages/nx/src/utils/params.ts
+++ b/packages/nx/src/utils/params.ts
@@ -234,7 +234,7 @@ export function validateObject(
         errors.push(e);
       }
     }
-    if (errors.length > 0) {
+    if (errors.length === schema.anyOf.length) {
       throw new Error(
         `Options did not match schema. Please fix any of the following errors:\n${errors
           .map((e) => ' - ' + e.message)
@@ -339,7 +339,7 @@ function validateProperty(
 
   if (schema.allOf) {
     if (!Array.isArray(schema.allOf))
-      throw new Error(`Invalid schema file. anyOf must be an array.`);
+      throw new Error(`Invalid schema file. allOf must be an array.`);
 
     if (
       !schema.allOf.every((r) => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
build command fails if schema has 2 `anyOf` objects but only one is satisfied: [Angular Universal Schema](https://github.com/angular/universal/blob/main/modules/builders/src/prerender/schema.json)

## Expected Behavior
`anyOf` – validates the value against any (one or more) of the subschemas

## Related Issue(s)
None
