### PR TITLE
fix(js): Avoid `@babel/preset-env` warning in js/babel.ts

### DIFF
--- a/packages/js/babel.ts
+++ b/packages/js/babel.ts
@@ -57,7 +57,7 @@ module.exports = function (api: any, options: NxWebBabelPresetOptions = {}) {
           : {
               // Allow importing core-js in entrypoint and use browserslist to select polyfills.
               useBuiltIns: options.useBuiltIns ?? 'entry',
-              corejs: 3,
+              corejs: options.useBuiltIns !== false ? 3 : null,
               // Do not transform modules to CJS
               modules: false,
               targets: isModern ? { esmodules: 'intersect' } : undefined,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When setting `useBuiltIns` to `false` while leaving `corejs` set to `3`, `@babel/preset-env` will give the warning in its output: 

```
WARNING (@babel/preset-env): The `corejs` option only has an effect when the `useBuiltIns` option is not `false`
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

There should not be that warning since `useBuiltIns` was explicitly set to false. By setting `corejs` to `null` when `useBuiltIns` is set to `false`, the warning gets suppressed.


See also: https://github.com/babel/babel/blob/main/packages/babel-preset-env/src/normalize-options.ts
