### PR TITLE
fix(bundling): support additionalEntryPoints properly

### DIFF
--- a/e2e/esbuild/src/esbuild.test.ts
+++ b/e2e/esbuild/src/esbuild.test.ts
@@ -172,4 +172,22 @@ describe('EsBuild Plugin', () => {
     // Check that the build is correct
     expect(runCommand(`node dist/libs/${myPkg}`)).toMatch(/new API/);
   }, 120_000);
+
+  it('should support additional entry points', () => {
+    const myPkg = uniq('my-pkg');
+    runCLI(`generate @nrwl/js:lib ${myPkg} --bundler=esbuild`);
+    updateFile(`libs/${myPkg}/src/index.ts`, `console.log('main');\n`);
+    updateFile(`libs/${myPkg}/src/extra.ts`, `console.log('extra');\n`);
+    updateProjectConfig(myPkg, (json) => {
+      json.targets.build.options.additionalEntryPoints = [
+        `libs/${myPkg}/src/extra.ts`,
+      ];
+      return json;
+    });
+
+    runCommand(`build ${myPkg}`);
+
+    expect(runCommand(`node dist/libs/${myPkg}/main.js`)).toMatch(/main/);
+    expect(runCommand(`node dist/libs/${myPkg}/extra.js`)).toMatch(/extra/);
+  });
 });

--- a/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
+++ b/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
@@ -179,6 +179,7 @@ export async function* esbuildExecutor(
         yield {
           success: buildResult.errors.length === 0,
           // Need to call getOutfile directly in the case of bundle=false and outfile is not set for esbuild.
+          // This field is needed for `@nrwl/js:node` executor to work.
           outfile: join(context.root, getOutfile(format, options, context)),
         };
       }
@@ -223,6 +224,7 @@ export async function* esbuildExecutor(
                         next({
                           success,
                           // Need to call getOutfile directly in the case of bundle=false and outfile is not set for esbuild.
+                          // This field is needed for `@nrwl/js:node` executor to work.
                           outfile: join(
                             context.root,
                             getOutfile(format, options, context)

--- a/packages/esbuild/src/executors/esbuild/lib/normalize.spec.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/normalize.spec.ts
@@ -38,6 +38,7 @@ describe('normalizeOptions', () => {
       tsConfig: 'apps/myapp/tsconfig.app.json',
       project: 'apps/myapp/package.json',
       assets: [],
+      outputFileName: 'index.js',
       additionalEntryPoints: ['apps/myapp/src/extra-entry.ts'],
       singleEntry: false,
       external: [],

--- a/packages/esbuild/src/executors/esbuild/lib/normalize.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/normalize.ts
@@ -18,6 +18,10 @@ export function normalizeOptions(
       ...rest,
       external: options.external ?? [],
       singleEntry: false,
+      // Use the `main` file name as the output file name.
+      // This is needed for `@nrwl/js:node` to know the main file to execute.
+      // NOTE: The .js default extension may be replaced later in getOutfile() call.
+      outputFileName: `${parse(options.main).name}.js`,
     };
   } else {
     return {
@@ -25,6 +29,7 @@ export function normalizeOptions(
       external: options.external ?? [],
       singleEntry: true,
       outputFileName:
+        // NOTE: The .js default extension may be replaced later in getOutfile() call.
         options.outputFileName ?? `${parse(options.main).name}.js`,
     };
   }


### PR DESCRIPTION
This PR fixes an issue with `additionalEntryPoints` and generating the `outfile` for `@nrwl/js:node` executor.

## Current Behavior
Currently, specifying `additionalEntryPoints` is not working.

## Expected Behavior
`additionalEntryPoints` should work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
