### PR TITLE
docs(core): add view-logs description

### DIFF
--- a/docs/generated/cli/view-logs.md
+++ b/docs/generated/cli/view-logs.md
@@ -1,0 +1,16 @@
+---
+title: 'view-logs - CLI command'
+description: 'Enables you to view and interact with the logs via the advanced analytic UI from Nx Cloud to help you debug your issue. To do this, Nx needs to connect your workspace to Nx Cloud and upload the most recent run details. Only the metrics are uploaded, not the artefacts.'
+---
+
+# view-logs
+
+Enables you to view and interact with the logs via the advanced analytic UI from Nx Cloud to help you debug your issue. To do this, Nx needs to connect your workspace to Nx Cloud and upload the most recent run details. Only the metrics are uploaded, not the artefacts.
+
+## Usage
+
+```shell
+nx view-logs
+```
+
+Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpm nx`.

--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -5257,6 +5257,14 @@
                 "isExternal": false,
                 "children": [],
                 "disableCollapsible": false
+              },
+              {
+                "name": "view-logs",
+                "path": "/packages/nx/documents/view-logs",
+                "id": "view-logs",
+                "isExternal": false,
+                "children": [],
+                "disableCollapsible": false
               }
             ],
             "isExternal": false,

--- a/docs/generated/manifests/packages.json
+++ b/docs/generated/manifests/packages.json
@@ -1847,6 +1847,17 @@
         "path": "/packages/nx/documents/show",
         "tags": [],
         "originalFilePath": "generated/cli/show"
+      },
+      "/packages/nx/documents/view-logs": {
+        "id": "view-logs",
+        "name": "view-logs",
+        "description": "The core Nx plugin contains the core functionality of Nx like the project graph, nx commands and task orchestration.",
+        "file": "generated/packages/nx/documents/view-logs",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/packages/nx/documents/view-logs",
+        "tags": [],
+        "originalFilePath": "generated/cli/view-logs"
       }
     },
     "root": "/packages/nx",

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -1825,6 +1825,17 @@
         "path": "nx/documents/show",
         "tags": [],
         "originalFilePath": "generated/cli/show"
+      },
+      {
+        "id": "view-logs",
+        "name": "view-logs",
+        "description": "The core Nx plugin contains the core functionality of Nx like the project graph, nx commands and task orchestration.",
+        "file": "generated/packages/nx/documents/view-logs",
+        "itemList": [],
+        "isExternal": false,
+        "path": "nx/documents/view-logs",
+        "tags": [],
+        "originalFilePath": "generated/cli/view-logs"
       }
     ],
     "executors": [

--- a/docs/generated/packages/nx/documents/view-logs.md
+++ b/docs/generated/packages/nx/documents/view-logs.md
@@ -1,0 +1,16 @@
+---
+title: 'view-logs - CLI command'
+description: 'Enables you to view and interact with the logs via the advanced analytic UI from Nx Cloud to help you debug your issue. To do this, Nx needs to connect your workspace to Nx Cloud and upload the most recent run details. Only the metrics are uploaded, not the artefacts.'
+---
+
+# view-logs
+
+Enables you to view and interact with the logs via the advanced analytic UI from Nx Cloud to help you debug your issue. To do this, Nx needs to connect your workspace to Nx Cloud and upload the most recent run details. Only the metrics are uploaded, not the artefacts.
+
+## Usage
+
+```shell
+nx view-logs
+```
+
+Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpm nx`.

--- a/docs/map.json
+++ b/docs/map.json
@@ -1493,6 +1493,11 @@
               "name": "show",
               "id": "show",
               "file": "generated/cli/show"
+            },
+            {
+              "name": "view-logs",
+              "id": "view-logs",
+              "file": "generated/cli/view-logs"
             }
           ]
         },

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -165,7 +165,7 @@ export const commandsObject = yargs
     command: 'affected:libs',
     deprecated:
       'Use `nx print-affected --type=lib ...` instead. This command will be removed in v15.',
-    describe: `Print libraries affected by changes`,
+    describe: 'Print libraries affected by changes',
     builder: (yargs) =>
       linkToNxDevAndExamples(
         withAffectedOptions(withPlainOption(yargs)),
@@ -369,7 +369,8 @@ export const commandsObject = yargs
   })
   .command({
     command: 'view-logs',
-    describe: false,
+    describe:
+      'Enables you to view and interact with the logs via the advanced analytic UI from Nx Cloud to help you debug your issue. To do this, Nx needs to connect your workspace to Nx Cloud and upload the most recent run details. Only the metrics are uploaded, not the artefacts.',
     handler: async () =>
       process.exit(await (await import('./view-logs')).viewLogs()),
   })


### PR DESCRIPTION
It adds a description to the `view-logs` command which make possible to index and reference the command in the documentation website.