### PR TITLE
fix(node): quote filepath in cli e2e sample test

### DIFF
--- a/packages/node/src/generators/e2e-project/e2e-project.spec.ts
+++ b/packages/node/src/generators/e2e-project/e2e-project.spec.ts
@@ -38,4 +38,33 @@ describe('e2eProjectGenerator', () => {
 
     expect(tree.exists(`e2e/src/server/server.spec.ts`)).toBeTruthy();
   });
+
+  it('should generate cli project', async () => {
+    await applicationGenerator(tree, {
+      name: 'api',
+      framework: 'none',
+      e2eTestRunner: 'none',
+    });
+    await e2eProjectGenerator(tree, {
+      projectType: 'cli',
+      project: 'api',
+    });
+    expect(tree.read('api-e2e/src/api/api.spec.ts', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "import { execSync } from 'child_process';
+      import { join } from 'path';
+
+      describe('CLI tests', () => {
+        it('should print a message', () => {
+          const cliPath = join(process.cwd(), \\"dist/api\\");
+
+          const output = execSync(\`node \${cliPath}\`).toString();
+
+          expect(output).toMatch(/Hello World/);
+        });
+      });
+
+      "
+    `);
+  });
 });

--- a/packages/node/src/generators/e2e-project/files/cli/src/__fileName__/__fileName__.spec.ts__tmpl__
+++ b/packages/node/src/generators/e2e-project/files/cli/src/__fileName__/__fileName__.spec.ts__tmpl__
@@ -3,7 +3,7 @@ import { join } from 'path';
 
 describe('CLI tests', () => {
   it('should print a message', () => {
-    const cliPath = join(process.cwd(), <%= mainFile %>);
+    const cliPath = join(process.cwd(), "<%= mainFile %>");
 
     const output = execSync(`node ${cliPath}`).toString();
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

generated sample e2e spec doesn't run for cli node projects

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

generated test works out of the box

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14761
