### PR TITLE
fix(core): update ensurePackage util with workaround for bad module cache

### DIFF
--- a/packages/devkit/src/utils/package-json.spec.ts
+++ b/packages/devkit/src/utils/package-json.spec.ts
@@ -456,6 +456,16 @@ describe('ensurePackage', () => {
     tree = createTree();
   });
 
+  it('should return successfully when package is present', async () => {
+    writeJson(tree, 'package.json', {});
+
+    await expect(
+      ensurePackage(tree, '@nrwl/devkit', '>=15.0.0', {
+        throwOnMissing: true,
+      })
+    ).resolves.toBeUndefined(); // return void
+  });
+
   it('should throw when dependencies are missing', async () => {
     writeJson(tree, 'package.json', {});
 


### PR DESCRIPTION
The current `ensurePackage` function from `@nrwl/devkit` fails for some packages like `typescript` due to bad module cache (Note: not require cache, but module/file cache).

See the problem here: https://github.com/jaysoo/ts-resolve-pkg

The solution is to avoid `require.resolve` or `require` when detecting the locally installed package version. Instead, use a sandboxed `require` from `createRequire(...)` to avoid any pollution.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
```js
await ensurePackage(tree, 'typescript')
await import(`typescript`) // fails
```

## Expected Behavior
```js
await ensurePackage(tree, 'typescript')
await import(`typescript`) // works
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
