### PR TITLE
chore(repo): inline native module requires so jest CLI runs successfully

### DIFF
--- a/packages/nx/src/hasher/native-file-hasher.ts
+++ b/packages/nx/src/hasher/native-file-hasher.ts
@@ -1,11 +1,12 @@
 import { FileHasherBase } from './file-hasher-base';
 import { performance } from 'perf_hooks';
-import { hashFile, hashFiles } from '../native';
 import { workspaceRoot } from '../utils/app-root';
 
 export class NativeFileHasher extends FileHasherBase {
   async init(): Promise<void> {
     performance.mark('init hashing:start');
+    // Import as needed. There is also an issue running unit tests in Nx repo if this is a top-level import.
+    const { hashFiles } = require('../native');
     this.clear();
     const filesObject = hashFiles(workspaceRoot);
     this.fileHashes = new Map(Object.entries(filesObject));
@@ -29,6 +30,8 @@ export class NativeFileHasher extends FileHasherBase {
   }
 
   hashFile(path: string): string {
+    // Import as needed. There is also an issue running unit tests in Nx repo if this is a top-level import.
+    const { hashFile } = require('../native');
     return hashFile(path).hash;
   }
 }


### PR DESCRIPTION
> NOTE: This only applies to the Nx repo itself.

When running Jest from IDEs or CLI, and the cwd is not worksapce root, the `__dirname` variable is resolved to the wrong path inside `packages/nx/src/native/index.js`. Not entirely sure why that's the case, but inlining the require is a workaround to allow tests to run from IDEs again.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
