### PR TITLE
feat(node): Added E2E project generation option to NestJs app generator 

### DIFF
--- a/docs/generated/packages/nest/generators/application.json
+++ b/docs/generated/packages/nest/generators/application.json
@@ -43,6 +43,12 @@
         "enum": ["jest", "none"],
         "default": "jest"
       },
+      "e2eTestRunner": {
+        "type": "string",
+        "enum": ["jest", "none"],
+        "description": "Test runner to use for end to end (e2e) tests",
+        "default": "jest"
+      },
       "tags": {
         "description": "Add tags to the application (used for linting).",
         "type": "string"

--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -13,6 +13,15 @@ describe('application generator', () => {
     jest.clearAllMocks();
   });
 
+  it('should generate project configurations', async () => {
+    await applicationGenerator(tree, { name: appName });
+
+    const projectConfigurations = devkit.getProjects(tree);
+
+    expect(projectConfigurations.get(appDirectory)).toBeTruthy();
+    expect(projectConfigurations.get(`${appDirectory}-e2e`)).toBeTruthy();
+  });
+
   it('should generate files', async () => {
     await applicationGenerator(tree, { name: appName });
 
@@ -65,6 +74,19 @@ describe('application generator', () => {
       await applicationGenerator(tree, { name: appName, skipFormat: true });
 
       expect(devkit.formatFiles).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('--e2e-test-runner none', () => {
+    it('should not generate e2e test project', async () => {
+      await applicationGenerator(tree, {
+        name: appName,
+        e2eTestRunner: 'none',
+      });
+
+      const projectConfigurations = devkit.getProjects(tree);
+
+      expect(projectConfigurations.get(`${appDirectory}-e2e`)).toBeUndefined();
     });
   });
 });

--- a/packages/nest/src/generators/application/lib/normalize-options.ts
+++ b/packages/nest/src/generators/application/lib/normalize-options.ts
@@ -26,6 +26,7 @@ export function normalizeOptions(
     appProjectRoot,
     linter: options.linter ?? Linter.EsLint,
     unitTestRunner: options.unitTestRunner ?? 'jest',
+    e2eTestRunner: options.e2eTestRunner ?? 'jest',
   };
 }
 
@@ -42,6 +43,7 @@ export function toNodeApplicationGeneratorOptions(
     standaloneConfig: options.standaloneConfig,
     tags: options.tags,
     unitTestRunner: options.unitTestRunner,
+    e2eTestRunner: options.e2eTestRunner,
     setParserOptionsProject: options.setParserOptionsProject,
     bundler: 'webpack', // Some features require webpack plugins such as TS transformers
   };

--- a/packages/nest/src/generators/application/schema.d.ts
+++ b/packages/nest/src/generators/application/schema.d.ts
@@ -1,5 +1,4 @@
 import { Linter } from '@nrwl/linter';
-import { UnitTestRunner } from '../../utils/test-runners';
 
 export interface ApplicationGeneratorOptions {
   name: string;
@@ -10,7 +9,8 @@ export interface ApplicationGeneratorOptions {
   skipPackageJson?: boolean;
   standaloneConfig?: boolean;
   tags?: string;
-  unitTestRunner?: UnitTestRunner;
+  unitTestRunner?: 'jest' | 'none';
+  e2eTestRunner?: 'jest' | 'none';
   setParserOptionsProject?: boolean;
 }
 

--- a/packages/nest/src/generators/application/schema.json
+++ b/packages/nest/src/generators/application/schema.json
@@ -43,6 +43,12 @@
       "enum": ["jest", "none"],
       "default": "jest"
     },
+    "e2eTestRunner": {
+      "type": "string",
+      "enum": ["jest", "none"],
+      "description": "Test runner to use for end to end (e2e) tests",
+      "default": "jest"
+    },
     "tags": {
       "description": "Add tags to the application (used for linting).",
       "type": "string"


### PR DESCRIPTION
## Current Behavior
Since E2E project generation option has been added to Node app generator, NestJS app generator always generates E2E project

## Expected Behavior
This PR adds a E2E test runner option to NestJS application generator schema, so you can choose not to have E2E tests with your NestJS project

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Implements #14572 