### PR TITLE
fix(vite): resolve dev & preview server promises on process exit

### DIFF
--- a/packages/vite/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/vite/src/executors/dev-server/dev-server.impl.ts
@@ -58,8 +58,11 @@ export default async function* viteDevServerExecutor(
     };
   }
 
-  // This Promise intentionally never resolves, leaving the process running
-  await new Promise(() => {});
+  await new Promise<void>((resolve) => {
+    process.once('SIGINT', () => resolve());
+    process.once('SIGTERM', () => resolve());
+    process.once('exit', () => resolve());
+  });
 }
 
 async function runViteDevServer(server: ViteDevServer): Promise<void> {
@@ -68,12 +71,9 @@ async function runViteDevServer(server: ViteDevServer): Promise<void> {
 
   const processOnExit = async () => {
     await server.close();
-    process.off('SIGINT', processOnExit);
-    process.off('SIGTERM', processOnExit);
-    process.off('exit', processOnExit);
   };
 
-  process.on('SIGINT', processOnExit);
-  process.on('SIGTERM', processOnExit);
-  process.on('exit', processOnExit);
+  process.once('SIGINT', processOnExit);
+  process.once('SIGTERM', processOnExit);
+  process.once('exit', processOnExit);
 }

--- a/packages/vite/src/executors/preview-server/preview-server.impl.ts
+++ b/packages/vite/src/executors/preview-server/preview-server.impl.ts
@@ -44,14 +44,11 @@ export default async function* vitePreviewServerExecutor(
 
   const processOnExit = async () => {
     await closeServer(server);
-    process.off('SIGINT', processOnExit);
-    process.off('SIGTERM', processOnExit);
-    process.off('exit', processOnExit);
   };
 
-  process.on('SIGINT', processOnExit);
-  process.on('SIGTERM', processOnExit);
-  process.on('exit', processOnExit);
+  process.once('SIGINT', processOnExit);
+  process.once('SIGTERM', processOnExit);
+  process.once('exit', processOnExit);
 
   // Launch the build target.
   const target = parseTargetString(options.buildTarget, context.projectGraph);
@@ -89,7 +86,11 @@ export default async function* vitePreviewServerExecutor(
     }
   }
 
-  await new Promise(() => {});
+  await new Promise<void>((resolve) => {
+    process.once('SIGINT', () => resolve());
+    process.once('SIGTERM', () => resolve());
+    process.once('exit', () => resolve());
+  });
 }
 
 function closeServer(server?: PreviewServer): Promise<void> {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Dev and preview server are creating promises that never exit. Because of this each time these servers executed and exited there's a new zombie process left.

To reproduce:
1. `npx create-nx-workspace zombie-processes --preset=react-monorepo --appName=my-app --bundler=vite`
2. In 2nd terminal run `ps aux | grep zombie-demo`
3. Back in 1st terminal `nx run my-app:serve` and then exit after it's established
4. Run command from step 2 again and see increased amount of processes. Repeat step 3 to see an extra process appears each time
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
There should be no zombie processes
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
