### PR TITLE
fix(vite): do not use merged options for preview's build target

### DIFF
--- a/packages/vite/src/executors/preview-server/preview-server.impl.ts
+++ b/packages/vite/src/executors/preview-server/preview-server.impl.ts
@@ -55,7 +55,7 @@ export default async function* vitePreviewServerExecutor(
 
   // Launch the build target.
   const target = parseTargetString(options.buildTarget, context.projectGraph);
-  const build = await runExecutor(target, mergedOptions, context);
+  const build = await runExecutor(target, buildTargetOptions, context);
 
   for await (const result of build) {
     if (result.success) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Right now options that are provided for the `preview` target are being merged with build target ones and used for both build and preview targets. 
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
This might not be correct, because in some cases we do not want the same to be applied for both targets and this behavior is not straightforward.

Moreover, there's an existing mechanism for customization of a target using configurations, so instead of passing certain options directly to the preview target and expect them to be applied to the build one, we should use something like `buildTarget: "build:preview"`, where preview configuration of a build target would apply everything itself.
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
