### PR TITLE
fix(core): do not hardcode checks for npm

### DIFF
--- a/packages/nx/src/utils/project-graph-utils.spec.ts
+++ b/packages/nx/src/utils/project-graph-utils.spec.ts
@@ -54,6 +54,9 @@ describe('project graph utils', () => {
           data: {},
         },
       },
+      externalNodes: {
+        'npm:chalk': {},
+      },
       dependencies: {
         'demo-app': [
           {

--- a/packages/nx/src/utils/project-graph-utils.ts
+++ b/packages/nx/src/utils/project-graph-utils.ts
@@ -112,7 +112,7 @@ function collectDependentProjectNodesNames(
     const dependencyName = dependency.target;
 
     // we're only interested in internal nodes, not external
-    if (nxDeps.externalNodes[dependencyName]) {
+    if (nxDeps.externalNodes?.[dependencyName]) {
       continue;
     }
 

--- a/packages/nx/src/utils/project-graph-utils.ts
+++ b/packages/nx/src/utils/project-graph-utils.ts
@@ -111,8 +111,8 @@ function collectDependentProjectNodesNames(
   for (const dependency of dependencies) {
     const dependencyName = dependency.target;
 
-    // we're only intersted in project dependencies, not npm
-    if (dependencyName.startsWith('npm:')) {
+    // we're only interested in internal nodes, not external
+    if (nxDeps.externalNodes[dependencyName]) {
       continue;
     }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
With project graph plugins, they contain support to add third party deps to the project graph. We have utils that were hard coded to only check if these third party deps started with `npm`. This caused issues because third party deps ended up in project deps

## Expected Behavior
All external nodes will be ignored when trying to get all internal dependent nodes. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
