### PR TITLE
fix(storybook): typescript config ts-node

### DIFF
--- a/packages/angular/src/generators/storybook-configuration/__snapshots__/storybook-configuration.spec.ts.snap
+++ b/packages/angular/src/generators/storybook-configuration/__snapshots__/storybook-configuration.spec.ts.snap
@@ -18,20 +18,15 @@ module.exports = {
   addons: [...rootMain.addons 
     
     
-  ],
-  webpackFinal: async (config, { configType }) => {
-    // apply any global webpack configs that might have been specified in .storybook/main.js
-    if (rootMain.webpackFinal) {
-      config = await rootMain.webpackFinal(config, { configType });
-    }
-    
-    
-
-    // add your own webpack tweaks if needed
-
-    return config;
-  },
+  ]
 };
+
+
+// To customize your webpack configuration you can use the webpackFinal field.
+// Check https://storybook.js.org/docs/react/builders/webpack#extending-storybooks-webpack-config
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
+
+
 "
 `;
 

--- a/packages/storybook/src/executors/build-storybook/build-storybook.impl.ts
+++ b/packages/storybook/src/executors/build-storybook/build-storybook.impl.ts
@@ -56,6 +56,13 @@ function runInstance(options: CLIOptions, storybook7: boolean): Promise<void> {
       mode: 'static',
     } as any); // TODO(katerina): Change to actual types when Storybook 7
   } else {
+    const nodeVersion = process.version.slice(1).split('.');
+    if (+nodeVersion[0] === 18) {
+      logger.warn(`
+        If you are using the @storybook/builder-vite you may experience issues with Node 18.
+        Please use Node 16 if you are using @storybook/builder-vite. 
+      `);
+    }
     return build.buildStaticStandalone({
       ...options,
       ci: true,

--- a/packages/storybook/src/generators/configuration/__snapshots__/configuration-nested.spec.ts.snap
+++ b/packages/storybook/src/generators/configuration/__snapshots__/configuration-nested.spec.ts.snap
@@ -29,9 +29,16 @@ const config: StorybookConfig = {
       ],
     });
   },
-};
+} as StorybookConfig;
 
 module.exports = config;
+
+
+
+
+// To customize your Vite configuration you can use the viteFinal field. 
+// Check https://storybook.js.org/docs/react/builders/vite#configuration
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
 "
 `;
 
@@ -91,20 +98,17 @@ const config: StorybookConfig = {
   addons: [...(rootMain.addons || []) , '@nrwl/react/plugins/storybook' 
     
     
-  ],
-  webpackFinal: async (config, { configType }: Options) => {
-    // apply any global webpack configs that might have been specified in .storybook/main.ts
-    if (rootMain.webpackFinal) {
-      config = await rootMain.webpackFinal(config, { configType } as Options);
-    }
-
-    // add your own webpack tweaks if needed
-
-    return config;
-  },
-};
+  ]
+} as StorybookConfig;
 
 module.exports = config;
+
+
+// To customize your webpack configuration you can use the webpackFinal field.
+// Check https://storybook.js.org/docs/react/builders/webpack#extending-storybooks-webpack-config
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
+
+
 "
 `;
 

--- a/packages/storybook/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/storybook/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -18,20 +18,15 @@ module.exports = {
   addons: [...rootMain.addons 
     
     
-  ],
-  webpackFinal: async (config, { configType }) => {
-    // apply any global webpack configs that might have been specified in .storybook/main.js
-    if (rootMain.webpackFinal) {
-      config = await rootMain.webpackFinal(config, { configType });
-    }
-    
-    
-
-    // add your own webpack tweaks if needed
-
-    return config;
-  },
+  ]
 };
+
+
+// To customize your webpack configuration you can use the webpackFinal field.
+// Check https://storybook.js.org/docs/react/builders/webpack#extending-storybooks-webpack-config
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
+
+
 "
 `;
 
@@ -123,24 +118,15 @@ module.exports = {
   addons: [...rootMain.addons 
     
     
-  ],
-  webpackFinal: async (config, { configType }) => {
-    // apply any global webpack configs that might have been specified in .storybook/main.js
-    if (rootMain.webpackFinal) {
-      config = await rootMain.webpackFinal(config, { configType });
-    }
-    
-    // for backwards compatibility call the \`rootWebpackConfig\`
-      // this can be removed once that one is migrated fully to
-      // use the \`webpackFinal\` property in the \`main.js\` file
-      config = rootWebpackConfig({ config });
-    
-
-    // add your own webpack tweaks if needed
-
-    return config;
-  },
+  ]
 };
+
+
+// To customize your webpack configuration you can use the webpackFinal field.
+// Check https://storybook.js.org/docs/react/builders/webpack#extending-storybooks-webpack-config
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
+
+
 "
 `;
 
@@ -173,9 +159,16 @@ const config: StorybookConfig = {
       ],
     });
   },
-};
+} as StorybookConfig;
 
 module.exports = config;
+
+
+
+
+// To customize your Vite configuration you can use the viteFinal field. 
+// Check https://storybook.js.org/docs/react/builders/vite#configuration
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
 "
 `;
 
@@ -233,9 +226,16 @@ const config: StorybookConfig = {
       ],
     });
   },
-};
+} as StorybookConfig;
 
 module.exports = config;
+
+
+
+
+// To customize your Vite configuration you can use the viteFinal field. 
+// Check https://storybook.js.org/docs/react/builders/vite#configuration
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
 "
 `;
 
@@ -300,9 +300,16 @@ const config: StorybookConfig = {
       ],
     });
   },
-};
+} as StorybookConfig;
 
 module.exports = config;
+
+
+
+
+// To customize your Vite configuration you can use the viteFinal field. 
+// Check https://storybook.js.org/docs/react/builders/vite#configuration
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
 "
 `;
 
@@ -360,9 +367,16 @@ const config: StorybookConfig = {
       ],
     });
   },
-};
+} as StorybookConfig;
 
 module.exports = config;
+
+
+
+
+// To customize your Vite configuration you can use the viteFinal field. 
+// Check https://storybook.js.org/docs/react/builders/vite#configuration
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
 "
 `;
 
@@ -420,9 +434,16 @@ const config: StorybookConfig = {
       ],
     });
   },
-};
+} as StorybookConfig;
 
 module.exports = config;
+
+
+
+
+// To customize your Vite configuration you can use the viteFinal field. 
+// Check https://storybook.js.org/docs/react/builders/vite#configuration
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
 "
 `;
 
@@ -480,9 +501,16 @@ const config: StorybookConfig = {
       ],
     });
   },
-};
+} as StorybookConfig;
 
 module.exports = config;
+
+
+
+
+// To customize your Vite configuration you can use the viteFinal field. 
+// Check https://storybook.js.org/docs/react/builders/vite#configuration
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
 "
 `;
 
@@ -530,20 +558,17 @@ const config: StorybookConfig = {
   addons: [...(rootMain.addons || []) , '@nrwl/react/plugins/storybook' 
     
     
-  ],
-  webpackFinal: async (config, { configType }: Options) => {
-    // apply any global webpack configs that might have been specified in .storybook/main.ts
-    if (rootMain.webpackFinal) {
-      config = await rootMain.webpackFinal(config, { configType } as Options);
-    }
-
-    // add your own webpack tweaks if needed
-
-    return config;
-  },
-};
+  ]
+} as StorybookConfig;
 
 module.exports = config;
+
+
+// To customize your webpack configuration you can use the webpackFinal field.
+// Check https://storybook.js.org/docs/react/builders/webpack#extending-storybooks-webpack-config
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
+
+
 "
 `;
 
@@ -591,20 +616,17 @@ const config: StorybookConfig = {
   addons: [...(rootMain.addons || []) , '@nrwl/react/plugins/storybook' 
     
     
-  ],
-  webpackFinal: async (config, { configType }: Options) => {
-    // apply any global webpack configs that might have been specified in .storybook/main.ts
-    if (rootMain.webpackFinal) {
-      config = await rootMain.webpackFinal(config, { configType } as Options);
-    }
-
-    // add your own webpack tweaks if needed
-
-    return config;
-  },
-};
+  ]
+} as StorybookConfig;
 
 module.exports = config;
+
+
+// To customize your webpack configuration you can use the webpackFinal field.
+// Check https://storybook.js.org/docs/react/builders/webpack#extending-storybooks-webpack-config
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
+
+
 "
 `;
 
@@ -659,20 +681,17 @@ const config: StorybookConfig = {
       },
     }
      
-  ],
-  webpackFinal: async (config, { configType }: Options) => {
-    // apply any global webpack configs that might have been specified in .storybook/main.ts
-    if (rootMain.webpackFinal) {
-      config = await rootMain.webpackFinal(config, { configType } as Options);
-    }
-
-    // add your own webpack tweaks if needed
-
-    return config;
-  },
-};
+  ]
+} as StorybookConfig;
 
 module.exports = config;
+
+
+// To customize your webpack configuration you can use the webpackFinal field.
+// Check https://storybook.js.org/docs/react/builders/webpack#extending-storybooks-webpack-config
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
+
+
 "
 `;
 
@@ -720,20 +739,17 @@ const config: StorybookConfig = {
   addons: [...(rootMain.addons || []) , '@nrwl/react/plugins/storybook' 
     
     
-  ],
-  webpackFinal: async (config, { configType }: Options) => {
-    // apply any global webpack configs that might have been specified in .storybook/main.ts
-    if (rootMain.webpackFinal) {
-      config = await rootMain.webpackFinal(config, { configType } as Options);
-    }
-
-    // add your own webpack tweaks if needed
-
-    return config;
-  },
-};
+  ]
+} as StorybookConfig;
 
 module.exports = config;
+
+
+// To customize your webpack configuration you can use the webpackFinal field.
+// Check https://storybook.js.org/docs/react/builders/webpack#extending-storybooks-webpack-config
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
+
+
 "
 `;
 
@@ -781,20 +797,17 @@ const config: StorybookConfig = {
   addons: [...(rootMain.addons || []) , '@nrwl/react/plugins/storybook' 
     , 'storybook-addon-swc' 
     
-  ],
-  webpackFinal: async (config, { configType }: Options) => {
-    // apply any global webpack configs that might have been specified in .storybook/main.ts
-    if (rootMain.webpackFinal) {
-      config = await rootMain.webpackFinal(config, { configType } as Options);
-    }
-
-    // add your own webpack tweaks if needed
-
-    return config;
-  },
-};
+  ]
+} as StorybookConfig;
 
 module.exports = config;
+
+
+// To customize your webpack configuration you can use the webpackFinal field.
+// Check https://storybook.js.org/docs/react/builders/webpack#extending-storybooks-webpack-config
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
+
+
 "
 `;
 
@@ -842,20 +855,17 @@ const config: StorybookConfig = {
   addons: [...(rootMain.addons || []) , '@nrwl/react/plugins/storybook' 
     
     
-  ],
-  webpackFinal: async (config, { configType }: Options) => {
-    // apply any global webpack configs that might have been specified in .storybook/main.ts
-    if (rootMain.webpackFinal) {
-      config = await rootMain.webpackFinal(config, { configType } as Options);
-    }
-
-    // add your own webpack tweaks if needed
-
-    return config;
-  },
-};
+  ]
+} as StorybookConfig;
 
 module.exports = config;
+
+
+// To customize your webpack configuration you can use the webpackFinal field.
+// Check https://storybook.js.org/docs/react/builders/webpack#extending-storybooks-webpack-config
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
+
+
 "
 `;
 
@@ -903,20 +913,15 @@ module.exports = {
   addons: [...rootMain.addons , '@nrwl/react/plugins/storybook' 
     
     
-  ],
-  webpackFinal: async (config, { configType }) => {
-    // apply any global webpack configs that might have been specified in .storybook/main.js
-    if (rootMain.webpackFinal) {
-      config = await rootMain.webpackFinal(config, { configType });
-    }
-    
-    
-
-    // add your own webpack tweaks if needed
-
-    return config;
-  },
+  ]
 };
+
+
+// To customize your webpack configuration you can use the webpackFinal field.
+// Check https://storybook.js.org/docs/react/builders/webpack#extending-storybooks-webpack-config
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
+
+
 "
 `;
 
@@ -963,20 +968,15 @@ module.exports = {
   addons: [...rootMain.addons , '@nrwl/react/plugins/storybook' 
     
     
-  ],
-  webpackFinal: async (config, { configType }) => {
-    // apply any global webpack configs that might have been specified in .storybook/main.js
-    if (rootMain.webpackFinal) {
-      config = await rootMain.webpackFinal(config, { configType });
-    }
-    
-    
-
-    // add your own webpack tweaks if needed
-
-    return config;
-  },
+  ]
 };
+
+
+// To customize your webpack configuration you can use the webpackFinal field.
+// Check https://storybook.js.org/docs/react/builders/webpack#extending-storybooks-webpack-config
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
+
+
 "
 `;
 
@@ -1030,20 +1030,15 @@ module.exports = {
       },
     }
      
-  ],
-  webpackFinal: async (config, { configType }) => {
-    // apply any global webpack configs that might have been specified in .storybook/main.js
-    if (rootMain.webpackFinal) {
-      config = await rootMain.webpackFinal(config, { configType });
-    }
-    
-    
-
-    // add your own webpack tweaks if needed
-
-    return config;
-  },
+  ]
 };
+
+
+// To customize your webpack configuration you can use the webpackFinal field.
+// Check https://storybook.js.org/docs/react/builders/webpack#extending-storybooks-webpack-config
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
+
+
 "
 `;
 
@@ -1090,20 +1085,15 @@ module.exports = {
   addons: [...rootMain.addons , '@nrwl/react/plugins/storybook' 
     
     
-  ],
-  webpackFinal: async (config, { configType }) => {
-    // apply any global webpack configs that might have been specified in .storybook/main.js
-    if (rootMain.webpackFinal) {
-      config = await rootMain.webpackFinal(config, { configType });
-    }
-    
-    
-
-    // add your own webpack tweaks if needed
-
-    return config;
-  },
+  ]
 };
+
+
+// To customize your webpack configuration you can use the webpackFinal field.
+// Check https://storybook.js.org/docs/react/builders/webpack#extending-storybooks-webpack-config
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
+
+
 "
 `;
 
@@ -1150,20 +1140,15 @@ module.exports = {
   addons: [...rootMain.addons , '@nrwl/react/plugins/storybook' 
     , 'storybook-addon-swc' 
     
-  ],
-  webpackFinal: async (config, { configType }) => {
-    // apply any global webpack configs that might have been specified in .storybook/main.js
-    if (rootMain.webpackFinal) {
-      config = await rootMain.webpackFinal(config, { configType });
-    }
-    
-    
-
-    // add your own webpack tweaks if needed
-
-    return config;
-  },
+  ]
 };
+
+
+// To customize your webpack configuration you can use the webpackFinal field.
+// Check https://storybook.js.org/docs/react/builders/webpack#extending-storybooks-webpack-config
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
+
+
 "
 `;
 
@@ -1210,20 +1195,15 @@ module.exports = {
   addons: [...rootMain.addons , '@nrwl/react/plugins/storybook' 
     
     
-  ],
-  webpackFinal: async (config, { configType }) => {
-    // apply any global webpack configs that might have been specified in .storybook/main.js
-    if (rootMain.webpackFinal) {
-      config = await rootMain.webpackFinal(config, { configType });
-    }
-    
-    
-
-    // add your own webpack tweaks if needed
-
-    return config;
-  },
+  ]
 };
+
+
+// To customize your webpack configuration you can use the webpackFinal field.
+// Check https://storybook.js.org/docs/react/builders/webpack#extending-storybooks-webpack-config
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
+
+
 "
 `;
 

--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -37,6 +37,7 @@ import {
   storybookSwcAddonVersion,
   storybookTestRunnerVersion,
   storybookVersion,
+  tsNodeVersion,
 } from '../../utils/versions';
 
 export async function configurationGenerator(
@@ -219,6 +220,7 @@ export async function configurationGenerator(
         {},
         {
           ['@storybook/core-common']: storybookVersion,
+          ['ts-node']: tsNodeVersion,
         }
       )
     );

--- a/packages/storybook/src/generators/configuration/project-files-ts/.storybook/main.ts__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files-ts/.storybook/main.ts__tmpl__
@@ -34,17 +34,19 @@ const config: StorybookConfig = {
         }),
       ],
     });
-  },<% } %><% if (!usesVite) { %>,
-  webpackFinal: async (config, { configType }: Options) => {
-    // apply any global webpack configs that might have been specified in .storybook/main.ts
-    if (rootMain.webpackFinal) {
-      config = await rootMain.webpackFinal(config, { configType } as Options);
-    }
-
-    // add your own webpack tweaks if needed
-
-    return config;
   },<% } %>
-};
+} as StorybookConfig;
 
 module.exports = config;
+
+<% if(!usesVite) { %>
+// To customize your webpack configuration you can use the webpackFinal field.
+// Check https://storybook.js.org/docs/react/builders/webpack#extending-storybooks-webpack-config
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
+<% } %>
+
+<% if(usesVite) { %>
+// To customize your Vite configuration you can use the viteFinal field. 
+// Check https://storybook.js.org/docs/react/builders/vite#configuration
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
+<% } %>

--- a/packages/storybook/src/generators/configuration/project-files/.storybook/main.js__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files/.storybook/main.js__tmpl__
@@ -34,21 +34,17 @@ module.exports = {
         }),
       ],
     });
-  },<% } %><% if (!usesVite) { %>,
-  webpackFinal: async (config, { configType }) => {
-    // apply any global webpack configs that might have been specified in .storybook/main.js
-    if (rootMain.webpackFinal) {
-      config = await rootMain.webpackFinal(config, { configType });
-    }
-    
-    <% if (existsRootWebpackConfig) { %>// for backwards compatibility call the `rootWebpackConfig`
-      // this can be removed once that one is migrated fully to
-      // use the `webpackFinal` property in the `main.js` file
-      config = rootWebpackConfig({ config });
-    <% } %>
-
-    // add your own webpack tweaks if needed
-
-    return config;
   },<% } %>
 };
+
+<% if(!usesVite) { %>
+// To customize your webpack configuration you can use the webpackFinal field.
+// Check https://storybook.js.org/docs/react/builders/webpack#extending-storybooks-webpack-config
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
+<% } %>
+
+<% if(usesVite) { %>
+// To customize your Vite configuration you can use the viteFinal field. 
+// Check https://storybook.js.org/docs/react/builders/vite#configuration
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
+<% } %>

--- a/packages/storybook/src/utils/versions.ts
+++ b/packages/storybook/src/utils/versions.ts
@@ -3,8 +3,8 @@ export const storybookVersion = '^6.5.15';
 export const babelCoreVersion = '7.12.13';
 export const babelLoaderVersion = '8.1.0';
 export const babelPresetTypescriptVersion = '7.12.13';
-export const svgrVersion = '^5.4.0';
-export const urlLoaderVersion = '^3.0.0';
+export const svgrVersion = '^6.1.2';
+export const urlLoaderVersion = '^4.1.1';
 export const webpack5Version = '^5.64.0';
 export const viteBuilderVersion = '^0.2.6';
 export const storybookReactNativeVersion = '^6.0.1-beta.11';
@@ -14,5 +14,6 @@ export const storybookNextAddonVersion = '^1.6.6';
 export const storybookTestRunnerVersion = '^0.7.2';
 export const litHtmlVersion = '^2.3.1';
 export const htmlWebpackPluginVersion = '^5.5.0';
+export const tsNodeVersion = '10.9.1';
 
 export const storybook7Version = '^7.0.0-beta.29';


### PR DESCRIPTION
closed #14814

If you're using Storybook with Typescript configuration and Vite:

* install `ts-node`
* warn that node 18 does not work with Storybook vite builder

Fixes #14814
