### PR TITLE
docs(core): add link to tRPC plugin guide

### DIFF
--- a/docs/shared/plugin-features/create-your-own-plugin.md
+++ b/docs/shared/plugin-features/create-your-own-plugin.md
@@ -71,6 +71,7 @@ and generators.
 ## Learn more
 
 - [Creating and Publishing Your Own Nx Plugin - Youtube](https://www.youtube.com/watch?v=vVT7Al01VZc)
+- [Walkthrough Creating an Nx Plugin for tRPC](https://blog.nrwl.io/create-your-own-trpc-stack-de42209f83a3)
 - [Local generators](/recipes/generators/local-generators)
 - [Local executors](/recipes/executors/creating-custom-executors)
 - [Nx Community Plugins](/community)


### PR DESCRIPTION
Adds a link to Zack's guide creating a plugin from scratch