### PR TITLE
fix(core): fix missing top-level dependencies

### DIFF
--- a/packages/workspace/src/utilities/buildable-libs-utils.ts
+++ b/packages/workspace/src/utilities/buildable-libs-utils.ts
@@ -139,7 +139,8 @@ function collectDependencies(
   areTopLevelDeps = true
 ): { name: string; isTopLevel: boolean }[] {
   (projGraph.dependencies[project] || []).forEach((dependency) => {
-    if (!acc.some((dep) => dep.name === dependency.target)) {
+    const existingEntry = acc.find((dep) => dep.name === dependency.target);
+    if (!existingEntry) {
       // Temporary skip this. Currently the set of external nodes is built from package.json, not lock file.
       // As a result, some nodes might be missing. This should not cause any issues, we can just skip them.
       if (
@@ -153,6 +154,8 @@ function collectDependencies(
       if (!shallow && isInternalTarget) {
         collectDependencies(dependency.target, projGraph, acc, shallow, false);
       }
+    } else if (areTopLevelDeps && !existingEntry.isTopLevel) {
+      existingEntry.isTopLevel = true;
     }
   });
   return acc;


### PR DESCRIPTION
Fix dependencies sometimes being omitted from the list of top-level dependencies when they are both top-level and transitive

closed #14513

