### PR TITLE
fix(core): fix issues regarding workspace.json migrations

### DIFF
--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -1062,10 +1062,10 @@ function addSplitConfigurationMigrationIfAvailable(
   from: string,
   packageJson: any
 ) {
-  if (!packageJson['@nrw/workspace']) return [];
+  if (!packageJson['@nrwl/workspace']) return [];
 
   if (
-    gte(packageJson['@nrw/workspace'].version, '15.7.0') &&
+    gte(packageJson['@nrwl/workspace'].version, '15.7.0') &&
     lt(from, '15.7.0')
   ) {
     return [

--- a/packages/nx/src/utils/assert-workspace-validity.spec.ts
+++ b/packages/nx/src/utils/assert-workspace-validity.spec.ts
@@ -36,7 +36,7 @@ describe('assertWorkspaceValidity', () => {
       fail('should not reach');
     } catch (e) {
       expect(e.message).toContain(
-        'The following implicitDependencies specified in project configurations are invalid'
+        'The following implicitDependencies point to non-existent project(s)'
       );
       expect(e.message).toContain('README.md');
       expect(e.message).toContain('invalidproj');
@@ -59,7 +59,7 @@ describe('assertWorkspaceValidity', () => {
       fail('should not reach');
     } catch (e) {
       expect(e.message).toContain(
-        'The following implicitDependencies specified in project configurations are invalid'
+        'The following implicitDependencies point to non-existent project(s)'
       );
       expect(e.message).toContain('invalidproj');
       expect(e.message).toContain('invalidproj');
@@ -74,7 +74,7 @@ describe('assertWorkspaceValidity', () => {
       fail('should not reach');
     } catch (e) {
       expect(e.message).toContain(
-        'The following implicitDependencies specified in project configurations are invalid'
+        'The following implicitDependencies point to non-existent project(s)'
       );
       expect(e.message).toContain('invalid*');
       expect(e.message).toContain('invalid*');

--- a/packages/nx/src/utils/assert-workspace-validity.ts
+++ b/packages/nx/src/utils/assert-workspace-validity.ts
@@ -80,7 +80,7 @@ export function assertWorkspaceValidity(
     return;
   }
 
-  let message = `The following implicitDependencies specified in project configurations are invalid:\n`;
+  let message = `The following implicitDependencies point to non-existent project(s):\n`;
   message += [...invalidImplicitDependencies.keys()]
     .map((key) => {
       const projectNames = invalidImplicitDependencies.get(key);

--- a/packages/workspace/src/generators/convert-to-nx-project/convert-to-nx-project.ts
+++ b/packages/workspace/src/generators/convert-to-nx-project/convert-to-nx-project.ts
@@ -4,6 +4,7 @@ import {
   formatFiles,
   readJson,
   Tree,
+  updateProjectConfiguration,
   writeJson,
 } from '@nrwl/devkit';
 import { join } from 'path';
@@ -52,14 +53,24 @@ export async function convertToNxProjectGenerator(host: Tree, schema: Schema) {
 
   for (const projectName of Object.keys(projects)) {
     const config = projects[projectName];
-    if (typeof config === 'string') continue;
     if (
       (!schema.project || schema.project === projectName) &&
       !schema.reformat
     ) {
-      const path = join(config.root, 'project.json');
-      if (!host.exists(path)) {
-        addProjectConfiguration(host, path, projects[projectName]);
+      if (typeof config === 'string') {
+        // configuration is in project.json
+        const projectConfig = readJson(host, join(config, 'project.json'));
+        if (projectConfig.name !== projectName) {
+          projectConfig.name = projectName;
+          updateProjectConfiguration(host, projectName, projectConfig);
+        }
+      } else {
+        // configuration is an object in workspace.json
+        const path = join(config.root, 'project.json');
+        if (!host.exists(path)) {
+          projects[projectName].name = projectName;
+          addProjectConfiguration(host, path, projects[projectName]);
+        }
       }
     } else {
       leftOverProjects[projectName] = config;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The migrations logic for workspace.json are off:

1. The project name is not transferred to the `project.json` correctly in some scenarios.
2. There's a typo when adding the migration where it splits the `workspace.json`
3. The error when there's an issue with implicitDependencies is vague and not helpful.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The migrations logic for workspace.json are off:

1. Project names are transferred to the `project.json` correctly.
2. The migration where it splits the `workspace.json` is added correctly.
3. The error when there's an issue with implicitDependencies is more helpful.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
