### PR TITLE
chore(repo): add more people to approve uncaught files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,5 @@
 # Any file not covered by a rule below, will default to Jason + Victor.
-/packages/**/* @FrozenPandaz @vsavkin
-/e2e/**/* @FrozenPandaz @vsavkin
-/scripts/**/* @FrozenPandaz @vsavkin
-/tools/**/* @FrozenPandaz @vsavkin
+* @FrozenPandaz @vsavkin @jaysoo @AgentEnder @bcabanes
 
 # Docs Site + Graph
 /docs/nx-cloud @StalkAltan @rarmatei @isaacplmann @juristr @bcabanes


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Only @vsavkin and I can approve uncaught files such as `package.json`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

More people can approve uncaught files.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
