### PR TITLE
fix(core): fix project locator for built in node modules

### DIFF
--- a/packages/nx/src/utils/target-project-locator.spec.ts
+++ b/packages/nx/src/utils/target-project-locator.spec.ts
@@ -856,4 +856,20 @@ describe('findTargetProjectWithImport (without tsconfig.json)', () => {
     );
     expect(similarDeepImportFromNpm).toEqual('npm:@proj/proj123-base');
   });
+
+  it('should return null for native modules', () => {
+    const result = targetProjectLocator.findProjectWithImport(
+      'path',
+      'libs/proj/index.ts'
+    );
+    expect(result).toEqual(null);
+  });
+
+  it('should return null for unresolved paths', () => {
+    const result = targetProjectLocator.findProjectWithImport(
+      'unresolved-path',
+      'libs/proj/index.ts'
+    );
+    expect(result).toEqual(null);
+  });
 });

--- a/packages/nx/src/utils/target-project-locator.ts
+++ b/packages/nx/src/utils/target-project-locator.ts
@@ -10,6 +10,9 @@ import {
   createProjectRootMappings,
   findProjectForPath,
 } from '../project-graph/utils/find-project-for-path';
+import { builtinModules } from 'module';
+
+const builtInModuleSet = new Set(builtinModules);
 
 export class TargetProjectLocator {
   private projectRootMappings = createProjectRootMappings(this.nodes);
@@ -70,6 +73,11 @@ export class TargetProjectLocator {
       }
     }
 
+    if (builtInModuleSet.has(normalizedImportExpr)) {
+      this.npmResolutionCache.set(normalizedImportExpr, null);
+      return null;
+    }
+
     try {
       const resolvedModule = this.resolveImportWithRequire(
         normalizedImportExpr,
@@ -80,7 +88,7 @@ export class TargetProjectLocator {
     } catch {}
 
     // nothing found, cache for later
-    this.npmResolutionCache.set(normalizedImportExpr, undefined);
+    this.npmResolutionCache.set(normalizedImportExpr, null);
     return null;
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Imports from built in node modules like `path`, `fs`, etc. will resolve to the root project which is incorrect.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Imports from built in node modules like `path`, `fs`, etc. will resolve to null.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/14571
