### PR TITLE
fix(angular): set project root when reading project.json in the adapter scoped host

### DIFF
--- a/packages/nx/src/adapter/ngcli-adapter.ts
+++ b/packages/nx/src/adapter/ngcli-adapter.ts
@@ -242,7 +242,10 @@ export class NxScopedHost extends virtualFs.ScopedHost<any> {
               .filter((p) => p !== null)
               .forEach((p) => {
                 delete p.version;
-                ret.projects[p.name] = p;
+                ret.projects[p.name] = {
+                  ...p,
+                  root: graph.nodes[p.name].data.root,
+                };
               });
 
             return ret;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The Angular CLI adapter is not setting the project root property when reading the config. When running Angular DevKit builders the Angular DevKit warns in Angular 14 and throws in Angular 15. The `compat` swallows the error in the latter case and fallback to reading the config differently (still not ideal, but there's no apparent issue for the users), but when using Angular 14 the warnings are logged out causing noise.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The Angular CLI adapter should set the project root property when reading the config. No error or warning should be thrown or logged by the Angular DevKit because of a missing `root` property.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
