### PR TITLE
chore(nextjs): changes application generator tsconfig strict to true

### DIFF
--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -106,7 +106,8 @@ describe('Next.js Applications', () => {
       `
           import { jsLibAsync } from '@${proj}/${jsLib}';
 
-          export default async function handler(_, res) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          export default async function handler(_: any, res: any) {
             const value = await jsLibAsync();
             res.send(value);
           }
@@ -261,7 +262,7 @@ describe('Next.js Applications', () => {
     updateFile(
       `apps/${appName}/pages/api/hello.js`,
       `
-        export default (_req, res) => {
+        export default (_req: any, res: any) => {
           res.status(200).send('Welcome');
         };
       `

--- a/packages/next/src/generators/application/files/common/tsconfig.json__tmpl__
+++ b/packages/next/src/generators/application/files/common/tsconfig.json__tmpl__
@@ -6,7 +6,7 @@
     "allowJs": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "strict": false,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
By default when creating a new nextjs application, `strict` in the tsconfig file is set to false. This is firstly inconsistent with other generators as that most of them do indeed set the `strict` option to true as well as that could introduce many issues until it's noticed that it's set to false.

The issues for example relate to my usage with tRPC as that when using `strict` to false, type checking behaves weirdly and  you will be hearing your PC  fans scream from the top of it's lungs as it's getting tortured by the typescript language server.