### PR TITLE
chore(repo): add additional granular scopes to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -59,10 +59,12 @@
 /packages/jest/** @barbados-clemens @FrozenPandaz
 /e2e/jest/** @barbados-clemens @FrozenPandaz
 
+# Linter
 /packages/eslint-plugin-nx/** @meeroslav @FrozenPandaz
 /packages/linter/** @meeroslav @FrozenPandaz
 /e2e/linter/** @meeroslav @FrozenPandaz
 
+# Storybook
 /packages/storybook/** @mandarini @jaysoo @Coly010
 /e2e/storybook/** @mandarini @FrozenPandaz @Coly010
 /e2e/storybook-angular/** @mandarini @Coly010
@@ -72,6 +74,7 @@
 /packages/devkit/index.ts @FrozenPandaz @vsavkin
 /packages/devkit/src/utils/module-federation @jaysoo @Coly010
 
+# Nx-Plugin
 /packages/nx-plugin/** @AgentEnder @FrozenPandaz
 /e2e/nx-plugin/** @AgentEnder @FrozenPandaz
 
@@ -83,6 +86,7 @@
 /packages/nx/src/plugins @AgentEnder @FrozenPandaz @vsavkin
 /packages/nx/src/utils @vsavkin @FrozenPandaz @AgentEnder
 /packages/nx/src/native @vsavkin @FrozenPandaz @Cammisuli
+/packages/nx/src/lock-file @meeroslav @FrozenPandaz
 /e2e/nx*/** @FrozenPandaz @AgentEnder @vsavkin
 /packages/workspace/** @FrozenPandaz @AgentEnder @vsavkin
 /e2e/workspace/** @FrozenPandaz @AgentEnder @vsavkin
@@ -102,6 +106,11 @@
 /scripts/documentation @bcabanes @isaacplmann
 /scripts/local-registry @FrozenPandaz @vsavkin
 /scripts/angular-support-upgrades @Coly010 @leosvelperez
+
+# CI
+/.circleci/** @meeroslav @vsavkin
+/.github/** @meeroslav @vsavkin
+/packages/workspace/src/generators/ci-workflow/** @meeroslav @StalkAltan @vsavkin
 
 # Global Files
 project.json @FrozenPandaz @vsavkin


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The `CI` and `Lock File` scopes are missing

## Expected Behavior
The `CI` and `Lock File` scopes should be present in the CODEOWNERS

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
