### PR TITLE
cleanup(core): remove deprecated ext from node`s file

### DIFF
--- a/packages/nx/src/config/project-graph.ts
+++ b/packages/nx/src/config/project-graph.ts
@@ -11,8 +11,6 @@ import { NxJsonConfiguration } from './nx-json';
 export interface FileData {
   file: string;
   hash: string;
-  /** @deprecated this field will be removed in v13. Use {@link path.extname} to parse extension */
-  ext?: string;
   deps?: string[];
 }
 

--- a/packages/nx/src/hasher/hasher.spec.ts
+++ b/packages/nx/src/hasher/hasher.spec.ts
@@ -89,7 +89,7 @@ describe('Hasher', () => {
                   ],
                 },
               },
-              files: [{ file: '/file', ext: '.ts', hash: 'file.hash' }],
+              files: [{ file: '/file', hash: 'file.hash' }],
             },
           },
         },

--- a/packages/nx/src/utils/target-project-locator.spec.ts
+++ b/packages/nx/src/utils/target-project-locator.spec.ts
@@ -94,7 +94,6 @@ describe('findTargetProjectWithImport', () => {
           {
             file: 'libs/proj2/deep/index.ts',
             hash: 'some-hash',
-            ext: '.ts',
           },
         ],
         proj3a: [
@@ -113,21 +112,18 @@ describe('findTargetProjectWithImport', () => {
           {
             file: 'libs/proj5/index.ts',
             hash: 'some-hash',
-            ext: '.ts',
           },
         ],
         proj6: [
           {
             file: 'libs/proj6/index.ts',
             hash: 'some-hash',
-            ext: '.ts',
           },
         ],
         proj7: [
           {
             file: 'libs/proj7/index.ts',
             hash: 'some-hash',
-            ext: '.ts',
           },
         ],
         proj123: [
@@ -535,7 +531,6 @@ describe('findTargetProjectWithImport (without tsconfig.json)', () => {
           {
             file: 'libs/proj2/deep/index.ts',
             hash: 'some-hash',
-            ext: '.ts',
           },
         ],
         proj3a: [
@@ -554,21 +549,18 @@ describe('findTargetProjectWithImport (without tsconfig.json)', () => {
           {
             file: 'libs/proj5/index.ts',
             hash: 'some-hash',
-            ext: '.ts',
           },
         ],
         proj6: [
           {
             file: 'libs/proj6/index.ts',
             hash: 'some-hash',
-            ext: '.ts',
           },
         ],
         proj7: [
           {
             file: 'libs/proj7/index.ts',
             hash: 'some-hash',
-            ext: '.ts',
           },
         ],
         proj123: [

--- a/packages/workspace/src/utils/ast-utils.ts
+++ b/packages/workspace/src/utils/ast-utils.ts
@@ -357,18 +357,6 @@ export function readJsonInTree<T extends object = any>(
   }
 }
 
-// TODO(v13): remove this deprecated method
-/**
- * @deprecated This method is deprecated
- */
-export function getFileDataInHost(host: Tree, path: Path): FileData {
-  return {
-    file: path,
-    ext: extname(normalize(path)),
-    hash: '',
-  };
-}
-
 export function allFilesInDirInHost(
   host: Tree,
   path: Path,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`FileData` in `ProjectGraphProjectNode` still contains `ext` property which is no longer used and marked as deprecated for v13

## Expected Behavior
`FileData` should not have this property anymore.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
