### PR TITLE
cleanup(core): remove reference to deprecated ProjectGraphNode

### DIFF
--- a/graph/client/src/app/feature-tasks/task-list.tsx
+++ b/graph/client/src/app/feature-tasks/task-list.tsx
@@ -1,5 +1,5 @@
 // nx-ignore-next-line
-import type { ProjectGraphNode } from '@nrwl/devkit';
+import type { ProjectGraphProjectNode } from '@nrwl/devkit';
 import {
   createTaskName,
   getProjectsByType,
@@ -13,7 +13,7 @@ import { TaskGraphErrorTooltip } from './task-graph-error-tooltip';
 import { ExperimentalFeature } from '../ui-components/experimental-feature';
 
 interface SidebarProject {
-  projectGraphNode: ProjectGraphNode;
+  projectGraphNode: ProjectGraphProjectNode;
   isSelected: boolean;
   error: string | null;
 }
@@ -108,7 +108,7 @@ function SubProjectList({
 }
 
 function mapToSidebarProjectWithTasks(
-  project: ProjectGraphNode,
+  project: ProjectGraphProjectNode,
   selectedProjects: string[],
   selectedTarget: string,
   errors: Record<string, string>
@@ -123,7 +123,7 @@ function mapToSidebarProjectWithTasks(
 }
 
 export interface TaskListProps {
-  projects: ProjectGraphNode[];
+  projects: ProjectGraphProjectNode[];
   workspaceLayout: WorkspaceLayout;
   selectedTarget: string;
   selectedProjects: string[];

--- a/graph/client/src/app/util.ts
+++ b/graph/client/src/app/util.ts
@@ -1,5 +1,5 @@
 // nx-ignore-next-line
-import { ProjectGraphDependency, ProjectGraphNode } from '@nrwl/devkit';
+import { ProjectGraphDependency, ProjectGraphProjectNode } from '@nrwl/devkit';
 import { getEnvironmentConfig } from './hooks/use-environment-config';
 import { To, useParams, useSearchParams } from 'react-router-dom';
 
@@ -83,17 +83,20 @@ export function hasPath(
   return false;
 }
 
-export function getProjectsByType(type: string, projects: ProjectGraphNode[]) {
+export function getProjectsByType(
+  type: string,
+  projects: ProjectGraphProjectNode[]
+): ProjectGraphProjectNode[] {
   return projects
     .filter((project) => project.type === type)
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
 export function groupProjectsByDirectory(
-  projects: ProjectGraphNode[],
+  projects: ProjectGraphProjectNode[],
   workspaceLayout: { appsDir: string; libsDir: string }
-): Record<string, ProjectGraphNode[]> {
-  let groups: Record<string, ProjectGraphNode[]> = {};
+): Record<string, ProjectGraphProjectNode[]> {
+  let groups: Record<string, ProjectGraphProjectNode[]> = {};
 
   projects.forEach((project) => {
     const workspaceRoot =

--- a/packages/nx/src/config/project-graph.ts
+++ b/packages/nx/src/config/project-graph.ts
@@ -33,6 +33,7 @@ export interface ProjectGraph {
   version?: string;
 }
 
+/** @deprecated this type will be removed in v16. Use {@link ProjectGraph} instead */
 export interface ProjectGraphV4<T = any> {
   nodes: Record<string, ProjectGraphNode>;
   dependencies: Record<string, ProjectGraphDependency[]>;
@@ -59,9 +60,7 @@ export enum DependencyType {
   implicit = 'implicit',
 }
 
-/**
- * A node describing a project or an external node in a workspace
- */
+/** @deprecated this type will be removed in v16. Use {@link ProjectGraphProjectNode} or {@link ProjectGraphExternalNode} instead */
 export type ProjectGraphNode =
   | ProjectGraphProjectNode
   | ProjectGraphExternalNode;

--- a/packages/nx/src/project-graph/nx-deps-cache.ts
+++ b/packages/nx/src/project-graph/nx-deps-cache.ts
@@ -9,7 +9,7 @@ import {
   ProjectGraph,
   ProjectGraphDependency,
   ProjectGraphExternalNode,
-  ProjectGraphNode,
+  ProjectGraphProjectNode,
 } from '../config/project-graph';
 import { ProjectsConfigurations } from '../config/workspace-json-project-json';
 import { projectGraphCacheDirectory } from '../utils/cache-directory';
@@ -27,7 +27,7 @@ export interface ProjectGraphCache {
   pathMappings: Record<string, any>;
   nxJsonPlugins: { name: string; version: string }[];
   pluginsConfig?: any;
-  nodes: Record<string, ProjectGraphNode>;
+  nodes: Record<string, ProjectGraphProjectNode>;
   externalNodes?: Record<string, ProjectGraphExternalNode>;
 
   // this is only used by scripts that read dependency from the file
@@ -241,7 +241,7 @@ export function extractCachedFileData(
 
 function processProjectNode(
   name: string,
-  cachedNode: ProjectGraphNode,
+  cachedNode: ProjectGraphProjectNode,
   cachedFileData: { [project: string]: { [file: string]: FileData } },
   filesToProcess: ProjectFileMap,
   fileMap: ProjectFileMap

--- a/packages/nx/src/project-graph/operators.ts
+++ b/packages/nx/src/project-graph/operators.ts
@@ -1,7 +1,6 @@
 import {
   ProjectGraph,
   ProjectGraphExternalNode,
-  ProjectGraphNode,
   ProjectGraphProjectNode,
 } from '../config/project-graph';
 
@@ -49,7 +48,7 @@ export function reverse(graph: ProjectGraph): ProjectGraph {
 }
 
 export function filterNodes(
-  predicate?: (n: ProjectGraphNode) => boolean
+  predicate?: (n: ProjectGraphProjectNode) => boolean
 ): (p: ProjectGraph) => ProjectGraph {
   return (original) => {
     const graph = { nodes: {}, dependencies: {} } as ProjectGraph;
@@ -73,7 +72,7 @@ export function filterNodes(
 }
 
 export function isNpmProject(
-  project: ProjectGraphNode
+  project: ProjectGraphProjectNode | ProjectGraphExternalNode
 ): project is ProjectGraphExternalNode {
   return project?.type === 'npm';
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The `ProjectGraphNode` has been deprecated since v13, but it's still referenced in some parts of our repo.

## Expected Behavior
The `ProjectGraphNode` should be deprecated and removed in v16

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
