### PR TITLE
fix(core): sort --help output by flag priority

### DIFF
--- a/packages/nx/src/utils/print-help.spec.ts
+++ b/packages/nx/src/utils/print-help.spec.ts
@@ -1,0 +1,65 @@
+import { Schema } from './params';
+import { logger } from './logger';
+import { printHelp } from './print-help';
+
+describe('printHelp', () => {
+  it('should sort options by priority and name', () => {
+    const schema: Schema = {
+      properties: {
+        aImp: {
+          'x-priority': 'important',
+        },
+        bImp: {
+          'x-priority': 'important',
+        },
+        aNormal: {},
+        bNormal: {},
+        aDep: {
+          'x-deprecated': 'great reason',
+        },
+        bDep: {
+          'x-deprecated': 'even better reason',
+        },
+        aReq: {},
+        bReq: {},
+        aInt: {
+          'x-priority': 'internal',
+        },
+        bInt: {
+          'x-priority': 'internal',
+        },
+      },
+      required: ['aReq', 'bReq'],
+      description: 'description',
+    };
+
+    let output = '';
+    jest.spyOn(logger, 'info').mockImplementation((x) => (output = x));
+
+    printHelp('nx g @nrwl/demo:example', schema, {
+      mode: 'generate',
+      plugin: '@nrwl/demo',
+      entity: 'example',
+      aliases: ['ex'],
+    });
+
+    const flagsFromOutput = output
+      .match(/--[a|b]\S*/g)
+      .map((x) => x.replace('--', ''));
+
+    expect(flagsFromOutput).toMatchInlineSnapshot(`
+      Array [
+        "aReq",
+        "bReq",
+        "aImp",
+        "bImp",
+        "aNormal",
+        "bNormal",
+        "aInt",
+        "bInt",
+        "aDep",
+        "bDep",
+      ]
+    `);
+  });
+});


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Currently, flags are displayed in the order they are written in the schema.

## Expected Behavior
Afterwards, flags will be displayed in the same order as on `nx.dev` and in Nx Console, which is:
- required
- important
- all others
- internal
- deprecated

with alphabetical sorting for equal priority items.

We could also add more 'styling' to it, like a subtle divider between required/important and other options.