### PR TITLE
feat(node): add default unit test for fastify framework

### DIFF
--- a/e2e/node/src/node-server.test.ts
+++ b/e2e/node/src/node-server.test.ts
@@ -57,6 +57,9 @@ describe('Node Applications + webpack', () => {
     expect(() => runCLI(`lint ${fastifyApp}-e2e`)).not.toThrow();
     expect(() => runCLI(`lint ${koaApp}-e2e`)).not.toThrow();
 
+    // Only Fastify generates with unit tests since it supports them without additional libraries.
+    expect(() => runCLI(`lint ${fastifyApp}`)).not.toThrow();
+
     await runE2eTests(expressApp);
     await runE2eTests(fastifyApp);
     await runE2eTests(koaApp);

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -459,4 +459,24 @@ describe('app', () => {
       expect(devkit.formatFiles).not.toHaveBeenCalled();
     });
   });
+
+  describe.each([
+    ['fastify' as const, true],
+    ['express' as const, false],
+    ['koa' as const, false],
+  ])('--unitTestRunner', (framework, checkSpecFile) => {
+    it('should generate test target and spec file by default', async () => {
+      await applicationGenerator(tree, {
+        name: 'api',
+        framework,
+      });
+
+      const project = readProjectConfiguration(tree, 'api');
+      expect(project.targets.test).toBeDefined();
+
+      if (checkSpecFile) {
+        expect(tree.exists(`api/src/app/app.spec.ts`)).toBeTruthy();
+      }
+    });
+  });
 });

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -361,6 +361,11 @@ export async function applicationGenerator(tree: Tree, schema: Schema) {
       skipFormat: true,
     });
     tasks.push(jestTask);
+  } else {
+    // No need for default spec file if unit testing is not setup.
+    tree.delete(
+      joinPathFragments(options.appProjectRoot, 'src/app/app.spec.ts')
+    );
   }
 
   if (options.e2eTestRunner === 'jest') {

--- a/packages/node/src/generators/application/files/fastify/src/app/app.spec.ts__tmpl__
+++ b/packages/node/src/generators/application/files/fastify/src/app/app.spec.ts__tmpl__
@@ -1,0 +1,20 @@
+import Fastify, { FastifyInstance } from 'fastify';
+import { app } from './app';
+
+describe('GET /', () => {
+  let server: FastifyInstance;
+
+  beforeEach(() => {
+    server = Fastify();
+    server.register(app);
+  });
+
+  it('should respond with a message', async () => {
+    const response = await server.inject({
+      method: 'GET',
+      url: '/'
+    });
+
+    expect(response.json()).toEqual({ message: 'Hello API' })
+  });
+});


### PR DESCRIPTION
Since the Fastify plugin architecture lends itself well to unit testing (and all of the Fastify official plugins have unit tests), it makes sense for us to generate it by default.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
