### PR TITLE
fix(core): use not scheduled task graph to schedule new batches

### DIFF
--- a/packages/nx/src/tasks-runner/tasks-schedule.ts
+++ b/packages/nx/src/tasks-runner/tasks-schedule.ts
@@ -188,7 +188,8 @@ export class TasksSchedule {
       } as TaskGraph));
 
     batch.tasks[task.id] = task;
-    batch.dependencies[task.id] = this.taskGraph.dependencies[task.id];
+    batch.dependencies[task.id] =
+      this.notScheduledTaskGraph.dependencies[task.id];
     if (isRoot) {
       batch.roots.push(task.id);
     }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When a batch depends on other tasks, the tasks will run first. But then when it is time to schedule the batch, the batch is scheduled as if nothing before it has been run yet.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When a batch is scheduled, it will be scheduled based on the not scheduled task graph which will reflect that some tasks have been scheduled.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
