### PR TITLE
feat(core): add standalone api prompt to CNW

### DIFF
--- a/docs/generated/cli/create-nx-workspace.md
+++ b/docs/generated/cli/create-nx-workspace.md
@@ -139,6 +139,12 @@ Default: `false`
 
 Skip initializing a git repository.
 
+### standaloneApi
+
+Type: `string`
+
+Use Standalone Components if generating an Angular app
+
 ### style
 
 Type: `string`

--- a/docs/generated/packages/nx/documents/create-nx-workspace.md
+++ b/docs/generated/packages/nx/documents/create-nx-workspace.md
@@ -139,6 +139,12 @@ Default: `false`
 
 Skip initializing a git repository.
 
+### standaloneApi
+
+Type: `string`
+
+Use Standalone Components if generating an Angular app
+
 ### style
 
 Type: `string`

--- a/docs/generated/packages/workspace/generators/new.json
+++ b/docs/generated/packages/workspace/generators/new.json
@@ -29,6 +29,11 @@
         "type": "string",
         "description": "Npm scope for importing libs."
       },
+      "standaloneApi": {
+        "description": "Use the Standalone APIs if generating an Angular application.",
+        "type": "boolean",
+        "default": false
+      },
       "defaultBase": {
         "type": "string",
         "description": "Default base branch for affected."

--- a/docs/generated/packages/workspace/generators/preset.json
+++ b/docs/generated/packages/workspace/generators/preset.json
@@ -53,6 +53,11 @@
           ]
         }
       },
+      "standaloneApi": {
+        "description": "Use the Standalone APIs if generating an Angular application.",
+        "type": "boolean",
+        "default": false
+      },
       "standaloneConfig": {
         "description": "Split the project configurations into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
         "type": "boolean",

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -139,6 +139,7 @@ export function runCreateWorkspace(
     cwd = e2eCwd,
     bundler,
     routing,
+    standaloneApi,
   }: {
     preset: string;
     appName?: string;
@@ -150,6 +151,7 @@ export function runCreateWorkspace(
     useDetectedPm?: boolean;
     cwd?: string;
     bundler?: 'webpack' | 'vite';
+    standaloneApi?: boolean;
     routing?: boolean;
   }
 ) {
@@ -170,6 +172,10 @@ export function runCreateWorkspace(
 
   if (bundler) {
     command += ` --bundler=${bundler}`;
+  }
+
+  if (standaloneApi !== undefined) {
+    command += ` --standaloneApi=${standaloneApi}`;
   }
 
   if (routing !== undefined) {

--- a/e2e/workspace-create/src/create-nx-workspace.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace.test.ts
@@ -42,11 +42,29 @@ describe('create-nx-workspace', () => {
       appName: wsName,
       style: 'css',
       packageManager,
+      standaloneApi: false,
       routing: false,
     });
 
     checkFilesExist('package.json');
     checkFilesExist('project.json');
+    checkFilesExist('src/app/app.module.ts');
+  });
+
+  it('should create a workspace with a single angular app at the root using standalone APIs', () => {
+    const wsName = uniq('angular');
+
+    runCreateWorkspace(wsName, {
+      preset: 'angular-standalone',
+      appName: wsName,
+      style: 'css',
+      packageManager,
+      standaloneApi: true,
+    });
+
+    checkFilesExist('package.json');
+    checkFilesExist('project.json');
+    checkFilesDoNotExist('src/app/app.module.ts');
   });
 
   it('should create a workspace with a single react app with vite at the root', () => {
@@ -129,6 +147,7 @@ describe('create-nx-workspace', () => {
       style: 'css',
       appName,
       packageManager,
+      standaloneApi: false,
       routing: true,
     });
   });
@@ -145,6 +164,7 @@ describe('create-nx-workspace', () => {
         style: 'css',
         appName,
         packageManager,
+        standaloneApi: false,
         routing: true,
       });
     } catch (e) {
@@ -313,6 +333,7 @@ describe('create-nx-workspace', () => {
       style: 'css',
       packageManager: 'npm',
       routing: true,
+      standaloneApi: false,
     });
 
     checkFilesDoNotExist('yarn.lock');

--- a/packages/workspace/src/generators/new/generate-preset.ts
+++ b/packages/workspace/src/generators/new/generate-preset.ts
@@ -77,6 +77,9 @@ export function generatePreset(host: Tree, opts: NormalizedSchema) {
       opts.framework ? `--framework=${opts.framework}` : null,
       opts.docker ? `--docker=${opts.docker}` : null,
       opts.packageManager ? `--packageManager=${opts.packageManager}` : null,
+      opts.standaloneApi !== undefined
+        ? `--standaloneApi=${opts.standaloneApi}`
+        : null,
       parsedArgs.interactive ? '--interactive=true' : '--interactive=false',
       opts.routing !== undefined ? `--routing=${opts.routing}` : null,
     ].filter((e) => !!e);

--- a/packages/workspace/src/generators/new/new.ts
+++ b/packages/workspace/src/generators/new/new.ts
@@ -27,6 +27,7 @@ interface Schema {
   docker?: boolean;
   linter?: Linter;
   bundler?: 'vite' | 'webpack';
+  standaloneApi?: boolean;
   routing?: boolean;
   packageManager?: PackageManager;
 }

--- a/packages/workspace/src/generators/new/schema.json
+++ b/packages/workspace/src/generators/new/schema.json
@@ -29,6 +29,11 @@
       "type": "string",
       "description": "Npm scope for importing libs."
     },
+    "standaloneApi": {
+      "description": "Use the Standalone APIs if generating an Angular application.",
+      "type": "boolean",
+      "default": false
+    },
     "defaultBase": {
       "type": "string",
       "description": "Default base branch for affected."

--- a/packages/workspace/src/generators/preset/preset.ts
+++ b/packages/workspace/src/generators/preset/preset.ts
@@ -32,6 +32,7 @@ async function createPreset(tree: Tree, options: Schema) {
       name: options.name,
       style: options.style,
       linter: options.linter,
+      standalone: options.standaloneApi,
       routing: options.routing,
     });
   } else if (options.preset === Preset.AngularStandalone) {
@@ -45,6 +46,7 @@ async function createPreset(tree: Tree, options: Schema) {
       linter: options.linter,
       routing: options.routing,
       rootProject: true,
+      standalone: options.standaloneApi,
     });
   } else if (options.preset === Preset.ReactMonorepo) {
     const {

--- a/packages/workspace/src/generators/preset/schema.d.ts
+++ b/packages/workspace/src/generators/preset/schema.d.ts
@@ -13,4 +13,5 @@ export interface Schema {
   bundler?: 'vite' | 'webpack';
   docker?: boolean;
   routing?: boolean;
+  standaloneApi?: boolean;
 }

--- a/packages/workspace/src/generators/preset/schema.json
+++ b/packages/workspace/src/generators/preset/schema.json
@@ -56,6 +56,11 @@
         ]
       }
     },
+    "standaloneApi": {
+      "description": "Use the Standalone APIs if generating an Angular application.",
+      "type": "boolean",
+      "default": false
+    },
     "standaloneConfig": {
       "description": "Split the project configurations into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
       "type": "boolean",


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
We do not ask if the user would like to use Standalone APIs when generating an Angular application with CNW

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Angular are soon going to be changing their docs to prioritise Standalone Components + APIs and we already support generating an app with them. 

We should ask users if they'd like to use them when generating an application along with a new workspace
