### PR TITLE
fix(angular): prevent init generator to bump versions and consider installed core packages versions

### DIFF
--- a/packages/angular/src/generators/karma/angular-v14/karma.ts
+++ b/packages/angular/src/generators/karma/angular-v14/karma.ts
@@ -1,6 +1,5 @@
 import type { Tree } from '@nrwl/devkit';
 import {
-  addDependenciesToPackageJson,
   generateFiles,
   joinPathFragments,
   readJson,
@@ -8,6 +7,7 @@ import {
   updateNxJson,
 } from '@nrwl/devkit';
 import { backwardCompatibleVersions } from '../../../utils/backward-compatible-versions';
+import { addDependenciesToPackageJsonIfDontExist } from '../../utils/version-utils';
 import { GeneratorOptions } from './schema';
 
 function addTestInputs(tree: Tree) {
@@ -54,7 +54,7 @@ export function karmaGenerator(tree: Tree, options: GeneratorOptions) {
     return () => {};
   }
 
-  return addDependenciesToPackageJson(
+  return addDependenciesToPackageJsonIfDontExist(
     tree,
     {},
     {

--- a/packages/angular/src/generators/karma/karma.ts
+++ b/packages/angular/src/generators/karma/karma.ts
@@ -1,6 +1,5 @@
 import type { Tree } from '@nrwl/devkit';
 import {
-  addDependenciesToPackageJson,
   generateFiles,
   joinPathFragments,
   readJson,
@@ -19,7 +18,10 @@ import {
   typesJasmineVersion,
   typesNodeVersion,
 } from '../../utils/versions';
-import { getGeneratorDirectoryForInstalledAngularVersion } from '../utils/version-utils';
+import {
+  addDependenciesToPackageJsonIfDontExist,
+  getGeneratorDirectoryForInstalledAngularVersion,
+} from '../utils/version-utils';
 import { GeneratorOptions } from './schema';
 
 function addTestInputs(tree: Tree) {
@@ -75,7 +77,7 @@ export async function karmaGenerator(tree: Tree, options: GeneratorOptions) {
     return () => {};
   }
 
-  return addDependenciesToPackageJson(
+  return addDependenciesToPackageJsonIfDontExist(
     tree,
     {},
     {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The init generator sometimes overrides the versions of installed packages. This is a bigger issue with the added support for multiple versions because it overrides the Angular-related package versions the workspace has installed with the latest minor version of the major currently installed.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The init generator shouldn't bump any version of installed packages, it should only add packages that are not present. Bumping versions is a task for migrations. Also, installing any Angular-related package should consider the versions of Angular core packages and use them if present.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14324 
