### PR TITLE
fix(angular): fix safari tp support and include last 2 chrome version in browserslist in ng-packgr executors

### DIFF
--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/styles/stylesheet-processor.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/styles/stylesheet-processor.ts
@@ -71,7 +71,7 @@ export class StylesheetProcessor {
     // We change the default query to browsers that Angular support.
     // https://angular.io/guide/browser-support
     (browserslist.defaults as string[]) = [
-      'last 1 Chrome version',
+      'last 2 Chrome version',
       'last 1 Firefox version',
       'last 2 Edge major versions',
       'last 2 Safari major versions',
@@ -320,7 +320,7 @@ function transformSupportedBrowsersToTargets(
     if (browserName === 'ie') {
       transformed.push('edge12');
     } else if (esBuildSupportedBrowsers.has(browserName)) {
-      if (browserName === 'safari' && version === 'TP') {
+      if (browserName === 'safari' && version === 'tp') {
         // esbuild only supports numeric versions so `TP` is converted to a high number (999) since
         // a Technology Preview (TP) of Safari is assumed to support all currently known features.
         version = '999';

--- a/packages/angular/src/executors/package/ng-packagr-adjustments/styles/stylesheet-processor.ts
+++ b/packages/angular/src/executors/package/ng-packagr-adjustments/styles/stylesheet-processor.ts
@@ -64,7 +64,7 @@ export class StylesheetProcessor {
     // We change the default query to browsers that Angular support.
     // https://angular.io/guide/browser-support
     (browserslist.defaults as string[]) = [
-      'last 1 Chrome version',
+      'last 2 Chrome version',
       'last 1 Firefox version',
       'last 2 Edge major versions',
       'last 2 Safari major versions',
@@ -313,7 +313,7 @@ function transformSupportedBrowsersToTargets(
     if (browserName === 'ie') {
       transformed.push('edge12');
     } else if (esBuildSupportedBrowsers.has(browserName)) {
-      if (browserName === 'safari' && version === 'TP') {
+      if (browserName === 'safari' && version === 'tp') {
         // esbuild only supports numeric versions so `TP` is converted to a high number (999) since
         // a Technology Preview (TP) of Safari is assumed to support all currently known features.
         version = '999';


### PR DESCRIPTION
Sync `package` and `ng-packagr-lite` executors with fixes on the `ng-packagr` builder:

- Fix support of Safari TP versions
- Update `browserslist` config to include last 2 Chrome versions