### PR TITLE
fix(misc): fix task graph when there is a target with no executor

### DIFF
--- a/packages/nx/src/command-line/dep-graph.ts
+++ b/packages/nx/src/command-line/dep-graph.ts
@@ -582,31 +582,35 @@ function getAllTaskGraphsForWorkspace(
     const targets = Object.keys(project.data.targets);
 
     targets.forEach((target) => {
-      taskGraphs[createTaskId(projectName, target)] = createTaskGraph(
-        projectGraph,
-        defaultDependencyConfigs,
-        [projectName],
-        [target],
-        undefined,
-        {}
-      );
+      try {
+        taskGraphs[createTaskId(projectName, target)] = createTaskGraph(
+          projectGraph,
+          defaultDependencyConfigs,
+          [projectName],
+          [target],
+          undefined,
+          {}
+        );
 
-      const configurations = Object.keys(
-        project.data.targets[target]?.configurations || {}
-      );
+        const configurations = Object.keys(
+          project.data.targets[target]?.configurations || {}
+        );
 
-      if (configurations.length > 0) {
-        configurations.forEach((configuration) => {
-          taskGraphs[createTaskId(projectName, target, configuration)] =
-            createTaskGraph(
-              projectGraph,
-              defaultDependencyConfigs,
-              [projectName],
-              [target],
-              configuration,
-              {}
-            );
-        });
+        if (configurations.length > 0) {
+          configurations.forEach((configuration) => {
+            taskGraphs[createTaskId(projectName, target, configuration)] =
+              createTaskGraph(
+                projectGraph,
+                defaultDependencyConfigs,
+                [projectName],
+                [target],
+                configuration,
+                {}
+              );
+          });
+        }
+      } catch (e) {
+        console.error(e);
       }
     });
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Task Graph doesn't show up when there is a target with no executor

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

If a task graph for a target fails to create, then we just skip it. We don't error for all the task graphs.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
