### PR TITLE
cleanup(nx-plugin): remove dependency fs-extra from create-nx-plugin

### DIFF
--- a/packages/create-nx-plugin/bin/create-nx-plugin.ts
+++ b/packages/create-nx-plugin/bin/create-nx-plugin.ts
@@ -9,7 +9,7 @@ import {
   output,
 } from '@nrwl/devkit';
 import { execSync } from 'child_process';
-import { removeSync } from 'fs-extra';
+import { rmSync } from 'fs';
 import * as path from 'path';
 import { dirSync } from 'tmp';
 import { initializeGitRepo, showNxWarning } from './shared';
@@ -119,8 +119,8 @@ function updateWorkspace(workspaceName: string) {
 
   writeJsonFile(nxJsonPath, nxJson);
 
-  removeSync(path.join(workspaceName, 'apps'));
-  removeSync(path.join(workspaceName, 'libs'));
+  rmSync(path.join(workspaceName, 'apps'), { recursive: true, force: true });
+  rmSync(path.join(workspaceName, 'libs'), { recursive: true, force: true });
 }
 
 function determineWorkspaceName(parsedArgs: any): Promise<string> {

--- a/packages/create-nx-plugin/package.json
+++ b/packages/create-nx-plugin/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "@nrwl/devkit": "file:../devkit",
     "enquirer": "~2.3.6",
-    "fs-extra": "^11.1.0",
     "nx": "file:../nx",
     "tmp": "~0.2.1",
     "yargs-parser": "21.1.1"


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`create-nx-plugin` depends on fs-extra but only uses the `removeSync` method which since fs-extra 11 is just a wrapper for rmSync with the options recursive and force set to true

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`create-nx-plugin` uses `rmSync` and does not depend on `fs-extra`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
