### PR TITLE
fix(webpack): pass the correct config to user when isolatedConfig=false

### DIFF
--- a/packages/webpack/src/executors/webpack/webpack.impl.ts
+++ b/packages/webpack/src/executors/webpack/webpack.impl.ts
@@ -48,14 +48,11 @@ async function getWebpackConfigs(
     : getWebpackConfig(context, options);
 
   if (customWebpack) {
-    return await customWebpack(
-      {},
-      {
-        options,
-        context,
-        configuration: context.configurationName, // backwards compat
-      }
-    );
+    return await customWebpack(config, {
+      options,
+      context,
+      configuration: context.configurationName, // backwards compat
+    });
   } else {
     // If the user has no webpackConfig specified then we always have to apply
     return config;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
If user sets `isolatedConfig: false` (skipped migration or manually changed it), then the legacy config is not passed to the user.

## Expected Behavior
The legacy config should be passed to the user's config function so they can enhance it.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
