### PR TITLE
fix(bundling): add a deprecation warning for users to update their project config before Nx 16

### DIFF
--- a/packages/node/src/executors/webpack/webpack.impl.ts
+++ b/packages/node/src/executors/webpack/webpack.impl.ts
@@ -1,8 +1,8 @@
 /**
  * For backwards compat.
- * TODO(jack): Remove in Nx 16.
+ * TODO(v16): Remove in Nx 16.
  */
-import { ExecutorContext } from '@nrwl/devkit';
+import { ExecutorContext, logger } from '@nrwl/devkit';
 import type { WebpackExecutorOptions } from '@nrwl/webpack';
 import { webpackExecutor as baseWebpackExecutor } from '@nrwl/webpack';
 
@@ -10,6 +10,9 @@ export async function* webpackExecutor(
   options: WebpackExecutorOptions,
   context: ExecutorContext
 ) {
+  logger.warn(
+    '"@nrwl/node:webpack" executor is deprecated. Use "@nrwl/webpack:webpack" instead in your project.json.'
+  );
   yield* baseWebpackExecutor(
     {
       ...options,

--- a/packages/web/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/web/src/executors/dev-server/dev-server.impl.ts
@@ -1,14 +1,17 @@
 /**
  * This is here for backwards-compat.
- * TODO(jack): remove in Nx 16.
+ * TODO(v16): remove in Nx 16.
  */
-import { ExecutorContext } from '@nrwl/devkit';
+import { ExecutorContext, logger } from '@nrwl/devkit';
 
 export async function* devServerExecutor(
   options: any,
   context: ExecutorContext
 ) {
   const { devServerExecutor: baseDevServerExecutor } = require('@nrwl/webpack');
+  logger.warn(
+    '"@nrwl/web:dev-server" executor is deprecated. Use "@nrwl/webpack:dev-server" instead in your project.json.'
+  );
   yield* baseDevServerExecutor(
     {
       ...options,

--- a/packages/web/src/executors/rollup/rollup.impl.ts
+++ b/packages/web/src/executors/rollup/rollup.impl.ts
@@ -1,15 +1,19 @@
 /**
  * This is here for backwards-compat.
- * TODO(jack): remove in Nx 16.
+ * TODO(v16): remove in Nx 16.
  */
 import {
   rollupExecutor as _rollupExecutor,
   RollupExecutorOptions as WebRollupOptions,
 } from '@nrwl/rollup';
+import { logger } from 'nx/src/utils/logger';
 
 export { WebRollupOptions };
 
 export async function* rollupExecutor(options: any, context: any) {
+  logger.warn(
+    '"@nrwl/web:rollup" executor is deprecated. Use "@nrwl/rollup:rollup" instead in your project.json.'
+  );
   return yield* _rollupExecutor(
     {
       ...options,

--- a/packages/web/src/executors/webpack/webpack.impl.ts
+++ b/packages/web/src/executors/webpack/webpack.impl.ts
@@ -1,11 +1,14 @@
 /**
  * For backwards compat.
- * TODO(jack): Remove in Nx 16.
+ * TODO(v16): Remove in Nx 16.
  */
-import { ExecutorContext } from '@nrwl/devkit';
+import { ExecutorContext, logger } from '@nrwl/devkit';
 
 export async function* webpackExecutor(options: any, context: ExecutorContext) {
   const { webpackExecutor: baseWebpackExecutor } = require('@nrwl/webpack');
+  logger.warn(
+    '"@nrwl/web:webpack" executor is deprecated. Use "@nrwl/webpack:webpack" instead in your project.json.'
+  );
   yield* baseWebpackExecutor(
     {
       ...options,


### PR DESCRIPTION
This PR adds a warning message for anyone still using:

- `@nrwl/web:webpack`
- `@nrwl/web:dev-server`
- `@nrwl/web:rollup`
- `@nrwl/node:webpack`


There were migrations added back in Nx 15.3 that updated projects configs, but it may have been skipped (e.g. user manually updated `package.json` rather than run migrate).