### PR TITLE
fix(webpack): ensure NODE_ENV is defaulted to development for dev-server, and HMR works

### DIFF
--- a/packages/webpack/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/webpack/src/executors/dev-server/dev-server.impl.ts
@@ -24,6 +24,9 @@ export async function* devServerExecutor(
   serveOptions: WebDevServerOptions,
   context: ExecutorContext
 ) {
+  // Default to dev mode so builds are faster and HMR mode works better.
+  process.env.NODE_ENV ??= 'development';
+
   const { root: projectRoot, sourceRoot } =
     context.projectsConfigurations.projects[context.projectName];
   const buildOptions = normalizeOptions(


### PR DESCRIPTION
This PR  ensures that `NODE_ENV` is defaulted to `development` so dev-server is not applying the correct config.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14580
