### PR TITLE
fix(angular): unit test runner none should skip tests

### DIFF
--- a/packages/angular/src/generators/application/angular-v14/lib/normalize-options.ts
+++ b/packages/angular/src/generators/application/angular-v14/lib/normalize-options.ts
@@ -3,7 +3,6 @@ import {
   getWorkspaceLayout,
   joinPathFragments,
   names,
-  readJson,
   Tree,
 } from '@nrwl/devkit';
 import type { Schema } from '../schema';
@@ -59,7 +58,7 @@ export function normalizeOptions(
     routing: false,
     inlineStyle: false,
     inlineTemplate: false,
-    skipTests: false,
+    skipTests: options.unitTestRunner === UnitTestRunner.None,
     skipFormat: false,
     unitTestRunner: UnitTestRunner.Jest,
     e2eTestRunner: E2eTestRunner.Cypress,

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -43,6 +43,18 @@ describe('app', () => {
       expect(readProjectConfiguration(appTree, 'my-app-e2e')).toMatchSnapshot();
     });
 
+    it('should not produce tests when UnitTestRunner = none', async () => {
+      // ACT
+      await generateApp(appTree, 'my-app', {
+        unitTestRunner: UnitTestRunner.None,
+      });
+      const { targets } = readProjectConfiguration(appTree, 'my-app');
+      expect(targets.test).toBeFalsy();
+      expect(
+        appTree.exists('apps/my-app/src/app/app.component.spec.ts')
+      ).toBeFalsy();
+    });
+
     it('should remove the e2e target on the application', async () => {
       // ACT
       await generateApp(appTree);

--- a/packages/angular/src/generators/application/lib/normalize-options.ts
+++ b/packages/angular/src/generators/application/lib/normalize-options.ts
@@ -1,8 +1,12 @@
-import { extractLayoutDirectory, joinPathFragments, Tree } from '@nrwl/devkit';
+import {
+  extractLayoutDirectory,
+  getWorkspaceLayout,
+  joinPathFragments,
+  names,
+  Tree,
+} from '@nrwl/devkit';
 import type { Schema } from '../schema';
 import type { NormalizedSchema } from './normalized-schema';
-
-import { names, getWorkspaceLayout } from '@nrwl/devkit';
 import { E2eTestRunner, UnitTestRunner } from '../../../utils/test-runners';
 import { Linter } from '@nrwl/linter';
 import {
@@ -54,7 +58,7 @@ export function normalizeOptions(
     routing: false,
     inlineStyle: false,
     inlineTemplate: false,
-    skipTests: false,
+    skipTests: options.unitTestRunner === UnitTestRunner.None,
     skipFormat: false,
     unitTestRunner: UnitTestRunner.Jest,
     e2eTestRunner: E2eTestRunner.Cypress,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Setting unitTestRunner none causes generation to fail because tests are not skipped. As the test file can depend on the test runner being used, it's safer to skip generation of tests.
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Skip generation of tests when unit test runner none
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
