### PR TITLE
fix(misc): make ts 4.8 update optional and add missing angular requirements

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -1489,6 +1489,9 @@
     },
     "14.5.3": {
       "version": "14.5.3-beta.0",
+      "requires": {
+        "@angular/core": "14.1.0"
+      },
       "packages": {
         "@angular-devkit/architect": {
           "version": "~0.1401.1",
@@ -1639,7 +1642,7 @@
       "version": "15.2.0-beta.0",
       "x-prompt": "Do you want to update the Angular version to v15?",
       "requires": {
-        "@angular/core": "^14.0.0"
+        "@angular/core": "^14.2.0"
       },
       "packages": {
         "@angular-devkit/architect": {

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -94,6 +94,7 @@
     "packageGroup": [
       "@nrwl/jest",
       "@nrwl/linter",
+      "@nrwl/workspace",
       "@nrwl/angular",
       "@nrwl/cli",
       "@nrwl/cypress",
@@ -116,7 +117,6 @@
       "@nrwl/vite",
       "@nrwl/web",
       "@nrwl/webpack",
-      "@nrwl/workspace",
       {
         "package": "@nrwl/nx-cloud",
         "version": "latest"

--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -1084,7 +1084,7 @@ function addSplitConfigurationMigrationIfAvailable(
       {
         version: '15.7.0-beta.0',
         description:
-          'Spilt global configuration files into individual project.json files. This migration has been added automatically to the beginning of your migration set to retroactively make them work with the new version of Nx.',
+          'Split global configuration files into individual project.json files. This migration has been added automatically to the beginning of your migration set to retroactively make them work with the new version of Nx.',
         cli: 'nx',
         implementation:
           './src/migrations/update-15-7-0/split-configuration-into-project-json-files',

--- a/packages/workspace/migrations.json
+++ b/packages/workspace/migrations.json
@@ -80,7 +80,7 @@
     },
     "15-7-0-split-configuration-into-project-json-files": {
       "version": "15.7.0-beta.0",
-      "description": "Spilt global configuration files (e.g., workspace.json) into individual project.json files.",
+      "description": "Split global configuration files (e.g., workspace.json) into individual project.json files.",
       "cli": "nx",
       "implementation": "./src/migrations/update-15-7-0/split-configuration-into-project-json-files"
     }
@@ -135,6 +135,7 @@
     },
     "14.8.0": {
       "version": "14.8.0-beta.0",
+      "x-prompt": "Do you want to update the TypeScript version to v4.8?",
       "packages": {
         "typescript": {
           "version": "~4.8.2",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Migrating to latest and skipping the Angular v15 update, results in a wrong setup with TS ~4.8.2 being installed which is not supported by Angular v14.
Migrating to latest when skipping the Angular v14.1 update we still get asked whether we want to update to Angular v15.
Migrating to latest when skipping the Angular v14.1 still installs Angular v14.1.1 (a required update for v14.1, but if v14.1 is not applied it shouldn't be applied either).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Users should be able to opt out of TS v4.8 update to allow using latest Nx with Angular v14.
If Angular v14.1 update is skipped, we shouldn't get asked whether we want to update to Angular v15.
Should only apply Angular v14.1.1 if v14.1 is applied.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
