### PR TITLE
fix(node): Update Proxy config port number

### DIFF
--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -336,8 +336,8 @@ describe('app', () => {
       expect(tree.exists('my-frontend/proxy.conf.json')).toBeTruthy();
 
       expect(readJson(tree, 'my-frontend/proxy.conf.json')).toEqual({
-        '/api': { target: 'http://localhost:3333', secure: false },
-        '/billing-api': { target: 'http://localhost:3333', secure: false },
+        '/api': { target: 'http://localhost:3000', secure: false },
+        '/billing-api': { target: 'http://localhost:3000', secure: false },
       });
     });
 

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -219,7 +219,7 @@ function addProxy(tree: Tree, options: NormalizedSchema) {
         JSON.stringify(
           {
             '/api': {
-              target: 'http://localhost:3333',
+              target: `http://localhost:${options.port}`,
               secure: false,
             },
           },
@@ -234,7 +234,7 @@ function addProxy(tree: Tree, options: NormalizedSchema) {
       const proxyModified = {
         ...JSON.parse(proxyFileContent),
         [`/${options.name}-api`]: {
-          target: 'http://localhost:3333',
+          target: `http://localhost:${options.port}`,
           secure: false,
         },
       };


### PR DESCRIPTION
When we generated a node-server and check the `frontend-project` flag the proxy-config should contain the port of where the server is being hosted