### PR TITLE
feat(node): create fastify setup closer to what fastify-cli creates

### DIFF
--- a/e2e/node/src/node.test.ts
+++ b/e2e/node/src/node.test.ts
@@ -79,7 +79,7 @@ describe('Node Applications', () => {
       return config;
     });
 
-    await runCLIAsync(`build ${nodeapp}`);
+    await runCLIAsync(`build ${nodeapp} --bundle`);
     checkFilesExist(`dist/apps/${nodeapp}/index.js`);
   }, 300000);
 

--- a/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
+++ b/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
@@ -36,6 +36,12 @@ export async function* esbuildExecutor(
   _options: EsBuildExecutorOptions,
   context: ExecutorContext
 ) {
+  if (!_options.bundle && _options.outputFileName) {
+    logger.warn(
+      `--outputFileName=${_options.outputFileName} can only work when --bundle is used`
+    );
+  }
+
   const options = normalizeOptions(_options);
   if (options.deleteOutputPath) removeSync(options.outputPath);
 

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -34,6 +34,8 @@ import {
   esbuildVersion,
   expressTypingsVersion,
   expressVersion,
+  fastifyAutoloadVersion,
+  fastifySensibleVersion,
   fastifyVersion,
   koaTypingsVersion,
   koaVersion,
@@ -105,6 +107,8 @@ function getEsBuildConfig(
       ),
       tsConfig: joinPathFragments(options.appProjectRoot, 'tsconfig.app.json'),
       assets: [joinPathFragments(project.sourceRoot, 'assets')],
+      // By default, don't bundle the app. Things like __dirname won't work in a bundle.
+      bundle: false,
       esbuildOptions: {
         sourcemap: true,
         // Generate CJS files as .js so imports can be './foo' rather than './foo.cjs'.
@@ -292,13 +296,26 @@ function addProjectDependencies(
     },
     fastify: {
       fastify: fastifyVersion,
+      '@fastify/autoload': fastifyAutoloadVersion,
+      '@fastify/sensible': fastifySensibleVersion,
     },
+  };
+  const frameworkDevDependencies = {
+    express: {
+      '@types/express': expressTypingsVersion,
+    },
+    koa: {
+      '@types/koa': koaTypingsVersion,
+    },
+    fastify: {},
   };
   return addDependenciesToPackageJson(
     tree,
-    {},
     {
       ...frameworkDependencies[options.framework],
+    },
+    {
+      ...frameworkDevDependencies[options.framework],
       ...bundlers[options.bundler],
     }
   );

--- a/packages/node/src/generators/application/files/fastify/src/app/app.ts__tmpl__
+++ b/packages/node/src/generators/application/files/fastify/src/app/app.ts__tmpl__
@@ -1,11 +1,27 @@
+import * as path from 'path';
 import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import AutoLoad from '@fastify/autoload';
 
 /* eslint-disable-next-line */
-export interface AppOptions {
-}
+export interface AppOptions { }
 
 export async function app(fastify: FastifyInstance, opts: AppOptions) {
-  fastify.get('/', async function(request: FastifyRequest, reply: FastifyReply) {
-    return { message: 'Hello API' };
+  // Place here your custom code!
+
+  // Do not touch the following lines
+
+  // This loads all plugins defined in plugins
+  // those should be support plugins that are reused
+  // through your application
+  fastify.register(AutoLoad, {
+    dir: path.join(__dirname, 'plugins'),
+    options: { ...opts },
+  });
+
+  // This loads all plugins defined in routes
+  // define your routes in one of these
+  fastify.register(AutoLoad, {
+    dir: path.join(__dirname, 'routes'),
+    options: { ...opts },
   });
 }

--- a/packages/node/src/generators/application/files/fastify/src/app/plugins/sensible.ts__tmpl__
+++ b/packages/node/src/generators/application/files/fastify/src/app/plugins/sensible.ts__tmpl__
@@ -1,0 +1,12 @@
+import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import fp from 'fastify-plugin';
+import sensible from '@fastify/sensible';
+
+/**
+ * This plugins adds some utilities to handle http errors
+ *
+ * @see https://github.com/fastify/fastify-sensible
+ */
+export default fp(async function(fastify: FastifyInstance, opts: {}) {
+  fastify.register(sensible);
+});

--- a/packages/node/src/generators/application/files/fastify/src/app/routes/root.ts__tmpl__
+++ b/packages/node/src/generators/application/files/fastify/src/app/routes/root.ts__tmpl__
@@ -1,0 +1,7 @@
+import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+
+export default async function(fastify: FastifyInstance, opts: {}) {
+  fastify.get('/', async function(request: FastifyRequest, reply: FastifyReply) {
+    return { message: 'Hello API' };
+  });
+}

--- a/packages/node/src/generators/setup-docker/files/Dockerfile__tmpl__
+++ b/packages/node/src/generators/setup-docker/files/Dockerfile__tmpl__
@@ -17,4 +17,8 @@ RUN addgroup --system <%= project %> && \
 COPY <%= buildLocation %> <%= project %>
 RUN chown -R <%= project %>:<%= project %> .
 
+# You can remove this install step if you build with `--bundle` option.
+# The bundled output will include external dependencies.
+RUN npm --prefix <%= project %> --omit=dev -f install
+
 CMD [ "node", "<%= project %>" ]

--- a/packages/node/src/utils/versions.ts
+++ b/packages/node/src/utils/versions.ts
@@ -2,16 +2,18 @@ export const nxVersion = require('../../package.json').version;
 
 export const tslibVersion = '^2.3.0';
 
-export const typesNodeVersion = '18.7.1';
+export const typesNodeVersion = '~18.7.1';
 
 export const esbuildVersion = '^0.17.5';
 
-export const expressVersion = '^4.18.1';
-export const expressTypingsVersion = '4.17.13';
+export const expressVersion = '~4.18.1';
+export const expressTypingsVersion = '~4.17.13';
 
-export const koaVersion = '2.14.1';
-export const koaTypingsVersion = '2.13.5';
+export const koaVersion = '~2.14.1';
+export const koaTypingsVersion = '~2.13.5';
 
-export const fastifyVersion = '4.11.0';
+export const fastifyVersion = '~4.13.0';
+export const fastifyAutoloadVersion = '~5.7.1';
+export const fastifySensibleVersion = '~5.2.0';
 
 export const axiosVersion = '^1.0.0';


### PR DESCRIPTION
This PR makes three changes:

- Set `bundle: false` for node apps. This is from feedback in Node commuity as well as Matteo from Fastify.
- Fastify app generates with `routes` and `plugins` architecture, same as through `fastify-cli`
- Docker build now includes a build step, unless user enables bundling.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
