### PR TITLE
fix(node): add missing .swcrc file for node libs

### DIFF
--- a/packages/node/src/generators/library/library.ts
+++ b/packages/node/src/generators/library/library.ts
@@ -17,6 +17,8 @@ import { getImportPath } from 'nx/src/utils/path';
 import { Schema } from './schema';
 import { libraryGenerator as workspaceLibraryGenerator } from '@nrwl/workspace/generators';
 import { join } from 'path';
+import { addSwcDependencies } from '@nrwl/js/src/utils/swc/add-swc-dependencies';
+import { addSwcConfig } from '@nrwl/js/src/utils/swc/add-swc-config';
 
 export interface NormalizedSchema extends Schema {
   name: string;
@@ -159,6 +161,11 @@ function updateProject(tree: Tree, options: NormalizedSchema) {
       assets: [`${options.projectRoot}/*.md`],
     },
   };
+
+  if (options.compiler === 'swc') {
+    addSwcDependencies(tree);
+    addSwcConfig(tree, options.projectRoot);
+  }
 
   if (options.rootDir) {
     project.targets.build.options.srcRootForCompilationRoot = options.rootDir;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

When you generate a lib with `@nrwl/node:lib mylib --buildable --compiler=swc` it does not generate a `.swcrc` file which leads to a build error.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
