### PR TITLE
fix(misc): throw an error when removing unsafe projects

### DIFF
--- a/packages/workspace/src/generators/remove/lib/check-project-is-safe-to-remove.spec.ts
+++ b/packages/workspace/src/generators/remove/lib/check-project-is-safe-to-remove.spec.ts
@@ -1,0 +1,52 @@
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import {
+  addProjectConfiguration,
+  readProjectConfiguration,
+  Tree,
+} from '@nrwl/devkit';
+import { checkProjectIsSafeToRemove } from './check-project-is-safe-to-remove';
+
+describe('checkProjectIsSafeToRemove', () => {
+  let tree: Tree;
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+  it('should not remove the root project', () => {
+    addProjectConfiguration(tree, 'root-project', {
+      root: '.',
+    });
+
+    expect(() => {
+      checkProjectIsSafeToRemove(
+        tree,
+        {
+          projectName: 'root-project',
+          forceRemove: false,
+          skipFormat: false,
+        },
+        readProjectConfiguration(tree, 'root-project')
+      );
+    }).toThrow();
+  });
+
+  it('should not remove the projects containing other projects', () => {
+    addProjectConfiguration(tree, 'parent-project', {
+      root: 'parent',
+    });
+    addProjectConfiguration(tree, 'nested-project', {
+      root: 'parent/nested',
+    });
+
+    expect(() => {
+      checkProjectIsSafeToRemove(
+        tree,
+        {
+          projectName: 'parent-project',
+          forceRemove: false,
+          skipFormat: false,
+        },
+        readProjectConfiguration(tree, 'parent-project')
+      );
+    }).toThrow();
+  });
+});

--- a/packages/workspace/src/generators/remove/lib/check-project-is-safe-to-remove.ts
+++ b/packages/workspace/src/generators/remove/lib/check-project-is-safe-to-remove.ts
@@ -1,0 +1,37 @@
+import { getProjects, logger, ProjectConfiguration, Tree } from '@nrwl/devkit';
+import { Schema } from '../schema';
+import { relative } from 'path';
+
+export function checkProjectIsSafeToRemove(
+  tree: Tree,
+  schema: Schema,
+  project: ProjectConfiguration
+) {
+  if (project.root === '.') {
+    throw new Error(
+      `"${schema.projectName}" is the root project. Running this would delete every file in your workspace.`
+    );
+  }
+  if (schema.forceRemove) {
+    logger.warn(`You have passed --forceRemove`);
+    return;
+  }
+  const containedProjects = [];
+  for (const [_, p] of getProjects(tree)) {
+    if (
+      project.name !== p.name &&
+      !relative(project.root, p.root).startsWith('../')
+    ) {
+      containedProjects.push(p.name);
+    }
+  }
+  if (containedProjects.length > 0) {
+    throw new Error(
+      `"${
+        schema.projectName
+      }" is a project that has nested projects within it. Removing this project would remove the following projects as well:\n - ${containedProjects.join(
+        '\n - '
+      )}\nPass --forceRemove to remove all of the above projects`
+    );
+  }
+}

--- a/packages/workspace/src/generators/remove/remove.ts
+++ b/packages/workspace/src/generators/remove/remove.ts
@@ -5,6 +5,7 @@ import {
   Tree,
 } from '@nrwl/devkit';
 
+import { checkProjectIsSafeToRemove } from './lib/check-project-is-safe-to-remove';
 import { checkDependencies } from './lib/check-dependencies';
 import { checkTargets } from './lib/check-targets';
 import { removeProject } from './lib/remove-project';
@@ -15,6 +16,7 @@ import { updateJestConfig } from './lib/update-jest-config';
 
 export async function removeGenerator(tree: Tree, schema: Schema) {
   const project = readProjectConfiguration(tree, schema.projectName);
+  await checkProjectIsSafeToRemove(tree, schema, project);
   await checkDependencies(tree, schema);
   await checkTargets(tree, schema);
   updateJestConfig(tree, schema, project);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When removing the root project of a workspace, every file gets removed.

If a project containing other projects within it is removed, the projects it contains will also be removed.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

An error is thrown in the above cases. If you really want to remove a project with other projects nested within it, pass `--forceRemove`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/14885
