### PR TITLE
fix(angular): add missing ts 4.8.2+ requirement to angular v15 update

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -1642,7 +1642,8 @@
       "version": "15.2.0-beta.0",
       "x-prompt": "Do you want to update the Angular version to v15?",
       "requires": {
-        "@angular/core": "^14.2.0"
+        "@angular/core": "^14.2.0",
+        "typescript": ">=4.8.2 <5.0"
       },
       "packages": {
         "@angular-devkit/architect": {
@@ -1774,7 +1775,8 @@
       "version": "15.5.0-beta.0",
       "x-prompt": "Do you want to update the Angular version to v15.1?",
       "requires": {
-        "@angular/core": ">=15.0.0 <15.1.0"
+        "@angular/core": ">=15.0.0 <15.1.0",
+        "typescript": ">=4.8.2 <5.0"
       },
       "packages": {
         "@angular-devkit/architect": {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When migrating and opting out of the TS 4.8 update, users are prompted whether they want to update to Angular v15. That's not correct because Angular v15 requires TS >=4.8.2 <5.0.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

If a user opts out of the TS 4.8 update, it shouldn't get prompted to apply the Angular v15 update.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
