### PR TITLE
docs(angular): use path alias for `shared/ui`

### DIFF
--- a/docs/shared/angular-standalone-tutorial/2-project-graph.md
+++ b/docs/shared/angular-standalone-tutorial/2-project-graph.md
@@ -63,7 +63,7 @@ Configure the routes:
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
-import { SharedUiModule } from 'shared/ui';
+import { SharedUiModule } from '@store/shared/ui';
 
 import { AppComponent } from './app.component';
 import { NxWelcomeComponent } from './nx-welcome.component';
@@ -152,7 +152,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { CartRouteComponent } from './cart-route/cart-route.component';
-import { SharedUiModule } from 'shared/ui';
+import { SharedUiModule } from '@store/shared/ui';
 
 @NgModule({
   declarations: [CartRouteComponent],


### PR DESCRIPTION
As per #14904 description, the code sample is missing a path alias generated automatically by NX.

/cc @artofjohn

Thanks!

Closes #14904
