### PR TITLE
docs(core): add Gitlab CI variable GIT_DEPTH: 0

### DIFF
--- a/docs/shared/monorepo-ci-gitlab.md
+++ b/docs/shared/monorepo-ci-gitlab.md
@@ -25,6 +25,9 @@ stages:
     - NX_HEAD=$CI_COMMIT_SHA
     - NX_BASE=${CI_MERGE_REQUEST_DIFF_BASE_SHA:-$CI_COMMIT_BEFORE_SHA}
 
+variables:
+  GIT_DEPTH: 0
+
 format-check:
   stage: test
   extends: .distributed


### PR DESCRIPTION
## Current Behavior
Gitlab CI errors:
```
fatal: Not a valid commit name _last_main_commit_hash_
fatal: No such ref: '_last_main_commit_hash_'
```

## Expected Behavior
Gitlab CI with no errors on merge requests with lot of commits.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
