### PR TITLE
fix(nx-plugin): generate index.ts in the package root

### DIFF
--- a/e2e/nx-plugin/src/nx-plugin.test.ts
+++ b/e2e/nx-plugin/src/nx-plugin.test.ts
@@ -1,6 +1,8 @@
 import { ProjectConfiguration } from '@nrwl/devkit';
 import {
   checkFilesExist,
+  cleanupProject,
+  createFile,
   expectTestsPass,
   isNotWindows,
   killPorts,
@@ -11,10 +13,6 @@ import {
   runCLIAsync,
   uniq,
   updateFile,
-  createFile,
-  readFile,
-  removeFile,
-  cleanupProject,
 } from '@nrwl/e2e/utils';
 
 import { ASYNC_GENERATOR_EXECUTOR_CONTENTS } from './nx-plugin.fixtures';
@@ -43,7 +41,7 @@ describe('Nx Plugin', () => {
       `dist/libs/${plugin}/package.json`,
       `dist/libs/${plugin}/generators.json`,
       `dist/libs/${plugin}/executors.json`,
-      `dist/libs/${plugin}/src/index.js`,
+      `dist/libs/${plugin}/index.js`,
       `dist/libs/${plugin}/src/generators/${plugin}/schema.json`,
       `dist/libs/${plugin}/src/generators/${plugin}/schema.d.ts`,
       `dist/libs/${plugin}/src/generators/${plugin}/generator.js`,
@@ -291,7 +289,7 @@ describe('Nx Plugin', () => {
     it('should be able to infer projects and targets', async () => {
       // Setup project inference + target inference
       updateFile(
-        `libs/${plugin}/src/index.ts`,
+        `libs/${plugin}/index.ts`,
         `import {basename} from 'path'
 
   export function registerProjectTargets(f) {

--- a/packages/nx-plugin/src/generators/e2e-project/files/tests/__pluginName__.spec.ts__tmpl__
+++ b/packages/nx-plugin/src/generators/e2e-project/files/tests/__pluginName__.spec.ts__tmpl__
@@ -41,7 +41,7 @@ describe('<%= pluginName %> e2e', () => {
         `generate <%=npmPackageName%>:<%= pluginName %> ${project} --directory subdir`
       );
       expect(() =>
-        checkFilesExist(`libs/subdir/${project}/src/index.ts`)
+        checkFilesExist(`libs/subdir/${project}/index.ts`)
       ).not.toThrow();
     }, 120000);
   });

--- a/packages/nx-plugin/src/generators/plugin/files/plugin/package.json__tmpl__
+++ b/packages/nx-plugin/src/generators/plugin/files/plugin/package.json__tmpl__
@@ -1,7 +1,7 @@
 {
     "name": "<%= npmPackageName %>",
     "version": "0.0.1",
-    "main": "index.js",
+    "main": "./index.js",
     "generators": "./generators.json",
     "executors": "./executors.json"
 }

--- a/packages/nx-plugin/src/generators/plugin/files/plugin/package.json__tmpl__
+++ b/packages/nx-plugin/src/generators/plugin/files/plugin/package.json__tmpl__
@@ -1,7 +1,7 @@
 {
     "name": "<%= npmPackageName %>",
     "version": "0.0.1",
-    "main": "src/index.js",
+    "main": "index.js",
     "generators": "./generators.json",
     "executors": "./executors.json"
 }

--- a/packages/nx-plugin/src/generators/plugin/plugin.spec.ts
+++ b/packages/nx-plugin/src/generators/plugin/plugin.spec.ts
@@ -40,7 +40,7 @@ describe('NxPlugin Plugin Generator', () => {
       options: {
         outputPath: 'dist/libs/my-plugin',
         tsConfig: 'libs/my-plugin/tsconfig.lib.json',
-        main: 'libs/my-plugin/src/index.ts',
+        main: 'libs/my-plugin/index.ts',
         assets: [
           'libs/my-plugin/*.md',
           {

--- a/packages/nx-plugin/src/generators/plugin/plugin.spec.ts
+++ b/packages/nx-plugin/src/generators/plugin/plugin.spec.ts
@@ -115,6 +115,7 @@ describe('NxPlugin Plugin Generator', () => {
       'libs/my-plugin/project.json',
       'libs/my-plugin/generators.json',
       'libs/my-plugin/executors.json',
+      'libs/my-plugin/index.ts',
       'libs/my-plugin/src/generators/my-plugin/schema.d.ts',
       'libs/my-plugin/src/generators/my-plugin/generator.ts',
       'libs/my-plugin/src/generators/my-plugin/generator.spec.ts',

--- a/packages/nx-plugin/src/generators/plugin/plugin.ts
+++ b/packages/nx-plugin/src/generators/plugin/plugin.ts
@@ -9,7 +9,6 @@ import {
   readProjectConfiguration,
   Tree,
   updateJson,
-  readJson,
   updateProjectConfiguration,
 } from '@nrwl/devkit';
 import { libraryGenerator } from '@nrwl/js';
@@ -26,7 +25,6 @@ import pluginLintCheckGenerator from '../lint-checks/generator';
 import { NormalizedSchema, normalizeOptions } from './utils/normalize-schema';
 
 import type { Schema } from './schema';
-import { readJSON } from 'fs-extra';
 
 async function addFiles(host: Tree, options: NormalizedSchema) {
   host.delete(normalizePath(`${options.projectRoot}/src/lib`));


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Generated nx-plugins contain their package.json index file located in `src/index.ts`, and this leads to error when dynamically installing the plugin and using functions exported by the index file as described in #14933.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Generated nx-plugins should have their `index.ts` file located at the package's root.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14933
