### PR TITLE
fix(core): ignore root configs and package.json for standalone explicit dependencies

### DIFF
--- a/packages/nx/src/project-graph/build-dependencies/explicit-package-json-dependencies.ts
+++ b/packages/nx/src/project-graph/build-dependencies/explicit-package-json-dependencies.ts
@@ -77,6 +77,7 @@ function processPackageJson(
   collectedDeps: any[],
   packageNameMap: { [packageName: string]: string }
 ) {
+  const isRootPackageJson = fileName === 'package.json';
   try {
     const deps = readDeps(parseJson(defaultFileRead(fileName)));
     // the name matches the import path
@@ -88,7 +89,7 @@ function processPackageJson(
           targetProjectName: packageNameMap[d],
           sourceProjectFile: fileName,
         });
-      } else if (graph.externalNodes[`npm:${d}`]) {
+      } else if (!isRootPackageJson && graph.externalNodes[`npm:${d}`]) {
         collectedDeps.push({
           sourceProjectName: sourceProject,
           targetProjectName: `npm:${d}`,

--- a/packages/nx/src/project-graph/build-dependencies/explicit-project-dependencies.ts
+++ b/packages/nx/src/project-graph/build-dependencies/explicit-project-dependencies.ts
@@ -6,6 +6,8 @@ import {
   ProjectGraph,
 } from '../../config/project-graph';
 
+const IGNORED_ROOT_FILES = ['jest.preset.js'];
+
 export function buildExplicitTypeScriptDependencies(
   graph: ProjectGraph,
   filesToProcess: ProjectFileMap
@@ -34,7 +36,10 @@ export function buildExplicitTypeScriptDependencies(
               // TODO: These edges technically should be allowed but we need to figure out how to separate config files out from root
               return;
             }
-
+            // standalone apps should not have dependency to jest.preset.js imports
+            if (isRoot(source) && IGNORED_ROOT_FILES.includes(f.file)) {
+              return;
+            }
             res.push({
               sourceProjectName: source,
               targetProjectName: target,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Explicit dependencies collection logic does not distinguish between standalone/root and regular packages leading to more static dependencies than needed

## Expected Behavior
For standalone packages, root package.json and root config files should be ignored.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
