### PR TITLE
fix(core): support wildcard and latest for pruning version normalization

### DIFF
--- a/packages/nx/src/utils/create-package-json.ts
+++ b/packages/nx/src/utils/create-package-json.ts
@@ -30,6 +30,13 @@ export function createPackageJson(
       packageJson = readJsonFile(
         `${graph.nodes[projectName].data.root}/package.json`
       );
+      // for standalone projects we don't want to include all the root dependencies
+      if (graph.nodes[projectName].data.root === '.') {
+        packageJson = {
+          name: packageJson.name,
+          version: packageJson.version,
+        };
+      }
     } catch (e) {}
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Lock file pruning dependencies normalization does not support `latest` and `*`

## Expected Behavior
Lock file pruning dependencies normalization should support `latest` and `*`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
