### PR TITLE
fix(core): nesting npm lock file deps should support multi nests

### DIFF
--- a/packages/nx/src/lock-file/npm-parser.ts
+++ b/packages/nx/src/lock-file/npm-parser.ts
@@ -496,9 +496,8 @@ function nestMappedPackages(
   }
 
   nestedNodes.forEach((node) => {
-    if (invertedGraph.dependencies[node.name].length === 1) {
-      const targetName = invertedGraph.dependencies[node.name][0].target;
-      const targetNode = invertedGraph.externalNodes[targetName];
+    invertedGraph.dependencies[node.name].forEach(({ target }) => {
+      const targetNode = invertedGraph.externalNodes[target];
 
       if (visitedNodes.has(targetNode)) {
         visitedNodes.get(targetNode).forEach((path) => {
@@ -520,7 +519,7 @@ function nestMappedPackages(
         });
         nestedNodes.delete(node);
       }
-    }
+    });
   });
 
   if (initialSize === nestedNodes.size) {

--- a/packages/nx/src/lock-file/npm-parser.ts
+++ b/packages/nx/src/lock-file/npm-parser.ts
@@ -496,6 +496,7 @@ function nestMappedPackages(
   }
 
   nestedNodes.forEach((node) => {
+    let unresolvedParents = invertedGraph.dependencies[node.name].length;
     invertedGraph.dependencies[node.name].forEach(({ target }) => {
       const targetNode = invertedGraph.externalNodes[target];
 
@@ -517,9 +518,12 @@ function nestMappedPackages(
           }
           visitedPaths.add(mappedPackage.path);
         });
-        nestedNodes.delete(node);
+        unresolvedParents--;
       }
     });
+    if (!unresolvedParents) {
+      nestedNodes.delete(node);
+    }
   });
 
   if (initialSize === nestedNodes.size) {


### PR DESCRIPTION
Imagine the following situation:

A@v1 -> D@v2 -> B@v2
B@v1
C@v1 -> B@v2
D@v1

Package `B@v2` will have two nests - one as a direct child of `C` and another one as a child of `A` (since A has no `B` child of its own). Current implementation explicitly checks that there is only a single slot to place `B@v2` causing this package to never be nested.

We need to support multiple nesting slots.

## Current Behavior
If the package version has multiple nesting places, the stringifier ends up in the loop

## Expected Behavior
Npm stringifier should support multiple nesting slots for the same package

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
