### PR TITLE
feat(vite): be able to use a custom build target for the preview server

### DIFF
--- a/docs/generated/packages/vite/executors/preview-server.json
+++ b/docs/generated/packages/vite/executors/preview-server.json
@@ -41,6 +41,11 @@
       "clearScreen": {
         "description": "Set to false to prevent Vite from clearing the terminal screen when logging certain messages.",
         "type": "boolean"
+      },
+      "staticFilePath": {
+        "type": "string",
+        "description": "Path where the build artifacts are located. If not provided then it will be infered from the buildTarget executor options as outputPath",
+        "x-completion-type": "directory"
       }
     },
     "definitions": {},

--- a/packages/vite/src/executors/preview-server/preview-server.impl.ts
+++ b/packages/vite/src/executors/preview-server/preview-server.impl.ts
@@ -9,22 +9,49 @@ import {
 import { ViteBuildExecutorOptions } from '../build/schema';
 import { VitePreviewServerExecutorOptions } from './schema';
 
+interface CustomBuildTargetOptions {
+  outputPath: string;
+}
+
 export async function* vitePreviewServerExecutor(
   options: VitePreviewServerExecutorOptions,
   context: ExecutorContext
 ) {
+  const target = parseTargetString(options.buildTarget, context.projectGraph);
+  const targetConfiguration =
+    context.projectsConfigurations.projects[target.project]?.targets[
+      target.target
+    ];
+  if (!targetConfiguration) {
+    throw new Error(`Invalid buildTarget: ${options.buildTarget}`);
+  }
+
+  const isCustomBuildTarget =
+    targetConfiguration.executor !== '@nrwl/vite:build';
+
   // Retrieve the option for the configured buildTarget.
-  const buildTargetOptions: ViteBuildExecutorOptions = getNxTargetOptions(
+  const buildTargetOptions:
+    | ViteBuildExecutorOptions
+    | CustomBuildTargetOptions = getNxTargetOptions(
     options.buildTarget,
     context
   );
+
+  const outputPath = options.staticFilePath ?? buildTargetOptions.outputPath;
+
+  if (!outputPath) {
+    throw new Error(
+      `Could not infer the "outputPath". It should either be a property of the "${options.buildTarget}" buildTarget or provided explicitly as a "staticFilePath" option.`
+    );
+  }
 
   // Merge the options from the build and preview-serve targets.
   // The latter takes precedence.
   const mergedOptions = {
     ...{ watch: {} },
-    ...buildTargetOptions,
+    ...(isCustomBuildTarget ? {} : buildTargetOptions),
     ...options,
+    outputPath,
   };
 
   // Retrieve the server configuration.
@@ -51,8 +78,9 @@ export async function* vitePreviewServerExecutor(
   process.once('exit', processOnExit);
 
   // Launch the build target.
-  const target = parseTargetString(options.buildTarget, context.projectGraph);
-  const build = await runExecutor(target, mergedOptions, context);
+  // If customBuildTarget is set to true, do not provide any overrides to it
+  const buildTargetOverrides = isCustomBuildTarget ? {} : mergedOptions;
+  const build = await runExecutor(target, buildTargetOverrides, context);
 
   for await (const result of build) {
     if (result.success) {

--- a/packages/vite/src/executors/preview-server/schema.d.ts
+++ b/packages/vite/src/executors/preview-server/schema.d.ts
@@ -8,4 +8,5 @@ export interface VitePreviewServerExecutorOptions {
   logLevel?: 'info' | 'warn' | 'error' | 'silent';
   mode?: string;
   clearScreen?: boolean;
+  staticFilePath?: string;
 }

--- a/packages/vite/src/executors/preview-server/schema.json
+++ b/packages/vite/src/executors/preview-server/schema.json
@@ -67,6 +67,11 @@
     "clearScreen": {
       "description": "Set to false to prevent Vite from clearing the terminal screen when logging certain messages.",
       "type": "boolean"
+    },
+    "staticFilePath": {
+      "type": "string",
+      "description": "Path where the build artifacts are located. If not provided then it will be infered from the buildTarget executor options as outputPath",
+      "x-completion-type": "directory"
     }
   },
   "definitions": {},


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
This PR is a result of this discussion https://github.com/nrwl/nx/pull/14815

Currently it's not possible to use a target with an executor different from `@nrwl/vite:build` for the preview-server's buildTarget
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Should be able to.
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
