### PR TITLE
fix(angular): fallback to buildTarget.options if no configuration provided

### DIFF
--- a/packages/angular/src/builders/webpack-dev-server/webpack-dev-server.impl.ts
+++ b/packages/angular/src/builders/webpack-dev-server/webpack-dev-server.impl.ts
@@ -42,7 +42,7 @@ export function executeWebpackDevServerBuilder(
     ? buildTarget.configurations[parsedBrowserTarget.configuration]
     : buildTarget.defaultConfiguration
     ? buildTarget.configurations[buildTarget.defaultConfiguration]
-    : undefined;
+    : buildTarget.options;
 
   const buildLibsFromSource =
     options.buildLibsFromSource ??


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
If no configuration is provided as the browserTarget string then the serve falls over

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Fallback to the buildTarget.options when no configuration provided. Assume that the buildTarget.options has all necessary options defined in this scenario

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
