### PR TITLE
fix(js): default build should work when rollup is selected

### DIFF
--- a/docs/generated/packages/js/generators/library.json
+++ b/docs/generated/packages/js/generators/library.json
@@ -113,7 +113,7 @@
       "bundler": {
         "description": "The bundler to use.",
         "type": "string",
-        "enum": ["none", "esbuild", "rollup", "vite", "webpack"],
+        "enum": ["none", "esbuild", "rollup", "vite"],
         "default": "none",
         "x-priority": "important"
       },

--- a/e2e/webpack/src/webpack.test.ts
+++ b/e2e/webpack/src/webpack.test.ts
@@ -58,35 +58,4 @@ describe('Webpack Plugin', () => {
     output = runCommand(`node dist/libs/${myPkg}/main.js`);
     expect(output).toMatch(/Hello/);
   }, 500000);
-
-  it('should define process.env variables only for --platform=web', async () => {
-    const myPkg = uniq('my-pkg');
-    runCLI(`generate @nrwl/js:lib ${myPkg} --bundler=webpack`);
-    updateFile(
-      `libs/${myPkg}/src/index.ts`,
-      `console.log(process.env['NX_TEST_VAR']);\n`
-    );
-
-    runCLI(`build ${myPkg} --platform=node`, {
-      env: {
-        NX_TEST_VAR: 'Hello build time',
-      },
-    });
-
-    expect(
-      runCommand(`node dist/libs/${myPkg}/main.js`, {
-        env: {
-          NX_TEST_VAR: 'Hello run time',
-        },
-      })
-    ).toMatch(/Hello run time/);
-
-    runCLI(`build ${myPkg} --platform=web`, {
-      env: {
-        NX_TEST_VAR: 'Hello build time',
-      },
-    });
-
-    expect(readFile(`dist/libs/${myPkg}/main.js`)).toMatch(/Hello build time/);
-  }, 300_000);
 });

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -80,8 +80,7 @@ export async function projectGenerator(
     });
     tasks.push(viteTask);
   }
-
-  if (schema.bundler === 'webpack' || schema.bundler === 'rollup') {
+  if (schema.bundler === 'rollup') {
     ensureBabelRootConfigExists(tree);
   }
 
@@ -154,17 +153,11 @@ function addProject(
         outputPath,
         main: `${options.projectRoot}/src/index` + (options.js ? '.js' : '.ts'),
         tsConfig: `${options.projectRoot}/tsconfig.lib.json`,
-        // TODO(jack): assets for webpack and rollup have validation that we need to fix (assets must be under <project-root>/src)
+        // TODO(jack): assets for rollup have validation that we need to fix (assets must be under <project-root>/src)
         assets:
-          options.bundler === 'webpack' || options.bundler === 'rollup'
-            ? []
-            : [`${options.projectRoot}/*.md`],
+          options.bundler === 'rollup' ? [] : [`${options.projectRoot}/*.md`],
       },
     };
-
-    if (options.bundler === 'webpack') {
-      projectConfiguration.targets.build.options.babelUpwardRootMode = true;
-    }
 
     if (options.compiler === 'swc' && options.skipTypeCheck) {
       projectConfiguration.targets.build.options.skipTypeCheck = true;
@@ -446,14 +439,6 @@ function addProjectDependencies(
     );
   }
 
-  if (options.bundler == 'webpack') {
-    return addDependenciesToPackageJson(
-      tree,
-      {},
-      { '@nrwl/webpack': nxVersion, '@types/node': typesNodeVersion }
-    );
-  }
-
   // noop
   return () => {};
 }
@@ -464,8 +449,6 @@ function getBuildExecutor(options: NormalizedSchema) {
       return `@nrwl/esbuild:esbuild`;
     case 'rollup':
       return `@nrwl/rollup:rollup`;
-    case 'webpack':
-      return `@nrwl/webpack:webpack`;
     default:
       return `@nrwl/js:${options.compiler}`;
   }

--- a/packages/js/src/generators/library/schema.json
+++ b/packages/js/src/generators/library/schema.json
@@ -113,7 +113,7 @@
     "bundler": {
       "description": "The bundler to use.",
       "type": "string",
-      "enum": ["none", "esbuild", "rollup", "vite", "webpack"],
+      "enum": ["none", "esbuild", "rollup", "vite"],
       "default": "none",
       "x-priority": "important"
     },

--- a/packages/js/src/utils/schema.d.ts
+++ b/packages/js/src/utils/schema.d.ts
@@ -7,7 +7,7 @@ import type {
 import { TransformerEntry } from './typescript/types';
 
 export type Compiler = 'tsc' | 'swc';
-export type Bundler = 'none' | 'rollup' | 'esbuild' | 'vite' | 'webpack';
+export type Bundler = 'none' | 'rollup' | 'esbuild' | 'vite';
 
 export interface LibraryGeneratorSchema {
   name: string;

--- a/packages/rollup/src/executors/rollup/lib/normalize.ts
+++ b/packages/rollup/src/executors/rollup/lib/normalize.ts
@@ -1,4 +1,4 @@
-import { basename, dirname, relative, resolve } from 'path';
+import { basename, dirname, join, relative, resolve } from 'path';
 import { statSync } from 'fs';
 import { normalizePath } from '@nrwl/devkit';
 
@@ -18,7 +18,9 @@ export function normalizeRollupExecutorOptions(
 ): NormalizedRollupExecutorOptions {
   const main = `${root}/${options.main}`;
   const entryRoot = dirname(main);
-  const project = `${root}/${options.project}`;
+  const project = options.project
+    ? `${root}/${options.project}`
+    : join(root, 'package.json');
   const projectRoot = dirname(project);
   const outputPath = `${root}/${options.outputPath}`;
 


### PR DESCRIPTION
When a user selects rollup when generating a js lib running `npx nx build {lib}` should work without errors.

Clean up `webpack` as a viable bundler for js libs

closed #14810