### PR TITLE
docs(nx-cloud): make access token doc discoverable

### DIFF
--- a/docs/nx-cloud/account/access-tokens.md
+++ b/docs/nx-cloud/account/access-tokens.md
@@ -11,7 +11,7 @@ There are currently two (2) types of Access Tokens for Nx Cloud's runner that yo
 
 ### Access Tokens: Read Only
 
-The `read-only` access tokens allow Nx Cloud to store metadata about runs and **read cached artifacts**, supports distributed task execution.
+The `read-only` access tokens will only read from the remote cache.  Task results will not be stored in the remote cache for other developers to use.
 
 ### Access Tokens: Read & Write
 

--- a/docs/nx-cloud/account/access-tokens.md
+++ b/docs/nx-cloud/account/access-tokens.md
@@ -2,11 +2,20 @@
 
 The permissions and membership define what developers can access on nx.app. They don't affect what happens when you run Nx commands locally or on CI. To manage that, you need to provision access tokens. To do that, go to Workspace Options / Manage Access Tokens.
 
-There are two types of tokens:
+## Types of Access Tokens
 
-Read - stores metadata about runs and reads cached artifacts, supports distributed task execution.
+They are currently two (2) types of Access Tokens for Nx Cloud's runner that you can use on your workspace.
 
-Read-write - stores metadata about runs, reads and writes cached artifacts, supports distributed task execution.
+- `read-only`
+- `read-write`
+
+### Access Tokens: Read Only
+
+The `read-only` access tokens allow Nx Cloud to store metadata about runs and **read cached artifacts**, supports distributed task execution.
+
+### Access Tokens: Read & Write
+
+The `read-write` access tokens allow Nx Cloud to store metadata about runs, **read and write cached artifacts**, supports distributed task execution.
 
 ## Setting Access Tokens
 

--- a/docs/nx-cloud/account/access-tokens.md
+++ b/docs/nx-cloud/account/access-tokens.md
@@ -4,7 +4,7 @@ The permissions and membership define what developers can access on nx.app. They
 
 ## Types of Access Tokens
 
-They are currently two (2) types of Access Tokens for Nx Cloud's runner that you can use on your workspace.
+There are currently two (2) types of Access Tokens for Nx Cloud's runner that you can use on your workspace.  Both tokens support distributed task execution and allow Nx Cloud to store metadata about runs.
 
 - `read-only`
 - `read-write`

--- a/docs/nx-cloud/account/access-tokens.md
+++ b/docs/nx-cloud/account/access-tokens.md
@@ -15,7 +15,7 @@ The `read-only` access tokens allow Nx Cloud to store metadata about runs and **
 
 ### Access Tokens: Read & Write
 
-The `read-write` access tokens allow Nx Cloud to store metadata about runs, **read and write cached artifacts**, supports distributed task execution.
+The `read-write` access tokens allows task results to be stored in the remote cache for other developers to download and replay on their machines.
 
 ## Setting Access Tokens
 

--- a/docs/nx-cloud/account/access-tokens.md
+++ b/docs/nx-cloud/account/access-tokens.md
@@ -4,14 +4,14 @@ The permissions and membership define what developers can access on nx.app. They
 
 ## Types of Access Tokens
 
-There are currently two (2) types of Access Tokens for Nx Cloud's runner that you can use on your workspace.  Both tokens support distributed task execution and allow Nx Cloud to store metadata about runs.
+There are currently two (2) types of Access Tokens for Nx Cloud's runner that you can use on your workspace. Both tokens support distributed task execution and allow Nx Cloud to store metadata about runs.
 
 - `read-only`
 - `read-write`
 
 ### Access Tokens: Read Only
 
-The `read-only` access tokens will only read from the remote cache.  Task results will not be stored in the remote cache for other developers to use.
+The `read-only` access tokens will only read from the remote cache. Task results will not be stored in the remote cache for other developers to use.
 
 ### Access Tokens: Read & Write
 


### PR DESCRIPTION
It makes the Nx Cloud access token documentation more discoverable and maybe a bit more easy to understand.