### PR TITLE
fix(devkit): fix support renaming directories with the tree

### DIFF
--- a/packages/cypress/src/generators/migrate-to-cypress-11/migrate-to-cypress-11.spec.ts
+++ b/packages/cypress/src/generators/migrate-to-cypress-11/migrate-to-cypress-11.spec.ts
@@ -397,6 +397,7 @@ describe('convertToCypressTen', () => {
       sourceRoot: 'apps/app-e2e/src',
     };
     const filePaths = [
+      'src/integration/nested/something.spec.ts',
       'src/integration/something.spec.ts',
       'src/integration/another.spec.ts',
       'src/integration/another.spec.js',
@@ -488,6 +489,26 @@ const eh = require("../../support")
       expect(tree.exists('apps/app-e2e/src/fixtures/example.json')).toEqual(
         true
       );
+    });
+
+    it('should rename files', () => {
+      const newIntegrationFolder = joinPathFragments(
+        projectConfig.root,
+        cypressConfigs.cypressConfigTs.e2e.integrationFolder
+      );
+      const oldIntegrationFolder = joinPathFragments(
+        projectConfig.root,
+        cypressConfigs.cypressConfigJson.integrationFolder
+      );
+      updateProjectPaths(tree, projectConfig, {
+        cypressConfigTs: cypressConfigs.cypressConfigTs,
+        cypressConfigJson: cypressConfigs.cypressConfigJson,
+      });
+      expect(tree.exists(newIntegrationFolder)).toEqual(true);
+      expect(tree.exists(oldIntegrationFolder)).toEqual(false);
+      expect(
+        tree.exists(`${newIntegrationFolder}/nested/something.cy.ts`)
+      ).toBe(true);
     });
   });
 

--- a/packages/nx/src/generators/tree.spec.ts
+++ b/packages/nx/src/generators/tree.spec.ts
@@ -262,12 +262,12 @@ describe('tree', () => {
           type: 'CREATE',
           content: 'new child content',
         },
-        { path: 'root-file.txt', type: 'DELETE', content: null },
         {
           path: 'renamed-root-file.txt',
           type: 'CREATE',
           content: 'root content',
         },
+        { path: 'root-file.txt', type: 'DELETE', content: null },
       ]);
 
       flushChanges(dir, tree.listChanges());
@@ -384,8 +384,41 @@ describe('tree', () => {
       });
     });
 
+    it('should be able to rename nested files', () => {
+      tree.write('a/b/hello.txt', '');
+
+      tree.rename('a/b/hello.txt', 'a/b/bye.txt');
+
+      expect(tree.exists('a/b/hello.txt')).toBe(false);
+      expect(tree.exists('a/b/bye.txt')).toBe(true);
+      expect(tree.children('a/b').length).toBe(1);
+      expect(tree.children('a').length).toBe(1);
+    });
+
     it('should be able to rename dirs', () => {
-      // not supported yet
+      tree.write('a/b/hello.txt', 'something');
+
+      tree.rename('a', 'z');
+
+      expect(tree.exists('a/b/hello.txt')).toBe(false);
+      expect(tree.exists('z/b/hello.txt')).toBe(true);
+      expect(tree.exists('a/b')).toBe(false);
+      expect(tree.exists('z/b')).toBe(true);
+      expect(tree.children('a/b').length).toBe(0);
+      expect(tree.children('a').length).toBe(0);
+      expect(tree.children('z/b').length).toBe(1);
+      expect(tree.children('z').length).toBe(1);
+    });
+
+    it('should do nothing when renaming to the same path', () => {
+      tree.write('a/b/hello.txt', 'something');
+
+      tree.rename('a', 'a');
+
+      expect(tree.exists('a/b/hello.txt')).toBe(true);
+      expect(tree.exists('a/b')).toBe(true);
+      expect(tree.children('a/b').length).toBe(1);
+      expect(tree.children('a').length).toBe(1);
     });
 
     describe('changePermissions', () => {

--- a/packages/nx/src/generators/tree.ts
+++ b/packages/nx/src/generators/tree.ts
@@ -222,9 +222,19 @@ export class FsTree implements Tree {
   rename(from: string, to: string): void {
     from = this.normalize(from);
     to = this.normalize(to);
-    const content = this.read(this.rp(from));
-    this.delete(this.rp(from));
-    this.write(this.rp(to), content);
+    if (from === to) {
+      return;
+    }
+
+    if (this.isFile(from)) {
+      const content = this.read(this.rp(from));
+      this.write(this.rp(to), content);
+      this.delete(this.rp(from));
+    } else {
+      for (const child of this.children(from)) {
+        this.rename(join(from, child), join(to, child));
+      }
+    }
   }
 
   isFile(filePath: string): boolean {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Tree.rename does not support renaming directories

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Tree.rename does support renaming directories

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
