### PR TITLE
fix(core): do not always use yarn as package manager in the gitlab ci t…

### DIFF
--- a/packages/workspace/src/generators/ci-workflow/files/gitlab/.gitlab-ci.yml__tmpl__
+++ b/packages/workspace/src/generators/ci-workflow/files/gitlab/.gitlab-ci.yml__tmpl__
@@ -32,8 +32,8 @@ variables:
   extends: .base-pipeline
   script:
     - <%= packageManagerPrefix %> nx-cloud start-ci-run --stop-agents-after="build"
-    - <%= packageManagerPrefix %> nx-cloud record -- yarn nx format:check --base=$NX_BASE --head=$NX_HEAD
-    - <%= packageManagerPrefix %> nx affected --base=$NX_BASE --head=$NX_HEAD --target=lint --parallel=3 & yarn nx affected --base=$NX_BASE --head=$NX_HEAD --target=test --parallel=3 --ci --code-coverage & yarn nx affected --base=$NX_BASE --head=$NX_HEAD --target=e2e --parallel=3 --ci --code-coverage & yarn nx affected --base=$NX_BASE --head=$NX_HEAD --target=build --parallel=3
+    - <%= packageManagerPrefix %> nx-cloud record -- <%= packageManagerPrefix %> nx format:check --base=$NX_BASE --head=$NX_HEAD
+    - <%= packageManagerPrefix %> nx affected --base=$NX_BASE --head=$NX_HEAD --target=lint --parallel=3 & <%= packageManagerPrefix %> nx affected --base=$NX_BASE --head=$NX_HEAD --target=test --parallel=3 --ci --code-coverage & <%= packageManagerPrefix %> nx affected --base=$NX_BASE --head=$NX_HEAD --target=e2e --parallel=3 --ci --code-coverage & <%= packageManagerPrefix %> nx affected --base=$NX_BASE --head=$NX_HEAD --target=build --parallel=3
 
 # Create as many agents as you want
 nx-dte-agent1:


### PR DESCRIPTION
## Current Behavior
Generating a GitLab CI script will use the package manager variable for some steps, and locked yarn for others

## Expected Behavior
The CI script should use the configured package manager for all steps

## Related Issue(s)
