### PR TITLE
chore(repo): add granular scope for angular shared docs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,6 +16,7 @@
 
 ## Angular
 /docs/generated/packages/angular/** @Coly010 @leosvelperez
+/docs/shared/packages/angular/** @Coly010 @leosvelperez @isaacplmann @juristr
 /packages/angular/** @Coly010 @leosvelperez
 /e2e/angular-core/** @Coly010 @leosvelperez
 /e2e/angular-extensions/** @Coly010 @leosvelperez


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Angular shared docs are not scoped to the vertical owners.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Angular shared docs are scoped to the vertical owners.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
