### PR TITLE
fix(misc): fix moving a project into a subfolder

### DIFF
--- a/e2e/angular-extensions/src/misc.test.ts
+++ b/e2e/angular-extensions/src/misc.test.ts
@@ -1,4 +1,13 @@
-import { cleanupProject, newProject, runCLI, uniq } from '@nrwl/e2e/utils';
+import {
+  checkFilesExist,
+  cleanupProject,
+  newProject,
+  readFile,
+  runCLI,
+  uniq,
+  updateFile,
+} from '@nrwl/e2e/utils';
+import { classify } from '@nrwl/workspace/src/utils/strings';
 
 describe('Move Angular Project', () => {
   let proj: string;
@@ -16,127 +25,126 @@ describe('Move Angular Project', () => {
 
   afterAll(() => cleanupProject());
 
-  it('reenabe', () => {});
   /**
    * Tries moving an app from ${app1} -> subfolder/${app2}
    */
-  //   it('should work for apps', () => {
-  //     const moveOutput = runCLI(
-  //       `generate @nrwl/angular:move --project ${app1} ${newPath}`
-  //     );
-  //
-  //     // just check the output
-  //     expect(moveOutput).toContain(`DELETE apps/${app1}`);
-  //     expect(moveOutput).toContain(`CREATE apps/${newPath}/jest.config.ts`);
-  //     expect(moveOutput).toContain(`CREATE apps/${newPath}/tsconfig.app.json`);
-  //     expect(moveOutput).toContain(`CREATE apps/${newPath}/tsconfig.json`);
-  //     expect(moveOutput).toContain(`CREATE apps/${newPath}/tsconfig.spec.json`);
-  //     expect(moveOutput).toContain(`CREATE apps/${newPath}/.eslintrc.json`);
-  //     expect(moveOutput).toContain(`CREATE apps/${newPath}/src/favicon.ico`);
-  //     expect(moveOutput).toContain(`CREATE apps/${newPath}/src/index.html`);
-  //     expect(moveOutput).toContain(`CREATE apps/${newPath}/src/main.ts`);
-  //     expect(moveOutput).toContain(`CREATE apps/${newPath}/src/styles.css`);
-  //     expect(moveOutput).toContain(`CREATE apps/${newPath}/src/test-setup.ts`);
-  //     expect(moveOutput).toContain(
-  //       `CREATE apps/${newPath}/src/app/app.component.html`
-  //     );
-  //     expect(moveOutput).toContain(
-  //       `CREATE apps/${newPath}/src/app/app.module.ts`
-  //     );
-  //     expect(moveOutput).toContain(`CREATE apps/${newPath}/src/assets/.gitkeep`);
-  //   });
-  //
-  //   /**
-  //    * Tries moving an e2e project from ${app1} -> ${newPath}
-  //    */
-  //   it('should work for e2e projects w/custom cypress config', () => {
-  //     // by default the cypress config doesn't contain any app specific paths
-  //     // create a custom config with some app specific paths
-  //     updateFile(
-  //       `apps/${app1}-e2e/cypress.config.ts`,
-  //       `
-  // import { defineConfig } from 'cypress';
-  // import { nxE2EPreset } from '@nrwl/cypress/plugins/cypress-preset';
-  //
-  // export default defineConfig({
-  //   e2e: {
-  //     ...nxE2EPreset(__dirname),
-  //     videosFolder: '../../dist/cypress/apps/${app1}-e2e/videos',
-  //     screenshotsFolder: '../../dist/cypress/apps/${app1}-e2e/screenshots',
-  //     },
-  // });
-  // `
-  //     );
-  //     const moveOutput = runCLI(
-  //       `generate @nrwl/angular:move --projectName=${app1}-e2e --destination=${newPath}-e2e`
-  //     );
-  //
-  //     // just check that the cypress.config.ts is updated correctly
-  //     const cypressConfigPath = `apps/${newPath}-e2e/cypress.config.ts`;
-  //     expect(moveOutput).toContain(`CREATE ${cypressConfigPath}`);
-  //     checkFilesExist(cypressConfigPath);
-  //     const cypressConfig = readFile(cypressConfigPath);
-  //
-  //     expect(cypressConfig).toContain(
-  //       `../../../dist/cypress/apps/${newPath}-e2e/videos`
-  //     );
-  //     expect(cypressConfig).toContain(
-  //       `../../../dist/cypress/apps/${newPath}-e2e/screenshots`
-  //     );
-  //   });
-  //
-  //   /**
-  //    * Tries moving a library from ${lib} -> shared/${lib}
-  //    */
-  //   it('should work for libraries', () => {
-  //     const lib1 = uniq('mylib');
-  //     const lib2 = uniq('mylib');
-  //     runCLI(`generate @nrwl/angular:lib ${lib1}`);
-  //
-  //     /**
-  //      * Create a library which imports the module from the other lib
-  //      */
-  //
-  //     runCLI(`generate @nrwl/angular:lib ${lib2}`);
-  //
-  //     updateFile(
-  //       `libs/${lib2}/src/lib/${lib2}.module.ts`,
-  //       `import { ${classify(lib1)}Module } from '@${proj}/${lib1}';
-  //
-  //         export class ExtendedModule extends ${classify(lib1)}Module { }`
-  //     );
-  //
-  //     const moveOutput = runCLI(
-  //       `generate @nrwl/angular:move --projectName=${lib1} --destination=shared/${lib1}`
-  //     );
-  //
-  //     const newPath = `libs/shared/${lib1}`;
-  //     const newModule = `Shared${classify(lib1)}Module`;
-  //
-  //     const testSetupPath = `${newPath}/src/test-setup.ts`;
-  //     expect(moveOutput).toContain(`CREATE ${testSetupPath}`);
-  //     checkFilesExist(testSetupPath);
-  //
-  //     const modulePath = `${newPath}/src/lib/shared-${lib1}.module.ts`;
-  //     expect(moveOutput).toContain(`CREATE ${modulePath}`);
-  //     checkFilesExist(modulePath);
-  //     const moduleFile = readFile(modulePath);
-  //     expect(moduleFile).toContain(`export class ${newModule}`);
-  //
-  //     const indexPath = `${newPath}/src/index.ts`;
-  //     expect(moveOutput).toContain(`CREATE ${indexPath}`);
-  //     checkFilesExist(indexPath);
-  //     const index = readFile(indexPath);
-  //     expect(index).toContain(`export * from './lib/shared-${lib1}.module'`);
-  //
-  //     /**
-  //      * Check that the import in lib2 has been updated
-  //      */
-  //     const lib2FilePath = `libs/${lib2}/src/lib/${lib2}.module.ts`;
-  //     const lib2File = readFile(lib2FilePath);
-  //     expect(lib2File).toContain(
-  //       `import { ${newModule} } from '@${proj}/shared/${lib1}';`
-  //     );
-  //     expect(lib2File).toContain(`extends ${newModule}`);
-  //   });
+  it('should work for apps', () => {
+    const moveOutput = runCLI(
+      `generate @nrwl/angular:move --project ${app1} ${newPath}`
+    );
+
+    // just check the output
+    expect(moveOutput).toContain(`DELETE apps/${app1}`);
+    expect(moveOutput).toContain(`CREATE apps/${newPath}/jest.config.ts`);
+    expect(moveOutput).toContain(`CREATE apps/${newPath}/tsconfig.app.json`);
+    expect(moveOutput).toContain(`CREATE apps/${newPath}/tsconfig.json`);
+    expect(moveOutput).toContain(`CREATE apps/${newPath}/tsconfig.spec.json`);
+    expect(moveOutput).toContain(`CREATE apps/${newPath}/.eslintrc.json`);
+    expect(moveOutput).toContain(`CREATE apps/${newPath}/src/favicon.ico`);
+    expect(moveOutput).toContain(`CREATE apps/${newPath}/src/index.html`);
+    expect(moveOutput).toContain(`CREATE apps/${newPath}/src/main.ts`);
+    expect(moveOutput).toContain(`CREATE apps/${newPath}/src/styles.css`);
+    expect(moveOutput).toContain(`CREATE apps/${newPath}/src/test-setup.ts`);
+    expect(moveOutput).toContain(
+      `CREATE apps/${newPath}/src/app/app.component.html`
+    );
+    expect(moveOutput).toContain(
+      `CREATE apps/${newPath}/src/app/app.module.ts`
+    );
+    expect(moveOutput).toContain(`CREATE apps/${newPath}/src/assets/.gitkeep`);
+  });
+
+  /**
+   * Tries moving an e2e project from ${app1} -> ${newPath}
+   */
+  it('should work for e2e projects w/custom cypress config', () => {
+    // by default the cypress config doesn't contain any app specific paths
+    // create a custom config with some app specific paths
+    updateFile(
+      `apps/${app1}-e2e/cypress.config.ts`,
+      `
+  import { defineConfig } from 'cypress';
+  import { nxE2EPreset } from '@nrwl/cypress/plugins/cypress-preset';
+  
+  export default defineConfig({
+    e2e: {
+      ...nxE2EPreset(__dirname),
+      videosFolder: '../../dist/cypress/apps/${app1}-e2e/videos',
+      screenshotsFolder: '../../dist/cypress/apps/${app1}-e2e/screenshots',
+      },
+  });
+  `
+    );
+    const moveOutput = runCLI(
+      `generate @nrwl/angular:move --projectName=${app1}-e2e --destination=${newPath}-e2e`
+    );
+
+    // just check that the cypress.config.ts is updated correctly
+    const cypressConfigPath = `apps/${newPath}-e2e/cypress.config.ts`;
+    expect(moveOutput).toContain(`CREATE ${cypressConfigPath}`);
+    checkFilesExist(cypressConfigPath);
+    const cypressConfig = readFile(cypressConfigPath);
+
+    expect(cypressConfig).toContain(
+      `../../../dist/cypress/apps/${newPath}-e2e/videos`
+    );
+    expect(cypressConfig).toContain(
+      `../../../dist/cypress/apps/${newPath}-e2e/screenshots`
+    );
+  });
+
+  /**
+   * Tries moving a library from ${lib} -> shared/${lib}
+   */
+  it('should work for libraries', () => {
+    const lib1 = uniq('mylib');
+    const lib2 = uniq('mylib');
+    runCLI(`generate @nrwl/angular:lib ${lib1}`);
+
+    /**
+     * Create a library which imports the module from the other lib
+     */
+
+    runCLI(`generate @nrwl/angular:lib ${lib2}`);
+
+    updateFile(
+      `libs/${lib2}/src/lib/${lib2}.module.ts`,
+      `import { ${classify(lib1)}Module } from '@${proj}/${lib1}';
+  
+          export class ExtendedModule extends ${classify(lib1)}Module { }`
+    );
+
+    const moveOutput = runCLI(
+      `generate @nrwl/angular:move --projectName=${lib1} --destination=shared/${lib1}`
+    );
+
+    const newPath = `libs/shared/${lib1}`;
+    const newModule = `Shared${classify(lib1)}Module`;
+
+    const testSetupPath = `${newPath}/src/test-setup.ts`;
+    expect(moveOutput).toContain(`CREATE ${testSetupPath}`);
+    checkFilesExist(testSetupPath);
+
+    const modulePath = `${newPath}/src/lib/shared-${lib1}.module.ts`;
+    expect(moveOutput).toContain(`CREATE ${modulePath}`);
+    checkFilesExist(modulePath);
+    const moduleFile = readFile(modulePath);
+    expect(moduleFile).toContain(`export class ${newModule}`);
+
+    const indexPath = `${newPath}/src/index.ts`;
+    expect(moveOutput).toContain(`CREATE ${indexPath}`);
+    checkFilesExist(indexPath);
+    const index = readFile(indexPath);
+    expect(index).toContain(`export * from './lib/shared-${lib1}.module'`);
+
+    /**
+     * Check that the import in lib2 has been updated
+     */
+    const lib2FilePath = `libs/${lib2}/src/lib/${lib2}.module.ts`;
+    const lib2File = readFile(lib2FilePath);
+    expect(lib2File).toContain(
+      `import { ${newModule} } from '@${proj}/shared/${lib1}';`
+    );
+    expect(lib2File).toContain(`extends ${newModule}`);
+  });
 });

--- a/e2e/nx-misc/src/workspace.test.ts
+++ b/e2e/nx-misc/src/workspace.test.ts
@@ -9,12 +9,10 @@ import {
   expectJestTestsToPass,
   readFile,
   exists,
-  renameFile,
   updateProjectConfig,
   readProjectConfig,
   tmpProjPath,
   readResolvedConfiguration,
-  removeFile,
   getPackageManagerCommand,
   getSelectedPackageManager,
   runCommand,
@@ -703,6 +701,136 @@ describe('Workspace Tests', () => {
       nxJson = readJson('nx.json');
       delete nxJson.workspaceLayout;
       updateFile('nx.json', JSON.stringify(nxJson));
+    });
+
+    it('should work when moving a lib to a subfolder', async () => {
+      const lib1 = uniq('lib1');
+      const lib2 = uniq('lib2');
+      const lib3 = uniq('lib3');
+      runCLI(`generate @nrwl/workspace:lib ${lib1}`);
+
+      updateFile(
+        `libs/${lib1}/src/lib/${lib1}.ts`,
+        `export function fromLibOne() { console.log('This is completely pointless'); }`
+      );
+
+      updateFile(
+        `libs/${lib1}/src/index.ts`,
+        `export * from './lib/${lib1}.ts'`
+      );
+
+      /**
+       * Create a library which imports a class from lib1
+       */
+
+      runCLI(`generate @nrwl/workspace:lib ${lib2}/ui`);
+
+      updateFile(
+        `libs/${lib2}/ui/src/lib/${lib2}-ui.ts`,
+        `import { fromLibOne } from '@${proj}/${lib1}';
+
+        export const fromLibTwo = () => fromLibOne();`
+      );
+
+      /**
+       * Create a library which has an implicit dependency on lib1
+       */
+
+      runCLI(`generate @nrwl/workspace:lib ${lib3}`);
+      updateProjectConfig(lib3, (config) => {
+        config.implicitDependencies = [lib1];
+        return config;
+      });
+
+      /**
+       * Now try to move lib1
+       */
+
+      const moveOutput = runCLI(
+        `generate @nrwl/workspace:move --project ${lib1} ${lib1}/data-access`
+      );
+
+      expect(moveOutput).toContain(`DELETE libs/${lib1}/project.json`);
+      expect(exists(`libs/${lib1}/project.json`)).toBeFalsy();
+
+      const newPath = `libs/${lib1}/data-access`;
+      const newName = `${lib1}-data-access`;
+
+      const readmePath = `${newPath}/README.md`;
+      expect(moveOutput).toContain(`CREATE ${readmePath}`);
+      checkFilesExist(readmePath);
+
+      const jestConfigPath = `${newPath}/jest.config.ts`;
+      expect(moveOutput).toContain(`CREATE ${jestConfigPath}`);
+      checkFilesExist(jestConfigPath);
+      const jestConfig = readFile(jestConfigPath);
+      expect(jestConfig).toContain(`displayName: '${lib1}-data-access'`);
+      expect(jestConfig).toContain(`preset: '../../../jest.preset.js'`);
+      expect(jestConfig).toContain(`'../../../coverage/${newPath}'`);
+
+      const tsConfigPath = `${newPath}/tsconfig.json`;
+      expect(moveOutput).toContain(`CREATE ${tsConfigPath}`);
+      checkFilesExist(tsConfigPath);
+
+      const tsConfigLibPath = `${newPath}/tsconfig.lib.json`;
+      expect(moveOutput).toContain(`CREATE ${tsConfigLibPath}`);
+      checkFilesExist(tsConfigLibPath);
+      const tsConfigLib = readJson(tsConfigLibPath);
+      expect(tsConfigLib.compilerOptions.outDir).toEqual(
+        '../../../dist/out-tsc'
+      );
+
+      const tsConfigSpecPath = `${newPath}/tsconfig.spec.json`;
+      expect(moveOutput).toContain(`CREATE ${tsConfigSpecPath}`);
+      checkFilesExist(tsConfigSpecPath);
+      const tsConfigSpec = readJson(tsConfigSpecPath);
+      expect(tsConfigSpec.compilerOptions.outDir).toEqual(
+        '../../../dist/out-tsc'
+      );
+
+      const indexPath = `${newPath}/src/index.ts`;
+      expect(moveOutput).toContain(`CREATE ${indexPath}`);
+      checkFilesExist(indexPath);
+
+      const rootClassPath = `${newPath}/src/lib/${lib1}.ts`;
+      expect(moveOutput).toContain(`CREATE ${rootClassPath}`);
+      checkFilesExist(rootClassPath);
+
+      let workspace = readResolvedConfiguration();
+      expect(workspace.projects[lib1]).toBeUndefined();
+      const newConfig = readProjectConfig(newName);
+      expect(newConfig).toMatchObject({
+        tags: [],
+      });
+      const lib3Config = readProjectConfig(lib3);
+      expect(lib3Config.implicitDependencies).toEqual([`${lib1}-data-access`]);
+
+      expect(moveOutput).toContain('UPDATE tsconfig.base.json');
+      const rootTsConfig = readJson('tsconfig.base.json');
+      expect(
+        rootTsConfig.compilerOptions.paths[`@${proj}/${lib1}`]
+      ).toBeUndefined();
+      expect(
+        rootTsConfig.compilerOptions.paths[`@${proj}/${lib1}/data-access`]
+      ).toEqual([`libs/${lib1}/data-access/src/index.ts`]);
+
+      workspace = readResolvedConfiguration();
+      expect(workspace.projects[lib1]).toBeUndefined();
+      const project = readProjectConfig(newName);
+      expect(project).toBeTruthy();
+      expect(project.sourceRoot).toBe(`${newPath}/src`);
+      expect(project.targets.lint.options.lintFilePatterns).toEqual([
+        `libs/${lib1}/data-access/**/*.ts`,
+      ]);
+
+      /**
+       * Check that the import in lib2 has been updated
+       */
+      const lib2FilePath = `libs/${lib2}/ui/src/lib/${lib2}-ui.ts`;
+      const lib2File = readFile(lib2FilePath);
+      expect(lib2File).toContain(
+        `import { fromLibOne } from '@${proj}/${lib1}/data-access';`
+      );
     });
 
     it('should work for libraries when scope is unset', async () => {

--- a/packages/workspace/src/generators/move/lib/create-project-configuration-in-new-destination.spec.ts
+++ b/packages/workspace/src/generators/move/lib/create-project-configuration-in-new-destination.spec.ts
@@ -1,13 +1,12 @@
-import { getProjects, Tree } from '@nrwl/devkit';
 import {
   addProjectConfiguration,
   ProjectConfiguration,
-  readJson,
   readProjectConfiguration,
+  Tree,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import type { NormalizedSchema } from '../schema';
-import { moveProjectConfiguration } from './move-project-configuration';
+import { createProjectConfigurationInNewDestination } from './create-project-configuration-in-new-destination';
 
 describe('moveProjectConfiguration', () => {
   let tree: Tree;
@@ -156,11 +155,8 @@ describe('moveProjectConfiguration', () => {
   it('should rename the project', async () => {
     setupWorkspace();
 
-    moveProjectConfiguration(tree, schema, projectConfig);
+    createProjectConfigurationInNewDestination(tree, schema, projectConfig);
 
-    expect(() => {
-      readProjectConfiguration(tree, 'my-source');
-    }).toThrow();
     expect(
       readProjectConfiguration(tree, 'subfolder-my-destination')
     ).toBeDefined();
@@ -169,7 +165,7 @@ describe('moveProjectConfiguration', () => {
   it('should update paths in only the intended project', async () => {
     setupWorkspace();
 
-    moveProjectConfiguration(tree, schema, projectConfig);
+    createProjectConfigurationInNewDestination(tree, schema, projectConfig);
 
     const actualProject = readProjectConfiguration(
       tree,
@@ -186,7 +182,7 @@ describe('moveProjectConfiguration', () => {
 
   it('should update tags and implicitDependencies', () => {
     setupWorkspace();
-    moveProjectConfiguration(tree, schema, projectConfig);
+    createProjectConfigurationInNewDestination(tree, schema, projectConfig);
 
     const actualProject = readProjectConfiguration(
       tree,
@@ -194,8 +190,6 @@ describe('moveProjectConfiguration', () => {
     );
     expect(actualProject.tags).toEqual(['type:ui']);
     expect(actualProject.implicitDependencies).toEqual(['my-other-lib']);
-    const projects = Object.fromEntries(getProjects(tree));
-    expect(projects['my-source']).not.toBeDefined();
   });
 
   it('should support moving a standalone project', () => {
@@ -222,11 +216,8 @@ describe('moveProjectConfiguration', () => {
       updateImportPath: true,
     };
 
-    moveProjectConfiguration(tree, moveSchema, projectConfig);
+    createProjectConfigurationInNewDestination(tree, moveSchema, projectConfig);
 
-    expect(() => {
-      readProjectConfiguration(tree, projectName);
-    }).toThrow();
     expect(readProjectConfiguration(tree, newProjectName)).toBeDefined();
   });
 });

--- a/packages/workspace/src/generators/move/lib/create-project-configuration-in-new-destination.ts
+++ b/packages/workspace/src/generators/move/lib/create-project-configuration-in-new-destination.ts
@@ -1,12 +1,11 @@
 import {
   addProjectConfiguration,
   ProjectConfiguration,
-  removeProjectConfiguration,
   Tree,
 } from '@nrwl/devkit';
 import { NormalizedSchema } from '../schema';
 
-export function moveProjectConfiguration(
+export function createProjectConfigurationInNewDestination(
   tree: Tree,
   schema: NormalizedSchema,
   projectConfig: ProjectConfiguration
@@ -15,17 +14,13 @@ export function moveProjectConfiguration(
     projectConfig.name = schema.newProjectName;
   }
 
+  // replace old root path with new one
   const projectString = JSON.stringify(projectConfig);
   const newProjectString = projectString.replace(
     new RegExp(projectConfig.root, 'g'),
     schema.relativeToRootDestination
   );
-
-  // rename
   const newProject: ProjectConfiguration = JSON.parse(newProjectString);
-
-  // Delete the original project
-  removeProjectConfiguration(tree, schema.projectName);
 
   // Create a new project with the root replaced
   addProjectConfiguration(tree, schema.newProjectName, newProject);

--- a/packages/workspace/src/generators/move/lib/move-project-files.spec.ts
+++ b/packages/workspace/src/generators/move/lib/move-project-files.spec.ts
@@ -4,9 +4,9 @@ import {
   Tree,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import { moveProject } from '@nrwl/workspace/src/generators/move/lib/move-project';
 import { libraryGenerator } from '../../library/library';
 import { NormalizedSchema } from '../schema';
+import { moveProjectFiles } from './move-project-files';
 
 describe('moveProject', () => {
   let tree: Tree;
@@ -28,7 +28,7 @@ describe('moveProject', () => {
       relativeToRootDestination: 'libs/my-destination',
     };
 
-    moveProject(tree, schema, projectConfig);
+    moveProjectFiles(tree, schema, projectConfig);
 
     const destinationChildren = tree.children('libs/my-destination');
     expect(destinationChildren.length).toBeGreaterThan(0);

--- a/packages/workspace/src/generators/move/lib/move-project-files.ts
+++ b/packages/workspace/src/generators/move/lib/move-project-files.ts
@@ -7,7 +7,7 @@ import { NormalizedSchema } from '../schema';
  *
  * @param schema The options provided to the schematic
  */
-export function moveProject(
+export function moveProjectFiles(
   tree: Tree,
   schema: NormalizedSchema,
   project: ProjectConfiguration

--- a/packages/workspace/src/generators/move/move.ts
+++ b/packages/workspace/src/generators/move/move.ts
@@ -2,12 +2,12 @@ import {
   convertNxGenerator,
   formatFiles,
   readProjectConfiguration,
+  removeProjectConfiguration,
   Tree,
 } from '@nrwl/devkit';
-
 import { checkDestination } from './lib/check-destination';
-import { moveProject } from './lib/move-project';
-import { moveProjectConfiguration } from './lib/move-project-configuration';
+import { createProjectConfigurationInNewDestination } from './lib/create-project-configuration-in-new-destination';
+import { moveProjectFiles } from './lib/move-project-files';
 import { normalizeSchema } from './lib/normalize-schema';
 import { updateBuildTargets } from './lib/update-build-targets';
 import { updateCypressConfig } from './lib/update-cypress-config';
@@ -27,8 +27,9 @@ export async function moveGenerator(tree: Tree, rawSchema: Schema) {
   checkDestination(tree, rawSchema, projectConfig);
   const schema = normalizeSchema(tree, rawSchema, projectConfig);
 
-  moveProjectConfiguration(tree, schema, projectConfig);
-  moveProject(tree, schema, projectConfig); // we MUST move the project first, if we don't we get a "This should never happen" error 🤦‍♀️
+  removeProjectConfiguration(tree, schema.projectName);
+  moveProjectFiles(tree, schema, projectConfig);
+  createProjectConfigurationInNewDestination(tree, schema, projectConfig);
   updateImports(tree, schema, projectConfig);
   updateProjectRootFiles(tree, schema, projectConfig);
   updateCypressConfig(tree, schema, projectConfig);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `move` generator doesn't work correctly when moving a project to a new destination that's a subfolder of its current root path. This happens because the project configuration is created in the new destination before moving the rest of the files. Because of that, when moving the files, it collects the new project configuration as a child and moves it to another nested level, which is wrong.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `move` generator should work correctly when moving a project to a new destination that's a subfolder of its current root path.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #13910 
