### PR TITLE
fix(linter): ng-package.json format

### DIFF
--- a/packages/eslint-plugin-nx/src/utils/runtime-lint-utils.spec.ts
+++ b/packages/eslint-plugin-nx/src/utils/runtime-lint-utils.spec.ts
@@ -409,19 +409,16 @@ describe('isAngularSecondaryEntrypoint', () => {
       'apps/app.ts': '',
       'libs/standard/package.json': '{ "version": "0.0.0" }',
       'libs/standard/secondary/ng-package.json': JSON.stringify({
-        version: '0.0.0',
-        ngPackage: { lib: { entryFile: 'src/index.ts' } },
+        lib: { entryFile: 'src/index.ts' },
       }),
       'libs/standard/secondary/src/index.ts': 'const bla = "foo"',
       'libs/standard/tertiary/ng-package.json': JSON.stringify({
-        version: '0.0.0',
-        ngPackage: { lib: { entryFile: 'src/public_api.ts' } },
+        lib: { entryFile: 'src/public_api.ts' },
       }),
       'libs/standard/tertiary/src/public_api.ts': 'const bla = "foo"',
       'libs/features/package.json': '{ "version": "0.0.0" }',
       'libs/features/secondary/ng-package.json': JSON.stringify({
-        version: '0.0.0',
-        ngPackage: { lib: { entryFile: 'random/folder/api.ts' } },
+        lib: { entryFile: 'random/folder/api.ts' },
       }),
       'libs/features/secondary/random/folder/api.ts': 'const bla = "foo"',
     };

--- a/packages/eslint-plugin-nx/src/utils/runtime-lint-utils.ts
+++ b/packages/eslint-plugin-nx/src/utils/runtime-lint-utils.ts
@@ -454,7 +454,8 @@ function fileIsSecondaryEntryPoint(file: string): boolean {
       joinPathFragments(workspaceRoot, parent, 'ng-package.json')
     );
     if (ngPackageContent) {
-      const entryFile = parseJson(ngPackageContent)?.ngPackage?.lib?.entryFile;
+      // https://github.com/ng-packagr/ng-packagr/blob/23c718d04eea85e015b4c261310b7bd0c39e5311/src/ng-package.schema.json#L54
+      const entryFile = parseJson(ngPackageContent)?.lib?.entryFile;
       return entryFile && file === joinPathFragments(parent, entryFile);
     }
     parent = joinPathFragments(parent, '../');


### PR DESCRIPTION
## Current Behavior

Linting secondary entrypoints is failing.

## Expected Behavior

Secondary entrypoints should be catching the special case for moudule boundries.

