### PR TITLE
fix(js): remove plugins from esbuild will be done as a feature

### DIFF
--- a/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
+++ b/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
@@ -100,7 +100,6 @@ export async function* esbuildExecutor(
               const ctx = await esbuild.context({
                 ...esbuildOptions,
                 plugins: [
-                  ...(esbuildOptions.plugins ?? []),
                   // Only emit info on one of the watch processes.
                   idx === 0
                     ? {


### PR DESCRIPTION
Remove the plugins feature since it doesn't fully conform to esbuild API for plugins: https://esbuild.github.io/plugins/#using-plugins

This will be done as a feature, I will post the issue after it is created so that it is linked.
closed #14823

