### PR TITLE
fix(js): move index.ts outside of src

### DIFF
--- a/e2e/esbuild/src/esbuild.test.ts
+++ b/e2e/esbuild/src/esbuild.test.ts
@@ -25,7 +25,7 @@ describe('EsBuild Plugin', () => {
   it('should setup and build projects using build', async () => {
     const myPkg = uniq('my-pkg');
     runCLI(`generate @nrwl/js:lib ${myPkg} --bundler=esbuild`);
-    updateFile(`libs/${myPkg}/src/index.ts`, `console.log('Hello');\n`);
+    updateFile(`libs/${myPkg}/index.ts`, `console.log('Hello');\n`);
     updateProjectConfig(myPkg, (json) => {
       json.targets.build.options.assets = [`libs/${myPkg}/assets/*`];
       return json;
@@ -58,7 +58,7 @@ describe('EsBuild Plugin', () => {
     /* Type errors are turned on by default
      */
     updateFile(
-      `libs/${myPkg}/src/index.ts`,
+      `libs/${myPkg}/index.ts`,
       `
       const x: number = 'a'; // type error
       console.log('Bye');
@@ -77,7 +77,7 @@ describe('EsBuild Plugin', () => {
     runCLI(`generate @nrwl/js:lib ${parentLib} --bundler=esbuild`);
     runCLI(`generate @nrwl/js:lib ${childLib} --buildable=false`);
     updateFile(
-      `libs/${parentLib}/src/index.ts`,
+      `libs/${parentLib}/index.ts`,
       `
         // @ts-ignore
         import _ from 'lodash';
@@ -88,7 +88,7 @@ describe('EsBuild Plugin', () => {
       `
     );
     updateFile(
-      `libs/${childLib}/src/index.ts`,
+      `libs/${childLib}/index.ts`,
       `
         import { always } from 'rambda';
         export const greet = always('Hello from child lib');
@@ -124,16 +124,16 @@ describe('EsBuild Plugin', () => {
     const myPkg = uniq('my-pkg');
     runCLI(`generate @nrwl/js:lib ${myPkg} --bundler=esbuild`);
     updateFile(`libs/${myPkg}/src/lib/${myPkg}.ts`, `console.log('Hello');\n`);
-    updateFile(`libs/${myPkg}/src/index.ts`, `import './lib/${myPkg}.js';\n`);
+    updateFile(`libs/${myPkg}/index.ts`, `import './src/lib/${myPkg}.js';\n`);
 
     runCLI(`build ${myPkg} --bundle=false`);
 
     checkFilesExist(
-      `dist/libs/${myPkg}/lib/${myPkg}.js`,
+      `dist/libs/${myPkg}/src/lib/${myPkg}.js`,
       `dist/libs/${myPkg}/index.js`
     );
     // Test files are excluded in tsconfig (e.g. tsconfig.lib.json)
-    checkFilesDoNotExist(`dist/libs/${myPkg}/lib/${myPkg}.spec.js`);
+    checkFilesDoNotExist(`dist/libs/${myPkg}/src/lib/${myPkg}.spec.js`);
     // Can run package (package.json fields are correctly generated)
     expect(runCommand(`node dist/libs/${myPkg}`)).toMatch(/Hello/);
   }, 300_000);
@@ -141,7 +141,7 @@ describe('EsBuild Plugin', () => {
   it('should support new watch API in >= 0.17.0 and old watch API in < 0.17.0', async () => {
     const myPkg = uniq('my-pkg');
     runCLI(`generate @nrwl/js:lib ${myPkg} --bundler=esbuild`);
-    updateFile(`libs/${myPkg}/src/index.ts`, `console.log('new API');\n`);
+    updateFile(`libs/${myPkg}/index.ts`, `console.log('new API');\n`);
 
     let watchProcess = await runCommandUntil(
       `build ${myPkg} --bundle=false --watch`,
@@ -176,7 +176,7 @@ describe('EsBuild Plugin', () => {
   it('should support additional entry points', () => {
     const myPkg = uniq('my-pkg');
     runCLI(`generate @nrwl/js:lib ${myPkg} --bundler=esbuild`);
-    updateFile(`libs/${myPkg}/src/index.ts`, `console.log('main');\n`);
+    updateFile(`libs/${myPkg}/index.ts`, `console.log('main');\n`);
     updateFile(`libs/${myPkg}/src/extra.ts`, `console.log('extra');\n`);
     updateProjectConfig(myPkg, (json) => {
       json.targets.build.options.additionalEntryPoints = [

--- a/e2e/nx-plugin/src/nx-plugin.test.ts
+++ b/e2e/nx-plugin/src/nx-plugin.test.ts
@@ -43,7 +43,7 @@ describe('Nx Plugin', () => {
       `dist/libs/${plugin}/package.json`,
       `dist/libs/${plugin}/generators.json`,
       `dist/libs/${plugin}/executors.json`,
-      `dist/libs/${plugin}/src/index.js`,
+      `dist/libs/${plugin}/index.js`,
       `dist/libs/${plugin}/src/generators/${plugin}/schema.json`,
       `dist/libs/${plugin}/src/generators/${plugin}/schema.d.ts`,
       `dist/libs/${plugin}/src/generators/${plugin}/generator.js`,
@@ -290,7 +290,7 @@ describe('Nx Plugin', () => {
     it('should be able to infer projects and targets', async () => {
       // Setup project inference + target inference
       updateFile(
-        `libs/${plugin}/src/index.ts`,
+        `libs/${plugin}/index.ts`,
         `import {basename} from 'path'
 
   export function registerProjectTargets(f) {

--- a/e2e/webpack/src/webpack.test.ts
+++ b/e2e/webpack/src/webpack.test.ts
@@ -17,11 +17,11 @@ describe('Webpack Plugin', () => {
   it('should be able to setup project to build node programs with webpack and different compilers', async () => {
     const myPkg = uniq('my-pkg');
     runCLI(`generate @nrwl/js:lib ${myPkg} --buildable=false`);
-    updateFile(`libs/${myPkg}/src/index.ts`, `console.log('Hello');\n`);
+    updateFile(`libs/${myPkg}/index.ts`, `console.log('Hello');\n`);
 
     // babel (default)
     runCLI(
-      `generate @nrwl/webpack:webpack-project ${myPkg} --target=node --tsConfig=libs/${myPkg}/tsconfig.lib.json --main=libs/${myPkg}/src/index.ts`
+      `generate @nrwl/webpack:webpack-project ${myPkg} --target=node --tsConfig=libs/${myPkg}/tsconfig.lib.json --main=libs/${myPkg}/index.ts`
     );
     rmDist();
     runCLI(`build ${myPkg}`);
@@ -37,7 +37,7 @@ describe('Webpack Plugin', () => {
 
     // swc
     runCLI(
-      `generate @nrwl/webpack:webpack-project ${myPkg} --target=node --tsConfig=libs/${myPkg}/tsconfig.lib.json --main=libs/${myPkg}/src/index.ts --compiler=swc`
+      `generate @nrwl/webpack:webpack-project ${myPkg} --target=node --tsConfig=libs/${myPkg}/tsconfig.lib.json --main=libs/${myPkg}/index.ts --compiler=swc`
     );
     rmDist();
     runCLI(`build ${myPkg}`);
@@ -51,7 +51,7 @@ describe('Webpack Plugin', () => {
 
     // tsc
     runCLI(
-      `generate @nrwl/webpack:webpack-project ${myPkg} --target=node --tsConfig=libs/${myPkg}/tsconfig.lib.json --main=libs/${myPkg}/src/index.ts --compiler=tsc`
+      `generate @nrwl/webpack:webpack-project ${myPkg} --target=node --tsConfig=libs/${myPkg}/tsconfig.lib.json --main=libs/${myPkg}/index.ts --compiler=tsc`
     );
     rmDist();
     runCLI(`build ${myPkg}`);
@@ -63,7 +63,7 @@ describe('Webpack Plugin', () => {
     const myPkg = uniq('my-pkg');
     runCLI(`generate @nrwl/js:lib ${myPkg} --bundler=webpack`);
     updateFile(
-      `libs/${myPkg}/src/index.ts`,
+      `libs/${myPkg}/index.ts`,
       `console.log(process.env['NX_TEST_VAR']);\n`
     );
 

--- a/packages/js/src/generators/library/files/lib/index.ts__tmpl__
+++ b/packages/js/src/generators/library/files/lib/index.ts__tmpl__
@@ -1,0 +1,1 @@
+export * from './src/lib/<%= fileName %>';

--- a/packages/js/src/generators/library/files/lib/src/index.ts__tmpl__
+++ b/packages/js/src/generators/library/files/lib/src/index.ts__tmpl__
@@ -1,1 +1,0 @@
-export * from './lib/<%= fileName %>';

--- a/packages/js/src/generators/library/files/lib/tsconfig.lib.json__tmpl__
+++ b/packages/js/src/generators/library/files/lib/tsconfig.lib.json__tmpl__
@@ -5,6 +5,6 @@
     "declaration": true,
     "types": ["node"]
   },
-  "include": ["src/**/*.ts"<% if (js) { %>, "src/**/*.js"<% } %>],
+  "include": ["src/**/*.ts", "index.ts"<% if (js) { %>, "src/**/*.js", "index.js"<% } %>],
   "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"<% if (js) { %>, "src/**/*.spec.js", "src/**/*.test.js"<% } %>]
 }

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -47,7 +47,7 @@ describe('lib', () => {
         },
       });
 
-      expect(tree.exists('libs/my-lib/src/index.ts')).toBeTruthy();
+      expect(tree.exists('libs/my-lib/index.ts')).toBeTruthy();
       expect(tree.exists('libs/my-lib/src/lib/my-lib.ts')).toBeTruthy();
 
       // unitTestRunner property is ignored.
@@ -96,7 +96,7 @@ describe('lib', () => {
         await libraryGenerator(tree, { ...defaultOptions, name: 'myLib' });
         const tsconfigJson = readJson(tree, '/tsconfig.base.json');
         expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-          'libs/my-lib/src/index.ts',
+          'libs/my-lib/index.ts',
         ]);
       });
 
@@ -107,7 +107,7 @@ describe('lib', () => {
 
         const tsconfigJson = readJson(tree, 'tsconfig.json');
         expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-          'libs/my-lib/src/index.ts',
+          'libs/my-lib/index.ts',
         ]);
       });
 
@@ -120,7 +120,7 @@ describe('lib', () => {
         await libraryGenerator(tree, { ...defaultOptions, name: 'myLib' });
         const tsconfigJson = readJson(tree, '/tsconfig.base.json');
         expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-          'libs/my-lib/src/index.ts',
+          'libs/my-lib/index.ts',
         ]);
       });
 
@@ -203,14 +203,14 @@ describe('lib', () => {
           directory: 'myDir',
         });
         expect(tree.exists(`libs/my-dir/my-lib/jest.config.ts`)).toBeTruthy();
-        expect(tree.exists('libs/my-dir/my-lib/src/index.ts')).toBeTruthy();
+        expect(tree.exists('libs/my-dir/my-lib/index.ts')).toBeTruthy();
         expect(
           tree.exists('libs/my-dir/my-lib/src/lib/my-dir-my-lib.ts')
         ).toBeTruthy();
         expect(
           tree.exists('libs/my-dir/my-lib/src/lib/my-dir-my-lib.spec.ts')
         ).toBeTruthy();
-        expect(tree.exists('libs/my-dir/my-lib/src/index.ts')).toBeTruthy();
+        expect(tree.exists('libs/my-dir/my-lib/index.ts')).toBeTruthy();
         expect(tree.exists(`libs/my-dir/my-lib/.eslintrc.json`)).toBeTruthy();
         expect(tree.exists(`libs/my-dir/my-lib/package.json`)).toBeFalsy();
       });
@@ -237,7 +237,7 @@ describe('lib', () => {
         const tsconfigJson = readJson(tree, '/tsconfig.base.json');
         expect(
           tsconfigJson.compilerOptions.paths['@proj/my-dir/my-lib']
-        ).toEqual(['libs/my-dir/my-lib/src/index.ts']);
+        ).toEqual(['libs/my-dir/my-lib/index.ts']);
         expect(
           tsconfigJson.compilerOptions.paths['my-dir-my-lib/*']
         ).toBeUndefined();
@@ -255,7 +255,7 @@ describe('lib', () => {
         const tsconfigJson = readJson(tree, '/tsconfig.json');
         expect(
           tsconfigJson.compilerOptions.paths['@proj/my-dir/my-lib']
-        ).toEqual(['libs/my-dir/my-lib/src/index.ts']);
+        ).toEqual(['libs/my-dir/my-lib/index.ts']);
         expect(
           tsconfigJson.compilerOptions.paths['my-dir-my-lib/*']
         ).toBeUndefined();
@@ -561,7 +561,7 @@ describe('lib', () => {
           js: true,
         });
         expect(tree.exists(`libs/my-lib/jest.config.js`)).toBeTruthy();
-        expect(tree.exists('libs/my-lib/src/index.js')).toBeTruthy();
+        expect(tree.exists('libs/my-lib/index.js')).toBeTruthy();
         expect(tree.exists('libs/my-lib/src/lib/my-lib.js')).toBeTruthy();
         expect(tree.exists('libs/my-lib/src/lib/my-lib.spec.js')).toBeTruthy();
       });
@@ -584,7 +584,7 @@ describe('lib', () => {
           js: true,
         });
         expect(readJson(tree, 'libs/my-lib/tsconfig.lib.json').include).toEqual(
-          ['src/**/*.ts', 'src/**/*.js']
+          ['src/**/*.ts', 'index.ts', 'src/**/*.js', 'index.js']
         );
       });
 
@@ -596,7 +596,7 @@ describe('lib', () => {
         });
         const tsconfigJson = readJson(tree, '/tsconfig.base.json');
         expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-          'libs/my-lib/src/index.js',
+          'libs/my-lib/index.js',
         ]);
       });
 
@@ -608,14 +608,14 @@ describe('lib', () => {
           js: true,
         });
         expect(tree.exists(`libs/my-dir/my-lib/jest.config.js`)).toBeTruthy();
-        expect(tree.exists('libs/my-dir/my-lib/src/index.js')).toBeTruthy();
+        expect(tree.exists('libs/my-dir/my-lib/index.js')).toBeTruthy();
         expect(
           tree.exists('libs/my-dir/my-lib/src/lib/my-dir-my-lib.js')
         ).toBeTruthy();
         expect(
           tree.exists('libs/my-dir/my-lib/src/lib/my-dir-my-lib.spec.js')
         ).toBeTruthy();
-        expect(tree.exists('libs/my-dir/my-lib/src/index.js')).toBeTruthy();
+        expect(tree.exists('libs/my-dir/my-lib/index.js')).toBeTruthy();
       });
 
       it('should configure the project for linting js files', async () => {
@@ -746,7 +746,7 @@ describe('lib', () => {
           executor: '@nrwl/js:tsc',
           options: {
             assets: ['libs/my-lib/*.md'],
-            main: 'libs/my-lib/src/index.ts',
+            main: 'libs/my-lib/index.ts',
             outputPath: 'dist/libs/my-lib',
             tsConfig: 'libs/my-lib/tsconfig.lib.json',
           },
@@ -767,7 +767,7 @@ describe('lib', () => {
           executor: '@nrwl/js:swc',
           options: {
             assets: ['libs/my-lib/*.md'],
-            main: 'libs/my-lib/src/index.ts',
+            main: 'libs/my-lib/index.ts',
             outputPath: 'dist/libs/my-lib',
             tsConfig: 'libs/my-lib/tsconfig.lib.json',
           },
@@ -825,7 +825,7 @@ describe('lib', () => {
           executor: '@nrwl/js:tsc',
           options: {
             assets: ['libs/my-lib/*.md'],
-            main: 'libs/my-lib/src/index.ts',
+            main: 'libs/my-lib/index.ts',
             outputPath: 'dist/libs/my-lib',
             tsConfig: 'libs/my-lib/tsconfig.lib.json',
           },

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -148,7 +148,7 @@ function addProject(
       outputs: ['{options.outputPath}'],
       options: {
         outputPath,
-        main: `${options.projectRoot}/src/index` + (options.js ? '.js' : '.ts'),
+        main: `${options.projectRoot}/index` + (options.js ? '.js' : '.ts'),
         tsConfig: `${options.projectRoot}/tsconfig.lib.json`,
         // TODO(jack): assets for webpack and rollup have validation that we need to fix (assets must be under <project-root>/src)
         assets:
@@ -450,7 +450,6 @@ function updateRootTsConfig(host: Tree, options: NormalizedSchema) {
     c.paths[options.importPath] = [
       joinPathFragments(
         options.projectRoot,
-        './src',
         'index.' + (options.js ? 'js' : 'ts')
       ),
     ];
@@ -463,36 +462,18 @@ function addProjectDependencies(
   tree: Tree,
   options: NormalizedSchema
 ): GeneratorCallback {
-  if (options.bundler == 'esbuild') {
-    return addDependenciesToPackageJson(
-      tree,
-      {},
-      {
-        '@nrwl/esbuild': nxVersion,
-        '@types/node': typesNodeVersion,
-        esbuild: esbuildVersion,
-      }
-    );
+  const devDependencies = {
+    '@types/node': typesNodeVersion,
+  };
+  if (options.bundler && options.bundler !== 'none') {
+    devDependencies[`@nrwl/${options.bundler}`] = nxVersion;
+
+    if (options.bundler == 'esbuild') {
+      devDependencies['esbuild'] = esbuildVersion;
+    }
   }
 
-  if (options.bundler == 'rollup') {
-    return addDependenciesToPackageJson(
-      tree,
-      {},
-      { '@nrwl/rollup': nxVersion, '@types/node': typesNodeVersion }
-    );
-  }
-
-  if (options.bundler == 'webpack') {
-    return addDependenciesToPackageJson(
-      tree,
-      {},
-      { '@nrwl/webpack': nxVersion, '@types/node': typesNodeVersion }
-    );
-  }
-
-  // noop
-  return () => {};
+  return addDependenciesToPackageJson(tree, {}, devDependencies);
 }
 
 function getBuildExecutor(options: NormalizedSchema) {

--- a/packages/js/src/utils/inline.ts
+++ b/packages/js/src/utils/inline.ts
@@ -16,6 +16,7 @@ interface InlineProjectNode {
   root: string;
   sourceRoot: string;
   pathAlias: string;
+  isInSrc: boolean;
   buildOutputPath?: string;
 }
 
@@ -82,9 +83,8 @@ export function postProcessInlinedDependencies(
         movePackage(depOutputPath, destDepOutputPath);
       }
 
-      // TODO: hard-coded "src"
       inlinedDepsDestOutputRecord[inlineDependency.pathAlias] =
-        destDepOutputPath + '/src';
+        destDepOutputPath + (inlineDependency.isInSrc ? '/src' : '');
     }
   }
 
@@ -124,6 +124,7 @@ function projectNodeToInlineProjectNode(
     root: projectNode.data.root,
     sourceRoot: projectNode.data.sourceRoot,
     pathAlias,
+    isInSrc: pathAlias.includes('/src/'),
     buildOutputPath,
   };
 }

--- a/packages/nest/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/nest/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -182,9 +182,9 @@ export class MyLibController {
 `;
 
 exports[`lib not nested should provide the controller and service 3`] = `
-"export * from './lib/my-lib.controller';
-export * from './lib/my-lib.service';
-export * from './lib/my-lib.module';
+"export * from './src/lib/my-lib.controller';
+export * from './src/lib/my-lib.service';
+export * from './src/lib/my-lib.module';
 
 "
 `;

--- a/packages/nest/src/generators/library/lib/add-exports-to-barrel.ts
+++ b/packages/nest/src/generators/library/lib/add-exports-to-barrel.ts
@@ -10,7 +10,7 @@ export function addExportsToBarrelFile(
   tree: Tree,
   options: NormalizedOptions
 ): void {
-  const indexPath = `${options.projectRoot}/src/index.ts`;
+  const indexPath = `${options.projectRoot}/index.ts`;
   const indexContent = tree.read(indexPath, 'utf-8');
   let sourceFile = ts.createSourceFile(
     indexPath,
@@ -24,13 +24,13 @@ export function addExportsToBarrelFile(
     sourceFile,
     indexPath,
     0,
-    `export * from './lib/${options.fileName}';`
+    `export * from './src/lib/${options.fileName}';`
   );
   sourceFile = addGlobal(
     tree,
     sourceFile,
     indexPath,
-    `export * from './lib/${options.fileName}.module';`
+    `export * from './src/lib/${options.fileName}.module';`
   );
 
   if (options.service) {
@@ -38,7 +38,7 @@ export function addExportsToBarrelFile(
       tree,
       sourceFile,
       indexPath,
-      `export * from './lib/${options.fileName}.service';`
+      `export * from './src/lib/${options.fileName}.service';`
     );
   }
   if (options.controller) {
@@ -46,7 +46,7 @@ export function addExportsToBarrelFile(
       tree,
       sourceFile,
       indexPath,
-      `export * from './lib/${options.fileName}.controller';`
+      `export * from './src/lib/${options.fileName}.controller';`
     );
   }
 }

--- a/packages/nest/src/generators/library/library.spec.ts
+++ b/packages/nest/src/generators/library/library.spec.ts
@@ -109,7 +109,7 @@ describe('lib', () => {
         )
       ).toMatchSnapshot();
       expect(
-        tree.read(`libs/${libFileName}/src/index.ts`, 'utf-8')
+        tree.read(`libs/${libFileName}/index.ts`, 'utf-8')
       ).toMatchSnapshot();
     });
 
@@ -130,7 +130,7 @@ describe('lib', () => {
       const tsconfigJson = readJson(tree, '/tsconfig.base.json');
       expect(
         tsconfigJson.compilerOptions.paths[`@proj/${libFileName}`]
-      ).toEqual([`libs/${libFileName}/src/index.ts`]);
+      ).toEqual([`libs/${libFileName}/index.ts`]);
     });
 
     it('should create a local tsconfig.json', async () => {
@@ -169,7 +169,7 @@ describe('lib', () => {
       await libraryGenerator(tree, { name: libName });
 
       expect(tree.exists(`libs/${libFileName}/jest.config.ts`)).toBeTruthy();
-      expect(tree.exists(`libs/${libFileName}/src/index.ts`)).toBeTruthy();
+      expect(tree.exists(`libs/${libFileName}/index.ts`)).toBeTruthy();
       expect(
         tree.exists(`libs/${libFileName}/src/lib/${libFileName}.spec.ts`)
       ).toBeFalsy();
@@ -204,7 +204,7 @@ describe('lib', () => {
         tree.exists(`libs/${dirFileName}/${libFileName}/jest.config.ts`)
       ).toBeTruthy();
       expect(
-        tree.exists(`libs/${dirFileName}/${libFileName}/src/index.ts`)
+        tree.exists(`libs/${dirFileName}/${libFileName}/index.ts`)
       ).toBeTruthy();
       expect(
         tree.exists(
@@ -235,7 +235,7 @@ describe('lib', () => {
         tsconfigJson.compilerOptions.paths[
           `@proj/${dirFileName}/${libFileName}`
         ]
-      ).toEqual([`libs/${dirFileName}/${libFileName}/src/index.ts`]);
+      ).toEqual([`libs/${dirFileName}/${libFileName}/index.ts`]);
       expect(
         tsconfigJson.compilerOptions.paths[`${nestedLibFileName}/*`]
       ).toBeUndefined();

--- a/packages/nx-plugin/src/generators/plugin/plugin.spec.ts
+++ b/packages/nx-plugin/src/generators/plugin/plugin.spec.ts
@@ -40,7 +40,7 @@ describe('NxPlugin Plugin Generator', () => {
       options: {
         outputPath: 'dist/libs/my-plugin',
         tsConfig: 'libs/my-plugin/tsconfig.lib.json',
-        main: 'libs/my-plugin/src/index.ts',
+        main: 'libs/my-plugin/index.ts',
         assets: [
           'libs/my-plugin/*.md',
           {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Generated `index.ts` is inside of `src/index.ts`. This has been working fine for most cases but won't work if a custom plugin is immediately required after `ensurePackage`

See https://github.com/nrwl/nx/issues/14933

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
- `index.ts` is under projectRoot.
- Generators that rely on `nrwl/js` are adjusted

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14933
