### PR TITLE
cleanup(core): use existing readJson function and remove extra dependency

### DIFF
--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -82,7 +82,6 @@
     "fs-extra": "^11.1.0",
     "glob": "7.1.4",
     "ignore": "^5.0.4",
-    "jsonc-parser": "3.2.0",
     "minimatch": "3.0.5",
     "npm-run-path": "^4.0.1",
     "open": "^8.4.0",

--- a/packages/workspace/src/generators/move/lib/update-imports.ts
+++ b/packages/workspace/src/generators/move/lib/update-imports.ts
@@ -9,15 +9,15 @@ import {
   Tree,
   visitNotIgnoredFiles,
   writeJson,
+  readJson,
+  getImportPath,
 } from '@nrwl/devkit';
-import { getImportPath } from 'nx/src/utils/path';
 import * as ts from 'typescript';
 import { getRootTsConfigPathInTree } from '../../../utilities/typescript';
 import { findNodes } from 'nx/src/utils/typescript';
 import { NormalizedSchema } from '../schema';
 import { normalizeSlashes } from './utils';
 import { relative } from 'path';
-import { parse } from 'jsonc-parser';
 
 /**
  * Updates all the imports in the workspace and modifies the tsconfig appropriately.
@@ -43,14 +43,7 @@ export function updateImports(
   let tsConfig: any;
   let fromPath: string;
   if (tree.exists(tsConfigPath)) {
-    const tsConfigRawContents = tree.read(tsConfigPath).toString('utf-8');
-    tsConfig = (() => {
-      try {
-        return JSON.parse(tsConfigRawContents);
-      } catch {
-        return parse(tsConfigRawContents);
-      }
-    })();
+    tsConfig = readJson(tree, tsConfigPath);
 
     fromPath = Object.keys(tsConfig.compilerOptions.paths).find((path) =>
       tsConfig.compilerOptions.paths[path].some((x) =>


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`@nrwl/workspace` depends on `jsonc-parser` 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`@nrwl/workspace` does not depend on `jsonc-parser` and uses util function `readJson`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
