### PR TITLE
cleanup(core): replace fs-extra.removeSync() with fs.rmSync()

### DIFF
--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -79,7 +79,6 @@
     "dotenv": "~10.0.0",
     "figures": "3.2.0",
     "flat": "^5.0.2",
-    "fs-extra": "^11.1.0",
     "glob": "7.1.4",
     "ignore": "^5.0.4",
     "minimatch": "3.0.5",

--- a/packages/workspace/src/utilities/typescript/compilation.ts
+++ b/packages/workspace/src/utilities/typescript/compilation.ts
@@ -1,5 +1,5 @@
 import { joinPathFragments, logger } from '@nrwl/devkit';
-import { removeSync } from 'fs-extra';
+import { rmSync } from 'fs';
 import * as ts from 'typescript';
 import type { CustomTransformers, Diagnostic, Program } from 'typescript';
 import { readTsConfig } from '../typescript';
@@ -29,7 +29,7 @@ export function compileTypeScript(options: TypeScriptCompilationOptions): {
   const tsConfig = getNormalizedTsConfig(normalizedOptions);
 
   if (normalizedOptions.deleteOutputPath) {
-    removeSync(normalizedOptions.outputPath);
+    rmSync(normalizedOptions.outputPath, { recursive: true, force: true });
   }
 
   return createProgram(tsConfig, normalizedOptions);
@@ -48,7 +48,7 @@ export function compileTypeScriptWatcher(
   const tsConfig = getNormalizedTsConfig(normalizedOptions);
 
   if (normalizedOptions.deleteOutputPath) {
-    removeSync(normalizedOptions.outputPath);
+    rmSync(normalizedOptions.outputPath, { recursive: true, force: true });
   }
 
   const host = ts.createWatchCompilerHost(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
removeSync is just a wrapper for rmSync with the options recursive and force set to true

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
