### PR TITLE
cleanup(webpack): replace fs-extra.removeSync() with fs.rmSync() and remove dependency fs-extra

### DIFF
--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -42,7 +42,6 @@
     "dotenv": "~10.0.0",
     "file-loader": "^6.2.0",
     "fork-ts-checker-webpack-plugin": "7.2.13",
-    "fs-extra": "^11.1.0",
     "ignore": "^5.0.4",
     "less": "3.12.2",
     "less-loader": "^11.1.0",

--- a/packages/webpack/src/executors/dev-server/lib/get-dev-server-config.ts
+++ b/packages/webpack/src/executors/dev-server/lib/get-dev-server-config.ts
@@ -2,7 +2,7 @@ import { ExecutorContext, logger } from '@nrwl/devkit';
 import type { Configuration as WebpackConfiguration } from 'webpack';
 import type { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
 import * as path from 'path';
-import { readFileSync } from 'fs-extra';
+import { readFileSync } from 'fs';
 
 import { getWebpackConfig } from '../../webpack/lib/get-webpack-config';
 import { WebDevServerOptions } from '../schema';

--- a/packages/webpack/src/utils/fs.ts
+++ b/packages/webpack/src/utils/fs.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { existsSync, removeSync } from 'fs-extra';
+import { existsSync, rmSync } from 'fs';
 import { directoryExists } from 'nx/src/utils/fileutils';
 
 export function findUp(
@@ -63,5 +63,5 @@ export function deleteOutputDir(root: string, outputPath: string) {
     throw new Error('Output path MUST not be project root directory!');
   }
 
-  removeSync(resolvedOutputPath);
+  rmSync(resolvedOutputPath, { recursive: true, force: true });
 }


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
removeSync is just a wrapper for rmSync with the options recursive and force set to true

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
