### PR TITLE
fix(core): run migrations with sync host

### DIFF
--- a/packages/nx/src/adapter/ngcli-adapter.ts
+++ b/packages/nx/src/adapter/ngcli-adapter.ts
@@ -20,7 +20,7 @@ import { concat, from, Observable, of, zip } from 'rxjs';
 import { catchError, concatMap, map, tap } from 'rxjs/operators';
 import { GenerateOptions } from '../command-line/generate';
 import { ProjectConfiguration } from '../config/workspace-json-project-json';
-import { Tree } from '../generators/tree';
+import { FsTree, Tree } from '../generators/tree';
 import { readJson } from '../generators/utils/json';
 import {
   addProjectConfiguration,
@@ -566,7 +566,10 @@ export async function runMigration(
   isVerbose: boolean
 ) {
   const logger = getLogger(isVerbose);
-  const fsHost = new NxScopedHost(root);
+  const fsHost = new NxScopeHostUsedForWrappedSchematics(
+    root,
+    new FsTree(root, isVerbose)
+  );
   const workflow = createWorkflow(fsHost, root, {});
   const collection = resolveMigrationsCollection(packageName);
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When running migrations from `@angular/material` or `@angular/cdk` an error is thrown: `Expected a synchronous delegate but got an asynchronous one`. This happens because the host used for running migrations has some async methods while the Angular DevKit expects them to be synchronous. This is a regression introduced in 15.7.0.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Running migrations from `@angular/material` or `@angular/cdk` should succeed. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14990 
