### PR TITLE
feat(webpack): allow to configure env using webpack.DefinePlugin

### DIFF
--- a/packages/webpack/src/utils/with-web.ts
+++ b/packages/webpack/src/utils/with-web.ts
@@ -48,6 +48,7 @@ export interface WithWebOptions {
   stylePreprocessorOptions?: any;
   styles?: Array<ExtraEntryPointClass | string>;
   subresourceIntegrity?: boolean;
+  composeClientEnvironment?: typeof getClientEnvironment;
 }
 
 // Omit deprecated options
@@ -111,9 +112,12 @@ export function withWeb(pluginOptions: WithWebOptions = {}): NxWebpackPlugin {
         })
       );
     }
+
+    const composeClientEnvironment =
+      mergedOptions.composeClientEnvironment || getClientEnvironment;
     plugins.push(
       new webpack.DefinePlugin(
-        getClientEnvironment(process.env.NODE_ENV).stringified
+        composeClientEnvironment(process.env.NODE_ENV).stringified
       )
     );
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Currently, its a hard rule that only env variables prefixed with `NX_` can be passed to webpack and allowed client side
Nx could allow the team/user to determine this behaviour to reduce friction when migrating large repositories to be built by nx

## Expected Behavior

This adds a `composeClientEnvironment` function to `WithWebOptions` which allows the user to specify what environment variables are allowed client side

## Related Issue(s)
not sure

Fixes #

not sure

-----

### Notes:

Im currently migrating an app to nx and this would be very helpful

I tried to configure my own DefinePlugin but there is a conflict

```
WARNING in DefinePlugin
Conflicting values for 'process.env'

```

Before I do anything further I'd like some feedback to know if this is something nx will support. 
if yes: also let me know what else should be updated.
Thanks
