### PR TITLE
fix(storybook): dont fail migration if stories array is missing

### DIFF
--- a/packages/storybook/src/migrations/update-15-7-0/__snapshots__/add-addon-essentials-to-all.spec.ts.snap
+++ b/packages/storybook/src/migrations/update-15-7-0/__snapshots__/add-addon-essentials-to-all.spec.ts.snap
@@ -200,7 +200,6 @@ exports[`Add addon-essentials to project-level main.js files should remove addon
       import type { StorybookConfig } from '@storybook/core-common';
 
       export const rootMain: StorybookConfig = {
-        
         addons: ['@storybook/addon-knobs', ],
       };
       "

--- a/packages/storybook/src/migrations/update-15-7-0/add-addon-essentials-to-all.spec.ts
+++ b/packages/storybook/src/migrations/update-15-7-0/add-addon-essentials-to-all.spec.ts
@@ -71,7 +71,6 @@ describe('Add addon-essentials to project-level main.js files', () => {
       import type { StorybookConfig } from '@storybook/core-common';
 
       export const rootMain: StorybookConfig = {
-        stories: [],
         addons: ['@storybook/addon-knobs', '@storybook/addon-essentials'],
       };
       `

--- a/packages/storybook/src/migrations/update-15-7-0/add-addon-essentials-to-all.ts
+++ b/packages/storybook/src/migrations/update-15-7-0/add-addon-essentials-to-all.ts
@@ -304,6 +304,10 @@ function removeStoriesArrayFromRootIfEmpty(
       'PropertyAssignment:has([name="stories"])'
     )?.[0];
 
+    if (!fullStoriesNode) {
+      return false;
+    }
+
     const stringLiterals = tsquery.query(fullStoriesNode, 'StringLiteral');
 
     if (stringLiterals?.length === 0) {

--- a/packages/storybook/src/migrations/update-15-7-0/remove-root-config.ts
+++ b/packages/storybook/src/migrations/update-15-7-0/remove-root-config.ts
@@ -147,7 +147,7 @@ function makeTheChanges(tree: Tree, options: {}): string | undefined {
           if (
             otherRootMainUse.parent.kind ===
               ts.SyntaxKind.PropertyAccessExpression &&
-            otherRootMainUse.parent.parent.kind === ts.SyntaxKind.IfStatement
+            otherRootMainUse.parent.parent?.kind === ts.SyntaxKind.IfStatement
           ) {
             changesToBeMade.push({
               type: ChangeType.Delete,
@@ -181,7 +181,7 @@ function checkIfUsesOldSyntaxAndUpdate(
   tree: Tree,
   filePath: string,
   rootMainVariableName: string
-) {
+): boolean {
   const mainJsTs = tree.read(filePath, 'utf-8');
   const changesToBeMade: StringChange[] = [];
   const { stringArray: addonsArrayString, expressionToDelete: addonsToDelete } =
@@ -192,7 +192,12 @@ function checkIfUsesOldSyntaxAndUpdate(
     expressionToDelete: storiesToDelete,
   } = getPropertyArray('stories', mainJsTs, rootMainVariableName);
 
-  changesToBeMade.push(addonsToDelete, storiesToDelete);
+  if (storiesToDelete) {
+    changesToBeMade.push(storiesToDelete);
+  }
+  if (addonsToDelete) {
+    changesToBeMade.push(addonsToDelete);
+  }
 
   if (addArrayToModuleExports('addons', mainJsTs, addonsArrayString)) {
     changesToBeMade.push(


### PR DESCRIPTION
closed #15005

Don't fail migration if root `.storybook/main.js` file does not contain a `stories` array.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15005
