### PR TITLE
fix(storybook): make v7 generator ignore uiFramework

### DIFF
--- a/docs/generated/packages/storybook/generators/configuration.json
+++ b/docs/generated/packages/storybook/generators/configuration.json
@@ -87,7 +87,7 @@
       },
       "storybook7UiFramework": {
         "type": "string",
-        "description": "Storybook UI Framework to use.",
+        "description": "Storybook UI Framework to use, for Storybook version 7.",
         "enum": [
           "@storybook/angular",
           "@storybook/html-webpack5",

--- a/packages/storybook/src/generators/configuration/__snapshots__/configuration-v7.spec.ts.snap
+++ b/packages/storybook/src/generators/configuration/__snapshots__/configuration-v7.spec.ts.snap
@@ -443,6 +443,114 @@ exports[`@nrwl/storybook:configuration for Storybook v7 generate Storybook confi
 "
 `;
 
+exports[`@nrwl/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/reapp/.storybook/" 1`] = `
+"const config = {
+  stories: [
+    
+    '../src/app/**/*.stories.@(js|jsx|ts|tsx|mdx)'
+  ],
+  addons: ['@storybook/addon-essentials' 
+    
+  ],
+  framework: {
+    name: '@storybook/react-vite',
+    options: {
+      
+      builder: {
+        viteConfigPath: 'apps/reapp/vite.config.ts',
+      },
+      
+    },
+  },
+};
+
+export default config;
+
+
+
+
+// To customize your Vite configuration you can use the viteFinal field. 
+// Check https://storybook.js.org/docs/react/builders/vite#configuration
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
+"
+`;
+
+exports[`@nrwl/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/reapp/.storybook/" 2`] = `
+"{
+  \\"extends\\": \\"../tsconfig.json\\",
+  \\"compilerOptions\\": {
+    \\"emitDecoratorMetadata\\": true
+    , \\"outDir\\": \\"\\" 
+  },
+  \\"files\\": [
+    \\"../../../node_modules/@nrwl/react/typings/styled-jsx.d.ts\\",
+    \\"../../../node_modules/@nrwl/react/typings/cssmodule.d.ts\\",
+    \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
+  ],
+  \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
+  \\"include\\": [
+    \\"../src/**/*.stories.ts\\",
+    \\"../src/**/*.stories.js\\",
+    \\"../src/**/*.stories.jsx\\",
+    \\"../src/**/*.stories.tsx\\",
+    \\"../src/**/*.stories.mdx\\",
+    \\"*.js\\"]
+}
+"
+`;
+
+exports[`@nrwl/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/reappw/.storybook/" 1`] = `
+"const config = {
+  stories: [
+    
+    '../src/app/**/*.stories.@(js|jsx|ts|tsx|mdx)'
+  ],
+  addons: ['@storybook/addon-essentials' , '@nrwl/react/plugins/storybook' 
+    
+  ],
+  framework: {
+    name: '@storybook/react-webpack5',
+    options: {
+      
+    },
+  },
+};
+
+export default config;
+
+
+// To customize your webpack configuration you can use the webpackFinal field.
+// Check https://storybook.js.org/docs/react/builders/webpack#extending-storybooks-webpack-config
+// and https://nx.dev/packages/storybook/documents/custom-builder-configs
+
+
+"
+`;
+
+exports[`@nrwl/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/reappw/.storybook/" 2`] = `
+"{
+  \\"extends\\": \\"../tsconfig.json\\",
+  \\"compilerOptions\\": {
+    \\"emitDecoratorMetadata\\": true
+    , \\"outDir\\": \\"\\" 
+  },
+  \\"files\\": [
+    \\"../../../node_modules/@nrwl/react/typings/styled-jsx.d.ts\\",
+    \\"../../../node_modules/@nrwl/react/typings/cssmodule.d.ts\\",
+    \\"../../../node_modules/@nrwl/react/typings/image.d.ts\\"
+  ],
+  \\"exclude\\": [\\"../**/*.spec.ts\\" , \\"../**/*.spec.js\\", \\"../**/*.spec.tsx\\", \\"../**/*.spec.jsx\\"],
+  \\"include\\": [
+    \\"../src/**/*.stories.ts\\",
+    \\"../src/**/*.stories.js\\",
+    \\"../src/**/*.stories.jsx\\",
+    \\"../src/**/*.stories.tsx\\",
+    \\"../src/**/*.stories.mdx\\",
+    \\"*.js\\"]
+}
+"
+`;
+
 exports[`@nrwl/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/wv1/.storybook/" 1`] = `
 "const config = {
   stories: [
@@ -1704,7 +1812,6 @@ Map {
         "options": Object {
           "configDir": "apps/reapp/.storybook",
           "outputDir": "dist/storybook/reapp",
-          "uiFramework": "@storybook/react",
         },
         "outputs": Array [
           "{options.outputDir}",
@@ -1748,7 +1855,6 @@ Map {
         "options": Object {
           "configDir": "apps/reapp/.storybook",
           "port": 4400,
-          "uiFramework": "@storybook/react",
         },
       },
       "test": Object {
@@ -1864,7 +1970,6 @@ Map {
         "options": Object {
           "configDir": "apps/reappw/.storybook",
           "outputDir": "dist/storybook/reappw",
-          "uiFramework": "@storybook/react",
         },
         "outputs": Array [
           "{options.outputDir}",
@@ -1908,7 +2013,6 @@ Map {
         "options": Object {
           "configDir": "apps/reappw/.storybook",
           "port": 4400,
-          "uiFramework": "@storybook/react",
         },
       },
       "test": Object {

--- a/packages/storybook/src/generators/configuration/configuration-v7.spec.ts
+++ b/packages/storybook/src/generators/configuration/configuration-v7.spec.ts
@@ -45,7 +45,7 @@ describe('@nrwl/storybook:configuration for Storybook v7', () => {
     it('should generate TypeScript Configuration files', async () => {
       await configurationGenerator(tree, {
         name: 'test-ui-lib',
-        uiFramework: '@storybook/angular',
+        uiFramework: '@storybook/react', // it's wrong on purpose to verify that it's being ignored
         standaloneConfig: false,
         tsConfiguration: true,
         storybook7betaConfiguration: true,
@@ -66,40 +66,10 @@ describe('@nrwl/storybook:configuration for Storybook v7', () => {
       ).toBeTruthy();
     });
 
-    it('should not update root files after generating them once', async () => {
-      await configurationGenerator(tree, {
-        name: 'test-ui-lib',
-        uiFramework: '@storybook/angular',
-        standaloneConfig: false,
-        storybook7betaConfiguration: true,
-        storybook7UiFramework: '@storybook/angular',
-      });
-
-      const newContents = `module.exports = {
-          stories: [],
-          addons: ['@storybook/addon-essentials', 'new-addon'],
-        };
-      `;
-      await libraryGenerator(tree, {
-        name: 'test-ui-lib-2',
-        standaloneConfig: false,
-      });
-
-      tree.write('.storybook/main.js', newContents);
-      await configurationGenerator(tree, {
-        name: 'test-ui-lib-2',
-        uiFramework: '@storybook/angular',
-        standaloneConfig: false,
-        storybook7betaConfiguration: true,
-      });
-
-      expect(tree.read('.storybook/main.js', 'utf-8')).toEqual(newContents);
-    });
-
     it('should update `tsconfig.lib.json` file', async () => {
       await configurationGenerator(tree, {
         name: 'test-ui-lib',
-        uiFramework: '@storybook/react',
+        uiFramework: '@storybook/angular', // it's wrong on purpose to verify that it's being ignored
         standaloneConfig: false,
         storybook7betaConfiguration: true,
         storybook7UiFramework: '@storybook/react-webpack5',
@@ -159,7 +129,7 @@ describe('@nrwl/storybook:configuration for Storybook v7', () => {
 
       await configurationGenerator(tree, {
         name: 'test-ui-lib2',
-        uiFramework: '@storybook/react',
+        uiFramework: '@storybook/angular', // it's wrong on purpose to verify that it's being ignored
         standaloneConfig: false,
         storybook7betaConfiguration: true,
         storybook7UiFramework: '@storybook/react-webpack5',
@@ -274,6 +244,13 @@ describe('@nrwl/storybook:configuration for Storybook v7', () => {
       tree.write('apps/wv1/vite.config.custom.ts', 'export default {}');
 
       await configurationGenerator(tree, {
+        name: 'reapp',
+        tsConfiguration: false,
+        uiFramework: '@storybook/react',
+        storybook7betaConfiguration: true,
+        storybook7UiFramework: '@storybook/react-vite',
+      });
+      await configurationGenerator(tree, {
         name: 'main-vite',
         tsConfiguration: false,
         uiFramework: '@storybook/react',
@@ -289,6 +266,12 @@ describe('@nrwl/storybook:configuration for Storybook v7', () => {
       });
       await configurationGenerator(tree, {
         name: 'main-webpack',
+        uiFramework: '@storybook/react',
+        storybook7betaConfiguration: true,
+        storybook7UiFramework: '@storybook/react-webpack5',
+      });
+      await configurationGenerator(tree, {
+        name: 'reappw',
         uiFramework: '@storybook/react',
         storybook7betaConfiguration: true,
         storybook7UiFramework: '@storybook/react-webpack5',

--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -132,10 +132,13 @@ export async function configurationGenerator(
     }
   }
 
+  // If we're on Storybook 7, ignore schema.uiFramework
+  const uiFrameworkUsed = schema.storybook7betaConfiguration
+    ? schema.storybook7UiFramework
+    : schema.uiFramework;
+
   const initTask = initGenerator(tree, {
-    uiFramework: schema.storybook7betaConfiguration
-      ? schema.storybook7UiFramework
-      : schema.uiFramework,
+    uiFramework: uiFrameworkUsed,
     bundler: schema.bundler,
     storybook7betaConfiguration: schema.storybook7betaConfiguration,
   });
@@ -144,9 +147,7 @@ export async function configurationGenerator(
   createProjectStorybookDir(
     tree,
     schema.name,
-    schema.storybook7betaConfiguration
-      ? schema.storybook7UiFramework
-      : schema.uiFramework,
+    uiFrameworkUsed,
     schema.js,
     schema.tsConfiguration,
     root,
@@ -166,13 +167,13 @@ export async function configurationGenerator(
   addBuildStorybookToCacheableOperations(tree);
   addStorybookToNamedInputs(tree);
 
-  if (schema.uiFramework === '@storybook/angular') {
+  if (uiFrameworkUsed === '@storybook/angular') {
     addAngularStorybookTask(tree, schema.name, schema.configureTestRunner);
   } else {
     addStorybookTask(
       tree,
       schema.name,
-      schema.uiFramework,
+      uiFrameworkUsed,
       schema.configureTestRunner,
       schema.storybook7betaConfiguration
     );

--- a/packages/storybook/src/generators/configuration/schema.json
+++ b/packages/storybook/src/generators/configuration/schema.json
@@ -87,7 +87,7 @@
     },
     "storybook7UiFramework": {
       "type": "string",
-      "description": "Storybook UI Framework to use.",
+      "description": "Storybook UI Framework to use, for Storybook version 7.",
       "enum": [
         "@storybook/angular",
         "@storybook/html-webpack5",

--- a/packages/storybook/src/generators/configuration/util-functions.ts
+++ b/packages/storybook/src/generators/configuration/util-functions.ts
@@ -43,7 +43,6 @@ export function addStorybookTask(
   projectConfig.targets['storybook'] = {
     executor: '@nrwl/storybook:storybook',
     options: {
-      uiFramework,
       port: DEFAULT_PORT,
       configDir: `${projectConfig.root}/.storybook`,
     },
@@ -58,7 +57,6 @@ export function addStorybookTask(
     executor: '@nrwl/storybook:build',
     outputs: ['{options.outputDir}'],
     options: {
-      uiFramework,
       outputDir: joinPathFragments('dist/storybook', projectName),
       configDir: `${projectConfig.root}/.storybook`,
     },
@@ -69,9 +67,9 @@ export function addStorybookTask(
     },
   };
 
-  if (usesV7) {
-    delete projectConfig.targets['storybook'].options.uiFramework;
-    delete projectConfig.targets['build-storybook'].options.uiFramework;
+  if (!usesV7) {
+    projectConfig.targets['storybook'].options.uiFramework = uiFramework;
+    projectConfig.targets['build-storybook'].options.uiFramework = uiFramework;
   }
 
   if (configureTestRunner === true) {
@@ -174,7 +172,8 @@ export function configureTsProjectConfig(
       '**/*.stories.ts',
       '**/*.stories.js',
       ...(schema.uiFramework === '@storybook/react' ||
-      schema.uiFramework === '@storybook/react-native'
+      schema.uiFramework === '@storybook/react-native' ||
+      schema.storybook7UiFramework?.startsWith('@storybook/react')
         ? ['**/*.stories.jsx', '**/*.stories.tsx']
         : []),
     ];


### PR DESCRIPTION
Make sure that `uiFramework` is ignored, and only `storybook7UiFramework` is taken into account when `storybook7betaConfiguration` is true on the Storybook generator.
