### PR TITLE
fix(core): support decorators in local executor and generator runs

### DIFF
--- a/packages/nx/src/utils/nx-plugin.ts
+++ b/packages/nx/src/utils/nx-plugin.ts
@@ -197,6 +197,8 @@ export function registerPluginTSTranspiler() {
       target: ts.ScriptTarget.ES2021,
       esModuleInterop: true,
       skipLibCheck: true,
+      experimentalDecorators: true,
+      emitDecoratorMetadata: true,
     });
   }
   tsNodeAndPathsRegistered = true;


### PR DESCRIPTION
## Current Behavior
In 15.7 local generators and exeuctors with decorators broke, they had worked in prior versions.

## Expected Behavior
Local generators and executors should allow TypeScript decorators.

