### PR TITLE
docs(core): standalone tutorial cards in 3 columns

### DIFF
--- a/docs/shared/getting-started/intro.md
+++ b/docs/shared/getting-started/intro.md
@@ -18,6 +18,10 @@ Get a pre-configured setup. Nx configures your favorite frameworks and lets you 
 
 {% /persona %}
 
+{% /personas %}
+
+{% cards cols="3" %}
+
 {% persona type="react" title="Create a Standalone React app" url="/getting-started/react-standalone-tutorial" %}
 
 A modern React setup with built-in support for Vite, ESLint, Cypress and more. Think CRA but modern, always up-to-date and scalable.
@@ -42,7 +46,7 @@ A modern Node server with scaffolding for Express, Fastify or Koa. There's also 
 
 {% /persona %}
 
-{% /personas %}
+{% /cards %}
 
 ## Adopting Nx
 

--- a/nx-dev/ui-markdoc/src/lib/tags/cards.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/cards.component.tsx
@@ -21,9 +21,7 @@ export function Cards({
   };
 
   return (
-    <div
-      className={`not-prose mt-8 grid grid-cols-1 gap-6 ${gridColums[cols]}`}
-    >
+    <div className={`mt-8 grid grid-cols-1 gap-6 ${gridColums[cols]}`}>
       {children}
     </div>
   );
@@ -63,7 +61,7 @@ export function Card({
           src={`https://img.youtube.com/vi/${hasYoutubeId}/default.jpg`}
         />
       )}
-      <div className="flex flex-col p-3 pr-0">
+      <div className="flex flex-col p-3 pr-0 pb-0">
         <a href={url} title={title} className="flex items-center font-semibold">
           <span className="absolute inset-0" aria-hidden="true"></span>
           {!hasYoutubeId ? iconMap[type] : null}


### PR DESCRIPTION
Arranges the standalone tutorial cards on the intro page into 3 columns.