### PR TITLE
fix(vite): explicitly export type instead of a value from d.ts files

### DIFF
--- a/packages/vite/executors.ts
+++ b/packages/vite/executors.ts
@@ -1,8 +1,8 @@
-export { ViteBuildExecutorOptions } from './src/executors/build/schema';
+export { type ViteBuildExecutorOptions } from './src/executors/build/schema';
 export { viteBuildExecutor } from './src/executors/build/build.impl';
-export { ViteDevServerExecutorOptions } from './src/executors/dev-server/schema';
+export { type ViteDevServerExecutorOptions } from './src/executors/dev-server/schema';
 export { viteDevServerExecutor } from './src/executors/dev-server/dev-server.impl';
-export { VitePreviewServerExecutorOptions } from './src/executors/preview-server/schema';
+export { type VitePreviewServerExecutorOptions } from './src/executors/preview-server/schema';
 export { vitePreviewServerExecutor } from './src/executors/preview-server/preview-server.impl';
-export { VitestExecutorOptions } from './src/executors/test/schema';
+export { type VitestExecutorOptions } from './src/executors/test/schema';
 export { vitestExecutor } from './src/executors/test/vitest.impl';

--- a/packages/vite/index.ts
+++ b/packages/vite/index.ts
@@ -1,8 +1,8 @@
 export * from './src/utils/versions';
 export * from './src/utils/generator-utils';
-export { ViteConfigurationGeneratorSchema } from './src/generators/configuration/schema';
+export { type ViteConfigurationGeneratorSchema } from './src/generators/configuration/schema';
 export { viteConfigurationGenerator } from './src/generators/configuration/configuration';
-export { VitestGeneratorSchema } from './src/generators/vitest/schema';
+export { type VitestGeneratorSchema } from './src/generators/vitest/schema';
 export { vitestGenerator } from './src/generators/vitest/vitest-generator';
-export { InitGeneratorSchema } from './src/generators/init/schema';
+export { type InitGeneratorSchema } from './src/generators/init/schema';
 export { initGenerator } from './src/generators/init/init';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When types are exported from d.ts files, typescript actually creates an export from corresponding module, which is not valid in case of types 
<img width="562" alt="image" src="https://user-images.githubusercontent.com/33101123/219117891-fd7df881-0017-4de9-891b-a2fe6f786049.png">

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Should have all exported types explicitly marked as type in order to not have require statements for them in compiled index.js of a package
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
