### PR TITLE
fix(core): removed caching from `reverse` operator

### DIFF
--- a/packages/nx/src/project-graph/operators.ts
+++ b/packages/nx/src/project-graph/operators.ts
@@ -4,8 +4,6 @@ import {
   ProjectGraphProjectNode,
 } from '../config/project-graph';
 
-const reverseMemo = new Map<ProjectGraph, ProjectGraph>();
-
 /**
  * Returns a new project graph where all the edges are reversed.
  *
@@ -13,11 +11,6 @@ const reverseMemo = new Map<ProjectGraph, ProjectGraph>();
  * B will depend on A.
  */
 export function reverse(graph: ProjectGraph): ProjectGraph {
-  const resultFromMemo = reverseMemo.get(graph);
-  if (resultFromMemo) {
-    return resultFromMemo;
-  }
-
   const result = {
     nodes: graph.nodes,
     externalNodes: graph.externalNodes,
@@ -42,8 +35,7 @@ export function reverse(graph: ProjectGraph): ProjectGraph {
       }
     });
   });
-  reverseMemo.set(graph, result);
-  reverseMemo.set(result, graph);
+
   return result;
 }
 


### PR DESCRIPTION
Proposal to fix #15019

On one hand [this is not used](https://github.com/nrwl/nx/pull/15035/files#diff-c26598c089f1026349889cf4a46ae35906fe174b3eaa98defb39bf25bc9326c9L46), on the other I cannot perceive any performance improvement on my machine [from this](https://github.com/nrwl/nx/pull/15035/files#diff-c26598c089f1026349889cf4a46ae35906fe174b3eaa98defb39bf25bc9326c9L16).

Furthermore, the cache key for the `graph` is calculated dangerously as [shown in here](https://codesandbox.io/s/js-playground-forked-pd5gcc?file=/src/index.js). It is better explained on the issue mentioned above.

These global caching methods, within methods, that are within other methods, are always dangerous to play with and even though I am not a super expert on `nx` I don't think is a common pattern.

<img src="https://media3.giphy.com/media/AoxGr8gxGquJQ0e4NF/giphy.gif"/>