### PR TITLE
fix(js): don't read dependency package.json if it doesn't exist

### DIFF
--- a/packages/js/src/utils/package-json/update-package-json.ts
+++ b/packages/js/src/utils/package-json/update-package-json.ts
@@ -17,6 +17,7 @@ import { writeFileSync } from 'fs-extra';
 import { isNpmProject } from 'nx/src/project-graph/operators';
 import { fileExists } from 'nx/src/utils/fileutils';
 import type { PackageJson } from 'nx/src/utils/package-json';
+import { existsSync } from 'fs';
 
 function getMainFileDirRelativeToProjectRoot(
   main: string,
@@ -138,10 +139,13 @@ function addMissingDependencies(
         );
 
         const depPackageJsonPath = join(root, outputs[0], 'package.json');
-        const version = readJsonFile(depPackageJsonPath).version;
 
-        packageJson[propType] ??= {};
-        packageJson[propType][packageName] = version;
+        if (existsSync(depPackageJsonPath)) {
+          const version = readJsonFile(depPackageJsonPath).version;
+
+          packageJson[propType] ??= {};
+          packageJson[propType][packageName] = version;
+        }
       }
     }
   });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We try to read all package.json from outputs of dependencies during `updatePackageJson`, without seeing if they exist first.

## Expected Behavior
Non-JS projects don't contain package.json. An implicit dependency from a project using @nrwl/js:tsc to a non-js project should be valid.

See: https://cloud.nx.app/runs/5xwrsmb3Pv/task/demo-libs-generated-webapi-types:build

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nx-dotnet/nx-dotnet/pull/622