### PR TITLE
feat(angular): add option for custom path to manifest file

### DIFF
--- a/docs/generated/packages/angular/executors/module-federation-dev-server.json
+++ b/docs/generated/packages/angular/executors/module-federation-dev-server.json
@@ -108,6 +108,10 @@
         "type": "array",
         "items": { "type": "string" },
         "description": "List of remote applications to not automatically serve, either statically or in development mode. This can be useful for multi-repository module federation setups where the host application uses a remote application from an external repository."
+      },
+      "pathToManifestFile": {
+        "type": "string",
+        "description": "Path to a module-federation.manifest.json file containing the dynamic remote applications relative to the workspace root."
       }
     },
     "additionalProperties": false,

--- a/docs/generated/packages/angular/executors/module-federation-dev-server.json
+++ b/docs/generated/packages/angular/executors/module-federation-dev-server.json
@@ -111,7 +111,7 @@
       },
       "pathToManifestFile": {
         "type": "string",
-        "description": "Path to a module-federation.manifest.json file containing the dynamic remote applications relative to the workspace root."
+        "description": "Path to a Module Federation manifest file (e.g. `my/path/to/module-federation.manifest.json`) containing the dynamic remote applications relative to the workspace root."
       }
     },
     "additionalProperties": false,

--- a/docs/generated/packages/angular/executors/module-federation-dev-ssr.json
+++ b/docs/generated/packages/angular/executors/module-federation-dev-ssr.json
@@ -80,7 +80,7 @@
       },
       "pathToManifestFile": {
         "type": "string",
-        "description": "Path to a module-federation.manifest.json file containing the dynamic remote applications relative to the workspace root."
+        "description": "Path to a Module Federation manifest file (e.g. `my/path/to/module-federation.manifest.json`) containing the dynamic remote applications relative to the workspace root."
       }
     },
     "additionalProperties": false,

--- a/docs/generated/packages/angular/executors/module-federation-dev-ssr.json
+++ b/docs/generated/packages/angular/executors/module-federation-dev-ssr.json
@@ -77,6 +77,10 @@
       "verbose": {
         "type": "boolean",
         "description": "Adds more details to output logging."
+      },
+      "pathToManifestFile": {
+        "type": "string",
+        "description": "Path to a module-federation.manifest.json file containing the dynamic remote applications relative to the workspace root."
       }
     },
     "additionalProperties": false,

--- a/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -12,6 +12,8 @@ import {
   getStaticRemotes,
   validateDevRemotes,
 } from '../utilities/module-federation';
+import { existsSync } from 'fs';
+import { extname, join } from 'path';
 
 export function executeModuleFederationDevServerBuilder(
   schema: Schema,
@@ -23,6 +25,29 @@ export function executeModuleFederationDevServerBuilder(
     readProjectsConfigurationFromProjectGraph(projectGraph);
   const ws = new Workspaces(workspaceRoot);
   const project = workspaceProjects[context.target.project];
+
+  let pathToManifestFile = join(
+    context.workspaceRoot,
+    project.sourceRoot,
+    'assets/module-federation.manifest.json'
+  );
+  if (options.pathToManifestFile) {
+    const userPathToManifestFile = join(
+      context.workspaceRoot,
+      options.pathToManifestFile
+    );
+    if (!existsSync(userPathToManifestFile)) {
+      throw new Error(
+        `Path to the Manifest File does not exist. Please check the file exists at ${userPathToManifestFile}.`
+      );
+    } else if (extname(options.pathToManifestFile) !== 'json') {
+      throw new Error(
+        `Manifest file must be JSON. Please ensure the file at ${userPathToManifestFile} is JSON.`
+      );
+    }
+
+    pathToManifestFile = userPathToManifestFile;
+  }
 
   validateDevRemotes(options, workspaceProjects);
 
@@ -37,7 +62,8 @@ export function executeModuleFederationDevServerBuilder(
     project,
     context,
     workspaceProjects,
-    remotesToSkip
+    remotesToSkip,
+    pathToManifestFile
   );
   const remotes = [...staticRemotes, ...dynamicRemotes];
 

--- a/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -38,11 +38,11 @@ export function executeModuleFederationDevServerBuilder(
     );
     if (!existsSync(userPathToManifestFile)) {
       throw new Error(
-        `Path to the Manifest File does not exist. Please check the file exists at ${userPathToManifestFile}.`
+        `The provided Module Federation manifest file path does not exist. Please check the file exists at "${userPathToManifestFile}".`
       );
-    } else if (extname(options.pathToManifestFile) !== 'json') {
+    } else if (extname(options.pathToManifestFile) !== '.json') {
       throw new Error(
-        `Manifest file must be JSON. Please ensure the file at ${userPathToManifestFile} is JSON.`
+        `The Module Federation manifest file must be a JSON. Please ensure the file at ${userPathToManifestFile} is a JSON.`
       );
     }
 

--- a/packages/angular/src/builders/module-federation-dev-server/schema.d.ts
+++ b/packages/angular/src/builders/module-federation-dev-server/schema.d.ts
@@ -19,4 +19,5 @@ export interface Schema {
   poll?: number;
   devRemotes?: string[];
   skipRemotes?: string[];
+  pathToManifestFile?: string;
 }

--- a/packages/angular/src/builders/module-federation-dev-server/schema.json
+++ b/packages/angular/src/builders/module-federation-dev-server/schema.json
@@ -121,7 +121,7 @@
     },
     "pathToManifestFile": {
       "type": "string",
-      "description": "Path to a module-federation.manifest.json file containing the dynamic remote applications relative to the workspace root."
+      "description": "Path to a Module Federation manifest file (e.g. `my/path/to/module-federation.manifest.json`) containing the dynamic remote applications relative to the workspace root."
     }
   },
   "additionalProperties": false,

--- a/packages/angular/src/builders/module-federation-dev-server/schema.json
+++ b/packages/angular/src/builders/module-federation-dev-server/schema.json
@@ -118,6 +118,10 @@
         "type": "string"
       },
       "description": "List of remote applications to not automatically serve, either statically or in development mode. This can be useful for multi-repository module federation setups where the host application uses a remote application from an external repository."
+    },
+    "pathToManifestFile": {
+      "type": "string",
+      "description": "Path to a module-federation.manifest.json file containing the dynamic remote applications relative to the workspace root."
     }
   },
   "additionalProperties": false,

--- a/packages/angular/src/builders/module-federation-dev-ssr/module-federation-dev-ssr.impl.ts
+++ b/packages/angular/src/builders/module-federation-dev-ssr/module-federation-dev-ssr.impl.ts
@@ -40,11 +40,11 @@ export function executeModuleFederationDevSSRBuilder(
     );
     if (!existsSync(userPathToManifestFile)) {
       throw new Error(
-        `Path to the Manifest File does not exist. Please check the file exists at ${userPathToManifestFile}.`
+        `The provided Module Federation manifest file path does not exist. Please check the file exists at "${userPathToManifestFile}".`
       );
-    } else if (extname(options.pathToManifestFile) !== 'json') {
+    } else if (extname(options.pathToManifestFile) !== '.json') {
       throw new Error(
-        `Manifest file must be JSON. Please ensure the file at ${userPathToManifestFile} is JSON.`
+        `The Module Federation manifest file must be a JSON. Please ensure the file at ${userPathToManifestFile} is a JSON.`
       );
     }
 

--- a/packages/angular/src/builders/module-federation-dev-ssr/module-federation-dev-ssr.impl.ts
+++ b/packages/angular/src/builders/module-federation-dev-ssr/module-federation-dev-ssr.impl.ts
@@ -12,9 +12,10 @@ import {
 } from '../utilities/module-federation';
 import { switchMap, tap } from 'rxjs/operators';
 import { from } from 'rxjs';
-import { join } from 'path';
+import { extname, join } from 'path';
 import { execSync, fork } from 'child_process';
 import { scheduleTarget } from 'nx/src/adapter/ngcli-adapter';
+import { existsSync } from 'fs';
 
 export function executeModuleFederationDevSSRBuilder(
   schema: Schema,
@@ -26,6 +27,29 @@ export function executeModuleFederationDevSSRBuilder(
     readProjectsConfigurationFromProjectGraph(projectGraph);
   const ws = new Workspaces(workspaceRoot);
   const project = workspaceProjects[context.target.project];
+
+  let pathToManifestFile = join(
+    context.workspaceRoot,
+    project.sourceRoot,
+    'assets/module-federation.manifest.json'
+  );
+  if (options.pathToManifestFile) {
+    const userPathToManifestFile = join(
+      context.workspaceRoot,
+      options.pathToManifestFile
+    );
+    if (!existsSync(userPathToManifestFile)) {
+      throw new Error(
+        `Path to the Manifest File does not exist. Please check the file exists at ${userPathToManifestFile}.`
+      );
+    } else if (extname(options.pathToManifestFile) !== 'json') {
+      throw new Error(
+        `Manifest file must be JSON. Please ensure the file at ${userPathToManifestFile} is JSON.`
+      );
+    }
+
+    pathToManifestFile = userPathToManifestFile;
+  }
 
   validateDevRemotes(options, workspaceProjects);
 
@@ -40,7 +64,8 @@ export function executeModuleFederationDevSSRBuilder(
     project,
     context,
     workspaceProjects,
-    remotesToSkip
+    remotesToSkip,
+    pathToManifestFile
   );
   const remotes = [...staticRemotes, ...dynamicRemotes];
 

--- a/packages/angular/src/builders/module-federation-dev-ssr/schema.d.ts
+++ b/packages/angular/src/builders/module-federation-dev-ssr/schema.d.ts
@@ -13,4 +13,5 @@ export interface Schema {
   devRemotes?: string[];
   skipRemotes?: string[];
   verbose?: boolean;
+  pathToManifestFile?: string;
 }

--- a/packages/angular/src/builders/module-federation-dev-ssr/schema.json
+++ b/packages/angular/src/builders/module-federation-dev-ssr/schema.json
@@ -78,6 +78,10 @@
     "verbose": {
       "type": "boolean",
       "description": "Adds more details to output logging."
+    },
+    "pathToManifestFile": {
+      "type": "string",
+      "description": "Path to a module-federation.manifest.json file containing the dynamic remote applications relative to the workspace root."
     }
   },
   "additionalProperties": false,

--- a/packages/angular/src/builders/module-federation-dev-ssr/schema.json
+++ b/packages/angular/src/builders/module-federation-dev-ssr/schema.json
@@ -81,7 +81,7 @@
     },
     "pathToManifestFile": {
       "type": "string",
-      "description": "Path to a module-federation.manifest.json file containing the dynamic remote applications relative to the workspace root."
+      "description": "Path to a Module Federation manifest file (e.g. `my/path/to/module-federation.manifest.json`) containing the dynamic remote applications relative to the workspace root."
     }
   },
   "additionalProperties": false,

--- a/packages/angular/src/builders/utilities/module-federation.ts
+++ b/packages/angular/src/builders/utilities/module-federation.ts
@@ -7,23 +7,23 @@ export function getDynamicRemotes(
   project: ProjectConfiguration,
   context: import('@angular-devkit/architect').BuilderContext,
   workspaceProjects: Record<string, ProjectConfiguration>,
-  remotesToSkip: Set<string>
+  remotesToSkip: Set<string>,
+  pathToManifestFile = join(
+    context.workspaceRoot,
+    project.sourceRoot,
+    'assets/module-federation.manifest.json'
+  )
 ): string[] {
   // check for dynamic remotes
   // we should only check for dynamic based on what we generate
   // and fallback to empty array
 
-  const standardPathToGeneratedMFManifestJson = join(
-    context.workspaceRoot,
-    project.sourceRoot,
-    'assets/module-federation.manifest.json'
-  );
-  if (!existsSync(standardPathToGeneratedMFManifestJson)) {
+  if (!existsSync(pathToManifestFile)) {
     return [];
   }
 
   const moduleFederationManifestJson = readFileSync(
-    standardPathToGeneratedMFManifestJson,
+    pathToManifestFile,
     'utf-8'
   );
 
@@ -54,8 +54,8 @@ export function getDynamicRemotes(
   if (invalidDynamicRemotes.length) {
     throw new Error(
       invalidDynamicRemotes.length === 1
-        ? `Invalid dynamic remote configured in "${standardPathToGeneratedMFManifestJson}": ${invalidDynamicRemotes[0]}.`
-        : `Invalid dynamic remotes configured in "${standardPathToGeneratedMFManifestJson}": ${invalidDynamicRemotes.join(
+        ? `Invalid dynamic remote configured in "${pathToManifestFile}": ${invalidDynamicRemotes[0]}.`
+        : `Invalid dynamic remotes configured in "${pathToManifestFile}": ${invalidDynamicRemotes.join(
             ', '
           )}.`
     );


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We do not allow users to specify a path to where their module-federation.manifest.json file lives in the repo

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Allow users to specify an option in the project.json with the path to the manifest file. Fallback to original location.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14993
