### PR TITLE
fix(storybook): dont touch config if is already using new schema

### DIFF
--- a/packages/storybook/src/migrations/update-15-4-6/__snapshots__/refactor-executor-options.spec.ts.snap
+++ b/packages/storybook/src/migrations/update-15-4-6/__snapshots__/refactor-executor-options.spec.ts.snap
@@ -2,6 +2,101 @@
 
 exports[`update the executor options to match the new schema for non-angular projects should update the target options 1`] = `
 Map {
+  "main-vite-new" => Object {
+    "$schema": "../../node_modules/nx/schemas/project-schema.json",
+    "name": "main-vite-new",
+    "projectType": "application",
+    "root": "apps/main-vite-new",
+    "sourceRoot": "apps/main-vite-new/src",
+    "tags": Array [],
+    "targets": Object {
+      "build": Object {
+        "configurations": Object {
+          "development": Object {
+            "mode": "development",
+          },
+          "production": Object {
+            "mode": "production",
+          },
+        },
+        "defaultConfiguration": "production",
+        "executor": "@nrwl/vite:build",
+        "options": Object {
+          "outputPath": "dist/apps/main-vite-new",
+        },
+        "outputs": Array [
+          "{options.outputPath}",
+        ],
+      },
+      "build-storybook": Object {
+        "configurations": Object {
+          "ci": Object {
+            "quiet": true,
+          },
+        },
+        "executor": "@nrwl/storybook:build",
+        "options": Object {
+          "configDir": "apps/main-vite-new/.storybook",
+          "outputDir": "dist/storybook/main-vite-new",
+          "uiFramework": "@storybook/react",
+        },
+        "outputs": Array [
+          "{options.outputDir}",
+        ],
+      },
+      "lint": Object {
+        "executor": "@nrwl/linter:eslint",
+        "options": Object {
+          "lintFilePatterns": Array [
+            "apps/main-vite-new/**/*.{ts,tsx,js,jsx}",
+          ],
+        },
+        "outputs": Array [
+          "{options.outputFile}",
+        ],
+      },
+      "serve": Object {
+        "configurations": Object {
+          "development": Object {
+            "buildTarget": "main-vite-new:build:development",
+            "hmr": true,
+          },
+          "production": Object {
+            "buildTarget": "main-vite-new:build:production",
+            "hmr": false,
+          },
+        },
+        "defaultConfiguration": "development",
+        "executor": "@nrwl/vite:dev-server",
+        "options": Object {
+          "buildTarget": "main-vite-new:build",
+        },
+      },
+      "storybook": Object {
+        "configurations": Object {
+          "ci": Object {
+            "quiet": true,
+          },
+        },
+        "executor": "@nrwl/storybook:storybook",
+        "options": Object {
+          "configDir": "apps/main-vite-new/.storybook",
+          "port": 4400,
+          "uiFramework": "@storybook/react",
+        },
+      },
+      "test": Object {
+        "executor": "@nrwl/vite:test",
+        "options": Object {
+          "passWithNoTests": true,
+          "reportsDirectory": "../../coverage/apps/main-vite-new",
+        },
+        "outputs": Array [
+          "coverage/apps/main-vite-new",
+        ],
+      },
+    },
+  },
   "main-vite" => Object {
     "$schema": "../../node_modules/nx/schemas/project-schema.json",
     "name": "main-vite",

--- a/packages/storybook/src/migrations/update-15-4-6/refactor-executor-options.ts
+++ b/packages/storybook/src/migrations/update-15-4-6/refactor-executor-options.ts
@@ -20,16 +20,26 @@ function updateNonAngularStorybookBuildTargets(tree: Tree) {
       if (!configuration) {
         return;
       }
-
       const projectConfiguration = readProjectConfiguration(tree, projectName);
-      projectConfiguration.targets[targetName].options = {
-        ...projectConfiguration.targets[targetName].options,
-        configDir:
-          projectConfiguration.targets[targetName].options?.config
-            ?.configFolder,
-        outputDir: projectConfiguration.targets[targetName].options?.outputPath,
-        docs: projectConfiguration.targets[targetName].options?.docsMode,
-      };
+
+      if (!projectConfiguration.targets[targetName].options) {
+        projectConfiguration.targets[targetName].options = {};
+      }
+
+      if (!projectConfiguration.targets[targetName].options.configDir) {
+        projectConfiguration.targets[targetName].options.configDir =
+          projectConfiguration.targets[targetName].options.config?.configFolder;
+      }
+
+      if (!projectConfiguration.targets[targetName].options.outputDir) {
+        projectConfiguration.targets[targetName].options.outputDir =
+          projectConfiguration.targets[targetName].options.outputPath;
+      }
+
+      if (!projectConfiguration.targets[targetName].options.docs) {
+        projectConfiguration.targets[targetName].options.docs =
+          projectConfiguration.targets[targetName].options.docsMode;
+      }
 
       projectConfiguration.targets[targetName].outputs =
         projectConfiguration.targets[targetName].outputs?.map(
@@ -58,13 +68,20 @@ function updateNonAngularStorybookServeTargets(tree: Tree) {
       }
 
       const projectConfiguration = readProjectConfiguration(tree, projectName);
-      projectConfiguration.targets[targetName].options = {
-        ...projectConfiguration.targets[targetName].options,
-        configDir:
-          projectConfiguration.targets[targetName].options?.config
-            ?.configFolder,
-        docs: projectConfiguration.targets[targetName].options?.docsMode,
-      };
+
+      if (!projectConfiguration.targets[targetName].options) {
+        projectConfiguration.targets[targetName].options = {};
+      }
+
+      if (!projectConfiguration.targets[targetName].options.configDir) {
+        projectConfiguration.targets[targetName].options.configDir =
+          projectConfiguration.targets[targetName].options.config?.configFolder;
+      }
+
+      if (!projectConfiguration.targets[targetName].options.docs) {
+        projectConfiguration.targets[targetName].options.docs =
+          projectConfiguration.targets[targetName].options.docsMode;
+      }
 
       delete projectConfiguration.targets[targetName].options.config;
       delete projectConfiguration.targets[targetName].options.docsMode;

--- a/packages/storybook/src/migrations/update-15-4-6/test-configs/various-projects.json
+++ b/packages/storybook/src/migrations/update-15-4-6/test-configs/various-projects.json
@@ -1,4 +1,73 @@
 {
+  "main-vite-new": {
+    "name": "main-vite-new",
+    "$schema": "../../node_modules/nx/schemas/project-schema.json",
+    "sourceRoot": "apps/main-vite-new/src",
+    "projectType": "application",
+    "targets": {
+      "build": {
+        "executor": "@nrwl/vite:build",
+        "outputs": ["{options.outputPath}"],
+        "defaultConfiguration": "production",
+        "options": { "outputPath": "dist/apps/main-vite-new" },
+        "configurations": {
+          "development": { "mode": "development" },
+          "production": { "mode": "production" }
+        }
+      },
+      "serve": {
+        "executor": "@nrwl/vite:dev-server",
+        "defaultConfiguration": "development",
+        "options": { "buildTarget": "main-vite-new:build" },
+        "configurations": {
+          "development": {
+            "buildTarget": "main-vite-new:build:development",
+            "hmr": true
+          },
+          "production": {
+            "buildTarget": "main-vite-new:build:production",
+            "hmr": false
+          }
+        }
+      },
+      "test": {
+        "executor": "@nrwl/vite:test",
+        "outputs": ["coverage/apps/main-vite-new"],
+        "options": {
+          "passWithNoTests": true,
+          "reportsDirectory": "../../coverage/apps/main-vite-new"
+        }
+      },
+      "lint": {
+        "executor": "@nrwl/linter:eslint",
+        "outputs": ["{options.outputFile}"],
+        "options": {
+          "lintFilePatterns": ["apps/main-vite-new/**/*.{ts,tsx,js,jsx}"]
+        }
+      },
+      "storybook": {
+        "executor": "@nrwl/storybook:storybook",
+        "options": {
+          "uiFramework": "@storybook/react",
+          "port": 4400,
+          "configDir": "apps/main-vite-new/.storybook"
+        },
+        "configurations": { "ci": { "quiet": true } }
+      },
+      "build-storybook": {
+        "executor": "@nrwl/storybook:build",
+        "outputs": ["{options.outputDir}"],
+        "options": {
+          "uiFramework": "@storybook/react",
+          "outputDir": "dist/storybook/main-vite-new",
+          "configDir": "apps/main-vite-new/.storybook"
+        },
+        "configurations": { "ci": { "quiet": true } }
+      }
+    },
+    "tags": [],
+    "root": "apps/main-vite-new"
+  },
   "main-vite": {
     "name": "main-vite",
     "$schema": "../../node_modules/nx/schemas/project-schema.json",


### PR DESCRIPTION
If Storybook targets are using the new schema (`configDir` and `outputDir`) don't edit `project.json`.

It would try to edit these options even if they were set, resulting in them being set to `undefined`.