### PR TITLE
fix(nx-plugin): local plugin execution should work with ts-node

### DIFF
--- a/e2e/nx-plugin/src/nx-plugin.test.ts
+++ b/e2e/nx-plugin/src/nx-plugin.test.ts
@@ -367,7 +367,7 @@ describe('Nx Plugin', () => {
 
     it('should work with ts-node only', async () => {
       const oldPackageJson: PackageJson = readJson('package.json');
-      updateJson<PackageJson>('packageJson', (j) => {
+      updateJson<PackageJson>('package.json', (j) => {
         delete j.dependencies['@swc-node/register'];
         delete j.devDependencies['@swc-node/register'];
         return j;

--- a/packages/nx/src/utils/register.spec.ts
+++ b/packages/nx/src/utils/register.spec.ts
@@ -1,0 +1,20 @@
+import { ModuleKind, ScriptTarget } from 'typescript';
+import { getTsNodeCompilerOptions } from './register';
+
+describe('getTsNodeCompilerOptions', () => {
+  it('should replace enum value with enum key for module', () => {
+    expect(
+      getTsNodeCompilerOptions({
+        module: ModuleKind.CommonJS,
+      }).module
+    ).toEqual('CommonJS');
+  });
+
+  it('should replace enum value with enum key for target', () => {
+    expect(
+      getTsNodeCompilerOptions({
+        target: ScriptTarget.ES2020,
+      }).target
+    ).toEqual('ES2020');
+  });
+});


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
ts-node is passed certain values as a number, and dies

## Expected Behavior
ts-node is passed values as expected, but we don't have to maintain that mapping manually.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15038
