### PR TITLE
fix(core): nx plugin cache should load new plugins

### DIFF
--- a/packages/nx/src/utils/nx-plugin.ts
+++ b/packages/nx/src/utils/nx-plugin.ts
@@ -47,7 +47,7 @@ export interface NxPlugin {
 // holding resolved nx plugin objects.
 // Allows loadNxPlugins to be called multiple times w/o
 // executing resolution mulitple times.
-let nxPluginCache: NxPlugin[] = null;
+let nxPluginCache: Map<string, NxPlugin> = new Map();
 
 function loadNxPlugin(moduleName: string, paths: string[], root: string) {
   let pluginPath: string;
@@ -98,13 +98,16 @@ export function loadNxPlugins(
   result.push(jsPlugin as NxPlugin);
 
   plugins ??= [];
-  if (!nxPluginCache) {
-    nxPluginCache = plugins.map((moduleName) =>
-      loadNxPlugin(moduleName, paths, root)
-    );
+  for (const plugin of plugins) {
+    let pluginModule = nxPluginCache.get(plugin);
+    if (!pluginModule) {
+      pluginModule = loadNxPlugin(plugin, paths, root);
+      nxPluginCache.set(plugin, pluginModule);
+    }
+    result.push(pluginModule);
   }
 
-  return result.concat(nxPluginCache);
+  return result;
 }
 
 export function mergePluginTargetsWithNxTargets(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The cache of loaded plugins doesn't care what plugins its trying to load, just that its loaded them at some point

## Expected Behavior
The plugin cache is per-plugin s.t. we catch new updates.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
