### PR TITLE
fix(detox): Update rn and expo buildTargets

### DIFF
--- a/packages/detox/src/generators/application/lib/get-targets.ts
+++ b/packages/detox/src/generators/application/lib/get-targets.ts
@@ -34,15 +34,17 @@ export function reactNativeTestTarget(
   platform: 'ios.sim' | 'android.emu',
   e2eName: string
 ) {
+  const buildPlatform = platform === 'ios.sim' ? 'ios' : 'android';
+
   return {
     options: {
       detoxConfiguration: `${platform}.debug`,
-      buildTarget: `${e2eName}:build-ios`,
+      buildTarget: `${e2eName}:build-${buildPlatform}}`,
     },
     configurations: {
       production: {
         detoxConfiguration: `${platform}.release`,
-        buildTarget: `${e2eName}:build-ios:production`,
+        buildTarget: `${e2eName}:build-${buildPlatform}:production`,
       },
     },
   };
@@ -52,23 +54,25 @@ export function expoTestTarget(
   platform: 'ios.sim' | 'android.emu',
   e2eName: string
 ) {
+  const buildPlatform = platform === 'ios.sim' ? 'ios' : 'android';
+
   return {
     options: {
       detoxConfiguration: `${platform}.eas`,
-      buildTarget: `${e2eName}:build-ios`,
+      buildTarget: `${e2eName}:build-${buildPlatform}`,
     },
     configurations: {
       local: {
         detoxConfiguration: `${platform}.local`,
-        buildTarget: `${e2eName}:build-ios:local`,
+        buildTarget: `${e2eName}:build-${buildPlatform}:local`,
       },
       bare: {
         detoxConfiguration: `${platform}.debug`,
-        buildTarget: `${e2eName}:build-ios:bare`,
+        buildTarget: `${e2eName}:build-${buildPlatform}:bare`,
       },
       production: {
         detoxConfiguration: `${platform}.release`,
-        buildTarget: `${e2eName}:build-ios:production`,
+        buildTarget: `${e2eName}:build-${buildPlatform}:production`,
       },
     },
   };


### PR DESCRIPTION
Previously, the React Native and Expo test targets were not being created with the correct buildTarget for the platforms iOS and Android. This caused issues when running e2e tests for Android.

To fix this issue, I updated the React Native and Expo test targets to ensure that the correct buildTarget is created for each platform. This ensures that the creation of project.json is accurate and reliable.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
