### PR TITLE
fix(core): misc encapuslated mode fixes

### DIFF
--- a/e2e/nx-misc/src/encapsulated.test.ts
+++ b/e2e/nx-misc/src/encapsulated.test.ts
@@ -7,6 +7,7 @@ import {
   checkFilesExist,
   cleanupProject,
   getPublishedVersion,
+  uniq,
 } from '@nrwl/e2e/utils';
 
 describe('encapsulated nx', () => {
@@ -68,6 +69,18 @@ describe('encapsulated nx', () => {
     expect(runEncapsulatedNx('report')).toMatch(
       new RegExp(`nx.*:.*${getPublishedVersion()}`)
     );
+  });
+
+  it('should work with basic generators', () => {
+    updateJson<NxJsonConfiguration>('nx.json', (j) => {
+      j.installation.plugins ??= {};
+      j.installation.plugins['@nrwl/workspace'] = getPublishedVersion();
+      return j;
+    });
+    expect(() =>
+      runEncapsulatedNx(`g npm-package ${uniq('pkg')}`)
+    ).not.toThrow();
+    expect(() => checkFilesExist());
   });
 });
 

--- a/packages/nx/src/command-line/generate.ts
+++ b/packages/nx/src/command-line/generate.ts
@@ -21,6 +21,7 @@ import { getLocalWorkspacePlugins } from '../utils/plugins/local-plugins';
 import { printHelp } from '../utils/print-help';
 import { workspaceRoot } from '../utils/workspace-root';
 import { NxJsonConfiguration } from '../config/nx-json';
+import { findInstalledPlugins } from '../utils/plugins/installed-plugins';
 
 export interface GenerateOptions {
   collectionName: string;
@@ -50,14 +51,10 @@ async function promptForCollection(
   interactive: boolean,
   projectsConfiguration: ProjectsConfigurations
 ): Promise<string> {
-  const packageJson = readJsonFile(`${workspaceRoot}/package.json`);
   const localPlugins = getLocalWorkspacePlugins(projectsConfiguration);
 
   const installedCollections = Array.from(
-    new Set([
-      ...Object.keys(packageJson.dependencies || {}),
-      ...Object.keys(packageJson.devDependencies || {}),
-    ])
+    new Set(findInstalledPlugins().map((x) => x.name))
   );
 
   const choicesMap = new Set<string>();

--- a/packages/nx/src/command-line/init.ts
+++ b/packages/nx/src/command-line/init.ts
@@ -18,8 +18,7 @@ export async function initHandler() {
   }) as any as { encapsulated: boolean };
 
   const version =
-    process.env.NX_VERSION ??
-    prerelease(require('../../../../package.json').version)
+    process.env.NX_VERSION ?? prerelease(require('../../package.json').version)
       ? 'next'
       : 'latest';
   if (process.env.NX_VERSION) {

--- a/packages/nx/src/command-line/init.ts
+++ b/packages/nx/src/command-line/init.ts
@@ -6,6 +6,7 @@ import { directoryExists, readJsonFile } from '../utils/fileutils';
 import { PackageJson } from '../utils/package-json';
 import * as parser from 'yargs-parser';
 import { generateEncapsulatedNxSetup } from '../nx-init/encapsulated/add-nx-scripts';
+import { prerelease } from 'semver';
 
 export async function initHandler() {
   const args = process.argv.slice(2).join(' ');
@@ -16,7 +17,11 @@ export async function initHandler() {
     },
   }) as any as { encapsulated: boolean };
 
-  const version = process.env.NX_VERSION ?? 'latest';
+  const version =
+    process.env.NX_VERSION ??
+    prerelease(require('../../../../package.json').version)
+      ? 'next'
+      : 'latest';
   if (process.env.NX_VERSION) {
     console.log(`Using version ${process.env.NX_VERSION}`);
   }

--- a/packages/nx/src/command-line/list.ts
+++ b/packages/nx/src/command-line/list.ts
@@ -3,7 +3,7 @@ import { output } from '../utils/output';
 import {
   fetchCommunityPlugins,
   fetchCorePlugins,
-  getInstalledPluginsFromPackageJson,
+  getInstalledPluginsAndCapabilities,
   listCommunityPlugins,
   listCorePlugins,
   listInstalledPlugins,
@@ -49,7 +49,7 @@ export async function listHandler(args: ListArgs): Promise<void> {
     const localPlugins = getLocalWorkspacePlugins(
       readProjectsConfigurationFromProjectGraph(projectGraph)
     );
-    const installedPlugins = getInstalledPluginsFromPackageJson(
+    const installedPlugins = getInstalledPluginsAndCapabilities(
       workspaceRoot,
       corePlugins,
       communityPlugins

--- a/packages/nx/src/command-line/report.spec.ts
+++ b/packages/nx/src/command-line/report.spec.ts
@@ -79,7 +79,7 @@ describe('report', () => {
       );
       const plugins = findInstalledCommunityPlugins();
       expect(plugins).toEqual([
-        expect.objectContaining({ package: 'plugin-two', version: '2.0.0' }),
+        expect.objectContaining({ name: 'plugin-two', version: '2.0.0' }),
       ]);
     });
 
@@ -112,8 +112,8 @@ describe('report', () => {
       );
       const plugins = findInstalledCommunityPlugins();
       expect(plugins).toEqual([
-        expect.objectContaining({ package: 'plugin-one', version: '1.0.0' }),
-        expect.objectContaining({ package: 'plugin-two', version: '2.0.0' }),
+        expect.objectContaining({ name: 'plugin-one', version: '1.0.0' }),
+        expect.objectContaining({ name: 'plugin-two', version: '2.0.0' }),
       ]);
     });
 
@@ -152,8 +152,8 @@ describe('report', () => {
       const plugins = findInstalledCommunityPlugins();
       expect(plugins).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ package: 'plugin-one', version: '1.0.0' }),
-          expect.objectContaining({ package: 'plugin-two', version: '2.0.0' }),
+          expect.objectContaining({ name: 'plugin-one', version: '1.0.0' }),
+          expect.objectContaining({ name: 'plugin-two', version: '2.0.0' }),
         ])
       );
     });

--- a/packages/nx/src/command-line/report.spec.ts
+++ b/packages/nx/src/command-line/report.spec.ts
@@ -189,7 +189,7 @@ describe('report', () => {
           },
         })
       );
-      const plugins = findInstalledCommunityPlugins().map((x) => x.package);
+      const plugins = findInstalledCommunityPlugins().map((x) => x.name);
       expect(plugins).not.toContain('other-package');
     });
   });

--- a/packages/nx/src/command-line/report.ts
+++ b/packages/nx/src/command-line/report.ts
@@ -20,6 +20,7 @@ import {
 } from '../project-graph/project-graph';
 import { gt, valid } from 'semver';
 import { NxJsonConfiguration } from '../config/nx-json';
+import { findInstalledPlugins } from '../utils/plugins/installed-plugins';
 
 const nxPackageJson = readJsonFile<typeof import('../../package.json')>(
   join(__dirname, '../../package.json')
@@ -79,11 +80,11 @@ export async function reportHandler() {
 
   if (communityPlugins.length) {
     bodyLines.push(LINE_SEPARATOR);
-    padding = Math.max(...communityPlugins.map((x) => x.package.length)) + 1;
+    padding = Math.max(...communityPlugins.map((x) => x.name.length)) + 1;
     bodyLines.push('Community plugins:');
     communityPlugins.forEach((p) => {
       bodyLines.push(
-        `${chalk.green(p.package.padEnd(padding))}: ${chalk.bold(p.version)}`
+        `${chalk.green(p.name.padEnd(padding))}: ${chalk.bold(p.version)}`
       );
     });
   }
@@ -129,9 +130,7 @@ export interface ReportData {
   pm: PackageManager;
   pmVersion: string;
   localPlugins: string[];
-  communityPlugins: (PackageJson & {
-    package: string;
-  })[];
+  communityPlugins: PackageJson[];
   packageVersionsWeCareAbout: {
     package: string;
     version: string;
@@ -249,48 +248,19 @@ export function findMisalignedPackagesForPackage(
     : undefined;
 }
 
-export function findInstalledCommunityPlugins(): (PackageJson & {
-  package: string;
-})[] {
-  const packageJsonDeps = getDependenciesFromPackageJson();
-  const nxJsonDeps = getDependenciesFromNxJson();
-  const deps = packageJsonDeps.concat(nxJsonDeps);
-  return deps.reduce(
-    (arr: any[], nextDep: string): { project: string; version: string }[] => {
-      if (
-        patternsWeIgnoreInCommunityReport.some((pattern) =>
-          typeof pattern === 'string'
-            ? pattern === nextDep
-            : pattern.test(nextDep)
-        )
-      ) {
-        return arr;
-      }
-      try {
-        const depPackageJson: Partial<PackageJson> =
-          readPackageJson(nextDep) || {};
-        if (
-          [
-            'ng-update',
-            'nx-migrations',
-            'schematics',
-            'generators',
-            'builders',
-            'executors',
-          ].some((field) => field in depPackageJson)
-        ) {
-          arr.push({ package: nextDep, ...depPackageJson });
-          return arr;
-        } else {
-          return arr;
-        }
-      } catch {
-        console.warn(`Error parsing packageJson for ${nextDep}`);
-        return arr;
-      }
-    },
-    []
-  );
+export function findInstalledCommunityPlugins(): PackageJson[] {
+  const installedPlugins = findInstalledPlugins();
+  return installedPlugins.filter((dep) => {
+    if (
+      patternsWeIgnoreInCommunityReport.some((pattern) =>
+        typeof pattern === 'string'
+          ? pattern === dep.name
+          : pattern.test(dep.name)
+      )
+    ) {
+      return false;
+    }
+  }, []);
 }
 export function findInstalledPackagesWeCareAbout() {
   return packagesWeCareAbout.reduce((acc, next) => {
@@ -300,26 +270,4 @@ export function findInstalledPackagesWeCareAbout() {
     }
     return acc;
   }, [] as { package: string; version: string }[]);
-}
-
-function getDependenciesFromPackageJson(
-  packageJsonPath = 'package.json'
-): string[] {
-  try {
-    const { dependencies, devDependencies } = readJsonFile(
-      join(workspaceRoot, packageJsonPath)
-    );
-    return Object.keys({ ...dependencies, ...devDependencies });
-  } catch {}
-  return [];
-}
-
-function getDependenciesFromNxJson(): string[] {
-  const { installation } = readJsonFile<NxJsonConfiguration>(
-    join(workspaceRoot, 'nx.json')
-  );
-  if (!installation) {
-    return [];
-  }
-  return ['nx', ...Object.keys(installation.plugins || {})];
 }

--- a/packages/nx/src/command-line/report.ts
+++ b/packages/nx/src/command-line/report.ts
@@ -250,17 +250,14 @@ export function findMisalignedPackagesForPackage(
 
 export function findInstalledCommunityPlugins(): PackageJson[] {
   const installedPlugins = findInstalledPlugins();
-  return installedPlugins.filter((dep) => {
-    if (
-      patternsWeIgnoreInCommunityReport.some((pattern) =>
+  return installedPlugins.filter(
+    (dep) =>
+      !patternsWeIgnoreInCommunityReport.some((pattern) =>
         typeof pattern === 'string'
           ? pattern === dep.name
           : pattern.test(dep.name)
       )
-    ) {
-      return false;
-    }
-  }, []);
+  );
 }
 export function findInstalledPackagesWeCareAbout() {
   return packagesWeCareAbout.reduce((acc, next) => {

--- a/packages/nx/src/nx-init/encapsulated/add-nx-scripts.ts
+++ b/packages/nx/src/nx-init/encapsulated/add-nx-scripts.ts
@@ -1,6 +1,5 @@
 import { execSync } from 'child_process';
 import { readFileSync, constants as FsConstants } from 'fs';
-import { stripIndent } from 'nx/src/utils/logger';
 import * as path from 'path';
 import { valid } from 'semver';
 import { NxJsonConfiguration } from '../../config/nx-json';
@@ -20,22 +19,18 @@ const NODE_MISSING_ERR =
 const NPM_MISSING_ERR =
   'Nx requires npm to be available. To install NodeJS and NPM, see: https://nodejs.org/en/download/ .';
 
-const BATCH_SCRIPT_CONTENTS = stripIndent(
-  `set path_to_root=%~dp0
-  WHERE node >nul 2>nul
-  IF %ERRORLEVEL% NEQ 0 (ECHO ${NODE_MISSING_ERR}; EXIT 1)
-  WHERE npm >nul 2>nul
-  IF %ERRORLEVEL% NEQ 0 (ECHO ${NPM_MISSING_ERR}; EXIT 1)
-  node ${path.win32.join('%path_to_root%', nxWrapperPath(path.win32))} %*`
-);
+const BATCH_SCRIPT_CONTENTS = `set path_to_root=%~dp0
+WHERE node >nul 2>nul
+IF %ERRORLEVEL% NEQ 0 (ECHO ${NODE_MISSING_ERR}; EXIT 1)
+WHERE npm >nul 2>nul
+IF %ERRORLEVEL% NEQ 0 (ECHO ${NPM_MISSING_ERR}; EXIT 1)
+node ${path.win32.join('%path_to_root%', nxWrapperPath(path.win32))} %*`;
 
-const SHELL_SCRIPT_CONTENTS = stripIndent(
-  `#!/bin/bash
-  command -v node >/dev/null 2>&1 || { echo >&2 "${NODE_MISSING_ERR}"; exit 1; }
-  command -v npm >/dev/null 2>&1 || { echo >&2 "${NPM_MISSING_ERR}"; exit 1; }
-  path_to_root=$(dirname $BASH_SOURCE)
-  node ${path.posix.join('$path_to_root', nxWrapperPath(path.posix))} $@`
-);
+const SHELL_SCRIPT_CONTENTS = `#!/bin/bash
+command -v node >/dev/null 2>&1 || { echo >&2 "${NODE_MISSING_ERR}"; exit 1; }
+command -v npm >/dev/null 2>&1 || { echo >&2 "${NPM_MISSING_ERR}"; exit 1; }
+path_to_root=$(dirname $BASH_SOURCE)
+node ${path.posix.join('$path_to_root', nxWrapperPath(path.posix))} $@`;
 
 export function generateEncapsulatedNxSetup(version?: string) {
   const host = new FsTree(process.cwd(), false);
@@ -81,9 +76,10 @@ export function updateGitIgnore(host: Tree) {
 }
 
 function getNodeScriptContents() {
-  // Read nxw.js, but remove any empty comments or comments that start with `INTERNAL: `
+  // Read nxw.js, but remove any empty comments or comments that start with `//#: `
+  // This removes the sourceMapUrl since it is invalid, as well as any internal comments.
   return readFileSync(path.join(__dirname, 'nxw.js'), 'utf-8').replace(
-    /(\/\/ INTERNAL: .*)|(\/\/\w*)$/gm,
+    /(\/\/# .*)|(\/\/\w*)$/gm,
     ''
   );
 }

--- a/packages/nx/src/nx-init/encapsulated/nxw.ts
+++ b/packages/nx/src/nx-init/encapsulated/nxw.ts
@@ -19,23 +19,16 @@ function matchesCurrentNxInstall(
   nxJsonInstallation: NxJsonConfiguration['installation']
 ) {
   try {
-    const currentInstallation: PackageJson = JSON.parse(
-      fs.readFileSync(installationPath, 'utf-8')
-    );
+    const currentInstallation: PackageJson = require(installationPath);
     if (
       currentInstallation.devDependencies['nx'] !==
         nxJsonInstallation.version ||
-      JSON.parse(
-        fs.readFileSync(
-          path.join(
-            path.dirname(installationPath),
-            'node_modules',
-            'nx',
-            'package.json'
-          ),
-          'utf-8'
-        )
-      ).version !== nxJsonInstallation.version
+      require(path.join(
+        path.dirname(installationPath),
+        'node_modules',
+        'nx',
+        'package.json'
+      )).version !== nxJsonInstallation.version
     ) {
       return false;
     }
@@ -64,7 +57,7 @@ function ensureUpToDateInstallation() {
   let nxJson: NxJsonConfiguration;
 
   try {
-    nxJson = JSON.parse(fs.readFileSync(nxJsonPath, 'utf-8'));
+    nxJson = require(nxJsonPath);
   } catch {
     console.error(
       '[NX]: nx.json is required when running in encapsulated mode. Run `npx nx init --encapsulated` to restore it.'

--- a/packages/nx/src/nx-init/encapsulated/nxw.ts
+++ b/packages/nx/src/nx-init/encapsulated/nxw.ts
@@ -2,9 +2,9 @@
 // that your local installation matches nx.json.
 // See: https://nx.dev/more-concepts/encapsulated-nx-and-the-wrapper for more info.
 //
-// INTERNAL: The contents of this file are executed before packages are installed.
-// INTERNAL: As such, we should not import anything from nx, other @nrwl packages,
-// INTERNAL: or any other npm packages. Only import node builtins.
+//# The contents of this file are executed before packages are installed.
+//# As such, we should not import anything from nx, other @nrwl packages,
+//# or any other npm packages. Only import node builtins.
 
 const fs: typeof import('fs') = require('fs');
 const path: typeof import('path') = require('path');
@@ -23,10 +23,16 @@ function matchesCurrentNxInstall(
       fs.readFileSync(installationPath, 'utf-8')
     );
     if (
-      currentInstallation.dependencies['nx'] !== nxJsonInstallation.version ||
+      currentInstallation.devDependencies['nx'] !==
+        nxJsonInstallation.version ||
       JSON.parse(
         fs.readFileSync(
-          path.join(installationPath, 'node_modules', 'nx', 'package.json'),
+          path.join(
+            path.dirname(installationPath),
+            'node_modules',
+            'nx',
+            'package.json'
+          ),
           'utf-8'
         )
       ).version !== nxJsonInstallation.version
@@ -36,7 +42,7 @@ function matchesCurrentNxInstall(
     for (const [plugin, desiredVersion] of Object.entries(
       nxJsonInstallation.plugins || {}
     )) {
-      if (currentInstallation.dependencies[plugin] !== desiredVersion) {
+      if (currentInstallation.devDependencies[plugin] !== desiredVersion) {
         return false;
       }
     }

--- a/packages/nx/src/utils/plugins/index.ts
+++ b/packages/nx/src/utils/plugins/index.ts
@@ -4,7 +4,7 @@ export {
 } from './community-plugins';
 export { fetchCorePlugins, listCorePlugins } from './core-plugins';
 export {
-  getInstalledPluginsFromPackageJson,
+  getInstalledPluginsAndCapabilities,
   listInstalledPlugins,
 } from './installed-plugins';
 export {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
- Running the nx wrapper always invokes npm install due to a typo. This wasn't noticed during development as the install command previously hid its output. 
- The wrapper contains a sourceMapURL at the end which is invalid.
- `nx generate` reads the root package.json to generate prompts for collectionName
- `nx list` reads the root package.json to determine installed plugins
- `nx list` and `nx report` duplicate a lot of handling for this stuff

## Expected Behavior
The nx wrapper only executes an install task when its needed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
