### PR TITLE
fix(angular): support large buffers in angular cli adapter

### DIFF
--- a/packages/nx/src/adapter/ngcli-adapter.spec.ts
+++ b/packages/nx/src/adapter/ngcli-adapter.spec.ts
@@ -1,0 +1,11 @@
+import { arrayBufferToString } from './ngcli-adapter';
+
+describe('ngcli-adapter', () => {
+  it('arrayBufferToString should support large buffers', () => {
+    const largeString = 'a'.repeat(1000000);
+
+    const result = arrayBufferToString(Buffer.from(largeString));
+
+    expect(result).toBe(largeString);
+  });
+});

--- a/packages/nx/src/adapter/ngcli-adapter.ts
+++ b/packages/nx/src/adapter/ngcli-adapter.ts
@@ -388,8 +388,19 @@ export class NxScopedHost extends virtualFs.ScopedHost<any> {
   }
 }
 
-function arrayBufferToString(buffer: any) {
-  return String.fromCharCode.apply(null, new Uint8Array(buffer));
+export function arrayBufferToString(buffer: any) {
+  const array = new Uint8Array(buffer);
+  let result = '';
+  const chunkSize = 8 * 1024;
+  let i = 0;
+  for (i = 0; i < array.length / chunkSize; i++) {
+    result += String.fromCharCode.apply(
+      null,
+      array.subarray(i * chunkSize, (i + 1) * chunkSize)
+    );
+  }
+  result += String.fromCharCode.apply(null, array.subarray(i * chunkSize));
+  return result;
 }
 
 export class NxScopeHostUsedForWrappedSchematics extends NxScopedHost {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When the Angular CLI adapter converts a large `Buffer` to `string` reading the `angular.json` file, it fails with `Maximum call stack size exceeded`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The Angular CLI adapter should support converting a large `Buffer` to `string` reading the `angular.json` file. The implementation now invokes `String.fromCharCode.apply` in batches.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15013 
