### PR TITLE
fix(angular): allow boolean usage of the prompts

### DIFF
--- a/docs/generated/cli/create-nx-workspace.md
+++ b/docs/generated/cli/create-nx-workspace.md
@@ -127,7 +127,7 @@ Customizes the initial content of your workspace. Default presets include: ["app
 
 ### routing
 
-Type: `string`
+Type: `boolean`
 
 Add a routing setup when a preset with pregenerated app is selected
 
@@ -141,7 +141,7 @@ Skip initializing a git repository.
 
 ### standaloneApi
 
-Type: `string`
+Type: `boolean`
 
 Use Standalone Components if generating an Angular app
 

--- a/docs/generated/packages/nx/documents/create-nx-workspace.md
+++ b/docs/generated/packages/nx/documents/create-nx-workspace.md
@@ -127,7 +127,7 @@ Customizes the initial content of your workspace. Default presets include: ["app
 
 ### routing
 
-Type: `string`
+Type: `boolean`
 
 Add a routing setup when a preset with pregenerated app is selected
 
@@ -141,7 +141,7 @@ Skip initializing a git repository.
 
 ### standaloneApi
 
-Type: `string`
+Type: `boolean`
 
 Use Standalone Components if generating an Angular app
 

--- a/e2e/workspace-create/src/create-nx-workspace.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace.test.ts
@@ -44,13 +44,13 @@ describe('create-nx-workspace', () => {
       appName: wsName,
       style: 'css',
       packageManager,
-      standaloneApi: false,
       routing: false,
     });
 
     checkFilesExist('package.json');
     checkFilesExist('project.json');
     checkFilesExist('src/app/app.module.ts');
+    checkFilesDoNotExist('src/app/app.routes.ts');
   });
 
   it('should create a workspace with a single angular app at the root using standalone APIs', () => {

--- a/packages/workspace/src/generators/new/generate-preset.ts
+++ b/packages/workspace/src/generators/new/generate-preset.ts
@@ -4,7 +4,7 @@ import {
   Tree,
 } from '@nrwl/devkit';
 import { Preset } from '../utils/presets';
-import { angularCliVersion, nxVersion } from '../../utils/versions';
+import { nxVersion } from '../../utils/versions';
 import { getNpmPackageVersion } from '../utils/get-npm-package-version';
 import { NormalizedSchema } from './new';
 import { join } from 'path';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Usage of the new `--standaloneApi` and `--routing` flags in CNW cannot be used unless given the values true or false
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Allow the flags to be used on their own

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15058, #15118