### PR TITLE
fix(core): fix setting of the interactive env var

### DIFF
--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -735,7 +735,7 @@ function withGenerateOptions(yargs: yargs.Argv) {
       default: false,
     })
     .middleware((args) => {
-      if (process.env.NX_INTERACTIVE !== 'false') {
+      if (process.env.NX_INTERACTIVE === 'true') {
         args.interactive = true;
       } else {
         process.env.NX_INTERACTIVE = `${args.interactive}`;

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -735,8 +735,8 @@ function withGenerateOptions(yargs: yargs.Argv) {
       default: false,
     })
     .middleware((args) => {
-      if (process.env.NX_INTERACTIVE === 'true') {
-        args.interactive = true;
+      if (process.env.NX_INTERACTIVE === 'false') {
+        args.interactive = false;
       } else {
         process.env.NX_INTERACTIVE = `${args.interactive}`;
       }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The if statement for setting interactive for the CLI was mishandling undefined env var
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should only force set interactive to true when the env var is set

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
