### PR TITLE
chore(react): skipFormat true when generating app in test

### DIFF
--- a/packages/react/src/generators/stories/stories.app.spec.ts
+++ b/packages/react/src/generators/stories/stories.app.spec.ts
@@ -347,7 +347,7 @@ export async function createTestUIApp(
   await applicationGenerator(appTree, {
     e2eTestRunner: 'cypress',
     linter: Linter.EsLint,
-    skipFormat: false,
+    skipFormat: true,
     style: 'css',
     unitTestRunner: 'none',
     name: libName,

--- a/packages/react/src/generators/stories/stories.lib.spec.ts
+++ b/packages/react/src/generators/stories/stories.lib.spec.ts
@@ -242,7 +242,7 @@ export async function createTestUILib(
   await applicationGenerator(appTree, {
     e2eTestRunner: 'none',
     linter: Linter.EsLint,
-    skipFormat: false,
+    skipFormat: true,
     style: 'css',
     unitTestRunner: 'none',
     name: `${libName}-e2e`,

--- a/packages/react/src/generators/stories/stories.nextjs.spec.ts
+++ b/packages/react/src/generators/stories/stories.nextjs.spec.ts
@@ -61,7 +61,7 @@ export async function createTestUIApp(name: string): Promise<Tree> {
   await applicationGenerator(tree, {
     e2eTestRunner: 'none',
     linter: Linter.EsLint,
-    skipFormat: false,
+    skipFormat: true,
     style: 'css',
     unitTestRunner: 'none',
     name,


### PR DESCRIPTION
## Current Behavior
Flaky test in react package. Fails with the error:
```
TypeError: prettier.resolveConfig is not a function
```

## Expected Behavior
Test should not fail.

I added `skipFormat: true` to the mock app generator, to skip the `formatFiles` step, which seems to be triggering the error. Since we're not testing the file formatting functionality, it is not needed in any case.
