### PR TITLE
fix(js): deprecate buildable flag - use only bundler for js lib gen

### DIFF
--- a/docs/generated/packages/js/generators/library.json
+++ b/docs/generated/packages/js/generators/library.json
@@ -87,9 +87,9 @@
       },
       "buildable": {
         "type": "boolean",
-        "default": true,
+        "default": false,
         "description": "Generate a buildable library.",
-        "x-priority": "important"
+        "x-deprecated": "Use the `bundler` option for greater control (none, esbuild, rollup, vite, webpack)."
       },
       "setParserOptionsProject": {
         "type": "boolean",
@@ -111,10 +111,11 @@
         "x-priority": "important"
       },
       "bundler": {
-        "description": "The bundler to use.",
+        "description": "The bundler to use. Choosing 'none' means this library is not buildable.",
         "type": "string",
         "enum": ["none", "esbuild", "rollup", "vite"],
         "default": "none",
+        "x-prompt": "Which bundler would you like to use to build the library? Choose 'none' to skip build setup.",
         "x-priority": "important"
       },
       "skipTypeCheck": {

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -201,6 +201,7 @@ describe('lib', () => {
           ...defaultOptions,
           name: 'myLib',
           directory: 'myDir',
+          bundler: 'none',
         });
         expect(tree.exists(`libs/my-dir/my-lib/jest.config.ts`)).toBeTruthy();
         expect(tree.exists('libs/my-dir/my-lib/src/index.ts')).toBeTruthy();
@@ -727,12 +728,23 @@ describe('lib', () => {
       expect(readme).toContain('nx test my-lib');
     });
 
-    describe('--buildable', () => {
+    it('should not generate a buildable lib if bundler=none', async () => {
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        name: 'myLib',
+        bundler: 'none',
+        compiler: 'tsc',
+      });
+
+      const config = readProjectConfiguration(tree, 'my-lib');
+      expect(config.targets.build).toBeUndefined();
+    });
+
+    describe('for buildable libs', () => {
       it('should generate the build target', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
-          buildable: true,
           compiler: 'tsc',
         });
 
@@ -749,11 +761,57 @@ describe('lib', () => {
         });
       });
 
+      it('should generate the build target for bundler esbuild', async () => {
+        await libraryGenerator(tree, {
+          ...defaultOptions,
+          name: 'myLib',
+          bundler: 'esbuild',
+          compiler: 'tsc',
+        });
+
+        const config = readProjectConfiguration(tree, 'my-lib');
+        expect(config.targets.build.executor).toEqual('@nrwl/esbuild:esbuild');
+      });
+
+      it('should generate the build target for bundler rollup', async () => {
+        await libraryGenerator(tree, {
+          ...defaultOptions,
+          name: 'myLib',
+          bundler: 'rollup',
+          compiler: 'tsc',
+        });
+
+        const config = readProjectConfiguration(tree, 'my-lib');
+        expect(config.targets.build.executor).toEqual('@nrwl/rollup:rollup');
+      });
+
+      it('should generate the build target for bundler vite', async () => {
+        await libraryGenerator(tree, {
+          ...defaultOptions,
+          name: 'myLib',
+          bundler: 'vite',
+          compiler: 'tsc',
+        });
+
+        const config = readProjectConfiguration(tree, 'my-lib');
+        expect(config.targets.build.executor).toEqual('@nrwl/vite:build');
+      });
+      it('should generate the build target for bundler webpack', async () => {
+        await libraryGenerator(tree, {
+          ...defaultOptions,
+          name: 'myLib',
+          bundler: 'webpack',
+          compiler: 'tsc',
+        });
+
+        const config = readProjectConfiguration(tree, 'my-lib');
+        expect(config.targets.build.executor).toEqual('@nrwl/webpack:webpack');
+      });
+
       it('should generate the build target for swc', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
-          buildable: true,
           compiler: 'swc',
         });
 
@@ -774,7 +832,6 @@ describe('lib', () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
-          buildable: true,
           compiler: 'swc',
         });
 
@@ -785,7 +842,6 @@ describe('lib', () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
-          buildable: true,
           compiler: 'swc',
         });
 
@@ -797,7 +853,6 @@ describe('lib', () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
-          buildable: true,
           compiler: 'tsc',
         });
 

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -143,7 +143,7 @@ function addProject(
     tags: options.parsedTags,
   };
 
-  if (options.buildable && options.config !== 'npm-scripts') {
+  if (options.bundler !== 'none' && options.config !== 'npm-scripts') {
     const outputPath = destinationDir
       ? `dist/${destinationDir}/${options.projectDirectory}`
       : `dist/${options.projectDirectory}`;
@@ -262,7 +262,7 @@ function createFiles(tree: Tree, options: NormalizedSchema, filesDir: string) {
     tmpl: '',
     offsetFromRoot: offsetFromRoot(options.projectRoot),
     rootTsConfigPath: getRelativePathToRootTsConfig(tree, options.projectRoot),
-    buildable: options.buildable === true,
+    buildable: options.bundler !== 'none',
     hasUnitTestRunner: options.unitTestRunner !== 'none',
   });
 
@@ -299,7 +299,7 @@ function createFiles(tree: Tree, options: NormalizedSchema, filesDir: string) {
       };
       return json;
     });
-  } else if (!options.buildable) {
+  } else if (options.bundler === 'none') {
     tree.delete(packageJsonPath);
   }
 
@@ -358,14 +358,13 @@ function normalizeOptions(
         `For publishable libs you have to provide a proper "--importPath" which needs to be a valid npm package name (e.g. my-awesome-lib or @myorg/my-lib)`
       );
     }
-    options.buildable = true;
   }
 
   const { Linter } = require('@nrwl/linter');
   if (options.config === 'npm-scripts') {
     options.unitTestRunner = 'none';
     options.linter = Linter.None;
-    options.buildable = false;
+    options.bundler = 'none';
   }
   options.compiler ??= 'tsc';
 
@@ -459,6 +458,8 @@ function getBuildExecutor(options: NormalizedSchema) {
       return `@nrwl/esbuild:esbuild`;
     case 'rollup':
       return `@nrwl/rollup:rollup`;
+    case 'none':
+      return;
     default:
       return `@nrwl/js:${options.compiler}`;
   }

--- a/packages/js/src/generators/library/schema.json
+++ b/packages/js/src/generators/library/schema.json
@@ -87,9 +87,9 @@
     },
     "buildable": {
       "type": "boolean",
-      "default": true,
+      "default": false,
       "description": "Generate a buildable library.",
-      "x-priority": "important"
+      "x-deprecated": "Use the `bundler` option for greater control (none, esbuild, rollup, vite, webpack)."
     },
     "setParserOptionsProject": {
       "type": "boolean",
@@ -111,10 +111,11 @@
       "x-priority": "important"
     },
     "bundler": {
-      "description": "The bundler to use.",
+      "description": "The bundler to use. Choosing 'none' means this library is not buildable.",
       "type": "string",
       "enum": ["none", "esbuild", "rollup", "vite"],
       "default": "none",
+      "x-prompt": "Which bundler would you like to use to build the library? Choose 'none' to skip build setup.",
       "x-priority": "important"
     },
     "skipTypeCheck": {


### PR DESCRIPTION
## DO NOT MERGE (yet)

## Current Behavior
Right now we are relying on the `buildable` flag for the `js:lib` generator.

If we don't pass the buildable flag, and we don't pass a bundler either, then library will be buildable since it defaults to `"@nrwl/js:tsc"` executor. If you do pass the `buildable` flag and miss to pass the bundler, it will default to `js:` + `options.compiler` for the executor. So we need to find a way to deprecate the buildable flag, but still be able to get the `js:tsc` or `js:swc` executors from the `bundler`.
Now the only way to get a non-buildable lib is to pass `bundler:none` and the only way to get the `js:tsc` or `js:swc` executors is to leave `bundler` undefined, which is poor UX imo.

## Expected Behavior
 We should make the behaviour of this generator consistent to the other lib generators, where the `buildable` flag is `deprecated` and we only take into account the `bundler` flag.


MOVED TO: https://github.com/nrwl/nx/pull/15376



