### PR TITLE
fix(core): do not overwrite package.json `start` script

### DIFF
--- a/packages/next/src/executors/build/lib/update-package-json.ts
+++ b/packages/next/src/executors/build/lib/update-package-json.ts
@@ -8,7 +8,9 @@ export function updatePackageJson(
   if (!packageJson.scripts) {
     packageJson.scripts = {};
   }
-  packageJson.scripts.start = 'next start';
+  if (!packageJson.scripts.start) {
+    packageJson.scripts.start = 'next start';
+  }
 
   const typescriptNode = context.projectGraph.externalNodes['npm:typescript'];
   if (typescriptNode) {


### PR DESCRIPTION
Do not overwrite app's package.json `start` script if the app already defines it.

## Current Behavior
`nx build <app>` doesn't fully respect the contents of `apps/<app>/package.json`. In particular, if the `<app>`'s package.json specifies custom script such as:
```json
{
  "scripts": {
    "start": "next start -p ${PORT:=8080}"
  }
}
```
The custom configuration is lost during `nx build <app>` and the generated `dist/apps/<lib>/package.json` misses the custom port configuration:
```json
{
  "scripts": {
    "start": "next start"
  },
```


## Expected Behavior
The file `dist/apps/<app>/package.json` should keep the custom start command, in this example it should be:
```json
{
  "scripts": {
    "start": "next start -p ${PORT:=8080}"
  },
```

The fix is simple and it is aligned with the existing logic for checking presence of `scripts` section.
