### PR TITLE
feat(node): create fastify setup closer to what fastify-cli creates

### DIFF
--- a/e2e/node/src/node-server.test.ts
+++ b/e2e/node/src/node-server.test.ts
@@ -13,7 +13,10 @@ import {
 } from '@nrwl/e2e/utils';
 
 describe('Node Applications + webpack', () => {
-  beforeEach(() => newProject());
+  let proj: string;
+  beforeEach(() => {
+    proj = newProject();
+  });
 
   afterEach(() => cleanupProject());
 
@@ -22,7 +25,7 @@ describe('Node Applications + webpack', () => {
     updateFile(
       `apps/${appName}/src/main.ts`,
       `
-      import { ${libName} } from '@proj/${libName}';
+      import { ${libName} } from '@${proj}/${libName}';
       ${content}
       console.log(${libName}());
       `
@@ -75,6 +78,10 @@ describe('Node Applications + webpack', () => {
 
     // Only Fastify generates with unit tests since it supports them without additional libraries.
     expect(() => runCLI(`lint ${fastifyApp}`)).not.toThrow();
+
+    addLibImport(expressApp, utilLib);
+    addLibImport(fastifyApp, utilLib);
+    addLibImport(koaApp, utilLib);
 
     await runE2eTests(expressApp);
     await runE2eTests(fastifyApp);

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -32,6 +32,9 @@ import {
   esbuildVersion,
   expressTypingsVersion,
   expressVersion,
+  fastifyAutoloadVersion,
+  fastifyPluginVersion,
+  fastifySensibleVersion,
   fastifyVersion,
   koaTypingsVersion,
   koaVersion,
@@ -99,6 +102,7 @@ function getEsBuildConfig(
       ),
       // Use CJS for Node apps for widest compatibility.
       format: ['cjs'],
+      bundle: false,
       main: joinPathFragments(
         project.sourceRoot,
         'main' + (options.js ? '.js' : '.ts')
@@ -293,13 +297,27 @@ function addProjectDependencies(
     },
     fastify: {
       fastify: fastifyVersion,
+      'fastify-plugin': fastifyPluginVersion,
+      '@fastify/autoload': fastifyAutoloadVersion,
+      '@fastify/sensible': fastifySensibleVersion,
     },
+  };
+  const frameworkDevDependencies = {
+    express: {
+      '@types/express': expressTypingsVersion,
+    },
+    koa: {
+      '@types/koa': koaTypingsVersion,
+    },
+    fastify: {},
   };
   return addDependenciesToPackageJson(
     tree,
-    {},
     {
       ...frameworkDependencies[options.framework],
+    },
+    {
+      ...frameworkDevDependencies[options.framework],
       ...bundlers[options.bundler],
     }
   );

--- a/packages/node/src/generators/application/files/fastify/src/app/app.ts__tmpl__
+++ b/packages/node/src/generators/application/files/fastify/src/app/app.ts__tmpl__
@@ -1,11 +1,27 @@
+import * as path from 'path';
 import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import AutoLoad from '@fastify/autoload';
 
 /* eslint-disable-next-line */
-export interface AppOptions {
-}
+export interface AppOptions { }
 
 export async function app(fastify: FastifyInstance, opts: AppOptions) {
-  fastify.get('/', async function(request: FastifyRequest, reply: FastifyReply) {
-    return { message: 'Hello API' };
+  // Place here your custom code!
+
+  // Do not touch the following lines
+
+  // This loads all plugins defined in plugins
+  // those should be support plugins that are reused
+  // through your application
+  fastify.register(AutoLoad, {
+    dir: path.join(__dirname, 'plugins'),
+    options: { ...opts },
+  });
+
+  // This loads all plugins defined in routes
+  // define your routes in one of these
+  fastify.register(AutoLoad, {
+    dir: path.join(__dirname, 'routes'),
+    options: { ...opts },
   });
 }

--- a/packages/node/src/generators/application/files/fastify/src/app/plugins/sensible.ts__tmpl__
+++ b/packages/node/src/generators/application/files/fastify/src/app/plugins/sensible.ts__tmpl__
@@ -1,0 +1,12 @@
+import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import fp from 'fastify-plugin';
+import sensible from '@fastify/sensible';
+
+/**
+ * This plugins adds some utilities to handle http errors
+ *
+ * @see https://github.com/fastify/fastify-sensible
+ */
+export default fp(async function(fastify: FastifyInstance) {
+  fastify.register(sensible);
+});

--- a/packages/node/src/generators/application/files/fastify/src/app/routes/root.ts__tmpl__
+++ b/packages/node/src/generators/application/files/fastify/src/app/routes/root.ts__tmpl__
@@ -1,0 +1,7 @@
+import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+
+export default async function(fastify: FastifyInstance) {
+  fastify.get('/', async function(request: FastifyRequest, reply: FastifyReply) {
+    return { message: 'Hello API' };
+  });
+}

--- a/packages/node/src/generators/setup-docker/files/Dockerfile__tmpl__
+++ b/packages/node/src/generators/setup-docker/files/Dockerfile__tmpl__
@@ -17,4 +17,8 @@ RUN addgroup --system <%= project %> && \
 COPY <%= buildLocation %> <%= project %>
 RUN chown -R <%= project %>:<%= project %> .
 
+# You can remove this install step if you build with `--bundle` option.
+# The bundled output will include external dependencies.
+RUN npm --prefix <%= project %> --omit=dev -f install
+
 CMD [ "node", "<%= project %>" ]

--- a/packages/node/src/utils/versions.ts
+++ b/packages/node/src/utils/versions.ts
@@ -2,16 +2,19 @@ export const nxVersion = require('../../package.json').version;
 
 export const tslibVersion = '^2.3.0';
 
-export const typesNodeVersion = '18.7.1';
+export const typesNodeVersion = '~18.7.1';
 
 export const esbuildVersion = '^0.17.5';
 
-export const expressVersion = '^4.18.1';
-export const expressTypingsVersion = '4.17.13';
+export const expressVersion = '~4.18.1';
+export const expressTypingsVersion = '~4.17.13';
 
-export const koaVersion = '2.14.1';
-export const koaTypingsVersion = '2.13.5';
+export const koaVersion = '~2.14.1';
+export const koaTypingsVersion = '~2.13.5';
 
-export const fastifyVersion = '4.11.0';
+export const fastifyVersion = '~4.13.0';
+export const fastifyAutoloadVersion = '~5.7.1';
+export const fastifySensibleVersion = '~5.2.0';
+export const fastifyPluginVersion = '~4.5.0';
 
 export const axiosVersion = '^1.0.0';


### PR DESCRIPTION
This PR updates the fastify setup to match the scaffolding provided through `fastify-cli`. This means unbundled apps with file-based routes and plugins.

e.g.

```
my-api/
  src/
    app/
      plugins/
      routes/
        root.ts
      app.ts
    main.ts
```