### PR TITLE
docs(storybook): reorder guides and refine config guide

### DIFF
--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -5949,6 +5949,14 @@
                 "disableCollapsible": false
               },
               {
+                "name": "How to configure Webpack and Vite for Storybook",
+                "path": "/packages/storybook/documents/custom-builder-configs",
+                "id": "custom-builder-configs",
+                "isExternal": false,
+                "children": [],
+                "disableCollapsible": false
+              },
+              {
                 "name": "Setting up Storybook Composition with Nx",
                 "path": "/packages/storybook/documents/storybook-composition-setup",
                 "id": "storybook-composition-setup",
@@ -5965,17 +5973,17 @@
                 "disableCollapsible": false
               },
               {
-                "name": "Angular: Information about the Storybook targets",
-                "path": "/packages/storybook/documents/angular-storybook-targets",
-                "id": "angular-storybook-targets",
+                "name": "Angular: Configuring styles and preprocessor options",
+                "path": "/packages/storybook/documents/angular-configuring-styles",
+                "id": "angular-configuring-styles",
                 "isExternal": false,
                 "children": [],
                 "disableCollapsible": false
               },
               {
-                "name": "Angular: Configuring styles and preprocessor options",
-                "path": "/packages/storybook/documents/angular-configuring-styles",
-                "id": "angular-configuring-styles",
+                "name": "Angular: Information about the Storybook targets",
+                "path": "/packages/storybook/documents/angular-storybook-targets",
+                "id": "angular-storybook-targets",
                 "isExternal": false,
                 "children": [],
                 "disableCollapsible": false
@@ -6016,14 +6024,6 @@
                 "name": "React: Upgrading to Storybook 6",
                 "path": "/packages/storybook/documents/upgrade-storybook-v6-react",
                 "id": "upgrade-storybook-v6-react",
-                "isExternal": false,
-                "children": [],
-                "disableCollapsible": false
-              },
-              {
-                "name": "How to configure Webpack and Vite for Storybook",
-                "path": "/packages/storybook/documents/custom-builder-configs",
-                "id": "custom-builder-configs",
                 "isExternal": false,
                 "children": [],
                 "disableCollapsible": false

--- a/docs/generated/manifests/packages.json
+++ b/docs/generated/manifests/packages.json
@@ -2465,6 +2465,17 @@
         "tags": [],
         "originalFilePath": "shared/packages/storybook/configuring-storybook"
       },
+      "/packages/storybook/documents/custom-builder-configs": {
+        "id": "custom-builder-configs",
+        "name": "How to configure Webpack and Vite for Storybook",
+        "description": "This guide explains how to customize the webpack configuration and your vite configuration for Storybook.",
+        "file": "generated/packages/storybook/documents/custom-builder-configs",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/packages/storybook/documents/custom-builder-configs",
+        "tags": [],
+        "originalFilePath": "shared/packages/storybook/custom-builder-configs"
+      },
       "/packages/storybook/documents/storybook-composition-setup": {
         "id": "storybook-composition-setup",
         "name": "Setting up Storybook Composition with Nx",
@@ -2487,17 +2498,6 @@
         "tags": [],
         "originalFilePath": "shared/packages/storybook/angular-storybook-compodoc"
       },
-      "/packages/storybook/documents/angular-storybook-targets": {
-        "id": "angular-storybook-targets",
-        "name": "Angular: Information about the Storybook targets",
-        "description": "This document explains the role of the storybook and build-storybook targets in Angular projects with a Storybook configuration, and specifically which executors are used for them.",
-        "file": "generated/packages/storybook/documents/angular-storybook-targets",
-        "itemList": [],
-        "isExternal": false,
-        "path": "/packages/storybook/documents/angular-storybook-targets",
-        "tags": [],
-        "originalFilePath": "shared/packages/storybook/angular-storybook-targets"
-      },
       "/packages/storybook/documents/angular-configuring-styles": {
         "id": "angular-configuring-styles",
         "name": "Angular: Configuring styles and preprocessor options",
@@ -2508,6 +2508,17 @@
         "path": "/packages/storybook/documents/angular-configuring-styles",
         "tags": [],
         "originalFilePath": "shared/packages/storybook/angular-configuring-styles"
+      },
+      "/packages/storybook/documents/angular-storybook-targets": {
+        "id": "angular-storybook-targets",
+        "name": "Angular: Information about the Storybook targets",
+        "description": "This document explains the role of the storybook and build-storybook targets in Angular projects with a Storybook configuration, and specifically which executors are used for them.",
+        "file": "generated/packages/storybook/documents/angular-storybook-targets",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/packages/storybook/documents/angular-storybook-targets",
+        "tags": [],
+        "originalFilePath": "shared/packages/storybook/angular-storybook-targets"
       },
       "/packages/storybook/documents/angular-browser-target": {
         "id": "angular-browser-target",
@@ -2563,17 +2574,6 @@
         "path": "/packages/storybook/documents/upgrade-storybook-v6-react",
         "tags": [],
         "originalFilePath": "shared/packages/storybook/storybook-v6-react"
-      },
-      "/packages/storybook/documents/custom-builder-configs": {
-        "id": "custom-builder-configs",
-        "name": "How to configure Webpack and Vite for Storybook",
-        "description": "This guide explains how to customize the webpack configuration and your vite configuration for Storybook.",
-        "file": "generated/packages/storybook/documents/custom-builder-configs",
-        "itemList": [],
-        "isExternal": false,
-        "path": "/packages/storybook/documents/custom-builder-configs",
-        "tags": [],
-        "originalFilePath": "shared/packages/storybook/custom-builder-configs"
       }
     },
     "root": "/packages/storybook",

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -2439,6 +2439,17 @@
         "originalFilePath": "shared/packages/storybook/configuring-storybook"
       },
       {
+        "id": "custom-builder-configs",
+        "name": "How to configure Webpack and Vite for Storybook",
+        "description": "This guide explains how to customize the webpack configuration and your vite configuration for Storybook.",
+        "file": "generated/packages/storybook/documents/custom-builder-configs",
+        "itemList": [],
+        "isExternal": false,
+        "path": "storybook/documents/custom-builder-configs",
+        "tags": [],
+        "originalFilePath": "shared/packages/storybook/custom-builder-configs"
+      },
+      {
         "id": "storybook-composition-setup",
         "name": "Setting up Storybook Composition with Nx",
         "description": "This guide explains how you can set up Storybook composition on your Nx workspace.",
@@ -2461,17 +2472,6 @@
         "originalFilePath": "shared/packages/storybook/angular-storybook-compodoc"
       },
       {
-        "id": "angular-storybook-targets",
-        "name": "Angular: Information about the Storybook targets",
-        "description": "This document explains the role of the storybook and build-storybook targets in Angular projects with a Storybook configuration, and specifically which executors are used for them.",
-        "file": "generated/packages/storybook/documents/angular-storybook-targets",
-        "itemList": [],
-        "isExternal": false,
-        "path": "storybook/documents/angular-storybook-targets",
-        "tags": [],
-        "originalFilePath": "shared/packages/storybook/angular-storybook-targets"
-      },
-      {
         "id": "angular-configuring-styles",
         "name": "Angular: Configuring styles and preprocessor options",
         "description": "This document explains how to configure styles and preprocessor options in Angular projects with a Storybook configuration.",
@@ -2481,6 +2481,17 @@
         "path": "storybook/documents/angular-configuring-styles",
         "tags": [],
         "originalFilePath": "shared/packages/storybook/angular-configuring-styles"
+      },
+      {
+        "id": "angular-storybook-targets",
+        "name": "Angular: Information about the Storybook targets",
+        "description": "This document explains the role of the storybook and build-storybook targets in Angular projects with a Storybook configuration, and specifically which executors are used for them.",
+        "file": "generated/packages/storybook/documents/angular-storybook-targets",
+        "itemList": [],
+        "isExternal": false,
+        "path": "storybook/documents/angular-storybook-targets",
+        "tags": [],
+        "originalFilePath": "shared/packages/storybook/angular-storybook-targets"
       },
       {
         "id": "angular-browser-target",
@@ -2536,17 +2547,6 @@
         "path": "storybook/documents/upgrade-storybook-v6-react",
         "tags": [],
         "originalFilePath": "shared/packages/storybook/storybook-v6-react"
-      },
-      {
-        "id": "custom-builder-configs",
-        "name": "How to configure Webpack and Vite for Storybook",
-        "description": "This guide explains how to customize the webpack configuration and your vite configuration for Storybook.",
-        "file": "generated/packages/storybook/documents/custom-builder-configs",
-        "itemList": [],
-        "isExternal": false,
-        "path": "storybook/documents/custom-builder-configs",
-        "tags": [],
-        "originalFilePath": "shared/packages/storybook/custom-builder-configs"
       }
     ],
     "executors": [

--- a/docs/map.json
+++ b/docs/map.json
@@ -1771,6 +1771,12 @@
               "file": "shared/packages/storybook/configuring-storybook"
             },
             {
+              "id": "custom-builder-configs",
+              "name": "How to configure Webpack and Vite for Storybook",
+              "description": "This guide explains how to customize the webpack configuration and your vite configuration for Storybook.",
+              "file": "shared/packages/storybook/custom-builder-configs"
+            },
+            {
               "id": "storybook-composition-setup",
               "name": "Setting up Storybook Composition with Nx",
               "description": "This guide explains how you can set up Storybook composition on your Nx workspace.",
@@ -1783,16 +1789,16 @@
               "file": "shared/packages/storybook/angular-storybook-compodoc"
             },
             {
-              "id": "angular-storybook-targets",
-              "name": "Angular: Information about the Storybook targets",
-              "description": "This document explains the role of the storybook and build-storybook targets in Angular projects with a Storybook configuration, and specifically which executors are used for them.",
-              "file": "shared/packages/storybook/angular-storybook-targets"
-            },
-            {
               "id": "angular-configuring-styles",
               "name": "Angular: Configuring styles and preprocessor options",
               "description": "This document explains how to configure styles and preprocessor options in Angular projects with a Storybook configuration.",
               "file": "shared/packages/storybook/angular-configuring-styles"
+            },
+            {
+              "id": "angular-storybook-targets",
+              "name": "Angular: Information about the Storybook targets",
+              "description": "This document explains the role of the storybook and build-storybook targets in Angular projects with a Storybook configuration, and specifically which executors are used for them.",
+              "file": "shared/packages/storybook/angular-storybook-targets"
             },
             {
               "id": "angular-browser-target",
@@ -1823,12 +1829,6 @@
               "name": "React: Upgrading to Storybook 6",
               "description": "This guide explains how you can upgrade your Storybook from versions 5.3 and below to Storybook 6, for React projects.",
               "file": "shared/packages/storybook/storybook-v6-react"
-            },
-            {
-              "id": "custom-builder-configs",
-              "name": "How to configure Webpack and Vite for Storybook",
-              "description": "This guide explains how to customize the webpack configuration and your vite configuration for Storybook.",
-              "file": "shared/packages/storybook/custom-builder-configs"
             }
           ]
         },


### PR DESCRIPTION
* Reorder the documents/guides for Storybook according to relevance/importance
* Refine the "customize webpack/vite" doc, now that we don't force a global config