### PR TITLE
fix(angular): use sync host when generating code with angular cli schematics

### DIFF
--- a/packages/nx/src/adapter/ngcli-adapter.ts
+++ b/packages/nx/src/adapter/ngcli-adapter.ts
@@ -503,7 +503,10 @@ export async function generate(
   verbose: boolean
 ) {
   const logger = getLogger(verbose);
-  const fsHost = new NxScopedHost(root);
+  const fsHost = new NxScopeHostUsedForWrappedSchematics(
+    root,
+    new FsTree(root, verbose)
+  );
   const workflow = createWorkflow(fsHost, root, opts);
   const collection = getCollection(workflow, opts.collectionName);
   const schematic = collection.createSchematic(opts.generatorName, true);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Generating code with Angular CLI schematics throw `Expected a synchronous delegate but got an asynchronous one`. That error is handled in some cases, but it's not reliable and can't handle all scenarios. The host provided by the Angular CLI adapter has some async methods while the Angular DevKit expects them to be synchronous. This is a regression introduced in 15.7.0.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Generating code with Angular CLI schematics should work correctly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15124 
