### PR TITLE
feat(nx-plugin): add lint option for the e2e generator

### DIFF
--- a/docs/generated/packages/nx-plugin/generators/e2e-project.json
+++ b/docs/generated/packages/nx-plugin/generators/e2e-project.json
@@ -35,6 +35,12 @@
         "default": true,
         "x-deprecated": "Nx only supports standaloneConfig"
       },
+      "linter": {
+        "description": "The tool to use for running lint checks.",
+        "type": "string",
+        "enum": ["eslint", "none"],
+        "default": "eslint"
+      },
       "minimal": {
         "type": "boolean",
         "description": "Generate the e2e project with a minimal setup. This would involve not generating tests for a default executor and generator.",

--- a/packages/nx-plugin/src/generators/e2e-project/e2e.spec.ts
+++ b/packages/nx-plugin/src/generators/e2e-project/e2e.spec.ts
@@ -157,4 +157,21 @@ describe('NxPlugin e2e-project Generator', () => {
       tree.read(joinPathFragments(root, 'tests/my-plugin.spec.ts'), 'utf-8')
     ).not.toContain("it('should create ");
   });
+
+  it('should setup the eslint builder', async () => {
+    await e2eProjectGenerator(tree, {
+      pluginName: 'my-plugin',
+      pluginOutputPath: `dist/libs/my-plugin`,
+      npmPackageName: '@proj/my-plugin',
+    });
+
+    const projectsConfigurations = getProjects(tree);
+    expect(projectsConfigurations.get('my-plugin-e2e').targets.lint).toEqual({
+      executor: '@nrwl/linter:eslint',
+      outputs: ['{options.outputFile}'],
+      options: {
+        lintFilePatterns: ['apps/my-plugin-e2e/**/*.ts'],
+      },
+    });
+  });
 });

--- a/packages/nx-plugin/src/generators/e2e-project/e2e.spec.ts
+++ b/packages/nx-plugin/src/generators/e2e-project/e2e.spec.ts
@@ -28,7 +28,7 @@ describe('NxPlugin e2e-project Generator', () => {
         pluginOutputPath: `dist/libs/my-plugin`,
         npmPackageName: '@proj/my-plugin',
       })
-    ).resolves.not.toThrow();
+    ).resolves.toBeDefined();
 
     await expect(
       e2eProjectGenerator(tree, {

--- a/packages/nx-plugin/src/generators/e2e-project/schema.d.ts
+++ b/packages/nx-plugin/src/generators/e2e-project/schema.d.ts
@@ -1,3 +1,5 @@
+import { Linter } from '@nrwl/linter';
+
 export interface Schema {
   pluginName: string;
   npmPackageName: string;
@@ -5,4 +7,5 @@ export interface Schema {
   pluginOutputPath?: string;
   jestConfig?: string;
   minimal?: boolean;
+  linter?: Linter;
 }

--- a/packages/nx-plugin/src/generators/e2e-project/schema.json
+++ b/packages/nx-plugin/src/generators/e2e-project/schema.json
@@ -35,6 +35,12 @@
       "default": true,
       "x-deprecated": "Nx only supports standaloneConfig"
     },
+    "linter": {
+      "description": "The tool to use for running lint checks.",
+      "type": "string",
+      "enum": ["eslint", "none"],
+      "default": "eslint"
+    },
     "minimal": {
       "type": "boolean",
       "description": "Generate the e2e project with a minimal setup. This would involve not generating tests for a default executor and generator.",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
e2e project for nx plugin is being generated without e2e target
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Should have the lint target in the plugin's e2e project.
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
