### PR TITLE
docs: fix typo of generate `nx-plugin` example

### DIFF
--- a/docs/generated/packages/nx-plugin/generators/plugin.json
+++ b/docs/generated/packages/nx-plugin/generators/plugin.json
@@ -10,7 +10,7 @@
     "type": "object",
     "examples": [
       {
-        "command": "g plugin my-plugin --directory=plugins --importPath=@myorg/my-plugin",
+        "command": "nx g plugin my-plugin --directory=plugins --importPath=@myorg/my-plugin",
         "description": "Generate `libs/plugins/my-plugin`"
       }
     ],

--- a/packages/nx-plugin/src/generators/plugin/schema.json
+++ b/packages/nx-plugin/src/generators/plugin/schema.json
@@ -7,7 +7,7 @@
   "type": "object",
   "examples": [
     {
-      "command": "g plugin my-plugin --directory=plugins --importPath=@myorg/my-plugin",
+      "command": "nx g plugin my-plugin --directory=plugins --importPath=@myorg/my-plugin",
       "description": "Generate `libs/plugins/my-plugin`"
     }
   ],


### PR DESCRIPTION
Hi there 👋🏽 
Just a little type on examples

## Current Behavior
Reference: https://nx.dev/packages/nx-plugin/generators/plugin#examples

Screenshot current state:
![image](https://user-images.githubusercontent.com/30556071/220226371-8eca3d5e-4f15-473a-a3cf-b5453488e687.png)

## Expected Behavior
```diff
- g plugin my-plugin --directory=plugins --importPath=@myorg/my-plugin
+ nx g plugin my-plugin --directory=plugins --importPath=@myorg/my-plugin
```

___

Sorry about the commit conventional, please align with the title and with Squash & Merge 🙏🏽 

