### PR TITLE
fix(core): normalize project config paths to properly match them when combining them

### DIFF
--- a/packages/nx/src/generators/utils/project-configuration.ts
+++ b/packages/nx/src/generators/utils/project-configuration.ts
@@ -180,7 +180,9 @@ function readAndCombineAllProjectConfigurations(tree: Tree): {
 } {
   const nxJson = readNxJson(tree);
 
-  const globbedFiles = globForProjectFiles(tree.root, nxJson);
+  const globbedFiles = globForProjectFiles(tree.root, nxJson).map(
+    normalizePath
+  );
   const createdFiles = findCreatedProjectFiles(tree);
   const deletedFiles = findDeletedProjectFiles(tree);
   const projectFiles = [...globbedFiles, ...createdFiles].filter(
@@ -218,7 +220,7 @@ function findCreatedProjectFiles(tree: Tree) {
       }
     }
   }
-  return deduplicateProjectFiles(createdProjectFiles);
+  return deduplicateProjectFiles(createdProjectFiles).map(normalizePath);
 }
 
 /**


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

On Windows, when combining globbed project config files with the tree changes there's a mix of Unix-like and Windows-like paths. Globbed files and newly created ones (from the tree) have Windows-like paths while the deleted files (from the tree) have Unix-like paths. That causes a filter where we remove the deleted project files not to work as expected because the file paths don't match. It ultimately results in an error when trying to read a file that no longer exists in the tree (it's deleted).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Getting all the project config files should work correctly in Windows.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15080 
