### PR TITLE
fix(node): support custom import paths based on tsconfig when building node apps

### DIFF
--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -36,7 +36,8 @@
     "dotenv": "~10.0.0",
     "fast-glob": "3.2.7",
     "fs-extra": "^11.1.0",
-    "tslib": "^2.3.0"
+    "tslib": "^2.3.0",
+    "tsconfig-paths": "^4.1.2"
   },
   "peerDependencies": {
     "esbuild": "~0.17.5"


### PR DESCRIPTION
This PR fixes an issue when a library has a custom import path that isn't just `@org/libname`.

For example, `nx g @nrwl/node:lib mylib --importPath=@something-custom/my-lib`.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
