### PR TITLE
fix(core): param prompts should not accept empty string for required properties

### DIFF
--- a/packages/nx/src/utils/params.spec.ts
+++ b/packages/nx/src/utils/params.spec.ts
@@ -1500,9 +1500,6 @@ describe('params', () => {
             name: {
               'x-prompt': 'What is your name?',
             },
-            type: {
-              'x-prompt': 'What type?',
-            },
           },
           required: ['name'],
         },
@@ -1519,7 +1516,6 @@ describe('params', () => {
           message: 'What is your name?',
           validate: expect.any(Function),
         },
-        { type: 'input', name: 'type', message: 'What type?' },
       ]);
     });
 
@@ -1541,7 +1537,12 @@ describe('params', () => {
       );
 
       expect(prompts).toEqual([
-        { type: 'confirm', name: 'isAwesome', message: 'Is this awesome?' },
+        {
+          type: 'confirm',
+          name: 'isAwesome',
+          message: 'Is this awesome?',
+          validate: expect.any(Function),
+        },
       ]);
     });
 
@@ -1567,6 +1568,7 @@ describe('params', () => {
           type: 'numeral',
           name: 'age',
           message: 'How old are you?',
+          validate: expect.any(Function),
         },
       ]);
     });
@@ -1599,6 +1601,7 @@ describe('params', () => {
           name: 'pets',
           message: 'What kind of pets do you have?',
           choices: ['Cat', 'Dog', 'Fish'],
+          validate: expect.any(Function),
         },
       ]);
     });
@@ -1638,6 +1641,7 @@ describe('params', () => {
             { message: 'Dog', name: 'dog' },
             { message: 'Fish', name: 'fish' },
           ],
+          validate: expect.any(Function),
         },
       ]);
     });
@@ -1678,6 +1682,7 @@ describe('params', () => {
             { message: 'Dog', name: 'dog' },
             { message: 'Fish', name: 'fish' },
           ],
+          validate: expect.any(Function),
         },
       ]);
     });
@@ -1709,6 +1714,7 @@ describe('params', () => {
             name: 'project',
             message: 'Which project?',
             choices: ['projA', 'projB'],
+            validate: expect.any(Function),
           },
         ]);
       });
@@ -1739,6 +1745,7 @@ describe('params', () => {
             name: 'projectName',
             message: 'Which project?',
             choices: ['projA', 'projB'],
+            validate: expect.any(Function),
           },
         ]);
       });
@@ -1770,6 +1777,7 @@ describe('params', () => {
             name: 'projectName',
             message: 'Which project?',
             choices: ['projA', 'projB'],
+            validate: expect.any(Function),
           },
         ]);
       });
@@ -1803,6 +1811,7 @@ describe('params', () => {
             name: 'yourProject',
             message: 'Which project?',
             choices: ['projA', 'projB'],
+            validate: expect.any(Function),
           },
         ]);
       });
@@ -1832,6 +1841,7 @@ describe('params', () => {
           name: 'name',
           message: 'What is your name?',
           choices: ['Bob', 'Joe', 'Jeff'],
+          validate: expect.any(Function),
         },
       ]);
     });
@@ -1862,6 +1872,7 @@ describe('params', () => {
           message: 'What is your name?',
           choices: ['Bob', 'Joe', 'Jeff'],
           initial: 'Joe',
+          validate: expect.any(Function),
         },
       ]);
     });
@@ -1886,7 +1897,12 @@ describe('params', () => {
       );
 
       expect(prompts).toEqual([
-        { type: 'input', name: 'name', message: 'What is your name?' },
+        {
+          type: 'input',
+          name: 'name',
+          message: 'What is your name?',
+          validate: expect.any(Function),
+        },
       ]);
     });
   });

--- a/packages/nx/src/utils/params.spec.ts
+++ b/packages/nx/src/utils/params.spec.ts
@@ -1500,7 +1500,11 @@ describe('params', () => {
             name: {
               'x-prompt': 'What is your name?',
             },
+            type: {
+              'x-prompt': 'What type?',
+            },
           },
+          required: ['name'],
         },
         {
           version: 2,
@@ -1509,7 +1513,13 @@ describe('params', () => {
       );
 
       expect(prompts).toEqual([
-        { type: 'input', name: 'name', message: 'What is your name?' },
+        {
+          type: 'input',
+          name: 'name',
+          message: 'What is your name?',
+          validate: expect.any(Function),
+        },
+        { type: 'input', name: 'type', message: 'What type?' },
       ]);
     });
 

--- a/packages/nx/src/utils/params.ts
+++ b/packages/nx/src/utils/params.ts
@@ -831,7 +831,6 @@ export function getPromptsForSchema(
         question.type = 'confirm';
       } else {
         question.type = 'input';
-        // Required strings cannot be empty
       }
       prompts.push(question);
     }


### PR DESCRIPTION
## Current Behavior
Generator properties that are marked required can be set to empty string when answering prompts, if "enter" is pressed. This may be done accidentally, or intentionally if the user thought the prompt was optional.

## Expected Behavior
Prompts validate string inputs that are marked as required, to ensure they are at least 1 character long.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15110
