### PR TITLE
fix(core): catch all lock file parsing/pruning errors and provide fallback

### DIFF
--- a/packages/nx/src/lock-file/npm-parser.ts
+++ b/packages/nx/src/lock-file/npm-parser.ts
@@ -9,7 +9,6 @@ import {
 } from '../config/project-graph';
 import { NormalizedPackageJson } from './utils/package-json';
 import { defaultHashing } from '../hasher/hashing-impl';
-import { output } from '../devkit-exports';
 
 /**
  * NPM
@@ -525,15 +524,12 @@ function nestMappedPackages(
   });
 
   if (initialSize === nestedNodes.size) {
-    output.error({
-      title: 'An error occured while creating pruned lockfile',
-      bodyLines: [
-        'Following packages could not be mapped to the lockfile.',
+    throw new Error(
+      [
+        'Following packages could not be mapped to the NPM lockfile:',
         ...Array.from(nestedNodes).map((n) => `- ${n.name}`),
-        '`npm ci` might fail due to missing dependencies in the lockfile. If this happens, please open an issue at `https://github.com/nrwl/nx/issues/new?template=1-bug.yml` and provide a reproduction.',
-        'You can still install your dependencies using full `npm install` that would override the pruned lockfile.',
-      ],
-    });
+      ].join('\n')
+    );
   } else {
     nestMappedPackages(
       invertedGraph,

--- a/packages/nx/src/lock-file/npm-parser.ts
+++ b/packages/nx/src/lock-file/npm-parser.ts
@@ -528,7 +528,7 @@ function nestMappedPackages(
     output.error({
       title: 'An error occured while creating pruned lockfile',
       bodyLines: [
-        'Your `npm ci` might fail due to missing dependencies in the lockfile. If this happens, please open an issue at `https://github.com/nrwl/nx/issues/new/choose` and provide a reproduction.',
+        '`npm ci` might fail due to missing dependencies in the lockfile. If this happens, please open an issue at `https://github.com/nrwl/nx/issues/new?template=1-bug.yml` and provide a reproduction.',
         'You can still install your dependencies using full `npm install` that would override the pruned lockfile.',
       ],
     });

--- a/packages/nx/src/lock-file/npm-parser.ts
+++ b/packages/nx/src/lock-file/npm-parser.ts
@@ -528,6 +528,8 @@ function nestMappedPackages(
     output.error({
       title: 'An error occured while creating pruned lockfile',
       bodyLines: [
+        'Following packages could not be mapped to the lockfile.',
+        ...Array.from(nestedNodes).map((n) => `- ${n.name}`),
         '`npm ci` might fail due to missing dependencies in the lockfile. If this happens, please open an issue at `https://github.com/nrwl/nx/issues/new?template=1-bug.yml` and provide a reproduction.',
         'You can still install your dependencies using full `npm install` that would override the pruned lockfile.',
       ],

--- a/packages/nx/src/lock-file/npm-parser.ts
+++ b/packages/nx/src/lock-file/npm-parser.ts
@@ -9,6 +9,7 @@ import {
 } from '../config/project-graph';
 import { NormalizedPackageJson } from './utils/package-json';
 import { defaultHashing } from '../hasher/hashing-impl';
+import { output } from '../devkit-exports';
 
 /**
  * NPM
@@ -524,7 +525,13 @@ function nestMappedPackages(
   });
 
   if (initialSize === nestedNodes.size) {
-    throw Error('Loop detected while pruning. Please report this issue.');
+    output.error({
+      title: 'An error occured while creating pruned lockfile',
+      bodyLines: [
+        'Your `npm ci` might fail due to missing dependencies in the lockfile. If this happens, please open an issue at `https://github.com/nrwl/nx/issues/new/choose` and provide a reproduction.',
+        'You can still install your dependencies using full `npm install` that would override the pruned lockfile.',
+      ],
+    });
   } else {
     nestMappedPackages(
       invertedGraph,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When npm stringification after pruning fails because some dependnecies could not be nested it throws an error, breaking the build.

## Expected Behavior
Lock file stringification error should not break the build. We should rather return existing (potentially functional) lock file and notify user of potential issue and how to overcome it.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
