### PR TITLE
chore(core): Update cacheable message for multiselect

### DIFF
--- a/packages/nx/src/nx-init/add-nx-to-npm-repo.ts
+++ b/packages/nx/src/nx-init/add-nx-to-npm-repo.ts
@@ -49,7 +49,7 @@ export async function addNxToNpmRepo() {
           type: 'multiselect',
           name: 'cacheableOperations',
           message:
-            'Which of the following scripts are cacheable? (Produce the same output given the same input, e.g. build, test and lint usually are, serve and start are not)',
+            'Which of the following scripts are cacheable? (Produce the same output given the same input, e.g. build, test and lint usually are, serve and start are not). You can use spacebar to select one or more scripts.',
           choices: scripts,
         },
       ])) as any


### PR DESCRIPTION
Whenever `npx nx init` runs at the cacheable operations selection there was no indicator message that instructs how to select.

This change adds the message that instructs how to select one or more choices

Screenshot:
![Screenshot 2023-02-24 at 2 26 54 PM](https://user-images.githubusercontent.com/338948/221296657-89876952-13d1-498b-836a-ec84eb57d4af.png)
