### PR TITLE
fix(linter): check for source package.json on banTransitiveDependencies

### DIFF
--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.ts
@@ -384,7 +384,10 @@ export default createESLintRule<Options, MessageIds>({
 
       // project => npm package
       if (targetProject.type === 'npm') {
-        if (banTransitiveDependencies && !isDirectDependency(targetProject)) {
+        if (
+          banTransitiveDependencies &&
+          !isDirectDependency(sourceProject, targetProject)
+        ) {
           context.report({
             node,
             messageId: 'noTransitiveDependencies',

--- a/packages/eslint-plugin-nx/src/utils/runtime-lint-utils.ts
+++ b/packages/eslint-plugin-nx/src/utils/runtime-lint-utils.ts
@@ -335,25 +335,38 @@ export function hasBannedDependencies(
     ]);
 }
 
-export function isDirectDependency(target: ProjectGraphExternalNode): boolean {
-  const fileName = 'package.json';
-  const content = readFileIfExisting(join(workspaceRoot, fileName));
+export function isDirectDependency(
+  source: ProjectGraphProjectNode,
+  target: ProjectGraphExternalNode
+): boolean {
+  return (
+    packageExistsInPackageJson(target.data.packageName, '.') ||
+    packageExistsInPackageJson(target.data.packageName, source.data.root)
+  );
+}
+
+function packageExistsInPackageJson(
+  packageName: string,
+  projectRoot: string
+): boolean {
+  const content = readFileIfExisting(
+    join(workspaceRoot, projectRoot, 'package.json')
+  );
   if (content) {
     const { dependencies, devDependencies, peerDependencies } =
       parseJson(content);
-    if (dependencies && dependencies[target.data.packageName]) {
+    if (dependencies && dependencies[packageName]) {
       return true;
     }
-    if (peerDependencies && peerDependencies[target.data.packageName]) {
+    if (peerDependencies && peerDependencies[packageName]) {
       return true;
     }
-    if (devDependencies && devDependencies[target.data.packageName]) {
+    if (devDependencies && devDependencies[packageName]) {
       return true;
     }
-    return false;
   }
 
-  return true;
+  return false;
 }
 
 /**


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
BanTransitiveDependencies only searches in the root `package.json`

## Expected Behavior
BanTransitiveDependencies should also check the source project for `package.json` in case of workspaces.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15129
