### PR TITLE
fix(core): improve running migrations for older workspaces

### DIFF
--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -353,7 +353,9 @@ export const commandsObject = yargs
     builder: (yargs) => withMigrationOptions(yargs),
     handler: async (args) =>
       process.exit(
-        await (await import('./migrate')).migrate(process.cwd(), args)
+        await (
+          await import('./migrate')
+        ).migrate(process.cwd(), args, process.argv.slice(3))
       ),
   })
   .command({


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Starting on Nx 15.7.0, Nx DevKit generators can only write to `project.json` files. When it comes to migrations, workspaces in older versions that are using the config format v1 and are migrating to a version lower than 15.7.0 have issues with any migration generators written with Nx DevKit and using `updateProjectConfiguration`. In those cases an error is thrown because the `project.json` file (expected by latest Nx) doesn't exist. This happens because migrations are always run with the latest version of Nx.
Workspaces migrating to a version lower than 13.9.0 don't get `@nrwl/tao` version bumped which is a package needed for those versions.
Workspaces using an Nx version older than 14.0.0 when migrating to a version higher than 14.0.0 don't get any package update unless the package is explicitly set in the command `nx migrate @nrwl/workspace@<version>`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Migrating a workspace to an older version than 15.7.0 should succeed. In those cases, the migrations would be run with the local installation of Nx.
The `@nrwl/tao` package should be updated when migrating to an older version of Nx where that package is required.
Migrating running `nx migrate latest` should work regardless of the version, explicitly specifying the package to update Nx should not be required.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15063 
Fixes #15141 
