### PR TITLE
fix(core): change error handling threshold on create-nx-workspace

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -1321,10 +1321,6 @@ function mapErrorToBodyLines(error: {
   return lines;
 }
 
-`>  NX   /Users/miro/Dev/Playground/angular is not an empty directory.
-  Pass --verbose to see the stacktrace.
-`;
-
 function execAndWait(command: string, cwd: string) {
   return new Promise((res, rej) => {
     exec(

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -1310,7 +1310,7 @@ function mapErrorToBodyLines(error: {
   code: number;
   logFile: string;
 }): string[] {
-  if (error.logMessage?.split('\n').filter((line) => !!line).length === 1) {
+  if (error.logMessage?.split('\n').filter((line) => !!line).length < 3) {
     // print entire log message only if it's only a single message
     return [`Error: ${error.logMessage}`];
   }
@@ -1320,6 +1320,10 @@ function mapErrorToBodyLines(error: {
   }
   return lines;
 }
+
+`>  NX   /Users/miro/Dev/Playground/angular is not an empty directory.
+  Pass --verbose to see the stacktrace.
+`;
 
 function execAndWait(command: string, cwd: string) {
   return new Promise((res, rej) => {


### PR DESCRIPTION
We have a check in place at `create-nx-workspace` that shows the error if error has just one line.
Unfortunately, recent changes in the nx core added additional `verbose` information to all the CLI errors so now minimal error has at least 2 (non-empty) lines:

```

 >  NX   /Users/miro/Dev/Playground/test is not an empty directory.

   Pass --verbose to see the stacktrace.

```

This breaks the previous behavior.

## Current Behavior
Even the most straightforward errors like "folder not empty" are abstracted away from user and written to log file.

## Expected Behavior
All one-liner error should be immediately shown to the user.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
