### PR TITLE
fix(bundling): libs generated with `@nrwl/js:lib --bundler rollup` should build

### DIFF
--- a/docs/generated/packages/rollup/executors/rollup.json
+++ b/docs/generated/packages/rollup/executors/rollup.json
@@ -158,7 +158,7 @@
         "default": false
       }
     },
-    "required": ["tsConfig", "project", "main", "outputPath"],
+    "required": ["tsConfig", "main", "outputPath"],
     "definitions": {
       "assetPattern": {
         "oneOf": [

--- a/docs/generated/packages/web/executors/rollup.json
+++ b/docs/generated/packages/web/executors/rollup.json
@@ -140,7 +140,7 @@
         "default": false
       }
     },
-    "required": ["tsConfig", "project", "entryFile", "outputPath"],
+    "required": ["tsConfig", "entryFile", "outputPath"],
     "definitions": {
       "assetPattern": {
         "oneOf": [

--- a/e2e/rollup/project.json
+++ b/e2e/rollup/project.json
@@ -7,5 +7,5 @@
     "e2e": {},
     "run-e2e-tests": {}
   },
-  "implicitDependencies": ["rollup"]
+  "implicitDependencies": ["rollup", "js"]
 }

--- a/e2e/rollup/src/rollup.test.ts
+++ b/e2e/rollup/src/rollup.test.ts
@@ -10,8 +10,8 @@ import {
 } from '@nrwl/e2e/utils';
 
 describe('Rollup Plugin', () => {
-  beforeEach(() => newProject());
-  afterEach(() => cleanupProject());
+  beforeAll(() => newProject());
+  afterAll(() => cleanupProject());
 
   it('should be able to setup project to build node programs with rollup and different compilers', async () => {
     const myPkg = uniq('my-pkg');
@@ -55,4 +55,10 @@ describe('Rollup Plugin', () => {
     output = runCommand(`node dist/libs/${myPkg}/index.cjs`);
     expect(output).toMatch(/Hello/);
   }, 500000);
+
+  it('should be able to build libs generated with @nrwl/js:lib --bundler rollup', () => {
+    const jsLib = uniq('jslib');
+    runCLI(`generate @nrwl/js:lib ${jsLib} --bundler rollup`);
+    expect(() => runCLI(`build ${jsLib}`)).not.toThrow();
+  });
 });

--- a/packages/rollup/src/executors/rollup/schema.json
+++ b/packages/rollup/src/executors/rollup/schema.json
@@ -139,7 +139,7 @@
       "default": false
     }
   },
-  "required": ["tsConfig", "project", "main", "outputPath"],
+  "required": ["tsConfig", "main", "outputPath"],
   "definitions": {
     "assetPattern": {
       "oneOf": [

--- a/packages/web/src/executors/rollup/schema.json
+++ b/packages/web/src/executors/rollup/schema.json
@@ -121,7 +121,7 @@
       "default": false
     }
   },
-  "required": ["tsConfig", "project", "entryFile", "outputPath"],
+  "required": ["tsConfig", "entryFile", "outputPath"],
   "definitions": {
     "assetPattern": {
       "oneOf": [


### PR DESCRIPTION
## Current Behavior
```
> npx create-nx-workspace@latest test-npm-dep
- Integrated Monorepo
- Apps
- No Nx Cloud

> cd test-npm-dep
> npm i -d @nrwl/js @nrwl/rollup
> nx g lib --bundler rollup test-lib-1
> nx build test-lib-1 // This failed? WTF. 
```

>  \>  NX   Required property 'project' is missing

## Expected Behavior
Generated library is buildable

## Notes
Issue was noted as fixed by #14971, but schema still lists the property as required.
