### PR TITLE
fix(js): generate correct build options for rollup bundler; by defaul…

### DIFF
--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -810,6 +810,35 @@ describe('lib', () => {
       });
     });
 
+    describe('bundler=rollup', () => {
+      it('should generate correct options for build', async () => {
+        await libraryGenerator(tree, {
+          ...defaultOptions,
+          name: 'myLib',
+          buildable: true,
+          bundler: 'rollup',
+        });
+
+        const config = readProjectConfiguration(tree, 'my-lib');
+        expect(config.targets.build.options.project).toEqual(
+          `libs/my-lib/package.json`
+        );
+      });
+
+      it('should set compiler to swc', async () => {
+        await libraryGenerator(tree, {
+          ...defaultOptions,
+          name: 'myLib',
+          buildable: true,
+          bundler: 'rollup',
+          compiler: 'swc',
+        });
+
+        const config = readProjectConfiguration(tree, 'my-lib');
+        expect(config.targets.build.options.compiler).toEqual('swc');
+      });
+    });
+
     describe('--publishable', () => {
       it('should generate the build target', async () => {
         await libraryGenerator(tree, {

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -83,7 +83,7 @@ export async function projectGenerator(
     });
     tasks.push(viteTask);
   }
-  if (schema.bundler === 'rollup') {
+  if (options.bundler === 'rollup') {
     ensureBabelRootConfigExists(tree);
   }
 
@@ -159,6 +159,13 @@ function addProject(
           options.bundler === 'rollup' ? [] : [`${options.projectRoot}/*.md`],
       },
     };
+
+    if (options.bundler === 'rollup') {
+      projectConfiguration.targets.build.options.project = `${options.projectRoot}/package.json`;
+      if (options.compiler === 'swc') {
+        projectConfiguration.targets.build.options.compiler = 'swc';
+      }
+    }
 
     if (options.compiler === 'swc' && options.skipTypeCheck) {
       projectConfiguration.targets.build.options.skipTypeCheck = true;


### PR DESCRIPTION
…t and with swc compiler

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Generate a library with `--bundle=rollup` fails `nx build lib-name` due to misconfigured `build#options`.
Generate a library with `--bundle=rollup --compiler=swc` does not use `swc` plugin from `rollup:rollup`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Generate the correct build options and use `swc` plugin if `--compiler=swc` is passed in when generating a library with `--bundle=rollup`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
