### PR TITLE
chore(storybook): remove typecast if not viteFinal

### DIFF
--- a/packages/storybook/src/generators/configuration/__snapshots__/configuration-nested.spec.ts.snap
+++ b/packages/storybook/src/generators/configuration/__snapshots__/configuration-nested.spec.ts.snap
@@ -83,7 +83,7 @@ const config: StorybookConfig = {
     
     
   ]
-} as StorybookConfig;
+};
 
 module.exports = config;
 

--- a/packages/storybook/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/storybook/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -493,7 +493,7 @@ const config: StorybookConfig = {
     
     
   ]
-} as StorybookConfig;
+};
 
 module.exports = config;
 
@@ -548,7 +548,7 @@ const config: StorybookConfig = {
     
     
   ]
-} as StorybookConfig;
+};
 
 module.exports = config;
 
@@ -610,7 +610,7 @@ const config: StorybookConfig = {
     }
      
   ]
-} as StorybookConfig;
+};
 
 module.exports = config;
 
@@ -665,7 +665,7 @@ const config: StorybookConfig = {
     
     
   ]
-} as StorybookConfig;
+};
 
 module.exports = config;
 
@@ -720,7 +720,7 @@ const config: StorybookConfig = {
     , 'storybook-addon-swc' 
     
   ]
-} as StorybookConfig;
+};
 
 module.exports = config;
 
@@ -775,7 +775,7 @@ const config: StorybookConfig = {
     
     
   ]
-} as StorybookConfig;
+};
 
 module.exports = config;
 

--- a/packages/storybook/src/generators/configuration/project-files-ts/.storybook/main.ts__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files-ts/.storybook/main.ts__tmpl__
@@ -32,7 +32,7 @@ const config: StorybookConfig = {
       ],
     });
   },<% } %>
-} as StorybookConfig;
+}<% if (usesVite) { %> as StorybookConfig<% } %>;
 
 module.exports = config;
 


### PR DESCRIPTION
Storybook v6.5 `StorybookConfig` type has a bug, it does not contain `viteFinal`. For that reason, when `viteFinal` is used, we need to typecast. If `viteFinal` is not used, then don't typecast.
