### PR TITLE
fix(core): handle positional args correctly for run command

### DIFF
--- a/e2e/nx-run/src/run.test.ts
+++ b/e2e/nx-run/src/run.test.ts
@@ -178,6 +178,13 @@ describe('Nx Running Tests', () => {
       runCLI(`build ${myapp}`);
     }, 10000);
 
+    it('should support project name positional arg non-consecutive to target', () => {
+      const myapp = uniq('app');
+      runCLI(`generate @nrwl/web:app ${myapp}`);
+
+      runCLI(`build --verbose ${myapp}`);
+    }, 10000);
+
     it('should run targets from package json', () => {
       const myapp = uniq('app');
       const target = uniq('script');

--- a/packages/nx/bin/init-local.ts
+++ b/packages/nx/bin/init-local.ts
@@ -82,15 +82,35 @@ export function rewriteTargetsAndProjects(args: string[]) {
 }
 
 function rewritePositionalArguments(args: string[]) {
-  if (!args[3] || args[3].startsWith('-')) {
-    return ['run', `${wrapIntoQuotesIfNeeded(args[2])}`, ...args.slice(3)];
-  } else {
+  const relevantPositionalArgs = [];
+  const rest = [];
+  for (let i = 2; i < args.length; i++) {
+    if (!args[i].startsWith('-')) {
+      relevantPositionalArgs.push(args[i]);
+      if (relevantPositionalArgs.length === 2) {
+        rest.push(...args.slice(i + 1));
+        break;
+      }
+    } else {
+      rest.push(args[i]);
+    }
+  }
+
+  if (relevantPositionalArgs.length === 1) {
     return [
       'run',
-      `${args[3]}:${wrapIntoQuotesIfNeeded(args[2])}`,
-      ...args.slice(4),
+      `${wrapIntoQuotesIfNeeded(relevantPositionalArgs[0])}`,
+      ...rest,
     ];
   }
+
+  return [
+    'run',
+    `${relevantPositionalArgs[1]}:${wrapIntoQuotesIfNeeded(
+      relevantPositionalArgs[0]
+    )}`,
+    ...rest,
+  ];
 }
 
 function wrapIntoQuotesIfNeeded(arg: string) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The positional args rewrite done for the `run` command only supports consecutive positional args for the project name.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The positional args rewrite done for the `run` command should handle non-consecutive positional args for the project name.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15015 
