### PR TITLE
fix(react): do not install webpack and jest when cra-to-nx is using vite

### DIFF
--- a/e2e/cra-to-nx/src/cra-to-nx.test.ts
+++ b/e2e/cra-to-nx/src/cra-to-nx.test.ts
@@ -29,6 +29,11 @@ describe('nx init (for CRA)', () => {
 
     expect(craToNxOutput).toContain('🎉 Done!');
 
+    const packageJson = readJson('package.json');
+    expect(packageJson.devDependencies['@nrwl/jest']).toBeDefined();
+    expect(packageJson.devDependencies['@nrwl/vite']).toBeUndefined();
+    expect(packageJson.devDependencies['@nrwl/webpack']).toBeDefined();
+
     runCLI(`build ${appName}`);
     checkFilesExist(`dist/apps/${appName}/index.html`);
   });
@@ -48,6 +53,11 @@ describe('nx init (for CRA)', () => {
     );
 
     expect(craToNxOutput).toContain('🎉 Done!');
+
+    const packageJson = readJson('package.json');
+    expect(packageJson.devDependencies['@nrwl/jest']).toBeUndefined();
+    expect(packageJson.devDependencies['@nrwl/vite']).toBeDefined();
+    expect(packageJson.devDependencies['@nrwl/webpack']).toBeUndefined();
 
     const viteConfig = readFile(`apps/${appName}/vite.config.js`);
     expect(viteConfig).toContain('port: 4200'); // default port

--- a/packages/cra-to-nx/src/lib/cra-to-nx.ts
+++ b/packages/cra-to-nx/src/lib/cra-to-nx.ts
@@ -130,7 +130,6 @@ async function reorgnizeWorkspaceStructure(options: NormalizedOptions) {
 
   if (options.isVite) {
     addDependencies(options.pmc, 'vite', 'vitest', '@vitejs/plugin-react');
-    removeDependencies(options.pmc, '@nrwl/jest');
   } else {
     addDependencies(
       options.pmc,
@@ -184,9 +183,11 @@ function createTempWorkspace(options: NormalizedOptions) {
       options.npxYesFlagNeeded ? '-y' : ''
     } create-nx-workspace@latest temp-workspace --appName=${
       options.reactAppName
-    } --preset=react-monorepo --style=css --bundler=webpack --packageManager=${
-      options.packageManager
-    } ${options.nxCloud ? '--nxCloud' : '--nxCloud=false'}`,
+    } --preset=react-monorepo --style=css --bundler=${
+      options.isVite ? 'vite' : 'webpack'
+    } --packageManager=${options.packageManager} ${
+      options.nxCloud ? '--nxCloud' : '--nxCloud=false'
+    }`,
     { stdio: [0, 1, 2] }
   );
 

--- a/packages/vite/src/utils/vite-config-edit-utils.ts
+++ b/packages/vite/src/utils/vite-config-edit-utils.ts
@@ -1,7 +1,7 @@
 import { applyChangesToString, ChangeType, Tree } from '@nrwl/devkit';
 import { findNodes } from 'nx/src/utils/typescript';
-import ts = require('typescript');
-import { tsquery } from '@phenomnomnominal/tsquery';
+import type * as ts from 'typescript';
+
 import { TargetFlags } from './generator-utils';
 
 export function ensureViteConfigIsCorrect(
@@ -66,6 +66,7 @@ function handleBuildOrTestNode(
   configContentObject: {},
   name: 'build' | 'test'
 ): string | undefined {
+  const { tsquery } = require('@phenomnomnominal/tsquery');
   const buildNode = tsquery.query(
     updatedFileContent,
     `PropertyAssignment:has(Identifier[name="${name}"])`
@@ -166,6 +167,7 @@ function transformCurrentBuildObject(
   if (!returnStatements?.[index]) {
     return undefined;
   }
+  const { tsquery } = require('@phenomnomnominal/tsquery');
   const currentBuildObject = tsquery
     .query(returnStatements[index], 'ObjectLiteralExpression')?.[0]
     .getText();
@@ -205,6 +207,8 @@ function transformConditionalConfig(
   appFileContent: string,
   buildConfigObject: {}
 ): string | undefined {
+  const { tsquery } = require('@phenomnomnominal/tsquery');
+  const { SyntaxKind } = require('typescript');
   const functionBlock = tsquery.query(conditionalConfig[0], 'Block');
 
   const ifStatement = tsquery.query(functionBlock?.[0], 'IfStatement');
@@ -223,10 +227,7 @@ function transformConditionalConfig(
     (binaryExpression) => binaryExpression.getText() === `command === 'serve'`
   );
 
-  const elseKeywordExists = findNodes(
-    ifStatement?.[0],
-    ts.SyntaxKind.ElseKeyword
-  );
+  const elseKeywordExists = findNodes(ifStatement?.[0], SyntaxKind.ElseKeyword);
   const returnStatements: ts.ReturnStatement[] = tsquery.query(
     ifStatement[0],
     'ReturnStatement'
@@ -282,6 +283,8 @@ function handlePluginNode(
   dtsImportLine: string,
   pluginOption: string
 ): string | undefined {
+  const { tsquery } = require('@phenomnomnominal/tsquery');
+
   const file = tsquery.ast(appFileContent);
   const pluginsNode = tsquery.query(
     file,
@@ -382,6 +385,8 @@ function handlePluginNode(
 }
 
 function handleCacheDirNode(appFileContent: string, cacheDir: string): string {
+  const { tsquery } = require('@phenomnomnominal/tsquery');
+
   const file = tsquery.ast(appFileContent);
   const cacheDirNode = tsquery.query(
     file,


### PR DESCRIPTION
This PR fixes the `npx nx init` command when converting CRA apps to Vite. 

Note: I also had to update vite config generator so TS is required when used.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Running `npx nx init` in CRA app results in webpack and jest being installed.

## Expected Behavior
Running `npx nx init` should only install vite.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
