### PR TITLE
docs(webpack): fix withWeb plugin generateIndexHtml option description

### DIFF
--- a/docs/generated/packages/webpack/documents/webpack-plugins.md
+++ b/docs/generated/packages/webpack/documents/webpack-plugins.md
@@ -69,7 +69,7 @@ Extract CSS into a `.css` file.
 
 Type: `boolean`
 
-Generates a `package.json` and pruned lock file with the project's `node_module` dependencies populated for installing in a container. If a `package.json` exists in the project's directory, it will be reused with dependencies populated.
+Generates `index.html` file to the output path. This can be turned off if using a webpack plugin to generate HTML such as `html-webpack-plugin`.
 
 #### index
 

--- a/docs/shared/packages/webpack/webpack-plugins.md
+++ b/docs/shared/packages/webpack/webpack-plugins.md
@@ -69,7 +69,7 @@ Extract CSS into a `.css` file.
 
 Type: `boolean`
 
-Generates a `package.json` and pruned lock file with the project's `node_module` dependencies populated for installing in a container. If a `package.json` exists in the project's directory, it will be reused with dependencies populated.
+Generates `index.html` file to the output path. This can be turned off if using a webpack plugin to generate HTML such as `html-webpack-plugin`.
 
 #### index
 


### PR DESCRIPTION
## Current Behavior
The [documentation](https://nx.dev/packages/webpack/documents/webpack-plugins#generateindexhtml) for the `generateIndexHtml` option of the withWeb Webpack plugin has the description of `generatePackageJson`.

## Expected Behavior
The `generateIndexHtml` option has the correct description.


