### PR TITLE
fix(core): prevent duplicated migration prompts

### DIFF
--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -92,6 +92,7 @@
   "nx-migrations": {
     "migrations": "./migrations.json",
     "packageGroup": [
+      "@nrwl/js",
       "@nrwl/jest",
       "@nrwl/linter",
       "@nrwl/workspace",
@@ -104,7 +105,6 @@
       "@nrwl/eslint-plugin-nx",
       "@nrwl/expo",
       "@nrwl/express",
-      "@nrwl/js",
       "@nrwl/nest",
       "@nrwl/next",
       "@nrwl/node",

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -33,6 +33,7 @@
     "requirements": {},
     "migrations": "./migrations.json",
     "packageGroup": {
+      "@nrwl/js": "*",
       "@nrwl/jest": "*",
       "@nrwl/linter": "*",
       "@nrwl/angular": "*",
@@ -44,7 +45,6 @@
       "@nrwl/eslint-plugin-nx": "*",
       "@nrwl/expo": "*",
       "@nrwl/express": "*",
-      "@nrwl/js": "*",
       "@nrwl/nest": "*",
       "@nrwl/next": "*",
       "@nrwl/node": "*",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When a package update with prompts is duplicated, multiple prompts are shown to the user when migrating.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When a package update with prompts is duplicated, as long as the definition of the package update is the same, a single prompt is shown to the user when migrating.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
