### PR TITLE
fix(testing): automatically enable coverage with --coverage flag for vitest

### DIFF
--- a/packages/vite/src/executors/test/schema.d.ts
+++ b/packages/vite/src/executors/test/schema.d.ts
@@ -7,4 +7,5 @@ export interface VitestExecutorOptions {
   watch?: boolean;
   update?: boolean;
   reportsDirectory?: string;
+  coverage?: boolean;
 }


### PR DESCRIPTION
vitest settings requires enabled = true when to turn on code coverage 
automatically set enabled = true when --coverage flag is passed so it is not required to be the vite.config.ts
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
using --coverage does not enable coverage.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
using --coverage turns on vitest coverage

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14835
