### PR TITLE
fix(js): use .swcrc for swcrc path for swc lib

### DIFF
--- a/docs/generated/packages/js/executors/swc.json
+++ b/docs/generated/packages/js/executors/swc.json
@@ -29,7 +29,7 @@
       },
       "swcrc": {
         "type": "string",
-        "description": "The path to the SWC configuration file. Default: .lib.swcrc",
+        "description": "The path to the SWC configuration file. Default: .swcrc",
         "x-completion-type": "file",
         "x-completion-glob": ".swcrc"
       },

--- a/e2e/js/src/js-swc.test.ts
+++ b/e2e/js/src/js-swc.test.ts
@@ -85,7 +85,7 @@ describe('js e2e', () => {
     runCLI(`build ${parentLib}`);
     checkFilesExist(`dist/libs/${parentLib}/package.json`);
 
-    updateJson(`libs/${lib}/.lib.swcrc`, (json) => {
+    updateJson(`libs/${lib}/.swcrc`, (json) => {
       json.jsc.externalHelpers = true;
       return json;
     });
@@ -105,7 +105,7 @@ describe('js e2e', () => {
 
     expect(swcHelpersFromDist).toEqual(swcHelpersFromRoot);
 
-    updateJson(`libs/${lib}/.lib.swcrc`, (json) => {
+    updateJson(`libs/${lib}/.swcrc`, (json) => {
       json.jsc.externalHelpers = false;
       return json;
     });

--- a/packages/js/migrations.json
+++ b/packages/js/migrations.json
@@ -29,6 +29,12 @@
       "version": "14.1.5-beta.0",
       "description": "Rename option swcrcPath to swcrc, and resolve relative to workspace root",
       "factory": "./src/migrations/update-14-1-5/update-swcrc-path"
+    },
+    "rename-swcrc-config": {
+      "cli": "nx",
+      "version": "15.8.1-beta.0",
+      "description": "Rename .lib.swcrc to .swcrc for better SWC support throughout the workspace",
+      "factory": "./src/migrations/update-15-8-1/rename-swcrc-config"
     }
   },
   "packageJsonUpdates": {

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -41,6 +41,7 @@
     "@babel/runtime": "^7.14.8",
     "@nrwl/devkit": "file:../devkit",
     "@nrwl/workspace": "file:../workspace",
+    "@phenomnomnominal/tsquery": "4.1.1",
     "babel-plugin-const-enum": "^1.0.1",
     "babel-plugin-macros": "^2.8.0",
     "babel-plugin-transform-typescript-metadata": "^0.3.1",

--- a/packages/js/src/executors/swc/schema.json
+++ b/packages/js/src/executors/swc/schema.json
@@ -26,7 +26,7 @@
     },
     "swcrc": {
       "type": "string",
-      "description": "The path to the SWC configuration file. Default: .lib.swcrc",
+      "description": "The path to the SWC configuration file. Default: .swcrc",
       "x-completion-type": "file",
       "x-completion-glob": ".swcrc"
     },

--- a/packages/js/src/generators/convert-to-swc/convert-to-swc.spec.ts
+++ b/packages/js/src/generators/convert-to-swc/convert-to-swc.spec.ts
@@ -45,7 +45,7 @@ describe('convert to swc', () => {
     ).toEqual('@nrwl/js:swc');
     expect(
       tree.exists(
-        join(readProjectConfiguration(tree, 'tsc-lib').root, '.lib.swcrc')
+        join(readProjectConfiguration(tree, 'tsc-lib').root, '.swcrc')
       )
     ).toEqual(true);
     expect(tree.read('package.json', 'utf-8')).toContain('@swc/core');

--- a/packages/js/src/generators/convert-to-swc/convert-to-swc.ts
+++ b/packages/js/src/generators/convert-to-swc/convert-to-swc.ts
@@ -62,9 +62,7 @@ function checkSwcDependencies(
   tree: Tree,
   projectConfiguration: ProjectConfiguration
 ) {
-  const isSwcrcPresent = tree.exists(
-    join(projectConfiguration.root, '.lib.swcrc')
-  );
+  const isSwcrcPresent = tree.exists(join(projectConfiguration.root, '.swcrc'));
 
   const packageJson = readJson(tree, 'package.json');
   const projectPackageJsonPath = join(
@@ -93,9 +91,7 @@ function checkSwcDependencies(
   if (!hasSwcHelpers) {
     addDependenciesToPackageJson(
       tree,
-      {
-        '@swc/helpers': swcHelpersVersion,
-      },
+      { '@swc/helpers': swcHelpersVersion },
       {},
       projectPackageJsonPath
     );

--- a/packages/js/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/js/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -7,8 +7,15 @@ const { readFileSync } = require('fs')
 // Reading the SWC compilation config and remove the \\"exclude\\"
 // for the test files to be compiled by SWC
 const { exclude: _, ...swcJestConfig } = JSON.parse(
-  readFileSync(\`\${__dirname}/.lib.swcrc\`, 'utf-8')
+  readFileSync(\`\${__dirname}/.swcrc\`, 'utf-8')
 );
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to \\"exclude\\"
+if (swcJestConfig.swcrc === undefined) {
+    swcJestConfig.swcrc = false;
+}
+
 module.exports = {
   displayName: 'my-lib',
   preset: '../../jest.preset.js',

--- a/packages/js/src/generators/library/files/jest-config/jest.config.__ext__
+++ b/packages/js/src/generators/library/files/jest-config/jest.config.__ext__
@@ -4,8 +4,15 @@
 // Reading the SWC compilation config and remove the "exclude"
 // for the test files to be compiled by SWC
 const { exclude: _, ...swcJestConfig } = JSON.parse(
-  readFileSync(`${__dirname}/.lib.swcrc`, 'utf-8')
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
 );
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+    swcJestConfig.swcrc = false;
+}
+
 <% if(js) {%>module.exports =<% } else { %>export default<% } %> {
   displayName: '<%= project %>',
   preset: '<%= offsetFromRoot %>jest.preset.js',

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -778,7 +778,7 @@ describe('lib', () => {
           compiler: 'swc',
         });
 
-        expect(tree.exists('libs/my-lib/.lib.swcrc')).toBeTruthy();
+        expect(tree.exists('libs/my-lib/.swcrc')).toBeTruthy();
       });
 
       it('should setup jest project using swc', async () => {

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -91,6 +91,7 @@ export async function projectGenerator(
     const lintCallback = await addLint(tree, options);
     tasks.push(lintCallback);
   }
+
   if (options.unitTestRunner === 'jest') {
     const jestCallback = await addJest(tree, options);
     tasks.push(jestCallback);
@@ -268,7 +269,11 @@ function createFiles(tree: Tree, options: NormalizedSchema, filesDir: string) {
 
   if (options.compiler === 'swc') {
     addSwcDependencies(tree);
-    addSwcConfig(tree, options.projectRoot);
+    addSwcConfig(
+      tree,
+      options.projectRoot,
+      options.bundler === 'rollup' ? 'es6' : 'commonjs'
+    );
   } else if (options.includeBabelRc) {
     addBabelRc(tree, options);
   }

--- a/packages/js/src/migrations/update-15-8-1/rename-swcrc-config.spec.ts
+++ b/packages/js/src/migrations/update-15-8-1/rename-swcrc-config.spec.ts
@@ -1,0 +1,104 @@
+import {
+  readProjectConfiguration,
+  Tree,
+  updateProjectConfiguration,
+} from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { libraryGenerator } from '../../generators/library/library';
+import renameSwcrcConfig from './rename-swcrc-config';
+
+describe('Rename swcrc file migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  });
+
+  it('should migrate .lib.swcrc to .swcrc', async () => {
+    await setup(tree);
+    await renameSwcrcConfig(tree);
+
+    expect(tree.exists('libs/my-lib/.lib.swcrc')).toBeFalsy();
+    expect(tree.exists('libs/my-lib/.swcrc')).toBeTruthy();
+
+    const jestConfig = tree.read('libs/my-lib/jest.config.ts', 'utf-8');
+    expect(jestConfig).toContain(`fs.readFileSync(\`\${__dirname}/.swcrc\``);
+    expect(jestConfig).toContain('swcJestConfig.swcrc = false');
+  });
+
+  it('should migrate custom path .lib.swcrc', async () => {
+    await setup(tree);
+    customSwcrcPath(tree);
+
+    await renameSwcrcConfig(tree);
+
+    expect(tree.exists('libs/my-lib/src/.lib.swcrc')).toBeFalsy();
+    expect(tree.exists('libs/my-lib/src/.swcrc')).toBeTruthy();
+
+    const projectConfig = readProjectConfiguration(tree, 'my-lib');
+    expect(projectConfig.targets.build.options.swcrc).toEqual(
+      'libs/my-lib/src/.swcrc'
+    );
+  });
+
+  it('should do nothing if custom path swcrc is not named .lib.swcrc', async () => {
+    await setup(tree);
+    customSwcrcPath(tree, true);
+
+    await renameSwcrcConfig(tree);
+
+    expect(tree.exists('libs/my-lib/src/.custom.swcrc')).toBeTruthy();
+    expect(tree.exists('libs/my-lib/src/.swcrc')).toBeFalsy();
+
+    const projectConfig = readProjectConfiguration(tree, 'my-lib');
+    expect(projectConfig.targets.build.options.swcrc).toEqual(
+      'libs/my-lib/src/.custom.swcrc'
+    );
+  });
+});
+
+async function setup(tree: Tree) {
+  await libraryGenerator(tree, {
+    name: 'my-lib',
+    compiler: 'swc',
+    unitTestRunner: 'jest',
+    buildable: true,
+    config: 'project',
+  });
+
+  tree.rename('libs/my-lib/.swcrc', 'libs/my-lib/.lib.swcrc');
+  tree.write(
+    'libs/my-lib/jest.config.ts',
+    `
+const fs = require('fs');
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  fs.readFileSync(\`\${__dirname}/.lib.swcrc\`, 'utf-8')
+);
+
+module.exports = {
+  displayName: 'my-lib',
+  preset: '../../jest.preset.js',
+  transform: {
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../coverage/packages/vite',
+};
+`
+  );
+}
+
+function customSwcrcPath(tree: Tree, custom = false) {
+  tree.rename(
+    'libs/my-lib/.lib.swcrc',
+    custom ? 'libs/my-lib/src/.custom.swcrc' : 'libs/my-lib/src/.lib.swcrc'
+  );
+  const projectConfig = readProjectConfiguration(tree, 'my-lib');
+  projectConfig.targets.build.options.swcrc = custom
+    ? 'libs/my-lib/src/.custom.swcrc'
+    : 'libs/my-lib/src/.lib.swcrc';
+  updateProjectConfiguration(tree, 'my-lib', projectConfig);
+}

--- a/packages/js/src/migrations/update-15-8-1/rename-swcrc-config.ts
+++ b/packages/js/src/migrations/update-15-8-1/rename-swcrc-config.ts
@@ -1,0 +1,119 @@
+import {
+  formatFiles,
+  getProjects,
+  joinPathFragments,
+  Tree,
+  updateProjectConfiguration,
+} from '@nrwl/devkit';
+import { forEachExecutorOptions } from '@nrwl/workspace/src/utilities/executor-options-utils';
+import { SwcExecutorOptions } from '../../utils/schema';
+import { tsquery } from '@phenomnomnominal/tsquery';
+import type { TemplateSpan } from 'typescript';
+
+export default async function (tree: Tree) {
+  let changesMade = false;
+  const projects = getProjects(tree);
+
+  forEachExecutorOptions(
+    tree,
+    '@nrwl/js:swc',
+    (_, projectName, target, configurationName) => {
+      const projectConfiguration = projects.get(projectName);
+      const executorOptions: SwcExecutorOptions = configurationName
+        ? projectConfiguration.targets[target].configurations[configurationName]
+        : projectConfiguration.targets[target].options;
+      // if the project uses a custom path to swcrc file
+      // and only if it's the default name
+      if (
+        executorOptions.swcrc &&
+        executorOptions.swcrc.includes('.lib.swcrc')
+      ) {
+        const newSwcrc = executorOptions.swcrc.replace('.lib.swcrc', '.swcrc');
+        // rename the swcrc file first
+        tree.rename(executorOptions.swcrc, newSwcrc);
+        // then update the executor options
+        executorOptions.swcrc = newSwcrc;
+        changesMade = true;
+      }
+
+      const libSwcrcPath =
+        joinPathFragments(projectConfiguration.root, '.lib.swcrc') ||
+        joinPathFragments(projectConfiguration.sourceRoot, '.lib.swcrc');
+      const isLibSwcrcExist = tree.exists(libSwcrcPath);
+
+      if (isLibSwcrcExist) {
+        tree.rename(libSwcrcPath, libSwcrcPath.replace('.lib.swcrc', '.swcrc'));
+        changesMade = true;
+      }
+
+      updateProjectConfiguration(tree, projectName, projectConfiguration);
+    }
+  );
+
+  forEachExecutorOptions(
+    tree,
+    '@nrwl/jest:jest',
+    (_, projectName, target, configurationName) => {
+      const projectConfiguration = projects.get(projectName);
+      const executorOptions = configurationName
+        ? projectConfiguration.targets[target].configurations[configurationName]
+        : projectConfiguration.targets[target].options;
+
+      const isJestConfigExist =
+        executorOptions.jestConfig && tree.exists(executorOptions.jestConfig);
+
+      if (isJestConfigExist) {
+        const jestConfig = tree.read(executorOptions.jestConfig, 'utf-8');
+
+        const jsonParseNodes = tsquery.query(
+          jestConfig,
+          ':matches(CallExpression:has(Identifier[name="JSON"]):has(Identifier[name="parse"]))'
+        );
+
+        if (jsonParseNodes.length) {
+          // if we already assign false to swcrc, skip
+          if (jestConfig.includes('.swcrc = false')) {
+            return;
+          }
+
+          let updatedJestConfig = tsquery.replace(
+            jestConfig,
+            'CallExpression:has(Identifier[name="JSON"]):has(Identifier[name="parse"]) TemplateSpan',
+            (templateSpan: TemplateSpan) => {
+              if (templateSpan.literal.text === '/.lib.swcrc') {
+                return templateSpan
+                  .getFullText()
+                  .replace('.lib.swcrc', '.swcrc');
+              }
+              return '';
+            }
+          );
+
+          updatedJestConfig = tsquery.replace(
+            updatedJestConfig,
+            ':matches(ExportAssignment, BinaryExpression:has(Identifier[name="module"]):has(Identifier[name="exports"]))',
+            (node) => {
+              return `
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+${node.getFullText()}
+`;
+            }
+          );
+
+          tree.write(executorOptions.jestConfig, updatedJestConfig);
+          changesMade = true;
+        }
+      }
+    }
+  );
+
+  if (changesMade) {
+    await formatFiles(tree);
+  }
+}

--- a/packages/js/src/utils/swc/add-swc-config.ts
+++ b/packages/js/src/utils/swc/add-swc-config.ts
@@ -12,7 +12,7 @@ export const defaultExclude = [
   '.*.js$',
 ];
 
-const swcOptionsString = () => `{
+const swcOptionsString = (type: 'commonjs' | 'es6' = 'commonjs') => `{
   "jsc": {
     "target": "es2017",
     "parser": {
@@ -29,7 +29,7 @@ const swcOptionsString = () => `{
     "loose": true
   },
   "module": {
-    "type": "commonjs",
+    "type": "${type}",
     "strict": true,
     "noInterop": true
   },
@@ -37,8 +37,12 @@ const swcOptionsString = () => `{
   "exclude": ${JSON.stringify(defaultExclude)}
 }`;
 
-export function addSwcConfig(tree: Tree, projectDir: string) {
-  const swcrcPath = join(projectDir, '.lib.swcrc');
+export function addSwcConfig(
+  tree: Tree,
+  projectDir: string,
+  type: 'commonjs' | 'es6' = 'commonjs'
+) {
+  const swcrcPath = join(projectDir, '.swcrc');
   if (tree.exists(swcrcPath)) return;
-  tree.write(swcrcPath, swcOptionsString());
+  tree.write(swcrcPath, swcOptionsString(type));
 }

--- a/packages/js/src/utils/swc/get-swcrc-path.ts
+++ b/packages/js/src/utils/swc/get-swcrc-path.ts
@@ -8,5 +8,5 @@ export function getSwcrcPath(
 ) {
   return options.swcrc
     ? join(contextRoot, options.swcrc)
-    : join(contextRoot, projectRoot, '.lib.swcrc');
+    : join(contextRoot, projectRoot, '.swcrc');
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Use a custom `.lib.swcrc` for SWC config file in `js:lib`. This was done because there was no way to stop swc to look up `.swcrc` leading to tests not working because we're excluding test files by default.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Use standard `.swcrc` and disable swc config file lookup with `swcrc: false` where it makes sense. This enables the swc toolings to work better.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #13093
