### PR TITLE
fix(nextjs): typo in next.config.js__tmpl__

### DIFF
--- a/packages/next/src/generators/application/files/next.config.js__tmpl__
+++ b/packages/next/src/generators/application/files/next.config.js__tmpl__
@@ -60,7 +60,7 @@ module.exports = withNx(nextConfig);
  **/
 const nextConfig = {
   nx: {
-    // Set this to true if you would like to to use SVGR
+    // Set this to true if you would like to use SVGR
     // See: https://github.com/gregberge/svgr
     svgr: false,
   },


### PR DESCRIPTION
Remove extra "to " in SVGR comment copy in next.config.js generator template file.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
