### PR TITLE
chore(core): disable js code analysis when typescript is not installed

### DIFF
--- a/packages/nx/src/project-graph/build-dependencies/build-explicit-typescript-and-package-json-dependencies.ts
+++ b/packages/nx/src/project-graph/build-dependencies/build-explicit-typescript-and-package-json-dependencies.ts
@@ -18,9 +18,17 @@ export function buildExplicitTypescriptAndPackageJsonDependencies(
   filesToProcess: ProjectFileMap
 ) {
   let res: ExplicitDependency[] = [];
+
+  let typescriptExists = false;
+
+  try {
+    require.resolve('typescript');
+    typescriptExists = true;
+  } catch {}
   if (
-    jsPluginConfig.analyzeSourceFiles === undefined ||
-    jsPluginConfig.analyzeSourceFiles === true
+    typescriptExists &&
+    (jsPluginConfig.analyzeSourceFiles === undefined ||
+      jsPluginConfig.analyzeSourceFiles === true)
   ) {
     res = res.concat(
       buildExplicitTypeScriptDependencies(projectGraph, filesToProcess)


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

JS Code analysis needs typescript so it throws an error when typescript is not installed.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

JS Code analysis is disabled when typescript is not installed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
