### PR TITLE
fix(angular): give informative log when `@Component styleUrls` names …

### DIFF
--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/styles/stylesheet-processor.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/styles/stylesheet-processor.ts
@@ -108,6 +108,10 @@ export class StylesheetProcessor {
   }): Promise<string> {
     let key: string | undefined;
 
+    if (content === undefined) {
+      return undefined;
+    }
+
     if (
       this.cacheDirectory &&
       !content.includes('@import') &&

--- a/packages/angular/src/executors/package/ng-packagr-adjustments/styles/stylesheet-processor.ts
+++ b/packages/angular/src/executors/package/ng-packagr-adjustments/styles/stylesheet-processor.ts
@@ -101,6 +101,10 @@ export class StylesheetProcessor {
   }): Promise<string> {
     let key: string | undefined;
 
+    if (content === undefined) {
+      return undefined;
+    }
+
     if (
       this.cacheDirectory &&
       !content.includes('@import') &&


### PR DESCRIPTION
this will show the path of the file that cannot be located unfortunately I was not able to log the name of the file with the `styleUrls` that specified the non-existing file

it is still an improvement as prior to this change the only feedback from the build would be this generic message: `Cannot read properties of undefined (reading 'includes')`

closed #15185

## Current Behavior

when some `styleUrls` property of `@Component` specifies a path to a non-existing file 
then when you run `nx build` on the library with this component the build fails with this error message:

`Cannot read properties of undefined (reading 'includes')`

## Expected Behavior

the error message of the failing build will be like this:

`Cannot read file /Users/xxx/work/git/wt/release/3.20/libs/some-librarysrc/lib/Stylex/some-file.scss.`

## Related Issue(s)

Fixes #15185
