### PR TITLE
fix(angular): show actionable error when component resource is not found in ng-packagr executors

### DIFF
--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ts/cache-compiler-host.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ts/cache-compiler-host.ts
@@ -174,6 +174,10 @@ export function cacheCompilerHost(
 
       const cache = sourcesFileCache.getOrCreate(fileName);
       if (cache.content === undefined) {
+        if (!compilerHost.fileExists(fileName)) {
+          throw new Error(`Cannot read file ${fileName}.`);
+        }
+
         if (/(?:html?|svg)$/.test(path.extname(fileName))) {
           // template
           cache.content = compilerHost.readFile.call(this, fileName);
@@ -183,10 +187,6 @@ export function cacheCompilerHost(
             filePath: fileName,
             content: compilerHost.readFile.call(this, fileName),
           });
-        }
-
-        if (cache.content === undefined) {
-          throw new Error(`Cannot read file ${fileName}.`);
         }
 
         cache.exists = true;

--- a/packages/angular/src/executors/package/ng-packagr-adjustments/ts/cache-compiler-host.ts
+++ b/packages/angular/src/executors/package/ng-packagr-adjustments/ts/cache-compiler-host.ts
@@ -198,6 +198,10 @@ export function cacheCompilerHost(
 
       const cache = sourcesFileCache.getOrCreate(fileName);
       if (cache.content === undefined) {
+        if (!compilerHost.fileExists(fileName)) {
+          throw new Error(`Cannot read file ${fileName}.`);
+        }
+
         if (/(?:html?|svg)$/.test(path.extname(fileName))) {
           // template
           cache.content = compilerHost.readFile.call(this, fileName);
@@ -207,10 +211,6 @@ export function cacheCompilerHost(
             filePath: fileName,
             content: compilerHost.readFile.call(this, fileName),
           });
-        }
-
-        if (cache.content === undefined) {
-          throw new Error(`Cannot read file ${fileName}.`);
         }
 
         cache.exists = true;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When an Angular component stylesheet path in `stylesUrl` is invalid, the `ng-packagr` executors throw a cryptic error `Cannot read properties of undefined (reading 'includes')`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When an Angular component stylesheet path in `stylesUrl` is invalid, the `ng-packagr` executors should throw a helpful/actionable message that allows to troubleshoot the issue.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15185 
