### PR TITLE
feat(angular): add option to enable/disable cors for file-server

### DIFF
--- a/docs/generated/packages/angular/executors/file-server.json
+++ b/docs/generated/packages/angular/executors/file-server.json
@@ -65,6 +65,11 @@
         "type": "boolean",
         "description": "Redirect 404 errors to index.html (useful for SPA's).",
         "default": false
+      },
+      "cors": {
+        "type": "boolean",
+        "description": "Enable CORS",
+        "default": true
       }
     },
     "additionalProperties": false,

--- a/packages/angular/src/executors/file-server/file-server.impl.ts
+++ b/packages/angular/src/executors/file-server/file-server.impl.ts
@@ -16,7 +16,12 @@ import { Schema } from './schema';
 const pmCmd = platform() === 'win32' ? `npx.cmd` : 'npx';
 
 function getHttpServerArgs(options: Schema) {
-  const args = ['-c-1', '--cors'];
+  const args = ['-c-1'];
+
+  if (options.cors) {
+    args.push(`--cors`);
+  }
+
   if (options.port) {
     args.push(`-p=${options.port}`);
   }

--- a/packages/angular/src/executors/file-server/schema.d.ts
+++ b/packages/angular/src/executors/file-server/schema.d.ts
@@ -12,4 +12,5 @@ export interface Schema {
   proxyOptions?: object;
   watch?: boolean;
   spa?: boolean;
+  cors?: boolean;
 }

--- a/packages/angular/src/executors/file-server/schema.json
+++ b/packages/angular/src/executors/file-server/schema.json
@@ -67,6 +67,11 @@
       "type": "boolean",
       "description": "Redirect 404 errors to index.html (useful for SPA's).",
       "default": false
+    },
+    "cors": {
+      "type": "boolean",
+      "description": "Enable CORS",
+      "default": true
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Cors is always enabled by default on `file-server` with no option of turning it off

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should allow users to optionally disable cors

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14454
