### PR TITLE
fix(angular): ngrx should attach to parent routes correctly

### DIFF
--- a/packages/angular/src/generators/ngrx/__snapshots__/ngrx.spec.ts.snap
+++ b/packages/angular/src/generators/ngrx/__snapshots__/ngrx.spec.ts.snap
@@ -550,6 +550,36 @@ export * from './lib/+state/super-users.actions';
   "
 `;
 
+exports[`ngrx Standalone APIs should add a feature module when route is non-empty 1`] = `
+"import { Routes } from '@angular/router';
+        import { NxWelcomeComponent } from './nx-welcome.component';
+import { provideStore, provideState } from '@ngrx/store';
+import { provideEffects } from '@ngrx/effects';
+import * as fromUsers from './+state/users.reducer';
+import { UsersEffects } from './+state/users.effects'; 
+      export const appRoutes: Routes = [{ path: 'home', component: NxWelcomeComponent , providers: [provideState(fromUsers.USERS_FEATURE_KEY, fromUsers.usersReducer), provideEffects(UsersEffects)]}];"
+`;
+
+exports[`ngrx Standalone APIs should add a feature module when route is set to default 1`] = `
+"import { Routes } from '@angular/router';
+        import { NxWelcomeComponent } from './nx-welcome.component';
+import { provideStore, provideState } from '@ngrx/store';
+import { provideEffects } from '@ngrx/effects';
+import * as fromUsers from './+state/users.reducer';
+import { UsersEffects } from './+state/users.effects'; 
+      export const appRoutes: Routes = [{ path: '', component: NxWelcomeComponent , providers: [provideState(fromUsers.USERS_FEATURE_KEY, fromUsers.usersReducer), provideEffects(UsersEffects)]}];"
+`;
+
+exports[`ngrx Standalone APIs should add a feature module when route is undefined 1`] = `
+"import { Routes } from '@angular/router';
+        import { NxWelcomeComponent } from './nx-welcome.component';
+import { provideStore, provideState } from '@ngrx/store';
+import { provideEffects } from '@ngrx/effects';
+import * as fromUsers from './+state/users.reducer';
+import { UsersEffects } from './+state/users.effects'; 
+      export const appRoutes: Routes = [{ path: '', component: NxWelcomeComponent , providers: [provideState(fromUsers.USERS_FEATURE_KEY, fromUsers.usersReducer), provideEffects(UsersEffects)]}];"
+`;
+
 exports[`ngrx Standalone APIs should add a root module with feature module when minimal is set to false 1`] = `
 "import { bootstrapApplication } from '@angular/platform-browser';
 import { provideRouter, withEnabledBlockingInitialNavigation } from '@angular/router';

--- a/packages/angular/src/generators/ngrx/lib/normalize-options.ts
+++ b/packages/angular/src/generators/ngrx/lib/normalize-options.ts
@@ -16,7 +16,7 @@ export function normalizeOptions(
       : options.parent
       ? dirname(options.parent)
       : undefined,
-    route: options.route ?? '',
+    route: options.route === '' ? `''` : options.route ?? `''`,
     directory: names(options.directory).fileName,
   };
 }

--- a/packages/angular/src/generators/ngrx/ngrx.spec.ts
+++ b/packages/angular/src/generators/ngrx/ngrx.spec.ts
@@ -564,6 +564,52 @@ describe('ngrx', () => {
       expect(tree.read('/apps/my-app/src/main.ts', 'utf-8')).toMatchSnapshot();
     });
 
+    it('should add a feature module when route is undefined', async () => {
+      await ngrxGenerator(tree, {
+        ...defaultStandaloneOptions,
+        root: false,
+        route: undefined,
+        parent: 'apps/my-app/src/app/app.routes.ts',
+      });
+
+      expect(
+        tree.read('/apps/my-app/src/app/app.routes.ts', 'utf-8')
+      ).toMatchSnapshot();
+    });
+
+    it('should add a feature module when route is non-empty', async () => {
+      tree.write(
+        'apps/my-app/src/app/app.routes.ts',
+        `import { Routes } from '@angular/router';
+        import { NxWelcomeComponent } from './nx-welcome.component'; 
+      export const appRoutes: Routes = [{ path: 'home', component: NxWelcomeComponent }];`
+      );
+
+      await ngrxGenerator(tree, {
+        ...defaultStandaloneOptions,
+        root: false,
+        route: 'home',
+        parent: 'apps/my-app/src/app/app.routes.ts',
+      });
+
+      expect(
+        tree.read('/apps/my-app/src/app/app.routes.ts', 'utf-8')
+      ).toMatchSnapshot();
+    });
+
+    it('should add a feature module when route is set to default', async () => {
+      await ngrxGenerator(tree, {
+        ...defaultStandaloneOptions,
+        root: false,
+        route: '',
+        parent: 'apps/my-app/src/app/app.routes.ts',
+      });
+
+      expect(
+        tree.read('/apps/my-app/src/app/app.routes.ts', 'utf-8')
+      ).toMatchSnapshot();
+    });
+
     it('should add facade provider when facade is true', async () => {
       await ngrxGenerator(tree, {
         ...defaultStandaloneOptions,

--- a/packages/angular/src/utils/nx-devkit/route-utils.ts
+++ b/packages/angular/src/utils/nx-devkit/route-utils.ts
@@ -114,7 +114,7 @@ export function addProviderToRoute(
     );
   }
 
-  const ROUTE_SELECTOR = `ObjectLiteralExpression:has(PropertyAssignment:has(Identifier[name=path]) > StringLiteral[value='${routeToAddProviderTo}']):last-child`;
+  const ROUTE_SELECTOR = `ObjectLiteralExpression:has(PropertyAssignment:has(Identifier[name=path]) > StringLiteral[value=${routeToAddProviderTo}]):last-child`;
   const ROUTE_PATH_PROVIDERS_SELECTOR =
     'ObjectLiteralExpression > PropertyAssignment:has(Identifier[name=providers])';
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Attaching ngrx providers to a route either intentionally or by using the default route can fail

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Attaching a route should not fail

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15119
