### PR TITLE
fix(expo): Add @testing-library/jest-native to tsconfig compiler options for type checking

### DIFF
--- a/docs/generated/packages/expo/generators/application.json
+++ b/docs/generated/packages/expo/generators/application.json
@@ -47,7 +47,7 @@
       },
       "unitTestRunner": {
         "type": "string",
-        "enum": ["jest", "none"],
+        "enum": ["@testing-library/jest-native", "jest", "none"],
         "description": "Test runner to use for unit tests",
         "default": "jest"
       },

--- a/docs/generated/packages/expo/generators/init.json
+++ b/docs/generated/packages/expo/generators/init.json
@@ -11,7 +11,7 @@
       "unitTestRunner": {
         "description": "Adds the specified unit test runner",
         "type": "string",
-        "enum": ["jest", "none"],
+        "enum": ["@testing-library/jest-native", "jest", "none"],
         "default": "jest"
       },
       "skipFormat": {

--- a/docs/generated/packages/expo/generators/library.json
+++ b/docs/generated/packages/expo/generators/library.json
@@ -34,7 +34,7 @@
       },
       "unitTestRunner": {
         "type": "string",
-        "enum": ["jest", "none"],
+        "enum": ["@testing-library/jest-native", "jest", "none"],
         "description": "Test runner to use for unit tests.",
         "default": "jest"
       },

--- a/packages/expo/src/generators/application/schema.json
+++ b/packages/expo/src/generators/application/schema.json
@@ -47,7 +47,7 @@
     },
     "unitTestRunner": {
       "type": "string",
-      "enum": ["jest", "none"],
+      "enum": ["@testing-library/jest-native", "jest", "none"],
       "description": "Test runner to use for unit tests",
       "default": "jest"
     },

--- a/packages/expo/src/generators/init/schema.json
+++ b/packages/expo/src/generators/init/schema.json
@@ -8,7 +8,7 @@
     "unitTestRunner": {
       "description": "Adds the specified unit test runner",
       "type": "string",
-      "enum": ["jest", "none"],
+      "enum": ["@testing-library/jest-native", "jest", "none"],
       "default": "jest"
     },
     "skipFormat": {

--- a/packages/expo/src/generators/library/schema.json
+++ b/packages/expo/src/generators/library/schema.json
@@ -34,7 +34,7 @@
     },
     "unitTestRunner": {
       "type": "string",
-      "enum": ["jest", "none"],
+      "enum": ["@testing-library/jest-native", "jest", "none"],
       "description": "Test runner to use for unit tests.",
       "default": "jest"
     },


### PR DESCRIPTION
Previously, our project was not properly recognizing the types for the "@testing-library/jest-native" package, resulting in type errors  in our test files within VSCode. To fix this issue, I added the entry  "@testing-library/jest-native" to the "types" array in the tsconfig  file. By doing this, Visual Studio Code (VSCode) is now able to  pick up the types for the package, allowing for proper type checking  and no more type errors in our test files.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
