### PR TITLE
fix(expo): Add @testing-library/jest-native to tsconfig compiler options for type checking

### DIFF
--- a/packages/expo/src/utils/add-jest.ts
+++ b/packages/expo/src/utils/add-jest.ts
@@ -1,5 +1,6 @@
-import { Tree } from '@nrwl/devkit';
+import { Tree, updateJson } from '@nrwl/devkit';
 import { jestProjectGenerator } from '@nrwl/jest';
+import { join } from 'path';
 
 export async function addJest(
   host: Tree,
@@ -36,6 +37,23 @@ export async function addJest(
     }
   };`;
   host.write(configPath, content);
+
+  await updateJson(
+    host,
+    join(appProjectRoot, 'tsconfig.spec.json'),
+    (json: any) => {
+      if (
+        json.compilerOptions &&
+        json.compilerOptions.types &&
+        !json.compilerOptions.types.some(
+          (type: string) => type === '@testing-library/jest-native'
+        )
+      ) {
+        json.compilerOptions.types.push('@testing-library/jest-native');
+      }
+      return json;
+    }
+  );
 
   return jestTask;
 }


### PR DESCRIPTION
Previously, our project was not properly recognizing the types for the "@testing-library/jest-native" package, resulting in type errors in our test files. To fix this issue, I added the entry "@testing-library/jest-native" to the "types" array in tsconfig.spec.json file. By doing this, Visual Studio Code (VSCode) is now able to pick up the types for the package, allowing for proper type checking and no more type errors in our test files.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
