### PR TITLE
fix(bundling): copy initial assets correctly in watch mode for esbuild

### DIFF
--- a/packages/js/src/utils/assets/index.ts
+++ b/packages/js/src/utils/assets/index.ts
@@ -31,18 +31,19 @@ export async function copyAssets(
     callback:
       typeof options?.watch === 'object' ? options.watch.onCopy : undefined,
   });
+  const result: CopyAssetsResult = {
+    success: true,
+  };
+
   if (options.watch) {
-    const dispose = await assetHandler.watchAndProcessOnAssetChange();
-    return {
-      success: true,
-      stop: dispose,
-    };
-  } else {
-    try {
-      await assetHandler.processAllAssetsOnce();
-    } catch {
-      return { success: false };
-    }
-    return { success: true };
+    result.stop = await assetHandler.watchAndProcessOnAssetChange();
   }
+
+  try {
+    await assetHandler.processAllAssetsOnce();
+  } catch {
+    result.success = false;
+  }
+
+  return result;
 }


### PR DESCRIPTION
This PR fixes a regression where assets are not being copied on initial call to `copyAssets` since `@parcel/watch` only sends events on change (create, update, delete).

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #12901
