### PR TITLE
docs(core): a link typo in the Angular standalone tutorial

### DIFF
--- a/docs/shared/angular-standalone-tutorial/4-task-pipelines.md
+++ b/docs/shared/angular-standalone-tutorial/4-task-pipelines.md
@@ -123,7 +123,7 @@ When you run a task, Nx uses the inputs for your task to create a hash that is u
 
 If this index does not exist, Nx runs the command and if the command succeeds, it stores the result in the cache.
 
-{% card title="More On Customizing Inputs" description="See the Customizing Inputs Guide for more details on how to set inputs for your tasks." url="/concepts/task-pipeline-configuration" /%}
+{% card title="More On Customizing Inputs" description="See the Customizing Inputs Guide for more details on how to set inputs for your tasks." url="/more-concepts/customizing-inputs" /%}
 
 ### Outputs
 


### PR DESCRIPTION
## Current Behavior
Wrong link in the Angular standalone tutorial file.

## Expected Behavior
Links are all correct in the Angular standalone tutorial file: [Customizing inputs](https://nx.dev/more-concepts/customizing-inputs).

## Related Issue(s)
Don't know.

Fixes #
Fix the link.