### PR TITLE
fix(testing): use root preset for snapshot config changes first

### DIFF
--- a/packages/jest/src/migrations/update-15-8-0/__snapshots__/update-configs-jest-29.spec.ts.snap
+++ b/packages/jest/src/migrations/update-15-8-0/__snapshots__/update-configs-jest-29.spec.ts.snap
@@ -1,6 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Jest Migration - jest 29 update configs should be idempotent 1`] = `
+exports[`Jest Migration - jest 29 update configs should NOT update ts-jest with no globals are preset 1`] = `
+"const nxPreset = require('@nrwl/jest/preset').default;
+module.exports = {
+...nxPreset,
+testMatch: ['**/+(*.)+(spec|test).+(ts|js)?(x)'],
+transform: {
+    '^.+\\\\.(ts|js|html)$': 'ts-jest',
+  },
+resolver: '@nrwl/jest/plugins/resolver',
+moduleFileExtensions: ['ts', 'js', 'html'],
+coverageReporters: ['html'],
+/* TODO: Update to latest Jest snapshotFormat
+ * By default Nx has kept the older style of Jest Snapshot formats
+ * to prevent breaking of any existing tests with snapshots.
+ * It's recommend you update to the latest format.
+ * You can do this by removing snapshotFormat property
+ * and running tests with --update-snapshot flag.
+ * Example: \\"nx affected --targets=test --update-snapshot\\"
+ * More info: https://jestjs.io/docs/upgrading-to-jest29#snapshot-format
+ */
+snapshotFormat: { escapeString: true, printBasicPrototype: true }
+};
+"
+`;
+
+exports[`Jest Migration - jest 29 update configs should add snapshot config with no root preset 1`] = `
 "/* eslint-disable */
 export default {
 displayName: 'my-lib',
@@ -19,7 +44,7 @@ coverageDirectory: '../../coverage/libs/my-lib',
  * It's recommend you update to the latest format.
  * You can do this by removing snapshotFormat property
  * and running tests with --update-snapshot flag.
- * Example: \\"nx test my-lib --update-snapshot\\"
+ * Example: From within the project directory, run \\"nx test --update-snapshot\\"
  * More info: https://jestjs.io/docs/upgrading-to-jest29#snapshot-format
  */
 snapshotFormat: { escapeString: true, printBasicPrototype: true }
@@ -27,7 +52,7 @@ snapshotFormat: { escapeString: true, printBasicPrototype: true }
 "
 `;
 
-exports[`Jest Migration - jest 29 update configs should be idempotent 2`] = `
+exports[`Jest Migration - jest 29 update configs should add snapshot config with no root preset 2`] = `
 "module.exports = {
 transform: {
   '^.+\\\\\\\\.[tj]sx?$': ['ts-jest', {
@@ -50,10 +75,48 @@ preset: '../../jest.preset.js',
  * It's recommend you update to the latest format.
  * You can do this by removing snapshotFormat property
  * and running tests with --update-snapshot flag.
- * Example: \\"nx test my-lib --update-snapshot\\"
+ * Example: From within the project directory, run \\"nx test --update-snapshot\\"
  * More info: https://jestjs.io/docs/upgrading-to-jest29#snapshot-format
  */
 snapshotFormat: { escapeString: true, printBasicPrototype: true }
+};
+"
+`;
+
+exports[`Jest Migration - jest 29 update configs should be idempotent 1`] = `
+"/* eslint-disable */
+export default {
+  displayName: 'my-lib',
+  preset: '../../jest.preset.js',
+  globals: {  },
+  transform: {
+    '^.+\\\\\\\\.[tj]sx?$': ['ts-jest', {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    }]
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../coverage/libs/my-lib'
+};
+"
+`;
+
+exports[`Jest Migration - jest 29 update configs should be idempotent 2`] = `
+"module.exports = {
+transform: {
+  '^.+\\\\\\\\.[tj]sx?$': ['ts-jest', {
+        tsconfig: '<rootDir>/tsconfig.spec.json' 
+    }]
+},
+// I am a comment and shouldn't be removed
+moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
+globals: { something: 'else',
+abc: [1234, true, {abc: 'yes'}] },
+/**
+ * Multi-line comment shouldn't be removed
+ */
+displayName: 'jest',
+testEnvironment: 'node',
+preset: '../../jest.preset.js'
 };
 "
 `;
@@ -75,16 +138,6 @@ moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
 displayName: 'jest',
 testEnvironment: 'node',
 preset: '../../jest.preset.js',
-/* TODO: Update to latest Jest snapshotFormat
- * By default Nx has kept the older style of Jest Snapshot formats
- * to prevent breaking of any existing tests with snapshots.
- * It's recommend you update to the latest format.
- * You can do this by removing snapshotFormat property
- * and running tests with --update-snapshot flag.
- * Example: \\"nx test jest-preset-angular --update-snapshot\\"
- * More info: https://jestjs.io/docs/upgrading-to-jest29#snapshot-format
- */
-snapshotFormat: { escapeString: true, printBasicPrototype: true },
 testEnvironmentOptions: { teardown: true }, 
 };"
 `;
@@ -97,57 +150,37 @@ globalThis.ngJest = {
 }
 
 module.exports = {
-globals: {  },
-transform: {
+  globals: {  },
+  transform: {
     '^.+.(ts|mjs|js|html)$': ['jest-preset-angular', {
       tsconfig: '<rootDir>/tsconfig.spec.json',
       stringifyContentPathRegex: '\\\\.(html|svg)$',
     }],
   },
-moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
-testEnvironmentOptions: {
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
+  testEnvironmentOptions: {
   blah: 123,
    teardown: false
   },
-displayName: 'jest',
-testEnvironment: 'node',
-preset: '../../jest.preset.js',
-/* TODO: Update to latest Jest snapshotFormat
- * By default Nx has kept the older style of Jest Snapshot formats
- * to prevent breaking of any existing tests with snapshots.
- * It's recommend you update to the latest format.
- * You can do this by removing snapshotFormat property
- * and running tests with --update-snapshot flag.
- * Example: \\"nx test jest-preset-angular --update-snapshot\\"
- * More info: https://jestjs.io/docs/upgrading-to-jest29#snapshot-format
- */
-snapshotFormat: { escapeString: true, printBasicPrototype: true }
+  displayName: 'jest',
+  testEnvironment: 'node',
+  preset: '../../jest.preset.js',
 };"
 `;
 
 exports[`Jest Migration - jest 29 update configs should update jest.config.ts 1`] = `
 "/* eslint-disable */
 export default {
-displayName: 'my-lib',
-preset: '../../jest.preset.js',
-globals: {  },
-transform: {
+  displayName: 'my-lib',
+  preset: '../../jest.preset.js',
+  globals: {  },
+  transform: {
     '^.+\\\\\\\\.[tj]sx?$': ['ts-jest', {
       tsconfig: '<rootDir>/tsconfig.spec.json',
     }]
   },
-moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
-coverageDirectory: '../../coverage/libs/my-lib',
-/* TODO: Update to latest Jest snapshotFormat
- * By default Nx has kept the older style of Jest Snapshot formats
- * to prevent breaking of any existing tests with snapshots.
- * It's recommend you update to the latest format.
- * You can do this by removing snapshotFormat property
- * and running tests with --update-snapshot flag.
- * Example: \\"nx test my-lib --update-snapshot\\"
- * More info: https://jestjs.io/docs/upgrading-to-jest29#snapshot-format
- */
-snapshotFormat: { escapeString: true, printBasicPrototype: true }
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../coverage/libs/my-lib'
 };
 "
 `;
@@ -168,14 +201,90 @@ abc: [1234, true, {abc: 'yes'}] },
  */
 displayName: 'jest',
 testEnvironment: 'node',
-preset: '../../jest.preset.js',
+preset: '../../jest.preset.js'
+};
+"
+`;
+
+exports[`Jest Migration - jest 29 update configs should update root preset 1`] = `
+"
+      const nxPreset = require('@nrwl/jest/preset').default;
+
+      module.exports = {
+...nxPreset,
 /* TODO: Update to latest Jest snapshotFormat
  * By default Nx has kept the older style of Jest Snapshot formats
  * to prevent breaking of any existing tests with snapshots.
  * It's recommend you update to the latest format.
  * You can do this by removing snapshotFormat property
  * and running tests with --update-snapshot flag.
- * Example: \\"nx test my-lib --update-snapshot\\"
+ * Example: \\"nx affected --targets=test --update-snapshot\\"
+ * More info: https://jestjs.io/docs/upgrading-to-jest29#snapshot-format
+ */
+snapshotFormat: { escapeString: true, printBasicPrototype: true }
+}"
+`;
+
+exports[`Jest Migration - jest 29 update configs should update root preset 2`] = `
+"/* eslint-disable */
+export default {
+  displayName: 'my-lib',
+  preset: '../../jest.preset.js',
+  globals: {  },
+  transform: {
+    '^.+\\\\\\\\.[tj]sx?$': ['ts-jest', {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    }]
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../coverage/libs/my-lib'
+};
+"
+`;
+
+exports[`Jest Migration - jest 29 update configs should update root preset 3`] = `
+"module.exports = {
+transform: {
+  '^.+\\\\\\\\.[tj]sx?$': ['ts-jest', {
+        tsconfig: '<rootDir>/tsconfig.spec.json' 
+    }]
+},
+// I am a comment and shouldn't be removed
+moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
+globals: { something: 'else',
+abc: [1234, true, {abc: 'yes'}] },
+/**
+ * Multi-line comment shouldn't be removed
+ */
+displayName: 'jest',
+testEnvironment: 'node',
+preset: '../../jest.preset.js'
+};
+"
+`;
+
+exports[`Jest Migration - jest 29 update configs should update root preset if ts-jest is preset 1`] = `
+"const nxPreset = require('@nrwl/jest/preset').default;
+module.exports = {
+...nxPreset,
+testMatch: ['**/+(*.)+(spec|test).+(ts|js)?(x)'],
+globals: { something: 'else',
+abc: [1234, true, {abc: 'yes'}] },
+transform: {
+    '^.+\\\\.(ts|js|html)$': ['ts-jest', {
+        tsconfig: '<rootDir>/tsconfig.spec.json' 
+    }],
+  },
+resolver: '@nrwl/jest/plugins/resolver',
+moduleFileExtensions: ['ts', 'js', 'html'],
+coverageReporters: ['html'],
+/* TODO: Update to latest Jest snapshotFormat
+ * By default Nx has kept the older style of Jest Snapshot formats
+ * to prevent breaking of any existing tests with snapshots.
+ * It's recommend you update to the latest format.
+ * You can do this by removing snapshotFormat property
+ * and running tests with --update-snapshot flag.
+ * Example: \\"nx affected --targets=test --update-snapshot\\"
  * More info: https://jestjs.io/docs/upgrading-to-jest29#snapshot-format
  */
 snapshotFormat: { escapeString: true, printBasicPrototype: true }
@@ -185,45 +294,25 @@ snapshotFormat: { escapeString: true, printBasicPrototype: true }
 
 exports[`Jest Migration - jest 29 update configs should work if not using ts-jest transformer 1`] = `
 "export default {
-transform: {
+  transform: {
     '^.+\\\\\\\\.[tj]sx?$': 'babel-jest',
   },
-moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
-displayName: 'jest',
-testEnvironment: 'node',
-preset: '../../jest.preset.js',
-/* TODO: Update to latest Jest snapshotFormat
- * By default Nx has kept the older style of Jest Snapshot formats
- * to prevent breaking of any existing tests with snapshots.
- * It's recommend you update to the latest format.
- * You can do this by removing snapshotFormat property
- * and running tests with --update-snapshot flag.
- * Example: \\"nx test no-ts-jest --update-snapshot\\"
- * More info: https://jestjs.io/docs/upgrading-to-jest29#snapshot-format
- */
-snapshotFormat: { escapeString: true, printBasicPrototype: true }
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html']
+  displayName: 'jest',
+  testEnvironment: 'node',
+  preset: '../../jest.preset.js',
 };"
 `;
 
 exports[`Jest Migration - jest 29 update configs should work if not using ts-jest transformer 2`] = `
 "module.exports = {
-transform: {
+  transform: {
     '^.+\\\\\\\\.[tj]sx?$': 'babel-jest',
   },
-moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
-displayName: 'jest',
-testEnvironment: 'node',
-preset: '../../jest.preset.js',
-/* TODO: Update to latest Jest snapshotFormat
- * By default Nx has kept the older style of Jest Snapshot formats
- * to prevent breaking of any existing tests with snapshots.
- * It's recommend you update to the latest format.
- * You can do this by removing snapshotFormat property
- * and running tests with --update-snapshot flag.
- * Example: \\"nx test no-ts-jest --update-snapshot\\"
- * More info: https://jestjs.io/docs/upgrading-to-jest29#snapshot-format
- */
-snapshotFormat: { escapeString: true, printBasicPrototype: true }
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html']
+  displayName: 'jest',
+  testEnvironment: 'node',
+  preset: '../../jest.preset.js',
 };"
 `;
 
@@ -261,79 +350,49 @@ abc: [1234, true, {abc: 'yes'}] },
 
 exports[`Jest Migration - jest 29 update configs should work with jest-preset-angular 1`] = `
 "export default {
-globals: {  },
-transform: {
+  globals: {  },
+  transform: {
     '^.+.(ts|mjs|js|html)$': ['jest-preset-angular', {
       tsconfig: '<rootDir>/tsconfig.spec.json',
       stringifyContentPathRegex: '\\\\.(html|svg)$',
     }],
   },
-moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
-displayName: 'jest',
-testEnvironment: 'node',
-preset: '../../jest.preset.js',
-/* TODO: Update to latest Jest snapshotFormat
- * By default Nx has kept the older style of Jest Snapshot formats
- * to prevent breaking of any existing tests with snapshots.
- * It's recommend you update to the latest format.
- * You can do this by removing snapshotFormat property
- * and running tests with --update-snapshot flag.
- * Example: \\"nx test jest-preset-angular --update-snapshot\\"
- * More info: https://jestjs.io/docs/upgrading-to-jest29#snapshot-format
- */
-snapshotFormat: { escapeString: true, printBasicPrototype: true }
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html']
+  displayName: 'jest',
+  testEnvironment: 'node',
+  preset: '../../jest.preset.js',
 };"
 `;
 
 exports[`Jest Migration - jest 29 update configs should work with jest-preset-angular 2`] = `
 "module.exports = {
-globals: {  },
-transform: {
+  globals: {  },
+  transform: {
     '^.+.(ts|mjs|js|html)$': ['jest-preset-angular', {
       tsconfig: '<rootDir>/tsconfig.spec.json',
       stringifyContentPathRegex: '\\\\.(html|svg)$',
     }],
   },
-moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
-displayName: 'jest',
-testEnvironment: 'node',
-preset: '../../jest.preset.js',
-/* TODO: Update to latest Jest snapshotFormat
- * By default Nx has kept the older style of Jest Snapshot formats
- * to prevent breaking of any existing tests with snapshots.
- * It's recommend you update to the latest format.
- * You can do this by removing snapshotFormat property
- * and running tests with --update-snapshot flag.
- * Example: \\"nx test jest-preset-angular --update-snapshot\\"
- * More info: https://jestjs.io/docs/upgrading-to-jest29#snapshot-format
- */
-snapshotFormat: { escapeString: true, printBasicPrototype: true }
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html']
+  displayName: 'jest',
+  testEnvironment: 'node',
+  preset: '../../jest.preset.js',
 };"
 `;
 
 exports[`Jest Migration - jest 29 update configs should work with multiple projects + configs 1`] = `
 "/* eslint-disable */
 export default {
-displayName: 'my-lib',
-preset: '../../jest.preset.js',
-globals: {  },
-transform: {
+  displayName: 'my-lib',
+  preset: '../../jest.preset.js',
+  globals: {  },
+  transform: {
     '^.+\\\\\\\\.[tj]sx?$': ['ts-jest', {
       tsconfig: '<rootDir>/tsconfig.spec.json',
     }]
   },
-moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
-coverageDirectory: '../../coverage/libs/my-lib',
-/* TODO: Update to latest Jest snapshotFormat
- * By default Nx has kept the older style of Jest Snapshot formats
- * to prevent breaking of any existing tests with snapshots.
- * It's recommend you update to the latest format.
- * You can do this by removing snapshotFormat property
- * and running tests with --update-snapshot flag.
- * Example: \\"nx test my-lib --update-snapshot\\"
- * More info: https://jestjs.io/docs/upgrading-to-jest29#snapshot-format
- */
-snapshotFormat: { escapeString: true, printBasicPrototype: true }
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../coverage/libs/my-lib'
 };
 "
 `;
@@ -354,17 +413,7 @@ abc: [1234, true, {abc: 'yes'}] },
  */
 displayName: 'jest',
 testEnvironment: 'node',
-preset: '../../jest.preset.js',
-/* TODO: Update to latest Jest snapshotFormat
- * By default Nx has kept the older style of Jest Snapshot formats
- * to prevent breaking of any existing tests with snapshots.
- * It's recommend you update to the latest format.
- * You can do this by removing snapshotFormat property
- * and running tests with --update-snapshot flag.
- * Example: \\"nx test my-lib --update-snapshot\\"
- * More info: https://jestjs.io/docs/upgrading-to-jest29#snapshot-format
- */
-snapshotFormat: { escapeString: true, printBasicPrototype: true }
+preset: '../../jest.preset.js'
 };
 "
 `;
@@ -372,26 +421,16 @@ snapshotFormat: { escapeString: true, printBasicPrototype: true }
 exports[`Jest Migration - jest 29 update configs should work with multiple projects + configs 3`] = `
 "/* eslint-disable */
 export default {
-displayName: 'another-lib',
-preset: '../../jest.preset.js',
-globals: {  },
-transform: {
+  displayName: 'another-lib',
+  preset: '../../jest.preset.js',
+  globals: {  },
+  transform: {
     '^.+\\\\\\\\.[tj]sx?$': ['ts-jest', {
       tsconfig: '<rootDir>/tsconfig.spec.json',
     }]
   },
-moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
-coverageDirectory: '../../coverage/libs/another-lib',
-/* TODO: Update to latest Jest snapshotFormat
- * By default Nx has kept the older style of Jest Snapshot formats
- * to prevent breaking of any existing tests with snapshots.
- * It's recommend you update to the latest format.
- * You can do this by removing snapshotFormat property
- * and running tests with --update-snapshot flag.
- * Example: \\"nx test another-lib --update-snapshot\\"
- * More info: https://jestjs.io/docs/upgrading-to-jest29#snapshot-format
- */
-snapshotFormat: { escapeString: true, printBasicPrototype: true }
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../coverage/libs/another-lib'
 };
 "
 `;
@@ -412,17 +451,7 @@ abc: [1234, true, {abc: 'yes'}] },
  */
 displayName: 'jest',
 testEnvironment: 'node',
-preset: '../../jest.preset.js',
-/* TODO: Update to latest Jest snapshotFormat
- * By default Nx has kept the older style of Jest Snapshot formats
- * to prevent breaking of any existing tests with snapshots.
- * It's recommend you update to the latest format.
- * You can do this by removing snapshotFormat property
- * and running tests with --update-snapshot flag.
- * Example: \\"nx test another-lib --update-snapshot\\"
- * More info: https://jestjs.io/docs/upgrading-to-jest29#snapshot-format
- */
-snapshotFormat: { escapeString: true, printBasicPrototype: true }
+preset: '../../jest.preset.js'
 };
 "
 `;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
jest 29 migration adds the snapshot configuration changes to every projects jest config which can be time consuming to update each individual jest config

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
update the shared root jest preset instead

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
