### PR TITLE
fix(testing): only install dependency for the desired --testEnvironment

### DIFF
--- a/docs/generated/packages/jest/generators/init.json
+++ b/docs/generated/packages/jest/generators/init.json
@@ -21,6 +21,13 @@
         "description": "Do not add dependencies to `package.json`.",
         "x-priority": "internal"
       },
+      "testEnvironment": {
+        "type": "string",
+        "enum": ["jsdom", "node", "none"],
+        "description": "The test environment for jest. This controls which jest-environment-* package is installed",
+        "default": "jsdom",
+        "x-priority": "important"
+      },
       "js": {
         "type": "boolean",
         "default": false,

--- a/docs/generated/packages/jest/generators/jest-project.json
+++ b/docs/generated/packages/jest/generators/jest-project.json
@@ -41,7 +41,7 @@
       },
       "testEnvironment": {
         "type": "string",
-        "enum": ["jsdom", "node"],
+        "enum": ["jsdom", "node", "none"],
         "description": "The test environment for jest.",
         "default": "jsdom",
         "x-priority": "important"

--- a/packages/jest/src/generators/init/init.spec.ts
+++ b/packages/jest/src/generators/init/init.spec.ts
@@ -131,6 +131,40 @@ export default {
     expect(packageJson.devDependencies['@types/jest']).toBeDefined();
     expect(packageJson.devDependencies['ts-jest']).toBeDefined();
     expect(packageJson.devDependencies['ts-node']).toBeDefined();
+    expect(packageJson.devDependencies['jest-environment-jsdom']).toBeDefined();
+    expect(
+      packageJson.devDependencies['jest-environment-node']
+    ).not.toBeDefined();
+  });
+
+  it('should add dependencies --testEnvironment=node', async () => {
+    await jestInitGenerator(tree, { testEnvironment: 'node' });
+    const packageJson = readJson(tree, 'package.json');
+    expect(packageJson.devDependencies.jest).toBeDefined();
+    expect(packageJson.devDependencies['@nrwl/jest']).toBeDefined();
+    expect(packageJson.devDependencies['@types/jest']).toBeDefined();
+    expect(packageJson.devDependencies['ts-jest']).toBeDefined();
+    expect(packageJson.devDependencies['ts-node']).toBeDefined();
+    expect(packageJson.devDependencies['jest-environment-node']).toBeDefined();
+    expect(
+      packageJson.devDependencies['jest-environment-jsdom']
+    ).not.toBeDefined();
+  });
+
+  it('should add dependencies --testEnvironment=none', async () => {
+    await jestInitGenerator(tree, { testEnvironment: 'none' });
+    const packageJson = readJson(tree, 'package.json');
+    expect(packageJson.devDependencies.jest).toBeDefined();
+    expect(packageJson.devDependencies['@nrwl/jest']).toBeDefined();
+    expect(packageJson.devDependencies['@types/jest']).toBeDefined();
+    expect(packageJson.devDependencies['ts-jest']).toBeDefined();
+    expect(packageJson.devDependencies['ts-node']).toBeDefined();
+    expect(
+      packageJson.devDependencies['jest-environment-jsdom']
+    ).not.toBeDefined();
+    expect(
+      packageJson.devDependencies['jest-environment-node']
+    ).not.toBeDefined();
   });
 
   it('should make js jest files', async () => {

--- a/packages/jest/src/generators/init/init.ts
+++ b/packages/jest/src/generators/init/init.ts
@@ -33,6 +33,7 @@ const schemaDefaults = {
   compiler: 'tsc',
   js: false,
   rootProject: false,
+  testEnvironment: 'jsdom',
 } as const;
 
 function generateGlobalConfig(tree: Tree, isJS: boolean) {
@@ -146,13 +147,16 @@ function updateDependencies(tree: Tree, options: NormalizedSchema) {
   const devDeps = {
     '@nrwl/jest': nxVersion,
     jest: jestVersion,
-    'jest-environment-jsdom': jestVersion,
 
     // because the default jest-preset uses ts-jest,
     // jest will throw an error if it's not installed
     // even if not using it in overriding transformers
     'ts-jest': tsJestVersion,
   };
+
+  if (options.testEnvironment !== 'none') {
+    devDeps[`jest-environment-${options.testEnvironment}`] = jestVersion;
+  }
 
   if (!options.js) {
     devDeps['ts-node'] = tsNodeVersion;

--- a/packages/jest/src/generators/init/schema.d.ts
+++ b/packages/jest/src/generators/init/schema.d.ts
@@ -2,6 +2,7 @@ export interface JestInitSchema {
   compiler?: 'tsc' | 'babel' | 'swc';
   js?: boolean;
   skipPackageJson?: boolean;
+  testEnvironment?: 'node' | 'jsdom' | 'none';
   /**
    * @deprecated
    */

--- a/packages/jest/src/generators/init/schema.json
+++ b/packages/jest/src/generators/init/schema.json
@@ -18,6 +18,13 @@
       "description": "Do not add dependencies to `package.json`.",
       "x-priority": "internal"
     },
+    "testEnvironment": {
+      "type": "string",
+      "enum": ["jsdom", "node", "none"],
+      "description": "The test environment for jest. This controls which jest-environment-* package is installed",
+      "default": "jsdom",
+      "x-priority": "important"
+    },
     "js": {
       "type": "boolean",
       "default": false,

--- a/packages/jest/src/generators/jest-project/jest-project.ts
+++ b/packages/jest/src/generators/jest-project/jest-project.ts
@@ -18,14 +18,12 @@ const schemaDefaults = {
   skipSetupFile: false,
   skipSerializers: false,
   rootProject: false,
+  testEnvironment: 'jsdom',
 } as const;
 
 function normalizeOptions(options: JestProjectSchema) {
   if (!options.testEnvironment) {
     options.testEnvironment = 'jsdom';
-  }
-  if (options.testEnvironment === 'jsdom') {
-    options.testEnvironment = '';
   }
 
   if (!options.hasOwnProperty('supportTsx')) {

--- a/packages/jest/src/generators/jest-project/lib/create-files.ts
+++ b/packages/jest/src/generators/jest-project/lib/create-files.ts
@@ -31,6 +31,11 @@ export function createFiles(tree: Tree, options: JestProjectSchema) {
   generateFiles(tree, join(__dirname, filesFolder), projectConfig.root, {
     tmpl: '',
     ...options,
+    // jsdom is the default
+    testEnvironment:
+      options.testEnvironment === 'none' || options.testEnvironment === 'jsdom'
+        ? ''
+        : options.testEnvironment,
     transformer,
     transformerOptions,
     js: !!options.js,

--- a/packages/jest/src/generators/jest-project/schema.d.ts
+++ b/packages/jest/src/generators/jest-project/schema.d.ts
@@ -7,7 +7,7 @@ export interface JestProjectSchema {
   skipSetupFile?: boolean;
   setupFile?: 'angular' | 'web-components' | 'none';
   skipSerializers?: boolean;
-  testEnvironment?: 'node' | 'jsdom' | '';
+  testEnvironment?: 'node' | 'jsdom' | 'none';
   /**
    * @deprecated use compiler: "babel" instead
    */

--- a/packages/jest/src/generators/jest-project/schema.json
+++ b/packages/jest/src/generators/jest-project/schema.json
@@ -40,7 +40,7 @@
     },
     "testEnvironment": {
       "type": "string",
-      "enum": ["jsdom", "node"],
+      "enum": ["jsdom", "node", "none"],
       "description": "The test environment for jest.",
       "default": "jsdom",
       "x-priority": "important"

--- a/packages/node/src/generators/init/init.ts
+++ b/packages/node/src/generators/init/init.ts
@@ -47,7 +47,9 @@ export async function initGenerator(tree: Tree, schema: Schema) {
     })
   );
   if (options.unitTestRunner === 'jest') {
-    tasks.push(await jestInitGenerator(tree, schema));
+    tasks.push(
+      await jestInitGenerator(tree, { ...schema, testEnvironment: 'node' })
+    );
   }
 
   tasks.push(updateDependencies(tree));

--- a/packages/node/src/generators/library/library.spec.ts
+++ b/packages/node/src/generators/library/library.spec.ts
@@ -49,6 +49,12 @@ describe('lib', () => {
           },
         },
       });
+      expect(
+        readJson(tree, 'package.json').devDependencies['jest-environment-jsdom']
+      ).not.toBeDefined();
+      expect(
+        readJson(tree, 'package.json').devDependencies['jest-environment-node']
+      ).toBeDefined();
     });
 
     it('adds srcRootForCompilationRoot', async () => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

jest always installs jest-environment-jsdom

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
jest should only install the environment needed by --testEnvironment arg.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15103 
