### PR TITLE
fix(testing): walk all project deps to check if CT project is used in buildTarget

### DIFF
--- a/e2e/angular-extensions/src/cypress-component-tests.test.ts
+++ b/e2e/angular-extensions/src/cypress-component-tests.test.ts
@@ -19,154 +19,15 @@ describe('Angular Cypress Component Tests', () => {
 
   beforeAll(async () => {
     projectName = newProject({ name: uniq('cy-ng') });
-    runCLI(`generate @nrwl/angular:app ${appName} --no-interactive`);
-    runCLI(
-      `generate @nrwl/angular:component fancy-component --project=${appName} --no-interactive`
-    );
-    runCLI(`generate @nrwl/angular:lib ${usedInAppLibName} --no-interactive`);
-    runCLI(
-      `generate @nrwl/angular:component btn --project=${usedInAppLibName} --inlineTemplate --inlineStyle --export --no-interactive`
-    );
-    runCLI(
-      `generate @nrwl/angular:component btn-standalone --project=${usedInAppLibName} --inlineTemplate --inlineStyle --export --standalone --no-interactive`
-    );
-    updateFile(
-      `libs/${usedInAppLibName}/src/lib/btn/btn.component.ts`,
-      `
-import { Component, Input } from '@angular/core';
 
-@Component({
-  selector: '${projectName}-btn',
-  template: '<button class="text-green-500">{{text}}</button>',
-  styles: []
-})
-export class BtnComponent {
-  @Input() text = 'something';
-}
-`
-    );
-    updateFile(
-      `libs/${usedInAppLibName}/src/lib/btn-standalone/btn-standalone.component.ts`,
-      `
-import { Component, Input } from '@angular/core';
-import { CommonModule } from '@angular/common';
-@Component({
-  selector: '${projectName}-btn-standalone',
-  standalone: true,
-  imports: [CommonModule],
-  template: '<button class="text-green-500">standlone-{{text}}</button>',
-  styles: [],
-})
-export class BtnStandaloneComponent {
-  @Input() text = 'something';
-}
-`
-    );
-    // use lib in the app
-    createFile(
-      `apps/${appName}/src/app/app.component.html`,
-      `
-<${projectName}-btn></${projectName}-btn>
-<${projectName}-btn-standalone></${projectName}-btn-standalone>
-<${projectName}-nx-welcome></${projectName}-nx-welcome>
-`
-    );
-    const btnModuleName = names(usedInAppLibName).className;
-    updateFile(
-      `apps/${appName}/src/app/app.component.scss`,
-      `
-@use 'styleguide' as *;
+    createApp(appName);
 
-h1 {
-  @include headline;
-}`
-    );
-    updateFile(
-      `apps/${appName}/src/app/app.module.ts`,
-      `
-import { NgModule } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
-import {${btnModuleName}Module} from "@${projectName}/${usedInAppLibName}";
+    createLib(projectName, appName, usedInAppLibName);
+    useLibInApp(projectName, appName, usedInAppLibName);
 
-import { AppComponent } from './app.component';
-import { NxWelcomeComponent } from './nx-welcome.component';
+    createBuildableLib(projectName, buildableLibName);
 
-@NgModule({
-  declarations: [AppComponent, NxWelcomeComponent],
-  imports: [BrowserModule, ${btnModuleName}Module],
-  providers: [],
-  bootstrap: [AppComponent],
-})
-export class AppModule {}
-`
-    );
-
-    runCLI(
-      `generate @nrwl/angular:lib ${buildableLibName} --buildable --no-interactive`
-    );
-    runCLI(
-      `generate @nrwl/angular:component input --project=${buildableLibName} --inlineTemplate --inlineStyle --export --no-interactive`
-    );
-    runCLI(
-      `generate @nrwl/angular:component input-standalone --project=${buildableLibName} --inlineTemplate --inlineStyle --export --standalone --no-interactive`
-    );
-    updateFile(
-      `libs/${buildableLibName}/src/lib/input/input.component.ts`,
-      `
-import {Component, Input} from '@angular/core';
-
-@Component({
-  selector: '${projectName}-input',
-  template: \`<label class="text-green-500">Email: <input class="border-blue-500" type="email" [readOnly]="readOnly"></label>\`,
-    styles  : []
-  })
-  export class InputComponent{
-    @Input() readOnly = false;
-  }
-  `
-    );
-    updateFile(
-      `libs/${buildableLibName}/src/lib/input-standalone/input-standalone.component.ts`,
-      `
-import {Component, Input} from '@angular/core';
-import {CommonModule} from '@angular/common';
-@Component({
-  selector: '${projectName}-input-standalone',
-  standalone: true,
-  imports: [CommonModule],
-  template: \`<label class="text-green-500">Email: <input class="border-blue-500" type="email" [readOnly]="readOnly"></label>\`,
-    styles  : []
-  })
-  export class InputStandaloneComponent{
-    @Input() readOnly = false;
-  }
-  `
-    );
-
-    // make sure assets from the workspace root work.
-    createFile('libs/assets/data.json', JSON.stringify({ data: 'data' }));
-    createFile(
-      'assets/styles/styleguide.scss',
-      `
-    @mixin headline {
-    font-weight: bold;
-    color: darkkhaki;
-    background: lightcoral;
-    font-weight: 24px;
-  }
-  `
-    );
-    updateProjectConfig(appName, (config) => {
-      config.targets['build'].options.stylePreprocessorOptions = {
-        includePaths: ['assets/styles'],
-      };
-      config.targets['build'].options.assets.push({
-        glob: '**/*',
-        input: 'libs/assets',
-        output: 'assets',
-      });
-      return config;
-    });
+    useWorkspaceAssetsInApp(appName);
   });
 
   afterAll(() => cleanupProject());
@@ -200,9 +61,211 @@ import {CommonModule} from '@angular/common';
         `generate @nrwl/angular:cypress-component-configuration --project=${buildableLibName} --generate-tests --no-interactive`
       );
     }).toThrow();
-    createFile(
+
+    updateTestToAssertTailwindIsNotApplied(buildableLibName);
+
+    runCLI(
+      `generate @nrwl/angular:cypress-component-configuration --project=${buildableLibName} --generate-tests --build-target=${appName}:build --no-interactive`
+    );
+    if (runCypressTests()) {
+      expect(runCLI(`component-test ${buildableLibName} --no-watch`)).toContain(
+        'All specs passed!'
+      );
+    }
+    // add tailwind
+    runCLI(
+      `generate @nrwl/angular:setup-tailwind --project=${buildableLibName}`
+    );
+    updateFile(
       `libs/${buildableLibName}/src/lib/input/input.component.cy.ts`,
-      `
+      (content) => {
+        // text-green-500 should now apply
+        return content.replace('rgb(0, 0, 0)', 'rgb(34, 197, 94)');
+      }
+    );
+    updateFile(
+      `libs/${buildableLibName}/src/lib/input-standalone/input-standalone.component.cy.ts`,
+      (content) => {
+        // text-green-500 should now apply
+        return content.replace('rgb(0, 0, 0)', 'rgb(34, 197, 94)');
+      }
+    );
+
+    if (runCypressTests()) {
+      expect(runCLI(`component-test ${buildableLibName} --no-watch`)).toContain(
+        'All specs passed!'
+      );
+      checkFilesDoNotExist(`tmp/libs/${buildableLibName}/ct-styles.css`);
+    }
+  }, 300_000);
+});
+
+function createApp(appName: string) {
+  runCLI(`generate @nrwl/angular:app ${appName} --no-interactive`);
+  runCLI(
+    `generate @nrwl/angular:component fancy-component --project=${appName} --no-interactive`
+  );
+}
+
+function createLib(projectName: string, appName: string, libName: string) {
+  runCLI(`generate @nrwl/angular:lib ${libName} --no-interactive`);
+  runCLI(
+    `generate @nrwl/angular:component btn --project=${libName} --inlineTemplate --inlineStyle --export --no-interactive`
+  );
+  runCLI(
+    `generate @nrwl/angular:component btn-standalone --project=${libName} --inlineTemplate --inlineStyle --export --standalone --no-interactive`
+  );
+  updateFile(
+    `libs/${libName}/src/lib/btn/btn.component.ts`,
+    `
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: '${projectName}-btn',
+  template: '<button class="text-green-500">{{text}}</button>',
+  styles: []
+})
+export class BtnComponent {
+  @Input() text = 'something';
+}
+`
+  );
+  updateFile(
+    `libs/${libName}/src/lib/btn-standalone/btn-standalone.component.ts`,
+    `
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+@Component({
+  selector: '${projectName}-btn-standalone',
+  standalone: true,
+  imports: [CommonModule],
+  template: '<button class="text-green-500">standlone-{{text}}</button>',
+  styles: [],
+})
+export class BtnStandaloneComponent {
+  @Input() text = 'something';
+}
+`
+  );
+}
+
+function createBuildableLib(projectName: string, libName: string) {
+  // create lib
+  runCLI(`generate @nrwl/angular:lib ${libName} --buildable --no-interactive`);
+  // create cmp for lib
+  runCLI(
+    `generate @nrwl/angular:component input --project=${libName} --inlineTemplate --inlineStyle --export --no-interactive`
+  );
+  // create standlone cmp for lib
+  runCLI(
+    `generate @nrwl/angular:component input-standalone --project=${libName} --inlineTemplate --inlineStyle --export --standalone --no-interactive`
+  );
+  // update cmp implmentation to use tailwind clasasserting in tests
+  updateFile(
+    `libs/${libName}/src/lib/input/input.component.ts`,
+    `
+import {Component, Input} from '@angular/core';
+
+@Component({
+  selector: '${projectName}-input',
+  template: \`<label class="text-green-500">Email: <input class="border-blue-500" type="email" [readOnly]="readOnly"></label>\`,
+    styles  : []
+  })
+  export class InputComponent{
+    @Input() readOnly = false;
+  }
+  `
+  );
+  updateFile(
+    `libs/${libName}/src/lib/input-standalone/input-standalone.component.ts`,
+    `
+import {Component, Input} from '@angular/core';
+import {CommonModule} from '@angular/common';
+@Component({
+  selector: '${projectName}-input-standalone',
+  standalone: true,
+  imports: [CommonModule],
+  template: \`<label class="text-green-500">Email: <input class="border-blue-500" type="email" [readOnly]="readOnly"></label>\`,
+    styles  : []
+  })
+  export class InputStandaloneComponent{
+    @Input() readOnly = false;
+  }
+  `
+  );
+}
+
+function useLibInApp(projectName: string, appName: string, libName: string) {
+  createFile(
+    `apps/${appName}/src/app/app.component.html`,
+    `
+<${projectName}-btn></${projectName}-btn>
+<${projectName}-btn-standalone></${projectName}-btn-standalone>
+<${projectName}-nx-welcome></${projectName}-nx-welcome>
+`
+  );
+  const btnModuleName = names(libName).className;
+  updateFile(
+    `apps/${appName}/src/app/app.component.scss`,
+    `
+@use 'styleguide' as *;
+
+h1 {
+  @include headline;
+}`
+  );
+  updateFile(
+    `apps/${appName}/src/app/app.module.ts`,
+    `
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import {${btnModuleName}Module} from "@${projectName}/${libName}";
+
+import { AppComponent } from './app.component';
+import { NxWelcomeComponent } from './nx-welcome.component';
+
+@NgModule({
+  declarations: [AppComponent, NxWelcomeComponent],
+  imports: [BrowserModule, ${btnModuleName}Module],
+  providers: [],
+  bootstrap: [AppComponent],
+})
+export class AppModule {}
+`
+  );
+}
+
+function useWorkspaceAssetsInApp(appName: string) {
+  // make sure assets from the workspace root work.
+  createFile('libs/assets/data.json', JSON.stringify({ data: 'data' }));
+  createFile(
+    'assets/styles/styleguide.scss',
+    `
+    @mixin headline {
+    font-weight: bold;
+    color: darkkhaki;
+    background: lightcoral;
+    font-weight: 24px;
+  }
+  `
+  );
+  updateProjectConfig(appName, (config) => {
+    config.targets['build'].options.stylePreprocessorOptions = {
+      includePaths: ['assets/styles'],
+    };
+    config.targets['build'].options.assets.push({
+      glob: '**/*',
+      input: 'libs/assets',
+      output: 'assets',
+    });
+    return config;
+  });
+}
+
+function updateTestToAssertTailwindIsNotApplied(libName: string) {
+  createFile(
+    `libs/${libName}/src/lib/input/input.component.cy.ts`,
+    `
 import { MountConfig } from 'cypress/angular';
 import { InputComponent } from './input.component';
 
@@ -229,11 +292,11 @@ describe(InputComponent.name, () => {
   });
 });
 `
-    );
+  );
 
-    createFile(
-      `libs/${buildableLibName}/src/lib/input-standalone/input-standalone.component.cy.ts`,
-      `
+  createFile(
+    `libs/${libName}/src/lib/input-standalone/input-standalone.component.cy.ts`,
+    `
 import { MountConfig } from 'cypress/angular';
 import { InputStandaloneComponent } from './input-standalone.component';
 
@@ -260,39 +323,5 @@ describe(InputStandaloneComponent.name, () => {
   });
 });
 `
-    );
-
-    runCLI(
-      `generate @nrwl/angular:cypress-component-configuration --project=${buildableLibName} --generate-tests --build-target=${appName}:build --no-interactive`
-    );
-    if (runCypressTests()) {
-      expect(runCLI(`component-test ${buildableLibName} --no-watch`)).toContain(
-        'All specs passed!'
-      );
-    }
-
-    // add tailwind
-    runCLI(
-      `generate @nrwl/angular:setup-tailwind --project=${buildableLibName}`
-    );
-    updateFile(
-      `libs/${buildableLibName}/src/lib/input/input.component.cy.ts`,
-      (content) => {
-        // text-green-500 should now apply
-        return content.replace('rgb(0, 0, 0)', 'rgb(34, 197, 94)');
-      }
-    );
-    updateFile(
-      `libs/${buildableLibName}/src/lib/input-standalone/input-standalone.component.cy.ts`,
-      (content) => {
-        // text-green-500 should now apply
-        return content.replace('rgb(0, 0, 0)', 'rgb(34, 197, 94)');
-      }
-    );
-
-    expect(runCLI(`component-test ${buildableLibName} --no-watch`)).toContain(
-      'All specs passed!'
-    );
-    checkFilesDoNotExist(`tmp/libs/${buildableLibName}/ct-styles.css`);
-  }, 300_000);
-});
+  );
+}

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -535,6 +535,10 @@ export function runCypressTests() {
   if (process.env.NX_E2E_RUN_CYPRESS === 'true') {
     ensureCypressInstallation();
     return true;
+  } else {
+    console.warn(
+      'Not running Cypress because NX_E2E_RUN_CYPRESS is not set to true.'
+    );
   }
   return false;
 }

--- a/packages/cypress/src/utils/ct-helpers.ts
+++ b/packages/cypress/src/utils/ct-helpers.ts
@@ -53,12 +53,11 @@ export function isCtProjectUsingBuildProject(
   if (isProjectDirectDep) {
     return true;
   }
+  const maybeIntermediateProjects = graph.dependencies[
+    parentProjectName
+  ].filter((p) => !graph.externalNodes[p.target]);
 
-  const maybeItermediateProjects = graph.dependencies[parentProjectName].filter(
-    (p) => !graph.externalNodes[p.target]
-  );
-
-  for (const maybeIntermediateProject of maybeItermediateProjects) {
+  for (const maybeIntermediateProject of maybeIntermediateProjects) {
     if (
       isCtProjectUsingBuildProject(
         graph,

--- a/packages/cypress/src/utils/ct-helpers.ts
+++ b/packages/cypress/src/utils/ct-helpers.ts
@@ -39,20 +39,37 @@ export function getTempTailwindPath(context: ExecutorContext) {
 }
 
 /**
- * also returns true if the ct project and build project are the same.
- * i.e. component testing inside an app.
- */
+ * Checks if the childProjectName is a decendent of the parentProjectName
+ * in the project graph
+ **/
 export function isCtProjectUsingBuildProject(
   graph: ProjectGraph,
   parentProjectName: string,
   childProjectName: string
-) {
-  return (
-    parentProjectName === childProjectName ||
-    graph.dependencies[parentProjectName].some(
-      (p) => p.target === childProjectName
-    )
+): boolean {
+  const isProjectDirectDep = graph.dependencies[parentProjectName].some(
+    (p) => p.target === childProjectName
   );
+  if (isProjectDirectDep) {
+    return true;
+  }
+
+  const maybeItermediateProjects = graph.dependencies[parentProjectName].filter(
+    (p) => !graph.externalNodes[p.target]
+  );
+
+  for (const maybeIntermediateProject of maybeItermediateProjects) {
+    if (
+      isCtProjectUsingBuildProject(
+        graph,
+        maybeIntermediateProject.target,
+        childProjectName
+      )
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export function getProjectConfigByPath(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

being more than 1 node away from the defined 'buildTarget' would not allows assets/scripts/styles to be included in the dynamic project config that angular CT creates for cypress.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The CT plugin walks all the deps from the buildTarget project to check if the CT project is being used instead of direct dependencies of buildTarget.

## TODO
- [x] add e2e tests
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14881 
