### PR TITLE
feat(repo): automatically lock closed issues after 30 days of inactivity

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -1,0 +1,29 @@
+name: "Lock Threads"
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Once a day, at midnight UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: lock
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v4
+        with:
+          github-token: ${{ github.token }}
+          issue-inactive-days: "30" # Lock issues after 30 days of being closed
+          pr-inactive-days: "5" # Lock closed PRs after 5 days. This ensures that issues that stem from a PR are opened as issues, rather than comments on the recently merged PR.
+          add-issue-labels: "outdated"
+          exclude-issue-created-before: "2023-01-01"
+          issue-comment: >
+            This issue has been closed for more than 30 days. If this issue is still occuring, please open a new issue with more recent context.
+          pr-comment: >
+            This pull request has already been merged/closed. If you experience issues related to these changes, please open a new issue referencing this pull request.


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

This PR addresses 2 issues:
- Comments on closed issues are hard to see, and easy to ignore. Its not uncommon for notifications from closed issues to be dismissed, without actually even seeing the comment. That said, since closed issues are able to be commented on, sometimes community members will leave a comment on an old issue when they discover a bug that appears to be the same as the old issue. This leads to frustration in the community, as their comment goes unheard, and frustration as a maintainer when you have to monitor notifications on old, closed. issues.
- Comments can be left on merged PRs. Sometimes community members will leave a comment on a merged PR, if the next release has a bug that they believe is related. Since the PR is merged, this is easy to ignore and leads to similar frustrations.

An example run of the included action can be found here: https://github.com/nx-dotnet/nx-dotnet/actions/runs/4266583420/jobs/7427279238

Here is an example locked issue: https://github.com/nx-dotnet/nx-dotnet/issues/381
Here is an example locked PR: https://github.com/nx-dotnet/nx-dotnet/pull/592

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
