### PR TITLE
fix(linter): init should succeed if project has null targets

### DIFF
--- a/packages/linter/src/generators/init/init-migration.ts
+++ b/packages/linter/src/generators/init/init-migration.ts
@@ -38,7 +38,7 @@ export function migrateConfigToMonorepoStyle(
 export function findLintTarget(
   project: ProjectConfiguration
 ): TargetConfiguration {
-  return Object.entries(project.targets).find(
+  return Object.entries(project.targets ?? {}).find(
     ([name, target]) =>
       name === 'lint' || target.executor === '@nrwl/linter:eslint'
   )?.[1];


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
@nrwl/linter:init fails if a project has null targets

## Expected Behavior
@nrwl/linter:init handles it

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14800
