### PR TITLE
fix(core): nx migrate should not prompt if on CI server

### DIFF
--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -52,6 +52,7 @@ import { messages, recordStat } from '../utils/ab-testing';
 import { nxVersion } from '../utils/versions';
 import { existsSync } from 'fs';
 import { workspaceRoot } from '../utils/workspace-root';
+import { isCI } from '../utils/is-ci';
 
 export interface ResolvedMigrationConfiguration extends MigrationsJson {
   packageGroup?: ArrayPackageGroup;
@@ -1108,7 +1109,8 @@ async function generateMigrationsJsonAndUpdatePackageJson(
     try {
       if (
         ['nx', '@nrwl/workspace'].includes(opts.targetPackage) &&
-        (await isMigratingToNewMajor(from, opts.targetVersion))
+        (await isMigratingToNewMajor(from, opts.targetVersion)) &&
+        !isCI
       ) {
         const useCloud = await connectToNxCloudCommand(
           messages.getPromptMessage('nxCloudMigration')
@@ -1137,7 +1139,7 @@ async function generateMigrationsJsonAndUpdatePackageJson(
       fetch: createFetcher(),
       from: opts.from,
       to: opts.to,
-      interactive: opts.interactive,
+      interactive: opts.interactive && !isCI,
       excludeAppliedMigrations: opts.excludeAppliedMigrations,
     });
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
nx migrate always prompts to enable cloud, but on CI servers this causes a failed migration

## Expected Behavior
nx migrate skips any prompts on CI servers

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/12397
