### PR TITLE
fix(vite): add missing types for tsconfigs

### DIFF
--- a/e2e/react/src/react-package.test.ts
+++ b/e2e/react/src/react-package.test.ts
@@ -1,6 +1,7 @@
 import {
   checkFilesDoNotExist,
   checkFilesExist,
+  cleanupProject,
   getSize,
   killPorts,
   newProject,
@@ -107,7 +108,7 @@ describe('Build React libraries and apps', () => {
 
   afterEach(() => {
     killPorts();
-    // cleanupProject();
+    cleanupProject();
   });
 
   describe('Buildable libraries', () => {

--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -44,6 +44,26 @@ describe('app', () => {
       expect(projects.get('my-app-e2e').root).toEqual('apps/my-app-e2e');
     });
 
+    it('should add vite types to tsconfigs', async () => {
+      await applicationGenerator(appTree, {
+        ...schema,
+        bundler: 'vite',
+        unitTestRunner: 'vitest',
+      });
+      const tsconfigApp = readJson(appTree, 'apps/my-app/tsconfig.app.json');
+      expect(tsconfigApp.compilerOptions.types).toEqual([
+        'node',
+        'vite/client',
+      ]);
+      const tsconfigSpec = readJson(appTree, 'apps/my-app/tsconfig.spec.json');
+      expect(tsconfigSpec.compilerOptions.types).toEqual([
+        'vitest/globals',
+        'vitest/importMeta',
+        'vite/client',
+        'node',
+      ]);
+    });
+
     it('should not overwrite default project if already set', async () => {
       const nxJson = readNxJson(appTree);
       nxJson.defaultProject = 'some-awesome-project';

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -61,6 +61,26 @@ describe('lib', () => {
       });
     });
 
+    it('should add vite types to tsconfigs', async () => {
+      await libraryGenerator(tree, {
+        ...defaultSchema,
+        bundler: 'vite',
+        unitTestRunner: 'vitest',
+      });
+      const tsconfigApp = readJson(tree, 'libs/my-lib/tsconfig.lib.json');
+      expect(tsconfigApp.compilerOptions.types).toEqual([
+        'node',
+        'vite/client',
+      ]);
+      const tsconfigSpec = readJson(tree, 'libs/my-lib/tsconfig.spec.json');
+      expect(tsconfigSpec.compilerOptions.types).toEqual([
+        'vitest/globals',
+        'vitest/importMeta',
+        'vite/client',
+        'node',
+      ]);
+    });
+
     it('should update tags', async () => {
       await libraryGenerator(tree, { ...defaultSchema, tags: 'one,two' });
       const project = readProjectConfiguration(tree, 'my-lib');

--- a/packages/react/src/utils/create-ts-config.ts
+++ b/packages/react/src/utils/create-ts-config.ts
@@ -1,6 +1,6 @@
 import { Tree } from 'nx/src/generators/tree';
 import * as shared from '@nrwl/js/src/utils/typescript/create-ts-config';
-import { writeJson } from 'nx/src/generators/utils/json';
+import { updateJson, writeJson } from 'nx/src/generators/utils/json';
 
 export function createTsConfig(
   host: Tree,
@@ -56,6 +56,21 @@ export function createTsConfig(
   }
 
   writeJson(host, `${projectRoot}/tsconfig.json`, json);
+
+  const tsconfigProjectPath = `${projectRoot}/tsconfig.${type}.json`;
+  if (options.bundler === 'vite' && host.exists(tsconfigProjectPath)) {
+    updateJson(host, tsconfigProjectPath, (json) => {
+      json.compilerOptions ??= {};
+
+      const types = new Set(json.compilerOptions.types ?? []);
+      types.add('node');
+      types.add('vite/client');
+
+      json.compilerOptions.types = Array.from(types);
+
+      return json;
+    });
+  }
 }
 
 export function extractTsConfigBase(host: Tree) {

--- a/packages/vite/src/generators/vitest/files/tsconfig.spec.json__tmpl__
+++ b/packages/vite/src/generators/vitest/files/tsconfig.spec.json__tmpl__
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "types": ["vitest/globals", "node"]
+    "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node"]
   },
   "include": [
     "vite.config.ts",

--- a/packages/vite/src/generators/vitest/vitest.spec.ts
+++ b/packages/vite/src/generators/vitest/vitest.spec.ts
@@ -93,6 +93,8 @@ describe('vitest generator', () => {
             "outDir": "../../dist/out-tsc",
             "types": Array [
               "vitest/globals",
+              "vitest/importMeta",
+              "vite/client",
               "node",
             ],
           },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

missing types for compiler options that correct type import.meta for vite and vitest, mainly import.meta.env shows a TS error because it's missing vite/client types

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

vite types are added to the vite related tsconfigs so that import.meta is correctly typed

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14176
