### PR TITLE
feat(core): be able to depend on a configuration of a target

### DIFF
--- a/docs/generated/cli/affected.md
+++ b/docs/generated/cli/affected.md
@@ -109,6 +109,14 @@ Type: `boolean`
 
 Show help
 
+### nx-accept-same-target-variations
+
+Type: `boolean`
+
+Default: `false`
+
+Do not throw if the same target is included multiple times with different configurations
+
 ### nx-bail
 
 Type: `boolean`

--- a/docs/generated/cli/exec.md
+++ b/docs/generated/cli/exec.md
@@ -29,6 +29,14 @@ Type: `string`
 
 Exclude certain projects from being processed
 
+### nx-accept-same-target-variations
+
+Type: `boolean`
+
+Default: `false`
+
+Do not throw if the same target is included multiple times with different configurations
+
 ### nx-bail
 
 Type: `boolean`

--- a/docs/generated/cli/run-many.md
+++ b/docs/generated/cli/run-many.md
@@ -81,6 +81,14 @@ Type: `boolean`
 
 Show help
 
+### nx-accept-same-target-variations
+
+Type: `boolean`
+
+Default: `false`
+
+Do not throw if the same target is included multiple times with different configurations
+
 ### nx-bail
 
 Type: `boolean`

--- a/docs/generated/packages/nx/documents/affected.md
+++ b/docs/generated/packages/nx/documents/affected.md
@@ -109,6 +109,14 @@ Type: `boolean`
 
 Show help
 
+### nx-accept-same-target-variations
+
+Type: `boolean`
+
+Default: `false`
+
+Do not throw if the same target is included multiple times with different configurations
+
 ### nx-bail
 
 Type: `boolean`

--- a/docs/generated/packages/nx/documents/exec.md
+++ b/docs/generated/packages/nx/documents/exec.md
@@ -29,6 +29,14 @@ Type: `string`
 
 Exclude certain projects from being processed
 
+### nx-accept-same-target-variations
+
+Type: `boolean`
+
+Default: `false`
+
+Do not throw if the same target is included multiple times with different configurations
+
 ### nx-bail
 
 Type: `boolean`

--- a/docs/generated/packages/nx/documents/run-many.md
+++ b/docs/generated/packages/nx/documents/run-many.md
@@ -81,6 +81,14 @@ Type: `boolean`
 
 Show help
 
+### nx-accept-same-target-variations
+
+Type: `boolean`
+
+Default: `false`
+
+Do not throw if the same target is included multiple times with different configurations
+
 ### nx-bail
 
 Type: `boolean`

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -515,6 +515,12 @@ function withRunOptions(yargs: yargs.Argv): yargs.Argv {
       type: 'boolean',
       default: false,
     })
+    .option('nx-accept-same-target-variations', {
+      describe:
+        'Do not throw if the same target is included multiple times with different configurations',
+      type: 'boolean',
+      default: false,
+    })
     .options('skip-nx-cache', {
       describe:
         'Rerun the tasks even when the results are available in the cache',

--- a/packages/nx/src/tasks-runner/task-graph-utils.spec.ts
+++ b/packages/nx/src/tasks-runner/task-graph-utils.spec.ts
@@ -1,4 +1,8 @@
-import { findCycle, makeAcyclic } from './task-graph-utils';
+import {
+  findAmbiguousTargets,
+  findCycle,
+  makeAcyclic,
+} from './task-graph-utils';
 
 describe('task graph utils', () => {
   describe('findCycles', () => {
@@ -55,6 +59,46 @@ describe('task graph utils', () => {
         e: [],
       });
       expect(graph.roots).toEqual(['d', 'e']);
+    });
+  });
+
+  describe('findAmbiguousTargets', () => {
+    it('should find ambiguous targets', () => {
+      const graph = {
+        tasks: {
+          'app1:build': {
+            target: {
+              project: 'app1',
+              target: 'build',
+            },
+          },
+          'lib1:build:production': {
+            target: {
+              project: 'lib1',
+              target: 'build',
+              configuration: 'production',
+            },
+          },
+          'lib3:build:production': {
+            target: {
+              project: 'lib3',
+              target: 'build',
+              configuration: 'production',
+            },
+          },
+          'lib3:build:ci': {
+            target: {
+              project: 'lib3',
+              target: 'build',
+              configuration: 'ci',
+            },
+          },
+        },
+      } as any;
+
+      expect(findAmbiguousTargets(graph)).toEqual([
+        ['lib3:build:production', 'lib3:build:ci'],
+      ]);
     });
   });
 });

--- a/packages/nx/src/tasks-runner/task-graph-utils.ts
+++ b/packages/nx/src/tasks-runner/task-graph-utils.ts
@@ -63,3 +63,25 @@ export function makeAcyclic(taskGraph: TaskGraph): void {
     (t) => taskGraph.dependencies[t].length === 0
   );
 }
+
+/** Finds targets that are included more than once with different configurations */
+export function findAmbiguousTargets(taskGraph: TaskGraph): string[][] {
+  const sameTaskVariations = Object.values(taskGraph.tasks).reduce(
+    (variations, { target }) => {
+      const inlineTarget = `${target.project}:${target.target}`;
+      let inlineTargetWithConfig = inlineTarget;
+      if (target.configuration) {
+        inlineTargetWithConfig = inlineTarget + `:${target.configuration}`;
+      }
+
+      (variations[inlineTarget] ??= []).push(inlineTargetWithConfig);
+
+      return variations;
+    },
+    {} as Record<string, string[]>
+  );
+
+  return Object.values(sameTaskVariations).filter(
+    (variation) => variation.length > 1
+  );
+}

--- a/packages/nx/src/utils/command-line-utils.ts
+++ b/packages/nx/src/utils/command-line-utils.ts
@@ -32,6 +32,7 @@ export interface NxArgs {
   outputStyle?: string;
   nxBail?: boolean;
   nxIgnoreCycles?: boolean;
+  nxAcceptSameTargetVariations?: boolean;
   type?: string;
 }
 

--- a/packages/nx/src/utils/project-graph-utils.ts
+++ b/packages/nx/src/utils/project-graph-utils.ts
@@ -5,6 +5,18 @@ import { readJsonFile } from './fileutils';
 import { readCachedProjectGraph } from '../project-graph/project-graph';
 import { TargetConfiguration } from '../config/workspace-json-project-json';
 
+export function projectHasTargetAndOptionalConfiguration(
+  project: ProjectGraphProjectNode,
+  target: string,
+  configuration: string | undefined
+) {
+  if (configuration) {
+    return projectHasTargetAndConfiguration(project, target, configuration);
+  } else {
+    return projectHasTarget(project, target);
+  }
+}
+
 export function projectHasTarget(
   project: ProjectGraphProjectNode,
   target: string


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Right now dependsOn syntax allows to specify only the name of the target. However, there're certain scenarios where it would be beneficial to have an ability to depend on a certain configuration of this target
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
See details here https://github.com/nrwl/nx/issues/15064 
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/15064
