### PR TITLE
chore(core): delete local .node files before publish

### DIFF
--- a/packages/nx/src/hasher/file-hasher.ts
+++ b/packages/nx/src/hasher/file-hasher.ts
@@ -10,10 +10,8 @@ import { NativeFileHasher } from './native-file-hasher';
 function createFileHasher(): FileHasherBase {
   try {
     if (
-      !(
-        process.env.NX_NON_NATIVE_HASHER &&
-        process.env.NX_NON_NATIVE_HASHER == 'false'
-      )
+      !process.env.NX_NON_NATIVE_HASHER ||
+      process.env.NX_NON_NATIVE_HASHER != 'true'
     ) {
       return new NativeFileHasher();
     }

--- a/scripts/nx-release.ts
+++ b/scripts/nx-release.ts
@@ -72,6 +72,12 @@ function hideFromGitIndex(uncommittedFiles: string[]) {
   }
 
   if (!options.local && process.env.NPM_TOKEN) {
+    // Delete all .node files that were built during the previous steps
+    // Always run before the artifacts step because we still need the .node files for native-packages
+    execSync('find ./build -name "*.node" -delete', {
+      stdio: [0, 1, 2],
+    });
+
     execSync('npx nx run-many --target=artifacts', {
       stdio: [0, 1, 2],
     });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Publishing included the .node file in `packages/nx/src/native`. This causes errors on CI machines not using latest linux images.

## Expected Behavior
There is no more local .node files being published. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
