### PR TITLE
chore(nx-dev): throw error if no dependency found when expected

### DIFF
--- a/nx-dev/nx-dev/tailwind.config.js
+++ b/nx-dev/nx-dev/tailwind.config.js
@@ -1,6 +1,9 @@
 const path = require('path');
 const { createGlobPatternsForDependencies } = require('@nrwl/next/tailwind');
 
+if (!createGlobPatternsForDependencies(__dirname).length)
+  throw Error('GRAPH ISSUE: No dependency found when many are expected.');
+
 module.exports = {
   experimental: {
     optimizeUniversalDefaults: true,


### PR DESCRIPTION
It will throw an error when the `createGlobPatternsForDependencies()` helper is not returning anything when it should in fact return lots of dependencies.