### PR TITLE
fix(core): fix tsconfig reference in hasher

### DIFF
--- a/packages/nx/src/hasher/hasher.spec.ts
+++ b/packages/nx/src/hasher/hasher.spec.ts
@@ -59,7 +59,7 @@ describe('Hasher', () => {
       },
       '/root'
     );
-    tsUtils.getRootTsConfigFileName = () => '/root/tsconfig.base.json';
+    tsUtils.getRootTsConfigPath = () => '/root/tsconfig.base.json';
   });
 
   afterEach(() => {

--- a/packages/nx/src/hasher/hasher.ts
+++ b/packages/nx/src/hasher/hasher.ts
@@ -1,6 +1,6 @@
 import { exec } from 'child_process';
 import * as minimatch from 'minimatch';
-import { getRootTsConfigFileName } from '../utils/typescript';
+import { getRootTsConfigPath } from '../utils/typescript';
 import { defaultHashing, HashingImpl } from './hashing-impl';
 import {
   FileData,
@@ -175,7 +175,7 @@ export class Hasher {
 
   private readTsConfig() {
     try {
-      const res = readJsonFile(getRootTsConfigFileName());
+      const res = readJsonFile(getRootTsConfigPath());
       res.compilerOptions.paths ??= {};
       return res;
     } catch {


### PR DESCRIPTION
The tsconfig filename reference is only valid when the command is run from the workspace root. Using the complete path provides proper support when running commands from subdirectories

The underlying cause is that the workspace root tsconfig file is referenced only by filename, and thus is dependent on the cwd. This PR changes the reference to use the complete path, thereby fixing the hash mismatch.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

The following commands generate different hashes, so result in cache misses.

From the workspace root:
```npx nx run my-lib:build```

From the project root:
```npx nx run my-lib:build``` (or ```npx nx build```)

## Expected Behavior

All of the following generate the same hash and result in cache hits.

From the workspace root:
```npx nx run my-lib:build```

From the project root:
```npx nx run my-lib:build``` or ```npx nx build```
