### PR TITLE
fix(angular): generate the right main.ts with host generator using dynamic and ssr

### DIFF
--- a/packages/angular/src/generators/host/__snapshots__/host.spec.ts.snap
+++ b/packages/angular/src/generators/host/__snapshots__/host.spec.ts.snap
@@ -25,26 +25,27 @@ export class AppModule { }
 "
 `;
 
-exports[`Host App Generator --ssr should generate the correct files 2`] = `
-"import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+exports[`Host App Generator --ssr should generate the correct files 2`] = `"import('./bootstrap').catch(err => console.error(err))"`;
 
+exports[`Host App Generator --ssr should generate the correct files 3`] = `
+"import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { AppModule } from './app/app.module';
 
 function bootstrap() {
   platformBrowserDynamic()
-  .bootstrapModule(AppModule)
-  .catch((err) => console.error(err));
-};
+    .bootstrapModule(AppModule)
+    .catch((err) => console.error(err));
+}
 
-
- if (document.readyState !== 'loading') {
-   bootstrap();
- } else {
-   document.addEventListener('DOMContentLoaded', bootstrap);
- }"
+if (document.readyState !== 'loading') {
+  bootstrap();
+} else {
+  document.addEventListener('DOMContentLoaded', bootstrap);
+}
+"
 `;
 
-exports[`Host App Generator --ssr should generate the correct files 3`] = `
+exports[`Host App Generator --ssr should generate the correct files 4`] = `
 "/***************************************************************************************************
  * Initialize the server environment - for example, adding DOM built-in types to the global scope.
  *
@@ -58,7 +59,7 @@ export { AppServerModule } from './app/app.server.module';
 export { renderModule } from '@angular/platform-server';"
 `;
 
-exports[`Host App Generator --ssr should generate the correct files 4`] = `
+exports[`Host App Generator --ssr should generate the correct files 5`] = `
 "import 'zone.js/dist/zone-node';
 
 import { APP_BASE_HREF } from '@angular/common';
@@ -127,22 +128,22 @@ run();
 export * from './bootstrap.server';"
 `;
 
-exports[`Host App Generator --ssr should generate the correct files 5`] = `"import('./src/main.server');"`;
+exports[`Host App Generator --ssr should generate the correct files 6`] = `"import('./src/main.server');"`;
 
-exports[`Host App Generator --ssr should generate the correct files 6`] = `
+exports[`Host App Generator --ssr should generate the correct files 7`] = `
 "module.exports = {
   name: 'test',
   remotes: []
 }"
 `;
 
-exports[`Host App Generator --ssr should generate the correct files 7`] = `
+exports[`Host App Generator --ssr should generate the correct files 8`] = `
 "const { withModuleFederationForSSR } = require('@nrwl/angular/module-federation');
 const config = require('./module-federation.config');
 module.exports = withModuleFederationForSSR(config)"
 `;
 
-exports[`Host App Generator --ssr should generate the correct files 8`] = `
+exports[`Host App Generator --ssr should generate the correct files 9`] = `
 "import { NxWelcomeComponent } from './nx-welcome.component';
     import { Route } from '@angular/router';
 
@@ -153,7 +154,7 @@ export const appRoutes: Route[] = [
     },];"
 `;
 
-exports[`Host App Generator --ssr should generate the correct files 9`] = `
+exports[`Host App Generator --ssr should generate the correct files 10`] = `
 Object {
   "configurations": Object {
     "development": Object {
@@ -181,7 +182,7 @@ Object {
 }
 `;
 
-exports[`Host App Generator --ssr should generate the correct files 10`] = `
+exports[`Host App Generator --ssr should generate the correct files 11`] = `
 Object {
   "configurations": Object {
     "development": Object {
@@ -196,6 +197,33 @@ Object {
   "defaultConfiguration": "development",
   "executor": "@nrwl/angular:module-federation-dev-ssr",
 }
+`;
+
+exports[`Host App Generator --ssr should not overwrite browser main.ts when using dynamic federation 1`] = `
+"import { setRemoteDefinitions } from '@nrwl/angular/mf';
+
+  fetch('/assets/module-federation.manifest.json')
+  .then((res) => res.json())
+  .then(definitions => setRemoteDefinitions(definitions))
+  .then(() => import('./bootstrap').catch(err => console.error(err)))"
+`;
+
+exports[`Host App Generator --ssr should not overwrite browser main.ts when using dynamic federation 2`] = `
+"import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { AppModule } from './app/app.module';
+
+function bootstrap() {
+  platformBrowserDynamic()
+    .bootstrapModule(AppModule)
+    .catch((err) => console.error(err));
+}
+
+if (document.readyState !== 'loading') {
+  bootstrap();
+} else {
+  document.addEventListener('DOMContentLoaded', bootstrap);
+}
+"
 `;
 
 exports[`Host App Generator should generate a host app with a remote 1`] = `

--- a/packages/angular/src/generators/host/host.spec.ts
+++ b/packages/angular/src/generators/host/host.spec.ts
@@ -206,6 +206,7 @@ describe('Host App Generator', () => {
       expect(
         tree.read(`apps/test/src/app/app.module.ts`, 'utf-8')
       ).toMatchSnapshot();
+      expect(tree.read(`apps/test/src/main.ts`, 'utf-8')).toMatchSnapshot();
       expect(
         tree.read(`apps/test/src/bootstrap.ts`, 'utf-8')
       ).toMatchSnapshot();
@@ -227,6 +228,24 @@ describe('Host App Generator', () => {
       ).toMatchSnapshot();
       expect(project.targets.server).toMatchSnapshot();
       expect(project.targets['serve-ssr']).toMatchSnapshot();
+    });
+
+    it('should not overwrite browser main.ts when using dynamic federation', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+
+      // ACT
+      await host(tree, {
+        name: 'test',
+        ssr: true,
+        dynamic: true,
+      });
+
+      // ASSERT
+      expect(tree.read(`apps/test/src/main.ts`, 'utf-8')).toMatchSnapshot();
+      expect(
+        tree.read(`apps/test/src/bootstrap.ts`, 'utf-8')
+      ).toMatchSnapshot();
     });
   });
 

--- a/packages/angular/src/generators/host/lib/add-ssr.ts
+++ b/packages/angular/src/generators/host/lib/add-ssr.ts
@@ -18,6 +18,11 @@ import {
 export async function addSsr(tree: Tree, options: Schema, appName: string) {
   let project = readProjectConfiguration(tree, appName);
 
+  const originalMain = tree.read(
+    joinPathFragments(project.sourceRoot, 'main.ts'),
+    'utf-8'
+  );
+
   await setupSsr(tree, {
     project: appName,
   });
@@ -35,10 +40,7 @@ export async function addSsr(tree: Tree, options: Schema, appName: string) {
     joinPathFragments(project.sourceRoot, 'main.ts'),
     joinPathFragments(project.sourceRoot, 'bootstrap.ts')
   );
-  tree.write(
-    joinPathFragments(project.sourceRoot, 'main.ts'),
-    `import("./bootstrap")`
-  );
+  tree.write(joinPathFragments(project.sourceRoot, 'main.ts'), originalMain);
 
   generateFiles(tree, joinPathFragments(__dirname, '../files'), project.root, {
     appName,

--- a/packages/angular/src/generators/setup-ssr/files/src/main.ts__tpl__
+++ b/packages/angular/src/generators/setup-ssr/files/src/main.ts__tpl__
@@ -1,16 +1,14 @@
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-
 import { AppModule } from './app/app.module';
 
 function bootstrap() {
   platformBrowserDynamic()
-  .bootstrapModule(AppModule)
-  .catch((err) => console.error(err));
-};
+    .bootstrapModule(AppModule)
+    .catch((err) => console.error(err));
+}
 
-
- if (document.readyState !== 'loading') {
-   bootstrap();
- } else {
-   document.addEventListener('DOMContentLoaded', bootstrap);
- }
+if (document.readyState !== 'loading') {
+  bootstrap();
+} else {
+  document.addEventListener('DOMContentLoaded', bootstrap);
+}

--- a/packages/angular/src/generators/setup-ssr/setup-ssr.spec.ts
+++ b/packages/angular/src/generators/setup-ssr/setup-ssr.spec.ts
@@ -45,21 +45,20 @@ describe('setupSSR', () => {
     `);
     expect(tree.read('apps/app1/src/main.ts', 'utf-8')).toMatchInlineSnapshot(`
       "import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-
       import { AppModule } from './app/app.module';
 
       function bootstrap() {
         platformBrowserDynamic()
-        .bootstrapModule(AppModule)
-        .catch((err) => console.error(err));
-      };
+          .bootstrapModule(AppModule)
+          .catch((err) => console.error(err));
+      }
 
-
-       if (document.readyState !== 'loading') {
-         bootstrap();
-       } else {
-         document.addEventListener('DOMContentLoaded', bootstrap);
-       }"
+      if (document.readyState !== 'loading') {
+        bootstrap();
+      } else {
+        document.addEventListener('DOMContentLoaded', bootstrap);
+      }
+      "
     `);
     expect(tree.read('apps/app1/tsconfig.server.json', 'utf-8'))
       .toMatchInlineSnapshot(`


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Generating a host with remotes using dynamic federation and SSR results in an invalid setup where navigating to the remote throws `Error: Call setRemoteDefinitions or setRemoteUrlResolver to allow Dynamic Federation to find the remote apps correctly`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Generating a host with remotes using dynamic federation and SSR should work correctly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15283
