### PR TITLE
fix(core): remove logs on missing hoisted package

### DIFF
--- a/packages/nx/src/lock-file/utils/package-json.ts
+++ b/packages/nx/src/lock-file/utils/package-json.ts
@@ -12,9 +12,6 @@ export function getHoistedPackageVersion(packageName: string): string {
     const content = readFileSync(fullPath, 'utf-8');
     return JSON.parse(content)?.version;
   }
-  if (process.env.NX_VERBOSE_LOGGING === 'true') {
-    console.warn(`Could not find ${fullPath}`);
-  }
   return;
 }
 


### PR DESCRIPTION
Optional or nested-only packages return no version on `getHoistedPackageVersion`. When this function is run in the verbose mode we get log:
```
Could not find /user/name/path/to/repo/node_modules/package-name/package.json
```

## Current Behavior
We see logs for "missing" hoisted packages during migration or generations if run with verbose mode.

## Expected Behavior
The logs should not be shows for missing hoisted package.json

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
