### PR TITLE
fix(devkit): ensure readTargetOptions is compatible with nx supported range

### DIFF
--- a/packages/devkit/src/executors/read-target-options.ts
+++ b/packages/devkit/src/executors/read-target-options.ts
@@ -15,7 +15,7 @@ export function readTargetOptions<T = any>(
   { project, target, configuration }: Target,
   context: ExecutorContext
 ): T {
-  const projectConfiguration = context.projectGraph.nodes[project].data;
+  const projectConfiguration = context.workspace.projects[project];
   const targetConfiguration = projectConfiguration.targets[target];
 
   const ws = new Workspaces(context.root);
@@ -24,7 +24,7 @@ export function readTargetOptions<T = any>(
 
   const defaultProject = ws.calculateDefaultProjectName(
     context.cwd,
-    context.projectsConfigurations,
+    { version: 2, projects: context.workspace.projects },
     context.nxJsonConfiguration
   );
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `readTargetOptions` function in the Nx DevKit uses some functionality that was made available in Nx 15.4.5. This breaks the compatibility of `@nrwl/devkit` with `nx` which is `>=14.1 <=16`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `readTargetOptions` function implementation in the Nx DevKit is compatible with `nx: >=14.1 <=16`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14413 
