### PR TITLE
fix(core): listing plugin capabilities causes issues when returning null

### DIFF
--- a/packages/nx/src/utils/plugins/installed-plugins.ts
+++ b/packages/nx/src/utils/plugins/installed-plugins.ts
@@ -74,7 +74,13 @@ export function getInstalledPluginsAndCapabilities(
   for (const plugin of Array.from(plugins).sort()) {
     try {
       const capabilities = getPluginCapabilities(workspaceRoot, plugin);
-      if (capabilities.executors || capabilities.generators) {
+      if (
+        capabilities &&
+        (capabilities.executors ||
+          capabilities.generators ||
+          capabilities.projectGraphExtension ||
+          capabilities.projectInference)
+      ) {
         result.set(plugin, capabilities);
       }
     } catch {}

--- a/packages/nx/src/utils/plugins/local-plugins.ts
+++ b/packages/nx/src/utils/plugins/local-plugins.ts
@@ -3,14 +3,11 @@ import { output } from '../output';
 import type { PluginCapabilities } from './models';
 import { hasElements } from './shared';
 import { readJsonFile } from '../fileutils';
-import { PackageJson, readNxMigrateConfig } from '../package-json';
+import { PackageJson } from '../package-json';
 import { ProjectsConfigurations } from '../../config/workspace-json-project-json';
 import { join } from 'path';
 import { workspaceRoot } from '../workspace-root';
 import { existsSync } from 'fs';
-import { ExecutorsJson, GeneratorsJson } from '../../config/misc-interfaces';
-import { loadNxPlugin } from '../nx-plugin';
-import { getNxRequirePaths } from '../installation-directory';
 import { getPluginCapabilities } from './plugin-capabilities';
 
 export function getLocalWorkspacePlugins(
@@ -26,10 +23,11 @@ export function getLocalWorkspacePlugins(
         packageJson.name
       );
       if (
-        capabilities.executors ||
-        capabilities.generators ||
-        capabilities.projectGraphExtension ||
-        capabilities.projectInference
+        capabilities &&
+        (capabilities.executors ||
+          capabilities.generators ||
+          capabilities.projectGraphExtension ||
+          capabilities.projectInference)
       ) {
         plugins.set(packageJson.name, {
           ...capabilities,

--- a/packages/nx/src/utils/plugins/models.ts
+++ b/packages/nx/src/utils/plugins/models.ts
@@ -5,10 +5,10 @@ import {
 
 export interface PluginCapabilities {
   name: string;
-  executors: { [name: string]: ExecutorsJsonEntry };
-  generators: { [name: string]: GeneratorsJsonEntry };
-  projectInference: boolean;
-  projectGraphExtension: boolean;
+  executors?: { [name: string]: ExecutorsJsonEntry };
+  generators?: { [name: string]: GeneratorsJsonEntry };
+  projectInference?: boolean;
+  projectGraphExtension?: boolean;
 }
 
 export interface CorePlugin {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

`loadNxPlugin` may error when trying to load a module which is not an Nx plugin. This is because we set the `name` property on the object, which could be readonly, or similar.

`getPluginCapabilities` returns null on error, and calls `loadNxPlugin`. 

## Expected Behavior
`getPluginCapabilities` doesn't return null on error

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15305
