### PR TITLE
fix(core): standardize chunking elements passing to cli

### DIFF
--- a/packages/nx/src/command-line/format.ts
+++ b/packages/nx/src/command-line/format.ts
@@ -20,6 +20,7 @@ import { createProjectGraphAsync } from '../project-graph/project-graph';
 import { filterAffected } from '../project-graph/affected/affected-project-graph';
 import { readNxJson } from '../config/configuration';
 import { ProjectGraph } from '../config/project-graph';
+import { chunkify } from '../utils/chunkify';
 
 const PRETTIER_PATH = require.resolve('prettier/bin-prettier');
 
@@ -40,7 +41,7 @@ export async function format(
   );
 
   // Chunkify the patterns array to prevent crashing the windows terminal
-  const chunkList: string[][] = chunkify(patterns, 50);
+  const chunkList: string[][] = chunkify(patterns);
 
   switch (command) {
     case 'write':
@@ -141,14 +142,6 @@ function getPatternsFromProjects(
   projectGraph: ProjectGraph
 ): string[] {
   return getProjectRoots(projects, projectGraph);
-}
-
-function chunkify(target: string[], size: number): string[][] {
-  return target.reduce((current: string[][], value: string, index: number) => {
-    if (index % size === 0) current.push([]);
-    current[current.length - 1].push(value);
-    return current;
-  }, []);
 }
 
 function write(patterns: string[]) {

--- a/packages/nx/src/utils/chunkify.spec.ts
+++ b/packages/nx/src/utils/chunkify.spec.ts
@@ -1,0 +1,15 @@
+import { chunkify } from './chunkify';
+
+describe('chunkify', () => {
+  it('should wrap chunks at passed in size', () => {
+    const files = ['aa', 'bb', 'cc', 'dd', 'ee'];
+    expect(chunkify(files, 4)).toHaveLength(5);
+    expect(chunkify(files, 7)).toHaveLength(3);
+    expect(chunkify(files, 16)).toHaveLength(1);
+  });
+
+  it('should contain all items from target', () => {
+    const files = ['aa', 'bb', 'cc', 'dd', 'ee'];
+    expect(chunkify(files, 7).flat()).toHaveLength(5);
+  });
+});

--- a/packages/nx/src/utils/chunkify.ts
+++ b/packages/nx/src/utils/chunkify.ts
@@ -1,0 +1,41 @@
+import { execSync } from 'child_process';
+
+const TERMINAL_SIZE =
+  process.platform === 'win32' ? 8192 : getUnixTerminalSize();
+
+export function chunkify(
+  target: string[],
+  maxChunkLength: number = TERMINAL_SIZE - 500
+): string[][] {
+  const chunks = [];
+  let currentChunk = [];
+  let currentChunkLength = 0;
+  for (const file of target) {
+    if (
+      // Prevent empty chunk if first file path is longer than maxChunkLength
+      currentChunk.length &&
+      // +1 accounts for the space between file names
+      currentChunkLength + file.length + 1 >= maxChunkLength
+    ) {
+      chunks.push(currentChunk);
+      currentChunk = [];
+      currentChunkLength = 0;
+    }
+    currentChunk.push(file);
+    currentChunkLength += file.length + 1;
+  }
+  chunks.push(currentChunk);
+  return chunks;
+}
+
+function getUnixTerminalSize() {
+  try {
+    const argMax = execSync('getconf ARG_MAX').toString().trim();
+    return Number.parseInt(argMax);
+  } catch {
+    // This number varies by system, but 100k seems like a safe
+    // number from some research...
+    // https://stackoverflow.com/questions/19354870/bash-command-line-and-input-limit
+    return 100000;
+  }
+}


### PR DESCRIPTION
Windows has a pretty short terminal length built in, and we can get errors such as "The command line is too long."

Closes #15301

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
