### PR TITLE
fix(js): handle swcrc path mappings if specified

### DIFF
--- a/packages/js/src/utils/swc/get-swcrc-path.ts
+++ b/packages/js/src/utils/swc/get-swcrc-path.ts
@@ -4,9 +4,14 @@ import { SwcExecutorOptions } from '../schema';
 export function getSwcrcPath(
   options: SwcExecutorOptions,
   contextRoot: string,
-  projectRoot: string
+  projectRoot: string,
+  temp = false
 ) {
-  return options.swcrc
-    ? join(contextRoot, options.swcrc)
-    : join(contextRoot, projectRoot, '.swcrc');
+  let swcrcPath = options.swcrc ?? join(projectRoot, '.swcrc');
+
+  if (temp) {
+    swcrcPath = join('tmp', swcrcPath.replace('.swcrc', '.generated.swcrc'));
+  }
+
+  return join(contextRoot, swcrcPath);
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`jsc.paths` are not handled properly if specified

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
if `jsc.paths` are specified and `jsc.baseUrl` is not, then `js:swc` will attempt to handle swcrc path mappings by specifying a default `baseUrl`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #11635
