### PR TITLE
fix(core): last project should be visible in `nx show projects`

### DIFF
--- a/e2e/nx-misc/src/misc.test.ts
+++ b/e2e/nx-misc/src/misc.test.ts
@@ -35,7 +35,7 @@ describe('Nx Commands', () => {
 
       const s = runCLI('show projects').split('\n');
 
-      expect(s.length).toEqual(4);
+      expect(s.length).toEqual(5);
       expect(s).toContain(app1);
       expect(s).toContain(app2);
       expect(s).toContain(`${app1}-e2e`);

--- a/packages/nx/src/command-line/show.ts
+++ b/packages/nx/src/command-line/show.ts
@@ -3,7 +3,10 @@ import { createProjectGraphAsync } from '../project-graph/project-graph';
 export async function show(args: { object: 'projects' }): Promise<void> {
   if (args.object == 'projects') {
     const graph = await createProjectGraphAsync();
-    process.stdout.write(Object.keys(graph.nodes).join('\n'));
+    const projects = Object.keys(graph.nodes).join('\n');
+    if (projects.length) {
+      console.log(projects);
+    }
   } else {
     throw new Error(`Unrecognized option: ${args.object}`);
   }


### PR DESCRIPTION
Observed last project not being visible when running `nx show`

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
