### PR TITLE
fix(core): inline source maps for local nx plugins

### DIFF
--- a/packages/nx/src/utils/nx-plugin.ts
+++ b/packages/nx/src/utils/nx-plugin.ts
@@ -203,6 +203,7 @@ export function registerPluginTSTranspiler() {
       lib: ['es2021'],
       module: ts.ModuleKind.CommonJS,
       target: ts.ScriptTarget.ES2021,
+      inlineSourceMap: true,
       esModuleInterop: true,
       skipLibCheck: true,
       experimentalDecorators: true,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Running local nx plugins is hard to debug as there's no source maps.

## Expected Behavior
We are able to place debug points in the ts file for local nx plugins and debug as expected. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #13892
