### PR TITLE
fix(core): encapsulated nx repos should invoke wrapper when invoked via npx or global install

### DIFF
--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -62,6 +62,10 @@ if (
 
   // this file is already in the local workspace
   if (localNx === resolveNx(null)) {
+    if (localNx.includes('.nx') && !process.env.NX_WRAPPER_SET) {
+      const nxWrapperPath = localNx.replace(/\.nx.*/, '.nx/') + 'nxw.js';
+      require(nxWrapperPath);
+    }
     initLocal(workspace);
   } else {
     // Nx is being run from globally installed CLI - hand off to the local

--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -47,6 +47,12 @@
       "version": "15.0.12-beta.1",
       "description": "Set project names in project.json files",
       "implementation": "./src/migrations/update-15-1-0/set-project-names"
+    },
+    "15.8.2-update-nx-wrapper": {
+      "cli": "nx",
+      "version": "15.8.2-beta.0",
+      "description": "Updates the nx wrapper in encapsulated repos.",
+      "implementation": "./src/migrations/update-15-8-2/update-nxw"
     }
   }
 }

--- a/packages/nx/src/migrations/update-15-8-2/update-nxw.ts
+++ b/packages/nx/src/migrations/update-15-8-2/update-nxw.ts
@@ -1,0 +1,13 @@
+import {
+  getNxWrapperContents,
+  nxWrapperPath,
+} from 'nx/src/nx-init/encapsulated/add-nx-scripts';
+import { normalizePath } from '../../utils/path';
+import { Tree } from '../../generators/tree';
+
+export default async function (tree: Tree) {
+  const wrapperPath = normalizePath(nxWrapperPath());
+  if (tree.exists(wrapperPath)) {
+    tree.write(wrapperPath, getNxWrapperContents());
+  }
+}

--- a/packages/nx/src/nx-init/encapsulated/add-nx-scripts.ts
+++ b/packages/nx/src/nx-init/encapsulated/add-nx-scripts.ts
@@ -11,7 +11,7 @@ import {
 } from '../../generators/tree';
 import { writeJson } from '../../generators/utils/json';
 
-const nxWrapperPath = (p: typeof import('path') = path) =>
+export const nxWrapperPath = (p: typeof import('path') = path) =>
   p.join('.nx', 'nxw.js');
 
 const NODE_MISSING_ERR =
@@ -36,7 +36,7 @@ export function generateEncapsulatedNxSetup(version?: string) {
   const host = new FsTree(process.cwd(), false);
   writeMinimalNxJson(host, version);
   updateGitIgnore(host);
-  host.write(nxWrapperPath(), getNodeScriptContents());
+  host.write(nxWrapperPath(), getNxWrapperContents());
   host.write('nx.bat', BATCH_SCRIPT_CONTENTS);
   host.write('nx', SHELL_SCRIPT_CONTENTS, {
     mode: FsConstants.S_IXUSR | FsConstants.S_IRUSR | FsConstants.S_IWUSR,
@@ -75,7 +75,7 @@ export function updateGitIgnore(host: Tree) {
   );
 }
 
-function getNodeScriptContents() {
+export function getNxWrapperContents() {
   // Read nxw.js, but remove any empty comments or comments that start with `//#: `
   // This removes the sourceMapUrl since it is invalid, as well as any internal comments.
   return readFileSync(path.join(__dirname, 'nxw.js'), 'utf-8').replace(

--- a/packages/nx/src/nx-init/encapsulated/nxw.ts
+++ b/packages/nx/src/nx-init/encapsulated/nxw.ts
@@ -99,7 +99,8 @@ function ensureUpToDateInstallation() {
   }
 }
 
-if (require.main === module) {
+if (require.main === module && !process.env.NX_WRAPPER_SET) {
+  process.env.NX_WRAPPER_SET = 'true';
   ensureUpToDateInstallation();
   require('./installation/node_modules/nx/bin/nx');
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`npx nx ...` works in a repo with encapsulated Nx, but doesn't invoke the wrapper. This can result in an out of date installation folder being used.

## Expected Behavior
`npx nx ...` works in a repo with encapsulated Nx, and invokes the wrapper.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
