### PR TITLE
fix(devkit): fix extractLayoutDirectory typescript types to better reflect allowed params and return value

### DIFF
--- a/docs/generated/devkit/extractLayoutDirectory.md
+++ b/docs/generated/devkit/extractLayoutDirectory.md
@@ -1,20 +1,20 @@
 # Function: extractLayoutDirectory
 
-▸ **extractLayoutDirectory**(`directory`): `Object`
+▸ **extractLayoutDirectory**(`directory?`): `Object`
 
 Experimental
 
 #### Parameters
 
-| Name        | Type     |
-| :---------- | :------- |
-| `directory` | `string` |
+| Name         | Type     |
+| :----------- | :------- |
+| `directory?` | `string` |
 
 #### Returns
 
 `Object`
 
-| Name               | Type     |
-| :----------------- | :------- |
-| `layoutDirectory`  | `string` |
-| `projectDirectory` | `string` |
+| Name                | Type               |
+| :------------------ | :----------------- |
+| `layoutDirectory`   | `string` \| `null` |
+| `projectDirectory?` | `string`           |

--- a/packages/devkit/src/utils/get-workspace-layout.spec.ts
+++ b/packages/devkit/src/utils/get-workspace-layout.spec.ts
@@ -1,5 +1,8 @@
 import { createTreeWithEmptyWorkspace } from 'nx/src/devkit-testing-exports';
-import { getWorkspaceLayout } from './get-workspace-layout';
+import {
+  getWorkspaceLayout,
+  extractLayoutDirectory,
+} from './get-workspace-layout';
 
 describe('getWorkspaceLayout', () => {
   it('should return selected values', () => {
@@ -56,6 +59,27 @@ describe('getWorkspaceLayout', () => {
       libsDir: '.',
       npmScope: undefined,
       standaloneAsDefault: true,
+    });
+  });
+});
+
+describe('extractLayoutDirectory', () => {
+  it('should extract layout directory', () => {
+    expect(extractLayoutDirectory('apps/my-app')).toEqual({
+      layoutDirectory: 'apps',
+      projectDirectory: 'my-app',
+    });
+    expect(extractLayoutDirectory('libs/my-lib')).toEqual({
+      layoutDirectory: 'libs',
+      projectDirectory: 'my-lib',
+    });
+    expect(extractLayoutDirectory('packages/my-package')).toEqual({
+      layoutDirectory: 'packages',
+      projectDirectory: 'my-package',
+    });
+    expect(extractLayoutDirectory(undefined)).toEqual({
+      layoutDirectory: null,
+      projectDirectory: undefined,
     });
   });
 });

--- a/packages/devkit/src/utils/get-workspace-layout.ts
+++ b/packages/devkit/src/utils/get-workspace-layout.ts
@@ -34,9 +34,9 @@ export function getWorkspaceLayout(tree: Tree): {
 /**
  * Experimental
  */
-export function extractLayoutDirectory(directory: string): {
-  layoutDirectory: string;
-  projectDirectory: string;
+export function extractLayoutDirectory(directory?: string): {
+  layoutDirectory: string | null;
+  projectDirectory?: string;
 } {
   if (directory) {
     directory = directory.startsWith('/') ? directory.substring(1) : directory;


### PR DESCRIPTION
In other projects with more strict TS settings the types on the `extractLayoutDirectory` did not line up with the allowed params and return value.  Example of this I found is in the `@nrwl/react` package that calls this function with `options.directory` which is `string | undefined` which I am not sure why TS is not complaining about this 🤔 

https://github.com/nrwl/nx/blob/b87f838e9a5a1bfb500ba0027c8604dea9492071/packages/react/src/generators/library/lib/normalize-options.ts#L20-L22
