### PR TITLE
docs(core): fix module federation config example

### DIFF
--- a/docs/generated/packages/webpack/documents/webpack-config-setup.md
+++ b/docs/generated/packages/webpack/documents/webpack-config-setup.md
@@ -173,7 +173,7 @@ module.exports = composePlugins(
       // your options here
     });
 
-    return merge(federatedModules(config, context), {
+    return merge(federatedModules(config, { options, context }), {
       // overwrite values here
     });
   }

--- a/docs/shared/packages/webpack/webpack-config-setup.md
+++ b/docs/shared/packages/webpack/webpack-config-setup.md
@@ -173,7 +173,7 @@ module.exports = composePlugins(
       // your options here
     });
 
-    return merge(federatedModules(config, context), {
+    return merge(federatedModules(config, { options, context }), {
       // overwrite values here
     });
   }


### PR DESCRIPTION
~~fix: `await` without `async` callback~~ fixed by: #15387
fix: `withModuleFederation` callback's second argument