### PR TITLE
fix(node): lint generator aware that app is root

### DIFF
--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -267,6 +267,7 @@ export async function addLintingToApplication(
     unitTestRunner: options.unitTestRunner,
     skipFormat: true,
     setParserOptionsProject: options.setParserOptionsProject,
+    rootProject: options.rootProject,
   });
 
   return lintTask;


### PR DESCRIPTION
The lint generator was not aware if the project created is a root-level project.

This could cause an infinite loop when trying to lint.

