### PR TITLE
fix(js): fix parsing link dependencies in yarn

### DIFF
--- a/packages/nx/src/lock-file/yarn-parser.ts
+++ b/packages/nx/src/lock-file/yarn-parser.ts
@@ -141,7 +141,11 @@ function findVersion(
   ) {
     return snapshot.resolution.slice(packageName.length + 1);
   }
-  if (!isBerry && !satisfies(snapshot.version, versionRange)) {
+  if (
+    !isBerry &&
+    snapshot.resolved &&
+    !satisfies(snapshot.version, versionRange)
+  ) {
     return snapshot.resolved;
   }
   // otherwise it's a standard version


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Snapshots of link dependencies do not have a resolved hash:
```
"@webda/aws": "link:../packages/aws/",
```

```
"@webda/aws@link:packages/aws":
  version "2.4.2"
  dependencies:
    "@aws-sdk/client-acm" "^3.58.0"
    ...
 ```

This means Nx will throw an error when creating the graph.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `version` of the snapshot is returned instead.

Nx is able to create a graph with link dependencies.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/15363
Fixes https://github.com/nrwl/nx/issues/15367
