### PR TITLE
fix(node) executor bug on Windows

### DIFF
--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
@@ -2,6 +2,7 @@ import * as esbuild from 'esbuild';
 import * as path from 'path';
 import { join, parse } from 'path';
 import {
+  normalizePath,
   ExecutorContext,
   joinPathFragments,
   ProjectGraphProjectNode,
@@ -197,6 +198,8 @@ export function getRegisterFileContent(
   mainFile: string,
   outExtension = '.js'
 ) {
+  mainFile = normalizePath(mainFile);
+
   // Sort by longest prefix so imports match the most specific path.
   const sortedKeys = Object.keys(paths).sort(
     (a: string, b: string) => getPrefixLength(b) - getPrefixLength(a)


### PR DESCRIPTION
While trying to run any `@nrwl/node` package error occurs as the `mainFile` combined Windows slash(s) `\` Adding this line solves the problem. 
There is probably more to it.

## Current Behavior
Run the same action `nx serve <node-package>` works on MacOS but not on Windows

For example, this is an error shows that the system tried to load the file without any slashes
```bash
For help, see: https://nodejs.org/en/docs/inspector
Error: Cannot find module './packages   estsrcmain.js'
Require stack:
```
Then I looked into the generated file `main-with-require-overrides.js` and found this line
```javascript
// Call the user-defined main.
require('./packages\test\src\main.js');
```
Because the slashes are Windows-style they recognize them as escaping ones.

## Expected Behavior
The value in the generated file should be as follow 
```javascript
// Call the user-defined main.
require('./packages/test/src/main.js');
```
## Related Issue(s)

Fixes #
I've added the line that will `replaceAll` just in case the slashes are indeed Windows-style, there isn't any option when those slashes are required.
