### PR TITLE
fix(core): reverts pull #14893

### DIFF
--- a/docs/generated/devkit/nrwl_devkit.md
+++ b/docs/generated/devkit/nrwl_devkit.md
@@ -48,6 +48,7 @@ It only uses language primitives and immutable objects
 - [ProjectGraphExternalNode](../../devkit/documents/nrwl_devkit#projectgraphexternalnode)
 - [ProjectGraphProcessorContext](../../devkit/documents/nrwl_devkit#projectgraphprocessorcontext)
 - [ProjectGraphProjectNode](../../devkit/documents/nrwl_devkit#projectgraphprojectnode)
+- [ProjectGraphV4](../../devkit/documents/nrwl_devkit#projectgraphv4)
 
 ### Tree Interfaces
 
@@ -301,6 +302,18 @@ A plugin for Nx
 ### ProjectGraphProjectNode
 
 • **ProjectGraphProjectNode**: `Object`
+
+---
+
+### ProjectGraphV4
+
+• **ProjectGraphV4**<`T`\>: `Object`
+
+#### Type parameters
+
+| Name | Type  |
+| :--- | :---- |
+| `T`  | `any` |
 
 ---
 

--- a/docs/generated/packages/devkit/documents/index.md
+++ b/docs/generated/packages/devkit/documents/index.md
@@ -48,6 +48,7 @@ It only uses language primitives and immutable objects
 - [ProjectGraphExternalNode](../../devkit/documents/nrwl_devkit#projectgraphexternalnode)
 - [ProjectGraphProcessorContext](../../devkit/documents/nrwl_devkit#projectgraphprocessorcontext)
 - [ProjectGraphProjectNode](../../devkit/documents/nrwl_devkit#projectgraphprojectnode)
+- [ProjectGraphV4](../../devkit/documents/nrwl_devkit#projectgraphv4)
 
 ### Tree Interfaces
 
@@ -297,6 +298,18 @@ A plugin for Nx
 ### ProjectGraphProjectNode
 
 • **ProjectGraphProjectNode**: `Object`
+
+---
+
+### ProjectGraphV4
+
+• **ProjectGraphV4**<`T`\>: `Object`
+
+#### Type parameters
+
+| Name | Type  |
+| :--- | :---- |
+| `T`  | `any` |
 
 ---
 

--- a/docs/generated/packages/devkit/documents/nrwl_devkit.md
+++ b/docs/generated/packages/devkit/documents/nrwl_devkit.md
@@ -48,6 +48,7 @@ It only uses language primitives and immutable objects
 - [ProjectGraphExternalNode](../../devkit/documents/nrwl_devkit#projectgraphexternalnode)
 - [ProjectGraphProcessorContext](../../devkit/documents/nrwl_devkit#projectgraphprocessorcontext)
 - [ProjectGraphProjectNode](../../devkit/documents/nrwl_devkit#projectgraphprojectnode)
+- [ProjectGraphV4](../../devkit/documents/nrwl_devkit#projectgraphv4)
 
 ### Tree Interfaces
 
@@ -301,6 +302,18 @@ A plugin for Nx
 ### ProjectGraphProjectNode
 
 • **ProjectGraphProjectNode**: `Object`
+
+---
+
+### ProjectGraphV4
+
+• **ProjectGraphV4**<`T`\>: `Object`
+
+#### Type parameters
+
+| Name | Type  |
+| :--- | :---- |
+| `T`  | `any` |
 
 ---
 

--- a/docs/shared/recipes/plugins/project-graph-plugins.md
+++ b/docs/shared/recipes/plugins/project-graph-plugins.md
@@ -86,9 +86,11 @@ You can create 2 types of dependencies.
 
 ### Implicit Dependencies
 
-An implicit dependency is not associated with any file, and can be created as follows:
+An implicit dependency is not associated with any file, and can be crated as follows:
 
 ```typescript
+import { DependencyType } from '@nrwl/devkit';
+
 // Add a new edge
 builder.addImplicitDependency('existing-project', 'new-project');
 ```
@@ -99,36 +101,22 @@ Even though the plugin is written in JavaScript, resolving dependencies of diffe
 
 Because an implicit dependency is not associated with any file, Nx doesn't know when it might change, so it will be recomputed every time.
 
-## Static Dependencies
+## Explicit Dependencies
 
 Nx knows what files have changed since the last invocation. Only those files will be present in the provided `filesToProcess`. You can associate a dependency with a particular file (e.g., if that file contains an import).
-
-```typescript
-// Add a new edge
-builder.addStaticDependency(
-  'existing-project',
-  'new-project',
-  'libs/existing-project/src/index.ts'
-);
-```
-
-If a file hasn't changed since the last invocation, it doesn't need to be reanalyzed. Nx knows what dependencies are associated with what files, so it will reuse this information for the files that haven't changed.
-
-## Dynamic Dependencies
-
-Dynamic dependencies are a special type of explicit dependencies. In contrast to standard `explicit` dependencies, they are only imported in the runtime under specific conditions.
-A typical example would be lazy-loaded routes. Having separation between these two allows us to identify situations where static import breaks the lazy-loading.
 
 ```typescript
 import { DependencyType } from '@nrwl/devkit';
 
 // Add a new edge
-builder.addDynamicDependency(
+builder.addExplicitDependency(
   'existing-project',
-  'lazy-route',
-  'libs/existing-project/src/router-setup.ts'
+  'libs/existing-project/src/index.ts',
+  'new-project'
 );
 ```
+
+If a file hasn't changed since the last invocation, it doesn't need to be reanalyzed. Nx knows what dependencies are associated with what files, so it will reuse this information for the files that haven't changed.
 
 ## Visualizing the Project Graph
 

--- a/e2e/nx-run/src/affected-graph.test.ts
+++ b/e2e/nx-run/src/affected-graph.test.ts
@@ -488,7 +488,7 @@ describe('Nx Affected and Graph Tests', () => {
               target: mylib,
               type: 'static',
             },
-            { source: myapp, target: mylib2, type: 'dynamic' },
+            { source: myapp, target: mylib2, type: 'static' },
           ],
           [myappE2e]: [
             {

--- a/graph/client/src/app/mock-project-graph-service.ts
+++ b/graph/client/src/app/mock-project-graph-service.ts
@@ -1,6 +1,5 @@
 // nx-ignore-next-line
 import type {
-  DependencyType,
   ProjectGraphDependency,
   ProjectGraphProjectNode,
 } from '@nrwl/devkit';
@@ -29,13 +28,7 @@ export class MockProjectGraphService implements ProjectGraphService {
             {
               file: 'some/file.ts',
               hash: 'ecccd8481d2e5eae0e59928be1bc4c2d071729d7',
-              dependencies: [
-                {
-                  target: 'existing-lib-1',
-                  source: 'existing-app-1',
-                  type: 'static' as DependencyType,
-                },
-              ],
+              deps: ['existing-lib-1'],
             },
           ],
         },

--- a/graph/ui-graph/src/lib/util-cytoscape/render-graph.ts
+++ b/graph/ui-graph/src/lib/util-cytoscape/render-graph.ts
@@ -281,9 +281,7 @@ export class RenderGraph {
               .source()
               .data('files')
               ?.filter(
-                (file) =>
-                  file.dependencies &&
-                  file.dependencies.find((d) => d.target === edge.target().id())
+                (file) => file.deps && file.deps.includes(edge.target().id())
               )
               .map((file) => {
                 return {

--- a/packages/angular/src/executors/delegate-build/delegate-build.impl.spec.ts
+++ b/packages/angular/src/executors/delegate-build/delegate-build.impl.spec.ts
@@ -1,13 +1,6 @@
 jest.mock('@nrwl/devkit');
 jest.mock('@nrwl/devkit');
 jest.mock('@nrwl/workspace/src/utilities/buildable-libs-utils');
-// nested code imports graph from the repo, which might have innacurate graph version
-jest.mock('nx/src/project-graph/project-graph', () => ({
-  ...jest.requireActual<any>('nx/src/project-graph/project-graph'),
-  readCachedProjectGraph: jest
-    .fn()
-    .mockImplementation(async () => ({ nodes: {}, dependencies: {} })),
-}));
 
 import type { ExecutorContext, Target } from '@nrwl/devkit';
 import * as devkit from '@nrwl/devkit';

--- a/packages/angular/src/generators/cypress-component-configuration/cypress-component-configuration.spec.ts
+++ b/packages/angular/src/generators/cypress-component-configuration/cypress-component-configuration.spec.ts
@@ -22,14 +22,6 @@ jest.mock('@nrwl/devkit', () => ({
     .fn()
     .mockImplementation(async () => projectGraph),
 }));
-// nested code imports graph from the repo, which might have innacurate graph version
-jest.mock('nx/src/project-graph/project-graph', () => ({
-  ...jest.requireActual<any>('nx/src/project-graph/project-graph'),
-  readCachedProjectGraph: jest
-    .fn()
-    .mockImplementation(async () => projectGraph),
-}));
-
 describe('Cypress Component Testing Configuration', () => {
   let tree: Tree;
   let mockedInstalledCypressVersion: jest.Mock<

--- a/packages/angular/src/generators/storybook-configuration/storybook-configuration.spec.ts
+++ b/packages/angular/src/generators/storybook-configuration/storybook-configuration.spec.ts
@@ -11,14 +11,6 @@ import { storybookConfigurationGenerator } from './storybook-configuration';
 // need to mock cypress otherwise it'll use the nx installed version from package.json
 //  which is v9 while we are testing for the new v10 version
 jest.mock('@nrwl/cypress/src/utils/cypress-version');
-// nested code imports graph from the repo, which might have innacurate graph version
-jest.mock('nx/src/project-graph/project-graph', () => ({
-  ...jest.requireActual<any>('nx/src/project-graph/project-graph'),
-  createProjectGraphAsync: jest
-    .fn()
-    .mockImplementation(async () => ({ nodes: {}, dependencies: {} })),
-}));
-
 function listFiles(tree: Tree): string[] {
   const files = new Set<string>();
   tree.listChanges().forEach((change) => {

--- a/packages/cypress/src/migrations/update-15-0-0/update-cy-mount-usage.spec.ts
+++ b/packages/cypress/src/migrations/update-15-0-0/update-cy-mount-usage.spec.ts
@@ -12,16 +12,7 @@ import {
 } from './update-cy-mount-usage';
 import { libraryGenerator } from '@nrwl/workspace';
 import { cypressComponentProject } from '../../generators/cypress-component-project/cypress-component-project';
-
 jest.mock('../../utils/cypress-version');
-// nested code imports graph from the repo, which might have innacurate graph version
-jest.mock('nx/src/project-graph/project-graph', () => ({
-  ...jest.requireActual<any>('nx/src/project-graph/project-graph'),
-  createProjectGraphAsync: jest
-    .fn()
-    .mockImplementation(async () => ({ nodes: {}, dependencies: {} })),
-}));
-
 describe('update cy.mount usage', () => {
   let tree: Tree;
   let mockedInstalledCypressVersion: jest.Mock<

--- a/packages/devkit/nx-reexports-pre16.ts
+++ b/packages/devkit/nx-reexports-pre16.ts
@@ -137,6 +137,7 @@ export type {
   ProjectFileMap,
   FileData,
   ProjectGraph,
+  ProjectGraphV4,
   ProjectGraphDependency,
   ProjectGraphNode,
   ProjectGraphProjectNode,

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.spec.ts
@@ -1,10 +1,6 @@
 import 'nx/src/utils/testing/mock-fs';
 
-import type {
-  FileData,
-  ProjectGraph,
-  ProjectGraphDependency,
-} from '@nrwl/devkit';
+import type { FileData, ProjectGraph } from '@nrwl/devkit';
 import { DependencyType } from '@nrwl/devkit';
 import * as parser from '@typescript-eslint/parser';
 import { TSESLint } from '@typescript-eslint/utils';
@@ -288,13 +284,7 @@ describe('Enforce Module Boundaries (eslint)', () => {
             implicitDependencies: [],
             targets: {},
             files: [
-              createFile(`libs/dependsOnPrivate/src/index.ts`, [
-                {
-                  source: 'dependsOnPrivateName',
-                  type: 'static',
-                  target: 'privateName',
-                },
-              ]),
+              createFile(`libs/dependsOnPrivate/src/index.ts`, ['privateName']),
             ],
           },
         },
@@ -308,11 +298,7 @@ describe('Enforce Module Boundaries (eslint)', () => {
             targets: {},
             files: [
               createFile(`libs/dependsOnPrivate2/src/index.ts`, [
-                {
-                  source: 'dependsOnPrivateName2',
-                  type: 'static',
-                  target: 'privateName',
-                },
+                'privateName',
               ]),
             ],
           },
@@ -327,12 +313,8 @@ describe('Enforce Module Boundaries (eslint)', () => {
             targets: {},
             files: [
               createFile(`libs/private/src/index.ts`, [
-                {
-                  source: 'privateName',
-                  type: 'static',
-                  target: 'untaggedName',
-                },
-                { source: 'privateName', type: 'static', target: 'taggedName' },
+                'untaggedName',
+                'taggedName',
               ]),
             ],
           },
@@ -1437,15 +1419,7 @@ Violation detected in:
               tags: [],
               implicitDependencies: [],
               targets: {},
-              files: [
-                createFile(`libs/mylib/src/main.ts`, [
-                  {
-                    source: 'mylibName',
-                    type: 'static',
-                    target: 'anotherlibName',
-                  },
-                ]),
-              ],
+              files: [createFile(`libs/mylib/src/main.ts`, ['anotherlibName'])],
             },
           },
           anotherlibName: {
@@ -1456,15 +1430,7 @@ Violation detected in:
               tags: [],
               implicitDependencies: [],
               targets: {},
-              files: [
-                createFile(`libs/anotherlib/src/main.ts`, [
-                  {
-                    source: 'anotherlibName',
-                    type: 'static',
-                    target: 'mylibName',
-                  },
-                ]),
-              ],
+              files: [createFile(`libs/anotherlib/src/main.ts`, ['mylibName'])],
             },
           },
           myappName: {
@@ -1520,13 +1486,7 @@ Circular file chain:
               implicitDependencies: [],
               targets: {},
               files: [
-                createFile(`libs/mylib/src/main.ts`, [
-                  {
-                    source: 'badcirclelibName',
-                    type: 'static',
-                    target: 'mylibName',
-                  },
-                ]),
+                createFile(`libs/mylib/src/main.ts`, ['badcirclelibName']),
               ],
             },
           },
@@ -1539,20 +1499,8 @@ Circular file chain:
               implicitDependencies: [],
               targets: {},
               files: [
-                createFile(`libs/anotherlib/src/main.ts`, [
-                  {
-                    source: 'anotherlibName',
-                    type: 'static',
-                    target: 'mylibName',
-                  },
-                ]),
-                createFile(`libs/anotherlib/src/index.ts`, [
-                  {
-                    source: 'anotherlibName',
-                    type: 'static',
-                    target: 'mylibName',
-                  },
-                ]),
+                createFile(`libs/anotherlib/src/main.ts`, ['mylibName']),
+                createFile(`libs/anotherlib/src/index.ts`, ['mylibName']),
               ],
             },
           },
@@ -1565,13 +1513,7 @@ Circular file chain:
               implicitDependencies: [],
               targets: {},
               files: [
-                createFile(`libs/badcirclelib/src/main.ts`, [
-                  {
-                    source: 'badcirclelibName',
-                    type: 'static',
-                    target: 'anotherlibName',
-                  },
-                ]),
+                createFile(`libs/badcirclelib/src/main.ts`, ['anotherlibName']),
               ],
             },
           },
@@ -2083,11 +2025,8 @@ const baseConfig = {
 linter.defineParser('@typescript-eslint/parser', parser);
 linter.defineRule(enforceModuleBoundariesRuleName, enforceModuleBoundaries);
 
-function createFile(
-  f: string,
-  dependencies?: ProjectGraphDependency[]
-): FileData {
-  return { file: f, hash: '', ...(dependencies && { dependencies }) };
+function createFile(f: string, deps?: string[]): FileData {
+  return { file: f, hash: '', ...(deps && { deps }) };
 }
 
 function runRule(

--- a/packages/eslint-plugin-nx/src/utils/graph-utils.ts
+++ b/packages/eslint-plugin-nx/src/utils/graph-utils.ts
@@ -146,9 +146,7 @@ export function findFilesInCircularPath(
     filePathChain.push(
       Object.keys(files)
         .filter(
-          (key) =>
-            files[key].dependencies &&
-            files[key].dependencies.find((d) => d.target === next)
+          (key) => files[key].deps && files[key].deps.indexOf(next) !== -1
         )
         .map((key) => files[key].file)
     );

--- a/packages/nx/src/config/project-graph.ts
+++ b/packages/nx/src/config/project-graph.ts
@@ -11,9 +11,7 @@ import { NxJsonConfiguration } from './nx-json';
 export interface FileData {
   file: string;
   hash: string;
-  /** @deprecated this field will be removed in v17. Use {@link dependencies} instead */
   deps?: string[];
-  dependencies?: ProjectGraphDependency[];
 }
 
 /**
@@ -29,6 +27,15 @@ export interface ProjectFileMap {
 export interface ProjectGraph {
   nodes: Record<string, ProjectGraphProjectNode>;
   externalNodes?: Record<string, ProjectGraphExternalNode>;
+  dependencies: Record<string, ProjectGraphDependency[]>;
+  // this is optional otherwise it might break folks who use project graph creation
+  allWorkspaceFiles?: FileData[];
+  version?: string;
+}
+
+/** @deprecated this type will be removed in v16. Use {@link ProjectGraph} instead */
+export interface ProjectGraphV4<T = any> {
+  nodes: Record<string, ProjectGraphNode>;
   dependencies: Record<string, ProjectGraphDependency[]>;
   // this is optional otherwise it might break folks who use project graph creation
   allWorkspaceFiles?: FileData[];
@@ -118,7 +125,7 @@ export interface ProjectGraphDependency {
 export interface ProjectGraphProcessorContext {
   /**
    * Workspace information such as projects and configuration
-   * @deprecated use {@link projectsConfigurations} or {@link nxJsonConfiguration} instead
+   * @deprecated use projectsConfigurations or nxJsonConfiguration
    */
   workspace: Workspace;
 

--- a/packages/nx/src/devkit-exports.ts
+++ b/packages/nx/src/devkit-exports.ts
@@ -132,6 +132,7 @@ export type {
   ProjectFileMap,
   FileData,
   ProjectGraph,
+  ProjectGraphV4,
   ProjectGraphDependency,
   ProjectGraphNode,
   ProjectGraphProjectNode,

--- a/packages/nx/src/hasher/hasher.ts
+++ b/packages/nx/src/hasher/hasher.ts
@@ -285,8 +285,6 @@ class TaskHasher {
     visited: string[]
   ) {
     const projectGraphDeps = this.projectGraph.dependencies[projectName] ?? [];
-    // we don't want random order of dependencies to change the hash
-    projectGraphDeps.sort((a, b) => a.target.localeCompare(b.target));
 
     const self = await this.hashSelfInputs(projectName, selfInputs);
     const deps = await this.hashDepsInputs(

--- a/packages/nx/src/lock-file/npm-parser.ts
+++ b/packages/nx/src/lock-file/npm-parser.ts
@@ -227,7 +227,7 @@ function addDependencies(
           Object.entries(section).forEach(([name, versionRange]) => {
             const target = findTarget(path, keyMap, name, versionRange);
             if (target) {
-              builder.addStaticDependency(sourceName, target.name);
+              builder.addExternalNodeDependency(sourceName, target.name);
             }
           });
         }
@@ -288,7 +288,7 @@ function addV1NodeDependencies(
     Object.entries(snapshot.requires).forEach(([name, versionRange]) => {
       const target = findTarget(path, keyMap, name, versionRange);
       if (target) {
-        builder.addStaticDependency(source, target.name);
+        builder.addExternalNodeDependency(source, target.name);
       }
     });
   }
@@ -314,7 +314,7 @@ function addV1NodeDependencies(
       ) {
         const target = findTarget(path, keyMap, depName, depSpec);
         if (target) {
-          builder.addStaticDependency(node.name, target.name);
+          builder.addExternalNodeDependency(node.name, target.name);
         }
       }
     });

--- a/packages/nx/src/lock-file/pnpm-parser.ts
+++ b/packages/nx/src/lock-file/pnpm-parser.ts
@@ -130,7 +130,7 @@ function addDependencies(
               builder.graph.externalNodes[`npm:${name}@${version}`] ||
               builder.graph.externalNodes[`npm:${name}`];
             if (target) {
-              builder.addStaticDependency(node.name, target.name);
+              builder.addExternalNodeDependency(node.name, target.name);
             }
           });
         }

--- a/packages/nx/src/lock-file/project-graph-pruning.ts
+++ b/packages/nx/src/lock-file/project-graph-pruning.ts
@@ -120,7 +120,7 @@ function traverseNode(
   graph.dependencies[node.name]?.forEach((dep) => {
     const depNode = graph.externalNodes[dep.target];
     traverseNode(graph, builder, depNode);
-    builder.addStaticDependency(node.name, dep.target);
+    builder.addExternalNodeDependency(node.name, dep.target);
   });
 }
 
@@ -197,12 +197,12 @@ function switchNodeToHoisted(
   invBuilder.addExternalNode(node);
 
   targets.forEach((target) => {
-    builder.addStaticDependency(node.name, target);
-    invBuilder.addStaticDependency(target, node.name);
+    builder.addExternalNodeDependency(node.name, target);
+    invBuilder.addExternalNodeDependency(target, node.name);
   });
   sources.forEach((source) => {
-    builder.addStaticDependency(source, node.name);
-    invBuilder.addStaticDependency(node.name, source);
+    builder.addExternalNodeDependency(source, node.name);
+    invBuilder.addExternalNodeDependency(node.name, source);
   });
 }
 

--- a/packages/nx/src/lock-file/yarn-parser.ts
+++ b/packages/nx/src/lock-file/yarn-parser.ts
@@ -173,7 +173,7 @@ function addDependencies(
                   keyMap.get(`${name}@npm:${versionRange}`) ||
                   keyMap.get(`${name}@${versionRange}`);
                 if (target) {
-                  builder.addStaticDependency(node.name, target.name);
+                  builder.addExternalNodeDependency(node.name, target.name);
                 }
               });
             }

--- a/packages/nx/src/project-graph/build-dependencies/build-explicit-typescript-and-package-json-dependencies.ts
+++ b/packages/nx/src/project-graph/build-dependencies/build-explicit-typescript-and-package-json-dependencies.ts
@@ -1,7 +1,4 @@
-import {
-  buildExplicitTypeScriptDependencies,
-  ExplicitDependency,
-} from './explicit-project-dependencies';
+import { buildExplicitTypeScriptDependencies } from './explicit-project-dependencies';
 import { buildExplicitPackageJsonDependencies } from './explicit-package-json-dependencies';
 import { ProjectFileMap, ProjectGraph } from '../../config/project-graph';
 import { ProjectsConfigurations } from '../../config/workspace-json-project-json';
@@ -17,7 +14,7 @@ export function buildExplicitTypescriptAndPackageJsonDependencies(
   projectGraph: ProjectGraph,
   filesToProcess: ProjectFileMap
 ) {
-  let res: ExplicitDependency[] = [];
+  let res = [];
 
   let typescriptExists = false;
 

--- a/packages/nx/src/project-graph/build-dependencies/explicit-package-json-dependencies.ts
+++ b/packages/nx/src/project-graph/build-dependencies/explicit-package-json-dependencies.ts
@@ -5,7 +5,6 @@ import { parseJson } from '../../utils/json';
 import { getImportPath, joinPathFragments } from '../../utils/path';
 import { ProjectsConfigurations } from '../../config/workspace-json-project-json';
 import { NxJsonConfiguration } from '../../config/nx-json';
-import { ExplicitDependency } from './explicit-project-dependencies';
 
 class ProjectGraphNodeRecords {}
 
@@ -75,7 +74,7 @@ function processPackageJson(
   sourceProject: string,
   fileName: string,
   graph: ProjectGraph,
-  collectedDeps: ExplicitDependency[],
+  collectedDeps: any[],
   packageNameMap: { [packageName: string]: string }
 ) {
   try {

--- a/packages/nx/src/project-graph/build-dependencies/explicit-project-dependencies.spec.ts
+++ b/packages/nx/src/project-graph/build-dependencies/explicit-project-dependencies.spec.ts
@@ -46,25 +46,21 @@ describe('explicit project dependencies', () => {
           sourceProjectName,
           sourceProjectFile: 'libs/proj/index.ts',
           targetProjectName: 'proj2',
-          type: 'static',
         },
         {
           sourceProjectName,
           sourceProjectFile: 'libs/proj/index.ts',
           targetProjectName: 'proj3a',
-          type: 'dynamic',
         },
         {
           sourceProjectName,
           sourceProjectFile: 'libs/proj/index.ts',
           targetProjectName: 'proj4ab',
-          type: 'static',
         },
         {
           sourceProjectName,
           sourceProjectFile: 'libs/proj/index.ts',
           targetProjectName: 'npm:npm-package',
-          type: 'static',
         },
       ]);
     });
@@ -95,19 +91,16 @@ describe('explicit project dependencies', () => {
           sourceProjectName,
           sourceProjectFile: 'libs/proj/index.ts',
           targetProjectName: 'proj2',
-          type: 'static',
         },
         {
           sourceProjectName,
           sourceProjectFile: 'libs/proj/index.ts',
           targetProjectName: 'proj3a',
-          type: 'static',
         },
         {
           sourceProjectName,
           sourceProjectFile: 'libs/proj/index.ts',
           targetProjectName: 'proj4ab',
-          type: 'static',
         },
       ]);
     });
@@ -138,19 +131,16 @@ describe('explicit project dependencies', () => {
           sourceProjectName,
           sourceProjectFile: 'libs/proj/index.ts',
           targetProjectName: 'proj2',
-          type: 'static',
         },
         {
           sourceProjectName,
           sourceProjectFile: 'libs/proj/index.ts',
           targetProjectName: 'proj3a',
-          type: 'static',
         },
         {
           sourceProjectName,
           sourceProjectFile: 'libs/proj/index.ts',
           targetProjectName: 'proj4ab',
-          type: 'static',
         },
       ]);
     });
@@ -178,7 +168,7 @@ describe('explicit project dependencies', () => {
           },
           {
             path: 'libs/proj/component.tsx',
-            content: `
+            content: `              
               export function App() {
                 import('@proj/my-second-proj')
                 return (
@@ -202,19 +192,16 @@ describe('explicit project dependencies', () => {
           sourceProjectName,
           sourceProjectFile: 'libs/proj/component.tsx',
           targetProjectName: 'proj2',
-          type: 'dynamic',
         },
         {
           sourceProjectName,
           sourceProjectFile: 'libs/proj/nested-dynamic-import.ts',
           targetProjectName: 'proj3a',
-          type: 'dynamic',
         },
         {
           sourceProjectName,
           sourceProjectFile: 'libs/proj/nested-require.ts',
           targetProjectName: 'proj4ab',
-          type: 'static',
         },
       ]);
     });
@@ -249,13 +236,11 @@ describe('explicit project dependencies', () => {
           sourceProjectName,
           sourceProjectFile: 'libs/proj/absolute-path.ts',
           targetProjectName: 'proj3a',
-          type: 'dynamic',
         },
         {
           sourceProjectName,
           sourceProjectFile: 'libs/proj/relative-path.ts',
           targetProjectName: 'proj4ab',
-          type: 'dynamic',
         },
       ]);
     });
@@ -328,15 +313,15 @@ describe('explicit project dependencies', () => {
           {
             path: 'libs/proj/comments-with-excess-whitespace.ts',
             content: `
-              /*
+              /* 
                 nx-ignore-next-line
-
+                
                 */
               require('@proj/proj4ab');
               //     nx-ignore-next-line
               import('@proj/proj4ab');
-              /*
-
+              /* 
+                
               nx-ignore-next-line */
               import { foo } from '@proj/proj4ab';
             `,
@@ -479,13 +464,11 @@ describe('explicit project dependencies', () => {
           sourceProjectName,
           sourceProjectFile: 'libs/proj/file-1.ts',
           targetProjectName: 'proj4ab',
-          type: 'dynamic',
         },
         {
           sourceProjectName,
           sourceProjectFile: 'libs/proj/file-2.ts',
           targetProjectName: 'proj3a',
-          type: 'dynamic',
         },
       ]);
     });

--- a/packages/nx/src/project-graph/build-dependencies/explicit-project-dependencies.ts
+++ b/packages/nx/src/project-graph/build-dependencies/explicit-project-dependencies.ts
@@ -6,13 +6,6 @@ import {
   ProjectGraph,
 } from '../../config/project-graph';
 
-export type ExplicitDependency = {
-  sourceProjectName: string;
-  targetProjectName: string;
-  sourceProjectFile: string;
-  type?: DependencyType.static | DependencyType.dynamic;
-};
-
 export function buildExplicitTypeScriptDependencies(
   graph: ProjectGraph,
   filesToProcess: ProjectFileMap
@@ -26,16 +19,12 @@ export function buildExplicitTypeScriptDependencies(
     graph.nodes as any,
     graph.externalNodes
   );
-  const res: ExplicitDependency[] = [];
+  const res = [] as any;
   Object.keys(filesToProcess).forEach((source) => {
     Object.values(filesToProcess[source]).forEach((f) => {
       importLocator.fromFile(
         f.file,
-        (
-          importExpr: string,
-          filePath: string,
-          type: DependencyType.static | DependencyType.dynamic
-        ) => {
+        (importExpr: string, filePath: string, type: DependencyType) => {
           const target = targetProjectLocator.findProjectWithImport(
             importExpr,
             f.file
@@ -50,7 +39,6 @@ export function buildExplicitTypeScriptDependencies(
               sourceProjectName: source,
               targetProjectName: target,
               sourceProjectFile: f.file,
-              type,
             });
           }
         }

--- a/packages/nx/src/project-graph/build-project-graph.spec.ts
+++ b/packages/nx/src/project-graph/build-project-graph.spec.ts
@@ -243,6 +243,7 @@ describe('project graph', () => {
     expect(graph.dependencies).toEqual({
       api: [{ source: 'api', target: 'npm:express', type: 'static' }],
       demo: [
+        { source: 'demo', target: 'api', type: 'implicit' },
         {
           source: 'demo',
           target: 'ui',
@@ -252,9 +253,8 @@ describe('project graph', () => {
         {
           source: 'demo',
           target: 'lazy-lib',
-          type: 'dynamic',
+          type: 'static',
         },
-        { source: 'demo', target: 'api', type: 'implicit' },
       ],
       'demo-e2e': [],
       'lazy-lib': [],
@@ -267,7 +267,7 @@ describe('project graph', () => {
         {
           source: 'ui',
           target: 'lazy-lib',
-          type: 'dynamic',
+          type: 'static',
         },
       ],
     });
@@ -295,7 +295,7 @@ describe('project graph', () => {
         target: 'shared-util',
       },
       {
-        type: DependencyType.dynamic,
+        type: DependencyType.static,
         source: 'ui',
         target: 'lazy-lib',
       },

--- a/packages/nx/src/project-graph/nx-deps-cache.spec.ts
+++ b/packages/nx/src/project-graph/nx-deps-cache.spec.ts
@@ -13,7 +13,7 @@ describe('nx deps utils', () => {
     it('should be false when nothing changes', () => {
       expect(
         shouldRecomputeWholeGraph(
-          createCache({ version: '5.1' }),
+          createCache({ version: '5.0' }),
           createPackageJsonDeps({}),
           createWorkspaceJson({}),
           createNxJson({}),
@@ -318,7 +318,7 @@ describe('nx deps utils', () => {
 
   function createCache(p: Partial<ProjectGraphCache>): ProjectGraphCache {
     const defaults: ProjectGraphCache = {
-      version: '5.1',
+      version: '5.0',
       deps: {
         '@nrwl/workspace': '12.0.0',
         plugin: '1.0.0',

--- a/packages/nx/src/project-graph/nx-deps-cache.ts
+++ b/packages/nx/src/project-graph/nx-deps-cache.ts
@@ -94,7 +94,7 @@ export function createCache(
     version: packageJsonDeps[p],
   }));
   const newValue: ProjectGraphCache = {
-    version: projectGraph.version || '5.1',
+    version: projectGraph.version || '5.0',
     deps: packageJsonDeps,
     lockFileHash,
     // compilerOptions may not exist, especially for repos converted through add-nx-to-monorepo
@@ -149,7 +149,7 @@ export function shouldRecomputeWholeGraph(
   nxJson: NxJsonConfiguration,
   tsConfig: { compilerOptions: { paths: { [k: string]: any } } }
 ): boolean {
-  if (cache.version !== '5.1') {
+  if (cache.version !== '5.0') {
     return true;
   }
   if (cache.deps['@nrwl/workspace'] !== packageJsonDeps['@nrwl/workspace']) {

--- a/packages/nx/src/project-graph/project-graph-builder.spec.ts
+++ b/packages/nx/src/project-graph/project-graph-builder.spec.ts
@@ -25,7 +25,7 @@ describe('ProjectGraphBuilder', () => {
     });
   });
 
-  it(`should add a dependency`, () => {
+  it(`should add an implicit dependency`, () => {
     expect(() =>
       builder.addImplicitDependency('invalid-source', 'target')
     ).toThrowError();
@@ -34,39 +34,10 @@ describe('ProjectGraphBuilder', () => {
     ).toThrowError();
 
     // ignore the self deps
-    builder.addDynamicDependency('source', 'source', 'source/index.ts');
+    builder.addImplicitDependency('source', 'source');
 
-    // don't include duplicates of the same type
+    // don't include duplicates
     builder.addImplicitDependency('source', 'target');
-    builder.addImplicitDependency('source', 'target');
-    builder.addStaticDependency('source', 'target', 'source/index.ts');
-    builder.addDynamicDependency('source', 'target', 'source/index.ts');
-    builder.addStaticDependency('source', 'target', 'source/index.ts');
-
-    const graph = builder.getUpdatedProjectGraph();
-    expect(graph.dependencies).toEqual({
-      source: [
-        {
-          source: 'source',
-          target: 'target',
-          type: 'implicit',
-        },
-        {
-          source: 'source',
-          target: 'target',
-          type: 'static',
-        },
-        {
-          source: 'source',
-          target: 'target',
-          type: 'dynamic',
-        },
-      ],
-      target: [],
-    });
-  });
-
-  it(`should add an implicit dependency`, () => {
     builder.addImplicitDependency('source', 'target');
 
     const graph = builder.getUpdatedProjectGraph();
@@ -125,10 +96,10 @@ describe('ProjectGraphBuilder', () => {
     });
   });
 
-  it(`should use both deps when both implicit and explicit deps are available`, () => {
+  it(`should use implicit dep when both implicit and explicit deps are available`, () => {
     // don't include duplicates
     builder.addImplicitDependency('source', 'target');
-    builder.addStaticDependency('source', 'target', 'source/index.ts');
+    builder.addExplicitDependency('source', 'source/index.ts', 'target');
 
     const graph = builder.getUpdatedProjectGraph();
     expect(graph.dependencies).toEqual({
@@ -137,11 +108,6 @@ describe('ProjectGraphBuilder', () => {
           source: 'source',
           target: 'target',
           type: 'implicit',
-        },
-        {
-          source: 'source',
-          target: 'target',
-          type: 'static',
         },
       ],
       target: [],
@@ -155,7 +121,7 @@ describe('ProjectGraphBuilder', () => {
       data: {} as any,
     });
     builder.addImplicitDependency('source', 'target');
-    builder.addStaticDependency('source', 'target', 'source/index.ts');
+    builder.addExplicitDependency('source', 'source/index.ts', 'target');
     builder.addImplicitDependency('source', 'target2');
     builder.removeDependency('source', 'target');
 

--- a/packages/nx/src/project-graph/project-graph-builder.ts
+++ b/packages/nx/src/project-graph/project-graph-builder.ts
@@ -44,6 +44,7 @@ export class ProjectGraphBuilder {
       }
     }
     this.graph.nodes[node.name] = node;
+    this.graph.dependencies[node.name] = [];
   }
 
   /**
@@ -71,61 +72,29 @@ export class ProjectGraphBuilder {
   }
 
   /**
-   * Adds static dependency from source project to target project
-   */
-  addStaticDependency(
-    sourceProjectName: string,
-    targetProjectName: string,
-    sourceProjectFile?: string
-  ): void {
-    if (this.graph.nodes[sourceProjectName] && !sourceProjectFile) {
-      throw new Error(`Source project file is required`);
-    }
-    this.addDependency(
-      sourceProjectName,
-      targetProjectName,
-      DependencyType.static,
-      sourceProjectFile
-    );
-  }
-
-  /**
-   * Adds dynamic dependency from source project to target project
-   */
-  addDynamicDependency(
-    sourceProjectName: string,
-    targetProjectName: string,
-    sourceProjectFile: string
-  ): void {
-    if (this.graph.externalNodes[sourceProjectName]) {
-      throw new Error(`External projects can't have "dynamic" dependencies`);
-    }
-    if (!sourceProjectFile) {
-      throw new Error(`Source project file is required`);
-    }
-    this.addDependency(
-      sourceProjectName,
-      targetProjectName,
-      DependencyType.dynamic,
-      sourceProjectFile
-    );
-  }
-
-  /**
-   * Adds implicit dependency from source project to target project
+   * Adds a dependency from source project to target project
    */
   addImplicitDependency(
     sourceProjectName: string,
     targetProjectName: string
   ): void {
-    if (this.graph.externalNodes[sourceProjectName]) {
-      throw new Error(`External projects can't have "implicit" dependencies`);
+    if (sourceProjectName === targetProjectName) {
+      return;
     }
-    this.addDependency(
-      sourceProjectName,
-      targetProjectName,
-      DependencyType.implicit
-    );
+    if (!this.graph.nodes[sourceProjectName]) {
+      throw new Error(`Source project does not exist: ${sourceProjectName}`);
+    }
+    if (
+      !this.graph.nodes[targetProjectName] &&
+      !this.graph.externalNodes[targetProjectName]
+    ) {
+      throw new Error(`Target project does not exist: ${targetProjectName}`);
+    }
+    this.graph.dependencies[sourceProjectName].push({
+      source: sourceProjectName,
+      target: targetProjectName,
+      type: DependencyType.implicit,
+    });
   }
 
   /**
@@ -155,7 +124,6 @@ export class ProjectGraphBuilder {
 
   /**
    * Add an explicit dependency from a file in source project to target project
-   * @deprecated this method will be removed in v17. Use {@link addStaticDependency} or {@link addDynamicDependency} instead
    */
   addExplicitDependency(
     sourceProjectName: string,
@@ -186,14 +154,46 @@ export class ProjectGraphBuilder {
       );
     }
 
-    if (!fileData.dependencies) {
-      fileData.dependencies = [];
+    if (!fileData.deps) {
+      fileData.deps = [];
     }
 
-    if (!fileData.dependencies.find((t) => t.target === targetProjectName)) {
-      fileData.dependencies.push({
-        target: targetProjectName,
+    if (!fileData.deps.find((t) => t === targetProjectName)) {
+      fileData.deps.push(targetProjectName);
+    }
+  }
+
+  /**
+   * Add an explicit dependency from a file in source project to target project
+   */
+  addExternalNodeDependency(
+    sourceProjectName: string,
+    targetProjectName: string
+  ): void {
+    if (sourceProjectName === targetProjectName) {
+      return;
+    }
+    const source = this.graph.externalNodes[sourceProjectName];
+    if (!source) {
+      throw new Error(`Source project does not exist: ${sourceProjectName}`);
+    }
+
+    if (!this.graph.externalNodes[targetProjectName]) {
+      throw new Error(`Target project does not exist: ${targetProjectName}`);
+    }
+
+    if (!this.graph.dependencies[sourceProjectName]) {
+      this.graph.dependencies[sourceProjectName] = [];
+    }
+
+    if (
+      !this.graph.dependencies[sourceProjectName].some(
+        (d) => d.target === targetProjectName
+      )
+    ) {
+      this.graph.dependencies[sourceProjectName].push({
         source: sourceProjectName,
+        target: targetProjectName,
         type: DependencyType.static,
       });
     }
@@ -212,102 +212,25 @@ export class ProjectGraphBuilder {
         this.calculateAlreadySetTargetDeps(sourceProject);
       this.graph.dependencies[sourceProject] = [
         ...alreadySetTargetProjects.values(),
-      ].flatMap((depsMap) => [...depsMap.values()]);
+      ];
 
       const fileDeps = this.calculateTargetDepsFromFiles(sourceProject);
-      for (const [targetProject, types] of fileDeps.entries()) {
-        for (const type of types.values()) {
+      for (const targetProject of fileDeps) {
+        if (!alreadySetTargetProjects.has(targetProject)) {
           if (
-            !alreadySetTargetProjects.has(targetProject) ||
-            !alreadySetTargetProjects.get(targetProject).has(type)
+            !this.removedEdges[sourceProject] ||
+            !this.removedEdges[sourceProject].has(targetProject)
           ) {
-            if (
-              !this.removedEdges[sourceProject] ||
-              !this.removedEdges[sourceProject].has(targetProject)
-            ) {
-              this.graph.dependencies[sourceProject].push({
-                source: sourceProject,
-                target: targetProject,
-                type,
-              });
-            }
+            this.graph.dependencies[sourceProject].push({
+              source: sourceProject,
+              target: targetProject,
+              type: DependencyType.static,
+            });
           }
         }
       }
     }
     return this.graph;
-  }
-
-  private addDependency(
-    sourceProjectName: string,
-    targetProjectName: string,
-    type: DependencyType,
-    sourceProjectFile?: string
-  ): void {
-    if (sourceProjectName === targetProjectName) {
-      return;
-    }
-    if (
-      !this.graph.nodes[sourceProjectName] &&
-      !this.graph.externalNodes[sourceProjectName]
-    ) {
-      throw new Error(`Source project does not exist: ${sourceProjectName}`);
-    }
-    if (
-      !this.graph.nodes[targetProjectName] &&
-      !this.graph.externalNodes[targetProjectName]
-    ) {
-      throw new Error(`Target project does not exist: ${targetProjectName}`);
-    }
-    if (
-      this.graph.externalNodes[sourceProjectName] &&
-      this.graph.nodes[targetProjectName]
-    ) {
-      throw new Error(`External projects can't depend on internal projects`);
-    }
-    if (!this.graph.dependencies[sourceProjectName]) {
-      this.graph.dependencies[sourceProjectName] = [];
-    }
-    // do not add duplicate
-    if (
-      this.graph.dependencies[sourceProjectName].find(
-        (d) => d.target === targetProjectName && d.type === type
-      )
-    ) {
-      return;
-    }
-
-    const dependency = {
-      source: sourceProjectName,
-      target: targetProjectName,
-      type,
-    };
-
-    if (sourceProjectFile) {
-      const source = this.graph.nodes[sourceProjectName];
-      if (!source) {
-        throw new Error(
-          `Source project is not a project node: ${sourceProjectName}`
-        );
-      }
-      const fileData = source.data.files.find(
-        (f) => f.file === sourceProjectFile
-      );
-      if (!fileData) {
-        throw new Error(
-          `Source project ${sourceProjectName} does not have a file: ${sourceProjectFile}`
-        );
-      }
-
-      if (!fileData.dependencies) {
-        fileData.dependencies = [];
-      }
-      if (!fileData.dependencies.find((t) => t.target === targetProjectName)) {
-        fileData.dependencies.push(dependency);
-      }
-    }
-
-    this.graph.dependencies[sourceProjectName].push(dependency);
   }
 
   private removeDependenciesWithNode(name: string) {
@@ -331,45 +254,26 @@ export class ProjectGraphBuilder {
     }
   }
 
-  private calculateTargetDepsFromFiles(
-    sourceProject: string
-  ): Map<string, Set<DependencyType | string>> {
-    const fileDeps = new Map<string, Set<DependencyType | string>>();
+  private calculateTargetDepsFromFiles(sourceProject: string) {
+    const fileDeps = new Set<string>();
     const files = this.graph.nodes[sourceProject].data.files;
-    if (!files) {
-      return fileDeps;
-    }
+    if (!files) return fileDeps;
     for (let f of files) {
-      if (f.dependencies) {
-        for (let d of f.dependencies) {
-          if (!fileDeps.has(d.target)) {
-            fileDeps.set(d.target, new Set([d.type]));
-          } else {
-            fileDeps.get(d.target).add(d.type);
-          }
+      if (f.deps) {
+        for (let p of f.deps) {
+          fileDeps.add(p);
         }
       }
     }
     return fileDeps;
   }
 
-  private calculateAlreadySetTargetDeps(
-    sourceProject: string
-  ): Map<string, Map<DependencyType | string, ProjectGraphDependency>> {
-    const alreadySetTargetProjects = new Map<
-      string,
-      Map<DependencyType | string, ProjectGraphDependency>
-    >();
-    if (this.graph.dependencies[sourceProject]) {
-      const removed = this.removedEdges[sourceProject];
-      for (const d of this.graph.dependencies[sourceProject]) {
-        if (!removed || !removed.has(d.target)) {
-          if (!alreadySetTargetProjects.has(d.target)) {
-            alreadySetTargetProjects.set(d.target, new Map([[d.type, d]]));
-          } else {
-            alreadySetTargetProjects.get(d.target).set(d.type, d);
-          }
-        }
+  private calculateAlreadySetTargetDeps(sourceProject: string) {
+    const alreadySetTargetProjects = new Map<string, ProjectGraphDependency>();
+    const removed = this.removedEdges[sourceProject];
+    for (const d of this.graph.dependencies[sourceProject]) {
+      if (!removed || !removed.has(d.target)) {
+        alreadySetTargetProjects.set(d.target, d);
       }
     }
     return alreadySetTargetProjects;

--- a/packages/nx/src/project-graph/project-graph.ts
+++ b/packages/nx/src/project-graph/project-graph.ts
@@ -3,7 +3,7 @@ import { buildProjectGraph } from './build-project-graph';
 import { output } from '../utils/output';
 import { defaultFileHasher } from '../hasher/file-hasher';
 import { markDaemonAsDisabled, writeDaemonLogs } from '../daemon/tmp-dir';
-import { ProjectGraph } from '../config/project-graph';
+import { ProjectGraph, ProjectGraphV4 } from '../config/project-graph';
 import { stripIndents } from '../utils/strip-indents';
 import {
   ProjectConfiguration,
@@ -12,6 +12,7 @@ import {
 import { daemonClient } from '../daemon/client/client';
 import { fileExists } from 'nx/src/utils/fileutils';
 import { workspaceRoot } from 'nx/src/utils/workspace-root';
+import { dependencies } from 'webpack';
 
 /**
  * Synchronously reads the latest cached copy of the workspace's ProjectGraph.
@@ -47,7 +48,7 @@ export function readCachedProjectGraph(): ProjectGraph {
 
   return projectGraphAdapter(
     projectGraph.version,
-    '5.1',
+    '5.0',
     projectGraph
   ) as ProjectGraph;
 }
@@ -201,13 +202,13 @@ function projectGraphCompatFileDependencies(
 ): ProjectGraph {
   Object.values(projectGraph.nodes).forEach(({ data }) => {
     if (data.files) {
-      data.files = data.files.map(({ file, hash, dependencies }) => ({
+      data.files = data.files.map(({ file, hash, deps }) => ({
         file,
         hash,
         // map dependencies to array of targets
-        ...(dependencies &&
-          dependencies.length && {
-            deps: [...new Set(dependencies.map((d) => d.target))],
+        ...(deps &&
+          deps.length && {
+            deps: [...new Set(deps)],
           }),
       }));
     }

--- a/packages/react-native/src/generators/storybook-configuration/configuration.spec.ts
+++ b/packages/react-native/src/generators/storybook-configuration/configuration.spec.ts
@@ -8,14 +8,6 @@ import applicationGenerator from '../application/application';
 import componentGenerator from '../component/component';
 import storybookConfigurationGenerator from './configuration';
 
-// nested code imports graph from the repo, which might have innacurate graph version
-jest.mock('nx/src/project-graph/project-graph', () => ({
-  ...jest.requireActual<any>('nx/src/project-graph/project-graph'),
-  createProjectGraphAsync: jest
-    .fn()
-    .mockImplementation(async () => ({ nodes: {}, dependencies: {} })),
-}));
-
 describe('react-native:storybook-configuration', () => {
   let appTree;
 

--- a/packages/react/src/generators/cypress-component-configuration/cypress-component-configuration.spec.ts
+++ b/packages/react/src/generators/cypress-component-configuration/cypress-component-configuration.spec.ts
@@ -22,14 +22,6 @@ jest.mock('@nrwl/devkit', () => ({
     .mockImplementation(async () => projectGraph),
 }));
 jest.mock('@nrwl/cypress/src/utils/cypress-version');
-// nested code imports graph from the repo, which might have innacurate graph version
-jest.mock('nx/src/project-graph/project-graph', () => ({
-  ...jest.requireActual<any>('nx/src/project-graph/project-graph'),
-  readCachedProjectGraph: jest
-    .fn()
-    .mockImplementation(async () => projectGraph),
-}));
-
 describe('React:CypressComponentTestConfiguration', () => {
   let tree: Tree;
   let mockedAssertCypressVersion: jest.Mock<

--- a/packages/react/src/generators/storybook-configuration/configuration.spec.ts
+++ b/packages/react/src/generators/storybook-configuration/configuration.spec.ts
@@ -9,14 +9,6 @@ import storybookConfigurationGenerator from './configuration';
 // need to mock cypress otherwise it'll use the nx installed version from package.json
 //  which is v9 while we are testing for the new v10 version
 jest.mock('@nrwl/cypress/src/utils/cypress-version');
-// nested code imports graph from the repo, which might have innacurate graph version
-jest.mock('nx/src/project-graph/project-graph', () => ({
-  ...jest.requireActual<any>('nx/src/project-graph/project-graph'),
-  createProjectGraphAsync: jest
-    .fn()
-    .mockImplementation(async () => ({ nodes: {}, dependencies: {} })),
-}));
-
 describe('react:storybook-configuration', () => {
   let appTree;
   let mockedInstalledCypressVersion: jest.Mock<

--- a/packages/storybook/src/generators/configuration/configuration-nested.spec.ts
+++ b/packages/storybook/src/generators/configuration/configuration-nested.spec.ts
@@ -10,14 +10,6 @@ import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import configurationGenerator from './configuration';
 import * as workspaceConfiguration from './test-configs/root-workspace-configuration.json';
 
-// nested code imports graph from the repo, which might have innacurate graph version
-jest.mock('nx/src/project-graph/project-graph', () => ({
-  ...jest.requireActual<any>('nx/src/project-graph/project-graph'),
-  createProjectGraphAsync: jest
-    .fn()
-    .mockImplementation(async () => ({ nodes: {}, dependencies: {} })),
-}));
-
 describe('@nrwl/storybook:configuration for workspaces with Root project', () => {
   describe('basic functionalities', () => {
     let tree: Tree;

--- a/packages/storybook/src/generators/configuration/configuration-v7.spec.ts
+++ b/packages/storybook/src/generators/configuration/configuration-v7.spec.ts
@@ -18,14 +18,6 @@ import { storybook7Version } from '../../utils/versions';
 import configurationGenerator from './configuration';
 import * as variousProjects from './test-configs/various-projects.json';
 
-// nested code imports graph from the repo, which might have innacurate graph version
-jest.mock('nx/src/project-graph/project-graph', () => ({
-  ...jest.requireActual<any>('nx/src/project-graph/project-graph'),
-  createProjectGraphAsync: jest
-    .fn()
-    .mockImplementation(async () => ({ nodes: {}, dependencies: {} })),
-}));
-
 describe('@nrwl/storybook:configuration for Storybook v7', () => {
   describe('basic functionalities', () => {
     let tree: Tree;

--- a/packages/storybook/src/generators/configuration/configuration.spec.ts
+++ b/packages/storybook/src/generators/configuration/configuration.spec.ts
@@ -15,14 +15,6 @@ import { TsConfig } from '../../utils/utilities';
 import configurationGenerator from './configuration';
 import * as workspaceConfiguration from './test-configs/workspace-conifiguration.json';
 
-// nested code imports graph from the repo, which might have innacurate graph version
-jest.mock('nx/src/project-graph/project-graph', () => ({
-  ...jest.requireActual<any>('nx/src/project-graph/project-graph'),
-  createProjectGraphAsync: jest
-    .fn()
-    .mockImplementation(async () => ({ nodes: {}, dependencies: {} })),
-}));
-
 describe('@nrwl/storybook:configuration', () => {
   describe('basic functionalities', () => {
     let tree: Tree;

--- a/packages/storybook/src/migrations/update-14-0-0/migrate-defaults-5-to-6/migrate-defaults-5-to-6.spec.ts
+++ b/packages/storybook/src/migrations/update-14-0-0/migrate-defaults-5-to-6/migrate-defaults-5-to-6.spec.ts
@@ -14,14 +14,6 @@ import {
 } from '../../../utils/testing';
 import { migrateDefaultsGenerator } from './migrate-defaults-5-to-6';
 
-// nested code imports graph from the repo, which might have innacurate graph version
-jest.mock('nx/src/project-graph/project-graph', () => ({
-  ...jest.requireActual<any>('nx/src/project-graph/project-graph'),
-  createProjectGraphAsync: jest
-    .fn()
-    .mockImplementation(async () => ({ nodes: {}, dependencies: {} })),
-}));
-
 describe('migrate-defaults-5-to-6 Generator', () => {
   let appTree: Tree;
 

--- a/packages/storybook/src/migrations/update-14-0-0/migrate-stories-to-6-2/migrate-stories-to-6-2.spec.ts
+++ b/packages/storybook/src/migrations/update-14-0-0/migrate-stories-to-6-2/migrate-stories-to-6-2.spec.ts
@@ -17,14 +17,6 @@ import {
 } from '@nrwl/devkit/ngcli-adapter';
 import { getTsSourceFile } from '@nrwl/storybook/src/utils/utilities';
 
-// nested code imports graph from the repo, which might have innacurate graph version
-jest.mock('nx/src/project-graph/project-graph', () => ({
-  ...jest.requireActual<any>('nx/src/project-graph/project-graph'),
-  createProjectGraphAsync: jest
-    .fn()
-    .mockImplementation(async () => ({ nodes: {}, dependencies: {} })),
-}));
-
 const componentSchematic = wrapAngularDevkitSchematic(
   '@schematics/angular',
   'component'

--- a/packages/storybook/src/utils/utilities.spec.ts
+++ b/packages/storybook/src/utils/utilities.spec.ts
@@ -11,14 +11,6 @@ import {
 import { nxVersion, storybookVersion } from './versions';
 import * as targetVariations from './test-configs/different-target-variations.json';
 
-// nested code imports graph from the repo, which might have innacurate graph version
-jest.mock('nx/src/project-graph/project-graph', () => ({
-  ...jest.requireActual<any>('nx/src/project-graph/project-graph'),
-  createProjectGraphAsync: jest
-    .fn()
-    .mockImplementation(async () => ({ nodes: {}, dependencies: {} })),
-}));
-
 const componentSchematic = wrapAngularDevkitSchematic(
   '@schematics/angular',
   'component'
@@ -74,14 +66,14 @@ describe('testing utilities', () => {
         `
       import { Story, Meta } from '@storybook/react';
       import { Button } from './button';
-
+      
       export default {
         component: Button,
         title: 'Button',
       } as Meta;
-
+      
       const Template: Story = (args) => <Button {...args} />;
-
+      
       export const Primary = Template.bind({});
       Primary.args = {};
     `
@@ -91,7 +83,7 @@ describe('testing utilities', () => {
         `test-ui-lib/src/lib/button/button.component.other.ts`,
         `
         import { Button } from './button';
-
+        
         // test test
       `
       );
@@ -100,7 +92,7 @@ describe('testing utilities', () => {
         `test-ui-lib/src/lib/button/button.component.react-native.ts`,
         `
        import { storiesOf } from '@storybook/react-native';
-
+        
         // test test
       `
       );
@@ -109,7 +101,7 @@ describe('testing utilities', () => {
         `test-ui-lib/src/lib/button/button.component.new-syntax.ts`,
         `
        import { ComponentStory } from '@storybook/react';
-
+        
         // test test
       `
       );

--- a/packages/workspace/src/generators/remove/lib/check-targets.spec.ts
+++ b/packages/workspace/src/generators/remove/lib/check-targets.spec.ts
@@ -3,14 +3,6 @@ import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { Schema } from '../schema';
 import { checkTargets } from './check-targets';
 
-// nested code imports graph from the repo, which might have innacurate graph version
-jest.mock('nx/src/project-graph/project-graph', () => ({
-  ...jest.requireActual<any>('nx/src/project-graph/project-graph'),
-  createProjectGraphAsync: jest
-    .fn()
-    .mockImplementation(async () => ({ nodes: {}, dependencies: {} })),
-}));
-
 describe('checkTargets', () => {
   let tree: Tree;
   let schema: Schema;


### PR DESCRIPTION
This PR reverts https://github.com/nrwl/nx/pull/14893, which is causing issues when dependencies from `package.json` is being marked as dynamic.

See: https://github.com/nrwl/nx/pull/14893#discussion_r1122496407

Repro: https://github.com/jaysoo/graph-issue (`test -> test2` is located via `packages/test/package.json` and should be static but is marked dynamic)

<img width="811" alt="Screenshot 2023-03-02 at 9 05 51 AM" src="https://user-images.githubusercontent.com/53559/222451012-e958958d-266a-4d1d-a298-3d8091679ff2.png">



## Current Behavior

`package.json` deps are marked as dynamic.

## Expected Behavior
`package.json` deps should be static.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
