### PR TITLE
fix(core): mark package.json dependencies as static

### DIFF
--- a/packages/nx/src/project-graph/build-dependencies/explicit-package-json-dependencies.spec.ts
+++ b/packages/nx/src/project-graph/build-dependencies/explicit-package-json-dependencies.spec.ts
@@ -116,16 +116,19 @@ describe('explicit package json dependencies', () => {
         sourceProjectName: 'proj',
         targetProjectName: 'proj2',
         sourceProjectFile: 'libs/proj/package.json',
+        type: 'static',
       },
       {
         sourceProjectFile: 'libs/proj/package.json',
         sourceProjectName: 'proj',
         targetProjectName: 'npm:external',
+        type: 'static',
       },
       {
         sourceProjectName: 'proj',
         targetProjectName: 'proj3',
         sourceProjectFile: 'libs/proj/package.json',
+        type: 'static',
       },
     ]);
   });

--- a/packages/nx/src/project-graph/build-dependencies/explicit-package-json-dependencies.ts
+++ b/packages/nx/src/project-graph/build-dependencies/explicit-package-json-dependencies.ts
@@ -1,6 +1,10 @@
 import { defaultFileRead } from '../file-utils';
 import { join } from 'path';
-import { ProjectFileMap, ProjectGraph } from '../../config/project-graph';
+import {
+  DependencyType,
+  ProjectFileMap,
+  ProjectGraph,
+} from '../../config/project-graph';
 import { parseJson } from '../../utils/json';
 import { getImportPath, joinPathFragments } from '../../utils/path';
 import { ProjectsConfigurations } from '../../config/workspace-json-project-json';
@@ -88,12 +92,14 @@ function processPackageJson(
           sourceProjectName: sourceProject,
           targetProjectName: packageNameMap[d],
           sourceProjectFile: fileName,
+          type: DependencyType.static,
         });
       } else if (graph.externalNodes[`npm:${d}`]) {
         collectedDeps.push({
           sourceProjectName: sourceProject,
           targetProjectName: `npm:${d}`,
           sourceProjectFile: fileName,
+          type: DependencyType.static,
         });
       }
     });


### PR DESCRIPTION
Fixes an issue where `package.json` deps are marked as dynamic.

Repro: https://github.com/jaysoo/graph-issue (`test -> test2` is located via `packages/test/package.json` and should be static but is marked dynamic)

<img width="811" alt="Screenshot 2023-03-02 at 9 05 51 AM" src="https://user-images.githubusercontent.com/53559/222451012-e958958d-266a-4d1d-a298-3d8091679ff2.png">



## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
