### PR TITLE
fix(react): fixes library type not passed to the module federation conf

### DIFF
--- a/packages/react/src/module-federation/with-module-federation.ts
+++ b/packages/react/src/module-federation/with-module-federation.ts
@@ -51,9 +51,7 @@ export async function withModuleFederation(
     config.plugins.push(
       new ModuleFederationPlugin({
         name: options.name,
-        library: {
-          type: 'module',
-        },
+        library: options.library ?? { type: 'module' },
         filename: 'remoteEntry.js',
         exposes: options.exposes,
         remotes: mappedRemotes,


### PR DESCRIPTION
the withModuleFederation plugin doesn't allow the library type to be configured using the `module-federation.config.js` file because the value is hardcoded.

This change allows the library type to be passed:

```
module.exports = {
  name: 'test-app',
  library: { type: 'var', name: 'test-app' },
  exposes: {
    './Test': './src/index',
  },
  // remotes: [],
};
```

closed #15316

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

library type is always 'module'

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

passing library: { type: 'var' } should override the default value

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15316
