### PR TITLE
fix(devkit): allow ensured packages to resolve from workspace node_mo…

### DIFF
--- a/packages/devkit/src/utils/package-json.ts
+++ b/packages/devkit/src/utils/package-json.ts
@@ -11,7 +11,8 @@ import { requireNx } from '../../nx';
 import { dirSync } from 'tmp';
 import { join } from 'path';
 
-const { readJson, updateJson, getPackageManagerCommand } = requireNx();
+const { readJson, updateJson, getPackageManagerCommand, workspaceRoot } =
+  requireNx();
 
 const UNIDENTIFIED_VERSION = 'UNIDENTIFIED_VERSION';
 const NON_SEMVER_TAGS = {
@@ -450,6 +451,7 @@ export function ensurePackage<T extends any = any>(
     stdio: [0, 1, 2],
   });
 
+  addToNodePath(join(workspaceRoot, 'node_modules'));
   addToNodePath(join(tempDir, 'node_modules'));
 
   // Re-initialize the added paths into require
@@ -472,6 +474,11 @@ function addToNodePath(dir: string) {
   const paths = process.env.NODE_PATH
     ? process.env.NODE_PATH.split(delimiter)
     : [];
+
+  // The path is already in the node path
+  if (paths.includes(dir)) {
+    return;
+  }
 
   // Add the tmp path
   paths.push(dir);


### PR DESCRIPTION
…dules

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Running `@nrwl/angular:storybook-configuration` for the first time will fail because the `configurationGenerator` cannot resolve `typescript` even though it is installed in the workspace.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Running `@nrwl/angular:storybook-configuration` for the first time will work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
