### PR TITLE
fix(misc): restore tsconfig utils as deprecated in @nrwl/workspace

### DIFF
--- a/packages/angular/src/generators/utils/storybook-ast/storybook-inputs.ts
+++ b/packages/angular/src/generators/utils/storybook-ast/storybook-inputs.ts
@@ -1,6 +1,6 @@
 import type { Tree } from '@nrwl/devkit';
 import { findNodes } from 'nx/src/utils/typescript';
-import { getSourceNodes } from '@nrwl/workspace/src/utilities/typescript';
+import { getSourceNodes } from '@nrwl/workspace/src/utilities/typescript/get-source-nodes';
 import type { PropertyDeclaration } from 'typescript';
 import { getTsSourceFile } from '../../../utils/nx-devkit/ast-utils';
 import { ensureTypescript } from '@nrwl/js/src/utils/typescript/ensure-typescript';

--- a/packages/workspace/src/utilities/ts-config.ts
+++ b/packages/workspace/src/utilities/ts-config.ts
@@ -47,9 +47,3 @@ export function getRootTsConfigFileName(): string | null {
 
   return null;
 }
-
-export function getRootTsConfigPath(): string | null {
-  const tsConfigFileName = getRootTsConfigFileName();
-
-  return tsConfigFileName ? join(workspaceRoot, tsConfigFileName) : null;
-}

--- a/packages/workspace/src/utilities/typescript.ts
+++ b/packages/workspace/src/utilities/typescript.ts
@@ -1,4 +1,4 @@
-import { ensurePackage, workspaceRoot } from '@nrwl/devkit';
+import { ensurePackage, Tree, workspaceRoot } from '@nrwl/devkit';
 import { dirname } from 'path';
 import type * as ts from 'typescript';
 import { typescriptVersion } from '../utils/versions';
@@ -86,4 +86,23 @@ export function ensureTypescript() {
     'typescript',
     typescriptVersion
   );
+}
+
+import {
+  getRelativePathToRootTsConfig as _getRelativePathToRootTsConfig,
+  getRootTsConfigPathInTree as _getRootTsConfigPathInTree,
+} from './ts-config';
+
+/**
+ * @deprecated Please import this from @nrwl/js instead. This function will be removed in v17
+ */
+export function getRelativePathToRootTsConfig(tree: Tree, targetPath: string) {
+  return _getRelativePathToRootTsConfig(tree, targetPath);
+}
+
+/**
+ * @deprecated Please import this from @nrwl/js instead. This function will be removed in v17
+ */
+export function getRootTsConfigPathInTree(tree: Tree) {
+  return _getRootTsConfigPathInTree(tree);
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

A few community plugins import this function and are broken by removing them.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

This function is restored but will be removed in v17. It has been marked deprecated.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
