### PR TITLE
fix(testing): fix generated testMatch pattern in jest config to support windows

### DIFF
--- a/packages/jest/src/generators/jest-project/files-angular/jest.config.ts__tmpl__
+++ b/packages/jest/src/generators/jest-project/files-angular/jest.config.ts__tmpl__
@@ -22,6 +22,6 @@
   ]<% } %><% if(rootProject){ %>,
   testMatch: [
     '<rootDir>/src/**/__tests__/**/*.[jt]s?(x)',
-    '<rootDir>/src/**/?(*.)+(spec|test).[jt]s?(x)',
+    '<rootDir>/src/**/*(*.)@(spec|test).[jt]s?(x)',
   ],<% } %>
 };

--- a/packages/jest/src/generators/jest-project/files/jest.config.ts__tmpl__
+++ b/packages/jest/src/generators/jest-project/files/jest.config.ts__tmpl__
@@ -11,6 +11,6 @@
   coverageDirectory: '<%= offsetFromRoot %>coverage/<%= projectRoot %>'<% if(rootProject){ %>,
   testMatch: [
     '<rootDir>/src/**/__tests__/**/*.[jt]s?(x)',
-    '<rootDir>/src/**/?(*.)+(spec|test).[jt]s?(x)',
+    '<rootDir>/src/**/*(*.)@(spec|test).[jt]s?(x)',
   ],<% } %>
 };

--- a/packages/jest/src/generators/jest-project/jest-project.spec.ts
+++ b/packages/jest/src/generators/jest-project/jest-project.spec.ts
@@ -388,7 +388,7 @@ describe('jestProject', () => {
           coverageDirectory: './coverage/my-project',
           testMatch: [
             '<rootDir>/src/**/__tests__/**/*.[jt]s?(x)',
-            '<rootDir>/src/**/?(*.)+(spec|test).[jt]s?(x)',
+            '<rootDir>/src/**/*(*.)@(spec|test).[jt]s?(x)',
           ],
         };
         "
@@ -421,7 +421,7 @@ describe('jestProject', () => {
           coverageDirectory: './coverage/my-project',
           testMatch: [
             '<rootDir>/src/**/__tests__/**/*.[jt]s?(x)',
-            '<rootDir>/src/**/?(*.)+(spec|test).[jt]s?(x)',
+            '<rootDir>/src/**/*(*.)@(spec|test).[jt]s?(x)',
           ],
         };
         "

--- a/packages/nx/src/nx-init/add-nx-to-nest.ts
+++ b/packages/nx/src/nx-init/add-nx-to-nest.ts
@@ -281,7 +281,7 @@ function getJestOptions(
   delete jestOptions['testRegex'];
   jestOptions['testMatch'] = isE2E
     ? ['<rootDir>/test/**/?(*.)+(e2e-spec|e2e-test).[jt]s?(x)']
-    : ['<rootDir>/src/**/?(*.)+(spec|test).[jt]s?(x)'];
+    : ['<rootDir>/src/**/*(*.)@(spec|test).[jt]s?(x)'];
 
   // set coverage directory for unit test
   if (!isE2E) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Generated testMatch pattern in the `jest.config.ts` doesn't work on Windows. It can't find any test files.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Generated testMatch pattern in the `jest.config.ts` works on Windows. The fix is a workaround for a Jest issue https://github.com/facebook/jest/issues/7914#issuecomment-464352069. The new pattern is still valid and follows the micromatch syntax, which Jest uses under the hood.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15121 
Fixes #13838 
