### PR TITLE
fix(core): do not return a default project when nxJson is undefined

### DIFF
--- a/packages/nx/src/config/workspaces.ts
+++ b/packages/nx/src/config/workspaces.ts
@@ -64,7 +64,7 @@ export class Workspaces {
       });
       if (matchingProject) return matchingProject;
     }
-    return nxJson.defaultProject;
+    return nxJson?.defaultProject;
   }
 
   readProjectsConfigurations(opts?: {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When nxJson is not found for some reason, an error is thrown when detecting a default project.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When nxjson is not found for some reason, no default project will be used.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
