### PR TITLE
fix(misc): move generator should null-check cypress props

### DIFF
--- a/packages/workspace/src/generators/move/lib/update-cypress-config.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-cypress-config.spec.ts
@@ -59,6 +59,23 @@ describe('updateCypressConfig', () => {
     });
   });
 
+  it('should noop if the videos and screenshots folders are not defined', async () => {
+    const cypressJson = {
+      fileServerFolder: '.',
+      fixturesFolder: './src/fixtures',
+      integrationFolder: './src/integration',
+      pluginsFile: './src/plugins/index',
+      supportFile: false,
+      video: false,
+      chromeWebSecurity: false,
+    };
+    writeJson(tree, '/libs/my-destination/cypress.json', cypressJson);
+
+    updateCypressConfig(tree, schema, projectConfig);
+
+    expect(readJson(tree, '/libs/my-destination/cypress.json')).toEqual(cypressJson);
+  });
+  
   it('should handle updating cypress.config.ts', async () => {
     tree.write(
       '/libs/my-destination/cypress.config.ts',

--- a/packages/workspace/src/generators/move/lib/update-cypress-config.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-cypress-config.spec.ts
@@ -73,9 +73,11 @@ describe('updateCypressConfig', () => {
 
     updateCypressConfig(tree, schema, projectConfig);
 
-    expect(readJson(tree, '/libs/my-destination/cypress.json')).toEqual(cypressJson);
+    expect(readJson(tree, '/libs/my-destination/cypress.json')).toEqual(
+      cypressJson
+    );
   });
-  
+
   it('should handle updating cypress.config.ts', async () => {
     tree.write(
       '/libs/my-destination/cypress.config.ts',

--- a/packages/workspace/src/generators/move/lib/update-cypress-config.ts
+++ b/packages/workspace/src/generators/move/lib/update-cypress-config.ts
@@ -33,16 +33,15 @@ export function updateCypressConfig(
       cypressJson.videosFolder = cypressJson.videosFolder.replace(
         project.root,
         schema.relativeToRootDestination
-      );  
+      );
     }
     // screenshotsFolder is not required as it has a default
     if (cypressJson.screenshotsFolder) {
       cypressJson.screenshotsFolder = cypressJson.screenshotsFolder.replace(
         project.root,
         schema.relativeToRootDestination
-      );  
+      );
     }
-    
 
     tree.write(cypressJsonPath, JSON.stringify(cypressJson));
     return tree;

--- a/packages/workspace/src/generators/move/lib/update-cypress-config.ts
+++ b/packages/workspace/src/generators/move/lib/update-cypress-config.ts
@@ -28,14 +28,21 @@ export function updateCypressConfig(
     const cypressJson = JSON.parse(
       tree.read(cypressJsonPath).toString('utf-8')
     ) as PartialCypressJson;
-    cypressJson.videosFolder = cypressJson.videosFolder.replace(
-      project.root,
-      schema.relativeToRootDestination
-    );
-    cypressJson.screenshotsFolder = cypressJson.screenshotsFolder.replace(
-      project.root,
-      schema.relativeToRootDestination
-    );
+    // videosFolder is not required because videos can be turned off - it also has a default
+    if (cypressJson.videosFolder) {
+      cypressJson.videosFolder = cypressJson.videosFolder.replace(
+        project.root,
+        schema.relativeToRootDestination
+      );  
+    }
+    // screenshotsFolder is not required as it has a default
+    if (cypressJson.screenshotsFolder) {
+      cypressJson.screenshotsFolder = cypressJson.screenshotsFolder.replace(
+        project.root,
+        schema.relativeToRootDestination
+      );  
+    }
+    
 
     tree.write(cypressJsonPath, JSON.stringify(cypressJson));
     return tree;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15433 
