### PR TITLE
feat(core): show task graph of commands

### DIFF
--- a/docs/generated/cli/affected-graph.md
+++ b/docs/generated/cli/affected-graph.md
@@ -129,7 +129,7 @@ Type: `number`
 
 Bind the project graph server to a specific port.
 
-### target
+### targets
 
 Type: `string`
 

--- a/docs/generated/cli/affected-graph.md
+++ b/docs/generated/cli/affected-graph.md
@@ -129,6 +129,12 @@ Type: `number`
 
 Bind the project graph server to a specific port.
 
+### target
+
+Type: `string`
+
+The target to show tasks for in the task graph
+
 ### uncommitted
 
 Type: `boolean`
@@ -146,6 +152,16 @@ Untracked changes
 Type: `boolean`
 
 Show version number
+
+### view
+
+Type: `string`
+
+Choices: [projects, tasks]
+
+Default: `projects`
+
+Choose whether to view the projects or task graph
 
 ### watch
 

--- a/docs/generated/cli/affected.md
+++ b/docs/generated/cli/affected.md
@@ -97,6 +97,14 @@ Type: `string`
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas or spaces
 
+### graph
+
+Type: `boolean`
+
+Default: `false`
+
+Show the task graph of the command
+
 ### head
 
 Type: `string`

--- a/docs/generated/cli/exec.md
+++ b/docs/generated/cli/exec.md
@@ -29,6 +29,14 @@ Type: `string`
 
 Exclude certain projects from being processed
 
+### graph
+
+Type: `boolean`
+
+Default: `false`
+
+Show the task graph of the command
+
 ### nx-bail
 
 Type: `boolean`

--- a/docs/generated/cli/graph.md
+++ b/docs/generated/cli/graph.md
@@ -117,11 +117,27 @@ Type: `number`
 
 Bind the project graph server to a specific port.
 
+### target
+
+Type: `string`
+
+The target to show tasks for in the task graph
+
 ### version
 
 Type: `boolean`
 
 Show version number
+
+### view
+
+Type: `string`
+
+Choices: [projects, tasks]
+
+Default: `projects`
+
+Choose whether to view the projects or task graph
 
 ### watch
 

--- a/docs/generated/cli/graph.md
+++ b/docs/generated/cli/graph.md
@@ -117,7 +117,7 @@ Type: `number`
 
 Bind the project graph server to a specific port.
 
-### target
+### targets
 
 Type: `string`
 

--- a/docs/generated/cli/run-many.md
+++ b/docs/generated/cli/run-many.md
@@ -75,6 +75,14 @@ Type: `string`
 
 Exclude certain projects from being processed
 
+### graph
+
+Type: `boolean`
+
+Default: `false`
+
+Show the task graph of the command
+
 ### help
 
 Type: `boolean`

--- a/docs/generated/packages/nx/documents/affected-dep-graph.md
+++ b/docs/generated/packages/nx/documents/affected-dep-graph.md
@@ -129,7 +129,7 @@ Type: `number`
 
 Bind the project graph server to a specific port.
 
-### target
+### targets
 
 Type: `string`
 

--- a/docs/generated/packages/nx/documents/affected-dep-graph.md
+++ b/docs/generated/packages/nx/documents/affected-dep-graph.md
@@ -129,6 +129,12 @@ Type: `number`
 
 Bind the project graph server to a specific port.
 
+### target
+
+Type: `string`
+
+The target to show tasks for in the task graph
+
 ### uncommitted
 
 Type: `boolean`
@@ -146,6 +152,16 @@ Untracked changes
 Type: `boolean`
 
 Show version number
+
+### view
+
+Type: `string`
+
+Choices: [projects, tasks]
+
+Default: `projects`
+
+Choose whether to view the projects or task graph
 
 ### watch
 

--- a/docs/generated/packages/nx/documents/affected.md
+++ b/docs/generated/packages/nx/documents/affected.md
@@ -97,6 +97,14 @@ Type: `string`
 
 Change the way Nx is calculating the affected command by providing directly changed files, list of files delimited by commas or spaces
 
+### graph
+
+Type: `boolean`
+
+Default: `false`
+
+Show the task graph of the command
+
 ### head
 
 Type: `string`

--- a/docs/generated/packages/nx/documents/dep-graph.md
+++ b/docs/generated/packages/nx/documents/dep-graph.md
@@ -117,11 +117,27 @@ Type: `number`
 
 Bind the project graph server to a specific port.
 
+### target
+
+Type: `string`
+
+The target to show tasks for in the task graph
+
 ### version
 
 Type: `boolean`
 
 Show version number
+
+### view
+
+Type: `string`
+
+Choices: [projects, tasks]
+
+Default: `projects`
+
+Choose whether to view the projects or task graph
 
 ### watch
 

--- a/docs/generated/packages/nx/documents/dep-graph.md
+++ b/docs/generated/packages/nx/documents/dep-graph.md
@@ -117,7 +117,7 @@ Type: `number`
 
 Bind the project graph server to a specific port.
 
-### target
+### targets
 
 Type: `string`
 

--- a/docs/generated/packages/nx/documents/exec.md
+++ b/docs/generated/packages/nx/documents/exec.md
@@ -29,6 +29,14 @@ Type: `string`
 
 Exclude certain projects from being processed
 
+### graph
+
+Type: `boolean`
+
+Default: `false`
+
+Show the task graph of the command
+
 ### nx-bail
 
 Type: `boolean`

--- a/docs/generated/packages/nx/documents/run-many.md
+++ b/docs/generated/packages/nx/documents/run-many.md
@@ -75,6 +75,14 @@ Type: `string`
 
 Exclude certain projects from being processed
 
+### graph
+
+Type: `boolean`
+
+Default: `false`
+
+Show the task graph of the command
+
 ### help
 
 Type: `boolean`

--- a/graph/client/src/app/feature-tasks/task-list.tsx
+++ b/graph/client/src/app/feature-tasks/task-list.tsx
@@ -141,7 +141,7 @@ export function TaskList({
 }: TaskListProps) {
   const filteredProjects = projects
     .filter((project) =>
-      (project.data as any).targets.hasOwnProperty(selectedTarget)
+      (project.data as any).targets?.hasOwnProperty(selectedTarget)
     )
     .sort((a, b) => a.name.localeCompare(b.name));
   const appProjects = getProjectsByType('app', filteredProjects);

--- a/graph/client/src/app/feature-tasks/tasks-sidebar.tsx
+++ b/graph/client/src/app/feature-tasks/tasks-sidebar.tsx
@@ -48,7 +48,7 @@ export function TasksSidebar() {
   const allProjectsWithTargetAndNoErrors = projects.filter(
     (project) =>
       project.data.targets?.hasOwnProperty(selectedTarget) &&
-      !errors.hasOwnProperty(createTaskName(project.name, selectedTarget))
+      !errors?.hasOwnProperty(createTaskName(project.name, selectedTarget))
   );
 
   const selectedProjects = useMemo(

--- a/graph/client/src/app/feature-tasks/tasks-sidebar.tsx
+++ b/graph/client/src/app/feature-tasks/tasks-sidebar.tsx
@@ -11,7 +11,7 @@ import type {
   TaskGraphClientResponse,
 } from 'nx/src/command-line/dep-graph';
 import { getGraphService } from '../machines/graph.service';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import { CheckboxPanel } from '../ui-components/checkbox-panel';
 
 import { Dropdown } from '@nrwl/graph/ui-components';
@@ -23,6 +23,7 @@ export function TasksSidebar() {
   const graphService = getGraphService();
   const navigate = useNavigate();
   const params = useParams();
+  const createRoute = useRouteConstructor();
 
   const [searchParams, setSearchParams] = useSearchParams();
   const groupByProject = searchParams.get('groupByProject') === 'true';
@@ -40,10 +41,21 @@ export function TasksSidebar() {
 
   const selectedTarget = params['selectedTarget'] ?? targets[0];
 
-  const [selectedProjects, setSelectedProjects] = useState<string[]>([]);
-
   const currentRoute = useCurrentPath();
-  const routeContructor = useRouteConstructor();
+  const isAllRoute =
+    currentRoute.currentPath === `/tasks/${selectedTarget}/all`;
+
+  const allProjectsWithTarget = projects.filter((project) =>
+    project.data.targets?.hasOwnProperty(selectedTarget)
+  );
+
+  const selectedProjects = useMemo(
+    () =>
+      isAllRoute
+        ? allProjectsWithTarget.map(({ name }) => name)
+        : searchParams.get('projects')?.split(' ') ?? [],
+    [allProjectsWithTarget, searchParams, isAllRoute]
+  );
 
   function selectTarget(target: string) {
     if (target === selectedTarget) return;
@@ -72,36 +84,25 @@ export function TasksSidebar() {
   }
 
   function selectProject(project: string) {
-    setSelectedProjects([...selectedProjects, project]);
-
-    const taskId = createTaskName(project, selectedTarget);
-
-    graphService.handleTaskEvent({
-      type: 'notifyTaskGraphTasksSelected',
-      taskIds: [taskId],
-    });
-  }
-
-  function selectAllProjects() {
-    navigate(
-      routeContructor(`/tasks/${encodeURIComponent(selectedTarget)}/all`, true)
-    );
-  }
-
-  function hideAllProjects() {
-    setSelectedProjects([]);
-
-    const allProjects = projects.map(
-      (project) => `${project.name}:${selectedTarget}`
-    );
-
-    graphService.handleTaskEvent({
-      type: 'notifyTaskGraphTasksDeselected',
-      taskIds: allProjects,
-    });
+    const newSelectedProjects = [...selectedProjects, project];
+    const allProjectsSelected =
+      newSelectedProjects.length === allProjectsWithTarget.length;
+    if (allProjectsSelected) {
+      searchParams.delete('projects');
+    } else {
+      searchParams.set('projects', newSelectedProjects.join(' '));
+    }
 
     navigate(
-      routeContructor(`/tasks/${encodeURIComponent(selectedTarget)}`, true)
+      createRoute(
+        {
+          pathname: allProjectsSelected
+            ? `/tasks/${encodeURIComponent(selectedTarget)}/all`
+            : `/tasks/${encodeURIComponent(selectedTarget)}`,
+          search: searchParams.toString(),
+        },
+        false
+      )
     );
   }
 
@@ -109,22 +110,48 @@ export function TasksSidebar() {
     const newSelectedProjects = selectedProjects.filter(
       (selectedProject) => selectedProject !== project
     );
-    setSelectedProjects(newSelectedProjects);
-
-    const taskId = `${project}:${selectedTarget}`;
-
-    graphService.handleTaskEvent({
-      type: 'notifyTaskGraphTasksDeselected',
-      taskIds: [taskId],
-    });
-
+    if (newSelectedProjects.length === 0) {
+      searchParams.delete('projects');
+    } else {
+      searchParams.set('projects', newSelectedProjects.join(' '));
+    }
     navigate(
-      routeContructor(`/tasks/${encodeURIComponent(selectedTarget)}`, true)
+      createRoute(
+        {
+          pathname: `/tasks/${encodeURIComponent(selectedTarget)}`,
+          search: searchParams.toString(),
+        },
+        false
+      )
     );
   }
 
+  function selectAllProjects() {
+    searchParams.delete('projects');
+    navigate(
+      createRoute(
+        {
+          pathname: `/tasks/${encodeURIComponent(selectedTarget)}/all`,
+          search: searchParams.toString(),
+        },
+        false
+      )
+    );
+  }
+
+  function hideAllProjects() {
+    searchParams.delete('projects');
+    navigate({
+      pathname: isAllRoute
+        ? '.'
+        : params['selectedTarget']
+        ? undefined
+        : `./${encodeURIComponent(selectedTarget)}`,
+      search: searchParams.toString(),
+    });
+  }
+
   useEffect(() => {
-    setSelectedProjects([]);
     graphService.handleTaskEvent({
       type: 'notifyTaskGraphSetProjects',
       projects: selectedWorkspaceRouteData.projects,
@@ -147,25 +174,11 @@ export function TasksSidebar() {
   }, [searchParams]);
 
   useEffect(() => {
-    switch (currentRoute.currentPath) {
-      case `/tasks/${selectedTarget}/all`:
-        const allProjectsWithSelectedTarget = projects.filter((project) =>
-          project.data.targets.hasOwnProperty(selectedTarget)
-        );
-
-        setSelectedProjects(
-          allProjectsWithSelectedTarget.map((project) => project.name)
-        );
-
-        graphService.handleTaskEvent({
-          type: 'notifyTaskGraphTasksSelected',
-          taskIds: allProjectsWithSelectedTarget.map(
-            (project) => `${project.name}:${selectedTarget}`
-          ),
-        });
-        break;
-    }
-  }, [currentRoute]);
+    graphService.handleTaskEvent({
+      type: 'notifyTaskGraphSetTasks',
+      taskIds: selectedProjects.map((p) => createTaskName(p, selectedTarget)),
+    });
+  }, [graphService, selectedProjects, selectedTarget]);
 
   function groupByProjectChanged(checked) {
     setSearchParams(

--- a/graph/client/src/app/feature-tasks/tasks-sidebar.tsx
+++ b/graph/client/src/app/feature-tasks/tasks-sidebar.tsx
@@ -141,14 +141,15 @@ export function TasksSidebar() {
 
   function hideAllProjects() {
     searchParams.delete('projects');
-    navigate({
-      pathname: isAllRoute
-        ? '.'
-        : params['selectedTarget']
-        ? undefined
-        : `./${encodeURIComponent(selectedTarget)}`,
-      search: searchParams.toString(),
-    });
+    navigate(
+      createRoute(
+        {
+          pathname: `/tasks/${encodeURIComponent(selectedTarget)}`,
+          search: searchParams.toString(),
+        },
+        false
+      )
+    );
   }
 
   useEffect(() => {

--- a/graph/client/src/app/feature-tasks/tasks-sidebar.tsx
+++ b/graph/client/src/app/feature-tasks/tasks-sidebar.tsx
@@ -45,16 +45,18 @@ export function TasksSidebar() {
   const isAllRoute =
     currentRoute.currentPath === `/tasks/${selectedTarget}/all`;
 
-  const allProjectsWithTarget = projects.filter((project) =>
-    project.data.targets?.hasOwnProperty(selectedTarget)
+  const allProjectsWithTargetAndNoErrors = projects.filter(
+    (project) =>
+      project.data.targets?.hasOwnProperty(selectedTarget) &&
+      !errors.hasOwnProperty(createTaskName(project.name, selectedTarget))
   );
 
   const selectedProjects = useMemo(
     () =>
       isAllRoute
-        ? allProjectsWithTarget.map(({ name }) => name)
+        ? allProjectsWithTargetAndNoErrors.map(({ name }) => name)
         : searchParams.get('projects')?.split(' ') ?? [],
-    [allProjectsWithTarget, searchParams, isAllRoute]
+    [allProjectsWithTargetAndNoErrors, searchParams, isAllRoute]
   );
 
   function selectTarget(target: string) {
@@ -86,7 +88,7 @@ export function TasksSidebar() {
   function selectProject(project: string) {
     const newSelectedProjects = [...selectedProjects, project];
     const allProjectsSelected =
-      newSelectedProjects.length === allProjectsWithTarget.length;
+      newSelectedProjects.length === allProjectsWithTargetAndNoErrors.length;
     if (allProjectsSelected) {
       searchParams.delete('projects');
     } else {

--- a/graph/client/src/app/util.ts
+++ b/graph/client/src/app/util.ts
@@ -23,7 +23,11 @@ export const useRouteConstructor = (): ((
       return {
         ...to,
         pathname,
-        search: retainSearchParams ? searchParams.toString() : '',
+        search: to.search
+          ? to.search.toString()
+          : retainSearchParams
+          ? searchParams.toString()
+          : '',
       };
     } else if (typeof to === 'string') {
       if (environment === 'dev') {

--- a/graph/client/src/assets/project-graphs/e2e.json
+++ b/graph/client/src/assets/project-graphs/e2e.json
@@ -7,7 +7,8 @@
       "data": {
         "tags": [],
         "root": "libs/project-a",
-        "files": []
+        "files": [],
+        "targets": {}
       }
     },
     {
@@ -16,7 +17,8 @@
       "data": {
         "tags": [],
         "root": "libs/project-a",
-        "files": []
+        "files": [],
+        "targets": {}
       }
     },
     {

--- a/graph/ui-graph/src/lib/graph.ts
+++ b/graph/ui-graph/src/lib/graph.ts
@@ -230,6 +230,11 @@ export class GraphService {
       case 'notifyTaskGraphSetProjects':
         this.taskTraversalGraph.setProjects(event.projects, event.taskGraphs);
         break;
+      case 'notifyTaskGraphSetTasks':
+        elementsToSendToRender = this.taskTraversalGraph.setTasks(
+          event.taskIds
+        );
+        break;
       case 'notifyTaskGraphTasksSelected':
         elementsToSendToRender = this.taskTraversalGraph.selectTask(
           event.taskIds

--- a/graph/ui-graph/src/lib/interfaces.ts
+++ b/graph/ui-graph/src/lib/interfaces.ts
@@ -100,7 +100,8 @@ export type TaskGraphRenderEvents =
   | {
       type: 'setGroupByProject';
       groupByProject: boolean;
-    };
+    }
+  | { type: 'notifyTaskGraphSetTasks'; taskIds: string[] };
 
 export type TooltipEvent =
   | {

--- a/graph/ui-graph/src/lib/util-cytoscape/task-traversal.graph.ts
+++ b/graph/ui-graph/src/lib/util-cytoscape/task-traversal.graph.ts
@@ -22,15 +22,6 @@ export class TaskTraversalGraph {
     this.taskGraphs = taskGraphs;
   }
 
-  selectTask(taskIds: string[]) {
-    taskIds.forEach((taskId) => {
-      this.selectedTasks.add(taskId);
-    });
-    this.createElements(Array.from(this.selectedTasks), this.groupByProject);
-
-    return this.cy.elements();
-  }
-
   setGroupByProject(groupByProject: boolean) {
     this.groupByProject = groupByProject;
 
@@ -42,6 +33,34 @@ export class TaskTraversalGraph {
         elements: [],
       });
     }
+
+    return this.cy.elements();
+  }
+
+  setTasks(taskIds: string[]) {
+    let changed = false;
+    this.selectedTasks.forEach((selectedTask) => {
+      if (!taskIds.includes(selectedTask)) {
+        this.selectedTasks.delete(selectedTask);
+        changed = true;
+      }
+    });
+    for (const taskId of taskIds) {
+      if (!this.selectedTasks.has(taskId)) {
+        this.selectedTasks.add(taskId);
+        changed = true;
+      }
+    }
+    if (changed) {
+      this.createElements(Array.from(this.selectedTasks), this.groupByProject);
+    }
+    return this.cy.elements();
+  }
+
+  selectTask(taskIds: string[]) {
+    taskIds.forEach((taskId) => {
+      this.selectedTasks.add(taskId);
+    });
 
     return this.cy.elements();
   }

--- a/packages/nx/src/command-line/affected.ts
+++ b/packages/nx/src/command-line/affected.ts
@@ -117,16 +117,31 @@ export async function affected(
 
       case 'affected': {
         const projectsWithTarget = allProjectsWithTarget(projects, nxArgs);
-        await runCommand(
-          projectsWithTarget,
-          projectGraph,
-          { nxJson },
-          nxArgs,
-          overrides,
-          null,
-          extraTargetDependencies,
-          { excludeTaskDependencies: false, loadDotEnvFiles: true }
-        );
+        if (nxArgs.graph) {
+          const projectNames = projectsWithTarget.map((t) => t.name);
+
+          return await generateGraph(
+            {
+              watch: true,
+              open: true,
+              view: 'tasks',
+              target: nxArgs.targets[0],
+              projects: projectNames,
+            },
+            projectNames
+          );
+        } else {
+          await runCommand(
+            projectsWithTarget,
+            projectGraph,
+            { nxJson },
+            nxArgs,
+            overrides,
+            null,
+            extraTargetDependencies,
+            { excludeTaskDependencies: false, loadDotEnvFiles: true }
+          );
+        }
         break;
       }
     }

--- a/packages/nx/src/command-line/affected.ts
+++ b/packages/nx/src/command-line/affected.ts
@@ -122,10 +122,10 @@ export async function affected(
 
           return await generateGraph(
             {
-              watch: true,
+              watch: false,
               open: true,
               view: 'tasks',
-              target: nxArgs.targets[0],
+              targets: nxArgs.targets,
               projects: projectNames,
             },
             projectNames

--- a/packages/nx/src/command-line/dep-graph.ts
+++ b/packages/nx/src/command-line/dep-graph.ts
@@ -181,12 +181,17 @@ export async function generateGraph(
     view: 'projects' | 'tasks';
     projects?: string[];
     all?: boolean;
-    target?: string;
+    targets?: string[];
     focus?: string;
     exclude?: string[];
   },
   affectedProjects: string[]
 ): Promise<void> {
+  // TODO: Graph Client should support multiple targets
+  const target = Array.isArray(args.targets && args.targets.length >= 1)
+    ? args.targets[0]
+    : args.targets;
+
   let graph = pruneExternalNodes(
     await createProjectGraphAsync({ exitOnError: true })
   );
@@ -320,8 +325,8 @@ export async function generateGraph(
       url.pathname += '/' + args.focus;
     }
 
-    if (args.target) {
-      url.pathname += '/' + args.target;
+    if (target) {
+      url.pathname += '/' + target;
     }
     if (args.all) {
       url.pathname += '/all';

--- a/packages/nx/src/command-line/dep-graph.ts
+++ b/packages/nx/src/command-line/dep-graph.ts
@@ -187,6 +187,15 @@ export async function generateGraph(
   },
   affectedProjects: string[]
 ): Promise<void> {
+  if (Array.isArray(args.targets) && args.targets.length > 1) {
+    output.warn({
+      title: 'Showing Multiple Targets is not supported yet',
+      bodyLines: [
+        `Only the task graph for "${args.targets[0]}" tasks will be shown`,
+      ],
+    });
+  }
+
   // TODO: Graph Client should support multiple targets
   const target = Array.isArray(args.targets && args.targets.length >= 1)
     ? args.targets[0]
@@ -342,7 +351,7 @@ export async function generateGraph(
       url.searchParams.append('groupByFolder', 'true');
     }
 
-    output.note({
+    output.success({
       title: `Project graph started at ${url.toString()}`,
     });
 

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -629,9 +629,10 @@ function withDepGraphOptions(yargs: yargs.Argv): yargs.Argv {
       default: 'projects',
       choices: ['projects', 'tasks'],
     })
-    .option('target', {
+    .option('targets', {
       describe: 'The target to show tasks for in the task graph',
       type: 'string',
+      coerce: parseCSV,
     })
     .option('focus', {
       describe:

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -501,6 +501,11 @@ function withRunOptions(yargs: yargs.Argv): yargs.Argv {
       default: false,
       hidden: true,
     })
+    .option('graph', {
+      type: 'boolean',
+      describe: 'Show the task graph of the command',
+      default: false,
+    })
     .option('verbose', {
       type: 'boolean',
       describe:
@@ -616,6 +621,16 @@ function withDepGraphOptions(yargs: yargs.Argv): yargs.Argv {
     .option('file', {
       describe:
         'Output file (e.g. --file=output.json or --file=dep-graph.html)',
+      type: 'string',
+    })
+    .option('view', {
+      describe: 'Choose whether to view the projects or task graph',
+      type: 'string',
+      default: 'projects',
+      choices: ['projects', 'tasks'],
+    })
+    .option('target', {
+      describe: 'The target to show tasks for in the task graph',
       type: 'string',
     })
     .option('focus', {

--- a/packages/nx/src/command-line/run-many.ts
+++ b/packages/nx/src/command-line/run-many.ts
@@ -46,11 +46,11 @@ export async function runMany(
     const projectNames = projects.map((t) => t.name);
     return await generateGraph(
       {
-        watch: true,
+        watch: false,
         open: true,
         view: 'tasks',
         all: nxArgs.all,
-        target: nxArgs.targets[0],
+        targets: nxArgs.targets,
         projects: projectNames,
       },
       projectNames

--- a/packages/nx/src/command-line/run-many.ts
+++ b/packages/nx/src/command-line/run-many.ts
@@ -11,6 +11,7 @@ import { readNxJson } from '../config/configuration';
 import { output } from '../utils/output';
 import { findMatchingProjects } from '../utils/find-matching-projects';
 import { workspaceConfigurationCheck } from '../utils/workspace-configuration-check';
+import { generateGraph } from './dep-graph';
 
 export async function runMany(
   args: { [k: string]: any },
@@ -41,16 +42,31 @@ export async function runMany(
   const projectGraph = await createProjectGraphAsync({ exitOnError: true });
   const projects = projectsToRun(nxArgs, projectGraph);
 
-  await runCommand(
-    projects,
-    projectGraph,
-    { nxJson },
-    nxArgs,
-    overrides,
-    null,
-    extraTargetDependencies,
-    extraOptions
-  );
+  if (nxArgs.graph) {
+    const projectNames = projects.map((t) => t.name);
+    return await generateGraph(
+      {
+        watch: true,
+        open: true,
+        view: 'tasks',
+        all: nxArgs.all,
+        target: nxArgs.targets[0],
+        projects: projectNames,
+      },
+      projectNames
+    );
+  } else {
+    await runCommand(
+      projects,
+      projectGraph,
+      { nxJson },
+      nxArgs,
+      overrides,
+      null,
+      extraTargetDependencies,
+      extraOptions
+    );
+  }
 }
 
 export function projectsToRun(

--- a/packages/nx/src/command-line/run-one.ts
+++ b/packages/nx/src/command-line/run-one.ts
@@ -17,6 +17,7 @@ import {
 } from '../config/workspace-json-project-json';
 import { readNxJson } from '../config/configuration';
 import { workspaceConfigurationCheck } from '../utils/workspace-configuration-check';
+import { generateGraph } from 'nx/src/command-line/dep-graph';
 
 export async function runOne(
   cwd: string,
@@ -63,16 +64,31 @@ export async function runOne(
 
   const { projects } = getProjects(projectGraph, opts.project);
 
-  await runCommand(
-    projects,
-    projectGraph,
-    { nxJson },
-    nxArgs,
-    overrides,
-    opts.project,
-    extraTargetDependencies,
-    extraOptions
-  );
+  if (nxArgs.graph) {
+    const projectNames = projects.map((t) => t.name);
+
+    return await generateGraph(
+      {
+        watch: true,
+        open: true,
+        view: 'tasks',
+        target: nxArgs.targets[0],
+        projects: projectNames,
+      },
+      projectNames
+    );
+  } else {
+    await runCommand(
+      projects,
+      projectGraph,
+      { nxJson },
+      nxArgs,
+      overrides,
+      opts.project,
+      extraTargetDependencies,
+      extraOptions
+    );
+  }
 }
 
 function getProjects(projectGraph: ProjectGraph, project: string): any {

--- a/packages/nx/src/command-line/run-one.ts
+++ b/packages/nx/src/command-line/run-one.ts
@@ -17,7 +17,7 @@ import {
 } from '../config/workspace-json-project-json';
 import { readNxJson } from '../config/configuration';
 import { workspaceConfigurationCheck } from '../utils/workspace-configuration-check';
-import { generateGraph } from 'nx/src/command-line/dep-graph';
+import { generateGraph } from './dep-graph';
 
 export async function runOne(
   cwd: string,

--- a/packages/nx/src/command-line/run-one.ts
+++ b/packages/nx/src/command-line/run-one.ts
@@ -69,10 +69,10 @@ export async function runOne(
 
     return await generateGraph(
       {
-        watch: true,
+        watch: false,
         open: true,
         view: 'tasks',
-        target: nxArgs.targets[0],
+        targets: nxArgs.targets,
         projects: projectNames,
       },
       projectNames

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -29,6 +29,7 @@ import { Hasher } from '../hasher/hasher';
 import { hashDependsOnOtherTasks, hashTask } from '../hasher/hash-task';
 import { daemonClient } from '../daemon/client/client';
 import { StoreRunInformationLifeCycle } from './life-cycles/store-run-information-life-cycle';
+import { generateGraph } from 'nx/src/command-line/dep-graph';
 
 async function getTerminalOutputLifeCycle(
   initiatingProject: string,

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -29,7 +29,6 @@ import { Hasher } from '../hasher/hasher';
 import { hashDependsOnOtherTasks, hashTask } from '../hasher/hash-task';
 import { daemonClient } from '../daemon/client/client';
 import { StoreRunInformationLifeCycle } from './life-cycles/store-run-information-life-cycle';
-import { generateGraph } from 'nx/src/command-line/dep-graph';
 
 async function getTerminalOutputLifeCycle(
   initiatingProject: string,

--- a/packages/nx/src/utils/command-line-utils.ts
+++ b/packages/nx/src/utils/command-line-utils.ts
@@ -29,6 +29,7 @@ export interface NxArgs {
   plain?: boolean;
   projects?: string[];
   select?: string;
+  graph?: boolean;
   skipNxCache?: boolean;
   outputStyle?: string;
   nxBail?: boolean;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

There is no easy way to show the task graph of a nx command.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`nx affected --target build --graph` opens up the tasks graph with affected tasks
`nx build app1 --graph` opens up the tasks graph for app1:build
`nx run-many --target build --graph` opens up the tasks graph of all build tasks
`nx graph --view tasks --target build` opens up the tasks graph at the test target

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
