### PR TITLE
fix(testing):  correctly error with jest.mock for invalid filepaths

### DIFF
--- a/packages/jest/plugins/resolver.ts
+++ b/packages/jest/plugins/resolver.ts
@@ -1,4 +1,4 @@
-import { dirname, extname } from 'path';
+import { dirname, extname, join } from 'path';
 import { resolve as resolveExports } from 'resolve.exports';
 import type defaultResolver from 'jest-resolve/build/defaultResolver';
 
@@ -81,7 +81,11 @@ module.exports = function (path: string, options: ResolveOptions) {
     ts = ts || require('typescript');
     compilerSetup = compilerSetup || getCompilerSetup(options.rootDir);
     const { compilerOptions, host } = compilerSetup;
-    return ts.resolveModuleName(path, options.basedir, compilerOptions, host)
-      .resolvedModule.resolvedFileName;
+    return ts.resolveModuleName(
+      path,
+      join(options.basedir, 'fake-placeholder.ts'),
+      compilerOptions,
+      host
+    ).resolvedModule.resolvedFileName;
   }
 };

--- a/scripts/patched-jest-resolver.js
+++ b/scripts/patched-jest-resolver.js
@@ -91,7 +91,11 @@ module.exports = function (path, options) {
     } else if (path === '@nrwl/devkit/testing') {
       return join(__dirname, '../', './packages/devkit/testing.js');
     }
-    return ts.resolveModuleName(path, options.basedir, compilerOptions, host)
-      .resolvedModule.resolvedFileName;
+    return ts.resolveModuleName(
+      path,
+      join(options.basedir, 'fake-placeholder.ts'),
+      compilerOptions,
+      host
+    ).resolvedModule.resolvedFileName;
   }
 };


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

when trying to mock a module that doesn't exit the nx jest resolver will _automagically_ find the file

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

jest correctly throws an error saying the module doesn't exist

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->


Fixes #15312
