### PR TITLE
cleanup(nx-dev): extract StaticDocumentPaths Interface to models-document

### DIFF
--- a/nx-dev/data-access-documents/src/lib/documents.api.ts
+++ b/nx-dev/data-access-documents/src/lib/documents.api.ts
@@ -2,14 +2,11 @@ import {
   DocumentMetadata,
   ProcessedDocument,
   RelatedDocument,
+  StaticDocumentPaths,
 } from '@nrwl/nx-dev/models-document';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { TagsApi } from './tags.api';
-
-interface StaticDocumentPaths {
-  params: { segments: string[] };
-}
 
 export class DocumentsApi {
   private readonly manifest: Record<string, DocumentMetadata>;

--- a/nx-dev/data-access-packages/src/lib/packages.api.ts
+++ b/nx-dev/data-access-packages/src/lib/packages.api.ts
@@ -1,5 +1,8 @@
 import { TagsApi } from '@nrwl/nx-dev/data-access-documents/node-only';
-import { DocumentMetadata } from '@nrwl/nx-dev/models-document';
+import {
+  DocumentMetadata,
+  StaticDocumentPaths,
+} from '@nrwl/nx-dev/models-document';
 import {
   FileMetadata,
   IntrinsicPackageMetadata,
@@ -8,10 +11,6 @@ import {
 } from '@nrwl/nx-dev/models-package';
 import { readFileSync } from 'fs';
 import { join } from 'path';
-
-interface StaticDocumentPaths {
-  params: { segments: string[] };
-}
 
 export class PackagesApi {
   private readonly manifest: Record<string, ProcessedPackageMetadata>;

--- a/nx-dev/models-document/src/lib/documents.models.ts
+++ b/nx-dev/models-document/src/lib/documents.models.ts
@@ -37,3 +37,7 @@ export interface RelatedDocument {
   name: string;
   path: string;
 }
+
+export interface StaticDocumentPaths {
+  params: { segments: string[] };
+}


### PR DESCRIPTION
## Current Behavior
StaticDocumentPaths is being declared in both `nx-dev/data-access-documents/src/lib/documents.api.ts` and `nx-dev/data-access-packages/src/lib/packages.api.ts`.

## Expected Behavior
Declare the interface once and reuse as needed.

## Related Issue(s)

Fixes #
