### PR TITLE
cleanup(misc): add known preset dependencies before generating it

### DIFF
--- a/packages/workspace/src/generators/new/__snapshots__/new.spec.ts.snap
+++ b/packages/workspace/src/generators/new/__snapshots__/new.spec.ts.snap
@@ -1,42 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`new --preset angular-monorepo should generate necessary npm dependencies 1`] = `
-Object {
-  "dependencies": Object {
-    "@nrwl/angular": "0.0.1",
-  },
-  "devDependencies": Object {
-    "@nrwl/workspace": "0.0.1",
-    "nx": "0.0.1",
-  },
-  "license": "MIT",
-  "name": "my-workspace",
-  "private": true,
-  "scripts": Object {},
-  "version": "0.0.0",
-}
-`;
-
-exports[`new --preset empty should generate necessary npm dependencies 1`] = `
+exports[`new --preset should generate necessary npm dependencies for empty preset 1`] = `
 Object {
   "dependencies": Object {},
   "devDependencies": Object {
-    "@nrwl/workspace": "0.0.1",
-    "nx": "0.0.1",
-  },
-  "license": "MIT",
-  "name": "my-workspace",
-  "private": true,
-  "scripts": Object {},
-  "version": "0.0.0",
-}
-`;
-
-exports[`new --preset react-monorepo should generate necessary npm dependencies 1`] = `
-Object {
-  "dependencies": Object {},
-  "devDependencies": Object {
-    "@nrwl/react": "0.0.1",
     "@nrwl/workspace": "0.0.1",
     "nx": "0.0.1",
   },

--- a/packages/workspace/src/generators/new/new.spec.ts
+++ b/packages/workspace/src/generators/new/new.spec.ts
@@ -1,8 +1,14 @@
-import { createTree } from '@nrwl/devkit/testing';
 import { readJson, Tree, writeJson } from '@nrwl/devkit';
-import { newGenerator, NormalizedSchema } from './new';
+import { createTree } from '@nrwl/devkit/testing';
 import { Linter } from '../../utils/lint';
+import {
+  angularCliVersion,
+  nxVersion,
+  prettierVersion,
+  typescriptVersion,
+} from '../../utils/versions';
 import { Preset } from '../utils/presets';
+import { newGenerator, NormalizedSchema } from './new';
 
 const defaultOptions: Omit<NormalizedSchema, 'name' | 'directory' | 'appName'> =
   {
@@ -31,22 +37,62 @@ describe('new', () => {
   });
 
   describe('--preset', () => {
-    describe.each([
-      [Preset.Empty],
-      [Preset.AngularMonorepo],
-      [Preset.ReactMonorepo],
-    ])('%s', (preset) => {
-      it('should generate necessary npm dependencies', async () => {
-        await newGenerator(tree, {
-          ...defaultOptions,
-          name: 'my-workspace',
-          directory: 'my-workspace',
-          npmScope: 'npmScope',
-          appName: 'app',
-          preset,
-        });
+    it('should generate necessary npm dependencies for empty preset', async () => {
+      await newGenerator(tree, {
+        ...defaultOptions,
+        name: 'my-workspace',
+        directory: 'my-workspace',
+        npmScope: 'npmScope',
+        appName: 'app',
+        preset: Preset.Empty,
+      });
 
-        expect(readJson(tree, 'my-workspace/package.json')).toMatchSnapshot();
+      expect(readJson(tree, 'my-workspace/package.json')).toMatchSnapshot();
+    });
+
+    it('should generate necessary npm dependencies for react preset', async () => {
+      await newGenerator(tree, {
+        ...defaultOptions,
+        name: 'my-workspace',
+        directory: 'my-workspace',
+        npmScope: 'npmScope',
+        appName: 'app',
+        preset: Preset.ReactMonorepo,
+        bundler: 'vite',
+      });
+
+      const { devDependencies } = readJson(tree, 'my-workspace/package.json');
+      expect(devDependencies).toStrictEqual({
+        '@nrwl/react': nxVersion,
+        '@nrwl/cypress': nxVersion,
+        '@nrwl/vite': nxVersion,
+        '@nrwl/workspace': nxVersion,
+        nx: nxVersion,
+      });
+    });
+
+    it('should generate necessary npm dependencies for angular preset', async () => {
+      await newGenerator(tree, {
+        ...defaultOptions,
+        name: 'my-workspace',
+        directory: 'my-workspace',
+        npmScope: 'npmScope',
+        appName: 'app',
+        preset: Preset.AngularMonorepo,
+      });
+
+      const { devDependencies, dependencies } = readJson(
+        tree,
+        'my-workspace/package.json'
+      );
+      expect(dependencies).toStrictEqual({ '@nrwl/angular': nxVersion });
+      expect(devDependencies).toStrictEqual({
+        '@angular-devkit/core': angularCliVersion,
+        '@angular-devkit/schematics': angularCliVersion,
+        '@nrwl/workspace': nxVersion,
+        '@schematics/angular': angularCliVersion,
+        nx: nxVersion,
+        typescript: typescriptVersion,
       });
     });
   });

--- a/packages/workspace/src/utils/versions.ts
+++ b/packages/workspace/src/utils/versions.ts
@@ -1,7 +1,11 @@
 export const nxVersion = require('../../package.json').version;
 
-export const angularCliVersion = '~15.2.0';
 export const typescriptVersion = '~4.9.5';
 export const typescriptESLintVersion = '^5.36.1';
 export const eslintVersion = '~8.15.0';
 export const eslintConfigPrettierVersion = '8.1.0';
+
+// TODO: remove when preset generation is reworked and
+// deps are not installed from workspace
+export const angularCliVersion = '~15.2.0';
+export const prettierVersion = '^2.6.2';

--- a/scripts/check-imports.js
+++ b/scripts/check-imports.js
@@ -34,6 +34,7 @@ function check() {
     'packages/workspace/src/core/file-command-line-utils.ts',
     'packages/workspace/src/generators/preset/preset.ts',
     'packages/workspace/src/generators/new/generate-preset.ts',
+    'packages/workspace/src/generators/new/new.spec.ts',
     'packages/workspace/src/generators/init/init.ts',
     'packages/workspace/src/migrations/update-8-3-0/update-8-3-0.spec.ts',
     'packages/workspace/src/migrations/update-8-3-0/update-ng-cli-8-1.ts',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `ensurePackage` utility adds some perf overhead to plugins initialization.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

During workspace creation, before generating the preset, install known preset dependencies that are installed using `ensurePackage`, so the `ensurePackage` doesn't perform an individual installation and perf is improved.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
