### PR TITLE
feat(repo): use caching for pnpm workspaces in e2e tests

### DIFF
--- a/e2e/utils/create-project-utils.ts
+++ b/e2e/utils/create-project-utils.ts
@@ -39,7 +39,7 @@ export function newProject({
   packageManager = getSelectedPackageManager(),
 } = {}): string {
   try {
-    const useBackupProject = packageManager !== 'pnpm';
+    const useBackupProject = /*packageManager !== 'pnpm'*/ true;
     const projScope = useBackupProject ? 'proj' : name;
 
     if (!useBackupProject || !directoryExists(tmpBackupProjPath())) {
@@ -376,7 +376,7 @@ export function newEncapsulatedNxWorkspace({
   projName = name;
   ensureDirSync(tmpProjPath());
   runCommand(`${pmc.runUninstalledPackage} nx@latest init --encapsulated`);
-  return (command: string, opts: Partial<ExecSyncOptions>) => {
+  return (command: string, opts: Partial<ExecSyncOptions> | undefined) => {
     if (process.platform === 'win32') {
       return runCommand(`./nx.bat ${command}`, { ...opts, failOnError: true });
     } else {

--- a/e2e/utils/create-project-utils.ts
+++ b/e2e/utils/create-project-utils.ts
@@ -39,10 +39,9 @@ export function newProject({
   packageManager = getSelectedPackageManager(),
 } = {}): string {
   try {
-    const useBackupProject = /*packageManager !== 'pnpm'*/ true;
-    const projScope = useBackupProject ? 'proj' : name;
+    const projScope = 'proj';
 
-    if (!useBackupProject || !directoryExists(tmpBackupProjPath())) {
+    if (!directoryExists(tmpBackupProjPath())) {
       runCreateWorkspace(projScope, {
         preset: 'empty',
         packageManager,
@@ -80,20 +79,16 @@ export function newProject({
       ];
       packageInstall(packages.join(` `), projScope);
 
-      if (useBackupProject) {
-        // stop the daemon
-        execSync('nx reset', {
-          cwd: `${e2eCwd}/proj`,
-          stdio: isVerbose() ? 'inherit' : 'pipe',
-        });
+      // stop the daemon
+      execSync('nx reset', {
+        cwd: `${e2eCwd}/proj`,
+        stdio: isVerbose() ? 'inherit' : 'pipe',
+      });
 
-        moveSync(`${e2eCwd}/proj`, `${tmpBackupProjPath()}`);
-      }
+      moveSync(`${e2eCwd}/proj`, `${tmpBackupProjPath()}`);
     }
     projName = name;
-    if (useBackupProject) {
-      copySync(`${tmpBackupProjPath()}`, `${tmpProjPath()}`);
-    }
+    copySync(`${tmpBackupProjPath()}`, `${tmpProjPath()}`);
 
     if (process.env.NX_VERBOSE_LOGGING == 'true') {
       logInfo(`NX`, `E2E test is creating a project: ${tmpProjPath()}`);


### PR DESCRIPTION
Use workspace caching for pnpm as well.

This will significantly cut down on CI times.

We had it switched off, since there were some issues in the past for pnpm but that has been resolved a long time ago.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
