### PR TITLE
feat(repo): make granular slack notifications when E2E tests fail

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -66,8 +66,66 @@ jobs:
           - os: macos-latest
             os-name: macos
           # codeowner groups
-          # - project: e2e-...
-          #   codeowners: 'S...'
+          - project: e2e-add-nx-to-monorepo
+            codeowners: 'S04SYHYKGNP'
+          - project: e2e-angular-core
+            codeowners: 'S04SS457V38'
+          - project: e2e-angular-extensions
+            codeowners: 'S04SS457V38'
+          - project: e2e-cra-to-nx
+            codeowners: 'S04TNCNJG5N'
+          - project: e2e-cypress
+            codeowners: 'S04T16BTJJY'
+          - project: e2e-detox
+            codeowners: 'S04TNCNJG5N'
+          - project: e2e-esbuild
+            codeowners: 'S04SJ6HHP0X'
+          - project: e2e-expo
+            codeowners: 'S04TNCNJG5N'
+          - project: e2e-jest
+            codeowners: 'S04T16BTJJY'
+          - project: e2e-js
+            codeowners: 'S04SJ6HHP0X'
+          - project: e2e-lerna-smoke-tests
+            codeowners: 'S04TNCVEETS'
+          - project: e2e-linter
+            codeowners: 'S04SYJGKSCT'
+          - project: e2e-make-angular-cli-faster
+            codeowners: 'S04SS457V38'
+          - project: e2e-next
+            codeowners: 'S04TNCNJG5N'
+          - project: e2e-node
+            codeowners: 'S04SJ6HHP0X'
+          - project: e2e-nx-init
+            codeowners: 'S04SYHYKGNP'
+          - project: e2e-nx-misc
+            codeowners: 'S04SYHYKGNP'
+          - project: e2e-nx-plugin
+            codeowners: 'S04SYHYKGNP'
+          - project: e2e-nx-run
+            codeowners: 'S04SYHYKGNP'
+          - project: e2e-react
+            codeowners: 'S04TNCNJG5N'
+          - project: e2e-react-native
+            codeowners: 'S04TNCNJG5N'
+          - project: e2e-web
+            codeowners: 'S04SJ6PL98X'
+          - project: e2e-rollup
+            codeowners: 'S04SJ6PL98X'
+          - project: e2e-storybook
+            codeowners: 'S04SVQ8H0G5'
+          - project: e2e-storybook-angular
+            codeowners: 'S04SVQ8H0G5'
+          - project: e2e-vite
+            codeowners: 'S04SJ6PL98X'
+          - project: e2e-webpack
+            codeowners: 'S04SJ6PL98X'
+          - project: e2e-workspace-create
+            codeowners: 'S04SYHYKGNP'
+          - project: e2e-e2e-workspace-create-npm
+            codeowners: 'S04SYHYKGNP'
+          - project: e2e-graph-client
+            codeowners: 'S04T16QL360'
         exclude:
           # exclude react-native tests from ubuntu
           - os: ubuntu-latest
@@ -179,7 +237,7 @@ jobs:
             *Package manager* ${{ matrix.package_manager }}
             *Workflow* {workflow}'
           footer: '<{run_url}|View Run> / Last commit <{commit_url}|{commit_sha}>'
-          # mention_groups: ${{ matrix.codeowners }}
+          mention_groups: ${{ matrix.codeowners }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -29,23 +29,35 @@ jobs:
           # - yarn
           # - pnpm
         project:
+          # - e2e-add-nx-to-monorepo
           # - e2e-angular-core
           # - e2e-angular-extensions
-          # - e2e-nx-run,e2e-nx-misc,e2e-nx-plugin
-          # - e2e-make-angular-cli-faster
-          - e2e-jest,e2e-cypress
-          - e2e-linter
+          # - e2e-cra-to-nx
           # - e2e-cypress
-          # - e2e-react
+          # - e2e-detox
+          # - e2e-esbuild
+          # - e2e-expo
+          # - e2e-jest
+          # - e2e-js
+          # - e2e-lerna-smoke-tests
+          - e2e-linter
+          # - e2e-make-angular-cli-faster
           # - e2e-next
           # - e2e-node
-          # - e2e-web
-          # - e2e-storybook,e2e-storybook-angular
-          # - e2e-cra-to-nx
-          # - e2e-workspace-create
+          # - e2e-nx-init
+          # - e2e-nx-misc
+          # - e2e-nx-plugin
+          # - e2e-nx-run
+          # - e2e-react
           # - e2e-react-native
-          # - e2e-detox
-          # - e2e-add-nx-to-monorepo
+          # - e2e-web
+          # - e2e-rollup
+          # - e2e-storybook
+          # - e2e-storybook-angular
+          # - e2e-vite
+          # - e2e-webpack
+          # - e2e-workspace-create
+          # - e2e-e2e-workspace-create-npm
           # - e2e-graph-client
         include:
           # os short names
@@ -54,10 +66,6 @@ jobs:
           - os: macos-latest
             os-name: macos
           # codeowners
-          - project: e2e-jest,e2e-cypress
-            codeowners:
-              - U01UELKLYF2 #Miro
-              - U9NPA6C90 #Jason
           - project: e2e-linter
             codeowners:
               - U01UELKLYF2 #Miro
@@ -167,7 +175,7 @@ jobs:
           xcrun simctl shutdown all && xcrun simctl erase all
 
       - name: Run e2e tests
-        id: e2e-tests
+        id: e2e-run
         run: yarn nx run-many --target=e2e --projects="${{ join(matrix.project) }}" --parallel=1
         env:
           GIT_AUTHOR_EMAIL: test@test.com
@@ -184,28 +192,23 @@ jobs:
           NX_E2E_SKIP_BUILD_CLEANUP: ${{ 'true' }}
           NX_CACHE_DIRECTORY: ${{ 'tmp' }}
 
-      - name: Check Failure
-        if: ${{ failure() }}
-        run: |
-          echo "${{ join(matrix.project) }} FAILED"
-          echo "INFORMING ${{ join(matrix.codeowners) }}"
-
-      - name: Check Success
-        if: ${{ success() }}
-        run: |
-          echo "${{ join(matrix.project) }} SUCCEEDED"
-          echo "INFORMING ${{ join(matrix.codeowners) }}"
-
-      - name: Notify test success
-        if: ${{ success() && github.event_name == 'workflow_dispatch' }} # only once it's fixed on manual dispatch
-        uses: ravsamhq/notify-slack-action@v1
+      - name: Notify test failure
+        # if: ${{ failure() && github.repository_owner == 'nrwl' && github.event_name !== 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        uses: ravsamhq/notify-slack-action@v2
         with:
-          status: 'success'
-          notification_title: 'This is test. Ignore it: ${{ join(matrix.project) }}'
-          message_format: '{emoji} *{workflow}* {status_message} (last commit <{commit_url}|{commit_sha}>)'
-          footer: '<{run_url}|View Run>'
+          status: 'failure'
+          # notification_title: 'This is test. Ignore it: ${{ join(matrix.project) }}'
+          # message_format: '{emoji} *${{ join(matrix.project) }}* {status_message}'
+          notification_title: 'Test requires attention'
+          message_format: '{emoji} *${{ join(matrix.project) }}* {status_message}
+            *OS* ${{ matrix.os-name }}
+            *Node* v${{ matrix.node_version }}
+            *Package manager* ${{ matrix.package_manager }}
+            *Workflow* {workflow}'
+          footer: '<{run_url}|View Run> / Last commit <{commit_url}|{commit_sha}>'
           mention_users: ${{ join(matrix.codeowners) }}
-          # mention_users_when: 'failure,warnings'
+          # mention_groups: 'S690SFLP9'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 
@@ -214,7 +217,7 @@ jobs:
         uses: mxschmitt/action-tmate@v3.8
 
   report:
-    if: ${{ always() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
+    if: ${{ success() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
     needs: e2e
     runs-on: ubuntu-latest
     name: Report status
@@ -223,8 +226,8 @@ jobs:
         uses: ravsamhq/notify-slack-action@v1
         with:
           status: ${{ needs.e2e.result }}
-          message_format: '{emoji} *{workflow}* {status_message} (last commit <{commit_url}|{commit_sha}>)'
-          notification_title: '{workflow} has {status_message}'
-          footer: '<{run_url}|View Run>'
+          message_format: '{emoji} Workflow has {status_message}'
+          notification_title: '{workflow}'
+          footer: '<{run_url}|View Run> / Last commit <{commit_url}|{commit_sha}>'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          # - macos-latest
+          - macos-latest
         node_version:
           - '16'
         package_manager:
@@ -29,116 +29,116 @@ jobs:
           - yarn
           - pnpm
         project:
-          # - e2e-add-nx-to-monorepo
-          # - e2e-angular-core
-          # - e2e-angular-extensions
-          # - e2e-cra-to-nx
-          # - e2e-cypress
-          # - e2e-detox
-          # - e2e-esbuild
-          # - e2e-expo
-          # - e2e-jest
-          # - e2e-js
-          # - e2e-lerna-smoke-tests
+          - e2e-add-nx-to-monorepo
+          - e2e-angular-core
+          - e2e-angular-extensions
+          - e2e-cra-to-nx
+          - e2e-cypress
+          - e2e-detox
+          - e2e-esbuild
+          - e2e-expo
+          - e2e-jest
+          - e2e-js
+          - e2e-lerna-smoke-tests
           - e2e-linter
-          # - e2e-make-angular-cli-faster
-          # - e2e-next
-          # - e2e-node
-          # - e2e-nx-init
-          # - e2e-nx-misc
-          # - e2e-nx-plugin
-          # - e2e-nx-run
-          # - e2e-react
-          # - e2e-react-native
-          # - e2e-web
-          # - e2e-rollup
+          - e2e-make-angular-cli-faster
+          - e2e-next
+          - e2e-node
+          - e2e-nx-init
+          - e2e-nx-misc
+          - e2e-nx-plugin
+          - e2e-nx-run
+          - e2e-react
+          - e2e-react-native
+          - e2e-web
+          - e2e-rollup
           - e2e-storybook
-          # - e2e-storybook-angular
-          # - e2e-vite
-          # - e2e-webpack
-          # - e2e-workspace-create
-          # - e2e-e2e-workspace-create-npm
-          # - e2e-graph-client
+          - e2e-storybook-angular
+          - e2e-vite
+          - e2e-webpack
+          - e2e-workspace-create
+          - e2e-e2e-workspace-create-npm
+          - e2e-graph-client
         include:
           # os short names
           - os: ubuntu-latest
             os_name: 'Linux'
-          # - os: macos-latest
-          #   os_name: 'MacOS'
+          - os: macos-latest
+            os_name: 'MacOS'
           # codeowner groups
-          # - project: e2e-add-nx-to-monorepo
-          #   codeowners: 'S04SYHYKGNP'
-          # - project: e2e-angular-core
-          #   codeowners: 'S04SS457V38'
-          # - project: e2e-angular-extensions
-          #   codeowners: 'S04SS457V38'
-          # - project: e2e-cra-to-nx
-          #   codeowners: 'S04TNCNJG5N'
-          # - project: e2e-cypress
-          #   codeowners: 'S04T16BTJJY'
-          # - project: e2e-detox
-          #   codeowners: 'S04TNCNJG5N'
-          # - project: e2e-esbuild
-          #   codeowners: 'S04SJ6HHP0X'
-          # - project: e2e-expo
-          #   codeowners: 'S04TNCNJG5N'
-          # - project: e2e-jest
-          #   codeowners: 'S04T16BTJJY'
-          # - project: e2e-js
-          #   codeowners: 'S04SJ6HHP0X'
-          # - project: e2e-lerna-smoke-tests
-          #   codeowners: 'S04TNCVEETS'
+          - project: e2e-add-nx-to-monorepo
+            codeowners: 'S04SYHYKGNP'
+          - project: e2e-angular-core
+            codeowners: 'S04SS457V38'
+          - project: e2e-angular-extensions
+            codeowners: 'S04SS457V38'
+          - project: e2e-cra-to-nx
+            codeowners: 'S04TNCNJG5N'
+          - project: e2e-cypress
+            codeowners: 'S04T16BTJJY'
+          - project: e2e-detox
+            codeowners: 'S04TNCNJG5N'
+          - project: e2e-esbuild
+            codeowners: 'S04SJ6HHP0X'
+          - project: e2e-expo
+            codeowners: 'S04TNCNJG5N'
+          - project: e2e-jest
+            codeowners: 'S04T16BTJJY'
+          - project: e2e-js
+            codeowners: 'S04SJ6HHP0X'
+          - project: e2e-lerna-smoke-tests
+            codeowners: 'S04TNCVEETS'
           - project: e2e-linter
             codeowners: 'S04SYJGKSCT'
-          # - project: e2e-make-angular-cli-faster
-          #   codeowners: 'S04SS457V38'
-          # - project: e2e-next
-          #   codeowners: 'S04TNCNJG5N'
-          # - project: e2e-node
-          #   codeowners: 'S04SJ6HHP0X'
-          # - project: e2e-nx-init
-          #   codeowners: 'S04SYHYKGNP'
-          # - project: e2e-nx-misc
-          #   codeowners: 'S04SYHYKGNP'
-          # - project: e2e-nx-plugin
-          #   codeowners: 'S04SYHYKGNP'
-          # - project: e2e-nx-run
-          #   codeowners: 'S04SYHYKGNP'
-          # - project: e2e-react
-          #   codeowners: 'S04TNCNJG5N'
-          # - project: e2e-react-native
-          #   codeowners: 'S04TNCNJG5N'
-          # - project: e2e-web
-          #   codeowners: 'S04SJ6PL98X'
-          # - project: e2e-rollup
-          #   codeowners: 'S04SJ6PL98X'
+          - project: e2e-make-angular-cli-faster
+            codeowners: 'S04SS457V38'
+          - project: e2e-next
+            codeowners: 'S04TNCNJG5N'
+          - project: e2e-node
+            codeowners: 'S04SJ6HHP0X'
+          - project: e2e-nx-init
+            codeowners: 'S04SYHYKGNP'
+          - project: e2e-nx-misc
+            codeowners: 'S04SYHYKGNP'
+          - project: e2e-nx-plugin
+            codeowners: 'S04SYHYKGNP'
+          - project: e2e-nx-run
+            codeowners: 'S04SYHYKGNP'
+          - project: e2e-react
+            codeowners: 'S04TNCNJG5N'
+          - project: e2e-react-native
+            codeowners: 'S04TNCNJG5N'
+          - project: e2e-web
+            codeowners: 'S04SJ6PL98X'
+          - project: e2e-rollup
+            codeowners: 'S04SJ6PL98X'
           - project: e2e-storybook
             codeowners: 'S04SVQ8H0G5'
-          # - project: e2e-storybook-angular
-          #   codeowners: 'S04SVQ8H0G5'
-          # - project: e2e-vite
-          #   codeowners: 'S04SJ6PL98X'
-          # - project: e2e-webpack
-          #   codeowners: 'S04SJ6PL98X'
-          # - project: e2e-workspace-create
-          #   codeowners: 'S04SYHYKGNP'
-          # - project: e2e-e2e-workspace-create-npm
-          #   codeowners: 'S04SYHYKGNP'
-          # - project: e2e-graph-client
-          #   codeowners: 'S04T16QL360'
-        # exclude:
-        #   # exclude react-native tests from ubuntu
-        #   - os: ubuntu-latest
-        #     project: e2e-react-native
-        #   - os: ubuntu-latest
-        #     project: e2e-detox
-        #   - os: ubuntu-latest
-        #     project: e2e-expo
-        #   # run just npm v16 on macos
-        #   - os: macos-latest
-        #     package_manager: yarn
-        #   - os: macos-latest
-        #     package_manager: pnpm
+          - project: e2e-storybook-angular
+            codeowners: 'S04SVQ8H0G5'
+          - project: e2e-vite
+            codeowners: 'S04SJ6PL98X'
+          - project: e2e-webpack
+            codeowners: 'S04SJ6PL98X'
+          - project: e2e-workspace-create
+            codeowners: 'S04SYHYKGNP'
+          - project: e2e-e2e-workspace-create-npm
+            codeowners: 'S04SYHYKGNP'
+          - project: e2e-graph-client
+            codeowners: 'S04T16QL360'
+        exclude:
+          # exclude react-native tests from ubuntu
+          - os: ubuntu-latest
+            project: e2e-react-native
+          - os: ubuntu-latest
+            project: e2e-detox
+          - os: ubuntu-latest
+            project: e2e-expo
+          # run just npm v16 on macos
+          - os: macos-latest
+            package_manager: yarn
+          - os: macos-latest
+            package_manager: pnpm
       fail-fast: false
 
     name: ${{ matrix.os_name }}/${{ matrix.package_manager }} ${{ join(matrix.project) }}
@@ -259,7 +259,6 @@ jobs:
     outputs:
       message: ${{ steps.process-json.outputs.SLACK_MESSAGE }}
       codeowners: ${{ steps.process-json.outputs.CODEOWNERS }}
-      # combi_message: ${{ steps.process-json.outputs.COMBI_SLACK_MESSAGE }}
     steps:
       - name: Load outputs
         uses: actions/download-artifact@v3
@@ -293,8 +292,8 @@ jobs:
             // message
             let result = `
               \`\`\`
-               | Failed project                | Node | PM   | OS   |
-               |-------------------------------|------|------|------|`;
+               | Failed project                 | Node | PM   | OS   |
+               |--------------------------------|------|------|------|`;
             failedProjects.forEach(matrix => {
               result += `\n| ${matrix.project.padEnd(30)} | v${matrix.node_version.padEnd(3)} | ${matrix.package_manager.padEnd(4)} | ${matrix.os_name} |`
             });
@@ -303,8 +302,7 @@ jobs:
             core.setOutput('SLACK_MESSAGE', message);
 
   report-failure:
-    # if: ${{ failure() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
-    if: ${{ failure() }}
+    if: ${{ failure() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
     needs: process-result
     runs-on: ubuntu-latest
     name: Report failure
@@ -321,8 +319,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 
   report-success:
-    # if: ${{ success() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
-    if: ${{ success() }}
+    if: ${{ success() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
     needs: e2e
     runs-on: ubuntu-latest
     name: Report status

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
+          # - macos-latest
         node_version:
           - '16'
         package_manager:
@@ -29,116 +29,116 @@ jobs:
           - yarn
           - pnpm
         project:
-          - e2e-add-nx-to-monorepo
-          - e2e-angular-core
-          - e2e-angular-extensions
-          - e2e-cra-to-nx
-          - e2e-cypress
-          - e2e-detox
-          - e2e-esbuild
-          - e2e-expo
-          - e2e-jest
-          - e2e-js
-          - e2e-lerna-smoke-tests
+          # - e2e-add-nx-to-monorepo
+          # - e2e-angular-core
+          # - e2e-angular-extensions
+          # - e2e-cra-to-nx
+          # - e2e-cypress
+          # - e2e-detox
+          # - e2e-esbuild
+          # - e2e-expo
+          # - e2e-jest
+          # - e2e-js
+          # - e2e-lerna-smoke-tests
           - e2e-linter
-          - e2e-make-angular-cli-faster
-          - e2e-next
-          - e2e-node
-          - e2e-nx-init
-          - e2e-nx-misc
-          - e2e-nx-plugin
-          - e2e-nx-run
-          - e2e-react
-          - e2e-react-native
-          - e2e-web
-          - e2e-rollup
+          # - e2e-make-angular-cli-faster
+          # - e2e-next
+          # - e2e-node
+          # - e2e-nx-init
+          # - e2e-nx-misc
+          # - e2e-nx-plugin
+          # - e2e-nx-run
+          # - e2e-react
+          # - e2e-react-native
+          # - e2e-web
+          # - e2e-rollup
           - e2e-storybook
-          - e2e-storybook-angular
-          - e2e-vite
-          - e2e-webpack
-          - e2e-workspace-create
-          - e2e-e2e-workspace-create-npm
-          - e2e-graph-client
+          # - e2e-storybook-angular
+          # - e2e-vite
+          # - e2e-webpack
+          # - e2e-workspace-create
+          # - e2e-e2e-workspace-create-npm
+          # - e2e-graph-client
         include:
           # os short names
           - os: ubuntu-latest
             os_name: 'Linux'
-          - os: macos-latest
-            os_name: 'MacOS'
+          # - os: macos-latest
+          #   os_name: 'MacOS'
           # codeowner groups
-          - project: e2e-add-nx-to-monorepo
-            codeowners: 'S04SYHYKGNP'
-          - project: e2e-angular-core
-            codeowners: 'S04SS457V38'
-          - project: e2e-angular-extensions
-            codeowners: 'S04SS457V38'
-          - project: e2e-cra-to-nx
-            codeowners: 'S04TNCNJG5N'
-          - project: e2e-cypress
-            codeowners: 'S04T16BTJJY'
-          - project: e2e-detox
-            codeowners: 'S04TNCNJG5N'
-          - project: e2e-esbuild
-            codeowners: 'S04SJ6HHP0X'
-          - project: e2e-expo
-            codeowners: 'S04TNCNJG5N'
-          - project: e2e-jest
-            codeowners: 'S04T16BTJJY'
-          - project: e2e-js
-            codeowners: 'S04SJ6HHP0X'
-          - project: e2e-lerna-smoke-tests
-            codeowners: 'S04TNCVEETS'
+          # - project: e2e-add-nx-to-monorepo
+          #   codeowners: 'S04SYHYKGNP'
+          # - project: e2e-angular-core
+          #   codeowners: 'S04SS457V38'
+          # - project: e2e-angular-extensions
+          #   codeowners: 'S04SS457V38'
+          # - project: e2e-cra-to-nx
+          #   codeowners: 'S04TNCNJG5N'
+          # - project: e2e-cypress
+          #   codeowners: 'S04T16BTJJY'
+          # - project: e2e-detox
+          #   codeowners: 'S04TNCNJG5N'
+          # - project: e2e-esbuild
+          #   codeowners: 'S04SJ6HHP0X'
+          # - project: e2e-expo
+          #   codeowners: 'S04TNCNJG5N'
+          # - project: e2e-jest
+          #   codeowners: 'S04T16BTJJY'
+          # - project: e2e-js
+          #   codeowners: 'S04SJ6HHP0X'
+          # - project: e2e-lerna-smoke-tests
+          #   codeowners: 'S04TNCVEETS'
           - project: e2e-linter
             codeowners: 'S04SYJGKSCT'
-          - project: e2e-make-angular-cli-faster
-            codeowners: 'S04SS457V38'
-          - project: e2e-next
-            codeowners: 'S04TNCNJG5N'
-          - project: e2e-node
-            codeowners: 'S04SJ6HHP0X'
-          - project: e2e-nx-init
-            codeowners: 'S04SYHYKGNP'
-          - project: e2e-nx-misc
-            codeowners: 'S04SYHYKGNP'
-          - project: e2e-nx-plugin
-            codeowners: 'S04SYHYKGNP'
-          - project: e2e-nx-run
-            codeowners: 'S04SYHYKGNP'
-          - project: e2e-react
-            codeowners: 'S04TNCNJG5N'
-          - project: e2e-react-native
-            codeowners: 'S04TNCNJG5N'
-          - project: e2e-web
-            codeowners: 'S04SJ6PL98X'
-          - project: e2e-rollup
-            codeowners: 'S04SJ6PL98X'
+          # - project: e2e-make-angular-cli-faster
+          #   codeowners: 'S04SS457V38'
+          # - project: e2e-next
+          #   codeowners: 'S04TNCNJG5N'
+          # - project: e2e-node
+          #   codeowners: 'S04SJ6HHP0X'
+          # - project: e2e-nx-init
+          #   codeowners: 'S04SYHYKGNP'
+          # - project: e2e-nx-misc
+          #   codeowners: 'S04SYHYKGNP'
+          # - project: e2e-nx-plugin
+          #   codeowners: 'S04SYHYKGNP'
+          # - project: e2e-nx-run
+          #   codeowners: 'S04SYHYKGNP'
+          # - project: e2e-react
+          #   codeowners: 'S04TNCNJG5N'
+          # - project: e2e-react-native
+          #   codeowners: 'S04TNCNJG5N'
+          # - project: e2e-web
+          #   codeowners: 'S04SJ6PL98X'
+          # - project: e2e-rollup
+          #   codeowners: 'S04SJ6PL98X'
           - project: e2e-storybook
             codeowners: 'S04SVQ8H0G5'
-          - project: e2e-storybook-angular
-            codeowners: 'S04SVQ8H0G5'
-          - project: e2e-vite
-            codeowners: 'S04SJ6PL98X'
-          - project: e2e-webpack
-            codeowners: 'S04SJ6PL98X'
-          - project: e2e-workspace-create
-            codeowners: 'S04SYHYKGNP'
-          - project: e2e-e2e-workspace-create-npm
-            codeowners: 'S04SYHYKGNP'
-          - project: e2e-graph-client
-            codeowners: 'S04T16QL360'
-        exclude:
-          # exclude react-native tests from ubuntu
-          - os: ubuntu-latest
-            project: e2e-react-native
-          - os: ubuntu-latest
-            project: e2e-detox
-          - os: ubuntu-latest
-            project: e2e-expo
-          # run just npm v16 on macos
-          - os: macos-latest
-            package_manager: yarn
-          - os: macos-latest
-            package_manager: pnpm
+          # - project: e2e-storybook-angular
+          #   codeowners: 'S04SVQ8H0G5'
+          # - project: e2e-vite
+          #   codeowners: 'S04SJ6PL98X'
+          # - project: e2e-webpack
+          #   codeowners: 'S04SJ6PL98X'
+          # - project: e2e-workspace-create
+          #   codeowners: 'S04SYHYKGNP'
+          # - project: e2e-e2e-workspace-create-npm
+          #   codeowners: 'S04SYHYKGNP'
+          # - project: e2e-graph-client
+          #   codeowners: 'S04T16QL360'
+        # exclude:
+        #   # exclude react-native tests from ubuntu
+        #   - os: ubuntu-latest
+        #     project: e2e-react-native
+        #   - os: ubuntu-latest
+        #     project: e2e-detox
+        #   - os: ubuntu-latest
+        #     project: e2e-expo
+        #   # run just npm v16 on macos
+        #   - os: macos-latest
+        #     package_manager: yarn
+        #   - os: macos-latest
+        #     package_manager: pnpm
       fail-fast: false
 
     name: ${{ matrix.os_name }}/${{ matrix.package_manager }} ${{ join(matrix.project) }}
@@ -250,6 +250,7 @@ jobs:
       - name: Setup tmate session
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled && failure() }}
         uses: mxschmitt/action-tmate@v3.8
+        timeout-minutes: 15
 
   process-result:
     if: ${{ always() }}
@@ -258,6 +259,7 @@ jobs:
     outputs:
       message: ${{ steps.process-json.outputs.SLACK_MESSAGE }}
       codeowners: ${{ steps.process-json.outputs.CODEOWNERS }}
+      # combi_message: ${{ steps.process-json.outputs.COMBI_SLACK_MESSAGE }}
     steps:
       - name: Load outputs
         uses: actions/download-artifact@v3
@@ -290,19 +292,22 @@ jobs:
 
             // message
             let result = `
-               | Failed project | Node | PM | OS |
-               |--|--|--|--|`;
+              \`\`\`
+               | Failed project                | Node | PM   | OS   |
+               |-------------------------------|------|------|------|`;
             failedProjects.forEach(matrix => {
-              result += `\n|**${matrix.project}**|v${matrix.node_version}|${matrix.package_manager}|${matrix.os_name}|`
+              result += `\n| ${matrix.project.padEnd(30)} | v${matrix.node_version.padEnd(3)} | ${matrix.package_manager.padEnd(4)} | ${matrix.os_name} |`
             });
+            result += `\`\`\``;
             const message = result.split('\n').map(l => l.trim()).join('\n');
             core.setOutput('SLACK_MESSAGE', message);
 
   report-failure:
-    if: ${{ failure() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
+    # if: ${{ failure() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
+    if: ${{ failure() }}
     needs: process-result
     runs-on: ubuntu-latest
-    name: Report status
+    name: Report failure
     steps:
       - name: Send notification
         uses: ravsamhq/notify-slack-action@v2
@@ -315,8 +320,9 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 
-  report:
-    if: ${{ success() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
+  report-success:
+    # if: ${{ success() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
+    if: ${{ success() }}
     needs: e2e
     runs-on: ubuntu-latest
     name: Report status

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -62,9 +62,9 @@ jobs:
         include:
           # os short names
           - os: ubuntu-latest
-            os-name: '🐧'
+            os_name: 'Linux'
           - os: macos-latest
-            os-name: ''
+            os_name: 'MacOS'
           # codeowner groups
           - project: e2e-add-nx-to-monorepo
             codeowners: 'S04SYHYKGNP'
@@ -141,10 +141,13 @@ jobs:
             package_manager: pnpm
       fail-fast: false
 
-    name: ${{ matrix.os-name }}/${{ matrix.package_manager }} ${{ join(matrix.project) }}
+    name: ${{ matrix.os_name }}/${{ matrix.package_manager }} ${{ join(matrix.project) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Prepare dir for output
+        run: mkdir -p outputs
 
       - name: Install PNPM
         if: ${{ matrix.package_manager == 'pnpm' }}
@@ -225,25 +228,92 @@ jobs:
           NX_E2E_SKIP_BUILD_CLEANUP: ${{ 'true' }}
           NX_CACHE_DIRECTORY: ${{ 'tmp' }}
 
-      - name: Notify test failure
-        if: ${{ failure() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
-        uses: ravsamhq/notify-slack-action@v2
+      - name: Save matrix config in file
+        if: ${{ always() }}
+        id: save-matrix
+        run: |
+          matrix=$((
+            echo '${{ toJSON(matrix) }}'
+          ) | jq -c '. + { "status": "${{ steps.e2e-run.outcome}}" }')
+          echo "$matrix" > matrix
+          path=outputs/${{ matrix.os_name}}-${{ matrix.node_version}}-${{ matrix.package_manager}}-${{ matrix.project }}
+          echo "path=$path" >> $GITHUB_OUTPUT
+          echo "$matrix" > $path
+
+      - name: Upload matrix config
+        uses: actions/upload-artifact@v3
+        if: ${{ always() }}
         with:
-          status: 'failure'
-          notification_title: 'Test requires attention'
-          message_format: '{emoji} *${{ join(matrix.project) }}* has {status_message}
-            *OS* ${{ matrix.os-name }}
-            *Node* v${{ matrix.node_version }}
-            *Package manager* ${{ matrix.package_manager }}
-            *Workflow* {workflow}'
-          footer: '<{run_url}|View Run> / Last commit <{commit_url}|{commit_sha}>'
-          mention_groups: ${{ matrix.codeowners }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
+          name: outputs
+          path: ${{ steps.save-matrix.outputs.path }}
 
       - name: Setup tmate session
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled && failure() }}
         uses: mxschmitt/action-tmate@v3.8
+
+  process-result:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs: e2e
+    outputs:
+      message: ${{ steps.process-json.outputs.SLACK_MESSAGE }}
+      codeowners: ${{ steps.process-json.outputs.CODEOWNERS }}
+    steps:
+      - name: Load outputs
+        uses: actions/download-artifact@v3
+        with:
+          name: outputs
+          path: outputs
+
+      - name: Join and stringify matrix configs
+        id: combine-json
+        run: |
+          combined=$((jq -s . outputs/*) | jq tostring)
+          echo "combined=$combined" >> $GITHUB_OUTPUT
+
+      - name: Make slack outputs
+        id: process-json
+        uses: actions/github-script@v6
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          script: |
+            const combined = JSON.parse(${{ steps.combine-json.outputs.combined }});
+            const failedProjects = combined.filter(c => c.status === 'failure');
+
+            // codeowners
+            const codeowners = new Set();
+            failedProjects.forEach(c => {
+              codeowners.add(c.codeowners);
+            });
+            core.setOutput('CODEOWNERS', Array.from(codeowners).join(','));
+
+            // message
+            let result = `
+               | Failed project | Node | PM | OS |
+               |--|--|--|--|`;
+            failedProjects.forEach(matrix => {
+              result += `\n|**${matrix.project}**|v${matrix.node_version}|${matrix.package_manager}|${matrix.os_name}|`
+            });
+            const message = result.split('\n').map(l => l.trim()).join('\n');
+            core.setOutput('SLACK_MESSAGE', message);
+
+  report-failure:
+    if: ${{ failure() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
+    needs: process-result
+    runs-on: ubuntu-latest
+    name: Report status
+    steps:
+      - name: Send notification
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: 'failure'
+          message_format: '{emoji} Workflow has {status_message} ${{ needs.process-result.outputs.message }}'
+          notification_title: '{workflow}'
+          footer: '<{run_url}|View Run> / Last commit <{commit_url}|{commit_sha}>'
+          mention_groups: ${{ needs.process-result.outputs.codeowners }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 
   report:
     if: ${{ success() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -168,7 +168,7 @@ jobs:
           NX_CACHE_DIRECTORY: ${{ 'tmp' }}
 
       - name: Notify test failure
-        if: ${{ failure() && github.repository_owner == 'nrwl' && github.event_name !== 'workflow_dispatch' }}
+        if: ${{ failure() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
         uses: ravsamhq/notify-slack-action@v2
         with:
           status: 'failure'

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -226,8 +226,7 @@ jobs:
           NX_CACHE_DIRECTORY: ${{ 'tmp' }}
 
       - name: Notify test failure
-        # if: ${{ failure() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
-        if: ${{ failure() }}
+        if: ${{ failure() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
         uses: ravsamhq/notify-slack-action@v2
         with:
           status: 'failure'
@@ -253,7 +252,7 @@ jobs:
     name: Report status
     steps:
       - name: Send notification
-        uses: ravsamhq/notify-slack-action@v1
+        uses: ravsamhq/notify-slack-action@v2
         with:
           status: ${{ needs.e2e.result }}
           message_format: '{emoji} Workflow has {status_message}'

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -62,9 +62,9 @@ jobs:
         include:
           # os short names
           - os: ubuntu-latest
-            os-name: linux
+            os-name: '🐧'
           - os: macos-latest
-            os-name: macos
+            os-name: ''
           # codeowner groups
           - project: e2e-add-nx-to-monorepo
             codeowners: 'S04SYHYKGNP'
@@ -129,11 +129,11 @@ jobs:
         exclude:
           # exclude react-native tests from ubuntu
           - os: ubuntu-latest
-            packages: e2e-react-native
+            project: e2e-react-native
           - os: ubuntu-latest
-            packages: e2e-detox
+            project: e2e-detox
           - os: ubuntu-latest
-            packages: e2e-expo
+            project: e2e-expo
           # run just npm v16 on macos
           - os: macos-latest
             package_manager: yarn
@@ -226,7 +226,8 @@ jobs:
           NX_CACHE_DIRECTORY: ${{ 'tmp' }}
 
       - name: Notify test failure
-        if: ${{ failure() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
+        # if: ${{ failure() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
+        if: ${{ failure() }}
         uses: ravsamhq/notify-slack-action@v2
         with:
           status: 'failure'

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -15,7 +15,7 @@ permissions: {}
 jobs:
   e2e:
     permissions:
-      contents: read  #  to fetch code (actions/checkout)
+      contents: read
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -26,86 +26,61 @@ jobs:
           - '16'
         package_manager:
           - npm
-          # - yarn
-          # - pnpm
+          - yarn
+          - pnpm
         project:
-          # - e2e-add-nx-to-monorepo
-          # - e2e-angular-core
-          # - e2e-angular-extensions
-          # - e2e-cra-to-nx
-          # - e2e-cypress
-          # - e2e-detox
-          # - e2e-esbuild
-          # - e2e-expo
-          # - e2e-jest
-          # - e2e-js
-          # - e2e-lerna-smoke-tests
+          - e2e-add-nx-to-monorepo
+          - e2e-angular-core
+          - e2e-angular-extensions
+          - e2e-cra-to-nx
+          - e2e-cypress
+          - e2e-detox
+          - e2e-esbuild
+          - e2e-expo
+          - e2e-jest
+          - e2e-js
+          - e2e-lerna-smoke-tests
           - e2e-linter
-          # - e2e-make-angular-cli-faster
-          # - e2e-next
-          # - e2e-node
-          # - e2e-nx-init
-          # - e2e-nx-misc
-          # - e2e-nx-plugin
-          # - e2e-nx-run
-          # - e2e-react
-          # - e2e-react-native
-          # - e2e-web
-          # - e2e-rollup
-          # - e2e-storybook
-          # - e2e-storybook-angular
-          # - e2e-vite
-          # - e2e-webpack
-          # - e2e-workspace-create
-          # - e2e-e2e-workspace-create-npm
-          # - e2e-graph-client
+          - e2e-make-angular-cli-faster
+          - e2e-next
+          - e2e-node
+          - e2e-nx-init
+          - e2e-nx-misc
+          - e2e-nx-plugin
+          - e2e-nx-run
+          - e2e-react
+          - e2e-react-native
+          - e2e-web
+          - e2e-rollup
+          - e2e-storybook
+          - e2e-storybook-angular
+          - e2e-vite
+          - e2e-webpack
+          - e2e-workspace-create
+          - e2e-e2e-workspace-create-npm
+          - e2e-graph-client
         include:
           # os short names
           - os: ubuntu-latest
             os-name: linux
           - os: macos-latest
             os-name: macos
-          # codeowners
-          - project: e2e-linter
-            codeowners:
-              - U01UELKLYF2 #Miro
-              - U9NPA6C90 #Jason
-        # exclude:
-        #   # exclude react-native and detox from ubuntu
-        #   - os: ubuntu-latest
-        #     packages: e2e-react-native
-        #   # - os: ubuntu-latest
-        #   #   packages: e2e-detox
-        #   # run just npm on macos
-        #   - os: macos-latest
-        #     package_manager: yarn
-        #   - os: macos-latest
-        #     package_manager: pnpm
-        #   # exclude everything but react-native and detox from macos
-        #   - os: macos-latest
-        #     packages: e2e-angular-core,e2e-angular-extensions
-        #   - os: macos-latest
-        #     packages: e2e-nx-run,e2e-nx-misc,e2e-nx-plugin,e2e-jest,e2e-linter
-        #   - os: macos-latest
-        #     packages: e2e-cypress
-        #   - os: macos-latest
-        #     packages: e2e-react
-        #   - os: macos-latest
-        #     packages: e2e-next
-        #   - os: macos-latest
-        #     packages: e2e-node
-        #   - os: macos-latest
-        #     packages: e2e-web
-        #   - os: macos-latest
-        #     packages: e2e-storybook,e2e-storybook-angular
-        #   - os: macos-latest
-        #     packages: e2e-workspace-create
-        #   - os: macos-latest
-        #     packages: e2e-add-nx-to-monorepo
-        #   - os: macos-latest
-        #     packages: e2e-graph-client
-        #   - os: macos-latest
-        #     packages: e2e-make-angular-cli-faster
+          # codeowner groups
+          # - project: e2e-...
+          #   codeowners: 'S...'
+        exclude:
+          # exclude react-native tests from ubuntu
+          - os: ubuntu-latest
+            packages: e2e-react-native
+          - os: ubuntu-latest
+            packages: e2e-detox
+          - os: ubuntu-latest
+            packages: e2e-expo
+          # run just npm v16 on macos
+          - os: macos-latest
+            package_manager: yarn
+          - os: macos-latest
+            package_manager: pnpm
       fail-fast: false
 
     name: ${{ matrix.os-name }}/${{ matrix.package_manager }} ${{ join(matrix.project) }}
@@ -193,22 +168,18 @@ jobs:
           NX_CACHE_DIRECTORY: ${{ 'tmp' }}
 
       - name: Notify test failure
-        # if: ${{ failure() && github.repository_owner == 'nrwl' && github.event_name !== 'workflow_dispatch' }}
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ failure() && github.repository_owner == 'nrwl' && github.event_name !== 'workflow_dispatch' }}
         uses: ravsamhq/notify-slack-action@v2
         with:
           status: 'failure'
-          # notification_title: 'This is test. Ignore it: ${{ join(matrix.project) }}'
-          # message_format: '{emoji} *${{ join(matrix.project) }}* {status_message}'
           notification_title: 'Test requires attention'
-          message_format: '{emoji} *${{ join(matrix.project) }}* {status_message}
+          message_format: '{emoji} *${{ join(matrix.project) }}* has {status_message}
             *OS* ${{ matrix.os-name }}
             *Node* v${{ matrix.node_version }}
             *Package manager* ${{ matrix.package_manager }}
             *Workflow* {workflow}'
           footer: '<{run_url}|View Run> / Last commit <{commit_url}|{commit_sha}>'
-          mention_users: ${{ join(matrix.codeowners) }}
-          # mention_groups: 'S690SFLP9'
+          # mention_groups: ${{ matrix.codeowners }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -22,75 +22,85 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-        include:
-          - os: ubuntu-latest
-            os-name: ubuntu
-          - os: macos-latest
-            os-name: osx
         node_version:
           - '16'
         package_manager:
           - npm
-          - yarn
-          - pnpm
-        packages:
-          - e2e-angular-core
-          - e2e-angular-extensions
-          - e2e-nx-run,e2e-nx-misc,e2e-nx-plugin
-          - e2e-make-angular-cli-faster
-          - e2e-jest
+          # - yarn
+          # - pnpm
+        project:
+          # - e2e-angular-core
+          # - e2e-angular-extensions
+          # - e2e-nx-run,e2e-nx-misc,e2e-nx-plugin
+          # - e2e-make-angular-cli-faster
+          - e2e-jest,e2e-cypress
           - e2e-linter
-          - e2e-cypress
-          - e2e-react
-          - e2e-next
-          - e2e-node
-          - e2e-web
-          - e2e-storybook,e2e-storybook-angular
-          - e2e-cra-to-nx
-          - e2e-workspace-create
-          - e2e-react-native
+          # - e2e-cypress
+          # - e2e-react
+          # - e2e-next
+          # - e2e-node
+          # - e2e-web
+          # - e2e-storybook,e2e-storybook-angular
+          # - e2e-cra-to-nx
+          # - e2e-workspace-create
+          # - e2e-react-native
           # - e2e-detox
-          - e2e-add-nx-to-monorepo
-          - e2e-graph-client
-        exclude:
-          # exclude react-native and detox from ubuntu
+          # - e2e-add-nx-to-monorepo
+          # - e2e-graph-client
+        include:
+          # os short names
           - os: ubuntu-latest
-            packages: e2e-react-native
-          # - os: ubuntu-latest
-          #   packages: e2e-detox
-          # run just npm on macos
+            os-name: linux
           - os: macos-latest
-            package_manager: yarn
-          - os: macos-latest
-            package_manager: pnpm
-          # exclude everything but react-native and detox from macos
-          - os: macos-latest
-            packages: e2e-angular-core,e2e-angular-extensions
-          - os: macos-latest
-            packages: e2e-nx-run,e2e-nx-misc,e2e-nx-plugin,e2e-jest,e2e-linter
-          - os: macos-latest
-            packages: e2e-cypress
-          - os: macos-latest
-            packages: e2e-react
-          - os: macos-latest
-            packages: e2e-next
-          - os: macos-latest
-            packages: e2e-node
-          - os: macos-latest
-            packages: e2e-web
-          - os: macos-latest
-            packages: e2e-storybook,e2e-storybook-angular
-          - os: macos-latest
-            packages: e2e-workspace-create
-          - os: macos-latest
-            packages: e2e-add-nx-to-monorepo
-          - os: macos-latest
-            packages: e2e-graph-client
-          - os: macos-latest
-            packages: e2e-make-angular-cli-faster
+            os-name: macos
+          # codeowners
+          - project: e2e-jest,e2e-cypress
+            codeowners:
+              - U01UELKLYF2 #Miro
+              - U9NPA6C90 #Jason
+          - project: e2e-linter
+            codeowners:
+              - U01UELKLYF2 #Miro
+              - U9NPA6C90 #Jason
+        # exclude:
+        #   # exclude react-native and detox from ubuntu
+        #   - os: ubuntu-latest
+        #     packages: e2e-react-native
+        #   # - os: ubuntu-latest
+        #   #   packages: e2e-detox
+        #   # run just npm on macos
+        #   - os: macos-latest
+        #     package_manager: yarn
+        #   - os: macos-latest
+        #     package_manager: pnpm
+        #   # exclude everything but react-native and detox from macos
+        #   - os: macos-latest
+        #     packages: e2e-angular-core,e2e-angular-extensions
+        #   - os: macos-latest
+        #     packages: e2e-nx-run,e2e-nx-misc,e2e-nx-plugin,e2e-jest,e2e-linter
+        #   - os: macos-latest
+        #     packages: e2e-cypress
+        #   - os: macos-latest
+        #     packages: e2e-react
+        #   - os: macos-latest
+        #     packages: e2e-next
+        #   - os: macos-latest
+        #     packages: e2e-node
+        #   - os: macos-latest
+        #     packages: e2e-web
+        #   - os: macos-latest
+        #     packages: e2e-storybook,e2e-storybook-angular
+        #   - os: macos-latest
+        #     packages: e2e-workspace-create
+        #   - os: macos-latest
+        #     packages: e2e-add-nx-to-monorepo
+        #   - os: macos-latest
+        #     packages: e2e-graph-client
+        #   - os: macos-latest
+        #     packages: e2e-make-angular-cli-faster
       fail-fast: false
 
-    name: ${{ matrix.os-name }}/${{ matrix.package_manager }} - ${{ matrix.packages }}
+    name: ${{ matrix.os-name }}/${{ matrix.package_manager }} ${{ join(matrix.project) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -157,7 +167,8 @@ jobs:
           xcrun simctl shutdown all && xcrun simctl erase all
 
       - name: Run e2e tests
-        run: yarn nx run-many --target=e2e --projects="${{ join(matrix.packages) }}" --parallel=1
+        id: e2e-tests
+        run: yarn nx run-many --target=e2e --projects="${{ join(matrix.project) }}" --parallel=1
         env:
           GIT_AUTHOR_EMAIL: test@test.com
           GIT_AUTHOR_NAME: Test
@@ -173,27 +184,34 @@ jobs:
           NX_E2E_SKIP_BUILD_CLEANUP: ${{ 'true' }}
           NX_CACHE_DIRECTORY: ${{ 'tmp' }}
 
+      - name: Check Failure
+        if: ${{ failure() }}
+        run: |
+          echo "${{ join(matrix.project) }} FAILED"
+          echo "INFORMING ${{ join(matrix.codeowners) }}"
+
+      - name: Check Success
+        if: ${{ success() }}
+        run: |
+          echo "${{ join(matrix.project) }} SUCCEEDED"
+          echo "INFORMING ${{ join(matrix.codeowners) }}"
+
+      - name: Notify test success
+        if: ${{ success() && github.event_name == 'workflow_dispatch' }} # only once it's fixed on manual dispatch
+        uses: ravsamhq/notify-slack-action@v1
+        with:
+          status: 'success'
+          notification_title: 'This is test. Ignore it: ${{ join(matrix.project) }}'
+          message_format: '{emoji} *{workflow}* {status_message} (last commit <{commit_url}|{commit_sha}>)'
+          footer: '<{run_url}|View Run>'
+          mention_users: ${{ join(matrix.codeowners) }}
+          # mention_users_when: 'failure,warnings'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
+
       - name: Setup tmate session
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled && failure() }}
         uses: mxschmitt/action-tmate@v3.8
-
-  report-success:
-    if: ${{ success() && github.repository_owner == 'nrwl' && github.event_name == 'workflow_dispatch' }} # only once it's fixed on manual dispatch
-    needs: e2e
-    runs-on: ubuntu-latest
-    name: Report success
-    steps:
-      - name: Send notification
-        uses: ravsamhq/notify-slack-action@v1
-        with:
-          status: ${{ needs.e2e.result }}
-          message_format: '{emoji} *{workflow}* {status_message} (last commit <{commit_url}|{commit_sha}>)'
-          notification_title: '{workflow} has {status_message}'
-          footer: '<{run_url}|View Run>'
-          mention_users: 'U01UELKLYF2,U9NPA6C90'
-          mention_users_when: 'failure,warnings'
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 
   report:
     if: ${{ always() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
@@ -208,7 +226,5 @@ jobs:
           message_format: '{emoji} *{workflow}* {status_message} (last commit <{commit_url}|{commit_sha}>)'
           notification_title: '{workflow} has {status_message}'
           footer: '<{run_url}|View Run>'
-          mention_users: 'U01UELKLYF2,U9NPA6C90'
-          mention_users_when: 'failure,warnings'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -52,10 +52,62 @@ jobs:
           - e2e-workspace-create
           - e2e-e2e-workspace-create-npm
           - e2e-graph-client
-        # include:
-        #   # codeowner groups
-        #   - project: e2e-...
-        #     codeowners: 'S...'
+        include:
+          # codeowner groups
+          - project: e2e-add-nx-to-monorepo
+            codeowners: 'S04SYHYKGNP'
+          - project: e2e-angular-core
+            codeowners: 'S04SS457V38'
+          - project: e2e-angular-extensions
+            codeowners: 'S04SS457V38'
+          - project: e2e-cra-to-nx
+            codeowners: 'S04TNCNJG5N'
+          - project: e2e-cypress
+            codeowners: 'S04T16BTJJY'
+          - project: e2e-esbuild
+            codeowners: 'S04SJ6HHP0X'
+          - project: e2e-jest
+            codeowners: 'S04T16BTJJY'
+          - project: e2e-js
+            codeowners: 'S04SJ6HHP0X'
+          - project: e2e-lerna-smoke-tests
+            codeowners: 'S04TNCVEETS'
+          - project: e2e-linter
+            codeowners: 'S04SYJGKSCT'
+          - project: e2e-make-angular-cli-faster
+            codeowners: 'S04SS457V38'
+          - project: e2e-next
+            codeowners: 'S04TNCNJG5N'
+          - project: e2e-node
+            codeowners: 'S04SJ6HHP0X'
+          - project: e2e-nx-init
+            codeowners: 'S04SYHYKGNP'
+          - project: e2e-nx-misc
+            codeowners: 'S04SYHYKGNP'
+          - project: e2e-nx-plugin
+            codeowners: 'S04SYHYKGNP'
+          - project: e2e-nx-run
+            codeowners: 'S04SYHYKGNP'
+          - project: e2e-react
+            codeowners: 'S04TNCNJG5N'
+          - project: e2e-web
+            codeowners: 'S04SJ6PL98X'
+          - project: e2e-rollup
+            codeowners: 'S04SJ6PL98X'
+          - project: e2e-storybook
+            codeowners: 'S04SVQ8H0G5'
+          - project: e2e-storybook-angular
+            codeowners: 'S04SVQ8H0G5'
+          - project: e2e-vite
+            codeowners: 'S04SJ6PL98X'
+          - project: e2e-webpack
+            codeowners: 'S04SJ6PL98X'
+          - project: e2e-workspace-create
+            codeowners: 'S04SYHYKGNP'
+          - project: e2e-e2e-workspace-create-npm
+            codeowners: 'S04SYHYKGNP'
+          - project: e2e-graph-client
+            codeowners: 'S04T16QL360'
       fail-fast: false
 
     name: ${{ matrix.packages }}
@@ -115,7 +167,7 @@ jobs:
             *Package manager* ${{ matrix.package_manager }}
             *Workflow* {workflow}'
           footer: '<{run_url}|View Run> / Last commit <{commit_url}|{commit_sha}>'
-          # mention_groups: ${{ matrix.codeowners }}
+          mention_groups: ${{ matrix.codeowners }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -52,74 +52,78 @@ jobs:
           - e2e-workspace-create
           - e2e-e2e-workspace-create-npm
           - e2e-graph-client
+        # include:
+        #   # codeowner groups
+        #   - project: e2e-...
+        #     codeowners: 'S...'
       fail-fast: false
 
     name: ${{ matrix.packages }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
-    - name: Use Node.js ${{ matrix.node_version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node_version }}
-        registry-url: http://localhost:4872
+      - name: Use Node.js ${{ matrix.node_version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node_version }}
+          registry-url: http://localhost:4872
 
-    - name: Yarn cache directory path
-      id: yarn-cache-dir-path
-      shell: bash
-      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+      - name: Yarn cache directory path
+        id: yarn-cache-dir-path
+        shell: bash
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
-    - name: Cache yarn
-      uses: actions/cache@v3
-      with:
-        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: windows-node-${{ matrix.node_version }}-yarn-${{ hashFiles('yarn.lock') }}
-        restore-keys: |
-          windows-node-${{ matrix.node_version }}-yarn-
-          windows-node-${{ matrix.node_version }}-
-          windows-
+      - name: Cache yarn
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: windows-node-${{ matrix.node_version }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            windows-node-${{ matrix.node_version }}-yarn-
+            windows-node-${{ matrix.node_version }}-
+            windows-
 
-    - name: Install packages
-      run: yarn install --prefer-offline --frozen-lockfile --non-interactive
+      - name: Install packages
+        run: yarn install --prefer-offline --frozen-lockfile --non-interactive
 
-    - name: Run e2e tests
-      run: yarn nx run-many --target=e2e --projects="${{ join(matrix.packages) }}" --parallel=1
-      env:
-        GIT_AUTHOR_EMAIL: test@test.com
-        GIT_AUTHOR_NAME: Test
-        GIT_COMMITTER_EMAIL: test@test.com
-        GIT_COMMITTER_NAME: Test
-        NX_E2E_CI_CACHE_KEY: e2e-gha-windows-${{ matrix.node_version }}-${{ matrix.package_manager }}
-        NX_E2E_RUN_CYPRESS: ${{ 'true' }}
-        NODE_OPTIONS: --max_old_space_size=8192
-        SELECTED_PM: ${{ matrix.package_manager }}
-        npm_config_registry: http://localhost:4872
-        NX_VERBOSE_LOGGING: ${{ 'true' }}
-        NX_E2E_SKIP_BUILD_CLEANUP: ${{ 'true' }}
-        NX_CACHE_DIRECTORY: ${{ 'tmp' }}
+      - name: Run e2e tests
+        run: yarn nx run-many --target=e2e --projects="${{ join(matrix.packages) }}" --parallel=1
+        env:
+          GIT_AUTHOR_EMAIL: test@test.com
+          GIT_AUTHOR_NAME: Test
+          GIT_COMMITTER_EMAIL: test@test.com
+          GIT_COMMITTER_NAME: Test
+          NX_E2E_CI_CACHE_KEY: e2e-gha-windows-${{ matrix.node_version }}-${{ matrix.package_manager }}
+          NX_E2E_RUN_CYPRESS: ${{ 'true' }}
+          NODE_OPTIONS: --max_old_space_size=8192
+          SELECTED_PM: ${{ matrix.package_manager }}
+          npm_config_registry: http://localhost:4872
+          NX_VERBOSE_LOGGING: ${{ 'true' }}
+          NX_E2E_SKIP_BUILD_CLEANUP: ${{ 'true' }}
+          NX_CACHE_DIRECTORY: ${{ 'tmp' }}
 
       - name: Notify test failure
-        if: ${{ failure() && github.repository_owner == 'nrwl' && github.event_name !== 'workflow_dispatch' }}
+        if: ${{ failure() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
         uses: ravsamhq/notify-slack-action@v2
         with:
           status: 'failure'
           notification_title: 'Test requires attention'
           message_format: '{emoji} *${{ join(matrix.project) }}* has {status_message}
-            *OS* ${{ matrix.os-name }}
+            *OS* windows
             *Node* v${{ matrix.node_version }}
             *Package manager* ${{ matrix.package_manager }}
             *Workflow* {workflow}'
           footer: '<{run_url}|View Run> / Last commit <{commit_url}|{commit_sha}>'
-          # mention_groups: 'S690SFLP9'
+          # mention_groups: ${{ matrix.codeowners }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 
-    - name: Setup tmate session
-      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled && failure() }}
-      uses: mxschmitt/action-tmate@v3.8
-      with:
-        sudo: false # disable sudo for windows debugging
+      - name: Setup tmate session
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled && failure() }}
+        uses: mxschmitt/action-tmate@v3.8
+        with:
+          sudo: false # disable sudo for windows debugging
 
   report:
     if: ${{ success() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -180,6 +180,7 @@ jobs:
       - name: Setup tmate session
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled && failure() }}
         uses: mxschmitt/action-tmate@v3.8
+        timeout-minutes: 15
         with:
           sudo: false # disable sudo for windows debugging
 
@@ -222,11 +223,13 @@ jobs:
 
             // message
             let result = `
-               | Failed project | Node | PM | OS |
-               |--|--|--|--|`;
+              \`\`\`
+               | Failed project                | Node | PM   | OS     |
+               |-------------------------------|------|------|--------|`;
             failedProjects.forEach(matrix => {
-              result += `\n|**${matrix.project}**|v${matrix.node_version}|${matrix.package_manager}|Windows|`
+              result += `\n| ${matrix.project.padEnd(30)} | v${matrix.node_version.padEnd(3)} | ${matrix.package_manager.padEnd(4)} | Windows |`
             });
+            result += `\`\`\``;
             const message = result.split('\n').map(l => l.trim()).join('\n');
             core.setOutput('SLACK_MESSAGE', message);
 
@@ -234,7 +237,7 @@ jobs:
     if: ${{ failure() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
     needs: process-result
     runs-on: ubuntu-latest
-    name: Report status
+    name: Report failure
     steps:
       - name: Send notification
         uses: ravsamhq/notify-slack-action@v2
@@ -247,11 +250,11 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 
-  report:
+  report-success:
     if: ${{ success() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
     needs: e2e
     runs-on: ubuntu-latest
-    name: Report status
+    name: Report success
     steps:
       - name: Send notification
         uses: ravsamhq/notify-slack-action@v2

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -15,7 +15,7 @@ permissions: {}
 jobs:
   e2e:
     permissions:
-      contents: read  #  to fetch code (actions/checkout)
+      contents: read
 
     runs-on: windows-latest
     strategy:
@@ -156,8 +156,7 @@ jobs:
           NX_CACHE_DIRECTORY: ${{ 'tmp' }}
 
       - name: Notify test failure
-        # if: ${{ failure() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
-        if: ${{ failure() }}
+        if: ${{ failure() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
         uses: ravsamhq/notify-slack-action@v2
         with:
           status: 'failure'
@@ -185,7 +184,7 @@ jobs:
     name: Report status
     steps:
       - name: Send notification
-        uses: ravsamhq/notify-slack-action@v1
+        uses: ravsamhq/notify-slack-action@v2
         with:
           status: ${{ needs.e2e.result }}
           message_format: '{emoji} Workflow has {status_message}'

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -99,6 +99,22 @@ jobs:
         NX_E2E_SKIP_BUILD_CLEANUP: ${{ 'true' }}
         NX_CACHE_DIRECTORY: ${{ 'tmp' }}
 
+      - name: Notify test failure
+        if: ${{ failure() && github.repository_owner == 'nrwl' && github.event_name !== 'workflow_dispatch' }}
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: 'failure'
+          notification_title: 'Test requires attention'
+          message_format: '{emoji} *${{ join(matrix.project) }}* has {status_message}
+            *OS* ${{ matrix.os-name }}
+            *Node* v${{ matrix.node_version }}
+            *Package manager* ${{ matrix.package_manager }}
+            *Workflow* {workflow}'
+          footer: '<{run_url}|View Run> / Last commit <{commit_url}|{commit_sha}>'
+          # mention_groups: 'S690SFLP9'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
+
     - name: Setup tmate session
       if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled && failure() }}
       uses: mxschmitt/action-tmate@v3.8

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -25,21 +25,32 @@ jobs:
         package_manager:
           - npm
         packages:
+          - e2e-add-nx-to-monorepo
           - e2e-angular-core
           - e2e-angular-extensions
-          - e2e-nx-run,e2e-nx-misc,e2e-nx-plugin
           - e2e-cra-to-nx
-          - e2e-make-angular-cli-faster
-          - e2e-jest
-          - e2e-linter
           - e2e-cypress
-          - e2e-react
+          - e2e-esbuild
+          - e2e-jest
+          - e2e-js
+          - e2e-lerna-smoke-tests
+          - e2e-linter
+          - e2e-make-angular-cli-faster
           - e2e-next
           - e2e-node
+          - e2e-nx-init
+          - e2e-nx-misc
+          - e2e-nx-plugin
+          - e2e-nx-run
+          - e2e-react
           - e2e-web
-          - e2e-storybook,e2e-storybook-angular
+          - e2e-rollup
+          - e2e-storybook
+          - e2e-storybook-angular
+          - e2e-vite
+          - e2e-webpack
           - e2e-workspace-create
-          - e2e-add-nx-to-monorepo
+          - e2e-e2e-workspace-create-npm
           - e2e-graph-client
       fail-fast: false
 
@@ -95,7 +106,7 @@ jobs:
         sudo: false # disable sudo for windows debugging
 
   report:
-    if: ${{ always() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
+    if: ${{ success() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
     needs: e2e
     runs-on: ubuntu-latest
     name: Report status
@@ -104,8 +115,8 @@ jobs:
         uses: ravsamhq/notify-slack-action@v1
         with:
           status: ${{ needs.e2e.result }}
-          message_format: '{emoji} *{workflow}* {status_message} (last commit <{commit_url}|{commit_sha}>)'
-          notification_title: '{workflow} has {status_message}'
-          footer: '<{run_url}|View Run>'
+          message_format: '{emoji} Workflow has {status_message}'
+          notification_title: '{workflow}'
+          footer: '<{run_url}|View Run> / Last commit <{commit_url}|{commit_sha}>'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -224,8 +224,8 @@ jobs:
             // message
             let result = `
               \`\`\`
-               | Failed project                | Node | PM   | OS     |
-               |-------------------------------|------|------|--------|`;
+               | Failed project                 | Node | PM   | OS     |
+               |--------------------------------|------|------|--------|`;
             failedProjects.forEach(matrix => {
               result += `\n| ${matrix.project.padEnd(30)} | v${matrix.node_version.padEnd(3)} | ${matrix.package_manager.padEnd(4)} | Windows |`
             });

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -115,6 +115,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Prepare dir for output
+        run: mkdir -p outputs
+
       - name: Use Node.js ${{ matrix.node_version }}
         uses: actions/setup-node@v3
         with:
@@ -155,27 +158,94 @@ jobs:
           NX_E2E_SKIP_BUILD_CLEANUP: ${{ 'true' }}
           NX_CACHE_DIRECTORY: ${{ 'tmp' }}
 
-      - name: Notify test failure
-        if: ${{ failure() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
-        uses: ravsamhq/notify-slack-action@v2
+      - name: Save matrix config in file
+        if: ${{ always() }}
+        id: save-matrix
+        run: |
+          matrix=$((
+            echo '${{ toJSON(matrix) }}'
+          ) | jq -c '. + { "status": "${{ steps.e2e-run.outcome}}" }')
+          echo "$matrix" > matrix
+          path=outputs/${{ matrix.node_version}}-${{ matrix.package_manager}}-${{ matrix.project }}
+          echo "path=$path" >> $GITHUB_OUTPUT
+          echo "$matrix" > $path
+
+      - name: Upload matrix config
+        uses: actions/upload-artifact@v3
+        if: ${{ always() }}
         with:
-          status: 'failure'
-          notification_title: 'Test requires attention'
-          message_format: '{emoji} *${{ join(matrix.project) }}* has {status_message}
-            *OS* windows
-            *Node* v${{ matrix.node_version }}
-            *Package manager* ${{ matrix.package_manager }}
-            *Workflow* {workflow}'
-          footer: '<{run_url}|View Run> / Last commit <{commit_url}|{commit_sha}>'
-          mention_groups: ${{ matrix.codeowners }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
+          name: outputs
+          path: ${{ steps.save-matrix.outputs.path }}
 
       - name: Setup tmate session
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled && failure() }}
         uses: mxschmitt/action-tmate@v3.8
         with:
           sudo: false # disable sudo for windows debugging
+
+  process-result:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs: e2e
+    outputs:
+      message: ${{ steps.process-json.outputs.SLACK_MESSAGE }}
+      codeowners: ${{ steps.process-json.outputs.CODEOWNERS }}
+    steps:
+      - name: Load outputs
+        uses: actions/download-artifact@v3
+        with:
+          name: outputs
+          path: outputs
+
+      - name: Join and stringify matrix configs
+        id: combine-json
+        run: |
+          combined=$((jq -s . outputs/*) | jq tostring)
+          echo "combined=$combined" >> $GITHUB_OUTPUT
+
+      - name: Make slack outputs
+        id: process-json
+        uses: actions/github-script@v6
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          script: |
+            const combined = JSON.parse(${{ steps.combine-json.outputs.combined }});
+            const failedProjects = combined.filter(c => c.status === 'failure');
+
+            // codeowners
+            const codeowners = new Set();
+            failedProjects.forEach(c => {
+              codeowners.add(c.codeowners);
+            });
+            core.setOutput('CODEOWNERS', Array.from(codeowners).join(','));
+
+            // message
+            let result = `
+               | Failed project | Node | PM | OS |
+               |--|--|--|--|`;
+            failedProjects.forEach(matrix => {
+              result += `\n|**${matrix.project}**|v${matrix.node_version}|${matrix.package_manager}|Windows|`
+            });
+            const message = result.split('\n').map(l => l.trim()).join('\n');
+            core.setOutput('SLACK_MESSAGE', message);
+
+  report-failure:
+    if: ${{ failure() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
+    needs: process-result
+    runs-on: ubuntu-latest
+    name: Report status
+    steps:
+      - name: Send notification
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: 'failure'
+          message_format: '{emoji} Workflow has {status_message} ${{ needs.process-result.outputs.message }}'
+          notification_title: '{workflow}'
+          footer: '<{run_url}|View Run> / Last commit <{commit_url}|{commit_sha}>'
+          mention_groups: ${{ needs.process-result.outputs.codeowners }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 
   report:
     if: ${{ success() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -24,7 +24,7 @@ jobs:
           - '16'
         package_manager:
           - npm
-        packages:
+        project:
           - e2e-add-nx-to-monorepo
           - e2e-angular-core
           - e2e-angular-extensions
@@ -110,7 +110,7 @@ jobs:
             codeowners: 'S04T16QL360'
       fail-fast: false
 
-    name: ${{ matrix.packages }}
+    name: ${{ matrix.project }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -140,7 +140,7 @@ jobs:
         run: yarn install --prefer-offline --frozen-lockfile --non-interactive
 
       - name: Run e2e tests
-        run: yarn nx run-many --target=e2e --projects="${{ join(matrix.packages) }}" --parallel=1
+        run: yarn nx run-many --target=e2e --projects="${{ join(matrix.project) }}" --parallel=1
         env:
           GIT_AUTHOR_EMAIL: test@test.com
           GIT_AUTHOR_NAME: Test
@@ -156,7 +156,8 @@ jobs:
           NX_CACHE_DIRECTORY: ${{ 'tmp' }}
 
       - name: Notify test failure
-        if: ${{ failure() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
+        # if: ${{ failure() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
+        if: ${{ failure() }}
         uses: ravsamhq/notify-slack-action@v2
         with:
           status: 'failure'

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -94,24 +94,6 @@ jobs:
       with:
         sudo: false # disable sudo for windows debugging
 
-  report-success:
-    if: ${{ success() && github.repository_owner == 'nrwl' && github.event_name == 'workflow_dispatch' }} # only once it's fixed on manual dispatch
-    needs: e2e
-    runs-on: ubuntu-latest
-    name: Report success
-    steps:
-      - name: Send notification
-        uses: ravsamhq/notify-slack-action@v1
-        with:
-          status: ${{ needs.e2e.result }}
-          message_format: '{emoji} *{workflow}* {status_message} (last commit <{commit_url}|{commit_sha}>)'
-          notification_title: '{workflow} has {status_message}'
-          footer: '<{run_url}|View Run>'
-          mention_users: 'U01UELKLYF2,U9NPA6C90'
-          mention_users_when: 'failure,warnings'
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
-
   report:
     if: ${{ always() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
     needs: e2e
@@ -125,7 +107,5 @@ jobs:
           message_format: '{emoji} *{workflow}* {status_message} (last commit <{commit_url}|{commit_sha}>)'
           notification_title: '{workflow} has {status_message}'
           footer: '<{run_url}|View Run>'
-          mention_users: 'U01UELKLYF2,U9NPA6C90'
-          mention_users_when: 'failure,warnings'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -35,27 +35,9 @@ jobs:
         uses: ravsamhq/notify-slack-action@v1
         with:
           status: ${{ needs.audit.result }}
-          message_format: '{emoji} *{workflow}* {status_message} (last commit <{commit_url}|{commit_sha}>)'
-          notification_title: '{workflow} has {status_message}'
-          footer: '<{run_url}|View Run>'
-          mention_users: 'U01UELKLYF2,U9NPA6C90'
-          mention_users_when: 'failure,warnings'
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
-
-  report-success:
-    if: ${{ success() && github.repository_owner == 'nrwl' && github.event_name == 'workflow_dispatch' }} # only once it's fixed on manual dispatch
-    needs: audit
-    runs-on: ubuntu-latest
-    name: Report success
-    steps:
-      - name: Send notification
-        uses: ravsamhq/notify-slack-action@v1
-        with:
-          status: ${{ needs.audit.result }}
-          message_format: '{emoji} *{workflow}* {status_message} (last commit <{commit_url}|{commit_sha}>)'
-          notification_title: '{workflow} has {status_message}'
-          footer: '<{run_url}|View Run>'
+          message_format: '{emoji} Audit has {status_message}'
+          notification_title: '{workflow}'
+          footer: '<{run_url}|View Run> / Last commit <{commit_url}|{commit_sha}>'
           mention_users: 'U01UELKLYF2,U9NPA6C90'
           mention_users_when: 'failure,warnings'
         env:

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -32,7 +32,7 @@ jobs:
     name: Report status
     steps:
       - name: Send notification
-        uses: ravsamhq/notify-slack-action@v1
+        uses: ravsamhq/notify-slack-action@v2
         with:
           status: ${{ needs.audit.result }}
           message_format: '{emoji} Audit has {status_message}'


### PR DESCRIPTION
This PR adds granular notifications to slack based on failed tests.

It will provide information on which tests failed, on which environment and will tag the appropriate user group

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
