### PR TITLE
fix(core): ensure correct $schema path is generated when adding project configuration

### DIFF
--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -147,7 +147,7 @@ exports[`app at the root should accept numbers in the path 1`] = `"src/9-website
 
 exports[`app nested should create project configs 1`] = `
 Object {
-  "$schema": "../node_modules/nx/schemas/project-schema.json",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "name": "my-dir-my-app",
   "prefix": "proj",
   "projectType": "application",
@@ -296,7 +296,7 @@ Object {
 
 exports[`app not nested should create project configs 1`] = `
 Object {
-  "$schema": "../node_modules/nx/schemas/project-schema.json",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "name": "my-app",
   "prefix": "proj",
   "projectType": "application",

--- a/packages/nx/src/generators/utils/project-configuration.ts
+++ b/packages/nx/src/generators/utils/project-configuration.ts
@@ -59,6 +59,7 @@ export function addProjectConfiguration(
     );
   }
 
+  delete (projectConfiguration as any).$schema;
   writeJson(tree, projectConfigFile, {
     name: projectName,
     $schema: getRelativeProjectJsonSchemaPath(tree, projectConfiguration),


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When adding a project configuration, if the config being passed contains the `$schema` property set, it overwrites the one that gets calculated based on the project root.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Adding a project configuration should always set the calculated `$schema` path.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15429 
