### PR TITLE
feat(core): move runTasksInSerial to devkit

### DIFF
--- a/docs/generated/devkit/nrwl_devkit.md
+++ b/docs/generated/devkit/nrwl_devkit.md
@@ -185,6 +185,7 @@ It only uses language primitives and immutable objects
 - [removeProjectConfiguration](../../devkit/documents/nrwl_devkit#removeprojectconfiguration)
 - [reverse](../../devkit/documents/nrwl_devkit#reverse)
 - [runExecutor](../../devkit/documents/nrwl_devkit#runexecutor)
+- [runTasksInSerial](../../devkit/documents/nrwl_devkit#runtasksinserial)
 - [serializeJson](../../devkit/documents/nrwl_devkit#serializejson)
 - [sharePackages](../../devkit/documents/nrwl_devkit#sharepackages)
 - [shareWorkspaceLibraries](../../devkit/documents/nrwl_devkit#shareworkspacelibraries)
@@ -2047,6 +2048,24 @@ Note that the return value is a promise of an iterator, so you need to await bef
 #### Returns
 
 `Promise`<`AsyncIterableIterator`<`T`\>\>
+
+---
+
+### runTasksInSerial
+
+▸ **runTasksInSerial**(...`tasks`): [`GeneratorCallback`](../../devkit/documents/nrwl_devkit#generatorcallback)
+
+Run tasks in serial
+
+#### Parameters
+
+| Name       | Type                                                                          | Description                 |
+| :--------- | :---------------------------------------------------------------------------- | :-------------------------- |
+| `...tasks` | [`GeneratorCallback`](../../devkit/documents/nrwl_devkit#generatorcallback)[] | The tasks to run in serial. |
+
+#### Returns
+
+[`GeneratorCallback`](../../devkit/documents/nrwl_devkit#generatorcallback)
 
 ---
 

--- a/docs/generated/packages/devkit/documents/nrwl_devkit.md
+++ b/docs/generated/packages/devkit/documents/nrwl_devkit.md
@@ -185,6 +185,7 @@ It only uses language primitives and immutable objects
 - [removeProjectConfiguration](../../devkit/documents/nrwl_devkit#removeprojectconfiguration)
 - [reverse](../../devkit/documents/nrwl_devkit#reverse)
 - [runExecutor](../../devkit/documents/nrwl_devkit#runexecutor)
+- [runTasksInSerial](../../devkit/documents/nrwl_devkit#runtasksinserial)
 - [serializeJson](../../devkit/documents/nrwl_devkit#serializejson)
 - [sharePackages](../../devkit/documents/nrwl_devkit#sharepackages)
 - [shareWorkspaceLibraries](../../devkit/documents/nrwl_devkit#shareworkspacelibraries)
@@ -2047,6 +2048,24 @@ Note that the return value is a promise of an iterator, so you need to await bef
 #### Returns
 
 `Promise`<`AsyncIterableIterator`<`T`\>\>
+
+---
+
+### runTasksInSerial
+
+▸ **runTasksInSerial**(...`tasks`): [`GeneratorCallback`](../../devkit/documents/nrwl_devkit#generatorcallback)
+
+Run tasks in serial
+
+#### Parameters
+
+| Name       | Type                                                                          | Description                 |
+| :--------- | :---------------------------------------------------------------------------- | :-------------------------- |
+| `...tasks` | [`GeneratorCallback`](../../devkit/documents/nrwl_devkit#generatorcallback)[] | The tasks to run in serial. |
+
+#### Returns
+
+[`GeneratorCallback`](../../devkit/documents/nrwl_devkit#generatorcallback)
 
 ---
 

--- a/packages/angular/src/generators/add-linting/add-linting.ts
+++ b/packages/angular/src/generators/add-linting/add-linting.ts
@@ -1,12 +1,12 @@
 import {
   GeneratorCallback,
   joinPathFragments,
+  runTasksInSerial,
   Tree,
   updateJson,
 } from '@nrwl/devkit';
 import { Linter, lintProjectGenerator } from '@nrwl/linter';
 import { mapLintPattern } from '@nrwl/linter/src/generators/lint-project/lint-project';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 import { join } from 'path';
 import { getGeneratorDirectoryForInstalledAngularVersion } from '../utils/version-utils';
 import { addAngularEsLintDependencies } from './lib/add-angular-eslint-dependencies';

--- a/packages/angular/src/generators/add-linting/angular-v14/add-linting.ts
+++ b/packages/angular/src/generators/add-linting/angular-v14/add-linting.ts
@@ -1,12 +1,13 @@
 import {
   GeneratorCallback,
   joinPathFragments,
+  runTasksInSerial,
   Tree,
   updateJson,
 } from '@nrwl/devkit';
 import { Linter, lintProjectGenerator } from '@nrwl/linter';
 import { mapLintPattern } from '@nrwl/linter/src/generators/lint-project/lint-project';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import { addAngularEsLintDependencies } from './lib/add-angular-eslint-dependencies';
 import { extendAngularEslintJson } from './lib/create-eslint-configuration';
 import type { AddLintingGeneratorSchema } from './schema';

--- a/packages/angular/src/generators/host/host.ts
+++ b/packages/angular/src/generators/host/host.ts
@@ -1,4 +1,10 @@
-import { formatFiles, getProjects, stripIndents, Tree } from '@nrwl/devkit';
+import {
+  formatFiles,
+  getProjects,
+  runTasksInSerial,
+  stripIndents,
+  Tree,
+} from '@nrwl/devkit';
 import type { Schema } from './schema';
 import applicationGenerator from '../application/application';
 import remoteGenerator from '../remote/remote';
@@ -6,7 +12,7 @@ import { normalizeProjectName } from '../utils/project';
 import { setupMf } from '../setup-mf/setup-mf';
 import { E2eTestRunner } from '../../utils/test-runners';
 import { addSsr } from './lib';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import { getInstalledAngularVersionInfo } from '../utils/version-utils';
 import { lt } from 'semver';
 

--- a/packages/angular/src/generators/init/angular-v14/init.ts
+++ b/packages/angular/src/generators/init/angular-v14/init.ts
@@ -6,13 +6,14 @@ import {
   GeneratorCallback,
   logger,
   readNxJson,
+  runTasksInSerial,
   Tree,
   updateNxJson,
 } from '@nrwl/devkit';
 import { jestInitGenerator } from '@nrwl/jest';
 import { Linter } from '@nrwl/linter';
 import { initGenerator as jsInitGenerator } from '@nrwl/js';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import { backwardCompatibleVersions } from '../../../utils/backward-compatible-versions';
 import { E2eTestRunner, UnitTestRunner } from '../../../utils/test-runners';
 import { karmaGenerator } from '../../karma/karma';

--- a/packages/angular/src/generators/init/init.ts
+++ b/packages/angular/src/generators/init/init.ts
@@ -6,13 +6,14 @@ import {
   GeneratorCallback,
   logger,
   readNxJson,
+  runTasksInSerial,
   Tree,
   updateNxJson,
 } from '@nrwl/devkit';
 import { jestInitGenerator } from '@nrwl/jest';
 import { Linter } from '@nrwl/linter';
 import { initGenerator as jsInitGenerator } from '@nrwl/js';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import { join } from 'path';
 import { E2eTestRunner, UnitTestRunner } from '../../utils/test-runners';
 import {

--- a/packages/angular/src/generators/remote/remote.ts
+++ b/packages/angular/src/generators/remote/remote.ts
@@ -1,11 +1,17 @@
-import { formatFiles, getProjects, stripIndents, Tree } from '@nrwl/devkit';
+import {
+  formatFiles,
+  getProjects,
+  runTasksInSerial,
+  stripIndents,
+  Tree,
+} from '@nrwl/devkit';
 import type { Schema } from './schema';
 import applicationGenerator from '../application/application';
 import { normalizeProjectName } from '../utils/project';
 import { setupMf } from '../setup-mf/setup-mf';
 import { E2eTestRunner } from '../../utils/test-runners';
 import { addSsr, findNextAvailablePort } from './lib';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import { getInstalledAngularVersionInfo } from '../utils/version-utils';
 import { lt } from 'semver';
 

--- a/packages/cypress/src/generators/cypress-project/cypress-project.ts
+++ b/packages/cypress/src/generators/cypress-project/cypress-project.ts
@@ -14,13 +14,14 @@ import {
   offsetFromRoot,
   ProjectConfiguration,
   readProjectConfiguration,
+  runTasksInSerial,
   stripIndents,
   toJS,
   Tree,
   updateJson,
 } from '@nrwl/devkit';
 import { Linter, lintProjectGenerator } from '@nrwl/linter';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import { getRelativePathToRootTsConfig } from '@nrwl/js';
 import {
   globalJavaScriptOverrides,

--- a/packages/cypress/src/generators/init/init.ts
+++ b/packages/cypress/src/generators/init/init.ts
@@ -4,6 +4,7 @@ import {
   GeneratorCallback,
   readNxJson,
   removeDependenciesFromPackageJson,
+  runTasksInSerial,
   Tree,
   updateNxJson,
 } from '@nrwl/devkit';
@@ -14,7 +15,6 @@ import {
 } from '../../utils/versions';
 import { Schema } from './schema';
 import { initGenerator } from '@nrwl/js';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 
 function setupE2ETargetDefaults(tree: Tree) {
   const nxJson = readNxJson(tree);

--- a/packages/detox/src/generators/application/application.ts
+++ b/packages/detox/src/generators/application/application.ts
@@ -1,6 +1,10 @@
-import { convertNxGenerator, formatFiles, Tree } from '@nrwl/devkit';
+import {
+  convertNxGenerator,
+  formatFiles,
+  runTasksInSerial,
+  Tree,
+} from '@nrwl/devkit';
 
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 import detoxInitGenerator from '../init/init';
 import { addGitIgnoreEntry } from './lib/add-git-ignore-entry';
 import { addLinting } from './lib/add-linting';

--- a/packages/detox/src/generators/application/lib/add-linting.ts
+++ b/packages/detox/src/generators/application/lib/add-linting.ts
@@ -1,8 +1,8 @@
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 import { Linter, lintProjectGenerator } from '@nrwl/linter';
 import {
   addDependenciesToPackageJson,
   joinPathFragments,
+  runTasksInSerial,
   Tree,
   updateJson,
 } from '@nrwl/devkit';

--- a/packages/detox/src/generators/init/init.ts
+++ b/packages/detox/src/generators/init/init.ts
@@ -4,10 +4,11 @@ import {
   formatFiles,
   GeneratorCallback,
   removeDependenciesFromPackageJson,
+  runTasksInSerial,
   Tree,
 } from '@nrwl/devkit';
 import { jestVersion, typesNodeVersion } from '@nrwl/jest/src/utils/versions';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import { Schema } from './schema';
 import {
   detoxVersion,

--- a/packages/devkit/public-api.ts
+++ b/packages/devkit/public-api.ts
@@ -31,6 +31,11 @@ export { updateTsConfigsToJs } from './src/generators/update-ts-configs-to-js';
 /**
  * @category Generators
  */
+export { runTasksInSerial } from './src/generators/run-tasks-in-serial';
+
+/**
+ * @category Generators
+ */
 export { visitNotIgnoredFiles } from './src/generators/visit-not-ignored-files';
 
 export {

--- a/packages/devkit/src/generators/run-tasks-in-serial.ts
+++ b/packages/devkit/src/generators/run-tasks-in-serial.ts
@@ -1,9 +1,8 @@
-import type { GeneratorCallback } from '@nrwl/devkit';
+import type { GeneratorCallback } from 'nx/src/config/misc-interfaces';
 
 /**
  * Run tasks in serial
  *
- * @deprecated This function will be removed from `@nrwl/workspace` in a future version. Prefer importing it from `@nrwl/devkit`.
  * @param tasks The tasks to run in serial.
  */
 export function runTasksInSerial(

--- a/packages/expo/src/generators/application/application.ts
+++ b/packages/expo/src/generators/application/application.ts
@@ -1,10 +1,10 @@
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 import {
   convertNxGenerator,
-  Tree,
   formatFiles,
-  joinPathFragments,
   GeneratorCallback,
+  joinPathFragments,
+  runTasksInSerial,
+  Tree,
 } from '@nrwl/devkit';
 
 import { addLinting } from '../../utils/add-linting';

--- a/packages/expo/src/generators/init/init.ts
+++ b/packages/expo/src/generators/init/init.ts
@@ -4,34 +4,34 @@ import {
   formatFiles,
   GeneratorCallback,
   removeDependenciesFromPackageJson,
+  runTasksInSerial,
   Tree,
 } from '@nrwl/devkit';
 import { Schema } from './schema';
 import {
-  expoVersion,
+  babelPresetExpoVersion,
+  deprecatedExpoCliVersion,
+  easCliVersion,
+  expoCliVersion,
+  expoMetroConfigVersion,
   expoSplashScreenVersion,
   expoStatusBarVersion,
-  nxVersion,
-  reactNativeVersion,
-  reactNativeWebVersion,
-  typesReactNativeVersion,
-  expoMetroConfigVersion,
+  expoVersion,
   metroVersion,
-  testingLibraryReactNativeVersion,
-  testingLibraryJestNativeVersion,
+  nxVersion,
+  reactDomVersion,
   reactNativeSvgTransformerVersion,
   reactNativeSvgVersion,
-  expoCliVersion,
-  babelPresetExpoVersion,
-  easCliVersion,
-  deprecatedExpoCliVersion,
-  reactVersion,
+  reactNativeVersion,
+  reactNativeWebVersion,
   reactTestRendererVersion,
+  reactVersion,
+  testingLibraryJestNativeVersion,
+  testingLibraryReactNativeVersion,
+  typesReactNativeVersion,
   typesReactVersion,
-  reactDomVersion,
 } from '../../utils/versions';
 
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 import { jestInitGenerator } from '@nrwl/jest';
 import { detoxInitGenerator } from '@nrwl/detox';
 import { initGenerator as jsInitGenerator } from '@nrwl/js';

--- a/packages/expo/src/generators/library/library.ts
+++ b/packages/expo/src/generators/library/library.ts
@@ -8,12 +8,13 @@ import {
   joinPathFragments,
   names,
   offsetFromRoot,
+  runTasksInSerial,
   TargetConfiguration,
   toJS,
   Tree,
   updateJson,
 } from '@nrwl/devkit';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import { updateRootTsConfig } from '@nrwl/js';
 
 import init from '../init/init';

--- a/packages/expo/src/utils/add-linting.ts
+++ b/packages/expo/src/utils/add-linting.ts
@@ -1,8 +1,8 @@
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 import { Linter, lintProjectGenerator } from '@nrwl/linter';
 import {
   addDependenciesToPackageJson,
   joinPathFragments,
+  runTasksInSerial,
   Tree,
   updateJson,
 } from '@nrwl/devkit';

--- a/packages/jest/src/generators/init/init.ts
+++ b/packages/jest/src/generators/init/init.ts
@@ -5,6 +5,7 @@ import {
   getProjects,
   readNxJson,
   removeDependenciesFromPackageJson,
+  runTasksInSerial,
   stripIndents,
   Tree,
   updateJson,
@@ -12,7 +13,7 @@ import {
   updateProjectConfiguration,
 } from '@nrwl/devkit';
 import { initGenerator as jsInitGenerator } from '@nrwl/js';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import { findRootJestConfig } from '../../utils/config/find-root-jest-files';
 import {
   babelJestVersion,

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -12,20 +12,21 @@ import {
   names,
   offsetFromRoot,
   ProjectConfiguration,
+  runTasksInSerial,
   toJS,
   Tree,
   updateJson,
   writeJson,
 } from '@nrwl/devkit';
 import { getImportPath } from 'nx/src/utils/path';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import {
   getRelativePathToRootTsConfig,
   updateRootTsConfig,
 } from '../../utils/typescript/ts-config';
 import { join } from 'path';
 import { addMinimalPublishScript } from '../../utils/minimal-publish-script';
-import { LibraryGeneratorSchema, Bundler } from '../../utils/schema';
+import { Bundler, LibraryGeneratorSchema } from '../../utils/schema';
 import { addSwcConfig } from '../../utils/swc/add-swc-config';
 import { addSwcDependencies } from '../../utils/swc/add-swc-dependencies';
 import {

--- a/packages/nest/src/generators/application/application.ts
+++ b/packages/nest/src/generators/application/application.ts
@@ -1,7 +1,11 @@
 import type { GeneratorCallback, Tree } from '@nrwl/devkit';
-import { convertNxGenerator, formatFiles } from '@nrwl/devkit';
+import {
+  convertNxGenerator,
+  formatFiles,
+  runTasksInSerial,
+} from '@nrwl/devkit';
 import { applicationGenerator as nodeApplicationGenerator } from '@nrwl/node';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import { initGenerator } from '../init/init';
 import {
   createFiles,

--- a/packages/nest/src/generators/init/init.ts
+++ b/packages/nest/src/generators/init/init.ts
@@ -1,7 +1,11 @@
 import type { GeneratorCallback, Tree } from '@nrwl/devkit';
-import { convertNxGenerator, formatFiles } from '@nrwl/devkit';
+import {
+  convertNxGenerator,
+  formatFiles,
+  runTasksInSerial,
+} from '@nrwl/devkit';
 import { initGenerator as nodeInitGenerator } from '@nrwl/node';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import { addDependencies, normalizeOptions } from './lib';
 import type { InitGeneratorOptions } from './schema';
 

--- a/packages/next/src/generators/application/application.ts
+++ b/packages/next/src/generators/application/application.ts
@@ -1,5 +1,9 @@
-import { convertNxGenerator, formatFiles, Tree } from '@nrwl/devkit';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+import {
+  convertNxGenerator,
+  formatFiles,
+  runTasksInSerial,
+  Tree,
+} from '@nrwl/devkit';
 
 import { normalizeOptions } from './lib/normalize-options';
 import { Schema } from './schema';

--- a/packages/next/src/generators/application/lib/add-linting.ts
+++ b/packages/next/src/generators/application/lib/add-linting.ts
@@ -3,6 +3,7 @@ import {
   addDependenciesToPackageJson,
   GeneratorCallback,
   joinPathFragments,
+  runTasksInSerial,
   Tree,
   updateJson,
 } from '@nrwl/devkit';
@@ -11,7 +12,6 @@ import {
   extraEslintDependencies,
 } from '@nrwl/react/src/utils/lint';
 import { NormalizedSchema } from './normalize-options';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 
 export async function addLinting(
   host: Tree,

--- a/packages/next/src/generators/component/component.ts
+++ b/packages/next/src/generators/component/component.ts
@@ -1,7 +1,12 @@
-import { convertNxGenerator, getProjects, Tree } from '@nrwl/devkit';
+import {
+  convertNxGenerator,
+  getProjects,
+  runTasksInSerial,
+  Tree,
+} from '@nrwl/devkit';
 import type { SupportedStyles } from '@nrwl/react';
 import { componentGenerator as reactComponentGenerator } from '@nrwl/react';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import { addStyleDependencies } from '../../utils/styles';
 
 interface Schema {

--- a/packages/next/src/generators/init/init.ts
+++ b/packages/next/src/generators/init/init.ts
@@ -2,9 +2,10 @@ import {
   addDependenciesToPackageJson,
   convertNxGenerator,
   GeneratorCallback,
+  runTasksInSerial,
   Tree,
 } from '@nrwl/devkit';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import { jestInitGenerator } from '@nrwl/jest';
 import { cypressInitGenerator } from '@nrwl/cypress';
 import { reactDomVersion, reactVersion } from '@nrwl/react/src/utils/versions';

--- a/packages/next/src/generators/library/library.ts
+++ b/packages/next/src/generators/library/library.ts
@@ -4,11 +4,12 @@ import {
   getWorkspaceLayout,
   joinPathFragments,
   names,
+  runTasksInSerial,
   Tree,
   updateJson,
 } from '@nrwl/devkit';
 import { libraryGenerator as reactLibraryGenerator } from '@nrwl/react/src/generators/library/library';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import { nextInitGenerator } from '../init/init';
 import { Schema } from './schema';
 

--- a/packages/next/src/generators/page/page.ts
+++ b/packages/next/src/generators/page/page.ts
@@ -1,14 +1,8 @@
 import { componentGenerator as reactComponentGenerator } from '@nrwl/react';
-import {
-  convertNxGenerator,
-  Tree,
-  names,
-  readProjectConfiguration,
-} from '@nrwl/devkit';
+import { convertNxGenerator, runTasksInSerial, Tree } from '@nrwl/devkit';
 
 import { addStyleDependencies } from '../../utils/styles';
 import { Schema } from './schema';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 
 /*
  * This schematic is basically the React component one, but for Next we need

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -13,6 +13,7 @@ import {
   offsetFromRoot,
   ProjectConfiguration,
   readProjectConfiguration,
+  runTasksInSerial,
   TargetConfiguration,
   toJS,
   Tree,
@@ -22,9 +23,8 @@ import {
 } from '@nrwl/devkit';
 import { Linter, lintProjectGenerator } from '@nrwl/linter';
 import { jestProjectGenerator } from '@nrwl/jest';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
-import { getRelativePathToRootTsConfig } from '@nrwl/js';
-import { tsConfigBaseOptions } from '@nrwl/js';
+
+import { getRelativePathToRootTsConfig, tsConfigBaseOptions } from '@nrwl/js';
 import { join } from 'path';
 
 import { initGenerator } from '../init/init';

--- a/packages/node/src/generators/e2e-project/e2e-project.ts
+++ b/packages/node/src/generators/e2e-project/e2e-project.ts
@@ -12,13 +12,13 @@ import {
   names,
   offsetFromRoot,
   readProjectConfiguration,
+  runTasksInSerial,
   Tree,
 } from '@nrwl/devkit';
 import { Linter, lintProjectGenerator } from '@nrwl/linter';
 
 import { Schema } from './schema';
 import { axiosVersion } from '../../utils/versions';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 
 export async function e2eProjectGenerator(host: Tree, _options: Schema) {
   const tasks: GeneratorCallback[] = [];

--- a/packages/node/src/generators/init/init.ts
+++ b/packages/node/src/generators/init/init.ts
@@ -4,10 +4,11 @@ import {
   formatFiles,
   GeneratorCallback,
   removeDependenciesFromPackageJson,
+  runTasksInSerial,
   Tree,
 } from '@nrwl/devkit';
 import { jestInitGenerator } from '@nrwl/jest';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import { initGenerator as jsInitGenerator } from '@nrwl/js';
 import {
   nxVersion,

--- a/packages/node/src/generators/library/library.ts
+++ b/packages/node/src/generators/library/library.ts
@@ -9,6 +9,7 @@ import {
   names,
   offsetFromRoot,
   readProjectConfiguration,
+  runTasksInSerial,
   toJS,
   Tree,
   updateProjectConfiguration,
@@ -17,7 +18,7 @@ import {
 import { getImportPath } from 'nx/src/utils/path';
 import { Schema } from './schema';
 import { libraryGenerator as workspaceLibraryGenerator } from '@nrwl/workspace/generators';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import { join } from 'path';
 import { addSwcDependencies } from '@nrwl/js/src/utils/swc/add-swc-dependencies';
 import { addSwcConfig } from '@nrwl/js/src/utils/swc/add-swc-config';

--- a/packages/node/src/generators/setup-docker/setup-docker.ts
+++ b/packages/node/src/generators/setup-docker/setup-docker.ts
@@ -1,5 +1,4 @@
 import {
-  addDependenciesToPackageJson,
   convertNxGenerator,
   formatFiles,
   generateFiles,
@@ -8,10 +7,11 @@ import {
   logger,
   readNxJson,
   readProjectConfiguration,
+  runTasksInSerial,
   Tree,
   updateProjectConfiguration,
 } from '@nrwl/devkit';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import { SetUpDockerOptions } from './schema';
 
 function normalizeOptions(

--- a/packages/nx-plugin/src/generators/e2e-project/e2e.ts
+++ b/packages/nx-plugin/src/generators/e2e-project/e2e.ts
@@ -1,3 +1,4 @@
+import type { Tree } from '@nrwl/devkit';
 import {
   addProjectConfiguration,
   convertNxGenerator,
@@ -9,16 +10,15 @@ import {
   joinPathFragments,
   names,
   readProjectConfiguration,
+  runTasksInSerial,
   updateProjectConfiguration,
 } from '@nrwl/devkit';
-import type { Tree } from '@nrwl/devkit';
 import { jestProjectGenerator } from '@nrwl/jest';
 import { getRelativePathToRootTsConfig } from '@nrwl/js';
 import * as path from 'path';
 
 import type { Schema } from './schema';
 import { Linter, lintProjectGenerator } from '@nrwl/linter';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 
 interface NormalizedSchema extends Schema {
   projectRoot: string;

--- a/packages/react-native/src/generators/application/application.ts
+++ b/packages/react-native/src/generators/application/application.ts
@@ -1,11 +1,12 @@
 import { join } from 'path';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import {
   convertNxGenerator,
-  Tree,
   formatFiles,
   GeneratorCallback,
   joinPathFragments,
+  runTasksInSerial,
+  Tree,
 } from '@nrwl/devkit';
 
 import { runPodInstall } from '../../utils/pod-install-task';

--- a/packages/react-native/src/generators/init/init.ts
+++ b/packages/react-native/src/generators/init/init.ts
@@ -5,10 +5,11 @@ import {
   formatFiles,
   GeneratorCallback,
   removeDependenciesFromPackageJson,
+  runTasksInSerial,
   Tree,
 } from '@nrwl/devkit';
 import { Schema } from './schema';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import { addBabelInputs } from '@nrwl/js/src/utils/add-babel-inputs';
 import { jestInitGenerator } from '@nrwl/jest';
 import { detoxInitGenerator } from '@nrwl/detox';

--- a/packages/react-native/src/generators/library/library.ts
+++ b/packages/react-native/src/generators/library/library.ts
@@ -8,12 +8,13 @@ import {
   joinPathFragments,
   names,
   offsetFromRoot,
+  runTasksInSerial,
   TargetConfiguration,
   toJS,
   Tree,
   updateJson,
 } from '@nrwl/devkit';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import { getRelativePathToRootTsConfig, updateRootTsConfig } from '@nrwl/js';
 import init from '../init/init';
 import { addLinting } from '../../utils/add-linting';

--- a/packages/react-native/src/generators/upgrade-native/upgrade-native.ts
+++ b/packages/react-native/src/generators/upgrade-native/upgrade-native.ts
@@ -2,13 +2,14 @@
  * This function is a destructive command that replace React Native iOS and Android code with latest.
  * It would replace the Android and iOS folder entirely.
  */
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import {
   convertNxGenerator,
-  Tree,
-  joinPathFragments,
   GeneratorCallback,
+  joinPathFragments,
   readProjectConfiguration,
+  runTasksInSerial,
+  Tree,
 } from '@nrwl/devkit';
 import { existsSync } from 'fs';
 

--- a/packages/react-native/src/utils/add-linting.ts
+++ b/packages/react-native/src/utils/add-linting.ts
@@ -1,9 +1,9 @@
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 import { Linter, lintProjectGenerator } from '@nrwl/linter';
 import {
   addDependenciesToPackageJson,
   GeneratorCallback,
   joinPathFragments,
+  runTasksInSerial,
   Tree,
   updateJson,
 } from '@nrwl/devkit';

--- a/packages/react/src/generators/application/application.ts
+++ b/packages/react/src/generators/application/application.ts
@@ -19,10 +19,11 @@ import {
   formatFiles,
   GeneratorCallback,
   joinPathFragments,
+  runTasksInSerial,
   Tree,
   updateJson,
 } from '@nrwl/devkit';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import reactInitGenerator from '../init/init';
 import { Linter, lintProjectGenerator } from '@nrwl/linter';
 import { mapLintPattern } from '@nrwl/linter/src/generators/lint-project/lint-project';

--- a/packages/react/src/generators/component/component.ts
+++ b/packages/react/src/generators/component/component.ts
@@ -9,10 +9,11 @@ import {
   joinPathFragments,
   logger,
   names,
+  runTasksInSerial,
   toJS,
   Tree,
 } from '@nrwl/devkit';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import { addStyledModuleDependencies } from '../../rules/add-styled-dependencies';
 import { assertValidStyle } from '../../utils/assertion';
 import { addImport } from '../../utils/ast-utils';
@@ -104,6 +105,7 @@ function createComponentFiles(host: Tree, options: NormalizedSchema) {
 }
 
 let tsModule: typeof import('typescript');
+
 function addExportsToBarrel(host: Tree, options: NormalizedSchema) {
   if (!tsModule) {
     tsModule = ensureTypescript();

--- a/packages/react/src/generators/host/host.ts
+++ b/packages/react/src/generators/host/host.ts
@@ -3,6 +3,7 @@ import {
   GeneratorCallback,
   joinPathFragments,
   readProjectConfiguration,
+  runTasksInSerial,
   Tree,
   updateProjectConfiguration,
 } from '@nrwl/devkit';
@@ -15,7 +16,7 @@ import { updateModuleFederationE2eProject } from './lib/update-module-federation
 
 import { Schema } from './schema';
 import remoteGenerator from '../remote/remote';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import setupSsrGenerator from '../setup-ssr/setup-ssr';
 import { setupSsrForHost } from './lib/setup-ssr-for-host';
 

--- a/packages/react/src/generators/host/lib/setup-ssr-for-host.ts
+++ b/packages/react/src/generators/host/lib/setup-ssr-for-host.ts
@@ -5,9 +5,9 @@ import {
   joinPathFragments,
   names,
   readProjectConfiguration,
+  runTasksInSerial,
   updateProjectConfiguration,
 } from '@nrwl/devkit';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 
 import type { Schema } from '../schema';
 import { moduleFederationNodeVersion } from '../../../utils/versions';

--- a/packages/react/src/generators/init/init.ts
+++ b/packages/react/src/generators/init/init.ts
@@ -5,11 +5,12 @@ import {
   GeneratorCallback,
   readNxJson,
   removeDependenciesFromPackageJson,
+  runTasksInSerial,
   Tree,
   updateNxJson,
   writeJson,
 } from '@nrwl/devkit';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import { initGenerator as jsInitGenerator } from '@nrwl/js';
 import {
   babelPresetReactVersion,

--- a/packages/react/src/generators/library/lib/add-linting.ts
+++ b/packages/react/src/generators/library/lib/add-linting.ts
@@ -2,8 +2,7 @@ import { Tree } from 'nx/src/generators/tree';
 import { Linter, lintProjectGenerator } from '@nrwl/linter';
 import { joinPathFragments } from 'nx/src/utils/path';
 import { updateJson } from 'nx/src/generators/utils/json';
-import { addDependenciesToPackageJson } from '@nrwl/devkit';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+import { addDependenciesToPackageJson, runTasksInSerial } from '@nrwl/devkit';
 
 import { NormalizedSchema } from '../schema';
 import {

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -5,10 +5,11 @@ import {
   formatFiles,
   GeneratorCallback,
   joinPathFragments,
+  runTasksInSerial,
   Tree,
   updateJson,
 } from '@nrwl/devkit';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import { updateRootTsConfig } from '@nrwl/js';
 
 import { nxVersion } from '../../utils/versions';

--- a/packages/react/src/generators/remote/lib/setup-ssr-for-remote.ts
+++ b/packages/react/src/generators/remote/lib/setup-ssr-for-remote.ts
@@ -4,9 +4,9 @@ import {
   generateFiles,
   joinPathFragments,
   readProjectConfiguration,
+  runTasksInSerial,
   updateProjectConfiguration,
 } from '@nrwl/devkit';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 
 import { NormalizedSchema } from '../../application/schema';
 import type { Schema } from '../schema';

--- a/packages/react/src/generators/remote/remote.ts
+++ b/packages/react/src/generators/remote/remote.ts
@@ -6,10 +6,10 @@ import {
   joinPathFragments,
   names,
   readProjectConfiguration,
+  runTasksInSerial,
   Tree,
   updateProjectConfiguration,
 } from '@nrwl/devkit';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 
 import { normalizeOptions } from '../application/lib/normalize-options';
 import applicationGenerator from '../application/application';

--- a/packages/react/src/generators/setup-tailwind/setup-tailwind.ts
+++ b/packages/react/src/generators/setup-tailwind/setup-tailwind.ts
@@ -7,8 +7,8 @@ import {
   joinPathFragments,
   logger,
   readProjectConfiguration,
+  runTasksInSerial,
 } from '@nrwl/devkit';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 
 import {
   autoprefixerVersion,

--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -5,9 +5,9 @@ import {
   GeneratorCallback,
   logger,
   readProjectConfiguration,
+  runTasksInSerial,
   Tree,
 } from '@nrwl/devkit';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 
 import { cypressProjectGenerator } from '../cypress-project/cypress-project';
 import { StorybookConfigureSchema } from './schema';

--- a/packages/storybook/src/generators/cypress-project/cypress-project.ts
+++ b/packages/storybook/src/generators/cypress-project/cypress-project.ts
@@ -14,12 +14,13 @@ import {
   joinPathFragments,
   readJson,
   readProjectConfiguration,
+  runTasksInSerial,
   Tree,
   updateJson,
   updateProjectConfiguration,
 } from '@nrwl/devkit';
 import { Linter } from '@nrwl/linter';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import { join } from 'path';
 import { safeFileDelete } from '../../utils/utilities';
 

--- a/packages/storybook/src/generators/init/init.ts
+++ b/packages/storybook/src/generators/init/init.ts
@@ -4,6 +4,7 @@ import {
   GeneratorCallback,
   readJson,
   readNxJson,
+  runTasksInSerial,
   Tree,
   updateJson,
   updateNxJson,
@@ -28,7 +29,6 @@ import {
   webpack5Version,
 } from '../../utils/versions';
 import { Schema } from './schema';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 
 function checkDependenciesInstalled(host: Tree, schema: Schema) {
   const packageJson = readJson(host, 'package.json');

--- a/packages/storybook/src/generators/migrate-7/migrate-7.ts
+++ b/packages/storybook/src/generators/migrate-7/migrate-7.ts
@@ -4,22 +4,23 @@ import {
   formatFiles,
   GeneratorCallback,
   readJson,
+  runTasksInSerial,
   Tree,
 } from '@nrwl/devkit';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import { output } from 'nx/src/utils/output';
 import { litVersion } from '../../utils/versions';
 import { callAutomigrate, callUpgrade } from './calling-storybook-cli';
 import {
-  removeUiFrameworkFromProjectJson,
-  getAllStorybookInfo,
-  prepareFiles,
-  handleMigrationResult,
   afterMigration,
-  checkWebComponentsInstalled,
   checkStorybookInstalled,
+  checkWebComponentsInstalled,
+  getAllStorybookInfo,
+  handleMigrationResult,
   logResult,
   onlyShowGuide,
+  prepareFiles,
+  removeUiFrameworkFromProjectJson,
 } from './helper-functions';
 import { Schema } from './schema';
 

--- a/packages/vite/src/generators/configuration/configuration.ts
+++ b/packages/vite/src/generators/configuration/configuration.ts
@@ -3,22 +3,23 @@ import {
   formatFiles,
   GeneratorCallback,
   readProjectConfiguration,
+  runTasksInSerial,
   Tree,
 } from '@nrwl/devkit';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import {
-  findExistingTargetsInProject,
   addOrChangeBuildTarget,
   addOrChangeServeTarget,
-  editTsConfig,
-  moveAndEditIndexHtml,
-  createOrEditViteConfig,
-  handleUnsupportedUserProvidedTargets,
-  handleUnknownExecutors,
-  UserProvidedTargetName,
-  TargetFlags,
   addPreviewTarget,
+  createOrEditViteConfig,
   deleteWebpackConfig,
+  editTsConfig,
+  findExistingTargetsInProject,
+  handleUnknownExecutors,
+  handleUnsupportedUserProvidedTargets,
+  moveAndEditIndexHtml,
+  TargetFlags,
+  UserProvidedTargetName,
 } from '../../utils/generator-utils';
 
 import initGenerator from '../init/init';

--- a/packages/vite/src/generators/vitest/vitest-generator.ts
+++ b/packages/vite/src/generators/vitest/vitest-generator.ts
@@ -7,16 +7,17 @@ import {
   joinPathFragments,
   offsetFromRoot,
   readProjectConfiguration,
+  runTasksInSerial,
   Tree,
   updateJson,
 } from '@nrwl/devkit';
 import {
   addOrChangeTestTarget,
-  findExistingTargetsInProject,
   createOrEditViteConfig,
+  findExistingTargetsInProject,
 } from '../../utils/generator-utils';
 import { VitestGeneratorSchema } from './schema';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import initGenerator from '../init/init';
 import {
   vitestCoverageC8Version,

--- a/packages/web/src/generators/application/application.ts
+++ b/packages/web/src/generators/application/application.ts
@@ -15,6 +15,7 @@ import {
   offsetFromRoot,
   readNxJson,
   readProjectConfiguration,
+  runTasksInSerial,
   TargetConfiguration,
   Tree,
   updateNxJson,
@@ -23,7 +24,7 @@ import {
 import { jestProjectGenerator } from '@nrwl/jest';
 import { swcCoreVersion } from '@nrwl/js/src/utils/versions';
 import { Linter, lintProjectGenerator } from '@nrwl/linter';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import { getRelativePathToRootTsConfig } from '@nrwl/js';
 
 import { nxVersion, swcLoaderVersion } from '../../utils/versions';

--- a/packages/web/src/generators/init/init.ts
+++ b/packages/web/src/generators/init/init.ts
@@ -5,10 +5,11 @@ import {
   formatFiles,
   GeneratorCallback,
   removeDependenciesFromPackageJson,
+  runTasksInSerial,
   Tree,
 } from '@nrwl/devkit';
 import { jestInitGenerator } from '@nrwl/jest';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+
 import { addBabelInputs } from '@nrwl/js/src/utils/add-babel-inputs';
 import { initGenerator as jsInitGenerator } from '@nrwl/js';
 import {

--- a/packages/workspace/src/generators/library/library.ts
+++ b/packages/workspace/src/generators/library/library.ts
@@ -12,13 +12,14 @@ import {
   names,
   offsetFromRoot,
   ProjectConfiguration,
+  runTasksInSerial,
   toJS,
   Tree,
   updateJson,
 } from '@nrwl/devkit';
 import { getImportPath } from 'nx/src/utils/path';
 import { join } from 'path';
-import { runTasksInSerial } from '../../utilities/run-tasks-in-serial';
+
 import {
   getRelativePathToRootTsConfig,
   getRootTsConfigFileName,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`runTasksInSerial` is an Nx Generator utility to handle running Generator Callbacks in serial.
It currently lives in `@nrwl/workspace`, however, as this is a devkit-specific utility, it is better placed in the Devkit package.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Add `runTasksInSerial` to `@nrwl/devkit`.

Deprecate `runTasksInSerial` from `@nrwl/workspace` in preference to removing it completely to allow Plugin Authors time to change their imports.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
