### PR TITLE
chore(repo): temporarily disabling flaky next test

### DIFF
--- a/e2e/next/src/next-styles.test.ts
+++ b/e2e/next/src/next-styles.test.ts
@@ -18,7 +18,8 @@ describe('Next.js apps', () => {
     process.env.NODE_ENV = originalEnv;
   });
 
-  it('should support different --style options', async () => {
+  // TODO (meeroslav): enable when this flaky test is fixed
+  xit('should support different --style options', async () => {
     const lessApp = uniq('app');
 
     runCLI(`generate @nrwl/next:app ${lessApp} --no-interactive --style=less`);


### PR DESCRIPTION
This test has been blocking the PRs causing us to rerun our CircleCI run to achieve green status.

This PR temporarily disables it until it's properly investigated and fixed.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
