### PR TITLE
feat(core): move string utils to devkit

### DIFF
--- a/e2e/angular-extensions/src/misc.test.ts
+++ b/e2e/angular-extensions/src/misc.test.ts
@@ -7,7 +7,7 @@ import {
   uniq,
   updateFile,
 } from '@nrwl/e2e/utils';
-import { classify } from '@nrwl/workspace/src/utils/strings';
+import { classify } from '@nrwl/devkit/src/utils/string-utils';
 
 describe('Move Angular Project', () => {
   let proj: string;

--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -1,4 +1,5 @@
 import { detectPackageManager, joinPathFragments } from '@nrwl/devkit';
+import { capitalize } from '@nrwl/devkit/src/utils/string-utils';
 import {
   checkFilesExist,
   cleanupProject,
@@ -17,7 +18,6 @@ import {
   updateFile,
   updateProjectConfig,
 } from '@nrwl/e2e/utils';
-import { stringUtils } from '@nrwl/workspace';
 import * as http from 'http';
 import { checkApp } from './utils';
 
@@ -111,7 +111,7 @@ describe('Next.js Applications', () => {
           import dynamic from 'next/dynamic';
 
           const TestComponent = dynamic(
-              () => import('@${proj}/${nextLib}').then(d => d.${stringUtils.capitalize(
+              () => import('@${proj}/${nextLib}').then(d => d.${capitalize(
         nextLib
       )})
             );

--- a/packages/angular/src/generators/add-linting/angular-v14/lib/create-eslint-configuration.ts
+++ b/packages/angular/src/generators/add-linting/angular-v14/lib/create-eslint-configuration.ts
@@ -1,8 +1,8 @@
 import type { Tree } from '@nrwl/devkit';
 import { joinPathFragments, offsetFromRoot, writeJson } from '@nrwl/devkit';
-import { camelize, dasherize } from '@nrwl/workspace/src/utils/strings';
 import type { Linter } from 'eslint';
 import type { AddLintingGeneratorSchema } from '../schema';
+import { camelize, dasherize } from '@nrwl/devkit/src/utils/string-utils';
 
 type EslintExtensionSchema = {
   prefix: string;

--- a/packages/angular/src/generators/add-linting/lib/create-eslint-configuration.ts
+++ b/packages/angular/src/generators/add-linting/lib/create-eslint-configuration.ts
@@ -1,8 +1,8 @@
 import type { Tree } from '@nrwl/devkit';
 import { joinPathFragments, offsetFromRoot, writeJson } from '@nrwl/devkit';
-import { camelize, dasherize } from '@nrwl/workspace/src/utils/strings';
 import type { Linter } from 'eslint';
 import type { AddLintingGeneratorSchema } from '../schema';
+import { camelize, dasherize } from '@nrwl/devkit/src/utils/string-utils';
 
 type EslintExtensionSchema = {
   prefix: string;

--- a/packages/devkit/src/utils/string-utils.spec.ts
+++ b/packages/devkit/src/utils/string-utils.spec.ts
@@ -1,0 +1,63 @@
+import { classify, dasherize } from './string-utils';
+
+describe('String utils', () => {
+  describe('dasherize', () => {
+    it('should format camel casing', () => {
+      expect(dasherize('twoWords')).toEqual('two-words');
+    });
+
+    it('should camel casing with abbreviations', () => {
+      expect(dasherize('twoWORDS')).toEqual('two-words');
+    });
+
+    it('should format spaces', () => {
+      expect(dasherize('two words')).toEqual('two-words');
+    });
+
+    it('should format underscores', () => {
+      expect(dasherize('two_words')).toEqual('two-words');
+    });
+
+    it('should format periods', () => {
+      expect(dasherize('two.words')).toEqual('two-words');
+    });
+
+    it('should format dashes', () => {
+      expect(dasherize('two-words')).toEqual('two-words');
+    });
+
+    it('should return single words', () => {
+      expect(dasherize('word')).toEqual('word');
+    });
+  });
+
+  describe('classify', () => {
+    it('should format camel casing', () => {
+      expect(classify('twoWords')).toEqual('TwoWords');
+    });
+
+    it('should camel casing with abbreviations', () => {
+      expect(classify('twoWORDS')).toEqual('TwoWORDS');
+    });
+
+    it('should format spaces', () => {
+      expect(classify('two words')).toEqual('TwoWords');
+    });
+
+    it('should format underscores', () => {
+      expect(classify('two_words')).toEqual('TwoWords');
+    });
+
+    it('should format periods', () => {
+      expect(classify('two.words')).toEqual('Two.Words');
+    });
+
+    it('should format dashes', () => {
+      expect(classify('two-words')).toEqual('TwoWords');
+    });
+
+    it('should return single words', () => {
+      expect(classify('word')).toEqual('Word');
+    });
+  });
+});

--- a/packages/devkit/src/utils/string-utils.ts
+++ b/packages/devkit/src/utils/string-utils.ts
@@ -22,7 +22,6 @@ const STRING_UNDERSCORE_REGEXP_2 = /-|\s+/g;
  ```
 
  @method decamelize
- @deprecated This will be removed from `@nrwl/workspace` in version 17. Prefer `@nrwl/js` when importing.
  @param {String} str The string to decamelize.
  @return {String} the decamelized string.
  */
@@ -42,7 +41,6 @@ export function decamelize(str: string): string {
  ```
 
  @method dasherize
- @deprecated This will be removed from `@nrwl/workspace` in version 17. Prefer `@nrwl/js` when importing.
  @param {String} str The string to dasherize.
  @return {String} the dasherized string.
  */
@@ -62,7 +60,6 @@ export function dasherize(str?: string): string {
  ```
 
  @method camelize
- @deprecated This will be removed from `@nrwl/workspace` in version 17. Prefer `@nrwl/js` when importing.
  @param {String} str The string to camelize.
  @return {String} the camelized string.
  */
@@ -88,7 +85,6 @@ export function camelize(str: string): string {
  ```
 
  @method classify
- @deprecated This will be removed from `@nrwl/workspace` in version 17. Prefer `@nrwl/js` when importing.
  @param {String} str the string to classify
  @return {String} the classified string
  */
@@ -111,7 +107,6 @@ export function classify(str: string): string {
  ```
 
  @method underscore
- @deprecated This will be removed from `@nrwl/workspace` in version 17. Prefer `@nrwl/js` when importing.
  @param {String} str The string to underscore.
  @return {String} the underscored string.
  */
@@ -133,7 +128,6 @@ export function underscore(str: string): string {
  ```
 
  @method capitalize
- @deprecated This will be removed from `@nrwl/workspace` in version 17. Prefer `@nrwl/js` when importing.
  @param {String} str The string to capitalize.
  @return {String} The capitalized string.
  */
@@ -141,22 +135,16 @@ export function capitalize(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
-/**
- * @deprecated This will be removed from `@nrwl/workspace` in version 17. Prefer `@nrwl/js` when importing.
- */
-export function group(name: string, group: string | undefined) {
+export function group(name: string, group: string | undefined): string {
   return group ? `${group}/${name}` : name;
 }
 
-/**
- * @deprecated This will be removed from `@nrwl/workspace` in version 17. Prefer `@nrwl/js` when importing.
- */
 export function featurePath(
   group: boolean | undefined,
   flat: boolean | undefined,
   path: string,
   name: string
-) {
+): string {
   if (group && !flat) {
     return `../../${path}/${name}/`;
   }

--- a/packages/linter/src/generators/workspace-rule/workspace-rule.ts
+++ b/packages/linter/src/generators/workspace-rule/workspace-rule.ts
@@ -8,7 +8,7 @@ import {
   logger,
   Tree,
 } from '@nrwl/devkit';
-import { camelize } from '@nrwl/workspace/src/utils/strings';
+import { camelize } from '@nrwl/devkit/src/utils/string-utils';
 import { join } from 'path';
 import * as ts from 'typescript';
 import { workspaceLintPluginDir } from '../../utils/workspace-lint-rules';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
There are string utils being used from `@nrwl/workspace`. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Move the string utils to devkit
Deprecate the existing utils in favour of the devkit package to allow plugin authors time to adjust their code.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
