### PR TITLE
feat(node): add nestjs support to node app plugin

### DIFF
--- a/docs/generated/packages/node/generators/application.json
+++ b/docs/generated/packages/node/generators/application.json
@@ -91,7 +91,7 @@
       "framework": {
         "description": "Generate the node application using a framework",
         "type": "string",
-        "enum": ["express", "fastify", "koa", "none"],
+        "enum": ["express", "fastify", "koa", "nest", "none"],
         "default": "none",
         "x-prompt": "Which framework do you want to use?",
         "x-priority": "important"

--- a/docs/generated/packages/workspace/generators/new.json
+++ b/docs/generated/packages/workspace/generators/new.json
@@ -67,7 +67,7 @@
       "framework": {
         "description": "The framework which the application is using",
         "type": "string",
-        "enum": ["express", "koa", "fastify", "connect"]
+        "enum": ["express", "koa", "fastify", "nest", "none"]
       }
     },
     "additionalProperties": true,

--- a/docs/generated/packages/workspace/generators/preset.json
+++ b/docs/generated/packages/workspace/generators/preset.json
@@ -72,7 +72,7 @@
       "framework": {
         "description": "The framework which the application is using",
         "type": "string",
-        "enum": ["express", "koa", "fastify", "connect"]
+        "enum": ["express", "koa", "fastify", "nest", "none"]
       },
       "bundler": {
         "description": "The bundler to use for building the application.",

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -731,11 +731,15 @@ async function determineFramework(
     },
     {
       name: 'fastify',
-      message: 'fastify [https://www.fastify.io/]',
+      message: 'Fastify [https://www.fastify.io/]',
     },
     {
       name: 'koa',
-      message: 'koa     [https://koajs.com/]',
+      message: 'Koa     [https://koajs.com/]',
+    },
+    {
+      name: 'nest',
+      message: 'NestJs  [https://nestjs.com/]',
     },
   ];
 

--- a/packages/nest/src/generators/application/lib/normalize-options.ts
+++ b/packages/nest/src/generators/application/lib/normalize-options.ts
@@ -16,10 +16,12 @@ export function normalizeOptions(
     ? `${names(projectDirectory).fileName}/${names(options.name).fileName}`
     : names(options.name).fileName;
 
-  const appProjectRoot = joinPathFragments(
-    layoutDirectory ?? getWorkspaceLayout(tree).appsDir,
-    appDirectory
-  );
+  const appProjectRoot = options.rootProject
+    ? '.'
+    : joinPathFragments(
+        layoutDirectory ?? getWorkspaceLayout(tree).appsDir,
+        appDirectory
+      );
 
   return {
     ...options,
@@ -43,6 +45,7 @@ export function toNodeApplicationGeneratorOptions(
     tags: options.tags,
     unitTestRunner: options.unitTestRunner,
     setParserOptionsProject: options.setParserOptionsProject,
+    rootProject: options.rootProject,
     bundler: 'webpack', // Some features require webpack plugins such as TS transformers
   };
 }

--- a/packages/nest/src/generators/application/schema.d.ts
+++ b/packages/nest/src/generators/application/schema.d.ts
@@ -12,6 +12,7 @@ export interface ApplicationGeneratorOptions {
   tags?: string;
   unitTestRunner?: UnitTestRunner;
   setParserOptionsProject?: boolean;
+  rootProject?: boolean;
 }
 
 interface NormalizedOptions extends ApplicationGeneratorOptions {

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -464,6 +464,7 @@ describe('app', () => {
     ['fastify' as const, true],
     ['express' as const, false],
     ['koa' as const, false],
+    ['nest' as const, false],
   ])('--unitTestRunner', (framework, checkSpecFile) => {
     it('should generate test target and spec file by default', async () => {
       await applicationGenerator(tree, {

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -2,6 +2,7 @@ import {
   addDependenciesToPackageJson,
   addProjectConfiguration,
   convertNxGenerator,
+  ensurePackage,
   extractLayoutDirectory,
   formatFiles,
   generateFiles,
@@ -352,6 +353,11 @@ function updateTsConfigOptions(tree: Tree, options: NormalizedSchema) {
 export async function applicationGenerator(tree: Tree, schema: Schema) {
   const options = normalizeOptions(tree, schema);
   const tasks: GeneratorCallback[] = [];
+
+  if (options.framework === 'nest') {
+    const { applicationGenerator } = ensurePackage('@nrwl/nest', nxVersion);
+    return await applicationGenerator(tree, options);
+  }
 
   const initTask = await initGenerator(tree, {
     ...schema,

--- a/packages/node/src/generators/application/schema.d.ts
+++ b/packages/node/src/generators/application/schema.d.ts
@@ -22,4 +22,4 @@ export interface Schema {
   docker?: boolean;
 }
 
-export type NodeJsFrameWorks = 'express' | 'koa' | 'fastify' | 'none';
+export type NodeJsFrameWorks = 'express' | 'koa' | 'fastify' | 'nest' | 'none';

--- a/packages/node/src/generators/application/schema.json
+++ b/packages/node/src/generators/application/schema.json
@@ -91,7 +91,7 @@
     "framework": {
       "description": "Generate the node application using a framework",
       "type": "string",
-      "enum": ["express", "fastify", "koa", "none"],
+      "enum": ["express", "fastify", "koa", "nest", "none"],
       "default": "none",
       "x-prompt": "Which framework do you want to use?",
       "x-priority": "important"

--- a/packages/workspace/src/generators/new/schema.json
+++ b/packages/workspace/src/generators/new/schema.json
@@ -70,7 +70,7 @@
     "framework": {
       "description": "The framework which the application is using",
       "type": "string",
-      "enum": ["express", "koa", "fastify", "connect"]
+      "enum": ["express", "koa", "fastify", "nest", "none"]
     }
   },
   "additionalProperties": true

--- a/packages/workspace/src/generators/preset/schema.json
+++ b/packages/workspace/src/generators/preset/schema.json
@@ -75,7 +75,7 @@
     "framework": {
       "description": "The framework which the application is using",
       "type": "string",
-      "enum": ["express", "koa", "fastify", "connect"]
+      "enum": ["express", "koa", "fastify", "nest", "none"]
     },
     "bundler": {
       "description": "The bundler to use for building the application.",


### PR DESCRIPTION
Esbuild's compatibility is not as smooth as other frameworks we have currently supported (express, fastify, koa).
So, currently, this PR is compatible with `webpack`.

A follow-up PR will be to support `esbuild`.


