### PR TITLE
cleanup(angular): remove deep import to nrwl/workspace for getNewProjectName

### DIFF
--- a/packages/angular/src/generators/move/lib/update-module-name.ts
+++ b/packages/angular/src/generators/move/lib/update-module-name.ts
@@ -5,7 +5,7 @@ import {
   Tree,
   visitNotIgnoredFiles,
 } from '@nrwl/devkit';
-import { getNewProjectName } from '@nrwl/workspace/src/generators/move/lib/utils';
+import { getNewProjectName } from '../../utils/get-new-project-name';
 import { join } from 'path';
 import { Schema } from '../schema';
 

--- a/packages/angular/src/generators/move/lib/update-ng-package.ts
+++ b/packages/angular/src/generators/move/lib/update-ng-package.ts
@@ -6,7 +6,7 @@ import {
   updateJson,
   workspaceRoot,
 } from '@nrwl/devkit';
-import { getNewProjectName } from '@nrwl/workspace/src/generators/move/lib/utils';
+import { getNewProjectName } from '../../utils/get-new-project-name';
 import { join, relative } from 'path';
 import { Schema } from '../schema';
 

--- a/packages/angular/src/generators/utils/get-new-project-name.ts
+++ b/packages/angular/src/generators/utils/get-new-project-name.ts
@@ -1,0 +1,8 @@
+/**
+ * Replaces slashes with dashes
+ *
+ * @param path
+ */
+export function getNewProjectName(path: string): string {
+  return path.replace(/\//g, '-');
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Two areas in Angular plugin deep import a function from the move generator that exists in @nrwl/workspace.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Duplicate the code fragment into nrwl/angular to allow it to import directly from its own packages.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
