### PR TITLE
cleanup(angular): import deduceDefaultBase from nx

### DIFF
--- a/packages/angular/src/generators/ng-add/utilities/workspace.ts
+++ b/packages/angular/src/generators/ng-add/utilities/workspace.ts
@@ -11,7 +11,7 @@ import {
 } from '@nrwl/devkit';
 import { Linter, lintInitGenerator } from '@nrwl/linter';
 import { DEFAULT_NRWL_PRETTIER_CONFIG } from '@nrwl/workspace/src/generators/new/generate-workspace-files';
-import { deduceDefaultBase } from '@nrwl/workspace/src/utilities/default-base';
+import { deduceDefaultBase } from 'nx/src/utils/default-base';
 import { resolveUserExistingPrettierConfig } from '@nrwl/workspace/src/utilities/prettier';
 import { getRootTsConfigPathInTree } from '@nrwl/js';
 import { prettierVersion } from '@nrwl/workspace/src/utils/versions';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
There's an import to deduceDefaultBase from @nrwl/workspace in Angular plugin

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Import deduceDefaultBase from nx package instead

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
