### PR TITLE
cleanup(core): inline monorepo migration logic into nx init

### DIFF
--- a/e2e/nx-init/src/nx-init-monorepo.test.ts
+++ b/e2e/nx-init/src/nx-init-monorepo.test.ts
@@ -1,0 +1,55 @@
+import {
+  createNonNxProjectDirectory,
+  getPackageManagerCommand,
+  getPublishedVersion,
+  getSelectedPackageManager,
+  runCLI,
+  runCommand,
+  updateFile,
+} from '@nrwl/e2e/utils';
+
+describe('nx init (Monorepo)', () => {
+  const pmc = getPackageManagerCommand({
+    packageManager: getSelectedPackageManager(),
+  });
+
+  it('should convert to an Nx workspace', () => {
+    createNonNxProjectDirectory();
+    runCommand(pmc.install);
+    updateFile(
+      'packages/package-a/package.json',
+      JSON.stringify({
+        name: 'package-a',
+        scripts: {
+          serve: 'some serve',
+          build: 'echo "build successful"',
+          test: 'some test',
+        },
+      })
+    );
+    updateFile(
+      'packages/package-b/package.json',
+      JSON.stringify({
+        name: 'package-b',
+        scripts: {
+          lint: 'some lint',
+        },
+      })
+    );
+
+    const output = runCommand(
+      `${
+        pmc.runUninstalledPackage
+      } nx@${getPublishedVersion()} init -y --cacheable=build`
+    );
+
+    expect(output).toContain('🎉 Done!');
+    // check build
+    const buildOutput = runCLI('build package-a');
+    expect(buildOutput).toContain('build successful');
+    // run build again for cache
+    const cachedBuildOutput = runCLI('build package-a');
+    expect(cachedBuildOutput).toContain('build successful');
+    expect(cachedBuildOutput).toContain('Nx read the output from the cache');
+  });
+});

--- a/e2e/nx-init/src/nx-init.test.ts
+++ b/e2e/nx-init/src/nx-init.test.ts
@@ -15,32 +15,6 @@ describe('nx init', () => {
     packageManager: getSelectedPackageManager(),
   });
 
-  it('should work in a monorepo', () => {
-    createNonNxProjectDirectory('monorepo', true);
-    updateFile(
-      'packages/package/package.json',
-      JSON.stringify({
-        name: 'package',
-        scripts: {
-          echo: 'echo 123',
-        },
-      })
-    );
-
-    runCommand(pmc.install);
-
-    const output = runCommand(
-      `${pmc.runUninstalledPackage} nx@${getPublishedVersion()}  init -y`
-    );
-    expect(output).toContain('Enabled computation caching');
-
-    expect(runCLI('run package:echo')).toContain('123');
-    renameFile('nx.json', 'nx.json.old');
-
-    expect(runCLI('run package:echo')).toContain('123');
-    cleanupProject();
-  });
-
   it('should work in a regular npm repo', () => {
     createNonNxProjectDirectory('regular-repo', false);
     updateFile(

--- a/packages/nx/src/command-line/init.ts
+++ b/packages/nx/src/command-line/init.ts
@@ -2,6 +2,7 @@ import { execSync } from 'child_process';
 import { existsSync } from 'fs';
 import { prerelease } from 'semver';
 import * as parser from 'yargs-parser';
+import { addNxToMonorepo } from '../nx-init/add-nx-to-monorepo';
 import { addNxToNest } from '../nx-init/add-nx-to-nest';
 import { addNxToNpmRepo } from '../nx-init/add-nx-to-npm-repo';
 import { addNxToAngularCliRepo } from '../nx-init/angular';
@@ -53,10 +54,7 @@ export async function initHandler() {
     } else if (isNestCLI(packageJson)) {
       await addNxToNest(packageJson);
     } else if (isMonorepo(packageJson)) {
-      // TODO: vsavkin remove add-nx-to-monorepo
-      execSync(`npx --yes add-nx-to-monorepo@${version} ${args}`, {
-        stdio: [0, 1, 2],
-      });
+      addNxToMonorepo();
     } else {
       await addNxToNpmRepo();
     }

--- a/packages/nx/src/nx-init/add-nx-to-monorepo.ts
+++ b/packages/nx/src/nx-init/add-nx-to-monorepo.ts
@@ -1,0 +1,185 @@
+import { prompt } from 'enquirer';
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
+import ignore from 'ignore';
+import { join, relative } from 'path';
+import * as yargsParser from 'yargs-parser';
+import { readJsonFile } from '../utils/fileutils';
+import { output } from '../utils/output';
+import { getPackageManagerCommand } from '../utils/package-manager';
+import { joinPathFragments } from '../utils/path';
+import {
+  addDepsToPackageJson,
+  askAboutNxCloud,
+  createNxJsonFile,
+  initCloud,
+  runInstall,
+} from './utils';
+
+const parsedArgs = yargsParser(process.argv, {
+  boolean: ['yes'],
+  string: ['cacheable'], // only used for testing
+  alias: {
+    yes: ['y'],
+  },
+});
+
+export async function addNxToMonorepo() {
+  const repoRoot = process.cwd();
+
+  if (!existsSync(joinPathFragments(repoRoot, 'package.json'))) {
+    output.error({
+      title: `Run the command in the folder with a package.json file.`,
+    });
+    process.exit(1);
+  }
+
+  output.log({ title: `🐳 Nx initialization` });
+
+  const packageJsonFiles = allProjectPackageJsonFiles(repoRoot);
+  const scripts = combineAllScriptNames(repoRoot, packageJsonFiles);
+
+  let targetDefaults: string[];
+  let cacheableOperations: string[];
+  let scriptOutputs = {} as { [script: string]: string };
+  let useCloud: boolean;
+
+  if (parsedArgs.yes !== true && scripts.length > 0) {
+    output.log({
+      title: `🧑‍🔧 Please answer the following questions about the scripts found in your workspace in order to generate task runner configuration`,
+    });
+
+    targetDefaults = (
+      (await prompt([
+        {
+          type: 'multiselect',
+          name: 'targetDefaults',
+          message: `Which scripts need to be run in order?  (e.g. before building a project, dependent projects must be built.)`,
+          choices: scripts,
+        },
+      ])) as any
+    ).targetDefaults;
+
+    cacheableOperations = (
+      (await prompt([
+        {
+          type: 'multiselect',
+          name: 'cacheableOperations',
+          message:
+            'Which scripts are cacheable? (Produce the same output given the same input, e.g. build, test and lint usually are, serve and start are not)',
+          choices: scripts,
+        },
+      ])) as any
+    ).cacheableOperations;
+
+    for (const scriptName of cacheableOperations) {
+      scriptOutputs[scriptName] = (
+        await prompt([
+          {
+            type: 'input',
+            name: scriptName,
+            message: `Does the "${scriptName}" script create any outputs? If not, leave blank, otherwise provide a path relative to a project root (e.g. dist, lib, build, coverage)`,
+          },
+        ])
+      )[scriptName];
+    }
+
+    useCloud = await askAboutNxCloud();
+  } else {
+    targetDefaults = [];
+    cacheableOperations = parsedArgs.cacheable
+      ? parsedArgs.cacheable.split(',')
+      : [];
+    useCloud = false;
+  }
+
+  createNxJsonFile(
+    repoRoot,
+    targetDefaults,
+    cacheableOperations,
+    scriptOutputs
+  );
+
+  addDepsToPackageJson(repoRoot, useCloud);
+
+  output.log({ title: `📦 Installing dependencies` });
+  runInstall(repoRoot);
+
+  if (useCloud) {
+    initCloud(repoRoot, 'nx-init-monorepo');
+  }
+
+  printFinalMessage();
+}
+
+// scanning package.json files
+function allProjectPackageJsonFiles(repoRoot: string) {
+  const packageJsonFiles = allPackageJsonFiles(repoRoot, repoRoot);
+  return packageJsonFiles.filter((c) => c != 'package.json');
+}
+
+function allPackageJsonFiles(repoRoot: string, dirName: string) {
+  const ignoredGlobs = getIgnoredGlobs(repoRoot);
+  const relDirName = relative(repoRoot, dirName);
+  if (
+    relDirName &&
+    (ignoredGlobs.ignores(relDirName) ||
+      relDirName.indexOf(`node_modules`) > -1)
+  ) {
+    return [];
+  }
+
+  let res = [];
+  try {
+    readdirSync(dirName).forEach((c) => {
+      const child = join(dirName, c);
+      if (ignoredGlobs.ignores(relative(repoRoot, child))) {
+        return;
+      }
+      try {
+        const s = statSync(child);
+        if (s.isFile() && c == 'package.json') {
+          res.push(relative(repoRoot, child));
+        } else if (s.isDirectory()) {
+          res = [...res, ...allPackageJsonFiles(repoRoot, child)];
+        }
+      } catch {}
+    });
+  } catch {}
+  return res;
+}
+
+function getIgnoredGlobs(repoRoot: string) {
+  const ig = ignore();
+  try {
+    ig.add(readFileSync(`${repoRoot}/.gitignore`, 'utf-8'));
+  } catch {}
+  return ig;
+}
+
+function combineAllScriptNames(
+  repoRoot: string,
+  packageJsonFiles: string[]
+): string[] {
+  const res = new Set<string>();
+  packageJsonFiles.forEach((p) => {
+    const packageJson = readJsonFile(join(repoRoot, p));
+    Object.keys(packageJson.scripts || {}).forEach((scriptName) =>
+      res.add(scriptName)
+    );
+  });
+  return [...res];
+}
+
+function printFinalMessage() {
+  const pmc = getPackageManagerCommand();
+  output.success({
+    title: `🎉 Done!`,
+    bodyLines: [
+      `- Enabled computation caching!`,
+      `- Run "${pmc.exec} nx run-many --target=build" to run the build script for every project in the monorepo.`,
+      `- Run it again to replay the cached computation.`,
+      `- Run "${pmc.exec} nx graph" to see the structure of the monorepo.`,
+      `- Learn more at https://nx.dev/recipes/adopting-nx/adding-to-monorepo`,
+    ],
+  });
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `nx init` command doesn't contain the implementation for migrating a monorepo to Nx. Instead, it defers that to a separate package (`add-nx-to-monorepo`).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `nx init` command contains the implementation for migrating a monorepo to Nx.

Note: the `add-nx-to-monorepo` package will be removed in a separate PR once this one lands.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
