### PR TITLE
feat(js): add getSourceNodes to nrwl/js package

### DIFF
--- a/packages/angular/src/generators/utils/storybook-ast/storybook-inputs.ts
+++ b/packages/angular/src/generators/utils/storybook-ast/storybook-inputs.ts
@@ -1,6 +1,6 @@
 import type { Tree } from '@nrwl/devkit';
 import { findNodes } from 'nx/src/utils/typescript';
-import { getSourceNodes } from '@nrwl/workspace/src/utilities/typescript/get-source-nodes';
+import { getSourceNodes } from '@nrwl/js';
 import type { PropertyDeclaration } from 'typescript';
 import { getTsSourceFile } from '../../../utils/nx-devkit/ast-utils';
 import { ensureTypescript } from '@nrwl/js/src/utils/typescript/ensure-typescript';
@@ -8,6 +8,7 @@ import { ensureTypescript } from '@nrwl/js/src/utils/typescript/ensure-typescrip
 let tsModule: typeof import('typescript');
 
 export type KnobType = 'text' | 'boolean' | 'number' | 'select';
+
 export interface InputDescriptor {
   name: string;
   type: KnobType;

--- a/packages/angular/src/utils/nx-devkit/ast-utils.ts
+++ b/packages/angular/src/utils/nx-devkit/ast-utils.ts
@@ -1,6 +1,6 @@
 import type * as ts from 'typescript';
 import { findNodes } from 'nx/src/utils/typescript';
-import { getSourceNodes } from '@nrwl/workspace/src/utilities/typescript/get-source-nodes';
+import { getSourceNodes } from '@nrwl/js';
 import { dirname, join } from 'path';
 import { names, readProjectConfiguration, Tree } from '@nrwl/devkit';
 import {

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -1,6 +1,7 @@
 export * from './utils/typescript/load-ts-transformers';
 export * from './utils/typescript/print-diagnostics';
 export * from './utils/typescript/run-type-check';
+export * from './utils/typescript/get-source-nodes';
 export * from './utils/compiler-helper-dependency';
 export * from './utils/typescript/ts-config';
 export * from './utils/typescript/create-ts-config';

--- a/packages/js/src/utils/typescript/get-source-nodes.ts
+++ b/packages/js/src/utils/typescript/get-source-nodes.ts
@@ -1,8 +1,5 @@
 import type * as ts from 'typescript';
 
-/**
- * @deprecated This function will be removed from @nrwl/workspace in version 17. Prefer importing from @nrwl/js.
- */
 export function getSourceNodes(sourceFile: ts.SourceFile): ts.Node[] {
   const nodes: ts.Node[] = [sourceFile];
   const result = [];


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Some TS Utils still live in @nrwl/workspace. They are deep imported into the Angular Plugin

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Begin moving these AST Utils to Nrwl/JS, starting with getSourceNodes.
Deprecate the existing function in nrwl/workspace for plugin authors to have time to update.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
