### PR TITLE
fix(angular): prevent updating unchanged projects when syncing changes to the wrapped tree

### DIFF
--- a/packages/nx/src/adapter/ngcli-adapter.ts
+++ b/packages/nx/src/adapter/ngcli-adapter.ts
@@ -872,7 +872,12 @@ function saveProjectsConfigurationsInWrappedSchematic(
       newAngularJson.projects[projectName] = projects[projectName];
     } else {
       if (existingProjects.has(projectName)) {
-        updateProjectConfiguration(host, projectName, projects[projectName]);
+        if (
+          JSON.stringify(existingProjects.get(projectName)) !==
+          JSON.stringify(projects[projectName])
+        ) {
+          updateProjectConfiguration(host, projectName, projects[projectName]);
+        }
       } else {
         addProjectConfiguration(host, projectName, projects[projectName]);
       }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When syncing changes back to the wrapped tree for schematics, the adapter updates all existing projects regardless of whether they are modified.

This surfaces an issue in workspaces with at least one project in a `package.json`. Because we update all projects, it throws when trying to update the `package.json` based project because our utility doesn't support updating those projects. If it throws before the project that needs to be updated or created, it results in the project not getting the changes or not being created.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The adapter should only update existing modified projects when syncing changes to the wrapped tree for schematics.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15348 
