### PR TITLE
feat(core): move checkAndCleanWithSemver to devkit

### DIFF
--- a/packages/angular/src/generators/ngrx/lib/add-ngrx-to-package-json.ts
+++ b/packages/angular/src/generators/ngrx/lib/add-ngrx-to-package-json.ts
@@ -1,6 +1,6 @@
 import type { GeneratorCallback, Tree } from '@nrwl/devkit';
 import { addDependenciesToPackageJson, readJson } from '@nrwl/devkit';
-import { checkAndCleanWithSemver } from '@nrwl/workspace/src/utilities/version-utils';
+import { checkAndCleanWithSemver } from '@nrwl/devkit/src/utils/semver';
 import { gte } from 'semver';
 import { getPkgVersionForAngularMajorVersion } from '../../../utils/version-utils';
 import { rxjsVersion as defaultRxjsVersion } from '../../../utils/versions';

--- a/packages/angular/src/generators/setup-tailwind/lib/detect-tailwind-installed-version.ts
+++ b/packages/angular/src/generators/setup-tailwind/lib/detect-tailwind-installed-version.ts
@@ -1,5 +1,5 @@
 import { readJson, Tree } from '@nrwl/devkit';
-import { checkAndCleanWithSemver } from '@nrwl/workspace/src/utilities/version-utils';
+import { checkAndCleanWithSemver } from '@nrwl/devkit/src/utils/semver';
 import { lt } from 'semver';
 
 export function detectTailwindInstalledVersion(

--- a/packages/cypress/src/migrations/update-14-7-0/update-cypress-version-if-10.ts
+++ b/packages/cypress/src/migrations/update-14-7-0/update-cypress-version-if-10.ts
@@ -6,7 +6,7 @@ import {
   updateJson,
 } from '@nrwl/devkit';
 // don't import from root level to prevent issue where angular isn't installed.
-import { checkAndCleanWithSemver } from '@nrwl/workspace/src/utilities/version-utils';
+import { checkAndCleanWithSemver } from '@nrwl/devkit/src/utils/semver';
 import { gte, lt } from 'semver';
 
 export function updateCypressVersionIf10(tree: Tree): GeneratorCallback {

--- a/packages/cypress/src/migrations/update-15-0-0/update-cy-mount-usage.ts
+++ b/packages/cypress/src/migrations/update-15-0-0/update-cy-mount-usage.ts
@@ -12,7 +12,7 @@ import {
   Tree,
   visitNotIgnoredFiles,
 } from '@nrwl/devkit';
-import { checkAndCleanWithSemver } from '@nrwl/workspace/src/utilities/version-utils';
+import { checkAndCleanWithSemver } from '@nrwl/devkit/src/utils/semver';
 import { forEachExecutorOptions } from '@nrwl/workspace/src/utilities/executor-options-utils';
 import { tsquery } from '@phenomnomnominal/tsquery';
 import { gte } from 'semver';

--- a/packages/devkit/src/utils/semver.ts
+++ b/packages/devkit/src/utils/semver.ts
@@ -1,6 +1,9 @@
 import { valid } from 'semver';
 
-export function checkAndCleanWithSemver(pkgName: string, version: string) {
+export function checkAndCleanWithSemver(
+  pkgName: string,
+  version: string
+): string {
   let newVersion = version;
 
   if (valid(newVersion)) {

--- a/packages/nest/src/migrations/update-13-2-0/update-to-nest-8.ts
+++ b/packages/nest/src/migrations/update-13-2-0/update-to-nest-8.ts
@@ -1,5 +1,5 @@
 import { formatFiles, logger, readJson, Tree, updateJson } from '@nrwl/devkit';
-import { checkAndCleanWithSemver } from '@nrwl/workspace';
+import { checkAndCleanWithSemver } from '@nrwl/devkit/src/utils/semver';
 import { satisfies } from 'semver';
 import { sortObjectByKeys } from '@nrwl/workspace/src/utils/ast-utils';
 

--- a/packages/next/src/executors/build/build.impl.ts
+++ b/packages/next/src/executors/build/build.impl.ts
@@ -16,7 +16,7 @@ import {
   calculateProjectDependencies,
   DependentBuildableProjectNode,
 } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
-import { checkAndCleanWithSemver } from '@nrwl/workspace/src/utilities/version-utils';
+import { checkAndCleanWithSemver } from '@nrwl/devkit/src/utils/semver';
 
 import { prepareConfig } from '../../utils/config';
 import { updatePackageJson } from './lib/update-package-json';

--- a/packages/storybook/src/migrations/update-14-0-0/migrate-defaults-5-to-6/migrate-defaults-5-to-6.ts
+++ b/packages/storybook/src/migrations/update-14-0-0/migrate-defaults-5-to-6/migrate-defaults-5-to-6.ts
@@ -9,7 +9,7 @@ import {
   visitNotIgnoredFiles,
 } from '@nrwl/devkit';
 import { lte } from 'semver';
-import { checkAndCleanWithSemver } from '@nrwl/workspace/src/utilities/version-utils';
+import { checkAndCleanWithSemver } from '@nrwl/devkit/src/utils/semver';
 import { storybookVersion } from '../../../utils/versions';
 import { createProjectStorybookDir } from '../../../generators/configuration/util-functions';
 import { StorybookConfigureSchema } from '../../../generators/configuration/schema';

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -70,7 +70,10 @@ export * from './src/utils/rules/ng-add';
 export { updateKarmaConf } from './src/utils/rules/update-karma-conf';
 export { visitNotIgnoredFiles } from './src/utils/rules/visit-not-ignored-files';
 import * as strings from './src/utils/strings';
+
+// TODO(v17): Remove this export.
 export { checkAndCleanWithSemver } from './src/utils/version-utils';
+
 export { updatePackagesInPackageJson } from './src/utils/update-packages-in-package-json';
 
 export { libraryGenerator } from './src/generators/library/library';

--- a/packages/workspace/src/utilities/version-utils.ts
+++ b/packages/workspace/src/utilities/version-utils.ts
@@ -1,21 +1,12 @@
-import { valid } from 'semver';
+import { checkAndCleanWithSemver as _checkAndCleanWithSemver } from '@nrwl/devkit/src/utils/semver';
+import { logger } from '@nrwl/devkit';
 
+/** @deprecated Use checkAndCleanWithSemver from @nrwl/devkit/src/utils/semver instead.
+ * TODO(v17): Remove this function from workspace. Keep it for now since there are projects that use it (e.g. https://github.com/gperdomor/nx-tools).
+ */
 export function checkAndCleanWithSemver(pkgName: string, version: string) {
-  let newVersion = version;
-
-  if (valid(newVersion)) {
-    return newVersion;
-  }
-
-  if (version.startsWith('~') || version.startsWith('^')) {
-    newVersion = version.substring(1);
-  }
-
-  if (!valid(newVersion)) {
-    throw new Error(
-      `The package.json lists a version of ${pkgName} that Nx is unable to validate - (${version})`
-    );
-  }
-
-  return newVersion;
+  logger.warn(
+    `checkAndCleanWithSemver has been moved to @nrwl/devkit/src/utils/semver`
+  );
+  return _checkAndCleanWithSemver(pkgName, version);
 }

--- a/packages/workspace/src/utils/update-packages-in-package-json.ts
+++ b/packages/workspace/src/utils/update-packages-in-package-json.ts
@@ -1,7 +1,7 @@
 import { chain, noop } from '@angular-devkit/schematics';
 import { updateJsonInTree } from './ast-utils';
 import { readFileSync } from 'fs';
-import { checkAndCleanWithSemver } from './version-utils';
+import { checkAndCleanWithSemver } from '@nrwl/devkit/src/utils/semver';
 import { lt } from 'semver';
 import { addInstallTask } from './rules/add-install-task';
 


### PR DESCRIPTION
This PR moves `checkAndCleanWithSemver` function from `@nrwl/workspace` to `@nrwl/devkit` and mark the former as deprecated. There are still some projects such as [`nx-tools`](https://github.com/gperdomor/nx-tools) that import from it.

Also removed the unused function from `nx` package. Looks like it was copied and pasted there but it was unused.