### PR TITLE
chore(devkit): fix root when unit testing generators wrapped as schematics

### DIFF
--- a/packages/devkit/src/utils/invoke-nx-generator.ts
+++ b/packages/devkit/src/utils/invoke-nx-generator.ts
@@ -104,7 +104,21 @@ class DevkitTreeFromAngularDevkitTree implements Tree {
     private tree,
     private _root: string,
     private skipWritingConfigInOldFormat?: boolean
-  ) {}
+  ) {
+    /**
+     * When using the UnitTestTree from @angular-devkit/schematics/testing, the root is just `/`.
+     * This causes a massive issue if `getProjects()` is used in the underlying generator because it
+     * causes fast-glob to be set to work on the user's entire file system.
+     *
+     * Therefore, in this case, patch the root to match what Nx Devkit does and use /virtual instead.
+     */
+    try {
+      const { UnitTestTree } = require('@angular-devkit/schematics/testing');
+      if (tree instanceof UnitTestTree && _root === '/') {
+        this._root = '/virtual';
+      }
+    } catch {}
+  }
 
   get root(): string {
     return this._root;

--- a/scripts/depcheck/missing.ts
+++ b/scripts/depcheck/missing.ts
@@ -55,7 +55,12 @@ const IGNORE_MATCHES_IN_PACKAGE = {
   ],
   cli: ['nx'],
   cypress: ['cypress', '@angular-devkit/schematics', '@nrwl/cypress', 'vite'],
-  devkit: ['@angular-devkit/architect', 'rxjs', 'webpack'],
+  devkit: [
+    '@angular-devkit/architect',
+    '@angular-devkit/schematics',
+    'rxjs',
+    'webpack',
+  ],
   'eslint-plugin-nx': ['@angular-eslint/eslint-plugin'],
   jest: [
     'jest',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

If you wrap an Nx generator as an Angular CLI schematic and write unit tests for it, you can run into a major issue if that generator contains a call to `getProjects()`.

See code comment for why.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

You should be able to unit test wrapped generators regardless of their implementation details.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
