### PR TITLE
fix(core): set the default branch for a repository after running git init

### DIFF
--- a/packages/create-nx-workspace/bin/git.ts
+++ b/packages/create-nx-workspace/bin/git.ts
@@ -78,6 +78,13 @@ export async function initializeGitRepo(
     await execute(['init']);
     await execute(['checkout', '-b', defaultBase]); // Git < 2.28 doesn't support -b on git init.
   }
+  await execute([
+    'config',
+    '--local',
+    '--add',
+    'init.defaultBranch',
+    defaultBase,
+  ]);
   await execute(['add', '.']);
   if (options.commit) {
     const message = options.commit.message || 'initial commit';

--- a/packages/workspace/src/generators/ci-workflow/ci-workflow.spec.ts
+++ b/packages/workspace/src/generators/ci-workflow/ci-workflow.spec.ts
@@ -7,8 +7,11 @@ import {
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { ciWorkflowGenerator } from './ci-workflow';
+import * as defaultBase from '../../utilities/default-base';
 
 describe('lib', () => {
+  jest.spyOn(defaultBase, 'deduceDefaultBase').mockReturnValue('main');
+
   let tree: Tree;
 
   beforeEach(() => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Sorry for my late response. I was trying to resolve the issue. I encountered a problem with the ci-workflow generator. Specifically, the result returned by deduceDefaultBase does not match my expectations. My main branch is 'main', but the deduceDefaultBase return 'master' in the repository.

Below is the process I used to create the repository:

```shell
$ npx create-nx-workspace@latest -a

 >  NX   Let's create a new workspace [https://nx.dev/getting-started/intro]

√ Choose what to create                 · integrated
√ What to create in the new workspace   · apps
√ Repository name                       · create-nx-use-default-base-main
√ Which package manager to use          · npm
√ Main branch name                    · main
√ Enable distributed caching to make your CI faster · Yes
√ CI workflow file to generate?       · github
```

```shell
$ git config --get init.defaultBranch
master
```

[repo](https://github.com/cbl980226/create-nx-use-default-base-main/blob/b1fd2e019d162943a168e807c0ff6f69ade215e5/.github/workflows/ci.yml#L6)

My main branch is "main", but the ci.yml file is using the "master" branch.
I think the default branch of the repository should be set after initializing the git repository in create-nx-workspace. [Here is the link to the relevant code](https://github.com/nrwl/nx/blob/06501e68d075e3b6195902d7de0c4f840dac31c4/packages/create-nx-workspace/bin/git.ts#L81)

The command to set the default branch to "main" after initializing the git repository is `git config --local --add init.defaultBranch main`. Please let me know if this is correct. Thank you!

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

```shell
$ npx create-nx-workspace@latest --preset=apps
$ git config --get init.defaultBranch
main
```

```shell
$ npx create-nx-workspace@latest --preset=apps --defaultBase=master
$ git config --get init.defaultBranch
master
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
