### PR TITLE
feat(repo): add new flag for verbose e2e logging

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -226,7 +226,7 @@ jobs:
           NX_CACHE_DIRECTORY: 'tmp'
           NX_E2E_SKIP_BUILD_CLEANUP: 'true'
           NX_E2E_RUN_CYPRESS: 'true'
-          NX_VERBOSE_LOGGING: 'true'
+          NX_E2E_VERBOSE_LOGGING: 'true'
           NX_PERF_LOGGING: 'false'
 
       - name: Save matrix config in file

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -156,7 +156,7 @@ jobs:
           NX_CACHE_DIRECTORY: 'tmp'
           NX_E2E_SKIP_BUILD_CLEANUP: 'true'
           NX_E2E_RUN_CYPRESS: 'true'
-          NX_VERBOSE_LOGGING: 'true'
+          NX_E2E_VERBOSE_LOGGING: 'true'
           NX_PERF_LOGGING: 'false'
 
       - name: Save matrix config in file

--- a/e2e/nx-misc/src/watch.test.ts
+++ b/e2e/nx-misc/src/watch.test.ts
@@ -4,13 +4,12 @@ import {
   newProject,
   runCLI,
   uniq,
-  getPackageManagerCommand,
   tmpProjPath,
   getStrippedEnvironmentVariables,
   updateJson,
-  isVerbose,
+  isVerboseE2ERun,
 } from '@nrwl/e2e/utils';
-import { exec, spawn } from 'child_process';
+import { spawn } from 'child_process';
 
 describe('Nx Commands', () => {
   let proj1 = uniq('proj1');
@@ -116,10 +115,8 @@ async function wait(timeout = 200) {
 }
 
 async function runWatch(command: string) {
-  const output = [];
-  const pm = getPackageManagerCommand();
   const runCommand = `npx -c 'nx watch --verbose ${command}'`;
-  isVerbose() && console.log(runCommand);
+  isVerboseE2ERun() && console.log(runCommand);
   return new Promise<(timeout?: number) => Promise<string[]>>((resolve) => {
     const p = spawn(runCommand, {
       cwd: tmpProjPath(),
@@ -136,7 +133,7 @@ async function runWatch(command: string) {
     p.stdout?.on('data', (data) => {
       output += data;
       const s = data.toString().trim();
-      isVerbose() && console.log(s);
+      isVerboseE2ERun() && console.log(s);
       if (s.includes('watch process waiting')) {
         resolve(async (timeout = 6000) => {
           await wait(timeout);

--- a/e2e/storybook/src/storybook-nested.test.ts
+++ b/e2e/storybook/src/storybook-nested.test.ts
@@ -11,7 +11,6 @@ import {
   runCreateWorkspace,
   tmpProjPath,
   uniq,
-  updateFile,
   updateJson,
 } from '@nrwl/e2e/utils';
 import { writeFileSync } from 'fs';

--- a/e2e/utils/command-utils.ts
+++ b/e2e/utils/command-utils.ts
@@ -6,6 +6,7 @@ import {
   getNpmMajorVersion,
   getPublishedVersion,
   getStrippedEnvironmentVariables,
+  isVerboseE2ERun,
 } from './get-env-info';
 import { TargetConfiguration } from '@nrwl/devkit';
 import { ChildProcess, exec, execSync, ExecSyncOptions } from 'child_process';
@@ -13,7 +14,6 @@ import { join } from 'path';
 import { check as portCheck } from 'tcp-port-used';
 import * as isCI from 'is-ci';
 import { Workspaces } from '../../packages/nx/src/config/workspaces';
-import { isVerbose } from './get-env-info';
 import { updateFile } from './file-utils';
 import { logError, logInfo, logSuccess, stripConsoleColors } from './log-utils';
 
@@ -70,7 +70,7 @@ export function runCommand(
 ): string {
   const { failOnError, ...childProcessOptions } = options ?? {};
   try {
-    const r = execSync(`${command}${isVerbose() ? ' --verbose' : ''}`, {
+    const r = execSync(command, {
       cwd: tmpProjPath(),
       stdio: 'pipe',
       env: {
@@ -82,7 +82,7 @@ export function runCommand(
       ...childProcessOptions,
     });
 
-    if (isVerbose()) {
+    if (isVerboseE2ERun()) {
       output.log({
         title: `Command: ${command}`,
         bodyLines: [r as string],
@@ -279,10 +279,7 @@ export function runNgAdd(
   try {
     const pmc = getPackageManagerCommand();
     packageInstall(packageName, undefined, version);
-    const fullCommand = pmc.run(
-      `ng g ${packageName}:ng-add`,
-      `${command}${isVerbose() ? ' --verbose' : ''}` ?? ''
-    );
+    const fullCommand = pmc.run(`ng g ${packageName}:ng-add`, command ?? '');
     const result = execSync(fullCommand, {
       cwd: tmpProjPath(),
       stdio: 'pipe',
@@ -292,7 +289,7 @@ export function runNgAdd(
 
     const r = stripConsoleColors(result);
 
-    if (isVerbose()) {
+    if (isVerboseE2ERun()) {
       output.log({
         title: `Original command: ${fullCommand}`,
         bodyLines: [result as string],
@@ -321,7 +318,7 @@ export function runCLI(
   try {
     const pm = getPackageManagerCommand();
     const logs = execSync(
-      `${pm.runNx} ${command} ${isVerbose() ? ' --verbose' : ''}`,
+      `${pm.runNx} ${command} ${isVerboseE2ERun() ? ' --verbose' : ''}`,
       {
         cwd: opts.cwd || tmpProjPath(),
         env: {
@@ -335,7 +332,7 @@ export function runCLI(
       }
     );
 
-    if (isVerbose()) {
+    if (isVerboseE2ERun()) {
       output.log({
         title: `Original command: ${command}`,
         bodyLines: [logs as string],
@@ -369,9 +366,7 @@ export function runLernaCLI(
 ): string {
   try {
     const pm = getPackageManagerCommand();
-    const fullCommand = `${pm.runLerna} ${command}${
-      isVerbose() ? ' --verbose' : ''
-    }`;
+    const fullCommand = `${pm.runLerna} ${command}`;
     const logs = execSync(fullCommand, {
       cwd: opts.cwd || tmpProjPath(),
       env: {
@@ -383,7 +378,7 @@ export function runLernaCLI(
       maxBuffer: 50 * 1024 * 1024,
     });
 
-    if (isVerbose()) {
+    if (isVerboseE2ERun()) {
       output.log({
         title: `Original command: ${fullCommand}`,
         bodyLines: [logs as string],

--- a/e2e/utils/create-project-utils.ts
+++ b/e2e/utils/create-project-utils.ts
@@ -12,6 +12,7 @@ import {
   getNpmMajorVersion,
   getPublishedVersion,
   getSelectedPackageManager,
+  isVerbose,
 } from './get-env-info';
 import * as isCI from 'is-ci';
 
@@ -19,7 +20,6 @@ import { angularCliVersion as defaultAngularCliVersion } from '@nrwl/workspace/s
 import { dump } from '@zkochan/js-yaml';
 import { execSync, ExecSyncOptions } from 'child_process';
 
-import { isVerbose } from './get-env-info';
 import { logError, logInfo } from './log-utils';
 import {
   getPackageManagerCommand,
@@ -92,7 +92,7 @@ export function newProject({
     copySync(`${tmpBackupProjPath()}`, `${tmpProjPath()}`);
 
     if (isVerbose()) {
-      logInfo(`NX`, `E2E test is creating a project: ${tmpProjPath()}`);
+      logInfo(`NX`, `E2E created a project: ${tmpProjPath()}`);
     }
     return projScope;
   } catch (e) {

--- a/e2e/utils/get-env-info.ts
+++ b/e2e/utils/get-env-info.ts
@@ -58,6 +58,10 @@ export function isVerbose() {
   );
 }
 
+export function isVerboseE2ERun() {
+  return process.env.NX_E2E_VERBOSE_LOGGING === 'true' || isVerbose();
+}
+
 export const e2eCwd = `${e2eRoot}/nx`;
 
 export function getSelectedPackageManager(): 'npm' | 'yarn' | 'pnpm' {

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -40,12 +40,14 @@ export function expectTestsPass(v: { stdout: string; stderr: string }) {
   expect(v.stderr).not.toContain('fail');
 }
 
+// TODO(meeroslav): This is test specific, it should not be in the utils
 export function expectNoAngularDevkit() {
   const { list } = getPackageManagerCommand();
   const result = runCommand(`${list} @angular-devkit/core`);
   expect(result).not.toContain('@angular-devkit/core');
 }
 
+// TODO(meeroslav): This is test specific, it should not be in the utils
 export function expectNoTsJestInJestConfig(appName: string) {
   const jestConfig = readFile(
     joinPathFragments('apps', appName, 'jest.config.ts')

--- a/e2e/workspace-create-npm/src/create-nx-workspace-npm.test.ts
+++ b/e2e/workspace-create-npm/src/create-nx-workspace-npm.test.ts
@@ -1,14 +1,11 @@
-import { forEach } from '@angular-devkit/schematics';
 import {
   checkFilesExist,
   cleanupProject,
   packageInstall,
   readJson,
-  removeFile,
   runCLI,
   runCreateWorkspace,
   uniq,
-  updateJson,
 } from '@nrwl/e2e/utils';
 
 describe('create-nx-workspace --preset=npm', () => {


### PR DESCRIPTION
Existing NX_VERBOSE_LOGGING is too broad for E2E tests and creates a lot of noise in the output.
The new NX_E2E_VERBOSE_LOGGING reports just relevant logs.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
