### PR TITLE
fix(node): add default build configuration

### DIFF
--- a/e2e/node/src/node-esbuild.test.ts
+++ b/e2e/node/src/node-esbuild.test.ts
@@ -27,7 +27,6 @@ describe('Node Applications + esbuild', () => {
     await runCLIAsync(`build ${app}`);
 
     checkFilesExist(`dist/apps/${app}/main.js`);
-    checkFilesExist(`dist/apps/${app}/main.js.map`);
     const result = execSync(`node dist/apps/${app}/main.js`, {
       cwd: tmpProjPath(),
     }).toString();

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -49,6 +49,7 @@ describe('app', () => {
           build: {
             executor: '@nrwl/webpack:webpack',
             outputs: ['{options.outputPath}'],
+            defaultConfiguration: 'production',
             options: {
               target: 'node',
               compiler: 'tsc',
@@ -60,19 +61,20 @@ describe('app', () => {
               assets: ['my-node-app/src/assets'],
             },
             configurations: {
-              production: {
-                optimization: true,
-                extractLicenses: true,
-                inspect: false,
-              },
+              development: {},
+              production: {},
             },
           },
           serve: {
             executor: '@nrwl/js:node',
+            defaultConfiguration: 'development',
             options: {
               buildTarget: 'my-node-app:build',
             },
             configurations: {
+              development: {
+                buildTarget: 'my-node-app:build:development',
+              },
               production: {
                 buildTarget: 'my-node-app:build:production',
               },

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -57,6 +57,7 @@ function getWebpackBuildConfig(
   return {
     executor: `@nrwl/webpack:webpack`,
     outputs: ['{options.outputPath}'],
+    defaultConfiguration: 'production',
     options: {
       target: 'node',
       compiler: 'tsc',
@@ -77,11 +78,9 @@ function getWebpackBuildConfig(
       ),
     },
     configurations: {
+      development: {},
       production: {
         ...(options.docker && { generateLockfile: true }),
-        optimization: true,
-        extractLicenses: true,
-        inspect: false,
       },
     },
   };
@@ -94,6 +93,7 @@ function getEsBuildConfig(
   return {
     executor: '@nrwl/esbuild:esbuild',
     outputs: ['{options.outputPath}'],
+    defaultConfiguration: 'production',
     options: {
       platform: 'node',
       outputPath: joinPathFragments(
@@ -116,9 +116,14 @@ function getEsBuildConfig(
       },
     },
     configurations: {
+      development: {},
       production: {
         ...(options.docker && { generateLockfile: true }),
-        esbuildOptions: { sourcemap: false },
+        esbuildOptions: {
+          sourcemap: false,
+          // Generate CJS files as .js so imports can be './foo' rather than './foo.cjs'.
+          outExtension: { '.js': '.js' },
+        },
       },
     },
   };
@@ -127,10 +132,14 @@ function getEsBuildConfig(
 function getServeConfig(options: NormalizedSchema): TargetConfiguration {
   return {
     executor: '@nrwl/js:node',
+    defaultConfiguration: 'development',
     options: {
       buildTarget: `${options.name}:build`,
     },
     configurations: {
+      development: {
+        buildTarget: `${options.name}:build:development`,
+      },
       production: {
         buildTarget: `${options.name}:build:production`,
       },


### PR DESCRIPTION
This PR adds a `development` config for Node build and serve targets, and fixes an issue where `esbuildOptions` in prod is being overridden to generate `.cjs` instead of `.js` files.



## Current Behavior

`npx nx build --prod` generates `.cjs` files

## Expected Behavior
`npx nx build --prod` generates `.js` files, and is the same as `npx nx build`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
