### PR TITLE
fix(core): negative implicit dependencies should exclude statically detected dependencies

### DIFF
--- a/packages/nx/src/project-graph/build-nodes/workspace-projects.ts
+++ b/packages/nx/src/project-graph/build-nodes/workspace-projects.ts
@@ -168,5 +168,11 @@ export function normalizeImplicitDependencies(
     projectNames,
     projectsSet
   );
-  return matches.filter((x) => x !== source);
+  return (
+    matches
+      .filter((x) => x !== source)
+      // implicit dependencies that start with ! should hang around, to be processed by
+      // implicit-project-dependencies.ts after explicit deps are added to graph.
+      .concat(implicitDependencies.filter((x) => x.startsWith('!')))
+  );
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Excluded implicit dependencies can only remove deps that are implicit, which is a breaking change from prior behavior

## Expected Behavior
Excluded implicit dependencies are left in the array s.t. they can later be used to remove static deps, the prior behavior

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14860
Fixes #15605
