### PR TITLE
fix(core): refactor the logging logic in e2e tests

### DIFF
--- a/e2e/make-angular-cli-faster/src/make-angular-cli-faster.test.ts
+++ b/e2e/make-angular-cli-faster/src/make-angular-cli-faster.test.ts
@@ -35,7 +35,7 @@ describe('make-angular-cli-faster', () => {
           cwd: tmpProjPath(),
           env: process.env,
           encoding: 'utf-8',
-          stdio: ['pipe', 'pipe', 'pipe'],
+          stdio: 'pipe',
         }
       )
     ).not.toThrow();

--- a/e2e/nx-init/src/nx-init-nest.test.ts
+++ b/e2e/nx-init/src/nx-init-nest.test.ts
@@ -27,7 +27,7 @@ describe('nx init (for NestCLI)', () => {
         cwd: e2eCwd,
         encoding: 'utf-8',
         env: process.env,
-        stdio: ['pipe', 'pipe', 'pipe'],
+        stdio: 'pipe',
       }
     );
 
@@ -39,7 +39,7 @@ describe('nx init (for NestCLI)', () => {
         cwd: projectRoot,
         encoding: 'utf-8',
         env: process.env,
-        stdio: ['pipe', 'pipe', 'pipe'],
+        stdio: 'pipe',
       }
     );
 

--- a/e2e/utils/create-project-utils.ts
+++ b/e2e/utils/create-project-utils.ts
@@ -27,6 +27,7 @@ import {
   RunCmdOpts,
   runCommand,
 } from './command-utils';
+import { output } from '@nrwl/devkit';
 
 let projName: string;
 
@@ -90,7 +91,7 @@ export function newProject({
     projName = name;
     copySync(`${tmpBackupProjPath()}`, `${tmpProjPath()}`);
 
-    if (process.env.NX_VERBOSE_LOGGING == 'true') {
+    if (isVerbose()) {
       logInfo(`NX`, `E2E test is creating a project: ${tmpProjPath()}`);
     }
     return projScope;
@@ -169,13 +170,27 @@ export function runCreateWorkspace(
     command += ` ${extraArgs}`;
   }
 
-  const create = execSync(command, {
-    cwd,
-    stdio: isVerbose() ? 'inherit' : 'pipe',
-    env: { CI: 'true', ...process.env },
-    encoding: 'utf-8',
-  });
-  return create ? create.toString() : '';
+  try {
+    const create = execSync(`${command}${isVerbose() ? ' --verbose' : ''}`, {
+      cwd,
+      stdio: 'pipe',
+      env: { CI: 'true', ...process.env },
+      encoding: 'utf-8',
+    });
+
+    if (isVerbose()) {
+      output.log({
+        title: `Command: ${command}`,
+        bodyLines: [create as string],
+        color: 'green',
+      });
+    }
+
+    return create;
+  } catch (e) {
+    logError(`Original command: ${command}`, `${e.stdout}\n\n${e.stderr}`);
+    throw e;
+  }
 }
 
 export function runCreatePlugin(
@@ -212,13 +227,27 @@ export function runCreatePlugin(
     command += ` ${extraArgs}`;
   }
 
-  const create = execSync(command, {
-    cwd: e2eCwd,
-    stdio: ['pipe', 'pipe', 'pipe'],
-    env: process.env,
-    encoding: 'utf-8',
-  });
-  return create ? create.toString() : '';
+  try {
+    const create = execSync(`${command}${isVerbose() ? ' --verbose' : ''}`, {
+      cwd: e2eCwd,
+      stdio: 'pipe',
+      env: process.env,
+      encoding: 'utf-8',
+    });
+
+    if (isVerbose()) {
+      output.log({
+        title: `Command: ${command}`,
+        bodyLines: [create as string],
+        color: 'green',
+      });
+    }
+
+    return create;
+  } catch (e) {
+    logError(`Original command: ${command}`, `${e.stdout}\n\n${e.stderr}`);
+    throw e;
+  }
 }
 
 export function packageInstall(
@@ -233,16 +262,37 @@ export function packageInstall(
     .split(' ')
     .map((pgk) => `${pgk}@${version}`)
     .join(' ');
-  const install = execSync(
-    `${mode === 'dev' ? pm.addDev : pm.addProd} ${pkgsWithVersions}`,
-    {
-      cwd,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      env: process.env,
-      encoding: 'utf-8',
+
+  const command = `${
+    mode === 'dev' ? pm.addDev : pm.addProd
+  } ${pkgsWithVersions}${isVerbose() ? ' --verbose' : ''}`;
+
+  try {
+    const install = execSync(
+      `${mode === 'dev' ? pm.addDev : pm.addProd} ${pkgsWithVersions}${
+        isVerbose() ? ' --verbose' : ''
+      }`,
+      {
+        cwd,
+        stdio: 'pipe',
+        env: process.env,
+        encoding: 'utf-8',
+      }
+    );
+
+    if (isVerbose()) {
+      output.log({
+        title: `Command: ${command}`,
+        bodyLines: [install as string],
+        color: 'green',
+      });
     }
-  );
-  return install ? install.toString() : '';
+
+    return install;
+  } catch (e) {
+    logError(`Original command: ${command}`, `${e.stdout}\n\n${e.stderr}`);
+    throw e;
+  }
 }
 
 export function runNgNew(
@@ -259,10 +309,10 @@ export function runNgNew(
 
   return execSync(command, {
     cwd: e2eCwd,
-    stdio: ['pipe', 'pipe', 'pipe'],
+    stdio: isVerbose() ? 'inherit' : 'pipe',
     env: process.env,
     encoding: 'utf-8',
-  }).toString();
+  });
 }
 
 export function newLernaWorkspace({
@@ -290,7 +340,7 @@ export function newLernaWorkspace({
       );
     }
 
-    if (process.env.NX_VERBOSE_LOGGING == 'true') {
+    if (isVerbose()) {
       logInfo(`NX`, `E2E test has created a lerna workspace: ${tmpProjPath()}`);
     }
 

--- a/e2e/utils/get-env-info.ts
+++ b/e2e/utils/get-env-info.ts
@@ -70,7 +70,9 @@ export function getNpmMajorVersion(): string {
 }
 
 export function getLatestLernaVersion(): string {
-  const lernaVersion = execSync(`npm view lerna version`).toString().trim();
+  const lernaVersion = execSync(`npm view lerna version`, {
+    encoding: 'utf-8',
+  }).trim();
   return lernaVersion;
 }
 

--- a/e2e/utils/log-utils.ts
+++ b/e2e/utils/log-utils.ts
@@ -40,7 +40,7 @@ export function logSuccess(title: string, body?: string) {
  * @returns
  */
 export function stripConsoleColors(log: string): string {
-  return log.replace(
+  return log?.replace(
     /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g,
     ''
   );


### PR DESCRIPTION
* change `['pipe', 'pipe', 'pipe']` to `pipe`
* enhance the way `isVerbose()` is used
* change look of output if `isVerbose()`
* make sure error is always caught and logged
* remove unnecessary `.toString()` since we're using `encoding` to all `execSync` commands
* add optional chaining where needed


## Comments

Output, if error, is always displayed. 

The thing is, however, that in the test summary, if there was an error, still the stack trace of `error on execSync` is displayed. We can take a look at whether this is configurable or not at a later PR.