### PR TITLE
cleanup(core): inline cra migration logic into nx init

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -124,6 +124,9 @@
 /packages/nx/src/lock-file @meeroslav @FrozenPandaz
 /packages/nx/src/nx-init/angular/** @Coly010 @leosvelperez @FrozenPandaz
 /e2e/nx-init/src/nx-init-angular.test.ts @Coly010 @leosvelperez
+/packages/nx/src/nx-init/react/** @jaysoo @xiongemi @mandarini
+/e2e/nx-init/src/nx-init-react.test.ts @jaysoo @xiongemi @mandarini @ndcunningham
+/e2e/nx-init/src/files/cra/** @jaysoo @xiongemi @mandarini @ndcunningham
 /e2e/nx*/** @FrozenPandaz @AgentEnder @vsavkin
 /packages/workspace/** @FrozenPandaz @AgentEnder @vsavkin
 /e2e/workspace-create/** @FrozenPandaz @AgentEnder @vsavkin

--- a/e2e/nx-init/src/files/cra/package.json.txt
+++ b/e2e/nx-init/src/files/cra/package.json.txt
@@ -1,0 +1,38 @@
+{
+  "name": "<%= appName %>",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@testing-library/jest-dom": "5.16.5",
+    "@testing-library/react": "13.4.0",
+    "@testing-library/user-event": "13.5.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1",
+    "web-vitals": "2.1.4"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "eslintConfig": {
+    "extends": [
+      "react-app",
+      "react-app/jest"
+    ]
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
+}

--- a/e2e/nx-init/src/files/cra/public/index.html.txt
+++ b/e2e/nx-init/src/files/cra/public/index.html.txt
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<body>
+  <div id="root"></div>
+</body>
+
+</html>

--- a/e2e/nx-init/src/files/cra/src/App.css.txt
+++ b/e2e/nx-init/src/files/cra/src/App.css.txt
@@ -1,0 +1,4 @@
+.App {
+  text-align: center;
+}
+

--- a/e2e/nx-init/src/files/cra/src/App.js.txt
+++ b/e2e/nx-init/src/files/cra/src/App.js.txt
@@ -1,0 +1,11 @@
+import './App.css';
+
+function App() {
+  return (
+    <div className="App">
+      Hello World!
+    </div>
+  );
+}
+
+export default App;

--- a/e2e/nx-init/src/files/cra/src/App.test.js.txt
+++ b/e2e/nx-init/src/files/cra/src/App.test.js.txt
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import App from './App';
+
+test('renders learn react link', () => {
+  render(<App />);
+  const linkElement = screen.getByText(/Hello/);
+  expect(linkElement).toBeInTheDocument();
+});

--- a/e2e/nx-init/src/files/cra/src/index.css.txt
+++ b/e2e/nx-init/src/files/cra/src/index.css.txt
@@ -1,0 +1,5 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+}
+

--- a/e2e/nx-init/src/files/cra/src/index.js.txt
+++ b/e2e/nx-init/src/files/cra/src/index.js.txt
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+import './index.css';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);
+

--- a/e2e/nx-init/src/files/cra/src/setupTests.js.txt
+++ b/e2e/nx-init/src/files/cra/src/setupTests.js.txt
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/e2e/nx-init/src/nx-init-npm-repo.test.ts
+++ b/e2e/nx-init/src/nx-init-npm-repo.test.ts
@@ -10,7 +10,7 @@ import {
   updateFile,
 } from '@nrwl/e2e/utils';
 
-describe('nx init', () => {
+describe('nx init (NPM repo)', () => {
   const pmc = getPackageManagerCommand({
     packageManager: getSelectedPackageManager(),
   });

--- a/e2e/nx-init/src/nx-init-react.test.ts
+++ b/e2e/nx-init/src/nx-init-react.test.ts
@@ -1,0 +1,200 @@
+import {
+  checkFilesDoNotExist,
+  checkFilesExist,
+  getPackageManagerCommand,
+  getPublishedVersion,
+  getSelectedPackageManager,
+  readFile,
+  readJson,
+  runCLI,
+  runCommand,
+  updateFile,
+} from '@nrwl/e2e/utils';
+import { copySync, renameSync } from 'fs-extra';
+import { sync as globSync } from 'glob';
+import { join } from 'path';
+import {
+  createNonNxProjectDirectory,
+  tmpProjPath,
+  updateJson,
+} from '../../utils';
+
+const pmc = getPackageManagerCommand({
+  packageManager: getSelectedPackageManager(),
+});
+
+describe('nx init (for React)', () => {
+  it('should convert to an integrated workspace with craco (webpack)', () => {
+    const appName = 'my-app';
+    createReactApp(appName);
+
+    const craToNxOutput = runCommand(
+      `${
+        pmc.runUninstalledPackage
+      } nx@${getPublishedVersion()} init --nxCloud=false --integrated --vite=false`
+    );
+
+    expect(craToNxOutput).toContain('🎉 Done!');
+
+    const packageJson = readJson('package.json');
+    expect(packageJson.devDependencies['@nrwl/jest']).toBeDefined();
+    expect(packageJson.devDependencies['@nrwl/vite']).toBeUndefined();
+    expect(packageJson.devDependencies['@nrwl/webpack']).toBeDefined();
+
+    runCLI(`build ${appName}`);
+    checkFilesExist(`dist/apps/${appName}/index.html`);
+  });
+
+  it('should convert to an integrated workspace with Vite', () => {
+    // TODO investigate why this is broken
+    const originalPM = process.env.SELECTED_PM;
+    process.env.SELECTED_PM = originalPM === 'pnpm' ? 'yarn' : originalPM;
+
+    const appName = 'my-app';
+    createReactApp(appName);
+
+    const craToNxOutput = runCommand(
+      `${
+        pmc.runUninstalledPackage
+      } nx@${getPublishedVersion()} init --nxCloud=false --integrated`
+    );
+
+    expect(craToNxOutput).toContain('🎉 Done!');
+
+    const packageJson = readJson('package.json');
+    expect(packageJson.devDependencies['@nrwl/jest']).toBeUndefined();
+    expect(packageJson.devDependencies['@nrwl/vite']).toBeDefined();
+    expect(packageJson.devDependencies['@nrwl/webpack']).toBeUndefined();
+
+    const viteConfig = readFile(`apps/${appName}/vite.config.js`);
+    expect(viteConfig).toContain('port: 4200'); // default port
+
+    runCLI(`build ${appName}`);
+    checkFilesExist(`dist/apps/${appName}/index.html`);
+
+    const unitTestsOutput = runCLI(`test ${appName}`);
+    expect(unitTestsOutput).toContain('Successfully ran target test');
+    process.env.SELECTED_PM = originalPM;
+  });
+
+  it('should convert to an integrated workspace with Vite with custom port', () => {
+    // TODO investigate why this is broken
+    const originalPM = process.env.SELECTED_PM;
+    process.env.SELECTED_PM = originalPM === 'pnpm' ? 'yarn' : originalPM;
+    const appName = 'my-app';
+    createReactApp(appName);
+    updateFile(`.env`, `NOT_THE_PORT=8000\nPORT=3000\nSOMETHING_ELSE=whatever`);
+
+    runCommand(
+      `${
+        pmc.runUninstalledPackage
+      } nx@${getPublishedVersion()} init --nxCloud=false --force --integrated`
+    );
+
+    const viteConfig = readFile(`apps/${appName}/vite.config.js`);
+    expect(viteConfig).toContain('port: 3000');
+
+    const unitTestsOutput = runCLI(`test ${appName}`);
+    expect(unitTestsOutput).toContain('Successfully ran target test');
+    process.env.SELECTED_PM = originalPM;
+  });
+
+  it('should convert to a standalone workspace with craco (webpack)', () => {
+    const appName = 'my-app';
+    createReactApp(appName);
+
+    const craToNxOutput = runCommand(
+      `${
+        pmc.runUninstalledPackage
+      } nx@${getPublishedVersion()} init --nxCloud=false --vite=false`
+    );
+
+    expect(craToNxOutput).toContain('🎉 Done!');
+
+    runCLI(`build ${appName}`);
+    checkFilesExist(`dist/${appName}/index.html`);
+  });
+
+  it('should convert to an standalone workspace with Vite', () => {
+    const appName = 'my-app';
+    createReactApp(appName);
+
+    const craToNxOutput = runCommand(
+      `${
+        pmc.runUninstalledPackage
+      } nx@${getPublishedVersion()} init --nxCloud=false --vite`
+    );
+
+    expect(craToNxOutput).toContain('🎉 Done!');
+
+    checkFilesDoNotExist(
+      'libs/.gitkeep',
+      'tools/tsconfig.tools.json',
+      'babel.config.json',
+      'jest.preset.js',
+      'jest.config.ts'
+    );
+
+    const packageJson = readJson('package.json');
+    expect(packageJson.devDependencies['@nrwl/jest']).toBeUndefined();
+
+    const viteConfig = readFile(`vite.config.js`);
+    expect(viteConfig).toContain('port: 4200'); // default port
+
+    runCLI(`build ${appName}`);
+    checkFilesExist(`dist/${appName}/index.html`);
+
+    const unitTestsOutput = runCLI(`test ${appName}`);
+    expect(unitTestsOutput).toContain('Successfully ran target test');
+  });
+});
+
+function createReactApp(appName: string) {
+  const pmc = getPackageManagerCommand({
+    packageManager: getSelectedPackageManager(),
+  });
+
+  createNonNxProjectDirectory();
+  const projPath = tmpProjPath();
+  copySync(join(__dirname, 'files/cra'), projPath);
+  const filesToRename = globSync(join(projPath, '**/*.txt'));
+  filesToRename.forEach((f) => {
+    renameSync(f, f.split('.txt')[0]);
+  });
+  updateFile('.gitignore', 'node_modules');
+  updateJson('package.json', (_) => ({
+    name: appName,
+    version: '0.1.0',
+    private: true,
+    dependencies: {
+      '@testing-library/jest-dom': '5.16.5',
+      '@testing-library/react': '13.4.0',
+      '@testing-library/user-event': '13.5.0',
+      react: '^18.2.0',
+      'react-dom': '^18.2.0',
+      'react-scripts': '5.0.1',
+      'web-vitals': '2.1.4',
+    },
+    scripts: {
+      start: 'react-scripts start',
+      build: 'react-scripts build',
+      test: 'react-scripts test',
+      eject: 'react-scripts eject',
+    },
+    eslintConfig: {
+      extends: ['react-app', 'react-app/jest'],
+    },
+    browserslist: {
+      production: ['>0.2%', 'not dead', 'not op_mini all'],
+      development: [
+        'last 1 chrome version',
+        'last 1 firefox version',
+        'last 1 safari version',
+      ],
+    },
+  }));
+  runCommand(pmc.install);
+  runCommand('git init');
+  runCommand('git add .');
+  runCommand('git commit -m "Init"');
+}

--- a/packages/nx/src/command-line/init.ts
+++ b/packages/nx/src/command-line/init.ts
@@ -1,16 +1,17 @@
 import { execSync } from 'child_process';
+import { prompt } from 'enquirer';
 import { existsSync } from 'fs';
 import { prerelease } from 'semver';
 import * as parser from 'yargs-parser';
-import { prompt } from 'enquirer';
 import { addNxToMonorepo } from '../nx-init/add-nx-to-monorepo';
 import { addNxToNest } from '../nx-init/add-nx-to-nest';
 import { addNxToNpmRepo } from '../nx-init/add-nx-to-npm-repo';
 import { addNxToAngularCliRepo } from '../nx-init/angular';
 import { generateDotNxSetup } from '../nx-init/dot-nx/add-nx-scripts';
+import { addNxToCraRepo } from '../nx-init/react';
+import { runNxSync } from '../utils/child-process';
 import { directoryExists, readJsonFile } from '../utils/fileutils';
 import { PackageJson } from '../utils/package-json';
-import { runNxSync } from '../utils/child-process';
 
 export async function initHandler() {
   const args = process.argv.slice(2).join(' ');
@@ -37,10 +38,7 @@ export async function initHandler() {
     if (existsSync('angular.json')) {
       await addNxToAngularCliRepo();
     } else if (isCRA(packageJson)) {
-      // TODO(jack): remove cra-to-nx
-      execSync(`npx --yes cra-to-nx@${version} ${args}`, {
-        stdio: [0, 1, 2],
-      });
+      await addNxToCraRepo();
     } else if (isNestCLI(packageJson)) {
       await addNxToNest(packageJson);
     } else if (isMonorepo(packageJson)) {

--- a/packages/nx/src/nx-init/react/add-craco-commands-to-package-scripts.ts
+++ b/packages/nx/src/nx-init/react/add-craco-commands-to-package-scripts.ts
@@ -1,0 +1,22 @@
+import { readJsonFile, writeJsonFile } from '../../utils/fileutils';
+
+export function addCracoCommandsToPackageScripts(
+  appName: string,
+  isStandalone: boolean
+) {
+  const packageJsonPath = isStandalone
+    ? 'package.json'
+    : `apps/${appName}/package.json`;
+  const distPath = isStandalone
+    ? `dist/${appName}`
+    : `../../dist/apps/${appName}`;
+  const packageJson = readJsonFile(packageJsonPath);
+  packageJson.scripts = {
+    ...packageJson.scripts,
+    start: 'nx exec -- craco start',
+    serve: 'npm start',
+    build: `cross-env BUILD_PATH=${distPath} nx exec -- craco build`,
+    test: 'nx exec -- craco test',
+  };
+  writeJsonFile(packageJsonPath, packageJson);
+}

--- a/packages/nx/src/nx-init/react/add-vite-commands-to-package-scripts.ts
+++ b/packages/nx/src/nx-init/react/add-vite-commands-to-package-scripts.ts
@@ -1,0 +1,19 @@
+import { readJsonFile, writeJsonFile } from '../../utils/fileutils';
+
+export function addViteCommandsToPackageScripts(
+  appName: string,
+  isStandalone: boolean
+) {
+  const packageJsonPath = isStandalone
+    ? 'package.json'
+    : `apps/${appName}/package.json`;
+  const packageJson = readJsonFile(packageJsonPath);
+  packageJson.scripts = {
+    ...packageJson.scripts,
+    start: 'nx exec -- vite',
+    serve: 'nx exec -- vite',
+    build: `nx exec -- vite build`,
+    test: 'nx exec -- vitest',
+  };
+  writeJsonFile(packageJsonPath, packageJson, { spaces: 2 });
+}

--- a/packages/nx/src/nx-init/react/check-for-custom-webpack-setup.ts
+++ b/packages/nx/src/nx-init/react/check-for-custom-webpack-setup.ts
@@ -1,0 +1,17 @@
+import { readJsonFile } from '../../utils/fileutils';
+
+export function checkForCustomWebpackSetup() {
+  const packageJson = readJsonFile('package.json');
+  const combinedDeps = {
+    ...packageJson.dependencies,
+    ...packageJson.devDependencies,
+  };
+  ['react-app-rewired', '@craco/craco'].forEach((pkg) => {
+    if (combinedDeps[pkg]) {
+      console.log(
+        `Skipping migration due to custom webpack setup. Found "${pkg}" usage. Use --force to continue anyway.`
+      );
+      process.exit(1);
+    }
+  });
+}

--- a/packages/nx/src/nx-init/react/check-for-uncommitted-changes.ts
+++ b/packages/nx/src/nx-init/react/check-for-uncommitted-changes.ts
@@ -1,0 +1,13 @@
+import { execSync } from 'child_process';
+
+export function checkForUncommittedChanges() {
+  const gitResult = execSync(`git status --porcelain`);
+  if (gitResult.length > 0) {
+    console.log('❗️ Careful!');
+    console.log('You have uncommited changes in your repository.');
+    console.log('');
+    console.log(gitResult.toString());
+    console.log('Please commit your changes before running the migrator!');
+    process.exit(1);
+  }
+}

--- a/packages/nx/src/nx-init/react/clean-up-files.ts
+++ b/packages/nx/src/nx-init/react/clean-up-files.ts
@@ -1,0 +1,33 @@
+import { removeSync } from 'fs-extra';
+import { readJsonFile, writeJsonFile } from '../../utils/fileutils';
+
+export function cleanUpFiles(appName: string, isStandalone: boolean) {
+  // Delete targets from project since we delegate to npm scripts.
+  const projectJsonPath = isStandalone
+    ? 'project.json'
+    : `apps/${appName}/project.json`;
+  const json = readJsonFile(projectJsonPath);
+  delete json.targets;
+  if (isStandalone) {
+    if (json.sourceRoot) {
+      json.sourceRoot = json.sourceRoot.replace(`apps/${appName}/`, '');
+    }
+    if (json['$schema']) {
+      json['$schema'] = json['$schema'].replace(
+        '../../node_modules',
+        'node_modules'
+      );
+    }
+  }
+  writeJsonFile(projectJsonPath, json);
+
+  removeSync('temp-workspace');
+
+  if (isStandalone) {
+    removeSync('babel.config.json');
+    removeSync('jest.preset.js');
+    removeSync('jest.config.ts');
+    removeSync('libs');
+    removeSync('tools');
+  }
+}

--- a/packages/nx/src/nx-init/react/index.ts
+++ b/packages/nx/src/nx-init/react/index.ts
@@ -1,0 +1,321 @@
+import { execSync } from 'child_process';
+import { copySync, moveSync, readdirSync, removeSync } from 'fs-extra';
+import { join } from 'path';
+import * as yargsParser from 'yargs-parser';
+import { fileExists, readJsonFile } from '../../utils/fileutils';
+import { output } from '../../utils/output';
+import {
+  PackageManagerCommands,
+  detectPackageManager,
+  getPackageManagerCommand,
+} from '../../utils/package-manager';
+import { checkForCustomWebpackSetup } from './check-for-custom-webpack-setup';
+import { checkForUncommittedChanges } from './check-for-uncommitted-changes';
+import { cleanUpFiles } from './clean-up-files';
+import { readNameFromPackageJson } from './read-name-from-package-json';
+import { renameJsToJsx } from './rename-js-to-jsx';
+import { setupE2eProject } from './setup-e2e-project';
+import { setupTsConfig } from './tsconfig-setup';
+import { writeCracoConfig } from './write-craco-config';
+import { writeViteConfig } from './write-vite-config';
+import { writeViteIndexHtml } from './write-vite-index-html';
+
+export interface Options {
+  force: boolean;
+  e2e: boolean;
+  nxCloud: boolean;
+  vite: boolean;
+  integrated: boolean;
+}
+
+interface NormalizedOptions extends Options {
+  packageManager: string;
+  pmc: PackageManagerCommands;
+  appIsJs: boolean;
+  reactAppName: string;
+  isCRA5: boolean;
+  npxYesFlagNeeded: boolean;
+  isVite: boolean;
+  isStandalone: boolean;
+}
+
+const parsedArgs = yargsParser(process.argv, {
+  boolean: ['force', 'e2e', 'nxCloud', 'vite', 'integrated'],
+  default: {
+    nxCloud: true,
+    vite: true,
+  },
+  configuration: {
+    'strip-dashed': true,
+  },
+});
+
+export async function addNxToCraRepo() {
+  if (!parsedArgs.force) {
+    checkForUncommittedChanges();
+    checkForCustomWebpackSetup();
+  }
+
+  output.log({ title: '✨ Nx initialization' });
+
+  const normalizedOptions = normalizeOptions(parsedArgs as unknown as Options);
+  await reorgnizeWorkspaceStructure(normalizedOptions);
+}
+
+function addDependencies(pmc: PackageManagerCommands, ...deps: string[]) {
+  const depsArg = deps.join(' ');
+  output.log({ title: `📦 Adding dependencies: ${depsArg}` });
+  execSync(`${pmc.addDev} ${depsArg}`, { stdio: [0, 1, 2] });
+}
+
+function normalizeOptions(options: Options): NormalizedOptions {
+  const packageManager = detectPackageManager();
+  const pmc = getPackageManagerCommand(packageManager);
+
+  const appIsJs = !fileExists(`tsconfig.json`);
+
+  const reactAppName = readNameFromPackageJson();
+  const packageJson = readJsonFile('package.json');
+  const deps = {
+    ...packageJson.dependencies,
+    ...packageJson.devDependencies,
+  };
+  const isCRA5 = /^[^~]?5/.test(deps['react-scripts']);
+  const npmVersion = execSync('npm -v').toString();
+  // Should remove this check 04/2023 once Node 14 & npm 6 reach EOL
+  const npxYesFlagNeeded = !npmVersion.startsWith('6'); // npm 7 added -y flag to npx
+  const isVite = options.vite;
+  const isStandalone = !options.integrated;
+
+  return {
+    ...options,
+    packageManager,
+    pmc,
+    appIsJs,
+    reactAppName,
+    isCRA5,
+    npxYesFlagNeeded,
+    isVite,
+    isStandalone,
+  };
+}
+
+async function reorgnizeWorkspaceStructure(options: NormalizedOptions) {
+  createTempWorkspace(options);
+
+  moveFilesToTempWorkspace(options);
+
+  await addBundler(options);
+
+  output.log({ title: '🧶  Updating .gitignore file' });
+
+  execSync(`echo "node_modules" >> .gitignore`, { stdio: [0, 1, 2] });
+  execSync(`echo "dist" >> .gitignore`, { stdio: [0, 1, 2] });
+
+  process.chdir('..');
+
+  copyFromTempWorkspaceToRoot();
+
+  cleanUpUnusedFilesAndAddConfigFiles(options);
+
+  output.log({ title: '🙂 Please be patient, one final step remaining!' });
+
+  output.log({
+    title: '🧶  Adding npm packages to your new Nx workspace',
+  });
+
+  addDependencies(
+    options.pmc,
+    '@testing-library/jest-dom',
+    'eslint-config-react-app',
+    'web-vitals',
+    'jest-watch-typeahead'
+  );
+
+  if (options.isVite) {
+    addDependencies(options.pmc, 'vite', 'vitest', '@vitejs/plugin-react');
+  } else {
+    addDependencies(
+      options.pmc,
+      '@craco/craco',
+      'cross-env',
+      'react-scripts',
+      'tsconfig-paths-webpack-plugin'
+    );
+  }
+
+  output.log({ title: '🎉 Done!' });
+  output.note({
+    title: 'First time using Nx? Check out this interactive Nx tutorial.',
+    bodyLines: [
+      `https://nx.dev/react-tutorial/1-code-generation`,
+      ` `,
+      `Prefer watching videos? Check out this free Nx course on Egghead.io.`,
+      `https://egghead.io/playlists/scale-react-development-with-nx-4038`,
+    ],
+  });
+
+  if (options.isVite) {
+    const indexPath = options.isStandalone
+      ? 'index.html'
+      : join('apps', options.reactAppName, 'index.html');
+    const oldIndexPath = options.isStandalone
+      ? join('public', 'index.html')
+      : join('apps', options.reactAppName, 'public', 'index.html');
+    output.note({
+      title: `A new ${indexPath} has been created. Compare it to the previous ${oldIndexPath} file and make any changes needed, then delete the previous file.`,
+    });
+  }
+
+  output.note({
+    title: 'Or, you can try the commands!',
+    bodyLines: [
+      options.integrated ? `npx nx serve ${options.reactAppName}` : 'npm start',
+      options.integrated
+        ? `npx nx build ${options.reactAppName}`
+        : 'npm run build',
+      options.integrated ? `npx nx test ${options.reactAppName}` : `npm test`,
+      ` `,
+      `https://nx.dev/getting-started/intro#10-try-the-commands`,
+    ],
+  });
+}
+
+function createTempWorkspace(options: NormalizedOptions) {
+  execSync(
+    `npx ${
+      options.npxYesFlagNeeded ? '-y' : ''
+    } create-nx-workspace@latest temp-workspace --appName=${
+      options.reactAppName
+    } --preset=react-monorepo --style=css --bundler=${
+      options.isVite ? 'vite' : 'webpack'
+    } --packageManager=${options.packageManager} ${
+      options.nxCloud ? '--nxCloud' : '--nxCloud=false'
+    }`,
+    { stdio: [0, 1, 2] }
+  );
+
+  output.log({ title: '👋 Welcome to Nx!' });
+
+  output.log({ title: '🧹 Clearing unused files' });
+
+  copySync(
+    join('temp-workspace', 'apps', options.reactAppName, 'project.json'),
+    'project.json'
+  );
+  removeSync(join('temp-workspace', 'apps', options.reactAppName));
+  removeSync('node_modules');
+}
+
+function moveFilesToTempWorkspace(options: NormalizedOptions) {
+  output.log({ title: '🚚 Moving your React app in your new Nx workspace' });
+
+  const requiredCraFiles = [
+    'project.json',
+    options.isStandalone ? null : 'package.json',
+    'src',
+    'public',
+    options.appIsJs ? null : 'tsconfig.json',
+    options.packageManager === 'yarn' ? 'yarn.lock' : null,
+    options.packageManager === 'pnpm' ? 'pnpm-lock.yaml' : null,
+    options.packageManager === 'npm' ? 'package-lock.json' : null,
+  ];
+
+  const optionalCraFiles = ['README.md'];
+
+  const filesToMove = [...requiredCraFiles, ...optionalCraFiles].filter(
+    Boolean
+  );
+
+  filesToMove.forEach((f) => {
+    try {
+      moveSync(
+        f,
+        options.isStandalone
+          ? join('temp-workspace', f)
+          : join('temp-workspace', 'apps', options.reactAppName, f),
+        {
+          overwrite: true,
+        }
+      );
+    } catch (error) {
+      if (requiredCraFiles.includes(f)) {
+        throw error;
+      }
+    }
+  });
+
+  process.chdir('temp-workspace');
+}
+
+async function addBundler(options: NormalizedOptions) {
+  if (options.isVite) {
+    output.log({ title: '🧑‍🔧  Setting up Vite' });
+    const { addViteCommandsToPackageScripts } = await import(
+      './add-vite-commands-to-package-scripts'
+    );
+    addViteCommandsToPackageScripts(options.reactAppName, options.isStandalone);
+    writeViteConfig(
+      options.reactAppName,
+      options.isStandalone,
+      options.appIsJs
+    );
+    writeViteIndexHtml(
+      options.reactAppName,
+      options.isStandalone,
+      options.appIsJs
+    );
+    renameJsToJsx(options.reactAppName, options.isStandalone);
+  } else {
+    output.log({ title: '🧑‍🔧  Setting up craco + Webpack' });
+    const { addCracoCommandsToPackageScripts } = await import(
+      './add-craco-commands-to-package-scripts'
+    );
+    addCracoCommandsToPackageScripts(
+      options.reactAppName,
+      options.isStandalone
+    );
+
+    writeCracoConfig(
+      options.reactAppName,
+      options.isCRA5,
+      options.isStandalone
+    );
+
+    output.log({
+      title: '🛬 Skip CRA preflight check since Nx manages the monorepo',
+    });
+
+    execSync(`echo "SKIP_PREFLIGHT_CHECK=true" > .env`, { stdio: [0, 1, 2] });
+  }
+}
+
+function copyFromTempWorkspaceToRoot() {
+  output.log({ title: '🚚 Folder restructuring.' });
+
+  readdirSync('temp-workspace').forEach((f) => {
+    moveSync(join('temp-workspace', f), f, { overwrite: true });
+  });
+}
+
+function cleanUpUnusedFilesAndAddConfigFiles(options: NormalizedOptions) {
+  output.log({ title: '🧹  Cleaning up.' });
+
+  cleanUpFiles(options.reactAppName, options.isStandalone);
+
+  output.log({ title: "📃 Extend the app's tsconfig.json from the base" });
+
+  setupTsConfig(options.reactAppName, options.isStandalone);
+
+  if (options.e2e && !options.isStandalone) {
+    output.log({ title: '📃 Setup e2e tests' });
+    setupE2eProject(options.reactAppName);
+  } else {
+    removeSync(join('apps', `${options.reactAppName}-e2e`));
+    execSync(`${options.pmc.rm} @nrwl/cypress eslint-plugin-cypress`);
+  }
+
+  if (options.isStandalone) {
+    removeSync('apps');
+  }
+}

--- a/packages/nx/src/nx-init/react/read-name-from-package-json.ts
+++ b/packages/nx/src/nx-init/react/read-name-from-package-json.ts
@@ -1,0 +1,16 @@
+import { fileExists, readJsonFile } from '../../utils/fileutils';
+
+export function readNameFromPackageJson(): string {
+  let appName = 'webapp';
+  if (fileExists('package.json')) {
+    const json = readJsonFile('package.json');
+    if (
+      json['name'] &&
+      json['name'].length &&
+      json['name'].replace(/\s/g, '').length
+    ) {
+      appName = json['name'].replace(/\s/g, '');
+    }
+  }
+  return appName;
+}

--- a/packages/nx/src/nx-init/react/rename-js-to-jsx.ts
+++ b/packages/nx/src/nx-init/react/rename-js-to-jsx.ts
@@ -1,0 +1,18 @@
+import { readFileSync, renameSync } from 'fs-extra';
+import { sync } from 'glob';
+
+// Vite cannot process JSX like <div> or <Header> unless the file is named .jsx or .tsx
+export function renameJsToJsx(appName: string, isStandalone: boolean) {
+  const files = sync(
+    isStandalone ? 'src/**/*.js' : `apps/${appName}/src/**/*.js`
+  );
+
+  files.forEach((file) => {
+    const content = readFileSync(file).toString();
+    // Try to detect JSX before renaming to .jsx
+    // Files like setupTests.js from CRA should not be renamed
+    if (/<[a-zA-Z0-9]+/.test(content)) {
+      renameSync(file, `${file}x`);
+    }
+  });
+}

--- a/packages/nx/src/nx-init/react/setup-e2e-project.ts
+++ b/packages/nx/src/nx-init/react/setup-e2e-project.ts
@@ -1,0 +1,42 @@
+import { writeFileSync } from 'fs';
+import { fileExists, readJsonFile, writeJsonFile } from '../../utils/fileutils';
+
+export function setupE2eProject(appName: string) {
+  const json = readJsonFile(`apps/${appName}-e2e/project.json`);
+  json.targets.e2e = {
+    executor: 'nx:run-commands',
+    options: {
+      commands: [`nx e2e-serve ${appName}-e2e`, `nx e2e-run ${appName}-e2e`],
+    },
+  };
+  json.targets['e2e-run'] = {
+    executor: '@nrwl/cypress:cypress',
+    options: {
+      cypressConfig: `apps/${appName}-e2e/cypress.json`,
+      tsConfig: `apps/${appName}-e2e/tsconfig.e2e.json`,
+      baseUrl: 'http://localhost:3000',
+    },
+  };
+  json.targets['e2e-serve'] = {
+    executor: 'nx:run-commands',
+    options: {
+      commands: [`nx serve ${appName}`],
+      readyWhen: 'can now view',
+    },
+  };
+  writeJsonFile(`apps/${appName}-e2e/project.json`, json);
+
+  if (fileExists(`apps/${appName}-e2e/src/integration/app.spec.ts`)) {
+    const integrationE2eTest = `
+      describe('${appName}', () => {
+        beforeEach(() => cy.visit('/'));
+        it('should contain a body', () => {
+          cy.get('body').should('exist');
+        });
+      });`;
+    writeFileSync(
+      `apps/${appName}-e2e/src/integration/app.spec.ts`,
+      integrationE2eTest
+    );
+  }
+}

--- a/packages/nx/src/nx-init/react/tsconfig-setup.ts
+++ b/packages/nx/src/nx-init/react/tsconfig-setup.ts
@@ -1,0 +1,107 @@
+import { join } from 'path';
+import { fileExists, readJsonFile, writeJsonFile } from '../../utils/fileutils';
+
+const defaultTsConfig = (relativePathToRoot: string) => ({
+  extends: relativePathToRoot
+    ? join(relativePathToRoot, 'tsconfig.base.json')
+    : './tsconfig.base.json',
+  compilerOptions: {
+    jsx: 'react',
+    allowJs: true,
+    esModuleInterop: true,
+    allowSyntheticDefaultImports: true,
+  },
+  files: [],
+  include: [],
+  references: [
+    {
+      path: './tsconfig.app.json',
+    },
+    {
+      path: './tsconfig.spec.json',
+    },
+  ],
+});
+
+const defaultTsConfigApp = (relativePathToRoot: string) => ({
+  extends: './tsconfig.json',
+  compilerOptions: {
+    outDir: join(relativePathToRoot, 'dist/out-tsc'),
+    types: ['node'],
+  },
+  files: [
+    join(relativePathToRoot, 'node_modules/@nrwl/react/typings/cssmodule.d.ts'),
+    join(relativePathToRoot, 'node_modules/@nrwl/react/typings/image.d.ts'),
+  ],
+  exclude: ['**/*.spec.ts', '**/*.spec.tsx'],
+  include: ['**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx'],
+});
+
+const defaultTsConfigSpec = (relativePathToRoot: string) => ({
+  extends: './tsconfig.json',
+  compilerOptions: {
+    outDir: join(relativePathToRoot, 'dist/out-tsc'),
+    module: 'commonjs',
+    types: ['jest', 'node'],
+  },
+  include: [
+    '**/*.spec.ts',
+    '**/*.spec.tsx',
+    '**/*.spec.js',
+    '**/*.spec.jsx',
+    '**/*.d.ts',
+  ],
+  files: [
+    join(relativePathToRoot, 'node_modules/@nrwl/react/typings/cssmodule.d.ts'),
+    join(relativePathToRoot, 'node_modules/@nrwl/react/typings/image.d.ts'),
+  ],
+});
+
+export function setupTsConfig(appName: string, isStandalone: boolean) {
+  const tsconfigPath = isStandalone
+    ? 'tsconfig.json'
+    : `apps/${appName}/tsconfig.json`;
+  const tsconfigAppPath = isStandalone
+    ? 'tsconfig.app.json'
+    : `apps/${appName}/tsconfig.app.json`;
+  const tsconfiSpecPath = isStandalone
+    ? 'tsconfig.spec.json'
+    : `apps/${appName}/tsconfig.spec.json`;
+  const tsconfigBasePath = isStandalone
+    ? './tsconfig.base.json'
+    : '../../tsconfig.base.json';
+  const relativePathToRoot = isStandalone ? '' : '../../';
+  if (fileExists(tsconfigPath)) {
+    const json = readJsonFile(tsconfigPath);
+    json.extends = tsconfigBasePath;
+    if (json.compilerOptions) {
+      json.compilerOptions.jsx = 'react';
+    } else {
+      json.compilerOptions = {
+        jsx: 'react',
+        allowJs: true,
+        esModuleInterop: true,
+        allowSyntheticDefaultImports: true,
+      };
+    }
+    writeJsonFile(tsconfigPath, json);
+  } else {
+    writeJsonFile(tsconfigPath, defaultTsConfig(relativePathToRoot));
+  }
+
+  if (fileExists(tsconfigAppPath)) {
+    const json = readJsonFile(tsconfigAppPath);
+    json.extends = './tsconfig.json';
+    writeJsonFile(tsconfigAppPath, json);
+  } else {
+    writeJsonFile(tsconfigAppPath, defaultTsConfigApp(relativePathToRoot));
+  }
+
+  if (fileExists(tsconfiSpecPath)) {
+    const json = readJsonFile(tsconfiSpecPath);
+    json.extends = './tsconfig.json';
+    writeJsonFile(tsconfiSpecPath, json);
+  } else {
+    writeJsonFile(tsconfiSpecPath, defaultTsConfigSpec(relativePathToRoot));
+  }
+}

--- a/packages/nx/src/nx-init/react/write-craco-config.ts
+++ b/packages/nx/src/nx-init/react/write-craco-config.ts
@@ -1,0 +1,68 @@
+import { writeFileSync } from 'fs';
+
+export function writeCracoConfig(
+  appName: string,
+  isCRA5: boolean,
+  isStandalone: boolean
+) {
+  const configOverride = `
+  const path = require('path');
+  const TsConfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
+  const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin');
+  module.exports = {
+    webpack: {
+      configure: (config) => {
+        // Remove guard against importing modules outside of \`src\`.
+        // Needed for workspace projects.
+        config.resolve.plugins = config.resolve.plugins.filter(
+          (plugin) => !(plugin instanceof ModuleScopePlugin)
+        );
+        // Add support for importing workspace projects.
+        config.resolve.plugins.push(
+          new TsConfigPathsPlugin({
+            configFile: path.resolve(__dirname, 'tsconfig.json'),
+            extensions: ['.ts', '.tsx', '.js', '.jsx'],
+            mainFields: ['browser', 'module', 'main'],
+          })
+        );
+        ${
+          isCRA5
+            ? `
+        // Replace include option for babel loader with exclude
+        // so babel will handle workspace projects as well.
+        config.module.rules[1].oneOf.forEach((r) => {
+          if (r.loader && r.loader.indexOf('babel') !== -1) {
+            r.exclude = /node_modules/;
+            delete r.include;
+          }
+        });`
+            : `
+        // Replace include option for babel loader with exclude
+        // so babel will handle workspace projects as well.
+        config.module.rules.forEach((r) => {
+          if (r.oneOf) {
+            const babelLoader = r.oneOf.find(
+              (rr) => rr.loader.indexOf('babel-loader') !== -1
+            );
+            babelLoader.exclude = /node_modules/;
+            delete babelLoader.include;
+          }
+        });
+        `
+        }
+        return config;
+      },
+    },
+    jest: {
+      configure: (config) => {
+        config.resolver = '@nrwl/jest/plugins/resolver';
+        return config;
+      },
+    },
+  };
+  `;
+  writeFileSync(
+    isStandalone ? 'craco.config.js' : `apps/${appName}/craco.config.js`,
+    configOverride
+  );
+}

--- a/packages/nx/src/nx-init/react/write-vite-config.ts
+++ b/packages/nx/src/nx-init/react/write-vite-config.ts
@@ -1,0 +1,46 @@
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+
+export function writeViteConfig(
+  appName: string,
+  isStandalone: boolean,
+  isJs: boolean
+) {
+  let port = 4200;
+
+  // Use PORT from .env file if it exists in project.
+  if (existsSync(`../.env`)) {
+    const envFile = readFileSync(`../.env`).toString();
+    const result = envFile.match(/\bport=(?<port>\d{4})/i);
+    const portCandidate = Number(result?.groups?.port);
+    if (!isNaN(portCandidate)) {
+      port = portCandidate;
+    }
+  }
+
+  writeFileSync(
+    isStandalone ? 'vite.config.js' : `apps/${appName}/vite.config.js`,
+    `import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  build: {
+    outDir: ${
+      isStandalone ? `'./dist/${appName}'` : `'../../dist/apps/${appName}'`
+    }
+  },
+  server: {
+    port: ${port},
+    open: true,
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: 'src/setupTests.${isJs ? 'js' : 'ts'}',
+    css: true,
+  },
+  plugins: [react()],
+});
+`
+  );
+}

--- a/packages/nx/src/nx-init/react/write-vite-index-html.ts
+++ b/packages/nx/src/nx-init/react/write-vite-index-html.ts
@@ -1,0 +1,29 @@
+import { copyFileSync, existsSync, writeFileSync } from 'fs';
+
+export function writeViteIndexHtml(
+  appName: string,
+  isStandalone: boolean,
+  isJs: boolean
+) {
+  const indexPath = isStandalone ? 'index.html' : `apps/${appName}/index.html`;
+  if (existsSync(indexPath)) {
+    copyFileSync(indexPath, indexPath + '.old');
+  }
+  const indexFile = isJs ? '/src/index.jsx' : '/src/index.tsx';
+  writeFileSync(
+    indexPath,
+    `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite + React + Nx</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="${indexFile}"></script>
+  </body>
+</html>`
+  );
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `nx init` command doesn't contain the implementation for migrating a CRA repo to Nx. Instead, it defers that to a separate package (`cra-to-nx`).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `nx init` command contains the implementation for migrating a CRA repo to Nx.

Note: in another PR the `cra-to-nx` package will redirect to `nx init`. Once a version is published with the redirect, the package will be removed in another PR.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
