### PR TITLE
chore(repo): add code owners for nx init angular migration e2e tests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -123,6 +123,7 @@
 /packages/nx/src/native @vsavkin @FrozenPandaz @Cammisuli
 /packages/nx/src/lock-file @meeroslav @FrozenPandaz
 /packages/nx/src/nx-init/angular/** @Coly010 @leosvelperez @FrozenPandaz
+/e2e/nx-init/src/nx-init-angular.test.ts @Coly010 @leosvelperez
 /e2e/nx*/** @FrozenPandaz @AgentEnder @vsavkin
 /packages/workspace/** @FrozenPandaz @AgentEnder @vsavkin
 /e2e/workspace-create/** @FrozenPandaz @AgentEnder @vsavkin


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The e2e tests for the Angular migration logic in `nx init` doesn't have the Angular vertical code owners assigned.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The e2e tests for the Angular migration logic in `nx init` have the Angular vertical code owners assigned.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
