### PR TITLE
feat(js): move buildable libs to js

### DIFF
--- a/packages/angular/src/builders/utilities/buildable-libs.ts
+++ b/packages/angular/src/builders/utilities/buildable-libs.ts
@@ -2,7 +2,7 @@ import {
   calculateProjectDependencies,
   createTmpTsConfig,
   DependentBuildableProjectNode,
-} from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+} from '@nrwl/js/src/utils/buildable-libs-utils';
 import { ProjectGraph, readCachedProjectGraph } from '@nrwl/devkit';
 import { join } from 'path';
 

--- a/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
+++ b/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
@@ -5,7 +5,7 @@ import {
   stripIndents,
 } from '@nrwl/devkit';
 import { WebpackNxBuildCoordinationPlugin } from '@nrwl/webpack/src/plugins/webpack-nx-build-coordination-plugin';
-import { DependentBuildableProjectNode } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+import { DependentBuildableProjectNode } from '@nrwl/js/src/utils/buildable-libs-utils';
 import { existsSync } from 'fs';
 import { readNxJson } from 'nx/src/project-graph/file-utils';
 import { isNpmProject } from 'nx/src/project-graph/operators';

--- a/packages/angular/src/builders/webpack-dev-server/webpack-dev-server.impl.ts
+++ b/packages/angular/src/builders/webpack-dev-server/webpack-dev-server.impl.ts
@@ -4,7 +4,7 @@ import {
   readCachedProjectGraph,
 } from '@nrwl/devkit';
 import { WebpackNxBuildCoordinationPlugin } from '@nrwl/webpack/src/plugins/webpack-nx-build-coordination-plugin';
-import { DependentBuildableProjectNode } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+import { DependentBuildableProjectNode } from '@nrwl/js/src/utils/buildable-libs-utils';
 import { readCachedProjectConfiguration } from 'nx/src/project-graph/project-graph';
 import { existsSync } from 'fs';
 import { isNpmProject } from 'nx/src/project-graph/operators';

--- a/packages/angular/src/executors/delegate-build/delegate-build.impl.spec.ts
+++ b/packages/angular/src/executors/delegate-build/delegate-build.impl.spec.ts
@@ -1,6 +1,6 @@
 jest.mock('@nrwl/devkit');
 jest.mock('@nrwl/devkit');
-jest.mock('@nrwl/workspace/src/utilities/buildable-libs-utils');
+jest.mock('@nrwl/js/src/utils/buildable-libs-utils');
 // nested code imports graph from the repo, which might have innacurate graph version
 jest.mock('nx/src/project-graph/project-graph', () => ({
   ...jest.requireActual<any>('nx/src/project-graph/project-graph'),
@@ -11,7 +11,7 @@ jest.mock('nx/src/project-graph/project-graph', () => ({
 
 import type { ExecutorContext, Target } from '@nrwl/devkit';
 import * as devkit from '@nrwl/devkit';
-import * as buildableLibsUtils from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+import * as buildableLibsUtils from '@nrwl/js/src/utils/buildable-libs-utils';
 import delegateBuildExecutor from './delegate-build.impl';
 import type { DelegateBuildExecutorSchema } from './schema';
 

--- a/packages/angular/src/executors/delegate-build/delegate-build.impl.ts
+++ b/packages/angular/src/executors/delegate-build/delegate-build.impl.ts
@@ -8,7 +8,7 @@ import {
   calculateProjectDependencies,
   checkDependentProjectsHaveBeenBuilt,
   createTmpTsConfig,
-} from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+} from '@nrwl/js/src/utils/buildable-libs-utils';
 import type { DelegateBuildExecutorSchema } from './schema';
 
 export async function* delegateBuildExecutor(

--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-lite.impl.spec.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-lite.impl.spec.ts
@@ -1,11 +1,11 @@
 jest.mock('@nrwl/devkit');
-jest.mock('@nrwl/workspace/src/utilities/buildable-libs-utils');
+jest.mock('@nrwl/js/src/utils/buildable-libs-utils');
 jest.mock('ng-packagr');
 jest.mock('ng-packagr/lib/utils/ng-compiler-cli');
 jest.mock('./ng-packagr-adjustments/ng-package/options.di');
 
 import type { ExecutorContext } from '@nrwl/devkit';
-import * as buildableLibsUtils from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+import * as buildableLibsUtils from '@nrwl/js/src/utils/buildable-libs-utils';
 import * as ngPackagr from 'ng-packagr';
 import { ngCompilerCli } from 'ng-packagr/lib/utils/ng-compiler-cli';
 import { BehaviorSubject } from 'rxjs';

--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-lite.impl.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-lite.impl.ts
@@ -2,7 +2,7 @@ import type { ExecutorContext } from '@nrwl/devkit';
 import {
   createTmpTsConfig,
   DependentBuildableProjectNode,
-} from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+} from '@nrwl/js/src/utils/buildable-libs-utils';
 import { NgPackagr } from 'ng-packagr';
 import { resolve } from 'path';
 import { createLibraryExecutor } from '../package/package.impl';

--- a/packages/angular/src/executors/package/package.impl.spec.ts
+++ b/packages/angular/src/executors/package/package.impl.spec.ts
@@ -1,11 +1,11 @@
 jest.mock('@nrwl/devkit');
-jest.mock('@nrwl/workspace/src/utilities/buildable-libs-utils');
+jest.mock('@nrwl/js/src/utils/buildable-libs-utils');
 jest.mock('ng-packagr');
 jest.mock('ng-packagr/lib/utils/ng-compiler-cli');
 jest.mock('./ng-packagr-adjustments/ng-package/options.di');
 
 import type { ExecutorContext } from '@nrwl/devkit';
-import * as buildableLibsUtils from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+import * as buildableLibsUtils from '@nrwl/js/src/utils/buildable-libs-utils';
 import * as ngPackagr from 'ng-packagr';
 import { ngCompilerCli } from 'ng-packagr/lib/utils/ng-compiler-cli';
 import { BehaviorSubject } from 'rxjs';

--- a/packages/angular/src/executors/package/package.impl.ts
+++ b/packages/angular/src/executors/package/package.impl.ts
@@ -6,7 +6,7 @@ import {
   createTmpTsConfig,
   DependentBuildableProjectNode,
   updateBuildableProjectPackageJsonDependencies,
-} from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+} from '@nrwl/js/src/utils/buildable-libs-utils';
 import type { NgPackagr } from 'ng-packagr';
 import { resolve } from 'path';
 import { from } from 'rxjs';

--- a/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
+++ b/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
@@ -22,7 +22,7 @@ import {
   getOutfile,
 } from './lib/build-esbuild-options';
 import { getExtraDependencies } from './lib/get-extra-dependencies';
-import { DependentBuildableProjectNode } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+import { DependentBuildableProjectNode } from '@nrwl/js/src/utils/buildable-libs-utils';
 import { join } from 'path';
 
 const BUILD_WATCH_FAILED = `[ ${chalk.red(

--- a/packages/esbuild/src/executors/esbuild/lib/get-extra-dependencies.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/get-extra-dependencies.ts
@@ -1,5 +1,5 @@
 import { ProjectGraph } from '@nrwl/devkit';
-import { DependentBuildableProjectNode } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+import { DependentBuildableProjectNode } from '@nrwl/js/src/utils/buildable-libs-utils';
 
 export function getExtraDependencies(
   projectName: string,

--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -5,7 +5,7 @@ import {
   parseTargetString,
   runExecutor,
 } from '@nrwl/devkit';
-import { calculateProjectDependencies } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+import { calculateProjectDependencies } from '../../utils/buildable-libs-utils';
 import { ChildProcess, fork } from 'child_process';
 import { randomUUID } from 'crypto';
 import { HashingImpl } from 'nx/src/hasher/hashing-impl';

--- a/packages/js/src/utils/buildable-libs-utils.spec.ts
+++ b/packages/js/src/utils/buildable-libs-utils.spec.ts
@@ -1,0 +1,196 @@
+import { DependencyType, ProjectGraph } from '@nrwl/devkit';
+import {
+  calculateProjectDependencies,
+  DependentBuildableProjectNode,
+  updatePaths,
+} from './buildable-libs-utils';
+
+describe('updatePaths', () => {
+  const deps: DependentBuildableProjectNode[] = [
+    { name: '@proj/lib', node: {} as any, outputs: ['dist/libs/lib'] },
+  ];
+
+  it('should add path', () => {
+    const paths: Record<string, string[]> = {
+      '@proj/test': ['libs/test/src/index.ts'],
+    };
+    updatePaths(deps, paths);
+    expect(paths).toEqual({
+      '@proj/lib': ['dist/libs/lib'],
+      '@proj/test': ['libs/test/src/index.ts'],
+    });
+  });
+
+  it('should replace paths', () => {
+    const paths: Record<string, string[]> = {
+      '@proj/lib': ['libs/lib/src/index.ts'],
+      '@proj/lib/sub': ['libs/lib/sub/src/index.ts'],
+    };
+    updatePaths(deps, paths);
+    expect(paths).toEqual({
+      '@proj/lib': ['dist/libs/lib'],
+      '@proj/lib/sub': ['dist/libs/lib/sub'],
+    });
+  });
+});
+
+describe('calculateProjectDependencies', () => {
+  it('should include npm packages in dependency list', async () => {
+    const graph: ProjectGraph = {
+      nodes: {
+        example: {
+          type: 'lib',
+          name: 'example',
+          data: {
+            files: [],
+            root: '/root/example',
+          },
+        },
+      },
+      externalNodes: {
+        'npm:formik': {
+          type: 'npm',
+          name: 'npm:formik',
+          data: {
+            packageName: 'formik',
+            version: '0.0.0',
+          },
+        },
+      },
+      dependencies: {
+        example: [
+          {
+            source: 'example',
+            target: 'npm:formik',
+            type: DependencyType.static,
+          },
+        ],
+      },
+    };
+
+    const results = await calculateProjectDependencies(
+      graph,
+      'root',
+      'example',
+      'build',
+      undefined
+    );
+    expect(results).toMatchObject({
+      target: {
+        type: 'lib',
+        name: 'example',
+      },
+      dependencies: [{ name: 'formik' }],
+    });
+  });
+
+  it('should include npm packages in dependency list and sort them correctly', async () => {
+    const graph: ProjectGraph = {
+      nodes: {
+        example: {
+          type: 'lib',
+          name: 'example',
+          data: {
+            files: [],
+            root: '/root/example',
+          },
+        },
+      },
+      externalNodes: {
+        'npm:some-lib': {
+          type: 'npm',
+          name: 'npm:some-lib',
+          data: {
+            packageName: 'some-lib',
+            version: '0.0.0',
+          },
+        },
+        'npm:formik': {
+          type: 'npm',
+          name: 'npm:formik',
+          data: {
+            packageName: 'formik',
+            version: '0.0.0',
+          },
+        },
+        'npm:@prefixed-lib': {
+          type: 'npm',
+          name: 'npm:@prefixed-lib',
+          data: {
+            packageName: '@prefixed-lib',
+            version: '0.0.0',
+          },
+        },
+      },
+      dependencies: {
+        example: [
+          {
+            source: 'example',
+            target: 'npm:some-lib',
+            type: DependencyType.static,
+          },
+          {
+            source: 'example',
+            target: 'npm:formik',
+            type: DependencyType.static,
+          },
+          {
+            source: 'example',
+            target: 'npm:@prefixed-lib',
+            type: DependencyType.static,
+          },
+        ],
+      },
+    };
+
+    const results = await calculateProjectDependencies(
+      graph,
+      'root',
+      'example',
+      'build',
+      undefined
+    );
+    expect(results).toMatchObject({
+      target: {
+        type: 'lib',
+        name: 'example',
+      },
+      dependencies: [
+        { name: '@prefixed-lib' },
+        { name: 'formik' },
+        { name: 'some-lib' },
+      ],
+    });
+  });
+});
+
+describe('missingDependencies', () => {
+  it('should throw an error if dependency is missing', async () => {
+    const graph: ProjectGraph = {
+      nodes: {
+        example: {
+          type: 'lib',
+          name: 'example',
+          data: {
+            files: [],
+            root: '/root/example',
+          },
+        },
+      },
+      externalNodes: {},
+      dependencies: {
+        example: [
+          {
+            source: 'example',
+            target: 'missing',
+            type: DependencyType.static,
+          },
+        ],
+      },
+    };
+
+    expect(() =>
+      calculateProjectDependencies(graph, 'root', 'example', 'build', undefined)
+    ).toThrow();
+  });
+});

--- a/packages/js/src/utils/buildable-libs-utils.ts
+++ b/packages/js/src/utils/buildable-libs-utils.ts
@@ -1,5 +1,5 @@
 import { dirname, join, relative } from 'path';
-import { directoryExists, fileExists } from './fileutils';
+import { directoryExists, fileExists } from 'nx/src/utils/fileutils';
 import type { ProjectGraph, ProjectGraphProjectNode } from '@nrwl/devkit';
 import {
   getOutputsForTargetAndConfiguration,
@@ -10,9 +10,9 @@ import {
 } from '@nrwl/devkit';
 import type * as ts from 'typescript';
 import { unlinkSync } from 'fs';
-import { output } from './output';
+import { output } from 'nx/src/utils/output';
 import { isNpmProject } from 'nx/src/project-graph/operators';
-import { ensureTypescript } from './typescript';
+import { ensureTypescript } from './typescript/ensure-typescript';
 
 let tsModule: typeof import('typescript');
 
@@ -24,18 +24,12 @@ function isBuildable(target: string, node: ProjectGraphProjectNode): boolean {
   );
 }
 
-/**
- * @deprecated This type will be removed from @nrwl/workspace in version 17. Prefer importing from @nrwl/js.
- */
 export type DependentBuildableProjectNode = {
   name: string;
   outputs: string[];
   node: ProjectGraphProjectNode | ProjectGraphExternalNode;
 };
 
-/**
- * @deprecated This function will be removed from @nrwl/workspace in version 17. Prefer importing from @nrwl/js.
- */
 export function calculateProjectDependencies(
   projGraph: ProjectGraph,
   root: string,
@@ -184,7 +178,15 @@ function readTsConfigWithRemappedPaths(
   return generatedTsConfig;
 }
 
-function computeCompilerOptionsPaths(
+/**
+ * Util function to create tsconfig compilerOptions object with support for workspace libs paths.
+ *
+ *
+ *
+ * @param tsConfig String of config path or object parsed via ts.parseJsonConfigFileContent.
+ * @param dependencies Dependencies calculated by Nx.
+ */
+export function computeCompilerOptionsPaths(
   tsConfig: string | ts.ParsedCommandLine,
   dependencies: DependentBuildableProjectNode[]
 ) {
@@ -222,9 +224,6 @@ function readPaths(tsConfig: string | ts.ParsedCommandLine) {
   }
 }
 
-/**
- * @deprecated This function will be removed from @nrwl/workspace in version 17. Prefer importing from @nrwl/js.
- */
 export function createTmpTsConfig(
   tsconfigPath: string,
   workspaceRoot: string,
@@ -255,9 +254,6 @@ function cleanupTmpTsConfigFile(tmpTsConfigPath) {
   } catch (e) {}
 }
 
-/**
- * @deprecated This function will be removed from @nrwl/workspace in version 17. Prefer importing from @nrwl/js.
- */
 export function checkDependentProjectsHaveBeenBuilt(
   root: string,
   projectName: string,
@@ -284,9 +280,6 @@ export function checkDependentProjectsHaveBeenBuilt(
   }
 }
 
-/**
- * @deprecated This function will be removed from @nrwl/workspace in version 17. Prefer importing from @nrwl/js.
- */
 export function findMissingBuildDependencies(
   root: string,
   projectName: string,
@@ -311,9 +304,6 @@ export function findMissingBuildDependencies(
   return depLibsToBuildFirst;
 }
 
-/**
- * @deprecated This function will be removed from @nrwl/workspace in version 17. Prefer importing from @nrwl/js.
- */
 export function updatePaths(
   dependencies: DependentBuildableProjectNode[],
   paths: Record<string, string[]>
@@ -361,7 +351,6 @@ export function updatePaths(
 /**
  * Updates the peerDependencies section in the `dist/lib/xyz/package.json` with
  * the proper dependency and version
- * @deprecated This function will be removed from @nrwl/workspace in version 17. Prefer importing from @nrwl/js.
  */
 export function updateBuildableProjectPackageJsonDependencies(
   root: string,

--- a/packages/js/src/utils/check-dependencies.ts
+++ b/packages/js/src/utils/check-dependencies.ts
@@ -3,7 +3,7 @@ import {
   calculateProjectDependencies,
   createTmpTsConfig,
   DependentBuildableProjectNode,
-} from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+} from './buildable-libs-utils';
 
 export function checkDependencies(
   context: ExecutorContext,

--- a/packages/js/src/utils/compiler-helper-dependency.ts
+++ b/packages/js/src/utils/compiler-helper-dependency.ts
@@ -4,7 +4,7 @@ import {
   ProjectGraphDependency,
   readJsonFile,
 } from '@nrwl/devkit';
-import { DependentBuildableProjectNode } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+import { DependentBuildableProjectNode } from './buildable-libs-utils';
 import { join } from 'path';
 import { readTsConfig } from './typescript/ts-config';
 import { ExecutorOptions, SwcExecutorOptions } from './schema';

--- a/packages/js/src/utils/package-json/index.ts
+++ b/packages/js/src/utils/package-json/index.ts
@@ -1,6 +1,5 @@
-import { join } from 'path';
 import { ExecutorContext } from '@nrwl/devkit';
-import { DependentBuildableProjectNode } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+import { DependentBuildableProjectNode } from '../buildable-libs-utils';
 
 import { watchForSingleFileChanges } from '../watch-for-single-file-changes';
 import type { UpdatePackageJsonOption } from './update-package-json';

--- a/packages/js/src/utils/package-json/update-package-json.spec.ts
+++ b/packages/js/src/utils/package-json/update-package-json.spec.ts
@@ -7,7 +7,7 @@ import {
 } from './update-package-json';
 import { vol } from 'memfs';
 import { ExecutorContext, ProjectGraph } from '@nrwl/devkit';
-import { DependentBuildableProjectNode } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+import { DependentBuildableProjectNode } from '../buildable-libs-utils';
 
 jest.mock('nx/src/utils/workspace-root', () => ({
   workspaceRoot: '/root',

--- a/packages/js/src/utils/package-json/update-package-json.ts
+++ b/packages/js/src/utils/package-json/update-package-json.ts
@@ -1,4 +1,4 @@
-import { createLockFile } from 'nx/src/lock-file/lock-file';
+import { createLockFile, getLockFileName } from 'nx/src/lock-file/lock-file';
 import { createPackageJson } from 'nx/src/utils/create-package-json';
 import {
   ExecutorContext,
@@ -10,9 +10,8 @@ import {
   workspaceRoot,
   writeJsonFile,
 } from '@nrwl/devkit';
-import { DependentBuildableProjectNode } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+import { DependentBuildableProjectNode } from '../buildable-libs-utils';
 import { basename, dirname, join, parse, relative } from 'path';
-import { getLockFileName } from 'nx/src/lock-file/lock-file';
 import { writeFileSync } from 'fs-extra';
 import { isNpmProject } from 'nx/src/project-graph/operators';
 import { fileExists } from 'nx/src/utils/fileutils';

--- a/packages/next/src/executors/build/build.impl.ts
+++ b/packages/next/src/executors/build/build.impl.ts
@@ -15,7 +15,7 @@ import { directoryExists } from '@nrwl/workspace/src/utilities/fileutils';
 import {
   calculateProjectDependencies,
   DependentBuildableProjectNode,
-} from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+} from '@nrwl/js/src/utils/buildable-libs-utils';
 import { checkAndCleanWithSemver } from '@nrwl/devkit/src/utils/semver';
 
 import { prepareConfig } from '../../utils/config';

--- a/packages/next/src/executors/export/export.impl.ts
+++ b/packages/next/src/executors/export/export.impl.ts
@@ -4,14 +4,14 @@ import {
   parseTargetString,
   readTargetOptions,
   runExecutor,
+  workspaceLayout,
 } from '@nrwl/devkit';
 import exportApp from 'next/dist/export';
 import { join, resolve } from 'path';
 import {
   calculateProjectDependencies,
   DependentBuildableProjectNode,
-} from '@nrwl/workspace/src/utilities/buildable-libs-utils';
-import { workspaceLayout } from '@nrwl/devkit';
+} from '@nrwl/js/src/utils/buildable-libs-utils';
 
 import { prepareConfig } from '../../utils/config';
 import {

--- a/packages/next/src/executors/server/server.impl.ts
+++ b/packages/next/src/executors/server/server.impl.ts
@@ -10,7 +10,7 @@ import {
 import * as chalk from 'chalk';
 import { existsSync } from 'fs';
 import { join, resolve } from 'path';
-import { calculateProjectDependencies } from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+import { calculateProjectDependencies } from '@nrwl/js/src/utils/buildable-libs-utils';
 
 import { prepareConfig } from '../../utils/config';
 import {

--- a/packages/next/src/utils/buildable-libs.ts
+++ b/packages/next/src/utils/buildable-libs.ts
@@ -1,7 +1,7 @@
 import {
   DependentBuildableProjectNode,
   findMissingBuildDependencies,
-} from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+} from '@nrwl/js/src/utils/buildable-libs-utils';
 import * as chalk from 'chalk';
 import { ExecutorContext, stripIndents } from '@nrwl/devkit';
 

--- a/packages/next/src/utils/config.ts
+++ b/packages/next/src/utils/config.ts
@@ -22,7 +22,7 @@ import { WithNxOptions } from '../../plugins/with-nx';
 import {
   createTmpTsConfig,
   DependentBuildableProjectNode,
-} from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+} from '@nrwl/js/src/utils/buildable-libs-utils';
 
 const loadConfig = require('next/dist/server/config').default;
 

--- a/packages/rollup/src/executors/rollup/lib/update-package-json.ts
+++ b/packages/rollup/src/executors/rollup/lib/update-package-json.ts
@@ -4,7 +4,7 @@ import { ProjectGraphProjectNode } from 'nx/src/config/project-graph';
 import {
   DependentBuildableProjectNode,
   updateBuildableProjectPackageJsonDependencies,
-} from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+} from '@nrwl/js/src/utils/buildable-libs-utils';
 import { writeJsonFile } from 'nx/src/utils/fileutils';
 import { PackageJson } from 'nx/src/utils/package-json';
 import { NormalizedRollupExecutorOptions } from './normalize';

--- a/packages/rollup/src/executors/rollup/rollup.impl.ts
+++ b/packages/rollup/src/executors/rollup/rollup.impl.ts
@@ -14,7 +14,7 @@ import {
   calculateProjectDependencies,
   computeCompilerOptionsPaths,
   DependentBuildableProjectNode,
-} from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+} from '@nrwl/js/src/utils/buildable-libs-utils';
 import nodeResolve from '@rollup/plugin-node-resolve';
 
 import { AssetGlobPattern, RollupExecutorOptions } from './schema';

--- a/packages/webpack/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/webpack/src/executors/dev-server/dev-server.impl.ts
@@ -13,7 +13,7 @@ import { getDevServerConfig } from './lib/get-dev-server-config';
 import {
   calculateProjectDependencies,
   createTmpTsConfig,
-} from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+} from '@nrwl/js/src/utils/buildable-libs-utils';
 import { runWebpackDevServer } from '../../utils/run-webpack';
 import { resolveCustomWebpackConfig } from '../../utils/webpack/custom-webpack';
 import { normalizeOptions } from '../webpack/lib/normalize-options';

--- a/packages/webpack/src/executors/webpack/webpack.impl.ts
+++ b/packages/webpack/src/executors/webpack/webpack.impl.ts
@@ -14,7 +14,7 @@ import { resolve } from 'path';
 import {
   calculateProjectDependencies,
   createTmpTsConfig,
-} from '@nrwl/workspace/src/utilities/buildable-libs-utils';
+} from '@nrwl/js/src/utils/buildable-libs-utils';
 
 import { getWebpackConfig } from './lib/get-webpack-config';
 import { runWebpack } from './lib/run-webpack';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Buildable Library Utilities currently live in Workspace

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Move Buildable Library Utilities to JS
Deprecate existing utils from Workspace for future removal as some OSS projects are using them currently.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
