### PR TITLE
cleanup(angular): fix unit tests setup so peer deps are not installed with ensurePackage

### DIFF
--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -12,19 +12,21 @@ import {
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
+import * as enquirer from 'enquirer';
 import { E2eTestRunner, UnitTestRunner } from '../../utils/test-runners';
 import {
   autoprefixerVersion,
   postcssVersion,
   tailwindVersion,
 } from '../../utils/versions';
-import { applicationGenerator } from './application';
+import { generateTestApplication } from '../utils/testing';
 import type { Schema } from './schema';
-import * as enquirer from 'enquirer';
+
 // need to mock cypress otherwise it'll use the nx installed version from package.json
 //  which is v9 while we are testing for the new v10 version
 jest.mock('@nrwl/cypress/src/utils/cypress-version');
 jest.mock('enquirer');
+
 describe('app', () => {
   let appTree: Tree;
   let mockedInstalledCypressVersion: jest.Mock<
@@ -942,7 +944,7 @@ async function generateApp(
   name: string = 'myApp',
   options: Partial<Schema> = {}
 ) {
-  await applicationGenerator(appTree, {
+  await generateTestApplication(appTree, {
     name,
     skipFormat: false,
     e2eTestRunner: E2eTestRunner.Cypress,

--- a/packages/angular/src/generators/component-cypress-spec/component-cypress-spec.spec.ts
+++ b/packages/angular/src/generators/component-cypress-spec/component-cypress-spec.spec.ts
@@ -3,12 +3,14 @@ import type { Tree } from '@nrwl/devkit';
 import * as devkit from '@nrwl/devkit';
 import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import { applicationGenerator } from '../application/application';
 import * as storybookUtils from '../utils/storybook-ast/storybook-inputs';
+import { generateTestApplication } from '../utils/testing';
 import { componentCypressSpecGenerator } from './component-cypress-spec';
+
 // need to mock cypress otherwise it'll use the nx installed version from package.json
 //  which is v9 while we are testing for the new v10 version
 jest.mock('@nrwl/cypress/src/utils/cypress-version');
+
 describe('componentCypressSpec generator', () => {
   let tree: Tree;
   const appName = 'ng-app1';
@@ -24,7 +26,7 @@ describe('componentCypressSpec generator', () => {
       'component'
     );
 
-    await applicationGenerator(tree, { name: appName });
+    await generateTestApplication(tree, { name: appName });
     await componentGenerator(tree, {
       name: 'test-button',
       project: appName,

--- a/packages/angular/src/generators/component-story/component-story.spec.ts
+++ b/packages/angular/src/generators/component-story/component-story.spec.ts
@@ -2,8 +2,8 @@ import type { Tree } from '@nrwl/devkit';
 import * as devkit from '@nrwl/devkit';
 import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import { libraryGenerator } from '../library/library';
 import * as storybookUtils from '../utils/storybook-ast/storybook-inputs';
+import { generateTestLibrary } from '../utils/testing';
 import { componentStoryGenerator } from './component-story';
 
 describe('componentStory generator', () => {
@@ -19,7 +19,7 @@ describe('componentStory generator', () => {
       'component'
     );
 
-    await libraryGenerator(tree, { name: libName });
+    await generateTestLibrary(tree, { name: libName });
     await componentGenerator(tree, {
       name: 'test-button',
       project: libName,

--- a/packages/angular/src/generators/component-test/component-test.spec.ts
+++ b/packages/angular/src/generators/component-test/component-test.spec.ts
@@ -4,9 +4,11 @@ import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import { UnitTestRunner } from '../../utils/test-runners';
 import { componentGenerator } from '../component/component';
-import { libraryGenerator } from '../library/library';
+import { generateTestLibrary } from '../utils/testing';
 import { componentTestGenerator } from './component-test';
+
 jest.mock('@nrwl/cypress/src/utils/cypress-version');
+
 describe('Angular Cypress Component Test Generator', () => {
   let tree: Tree;
   let mockedAssertMinimumCypressVersion: jest.Mock<
@@ -20,7 +22,7 @@ describe('Angular Cypress Component Test Generator', () => {
   });
 
   it('should handle component w/o inputs', async () => {
-    await libraryGenerator(tree, {
+    await generateTestLibrary(tree, {
       name: 'my-lib',
       unitTestRunner: UnitTestRunner.None,
       linter: Linter.None,
@@ -41,7 +43,7 @@ describe('Angular Cypress Component Test Generator', () => {
   });
 
   it('should generate a component test', async () => {
-    await libraryGenerator(tree, {
+    await generateTestLibrary(tree, {
       name: 'my-lib',
       unitTestRunner: UnitTestRunner.None,
       linter: Linter.None,
@@ -93,7 +95,7 @@ export class MyLibComponent implements OnInit {
   });
 
   it('should work with standalone components', async () => {
-    await libraryGenerator(tree, {
+    await generateTestLibrary(tree, {
       name: 'my-lib',
       unitTestRunner: UnitTestRunner.None,
       linter: Linter.None,
@@ -144,7 +146,7 @@ export class MyLibComponent implements OnInit {
   });
 
   it('should not overwrite an existing component test', async () => {
-    await libraryGenerator(tree, {
+    await generateTestLibrary(tree, {
       name: 'my-lib',
       unitTestRunner: UnitTestRunner.None,
       linter: Linter.None,
@@ -169,7 +171,7 @@ export class MyLibComponent implements OnInit {
   });
 
   it('should be idempotent', async () => {
-    await libraryGenerator(tree, {
+    await generateTestLibrary(tree, {
       name: 'my-lib',
       unitTestRunner: UnitTestRunner.None,
       linter: Linter.None,

--- a/packages/angular/src/generators/cypress-component-configuration/cypress-component-configuration.spec.ts
+++ b/packages/angular/src/generators/cypress-component-configuration/cypress-component-configuration.spec.ts
@@ -8,10 +8,9 @@ import {
   updateProjectConfiguration,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import { applicationGenerator } from '../application/application';
 import { componentGenerator } from '../component/component';
-import librarySecondaryEntryPointGenerator from '../library-secondary-entry-point/library-secondary-entry-point';
-import { libraryGenerator } from '../library/library';
+import { librarySecondaryEntryPointGenerator } from '../library-secondary-entry-point/library-secondary-entry-point';
+import { generateTestApplication, generateTestLibrary } from '../utils/testing';
 import { cypressComponentConfiguration } from './cypress-component-configuration';
 
 let projectGraph: ProjectGraph;
@@ -44,10 +43,10 @@ describe('Cypress Component Testing Configuration', () => {
 
   describe('updateProjectConfig', () => {
     it('should add project config with --target=<project>:<target>', async () => {
-      await applicationGenerator(tree, {
+      await generateTestApplication(tree, {
         name: 'fancy-app',
       });
-      await libraryGenerator(tree, {
+      await generateTestLibrary(tree, {
         name: 'fancy-lib',
       });
       await componentGenerator(tree, {
@@ -106,10 +105,10 @@ describe('Cypress Component Testing Configuration', () => {
     });
 
     it('should add project config with --target=<project>:<target>:<config>', async () => {
-      await applicationGenerator(tree, {
+      await generateTestApplication(tree, {
         name: 'fancy-app',
       });
-      await libraryGenerator(tree, {
+      await generateTestLibrary(tree, {
         name: 'fancy-lib',
       });
       await componentGenerator(tree, {
@@ -168,10 +167,10 @@ describe('Cypress Component Testing Configuration', () => {
     });
 
     it('should throw with invalid --build-target', async () => {
-      await applicationGenerator(tree, {
+      await generateTestApplication(tree, {
         name: 'fancy-app',
       });
-      await libraryGenerator(tree, {
+      await generateTestLibrary(tree, {
         name: 'fancy-lib',
       });
       await componentGenerator(tree, {
@@ -223,7 +222,7 @@ describe('Cypress Component Testing Configuration', () => {
       `);
     });
     it('should use own project config', async () => {
-      await applicationGenerator(tree, {
+      await generateTestApplication(tree, {
         name: 'fancy-app',
       });
       await componentGenerator(tree, {
@@ -261,10 +260,10 @@ describe('Cypress Component Testing Configuration', () => {
     });
 
     it('should use the project graph to find the correct project config', async () => {
-      await applicationGenerator(tree, {
+      await generateTestApplication(tree, {
         name: 'fancy-app',
       });
-      await libraryGenerator(tree, {
+      await generateTestLibrary(tree, {
         name: 'fancy-lib',
       });
       await componentGenerator(tree, {
@@ -323,7 +322,7 @@ describe('Cypress Component Testing Configuration', () => {
 
   it('should throw if an invalid --build-target', async () => {});
   it('should work with simple components', async () => {
-    await libraryGenerator(tree, {
+    await generateTestLibrary(tree, {
       name: 'my-lib',
     });
 
@@ -375,7 +374,7 @@ describe('Cypress Component Testing Configuration', () => {
   });
 
   it('should work with standalone component', async () => {
-    await libraryGenerator(tree, {
+    await generateTestLibrary(tree, {
       name: 'my-lib-standalone',
     });
 
@@ -427,7 +426,7 @@ describe('Cypress Component Testing Configuration', () => {
   });
 
   it('should work with complex component', async () => {
-    await libraryGenerator(tree, {
+    await generateTestLibrary(tree, {
       name: 'with-inputs-cmp',
     });
 
@@ -481,7 +480,7 @@ describe('Cypress Component Testing Configuration', () => {
   });
 
   it('should work with complex standalone component', async () => {
-    await libraryGenerator(tree, {
+    await generateTestLibrary(tree, {
       name: 'with-inputs-standalone-cmp',
     });
 
@@ -535,10 +534,10 @@ describe('Cypress Component Testing Configuration', () => {
   });
 
   it('should work with secondary entry point libs', async () => {
-    await applicationGenerator(tree, {
+    await generateTestApplication(tree, {
       name: 'my-cool-app',
     });
-    await libraryGenerator(tree, {
+    await generateTestLibrary(tree, {
       name: 'secondary',
       buildable: true,
     });
@@ -599,7 +598,7 @@ describe('Cypress Component Testing Configuration', () => {
   });
 
   it('should not overwrite existing component test', async () => {
-    await libraryGenerator(tree, {
+    await generateTestLibrary(tree, {
       name: 'cool-lib',
       flat: true,
     });
@@ -653,7 +652,7 @@ describe('Cypress Component Testing Configuration', () => {
 
   // TODO: should we support this?
   it.skip('should handle multiple components per file', async () => {
-    await libraryGenerator(tree, {
+    await generateTestLibrary(tree, {
       name: 'multiple-components',
       flat: true,
     });
@@ -744,7 +743,7 @@ async function setup(
     basePath?: string;
   }
 ) {
-  await applicationGenerator(tree, {
+  await generateTestApplication(tree, {
     name: options.name,
     standalone: options.standalone,
   });

--- a/packages/angular/src/generators/host/host.spec.ts
+++ b/packages/angular/src/generators/host/host.spec.ts
@@ -1,12 +1,14 @@
+import { stripIndents, updateJson } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import host from './host';
-import remote from '../remote/remote';
-import { E2eTestRunner } from '../../utils/test-runners';
 import {
   getProjects,
   readProjectConfiguration,
 } from 'nx/src/generators/utils/project-configuration';
-import { stripIndents, updateJson } from '@nrwl/devkit';
+import { E2eTestRunner } from '../../utils/test-runners';
+import {
+  generateTestHostApplication,
+  generateTestRemoteApplication,
+} from '../utils/testing';
 
 describe('Host App Generator', () => {
   it('should generate a host app with no remotes', async () => {
@@ -14,7 +16,7 @@ describe('Host App Generator', () => {
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
 
     // ACT
-    await host(tree, {
+    await generateTestHostApplication(tree, {
       name: 'test',
     });
 
@@ -26,12 +28,12 @@ describe('Host App Generator', () => {
     // ARRANGE
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
 
-    await remote(tree, {
+    await generateTestRemoteApplication(tree, {
       name: 'remote',
     });
 
     // ACT
-    await host(tree, {
+    await generateTestHostApplication(tree, {
       name: 'test',
       remotes: ['remote'],
     });
@@ -49,7 +51,7 @@ describe('Host App Generator', () => {
 
     // ACT
 
-    await host(tree, {
+    await generateTestHostApplication(tree, {
       name: 'hostApp',
       remotes: ['remote1', 'remote2'],
     });
@@ -76,12 +78,12 @@ describe('Host App Generator', () => {
   it('should generate a host, integrate existing remotes and generate any remotes that dont exist', async () => {
     // ARRANGE
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-    await remote(tree, {
+    await generateTestRemoteApplication(tree, {
       name: 'remote1',
     });
 
     // ACT
-    await host(tree, {
+    await generateTestHostApplication(tree, {
       name: 'hostApp',
       remotes: ['remote1', 'remote2', 'remote3'],
     });
@@ -98,12 +100,12 @@ describe('Host App Generator', () => {
   it('should generate a host, integrate existing remotes and generate any remotes that dont exist, in a directory', async () => {
     // ARRANGE
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-    await remote(tree, {
+    await generateTestRemoteApplication(tree, {
       name: 'remote1',
     });
 
     // ACT
-    await host(tree, {
+    await generateTestHostApplication(tree, {
       name: 'hostApp',
       directory: 'foo',
       remotes: ['remote1', 'remote2', 'remote3'],
@@ -123,7 +125,7 @@ describe('Host App Generator', () => {
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
 
     // ACT
-    await host(tree, {
+    await generateTestHostApplication(tree, {
       name: 'host',
       remotes: ['remote1'],
       standalone: true,
@@ -143,7 +145,7 @@ describe('Host App Generator', () => {
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
 
     // ACT
-    await host(tree, {
+    await generateTestHostApplication(tree, {
       name: 'host',
       remotes: ['remote1'],
       standalone: true,
@@ -160,7 +162,7 @@ describe('Host App Generator', () => {
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
 
     // ACT
-    await host(tree, {
+    await generateTestHostApplication(tree, {
       name: 'dashboard',
       remotes: ['remote1'],
       directory: 'test',
@@ -178,7 +180,7 @@ describe('Host App Generator', () => {
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
 
     // ACT
-    await host(tree, {
+    await generateTestHostApplication(tree, {
       name: 'dashboard',
       remotes: ['remote1'],
       e2eTestRunner: E2eTestRunner.None,
@@ -196,7 +198,7 @@ describe('Host App Generator', () => {
       const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
 
       // ACT
-      await host(tree, {
+      await generateTestHostApplication(tree, {
         name: 'test',
         ssr: true,
       });
@@ -242,7 +244,7 @@ describe('Host App Generator', () => {
 
     // ACT & ASSERT
     await expect(
-      host(tree, {
+      generateTestHostApplication(tree, {
         name: 'test',
         standalone: true,
       })

--- a/packages/angular/src/generators/init/init.spec.ts
+++ b/packages/angular/src/generators/init/init.spec.ts
@@ -17,7 +17,6 @@ describe('init', () => {
 
   beforeEach(() => {
     tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-    require('@nrwl/devkit').ensurePackage.mockImplementation(() => {});
   });
 
   it('should add angular dependencies', async () => {

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -9,8 +9,8 @@ import {
   updateJson,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import { backwardCompatibleVersions } from '../../utils/backward-compatible-versions';
 import { Linter } from '@nrwl/linter';
+import { backwardCompatibleVersions } from '../../utils/backward-compatible-versions';
 import { createApp } from '../../utils/nx-devkit/testing';
 import { UnitTestRunner } from '../../utils/test-runners';
 import {
@@ -18,8 +18,7 @@ import {
   postcssVersion,
   tailwindVersion,
 } from '../../utils/versions';
-import applicationGenerator from '../application/application';
-import libraryGenerator from './library';
+import { generateTestApplication, generateTestLibrary } from '../utils/testing';
 import { Schema } from './schema';
 
 let projectGraph: ProjectGraph;
@@ -27,9 +26,6 @@ jest.mock('@nrwl/devkit', () => {
   return {
     ...jest.requireActual('@nrwl/devkit'),
     createProjectGraphAsync: jest.fn().mockImplementation(() => projectGraph),
-    // need to mock so it doesn't resolve what the workspace has installed
-    // and be able to test with different versions
-    ensurePackage: jest.fn().mockImplementation((pkg) => require(pkg)),
   };
 });
 
@@ -37,7 +33,7 @@ describe('lib', () => {
   let tree: Tree;
 
   async function runLibraryGeneratorWithOpts(opts: Partial<Schema> = {}) {
-    await libraryGenerator(tree, {
+    await generateTestLibrary(tree, {
       name: 'myLib',
       publishable: false,
       buildable: false,
@@ -1419,7 +1415,7 @@ describe('lib', () => {
 
     it('should generate a library with a standalone component as entry point with routing setup and attach it to parent module as direct child', async () => {
       // ARRANGE
-      await applicationGenerator(tree, {
+      await generateTestApplication(tree, {
         name: 'app1',
         routing: true,
       });
@@ -1443,7 +1439,7 @@ describe('lib', () => {
 
     it('should generate a library with a standalone component as entry point with routing setup and attach it to parent module as a lazy child', async () => {
       // ARRANGE
-      await applicationGenerator(tree, {
+      await generateTestApplication(tree, {
         name: 'app1',
         routing: true,
       });
@@ -1468,7 +1464,7 @@ describe('lib', () => {
 
     it('should generate a library with a standalone component as entry point with routing setup and attach it to standalone parent module as direct child', async () => {
       // ARRANGE
-      await applicationGenerator(tree, {
+      await generateTestApplication(tree, {
         name: 'app1',
         routing: true,
         standalone: true,
@@ -1494,7 +1490,7 @@ describe('lib', () => {
 
     it('should generate a library with a standalone component as entry point with routing setup and attach it to standalone parent module as a lazy child', async () => {
       // ARRANGE
-      await applicationGenerator(tree, {
+      await generateTestApplication(tree, {
         name: 'app1',
         routing: true,
         standalone: true,

--- a/packages/angular/src/generators/move/lib/update-module-name.spec.ts
+++ b/packages/angular/src/generators/move/lib/update-module-name.spec.ts
@@ -3,7 +3,7 @@ import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import { moveGenerator } from '@nrwl/workspace/generators';
 import { UnitTestRunner } from '../../../utils/test-runners';
-import libraryGenerator from '../../library/library';
+import { generateTestLibrary } from '../../utils/testing';
 import { Schema } from '../schema';
 import { updateModuleName } from './update-module-name';
 
@@ -16,7 +16,7 @@ describe('updateModuleName Rule', () => {
 
   it('should handle nesting resulting in the same project name', async () => {
     const updatedModulePath = '/libs/my/first/src/lib/my-first.module.ts';
-    await libraryGenerator(tree, {
+    await generateTestLibrary(tree, {
       name: 'my-first',
       simpleName: true,
     });
@@ -49,7 +49,7 @@ describe('updateModuleName Rule', () => {
     };
 
     beforeEach(async () => {
-      await libraryGenerator(tree, {
+      await generateTestLibrary(tree, {
         name: 'my-first',
         buildable: false,
         linter: Linter.EsLint,
@@ -58,7 +58,7 @@ describe('updateModuleName Rule', () => {
         skipFormat: false,
         unitTestRunner: UnitTestRunner.Jest,
       });
-      await libraryGenerator(tree, {
+      await generateTestLibrary(tree, {
         name: 'my-second',
         buildable: false,
         linter: Linter.EsLint,
@@ -164,7 +164,7 @@ describe('updateModuleName Rule', () => {
 
     beforeEach(async () => {
       // fake a mid-move tree:
-      await libraryGenerator(tree, {
+      await generateTestLibrary(tree, {
         name: 'my-destination',
         buildable: false,
         linter: Linter.EsLint,
@@ -209,7 +209,7 @@ describe('updateModuleName Rule', () => {
       tree.delete(modulePath);
       tree.delete(moduleSpecPath);
 
-      await libraryGenerator(tree, {
+      await generateTestLibrary(tree, {
         name: 'my-importer',
         buildable: false,
         linter: Linter.EsLint,

--- a/packages/angular/src/generators/move/move.spec.ts
+++ b/packages/angular/src/generators/move/move.spec.ts
@@ -1,10 +1,10 @@
-import { readJson, Tree } from '@nrwl/devkit';
 import * as devkit from '@nrwl/devkit';
+import { readJson, Tree } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import { angularMoveGenerator } from './move';
-import libraryGenerator from '../library/library';
 import { Linter } from '@nrwl/linter';
 import { UnitTestRunner } from '../../utils/test-runners';
+import { generateTestLibrary } from '../utils/testing';
+import { angularMoveGenerator } from './move';
 
 describe('@nrwl/angular:move', () => {
   let tree: Tree;
@@ -12,7 +12,7 @@ describe('@nrwl/angular:move', () => {
   beforeEach(async () => {
     tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
 
-    await libraryGenerator(tree, {
+    await generateTestLibrary(tree, {
       name: 'mylib',
       buildable: false,
       linter: Linter.EsLint,
@@ -38,7 +38,7 @@ describe('@nrwl/angular:move', () => {
   });
 
   it('should update ng-package.json dest property', async () => {
-    await libraryGenerator(tree, { name: 'mylib2', buildable: true });
+    await generateTestLibrary(tree, { name: 'mylib2', buildable: true });
 
     await angularMoveGenerator(tree, {
       projectName: 'mylib2',

--- a/packages/angular/src/generators/ngrx/ngrx.spec.ts
+++ b/packages/angular/src/generators/ngrx/ngrx.spec.ts
@@ -2,6 +2,7 @@ import type { Tree } from '@nrwl/devkit';
 import * as devkit from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { dirname } from 'path';
+import { backwardCompatibleVersions } from '../../utils/backward-compatible-versions';
 import {
   AppConfig,
   createApp,
@@ -10,10 +11,9 @@ import {
   getLibConfig,
 } from '../../utils/nx-devkit/testing';
 import { ngrxVersion } from '../../utils/versions';
+import { generateTestApplication } from '../utils/testing';
 import { ngrxGenerator } from './ngrx';
-import applicationGenerator from '../application/application';
 import type { NgRxGeneratorOptions } from './schema';
-import { backwardCompatibleVersions } from '../../utils/backward-compatible-versions';
 
 describe('ngrx', () => {
   let appConfig: AppConfig;
@@ -496,7 +496,7 @@ describe('ngrx', () => {
     beforeEach(async () => {
       jest.clearAllMocks();
       tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-      await applicationGenerator(tree, {
+      await generateTestApplication(tree, {
         name: 'my-app',
         standalone: true,
         routing: true,
@@ -640,7 +640,7 @@ describe('ngrx', () => {
     beforeEach(async () => {
       jest.clearAllMocks();
       tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-      await applicationGenerator(tree, { name: 'myapp' });
+      await generateTestApplication(tree, { name: 'myapp' });
       devkit.updateJson(tree, 'package.json', (json) => ({
         ...json,
         dependencies: {

--- a/packages/angular/src/generators/remote/remote.spec.ts
+++ b/packages/angular/src/generators/remote/remote.spec.ts
@@ -1,3 +1,4 @@
+import { E2eTestRunner } from '@nrwl/angular/src/utils/test-runners';
 import {
   getProjects,
   readNxJson,
@@ -6,9 +7,10 @@ import {
   updateJson,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import host from '../host/host';
-import remote from './remote';
-import { E2eTestRunner } from '@nrwl/angular/src/utils/test-runners';
+import {
+  generateTestHostApplication,
+  generateTestRemoteApplication,
+} from '../utils/testing';
 
 describe('MF Remote App Generator', () => {
   it('should generate a remote mf app with no host', async () => {
@@ -16,7 +18,7 @@ describe('MF Remote App Generator', () => {
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
 
     // ACT
-    await remote(tree, {
+    await generateTestRemoteApplication(tree, {
       name: 'test',
       port: 4201,
     });
@@ -29,12 +31,12 @@ describe('MF Remote App Generator', () => {
     // ARRANGE
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
 
-    await host(tree, {
+    await generateTestHostApplication(tree, {
       name: 'host',
     });
 
     // ACT
-    await remote(tree, {
+    await generateTestRemoteApplication(tree, {
       name: 'test',
       host: 'host',
     });
@@ -50,7 +52,7 @@ describe('MF Remote App Generator', () => {
 
     // ACT
     try {
-      await remote(tree, {
+      await generateTestRemoteApplication(tree, {
         name: 'test',
         host: 'host',
       });
@@ -65,13 +67,13 @@ describe('MF Remote App Generator', () => {
   it('should generate a remote mf app and automatically find the next port available', async () => {
     // ARRANGE
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-    await remote(tree, {
+    await generateTestRemoteApplication(tree, {
       name: 'existing',
       port: 4201,
     });
 
     // ACT
-    await remote(tree, {
+    await generateTestRemoteApplication(tree, {
       name: 'test',
     });
 
@@ -85,7 +87,7 @@ describe('MF Remote App Generator', () => {
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
 
     // ACT
-    await remote(tree, {
+    await generateTestRemoteApplication(tree, {
       name: 'test',
     });
 
@@ -99,7 +101,7 @@ describe('MF Remote App Generator', () => {
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
 
     // ACT
-    await remote(tree, {
+    await generateTestRemoteApplication(tree, {
       name: 'test',
       port: 4201,
     });
@@ -114,7 +116,7 @@ describe('MF Remote App Generator', () => {
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
 
     // ACT
-    await remote(tree, {
+    await generateTestRemoteApplication(tree, {
       name: 'test',
       standalone: true,
     });
@@ -145,7 +147,7 @@ describe('MF Remote App Generator', () => {
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
 
     // ACT
-    await remote(tree, {
+    await generateTestRemoteApplication(tree, {
       name: 'remote1',
       e2eTestRunner: E2eTestRunner.None,
     });
@@ -160,7 +162,7 @@ describe('MF Remote App Generator', () => {
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
 
     // ACT
-    await remote(tree, {
+    await generateTestRemoteApplication(tree, {
       name: 'test',
       inlineTemplate: true,
     });
@@ -184,7 +186,7 @@ describe('MF Remote App Generator', () => {
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
 
     // ACT
-    await remote(tree, {
+    await generateTestRemoteApplication(tree, {
       name: 'test',
       standalone: true,
     });
@@ -204,7 +206,7 @@ describe('MF Remote App Generator', () => {
       const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
 
       // ACT
-      await remote(tree, {
+      await generateTestRemoteApplication(tree, {
         name: 'test',
         ssr: true,
       });
@@ -262,7 +264,7 @@ describe('MF Remote App Generator', () => {
 
     // ACT & ASSERT
     await expect(
-      remote(tree, {
+      generateTestRemoteApplication(tree, {
         name: 'test',
         standalone: true,
       })

--- a/packages/angular/src/generators/scam-to-standalone/scam-to-standalone.spec.ts
+++ b/packages/angular/src/generators/scam-to-standalone/scam-to-standalone.spec.ts
@@ -1,13 +1,13 @@
-import { scamToStandalone } from './scam-to-standalone';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import applicationGenerator from '../application/application';
-import scamGenerator from '../scam/scam';
 import { stripIndents, updateJson } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import scamGenerator from '../scam/scam';
+import { generateTestApplication } from '../utils/testing';
+import { scamToStandalone } from './scam-to-standalone';
 
 describe('scam-to-standalone', () => {
   it('should convert an inline scam to standalone', async () => {
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-    await applicationGenerator(tree, { name: 'foo' });
+    await generateTestApplication(tree, { name: 'foo' });
     await scamGenerator(tree, { name: 'bar', project: 'foo' });
 
     tree.write(

--- a/packages/angular/src/generators/setup-mf/setup-mf.spec.ts
+++ b/packages/angular/src/generators/setup-mf/setup-mf.spec.ts
@@ -5,20 +5,19 @@ import {
   updateJson,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-
+import { generateTestApplication } from '../utils/testing';
 import { setupMf } from './setup-mf';
-import applicationGenerator from '../application/application';
 
 describe('Init MF', () => {
   let tree: Tree;
 
   beforeEach(async () => {
     tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-    await applicationGenerator(tree, {
+    await generateTestApplication(tree, {
       name: 'app1',
       routing: true,
     });
-    await applicationGenerator(tree, {
+    await generateTestApplication(tree, {
       name: 'remote1',
       routing: true,
     });
@@ -204,7 +203,7 @@ describe('Init MF', () => {
 
   it('should add a remote application and add it to a specified host applications webpack config that contains a remote application already', async () => {
     // ARRANGE
-    await applicationGenerator(tree, {
+    await generateTestApplication(tree, {
       name: 'remote2',
     });
 
@@ -238,7 +237,7 @@ describe('Init MF', () => {
 
   it('should add a remote application and add it to a specified host applications router config', async () => {
     // ARRANGE
-    await applicationGenerator(tree, {
+    await generateTestApplication(tree, {
       name: 'remote2',
       routing: true,
     });
@@ -273,7 +272,7 @@ describe('Init MF', () => {
 
   it('should modify the associated cypress project to add the workaround correctly', async () => {
     // ARRANGE
-    await applicationGenerator(tree, {
+    await generateTestApplication(tree, {
       name: 'testApp',
       routing: true,
     });
@@ -327,7 +326,7 @@ describe('Init MF', () => {
       },
     }));
 
-    await applicationGenerator(tree, {
+    await generateTestApplication(tree, {
       name: 'ng14',
       routing: true,
       standalone: true,

--- a/packages/angular/src/generators/setup-ssr/setup-ssr.spec.ts
+++ b/packages/angular/src/generators/setup-ssr/setup-ssr.spec.ts
@@ -8,16 +8,15 @@ import {
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { PackageJson } from 'nx/src/utils/package-json';
 import { angularVersion, ngUniversalVersion } from '../../utils/versions';
-
-import applicationGenerator from '../application/application';
-import setupSsr from './setup-ssr';
+import { generateTestApplication } from '../utils/testing';
+import { setupSsr } from './setup-ssr';
 
 describe('setupSSR', () => {
   it('should create the files correctly for ssr', async () => {
     // ARRANGE
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
 
-    await applicationGenerator(tree, {
+    await generateTestApplication(tree, {
       name: 'app1',
     });
 
@@ -155,7 +154,7 @@ describe('setupSSR', () => {
     // ARRANGE
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
 
-    await applicationGenerator(tree, {
+    await generateTestApplication(tree, {
       name: 'app1',
     });
 
@@ -183,7 +182,7 @@ describe('setupSSR', () => {
     // ARRANGE
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
 
-    await applicationGenerator(tree, {
+    await generateTestApplication(tree, {
       name: 'app1',
     });
 

--- a/packages/angular/src/generators/stories/stories-app.spec.ts
+++ b/packages/angular/src/generators/stories/stories-app.spec.ts
@@ -1,14 +1,15 @@
 import { installedCypressVersion } from '@nrwl/cypress/src/utils/cypress-version';
 import type { Tree } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import { applicationGenerator } from '../application/application';
-import { scamGenerator } from '../scam/scam';
 import { componentGenerator } from '../component/component';
+import { scamGenerator } from '../scam/scam';
+import { generateTestApplication } from '../utils/testing';
 import { angularStoriesGenerator } from './stories';
 
 // need to mock cypress otherwise it'll use the nx installed version from package.json
 //  which is v9 while we are testing for the new v10 version
 jest.mock('@nrwl/cypress/src/utils/cypress-version');
+
 describe('angularStories generator: applications', () => {
   let tree: Tree;
   const appName = 'test-app';
@@ -19,7 +20,7 @@ describe('angularStories generator: applications', () => {
   beforeEach(async () => {
     mockedInstalledCypressVersion.mockReturnValue(10);
     tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-    await applicationGenerator(tree, {
+    await generateTestApplication(tree, {
       name: appName,
     });
   });

--- a/packages/angular/src/generators/stories/stories-lib.spec.ts
+++ b/packages/angular/src/generators/stories/stories-lib.spec.ts
@@ -5,10 +5,13 @@ import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import { componentGenerator } from '../component/component';
 import { librarySecondaryEntryPointGenerator } from '../library-secondary-entry-point/library-secondary-entry-point';
-import { libraryGenerator } from '../library/library';
 import { scamGenerator } from '../scam/scam';
-import { createStorybookTestWorkspaceForLib } from '../utils/testing';
+import {
+  createStorybookTestWorkspaceForLib,
+  generateTestLibrary,
+} from '../utils/testing';
 import { angularStoriesGenerator } from './stories';
+
 // need to mock cypress otherwise it'll use the nx installed version from package.json
 //  which is v9 while we are testing for the new v10 version
 jest.mock('@nrwl/cypress/src/utils/cypress-version');
@@ -28,7 +31,7 @@ describe('angularStories generator: libraries', () => {
 
     beforeEach(async () => {
       tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-      await libraryGenerator(tree, { name: libName });
+      await generateTestLibrary(tree, { name: libName });
     });
 
     it('should not fail on empty NgModule declarations', () => {

--- a/packages/angular/src/generators/storybook-configuration/storybook-configuration.spec.ts
+++ b/packages/angular/src/generators/storybook-configuration/storybook-configuration.spec.ts
@@ -8,6 +8,7 @@ import { librarySecondaryEntryPointGenerator } from '../library-secondary-entry-
 import { createStorybookTestWorkspaceForLib } from '../utils/testing';
 import type { StorybookConfigurationOptions } from './schema';
 import { storybookConfigurationGenerator } from './storybook-configuration';
+
 // need to mock cypress otherwise it'll use the nx installed version from package.json
 //  which is v9 while we are testing for the new v10 version
 jest.mock('@nrwl/cypress/src/utils/cypress-version');

--- a/packages/angular/src/generators/utils/testing.ts
+++ b/packages/angular/src/generators/utils/testing.ts
@@ -1,13 +1,55 @@
 import type { Tree } from '@nrwl/devkit';
+import { updateJson } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { Linter } from '@nrwl/linter';
 import { UnitTestRunner } from '../../utils/test-runners';
-import libraryGenerator from '../library/library';
+import { angularDevkitVersion } from '../../utils/versions';
+import { applicationGenerator } from '../application/application';
+import type { Schema as ApplicationOptions } from '../application/schema';
+import { host } from '../host/host';
+import type { Schema as HostOptions } from '../host/schema';
+import { libraryGenerator } from '../library/library';
+import type { Schema as LibraryOptions } from '../library/schema';
+import { remote } from '../remote/remote';
+import type { Schema as RemoteOptions } from '../remote/schema';
+
+export async function generateTestApplication(
+  tree: Tree,
+  options: ApplicationOptions
+): Promise<void> {
+  addAngularPluginPeerDeps(tree);
+  await applicationGenerator(tree, options);
+}
+
+export async function generateTestHostApplication(
+  tree: Tree,
+  options: HostOptions
+): Promise<void> {
+  addAngularPluginPeerDeps(tree);
+  await host(tree, options);
+}
+
+export async function generateTestRemoteApplication(
+  tree: Tree,
+  options: RemoteOptions
+): Promise<void> {
+  addAngularPluginPeerDeps(tree);
+  await remote(tree, options);
+}
+
+export async function generateTestLibrary(
+  tree: Tree,
+  options: LibraryOptions
+): Promise<void> {
+  addAngularPluginPeerDeps(tree);
+  await libraryGenerator(tree, options);
+}
 
 export async function createStorybookTestWorkspaceForLib(
   libName: string
 ): Promise<Tree> {
   let tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  addAngularPluginPeerDeps(tree);
 
   const { wrapAngularDevkitSchematic } = require('@nrwl/devkit/ngcli-adapter');
   const moduleGenerator = wrapAngularDevkitSchematic(
@@ -240,4 +282,16 @@ export class StaticMemberDeclarationsModule {
   });
 
   return tree;
+}
+
+function addAngularPluginPeerDeps(tree: Tree): void {
+  updateJson(tree, 'package.json', (json) => ({
+    ...json,
+    devDependencies: {
+      ...json.devDependencies,
+      '@angular-devkit/core': angularDevkitVersion,
+      '@angular-devkit/schematics': angularDevkitVersion,
+      '@schematics/angular': angularDevkitVersion,
+    },
+  }));
 }

--- a/packages/angular/src/generators/web-worker/web-worker.spec.ts
+++ b/packages/angular/src/generators/web-worker/web-worker.spec.ts
@@ -1,7 +1,7 @@
 import type { Tree } from '@nrwl/devkit';
 import * as devkit from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import { applicationGenerator } from '../application/application';
+import { generateTestApplication } from '../utils/testing';
 import { webWorkerGenerator } from './web-worker';
 
 describe('webWorker generator', () => {
@@ -10,7 +10,7 @@ describe('webWorker generator', () => {
 
   beforeEach(async () => {
     tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-    await applicationGenerator(tree, { name: appName });
+    await generateTestApplication(tree, { name: appName });
     jest.clearAllMocks();
   });
 

--- a/packages/angular/src/migrations/update-14-8-0/rename-webpack-server.spec.ts
+++ b/packages/angular/src/migrations/update-14-8-0/rename-webpack-server.spec.ts
@@ -1,13 +1,13 @@
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { readJson, updateJson } from '@nrwl/devkit';
-import remote from '../../generators/remote/remote';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { generateTestRemoteApplication } from '../../generators/utils/testing';
 import renameWebpackServer from './rename-webpack-server';
 
 describe('renameWebpackServer', () => {
   it('should rename webpack-server to webpack-dev-server correctly', async () => {
     // ARRANGE
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-    await remote(tree, { name: 'remote' });
+    await generateTestRemoteApplication(tree, { name: 'remote' });
 
     updateJson(tree, 'apps/remote/project.json', (json) => {
       json.targets.serve.executor = '@nrwl/angular:webpack-server';

--- a/packages/angular/src/migrations/update-15-2-0/remove-browserlist-config.spec.ts
+++ b/packages/angular/src/migrations/update-15-2-0/remove-browserlist-config.spec.ts
@@ -1,16 +1,16 @@
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import type { Tree } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { generateTestApplication } from '../../generators/utils/testing';
 import removeBrowserlistConfig, {
   DEFAULT_BROWSERS,
 } from './remove-browserlist-config';
-import applicationGenerator from '../../generators/application/application';
 
 describe('Migration to delete Browserslist configurations', () => {
   let tree: Tree;
 
   beforeEach(async () => {
     tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-    await applicationGenerator(tree, {
+    await generateTestApplication(tree, {
       name: 'test',
     });
   });

--- a/packages/angular/src/migrations/update-15-2-0/update-typescript-target.spec.ts
+++ b/packages/angular/src/migrations/update-15-2-0/update-typescript-target.spec.ts
@@ -1,3 +1,4 @@
+import { UnitTestRunner } from '@nrwl/angular/src/utils/test-runners';
 import {
   readJson,
   readProjectConfiguration,
@@ -6,18 +7,17 @@ import {
   writeJson,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import applicationGenerator from '../../generators/application/application';
+import { generateTestApplication } from '../../generators/utils/testing';
 import updateTypescriptTarget from './update-typescript-target';
-import { UnitTestRunner } from '@nrwl/angular/src/utils/test-runners';
 
 describe('Migration to update target and add useDefineForClassFields', () => {
   let tree: Tree;
   beforeEach(async () => {
     tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-    await applicationGenerator(tree, {
+    await generateTestApplication(tree, {
       name: 'test',
     });
-    await applicationGenerator(tree, {
+    await generateTestApplication(tree, {
       name: 'karma',
       unitTestRunner: UnitTestRunner.Karma,
     });

--- a/packages/angular/src/migrations/update-15-2-0/update-typescript-target.spec.ts
+++ b/packages/angular/src/migrations/update-15-2-0/update-typescript-target.spec.ts
@@ -1,4 +1,3 @@
-import { UnitTestRunner } from '@nrwl/angular/src/utils/test-runners';
 import {
   readJson,
   readProjectConfiguration,
@@ -8,6 +7,7 @@ import {
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { generateTestApplication } from '../../generators/utils/testing';
+import { UnitTestRunner } from '../../utils/test-runners';
 import updateTypescriptTarget from './update-typescript-target';
 
 describe('Migration to update target and add useDefineForClassFields', () => {

--- a/packages/angular/src/migrations/update-15-2-0/update-workspace-config.spec.ts
+++ b/packages/angular/src/migrations/update-15-2-0/update-workspace-config.spec.ts
@@ -1,16 +1,16 @@
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import applicationGenerator from '../../generators/application/application';
-import updateWorkspaceConfig from './update-workspace-config';
+import { Builders } from '@schematics/angular/utility/workspace-models';
 import {
   readProjectConfiguration,
   updateProjectConfiguration,
 } from 'nx/src/generators/utils/project-configuration';
-import { Builders } from '@schematics/angular/utility/workspace-models';
+import { generateTestApplication } from '../../generators/utils/testing';
+import updateWorkspaceConfig from './update-workspace-config';
 
 describe(`Migration to remove bundleDependencies`, () => {
   it(`should remove 'bundleDependencies'`, async () => {
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-    await applicationGenerator(tree, {
+    await generateTestApplication(tree, {
       name: 'test',
     });
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When running the Angular plugin unit tests, several package installations occurs. This happens because the `init` generator (invoked from app, lib, host, remote generators) install the plugin peer deps if they are not found in the `package.json` that's on the `Tree`. This also causes a degradation in the performance of the tests.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When running the Angular plugin unit tests, no package installations should occur. The `Tree` used in the tests should contain the required peer deps in the `package.json`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
