### PR TITLE
fix(repo): disable long running manual dispatch

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       debug_enabled:
+        type: boolean
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
         required: false
         default: false
@@ -173,7 +174,7 @@ jobs:
           NX_CACHE_DIRECTORY: ${{ 'tmp' }}
 
       - name: Setup tmate session
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled && failure() }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled && failure() }}
         uses: mxschmitt/action-tmate@v3.8
 
   report-success:

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       debug_enabled:
+        type: boolean
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
         required: false
         default: false
@@ -88,7 +89,7 @@ jobs:
         NX_CACHE_DIRECTORY: ${{ 'tmp' }}
 
     - name: Setup tmate session
-      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled && failure() }}
+      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled && failure() }}
       uses: mxschmitt/action-tmate@v3.8
       with:
         sudo: false # disable sudo for windows debugging


### PR DESCRIPTION
Manual workflow runs do not properly skip tmate step when not explicitly selected.

This PR changes the input from string to boolean to resolve that.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
