### PR TITLE
docs(bundling): updating rspack overview and add app generator

### DIFF
--- a/nx-dev/nx-dev/lib/rspack/content/overview.ts
+++ b/nx-dev/nx-dev/lib/rspack/content/overview.ts
@@ -48,7 +48,23 @@ pnpm add -D @nrwl/rspack@latest
 {% /tab %}
 {% /tabs %}
 
-### Generate a new project using Rspack
+### Generate a new React project using Rspack
+
+The easiest way to generate a new application that uses Rspack is by using the \`@nrwl/rspack:app\` generator.
+
+\`\`\`bash
+nx g @nrwl/rspack:app my-app --style=css
+\`\`\`
+
+Then you should be able to serve, test, and build the application.
+
+\`\`\`bash
+nx serve my-app
+nx test my-app
+nx build my-app
+\`\`\`
+
+### Generate a non-React project using Rspack
 
 You can generate a [Web](/packages/web) application, and then use the \`@nrwl/rspack:configuration\` generator to configure the build and serve targets.
 

--- a/nx-dev/nx-dev/lib/rspack/pkg.ts
+++ b/nx-dev/nx-dev/lib/rspack/pkg.ts
@@ -76,6 +76,16 @@ export const pkg: ProcessedPackageMetadata = {
       path: '/packages/rspack/generators/configuration',
       type: 'generator',
     },
+    '/packages/rspack/generators/application': {
+      description: 'Add Rspack application to a project.',
+      file: 'generated/packages/rspack/generators/application.json',
+      hidden: false,
+      name: 'application',
+      originalFilePath:
+        '/packages/rspack/src/generators/application/schema.json',
+      path: '/packages/rspack/generators/application',
+      type: 'generator',
+    },
   },
   githubRoot: 'https://github.com/nrwl/nx-labs/tree/main/packages/rspack',
   name: 'Rspack',

--- a/nx-dev/nx-dev/lib/rspack/schema/generators/application.ts
+++ b/nx-dev/nx-dev/lib/rspack/schema/generators/application.ts
@@ -1,0 +1,106 @@
+export const schema = {
+  name: 'application',
+  factory: './src/generators/application/application#applicationGenerator',
+  schema: {
+    $schema: 'http://json-schema.org/schema',
+    cli: 'nx',
+    $id: 'Application',
+    title: 'Application generator for React + rspack',
+    type: 'object',
+    examples: [
+      {
+        command: 'nx g app myapp --directory=myorg',
+        description: 'Generate `apps/myorg/myapp` and `apps/myorg/myapp-e2e`',
+      },
+    ],
+    properties: {
+      name: {
+        description: 'The name of the application.',
+        type: 'string',
+        $default: {
+          $source: 'argv',
+          index: 0,
+        },
+        'x-prompt': 'What name would you like to use for the application?',
+        pattern: '^[a-zA-Z].*$',
+        'x-priority': 'important',
+      },
+      style: {
+        description: 'The file extension to be used for style files.',
+        type: 'string',
+        default: 'css',
+        alias: 's',
+        'x-prompt': {
+          message: 'Which stylesheet format would you like to use?',
+          type: 'list',
+          items: [
+            {
+              value: 'css',
+              label: 'CSS',
+            },
+            {
+              value: 'scss',
+              label:
+                'SASS(.scss)       [ http://sass-lang.com                     ]',
+            },
+            {
+              value: 'styl',
+              label:
+                'Stylus(.styl)     [ http://stylus-lang.com                   ]',
+            },
+            {
+              value: 'less',
+              label:
+                'LESS              [ http://lesscss.org                       ]',
+            },
+            {
+              value: 'none',
+              label: 'None',
+            },
+          ],
+        },
+      },
+      unitTestRunner: {
+        type: 'string',
+        description: 'The unit test runner to use.',
+        enum: ['none', 'jest'],
+        default: 'jest',
+      },
+      e2eTestRunner: {
+        type: 'string',
+        description: 'The e2e test runner to use.',
+        enum: ['none', 'cypress'],
+        default: 'cypress',
+      },
+      directory: {
+        type: 'string',
+        description: 'The directory to nest the app under.',
+      },
+      tags: {
+        type: 'array',
+        description: 'The tags to assign to the project.',
+        items: {
+          type: 'string',
+        },
+        default: [],
+      },
+      monorepo: {
+        type: 'boolean',
+        description: 'Creates an integrated monorepo.',
+        aliases: ['integrated'],
+      },
+      rootProject: {
+        type: 'boolean',
+        'x-priority': 'internal',
+      },
+    },
+    required: ['name'],
+  },
+  description: 'Generates a React + Rspack project.',
+  aliases: [],
+  hidden: false,
+  implementation:
+    '/packages/rspack/src/generators/application/application#applicationGenerator.ts',
+  path: '/packages/rspack/src/generators/application/schema.json',
+  type: 'generator',
+};

--- a/nx-dev/nx-dev/lib/rspack/schema/generators/configuration.ts
+++ b/nx-dev/nx-dev/lib/rspack/schema/generators/configuration.ts
@@ -57,7 +57,7 @@ export const schema = {
     },
     required: ['project'],
   },
-  description: 'configurationialize the `@nrwl/rspack` plugin.',
+  description: 'Configures Rspack for a project.',
   aliases: [],
   hidden: false,
   implementation:

--- a/nx-dev/nx-dev/pages/packages/index.tsx
+++ b/nx-dev/nx-dev/pages/packages/index.tsx
@@ -40,7 +40,6 @@ export default function Packages({
     },
     packages: useMemo(() => {
       const storybookIdx = packages.findIndex((p) => p.name === 'storybook');
-      console.log({ packages, storybookIdx });
       const packagesWithRspack = [
         ...packages.slice(0, storybookIdx),
         {

--- a/nx-dev/nx-dev/pages/packages/rspack/generators/application.tsx
+++ b/nx-dev/nx-dev/pages/packages/rspack/generators/application.tsx
@@ -1,0 +1,99 @@
+import { PackageSchemaViewer } from '@nrwl/nx-dev-feature-package-schema-viewer';
+import { getPackagesSections } from '@nrwl/nx-dev/data-access-menu';
+import { sortCorePackagesFirst } from '@nrwl/nx-dev/data-access-packages';
+import { Menu, MenuItem, MenuSection } from '@nrwl/nx-dev/models-menu';
+import {
+  ProcessedPackageMetadata,
+  SchemaMetadata,
+} from '@nrwl/nx-dev/models-package';
+import { DocumentationHeader, SidebarContainer } from '@nrwl/nx-dev/ui-common';
+import { useRouter } from 'next/router';
+import { useEffect, useRef } from 'react';
+import { menusApi } from '../../../../lib/menus.api';
+import { useNavToggle } from '../../../../lib/navigation-toggle.effect';
+import { schema } from '../../../../lib/rspack/schema/generators/application';
+import { pkg } from '../../../../lib/rspack/pkg';
+
+export default function ApplicationGenerator({
+  menu,
+  pkg,
+  schema,
+}: {
+  menu: MenuItem[];
+  pkg: ProcessedPackageMetadata;
+  schema: SchemaMetadata;
+}): JSX.Element {
+  const router = useRouter();
+  const { toggleNav, navIsOpen } = useNavToggle();
+  const wrapperElement = useRef(null);
+
+  useEffect(() => {
+    const handleRouteChange = (url: string) => {
+      if (url.includes('#')) return;
+      if (!wrapperElement) return;
+
+      (wrapperElement as any).current.scrollTo({
+        top: 0,
+        left: 0,
+        behavior: 'smooth',
+      });
+    };
+
+    router.events.on('routeChangeComplete', handleRouteChange);
+    return () => router.events.off('routeChangeComplete', handleRouteChange);
+  }, [router, wrapperElement]);
+
+  const vm: {
+    menu: Menu;
+    package: ProcessedPackageMetadata;
+    schema: SchemaMetadata;
+  } = {
+    menu: {
+      sections: sortCorePackagesFirst<MenuSection>(
+        getPackagesSections(menu),
+        'id'
+      ),
+    },
+    package: pkg,
+    schema: schema,
+  };
+
+  /**
+   * Show either the docviewer or the package view depending on:
+   * - docviewer: it is a documentation document
+   * - packageviewer: it is package generated documentation
+   */
+
+  return (
+    <div id="shell" className="flex h-full flex-col">
+      <div className="w-full flex-shrink-0">
+        <DocumentationHeader isNavOpen={navIsOpen} toggleNav={toggleNav} />
+      </div>
+      <main
+        id="main"
+        role="main"
+        className="flex h-full flex-1 overflow-y-hidden"
+      >
+        <SidebarContainer menu={vm.menu} navIsOpen={navIsOpen} />
+        <div
+          ref={wrapperElement}
+          id="wrapper"
+          data-testid="wrapper"
+          className="relative flex flex-grow flex-col items-stretch justify-start overflow-y-scroll"
+        >
+          <PackageSchemaViewer pkg={vm.package} schema={vm.schema} />
+        </div>
+      </main>
+    </div>
+  );
+}
+
+export async function getStaticProps() {
+  return {
+    props: {
+      pkg,
+      schema,
+      menu: menusApi.getMenu('packages', 'packages'),
+    },
+  };
+}

--- a/nx-dev/ui-common/src/lib/sidebar-container.tsx
+++ b/nx-dev/ui-common/src/lib/sidebar-container.tsx
@@ -86,6 +86,14 @@ const rspackSection = {
           isExternal: false,
           disableCollapsible: false,
         },
+        {
+          id: 'application',
+          path: '/packages/rspack/generators/application',
+          name: 'application',
+          children: [],
+          isExternal: false,
+          disableCollapsible: false,
+        },
       ],
       isExternal: false,
       disableCollapsible: false,
@@ -104,11 +112,14 @@ export function SidebarContainer({
   // TODO(jack): Remove this rspack modification once we move rspack into main repo (when stable).
   const menuWithRspack = useMemo(() => {
     const storybookIdx = menu.sections.findIndex((s) => s.id === 'storybook');
-    const sections = [
-      ...menu.sections.slice(0, storybookIdx),
-      rspackSection,
-      ...menu.sections.slice(storybookIdx),
-    ];
+    const sections =
+      storybookIdx > -1
+        ? [
+            ...menu.sections.slice(0, storybookIdx),
+            rspackSection,
+            ...menu.sections.slice(storybookIdx),
+          ]
+        : menu.sections;
     return {
       ...menu,
       sections,


### PR DESCRIPTION
Adding updates missed in the last PR: https://github.com/nrwl/nx/commit/d7a008ff5e33c5a6a2a1037abd70aad7f311da18.

- Add `@nrwl/rspack:app` generator to docs.
- Overview page for Rspack now mentions `@nrwl/rspack:app` as the first option to highlight React+Rspack more.