### PR TITLE
fix(storybook): better detection of failed migrations

### DIFF
--- a/packages/storybook/src/generators/migrate-7/__snapshots__/helper-functions.spec.ts.snap
+++ b/packages/storybook/src/generators/migrate-7/__snapshots__/helper-functions.spec.ts.snap
@@ -169,6 +169,8 @@ Please make sure to check the results yourself and make sure that everything is 
 
 
 
+### Some migrations failed
+
 The following commands failed and your Storybook configuration for these projects was not
 migrated to the latest version 7:
 
@@ -181,6 +183,10 @@ migrated to the latest version 7:
 You can run these commands again, manually, and follow the instructions in the
 output of these commands to migrate your Storybook configuration to the latest version 7.
 
+
+Also, we may have missed something. Please make sure to check the logs of the Storybook CLI commands that were run, and look for 
+the \`❌ Failed trying to evaluate\` message or \`❌ The migration failed to update\` message. This will indicate if a command was 
+unsuccessful, and will help you run the migration again, manually.
 
 ## Final adjustments
 

--- a/packages/storybook/src/generators/migrate-7/calling-storybook-cli.ts
+++ b/packages/storybook/src/generators/migrate-7/calling-storybook-cli.ts
@@ -79,24 +79,14 @@ export function callAutomigrate(
           color: 'green',
         });
 
-        const result = execSync(
+        execSync(
           `${commandToRun}  ${schema.autoAcceptAllPrompts ? '--yes' : ''}`,
           {
-            stdio: [0, 1, 2],
+            stdio: 'inherit',
           }
         );
 
-        const outputResult = result?.toString();
-
-        if (
-          outputResult?.includes(
-            `The migration failed to update your ${storybookProjectInfo.configDir}`
-          )
-        ) {
-          resultOfMigration.failedProjects[projectName] = commandToRun;
-        } else {
-          resultOfMigration.successfulProjects[projectName] = commandToRun;
-        }
+        resultOfMigration.successfulProjects[projectName] = commandToRun;
       } catch (e) {
         output.error({
           title: 'Migration failed',

--- a/packages/storybook/src/generators/migrate-7/files/storybook-migration-summary.md__tmpl__
+++ b/packages/storybook/src/generators/migrate-7/files/storybook-migration-summary.md__tmpl__
@@ -30,6 +30,8 @@ Please make sure to check the results yourself and make sure that everything is 
 <% } %>
 
 <% if ( hasFailedProjects ) { %>
+### Some migrations failed
+
 The following commands failed and your Storybook configuration for these projects was not
 migrated to the latest version 7:
 
@@ -40,6 +42,10 @@ migrated to the latest version 7:
 You can run these commands again, manually, and follow the instructions in the
 output of these commands to migrate your Storybook configuration to the latest version 7.
 <% } %>
+
+Also, we may have missed something. Please make sure to check the logs of the Storybook CLI commands that were run, and look for 
+the `❌ Failed trying to evaluate` message or `❌ The migration failed to update` message. This will indicate if a command was 
+unsuccessful, and will help you run the migration again, manually.
 
 ## Final adjustments
 

--- a/packages/storybook/src/generators/migrate-7/helper-functions.ts
+++ b/packages/storybook/src/generators/migrate-7/helper-functions.ts
@@ -7,11 +7,15 @@ import {
   readProjectConfiguration,
   Tree,
   updateProjectConfiguration,
+  workspaceRoot,
 } from '@nrwl/devkit';
 import { forEachExecutorOptions } from '@nrwl/workspace/src/utilities/executor-options-utils';
 import { tsquery } from '@phenomnomnominal/tsquery';
 import ts = require('typescript');
 import * as fs from 'fs';
+import { fileExists } from 'nx/src/utils/fileutils';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 export function onlyShowGuide(storybookProjects: {
   [key: string]: {
@@ -530,10 +534,37 @@ export function handleMigrationResult(
     successfulProjects: {};
     failedProjects: {};
   },
-  allStorybookProjectsLength: number
-) {
+  allStorybookProjects: {
+    [key: string]: {
+      configDir: string;
+      uiFramework: string;
+      viteConfigFilePath?: string;
+    };
+  }
+): { successfulProjects: {}; failedProjects: {} } {
   if (
-    allStorybookProjectsLength ===
+    fileExists(join(workspaceRoot, 'migration-storybook.log')) &&
+    Object.keys(migrateResult.successfulProjects)?.length
+  ) {
+    const sbLogFile = readFileSync(
+      join(workspaceRoot, 'migration-storybook.log'),
+      'utf-8'
+    );
+    Object.keys(migrateResult.successfulProjects).forEach((projectName) => {
+      if (
+        sbLogFile.includes(
+          `The migration failed to update your ${allStorybookProjects[projectName].configDir}`
+        )
+      ) {
+        migrateResult.failedProjects[projectName] =
+          migrateResult.successfulProjects[projectName];
+        delete migrateResult.successfulProjects[projectName];
+      }
+    });
+  }
+
+  if (
+    Object.keys(allStorybookProjects)?.length ===
       Object.keys(migrateResult.successfulProjects)?.length ||
     Object.keys(migrateResult.failedProjects)?.length === 0
   ) {
@@ -578,6 +609,7 @@ export function handleMigrationResult(
       });
     }
   }
+  return migrateResult;
 }
 
 export function checkStorybookInstalled(packageJson): boolean {

--- a/packages/storybook/src/generators/migrate-7/migrate-7.ts
+++ b/packages/storybook/src/generators/migrate-7/migrate-7.ts
@@ -68,9 +68,9 @@ export async function migrate7Generator(tree: Tree, schema: Schema) {
 
       migrateResult = callAutomigrate(allStorybookProjects, schema);
 
-      handleMigrationResult(
+      migrateResult = handleMigrationResult(
         migrateResult,
-        Object.keys(allStorybookProjects).length
+        allStorybookProjects
       );
     }
   }


### PR DESCRIPTION
## Current Behavior
Was wrongly trying to read inherited output.

## Expected Behavior
Should try to find any failed migrations in Storybook's output log.


