### PR TITLE
cleanup(angular): convert ng cli migrations to nx devkit

### DIFF
--- a/packages/angular/src/generators/ng-add/migrators/projects/e2e.migrator.ts
+++ b/packages/angular/src/generators/ng-add/migrators/projects/e2e.migrator.ts
@@ -42,7 +42,7 @@ import type {
   Target,
   ValidationResult,
 } from '../../utilities';
-import { FileChangeRecorder } from '../../utilities';
+import { FileChangeRecorder } from '../../../../utils/file-change-recorder';
 import { ProjectMigrator } from './project.migrator';
 import { ensureTypescript } from '@nrwl/js/src/utils/typescript/ensure-typescript';
 

--- a/packages/angular/src/generators/ng-add/utilities/index.ts
+++ b/packages/angular/src/generators/ng-add/utilities/index.ts
@@ -1,5 +1,4 @@
 export * from './dependencies';
-export * from './file-change-recorder';
 export * from './format-files-task';
 export * from './logger';
 export * from './normalize-options';

--- a/packages/angular/src/migrations/update-15-2-0/remove-platform-server-exports.spec.ts
+++ b/packages/angular/src/migrations/update-15-2-0/remove-platform-server-exports.spec.ts
@@ -1,0 +1,86 @@
+import type { Tree } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing-pre16';
+
+import removePlatformServerExports from './remove-platform-server-exports';
+
+describe('remove-platform-server-exports', () => {
+  let tree: Tree;
+  const testTypeScriptFilePath = 'test.ts';
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe(`Migration to remove '@angular/platform-server' exports`, () => {
+    it(`should delete '@angular/platform-server' export when 'renderModule' is the only exported symbol`, async () => {
+      tree.write(
+        testTypeScriptFilePath,
+        `
+          import { Path, join } from '@angular-devkit/core';
+          export { renderModule } from '@angular/platform-server';
+        `
+      );
+
+      await removePlatformServerExports(tree);
+
+      const content = tree.read(testTypeScriptFilePath, 'utf-8');
+      expect(content).not.toContain('@angular/platform-server');
+      expect(content).toContain(
+        `import { Path, join } from '@angular-devkit/core';`
+      );
+    });
+
+    it(`should delete only 'renderModule' when there are additional exports`, async () => {
+      tree.write(
+        testTypeScriptFilePath,
+        `
+          import { Path, join } from '@angular-devkit/core';
+          export { renderModule, ServerModule } from '@angular/platform-server';
+        `
+      );
+
+      await removePlatformServerExports(tree);
+
+      const content = tree.read(testTypeScriptFilePath, 'utf-8');
+
+      expect(content).toContain(
+        `import { Path, join } from '@angular-devkit/core';`
+      );
+      expect(content).toContain(
+        `export { ServerModule } from '@angular/platform-server';`
+      );
+    });
+
+    it(`should not delete 'renderModule' when it's exported from another module`, async () => {
+      tree.write(
+        testTypeScriptFilePath,
+        `
+          export { renderModule } from '@angular/core';
+        `
+      );
+
+      await removePlatformServerExports(tree);
+
+      const content = tree.read(testTypeScriptFilePath, 'utf-8');
+      expect(content).toContain(
+        `export { renderModule } from '@angular/core';`
+      );
+    });
+
+    it(`should not delete 'renderModule' when it's imported from '@angular/platform-server'`, async () => {
+      tree.write(
+        testTypeScriptFilePath,
+        `
+          import { renderModule } from '@angular/platform-server';
+        `
+      );
+
+      await removePlatformServerExports(tree);
+
+      const content = tree.read(testTypeScriptFilePath, 'utf-8');
+      expect(content).toContain(
+        `import { renderModule } from '@angular/platform-server'`
+      );
+    });
+  });
+});

--- a/packages/angular/src/migrations/update-15-2-0/update-karma-main-file.spec.ts
+++ b/packages/angular/src/migrations/update-15-2-0/update-karma-main-file.spec.ts
@@ -1,0 +1,120 @@
+import type { Tree } from '@nrwl/devkit';
+import { addProjectConfiguration, stripIndents } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing-pre16';
+import { Builders } from '@schematics/angular/utility/workspace-models';
+import updateKarmaMainFile from './update-karma-main-file';
+
+describe(`Migration to karma builder main file (test.ts)`, () => {
+  let tree: Tree;
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+    addProjectConfiguration(tree, 'app', {
+      root: '',
+      sourceRoot: 'src',
+      projectType: 'application',
+      targets: {
+        test: {
+          executor: Builders.Karma,
+          options: {
+            main: 'test.ts',
+            karmaConfig: './karma.config.js',
+            tsConfig: 'test-spec.json',
+          },
+          configurations: {
+            production: {
+              main: 'test-multiple-context.ts',
+            },
+          },
+        },
+      },
+    });
+
+    tree.write(
+      'test.ts',
+      stripIndents`
+  import { getTestBed } from '@angular/core/testing';
+  import {
+    BrowserDynamicTestingModule,
+    platformBrowserDynamicTesting
+  } from '@angular/platform-browser-dynamic/testing';
+  declare const require: {
+    context(path: string, deep?: boolean, filter?: RegExp): {
+      <T>(id: string): T;
+      keys(): string[];
+    };
+  };
+  // First, initialize the Angular testing environment.
+  getTestBed().initTestEnvironment(
+    BrowserDynamicTestingModule,
+    platformBrowserDynamicTesting(),
+  );
+  // Then we find all the tests.
+  const context = require.context('./', true, /\.spec\.ts$/);
+  // And load the modules.
+  context.keys().map(context);
+  `
+    );
+
+    tree.write(
+      'test-multiple-context.ts',
+      stripIndents`
+  import { getTestBed } from '@angular/core/testing';
+  import {
+    BrowserDynamicTestingModule,
+    platformBrowserDynamicTesting
+  } from '@angular/platform-browser-dynamic/testing';
+  declare const require: {
+    context(path: string, deep?: boolean, filter?: RegExp): {
+      <T>(id: string): T;
+      keys(): string[];
+    };
+  };
+  // First, initialize the Angular testing environment.
+  getTestBed().initTestEnvironment(
+    BrowserDynamicTestingModule,
+    platformBrowserDynamicTesting(),
+  );
+  // Then we find all the tests.
+  const context1 = require.context('./', true, /\.spec\.ts$/);
+  const context2 = require.context('./', true, /\.spec\.ts$/);
+  // And load the modules.
+  context2.keys().forEach(context2);
+  context1.keys().map(context1);
+  `
+    );
+  });
+
+  it(`should remove 'declare const require' and 'require.context' usages`, async () => {
+    await updateKarmaMainFile(tree);
+
+    expect(tree.read('test.ts', 'utf-8')).toBe(stripIndents`
+      import { getTestBed } from '@angular/core/testing';
+      import {
+        BrowserDynamicTestingModule,
+        platformBrowserDynamicTesting
+      } from '@angular/platform-browser-dynamic/testing';
+      // First, initialize the Angular testing environment.
+      getTestBed().initTestEnvironment(
+        BrowserDynamicTestingModule,
+        platformBrowserDynamicTesting(),
+      );
+    `);
+  });
+
+  it(`should remove multiple 'require.context' usages`, async () => {
+    await updateKarmaMainFile(tree);
+
+    expect(tree.read('test-multiple-context.ts', 'utf-8')).toBe(stripIndents`
+      import { getTestBed } from '@angular/core/testing';
+      import {
+        BrowserDynamicTestingModule,
+        platformBrowserDynamicTesting
+      } from '@angular/platform-browser-dynamic/testing';
+      // First, initialize the Angular testing environment.
+      getTestBed().initTestEnvironment(
+        BrowserDynamicTestingModule,
+        platformBrowserDynamicTesting(),
+      );
+    `);
+  });
+});

--- a/packages/angular/src/migrations/update-15-2-0/update-karma-main-file.ts
+++ b/packages/angular/src/migrations/update-15-2-0/update-karma-main-file.ts
@@ -1,53 +1,36 @@
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
-
-import { chain, Rule, Tree } from '@angular-devkit/schematics';
+import type { Tree } from '@nrwl/devkit';
+import { formatFiles } from '@nrwl/devkit';
 import * as ts from 'typescript';
-import { readWorkspace } from '@schematics/angular/utility';
 import { Builders } from '@schematics/angular/utility/workspace-models';
-import { allTargetOptions } from '@schematics/angular/utility/workspace';
-import { formatFiles } from '@nrwl/workspace';
+import { forEachExecutorOptions } from '@nrwl/workspace/src/utilities/executor-options-utils';
+import { FileChangeRecorder } from '../../utils/file-change-recorder';
 
-export default function (): Rule {
-  return chain([
-    async (host) => {
-      for (const file of await findTestMainFiles(host)) {
-        updateTestFile(host, file);
-      }
-    },
-    formatFiles(),
-  ]);
+export default async function (tree: Tree) {
+  for (const file of findTestMainFiles(tree)) {
+    updateTestFile(tree, file);
+  }
+  await formatFiles(tree);
 }
 
-async function findTestMainFiles(host: Tree): Promise<Set<string>> {
+function findTestMainFiles(tree: Tree): Set<string> {
   const testFiles = new Set<string>();
-  const workspace = await readWorkspace(host);
 
   // find all test.ts files.
-  for (const project of workspace.projects.values()) {
-    for (const target of project.targets.values()) {
-      if (target.builder !== Builders.Karma) {
-        continue;
-      }
-
-      for (const [, options] of allTargetOptions(target)) {
-        if (typeof options.main === 'string' && host.exists(options.main)) {
-          testFiles.add(options.main);
-        }
+  forEachExecutorOptions<{ main: string | undefined }>(
+    tree,
+    Builders.Karma,
+    (options) => {
+      if (typeof options.main === 'string' && tree.exists(options.main)) {
+        testFiles.add(options.main);
       }
     }
-  }
+  );
 
   return testFiles;
 }
 
-function updateTestFile(host: Tree, file: string): void {
-  const content = host.readText(file);
+function updateTestFile(tree: Tree, file: string): void {
+  const content = tree.read(file, 'utf8');
   if (!content.includes('require.context')) {
     return;
   }
@@ -60,7 +43,7 @@ function updateTestFile(host: Tree, file: string): void {
   );
 
   const usedVariableNames = new Set<string>();
-  const recorder = host.beginUpdate(sourceFile.fileName);
+  const recorder = new FileChangeRecorder(tree, sourceFile.fileName);
 
   ts.forEachChild(sourceFile, (node) => {
     if (ts.isVariableStatement(node)) {
@@ -90,7 +73,10 @@ function updateTestFile(host: Tree, file: string): void {
       }
 
       // Delete node.
-      recorder.remove(node.getFullStart(), node.getFullWidth());
+      recorder.remove(
+        node.getFullStart(),
+        node.getFullStart() + node.getFullWidth()
+      );
     }
 
     if (
@@ -111,9 +97,12 @@ function updateTestFile(host: Tree, file: string): void {
     ) {
       // `context.keys().map(context);`
       // `context.keys().forEach(context);`
-      recorder.remove(node.getFullStart(), node.getFullWidth());
+      recorder.remove(
+        node.getFullStart(),
+        node.getFullStart() + node.getFullWidth()
+      );
     }
   });
 
-  host.commitUpdate(recorder);
+  recorder.applyChanges();
 }

--- a/packages/angular/src/utils/file-change-recorder.ts
+++ b/packages/angular/src/utils/file-change-recorder.ts
@@ -8,6 +8,7 @@ export class FileChangeRecorder {
   get content(): string {
     return this.mutableContent.toString();
   }
+
   get originalContent(): string {
     return this.mutableContent.original;
   }
@@ -28,8 +29,8 @@ export class FileChangeRecorder {
     this.mutableContent.appendRight(index, content);
   }
 
-  remove(index: number, length: number): void {
-    this.mutableContent.remove(index, length);
+  remove(index: number, end: number): void {
+    this.mutableContent.remove(index, end);
   }
 
   replace(node: Node, content: string): void {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Two of our Angular 15 migrations are written with the Angular Devkit

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Convert them to Nx Devkit
This removes deep import to nrwl/workspace for formatFiles()

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
