### PR TITLE
docs(webpack): react lib does not generate with webpack

### DIFF
--- a/docs/generated/packages/webpack/documents/overview.md
+++ b/docs/generated/packages/webpack/documents/overview.md
@@ -27,7 +27,7 @@ npx create-nx-workspace@latest --preset=react-monorepo --bundler=webpack
 
 ## Generate a new project using Webpack
 
-You can generate a [React](/packages/react) application or library or a [Web](/packages/web) application that uses Webpack in an existing Nx workspace. The [`@nrwl/react:app`](/packages/react/generators/application), [`@nrwl/react:lib`](/packages/react/generators/library) and [`@nrwl/web:app`](/packages/web/generators/application) generators accept the `bundler` option, where you can pass `webpack`. This will generate a new application configured to use Webpack, and it will also install all the necessary dependencies, including the `@nrwl/webpack` plugin.
+You can generate a [React](/packages/react) application or library or a [Web](/packages/web) application that uses Webpack in an existing Nx workspace. The [`@nrwl/react:app`](/packages/react/generators/application), [`@nrwl/node:app`](/packages/node/generators/application) and [`@nrwl/web:app`](/packages/web/generators/application) generators accept the `bundler` option, where you can pass `webpack`. This will generate a new application configured to use Webpack, and it will also install all the necessary dependencies, including the `@nrwl/webpack` plugin.
 
 To generate a React application using Webpack, run the following:
 
@@ -35,10 +35,10 @@ To generate a React application using Webpack, run the following:
 nx g @nrwl/react:app my-app --bundler=webpack
 ```
 
-To generate a React library using Webpack, run the following:
+To generate a Node application using Webpack, run the following:
 
 ```bash
-nx g @nrwl/react:lib my-lib --bundler=webpack
+nx g @nrwl/node:app my-app --bundler=webpack
 ```
 
 To generate a Web application using Webpack, run the following:

--- a/docs/shared/packages/webpack/plugin-overview.md
+++ b/docs/shared/packages/webpack/plugin-overview.md
@@ -27,7 +27,7 @@ npx create-nx-workspace@latest --preset=react-monorepo --bundler=webpack
 
 ## Generate a new project using Webpack
 
-You can generate a [React](/packages/react) application or library or a [Web](/packages/web) application that uses Webpack in an existing Nx workspace. The [`@nrwl/react:app`](/packages/react/generators/application), [`@nrwl/react:lib`](/packages/react/generators/library) and [`@nrwl/web:app`](/packages/web/generators/application) generators accept the `bundler` option, where you can pass `webpack`. This will generate a new application configured to use Webpack, and it will also install all the necessary dependencies, including the `@nrwl/webpack` plugin.
+You can generate a [React](/packages/react) application or library or a [Web](/packages/web) application that uses Webpack in an existing Nx workspace. The [`@nrwl/react:app`](/packages/react/generators/application), [`@nrwl/node:app`](/packages/node/generators/application) and [`@nrwl/web:app`](/packages/web/generators/application) generators accept the `bundler` option, where you can pass `webpack`. This will generate a new application configured to use Webpack, and it will also install all the necessary dependencies, including the `@nrwl/webpack` plugin.
 
 To generate a React application using Webpack, run the following:
 
@@ -35,10 +35,10 @@ To generate a React application using Webpack, run the following:
 nx g @nrwl/react:app my-app --bundler=webpack
 ```
 
-To generate a React library using Webpack, run the following:
+To generate a Node application using Webpack, run the following:
 
 ```bash
-nx g @nrwl/react:lib my-lib --bundler=webpack
+nx g @nrwl/node:app my-app --bundler=webpack
 ```
 
 To generate a Web application using Webpack, run the following:


### PR DESCRIPTION
## Current Behavior

[Docs](https://nx.dev/packages/webpack#generate-a-new-project-using-webpack) say you can do `nx g @nrwl/react:lib my-lib --bundler=webpack` but you cannot do that.

## Expected Behavior

Fix docs so that they don't say something you cannot do.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15579
