### PR TITLE
fix(core): fix pnpm hoisted dependencies resolution with hoisted node-linker

### DIFF
--- a/packages/nx/src/lock-file/utils/pnpm-normalizer.ts
+++ b/packages/nx/src/lock-file/utils/pnpm-normalizer.ts
@@ -36,7 +36,7 @@ export function loadPnpmHoistedDepsDefinition() {
 
   if (existsSync(fullPath)) {
     const content = readFileSync(fullPath, 'utf-8');
-    return load(content)?.hoistedDependencies;
+    return load(content)?.hoistedDependencies ?? {};
   } else {
     throw new Error(`Could not find ".modules.yaml" at "${fullPath}"`);
   }


### PR DESCRIPTION
## Current Behavior
Any nx command fails with the below error, when pnpm is configured with node-linker-hoisted
Everything works when with shamefully-hoist=true.

I was unable to recreate a minimal repro (and thus couldn't create a test case), from my exploration in the private project where it happens it happens when these conditions are met

- Using `pnpm` as package manager
- `node-linker=hoisted` in `.npmrc`
- Some condition causes nx to fetch version of an optional package (that was not installed) from `hoistedDependencies` in modules manifest
- `hoistedDependencies` field is not there in hoisted node-linker mode
- we try to do Object.keys on `hoistedDependencies` which is undefined, and thus throws

## Expected Behavior
nx commands should work as expected when pnpm is configured via node-linker-hoisted as well.

## Related Issue(s)
https://github.com/nrwl/nx/issues/15448

Fixes #15448 
