### PR TITLE
feat(nx-plugin): plugin presets can now be standalone

### DIFF
--- a/packages/nx-plugin/src/generators/generator/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/generator/generator.spec.ts
@@ -1,4 +1,9 @@
-import { readJson, readProjectConfiguration, Tree } from '@nrwl/devkit';
+import {
+  GeneratorsJson,
+  readJson,
+  readProjectConfiguration,
+  Tree,
+} from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { libraryGenerator as jsLibraryGenerator } from '@nrwl/js';
 import { pluginGenerator } from '../plugin/plugin';
@@ -158,6 +163,27 @@ describe('NxPlugin Generator Generator', () => {
           )
         ).toBeFalsy();
       });
+    });
+  });
+
+  describe('preset generator', () => {
+    it('should default to standalone layout: true', async () => {
+      await generatorGenerator(tree, {
+        project: projectName,
+        name: 'preset',
+        unitTestRunner: 'none',
+      });
+
+      const generatorJson = readJson<GeneratorsJson>(
+        tree,
+        'libs/my-plugin/generators.json'
+      );
+
+      console.log(generatorJson.generators['preset']);
+
+      expect(
+        generatorJson.generators['preset']['x-use-standalone-layout']
+      ).toEqual(true);
     });
   });
 });

--- a/packages/nx-plugin/src/generators/generator/generator.ts
+++ b/packages/nx-plugin/src/generators/generator/generator.ts
@@ -122,7 +122,7 @@ function updateGeneratorJson(host: Tree, options: NormalizedSchema) {
     createGeneratorsJson(host, options);
   }
 
-  return updateJson(host, generatorsPath, (json) => {
+  return updateJson<GeneratorsJson>(host, generatorsPath, (json) => {
     let generators = json.generators ?? json.schematics;
     generators = generators || {};
     generators[options.name] = {
@@ -130,6 +130,10 @@ function updateGeneratorJson(host: Tree, options: NormalizedSchema) {
       schema: `./src/generators/${options.fileName}/schema.json`,
       description: options.description,
     };
+    // @todo(v17): Remove this, prop is defunct.
+    if (options.name === 'preset') {
+      generators[options.name]['x-use-standalone-layout'] = true;
+    }
     json.generators = generators;
 
     return json;

--- a/packages/nx/src/command-line/generate.ts
+++ b/packages/nx/src/command-line/generate.ts
@@ -319,7 +319,12 @@ export async function generate(cwd: string, args: { [k: string]: any }) {
       normalizedGeneratorName,
       schema,
       implementationFactory,
-      generatorConfiguration: { aliases, hidden, ['x-deprecated']: deprecated },
+      generatorConfiguration: {
+        aliases,
+        hidden,
+        ['x-deprecated']: deprecated,
+        ['x-use-standalone-layout']: isStandalonePreset,
+      },
     } = ws.readGenerator(opts.collectionName, opts.generatorName);
 
     if (deprecated) {
@@ -359,6 +364,13 @@ export async function generate(cwd: string, args: { [k: string]: any }) {
     if (ws.isNxGenerator(opts.collectionName, normalizedGeneratorName)) {
       const host = new FsTree(workspaceRoot, verbose);
       const implementation = implementationFactory();
+
+      // @todo(v17): Remove this, isStandalonePreset property is defunct.
+      if (normalizedGeneratorName === 'preset' && !isStandalonePreset) {
+        host.write('apps/.gitkeep', '');
+        host.write('libs/.gitkeep', '');
+      }
+
       const task = await implementation(host, combinedOpts);
       const changes = host.listChanges();
 

--- a/packages/nx/src/config/misc-interfaces.ts
+++ b/packages/nx/src/config/misc-interfaces.ts
@@ -31,6 +31,8 @@ export interface GeneratorsJsonEntry {
   cli?: 'nx';
   'x-type'?: 'library' | 'application';
   'x-deprecated'?: string;
+  // @todo(v17) Remove this and make it default behavior.
+  'x-use-standalone-layout'?: boolean;
 }
 
 export type OutputCaptureMethod = 'direct-nodejs' | 'pipe';

--- a/packages/workspace/src/generators/new/generate-workspace-files.spec.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.spec.ts
@@ -19,6 +19,7 @@ describe('@nrwl/workspace:generateWorkspaceFiles', () => {
       directory: 'proj',
       preset: Preset.Empty,
       defaultBase: 'main',
+      isCustomPreset: false,
     });
     expect(tree.exists('/proj/README.md')).toBe(true);
     expect(tree.exists('/proj/nx.json')).toBe(true);
@@ -51,6 +52,7 @@ describe('@nrwl/workspace:generateWorkspaceFiles', () => {
           preset: Preset[preset],
           defaultBase: 'main',
           appName,
+          isCustomPreset: false,
         });
         expect(tree.read('proj/README.md', 'utf-8')).toMatchSnapshot();
       }
@@ -61,8 +63,10 @@ describe('@nrwl/workspace:generateWorkspaceFiles', () => {
         directory: 'proj',
         preset: 'custom-nx-preset',
         defaultBase: 'main',
+        isCustomPreset: true,
       });
       expect(tree.read('proj/README.md', 'utf-8')).toMatchSnapshot();
+      expect(tree.exists('proj/apps/.gitkeep')).toBeFalsy();
     });
   });
 
@@ -74,6 +78,7 @@ describe('@nrwl/workspace:generateWorkspaceFiles', () => {
       directory: 'proj',
       preset: Preset.Empty,
       defaultBase: 'main',
+      isCustomPreset: false,
     });
     const nxJson = readJson<NxJsonConfiguration>(tree, '/proj/nx.json');
     expect(nxJson).toMatchInlineSnapshot(`
@@ -112,6 +117,7 @@ describe('@nrwl/workspace:generateWorkspaceFiles', () => {
       directory: 'proj',
       preset: Preset.ReactMonorepo,
       defaultBase: 'main',
+      isCustomPreset: false,
     });
     const nxJson = readJson<NxJsonConfiguration>(tree, '/proj/nx.json');
     expect(nxJson).toMatchInlineSnapshot(`
@@ -162,6 +168,7 @@ describe('@nrwl/workspace:generateWorkspaceFiles', () => {
       directory: 'proj',
       preset: Preset.Empty,
       defaultBase: 'main',
+      isCustomPreset: false,
     });
     const recommendations = readJson<{ recommendations: string[] }>(
       tree,
@@ -177,6 +184,7 @@ describe('@nrwl/workspace:generateWorkspaceFiles', () => {
       directory: 'proj',
       preset: Preset.Empty,
       defaultBase: 'main',
+      isCustomPreset: false,
     });
     const recommendations = readJson<{ recommendations: string[] }>(
       tree,
@@ -194,6 +202,7 @@ describe('@nrwl/workspace:generateWorkspaceFiles', () => {
       preset: Preset.NPM,
       defaultBase: 'main',
       packageManager: 'npm',
+      isCustomPreset: false,
     });
     expect(tree.exists('/proj/packages/.gitkeep')).toBe(true);
     expect(tree.exists('/proj/apps/.gitkeep')).toBe(false);
@@ -246,6 +255,7 @@ describe('@nrwl/workspace:generateWorkspaceFiles', () => {
       preset: Preset.NPM,
       defaultBase: 'main',
       packageManager: 'pnpm',
+      isCustomPreset: false,
     });
     const packageJson = readJson(tree, '/proj/package.json');
     expect(packageJson).toMatchInlineSnapshot(`

--- a/packages/workspace/src/generators/new/generate-workspace-files.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.ts
@@ -67,7 +67,8 @@ function createAppsAndLibsFolders(tree: Tree, options: NormalizedSchema) {
   } else if (
     options.preset === Preset.AngularStandalone ||
     options.preset === Preset.ReactStandalone ||
-    options.preset === Preset.NodeServer
+    options.preset === Preset.NodeServer ||
+    options.isCustomPreset
   ) {
     // don't generate any folders
   } else {

--- a/packages/workspace/src/generators/new/new.spec.ts
+++ b/packages/workspace/src/generators/new/new.spec.ts
@@ -4,13 +4,15 @@ import { newGenerator, NormalizedSchema } from './new';
 import { Linter } from '../../utils/lint';
 import { Preset } from '../utils/presets';
 
-const defaultOptions: Omit<NormalizedSchema, 'name' | 'directory' | 'appName'> =
-  {
-    preset: Preset.Apps,
-    skipInstall: false,
-    linter: Linter.EsLint,
-    defaultBase: 'main',
-  };
+const defaultOptions: Omit<
+  NormalizedSchema,
+  'name' | 'directory' | 'appName' | 'isCustomPreset'
+> = {
+  preset: Preset.Apps,
+  skipInstall: false,
+  linter: Linter.EsLint,
+  defaultBase: 'main',
+};
 
 describe('new', () => {
   let tree: Tree;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Custom presets start off with apps + libs layout

## Expected Behavior
Custom presets start off with no layout directories by default. This is accomplished with a flag, `"x-use-standalone-layout": true` inside `generators.json`. 

The flag will be removed in v17, with the new behavior becoming the only supported behavior.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
