### PR TITLE
fix(angular): misc fixes in some generator schemas

### DIFF
--- a/docs/generated/packages/angular/generators/component.json
+++ b/docs/generated/packages/angular/generators/component.json
@@ -19,8 +19,7 @@
       "project": {
         "type": "string",
         "description": "The name of the project.",
-        "x-dropdown": "projects",
-        "x-priority": "important"
+        "x-dropdown": "projects"
       },
       "name": {
         "type": "string",
@@ -113,7 +112,7 @@
         "x-priority": "important"
       }
     },
-    "required": ["name"],
+    "required": ["name", "project"],
     "examplesFile": "## Examples\n\n{% tabs %}\n{% tab label=\"Simple Component\" %}\n\nCreate a component named `my-component`:\n\n```bash\nnx g @nrwl/angular:component my-component\n```\n\n{% /tab %}\n\n{% tab label=\"Standalone Component\" %}\n\nCreate a standalone component named `my-component`:\n\n```bash\nnx g @nrwl/angular:component my-component --standalone\n```\n\n{% /tab %}\n\n{% tab label=\"Single File Component\" %}\n\nCreate a component named `my-component` with inline styles and inline template:\n\n```bash\nnx g @nrwl/angular:component my-component --inlineStyle --inlineTemplate\n```\n\n{% /tab %}\n\n{% tab label=\"Component with OnPush Change Detection Strategy\" %}\n\nCreate a component named `my-component` with OnPush Change Detection Strategy:\n\n```bash\nnx g @nrwl/angular:component my-component --changeDetection=OnPush\n```\n\n{% /tab %}\n",
     "presets": []
   },

--- a/docs/generated/packages/angular/generators/host.json
+++ b/docs/generated/packages/angular/generators/host.json
@@ -18,7 +18,8 @@
       "name": {
         "type": "string",
         "description": "The name to give to the host Angular application.",
-        "$default": { "$source": "argv", "index": 0 }
+        "$default": { "$source": "argv", "index": 0 },
+        "pattern": "^[a-zA-Z].*$"
       },
       "remotes": {
         "type": "array",

--- a/docs/generated/packages/angular/generators/remote.json
+++ b/docs/generated/packages/angular/generators/remote.json
@@ -18,7 +18,8 @@
       "name": {
         "type": "string",
         "description": "The name to give to the remote Angular app.",
-        "$default": { "$source": "argv", "index": 0 }
+        "$default": { "$source": "argv", "index": 0 },
+        "pattern": "^[a-zA-Z].*$"
       },
       "host": {
         "type": "string",

--- a/docs/generated/packages/angular/generators/scam-directive.json
+++ b/docs/generated/packages/angular/generators/scam-directive.json
@@ -25,8 +25,7 @@
       "project": {
         "type": "string",
         "description": "The name of the project.",
-        "x-dropdown": "projects",
-        "x-priority": "important"
+        "x-dropdown": "projects"
       },
       "name": {
         "type": "string",
@@ -72,7 +71,7 @@
         "x-priority": "important"
       }
     },
-    "required": ["name"],
+    "required": ["name", "project"],
     "presets": []
   },
   "description": "Generate a directive with an accompanying Single Component Angular Module (SCAM).",

--- a/docs/generated/packages/angular/generators/scam-pipe.json
+++ b/docs/generated/packages/angular/generators/scam-pipe.json
@@ -25,8 +25,7 @@
       "project": {
         "type": "string",
         "description": "The name of the project.",
-        "x-dropdown": "projects",
-        "x-priority": "important"
+        "x-dropdown": "projects"
       },
       "name": {
         "type": "string",
@@ -58,7 +57,7 @@
         "x-priority": "important"
       }
     },
-    "required": ["name"],
+    "required": ["name", "project"],
     "presets": []
   },
   "description": "Generate a pipe with an accompanying Single Component Angular Module (SCAM).",

--- a/docs/generated/packages/angular/generators/scam.json
+++ b/docs/generated/packages/angular/generators/scam.json
@@ -25,8 +25,7 @@
       "project": {
         "type": "string",
         "description": "The name of the project.",
-        "x-dropdown": "projects",
-        "x-priority": "important"
+        "x-dropdown": "projects"
       },
       "name": {
         "type": "string",
@@ -118,7 +117,7 @@
         "x-priority": "important"
       }
     },
-    "required": ["name"],
+    "required": ["name", "project"],
     "presets": []
   },
   "description": "Generate a component with an accompanying Single Component Angular Module (SCAM).",

--- a/packages/angular/src/generators/component/schema.json
+++ b/packages/angular/src/generators/component/schema.json
@@ -16,8 +16,7 @@
     "project": {
       "type": "string",
       "description": "The name of the project.",
-      "x-dropdown": "projects",
-      "x-priority": "important"
+      "x-dropdown": "projects"
     },
     "name": {
       "type": "string",
@@ -113,6 +112,6 @@
       "x-priority": "important"
     }
   },
-  "required": ["name"],
+  "required": ["name", "project"],
   "examplesFile": "../../../docs/component-examples.md"
 }

--- a/packages/angular/src/generators/host/schema.json
+++ b/packages/angular/src/generators/host/schema.json
@@ -18,7 +18,8 @@
       "$default": {
         "$source": "argv",
         "index": 0
-      }
+      },
+      "pattern": "^[a-zA-Z].*$"
     },
     "remotes": {
       "type": "array",

--- a/packages/angular/src/generators/remote/schema.json
+++ b/packages/angular/src/generators/remote/schema.json
@@ -18,7 +18,8 @@
       "$default": {
         "$source": "argv",
         "index": 0
-      }
+      },
+      "pattern": "^[a-zA-Z].*$"
     },
     "host": {
       "type": "string",

--- a/packages/angular/src/generators/scam-directive/schema.json
+++ b/packages/angular/src/generators/scam-directive/schema.json
@@ -22,8 +22,7 @@
     "project": {
       "type": "string",
       "description": "The name of the project.",
-      "x-dropdown": "projects",
-      "x-priority": "important"
+      "x-dropdown": "projects"
     },
     "name": {
       "type": "string",
@@ -77,5 +76,5 @@
       "x-priority": "important"
     }
   },
-  "required": ["name"]
+  "required": ["name", "project"]
 }

--- a/packages/angular/src/generators/scam-pipe/schema.json
+++ b/packages/angular/src/generators/scam-pipe/schema.json
@@ -22,8 +22,7 @@
     "project": {
       "type": "string",
       "description": "The name of the project.",
-      "x-dropdown": "projects",
-      "x-priority": "important"
+      "x-dropdown": "projects"
     },
     "name": {
       "type": "string",
@@ -58,5 +57,5 @@
       "x-priority": "important"
     }
   },
-  "required": ["name"]
+  "required": ["name", "project"]
 }

--- a/packages/angular/src/generators/scam/schema.json
+++ b/packages/angular/src/generators/scam/schema.json
@@ -22,8 +22,7 @@
     "project": {
       "type": "string",
       "description": "The name of the project.",
-      "x-dropdown": "projects",
-      "x-priority": "important"
+      "x-dropdown": "projects"
     },
     "name": {
       "type": "string",
@@ -123,5 +122,5 @@
       "x-priority": "important"
     }
   },
-  "required": ["name"]
+  "required": ["name", "project"]
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

- `component`, `scam`, `scam-directive`, and `scam-pipe` don't have the `project` option as required even though it is
- `host` and `remote` are missing the validation pattern for the `name` option, which is correctly set in the `application` generator

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

- `component`, `scam`, `scam-directive`, and `scam-pipe` should have the `project` option as required
- `host` and `remote` should have the validation pattern for the `name` option

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
