### PR TITLE
fix(js): Always create tmp tsconfig

### DIFF
--- a/packages/js/src/utils/check-dependencies.ts
+++ b/packages/js/src/utils/check-dependencies.ts
@@ -22,23 +22,13 @@ export function checkDependencies(
     context.configurationName
   );
   const projectRoot = target.data.root;
-
-  if (dependencies.length > 0) {
-    return {
-      tmpTsConfig: createTmpTsConfig(
-        tsConfigPath,
-        context.root,
-        projectRoot,
-        dependencies
-      ),
-      projectRoot,
-      target,
-      dependencies,
-    };
-  }
-
   return {
-    tmpTsConfig: null,
+    tmpTsConfig: createTmpTsConfig(
+      tsConfigPath,
+      context.root,
+      projectRoot,
+      dependencies
+    ),
     projectRoot,
     target,
     dependencies,


### PR DESCRIPTION
CheckDependencies didnt generate tmpTsConfig when no project dependencies were found even though a base tsconfig might still exist

Closes #15043

## Current Behavior
When building a js lib with 0 dependencies, which uses a derived tsconfig.base the nx build commands gives an error:
Cannot read properties of undefined (reading 'paths').

## Expected Behavior
No error occurs when building a js lib with 0 dependencies

## Related Issue(s)
Fixes #15043
