### PR TITLE
fix(misc): handle standalone repos when removing nested projects

### DIFF
--- a/packages/workspace/src/generators/remove/lib/check-project-is-safe-to-remove.spec.ts
+++ b/packages/workspace/src/generators/remove/lib/check-project-is-safe-to-remove.spec.ts
@@ -49,4 +49,25 @@ describe('checkProjectIsSafeToRemove', () => {
       );
     }).toThrow();
   });
+
+  it('should be able to remove e2e project in standalone', () => {
+    addProjectConfiguration(tree, 'e2e', {
+      root: 'e2e',
+    });
+    addProjectConfiguration(tree, 'root', {
+      root: '.',
+    });
+
+    expect(() => {
+      checkProjectIsSafeToRemove(
+        tree,
+        {
+          projectName: 'e2e',
+          forceRemove: false,
+          skipFormat: false,
+        },
+        readProjectConfiguration(tree, 'e2e')
+      );
+    }).not.toThrow();
+  });
 });

--- a/packages/workspace/src/generators/remove/lib/check-project-is-safe-to-remove.ts
+++ b/packages/workspace/src/generators/remove/lib/check-project-is-safe-to-remove.ts
@@ -26,7 +26,7 @@ export function checkProjectIsSafeToRemove(
   for (const [_, p] of getProjects(tree)) {
     if (
       project.name !== p.name &&
-      !normalizePath(relative(project.root, p.root)).startsWith('../')
+      !normalizePath(relative(project.root, p.root)).startsWith('..')
     ) {
       containedProjects.push(p.name);
     }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

In a standalone repo, you may not remove e2e tests.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

In a standalone repo, you may remove e2e tests.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
