### PR TITLE
feat(misc): add a link to Nx Console for IntelliJ on React & Angular Nx welcome page

### DIFF
--- a/packages/angular/src/generators/application/angular-v14/lib/nrwl-home-tpl.ts
+++ b/packages/angular/src/generators/application/angular-v14/lib/nrwl-home-tpl.ts
@@ -245,6 +245,7 @@ export const nrwlHomeTemplate = {
       }
       .button-pill {
         padding: 1.5rem 2rem;
+        margin-bottom: 2rem;
         transition-duration: 300ms;
         transition-property: background-color, border-color, color, fill, stroke,
           opacity, box-shadow, transform, filter, backdrop-filter,
@@ -280,11 +281,17 @@ export const nrwlHomeTemplate = {
       .button-pill:hover {
         color: rgba(255, 255, 255, 1) !important;
       }
-      #nx-console:hover {
+      #nx-console-vscode:hover {
         background-color: rgba(0, 122, 204, 1);
       }
-      #nx-console svg {
+      #nx-console-vscode svg {
         color: rgba(0, 122, 204, 1);
+      }
+      #nx-console-intellij:hover {
+        background-color: rgba(138, 84, 170, 1);
+      }
+      #nx-console-intellij svg {
+        color: rgba(138, 84, 170, 1);
       }
 
       #nx-repo:hover {
@@ -636,7 +643,7 @@ export const nrwlHomeTemplate = {
             </a>
           </div>
           <div id="other-links">
-            <a id="nx-console" class="button-pill rounded shadow" href="https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console&utm_source=nx-project" target="_blank" rel="noreferrer">
+            <a id="nx-console-vscode" class="button-pill rounded shadow" href="https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console&utm_source=nx-project" target="_blank" rel="noreferrer">
               <svg
                 fill="currentColor"
                 role="img"
@@ -649,8 +656,29 @@ export const nrwlHomeTemplate = {
                 />
               </svg>
               <span>
-                Install Nx Console
-                <span>Plugin for VSCode</span>
+                Install Nx Console for VSCode
+                <span>The official VSCode plugin for Nx.</span>
+              </span>
+            </a>
+            <a
+              id="nx-console-intellij"
+              class="button-pill rounded shadow"
+              href="https://plugins.jetbrains.com/plugin/21060-nx-console"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <svg
+                fill="currentColor"
+                role="img"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <title>IntelliJ</title>
+                <path d="M0 0v24h24V0zm3.723 3.111h5v1.834h-1.39v6.277h1.39v1.834h-5v-1.834h1.444V4.945H3.723zm11.055 0H17v6.5c0 .612-.055 1.111-.222 1.556-.167.444-.39.777-.723 1.11-.277.279-.666.557-1.11.668a3.933 3.933 0 0 1-1.445.278c-.778 0-1.444-.167-1.944-.445a4.81 4.81 0 0 1-1.279-1.056l1.39-1.555c.277.334.555.555.833.722.277.167.611.278.945.278.389 0 .721-.111 1-.389.221-.278.333-.667.333-1.278zM2.222 19.5h9V21h-9z"></path>
+              </svg>
+              <span>
+                Install Nx Console for JetBrains
+                <span>Available for WebStorm, Intellij IDEA Ultimate and more!</span>
               </span>
             </a>
             <div id="nx-cloud" class="rounded shadow">

--- a/packages/angular/src/generators/application/angular-v14/lib/nrwl-home-tpl.ts
+++ b/packages/angular/src/generators/application/angular-v14/lib/nrwl-home-tpl.ts
@@ -281,17 +281,11 @@ export const nrwlHomeTemplate = {
       .button-pill:hover {
         color: rgba(255, 255, 255, 1) !important;
       }
-      #nx-console-vscode:hover {
+      .nx-console:hover {
         background-color: rgba(0, 122, 204, 1);
       }
-      #nx-console-vscode svg {
+      .nx-console svg {
         color: rgba(0, 122, 204, 1);
-      }
-      #nx-console-intellij:hover {
-        background-color: rgba(138, 84, 170, 1);
-      }
-      #nx-console-intellij svg {
-        color: rgba(138, 84, 170, 1);
       }
 
       #nx-repo:hover {
@@ -643,7 +637,7 @@ export const nrwlHomeTemplate = {
             </a>
           </div>
           <div id="other-links">
-            <a id="nx-console-vscode" class="button-pill rounded shadow" href="https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console&utm_source=nx-project" target="_blank" rel="noreferrer">
+            <a class="button-pill rounded shadow nx-console" href="https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console&utm_source=nx-project" target="_blank" rel="noreferrer">
               <svg
                 fill="currentColor"
                 role="img"
@@ -661,8 +655,7 @@ export const nrwlHomeTemplate = {
               </span>
             </a>
             <a
-              id="nx-console-intellij"
-              class="button-pill rounded shadow"
+              class="button-pill rounded shadow nx-console"
               href="https://plugins.jetbrains.com/plugin/21060-nx-console"
               target="_blank"
               rel="noreferrer"

--- a/packages/angular/src/generators/application/lib/nrwl-home-tpl.ts
+++ b/packages/angular/src/generators/application/lib/nrwl-home-tpl.ts
@@ -245,6 +245,7 @@ export const nrwlHomeTemplate = {
       }
       .button-pill {
         padding: 1.5rem 2rem;
+        margin-bottom: 2rem;
         transition-duration: 300ms;
         transition-property: background-color, border-color, color, fill, stroke,
           opacity, box-shadow, transform, filter, backdrop-filter,
@@ -280,11 +281,17 @@ export const nrwlHomeTemplate = {
       .button-pill:hover {
         color: rgba(255, 255, 255, 1) !important;
       }
-      #nx-console:hover {
+      #nx-console-vscode:hover {
         background-color: rgba(0, 122, 204, 1);
       }
-      #nx-console svg {
+      #nx-console-vscode svg {
         color: rgba(0, 122, 204, 1);
+      }
+      #nx-console-intellij:hover {
+        background-color: rgba(138, 84, 170, 1);
+      }
+      #nx-console-intellij svg {
+        color: rgba(138, 84, 170, 1);
       }
 
       #nx-repo:hover {
@@ -636,7 +643,7 @@ export const nrwlHomeTemplate = {
             </a>
           </div>
           <div id="other-links">
-            <a id="nx-console" class="button-pill rounded shadow" href="https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console&utm_source=nx-project" target="_blank" rel="noreferrer">
+            <a id="nx-console-vscode" class="button-pill rounded shadow" href="https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console&utm_source=nx-project" target="_blank" rel="noreferrer">
               <svg
                 fill="currentColor"
                 role="img"
@@ -649,8 +656,29 @@ export const nrwlHomeTemplate = {
                 />
               </svg>
               <span>
-                Install Nx Console
-                <span>Plugin for VSCode</span>
+                Install Nx Console for VSCode
+                <span>The official VSCode plugin for Nx.</span>
+              </span>
+            </a>
+            <a
+              id="nx-console-intellij"
+              class="button-pill rounded shadow"
+              href="https://plugins.jetbrains.com/plugin/21060-nx-console"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <svg
+                fill="currentColor"
+                role="img"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <title>IntelliJ</title>
+                <path d="M0 0v24h24V0zm3.723 3.111h5v1.834h-1.39v6.277h1.39v1.834h-5v-1.834h1.444V4.945H3.723zm11.055 0H17v6.5c0 .612-.055 1.111-.222 1.556-.167.444-.39.777-.723 1.11-.277.279-.666.557-1.11.668a3.933 3.933 0 0 1-1.445.278c-.778 0-1.444-.167-1.944-.445a4.81 4.81 0 0 1-1.279-1.056l1.39-1.555c.277.334.555.555.833.722.277.167.611.278.945.278.389 0 .721-.111 1-.389.221-.278.333-.667.333-1.278zM2.222 19.5h9V21h-9z"></path>
+              </svg>
+              <span>
+                Install Nx Console for JetBrains
+                <span>Available for WebStorm, Intellij IDEA Ultimate and more!</span>
               </span>
             </a>
             <div id="nx-cloud" class="rounded shadow">

--- a/packages/angular/src/generators/application/lib/nrwl-home-tpl.ts
+++ b/packages/angular/src/generators/application/lib/nrwl-home-tpl.ts
@@ -281,17 +281,11 @@ export const nrwlHomeTemplate = {
       .button-pill:hover {
         color: rgba(255, 255, 255, 1) !important;
       }
-      #nx-console-vscode:hover {
+      .nx-console:hover {
         background-color: rgba(0, 122, 204, 1);
       }
-      #nx-console-vscode svg {
+      .nx-console svg {
         color: rgba(0, 122, 204, 1);
-      }
-      #nx-console-intellij:hover {
-        background-color: rgba(138, 84, 170, 1);
-      }
-      #nx-console-intellij svg {
-        color: rgba(138, 84, 170, 1);
       }
 
       #nx-repo:hover {
@@ -643,7 +637,7 @@ export const nrwlHomeTemplate = {
             </a>
           </div>
           <div id="other-links">
-            <a id="nx-console-vscode" class="button-pill rounded shadow" href="https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console&utm_source=nx-project" target="_blank" rel="noreferrer">
+            <a class="button-pill rounded shadow nx-console" href="https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console&utm_source=nx-project" target="_blank" rel="noreferrer">
               <svg
                 fill="currentColor"
                 role="img"
@@ -661,8 +655,7 @@ export const nrwlHomeTemplate = {
               </span>
             </a>
             <a
-              id="nx-console-intellij"
-              class="button-pill rounded shadow"
+              class="button-pill rounded shadow nx-console"
               href="https://plugins.jetbrains.com/plugin/21060-nx-console"
               target="_blank"
               rel="noreferrer"

--- a/packages/react/src/generators/application/files/nx-welcome/src/app/nx-welcome.tsx
+++ b/packages/react/src/generators/application/files/nx-welcome/src/app/nx-welcome.tsx
@@ -274,17 +274,11 @@ export function NxWelcome({ title }: { title: string }) {
     .button-pill:hover {
       color: rgba(255, 255, 255, 1) !important;
     }
-    #nx-console-vscode:hover {
+    .nx-console:hover {
       background-color: rgba(0, 122, 204, 1);
     }
-    #nx-console-vscode svg {
+    .nx-console svg {
       color: rgba(0, 122, 204, 1);
-    }
-    #nx-console-intellij:hover {
-      background-color: rgba(138, 84, 170, 1);
-    }
-    #nx-console-intellij svg {
-      color: rgba(138, 84, 170, 1);
     }
     #nx-repo:hover {
       background-color: rgba(24, 23, 23, 1);
@@ -650,8 +644,7 @@ export function NxWelcome({ title }: { title: string }) {
             </div>
             <div id="other-links">
               <a
-                id="nx-console-vscode"
-                className="button-pill rounded shadow"
+                className="button-pill nx-console rounded shadow"
                 href="https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console&utm_source=nx-project"
                 target="_blank"
                 rel="noreferrer"
@@ -671,8 +664,7 @@ export function NxWelcome({ title }: { title: string }) {
                 </span>
               </a>
               <a
-                id="nx-console-intellij"
-                className="button-pill rounded shadow"
+                className="button-pill nx-console rounded shadow"
                 href="https://plugins.jetbrains.com/plugin/21060-nx-console"
                 target="_blank"
                 rel="noreferrer"

--- a/packages/react/src/generators/application/files/nx-welcome/src/app/nx-welcome.tsx
+++ b/packages/react/src/generators/application/files/nx-welcome/src/app/nx-welcome.tsx
@@ -238,6 +238,7 @@ export function NxWelcome({ title }: { title: string }) {
     #other-links {}
     .button-pill {
       padding: 1.5rem 2rem;
+      margin-bottom: 2rem;
       transition-duration: 300ms;
       transition-property: background-color, border-color, color, fill, stroke,
       opacity, box-shadow, transform, filter, backdrop-filter,
@@ -273,11 +274,17 @@ export function NxWelcome({ title }: { title: string }) {
     .button-pill:hover {
       color: rgba(255, 255, 255, 1) !important;
     }
-    #nx-console:hover {
+    #nx-console-vscode:hover {
       background-color: rgba(0, 122, 204, 1);
     }
-    #nx-console svg {
+    #nx-console-vscode svg {
       color: rgba(0, 122, 204, 1);
+    }
+    #nx-console-intellij:hover {
+      background-color: rgba(138, 84, 170, 1);
+    }
+    #nx-console-intellij svg {
+      color: rgba(138, 84, 170, 1);
     }
     #nx-repo:hover {
       background-color: rgba(24, 23, 23, 1);
@@ -643,7 +650,7 @@ export function NxWelcome({ title }: { title: string }) {
             </div>
             <div id="other-links">
               <a
-                id="nx-console"
+                id="nx-console-vscode"
                 className="button-pill rounded shadow"
                 href="https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console&utm_source=nx-project"
                 target="_blank"
@@ -659,8 +666,31 @@ export function NxWelcome({ title }: { title: string }) {
                   <path d="M23.15 2.587L18.21.21a1.494 1.494 0 0 0-1.705.29l-9.46 8.63-4.12-3.128a.999.999 0 0 0-1.276.057L.327 7.261A1 1 0 0 0 .326 8.74L3.899 12 .326 15.26a1 1 0 0 0 .001 1.479L1.65 17.94a.999.999 0 0 0 1.276.057l4.12-3.128 9.46 8.63a1.492 1.492 0 0 0 1.704.29l4.942-2.377A1.5 1.5 0 0 0 24 20.06V3.939a1.5 1.5 0 0 0-.85-1.352zm-5.146 14.861L10.826 12l7.178-5.448v10.896z" />
                 </svg>
                 <span>
-                  Install Nx Console
-                  <span>Plugin for VSCode</span>
+                  Install Nx Console for VSCode
+                  <span>The official VSCode plugin for Nx.</span>
+                </span>
+              </a>
+              <a
+                id="nx-console-intellij"
+                className="button-pill rounded shadow"
+                href="https://plugins.jetbrains.com/plugin/21060-nx-console"
+                target="_blank"
+                rel="noreferrer"
+              >
+                <svg
+                  fill="currentColor"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <title>IntelliJ</title>
+                  <path d="M0 0v24h24V0zm3.723 3.111h5v1.834h-1.39v6.277h1.39v1.834h-5v-1.834h1.444V4.945H3.723zm11.055 0H17v6.5c0 .612-.055 1.111-.222 1.556-.167.444-.39.777-.723 1.11-.277.279-.666.557-1.11.668a3.933 3.933 0 0 1-1.445.278c-.778 0-1.444-.167-1.944-.445a4.81 4.81 0 0 1-1.279-1.056l1.39-1.555c.277.334.555.555.833.722.277.167.611.278.945.278.389 0 .721-.111 1-.389.221-.278.333-.667.333-1.278zM2.222 19.5h9V21h-9z"></path>
+                </svg>
+                <span>
+                  Install Nx Console for JetBrains
+                  <span>
+                    Available for WebStorm, Intellij IDEA Ultimate and more!
+                  </span>
                 </span>
               </a>
               <div id="nx-cloud" className="rounded shadow">


### PR DESCRIPTION
Now that the [official Nx Console plugin for IntelliJ](https://plugins.jetbrains.com/plugin/21060-nx-console) is out, it would be nice to have a link to it on the auto-generated Nx welcome page as well.

I tried to be consistent with the wording on the [Integrate with Editors](https://nx.dev/core-features/integrate-with-editors#official-integrations) page on Nx Docs.

## Current Behavior
The Nx Welcome starter page for a new React and Angular app does not contain a link to the Nx Console plugin for IntelliJ.

## Expected Behavior
It should contain the link to IntelliJ Nx Console plugin.

## Preview
![Screenshot 2023-03-11 at 18 50 55](https://user-images.githubusercontent.com/6420535/224504458-7a16c90b-a63d-4762-b3df-61443db99c6c.png)