### PR TITLE
fix(vite): add configuration option for emptyOutDir

### DIFF
--- a/docs/generated/packages/vite/executors/build.json
+++ b/docs/generated/packages/vite/executors/build.json
@@ -49,6 +49,11 @@
         },
         "default": []
       },
+      "emptyOutDir": {
+        "description": "When set to false, outputPath will not be emptied during the build process.",
+        "type": "boolean",
+        "default": true
+      },
       "sourcemap": {
         "description": "Output sourcemaps. Use 'hidden' for use with error reporting tools without generating sourcemap comment.",
         "oneOf": [{ "type": "boolean" }, { "type": "string" }]

--- a/packages/vite/src/executors/build/schema.d.ts
+++ b/packages/vite/src/executors/build/schema.d.ts
@@ -1,6 +1,7 @@
 import type { FileReplacement } from '../../plugins/rollup-replace-files.plugin';
 export interface ViteBuildExecutorOptions {
   outputPath: string;
+  emptyOutDir?: boolean;
   base?: string;
   configFile?: string;
   fileReplacements?: FileReplacement[];

--- a/packages/vite/src/executors/build/schema.json
+++ b/packages/vite/src/executors/build/schema.json
@@ -51,6 +51,11 @@
       },
       "default": []
     },
+    "emptyOutDir": {
+      "description": "When set to false, outputPath will not be emptied during the build process.",
+      "type": "boolean",
+      "default": true
+    },
     "sourcemap": {
       "description": "Output sourcemaps. Use 'hidden' for use with error reporting tools without generating sourcemap comment.",
       "oneOf": [

--- a/packages/vite/src/utils/options-utils.ts
+++ b/packages/vite/src/utils/options-utils.ts
@@ -136,7 +136,7 @@ export function getViteBuildOptions(
 
   return {
     outDir: relative(projectRoot, options.outputPath),
-    emptyOutDir: true,
+    emptyOutDir: options.emptyOutDir,
     reportCompressedSize: true,
     cssCodeSplit: true,
     target: 'esnext',


### PR DESCRIPTION
There are some cases where `emptyOutDir` should be false. This change allows `emptyOutDir` to be configured rather than hardcoded to `true`.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`emptyOutDir` is hardcoded to `true` and overriding via `vite.config.ts` is ignored.

## Expected Behavior
`emptyOutDir` should be configurable to support projects that need to retain the output directory.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
N/A - I am contributing a fix rather than submitting a bug for my issue.
