### PR TITLE
feat(vite): ts-node register paths in vite

### DIFF
--- a/packages/vite/src/executors/build/build.impl.ts
+++ b/packages/vite/src/executors/build/build.impl.ts
@@ -11,13 +11,18 @@ import { existsSync } from 'fs';
 import { resolve } from 'path';
 import { createAsyncIterable } from '@nrwl/devkit/src/utils/async-iterable';
 
+import { registerTsConfigPaths } from 'nx/src/utils/register';
+
 export async function* viteBuildExecutor(
   options: ViteBuildExecutorOptions,
   context: ExecutorContext
 ) {
-  const normalizedOptions = normalizeOptions(options);
   const projectRoot =
     context.projectsConfigurations.projects[context.projectName].root;
+
+  registerTsConfigPaths(resolve(projectRoot, 'tsconfig.json'));
+
+  const normalizedOptions = normalizeOptions(options);
 
   const buildConfig = mergeConfig(
     getViteSharedConfig(normalizedOptions, false, context),

--- a/packages/vite/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/vite/src/executors/dev-server/dev-server.impl.ts
@@ -11,11 +11,18 @@ import {
 
 import { ViteDevServerExecutorOptions } from './schema';
 import { ViteBuildExecutorOptions } from '../build/schema';
+import { registerTsConfigPaths } from 'nx/src/utils/register';
+import { resolve } from 'path';
 
 export async function* viteDevServerExecutor(
   options: ViteDevServerExecutorOptions,
   context: ExecutorContext
 ): AsyncGenerator<{ success: boolean; baseUrl: string }> {
+  const projectRoot =
+    context.projectsConfigurations.projects[context.projectName].root;
+
+  registerTsConfigPaths(resolve(projectRoot, 'tsconfig.json'));
+
   // Retrieve the option for the configured buildTarget.
   const buildTargetOptions: ViteBuildExecutorOptions = getNxTargetOptions(
     options.buildTarget,


### PR DESCRIPTION
Register `ts-node` and `tsconfig-paths` on Vite (we do so [in webpack, too](https://github.com/nrwl/nx/blob/master/packages/webpack/src/utils/webpack/custom-webpack.ts#L26), but in a different place/context).
 
Fixes #15277
