### PR TITLE
cleanup(misc): unset NODE_ENV=test when running craco in e2e tests

### DIFF
--- a/e2e/cra-to-nx/src/cra-to-nx.test.ts
+++ b/e2e/cra-to-nx/src/cra-to-nx.test.ts
@@ -34,7 +34,13 @@ describe('nx init (for CRA)', () => {
     expect(packageJson.devDependencies['@nrwl/vite']).toBeUndefined();
     expect(packageJson.devDependencies['@nrwl/webpack']).toBeDefined();
 
-    runCLI(`build ${appName}`);
+    runCLI(`build ${appName}`, {
+      env: {
+        // since craco 7.1.0 the NODE_ENV is used, since the tests set it
+        // to "test" is causes an issue with React Refresh Babel
+        NODE_ENV: undefined,
+      },
+    });
     checkFilesExist(`dist/apps/${appName}/index.html`);
   });
 
@@ -104,7 +110,13 @@ describe('nx init (for CRA)', () => {
 
     expect(craToNxOutput).toContain('🎉 Done!');
 
-    runCLI(`build ${appName}`);
+    runCLI(`build ${appName}`, {
+      env: {
+        // since craco 7.1.0 the NODE_ENV is used, since the tests set it
+        // to "test" is causes an issue with React Refresh Babel
+        NODE_ENV: undefined,
+      },
+    });
     checkFilesExist(`dist/${appName}/index.html`);
   });
 

--- a/e2e/nx-init/src/nx-init-react.test.ts
+++ b/e2e/nx-init/src/nx-init-react.test.ts
@@ -41,7 +41,13 @@ describe('nx init (for React)', () => {
     expect(packageJson.devDependencies['@nrwl/vite']).toBeUndefined();
     expect(packageJson.devDependencies['@nrwl/webpack']).toBeDefined();
 
-    runCLI(`build ${appName}`);
+    runCLI(`build ${appName}`, {
+      env: {
+        // since craco 7.1.0 the NODE_ENV is used, since the tests set it
+        // to "test" is causes an issue with React Refresh Babel
+        NODE_ENV: undefined,
+      },
+    });
     checkFilesExist(`dist/apps/${appName}/index.html`);
   });
 
@@ -111,7 +117,13 @@ describe('nx init (for React)', () => {
 
     expect(craToNxOutput).toContain('🎉 Done!');
 
-    runCLI(`build ${appName}`);
+    runCLI(`build ${appName}`, {
+      env: {
+        // since craco 7.1.0 the NODE_ENV is used, since the tests set it
+        // to "test" is causes an issue with React Refresh Babel
+        NODE_ENV: undefined,
+      },
+    });
     checkFilesExist(`dist/${appName}/index.html`);
   });
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The e2e tests for converting CRA projects to Nx started to fail recently due to a new release in `@craco/craco` that changes how the `NODE_ENV` env variable is handled. Jest set `NODE_ENV=test` and our E2E util for running commands forward that variable to the child process. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The e2e tests for converting CRA projects to Nx should work correctly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
