### PR TITLE
fix(angular): resolve browserTarget options correctly in webpack-dev-server

### DIFF
--- a/packages/angular/src/builders/webpack-dev-server/webpack-dev-server.impl.ts
+++ b/packages/angular/src/builders/webpack-dev-server/webpack-dev-server.impl.ts
@@ -38,27 +38,25 @@ export function executeWebpackDevServerBuilder(
   const buildTarget =
     browserTargetProjectConfiguration.targets[parsedBrowserTarget.target];
 
-  const buildTargetConfiguration = parsedBrowserTarget.configuration
-    ? buildTarget.configurations[parsedBrowserTarget.configuration]
-    : buildTarget.defaultConfiguration
-    ? buildTarget.configurations[buildTarget.defaultConfiguration]
-    : buildTarget.options;
+  const buildTargetOptions = {
+    ...buildTarget.options,
+    ...(parsedBrowserTarget.configuration
+      ? buildTarget.configurations[parsedBrowserTarget.configuration]
+      : buildTarget.defaultConfiguration
+      ? buildTarget.configurations[buildTarget.defaultConfiguration]
+      : {}),
+  };
 
   const buildLibsFromSource =
     options.buildLibsFromSource ??
-    buildTargetConfiguration?.buildLibsFromSource ??
-    buildTarget.options.buildLibsFromSource ??
+    buildTargetOptions.buildLibsFromSource ??
     true;
 
-  const customWebpackConfig: { path: string } =
-    buildTargetConfiguration?.customWebpackConfig ??
-    buildTarget.options.customWebpackConfig;
-
   let pathToWebpackConfig: string;
-  if (customWebpackConfig && customWebpackConfig.path) {
+  if (buildTargetOptions.customWebpackConfig?.path) {
     pathToWebpackConfig = joinPathFragments(
       context.workspaceRoot,
-      customWebpackConfig.path
+      buildTargetOptions.customWebpackConfig.path
     );
 
     if (pathToWebpackConfig && !existsSync(pathToWebpackConfig)) {
@@ -68,15 +66,11 @@ export function executeWebpackDevServerBuilder(
     }
   }
 
-  const indexFileTransformer: string =
-    buildTargetConfiguration?.indexFileTransformer ??
-    buildTarget.options.indexFileTransformer;
-
   let pathToIndexFileTransformer: string;
-  if (indexFileTransformer) {
+  if (buildTargetOptions.indexFileTransformer) {
     pathToIndexFileTransformer = joinPathFragments(
       context.workspaceRoot,
-      indexFileTransformer
+      buildTargetOptions.indexFileTransformer
     );
 
     if (pathToIndexFileTransformer && !existsSync(pathToIndexFileTransformer)) {
@@ -88,12 +82,14 @@ export function executeWebpackDevServerBuilder(
 
   let dependencies: DependentBuildableProjectNode[];
   if (!buildLibsFromSource) {
-    const buildTargetTsConfigPath =
-      buildTargetConfiguration?.tsConfig ?? buildTarget.options.tsConfig;
     const { tsConfigPath, dependencies: foundDependencies } =
-      createTmpTsConfigForBuildableLibs(buildTargetTsConfigPath, context, {
-        target: parsedBrowserTarget.target,
-      });
+      createTmpTsConfigForBuildableLibs(
+        buildTargetOptions.buildTargetTsConfigPath,
+        context,
+        {
+          target: parsedBrowserTarget.target,
+        }
+      );
     dependencies = foundDependencies;
 
     // We can't just pass the tsconfig path in memory to the angular builder
@@ -113,7 +109,7 @@ export function executeWebpackDevServerBuilder(
     // otherwise the build will fail if customWebpack function/file is referencing
     // local libs. This synchronize the behavior with webpack-browser and
     // webpack-server implementation.
-    buildTargetConfiguration.tsConfig = tsConfigPath;
+    buildTargetOptions.tsConfig = tsConfigPath;
   }
 
   return from(import('@angular-devkit/build-angular')).pipe(
@@ -146,7 +142,7 @@ export function executeWebpackDevServerBuilder(
           return mergeCustomWebpackConfig(
             baseWebpackConfig,
             pathToWebpackConfig,
-            buildTargetConfiguration,
+            buildTargetOptions,
             context.target
           );
         },
@@ -155,7 +151,7 @@ export function executeWebpackDevServerBuilder(
           ? {
               indexHtml: resolveIndexHtmlTransformer(
                 pathToIndexFileTransformer,
-                buildTargetConfiguration.tsConfig,
+                buildTargetOptions.tsConfig,
                 context.target
               ),
             }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `@nrwl/angular:webpack-dev-server` executor is not correctly resolving the `browserTarget` options.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `@nrwl/angular:webpack-dev-server` executor should resolve the `browserTarget` options correctly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15561 
