### PR TITLE
fix(misc): cli - case in drive letters - windows

### DIFF
--- a/packages/nx/src/command-line/run-one.ts
+++ b/packages/nx/src/command-line/run-one.ts
@@ -163,6 +163,14 @@ export function calculateDefaultProjectName(
   projectsConfigurations: ProjectsConfigurations,
   nxJsonConfiguration: NxJsonConfiguration
 ) {
+  if (cwd && /^[A-Z]:/.test(cwd)) {
+    cwd = cwd.charAt(0).toLowerCase() + cwd.slice(1);
+  }
+
+  if (root && /^[A-Z]:/.test(root)) {
+    root = root.charAt(0).toLowerCase() + root.slice(1);
+  }
+
   let relativeCwd = cwd.replace(/\\/g, '/').split(root.replace(/\\/g, '/'))[1];
 
   relativeCwd = relativeCwd.startsWith('/')


### PR DESCRIPTION
In the cli, `cmd` and `root` end up in certain occasions with different cases for drive letter (windows, vscode)

## Current Behavior
cwd and root might have different case in drive letter in windows.

## Expected Behavior
ignore case on drive letter in windows