### PR TITLE
fix(core): fix invalid yarn parser dependencies grouping key

### DIFF
--- a/packages/nx/src/lock-file/yarn-parser.ts
+++ b/packages/nx/src/lock-file/yarn-parser.ts
@@ -227,7 +227,7 @@ function groupDependencies(
   const resolutionMap = new Map<string, YarnDependency>();
   const snapshotMap = new Map<YarnDependency, Set<string>>();
   Object.entries(dependencies).forEach(([key, snapshot]) => {
-    const resolutionKey = `${snapshot.resolution}${snapshot.integrity}`;
+    const resolutionKey = `${snapshot.resolved}${snapshot.integrity}`;
     if (resolutionMap.has(resolutionKey)) {
       const existingSnapshot = resolutionMap.get(resolutionKey);
       snapshotMap.get(existingSnapshot).add(key);


### PR DESCRIPTION
The yarn parser uses an invalid key for grouping dependencies causing different snapshots to be grouped together.

Reported by @yharaskrik on Slack: https://nrwlcommunity.slack.com/archives/CMFKWPU6Q/p1677717333068159

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Related to https://github.com/nrwl/nx/pull/15364
Fixes #15603


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204166876602367