### PR TITLE
fix(nextjs): refactor how webpack config is loaded with nextjs

### DIFF
--- a/nx-dev/nx-dev/next.config.js
+++ b/nx-dev/nx-dev/next.config.js
@@ -1,5 +1,5 @@
 // nx-ignore-next-line
-const withNx = require('@nrwl/next/plugins/with-nx');
+const { withNx } = require('@nrwl/next/plugins/with-nx');
 const { copySync } = require('fs-extra');
 const path = require('path');
 const redirectRules = require('./redirect-rules.config');

--- a/packages/next/plugins/with-nx.spec.ts
+++ b/packages/next/plugins/with-nx.spec.ts
@@ -1,10 +1,10 @@
 import { NextConfigComplete } from 'next/dist/server/config-shared';
-import { withNx } from './with-nx';
+import { getNextConfig } from './with-nx';
 
 describe('withNx', () => {
   describe('svgr', () => {
     it('should be used by default', () => {
-      const config = withNx({});
+      const config = getNextConfig();
 
       const result = config.webpack(
         {
@@ -32,7 +32,7 @@ describe('withNx', () => {
     });
 
     it('should not be used when disabled', () => {
-      const config = withNx({
+      const config = getNextConfig({
         nx: {
           svgr: false,
         },

--- a/packages/next/src/executors/build/build.impl.ts
+++ b/packages/next/src/executors/build/build.impl.ts
@@ -2,7 +2,6 @@ import 'dotenv/config';
 import {
   ExecutorContext,
   readJsonFile,
-  workspaceLayout,
   workspaceRoot,
   writeJsonFile,
 } from '@nrwl/devkit';
@@ -12,18 +11,13 @@ import { join, resolve } from 'path';
 import { copySync, existsSync, mkdir, writeFileSync } from 'fs-extra';
 import { gte } from 'semver';
 import { directoryExists } from '@nrwl/workspace/src/utilities/fileutils';
-import {
-  calculateProjectDependencies,
-  DependentBuildableProjectNode,
-} from '@nrwl/js/src/utils/buildable-libs-utils';
 import { checkAndCleanWithSemver } from '@nrwl/devkit/src/utils/semver';
 
-import { prepareConfig } from '../../utils/config';
 import { updatePackageJson } from './lib/update-package-json';
 import { createNextConfigFile } from './lib/create-next-config-file';
 import { checkPublicDirectory } from './lib/check-project';
 import { NextBuildBuilderOptions } from '../../utils/types';
-import { PHASE_PRODUCTION_BUILD } from '../../utils/constants';
+
 import { getLockFileName } from 'nx/src/lock-file/lock-file';
 
 export default async function buildExecutor(
@@ -33,22 +27,9 @@ export default async function buildExecutor(
   // Cast to any to overwrite NODE_ENV
   (process.env as any).NODE_ENV ||= 'production';
 
-  let dependencies: DependentBuildableProjectNode[] = [];
   const root = resolve(context.root, options.root);
-  const libsDir = join(context.root, workspaceLayout().libsDir);
 
   checkPublicDirectory(root);
-
-  if (!options.buildLibsFromSource && context.targetName) {
-    const result = calculateProjectDependencies(
-      context.projectGraph,
-      context.root,
-      context.projectName,
-      context.targetName,
-      context.configurationName
-    );
-    dependencies = result.dependencies;
-  }
 
   // Set `__NEXT_REACT_ROOT` based on installed ReactDOM version
   const packageJsonPath = join(root, 'package.json');
@@ -66,15 +47,7 @@ export default async function buildExecutor(
     (process.env as any).__NEXT_REACT_ROOT ||= 'true';
   }
 
-  const config = await prepareConfig(
-    PHASE_PRODUCTION_BUILD,
-    options,
-    context,
-    dependencies,
-    libsDir
-  );
-
-  await build(root, config as any);
+  await build(root);
 
   if (!directoryExists(options.outputPath)) {
     mkdir(options.outputPath);

--- a/packages/next/src/executors/export/export.impl.ts
+++ b/packages/next/src/executors/export/export.impl.ts
@@ -3,7 +3,6 @@ import {
   ExecutorContext,
   parseTargetString,
   readTargetOptions,
-  runExecutor,
   workspaceLayout,
 } from '@nrwl/devkit';
 import exportApp from 'next/dist/export';
@@ -13,13 +12,18 @@ import {
   DependentBuildableProjectNode,
 } from '@nrwl/js/src/utils/buildable-libs-utils';
 
-import { prepareConfig } from '../../utils/config';
 import {
   NextBuildBuilderOptions,
   NextExportBuilderOptions,
 } from '../../utils/types';
 import { PHASE_EXPORT } from '../../utils/constants';
 import nextTrace = require('next/dist/trace');
+import { platform } from 'os';
+import { execFileSync } from 'child_process';
+import * as chalk from 'chalk';
+
+// platform specific command name
+const pmCmd = platform() === 'win32' ? `npx.cmd` : 'npx';
 
 export default async function exportExecutor(
   options: NextExportBuilderOptions,
@@ -38,13 +42,18 @@ export default async function exportExecutor(
   }
 
   const libsDir = join(context.root, workspaceLayout().libsDir);
-  const buildTarget = parseTargetString(options.buildTarget);
-  const build = await runExecutor(buildTarget, {}, context);
+  const buildTarget = parseTargetString(
+    options.buildTarget,
+    context.projectGraph
+  );
 
-  for await (const result of build) {
-    if (!result.success) {
-      return result;
-    }
+  try {
+    const args = getBuildTargetCommand(options);
+    execFileSync(pmCmd, args, {
+      stdio: [0, 1, 2],
+    });
+  } catch {
+    throw new Error(`Build target failed: ${chalk.bold(options.buildTarget)}`);
   }
 
   const buildOptions = readTargetOptions<NextBuildBuilderOptions>(
@@ -52,13 +61,6 @@ export default async function exportExecutor(
     context
   );
   const root = resolve(context.root, buildOptions.root);
-  const config = await prepareConfig(
-    PHASE_EXPORT,
-    buildOptions,
-    context,
-    dependencies,
-    libsDir
-  );
 
   // Taken from:
   // https://github.com/vercel/next.js/blob/ead56eaab68409e96c19f7d9139747bac1197aa9/packages/next/cli/next-export.ts#L13
@@ -72,9 +74,13 @@ export default async function exportExecutor(
       threads: options.threads,
       outdir: `${buildOptions.outputPath}/exported`,
     } as any,
-    nextExportCliSpan,
-    config
+    nextExportCliSpan
   );
 
   return { success: true };
+}
+
+function getBuildTargetCommand(options: NextExportBuilderOptions) {
+  const cmd = ['nx', 'run', options.buildTarget];
+  return cmd;
 }

--- a/packages/next/src/executors/server/server.impl.ts
+++ b/packages/next/src/executors/server/server.impl.ts
@@ -5,14 +5,11 @@ import {
   parseTargetString,
   readTargetOptions,
   runExecutor,
-  workspaceLayout,
 } from '@nrwl/devkit';
 import * as chalk from 'chalk';
 import { existsSync } from 'fs';
 import { join, resolve } from 'path';
-import { calculateProjectDependencies } from '@nrwl/js/src/utils/buildable-libs-utils';
 
-import { prepareConfig } from '../../utils/config';
 import {
   NextBuildBuilderOptions,
   NextServeBuilderOptions,
@@ -22,10 +19,6 @@ import {
 } from '../../utils/types';
 import { customServer } from './lib/custom-server';
 import { defaultServer } from './lib/default-server';
-import {
-  PHASE_DEVELOPMENT_SERVER,
-  PHASE_PRODUCTION_SERVER,
-} from '../../utils/constants';
 
 const infoPrefix = `[ ${chalk.dim(chalk.cyan('info'))} ] `;
 
@@ -48,42 +41,16 @@ export default async function* serveExecutor(
     context
   );
   const root = resolve(context.root, buildOptions.root);
-  const config = await prepareConfig(
-    options.dev ? PHASE_DEVELOPMENT_SERVER : PHASE_PRODUCTION_SERVER,
-    buildOptions,
-    context,
-    getDependencies(options, context),
-    join(context.root, workspaceLayout().libsDir)
-  );
 
   if (options.customServerTarget) {
-    yield* runCustomServer(root, config, options, buildOptions, context);
+    yield* runCustomServer(root, options, buildOptions, context);
   } else {
-    yield* runNextDevServer(root, config, options, buildOptions, context);
-  }
-}
-
-function getDependencies(
-  options: NextServeBuilderOptions,
-  context: ExecutorContext
-) {
-  if (options.buildLibsFromSource) {
-    return [];
-  } else {
-    const result = calculateProjectDependencies(
-      context.projectGraph,
-      context.root,
-      context.projectName,
-      'build', // should be generalized
-      context.configurationName
-    );
-    return result.dependencies;
+    yield* runNextDevServer(root, options, buildOptions, context);
   }
 }
 
 async function* runNextDevServer(
   root: string,
-  config: ReturnType<typeof prepareConfig>,
   options: NextServeBuilderOptions,
   buildOptions: NextBuildBuilderOptions,
   context: ExecutorContext
@@ -94,7 +61,6 @@ async function* runNextDevServer(
     dir: root,
     staticMarkup: options.staticMarkup,
     quiet: options.quiet,
-    conf: config,
     port: options.port,
     customServer: !!options.customServerTarget,
     hostname: options.hostname || 'localhost',
@@ -144,7 +110,6 @@ async function* runNextDevServer(
 
 async function* runCustomServer(
   root: string,
-  config: ReturnType<typeof prepareConfig>,
   options: NextServeBuilderOptions,
   buildOptions: NextBuildBuilderOptions,
   context: ExecutorContext

--- a/packages/next/src/utils/config.spec.ts
+++ b/packages/next/src/utils/config.spec.ts
@@ -1,14 +1,8 @@
 import 'nx/src/utils/testing/mock-fs';
 import { createWebpackConfig } from './config';
-import { NextBuildBuilderOptions } from '@nrwl/next';
-import { dirname } from 'path';
 import { TsconfigPathsPlugin } from 'tsconfig-paths-webpack-plugin';
 
-import { PHASE_PRODUCTION_BUILD } from './constants';
-
-jest.mock('@nrwl/webpack', () => ({
-  createCopyPlugin: () => {},
-}));
+jest.mock('@nrwl/webpack', () => ({}));
 jest.mock('tsconfig-paths-webpack-plugin');
 jest.mock('next/dist/server/config', () => ({
   __esModule: true,
@@ -57,17 +51,28 @@ describe('Next.js webpack config builder', () => {
       });
     });
 
-    it('should set the rules', () => {
+    it('should add rules for ts', () => {
       const webpackConfig = createWebpackConfig('/root', 'apps/wibble', []);
 
       const config = webpackConfig(
-        { resolve: { alias: {} }, module: { rules: [] }, plugins: [] },
+        {
+          resolve: { alias: {} },
+          module: {
+            rules: [
+              {
+                test: /\.*.ts/,
+                loader: 'some-ts-loader',
+              },
+            ],
+          },
+          plugins: [],
+        },
         { defaultLoaders: {} }
       );
 
       // not much value in checking what they are
       // just check they get added
-      expect(config.module.rules.length).toBe(1);
+      expect(config.module.rules.length).toBe(2);
     });
   });
 });

--- a/packages/next/src/utils/config.spec.ts
+++ b/packages/next/src/utils/config.spec.ts
@@ -1,5 +1,5 @@
 import 'nx/src/utils/testing/mock-fs';
-import { createWebpackConfig, prepareConfig } from './config';
+import { createWebpackConfig } from './config';
 import { NextBuildBuilderOptions } from '@nrwl/next';
 import { dirname } from 'path';
 import { TsconfigPathsPlugin } from 'tsconfig-paths-webpack-plugin';
@@ -68,86 +68,6 @@ describe('Next.js webpack config builder', () => {
       // not much value in checking what they are
       // just check they get added
       expect(config.module.rules.length).toBe(1);
-    });
-  });
-
-  describe('prepareConfig', () => {
-    it('should set the dist directory', async () => {
-      const config = await prepareConfig(
-        PHASE_PRODUCTION_BUILD,
-        {
-          root: 'apps/wibble',
-          outputPath: 'dist/apps/wibble',
-          fileReplacements: [],
-        },
-        { root: '/root' } as any,
-        [],
-        ''
-      );
-
-      expect(config).toEqual(
-        expect.objectContaining({
-          distDir: '../../dist/apps/wibble/.next',
-        })
-      );
-    });
-
-    it('should support nextConfig option to customize the config', async () => {
-      const fullPath = require.resolve('./config.fixture');
-      const rootPath = dirname(fullPath);
-      const config = await prepareConfig(
-        PHASE_PRODUCTION_BUILD,
-        {
-          root: 'apps/wibble',
-          outputPath: 'dist/apps/wibble',
-          fileReplacements: [],
-          nextConfig: 'config.fixture',
-          customValue: 'test',
-        } as NextBuildBuilderOptions,
-        { root: rootPath } as any,
-        [],
-        ''
-      );
-
-      expect(config).toMatchObject({
-        myCustomValue: 'test',
-      });
-    });
-
-    it('should provide error message when nextConfig path is invalid', async () => {
-      await expect(() =>
-        prepareConfig(
-          PHASE_PRODUCTION_BUILD,
-          {
-            root: 'apps/wibble',
-            outputPath: 'dist/apps/wibble',
-            fileReplacements: [],
-            nextConfig: 'config-does-not-exist.fixture',
-            customValue: 'test',
-          } as NextBuildBuilderOptions,
-          { root: '/root' } as any,
-          [],
-          ''
-        )
-      ).rejects.toThrow(/Could not find file/);
-    });
-
-    it('should provide error message when nextConfig does not export a function', async () => {
-      await expect(() =>
-        prepareConfig(
-          PHASE_PRODUCTION_BUILD,
-          {
-            root: 'apps/wibble',
-            outputPath: 'dist/apps/wibble',
-            fileReplacements: [],
-            nextConfig: require.resolve('./config-not-a-function.fixture'),
-            customValue: 'test',
-          } as NextBuildBuilderOptions,
-          { root: '/root' } as any,
-          [],
-          ''
-        )
-      ).rejects.toThrow(/option does not export a function/);
     });
   });
 });

--- a/packages/next/src/utils/types.ts
+++ b/packages/next/src/utils/types.ts
@@ -17,7 +17,6 @@ export interface NextServerOptions {
   dir: string;
   staticMarkup: boolean;
   quiet: boolean;
-  conf: any;
   port: number;
   path: string;
   hostname: string;

--- a/packages/webpack/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/webpack/src/executors/dev-server/dev-server.impl.ts
@@ -25,7 +25,7 @@ export async function* devServerExecutor(
   context: ExecutorContext
 ) {
   // Default to dev mode so builds are faster and HMR mode works better.
-  process.env.NODE_ENV ??= 'development';
+  (process.env as any).NODE_ENV ??= 'development';
 
   const { root: projectRoot, sourceRoot } =
     context.projectsConfigurations.projects[context.projectName];

--- a/packages/webpack/src/executors/webpack/webpack.impl.ts
+++ b/packages/webpack/src/executors/webpack/webpack.impl.ts
@@ -96,7 +96,9 @@ export async function* webpackExecutor(
       ? options.optimization.scripts
       : false;
 
-  process.env.NODE_ENV ||= isScriptOptimizeOn ? 'production' : 'development';
+  (process.env as any).NODE_ENV ||= isScriptOptimizeOn
+    ? 'production'
+    : 'development';
 
   if (options.compiler === 'swc') {
     try {


### PR DESCRIPTION
Currently, there is a breaking change that exists after you upgrade your `next` dependency to `next:13.2.x`

This happened because we would pass the webpack configuration to the nextJs's build function which is no longer supported

What does the mean for new / existing workspaces
- No changes are required


**TODO**

- [x] Ensure imported shared libs compiles without errors
- [x] Add e2e tests for nextjs workspaces
- [x] Rename `withNxnew` function 
- [x] Remove webpack config from `build.impl`

Fixes: #15214, https://github.com/nrwl/nx/issues/13194