### PR TITLE
fix(misc): filter out deps early based on shared config from module federation

### DIFF
--- a/packages/angular/src/utils/mf/utils.ts
+++ b/packages/angular/src/utils/mf/utils.ts
@@ -51,6 +51,16 @@ export async function getModuleFederationConfig(
     projectGraph,
     mfConfig.name
   );
+
+  if (mfConfig.shared) {
+    dependencies.workspaceLibraries = dependencies.workspaceLibraries.filter(
+      (lib) => mfConfig.shared(lib.name, {})
+    );
+    dependencies.npmPackages = dependencies.npmPackages.filter((pkg) =>
+      mfConfig.shared(pkg, {})
+    );
+  }
+
   const sharedLibraries = shareWorkspaceLibraries(
     dependencies.workspaceLibraries
   );

--- a/packages/react/src/module-federation/utils.ts
+++ b/packages/react/src/module-federation/utils.ts
@@ -37,6 +37,16 @@ export async function getModuleFederationConfig(
     projectGraph,
     mfConfig.name
   );
+
+  if (mfConfig.shared) {
+    dependencies.workspaceLibraries = dependencies.workspaceLibraries.filter(
+      (lib) => mfConfig.shared(lib.name, {})
+    );
+    dependencies.npmPackages = dependencies.npmPackages.filter((pkg) =>
+      mfConfig.shared(pkg, {})
+    );
+  }
+
   const sharedLibraries = shareWorkspaceLibraries(
     dependencies.workspaceLibraries
   );


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `withModuleFederation` helpers warn when a project dep is not found in the `package.json` even if it's excluded in the `shared` function.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `withModuleFederation` helpers don't warn when a project dep is not found in the `package.json` but it's excluded in the `shared` function.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15456 
