### PR TITLE
fix(core): ignore missing modules.yaml during postinstall

### DIFF
--- a/packages/nx/src/lock-file/utils/pnpm-normalizer.ts
+++ b/packages/nx/src/lock-file/utils/pnpm-normalizer.ts
@@ -11,7 +11,6 @@ import type {
 import { dump, load } from '@zkochan/js-yaml';
 import { existsSync, readFileSync } from 'fs';
 import { workspaceRoot } from '../../utils/workspace-root';
-import { output } from '../../utils/output';
 
 const LOCKFILE_YAML_FORMAT = {
   blankLines: true,
@@ -39,15 +38,7 @@ export function loadPnpmHoistedDepsDefinition() {
     const content = readFileSync(fullPath, 'utf-8');
     return load(content)?.hoistedDependencies ?? {};
   } else {
-    output.error({
-      title: `Could not find ".modules.yaml" at "${fullPath}"`,
-      bodyLines: [
-        'This error might be reported during the "pnpm install" in which case you can ignore it.',
-        'If this error is reported while running "nx..." commands please open an issue at `https://github.com/nrwl/nx/issues/new?template=1-bug.yml` and provide a reproduction.',
-      ],
-    });
-
-    return {};
+    throw new Error(`Could not find ".modules.yaml" at "${fullPath}"`);
   }
 }
 

--- a/packages/nx/src/lock-file/utils/pnpm-normalizer.ts
+++ b/packages/nx/src/lock-file/utils/pnpm-normalizer.ts
@@ -11,6 +11,7 @@ import type {
 import { dump, load } from '@zkochan/js-yaml';
 import { existsSync, readFileSync } from 'fs';
 import { workspaceRoot } from '../../utils/workspace-root';
+import { output } from '../../utils/output';
 
 const LOCKFILE_YAML_FORMAT = {
   blankLines: true,
@@ -38,7 +39,15 @@ export function loadPnpmHoistedDepsDefinition() {
     const content = readFileSync(fullPath, 'utf-8');
     return load(content)?.hoistedDependencies ?? {};
   } else {
-    throw new Error(`Could not find ".modules.yaml" at "${fullPath}"`);
+    output.error({
+      title: `Could not find ".modules.yaml" at "${fullPath}"`,
+      bodyLines: [
+        'This error might be reported during the "pnpm install" in which case you can ignore it.',
+        'If this error is reported while running "nx..." commands please open an issue at `https://github.com/nrwl/nx/issues/new?template=1-bug.yml` and provide a reproduction.',
+      ],
+    });
+
+    return {};
   }
 }
 


### PR DESCRIPTION
Pnpm lockfile parsing fails on postinstall since there is no `.modules.yaml`. The parsing should fail silently in such cases, since the first nx command run will recreate the graph anyway.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15642
Fixes #15656
