### PR TITLE
fix(angular): set projectName as the default source for relevant generators

### DIFF
--- a/docs/generated/packages/angular/generators/component-cypress-spec.json
+++ b/docs/generated/packages/angular/generators/component-cypress-spec.json
@@ -11,6 +11,7 @@
       "projectName": {
         "type": "string",
         "description": "The name of the project.",
+        "$default": { "$source": "projectName", "index": 0 },
         "examples": ["ui-samples"],
         "x-priority": "important"
       },

--- a/docs/generated/packages/angular/generators/component-test.json
+++ b/docs/generated/packages/angular/generators/component-test.json
@@ -11,6 +11,7 @@
       "project": {
         "type": "string",
         "description": "The name of the project where the component is located.",
+        "$default": { "$source": "projectName", "index": 0 },
         "x-dropdown": "projects",
         "x-prompt": "What project is the component located in?",
         "x-priority": "important"

--- a/docs/generated/packages/angular/generators/component.json
+++ b/docs/generated/packages/angular/generators/component.json
@@ -19,6 +19,7 @@
       "project": {
         "type": "string",
         "description": "The name of the project.",
+        "$default": { "$source": "projectName", "index": 0 },
         "x-dropdown": "projects"
       },
       "name": {

--- a/docs/generated/packages/angular/generators/cypress-component-configuration.json
+++ b/docs/generated/packages/angular/generators/cypress-component-configuration.json
@@ -12,6 +12,7 @@
       "project": {
         "type": "string",
         "description": "The name of the project to add cypress component testing configuration to",
+        "$default": { "$source": "projectName", "index": 0 },
         "x-dropdown": "projects",
         "x-prompt": "What project should we add Cypress component testing to?",
         "x-priority": "important"

--- a/docs/generated/packages/angular/generators/scam-directive.json
+++ b/docs/generated/packages/angular/generators/scam-directive.json
@@ -25,6 +25,7 @@
       "project": {
         "type": "string",
         "description": "The name of the project.",
+        "$default": { "$source": "projectName", "index": 0 },
         "x-dropdown": "projects"
       },
       "name": {

--- a/docs/generated/packages/angular/generators/scam-pipe.json
+++ b/docs/generated/packages/angular/generators/scam-pipe.json
@@ -25,6 +25,7 @@
       "project": {
         "type": "string",
         "description": "The name of the project.",
+        "$default": { "$source": "projectName", "index": 0 },
         "x-dropdown": "projects"
       },
       "name": {

--- a/docs/generated/packages/angular/generators/scam.json
+++ b/docs/generated/packages/angular/generators/scam.json
@@ -25,6 +25,7 @@
       "project": {
         "type": "string",
         "description": "The name of the project.",
+        "$default": { "$source": "projectName", "index": 0 },
         "x-dropdown": "projects"
       },
       "name": {

--- a/docs/generated/packages/angular/generators/web-worker.json
+++ b/docs/generated/packages/angular/generators/web-worker.json
@@ -17,6 +17,7 @@
       "project": {
         "type": "string",
         "description": "The name of the project.",
+        "$default": { "$source": "projectName", "index": 0 },
         "x-dropdown": "projects",
         "x-priority": "important"
       },

--- a/packages/angular/src/generators/component-cypress-spec/schema.json
+++ b/packages/angular/src/generators/component-cypress-spec/schema.json
@@ -8,6 +8,10 @@
     "projectName": {
       "type": "string",
       "description": "The name of the project.",
+      "$default": {
+        "$source": "projectName",
+        "index": 0
+      },
       "examples": ["ui-samples"],
       "x-priority": "important"
     },

--- a/packages/angular/src/generators/component-test/schema.json
+++ b/packages/angular/src/generators/component-test/schema.json
@@ -8,6 +8,10 @@
     "project": {
       "type": "string",
       "description": "The name of the project where the component is located.",
+      "$default": {
+        "$source": "projectName",
+        "index": 0
+      },
       "x-dropdown": "projects",
       "x-prompt": "What project is the component located in?",
       "x-priority": "important"

--- a/packages/angular/src/generators/component/__snapshots__/component.spec.ts.snap
+++ b/packages/angular/src/generators/component/__snapshots__/component.spec.ts.snap
@@ -42,20 +42,6 @@ export class ExampleComponent {
 "
 `;
 
-exports[`component Generator --path should infer project from path and generate component correctly 1`] = `
-"import { Component } from '@angular/core';
-
-@Component({
-  selector: 'example',
-  templateUrl: './example.component.html',
-  styleUrls: ['./example.component.css']
-})
-export class ExampleComponent {
-
-}
-"
-`;
-
 exports[`component Generator secondary entry points should create the component correctly and export it in the entry point 1`] = `
 "import { Component } from '@angular/core';
 

--- a/packages/angular/src/generators/component/component.spec.ts
+++ b/packages/angular/src/generators/component/component.spec.ts
@@ -1,4 +1,3 @@
-import type { ProjectGraph } from '@nrwl/devkit';
 import {
   addProjectConfiguration,
   stripIndents,
@@ -7,14 +6,6 @@ import {
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import componentGenerator from './component';
-
-let projectGraph: ProjectGraph;
-jest.mock('@nrwl/devkit', () => {
-  return {
-    ...jest.requireActual('@nrwl/devkit'),
-    createProjectGraphAsync: jest.fn().mockImplementation(() => projectGraph),
-  };
-});
 
 describe('component Generator', () => {
   it('should create the component correctly and export it in the entry point when "export=true"', async () => {
@@ -420,50 +411,6 @@ describe('component Generator', () => {
       );
     });
 
-    it('should infer project from path and generate component correctly', async () => {
-      // ARRANGE
-      const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-      addProjectConfiguration(tree, 'lib1', {
-        projectType: 'library',
-        sourceRoot: 'libs/lib1/src',
-        root: 'libs/lib1',
-      });
-      tree.write(
-        'libs/lib1/src/lib/lib.module.ts',
-        `
-    import { NgModule } from '@angular/core';
-    
-    @NgModule({
-      declarations: [],
-      exports: []
-    })
-    export class LibModule {}`
-      );
-      projectGraph = {
-        nodes: {
-          lib1: {
-            name: 'lib1',
-            type: 'lib',
-            data: { root: 'libs/lib1' } as any,
-          },
-        },
-        dependencies: {},
-      };
-
-      // ACT
-      await componentGenerator(tree, {
-        name: 'example',
-        path: 'libs/lib1/src/lib/mycomp',
-      });
-
-      // ASSERT
-      const componentSource = tree.read(
-        'libs/lib1/src/lib/mycomp/example/example.component.ts',
-        'utf-8'
-      );
-      expect(componentSource).toMatchSnapshot();
-    });
-
     it('should throw if the path specified is not under the project root', async () => {
       // ARRANGE
       const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
@@ -491,36 +438,6 @@ describe('component Generator', () => {
           name: 'example',
           project: 'lib1',
           path: 'apps/app1/src/mycomp',
-          export: false,
-        })
-      ).rejects.toThrow();
-    });
-
-    it('should throw when path and projects are not provided and defaultProject is not set', async () => {
-      // ARRANGE
-      const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-      addProjectConfiguration(tree, 'lib1', {
-        projectType: 'library',
-        sourceRoot: 'libs/lib1/src',
-        root: 'libs/lib1',
-      });
-      tree.write(
-        'libs/lib1/src/lib/lib.module.ts',
-        `
-    import { NgModule } from '@angular/core';
-    
-    @NgModule({
-      declarations: [],
-      exports: []
-    })
-    export class LibModule {}`
-      );
-      tree.write('libs/lib1/src/index.ts', 'export * from "./lib/lib.module";');
-
-      // ACT & ASSERT
-      await expect(
-        componentGenerator(tree, {
-          name: 'example',
           export: false,
         })
       ).rejects.toThrow();

--- a/packages/angular/src/generators/component/component.ts
+++ b/packages/angular/src/generators/component/component.ts
@@ -1,11 +1,11 @@
 import type { Tree } from '@nrwl/devkit';
 import { formatFiles, stripIndents } from '@nrwl/devkit';
+import { lt } from 'semver';
+import { checkPathUnderProjectRoot } from '../utils/path';
+import { getInstalledAngularVersionInfo } from '../utils/version-utils';
 import { exportComponentInEntryPoint } from './lib/component';
 import { normalizeOptions } from './lib/normalize-options';
 import type { Schema } from './schema';
-import { getInstalledAngularVersionInfo } from '../utils/version-utils';
-import { lt } from 'semver';
-import { checkPathUnderProjectRoot } from '../utils/path';
 
 export async function componentGenerator(tree: Tree, rawOptions: Schema) {
   const installedAngularVersionInfo = getInstalledAngularVersionInfo(tree);

--- a/packages/angular/src/generators/component/lib/normalize-options.ts
+++ b/packages/angular/src/generators/component/lib/normalize-options.ts
@@ -1,52 +1,14 @@
 import type { Tree } from '@nrwl/devkit';
-import {
-  createProjectGraphAsync,
-  joinPathFragments,
-  readNxJson,
-  readProjectConfiguration,
-} from '@nrwl/devkit';
+import { joinPathFragments, readProjectConfiguration } from '@nrwl/devkit';
 import type { NormalizedSchema, Schema } from '../schema';
-import {
-  createProjectRootMappings,
-  findProjectForPath,
-} from 'nx/src/project-graph/utils/find-project-for-path';
-
-async function findProjectFromOptions(options: Schema) {
-  const projectGraph = await createProjectGraphAsync();
-  const projectRootMappings = createProjectRootMappings(projectGraph.nodes);
-
-  // path can be undefined when running on the root of the workspace, we default to the root
-  // to handle standalone layouts
-  return findProjectForPath(options.path || '', projectRootMappings);
-}
 
 export async function normalizeOptions(
   tree: Tree,
   options: Schema
 ): Promise<NormalizedSchema> {
-  const project =
-    options.project ??
-    (await findProjectFromOptions(options)) ??
-    readNxJson(tree).defaultProject;
-
-  if (!project) {
-    // path is hidden, so if not provided we don't suggest setting it
-    if (!options.path) {
-      throw new Error(
-        'No "project" was specified and "defaultProject" is not set in the workspace configuration. Please provide the "project" option and try again.'
-      );
-    }
-
-    // path was provided, so it's wrong and we should mention it
-    throw new Error(
-      'The provided "path" is wrong and no "project" was specified and "defaultProject" is not set in the workspace configuration. ' +
-        'Please provide a correct "path" or provide the "project" option instead and try again.'
-    );
-  }
-
   const { projectType, root, sourceRoot } = readProjectConfiguration(
     tree,
-    project
+    options.project
   );
   const projectSourceRoot = sourceRoot ?? joinPathFragments(root, 'src');
   const path =
@@ -59,7 +21,6 @@ export async function normalizeOptions(
   return {
     ...options,
     path,
-    project,
     projectSourceRoot,
   };
 }

--- a/packages/angular/src/generators/component/schema.d.ts
+++ b/packages/angular/src/generators/component/schema.d.ts
@@ -1,7 +1,7 @@
 export interface Schema {
   name: string;
+  project: string;
   path?: string;
-  project?: string;
   displayBlock?: boolean;
   inlineStyle?: boolean;
   inlineTemplate?: boolean;
@@ -21,6 +21,5 @@ export interface Schema {
 
 export interface NormalizedSchema extends Schema {
   path: string;
-  project: string;
   projectSourceRoot: string;
 }

--- a/packages/angular/src/generators/component/schema.json
+++ b/packages/angular/src/generators/component/schema.json
@@ -16,6 +16,10 @@
     "project": {
       "type": "string",
       "description": "The name of the project.",
+      "$default": {
+        "$source": "projectName",
+        "index": 0
+      },
       "x-dropdown": "projects"
     },
     "name": {

--- a/packages/angular/src/generators/cypress-component-configuration/schema.json
+++ b/packages/angular/src/generators/cypress-component-configuration/schema.json
@@ -9,6 +9,10 @@
     "project": {
       "type": "string",
       "description": "The name of the project to add cypress component testing configuration to",
+      "$default": {
+        "$source": "projectName",
+        "index": 0
+      },
       "x-dropdown": "projects",
       "x-prompt": "What project should we add Cypress component testing to?",
       "x-priority": "important"

--- a/packages/angular/src/generators/scam-directive/lib/normalize-options.ts
+++ b/packages/angular/src/generators/scam-directive/lib/normalize-options.ts
@@ -1,19 +1,14 @@
 import type { Tree } from '@nrwl/devkit';
-import {
-  joinPathFragments,
-  readNxJson,
-  readProjectConfiguration,
-} from '@nrwl/devkit';
+import { joinPathFragments, readProjectConfiguration } from '@nrwl/devkit';
 import type { NormalizedSchema, Schema } from '../schema';
 
 export function normalizeOptions(
   tree: Tree,
   options: Schema
 ): NormalizedSchema {
-  const project = options.project ?? readNxJson(tree).defaultProject;
   const { projectType, root, sourceRoot } = readProjectConfiguration(
     tree,
-    project
+    options.project
   );
   const projectSourceRoot = sourceRoot ?? joinPathFragments(root, 'src');
   const path =
@@ -29,7 +24,6 @@ export function normalizeOptions(
     flat: options.flat ?? true,
     inlineScam: options.inlineScam ?? true,
     path,
-    project,
     projectSourceRoot,
   };
 }

--- a/packages/angular/src/generators/scam-directive/scam-directive.ts
+++ b/packages/angular/src/generators/scam-directive/scam-directive.ts
@@ -2,7 +2,6 @@ import type { Tree } from '@nrwl/devkit';
 import {
   formatFiles,
   normalizePath,
-  readNxJson,
   readProjectConfiguration,
 } from '@nrwl/devkit';
 import { exportScam } from '../utils/export-scam';
@@ -41,8 +40,7 @@ function checkPathUnderProjectRoot(tree: Tree, options: Partial<Schema>) {
     return;
   }
 
-  const project = options.project ?? readNxJson(tree).defaultProject;
-  const { root } = readProjectConfiguration(tree, project);
+  const { root } = readProjectConfiguration(tree, options.project);
 
   let pathToDirective = normalizePath(options.path);
   pathToDirective = pathToDirective.startsWith('/')

--- a/packages/angular/src/generators/scam-directive/schema.d.ts
+++ b/packages/angular/src/generators/scam-directive/schema.d.ts
@@ -1,7 +1,7 @@
 export interface Schema {
   name: string;
+  project: string;
   path?: string;
-  project?: string;
   skipTests?: boolean;
   inlineScam?: boolean;
   flat?: boolean;
@@ -15,6 +15,5 @@ export interface NormalizedSchema extends Schema {
   flat: boolean;
   inlineScam: boolean;
   path: string;
-  project: string;
   projectSourceRoot: string;
 }

--- a/packages/angular/src/generators/scam-directive/schema.json
+++ b/packages/angular/src/generators/scam-directive/schema.json
@@ -22,6 +22,10 @@
     "project": {
       "type": "string",
       "description": "The name of the project.",
+      "$default": {
+        "$source": "projectName",
+        "index": 0
+      },
       "x-dropdown": "projects"
     },
     "name": {

--- a/packages/angular/src/generators/scam-pipe/lib/normalize-options.ts
+++ b/packages/angular/src/generators/scam-pipe/lib/normalize-options.ts
@@ -1,19 +1,14 @@
 import type { Tree } from '@nrwl/devkit';
-import {
-  joinPathFragments,
-  readNxJson,
-  readProjectConfiguration,
-} from '@nrwl/devkit';
+import { joinPathFragments, readProjectConfiguration } from '@nrwl/devkit';
 import type { NormalizedSchema, Schema } from '../schema';
 
 export function normalizeOptions(
   tree: Tree,
   options: Schema
 ): NormalizedSchema {
-  const project = options.project ?? readNxJson(tree).defaultProject;
   const { projectType, root, sourceRoot } = readProjectConfiguration(
     tree,
-    project
+    options.project
   );
   const projectSourceRoot = sourceRoot ?? joinPathFragments(root, 'src');
   const path =
@@ -29,7 +24,6 @@ export function normalizeOptions(
     flat: options.flat ?? true,
     inlineScam: options.inlineScam ?? true,
     path,
-    project,
     projectSourceRoot,
   };
 }

--- a/packages/angular/src/generators/scam-pipe/scam-pipe.ts
+++ b/packages/angular/src/generators/scam-pipe/scam-pipe.ts
@@ -2,7 +2,6 @@ import type { Tree } from '@nrwl/devkit';
 import {
   formatFiles,
   normalizePath,
-  readNxJson,
   readProjectConfiguration,
 } from '@nrwl/devkit';
 import { exportScam } from '../utils/export-scam';
@@ -41,8 +40,7 @@ function checkPathUnderProjectRoot(tree: Tree, options: Partial<Schema>) {
     return;
   }
 
-  const project = options.project ?? readNxJson(tree).defaultProject;
-  const { root } = readProjectConfiguration(tree, project);
+  const { root } = readProjectConfiguration(tree, options.project);
 
   let pathToPipe = normalizePath(options.path);
   pathToPipe = pathToPipe.startsWith('/') ? pathToPipe.slice(1) : pathToPipe;

--- a/packages/angular/src/generators/scam-pipe/schema.d.ts
+++ b/packages/angular/src/generators/scam-pipe/schema.d.ts
@@ -1,7 +1,7 @@
 export interface Schema {
   name: string;
+  project: string;
   path?: string;
-  project?: string;
   skipTests?: boolean;
   inlineScam?: boolean;
   flat?: boolean;
@@ -13,6 +13,5 @@ export interface NormalizedSchema extends Schema {
   flat: boolean;
   inlineScam: boolean;
   path: string;
-  project: string;
   projectSourceRoot: string;
 }

--- a/packages/angular/src/generators/scam-pipe/schema.json
+++ b/packages/angular/src/generators/scam-pipe/schema.json
@@ -22,6 +22,10 @@
     "project": {
       "type": "string",
       "description": "The name of the project.",
+      "$default": {
+        "$source": "projectName",
+        "index": 0
+      },
       "x-dropdown": "projects"
     },
     "name": {

--- a/packages/angular/src/generators/scam/lib/normalize-options.ts
+++ b/packages/angular/src/generators/scam/lib/normalize-options.ts
@@ -1,19 +1,14 @@
 import type { Tree } from '@nrwl/devkit';
-import {
-  joinPathFragments,
-  readNxJson,
-  readProjectConfiguration,
-} from '@nrwl/devkit';
+import { joinPathFragments, readProjectConfiguration } from '@nrwl/devkit';
 import type { NormalizedSchema, Schema } from '../schema';
 
 export function normalizeOptions(
   tree: Tree,
   options: Schema
 ): NormalizedSchema {
-  const project = options.project ?? readNxJson(tree).defaultProject;
   const { projectType, root, sourceRoot } = readProjectConfiguration(
     tree,
-    project
+    options.project
   );
   const projectSourceRoot = sourceRoot ?? joinPathFragments(root, 'src');
   const path =
@@ -28,7 +23,6 @@ export function normalizeOptions(
     export: options.export ?? true,
     inlineScam: options.inlineScam ?? true,
     path,
-    project,
     projectSourceRoot,
   };
 }

--- a/packages/angular/src/generators/scam/scam.ts
+++ b/packages/angular/src/generators/scam/scam.ts
@@ -41,8 +41,7 @@ function checkPathUnderProjectRoot(tree: Tree, options: Partial<Schema>) {
     return;
   }
 
-  const project = options.project ?? readNxJson(tree).defaultProject;
-  const { root } = readProjectConfiguration(tree, project);
+  const { root } = readProjectConfiguration(tree, options.project);
 
   let pathToComponent = normalizePath(options.path);
   pathToComponent = pathToComponent.startsWith('/')

--- a/packages/angular/src/generators/scam/schema.d.ts
+++ b/packages/angular/src/generators/scam/schema.d.ts
@@ -1,7 +1,7 @@
 export interface Schema {
   name: string;
+  project: string;
   path?: string;
-  project?: string;
   displayBlock?: boolean;
   inlineStyle?: boolean;
   inlineTemplate?: boolean;
@@ -22,6 +22,5 @@ export interface NormalizedSchema extends Schema {
   export: boolean;
   inlineScam: boolean;
   path: string;
-  project: string;
   projectSourceRoot: string;
 }

--- a/packages/angular/src/generators/scam/schema.json
+++ b/packages/angular/src/generators/scam/schema.json
@@ -22,6 +22,10 @@
     "project": {
       "type": "string",
       "description": "The name of the project.",
+      "$default": {
+        "$source": "projectName",
+        "index": 0
+      },
       "x-dropdown": "projects"
     },
     "name": {

--- a/packages/angular/src/generators/utils/file-info.ts
+++ b/packages/angular/src/generators/utils/file-info.ts
@@ -2,16 +2,15 @@ import {
   joinPathFragments,
   names,
   normalizePath,
-  readNxJson,
   readProjectConfiguration,
   Tree,
 } from '@nrwl/devkit';
 
 export type GenerationOptions = {
   name: string;
+  project: string;
   flat?: boolean;
   path?: string;
-  project?: string;
   type?: string;
 };
 export type FileInfo = {
@@ -46,10 +45,9 @@ function getFileInfo(
   options: GenerationOptions,
   defaultType: string
 ): FileInfo {
-  const project = options.project ?? readNxJson(tree).defaultProject;
   const { root, sourceRoot, projectType } = readProjectConfiguration(
     tree,
-    project
+    options.project
   );
   const { fileName: normalizedName } = names(options.name);
 

--- a/packages/angular/src/generators/utils/path.ts
+++ b/packages/angular/src/generators/utils/path.ts
@@ -39,8 +39,7 @@ export function checkPathUnderProjectRoot(
     return;
   }
 
-  const project = projectName ?? readNxJson(tree).defaultProject;
-  const { root } = readProjectConfiguration(tree, project);
+  const { root } = readProjectConfiguration(tree, projectName);
 
   let pathToComponent = normalizePath(path);
   pathToComponent = pathToComponent.startsWith('/')

--- a/packages/angular/src/generators/web-worker/schema.json
+++ b/packages/angular/src/generators/web-worker/schema.json
@@ -14,6 +14,10 @@
     "project": {
       "type": "string",
       "description": "The name of the project.",
+      "$default": {
+        "$source": "projectName",
+        "index": 0
+      },
       "x-dropdown": "projects",
       "x-priority": "important"
     },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Some Angular generators with `project` as a required option fail the schema validation when it is not explicitly provided. The `project` option is not being auto-populated with the default project.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The relevant Angular generators should auto-populate the `project` option and pass the schema validation. The `$default.$source` should be set to `projectName`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15658 
