### PR TITLE
docs(detox): fix typo for script to run test for android in release mode

### DIFF
--- a/docs/generated/packages/detox/documents/overview.md
+++ b/docs/generated/packages/detox/documents/overview.md
@@ -83,7 +83,7 @@ You can run below commands:
 You can run your e2e test against a production build:
 
 - `nx test-ios frontend-e2e --prod`: to build the iOS app and execute e2e tests with Detox for iOS with Release configuration (Mac only)
-- `nx test-android frontend-e2e`: rto build the Android app and execute e2e tests with Detox for Android with release build type
+- `nx test-android frontend-e2e --prod`: to build the Android app and execute e2e tests with Detox for Android with release build type
 - `nx build-ios frontend-e2e --prod`: build the iOS app using Release configuration (Mac only)
 - `nx build-android frontend-e2e --prod`: build the Android app using release build type
 

--- a/docs/shared/packages/detox/detox-plugin.md
+++ b/docs/shared/packages/detox/detox-plugin.md
@@ -83,7 +83,7 @@ You can run below commands:
 You can run your e2e test against a production build:
 
 - `nx test-ios frontend-e2e --prod`: to build the iOS app and execute e2e tests with Detox for iOS with Release configuration (Mac only)
-- `nx test-android frontend-e2e`: rto build the Android app and execute e2e tests with Detox for Android with release build type
+- `nx test-android frontend-e2e --prod`: to build the Android app and execute e2e tests with Detox for Android with release build type
 - `nx build-ios frontend-e2e --prod`: build the iOS app using Release configuration (Mac only)
 - `nx build-android frontend-e2e --prod`: build the Android app using release build type
 


### PR DESCRIPTION
docs(detox): fix typo for script to run test for android in release mode

Fix typo in docs for testing agains prod build in android

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
