### PR TITLE
fix(core): include target and configuration being run in env variables

### DIFF
--- a/docs/shared/reference/environment-variables.md
+++ b/docs/shared/reference/environment-variables.md
@@ -1,5 +1,7 @@
 # Environment Variables
 
+The following environment variables are ones that you can set to change the behavior of Nx in different environments.
+
 | Property                         | Type    | Description                                                                                                                                                                                                                  |
 | -------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | NX_BASE                          | string  | The default base branch to use when calculating the affected projects. Can be overridden on the command line with `--base`.                                                                                                  |
@@ -16,3 +18,13 @@
 | NX_VERBOSE_LOGGING               | boolean | If set to `true`, will print debug information useful for troubleshooting                                                                                                                                                    |
 | NX_DRY_RUN                       | boolean | If set to `true`, will perform a dry run of the generator. No files will be created and no packages will be installed.                                                                                                       |
 | NX_INTERACTIVE                   | boolean | If set to `true`, will allow Nx to prompt you in the terminal to answer some further questions when running generators.                                                                                                      |
+
+Nx will set the following environment variables so they can be accessible within the process even outside of executors and generators
+
+| Property                     | Type    | Description                                                                                                           |
+| ---------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------- |
+| NX_TASK_TARGET_PROJECT       | string  | Set to the project name of the task being run. Use this to tell which project is being run.                           |
+| NX_TASK_TARGET_TARGET        | string  | Set to the target name of the task being run. Use this to tell which target of the project is being run.              |
+| NX_TASK_TARGET_CONFIGURATION | string  | Set to the configuration name of the task being run. Use this to tell which configuration of the target is being run. |
+| NX_DRY_RUN                   | boolean | Set to `true` during dry runs of generators. Use this to avoid side effects during generators.                        |
+| NX_INTERACTIVE               | boolean | Set to `false` when running generators with `--interactive=false`. Use this to prevent prompting during generators    |

--- a/packages/nx/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/nx/src/tasks-runner/forked-process-task-runner.ts
@@ -351,6 +351,8 @@ export class ForkedProcessTaskRunner {
   ) {
     const env: NodeJS.ProcessEnv = {
       NX_TASK_TARGET_PROJECT: task.target.project,
+      NX_TASK_TARGET_TARGET: task.target.target,
+      NX_TASK_TARGET_CONFIGURATION: task.target.configuration,
       NX_TASK_HASH: task.hash,
       // used when Nx is invoked via Lerna
       LERNA_PACKAGE_NAME: task.target.project,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Only the project is included on the environment variables.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The project, target name, and configuration name will be available in process.env when running through Nx.

```
nx build a --configuration c

NX_TASK_TARGET_PROJECT=a
NX_TASK_TARGET_TARGET=build
NX_TASK_TARGET_CONFIGURATION=c
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
