### PR TITLE
fix(core): nx migrate should accept tags other than latest and next for community packages

### DIFF
--- a/packages/nx/src/command-line/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate.spec.ts
@@ -1479,6 +1479,9 @@ describe('Migration', () => {
     it('should return version when it meets semver requirements', () => {
       expect(normalizeVersion('1.2.3')).toEqual('1.2.3');
       expect(normalizeVersion('1.2.3-beta.1')).toEqual('1.2.3-beta.1');
+      expect(normalizeVersion('1.2.3-beta-next.1')).toEqual(
+        '1.2.3-beta-next.1'
+      );
     });
 
     it('should handle versions missing a patch or a minor', () => {
@@ -1488,7 +1491,9 @@ describe('Migration', () => {
     });
 
     it('should handle incorrect versions', () => {
-      expect(normalizeVersion('1-invalid-version')).toEqual('1.0.0-invalid');
+      expect(normalizeVersion('1-invalid-version')).toEqual(
+        '1.0.0-invalid-version'
+      );
       expect(normalizeVersion('1.invalid-version')).toEqual('1.0.0');
       expect(normalizeVersion('invalid-version')).toEqual('0.0.0');
     });

--- a/packages/nx/src/command-line/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate.spec.ts
@@ -1,5 +1,7 @@
 import * as enquirer from 'enquirer';
 import { PackageJson } from '../utils/package-json';
+import * as packageMgrUtils from '../utils/package-manager';
+
 import {
   Migrator,
   normalizeVersion,
@@ -1493,8 +1495,8 @@ describe('Migration', () => {
   });
 
   describe('parseMigrationsOptions', () => {
-    it('should work for generating migrations', () => {
-      const r = parseMigrationsOptions({
+    it('should work for generating migrations', async () => {
+      const r = await parseMigrationsOptions({
         packageAndVersion: '8.12.0',
         from: '@myscope/a@12.3,@myscope/b@1.1.1',
         to: '@myscope/c@12.3.1',
@@ -1513,8 +1515,8 @@ describe('Migration', () => {
       });
     });
 
-    it('should work for running migrations', () => {
-      const r = parseMigrationsOptions({
+    it('should work for running migrations', async () => {
+      const r = await parseMigrationsOptions({
         runMigrations: '',
         ifExists: true,
       });
@@ -1525,117 +1527,148 @@ describe('Migration', () => {
       });
     });
 
-    it('should handle different variations of the target package', () => {
+    it('should handle different variations of the target package', async () => {
+      jest
+        .spyOn(packageMgrUtils, 'packageRegistryView')
+        .mockImplementation((pkg, version) => {
+          return Promise.resolve(version);
+        });
       expect(
-        parseMigrationsOptions({ packageAndVersion: '@angular/core' })
+        await parseMigrationsOptions({ packageAndVersion: '@angular/core' })
       ).toMatchObject({
         targetPackage: '@angular/core',
         targetVersion: 'latest',
       });
       expect(
-        parseMigrationsOptions({ packageAndVersion: '8.12' })
+        await parseMigrationsOptions({ packageAndVersion: '8.12' })
       ).toMatchObject({
         targetPackage: '@nrwl/workspace',
         targetVersion: '8.12.0',
       });
-      expect(parseMigrationsOptions({ packageAndVersion: '8' })).toMatchObject({
+      expect(
+        await parseMigrationsOptions({ packageAndVersion: '8' })
+      ).toMatchObject({
         targetPackage: '@nrwl/workspace',
         targetVersion: '8.0.0',
       });
-      expect(parseMigrationsOptions({ packageAndVersion: '12' })).toMatchObject(
-        {
-          targetPackage: '@nrwl/workspace',
-          targetVersion: '12.0.0',
-        }
-      );
       expect(
-        parseMigrationsOptions({ packageAndVersion: '8.12.0-beta.0' })
+        await parseMigrationsOptions({ packageAndVersion: '12' })
+      ).toMatchObject({
+        targetPackage: '@nrwl/workspace',
+        targetVersion: '12.0.0',
+      });
+      expect(
+        await parseMigrationsOptions({ packageAndVersion: '8.12.0-beta.0' })
       ).toMatchObject({
         targetPackage: '@nrwl/workspace',
         targetVersion: '8.12.0-beta.0',
       });
       expect(
-        parseMigrationsOptions({ packageAndVersion: 'next' })
+        await parseMigrationsOptions({ packageAndVersion: 'next' })
       ).toMatchObject({
         targetPackage: 'nx',
         targetVersion: 'next',
       });
       expect(
-        parseMigrationsOptions({ packageAndVersion: '13.10.0' })
+        await parseMigrationsOptions({ packageAndVersion: '13.10.0' })
       ).toMatchObject({
         targetPackage: '@nrwl/workspace',
         targetVersion: '13.10.0',
       });
       expect(
-        parseMigrationsOptions({ packageAndVersion: '@nrwl/workspace@8.12' })
+        await parseMigrationsOptions({
+          packageAndVersion: '@nrwl/workspace@8.12',
+        })
       ).toMatchObject({
         targetPackage: '@nrwl/workspace',
         targetVersion: '8.12.0',
       });
       expect(
-        parseMigrationsOptions({ packageAndVersion: 'mypackage@8.12' })
+        await parseMigrationsOptions({ packageAndVersion: 'mypackage@8.12' })
       ).toMatchObject({
         targetPackage: 'mypackage',
         targetVersion: '8.12.0',
       });
       expect(
-        parseMigrationsOptions({ packageAndVersion: 'mypackage' })
+        await parseMigrationsOptions({ packageAndVersion: 'mypackage' })
       ).toMatchObject({
         targetPackage: 'mypackage',
         targetVersion: 'latest',
       });
       expect(
-        parseMigrationsOptions({ packageAndVersion: 'mypackage2' })
+        await parseMigrationsOptions({ packageAndVersion: 'mypackage2' })
       ).toMatchObject({
         targetPackage: 'mypackage2',
         targetVersion: 'latest',
       });
       expect(
-        parseMigrationsOptions({ packageAndVersion: '@nrwl/workspace@latest' })
+        await parseMigrationsOptions({
+          packageAndVersion: '@nrwl/workspace@latest',
+        })
       ).toMatchObject({
         targetPackage: '@nrwl/workspace',
         targetVersion: 'latest',
       });
+      expect(
+        await parseMigrationsOptions({
+          packageAndVersion: '@nrwl/workspace@alpha',
+        })
+      ).toMatchObject({
+        targetPackage: '@nrwl/workspace',
+        targetVersion: 'alpha',
+      });
     });
 
-    it('should handle incorrect from', () => {
-      expect(() =>
+    it('should handle incorrect from', async () => {
+      await expect(() =>
         parseMigrationsOptions({
           packageAndVersion: '8.12.0',
           from: '@myscope/a@',
         })
-      ).toThrowError(`Incorrect 'from' section. Use --from="package@version"`);
-      expect(() =>
+      ).rejects.toThrowError(
+        `Incorrect 'from' section. Use --from="package@version"`
+      );
+      await expect(() =>
         parseMigrationsOptions({
           packageAndVersion: '8.12.0',
           from: '@myscope/a',
         })
-      ).toThrowError(`Incorrect 'from' section. Use --from="package@version"`);
-      expect(() =>
+      ).rejects.toThrowError(
+        `Incorrect 'from' section. Use --from="package@version"`
+      );
+      await expect(() =>
         parseMigrationsOptions({ packageAndVersion: '8.12.0', from: 'myscope' })
-      ).toThrowError(`Incorrect 'from' section. Use --from="package@version"`);
+      ).rejects.toThrowError(
+        `Incorrect 'from' section. Use --from="package@version"`
+      );
     });
 
-    it('should handle incorrect to', () => {
-      expect(() =>
+    it('should handle incorrect to', async () => {
+      await expect(() =>
         parseMigrationsOptions({
           packageAndVersion: '8.12.0',
           to: '@myscope/a@',
         })
-      ).toThrowError(`Incorrect 'to' section. Use --to="package@version"`);
-      expect(() =>
+      ).rejects.toThrowError(
+        `Incorrect 'to' section. Use --to="package@version"`
+      );
+      await expect(() =>
         parseMigrationsOptions({
           packageAndVersion: '8.12.0',
           to: '@myscope/a',
         })
-      ).toThrowError(`Incorrect 'to' section. Use --to="package@version"`);
-      expect(() =>
+      ).rejects.toThrowError(
+        `Incorrect 'to' section. Use --to="package@version"`
+      );
+      await expect(() =>
         parseMigrationsOptions({ packageAndVersion: '8.12.0', to: 'myscope' })
-      ).toThrowError(`Incorrect 'to' section. Use --to="package@version"`);
+      ).rejects.toThrowError(
+        `Incorrect 'to' section. Use --to="package@version"`
+      );
     });
 
-    it('should handle backslashes in package names', () => {
-      const r = parseMigrationsOptions({
+    it('should handle backslashes in package names', async () => {
+      const r = await parseMigrationsOptions({
         packageAndVersion: '@nrwl\\workspace@8.12.0',
         from: '@myscope\\a@12.3,@myscope\\b@1.1.1',
         to: '@myscope\\c@12.3.1',

--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -64,7 +64,10 @@ export interface ResolvedMigrationConfiguration extends MigrationsJson {
 const execAsync = promisify(exec);
 
 export function normalizeVersion(version: string) {
-  const [semver, prereleaseTag] = version.split('-');
+  const [semver, ...prereleaseTagParts] = version.split('-');
+  // Handle versions like 1.0.0-beta-next.2
+  const prereleaseTag = prereleaseTagParts.join('-');
+
   const [major, minor, patch] = semver.split('.');
 
   const newSemver = `${major || 0}.${minor || 0}.${patch || 0}`;

--- a/scripts/depcheck/discrepancies.ts
+++ b/scripts/depcheck/discrepancies.ts
@@ -3,7 +3,7 @@ import { satisfies } from 'semver';
 
 // Ignore packages that are defined here per package
 const IGNORE_MATCHES = {
-  '*': [],
+  '*': [] as string[],
   angular: ['webpack-merge', '@phenomnomnominal/tsquery'],
   cypress: ['webpack', '@babel/core', 'babel-loader'],
 };
@@ -13,7 +13,7 @@ export default function getDiscrepancies(
   projectDependencies: JSON,
   devDependencies: JSON
 ) {
-  return Object.keys(projectDependencies)
+  return Object.keys(projectDependencies ?? ({} as Record<string, string>))
     .filter((p) => !p.startsWith('@nrwl/') && p !== 'nx')
     .filter((p) =>
       !IGNORE_MATCHES['*'].includes(p) && IGNORE_MATCHES[name]


### PR DESCRIPTION
## Current Behavior
`nx migrate mypackage@alpha` fails, resolves the version as 0.0.0 since the tag is not normalized properly.

## Expected Behavior
`nx migrate mypackage@alpha` fails, resolves the version as 0.0.0 since the tag is not normalized properly.

## Alt solutions:
Instead of resolving on the registry ahead of time, we could feasibly just inline a list of accepted tags. This wouldn't fix the issue in the general case, but realistically a list of `['prev', 'previous', 'next', 'latest', 'beta', 'alpha', 'rc', 'dev']` would likely hit most use cases.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15633	
