### PR TITLE
fix(core): clear line escape code shouldn't erase prefix in output

### DIFF
--- a/packages/nx/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/nx/src/tasks-runner/forked-process-task-runner.ts
@@ -20,6 +20,7 @@ import {
 } from './batch/batch-messages';
 import { stripIndents } from '../utils/strip-indents';
 import { Task } from '../config/task-graph';
+import { Transform } from 'stream';
 
 const workerPath = join(__dirname, './batch/run-batch.js');
 
@@ -152,9 +153,13 @@ export class ForkedProcessTaskRunner {
             const prefixText = `${task.target.project}:`;
 
             p.stdout
+              .pipe(
+                logClearLineToPrefixTransformer(color.bold(prefixText) + ' ')
+              )
               .pipe(logTransformer({ tag: color.bold(prefixText) }))
               .pipe(process.stdout);
             p.stderr
+              .pipe(logClearLineToPrefixTransformer(color(prefixText) + ' '))
               .pipe(logTransformer({ tag: color(prefixText) }))
               .pipe(process.stderr);
           } else {
@@ -490,4 +495,21 @@ function getColor(projectName: string) {
   const colorIndex = code % colors.length;
 
   return colors[colorIndex];
+}
+
+/**
+ * Prevents terminal escape sequence from clearing line prefix.
+ */
+function logClearLineToPrefixTransformer(prefix) {
+  let prevChunk = null;
+  return new Transform({
+    transform(chunk, _encoding, callback) {
+      if (prevChunk && prevChunk.toString() === '\x1b[2K') {
+        chunk = chunk.toString().replace(/\x1b\[1G/g, (m) => m + prefix);
+      }
+      this.push(chunk);
+      prevChunk = chunk;
+      callback();
+    },
+  });
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Escape codes in output can cause prefixes to disappear

## Expected Behavior
Escape codes in output don't clear the prefix

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15586
