### PR TITLE
fix(core): prevent running arbitrary code when attempting to detect plugin capabilities

### DIFF
--- a/packages/nx/src/utils/plugins/plugin-capabilities.ts
+++ b/packages/nx/src/utils/plugins/plugin-capabilities.ts
@@ -6,7 +6,7 @@ import type { PluginCapabilities } from './models';
 import { hasElements } from './shared';
 import { readJsonFile } from '../fileutils';
 import { getPackageManagerCommand } from '../package-manager';
-import { loadNxPlugin, readPluginPackageJson } from '../nx-plugin';
+import { loadNxPlugin, NxPlugin, readPluginPackageJson } from '../nx-plugin';
 import { getNxRequirePaths } from '../installation-directory';
 
 function tryGetCollection<T extends object>(
@@ -35,11 +35,20 @@ export function getPluginCapabilities(
       pluginName,
       getNxRequirePaths(workspaceRoot)
     );
-    const pluginModule = loadNxPlugin(
-      pluginName,
-      getNxRequirePaths(workspaceRoot),
-      workspaceRoot
-    );
+    const pluginModule =
+      packageJson.generators ??
+      packageJson.executors ??
+      packageJson['nx-migrations'] ??
+      packageJson['schematics'] ??
+      packageJson['builders']
+        ? loadNxPlugin(
+            pluginName,
+            getNxRequirePaths(workspaceRoot),
+            workspaceRoot
+          )
+        : ({
+            name: pluginName,
+          } as NxPlugin);
     return {
       name: pluginName,
       generators:


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Non-plugin modules are loaded when running `nx list` and `nx report`

## Expected Behavior
Only plugins are loaded when running list or report.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15488
