### PR TITLE
fix(node): fix standalone linter setup

### DIFF
--- a/e2e/linter/src/linter.test.ts
+++ b/e2e/linter/src/linter.test.ts
@@ -474,7 +474,7 @@ describe('Linter', () => {
       ]);
 
       runCLI(`generate @nrwl/workspace:lib ${mylib} --unitTestRunner=jest`);
-      // should add new tslint
+      // should generate new eslint config file
       expect(() => checkFilesExist(`.eslintrc.base.json`)).not.toThrow();
       const appEslint = readJson(`.eslintrc.json`);
       rootEslint = readJson('.eslintrc.base.json');
@@ -544,7 +544,7 @@ describe('Linter', () => {
       ]);
 
       runCLI(`generate @nrwl/workspace:lib ${mylib} --no-interactive`);
-      // should add new tslint
+      // should add new eslint config file
       expect(() => checkFilesExist(`.eslintrc.base.json`)).not.toThrow();
       const appEslint = readJson(`.eslintrc.json`);
       rootEslint = readJson('.eslintrc.base.json');
@@ -604,7 +604,7 @@ describe('Linter', () => {
       ]);
 
       runCLI(`generate @nrwl/workspace:lib ${mylib} --no-interactive`);
-      // should add new tslint
+      // should add new eslint config file
       expect(() => checkFilesExist(`.eslintrc.base.json`)).not.toThrow();
       const appEslint = readJson(`.eslintrc.json`);
       rootEslint = readJson('.eslintrc.base.json');

--- a/e2e/linter/src/linter.test.ts
+++ b/e2e/linter/src/linter.test.ts
@@ -443,65 +443,81 @@ describe('Linter', () => {
     beforeEach(() => newProject());
     afterEach(() => cleanupProject());
 
+    function verifySuccessfulStandaloneSetup(myapp: string) {
+      expect(runCLI(`lint ${myapp}`, { silenceError: true })).toContain(
+        'All files pass linting'
+      );
+      expect(runCLI(`lint e2e`, { silenceError: true })).toContain(
+        'All files pass linting'
+      );
+      expect(() => checkFilesExist(`.eslintrc.base.json`)).toThrow();
+
+      const rootEslint = readJson('.eslintrc.json');
+      const e2eEslint = readJson('e2e/.eslintrc.json');
+
+      // should directly refer to nx plugin
+      expect(rootEslint.plugins).toEqual(['@nrwl/nx']);
+      expect(e2eEslint.plugins).toEqual(['@nrwl/nx']);
+    }
+
+    function verifySuccessfulMigratedSetup(myapp: string, mylib: string) {
+      expect(runCLI(`lint ${myapp}`, { silenceError: true })).toContain(
+        'All files pass linting'
+      );
+      expect(runCLI(`lint e2e`, { silenceError: true })).toContain(
+        'All files pass linting'
+      );
+      expect(runCLI(`lint ${mylib}`, { silenceError: true })).toContain(
+        'All files pass linting'
+      );
+      expect(() => checkFilesExist(`.eslintrc.base.json`)).not.toThrow();
+
+      const rootEslint = readJson('.eslintrc.base.json');
+      const appEslint = readJson('.eslintrc.json');
+      const e2eEslint = readJson('e2e/.eslintrc.json');
+      const libEslint = readJson(`libs/${mylib}/.eslintrc.json`);
+
+      // should directly refer to nx plugin
+      expect(rootEslint.plugins).toEqual(['@nrwl/nx']);
+      expect(appEslint.plugins).toBeUndefined();
+      expect(e2eEslint.plugins).toBeUndefined();
+      expect(libEslint.plugins).toBeUndefined();
+
+      // should extend base
+      expect(appEslint.extends.slice(-1)).toEqual(['./.eslintrc.base.json']);
+      expect(e2eEslint.extends.slice(-1)).toEqual(['../.eslintrc.base.json']);
+      expect(libEslint.extends.slice(-1)).toEqual([
+        '../../.eslintrc.base.json',
+      ]);
+    }
+
     it('(React standalone) should set root project config to app and e2e app and migrate when another lib is added', () => {
       const myapp = uniq('myapp');
       const mylib = uniq('mylib');
 
       runCLI(`generate @nrwl/react:app ${myapp} --rootProject=true`);
+      verifySuccessfulStandaloneSetup(myapp);
 
-      let rootEslint = readJson('.eslintrc.json');
+      let appEslint = readJson('.eslintrc.json');
       let e2eEslint = readJson('e2e/.eslintrc.json');
-      expect(() => checkFilesExist(`.eslintrc.base.json`)).toThrow();
 
-      // should directly refer to nx plugin
-      expect(rootEslint.plugins).toEqual(['@nrwl/nx']);
-      expect(e2eEslint.plugins).toEqual(['@nrwl/nx']);
-      // should only extend framework plugin
-      expect(rootEslint.extends).toEqual(['plugin:@nrwl/nx/react']);
-      expect(e2eEslint.extends).toEqual(['plugin:cypress/recommended']);
       // should have plugin extends
-      expect(rootEslint.overrides[0].extends).toEqual([
-        'plugin:@nrwl/nx/typescript',
-      ]);
-      expect(rootEslint.overrides[1].extends).toEqual([
-        'plugin:@nrwl/nx/javascript',
-      ]);
-      expect(e2eEslint.overrides[0].extends).toEqual([
-        'plugin:@nrwl/nx/typescript',
-      ]);
-      expect(e2eEslint.overrides[1].extends).toEqual([
-        'plugin:@nrwl/nx/javascript',
-      ]);
+      expect(appEslint.overrides[0].extends).toBeDefined();
+      expect(appEslint.overrides[1].extends).toBeDefined();
+      expect(e2eEslint.overrides[0].extends).toBeDefined();
+      expect(e2eEslint.overrides[1].extends).toBeDefined();
 
       runCLI(`generate @nrwl/workspace:lib ${mylib} --unitTestRunner=jest`);
-      // should generate new eslint config file
-      expect(() => checkFilesExist(`.eslintrc.base.json`)).not.toThrow();
-      const appEslint = readJson(`.eslintrc.json`);
-      rootEslint = readJson('.eslintrc.base.json');
-      e2eEslint = readJson('e2e/.eslintrc.json');
-      const libEslint = readJson(`libs/${mylib}/.eslintrc.json`);
+      verifySuccessfulMigratedSetup(myapp, mylib);
 
-      // should directly refer to nx plugin only in the root
-      expect(rootEslint.plugins).toEqual(['@nrwl/nx']);
-      expect(appEslint.plugins).toBeUndefined();
-      expect(e2eEslint.plugins).toBeUndefined();
-      // should extend framework plugin and root config
-      expect(appEslint.extends).toEqual([
-        'plugin:@nrwl/nx/react',
-        './.eslintrc.base.json',
-      ]);
-      expect(e2eEslint.extends).toEqual([
-        'plugin:cypress/recommended',
-        '../.eslintrc.base.json',
-      ]);
-      expect(libEslint.extends).toEqual(['../../.eslintrc.base.json']);
+      appEslint = readJson(`.eslintrc.json`);
+      e2eEslint = readJson('e2e/.eslintrc.json');
+
       // should have no plugin extends
       expect(appEslint.overrides[0].extends).toBeUndefined();
       expect(appEslint.overrides[1].extends).toBeUndefined();
       expect(e2eEslint.overrides[0].extends).toBeUndefined();
       expect(e2eEslint.overrides[1].extends).toBeUndefined();
-      expect(libEslint.overrides[1].extends).toBeUndefined();
-      expect(libEslint.overrides[1].extends).toBeUndefined();
     });
 
     it('(Angular standalone) should set root project config to app and e2e app and migrate when another lib is added', () => {
@@ -511,57 +527,23 @@ describe('Linter', () => {
       runCLI(
         `generate @nrwl/angular:app ${myapp} --rootProject=true --no-interactive`
       );
+      verifySuccessfulStandaloneSetup(myapp);
 
-      let rootEslint = readJson('.eslintrc.json');
+      let appEslint = readJson('.eslintrc.json');
       let e2eEslint = readJson('e2e/.eslintrc.json');
-      expect(() => checkFilesExist(`.eslintrc.base.json`)).toThrow();
 
-      // should directly refer to nx plugin
-      expect(rootEslint.plugins).toEqual(['@nrwl/nx']);
-      expect(e2eEslint.plugins).toEqual(['@nrwl/nx']);
-      // should only extend framework plugin
-      expect(e2eEslint.extends).toEqual(['plugin:cypress/recommended']);
       // should have plugin extends
-      expect(rootEslint.overrides[0].files).toEqual(['*.ts']);
-      expect(rootEslint.overrides[0].extends).toEqual([
-        'plugin:@nrwl/nx/typescript',
-        'plugin:@nrwl/nx/angular',
-        'plugin:@angular-eslint/template/process-inline-templates',
-      ]);
-      expect(Object.keys(rootEslint.overrides[0].rules)).toEqual([
-        '@angular-eslint/directive-selector',
-        '@angular-eslint/component-selector',
-      ]);
-      expect(rootEslint.overrides[1].files).toEqual(['*.html']);
-      expect(rootEslint.overrides[1].extends).toEqual([
-        'plugin:@nrwl/nx/angular-template',
-      ]);
-      expect(e2eEslint.overrides[0].extends).toEqual([
-        'plugin:@nrwl/nx/typescript',
-      ]);
-      expect(e2eEslint.overrides[1].extends).toEqual([
-        'plugin:@nrwl/nx/javascript',
-      ]);
+      expect(appEslint.overrides[0].extends).toBeDefined();
+      expect(appEslint.overrides[1].extends).toBeDefined();
+      expect(e2eEslint.overrides[0].extends).toBeDefined();
+      expect(e2eEslint.overrides[1].extends).toBeDefined();
 
       runCLI(`generate @nrwl/workspace:lib ${mylib} --no-interactive`);
-      // should add new eslint config file
-      expect(() => checkFilesExist(`.eslintrc.base.json`)).not.toThrow();
-      const appEslint = readJson(`.eslintrc.json`);
-      rootEslint = readJson('.eslintrc.base.json');
-      e2eEslint = readJson('e2e/.eslintrc.json');
-      const libEslint = readJson(`libs/${mylib}/.eslintrc.json`);
+      verifySuccessfulMigratedSetup(myapp, mylib);
 
-      // should directly refer to nx plugin only in the root
-      expect(rootEslint.plugins).toEqual(['@nrwl/nx']);
-      expect(appEslint.plugins).toBeUndefined();
-      expect(e2eEslint.plugins).toBeUndefined();
-      // should extend framework plugin and root config
-      expect(appEslint.extends).toEqual(['./.eslintrc.base.json']);
-      expect(e2eEslint.extends).toEqual([
-        'plugin:cypress/recommended',
-        '../.eslintrc.base.json',
-      ]);
-      expect(libEslint.extends).toEqual(['../../.eslintrc.base.json']);
+      appEslint = readJson(`.eslintrc.json`);
+      e2eEslint = readJson('e2e/.eslintrc.json');
+
       // should have no plugin extends
       expect(appEslint.overrides[0].extends).toEqual([
         'plugin:@nrwl/nx/angular',
@@ -569,7 +551,6 @@ describe('Linter', () => {
       ]);
       expect(e2eEslint.overrides[0].extends).toBeUndefined();
       expect(e2eEslint.overrides[1].extends).toBeUndefined();
-      expect(libEslint.overrides[0].extends).toBeUndefined();
     });
 
     it('(Node standalone) should set root project config to app and e2e app and migrate when another lib is added', () => {
@@ -579,51 +560,28 @@ describe('Linter', () => {
       runCLI(
         `generate @nrwl/node:app ${myapp} --rootProject=true --no-interactive`
       );
+      verifySuccessfulStandaloneSetup(myapp);
 
-      let rootEslint = readJson('.eslintrc.json');
+      let appEslint = readJson('.eslintrc.json');
       let e2eEslint = readJson('e2e/.eslintrc.json');
-      expect(() => checkFilesExist(`.eslintrc.base.json`)).toThrow();
 
-      // should directly refer to nx plugin
-      expect(rootEslint.plugins).toEqual(['@nrwl/nx']);
-      expect(e2eEslint.plugins).toEqual(['@nrwl/nx']);
-      // should only extend framework plugin
-      expect(e2eEslint.extends).toEqual([]);
       // should have plugin extends
-      expect(rootEslint.overrides[0].extends).toEqual([
-        'plugin:@nrwl/nx/typescript',
-      ]);
-      expect(rootEslint.overrides[1].extends).toEqual([
-        'plugin:@nrwl/nx/javascript',
-      ]);
-      expect(e2eEslint.overrides[0].extends).toEqual([
-        'plugin:@nrwl/nx/typescript',
-      ]);
-      expect(e2eEslint.overrides[1].extends).toEqual([
-        'plugin:@nrwl/nx/javascript',
-      ]);
+      expect(appEslint.overrides[0].extends).toBeDefined();
+      expect(appEslint.overrides[1].extends).toBeDefined();
+      expect(e2eEslint.overrides[0].extends).toBeDefined();
+      expect(e2eEslint.overrides[1].extends).toBeDefined();
 
       runCLI(`generate @nrwl/workspace:lib ${mylib} --no-interactive`);
-      // should add new eslint config file
-      expect(() => checkFilesExist(`.eslintrc.base.json`)).not.toThrow();
-      const appEslint = readJson(`.eslintrc.json`);
-      rootEslint = readJson('.eslintrc.base.json');
-      e2eEslint = readJson('e2e/.eslintrc.json');
-      const libEslint = readJson(`libs/${mylib}/.eslintrc.json`);
+      verifySuccessfulMigratedSetup(myapp, mylib);
 
-      // should directly refer to nx plugin only in the root
-      expect(rootEslint.plugins).toEqual(['@nrwl/nx']);
-      expect(appEslint.plugins).toBeUndefined();
-      expect(e2eEslint.plugins).toBeUndefined();
-      // should extend framework plugin and root config
-      expect(appEslint.extends).toEqual(['./.eslintrc.base.json']);
-      expect(e2eEslint.extends).toEqual(['../.eslintrc.base.json']);
-      expect(libEslint.extends).toEqual(['../../.eslintrc.base.json']);
+      appEslint = readJson(`.eslintrc.json`);
+      e2eEslint = readJson('e2e/.eslintrc.json');
+
       // should have no plugin extends
       expect(appEslint.overrides[0].extends).toBeUndefined();
+      expect(appEslint.overrides[1].extends).toBeUndefined();
       expect(e2eEslint.overrides[0].extends).toBeUndefined();
       expect(e2eEslint.overrides[1].extends).toBeUndefined();
-      expect(libEslint.overrides[0].extends).toBeUndefined();
     });
   });
 });

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -45,6 +45,7 @@ import { e2eProjectGenerator } from '../e2e-project/e2e-project';
 import { setupDockerGenerator } from '../setup-docker/setup-docker';
 
 import { Schema } from './schema';
+import { mapLintPattern } from '@nrwl/linter/src/generators/lint-project/lint-project';
 
 export interface NormalizedSchema extends Schema {
   appProjectRoot: string;
@@ -272,7 +273,11 @@ export async function addLintingToApplication(
       joinPathFragments(options.appProjectRoot, 'tsconfig.app.json'),
     ],
     eslintFilePatterns: [
-      `${options.appProjectRoot}/**/*.${options.js ? 'js' : 'ts'}`,
+      mapLintPattern(
+        options.appProjectRoot,
+        options.js ? 'js' : 'ts',
+        options.rootProject
+      ),
     ],
     unitTestRunner: options.unitTestRunner,
     skipFormat: true,
@@ -381,11 +386,8 @@ export async function applicationGenerator(tree: Tree, schema: Schema) {
 
   updateTsConfigOptions(tree, options);
 
-  if (options.linter !== Linter.None) {
-    const lintTask = await addLintingToApplication(tree, {
-      ...options,
-      skipFormat: true,
-    });
+  if (options.linter === Linter.EsLint) {
+    const lintTask = await addLintingToApplication(tree, options);
     tasks.push(lintTask);
   }
 


### PR DESCRIPTION
The current implementation of `node-server` preset (node standalone) will produce `.eslintrc.json` that is broken.

This PR fixes that.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
