### PR TITLE
feat(repo): improve yarn install caching for nightly

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -13,7 +13,35 @@ on:
 
 permissions: {}
 jobs:
+  preinstall:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Cache node_modules
+        id: cache-modules
+        uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install packages
+        if: steps.cache-modules.outputs.cache-hit != 'true'
+        run: yarn install --prefer-offline --frozen-lockfile --non-interactive
+
   e2e:
+    needs: preinstall
     permissions:
       contents: read
     runs-on: ${{ matrix.os }}
@@ -161,20 +189,15 @@ jobs:
           node-version: ${{ matrix.node_version }}
           registry-url: http://localhost:4872
 
-      - name: Yarn cache directory path
-        id: yarn-cache-dir-path
-        shell: bash
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache yarn
+      - name: Cache node_modules
+        id: cache-modules
         uses: actions/cache@v3
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ matrix.os }}-node-${{ matrix.node_version }}-yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ matrix.os }}-node-${{ matrix.node_version }}-yarn-
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install packages
+        if: steps.cache-modules.outputs.cache-hit != 'true'
         run: yarn install --prefer-offline --frozen-lockfile --non-interactive
 
       - name: Cleanup

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -13,7 +13,30 @@ on:
 
 permissions: {}
 jobs:
+  preinstall:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Cache node_modules
+        id: cache-modules
+        uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: windows-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install packages
+        if: steps.cache-modules.outputs.cache-hit != 'true'
+        run: yarn install --prefer-offline --frozen-lockfile --non-interactive
+
   e2e:
+    needs: preinstall
     permissions:
       contents: read
 
@@ -124,22 +147,15 @@ jobs:
           node-version: ${{ matrix.node_version }}
           registry-url: http://localhost:4872
 
-      - name: Yarn cache directory path
-        id: yarn-cache-dir-path
-        shell: bash
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache yarn
+      - name: Cache node_modules
+        id: cache-modules
         uses: actions/cache@v3
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: windows-node-${{ matrix.node_version }}-yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            windows-node-${{ matrix.node_version }}-yarn-
-            windows-node-${{ matrix.node_version }}-
-            windows-
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install packages
+        if: steps.cache-modules.outputs.cache-hit != 'true'
         run: yarn install --prefer-offline --frozen-lockfile --non-interactive
 
       - name: Run e2e tests


### PR DESCRIPTION
This PR adds a pre-job to matrix runs that ensure node_modules are cached, and each run can benefit from the cached installation.

This cuts down test run:
- ubuntu - from max 5min to 30sec
- macOS - from max 12min to 4min
- windows - from max 14min to 4min

![Screenshot 2023-03-14 at 23 20 23](https://user-images.githubusercontent.com/881612/225155355-ed439035-49e3-4d2e-8932-b44afd8ebcc7.png)


## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
