### PR TITLE
fix(angular): throw error for invalid project name in withModuleFederation helper

### DIFF
--- a/packages/angular/src/utils/mf/utils.ts
+++ b/packages/angular/src/utils/mf/utils.ts
@@ -47,6 +47,12 @@ export async function getModuleFederationConfig(
     projectGraph = await createProjectGraphAsync();
   }
 
+  if (!projectGraph.nodes[mfConfig.name]?.data) {
+    throw Error(
+      `Cannot find project "${mfConfig.name}". Check that the name is correct in module-federation.config.js`
+    );
+  }
+
   const dependencies = getDependentPackagesForProject(
     projectGraph,
     mfConfig.name


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

If an invalid project name is set in the module federation config, an empty set of dependencies is collected and no error is thrown.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

If an invalid project name is set in the module federation config, an error should be thrown providing feedback for the dev to address the issue.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15686 
