### PR TITLE
fix(core): wildcard implicit dependency should support scoped project names

### DIFF
--- a/packages/nx/src/utils/find-matching-projects.ts
+++ b/packages/nx/src/utils/find-matching-projects.ts
@@ -31,7 +31,8 @@ export function findMatchingProjects(
     const exclude = nameOrGlob.startsWith('!');
     const pattern = exclude ? nameOrGlob.substring(1) : nameOrGlob;
 
-    const matchedProjectNames = minimatch.match(projectNames, pattern);
+    const matchedProjectNames =
+      pattern === '*' ? projectNames : minimatch.match(projectNames, pattern);
 
     matchedProjectNames.forEach((matchedProjectName) => {
       if (exclude) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Wildcards don't function as expected in project based repositories because `@org/package` doesn't match `*` as a glob pattern. `**/*` would perform the expected match, but isn't what we want.

## Expected Behavior
`*` selects expected projects

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
