### PR TITLE
cleanup(angular): use our own pipe for scam-pipe

### DIFF
--- a/packages/angular/src/generators/scam-pipe/scam-pipe.ts
+++ b/packages/angular/src/generators/scam-pipe/scam-pipe.ts
@@ -9,20 +9,16 @@ import { getPipeFileInfo } from '../utils/file-info';
 import { pathStartsWith } from '../utils/path';
 import { convertPipeToScam, normalizeOptions } from './lib';
 import type { Schema } from './schema';
+import { pipeGenerator } from '../pipe/pipe';
 
 export async function scamPipeGenerator(tree: Tree, rawOptions: Schema) {
   const options = normalizeOptions(tree, rawOptions);
-  const { inlineScam, projectSourceRoot, ...schematicOptions } = options;
+  const { inlineScam, projectSourceRoot, ...pipeOptions } = options;
 
   checkPathUnderProjectRoot(tree, options);
 
-  const { wrapAngularDevkitSchematic } = require('@nrwl/devkit/ngcli-adapter');
-  const angularPipeSchematic = wrapAngularDevkitSchematic(
-    '@schematics/angular',
-    'pipe'
-  );
-  await angularPipeSchematic(tree, {
-    ...schematicOptions,
+  await pipeGenerator(tree, {
+    ...pipeOptions,
     skipImport: true,
     export: false,
     standalone: false,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We use wrapAngularDevkitSchematics when generating scam pipes.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should use our own pipe generator

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
