### PR TITLE
chore(repo): update codeowners for CT and linter

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -23,6 +23,9 @@
 /e2e/angular-extensions/** @Coly010 @leosvelperez
 /packages/make-angular-cli-faster/** @leosvelperez @Coly010
 /e2e/make-angular-cli-faster/** @leosvelperez @Coly010
+/packages/angular/plugins/component-testing.ts @leosvelperez @Coly010 @barbados-clemens
+/packages/angular/src/generators/cypress-component-configuration/** @leosvelperez @Coly010 @barbados-clemens
+/packages/angular/src/generators/component-test/** @leosvelperez @Coly010 @barbados-clemens
 
 ## React
 /docs/generated/packages/react/** @jaysoo @ndcunningham @mandarini @xiongemi
@@ -35,6 +38,9 @@
 /e2e/next/** @ndcunningham @jaysoo @xiongemi
 /packages/cra-to-nx/** @jaysoo @xiongemi @mandarini
 /e2e/cra-to-nx/** @jaysoo @xiongemi @mandarini @ndcunningham
+/packages/react/plugins/component-testing/** @jaysoo @ndcunningham @barbados-clemens
+/packages/react/src/generators/cypress-component-configuration/** @jaysoo @ndcunningham @barbados-clemens
+/packages/react/src/generators/component-test/** @jaysoo @ndcunningham @barbados-clemens
 
 # React Native
 /docs/generated/packages/detox/** @xiongemi @jaysoo @ndcunningham
@@ -93,7 +99,7 @@
 /docs/generated/packages/linter/** @meeroslav @FrozenPandaz @JamesHenry
 /packages/eslint-plugin-nx/** @meeroslav @FrozenPandaz @JamesHenry
 /packages/linter/** @meeroslav @FrozenPandaz @JamesHenry
-/e2e/linter/** @meeroslav @FrozenPandaz @barbados-clemens
+/e2e/linter/** @meeroslav @FrozenPandaz 
 .eslint* @meeroslav @FrozenPandaz @JamesHenry
 
 # Storybook


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
component testing files inside the react/angular vertical do not include @barbados-clemens as an owner

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
each vertical component testing files include @barbados-clemens 

also not sure why I'm in the linter e2e codeowner so removed myself from there as well.
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

