### PR TITLE
fix(core): fix NX_TASK_TARGET_CONFIGURATION being set to 'null'

### DIFF
--- a/packages/nx/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/nx/src/tasks-runner/forked-process-task-runner.ts
@@ -357,7 +357,7 @@ export class ForkedProcessTaskRunner {
     const env: NodeJS.ProcessEnv = {
       NX_TASK_TARGET_PROJECT: task.target.project,
       NX_TASK_TARGET_TARGET: task.target.target,
-      NX_TASK_TARGET_CONFIGURATION: task.target.configuration,
+      NX_TASK_TARGET_CONFIGURATION: task.target.configuration ?? undefined,
       NX_TASK_HASH: task.hash,
       // used when Nx is invoked via Lerna
       LERNA_PACKAGE_NAME: task.target.project,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

During Distributed Task Execution, the `NX_TASK_TARGET_CONFIGURATION` variable is set to `"null"`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

During Distributed Task Execution, the `NX_TASK_TARGET_CONFIGURATION` variable is not defined.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
