### PR TITLE
fix(angular): do not set angularCompilerOptions in e2e tsconfig when generating an app

### DIFF
--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -141,6 +141,67 @@ describe('AppComponent', () => {
 "
 `;
 
+exports[`app --strict should enable strict type checking: app tsconfig.json 1`] = `
+Object {
+  "angularCompilerOptions": Object {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true,
+  },
+  "compilerOptions": Object {
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "strict": true,
+    "target": "es2022",
+    "useDefineForClassFields": false,
+  },
+  "extends": "../../tsconfig.base.json",
+  "files": Array [],
+  "include": Array [],
+  "references": Array [
+    Object {
+      "path": "./tsconfig.app.json",
+    },
+    Object {
+      "path": "./tsconfig.spec.json",
+    },
+    Object {
+      "path": "./tsconfig.editor.json",
+    },
+  ],
+}
+`;
+
+exports[`app --strict should enable strict type checking: e2e tsconfig.json 1`] = `
+Object {
+  "compilerOptions": Object {
+    "allowJs": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "outDir": "../../dist/out-tsc",
+    "sourceMap": false,
+    "strict": true,
+    "types": Array [
+      "cypress",
+      "node",
+    ],
+  },
+  "extends": "../../tsconfig.base.json",
+  "include": Array [
+    "src/**/*.ts",
+    "src/**/*.js",
+    "cypress.config.ts",
+  ],
+}
+`;
+
 exports[`app at the root should accept numbers in the path 1`] = `"src/9-websites/my-app"`;
 
 exports[`app nested should create project configs 1`] = `
@@ -443,12 +504,6 @@ Object {
 
 exports[`app not nested should generate files 1`] = `
 Object {
-  "angularCompilerOptions": Object {
-    "enableI18nLegacyMessageIdFormat": false,
-    "strictInjectionParameters": true,
-    "strictInputAccessModifiers": true,
-    "strictTemplates": true,
-  },
   "compilerOptions": Object {
     "allowJs": true,
     "forceConsistentCasingInFileNames": true,

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -657,29 +657,10 @@ describe('app', () => {
     it('should enable strict type checking', async () => {
       await generateApp(appTree, 'my-app', { strict: true });
 
-      // define all the tsconfig files to update
-      const configFiles = [
-        'apps/my-app/tsconfig.json',
-        'apps/my-app-e2e/tsconfig.json',
-      ];
-
-      for (const configFile of configFiles) {
-        const { compilerOptions, angularCompilerOptions } = parseJson(
-          appTree.read(configFile, 'utf-8')
-        );
-
-        // check that the TypeScript compiler options have been updated
-        expect(compilerOptions.forceConsistentCasingInFileNames).toBe(true);
-        expect(compilerOptions.strict).toBe(true);
-        expect(compilerOptions.noImplicitOverride).toBe(true);
-        expect(compilerOptions.noPropertyAccessFromIndexSignature).toBe(true);
-        expect(compilerOptions.noImplicitReturns).toBe(true);
-        expect(compilerOptions.noFallthroughCasesInSwitch).toBe(true);
-
-        // check that the Angular Template options have been updated
-        expect(angularCompilerOptions.strictInjectionParameters).toBe(true);
-        expect(angularCompilerOptions.strictTemplates).toBe(true);
-      }
+      const appTsConfig = readJson(appTree, 'apps/my-app/tsconfig.json');
+      expect(appTsConfig).toMatchSnapshot('app tsconfig.json');
+      const e2eTsConfig = readJson(appTree, 'apps/my-app-e2e/tsconfig.json');
+      expect(e2eTsConfig).toMatchSnapshot('e2e tsconfig.json');
 
       // should not update workspace configuration since --strict=true is the default
       const nxJson = readJson<NxJsonConfiguration>(appTree, 'nx.json');

--- a/packages/angular/src/generators/application/lib/enable-strict-type-checking.ts
+++ b/packages/angular/src/generators/application/lib/enable-strict-type-checking.ts
@@ -1,45 +1,39 @@
 import type { Tree } from '@nrwl/devkit';
-import type { NormalizedSchema } from './normalized-schema';
-
 import { updateJson } from '@nrwl/devkit';
+import type { NormalizedSchema } from './normalized-schema';
 
 export function enableStrictTypeChecking(
   host: Tree,
   options: NormalizedSchema
-) {
-  const configFiles = [
-    `${options.appProjectRoot}/tsconfig.json`,
-    `${options.e2eProjectRoot}/tsconfig.json`,
-  ];
+): void {
+  // This matches the settings defined by the Angular CLI https://angular.io/guide/strict-mode
+  const compilerOptions = {
+    forceConsistentCasingInFileNames: true,
+    strict: true,
+    noImplicitOverride: true,
+    noPropertyAccessFromIndexSignature: true,
+    noImplicitReturns: true,
+    noFallthroughCasesInSwitch: true,
+  };
 
-  for (const configFile of configFiles) {
-    if (!host.exists(configFile)) {
-      continue;
-    }
-
-    // Update the settings in the tsconfig.app.json to enable strict type checking.
-    // This matches the settings defined by the Angular CLI https://angular.io/guide/strict-mode
-    updateJson(host, configFile, (json) => {
-      // update the TypeScript settings
-      json.compilerOptions = {
-        ...(json.compilerOptions ?? {}),
-        forceConsistentCasingInFileNames: true,
-        strict: true,
-        noImplicitOverride: true,
-        noPropertyAccessFromIndexSignature: true,
-        noImplicitReturns: true,
-        noFallthroughCasesInSwitch: true,
-      };
-
-      // update Angular Template Settings
+  const appTsConfigPath = `${options.appProjectRoot}/tsconfig.json`;
+  if (host.exists(appTsConfigPath)) {
+    updateJson(host, appTsConfigPath, (json) => {
+      json.compilerOptions = { ...json.compilerOptions, ...compilerOptions };
       json.angularCompilerOptions = {
-        ...(json.angularCompilerOptions ?? {}),
         enableI18nLegacyMessageIdFormat: false,
         strictInjectionParameters: true,
         strictInputAccessModifiers: true,
         strictTemplates: true,
       };
+      return json;
+    });
+  }
 
+  const e2eTsConfigPath = `${options.e2eProjectRoot}/tsconfig.json`;
+  if (host.exists(e2eTsConfigPath)) {
+    updateJson(host, e2eTsConfigPath, (json) => {
+      json.compilerOptions = { ...json.compilerOptions, ...compilerOptions };
       return json;
     });
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When generating an Angular application, the `tsconfig.json` file in the generated e2e project ends up with the `angularCompilerOptions` set. These options are not needed for Cypress projects.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `tsconfig.json` in generated e2e projects as part of an Angular application generation should not contain the `angularCompilerOptions`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
