### PR TITLE
chore(graph): remove e2e-graph-client from e2e-matrix

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -86,7 +86,6 @@ jobs:
           - e2e-webpack
           - e2e-workspace-create
           - e2e-e2e-workspace-create-npm
-          - e2e-graph-client
         include:
           # os short names
           - os: ubuntu-latest
@@ -152,8 +151,6 @@ jobs:
             codeowners: 'S04SYHYKGNP'
           - project: e2e-e2e-workspace-create-npm
             codeowners: 'S04SYHYKGNP'
-          - project: e2e-graph-client
-            codeowners: 'S04T16QL360'
         exclude:
           # exclude react-native tests from ubuntu
           - os: ubuntu-latest

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -74,7 +74,6 @@ jobs:
           - e2e-webpack
           - e2e-workspace-create
           - e2e-e2e-workspace-create-npm
-          - e2e-graph-client
         include:
           # codeowner groups
           - project: e2e-add-nx-to-monorepo
@@ -129,8 +128,6 @@ jobs:
             codeowners: 'S04SYHYKGNP'
           - project: e2e-e2e-workspace-create-npm
             codeowners: 'S04SYHYKGNP'
-          - project: e2e-graph-client
-            codeowners: 'S04T16QL360'
       fail-fast: false
 
     name: ${{ matrix.project }}


### PR DESCRIPTION
## Current Behavior
`e2e-graph-client` is run during the nightly e2e-matrix

## Expected Behavior
`e2e-graph-client` is not run during the nightly e2e-matrix

There some issues with flakiness and Cypress caching with the `e2e-graph-client` when run during the e2e matrix. Because the graph client is covered by e2e tests on PRs, I don't think there's a need to run it during the e2e matrix. The tests doesn't run against a real Nx install, it's just mocking data and testing the frontend. The frontend is isolated from changes to operating system changes, external changes, Nx itself, so the e2e matrix likely won't catch any regressions.
