### PR TITLE
fix(js): do not run prettier when we can run formatFiles

### DIFF
--- a/packages/web/src/generators/init/init.ts
+++ b/packages/web/src/generators/init/init.ts
@@ -43,6 +43,7 @@ export async function webInitGenerator(tree: Tree, schema: Schema) {
 
   const jsInitTask = await jsInitGenerator(tree, {
     js: false,
+    skipFormat: true,
   });
   tasks.push(jsInitTask);
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Prettier runs on all the files every time a generator is run.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Prettier is not run on all the files. The normal `formatFiles` is used.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
