### PR TITLE
fix(misc): do not create apps libs for standalone presets

### DIFF
--- a/docs/generated/packages/workspace/generators/preset.json
+++ b/docs/generated/packages/workspace/generators/preset.json
@@ -89,6 +89,7 @@
     "presets": []
   },
   "description": "Create application in an empty workspace.",
+  "x-use-standalone-layout": true,
   "hidden": true,
   "implementation": "/packages/workspace/src/generators/preset/preset#presetGenerator.ts",
   "aliases": [],

--- a/packages/workspace/generators.json
+++ b/packages/workspace/generators.json
@@ -46,6 +46,7 @@
       "factory": "./src/generators/preset/preset#presetGenerator",
       "schema": "./src/generators/preset/schema.json",
       "description": "Create application in an empty workspace.",
+      "x-use-standalone-layout": true,
       "hidden": true
     },
     "move": {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Even standalone presets are getting `apps` and `libs` directories created.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

standalone presets are not getting `apps` and `libs` directories created.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
