### PR TITLE
fix(node): align proxy port with default api port

### DIFF
--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -338,8 +338,8 @@ describe('app', () => {
       expect(tree.exists('my-frontend/proxy.conf.json')).toBeTruthy();
 
       expect(readJson(tree, 'my-frontend/proxy.conf.json')).toEqual({
-        '/api': { target: 'http://localhost:3000', secure: false },
-        '/billing-api': { target: 'http://localhost:3000', secure: false },
+        '/api': { target: 'http://localhost:3333', secure: false },
+        '/billing-api': { target: 'http://localhost:3333', secure: false },
       });
     });
 

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -478,7 +478,7 @@ function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
     linter: options.linter ?? Linter.EsLint,
     unitTestRunner: options.unitTestRunner ?? 'jest',
     rootProject: options.rootProject ?? false,
-    port: options.port ?? 3000,
+    port: options.port ?? 3333,
   };
 }
 


### PR DESCRIPTION

## Current Behavior
When generating a Node application with `--frontendProject` flag a proxy gets generated with default port `3000` but the default port of our API is `3333`.

## Expected Behavior
Default Proxy and API ports should be in sync

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
