### PR TITLE
fix(angular): fix wrong tsconfig option name in webpack-dev-server implementation

### DIFF
--- a/packages/angular/src/builders/webpack-dev-server/webpack-dev-server.impl.ts
+++ b/packages/angular/src/builders/webpack-dev-server/webpack-dev-server.impl.ts
@@ -19,6 +19,13 @@ import { from } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { getRootTsConfigPath } from 'nx/src/utils/typescript';
 
+type BuildTargetOptions = {
+  tsConfig: string;
+  buildLibsFromSource?: boolean;
+  customWebpackConfig?: { path?: string };
+  indexFileTransformer?: string;
+};
+
 export function executeWebpackDevServerBuilder(
   rawOptions: Schema,
   context: import('@angular-devkit/architect').BuilderContext
@@ -38,7 +45,7 @@ export function executeWebpackDevServerBuilder(
   const buildTarget =
     browserTargetProjectConfiguration.targets[parsedBrowserTarget.target];
 
-  const buildTargetOptions = {
+  const buildTargetOptions: BuildTargetOptions = {
     ...buildTarget.options,
     ...(parsedBrowserTarget.configuration
       ? buildTarget.configurations[parsedBrowserTarget.configuration]
@@ -83,13 +90,9 @@ export function executeWebpackDevServerBuilder(
   let dependencies: DependentBuildableProjectNode[];
   if (!buildLibsFromSource) {
     const { tsConfigPath, dependencies: foundDependencies } =
-      createTmpTsConfigForBuildableLibs(
-        buildTargetOptions.buildTargetTsConfigPath,
-        context,
-        {
-          target: parsedBrowserTarget.target,
-        }
-      );
+      createTmpTsConfigForBuildableLibs(buildTargetOptions.tsConfig, context, {
+        target: parsedBrowserTarget.target,
+      });
     dependencies = foundDependencies;
 
     // We can't just pass the tsconfig path in memory to the angular builder


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When serving an application using buildable libraries, it errors because of an `undefined` tsConfig path. This is happening because a wrong option name is being used in the `webpack-dev-server` executor implementation.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Serving an application with the `webpack-dev-server` executor and using buildable libraries should work correctly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15746 
