### PR TITLE
chore(repo): optimize nightly report for better readability

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -281,7 +281,7 @@ jobs:
         with:
           script: |
             const combined = JSON.parse(${{ steps.combine-json.outputs.combined }});
-            const failedProjects = combined.filter(c => c.status === 'failure');
+            const failedProjects = combined.filter(c => c.status === 'failure').sort((a, b) => a.project.localeCompare(b.project));
 
             // codeowners
             const codeowners = new Set();
@@ -291,12 +291,16 @@ jobs:
             core.setOutput('CODEOWNERS', Array.from(codeowners).join(','));
 
             // message
+            let lastProject;
             let result = `
+              **Node** v16
               \`\`\`
-               | Failed project                 | Node | PM   | OS    |
-               |--------------------------------|------|------|-------|`;
+              | Failed project                 | PM   | OS    |
+              |--------------------------------|------|-------|`;
             failedProjects.forEach(matrix => {
-              result += `\n| ${matrix.project.padEnd(30)} | v${matrix.node_version.padEnd(3)} | ${matrix.package_manager.padEnd(4)} | ${matrix.os_name} |`
+              const project = matrix.project !== lastProject ? matrix.project : '...';
+              result += `\n| ${project.padEnd(30)} | ${matrix.package_manager.padEnd(4)} | ${matrix.os_name} |`
+              lastProject = matrix.project;
             });
             result += `\`\`\``;
             const message = result.split('\n').map(l => l.trim()).join('\n');

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -216,7 +216,7 @@ jobs:
         with:
           script: |
             const combined = JSON.parse(${{ steps.combine-json.outputs.combined }});
-            const failedProjects = combined.filter(c => c.status === 'failure');
+            const failedProjects = combined.filter(c => c.status === 'failure').sort((a, b) => a.project.localeCompare(b.project));
 
             // codeowners
             const codeowners = new Set();
@@ -227,11 +227,14 @@ jobs:
 
             // message
             let result = `
+              **Node** v16
+              **OS** Windows
+              **Package manager** npm
               \`\`\`
-               | Failed project                 | Node | PM   | OS      |
-               |--------------------------------|------|------|---------|`;
+              | Failed project                 |
+              |--------------------------------|`;
             failedProjects.forEach(matrix => {
-              result += `\n| ${matrix.project.padEnd(30)} | v${matrix.node_version.padEnd(3)} | ${matrix.package_manager.padEnd(4)} | Windows |`
+              result += `\n| ${matrix.project.padEnd(30)} |`
             });
             result += `\`\`\``;
             const message = result.split('\n').map(l => l.trim()).join('\n');


### PR DESCRIPTION
Optimizes nightly E2E report for better readability:
- Sorts project by name
- Removes (currently) irrelevant `node version` column

Before:
![Screenshot 2023-03-20 at 10 28 11](https://user-images.githubusercontent.com/881612/226298876-47c4f606-5eb9-49aa-913e-7ceab43b43ec.png)

After:
![Screenshot 2023-03-20 at 10 38 35](https://user-images.githubusercontent.com/881612/226301489-b9dd95a4-cf77-4bd0-bb9a-aa6e6a96feb6.png)


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
