### PR TITLE
cleanup(storybook): fix nested layout e2e test case

### DIFF
--- a/e2e/storybook/src/storybook-nested.test.ts
+++ b/e2e/storybook/src/storybook-nested.test.ts
@@ -80,8 +80,8 @@ describe('Storybook generators for nested workspaces', () => {
         `generate @nrwl/react:storybook-configuration ${nestedAppName} --generateStories --no-interactive`
       );
       checkFilesExist(
-        `apps/${nestedAppName}/.storybook/main.js`,
-        `apps/${nestedAppName}/.storybook/tsconfig.json`
+        `${nestedAppName}/.storybook/main.js`,
+        `${nestedAppName}/.storybook/tsconfig.json`
       );
     });
   });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

A Storybook e2e test case for nested project layouts is failing due to expecting an app to be created under the `apps` folder. The `apps` folder is no longer generated for standalone presets (https://github.com/nrwl/nx/pull/15741) and the test fails because apps are created at the workspace root.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Storybook e2e tests should succeed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
