### PR TITLE
feat(core): do not affect all if lock changed but not root package.json

### DIFF
--- a/packages/nx/src/project-graph/affected/locators/workspace-projects.ts
+++ b/packages/nx/src/project-graph/affected/locators/workspace-projects.ts
@@ -27,14 +27,16 @@ export const getImplicitlyTouchedProjects: TouchedProjectLocator = (
   nxJson
 ): string[] => {
   const implicits = { ...nxJson.implicitDependencies };
-  const globalFiles = [
-    ...extractGlobalFilesFromInputs(nxJson),
-    'nx.json',
+  const lockFiles = [
     'package-lock.json',
     'yarn.lock',
     'pnpm-lock.yaml',
     'pnpm-lock.yml',
   ];
+  const globalFiles = [...extractGlobalFilesFromInputs(nxJson), 'nx.json'];
+  if (fileChanges.find((fileChange) => fileChange.file === 'package.json')) {
+    globalFiles.push(...lockFiles);
+  }
   globalFiles.forEach((file) => {
     implicits[file] = '*' as any;
   });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

Given an NX workspace using yarn, npm or pnpm workspaces, with projects `a`, `b`, and `c`, where each of them has a package.json;

Installing or updating a dependency to a specific package:
- `yarn workspace a add {package}`
- `pnpm i --filter a {package}`
- or `npm install {package} -w a`

Causes all projects (`a`, `b`, and `c`) to be affected (implicit).

## Expected Behavior

Only project `a` should be affected (explicit).

## Related Issue(s)
[<!-- Please link the issue being fixed so it gets closed when this is merged. -->](https://github.com/nrwl/nx/issues/10842)

Fixes #10842

## Notes

The logic is simple: only consider the lock files as global/implicit inputs if the root package.json changed.
Locator `getImplicitlyTouchedProjects` will not return any project otherwise.
Projects that were really affected will be return by `getTouchedProjects`.

This is mostly safe because the lock file should only change when there are changes in any package.json.
The root package json is where NX and shared dependencies are declared, so updating it will likely trigger a full build anyway.
Changing a project's package.json is expected to only affect the touched project.
