### PR TITLE
fix(bundling): respect --sourcemap option for esbuild

### DIFF
--- a/docs/generated/packages/esbuild/executors/esbuild.json
+++ b/docs/generated/packages/esbuild/executors/esbuild.json
@@ -114,7 +114,13 @@
         "default": false
       },
       "sourcemap": {
-        "type": "boolean",
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": ["linked", "inline", "external", "both"]
+          },
+          { "type": "boolean" }
+        ],
         "alias": "sourceMap",
         "description": "Generate sourcemap.",
         "default": false

--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.spec.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.spec.ts
@@ -356,4 +356,39 @@ describe('buildEsbuildOptions', () => {
       },
     });
   });
+
+  it('should set sourcemap', () => {
+    expect(
+      buildEsbuildOptions(
+        'esm',
+        {
+          bundle: false,
+          platform: 'node',
+          main: 'apps/myapp/src/index.ts',
+          outputPath: 'dist/apps/myapp',
+          tsConfig: 'apps/myapp/tsconfig.app.json',
+          project: 'apps/myapp/package.json',
+          outputFileName: 'index.js',
+          assets: [],
+          singleEntry: true,
+          sourcemap: true,
+          external: [],
+        },
+        context
+      )
+    ).toEqual({
+      bundle: false,
+      entryNames: '[dir]/[name]',
+      entryPoints: ['apps/myapp/src/index.ts'],
+      format: 'esm',
+      platform: 'node',
+      outdir: 'dist/apps/myapp',
+      tsconfig: 'apps/myapp/tsconfig.app.json',
+      external: undefined,
+      sourcemap: true,
+      outExtension: {
+        '.js': '.js',
+      },
+    });
+  });
 });

--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
@@ -39,6 +39,7 @@ export function buildEsbuildOptions(
     target: options.target,
     metafile: options.metafile,
     tsconfig: options.tsConfig,
+    sourcemap: options.sourcemap,
     format,
     outExtension: {
       '.js': outExtension,

--- a/packages/esbuild/src/executors/esbuild/schema.d.ts
+++ b/packages/esbuild/src/executors/esbuild/schema.d.ts
@@ -12,6 +12,7 @@ export interface EsBuildExecutorOptions {
   esbuildOptions?: Record<string, any>;
   external?: string[];
   format?: Array<'esm' | 'cjs'>;
+  generatePackageJson?: boolean;
   main: string;
   metafile?: boolean;
   minify?: boolean;
@@ -20,6 +21,7 @@ export interface EsBuildExecutorOptions {
   outputPath: string;
   platform?: 'node' | 'browser' | 'neutral';
   project: string;
+  sourcemap?: boolean | 'linked' | 'inline' | 'external' | 'both';
   skipTypeCheck?: boolean;
   target?: string;
   thirdParty?: boolean;

--- a/packages/esbuild/src/executors/esbuild/schema.json
+++ b/packages/esbuild/src/executors/esbuild/schema.json
@@ -92,7 +92,10 @@
       "default": false
     },
     "sourcemap": {
-      "type": "boolean",
+      "oneOf": [
+        { "type": "string", "enum": ["linked", "inline", "external", "both"] },
+        { "type": "boolean" }
+      ],
       "alias": "sourceMap",
       "description": "Generate sourcemap.",
       "default": false


### PR DESCRIPTION
This PR fixes an issue where `--sourcemap` from CLI or `project.json` is not respected when running the build. Note, this option should supercede anything in `esbuildOptions` since the former can be from the CLI, which takes precedence when running in different contexts (e.g. CI, dev, prod, etc.).


<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`--sourcemap` does nothing

## Expected Behavior
`--sourcemap` should be passed down to esbuild as an option

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
