### PR TITLE
fix(angular): format files after angular jest migration

### DIFF
--- a/packages/angular/src/migrations/update-15-9-0/update-testing-tsconfig.ts
+++ b/packages/angular/src/migrations/update-15-9-0/update-testing-tsconfig.ts
@@ -1,5 +1,6 @@
 import {
   createProjectGraphAsync,
+  formatFiles,
   getProjects,
   joinPathFragments,
   Tree,
@@ -40,6 +41,8 @@ export async function updateTestingTsconfigForJest(tree: Tree) {
       }
     }
   );
+
+  await formatFiles(tree);
 }
 
 function isJestPresetAngular(tree: Tree, jestConfigPath: string) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`tsconfig.spec.json` files are not formatted after the migration to change it to `es2016`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`tsconfig.spec.json` files are formatted after the migration to change it to `es2016`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
