### PR TITLE
feat(core): provide better error messaging when attempting to use a FsTree instance after changes are committed to disk.

### DIFF
--- a/packages/nx/src/command-line/generate.ts
+++ b/packages/nx/src/command-line/generate.ts
@@ -372,6 +372,8 @@ export async function generate(cwd: string, args: { [k: string]: any }) {
       }
 
       const task = await implementation(host, combinedOpts);
+      host.lock();
+
       const changes = host.listChanges();
 
       printChanges(changes);

--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -1540,6 +1540,7 @@ async function runNxMigration(root: string, packageName: string, name: string) {
   const fn = require(implPath).default;
   const host = new FsTree(root, false);
   await fn(host, {});
+  host.lock();
   const changes = host.listChanges();
   flushChanges(root, changes);
   return changes;

--- a/packages/nx/src/command-line/new.ts
+++ b/packages/nx/src/command-line/new.ts
@@ -35,6 +35,7 @@ export async function newWorkspace(cwd: string, args: { [k: string]: any }) {
     const implementation = implementationFactory();
     const task = await implementation(host, combinedOpts);
     flushChanges(cwd, host.listChanges());
+    host.lock();
     if (task) {
       await task();
     }

--- a/packages/nx/src/generators/tree.ts
+++ b/packages/nx/src/generators/tree.ts
@@ -9,8 +9,10 @@ import {
 } from 'fs-extra';
 import type { Mode } from 'fs';
 import { logger } from '../utils/logger';
+import { output } from '../utils/output';
 import { dirname, join, relative, sep } from 'path';
 import * as chalk from 'chalk';
+import { gt } from 'semver';
 
 /**
  * Options to set when writing a file in the Virtual file system tree.
@@ -339,9 +341,20 @@ export class FsTree implements Tree {
 
   private assertUnlocked() {
     if (this.locked) {
-      throw new Error(
-        'The tree has already been committed to disk. It can no longer be modified. Do not modify the tree during a GeneratorCallback and ensure that Promises have resolved before the generator returns or resolves.'
-      );
+      // TODO (v17): Remove condition
+      if (gt(require('../../package.json').version, '17.0.0')) {
+        throw new Error(
+          'The tree has already been committed to disk. It can no longer be modified. Do not modify the tree during a GeneratorCallback and ensure that Promises have resolved before the generator returns or resolves.'
+        );
+      } else {
+        output.warn({
+          title: 'Tree modified after commit to disk.',
+          bodyLines: [
+            'The tree has already been committed to disk. It can no longer be modified. Do not modify the tree during a GeneratorCallback and ensure that Promises have resolved before the generator returns or resolves.',
+            `This will be an error in version 16. Please open an issue on the Nx repo if experiencing this with a first-party plugin, or the plugin's repo if using a community plugin.`,
+          ],
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Current Behavior
Trying to use the tree within a GeneratorCallback doesn't produce an error, but any intended changes are never committed to disk.

## Expected Behavior
Trying to use the tree produces an error that provides more context. This error will be triggered when:
- Attempting to use the `tree` instance to make modifications after the implementation factory has been executed (e.g. in a generator callback)
- Attempting to use the `tree` instance to make modifications when a dev doesn't await a promise, effectively causing the modification to occur after the implementation factory has been executed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Prevents confusion that was noted on the community slack.

Fixes #
