### PR TITLE
fix(core): move the daemon stop log out of client

### DIFF
--- a/packages/nx/src/command-line/daemon.ts
+++ b/packages/nx/src/command-line/daemon.ts
@@ -17,7 +17,8 @@ export async function daemonHandler(args: Arguments) {
     });
   } else if (args.stop) {
     const { daemonClient } = await import('../daemon/client/client');
-    daemonClient.stop();
+    await daemonClient.stop();
+    output.log({ title: 'Daemon Server - Stopped' });
   } else {
     console.log(generateDaemonHelpOutput());
   }

--- a/packages/nx/src/command-line/reset.ts
+++ b/packages/nx/src/command-line/reset.ts
@@ -9,6 +9,7 @@ export async function resetHandler() {
     bodyLines: [`This might take a few minutes.`],
   });
   await daemonClient.stop();
+  output.log({ title: 'Daemon Server - Stopped' });
   removeSync(cacheDir);
   if (projectGraphCacheDirectory !== cacheDir) {
     removeSync(projectGraphCacheDirectory);

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -376,7 +376,6 @@ export class DaemonClient {
     }
 
     removeSocketDir();
-    output.log({ title: 'Daemon Server - Stopped' });
   }
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

During postinstall and migrate, the `Daemon Server - Stopped` is shown and can be somewhat alarming to some people while it is actually intentional behavior.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `Daemon Server - Stopped` message is only shown during `nx daemon --stop` and `nx reset`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
