### PR TITLE
feat(node): Add node server-less platform support

### DIFF
--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -5128,6 +5128,14 @@
                 "children": [],
                 "isExternal": false,
                 "disableCollapsible": false
+              },
+              {
+                "id": "setup-serverless",
+                "path": "/packages/node/generators/setup-serverless",
+                "name": "setup-serverless",
+                "children": [],
+                "isExternal": false,
+                "disableCollapsible": false
               }
             ],
             "isExternal": false,

--- a/docs/generated/manifests/packages.json
+++ b/docs/generated/manifests/packages.json
@@ -1548,6 +1548,15 @@
         "originalFilePath": "/packages/node/src/generators/setup-docker/schema.json",
         "path": "/packages/node/generators/setup-docker",
         "type": "generator"
+      },
+      "/packages/node/generators/setup-serverless": {
+        "description": "Sets up a Serverless configuration for a project.",
+        "file": "generated/packages/node/generators/setup-serverless.json",
+        "hidden": false,
+        "name": "setup-serverless",
+        "originalFilePath": "/packages/node/src/generators/setup-serverless/schema.json",
+        "path": "/packages/node/generators/setup-serverless",
+        "type": "generator"
       }
     },
     "path": "/packages/node"

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -1525,6 +1525,15 @@
         "originalFilePath": "/packages/node/src/generators/setup-docker/schema.json",
         "path": "node/generators/setup-docker",
         "type": "generator"
+      },
+      {
+        "description": "Sets up a Serverless configuration for a project.",
+        "file": "generated/packages/node/generators/setup-serverless.json",
+        "hidden": false,
+        "name": "setup-serverless",
+        "originalFilePath": "/packages/node/src/generators/setup-serverless/schema.json",
+        "path": "node/generators/setup-serverless",
+        "type": "generator"
       }
     ],
     "githubRoot": "https://github.com/nrwl/nx/blob/master",

--- a/docs/generated/packages/node/generators/application.json
+++ b/docs/generated/packages/node/generators/application.json
@@ -117,6 +117,15 @@
       "docker": {
         "type": "boolean",
         "description": "Add a docker build target"
+      },
+      "platform": {
+        "description": "The name of the platform where the serverless functions should be published",
+        "type": "string",
+        "enum": ["netlify", "none"]
+      },
+      "site": {
+        "description": "The site where the serverless function will be deployed",
+        "type": "string"
       }
     },
     "required": ["name"],

--- a/docs/generated/packages/node/generators/setup-docker.json
+++ b/docs/generated/packages/node/generators/setup-docker.json
@@ -25,6 +25,12 @@
         "description": "The name of the build target",
         "type": "string",
         "default": "build"
+      },
+      "skipFormat": {
+        "description": "Skip formatting files",
+        "type": "boolean",
+        "default": false,
+        "x-priority": "internal"
       }
     },
     "presets": []

--- a/docs/generated/packages/node/generators/setup-serverless.json
+++ b/docs/generated/packages/node/generators/setup-serverless.json
@@ -1,0 +1,59 @@
+{
+  "name": "setup-serverless",
+  "factory": "./src/generators/setup-serverless/setup-serverless",
+  "schema": {
+    "$schema": "http://json-schema.org/schema",
+    "cli": "nx",
+    "$id": "SchematicsNxSetupServerless",
+    "title": "Nx Node Setup Serverless Function Schema",
+    "description": "Nx Node Setup Serverless Function Schema.",
+    "type": "object",
+    "properties": {
+      "project": {
+        "description": "The name of the project",
+        "$default": { "$source": "projectName" },
+        "type": "string",
+        "x-prompt": "What project would you like to add a serverless functions to?",
+        "x-priority": "important"
+      },
+      "platform": {
+        "description": "The name of the platform where the serverless functions should be published",
+        "type": "string",
+        "enum": ["netlify", "none"]
+      },
+      "buildTarget": {
+        "description": "The name of the build target",
+        "type": "string",
+        "default": "build"
+      },
+      "deployTarget": {
+        "description": "The name of the deploy target",
+        "type": "string",
+        "default": "deploy"
+      },
+      "skipFormat": {
+        "description": "Skips formatting the workspace after the generator completes.",
+        "type": "boolean",
+        "default": false,
+        "x-priority": "internal"
+      },
+      "skipPackageJson": {
+        "type": "boolean",
+        "default": false,
+        "description": "Do not add dependencies to `package.json`.",
+        "x-priority": "internal"
+      },
+      "site": {
+        "description": "The site where the serverless function will be deployed",
+        "type": "string"
+      }
+    },
+    "presets": []
+  },
+  "description": "Sets up a Serverless configuration for a project.",
+  "hidden": false,
+  "implementation": "/packages/node/src/generators/setup-serverless/setup-serverless.ts",
+  "aliases": [],
+  "path": "/packages/node/src/generators/setup-serverless/schema.json",
+  "type": "generator"
+}

--- a/docs/generated/packages/workspace/generators/preset.json
+++ b/docs/generated/packages/workspace/generators/preset.json
@@ -84,6 +84,11 @@
         "description": "Generate a Dockerfile",
         "type": "boolean",
         "default": false
+      },
+      "platform": {
+        "description": "Generate serverless a function and configuration for the given platform",
+        "type": "string",
+        "enum": ["netlify", "none"]
       }
     },
     "presets": []

--- a/e2e/next/src/next-storybook.test.ts
+++ b/e2e/next/src/next-storybook.test.ts
@@ -1,12 +1,9 @@
 import {
   checkFilesExist,
   cleanupProject,
-  getPackageManagerCommand,
   newProject,
   runCLI,
-  runCommand,
   uniq,
-  updateJson,
 } from '@nrwl/e2e/utils';
 
 describe('Next.js Applications', () => {

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -23,12 +23,14 @@ import { yargsDecorator } from './decorator';
 import { getThirdPartyPreset } from '../src/utils/preset/get-third-party-preset';
 import { Framework, frameworkList } from './types/framework-list';
 import { Bundler, bundlerList } from './types/bundler-list';
+import { ServerlessPlatform } from './types/serverless-platform-list';
 
 interface Arguments extends CreateWorkspaceOptions {
   preset: string;
   appName: string;
   style: string;
   framework: Framework;
+  platform: ServerlessPlatform;
   standaloneApi: boolean;
   docker: boolean;
   routing: boolean;
@@ -184,6 +186,7 @@ async function normalizeArgsMiddleware(
       style,
       preset,
       framework,
+      platform,
       bundler,
       docker,
       routing,
@@ -243,6 +246,7 @@ async function normalizeArgsMiddleware(
         if (preset === Preset.NodeServer) {
           framework = await determineFramework(argv);
           docker = await determineDockerfile(argv);
+          platform = argv.platform;
         }
 
         if (preset === Preset.ReactStandalone) {
@@ -289,6 +293,7 @@ async function normalizeArgsMiddleware(
       standaloneApi,
       routing,
       framework,
+      platform,
       nxCloud,
       packageManager,
       defaultBase,

--- a/packages/create-nx-workspace/bin/types/serverless-platform-list.ts
+++ b/packages/create-nx-workspace/bin/types/serverless-platform-list.ts
@@ -1,0 +1,4 @@
+// Platform option to be used when the node-server preset is selected
+export const serverlessPlatformList = ['netlify', 'none'];
+
+export type ServerlessPlatform = typeof serverlessPlatformList[number];

--- a/packages/node/generators.json
+++ b/packages/node/generators.json
@@ -29,6 +29,12 @@
       "schema": "./src/generators/setup-docker/schema.json",
       "description": "Set up Docker configuration for a project.",
       "hidden": false
+    },
+    "setup-serverless": {
+      "factory": "./src/generators/setup-serverless/setup-serverless",
+      "schema": "./src/generators/setup-serverless/schema.json",
+      "description": "Sets up a Serverless configuration for a project.",
+      "hidden": false
     }
   },
   "schematics": {
@@ -54,9 +60,14 @@
       "description": "Create a node library."
     },
     "setup-docker": {
-      "factory": "./src/generators/setup-docker/setup-docker#setupDockerGenerator",
+      "factory": "./src/generators/setup-docker/setup-docker#setupDockerSchematic",
       "schema": "./src/generators/setup-docker/schema.json",
       "description": "Set up Docker configuration for a project."
+    },
+    "setup-serverless": {
+      "factory": "./src/generators/setup-serverless/setup-serverless#setupServerlessSchematic",
+      "schema": "./src/generators/setup-serverless/schema.json",
+      "description": "Sets up a Serverless configuration for a project."
     }
   }
 }

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -46,6 +46,7 @@ import { setupDockerGenerator } from '../setup-docker/setup-docker';
 
 import { Schema } from './schema';
 import { mapLintPattern } from '@nrwl/linter/src/generators/lint-project/lint-project';
+import { setupServerlessGenerator } from '../setup-serverless/setup-serverless';
 
 export interface NormalizedSchema extends Schema {
   appProjectRoot: string;
@@ -438,6 +439,15 @@ export async function applicationGenerator(tree: Tree, schema: Schema) {
     });
 
     tasks.push(dockerTask);
+  }
+
+  if (options.platform && options.platform !== 'none') {
+    const serverlessTask = await setupServerlessGenerator(tree, {
+      ...options,
+      project: options.name,
+    });
+
+    tasks.push(serverlessTask);
   }
 
   if (!options.skipFormat) {

--- a/packages/node/src/generators/application/schema.d.ts
+++ b/packages/node/src/generators/application/schema.d.ts
@@ -1,4 +1,5 @@
 import { Linter } from '@nrwl/linter';
+import { ServerlessPlatforms } from '../setup-serverless/schema';
 
 export interface Schema {
   name: string;
@@ -20,6 +21,8 @@ export interface Schema {
   port?: number;
   rootProject?: boolean;
   docker?: boolean;
+  platform?: ServerlessPlatforms;
+  site?: string;
   isNest?: boolean;
 }
 

--- a/packages/node/src/generators/application/schema.json
+++ b/packages/node/src/generators/application/schema.json
@@ -117,6 +117,15 @@
     "docker": {
       "type": "boolean",
       "description": "Add a docker build target"
+    },
+    "platform": {
+      "description": "The name of the platform where the serverless functions should be published",
+      "type": "string",
+      "enum": ["netlify", "none"]
+    },
+    "site": {
+      "description": "The site where the serverless function will be deployed",
+      "type": "string"
     }
   },
   "required": ["name"]

--- a/packages/node/src/generators/setup-docker/schema.json
+++ b/packages/node/src/generators/setup-docker/schema.json
@@ -24,6 +24,12 @@
       "description": "The name of the build target",
       "type": "string",
       "default": "build"
+    },
+    "skipFormat": {
+      "description": "Skip formatting files",
+      "type": "boolean",
+      "default": false,
+      "x-priority": "internal"
     }
   }
 }

--- a/packages/node/src/generators/setup-serverless/files/netlify/functions/hello/hello.ts__tmpl__
+++ b/packages/node/src/generators/setup-serverless/files/netlify/functions/hello/hello.ts__tmpl__
@@ -1,0 +1,10 @@
+import { Handler } from '@netlify/functions'
+
+export const handler: Handler = async(event, context) => {
+    return {
+        statusCode: 200,
+        body: JSON.stringify({
+            message: `Hello, world!`
+        }),
+    };
+},

--- a/packages/node/src/generators/setup-serverless/files/netlify/netlify.toml__tmpl__
+++ b/packages/node/src/generators/setup-serverless/files/netlify/netlify.toml__tmpl__
@@ -1,0 +1,26 @@
+[build]
+  # netlify requires a publish directory even if we only care about the functions
+  publish = "<%= outputPath %>"
+
+[functions]
+  # Directory with serverless functions, including background
+  # functions, to deploy. This is relative to the base directory
+  # if one has been set, or the root directory if
+  # a base hasn’t been set.
+  directory = "<%= outputPath %>"
+
+  # Specifies `esbuild` for functions bundling, esbuild is the default for TS
+  # node_bundler = "esbuild"
+
+  # Flags "package-1" as an external node module for all functions
+  # list of Node.js modules that are copied to the bundled artifact without adjusting their source or references during the bundling process; 
+  # only applies when node_bundler is set to esbuild. 
+  # This property helps handle dependencies that can’t be inlined, such as modules with native add-ons.
+  # external_node_modules = ["package-1"]
+
+  # Includes all Markdown files inside the "files/" directory.
+  # lets you specify additional files or directories and reference them dynamically in function code. 
+  # staticly referenced files are automatically included in the bundle
+  # You can use * to match any character or prefix an entry with ! to exclude files. 
+  # Paths are relative to the base directory.
+  # included_files = ["files/*.md"]

--- a/packages/node/src/generators/setup-serverless/schema.d.ts
+++ b/packages/node/src/generators/setup-serverless/schema.d.ts
@@ -1,0 +1,12 @@
+export interface SetupServerlessFunctionOptions {
+  project?: string;
+  platform?: ServerlessPlatforms;
+  buildTarget?: string;
+  deployTarget?: string;
+  skipFormat?: boolean;
+  skipPackageJson?: boolean;
+  site?: string;
+}
+export type ServerlessPlatforms = typeof serverlessPlatforms[number];
+
+export const serverlessPlatforms = ['netlify', 'none'] as const;

--- a/packages/node/src/generators/setup-serverless/schema.json
+++ b/packages/node/src/generators/setup-serverless/schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "$id": "SchematicsNxSetupServerless",
+  "title": "Nx Node Setup Serverless Function Schema",
+  "description": "Nx Node Setup Serverless Function Schema.",
+  "type": "object",
+  "properties": {
+    "project": {
+      "description": "The name of the project",
+      "$default": {
+        "$source": "projectName"
+      },
+      "type": "string",
+      "x-prompt": "What project would you like to add a serverless functions to?",
+      "x-priority": "important"
+    },
+    "platform": {
+      "description": "The name of the platform where the serverless functions should be published",
+      "type": "string",
+      "enum": ["netlify", "none"]
+    },
+    "buildTarget": {
+      "description": "The name of the build target",
+      "type": "string",
+      "default": "build"
+    },
+    "deployTarget": {
+      "description": "The name of the deploy target",
+      "type": "string",
+      "default": "deploy"
+    },
+    "skipFormat": {
+      "description": "Skips formatting the workspace after the generator completes.",
+      "type": "boolean",
+      "default": false,
+      "x-priority": "internal"
+    },
+    "skipPackageJson": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not add dependencies to `package.json`.",
+      "x-priority": "internal"
+    },
+    "site": {
+      "description": "The site where the serverless function will be deployed",
+      "type": "string"
+    }
+  }
+}

--- a/packages/node/src/generators/setup-serverless/setup-serverless.spec.ts
+++ b/packages/node/src/generators/setup-serverless/setup-serverless.spec.ts
@@ -1,0 +1,72 @@
+import { applicationGenerator } from '../application/application';
+import { readProjectConfiguration, Tree } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { setupServerlessGenerator } from './setup-serverless';
+describe('setupServerlessGenerator', () => {
+  let tree: Tree;
+
+  beforeEach(() => (tree = createTreeWithEmptyWorkspace()));
+
+  describe('integrated', () => {
+    it('should create a netlify platform specific asset which is used to deploy', async () => {
+      await applicationGenerator(tree, {
+        name: 'api',
+        framework: 'express',
+        e2eTestRunner: 'none',
+        docker: false,
+      });
+      await setupServerlessGenerator(tree, {
+        project: 'api',
+        platform: 'netlify',
+      });
+
+      const project = readProjectConfiguration(tree, 'api');
+      expect(tree.exists('netlify.toml'));
+      expect(project.targets).toEqual(
+        expect.objectContaining({
+          deploy: {
+            dependsOn: ['build'],
+            command: 'npx netlify deploy --site api',
+            configurations: {
+              production: {
+                command: 'npx netlify deploy --site api --prod-if-unlocked',
+              },
+            },
+          },
+        })
+      );
+    });
+  });
+
+  describe('standalone', () => {
+    it('should create a netlify platform specific asset which is used to deploy', async () => {
+      await applicationGenerator(tree, {
+        name: 'api',
+        framework: 'express',
+        rootProject: true,
+        docker: true,
+      });
+
+      await setupServerlessGenerator(tree, {
+        project: 'api',
+        platform: 'netlify',
+      });
+
+      const project = readProjectConfiguration(tree, 'api');
+      expect(tree.exists('netlify.toml'));
+      expect(project.targets).toEqual(
+        expect.objectContaining({
+          deploy: {
+            dependsOn: ['build'],
+            command: 'npx netlify deploy --site api',
+            configurations: {
+              production: {
+                command: 'npx netlify deploy --site api --prod-if-unlocked',
+              },
+            },
+          },
+        })
+      );
+    });
+  });
+});

--- a/packages/node/src/generators/setup-serverless/setup-serverless.ts
+++ b/packages/node/src/generators/setup-serverless/setup-serverless.ts
@@ -1,0 +1,132 @@
+import {
+  addDependenciesToPackageJson,
+  convertNxGenerator,
+  formatFiles,
+  generateFiles,
+  GeneratorCallback,
+  joinPathFragments,
+  logger,
+  names,
+  readNxJson,
+  readProjectConfiguration,
+  runTasksInSerial,
+  Tree,
+  updateProjectConfiguration,
+} from '@nrwl/devkit';
+import {
+  netlifyCliVersion,
+  netlifyFunctionVersion,
+} from '../../utils/versions';
+import { SetupServerlessFunctionOptions } from './schema';
+
+const serverlessPlatformPackage = {
+  netlify: {
+    '@netlify/functions': netlifyFunctionVersion,
+    'netlify-cli': netlifyCliVersion,
+  },
+};
+function normalizeOptions(
+  tree: Tree,
+  setupOptions: SetupServerlessFunctionOptions
+) {
+  const project = setupOptions.project ?? readNxJson(tree).defaultProject;
+  const siteName = names(project).fileName;
+  return {
+    ...setupOptions,
+    project,
+    site: setupOptions.site ?? siteName,
+    buildTarget: setupOptions.buildTarget ?? 'build',
+    deployTarget: setupOptions.deployTarget ?? 'deploy',
+  };
+}
+
+function addServerlessFiles(
+  tree: Tree,
+  options: SetupServerlessFunctionOptions
+) {
+  const project = readProjectConfiguration(tree, options.project);
+  if (!options.project || !options.deployTarget) {
+    return;
+  }
+
+  switch (options.platform) {
+    case 'netlify':
+      if (tree.exists(joinPathFragments(project.root, 'netlify.toml'))) {
+        logger.info(
+          `Skipping setup since a netlify.toml already exists inside ${project.root}`
+        );
+      }
+      break;
+
+    default:
+      return;
+  }
+  const outputPath =
+    project.targets[`${options.buildTarget}`]?.options.outputPath;
+  generateFiles(
+    tree,
+    joinPathFragments(__dirname, `./files/${options.platform}`),
+    project.root,
+    {
+      tmpl: '',
+      app: project.sourceRoot,
+      outputPath,
+    }
+  );
+}
+
+function updateProjectConfig(
+  tree: Tree,
+  options: SetupServerlessFunctionOptions
+) {
+  const projectConfig = readProjectConfiguration(tree, options.project);
+
+  if (projectConfig) {
+    projectConfig.targets[`${options.buildTarget}`].options.bundle = true;
+    projectConfig.targets[`${options.deployTarget}`] = {
+      dependsOn: [`${options.buildTarget}`],
+      command: `npx netlify deploy --site ${options.site}`,
+      configurations: {
+        production: {
+          command: `npx netlify deploy --site ${options.site} --prod-if-unlocked`,
+        },
+      },
+    };
+
+    updateProjectConfiguration(tree, options.project, projectConfig);
+  }
+}
+
+export async function setupServerlessGenerator(
+  tree: Tree,
+  setupOptions: SetupServerlessFunctionOptions
+) {
+  const tasks: GeneratorCallback[] = [];
+  const options = normalizeOptions(tree, setupOptions);
+
+  addServerlessFiles(tree, options);
+  updateProjectConfig(tree, options);
+
+  if (!options.skipPackageJson && ['netlify'].includes(options.platform)) {
+    tasks.push(
+      addDependenciesToPackageJson(
+        tree,
+        {},
+        {
+          ...serverlessPlatformPackage[options.platform],
+        }
+      )
+    );
+  }
+
+  if (!options.skipFormat) {
+    await formatFiles(tree);
+  }
+
+  return runTasksInSerial(...tasks);
+}
+
+export default setupServerlessGenerator;
+export const setupServerlessSchematic = convertNxGenerator(
+  setupServerlessGenerator
+);

--- a/packages/node/src/utils/versions.ts
+++ b/packages/node/src/utils/versions.ts
@@ -18,3 +18,6 @@ export const fastifySensibleVersion = '~5.2.0';
 export const fastifyPluginVersion = '~4.5.0';
 
 export const axiosVersion = '^1.0.0';
+
+export const netlifyFunctionVersion = '^1.4.0';
+export const netlifyCliVersion = '13.2.1';

--- a/packages/workspace/src/generators/new/generate-preset.ts
+++ b/packages/workspace/src/generators/new/generate-preset.ts
@@ -76,6 +76,7 @@ export function generatePreset(host: Tree, opts: NormalizedSchema) {
       opts.preset ? `--preset=${opts.preset}` : null,
       opts.bundler ? `--bundler=${opts.bundler}` : null,
       opts.framework ? `--framework=${opts.framework}` : null,
+      opts.platform ? `--platform=${opts.platform}` : null,
       opts.docker ? `--docker=${opts.docker}` : null,
       opts.packageManager ? `--packageManager=${opts.packageManager}` : null,
       opts.standaloneApi !== undefined

--- a/packages/workspace/src/generators/new/new.ts
+++ b/packages/workspace/src/generators/new/new.ts
@@ -24,6 +24,7 @@ interface Schema {
   defaultBase: string;
   framework?: string;
   docker?: boolean;
+  platform?: string;
   linter?: Linter;
   bundler?: 'vite' | 'webpack';
   standaloneApi?: boolean;

--- a/packages/workspace/src/generators/preset/preset.ts
+++ b/packages/workspace/src/generators/preset/preset.ts
@@ -139,6 +139,7 @@ async function createPreset(tree: Tree, options: Schema) {
       linter: options.linter,
       standaloneConfig: options.standaloneConfig,
       framework: options.framework,
+      platform: options.platform,
       docker: options.docker,
       rootProject: true,
     });

--- a/packages/workspace/src/generators/preset/schema.d.ts
+++ b/packages/workspace/src/generators/preset/schema.d.ts
@@ -9,6 +9,7 @@ export interface Schema {
   preset: Preset;
   standaloneConfig?: boolean;
   framework?: string;
+  platform?: 'netlify' | 'none';
   packageManager?: PackageManager;
   bundler?: 'vite' | 'webpack';
   docker?: boolean;

--- a/packages/workspace/src/generators/preset/schema.json
+++ b/packages/workspace/src/generators/preset/schema.json
@@ -87,6 +87,11 @@
       "description": "Generate a Dockerfile",
       "type": "boolean",
       "default": false
+    },
+    "platform": {
+      "description": "Generate serverless a function and configuration for the given platform",
+      "type": "string",
+      "enum": ["netlify", "none"]
     }
   }
 }


### PR DESCRIPTION
This PR adds Serverless function support on Netlify

- Generate a node application
- Run `npx nx generate @nrwl/node:setup-serverless --project=proj--platform=netlify`
- Run `npx nx run proj:deploy`

This should 

1. Create a node application with the `netlify.toml` deploy file
2. Add the `functions/hello.ts` serverless function
3. Install `netlify-cli` which is used to deploy your node server
4. Add a deploy target to netlify