### PR TITLE
feat(web): remove hard dependencies on cypress, rollup, jest, and linter

### DIFF
--- a/docs/generated/packages/web/generators/application.json
+++ b/docs/generated/packages/web/generators/application.json
@@ -62,7 +62,7 @@
       "linter": {
         "description": "The tool to use for running lint checks.",
         "type": "string",
-        "enum": ["eslint"],
+        "enum": ["eslint", "none"],
         "default": "eslint"
       },
       "skipFormat": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -30,12 +30,8 @@
     "migrations": "./migrations.json"
   },
   "dependencies": {
-    "@nrwl/cypress": "file:../cypress",
     "@nrwl/devkit": "file:../devkit",
-    "@nrwl/jest": "file:../jest",
     "@nrwl/js": "file:../js",
-    "@nrwl/linter": "file:../linter",
-    "@nrwl/rollup": "file:../rollup",
     "@nrwl/workspace": "file:../workspace",
     "chalk": "^4.1.0",
     "chokidar": "^3.5.1",

--- a/packages/web/src/generators/application/schema.d.ts
+++ b/packages/web/src/generators/application/schema.d.ts
@@ -1,4 +1,4 @@
-import { Linter } from '@nrwl/linter';
+import type { Linter } from '@nrwl/linter';
 
 export interface Schema {
   name: string;

--- a/packages/web/src/generators/application/schema.json
+++ b/packages/web/src/generators/application/schema.json
@@ -65,7 +65,7 @@
     "linter": {
       "description": "The tool to use for running lint checks.",
       "type": "string",
-      "enum": ["eslint"],
+      "enum": ["eslint", "none"],
       "default": "eslint"
     },
     "skipFormat": {

--- a/packages/web/src/generators/init/init.ts
+++ b/packages/web/src/generators/init/init.ts
@@ -1,14 +1,13 @@
-import { cypressInitGenerator } from '@nrwl/cypress';
 import {
   addDependenciesToPackageJson,
   convertNxGenerator,
+  ensurePackage,
   formatFiles,
   GeneratorCallback,
   removeDependenciesFromPackageJson,
   runTasksInSerial,
   Tree,
 } from '@nrwl/devkit';
-import { jestInitGenerator } from '@nrwl/jest';
 
 import { addBabelInputs } from '@nrwl/js/src/utils/add-babel-inputs';
 import { initGenerator as jsInitGenerator } from '@nrwl/js';
@@ -48,12 +47,17 @@ export async function webInitGenerator(tree: Tree, schema: Schema) {
   tasks.push(jsInitTask);
 
   if (!schema.unitTestRunner || schema.unitTestRunner === 'jest') {
+    const { jestInitGenerator } = await ensurePackage('@nrwl/jest', nxVersion);
     const jestTask = await jestInitGenerator(tree, {
       skipPackageJson: schema.skipPackageJson,
     });
     tasks.push(jestTask);
   }
   if (!schema.e2eTestRunner || schema.e2eTestRunner === 'cypress') {
+    const { cypressInitGenerator } = await ensurePackage(
+      '@nrwl/cypress',
+      nxVersion
+    );
     const cypressTask = await cypressInitGenerator(tree, {
       skipPackageJson: schema.skipPackageJson,
     });


### PR DESCRIPTION
This PR cleans up the dependencies of `@nrwl/web` so that it can be used by other plugins without pulling in unnecessary packages. Use `ensurePackage` to install the packages as needed from generators.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
