### PR TITLE
fix(testing): use direct-nodejs capture mode

### DIFF
--- a/docs/generated/packages/cypress/executors/cypress.json
+++ b/docs/generated/packages/cypress/executors/cypress.json
@@ -6,7 +6,7 @@
     "title": "Cypress Target",
     "description": "Run Cypress for e2e, integration and component testing.",
     "type": "object",
-    "outputCapture": "pipe",
+    "outputCapture": "direct-nodejs",
     "cli": "nx",
     "presets": [
       {

--- a/packages/cypress/src/executors/cypress/schema.json
+++ b/packages/cypress/src/executors/cypress/schema.json
@@ -3,7 +3,7 @@
   "title": "Cypress Target",
   "description": "Run Cypress for e2e, integration and component testing.",
   "type": "object",
-  "outputCapture": "pipe",
+  "outputCapture": "direct-nodejs",
   "cli": "nx",
   "presets": [
     {

--- a/packages/expo/migrations.json
+++ b/packages/expo/migrations.json
@@ -704,6 +704,19 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "15.9.0": {
+      "version": "15.9.0-beta.0",
+      "packages": {
+        "react-native": {
+          "version": "0.71.4",
+          "alwaysAddToPackageJson": false
+        },
+        "@types/react-native": {
+          "version": "0.71.4",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/expo/src/utils/versions.ts
+++ b/packages/expo/src/utils/versions.ts
@@ -14,8 +14,8 @@ export const reactDomVersion = '18.2.0';
 export const reactTestRendererVersion = '18.2.0';
 export const typesReactVersion = '18.0.28';
 
-export const reactNativeVersion = '0.71.3';
-export const typesReactNativeVersion = '0.71.3';
+export const reactNativeVersion = '0.71.4';
+export const typesReactNativeVersion = '0.71.4';
 export const reactNativeWebVersion = '~0.18.12';
 
 export const reactNativeSvgTransformerVersion = '1.0.0';

--- a/packages/nx/src/command-line/daemon.ts
+++ b/packages/nx/src/command-line/daemon.ts
@@ -17,7 +17,8 @@ export async function daemonHandler(args: Arguments) {
     });
   } else if (args.stop) {
     const { daemonClient } = await import('../daemon/client/client');
-    daemonClient.stop();
+    await daemonClient.stop();
+    output.log({ title: 'Daemon Server - Stopped' });
   } else {
     console.log(generateDaemonHelpOutput());
   }

--- a/packages/nx/src/command-line/reset.ts
+++ b/packages/nx/src/command-line/reset.ts
@@ -9,6 +9,7 @@ export async function resetHandler() {
     bodyLines: [`This might take a few minutes.`],
   });
   await daemonClient.stop();
+  output.log({ title: 'Daemon Server - Stopped' });
   removeSync(cacheDir);
   if (projectGraphCacheDirectory !== cacheDir) {
     removeSync(projectGraphCacheDirectory);

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -376,7 +376,6 @@ export class DaemonClient {
     }
 
     removeSocketDir();
-    output.log({ title: 'Daemon Server - Stopped' });
   }
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

sometimes cypress summary table will be cut off

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

full output is displayed from cypress before nx reports task status

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

this looks to cause issues when running multiple tasks in the dynamic output style


Fixes #
