### PR TITLE
feat(core): add --quiet option to suppress generate output

### DIFF
--- a/docs/shared/reference/environment-variables.md
+++ b/docs/shared/reference/environment-variables.md
@@ -20,6 +20,7 @@ The following environment variables are ones that you can set to change the beha
 | NX_VERBOSE_LOGGING               | boolean | If set to `true`, will print debug information useful for troubleshooting                                                                                                                                                    |
 | NX_DRY_RUN                       | boolean | If set to `true`, will perform a dry run of the generator. No files will be created and no packages will be installed.                                                                                                       |
 | NX_INTERACTIVE                   | boolean | If set to `true`, will allow Nx to prompt you in the terminal to answer some further questions when running generators.                                                                                                      |
+| NX_GENERATE_QUIET                | boolean | If set to `true`, will prevent Nx logging file operations during generate                                                                                                                                                    |
 
 Nx will set the following environment variables so they can be accessible within the process even outside of executors and generators
 

--- a/e2e/nx-misc/src/extras.test.ts
+++ b/e2e/nx-misc/src/extras.test.ts
@@ -260,4 +260,12 @@ describe('Extra Nx Misc Tests', () => {
       checkFilesExist(`${folder}/dummy.txt`);
     }, 120000);
   });
+
+  describe('generate --quiet', () => {
+    it('should not log tree operations or install tasks', () => {
+      const output = runCLI('generate @nrwl/react:app --quiet test-project');
+      expect(output).not.toContain('CREATE');
+      expect(output).not.toContain('Installed');
+    });
+  });
 });

--- a/packages/create-nx-workspace/src/create-preset.ts
+++ b/packages/create-nx-workspace/src/create-preset.ts
@@ -38,7 +38,7 @@ export async function createPreset<T extends CreateWorkspaceOptions>(
     }
   }
 
-  const command = `g ${preset}:preset ${args}`;
+  const command = `g ${preset}:preset --quiet ${args}`;
 
   try {
     const [exec, ...args] = pmc.exec.split(' ');

--- a/packages/devkit/src/tasks/install-packages-task.ts
+++ b/packages/devkit/src/tasks/install-packages-task.ts
@@ -40,7 +40,7 @@ export function installPackagesTask(
     const pmc = getPackageManagerCommand(packageManager);
     execSync(pmc.install, {
       cwd: join(tree.root, cwd),
-      stdio: [0, 1, 2],
+      stdio: process.env.NX_GENERATE_QUIET === 'true' ? 'ignore' : 'inherit',
     });
   }
 }

--- a/packages/devkit/src/utils/package-json.ts
+++ b/packages/devkit/src/utils/package-json.ts
@@ -446,9 +446,11 @@ export function ensurePackage<T extends any = any>(
   }
 
   const tempDir = dirSync().name;
+
+  console.log(`Fetching ${pkg}...`);
   execSync(`${getPackageManagerCommand().addDev} ${pkg}@${requiredVersion}`, {
     cwd: tempDir,
-    stdio: [0, 1, 2],
+    stdio: 'ignore',
   });
 
   addToNodePath(join(workspaceRoot, 'node_modules'));

--- a/packages/nx/src/adapter/ngcli-adapter.ts
+++ b/packages/nx/src/adapter/ngcli-adapter.ts
@@ -792,6 +792,7 @@ export function wrapAngularDevkitSchematic(
       generatorName,
       force: false,
       defaults: false,
+      quiet: false,
     };
     const workflow = createWorkflow(fsHost, host.root, options);
 

--- a/packages/nx/src/command-line/generate.ts
+++ b/packages/nx/src/command-line/generate.ts
@@ -31,6 +31,7 @@ export interface GenerateOptions {
   dryRun: boolean;
   interactive: boolean;
   defaults: boolean;
+  quiet: boolean;
 }
 
 export function printChanges(fileChanges: FileChange[]) {
@@ -245,6 +246,7 @@ async function convertToGenerateOptions(
     dryRun: generatorOptions.dryRun as boolean,
     interactive,
     defaults: generatorOptions.defaults as boolean,
+    quiet: generatorOptions.quiet,
   };
 
   delete generatorOptions.d;
@@ -257,6 +259,7 @@ async function convertToGenerateOptions(
   delete generatorOptions.generator;
   delete generatorOptions['--'];
   delete generatorOptions['$0'];
+  delete generatorOptions.quiet;
 
   return res;
 }
@@ -374,7 +377,9 @@ export async function generate(cwd: string, args: { [k: string]: any }) {
       const task = await implementation(host, combinedOpts);
       const changes = host.listChanges();
 
-      printChanges(changes);
+      if (!opts.quiet) {
+        printChanges(changes);
+      }
       if (!opts.dryRun) {
         flushChanges(workspaceRoot, changes);
         if (task) {

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -738,6 +738,11 @@ function withGenerateOptions(yargs: yargs.Argv) {
       type: 'boolean',
       default: false,
     })
+    .option('quiet', {
+      describe: 'Hides logs from tree operations (e.g. `CREATE package.json`)',
+      type: 'boolean',
+      default: false,
+    })
     .middleware((args) => {
       if (process.env.NX_INTERACTIVE === 'false') {
         args.interactive = false;
@@ -748,6 +753,11 @@ function withGenerateOptions(yargs: yargs.Argv) {
         args.dryRun = true;
       } else {
         process.env.NX_DRY_RUN = `${args.dryRun}`;
+      }
+      if (process.env.NX_GENERATE_QUIET === 'true') {
+        args.quiet = true;
+      } else {
+        process.env.NX_GENERATE_QUIET = `${args.quiet}`;
       }
     });
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Generating a workspace with a custom preset displays extra outputs which are not displayed when generating first-party presets

## Expected Behavior
Generating a workspace with a custom preset uses `--quiet` when invoking the plugin's preset generator - thus ensuring that the appearance isn't more clunky.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
