### PR TITLE
feat(angular): generate serve-static for e2e tests rather than run the dev-server

### DIFF
--- a/docs/generated/packages/cypress/generators/cypress-project.json
+++ b/docs/generated/packages/cypress/generators/cypress-project.json
@@ -71,6 +71,11 @@
         "hidden": true,
         "x-priority": "internal"
       },
+      "devServerTarget": {
+        "description": "The target name to run the server to test against.",
+        "type": "string",
+        "default": "serve"
+      },
       "bundler": {
         "description": "The Cypress bundler to use.",
         "type": "string",

--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -322,67 +322,6 @@ describe('AppComponent', () => {
 "
 `;
 
-exports[`app --strict should enable strict type checking: app tsconfig.json 1`] = `
-Object {
-  "angularCompilerOptions": Object {
-    "enableI18nLegacyMessageIdFormat": false,
-    "strictInjectionParameters": true,
-    "strictInputAccessModifiers": true,
-    "strictTemplates": true,
-  },
-  "compilerOptions": Object {
-    "forceConsistentCasingInFileNames": true,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitOverride": true,
-    "noImplicitReturns": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "strict": true,
-    "target": "es2022",
-    "useDefineForClassFields": false,
-  },
-  "extends": "../../tsconfig.base.json",
-  "files": Array [],
-  "include": Array [],
-  "references": Array [
-    Object {
-      "path": "./tsconfig.app.json",
-    },
-    Object {
-      "path": "./tsconfig.spec.json",
-    },
-    Object {
-      "path": "./tsconfig.editor.json",
-    },
-  ],
-}
-`;
-
-exports[`app --strict should enable strict type checking: e2e tsconfig.json 1`] = `
-Object {
-  "compilerOptions": Object {
-    "allowJs": true,
-    "forceConsistentCasingInFileNames": true,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitOverride": true,
-    "noImplicitReturns": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "outDir": "../../dist/out-tsc",
-    "sourceMap": false,
-    "strict": true,
-    "types": Array [
-      "cypress",
-      "node",
-    ],
-  },
-  "extends": "../../tsconfig.base.json",
-  "include": Array [
-    "src/**/*.ts",
-    "src/**/*.js",
-    "cypress.config.ts",
-  ],
-}
-`;
-
 exports[`app at the root should accept numbers in the path 1`] = `"src/9-websites/my-app"`;
 
 exports[`app nested should create project configs 1`] = `
@@ -474,6 +413,21 @@ Object {
       "defaultConfiguration": "development",
       "executor": "@angular-devkit/build-angular:dev-server",
     },
+    "serve-static": Object {
+      "configurations": Object {
+        "development": Object {
+          "buildTarget": "my-dir-my-app:build:development",
+        },
+        "production": Object {
+          "buildTarget": "my-dir-my-app:build:production",
+        },
+      },
+      "defaultConfiguration": "development",
+      "executor": "@nrwl/angular:file-server",
+      "options": Object {
+        "buildTarget": "my-dir-my-app:build",
+      },
+    },
     "test": Object {
       "configurations": Object {
         "ci": Object {
@@ -509,13 +463,13 @@ Object {
     "e2e": Object {
       "configurations": Object {
         "production": Object {
-          "devServerTarget": "my-dir-my-app:serve:production",
+          "devServerTarget": "my-dir-my-app:serve-static:production",
         },
       },
       "executor": "@nrwl/cypress:cypress",
       "options": Object {
         "cypressConfig": "apps/my-dir/my-app-e2e/cypress.config.ts",
-        "devServerTarget": "my-dir-my-app:serve:development",
+        "devServerTarget": "my-dir-my-app:serve-static:development",
         "testingType": "e2e",
       },
     },
@@ -623,6 +577,21 @@ Object {
       "defaultConfiguration": "development",
       "executor": "@angular-devkit/build-angular:dev-server",
     },
+    "serve-static": Object {
+      "configurations": Object {
+        "development": Object {
+          "buildTarget": "my-app:build:development",
+        },
+        "production": Object {
+          "buildTarget": "my-app:build:production",
+        },
+      },
+      "defaultConfiguration": "development",
+      "executor": "@nrwl/angular:file-server",
+      "options": Object {
+        "buildTarget": "my-app:build",
+      },
+    },
     "test": Object {
       "configurations": Object {
         "ci": Object {
@@ -658,13 +627,13 @@ Object {
     "e2e": Object {
       "configurations": Object {
         "production": Object {
-          "devServerTarget": "my-app:serve:production",
+          "devServerTarget": "my-app:serve-static:production",
         },
       },
       "executor": "@nrwl/cypress:cypress",
       "options": Object {
         "cypressConfig": "apps/my-app-e2e/cypress.config.ts",
-        "devServerTarget": "my-app:serve:development",
+        "devServerTarget": "my-app:serve-static:development",
         "testingType": "e2e",
       },
     },
@@ -680,87 +649,5 @@ Object {
       ],
     },
   },
-}
-`;
-
-exports[`app not nested should generate files: e2e tsconfig.json 1`] = `
-Object {
-  "compilerOptions": Object {
-    "allowJs": true,
-    "forceConsistentCasingInFileNames": true,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitOverride": true,
-    "noImplicitReturns": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "outDir": "../../dist/out-tsc",
-    "sourceMap": false,
-    "strict": true,
-    "types": Array [
-      "cypress",
-      "node",
-    ],
-  },
-  "extends": "../../tsconfig.base.json",
-  "include": Array [
-    "src/**/*.ts",
-    "src/**/*.js",
-    "cypress.config.ts",
-  ],
-}
-`;
-
-exports[`app not nested should generate files: tsconfig.app.json 1`] = `
-Object {
-  "compilerOptions": Object {
-    "outDir": "../../dist/out-tsc",
-    "types": Array [],
-  },
-  "exclude": Array [
-    "jest.config.ts",
-    "src/**/*.test.ts",
-    "src/**/*.spec.ts",
-  ],
-  "extends": "./tsconfig.json",
-  "files": Array [
-    "src/main.ts",
-  ],
-  "include": Array [
-    "src/**/*.d.ts",
-  ],
-}
-`;
-
-exports[`app not nested should generate files: tsconfig.json 1`] = `
-Object {
-  "angularCompilerOptions": Object {
-    "enableI18nLegacyMessageIdFormat": false,
-    "strictInjectionParameters": true,
-    "strictInputAccessModifiers": true,
-    "strictTemplates": true,
-  },
-  "compilerOptions": Object {
-    "forceConsistentCasingInFileNames": true,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitOverride": true,
-    "noImplicitReturns": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "strict": true,
-    "target": "es2022",
-    "useDefineForClassFields": false,
-  },
-  "extends": "../../tsconfig.base.json",
-  "files": Array [],
-  "include": Array [],
-  "references": Array [
-    Object {
-      "path": "./tsconfig.app.json",
-    },
-    Object {
-      "path": "./tsconfig.spec.json",
-    },
-    Object {
-      "path": "./tsconfig.editor.json",
-    },
-  ],
 }
 `;

--- a/packages/angular/src/generators/application/lib/add-e2e.ts
+++ b/packages/angular/src/generators/application/lib/add-e2e.ts
@@ -1,12 +1,20 @@
 import type { Tree } from '@nrwl/devkit';
 import type { NormalizedSchema } from './normalized-schema';
 
+import {
+  readProjectConfiguration,
+  updateProjectConfiguration,
+} from '@nrwl/devkit';
 import { cypressProjectGenerator } from '@nrwl/cypress';
 import { removeScaffoldedE2e } from './remove-scaffolded-e2e';
 
 export async function addE2e(tree: Tree, options: NormalizedSchema) {
   removeScaffoldedE2e(tree, options, options.ngCliSchematicE2ERoot);
+
   if (options.e2eTestRunner === 'cypress') {
+    // TODO: This can call `@nrwl/web:static-config` generator once we merge `@nrwl/angular:file-server` into `@nrwl/web:file-server`.
+    addFileServerTarget(tree, options, 'serve-static');
+
     await cypressProjectGenerator(tree, {
       name: options.e2eProjectName,
       directory: options.directory,
@@ -16,6 +24,32 @@ export async function addE2e(tree: Tree, options: NormalizedSchema) {
       standaloneConfig: options.standaloneConfig,
       skipPackageJson: options.skipPackageJson,
       rootProject: options.rootProject,
+      devServerTarget: 'serve-static',
     });
   }
+}
+
+function addFileServerTarget(
+  tree: Tree,
+  options: NormalizedSchema,
+  targetName: string
+) {
+  const projectConfig = readProjectConfiguration(tree, options.name);
+  projectConfig.targets[targetName] = {
+    executor: '@nrwl/angular:file-server',
+    defaultConfiguration: 'development',
+    options: {
+      buildTarget: `${options.name}:build`,
+      port: options.port,
+    },
+    configurations: {
+      development: {
+        buildTarget: `${options.name}:build:development`,
+      },
+      production: {
+        buildTarget: `${options.name}:build:production`,
+      },
+    },
+  };
+  updateProjectConfiguration(tree, options.name, projectConfig);
 }

--- a/packages/cypress/src/generators/cypress-project/cypress-project.spec.ts
+++ b/packages/cypress/src/generators/cypress-project/cypress-project.spec.ts
@@ -39,6 +39,13 @@ describe('Cypress Project', () => {
             production: {},
           },
         },
+        'static-serve': {
+          executor: 'static-serve-executor',
+          options: {},
+          configurations: {
+            production: {},
+          },
+        },
       },
     });
 
@@ -353,6 +360,27 @@ describe('Cypress Project', () => {
         'apps/one/two/other-e2e/cypress.config.ts',
         'apps/one/two/other-e2e/src/e2e/app.cy.ts',
       ].forEach((path) => expect(tree.exists(path)).toBeTruthy());
+    });
+
+    describe('--devServerTarget', () => {
+      it('should configure Cypress with custom target', async () => {
+        await cypressProjectGenerator(tree, {
+          ...defaultOptions,
+          name: 'my-app-e2e',
+          project: 'my-app',
+          devServerTarget: 'serve-static',
+        });
+
+        const projectConfig = readProjectConfiguration(tree, 'my-app-e2e');
+        expect(projectConfig.targets.e2e).toMatchObject({
+          options: {
+            devServerTarget: 'my-app:serve-static',
+          },
+          configurations: {
+            production: { devServerTarget: 'my-app:serve-static:production' },
+          },
+        });
+      });
     });
   });
 

--- a/packages/cypress/src/generators/cypress-project/cypress-project.ts
+++ b/packages/cypress/src/generators/cypress-project/cypress-project.ts
@@ -126,9 +126,12 @@ function addProject(tree: Tree, options: CypressProjectSchema) {
       `);
     }
     const devServerTarget =
-      project.targets?.serve && project.targets?.serve?.defaultConfiguration
-        ? `${options.project}:serve:${project.targets.serve.defaultConfiguration}`
-        : `${options.project}:serve`;
+      project.targets?.[options.devServerTarget] &&
+      project.targets?.[options.devServerTarget]?.defaultConfiguration
+        ? `${options.project}:${options.devServerTarget}:${
+            project.targets[options.devServerTarget].defaultConfiguration
+          }`
+        : `${options.project}:${options.devServerTarget}`;
     e2eProjectConfig = {
       root: options.projectRoot,
       sourceRoot: joinPathFragments(options.projectRoot, 'src'),
@@ -146,7 +149,7 @@ function addProject(tree: Tree, options: CypressProjectSchema) {
           },
           configurations: {
             production: {
-              devServerTarget: `${options.project}:serve:production`,
+              devServerTarget: `${options.project}:${options.devServerTarget}:production`,
             },
           },
         },
@@ -340,6 +343,7 @@ function normalizeOptions(host: Tree, options: Schema): CypressProjectSchema {
     rootProject: isRootProject,
     projectName,
     projectRoot,
+    devServerTarget: options.devServerTarget ?? 'serve',
   };
 }
 

--- a/packages/cypress/src/generators/cypress-project/schema.d.ts
+++ b/packages/cypress/src/generators/cypress-project/schema.d.ts
@@ -12,5 +12,6 @@ export interface Schema {
   standaloneConfig?: boolean;
   skipPackageJson?: boolean;
   rootProject?: boolean;
+  devServerTarget?: string;
   bundler?: 'webpack' | 'vite' | 'none';
 }

--- a/packages/cypress/src/generators/cypress-project/schema.json
+++ b/packages/cypress/src/generators/cypress-project/schema.json
@@ -73,6 +73,11 @@
       "hidden": true,
       "x-priority": "internal"
     },
+    "devServerTarget": {
+      "description": "The target name to run the server to test against.",
+      "type": "string",
+      "default": "serve"
+    },
     "bundler": {
       "description": "The Cypress bundler to use.",
       "type": "string",


### PR DESCRIPTION
This PR updates the existing Angular setup such that a `serve-static` target is added to the app, and e2e project will use `serve-static` rather than the dev-server. If the application is already built, the start-up is much faster e.g. in CI.


## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
