### PR TITLE
feat(testing): add static serve target for e2e tests in CI

### DIFF
--- a/e2e/web/src/file-server.test.ts
+++ b/e2e/web/src/file-server.test.ts
@@ -44,8 +44,12 @@ describe('file-server', () => {
     const ngAppName = uniq('ng-app');
     const reactAppName = uniq('react-app');
 
-    runCLI(`generate @nrwl/angular:app ${ngAppName} --no-interactive`);
-    runCLI(`generate @nrwl/react:app ${reactAppName} --no-interactive`);
+    runCLI(
+      `generate @nrwl/angular:app ${ngAppName} --no-interactive --e2eTestRunner=none`
+    );
+    runCLI(
+      `generate @nrwl/react:app ${reactAppName} --no-interactive --e2eTestRunner=none`
+    );
     runCLI(
       `generate @nrwl/web:static-config --buildTarget=${ngAppName}:build --no-interactive`
     );

--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -474,6 +474,12 @@ Object {
       "defaultConfiguration": "development",
       "executor": "@angular-devkit/build-angular:dev-server",
     },
+    "serve-static": Object {
+      "executor": "@nrwl/angular:file-server",
+      "options": Object {
+        "buildTarget": "my-dir-my-app:build",
+      },
+    },
     "test": Object {
       "configurations": Object {
         "ci": Object {
@@ -508,6 +514,9 @@ Object {
   "targets": Object {
     "e2e": Object {
       "configurations": Object {
+        "ci": Object {
+          "devServerTarget": "my-dir-my-app:serve-static",
+        },
         "production": Object {
           "devServerTarget": "my-dir-my-app:serve:production",
         },
@@ -623,6 +632,12 @@ Object {
       "defaultConfiguration": "development",
       "executor": "@angular-devkit/build-angular:dev-server",
     },
+    "serve-static": Object {
+      "executor": "@nrwl/angular:file-server",
+      "options": Object {
+        "buildTarget": "my-app:build",
+      },
+    },
     "test": Object {
       "configurations": Object {
         "ci": Object {
@@ -657,6 +672,9 @@ Object {
   "targets": Object {
     "e2e": Object {
       "configurations": Object {
+        "ci": Object {
+          "devServerTarget": "my-app:serve-static",
+        },
         "production": Object {
           "devServerTarget": "my-app:serve:production",
         },

--- a/packages/angular/src/generators/application/lib/add-e2e.ts
+++ b/packages/angular/src/generators/application/lib/add-e2e.ts
@@ -1,12 +1,20 @@
 import type { Tree } from '@nrwl/devkit';
 import type { NormalizedSchema } from './normalized-schema';
 
+import {
+  readProjectConfiguration,
+  updateProjectConfiguration,
+} from '@nrwl/devkit';
 import { cypressProjectGenerator } from '@nrwl/cypress';
 import { removeScaffoldedE2e } from './remove-scaffolded-e2e';
 
 export async function addE2e(tree: Tree, options: NormalizedSchema) {
   removeScaffoldedE2e(tree, options, options.ngCliSchematicE2ERoot);
+
   if (options.e2eTestRunner === 'cypress') {
+    // TODO: This can call `@nrwl/web:static-config` generator once we merge `@nrwl/angular:file-server` into `@nrwl/web:file-server`.
+    addFileServerTarget(tree, options, 'serve-static');
+
     await cypressProjectGenerator(tree, {
       name: options.e2eProjectName,
       directory: options.directory,
@@ -18,4 +26,20 @@ export async function addE2e(tree: Tree, options: NormalizedSchema) {
       rootProject: options.rootProject,
     });
   }
+}
+
+function addFileServerTarget(
+  tree: Tree,
+  options: NormalizedSchema,
+  targetName: string
+) {
+  const projectConfig = readProjectConfiguration(tree, options.name);
+  projectConfig.targets[targetName] = {
+    executor: '@nrwl/angular:file-server',
+    options: {
+      buildTarget: `${options.name}:build`,
+      port: options.port,
+    },
+  };
+  updateProjectConfiguration(tree, options.name, projectConfig);
 }

--- a/packages/cypress/src/generators/cypress-project/cypress-project.ts
+++ b/packages/cypress/src/generators/cypress-project/cypress-project.ts
@@ -154,6 +154,11 @@ function addProject(tree: Tree, options: CypressProjectSchema) {
       tags: [],
       implicitDependencies: options.project ? [options.project] : undefined,
     };
+    if (project.targets?.['serve-static']) {
+      e2eProjectConfig.targets.e2e.configurations.ci = {
+        devServerTarget: `${options.project}:serve-static`,
+      };
+    }
   } else {
     throw new Error(`Either project or baseUrl should be specified.`);
   }

--- a/packages/react/src/generators/application/lib/add-cypress.ts
+++ b/packages/react/src/generators/application/lib/add-cypress.ts
@@ -1,4 +1,4 @@
-import { ensurePackage, Tree } from '@nrwl/devkit';
+import { ensurePackage, joinPathFragments, Tree } from '@nrwl/devkit';
 import { nxVersion } from '../../../utils/versions';
 import { NormalizedSchema } from '../schema';
 
@@ -6,6 +6,12 @@ export async function addCypress(host: Tree, options: NormalizedSchema) {
   if (options.e2eTestRunner !== 'cypress') {
     return () => {};
   }
+
+  const { webStaticServeGenerator } = ensurePackage('@nrwl/web', nxVersion);
+  await webStaticServeGenerator(host, {
+    buildTarget: `${options.projectName}:build`,
+    targetName: 'serve-static',
+  });
 
   const { cypressProjectGenerator } = ensurePackage('@nrwl/cypress', nxVersion);
 

--- a/packages/web/index.ts
+++ b/packages/web/index.ts
@@ -1,2 +1,3 @@
 export { webInitGenerator } from './src/generators/init/init';
 export { applicationGenerator } from './src/generators/application/application';
+export { webStaticServeGenerator } from './src/generators/static-serve/static-serve-configuration';


### PR DESCRIPTION
This PR adds `serve-static` targets when generating apps using `@nrwl/angular:app` and `@nrwl/react:app`.

When the Cypress project is configured, it will find the `serve-static` target and add the following:

```
e2e: {
    //...
  configuration: {
    //...
    ci: {
        devServerTarget: `<app-name>:serve-static`,
    }
  }
}
```

The user can then run `nx e2e <e2e-name> --configuration=ci` in their CI so the built app (which might be cached already) to speed up jobs.

## Example

```
nx g @nrwl/angular:app my-app

# Run normally with dev-server (good for development)
nx e2e my-app-e2e

# Run with static server (good for CI)
nx e2e my-app-e2e --configuration=ci 
```

## Note

The `serve-static` and `--configuration=ci` will be generated when using `npx create-nx-workspace` as well.