### PR TITLE
cleanup(angular): add warning to schematic usage of generators

### DIFF
--- a/packages/angular/src/generators/add-linting/compat.ts
+++ b/packages/angular/src/generators/add-linting/compat.ts
@@ -1,4 +1,5 @@
 import { convertNxGenerator } from '@nrwl/devkit';
+import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
 import { addLintingGenerator } from './add-linting';
 
-export default convertNxGenerator(addLintingGenerator);
+export default warnForSchematicUsage(convertNxGenerator(addLintingGenerator));

--- a/packages/angular/src/generators/application/application.compat.ts
+++ b/packages/angular/src/generators/application/application.compat.ts
@@ -1,4 +1,7 @@
 import { convertNxGenerator } from '@nrwl/devkit';
+import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
 import application from './application';
 
-export const applicationSchematic = convertNxGenerator(application);
+export const applicationSchematic = warnForSchematicUsage(
+  convertNxGenerator(application)
+);

--- a/packages/angular/src/generators/component-cypress-spec/compat.ts
+++ b/packages/angular/src/generators/component-cypress-spec/compat.ts
@@ -1,4 +1,7 @@
 import { convertNxGenerator } from '@nrwl/devkit';
+import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
 import { componentCypressSpecGenerator } from './component-cypress-spec';
 
-export default convertNxGenerator(componentCypressSpecGenerator);
+export default warnForSchematicUsage(
+  convertNxGenerator(componentCypressSpecGenerator)
+);

--- a/packages/angular/src/generators/component-story/compat.ts
+++ b/packages/angular/src/generators/component-story/compat.ts
@@ -1,4 +1,7 @@
 import { convertNxGenerator } from '@nrwl/devkit';
+import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
 import { componentStoryGenerator } from './component-story';
 
-export default convertNxGenerator(componentStoryGenerator);
+export default warnForSchematicUsage(
+  convertNxGenerator(componentStoryGenerator)
+);

--- a/packages/angular/src/generators/component-test/compat.ts
+++ b/packages/angular/src/generators/component-test/compat.ts
@@ -1,4 +1,7 @@
 import { convertNxGenerator } from '@nrwl/devkit';
+import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
 import { componentTestGenerator } from './component-test';
 
-export default convertNxGenerator(componentTestGenerator);
+export default warnForSchematicUsage(
+  convertNxGenerator(componentTestGenerator)
+);

--- a/packages/angular/src/generators/component/component.compat.ts
+++ b/packages/angular/src/generators/component/component.compat.ts
@@ -1,4 +1,5 @@
 import componentGenerator from './component';
+import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
 import { convertNxGenerator } from '@nrwl/devkit';
 
-export default convertNxGenerator(componentGenerator);
+export default warnForSchematicUsage(convertNxGenerator(componentGenerator));

--- a/packages/angular/src/generators/convert-to-with-mf/convert-to-with-mf.compat.ts
+++ b/packages/angular/src/generators/convert-to-with-mf/convert-to-with-mf.compat.ts
@@ -1,4 +1,5 @@
 import { convertNxGenerator } from '@nrwl/devkit';
+import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
 import convertToWithMF from './convert-to-with-mf';
 
-export default convertNxGenerator(convertToWithMF);
+export default warnForSchematicUsage(convertNxGenerator(convertToWithMF));

--- a/packages/angular/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
+++ b/packages/angular/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
@@ -6,6 +6,7 @@ import {
   logger,
   Tree,
 } from '@nrwl/devkit';
+import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
 import { ConvertTSLintToESLintSchema, ProjectConverter } from '@nrwl/linter';
 import type { Linter } from 'eslint';
 import { addLintingGenerator } from '../add-linting/add-linting';
@@ -137,7 +138,9 @@ export async function conversionGenerator(
   };
 }
 
-export const conversionSchematic = convertNxGenerator(conversionGenerator);
+export const conversionSchematic = warnForSchematicUsage(
+  convertNxGenerator(conversionGenerator)
+);
 
 /**
  * In the case of Angular lint rules, we need to apply them to correct override depending upon whether

--- a/packages/angular/src/generators/cypress-component-configuration/compat.ts
+++ b/packages/angular/src/generators/cypress-component-configuration/compat.ts
@@ -1,4 +1,7 @@
 import { convertNxGenerator } from '@nrwl/devkit';
+import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
 import { cypressComponentConfiguration } from './cypress-component-configuration';
 
-export default convertNxGenerator(cypressComponentConfiguration);
+export default warnForSchematicUsage(
+  convertNxGenerator(cypressComponentConfiguration)
+);

--- a/packages/angular/src/generators/host/host.compat.ts
+++ b/packages/angular/src/generators/host/host.compat.ts
@@ -1,4 +1,5 @@
 import { convertNxGenerator } from '@nrwl/devkit';
+import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
 import host from './host';
 
-export default convertNxGenerator(host);
+export default warnForSchematicUsage(convertNxGenerator(host));

--- a/packages/angular/src/generators/init/init.compat.ts
+++ b/packages/angular/src/generators/init/init.compat.ts
@@ -1,4 +1,7 @@
 import { convertNxGenerator } from '@nrwl/devkit';
+import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
 import { angularInitGenerator } from './init';
 
-export const initSchematic = convertNxGenerator(angularInitGenerator);
+export const initSchematic = warnForSchematicUsage(
+  convertNxGenerator(angularInitGenerator)
+);

--- a/packages/angular/src/generators/library-secondary-entry-point/compat.ts
+++ b/packages/angular/src/generators/library-secondary-entry-point/compat.ts
@@ -1,4 +1,7 @@
 import { convertNxGenerator } from '@nrwl/devkit';
+import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
 import { librarySecondaryEntryPointGenerator } from './library-secondary-entry-point';
 
-export default convertNxGenerator(librarySecondaryEntryPointGenerator);
+export default warnForSchematicUsage(
+  convertNxGenerator(librarySecondaryEntryPointGenerator)
+);

--- a/packages/angular/src/generators/library/library.compat.ts
+++ b/packages/angular/src/generators/library/library.compat.ts
@@ -1,4 +1,7 @@
 import { convertNxGenerator } from '@nrwl/devkit';
+import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
 import library from './library';
 
-export const librarySchematic = convertNxGenerator(library);
+export const librarySchematic = warnForSchematicUsage(
+  convertNxGenerator(library)
+);

--- a/packages/angular/src/generators/move/move.ts
+++ b/packages/angular/src/generators/move/move.ts
@@ -1,4 +1,5 @@
 import { convertNxGenerator, formatFiles, Tree } from '@nrwl/devkit';
+import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
 import { moveGenerator } from '@nrwl/workspace/generators';
 import { updateModuleName } from './lib/update-module-name';
 import { updateNgPackage } from './lib/update-ng-package';
@@ -24,4 +25,6 @@ export async function angularMoveGenerator(
   }
 }
 
-export const angularMoveSchematic = convertNxGenerator(angularMoveGenerator);
+export const angularMoveSchematic = warnForSchematicUsage(
+  convertNxGenerator(angularMoveGenerator)
+);

--- a/packages/angular/src/generators/ngrx/compat.ts
+++ b/packages/angular/src/generators/ngrx/compat.ts
@@ -1,4 +1,5 @@
 import { convertNxGenerator } from '@nrwl/devkit';
+import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
 import { ngrxGenerator } from './ngrx';
 
-export default convertNxGenerator(ngrxGenerator);
+export default warnForSchematicUsage(convertNxGenerator(ngrxGenerator));

--- a/packages/angular/src/generators/remote/remote.compat.ts
+++ b/packages/angular/src/generators/remote/remote.compat.ts
@@ -1,4 +1,5 @@
 import { convertNxGenerator } from '@nrwl/devkit';
+import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
 import remote from './remote';
 
-export default convertNxGenerator(remote);
+export default warnForSchematicUsage(convertNxGenerator(remote));

--- a/packages/angular/src/generators/scam-directive/scam-directive.compat.ts
+++ b/packages/angular/src/generators/scam-directive/scam-directive.compat.ts
@@ -1,4 +1,5 @@
 import scamGenerator from './scam-directive';
+import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
 import { convertNxGenerator } from '@nrwl/devkit';
 
-export default convertNxGenerator(scamGenerator);
+export default warnForSchematicUsage(convertNxGenerator(scamGenerator));

--- a/packages/angular/src/generators/scam-pipe/scam-pipe.compat.ts
+++ b/packages/angular/src/generators/scam-pipe/scam-pipe.compat.ts
@@ -1,4 +1,5 @@
 import scamPipeGenerator from './scam-pipe';
+import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
 import { convertNxGenerator } from '@nrwl/devkit';
 
-export default convertNxGenerator(scamPipeGenerator);
+export default warnForSchematicUsage(convertNxGenerator(scamPipeGenerator));

--- a/packages/angular/src/generators/scam-to-standalone/compat.ts
+++ b/packages/angular/src/generators/scam-to-standalone/compat.ts
@@ -1,4 +1,5 @@
 import { convertNxGenerator } from '@nrwl/devkit';
+import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
 import { scamToStandalone } from './scam-to-standalone';
 
-export default convertNxGenerator(scamToStandalone);
+export default warnForSchematicUsage(convertNxGenerator(scamToStandalone));

--- a/packages/angular/src/generators/scam/scam.compat.ts
+++ b/packages/angular/src/generators/scam/scam.compat.ts
@@ -1,4 +1,5 @@
 import scamGenerator from './scam';
+import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
 import { convertNxGenerator } from '@nrwl/devkit';
 
-export default convertNxGenerator(scamGenerator);
+export default warnForSchematicUsage(convertNxGenerator(scamGenerator));

--- a/packages/angular/src/generators/setup-mf/setup-mf.compat.ts
+++ b/packages/angular/src/generators/setup-mf/setup-mf.compat.ts
@@ -1,4 +1,5 @@
 import { convertNxGenerator } from '@nrwl/devkit';
+import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
 import { setupMf } from './setup-mf';
 
-export default convertNxGenerator(setupMf);
+export default warnForSchematicUsage(convertNxGenerator(setupMf));

--- a/packages/angular/src/generators/setup-ssr/setup-ssr.compat.ts
+++ b/packages/angular/src/generators/setup-ssr/setup-ssr.compat.ts
@@ -1,4 +1,5 @@
 import { convertNxGenerator } from '@nrwl/devkit';
+import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
 import { setupSsr } from './setup-ssr';
 
-export default convertNxGenerator(setupSsr);
+export default warnForSchematicUsage(convertNxGenerator(setupSsr));

--- a/packages/angular/src/generators/setup-tailwind/setup-tailwind.compat.ts
+++ b/packages/angular/src/generators/setup-tailwind/setup-tailwind.compat.ts
@@ -1,4 +1,7 @@
 import { convertNxGenerator } from '@nrwl/devkit';
+import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
 import { setupTailwindGenerator } from './setup-tailwind';
 
-export default convertNxGenerator(setupTailwindGenerator);
+export default warnForSchematicUsage(
+  convertNxGenerator(setupTailwindGenerator)
+);

--- a/packages/angular/src/generators/stories/compat.ts
+++ b/packages/angular/src/generators/stories/compat.ts
@@ -1,4 +1,7 @@
 import { convertNxGenerator } from '@nrwl/devkit';
+import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
 import { angularStoriesGenerator } from './stories';
 
-export default convertNxGenerator(angularStoriesGenerator);
+export default warnForSchematicUsage(
+  convertNxGenerator(angularStoriesGenerator)
+);

--- a/packages/angular/src/generators/storybook-configuration/compat.ts
+++ b/packages/angular/src/generators/storybook-configuration/compat.ts
@@ -1,4 +1,7 @@
 import { convertNxGenerator } from '@nrwl/devkit';
+import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
 import { storybookConfigurationGenerator } from './storybook-configuration';
 
-export default convertNxGenerator(storybookConfigurationGenerator);
+export default warnForSchematicUsage(
+  convertNxGenerator(storybookConfigurationGenerator)
+);

--- a/packages/angular/src/generators/utils/warn-for-schematic-usage.ts
+++ b/packages/angular/src/generators/utils/warn-for-schematic-usage.ts
@@ -1,0 +1,7 @@
+export function warnForSchematicUsage<T>(convertedGenerator: T): T {
+  console.warn(
+    'Running generators as schematics is deprecated and will be removed in v17.'
+  );
+
+  return convertedGenerator;
+}

--- a/packages/angular/src/generators/web-worker/compat.ts
+++ b/packages/angular/src/generators/web-worker/compat.ts
@@ -1,4 +1,5 @@
 import { convertNxGenerator } from '@nrwl/devkit';
+import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
 import { webWorkerGenerator } from './web-worker';
 
-export default convertNxGenerator(webWorkerGenerator);
+export default warnForSchematicUsage(convertNxGenerator(webWorkerGenerator));


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We support using schematic versions of our generators. However, we moving forward we will prefer Nx Devkit Generators.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Add a warning to inform people that the schematics usage will be removed in v17

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
