### PR TITLE
fix(storybook): alias new flag name to old

### DIFF
--- a/docs/generated/packages/storybook/generators/configuration.json
+++ b/docs/generated/packages/storybook/generators/configuration.json
@@ -83,7 +83,8 @@
         "description": "Configure your workspace to use Storybook 7, even though Storybook v7 is still in beta.",
         "type": "boolean",
         "default": false,
-        "hidden": true
+        "hidden": true,
+        "aliases": ["storybook7Configuration"]
       },
       "storybook7UiFramework": {
         "type": "string",

--- a/packages/storybook/src/generators/configuration/schema.json
+++ b/packages/storybook/src/generators/configuration/schema.json
@@ -83,7 +83,8 @@
       "description": "Configure your workspace to use Storybook 7, even though Storybook v7 is still in beta.",
       "type": "boolean",
       "default": false,
-      "hidden": true
+      "hidden": true,
+      "aliases": ["storybook7Configuration"]
     },
     "storybook7UiFramework": {
       "type": "string",


### PR DESCRIPTION
People already use the new Storybook 7 configuration flag (`storybook7Configuration `) [as per our docs](https://nx.dev/packages/storybook/documents/storybook-7-setup#generating-storybook-configuration) instead of the one that is actually working (`storybook7betaConfiguration `).

Old flag should get the new flag as an alias, so that it works.
