### PR TITLE
fix(storybook): show e2e error only if configureCypress is true

### DIFF
--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -186,23 +186,25 @@ export async function configurationGenerator(
     addStaticTarget(tree, schema);
   }
 
-  const e2eProject = await getE2EProjectName(tree, schema.name);
-  if (schema.configureCypress && !e2eProject) {
-    const cypressTask = await cypressProjectGenerator(tree, {
-      name: schema.name,
-      js: schema.js,
-      linter: schema.linter,
-      directory: schema.cypressDirectory,
-      standaloneConfig: schema.standaloneConfig,
-      ciTargetName: schema.configureStaticServe
-        ? 'static-storybook'
-        : undefined,
-    });
-    tasks.push(cypressTask);
-  } else {
-    logger.warn(
-      `There is already an e2e project setup for ${schema.name}, called ${e2eProject}.`
-    );
+  if (schema.configureCypress) {
+    const e2eProject = await getE2EProjectName(tree, schema.name);
+    if (!e2eProject) {
+      const cypressTask = await cypressProjectGenerator(tree, {
+        name: schema.name,
+        js: schema.js,
+        linter: schema.linter,
+        directory: schema.cypressDirectory,
+        standaloneConfig: schema.standaloneConfig,
+        ciTargetName: schema.configureStaticServe
+          ? 'static-storybook'
+          : undefined,
+      });
+      tasks.push(cypressTask);
+    } else {
+      logger.warn(
+        `There is already an e2e project setup for ${schema.name}, called ${e2eProject}.`
+      );
+    }
   }
 
   const devDeps = {};


### PR DESCRIPTION
Only check for Cypress Project if user wants to configure cypress. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15813
