### PR TITLE
cleanup(misc): remove internal rootProject flag from generators that can derive it

### DIFF
--- a/docs/generated/packages/cypress/generators/cypress-project.json
+++ b/docs/generated/packages/cypress/generators/cypress-project.json
@@ -64,13 +64,6 @@
         "description": "Do not add dependencies to `package.json`.",
         "x-priority": "internal"
       },
-      "rootProject": {
-        "description": "Create a application at the root of the workspace",
-        "type": "boolean",
-        "default": false,
-        "hidden": true,
-        "x-priority": "internal"
-      },
       "bundler": {
         "description": "The Cypress bundler to use.",
         "type": "string",

--- a/docs/generated/packages/jest/generators/jest-project.json
+++ b/docs/generated/packages/jest/generators/jest-project.json
@@ -75,13 +75,6 @@
         "type": "boolean",
         "default": false,
         "description": "Use JavaScript instead of TypeScript for config files"
-      },
-      "rootProject": {
-        "description": "Add Jest to an application at the root of the workspace",
-        "type": "boolean",
-        "default": false,
-        "hidden": true,
-        "x-priority": "internal"
       }
     },
     "required": [],

--- a/packages/angular/src/generators/application/lib/add-e2e.ts
+++ b/packages/angular/src/generators/application/lib/add-e2e.ts
@@ -23,7 +23,6 @@ export async function addE2e(tree: Tree, options: NormalizedSchema) {
       skipFormat: options.skipFormat,
       standaloneConfig: options.standaloneConfig,
       skipPackageJson: options.skipPackageJson,
-      rootProject: options.rootProject,
     });
   }
 }

--- a/packages/angular/src/generators/application/lib/add-unit-test-runner.ts
+++ b/packages/angular/src/generators/application/lib/add-unit-test-runner.ts
@@ -13,7 +13,6 @@ export async function addUnitTestRunner(host: Tree, options: NormalizedSchema) {
       supportTsx: false,
       skipSerializers: false,
       skipPackageJson: options.skipPackageJson,
-      rootProject: options.rootProject,
     });
   }
 }

--- a/packages/cypress/src/generators/cypress-project/cypress-project.spec.ts
+++ b/packages/cypress/src/generators/cypress-project/cypress-project.spec.ts
@@ -4,7 +4,6 @@ import {
   readProjectConfiguration,
   Tree,
   updateProjectConfiguration,
-  WorkspaceJsonConfiguration,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { cypressProjectGenerator } from './cypress-project';
@@ -264,7 +263,6 @@ describe('Cypress Project', () => {
             name: 'e2e-tests',
             baseUrl: 'http://localhost:1234',
             project: 'root',
-            rootProject: true,
           });
           expect(tree.listChanges().map((c) => c.path)).toEqual(
             expect.arrayContaining([

--- a/packages/cypress/src/generators/cypress-project/cypress-project.ts
+++ b/packages/cypress/src/generators/cypress-project/cypress-project.ts
@@ -43,6 +43,7 @@ import { Schema } from './schema';
 export interface CypressProjectSchema extends Schema {
   projectName: string;
   projectRoot: string;
+  rootProject: boolean;
 }
 
 function createFiles(tree: Tree, options: CypressProjectSchema) {

--- a/packages/cypress/src/generators/cypress-project/schema.d.ts
+++ b/packages/cypress/src/generators/cypress-project/schema.d.ts
@@ -11,6 +11,5 @@ export interface Schema {
   setParserOptionsProject?: boolean;
   standaloneConfig?: boolean;
   skipPackageJson?: boolean;
-  rootProject?: boolean;
   bundler?: 'webpack' | 'vite' | 'none';
 }

--- a/packages/cypress/src/generators/cypress-project/schema.json
+++ b/packages/cypress/src/generators/cypress-project/schema.json
@@ -66,13 +66,6 @@
       "description": "Do not add dependencies to `package.json`.",
       "x-priority": "internal"
     },
-    "rootProject": {
-      "description": "Create a application at the root of the workspace",
-      "type": "boolean",
-      "default": false,
-      "hidden": true,
-      "x-priority": "internal"
-    },
     "bundler": {
       "description": "The Cypress bundler to use.",
       "type": "string",

--- a/packages/jest/src/generators/jest-project/jest-project.spec.ts
+++ b/packages/jest/src/generators/jest-project/jest-project.spec.ts
@@ -379,7 +379,6 @@ describe('jestProject', () => {
       await jestProjectGenerator(tree, {
         ...defaultOptions,
         project: 'my-project',
-        rootProject: true,
       });
       expect(tree.read('jest.config.ts', 'utf-8')).toMatchInlineSnapshot(`
         "/* eslint-disable */
@@ -411,7 +410,6 @@ describe('jestProject', () => {
       await jestProjectGenerator(tree, {
         ...defaultOptions,
         project: 'my-project',
-        rootProject: true,
         js: true,
       });
       expect(tree.read('jest.config.js', 'utf-8')).toMatchInlineSnapshot(`

--- a/packages/jest/src/generators/jest-project/lib/check-for-test-target.ts
+++ b/packages/jest/src/generators/jest-project/lib/check-for-test-target.ts
@@ -1,7 +1,10 @@
 import { readProjectConfiguration, Tree } from '@nrwl/devkit';
-import { JestProjectSchema } from '../schema';
+import { NormalizedJestProjectSchema } from '../schema';
 
-export function checkForTestTarget(tree: Tree, options: JestProjectSchema) {
+export function checkForTestTarget(
+  tree: Tree,
+  options: NormalizedJestProjectSchema
+) {
   const projectConfig = readProjectConfiguration(tree, options.project);
   if (projectConfig?.targets?.test) {
     throw new Error(`${options.project}: already has a test target set.`);

--- a/packages/jest/src/generators/jest-project/lib/create-files.ts
+++ b/packages/jest/src/generators/jest-project/lib/create-files.ts
@@ -5,9 +5,9 @@ import {
   Tree,
 } from '@nrwl/devkit';
 import { join } from 'path';
-import { JestProjectSchema } from '../schema';
+import { NormalizedJestProjectSchema } from '../schema';
 
-export function createFiles(tree: Tree, options: JestProjectSchema) {
+export function createFiles(tree: Tree, options: NormalizedJestProjectSchema) {
   const projectConfig = readProjectConfiguration(tree, options.project);
 
   const filesFolder =

--- a/packages/jest/src/generators/jest-project/lib/update-jestconfig.ts
+++ b/packages/jest/src/generators/jest-project/lib/update-jestconfig.ts
@@ -1,5 +1,5 @@
 import { findRootJestConfig } from '../../../utils/config/find-root-jest-files';
-import { JestProjectSchema } from '../schema';
+import { NormalizedJestProjectSchema } from '../schema';
 import { addPropertyToJestConfig } from '../../../utils/config/update-config';
 import { readProjectConfiguration, Tree } from '@nrwl/devkit';
 
@@ -10,7 +10,10 @@ function isUsingUtilityFunction(host: Tree) {
   );
 }
 
-export function updateJestConfig(host: Tree, options: JestProjectSchema) {
+export function updateJestConfig(
+  host: Tree,
+  options: NormalizedJestProjectSchema
+) {
   if (isUsingUtilityFunction(host)) {
     return;
   }

--- a/packages/jest/src/generators/jest-project/lib/update-tsconfig.ts
+++ b/packages/jest/src/generators/jest-project/lib/update-tsconfig.ts
@@ -1,8 +1,11 @@
 import { join } from 'path';
-import { JestProjectSchema } from '../schema';
+import { NormalizedJestProjectSchema } from '../schema';
 import { readProjectConfiguration, Tree, updateJson } from '@nrwl/devkit';
 
-export function updateTsConfig(host: Tree, options: JestProjectSchema) {
+export function updateTsConfig(
+  host: Tree,
+  options: NormalizedJestProjectSchema
+) {
   const projectConfig = readProjectConfiguration(host, options.project);
   if (!host.exists(join(projectConfig.root, 'tsconfig.json'))) {
     throw new Error(

--- a/packages/jest/src/generators/jest-project/lib/update-workspace.ts
+++ b/packages/jest/src/generators/jest-project/lib/update-workspace.ts
@@ -1,4 +1,4 @@
-import { JestProjectSchema } from '../schema';
+import { NormalizedJestProjectSchema } from '../schema';
 import {
   readProjectConfiguration,
   Tree,
@@ -7,7 +7,10 @@ import {
   normalizePath,
 } from '@nrwl/devkit';
 
-export function updateWorkspace(tree: Tree, options: JestProjectSchema) {
+export function updateWorkspace(
+  tree: Tree,
+  options: NormalizedJestProjectSchema
+) {
   const projectConfig = readProjectConfiguration(tree, options.project);
   projectConfig.targets.test = {
     executor: '@nrwl/jest:jest',

--- a/packages/jest/src/generators/jest-project/schema.d.ts
+++ b/packages/jest/src/generators/jest-project/schema.d.ts
@@ -16,5 +16,8 @@ export interface JestProjectSchema {
   compiler?: 'tsc' | 'babel' | 'swc';
   skipPackageJson?: boolean;
   js?: boolean;
-  rootProject?: boolean;
 }
+
+export type NormalizedJestProjectSchema = JestProjectSchema & {
+  rootProject: boolean;
+};

--- a/packages/jest/src/generators/jest-project/schema.json
+++ b/packages/jest/src/generators/jest-project/schema.json
@@ -74,13 +74,6 @@
       "type": "boolean",
       "default": false,
       "description": "Use JavaScript instead of TypeScript for config files"
-    },
-    "rootProject": {
-      "description": "Add Jest to an application at the root of the workspace",
-      "type": "boolean",
-      "default": false,
-      "hidden": true,
-      "x-priority": "internal"
     }
   },
   "required": []


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

An internal `rootProject` flag is used by generators to know whether they are running for a standalone project. Some generators shouldn't need this flag and instead, they shoul derive it from the project configuration.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The project generators from `cypress` and `jest` shouldn't have the `rootProject` flag. They should derive the information from the project configuration.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
