### PR TITLE
fix(nextjs): add missing style deps for less and stylus

### DIFF
--- a/packages/next/migrations.json
+++ b/packages/next/migrations.json
@@ -53,6 +53,12 @@
       "version": "14.5.3-beta.0",
       "description": "Update development outputPath to the project root.",
       "factory": "./src/migrations/update-14-5-3/update-dev-output-path"
+    },
+    "add-style-packages": {
+      "cli": "nx",
+      "version": "15.8.8-beta.0",
+      "description": "Add less and stylus packages if used.",
+      "factory": "./src/migrations/update-15-8-8/add-style-packages"
     }
   },
   "packageJsonUpdates": {

--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -24,6 +24,10 @@ export interface WithNxOptions extends NextConfig {
   };
 }
 
+export interface NextConfigFn {
+  (phase: string): Promise<NextConfig>;
+}
+
 export interface WithNxContext {
   workspaceRoot: string;
   libsDir: string;
@@ -114,7 +118,7 @@ function getNxContext(
 export function withNx(
   _nextConfig = {} as WithNxOptions,
   context: WithNxContext = getWithNxContext()
-): (phase: string) => Promise<NextConfig> {
+): NextConfigFn {
   return async (phase: string) => {
     if (phase === PHASE_PRODUCTION_SERVER) {
       // If we are running an already built production server, just return the configuration.

--- a/packages/next/plugins/with-stylus.ts
+++ b/packages/next/plugins/with-stylus.ts
@@ -1,5 +1,6 @@
 // Adapted from https://raw.githubusercontent.com/elado/next-with-less/main/src/index.js
 import { merge } from 'webpack-merge';
+import { NextConfigFn } from './with-nx';
 
 const addStylusToRegExp = (rx) =>
   new RegExp(rx.source.replace('|sass', '|sass|styl'), rx.flags);
@@ -12,85 +13,91 @@ function patchNextCSSWithStylus(
 
 patchNextCSSWithStylus();
 
-export function withStylus({ stylusLoaderOptions = {}, ...nextConfig }: any) {
-  return Object.assign({}, nextConfig, {
-    webpack(config, opts) {
-      // there are 2 relevant sass rules in next.js - css modules and global css
-      let sassModuleRule;
-      // global sass rule (does not exist in server builds)
-      let sassGlobalRule;
+export function withStylus(configFn: NextConfigFn): NextConfigFn {
+  return async (phase: string) => {
+    const { stylusLoaderOptions = {}, ...nextConfig } = await configFn(phase);
 
-      const cssRule = config.module.rules.find((rule) =>
-        rule.oneOf?.find((r) => r?.[Symbol.for('__next_css_remove')])
-      );
+    return Object.assign({}, nextConfig, {
+      webpack(config, opts) {
+        // there are 2 relevant sass rules in next.js - css modules and global css
+        let sassModuleRule;
+        // global sass rule (does not exist in server builds)
+        let sassGlobalRule;
 
-      const addStylusRuleToTest = (test) => {
-        if (Array.isArray(test)) {
-          return test.map((rx) => addStylusToRegExp(rx));
-        } else {
-          return addStylusToRegExp(test);
-        }
-      };
-
-      cssRule.oneOf.forEach((rule) => {
-        if (rule.options?.__next_css_remove) return;
-
-        if (rule.use?.loader === 'error-loader') {
-          rule.test = addStylusRuleToTest(rule.test);
-        } else if (rule.use?.loader?.includes('file-loader')) {
-          rule.issuer = addStylusRuleToTest(rule.issuer);
-        } else if (rule.use?.includes?.('ignore-loader')) {
-          rule.test = addStylusRuleToTest(rule.test);
-        } else if (rule.test?.source === '\\.module\\.(scss|sass)$') {
-          sassModuleRule = rule;
-        } else if (rule.test?.source === '(?<!\\.module)\\.(scss|sass)$') {
-          sassGlobalRule = rule;
-        }
-      });
-
-      const stylusLoader = {
-        loader: 'stylus-loader',
-        options: {
-          ...stylusLoaderOptions,
-          stylusOptions: {
-            javascriptEnabled: true,
-            ...stylusLoaderOptions.stylusOptions,
-          },
-        },
-      };
-
-      let stylusModuleRule = merge({}, sassModuleRule);
-
-      const configureStylusRule = (rule) => {
-        rule.test = new RegExp(rule.test.source.replace('(scss|sass)', 'styl'));
-        // replace sass-loader (last entry) with stylus-loader
-        rule.use.splice(-1, 1, stylusLoader);
-      };
-
-      configureStylusRule(stylusModuleRule);
-      cssRule.oneOf.splice(
-        cssRule.oneOf.indexOf(sassModuleRule) + 1,
-        0,
-        stylusModuleRule
-      );
-
-      if (sassGlobalRule) {
-        let stylusGlobalRule = merge({}, sassGlobalRule);
-        configureStylusRule(stylusGlobalRule);
-        cssRule.oneOf.splice(
-          cssRule.oneOf.indexOf(sassGlobalRule) + 1,
-          0,
-          stylusGlobalRule
+        const cssRule = config.module.rules.find((rule) =>
+          rule.oneOf?.find((r) => r?.[Symbol.for('__next_css_remove')])
         );
-      }
 
-      if (typeof nextConfig.webpack === 'function') {
-        return nextConfig.webpack(config, opts);
-      }
+        const addStylusRuleToTest = (test) => {
+          if (Array.isArray(test)) {
+            return test.map((rx) => addStylusToRegExp(rx));
+          } else {
+            return addStylusToRegExp(test);
+          }
+        };
 
-      return config;
-    },
-  });
+        cssRule.oneOf.forEach((rule) => {
+          if (rule.options?.__next_css_remove) return;
+
+          if (rule.use?.loader === 'error-loader') {
+            rule.test = addStylusRuleToTest(rule.test);
+          } else if (rule.use?.loader?.includes('file-loader')) {
+            rule.issuer = addStylusRuleToTest(rule.issuer);
+          } else if (rule.use?.includes?.('ignore-loader')) {
+            rule.test = addStylusRuleToTest(rule.test);
+          } else if (rule.test?.source === '\\.module\\.(scss|sass)$') {
+            sassModuleRule = rule;
+          } else if (rule.test?.source === '(?<!\\.module)\\.(scss|sass)$') {
+            sassGlobalRule = rule;
+          }
+        });
+
+        const stylusLoader = {
+          loader: 'stylus-loader',
+          options: {
+            ...stylusLoaderOptions,
+            stylusOptions: {
+              javascriptEnabled: true,
+              ...stylusLoaderOptions.stylusOptions,
+            },
+          },
+        };
+
+        let stylusModuleRule = merge({}, sassModuleRule);
+
+        const configureStylusRule = (rule) => {
+          rule.test = new RegExp(
+            rule.test.source.replace('(scss|sass)', 'styl')
+          );
+          // replace sass-loader (last entry) with stylus-loader
+          rule.use.splice(-1, 1, stylusLoader);
+        };
+
+        configureStylusRule(stylusModuleRule);
+        cssRule.oneOf.splice(
+          cssRule.oneOf.indexOf(sassModuleRule) + 1,
+          0,
+          stylusModuleRule
+        );
+
+        if (sassGlobalRule) {
+          let stylusGlobalRule = merge({}, sassGlobalRule);
+          configureStylusRule(stylusGlobalRule);
+          cssRule.oneOf.splice(
+            cssRule.oneOf.indexOf(sassGlobalRule) + 1,
+            0,
+            stylusGlobalRule
+          );
+        }
+
+        if (typeof nextConfig.webpack === 'function') {
+          return nextConfig.webpack(config, opts);
+        }
+
+        return config;
+      },
+    });
+  };
 }
 
 module.exports = withStylus;

--- a/packages/next/src/migrations/update-15-8-8/add-style-packages.spec.ts
+++ b/packages/next/src/migrations/update-15-8-8/add-style-packages.spec.ts
@@ -1,0 +1,117 @@
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import {
+  writeJson,
+  readJson,
+  Tree,
+  addProjectConfiguration,
+} from '@nrwl/devkit';
+import update from './add-style-packages';
+
+describe('Add less and stylus if needed', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should add less if used', async () => {
+    writeJson(tree, 'package.json', {
+      dependencies: {},
+      devDependencies: {},
+    });
+    addProjectConfiguration(tree, 'myapp', {
+      root: 'myapp',
+      targets: {
+        build: {
+          executor: '@nrwl/next:build',
+        },
+      },
+    });
+    tree.write(
+      `myapp/next.config.js`,
+      `require('@nrwl/next/plugins/with-less')`
+    );
+
+    await update(tree);
+
+    const packageJson = readJson(tree, 'package.json');
+    expect(packageJson).toEqual({
+      dependencies: {},
+      devDependencies: { less: '3.12.2' },
+    });
+  });
+
+  it('should add stylus if used', async () => {
+    writeJson(tree, 'package.json', {
+      dependencies: {},
+      devDependencies: {},
+    });
+    addProjectConfiguration(tree, 'myapp', {
+      root: 'myapp',
+      targets: {
+        build: {
+          executor: '@nrwl/next:build',
+        },
+      },
+    });
+    tree.write(
+      `myapp/next.config.js`,
+      `require('@nrwl/next/plugins/with-stylus')`
+    );
+
+    await update(tree);
+
+    const packageJson = readJson(tree, 'package.json');
+    expect(packageJson).toEqual({
+      dependencies: {},
+      devDependencies: { stylus: '^0.55.0' },
+    });
+  });
+
+  it('should not add anything if less/stylus not used by Next.js app', async () => {
+    writeJson(tree, 'package.json', {
+      dependencies: {},
+      devDependencies: {},
+    });
+    addProjectConfiguration(tree, 'myapp', {
+      root: 'myapp',
+      targets: {
+        build: {
+          executor: '@nrwl/next:build',
+        },
+      },
+    });
+    tree.write(`myapp/next.config.js`, `require('@nrwl/next/plugins/with-nx')`);
+
+    await update(tree);
+
+    const packageJson = readJson(tree, 'package.json');
+    expect(packageJson).toEqual({
+      dependencies: {},
+      devDependencies: {},
+    });
+  });
+
+  it('should not add anything if no Next.js apps are in workspace', async () => {
+    writeJson(tree, 'package.json', {
+      dependencies: {},
+      devDependencies: {},
+    });
+    addProjectConfiguration(tree, 'myapp', {
+      root: 'myapp',
+      targets: {
+        build: {
+          executor: '@nrwl/webpack:webpack',
+        },
+      },
+    });
+
+    await update(tree);
+
+    const packageJson = readJson(tree, 'package.json');
+    expect(packageJson).toEqual({
+      dependencies: {},
+      devDependencies: {},
+    });
+  });
+});

--- a/packages/next/src/migrations/update-15-8-8/add-style-packages.ts
+++ b/packages/next/src/migrations/update-15-8-8/add-style-packages.ts
@@ -1,0 +1,35 @@
+import {
+  addDependenciesToPackageJson,
+  getProjects,
+  joinPathFragments,
+  Tree,
+} from '@nrwl/devkit';
+
+export async function update(tree: Tree) {
+  const projects = getProjects(tree);
+  const missingDeps = {};
+
+  for (const [, config] of projects) {
+    if (
+      config.targets?.build?.executor === '@nrwl/next:build' &&
+      tree.exists(joinPathFragments(config.root, 'next.config.js'))
+    ) {
+      const nextConfigContent = tree.read(
+        joinPathFragments(config.root, 'next.config.js'),
+        'utf-8'
+      );
+
+      if (nextConfigContent.includes('@nrwl/next/plugins/with-less')) {
+        missingDeps['less'] = '3.12.2';
+      }
+
+      if (nextConfigContent.includes('@nrwl/next/plugins/with-stylus')) {
+        missingDeps['stylus'] = '^0.55.0';
+      }
+    }
+  }
+
+  return addDependenciesToPackageJson(tree, {}, missingDeps);
+}
+
+export default update;

--- a/packages/next/src/utils/styles.ts
+++ b/packages/next/src/utils/styles.ts
@@ -5,6 +5,7 @@ import {
   updateJson,
 } from '@nrwl/devkit';
 
+import { lessVersion, stylusVersion } from '@nrwl/react/src/utils/versions';
 import { CSS_IN_JS_DEPENDENCIES } from '@nrwl/react/src/utils/styled';
 import {
   babelPluginStyledComponentsVersion,
@@ -40,11 +41,13 @@ export const NEXT_SPECIFIC_STYLE_DEPENDENCIES = {
   less: {
     dependencies: {},
     devDependencies: {
+      less: lessVersion,
       'less-loader': lessLoader,
     },
   },
   styl: {
     dependencies: {
+      stylus: stylusVersion,
       'stylus-loader': stylusLoader,
     },
     devDependencies: {},


### PR DESCRIPTION
This PR fixes an issue where less and stylus apps aren't built properly due to the recent updates to `withNx` to return a function rather than a next.js config object.

https://github.com/nrwl/nx/commit/be81405a84777df7916d5a0979a5bd32a4d63cd7

Also adds missing `less` and `stylus` dependencies to the workspace now that webpack is no longer being installed to new workspaces/apps.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
