### PR TITLE
fix(core): resolve some strip-source-code bugs

### DIFF
--- a/packages/nx/src/utils/strip-source-code.spec.ts
+++ b/packages/nx/src/utils/strip-source-code.spec.ts
@@ -258,6 +258,20 @@ require('./d')`;
     expect(stripSourceCode(scanner, input)).toEqual(expected);
   });
 
+  it('should find an import after a template literal with a 2 variables in it', () => {
+    const input = `
+      const a = 1;
+      const b = 2;
+      const c = \`a: $\{a}, b: $\{b}\`
+      const d = await import('./d')
+      const e = require('./e')
+    `;
+    const expected = `import('./d')
+require('./e')`;
+
+    expect(stripSourceCode(scanner, input)).toEqual(expected);
+  });
+
   it('finds imports after an escaped character', () => {
     const input = `
       const b = unquotedLiteral.replace(/"/g, '\\\\"')
@@ -279,6 +293,39 @@ require('./d')`;
     `;
     const expected = `import('./c')
 require('./d')`;
+
+    expect(stripSourceCode(scanner, input)).toEqual(expected);
+  });
+
+  it('finds imports in the same line as template literals with division inside', () => {
+    const input = `
+      const a = 1;
+      const b = \`"$\{1 / 2} $\{await import('./b')} $\{await require('./c')}"\`;
+    `;
+    const expected = `import('./b')
+require('./c')`;
+
+    expect(stripSourceCode(scanner, input)).toEqual(expected);
+  });
+
+  it('finds imports in the same line after a regex', () => {
+    const input = `
+      const a = 1;
+      const b = /"/g; const c = await import('./c'); const d = require('./d')
+    `;
+    const expected = `import('./c')
+require('./d')`;
+
+    expect(stripSourceCode(scanner, input)).toEqual(expected);
+  });
+
+  it('finds imports inside template literals', () => {
+    const input = `
+      const a = \`"$\{require('./a')}"\`
+      const b = \`"$\{await import('./b')}"\`
+    `;
+    const expected = `require('./a')
+import('./b')`;
 
     expect(stripSourceCode(scanner, input)).toEqual(expected);
   });


### PR DESCRIPTION
I found some bugs, added some test cases, and used my knowledge of js parsing quirks around template and regex literals to resolve them.

The regex handling was adapted from https://github.com/Microsoft/typescript/blob/2c952fe8505fc427cdfe30ed4b40343f0f5f39bc/src/services/classifier.ts#L260

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Imports after a template literal with 2 variables are not analyzed

## Expected Behavior
These imports should be included in the dependency graph

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
