### PR TITLE
fix(core): don't use relative paths for daemon socket on macos

### DIFF
--- a/packages/nx/src/daemon/socket-utils.ts
+++ b/packages/nx/src/daemon/socket-utils.ts
@@ -6,7 +6,7 @@ import { ProjectGraph } from '../config/project-graph';
 import { workspaceRoot } from '../utils/workspace-root';
 
 export const isWindows = platform() === 'win32';
-
+export const isLinux = platform() === 'linux';
 /**
  * For IPC with the daemon server we use unix sockets or windows named pipes, depending on the user's operating system.
  *
@@ -17,7 +17,9 @@ export const isWindows = platform() === 'win32';
  */
 export const FULL_OS_SOCKET_PATH = isWindows
   ? '\\\\.\\pipe\\nx\\' + resolve(DAEMON_SOCKET_PATH)
-  : relative(workspaceRoot, resolve(DAEMON_SOCKET_PATH));
+  : isLinux
+  ? relative(workspaceRoot, resolve(DAEMON_SOCKET_PATH))
+  : resolve(DAEMON_SOCKET_PATH);
 
 export function killSocketOrPath(): void {
   try {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Daemon status checks do not work on macos because of the relative path. Getting ENOENT error behind the scenes

## Expected Behavior
Daemon will use the absolute path for macos, relative paths for linux, and named pipe for windows

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
