### PR TITLE
feat(nextjs): deprecate proxy config option for server executor

### DIFF
--- a/docs/generated/packages/next/executors/server.json
+++ b/docs/generated/packages/next/executors/server.json
@@ -51,7 +51,8 @@
       "proxyConfig": {
         "type": "string",
         "description": "Path to the proxy configuration file.",
-        "x-completion-type": "file"
+        "x-completion-type": "file",
+        "x-deprecated": "Use the built-in rewrite feature from Next.js. See: https://nextjs.org/docs/api-reference/next.config.js/rewrites"
       },
       "buildLibsFromSource": {
         "type": "boolean",

--- a/packages/next/src/executors/server/schema.json
+++ b/packages/next/src/executors/server/schema.json
@@ -48,7 +48,8 @@
     "proxyConfig": {
       "type": "string",
       "description": "Path to the proxy configuration file.",
-      "x-completion-type": "file"
+      "x-completion-type": "file",
+      "x-deprecated": "Use the built-in rewrite feature from Next.js. See: https://nextjs.org/docs/api-reference/next.config.js/rewrites"
     },
     "buildLibsFromSource": {
       "type": "boolean",

--- a/packages/next/src/executors/server/server.impl.ts
+++ b/packages/next/src/executors/server/server.impl.ts
@@ -20,8 +20,6 @@ import {
 import { customServer } from './lib/custom-server';
 import { defaultServer } from './lib/default-server';
 
-const infoPrefix = `[ ${chalk.dim(chalk.cyan('info'))} ] `;
-
 export default async function* serveExecutor(
   options: NextServeBuilderOptions,
   context: ExecutorContext
@@ -79,9 +77,10 @@ async function* runNextDevServer(
     ? join(context.root, options.proxyConfig)
     : join(root, 'proxy.conf.json');
 
+  // TODO(v16): Remove proxy support.
   if (existsSync(proxyConfigPath)) {
-    logger.info(
-      `${infoPrefix} found proxy configuration at ${proxyConfigPath}`
+    logger.warn(
+      `The "proxyConfig" option will be removed in Nx 16. Use the "rewrites" feature from Next.js instead. See: https://nextjs.org/docs/api-reference/next.config.js/rewrites`
     );
     proxyConfig = require(proxyConfigPath);
   }


### PR DESCRIPTION
This feature is no longer useful since Next.js has the `rewrite` feature.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
