### PR TITLE
Revert "fix(core): use relative paths for socket path (#10896)"

### DIFF
--- a/packages/nx/src/daemon/socket-utils.ts
+++ b/packages/nx/src/daemon/socket-utils.ts
@@ -1,9 +1,7 @@
 import { unlinkSync } from 'fs';
 import { platform } from 'os';
-import { relative, resolve } from 'path';
+import { resolve } from 'path';
 import { DAEMON_SOCKET_PATH } from './tmp-dir';
-import { ProjectGraph } from '../config/project-graph';
-import { workspaceRoot } from '../utils/workspace-root';
 
 export const isWindows = platform() === 'win32';
 
@@ -12,12 +10,10 @@ export const isWindows = platform() === 'win32';
  *
  * See https://nodejs.org/dist/latest-v14.x/docs/api/net.html#net_identifying_paths_for_ipc_connections for a full breakdown
  * of OS differences between Unix domain sockets and named pipes.
- *
- * Updated non-windows platforms to use relative paths allowing for workspaces that exist in long paths.
  */
 export const FULL_OS_SOCKET_PATH = isWindows
   ? '\\\\.\\pipe\\nx\\' + resolve(DAEMON_SOCKET_PATH)
-  : relative(workspaceRoot, resolve(DAEMON_SOCKET_PATH));
+  : resolve(DAEMON_SOCKET_PATH);
 
 export function killSocketOrPath(): void {
   try {


### PR DESCRIPTION
This reverts commit f60f8cdc53b26a4442f1f2721567391296515512.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Using relative paths causes issues on macos

## Expected Behavior
Reverts to the original change because the socket path is created with hashing the workspace path and long names are not an issue. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
