### PR TITLE
fix(nextjs): deference symlinks when copying public folder to dist

### DIFF
--- a/packages/next/src/executors/build/build.impl.ts
+++ b/packages/next/src/executors/build/build.impl.ts
@@ -74,7 +74,9 @@ export default async function buildExecutor(
 
   createNextConfigFile(options, context);
 
-  copySync(join(root, 'public'), join(options.outputPath, 'public'));
+  copySync(join(root, 'public'), join(options.outputPath, 'public'), {
+    dereference: true,
+  });
 
   return { success: true };
 }


### PR DESCRIPTION
Symlinks should be deferences so that the files are copied to `dist`, not the invalid link.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
Fixes #13065
