### PR TITLE
cleanup(angular): remove dep on schematics angular

### DIFF
--- a/packages/angular/src/generators/init/init.ts
+++ b/packages/angular/src/generators/init/init.ts
@@ -36,7 +36,6 @@ export async function angularInitGenerator(
   const peerDepsToInstall = [
     '@angular-devkit/core',
     '@angular-devkit/schematics',
-    '@schematics/angular',
   ];
   let devkitVersion: string;
   peerDepsToInstall.forEach((pkg) => {
@@ -165,6 +164,7 @@ function updateDependencies(
       '@angular/compiler-cli': angularVersion,
       '@angular/language-service': angularVersion,
       '@angular-devkit/build-angular': angularDevkitVersion,
+      '@schematics/angular': angularDevkitVersion,
     }
   );
 }

--- a/packages/workspace/src/generators/new/generate-preset.ts
+++ b/packages/workspace/src/generators/new/generate-preset.ts
@@ -103,7 +103,6 @@ function getPresetDependencies({
         dev: {
           '@angular-devkit/core': angularCliVersion,
           '@angular-devkit/schematics': angularCliVersion,
-          '@schematics/angular': angularCliVersion,
           typescript: typescriptVersion,
         },
       };

--- a/packages/workspace/src/generators/new/new.spec.ts
+++ b/packages/workspace/src/generators/new/new.spec.ts
@@ -4,7 +4,6 @@ import { Linter } from '../../utils/lint';
 import {
   angularCliVersion,
   nxVersion,
-  prettierVersion,
   typescriptVersion,
 } from '../../utils/versions';
 import { Preset } from '../utils/presets';
@@ -92,7 +91,6 @@ describe('new', () => {
         '@angular-devkit/core': angularCliVersion,
         '@angular-devkit/schematics': angularCliVersion,
         '@nrwl/workspace': nxVersion,
-        '@schematics/angular': angularCliVersion,
         nx: nxVersion,
         typescript: typescriptVersion,
       });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We dont need schematics angular to be installed for our generators

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Remove it
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
