### PR TITLE
fix(linter): remove outdated e2e test check

### DIFF
--- a/e2e/linter/src/linter.test.ts
+++ b/e2e/linter/src/linter.test.ts
@@ -505,7 +505,6 @@ describe('Linter', () => {
       expect(appEslint.overrides[0].extends).toBeDefined();
       expect(appEslint.overrides[1].extends).toBeDefined();
       expect(e2eEslint.overrides[0].extends).toBeDefined();
-      expect(e2eEslint.overrides[1].extends).toBeDefined();
 
       runCLI(`generate @nrwl/workspace:lib ${mylib} --unitTestRunner=jest`);
       verifySuccessfulMigratedSetup(myapp, mylib);
@@ -517,7 +516,6 @@ describe('Linter', () => {
       expect(appEslint.overrides[0].extends).toBeUndefined();
       expect(appEslint.overrides[1].extends).toBeUndefined();
       expect(e2eEslint.overrides[0].extends).toBeUndefined();
-      expect(e2eEslint.overrides[1].extends).toBeUndefined();
     });
 
     it('(Angular standalone) should set root project config to app and e2e app and migrate when another lib is added', () => {
@@ -536,7 +534,6 @@ describe('Linter', () => {
       expect(appEslint.overrides[0].extends).toBeDefined();
       expect(appEslint.overrides[1].extends).toBeDefined();
       expect(e2eEslint.overrides[0].extends).toBeDefined();
-      expect(e2eEslint.overrides[1].extends).toBeDefined();
 
       runCLI(`generate @nrwl/workspace:lib ${mylib} --no-interactive`);
       verifySuccessfulMigratedSetup(myapp, mylib);
@@ -550,7 +547,6 @@ describe('Linter', () => {
         'plugin:@angular-eslint/template/process-inline-templates',
       ]);
       expect(e2eEslint.overrides[0].extends).toBeUndefined();
-      expect(e2eEslint.overrides[1].extends).toBeUndefined();
     });
 
     it('(Node standalone) should set root project config to app and e2e app and migrate when another lib is added', () => {
@@ -569,7 +565,6 @@ describe('Linter', () => {
       expect(appEslint.overrides[0].extends).toBeDefined();
       expect(appEslint.overrides[1].extends).toBeDefined();
       expect(e2eEslint.overrides[0].extends).toBeDefined();
-      expect(e2eEslint.overrides[1].extends).toBeDefined();
 
       runCLI(`generate @nrwl/workspace:lib ${mylib} --no-interactive`);
       verifySuccessfulMigratedSetup(myapp, mylib);
@@ -581,7 +576,6 @@ describe('Linter', () => {
       expect(appEslint.overrides[0].extends).toBeUndefined();
       expect(appEslint.overrides[1].extends).toBeUndefined();
       expect(e2eEslint.overrides[0].extends).toBeUndefined();
-      expect(e2eEslint.overrides[1].extends).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
A PR was merged last week that changes eslint overrides for Cypress project causing 2 tests that check for those overrides to fail.

## Current Behavior
Linter E2E tests are failing

## Expected Behavior
Linter E2E tests are passing

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
