### PR TITLE
fix(repo): add missing git config on nightly for lerna e2e

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -230,6 +230,11 @@ jobs:
           HOMEBREW_NO_AUTO_UPDATE=1 brew install applesimutils >/dev/null
           xcrun simctl shutdown all && xcrun simctl erase all
 
+      - name: Configure git metadata (needed for lerna smoke tests)
+        run: |
+          git config --global user.email test@test.com
+          git config --global user.name "Test Test"
+
       - name: Run e2e tests
         id: e2e-run
         run: yarn nx run-many --target=e2e --projects="${{ join(matrix.project) }}" --parallel=1

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -155,6 +155,11 @@ jobs:
         if: steps.cache-modules.outputs.cache-hit != 'true'
         run: yarn install --prefer-offline --frozen-lockfile --non-interactive
 
+      - name: Configure git metadata (needed for lerna smoke tests)
+        run: |
+          git config --global user.email test@test.com
+          git config --global user.name "Test Test"
+
       - name: Run e2e tests
         id: e2e-run
         run: yarn nx run-many --target=e2e --projects="${{ join(matrix.project) }}" --parallel=1


### PR DESCRIPTION
Lerna E2E smoke tests require user to be set globally on machine or local to the project. Failing to provide this will fail the `git config --get user.name` command ran by Lerna

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
