### PR TITLE
cleanup(angular): remove devkit schematics from ensured package

### DIFF
--- a/packages/angular/src/generators/init/init.ts
+++ b/packages/angular/src/generators/init/init.ts
@@ -31,10 +31,7 @@ export async function angularInitGenerator(
 
   const pkgVersions = versions(tree);
 
-  const peerDepsToInstall = [
-    '@angular-devkit/core',
-    '@angular-devkit/schematics',
-  ];
+  const peerDepsToInstall = ['@angular-devkit/core'];
   let devkitVersion: string;
   peerDepsToInstall.forEach((pkg) => {
     const packageVersion = getInstalledPackageVersion(tree, pkg);
@@ -162,6 +159,7 @@ function updateDependencies(
       '@angular/compiler-cli': angularVersion,
       '@angular/language-service': angularVersion,
       '@angular-devkit/build-angular': angularDevkitVersion,
+      '@angular-devkit/schematics': angularDevkitVersion,
       '@schematics/angular': angularDevkitVersion,
     }
   );

--- a/packages/workspace/src/generators/new/generate-preset.ts
+++ b/packages/workspace/src/generators/new/generate-preset.ts
@@ -102,7 +102,6 @@ function getPresetDependencies({
         dependencies: { '@nrwl/angular': nxVersion },
         dev: {
           '@angular-devkit/core': angularCliVersion,
-          '@angular-devkit/schematics': angularCliVersion,
           typescript: typescriptVersion,
         },
       };

--- a/packages/workspace/src/generators/new/new.spec.ts
+++ b/packages/workspace/src/generators/new/new.spec.ts
@@ -89,7 +89,6 @@ describe('new', () => {
       expect(dependencies).toStrictEqual({ '@nrwl/angular': nxVersion });
       expect(devDependencies).toStrictEqual({
         '@angular-devkit/core': angularCliVersion,
-        '@angular-devkit/schematics': angularCliVersion,
         '@nrwl/workspace': nxVersion,
         nx: nxVersion,
         typescript: typescriptVersion,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We install the @angular-devkit/schematics package separately at the start of the workspace creation flow

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We don't need to have this package installed before the workspace is created

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
