### PR TITLE
feat(repo): add nightly tests for several node versions 

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -20,6 +20,18 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
+        node_version:
+          - 19
+          - 18
+          - 16
+        exclude:
+          # run just node v18 on macos
+          - os: macos-latest
+            node_version: 19
+          - os: macos-latest
+            node_version: 16
+
+    name: Cache install (${{ matrix.os }}, node v${{ matrix.node_version }})
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -27,14 +39,15 @@ jobs:
       - name: Set node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: ${{ matrix.node_version }}
 
       - name: Cache node_modules
         id: cache-modules
         uses: actions/cache@v3
         with:
+          lookup-only: true
           path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-modules-${{ matrix.node_version }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install packages
         if: steps.cache-modules.outputs.cache-hit != 'true'
@@ -51,7 +64,9 @@ jobs:
           - ubuntu-latest
           - macos-latest
         node_version:
-          - '16'
+          - 19
+          - 18
+          - 16
         package_manager:
           - npm
           - yarn
@@ -85,7 +100,7 @@ jobs:
           - e2e-vite
           - e2e-webpack
           - e2e-workspace-create
-          - e2e-e2e-workspace-create-npm
+          - e2e-workspace-create-npm
         include:
           # os short names
           - os: ubuntu-latest
@@ -149,7 +164,7 @@ jobs:
             codeowners: 'S04SJ6PL98X'
           - project: e2e-workspace-create
             codeowners: 'S04SYHYKGNP'
-          - project: e2e-e2e-workspace-create-npm
+          - project: e2e-workspace-create-npm
             codeowners: 'S04SYHYKGNP'
         exclude:
           # exclude react-native tests from ubuntu
@@ -159,14 +174,123 @@ jobs:
             project: e2e-detox
           - os: ubuntu-latest
             project: e2e-expo
-          # run just npm v16 on macos
+          # exclude non-CNW/Lerna tests from non-LTS node versions
+          - node_version: 16
+            project: e2e-add-nx-to-monorepo
+          - node_version: 16
+            project: e2e-angular-core
+          - node_version: 16
+            project: e2e-angular-extensions
+          - node_version: 16
+            project: e2e-cra-to-nx
+          - node_version: 16
+            project: e2e-cypress
+          - node_version: 16
+            project: e2e-detox
+          - node_version: 16
+            project: e2e-esbuild
+          - node_version: 16
+            project: e2e-expo
+          - node_version: 16
+            project: e2e-jest
+          - node_version: 16
+            project: e2e-js
+          - node_version: 16
+            project: e2e-linter
+          - node_version: 16
+            project: e2e-make-angular-cli-faster
+          - node_version: 16
+            project: e2e-next
+          - node_version: 16
+            project: e2e-node
+          - node_version: 16
+            project: e2e-nx-init
+          - node_version: 16
+            project: e2e-nx-misc
+          - node_version: 16
+            project: e2e-nx-plugin
+          - node_version: 16
+            project: e2e-nx-run
+          - node_version: 16
+            project: e2e-react
+          - node_version: 16
+            project: e2e-react-native
+          - node_version: 16
+            project: e2e-web
+          - node_version: 16
+            project: e2e-rollup
+          - node_version: 16
+            project: e2e-storybook
+          - node_version: 16
+            project: e2e-storybook-angular
+          - node_version: 16
+            project: e2e-vite
+          - node_version: 16
+            project: e2e-webpack
+          - node_version: 19
+            project: e2e-add-nx-to-monorepo
+          - node_version: 19
+            project: e2e-angular-core
+          - node_version: 19
+            project: e2e-angular-extensions
+          - node_version: 19
+            project: e2e-cra-to-nx
+          - node_version: 19
+            project: e2e-cypress
+          - node_version: 19
+            project: e2e-detox
+          - node_version: 19
+            project: e2e-esbuild
+          - node_version: 19
+            project: e2e-expo
+          - node_version: 19
+            project: e2e-jest
+          - node_version: 19
+            project: e2e-js
+          - node_version: 19
+            project: e2e-linter
+          - node_version: 19
+            project: e2e-make-angular-cli-faster
+          - node_version: 19
+            project: e2e-next
+          - node_version: 19
+            project: e2e-node
+          - node_version: 19
+            project: e2e-nx-init
+          - node_version: 19
+            project: e2e-nx-misc
+          - node_version: 19
+            project: e2e-nx-plugin
+          - node_version: 19
+            project: e2e-nx-run
+          - node_version: 19
+            project: e2e-react
+          - node_version: 19
+            project: e2e-react-native
+          - node_version: 19
+            project: e2e-web
+          - node_version: 19
+            project: e2e-rollup
+          - node_version: 19
+            project: e2e-storybook
+          - node_version: 19
+            project: e2e-storybook-angular
+          - node_version: 19
+            project: e2e-vite
+          - node_version: 19
+            project: e2e-webpack
+          # run just npm v18 on macos
           - os: macos-latest
             package_manager: yarn
           - os: macos-latest
             package_manager: pnpm
+          - os: macos-latest
+            node_version: 16
+          - os: macos-latest
+            node_version: 19
       fail-fast: false
 
-    name: ${{ matrix.os_name }}/${{ matrix.package_manager }} ${{ join(matrix.project) }}
+    name: ${{ matrix.os_name }}/${{ matrix.package_manager }}/${{ matrix.node_version }} ${{ join(matrix.project) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -191,7 +315,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-modules-${{ matrix.node_version }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install packages
         if: steps.cache-modules.outputs.cache-hit != 'true'
@@ -318,13 +442,12 @@ jobs:
             // message
             let lastProject;
             let result = `
-              **Node** v16
               \`\`\`
-              | Failed project                 | PM   | OS    |
-              |--------------------------------|------|-------|`;
+              | Failed project                 | PM   | OS    | Node |
+              |--------------------------------|------|-------|------|`;
             failedProjects.forEach(matrix => {
               const project = matrix.project !== lastProject ? matrix.project : '...';
-              result += `\n| ${project.padEnd(30)} | ${matrix.package_manager.padEnd(4)} | ${matrix.os_name} |`
+              result += `\n| ${project.padEnd(30)} | ${matrix.package_manager.padEnd(4)} | ${matrix.os_name} | v${matrix.node_version.pad(3)} |`
               lastProject = matrix.project;
             });
             result += `\`\`\``;

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -210,7 +210,7 @@ jobs:
           - node_version: 16
             project: e2e-nx-plugin
           - node_version: 16
-            project: e2e-nx-run
+            project: e2e-lerna-smoke-tests
           - node_version: 16
             project: e2e-react
           - node_version: 16
@@ -262,7 +262,7 @@ jobs:
           - node_version: 19
             project: e2e-nx-plugin
           - node_version: 19
-            project: e2e-nx-run
+            project: e2e-lerna-smoke-tests
           - node_version: 19
             project: e2e-react
           - node_version: 19

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -15,6 +15,14 @@ permissions: {}
 jobs:
   preinstall:
     runs-on: windows-latest
+    strategy:
+      matrix:
+        node_version:
+          - 19
+          - 18
+          - 16
+
+    name: Cache install (node v${{ matrix.node_version }})
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -22,14 +30,14 @@ jobs:
       - name: Set node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: ${{ matrix.node_version }}
 
       - name: Cache node_modules
         id: cache-modules
         uses: actions/cache@v3
         with:
           path: '**/node_modules'
-          key: windows-modules-${{ hashFiles('**/yarn.lock') }}
+          key: windows-modules-${{ matrix.node_version }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install packages
         if: steps.cache-modules.outputs.cache-hit != 'true'
@@ -44,7 +52,9 @@ jobs:
     strategy:
       matrix:
         node_version:
-          - '16'
+          - 19
+          - 18
+          - 16
         package_manager:
           - npm
         project:
@@ -73,7 +83,7 @@ jobs:
           - e2e-vite
           - e2e-webpack
           - e2e-workspace-create
-          - e2e-e2e-workspace-create-npm
+          - e2e-workspace-create-npm
         include:
           # codeowner groups
           - project: e2e-add-nx-to-monorepo
@@ -126,11 +136,105 @@ jobs:
             codeowners: 'S04SJ6PL98X'
           - project: e2e-workspace-create
             codeowners: 'S04SYHYKGNP'
-          - project: e2e-e2e-workspace-create-npm
+          - project: e2e-workspace-create-npm
             codeowners: 'S04SYHYKGNP'
+        exclude:
+          # exclude non-CNW/Lerna tests from non-LTS node versions
+          - node_version: 16
+            project: e2e-add-nx-to-monorepo
+          - node_version: 16
+            project: e2e-angular-core
+          - node_version: 16
+            project: e2e-angular-extensions
+          - node_version: 16
+            project: e2e-cra-to-nx
+          - node_version: 16
+            project: e2e-cypress
+          - node_version: 16
+            project: e2e-esbuild
+          - node_version: 16
+            project: e2e-jest
+          - node_version: 16
+            project: e2e-js
+          - node_version: 16
+            project: e2e-linter
+          - node_version: 16
+            project: e2e-make-angular-cli-faster
+          - node_version: 16
+            project: e2e-next
+          - node_version: 16
+            project: e2e-node
+          - node_version: 16
+            project: e2e-nx-init
+          - node_version: 16
+            project: e2e-nx-misc
+          - node_version: 16
+            project: e2e-nx-plugin
+          - node_version: 16
+            project: e2e-nx-run
+          - node_version: 16
+            project: e2e-react
+          - node_version: 16
+            project: e2e-web
+          - node_version: 16
+            project: e2e-rollup
+          - node_version: 16
+            project: e2e-storybook
+          - node_version: 16
+            project: e2e-storybook-angular
+          - node_version: 16
+            project: e2e-vite
+          - node_version: 16
+            project: e2e-webpack
+          - node_version: 19
+            project: e2e-add-nx-to-monorepo
+          - node_version: 19
+            project: e2e-angular-core
+          - node_version: 19
+            project: e2e-angular-extensions
+          - node_version: 19
+            project: e2e-cra-to-nx
+          - node_version: 19
+            project: e2e-cypress
+          - node_version: 19
+            project: e2e-esbuild
+          - node_version: 19
+            project: e2e-jest
+          - node_version: 19
+            project: e2e-js
+          - node_version: 19
+            project: e2e-linter
+          - node_version: 19
+            project: e2e-make-angular-cli-faster
+          - node_version: 19
+            project: e2e-next
+          - node_version: 19
+            project: e2e-node
+          - node_version: 19
+            project: e2e-nx-init
+          - node_version: 19
+            project: e2e-nx-misc
+          - node_version: 19
+            project: e2e-nx-plugin
+          - node_version: 19
+            project: e2e-nx-run
+          - node_version: 19
+            project: e2e-react
+          - node_version: 19
+            project: e2e-web
+          - node_version: 19
+            project: e2e-rollup
+          - node_version: 19
+            project: e2e-storybook
+          - node_version: 19
+            project: e2e-storybook-angular
+          - node_version: 19
+            project: e2e-vite
+          - node_version: 19
+            project: e2e-webpack
       fail-fast: false
 
-    name: ${{ matrix.project }}
+    name: ${{ matrix.project }} (v${{ matrix.node_version }})
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -149,7 +253,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-modules-${{ matrix.node_version }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install packages
         if: steps.cache-modules.outputs.cache-hit != 'true'
@@ -245,14 +349,13 @@ jobs:
 
             // message
             let result = `
-              **Node** v16
-              **OS** Windows
-              **Package manager** npm
+              *OS* Windows
+              *Package manager* npm
               \`\`\`
-              | Failed project                 |
-              |--------------------------------|`;
+              | Failed project                 | Node |
+              |--------------------------------|------|`;
             failedProjects.forEach(matrix => {
-              result += `\n| ${matrix.project.padEnd(30)} |`
+              result += `\n| ${matrix.project.padEnd(30)} | v${matrix.node_version.pad(3)} |`
             });
             result += `\`\`\``;
             const message = result.split('\n').map(l => l.trim()).join('\n');

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -171,7 +171,7 @@ jobs:
           - node_version: 16
             project: e2e-nx-plugin
           - node_version: 16
-            project: e2e-nx-run
+            project: e2e-lerna-smoke-tests
           - node_version: 16
             project: e2e-react
           - node_version: 16
@@ -217,7 +217,7 @@ jobs:
           - node_version: 19
             project: e2e-nx-plugin
           - node_version: 19
-            project: e2e-nx-run
+            project: e2e-lerna-smoke-tests
           - node_version: 19
             project: e2e-react
           - node_version: 19


### PR DESCRIPTION
This PR:
- Switches default Node version to v18
- Adds tests for Node v16 and v19 (only nx-run and CNW tests)
- Improves report
- Fixes typo with `e2e-workspace-create-npm` test project

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
