### PR TITLE
feat(core): version option should display global and local installation separately

### DIFF
--- a/e2e/nx-misc/src/misc.test.ts
+++ b/e2e/nx-misc/src/misc.test.ts
@@ -623,6 +623,7 @@ describe('global installation', () => {
   });
 
   it('should warn if local Nx has higher major version', () => {
+    const packageJsonContents = readFile('node_modules/nx/package.json');
     updateJson('node_modules/nx/package.json', (json) => {
       json.version = `${major(getPublishedVersion()) + 2}.0.0`;
       return json;
@@ -632,5 +633,44 @@ describe('global installation', () => {
       output = runCommand(`nx show projects`);
     }).not.toThrow();
     expect(output).toContain('Its time to update Nx');
+    updateFile('node_modules/nx/package.json', packageJsonContents);
+  });
+
+  it('--version should display global installs version', () => {
+    const packageJsonContents = readFile('node_modules/nx/package.json');
+    const localVersion = `${major(getPublishedVersion()) + 2}.0.0`;
+    updateJson('node_modules/nx/package.json', (json) => {
+      json.version = localVersion;
+      return json;
+    });
+    let output: string;
+    expect(() => {
+      output = runCommand(`nx --version`);
+    }).not.toThrow();
+    expect(output).toContain(`- Local: v${localVersion}`);
+    expect(output).toContain(`- Global: v${getPublishedVersion()}`);
+    updateFile('node_modules/nx/package.json', packageJsonContents);
+  });
+
+  it('report should display global installs version', () => {
+    const packageJsonContents = readFile('node_modules/nx/package.json');
+    const localVersion = `${major(getPublishedVersion()) + 2}.0.0`;
+    updateJson('node_modules/nx/package.json', (json) => {
+      json.version = localVersion;
+      return json;
+    });
+    let output: string;
+    expect(() => {
+      output = runCommand(`nx report`);
+    }).not.toThrow();
+    expect(output).toEqual(
+      expect.stringMatching(new RegExp(`nx.*:.*${localVersion}`))
+    );
+    expect(output).toEqual(
+      expect.stringMatching(
+        new RegExp(`nx \\(global\\).*:.*${getPublishedVersion()}`)
+      )
+    );
+    updateFile('node_modules/nx/package.json', packageJsonContents);
   });
 });

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -9,6 +9,7 @@ import { getPackageManagerCommand } from '../utils/package-manager';
 import { writeJsonFile } from '../utils/fileutils';
 import { WatchArguments } from './watch';
 import { runNxSync } from '../utils/child-process';
+import { stripIndents } from '../utils/strip-indents';
 
 // Ensure that the output takes up the available width of the terminal.
 yargs.wrap(yargs.terminalWidth());
@@ -411,7 +412,10 @@ export const commandsObject = yargs
   })
   .scriptName('nx')
   .help()
-  .version(nxVersion);
+  // NOTE: we handle --version in nx.ts, this just tells yargs that the option exists
+  // so that it shows up in help. The default yargs implementation of --version is not
+  // hit, as the implementation in nx.ts is hit first and calls process.exit(0).
+  .version();
 
 function withShowOptions(yargs: yargs.Argv): yargs.Argv {
   return yargs.positional('object', {

--- a/packages/nx/src/command-line/report.ts
+++ b/packages/nx/src/command-line/report.ts
@@ -1,5 +1,4 @@
 import * as chalk from 'chalk';
-import { workspaceRoot } from '../utils/workspace-root';
 import { output } from '../utils/output';
 import { join } from 'path';
 import {
@@ -27,7 +26,6 @@ const nxPackageJson = readJsonFile<typeof import('../../package.json')>(
 );
 
 export const packagesWeCareAbout = [
-  'nx',
   'lerna',
   ...nxPackageJson['nx-migrations'].packageGroup.map((x) =>
     typeof x === 'string' ? x : x.package
@@ -161,6 +159,16 @@ export async function getReportData(): Promise<ReportData> {
   }
 
   const packageVersionsWeCareAbout = findInstalledPackagesWeCareAbout();
+  packageVersionsWeCareAbout.unshift({
+    package: 'nx',
+    version: nxPackageJson.version,
+  });
+  if (globalThis.GLOBAL_NX_VERSION) {
+    packageVersionsWeCareAbout.unshift({
+      package: 'nx (global)',
+      version: globalThis.GLOBAL_NX_VERSION,
+    });
+  }
 
   const outOfSyncPackageGroup = findMisalignedPackagesForPackage(nxPackageJson);
 
@@ -248,6 +256,7 @@ export function findInstalledCommunityPlugins(): PackageJson[] {
   const installedPlugins = findInstalledPlugins();
   return installedPlugins.filter(
     (dep) =>
+      dep.name !== 'nx' &&
       !patternsWeIgnoreInCommunityReport.some((pattern) =>
         typeof pattern === 'string'
           ? pattern === dep.name


### PR DESCRIPTION
## Current Behavior
`nx --version` only reports the locally installed Nx version, and throws when outside of a workspace

## Expected Behavior
`nx --version` can report the global Nx version if available, and doesn't throw if running it outside of a workspace.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15825
