### PR TITLE
docs(angular): suggest the correct ngrx router state serializer in data persistence docs

### DIFF
--- a/docs/shared/guides/misc-data-persistence.md
+++ b/docs/shared/guides/misc-data-persistence.md
@@ -198,19 +198,19 @@ class TodoEffects {
 }
 ```
 
-The StoreRouterConnectingModule must be configured with an appropriate serializer. The `DefaultRouterStateSerializer` provides the full router state instead of the `MinimalRouterStateSerializer` that is used without configuration.
+The StoreRouterConnectingModule must be configured with an appropriate serializer. The `FullRouterStateSerializer` provides the full router state instead of the `MinimalRouterStateSerializer` that is used without configuration.
 
 ```typescript
 import { NgModule } from '@angular/core';
 import {
   StoreRouterConnectingModule,
-  DefaultRouterStateSerializer,
+  FullRouterStateSerializer,
 } from '@ngrx/router-store';
 
 @NgModule({
   imports: [
     StoreRouterConnectingModule.forRoot({
-      serializer: DefaultRouterStateSerializer,
+      serializer: FullRouterStateSerializer,
     }),
   ],
 })


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The Data Persistence docs suggest using the `DefaultRouterStateSerializer` which was renamed to `FullRouterStateSerializer` in NgRx v14.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The Data Persistence docs should suggest using the `FullRouterStateSerializer`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15879 
