### PR TITLE
feat(node): add --framework=none to create-nx-workspace for Node projects

### DIFF
--- a/docs/generated/cli/create-nx-workspace.md
+++ b/docs/generated/cli/create-nx-workspace.md
@@ -129,7 +129,7 @@ Package manager to use
 
 Type: `string`
 
-Customizes the initial content of your workspace. Default presets include: ["apps", "empty", "core", "npm", "ts", "web-components", "angular-monorepo", "angular-standalone", "react-monorepo", "react-standalone", "react-native", "expo", "next", "nest", "express", "react", "angular", "node-server"]. To build your own see https://nx.dev/packages/nx-plugin#preset
+Customizes the initial content of your workspace. Default presets include: ["apps", "empty", "core", "npm", "ts", "web-components", "angular-monorepo", "angular-standalone", "react-monorepo", "react-standalone", "react-native", "expo", "next", "nest", "express", "react", "angular", "node-standalone"]. To build your own see https://nx.dev/packages/nx-plugin#preset
 
 ### routing
 

--- a/docs/generated/packages/nx/documents/create-nx-workspace.md
+++ b/docs/generated/packages/nx/documents/create-nx-workspace.md
@@ -129,7 +129,7 @@ Package manager to use
 
 Type: `string`
 
-Customizes the initial content of your workspace. Default presets include: ["apps", "empty", "core", "npm", "ts", "web-components", "angular-monorepo", "angular-standalone", "react-monorepo", "react-standalone", "react-native", "expo", "next", "nest", "express", "react", "angular", "node-server"]. To build your own see https://nx.dev/packages/nx-plugin#preset
+Customizes the initial content of your workspace. Default presets include: ["apps", "empty", "core", "npm", "ts", "web-components", "angular-monorepo", "angular-standalone", "react-monorepo", "react-standalone", "react-native", "expo", "next", "nest", "express", "react", "angular", "node-standalone"]. To build your own see https://nx.dev/packages/nx-plugin#preset
 
 ### routing
 

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -219,8 +219,8 @@ async function normalizeArgsMiddleware(
           preset = Preset.ReactStandalone;
         } else if (monorepoStyle === 'angular') {
           preset = Preset.AngularStandalone;
-        } else if (monorepoStyle === 'node-server') {
-          preset = Preset.NodeServer;
+        } else if (monorepoStyle === 'node-standalone') {
+          preset = Preset.NodeStandalone;
         } else {
           preset = await determinePreset(argv);
         }
@@ -235,15 +235,17 @@ async function normalizeArgsMiddleware(
       if (
         preset === Preset.ReactStandalone ||
         preset === Preset.AngularStandalone ||
-        preset === Preset.NodeServer
+        preset === Preset.NodeStandalone
       ) {
         appName =
           argv.appName ?? argv.name ?? (await determineAppName(preset, argv));
         name = argv.name ?? appName;
 
-        if (preset === Preset.NodeServer) {
+        if (preset === Preset.NodeStandalone) {
           framework = await determineFramework(argv);
-          docker = await determineDockerfile(argv);
+          if (framework !== 'none') {
+            docker = await determineDockerfile(argv);
+          }
         }
 
         if (preset === Preset.ReactStandalone) {
@@ -368,27 +370,27 @@ async function determineMonorepoStyle(): Promise<string> {
         {
           name: 'package-based',
           message:
-            'Package-based monorepo:     Nx makes it fast, but lets you run things your way.',
+            'Package-based monorepo: Nx makes it fast, but lets you run things your way.',
         },
         {
           name: 'integrated',
           message:
-            'Integrated monorepo:        Nx configures your favorite frameworks and lets you focus on shipping features.',
+            'Integrated monorepo:    Nx configures your favorite frameworks and lets you focus on shipping features.',
         },
         {
           name: 'react',
           message:
-            'Standalone React app:       Nx configures Vite (or Webpack), ESLint, and Cypress.',
+            'Standalone React app:   Nx configures Vite (or Webpack), ESLint, and Cypress.',
         },
         {
           name: 'angular',
           message:
-            'Standalone Angular app:     Nx configures Jest, ESLint and Cypress.',
+            'Standalone Angular app: Nx configures Jest, ESLint and Cypress.',
         },
         {
-          name: 'node-server',
+          name: 'node-standalone',
           message:
-            'Standalone Node Server app: Nx configures a framework (ex. Express), esbuild, ESlint and Jest.',
+            'Standalone Node app:    Nx configures a framework (ex. Express), esbuild, ESlint and Jest.',
         },
       ],
     },
@@ -561,6 +563,10 @@ async function determineFramework(
       name: 'nest',
       message: 'NestJs  [https://nestjs.com/]',
     },
+    {
+      name: 'none',
+      message: 'None',
+    },
   ];
 
   if (!parsedArgs.framework) {
@@ -668,7 +674,7 @@ async function determineStyle(
     preset === Preset.Express ||
     preset === Preset.ReactNative ||
     preset === Preset.Expo ||
-    preset === Preset.NodeServer
+    preset === Preset.NodeStandalone
   ) {
     return Promise.resolve(null);
   }

--- a/packages/create-nx-workspace/src/utils/preset/point-to-tutorial-and-course.ts
+++ b/packages/create-nx-workspace/src/utils/preset/point-to-tutorial-and-course.ts
@@ -54,7 +54,7 @@ export function pointToTutorialAndCourse(preset: Preset) {
       });
       break;
     case Preset.Express:
-    case Preset.NodeServer:
+    case Preset.NodeStandalone:
       output.addVerticalSeparator();
       output.note({
         title,

--- a/packages/create-nx-workspace/src/utils/preset/preset.ts
+++ b/packages/create-nx-workspace/src/utils/preset/preset.ts
@@ -16,7 +16,7 @@ export enum Preset {
   Express = 'express',
   React = 'react',
   Angular = 'angular',
-  NodeServer = 'node-server',
+  NodeStandalone = 'node-standalone',
 }
 
 /**

--- a/packages/node/src/generators/e2e-project/e2e-project.ts
+++ b/packages/node/src/generators/e2e-project/e2e-project.ts
@@ -80,7 +80,7 @@ export async function e2eProjectGenerator(host: Tree, _options: Schema) {
       options.e2eProjectRoot,
       {
         ...options,
-        ...names(options.rootProject ? 'server' : options.project),
+        ...names(options.rootProject ? 'cli' : options.project),
         mainFile,
         offsetFromRoot: offsetFromRoot(options.e2eProjectRoot),
         tmpl: '',

--- a/packages/workspace/src/generators/new/__snapshots__/generate-workspace-files.spec.ts.snap
+++ b/packages/workspace/src/generators/new/__snapshots__/generate-workspace-files.spec.ts.snap
@@ -230,7 +230,7 @@ Visit the [Nx Documentation](https://nx.dev) to learn more.
 "
 `;
 
-exports[`@nrwl/workspace:generateWorkspaceFiles README.md should be created for NodeServer preset 1`] = `
+exports[`@nrwl/workspace:generateWorkspaceFiles README.md should be created for NodeStandalone preset 1`] = `
 "# Proj
 
 <a alt=\\"Nx logo\\" href=\\"https://nx.dev\\" target=\\"_blank\\" rel=\\"noreferrer\\"><img src=\\"https://raw.githubusercontent.com/nrwl/nx/master/images/nx-logo.png\\" width=\\"45\\"></a>

--- a/packages/workspace/src/generators/new/generate-preset.ts
+++ b/packages/workspace/src/generators/new/generate-preset.ts
@@ -145,7 +145,7 @@ function getPresetDependencies({
         dev: { '@nrwl/web': nxVersion, typescript: typescriptVersion },
       };
 
-    case Preset.NodeServer:
+    case Preset.NodeStandalone:
       return { dependencies: {}, dev: { '@nrwl/node': nxVersion } };
 
     default: {

--- a/packages/workspace/src/generators/new/generate-workspace-files.spec.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.spec.ts
@@ -40,7 +40,7 @@ describe('@nrwl/workspace:generateWorkspaceFiles', () => {
             Preset.NextJs,
             Preset.WebComponents,
             Preset.Express,
-            Preset.NodeServer,
+            Preset.NodeStandalone,
           ].includes(Preset[preset])
         ) {
           appName = 'app1';

--- a/packages/workspace/src/generators/new/generate-workspace-files.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.ts
@@ -67,7 +67,7 @@ function createAppsAndLibsFolders(tree: Tree, options: NormalizedSchema) {
   } else if (
     options.preset === Preset.AngularStandalone ||
     options.preset === Preset.ReactStandalone ||
-    options.preset === Preset.NodeServer ||
+    options.preset === Preset.NodeStandalone ||
     options.isCustomPreset
   ) {
     // don't generate any folders
@@ -127,7 +127,7 @@ function createFiles(tree: Tree, options: NormalizedSchema) {
   const filesDirName =
     options.preset === Preset.AngularStandalone ||
     options.preset === Preset.ReactStandalone ||
-    options.preset === Preset.NodeServer
+    options.preset === Preset.NodeStandalone
       ? './files-root-app'
       : options.preset === Preset.NPM || options.preset === Preset.Core
       ? './files-package-based-repo'
@@ -178,7 +178,7 @@ function addNpmScripts(tree: Tree, options: NormalizedSchema) {
   if (
     options.preset === Preset.AngularStandalone ||
     options.preset === Preset.ReactStandalone ||
-    options.preset === Preset.NodeServer
+    options.preset === Preset.NodeStandalone
   ) {
     updateJson(tree, join(options.directory, 'package.json'), (json) => {
       Object.assign(json.scripts, {

--- a/packages/workspace/src/generators/new/new.ts
+++ b/packages/workspace/src/generators/new/new.ts
@@ -75,7 +75,7 @@ function validateOptions(options: Schema, host: Tree) {
     throw new Error(`Cannot select nxCloud when skipInstall is set to true.`);
   }
 
-  if (options.preset === Preset.NodeServer && !options.framework) {
+  if (options.preset === Preset.NodeStandalone && !options.framework) {
     throw new Error(
       `Cannot generate ${options.preset} without selecting a framework`
     );

--- a/packages/workspace/src/generators/preset/preset.ts
+++ b/packages/workspace/src/generators/preset/preset.ts
@@ -131,7 +131,7 @@ async function createPreset(tree: Tree, options: Schema) {
     };
     updateNxJson(tree, c);
     return initGenerator(tree, {});
-  } else if (options.preset === Preset.NodeServer) {
+  } else if (options.preset === Preset.NodeStandalone) {
     const { applicationGenerator: nodeApplicationGenerator } = require('@nrwl' +
       '/node');
     return nodeApplicationGenerator(tree, {

--- a/packages/workspace/src/generators/utils/presets.ts
+++ b/packages/workspace/src/generators/utils/presets.ts
@@ -14,5 +14,5 @@ export enum Preset {
   NextJs = 'next',
   Nest = 'nest',
   Express = 'express',
-  NodeServer = 'node-server',
+  NodeStandalone = 'node-standalone',
 }


### PR DESCRIPTION
This PR adds the `--framework=none` preset when users run `create-nx-workspace` and choose Node. Also renames `Node Server app` to just `Node app`. This way users can generate a barebones app, and add any framework on top of it, and Nx provides lint, test, e2e targets.

<img width="1247" alt="Screenshot 2023-03-28 at 11 36 09 AM" src="https://user-images.githubusercontent.com/53559/228292958-c65ef366-71ed-4bd4-b536-f4db5482669b.png">

<img width="1247" alt="Screenshot 2023-03-28 at 11 36 22 AM" src="https://user-images.githubusercontent.com/53559/228293012-2f372bab-582a-4b6a-8adf-1d31e77ce7b8.png">
