### PR TITLE
fix(angular): prevent inserting a leading comma in NgModule properties

### DIFF
--- a/packages/angular/src/generators/directive/__snapshots__/directive.spec.ts.snap
+++ b/packages/angular/src/generators/directive/__snapshots__/directive.spec.ts.snap
@@ -29,8 +29,8 @@ exports[`directive generator should export the directive correctly when flat=fal
 import { TestDirective } from './my-directives/test/test.directive';
 @NgModule({
   imports: [],
-  declarations: [, TestDirective],
-  exports: [, TestDirective],
+  declarations: [TestDirective],
+  exports: [TestDirective],
 })
 export class TestModule {}
 "
@@ -65,7 +65,7 @@ exports[`directive generator should generate a directive with test files and att
 import { TestDirective } from './test.directive';
 @NgModule({
   imports: [],
-  declarations: [, TestDirective],
+  declarations: [TestDirective],
   exports: [],
 })
 export class TestModule {}
@@ -101,7 +101,7 @@ exports[`directive generator should import the directive correctly when flat=fal
 import { TestDirective } from './test/test.directive';
 @NgModule({
   imports: [],
-  declarations: [, TestDirective],
+  declarations: [TestDirective],
   exports: [],
 })
 export class TestModule {}
@@ -137,7 +137,7 @@ exports[`directive generator should import the directive correctly when flat=fal
 import { TestDirective } from './my-directives/test/test.directive';
 @NgModule({
   imports: [],
-  declarations: [, TestDirective],
+  declarations: [TestDirective],
   exports: [],
 })
 export class TestModule {}
@@ -161,7 +161,7 @@ exports[`directive generator should not generate test file when skipTests=true 2
 import { TestDirective } from './my-directives/test/test.directive';
 @NgModule({
   imports: [],
-  declarations: [, TestDirective],
+  declarations: [TestDirective],
   exports: [],
 })
 export class TestModule {}

--- a/packages/angular/src/generators/pipe/__snapshots__/pipe.spec.ts.snap
+++ b/packages/angular/src/generators/pipe/__snapshots__/pipe.spec.ts.snap
@@ -31,8 +31,8 @@ exports[`pipe generator should export the pipe correctly when flat=false and pat
 import { TestPipe } from './my-pipes/test/test.pipe';
 @NgModule({
   imports: [],
-  declarations: [, TestPipe],
-  exports: [, TestPipe],
+  declarations: [TestPipe],
+  exports: [TestPipe],
 })
 export class TestModule {}
 "
@@ -69,7 +69,7 @@ exports[`pipe generator should generate a pipe with test files and attach to the
 import { TestPipe } from './test.pipe';
 @NgModule({
   imports: [],
-  declarations: [, TestPipe],
+  declarations: [TestPipe],
   exports: [],
 })
 export class TestModule {}
@@ -107,7 +107,7 @@ exports[`pipe generator should import the pipe correctly when flat=false 3`] = `
 import { TestPipe } from './test/test.pipe';
 @NgModule({
   imports: [],
-  declarations: [, TestPipe],
+  declarations: [TestPipe],
   exports: [],
 })
 export class TestModule {}
@@ -145,7 +145,7 @@ exports[`pipe generator should import the pipe correctly when flat=false and pat
 import { TestPipe } from './my-pipes/test/test.pipe';
 @NgModule({
   imports: [],
-  declarations: [, TestPipe],
+  declarations: [TestPipe],
   exports: [],
 })
 export class TestModule {}
@@ -171,7 +171,7 @@ exports[`pipe generator should not generate test file when skipTests=true 2`] = 
 import { TestPipe } from './my-pipes/test/test.pipe';
 @NgModule({
   imports: [],
-  declarations: [, TestPipe],
+  declarations: [TestPipe],
   exports: [],
 })
 export class TestModule {}

--- a/packages/angular/src/generators/utils/insert-ngmodule-import.ts
+++ b/packages/angular/src/generators/utils/insert-ngmodule-import.ts
@@ -108,7 +108,7 @@ export function insertNgModuleProperty(
       let text = `${property}: [${name}]`;
       if (ngModuleOptions.properties.hasTrailingComma) {
         text = `${text},`;
-      } else {
+      } else if (ngModuleOptions.properties.length) {
         text = `, ${text}`;
       }
       const newContents = applyChangesToString(contents, [
@@ -129,8 +129,10 @@ export function insertNgModuleProperty(
       let text: string;
       if (typeProperty.initializer.elements.hasTrailingComma) {
         text = `${name},`;
-      } else {
+      } else if (typeProperty.initializer.elements.length) {
         text = `, ${name}`;
+      } else {
+        text = name;
       }
       const newContents = applyChangesToString(contents, [
         {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The utility used by various generators to insert a property value in an `NgModule` inserts a leading comma when the existing property value is an empty array.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The utility used by various generators to insert a property value in an `NgModule` should not insert a leading comma when the existing property value is an empty array.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
