### PR TITLE
chore(repo): cache Cypress install for nightly tests to avoid "Cypress binary is missing" errors

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -11,6 +11,9 @@ on:
         required: false
         default: false
 
+env:
+  CYPRESS_CACHE_FOLDER: '.cypress'
+
 permissions: {}
 jobs:
   preinstall:
@@ -222,6 +225,13 @@ jobs:
           key: brew-${{ matrix.node_version }}
           restore-keys: |
             brew-
+
+      - name: Cache Cypress
+        id: cache-cypress
+        uses: actions/cache@v3
+        with:
+          path: '.cypress'
+          key: ${{ runner.os }}-cypress
 
       - name: Install applesimutils, reset ios simulators
         if: ${{ matrix.os == 'macos-latest' }}

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -11,6 +11,9 @@ on:
         required: false
         default: false
 
+env:
+  CYPRESS_CACHE_FOLDER: '.cypress'
+
 permissions: {}
 jobs:
   preinstall:
@@ -155,6 +158,13 @@ jobs:
         if: steps.cache-modules.outputs.cache-hit != 'true'
         run: yarn install --prefer-offline --frozen-lockfile --non-interactive
 
+      - name: Cache Cypress
+        id: cache-cypress
+        uses: actions/cache@v3
+        with:
+          path: '.cypress'
+          key: ${{ runner.os }}-cypress
+          
       - name: Configure git metadata (needed for lerna smoke tests)
         run: |
           git config --global user.email test@test.com


### PR DESCRIPTION
This PR sets `CYPRESS_CACHE_FOLDER` for the Cypress install and run, and caches the folder between jobs.

Currently, there are failures when `node_modules` is cached but Cypress binary is not found.

See: https://github.com/nrwl/nx/actions/runs/4537758696/jobs/7996065333#step:13:2022

```bash
FAIL e2e-react e2e/react/src/react.test.ts (309.593 s)
  ● React Applications › should be able to use Vite to build and test apps

    Command failed: npx nx e2e app7735587-e2e --no-watch  --verbose
    The cypress npm package is installed, but the Cypress binary is missing.
    
    We expected the binary to be installed here: /home/runner/.cache/Cypress/12.8.1/Cypress/Cypress
    
    Reasons it may be missing:
    
    - You're caching 'node_modules' but are not caching this path: /home/runner/.cache/Cypress
    - You ran 'npm install' at an earlier build step but did not persist: /home/runner/.cache/Cypress
    
    Properly caching the binary will fix this error and avoid downloading and unzipping Cypress.
    
    Alternatively, you can run 'cypress install' to download the binary again.
    
    https://on.cypress.io/not-installed-ci-error
    
    ----------
    
    Platform: linux-x64 (Ubuntu - 22.04)
    Cypress Version: 12.8.1
```