### PR TITLE
fix(react): setParserOptionsProject option should be respected

### DIFF
--- a/packages/react/src/generators/library/lib/add-linting.ts
+++ b/packages/react/src/generators/library/lib/add-linting.ts
@@ -22,6 +22,7 @@ export async function addLinting(host: Tree, options: NormalizedSchema) {
       eslintFilePatterns: [`${options.projectRoot}/**/*.{ts,tsx,js,jsx}`],
       skipFormat: true,
       skipPackageJson: options.skipPackageJson,
+      setParserOptionsProject: options.setParserOptionsProject,
     });
 
     updateJson(

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -712,6 +712,21 @@ describe('lib', () => {
     });
   });
 
+  describe('--setParserOptionsProject', () => {
+    it('should set the parserOptions.project in the eslintrc.json file', async () => {
+      await libraryGenerator(tree, {
+        ...defaultSchema,
+        setParserOptionsProject: true,
+      });
+
+      const eslintConfig = readJson(tree, 'libs/my-lib/.eslintrc.json');
+
+      expect(eslintConfig.overrides[0].parserOptions.project).toEqual([
+        'libs/my-lib/tsconfig.*?.json',
+      ]);
+    });
+  });
+
   it.each`
     style
     ${'styled-components'}


### PR DESCRIPTION
Setting setParserOptionsProject was not having any effect. This now forwards the option to the lintProjectGenerator.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Setting setParserOptionsProject was having no effect

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Setting setParserOptionsProject should update the eslint config as expected

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

