### PR TITLE
chore(repo): add Cypress cache to top-level install job

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -12,7 +12,8 @@ on:
         default: false
 
 env:
-  CYPRESS_CACHE_FOLDER: '.cypress'
+  CYPRESS_CACHE_FOLDER: '${HOME}/.cypress'
+
 
 permissions: {}
 jobs:
@@ -55,6 +56,17 @@ jobs:
       - name: Install packages
         if: steps.cache-modules.outputs.cache-hit != 'true'
         run: yarn install --prefer-offline --frozen-lockfile --non-interactive
+
+      - name: Cache Cypress
+        id: cache-cypress
+        uses: actions/cache@v3
+        with:
+          path: '.cypress'
+          key: ${{ runner.os }}-cypress
+
+      - name: Install Cypress
+        if: steps.cache-cypress.outputs.cache-hit != 'true'
+        run: npx cypress install
 
   e2e:
     needs: preinstall
@@ -356,6 +368,10 @@ jobs:
         with:
           path: '.cypress'
           key: ${{ runner.os }}-cypress
+
+      - name: Install Cypress
+        if: steps.cache-cypress.outputs.cache-hit != 'true'
+        run: npx cypress install
 
       - name: Install applesimutils, reset ios simulators
         if: ${{ matrix.os == 'macos-latest' }}

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -12,7 +12,7 @@ on:
         default: false
 
 env:
-  CYPRESS_CACHE_FOLDER: '.cypress'
+  CYPRESS_CACHE_FOLDER: '${HOME}/.cypress'
 
 permissions: {}
 jobs:
@@ -45,6 +45,17 @@ jobs:
       - name: Install packages
         if: steps.cache-modules.outputs.cache-hit != 'true'
         run: yarn install --prefer-offline --frozen-lockfile --non-interactive
+
+      - name: Cache Cypress
+        id: cache-cypress
+        uses: actions/cache@v3
+        with:
+          path: '.cypress'
+          key: windows-cypress
+
+      - name: Install Cypress
+        if: steps.cache-cypress.outputs.cache-hit != 'true'
+        run: npx cypress install
 
   e2e:
     needs: preinstall
@@ -269,6 +280,10 @@ jobs:
           path: '.cypress'
           key: ${{ runner.os }}-cypress
           
+      - name: Install Cypress
+        if: steps.cache-cypress.outputs.cache-hit != 'true'
+        run: npx cypress install
+
       - name: Configure git metadata (needed for lerna smoke tests)
         run: |
           git config --global user.email test@test.com


### PR DESCRIPTION
This PR adds the `Install Cypress` step to the nightly tests. 

If the `.cypress` binary cache is not found (`Cache Cypress`), then `npx cypress install` is run. If the binary is already available from `Install packages` then the install is skipped. Without this change, then skipping installs due to `Cache node_modules` having a hit may result in missing Cypress binary if the `Cache Cypress` does not also have a hit.