### PR TITLE
fix(angular): handle projects with no targets in angular migration

### DIFF
--- a/packages/angular/src/migrations/update-15-9-0/update-file-server-executor.spec.ts
+++ b/packages/angular/src/migrations/update-15-9-0/update-file-server-executor.spec.ts
@@ -64,4 +64,22 @@ describe('updateFileServerExecutor', () => {
       '@nrwl/web:file-server'
     );
   });
+
+  it('should handle projects with no targets', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+
+    const project = {
+      name: 'test',
+      root: '/',
+      sourceRoot: '/src',
+    };
+
+    addProjectConfiguration(tree, 'test', project);
+
+    // ACT
+    expect(async () => {
+      await updateFileServerExecutor(tree);
+    }).not.toThrow();
+  });
 });

--- a/packages/angular/src/migrations/update-15-9-0/update-file-server-executor.ts
+++ b/packages/angular/src/migrations/update-15-9-0/update-file-server-executor.ts
@@ -35,7 +35,7 @@ export default async function updateFileServerExecutor(tree: Tree) {
   for (const [projectName, project] of projects.entries()) {
     let projectChanged = false;
 
-    for (const [targetName, target] of Object.entries(project.targets)) {
+    for (const [targetName, target] of Object.entries(project.targets ?? {})) {
       if (target.executor === oldExecutor) {
         project.targets[targetName].executor = newExecutor;
         projectChanged = true;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Angular file-server migration errors when there is a project with no targets.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Angular file-server migration skips over projects with no targets and does not error.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
