### PR TITLE
chore(nextjs): fix invalid spelling `intialProps` to `initialProps`

### DIFF
--- a/packages/next/src/generators/application/files/pages/_document.tsx__tmpl__
+++ b/packages/next/src/generators/application/files/pages/_document.tsx__tmpl__
@@ -13,10 +13,10 @@ export default class CustomDocument extends Document {
     enhanceComponent: (Component) => Component,
    });
 
-   const intialProps = await Document.getInitialProps(ctx);
+   const initialProps = await Document.getInitialProps(ctx);
    const styles = sheet.getStyleElement();
 
-   return {...intialProps, styles };
+   return {...initialProps, styles };
   }
 
   render() {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

chore(nextjs): fix invalid spelling `intialProps` to `initialProps`

## Current Behavior

- affected package: @nrwl/next generator
- invalid spelling `intialProps` (initialProps) [_document.tsx__tmpl__#L16](https://github.com/nrwl/nx/blob/master/packages/next/src/generators/application/files/pages/_document.tsx__tmpl__#L16)

## Expected Behavior

- Changed to the correct spelling `initialProps`.
