### PR TITLE
fix(angular): prevent nested calls to formatFiles in generators

### DIFF
--- a/packages/angular/src/generators/add-linting/add-linting.ts
+++ b/packages/angular/src/generators/add-linting/add-linting.ts
@@ -1,4 +1,5 @@
 import {
+  formatFiles,
   GeneratorCallback,
   joinPathFragments,
   runTasksInSerial,
@@ -41,8 +42,12 @@ export async function addLintingGenerator(
   );
 
   if (!options.skipPackageJson) {
-    const installTask = await addAngularEsLintDependencies(tree);
+    const installTask = addAngularEsLintDependencies(tree);
     tasks.push(installTask);
+  }
+
+  if (!options.skipFormat) {
+    await formatFiles(tree);
   }
 
   return runTasksInSerial(...tasks);

--- a/packages/angular/src/generators/application/lib/add-e2e.ts
+++ b/packages/angular/src/generators/application/lib/add-e2e.ts
@@ -20,9 +20,9 @@ export async function addE2e(tree: Tree, options: NormalizedSchema) {
       directory: options.directory,
       project: options.name,
       linter: options.linter,
-      skipFormat: options.skipFormat,
       standaloneConfig: options.standaloneConfig,
       skipPackageJson: options.skipPackageJson,
+      skipFormat: true,
     });
   }
 }

--- a/packages/angular/src/generators/application/lib/add-linting.ts
+++ b/packages/angular/src/generators/application/lib/add-linting.ts
@@ -15,5 +15,6 @@ export async function addLinting(host: Tree, options: NormalizedSchema) {
     setParserOptionsProject: options.setParserOptionsProject,
     skipPackageJson: options.skipPackageJson,
     unitTestRunner: options.unitTestRunner,
+    skipFormat: true,
   });
 }

--- a/packages/angular/src/generators/application/lib/add-unit-test-runner.ts
+++ b/packages/angular/src/generators/application/lib/add-unit-test-runner.ts
@@ -13,6 +13,7 @@ export async function addUnitTestRunner(host: Tree, options: NormalizedSchema) {
       supportTsx: false,
       skipSerializers: false,
       skipPackageJson: options.skipPackageJson,
+      skipFormat: true,
     });
   }
 }

--- a/packages/angular/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
+++ b/packages/angular/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
@@ -40,7 +40,7 @@ export async function conversionGenerator(
          * does and remove the config again if it doesn't, so that it is most efficient.
          */
         setParserOptionsProject: true,
-        skipFormat: options.skipFormat,
+        skipFormat: true,
       });
     },
   });
@@ -105,7 +105,7 @@ export async function conversionGenerator(
          * step of this parent generator, if applicable
          */
         removeTSLintIfNoMoreTSLintTargets: false,
-        skipFormat: options.skipFormat,
+        skipFormat: true,
       });
     } catch {
       logger.warn(

--- a/packages/angular/src/generators/ng-add/utilities/workspace.ts
+++ b/packages/angular/src/generators/ng-add/utilities/workspace.ts
@@ -264,7 +264,7 @@ export function cleanupEsLintPackages(tree: Tree): void {
 export async function createWorkspaceFiles(tree: Tree): Promise<void> {
   updateVsCodeRecommendedExtensions(tree);
 
-  await jsInitGenerator(tree, {});
+  await jsInitGenerator(tree, { skipFormat: true });
 
   generateFiles(tree, joinPathFragments(__dirname, '../files/root'), '.', {
     tmpl: '',

--- a/packages/angular/src/generators/remote/remote.ts
+++ b/packages/angular/src/generators/remote/remote.ts
@@ -38,6 +38,7 @@ export async function remote(tree: Tree, options: Schema) {
     standalone: options.standalone ?? false,
     routing: true,
     port,
+    skipFormat: true,
   });
 
   const skipE2E =

--- a/packages/angular/src/generators/scam-directive/scam-directive.ts
+++ b/packages/angular/src/generators/scam-directive/scam-directive.ts
@@ -22,6 +22,7 @@ export async function scamDirectiveGenerator(tree: Tree, rawOptions: Schema) {
     skipImport: true,
     export: false,
     standalone: false,
+    skipFormat: true,
   });
 
   const pipeFileInfo = getDirectiveFileInfo(tree, options);

--- a/packages/angular/src/generators/scam-pipe/scam-pipe.ts
+++ b/packages/angular/src/generators/scam-pipe/scam-pipe.ts
@@ -22,6 +22,7 @@ export async function scamPipeGenerator(tree: Tree, rawOptions: Schema) {
     skipImport: true,
     export: false,
     standalone: false,
+    skipFormat: true,
   });
 
   const pipeFileInfo = getPipeFileInfo(tree, options);

--- a/packages/angular/src/generators/setup-mf/lib/update-host-app-routes.ts
+++ b/packages/angular/src/generators/setup-mf/lib/update-host-app-routes.ts
@@ -28,8 +28,7 @@ export function updateHostAppRoutes(tree: Tree, options: Schema) {
   tree.write(
     joinPathFragments(sourceRoot, 'app/app.component.html'),
     `<ul class="remote-menu">
-<li><a routerLink='/'>Home</a></li>
-${remoteRoutes}
+<li><a routerLink='/'>Home</a></li>${remoteRoutes}
 </ul>
 <router-outlet></router-outlet>
 `

--- a/packages/angular/src/generators/storybook-configuration/lib/generate-stories.ts
+++ b/packages/angular/src/generators/storybook-configuration/lib/generate-stories.ts
@@ -21,5 +21,6 @@ export async function generateStories(
       options.configureCypress && options.generateCypressSpecs,
     cypressProject: e2eProjectName,
     ignorePaths: options.ignorePaths,
+    skipFormat: true,
   });
 }

--- a/packages/angular/src/generators/storybook-configuration/lib/generate-storybook-configuration.ts
+++ b/packages/angular/src/generators/storybook-configuration/lib/generate-storybook-configuration.ts
@@ -20,5 +20,6 @@ export async function generateStorybookConfiguration(
     configureTestRunner: options.configureTestRunner,
     storybook7Configuration: options.storybook7Configuration,
     configureStaticServe: options.configureStaticServe,
+    skipFormat: true,
   });
 }

--- a/packages/angular/src/migrations/update-15-9-0/update-testing-tsconfig.spec.ts
+++ b/packages/angular/src/migrations/update-15-9-0/update-testing-tsconfig.spec.ts
@@ -6,8 +6,10 @@ import {
   updateJson,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from 'nx/src/devkit-testing-exports';
-import applicationGenerator from '../../generators/application/application';
-import libraryGenerator from '../../generators/library/library';
+import {
+  generateTestApplication,
+  generateTestLibrary,
+} from '../../generators/utils/testing';
 import { updateTestingTsconfigForJest } from './update-testing-tsconfig';
 
 let projectGraph: ProjectGraph;
@@ -68,7 +70,7 @@ describe('Jest+Ng - 15.9.0 - tsconfig updates', () => {
 });
 
 async function setup(tree: Tree, name: string) {
-  await applicationGenerator(tree, {
+  await generateTestApplication(tree, {
     name,
     skipPackageJson: true,
   });
@@ -79,7 +81,7 @@ async function setup(tree: Tree, name: string) {
     return json;
   });
 
-  await libraryGenerator(tree, {
+  await generateTestLibrary(tree, {
     name: `${name}-lib`,
   });
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Several composed generators execute `formatFiles` multiple times.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Composed generators should ensure the inner generator calls don't run `formatFiles`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
