### PR TITLE
fix(react): ensureCypressInstallation on e2e tests

### DIFF
--- a/e2e/react/src/cypress-component-tests.test.ts
+++ b/e2e/react/src/cypress-component-tests.test.ts
@@ -1,6 +1,7 @@
 import {
   cleanupProject,
   createFile,
+  ensureCypressInstallation,
   newProject,
   runCLI,
   uniq,
@@ -17,6 +18,7 @@ describe('React Cypress Component Tests', () => {
 
   beforeAll(() => {
     projectName = newProject({ name: uniq('cy-react') });
+    ensureCypressInstallation();
 
     runCLI(
       `generate @nrwl/react:app ${appName} --bundler=webpack --no-interactive`
@@ -224,7 +226,7 @@ ${content}`;
       `
         const { composePlugins, withNx } = require('@nrwl/webpack');
         const { withReact } = require('@nrwl/react');
-        
+
         module.exports = composePlugins(
           withNx(),
           withReact(),

--- a/e2e/react/src/react.test.ts
+++ b/e2e/react/src/react.test.ts
@@ -3,6 +3,7 @@ import {
   checkFilesExist,
   cleanupProject,
   createFile,
+  ensureCypressInstallation,
   killPorts,
   newProject,
   readFile,
@@ -20,7 +21,10 @@ import { join } from 'path';
 describe('React Applications', () => {
   let proj: string;
 
-  beforeEach(() => (proj = newProject()));
+  beforeEach(() => {
+    proj = newProject();
+    ensureCypressInstallation();
+  });
 
   afterEach(() => cleanupProject());
 
@@ -70,7 +74,7 @@ describe('React Applications', () => {
             </>
           );
         }
-        
+
         export default App;
       `
     );


### PR DESCRIPTION
Restoring cypress cache only partially helps with fixing tests.

We have a handy `ensureCypressInstallation` that installs Cypress on workspace if it's missing. All tests that use cypress should have this running. Optionally we can wrap assertion in `runCypressTests`

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
