### PR TITLE
fix(repo): remove command from the output to match test

### DIFF
--- a/e2e/nx-misc/src/misc.test.ts
+++ b/e2e/nx-misc/src/misc.test.ts
@@ -32,7 +32,9 @@ describe('Nx Commands', () => {
     it('should show the list of projects', () => {
       const app1 = uniq('myapp');
       const app2 = uniq('myapp');
-      expect(runCLI('show projects')).toEqual('');
+      expect(
+        runCLI('show projects').replace(/.*nx show projects( --verbose)?\n/, '')
+      ).toEqual('');
 
       runCLI(`generate @nrwl/web:app ${app1}`);
       runCLI(`generate @nrwl/web:app ${app2}`);

--- a/e2e/nx-run/src/affected-graph.test.ts
+++ b/e2e/nx-run/src/affected-graph.test.ts
@@ -277,7 +277,12 @@ describe('Nx Affected and Graph Tests', () => {
 
       const affectedProjects = runCLI(
         'print-affected --uncommitted --select projects'
-      ).split(', ');
+      )
+        .replace(
+          /.*nx print-affected --uncommitted --select projects( --verbose)?\n/,
+          ''
+        )
+        .split(', ');
 
       expect(affectedProjects).toContain(myapp);
       expect(affectedProjects).toContain(myapp2);


### PR DESCRIPTION
The test `'should handle file renames'` outputs in verbose mode:

```
$ /tmp/nx-e2e--2332-bKA8ArUNOawE/nx/proj3710160/node_modules/.bin/nx print-affected --uncommitted --select projects
myapp4659802, myapp4659802-e2e, myapp9813790, myapp9813790-e2e
```

which fails the test that doesn't expect the command to be visible in the log.

This PR strips the command before checking the asserts

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
