### PR TITLE
fix(angular): allow skiping formatFiles in component generator when called from another generator

### DIFF
--- a/docs/generated/packages/angular/generators/component.json
+++ b/docs/generated/packages/angular/generators/component.json
@@ -116,6 +116,12 @@
         "description": "Specifies if the component should be exported in the declaring `NgModule`. Additionally, if the project is a library, the component will be exported from the project's entry point (normally `index.ts`) if the module it belongs to is also exported or if the component is standalone.",
         "default": false,
         "x-priority": "important"
+      },
+      "skipFormat": {
+        "description": "Skip formatting files.",
+        "type": "boolean",
+        "default": false,
+        "x-priority": "internal"
       }
     },
     "required": ["name", "project"],

--- a/packages/angular/src/generators/component/component.ts
+++ b/packages/angular/src/generators/component/component.ts
@@ -118,7 +118,9 @@ export async function componentGenerator(tree: Tree, rawOptions: Schema) {
 
   exportComponentInEntryPoint(tree, options);
 
-  await formatFiles(tree);
+  if (!options.skipFormat) {
+    await formatFiles(tree);
+  }
 }
 
 function buildSelector(tree: Tree, name: string, prefix: string) {

--- a/packages/angular/src/generators/component/schema.d.ts
+++ b/packages/angular/src/generators/component/schema.d.ts
@@ -18,6 +18,7 @@ export interface Schema {
   skipSelector?: boolean;
   export?: boolean;
   prefix?: string;
+  skipFormat?: boolean;
 }
 
 export interface NormalizedSchema extends Schema {

--- a/packages/angular/src/generators/component/schema.json
+++ b/packages/angular/src/generators/component/schema.json
@@ -118,6 +118,12 @@
       "description": "Specifies if the component should be exported in the declaring `NgModule`. Additionally, if the project is a library, the component will be exported from the project's entry point (normally `index.ts`) if the module it belongs to is also exported or if the component is standalone.",
       "default": false,
       "x-priority": "important"
+    },
+    "skipFormat": {
+      "description": "Skip formatting files.",
+      "type": "boolean",
+      "default": false,
+      "x-priority": "internal"
     }
   },
   "required": ["name", "project"],

--- a/packages/angular/src/generators/library/lib/add-standalone-component.ts
+++ b/packages/angular/src/generators/library/lib/add-standalone-component.ts
@@ -15,6 +15,7 @@ export async function addStandaloneComponent(
     export: true,
     project: libraryOptions.name,
     flat: componentOptions.flat,
+    skipFormat: true,
   });
 
   if (libraryOptions.routing) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When creating a library with a standalone component, the component generator is invoked and this generator calls `formatFiles`. There's no way to skip that inner call which causes multiple `formatFiles` to run.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When creating a library with a standalone component, `formatFiles` shouldn't run multiple times.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
