### PR TITLE
cleanup(js): move assets to js package

### DIFF
--- a/packages/esbuild/src/executors/esbuild/schema.d.ts
+++ b/packages/esbuild/src/executors/esbuild/schema.d.ts
@@ -1,4 +1,4 @@
-import { AssetGlob } from '@nrwl/workspace/src/utilities/assets';
+import { AssetGlob } from '@nrwl/js/src/utils/assets/assets';
 
 type Compiler = 'babel' | 'swc';
 

--- a/packages/js/src/executors/swc/swc.impl.ts
+++ b/packages/js/src/executors/swc/swc.impl.ts
@@ -1,8 +1,5 @@
 import { ExecutorContext, readJsonFile, writeJsonFile } from '@nrwl/devkit';
-import {
-  assetGlobsToFiles,
-  FileInputOutput,
-} from '@nrwl/workspace/src/utilities/assets';
+import { assetGlobsToFiles, FileInputOutput } from '../../utils/assets/assets';
 import { removeSync } from 'fs-extra';
 import { dirname, join, relative, resolve } from 'path';
 import { copyAssets } from '../../utils/assets';

--- a/packages/js/src/executors/tsc/tsc.impl.ts
+++ b/packages/js/src/executors/tsc/tsc.impl.ts
@@ -1,8 +1,5 @@
 import { ExecutorContext } from '@nrwl/devkit';
-import {
-  assetGlobsToFiles,
-  FileInputOutput,
-} from '@nrwl/workspace/src/utilities/assets';
+import { assetGlobsToFiles, FileInputOutput } from '../../utils/assets/assets';
 import type { TypeScriptCompilationOptions } from '@nrwl/workspace/src/utilities/typescript/compilation';
 import { join, resolve } from 'path';
 import {

--- a/packages/js/src/utils/assets/assets.ts
+++ b/packages/js/src/utils/assets/assets.ts
@@ -1,4 +1,4 @@
-import * as glob from 'glob';
+import * as fastGlob from 'fast-glob';
 import { basename, join } from 'path';
 
 export type FileInputOutput = {
@@ -24,9 +24,9 @@ export function assetGlobsToFiles(
     ignore: string[] = [],
     dot: boolean = false
   ) => {
-    return glob.sync(pattern, {
+    return fastGlob.sync(pattern, {
       cwd: input,
-      nodir: true,
+      onlyFiles: true,
       dot,
       ignore,
     });

--- a/packages/js/src/utils/assets/copy-assets-handler.ts
+++ b/packages/js/src/utils/assets/copy-assets-handler.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as fse from 'fs-extra';
 import ignore, { Ignore } from 'ignore';
 import * as fg from 'fast-glob';
-import { AssetGlob } from '@nrwl/workspace/src/utilities/assets';
+import { AssetGlob } from './assets';
 import { logger } from '@nrwl/devkit';
 import { ChangedFile, daemonClient } from 'nx/src/daemon/client/client';
 

--- a/packages/js/src/utils/assets/index.ts
+++ b/packages/js/src/utils/assets/index.ts
@@ -1,4 +1,4 @@
-import { AssetGlob } from '@nrwl/workspace/src/utilities/assets';
+import { AssetGlob } from './assets';
 import { CopyAssetsHandler, FileEvent } from './copy-assets-handler';
 import { ExecutorContext } from '@nrwl/devkit';
 

--- a/packages/js/src/utils/schema.d.ts
+++ b/packages/js/src/utils/schema.d.ts
@@ -1,9 +1,6 @@
 // nx-ignore-next-line
 const { Linter } = require('@nrwl/linter'); // use require to import to avoid circular dependency
-import type {
-  AssetGlob,
-  FileInputOutput,
-} from '@nrwl/workspace/src/utilities/assets';
+import type { AssetGlob, FileInputOutput } from './assets/assets';
 import { TransformerEntry } from './typescript/types';
 
 export type Compiler = 'tsc' | 'swc';

--- a/packages/webpack/src/executors/webpack/schema.d.ts
+++ b/packages/webpack/src/executors/webpack/schema.d.ts
@@ -1,4 +1,4 @@
-import { AssetGlob } from '@nrwl/workspace/src/utilities/assets';
+import { AssetGlob } from '@nrwl/js/src/utils/assets/assets';
 
 export interface AssetGlobPattern {
   glob: string;

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -71,7 +71,6 @@
     "dotenv": "~10.0.0",
     "figures": "3.2.0",
     "flat": "^5.0.2",
-    "glob": "7.1.4",
     "ignore": "^5.0.4",
     "minimatch": "3.0.5",
     "npm-run-path": "^4.0.1",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Assets utils currently lives in workspace

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Assets utils should live in js

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
