### PR TITLE
fix(react-native): fix pnpm module resolver

### DIFF
--- a/packages/expo/plugins/metro-resolver.ts
+++ b/packages/expo/plugins/metro-resolver.ts
@@ -204,6 +204,7 @@ function getPnpmResolver(extensions: string[]) {
       useSyncFileSystemCalls: true,
       modules: [join(workspaceRoot, 'node_modules'), 'node_modules'],
       conditionNames: ['native', 'browser', 'require', 'default'],
+      mainFields: ['react-native', 'browser', 'main'],
     });
   }
   return resolver;

--- a/packages/react-native/plugins/metro-resolver.ts
+++ b/packages/react-native/plugins/metro-resolver.ts
@@ -204,6 +204,7 @@ function getPnpmResolver(extensions: string[]) {
       useSyncFileSystemCalls: true,
       modules: [join(workspaceRoot, 'node_modules'), 'node_modules'],
       conditionNames: ['native', 'browser', 'require', 'default'],
+      mainFields: ['react-native', 'browser', 'main'],
     });
   }
   return resolver;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Pnpm resolver looks for the wrong package entry file.

Resolved path
`.../node_modules/.pnpm/supports-color@5.5.0/node_modules/supports-color/index.js`


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Should look for the entry file for browser env. 
`.../node_modules/.pnpm/supports-color@5.5.0/node_modules/supports-color/browser.js`

Add `mainFields` option solves this problem, option value respects the default value of metro [resolverMainFields](https://facebook.github.io/metro/docs/configuration/#resolvermainfields)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15763 #9743
