### PR TITLE
cleanup(angular): increase e2e test case timeout to account for slower windows runs

### DIFF
--- a/e2e/angular-core/src/module-federation.test.ts
+++ b/e2e/angular-core/src/module-federation.test.ts
@@ -129,7 +129,7 @@ describe('Angular Module Federation', () => {
 
     // port and process cleanup
     await killProcessAndPorts(process.pid, hostPort, remotePort);
-  }, 300000);
+  }, 20_000_000);
 
   it('should convert apps to MF successfully', async () => {
     const app1 = uniq('app1');


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

An E2E test case in the `e2e-angular-core` project fails on the Windows nightly runs due to a timeout (https://github.com/nrwl/nx/actions/runs/4548821575/jobs/8020534234#step:9:3268).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

All the E2E test cases in the `e2e-angular-core` succeed on the Windows nightly runs (the change was tested on a branch of my fork). The timeout was increased matching the timeouts the other test cases in the same suite have.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
