### PR TITLE
chore(repo): add Cypress cache to top-level install job

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -12,7 +12,7 @@ on:
         default: false
 
 env:
-  CYPRESS_CACHE_FOLDER: '.cypress'
+  CYPRESS_CACHE_FOLDER: ${{ github.workspace }}/.cypress
 
 permissions: {}
 jobs:
@@ -55,6 +55,18 @@ jobs:
       - name: Install packages
         if: steps.cache-modules.outputs.cache-hit != 'true'
         run: yarn install --prefer-offline --frozen-lockfile --non-interactive
+
+      - name: Cache Cypress
+        id: cache-cypress
+        uses: actions/cache@v3
+        with:
+          lookup-only: true
+          path: '${{ github.workspace }}/.cypress'
+          key: ${{ runner.os }}-cypress
+
+      - name: Install Cypress
+        if: steps.cache-cypress.outputs.cache-hit != 'true'
+        run: npx cypress install
 
   e2e:
     needs: preinstall
@@ -354,8 +366,12 @@ jobs:
         id: cache-cypress
         uses: actions/cache@v3
         with:
-          path: '.cypress'
+          path: '${{ github.workspace }}/.cypress'
           key: ${{ runner.os }}-cypress
+
+      - name: Install Cypress
+        if: steps.cache-cypress.outputs.cache-hit != 'true'
+        run: npx cypress install
 
       - name: Install applesimutils, reset ios simulators
         if: ${{ matrix.os == 'macos-latest' }}

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -12,7 +12,7 @@ on:
         default: false
 
 env:
-  CYPRESS_CACHE_FOLDER: '.cypress'
+  CYPRESS_CACHE_FOLDER: ${{ github.workspace }}/.cypress
 
 permissions: {}
 jobs:
@@ -45,6 +45,18 @@ jobs:
       - name: Install packages
         if: steps.cache-modules.outputs.cache-hit != 'true'
         run: yarn install --prefer-offline --frozen-lockfile --non-interactive
+
+      - name: Cache Cypress
+        id: cache-cypress
+        uses: actions/cache@v3
+        with:
+          lookup-only: true
+          path: '${{ github.workspace }}/.cypress'
+          key: windows-cypress
+
+      - name: Install Cypress
+        if: steps.cache-cypress.outputs.cache-hit != 'true'
+        run: npx cypress install
 
   e2e:
     needs: preinstall
@@ -266,9 +278,13 @@ jobs:
         id: cache-cypress
         uses: actions/cache@v3
         with:
-          path: '.cypress'
+          path: '${{ github.workspace }}/.cypress'
           key: ${{ runner.os }}-cypress
           
+      - name: Install Cypress
+        if: steps.cache-cypress.outputs.cache-hit != 'true'
+        run: npx cypress install
+
       - name: Configure git metadata (needed for lerna smoke tests)
         run: |
           git config --global user.email test@test.com


### PR DESCRIPTION
This PR updates `CYPRESS_CACHE_FOLDER` to be an absolute path so it still works when running Cypress e2e tests within our Nx e2e tests. Previously, it was set as `CYPRESS_CACHE_FOLDER=.cypress` which would resolve to something like `/tmp/nx-e2e/nx/<proj>/.cypress`, and since we do not cache this folder it would fail with `Cypress binary not found` error.

To make it more resilient, there is a `Install Cypress` task in the case that the cache isn't found. This step is skipped if the cache is found, and if cache misses _but_ package manager install (e.g. `npm install`) already downloaded the binary it would be a no-op.

Here's an example of a successful React nightly test run that was previously failing due to missing Cypress binary: https://github.com/nrwl/nx/actions/runs/4554668922/jobs/8032914216.

## Current Behavior
Nightly tests do not use correct Cypress cache location.

## Expected Behavior
Nightly tests work with cached Cypress install.