### PR TITLE
fix(webpack): web app in default nx config not working with @aws-sdk

### DIFF
--- a/packages/webpack/src/utils/with-web.ts
+++ b/packages/webpack/src/utils/with-web.ts
@@ -401,10 +401,7 @@ export function withWeb(pluginOptions: WithWebOptions = {}): NxWebpackPlugin {
 
     config.plugins.push(...plugins);
 
-    config.resolve.mainFields = [
-      'browser',
-      ...(config.resolve.mainFields ?? []),
-    ];
+    config.resolve.mainFields = ['browser', 'module', 'main'];
 
     config.module = {
       ...config.module,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
web apps created via default NX configurations won't work with [@aws-sdk](https://github.com/aws/aws-sdk-js-v3)

the reason is that all AWS SKD v3 packages define only partial entry via `browser`, and the rest via either `module` for browser, or `main` for node.js

with default NX `withWeb` settings, which inherit from `withNX` settings, the order will be `browser`, `main`, and `module`, in the case of AWS SDK, webpack will wrongly import most of the node.js packages instead of browser oriented packages.

I do not see a reason why this shouldn't be overwritten in `withWeb` config to let `module` takes priority. Thus the changes in this PR did it.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
should work with AWS SDK (and potentially other open source libraries uses similar strategy as AWS SDK

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
https://github.com/nrwl/nx/issues/14920

Fixes #14920
