### PR TITLE
docs(bundling): rspack executor mode

### DIFF
--- a/nx-dev/nx-dev/lib/rspack/schema/executors/dev-server.ts
+++ b/nx-dev/nx-dev/lib/rspack/schema/executors/dev-server.ts
@@ -18,6 +18,11 @@ export const schema = {
         type: 'number',
         description: 'The port to for the dev-server to listen on.',
       },
+      mode: {
+        type: 'string',
+        description: 'Mode to run the server in.',
+        enum: ['development', 'production', 'none'],
+      },
     },
     required: ['buildTarget'],
     presets: [],

--- a/nx-dev/nx-dev/lib/rspack/schema/executors/rspack.ts
+++ b/nx-dev/nx-dev/lib/rspack/schema/executors/rspack.ts
@@ -51,6 +51,11 @@ export const schema = {
           },
         ],
       },
+      mode: {
+        type: 'string',
+        description: 'Mode to run the build in.',
+        enum: ['development', 'production', 'none'],
+      },
       assets: {
         type: 'array',
         description: 'List of static application assets.',


### PR DESCRIPTION
`mode` option is available on `@nrwl/rspack` executors, but it's not documented
