### PR TITLE
fix(nextjs): ensure requred Next.js packages are always added to generated package.json

### DIFF
--- a/packages/next/src/executors/build/lib/update-package-json.ts
+++ b/packages/next/src/executors/build/lib/update-package-json.ts
@@ -12,9 +12,14 @@ export function updatePackageJson(
     packageJson.scripts.start = 'next start';
   }
 
-  const typescriptNode = context.projectGraph.externalNodes['npm:typescript'];
-  if (typescriptNode) {
-    packageJson.dependencies = packageJson.dependencies || {};
-    packageJson.dependencies['typescript'] = typescriptNode.data.version;
+  packageJson.dependencies ??= {};
+
+  // These are always required for a production Next.js app to run.
+  const requiredPackages = ['react', 'react-dom', 'next', 'typescript'];
+  for (const pkg of requiredPackages) {
+    const externalNode = context.projectGraph.externalNodes[`npm:${pkg}`];
+    if (externalNode) {
+      packageJson.dependencies[pkg] ??= externalNode.data.version;
+    }
   }
 }


### PR DESCRIPTION
This PR ensures that required packages are added to `dist/<proj>/package.json` when building Next.js apps.

It fixes an issue for pnpm nightly tests: 

- Broken: https://github.com/nrwl/nx/actions/runs/4554668922/jobs/8032925306
- Fixed (by PR): https://github.com/nrwl/nx/actions/runs/4557668792/jobs/8039770870