### PR TITLE
fix(storybook): install correct dependencies on storybook init when no framework specified

### DIFF
--- a/packages/storybook/src/generators/init/init.spec.ts
+++ b/packages/storybook/src/generators/init/init.spec.ts
@@ -390,6 +390,26 @@ describe('@nrwl/storybook:init', () => {
         nxJson.tasksRunnerOptions.default.options.cacheableOperations
       ).toContain('build-storybook');
     });
+
+    it('should not add any framework specific dependencies when no framework is specified', async () => {
+      await initGenerator(tree, { uiFramework: undefined });
+
+      // get the updated package.json
+      const packageJson = readJson(tree, 'package.json');
+
+      // check that only the following dependencies have been added
+      expect(Object.keys(packageJson.devDependencies)).toEqual([
+        '@nrwl/js',
+        '@nrwl/storybook',
+        '@storybook/addon-essentials',
+        '@storybook/builder-webpack5',
+        '@storybook/core-server',
+        '@storybook/manager-webpack5',
+        'html-webpack-plugin',
+        'prettier',
+        'typescript',
+      ]);
+    });
   });
 
   describe('update root tsconfig.json', () => {

--- a/packages/storybook/src/generators/init/init.ts
+++ b/packages/storybook/src/generators/init/init.ts
@@ -82,7 +82,7 @@ function checkDependenciesInstalled(host: Tree, schema: Schema) {
     // TODO(katerina): Remove when Storybook v7
     if (schema.uiFramework === '@storybook/react-native') {
       devDependencies['@storybook/react-native'] = storybookReactNativeVersion;
-    } else {
+    } else if (schema.uiFramework !== undefined) {
       devDependencies[schema.uiFramework] = storybookVersion;
     }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When installing @nrwl/storybook via Nx Console the @nrwl/storybook:init generator is automatically run. As a result `uiFramework` is given a value of "undefined". This results in the generator installing an NPM package called "undefined" which shouldn't happen.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
This should not add the specified `uiFramework` as a dependency if it is `undefined`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

