### PR TITLE
fix(core): hidden executor and generator options shouldn't be displayed in help text

### DIFF
--- a/packages/nx/src/utils/params.ts
+++ b/packages/nx/src/utils/params.ts
@@ -20,6 +20,7 @@ type PropertyDescription = {
   description?: string;
   format?: string;
   visible?: boolean;
+  hidden?: boolean;
   default?:
     | string
     | number

--- a/packages/nx/src/utils/print-help.ts
+++ b/packages/nx/src/utils/print-help.ts
@@ -242,11 +242,13 @@ function generateOptionsOutput(schema: Schema): string {
         : ''
     }`;
 
-    optionsToRender.set(optionName, {
-      renderedFlagAndAlias,
-      renderedDescription,
-      renderedTypesAndDefault,
-    });
+    optionConfig.hidden ??= optionConfig.visible === false;
+    if (!optionConfig.hidden)
+      optionsToRender.set(optionName, {
+        renderedFlagAndAlias,
+        renderedDescription,
+        renderedTypesAndDefault,
+      });
   }
 
   ui.div({


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
- Options which have `"hidden": true` or `"visible": false` in schema.json are still displayed.

## Expected Behavior
- Options which have `"hidden": true` or `"visible": false` in schema.json not displayed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
