### PR TITLE
fix(webpack): configure terser plugin with non-deprecated options for…

### DIFF
--- a/packages/webpack/src/utils/with-nx.ts
+++ b/packages/webpack/src/utils/with-nx.ts
@@ -211,12 +211,13 @@ export function withNx(pluginOptions?: WithNxOptions): NxWebpackPlugin {
                   keep_classnames: true,
                   ecma: 2020,
                   safari10: true,
-                  output: {
+                  format: {
                     ascii_only: true,
                     comments: false,
                     webkit: true,
                   },
                 },
+                extractComments: false,
               })
             : new TerserPlugin({
                 minify: TerserPlugin.swcMinify,


### PR DESCRIPTION
… tsc

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

the webpack plugin is currently using what looks like deprecated options for the terser webpack plugin (they have moved to `format` from `output` now).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

This moves the options to the right spot in the terser webpack plugin config and adds the `extractComments` flag set to false as it seems based on existing functionality the intention was to not include comments by default so I added the other flag as that is what the documentation has for that case: https://webpack.js.org/plugins/terser-webpack-plugin/#remove-comments

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
