### PR TITLE
fix(react): add missing dependencies

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,7 +36,9 @@
     "@nrwl/linter": "file:../linter",
     "@nrwl/workspace": "file:../workspace",
     "@phenomnomnominal/tsquery": "4.1.1",
+    "@svgr/webpack": "^6.1.2",
     "chalk": "^4.1.0",
+    "file-loader": "^6.2.0",
     "minimatch": "3.0.5"
   },
   "publishConfig": {


### PR DESCRIPTION
A couple of dependencies (`'file-loader` and `@svgr/webpack`) are used by the `withReact` webpack plugin, but they are missing in `@nrwl/react/package.json` so they might not be resolved if not hoisted to root `node_modules`. This PR adds those missing dependencies.