### PR TITLE
fix(misc): filter shared libraries by import name in module federation helpers

### DIFF
--- a/packages/angular/src/utils/mf/utils.ts
+++ b/packages/angular/src/utils/mf/utils.ts
@@ -60,7 +60,7 @@ export async function getModuleFederationConfig(
 
   if (mfConfig.shared) {
     dependencies.workspaceLibraries = dependencies.workspaceLibraries.filter(
-      (lib) => mfConfig.shared(lib.name, {})
+      (lib) => mfConfig.shared(lib.importKey, {})
     );
     dependencies.npmPackages = dependencies.npmPackages.filter((pkg) =>
       mfConfig.shared(pkg, {})

--- a/packages/react/src/module-federation/utils.ts
+++ b/packages/react/src/module-federation/utils.ts
@@ -40,7 +40,7 @@ export async function getModuleFederationConfig(
 
   if (mfConfig.shared) {
     dependencies.workspaceLibraries = dependencies.workspaceLibraries.filter(
-      (lib) => mfConfig.shared(lib.name, {})
+      (lib) => mfConfig.shared(lib.importKey, {})
     );
     dependencies.npmPackages = dependencies.npmPackages.filter((pkg) =>
       mfConfig.shared(pkg, {})


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The initial `shared` filter pass for workspace libraries uses the project name (e.g. `lib1`), while the second pass uses the import name (e.g. `@my-org/lib1`). This inconsistency causes the `shared` function logic to either be right for the first pass or the second, unless folks consider both possible names.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `shared` function should receive a consistent library name for its execution.

We're sticking with the import name because it's what's used by webpack Module Federation and was the original behavior before the first pass was added where the project name was wrongly used.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15975 
