### PR TITLE
fix(nextjs): adding "none" style option to next component generator

### DIFF
--- a/docs/generated/packages/next/generators/component.json
+++ b/docs/generated/packages/next/generators/component.json
@@ -57,7 +57,8 @@
             {
               "value": "styled-jsx",
               "label": "styled-jsx        [ https://www.npmjs.com/package/styled-jsx ]"
-            }
+            },
+            { "value": "none", "label": "None" }
           ]
         }
       },

--- a/packages/next/src/generators/component/schema.json
+++ b/packages/next/src/generators/component/schema.json
@@ -59,6 +59,10 @@
           {
             "value": "styled-jsx",
             "label": "styled-jsx        [ https://www.npmjs.com/package/styled-jsx ]"
+          },
+          {
+            "value": "none",
+            "label": "None"
           }
         ]
       }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

The React component generator has the option to choose "none" as a style option, particularly useful when using Tailwind. The Next.js component generator omits this option, even though the underlying React component generator allows it. This updates the generator schema to expose "none" as an option.

## Current Behavior
<!-- This is the behavior we have today -->
There is a "none" style option for the React component generator, but not the Next.js component generator.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
"None" should be supported in the Next.js generator.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
