### PR TITLE
fix(web): add migration for dropped dependencies

### DIFF
--- a/packages/web/migrations.json
+++ b/packages/web/migrations.json
@@ -53,6 +53,12 @@
       "version": "15.5.4-beta.0",
       "description": "Update `@nrwl/web/babel` preset to `@nrwl/js/babel` for projects that have a .babelrc file.",
       "factory": "./src/migrations/update-15-5-4/update-babel-preset"
+    },
+    "add-dropped-dependencies": {
+      "cli": "nx",
+      "version": "15.9.1",
+      "description": "Add @nrwl/linter, @nrwl/cypress, @nrwl/jest, @nrwl/rollup if they are used",
+      "factory": "./src/migrations/update-15-9-1/add-dropped-dependencies"
     }
   },
   "packageJsonUpdates": {

--- a/packages/web/src/migrations/update-15-9-1/add-dropped-dependencies.spec.ts
+++ b/packages/web/src/migrations/update-15-9-1/add-dropped-dependencies.spec.ts
@@ -1,0 +1,115 @@
+import {
+  addProjectConfiguration,
+  readJson,
+  Tree,
+  updateNxJson,
+} from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+
+import addDroppedDependencies from './add-dropped-dependencies';
+
+describe('addDroppedDependencies', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+
+    addProjectConfiguration(tree, 'project-with-no-targets', {
+      root: 'proj-with-no-targets',
+    });
+    addProjectConfiguration(tree, 'project-with-command', {
+      root: 'proj-with-command',
+      targets: {
+        run: {
+          command: 'echo hi',
+        },
+      },
+    });
+  });
+
+  it('should add rollup', async () => {
+    addProjectConfiguration(tree, 'rollup-project', {
+      root: 'rollup-proj',
+      targets: {
+        build: {
+          executor: '@nrwl/rollup:rollup',
+          options: {},
+        },
+      },
+    });
+
+    await addDroppedDependencies(tree);
+
+    expect(
+      readJson(tree, 'package.json').devDependencies['@nrwl/rollup']
+    ).toBeDefined();
+    expect(
+      readJson(tree, 'package.json').devDependencies['@nrwl/cypress']
+    ).not.toBeDefined();
+  });
+
+  it('should add cypress', async () => {
+    addProjectConfiguration(tree, 'cypress-project', {
+      root: 'cypress-proj',
+      targets: {
+        build: {
+          executor: '@nrwl/cypress:cypress',
+          options: {},
+        },
+      },
+    });
+
+    await addDroppedDependencies(tree);
+
+    expect(
+      readJson(tree, 'package.json').devDependencies['@nrwl/cypress']
+    ).toBeDefined();
+    expect(
+      readJson(tree, 'package.json').devDependencies['@nrwl/rollup']
+    ).not.toBeDefined();
+  });
+
+  it('should add linter', async () => {
+    addProjectConfiguration(tree, 'linter-project', {
+      root: 'linter-proj',
+      targets: {
+        build: {
+          executor: '@nrwl/linter:eslint',
+          options: {},
+        },
+      },
+    });
+
+    await addDroppedDependencies(tree);
+
+    expect(
+      readJson(tree, 'package.json').devDependencies['@nrwl/linter']
+    ).toBeDefined();
+    expect(
+      readJson(tree, 'package.json').devDependencies['@nrwl/cypress']
+    ).not.toBeDefined();
+  });
+
+  it('should add a dependency if it is used in nx.json', async () => {
+    updateNxJson(tree, {
+      targetDefaults: {
+        build: {
+          executor: '@nrwl/linter:eslint',
+          options: {},
+        },
+        test: {
+          options: {},
+        },
+      },
+    });
+
+    await addDroppedDependencies(tree);
+
+    expect(
+      readJson(tree, 'package.json').devDependencies['@nrwl/linter']
+    ).toBeDefined();
+    expect(
+      readJson(tree, 'package.json').devDependencies['@nrwl/cypress']
+    ).not.toBeDefined();
+  });
+});

--- a/packages/web/src/migrations/update-15-9-1/add-dropped-dependencies.ts
+++ b/packages/web/src/migrations/update-15-9-1/add-dropped-dependencies.ts
@@ -1,0 +1,49 @@
+import {
+  addDependenciesToPackageJson,
+  formatFiles,
+  getProjects,
+  NX_VERSION,
+  readNxJson,
+  Tree,
+} from '@nrwl/devkit';
+
+export default async function addDroppedDependencies(tree: Tree) {
+  const devDependencies = {};
+  const droppedDependencies = [
+    '@nrwl/linter',
+    '@nrwl/cypress',
+    '@nrwl/jest',
+    '@nrwl/rollup',
+  ];
+  const projects = getProjects(tree);
+
+  for (const [_, projectConfiguration] of projects) {
+    for (const [_, targetConfiguration] of Object.entries(
+      projectConfiguration.targets ?? {}
+    )) {
+      for (const droppedDependency of droppedDependencies) {
+        if (targetConfiguration.executor?.startsWith(droppedDependency + ':')) {
+          devDependencies[droppedDependency] = NX_VERSION;
+        }
+      }
+    }
+  }
+
+  const nxJson = readNxJson(tree);
+
+  for (const [_, targetConfiguration] of Object.entries(
+    nxJson?.targetDefaults ?? {}
+  )) {
+    for (const droppedDependency of droppedDependencies) {
+      if (targetConfiguration.executor?.startsWith(droppedDependency + ':')) {
+        devDependencies[droppedDependency] = NX_VERSION;
+      }
+    }
+  }
+
+  if (Object.keys(devDependencies).length > 0) {
+    addDependenciesToPackageJson(tree, {}, devDependencies);
+  }
+
+  await formatFiles(tree);
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Workspaces migrating from below 15.9.0 that do not have `@nrwl/rollup` but use it, will lose the `@nrwl/rollup` package.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Workspaces migrating from below 15.9.0 that do not have `@nrwl/rollup` but use it, will have it added.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15986
