### PR TITLE
docs(core): removed setting variable ci to true

### DIFF
--- a/docs/shared/monorepo-ci-gitlab.md
+++ b/docs/shared/monorepo-ci-gitlab.md
@@ -3,7 +3,7 @@
 Below is an example of a GitLab pipeline setup for an Nx workspace - building and testing only what is affected.
 
 ```yaml
-image: node:16
+image: node:18
 
 stages:
   - test
@@ -63,8 +63,6 @@ Read more about [Distributed Task Execution (DTE)](/core-features/distribute-tas
 
 ```yaml
 image: node:18
-variables:
-  CI: 'true'
 
 # Creating template for DTE agents
 .dte-agent:


### PR DESCRIPTION
Removed unnecessary setting of `CI=true`, since this is set on every job per default, see https://docs.gitlab.com/ee/ci/variables/predefined_variables.html

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
