### PR TITLE
docs(core): use proper NX_FILE_CHANGES env variable

### DIFF
--- a/docs/shared/recipes/workspace-watching.md
+++ b/docs/shared/recipes/workspace-watching.md
@@ -150,7 +150,7 @@ yarn nx -- watch --all -- echo %NX_PROJECT_NAME%
 To watch for specific projects and echo the changed files, run this command:
 
 ```shell
-nx watch --projects=app1,app2 -- echo \$NX_CHANGED_FILES
+nx watch --projects=app1,app2 -- echo \$NX_FILE_CHANGES
 ```
 
 ### Watching for dependent projects


### PR DESCRIPTION
Also mentioned this typo in the [Nx 15.4 blog post](https://blog.nrwl.io/nx-15-4-vite-4-support-a-new-nx-watch-command-and-more-77cbf6c9a711).

## Current Behavior
Nx watch documentation use `NX_CHANGED_FILES` environment variable

## Expected Behavior
Nx watch documentation should use `NX_FILE_CHANGES` environment variable
