### PR TITLE
fix(core): fix handling of legacy angular versions in nx init

### DIFF
--- a/packages/nx/src/nx-init/angular/legacy-angular-versions.ts
+++ b/packages/nx/src/nx-init/angular/legacy-angular-versions.ts
@@ -28,7 +28,7 @@ export async function getLegacyMigrationFunctionIfApplicable(
   const angularVersion =
     readModulePackageJson('@angular/core').packageJson.version;
   const majorAngularVersion = major(angularVersion);
-  if (majorAngularVersion > minMajorAngularVersionSupported) {
+  if (majorAngularVersion >= minMajorAngularVersionSupported) {
     // non-legacy
     return null;
   }
@@ -51,9 +51,14 @@ export async function getLegacyMigrationFunctionIfApplicable(
     legacyMigrationCommand = `ng g ${pkgName}:ng-add --preserve-angular-cli-layout`;
   } else {
     // use the latest Nx version that supported the Angular version
-    legacyMigrationCommand = `nx@${
+    pkgName = '@nrwl/angular';
+    pkgVersion = await resolvePackageVersion(
+      'nx',
       nxAngularLegacyVersionMap[majorAngularVersion]
-    } init ${process.argv.slice(2).join(' ')}`;
+    );
+    legacyMigrationCommand = `nx@${pkgVersion} init ${process.argv
+      .slice(2)
+      .join(' ')}`;
   }
 
   return async () => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `nx init` command is failing for Angular v14 workspaces.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `nx init` command works for Angular v14 workspaces.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15989 
