### PR TITLE
feat(core): recalculate affected graph projects in watch mode with git commits

### DIFF
--- a/graph/client/src/app/feature-projects/machines/interfaces.ts
+++ b/graph/client/src/app/feature-projects/machines/interfaces.ts
@@ -65,6 +65,11 @@ export type ProjectGraphMachineEvents =
       type: 'updateGraph';
       projects: ProjectGraphProjectNode[];
       dependencies: Record<string, ProjectGraphDependency[]>;
+      affectedProjects: string[];
+      workspaceLayout: {
+        libsDir: string;
+        appsDir: string;
+      };
     };
 
 // The context (extended state) of the machine

--- a/graph/client/src/app/feature-projects/machines/project-graph.machine.ts
+++ b/graph/client/src/app/feature-projects/machines/project-graph.machine.ts
@@ -254,10 +254,8 @@ export const projectGraphMachine = createMachine<
         //   name: 'route',
         // });
 
-        if (event.type === 'setProjects') {
-          ctx.workspaceLayout = event.workspaceLayout;
-          ctx.affectedProjects = event.affectedProjects;
-        }
+        ctx.workspaceLayout = event.workspaceLayout;
+        ctx.affectedProjects = event.affectedProjects;
       }),
       notifyGraphTracing: send(
         (ctx, event) => {

--- a/graph/client/src/app/feature-projects/projects-sidebar.tsx
+++ b/graph/client/src/app/feature-projects/projects-sidebar.tsx
@@ -307,6 +307,8 @@ export function ProjectsSidebar(): JSX.Element {
           type: 'updateGraph',
           projects: project.projects,
           dependencies: project.dependencies,
+          affectedProjects: project.affected,
+          workspaceLayout: selectedProjectRouteData.layout,
         });
       };
 

--- a/packages/nx/src/command-line/graph/command-object.ts
+++ b/packages/nx/src/command-line/graph/command-object.ts
@@ -9,5 +9,7 @@ export const yargsDepGraphCommand: CommandModule = {
   builder: (yargs) =>
     linkToNxDevAndExamples(withDepGraphOptions(yargs), 'dep-graph'),
   handler: async (args) =>
-    await (await import('./graph')).generateGraph(args as any, []),
+    await (
+      await import('./graph')
+    ).generateGraph(args as any, () => Promise.resolve([])),
 };

--- a/packages/nx/src/command-line/run-many/run-many.ts
+++ b/packages/nx/src/command-line/run-many/run-many.ts
@@ -56,7 +56,7 @@ export async function runMany(
         targets: nxArgs.targets,
         projects: projectNames,
       },
-      projectNames
+      () => Promise.resolve(projectNames)
     );
   } else {
     await runCommand(

--- a/packages/nx/src/utils/command-line-utils.ts
+++ b/packages/nx/src/utils/command-line-utils.ts
@@ -294,7 +294,7 @@ function getUntrackedFiles(): string[] {
   return parseGitOutput(`git ls-files --others --exclude-standard`);
 }
 
-function getMergeBase(base: string, head: string = 'HEAD') {
+export function getMergeBase(base: string, head: string = 'HEAD') {
   try {
     return execSync(`git merge-base "${base}" "${head}"`, {
       maxBuffer: TEN_MEGABYTES,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When running `nx affected:graph --watch` affected changes are not updated on the graph
 
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Affected projects should be recalculated in watch mode and if no --base or --head option has been passed in, any further git commits should be reflected in the graph.

https://user-images.githubusercontent.com/12140467/229098732-0d3509e7-65bc-4e28-9ae0-33a5c073d4c8.mp4


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
