### PR TITLE
chore(repo): change to new circleci mac resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,8 +44,9 @@ executors:
 
   macos:
     <<: *defaults
+    resource_class: macos.x86.medium.gen2
     macos:
-      xcode: &_XCODE_VERSION '13.0.0'
+      xcode: &_XCODE_VERSION '14.2.0'
 
 # -------------------------
 #        COMMANDS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ executors:
     <<: *defaults
     resource_class: macos.x86.medium.gen2
     macos:
-      xcode: &_XCODE_VERSION '14.2.0'
+      xcode: &_XCODE_VERSION '13.0.0'
 
 # -------------------------
 #        COMMANDS


### PR DESCRIPTION
The existing `medium` mac resource class has been deprecated in March and will be removed in October. The replacement is `macos.x86.medium.gen2`. The old `medium` supports Xcode up to 14.2 (dec 2022). The latest Xcode 14.3 only works on new machines.

Official info: https://discuss.circleci.com/t/macos-resource-deprecation-update/46891

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
