### PR TITLE
fix(bundling): pass tsConfig from project when --bundle=false so the correct file is applied

### DIFF
--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
@@ -71,6 +71,7 @@ export function buildEsbuildOptions(
       context.projectName,
       context,
       {
+        initialTsConfigFileName: options.tsConfig,
         initialEntryPoints: entryPoints,
         recursive: true,
       }
@@ -105,6 +106,7 @@ export function buildEsbuildOptions(
   } else {
     // Otherwise, just transpile the project source files. Any workspace lib will need to be published separately.
     esbuildOptions.entryPoints = getEntryPoints(context.projectName, context, {
+      initialTsConfigFileName: options.tsConfig,
       initialEntryPoints: entryPoints,
       recursive: false,
     });


### PR DESCRIPTION
This PR fixes edge cases where the tsconfig file is not one of the "usual" ones. For example, if a React projects sets up SSR then it might have a `tsconfig.server.json` file.

## Current Behavior

The project's `tsConfig` is not used.

## Expected Behavior
The project's `tsConfig` option is passed as the config used to find files to transpile (when `--bundle=false`).

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
