### PR TITLE
fix(repo): increase timeouts until we improve tests

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -125,9 +125,9 @@ jobs:
             os_name: 'MacOS'
           # test timeouts
           - os: ubuntu-latest
-            os_timeout: 30
-          - os: macos-latest
             os_timeout: 60
+          - os: macos-latest
+            os_timeout: 90
           # codeowner groups
           - project: e2e-add-nx-to-monorepo
             codeowners: 'S04SYHYKGNP'


### PR DESCRIPTION
Some tests are failing because they hit the timeout limit. Let's make those numbers pessimistic until we improve tests.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
