### PR TITLE
fix(angular): use @nrwl/web:file-server in serve-static targets

### DIFF
--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -487,7 +487,7 @@ Object {
       "executor": "@angular-devkit/build-angular:dev-server",
     },
     "serve-static": Object {
-      "executor": "@nrwl/angular:file-server",
+      "executor": "@nrwl/web:file-server",
       "options": Object {
         "buildTarget": "my-dir-my-app:build",
       },
@@ -645,7 +645,7 @@ Object {
       "executor": "@angular-devkit/build-angular:dev-server",
     },
     "serve-static": Object {
-      "executor": "@nrwl/angular:file-server",
+      "executor": "@nrwl/web:file-server",
       "options": Object {
         "buildTarget": "my-app:build",
       },

--- a/packages/angular/src/generators/application/lib/add-e2e.ts
+++ b/packages/angular/src/generators/application/lib/add-e2e.ts
@@ -1,18 +1,19 @@
+import { cypressProjectGenerator } from '@nrwl/cypress';
 import type { Tree } from '@nrwl/devkit';
-import type { NormalizedSchema } from './normalized-schema';
-
 import {
+  addDependenciesToPackageJson,
   readProjectConfiguration,
   updateProjectConfiguration,
 } from '@nrwl/devkit';
-import { cypressProjectGenerator } from '@nrwl/cypress';
+import { nxVersion } from '../../../utils/versions';
+import type { NormalizedSchema } from './normalized-schema';
 import { removeScaffoldedE2e } from './remove-scaffolded-e2e';
 
 export async function addE2e(tree: Tree, options: NormalizedSchema) {
   removeScaffoldedE2e(tree, options, options.ngCliSchematicE2ERoot);
 
   if (options.e2eTestRunner === 'cypress') {
-    // TODO: This can call `@nrwl/web:static-config` generator once we merge `@nrwl/angular:file-server` into `@nrwl/web:file-server`.
+    // TODO: This can call `@nrwl/web:static-config` generator when ready
     addFileServerTarget(tree, options, 'serve-static');
 
     await cypressProjectGenerator(tree, {
@@ -32,9 +33,11 @@ function addFileServerTarget(
   options: NormalizedSchema,
   targetName: string
 ) {
+  addDependenciesToPackageJson(tree, {}, { '@nrwl/web': nxVersion });
+
   const projectConfig = readProjectConfiguration(tree, options.name);
   projectConfig.targets[targetName] = {
-    executor: '@nrwl/angular:file-server',
+    executor: '@nrwl/web:file-server',
     options: {
       buildTarget: `${options.name}:build`,
       port: options.port,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The application generator creates the `serve-static` target with the non-existent `@nrwl/angular:file-server` executor.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The application generator should create the `serve-static` target with the `@nrwl/web:file-server` executor.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16005 
