### PR TITLE
fix: federation: dont default to esm

### DIFF
--- a/docs/generated/packages/webpack/documents/webpack-config-setup.md
+++ b/docs/generated/packages/webpack/documents/webpack-config-setup.md
@@ -173,7 +173,7 @@ module.exports = composePlugins(
       // your options here
     });
 
-    return merge(federatedModules(config, context), {
+    return merge(federatedModules(config, { options, context }), {
       // overwrite values here
     });
   }

--- a/docs/shared/packages/webpack/webpack-config-setup.md
+++ b/docs/shared/packages/webpack/webpack-config-setup.md
@@ -173,7 +173,7 @@ module.exports = composePlugins(
       // your options here
     });
 
-    return merge(federatedModules(config, context), {
+    return merge(federatedModules(config, { options, context }), {
       // overwrite values here
     });
   }


### PR DESCRIPTION
NX is breaking my builds due to the wrapper plugin here. Id not default to esm as module outputs are buggy and require several little config options to actually work correctly.

Can we please use var or window as default here?

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
