### PR TITLE
fix(js): remove thirdParty default so that package.json will be generated by default

### DIFF
--- a/docs/generated/packages/esbuild/executors/esbuild.json
+++ b/docs/generated/packages/esbuild/executors/esbuild.json
@@ -154,8 +154,7 @@
       },
       "thirdParty": {
         "type": "boolean",
-        "description": "Includes third-party packages in the bundle (i.e. npm packages).",
-        "default": true
+        "description": "Includes third-party packages in the bundle (i.e. npm packages)."
       },
       "dependenciesFieldType": {
         "type": "string",

--- a/packages/esbuild/src/executors/esbuild/lib/normalize.spec.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/normalize.spec.ts
@@ -43,6 +43,7 @@ describe('normalizeOptions', () => {
       outputFileName: 'index.js',
       singleEntry: true,
       external: [],
+      thirdParty: false,
     });
   });
 
@@ -69,6 +70,7 @@ describe('normalizeOptions', () => {
       additionalEntryPoints: ['apps/myapp/src/extra-entry.ts'],
       singleEntry: false,
       external: [],
+      thirdParty: false,
     });
   });
 
@@ -94,6 +96,7 @@ describe('normalizeOptions', () => {
       outputFileName: 'test.js',
       singleEntry: true,
       external: [],
+      thirdParty: false,
     });
   });
 
@@ -108,6 +111,7 @@ describe('normalizeOptions', () => {
           generatePackageJson: true,
           additionalEntryPoints: ['apps/myapp/src/extra-entry.ts'],
           outputFileName: 'test.js',
+          thirdParty: false,
         },
         context
       )
@@ -135,6 +139,24 @@ describe('normalizeOptions', () => {
       outputFileName: 'index.js',
       singleEntry: true,
       external: [],
+      thirdParty: false,
     });
+  });
+
+  it('should override thirdParty if bundle:false', () => {
+    expect(
+      normalizeOptions(
+        {
+          main: 'apps/myapp/src/index.ts',
+          outputPath: 'dist/apps/myapp',
+          tsConfig: 'apps/myapp/tsconfig.app.json',
+          generatePackageJson: true,
+          bundle: false,
+          thirdParty: true,
+          assets: [],
+        },
+        context
+      )
+    ).toEqual(expect.objectContaining({ thirdParty: false }));
   });
 });

--- a/packages/esbuild/src/executors/esbuild/lib/normalize.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/normalize.ts
@@ -3,7 +3,8 @@ import {
   EsBuildExecutorOptions,
   NormalizedEsBuildExecutorOptions,
 } from '../schema';
-import { ExecutorContext, joinPathFragments } from '@nrwl/devkit';
+import { ExecutorContext, joinPathFragments, logger } from '@nrwl/devkit';
+import chalk = require('chalk');
 
 export function normalizeOptions(
   options: EsBuildExecutorOptions,
@@ -20,6 +21,21 @@ export function normalizeOptions(
         ),
       ];
 
+  if (!options.bundle && options.thirdParty) {
+    logger.info(
+      chalk.yellow(
+        `Your build has conflicting options, ${chalk.bold(
+          'bundle:false'
+        )} and ${chalk.bold(
+          'thirdParty:true'
+        )}. Your package.json depedencies might not be generated correctly so we added an update ${chalk.bold(
+          'thirdParty:false'
+        )}`
+      )
+    );
+  }
+
+  const thirdParty = !options.bundle ? false : options.thirdParty;
   if (options.additionalEntryPoints?.length > 0) {
     const { outputFileName, ...rest } = options;
     if (outputFileName) {
@@ -29,6 +45,7 @@ export function normalizeOptions(
     }
     return {
       ...rest,
+      thirdParty,
       assets,
       external: options.external ?? [],
       singleEntry: false,
@@ -40,6 +57,7 @@ export function normalizeOptions(
   } else {
     return {
       ...options,
+      thirdParty,
       assets,
       external: options.external ?? [],
       singleEntry: true,

--- a/packages/esbuild/src/executors/esbuild/schema.json
+++ b/packages/esbuild/src/executors/esbuild/schema.json
@@ -129,8 +129,7 @@
     },
     "thirdParty": {
       "type": "boolean",
-      "description": "Includes third-party packages in the bundle (i.e. npm packages).",
-      "default": true
+      "description": "Includes third-party packages in the bundle (i.e. npm packages)."
     },
     "dependenciesFieldType": {
       "type": "string",


### PR DESCRIPTION
closed #15954
Remove the defaulted `--third-party=true`

If you provide `--third-party=true --bundle=false` you will now get a warning message


https://user-images.githubusercontent.com/338948/229179352-f629b6b8-841a-4a2e-835e-241b1a997485.mov

