### PR TITLE
fix(misc): create-nx-workspace should show some stdout if stderr empty on error

### DIFF
--- a/packages/create-nx-workspace/src/utils/child-process-utils.ts
+++ b/packages/create-nx-workspace/src/utils/child-process-utils.ts
@@ -33,7 +33,8 @@ export function execAndWait(command: string, cwd: string) {
         if (error) {
           const logFile = join(cwd, 'error.log');
           writeFileSync(logFile, `${stdout}\n${stderr}`);
-          rej(new CreateNxWorkspaceError(stderr, error.code, logFile));
+          const message = stderr && stderr.trim().length ? stderr : stdout;
+          rej(new CreateNxWorkspaceError(message, error.code, logFile));
         } else {
           res({ code: 0, stdout });
         }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
