### PR TITLE
fix(bundling): add missing @babel/core dependency to @nrwl/webpack

### DIFF
--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -29,6 +29,7 @@
     "migrations": "./migrations.json"
   },
   "dependencies": {
+    "@babel/core": "^7.15.0",
     "@nrwl/devkit": "file:../devkit",
     "@nrwl/js": "file:../js",
     "@nrwl/workspace": "file:../workspace",


### PR DESCRIPTION
Since `babel-loader` has a peer dependency on `@babel/core`, we need to make sure the version installed is correct. It was missing for `@nrwl/webpack` which leads to problems if the workspace has its own version installed.


## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15985
