### PR TITLE
feat(js): adding simpleName option to library generator

### DIFF
--- a/docs/generated/packages/js/generators/library.json
+++ b/docs/generated/packages/js/generators/library.json
@@ -127,6 +127,11 @@
         "type": "boolean",
         "description": "Generate a library with a minimal setup. No README.md generated.",
         "default": false
+      },
+      "simpleName": {
+        "description": "Don't include the directory in the generated file name.",
+        "type": "boolean",
+        "default": false
       }
     },
     "required": ["name"],

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -183,7 +183,6 @@ describe('lib', () => {
           name: 'myLib2',
           directory: 'myDir',
           tags: 'one,two',
-          simpleModuleName: true,
         });
         projects = Object.fromEntries(getProjects(tree));
         expect(projects).toMatchObject({
@@ -1145,6 +1144,22 @@ describe('lib', () => {
 
       const project = readProjectConfiguration(tree, 'my-lib');
       expect(project.targets.build.options.assets).toEqual([]);
+    });
+  });
+
+  describe('--simpleName', () => {
+    it('should generate a simple name', async () => {
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        name: 'myLib',
+        simpleName: true,
+        directory: 'web',
+      });
+
+      expect(tree.read('libs/web/my-lib/src/index.ts', 'utf-8')).toContain(
+        `export * from './lib/my-lib';`
+      );
+      expect(tree.exists('libs/web/my-lib/src/lib/my-lib.ts')).toBeTruthy();
     });
   });
 });

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -487,7 +487,7 @@ function normalizeOptions(
     ? name
     : projectDirectory.replace(new RegExp('/', 'g'), '-');
   const fileName = getCaseAwareFileName({
-    fileName: options.simpleModuleName ? name : projectName,
+    fileName: options.simpleName ? name : projectName,
     pascalCaseFiles: options.pascalCaseFiles,
   });
 

--- a/packages/js/src/generators/library/schema.json
+++ b/packages/js/src/generators/library/schema.json
@@ -127,6 +127,11 @@
       "type": "boolean",
       "description": "Generate a library with a minimal setup. No README.md generated.",
       "default": false
+    },
+    "simpleName": {
+      "description": "Don't include the directory in the generated file name.",
+      "type": "boolean",
+      "default": false
     }
   },
   "required": ["name"],

--- a/packages/js/src/utils/schema.d.ts
+++ b/packages/js/src/utils/schema.d.ts
@@ -11,7 +11,6 @@ export interface LibraryGeneratorSchema {
   directory?: string;
   skipFormat?: boolean;
   tags?: string;
-  simpleModuleName?: boolean;
   skipTsConfig?: boolean;
   includeBabelRc?: boolean;
   unitTestRunner?: 'jest' | 'vitest' | 'none';
@@ -30,6 +29,7 @@ export interface LibraryGeneratorSchema {
   skipTypeCheck?: boolean;
   minimal?: boolean;
   rootProject?: boolean;
+  simpleName?: boolean;
 }
 
 export interface ExecutorOptions {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Directory name is always included in the generate file name

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Add option to have a simple file name

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15564
