### PR TITLE
fix(nx-dev): adjust tab cmp spacing

### DIFF
--- a/nx-dev/ui-markdoc/src/lib/tags/tabs.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/tabs.component.tsx
@@ -15,7 +15,7 @@ export function Tabs({
 
   return (
     <TabContext.Provider value={currentTab}>
-      <section className="mb-8 py-4">
+      <section>
         <div className="not-prose ">
           <div className="border-b border-slate-100 dark:border-slate-800">
             <nav className="-mb-px flex space-x-8" aria-label="Tabs">


### PR DESCRIPTION
Optimizes spacing around the tab component.

Before:
![image](https://user-images.githubusercontent.com/542458/229239131-95984685-4b12-4fb7-bf7a-3a6d8d61eac5.png)

After:
![image](https://user-images.githubusercontent.com/542458/229239146-b78c0d33-b8ad-45e1-8ad0-3c801d658dd1.png)
