### PR TITLE
feat(core): allow local execution transpiler overriding with env var

### DIFF
--- a/docs/shared/reference/environment-variables.md
+++ b/docs/shared/reference/environment-variables.md
@@ -3,7 +3,7 @@
 The following environment variables are ones that you can set to change the behavior of Nx in different environments.
 
 | Property                         | Type    | Description                                                                                                                                                                                                                  |
-|----------------------------------| ------- |------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| -------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | NX_BASE                          | string  | The default base branch to use when calculating the affected projects. Can be overridden on the command line with `--base`.                                                                                                  |
 | NX_CACHE_DIRECTORY               | string  | The cache for task outputs is stored in `node_modules/.cache/nx` by default. Set this variable to use a different directory.                                                                                                 |
 | NX_CACHE_PROJECT_GRAPH           | boolean | If set to `false`, disables the project graph cache. Most useful when developing a plugin that modifies the project graph.                                                                                                   |

--- a/docs/shared/reference/environment-variables.md
+++ b/docs/shared/reference/environment-variables.md
@@ -3,7 +3,7 @@
 The following environment variables are ones that you can set to change the behavior of Nx in different environments.
 
 | Property                         | Type    | Description                                                                                                                                                                                                                  |
-| -------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------------------------| ------- |------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | NX_BASE                          | string  | The default base branch to use when calculating the affected projects. Can be overridden on the command line with `--base`.                                                                                                  |
 | NX_CACHE_DIRECTORY               | string  | The cache for task outputs is stored in `node_modules/.cache/nx` by default. Set this variable to use a different directory.                                                                                                 |
 | NX_CACHE_PROJECT_GRAPH           | boolean | If set to `false`, disables the project graph cache. Most useful when developing a plugin that modifies the project graph.                                                                                                   |
@@ -21,6 +21,7 @@ The following environment variables are ones that you can set to change the beha
 | NX_DRY_RUN                       | boolean | If set to `true`, will perform a dry run of the generator. No files will be created and no packages will be installed.                                                                                                       |
 | NX_INTERACTIVE                   | boolean | If set to `true`, will allow Nx to prompt you in the terminal to answer some further questions when running generators.                                                                                                      |
 | NX_GENERATE_QUIET                | boolean | If set to `true`, will prevent Nx logging file operations during generate                                                                                                                                                    |
+| NX_PREFER_TS_NODE                | boolean | If set to `true`, Nx will use ts-node for local execution of plugins even if `@swc-node/register` is installed.                                                                                                              |
 
 Nx will set the following environment variables so they can be accessible within the process even outside of executors and generators
 

--- a/packages/nx/src/utils/register.ts
+++ b/packages/nx/src/utils/register.ts
@@ -49,7 +49,7 @@ export function registerTranspiler(
   // Function to register transpiler that returns cleanup function
   let registerTranspiler: () => () => void;
 
-  const preferTsNode = process.env.NX_TS_NODE_LOCAL_EXECUTION === 'true';
+  const preferTsNode = process.env.NX_PREFER_TS_NODE === 'true';
 
   if (swcNodeInstalled && !preferTsNode) {
     // These are requires to prevent it from registering when it shouldn't

--- a/packages/nx/src/utils/register.ts
+++ b/packages/nx/src/utils/register.ts
@@ -49,14 +49,16 @@ export function registerTranspiler(
   // Function to register transpiler that returns cleanup function
   let registerTranspiler: () => () => void;
 
-  if (swcNodeInstalled) {
+  const preferTsNode = process.env.NX_TS_NODE_LOCAL_EXECUTION === 'true';
+
+  if (swcNodeInstalled && !preferTsNode) {
     // These are requires to prevent it from registering when it shouldn't
     const { register } =
       require('@swc-node/register/register') as typeof import('@swc-node/register/register');
 
     registerTranspiler = () => register(compilerOptions);
   } else {
-    // We can fall back on ts-node if its available
+    // We can fall back on ts-node if it's available
 
     if (tsNodeInstalled) {
       const { register } = require('ts-node') as typeof import('ts-node');


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Currently the transpiler being picked for local execution is entirely depending on if `@swc-node/register'` is installed or not. While this works for the overwhelmingly large majority of cases there are times when we may want to force the transpiling to use ts-node even though swc-node is installed. For example in our CI, we use CircleCI arm64 resources to run all of our build steps (as they end up cheaper than the x86/amd64 resources) except for when we dockerize our servers, we dockerize our servers on x86 Docker containers (since they are being deployed to x86 servers so we can't* build them on arm resources). This means that if we have `@swc-node/register` installed then when our dependencies are installed on arm resources we have arm swc native code compiled which doesn't run when we call local executions in our step that dockerizes (since its x86 and we do not have x86 swc compiled binaries).

* we COULD but I was not able to get building for a different architecture working with docker regardless of what I tried.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

This PR would allow us to set an env var to tell Nx to use `ts-node` even though swc-register is installed. This allows us to have local executions happening for all cases it can work, like dev'ing locally, or on most of our CI steps, but then set it to ts-node when we know we need it to fallback.

There may be another way to get around this I am missing so if there is I am more than happy to close this and do that!

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
