### PR TITLE
feat(core): allow environment based .env files to be loaded

### DIFF
--- a/docs/generated/cli/affected.md
+++ b/docs/generated/cli/affected.md
@@ -91,6 +91,14 @@ Type: `string`
 
 This is the configuration to use when performing tasks on projects
 
+### environment
+
+Type: `string`
+
+Default: `local`
+
+This is the environment name to use when loading env files
+
 ### exclude
 
 Type: `string`

--- a/docs/generated/cli/exec.md
+++ b/docs/generated/cli/exec.md
@@ -23,6 +23,14 @@ Type: `string`
 
 This is the configuration to use when performing tasks on projects
 
+### environment
+
+Type: `string`
+
+Default: `local`
+
+This is the environment name to use when loading env files
+
 ### exclude
 
 Type: `string`

--- a/docs/generated/cli/print-affected.md
+++ b/docs/generated/cli/print-affected.md
@@ -61,6 +61,14 @@ Type: `string`
 
 This is the configuration to use when performing tasks on projects
 
+### environment
+
+Type: `string`
+
+Default: `local`
+
+This is the environment name to use when loading env files
+
 ### exclude
 
 Type: `string`

--- a/docs/generated/cli/run-many.md
+++ b/docs/generated/cli/run-many.md
@@ -75,6 +75,14 @@ Type: `string`
 
 This is the configuration to use when performing tasks on projects
 
+### environment
+
+Type: `string`
+
+Default: `local`
+
+This is the environment name to use when loading env files
+
 ### exclude
 
 Type: `string`

--- a/docs/generated/packages/nx/documents/affected.md
+++ b/docs/generated/packages/nx/documents/affected.md
@@ -91,6 +91,14 @@ Type: `string`
 
 This is the configuration to use when performing tasks on projects
 
+### environment
+
+Type: `string`
+
+Default: `local`
+
+This is the environment name to use when loading env files
+
 ### exclude
 
 Type: `string`

--- a/docs/generated/packages/nx/documents/exec.md
+++ b/docs/generated/packages/nx/documents/exec.md
@@ -23,6 +23,14 @@ Type: `string`
 
 This is the configuration to use when performing tasks on projects
 
+### environment
+
+Type: `string`
+
+Default: `local`
+
+This is the environment name to use when loading env files
+
 ### exclude
 
 Type: `string`

--- a/docs/generated/packages/nx/documents/print-affected.md
+++ b/docs/generated/packages/nx/documents/print-affected.md
@@ -61,6 +61,14 @@ Type: `string`
 
 This is the configuration to use when performing tasks on projects
 
+### environment
+
+Type: `string`
+
+Default: `local`
+
+This is the environment name to use when loading env files
+
 ### exclude
 
 Type: `string`

--- a/docs/generated/packages/nx/documents/run-many.md
+++ b/docs/generated/packages/nx/documents/run-many.md
@@ -75,6 +75,14 @@ Type: `string`
 
 This is the configuration to use when performing tasks on projects
 
+### environment
+
+Type: `string`
+
+Default: `local`
+
+This is the environment name to use when loading env files
+
 ### exclude
 
 Type: `string`

--- a/docs/shared/guides/define-environment-variables.md
+++ b/docs/shared/guides/define-environment-variables.md
@@ -13,15 +13,15 @@ By default, Nx will load any environment variables you place in the following fi
 2. `apps/my-app/.[target-name].[configuration-name].env`
 3. `apps/my-app/.env.[target-name]`
 4. `apps/my-app/.[target-name].env`
-5. `apps/my-app/.env.local`
-6. `apps/my-app/.local.env`
+5. `apps/my-app/.env.[environment-name]`
+6. `apps/my-app/.[environment-name].env`
 7. `apps/my-app/.env`
 8. `.env.[target-name].[configuration-name]`
 9. `.[target-name].[configuration-name].env`
 10. `.env.[target-name]`
 11. `.[target-name].env`
-12. `.local.env`
-13. `.env.local`
+12. `.[environment-name].env`
+13. `.env.[environment-name]`
 14. `.env`
 
 {% callout type="warning" title="Order is important" %}
@@ -29,17 +29,16 @@ Nx will move through the above list, ignoring files it can't find, and loading e
 into the current process for the ones it can find. If it finds a variable that has already been loaded into the process,
 it will ignore it. It does this for two reasons:
 
-1. Developers can't accidentally overwrite important system level variables (like `NODE_ENV`)
-2. Allows developers to create `.env.local` or `.local.env` files for their local environment and override any project
-   defaults set in `.env`
-3. Allows developers to create target specific `.env.[target-name]` or `.[target-name].env` to overwrite environment variables for specific targets. For instance, you could increase the memory use for node processes only for build targets by setting `NODE_OPTIONS=--max-old-space-size=4096` in `.build.env`
+1. Protects important system-level variables, such as `NODE_ENV`, from being accidentally overwritten by developers.
+2. Enables the creation of `.env.local` or `.local.env` files for local environments, which can override project defaults set in `.env`.
+3. Supports the use of `.env.[environment-name]` or `.[environment-name].env` files to manage environment-specific configurations. If `-e [environment-name]` is not passed when the `nx` command is run, `[environment-name]` will default to `local`.
+4. Allows developers to create target specific `.env.[target-name]` or `.[target-name].env` files to overwrite environment variables for specific targets. For instance, you could increase the memory use for node processes only for build targets by setting `NODE_OPTIONS=--max-old-space-size=4096` in `.build.env`.
 
 For example:
 
 1. `apps/my-app/.env.local` contains `NX_API_URL=http://localhost:3333`
 2. `apps/my-app/.env` contains `NX_API_URL=https://api.example.com`
-3. Nx will first load the variables from `apps/my-app/.env.local` into the process. When it tries to load the variables
-   from `apps/my-app/.env`, it will notice that `NX_API_URL` already exists, so it will ignore it.
+3. Nx will first load the variables from `apps/my-app/.env.local` into the process. When it tries to load the variables from `apps/my-app/.env`, it will notice that `NX_API_URL` already exists, so it will ignore it.
 
 We recommend nesting your **app** specific `env` files in `apps/your-app`, and creating workspace/root level `env` files
 for workspace-specific settings (like the [Nx Cloud token](/core-features/share-your-cache)).

--- a/packages/nx/src/command-line/affected/print-affected.ts
+++ b/packages/nx/src/command-line/affected/print-affected.ts
@@ -79,6 +79,7 @@ async function createTasks(
             p.getId(affectedProject.name, target, resolvedConfiguration),
             affectedProject,
             target,
+            nxArgs.environment,
             resolvedConfiguration,
             overrides
           )

--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -638,6 +638,7 @@ function getAllTaskGraphsForWorkspace(projectGraph: ProjectGraph): {
           [projectName],
           [target],
           undefined,
+          undefined,
           {}
         );
       } catch (err) {
@@ -663,6 +664,7 @@ function getAllTaskGraphsForWorkspace(projectGraph: ProjectGraph): {
               defaultDependencyConfigs,
               [projectName],
               [target],
+              undefined,
               configuration,
               {}
             );
@@ -742,6 +744,7 @@ function createJsonOutput(
       defaultDependencyConfigs,
       projects,
       targets,
+      undefined,
       undefined,
       {}
     );

--- a/packages/nx/src/command-line/run-many/command-object.ts
+++ b/packages/nx/src/command-line/run-many/command-object.ts
@@ -5,6 +5,7 @@ import {
   withOutputStyleOption,
   withTargetAndConfigurationOption,
   withOverrides,
+  withEnvironment,
 } from '../yargs-utils/shared-options';
 
 export const yargsRunManyCommand: CommandModule = {

--- a/packages/nx/src/command-line/yargs-utils/shared-options.ts
+++ b/packages/nx/src/command-line/yargs-utils/shared-options.ts
@@ -87,11 +87,20 @@ export function withTargetAndConfigurationOption(
 }
 
 export function withConfiguration(yargs: Argv) {
-  return yargs.options('configuration', {
+  return withEnvironment(yargs).options('configuration', {
     describe:
       'This is the configuration to use when performing tasks on projects',
     type: 'string',
     alias: 'c',
+  });
+}
+
+export function withEnvironment(yargs: Argv) {
+  return yargs.options('environment', {
+    describe: 'This is the environment name to use when loading env files',
+    default: 'local',
+    type: 'string',
+    alias: 'e',
   });
 }
 

--- a/packages/nx/src/config/task-graph.ts
+++ b/packages/nx/src/config/task-graph.ts
@@ -19,6 +19,11 @@ export interface Task {
      */
     target: string;
     /**
+     * The environment name to use when loading env files for the task.
+     * Defaults to 'local' if not provided.
+     */
+    environment?: string;
+    /**
      * The configuration of the target which the task invokes
      */
     configuration?: string;

--- a/packages/nx/src/tasks-runner/create-task-graph.spec.ts
+++ b/packages/nx/src/tasks-runner/create-task-graph.spec.ts
@@ -73,6 +73,7 @@ describe('createTaskGraph', () => {
       {},
       [],
       ['test'],
+      undefined,
       'development',
       {}
     );
@@ -90,6 +91,7 @@ describe('createTaskGraph', () => {
       {},
       ['app1'],
       ['test'],
+      undefined,
       'development',
       {
         a: 123,
@@ -118,6 +120,7 @@ describe('createTaskGraph', () => {
       {},
       ['app1', 'lib1'],
       ['test'],
+      undefined,
       'development',
       {
         a: 123,
@@ -230,6 +233,7 @@ describe('createTaskGraph', () => {
       {},
       ['lib1'],
       ['build'],
+      undefined,
       null,
       {}
     );
@@ -270,6 +274,7 @@ describe('createTaskGraph', () => {
       {},
       ['app1'],
       ['build'],
+      'local',
       'ci',
       {}
     );
@@ -282,6 +287,7 @@ describe('createTaskGraph', () => {
           target: {
             project: 'app1',
             target: 'build',
+            environment: 'local',
             configuration: 'ci',
           },
           overrides: {},
@@ -292,6 +298,7 @@ describe('createTaskGraph', () => {
           target: {
             project: 'lib1',
             target: 'build',
+            environment: 'local',
             configuration: 'libDefault',
           },
           overrides: {
@@ -304,6 +311,7 @@ describe('createTaskGraph', () => {
           target: {
             project: 'lib2',
             target: 'build',
+            environment: 'local',
             configuration: 'ci',
           },
           overrides: {
@@ -390,6 +398,7 @@ describe('createTaskGraph', () => {
       {},
       ['app1'],
       ['build'],
+      undefined,
       null,
       {}
     );
@@ -431,6 +440,7 @@ describe('createTaskGraph', () => {
       {},
       ['app1'],
       ['test'],
+      undefined,
       'development',
       {
         a: '--value={project.root}',
@@ -461,6 +471,7 @@ describe('createTaskGraph', () => {
       {},
       ['app1'],
       ['test'],
+      undefined,
       'development',
       {
         a: '--base-href=/{projectRoot}${deploymentId}',
@@ -573,6 +584,7 @@ describe('createTaskGraph', () => {
       {},
       ['app1'],
       ['build'],
+      undefined,
       'development',
       {
         myFlag: 'flag value',
@@ -634,6 +646,7 @@ describe('createTaskGraph', () => {
       {},
       ['app1'],
       ['build'],
+      undefined,
       'development',
       {
         __overrides_unparsed__: [],
@@ -703,6 +716,7 @@ describe('createTaskGraph', () => {
       {},
       ['app1', 'lib1'],
       ['build', 'prebuild'],
+      undefined,
       'development',
       {
         __overrides_unparsed__: [],
@@ -841,6 +855,7 @@ describe('createTaskGraph', () => {
       },
       ['app1'],
       ['build'],
+      undefined,
       'development',
       {
         __overrides_unparsed__: [],
@@ -1000,6 +1015,7 @@ describe('createTaskGraph', () => {
       },
       ['infra1'],
       ['apply'],
+      undefined,
       'development',
       {
         myFlag: 'flag value',
@@ -1085,6 +1101,7 @@ describe('createTaskGraph', () => {
       {},
       ['app1'],
       ['build'],
+      undefined,
       'development',
       {
         __overrides_unparsed__: [],
@@ -1177,6 +1194,7 @@ describe('createTaskGraph', () => {
       },
       ['app1'],
       ['build'],
+      undefined,
       'development',
       {
         __overrides_unparsed__: [],
@@ -1265,6 +1283,7 @@ describe('createTaskGraph', () => {
       },
       ['app1'],
       ['build'],
+      undefined,
       'development',
       {
         __overrides_unparsed__: [],
@@ -1349,6 +1368,7 @@ describe('createTaskGraph', () => {
       {},
       ['app1'],
       ['build'],
+      undefined,
       'development',
       {
         __overrides_unparsed__: [],
@@ -1381,6 +1401,7 @@ describe('createTaskGraph', () => {
       {},
       ['app1', 'app2'],
       ['build'],
+      undefined,
       'development',
       {
         __overrides_unparsed__: [],
@@ -1466,7 +1487,15 @@ describe('createTaskGraph', () => {
         app1: [],
       },
     };
-    const taskGraph = createTaskGraph(graph, {}, ['app1'], ['build'], null, {});
+    const taskGraph = createTaskGraph(
+      graph,
+      {},
+      ['app1'],
+      ['build'],
+      undefined,
+      null,
+      {}
+    );
     expect(taskGraph.tasks).toHaveProperty('app1:build');
     expect(taskGraph.tasks).toHaveProperty('lib1:build');
     expect(taskGraph.tasks).toHaveProperty('lib2:build');

--- a/packages/nx/src/tasks-runner/create-task-graph.ts
+++ b/packages/nx/src/tasks-runner/create-task-graph.ts
@@ -23,6 +23,7 @@ export class ProcessTasks {
   processTasks(
     projectNames: string[],
     targets: string[],
+    environment: string,
     configuration: string,
     overrides: Object,
     excludeTaskDependencies: boolean
@@ -41,6 +42,7 @@ export class ProcessTasks {
             id,
             project,
             target,
+            environment,
             resolvedConfiguration,
             overrides
           );
@@ -55,7 +57,13 @@ export class ProcessTasks {
 
     for (const taskId of Object.keys(this.tasks)) {
       const task = this.tasks[taskId];
-      this.processTask(task, task.target.project, configuration, overrides);
+      this.processTask(
+        task,
+        task.target.project,
+        environment,
+        configuration,
+        overrides
+      );
     }
 
     if (excludeTaskDependencies) {
@@ -88,6 +96,7 @@ export class ProcessTasks {
   processTask(
     task: Task,
     projectUsedToDeriveDependencies: string,
+    environment: string,
     configuration: string,
     overrides: Object
   ) {
@@ -111,6 +120,7 @@ export class ProcessTasks {
         this.processTasksForMatchingProjects(
           dependencyConfig,
           projectUsedToDeriveDependencies,
+          environment,
           configuration,
           task,
           taskOverrides,
@@ -120,6 +130,7 @@ export class ProcessTasks {
         this.processTasksForDependencies(
           projectUsedToDeriveDependencies,
           dependencyConfig,
+          environment,
           configuration,
           task,
           taskOverrides,
@@ -130,6 +141,7 @@ export class ProcessTasks {
           task,
           task.target.project,
           dependencyConfig,
+          environment,
           configuration,
           taskOverrides,
           overrides
@@ -141,6 +153,7 @@ export class ProcessTasks {
   private processTasksForMatchingProjects(
     dependencyConfig: TargetDependencyConfig,
     projectUsedToDeriveDependencies: string,
+    environment: string,
     configuration: string,
     task: Task,
     taskOverrides: Object | { __overrides_unparsed__: any[] },
@@ -161,6 +174,7 @@ export class ProcessTasks {
         this.processTasksForDependencies(
           projectUsedToDeriveDependencies,
           dependencyConfig,
+          environment,
           configuration,
           task,
           taskOverrides,
@@ -192,6 +206,7 @@ export class ProcessTasks {
             task,
             projectName,
             dependencyConfig,
+            environment,
             configuration,
             taskOverrides,
             overrides
@@ -205,6 +220,7 @@ export class ProcessTasks {
     task: Task,
     projectName: string,
     dependencyConfig: TargetDependencyConfig,
+    environment: string,
     configuration: string,
     taskOverrides: Object | { __overrides_unparsed__: any[] },
     overrides: Object
@@ -232,6 +248,7 @@ export class ProcessTasks {
           selfTaskId,
           selfProject,
           dependencyConfig.target,
+          environment,
           resolvedConfiguration,
           taskOverrides
         );
@@ -240,6 +257,7 @@ export class ProcessTasks {
         this.processTask(
           newTask,
           newTask.target.project,
+          environment,
           configuration,
           overrides
         );
@@ -250,6 +268,7 @@ export class ProcessTasks {
   private processTasksForDependencies(
     projectUsedToDeriveDependencies: string,
     dependencyConfig: TargetDependencyConfig,
+    environment: string,
     configuration: string,
     task: Task,
     taskOverrides: Object | { __overrides_unparsed__: any[] },
@@ -285,6 +304,7 @@ export class ProcessTasks {
             depTargetId,
             depProject,
             dependencyConfig.target,
+            environment,
             resolvedConfiguration,
             taskOverrides
           );
@@ -294,12 +314,19 @@ export class ProcessTasks {
           this.processTask(
             newTask,
             newTask.target.project,
+            environment,
             configuration,
             overrides
           );
         }
       } else {
-        this.processTask(task, depProject.name, configuration, overrides);
+        this.processTask(
+          task,
+          depProject.name,
+          environment,
+          configuration,
+          overrides
+        );
       }
     }
   }
@@ -308,6 +335,7 @@ export class ProcessTasks {
     id: string,
     project: ProjectGraphProjectNode,
     target: string,
+    environment: string | undefined,
     resolvedConfiguration: string | undefined,
     overrides: Object
   ): Task {
@@ -326,6 +354,7 @@ export class ProcessTasks {
     const qualifiedTarget = {
       project: project.name,
       target,
+      environment,
       configuration: resolvedConfiguration,
     };
 
@@ -368,6 +397,7 @@ export function createTaskGraph(
   defaultDependencyConfigs: TargetDependencies,
   projectNames: string[],
   targets: string[],
+  environment: string | undefined,
   configuration: string | undefined,
   overrides: Object,
   excludeTaskDependencies: boolean = false
@@ -376,6 +406,7 @@ export function createTaskGraph(
   const roots = p.processTasks(
     projectNames,
     targets,
+    environment,
     configuration,
     overrides,
     excludeTaskDependencies

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -110,6 +110,7 @@ function createTaskGraphAndValidateCycles(
     defaultDependencyConfigs,
     projectNames,
     nxArgs.targets,
+    nxArgs.environment,
     nxArgs.configuration,
     overrides,
     extraOptions.excludeTaskDependencies

--- a/packages/nx/src/utils/command-line-utils.ts
+++ b/packages/nx/src/utils/command-line-utils.ts
@@ -13,6 +13,7 @@ export interface RawNxArgs extends NxArgs {
 
 export interface NxArgs {
   targets?: string[];
+  environment?: string;
   configuration?: string;
   runner?: string;
   parallel?: number;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Currently, NX allows you to load `.env` files based on a list of [different configurations](https://nx.dev/recipes/environment-variables/define-environment-variables), but it does not provide a way to override the `local` environment name with a user-defined environment name.

## Expected Behavior
This PR introduces the ability to load `.env` files based on a user-defined `[environment-name]`, with the default being `local`. This enhancement provides a more streamlined approach to managing configurations across all targets.

The `-e` and `--environment` flags have been added to allow users to specify a custom environment name when running NX commands. These flags provide greater flexibility and control over environment configurations, simplifying the management of different environments across all targets in NX projects.

It is important to note that this change does not affect the existing `.env` file [loading order](https://nx.dev/recipes/environment-variables/define-environment-variables). The update merely allows for the replacement of `local` with a custom string, offering flexibility while maintaining compatibility with existing configurations.

The updated list of supported `.env` files is as follows:

```
- apps/my-app/.env.[target-name].[configuration-name]
- apps/my-app/.[target-name].[configuration-name].env
- apps/my-app/.env.[target-name]
- apps/my-app/.[target-name].env
- apps/my-app/.env.[environment-name]
- apps/my-app/.[environment-name].env
- apps/my-app/.env
- .env.[target-name].[configuration-name]
- .[target-name].[configuration-name].env
- .env.[target-name]
- .[target-name].env
- .[environment-name].env
- .env.[environment-name]
- .env
```

## Example

```
# Reads from .env.local or apps/my-app/.env.local
nx build my-app
# Reads from .env.beta or apps/my-app/.env.beta
nx build my-app -e beta
nx build my-app --environment beta
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/15130
