### PR TITLE
feat(misc): bump tsquery dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@nrwl/web": "15.9.0-rc.1",
     "@nrwl/webpack": "15.9.0-rc.1",
     "@parcel/watcher": "2.0.4",
-    "@phenomnomnominal/tsquery": "4.1.1",
+    "@phenomnomnominal/tsquery": "~5.0.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",
     "@pnpm/lockfile-types": "^5.0.0",
     "@reduxjs/toolkit": "1.9.0",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -43,7 +43,7 @@
     "@nrwl/linter": "file:../linter",
     "@nrwl/webpack": "file:../webpack",
     "@nrwl/workspace": "file:../workspace",
-    "@phenomnomnominal/tsquery": "4.1.1",
+    "@phenomnomnominal/tsquery": "~5.0.1",
     "chalk": "^4.1.0",
     "chokidar": "^3.5.1",
     "http-server": "^14.1.0",

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -38,7 +38,7 @@
     "@nrwl/js": "file:../js",
     "@nrwl/linter": "file:../linter",
     "@nrwl/workspace": "file:../workspace",
-    "@phenomnomnominal/tsquery": "4.1.1",
+    "@phenomnomnominal/tsquery": "~5.0.1",
     "dotenv": "~10.0.0",
     "semver": "7.3.4",
     "detect-port": "^1.5.1"

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -38,7 +38,7 @@
     "@jest/test-result": "28.1.1",
     "@nrwl/devkit": "file:../devkit",
     "@nrwl/js": "file:../js",
-    "@phenomnomnominal/tsquery": "4.1.1",
+    "@phenomnomnominal/tsquery": "~5.0.1",
     "chalk": "^4.1.0",
     "dotenv": "~10.0.0",
     "identity-obj-proxy": "3.0.0",

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -41,7 +41,7 @@
     "@babel/runtime": "^7.14.8",
     "@nrwl/devkit": "file:../devkit",
     "@nrwl/workspace": "file:../workspace",
-    "@phenomnomnominal/tsquery": "4.1.1",
+    "@phenomnomnominal/tsquery": "~5.0.1",
     "babel-plugin-const-enum": "^1.0.1",
     "babel-plugin-macros": "^2.8.0",
     "babel-plugin-transform-typescript-metadata": "^0.3.1",

--- a/packages/linter/package.json
+++ b/packages/linter/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@nrwl/devkit": "file:../devkit",
     "@nrwl/js": "file:../js",
-    "@phenomnomnominal/tsquery": "4.1.1",
+    "@phenomnomnominal/tsquery": "~5.0.1",
     "tmp": "~0.2.1",
     "tslib": "^2.3.0"
   },

--- a/packages/nx-plugin/package.json
+++ b/packages/nx-plugin/package.json
@@ -32,7 +32,7 @@
     "@nrwl/jest": "file:../jest",
     "@nrwl/js": "file:../js",
     "@nrwl/linter": "file:../linter",
-    "@phenomnomnominal/tsquery": "4.1.1",
+    "@phenomnomnominal/tsquery": "~5.0.1",
     "dotenv": "~10.0.0",
     "fs-extra": "^11.1.0",
     "tslib": "^2.3.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -35,7 +35,7 @@
     "@nrwl/js": "file:../js",
     "@nrwl/linter": "file:../linter",
     "@nrwl/workspace": "file:../workspace",
-    "@phenomnomnominal/tsquery": "4.1.1",
+    "@phenomnomnominal/tsquery": "~5.0.1",
     "@svgr/webpack": "^6.1.2",
     "chalk": "^4.1.0",
     "file-loader": "^6.2.0",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -37,7 +37,7 @@
     "@nrwl/workspace": "file:../workspace",
     "dotenv": "~10.0.0",
     "enquirer": "~2.3.6",
-    "@phenomnomnominal/tsquery": "4.1.1",
+    "@phenomnomnominal/tsquery": "~5.0.1",
     "semver": "7.3.4"
   },
   "publishConfig": {

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -32,7 +32,7 @@
     "@nrwl/devkit": "file:../devkit",
     "@nrwl/workspace": "file:../workspace",
     "@nrwl/js": "file:../js",
-    "@phenomnomnominal/tsquery": "4.1.1",
+    "@phenomnomnominal/tsquery": "~5.0.1",
     "@swc/helpers": "^0.4.11",
     "dotenv": "~10.0.0",
     "enquirer": "~2.3.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5694,6 +5694,13 @@
   dependencies:
     esquery "^1.0.1"
 
+"@phenomnomnominal/tsquery@~5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@phenomnomnominal/tsquery/-/tsquery-5.0.1.tgz#a2a5abc89f92c01562a32806655817516653a388"
+  integrity sha512-3nVv+e2FQwsW8Aw6qTU6f+1rfcJ3hrcnvH/mu9i8YhxO+9sqbOfpL8m6PbET5+xKOlz/VSbp0RoYWYCtIsnmuA==
+  dependencies:
+    esquery "^1.4.0"
+
 "@pkgr/utils@^2.3.1":
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/@pkgr/utils/-/utils-2.3.1.tgz#0a9b06ffddee364d6642b3cd562ca76f55b34a03"


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The installed version of`@phenomnomnominal/tsquery` doesn't support TypeScript 5.0 which will be needed soon for Angular 16.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The installed version of`@phenomnomnominal/tsquery` supports TypeScript 5.0.

Note: The new version **~5.0.1** also supports older TS versions, so we can make this change ahead of the Angular 16 support. This reduces the size of the Angular 16 support PR and allows us to have a more granular PR.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
