### PR TITLE
fix(angular): validate standalone option in the directive generator

### DIFF
--- a/docs/generated/packages/angular/generators/directive.json
+++ b/docs/generated/packages/angular/generators/directive.json
@@ -54,7 +54,7 @@
         "description": "The HTML selector to use for this directive."
       },
       "standalone": {
-        "description": "Whether the generated directive is standalone.",
+        "description": "Whether the generated directive is standalone. _Note: This is only supported in Angular versions >= 14.1.0_.",
         "type": "boolean",
         "default": false
       },

--- a/packages/angular/src/generators/directive/lib/validate-options.ts
+++ b/packages/angular/src/generators/directive/lib/validate-options.ts
@@ -1,6 +1,8 @@
 import type { Tree } from '@nrwl/devkit';
-import { getProjects } from '@nrwl/devkit';
+import { getProjects, stripIndents } from '@nrwl/devkit';
+import { lt } from 'semver';
 import { checkPathUnderProjectRoot } from '../../utils/path';
+import { getInstalledAngularVersionInfo } from '../../utils/version-utils';
 import type { Schema } from '../schema';
 
 export function validateOptions(tree: Tree, options: Schema): void {
@@ -10,4 +12,10 @@ export function validateOptions(tree: Tree, options: Schema): void {
   }
 
   checkPathUnderProjectRoot(tree, options.project, options.path);
+
+  const installedAngularVersionInfo = getInstalledAngularVersionInfo(tree);
+  if (lt(installedAngularVersionInfo.version, '14.1.0') && options.standalone) {
+    throw new Error(stripIndents`The "standalone" option is only supported in Angular >= 14.1.0. You are currently using "${installedAngularVersionInfo.version}".
+    You can resolve this error by removing the "standalone" option or by migrating to Angular 14.1.0.`);
+  }
 }

--- a/packages/angular/src/generators/directive/schema.json
+++ b/packages/angular/src/generators/directive/schema.json
@@ -63,7 +63,7 @@
       "description": "The HTML selector to use for this directive."
     },
     "standalone": {
-      "description": "Whether the generated directive is standalone.",
+      "description": "Whether the generated directive is standalone. _Note: This is only supported in Angular versions >= 14.1.0_.",
       "type": "boolean",
       "default": false
     },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The directive generator doesn't validate the `standalone` option for Angular versions that don't support it (<14.1.0).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The directive generator should validate the `standalone` option for Angular versions that don't support it (<14.1.0).

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
