### PR TITLE
chore(repo): remove obsolete root-lint from ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,7 @@ jobs:
             npx nx-cloud record -- nx format:check --base=$NX_BASE --head=$NX_HEAD &
             pids+=($!)
 
-            npx nx run-many -t root-lint check-imports check-commit check-lock-files depcheck --parallel=1 --no-dte &
+            npx nx run-many -t check-imports check-commit check-lock-files depcheck --parallel=1 --no-dte &
             pids+=($!)
 
             yarn nx affected --target=lint --base=$NX_BASE --head=$NX_HEAD --parallel=3 &

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "submit-plugin": "node ./scripts/submit-plugin.js",
     "prepare": "is-ci || husky install",
     "echo": "echo 123458",
-    "root-lint": "nx workspace-lint",
     "preinstall": "node ./scripts/preinstall.js"
   },
   "devDependencies": {
@@ -333,8 +332,7 @@
       "check-imports",
       "check-lock-files",
       "depcheck",
-      "documentation",
-      "root-lint"
+      "documentation"
     ]
   }
 }


### PR DESCRIPTION
`root-lint` is running `nx workspace-lint`, which is deprecated and does nothing apart from printing the deprecation message.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
