### PR TITLE
fix(misc): allow npmScope to be single @

### DIFF
--- a/packages/nx/src/utils/path.spec.ts
+++ b/packages/nx/src/utils/path.spec.ts
@@ -1,4 +1,4 @@
-import { normalizePath, joinPathFragments } from './path';
+import { getImportPath, joinPathFragments, normalizePath } from './path';
 
 describe('normalizePath', () => {
   it('should remove drive letters', () => {
@@ -19,5 +19,19 @@ describe('joinPathFragments', () => {
     expect(joinPathFragments('C://some/path', '../other-path')).toEqual(
       '/some/other-path'
     );
+  });
+});
+
+describe('getImportPath', () => {
+  it('should use the npmScope if it is set to anything other than @', () => {
+    expect(getImportPath('myorg', 'my-package')).toEqual('@myorg/my-package');
+  });
+
+  it('should allow for a single @ to be used as the npmScope', () => {
+    expect(getImportPath('@', 'my-package')).toEqual('@/my-package');
+  });
+
+  it('should just use the package name if npmScope is empty', () => {
+    expect(getImportPath('', 'my-package')).toEqual('my-package');
   });
 });

--- a/packages/nx/src/utils/path.ts
+++ b/packages/nx/src/utils/path.ts
@@ -36,5 +36,7 @@ export function getImportPath(
   npmScope: string,
   projectDirectory: string
 ): string {
-  return npmScope ? `@${npmScope}/${projectDirectory}` : projectDirectory;
+  return npmScope
+    ? `${npmScope === '@' ? '' : '@'}${npmScope}/${projectDirectory}`
+    : projectDirectory;
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We changed behaviour such that when the npmScope is empty, we no longer default to using '@' for the importPath for libraries.
If people set their npmScope to @, we transform this to `@@/{package}`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should allow people to use @ as their npmScope, without transforming it.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14693
