### PR TITLE
fix(core): fix NX_PERF_LOGGING toggles

### DIFF
--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -292,7 +292,7 @@ function constructLifeCycles(lifeCycle: LifeCycle) {
   const lifeCycles = [] as LifeCycle[];
   lifeCycles.push(new StoreRunInformationLifeCycle());
   lifeCycles.push(lifeCycle);
-  if (process.env.NX_PERF_LOGGING) {
+  if (process.env.NX_PERF_LOGGING === 'true') {
     lifeCycles.push(new TaskTimingsLifeCycle());
   }
   if (process.env.NX_PROFILE) {

--- a/packages/nx/src/utils/perf-logging.ts
+++ b/packages/nx/src/utils/perf-logging.ts
@@ -1,6 +1,6 @@
 import { PerformanceObserver } from 'perf_hooks';
 
-if (process.env.NX_PERF_LOGGING) {
+if (process.env.NX_PERF_LOGGING === 'true') {
   const obs = new PerformanceObserver((list) => {
     for (const entry of list.getEntries()) {
       console.log(`Time for '${entry.name}'`, entry.duration);

--- a/packages/workspace/src/utils/perf-logging.ts
+++ b/packages/workspace/src/utils/perf-logging.ts
@@ -1,6 +1,6 @@
 import { PerformanceObserver } from 'perf_hooks';
 
-if (process.env.NX_PERF_LOGGING) {
+if (process.env.NX_PERF_LOGGING === 'true') {
   const obs = new PerformanceObserver((list) => {
     const entry = list.getEntries()[0];
     console.log(`Time for '${entry.name}'`, entry.duration);


### PR DESCRIPTION
Code toggles for `NX_PERF_LOGGING` expect it to be a boolean value, but setting the value to `false` (like we have it on CI) always enables it.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
