### PR TITLE
feat(angular): export some utils as public api #15669

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -20,6 +20,7 @@
     "./executors": "./executors.js",
     "./tailwind": "./tailwind.js",
     "./src/generators/utils": "./src/generators/utils/index.js",
+    "./src/utils": "./src/utils/public-api.js",
     "./module-federation": "./module-federation/index.js",
     "./plugins/component-testing": "./plugins/component-testing.js"
   },

--- a/packages/angular/src/utils/nx-devkit/ast-utils.ts
+++ b/packages/angular/src/utils/nx-devkit/ast-utils.ts
@@ -1,9 +1,14 @@
 import type * as ts from 'typescript';
 import { findNodes } from 'nx/src/utils/typescript';
-import { getSourceNodes } from '@nrwl/js';
+import {
+  getImport,
+  getSourceNodes,
+  insertChange,
+  removeChange,
+  replaceChange,
+} from '@nrwl/js';
 import { dirname, join } from 'path';
 import { names, readProjectConfiguration, Tree } from '@nrwl/devkit';
-import { getImport, insertChange, removeChange, replaceChange } from '@nrwl/js';
 import { ensureTypescript } from '@nrwl/js/src/utils/typescript/ensure-typescript';
 
 let tsModule: typeof import('typescript');
@@ -65,6 +70,11 @@ function _angularImportsFromNode(
   }
 }
 
+/**
+ * Check if the Component, Directive or Pipe is standalone
+ * @param sourceFile TS Source File containing the token to check
+ * @param decoratorName The type of decorator to check (Component, Directive, Pipe)
+ */
 export function isStandalone(
   sourceFile: ts.SourceFile,
   decoratorName: DecoratorName
@@ -341,6 +351,13 @@ export function removeFromNgModule(
   }
 }
 
+/**
+ * Add an import to a Standalone Component
+ * @param host Virtual Tree
+ * @param source TS Source File containing the Component
+ * @param componentPath The path to the Component
+ * @param symbolName The import to add to the Component
+ */
 export function addImportToComponent(
   host: Tree,
   source: ts.SourceFile,
@@ -357,6 +374,13 @@ export function addImportToComponent(
   );
 }
 
+/**
+ * Add an import to a Standalone Directive
+ * @param host Virtual Tree
+ * @param source TS Source File containing the Directive
+ * @param directivePath The path to the Directive
+ * @param symbolName The import to add to the Directive
+ */
 export function addImportToDirective(
   host: Tree,
   source: ts.SourceFile,
@@ -373,6 +397,13 @@ export function addImportToDirective(
   );
 }
 
+/**
+ * Add an import to a Standalone Pipe
+ * @param host Virtual Tree
+ * @param source TS Source File containing the Pipe
+ * @param pipePath The path to the Pipe
+ * @param symbolName The import to add to the Pipe
+ */
 export function addImportToPipe(
   host: Tree,
   source: ts.SourceFile,
@@ -389,6 +420,13 @@ export function addImportToPipe(
   );
 }
 
+/**
+ * Add an import to an NgModule
+ * @param host Virtual Tree
+ * @param source TS Source File containing the NgModule
+ * @param modulePath The path to the NgModule
+ * @param symbolName The import to add to the NgModule
+ */
 export function addImportToModule(
   host: Tree,
   source: ts.SourceFile,
@@ -638,6 +676,12 @@ function getListOfRoutes(
   return null;
 }
 
+/**
+ * Add a provider to bootstrapApplication call for Standalone Applications
+ * @param tree Virtual Tree
+ * @param filePath Path to the file containing the bootstrapApplication call
+ * @param providerToAdd Provider to add
+ */
 export function addProviderToBootstrapApplication(
   tree: Tree,
   filePath: string,
@@ -672,6 +716,13 @@ export function addProviderToBootstrapApplication(
   tree.write(filePath, newFileContents);
 }
 
+/**
+ * Add a provider to an NgModule
+ * @param host Virtual Tree
+ * @param source TS Source File containing the NgModule
+ * @param modulePath Path to the NgModule
+ * @param symbolName The provider to add
+ */
 export function addProviderToModule(
   host: Tree,
   source: ts.SourceFile,
@@ -687,6 +738,13 @@ export function addProviderToModule(
   );
 }
 
+/**
+ * Add a provider to a Standalone Component
+ * @param host Virtual Tree
+ * @param source TS Source File containing the Component
+ * @param componentPath Path to the Component
+ * @param symbolName The provider to add
+ */
 export function addProviderToComponent(
   host: Tree,
   source: ts.SourceFile,

--- a/packages/angular/src/utils/nx-devkit/route-utils.ts
+++ b/packages/angular/src/utils/nx-devkit/route-utils.ts
@@ -5,6 +5,15 @@ import { ensureTypescript } from '@nrwl/js/src/utils/typescript/ensure-typescrip
 
 let tsModule: typeof import('typescript');
 
+/**
+ * Add a new route to a routes definition
+ * @param tree Virtual Tree
+ * @param routesFile File containing the routes definition
+ * @param route Route to add
+ * @param lazy If Route should be lazy-loaded
+ * @param routesConst Used when eager-loading a route: Class name of the Component
+ * @param importPath Used when eager-loading a route: The import path to the Component
+ */
 export function addRoute(
   tree: Tree,
   routesFile: string,
@@ -81,6 +90,13 @@ export function addRoute(
   tree.write(routesFile, newRoutesFileContents);
 }
 
+/**
+ * Add a provider to a standalone routes definition
+ * @param tree Virtual Tree
+ * @param routesFile The file containing the routes definition
+ * @param routeToAddProviderTo The route to add the provider to
+ * @param providerToAdd The provider to add to the route
+ */
 export function addProviderToRoute(
   tree: Tree,
   routesFile: string,

--- a/packages/angular/src/utils/public-api.ts
+++ b/packages/angular/src/utils/public-api.ts
@@ -1,0 +1,12 @@
+export {
+  isStandalone,
+  addImportToComponent,
+  addImportToDirective,
+  addImportToPipe,
+  addImportToModule,
+  addProviderToBootstrapApplication,
+  addProviderToComponent,
+  addProviderToModule,
+} from './nx-devkit/ast-utils';
+
+export { addRoute, addProviderToRoute } from './nx-devkit/route-utils';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We have some util functions that we use internally to help write our generators.
These utils can be beneficial to Plugin and Generator Authors, however, they are currently inaccesible.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Make public some of the utils that we use to write our generators.
Restrict this to specific utils for now, using the exports property in package.json.
The exports property will point to a specific file that re-exports some of the utils we will allow to be used by public.

This will help us to know which methods could actively be used by the public and therefore will need more considerations if changes are to be made to them.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15669
