### PR TITLE
chore(nextjs): increase test timeout to avoid intermittent failure

### DIFF
--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -198,7 +198,7 @@ describe('Next.js Applications', () => {
     selfContainedProcess.kill();
     await killPort(prodServePort);
     await killPort(selfContainedPort);
-  }, 300_000);
+  }, 600_000);
 
   it('should build and install pruned lock file', () => {
     const appName = uniq('app');


### PR DESCRIPTION
Nightly tests fail intermittently because one of the tests time out. This PR increases the timeout from 5 mins to 10 mins.

https://github.com/nrwl/nx/actions/runs/4591502478/jobs/8107832201


## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
