### PR TITLE
docs(nx-cloud): remove side-by-side usage for code

### DIFF
--- a/docs/shared/angular-standalone-tutorial/1-code-generation.md
+++ b/docs/shared/angular-standalone-tutorial/1-code-generation.md
@@ -84,8 +84,6 @@ UPDATE src/app/app.module.ts
 
 To create the `cart` and `shared/ui` libraries, use the `@nrwl/angular:lib` generator:
 
-{% side-by-side %}
-
 ```{% command="npx nx g @nrwl/angular:library cart" path="~/store" %}
 
 >  NX  Generating @nrwl/angular:library
@@ -138,8 +136,6 @@ To address all issues (including breaking changes), run:
 
 Run `npm audit` for details.
 ```
-
-{% /side-by-side %}
 
 You should now be able to see all three projects of our design:
 

--- a/docs/shared/angular-tutorial/1-code-generation.md
+++ b/docs/shared/angular-tutorial/1-code-generation.md
@@ -97,8 +97,6 @@ CREATE apps/admin-e2e/.eslintrc.json
 
 To create the `common-ui` and `products` libraries, use the `@nrwl/angular:lib` and `@nrwl/js:lib` generators respectively:
 
-{% side-by-side %}
-
 ```{% command="npx nx g @nrwl/angular:lib common-ui" path="~/myorg" %}
 
 >  NX  Generating @nrwl/angular:library
@@ -136,8 +134,6 @@ CREATE libs/products/.eslintrc.json
 CREATE libs/products/jest.config.ts
 CREATE libs/products/tsconfig.spec.json
 ```
-
-{% /side-by-side %}
 
 You should now be able to see all four projects of our design:
 

--- a/docs/shared/react-standalone-tutorial/1-code-generation.md
+++ b/docs/shared/react-standalone-tutorial/1-code-generation.md
@@ -84,8 +84,6 @@ CREATE src/app/shop/shop.tsx
 
 To create the `cart` and `shared/ui` libraries, use the `@nrwl/react:lib` generator:
 
-{% side-by-side %}
-
 ```{% command="npx nx g @nrwl/react:library cart" path="~/store" %}
 
 >  NX  Generating @nrwl/react:library
@@ -136,8 +134,6 @@ CREATE shared/ui/src/lib/shared-ui.module.css
 CREATE shared/ui/src/lib/shared-ui.spec.tsx
 CREATE shared/ui/src/lib/shared-ui.tsx
 ```
-
-{% /side-by-side %}
 
 You should now be able to see all three projects of our design:
 

--- a/docs/shared/react-tutorial/1-code-generation.md
+++ b/docs/shared/react-tutorial/1-code-generation.md
@@ -93,8 +93,6 @@ CREATE apps/admin/tsconfig.spec.json
 
 To create the `common-ui` and `products` libraries, use the `@nrwl/react:lib` and `@nrwl/js:lib` generators respectively:
 
-{% side-by-side %}
-
 ```{% command="npx nx g @nrwl/react:lib common-ui" path="~/myorg" %}
 
 > NX Generating @nrwl/react:library
@@ -132,8 +130,6 @@ CREATE libs/products/.eslintrc.json
 CREATE libs/products/jest.config.ts
 CREATE libs/products/tsconfig.spec.json
 ```
-
-{% /side-by-side %}
 
 You should now be able to see all four projects of our design:
 


### PR DESCRIPTION
It basically removes the usage of the `side-by-side` component when it looks weird and objects do not have the same sizes.