### PR TITLE
docs(misc): add Deno deployment recipes

### DIFF
--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -2588,6 +2588,22 @@
             "isExternal": false,
             "children": [],
             "disableCollapsible": false
+          },
+          {
+            "name": "Serverless deployment with Deno Deploy",
+            "path": "/recipes/deployment/deno-deploy",
+            "id": "deno-deploy",
+            "isExternal": false,
+            "children": [],
+            "disableCollapsible": false
+          },
+          {
+            "name": "Serverless deployment with Deno and Netlify",
+            "path": "/recipes/deployment/deno-netlify",
+            "id": "deno-netlify",
+            "isExternal": false,
+            "children": [],
+            "disableCollapsible": false
           }
         ],
         "disableCollapsible": false
@@ -2596,6 +2612,22 @@
         "name": "Deploying a Node.js server to Fly.io",
         "path": "/recipes/deployment/node-server-fly-io",
         "id": "node-server-fly-io",
+        "isExternal": false,
+        "children": [],
+        "disableCollapsible": false
+      },
+      {
+        "name": "Serverless deployment with Deno Deploy",
+        "path": "/recipes/deployment/deno-deploy",
+        "id": "deno-deploy",
+        "isExternal": false,
+        "children": [],
+        "disableCollapsible": false
+      },
+      {
+        "name": "Serverless deployment with Deno and Netlify",
+        "path": "/recipes/deployment/deno-netlify",
+        "id": "deno-netlify",
         "isExternal": false,
         "children": [],
         "disableCollapsible": false

--- a/docs/generated/manifests/recipes.json
+++ b/docs/generated/manifests/recipes.json
@@ -1064,6 +1064,26 @@
         "isExternal": false,
         "path": "/recipes/deployment/node-server-fly-io",
         "tags": ["deployment", "node"]
+      },
+      {
+        "id": "deno-deploy",
+        "name": "Serverless deployment with Deno Deploy",
+        "description": "",
+        "file": "shared/recipes/deployment/deno-deploy",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/recipes/deployment/deno-deploy",
+        "tags": ["deployment", "deno"]
+      },
+      {
+        "id": "deno-netlify",
+        "name": "Serverless deployment with Deno and Netlify",
+        "description": "",
+        "file": "shared/recipes/deployment/deno-netlify",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/recipes/deployment/deno-netlify",
+        "tags": ["deployment", "deno"]
       }
     ],
     "isExternal": false,
@@ -1079,6 +1099,26 @@
     "isExternal": false,
     "path": "/recipes/deployment/node-server-fly-io",
     "tags": ["deployment", "node"]
+  },
+  "/recipes/deployment/deno-deploy": {
+    "id": "deno-deploy",
+    "name": "Serverless deployment with Deno Deploy",
+    "description": "",
+    "file": "shared/recipes/deployment/deno-deploy",
+    "itemList": [],
+    "isExternal": false,
+    "path": "/recipes/deployment/deno-deploy",
+    "tags": ["deployment", "deno"]
+  },
+  "/recipes/deployment/deno-netlify": {
+    "id": "deno-netlify",
+    "name": "Serverless deployment with Deno and Netlify",
+    "description": "",
+    "file": "shared/recipes/deployment/deno-netlify",
+    "itemList": [],
+    "isExternal": false,
+    "path": "/recipes/deployment/deno-netlify",
+    "tags": ["deployment", "deno"]
   },
   "/recipes/other": {
     "id": "other",

--- a/docs/generated/manifests/tags.json
+++ b/docs/generated/manifests/tags.json
@@ -835,6 +835,20 @@
       "id": "node-server-fly-io",
       "name": "Deploying a Node.js server to Fly.io",
       "path": "/recipes/deployment/node-server-fly-io"
+    },
+    {
+      "description": "",
+      "file": "shared/recipes/deployment/deno-deploy",
+      "id": "deno-deploy",
+      "name": "Serverless deployment with Deno Deploy",
+      "path": "/recipes/deployment/deno-deploy"
+    },
+    {
+      "description": "",
+      "file": "shared/recipes/deployment/deno-netlify",
+      "id": "deno-netlify",
+      "name": "Serverless deployment with Deno and Netlify",
+      "path": "/recipes/deployment/deno-netlify"
     }
   ],
   "node": [
@@ -844,6 +858,22 @@
       "id": "node-server-fly-io",
       "name": "Deploying a Node.js server to Fly.io",
       "path": "/recipes/deployment/node-server-fly-io"
+    }
+  ],
+  "deno": [
+    {
+      "description": "",
+      "file": "shared/recipes/deployment/deno-deploy",
+      "id": "deno-deploy",
+      "name": "Serverless deployment with Deno Deploy",
+      "path": "/recipes/deployment/deno-deploy"
+    },
+    {
+      "description": "",
+      "file": "shared/recipes/deployment/deno-netlify",
+      "id": "deno-netlify",
+      "name": "Serverless deployment with Deno and Netlify",
+      "path": "/recipes/deployment/deno-netlify"
     }
   ],
   "workspace-watching": [

--- a/docs/map.json
+++ b/docs/map.json
@@ -1047,6 +1047,18 @@
               "id": "node-server-fly-io",
               "tags": ["deployment", "node"],
               "file": "shared/recipes/deployment/node-server-fly-io"
+            },
+            {
+              "name": "Serverless deployment with Deno Deploy",
+              "id": "deno-deploy",
+              "tags": ["deployment", "deno"],
+              "file": "shared/recipes/deployment/deno-deploy"
+            },
+            {
+              "name": "Serverless deployment with Deno and Netlify",
+              "id": "deno-netlify",
+              "tags": ["deployment", "deno"],
+              "file": "shared/recipes/deployment/deno-netlify"
             }
           ]
         },

--- a/docs/shared/recipes/deployment/deno-deploy.md
+++ b/docs/shared/recipes/deployment/deno-deploy.md
@@ -1,0 +1,83 @@
+# Serverless deployment with Deno Deploy
+
+In this guide, we'll show you how to deploy serverless functions using [Deno Deploy](https://deno.com/deploy).
+
+## Creating the project
+
+You can create a new Deno project with a single command.
+
+```shell
+npx create-nx-workspace@latest denoapp --preset=@nrwl/deno
+```
+
+Once the command is finished, you can `cd` into the workspace.
+
+```shell
+cd denoapp
+```
+
+To run the server, use `nx serve` and the server will start on `http://localhost:8000`. You can also run lint and tests with `nx lint` and `nx test` respectively.
+
+For existing projects, see the next section, otherwise you can skip to [deployment](#deno-deploy).
+
+### Configure existing projects
+
+**Skip this step if you are not configuring an existing project.**
+
+For existing workspaces, you will need to install the `@nrwl/deno` package.
+
+{% tabs %}
+{% tab label="npm" %}
+
+```shell
+npm i -D @nrwl/deno
+```
+
+{% /tab %}
+{% tab label="yarn" %}
+
+```shell
+yarn add -D @nrwl/deno
+```
+
+{% /tab %}
+{% tab label="pnpm" %}
+
+```shell
+pnpm add -D @nrwl/deno
+```
+
+{% /tab %}
+{% /tabs %}
+
+Now, you can generate a Deno project.
+
+```shell
+nx g @nrwl/deno:app denoapp
+```
+
+You are now ready to deploy the project.
+
+## Deno Deploy
+
+We will use [Deno Deploy](https://deno.com/deploy) to host our serverless functions. First, you'll need to run the generator to set up your project.
+
+```shell
+nx g @nrwl/deno:setup-serverless --platform=deno-deploy
+```
+
+A new `nx deploy` target will be added to your project, but before you can run it there are a few set up steps.
+
+1. Push your repository to [GitHub](https://github.com/).
+2. Go to [Deno dashboard](https://dash.deno.com/) and set up your Deno project. You need to authorize GitHub to allow access to your repositories, then you need to specify the main file (e.g. `src/main.ts`), and the production branch (e.g. `main`).
+3. Generate an access token from your [account settings page](https://dash.deno.com/account#access-tokens). Copy the new token somewhere.
+4. Add an entry to the project's `.env` file: `DENO_DEPLOY_TOKEN=<token-from-previous-step>` (create this file if needed, and add it to `.gitignore` so you don't commit it)
+5. Install the [`deployctl`](https://deno.com/deploy/docs/deployctl) CLI tool.
+
+Once you are done the above steps, you can deploy and view your Deno app!
+
+```shell
+nx deploy
+```
+
+You can find the production URL from the [Deno dashboard](https://dash.deno.com/) (e.g. `https://acme-denoapp.deno.dev/`). Browsing to the production URL should return the default JSON message: `{ "message": "Hello denoapp" }`.

--- a/docs/shared/recipes/deployment/deno-netlify.md
+++ b/docs/shared/recipes/deployment/deno-netlify.md
@@ -1,0 +1,75 @@
+# Serverless deployment with Deno and Netlify
+
+In this guide, we'll show you how to deploy Deno serverless functions using [Netlify](https://netlify.com/).
+
+## Creating the project
+
+You can create a new Deno project with a single command.
+
+```shell
+npx create-nx-workspace@latest denoapp --preset=@nrwl/deno
+```
+
+Once the command is finished, you can `cd` into the workspace.
+
+```shell
+cd denoapp
+```
+
+To serve the functions locally, run `nx serve-functions` and the server will start on `http://localhost:8888`. The Hello function is available on `http://localhost:8888/api/geo`.
+
+For existing projects, see the next section, otherwise you can skip to [deployment](#deploying-to-netlify).
+
+### Configure existing projects
+
+**Skip this step if you are not configuring an existing project.**
+
+For existing workspaces, you will need to install the `@nrwl/deno` package.
+
+{% tabs %}
+{% tab label="npm" %}
+
+```shell
+npm i -D @nrwl/deno
+```
+
+{% /tab %}
+{% tab label="yarn" %}
+
+```shell
+yarn add -D @nrwl/deno
+```
+
+{% /tab %}
+{% tab label="pnpm" %}
+
+```shell
+pnpm add -D @nrwl/deno
+```
+
+{% /tab %}
+{% /tabs %}
+
+Now, you can generate a Deno project.
+
+```shell
+nx g @nrwl/deno:app denoapp
+```
+
+You are now ready to deploy the project.
+
+## Deploying to Netlify
+
+First, you'll need to run the generator to set up your project.
+
+```shell
+nx g @nrwl/deno:setup-serverless --platform=netlify
+```
+
+This will add a `netlify.toml` file and install the `netlify-cli` package. You can deploy your app with the following command.
+
+```shell
+npx netlify deploy
+```
+
+You will be prompted to set up the project when deploying for the first time. Once deployed, the production URL will be logged out, and you can see the Hello function by visiting `https://<deploy-id>.netlify.app/api/geo`.

--- a/nx-dev/data-access-documents/src/lib/tags.api.ts
+++ b/nx-dev/data-access-documents/src/lib/tags.api.ts
@@ -25,8 +25,11 @@ export class TagsApi {
   }
 
   sortAndDeduplicateItems(tags: RelatedDocument[][]): RelatedDocument[] {
-    return tags
-      .flat()
-      .filter((item, index, items) => items.indexOf(item) === index);
+    return tags.flat().reduce((acc, item: RelatedDocument) => {
+      if (acc.findIndex((curr) => curr.file === item.file) === -1) {
+        acc.push(item);
+      }
+      return acc;
+    }, [] as RelatedDocument[]);
   }
 }

--- a/nx-dev/nx-dev-e2e/src/e2e/recipes.cy.ts
+++ b/nx-dev/nx-dev-e2e/src/e2e/recipes.cy.ts
@@ -1,0 +1,18 @@
+import { uniq } from '@nrwl/e2e/utils';
+
+describe('nx-dev: Recipes pages', () => {
+  it('should list related recipes based on tags', () => {
+    const { map, uniq } = Cypress._;
+
+    cy.visit('/recipes/deployment/deno-deploy');
+
+    // All text content has to be different
+    cy.get('[data-document="related"] > article > ul > li').should(($list) => {
+      const values = map($list, 'innerText');
+      const distinct = uniq(values);
+      expect(distinct, 'all strings are different').to.have.length(
+        values.length
+      );
+    });
+  });
+});


### PR DESCRIPTION
This PR adds two new recipes for Deno deployment.

- Deno Deploy https://nx-dev-git-fork-jaysoo-docs-deno-deploy-nrwl.vercel.app/recipes/deployment/deno-deploy
- Deno + Netlify https://nx-dev-git-fork-jaysoo-docs-deno-deploy-nrwl.vercel.app/recipes/deployment/deno-netlify

## Notes

Also fixes `Related Document` section for recipes to remove duplicates when multiple recipes share the same set of tags (e.g. `["deno", "deployment"]`
