### PR TITLE
docs(node): Add recipe for deploying serverless functions to Netlify

### DIFF
--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -2590,6 +2590,14 @@
             "disableCollapsible": false
           },
           {
+            "name": "Deploying Node.js serverless functions to Netlify",
+            "path": "/recipes/deployment/node-serverless-functions-netlify",
+            "id": "node-serverless-functions-netlify",
+            "isExternal": false,
+            "children": [],
+            "disableCollapsible": false
+          },
+          {
             "name": "Serverless deployment with Deno Deploy",
             "path": "/recipes/deployment/deno-deploy",
             "id": "deno-deploy",
@@ -2612,6 +2620,14 @@
         "name": "Deploying a Node.js server to Fly.io",
         "path": "/recipes/deployment/node-server-fly-io",
         "id": "node-server-fly-io",
+        "isExternal": false,
+        "children": [],
+        "disableCollapsible": false
+      },
+      {
+        "name": "Deploying Node.js serverless functions to Netlify",
+        "path": "/recipes/deployment/node-serverless-functions-netlify",
+        "id": "node-serverless-functions-netlify",
         "isExternal": false,
         "children": [],
         "disableCollapsible": false

--- a/docs/generated/manifests/recipes.json
+++ b/docs/generated/manifests/recipes.json
@@ -1066,6 +1066,16 @@
         "tags": ["deployment", "node"]
       },
       {
+        "id": "node-serverless-functions-netlify",
+        "name": "Deploying Node.js serverless functions to Netlify",
+        "description": "",
+        "file": "shared/recipes/deployment/node-serverless-functions-netlify",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/recipes/deployment/node-serverless-functions-netlify",
+        "tags": ["deployment", "node"]
+      },
+      {
         "id": "deno-deploy",
         "name": "Serverless deployment with Deno Deploy",
         "description": "",
@@ -1098,6 +1108,16 @@
     "itemList": [],
     "isExternal": false,
     "path": "/recipes/deployment/node-server-fly-io",
+    "tags": ["deployment", "node"]
+  },
+  "/recipes/deployment/node-serverless-functions-netlify": {
+    "id": "node-serverless-functions-netlify",
+    "name": "Deploying Node.js serverless functions to Netlify",
+    "description": "",
+    "file": "shared/recipes/deployment/node-serverless-functions-netlify",
+    "itemList": [],
+    "isExternal": false,
+    "path": "/recipes/deployment/node-serverless-functions-netlify",
     "tags": ["deployment", "node"]
   },
   "/recipes/deployment/deno-deploy": {

--- a/docs/generated/manifests/tags.json
+++ b/docs/generated/manifests/tags.json
@@ -838,6 +838,13 @@
     },
     {
       "description": "",
+      "file": "shared/recipes/deployment/node-serverless-functions-netlify",
+      "id": "node-serverless-functions-netlify",
+      "name": "Deploying Node.js serverless functions to Netlify",
+      "path": "/recipes/deployment/node-serverless-functions-netlify"
+    },
+    {
+      "description": "",
       "file": "shared/recipes/deployment/deno-deploy",
       "id": "deno-deploy",
       "name": "Serverless deployment with Deno Deploy",
@@ -858,6 +865,13 @@
       "id": "node-server-fly-io",
       "name": "Deploying a Node.js server to Fly.io",
       "path": "/recipes/deployment/node-server-fly-io"
+    },
+    {
+      "description": "",
+      "file": "shared/recipes/deployment/node-serverless-functions-netlify",
+      "id": "node-serverless-functions-netlify",
+      "name": "Deploying Node.js serverless functions to Netlify",
+      "path": "/recipes/deployment/node-serverless-functions-netlify"
     }
   ],
   "deno": [

--- a/docs/map.json
+++ b/docs/map.json
@@ -1049,6 +1049,12 @@
               "file": "shared/recipes/deployment/node-server-fly-io"
             },
             {
+              "name": "Deploying Node.js serverless functions to Netlify",
+              "id": "node-serverless-functions-netlify",
+              "tags": ["deployment", "node"],
+              "file": "shared/recipes/deployment/node-serverless-functions-netlify"
+            },
+            {
               "name": "Serverless deployment with Deno Deploy",
               "id": "deno-deploy",
               "tags": ["deployment", "deno"],

--- a/docs/shared/recipes/deployment/node-server-fly-io.md
+++ b/docs/shared/recipes/deployment/node-server-fly-io.md
@@ -32,7 +32,7 @@ For existing projects, see the next section, otherwise you can skip to [deployme
 
 ### Configure existing projects
 
-**Skip this step if you are not configuring an exist project.**
+**Skip this step if you are not configuring an existing project.**
 
 If you have an existing Node.js server project, you can add the same deployment capabilities as we've just covered. Firstly, if the project is not an Nx project you can initialize it as such by running the `npx nx init` command in your project. Next, we can add the `build` and `docker-build` targets by invoking a couple of generators.
 

--- a/docs/shared/recipes/deployment/node-serverless-functions-netlify.md
+++ b/docs/shared/recipes/deployment/node-serverless-functions-netlify.md
@@ -1,0 +1,93 @@
+# Deploying Node.js serverless functions to Netlify
+
+Deploying Node.js serverless functions to Netlify involes a few steps:
+
+## Creating the project
+
+For new workspaces you can create a Nx workspace with serverless function with one command:
+
+```shell
+npx create-nx-workspace@latest my-functions \
+--preset=@nrwl/netlify \
+--site=my-site \ # Site ID or name to deploy the functions
+```
+
+## Configuring existing projects
+
+**Skip this step if you are not configuring an existing project.**
+
+You will need to install `@nrwl/netlify` if you haven't already.
+
+{% tabs %}
+{% tab label="npm" %}
+
+```shell
+npm i -D @nrwl/netlify
+```
+
+{% /tab %}
+{% tab label="yarn" %}
+
+```shell
+yarn add -D @nrwl/netlify
+```
+
+{% /tab %}
+{% tab label="pnpm" %}
+
+```shell
+pnpm add -D @nrwl/netlify
+```
+
+{% /tab %}
+{% /tabs %}
+
+- Add serverless configuration by running the following command:
+
+```shell
+nx generate @nrwl/netlify:setup-serverless
+```
+
+- Create a new netlify serverless project with:
+
+```shell
+nx generate @nrwl/netlfiy:serverless
+```
+
+This will do a few things:
+
+1. Create a new serverless function in `src/functions`.
+2. Add the `netlify.toml` in the root of the project
+3. Update your `project.json` to have 2 new targets `dev` & `deploy`.
+
+## Configure your Netlify deploy settings
+
+If you **do not** have a _site_ setup within your workspace, go inside the Netlify dashboard, and create/use an existing site where your serverless functions will be deployed.
+
+In your `project.json` you can update your deploy site by going to the `deploy` target adding `--site=my-site-name-or-id` replace **my-site-name-or-id** to what you have in your Netlify dashboard.
+
+It should look similar to:
+
+```json
+    "deploy": {
+      "dependsOn": ["lint"],
+      "command": "npx netlify deploy --prod-if-unlocked --site=my-site"
+    }
+```
+
+## Deployment
+
+To view your functions locally you run:
+
+```shell
+nx serve
+```
+
+Inside your `netlify.toml` your functions _path_ should be already configured.
+To deploy them to Netlify you would run:
+
+```shell
+nx deploy
+```
+
+The netlify CLI will output the link where you functions can be accessed. You can either click that link or open your browser and navigate to it!


### PR DESCRIPTION
Adds a new entry in the `Deployment` under `Recipes` with a guide for deploying Node Serverless functions to Netlify.

https://nx-dev-git-fork-ndcunningham-docs-node-serverless-f-ea4c98-nrwl.vercel.app/