### PR TITLE
fix(core): should not throw 'unable to resolve nx/package.json'

### DIFF
--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -11,8 +11,8 @@ import {
   getNxRequirePaths,
 } from '../src/utils/installation-directory';
 import { major } from 'semver';
-import { readJsonFile } from '../src/utils/fileutils';
 import { stripIndents } from '../src/utils/strip-indents';
+import { readModulePackageJson } from '../src/utils/package-json';
 import { execSync } from 'child_process';
 
 function main() {
@@ -163,12 +163,17 @@ function warnIfUsingOutdatedGlobalInstall(
   }
 }
 
-function getLocalNxVersion(workspace: WorkspaceTypeAndRoot): string {
-  return readJsonFile(
-    require.resolve('nx/package.json', {
-      paths: getNxRequirePaths(workspace.dir),
-    })
-  ).version;
+function getLocalNxVersion(workspace: WorkspaceTypeAndRoot): string | null {
+  const localNxPackages = ['nx', '@nrwl/tao', '@nrwl/cli'];
+  for (const pkg of localNxPackages) {
+    try {
+      const { packageJson } = readModulePackageJson(
+        'nx',
+        getNxRequirePaths(workspace.dir)
+      );
+      return packageJson.version;
+    } catch {}
+  }
 }
 
 function _getLatestVersionOfNx(): string {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
In older workspaces that do not have a dep on `nx`, rather using `@nrwl/cli`, the global CLI can throw

## Expected Behavior
The global CLI is more graceful when it cannot resolve `nx/package.json`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15919
