### PR TITLE
fix(devkit): tree.children should support writes to directories that have the same name as their parent

### DIFF
--- a/packages/nx/src/generators/tree.spec.ts
+++ b/packages/nx/src/generators/tree.spec.ts
@@ -355,6 +355,14 @@ describe('tree', () => {
         ]);
       });
 
+      it('should support nested dirs with same name as parent', () => {
+        tree.write('/parent-a/parent-a/parent-a-file.txt', 'parent content');
+        expect(tree.children('/parent-a')).toEqual(['parent-a']);
+        expect(tree.children('/parent-a/parent-a')).toEqual([
+          'parent-a-file.txt',
+        ]);
+      });
+
       describe('at the root', () => {
         it('should return a list of children', () => {
           expect(tree.children('')).toEqual(['parent', 'root-file.txt']);

--- a/packages/nx/src/generators/tree.ts
+++ b/packages/nx/src/generators/tree.ts
@@ -403,8 +403,12 @@ export class FsTree implements Tree {
     }
     Object.keys(this.recordedChanges).forEach((f) => {
       if (f.startsWith(`${path}/`)) {
-        const [_, file] = f.split(`${path}/`);
-        res[file.split('/')[0]] = true;
+        // Remove the current folder's path from the directory
+        const file = f.substring(path.length + 1);
+        // Split the path on segments, and take the first one
+        const basePath = file.split('/')[0];
+        // Mark it as a child of the current directory
+        res[basePath] = true;
       }
     });
 


### PR DESCRIPTION
…have the same name as the parent

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
