### PR TITLE
fix(angular): fix path handling and validate standalone option in pipe generator

### DIFF
--- a/docs/generated/packages/angular/generators/pipe.json
+++ b/docs/generated/packages/angular/generators/pipe.json
@@ -45,7 +45,7 @@
         "description": "Do not import this pipe into the owning NgModule."
       },
       "standalone": {
-        "description": "Whether the generated pipe is standalone.",
+        "description": "Whether the generated pipe is standalone. _Note: This is only supported in Angular versions >= 14.1.0_.",
         "type": "boolean",
         "default": false
       },

--- a/packages/angular/src/generators/pipe/lib/index.ts
+++ b/packages/angular/src/generators/pipe/lib/index.ts
@@ -1,0 +1,2 @@
+export * from './normalize-options';
+export * from './validate-options';

--- a/packages/angular/src/generators/pipe/lib/normalize-options.ts
+++ b/packages/angular/src/generators/pipe/lib/normalize-options.ts
@@ -1,0 +1,27 @@
+import type { Tree } from '@nrwl/devkit';
+import { joinPathFragments, readProjectConfiguration } from '@nrwl/devkit';
+import { parseNameWithPath } from '../../utils/names';
+import type { NormalizedSchema, Schema } from '../schema';
+
+export function normalizeOptions(
+  tree: Tree,
+  options: Schema
+): NormalizedSchema {
+  const { projectType, root, sourceRoot } = readProjectConfiguration(
+    tree,
+    options.project
+  );
+
+  const projectSourceRoot = sourceRoot ?? joinPathFragments(root, 'src');
+  const { name, path: namePath } = parseNameWithPath(options.name);
+
+  const path =
+    options.path ??
+    joinPathFragments(
+      projectSourceRoot,
+      projectType === 'application' ? 'app' : 'lib',
+      namePath
+    );
+
+  return { ...options, name, path };
+}

--- a/packages/angular/src/generators/pipe/lib/validate-options.ts
+++ b/packages/angular/src/generators/pipe/lib/validate-options.ts
@@ -1,0 +1,13 @@
+import type { Tree } from '@nrwl/devkit';
+import { checkPathUnderProjectRoot } from '../../utils/path';
+import {
+  validateProject,
+  validateStandaloneOption,
+} from '../../utils/validations';
+import type { Schema } from '../schema';
+
+export function validateOptions(tree: Tree, options: Schema): void {
+  validateProject(tree, options.project);
+  checkPathUnderProjectRoot(tree, options.project, options.path);
+  validateStandaloneOption(tree, options.standalone);
+}

--- a/packages/angular/src/generators/pipe/pipe.spec.ts
+++ b/packages/angular/src/generators/pipe/pipe.spec.ts
@@ -12,10 +12,11 @@ describe('pipe generator', () => {
     addProjectConfiguration(tree, 'test', {
       root: 'test',
       sourceRoot: 'test/src',
+      projectType: 'application',
     });
 
     tree.write(
-      'test/src/test.module.ts',
+      'test/src/app/test.module.ts',
       `import {NgModule} from "@angular/core";
     @NgModule({
       imports: [],
@@ -33,9 +34,11 @@ describe('pipe generator', () => {
     await generatePipeWithDefaultOptions(tree);
 
     // ASSERT
-    expect(tree.read('test/src/test.pipe.ts', 'utf-8')).toMatchSnapshot();
-    expect(tree.read('test/src/test.pipe.spec.ts', 'utf-8')).toMatchSnapshot();
-    expect(tree.read('test/src/test.module.ts', 'utf-8')).toMatchSnapshot();
+    expect(tree.read('test/src/app/test.pipe.ts', 'utf-8')).toMatchSnapshot();
+    expect(
+      tree.read('test/src/app/test.pipe.spec.ts', 'utf-8')
+    ).toMatchSnapshot();
+    expect(tree.read('test/src/app/test.module.ts', 'utf-8')).toMatchSnapshot();
   });
 
   it('should import the pipe correctly when flat=false', async () => {
@@ -45,11 +48,13 @@ describe('pipe generator', () => {
     await generatePipeWithDefaultOptions(tree, { flat: false });
 
     // ASSERT
-    expect(tree.read('test/src/test/test.pipe.ts', 'utf-8')).toMatchSnapshot();
     expect(
-      tree.read('test/src/test/test.pipe.spec.ts', 'utf-8')
+      tree.read('test/src/app/test/test.pipe.ts', 'utf-8')
     ).toMatchSnapshot();
-    expect(tree.read('test/src/test.module.ts', 'utf-8')).toMatchSnapshot();
+    expect(
+      tree.read('test/src/app/test/test.pipe.spec.ts', 'utf-8')
+    ).toMatchSnapshot();
+    expect(tree.read('test/src/app/test.module.ts', 'utf-8')).toMatchSnapshot();
   });
 
   it('should not import the pipe when standalone=true', async () => {
@@ -59,9 +64,11 @@ describe('pipe generator', () => {
     await generatePipeWithDefaultOptions(tree, { standalone: true });
 
     // ASSERT
-    expect(tree.read('test/src/test.pipe.ts', 'utf-8')).toMatchSnapshot();
-    expect(tree.read('test/src/test.pipe.spec.ts', 'utf-8')).toMatchSnapshot();
-    expect(tree.read('test/src/test.module.ts', 'utf-8')).toMatchSnapshot();
+    expect(tree.read('test/src/app/test.pipe.ts', 'utf-8')).toMatchSnapshot();
+    expect(
+      tree.read('test/src/app/test.pipe.spec.ts', 'utf-8')
+    ).toMatchSnapshot();
+    expect(tree.read('test/src/app/test.module.ts', 'utf-8')).toMatchSnapshot();
   });
 
   it('should import the pipe correctly when flat=false and path is nested deeper', async () => {
@@ -70,17 +77,17 @@ describe('pipe generator', () => {
     // ACT
     await generatePipeWithDefaultOptions(tree, {
       flat: false,
-      path: 'test/src/my-pipes',
+      path: 'test/src/app/my-pipes',
     });
 
     // ASSERT
     expect(
-      tree.read('test/src/my-pipes/test/test.pipe.ts', 'utf-8')
+      tree.read('test/src/app/my-pipes/test/test.pipe.ts', 'utf-8')
     ).toMatchSnapshot();
     expect(
-      tree.read('test/src/my-pipes/test/test.pipe.spec.ts', 'utf-8')
+      tree.read('test/src/app/my-pipes/test/test.pipe.spec.ts', 'utf-8')
     ).toMatchSnapshot();
-    expect(tree.read('test/src/test.module.ts', 'utf-8')).toMatchSnapshot();
+    expect(tree.read('test/src/app/test.module.ts', 'utf-8')).toMatchSnapshot();
   });
 
   it('should export the pipe correctly when flat=false and path is nested deeper', async () => {
@@ -89,18 +96,18 @@ describe('pipe generator', () => {
     // ACT
     await generatePipeWithDefaultOptions(tree, {
       flat: false,
-      path: 'test/src/my-pipes',
+      path: 'test/src/app/my-pipes',
       export: true,
     });
 
     // ASSERT
     expect(
-      tree.read('test/src/my-pipes/test/test.pipe.ts', 'utf-8')
+      tree.read('test/src/app/my-pipes/test/test.pipe.ts', 'utf-8')
     ).toMatchSnapshot();
     expect(
-      tree.read('test/src/my-pipes/test/test.pipe.spec.ts', 'utf-8')
+      tree.read('test/src/app/my-pipes/test/test.pipe.spec.ts', 'utf-8')
     ).toMatchSnapshot();
-    expect(tree.read('test/src/test.module.ts', 'utf-8')).toMatchSnapshot();
+    expect(tree.read('test/src/app/test.module.ts', 'utf-8')).toMatchSnapshot();
   });
 
   it('should not import the pipe when skipImport=true', async () => {
@@ -109,18 +116,18 @@ describe('pipe generator', () => {
     // ACT
     await generatePipeWithDefaultOptions(tree, {
       flat: false,
-      path: 'test/src/my-pipes',
+      path: 'test/src/app/my-pipes',
       skipImport: true,
     });
 
     // ASSERT
     expect(
-      tree.read('test/src/my-pipes/test/test.pipe.ts', 'utf-8')
+      tree.read('test/src/app/my-pipes/test/test.pipe.ts', 'utf-8')
     ).toMatchSnapshot();
     expect(
-      tree.read('test/src/my-pipes/test/test.pipe.spec.ts', 'utf-8')
+      tree.read('test/src/app/my-pipes/test/test.pipe.spec.ts', 'utf-8')
     ).toMatchSnapshot();
-    expect(tree.read('test/src/test.module.ts', 'utf-8')).toMatchSnapshot();
+    expect(tree.read('test/src/app/test.module.ts', 'utf-8')).toMatchSnapshot();
   });
 
   it('should not generate test file when skipTests=true', async () => {
@@ -129,16 +136,18 @@ describe('pipe generator', () => {
     // ACT
     await generatePipeWithDefaultOptions(tree, {
       flat: false,
-      path: 'test/src/my-pipes',
+      path: 'test/src/app/my-pipes',
       skipTests: true,
     });
 
     // ASSERT
     expect(
-      tree.read('test/src/my-pipes/test/test.pipe.ts', 'utf-8')
+      tree.read('test/src/app/my-pipes/test/test.pipe.ts', 'utf-8')
     ).toMatchSnapshot();
-    expect(tree.exists('test/src/my-pipes/test/test.pipe.spec.ts')).toBeFalsy();
-    expect(tree.read('test/src/test.module.ts', 'utf-8')).toMatchSnapshot();
+    expect(
+      tree.exists('test/src/app/my-pipes/test/test.pipe.spec.ts')
+    ).toBeFalsy();
+    expect(tree.read('test/src/app/test.module.ts', 'utf-8')).toMatchSnapshot();
   });
 });
 

--- a/packages/angular/src/generators/pipe/schema.d.ts
+++ b/packages/angular/src/generators/pipe/schema.d.ts
@@ -10,3 +10,7 @@ export interface Schema {
   export?: boolean;
   skipFormat?: boolean;
 }
+
+export interface NormalizedSchema extends Schema {
+  path: string;
+}

--- a/packages/angular/src/generators/pipe/schema.json
+++ b/packages/angular/src/generators/pipe/schema.json
@@ -49,7 +49,7 @@
       "description": "Do not import this pipe into the owning NgModule."
     },
     "standalone": {
-      "description": "Whether the generated pipe is standalone.",
+      "description": "Whether the generated pipe is standalone. _Note: This is only supported in Angular versions >= 14.1.0_.",
       "type": "boolean",
       "default": false
     },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `pipe` generator:

- doesn't add the `app` or `lib` segment to the path based on the project type
- doesn't validate the `standalone` option support

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `pipe` generator builds correctly the path and validates the `standalone` option support.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
