### PR TITLE
cleanup(angular): use generators instead of wrapped ng cli schematics

### DIFF
--- a/packages/angular/src/generators/component-cypress-spec/component-cypress-spec.spec.ts
+++ b/packages/angular/src/generators/component-cypress-spec/component-cypress-spec.spec.ts
@@ -1,8 +1,8 @@
 import { installedCypressVersion } from '@nrwl/cypress/src/utils/cypress-version';
 import type { Tree } from '@nrwl/devkit';
 import * as devkit from '@nrwl/devkit';
-import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { componentGenerator } from '../component/component';
 import * as storybookUtils from '../utils/storybook-ast/storybook-inputs';
 import { generateTestApplication } from '../utils/testing';
 import { componentCypressSpecGenerator } from './component-cypress-spec';
@@ -20,11 +20,6 @@ describe('componentCypressSpec generator', () => {
   > = installedCypressVersion as never;
   beforeEach(async () => {
     tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-
-    const componentGenerator = wrapAngularDevkitSchematic(
-      '@schematics/angular',
-      'component'
-    );
 
     await generateTestApplication(tree, { name: appName });
     await componentGenerator(tree, {

--- a/packages/angular/src/generators/component-story/component-story.spec.ts
+++ b/packages/angular/src/generators/component-story/component-story.spec.ts
@@ -1,7 +1,7 @@
 import type { Tree } from '@nrwl/devkit';
 import * as devkit from '@nrwl/devkit';
-import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { componentGenerator } from '../component/component';
 import * as storybookUtils from '../utils/storybook-ast/storybook-inputs';
 import { generateTestLibrary } from '../utils/testing';
 import { componentStoryGenerator } from './component-story';
@@ -13,11 +13,6 @@ describe('componentStory generator', () => {
 
   beforeEach(async () => {
     tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-
-    const componentGenerator = wrapAngularDevkitSchematic(
-      '@schematics/angular',
-      'component'
-    );
 
     await generateTestLibrary(tree, { name: libName });
     await componentGenerator(tree, {

--- a/packages/angular/src/generators/scam-directive/lib/convert-directive-to-scam.spec.ts
+++ b/packages/angular/src/generators/scam-directive/lib/convert-directive-to-scam.spec.ts
@@ -1,6 +1,6 @@
 import { addProjectConfiguration } from '@nrwl/devkit';
-import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { directiveGenerator } from '../../directive/directive';
 import { convertDirectiveToScam } from './convert-directive-to-scam';
 
 describe('convertDirectiveToScam', () => {
@@ -13,11 +13,7 @@ describe('convertDirectiveToScam', () => {
       root: 'apps/app1',
     });
 
-    const angularDirectiveSchematic = wrapAngularDevkitSchematic(
-      '@schematics/angular',
-      'directive'
-    );
-    await angularDirectiveSchematic(tree, {
+    await directiveGenerator(tree, {
       name: 'example',
       project: 'app1',
       skipImport: true,
@@ -54,12 +50,10 @@ describe('convertDirectiveToScam', () => {
       import { CommonModule } from '@angular/common';
 
       @Directive({
-        selector: '[example]'
+        selector: '[projExample]',
       })
       export class ExampleDirective {
-
-        constructor() { }
-
+        constructor() {}
       }
 
       @NgModule({
@@ -80,11 +74,7 @@ describe('convertDirectiveToScam', () => {
       root: 'apps/app1',
     });
 
-    const angularDirectiveSchematic = wrapAngularDevkitSchematic(
-      '@schematics/angular',
-      'directive'
-    );
-    await angularDirectiveSchematic(tree, {
+    await directiveGenerator(tree, {
       name: 'example',
       project: 'app1',
       skipImport: true,
@@ -139,11 +129,7 @@ describe('convertDirectiveToScam', () => {
       root: 'apps/app1',
     });
 
-    const angularDirectiveSchematic = wrapAngularDevkitSchematic(
-      '@schematics/angular',
-      'directive'
-    );
-    await angularDirectiveSchematic(tree, {
+    await directiveGenerator(tree, {
       name: 'example',
       project: 'app1',
       skipImport: true,
@@ -180,12 +166,10 @@ describe('convertDirectiveToScam', () => {
       import { CommonModule } from '@angular/common';
 
       @Directive({
-        selector: '[example]'
+        selector: '[projExample]',
       })
       export class ExampleDirective {
-
-        constructor() { }
-
+        constructor() {}
       }
 
       @NgModule({
@@ -206,11 +190,7 @@ describe('convertDirectiveToScam', () => {
       root: 'apps/app1',
     });
 
-    const angularDirectiveSchematic = wrapAngularDevkitSchematic(
-      '@schematics/angular',
-      'directive'
-    );
-    await angularDirectiveSchematic(tree, {
+    await directiveGenerator(tree, {
       name: 'example',
       project: 'app1',
       skipImport: true,
@@ -265,11 +245,7 @@ describe('convertDirectiveToScam', () => {
       root: 'apps/app1',
     });
 
-    const angularDirectiveSchematic = wrapAngularDevkitSchematic(
-      '@schematics/angular',
-      'directive'
-    );
-    await angularDirectiveSchematic(tree, {
+    await directiveGenerator(tree, {
       name: 'example',
       project: 'app1',
       skipImport: true,
@@ -307,12 +283,10 @@ describe('convertDirectiveToScam', () => {
       import { CommonModule } from '@angular/common';
 
       @Directive({
-        selector: '[example]'
+        selector: '[projExample]',
       })
       export class ExampleDirective {
-
-        constructor() { }
-
+        constructor() {}
       }
 
       @NgModule({
@@ -333,11 +307,7 @@ describe('convertDirectiveToScam', () => {
       root: 'apps/app1',
     });
 
-    const angularDirectiveSchematic = wrapAngularDevkitSchematic(
-      '@schematics/angular',
-      'directive'
-    );
-    await angularDirectiveSchematic(tree, {
+    await directiveGenerator(tree, {
       name: 'example',
       project: 'app1',
       skipImport: true,
@@ -375,12 +345,10 @@ describe('convertDirectiveToScam', () => {
       import { CommonModule } from '@angular/common';
 
       @Directive({
-        selector: '[example]'
+        selector: '[projExample]',
       })
       export class ExampleDirective {
-
-        constructor() { }
-
+        constructor() {}
       }
 
       @NgModule({

--- a/packages/angular/src/generators/scam-pipe/lib/convert-pipe-to-scam.spec.ts
+++ b/packages/angular/src/generators/scam-pipe/lib/convert-pipe-to-scam.spec.ts
@@ -1,6 +1,6 @@
 import { addProjectConfiguration } from '@nrwl/devkit';
-import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { pipeGenerator } from '../../pipe/pipe';
 import { convertPipeToScam } from './convert-pipe-to-scam';
 
 describe('convertPipeToScam', () => {
@@ -13,11 +13,7 @@ describe('convertPipeToScam', () => {
       root: 'apps/app1',
     });
 
-    const angularPipeSchematic = wrapAngularDevkitSchematic(
-      '@schematics/angular',
-      'pipe'
-    );
-    await angularPipeSchematic(tree, {
+    await pipeGenerator(tree, {
       name: 'example',
       project: 'app1',
       skipImport: true,
@@ -54,14 +50,12 @@ describe('convertPipeToScam', () => {
       import { CommonModule } from '@angular/common';
 
       @Pipe({
-        name: 'example'
+        name: 'example',
       })
       export class ExamplePipe implements PipeTransform {
-
         transform(value: unknown, ...args: unknown[]): unknown {
           return null;
         }
-
       }
 
       @NgModule({
@@ -82,11 +76,7 @@ describe('convertPipeToScam', () => {
       root: 'apps/app1',
     });
 
-    const angularPipeSchematic = wrapAngularDevkitSchematic(
-      '@schematics/angular',
-      'pipe'
-    );
-    await angularPipeSchematic(tree, {
+    await pipeGenerator(tree, {
       name: 'example',
       project: 'app1',
       skipImport: true,
@@ -141,11 +131,7 @@ describe('convertPipeToScam', () => {
       root: 'apps/app1',
     });
 
-    const angularPipeSchematic = wrapAngularDevkitSchematic(
-      '@schematics/angular',
-      'pipe'
-    );
-    await angularPipeSchematic(tree, {
+    await pipeGenerator(tree, {
       name: 'example',
       project: 'app1',
       skipImport: true,
@@ -179,14 +165,12 @@ describe('convertPipeToScam', () => {
       import { CommonModule } from '@angular/common';
 
       @Pipe({
-        name: 'example'
+        name: 'example',
       })
       export class ExamplePipe implements PipeTransform {
-
         transform(value: unknown, ...args: unknown[]): unknown {
           return null;
         }
-
       }
 
       @NgModule({
@@ -207,11 +191,7 @@ describe('convertPipeToScam', () => {
       root: 'apps/app1',
     });
 
-    const angularPipeSchematic = wrapAngularDevkitSchematic(
-      '@schematics/angular',
-      'pipe'
-    );
-    await angularPipeSchematic(tree, {
+    await pipeGenerator(tree, {
       name: 'example',
       project: 'app1',
       skipImport: true,
@@ -266,11 +246,7 @@ describe('convertPipeToScam', () => {
       root: 'apps/app1',
     });
 
-    const angularPipeSchematic = wrapAngularDevkitSchematic(
-      '@schematics/angular',
-      'pipe'
-    );
-    await angularPipeSchematic(tree, {
+    await pipeGenerator(tree, {
       name: 'example',
       project: 'app1',
       skipImport: true,
@@ -308,14 +284,12 @@ describe('convertPipeToScam', () => {
       import { CommonModule } from '@angular/common';
 
       @Pipe({
-        name: 'example'
+        name: 'example',
       })
       export class ExamplePipe implements PipeTransform {
-
         transform(value: unknown, ...args: unknown[]): unknown {
           return null;
         }
-
       }
 
       @NgModule({
@@ -336,11 +310,7 @@ describe('convertPipeToScam', () => {
       root: 'apps/app1',
     });
 
-    const angularPipeSchematic = wrapAngularDevkitSchematic(
-      '@schematics/angular',
-      'pipe'
-    );
-    await angularPipeSchematic(tree, {
+    await pipeGenerator(tree, {
       name: 'example',
       project: 'app1',
       skipImport: true,
@@ -378,14 +348,12 @@ describe('convertPipeToScam', () => {
       import { CommonModule } from '@angular/common';
 
       @Pipe({
-        name: 'example'
+        name: 'example',
       })
       export class ExamplePipe implements PipeTransform {
-
         transform(value: unknown, ...args: unknown[]): unknown {
           return null;
         }
-
       }
 
       @NgModule({

--- a/packages/angular/src/generators/scam-to-standalone/scam-to-standalone.spec.ts
+++ b/packages/angular/src/generators/scam-to-standalone/scam-to-standalone.spec.ts
@@ -55,7 +55,6 @@ describe('scam-to-standalone', () => {
     expect(tree.read('apps/foo/src/app/bar/bar.component.spec.ts', 'utf-8'))
       .toMatchInlineSnapshot(`
       "import { ComponentFixture, TestBed } from '@angular/core/testing';
-
       import { BarComponent } from './bar.component';
 
       describe('BarComponent', () => {

--- a/packages/angular/src/generators/scam/lib/convert-component-to-scam.spec.ts
+++ b/packages/angular/src/generators/scam/lib/convert-component-to-scam.spec.ts
@@ -1,6 +1,6 @@
 import { addProjectConfiguration } from '@nrwl/devkit';
-import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { componentGenerator } from '../../component/component';
 import { convertComponentToScam } from './convert-component-to-scam';
 
 describe('convertComponentToScam', () => {
@@ -13,11 +13,7 @@ describe('convertComponentToScam', () => {
       root: 'apps/app1',
     });
 
-    const angularComponentSchematic = wrapAngularDevkitSchematic(
-      '@schematics/angular',
-      'component'
-    );
-    await angularComponentSchematic(tree, {
+    await componentGenerator(tree, {
       name: 'example',
       project: 'app1',
       skipImport: true,
@@ -52,13 +48,11 @@ describe('convertComponentToScam', () => {
       import { CommonModule } from '@angular/common';
 
       @Component({
-        selector: 'example',
+        selector: 'proj-example',
         templateUrl: './example.component.html',
-        styleUrls: ['./example.component.css']
+        styleUrls: ['./example.component.css'],
       })
-      export class ExampleComponent {
-
-      }
+      export class ExampleComponent {}
 
       @NgModule({
         imports: [CommonModule],
@@ -78,11 +72,7 @@ describe('convertComponentToScam', () => {
       root: 'apps/app1',
     });
 
-    const angularComponentSchematic = wrapAngularDevkitSchematic(
-      '@schematics/angular',
-      'component'
-    );
-    await angularComponentSchematic(tree, {
+    await componentGenerator(tree, {
       name: 'example',
       project: 'app1',
       skipImport: true,
@@ -135,11 +125,7 @@ describe('convertComponentToScam', () => {
       root: 'apps/app1',
     });
 
-    const angularComponentSchematic = wrapAngularDevkitSchematic(
-      '@schematics/angular',
-      'component'
-    );
-    await angularComponentSchematic(tree, {
+    await componentGenerator(tree, {
       name: 'example',
       project: 'app1',
       skipImport: true,
@@ -176,13 +162,11 @@ describe('convertComponentToScam', () => {
       import { CommonModule } from '@angular/common';
 
       @Component({
-        selector: 'example',
+        selector: 'proj-example',
         templateUrl: './example.component.html',
-        styleUrls: ['./example.component.css']
+        styleUrls: ['./example.component.css'],
       })
-      export class ExampleComponent {
-
-      }
+      export class ExampleComponent {}
 
       @NgModule({
         imports: [CommonModule],
@@ -202,11 +186,7 @@ describe('convertComponentToScam', () => {
       root: 'apps/app1',
     });
 
-    const angularComponentSchematic = wrapAngularDevkitSchematic(
-      '@schematics/angular',
-      'component'
-    );
-    await angularComponentSchematic(tree, {
+    await componentGenerator(tree, {
       name: 'example',
       project: 'app1',
       skipImport: true,
@@ -261,11 +241,7 @@ describe('convertComponentToScam', () => {
       root: 'apps/app1',
     });
 
-    const angularComponentSchematic = wrapAngularDevkitSchematic(
-      '@schematics/angular',
-      'component'
-    );
-    await angularComponentSchematic(tree, {
+    await componentGenerator(tree, {
       name: 'example',
       project: 'app1',
       skipImport: true,
@@ -304,13 +280,11 @@ describe('convertComponentToScam', () => {
       import { CommonModule } from '@angular/common';
 
       @Component({
-        selector: 'example',
+        selector: 'proj-example',
         templateUrl: './example.random.html',
-        styleUrls: ['./example.random.css']
+        styleUrls: ['./example.random.css'],
       })
-      export class ExampleRandom {
-
-      }
+      export class ExampleRandom {}
 
       @NgModule({
         imports: [CommonModule],
@@ -330,11 +304,7 @@ describe('convertComponentToScam', () => {
       root: 'apps/app1',
     });
 
-    const angularComponentSchematic = wrapAngularDevkitSchematic(
-      '@schematics/angular',
-      'component'
-    );
-    await angularComponentSchematic(tree, {
+    await componentGenerator(tree, {
       name: 'example',
       project: 'app1',
       skipImport: true,
@@ -391,11 +361,7 @@ describe('convertComponentToScam', () => {
       root: 'apps/app1',
     });
 
-    const angularComponentSchematic = wrapAngularDevkitSchematic(
-      '@schematics/angular',
-      'component'
-    );
-    await angularComponentSchematic(tree, {
+    await componentGenerator(tree, {
       name: 'example',
       project: 'app1',
       skipImport: true,
@@ -433,13 +399,11 @@ describe('convertComponentToScam', () => {
       import { CommonModule } from '@angular/common';
 
       @Component({
-        selector: 'example',
+        selector: 'proj-example',
         templateUrl: './example.component.html',
-        styleUrls: ['./example.component.css']
+        styleUrls: ['./example.component.css'],
       })
-      export class ExampleComponent {
-
-      }
+      export class ExampleComponent {}
 
       @NgModule({
         imports: [CommonModule],
@@ -459,11 +423,7 @@ describe('convertComponentToScam', () => {
       root: 'apps/app1',
     });
 
-    const angularComponentSchematic = wrapAngularDevkitSchematic(
-      '@schematics/angular',
-      'component'
-    );
-    await angularComponentSchematic(tree, {
+    await componentGenerator(tree, {
       name: 'example',
       project: 'app1',
       skipImport: true,
@@ -501,13 +461,11 @@ describe('convertComponentToScam', () => {
       import { CommonModule } from '@angular/common';
 
       @Component({
-        selector: 'example',
+        selector: 'proj-example',
         templateUrl: './example.component.html',
-        styleUrls: ['./example.component.css']
+        styleUrls: ['./example.component.css'],
       })
-      export class ExampleComponent {
-
-      }
+      export class ExampleComponent {}
 
       @NgModule({
         imports: [CommonModule],

--- a/packages/angular/src/generators/scam/scam.spec.ts
+++ b/packages/angular/src/generators/scam/scam.spec.ts
@@ -29,7 +29,7 @@ describe('SCAM Generator', () => {
       import { CommonModule } from '@angular/common';
 
       @Component({
-        selector: 'example',
+        selector: 'proj-example',
         templateUrl: './example.component.html',
         styleUrls: ['./example.component.css'],
       })
@@ -160,7 +160,7 @@ describe('SCAM Generator', () => {
         import { CommonModule } from '@angular/common';
 
         @Component({
-          selector: 'example',
+          selector: 'proj-example',
           templateUrl: './example.component.html',
           styleUrls: ['./example.component.css'],
         })
@@ -203,7 +203,7 @@ describe('SCAM Generator', () => {
         import { CommonModule } from '@angular/common';
 
         @Component({
-          selector: 'example',
+          selector: 'proj-example',
           templateUrl: './example.component.html',
           styleUrls: ['./example.component.css'],
         })

--- a/packages/angular/src/generators/scam/scam.ts
+++ b/packages/angular/src/generators/scam/scam.ts
@@ -2,9 +2,9 @@ import type { Tree } from '@nrwl/devkit';
 import {
   formatFiles,
   normalizePath,
-  readNxJson,
   readProjectConfiguration,
 } from '@nrwl/devkit';
+import componentGenerator from '../component/component';
 import { exportScam } from '../utils/export-scam';
 import { getComponentFileInfo } from '../utils/file-info';
 import { pathStartsWith } from '../utils/path';
@@ -17,12 +17,7 @@ export async function scamGenerator(tree: Tree, rawOptions: Schema) {
 
   checkPathUnderProjectRoot(tree, options);
 
-  const { wrapAngularDevkitSchematic } = require('@nrwl/devkit/ngcli-adapter');
-  const angularComponentSchematic = wrapAngularDevkitSchematic(
-    '@schematics/angular',
-    'component'
-  );
-  await angularComponentSchematic(tree, {
+  await componentGenerator(tree, {
     ...schematicOptions,
     skipImport: true,
     export: false,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Some code in the Angular plugin still uses Angular CLI schematics to generate code or to test.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The Angular plugin should use available generators instead of wrapping Angular CLI schematics.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
