### PR TITLE
chore(node): increase timeout for Node server e2e test

### DIFF
--- a/e2e/node/src/node-server.test.ts
+++ b/e2e/node/src/node-server.test.ts
@@ -116,7 +116,7 @@ describe('Node Applications + webpack', () => {
     await runE2eTests(fastifyApp);
     await runE2eTests(koaApp);
     await runE2eTests(nestApp);
-  }, 300_000);
+  }, 900_000);
 
   it('should generate a Dockerfile', async () => {
     const expressApp = uniq('expressapp');


### PR DESCRIPTION
Timeouts are causing intermittent test failures.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
