### PR TITLE
chore(repo): use --silent when running through yarn to avoid unexpected strings

### DIFF
--- a/e2e/utils/command-utils.ts
+++ b/e2e/utils/command-utils.ts
@@ -326,7 +326,7 @@ export function runCLI(
   try {
     const pm = getPackageManagerCommand();
     const logs = execSync(
-      `${pm.runNx} ${command} ${
+      `${pm.runNxSilent} ${command} ${
         opts.verbose ?? isVerboseE2ERun() ? ' --verbose' : ''
       }`,
       {


### PR DESCRIPTION
If you run `yarn nx` it will print a string like `✨  Done in 1.24s.` at the end of the output. This messes up e2e tests that are checking for specific output (such as correct length, JSON output, etc.)

Should fix some of the core and misc nightly tests.