### PR TITLE
feat(bundling): add support for esbuild.config.js file

### DIFF
--- a/docs/generated/packages/esbuild/executors/esbuild.json
+++ b/docs/generated/packages/esbuild/executors/esbuild.json
@@ -163,8 +163,13 @@
       },
       "esbuildOptions": {
         "type": "object",
-        "description": "Additional options to pass to esbuild. See https://esbuild.github.io/api/.",
+        "description": "Additional options to pass to esbuild. See https://esbuild.github.io/api/. Cannot be used with 'esbuildConfig' option.",
         "additionalProperties": true,
+        "x-priority": "important"
+      },
+      "esbuildConfig": {
+        "type": "string",
+        "description": "Path to a esbuild configuration file. See https://esbuild.github.io/api/. Cannot be used with 'esbuildOptions' option.",
         "x-priority": "important"
       }
     },

--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.spec.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.spec.ts
@@ -49,6 +49,7 @@ describe('buildEsbuildOptions', () => {
           outputFileName: 'index.js',
           singleEntry: true,
           external: [],
+          userDefinedBuildOptions: {},
         },
         context
       )
@@ -89,6 +90,7 @@ describe('buildEsbuildOptions', () => {
           outputFileName: 'index.js',
           singleEntry: false,
           external: [],
+          userDefinedBuildOptions: {},
         },
         context
       )
@@ -128,6 +130,7 @@ describe('buildEsbuildOptions', () => {
           outputFileName: 'index.js',
           singleEntry: true,
           external: [],
+          userDefinedBuildOptions: {},
         },
         context
       )
@@ -167,6 +170,7 @@ describe('buildEsbuildOptions', () => {
           outputFileName: 'index.js',
           singleEntry: true,
           external: [],
+          userDefinedBuildOptions: {},
         },
         context
       )
@@ -203,7 +207,7 @@ describe('buildEsbuildOptions', () => {
           assets: [],
           singleEntry: true,
           external: [],
-          esbuildOptions: {
+          userDefinedBuildOptions: {
             outExtension: {
               '.js': '.mjs',
             },
@@ -242,7 +246,7 @@ describe('buildEsbuildOptions', () => {
           assets: [],
           singleEntry: true,
           external: [],
-          esbuildOptions: {
+          userDefinedBuildOptions: {
             outExtension: {
               '.js': '.js',
             },
@@ -282,7 +286,7 @@ describe('buildEsbuildOptions', () => {
           assets: [],
           singleEntry: true,
           external: [],
-          esbuildOptions: {
+          userDefinedBuildOptions: {
             outExtension: {
               '.js': '.cjs',
             },
@@ -323,7 +327,7 @@ describe('buildEsbuildOptions', () => {
           singleEntry: true,
           outputFileName: 'index.js',
           external: ['foo'],
-          esbuildOptions: {
+          userDefinedBuildOptions: {
             external: ['bar'],
           },
         },
@@ -361,6 +365,7 @@ describe('buildEsbuildOptions', () => {
           assets: [],
           singleEntry: true,
           external: ['foo'],
+          userDefinedBuildOptions: {},
         },
         context
       )
@@ -398,6 +403,7 @@ describe('buildEsbuildOptions', () => {
           singleEntry: true,
           sourcemap: true,
           external: [],
+          userDefinedBuildOptions: {},
         },
         context
       )
@@ -434,6 +440,7 @@ describe('buildEsbuildOptions', () => {
           assets: [],
           singleEntry: true,
           external: [],
+          userDefinedBuildOptions: {},
         },
         context
       )
@@ -469,7 +476,7 @@ describe('buildEsbuildOptions', () => {
           outputFileName: 'index.js',
           assets: [],
           singleEntry: true,
-          esbuildOptions: {
+          userDefinedBuildOptions: {
             sourcemap: true,
           },
           external: [],
@@ -508,7 +515,7 @@ describe('buildEsbuildOptions', () => {
           outputFileName: 'index.js',
           assets: [],
           singleEntry: true,
-          esbuildOptions: {
+          userDefinedBuildOptions: {
             sourcemap: false,
           },
           sourcemap: true,

--- a/packages/esbuild/src/executors/esbuild/schema.d.ts
+++ b/packages/esbuild/src/executors/esbuild/schema.d.ts
@@ -1,4 +1,5 @@
 import { AssetGlob } from '@nrwl/js/src/utils/assets/assets';
+import * as esbuild from 'esbuild';
 
 type Compiler = 'babel' | 'swc';
 
@@ -10,6 +11,7 @@ export interface EsBuildExecutorOptions {
   deleteOutputPath?: boolean;
   dependenciesFieldType?: boolean;
   esbuildOptions?: Record<string, any>;
+  esbuildConfig?: string;
   external?: string[];
   format?: Array<'esm' | 'cjs'>;
   generatePackageJson?: boolean;
@@ -29,7 +31,8 @@ export interface EsBuildExecutorOptions {
 }
 
 export interface NormalizedEsBuildExecutorOptions
-  extends EsBuildExecutorOptions {
+  extends Omit<EsBuildExecutorOptions, 'esbuildOptions' | 'esbuildConfig'> {
   singleEntry: boolean;
   external: string[];
+  userDefinedBuildOptions: esbuild.BuildOptions;
 }

--- a/packages/esbuild/src/executors/esbuild/schema.json
+++ b/packages/esbuild/src/executors/esbuild/schema.json
@@ -138,8 +138,13 @@
     },
     "esbuildOptions": {
       "type": "object",
-      "description": "Additional options to pass to esbuild. See https://esbuild.github.io/api/.",
+      "description": "Additional options to pass to esbuild. See https://esbuild.github.io/api/. Cannot be used with 'esbuildConfig' option.",
       "additionalProperties": true,
+      "x-priority": "important"
+    },
+    "esbuildConfig": {
+      "type": "string",
+      "description": "Path to a esbuild configuration file. See https://esbuild.github.io/api/. Cannot be used with 'esbuildOptions' option.",
       "x-priority": "important"
     }
   },


### PR DESCRIPTION
This PR adds a new `esbuildConfig` option for `@nrwl/esbuild:esbuild` so that users can add plugins properly to their build.

## Current Behavior
No way to load esbuild plugins.

## Expected Behavior
User can add a `esbuild.config.js` file and load plugins in the file.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15021
