### PR TITLE
fix(core): don't error if lock file not present when precomputing js dependencies

### DIFF
--- a/packages/nx/src/plugins/js/index.ts
+++ b/packages/nx/src/plugins/js/index.ts
@@ -24,9 +24,9 @@ export const processProjectGraph: ProjectGraphProcessor = async (
 ) => {
   const builder = new ProjectGraphBuilder(graph);
 
-  const lockHash = lockFileHash() ?? 'n/a';
   // during the create-nx-workspace lock file might not exists yet
   if (lockFileExists()) {
+    const lockHash = lockFileHash() ?? 'n/a';
     if (lockFileNeedsReprocessing(lockHash)) {
       removeNpmNodes(graph, builder);
       parseLockFile(builder);

--- a/packages/nx/src/utils/nx-plugin.ts
+++ b/packages/nx/src/utils/nx-plugin.ts
@@ -132,7 +132,7 @@ export function loadNxPluginsSync(
   // Temporarily load js as if it were a plugin which is built into nx
   // In the future, this will be optional and need to be specified in nx.json
   const jsPlugin: any = require('../plugins/js');
-  jsPlugin.name = 'index';
+  jsPlugin.name = 'nx-js-graph-plugin';
   result.push(jsPlugin as NxPlugin);
 
   plugins ??= [];
@@ -163,7 +163,7 @@ export async function loadNxPlugins(
   // Temporarily load js as if it were a plugin which is built into nx
   // In the future, this will be optional and need to be specified in nx.json
   const jsPlugin: any = await import('../plugins/js');
-  jsPlugin.name = 'index';
+  jsPlugin.name = 'nx-js-graph-plugin';
   result.push(jsPlugin as NxPlugin);
 
   plugins ??= [];


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When running `npm i`, `yarn`, `pnpm i` without a lock file present JS analysis errors and doesn't add dependencies. This can cause a project graph that contains no source file related edges, thus causing builds to not respect target dependencies as one may expect.

## Expected Behavior
JS analysis doesn't error if no lock file present.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Related to: #16071
