### PR TITLE
feat(core): error when a project graph plugin fails

### DIFF
--- a/packages/nx/src/project-graph/build-project-graph.ts
+++ b/packages/nx/src/project-graph/build-project-graph.ts
@@ -24,7 +24,6 @@ import {
 } from '../config/project-graph';
 import { readJsonFile } from '../utils/fileutils';
 import { NxJsonConfiguration } from '../config/nx-json';
-import { logger } from '../utils/logger';
 import { ProjectGraphBuilder } from './project-graph-builder';
 import {
   ProjectConfiguration,
@@ -235,15 +234,12 @@ async function updateProjectGraphWithPlugins(
     try {
       graph = await plugin.processProjectGraph(graph, context);
     } catch (e) {
-      const message = `Failed to process the project graph with "${plugin.name}". This will error in the future!`;
-      if (process.env.NX_VERBOSE_LOGGING === 'true') {
-        console.error(e);
-        logger.error(message);
-        return graph;
-      } else {
-        logger.warn(message);
-        logger.warn(`Run with NX_VERBOSE_LOGGING=true to see the error.`);
+      let message = `Failed to process the project graph with "${plugin.name}".`;
+      if (e instanceof Error) {
+        e.message = message + '\n' + e.message;
+        throw e;
       }
+      throw new Error(message);
     }
   }
   return graph;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We warn when a project graph throws - this can hide logs and leave the repository in a confusing state.

## Expected Behavior
We throw when a project graph plugin throws - this prevents the repository from ending up in a half-baked state.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
