### PR TITLE
feat(core): allow dependsOn to accept a single project dependency

### DIFF
--- a/docs/shared/reference/project-configuration.md
+++ b/docs/shared/reference/project-configuration.md
@@ -276,6 +276,9 @@ result in `mylib`'s dependencies being built as well.
 
 You can also express the same configuration using:
 
+{% tabs %}
+{% tab label="Version < 16" %}
+
 ```json
 "build": {
   "dependsOn": [{ "projects": "dependencies", "target": "build" }]
@@ -285,7 +288,25 @@ You can also express the same configuration using:
 }
 ```
 
+{% /tab %}
+{% tab label="Version 16+" %}
+
+```json
+"build": {
+  "dependsOn": [{ "projects": "{dependencies}", "target": "build" }]
+},
+"test": {
+  "dependsOn": [{ "projects": "{self}", "target": "build" }]
+}
+```
+
+{% /tab %}
+{% /tabs %}
+
 With the expanded syntax, you also have a third option available to configure how to handle the params passed to the target. You can either forward them or you can ignore them (default).
+
+{% tabs %}
+{% tab label="Version < 16" %}
 
 ```json
 "build": {
@@ -302,7 +323,31 @@ With the expanded syntax, you also have a third option available to configure ho
 }
 ```
 
+{% /tab %}
+{% tab label="Version 16+" %}
+
+```json
+"build": {
+   // forward params passed to this target to the dependency targets
+  "dependsOn": [{ "projects": "{dependencies}", "target": "build", "params": "forward" }]
+},
+"test": {
+  // ignore params passed to this target, won't be forwarded to the dependency targets
+  "dependsOn": [{ "projects": "{dependencies}", "target": "build", "params": "ignore" }]
+}
+"lint": {
+  // ignore params passed to this target, won't be forwarded to the dependency targets
+  "dependsOn": [{ "projects": "{dependencies}", "target": "build" }]
+}
+```
+
+{% /tab %}
+{% /tabs %}
+
 Obviously this also works when defining a relation for the target of the project itself using `"projects": "self"`:
+
+{% tabs %}
+{% tab label="Version < 16" %}
 
 ```json
 "build": {
@@ -311,7 +356,20 @@ Obviously this also works when defining a relation for the target of the project
 }
 ```
 
-Additionally, when using the expanded object syntax, you can specify individual projects.
+{% /tab %}
+{% tab label="Version 16+" %}
+
+```json
+"build": {
+   // forward params passed to this target to the project target
+  "dependsOn": [{ "projects": "{self}", "target": "pre-build", "params": "forward" }]
+}
+```
+
+{% /tab %}
+{% /tabs %}
+
+Additionally, when using the expanded object syntax, you can specify individual projects in version 16 or greater.
 
 ```json
 "build": {

--- a/docs/shared/reference/project-configuration.md
+++ b/docs/shared/reference/project-configuration.md
@@ -278,10 +278,10 @@ You can also express the same configuration using:
 
 ```json
 "build": {
-  "dependsOn": [{ "projects": "dependencies", "target": "build" }]
+  "dependsOn": [{ "projects": "{dependencies}", "target": "build" }]
 },
 "test": {
-  "dependsOn": [{ "projects": "self", "target": "build" }]
+  "dependsOn": [{ "projects": "{self}", "target": "build" }]
 }
 ```
 
@@ -290,24 +290,33 @@ With the expanded syntax, you also have a third option available to configure ho
 ```json
 "build": {
    // forward params passed to this target to the dependency targets
-  "dependsOn": [{ "projects": "dependencies", "target": "build", "params": "forward" }]
+  "dependsOn": [{ "projects": "{dependencies}", "target": "build", "params": "forward" }]
 },
 "test": {
   // ignore params passed to this target, won't be forwarded to the dependency targets
-  "dependsOn": [{ "projects": "dependencies", "target": "build", "params": "ignore" }]
+  "dependsOn": [{ "projects": "{dependencies}", "target": "build", "params": "ignore" }]
 }
 "lint": {
   // ignore params passed to this target, won't be forwarded to the dependency targets
-  "dependsOn": [{ "projects": "dependencies", "target": "build" }]
+  "dependsOn": [{ "projects": "{dependencies}", "target": "build" }]
 }
 ```
 
-Obviously this also works when defining a relation for the target of the project itself using `"projects": "self"`:
+Obviously this also works when defining a relation for the target of the project itself using `"projects": "{self}"`:
 
 ```json
 "build": {
    // forward params passed to this target to the project target
-  "dependsOn": [{ "projects": "self", "target": "pre-build", "params": "forward" }]
+  "dependsOn": [{ "projects": "{self}", "target": "pre-build", "params": "forward" }]
+}
+```
+
+Additionally, when using the expanded object syntax, you can specify individual projects.
+
+```json
+"build": {
+   // Run is-even:pre-build and is-odd:pre-build before this target
+  "dependsOn": [{ "projects": ["is-even", "is-odd"], "target": "pre-build" }]
 }
 ```
 

--- a/docs/shared/reference/project-configuration.md
+++ b/docs/shared/reference/project-configuration.md
@@ -278,10 +278,10 @@ You can also express the same configuration using:
 
 ```json
 "build": {
-  "dependsOn": [{ "projects": "{dependencies}", "target": "build" }]
+  "dependsOn": [{ "projects": "dependencies", "target": "build" }]
 },
 "test": {
-  "dependsOn": [{ "projects": "{self}", "target": "build" }]
+  "dependsOn": [{ "projects": "self", "target": "build" }]
 }
 ```
 
@@ -290,24 +290,24 @@ With the expanded syntax, you also have a third option available to configure ho
 ```json
 "build": {
    // forward params passed to this target to the dependency targets
-  "dependsOn": [{ "projects": "{dependencies}", "target": "build", "params": "forward" }]
+  "dependsOn": [{ "projects": "dependencies", "target": "build", "params": "forward" }]
 },
 "test": {
   // ignore params passed to this target, won't be forwarded to the dependency targets
-  "dependsOn": [{ "projects": "{dependencies}", "target": "build", "params": "ignore" }]
+  "dependsOn": [{ "projects": "dependencies", "target": "build", "params": "ignore" }]
 }
 "lint": {
   // ignore params passed to this target, won't be forwarded to the dependency targets
-  "dependsOn": [{ "projects": "{dependencies}", "target": "build" }]
+  "dependsOn": [{ "projects": "dependencies", "target": "build" }]
 }
 ```
 
-Obviously this also works when defining a relation for the target of the project itself using `"projects": "{self}"`:
+Obviously this also works when defining a relation for the target of the project itself using `"projects": "self"`:
 
 ```json
 "build": {
    // forward params passed to this target to the project target
-  "dependsOn": [{ "projects": "{self}", "target": "pre-build", "params": "forward" }]
+  "dependsOn": [{ "projects": "self", "target": "pre-build", "params": "forward" }]
 }
 ```
 

--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -59,6 +59,12 @@
       "version": "16.0.0-beta.0",
       "description": "Remove @nrwl/cli.",
       "implementation": "./src/migrations/update-16-0-0/remove-nrwl-cli"
+    },
+    "16.0.0-tokens-for-depends-on": {
+      "cli": "nx",
+      "version": "16.0.0-beta.0",
+      "description": "Replace `dependsOn.projects` with {self} or {dependencies} tokens so that it matches the new expected formatting.",
+      "implementation": "./src/migrations/update-16-0-0/update-depends-on-to-tokens"
     }
   }
 }

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -247,9 +247,19 @@
                 "type": "object",
                 "properties": {
                   "projects": {
-                    "type": "string",
-                    "description": "The projects that the targets belong to.",
-                    "enum": ["self", "dependencies"]
+                    "oneOf": [
+                      {
+                        "type": "string",
+                        "description": "{self}, {dependencies}, or a project name."
+                      },
+                      {
+                        "type": "array",
+                        "description": "An array of project specifiers: {self}, {dependencies}, or a project name.",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    ]
                   },
                   "target": {
                     "type": "string",

--- a/packages/nx/schemas/project-schema.json
+++ b/packages/nx/schemas/project-schema.json
@@ -55,9 +55,19 @@
                   "type": "object",
                   "properties": {
                     "projects": {
-                      "type": "string",
-                      "description": "The projects that the targets belong to.",
-                      "enum": ["self", "dependencies"]
+                      "oneOf": [
+                        {
+                          "type": "string",
+                          "description": "{self}, {dependencies}, or a project name."
+                        },
+                        {
+                          "type": "array",
+                          "description": "An array of project specifiers: {self}, {dependencies}, or a project name.",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      ]
                     },
                     "target": {
                       "type": "string",

--- a/packages/nx/schemas/workspace-schema.json
+++ b/packages/nx/schemas/workspace-schema.json
@@ -65,9 +65,19 @@
                                   "type": "object",
                                   "properties": {
                                     "projects": {
-                                      "type": "string",
-                                      "description": "The projects that the targets belong to.",
-                                      "enum": ["self", "dependencies"]
+                                      "oneOf": [
+                                        {
+                                          "type": "string",
+                                          "description": "{self}, {dependencies}, or a project name."
+                                        },
+                                        {
+                                          "type": "array",
+                                          "description": "An array of project specifiers: {self}, {dependencies}, or a project name.",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ]
                                     },
                                     "target": {
                                       "type": "string",

--- a/packages/nx/src/config/workspace-json-project-json.ts
+++ b/packages/nx/src/config/workspace-json-project-json.ts
@@ -102,10 +102,13 @@ export interface ProjectConfiguration {
 
 export interface TargetDependencyConfig {
   /**
-   * A list of projects that have `target`. Supports two tokens or a string[]:
+   * A list of projects that have `target`. Supports project names or two special values:
    *
    * - '{self}': This target depends on another target of the same project
    * - '{dependencies}': This target depends on targets of the projects of it's deps.
+   *
+   * The special values {self}/{dependencies} should be preferred - they prevent cases where a project
+   * that needs to be built is missed.
    */
   projects: string[] | string;
 

--- a/packages/nx/src/config/workspace-json-project-json.ts
+++ b/packages/nx/src/config/workspace-json-project-json.ts
@@ -102,12 +102,12 @@ export interface ProjectConfiguration {
 
 export interface TargetDependencyConfig {
   /**
-   * This the projects that the targets belong to
+   * A list of projects that have `target`. Supports two tokens or a string[]:
    *
-   * 'self': This target depends on another target of the same project
-   * 'deps': This target depends on targets of the projects of it's deps.
+   * - '{self}': This target depends on another target of the same project
+   * - '{dependencies}': This target depends on targets of the projects of it's deps.
    */
-  projects: 'self' | 'dependencies';
+  projects: string[] | string;
 
   /**
    * The name of the target

--- a/packages/nx/src/migrations/update-16-0-0/update-depends-on-to-tokens.spec.ts
+++ b/packages/nx/src/migrations/update-16-0-0/update-depends-on-to-tokens.spec.ts
@@ -1,0 +1,104 @@
+import {
+  addProjectConfiguration,
+  getProjects,
+  readNxJson,
+  readProjectConfiguration,
+} from '../../generators/utils/project-configuration';
+import { Tree } from '../../generators/tree';
+
+import update from './update-depends-on-to-tokens';
+import { updateJson, writeJson } from 'nx/src/devkit-exports';
+import { createTreeWithEmptyWorkspace } from '../../generators/testing-utils/create-tree-with-empty-workspace';
+
+describe('update-depends-on-to-tokens', () => {
+  it('should update nx.json', async () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'nx.json', (json) => {
+      json.targetDefaults = {
+        build: {
+          dependsOn: [
+            {
+              projects: 'self',
+            },
+          ],
+        },
+        test: {
+          dependsOn: [
+            {
+              projects: 'dependencies',
+            },
+          ],
+        },
+        other: {
+          dependsOn: ['^deps'],
+        },
+      };
+      return json;
+    });
+    await update(tree);
+    const nxJson = readNxJson(tree);
+    const build = nxJson.targetDefaults.build.dependsOn[0] as any;
+    const test = nxJson.targetDefaults.test.dependsOn[0] as any;
+    expect(build.projects).toEqual('{self}');
+    expect(test.projects).toEqual('{dependencies}');
+    expect(nxJson.targetDefaults.other.dependsOn).toEqual(['^deps']);
+  });
+
+  it('should update project configurations', async () => {
+    const tree = createTreeWithEmptyWorkspace();
+    addProjectConfiguration(tree, 'proj1', {
+      root: 'proj1',
+      targets: {
+        build: {
+          dependsOn: [
+            {
+              projects: 'self',
+              target: 'build',
+            },
+          ],
+        },
+        test: {
+          dependsOn: [
+            {
+              projects: 'dependencies',
+              target: 'test',
+            },
+          ],
+        },
+        other: {
+          dependsOn: ['^deps'],
+        },
+      },
+    });
+    await update(tree);
+    const project = readProjectConfiguration(tree, 'proj1');
+    const build = project.targets.build.dependsOn[0] as any;
+    const test = project.targets.test.dependsOn[0] as any;
+    expect(build.projects).toEqual('{self}');
+    expect(test.projects).toEqual('{dependencies}');
+    expect(project.targets.other.dependsOn).toEqual(['^deps']);
+  });
+
+  it('should not throw on nulls', async () => {
+    const tree = createTreeWithEmptyWorkspace();
+    addProjectConfiguration(tree, 'proj1', {
+      root: 'proj1',
+    });
+    addProjectConfiguration(tree, 'proj2', {
+      root: 'proj2',
+      targets: {
+        build: {},
+      },
+    });
+    writeJson(tree, 'nx.json', {});
+    let promise = update(tree);
+    await expect(promise).resolves.toBeUndefined();
+    writeJson(tree, 'nx.json', {
+      targetDefaults: {
+        build: {},
+      },
+    });
+    promise = update(tree);
+    await expect(promise).resolves.toBeUndefined();
+  });
+});

--- a/packages/nx/src/migrations/update-16-0-0/update-depends-on-to-tokens.ts
+++ b/packages/nx/src/migrations/update-16-0-0/update-depends-on-to-tokens.ts
@@ -1,0 +1,51 @@
+import {
+  getProjects,
+  readNxJson,
+  updateProjectConfiguration,
+} from '../../generators/utils/project-configuration';
+import { Tree } from '../../generators/tree';
+
+export default async function (tree: Tree) {
+  updateNxJson(tree);
+
+  const projectsConfigurations = getProjects(tree);
+  for (const [projectName, projectConfiguration] of projectsConfigurations) {
+    let projectChanged = false;
+    for (const [targetName, targetConfiguration] of Object.entries(
+      projectConfiguration.targets ?? {}
+    )) {
+      for (const dependency of targetConfiguration.dependsOn ?? []) {
+        if (typeof dependency !== 'string') {
+          dependency.projects =
+            (dependency.projects as string) === 'self'
+              ? '{self}'
+              : '{dependencies}';
+          projectChanged = true;
+        }
+      }
+    }
+    if (projectChanged) {
+      updateProjectConfiguration(tree, projectName, projectConfiguration);
+    }
+  }
+}
+function updateNxJson(tree: Tree) {
+  const nxJson = readNxJson(tree);
+  let nxJsonChanged = false;
+  for (const [target, defaults] of Object.entries(
+    nxJson?.targetDefaults ?? {}
+  )) {
+    for (const dependency of defaults.dependsOn ?? []) {
+      if (typeof dependency !== 'string') {
+        dependency.projects =
+          (dependency.projects as string) === 'self'
+            ? '{self}'
+            : '{dependencies}';
+        nxJsonChanged = true;
+      }
+    }
+  }
+  if (nxJsonChanged) {
+    tree.write('nx.json', JSON.stringify(nxJson, null, 2));
+  }
+}

--- a/packages/nx/src/tasks-runner/create-task-graph.spec.ts
+++ b/packages/nx/src/tasks-runner/create-task-graph.spec.ts
@@ -17,16 +17,23 @@ describe('createTaskGraph', () => {
               prebuild: {
                 executor: 'nx:run-commands',
               },
+              prebuild2: {
+                executor: 'nx:run-commands',
+              },
               build: {
                 executor: 'nx:run-commands',
                 dependsOn: [
                   {
-                    projects: 'dependencies',
+                    projects: '{dependencies}',
                     target: 'build',
                   },
                   {
-                    projects: 'self',
+                    projects: '{self}',
                     target: 'prebuild',
+                  },
+                  {
+                    projects: 'app1',
+                    target: 'prebuild2',
                   },
                 ],
               },
@@ -166,7 +173,7 @@ describe('createTaskGraph', () => {
                 },
                 dependsOn: [
                   {
-                    projects: 'dependencies',
+                    projects: '{dependencies}',
                     target: 'build',
                   },
                 ],
@@ -189,7 +196,7 @@ describe('createTaskGraph', () => {
                 defaultConfiguration: 'libDefault',
                 dependsOn: [
                   {
-                    projects: 'dependencies',
+                    projects: '{dependencies}',
                     target: 'build',
                   },
                 ],
@@ -330,7 +337,7 @@ describe('createTaskGraph', () => {
                 executor: 'my-executor',
                 dependsOn: [
                   {
-                    projects: 'dependencies',
+                    projects: '{dependencies}',
                     target: 'build',
                   },
                 ],
@@ -501,11 +508,11 @@ describe('createTaskGraph', () => {
                 executor: 'nx:run-commands',
                 dependsOn: [
                   {
-                    projects: 'dependencies',
+                    projects: '{dependencies}',
                     target: 'build',
                     params: 'forward',
                   },
-                  { projects: 'self', target: 'prebuild', params: 'forward' },
+                  { projects: '{self}', target: 'prebuild', params: 'forward' },
                 ],
               },
               test: {
@@ -528,7 +535,7 @@ describe('createTaskGraph', () => {
                 executor: 'nx:run-commands',
                 dependsOn: [
                   {
-                    projects: 'dependencies',
+                    projects: '{dependencies}',
                     target: 'build',
                     params: 'ignore',
                   },
@@ -640,7 +647,7 @@ describe('createTaskGraph', () => {
     );
     // prebuild should also be in here
     expect(taskGraph).toEqual({
-      roots: ['lib1:build', 'app1:prebuild'],
+      roots: ['lib1:build', 'app1:prebuild', 'app1:prebuild2'],
       tasks: {
         'app1:build': {
           id: 'app1:build',
@@ -664,6 +671,17 @@ describe('createTaskGraph', () => {
           },
           projectRoot: 'app1-root',
         },
+        'app1:prebuild2': {
+          id: 'app1:prebuild2',
+          target: {
+            project: 'app1',
+            target: 'prebuild2',
+          },
+          overrides: {
+            __overrides_unparsed__: [],
+          },
+          projectRoot: 'app1-root',
+        },
         'lib1:build': {
           id: 'lib1:build',
           target: {
@@ -677,8 +695,9 @@ describe('createTaskGraph', () => {
         },
       },
       dependencies: {
-        'app1:build': ['lib1:build', 'app1:prebuild'],
+        'app1:build': ['lib1:build', 'app1:prebuild', 'app1:prebuild2'],
         'app1:prebuild': [],
+        'app1:prebuild2': [],
         'lib1:build': [],
       },
     });
@@ -697,7 +716,7 @@ describe('createTaskGraph', () => {
     );
     // prebuild should also be in here
     expect(taskGraph).toEqual({
-      roots: ['app1:prebuild', 'lib1:build'],
+      roots: ['app1:prebuild', 'lib1:build', 'app1:prebuild2'],
       tasks: {
         'app1:build': {
           id: 'app1:build',
@@ -721,6 +740,17 @@ describe('createTaskGraph', () => {
           },
           projectRoot: 'app1-root',
         },
+        'app1:prebuild2': {
+          id: 'app1:prebuild2',
+          target: {
+            project: 'app1',
+            target: 'prebuild2',
+          },
+          overrides: {
+            __overrides_unparsed__: [],
+          },
+          projectRoot: 'app1-root',
+        },
         'lib1:build': {
           id: 'lib1:build',
           target: {
@@ -734,8 +764,9 @@ describe('createTaskGraph', () => {
         },
       },
       dependencies: {
-        'app1:build': ['lib1:build', 'app1:prebuild'],
+        'app1:build': ['lib1:build', 'app1:prebuild', 'app1:prebuild2'],
         'app1:prebuild': [],
+        'app1:prebuild2': [],
         'lib1:build': [],
       },
     });
@@ -813,7 +844,7 @@ describe('createTaskGraph', () => {
       {
         build: [
           {
-            projects: 'dependencies',
+            projects: '{dependencies}',
             target: 'build',
           },
         ],
@@ -974,9 +1005,9 @@ describe('createTaskGraph', () => {
       {
         build: ['^build'],
         apply: [
-          { projects: 'dependencies', target: 'build' },
+          { projects: '{dependencies}', target: 'build' },
           {
-            projects: 'dependencies',
+            projects: '{dependencies}',
             target: 'apply',
             params: 'forward',
           },
@@ -1052,11 +1083,11 @@ describe('createTaskGraph', () => {
             targets: {
               build: {
                 executor: 'nx:run-commands',
-                dependsOn: [{ target: 'test', projects: 'self' }],
+                dependsOn: [{ target: 'test', projects: '{self}' }],
               },
               test: {
                 executor: 'nx:run-commands',
-                dependsOn: [{ target: 'build', projects: 'self' }],
+                dependsOn: [{ target: 'build', projects: '{self}' }],
               },
             },
           },
@@ -1161,7 +1192,7 @@ describe('createTaskGraph', () => {
     const taskGraph = createTaskGraph(
       projectGraph,
       {
-        build: [{ target: 'build', projects: 'dependencies' }],
+        build: [{ target: 'build', projects: '{dependencies}' }],
       },
       ['app1'],
       ['build'],
@@ -1252,7 +1283,7 @@ describe('createTaskGraph', () => {
     const taskGraph = createTaskGraph(
       projectGraph,
       {
-        build: [{ target: 'build', projects: 'dependencies' }],
+        build: [{ target: 'build', projects: '{dependencies}' }],
       },
       ['app1'],
       ['build'],
@@ -1307,8 +1338,8 @@ describe('createTaskGraph', () => {
               build: {
                 executor: 'nx:run-commands',
                 dependsOn: [
-                  { target: 'prebuild', projects: 'self' },
-                  { target: 'build', projects: 'dependencies' },
+                  { target: 'prebuild', projects: '{self}' },
+                  { target: 'build', projects: '{dependencies}' },
                 ],
               },
               prebuild: {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
In its object form, `dependsOn` has a `projects` property. This property takes a string, despite being plural, and only accepts `self` or `dependencies` as its value.

## Expected Behavior
`projects` can be an array of project names, but supports `{self}` and `{dependencies}` as tokens

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16100
