### PR TITLE
fix(core): don't show global version warning when Nx is invoked by itself

### DIFF
--- a/packages/nx/bin/init-local.ts
+++ b/packages/nx/bin/init-local.ts
@@ -12,9 +12,10 @@ import { stripIndents } from '../src/utils/strip-indents';
  *
  * @param workspace Relevant local workspace properties
  */
-process.env.NX_CLI_SET = 'true';
 
 export function initLocal(workspace: WorkspaceTypeAndRoot) {
+  process.env.NX_CLI_SET = 'true';
+
   try {
     performance.mark('init-local');
     require('nx/src/utils/perf-logging');

--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -138,6 +138,11 @@ function warnIfUsingOutdatedGlobalInstall(
   globalNxVersion: string,
   localNxVersion?: string
 ) {
+  // Never display this warning if Nx is already running via Nx
+  if (process.env.NX_CLI_SET) {
+    return;
+  }
+
   const isOutdatedGlobalInstall =
     globalNxVersion &&
     ((localNxVersion && major(globalNxVersion) < major(localNxVersion)) ||


### PR DESCRIPTION
…self

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
