### PR TITLE
fix(react-native): add aliasFields to handle replaced files in browser env

### DIFF
--- a/packages/expo/plugins/metro-resolver.ts
+++ b/packages/expo/plugins/metro-resolver.ts
@@ -205,6 +205,7 @@ function getPnpmResolver(extensions: string[]) {
       modules: [join(workspaceRoot, 'node_modules'), 'node_modules'],
       conditionNames: ['native', 'browser', 'require', 'default'],
       mainFields: ['react-native', 'browser', 'main'],
+      aliasFields: ['browser'],
     });
   }
   return resolver;

--- a/packages/react-native/plugins/metro-resolver.ts
+++ b/packages/react-native/plugins/metro-resolver.ts
@@ -205,6 +205,7 @@ function getPnpmResolver(extensions: string[]) {
       modules: [join(workspaceRoot, 'node_modules'), 'node_modules'],
       conditionNames: ['native', 'browser', 'require', 'default'],
       mainFields: ['react-native', 'browser', 'main'],
+      aliasFields: ['browser'],
     });
   }
   return resolver;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
[browser](https://github.com/defunctzombie/package-browser-field-spec) field in `package.json` can be an object, hints some files need to be replaced when packaging. Currently, pnpm module resolver doesn't do the file replacements.

e.g. 
When resolving [picocolors](https://github.com/alexeyraspopov/picocolors), module resolver resolves to the wrong entry file.
Current behavior: `…/node_modules/picocolors/picocolors.js`

Picocolors has the following package.json

```json
"name": "picocolors",
  "version": "1.0.0",
  "main": "./picocolors.js",
  "types": "./picocolors.d.ts",
  "browser": {
    "./picocolors.js": "./picocolors.browser.js"
  }
```


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Should resolve to `…/node_modules/picocolors/picocolors.browser.js`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16105
