### PR TITLE
docs(angular): fix wrong link to angular cli migration docs in plugin overview page

### DIFF
--- a/docs/generated/packages/angular/documents/overview.md
+++ b/docs/generated/packages/angular/documents/overview.md
@@ -92,7 +92,7 @@ nx g @nrwl/angular:service my-service
 ## More Documentation
 
 - [Angular Nx Tutorial](/angular-tutorial/1-code-generation)
-- [Migrating from the Angular CLI](recipe/migration-angular)
+- [Migrating from the Angular CLI](/recipes/adopting-nx/migration-angular)
 - [Setup Module Federation with Angular and Nx](/recipes/module-federation/faster-builds)
 - [Using NgRx](/recipes/other/misc-ngrx)
 - [Using Data Persistence operators](/recipes/other/misc-data-persistence)

--- a/docs/shared/packages/angular/angular-plugin.md
+++ b/docs/shared/packages/angular/angular-plugin.md
@@ -92,7 +92,7 @@ nx g @nrwl/angular:service my-service
 ## More Documentation
 
 - [Angular Nx Tutorial](/angular-tutorial/1-code-generation)
-- [Migrating from the Angular CLI](recipe/migration-angular)
+- [Migrating from the Angular CLI](/recipes/adopting-nx/migration-angular)
 - [Setup Module Federation with Angular and Nx](/recipes/module-federation/faster-builds)
 - [Using NgRx](/recipes/other/misc-ngrx)
 - [Using Data Persistence operators](/recipes/other/misc-data-persistence)


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The link to "Migrating from the Angular CLI" in the Angular plugin overview page is wrong and results in a 404 page.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The link to "Migrating from the Angular CLI" in the Angular plugin overview page is correct.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
