### PR TITLE
docs(nx-plugin): fixed the uses of the wrong example

### DIFF
--- a/docs/shared/recipes/generators/generator-options.md
+++ b/docs/shared/recipes/generators/generator-options.md
@@ -903,7 +903,7 @@ Make sure that the number is less than the specified number.
 {
   "value": {
     "type": "number",
-    "maximum": 201
+    "exclusiveMaximum": 201
   }
 }
 ```


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
In the documentation of the generator options,  about the example of `exclusiveMaximum`, It uses the` maximum` option.
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
use `exclusiveMaximum` instead of `maximum`


