### PR TITLE
fix(angular): host and remote app generation with directory

### DIFF
--- a/packages/angular/src/generators/host/host.ts
+++ b/packages/angular/src/generators/host/host.ts
@@ -1,4 +1,5 @@
 import {
+  extractLayoutDirectory,
   formatFiles,
   getProjects,
   runTasksInSerial,
@@ -39,7 +40,8 @@ export async function host(tree: Tree, options: Schema) {
     });
   }
 
-  const appName = normalizeProjectName(options.name, options.directory);
+  const { projectDirectory } = extractLayoutDirectory(options.directory);
+  const appName = normalizeProjectName(options.name, projectDirectory);
 
   const appInstallTask = await applicationGenerator(tree, {
     ...options,

--- a/packages/angular/src/generators/remote/remote.ts
+++ b/packages/angular/src/generators/remote/remote.ts
@@ -1,4 +1,5 @@
 import {
+  extractLayoutDirectory,
   formatFiles,
   getProjects,
   runTasksInSerial,
@@ -30,7 +31,8 @@ export async function remote(tree: Tree, options: Schema) {
     );
   }
 
-  const appName = normalizeProjectName(options.name, options.directory);
+  const { projectDirectory } = extractLayoutDirectory(options.directory);
+  const appName = normalizeProjectName(options.name, projectDirectory);
   const port = options.port ?? findNextAvailablePort(tree);
 
   const appInstallTask = await applicationGenerator(tree, {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Passing a directory option to remote and host generator that contains a layout directory causes an incorrect project name resolution in the generators. 
This leads to being unable to find the correct project in the workspace.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The layout directory should be extracted if it exists, therefore the app name can be resolved correctly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16083
