### PR TITLE
feat(repo): replace pnpm with yarn for CI runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,7 @@ jobs:
         default: 'linux'
       pm:
         type: string
-        default: 'pnpm'
+        default: 'yarn'
     executor: << parameters.os >>
     environment:
       GIT_AUTHOR_EMAIL: test@test.com
@@ -217,7 +217,7 @@ jobs:
       NX_E2E_CI_CACHE_KEY: e2e-circleci-macos
       NX_DAEMON: 'true'
       NX_PERF_LOGGING: 'false'
-      SELECTED_PM: 'npm' # explicitly define npm for macOS tests
+      SELECTED_PM: 'yarn'
     steps:
       - run:
           name: Set dynamic nx run variable

--- a/nx.json
+++ b/nx.json
@@ -113,6 +113,7 @@
       "inputs": [
         "default",
         "^production",
+        "{workspaceRoot}/.circleci/config.yml",
         {
           "env": "SELECTED_CLI"
         },

--- a/nx.json
+++ b/nx.json
@@ -113,7 +113,6 @@
       "inputs": [
         "default",
         "^production",
-        "{workspaceRoot}/.circleci/config.yml",
         {
           "env": "SELECTED_CLI"
         },


### PR DESCRIPTION
Based on the test CI e2e runs with `yarn` are significantly faster than `pnpm`
![Screenshot 2023-04-06 at 15 07 36](https://user-images.githubusercontent.com/881612/230389752-b775e94e-286d-48b5-89d3-20a24e97c8f2.png)

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
