### PR TITLE
feat(nextjs): update to Next.js 13.3.0

### DIFF
--- a/e2e/workspace-create-npm/src/create-nx-workspace-npm.test.ts
+++ b/e2e/workspace-create-npm/src/create-nx-workspace-npm.test.ts
@@ -136,6 +136,7 @@ describe('create-nx-workspace --preset=npm', () => {
     const tsconfig = readJson(`tsconfig.base.json`);
     expect(tsconfig.compilerOptions.paths).toEqual({
       [libName]: [`packages/${libName}/src/index.ts`],
+      [`${libName}/server`]: [`packages/${libName}/src/server.ts`],
     });
   });
 

--- a/packages/angular/src/generators/library/library.ts
+++ b/packages/angular/src/generators/library/library.ts
@@ -3,12 +3,13 @@ import {
   formatFiles,
   GeneratorCallback,
   installPackagesTask,
+  joinPathFragments,
   removeDependenciesFromPackageJson,
   Tree,
 } from '@nrwl/devkit';
 import { jestProjectGenerator } from '@nrwl/jest';
 import { Linter } from '@nrwl/linter';
-import { updateRootTsConfig } from '@nrwl/js';
+import { addTsConfigPath } from '@nrwl/js';
 import { lt } from 'semver';
 import init from '../../generators/init/init';
 import { E2eTestRunner } from '../../utils/test-runners';
@@ -107,7 +108,9 @@ export async function libraryGenerator(
     addBuildableLibrariesPostCssDependencies(tree);
   }
 
-  updateRootTsConfig(tree, { ...libraryOptions, js: false });
+  addTsConfigPath(tree, libraryOptions.importPath, [
+    joinPathFragments(libraryOptions.projectRoot, './src', 'index.ts'),
+  ]);
 
   if (!libraryOptions.skipFormat) {
     await formatFiles(tree);

--- a/packages/expo/src/generators/library/library.ts
+++ b/packages/expo/src/generators/library/library.ts
@@ -15,7 +15,7 @@ import {
   updateJson,
 } from '@nrwl/devkit';
 
-import { updateRootTsConfig } from '@nrwl/js';
+import { addTsConfigPath } from '@nrwl/js';
 
 import init from '../init/init';
 import { addLinting } from '../../utils/add-linting';
@@ -54,7 +54,13 @@ export async function expoLibraryGenerator(
   );
 
   if (!options.skipTsConfig) {
-    updateRootTsConfig(host, options);
+    addTsConfigPath(host, options.importPath, [
+      joinPathFragments(
+        options.projectRoot,
+        './src',
+        'index.' + (options.js ? 'js' : 'ts')
+      ),
+    ]);
   }
 
   const jestTask = await addJest(

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -21,8 +21,8 @@ import {
 import { getImportPath } from 'nx/src/utils/path';
 
 import {
+  addTsConfigPath,
   getRelativePathToRootTsConfig,
-  updateRootTsConfig,
 } from '../../utils/typescript/ts-config';
 import { join } from 'path';
 import { addMinimalPublishScript } from '../../utils/minimal-publish-script';
@@ -117,7 +117,13 @@ export async function projectGenerator(
   }
 
   if (!schema.skipTsConfig) {
-    updateRootTsConfig(tree, options);
+    addTsConfigPath(tree, options.importPath, [
+      joinPathFragments(
+        options.projectRoot,
+        './src',
+        'index.' + (options.js ? 'js' : 'ts')
+      ),
+    ]);
   }
 
   if (!options.skipFormat) {

--- a/packages/js/src/utils/typescript/ts-config.ts
+++ b/packages/js/src/utils/typescript/ts-config.ts
@@ -52,38 +52,22 @@ export function getRootTsConfigFileName(tree: Tree): string | null {
   return null;
 }
 
-export function updateRootTsConfig(
-  host: Tree,
-  options: {
-    name: string;
-    importPath?: string;
-    projectRoot: string;
-    js?: boolean;
-  }
+export function addTsConfigPath(
+  tree: Tree,
+  importPath: string,
+  lookupPaths: string[]
 ) {
-  if (!options.importPath) {
-    throw new Error(
-      `Unable to update ${options.name} using the import path "${options.importPath}". Make sure to specify a valid import path one.`
-    );
-  }
-  updateJson(host, getRootTsConfigPathInTree(host), (json) => {
+  updateJson(tree, getRootTsConfigPathInTree(tree), (json) => {
     const c = json.compilerOptions;
-    c.paths = c.paths || {};
-    delete c.paths[options.name];
+    c.paths ??= {};
 
-    if (c.paths[options.importPath]) {
+    if (c.paths[importPath]) {
       throw new Error(
-        `You already have a library using the import path "${options.importPath}". Make sure to specify a unique one.`
+        `You already have a library using the import path "${importPath}". Make sure to specify a unique one.`
       );
     }
 
-    c.paths[options.importPath] = [
-      joinPathFragments(
-        options.projectRoot,
-        './src',
-        'index.' + (options.js ? 'js' : 'ts')
-      ),
-    ];
+    c.paths[importPath] = lookupPaths;
 
     return json;
   });

--- a/packages/next/src/generators/library/lib/normalize-options.spec.ts
+++ b/packages/next/src/generators/library/lib/normalize-options.spec.ts
@@ -1,0 +1,26 @@
+import type { Tree } from '@nrwl/devkit';
+import { Linter } from '@nrwl/linter';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { normalizeOptions } from './normalize-options';
+
+describe('normalizeOptions', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should set importPath and projectRoot', () => {
+    const options = normalizeOptions(tree, {
+      name: 'my-lib',
+      style: 'css',
+      linter: Linter.None,
+      unitTestRunner: 'jest',
+    });
+
+    expect(options).toMatchObject({
+      importPath: '@proj/my-lib',
+      projectRoot: 'my-lib',
+    });
+  });
+});

--- a/packages/next/src/generators/library/lib/normalize-options.ts
+++ b/packages/next/src/generators/library/lib/normalize-options.ts
@@ -1,0 +1,32 @@
+import {
+  getImportPath,
+  getWorkspaceLayout,
+  joinPathFragments,
+  names,
+  Tree,
+} from '@nrwl/devkit';
+import { Schema } from '../schema';
+
+export interface NormalizedSchema extends Schema {
+  importPath: string;
+  projectRoot: string;
+}
+
+export function normalizeOptions(
+  host: Tree,
+  options: Schema
+): NormalizedSchema {
+  const name = names(options.name).fileName;
+  const projectDirectory = options.directory
+    ? `${names(options.directory).fileName}/${name}`
+    : name;
+
+  const { libsDir } = getWorkspaceLayout(host);
+  const projectRoot = joinPathFragments(libsDir, projectDirectory);
+  const { npmScope } = getWorkspaceLayout(host);
+  return {
+    ...options,
+    importPath: options.importPath ?? getImportPath(npmScope, projectDirectory),
+    projectRoot,
+  };
+}

--- a/packages/next/src/generators/library/schema.d.ts
+++ b/packages/next/src/generators/library/schema.d.ts
@@ -5,8 +5,8 @@ export interface Schema {
   name: string;
   directory?: string;
   style: SupportedStyles;
-  skipTsConfig: boolean;
-  skipFormat: boolean;
+  skipTsConfig?: boolean;
+  skipFormat?: boolean;
   tags?: string;
   pascalCaseFiles?: boolean;
   routing?: boolean;

--- a/packages/next/src/utils/versions.ts
+++ b/packages/next/src/utils/versions.ts
@@ -1,8 +1,8 @@
 export const nxVersion = require('../../package.json').version;
 
-export const nextVersion = '13.1.1';
-export const eslintConfigNextVersion = '13.1.1';
-export const sassVersion = '1.55.0';
+export const nextVersion = '13.3.0';
+export const eslintConfigNextVersion = '13.3.0';
+export const sassVersion = '1.61.0';
 export const lessLoader = '11.1.0';
 export const stylusLoader = '7.1.0';
 export const emotionServerVersion = '11.10.0';

--- a/packages/react-native/src/generators/library/library.ts
+++ b/packages/react-native/src/generators/library/library.ts
@@ -15,7 +15,7 @@ import {
   updateJson,
 } from '@nrwl/devkit';
 
-import { getRelativePathToRootTsConfig, updateRootTsConfig } from '@nrwl/js';
+import { addTsConfigPath, getRelativePathToRootTsConfig } from '@nrwl/js';
 import init from '../init/init';
 import { addLinting } from '../../utils/add-linting';
 import { addJest } from '../../utils/add-jest';
@@ -64,7 +64,9 @@ export async function reactNativeLibraryGenerator(
   }
 
   if (!options.skipTsConfig) {
-    updateRootTsConfig(host, { ...options, js: false });
+    addTsConfigPath(host, options.importPath, [
+      joinPathFragments(options.projectRoot, './src', 'index.ts'),
+    ]);
   }
 
   if (!options.skipFormat) {

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -10,7 +10,7 @@ import {
   updateJson,
 } from '@nrwl/devkit';
 
-import { updateRootTsConfig } from '@nrwl/js';
+import { addTsConfigPath } from '@nrwl/js';
 
 import { nxVersion } from '../../utils/versions';
 import componentGenerator from '../component/component';
@@ -162,8 +162,15 @@ export async function libraryGenerator(host: Tree, schema: Schema) {
   setDefaults(host, options);
 
   extractTsConfigBase(host);
+
   if (!options.skipTsConfig) {
-    updateRootTsConfig(host, options);
+    addTsConfigPath(host, options.importPath, [
+      joinPathFragments(
+        options.projectRoot,
+        './src',
+        'index.' + (options.js ? 'js' : 'ts')
+      ),
+    ]);
   }
 
   if (!options.skipFormat) {

--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -53,7 +53,7 @@ export async function configurationGenerator(
    */
 
   let storybook7 =
-    storybookMajorVersion() === 7 ?? rawSchema.storybook7Configuration;
+    storybookMajorVersion() === 7 || rawSchema.storybook7Configuration;
 
   if (storybookMajorVersion() === 6 && rawSchema.storybook7Configuration) {
     logger.error(


### PR DESCRIPTION
This PR updates the installed version of Next.js to 13.3.0 ~~and migrates existing workspaces~~.

We will hold off on migrating existing workspaces to 13.3 until we can put together a better migration experience for those using Storybook (they need to go to v7).

Also includes a few fixes. See below.

## ~~Use Storybook v7 for React/Next.js~~

~~Storybook v7 is stable now, and v6 is no longer maintained. Next.js 13.2 requires v7 to work, so it will be the default moving forward unless the user passes `--storybook7Configuration=false` when generating Storybook config (i.e. `nx g @nrwl/react:storybook-configuration --storybook7Configuration=false`).~~

> Note: Another PR just landed to update Storybook to v7 for new projects. No changes needed here anymore.

## Disable type checks by default (app/layout types are incorrect)

This only applies when appDir is enabled in `next.config.js`.

The Next.js type generation has a bug where the paths are wrong inside a monorepo. The PR is merged but waiting for a release (https://github.com/vercel/next.js/pull/47534).

Once released we can re-enable the type-check by default. In the meantime the user can update `next.config.js` config to enable it if the patch is released before we update.

## Generate libraries with separate RSC entry

Add a server-only entry for libraries generated with `@nrwl/next:lib` to help with libraries that export both client and server components. So users can import client-only components using deep import path. See: https://github.com/nrwl/nx/issues/15830

e.g. 

Say our library `my-lib` exported both RSC and client components in `index.ts`.

```ts
// my-lib/src/index.ts
export { MyClientOnlyComponent } from './my-client-only-component';
export { MyServerOnlyComponent } from './my-server-only-component';
```

Then importing this in a client component will error out.

**Fails:**

```ts
'use client';
import { MyClientOnlyComponent } from '@acme/my-lib';

export function ParentComponent() {
  return <MyClientOnlyComponent />;
}
```

But if we separate the two components into separate entry files.

```ts
// my-lib/src/index.ts
export { MyClientOnlyComponent } from './my-client-only-component';

// my-lib/src/server.ts
export { MyServerOnlyComponent } from './my-server-only-component';
```

Then importing from client entry file will work in both server _and_ client components.

**Works:**
```ts
'use client';
import { MyClientOnlyComponent } from '@acme/my-lib';

export function ParentComponent() {
  // Works because the main entry no longer has server-only components
  return <MyClientOnlyComponent />;
}
```

**Also works:**
```ts
import { MyClientOnlyComponent } from '@acme/my-lib';
import { MyServerOnlyComponent } from '@acme/my-lib/server';

export async function SomePage() {
  // Can render client component from server component
  return (
    <MyClientOnlyComponent/>
    <MyServerOnlyComponent/>
  );
}
```

This isn't an Nx issue because it's coming from `@next/swc`:
- How imports are collected:  https://github.com/vercel/next.js/blob/2820f0787512b6514e36c02cbddd4d3ab69f0251/packages/next-swc/crates/core/src/react_server_components.rs#L64
- The check that fails due to forbidden imports: https://github.com/vercel/next.js/blob/2820f0787512b6514e36c02cbddd4d3ab69f0251/packages/next-swc/crates/core/src/react_server_components.rs#L384