### PR TITLE
chore(repo): do not store node_modules in pipeline cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,6 @@ commands:
           name: Save Yarn Package Cache
           key: node-deps-{{ arch }}-v1-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
           paths:
-            - node_modules
             - ~/.cache/yarn
             - ~/.cache/Cypress
   install-pnpm:


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `node_modules` folder is being saved to the pipeline cache. This folder contains the Nx cache files and therefore, these files are restored and can cause issues with the pipeline run.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `node_modules` folder should not be cached. We already cache the package manager cache files which allow fast installations.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
