### PR TITLE
feat(misc): add --integrated option to nx init command

### DIFF
--- a/docs/generated/cli/init.md
+++ b/docs/generated/cli/init.md
@@ -14,3 +14,17 @@ nx init
 ```
 
 Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpm nx`.
+
+## Options
+
+### help
+
+Type: `boolean`
+
+Show help
+
+### version
+
+Type: `boolean`
+
+Show version number

--- a/docs/generated/packages/nx/documents/init.md
+++ b/docs/generated/packages/nx/documents/init.md
@@ -14,3 +14,17 @@ nx init
 ```
 
 Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpm nx`.
+
+## Options
+
+### help
+
+Type: `boolean`
+
+Show help
+
+### version
+
+Type: `boolean`
+
+Show version number

--- a/e2e/nx-init/src/nx-init-angular.test.ts
+++ b/e2e/nx-init/src/nx-init-angular.test.ts
@@ -28,7 +28,7 @@ describe('nx init (Angular CLI)', () => {
     cleanupProject();
   });
 
-  it('should successfully convert an Angular CLI workspace to an Nx workspace', () => {
+  it('should successfully convert an Angular CLI workspace to an Nx standalone workspace', () => {
     const output = runCommand(
       `${pmc.runUninstalledPackage} nx@${getPublishedVersion()} init -y`
     );
@@ -48,6 +48,40 @@ describe('nx init (Angular CLI)', () => {
       `Successfully ran target build for project ${project}`
     );
     checkFilesExist(`dist/${project}/main.js`);
+
+    // run build again to check is coming from cache
+    const cachedBuildOutput = runCLI(`build ${project} --outputHashing none`);
+    expect(cachedBuildOutput).toContain(
+      `> nx run ${project}:build:production --outputHashing none  [local cache]`
+    );
+    expect(cachedBuildOutput).toContain('Nx read the output from the cache');
+    expect(cachedBuildOutput).toContain(
+      `Successfully ran target build for project ${project}`
+    );
+  });
+
+  it('should successfully convert an Angular CLI workspace to an Nx integrated workspace', () => {
+    const output = runCommand(
+      `${
+        pmc.runUninstalledPackage
+      } nx@${getPublishedVersion()} init -y --integrated`
+    );
+
+    expect(output).toContain('Nx is now enabled in your workspace!');
+    // angular.json should have been deleted
+    checkFilesDoNotExist('angular.json');
+    // check nx config files exist
+    checkFilesExist('nx.json', `apps/${project}/project.json`);
+
+    // check build
+    const coldBuildOutput = runCLI(`build ${project} --outputHashing none`);
+    expect(coldBuildOutput).toContain(
+      `> nx run ${project}:build:production --outputHashing none`
+    );
+    expect(coldBuildOutput).toContain(
+      `Successfully ran target build for project ${project}`
+    );
+    checkFilesExist(`dist/apps/${project}/main.js`);
 
     // run build again to check is coming from cache
     const cachedBuildOutput = runCLI(`build ${project} --outputHashing none`);

--- a/packages/nx/src/command-line/init.ts
+++ b/packages/nx/src/command-line/init.ts
@@ -13,7 +13,11 @@ import { runNxSync } from '../utils/child-process';
 import { directoryExists, readJsonFile } from '../utils/fileutils';
 import { PackageJson } from '../utils/package-json';
 
-export async function initHandler() {
+export interface InitArgs {
+  integrated: boolean;
+}
+
+export async function initHandler(options: InitArgs) {
   const args = process.argv.slice(2).join(' ');
   const flags = parser(args, {
     boolean: ['useDotNxInstallation'],
@@ -36,9 +40,9 @@ export async function initHandler() {
   } else if (existsSync('package.json')) {
     const packageJson: PackageJson = readJsonFile('package.json');
     if (existsSync('angular.json')) {
-      await addNxToAngularCliRepo();
+      await addNxToAngularCliRepo(options.integrated);
     } else if (isCRA(packageJson)) {
-      await addNxToCraRepo();
+      await addNxToCraRepo(options.integrated);
     } else if (isNestCLI(packageJson)) {
       await addNxToNest(packageJson);
     } else if (isMonorepo(packageJson)) {

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -304,8 +304,9 @@ export const commandsObject = yargs
   .command({
     command: 'init',
     describe: 'Adds nx.json file and installs nx if not installed already',
-    handler: async () => {
-      await (await import('./init')).initHandler();
+    builder: (yargs) => withIntegratedOption(yargs),
+    handler: async (args: any) => {
+      await (await import('./init')).initHandler(args);
       process.exit(0);
     },
   })
@@ -1115,6 +1116,16 @@ function withListOptions(yargs) {
   return yargs.positional('plugin', {
     type: 'string',
     description: 'The name of an installed plugin to query',
+  });
+}
+
+function withIntegratedOption(yargs) {
+  return yargs.option('integrated', {
+    type: 'boolean',
+    description:
+      'Migrate to an Nx integrated layout workspace. Only for CRA and Angular projects.',
+    // TODO(leo): keep it hidden until feature is released
+    hidden: true,
   });
 }
 

--- a/packages/nx/src/nx-init/angular/integrated-workspace.ts
+++ b/packages/nx/src/nx-init/angular/integrated-workspace.ts
@@ -1,0 +1,7 @@
+import { execSync } from 'child_process';
+import { getPackageManagerCommand } from '../../utils/package-manager';
+
+export function setupIntegratedWorkspace(): void {
+  const pmc = getPackageManagerCommand();
+  execSync(`${pmc.exec} ng g @nrwl/angular:ng-add`, { stdio: [0, 1, 2] });
+}

--- a/packages/nx/src/nx-init/angular/legacy-angular-versions.ts
+++ b/packages/nx/src/nx-init/angular/legacy-angular-versions.ts
@@ -23,6 +23,7 @@ const versionWithConsolidatedPackages = '13.9.0';
 
 export async function getLegacyMigrationFunctionIfApplicable(
   repoRoot: string,
+  isIntegratedMigration: boolean,
   interactive: boolean
 ): Promise<() => Promise<void> | null> {
   const angularVersion =
@@ -43,12 +44,18 @@ export async function getLegacyMigrationFunctionIfApplicable(
       pkgName,
       `^${majorAngularVersion}.0.0`
     );
-    legacyMigrationCommand = `ng g ${pkgName}:ng-add --preserveAngularCLILayout`;
+    const preserveAngularCliLayoutFlag = !isIntegratedMigration
+      ? '--preserveAngularCLILayout'
+      : '--preserveAngularCLILayout=false';
+    legacyMigrationCommand = `ng g ${pkgName}:ng-add ${preserveAngularCliLayoutFlag}`;
   } else if (majorAngularVersion < 14) {
     // for v13, the migration was in @nrwl/angular:ng-add
     pkgName = '@nrwl/angular';
     pkgVersion = await resolvePackageVersion(pkgName, '~14.1.0');
-    legacyMigrationCommand = `ng g ${pkgName}:ng-add --preserve-angular-cli-layout`;
+    const preserveAngularCliLayoutFlag = !isIntegratedMigration
+      ? '--preserve-angular-cli-layout'
+      : '--preserve-angular-cli-layout=false';
+    legacyMigrationCommand = `ng g ${pkgName}:ng-add ${preserveAngularCliLayoutFlag}`;
   } else {
     // use the latest Nx version that supported the Angular version
     pkgName = '@nrwl/angular';

--- a/packages/nx/src/nx-init/angular/standalone-workspace.ts
+++ b/packages/nx/src/nx-init/angular/standalone-workspace.ts
@@ -1,0 +1,225 @@
+import { unlinkSync } from 'fs';
+import { dirname, join, relative, resolve } from 'path';
+import { toNewFormat } from '../../adapter/angular-json';
+import type { NxJsonConfiguration } from '../../config/nx-json';
+import type { ProjectConfiguration } from '../../config/workspace-json-project-json';
+import { fileExists, readJsonFile, writeJsonFile } from '../../utils/fileutils';
+import type { PackageJson } from '../../utils/package-json';
+import { normalizePath } from '../../utils/path';
+import { addVsCodeRecommendedExtensions, createNxJsonFile } from '../utils';
+import type {
+  AngularJsonConfig,
+  AngularJsonProjectConfiguration,
+  WorkspaceCapabilities,
+} from './types';
+
+export async function setupStandaloneWorkspace(
+  repoRoot: string,
+  cacheableOperations: string[],
+  workspaceTargets: string[]
+): Promise<void> {
+  const angularJsonPath = join(repoRoot, 'angular.json');
+  const angularJson = readJsonFile<AngularJsonConfig>(angularJsonPath);
+  const workspaceCapabilities = getWorkspaceCapabilities(angularJson.projects);
+  createNxJson(
+    repoRoot,
+    angularJson,
+    cacheableOperations,
+    workspaceCapabilities,
+    workspaceTargets
+  );
+  addVsCodeRecommendedExtensions(
+    repoRoot,
+    [
+      'nrwl.angular-console',
+      'angular.ng-template',
+      workspaceCapabilities.eslintProjectConfigFile
+        ? 'dbaeumer.vscode-eslint'
+        : undefined,
+    ].filter(Boolean)
+  );
+  replaceNgWithNxInPackageJsonScripts(repoRoot);
+
+  // convert workspace config format to standalone project configs
+  // update its targets outputs and delete angular.json
+  const projects = toNewFormat(angularJson).projects;
+  for (const [projectName, project] of Object.entries(projects)) {
+    updateProjectOutputs(repoRoot, project);
+    writeJsonFile(join(project.root, 'project.json'), {
+      $schema: normalizePath(
+        relative(
+          join(repoRoot, project.root),
+          join(repoRoot, 'node_modules/nx/schemas/project-schema.json')
+        )
+      ),
+      name: projectName,
+      ...project,
+      root: undefined,
+    });
+  }
+  unlinkSync(angularJsonPath);
+}
+
+function createNxJson(
+  repoRoot: string,
+  angularJson: AngularJsonConfig,
+  cacheableOperations: string[],
+  {
+    eslintProjectConfigFile,
+    test,
+    karmaProjectConfigFile,
+  }: WorkspaceCapabilities,
+  workspaceTargets: string[]
+): void {
+  createNxJsonFile(repoRoot, [], cacheableOperations, {});
+
+  const nxJson = readJsonFile<NxJsonConfiguration>(join(repoRoot, 'nx.json'));
+  nxJson.namedInputs = {
+    sharedGlobals: [],
+    default: ['{projectRoot}/**/*', 'sharedGlobals'],
+    production: [
+      'default',
+      ...(test
+        ? [
+            '!{projectRoot}/tsconfig.spec.json',
+            '!{projectRoot}/**/*.spec.[jt]s',
+            karmaProjectConfigFile ? '!{projectRoot}/karma.conf.js' : undefined,
+          ].filter(Boolean)
+        : []),
+      eslintProjectConfigFile ? '!{projectRoot}/.eslintrc.json' : undefined,
+    ].filter(Boolean),
+  };
+  nxJson.targetDefaults = {};
+  if (workspaceTargets.includes('build')) {
+    nxJson.targetDefaults.build = {
+      dependsOn: ['^build'],
+      inputs: ['production', '^production'],
+    };
+  }
+  if (workspaceTargets.includes('server')) {
+    nxJson.targetDefaults.server = { inputs: ['production', '^production'] };
+  }
+  if (workspaceTargets.includes('test')) {
+    const inputs = ['default', '^production'];
+    if (fileExists(join(repoRoot, 'karma.conf.js'))) {
+      inputs.push('{workspaceRoot}/karma.conf.js');
+    }
+    nxJson.targetDefaults.test = { inputs };
+  }
+  if (workspaceTargets.includes('lint')) {
+    const inputs = ['default'];
+    if (fileExists(join(repoRoot, '.eslintrc.json'))) {
+      inputs.push('{workspaceRoot}/.eslintrc.json');
+    }
+    nxJson.targetDefaults.lint = { inputs };
+  }
+  if (workspaceTargets.includes('e2e')) {
+    nxJson.targetDefaults.e2e = { inputs: ['default', '^production'] };
+  }
+  // Angular 14 workspaces support defaultProject, keep it until we drop support
+  nxJson.defaultProject = angularJson.defaultProject;
+  writeJsonFile(join(repoRoot, 'nx.json'), nxJson);
+}
+
+function updateProjectOutputs(
+  repoRoot: string,
+  project: ProjectConfiguration
+): void {
+  Object.values(project.targets ?? {}).forEach((target) => {
+    if (
+      [
+        '@angular-devkit/build-angular:browser',
+        '@angular-builders/custom-webpack:browser',
+        'ngx-build-plus:browser',
+        '@angular-devkit/build-angular:server',
+        '@angular-builders/custom-webpack:server',
+        'ngx-build-plus:server',
+      ].includes(target.executor)
+    ) {
+      target.outputs = ['{options.outputPath}'];
+    } else if (target.executor === '@angular-eslint/builder:lint') {
+      target.outputs = ['{options.outputFile}'];
+    } else if (target.executor === '@angular-devkit/build-angular:ng-packagr') {
+      try {
+        const ngPackageJsonPath = join(repoRoot, target.options.project);
+        const ngPackageJson = readJsonFile(ngPackageJsonPath);
+        const outputPath = relative(
+          repoRoot,
+          resolve(dirname(ngPackageJsonPath), ngPackageJson.dest)
+        );
+        target.outputs = [`{workspaceRoot}/${normalizePath(outputPath)}`];
+      } catch {}
+    }
+  });
+}
+
+function getWorkspaceCapabilities(
+  projects: Record<string, AngularJsonProjectConfiguration>
+): WorkspaceCapabilities {
+  const capabilities = {
+    eslintProjectConfigFile: false,
+    test: false,
+    karmaProjectConfigFile: false,
+  };
+
+  for (const project of Object.values(projects)) {
+    if (
+      !capabilities.eslintProjectConfigFile &&
+      projectHasEslintConfig(project)
+    ) {
+      capabilities.eslintProjectConfigFile = true;
+    }
+    if (!capabilities.test && projectUsesKarmaBuilder(project)) {
+      capabilities.test = true;
+    }
+    if (
+      !capabilities.karmaProjectConfigFile &&
+      projectHasKarmaConfig(project)
+    ) {
+      capabilities.karmaProjectConfigFile = true;
+    }
+
+    if (
+      capabilities.eslintProjectConfigFile &&
+      capabilities.test &&
+      capabilities.karmaProjectConfigFile
+    ) {
+      return capabilities;
+    }
+  }
+
+  return capabilities;
+}
+
+function projectUsesKarmaBuilder(
+  project: AngularJsonProjectConfiguration
+): boolean {
+  return Object.values(project.architect ?? {}).some(
+    (target) => target.builder === '@angular-devkit/build-angular:karma'
+  );
+}
+
+function projectHasKarmaConfig(
+  project: AngularJsonProjectConfiguration
+): boolean {
+  return fileExists(join(project.root, 'karma.conf.js'));
+}
+
+function projectHasEslintConfig(
+  project: AngularJsonProjectConfiguration
+): boolean {
+  return fileExists(join(project.root, '.eslintrc.json'));
+}
+
+function replaceNgWithNxInPackageJsonScripts(repoRoot: string): void {
+  const packageJsonPath = join(repoRoot, 'package.json');
+  const packageJson = readJsonFile<PackageJson>(packageJsonPath);
+  packageJson.scripts ??= {};
+  Object.keys(packageJson.scripts).forEach((script) => {
+    packageJson.scripts[script] = packageJson.scripts[script]
+      .replace(/^nx$/, 'nx')
+      .replace(/^ng /, 'nx ')
+      .replace(/ ng /g, ' nx ');
+  });
+  writeJsonFile(packageJsonPath, packageJson);
+}

--- a/packages/nx/src/nx-init/angular/types.ts
+++ b/packages/nx/src/nx-init/angular/types.ts
@@ -1,0 +1,25 @@
+import type { TargetConfiguration } from '../../config/workspace-json-project-json';
+
+export type AngularJsonConfigTargetConfiguration = Exclude<
+  TargetConfiguration,
+  'command' | 'executor' | 'outputs' | 'dependsOn' | 'inputs'
+> & {
+  builder: string;
+};
+
+export type AngularJsonProjectConfiguration = {
+  root: string;
+  sourceRoot: string;
+  architect?: Record<string, AngularJsonConfigTargetConfiguration>;
+};
+
+export interface AngularJsonConfig {
+  projects: Record<string, AngularJsonProjectConfiguration>;
+  defaultProject?: string;
+}
+
+export type WorkspaceCapabilities = {
+  eslintProjectConfigFile: boolean;
+  test: boolean;
+  karmaProjectConfigFile: boolean;
+};

--- a/packages/nx/src/nx-init/react/index.ts
+++ b/packages/nx/src/nx-init/react/index.ts
@@ -40,7 +40,7 @@ interface NormalizedOptions extends Options {
 }
 
 const parsedArgs = yargsParser(process.argv, {
-  boolean: ['force', 'e2e', 'nxCloud', 'vite', 'integrated'],
+  boolean: ['force', 'e2e', 'nxCloud', 'vite'],
   default: {
     nxCloud: true,
     vite: true,
@@ -50,7 +50,7 @@ const parsedArgs = yargsParser(process.argv, {
   },
 });
 
-export async function addNxToCraRepo() {
+export async function addNxToCraRepo(integrated: boolean) {
   if (!parsedArgs.force) {
     checkForUncommittedChanges();
     checkForCustomWebpackSetup();
@@ -58,7 +58,10 @@ export async function addNxToCraRepo() {
 
   output.log({ title: '✨ Nx initialization' });
 
-  const normalizedOptions = normalizeOptions(parsedArgs as unknown as Options);
+  const normalizedOptions = normalizeOptions(
+    parsedArgs as unknown as Options,
+    integrated
+  );
   await reorgnizeWorkspaceStructure(normalizedOptions);
 }
 
@@ -68,7 +71,10 @@ function addDependencies(pmc: PackageManagerCommands, ...deps: string[]) {
   execSync(`${pmc.addDev} ${depsArg}`, { stdio: [0, 1, 2] });
 }
 
-function normalizeOptions(options: Options): NormalizedOptions {
+function normalizeOptions(
+  options: Options,
+  integrated: boolean
+): NormalizedOptions {
   const packageManager = detectPackageManager();
   const pmc = getPackageManagerCommand(packageManager);
 
@@ -85,7 +91,7 @@ function normalizeOptions(options: Options): NormalizedOptions {
   // Should remove this check 04/2023 once Node 14 & npm 6 reach EOL
   const npxYesFlagNeeded = !npmVersion.startsWith('6'); // npm 7 added -y flag to npx
   const isVite = options.vite;
-  const isStandalone = !options.integrated;
+  const isStandalone = !integrated;
 
   return {
     ...options,
@@ -97,6 +103,7 @@ function normalizeOptions(options: Options): NormalizedOptions {
     npxYesFlagNeeded,
     isVite,
     isStandalone,
+    integrated,
   };
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `nx init` command doesn't support migrating an Angular CLI workspace to an integrated Nx workspace. While it currently supports it for CRA projects, the `--integrated` flag is sort of "hidden" and handled internally by the CRA to Nx flow implementation.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `nx init` command should support migrating an Angular CLI workspace to an integrated Nx workspace. The `--integrated` flag should be part of the `nx init` command itself so it's included in the help and docs.

**NOTE**: The PR still keeps the `--interactive` flag hidden from the docs and help until the feature is released.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
