### PR TITLE
fix(repo): enable mac tests on nightly and fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,7 +234,7 @@ jobs:
           name: Run E2E Tests for macOS
           # FIXME: remove --exclude=e2e-detox once we have a fix for the detox tests
           command: |
-            npx nx run-many -t e2e-macos --parallel=1 --exclude=e2e-detox
+            npx nx affected -t e2e-macos --parallel=1 --exclude=e2e-detox
           no_output_timeout: 45m
 
 # -------------------------

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -407,10 +407,7 @@ jobs:
 
       - name: Run e2e tests
         id: e2e-run
-        run: |
-          # each project has either "e2e" or "e2e-macos" target
-          yarn nx run-many --target=e2e --projects="${{ join(matrix.project) }}" --parallel=1
-          yarn nx run-many --target=e2e-macos --projects="${{ join(matrix.project) }}" --parallel=1
+        run: yarn nx run-many --target=e2e,e2e-macos --projects="${{ join(matrix.project) }}" --parallel=1
         timeout-minutes: ${{ matrix.os_timeout }}
         env:
           GIT_AUTHOR_EMAIL: test@test.com

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -407,7 +407,10 @@ jobs:
 
       - name: Run e2e tests
         id: e2e-run
-        run: yarn nx run-many --target=e2e --projects="${{ join(matrix.project) }}" --parallel=1
+        run: |
+          # each project has either "e2e" or "e2e-macos" target
+          yarn nx run-many --target=e2e --projects="${{ join(matrix.project) }}" --parallel=1
+          yarn nx run-many --target=e2e-macos --projects="${{ join(matrix.project) }}" --parallel=1
         timeout-minutes: ${{ matrix.os_timeout }}
         env:
           GIT_AUTHOR_EMAIL: test@test.com


### PR DESCRIPTION
The https://github.com/nrwl/nx/pull/14347 had two side effects of introducing a dedicated `e2e-macos` target for mac-related projects:
- CI **always runs** all mac e2e tests regardless whether they are affected or not
- Nightly **never runs** any of them since the config is set to run only `e2e` target

This PR fixes that

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
