### PR TITLE
fix(core): fix broken command-line unit test

### DIFF
--- a/packages/nx/src/utils/command-line-utils.spec.ts
+++ b/packages/nx/src/utils/command-line-utils.spec.ts
@@ -178,6 +178,7 @@ describe('splitArgs', () => {
         {} as any
       ).nxArgs
     ).toEqual({
+      parallel: 3,
       projects: ['aaa', 'bbb'],
       skipNxCache: false,
     });


### PR DESCRIPTION
The PR https://github.com/nrwl/nx/pull/13837 broke one of the unit tests. This adds the missing argument to the unit test.

cc @AgentEnder 

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
