### PR TITLE
fix(repo): use lerna command in e2e with yarn --silent

### DIFF
--- a/e2e/utils/command-utils.ts
+++ b/e2e/utils/command-utils.ts
@@ -147,7 +147,7 @@ export function getPackageManagerCommand({
       addProd: `yarn add`,
       addDev: `yarn add -D`,
       list: 'npm ls --depth 10',
-      runLerna: `yarn lerna`,
+      runLerna: `yarn --silent lerna`,
     },
     // Pnpm 3.5+ adds nx to
     pnpm: {


### PR DESCRIPTION
This is a followup to https://github.com/nrwl/nx/pull/16089 and adds same `--silent` to `yarn lerna`

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
