### PR TITLE
fix(angular): fix migrations cli type and use @angular-devkit/build-angular to determine ng devkit version

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -121,7 +121,7 @@
       "factory": "./src/migrations/update-15-2-0/update-workspace-config"
     },
     "update-platform-server-exports": {
-      "cli": "ng",
+      "cli": "nx",
       "version": "15.2.0-beta.0",
       "requires": {
         "@angular/core": ">=15.0.0"
@@ -130,7 +130,7 @@
       "factory": "./src/migrations/update-15-2-0/remove-platform-server-exports"
     },
     "update-karma-main-file": {
-      "cli": "ng",
+      "cli": "nx",
       "version": "15.2.0-beta.0",
       "requires": {
         "@angular/core": ">=15.0.0"

--- a/packages/angular/src/migrations/update-15-7-0/install-required-packages.spec.ts
+++ b/packages/angular/src/migrations/update-15-7-0/install-required-packages.spec.ts
@@ -20,7 +20,7 @@ describe('installed-required-packages', () => {
         '@angular/core': '~15.0.0',
       },
       devDependencies: {
-        '@angular/cli': '~15.0.0',
+        '@angular-devkit/build-angular': '~15.0.0',
       },
     }));
 
@@ -36,9 +36,9 @@ describe('installed-required-packages', () => {
     `);
     expect(pkgJson.devDependencies).toMatchInlineSnapshot(`
       Object {
+        "@angular-devkit/build-angular": "~15.0.0",
         "@angular-devkit/core": "~15.0.0",
         "@angular-devkit/schematics": "~15.0.0",
-        "@angular/cli": "~15.0.0",
         "@schematics/angular": "~15.0.0",
       }
     `);
@@ -53,7 +53,7 @@ describe('installed-required-packages', () => {
         '@angular/core': '~14.0.0',
       },
       devDependencies: {
-        '@angular/cli': '~14.0.0',
+        '@angular-devkit/build-angular': '~14.0.0',
       },
     }));
 
@@ -69,9 +69,9 @@ describe('installed-required-packages', () => {
     `);
     expect(pkgJson.devDependencies).toMatchInlineSnapshot(`
       Object {
+        "@angular-devkit/build-angular": "~14.0.0",
         "@angular-devkit/core": "~14.0.0",
         "@angular-devkit/schematics": "~14.0.0",
-        "@angular/cli": "~14.0.0",
         "@schematics/angular": "~14.0.0",
       }
     `);
@@ -86,7 +86,7 @@ describe('installed-required-packages', () => {
         '@angular/core': '~15.0.0',
       },
       devDependencies: {
-        '@angular/cli': '~15.0.0',
+        '@angular-devkit/build-angular': '~15.0.0',
         '@angular-devkit/core': '~15.0.0',
         '@angular-devkit/schematics': '~15.0.0',
         '@schematics/angular': '~15.0.0',
@@ -105,9 +105,9 @@ describe('installed-required-packages', () => {
     `);
     expect(pkgJson.devDependencies).toMatchInlineSnapshot(`
       Object {
+        "@angular-devkit/build-angular": "~15.0.0",
         "@angular-devkit/core": "~15.0.0",
         "@angular-devkit/schematics": "~15.0.0",
-        "@angular/cli": "~15.0.0",
         "@schematics/angular": "~15.0.0",
       }
     `);
@@ -122,7 +122,7 @@ describe('installed-required-packages', () => {
         '@angular/core': '~14.0.0',
       },
       devDependencies: {
-        '@angular/cli': '~14.0.0',
+        '@angular-devkit/build-angular': '~14.0.0',
         '@angular-devkit/core': '~14.0.0',
         '@angular-devkit/schematics': '~14.0.0',
         '@schematics/angular': '~14.0.0',
@@ -141,9 +141,9 @@ describe('installed-required-packages', () => {
     `);
     expect(pkgJson.devDependencies).toMatchInlineSnapshot(`
       Object {
+        "@angular-devkit/build-angular": "~14.0.0",
         "@angular-devkit/core": "~14.0.0",
         "@angular-devkit/schematics": "~14.0.0",
-        "@angular/cli": "~14.0.0",
         "@schematics/angular": "~14.0.0",
       }
     `);
@@ -158,7 +158,7 @@ describe('installed-required-packages', () => {
         '@angular/core': '~15.0.0',
       },
       devDependencies: {
-        '@angular/cli': '~15.0.0',
+        '@angular-devkit/build-angular': '~15.0.0',
         '@angular-devkit/core': '~15.0.0',
         '@schematics/angular': '~15.0.0',
       },
@@ -176,9 +176,9 @@ describe('installed-required-packages', () => {
     `);
     expect(pkgJson.devDependencies).toMatchInlineSnapshot(`
       Object {
+        "@angular-devkit/build-angular": "~15.0.0",
         "@angular-devkit/core": "~15.0.0",
         "@angular-devkit/schematics": "~15.0.0",
-        "@angular/cli": "~15.0.0",
         "@schematics/angular": "~15.0.0",
       }
     `);
@@ -193,7 +193,7 @@ describe('installed-required-packages', () => {
         '@angular/core': '~14.0.0',
       },
       devDependencies: {
-        '@angular/cli': '~14.0.0',
+        '@angular-devkit/build-angular': '~14.0.0',
         '@angular-devkit/core': '~14.0.0',
         '@schematics/angular': '~14.0.0',
       },
@@ -211,9 +211,9 @@ describe('installed-required-packages', () => {
     `);
     expect(pkgJson.devDependencies).toMatchInlineSnapshot(`
       Object {
+        "@angular-devkit/build-angular": "~14.0.0",
         "@angular-devkit/core": "~14.0.0",
         "@angular-devkit/schematics": "~14.0.0",
-        "@angular/cli": "~14.0.0",
         "@schematics/angular": "~14.0.0",
       }
     `);

--- a/packages/angular/src/migrations/update-15-7-0/install-required-packages.ts
+++ b/packages/angular/src/migrations/update-15-7-0/install-required-packages.ts
@@ -25,8 +25,8 @@ export default async function (tree: Tree) {
   );
 
   const angularCliVersion =
-    pkgJson.devDependencies?.['@angular/cli'] ??
-    pkgJson.dependencies?.['@angular/cli'] ??
+    pkgJson.devDependencies?.['@angular-devkit/build-angular'] ??
+    pkgJson.dependencies?.['@angular-devkit/build-angular'] ??
     angularDevkitVersion;
 
   const filteredPackages: Record<string, string> = packagesToInstall


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

A couple of migrations that were recently rewritten using the Nx DevKit still have their `cli` type as `ng`.

The migration installing the required peer deps uses the `@angular/cli` package to determine the version to use for those packages, but we don't bump the `@angular/cli` version automatically. We only update the `@angular/cli` package version in migration generators that run after the migration installing the peer deps. As such, an old version of the `@angular/cli` package is picked up.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Migrations written with the Nx DevKit should have the `cli` type set as `nx`.

The migration installing the required peer deps sets the correct version of the Angular DevKit. Instead of using the `@angular/cli` package as reference, it should use the `@angular-devkit/build-angular`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
