### PR TITLE
chore(core): add `.trim()` to output before parsing as JSON.

### DIFF
--- a/e2e/nx-run/src/affected-graph.test.ts
+++ b/e2e/nx-run/src/affected-graph.test.ts
@@ -328,17 +328,16 @@ describe('Nx Affected and Graph Tests', () => {
           ${app2ElementSpec}
           `
       );
-
-      const resWithoutTarget = JSON.parse(
-        (
-          await runCLIAsync(
-            `print-affected --files=apps/${myapp}/src/app/app.element.spec.ts`,
-            {
-              silent: true,
-            }
-          )
-        ).stdout
-      );
+      const outputWithoutTarget = (
+        await runCLIAsync(
+          `print-affected --files=apps/${myapp}/src/app/app.element.spec.ts`,
+          {
+            silent: true,
+          }
+        )
+      ).stdout.trim();
+      console.log({ outputWithoutTarget });
+      const resWithoutTarget = JSON.parse(outputWithoutTarget);
       expect(resWithoutTarget.tasks).toEqual([]);
       compareTwoArrays(resWithoutTarget.projects, [`${myapp}-e2e`, myapp]);
 


### PR DESCRIPTION
**DO NOT MERGE** 

Attempt to fix a nightly test failure. Currently there might be some console.logs to debug what's going on.