### PR TITLE
feat(nx-plugin): slim down default generated nx-plugin

### DIFF
--- a/docs/generated/manifests/packages.json
+++ b/docs/generated/manifests/packages.json
@@ -1835,7 +1835,7 @@
       "/packages/nx-plugin/generators/e2e-project": {
         "description": "Create a E2E application for a Nx Plugin.",
         "file": "generated/packages/nx-plugin/generators/e2e-project.json",
-        "hidden": true,
+        "hidden": false,
         "name": "e2e-project",
         "originalFilePath": "/packages/nx-plugin/src/generators/e2e-project/schema.json",
         "path": "/packages/nx-plugin/generators/e2e-project",

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -1813,7 +1813,7 @@
       {
         "description": "Create a E2E application for a Nx Plugin.",
         "file": "generated/packages/nx-plugin/generators/e2e-project.json",
-        "hidden": true,
+        "hidden": false,
         "name": "e2e-project",
         "originalFilePath": "/packages/nx-plugin/src/generators/e2e-project/schema.json",
         "path": "nx-plugin/generators/e2e-project",

--- a/docs/generated/packages/nx-plugin/generators/e2e-project.json
+++ b/docs/generated/packages/nx-plugin/generators/e2e-project.json
@@ -57,9 +57,9 @@
     "presets": []
   },
   "description": "Create a E2E application for a Nx Plugin.",
-  "hidden": true,
   "implementation": "/packages/nx-plugin/src/generators/e2e-project/e2e.ts",
   "aliases": [],
+  "hidden": false,
   "path": "/packages/nx-plugin/src/generators/e2e-project/schema.json",
   "type": "generator"
 }

--- a/docs/generated/packages/nx-plugin/generators/executor.json
+++ b/docs/generated/packages/nx-plugin/generators/executor.json
@@ -44,6 +44,11 @@
         "type": "boolean",
         "default": false,
         "description": "Should the boilerplate for a custom hasher be generated?"
+      },
+      "skipLintChecks": {
+        "type": "boolean",
+        "default": false,
+        "description": "Do not eslint configuration for plugin json files."
       }
     },
     "required": ["project", "name"],

--- a/docs/generated/packages/nx-plugin/generators/executor.json
+++ b/docs/generated/packages/nx-plugin/generators/executor.json
@@ -48,7 +48,7 @@
       "skipLintChecks": {
         "type": "boolean",
         "default": false,
-        "description": "Do not eslint configuration for plugin json files."
+        "description": "Do not add an eslint configuration for plugin json files."
       }
     },
     "required": ["project", "name"],

--- a/docs/generated/packages/nx-plugin/generators/generator.json
+++ b/docs/generated/packages/nx-plugin/generators/generator.json
@@ -44,7 +44,13 @@
       "skipLintChecks": {
         "type": "boolean",
         "default": false,
-        "description": "Do not eslint configuration for plugin json files."
+        "description": "Do not add an eslint configuration for plugin json files."
+      },
+      "skipFormat": {
+        "type": "boolean",
+        "default": false,
+        "description": "Do not format files with prettier.",
+        "x-priority": "internal"
       }
     },
     "required": ["project", "name"],

--- a/docs/generated/packages/nx-plugin/generators/generator.json
+++ b/docs/generated/packages/nx-plugin/generators/generator.json
@@ -40,6 +40,11 @@
         "enum": ["jest", "none"],
         "description": "Test runner to use for unit tests.",
         "default": "jest"
+      },
+      "skipLintChecks": {
+        "type": "boolean",
+        "default": false,
+        "description": "Do not eslint configuration for plugin json files."
       }
     },
     "required": ["project", "name"],

--- a/docs/generated/packages/nx-plugin/generators/migration.json
+++ b/docs/generated/packages/nx-plugin/generators/migration.json
@@ -45,6 +45,11 @@
         "description": "Whether or not to include `package.json` updates.",
         "alias": "p",
         "default": false
+      },
+      "skipLintChecks": {
+        "type": "boolean",
+        "default": false,
+        "description": "Do not eslint configuration for plugin json files."
       }
     },
     "required": ["project", "packageVersion"],

--- a/docs/generated/packages/nx-plugin/generators/plugin-lint-checks.json
+++ b/docs/generated/packages/nx-plugin/generators/plugin-lint-checks.json
@@ -14,6 +14,12 @@
         "description": "Which project should be the configuration be added to?",
         "$default": { "$source": "projectName" },
         "x-priority": "important"
+      },
+      "skipFormat": {
+        "type": "boolean",
+        "x-priority": "internal",
+        "description": "Skip formatting files with prettier.",
+        "default": false
       }
     },
     "required": ["projectName"],

--- a/docs/generated/packages/nx-plugin/generators/plugin.json
+++ b/docs/generated/packages/nx-plugin/generators/plugin.json
@@ -69,7 +69,7 @@
         "type": "string",
         "enum": ["jest", "none"],
         "description": "Test runner to use for end to end (E2E) tests.",
-        "default": "jest"
+        "default": "none"
       },
       "standaloneConfig": {
         "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
@@ -87,15 +87,9 @@
         "enum": ["tsc", "swc"],
         "default": "tsc",
         "description": "The compiler used by the build and test targets."
-      },
-      "minimal": {
-        "type": "boolean",
-        "description": "Generate the plugin with a minimal setup. This would involve not generating a default executor and generator.",
-        "default": false
       }
     },
     "required": ["name"],
-    "additionalProperties": false,
     "presets": []
   },
   "description": "Create a Nx Plugin.",

--- a/e2e/nx-plugin/src/nx-plugin.test.ts
+++ b/e2e/nx-plugin/src/nx-plugin.test.ts
@@ -48,21 +48,6 @@ describe('Nx Plugin', () => {
     });
   }, 90000);
 
-  // the test invoke ensureNxProject, which points to @nrwl/workspace collection
-  // which walks up the directory to find it in the next repo itself, so it
-  // doesn't use the collection we are building
-  // we should change it to point to the right collection using relative path
-  // TODO: Re-enable this to work with pnpm
-  it(`should run the plugin's e2e tests`, async () => {
-    const plugin = uniq('plugin-name');
-    runCLI(
-      `generate @nrwl/nx-plugin:plugin ${plugin} --linter=eslint --e2eTestRunner jest`
-    );
-    const e2eResults = runCLI(`e2e ${plugin}-e2e`);
-    expect(e2eResults).toContain('Successfully ran target e2e');
-    expect(await killPorts()).toBeTruthy();
-  }, 250000);
-
   it('should be able to generate a migration', async () => {
     const plugin = uniq('plugin');
     const version = '1.0.0';

--- a/e2e/utils/create-project-utils.ts
+++ b/e2e/utils/create-project-utils.ts
@@ -215,12 +215,10 @@ export function runCreateWorkspace(
 export function runCreatePlugin(
   name: string,
   {
-    pluginName,
     packageManager,
     extraArgs,
     useDetectedPm = false,
   }: {
-    pluginName?: string;
     packageManager?: 'npm' | 'yarn' | 'pnpm';
     extraArgs?: string;
     useDetectedPm?: boolean;
@@ -232,11 +230,7 @@ export function runCreatePlugin(
 
   let command = `${
     pm.runUninstalledPackage
-  } create-nx-plugin@${getPublishedVersion()} ${name}`;
-
-  if (pluginName) {
-    command += ` --pluginName=${pluginName} --no-nxCloud`;
-  }
+  } create-nx-plugin@${getPublishedVersion()} ${name} --no-nxCloud`;
 
   if (packageManager && !useDetectedPm) {
     command += ` --package-manager=${packageManager}`;

--- a/e2e/workspace-create/src/create-nx-plugin.test.ts
+++ b/e2e/workspace-create/src/create-nx-plugin.test.ts
@@ -14,13 +14,11 @@ describe('create-nx-plugin', () => {
 
   afterEach(() => cleanupProject());
 
-  it('should be able to create a plugin repo and run plugin e2e', () => {
-    const wsName = uniq('ws-plugin');
+  it('should be able to create a plugin repo build a plugin', () => {
     const pluginName = uniq('plugin');
 
-    runCreatePlugin(wsName, {
+    runCreatePlugin(pluginName, {
       packageManager,
-      pluginName,
     });
 
     checkFilesExist(
@@ -31,6 +29,12 @@ describe('create-nx-plugin', () => {
       `executors.json`
     );
 
-    expect(() => runCLI(`e2e e2e`)).not.toThrow();
+    runCLI(`build ${pluginName}`);
+
+    checkFilesExist(
+      `dist/package.json`,
+      `dist/generators.json`,
+      `dist/executors.json`
+    );
   });
 });

--- a/packages/nx-plugin/generators.json
+++ b/packages/nx-plugin/generators.json
@@ -11,8 +11,7 @@
     "e2e-project": {
       "factory": "./src/generators/e2e-project/e2e",
       "schema": "./src/generators/e2e-project/schema.json",
-      "description": "Create a E2E application for a Nx Plugin.",
-      "hidden": true
+      "description": "Create a E2E application for a Nx Plugin."
     },
     "migration": {
       "factory": "./src/generators/migration/migration",
@@ -51,8 +50,7 @@
     "e2e-project": {
       "factory": "./src/generators/e2e-project/e2e#e2eProjectSchematic",
       "schema": "./src/generators/e2e-project/schema.json",
-      "description": "Create a E2E application for a Nx Plugin.",
-      "hidden": true
+      "description": "Create a E2E application for a Nx Plugin."
     },
     "migration": {
       "factory": "./src/generators/migration/migration#migrationSchematic",

--- a/packages/nx-plugin/src/generators/e2e-project/e2e.spec.ts
+++ b/packages/nx-plugin/src/generators/e2e-project/e2e.spec.ts
@@ -140,24 +140,6 @@ describe('NxPlugin e2e-project Generator', () => {
     expect(tree.exists('apps/my-plugin-e2e/jest.config.ts')).toBeTruthy();
   });
 
-  it('should not generate tests when minimal flag is passed', async () => {
-    // ARRANGE & ACT
-    await e2eProjectGenerator(tree, {
-      pluginName: 'my-plugin',
-      pluginOutputPath: `dist/libs/my-plugin`,
-      npmPackageName: '@proj/my-plugin',
-      minimal: true,
-    });
-
-    const { root } = readProjectConfiguration(tree, 'my-plugin-e2e');
-
-    // ASSERT
-
-    expect(
-      tree.read(joinPathFragments(root, 'tests/my-plugin.spec.ts'), 'utf-8')
-    ).not.toContain("it('should create ");
-  });
-
   it('should setup the eslint builder', async () => {
     await e2eProjectGenerator(tree, {
       pluginName: 'my-plugin',

--- a/packages/nx-plugin/src/generators/e2e-project/e2e.ts
+++ b/packages/nx-plugin/src/generators/e2e-project/e2e.ts
@@ -46,7 +46,6 @@ function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
 
   return {
     ...options,
-    minimal: options.minimal ?? false,
     projectName,
     linter: options.linter ?? Linter.EsLint,
     pluginPropertyName,

--- a/packages/nx-plugin/src/generators/e2e-project/files/tests/__pluginName__.spec.ts__tmpl__
+++ b/packages/nx-plugin/src/generators/e2e-project/files/tests/__pluginName__.spec.ts__tmpl__
@@ -3,6 +3,7 @@ import {
   ensureNxProject,
   readJson,
   runNxCommandAsync,
+  runNxCommand,
   uniq,
 } from '@nx/nx-plugin/testing';
 
@@ -23,39 +24,14 @@ describe('<%= pluginName %> e2e', () => {
     runNxCommandAsync('reset');
   });
 
-  <% if(!minimal) { %>
 
-  it('should create <%= pluginName %>', async () => {
-    const project = uniq('<%= pluginName %>');
-    await runNxCommandAsync(
-      `generate <%=npmPackageName%>:<%= pluginName %> ${project}`
-    );
-    const result = await runNxCommandAsync(`build ${project}`);
-    expect(result.stdout).toContain('Executor ran');
-  }, 120000);
-
-  describe('--directory', () => {
-    it('should create src in the specified directory', async () => {
-      const project = uniq('<%= pluginName %>');
-      await runNxCommandAsync(
-        `generate <%=npmPackageName%>:<%= pluginName %> ${project} --directory subdir`
-      );
-      expect(() =>
-        checkFilesExist(`libs/subdir/${project}/src/index.ts`)
-      ).not.toThrow();
-    }, 120000);
-  });
-
-  describe('--tags', () => {
-    it('should add tags to the project', async () => {
-      const projectName = uniq('<%= pluginName %>');
-      ensureNxProject('<%= npmPackageName %>', '<%= pluginOutputPath %>');
-      await runNxCommandAsync(
-        `generate <%=npmPackageName%>:<%= pluginName %> ${projectName} --tags e2etag,e2ePackage`
-      );
-      const project = readJson(`libs/${projectName}/project.json`);
-      expect(project.tags).toEqual(['e2etag', 'e2ePackage']);
-    }, 120000);
-  });
-  <% } %>
+  // Add some tests here to check that your plugin functionality works as expected.
+  // A sample test is included below to give you some ideas.
+  //
+  // it('should be able to build generated projects', async () => {
+  //   const name = uniq('proj')
+  //   await runNxCommandAsync(`generate <%= npmPackageName %>:{my-generator} --name ${name}`);
+  //   expect(() => runNxCommand('build ${proj}')).not.toThrow();
+  //   expect(() => checkFilesExist([`dist/${name}/index.js`])).not.toThrow();
+  // });
 });

--- a/packages/nx-plugin/src/generators/e2e-project/files/tests/__pluginName__.spec.ts__tmpl__
+++ b/packages/nx-plugin/src/generators/e2e-project/files/tests/__pluginName__.spec.ts__tmpl__
@@ -27,11 +27,11 @@ describe('<%= pluginName %> e2e', () => {
 
   // Add some tests here to check that your plugin functionality works as expected.
   // A sample test is included below to give you some ideas.
-  //
-  // it('should be able to build generated projects', async () => {
-  //   const name = uniq('proj')
-  //   await runNxCommandAsync(`generate <%= npmPackageName %>:{my-generator} --name ${name}`);
-  //   expect(() => runNxCommand('build ${proj}')).not.toThrow();
-  //   expect(() => checkFilesExist([`dist/${name}/index.js`])).not.toThrow();
-  // });
+  xit('should be able to build generated projects', async () => {
+    const name = uniq('proj');
+    const generator = 'PLACEHOLDER';
+    await runNxCommandAsync(`generate <%= npmPackageName %>:${generator} --name ${name}`);
+    expect(() => runNxCommand('build ${proj}')).not.toThrow();
+    expect(() => checkFilesExist([`dist/${name}/index.js`])).not.toThrow();
+  });
 });

--- a/packages/nx-plugin/src/generators/e2e-project/schema.d.ts
+++ b/packages/nx-plugin/src/generators/e2e-project/schema.d.ts
@@ -6,7 +6,6 @@ export interface Schema {
   projectDirectory?: string;
   pluginOutputPath?: string;
   jestConfig?: string;
-  minimal?: boolean;
   linter?: Linter;
   skipFormat?: boolean;
   rootProject?: boolean;

--- a/packages/nx-plugin/src/generators/executor/executor.spec.ts
+++ b/packages/nx-plugin/src/generators/executor/executor.spec.ts
@@ -158,7 +158,7 @@ describe('NxPlugin Executor Generator', () => {
          * you can consume workspace details from the context.
          */
         export const myExecutorHasher: CustomHasher = async (task, context) => {
-            return context.hasher.hashTask(task)
+          return context.hasher.hashTask(task);
         };
 
         export default myExecutorHasher;

--- a/packages/nx-plugin/src/generators/executor/files/hasher/__fileName__/hasher.ts__tmpl__
+++ b/packages/nx-plugin/src/generators/executor/files/hasher/__fileName__/hasher.ts__tmpl__
@@ -6,7 +6,7 @@ import { CustomHasher } from '@nx/devkit';
  * you can consume workspace details from the context.
  */
 export const <%=propertyName%>Hasher: CustomHasher = async (task, context) => {
-    return context.hasher.hashTask(task)
+    return context.hasher.hashTask(task);
 };
 
 export default <%=propertyName%>Hasher;

--- a/packages/nx-plugin/src/generators/executor/schema.d.ts
+++ b/packages/nx-plugin/src/generators/executor/schema.d.ts
@@ -4,4 +4,5 @@ export interface Schema {
   description?: string;
   unitTestRunner: 'jest' | 'none';
   includeHasher: boolean;
+  skipLintChecks?: boolean;
 }

--- a/packages/nx-plugin/src/generators/executor/schema.json
+++ b/packages/nx-plugin/src/generators/executor/schema.json
@@ -46,6 +46,11 @@
       "type": "boolean",
       "default": false,
       "description": "Should the boilerplate for a custom hasher be generated?"
+    },
+    "skipLintChecks": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not eslint configuration for plugin json files."
     }
   },
   "required": ["project", "name"],

--- a/packages/nx-plugin/src/generators/executor/schema.json
+++ b/packages/nx-plugin/src/generators/executor/schema.json
@@ -50,7 +50,7 @@
     "skipLintChecks": {
       "type": "boolean",
       "default": false,
-      "description": "Do not eslint configuration for plugin json files."
+      "description": "Do not add an eslint configuration for plugin json files."
     }
   },
   "required": ["project", "name"],

--- a/packages/nx-plugin/src/generators/generator/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/generator/generator.spec.ts
@@ -179,8 +179,6 @@ describe('NxPlugin Generator Generator', () => {
         'libs/my-plugin/generators.json'
       );
 
-      console.log(generatorJson.generators['preset']);
-
       expect(
         generatorJson.generators['preset']['x-use-standalone-layout']
       ).toEqual(true);

--- a/packages/nx-plugin/src/generators/generator/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/generator/generator.spec.ts
@@ -65,6 +65,21 @@ describe('NxPlugin Generator Generator', () => {
     );
   });
 
+  it('should throw if recreating an existing generator', async () => {
+    await generatorGenerator(tree, {
+      project: projectName,
+      name: 'my-generator',
+      unitTestRunner: 'jest',
+    });
+    expect(
+      generatorGenerator(tree, {
+        project: projectName,
+        name: 'my-generator',
+        unitTestRunner: 'jest',
+      })
+    ).rejects.toThrow('Generator my-generator already exists');
+  });
+
   it('should update generators.json with the same path as where the generator files folder is located', async () => {
     const generatorName = 'myGenerator';
     const generatorFileName = 'my-generator';

--- a/packages/nx-plugin/src/generators/generator/generator.ts
+++ b/packages/nx-plugin/src/generators/generator/generator.ts
@@ -10,6 +10,7 @@ import {
 } from '@nx/devkit';
 import { PackageJson } from 'nx/src/utils/package-json';
 import * as path from 'path';
+import pluginLintCheckGenerator from '../lint-checks/generator';
 import type { Schema } from './schema';
 
 interface NormalizedSchema extends Schema {
@@ -81,10 +82,15 @@ function addFiles(host: Tree, options: NormalizedSchema) {
   }
 }
 
-function createGeneratorsJson(host: Tree, options: NormalizedSchema) {
+export async function createGeneratorsJson(
+  host: Tree,
+  projectRoot: string,
+  projectName: string,
+  skipLintChecks?: boolean
+) {
   updateJson<PackageJson>(
     host,
-    joinPathFragments(options.projectRoot, 'package.json'),
+    joinPathFragments(projectRoot, 'package.json'),
     (json) => {
       json.generators ??= './generators.json';
       return json;
@@ -92,14 +98,19 @@ function createGeneratorsJson(host: Tree, options: NormalizedSchema) {
   );
   writeJson<GeneratorsJson>(
     host,
-    joinPathFragments(options.projectRoot, 'generators.json'),
+    joinPathFragments(projectRoot, 'generators.json'),
     {
       generators: {},
     }
   );
+  if (!skipLintChecks) {
+    await pluginLintCheckGenerator(host, {
+      projectName,
+    });
+  }
 }
 
-function updateGeneratorJson(host: Tree, options: NormalizedSchema) {
+async function updateGeneratorJson(host: Tree, options: NormalizedSchema) {
   const packageJson = readJson<PackageJson>(
     host,
     joinPathFragments(options.projectRoot, 'package.json')
@@ -114,10 +125,16 @@ function updateGeneratorJson(host: Tree, options: NormalizedSchema) {
     generatorsPath = joinPathFragments(options.projectRoot, 'generators.json');
   }
   if (!host.exists(generatorsPath)) {
-    createGeneratorsJson(host, options);
+    await createGeneratorsJson(
+      host,
+      options.projectRoot,
+      options.project,
+      options.skipLintChecks
+    );
+    console.log('CREATED GENERATORS.JSON');
   }
 
-  return updateJson<GeneratorsJson>(host, generatorsPath, (json) => {
+  updateJson<GeneratorsJson>(host, generatorsPath, (json) => {
     let generators = json.generators ?? json.schematics;
     generators = generators || {};
     generators[options.name] = {
@@ -130,7 +147,6 @@ function updateGeneratorJson(host: Tree, options: NormalizedSchema) {
       generators[options.name]['x-use-standalone-layout'] = true;
     }
     json.generators = generators;
-
     return json;
   });
 }
@@ -140,7 +156,7 @@ export async function generatorGenerator(host: Tree, schema: Schema) {
 
   addFiles(host, options);
 
-  updateGeneratorJson(host, options);
+  await updateGeneratorJson(host, options);
 }
 
 export default generatorGenerator;

--- a/packages/nx-plugin/src/generators/generator/schema.d.ts
+++ b/packages/nx-plugin/src/generators/generator/schema.d.ts
@@ -4,4 +4,5 @@ export interface Schema {
   description?: string;
   unitTestRunner: 'jest' | 'none';
   skipLintChecks?: boolean;
+  skipFormat?: boolean;
 }

--- a/packages/nx-plugin/src/generators/generator/schema.d.ts
+++ b/packages/nx-plugin/src/generators/generator/schema.d.ts
@@ -3,4 +3,5 @@ export interface Schema {
   name: string;
   description?: string;
   unitTestRunner: 'jest' | 'none';
+  skipLintChecks?: boolean;
 }

--- a/packages/nx-plugin/src/generators/generator/schema.json
+++ b/packages/nx-plugin/src/generators/generator/schema.json
@@ -46,7 +46,13 @@
     "skipLintChecks": {
       "type": "boolean",
       "default": false,
-      "description": "Do not eslint configuration for plugin json files."
+      "description": "Do not add an eslint configuration for plugin json files."
+    },
+    "skipFormat": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not format files with prettier.",
+      "x-priority": "internal"
     }
   },
   "required": ["project", "name"],

--- a/packages/nx-plugin/src/generators/generator/schema.json
+++ b/packages/nx-plugin/src/generators/generator/schema.json
@@ -42,6 +42,11 @@
       "enum": ["jest", "none"],
       "description": "Test runner to use for unit tests.",
       "default": "jest"
+    },
+    "skipLintChecks": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not eslint configuration for plugin json files."
     }
   },
   "required": ["project", "name"],

--- a/packages/nx-plugin/src/generators/lint-checks/schema.d.ts
+++ b/packages/nx-plugin/src/generators/lint-checks/schema.d.ts
@@ -1,3 +1,4 @@
 export interface PluginLintChecksGeneratorSchema {
   projectName: string;
+  skipFormat?: boolean;
 }

--- a/packages/nx-plugin/src/generators/lint-checks/schema.json
+++ b/packages/nx-plugin/src/generators/lint-checks/schema.json
@@ -13,6 +13,12 @@
         "$source": "projectName"
       },
       "x-priority": "important"
+    },
+    "skipFormat": {
+      "type": "boolean",
+      "x-priority": "internal",
+      "description": "Skip formatting files with prettier.",
+      "default": false
     }
   },
   "required": ["projectName"]

--- a/packages/nx-plugin/src/generators/migration/files/migration/__name__/__name__.spec.ts__tmpl__
+++ b/packages/nx-plugin/src/generators/migration/files/migration/__name__/__name__.spec.ts__tmpl__
@@ -1,0 +1,17 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { Tree } from '@nx/devkit';
+
+import update from './<%= name %>';
+
+describe('<%= name %> migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace({layout: 'apps-libs'});
+  });
+
+  it('should run successfully', async () => {
+    await update(tree);
+    // ... expect changes made
+  });
+});

--- a/packages/nx-plugin/src/generators/migration/schema.json
+++ b/packages/nx-plugin/src/generators/migration/schema.json
@@ -47,6 +47,11 @@
       "description": "Whether or not to include `package.json` updates.",
       "alias": "p",
       "default": false
+    },
+    "skipLintChecks": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not eslint configuration for plugin json files."
     }
   },
   "required": ["project", "packageVersion"],

--- a/packages/nx-plugin/src/generators/plugin/plugin.spec.ts
+++ b/packages/nx-plugin/src/generators/plugin/plugin.spec.ts
@@ -30,7 +30,7 @@ describe('NxPlugin Plugin Generator', () => {
     tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
   });
 
-  it('should update the workspace.json file', async () => {
+  it('should update the project configuration', async () => {
     await pluginGenerator(tree, getSchema());
     const project = readProjectConfiguration(tree, 'my-plugin');
     expect(project.root).toEqual('libs/my-plugin');
@@ -72,9 +72,7 @@ describe('NxPlugin Plugin Generator', () => {
       options: {
         lintFilePatterns: expect.arrayContaining([
           'libs/my-plugin/**/*.ts',
-          'libs/my-plugin/generators.json',
           'libs/my-plugin/package.json',
-          'libs/my-plugin/executors.json',
         ]),
       },
     });
@@ -108,52 +106,6 @@ describe('NxPlugin Plugin Generator', () => {
     expect(projectE2e.root).toEqual('apps/plugins/my-plugin-e2e');
   });
 
-  it('should create schematic and builder files', async () => {
-    await pluginGenerator(tree, getSchema({ name: 'myPlugin' }));
-
-    [
-      'libs/my-plugin/project.json',
-      'libs/my-plugin/generators.json',
-      'libs/my-plugin/executors.json',
-      'libs/my-plugin/src/generators/my-plugin/schema.d.ts',
-      'libs/my-plugin/src/generators/my-plugin/generator.ts',
-      'libs/my-plugin/src/generators/my-plugin/generator.spec.ts',
-      'libs/my-plugin/src/generators/my-plugin/schema.json',
-      'libs/my-plugin/src/generators/my-plugin/schema.d.ts',
-      'libs/my-plugin/src/generators/my-plugin/files/src/index.ts__template__',
-      'libs/my-plugin/src/executors/build/executor.ts',
-      'libs/my-plugin/src/executors/build/executor.spec.ts',
-      'libs/my-plugin/src/executors/build/schema.json',
-      'libs/my-plugin/src/executors/build/schema.d.ts',
-    ].forEach((path) => expect(tree.exists(path)).toBeTruthy());
-
-    expect(
-      tree.read(
-        'libs/my-plugin/src/generators/my-plugin/files/src/index.ts__template__',
-        'utf-8'
-      )
-    ).toContain('const variable = "<%= projectName %>";');
-  });
-
-  it('should not create generator and executor files for minimal setups', async () => {
-    await pluginGenerator(tree, getSchema({ name: 'myPlugin', minimal: true }));
-
-    expect(tree.exists('libs/my-plugin/project.json')).toBeTruthy();
-
-    [
-      'libs/my-plugin/src/generators/my-plugin/schema.d.ts',
-      'libs/my-plugin/src/generators/my-plugin/generator.ts',
-      'libs/my-plugin/src/generators/my-plugin/generator.spec.ts',
-      'libs/my-plugin/src/generators/my-plugin/schema.json',
-      'libs/my-plugin/src/generators/my-plugin/schema.d.ts',
-      'libs/my-plugin/src/generators/my-plugin/files/src/index.ts__template__',
-      'libs/my-plugin/src/executors/build/executor.ts',
-      'libs/my-plugin/src/executors/build/executor.spec.ts',
-      'libs/my-plugin/src/executors/build/schema.json',
-      'libs/my-plugin/src/executors/build/schema.d.ts',
-    ].forEach((path) => expect(tree.exists(path)).toBeFalsy());
-  });
-
   describe('--unitTestRunner', () => {
     describe('none', () => {
       it('should not generate test files', async () => {
@@ -165,15 +117,13 @@ describe('NxPlugin Plugin Generator', () => {
           })
         );
 
-        [
-          'libs/my-plugin/src/generators/my-plugin/generator.ts',
-          'libs/my-plugin/src/executors/build/executor.ts',
-        ].forEach((path) => expect(tree.exists(path)).toBeTruthy());
+        ['libs/my-plugin/jest.config.ts'].forEach((path) =>
+          expect(tree.exists(path)).toBeFalsy()
+        );
 
-        [
-          'libs/my-plugin/src/generators/my-plugin/generator.spec.ts',
-          'libs/my-plugin/src/executors/build/executor.spec.ts',
-        ].forEach((path) => expect(tree.exists(path)).toBeFalsy());
+        expect(
+          readProjectConfiguration(tree, 'my-plugin').targets.test
+        ).not.toBeDefined();
       });
     });
   });

--- a/packages/nx-plugin/src/generators/plugin/plugin.ts
+++ b/packages/nx-plugin/src/generators/plugin/plugin.ts
@@ -37,21 +37,6 @@ async function addFiles(host: Tree, options: NormalizedSchema) {
       tmpl: '',
     }
   );
-
-  if (options.minimal) {
-    return;
-  }
-  await generatorGenerator(host, {
-    project: options.name,
-    name: options.name,
-    unitTestRunner: options.unitTestRunner,
-  });
-  await executorGenerator(host, {
-    project: options.name,
-    name: 'build',
-    unitTestRunner: options.unitTestRunner,
-    includeHasher: false,
-  });
 }
 
 function updatePluginConfig(host: Tree, options: NormalizedSchema) {
@@ -126,7 +111,6 @@ export async function pluginGenerator(host: Tree, schema: Schema) {
       projectDirectory: options.projectDirectory,
       pluginOutputPath: `dist/${options.libsDir}/${options.projectDirectory}`,
       npmPackageName: options.npmPackageName,
-      minimal: options.minimal ?? false,
       skipFormat: true,
       rootProject: options.rootProject,
     });

--- a/packages/nx-plugin/src/generators/plugin/schema.d.ts
+++ b/packages/nx-plugin/src/generators/plugin/schema.d.ts
@@ -13,6 +13,5 @@ export interface Schema {
   linter: Linter;
   setParserOptionsProject?: boolean;
   compiler: 'swc' | 'tsc';
-  minimal?: boolean;
   rootProject?: boolean;
 }

--- a/packages/nx-plugin/src/generators/plugin/schema.json
+++ b/packages/nx-plugin/src/generators/plugin/schema.json
@@ -69,7 +69,7 @@
       "type": "string",
       "enum": ["jest", "none"],
       "description": "Test runner to use for end to end (E2E) tests.",
-      "default": "jest"
+      "default": "none"
     },
     "standaloneConfig": {
       "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
@@ -87,13 +87,7 @@
       "enum": ["tsc", "swc"],
       "default": "tsc",
       "description": "The compiler used by the build and test targets."
-    },
-    "minimal": {
-      "type": "boolean",
-      "description": "Generate the plugin with a minimal setup. This would involve not generating a default executor and generator.",
-      "default": false
     }
   },
-  "required": ["name"],
-  "additionalProperties": false
+  "required": ["name"]
 }

--- a/packages/nx-plugin/src/generators/preset/generator.spec.ts
+++ b/packages/nx-plugin/src/generators/preset/generator.spec.ts
@@ -23,8 +23,7 @@ describe('preset generator', () => {
     const config = readProjectConfiguration(tree, 'my-plugin');
     expect(config).toBeDefined();
     const packageJson = readJson<PackageJson>(tree, 'package.json');
-    expect(packageJson.generators).toEqual('./generators.json');
-    expect(packageJson.executors).toEqual('./executors.json');
+    expect(packageJson.dependencies).toHaveProperty('@nx/devkit');
     expect(readNxJson(tree).npmScope).not.toBeDefined();
   });
 });

--- a/packages/nx-plugin/src/generators/preset/generator.ts
+++ b/packages/nx-plugin/src/generators/preset/generator.ts
@@ -1,13 +1,14 @@
 import {
   Tree,
-  readJson,
-  joinPathFragments,
   updateJson,
   updateNxJson,
   readNxJson,
+  readProjectConfiguration,
 } from '@nx/devkit';
 import { Linter } from '@nx/linter';
 import { PackageJson } from 'nx/src/utils/package-json';
+import { createExecutorsJson } from '../executor/executor';
+import { createGeneratorsJson } from '../generator/generator';
 import { pluginGenerator } from '../plugin/plugin';
 import { PresetGeneratorSchema } from './schema';
 
@@ -24,7 +25,12 @@ export default async function (tree: Tree, options: PresetGeneratorSchema) {
     unitTestRunner: 'jest',
     importPath: options.pluginName,
     rootProject: true,
+    e2eTestRunner: 'jest',
   });
+
+  const { root } = readProjectConfiguration(tree, options.pluginName);
+  await createExecutorsJson(tree, root, options.pluginName);
+  await createGeneratorsJson(tree, root, options.pluginName);
 
   removeNpmScope(tree);
   moveNxPluginToDevDeps(tree);

--- a/packages/nx-plugin/src/generators/preset/generator.ts
+++ b/packages/nx-plugin/src/generators/preset/generator.ts
@@ -1,14 +1,6 @@
-import {
-  Tree,
-  updateJson,
-  updateNxJson,
-  readNxJson,
-  readProjectConfiguration,
-} from '@nx/devkit';
+import { Tree, updateJson, updateNxJson, readNxJson } from '@nx/devkit';
 import { Linter } from '@nx/linter';
 import { PackageJson } from 'nx/src/utils/package-json';
-import { createExecutorsJson } from '../executor/executor';
-import { createGeneratorsJson } from '../generator/generator';
 import { pluginGenerator } from '../plugin/plugin';
 import { PresetGeneratorSchema } from './schema';
 
@@ -27,10 +19,6 @@ export default async function (tree: Tree, options: PresetGeneratorSchema) {
     rootProject: true,
     e2eTestRunner: 'jest',
   });
-
-  const { root } = readProjectConfiguration(tree, options.pluginName);
-  await createExecutorsJson(tree, root, options.pluginName);
-  await createGeneratorsJson(tree, root, options.pluginName);
 
   removeNpmScope(tree);
   moveNxPluginToDevDeps(tree);

--- a/packages/nx-plugin/src/migrations/update-15-0-0/specify-output-capture.spec.ts
+++ b/packages/nx-plugin/src/migrations/update-15-0-0/specify-output-capture.spec.ts
@@ -2,12 +2,13 @@ import { readJson, updateJson } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { Linter } from '@nx/linter';
 import { ExecutorConfig } from 'nx/src/config/misc-interfaces';
+import executorGenerator from '../../generators/executor/executor';
 import pluginGenerator from '../../generators/plugin/plugin';
 import update from './specify-output-capture';
 
 const schemaPath = `libs/plugin/src/executors/build/schema.json`;
 
-describe('update-14-2-0-split-create-empty-tree', () => {
+describe('update-15-0-0-specify-output-capture', () => {
   it('should not change outputCapture if already present', async () => {
     const { tree } = await createTreeWithBoilerplate();
     updateJson(tree, schemaPath, (json) => {
@@ -61,6 +62,12 @@ async function createTreeWithBoilerplate() {
     skipLintChecks: false,
     skipTsConfig: false,
     unitTestRunner: 'jest',
+  });
+  await executorGenerator(tree, {
+    name: 'build',
+    project: 'plugin',
+    unitTestRunner: 'jest',
+    includeHasher: false,
   });
   return { tree };
 }

--- a/packages/nx-plugin/src/migrations/update-16-0-0/cli-in-schema-json.spec.ts
+++ b/packages/nx-plugin/src/migrations/update-16-0-0/cli-in-schema-json.spec.ts
@@ -134,7 +134,7 @@ describe('updateCliPropsForPlugins', () => {
   it('should remove cli property from executors', async () => {
     const tree = createTreeWithEmptyWorkspace();
     const { root, name } = await createPlugin(tree);
-    executorGenerator(tree, {
+    await executorGenerator(tree, {
       name: 'my-executor',
       project: name,
       unitTestRunner: 'jest',
@@ -156,7 +156,7 @@ describe('updateCliPropsForPlugins', () => {
   it('should remove cli property from builders', async () => {
     const tree = createTreeWithEmptyWorkspace();
     const { root, name } = await createPlugin(tree);
-    executorGenerator(tree, {
+    await executorGenerator(tree, {
       name: 'my-executor',
       project: name,
       unitTestRunner: 'jest',
@@ -187,7 +187,7 @@ describe('updateCliPropsForPlugins', () => {
   it('should remove cli property from generators', async () => {
     const tree = createTreeWithEmptyWorkspace();
     const { root, name } = await createPlugin(tree);
-    generatorGenerator(tree, {
+    await generatorGenerator(tree, {
       name: 'my-generator',
       project: name,
       unitTestRunner: 'jest',
@@ -208,7 +208,7 @@ describe('updateCliPropsForPlugins', () => {
   it('should remove cli property from schematics', async () => {
     const tree = createTreeWithEmptyWorkspace();
     const { root, name } = await createPlugin(tree);
-    generatorGenerator(tree, {
+    await generatorGenerator(tree, {
       name: 'my-schematic',
       project: name,
       unitTestRunner: 'jest',

--- a/packages/nx-plugin/src/utils/has-generator.ts
+++ b/packages/nx-plugin/src/utils/has-generator.ts
@@ -1,0 +1,32 @@
+import {
+  GeneratorsJson,
+  joinPathFragments,
+  readJson,
+  readProjectConfiguration,
+  Tree,
+} from '@nx/devkit';
+import { PackageJson } from 'nx/src/utils/package-json';
+
+export function hasGenerator(
+  tree: Tree,
+  projectName: string,
+  generatorName: string
+): boolean {
+  const project = readProjectConfiguration(tree, projectName);
+  const packageJson = readJson<PackageJson>(
+    tree,
+    joinPathFragments(project.root, 'package.json')
+  );
+  if (!packageJson.generators && !packageJson.schematics) {
+    return false;
+  }
+  const generatorsPath = joinPathFragments(
+    project.root,
+    packageJson.generators ?? packageJson.schematics
+  );
+  const generatorsJson = readJson<GeneratorsJson>(tree, generatorsPath);
+  return (
+    (generatorsJson.generators?.[generatorName] ??
+      generatorsJson.schematics?.[generatorName]) !== undefined
+  );
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
nx g plugin creates:
- e2e tests by default
- Boilerplate executor + generator

## Expected Behavior
- To add e2e you can specify `--e2eTestRunner jest`, or generate it with `nx g @nrwl/nx-plugin:e2e-project`
- You can add a generator with `nx g generator`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204424637634825