### PR TITLE
fix(storybook): correctly determine version of SB

### DIFF
--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -56,7 +56,7 @@ export async function configurationGenerator(
     storybookMajorVersion() === 7 || rawSchema.storybook7Configuration;
 
   if (storybookMajorVersion() === 6 && rawSchema.storybook7Configuration) {
-    logger.error(
+    logger.warn(
       `You are using Storybook version 6. 
          So Nx will configure Storybook for version 6.`
     );


### PR DESCRIPTION
Use `OR` instead of nullish coallescing, since a user may have no version of storybook installed yet.