### PR TITLE
fix(misc): shared deps that rely on default configuration are filtered out

### DIFF
--- a/packages/angular/src/utils/mf/utils.ts
+++ b/packages/angular/src/utils/mf/utils.ts
@@ -60,10 +60,10 @@ export async function getModuleFederationConfig(
 
   if (mfConfig.shared) {
     dependencies.workspaceLibraries = dependencies.workspaceLibraries.filter(
-      (lib) => mfConfig.shared(lib.importKey, {})
+      (lib) => mfConfig.shared(lib.importKey, {}) !== false
     );
-    dependencies.npmPackages = dependencies.npmPackages.filter((pkg) =>
-      mfConfig.shared(pkg, {})
+    dependencies.npmPackages = dependencies.npmPackages.filter(
+      (pkg) => mfConfig.shared(pkg, {}) !== false
     );
   }
 

--- a/packages/react/src/module-federation/utils.ts
+++ b/packages/react/src/module-federation/utils.ts
@@ -40,10 +40,10 @@ export async function getModuleFederationConfig(
 
   if (mfConfig.shared) {
     dependencies.workspaceLibraries = dependencies.workspaceLibraries.filter(
-      (lib) => mfConfig.shared(lib.importKey, {})
+      (lib) => mfConfig.shared(lib.importKey, {}) !== false
     );
-    dependencies.npmPackages = dependencies.npmPackages.filter((pkg) =>
-      mfConfig.shared(pkg, {})
+    dependencies.npmPackages = dependencies.npmPackages.filter(
+      (pkg) => mfConfig.shared(pkg, {}) !== false
     );
   }
 


### PR DESCRIPTION
The issue was introduced by #15654. It then filters out and omits shared deps that rely on default configuration when return value from `shared` function is `undefined`.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
NPM package dependencies are not made shared in module federation configuration when are not explicitly excluded in user provided `shared` function by returning `undefined` value

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
NPM package dependencies should be made shared in module federation configuration unless `shared` function returns `false` value

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15811
