### PR TITLE
feat(misc): make createWorkspace quieter by default

### DIFF
--- a/packages/create-nx-workspace/src/create-empty-workspace.ts
+++ b/packages/create-nx-workspace/src/create-empty-workspace.ts
@@ -64,13 +64,13 @@ export async function createEmptyWorkspace<T extends CreateWorkspaceOptions>(
     await execAndWait(fullCommand, tmpDir);
 
     workspaceSetupSpinner.succeed(
-      `Nx has successfully created the workspace: ${getFileName(name)}.`
+      `Successfully created the workspace: ${getFileName(name)}.`
     );
   } catch (e) {
     workspaceSetupSpinner.fail();
     if (e instanceof Error) {
       output.error({
-        title: `Nx failed to create a workspace.`,
+        title: `Failed to create a workspace.`,
         bodyLines: mapErrorToBodyLines(e),
       });
     } else {

--- a/packages/create-nx-workspace/src/create-preset.ts
+++ b/packages/create-nx-workspace/src/create-preset.ts
@@ -52,10 +52,6 @@ export async function createPreset<T extends CreateWorkspaceOptions>(
       ...command.split(' ')
     );
     await spawnAndWait(exec, args, directory);
-
-    output.log({
-      title: `Successfully applied preset: ${preset}.`,
-    });
   } catch (e) {
     output.error({
       title: `Failed to apply preset: ${preset}`,

--- a/packages/create-nx-workspace/src/create-sandbox.ts
+++ b/packages/create-nx-workspace/src/create-sandbox.ts
@@ -46,7 +46,7 @@ export async function createSandbox(packageManager: PackageManager) {
     installSpinner.fail();
     if (e instanceof Error) {
       output.error({
-        title: `Nx failed to install dependencies`,
+        title: `Failed to install dependencies`,
         bodyLines: mapErrorToBodyLines(e),
       });
     } else {

--- a/packages/create-nx-workspace/src/create-workspace-options.d.ts
+++ b/packages/create-nx-workspace/src/create-workspace-options.d.ts
@@ -29,4 +29,5 @@ export interface CreateWorkspaceOptions {
     email: string; // Email to use for the initial commit
     message: string; // Message to use for the initial commit
   };
+  cliName?: string; // Name of the CLI, used when displaying outputs. e.g. nx, Nx
 }

--- a/packages/create-nx-workspace/src/create-workspace.ts
+++ b/packages/create-nx-workspace/src/create-workspace.ts
@@ -1,10 +1,9 @@
 import { CreateWorkspaceOptions } from './create-workspace-options';
 import { output } from './utils/output';
-import { printNxCloudSuccessMessage, setupNxCloud } from './utils/nx/nx-cloud';
+import { setupNxCloud } from './utils/nx/nx-cloud';
 import { createSandbox } from './create-sandbox';
 import { createEmptyWorkspace } from './create-empty-workspace';
 import { createPreset } from './create-preset';
-import { showNxWarning } from './utils/nx/show-nx-warning';
 import { setupCI } from './utils/ci/setup-ci';
 import { messages, recordStat } from './utils/nx/ab-testing';
 import { initializeGitRepo } from './utils/git/git';
@@ -24,15 +23,12 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
     skipGit = false,
     defaultBase = 'main',
     commit,
+    cliName,
   } = options;
 
-  output.log({
-    title: `Nx is creating your v${nxVersion} workspace.`,
-    bodyLines: [
-      'To make sure the command works reliably in all environments, and that the preset is applied correctly,',
-      `Nx will run "${options.packageManager} install" several times. Please wait.`,
-    ],
-  });
+  if (cliName) {
+    output.setCliName(cliName ?? 'NX');
+  }
 
   const tmpDir = await createSandbox(packageManager);
 
@@ -79,16 +75,8 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
     }
   }
 
-  showNxWarning(name);
-
-  if (nxCloud && nxCloudInstallRes?.code === 0) {
-    printNxCloudSuccessMessage(nxCloudInstallRes.stdout);
-  }
-
-  await recordStat({
-    nxVersion,
-    command: 'create-nx-workspace',
-    useCloud: nxCloud,
-    meta: messages.codeOfSelectedPromptMessage('nxCloudCreation'),
-  });
+  return {
+    nxCloudInfo: nxCloudInstallRes?.stdout,
+    directory,
+  };
 }

--- a/packages/create-nx-workspace/src/utils/ci/setup-ci.ts
+++ b/packages/create-nx-workspace/src/utils/ci/setup-ci.ts
@@ -35,7 +35,7 @@ export async function setupCI(
     ciSpinner.fail();
     if (e instanceof Error) {
       output.error({
-        title: `Nx failed to generate CI workflow`,
+        title: `Failed to generate CI workflow`,
         bodyLines: mapErrorToBodyLines(e),
       });
     } else {

--- a/packages/create-nx-workspace/src/utils/git/git.ts
+++ b/packages/create-nx-workspace/src/utils/git/git.ts
@@ -83,7 +83,4 @@ export async function initializeGitRepo(
     const message = options.commit.message || 'initial commit';
     await execute(['commit', `-m "${message}"`]);
   }
-  output.log({
-    title: 'Successfully initialized git.',
-  });
 }

--- a/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
+++ b/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
@@ -24,7 +24,7 @@ export async function setupNxCloud(
 
     if (e instanceof Error) {
       output.error({
-        title: `Nx failed to setup NxCloud`,
+        title: `Failed to setup NxCloud`,
         bodyLines: mapErrorToBodyLines(e),
       });
     } else {

--- a/packages/create-nx-workspace/src/utils/output.ts
+++ b/packages/create-nx-workspace/src/utils/output.ts
@@ -10,13 +10,11 @@ import { isCI } from './ci/is-ci';
 export interface CLIErrorMessageConfig {
   title: string;
   bodyLines?: string[];
-  slug?: string;
 }
 
 export interface CLIWarnMessageConfig {
   title: string;
   bodyLines?: string[];
-  slug?: string;
 }
 
 export interface CLINoteMessageConfig {
@@ -82,7 +80,7 @@ class CLIOutput {
     color: string;
     title: string;
   }): void {
-    this.writeToStdOut(` ${this.applyNxPrefix(color, title)}${EOL}`);
+    this.writeToStdOut(` ${this.applyCLIPrefix(color, title)}${EOL}`);
   }
 
   private writeOptionalOutputBody(bodyLines?: string[]): void {
@@ -93,18 +91,24 @@ class CLIOutput {
     bodyLines.forEach((bodyLine) => this.writeToStdOut(`   ${bodyLine}${EOL}`));
   }
 
-  applyNxPrefix(color = 'cyan', text: string): string {
-    let nxPrefix = '';
+  private cliName = 'NX';
+
+  setCliName(name: string) {
+    this.cliName = name;
+  }
+
+  applyCLIPrefix(color = 'cyan', text: string): string {
+    let cliPrefix = '';
     if ((chalk as any)[color]) {
-      nxPrefix = `${(chalk as any)[color]('>')} ${(
+      cliPrefix = `${(chalk as any)[color]('>')} ${(
         chalk as any
-      ).reset.inverse.bold[color](' NX ')}`;
+      ).reset.inverse.bold[color](` ${this.cliName} `)}`;
     } else {
-      nxPrefix = `${chalk.keyword(color)(
+      cliPrefix = `${chalk.keyword(color)(
         '>'
-      )} ${chalk.reset.inverse.bold.keyword(color)(' NX ')}`;
+      )} ${chalk.reset.inverse.bold.keyword(color)(` ${this.cliName} `)}`;
     }
-    return `${nxPrefix}  ${text}`;
+    return `${cliPrefix}  ${text}`;
   }
 
   addNewline() {
@@ -125,7 +129,7 @@ class CLIOutput {
     );
   }
 
-  error({ title, slug, bodyLines }: CLIErrorMessageConfig) {
+  error({ title, bodyLines }: CLIErrorMessageConfig) {
     this.addNewline();
 
     this.writeOutputTitle({
@@ -135,22 +139,10 @@ class CLIOutput {
 
     this.writeOptionalOutputBody(bodyLines);
 
-    /**
-     * Optional slug to be used in an Nx error message redirect URL
-     */
-    if (slug && typeof slug === 'string') {
-      this.addNewline();
-      this.writeToStdOut(
-        `${chalk.grey(
-          '  Learn more about this error: '
-        )}https://errors.nx.dev/${slug}${EOL}`
-      );
-    }
-
     this.addNewline();
   }
 
-  warn({ title, slug, bodyLines }: CLIWarnMessageConfig) {
+  warn({ title, bodyLines }: CLIWarnMessageConfig) {
     this.addNewline();
 
     this.writeOutputTitle({
@@ -159,18 +151,6 @@ class CLIOutput {
     });
 
     this.writeOptionalOutputBody(bodyLines);
-
-    /**
-     * Optional slug to be used in an Nx warning message redirect URL
-     */
-    if (slug && typeof slug === 'string') {
-      this.addNewline();
-      this.writeToStdOut(
-        `${chalk.grey(
-          '  Learn more about this warning: '
-        )}https://errors.nx.dev/${slug}\n`
-      );
-    }
 
     this.addNewline();
   }
@@ -211,8 +191,6 @@ class CLIOutput {
 
     this.addNewline();
   }
-
-  logCommand(message: string) {}
 
   log({ title, bodyLines, color }: CLIWarnMessageConfig & { color?: string }) {
     this.addNewline();

--- a/packages/nx/src/command-line/generate.ts
+++ b/packages/nx/src/command-line/generate.ts
@@ -333,9 +333,11 @@ export async function generate(cwd: string, args: { [k: string]: any }) {
         ].join('/n')
       );
     }
-    logger.info(
-      `NX Generating ${opts.collectionName}:${normalizedGeneratorName}`
-    );
+    if (!opts.quiet) {
+      logger.info(
+        `NX Generating ${opts.collectionName}:${normalizedGeneratorName}`
+      );
+    }
 
     if (opts.help) {
       printGenHelp(opts, schema, normalizedGeneratorName, aliases);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Using the `createWorkspace` API triggers the same logs that a user gets with `create-nx-workspace`

## Expected Behavior
Folks using `createWorkspace` can provide their own logging provider.

<img width="1137" alt="image" src="https://user-images.githubusercontent.com/6933928/232159702-5a33c097-7d09-4978-b23b-8301c8151b87.png">

Breaking down the above output: 
- 3 spinners that don't mention Nx
- `Fetching prettier...` - logged by the nx-plugin preset generator as @nrwl/js is initialized
- Output text logged by the nx-plugin plugin generator during preset generation 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
