### PR TITLE
feat(core): add --why for nx affected

### DIFF
--- a/docs/generated/cli/affected-apps.md
+++ b/docs/generated/cli/affected-apps.md
@@ -96,3 +96,9 @@ Untracked changes
 Type: `boolean`
 
 Show version number
+
+### why
+
+Type: `string`
+
+Print the reasons that a project is marked as affected.

--- a/docs/generated/cli/affected-graph.md
+++ b/docs/generated/cli/affected-graph.md
@@ -170,3 +170,9 @@ Type: `boolean`
 Default: `false`
 
 Watch for changes to project graph and update in-browser
+
+### why
+
+Type: `string`
+
+Print the reasons that a project is marked as affected.

--- a/docs/generated/cli/affected-libs.md
+++ b/docs/generated/cli/affected-libs.md
@@ -96,3 +96,9 @@ Untracked changes
 Type: `boolean`
 
 Show version number
+
+### why
+
+Type: `string`
+
+Print the reasons that a project is marked as affected.

--- a/docs/generated/cli/affected.md
+++ b/docs/generated/cli/affected.md
@@ -190,3 +190,9 @@ Prints additional information about the commands (e.g., stack traces)
 Type: `boolean`
 
 Show version number
+
+### why
+
+Type: `string`
+
+Print the reasons that a project is marked as affected.

--- a/docs/generated/cli/format-check.md
+++ b/docs/generated/cli/format-check.md
@@ -82,3 +82,9 @@ Untracked changes
 Type: `boolean`
 
 Show version number
+
+### why
+
+Type: `string`
+
+Print the reasons that a project is marked as affected.

--- a/docs/generated/cli/format-write.md
+++ b/docs/generated/cli/format-write.md
@@ -82,3 +82,9 @@ Untracked changes
 Type: `boolean`
 
 Show version number
+
+### why
+
+Type: `string`
+
+Print the reasons that a project is marked as affected.

--- a/docs/generated/cli/print-affected.md
+++ b/docs/generated/cli/print-affected.md
@@ -128,3 +128,9 @@ Untracked changes
 Type: `boolean`
 
 Show version number
+
+### why
+
+Type: `string`
+
+Print the reasons that a project is marked as affected.

--- a/docs/generated/packages/nx/documents/affected-apps.md
+++ b/docs/generated/packages/nx/documents/affected-apps.md
@@ -96,3 +96,9 @@ Untracked changes
 Type: `boolean`
 
 Show version number
+
+### why
+
+Type: `string`
+
+Print the reasons that a project is marked as affected.

--- a/docs/generated/packages/nx/documents/affected-dep-graph.md
+++ b/docs/generated/packages/nx/documents/affected-dep-graph.md
@@ -170,3 +170,9 @@ Type: `boolean`
 Default: `false`
 
 Watch for changes to project graph and update in-browser
+
+### why
+
+Type: `string`
+
+Print the reasons that a project is marked as affected.

--- a/docs/generated/packages/nx/documents/affected-libs.md
+++ b/docs/generated/packages/nx/documents/affected-libs.md
@@ -96,3 +96,9 @@ Untracked changes
 Type: `boolean`
 
 Show version number
+
+### why
+
+Type: `string`
+
+Print the reasons that a project is marked as affected.

--- a/docs/generated/packages/nx/documents/affected.md
+++ b/docs/generated/packages/nx/documents/affected.md
@@ -190,3 +190,9 @@ Prints additional information about the commands (e.g., stack traces)
 Type: `boolean`
 
 Show version number
+
+### why
+
+Type: `string`
+
+Print the reasons that a project is marked as affected.

--- a/docs/generated/packages/nx/documents/format-check.md
+++ b/docs/generated/packages/nx/documents/format-check.md
@@ -82,3 +82,9 @@ Untracked changes
 Type: `boolean`
 
 Show version number
+
+### why
+
+Type: `string`
+
+Print the reasons that a project is marked as affected.

--- a/docs/generated/packages/nx/documents/format-write.md
+++ b/docs/generated/packages/nx/documents/format-write.md
@@ -82,3 +82,9 @@ Untracked changes
 Type: `boolean`
 
 Show version number
+
+### why
+
+Type: `string`
+
+Print the reasons that a project is marked as affected.

--- a/docs/generated/packages/nx/documents/print-affected.md
+++ b/docs/generated/packages/nx/documents/print-affected.md
@@ -128,3 +128,9 @@ Untracked changes
 Type: `boolean`
 
 Show version number
+
+### why
+
+Type: `string`
+
+Print the reasons that a project is marked as affected.

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -579,6 +579,10 @@ function withAffectedOptions(yargs: yargs.Argv): yargs.Argv {
       type: 'string',
       requiresArg: true,
     })
+    .option('why', {
+      describe: 'Print the reasons that a project is marked as affected.',
+      type: 'string',
+    })
     .group(
       ['base'],
       'Run command using --base=[SHA1] (affected by the committed, uncommitted and untracked changes):'
@@ -594,6 +598,16 @@ function withAffectedOptions(yargs: yargs.Argv): yargs.Argv {
       untracked: ['uncommitted', 'files', 'base', 'head', 'all'],
       uncommitted: ['files', 'untracked', 'base', 'head', 'all'],
       all: ['files', 'untracked', 'uncommitted', 'base', 'head'],
+    })
+    .middleware((argv) => {
+      if (argv.why !== null && argv.why !== undefined) {
+        argv.target = '_';
+        if (argv.why === 'false') {
+          delete argv['why'];
+        } else if (argv.why === 'true' || argv.why === '') {
+          argv['why'] = 'affected';
+        }
+      }
     });
 }
 

--- a/packages/nx/src/project-graph/affected/affected-project-graph-models.ts
+++ b/packages/nx/src/project-graph/affected/affected-project-graph-models.ts
@@ -12,6 +12,11 @@ export interface AffectedProjectGraphContext {
   touchedProjects: string[];
 }
 
+export type LocatorResult = Map<
+  string,
+  (string | { reason: string; occurences: string[] })[]
+>;
+
 export interface TouchedProjectLocator<T extends Change = Change> {
   (
     fileChanges: FileChange<T>[],
@@ -19,5 +24,5 @@ export interface TouchedProjectLocator<T extends Change = Change> {
     nxJson?: NxJsonConfiguration<any>,
     packageJson?: any,
     projectGraph?: ProjectGraph
-  ): string[] | Promise<string[]>;
+  ): LocatorResult | Promise<LocatorResult>;
 }

--- a/packages/nx/src/project-graph/affected/locators/locator-utils.ts
+++ b/packages/nx/src/project-graph/affected/locators/locator-utils.ts
@@ -1,0 +1,30 @@
+import { LocatorResult } from '../affected-project-graph-models';
+
+export function addReasonForProject(
+  project: string,
+  reason: string,
+  occurence: string | null,
+  touched: LocatorResult
+) {
+  const existingProjectEntry = touched.get(project);
+  if (existingProjectEntry) {
+    if (occurence) {
+      const existingReasonEntry = existingProjectEntry.find(
+        (r) => typeof r === 'object' && r !== null && r.reason === reason
+      );
+      if (existingReasonEntry && typeof existingReasonEntry === 'object') {
+        existingReasonEntry.occurences.push(occurence);
+      } else {
+        existingProjectEntry.push({ reason, occurences: [occurence] });
+      }
+    } else {
+      existingProjectEntry.push(reason);
+    }
+  } else {
+    if (occurence) {
+      touched.set(project, [{ reason, occurences: [occurence] }]);
+    } else {
+      touched.set(project, [reason]);
+    }
+  }
+}

--- a/packages/nx/src/project-graph/affected/locators/npm-packages.spec.ts
+++ b/packages/nx/src/project-graph/affected/locators/npm-packages.spec.ts
@@ -61,132 +61,148 @@ describe('getTouchedNpmPackages', () => {
     };
   });
 
-  it('should handle json changes', () => {
-    const result = getTouchedNpmPackages(
-      [
-        {
-          file: 'package.json',
-          hash: 'some-hash',
-          getChanges: () => [
+  it('should handle json changes', async () => {
+    const result = [
+      ...(
+        await getTouchedNpmPackages(
+          [
             {
-              type: JsonDiffType.Modified,
-              path: ['dependencies', 'happy-nrwl'],
-              value: {
-                lhs: '0.0.1',
-                rhs: '0.0.2',
-              },
+              file: 'package.json',
+              hash: 'some-hash',
+              getChanges: () => [
+                {
+                  type: JsonDiffType.Modified,
+                  path: ['dependencies', 'happy-nrwl'],
+                  value: {
+                    lhs: '0.0.1',
+                    rhs: '0.0.2',
+                  },
+                },
+              ],
             },
           ],
-        },
-      ],
-      projectsConfigurations,
-      nxJson,
-      {
-        dependencies: {
-          'happy-nrwl': '0.0.2',
-        },
-      },
-      projectGraph
-    );
+          projectsConfigurations,
+          nxJson,
+          {
+            dependencies: {
+              'happy-nrwl': '0.0.2',
+            },
+          },
+          projectGraph
+        )
+      ).keys(),
+    ];
     expect(result).toEqual(['npm:happy-nrwl']);
   });
 
-  it('should handle json changes for type declaration packages where the implementation package exists', () => {
-    const result = getTouchedNpmPackages(
-      [
-        {
-          file: 'package.json',
-          hash: 'some-hash',
-          getChanges: () => [
+  it('should handle json changes for type declaration packages where the implementation package exists', async () => {
+    const result = [
+      ...(
+        await getTouchedNpmPackages(
+          [
             {
-              type: JsonDiffType.Modified,
-              path: ['dependencies', '@types/happy-nrwl'],
-              value: {
-                lhs: '0.0.1',
-                rhs: '0.0.2',
-              },
+              file: 'package.json',
+              hash: 'some-hash',
+              getChanges: () => [
+                {
+                  type: JsonDiffType.Modified,
+                  path: ['dependencies', '@types/happy-nrwl'],
+                  value: {
+                    lhs: '0.0.1',
+                    rhs: '0.0.2',
+                  },
+                },
+              ],
             },
           ],
-        },
-      ],
-      projectsConfigurations,
-      nxJson,
-      {
-        dependencies: {
-          'happy-nrwl': '0.0.2',
-        },
-        devDependencies: {
-          '@types/happy-nrwl': '0.0.2',
-        },
-      },
-      projectGraph
-    );
+          projectsConfigurations,
+          nxJson,
+          {
+            dependencies: {
+              'happy-nrwl': '0.0.2',
+            },
+            devDependencies: {
+              '@types/happy-nrwl': '0.0.2',
+            },
+          },
+          projectGraph
+        )
+      ).keys(),
+    ];
     expect(result).toEqual(
       expect.arrayContaining(['npm:@types/happy-nrwl', 'npm:happy-nrwl'])
     );
   });
 
-  it('should handle json changes for type declaration packages where the implementation package does not exist', () => {
-    const result = getTouchedNpmPackages(
-      [
-        {
-          file: 'package.json',
-          hash: 'some-hash',
-          getChanges: () => [
+  it('should handle json changes for type declaration packages where the implementation package does not exist', async () => {
+    const result = [
+      ...(
+        await getTouchedNpmPackages(
+          [
             {
-              type: JsonDiffType.Modified,
-              path: ['dependencies', '@types/happy-nrwl'],
-              value: {
-                lhs: '0.0.1',
-                rhs: '0.0.2',
-              },
+              file: 'package.json',
+              hash: 'some-hash',
+              getChanges: () => [
+                {
+                  type: JsonDiffType.Modified,
+                  path: ['dependencies', '@types/happy-nrwl'],
+                  value: {
+                    lhs: '0.0.1',
+                    rhs: '0.0.2',
+                  },
+                },
+              ],
             },
           ],
-        },
-      ],
-      projectsConfigurations,
-      nxJson,
-      {
-        devDependencies: {
-          '@types/happy-nrwl': '0.0.2',
-        },
-      },
-      projectGraph
-    );
+          projectsConfigurations,
+          nxJson,
+          {
+            devDependencies: {
+              '@types/happy-nrwl': '0.0.2',
+            },
+          },
+          projectGraph
+        )
+      ).keys(),
+    ];
     expect(result).toEqual(expect.arrayContaining(['npm:@types/happy-nrwl']));
   });
 
-  it('should handle package deletion', () => {
-    const result = getTouchedNpmPackages(
-      [
-        {
-          file: 'package.json',
-          hash: 'some-hash',
-          getChanges: () => [
+  it('should handle package deletion', async () => {
+    const result = [
+      ...(
+        await getTouchedNpmPackages(
+          [
             {
-              type: JsonDiffType.Deleted,
-              path: ['dependencies', 'sad-nrwl'],
-              value: {
-                lhs: '0.0.1',
-                rhs: undefined,
-              },
+              file: 'package.json',
+              hash: 'some-hash',
+              getChanges: () => [
+                {
+                  type: JsonDiffType.Deleted,
+                  path: ['dependencies', 'sad-nrwl'],
+                  value: {
+                    lhs: '0.0.1',
+                    rhs: undefined,
+                  },
+                },
+              ],
             },
           ],
-        },
-      ],
-      projectsConfigurations,
-      nxJson,
-      {
-        dependencies: {
-          'happy-nrwl': '0.0.2',
-        },
-      },
-      projectGraph
-    );
+          projectsConfigurations,
+          nxJson,
+          {
+            dependencies: {
+              'happy-nrwl': '0.0.2',
+            },
+          },
+          projectGraph
+        )
+      ).keys(),
+    ];
     expect(result).toEqual(['proj1', 'proj2']);
   });
 
-  it('should handle package addition', () => {
+  it('should handle package addition', async () => {
     projectGraph.externalNodes['npm:awesome-nrwl'] = {
       name: 'npm:awesome-nrwl',
       type: 'npm',
@@ -195,37 +211,41 @@ describe('getTouchedNpmPackages', () => {
         version: '1',
       },
     };
-    const result = getTouchedNpmPackages(
-      [
-        {
-          file: 'package.json',
-          hash: 'some-hash',
-          getChanges: () => [
+    const result = [
+      ...(
+        await getTouchedNpmPackages(
+          [
             {
-              type: JsonDiffType.Added,
-              path: ['dependencies', 'awesome-nrwl'],
-              value: {
-                lhs: undefined,
-                rhs: '0.0.1',
-              },
+              file: 'package.json',
+              hash: 'some-hash',
+              getChanges: () => [
+                {
+                  type: JsonDiffType.Added,
+                  path: ['dependencies', 'awesome-nrwl'],
+                  value: {
+                    lhs: undefined,
+                    rhs: '0.0.1',
+                  },
+                },
+              ],
             },
           ],
-        },
-      ],
-      projectsConfigurations,
-      nxJson,
-      {
-        dependencies: {
-          'happy-nrwl': '0.0.2',
-          'awesome-nrwl': '0.0.1',
-        },
-      },
-      projectGraph
-    );
+          projectsConfigurations,
+          nxJson,
+          {
+            dependencies: {
+              'happy-nrwl': '0.0.2',
+              'awesome-nrwl': '0.0.1',
+            },
+          },
+          projectGraph
+        )
+      ).keys(),
+    ];
     expect(result).toEqual(['npm:awesome-nrwl']);
   });
 
-  it('should handle whole file changes', () => {
+  it('should handle whole file changes', async () => {
     projectGraph.externalNodes['npm:awesome-nrwl'] = {
       name: 'npm:awesome-nrwl',
       type: 'npm',
@@ -234,24 +254,28 @@ describe('getTouchedNpmPackages', () => {
         version: '1',
       },
     };
-    const result = getTouchedNpmPackages(
-      [
-        {
-          file: 'package.json',
-          hash: 'some-hash',
-          getChanges: () => [new WholeFileChange()],
-        },
-      ],
-      projectsConfigurations,
-      nxJson,
-      {
-        dependencies: {
-          'happy-nrwl': '0.0.1',
-          'awesome-nrwl': '0.0.1',
-        },
-      },
-      projectGraph
-    );
+    const result = [
+      ...(
+        await getTouchedNpmPackages(
+          [
+            {
+              file: 'package.json',
+              hash: 'some-hash',
+              getChanges: () => [new WholeFileChange()],
+            },
+          ],
+          projectsConfigurations,
+          nxJson,
+          {
+            dependencies: {
+              'happy-nrwl': '0.0.1',
+              'awesome-nrwl': '0.0.1',
+            },
+          },
+          projectGraph
+        )
+      ).keys(),
+    ];
     expect(result).toEqual([
       'npm:happy-nrwl',
       'npm:@types/happy-nrwl',
@@ -259,41 +283,45 @@ describe('getTouchedNpmPackages', () => {
     ]);
   });
 
-  it('should handle and workspace packages when defined in dependencies', () => {
-    const result = getTouchedNpmPackages(
-      [
-        {
-          file: 'package.json',
-          hash: 'some-hash',
-          getChanges: () => [
+  it('should handle and workspace packages when defined in dependencies', async () => {
+    const result = [
+      ...(
+        await getTouchedNpmPackages(
+          [
             {
-              type: 'JsonPropertyAdded',
-              path: ['devDependencies', 'changed-test-pkg-name-1'],
-              value: { rhs: 'workspace:*' },
+              file: 'package.json',
+              hash: 'some-hash',
+              getChanges: () => [
+                {
+                  type: 'JsonPropertyAdded',
+                  path: ['devDependencies', 'changed-test-pkg-name-1'],
+                  value: { rhs: 'workspace:*' },
+                },
+              ],
             },
           ],
-        },
-      ],
-      projectsConfigurations,
-      nxJson,
-      {
-        dependencies: {
-          'happy-nrwl': '0.0.1',
-          'awesome-nrwl': '0.0.1',
-        },
-      },
-      {
-        ...projectGraph,
-        nodes: {
-          ...projectGraph.nodes,
-          'any-random-name': {
-            name: 'changed-test-pkg-name-1',
-            type: 'lib',
-            data: {} as any,
+          projectsConfigurations,
+          nxJson,
+          {
+            dependencies: {
+              'happy-nrwl': '0.0.1',
+              'awesome-nrwl': '0.0.1',
+            },
           },
-        },
-      }
-    );
+          {
+            ...projectGraph,
+            nodes: {
+              ...projectGraph.nodes,
+              'any-random-name': {
+                name: 'changed-test-pkg-name-1',
+                type: 'lib',
+                data: {} as any,
+              },
+            },
+          }
+        )
+      ).keys(),
+    ];
     expect(result).toEqual(['changed-test-pkg-name-1']);
   });
 

--- a/packages/nx/src/project-graph/affected/locators/project-glob-changes.spec.ts
+++ b/packages/nx/src/project-graph/affected/locators/project-glob-changes.spec.ts
@@ -30,22 +30,26 @@ describe('getTouchedProjectsFromProjectGlobChanges', () => {
   });
 
   it('should affect all projects if a project is removed', async () => {
-    const result = await getTouchedProjectsFromProjectGlobChanges(
-      [
-        {
-          file: 'libs/proj1/project.json',
-          hash: 'some-hash',
-          getChanges: () => [new DeletedFileChange()],
-        },
-      ],
-      {
-        proj2: makeProjectGraphNode('proj2'),
-        proj3: makeProjectGraphNode('proj3'),
-      },
-      {
-        plugins: [],
-      }
-    );
+    const result = [
+      ...(
+        await getTouchedProjectsFromProjectGlobChanges(
+          [
+            {
+              file: 'libs/proj1/project.json',
+              hash: 'some-hash',
+              getChanges: () => [new DeletedFileChange()],
+            },
+          ],
+          {
+            proj2: makeProjectGraphNode('proj2'),
+            proj3: makeProjectGraphNode('proj3'),
+          },
+          {
+            plugins: [],
+          }
+        )
+      ).keys(),
+    ];
     expect(result).toEqual(['proj2', 'proj3']);
   });
 });

--- a/packages/nx/src/project-graph/affected/locators/tsconfig-json-changes.spec.ts
+++ b/packages/nx/src/project-graph/affected/locators/tsconfig-json-changes.spec.ts
@@ -48,269 +48,308 @@ describe('getTouchedProjectsFromTsConfig', () => {
         jest.clearAllMocks();
       });
 
-      it(`should not return changes when ${tsConfig} is not touched`, () => {
-        const result = getTouchedProjectsFromTsConfig(
-          [
-            {
-              file: 'source.ts',
-              hash: 'some-hash',
-              getChanges: () => [new WholeFileChange()],
-            },
-          ],
-          {},
-          {
-            npmScope: 'proj',
-          }
-        );
+      it(`should not return changes when ${tsConfig} is not touched`, async () => {
+        const result = [
+          ...(
+            await getTouchedProjectsFromTsConfig(
+              [
+                {
+                  file: 'source.ts',
+                  hash: 'some-hash',
+                  getChanges: () => [new WholeFileChange()],
+                },
+              ],
+              {},
+              {
+                npmScope: 'proj',
+              }
+            )
+          ).keys(),
+        ];
         expect(result).toEqual([]);
       });
 
       describe('Whole File Changes', () => {
-        it('should return all projects for a whole file change', () => {
-          const result = getTouchedProjectsFromTsConfig(
-            [
-              {
-                file: tsConfig,
-                hash: 'some-hash',
-                getChanges: () => [new WholeFileChange()],
-              },
-            ],
-            null,
-            null,
-            null,
-            graph
-          );
+        it('should return all projects for a whole file change', async () => {
+          const result = [
+            ...(
+              await getTouchedProjectsFromTsConfig(
+                [
+                  {
+                    file: tsConfig,
+                    hash: 'some-hash',
+                    getChanges: () => [new WholeFileChange()],
+                  },
+                ],
+                null,
+                null,
+                null,
+                graph
+              )
+            ).keys(),
+          ];
           expect(result).toEqual(['proj1', 'proj2']);
         });
       });
 
       describe('Changes to other compiler options', () => {
-        it('should return all projects', () => {
-          const result = getTouchedProjectsFromTsConfig(
-            [
-              {
-                file: tsConfig,
-                hash: 'some-hash',
-                getChanges: () =>
-                  jsonDiff(
-                    {
-                      compilerOptions: {
-                        strict: false,
-                      },
-                    },
-                    {
-                      compilerOptions: {
-                        strict: true,
-                      },
-                    }
-                  ),
-              },
-            ],
-            null,
-            null,
-            null,
-            graph
-          );
+        it('should return all projects', async () => {
+          const result = [
+            ...(
+              await getTouchedProjectsFromTsConfig(
+                [
+                  {
+                    file: tsConfig,
+                    hash: 'some-hash',
+                    getChanges: () =>
+                      jsonDiff(
+                        {
+                          compilerOptions: {
+                            strict: false,
+                          },
+                        },
+                        {
+                          compilerOptions: {
+                            strict: true,
+                          },
+                        }
+                      ),
+                  },
+                ],
+                null,
+                null,
+                null,
+                graph
+              )
+            ).keys(),
+          ];
           expect(result).toEqual(['proj1', 'proj2']);
         });
       });
 
       describe('Adding new path mappings', () => {
-        it('should return projects pointed to by the path mappings', () => {
-          const result = getTouchedProjectsFromTsConfig(
-            [
-              {
-                file: tsConfig,
-                hash: 'some-hash',
-                getChanges: () =>
-                  jsonDiff(
-                    {
-                      compilerOptions: {
-                        paths: {},
-                      },
-                    },
-                    {
-                      compilerOptions: {
-                        paths: {
-                          '@proj/proj1': ['proj1/index.ts'],
+        it('should return projects pointed to by the path mappings', async () => {
+          const result = [
+            ...(
+              await getTouchedProjectsFromTsConfig(
+                [
+                  {
+                    file: tsConfig,
+                    hash: 'some-hash',
+                    getChanges: () =>
+                      jsonDiff(
+                        {
+                          compilerOptions: {
+                            paths: {},
+                          },
                         },
-                      },
-                    }
-                  ),
-              },
-            ],
-            null,
-            null,
-            null,
-            graph
-          );
+                        {
+                          compilerOptions: {
+                            paths: {
+                              '@proj/proj1': ['proj1/index.ts'],
+                            },
+                          },
+                        }
+                      ),
+                  },
+                ],
+                null,
+                null,
+                null,
+                graph
+              )
+            ).keys(),
+          ];
           expect(result).toEqual(['proj1']);
         });
 
-        it('should accept different types of paths', () => {
-          const result = getTouchedProjectsFromTsConfig(
-            [
-              {
-                file: tsConfig,
-                hash: 'some-hash',
-                getChanges: () =>
-                  jsonDiff(
-                    {
-                      compilerOptions: {
-                        paths: {},
-                      },
-                    },
-                    {
-                      compilerOptions: {
-                        paths: {
-                          '@proj/proj1': ['./proj1/index.ts'],
+        it('should accept different types of paths', async () => {
+          const result = [
+            ...(
+              await getTouchedProjectsFromTsConfig(
+                [
+                  {
+                    file: tsConfig,
+                    hash: 'some-hash',
+                    getChanges: () =>
+                      jsonDiff(
+                        {
+                          compilerOptions: {
+                            paths: {},
+                          },
                         },
-                      },
-                    }
-                  ),
-              },
-            ],
-            null,
-            null,
-            null,
-            graph
-          );
+                        {
+                          compilerOptions: {
+                            paths: {
+                              '@proj/proj1': ['./proj1/index.ts'],
+                            },
+                          },
+                        }
+                      ),
+                  },
+                ],
+                null,
+                null,
+                null,
+                graph
+              )
+            ).keys(),
+          ];
           expect(result).toEqual(['proj1']);
         });
       });
 
       describe('Removing path mappings', () => {
-        it('should affect all projects if a project is removed', () => {
-          const result = getTouchedProjectsFromTsConfig(
-            [
-              {
-                file: tsConfig,
-                hash: 'some-hash',
-                getChanges: () =>
-                  jsonDiff(
-                    {
-                      compilerOptions: {
-                        paths: {
-                          '@proj/proj1': ['proj1/index.ts'],
+        it('should affect all projects if a project is removed', async () => {
+          const result = [
+            ...(
+              await getTouchedProjectsFromTsConfig(
+                [
+                  {
+                    file: tsConfig,
+                    hash: 'some-hash',
+                    getChanges: () =>
+                      jsonDiff(
+                        {
+                          compilerOptions: {
+                            paths: {
+                              '@proj/proj1': ['proj1/index.ts'],
+                            },
+                          },
                         },
-                      },
-                    },
-                    {
-                      compilerOptions: {
-                        paths: {},
-                      },
-                    }
-                  ),
-              },
-            ],
-            null,
-            null,
-            null,
-            graph
-          );
+                        {
+                          compilerOptions: {
+                            paths: {},
+                          },
+                        }
+                      ),
+                  },
+                ],
+                null,
+                null,
+                null,
+                graph
+              )
+            ).keys(),
+          ];
           expect(result).toEqual(['proj1', 'proj2']);
         });
 
-        it('should affect all projects if a path mapping is removed', () => {
-          const result = getTouchedProjectsFromTsConfig(
-            [
-              {
-                file: tsConfig,
-                hash: 'some-hash',
-                getChanges: () =>
-                  jsonDiff(
-                    {
-                      compilerOptions: {
-                        paths: {
-                          '@proj/proj1': ['proj1/index.ts', 'proj1/index2.ts'],
+        it('should affect all projects if a path mapping is removed', async () => {
+          const result = [
+            ...(
+              await getTouchedProjectsFromTsConfig(
+                [
+                  {
+                    file: tsConfig,
+                    hash: 'some-hash',
+                    getChanges: () =>
+                      jsonDiff(
+                        {
+                          compilerOptions: {
+                            paths: {
+                              '@proj/proj1': [
+                                'proj1/index.ts',
+                                'proj1/index2.ts',
+                              ],
+                            },
+                          },
                         },
-                      },
-                    },
-                    {
-                      compilerOptions: {
-                        paths: {
-                          '@proj/proj1': ['proj1/index.ts'],
-                        },
-                      },
-                    }
-                  ),
-              },
-            ],
-            null,
-            null,
-            null,
-            graph
-          );
+                        {
+                          compilerOptions: {
+                            paths: {
+                              '@proj/proj1': ['proj1/index.ts'],
+                            },
+                          },
+                        }
+                      ),
+                  },
+                ],
+                null,
+                null,
+                null,
+                graph
+              )
+            ).keys(),
+          ];
           expect(result).toContainEqual('proj1');
           expect(result).toContainEqual('proj2');
         });
       });
 
       describe('Modifying Path Mappings', () => {
-        it('should return projects that have path mappings modified within them', () => {
-          const result = getTouchedProjectsFromTsConfig(
-            [
-              {
-                file: tsConfig,
-                hash: 'some-hash',
-                getChanges: () =>
-                  jsonDiff(
-                    {
-                      compilerOptions: {
-                        paths: {
-                          '@proj/proj1': ['proj1/index.ts'],
+        it('should return projects that have path mappings modified within them', async () => {
+          const result = [
+            ...(
+              await getTouchedProjectsFromTsConfig(
+                [
+                  {
+                    file: tsConfig,
+                    hash: 'some-hash',
+                    getChanges: () =>
+                      jsonDiff(
+                        {
+                          compilerOptions: {
+                            paths: {
+                              '@proj/proj1': ['proj1/index.ts'],
+                            },
+                          },
                         },
-                      },
-                    },
-                    {
-                      compilerOptions: {
-                        paths: {
-                          '@proj/proj1': ['proj1/index2.ts'],
-                        },
-                      },
-                    }
-                  ),
-              },
-            ],
-            null,
-            null,
-            null,
-            graph
-          );
+                        {
+                          compilerOptions: {
+                            paths: {
+                              '@proj/proj1': ['proj1/index2.ts'],
+                            },
+                          },
+                        }
+                      ),
+                  },
+                ],
+                null,
+                null,
+                null,
+                graph
+              )
+            ).keys(),
+          ];
           expect(result).toContainEqual('proj1');
           expect(result).not.toContainEqual('proj2');
         });
 
-        it('should return both projects that the mappings used to point to and point to now', () => {
-          const result = getTouchedProjectsFromTsConfig(
-            [
-              {
-                file: tsConfig,
-                hash: 'some-hash',
-                getChanges: () =>
-                  jsonDiff(
-                    {
-                      compilerOptions: {
-                        paths: {
-                          '@proj/proj1': ['proj1/index.ts'],
+        it('should return both projects that the mappings used to point to and point to now', async () => {
+          const result = [
+            ...(
+              await getTouchedProjectsFromTsConfig(
+                [
+                  {
+                    file: tsConfig,
+                    hash: 'some-hash',
+                    getChanges: () =>
+                      jsonDiff(
+                        {
+                          compilerOptions: {
+                            paths: {
+                              '@proj/proj1': ['proj1/index.ts'],
+                            },
+                          },
                         },
-                      },
-                    },
-                    {
-                      compilerOptions: {
-                        paths: {
-                          '@proj/proj1': ['proj2/index.ts'],
-                        },
-                      },
-                    }
-                  ),
-              },
-            ],
-            null,
-            null,
-            null,
-            graph
-          );
+                        {
+                          compilerOptions: {
+                            paths: {
+                              '@proj/proj1': ['proj2/index.ts'],
+                            },
+                          },
+                        }
+                      ),
+                  },
+                ],
+                null,
+                null,
+                null,
+                graph
+              )
+            ).keys(),
+          ];
           expect(result).toContainEqual('proj1');
           expect(result).toContainEqual('proj2');
         });

--- a/packages/nx/src/project-graph/affected/locators/workspace-json-changes.spec.ts
+++ b/packages/nx/src/project-graph/affected/locators/workspace-json-changes.spec.ts
@@ -3,8 +3,8 @@ import { WholeFileChange } from '../../file-utils';
 import { JsonDiffType } from '../../../utils/json-diff';
 
 describe('getTouchedProjectsInWorkspaceJson', () => {
-  it('should not return changes when angular.json is not touched', () => {
-    const result = getTouchedProjectsInWorkspaceJson(
+  it('should not return changes when angular.json is not touched', async () => {
+    const result = await getTouchedProjectsInWorkspaceJson(
       [
         {
           file: 'source.ts',
@@ -17,11 +17,11 @@ describe('getTouchedProjectsInWorkspaceJson', () => {
         npmScope: 'proj',
       }
     );
-    expect(result).toEqual([]);
+    expect([...result.keys()]).toEqual([]);
   });
 
-  it('should return all projects for a whole file change', () => {
-    const result = getTouchedProjectsInWorkspaceJson(
+  it('should return all projects for a whole file change', async () => {
+    const result = await getTouchedProjectsInWorkspaceJson(
       [
         {
           file: 'angular.json',
@@ -50,11 +50,11 @@ describe('getTouchedProjectsInWorkspaceJson', () => {
         },
       }
     );
-    expect(result).toEqual(['proj1', 'proj2']);
+    expect([...result.keys()]).toEqual(['proj1', 'proj2']);
   });
 
-  it('should return all projects for changes to newProjectRoot', () => {
-    const result = getTouchedProjectsInWorkspaceJson(
+  it('should return all projects for changes to newProjectRoot', async () => {
+    const result = await getTouchedProjectsInWorkspaceJson(
       [
         {
           file: 'angular.json',
@@ -92,11 +92,11 @@ describe('getTouchedProjectsInWorkspaceJson', () => {
         },
       }
     );
-    expect(result).toEqual(['proj1', 'proj2']);
+    expect([...result.keys()]).toEqual(['proj1', 'proj2']);
   });
 
-  it('should return projects added in angular.json', () => {
-    const result = getTouchedProjectsInWorkspaceJson(
+  it('should return projects added in angular.json', async () => {
+    const result = await getTouchedProjectsInWorkspaceJson(
       [
         {
           file: 'angular.json',
@@ -136,11 +136,11 @@ describe('getTouchedProjectsInWorkspaceJson', () => {
         },
       }
     );
-    expect(result).toEqual(['proj1']);
+    expect([...result.keys()]).toEqual(['proj1']);
   });
 
-  it('should affect all projects if a project is removed from angular.json', () => {
-    const result = getTouchedProjectsInWorkspaceJson(
+  it('should affect all projects if a project is removed from angular.json', async () => {
+    const result = await getTouchedProjectsInWorkspaceJson(
       [
         {
           file: 'angular.json',
@@ -180,11 +180,11 @@ describe('getTouchedProjectsInWorkspaceJson', () => {
         },
       }
     );
-    expect(result).toEqual(['proj1', 'proj2']);
+    expect([...result.keys()]).toEqual(['proj1', 'proj2']);
   });
 
-  it('should return projects modified in angular.json', () => {
-    const result = getTouchedProjectsInWorkspaceJson(
+  it('should return projects modified in angular.json', async () => {
+    const result = await getTouchedProjectsInWorkspaceJson(
       [
         {
           file: 'angular.json',
@@ -234,6 +234,6 @@ describe('getTouchedProjectsInWorkspaceJson', () => {
         },
       }
     );
-    expect(result).toEqual(['proj1']);
+    expect([...result.keys()]).toEqual(['proj1']);
   });
 });

--- a/packages/nx/src/project-graph/affected/locators/workspace-json-changes.ts
+++ b/packages/nx/src/project-graph/affected/locators/workspace-json-changes.ts
@@ -4,57 +4,73 @@ import {
   isJsonChange,
   JsonChange,
 } from '../../../utils/json-diff';
-import { TouchedProjectLocator } from '../affected-project-graph-models';
+import {
+  LocatorResult,
+  TouchedProjectLocator,
+} from '../affected-project-graph-models';
 
 export const getTouchedProjectsInWorkspaceJson: TouchedProjectLocator<
   WholeFileChange | JsonChange
-> = (touchedFiles, projectGraphNodes): string[] => {
+> = (touchedFiles, projectGraphNodes): LocatorResult => {
   const workspaceChange = touchedFiles.find(
     (change) => change.file === `angular.json`
   );
   if (!workspaceChange) {
-    return [];
+    return new Map();
   }
 
   const changes = workspaceChange.getChanges();
 
-  if (
-    changes.some((change) => {
-      if (isJsonChange(change)) {
-        return change.path[0] !== 'projects';
-      }
-      if (isWholeFileChange(change)) {
-        return true;
-      }
-      return false;
-    })
-  ) {
-    return Object.keys(projectGraphNodes);
-  }
+  const touched: LocatorResult = new Map();
 
-  const touched = [];
   for (let i = 0; i < changes.length; i++) {
     const change = changes[i];
-    if (!isJsonChange(change) || change.path[0] !== 'projects') {
-      continue;
+    if (isJsonChange(change)) {
+      if (change.path[0] !== 'projects') {
+        return new Map(
+          Object.keys(projectGraphNodes).map((p) => [
+            p,
+            [
+              'Non project related property in workspace.json changed: ' +
+                change.path[0],
+            ],
+          ])
+        );
+      }
+      if (change.path.length !== 2) {
+        continue;
+      }
+      switch (change.type) {
+        case JsonDiffType.Deleted: {
+          // We are not sure which projects used to depend on a deleted project
+          // so return all projects to be safe
+          return new Map(
+            Object.keys(projectGraphNodes).map((p) => [
+              p,
+              ['A project was deleted, which affects all projects'],
+            ])
+          );
+        }
+        default: {
+          // Add the project name
+          const projectName = change.path[1];
+          touched.set(projectName, [
+            `${projectName}'s configuration was changed`,
+          ]);
+        }
+      }
+    }
+    if (isWholeFileChange(change)) {
+      return new Map(
+        Object.keys(projectGraphNodes).map((p) => [
+          p,
+          ['Workspace.json changed - whole file marked changed'],
+        ])
+      );
     }
 
     // Only look for changes that are changes to the whole project definition
-    if (change.path.length !== 2) {
-      continue;
-    }
-
-    switch (change.type) {
-      case JsonDiffType.Deleted: {
-        // We are not sure which projects used to depend on a deleted project
-        // so return all projects to be safe
-        return Object.keys(projectGraphNodes);
-      }
-      default: {
-        // Add the project name
-        touched.push(change.path[1]);
-      }
-    }
   }
+
   return touched;
 };

--- a/packages/nx/src/project-graph/affected/locators/workspace-projects.spec.ts
+++ b/packages/nx/src/project-graph/affected/locators/workspace-projects.spec.ts
@@ -19,62 +19,72 @@ function getFileChanges(files: string[]) {
 }
 
 describe('getTouchedProjects', () => {
-  it('should return a list of projects for the given changes', () => {
+  it('should return a list of projects for the given changes', async () => {
     const fileChanges = getFileChanges(['libs/a/index.ts', 'libs/b/index.ts']);
     const projects = {
       a: { root: 'libs/a' },
       b: { root: 'libs/b' },
       c: { root: 'libs/c' },
     };
-    expect(
-      getTouchedProjects(fileChanges, buildProjectGraphNodes(projects))
-    ).toEqual(['a', 'b']);
+    expect([
+      ...(
+        await getTouchedProjects(fileChanges, buildProjectGraphNodes(projects))
+      ).keys(),
+    ]).toEqual(['a', 'b']);
   });
 
-  it('should return projects with the root matching a whole directory name in the file path', () => {
+  it('should return projects with the root matching a whole directory name in the file path', async () => {
     const fileChanges = getFileChanges(['libs/a-b/index.ts']);
     const projects = {
       a: { root: 'libs/a' },
       abc: { root: 'libs/a-b-c' },
       ab: { root: 'libs/a-b' },
     };
-    expect(
-      getTouchedProjects(fileChanges, buildProjectGraphNodes(projects))
-    ).toEqual(['ab']);
+    expect([
+      ...(
+        await getTouchedProjects(fileChanges, buildProjectGraphNodes(projects))
+      ).keys(),
+    ]).toEqual(['ab']);
   });
 
-  it('should return projects with the root matching a whole directory name in the file path', () => {
+  it('should return projects with the root matching a whole directory name in the file path', async () => {
     const fileChanges = getFileChanges(['libs/a-b/index.ts']);
     const projects = {
       aaaaa: { root: 'libs/a' },
       abc: { root: 'libs/a-b-c' },
       ab: { root: 'libs/a-b' },
     };
-    expect(
-      getTouchedProjects(fileChanges, buildProjectGraphNodes(projects))
-    ).toEqual(['ab']);
+    expect([
+      ...(
+        await getTouchedProjects(fileChanges, buildProjectGraphNodes(projects))
+      ).keys(),
+    ]).toEqual(['ab']);
   });
 
-  it('should return the most qualifying match with the file path', () => {
+  it('should return the most qualifying match with the file path', async () => {
     const fileChanges = getFileChanges(['libs/a/b/index.ts']);
     const projects = {
       aaaaa: { root: 'libs/a' },
       ab: { root: 'libs/a/b' },
     };
-    expect(
-      getTouchedProjects(fileChanges, buildProjectGraphNodes(projects))
-    ).toEqual(['ab']);
+    expect([
+      ...(
+        await getTouchedProjects(fileChanges, buildProjectGraphNodes(projects))
+      ).keys(),
+    ]).toEqual(['ab']);
   });
 
-  it('should not return parent project if nested project is touched', () => {
+  it('should not return parent project if nested project is touched', async () => {
     const fileChanges = getFileChanges(['libs/a/b/index.ts']);
     const projects = {
       a: { root: 'libs/a' },
       b: { root: 'libs/a/b' },
     };
-    expect(
-      getTouchedProjects(fileChanges, buildProjectGraphNodes(projects))
-    ).toEqual(['b']);
+    expect([
+      ...(
+        await getTouchedProjects(fileChanges, buildProjectGraphNodes(projects))
+      ).keys(),
+    ]).toEqual(['b']);
   });
 });
 
@@ -88,7 +98,7 @@ describe('getImplicitlyTouchedProjects', () => {
     };
   });
 
-  it('should return projects which have touched files in their named inputs', () => {
+  it('should return projects which have touched files in their named inputs', async () => {
     const graph = buildProjectGraphNodes({
       a: {
         root: 'a',
@@ -101,12 +111,14 @@ describe('getImplicitlyTouchedProjects', () => {
       },
     });
     let fileChanges = getFileChanges(['a.txt']);
-    expect(getImplicitlyTouchedProjects(fileChanges, graph, nxJson)).toEqual([
-      'a',
-    ]);
+    expect([
+      ...(
+        await getImplicitlyTouchedProjects(fileChanges, graph, nxJson)
+      ).keys(),
+    ]).toEqual(['a']);
   });
 
-  it('should return projects which have touched files in their target inputs', () => {
+  it('should return projects which have touched files in their target inputs', async () => {
     const graph = buildProjectGraphNodes({
       a: {
         root: 'a',
@@ -121,9 +133,11 @@ describe('getImplicitlyTouchedProjects', () => {
       },
     });
     let fileChanges = getFileChanges(['a.txt']);
-    expect(getImplicitlyTouchedProjects(fileChanges, graph, nxJson)).toEqual([
-      'a',
-    ]);
+    expect([
+      ...(
+        await getImplicitlyTouchedProjects(fileChanges, graph, nxJson)
+      ).keys(),
+    ]).toEqual(['a']);
   });
 });
 

--- a/packages/nx/src/utils/command-line-utils.ts
+++ b/packages/nx/src/utils/command-line-utils.ts
@@ -35,6 +35,7 @@ export interface NxArgs {
   nxBail?: boolean;
   nxIgnoreCycles?: boolean;
   type?: string;
+  why?: string;
 }
 
 export function splitArgsIntoNxArgsAndOverrides(


### PR DESCRIPTION
> **Warning**
> This PR is a draft, and honestly more of an experiment. - It may be closed without merging if we decide to go in a different direction.

## Current Behavior
There is no way to determine why Nx thinks a project has been affected

## Expected Behavior
Running `nx affected --target build --why` prints why each project is considered affected. Running with `--why {projectName}` will explain why a singular project is affected.

Example output:
<img width="939" alt="image" src="https://user-images.githubusercontent.com/6933928/230998692-8cc6a3ab-c9e9-407f-8e99-cea8be761b12.png">


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
