### PR TITLE
fix(core): deleted projects should not be in cached graph

### DIFF
--- a/packages/nx/src/project-graph/build-project-graph.ts
+++ b/packages/nx/src/project-graph/build-project-graph.ts
@@ -74,7 +74,7 @@ export async function buildProjectGraphUsingProjectFileMap(
 
   let filesToProcess;
   let cachedFileData;
-  if (
+  const useCacheData =
     cache &&
     !shouldRecomputeWholeGraph(
       cache,
@@ -82,8 +82,8 @@ export async function buildProjectGraphUsingProjectFileMap(
       projectsConfigurations,
       nxJson,
       rootTsConfig
-    )
-  ) {
+    );
+  if (useCacheData) {
     const fromCache = extractCachedFileData(projectFileMap, cache);
     filesToProcess = fromCache.filesToProcess;
     cachedFileData = fromCache.cachedFileData;
@@ -103,7 +103,7 @@ export async function buildProjectGraphUsingProjectFileMap(
     context,
     cachedFileData,
     projectGraphVersion,
-    cache
+    useCacheData ? cache : null
   );
   const projectGraphCache = createCache(
     nxJson,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
After refactoring JS into its own subfolder, projects that had been deleted are still present in the project graph and this causes some serious issues after deleting a project. (ref: https://github.com/nrwl/nx/pull/15365)

## Expected Behavior
Deleting a project causes the graph builder to recompute from scratch.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16091 
Fixes https://github.com/nrwl/nx-console/issues/1659
