### PR TITLE
fix(core): run-many doesn't strip quotes surrounding target names

### DIFF
--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -1093,7 +1093,10 @@ function parseCSV(args: string[] | string) {
   if (Array.isArray(args)) {
     return args;
   }
-  return args.split(',');
+  const items = args.split(',');
+  return items.map((i) =>
+    i.startsWith('"') && i.endsWith('"') ? i.slice(1, -1) : i
+  );
 }
 
 function linkToNxDevAndExamples(yargs: yargs.Argv, command: string) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
run-many doesn't strip quotes surrounding its targets, which can cause unexpected behavior

## Expected Behavior
run-many strips quotes

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16203
