### PR TITLE
fix(repo): cache nightly node_modules per run to avoid stale graph

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           lookup-only: true
           path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ matrix.node_version }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-modules-${{ matrix.node_version }}-${{ github.run_id }}
 
       - name: Install packages
         if: steps.cache-modules.outputs.cache-hit != 'true'
@@ -350,7 +350,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ matrix.node_version }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-modules-${{ matrix.node_version }}-${{ github.run_id }}
 
       - name: Install packages
         if: steps.cache-modules.outputs.cache-hit != 'true'

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -412,9 +412,7 @@ jobs:
 
       - name: Run e2e tests
         id: e2e-run
-        run: |
-          yarn nx run-many --target=e2e --projects="${{ join(matrix.project) }}" --parallel=1
-          yarn nx run-many --target=e2e-macos --projects="${{ join(matrix.project) }}" --parallel=1
+        run: yarn nx run-many -t e2e,e2e-macos -p ${{ matrix.project }}
         timeout-minutes: ${{ matrix.os_timeout }}
         env:
           GIT_AUTHOR_EMAIL: test@test.com

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: '**/node_modules'
-          key: windows-modules-${{ matrix.node_version }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-modules-${{ matrix.node_version }}-${{ github.run_id }}
 
       - name: Install packages
         if: steps.cache-modules.outputs.cache-hit != 'true'
@@ -268,7 +268,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ matrix.node_version }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-modules-${{ matrix.node_version }}-${{ github.run_id }}
 
       - name: Install packages
         if: steps.cache-modules.outputs.cache-hit != 'true'
@@ -280,7 +280,7 @@ jobs:
         with:
           path: '${{ github.workspace }}/.cypress'
           key: ${{ runner.os }}-cypress
-          
+
       - name: Install Cypress
         if: steps.cache-cypress.outputs.cache-hit != 'true'
         run: npx cypress install

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -292,7 +292,7 @@ jobs:
 
       - name: Run e2e tests
         id: e2e-run
-        run: yarn nx run-many --target=e2e --projects="${{ join(matrix.project) }}" --parallel=1
+        run: yarn nx run ${{ matrix.project }}:e2e
         timeout-minutes: 120
         env:
           GIT_AUTHOR_EMAIL: test@test.com


### PR DESCRIPTION
Nightly fails due to the removal of `@nrwl/cli` since we grab cached `node_modules` that contain stale graph with `cli` project still there.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
