### PR TITLE
feat(angular): remove deprecated simpleModuleName option from library generator

### DIFF
--- a/docs/generated/packages/angular/generators/library.json
+++ b/docs/generated/packages/angular/generators/library.json
@@ -45,12 +45,6 @@
         "default": false,
         "x-priority": "internal"
       },
-      "simpleModuleName": {
-        "description": "Keep the module name simple (when using `--directory`).",
-        "type": "boolean",
-        "default": false,
-        "x-deprecated": "Use `simpleName` instead. It will be removed in v16."
-      },
       "simpleName": {
         "description": "Don't include the directory in the name of the module or standalone component entry of the library.",
         "type": "boolean",

--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -164,6 +164,12 @@
       "version": "15.9.0-beta.9",
       "description": "Update the file-server executor to use @nrwl/web:file-server",
       "factory": "./src/migrations/update-15-9-0/update-file-server-executor"
+    },
+    "remove-library-generator-simple-module-name-option": {
+      "cli": "nx",
+      "version": "16.0.0-beta.1",
+      "description": "Replace the deprecated library generator 'simpleModuleName' option from generator defaults with 'simpleName'",
+      "factory": "./src/migrations/update-16-0-0/remove-library-generator-simple-module-name-option"
     }
   },
   "packageJsonUpdates": {

--- a/packages/angular/src/generators/library/lib/normalize-options.ts
+++ b/packages/angular/src/generators/library/lib/normalize-options.ts
@@ -47,8 +47,7 @@ export function normalizeOptions(host: Tree, schema: Schema): NormalizedSchema {
   const projectName = fullProjectDirectory
     .replace(new RegExp('/', 'g'), '-')
     .replace(/-\d+/g, '');
-  const fileName =
-    options.simpleName || options.simpleModuleName ? name : projectName;
+  const fileName = options.simpleName ? name : projectName;
   const projectRoot = joinPathFragments(libsDir, fullProjectDirectory);
 
   const moduleName = `${names(fileName).className}Module`;

--- a/packages/angular/src/generators/library/schema.d.ts
+++ b/packages/angular/src/generators/library/schema.d.ts
@@ -5,10 +5,6 @@ export interface Schema {
   name: string;
   addTailwind?: boolean;
   skipFormat?: boolean;
-  /**
-   * @deprecated Use `simpleName` instead. It will be removed in v16.
-   */
-  simpleModuleName?: boolean;
   simpleName?: boolean;
   addModuleSpec?: boolean;
   directory?: string;

--- a/packages/angular/src/generators/library/schema.json
+++ b/packages/angular/src/generators/library/schema.json
@@ -45,12 +45,6 @@
       "default": false,
       "x-priority": "internal"
     },
-    "simpleModuleName": {
-      "description": "Keep the module name simple (when using `--directory`).",
-      "type": "boolean",
-      "default": false,
-      "x-deprecated": "Use `simpleName` instead. It will be removed in v16."
-    },
     "simpleName": {
       "description": "Don't include the directory in the name of the module or standalone component entry of the library.",
       "type": "boolean",

--- a/packages/angular/src/migrations/update-16-0-0/remove-library-generator-simple-module-name-option.spec.ts
+++ b/packages/angular/src/migrations/update-16-0-0/remove-library-generator-simple-module-name-option.spec.ts
@@ -1,0 +1,277 @@
+import type { Tree } from '@nrwl/devkit';
+import {
+  addProjectConfiguration,
+  readNxJson,
+  readProjectConfiguration,
+  updateNxJson,
+} from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import removeLibraryGeneratorSimpleModuleNameOption from './remove-library-generator-simple-module-name-option';
+
+describe('removeLibraryGeneratorSimpleModuleNameOption', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('nx.json', () => {
+    it('should replace simpleModuleName with simpleName', async () => {
+      const nxJson = readNxJson(tree);
+      updateNxJson(tree, {
+        ...nxJson,
+        generators: {
+          '@nrwl/angular:library': {
+            simpleModuleName: true,
+          },
+        },
+      });
+
+      await removeLibraryGeneratorSimpleModuleNameOption(tree);
+
+      const updatedNxJson = readNxJson(tree);
+      expect(updatedNxJson.generators['@nrwl/angular:library']).toStrictEqual({
+        simpleName: true,
+      });
+    });
+
+    it('should support nested library generator default', async () => {
+      const nxJson = readNxJson(tree);
+      updateNxJson(tree, {
+        ...nxJson,
+        generators: {
+          '@nrwl/angular': {
+            library: {
+              simpleModuleName: true,
+            },
+          },
+        },
+      });
+
+      await removeLibraryGeneratorSimpleModuleNameOption(tree);
+
+      const updatedNxJson = readNxJson(tree);
+      expect(updatedNxJson.generators['@nrwl/angular']).toStrictEqual({
+        library: {
+          simpleName: true,
+        },
+      });
+    });
+
+    it('should keep simpleName if defined and remove simpleModuleName', async () => {
+      const nxJson = readNxJson(tree);
+      updateNxJson(tree, {
+        ...nxJson,
+        generators: {
+          '@nrwl/angular:library': {
+            simpleModuleName: true,
+            simpleName: false,
+          },
+        },
+      });
+
+      await removeLibraryGeneratorSimpleModuleNameOption(tree);
+
+      const updatedNxJson = readNxJson(tree);
+      expect(updatedNxJson.generators['@nrwl/angular:library']).toStrictEqual({
+        simpleName: false,
+      });
+    });
+
+    it('should do nothing if simpleModuleName is not set', async () => {
+      const nxJson = readNxJson(tree);
+      updateNxJson(tree, {
+        ...nxJson,
+        generators: {
+          '@nrwl/angular:library': {
+            simpleName: true,
+          },
+        },
+      });
+
+      await removeLibraryGeneratorSimpleModuleNameOption(tree);
+
+      const updatedNxJson = readNxJson(tree);
+      expect(updatedNxJson.generators['@nrwl/angular:library']).toStrictEqual({
+        simpleName: true,
+      });
+    });
+
+    it('should not throw when library generator defaults are not set', async () => {
+      const nxJson = readNxJson(tree);
+      updateNxJson(tree, {
+        ...nxJson,
+        generators: {
+          '@nrwl/angular:component': {
+            standalone: true,
+          },
+        },
+      });
+
+      await expect(
+        removeLibraryGeneratorSimpleModuleNameOption(tree)
+      ).resolves.not.toThrow();
+
+      const updatedNxJson = readNxJson(tree);
+      expect(updatedNxJson.generators).toStrictEqual({
+        '@nrwl/angular:component': {
+          standalone: true,
+        },
+      });
+    });
+
+    it('should not throw when generators defaults are not set', async () => {
+      const nxJson = readNxJson(tree);
+      updateNxJson(tree, { ...nxJson, generators: undefined });
+
+      await expect(
+        removeLibraryGeneratorSimpleModuleNameOption(tree)
+      ).resolves.not.toThrow();
+
+      const updatedNxJson = readNxJson(tree);
+      expect(updatedNxJson.generators).toBeUndefined();
+    });
+
+    it('should not throw when nx.json does not exist', async () => {
+      tree.delete('nx.json');
+
+      await expect(
+        removeLibraryGeneratorSimpleModuleNameOption(tree)
+      ).resolves.not.toThrow();
+
+      expect(tree.exists('nx.json')).toBe(false);
+    });
+  });
+
+  describe('project configs', () => {
+    it('should replace simpleModuleName with simpleName', async () => {
+      const project = {
+        name: 'project',
+        root: '/',
+        targets: {},
+        generators: {
+          '@nrwl/angular:library': {
+            simpleModuleName: true,
+          },
+        },
+      };
+      addProjectConfiguration(tree, 'project', project);
+
+      await removeLibraryGeneratorSimpleModuleNameOption(tree);
+
+      const updatedProject = readProjectConfiguration(tree, 'project');
+      expect(updatedProject.generators['@nrwl/angular:library']).toStrictEqual({
+        simpleName: true,
+      });
+    });
+
+    it('should support nested library generator default', async () => {
+      const project = {
+        name: 'project',
+        root: '/',
+        targets: {},
+        generators: {
+          '@nrwl/angular': {
+            library: {
+              simpleModuleName: true,
+            },
+          },
+        },
+      };
+      addProjectConfiguration(tree, 'project', project);
+
+      await removeLibraryGeneratorSimpleModuleNameOption(tree);
+
+      const updatedProject = readProjectConfiguration(tree, 'project');
+      expect(updatedProject.generators['@nrwl/angular']).toStrictEqual({
+        library: {
+          simpleName: true,
+        },
+      });
+    });
+
+    it('should keep simpleName if defined and remove simpleModuleName', async () => {
+      const project = {
+        name: 'project',
+        root: '/',
+        targets: {},
+        generators: {
+          '@nrwl/angular:library': {
+            simpleModuleName: true,
+            simpleName: false,
+          },
+        },
+      };
+      addProjectConfiguration(tree, 'project', project);
+
+      await removeLibraryGeneratorSimpleModuleNameOption(tree);
+
+      const updatedProject = readProjectConfiguration(tree, 'project');
+      expect(updatedProject.generators['@nrwl/angular:library']).toStrictEqual({
+        simpleName: false,
+      });
+    });
+
+    it('should do nothing if simpleModuleName is not set', async () => {
+      const project = {
+        name: 'project',
+        root: '/',
+        targets: {},
+        generators: {
+          '@nrwl/angular:library': {
+            simpleName: true,
+          },
+        },
+      };
+      addProjectConfiguration(tree, 'project', project);
+
+      await removeLibraryGeneratorSimpleModuleNameOption(tree);
+
+      const updatedProject = readProjectConfiguration(tree, 'project');
+      expect(updatedProject.generators['@nrwl/angular:library']).toStrictEqual({
+        simpleName: true,
+      });
+    });
+
+    it('should not throw when library generator defaults are not set', async () => {
+      const project = {
+        name: 'project',
+        root: '/',
+        targets: {},
+        generators: {
+          '@nrwl/angular:component': {
+            standalone: true,
+          },
+        },
+      };
+      addProjectConfiguration(tree, 'project', project);
+
+      await expect(
+        removeLibraryGeneratorSimpleModuleNameOption(tree)
+      ).resolves.not.toThrow();
+
+      const updatedProject = readProjectConfiguration(tree, 'project');
+      expect(updatedProject.generators).toStrictEqual({
+        '@nrwl/angular:component': {
+          standalone: true,
+        },
+      });
+    });
+
+    it('should not throw when generators defaults are not set', async () => {
+      const project = {
+        name: 'project',
+        root: '/',
+        targets: {},
+      };
+      addProjectConfiguration(tree, 'project', project);
+
+      await expect(
+        removeLibraryGeneratorSimpleModuleNameOption(tree)
+      ).resolves.not.toThrow();
+
+      const updatedProject = readProjectConfiguration(tree, 'project');
+      expect(updatedProject.generators).toBeUndefined();
+    });
+  });
+});

--- a/packages/angular/src/migrations/update-16-0-0/remove-library-generator-simple-module-name-option.ts
+++ b/packages/angular/src/migrations/update-16-0-0/remove-library-generator-simple-module-name-option.ts
@@ -1,0 +1,65 @@
+import type {
+  NxJsonConfiguration,
+  ProjectConfiguration,
+  Tree,
+} from '@nrwl/devkit';
+import {
+  formatFiles,
+  getProjects,
+  readNxJson,
+  updateNxJson,
+  updateProjectConfiguration,
+} from '@nrwl/devkit';
+
+export default async function removeLibraryGeneratorSimpleModuleNameOption(
+  tree: Tree
+): Promise<void> {
+  const nxJson = readNxJson(tree);
+
+  // update global config
+  const nxJsonUpdated = replaceSimpleModuleNameInConfig(nxJson);
+  if (nxJsonUpdated) {
+    updateNxJson(tree, nxJson);
+  }
+
+  // update project configs
+  const projects = getProjects(tree);
+  for (const [name, project] of projects) {
+    const projectUpdated = replaceSimpleModuleNameInConfig(project);
+    if (projectUpdated) {
+      updateProjectConfiguration(tree, name, project);
+    }
+  }
+
+  await formatFiles(tree);
+}
+
+function replaceSimpleModuleNameInConfig(
+  configObject: {
+    generators?:
+      | NxJsonConfiguration['generators']
+      | ProjectConfiguration['generators'];
+  } | null
+): boolean {
+  if (!configObject?.generators) {
+    return false;
+  }
+
+  let updated = false;
+
+  if (configObject.generators['@nrwl/angular']?.['library']?.simpleModuleName) {
+    configObject.generators['@nrwl/angular']['library'].simpleName ??=
+      configObject.generators['@nrwl/angular']['library'].simpleModuleName;
+    delete configObject.generators['@nrwl/angular']['library'].simpleModuleName;
+    updated = true;
+  } else if (
+    configObject.generators['@nrwl/angular:library']?.simpleModuleName
+  ) {
+    configObject.generators['@nrwl/angular:library'].simpleName ??=
+      configObject.generators['@nrwl/angular:library'].simpleModuleName;
+    delete configObject.generators['@nrwl/angular:library'].simpleModuleName;
+    updated = true;
+  }
+
+  return updated;
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The deprecated `simpleModuleName` option from the `@nrwl/angular:library` is deprecated and scheduled to be removed in Nx v16.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The deprecated `simpleModuleName` option from the `@nrwl/angular:library` is removed.

## Breaking Changes

The deprecated `simpleModuleName` option from the `@nrwl/angular:library` generator has been removed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
