### PR TITLE
fix(repo): add CODEOWNERS to prettier ignore list

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -32,3 +32,4 @@ graph/client/src/assets/generated-task-graphs
 /.verdaccio/build/local-registry
 /dist
 /.env
+CODEOWNERS


### PR DESCRIPTION
Ensure `prettier` does not pick up `CODEOWNERS` file accidentally

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
