### PR TITLE
docs(angular): update guide on environment variables usage

### DIFF
--- a/docs/shared/guides/use-environment-variables-in-angular.md
+++ b/docs/shared/guides/use-environment-variables-in-angular.md
@@ -1,10 +1,31 @@
 # Using environment variables in Angular applications
 
-By default, Angular only provides the `NODE_ENV` variable when building the application. You may use `process.env.NODE_ENV`
-anywhere in your TS/JS source, and the build will inline this value in the output chunks.
+Angular builders (e.g. `@nrwl/angular:webpack-browser` and `@angular-devkit/build-angular:browser`) don't have built-in support for using environment variables when building applications.
 
-Other variables, such as those prefixed by `NX_` will not work in Angular. To add support for other environment variables,
-do the following.
+To add support for environment variables we need to use the webpack `DefinePlugin` in our own custom webpack configuration. We'll see how to do so in the following sections.
+
+## A note on `NODE_ENV`
+
+The webpack-based Angular builders (e.g. `@nrwl/angular:webpack-browser` and `@angular-devkit/build-angular:browser`) set the webpack's `mode` configuration option based on the values for the following in the builder options:
+
+- `optimization`
+- `optimization.scripts`
+- `optimization.styles`
+- `optimization.styles.minify`
+
+If any of the above is set to `true`, webpack's `mode` is set to `production`. Otherwise, it's set to `development`.
+
+By default, webpack automatically sets the `NODE_ENV` variable to the value of the `mode` configuration option. Therefore, Angular applications code have access to that environment variable at build time, but we can't change the `NODE_ENV` variable value directly as we would do with other environment variables because Angular always set the `mode` configuration option based on the above.
+
+To change the `NODE_ENV` variable we can do one of the following:
+
+- Turn on the builder optimizations to set it to `production`
+- Turn off the builder optimizations to set it to `development`
+- Use a custom webpack configuration to override the webpack `mode` set by Angular builders
+
+The first two options is a matter of changing your build target configuration or passing the specific flag in the command line. We'll see how to do the last in the following section.
+
+## Use a custom webpack configuration to support environment variables
 
 First, install `@types/node` so we can use `process.env` in our code.
 
@@ -44,22 +65,17 @@ Then, we can use `DefinePlugin` in our custom webpack.
 ```javascript {% fileName="apps/myapp/webpack.config.js" %}
 const webpack = require('webpack');
 
-function getClientEnvironment(configuration) {
-  // Grab NODE_ENV and NX_* environment variables and prepare them to be
-  // injected into the application via DefinePlugin in webpack configuration.
+function getClientEnvironment() {
+  // Grab NX_* environment variables and prepare them to be injected
+  // into the application via DefinePlugin in webpack configuration.
   const NX_APP = /^NX_/i;
 
   const raw = Object.keys(process.env)
     .filter((key) => NX_APP.test(key))
-    .reduce(
-      (env, key) => {
-        env[key] = process.env[key];
-        return env;
-      },
-      {
-        NODE_ENV: process.env.NODE_ENV || configuration,
-      }
-    );
+    .reduce((env, key) => {
+      env[key] = process.env[key];
+      return env;
+    }, {});
 
   // Stringify all values so we can feed into webpack DefinePlugin
   return {
@@ -71,9 +87,9 @@ function getClientEnvironment(configuration) {
 }
 
 module.exports = (config, options, context) => {
-  config.plugins.push(
-    new webpack.DefinePlugin(getClientEnvironment(context.configuration))
-  );
+  // Overwrite the mode set by Angular if the NODE_ENV is set
+  config.mode = process.env.NODE_ENV || config.mode;
+  config.plugins.push(new webpack.DefinePlugin(getClientEnvironment()));
   return config;
 };
 ```


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The guide on using environment variables in Angular doesn't provide much info about the `NODE_ENV` variable which is a special because of how Angular builders set it.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The guide on using environment variables in Angular addresses the `NODE_ENV` variable special case and suggests a setup that's more appropriate to handle it.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16194 
