### PR TITLE
fix(core): correctly pass resolved compilerOptions to ts-node

### DIFF
--- a/packages/nx/src/utils/register.spec.ts
+++ b/packages/nx/src/utils/register.spec.ts
@@ -1,4 +1,4 @@
-import { ModuleKind, ScriptTarget } from 'typescript';
+import { JsxEmit, ModuleKind, ScriptTarget } from 'typescript';
 import { getTsNodeCompilerOptions } from './register';
 
 describe('getTsNodeCompilerOptions', () => {
@@ -16,5 +16,21 @@ describe('getTsNodeCompilerOptions', () => {
         target: ScriptTarget.ES2020,
       }).target
     ).toEqual('ES2020');
+  });
+
+  it('should remove jsx option', () => {
+    expect(
+      getTsNodeCompilerOptions({
+        jsx: JsxEmit.ReactJSX,
+      }).jsx
+    ).toBeUndefined();
+  });
+
+  it('should use correct lib value', () => {
+    expect(
+      getTsNodeCompilerOptions({
+        lib: ['lib.es2022.d.ts'],
+      }).lib
+    ).toEqual(['es2022']);
   });
 });

--- a/packages/nx/src/utils/register.ts
+++ b/packages/nx/src/utils/register.ts
@@ -130,7 +130,7 @@ function readCompilerOptionsWithTypescript(tsConfigPath) {
   const { readConfigFile, parseJsonConfigFileContent, sys } = ts;
   const jsonContent = readConfigFile(tsConfigPath, sys.readFile);
   const { options } = parseJsonConfigFileContent(
-    jsonContent,
+    jsonContent.config,
     sys,
     dirname(tsConfigPath)
   );
@@ -203,6 +203,15 @@ export function getTsNodeCompilerOptions(compilerOptions: CompilerOptions) {
 
   delete result.pathsBasePath;
   delete result.configFilePath;
+
+  // instead of mapping to enum value we just remove it as it shouldn't ever need to be set for ts-node
+  delete result.jsx;
+
+  // lib option is in the format `lib.es2022.d.ts`, so we need to remove the leading `lib.` and trailing `.d.ts` to make it valid
+  result.lib = result.lib?.map((value) => {
+    return value.replace(/^lib\./, '').replace(/\.d\.ts$/, '');
+  });
+
   if (result.moduleResolution) {
     result.moduleResolution =
       result.moduleResolution === 'NodeJs'


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Linting using custom workspace rules in webstorm is broken:
<img width="1061" alt="CleanShot 2023-04-11 at 17 03 37@2x" src="https://user-images.githubusercontent.com/6425649/231313999-915937c8-0be9-46a0-88c8-da588c08bbf9.png">

The regression was introduced in this commit which removed the hard coding of `module: commonjs` in favor of using the config from `tsconfig.json`:
https://github.com/nrwl/nx/commit/b2df83107639d78aa1c1524f887ae45abda7c3a8#diff-2851f63978cee5996bae7a52b7ce339437421238099e62883d06fd64f3672bd6L46-L48

However due to the type of the config passed to `parseJsonConfigFileContent` being `any` a regression was introduced which passed an empty object as the compiler options instead of the actual compiler options.

When testing the fix on our application we ran into further issues due to the `jsx` + `lib` options being set in the custom workspace rules `tsconfig` so I added a fix for that as well.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Linting using custom workspace rules in webstorm works

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

N/A
