### PR TITLE
docs(angular): replace ng add usage with nx init --integrated for integrated migration

### DIFF
--- a/docs/generated/packages/angular/generators/ng-add.json
+++ b/docs/generated/packages/angular/generators/ng-add.json
@@ -69,7 +69,7 @@
       }
     },
     "additionalProperties": false,
-    "examplesFile": "## Information\n\nThis generator is usually used as part of the process of migrating from an Angular CLI Workspace to Nx Workspaces using `ng add @nx/angular`.\n\nYou can read more about [migrating from Angular CLI to Nx here](https://nx.dev/recipes/adopting-nx/migration-angular).\n",
+    "examplesFile": "## Information\n\nThis generator is usually used as part of the process of migrating from an Angular CLI Workspace to an [Nx Integrated Workspace](/concepts/integrated-vs-package-based#integrated-repos) using `npx nx@latest init --integrated`.\n\nYou can read more about [migrating from Angular CLI to Nx here](/recipes/adopting-nx-angular).\n",
     "presets": []
   },
   "description": "Migrates an Angular CLI workspace to Nx or adds the Angular plugin to an Nx workspace.",

--- a/docs/shared/migration/angular-integrated.md
+++ b/docs/shared/migration/angular-integrated.md
@@ -1,14 +1,14 @@
 # Migrating an Angular CLI workspace to an Integrated Nx Monorepo
 
-To take advantage of Nx's monorepo features provided by Nx and the Nx Angular plugin, you can also perform a migration from an Angular CLI to an Integrated Nx Monorepo with the command:
+If you want to migrate your Angular CLI project to an [Integrated Nx Monorepo](/concepts/integrated-vs-package-based#integrated-repos), run the following command:
 
 ```shell
-ng add @nx/angular@<version_number>
+npx nx@latest init --integrated
 ```
 
-This installs the `@nx/angular` (or `@nx/workspace`) package into your workspace and runs a generator (or schematic) to transform your workspace. The generator applies the following changes to your workspace:
+The command applies the following changes to your workspace:
 
-- Installs the `nx` and `@nx/workspace` packages.
+- Installs the `nx`, `@nx/angular` and `@nx/workspace` packages.
 - Moves your applications into the `apps` folder, and updates the relevant file paths in your configuration files.
 - Moves your e2e suites into the `apps/<app name>-e2e` folder, and updates the relevant file paths in your configuration files.
 - Moves your libraries into the `libs` folder, and updates the relevant file paths in your configuration files.
@@ -63,14 +63,6 @@ Your workspace is now powered by Nx! You can verify that your application still 
 > Your project graph will grow as you add and use more applications and libraries. You can add the `--watch` flag to `nx graph` to see the changes in-browser as you add them.
 
 ## Older Versions of Angular
-
-To migrate to legacy versions of Nx prior to Nx 13.10, run the command:
-
-```shell
-ng add @nx/workspace@<version_number>
-```
-
-Refer to the [Nx and Angular Version Compatibility Matrix](/packages/angular/documents/angular-nx-version-matrix) for matching Angular and Nx versions.
 
 Support for workspaces with multiple applications and libraries was added in Nx v14.1.0. If you are migrating using an older version of Nx, your workspace can only contain one application and no libraries in order to use the automated migration, otherwise, you can still [migrate manually](/recipes/adopting-nx-angular/angular-manual).
 

--- a/docs/shared/migration/angular-manual.md
+++ b/docs/shared/migration/angular-manual.md
@@ -4,7 +4,7 @@
 If you are using older versions of Angular (version 13 or lower), make sure to use the appropriate version of Nx that matches your version of Angular. See the [Nx and Angular Version Compatibility Matrix](/packages/angular/documents/angular-nx-version-matrix) to find the correct version. The generated files will also be slightly different.
 {% /callout %}
 
-If you are unable to automatically transform your Angular CLI workspace to an Nx workspace using the [ng add](#transforming-an-angular-cli-workspace-to-an-nx-workspace) method, there are some manual steps you can take to move your project(s) into an Nx workspace.
+If you are unable to automatically transform your Angular CLI workspace to an [Nx Integrated workspace](/recipes/adopting-nx-angular/angular-integrated), there are some manual steps you can take to move your project(s) into an Nx workspace.
 
 ### Generating a new workspace
 

--- a/packages/angular/docs/ng-add-examples.md
+++ b/packages/angular/docs/ng-add-examples.md
@@ -1,5 +1,5 @@
 ## Information
 
-This generator is usually used as part of the process of migrating from an Angular CLI Workspace to Nx Workspaces using `ng add @nx/angular`.
+This generator is usually used as part of the process of migrating from an Angular CLI Workspace to an [Nx Integrated Workspace](/concepts/integrated-vs-package-based#integrated-repos) using `npx nx@latest init --integrated`.
 
-You can read more about [migrating from Angular CLI to Nx here](https://nx.dev/recipes/adopting-nx/migration-angular).
+You can read more about [migrating from Angular CLI to Nx here](/recipes/adopting-nx-angular).


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The migration from an Angular CLI workspace to an Nx Integrated workspace docs page suggests using `ng add @nrwl/angular`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The migration from an Angular CLI workspace to an Nx Integrated workspace docs page should suggest using `npx nx@latest --integrated`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
