### PR TITLE
chore(misc): add a --quiet flag when running "npx nx" to avoid extra info from being logged

### DIFF
--- a/e2e/utils/command-utils.ts
+++ b/e2e/utils/command-utils.ts
@@ -128,7 +128,7 @@ export function getPackageManagerCommand({
       } create-nx-workspace@${publishedVersion}`,
       run: (script: string, args: string) => `npm run ${script} -- ${args}`,
       runNx: `npx nx`,
-      runNxSilent: `npx nx`,
+      runNxSilent: `npx --quiet nx`,
       runUninstalledPackage: `npx --yes`,
       install: 'npm install',
       ciInstall: 'npm ci',


### PR DESCRIPTION
This PR adds a `--quiet` flag when running `npx` during e2e tests. It might help resolve the failures in one of the core tests: https://github.com/nrwl/nx/actions/runs/4673097868/jobs/8276174991.

Waiting for the new run to finish to see the results: https://github.com/nrwl/nx/actions/runs/4679129040.