### PR TITLE
fix(testing): use jest v29 deps in @nrwl/jest

### DIFF
--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -34,17 +34,17 @@
     "migrations": "./migrations.json"
   },
   "dependencies": {
-    "@jest/reporters": "28.1.1",
-    "@jest/test-result": "28.1.1",
+    "@jest/reporters": "^29.4.1",
+    "@jest/test-result": "^29.4.1",
     "@nrwl/devkit": "file:../devkit",
     "@nrwl/js": "file:../js",
     "@phenomnomnominal/tsquery": "~5.0.1",
     "chalk": "^4.1.0",
     "dotenv": "~10.0.0",
     "identity-obj-proxy": "3.0.0",
-    "jest-config": "28.1.1",
-    "jest-resolve": "28.1.1",
-    "jest-util": "28.1.1",
+    "jest-config": "^29.4.1",
+    "jest-resolve": "^29.4.1",
+    "jest-util": "^29.4.1",
     "resolve.exports": "1.1.0",
     "tslib": "^2.3.0"
   },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
jest lists v28 of deps in package.json

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
jest uses v29 of deps in package.json

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16209
