### PR TITLE
feat(core): add hasher implementation info in `nx report`

### DIFF
--- a/packages/nx/src/command-line/report.ts
+++ b/packages/nx/src/command-line/report.ts
@@ -20,6 +20,10 @@ import {
 import { gt, valid } from 'semver';
 import { findInstalledPlugins } from '../utils/plugins/installed-plugins';
 import { getNxRequirePaths } from '../utils/installation-directory';
+import {
+  getHashingImplementation,
+  HasherImplementation,
+} from '../utils/get-hashing-implementation';
 
 const nxPackageJson = readJsonFile<typeof import('../../package.json')>(
   join(__dirname, '../../package.json')
@@ -59,12 +63,14 @@ export async function reportHandler() {
     packageVersionsWeCareAbout,
     outOfSyncPackageGroup,
     projectGraphError,
+    currentHasherImplementation,
   } = await getReportData();
 
   const bodyLines = [
-    `Node : ${process.versions.node}`,
-    `OS   : ${process.platform} ${process.arch}`,
-    `${pm.padEnd(5)}: ${pmVersion}`,
+    `Node   : ${process.versions.node}`,
+    `OS     : ${process.platform} ${process.arch}`,
+    `${pm.padEnd(7)}: ${pmVersion}`,
+    `hasher : ${currentHasherImplementation}`,
     ``,
   ];
 
@@ -142,6 +148,7 @@ export interface ReportData {
     migrateTarget: string;
   };
   projectGraphError?: Error | null;
+  currentHasherImplementation: HasherImplementation;
 }
 
 export async function getReportData(): Promise<ReportData> {
@@ -172,6 +179,8 @@ export async function getReportData(): Promise<ReportData> {
 
   const outOfSyncPackageGroup = findMisalignedPackagesForPackage(nxPackageJson);
 
+  const currentHasherImplementation = getHashingImplementation();
+
   return {
     pm,
     pmVersion,
@@ -180,6 +189,7 @@ export async function getReportData(): Promise<ReportData> {
     packageVersionsWeCareAbout,
     outOfSyncPackageGroup,
     projectGraphError,
+    currentHasherImplementation,
   };
 }
 

--- a/packages/nx/src/command-line/report.ts
+++ b/packages/nx/src/command-line/report.ts
@@ -70,7 +70,7 @@ export async function reportHandler() {
     `Node   : ${process.versions.node}`,
     `OS     : ${process.platform} ${process.arch}`,
     `${pm.padEnd(7)}: ${pmVersion}`,
-    `hasher : ${currentHasherImplementation}`,
+    `Hasher : ${currentHasherImplementation}`,
     ``,
   ];
 

--- a/packages/nx/src/hasher/file-hasher.ts
+++ b/packages/nx/src/hasher/file-hasher.ts
@@ -1,35 +1,20 @@
 import { GitBasedFileHasher } from './git-based-file-hasher';
-import { workspaceRoot } from '../utils/workspace-root';
 import { NodeBasedFileHasher } from './node-based-file-hasher';
 import { FileHasherBase } from './file-hasher-base';
-import { execSync } from 'child_process';
-import { existsSync } from 'fs';
-import { join } from 'path';
 import { NativeFileHasher } from './native-file-hasher';
+import {
+  HasherImplementation,
+  getHashingImplementation,
+} from '../utils/get-hashing-implementation';
 
 function createFileHasher(): FileHasherBase {
-  try {
-    if (
-      (!process.env.NX_NON_NATIVE_HASHER ||
-        process.env.NX_NON_NATIVE_HASHER != 'true') &&
-      NativeFileHasher.available()
-    ) {
+  switch (getHashingImplementation()) {
+    case HasherImplementation.Native:
       return new NativeFileHasher();
-    }
-
-    execSync('git rev-parse --is-inside-work-tree', {
-      stdio: 'ignore',
-      windowsHide: true,
-    });
-
-    // we don't use git based hasher when the repo uses git submodules
-    if (!existsSync(join(workspaceRoot, '.git', 'modules'))) {
+    case HasherImplementation.Git:
       return new GitBasedFileHasher();
-    } else {
+    case HasherImplementation.Node:
       return new NodeBasedFileHasher();
-    }
-  } catch {
-    return new NodeBasedFileHasher();
   }
 }
 

--- a/packages/nx/src/utils/get-hashing-implementation.ts
+++ b/packages/nx/src/utils/get-hashing-implementation.ts
@@ -1,0 +1,38 @@
+import { NativeFileHasher } from '../hasher/native-file-hasher';
+import { workspaceRoot } from './workspace-root';
+
+import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+export enum HasherImplementation {
+  Native = 'Native',
+  Git = 'Git',
+  Node = 'Node',
+}
+
+export function getHashingImplementation() {
+  try {
+    if (
+      (!process.env.NX_NON_NATIVE_HASHER ||
+        process.env.NX_NON_NATIVE_HASHER != 'true') &&
+      NativeFileHasher.available()
+    ) {
+      return HasherImplementation.Native;
+    }
+
+    execSync('git rev-parse --is-inside-work-tree', {
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+
+    // we don't use git based hasher when the repo uses git submodules
+    if (!existsSync(join(workspaceRoot, '.git', 'modules'))) {
+      return HasherImplementation.Git;
+    } else {
+      return HasherImplementation.Node;
+    }
+  } catch {
+    return HasherImplementation.Node;
+  }
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
There is no way of knowing if the workspace is using the native, git or node hasher. 

## Expected Behavior
Running `nx report` will now have information about the hasher implementation:
```
$ nx report

 >  NX   Report complete - copy this into the issue template

   Node   : 18.15.0
   OS     : darwin arm64
   yarn   : 1.22.19
   Hasher : Native
   
   nx                      : 0.0.1
   lerna                   : 6.0.0
   ....
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
