### PR TITLE
fix(storybook): add correct v7 packages when generating storybook configuration

### DIFF
--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -53,7 +53,7 @@ export async function configurationGenerator(
    */
 
   let storybook7 =
-    storybookMajorVersion() === 7 ?? rawSchema.storybook7Configuration;
+    storybookMajorVersion() === 7 || rawSchema.storybook7Configuration;
 
   if (storybookMajorVersion() === 6 && rawSchema.storybook7Configuration) {
     logger.error(


### PR DESCRIPTION
This PR fixes a logic issue where v6 packages were being installed even though v7 was specified.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
