### PR TITLE
fix(documentation): generated package.json does not currently match the documentation. 

### DIFF
--- a/docs/shared/core-tutorial/01-create-blog.md
+++ b/docs/shared/core-tutorial/01-create-blog.md
@@ -48,6 +48,13 @@ The `package.json` file contains this property:
 
 ```json
   "workspaces": [
+    "packages/*"
+  ]
+```
+
+You need to amend it to the following:
+```json
+  "workspaces": [
     "packages/**"
   ]
 ```


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->


## Current Behavior
Whilst running through the example, I experienced the error:
```
 >  NX   Cannot find project 'blog'
```

This was because the generated project only had a single * in packages.workspace. This small amendment got me working again.

## Expected Behavior
The documentation matches the CLI output.

