### PR TITLE
cleanup(misc): consolidate common functionality and messaging across nx init flows

### DIFF
--- a/e2e/nx-init/src/nx-init-angular.test.ts
+++ b/e2e/nx-init/src/nx-init-angular.test.ts
@@ -33,7 +33,7 @@ describe('nx init (Angular CLI)', () => {
       `${pmc.runUninstalledPackage} nx@${getPublishedVersion()} init -y`
     );
 
-    expect(output).toContain('Nx is now enabled in your workspace!');
+    expect(output).toContain('🎉 Done!');
     // angular.json should have been deleted
     checkFilesDoNotExist('angular.json');
     // check nx config files exist
@@ -67,7 +67,7 @@ describe('nx init (Angular CLI)', () => {
       } nx@${getPublishedVersion()} init -y --integrated`
     );
 
-    expect(output).toContain('Nx is now enabled in your workspace!');
+    expect(output).toContain('🎉 Done!');
     // angular.json should have been deleted
     checkFilesDoNotExist('angular.json');
     // check nx config files exist

--- a/packages/nx/src/nx-init/add-nx-to-monorepo.ts
+++ b/packages/nx/src/nx-init/add-nx-to-monorepo.ts
@@ -1,17 +1,17 @@
 import { prompt } from 'enquirer';
-import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
+import { readdirSync, readFileSync, statSync } from 'fs';
 import ignore from 'ignore';
 import { join, relative } from 'path';
 import * as yargsParser from 'yargs-parser';
 import { readJsonFile } from '../utils/fileutils';
 import { output } from '../utils/output';
 import { getPackageManagerCommand } from '../utils/package-manager';
-import { joinPathFragments } from '../utils/path';
 import {
   addDepsToPackageJson,
   askAboutNxCloud,
   createNxJsonFile,
   initCloud,
+  printFinalMessage,
   runInstall,
 } from './utils';
 
@@ -26,14 +26,7 @@ const parsedArgs = yargsParser(process.argv, {
 export async function addNxToMonorepo() {
   const repoRoot = process.cwd();
 
-  if (!existsSync(joinPathFragments(repoRoot, 'package.json'))) {
-    output.error({
-      title: `Run the command in the folder with a package.json file.`,
-    });
-    process.exit(1);
-  }
-
-  output.log({ title: `🐳 Nx initialization` });
+  output.log({ title: '🐳 Nx initialization' });
 
   const packageJsonFiles = allProjectPackageJsonFiles(repoRoot);
   const scripts = combineAllScriptNames(repoRoot, packageJsonFiles);
@@ -41,11 +34,12 @@ export async function addNxToMonorepo() {
   let targetDefaults: string[];
   let cacheableOperations: string[];
   let scriptOutputs = {} as { [script: string]: string };
-  let useCloud: boolean;
+  let useNxCloud: boolean;
 
   if (parsedArgs.yes !== true && scripts.length > 0) {
     output.log({
-      title: `🧑‍🔧 Please answer the following questions about the scripts found in your workspace in order to generate task runner configuration`,
+      title:
+        '🧑‍🔧 Please answer the following questions about the scripts found in your workspace in order to generate task runner configuration',
     });
 
     targetDefaults = (
@@ -53,7 +47,8 @@ export async function addNxToMonorepo() {
         {
           type: 'multiselect',
           name: 'targetDefaults',
-          message: `Which scripts need to be run in order?  (e.g. before building a project, dependent projects must be built.)`,
+          message:
+            'Which scripts need to be run in order? (e.g. before building a project, dependent projects must be built)',
           choices: scripts,
         },
       ])) as any
@@ -83,13 +78,13 @@ export async function addNxToMonorepo() {
       )[scriptName];
     }
 
-    useCloud = await askAboutNxCloud();
+    useNxCloud = await askAboutNxCloud();
   } else {
     targetDefaults = [];
     cacheableOperations = parsedArgs.cacheable
       ? parsedArgs.cacheable.split(',')
       : [];
-    useCloud = false;
+    useNxCloud = false;
   }
 
   createNxJsonFile(
@@ -99,16 +94,25 @@ export async function addNxToMonorepo() {
     scriptOutputs
   );
 
-  addDepsToPackageJson(repoRoot, useCloud);
+  addDepsToPackageJson(repoRoot, useNxCloud);
 
-  output.log({ title: `📦 Installing dependencies` });
+  output.log({ title: '📦 Installing dependencies' });
   runInstall(repoRoot);
 
-  if (useCloud) {
+  if (useNxCloud) {
+    output.log({ title: '🛠️ Setting up Nx Cloud' });
     initCloud(repoRoot, 'nx-init-monorepo');
   }
 
-  printFinalMessage();
+  const pmc = getPackageManagerCommand();
+  printFinalMessage({
+    learnMoreLink: 'https://nx.dev/recipes/adopting-nx/adding-to-monorepo',
+    bodyLines: [
+      `- Run "${pmc.exec} nx run-many --target=build" to run the build script for every project in the monorepo.`,
+      '- Run it again to replay the cached computation.',
+      `- Run "${pmc.exec} nx graph" to see the structure of the monorepo.`,
+    ],
+  });
 }
 
 // scanning package.json files
@@ -168,18 +172,4 @@ function combineAllScriptNames(
     );
   });
   return [...res];
-}
-
-function printFinalMessage() {
-  const pmc = getPackageManagerCommand();
-  output.success({
-    title: `🎉 Done!`,
-    bodyLines: [
-      `- Enabled computation caching!`,
-      `- Run "${pmc.exec} nx run-many --target=build" to run the build script for every project in the monorepo.`,
-      `- Run it again to replay the cached computation.`,
-      `- Run "${pmc.exec} nx graph" to see the structure of the monorepo.`,
-      `- Learn more at https://nx.dev/recipes/adopting-nx/adding-to-monorepo`,
-    ],
-  });
 }

--- a/packages/nx/src/nx-init/angular/index.ts
+++ b/packages/nx/src/nx-init/angular/index.ts
@@ -8,6 +8,7 @@ import {
   addDepsToPackageJson,
   askAboutNxCloud,
   initCloud,
+  printFinalMessage,
   runInstall,
 } from '../utils';
 import { setupIntegratedWorkspace } from './integrated-workspace';
@@ -70,11 +71,10 @@ export async function addNxToAngularCliRepo(integrated: boolean) {
     initCloud(repoRoot, 'nx-init-angular');
   }
 
-  output.success({
-    title: '🎉 Nx is now enabled in your workspace!',
+  printFinalMessage({
+    learnMoreLink: 'https://nx.dev/recipes/adopting-nx/migration-angular',
     bodyLines: [
-      `Execute 'npx nx build' twice to see the computation caching in action.`,
-      'Learn more about the changes done to your workspace at https://nx.dev/recipes/adopting-nx/migration-angular.',
+      '- Execute "npx nx build" twice to see the computation caching in action.',
     ],
   });
 }
@@ -89,7 +89,8 @@ async function collectCacheableOperations(): Promise<string[]> {
 
   if (parsedArgs.yes !== true) {
     output.log({
-      title: `🧑‍🔧 Please answer the following questions about the targets found in your angular.json in order to generate task runner configuration`,
+      title:
+        '🧑‍🔧 Please answer the following questions about the targets found in your angular.json in order to generate task runner configuration',
     });
 
     cacheableOperations = (

--- a/packages/nx/src/nx-init/angular/legacy-angular-versions.ts
+++ b/packages/nx/src/nx-init/angular/legacy-angular-versions.ts
@@ -6,12 +6,12 @@ import { sortObjectByKeys } from '../../utils/object-sort';
 import { output } from '../../utils/output';
 import { readModulePackageJson } from '../../utils/package-json';
 import {
-  PackageManagerCommands,
   getPackageManagerCommand,
+  PackageManagerCommands,
   resolvePackageVersionUsingInstallation,
   resolvePackageVersionUsingRegistry,
 } from '../../utils/package-manager';
-import { askAboutNxCloud, initCloud } from '../utils';
+import { askAboutNxCloud, initCloud, printFinalMessage } from '../utils';
 
 // map of Angular major versions to Nx versions to use for legacy `nx init` migrations,
 // key is major Angular version and value is Nx version to use
@@ -84,11 +84,10 @@ export async function getLegacyMigrationFunctionIfApplicable(
       initCloud(repoRoot, 'nx-init-angular');
     }
 
-    output.success({
-      title: '🎉 Nx is now enabled in your workspace!',
+    printFinalMessage({
+      learnMoreLink: 'https://nx.dev/recipes/adopting-nx/migration-angular',
       bodyLines: [
-        `Execute 'npx nx build' twice to see the computation caching in action.`,
-        'Learn more about the changes done to your workspace at https://nx.dev/recipes/adopting-nx/migration-angular.',
+        '- Execute "npx nx build" twice to see the computation caching in action.',
       ],
     });
   };

--- a/packages/nx/src/nx-init/utils.ts
+++ b/packages/nx/src/nx-init/utils.ts
@@ -1,16 +1,18 @@
 import { execSync } from 'child_process';
 import * as enquirer from 'enquirer';
 import { join } from 'path';
+import { runNxSync } from '../utils/child-process';
 import { fileExists, readJsonFile, writeJsonFile } from '../utils/fileutils';
+import { output } from '../utils/output';
+import { PackageJson } from '../utils/package-json';
 import {
   getPackageManagerCommand,
   PackageManagerCommands,
 } from '../utils/package-manager';
-import { runNxSync } from '../utils/child-process';
 import { joinPathFragments } from '../utils/path';
 
-export function askAboutNxCloud() {
-  return enquirer
+export async function askAboutNxCloud(): Promise<boolean> {
+  return await enquirer
     .prompt([
       {
         name: 'NxCloud',
@@ -159,4 +161,59 @@ export function addVsCodeRecommendedExtensions(
   } else {
     writeJsonFile(vsCodeExtensionsPath, { recommendations: extensions });
   }
+}
+
+export function markRootPackageJsonAsNxProject(
+  repoRoot: string,
+  cacheableScripts: string[],
+  scriptOutputs: { [script: string]: string },
+  pmc: PackageManagerCommands
+) {
+  const json = readJsonFile<PackageJson>(
+    joinPathFragments(repoRoot, `package.json`)
+  );
+  json.nx = { targets: {} };
+  for (let script of Object.keys(scriptOutputs)) {
+    if (scriptOutputs[script]) {
+      json.nx.targets[script] = {
+        outputs: [`{projectRoot}/${scriptOutputs[script]}`],
+      };
+    }
+  }
+  for (let script of cacheableScripts) {
+    const scriptDefinition = json.scripts[script];
+    if (!scriptDefinition) {
+      continue;
+    }
+
+    if (scriptDefinition.includes('&&') || scriptDefinition.includes('||')) {
+      let backingScriptName = `_${script}`;
+      json.scripts[backingScriptName] = scriptDefinition;
+      json.scripts[script] = `nx exec -- ${pmc.run(backingScriptName, '')}`;
+    } else {
+      json.scripts[script] = `nx exec -- ${json.scripts[script]}`;
+    }
+  }
+  writeJsonFile(`package.json`, json);
+}
+
+export function printFinalMessage({
+  learnMoreLink,
+  bodyLines,
+}: {
+  learnMoreLink?: string;
+  bodyLines?: string[];
+}): void {
+  const normalizedBodyLines = (bodyLines ?? []).map((l) =>
+    l.startsWith('- ') ? l : `- ${l}`
+  );
+
+  output.success({
+    title: '🎉 Done!',
+    bodyLines: [
+      '- Enabled computation caching!',
+      ...normalizedBodyLines,
+      learnMoreLink ? `- Learn more at ${learnMoreLink}.` : undefined,
+    ].filter(Boolean),
+  });
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The different `nx init` flows have messaging and implementation differences for common functionalities.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The different `nx init` flows have common messaging and functionalities where it makes sense.

Changes made:

- Standardized common messaging for similar messages across flows 
- CRA now prompts for Nx Cloud usage, don't default to `true`
- CRA can skip prompts with an `interactive` flag

**Note**: A follow-up PR (https://github.com/nrwl/nx/pull/16287) will standardize and expose all the different flags so they are shown in the docs and the terminal help. As part of that:

- The flag for Nx Cloud will be standardized for all flows
- The currently internal `--yes` flag in some flows will be standardized as `--interactive` for all flows
- Flags for specific flows will have a disclaimer in their description to communicate the flows that use them

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
