### PR TITLE
fix(angular): consider app-routing.module.ts when setting up module federation host routes

### DIFF
--- a/packages/angular/src/generators/setup-mf/lib/update-host-app-routes.ts
+++ b/packages/angular/src/generators/setup-mf/lib/update-host-app-routes.ts
@@ -42,7 +42,10 @@ export function updateHostAppRoutes(tree: Tree, options: Schema) {
   let hostRootRoutingFile = tree.read(pathToHostRootRoutingFile, 'utf-8');
 
   if (!hostRootRoutingFile) {
-    pathToHostRootRoutingFile = joinPathFragments(sourceRoot, 'app/app-routing.module.ts');
+    pathToHostRootRoutingFile = joinPathFragments(
+      sourceRoot,
+      'app/app-routing.module.ts'
+    );
     hostRootRoutingFile = tree.read(pathToHostRootRoutingFile, 'utf-8');
   }
 

--- a/packages/angular/src/generators/setup-mf/lib/update-host-app-routes.ts
+++ b/packages/angular/src/generators/setup-mf/lib/update-host-app-routes.ts
@@ -42,7 +42,7 @@ export function updateHostAppRoutes(tree: Tree, options: Schema) {
   let hostRootRoutingFile = tree.read(pathToHostRootRoutingFile, 'utf-8');
 
   if (!hostRootRoutingFile) {
-    pathToHostRootRoutingFile = (0, devkit_1.joinPathFragments)(sourceRoot, 'app/app-routing.module.ts');
+    pathToHostRootRoutingFile = joinPathFragments(sourceRoot, 'app/app-routing.module.ts');
     hostRootRoutingFile = tree.read(pathToHostRootRoutingFile, 'utf-8');
   }
 

--- a/packages/angular/src/generators/setup-mf/lib/update-host-app-routes.ts
+++ b/packages/angular/src/generators/setup-mf/lib/update-host-app-routes.ts
@@ -34,12 +34,17 @@ export function updateHostAppRoutes(tree: Tree, options: Schema) {
 `
   );
 
-  const pathToHostRootRoutingFile = joinPathFragments(
+  let pathToHostRootRoutingFile = joinPathFragments(
     sourceRoot,
     'app/app.routes.ts'
   );
 
-  const hostRootRoutingFile = tree.read(pathToHostRootRoutingFile, 'utf-8');
+  let hostRootRoutingFile = tree.read(pathToHostRootRoutingFile, 'utf-8');
+
+  if (!hostRootRoutingFile) {
+    pathToHostRootRoutingFile = (0, devkit_1.joinPathFragments)(sourceRoot, 'app/app-routing.module.ts');
+    hostRootRoutingFile = tree.read(pathToHostRootRoutingFile, 'utf-8');
+  }
 
   let sourceFile = tsModule.createSourceFile(
     pathToHostRootRoutingFile,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Getting `Cannot read properties of null (reading 'length')` when running:
`npx nx g @nrwl/angular:setup-mf appName --mfType=host`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
It should generate the module federation config regardless of whether you use `app.routes.ts` or `app-routing.module.ts`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #14075
