### PR TITLE
feat(misc): expose nx init command flags

### DIFF
--- a/e2e/nx-init/src/nx-init-angular.test.ts
+++ b/e2e/nx-init/src/nx-init-angular.test.ts
@@ -30,7 +30,9 @@ describe('nx init (Angular CLI)', () => {
 
   it('should successfully convert an Angular CLI workspace to an Nx standalone workspace', () => {
     const output = runCommand(
-      `${pmc.runUninstalledPackage} nx@${getPublishedVersion()} init -y`
+      `${
+        pmc.runUninstalledPackage
+      } nx@${getPublishedVersion()} init --no-interactive`
     );
 
     expect(output).toContain('🎉 Done!');
@@ -64,7 +66,7 @@ describe('nx init (Angular CLI)', () => {
     const output = runCommand(
       `${
         pmc.runUninstalledPackage
-      } nx@${getPublishedVersion()} init -y --integrated`
+      } nx@${getPublishedVersion()} init --integrated --no-interactive`
     );
 
     expect(output).toContain('🎉 Done!');

--- a/e2e/nx-init/src/nx-init-monorepo.test.ts
+++ b/e2e/nx-init/src/nx-init-monorepo.test.ts
@@ -40,7 +40,7 @@ describe('nx init (Monorepo)', () => {
     const output = runCommand(
       `${
         pmc.runUninstalledPackage
-      } nx@${getPublishedVersion()} init -y --cacheable=build`
+      } nx@${getPublishedVersion()} init --cacheable=build --no-interactive`
     );
 
     expect(output).toContain('🎉 Done!');

--- a/e2e/nx-init/src/nx-init-nest.test.ts
+++ b/e2e/nx-init/src/nx-init-nest.test.ts
@@ -34,7 +34,7 @@ describe('nx init (for NestCLI)', () => {
     const output = execSync(
       `${
         pmc.runUninstalledPackage
-      } nx@${getPublishedVersion()} init -y --cacheable=format`,
+      } nx@${getPublishedVersion()} init --cacheable=format --no-interactive`,
       {
         cwd: projectRoot,
         encoding: 'utf-8',

--- a/e2e/nx-init/src/nx-init-npm-repo.test.ts
+++ b/e2e/nx-init/src/nx-init-npm-repo.test.ts
@@ -32,7 +32,7 @@ describe('nx init (NPM repo)', () => {
     const output = runCommand(
       `${
         pmc.runUninstalledPackage
-      } nx@${getPublishedVersion()} init -y --cacheable=echo`
+      } nx@${getPublishedVersion()} init --cacheable=echo --no-interactive`
     );
     console.log(output);
     expect(output).toContain('Enabled computation caching');
@@ -61,7 +61,7 @@ describe('nx init (NPM repo)', () => {
     runCommand(
       `${
         pmc.runUninstalledPackage
-      } nx@${getPublishedVersion()} init -y --cacheable=compound`
+      } nx@${getPublishedVersion()} init --cacheable=compound --no-interactive`
     );
 
     const output = runCommand('npm run compound TEST');

--- a/packages/nx/src/command-line/init.ts
+++ b/packages/nx/src/command-line/init.ts
@@ -20,6 +20,7 @@ export interface InitArgs {
   interactive: boolean;
   vite: boolean;
   nxCloud?: boolean;
+  cacheable?: string[];
 }
 
 export async function initHandler(options: InitArgs) {

--- a/packages/nx/src/command-line/init.ts
+++ b/packages/nx/src/command-line/init.ts
@@ -14,7 +14,12 @@ import { directoryExists, readJsonFile } from '../utils/fileutils';
 import { PackageJson } from '../utils/package-json';
 
 export interface InitArgs {
+  addE2e: boolean;
+  force: boolean;
   integrated: boolean;
+  interactive: boolean;
+  vite: boolean;
+  nxCloud?: boolean;
 }
 
 export async function initHandler(options: InitArgs) {
@@ -40,15 +45,15 @@ export async function initHandler(options: InitArgs) {
   } else if (existsSync('package.json')) {
     const packageJson: PackageJson = readJsonFile('package.json');
     if (existsSync('angular.json')) {
-      await addNxToAngularCliRepo(options.integrated);
+      await addNxToAngularCliRepo(options);
     } else if (isCRA(packageJson)) {
-      await addNxToCraRepo(options.integrated);
+      await addNxToCraRepo(options);
     } else if (isNestCLI(packageJson)) {
-      await addNxToNest(packageJson);
+      await addNxToNest(options, packageJson);
     } else if (isMonorepo(packageJson)) {
-      await addNxToMonorepo();
+      await addNxToMonorepo(options);
     } else {
-      await addNxToNpmRepo();
+      await addNxToNpmRepo(options);
     }
   } else {
     const useDotNxFolder = await prompt<{ useDotNxFolder: string }>([

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -2,14 +2,12 @@ import * as chalk from 'chalk';
 import { execSync } from 'child_process';
 import * as path from 'path';
 import * as yargs from 'yargs';
-import { nxVersion } from '../utils/versions';
-import { examples } from './examples';
-import { workspaceRoot } from '../utils/workspace-root';
-import { getPackageManagerCommand } from '../utils/package-manager';
-import { writeJsonFile } from '../utils/fileutils';
-import { WatchArguments } from './watch';
 import { runNxSync } from '../utils/child-process';
-import { stripIndents } from '../utils/strip-indents';
+import { writeJsonFile } from '../utils/fileutils';
+import { getPackageManagerCommand } from '../utils/package-manager';
+import { workspaceRoot } from '../utils/workspace-root';
+import { examples } from './examples';
+import { WatchArguments } from './watch';
 
 // Ensure that the output takes up the available width of the terminal.
 yargs.wrap(yargs.terminalWidth());
@@ -305,7 +303,7 @@ export const commandsObject = yargs
     command: 'init',
     describe:
       'Adds Nx to any type of workspace. It installs nx, creates an nx.json configuration file and optionally sets up distributed caching. For more info, check https://nx.dev/recipes/adopting-nx.',
-    builder: (yargs) => withIntegratedOption(yargs),
+    builder: (yargs) => withInitOptions(yargs),
     handler: async (args: any) => {
       await (await import('./init')).initHandler(args);
       process.exit(0);
@@ -1122,14 +1120,47 @@ function withListOptions(yargs) {
   });
 }
 
-function withIntegratedOption(yargs) {
-  return yargs.option('integrated', {
-    type: 'boolean',
-    description:
-      'Migrate to an Nx integrated layout workspace. Only for CRA and Angular projects.',
-    // TODO(leo): keep it hidden until feature is released
-    hidden: true,
-  });
+function withInitOptions(yargs: yargs.Argv) {
+  // TODO(leo): make them visible in docs/help once the feature is released in Nx 16
+  return yargs
+    .options('nxCloud', {
+      type: 'boolean',
+      description: 'Set up distributed caching with Nx Cloud.',
+      hidden: true,
+    })
+    .option('interactive', {
+      describe: 'When false disables interactive input prompts for options.',
+      type: 'boolean',
+      default: true,
+      hidden: true,
+    })
+    .option('integrated', {
+      type: 'boolean',
+      description:
+        'Migrate to an Nx integrated layout workspace. Only for Angular CLI workspaces and CRA projects.',
+      default: false,
+      hidden: true,
+    })
+    .option('addE2e', {
+      describe:
+        'Set up Cypress E2E tests in integrated workspaces. Only for CRA projects.',
+      type: 'boolean',
+      default: false,
+      hidden: true,
+    })
+    .option('force', {
+      describe:
+        'Force the migration to continue and ignore custom webpack setup or uncommitted changes. Only for CRA projects.',
+      type: 'boolean',
+      default: false,
+      hidden: true,
+    })
+    .options('vite', {
+      type: 'boolean',
+      description: 'Use Vite as the bundler. Only for CRA projects.',
+      default: true,
+      hidden: true,
+    });
 }
 
 function runMigration() {

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -1160,6 +1160,13 @@ function withInitOptions(yargs: yargs.Argv) {
       description: 'Use Vite as the bundler. Only for CRA projects.',
       default: true,
       hidden: true,
+    })
+    .options('cacheable', {
+      type: 'string',
+      description:
+        'Comma-separated list of cacheable operations. Only used for internal testing.',
+      coerce: parseCSV,
+      hidden: true,
     });
 }
 

--- a/packages/nx/src/nx-init/add-nx-to-monorepo.ts
+++ b/packages/nx/src/nx-init/add-nx-to-monorepo.ts
@@ -2,7 +2,6 @@ import { prompt } from 'enquirer';
 import { readdirSync, readFileSync, statSync } from 'fs';
 import ignore from 'ignore';
 import { join, relative } from 'path';
-import * as yargsParser from 'yargs-parser';
 import { InitArgs } from '../command-line/init';
 import { readJsonFile } from '../utils/fileutils';
 import { output } from '../utils/output';
@@ -16,11 +15,7 @@ import {
   runInstall,
 } from './utils';
 
-type Options = Pick<InitArgs, 'nxCloud' | 'interactive'>;
-
-const parsedArgs = yargsParser(process.argv, {
-  string: ['cacheable'], // only used for testing
-});
+type Options = Pick<InitArgs, 'nxCloud' | 'interactive' | 'cacheable'>;
 
 export async function addNxToMonorepo(options: Options) {
   const repoRoot = process.cwd();
@@ -80,9 +75,7 @@ export async function addNxToMonorepo(options: Options) {
     useNxCloud = options.nxCloud ?? (await askAboutNxCloud());
   } else {
     targetDefaults = [];
-    cacheableOperations = parsedArgs.cacheable
-      ? parsedArgs.cacheable.split(',')
-      : [];
+    cacheableOperations = options.cacheable ?? [];
     useNxCloud =
       options.nxCloud ??
       (options.interactive ? await askAboutNxCloud() : false);

--- a/packages/nx/src/nx-init/add-nx-to-nest.ts
+++ b/packages/nx/src/nx-init/add-nx-to-nest.ts
@@ -1,7 +1,6 @@
 import * as enquirer from 'enquirer';
 import { unlinkSync, writeFileSync } from 'fs-extra';
 import { join } from 'path';
-import * as yargsParser from 'yargs-parser';
 import { InitArgs } from '../command-line/init';
 import { NrwlJsPluginConfig, NxJsonConfiguration } from '../config/nx-json';
 import { ProjectConfiguration } from '../config/workspace-json-project-json';
@@ -19,12 +18,8 @@ import {
   runInstall,
 } from './utils';
 
-type Options = Pick<InitArgs, 'nxCloud' | 'interactive'>;
+type Options = Pick<InitArgs, 'nxCloud' | 'interactive' | 'cacheable'>;
 type NestCLIConfiguration = any;
-
-const parsedArgs = yargsParser(process.argv, {
-  string: ['cacheable'], // only used for testing
-});
 
 export async function addNxToNest(options: Options, packageJson: PackageJson) {
   const repoRoot = process.cwd();
@@ -99,9 +94,7 @@ export async function addNxToNest(options: Options, packageJson: PackageJson) {
 
     useNxCloud = options.nxCloud ?? (await askAboutNxCloud());
   } else {
-    cacheableOperations = parsedArgs.cacheable
-      ? parsedArgs.cacheable.split(',')
-      : [];
+    cacheableOperations = options.cacheable ?? [];
     useNxCloud = options.nxCloud ?? false;
   }
 

--- a/packages/nx/src/nx-init/add-nx-to-npm-repo.ts
+++ b/packages/nx/src/nx-init/add-nx-to-npm-repo.ts
@@ -1,5 +1,4 @@
 import * as enquirer from 'enquirer';
-import * as yargsParser from 'yargs-parser';
 import { InitArgs } from '../command-line/init';
 import { readJsonFile } from '../utils/fileutils';
 import { output } from '../utils/output';
@@ -14,11 +13,7 @@ import {
   runInstall,
 } from './utils';
 
-type Options = Pick<InitArgs, 'nxCloud' | 'interactive'>;
-
-const parsedArgs = yargsParser(process.argv, {
-  string: ['cacheable'], // only used for testing
-});
+type Options = Pick<InitArgs, 'nxCloud' | 'interactive' | 'cacheable'>;
 
 export async function addNxToNpmRepo(options: Options) {
   const repoRoot = process.cwd();
@@ -67,9 +62,7 @@ export async function addNxToNpmRepo(options: Options) {
 
     useNxCloud = options.nxCloud ?? (await askAboutNxCloud());
   } else {
-    cacheableOperations = parsedArgs.cacheable
-      ? parsedArgs.cacheable.split(',')
-      : [];
+    cacheableOperations = options.cacheable ?? [];
     useNxCloud = options.nxCloud ?? false;
   }
 

--- a/packages/nx/src/nx-init/add-nx-to-npm-repo.ts
+++ b/packages/nx/src/nx-init/add-nx-to-npm-repo.ts
@@ -1,5 +1,6 @@
 import * as enquirer from 'enquirer';
 import * as yargsParser from 'yargs-parser';
+import { InitArgs } from '../command-line/init';
 import { readJsonFile } from '../utils/fileutils';
 import { output } from '../utils/output';
 import { getPackageManagerCommand } from '../utils/package-manager';
@@ -13,15 +14,13 @@ import {
   runInstall,
 } from './utils';
 
+type Options = Pick<InitArgs, 'nxCloud' | 'interactive'>;
+
 const parsedArgs = yargsParser(process.argv, {
-  boolean: ['yes'],
   string: ['cacheable'], // only used for testing
-  alias: {
-    yes: ['y'],
-  },
 });
 
-export async function addNxToNpmRepo() {
+export async function addNxToNpmRepo(options: Options) {
   const repoRoot = process.cwd();
 
   output.log({ title: '🐳 Nx initialization' });
@@ -35,7 +34,7 @@ export async function addNxToNpmRepo() {
     (s) => !s.startsWith('pre') && !s.startsWith('post')
   );
 
-  if (parsedArgs.yes !== true) {
+  if (options.interactive) {
     output.log({
       title:
         '🧑‍🔧 Please answer the following questions about the scripts found in your package.json in order to generate task runner configuration',
@@ -66,12 +65,12 @@ export async function addNxToNpmRepo() {
       )[scriptName];
     }
 
-    useNxCloud = await askAboutNxCloud();
+    useNxCloud = options.nxCloud ?? (await askAboutNxCloud());
   } else {
     cacheableOperations = parsedArgs.cacheable
       ? parsedArgs.cacheable.split(',')
       : [];
-    useNxCloud = false;
+    useNxCloud = options.nxCloud ?? false;
   }
 
   createNxJsonFile(repoRoot, [], cacheableOperations, {});

--- a/packages/nx/src/nx-init/angular/index.ts
+++ b/packages/nx/src/nx-init/angular/index.ts
@@ -1,6 +1,5 @@
 import { prompt } from 'enquirer';
 import { join } from 'path';
-import { InitArgs } from '../../command-line/init';
 import { readJsonFile, writeJsonFile } from '../../utils/fileutils';
 import { sortObjectByKeys } from '../../utils/object-sort';
 import { output } from '../../utils/output';
@@ -16,7 +15,6 @@ import { setupIntegratedWorkspace } from './integrated-workspace';
 import { getLegacyMigrationFunctionIfApplicable } from './legacy-angular-versions';
 import { setupStandaloneWorkspace } from './standalone-workspace';
 import type { AngularJsonConfig, Options } from './types';
-import yargsParser = require('yargs-parser');
 
 const defaultCacheableOperations: string[] = [
   'build',
@@ -24,9 +22,6 @@ const defaultCacheableOperations: string[] = [
   'test',
   'lint',
 ];
-const parsedArgs = yargsParser(process.argv, {
-  string: ['cacheable'], // only used for testing
-});
 
 let repoRoot: string;
 let workspaceTargets: string[];
@@ -52,7 +47,7 @@ export async function addNxToAngularCliRepo(options: Options) {
 
   output.log({ title: '🐳 Nx initialization' });
   const cacheableOperations = !options.integrated
-    ? await collectCacheableOperations(options.interactive)
+    ? await collectCacheableOperations(options)
     : [];
   const useNxCloud =
     options.nxCloud ?? (options.interactive ? await askAboutNxCloud() : false);
@@ -76,9 +71,7 @@ export async function addNxToAngularCliRepo(options: Options) {
   });
 }
 
-async function collectCacheableOperations(
-  interactive: boolean
-): Promise<string[]> {
+async function collectCacheableOperations(options: Options): Promise<string[]> {
   let cacheableOperations: string[];
 
   workspaceTargets = getWorkspaceTargets();
@@ -86,7 +79,7 @@ async function collectCacheableOperations(
     (t) => workspaceTargets.includes(t)
   );
 
-  if (interactive) {
+  if (options.interactive) {
     output.log({
       title:
         '🧑‍🔧 Please answer the following questions about the targets found in your angular.json in order to generate task runner configuration',
@@ -106,9 +99,8 @@ async function collectCacheableOperations(
       ])) as any
     ).cacheableOperations;
   } else {
-    cacheableOperations = parsedArgs.cacheable
-      ? parsedArgs.cacheable.split(',')
-      : defaultCacheableTargetsInWorkspace;
+    cacheableOperations =
+      options.cacheable ?? defaultCacheableTargetsInWorkspace;
   }
 
   return cacheableOperations;

--- a/packages/nx/src/nx-init/angular/legacy-angular-versions.ts
+++ b/packages/nx/src/nx-init/angular/legacy-angular-versions.ts
@@ -12,6 +12,7 @@ import {
   resolvePackageVersionUsingRegistry,
 } from '../../utils/package-manager';
 import { askAboutNxCloud, initCloud, printFinalMessage } from '../utils';
+import type { Options } from './types';
 
 // map of Angular major versions to Nx versions to use for legacy `nx init` migrations,
 // key is major Angular version and value is Nx version to use
@@ -23,8 +24,7 @@ const versionWithConsolidatedPackages = '13.9.0';
 
 export async function getLegacyMigrationFunctionIfApplicable(
   repoRoot: string,
-  isIntegratedMigration: boolean,
-  interactive: boolean
+  options: Options
 ): Promise<() => Promise<void> | null> {
   const angularVersion =
     readModulePackageJson('@angular/core').packageJson.version;
@@ -44,7 +44,7 @@ export async function getLegacyMigrationFunctionIfApplicable(
       pkgName,
       `^${majorAngularVersion}.0.0`
     );
-    const preserveAngularCliLayoutFlag = !isIntegratedMigration
+    const preserveAngularCliLayoutFlag = !options.integrated
       ? '--preserveAngularCLILayout'
       : '--preserveAngularCLILayout=false';
     legacyMigrationCommand = `ng g ${pkgName}:ng-add ${preserveAngularCliLayoutFlag}`;
@@ -52,7 +52,7 @@ export async function getLegacyMigrationFunctionIfApplicable(
     // for v13, the migration was in @nrwl/angular:ng-add
     pkgName = '@nrwl/angular';
     pkgVersion = await resolvePackageVersion(pkgName, '~14.1.0');
-    const preserveAngularCliLayoutFlag = !isIntegratedMigration
+    const preserveAngularCliLayoutFlag = !options.integrated
       ? '--preserve-angular-cli-layout'
       : '--preserve-angular-cli-layout=false';
     legacyMigrationCommand = `ng g ${pkgName}:ng-add ${preserveAngularCliLayoutFlag}`;
@@ -70,7 +70,9 @@ export async function getLegacyMigrationFunctionIfApplicable(
 
   return async () => {
     output.log({ title: '🐳 Nx initialization' });
-    const useNxCloud = interactive ? await askAboutNxCloud() : false;
+    const useNxCloud =
+      options.nxCloud ??
+      (options.interactive ? await askAboutNxCloud() : false);
 
     output.log({ title: '📦 Installing dependencies' });
     const pmc = getPackageManagerCommand();

--- a/packages/nx/src/nx-init/angular/types.ts
+++ b/packages/nx/src/nx-init/angular/types.ts
@@ -1,4 +1,7 @@
+import { InitArgs } from '../../command-line/init';
 import type { TargetConfiguration } from '../../config/workspace-json-project-json';
+
+export type Options = Pick<InitArgs, 'nxCloud' | 'integrated' | 'interactive'>;
 
 export type AngularJsonConfigTargetConfiguration = Exclude<
   TargetConfiguration,

--- a/packages/nx/src/nx-init/angular/types.ts
+++ b/packages/nx/src/nx-init/angular/types.ts
@@ -1,7 +1,10 @@
 import { InitArgs } from '../../command-line/init';
 import type { TargetConfiguration } from '../../config/workspace-json-project-json';
 
-export type Options = Pick<InitArgs, 'nxCloud' | 'integrated' | 'interactive'>;
+export type Options = Pick<
+  InitArgs,
+  'nxCloud' | 'integrated' | 'interactive' | 'cacheable'
+>;
 
 export type AngularJsonConfigTargetConfiguration = Exclude<
   TargetConfiguration,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `nx init` command supports several flags (some specific to some flows) but all are "hidden" in the individual flow implementations (except the recently exposed `--integrated`). 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `nx init` command exposes the supported flags.

**Note**: The flags are still hidden from the docs and the terminal help until Nx 16 is released. A Draft PR will be ready with the change to make them visible.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
