### PR TITLE
feat(nextjs): add composePlugins util when using multiple plugins

### DIFF
--- a/packages/next/index.ts
+++ b/packages/next/index.ts
@@ -5,3 +5,5 @@ export { applicationGenerator } from './src/generators/application/application';
 export { componentGenerator } from './src/generators/component/component';
 export { libraryGenerator } from './src/generators/library/library';
 export { pageGenerator } from './src/generators/page/page';
+export { withNx } from './plugins/with-nx';
+export { composePlugins } from './src/utils/config';

--- a/packages/next/plugins/with-less.ts
+++ b/packages/next/plugins/with-less.ts
@@ -1,6 +1,6 @@
 // Adapted from https://raw.githubusercontent.com/elado/next-with-less/main/src/index.js
 import { merge } from 'webpack-merge';
-import { NextConfigFn } from './with-nx';
+import { NextConfigFn } from '../src/utils/config';
 
 const addLessToRegExp = (rx) =>
   new RegExp(rx.source.replace('|sass', '|sass|less'), rx.flags);

--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -16,17 +16,13 @@ import type { NextConfig } from 'next';
 import { PHASE_PRODUCTION_SERVER } from 'next/constants';
 
 import * as path from 'path';
-import { createWebpackConfig } from '../src/utils/config';
+import { createWebpackConfig, NextConfigFn } from '../src/utils/config';
 import { NextBuildBuilderOptions } from '../src/utils/types';
 
 export interface WithNxOptions extends NextConfig {
   nx?: {
     svgr?: boolean;
   };
-}
-
-export interface NextConfigFn {
-  (phase: string): Promise<NextConfig>;
 }
 
 export interface WithNxContext {

--- a/packages/next/plugins/with-stylus.ts
+++ b/packages/next/plugins/with-stylus.ts
@@ -1,6 +1,6 @@
 // Adapted from https://raw.githubusercontent.com/elado/next-with-less/main/src/index.js
 import { merge } from 'webpack-merge';
-import { NextConfigFn } from './with-nx';
+import { NextConfigFn } from '../src/utils/config';
 
 const addStylusToRegExp = (rx) =>
   new RegExp(rx.source.replace('|sass', '|sass|styl'), rx.flags);

--- a/packages/next/src/generators/application/files/common/next.config.js__tmpl__
+++ b/packages/next/src/generators/application/files/common/next.config.js__tmpl__
@@ -1,7 +1,7 @@
 //@ts-check
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { withNx } = require('@nrwl/next/plugins/with-nx');
+const { composePlugins, withNx } = require('@nrwl/next');
 
 <% if (style === 'less') { %>
 // This plugin is needed until this PR is merged.
@@ -24,7 +24,13 @@ const nextConfig = {
   <% } %>
 };
 
-module.exports = withLess(withNx(nextConfig));
+const plugins = [
+  // Add more Next.js plugins to this list if needed.
+  withLess,
+  withNx,
+];
+
+module.exports = composePlugins(...plugins)(nextConfig));
 <% } else if (style === 'styl') { %>
 const { withStylus } = require('@nrwl/next/plugins/with-stylus');
 
@@ -44,7 +50,13 @@ const nextConfig = {
   <% } %>
 };
 
-module.exports = withStylus(withNx(nextConfig));
+const plugins = [
+  // Add more Next.js plugins to this list if needed.
+  withStylus,
+  withNx,
+];
+
+module.exports = composePlugins(...plugins)(nextConfig);
 <% } else if (
   style === 'styled-components'
   ||style === '@emotion/styled'
@@ -67,7 +79,12 @@ const nextConfig = {
   <% } %>
 };
 
-module.exports = withNx(nextConfig);
+const plugins = [
+  // Add more Next.js plugins to this list if needed.
+  withNx,
+];
+
+module.exports = composePlugins(...plugins)(nextConfig);
 <% } else {
 // Defaults to CSS/SASS (which don't need plugin as of Next 9.3) %>
 /**
@@ -86,5 +103,10 @@ const nextConfig = {
   <% } %>
 };
 
-module.exports = withNx(nextConfig);
+const plugins = [
+  // Add more Next.js plugins to this list if needed.
+  withNx,
+];
+
+module.exports = composePlugins(...plugins)(nextConfig);
 <% } %>

--- a/packages/next/src/utils/config.spec.ts
+++ b/packages/next/src/utils/config.spec.ts
@@ -1,5 +1,6 @@
+import type { NextConfig } from 'next';
 import 'nx/src/utils/testing/mock-fs';
-import { createWebpackConfig } from './config';
+import { composePlugins, createWebpackConfig, NextConfigFn } from './config';
 import { TsconfigPathsPlugin } from 'tsconfig-paths-webpack-plugin';
 
 jest.mock('@nrwl/webpack', () => ({}));
@@ -73,6 +74,62 @@ describe('Next.js webpack config builder', () => {
       // not much value in checking what they are
       // just check they get added
       expect(config.module.rules.length).toBe(2);
+    });
+  });
+
+  describe('composePlugins', () => {
+    it('should combine multiple plugins', async () => {
+      const nextConfig: NextConfig = {
+        env: {
+          original: 'original',
+        },
+      };
+      const a = (config: NextConfig): NextConfig => {
+        config.env['a'] = 'a';
+        return config;
+      };
+      const b = (config: NextConfig): NextConfig => {
+        config.env['b'] = 'b';
+        return config;
+      };
+      const fn = await composePlugins(a, b);
+      const output = await fn(nextConfig)('test', {});
+
+      expect(output).toEqual({
+        env: {
+          original: 'original',
+          a: 'a',
+          b: 'b',
+        },
+      });
+    });
+
+    it('should compose plugins that return an async function', async () => {
+      const nextConfig: NextConfig = {
+        env: {
+          original: 'original',
+        },
+      };
+      const a = (config: NextConfig): NextConfig => {
+        config.env['a'] = 'a';
+        return config;
+      };
+      const b = (config: NextConfig): NextConfigFn => {
+        return (phase: string) => {
+          config.env['b'] = phase;
+          return config;
+        };
+      };
+      const fn = await composePlugins(a, b);
+      const output = await fn(nextConfig)('test', {});
+
+      expect(output).toEqual({
+        env: {
+          original: 'original',
+          a: 'a',
+          b: 'test',
+        },
+      });
     });
   });
 });


### PR DESCRIPTION
This PR adds a `composePlugins` function to `@nrwl/next`, which makes it easier when using multiple Next.js plugins together with Nx.

```
// next.config.js

const plugins = [
  // Add as many plugins here
  withMDX,
  withNx
  // ...
];

// The composed function will know how to handle normal plugins and plugins that return an async function (e.g. `withNx`).
module.exports = composePlugins(...plugins)({
  // normal next.js config
});
```

Also generates apps with `plugins` array and `composePlugins` function so it's obvious to users how they can add more plugins.

---

Closes #16278