### PR TITLE
feat(testing): add "video" option to cypress executor

### DIFF
--- a/docs/generated/packages/cypress/executors/cypress.json
+++ b/docs/generated/packages/cypress/executors/cypress.json
@@ -132,6 +132,11 @@
         "description": "A comma delimited list to identify a run with.",
         "aliases": ["t"]
       },
+      "video": {
+        "type": "boolean",
+        "description": "Whether Cypress will capture a video of the tests run with cypress run.",
+        "default": true
+      },
       "port": {
         "oneOf": [
           { "type": "string", "enum": ["cypress-auto"] },

--- a/packages/cypress/src/executors/cypress/cypress.impl.spec.ts
+++ b/packages/cypress/src/executors/cypress/cypress.impl.spec.ts
@@ -440,6 +440,49 @@ A generator to migrate from v8 to v10 is provided. See https://nx.dev/cypress/v1
     );
   });
 
+  it('should forward video option', async () => {
+    const { success } = await cypressExecutor(
+      {
+        ...cypressOptions,
+        video: false,
+      },
+      mockContext
+    );
+    expect(success).toEqual(true);
+    expect(cypressRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: {
+          baseUrl: 'http://localhost:4200',
+          e2e: {
+            video: false,
+          },
+        },
+      })
+    );
+  });
+
+  it('should forward video option to the correct testingType config', async () => {
+    const { success } = await cypressExecutor(
+      {
+        ...cypressOptions,
+        video: false,
+        testingType: 'component',
+      },
+      mockContext
+    );
+    expect(success).toEqual(true);
+    expect(cypressRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: {
+          baseUrl: 'http://localhost:4200',
+          component: {
+            video: false,
+          },
+        },
+      })
+    );
+  });
+
   describe('Component Testing', () => {
     beforeEach(() => {
       mockGetTailwindPath.mockReturnValue(undefined);

--- a/packages/cypress/src/executors/cypress/cypress.impl.spec.ts
+++ b/packages/cypress/src/executors/cypress/cypress.impl.spec.ts
@@ -462,11 +462,13 @@ A generator to migrate from v8 to v10 is provided. See https://nx.dev/cypress/v1
   });
 
   it('should forward video option to the correct testingType config', async () => {
+    mockedInstalledCypressVersion.mockReturnValue(12);
     const { success } = await cypressExecutor(
       {
         ...cypressOptions,
         video: false,
         testingType: 'component',
+        ignoreTestFiles: '**/*.spec.ts',
       },
       mockContext
     );
@@ -477,6 +479,7 @@ A generator to migrate from v8 to v10 is provided. See https://nx.dev/cypress/v1
           baseUrl: 'http://localhost:4200',
           component: {
             video: false,
+            excludeSpecPattern: '**/*.spec.ts',
           },
         },
       })

--- a/packages/cypress/src/executors/cypress/cypress.impl.ts
+++ b/packages/cypress/src/executors/cypress/cypress.impl.ts
@@ -51,6 +51,7 @@ export interface CypressExecutorOptions extends Json {
   skipServe?: boolean;
   testingType?: 'component' | 'e2e';
   tag?: string;
+  video?: boolean;
   port?: number | 'cypress-auto';
 }
 
@@ -291,8 +292,13 @@ async function runCypress(
   if (opts.reporterOptions) {
     options.reporterOptions = opts.reporterOptions;
   }
-
   options.testingType = opts.testingType;
+
+  if (opts.video !== undefined) {
+    options.config[opts.testingType ?? 'e2e'] = {
+      video: opts.video,
+    };
+  }
 
   const result = await (opts.watch
     ? Cypress.open(options)

--- a/packages/cypress/src/executors/cypress/cypress.impl.ts
+++ b/packages/cypress/src/executors/cypress/cypress.impl.ts
@@ -295,7 +295,9 @@ async function runCypress(
   options.testingType = opts.testingType;
 
   if (opts.video !== undefined) {
-    options.config[opts.testingType ?? 'e2e'] = {
+    const testingType = opts.testingType ?? 'e2e';
+    options.config[testingType] = {
+      ...options.config[testingType],
       video: opts.video,
     };
   }

--- a/packages/cypress/src/executors/cypress/schema.json
+++ b/packages/cypress/src/executors/cypress/schema.json
@@ -139,6 +139,11 @@
       "description": "A comma delimited list to identify a run with.",
       "aliases": ["t"]
     },
+    "video": {
+      "type": "boolean",
+      "description": "Whether Cypress will capture a video of the tests run with cypress run.",
+      "default": true
+    },
     "port": {
       "oneOf": [
         {


### PR DESCRIPTION
adds the ability to set the video option from the cypress executor options

https://docs.cypress.io/guides/references/configuration#Videos

closed #16305

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
