### PR TITLE
feat(vite): add `--testFile` argument to @nrwl/vite:test

### DIFF
--- a/docs/generated/packages/vite/executors/test.json
+++ b/docs/generated/packages/vite/executors/test.json
@@ -57,6 +57,10 @@
       "reportsDirectory": {
         "type": "string",
         "description": "Directory to write coverage report to."
+      },
+      "testFile": {
+        "description": "The name of the file to test.",
+        "type": "string"
       }
     },
     "required": [],

--- a/packages/vite/src/executors/test/schema.d.ts
+++ b/packages/vite/src/executors/test/schema.d.ts
@@ -8,4 +8,5 @@ export interface VitestExecutorOptions {
   update?: boolean;
   reportsDirectory?: string;
   coverage?: boolean;
+  testFile?: string;
 }

--- a/packages/vite/src/executors/test/schema.json
+++ b/packages/vite/src/executors/test/schema.json
@@ -56,6 +56,10 @@
     "reportsDirectory": {
       "type": "string",
       "description": "Directory to write coverage report to."
+    },
+    "testFile": {
+      "description": "The name of the file to test.",
+      "type": "string"
     }
   },
   "required": [],

--- a/packages/vite/src/executors/test/vitest.impl.ts
+++ b/packages/vite/src/executors/test/vitest.impl.ts
@@ -56,8 +56,9 @@ export async function* vitestExecutor(
   const nxReporter = new NxReporter(options.watch);
   const settings = await getSettings(options, context);
   settings.reporters.push(nxReporter);
+  const cliFilters = options.testFile ? [options.testFile] : [];
 
-  const ctx = await startVitest(options.mode, [], settings);
+  const ctx = await startVitest(options.mode, cliFilters, settings);
 
   let hasErrors = false;
 


### PR DESCRIPTION
closed #16280

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When running the `@nrwl/vite:test` executor, we don't currently have the option to run a specific test file.
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
After this change, `@nrwl/vite:test` will have a new option `--testFile` available, which can be used to run a single test file.
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
#16280 
Fixes #
