### PR TITLE
fix(core): use the module name as the name of the nx plugin

### DIFF
--- a/packages/nx/src/utils/nx-plugin.ts
+++ b/packages/nx/src/utils/nx-plugin.ts
@@ -80,11 +80,12 @@ function getPluginPathAndName(
     }
   }
   const packageJsonPath = path.join(pluginPath, 'package.json');
+
   const { name } =
     !['.ts', '.js'].some((x) => x === path.extname(pluginPath)) && // Not trying to point to a ts or js file
     existsSync(packageJsonPath) // plugin has a package.json
       ? readJsonFile(packageJsonPath) // read name from package.json
-      : { name: path.basename(pluginPath) }; // use the name of the file we point to
+      : { name: moduleName };
   return { pluginPath, name };
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The fall back of getting the name of a registered nx.json plugin defaults to "index.js" after it cannot find the package.json. 

```
>  NX   Failed to process the project graph with "index.js".

   Source project nx does not have a file: C:\dev\nx\packages\nx\Cargo.toml
```

## Expected Behavior
Since we already have the module name of the plugin, using the module name instead of using the base file name is more descriptive. 

```
>  NX   Failed to process the project graph with "@monodon/rust".

   Source project nx does not have a file: C:\dev\nx\packages\nx\Cargo.toml
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
