### PR TITLE
fix(core): hide duplicate log entry when displaying generator help

### DIFF
--- a/packages/nx/src/command-line/generate.ts
+++ b/packages/nx/src/command-line/generate.ts
@@ -333,7 +333,7 @@ export async function generate(cwd: string, args: { [k: string]: any }) {
         ].join('/n')
       );
     }
-    if (!opts.quiet) {
+    if (!opts.quiet && !opts.help) {
       logger.info(
         `NX Generating ${opts.collectionName}:${normalizedGeneratorName}`
       );

--- a/packages/nx/src/utils/print-help.ts
+++ b/packages/nx/src/utils/print-help.ts
@@ -6,6 +6,7 @@ import { logger } from './logger';
 import { output } from './output';
 import { Schema } from './params';
 import { nxVersion } from './versions';
+import { readModulePackageJson } from './package-json';
 
 export function printHelp(
   header: string,
@@ -97,6 +98,11 @@ function generateGeneratorOverviewOutput({
     // The `:` char
     1;
 
+  let installedVersion: string;
+  try {
+    installedVersion = readModulePackageJson(pluginName).packageJson.version;
+  } catch {}
+
   ui.div(
     ...[
       {
@@ -107,9 +113,7 @@ function generateGeneratorOverviewOutput({
       {
         text:
           pluginName +
-          (pluginName.startsWith('@nx/') || pluginName.startsWith('@nrwl/')
-            ? chalk.dim(` (v${nxVersion})`)
-            : ''),
+          (installedVersion ? chalk.dim(` (v${installedVersion})`) : ''),
         padding: [1, 0, 0, 2],
       },
     ]


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

- Package version only displayed for @nrwl / @nx packages
- Package version incorrect for @nrwl/labs packages, or if nx version mismatch present
- Logs show some duplicate messaging (see screenshot)

<img width="1137" alt="image" src="https://user-images.githubusercontent.com/6933928/232607932-e6a386e1-0a91-41e4-b4bb-905e7f82ff2a.png">

## Expected Behavior

- Help text is consistent for community plugins (includes version number)
- Package version based on installed version, rather than just the Nx version
- Logs don't show duplicate messaging

<img width="1137" alt="image" src="https://user-images.githubusercontent.com/6933928/232608133-f04472e6-acd8-486e-bd4c-81228af51705.png">


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204424637634825