### PR TITLE
feat(storybook): add migration to v7 and bump next.js to 13.3.0

### DIFF
--- a/packages/next/migrations.json
+++ b/packages/next/migrations.json
@@ -307,6 +307,15 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "16.0.0": {
+      "version": "16.0.0-beta.0",
+      "packages": {
+        "next": {
+          "version": "13.3.0",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/react/plugins/storybook/index.ts
+++ b/packages/react/plugins/storybook/index.ts
@@ -116,6 +116,14 @@ export const webpack = async (
     },
     resolve: {
       ...storybookWebpackConfig.resolve,
+      fallback: {
+        ...storybookWebpackConfig.resolve?.fallback,
+        // Next.js and other React frameworks may have server-code that uses these modules.
+        // They are not meant for client-side components so skip the fallbacks.
+        assert: false,
+        path: false,
+        util: false,
+      },
       plugins: mergePlugins(
         ...((storybookWebpackConfig.resolve.plugins ??
           []) as ResolvePluginInstance[]),

--- a/packages/storybook/migrations.json
+++ b/packages/storybook/migrations.json
@@ -47,6 +47,12 @@
       "version": "16.0.0-beta.1",
       "description": "Replace @nrwl/storybook with @nx/storybook",
       "implementation": "./src/migrations/update-16-0-0-add-nx-packages/update-16-0-0-add-nx-packages"
+    },
+    "update-16-0-0-storybook-7": {
+      "cli": "nx",
+      "version": "16.0.0-beta.1",
+      "description": "Updates Storybook from v6 to v7.",
+      "implementation": "./src/migrations/update-16-0-0-storybook-7/migrate-to-v7"
     }
   },
   "packageJsonUpdates": {

--- a/packages/storybook/src/migrations/update-16-0-0-storybook-7/migrate-to-v7.ts
+++ b/packages/storybook/src/migrations/update-16-0-0-storybook-7/migrate-to-v7.ts
@@ -1,0 +1,21 @@
+import { logger, readJson, Tree } from '@nx/devkit';
+import * as semver from 'semver';
+import migrate from '../../generators/migrate-7/migrate-7';
+
+export default async function migrateStorybookV7(tree: Tree) {
+  const packageJson = readJson(tree, 'package.json');
+
+  // In case someone installed into dependencies.
+  const installedVersion =
+    packageJson.devDependencies?.['@storybook/core-server'] ||
+    packageJson.dependencies?.['@storybook/core-server'];
+
+  if (installedVersion && semver.gte(installedVersion, '7.0.0')) {
+    logger.info(`Storybook is already at v7. Skipping migration.`);
+    return;
+  }
+
+  await migrate(tree, {
+    autoAcceptAllPrompts: true,
+  });
+}


### PR DESCRIPTION
Storybook v6 is unmaintained, and Next.js 13.3.0 only works with v7. This PR adds a migration to update workspaces to SB v7, and Next.js to 13.3.0.

I included some extra configuration in the `@nrwl/react/plugins/storybook` module to skip fallbacks for `util`, `path`, and `assert` since they are imported by Next.js for server-code, but don't apply to client components -- without this change the build seems to error out.


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
