### PR TITLE
fix(angular): add component import path correctly to NgModule when flat=false

### DIFF
--- a/packages/angular/src/generators/component/__snapshots__/component.spec.ts.snap
+++ b/packages/angular/src/generators/component/__snapshots__/component.spec.ts.snap
@@ -24,6 +24,18 @@ export class ExampleComponent {}
 "
 `;
 
+exports[`component Generator --module should import the component correctly to the module file when flat is false 1`] = `
+"import { NgModule } from '@angular/core';
+import { ExampleComponent } from './example/example.component';
+
+@NgModule({
+  declarations: [ExampleComponent],
+  exports: [ExampleComponent],
+})
+export class LibModule {}
+"
+`;
+
 exports[`component Generator --path should create the component correctly and export it in the entry point 1`] = `
 "import { Component } from '@angular/core';
 

--- a/packages/angular/src/generators/component/component.spec.ts
+++ b/packages/angular/src/generators/component/component.spec.ts
@@ -648,6 +648,46 @@ describe('component Generator', () => {
       }
     );
 
+    it('should import the component correctly to the module file when flat is false', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+      addProjectConfiguration(tree, 'shared-ui', {
+        projectType: 'library',
+        sourceRoot: 'libs/shared/ui/src',
+        root: 'libs/shared/ui',
+      });
+      tree.write(
+        'libs/shared/ui/src/lib/lib.module.ts',
+        `
+    import { NgModule } from '@angular/core';
+    
+    @NgModule({
+      declarations: [],
+      exports: []
+    })
+    export class LibModule {}`
+      );
+      tree.write(
+        'libs/shared/ui/src/index.ts',
+        'export * from "./lib/lib.module";'
+      );
+
+      // ACT
+      await componentGenerator(tree, {
+        name: 'example',
+        project: 'shared-ui',
+        export: true,
+        flat: false,
+      });
+
+      // ASSERT
+      const moduleSource = tree.read(
+        'libs/shared/ui/src/lib/lib.module.ts',
+        'utf-8'
+      );
+      expect(moduleSource).toMatchSnapshot();
+    });
+
     it('should not export it in the entry point when the module it belong to is not exported', async () => {
       // ARRANGE
       const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });

--- a/packages/angular/src/generators/component/component.ts
+++ b/packages/angular/src/generators/component/component.ts
@@ -82,12 +82,7 @@ export async function componentGenerator(tree: Tree, rawOptions: Schema) {
       modulePath,
       componentNames.fileName,
       `${componentNames.className}${typeNames.className}`,
-      options.flat
-        ? `${componentNames.fileName}.${typeNames.fileName}`
-        : joinPathFragments(
-            componentNames.fileName,
-            `${componentNames.fileName}.${typeNames.fileName}`
-          ),
+      `${componentNames.fileName}.${typeNames.fileName}`,
       'declarations',
       options.flat,
       options.export

--- a/packages/angular/src/generators/component/lib/normalize-options.ts
+++ b/packages/angular/src/generators/component/lib/normalize-options.ts
@@ -27,6 +27,7 @@ export function normalizeOptions(
     name,
     changeDetection: options.changeDetection ?? 'Default',
     style: options.style ?? 'css',
+    flat: options.flat ?? false,
     directory,
     filePath,
     path,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When generating a component that is exported and flat=false, the import path in the NgModule is incorrect

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The import path that is generated should be correct

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16325
