### PR TITLE
feat(nextjs): add migration for Next.js 13.3.0

### DIFF
--- a/packages/next/migrations.json
+++ b/packages/next/migrations.json
@@ -307,6 +307,15 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "16.0.0": {
+      "version": "16.0.0-beta.0",
+      "packages": {
+        "next": {
+          "version": "13.3.0",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/react/plugins/storybook/index.ts
+++ b/packages/react/plugins/storybook/index.ts
@@ -116,6 +116,14 @@ export const webpack = async (
     },
     resolve: {
       ...storybookWebpackConfig.resolve,
+      fallback: {
+        ...storybookWebpackConfig.resolve?.fallback,
+        // Next.js and other React frameworks may have server-code that uses these modules.
+        // They are not meant for client-side components so skip the fallbacks.
+        assert: false,
+        path: false,
+        util: false,
+      },
       plugins: mergePlugins(
         ...((storybookWebpackConfig.resolve.plugins ??
           []) as ResolvePluginInstance[]),


### PR DESCRIPTION
This PR adds migration to bring Next.js to 13.3.0.

I also included a fix for not providing fallbacks to `util`, `path`, and `assert` modules. It look likes Next.js server code is bringing them in, but we don't need them for client components.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
