### PR TITLE
fix(react): install rollup package when generating lib

### DIFF
--- a/packages/rollup/src/generators/init/init.spec.ts
+++ b/packages/rollup/src/generators/init/init.spec.ts
@@ -52,6 +52,7 @@ describe('rollupInitGenerator', () => {
       name: expect.any(String),
       dependencies: {},
       devDependencies: {
+        '@nx/rollup': nxVersion,
         tslib: expect.any(String),
       },
     });

--- a/packages/rollup/src/generators/init/init.ts
+++ b/packages/rollup/src/generators/init/init.ts
@@ -33,7 +33,14 @@ export async function rollupInitGenerator(tree: Tree, schema: Schema) {
       }
     );
   } else {
-    task = addDependenciesToPackageJson(tree, {}, { tslib: tsLibVersion });
+    task = addDependenciesToPackageJson(
+      tree,
+      {},
+      {
+        '@nx/rollup': nxVersion,
+        tslib: tsLibVersion,
+      }
+    );
   }
 
   if (!schema.skipFormat) {


### PR DESCRIPTION
## Current Behavior

The `@nrwl/rollup` package is not getting installed when generating a buildable react library that uses the `@nrwl/rollup:rollup` executor, which results in the following error:

```
npx nx build rollib

 >  NX   Ran target build for project rollib (53ms)

    ✖    0/0 failed
    ✔    0/0 succeeded [0 read from cache]

   View logs and run details at https://nx.app/runs/785BGG9zna

 >  NX   Unable to resolve @nrwl/rollup:rollup.

   Cannot find module '@nrwl/rollup/package.json'
   Require stack:
   - /Users/katerina/Projects/nrwl/test_nx_workspaces/rolls/node_modules/nx/src/utils/package-json.js
   - /Users/katerina/Projects/nrwl/test_nx_workspaces/rolls/node_modules/nx/src/utils/package-manager.js
   - /Users/katerina/Projects/nrwl/test_nx_workspaces/rolls/node_modules/nx/bin/init-local.js
   - /Users/katerina/Projects/nrwl/test_nx_workspaces/rolls/node_modules/nx/bin/nx.js
   Pass --verbose to see the stacktrace.
```

## Expected Behavior

`@nrwl/rollup` package should get installed.

