### PR TITLE
fix(angular): fix resolve builder in ngcli adapter

### DIFF
--- a/packages/nx/src/config/workspaces.ts
+++ b/packages/nx/src/config/workspaces.ts
@@ -482,7 +482,7 @@ function findMatchingProjectInCwd(
   return matchingProject;
 }
 
-function normalizeExecutorSchema(
+export function normalizeExecutorSchema(
   schema: Partial<ExecutorConfig['schema']>
 ): ExecutorConfig['schema'] {
   const version = (schema.version ??= 1);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The ngcli adapter workspace host can resolve a Nx Devkit executor.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The ngcli adapter workspace host can only resolve a Angular Devkit builder.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
