### PR TITLE
fix(storybook): handle @nrwl packages in storybook installed check

### DIFF
--- a/packages/storybook/src/generators/migrate-7/helper-functions.ts
+++ b/packages/storybook/src/generators/migrate-7/helper-functions.ts
@@ -617,7 +617,9 @@ export function checkStorybookInstalled(packageJson): boolean {
     (packageJson.dependencies['@storybook/core-server'] ||
       packageJson.devDependencies['@storybook/core-server']) &&
     (packageJson.dependencies['@nx/storybook'] ||
-      packageJson.devDependencies['@nx/storybook'])
+      packageJson.devDependencies['@nx/storybook'] ||
+      packageJson.dependencies['@nrwl/storybook'] ||
+      packageJson.devDependencies['@nrwl/storybook'])
   );
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Storybook migration doesn't say there are storybook packages installed if `@nrwl/storybook` is installed instead of `@nx/storybook`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Storybook migration does say there are storybook packages installed if `@nrwl/storybook` OR `@nx/storybook` is installed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
