### PR TITLE
fix(core): optional dependencies should be tracked by project graph

### DIFF
--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-package-json-dependencies.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-package-json-dependencies.ts
@@ -10,6 +10,7 @@ import { getImportPath, joinPathFragments } from '../../../../utils/path';
 import { ProjectsConfigurations } from '../../../../config/workspace-json-project-json';
 import { NxJsonConfiguration } from '../../../../config/nx-json';
 import { ExplicitDependency } from './explicit-project-dependencies';
+import { PackageJson } from '../../../../utils/package-json';
 
 class ProjectGraphNodeRecords {}
 
@@ -110,10 +111,11 @@ function processPackageJson(
   }
 }
 
-function readDeps(packageJsonDeps: any) {
+function readDeps(packageJson: PackageJson) {
   return [
-    ...Object.keys(packageJsonDeps?.dependencies ?? {}),
-    ...Object.keys(packageJsonDeps?.devDependencies ?? {}),
-    ...Object.keys(packageJsonDeps?.peerDependencies ?? {}),
+    ...Object.keys(packageJson?.dependencies ?? {}),
+    ...Object.keys(packageJson?.devDependencies ?? {}),
+    ...Object.keys(packageJson?.peerDependencies ?? {}),
+    ...Object.keys(packageJson?.optionalDependencies ?? {}),
   ];
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
- projects listed under `optionalDependencies` don't have an edge drawn

## Expected Behavior
- projects listed under `optionalDependencies` have an edge drawn

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
