### PR TITLE
fix(js): update swc options so path mappings can work in all environments

### DIFF
--- a/e2e/js/src/js-swc.test.ts
+++ b/e2e/js/src/js-swc.test.ts
@@ -134,8 +134,9 @@ export function x() {
 
     // update .swcrc to use path mappings
     updateJson(`libs/${lib}/.swcrc`, (json) => {
+      json.jsc.baseUrl = '.';
       json.jsc.paths = {
-        'src/*': ['src/*'],
+        '~/*': ['./src/*'],
       };
       return json;
     });
@@ -144,7 +145,7 @@ export function x() {
     updateFile(`libs/${lib}/src/lib/${lib}.ts`, () => {
       return `
 // @ts-ignore
-import { x } from 'src/x';
+import { x } from '~/x';
 
 export function myLib() {
   console.log(x());
@@ -154,8 +155,8 @@ myLib();
   `;
     });
 
-    // now run build
-    runCLI(`build ${lib}`);
+    // now run build without type checking (since we're using path mappings not in tsconfig)
+    runCLI(`build ${lib} --skipTypeCheck`);
 
     // invoke the lib with node
     const result = execSync(`node dist/libs/${lib}/src/lib/${lib}.js`, {

--- a/packages/js/src/executors/swc/swc.impl.ts
+++ b/packages/js/src/executors/swc/swc.impl.ts
@@ -66,21 +66,7 @@ export function normalizeOptions(
   // default to current directory if projectRootParts is [].
   // Eg: when a project is at the root level, outside of layout dir
   const swcCwd = projectRootParts.join('/') || '.';
-  let swcrcPath = getSwcrcPath(options, contextRoot, projectRoot);
-
-  try {
-    const swcrcContent = readJsonFile(swcrcPath) as Options;
-    // if we have path mappings setup but baseUrl isn't specified, then we're proceeding with the following logic
-    if (
-      swcrcContent.jsc &&
-      swcrcContent.jsc.paths &&
-      !swcrcContent.jsc.baseUrl
-    ) {
-      swcrcContent.jsc.baseUrl = `./${projectDir}`;
-      swcrcPath = getSwcrcPath(options, contextRoot, projectRoot, true);
-      writeJsonFile(swcrcPath, swcrcContent);
-    }
-  } catch (e) {}
+  const swcrcPath = getSwcrcPath(options, contextRoot, projectRoot);
 
   const swcCliOptions = {
     srcPath: projectDir,

--- a/packages/js/src/utils/swc/compile-swc.ts
+++ b/packages/js/src/utils/swc/compile-swc.ts
@@ -10,7 +10,7 @@ function getSwcCmd(
   { swcrcPath, srcPath, destPath }: SwcCliOptions,
   watch = false
 ) {
-  let swcCmd = `npx swc ${srcPath} -d ${destPath} --no-swcrc --config-file=${swcrcPath}`;
+  let swcCmd = `npx swc ${srcPath} -d ${destPath} --config-file=${swcrcPath}`;
   return watch ? swcCmd.concat(' --watch') : swcCmd;
 }
 

--- a/packages/js/src/utils/swc/get-swcrc-path.ts
+++ b/packages/js/src/utils/swc/get-swcrc-path.ts
@@ -4,14 +4,9 @@ import { SwcExecutorOptions } from '../schema';
 export function getSwcrcPath(
   options: SwcExecutorOptions,
   contextRoot: string,
-  projectRoot: string,
-  temp = false
+  projectRoot: string
 ) {
-  let swcrcPath = options.swcrc ?? join(projectRoot, '.swcrc');
-
-  if (temp) {
-    swcrcPath = join('tmp', swcrcPath.replace('.swcrc', '.generated.swcrc'));
-  }
-
-  return join(contextRoot, swcrcPath);
+  return options.swcrc
+    ? join(contextRoot, options.swcrc)
+    : join(contextRoot, projectRoot, '.swcrc');
 }


### PR DESCRIPTION
This PR updates `@nx/js:swc` executor so it properly compiles with `jsc.paths` set in `.swcrc` for all environments. Another PR is failing because the compiled code has wrong path mapping. https://github.com/nrwl/nx/pull/16284

**Details:**
1. It looks like we're setting `jsc.baseUrl` with the wrong default. It should be `.` since `cwd` is set to the project root. That way, when mappings are used in output, it will be relative to the project root. Removing that whole logic and relying on users to set `baseUrl` seems more reliable. Also with local testing (macos, debian) it doesn't look like `baseUrl` is needed by swc at all (at least on latest version).
2. Passing both `--no-swc` and `--config-file` together is causing wrong paths in output as well for some reason (able to replicate this in CI with just `npx swc` and not Nx, but not locally). Since we're passing the config file anyway, we don't need the `--no-swc` option to find the file.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
