### PR TITLE
fix(core): do not expect each package to have hoisted version in lockfile

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/project-graph-pruning.ts
+++ b/packages/nx/src/plugins/js/lock-file/project-graph-pruning.ts
@@ -85,6 +85,7 @@ function findNodeMatchingVersion(
     return nodes.sort((a, b) => +gte(b.data.version, a.data.version))[0];
   }
   if (
+    graph.externalNodes[`npm:${packageName}`] &&
     satisfies(
       graph.externalNodes[`npm:${packageName}`].data.version,
       versionExpr


### PR DESCRIPTION
Package managers like `pnpm` or `yarn berry` might not have a hoisted version of each package, so attempting to get hoisted version might fail.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16097 
