### PR TITLE
feat(testing): export cypressE2EConfigurationGenerator

### DIFF
--- a/packages/cypress/index.ts
+++ b/packages/cypress/index.ts
@@ -3,3 +3,4 @@ export { cypressInitGenerator } from './src/generators/init/init';
 export { conversionGenerator } from './src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint';
 export { cypressComponentProject } from './src/generators/cypress-component-project/cypress-component-project';
 export { migrateCypressProject } from './src/generators/migrate-to-cypress-11/migrate-to-cypress-11';
+export { cypressE2EConfigurationGenerator } from './src/generators/cypress-e2e-configuration/cypress-e2e-configuration';


### PR DESCRIPTION
cypressProjectGenerator is deprecated with a hint on cypressE2EConfigurationGenerator. cypressE2EConfigurationGenerator isn't exported yet

## Current Behavior
cypressE2EConfigurationGenerator isn't exported

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
