### PR TITLE
fix(angular): schematics warning should only occur when run as schematic

### DIFF
--- a/packages/angular/generators.json
+++ b/packages/angular/generators.json
@@ -40,7 +40,7 @@
       "description": "Creates a cypress component test file for a component."
     },
     "convert-tslint-to-eslint": {
-      "factory": "./src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint#conversionSchematic",
+      "factory": "./src/generators/convert-tslint-to-eslint/compat",
       "schema": "./src/generators/convert-tslint-to-eslint/schema.json",
       "description": "Converts a project from TSLint to ESLint."
     },
@@ -70,7 +70,7 @@
       "description": "Generate a Remote Angular Module Federation Application."
     },
     "move": {
-      "factory": "./src/generators/move/move#angularMoveSchematic",
+      "factory": "./src/generators/move/compat",
       "schema": "./src/generators/move/schema.json",
       "aliases": ["mv"],
       "description": "Moves an Angular application or library to another folder within the workspace and updates the project configuration."

--- a/packages/angular/src/generators/convert-tslint-to-eslint/compat.ts
+++ b/packages/angular/src/generators/convert-tslint-to-eslint/compat.ts
@@ -1,0 +1,7 @@
+import { convertNxGenerator } from '@nx/devkit';
+import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
+import { conversionGenerator } from './convert-tslint-to-eslint';
+
+export const conversionSchematic = warnForSchematicUsage(
+  convertNxGenerator(conversionGenerator)
+);

--- a/packages/angular/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
+++ b/packages/angular/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.ts
@@ -1,16 +1,9 @@
 import { conversionGenerator as cypressConversionGenerator } from '@nx/cypress';
-import {
-  convertNxGenerator,
-  formatFiles,
-  GeneratorCallback,
-  logger,
-  Tree,
-} from '@nx/devkit';
+import { formatFiles, GeneratorCallback, logger, Tree } from '@nx/devkit';
 import { ConvertTSLintToESLintSchema, ProjectConverter } from '@nx/linter';
 import type { Linter } from 'eslint';
 import type { AngularProjectConfiguration } from '../../utils/types';
 import { addLintingGenerator } from '../add-linting/add-linting';
-import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
 
 export async function conversionGenerator(
   host: Tree,
@@ -138,10 +131,6 @@ export async function conversionGenerator(
     await uninstallTSLintTask();
   };
 }
-
-export const conversionSchematic = warnForSchematicUsage(
-  convertNxGenerator(conversionGenerator)
-);
 
 /**
  * In the case of Angular lint rules, we need to apply them to correct override depending upon whether

--- a/packages/angular/src/generators/move/compat.ts
+++ b/packages/angular/src/generators/move/compat.ts
@@ -1,0 +1,7 @@
+import { convertNxGenerator } from '@nx/devkit';
+import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
+import { angularMoveGenerator } from './move';
+
+export const angularMoveSchematic = warnForSchematicUsage(
+  convertNxGenerator(angularMoveGenerator)
+);

--- a/packages/angular/src/generators/move/move.ts
+++ b/packages/angular/src/generators/move/move.ts
@@ -1,5 +1,4 @@
-import { convertNxGenerator, formatFiles, Tree } from '@nx/devkit';
-import { warnForSchematicUsage } from '../utils/warn-for-schematic-usage';
+import { formatFiles, Tree } from '@nx/devkit';
 import { moveGenerator } from '@nx/workspace/generators';
 import { updateModuleName } from './lib/update-module-name';
 import { updateNgPackage } from './lib/update-ng-package';
@@ -24,7 +23,3 @@ export async function angularMoveGenerator(
     await formatFiles(tree);
   }
 }
-
-export const angularMoveSchematic = warnForSchematicUsage(
-  convertNxGenerator(angularMoveGenerator)
-);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Some generators have their schematic compat versions in the same file as the generator.
Therefore, when running a generator as a generator, when the file is required, the warning for schematic usage will still be printed.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Only print the schematic warning when used as a schematic

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
