### PR TITLE
fix(misc): handle packages rescope in nx init flows

### DIFF
--- a/e2e/nx-init/src/nx-init-react.test.ts
+++ b/e2e/nx-init/src/nx-init-react.test.ts
@@ -37,18 +37,9 @@ describe('nx init (for React)', () => {
     expect(craToNxOutput).toContain('🎉 Done!');
 
     const packageJson = readJson('package.json');
-    expect(
-      packageJson.devDependencies['@nrwl/jest'] ||
-        packageJson.devDependencies['@nx/jest']
-    ).toBeDefined();
-    expect(
-      packageJson.devDependencies['@nrwl/vite'] ||
-        packageJson.devDependencies['@nx/vite']
-    ).toBeUndefined();
-    expect(
-      packageJson.devDependencies['@nrwl/webpack'] ||
-        packageJson.devDependencies['@nx/webpack']
-    ).toBeDefined();
+    expect(packageJson.devDependencies['@nx/jest']).toBeDefined();
+    expect(packageJson.devDependencies['@nx/vite']).toBeUndefined();
+    expect(packageJson.devDependencies['@nx/webpack']).toBeDefined();
 
     runCLI(`build ${appName}`, {
       env: {
@@ -77,18 +68,9 @@ describe('nx init (for React)', () => {
     expect(craToNxOutput).toContain('🎉 Done!');
 
     const packageJson = readJson('package.json');
-    expect(
-      packageJson.devDependencies['@nrwl/jest'] ||
-        packageJson.devDependencies['@nx/jest']
-    ).toBeUndefined();
-    expect(
-      packageJson.devDependencies['@nrwl/vite'] ||
-        packageJson.devDependencies['@nx/vite']
-    ).toBeDefined();
-    expect(
-      packageJson.devDependencies['@nrwl/webpack'] ||
-        packageJson.devDependencies['@nx/webpack']
-    ).toBeUndefined();
+    expect(packageJson.devDependencies['@nx/jest']).toBeUndefined();
+    expect(packageJson.devDependencies['@nx/vite']).toBeDefined();
+    expect(packageJson.devDependencies['@nx/webpack']).toBeUndefined();
 
     const viteConfig = readFile(`apps/${appName}/vite.config.js`);
     expect(viteConfig).toContain('port: 4200'); // default port
@@ -166,7 +148,7 @@ describe('nx init (for React)', () => {
     );
 
     const packageJson = readJson('package.json');
-    expect(packageJson.devDependencies['@nrwl/jest']).toBeUndefined();
+    expect(packageJson.devDependencies['@nx/jest']).toBeUndefined();
 
     const viteConfig = readFile(`vite.config.js`);
     expect(viteConfig).toContain('port: 4200'); // default port

--- a/packages/nx/src/nx-init/angular/legacy-angular-versions.ts
+++ b/packages/nx/src/nx-init/angular/legacy-angular-versions.ts
@@ -20,8 +20,8 @@ const nxAngularLegacyVersionMap: Record<number, string> = {};
 const minMajorAngularVersionSupported = 14;
 // version when the Nx CLI changed from @nrwl/tao & @nrwl/cli to nx
 const versionWithConsolidatedPackages = '13.9.0';
-// version when packages were reescoped from @nrwl/* to @nx/*
-const versionWithReescopeToNx = '16.0.0-beta.2';
+// version when packages were rescoped from @nrwl/* to @nx/*
+const versionWithRescopeToNx = '16.0.0-beta.2';
 
 export async function getLegacyMigrationFunctionIfApplicable(
   repoRoot: string,
@@ -71,7 +71,7 @@ export async function getLegacyMigrationFunctionIfApplicable(
       nxAngularLegacyVersionMap[majorAngularVersion]
     );
 
-    pkgScope = gte(pkgVersion, versionWithReescopeToNx) ? '@nx' : '@nrwl';
+    pkgScope = gte(pkgVersion, versionWithRescopeToNx) ? '@nx' : '@nrwl';
     unscopedPkgName = 'angular';
     pkgName = `${pkgScope}/${unscopedPkgName}`;
 

--- a/packages/nx/src/nx-init/angular/legacy-angular-versions.ts
+++ b/packages/nx/src/nx-init/angular/legacy-angular-versions.ts
@@ -20,6 +20,8 @@ const nxAngularLegacyVersionMap: Record<number, string> = {};
 const minMajorAngularVersionSupported = 14;
 // version when the Nx CLI changed from @nrwl/tao & @nrwl/cli to nx
 const versionWithConsolidatedPackages = '13.9.0';
+// version when packages were reescoped from @nrwl/* to @nx/*
+const versionWithReescopeToNx = '16.0.0-beta.2';
 
 export async function getLegacyMigrationFunctionIfApplicable(
   repoRoot: string,
@@ -36,10 +38,14 @@ export async function getLegacyMigrationFunctionIfApplicable(
 
   let legacyMigrationCommand: string;
   let pkgName: string;
+  let unscopedPkgName: string;
+  let pkgScope: string;
   let pkgVersion: string;
   if (majorAngularVersion < 13) {
     // for versions lower than 13, the migration was in @nrwl/workspace:ng-add
-    pkgName = '@nrwl/workspace';
+    pkgScope = '@nrwl';
+    unscopedPkgName = 'workspace';
+    pkgName = `${pkgScope}/${unscopedPkgName}`;
     pkgVersion = await resolvePackageVersion(
       pkgName,
       `^${majorAngularVersion}.0.0`
@@ -50,7 +56,9 @@ export async function getLegacyMigrationFunctionIfApplicable(
     legacyMigrationCommand = `ng g ${pkgName}:ng-add ${preserveAngularCliLayoutFlag}`;
   } else if (majorAngularVersion < 14) {
     // for v13, the migration was in @nrwl/angular:ng-add
-    pkgName = '@nrwl/angular';
+    pkgScope = '@nrwl';
+    unscopedPkgName = 'angular';
+    pkgName = `${pkgScope}/${unscopedPkgName}`;
     pkgVersion = await resolvePackageVersion(pkgName, '~14.1.0');
     const preserveAngularCliLayoutFlag = !isIntegratedMigration
       ? '--preserve-angular-cli-layout'
@@ -58,11 +66,15 @@ export async function getLegacyMigrationFunctionIfApplicable(
     legacyMigrationCommand = `ng g ${pkgName}:ng-add ${preserveAngularCliLayoutFlag}`;
   } else {
     // use the latest Nx version that supported the Angular version
-    pkgName = '@nrwl/angular';
     pkgVersion = await resolvePackageVersion(
       'nx',
       nxAngularLegacyVersionMap[majorAngularVersion]
     );
+
+    pkgScope = gte(pkgVersion, versionWithReescopeToNx) ? '@nx' : '@nrwl';
+    unscopedPkgName = 'angular';
+    pkgName = `${pkgScope}/${unscopedPkgName}`;
+
     legacyMigrationCommand = `nx@${pkgVersion} init ${process.argv
       .slice(2)
       .join(' ')}`;
@@ -74,7 +86,17 @@ export async function getLegacyMigrationFunctionIfApplicable(
 
     output.log({ title: '📦 Installing dependencies' });
     const pmc = getPackageManagerCommand();
-    await installDependencies(repoRoot, pkgName, pkgVersion, useNxCloud, pmc);
+    await installDependencies(
+      repoRoot,
+      {
+        pkgName,
+        pkgScope,
+        pkgVersion,
+        unscopedPkgName,
+      },
+      useNxCloud,
+      pmc
+    );
 
     output.log({ title: '📝 Setting up workspace' });
     execSync(`${pmc.exec} ${legacyMigrationCommand}`, { stdio: [0, 1, 2] });
@@ -95,21 +117,25 @@ export async function getLegacyMigrationFunctionIfApplicable(
 
 async function installDependencies(
   repoRoot: string,
-  pkgName: string,
-  pkgVersion: string,
+  pkgInfo: {
+    pkgName: string;
+    pkgScope: string;
+    pkgVersion: string;
+    unscopedPkgName: string;
+  },
   useNxCloud: boolean,
   pmc: PackageManagerCommands
 ): Promise<void> {
   const json = readJsonFile(join(repoRoot, 'package.json'));
 
   json.devDependencies ??= {};
-  json.devDependencies['@nrwl/workspace'] = pkgVersion;
+  json.devDependencies[`${pkgInfo.pkgScope}/workspace`] = pkgInfo.pkgVersion;
 
-  if (gte(pkgVersion, versionWithConsolidatedPackages)) {
-    json.devDependencies['nx'] = pkgVersion;
+  if (gte(pkgInfo.pkgVersion, versionWithConsolidatedPackages)) {
+    json.devDependencies['nx'] = pkgInfo.pkgVersion;
   } else {
-    json.devDependencies['@nrwl/cli'] = pkgVersion;
-    json.devDependencies['@nrwl/tao'] = pkgVersion;
+    json.devDependencies[`${pkgInfo.pkgScope}/cli`] = pkgInfo.pkgVersion;
+    json.devDependencies[`${pkgInfo.pkgScope}/tao`] = pkgInfo.pkgVersion;
   }
 
   if (useNxCloud) {
@@ -117,14 +143,14 @@ async function installDependencies(
     // version being installed
     json.devDependencies['nx-cloud'] = await resolvePackageVersion(
       'nx-cloud',
-      `^${major(pkgVersion)}.0.0`
+      `^${major(pkgInfo.pkgVersion)}.0.0`
     );
   }
   json.devDependencies = sortObjectByKeys(json.devDependencies);
 
-  if (pkgName === '@nrwl/angular') {
+  if (pkgInfo.unscopedPkgName === 'angular') {
     json.dependencies ??= {};
-    json.dependencies['@nrwl/angular'] = pkgVersion;
+    json.dependencies[pkgInfo.pkgName] = pkgInfo.pkgVersion;
     json.dependencies = sortObjectByKeys(json.dependencies);
   }
   writeJsonFile(`package.json`, json);

--- a/packages/nx/src/nx-init/react/index.ts
+++ b/packages/nx/src/nx-init/react/index.ts
@@ -317,13 +317,7 @@ function cleanUpUnusedFilesAndAddConfigFiles(options: NormalizedOptions) {
     setupE2eProject(options.reactAppName);
   } else {
     removeSync(join('apps', `${options.reactAppName}-e2e`));
-    const packageJson = readJsonFile('package.json');
-    const cypressPkgName =
-      packageJson.devDependencies?.['@nrwl/cypress'] ||
-      packageJson.dependencies?.['@nrwl/cypress']
-        ? '@nrwl/cypress'
-        : '@nx/cypress';
-    execSync(`${options.pmc.rm} ${cypressPkgName} eslint-plugin-cypress`);
+    execSync(`${options.pmc.rm} @nx/cypress eslint-plugin-cypress`);
   }
 
   if (options.isStandalone) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Some `nx init` flows reference the `@nrwl` scope and don't handle the new `@nx` scope. The E2E tests for the CRA flow check the presence of the packages with the old scopes.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `nx init` flows reference the new `@nx` scope and handle the old one where needed (e.g. for Angular CLI legacy versions). The E2E tests for the CRA flow only check the presence of the packages with the new scopes.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
