### PR TITLE
fix(storybook): do not override existing v7 on init

### DIFF
--- a/packages/storybook/src/generators/init/init.ts
+++ b/packages/storybook/src/generators/init/init.ts
@@ -30,6 +30,11 @@ import {
   webpack5Version,
 } from '../../utils/versions';
 import { Schema } from './schema';
+import {
+  getInstalledStorybookVersion,
+  storybookMajorVersion,
+} from '../../utils/utilities';
+import { gte } from 'semver';
 
 function checkDependenciesInstalled(host: Tree, schema: Schema) {
   const packageJson = readJson(host, 'package.json');
@@ -43,6 +48,15 @@ function checkDependenciesInstalled(host: Tree, schema: Schema) {
   devDependencies['@nx/storybook'] = nxVersion;
 
   if (schema.storybook7Configuration) {
+    let storybook7VersionToInstall = storybook7Version;
+    if (
+      storybookMajorVersion() === 7 &&
+      getInstalledStorybookVersion() &&
+      gte(getInstalledStorybookVersion(), '7.0.0')
+    ) {
+      storybook7VersionToInstall = getInstalledStorybookVersion();
+    }
+
     // Needed for Storybook 7
     // https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#react-peer-dependencies-required
     if (
@@ -61,10 +75,10 @@ function checkDependenciesInstalled(host: Tree, schema: Schema) {
     if (schema.uiFramework === '@storybook/react-native') {
       devDependencies['@storybook/react-native'] = storybookReactNativeVersion;
     } else {
-      devDependencies[schema.uiFramework] = storybook7Version;
+      devDependencies[schema.uiFramework] = storybook7VersionToInstall;
     }
-    devDependencies['@storybook/core-server'] = storybook7Version;
-    devDependencies['@storybook/addon-essentials'] = storybook7Version;
+    devDependencies['@storybook/core-server'] = storybook7VersionToInstall;
+    devDependencies['@storybook/addon-essentials'] = storybook7VersionToInstall;
 
     if (schema.uiFramework === '@storybook/angular') {
       if (

--- a/packages/storybook/src/utils/utilities.ts
+++ b/packages/storybook/src/utils/utilities.ts
@@ -63,6 +63,18 @@ export function storybookMajorVersion(): number | undefined {
   }
 }
 
+export function getInstalledStorybookVersion(): string | undefined {
+  try {
+    const storybookPackageVersion = require(join(
+      '@storybook/core-server',
+      'package.json'
+    )).version;
+    return storybookPackageVersion;
+  } catch {
+    return undefined;
+  }
+}
+
 export function safeFileDelete(tree: Tree, path: string): boolean {
   if (tree.exists(path)) {
     tree.delete(path);


### PR DESCRIPTION
Fixes part of: https://github.com/nrwl/nx/issues/16395

Use existing version of Storybook, if it's greater than `7.0.0`.