### PR TITLE
feat(react): add @nx/web as a dependency since it is needed by cypress/etc.

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -38,7 +38,8 @@
     "minimatch": "3.0.5",
     "@nx/devkit": "file:../devkit",
     "@nx/js": "file:../js",
-    "@nx/linter": "file:../linter"
+    "@nx/linter": "file:../linter",
+    "@nx/web": "file:../web"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react/src/generators/application/lib/add-cypress.ts
+++ b/packages/react/src/generators/application/lib/add-cypress.ts
@@ -1,4 +1,5 @@
-import { ensurePackage, joinPathFragments, Tree } from '@nx/devkit';
+import { ensurePackage, Tree } from '@nx/devkit';
+import { webStaticServeGenerator } from '@nx/web';
 import { nxVersion } from '../../../utils/versions';
 import { NormalizedSchema } from '../schema';
 
@@ -7,7 +8,6 @@ export async function addCypress(host: Tree, options: NormalizedSchema) {
     return () => {};
   }
 
-  const { webStaticServeGenerator } = ensurePackage('@nx/web', nxVersion);
   await webStaticServeGenerator(host, {
     buildTarget: `${options.projectName}:build`,
     targetName: 'serve-static',


### PR DESCRIPTION
We previously removed `@nrwl/web` as a dependency since it added webpack and other packages that may not be needed. Now that webpack and jest are no longer installed by default, we can add it back in.

## Why?

Other optional packages such as `@nx/cypress` pulls in the web package, so having it installed as a dependency initially saves time. Also, `@nx/web:file-server` is used in certain setups in React, such as module federation.