### PR TITLE
fix(storybook): dont use swc addon on sb7 and format

### DIFF
--- a/packages/react/src/generators/storybook-configuration/configuration.ts
+++ b/packages/react/src/generators/storybook-configuration/configuration.ts
@@ -3,6 +3,7 @@ import storiesGenerator from '../stories/stories';
 import {
   convertNxGenerator,
   ensurePackage,
+  formatFiles,
   logger,
   readProjectConfiguration,
   Tree,
@@ -77,6 +78,8 @@ export async function storybookConfigurationGenerator(
   if (schema.generateStories) {
     await generateStories(host, schema);
   }
+
+  await formatFiles(host);
 
   return installTask;
 }

--- a/packages/storybook/src/generators/configuration/__snapshots__/configuration-v7.spec.ts.snap
+++ b/packages/storybook/src/generators/configuration/__snapshots__/configuration-v7.spec.ts.snap
@@ -360,11 +360,7 @@ exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configu
 exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/react-swc/.storybook/" 1`] = `
 "const config = {
   stories: ['../src/app/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
-  addons: [
-    '@storybook/addon-essentials',
-    '@nx/react/plugins/storybook',
-    'storybook-addon-swc',
-  ],
+  addons: ['@storybook/addon-essentials', '@nx/react/plugins/storybook'],
   framework: {
     name: '@storybook/react-webpack5',
     options: {},

--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -255,7 +255,7 @@ export async function configurationGenerator(
   if (nextBuildTarget && projectType === 'application' && !storybook7) {
     devDeps['storybook-addon-next'] = storybookNextAddonVersion;
     devDeps['storybook-addon-swc'] = storybookSwcAddonVersion;
-  } else if (compiler === 'swc') {
+  } else if (compiler === 'swc' && !storybook7) {
     devDeps['storybook-addon-swc'] = storybookSwcAddonVersion;
   }
 

--- a/packages/storybook/src/generators/configuration/project-files-7-ts/.storybook/main.ts__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files-7-ts/.storybook/main.ts__tmpl__
@@ -6,9 +6,7 @@ const config: StorybookConfig = {
     '../**/*.stories.@(js|jsx|ts|tsx|mdx)' <% } else { %>
     '../<%= projectDirectory %>/**/*.stories.@(js|jsx|ts|tsx|mdx)'
   <% } %>],
-  addons: ['@storybook/addon-essentials' <% if(uiFramework === '@storybook/react-webpack5') { %>, '@nx/react/plugins/storybook' <% } %><% if(uiFramework === '@storybook/react-native') { %>, '@storybook/addon-ondevice-actions',  '@storybook/addon-ondevice-backgrounds', '@storybook/addon-ondevice-controls', '@storybook/addon-ondevice-notes'  <% } %>
-    <% if(usesSwc) { %>, 'storybook-addon-swc' <% } %>
-  ],
+  addons: ['@storybook/addon-essentials' <% if(uiFramework === '@storybook/react-webpack5') { %>, '@nx/react/plugins/storybook' <% } %><% if(uiFramework === '@storybook/react-native') { %>, '@storybook/addon-ondevice-actions',  '@storybook/addon-ondevice-backgrounds', '@storybook/addon-ondevice-controls', '@storybook/addon-ondevice-notes'  <% } %>],
   framework: {
     name: '<%= uiFramework %>',
     options: {

--- a/packages/storybook/src/generators/configuration/project-files-7/.storybook/main.js__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files-7/.storybook/main.js__tmpl__
@@ -4,9 +4,7 @@ const config = {
     '../**/*.stories.@(js|jsx|ts|tsx|mdx)' <% } else { %>
     '../<%= projectDirectory %>/**/*.stories.@(js|jsx|ts|tsx|mdx)'
   <% } %>],
-  addons: ['@storybook/addon-essentials' <% if(uiFramework === '@storybook/react-webpack5') { %>, '@nx/react/plugins/storybook' <% } %><% if(uiFramework === '@storybook/react-native') { %>, '@storybook/addon-ondevice-actions',  '@storybook/addon-ondevice-backgrounds', '@storybook/addon-ondevice-controls', '@storybook/addon-ondevice-notes'  <% } %>
-    <% if(usesSwc) { %>, 'storybook-addon-swc' <% } %>
-  ],
+  addons: ['@storybook/addon-essentials' <% if(uiFramework === '@storybook/react-webpack5') { %>, '@nx/react/plugins/storybook' <% } %><% if(uiFramework === '@storybook/react-native') { %>, '@storybook/addon-ondevice-actions',  '@storybook/addon-ondevice-backgrounds', '@storybook/addon-ondevice-controls', '@storybook/addon-ondevice-notes'  <% } %>],
   framework: {
     name: '<%= uiFramework %>',
     options: {


### PR DESCRIPTION
Do not use the `storybook-addon-swc` for Storybook v7 since it's no longer needed.

Also, format files when generating React sb config.