### PR TITLE
fix(testing): nullcheck polyfills in ng component testing

### DIFF
--- a/packages/angular/plugins/component-testing.ts
+++ b/packages/angular/plugins/component-testing.ts
@@ -200,10 +200,15 @@ function normalizeBuildTargetOptions(
       return polyfill;
     };
     // paths need to be unix paths for angular devkit
-    buildOptions.polyfills =
-      Array.isArray(buildOptions.polyfills) && buildOptions.polyfills.length > 0
-        ? (buildOptions.polyfills as string[]).map((p) => handlePolyfillPath(p))
-        : handlePolyfillPath(buildOptions.polyfills as string);
+    if (buildOptions.polyfills) {
+      buildOptions.polyfills =
+        Array.isArray(buildOptions.polyfills) &&
+        buildOptions.polyfills.length > 0
+          ? (buildOptions.polyfills as string[]).map((p) =>
+              handlePolyfillPath(p)
+            )
+          : handlePolyfillPath(buildOptions.polyfills as string);
+    }
     buildOptions.main = joinPathFragments(offset, buildOptions.main);
     buildOptions.index =
       typeof buildOptions.index === 'string'


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
polyfills is an optional executor option but ng CT throws trying to read it's path

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
polyfills shouldn't cause ng ct to error

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #12114
