### PR TITLE
fix(core): fix devkit compatibility

### DIFF
--- a/packages/nx/src/utils/typescript.ts
+++ b/packages/nx/src/utils/typescript.ts
@@ -1,0 +1,3 @@
+// TODO(v18): Nx Devkit 15 depends on this file. Remove this when we no longer support Nx Devkit 15
+
+export * from '../plugins/js/utils/typescript';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`nx/src/utils/typescript` is imported from devkit here: https://github.com/nrwl/nx/blob/0d7dbbc5254390f53a28d94de536da916ed06a70/packages/devkit/src/utils/module-federation/share.ts#L15

This breaks plugins that use devkit with later versions of nx

```
Executing: NX_MIGRATE_USE_NEXT=true nx migrate --run-migrations --verbose --if-exists && yarn local-registry enable && rm migrations.json && git checkout "packages/*/src/**/*" && git commit -am "chore(repo): run migrations"

 >  NX   Its time to update Nx 🎉

   Your repository uses a higher version of Nx (16.0.0-beta.3) than your global CLI version (15.9.2)
   For more information, see https://nx.dev/more-concepts/global-nx


 >  NX   Running 'yarn' to make sure necessary packages are installed

yarn install v1.22.19
$ node ./scripts/preinstall.js
[1/4] Resolving packages...
success Already up-to-date.
$ is-ci || husky install
husky - Git hooks installed
Done in 1.14s.
yarn run v1.22.19
$ /home/jason/projects/nx2/node_modules/.bin/nx migrate --run-migrations --verbose --if-exists
$ /home/jason/projects/nx2/node_modules/.bin/nx _migrate --run-migrations --verbose --if-exists

 >  NX   Running migrations from 'migrations.json'


 >  NX   Failed to run update-16-0-0-add-nx-packages from @nrwl/devkit. This workspace is NOT up to date!


 >  NX   Cannot find module 'nx/src/utils/typescript'

   Require stack:
   - /home/jason/projects/nx2/node_modules/@monodon/rust/node_modules/@nrwl/devkit/src/utils/module-federation/typescript.js
   - /home/jason/projects/nx2/node_modules/@monodon/rust/node_modules/@nrwl/devkit/src/utils/module-federation/share.js
   - /home/jason/projects/nx2/node_modules/@monodon/rust/node_modules/@nrwl/devkit/src/utils/module-federation/index.js
   - /home/jason/projects/nx2/node_modules/@monodon/rust/node_modules/@nrwl/devkit/public-api.js
   - /home/jason/projects/nx2/node_modules/@monodon/rust/node_modules/@nrwl/devkit/index.js
   - /home/jason/projects/nx2/node_modules/@monodon/rust/src/graph.js
   - /home/jason/projects/nx2/node_modules/@monodon/rust/src/index.js
   - /home/jason/projects/nx2/node_modules/nx/src/utils/nx-plugin.js
   - /home/jason/projects/nx2/node_modules/nx/src/config/workspaces.js
   - /home/jason/projects/nx2/node_modules/nx/src/config/configuration.js
   - /home/jason/projects/nx2/node_modules/nx/src/command-line/connect.js
   - /home/jason/projects/nx2/node_modules/nx/src/command-line/migrate.js
   - /home/jason/projects/nx2/node_modules/nx/src/command-line/nx-commands.js
   - /home/jason/projects/nx2/node_modules/nx/bin/init-local.js
   - /home/jason/projects/nx2/node_modules/nx/bin/nx.js

Error: Cannot find module 'nx/src/utils/typescript'
Require stack:
- /home/jason/projects/nx2/node_modules/@monodon/rust/node_modules/@nrwl/devkit/src/utils/module-federation/typescript.js
- /home/jason/projects/nx2/node_modules/@monodon/rust/node_modules/@nrwl/devkit/src/utils/module-federation/share.js
- /home/jason/projects/nx2/node_modules/@monodon/rust/node_modules/@nrwl/devkit/src/utils/module-federation/index.js
- /home/jason/projects/nx2/node_modules/@monodon/rust/node_modules/@nrwl/devkit/public-api.js
- /home/jason/projects/nx2/node_modules/@monodon/rust/node_modules/@nrwl/devkit/index.js
- /home/jason/projects/nx2/node_modules/@monodon/rust/src/graph.js
- /home/jason/projects/nx2/node_modules/@monodon/rust/src/index.js
- /home/jason/projects/nx2/node_modules/nx/src/utils/nx-plugin.js
- /home/jason/projects/nx2/node_modules/nx/src/config/workspaces.js
- /home/jason/projects/nx2/node_modules/nx/src/config/configuration.js
- /home/jason/projects/nx2/node_modules/nx/src/command-line/connect.js
- /home/jason/projects/nx2/node_modules/nx/src/command-line/migrate.js
- /home/jason/projects/nx2/node_modules/nx/src/command-line/nx-commands.js
- /home/jason/projects/nx2/node_modules/nx/bin/init-local.js
- /home/jason/projects/nx2/node_modules/nx/bin/nx.js

```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `nx/src/utils/typescript.ts` file re-exports from `nx/src/plugins/js/utils/typescript`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
