### PR TITLE
fix(misc): pass e2eTestRunner to child preset generator

### DIFF
--- a/docs/generated/packages/workspace/generators/new.json
+++ b/docs/generated/packages/workspace/generators/new.json
@@ -73,6 +73,11 @@
         "description": "Enable experimental app directory for the project",
         "type": "boolean",
         "default": false
+      },
+      "e2eTestRunner": {
+        "description": "The tool to use for running e2e tests.",
+        "type": "string",
+        "enum": ["cypress", "jest", "detox", "none"]
       }
     },
     "additionalProperties": true,

--- a/docs/generated/packages/workspace/generators/preset.json
+++ b/docs/generated/packages/workspace/generators/preset.json
@@ -85,6 +85,11 @@
         "description": "Enable experimental app/ for the project",
         "type": "boolean",
         "default": false
+      },
+      "e2eTestRunner": {
+        "description": "The tool to use for running e2e tests.",
+        "type": "string",
+        "enum": ["cypress", "jest", "detox", "none"]
       }
     },
     "presets": []

--- a/packages/workspace/src/generators/new/generate-preset.ts
+++ b/packages/workspace/src/generators/new/generate-preset.ts
@@ -84,6 +84,9 @@ export function generatePreset(host: Tree, opts: NormalizedSchema) {
         : null,
       parsedArgs.interactive ? '--interactive=true' : '--interactive=false',
       opts.routing !== undefined ? `--routing=${opts.routing}` : null,
+      opts.e2eTestRunner !== undefined
+        ? `--e2eTestRunner=${opts.e2eTestRunner}`
+        : null,
     ].filter((e) => !!e);
   }
 }
@@ -92,6 +95,7 @@ function getPresetDependencies({
   preset,
   presetVersion,
   bundler,
+  e2eTestRunner,
 }: NormalizedSchema) {
   switch (preset) {
     case Preset.TS:
@@ -126,7 +130,7 @@ function getPresetDependencies({
         dependencies: {},
         dev: {
           '@nx/react': nxVersion,
-          '@nx/cypress': nxVersion,
+          '@nx/cypress': e2eTestRunner !== 'none' ? nxVersion : undefined,
           '@nx/jest': bundler !== 'vite' ? nxVersion : undefined,
           '@nx/vite': bundler === 'vite' ? nxVersion : undefined,
           '@nx/webpack': bundler === 'webpack' ? nxVersion : undefined,

--- a/packages/workspace/src/generators/new/new.ts
+++ b/packages/workspace/src/generators/new/new.ts
@@ -30,6 +30,7 @@ interface Schema {
   standaloneApi?: boolean;
   routing?: boolean;
   packageManager?: PackageManager;
+  e2eTestRunner?: 'cypress' | 'detox' | 'jest' | 'none';
 }
 
 export interface NormalizedSchema extends Schema {

--- a/packages/workspace/src/generators/new/schema.json
+++ b/packages/workspace/src/generators/new/schema.json
@@ -76,6 +76,11 @@
       "description": "Enable experimental app directory for the project",
       "type": "boolean",
       "default": false
+    },
+    "e2eTestRunner": {
+      "description": "The tool to use for running e2e tests.",
+      "type": "string",
+      "enum": ["cypress", "jest", "detox", "none"]
     }
   },
   "additionalProperties": true

--- a/packages/workspace/src/generators/preset/preset.ts
+++ b/packages/workspace/src/generators/preset/preset.ts
@@ -33,6 +33,7 @@ async function createPreset(tree: Tree, options: Schema) {
       linter: options.linter,
       standalone: options.standaloneApi,
       routing: options.routing,
+      e2eTestRunner: options.e2eTestRunner,
     });
   } else if (options.preset === Preset.AngularStandalone) {
     const {
@@ -46,6 +47,7 @@ async function createPreset(tree: Tree, options: Schema) {
       routing: options.routing,
       rootProject: true,
       standalone: options.standaloneApi,
+      e2eTestRunner: options.e2eTestRunner ?? 'cypress',
     });
   } else if (options.preset === Preset.ReactMonorepo) {
     const { applicationGenerator: reactApplicationGenerator } = require('@nx' +
@@ -56,6 +58,7 @@ async function createPreset(tree: Tree, options: Schema) {
       style: options.style,
       linter: options.linter,
       bundler: options.bundler ?? 'webpack',
+      e2eTestRunner: options.e2eTestRunner ?? 'cypress',
     });
   } else if (options.preset === Preset.ReactStandalone) {
     const { applicationGenerator: reactApplicationGenerator } = require('@nx' +
@@ -67,7 +70,7 @@ async function createPreset(tree: Tree, options: Schema) {
       linter: options.linter,
       rootProject: true,
       bundler: options.bundler ?? 'vite',
-      e2eTestRunner: 'cypress',
+      e2eTestRunner: options.e2eTestRunner ?? 'cypress',
       unitTestRunner: options.bundler === 'vite' ? 'vitest' : 'jest',
     });
   } else if (options.preset === Preset.NextJs) {
@@ -78,6 +81,7 @@ async function createPreset(tree: Tree, options: Schema) {
       name: options.name,
       style: options.style,
       linter: options.linter,
+      e2eTestRunner: options.e2eTestRunner ?? 'cypress',
     });
   } else if (options.preset === Preset.NextJsStandalone) {
     const { applicationGenerator: nextApplicationGenerator } = require('@nx' +
@@ -98,6 +102,7 @@ async function createPreset(tree: Tree, options: Schema) {
       style: options.style,
       linter: options.linter,
       bundler: 'vite',
+      e2eTestRunner: options.e2eTestRunner ?? 'cypress',
     });
   } else if (options.preset === Preset.Nest) {
     const { applicationGenerator: nestApplicationGenerator } = require('@nx' +
@@ -106,6 +111,7 @@ async function createPreset(tree: Tree, options: Schema) {
     return nestApplicationGenerator(tree, {
       name: options.name,
       linter: options.linter,
+      e2eTestRunner: options.e2eTestRunner ?? 'jest',
     });
   } else if (options.preset === Preset.Express) {
     const {
@@ -114,6 +120,7 @@ async function createPreset(tree: Tree, options: Schema) {
     return expressApplicationGenerator(tree, {
       name: options.name,
       linter: options.linter,
+      e2eTestRunner: options.e2eTestRunner ?? 'jest',
     });
   } else if (options.preset === Preset.ReactNative) {
     const { reactNativeApplicationGenerator } = require('@nx' +
@@ -121,14 +128,14 @@ async function createPreset(tree: Tree, options: Schema) {
     return reactNativeApplicationGenerator(tree, {
       name: options.name,
       linter: options.linter,
-      e2eTestRunner: 'detox',
+      e2eTestRunner: options.e2eTestRunner ?? 'detox',
     });
   } else if (options.preset === Preset.Expo) {
     const { expoApplicationGenerator } = require('@nx' + '/expo');
     return expoApplicationGenerator(tree, {
       name: options.name,
       linter: options.linter,
-      e2eTestRunner: 'detox',
+      e2eTestRunner: options.e2eTestRunner ?? 'detox',
     });
   } else if (options.preset === Preset.TS) {
     const c = readNxJson(tree);
@@ -149,6 +156,7 @@ async function createPreset(tree: Tree, options: Schema) {
       framework: options.framework,
       docker: options.docker,
       rootProject: true,
+      e2eTestRunner: options.e2eTestRunner ?? 'jest',
     });
   } else {
     throw new Error(`Invalid preset ${options.preset}`);

--- a/packages/workspace/src/generators/preset/schema.d.ts
+++ b/packages/workspace/src/generators/preset/schema.d.ts
@@ -15,4 +15,5 @@ export interface Schema {
   nextAppDir?: boolean;
   routing?: boolean;
   standaloneApi?: boolean;
+  e2eTestRunner?: 'cypress' | 'jest' | 'detox' | 'none';
 }

--- a/packages/workspace/src/generators/preset/schema.json
+++ b/packages/workspace/src/generators/preset/schema.json
@@ -88,6 +88,11 @@
       "description": "Enable experimental app/ for the project",
       "type": "boolean",
       "default": false
+    },
+    "e2eTestRunner": {
+      "description": "The tool to use for running e2e tests.",
+      "type": "string",
+      "enum": ["cypress", "jest", "detox", "none"]
     }
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
No way to opt out of e2e project at `create-nx-workspace` time

## Expected Behavior
Some corporate firewalls do not allow installation of cypress. To make the flow not error, `--e2eTestRunner=none` is respected for our presets.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #13989
