### PR TITLE
fix(core): whitelist registries that support obtaining migration config via 'npm view'

### DIFF
--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -949,7 +949,11 @@ async function getPackageMigrationsConfigFromRegistry(
 
     // Registries other than npmjs and the local registry may not support full metadata via npm view
     // so throw error so that fetcher falls back to getting config via install
-    if (!['registry.npmjs.org', 'localhost'].includes(registry)) {
+    if (
+      !['registry.npmjs.org', 'localhost', 'artifactory'].some((v) =>
+        registry.includes(v)
+      )
+    ) {
       throw new Error(
         `Getting migration config from registry is not supported from ${registry}`
       );


### PR DESCRIPTION
## Current Behavior
Determining migration config for plugins that are published to a different registry than npmjs.org doesn't work if the registry doesn't support full package metadata. Such registries return no results via 'npm view' which causes migrate to think that no migrations are necessary.

## Expected Behavior
Migrate will fallback to determining migration config via install in the event that no config is returned from 'npm view' for registries other then npmjs.org.

## Related Issue(s)

Fixes #16387, #10223
