### PR TITLE
docs(core): fixing some references to old architect terminology

### DIFF
--- a/docs/generated/cli/run.md
+++ b/docs/generated/cli/run.md
@@ -1,11 +1,11 @@
 ---
 title: 'run - CLI command'
-description: 'Runs a target defined for your project. Target definitions can be found in the `scripts` property of the project's `package.json`, or in the `targets` property of the project's `project.json` file.'
+description: 'Runs a target defined for your project. Target definitions can be found in the `scripts` property of the project `package.json`, or in the `targets` property of the project `project.json` file.'
 ---
 
 # run
 
-Runs a target defined for your project. Target definitions can be found in the `scripts` property of the project's `package.json`, or in the `targets` property of the project's `project.json` file.
+Runs a target defined for your project. Target definitions can be found in the `scripts` property of the project `package.json`, or in the `targets` property of the project `project.json` file.
 
 ## Usage
 

--- a/docs/generated/cli/run.md
+++ b/docs/generated/cli/run.md
@@ -1,11 +1,11 @@
 ---
 title: 'run - CLI command'
-description: 'Runs an Architect target with an optional custom builder configuration defined in your project.'
+description: 'Runs a target defined for your project. Target definitions can be found in the `scripts` property of the project's `package.json`, or in the `targets` property of the project's `project.json` file.'
 ---
 
 # run
 
-Runs an Architect target with an optional custom builder configuration defined in your project.
+Runs a target defined for your project. Target definitions can be found in the `scripts` property of the project's `package.json`, or in the `targets` property of the project's `project.json` file.
 
 ## Usage
 

--- a/docs/generated/packages/nest/documents/overview.md
+++ b/docs/generated/packages/nest/documents/overview.md
@@ -93,7 +93,7 @@ nx build my-nest-lib
 
 #### Waiting for other builds
 
-Setting the `waitUntilTargets` option with an array of projects (with the following format: `"project:architect"`) will execute those commands before serving the Nest application.
+Setting the `waitUntilTargets` option with an array of projects (with the following format: `"project:target"`) will execute those commands before serving the Nest application.
 
 ### Serve
 

--- a/docs/generated/packages/node/documents/overview.md
+++ b/docs/generated/packages/node/documents/overview.md
@@ -76,7 +76,7 @@ nx g @nrwl/node:application my-new-app \
 
 ### Debugging
 
-Debugging is set to use a random port that is available on the system. The port can be changed by setting the port option in the `serve` architect in the project.json. Or by running the serve command with `--port <number>`.
+Debugging is set to use a random port that is available on the system. The port can be changed by setting the port option in the `serve` target in the project.json. Or by running the serve command with `--port <number>`.
 
 For additional information on how to debug Node applications, see the [Node.js debugging getting started guide](https://nodejs.org/en/docs/guides/debugging-getting-started/#inspector-clients).
 

--- a/docs/generated/packages/nx/documents/run.md
+++ b/docs/generated/packages/nx/documents/run.md
@@ -1,11 +1,11 @@
 ---
 title: 'run - CLI command'
-description: 'Runs a target defined for your project. Target definitions can be found in the `scripts` property of the project's `package.json`, or in the `targets` property of the project's `project.json` file.'
+description: 'Runs a target defined for your project. Target definitions can be found in the `scripts` property of the project `package.json`, or in the `targets` property of the project `project.json` file.'
 ---
 
 # run
 
-Runs a target defined for your project. Target definitions can be found in the `scripts` property of the project's `package.json`, or in the `targets` property of the project's `project.json` file.
+Runs a target defined for your project. Target definitions can be found in the `scripts` property of the project `package.json`, or in the `targets` property of the project `project.json` file.
 
 ## Usage
 

--- a/docs/generated/packages/nx/documents/run.md
+++ b/docs/generated/packages/nx/documents/run.md
@@ -1,11 +1,11 @@
 ---
 title: 'run - CLI command'
-description: 'Runs an Architect target with an optional custom builder configuration defined in your project.'
+description: 'Runs a target defined for your project. Target definitions can be found in the `scripts` property of the project's `package.json`, or in the `targets` property of the project's `project.json` file.'
 ---
 
 # run
 
-Runs an Architect target with an optional custom builder configuration defined in your project.
+Runs a target defined for your project. Target definitions can be found in the `scripts` property of the project's `package.json`, or in the `targets` property of the project's `project.json` file.
 
 ## Usage
 

--- a/docs/shared/cli/run.md
+++ b/docs/shared/cli/run.md
@@ -1,11 +1,11 @@
 ---
 title: 'run - CLI command'
-description: 'Runs a target defined for your project. Target definitions can be found in the `scripts` property of the project's `package.json`, or in the `targets` property of the project's `project.json` file.'
+description: 'Runs a target defined for your project. Target definitions can be found in the `scripts` property of the project `package.json`, or in the `targets` property of the project `project.json` file.'
 ---
 
 # run
 
-Runs a target defined for your project. Target definitions can be found in the `scripts` property of the project's `package.json`, or in the `targets` property of the project's `project.json` file.
+Runs a target defined for your project. Target definitions can be found in the `scripts` property of the project `package.json`, or in the `targets` property of the project `project.json` file.
 
 ## Usage
 

--- a/docs/shared/cli/run.md
+++ b/docs/shared/cli/run.md
@@ -1,11 +1,11 @@
 ---
 title: 'run - CLI command'
-description: 'Runs an Architect target with an optional custom builder configuration defined in your project.'
+description: 'Runs a target defined for your project. Target definitions can be found in the `scripts` property of the project's `package.json`, or in the `targets` property of the project's `project.json` file.'
 ---
 
 # run
 
-Runs an Architect target with an optional custom builder configuration defined in your project.
+Runs a target defined for your project. Target definitions can be found in the `scripts` property of the project's `package.json`, or in the `targets` property of the project's `project.json` file.
 
 ## Usage
 

--- a/docs/shared/core-features/integrate-with-editors.md
+++ b/docs/shared/core-features/integrate-with-editors.md
@@ -1,6 +1,6 @@
 # Integrate with Editors
 
-Nx Console is the UI for Nx. It works for any generator or any architect commands. Nx Console does not have a specific UI for, say, generating a component. Instead, Nx Console does what the command-line version of Nx does - it analyzes the same meta information to create the needed UI. This means that anything you can do with Nx, you can do with Nx Console.
+Nx Console is the UI for Nx. It works for any installed generators or any targets defined in your workspace. Nx Console does not have a specific UI for, say, generating a component. Instead, Nx Console does what the command-line version of Nx does - it analyzes the same meta information to create the needed UI. This means that anything you can do with Nx, you can do with Nx Console.
 
 ## Download
 

--- a/docs/shared/packages/nest/nest-plugin.md
+++ b/docs/shared/packages/nest/nest-plugin.md
@@ -93,7 +93,7 @@ nx build my-nest-lib
 
 #### Waiting for other builds
 
-Setting the `waitUntilTargets` option with an array of projects (with the following format: `"project:architect"`) will execute those commands before serving the Nest application.
+Setting the `waitUntilTargets` option with an array of projects (with the following format: `"project:target"`) will execute those commands before serving the Nest application.
 
 ### Serve
 

--- a/docs/shared/packages/node/node-plugin.md
+++ b/docs/shared/packages/node/node-plugin.md
@@ -76,7 +76,7 @@ nx g @nrwl/node:application my-new-app \
 
 ### Debugging
 
-Debugging is set to use a random port that is available on the system. The port can be changed by setting the port option in the `serve` architect in the project.json. Or by running the serve command with `--port <number>`.
+Debugging is set to use a random port that is available on the system. The port can be changed by setting the port option in the `serve` target in the project.json. Or by running the serve command with `--port <number>`.
 
 For additional information on how to debug Node applications, see the [Node.js debugging getting started guide](https://nodejs.org/en/docs/guides/debugging-getting-started/#inspector-clients).
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Docs reference in several places "architect".

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Should reflect the current terminology: "target"

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
