### PR TITLE
feat(vite): add option to generate a package.json to build executor

### DIFF
--- a/docs/generated/packages/vite/executors/build.json
+++ b/docs/generated/packages/vite/executors/build.json
@@ -92,6 +92,14 @@
         "description": "Enable re-building when files change.",
         "oneOf": [{ "type": "boolean" }, { "type": "object" }],
         "default": false
+      },
+      "generatePackageJson": {
+        "description": "Generate a package.json for the build output.",
+        "type": "boolean"
+      },
+      "includeDevDependenciesInPackageJson": {
+        "description": "Include devDependencies in the generated package.json.",
+        "type": "boolean"
       }
     },
     "definitions": {},

--- a/packages/vite/src/executors/build/schema.d.ts
+++ b/packages/vite/src/executors/build/schema.d.ts
@@ -15,4 +15,6 @@ export interface ViteBuildExecutorOptions {
   ssr?: boolean | string;
   watch?: object | boolean;
   target?: string | string[];
+  generatePackageJson?: boolean;
+  includeDevDependenciesInPackageJson?: boolean;
 }

--- a/packages/vite/src/executors/build/schema.json
+++ b/packages/vite/src/executors/build/schema.json
@@ -139,6 +139,14 @@
         }
       ],
       "default": false
+    },
+    "generatePackageJson": {
+      "description": "Generate a package.json for the build output.",
+      "type": "boolean"
+    },
+    "includeDevDependenciesInPackageJson": {
+      "description": "Include devDependencies in the generated package.json.",
+      "type": "boolean"
     }
   },
   "definitions": {},


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
There's currently no way of generating a minimal `package.json` when using the `vite:build` executor

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The ability to generate a `package.json` including only the dependencies of the project should be enabled by setting `generatePackageJson: true` in the `vite:build` executor options
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
