### PR TITLE
feat(linter): add internal rules to prevent deep nx imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,18 @@
   "extends": [],
   "rules": {
     "@typescript-eslint/explicit-module-boundary-types": "off",
-    "no-restricted-imports": ["error", "create-nx-workspace"]
+    "no-restricted-imports": ["error", "create-nx-workspace"],
+    "@typescript-eslint/no-restricted-imports": [
+      "error",
+      {
+        "patterns": [
+          {
+            "group": ["nx/src/plugins/js*"],
+            "message": "Imports from 'nx/src/plugins/js' are not allowed. Use '@nx/js' instead"
+          }
+        ]
+      }
+    ]
   },
   "overrides": [
     {

--- a/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin-nx/src/rules/enforce-module-boundaries.spec.ts
@@ -9,7 +9,7 @@ import { DependencyType } from '@nx/devkit';
 import * as parser from '@typescript-eslint/parser';
 import { TSESLint } from '@typescript-eslint/utils';
 import { vol } from 'memfs';
-import { TargetProjectLocator } from 'nx/src/plugins/js/project-graph/build-dependencies/target-project-locator';
+import { TargetProjectLocator } from '@nx/js/src/internal';
 import enforceModuleBoundaries, {
   RULE_NAME as enforceModuleBoundariesRuleName,
 } from '../../src/rules/enforce-module-boundaries';

--- a/packages/eslint-plugin-nx/src/utils/ast-utils.ts
+++ b/packages/eslint-plugin-nx/src/utils/ast-utils.ts
@@ -3,7 +3,7 @@ import {
   ProjectGraphProjectNode,
   readJsonFile,
 } from '@nx/devkit';
-import { findNodes } from 'nx/src/plugins/js/utils/typescript';
+import { findNodes } from '@nx/js';
 import { existsSync, readFileSync } from 'fs';
 import { dirname } from 'path';
 import ts = require('typescript');

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -12,11 +12,14 @@ export * from './utils/package-json/update-package-json';
 export { libraryGenerator } from './generators/library/library';
 export { initGenerator } from './generators/init/init';
 
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 export {
   createLockFile,
   getLockFileName,
 } from 'nx/src/plugins/js/lock-file/lock-file';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 export { createPackageJson } from 'nx/src/plugins/js/package-json/create-package-json';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 export {
   findNodes,
   getRootTsConfigPath,

--- a/packages/js/src/internal.ts
+++ b/packages/js/src/internal.ts
@@ -1,6 +1,9 @@
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 export { resolveModuleByImport } from 'nx/src/plugins/js/utils/typescript';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 export {
   registerTsProject,
   registerTsConfigPaths,
 } from 'nx/src/plugins/js/utils/register';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 export { TargetProjectLocator } from 'nx/src/plugins/js/project-graph/build-dependencies/target-project-locator';

--- a/packages/js/src/utils/package-json/update-package-json.ts
+++ b/packages/js/src/utils/package-json/update-package-json.ts
@@ -1,7 +1,9 @@
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import {
   createLockFile,
   getLockFileName,
 } from 'nx/src/plugins/js/lock-file/lock-file';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { createPackageJson } from 'nx/src/plugins/js/package-json/create-package-json';
 import {
   ExecutorContext,

--- a/packages/js/src/utils/typescript/ast-utils.ts
+++ b/packages/js/src/utils/typescript/ast-utils.ts
@@ -2,6 +2,7 @@ import type { Tree } from '@nx/devkit';
 import type * as ts from 'typescript';
 // TODO(colum): replace when https://github.com/nrwl/nx/pull/15497 is merged
 import { getSourceNodes } from '@nx/workspace/src/utilities/typescript';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { findNodes } from 'nx/src/plugins/js/utils/typescript';
 import { ensureTypescript } from './ensure-typescript';
 

--- a/packages/nx/.eslintrc.json
+++ b/packages/nx/.eslintrc.json
@@ -20,6 +20,12 @@
                 "message": "TypeScript is an optional dependency for Nx. If you need to use it, make sure its installed first with ensureTypescript.",
                 "allowTypeImports": true
               }
+            ],
+            "patterns": [
+              {
+                "group": ["nx/*"],
+                "message": "Circular import in 'nx' found. Use relative path."
+              }
             ]
           }
         ]

--- a/packages/nx/src/adapter/ngcli-adapter.ts
+++ b/packages/nx/src/adapter/ngcli-adapter.ts
@@ -50,7 +50,7 @@ import {
   ExecutorsJson,
   TaskGraphExecutor,
 } from '../config/misc-interfaces';
-import { readPluginPackageJson } from 'nx/src/utils/nx-plugin';
+import { readPluginPackageJson } from '../utils/nx-plugin';
 
 class WrappedWorkspaceNodeModulesArchitectHost extends WorkspaceNodeModulesArchitectHost {
   private workspaces = new Workspaces(this.root);

--- a/packages/nx/src/generators/utils/project-configuration.ts
+++ b/packages/nx/src/generators/utils/project-configuration.ts
@@ -1,4 +1,4 @@
-import { basename, dirname, join, relative } from 'path';
+import { basename, join, relative } from 'path';
 import {
   ProjectConfiguration,
   ProjectsConfigurations,
@@ -18,7 +18,7 @@ import { readJson, writeJson } from './json';
 import { PackageJson } from '../../utils/package-json';
 import { readNxJson } from './nx-json';
 import { output } from '../../utils/output';
-import { getNxRequirePaths } from 'nx/src/utils/installation-directory';
+import { getNxRequirePaths } from '../../utils/installation-directory';
 
 export { readNxJson, updateNxJson } from './nx-json';
 export {

--- a/packages/nx/src/migrations/update-15-1-0/set-project-names.ts
+++ b/packages/nx/src/migrations/update-15-1-0/set-project-names.ts
@@ -7,7 +7,7 @@ import {
 import { dirname } from 'path';
 import { readJson, writeJson } from '../../generators/utils/json';
 import { formatChangedFilesWithPrettierIfAvailable } from '../../generators/internal-utils/format-changed-files-with-prettier-if-available';
-import { getNxRequirePaths } from 'nx/src/utils/installation-directory';
+import { getNxRequirePaths } from '../../utils/installation-directory';
 
 export default async function (tree: Tree) {
   const nxJson = readNxJson(tree);

--- a/packages/nx/src/migrations/update-16-0-0/update-depends-on-to-tokens.spec.ts
+++ b/packages/nx/src/migrations/update-16-0-0/update-depends-on-to-tokens.spec.ts
@@ -1,13 +1,11 @@
 import {
   addProjectConfiguration,
-  getProjects,
   readNxJson,
   readProjectConfiguration,
 } from '../../generators/utils/project-configuration';
-import { Tree } from '../../generators/tree';
 
 import update from './update-depends-on-to-tokens';
-import { updateJson, writeJson } from 'nx/src/devkit-exports';
+import { updateJson, writeJson } from '../../generators/utils/json';
 import { createTreeWithEmptyWorkspace } from '../../generators/testing-utils/create-tree-with-empty-workspace';
 
 describe('update-depends-on-to-tokens', () => {

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
@@ -3,7 +3,7 @@ import { parsePnpmLockfile, stringifyPnpmLockfile } from './pnpm-parser';
 import { ProjectGraph } from '../../../config/project-graph';
 import { vol } from 'memfs';
 import { pruneProjectGraph } from './project-graph-pruning';
-import { ProjectGraphBuilder } from 'nx/src/project-graph/project-graph-builder';
+import { ProjectGraphBuilder } from '../../../project-graph/project-graph-builder';
 
 jest.mock('fs', () => require('memfs').fs);
 

--- a/packages/nx/src/project-graph/build-nodes/workspace-projects.spec.ts
+++ b/packages/nx/src/project-graph/build-nodes/workspace-projects.spec.ts
@@ -1,4 +1,4 @@
-import { ProjectGraphProjectNode } from 'nx/src/config/project-graph';
+import { ProjectGraphProjectNode } from '../../config/project-graph';
 import { normalizeImplicitDependencies } from './workspace-projects';
 
 describe('workspace-projects', () => {


### PR DESCRIPTION
- Rule to prevent circular import of `nx` package
- Rule to prevent deep import to `nx/src/plugins/js`

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
