### PR TITLE
docs(misc): expose nx init command flags in docs and the terminal help

### DIFF
--- a/docs/generated/cli/init.md
+++ b/docs/generated/cli/init.md
@@ -17,14 +17,60 @@ Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`
 
 ## Options
 
+### addE2e
+
+Type: `boolean`
+
+Default: `false`
+
+Set up Cypress E2E tests in integrated workspaces. Only for CRA projects.
+
+### force
+
+Type: `boolean`
+
+Default: `false`
+
+Force the migration to continue and ignore custom webpack setup or uncommitted changes. Only for CRA projects.
+
 ### help
 
 Type: `boolean`
 
 Show help
 
+### integrated
+
+Type: `boolean`
+
+Default: `false`
+
+Migrate to an Nx integrated layout workspace. Only for Angular CLI workspaces and CRA projects.
+
+### interactive
+
+Type: `boolean`
+
+Default: `true`
+
+When false disables interactive input prompts for options.
+
+### nxCloud
+
+Type: `boolean`
+
+Set up distributed caching with Nx Cloud.
+
 ### version
 
 Type: `boolean`
 
 Show version number
+
+### vite
+
+Type: `boolean`
+
+Default: `true`
+
+Use Vite as the bundler. Only for CRA projects.

--- a/docs/generated/packages/nx/documents/init.md
+++ b/docs/generated/packages/nx/documents/init.md
@@ -17,14 +17,60 @@ Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`
 
 ## Options
 
+### addE2e
+
+Type: `boolean`
+
+Default: `false`
+
+Set up Cypress E2E tests in integrated workspaces. Only for CRA projects.
+
+### force
+
+Type: `boolean`
+
+Default: `false`
+
+Force the migration to continue and ignore custom webpack setup or uncommitted changes. Only for CRA projects.
+
 ### help
 
 Type: `boolean`
 
 Show help
 
+### integrated
+
+Type: `boolean`
+
+Default: `false`
+
+Migrate to an Nx integrated layout workspace. Only for Angular CLI workspaces and CRA projects.
+
+### interactive
+
+Type: `boolean`
+
+Default: `true`
+
+When false disables interactive input prompts for options.
+
+### nxCloud
+
+Type: `boolean`
+
+Set up distributed caching with Nx Cloud.
+
 ### version
 
 Type: `boolean`
 
 Show version number
+
+### vite
+
+Type: `boolean`
+
+Default: `true`
+
+Use Vite as the bundler. Only for CRA projects.

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -953,45 +953,38 @@ function withListOptions(yargs) {
 }
 
 function withInitOptions(yargs: yargs.Argv) {
-  // TODO(leo): make them visible in docs/help once the feature is released in Nx 16
   return yargs
     .options('nxCloud', {
       type: 'boolean',
       description: 'Set up distributed caching with Nx Cloud.',
-      hidden: true,
     })
     .option('interactive', {
       describe: 'When false disables interactive input prompts for options.',
       type: 'boolean',
       default: true,
-      hidden: true,
     })
     .option('integrated', {
       type: 'boolean',
       description:
         'Migrate to an Nx integrated layout workspace. Only for Angular CLI workspaces and CRA projects.',
       default: false,
-      hidden: true,
     })
     .option('addE2e', {
       describe:
         'Set up Cypress E2E tests in integrated workspaces. Only for CRA projects.',
       type: 'boolean',
       default: false,
-      hidden: true,
     })
     .option('force', {
       describe:
         'Force the migration to continue and ignore custom webpack setup or uncommitted changes. Only for CRA projects.',
       type: 'boolean',
       default: false,
-      hidden: true,
     })
     .options('vite', {
       type: 'boolean',
       description: 'Use Vite as the bundler. Only for CRA projects.',
       default: true,
-      hidden: true,
     })
     .options('cacheable', {
       type: 'string',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `nx init` command flags are hidden.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `nx init` command flags are shown in the docs and the terminal help.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16251 
