### PR TITLE
fix(nx-plugin): correct importPath and import updates for migration to local plugins

### DIFF
--- a/docs/generated/cli/workspace-generator.md
+++ b/docs/generated/cli/workspace-generator.md
@@ -12,7 +12,7 @@ description: 'Runs a workspace generator from the tools/generators directory'
 ## Usage
 
 ```shell
-nx workspace-generator [name]
+nx workspace-generator [generator]
 ```
 
 Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpm nx`.

--- a/docs/generated/packages/nx/documents/workspace-generator.md
+++ b/docs/generated/packages/nx/documents/workspace-generator.md
@@ -12,7 +12,7 @@ description: 'Runs a workspace generator from the tools/generators directory'
 ## Usage
 
 ```shell
-nx workspace-generator [name]
+nx workspace-generator [generator]
 ```
 
 Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpm nx`.

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -238,11 +238,11 @@ export const commandsObject = yargs
    * @deprecated(v17): Remove `workspace-generator in v17. Use local plugins.
    */
   .command({
-    command: 'workspace-generator [name]',
+    command: 'workspace-generator [generator]',
     describe: 'Runs a workspace generator from the tools/generators directory',
     deprecated:
       'Use a local plugin instead. See: https://nx.dev/deprecated/workspace-generators',
-    aliases: ['workspace-schematic [name]'],
+    aliases: ['workspace-schematic [generator]'],
     builder: async (yargs) =>
       linkToNxDevAndExamples(withGenerateOptions(yargs), 'workspace-generator'),
     handler: workspaceGeneratorHandler,

--- a/packages/nx/src/command-line/workspace-generators.ts
+++ b/packages/nx/src/command-line/workspace-generators.ts
@@ -13,7 +13,7 @@ export async function workspaceGenerators(args: yargs.Arguments) {
   const generator = process.argv.slice(3);
 
   output.warn({
-    title: `${NX_PREFIX} Workspace Generators are no longer supported`,
+    title: `Workspace Generators are no longer supported`,
     bodyLines: [
       'Instead, Nx now supports executing generators or executors from ',
       'local plugins. To run a generator from a local plugin, ',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
- If the workspace-generator used any utils that lived in the `tools` folder, their import paths would be broken
- If the workspace has an npmScope, the import path for the plugin is `${npmScope}/workspace-plugin`
- The workspace-generator wrapper was clobbering any arguments called "name" since there was a positional called name as well.
	- This was something that was worked around in the previous yargs config that I did not notice

## Expected Behavior
- If the workspace-generator used any utils that lived in the `tools` folder, their import paths are not broken
- If the workspace has an npmScope, the import path for the plugin is `@${npmScope}/workspace-plugin`
- You can pass `--name` to converted generators

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
