### PR TITLE
fix(nextjs): styled-jsx and styled-components should have "use client directive"

### DIFF
--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -401,7 +401,7 @@ describe('app', () => {
           {},
           `
           [
-            "plugin:@nx/nx/react-typescript",
+            "plugin:@nx/react-typescript",
             "next",
             "next/core-web-vitals",
           ]

--- a/packages/next/src/generators/application/files/app/page.tsx__tmpl__
+++ b/packages/next/src/generators/application/files/app/page.tsx__tmpl__
@@ -1,3 +1,6 @@
+<% if (styledModule && (styledModule === 'styled-jsx' || styledModule === 'styled-components'))  {%>
+'use client';
+<% }%> 
 <% if (styledModule && styledModule !== 'styled-jsx') {
   var wrapper = 'StyledPage';
 %>import styled from '<%= styledModule %>';<% } else {


### PR DESCRIPTION
CSS-in-JS libraries which require runtime JavaScript are not currently supported in Server Components.

Currently, only `styled-jsx` and `styled-components` are supported.

`emotion` (https://github.com/emotion-js/emotion/issues/2928) is still in progress along with a few others