### PR TITLE
fix(react): use babel-loader when using styled-jsx with rspack

### DIFF
--- a/packages/react/src/utils/versions.ts
+++ b/packages/react/src/utils/versions.ts
@@ -7,6 +7,7 @@ export const reactVersion = '18.2.0';
 export const reactDomVersion = '18.2.0';
 export const reactIsVersion = '18.2.0';
 export const swcLoaderVersion = '0.1.15';
+export const babelLoaderVersion = '^9.1.2';
 export const typesReactVersion = '18.0.28';
 export const typesReactDomVersion = '18.0.11';
 export const typesReactIsVersion = '17.0.3';


### PR DESCRIPTION
`styled-jsx` needs babel in order to transpile `<style jsx>{...}</style>` syntax, otherwise the app will not render (you can get error because the react child is an unsupported object).

This PR fixes the setup to bring in `babel-loader`, which corrects the build but will be slower. A warning is logged to the user.
<img width="1270" alt="Screenshot 2023-04-20 at 2 53 58 PM" src="https://user-images.githubusercontent.com/53559/233460992-b37195ea-fbae-47e5-8128-2c6a440912c3.png">
