### PR TITLE
fix(nx-plugin): generated root plugin should not have wonky paths

### DIFF
--- a/e2e/workspace-create/src/create-nx-plugin.test.ts
+++ b/e2e/workspace-create/src/create-nx-plugin.test.ts
@@ -32,7 +32,10 @@ describe('create-nx-plugin', () => {
 
     runCLI(`build ${pluginName}`);
 
-    checkFilesExist(`dist/package.json`, `dist/src/index.js`);
+    checkFilesExist(
+      `dist/${pluginName}/package.json`,
+      `dist/${pluginName}/src/index.js`
+    );
 
     runCLI(
       `generate @nrwl/nx-plugin:generator ${generatorName} --project=${pluginName}`
@@ -44,9 +47,9 @@ describe('create-nx-plugin', () => {
     runCLI(`build ${pluginName}`);
 
     checkFilesExist(
-      `dist/package.json`,
-      `dist/generators.json`,
-      `dist/executors.json`
+      `dist/${pluginName}/package.json`,
+      `dist/${pluginName}/generators.json`,
+      `dist/${pluginName}/executors.json`
     );
   });
 
@@ -59,7 +62,10 @@ describe('create-nx-plugin', () => {
     });
 
     runCLI(`build ${pluginName}`);
-    checkFilesExist(`dist/package.json`, `dist/generators.json`);
+    checkFilesExist(
+      `dist/${pluginName}/package.json`,
+      `dist/${pluginName}/generators.json`
+    );
 
     runCLI(`build create-${pluginName}-package`);
     checkFilesExist(`dist/create-${pluginName}-package/bin/index.js`);

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -157,9 +157,7 @@ function addProject(
     options.bundler !== 'none' &&
     options.config !== 'npm-scripts'
   ) {
-    const outputPath = destinationDir
-      ? `dist/${destinationDir}/${options.projectDirectory}`
-      : `dist/${options.projectDirectory}`;
+    const outputPath = getOutputPath(options, destinationDir);
     projectConfiguration.targets.build = {
       executor: getBuildExecutor(options.bundler),
       outputs: ['{options.outputPath}'],
@@ -578,6 +576,19 @@ function ensureBabelRootConfigExists(tree: Tree) {
   writeJson(tree, 'babel.config.json', {
     babelrcRoots: ['*'],
   });
+}
+
+function getOutputPath(options: NormalizedSchema, destinationDir?: string) {
+  const parts = ['dist'];
+  if (destinationDir) {
+    parts.push(destinationDir);
+  }
+  if (options.projectDirectory === '.') {
+    parts.push(options.name);
+  } else {
+    parts.push(options.projectDirectory);
+  }
+  return joinPathFragments(...parts);
 }
 
 export default libraryGenerator;

--- a/packages/plugin/src/generators/plugin/plugin.ts
+++ b/packages/plugin/src/generators/plugin/plugin.ts
@@ -44,25 +44,27 @@ function updatePluginConfig(host: Tree, options: NormalizedSchema) {
   if (project.targets.build) {
     project.targets.build.options.assets ??= [];
 
+    const root =
+      options.projectRoot === '.' ? './' : './' + options.projectRoot;
     project.targets.build.options.assets = [
       ...project.targets.build.options.assets,
       {
-        input: `./${options.projectRoot}/src`,
+        input: `${root}/src`,
         glob: '**/!(*.ts)',
         output: './src',
       },
       {
-        input: `./${options.projectRoot}/src`,
+        input: `${root}/src`,
         glob: '**/*.d.ts',
         output: './src',
       },
       {
-        input: `./${options.projectRoot}`,
+        input: root,
         glob: 'generators.json',
         output: '.',
       },
       {
-        input: `./${options.projectRoot}`,
+        input: root,
         glob: 'executors.json',
         output: '.',
       },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<img width="390" alt="image" src="https://user-images.githubusercontent.com/6933928/233463571-4f39a09f-4c34-42b1-9a01-8f69c942f873.png">


## Expected Behavior
- Path's dont start with '././'
- Plugin outputs to `dist/${pluginName}`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
