### PR TITLE
fix(angular): build plugin runtime code with ts module option set to esnext

### DIFF
--- a/packages-legacy/angular/project.json
+++ b/packages-legacy/angular/project.json
@@ -9,7 +9,7 @@
       "executor": "@nrwl/angular:package",
       "options": {
         "project": "packages-legacy/angular/ng-package.json",
-        "tsConfig": "packages-legacy/angular/tsconfig.json"
+        "tsConfig": "packages-legacy/angular/tsconfig.runtime.json"
       },
       "outputs": ["build/packages/angular-legacy"]
     },

--- a/packages-legacy/angular/tsconfig.json
+++ b/packages-legacy/angular/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "../../tsconfig.base.json",
-  "angularCompilerOptions": {
-    "compilationMode": "partial"
-  },
   "include": ["**/*.ts"],
   "files": ["index.ts"]
 }

--- a/packages-legacy/angular/tsconfig.runtime.json
+++ b/packages-legacy/angular/tsconfig.runtime.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext"
+  },
+  "angularCompilerOptions": {
+    "compilationMode": "partial"
+  }
+}

--- a/packages/angular/project.json
+++ b/packages/angular/project.json
@@ -10,7 +10,7 @@
       "executor": "@nrwl/angular:package",
       "options": {
         "project": "packages/angular/ng-package.json",
-        "tsConfig": "packages/angular/tsconfig.lib.json"
+        "tsConfig": "packages/angular/tsconfig.lib.runtime.json"
       },
       "outputs": ["build/packages/angular"]
     },

--- a/packages/angular/tsconfig.lib.json
+++ b/packages/angular/tsconfig.lib.json
@@ -6,9 +6,6 @@
     "declaration": true,
     "types": ["node"]
   },
-  "angularCompilerOptions": {
-    "compilationMode": "partial"
-  },
   "exclude": [
     "**/*.spec.ts",
     "**/*.test.ts",

--- a/packages/angular/tsconfig.lib.runtime.json
+++ b/packages/angular/tsconfig.lib.runtime.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "compilerOptions": {
+    "module": "esnext"
+  },
+  "angularCompilerOptions": {
+    "compilationMode": "partial"
+  }
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The runtime code in the Angular plugin is built with `"module": "commonjs"`. This is producing a wrong output for the plugin.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The runtime code in the Angular plugin is built with `"module": "esnext"`.

**Some context:**

Before the runtime code was built running:

```shell
npx ng-packagr -p packages/angular/ng-package.json
```

This was ignoring the tsconfig and using some defaults from `ng-packagr`. With the rescope, we now build the plugin using the `@nx/angular:package` executor using the `tsconfig.lib.json` settings for the build. There are differences in settings for the tooling code and the runtime code, so we build each with its own config.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
