### PR TITLE
fix(react): swapped fragments with <div> so avoid lint warnings for default

### DIFF
--- a/packages/react/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/react/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -6,12 +6,12 @@ import styles from './app.module.css';
 
 export function App() {
   return (
-    <>
+    <div>
       <h1>
         <span> Hello there, </span>
         Welcome plain 👋
       </h1>
-    </>
+    </div>
   );
 }
 
@@ -49,9 +49,9 @@ import NxWelcome from './nx-welcome';
 
 export function App() {
   return (
-    <>
+    <div>
       <NxWelcome title="my-app" />
-    </>
+    </div>
   );
 }
 
@@ -67,9 +67,9 @@ import NxWelcome from './nx-welcome';
 
 export function App() {
   return (
-    <>
+    <div>
       <NxWelcome title="my-dir-my-app" />
-    </>
+    </div>
   );
 }
 

--- a/packages/react/src/generators/application/files/style-css-module/src/app/__fileName__.tsx__tmpl__
+++ b/packages/react/src/generators/application/files/style-css-module/src/app/__fileName__.tsx__tmpl__
@@ -14,7 +14,7 @@ export class App extends Component {
 export function App() {
 <% } %>
   return (
-    <>
+    <div>
       <% if (!minimal) { %>
       <NxWelcome title="<%= projectName %>"/>
      <% } else { %>
@@ -23,7 +23,7 @@ export function App() {
         Welcome <%= projectName %> 👋
       </h1>
      <% } %>
-    </>);
+    </div>);
 <% if (classComponent) { %>
   }
 }

--- a/packages/react/src/generators/application/files/style-global-css/src/app/__fileName__.tsx__tmpl__
+++ b/packages/react/src/generators/application/files/style-global-css/src/app/__fileName__.tsx__tmpl__
@@ -13,7 +13,7 @@ export class App extends Component {
 export function App() {
 <% } %>
   return (
-  <>
+  <div>
     <% if (!minimal) { %>
     <NxWelcome title="<%= projectName %>"/>
      <% } else { %>
@@ -22,7 +22,7 @@ export function App() {
         Welcome <%= projectName %> 👋
       </h1>
      <% } %>
-  </>);
+  </div>);
 <% if (classComponent) { %>
   }
 }

--- a/packages/react/src/generators/application/files/style-none/src/app/__fileName__.tsx__tmpl__
+++ b/packages/react/src/generators/application/files/style-none/src/app/__fileName__.tsx__tmpl__
@@ -12,7 +12,7 @@ export class App extends Component {
 export function App() {
 <% } %>
   return (
-    <>
+    <div>
       <% if (!minimal) { %>
       <NxWelcome title="<%= projectName %>"/>
       <% } else { %>
@@ -21,7 +21,7 @@ export function App() {
         Welcome <%= projectName %> 👋
       </h1>
      <% } %>
-    </>);
+    </div>);
 <% if (classComponent) { %>
   }
 }

--- a/packages/react/src/generators/application/files/style-styled-jsx/src/app/__fileName__.tsx__tmpl__
+++ b/packages/react/src/generators/application/files/style-styled-jsx/src/app/__fileName__.tsx__tmpl__
@@ -12,9 +12,9 @@ export class App extends Component {
 export function App() {
 <% } %>
   return (
-    <>
+    <div>
       <style jsx>{`/** your style here **/`}</style>
-    </>
+    </div>
   );
 
 <% if (classComponent) { %>


### PR DESCRIPTION
Now that the empty `<div/>` is removed, the unnecessary `<></>` fragments are causing lint warnings for the linter e2e tests. This PR sets them to `<div></div>` to avoid the warning. Removing the fragments completely breaks the AST utils to add routes to the app, since it is currently expecting at least one set of open-close JSX element.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
