### PR TITLE
feat(repo): ignore macos timings for nightly duration report

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -583,7 +583,7 @@ jobs:
             resultPkg += `\`\`\``;
             core.setOutput('SLACK_PROJ_DURATION', trimSpace(resultPkg));
 
-            // instant check on manual runs
+            // Print project duration report inline to allow reviewing on manual runs (when no slack message will be sent)
             console.log(trimSpace(resultPkg));
 
             let resultPm = `
@@ -596,7 +596,7 @@ jobs:
             resultPm += `\`\`\``;
             core.setOutput('SLACK_PM_DURATION', trimSpace(resultPm));
 
-            // instant check on manual runs
+            // Print package manager duration report inline to allow reviewing on manual runs (when no slack message will be sent)
             console.log(trimSpace(resultPm));
 
   report-failure:

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -525,30 +525,33 @@ jobs:
               yarn: 0,
               pnpm: 0
             };
+            const macosProjects = ['e2e-detox', 'e2e-expo', 'e2e-react-native'];
             combined.forEach((matrix) => {
               if (matrix.os_name === 'Linux' && matrix.node_version === 18) {
                 pmReport[matrix.package_manager] += matrix.duration;
               }
-              if (timeReport[matrix.project]) {
-                if (matrix.duration > timeReport[matrix.project].max) {
-                  timeReport[matrix.project].max = matrix.duration;
-                  timeReport[
-                    matrix.project
-                  ].maxEnv = `${matrix.os_name}, ${matrix.package_manager}`;
+              if (matrix.os_name === 'Linux' || macosProjects.includes(matrix.project)) {
+                if (timeReport[matrix.project]) {
+                  if (matrix.duration > timeReport[matrix.project].max) {
+                    timeReport[matrix.project].max = matrix.duration;
+                    timeReport[
+                      matrix.project
+                    ].maxEnv = `${matrix.os_name}, ${matrix.package_manager}`;
+                  }
+                  if (matrix.duration < timeReport[matrix.project].min) {
+                    timeReport[matrix.project].min = matrix.duration;
+                    timeReport[
+                      matrix.project
+                    ].minEnv = `${matrix.os_name}, ${matrix.package_manager}`;
+                  }
+                } else {
+                  timeReport[matrix.project] = {
+                    min: matrix.duration,
+                    max: matrix.duration,
+                    minEnv: `${matrix.os_name}, ${matrix.package_manager}`,
+                    maxEnv: `${matrix.os_name}, ${matrix.package_manager}`,
+                  };
                 }
-                if (matrix.duration < timeReport[matrix.project].min) {
-                  timeReport[matrix.project].min = matrix.duration;
-                  timeReport[
-                    matrix.project
-                  ].minEnv = `${matrix.os_name}, ${matrix.package_manager}`;
-                }
-              } else {
-                timeReport[matrix.project] = {
-                  min: matrix.duration,
-                  max: matrix.duration,
-                  minEnv: `${matrix.os_name}, ${matrix.package_manager}`,
-                  maxEnv: `${matrix.os_name}, ${matrix.package_manager}`,
-                };
               }
             });
 
@@ -580,6 +583,9 @@ jobs:
             resultPkg += `\`\`\``;
             core.setOutput('SLACK_PROJ_DURATION', trimSpace(resultPkg));
 
+            // instant check on manual runs
+            console.log(trimSpace(resultPkg));
+
             let resultPm = `
                 \`\`\`
                 | PM   | Total time  |
@@ -589,6 +595,9 @@ jobs:
             });
             resultPm += `\`\`\``;
             core.setOutput('SLACK_PM_DURATION', trimSpace(resultPm));
+
+            // instant check on manual runs
+            console.log(trimSpace(resultPm));
 
   report-failure:
     if: ${{ failure() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}


### PR DESCRIPTION
Nightly report of test durations per project takes into account runs on `macOS` which are always the slowest ones due to different agent, so that information does not give us any valuable information.

This PR checks duration only on Ubuntu for all the tests that don't require MacOS (detox, expo, react-native).

Additionally it adds convenient output log useful for debugging with manual runs.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
