### PR TITLE
fix(repo): add missing package manager flag to e2e utils

### DIFF
--- a/e2e/utils/command-utils.ts
+++ b/e2e/utils/command-utils.ts
@@ -143,7 +143,7 @@ export function getPackageManagerCommand({
     yarn: {
       createWorkspace: `npx ${
         +npmMajorVersion >= 7 ? '--yes' : ''
-      } create-nx-workspace@${publishedVersion}`,
+      } create-nx-workspace@${publishedVersion} --pm=yarn`,
       run: (script: string, args: string) => `yarn ${script} ${args}`,
       runNx: `yarn nx`,
       runNxSilent: `yarn --silent nx`,


### PR DESCRIPTION
The https://github.com/nrwl/nx/pull/16451 PR changed the way how yarn creates nx workspace but is missing a flag to enforce proper package manager.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
