### PR TITLE
fix(misc): cleanup migration to workspace-plugin

### DIFF
--- a/docs/generated/packages/plugin/generators/plugin.json
+++ b/docs/generated/packages/plugin/generators/plugin.json
@@ -87,6 +87,11 @@
         "enum": ["tsc", "swc"],
         "default": "tsc",
         "description": "The compiler used by the build and test targets."
+      },
+      "publishable": {
+        "type": "boolean",
+        "description": "Generates a boilerplate for publishing the plugin to npm.",
+        "default": false
       }
     },
     "required": ["name"],

--- a/packages/nx/src/generators/tree.spec.ts
+++ b/packages/nx/src/generators/tree.spec.ts
@@ -364,6 +364,13 @@ describe('tree', () => {
       } catch (e) {}
     });
 
+    it('should mark deleted folders as present if a file is created within it', () => {
+      tree.write('tools/some-file.txt', 'some content');
+      tree.delete('tools');
+      tree.write('tools/some-file2.txt', 'some content');
+      expect(tree.exists('tools')).toBe(true);
+    });
+
     describe('children', () => {
       it('should return the list of children of a dir', () => {
         expect(tree.children('parent')).toEqual([

--- a/packages/nx/src/generators/tree.ts
+++ b/packages/nx/src/generators/tree.ts
@@ -175,6 +175,15 @@ export class FsTree implements Tree {
       delete this.recordedChanges[this.rp(filePath)];
       return;
     }
+    // Remove any recorded changes where a parent directory has been
+    // deleted when writing a new file within the directory.
+    let parent = dirname(this.rp(filePath));
+    while (parent !== '.') {
+      if (this.recordedChanges[parent]?.isDeleted) {
+        delete this.recordedChanges[parent];
+      }
+      parent = dirname(parent);
+    }
     try {
       this.recordedChanges[this.rp(filePath)] = {
         content: Buffer.from(content),

--- a/packages/plugin/src/generators/plugin/plugin.ts
+++ b/packages/plugin/src/generators/plugin/plugin.ts
@@ -81,7 +81,7 @@ export async function pluginGenerator(host: Tree, schema: Schema) {
       ...schema,
       config: 'project',
       bundler: options.bundler,
-      publishable: true,
+      publishable: options.publishable,
       importPath: options.npmPackageName,
       skipFormat: true,
     })

--- a/packages/plugin/src/generators/plugin/schema.d.ts
+++ b/packages/plugin/src/generators/plugin/schema.d.ts
@@ -14,4 +14,5 @@ export interface Schema {
   setParserOptionsProject?: boolean;
   compiler: 'swc' | 'tsc';
   rootProject?: boolean;
+  publishable?: boolean;
 }

--- a/packages/plugin/src/generators/plugin/schema.json
+++ b/packages/plugin/src/generators/plugin/schema.json
@@ -87,6 +87,11 @@
       "enum": ["tsc", "swc"],
       "default": "tsc",
       "description": "The compiler used by the build and test targets."
+    },
+    "publishable": {
+      "type": "boolean",
+      "description": "Generates a boilerplate for publishing the plugin to npm.",
+      "default": false
     }
   },
   "required": ["name"]

--- a/packages/plugin/src/generators/plugin/utils/normalize-schema.ts
+++ b/packages/plugin/src/generators/plugin/utils/normalize-schema.ts
@@ -18,6 +18,7 @@ export interface NormalizedSchema extends Schema {
   npmScope: string;
   npmPackageName: string;
   bundler: 'swc' | 'tsc';
+  publishable: boolean;
 }
 export function normalizeOptions(
   host: Tree,
@@ -58,5 +59,6 @@ export function normalizeOptions(
     projectDirectory: fullProjectDirectory,
     parsedTags,
     npmPackageName,
+    publishable: options.publishable ?? false,
   };
 }

--- a/packages/plugin/src/generators/preset/generator.ts
+++ b/packages/plugin/src/generators/preset/generator.ts
@@ -26,6 +26,7 @@ export default async function (tree: Tree, options: PresetGeneratorSchema) {
     importPath: options.pluginName,
     rootProject: true,
     e2eTestRunner: 'jest',
+    publishable: true,
   });
   tasks.push(pluginTask);
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
- The migration to a workspace-plugin adds a publish target
- Plugins have a publish target by default even when created in an existing workspace (which likely has its own publish flow)
- The migration runs even if the only element in the `generators` directory is .gitkeep

## Expected Behavior
- Generated plugin does not include a publish target
- Migration skips most of the changes if no generators present

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
