### PR TITLE
fix(misc): set default e2e test runner when creating angular and next workspaces

### DIFF
--- a/packages/workspace/src/generators/preset/preset.ts
+++ b/packages/workspace/src/generators/preset/preset.ts
@@ -33,7 +33,7 @@ async function createPreset(tree: Tree, options: Schema) {
       linter: options.linter,
       standalone: options.standaloneApi,
       routing: options.routing,
-      e2eTestRunner: options.e2eTestRunner,
+      e2eTestRunner: options.e2eTestRunner ?? 'cypress',
     });
   } else if (options.preset === Preset.AngularStandalone) {
     const {
@@ -91,6 +91,7 @@ async function createPreset(tree: Tree, options: Schema) {
       style: options.style,
       linter: options.linter,
       appDir: options.nextAppDir,
+      e2eTestRunner: options.e2eTestRunner ?? 'cypress',
       rootProject: true,
     });
   } else if (options.preset === Preset.WebComponents) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Creating a new Angular or Next.js workspace doesn't create the Cypress E2E project.

This is a regression introduced in https://github.com/nrwl/nx/pull/16414.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Creating a new Angular or Next.js workspace should create a Cypress E2E project by default.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
