### PR TITLE
fix(nextjs): output path for standalone apps

### DIFF
--- a/packages/next/src/generators/application/lib/add-project.ts
+++ b/packages/next/src/generators/application/lib/add-project.ts
@@ -9,13 +9,18 @@ import {
 export function addProject(host: Tree, options: NormalizedSchema) {
   const targets: Record<string, any> = {};
 
+  const outputPath = joinPathFragments(
+    'dist',
+    options.appProjectRoot,
+    ...(options.rootProject ? [options.name] : [])
+  );
   targets.build = {
     executor: '@nx/next:build',
     outputs: ['{options.outputPath}'],
     defaultConfiguration: 'production',
     options: {
       root: options.appProjectRoot,
-      outputPath: joinPathFragments('dist', options.appProjectRoot),
+      outputPath: outputPath,
     },
     configurations: {
       development: {

--- a/packages/next/src/generators/application/lib/create-application-files.ts
+++ b/packages/next/src/generators/application/lib/create-application-files.ts
@@ -80,6 +80,7 @@ export function createApplicationFiles(host: Tree, options: NormalizedSchema) {
             ...(updatedJson.exclude || []),
             ...(appJSON.exclude || []),
             '**e2e/**/*',
+            `dist/${options.name}/**/*`,
           ]),
         ],
       };


### PR DESCRIPTION
When you create a standalone `nextjs` app the output path should be `dist/<app-name>` instead of `dist` which aligns with other nx plugins such as React and Angular