### PR TITLE
feat(testing): add --strict flag for jest-preset-angular test env opts

### DIFF
--- a/packages/angular/src/generators/application/lib/add-unit-test-runner.ts
+++ b/packages/angular/src/generators/application/lib/add-unit-test-runner.ts
@@ -1,4 +1,4 @@
-import type { Tree } from '@nx/devkit';
+import { Tree, joinPathFragments } from '@nx/devkit';
 import type { NormalizedSchema } from './normalized-schema';
 
 import { jestProjectGenerator } from '@nx/jest';
@@ -15,5 +15,24 @@ export async function addUnitTestRunner(host: Tree, options: NormalizedSchema) {
       skipPackageJson: options.skipPackageJson,
       skipFormat: true,
     });
+    const setupFile = joinPathFragments(
+      options.appProjectRoot,
+      'src',
+      'test-setup.ts'
+    );
+    if (options.strict && host.exists(setupFile)) {
+      const contents = host.read(setupFile, 'utf-8');
+      host.write(
+        setupFile,
+        `// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
+globalThis.ngJest = {
+  testEnvironmentOptions: {
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true,
+  },
+};
+${contents}`
+      );
+    }
   }
 }

--- a/packages/angular/src/generators/library/library.ts
+++ b/packages/angular/src/generators/library/library.ts
@@ -134,6 +134,25 @@ async function addUnitTestRunner(
       skipFormat: true,
       skipPackageJson: options.skipPackageJson,
     });
+    const setupFile = joinPathFragments(
+      options.projectRoot,
+      'src',
+      'test-setup.ts'
+    );
+    if (options.strict && host.exists(setupFile)) {
+      const contents = host.read(setupFile, 'utf-8');
+      host.write(
+        setupFile,
+        `// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
+globalThis.ngJest = {
+  testEnvironmentOptions: {
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true,
+  },
+};
+${contents}`
+      );
+    }
   }
 }
 

--- a/packages/jest/src/generators/jest-project/__snapshots__/jest-project.spec.ts.snap
+++ b/packages/jest/src/generators/jest-project/__snapshots__/jest-project.spec.ts.snap
@@ -81,7 +81,7 @@ export default {
 "
 `;
 
-exports[`jestProject should generate files 1`] = `
+exports[`jestProject should generate files 2`] = `
 "/* eslint-disable */
 export default {
   displayName: 'lib1',

--- a/packages/jest/src/generators/jest-project/jest-project.spec.ts
+++ b/packages/jest/src/generators/jest-project/jest-project.spec.ts
@@ -50,7 +50,11 @@ describe('jestProject', () => {
       project: 'lib1',
       setupFile: 'angular',
     } as JestProjectSchema);
-    expect(tree.exists('libs/lib1/src/test-setup.ts')).toBeTruthy();
+    expect(tree.read('libs/lib1/src/test-setup.ts', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "import 'jest-preset-angular/setup-jest';
+      "
+    `);
     expect(tree.exists('libs/lib1/jest.config.ts')).toBeTruthy();
     expect(tree.exists('libs/lib1/tsconfig.spec.json')).toBeTruthy();
     expect(tree.read('libs/lib1/jest.config.ts', 'utf-8')).toMatchSnapshot();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
jest-preset-angular has options to configure ng TestBed to error on unknown properties and elements but must be manually configured in each test-setup file

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
when creating an angular project. providing the --strict flag should auto setup jest-preset-angular to fail when unknown properties/elements are used

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16352 
