### PR TITLE
fix(core): fix cache recalculation

### DIFF
--- a/packages/nx/src/project-graph/nx-deps-cache.spec.ts
+++ b/packages/nx/src/project-graph/nx-deps-cache.spec.ts
@@ -7,6 +7,7 @@ import {
 import { ProjectGraph } from '../config/project-graph';
 import { ProjectsConfigurations } from '../config/workspace-json-project-json';
 import { NxJsonConfiguration } from '../config/nx-json';
+import { nxVersion } from '../utils/versions';
 
 describe('nx deps utils', () => {
   describe('shouldRecomputeWholeGraph', () => {
@@ -34,14 +35,11 @@ describe('nx deps utils', () => {
       ).toEqual(true);
     });
 
-    it('should be true when version of nrwl/workspace changes', () => {
+    it('should be true when version of nx changes', () => {
       expect(
         shouldRecomputeWholeGraph(
           createCache({
-            deps: {
-              '@nx/workspace': '12.0.1',
-              plugin: '1.0.0',
-            },
+            nxVersion: '12.0.1',
           }),
           createPackageJsonDeps({}),
           createProjectsConfiguration({}),
@@ -317,10 +315,8 @@ describe('nx deps utils', () => {
   function createCache(p: Partial<ProjectGraphCache>): ProjectGraphCache {
     const defaults: ProjectGraphCache = {
       version: '5.1',
-      deps: {
-        '@nx/workspace': '12.0.0',
-        plugin: '1.0.0',
-      },
+      nxVersion: nxVersion,
+      deps: {},
       pathMappings: {
         mylib: ['libs/mylib/index.ts'],
       },

--- a/packages/nx/src/project-graph/nx-deps-cache.ts
+++ b/packages/nx/src/project-graph/nx-deps-cache.ts
@@ -19,9 +19,11 @@ import {
   readJsonFile,
   writeJsonFile,
 } from '../utils/fileutils';
+import { nxVersion } from '../utils/versions';
 
 export interface ProjectGraphCache {
   version: string;
+  nxVersion: string;
   deps: Record<string, string>;
   pathMappings: Record<string, any>;
   nxJsonPlugins: { name: string; version: string }[];
@@ -93,7 +95,8 @@ export function createCache(
   }));
   const newValue: ProjectGraphCache = {
     version: projectGraph.version || '5.1',
-    deps: packageJsonDeps,
+    nxVersion: nxVersion,
+    deps: packageJsonDeps, // TODO(v18): We can remove this in favor of nxVersion
     // compilerOptions may not exist, especially for package-based repos
     pathMappings: tsConfig?.compilerOptions?.paths || {},
     nxJsonPlugins,
@@ -149,13 +152,7 @@ export function shouldRecomputeWholeGraph(
   if (cache.version !== '5.1') {
     return true;
   }
-  if (
-    cache.deps['@nx/workspace'] !== packageJsonDeps['@nx/workspace'] ||
-    cache.deps['@nrwl/workspace'] !== packageJsonDeps['@nrwl/workspace']
-  ) {
-    return true;
-  }
-  if (cache.deps['nx'] !== packageJsonDeps['nx']) {
+  if (cache.nxVersion !== nxVersion) {
     return true;
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When the nx cache is checked, the version that is being compared, is the version in the workspace's `package.json`. So even if `install` has not been run yet, it will report that it calculated the graph with the new version. Thus, when the new version is actually installed, it will not need to recalculate the graph.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When the nx cache is checked, the version being compared will be the installed version of `nx`. So if `install` hasn't been run yet, it will reuse the cache. But when the new version is installed, it will recalculate.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
