### PR TITLE
fix(core): fix nx package group to have correct legacy eslint-plugin

### DIFF
--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -111,7 +111,7 @@
       "@nx/esbuild",
       "@nrwl/esbuild",
       "@nx/eslint-plugin",
-      "@nx/eslint-plugin",
+      "@nrwl/eslint-plugin-nx",
       "@nx/expo",
       "@nrwl/expo",
       "@nx/express",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The legacy `eslint-plugin` in the `nx` package got mistakenly renamed.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The legacy `eslint-plugin` in the `nx` package is correct.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
