### PR TITLE
fix(nextjs): support workspace libs with standalone Next.js app

### DIFF
--- a/packages/next/src/generators/application/lib/create-application-files.ts
+++ b/packages/next/src/generators/application/lib/create-application-files.ts
@@ -63,6 +63,10 @@ export function createApplicationFiles(host: Tree, options: NormalizedSchema) {
 
       let { extends: _, ...updatedJson } = json;
 
+      // Don't generate the `paths` object or else workspace libs will not work later.
+      // It'll be generated as needed when a lib is first added.
+      delete json.compilerOptions.paths;
+
       updatedJson = {
         ...updateJson,
         compilerOptions: {

--- a/packages/next/src/generators/library/library.ts
+++ b/packages/next/src/generators/library/library.ts
@@ -54,7 +54,20 @@ export async function libraryGenerator(host: Tree, rawOptions: Schema) {
       'src',
       `server.${options.js ? 'js' : 'ts'}`
     ),
-    `// Use this file to export React server components\n`
+    `// Use this file to export React server components
+    export * from './lib/hello-server';`
+  );
+  host.write(
+    joinPathFragments(
+      options.projectRoot,
+      'src/lib',
+      `hello-server.${options.js ? 'js' : 'tsx'}`
+    ),
+    `// React server components are async so you make database or API calls.
+      export async function HelloServer() {
+        return <h1>Hello Server</h1>
+      }
+    `
   );
   addTsConfigPath(host, `${options.importPath}/server`, [serverEntryPath]);
 

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -43,7 +43,7 @@ export async function libraryGenerator(host: Tree, schema: Schema) {
     ...options,
     e2eTestRunner: 'none',
     skipFormat: true,
-    skipBabelConfig: options.bundler === 'vite',
+    skipBabelConfig: options.bundler === 'vite' || options.compiler === 'swc',
     skipHelperLibs: options.bundler === 'vite',
   });
   tasks.push(initTask);


### PR DESCRIPTION
This PR fixes the setup when generating and using workspace libs in a Next.js standalone app.

1. When `@nx/next:lib` is used, babel files should not be generated since we are using SWC.
2. `compilerOptions.paths: {}` should not exist for standalone `tsconfig.json`, because migrating after generating lib will override the base paths in `tsconfig.base.json` file.