### PR TITLE
fix(misc): create-nx-workspace should work with custom presets on windows

### DIFF
--- a/packages/create-nx-workspace/src/utils/child-process-utils.ts
+++ b/packages/create-nx-workspace/src/utils/child-process-utils.ts
@@ -12,6 +12,8 @@ export function spawnAndWait(command: string, args: string[], cwd: string) {
       cwd,
       stdio: 'inherit',
       env: { ...process.env, NX_DAEMON: 'false' },
+      shell: true,
+      windowsHide: true,
     });
 
     childProcess.on('exit', (code) => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`create-nx-workspace` fails when trying to run something like this on windows:
```typescript
spawn('npx', args, {
 // ... some options
})
```

This is because `npx` is actually `npx.cmd` on windows - but, using `shell: true` also fixes it and handles similar problems for yarn or pnpx.

## Expected Behavior
`create-nx-workspace` can generate custom presets on windows

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16231 
