### PR TITLE
fix(testing): fix react CT w/ vite and dependant projects

### DIFF
--- a/packages/react/src/generators/cypress-component-configuration/lib/add-files.ts
+++ b/packages/react/src/generators/cypress-component-configuration/lib/add-files.ts
@@ -56,6 +56,13 @@ export async function addFiles(
     addDependenciesToPackageJson(tree, {}, { '@nx/webpack': nxVersion });
   }
 
+  if (
+    options.bundler === 'vite' ||
+    (!options.bundler && actualBundler === 'vite')
+  ) {
+    addDependenciesToPackageJson(tree, {}, { '@nx/vite': nxVersion });
+  }
+
   if (options.generateTests) {
     const filePaths = [];
     visitNotIgnoredFiles(tree, projectConfig.sourceRoot, (filePath) => {

--- a/scripts/depcheck/missing.ts
+++ b/scripts/depcheck/missing.ts
@@ -114,6 +114,8 @@ const IGNORE_MATCHES_IN_PACKAGE = {
     'url-loader',
     'webpack',
     'webpack-merge',
+    // used via the CT react plugin installed via vite plugin
+    'vite',
   ],
   'react-native': ['@nx/storybook'],
   rollup: ['@swc/core'],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When using vite with react component testing and trying to import a dependent project, vite will throw an error saying it's outside of the allows list of reading from the file system

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
vite should be allowed to react dependent projects files in CT

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Note this is only an issue in CT because cypress loads the given vite file which is missing the fs allow entry, but isn't a problem when serving projects via nx due to vite executor providing this value automatically (which cypress does not do)

TODO:
- [x] write tests
