### PR TITLE
fix(core): use located tsconfig name for tsconfig-paths when registering local plugin transpiler

### DIFF
--- a/packages/nx/src/utils/nx-plugin.ts
+++ b/packages/nx/src/utils/nx-plugin.ts
@@ -260,16 +260,18 @@ export function registerPluginTSTranspiler() {
   if (!tsNodeAndPathsRegistered) {
     // nx-ignore-next-line
     const ts: typeof import('typescript') = require('typescript');
-    const tsConfigName = existsSync('tsconfig.base.json')
-      ? 'tsconfig.base.json'
-      : existsSync('tsconfig.json')
-      ? 'tsconfig.json'
-      : null;
+
+    // Get the first tsconfig that matches the allowed set
+    const tsConfigName = [
+      join(workspaceRoot, 'tsconfig.base.json'),
+      join(workspaceRoot, 'tsconfig.json'),
+    ].find((x) => existsSync(x));
+
     const tsConfig: Partial<ts.ParsedCommandLine> = tsConfigName
       ? readTsConfig(tsConfigName)
       : {};
 
-    registerTsConfigPaths(join(workspaceRoot, 'tsconfig.base.json'));
+    registerTsConfigPaths(tsConfigName);
     registerTranspiler({
       experimentalDecorators: true,
       emitDecoratorMetadata: true,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
In standalone workspaces (or other workspaces that use tsconfig.json instead of tsconfig.base.json), there is a warning shown: 
![image](https://user-images.githubusercontent.com/6933928/233737414-8b663233-2f9c-4412-819c-2275dbd4cc47.png)


## Expected Behavior
No warning:
![image](https://user-images.githubusercontent.com/6933928/233737383-0b461414-6e2f-4742-98a3-d701b2eb22c4.png)


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
