### PR TITLE
docs(misc): add scroll to terminal component

### DIFF
--- a/nx-dev/ui-markdoc/src/lib/nodes/fences/terminal-output.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/nodes/fences/terminal-output.component.tsx
@@ -19,7 +19,7 @@ export function TerminalOutput({
         </div>
         <span>Terminal</span>
       </div>
-      <div className="p-4 pt-2">
+      <div className="overflow-x-auto p-4 pt-2">
         <div className="flex items-center">
           <p className="mt-0.5">
             <span className="text-purple-600 dark:text-fuchsia-500">


### PR DESCRIPTION
## Current Behavior
Terminal components cut off content wider than width.

https://nx.dev/tutorials/package-based-repo-tutorial#cache-build-results
<img width="1470" alt="Screenshot 2023-04-22 at 10 08 23 AM" src="https://user-images.githubusercontent.com/1536471/233795170-e168ea14-6fa7-4c4b-ba64-faba0a1672f7.png">

## Expected Behavior
Terminal components scroll horizontally when content is too wide.

