### PR TITLE
fix(node): use consistent default port

### DIFF
--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -323,8 +323,8 @@ describe('app', () => {
       expect(tree.exists('my-frontend/proxy.conf.json')).toBeTruthy();
 
       expect(readJson(tree, 'my-frontend/proxy.conf.json')).toEqual({
-        '/api': { target: 'http://localhost:3333', secure: false },
-        '/billing-api': { target: 'http://localhost:3333', secure: false },
+        '/api': { target: 'http://localhost:3000', secure: false },
+        '/billing-api': { target: 'http://localhost:3000', secure: false },
       });
     });
 

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -483,7 +483,7 @@ function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
     linter: options.linter ?? Linter.EsLint,
     unitTestRunner: options.unitTestRunner ?? 'jest',
     rootProject: options.rootProject ?? false,
-    port: options.port ?? 3333,
+    port: options.port ?? 3000,
   };
 }
 


### PR DESCRIPTION
## Current Behavior
The Node application generator has two different default ports: 3000 in the `schema.json` and 3333 in the generator itself. This results in a failing e2e test after generation.

## Expected Behavior
The default port is consistent.

