### PR TITLE
feat(repo): use @pnpm/exe over pnpm for CI runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ commands:
     steps:
       - run:
           name: Install PNPM
-          command: npm install --prefix=$HOME/.local -g pnpm@7.30.3
+          command: npm install --prefix=$HOME/.local -g @pnpm/exe@8.3.1
 
   setup:
     parameters:

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -321,9 +321,8 @@ jobs:
 
       - name: Install PNPM
         if: ${{ matrix.package_manager == 'pnpm' }}
-        uses: pnpm/action-setup@v2
-        with:
-          version: 7.30.5
+        run: |
+          npm install -g @pnpm/exe@8.3.1
 
       - name: Use Node.js ${{ matrix.node_version }}
         uses: actions/setup-node@v3


### PR DESCRIPTION
Use `@pnpm/exe` instead of `pnpm` on CIs

Based on the [investigation](https://github.com/pnpm/pnpm/issues/6447) using `@pnpm/exe` (standalone installation) is considerably faster than standard `pnpm`.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
