### PR TITLE
fix(nextjs): use require("next") since exports.default is no longer provided

### DIFF
--- a/packages/next/src/executors/server/lib/default-server.ts
+++ b/packages/next/src/executors/server/lib/default-server.ts
@@ -1,6 +1,4 @@
 import * as express from 'express';
-import * as path from 'path';
-import next from 'next';
 import { NextServerOptions, ProxyConfig } from '../../../utils/types';
 
 /**
@@ -11,6 +9,7 @@ export async function defaultServer(
   settings: NextServerOptions,
   proxyConfig?: ProxyConfig
 ): Promise<void> {
+  const next = require('next');
   const app = next(settings);
   const handle = app.getRequestHandler();
 


### PR DESCRIPTION
WIth Next.js 13.3.1, `exports.default` is no longer provided when imported as a CommonJS module. This is breaking our `serve` executor.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16479
