### PR TITLE
fix(repo): fix mismatched package manager e2e utils

### DIFF
--- a/e2e/utils/command-utils.ts
+++ b/e2e/utils/command-utils.ts
@@ -152,7 +152,7 @@ export function getPackageManagerCommand({
       ciInstall: 'yarn --frozen-lockfile',
       addProd: isYarnWorkspace ? 'yarn add -W' : 'yarn add',
       addDev: isYarnWorkspace ? 'yarn add -DW' : 'yarn add -D',
-      list: 'npm ls --depth 10',
+      list: 'yarn list --pattern',
       runLerna: `yarn --silent lerna`,
     },
     // Pnpm 3.5+ adds nx to
@@ -166,7 +166,7 @@ export function getPackageManagerCommand({
       ciInstall: 'pnpm install --frozen-lockfile',
       addProd: isPnpmWorkspace ? 'pnpm add -w' : 'pnpm add',
       addDev: isPnpmWorkspace ? 'pnpm add -Dw' : 'pnpm add -D',
-      list: 'npm ls --depth 10',
+      list: 'pnpm ls --depth 10',
       runLerna: `pnpm exec lerna`,
     },
   }[packageManager.trim() as PackageManager];


### PR DESCRIPTION
Several tests are failing on nightly because we are attempting to run `npm ls` on `pnpm` or `yarn` repo.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
