### PR TITLE
fix(misc): safely iterate over package.json scripts in nx init command

### DIFF
--- a/packages/nx/src/nx-init/add-nx-to-nest.ts
+++ b/packages/nx/src/nx-init/add-nx-to-nest.ts
@@ -51,7 +51,7 @@ export async function addNxToNest(options: Options, packageJson: PackageJson) {
     'test:watch',
   ];
 
-  const scripts = Object.keys(packageJson.scripts).filter((s) => {
+  const scripts = Object.keys(packageJson.scripts ?? {}).filter((s) => {
     if (nestCacheableScripts.includes(s) || nestIgnoreScripts.includes(s)) {
       return false;
     }

--- a/packages/nx/src/nx-init/add-nx-to-npm-repo.ts
+++ b/packages/nx/src/nx-init/add-nx-to-npm-repo.ts
@@ -25,7 +25,7 @@ export async function addNxToNpmRepo(options: Options) {
   let useNxCloud: boolean;
 
   const packageJson = readJsonFile('package.json');
-  const scripts = Object.keys(packageJson.scripts).filter(
+  const scripts = Object.keys(packageJson.scripts ?? {}).filter(
     (s) => !s.startsWith('pre') && !s.startsWith('post')
   );
 

--- a/packages/nx/src/nx-init/angular/standalone-workspace.ts
+++ b/packages/nx/src/nx-init/angular/standalone-workspace.ts
@@ -43,7 +43,7 @@ export async function setupStandaloneWorkspace(
   // convert workspace config format to standalone project configs
   // update its targets outputs and delete angular.json
   const projects = toNewFormat(angularJson).projects;
-  for (const [projectName, project] of Object.entries(projects)) {
+  for (const [projectName, project] of Object.entries(projects ?? {})) {
     updateProjectOutputs(repoRoot, project);
     writeJsonFile(join(project.root, 'project.json'), {
       $schema: normalizePath(
@@ -162,7 +162,7 @@ function getWorkspaceCapabilities(
     karmaProjectConfigFile: false,
   };
 
-  for (const project of Object.values(projects)) {
+  for (const project of Object.values(projects ?? {})) {
     if (
       !capabilities.eslintProjectConfigFile &&
       projectHasEslintConfig(project)


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Running `nx init` command on a repo where the `package.json` file doesn't have a `scripts` entry throws an error.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `nx init` command should safely handle a repo with a `package.json` without a `scripts` entry.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16505 
