### PR TITLE
fix(nextjs): do not generate test for appDir page.tsx

### DIFF
--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -452,12 +452,12 @@ describe('app', () => {
 
       expect(tree.exists('apps/testApp/pages/styles.css')).toBeFalsy();
 
-      expect(tree.exists('apps/testApp/app/global.css'));
-      expect(tree.exists('apps/testApp/app/page.tsx'));
-      expect(tree.exists('apps/testApp/app/layout.tsx'));
-      expect(tree.exists('apps/testApp/app/api/hello/route.ts'));
-      expect(tree.exists('apps/testApp/app/page.module.css'));
-      expect(tree.exists('apps/testApp/app/favicon.ico'));
+      expect(tree.exists('apps/test-app/app/global.css')).toBeTruthy();
+      expect(tree.exists('apps/test-app/app/page.tsx')).toBeTruthy();
+      expect(tree.exists('apps/test-app/app/layout.tsx')).toBeTruthy();
+      expect(tree.exists('apps/test-app/app/api/hello/route.ts')).toBeTruthy();
+      expect(tree.exists('apps/test-app/app/page.module.css')).toBeTruthy();
+      expect(tree.exists('apps/test-app/public/favicon.ico')).toBeTruthy();
     });
   });
 });

--- a/packages/next/src/generators/application/lib/create-application-files.ts
+++ b/packages/next/src/generators/application/lib/create-application-files.ts
@@ -1,6 +1,7 @@
 import { join } from 'path';
 import {
   generateFiles,
+  joinPathFragments,
   names,
   readJson,
   toJS,
@@ -47,6 +48,13 @@ export function createApplicationFiles(host: Tree, options: NormalizedSchema) {
       join(__dirname, '../files/app'),
       join(options.appProjectRoot, 'app'),
       templateVariables
+    );
+    host.delete(
+      joinPathFragments(
+        options.appProjectRoot,
+        'specs',
+        `index.spec.${options.js ? 'jsx' : 'tsx'}`
+      )
     );
   } else {
     generateFiles(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
when using the new appDir apps are generated with a spec file pointing to the old pages dir

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
tests are not generated for appDir since page.tsx is an async server side component.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
