### PR TITLE
fix(js): throw better error messaging when a dependency is not in the graph

### DIFF
--- a/packages/nx/src/plugins/js/package-json/create-package-json.ts
+++ b/packages/nx/src/plugins/js/package-json/create-package-json.ts
@@ -226,7 +226,7 @@ function findAllNpmDeps(
         seen.add(dep);
         npmDeps.dependencies[node.data.packageName] = node.data.version;
         recursivelyCollectPeerDependencies(node.name, graph, npmDeps, seen);
-      } else {
+      } else if (graph.nodes[dep]) {
         findAllNpmDeps(
           graph.nodes[dep],
           graph,
@@ -234,6 +234,8 @@ function findAllNpmDeps(
           seen,
           dependencyPatterns
         );
+      } else {
+        throw new Error(`Could not find ${dep} in the project graph.`);
       }
     }
   }


### PR DESCRIPTION
… graph

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When trying to build the package.json, we don't null check a property access resulting in a confusing error message

## Expected Behavior
We null check and throw a more appropriate error.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16489
