### PR TITLE
feat(core): add a monkey-patch for require to use @nx packages instea…

### DIFF
--- a/packages/nx/src/plugins/js/utils/register.spec.ts
+++ b/packages/nx/src/plugins/js/utils/register.spec.ts
@@ -1,5 +1,5 @@
 import { JsxEmit, ModuleKind, ScriptTarget } from 'typescript';
-import { getTsNodeCompilerOptions } from '../plugins/js/utils/register';
+import { getTsNodeCompilerOptions } from './register';
 
 describe('getTsNodeCompilerOptions', () => {
   it('should replace enum value with enum key for module', () => {

--- a/packages/nx/src/utils/register.ts
+++ b/packages/nx/src/utils/register.ts
@@ -1,0 +1,2 @@
+// TODO(v17): remove this re-export
+export * from '../plugins/js/utils/register';


### PR DESCRIPTION
…d of @nrwl

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Deep imports to `@nrwl/` packages can break with the rescope.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Hopefully, most of these imports are done within the Nx process (generators, executors, etc.). Sometimes, they can be outside of these contexts, such as worker processes. We can address those by actually re-exporting the failing imports.

This monkey patch gives us most of the backwards compatibility without adding a lot of unnecessary code to maintain.

Also, there is a file from `nx` that has been removed, which breaks backwards compatibility. This adds the file back which re-exports the same tokens from the new file.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
