### PR TITLE
feat(nx-plugin): add execute target to generated create-package

### DIFF
--- a/docs/generated/packages/js/executors/node.json
+++ b/docs/generated/packages/js/executors/node.json
@@ -59,6 +59,11 @@
         "type": "boolean",
         "description": "Enable re-building when files change.",
         "default": true
+      },
+      "cwd": {
+        "type": "string",
+        "description": "The current working directory for the process.",
+        "default": "${workspaceRoot}"
       }
     },
     "additionalProperties": false,

--- a/e2e/workspace-create/src/create-nx-plugin.test.ts
+++ b/e2e/workspace-create/src/create-nx-plugin.test.ts
@@ -70,6 +70,12 @@ describe('create-nx-plugin', () => {
     runCLI(`build create-${pluginName}-package`);
     checkFilesExist(`dist/create-${pluginName}-package/bin/index.js`);
 
+    expect(() =>
+      runCLI(`execute create-${pluginName}-package --args test-workspace`)
+    ).not.toThrow();
+    expect(() =>
+      checkFilesExist('tmp/test-workspace/package.json')
+    ).not.toThrow();
     expect(() => runCLI(`e2e e2e`)).not.toThrow();
     expect(() => runCLI(`e2e create-${pluginName}-package-e2e`)).not.toThrow();
   });

--- a/packages/create-nx-workspace/src/utils/package-manager.ts
+++ b/packages/create-nx-workspace/src/utils/package-manager.ts
@@ -43,7 +43,7 @@ export function getPackageManagerCommand(
   switch (packageManager) {
     case 'yarn':
       const useBerry = +pmMajor >= 2;
-      const installCommand = 'yarn install --silent';
+      const installCommand = 'yarn install';
       return {
         install: useBerry
           ? installCommand
@@ -57,13 +57,13 @@ export function getPackageManagerCommand(
         useExec = true;
       }
       return {
-        install: 'pnpm install --no-frozen-lockfile --silent --ignore-scripts',
+        install: 'pnpm install --no-frozen-lockfile --ignore-scripts',
         exec: useExec ? 'pnpm exec' : 'pnpx',
       };
 
     case 'npm':
       return {
-        install: 'npm install --silent --ignore-scripts',
+        install: 'npm install --ignore-scripts',
         exec: 'npx',
       };
   }

--- a/packages/js/src/executors/node/schema.d.ts
+++ b/packages/js/src/executors/node/schema.d.ts
@@ -13,4 +13,5 @@ export interface NodeExecutorOptions {
   host: string;
   port: number;
   watch?: boolean;
+  cwd?: string;
 }

--- a/packages/js/src/executors/node/schema.json
+++ b/packages/js/src/executors/node/schema.json
@@ -67,6 +67,11 @@
       "type": "boolean",
       "description": "Enable re-building when files change.",
       "default": true
+    },
+    "cwd": {
+      "type": "string",
+      "description": "The current working directory for the process.",
+      "default": "${workspaceRoot}"
     }
   },
   "additionalProperties": false,

--- a/packages/plugin/src/generators/create-package/create-package.ts
+++ b/packages/plugin/src/generators/create-package/create-package.ts
@@ -13,6 +13,7 @@ import {
   joinPathFragments,
 } from '@nx/devkit';
 import { libraryGenerator as jsLibraryGenerator } from '@nx/js';
+import { NodeExecutorOptions } from '@nx/js/src/executors/node/schema';
 import { nxVersion } from 'nx/src/utils/versions';
 import generatorGenerator from '../generator/generator';
 import { CreatePackageSchema } from './schema';
@@ -122,6 +123,16 @@ async function createCliPackage(
   projectConfiguration.targets.build.options.updateBuildableProjectDepsInPackageJson =
     false;
   projectConfiguration.implicitDependencies = [options.project];
+
+  projectConfiguration.targets.execute = {
+    executor: '@nx/js:node',
+    options: {
+      cwd: './tmp',
+      buildTarget: `${options.projectName}:build`,
+      watch: false,
+    } as NodeExecutorOptions,
+  };
+
   updateProjectConfiguration(host, options.projectName, projectConfiguration);
 
   // Add bin files to tsconfg.lib.json


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
There is no clear way to run a create-package generated for an nx-plugin

## Expected Behavior
There is a target called "execute" you can use to run the create-package

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
