### PR TITLE
fix(nextjs): ignore components in appDir when generating cy files

### DIFF
--- a/packages/next/src/generators/cypress-component-configuration/cypress-component-configuration.ts
+++ b/packages/next/src/generators/cypress-component-configuration/cypress-component-configuration.ts
@@ -15,6 +15,7 @@ import { isComponent } from '@nx/react/src/utils/ct-utils';
 import { CypressComponentConfigurationGeneratorSchema } from './schema';
 import { nxVersion } from '../../utils/versions';
 import { componentTestGenerator } from '@nx/react';
+import { normalize, relative } from 'path';
 
 export async function cypressComponentConfiguration(
   tree: Tree,
@@ -99,8 +100,14 @@ async function addFiles(
   if (opts.generateTests) {
     const filePaths = [];
     visitNotIgnoredFiles(tree, projectConfig.sourceRoot, (filePath) => {
-      // we don't generate tests for pages/server-side components
-      if (filePath.includes('pages') || filePath.includes('server')) {
+      const fromProjectRootPath = relative(projectConfig.root, filePath);
+      console.log({ fromProjectRootPath, filePath });
+      // we don't generate tests for pages/server-side/appDir components
+      if (
+        fromProjectRootPath.includes('pages') ||
+        fromProjectRootPath.includes('server') ||
+        fromProjectRootPath.includes('app')
+      ) {
         return;
       }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
nx g cypress-component-configuration generates tests for SSR components in the appDir

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
nx g cypress-component-configuration ignores app dir like the pages directory

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
