### PR TITLE
fix(linter): replace eslint ignore comments during @nrwl -> @nx migra…

### DIFF
--- a/packages/eslint-plugin/src/migrations/update-16-0-0-add-nx-packages/update-16-0-0-add-nx-packages.spec.ts
+++ b/packages/eslint-plugin/src/migrations/update-16-0-0-add-nx-packages/update-16-0-0-add-nx-packages.spec.ts
@@ -59,4 +59,27 @@ describe('update-16-0-0-add-nx-packages', () => {
       }
     `);
   });
+
+  it('should replace eslint-ignore comments', async () => {
+    tree.write(
+      'ignored-file.ts',
+      '// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries\n /*\n* eslint-disable @nrwl/nx/enforce-module-boundaries\n*/\n // eslint-disable-line @nrwl/nx/enforce-module-boundaries'
+    );
+    tree.write('plugin.ts', `import * as p from '@nrwl/nx-plugin'`);
+
+    await replacePackage(tree);
+
+    expect(tree.read('ignored-file.ts').toString()).toMatchInlineSnapshot(`
+      "// eslint-disable-next-line @nx/enforce-module-boundaries
+      /*
+       * eslint-disable @nx/enforce-module-boundaries
+       */
+      // eslint-disable-line @nx/enforce-module-boundaries
+      "
+    `);
+    expect(tree.read('plugin.ts').toString()).toMatchInlineSnapshot(`
+      "import * as p from '@nrwl/nx-plugin';
+      "
+    `);
+  });
 });


### PR DESCRIPTION
…tion

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Eslint ignore comments for @nrwl/nx rules are not replaced during migration.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Eslint ignore comments for @nrwl/nx rules are replaced with @nx/*.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
