### PR TITLE
fix(linter): ensure target project locator is not using stale graph in IDE

### DIFF
--- a/packages/eslint-plugin/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin/src/rules/enforce-module-boundaries.ts
@@ -168,22 +168,14 @@ export default createESLintRule<Options, MessageIds>({
     );
     const fileName = normalizePath(context.getFilename());
 
-    const { projectGraph, projectRootMappings } = readProjectGraph(RULE_NAME);
+    const { projectGraph, projectRootMappings, targetProjectLocator } =
+      readProjectGraph(RULE_NAME);
 
     if (!projectGraph) {
       return {};
     }
 
     const workspaceLayout = (global as any).workspaceLayout;
-
-    if (!(global as any).targetProjectLocator) {
-      (global as any).targetProjectLocator = new TargetProjectLocator(
-        projectGraph.nodes,
-        projectGraph.externalNodes
-      );
-    }
-    const targetProjectLocator = (global as any)
-      .targetProjectLocator as TargetProjectLocator;
 
     function run(
       node:

--- a/packages/eslint-plugin/src/utils/project-graph-utils.ts
+++ b/packages/eslint-plugin/src/utils/project-graph-utils.ts
@@ -6,6 +6,7 @@ import {
   ProjectRootMappings,
 } from 'nx/src/project-graph/utils/find-project-for-path';
 import { readNxJson } from 'nx/src/project-graph/file-utils';
+import { TargetProjectLocator } from '@nx/js/src/internal';
 
 export function ensureGlobalProjectGraph(ruleName: string) {
   /**
@@ -25,9 +26,14 @@ export function ensureGlobalProjectGraph(ruleName: string) {
      * the ProjectGraph may or may not exist by the time the lint rule is invoked for the first time.
      */
     try {
-      (global as any).projectGraph = readCachedProjectGraph();
+      const projectGraph = readCachedProjectGraph();
+      (global as any).projectGraph = projectGraph;
       (global as any).projectRootMappings = createProjectRootMappings(
-        (global as any).projectGraph.nodes
+        projectGraph.nodes
+      );
+      (global as any).targetProjectLocator = new TargetProjectLocator(
+        projectGraph.nodes,
+        projectGraph.externalNodes
       );
     } catch {
       const WARNING_PREFIX = `${chalk.reset.keyword('orange')('warning')}`;
@@ -43,10 +49,12 @@ export function ensureGlobalProjectGraph(ruleName: string) {
 export function readProjectGraph(ruleName: string): {
   projectGraph: ProjectGraph;
   projectRootMappings: ProjectRootMappings;
+  targetProjectLocator: TargetProjectLocator;
 } {
   ensureGlobalProjectGraph(ruleName);
   return {
     projectGraph: (global as any).projectGraph,
     projectRootMappings: (global as any).projectRootMappings,
+    targetProjectLocator: (global as any).targetProjectLocator,
   };
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Despite project graph, and root mappings being generated fresh in IDE on every change, the rule uses stale target project locator

## Expected Behavior
The target project locator should be recreated every time the graph is changed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
