### PR TITLE
fix(expo): fix test clashing with react-native

### DIFF
--- a/e2e/expo/src/expo.test.ts
+++ b/e2e/expo/src/expo.test.ts
@@ -2,6 +2,7 @@ import {
   checkFilesExist,
   cleanupProject,
   expectTestsPass,
+  getPackageManagerCommand,
   killPorts,
   newProject,
   promisifiedTreeKill,
@@ -9,6 +10,7 @@ import {
   readResolvedConfiguration,
   runCLI,
   runCLIAsync,
+  runCommand,
   runCommandUntil,
   uniq,
   updateFile,
@@ -22,6 +24,8 @@ describe('expo', () => {
 
   beforeAll(() => {
     proj = newProject();
+    runCommand(`${getPackageManagerCommand().rm} @nx/react-native`);
+
     runCLI(`generate @nx/expo:application ${appName} --no-interactive`);
     runCLI(
       `generate @nx/expo:library ${libName} --buildable --publishable --importPath=${proj}/${libName}`

--- a/e2e/utils/command-utils.ts
+++ b/e2e/utils/command-utils.ts
@@ -114,6 +114,7 @@ export function getPackageManagerCommand({
   ciInstall: string;
   addProd: string;
   addDev: string;
+  rm: string;
   list: string;
   runLerna: string;
 } {
@@ -137,6 +138,7 @@ export function getPackageManagerCommand({
       ciInstall: 'npm ci',
       addProd: `npm install`,
       addDev: `npm install -D`,
+      rm: 'yarn remove',
       list: 'npm ls --depth 10',
       runLerna: `npx lerna`,
     },
@@ -152,6 +154,7 @@ export function getPackageManagerCommand({
       ciInstall: 'yarn --frozen-lockfile',
       addProd: isYarnWorkspace ? 'yarn add -W' : 'yarn add',
       addDev: isYarnWorkspace ? 'yarn add -DW' : 'yarn add -D',
+      rm: 'npm rm',
       list: 'yarn list --pattern',
       runLerna: `yarn --silent lerna`,
     },
@@ -166,6 +169,7 @@ export function getPackageManagerCommand({
       ciInstall: 'pnpm install --frozen-lockfile',
       addProd: isPnpmWorkspace ? 'pnpm add -w' : 'pnpm add',
       addDev: isPnpmWorkspace ? 'pnpm add -Dw' : 'pnpm add -D',
+      rm: 'pnpm rm',
       list: 'pnpm ls --depth 10',
       runLerna: `pnpm exec lerna`,
     },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
React-native has updated dependency to `react-native@0.71.7` while `expo` still depends on `react-native@0.71.6`.
The npm install fails because the peer deps (`expo`) have not been satisfied.

## Expected Behavior
Expo tests should not depend on the react-native version from `@nx/react-native`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
