### PR TITLE
fix(angular): remote static serve target should not watch for changes

### DIFF
--- a/packages/angular/src/generators/setup-mf/lib/setup-serve-target.ts
+++ b/packages/angular/src/generators/setup-mf/lib/setup-serve-target.ts
@@ -28,6 +28,7 @@ export function setupServeTarget(host: Tree, options: Schema) {
       options: {
         buildTarget: `${options.appName}:build`,
         port: options.port,
+        watch: false,
       },
       configurations: {
         development: {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
After switching to use the @nx/web:file-server executor, we didn't take into account that watch is set to true by default

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Generate remote applications to set watch to false for static serve

We can't write a migration for this because we have no discernable way of knowing if an application is a remote, and other generators now generate a static-serve target that use the same exectuor.
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16118
