### PR TITLE
fix(nextjs): Add debug ability when verbose is passed to build

### DIFF
--- a/docs/generated/packages/next/executors/build.json
+++ b/docs/generated/packages/next/executors/build.json
@@ -65,6 +65,11 @@
         "description": "Generate a lockfile (e.g. yarn.lock) that matches the workspace lockfile to ensure package versions match.",
         "default": false,
         "x-priority": "internal"
+      },
+      "debug": {
+        "type": "boolean",
+        "description": "Enable Next.js debug build logging",
+        "default": false
       }
     },
     "required": ["root", "outputPath"],

--- a/packages/next/src/executors/build/build.impl.ts
+++ b/packages/next/src/executors/build/build.impl.ts
@@ -9,7 +9,7 @@ import { createLockFile, createPackageJson, getLockFileName } from '@nx/js';
 import build from 'next/dist/build';
 import { join, resolve } from 'path';
 import { copySync, existsSync, mkdir, writeFileSync } from 'fs-extra';
-import { gte } from 'semver';
+import { lt, gte } from 'semver';
 import { directoryExists } from '@nx/workspace/src/utilities/fileutils';
 import { checkAndCleanWithSemver } from '@nx/devkit/src/utils/semver';
 
@@ -45,7 +45,20 @@ export default async function buildExecutor(
     (process.env as any).__NEXT_REACT_ROOT ||= 'true';
   }
 
-  await build(root);
+  // Get the installed Next.js version (will be removed after Nx 16 and Next.js update)
+  const nextVersion = require('next/package.json').version;
+
+  const debug = !!process.env.NX_VERBOSE_LOGGING || options.debug;
+
+  // Check the major and minor version numbers
+  if (lt(nextVersion, '13.2.0')) {
+    // If the version is lower than 13.2.0, use the second parameter as the config object
+    await build(root, null, false, debug);
+  } else {
+    // Otherwise, use the third parameter as a boolean flag for verbose logging
+    // @ts-ignore
+    await build(root, false, debug);
+  }
 
   if (!directoryExists(options.outputPath)) {
     mkdir(options.outputPath);

--- a/packages/next/src/executors/build/schema.json
+++ b/packages/next/src/executors/build/schema.json
@@ -62,6 +62,11 @@
       "description": "Generate a lockfile (e.g. yarn.lock) that matches the workspace lockfile to ensure package versions match.",
       "default": false,
       "x-priority": "internal"
+    },
+    "debug": {
+      "type": "boolean",
+      "description": "Enable Next.js debug build logging",
+      "default": false
     }
   },
   "required": ["root", "outputPath"]

--- a/packages/next/src/utils/types.ts
+++ b/packages/next/src/utils/types.ts
@@ -37,6 +37,7 @@ export interface NextBuildBuilderOptions {
   includeDevDependenciesInPackageJson?: boolean;
   generateLockfile?: boolean;
   watch?: boolean;
+  debug?: boolean;
 }
 
 export interface NextServeBuilderOptions {


### PR DESCRIPTION
Passing `--verbose` or `--debug` will add the debug to `next.js`' build

Fixes: #13164 