### PR TITLE
fix(core): do not replace legacy package mentions in binary files

### DIFF
--- a/packages/devkit/src/generators/generate-files.ts
+++ b/packages/devkit/src/generators/generate-files.ts
@@ -2,42 +2,9 @@ import { readFileSync, readdirSync, statSync } from 'fs';
 import * as path from 'path';
 import type { Tree } from 'nx/src/generators/tree';
 import { requireNx } from '../../nx';
+import { isBinaryPath } from '../utils/binary-extensions';
 
 const { logger } = requireNx();
-
-const binaryExts = new Set([
-  // // Image types originally from https://github.com/sindresorhus/image-type/blob/5541b6a/index.js
-  '.jpg',
-  '.jpeg',
-  '.png',
-  '.gif',
-  '.webp',
-  '.flif',
-  '.cr2',
-  '.tif',
-  '.bmp',
-  '.jxr',
-  '.psd',
-  '.ico',
-  '.bpg',
-  '.jp2',
-  '.jpm',
-  '.jpx',
-  '.heic',
-  '.cur',
-  '.tgz',
-
-  // Java files
-  '.jar',
-  '.keystore',
-
-  // Font files
-  '.ttf',
-  '.otf',
-  '.woff',
-  '.woff2',
-  '.eot',
-]);
 
 /**
  * Generates a folder of files based on provided templates.
@@ -84,7 +51,7 @@ export function generateFiles(
         substitutions
       );
 
-      if (binaryExts.has(path.extname(filePath))) {
+      if (isBinaryPath(filePath)) {
         newContent = readFileSync(filePath);
       } else {
         const template = readFileSync(filePath, 'utf-8');

--- a/packages/devkit/src/utils/binary-extensions.ts
+++ b/packages/devkit/src/utils/binary-extensions.ts
@@ -1,0 +1,48 @@
+import { extname } from 'path';
+
+const binaryExtensions = new Set([
+  // // Image types originally from https://github.com/sindresorhus/image-type/blob/5541b6a/index.js
+  '.jpg',
+  '.jpeg',
+  '.png',
+  '.gif',
+  '.webp',
+  '.flif',
+  '.cr2',
+  '.tif',
+  '.bmp',
+  '.jxr',
+  '.psd',
+  '.ico',
+  '.bpg',
+  '.jp2',
+  '.jpm',
+  '.jpx',
+  '.heic',
+  '.cur',
+  '.avif',
+  '.dcm',
+
+  // Compressed files
+  '.tgz',
+  '.gz',
+  '.zip',
+
+  // Documents
+  '.pdf',
+
+  // Java files
+  '.jar',
+  '.keystore',
+
+  // Font files
+  '.ttf',
+  '.otf',
+  '.woff',
+  '.woff2',
+  '.eot',
+]);
+
+export function isBinaryPath(path: string): boolean {
+  return binaryExtensions.has(extname(path));
+}

--- a/packages/devkit/src/utils/replace-package.ts
+++ b/packages/devkit/src/utils/replace-package.ts
@@ -4,6 +4,7 @@ import { requireNx } from '../../nx';
 import { NX_VERSION } from './package-json';
 import { visitNotIgnoredFiles } from '../generators/visit-not-ignored-files';
 import { basename } from 'path';
+import { isBinaryPath } from './binary-extensions';
 
 const {
   getProjects,
@@ -148,6 +149,10 @@ function replaceMentions(
   newPackageName: string
 ) {
   visitNotIgnoredFiles(tree, '.', (path) => {
+    if (isBinaryPath(path)) {
+      return;
+    }
+
     const ignoredFiles = [
       'yarn.lock',
       'package-lock.json',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Mentions of old packages are replaced in binary files such as images and `.jar` files.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Mentions of old packages are not replaced in binary files such as images and `.jar` files.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
