### PR TITLE
fix(js): ensure publishable libraries are not marked as private

### DIFF
--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -318,10 +318,14 @@ function createFiles(tree: Tree, options: NormalizedSchema, filesDir: string) {
     'package.json'
   );
   if (tree.exists(packageJsonPath)) {
-    updateJson(tree, packageJsonPath, (json) => {
+    updateJson<PackageJson>(tree, packageJsonPath, (json) => {
       json.name = options.importPath;
       json.version = '0.0.1';
       json.type = 'commonjs';
+      // If the package is publishable, we should remove the private field.
+      if (json.private && options.publishable) {
+        delete json.private;
+      }
       return json;
     });
   } else {

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -39,6 +39,7 @@ export interface PackageJson {
   name: string;
   version: string;
   license?: string;
+  private?: boolean;
   scripts?: Record<string, string>;
   type?: 'module' | 'commonjs';
   main?: string;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Running `create-nx-plugin` generates a publishable JS library at the root. Since the root package.json contains `private: true` by default, and the js lib generator updates it rather than replacing it, we end up with `private: true` inside the plugin.

## Expected Behavior
When generating any publishable lib, we make sure that the package.json in its root doesnt contain `private: true`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
