### PR TITLE
fix(js): fix publish script being unable to load @nx/devkit

### DIFF
--- a/packages/js/src/utils/minimal-publish-script.ts
+++ b/packages/js/src/utils/minimal-publish-script.ts
@@ -9,8 +9,9 @@ const publishScriptContent = `
  *
  * You might need to authenticate with NPM before running this script.
  */
-
-import { readCachedProjectGraph  } from '@nx/devkit';
+ 
+import devkit from '@nx/devkit';
+const { readCachedProjectGraph } = devkit;
 import { execSync } from 'child_process';
 import { readFileSync, writeFileSync } from 'fs';
 import chalk from 'chalk';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

This error occurs when trying to publish:

```ts
npx nx publish is-even

> nx run is-even:build  [existing outputs match the cache, left as is]

Compiling TypeScript files for project "is-even"...
Done compiling TypeScript files for project "is-even".

> nx run is-even:publish

file:///Users/philipfulcher/nx-repos/myorg-latest/tools/scripts/publish.mjs:10
import { readCachedProjectGraph } from '@nrwl/devkit';
         ^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: Named export 'readCachedProjectGraph' not found. The requested module '@nrwl/devkit' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:
import pkg from '@nrwl/devkit';
const { readCachedProjectGraph } = pkg;
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The above error is not thrown

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
