### PR TITLE
fix(storybook): add @swc/core when adding storybook-addon-swc package for Next.js storybook config

### DIFF
--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -41,6 +41,7 @@ import {
   tsNodeVersion,
 } from '../../utils/versions';
 import { getGeneratorConfigurationOptions } from './lib/user-prompts';
+import { swcCoreVersion } from '@nrwl/js/src/utils/versions';
 
 export async function configurationGenerator(
   tree: Tree,
@@ -231,8 +232,10 @@ export async function configurationGenerator(
   ) {
     devDeps['storybook-addon-next'] = storybookNextAddonVersion;
     devDeps['storybook-addon-swc'] = storybookSwcAddonVersion;
+    devDeps['@swc/core'] = swcCoreVersion;
   } else if (compiler === 'swc') {
     devDeps['storybook-addon-swc'] = storybookSwcAddonVersion;
+    devDeps['@swc/core'] = swcCoreVersion;
   }
 
   if (schema.configureTestRunner === true) {


### PR DESCRIPTION
We missed a previous install of `@swc/core` when generating Next.js storybook configuration for Storybook v6.

Note, SB v7 has a different `@storybook/nextjs` addon that doesn't need this fix.

## Current Behavior
Generating stories for Next.js app in 15.9 results in an error due to `@swc/core` not being installed.

## Expected Behavior
Generating stories for Next.js app in 15.9 works.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
