### PR TITLE
fix(devkit): handle moving a file back to the spot it was already on disk

### DIFF
--- a/packages/nx/src/generators/tree.ts
+++ b/packages/nx/src/generators/tree.ts
@@ -167,14 +167,7 @@ export class FsTree implements Tree {
   ): void {
     this.assertUnlocked();
     filePath = this.normalize(filePath);
-    if (
-      this.fsExists(this.rp(filePath)) &&
-      Buffer.from(content).equals(this.fsReadFile(filePath))
-    ) {
-      // Remove recorded change because the file has been restored to it's original contents
-      delete this.recordedChanges[this.rp(filePath)];
-      return;
-    }
+
     // Remove any recorded changes where a parent directory has been
     // deleted when writing a new file within the directory.
     let parent = dirname(this.rp(filePath));
@@ -184,6 +177,16 @@ export class FsTree implements Tree {
       }
       parent = dirname(parent);
     }
+
+    if (
+      this.fsExists(this.rp(filePath)) &&
+      Buffer.from(content).equals(this.fsReadFile(filePath))
+    ) {
+      // Remove recorded change because the file has been restored to it's original contents
+      delete this.recordedChanges[this.rp(filePath)];
+      return;
+    }
+
     try {
       this.recordedChanges[this.rp(filePath)] = {
         content: Buffer.from(content),


### PR DESCRIPTION
## Current Behavior
Imagine you have this file on disk: `libs/my-lib/lib.ts`

Running a generator that looks like this:
```typescript
export default async function (tree) {
  const contents = tree.read('libs/my-lib/lib.ts')
  tree.delete('libs/my-lib')
  tree.write('libs/my-lib/lib.ts, contents)
}
```

will result in the file being deleted.

## Expected Behavior
The above results in no changes

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
