### PR TITLE
fix(devkit): add .pxd and .pxz to binary extensions

### DIFF
--- a/packages/devkit/src/utils/binary-extensions.ts
+++ b/packages/devkit/src/utils/binary-extensions.ts
@@ -41,6 +41,10 @@ const binaryExtensions = new Set([
   '.woff',
   '.woff2',
   '.eot',
+
+  // Misc files
+  '.pxd',
+  '.pxz',
 ]);
 
 export function isBinaryPath(path: string): boolean {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`.pxd` and `pxz` extensions are not considered binary

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`.pxd` and `pxz` extensions are considered as binary

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
