### PR TITLE
fix(js): fix minimal publish script devkit import

### DIFF
--- a/packages/js/src/utils/minimal-publish-script.ts
+++ b/packages/js/src/utils/minimal-publish-script.ts
@@ -10,10 +10,12 @@ const publishScriptContent = `
  * You might need to authenticate with NPM before running this script.
  */
 
-import { readCachedProjectGraph  } from '@nx/devkit';
 import { execSync } from 'child_process';
 import { readFileSync, writeFileSync } from 'fs';
 import chalk from 'chalk';
+
+import devkit from '@nx/devkit';
+const { readCachedProjectGraph } = devkit;
 
 function invariant(condition, message) {
   if (!condition) {


### PR DESCRIPTION
## Current Behavior
The minimal publish script provided by the `@nx/js:lib` generator does not work out of the box due to how `@nx/devkit` is imported.

## Expected Behavior
The minimal publish script provided by the `@nx/js:lib` generator works out of the box.
