### PR TITLE
fix(nx-plugin): runNxCommand should default to using tmpProjPath as the cwd

### DIFF
--- a/packages/plugin/src/utils/testing-utils/commands.ts
+++ b/packages/plugin/src/utils/testing-utils/commands.ts
@@ -18,7 +18,7 @@ export function runNxCommand(
 ): string {
   function _runNxCommand(c) {
     const execSyncOptions: ExecOptions = {
-      cwd: opts.cwd,
+      cwd: opts.cwd ?? tmpProjPath(),
       env: { ...process.env, ...opts.env },
     };
     if (fileExists(tmpProjPath('package.json'))) {


### PR DESCRIPTION

## Current Behavior
runNxCommand started running with a null `cwd`, causing generators to run locally instead of inside the test repo

## Expected Behavior
runNxCommand defaults to using the `tmpProjPath` for the cwd

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
