### PR TITLE
docs(misc): update community page  nx-plugin links to the current url

### DIFF
--- a/nx-dev/ui-community/src/lib/create-nx-plugin.tsx
+++ b/nx-dev/ui-community/src/lib/create-nx-plugin.tsx
@@ -33,7 +33,7 @@ export function CreateNxPlugin(): JSX.Element {
         <ul className="mx-4 mt-8 list-disc">
           <li className="mt-2">
             <Link
-              href="/packages/nx-plugin#generating-a-plugin"
+              href="/packages/plugin#generating-a-plugin"
               className="hover:underline"
             >
               Create your Nx Plugin
@@ -41,7 +41,7 @@ export function CreateNxPlugin(): JSX.Element {
           </li>
           <li className="mt-2">
             <Link
-              href="/packages/nx-plugin#testing-your-plugin"
+              href="/packages/plugin#testing-your-plugin"
               className="hover:underline"
             >
               Test your plugin
@@ -49,7 +49,7 @@ export function CreateNxPlugin(): JSX.Element {
           </li>
           <li className="mt-2">
             <Link
-              href="/packages/nx-plugin#generating-a-plugin"
+              href="/recipes/advanced-plugins/share-your-plugin"
               className="hover:underline"
             >
               Publish your Nx Plugin
@@ -72,7 +72,7 @@ export function CreateNxPlugin(): JSX.Element {
               <div className="flex w-full px-4 py-3">
                 <div className="min-w-0 flex-1">
                   <Link
-                    href="/packages/nx-plugin#generating-a-plugin"
+                    href="/packages/plugin#generating-a-plugin"
                     className="focus:outline-none"
                   >
                     <span className="absolute inset-0" aria-hidden="true" />
@@ -100,7 +100,7 @@ export function CreateNxPlugin(): JSX.Element {
               <div className="flex w-full px-4 py-3">
                 <div className="min-w-0 flex-1">
                   <Link
-                    href="/packages/nx-plugin#publishing-your-nx-plugin"
+                    href="/recipes/advanced-plugins/share-your-plugin"
                     className="focus:outline-none"
                   >
                     <span className="absolute inset-0" aria-hidden="true" />


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Nx community page (https://nx.dev/community) links to multiple outdated nx-plugin links (404):
https://nx.dev/packages/nx-plugin#generating-a-plugin
https://nx.dev/packages/nx-plugin#testing-your-plugin
https://nx.dev/packages/nx-plugin#generating-a-plugin

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Links should direct to the intended urls:
https://nx.dev/packages/plugin#generating-a-plugin
https://nx.dev/packages/plugin#testing-your-plugin
https://nx.dev/recipes/advanced-plugins/share-your-plugin

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
