### PR TITLE
fix(core): deprecate mf utils from devkit public api

### DIFF
--- a/packages/angular/src/utils/mf/utils.ts
+++ b/packages/angular/src/utils/mf/utils.ts
@@ -1,16 +1,19 @@
 import {
   applyAdditionalShared,
   applySharedFunction,
-  createProjectGraphAsync,
   getDependentPackagesForProject,
   mapRemotes,
   mapRemotesForSSR,
   ModuleFederationConfig,
-  ProjectGraph,
-  readCachedProjectGraph,
   SharedLibraryConfig,
   sharePackages,
   shareWorkspaceLibraries,
+} from '@nx/devkit/src/utils/module-federation';
+
+import {
+  createProjectGraphAsync,
+  ProjectGraph,
+  readCachedProjectGraph,
 } from '@nx/devkit';
 
 export function applyDefaultEagerPackages(

--- a/packages/angular/src/utils/mf/with-module-federation-ssr.ts
+++ b/packages/angular/src/utils/mf/with-module-federation-ssr.ts
@@ -1,5 +1,5 @@
 import { readCachedProjectConfiguration } from 'nx/src/project-graph/project-graph';
-import { ModuleFederationConfig } from '@nx/devkit';
+import { ModuleFederationConfig } from '@nx/devkit/src/utils/module-federation';
 import { getModuleFederationConfig } from './utils';
 
 function determineRemoteUrl(remote: string) {

--- a/packages/angular/src/utils/mf/with-module-federation.ts
+++ b/packages/angular/src/utils/mf/with-module-federation.ts
@@ -1,4 +1,4 @@
-import { ModuleFederationConfig } from '@nx/devkit';
+import { ModuleFederationConfig } from '@nx/devkit/src/utils/module-federation';
 import { getModuleFederationConfig } from './utils';
 import { readCachedProjectConfiguration } from 'nx/src/project-graph/project-graph';
 import ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');

--- a/packages/devkit/public-api.ts
+++ b/packages/devkit/public-api.ts
@@ -112,24 +112,25 @@ export { moveFilesToNewDirectory } from './src/utils/move-dir';
 
 /**
  * @category Utils
+ * @deprecated Accessing the Module Federation Utils from the Public API of @nx/devkit is deprecated and they will be removed from the Public API in v17.
  */
 export {
+  AdditionalSharedConfig,
+  ModuleFederationConfig,
   SharedLibraryConfig,
   SharedWorkspaceLibraryConfig,
-  AdditionalSharedConfig,
-  applySharedFunction,
-  applyAdditionalShared,
-  mapRemotes,
-  mapRemotesForSSR,
-  getNpmPackageSharedConfig,
-  shareWorkspaceLibraries,
-  sharePackages,
-  getDependentPackagesForProject,
-  ModuleFederationConfig,
-  ModuleFederationLibrary,
-  readRootPackageJson,
   WorkspaceLibrary,
   SharedFunction,
   WorkspaceLibrarySecondaryEntryPoint,
   Remotes,
-} from './src/utils/module-federation';
+  ModuleFederationLibrary,
+  applySharedFunction,
+  applyAdditionalShared,
+  getNpmPackageSharedConfig,
+  shareWorkspaceLibraries,
+  sharePackages,
+  mapRemotes,
+  mapRemotesForSSR,
+  getDependentPackagesForProject,
+  readRootPackageJson,
+} from './src/utils/module-federation/public-api';

--- a/packages/devkit/src/utils/module-federation/public-api.ts
+++ b/packages/devkit/src/utils/module-federation/public-api.ts
@@ -1,0 +1,100 @@
+import {
+  AdditionalSharedConfig,
+  ModuleFederationConfig,
+  ModuleFederationLibrary,
+  Remotes,
+  SharedFunction,
+  SharedLibraryConfig,
+  SharedWorkspaceLibraryConfig,
+  WorkspaceLibrary,
+  WorkspaceLibrarySecondaryEntryPoint,
+} from './models';
+
+import {
+  applyAdditionalShared,
+  applySharedFunction,
+  getNpmPackageSharedConfig,
+  sharePackages,
+  shareWorkspaceLibraries,
+} from './share';
+
+import { mapRemotes, mapRemotesForSSR } from './remotes';
+
+import { getDependentPackagesForProject } from './dependencies';
+
+import { readRootPackageJson } from './package-json';
+
+export {
+  /**
+   * @deprecated Accessing the Module Federation Utils from the Public API of @nx/devkit is deprecated and they will be removed from the Public API in v17.
+   */
+  ModuleFederationConfig,
+  /**
+   * @deprecated Accessing the Module Federation Utils from the Public API of @nx/devkit is deprecated and they will be removed from the Public API in v17.
+   */
+  SharedLibraryConfig,
+  /**
+   * @deprecated Accessing the Module Federation Utils from the Public API of @nx/devkit is deprecated and they will be removed from the Public API in v17.
+   */
+  SharedWorkspaceLibraryConfig,
+  /**
+   * @deprecated Accessing the Module Federation Utils from the Public API of @nx/devkit is deprecated and they will be removed from the Public API in v17.
+   */
+  AdditionalSharedConfig,
+  /**
+   * @deprecated Accessing the Module Federation Utils from the Public API of @nx/devkit is deprecated and they will be removed from the Public API in v17.
+   */
+  WorkspaceLibrary,
+  /**
+   * @deprecated Accessing the Module Federation Utils from the Public API of @nx/devkit is deprecated and they will be removed from the Public API in v17.
+   */
+  SharedFunction,
+  /**
+   * @deprecated Accessing the Module Federation Utils from the Public API of @nx/devkit is deprecated and they will be removed from the Public API in v17.
+   */
+  WorkspaceLibrarySecondaryEntryPoint,
+  /**
+   * @deprecated Accessing the Module Federation Utils from the Public API of @nx/devkit is deprecated and they will be removed from the Public API in v17.
+   */
+  Remotes,
+  /**
+   * @deprecated Accessing the Module Federation Utils from the Public API of @nx/devkit is deprecated and they will be removed from the Public API in v17.
+   */
+  ModuleFederationLibrary,
+  /**
+   * @deprecated Accessing the Module Federation Utils from the Public API of @nx/devkit is deprecated and they will be removed from the Public API in v17.
+   */
+  applySharedFunction,
+  /**
+   * @deprecated Accessing the Module Federation Utils from the Public API of @nx/devkit is deprecated and they will be removed from the Public API in v17.
+   */
+  applyAdditionalShared,
+  /**
+   * @deprecated Accessing the Module Federation Utils from the Public API of @nx/devkit is deprecated and they will be removed from the Public API in v17.
+   */
+  getNpmPackageSharedConfig,
+  /**
+   * @deprecated Accessing the Module Federation Utils from the Public API of @nx/devkit is deprecated and they will be removed from the Public API in v17.
+   */
+  shareWorkspaceLibraries,
+  /**
+   * @deprecated Accessing the Module Federation Utils from the Public API of @nx/devkit is deprecated and they will be removed from the Public API in v17.
+   */
+  sharePackages,
+  /**
+   * @deprecated Accessing the Module Federation Utils from the Public API of @nx/devkit is deprecated and they will be removed from the Public API in v17.
+   */
+  mapRemotes,
+  /**
+   * @deprecated Accessing the Module Federation Utils from the Public API of @nx/devkit is deprecated and they will be removed from the Public API in v17.
+   */
+  mapRemotesForSSR,
+  /**
+   * @deprecated Accessing the Module Federation Utils from the Public API of @nx/devkit is deprecated and they will be removed from the Public API in v17.
+   */
+  getDependentPackagesForProject,
+  /**
+   * @deprecated Accessing the Module Federation Utils from the Public API of @nx/devkit is deprecated and they will be removed from the Public API in v17.
+   */
+  readRootPackageJson,
+};

--- a/packages/react/src/module-federation/utils.ts
+++ b/packages/react/src/module-federation/utils.ts
@@ -1,16 +1,18 @@
 import {
   applyAdditionalShared,
   applySharedFunction,
-  createProjectGraphAsync,
   getDependentPackagesForProject,
   mapRemotes,
   mapRemotesForSSR,
   ModuleFederationConfig,
-  ProjectConfiguration,
-  ProjectGraph,
-  readCachedProjectGraph,
   sharePackages,
   shareWorkspaceLibraries,
+} from '@nx/devkit/src/utils/module-federation';
+
+import {
+  createProjectGraphAsync,
+  ProjectGraph,
+  readCachedProjectGraph,
 } from '@nx/devkit';
 
 export async function getModuleFederationConfig(

--- a/packages/react/src/module-federation/with-module-federation-ssr.ts
+++ b/packages/react/src/module-federation/with-module-federation-ssr.ts
@@ -1,4 +1,4 @@
-import { ModuleFederationConfig } from '@nx/devkit';
+import { ModuleFederationConfig } from '@nx/devkit/src/utils/module-federation';
 import { readCachedProjectConfiguration } from 'nx/src/project-graph/project-graph';
 import { getModuleFederationConfig } from './utils';
 

--- a/packages/react/src/module-federation/with-module-federation.ts
+++ b/packages/react/src/module-federation/with-module-federation.ts
@@ -1,8 +1,8 @@
-import { ModuleFederationConfig } from '@nx/devkit';
+import { ModuleFederationConfig } from '@nx/devkit/src/utils/module-federation';
 import { readCachedProjectConfiguration } from 'nx/src/project-graph/project-graph';
 import { getModuleFederationConfig } from './utils';
-import ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
 import type { AsyncNxWebpackPlugin } from '@nx/webpack';
+import ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
 
 function determineRemoteUrl(remote: string) {
   const remoteConfiguration = readCachedProjectConfiguration(remote);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
MF utils are exposed via the @nx/devkit public api.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
They should not be exposed, but deprecate first for safety.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
