### PR TITLE
fix(core): keep all explicit dependencies in the graph

### DIFF
--- a/e2e/linter/src/linter.test.ts
+++ b/e2e/linter/src/linter.test.ts
@@ -232,7 +232,7 @@ describe('Linter', () => {
         import '@${projScope}/${invalidtaglib}';
         import '@${projScope}/${validtaglib}';
 
-        const s = {loadChildren: '@${projScope}/${lazylib}'};
+        const s = {loadChildren: '@secondScope/${lazylib}'};
       `
         );
 

--- a/packages/nx/src/plugins/js/package-json/create-package-json.ts
+++ b/packages/nx/src/plugins/js/package-json/create-package-json.ts
@@ -234,8 +234,6 @@ function findAllNpmDeps(
           seen,
           dependencyPatterns
         );
-      } else {
-        throw new Error(`Could not find ${dep} in the project graph.`);
       }
     }
   }

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.ts
@@ -40,19 +40,28 @@ export function buildExplicitTypeScriptDependencies(
             importExpr,
             f.file
           );
+          let targetProjectName;
           if (target) {
             if (!isRoot(source) && isRoot(target)) {
               // TODO: These edges technically should be allowed but we need to figure out how to separate config files out from root
               return;
             }
 
-            res.push({
-              sourceProjectName: source,
-              targetProjectName: target,
-              sourceProjectFile: f.file,
-              type,
-            });
+            targetProjectName = target;
+          } else {
+            // treat all unknowns as npm packages, they can be eiher
+            // - mistyped local import, which has to be fixed manually
+            // - node internals, which should still be tracked as a dependency
+            // - npm packages, which are not yet installed but should be tracked
+            targetProjectName = `npm:${importExpr}`;
           }
+
+          res.push({
+            sourceProjectName: source,
+            targetProjectName,
+            sourceProjectFile: f.file,
+            type,
+          });
         }
       );
     });

--- a/packages/nx/src/project-graph/project-graph-builder.spec.ts
+++ b/packages/nx/src/project-graph/project-graph-builder.spec.ts
@@ -96,13 +96,6 @@ describe('ProjectGraphBuilder', () => {
     expect(() =>
       builder.addExplicitDependency(
         'source',
-        'source/index.ts',
-        'invalid-target'
-      )
-    ).toThrowError();
-    expect(() =>
-      builder.addExplicitDependency(
-        'source',
         'source/invalid-index.ts',
         'target'
       )

--- a/packages/nx/src/project-graph/project-graph-builder.spec.ts
+++ b/packages/nx/src/project-graph/project-graph-builder.spec.ts
@@ -33,6 +33,8 @@ describe('ProjectGraphBuilder', () => {
     expect(() =>
       builder.addImplicitDependency('source', 'invalid-target')
     ).toThrowError();
+    // this should not break, but should not exist in resulting dependencies either
+    builder.addStaticDependency('source', 'invalid-target', 'source/index.ts');
 
     // ignore the self deps
     builder.addDynamicDependency('source', 'source', 'source/index.ts');

--- a/packages/nx/src/project-graph/project-graph-builder.ts
+++ b/packages/nx/src/project-graph/project-graph-builder.ts
@@ -229,20 +229,26 @@ export class ProjectGraphBuilder {
 
       const fileDeps = this.calculateTargetDepsFromFiles(sourceProject);
       for (const [targetProject, types] of fileDeps.entries()) {
-        for (const type of types.values()) {
-          if (
-            !alreadySetTargetProjects.has(targetProject) ||
-            !alreadySetTargetProjects.get(targetProject).has(type)
-          ) {
+        // only add known nodes
+        if (
+          this.graph.nodes[targetProject] ||
+          this.graph.externalNodes[targetProject]
+        ) {
+          for (const type of types.values()) {
             if (
-              !this.removedEdges[sourceProject] ||
-              !this.removedEdges[sourceProject].has(targetProject)
+              !alreadySetTargetProjects.has(targetProject) ||
+              !alreadySetTargetProjects.get(targetProject).has(type)
             ) {
-              this.graph.dependencies[sourceProject].push({
-                source: sourceProject,
-                target: targetProject,
-                type,
-              });
+              if (
+                !this.removedEdges[sourceProject] ||
+                !this.removedEdges[sourceProject].has(targetProject)
+              ) {
+                this.graph.dependencies[sourceProject].push({
+                  source: sourceProject,
+                  target: targetProject,
+                  type,
+                });
+              }
             }
           }
         }

--- a/packages/nx/src/project-graph/project-graph-builder.ts
+++ b/packages/nx/src/project-graph/project-graph-builder.ts
@@ -268,7 +268,8 @@ export class ProjectGraphBuilder {
     }
     if (
       !this.graph.nodes[targetProjectName] &&
-      !this.graph.externalNodes[targetProjectName]
+      !this.graph.externalNodes[targetProjectName] &&
+      !targetProjectName.startsWith('npm:')
     ) {
       throw new Error(`Target project does not exist: ${targetProjectName}`);
     }

--- a/packages/nx/src/project-graph/project-graph-builder.ts
+++ b/packages/nx/src/project-graph/project-graph-builder.ts
@@ -175,41 +175,11 @@ export class ProjectGraphBuilder {
     sourceProjectFile: string,
     targetProjectName: string
   ): void {
-    if (sourceProjectName === targetProjectName) {
-      return;
-    }
-    const source = this.graph.nodes[sourceProjectName];
-    if (!source) {
-      throw new Error(`Source project does not exist: ${sourceProjectName}`);
-    }
-
-    if (
-      !this.graph.nodes[targetProjectName] &&
-      !this.graph.externalNodes[targetProjectName]
-    ) {
-      throw new Error(`Target project does not exist: ${targetProjectName}`);
-    }
-
-    const fileData = source.data.files.find(
-      (f) => f.file === sourceProjectFile
+    this.addStaticDependency(
+      sourceProjectName,
+      targetProjectName,
+      sourceProjectFile
     );
-    if (!fileData) {
-      throw new Error(
-        `Source project ${sourceProjectName} does not have a file: ${sourceProjectFile}`
-      );
-    }
-
-    if (!fileData.dependencies) {
-      fileData.dependencies = [];
-    }
-
-    if (!fileData.dependencies.find((t) => t.target === targetProjectName)) {
-      fileData.dependencies.push({
-        target: targetProjectName,
-        source: sourceProjectName,
-        type: DependencyType.static,
-      });
-    }
   }
 
   /**

--- a/packages/nx/src/project-graph/project-graph-builder.ts
+++ b/packages/nx/src/project-graph/project-graph-builder.ts
@@ -231,24 +231,25 @@ export class ProjectGraphBuilder {
       for (const [targetProject, types] of fileDeps.entries()) {
         // only add known nodes
         if (
-          this.graph.nodes[targetProject] ||
-          this.graph.externalNodes[targetProject]
+          !this.graph.nodes[targetProject] &&
+          !this.graph.externalNodes[targetProject]
         ) {
-          for (const type of types.values()) {
+          continue;
+        }
+        for (const type of types.values()) {
+          if (
+            !alreadySetTargetProjects.has(targetProject) ||
+            !alreadySetTargetProjects.get(targetProject).has(type)
+          ) {
             if (
-              !alreadySetTargetProjects.has(targetProject) ||
-              !alreadySetTargetProjects.get(targetProject).has(type)
+              !this.removedEdges[sourceProject] ||
+              !this.removedEdges[sourceProject].has(targetProject)
             ) {
-              if (
-                !this.removedEdges[sourceProject] ||
-                !this.removedEdges[sourceProject].has(targetProject)
-              ) {
-                this.graph.dependencies[sourceProject].push({
-                  source: sourceProject,
-                  target: targetProject,
-                  type,
-                });
-              }
+              this.graph.dependencies[sourceProject].push({
+                source: sourceProject,
+                target: targetProject,
+                type,
+              });
             }
           }
         }
@@ -275,7 +276,7 @@ export class ProjectGraphBuilder {
     if (
       !this.graph.nodes[targetProjectName] &&
       !this.graph.externalNodes[targetProjectName] &&
-      !targetProjectName.startsWith('npm:')
+      !sourceProjectFile
     ) {
       throw new Error(`Target project does not exist: ${targetProjectName}`);
     }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Explicit dependencies not matched to internal or external nodes are ignored during the graph creation.
This leads to:
- inaccurate representation of the actual state
- broken graph when adding missing packages subsequently (see #15964)

## Expected Behavior
All explicit dependencies of a project should be presented in `dependencies` regardless whether we can map it to an actual node or not.

## Methodology

* File dependencies can be created to nodes which do not exist.
* When calculating the updated graph, we omit reporting file dependencies which point to nodes that do not exist so this has no impact on the `ProjectGraph` which is created.
* Once the npm package is installed, recalculating the updated project graph will yield the new dependencies as they can now be resolved.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15964
