### PR TITLE
fix(js): skip lockfile errors during Vercel builds

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/lock-file.ts
+++ b/packages/nx/src/plugins/js/lock-file/lock-file.ts
@@ -100,7 +100,7 @@ export function parseLockFile(
       return builder.getUpdatedProjectGraph();
     }
   } catch (e) {
-    if (!isPostInstallProcess()) {
+    if (shouldLogErrors()) {
       output.error({
         title: `Failed to parse ${packageManager} lockfile`,
         bodyLines: errorBodyLines(e),
@@ -170,7 +170,7 @@ export function createLockFile(
       return stringifyNpmLockfile(prunedGraph, content, normalizedPackageJson);
     }
   } catch (e) {
-    if (!isPostInstallProcess()) {
+    if (shouldLogErrors()) {
       const additionalInfo = [
         'To prevent the build from breaking we are returning the root lock file.',
       ];
@@ -205,8 +205,9 @@ function errorBodyLines(originalError: Error, additionalInfo: string[] = []) {
   ];
 }
 
-function isPostInstallProcess(): boolean {
-  return (
+function shouldLogErrors(): boolean {
+  return !(
+    process.env.VERCEL &&
     process.env.npm_command === 'install' &&
     process.env.npm_lifecycle_event === 'postinstall'
   );


### PR DESCRIPTION
- Logged errors cause JSON parse of affected projects to fail like this:

```

undefined:2
--
12:08:07.949 | >  NX   Failed to parse pnpm lockfile
12:08:07.949 | ^
12:08:07.949 |  
12:08:07.950 | SyntaxError: Unexpected token > in JSON at position 2
12:08:07.950 | at JSON.parse (<anonymous>)
12:08:07.950 | at /vercel/.npm/_npx/f3975d057d897afd/node_modules/nx-ignore/src/index.js:70:23
12:08:07.950 | at Generator.next (<anonymous>)
12:08:07.950 | at asyncGeneratorStep (/vercel/.npm/_npx/f3975d057d897afd/node_modules/@swc/helpers/lib/_async_to_generator.js:13:28)
12:08:07.950 | at _next (/vercel/.npm/_npx/f3975d057d897afd/node_modules/@swc/helpers/lib/_async_to_generator.js:31:17)
12:08:07.950 | at /vercel/.npm/_npx/f3975d057d897afd/node_modules/@swc/helpers/lib/_async_to_generator.js:36:13
12:08:07.950 | at new Promise (<anonymous>)
12:08:07.950 | at /vercel/.npm/_npx/f3975d057d897afd/node_modules/@swc/helpers/lib/_async_to_generator.js:28:16
12:08:07.950 | at _main (/vercel/.npm/_npx/f3975d057d897afd/node_modules/nx-ignore/src/index.js:83:18)
12:08:07.950 | at main (/vercel/.npm/_npx/f3975d057d897afd/node_modules/nx-ignore/src/index.js:30:18)

```

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`nx-ignore` fails when parsing affected projects, and the build is not skipped

## Expected Behavior
`nx-ignore` should work 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
