### PR TITLE
feat(core): update dependsOn configuration to use dependencies property

### DIFF
--- a/docs/shared/reference/project-configuration.md
+++ b/docs/shared/reference/project-configuration.md
@@ -290,12 +290,37 @@ You can also express task dependencies with an object syntax:
 ```
 
 {% /tab %}
-{% tab label="Version 16+" %}
+{% tab label="Version 16+ (self)" %}
 
 ```json
 "build": {
   "dependsOn": [{
-    "projects": "{dependencies}", // "{dependencies}", "{self}" or "project-name"
+    "target": "build", // target name
+    "params": "ignore" // "forward" or "ignore", defaults to "ignore"
+  }]
+}
+```
+
+{% /tab %}
+{% tab label="Version 16+ (dependencies)" %}
+
+```json
+"build": {
+  "dependsOn": [{
+    "dependencies": true, // Run this target on all dependencies first
+    "target": "build", // target name
+    "params": "ignore" // "forward" or "ignore", defaults to "ignore"
+  }]
+}
+```
+
+{% /tab %}
+{% tab label="Version 16+ (specific projects)" %}
+
+```json
+"build": {
+  "dependsOn": [{
+    "projects": ["my-app"], // Run build on "my-app" first
     "target": "build", // target name
     "params": "ignore" // "forward" or "ignore", defaults to "ignore"
   }]
@@ -326,10 +351,10 @@ You can write the shorthand configuration above in the object syntax like this:
 
 ```json
 "build": {
-  "dependsOn": [{ "projects": "{dependencies}", "target": "build" }]
+  "dependsOn": [{ "dependencies": true, "target": "build" }] // Run build on my dependencies first
 },
 "test": {
-  "dependsOn": [{ "projects": "{self}", "target": "build" }]
+  "dependsOn": [{ "target": "build" }] // Run build on myself first
 }
 ```
 
@@ -395,7 +420,7 @@ This also works when defining a relation for the target of the project itself us
 ```json
 "build": {
    // forward params passed to this target to the project target
-  "dependsOn": [{ "projects": "{self}", "target": "pre-build", "params": "forward" }]
+  "dependsOn": [{ "target": "pre-build", "params": "forward" }]
 }
 ```
 

--- a/docs/shared/reference/project-configuration.md
+++ b/docs/shared/reference/project-configuration.md
@@ -163,7 +163,7 @@ _Named Inputs_
 Examples:
 
 - `inputs: ["production"]`
-- same as `inputs: [{input: "production", projects: "self"}]`
+- same as `"inputs": [{"input": "production", "projects": "self"}]` in versions prior to Nx 16, or `"inputs": [{"input": "production"}]` after version 16.
 
 Often the same glob will appear in many places (e.g., prod fileset will exclude spec files for all projects). Because
 keeping them in sync is error-prone, we recommend defining `namedInputs`, which you can then reference in all of those
@@ -174,7 +174,7 @@ places.
 Examples:
 
 - `inputs: ["^production"]`
-- same as `inputs: [{input: "production", projects: "dependencies"}]`
+- same as `inputs: [{"input": "production", "projects": "dependencies"}]` prior to Nx 16, or `"inputs": [{"input": "production", "dependencies": true }]` after version 16.
 
 Similar to `dependsOn`, the "^" symbols means "dependencies". This is a very important idea, so let's illustrate it with
 an example.

--- a/nx-dev/nx-dev/project.json
+++ b/nx-dev/nx-dev/project.json
@@ -8,6 +8,7 @@
       "dependsOn": [
         {
           "target": "build-base",
+          "projects": "{self}"
         }
       ],
       "executor": "nx:run-commands",

--- a/nx-dev/nx-dev/project.json
+++ b/nx-dev/nx-dev/project.json
@@ -8,7 +8,6 @@
       "dependsOn": [
         {
           "target": "build-base",
-          "projects": "{self}"
         }
       ],
       "executor": "nx:run-commands",

--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -62,7 +62,7 @@
     },
     "16.0.0-tokens-for-depends-on": {
       "cli": "nx",
-      "version": "16.0.0-beta.0",
+      "version": "16.0.0-beta.9",
       "description": "Replace `dependsOn.projects` and `inputs` definitions with new configuration format.",
       "implementation": "./src/migrations/update-16-0-0/update-depends-on-to-tokens"
     },

--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -63,7 +63,7 @@
     "16.0.0-tokens-for-depends-on": {
       "cli": "nx",
       "version": "16.0.0-beta.0",
-      "description": "Replace `dependsOn.projects` with {self} or {dependencies} tokens so that it matches the new expected formatting.",
+      "description": "Replace `dependsOn.projects` and `inputs` definitions with new configuration format.",
       "implementation": "./src/migrations/update-16-0-0/update-depends-on-to-tokens"
     },
     "16.0.0-update-nx-cloud-runner": {

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -98,15 +98,44 @@
             "type": "object",
             "properties": {
               "projects": {
-                "type": "string",
-                "description": "The projects that the targets belong to.",
-                "enum": ["self", "dependencies"]
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "description": "The project that the targets belong to."
+                  },
+                  {
+                    "type": "array",
+                    "description": "The projects that the targets belong to.",
+                    "items": { "type": "string" }
+                  }
+                ]
+              },
+              "dependencies": {
+                "type": "boolean",
+                "description": "Include files belonging to the input for all the project dependencies of this target."
               },
               "input": {
                 "type": "string",
                 "description": "The name of the input."
               }
             },
+            "oneOf": [
+              {
+                "required": ["projects", "input"]
+              },
+              {
+                "required": ["dependencies", "input"]
+              },
+              {
+                "required": ["input"],
+                "not": {
+                  "anyOf": [
+                    { "required": ["projects"] },
+                    { "required": ["dependencies"] }
+                  ]
+                }
+              }
+            ],
             "additionalProperties": false
           },
           {

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -211,16 +211,19 @@
                     "oneOf": [
                       {
                         "type": "string",
-                        "description": "{self}, {dependencies}, or a project name."
+                        "description": "A project name"
                       },
                       {
                         "type": "array",
-                        "description": "An array of project specifiers: {self}, {dependencies}, or a project name.",
+                        "description": "An array of project names",
                         "items": {
                           "type": "string"
                         }
                       }
                     ]
+                  },
+                  "dependencies": {
+                    "type": "boolean"
                   },
                   "target": {
                     "type": "string",
@@ -233,8 +236,24 @@
                     "default": "ignore"
                   }
                 },
-                "additionalProperties": false,
-                "required": ["projects", "target"]
+                "oneOf": [
+                  {
+                    "required": ["projects", "target"]
+                  },
+                  {
+                    "required": ["dependencies", "target"]
+                  },
+                  {
+                    "required": ["target"],
+                    "not": {
+                      "anyOf": [
+                        { "required": ["projects"] },
+                        { "required": ["dependencies"] }
+                      ]
+                    }
+                  }
+                ],
+                "additionalProperties": false
               }
             ]
           }

--- a/packages/nx/schemas/project-schema.json
+++ b/packages/nx/schemas/project-schema.json
@@ -58,16 +58,19 @@
                       "oneOf": [
                         {
                           "type": "string",
-                          "description": "{self}, {dependencies}, or a project name."
+                          "description": "A project name"
                         },
                         {
                           "type": "array",
-                          "description": "An array of project specifiers: {self}, {dependencies}, or a project name.",
+                          "description": "An array of project names",
                           "items": {
                             "type": "string"
                           }
                         }
                       ]
+                    },
+                    "dependencies": {
+                      "type": "boolean"
                     },
                     "target": {
                       "type": "string",
@@ -80,8 +83,24 @@
                       "default": "ignore"
                     }
                   },
-                  "additionalProperties": false,
-                  "required": ["projects", "target"]
+                  "oneOf": [
+                    {
+                      "required": ["projects", "target"]
+                    },
+                    {
+                      "required": ["dependencies", "target"]
+                    },
+                    {
+                      "required": ["target"],
+                      "not": {
+                        "anyOf": [
+                          { "required": ["projects"] },
+                          { "required": ["dependencies"] }
+                        ]
+                      }
+                    }
+                  ],
+                  "additionalProperties": false
                 }
               ]
             }

--- a/packages/nx/schemas/project-schema.json
+++ b/packages/nx/schemas/project-schema.json
@@ -147,15 +147,44 @@
             "type": "object",
             "properties": {
               "projects": {
-                "type": "string",
-                "description": "The projects that the input belong to.",
-                "enum": ["self", "dependencies"]
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "description": "The project that the targets belong to."
+                  },
+                  {
+                    "type": "array",
+                    "description": "The projects that the targets belong to.",
+                    "items": { "type": "string" }
+                  }
+                ]
+              },
+              "dependencies": {
+                "type": "boolean",
+                "description": "Include files belonging to the input for all the project dependencies of this target."
               },
               "input": {
                 "type": "string",
-                "description": "Named input."
+                "description": "The name of the input."
               }
             },
+            "oneOf": [
+              {
+                "required": ["projects", "input"]
+              },
+              {
+                "required": ["dependencies", "input"]
+              },
+              {
+                "required": ["input"],
+                "not": {
+                  "anyOf": [
+                    { "required": ["projects"] },
+                    { "required": ["dependencies"] }
+                  ]
+                }
+              }
+            ],
             "additionalProperties": false
           },
           {

--- a/packages/nx/schemas/workspace-schema.json
+++ b/packages/nx/schemas/workspace-schema.json
@@ -68,16 +68,19 @@
                                       "oneOf": [
                                         {
                                           "type": "string",
-                                          "description": "{self}, {dependencies}, or a project name."
+                                          "description": "A project name"
                                         },
                                         {
                                           "type": "array",
-                                          "description": "An array of project specifiers: {self}, {dependencies}, or a project name.",
+                                          "description": "An array of project names",
                                           "items": {
                                             "type": "string"
                                           }
                                         }
                                       ]
+                                    },
+                                    "dependencies": {
+                                      "type": "boolean"
                                     },
                                     "target": {
                                       "type": "string",
@@ -90,8 +93,24 @@
                                       "default": "ignore"
                                     }
                                   },
-                                  "additionalProperties": false,
-                                  "required": ["projects", "target"]
+                                  "oneOf": [
+                                    {
+                                      "required": ["projects", "target"]
+                                    },
+                                    {
+                                      "required": ["dependencies", "target"]
+                                    },
+                                    {
+                                      "required": ["target"],
+                                      "not": {
+                                        "anyOf": [
+                                          { "required": ["projects"] },
+                                          { "required": ["dependencies"] }
+                                        ]
+                                      }
+                                    }
+                                  ],
+                                  "additionalProperties": false
                                 }
                               ]
                             }

--- a/packages/nx/src/config/workspace-json-project-json.ts
+++ b/packages/nx/src/config/workspace-json-project-json.ts
@@ -126,7 +126,9 @@ export interface TargetDependencyConfig {
 }
 
 export type InputDefinition =
-  | { input: string; projects: 'self' | 'dependencies' }
+  | { input: string; projects: string | string[] }
+  | { input: string; dependencies: true }
+  | { input: string }
   | { fileset: string }
   | { runtime: string }
   | { env: string };

--- a/packages/nx/src/config/workspace-json-project-json.ts
+++ b/packages/nx/src/config/workspace-json-project-json.ts
@@ -102,18 +102,20 @@ export interface ProjectConfiguration {
 
 export interface TargetDependencyConfig {
   /**
-   * A list of projects that have `target`. Supports project names or two special values:
-   *
-   * - '{self}': This target depends on another target of the same project
-   * - '{dependencies}': This target depends on targets of the projects of it's deps.
-   *
-   * The special values {self}/{dependencies} should be preferred - they prevent cases where a project
-   * that needs to be built is missed.
+   * A list of projects that have `target`.
+   * Should not be specified together with `dependencies`.
    */
-  projects: string[] | string;
+  projects?: string[] | string;
 
   /**
-   * The name of the target
+   * If true, the target will be executed for each project that this project depends on.
+   * Should not be specified together with `projects`.
+   */
+  dependencies?: boolean;
+
+  /**
+   * The name of the target to run. If `projects` and `dependencies` are not specified,
+   * the target will be executed for the same project the the current target is running on`.
    */
   target: string;
 

--- a/packages/nx/src/migrations/update-16-0-0/update-depends-on-to-tokens.spec.ts
+++ b/packages/nx/src/migrations/update-16-0-0/update-depends-on-to-tokens.spec.ts
@@ -19,6 +19,7 @@ describe('update-depends-on-to-tokens', () => {
               projects: 'self',
             },
           ],
+          inputs: [{ projects: 'self', input: 'someInput' }],
         },
         test: {
           dependsOn: [
@@ -26,6 +27,7 @@ describe('update-depends-on-to-tokens', () => {
               projects: 'dependencies',
             },
           ],
+          inputs: [{ projects: 'dependencies', input: 'someInput' }],
         },
         other: {
           dependsOn: ['^deps'],
@@ -35,11 +37,21 @@ describe('update-depends-on-to-tokens', () => {
     });
     await update(tree);
     const nxJson = readNxJson(tree);
-    const build = nxJson.targetDefaults.build.dependsOn[0] as any;
-    const test = nxJson.targetDefaults.test.dependsOn[0] as any;
-    expect(build.projects).not.toBeDefined();
-    expect(test.projects).not.toBeDefined();
-    expect(test.dependencies).toEqual(true);
+    const buildDependencyConfiguration = nxJson.targetDefaults.build
+      .dependsOn[0] as any;
+    const testDependencyConfiguration = nxJson.targetDefaults.test
+      .dependsOn[0] as any;
+    const buildInputConfiguration = nxJson.targetDefaults.build
+      .inputs[0] as any;
+    const testInputConfiguration = nxJson.targetDefaults.test.inputs[0] as any;
+    expect(buildDependencyConfiguration.projects).not.toBeDefined();
+    expect(buildDependencyConfiguration.dependencies).not.toBeDefined();
+    expect(buildInputConfiguration.projects).not.toBeDefined();
+    expect(buildInputConfiguration.dependencies).not.toBeDefined();
+    expect(testInputConfiguration.projects).not.toBeDefined();
+    expect(testInputConfiguration.dependencies).toEqual(true);
+    expect(testDependencyConfiguration.projects).not.toBeDefined();
+    expect(testDependencyConfiguration.dependencies).toEqual(true);
     expect(nxJson.targetDefaults.other.dependsOn).toEqual(['^deps']);
   });
 
@@ -55,6 +67,7 @@ describe('update-depends-on-to-tokens', () => {
               target: 'build',
             },
           ],
+          inputs: [{ projects: 'self', input: 'someInput' }],
         },
         test: {
           dependsOn: [
@@ -63,6 +76,7 @@ describe('update-depends-on-to-tokens', () => {
               target: 'test',
             },
           ],
+          inputs: [{ projects: 'dependencies', input: 'someInput' }],
         },
         other: {
           dependsOn: ['^deps'],
@@ -71,13 +85,22 @@ describe('update-depends-on-to-tokens', () => {
     });
     await update(tree);
     const project = readProjectConfiguration(tree, 'proj1');
-    const build = project.targets.build.dependsOn[0] as any;
-    const test = project.targets.test.dependsOn[0] as any;
-    expect(build.projects).not.toBeDefined();
-    expect(build.dependencies).not.toBeDefined();
-    expect(test.projects).not.toBeDefined();
-    expect(test.dependencies).toEqual(true);
+    const buildDependencyConfiguration = project.targets.build
+      .dependsOn[0] as any;
+    const testDependencyConfiguration = project.targets.test
+      .dependsOn[0] as any;
+    const buildInputConfiguration = project.targets.build.inputs[0] as any;
+    const testInputConfiguration = project.targets.test.inputs[0] as any;
+    expect(buildDependencyConfiguration.projects).not.toBeDefined();
+    expect(buildDependencyConfiguration.dependencies).not.toBeDefined();
+    expect(buildInputConfiguration.projects).not.toBeDefined();
+    expect(buildInputConfiguration.dependencies).not.toBeDefined();
+    expect(testDependencyConfiguration.projects).not.toBeDefined();
+    expect(testDependencyConfiguration.dependencies).toEqual(true);
+    expect(testInputConfiguration.projects).not.toBeDefined();
+    expect(testInputConfiguration.dependencies).toEqual(true);
     expect(project.targets.other.dependsOn).toEqual(['^deps']);
+    expect(project.targets.other.inputs).not.toBeDefined();
   });
 
   it('should not throw on nulls', async () => {

--- a/packages/nx/src/migrations/update-16-0-0/update-depends-on-to-tokens.spec.ts
+++ b/packages/nx/src/migrations/update-16-0-0/update-depends-on-to-tokens.spec.ts
@@ -37,8 +37,9 @@ describe('update-depends-on-to-tokens', () => {
     const nxJson = readNxJson(tree);
     const build = nxJson.targetDefaults.build.dependsOn[0] as any;
     const test = nxJson.targetDefaults.test.dependsOn[0] as any;
-    expect(build.projects).toEqual('{self}');
-    expect(test.projects).toEqual('{dependencies}');
+    expect(build.projects).not.toBeDefined();
+    expect(test.projects).not.toBeDefined();
+    expect(test.dependencies).toEqual(true);
     expect(nxJson.targetDefaults.other.dependsOn).toEqual(['^deps']);
   });
 
@@ -72,8 +73,10 @@ describe('update-depends-on-to-tokens', () => {
     const project = readProjectConfiguration(tree, 'proj1');
     const build = project.targets.build.dependsOn[0] as any;
     const test = project.targets.test.dependsOn[0] as any;
-    expect(build.projects).toEqual('{self}');
-    expect(test.projects).toEqual('{dependencies}');
+    expect(build.projects).not.toBeDefined();
+    expect(build.dependencies).not.toBeDefined();
+    expect(test.projects).not.toBeDefined();
+    expect(test.dependencies).toEqual(true);
     expect(project.targets.other.dependsOn).toEqual(['^deps']);
   });
 

--- a/packages/nx/src/migrations/update-16-0-0/update-depends-on-to-tokens.ts
+++ b/packages/nx/src/migrations/update-16-0-0/update-depends-on-to-tokens.ts
@@ -17,10 +17,16 @@ export default async function (tree: Tree) {
     )) {
       for (const dependency of targetConfiguration.dependsOn ?? []) {
         if (typeof dependency !== 'string') {
-          if (dependency.projects === 'self') {
+          if (
+            dependency.projects === 'self' ||
+            dependency.projects === '{self}'
+          ) {
             delete dependency.projects;
             projectChanged = true;
-          } else if (dependency.projects === 'dependencies') {
+          } else if (
+            dependency.projects === 'dependencies' ||
+            dependency.projects === '{dependencies}'
+          ) {
             delete dependency.projects;
             dependency.dependencies = true;
             projectChanged = true;
@@ -30,10 +36,17 @@ export default async function (tree: Tree) {
       for (let i = 0; i < targetConfiguration.inputs?.length ?? 0; i++) {
         const input = targetConfiguration.inputs[i];
         if (typeof input !== 'string') {
-          if ('projects' in input && input.projects === 'self') {
+          if (
+            'projects' in input &&
+            (input.projects === 'self' || input.projects === '{self}')
+          ) {
             delete input.projects;
             projectChanged = true;
-          } else if ('projects' in input && input.projects === 'dependencies') {
+          } else if (
+            'projects' in input &&
+            (input.projects === 'dependencies' ||
+              input.projects === '{dependencies}')
+          ) {
             delete input.projects;
             targetConfiguration.inputs[i] = {
               ...input,
@@ -57,10 +70,16 @@ function updateDependsOnAndInputsInsideNxJson(tree: Tree) {
   )) {
     for (const dependency of defaults.dependsOn ?? []) {
       if (typeof dependency !== 'string') {
-        if (dependency.projects === 'self') {
+        if (
+          dependency.projects === 'self' ||
+          dependency.projects === '{self}'
+        ) {
           delete dependency.projects;
           nxJsonChanged = true;
-        } else if (dependency.projects === 'dependencies') {
+        } else if (
+          dependency.projects === 'dependencies' ||
+          dependency.projects === '{dependencies}'
+        ) {
           delete dependency.projects;
           dependency.dependencies = true;
           nxJsonChanged = true;
@@ -70,10 +89,17 @@ function updateDependsOnAndInputsInsideNxJson(tree: Tree) {
     for (let i = 0; i < defaults.inputs?.length ?? 0; i++) {
       const input = defaults.inputs[i];
       if (typeof input !== 'string') {
-        if ('projects' in input && input.projects === 'self') {
+        if (
+          'projects' in input &&
+          (input.projects === 'self' || input.projects === '{self}')
+        ) {
           delete input.projects;
           nxJsonChanged = true;
-        } else if ('projects' in input && input.projects === 'dependencies') {
+        } else if (
+          'projects' in input &&
+          (input.projects === 'dependencies' ||
+            input.projects === '{dependencies}')
+        ) {
           delete input.projects;
           defaults.inputs[i] = {
             ...input,

--- a/packages/nx/src/migrations/update-16-0-0/update-depends-on-to-tokens.ts
+++ b/packages/nx/src/migrations/update-16-0-0/update-depends-on-to-tokens.ts
@@ -7,7 +7,7 @@ import {
 import { Tree } from '../../generators/tree';
 
 export default async function (tree: Tree) {
-  updateDependsOnInsideNxJson(tree);
+  updateDependsOnAndInputsInsideNxJson(tree);
 
   const projectsConfigurations = getProjects(tree);
   for (const [projectName, projectConfiguration] of projectsConfigurations) {
@@ -21,8 +21,24 @@ export default async function (tree: Tree) {
             delete dependency.projects;
             projectChanged = true;
           } else if (dependency.projects === 'dependencies') {
-            delete dependency.projects
+            delete dependency.projects;
             dependency.dependencies = true;
+            projectChanged = true;
+          }
+        }
+      }
+      for (let i = 0; i < targetConfiguration.inputs?.length ?? 0; i++) {
+        const input = targetConfiguration.inputs[i];
+        if (typeof input !== 'string') {
+          if ('projects' in input && input.projects === 'self') {
+            delete input.projects;
+            projectChanged = true;
+          } else if ('projects' in input && input.projects === 'dependencies') {
+            delete input.projects;
+            targetConfiguration.inputs[i] = {
+              ...input,
+              dependencies: true,
+            };
             projectChanged = true;
           }
         }
@@ -33,7 +49,7 @@ export default async function (tree: Tree) {
     }
   }
 }
-function updateDependsOnInsideNxJson(tree: Tree) {
+function updateDependsOnAndInputsInsideNxJson(tree: Tree) {
   const nxJson = readNxJson(tree);
   let nxJsonChanged = false;
   for (const [target, defaults] of Object.entries(
@@ -45,8 +61,24 @@ function updateDependsOnInsideNxJson(tree: Tree) {
           delete dependency.projects;
           nxJsonChanged = true;
         } else if (dependency.projects === 'dependencies') {
-          delete dependency.projects
+          delete dependency.projects;
           dependency.dependencies = true;
+          nxJsonChanged = true;
+        }
+      }
+    }
+    for (let i = 0; i < defaults.inputs?.length ?? 0; i++) {
+      const input = defaults.inputs[i];
+      if (typeof input !== 'string') {
+        if ('projects' in input && input.projects === 'self') {
+          delete input.projects;
+          nxJsonChanged = true;
+        } else if ('projects' in input && input.projects === 'dependencies') {
+          delete input.projects;
+          defaults.inputs[i] = {
+            ...input,
+            dependencies: true,
+          };
           nxJsonChanged = true;
         }
       }

--- a/packages/nx/src/migrations/update-16-0-0/update-depends-on-to-tokens.ts
+++ b/packages/nx/src/migrations/update-16-0-0/update-depends-on-to-tokens.ts
@@ -18,10 +18,11 @@ export default async function (tree: Tree) {
       for (const dependency of targetConfiguration.dependsOn ?? []) {
         if (typeof dependency !== 'string') {
           if (dependency.projects === 'self') {
-            dependency.projects = '{self}';
+            delete dependency.projects;
             projectChanged = true;
           } else if (dependency.projects === 'dependencies') {
-            dependency.projects = '{dependencies}';
+            delete dependency.projects
+            dependency.dependencies = true;
             projectChanged = true;
           }
         }
@@ -41,10 +42,11 @@ function updateDependsOnInsideNxJson(tree: Tree) {
     for (const dependency of defaults.dependsOn ?? []) {
       if (typeof dependency !== 'string') {
         if (dependency.projects === 'self') {
-          dependency.projects = '{self}';
+          delete dependency.projects;
           nxJsonChanged = true;
         } else if (dependency.projects === 'dependencies') {
-          dependency.projects = '{dependencies}';
+          delete dependency.projects
+          dependency.dependencies = true;
           nxJsonChanged = true;
         }
       }

--- a/packages/nx/src/tasks-runner/create-task-graph.spec.ts
+++ b/packages/nx/src/tasks-runner/create-task-graph.spec.ts
@@ -24,11 +24,10 @@ describe('createTaskGraph', () => {
                 executor: 'nx:run-commands',
                 dependsOn: [
                   {
-                    projects: '{dependencies}',
+                    dependencies: true,
                     target: 'build',
                   },
                   {
-                    projects: '{self}',
                     target: 'prebuild',
                   },
                   {
@@ -173,7 +172,7 @@ describe('createTaskGraph', () => {
                 },
                 dependsOn: [
                   {
-                    projects: '{dependencies}',
+                    dependencies: true,
                     target: 'build',
                   },
                 ],
@@ -196,7 +195,7 @@ describe('createTaskGraph', () => {
                 defaultConfiguration: 'libDefault',
                 dependsOn: [
                   {
-                    projects: '{dependencies}',
+                    dependencies: true,
                     target: 'build',
                   },
                 ],
@@ -337,7 +336,7 @@ describe('createTaskGraph', () => {
                 executor: 'my-executor',
                 dependsOn: [
                   {
-                    projects: '{dependencies}',
+                    dependencies: true,
                     target: 'build',
                   },
                 ],
@@ -508,11 +507,11 @@ describe('createTaskGraph', () => {
                 executor: 'nx:run-commands',
                 dependsOn: [
                   {
-                    projects: '{dependencies}',
+                    dependencies: true,
                     target: 'build',
                     params: 'forward',
                   },
-                  { projects: '{self}', target: 'prebuild', params: 'forward' },
+                  { target: 'prebuild', params: 'forward' },
                 ],
               },
               test: {
@@ -535,7 +534,7 @@ describe('createTaskGraph', () => {
                 executor: 'nx:run-commands',
                 dependsOn: [
                   {
-                    projects: '{dependencies}',
+                    dependencies: true,
                     target: 'build',
                     params: 'ignore',
                   },
@@ -844,7 +843,7 @@ describe('createTaskGraph', () => {
       {
         build: [
           {
-            projects: '{dependencies}',
+            dependencies: true,
             target: 'build',
           },
         ],
@@ -1005,9 +1004,9 @@ describe('createTaskGraph', () => {
       {
         build: ['^build'],
         apply: [
-          { projects: '{dependencies}', target: 'build' },
+          { dependencies: true, target: 'build' },
           {
-            projects: '{dependencies}',
+            dependencies: true,
             target: 'apply',
             params: 'forward',
           },
@@ -1083,11 +1082,11 @@ describe('createTaskGraph', () => {
             targets: {
               build: {
                 executor: 'nx:run-commands',
-                dependsOn: [{ target: 'test', projects: '{self}' }],
+                dependsOn: [{ target: 'test' }],
               },
               test: {
                 executor: 'nx:run-commands',
-                dependsOn: [{ target: 'build', projects: '{self}' }],
+                dependsOn: [{ target: 'build' }],
               },
             },
           },
@@ -1192,7 +1191,7 @@ describe('createTaskGraph', () => {
     const taskGraph = createTaskGraph(
       projectGraph,
       {
-        build: [{ target: 'build', projects: '{dependencies}' }],
+        build: [{ target: 'build', dependencies: true }],
       },
       ['app1'],
       ['build'],
@@ -1283,7 +1282,7 @@ describe('createTaskGraph', () => {
     const taskGraph = createTaskGraph(
       projectGraph,
       {
-        build: [{ target: 'build', projects: '{dependencies}' }],
+        build: [{ target: 'build', dependencies: true }],
       },
       ['app1'],
       ['build'],
@@ -1338,8 +1337,8 @@ describe('createTaskGraph', () => {
               build: {
                 executor: 'nx:run-commands',
                 dependsOn: [
-                  { target: 'prebuild', projects: '{self}' },
-                  { target: 'build', projects: '{dependencies}' },
+                  { target: 'prebuild' },
+                  { target: 'build', dependencies: true },
                 ],
               },
               prebuild: {

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -35,23 +35,32 @@ export function getDependencyConfigs(
     const specifiers =
       typeof dependencyConfig.projects === 'string'
         ? [dependencyConfig.projects]
-        : dependencyConfig.projects;
+        : dependencyConfig.projects ?? [];
     for (const specifier of specifiers) {
       if (
         !(specifier in projectGraph.nodes) &&
-        // Todo(@agentender): Remove the non-token forms of these for v17
-        !['{self}', '{dependencies}', 'self', 'dependencies'].includes(
+        // Todo(@agentender): Remove the check for self / dependencies in v17
+        !['self', 'dependencies'].includes(
           specifier
         )
       ) {
         output.error({
           title: `dependsOn is improperly configured for ${project}:${target}`,
           bodyLines: [
-            `${specifier} in dependsOn.projects is invalid. It should be "{self}", "{dependencies}", or a project name.`,
+            `${specifier} in dependsOn.projects is invalid. It should be "self", "dependencies", or a project name.`,
           ],
         });
         process.exit(1);
       }
+    }
+    if (dependencyConfig.projects && dependencyConfig.dependencies) {
+      output.error({
+        title: `dependsOn is improperly configured for ${project}:${target}`,
+        bodyLines: [
+          `dependsOn.projects and dependsOn.dependencies cannot be used together.`,
+        ],
+      });
+      process.exit(1);
     }
   }
   return dependencyConfigs;
@@ -63,9 +72,9 @@ function expandDependencyConfigSyntaxSugar(
   return deps.map((d) => {
     if (typeof d === 'string') {
       if (d.startsWith('^')) {
-        return { projects: '{dependencies}', target: d.substring(1) };
+        return { dependencies: true, target: d.substring(1) };
       } else {
-        return { projects: '{self}', target: d };
+        return { target: d };
       }
     } else {
       return d;

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -35,14 +35,12 @@ export function getDependencyConfigs(
     const specifiers =
       typeof dependencyConfig.projects === 'string'
         ? [dependencyConfig.projects]
-        : dependencyConfig.projects ?? [];
-    for (const specifier of specifiers) {
+        : dependencyConfig.projects;
+    for (const specifier of specifiers ?? []) {
       if (
         !(specifier in projectGraph.nodes) &&
         // Todo(@agentender): Remove the check for self / dependencies in v17
-        !['self', 'dependencies'].includes(
-          specifier
-        )
+        !['self', 'dependencies'].includes(specifier)
       ) {
         output.error({
           title: `dependsOn is improperly configured for ${project}:${target}`,


### PR DESCRIPTION
…ty rather than tokens<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We introduced {self} and {dependencies} for TargetDependencyConfig['projects'], but have decided to move in a slightly different direction.

## Expected Behavior
Instead, we use the lack of a `projects` field to indicate `self`, and a field `dependencies: true` to indicate `dependencies`.

Also, this is equivalent for hashing and `inputs`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
