### PR TITLE
fix(vite): build executor should not overwrite package.json in dist

### DIFF
--- a/packages/vite/src/executors/build/build.impl.ts
+++ b/packages/vite/src/executors/build/build.impl.ts
@@ -35,9 +35,11 @@ export async function* viteBuildExecutor(
 
   const libraryPackageJson = resolve(projectRoot, 'package.json');
   const rootPackageJson = resolve(context.root, 'package.json');
+  const distPackageJson = resolve(normalizedOptions.outputPath, 'package.json');
 
   // For buildable libs, copy package.json if it exists.
   if (
+    !existsSync(distPackageJson) &&
     existsSync(libraryPackageJson) &&
     rootPackageJson !== libraryPackageJson
   ) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Right now if any plugins process/create package.json during the build process, it will be overwritten by `@nrwl/vite:build` executor.

For example, using `rollup-plugin-generate-package-json` plugin, if you put in the app's vite config the following
```
    generatePackageJson({
      inputFolder: './',
      outputFolder: `./dist/apps/myapp`,
    }),
```
it will take no effect if built with nx
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Should check for the existing package.json under dist and not overwrite it
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
