### PR TITLE
feat(vite): allow setting of build target

### DIFF
--- a/docs/generated/packages/vite/executors/build.json
+++ b/docs/generated/packages/vite/executors/build.json
@@ -58,6 +58,10 @@
         "description": "Output sourcemaps. Use 'hidden' for use with error reporting tools without generating sourcemap comment.",
         "oneOf": [{ "type": "boolean" }, { "type": "string" }]
       },
+      "target": {
+        "description": "Browser compatibility target for the final bundle. For more info: https://vitejs.dev/config/build-options.html#build-target",
+        "type": "string"
+      },
       "minify": {
         "description": "Output sourcemaps. Use 'hidden' for use with error reporting tools without generating sourcemap comment.",
         "oneOf": [{ "type": "boolean" }, { "type": "string" }]

--- a/packages/vite/src/executors/build/schema.d.ts
+++ b/packages/vite/src/executors/build/schema.d.ts
@@ -14,4 +14,5 @@ export interface ViteBuildExecutorOptions {
   mode?: string;
   ssr?: boolean | string;
   watch?: object | boolean;
+  target?: string | string[];
 }

--- a/packages/vite/src/executors/build/schema.json
+++ b/packages/vite/src/executors/build/schema.json
@@ -67,6 +67,10 @@
         }
       ]
     },
+    "target": {
+      "description": "Browser compatibility target for the final bundle. For more info: https://vitejs.dev/config/build-options.html#build-target",
+      "type": "string"
+    },
     "minify": {
       "description": "Output sourcemaps. Use 'hidden' for use with error reporting tools without generating sourcemap comment.",
       "oneOf": [

--- a/packages/vite/src/utils/options-utils.ts
+++ b/packages/vite/src/utils/options-utils.ts
@@ -139,7 +139,7 @@ export function getViteBuildOptions(
     emptyOutDir: options.emptyOutDir,
     reportCompressedSize: true,
     cssCodeSplit: true,
-    target: 'esnext',
+    target: options.target ?? 'esnext',
     commonjsOptions: {
       transformMixedEsModules: true,
     },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Vite `build.target` is hard-coded as `esnext`.

## Expected Behavior
Users should be allowed to set `build.target`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16389
