### PR TITLE
docs(core): make migrate latest more prominent

### DIFF
--- a/docs/generated/cli/migrate.md
+++ b/docs/generated/cli/migrate.md
@@ -23,13 +23,13 @@ Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`
 
 ### Examples
 
-Update @nrwl/workspace to "next". This will update other packages and will generate migrations.json:
+Update all Nx plugins to "latest". This will generate migrations.json:
 
 ```shell
- nx migrate next
+ nx migrate latest
 ```
 
-Update @nrwl/workspace to "9.0.0". This will update other packages and will generate migrations.json:
+Update all Nx plugins to "9.0.0". This will generate migrations.json:
 
 ```shell
  nx migrate 9.0.0

--- a/docs/generated/packages/nx/documents/migrate.md
+++ b/docs/generated/packages/nx/documents/migrate.md
@@ -23,13 +23,13 @@ Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`
 
 ### Examples
 
-Update @nrwl/workspace to "next". This will update other packages and will generate migrations.json:
+Update all Nx plugins to "latest". This will generate migrations.json:
 
 ```shell
- nx migrate next
+ nx migrate latest
 ```
 
-Update @nrwl/workspace to "9.0.0". This will update other packages and will generate migrations.json:
+Update all Nx plugins to "9.0.0". This will generate migrations.json:
 
 ```shell
  nx migrate 9.0.0

--- a/packages/nx/src/command-line/examples.ts
+++ b/packages/nx/src/command-line/examples.ts
@@ -288,14 +288,14 @@ export const examples: Record<string, Example[]> = {
   ],
   migrate: [
     {
-      command: 'migrate next',
+      command: 'migrate latest',
       description:
-        'Update @nrwl/workspace to "next". This will update other packages and will generate migrations.json',
+        'Update all Nx plugins to "latest". This will generate migrations.json',
     },
     {
       command: 'migrate 9.0.0',
       description:
-        'Update @nrwl/workspace to "9.0.0". This will update other packages and will generate migrations.json',
+        'Update all Nx plugins to "9.0.0". This will generate migrations.json',
     },
     {
       command:


### PR DESCRIPTION
Fixes #16483

Make `nx migrate latest` more visible near the top of the migrate command docs.