### PR TITLE
fix(nx): switch prettier check to use --check instead of --list-different

### DIFF
--- a/packages/nx/src/command-line/format.ts
+++ b/packages/nx/src/command-line/format.ts
@@ -181,7 +181,7 @@ function check(patterns: string[], verbose: boolean): boolean {
     return true;
   }
   try {
-    const logFlag = verbose ? "--check" : "--list-different";
+    const logFlag = verbose ? '--check' : '--list-different';
     execSync(`node "${PRETTIER_PATH}" ${logFlag} ${patterns.join(' ')}`, {
       stdio: [0, 1, 2],
     });

--- a/packages/nx/src/command-line/format.ts
+++ b/packages/nx/src/command-line/format.ts
@@ -181,7 +181,7 @@ function check(patterns: string[]): boolean {
     return true;
   }
   try {
-    execSync(`node "${PRETTIER_PATH}" --list-different ${patterns.join(' ')}`, {
+    execSync(`node "${PRETTIER_PATH}" --check ${patterns.join(' ')}`, {
       stdio: [0, 1, 2],
     });
     return true;

--- a/packages/nx/src/command-line/format.ts
+++ b/packages/nx/src/command-line/format.ts
@@ -51,7 +51,7 @@ export async function format(
       break;
     case 'check':
       const pass = chunkList.reduce(
-        (pass, chunk) => check(chunk) && pass,
+        (pass, chunk) => check(chunk, args.verbose) && pass,
         true
       );
       if (!pass) {
@@ -176,12 +176,13 @@ function write(patterns: string[]) {
   }
 }
 
-function check(patterns: string[]): boolean {
+function check(patterns: string[], verbose: boolean): boolean {
   if (patterns.length === 0) {
     return true;
   }
   try {
-    execSync(`node "${PRETTIER_PATH}" --check ${patterns.join(' ')}`, {
+    const logFlag = verbose ? "--check" : "--list-different"
+    execSync(`node "${PRETTIER_PATH}" ${logFlag} ${patterns.join(' ')}`, {
       stdio: [0, 1, 2],
     });
     return true;

--- a/packages/nx/src/command-line/format.ts
+++ b/packages/nx/src/command-line/format.ts
@@ -181,7 +181,7 @@ function check(patterns: string[], verbose: boolean): boolean {
     return true;
   }
   try {
-    const logFlag = verbose ? "--check" : "--list-different"
+    const logFlag = verbose ? "--check" : "--list-different";
     execSync(`node "${PRETTIER_PATH}" ${logFlag} ${patterns.join(' ')}`, {
       stdio: [0, 1, 2],
     });


### PR DESCRIPTION
## Current Behavior
Running `format:check` simply lists the files with issues, with no context to the developers.

```
yarn format:check
Checking formatting...
nx.json
```

- `--list-different` docs:  https://prettier.io/docs/en/cli.html#--list-different

## Expected Behavior
Running `format:check` provides consumable information to the developers. 

> "This will output a human-friendly message and a list of unformatted files, if any."

```
yarn format:check
Checking formatting...
[warn] nx.json
[warn] Code style issues found in the above file. Forgot to run Prettier?
```

- `--check` docs: https://prettier.io/docs/en/cli.html#--check

## Related Issue(s)
https://github.com/nrwl/nx/issues/4159
