### PR TITLE
feat(vite): throw an error if vite config is not found at provided path

### DIFF
--- a/packages/vite/src/utils/options-utils.ts
+++ b/packages/vite/src/utils/options-utils.ts
@@ -28,9 +28,16 @@ export function normalizeViteConfigFilePath(
   projectRoot: string,
   configFile?: string
 ): string | undefined {
-  return configFile && existsSync(joinPathFragments(configFile))
-    ? configFile
-    : existsSync(joinPathFragments(`${projectRoot}/vite.config.ts`))
+  if (configFile) {
+    const normalized = joinPathFragments(configFile);
+    if (!existsSync(normalized)) {
+      throw new Error(
+        `Could not find vite config at provided path "${normalized}".`
+      );
+    }
+    return normalized;
+  }
+  return existsSync(joinPathFragments(`${projectRoot}/vite.config.ts`))
     ? joinPathFragments(`${projectRoot}/vite.config.ts`)
     : existsSync(joinPathFragments(`${projectRoot}/vite.config.js`))
     ? joinPathFragments(`${projectRoot}/vite.config.js`)


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
If the path to vite.config cannot be resolved, `@nrwl/vite:build` executor will silently replace it with the one it is able to resolve

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Should throw an error instead.

This change applies only to `normalizeViteConfigFilePath` function, I think that it is fine to replace vite config in `normalizeViteConfigFilePathWithTree` as it mutates the code instead of running it.

