### PR TITLE
fix(repo): run nightly e2e with pnpm

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -70,6 +70,7 @@ jobs:
         if: ${{ matrix.os == 'macos-latest' }}
         uses: actions/cache@v3
         with:
+          lookup-only: true
           path: ${{ steps.homebrew-cache-dir-path.outputs.dir }}
           key: brew-${{ matrix.node_version }}
           restore-keys: |
@@ -401,7 +402,7 @@ jobs:
 
       - name: Run e2e tests
         id: e2e-run
-        run: yarn nx run-many -t e2e,e2e-macos -p ${{ matrix.project }}
+        run: pnpm nx run-many -t e2e,e2e-macos -p ${{ matrix.project }}
         timeout-minutes: ${{ matrix.os_timeout }}
         env:
           GIT_AUTHOR_EMAIL: test@test.com

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -44,6 +44,7 @@ jobs:
         id: cache-modules
         uses: actions/cache@v3
         with:
+          lookup-only: true
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ matrix.node_version }}-${{ github.run_id }}
 
@@ -67,7 +68,6 @@ jobs:
     needs: preinstall
     permissions:
       contents: read
-
     runs-on: windows-latest
     strategy:
       matrix:
@@ -287,7 +287,7 @@ jobs:
 
       - name: Run e2e tests
         id: e2e-run
-        run: yarn nx run ${{ matrix.project }}:e2e
+        run: pnpm nx run ${{ matrix.project }}:e2e
         timeout-minutes: 120
         env:
           GIT_AUTHOR_EMAIL: test@test.com


### PR DESCRIPTION
- add missing `lookup-only` to `preinstall` job
- run e2e command with pnpm, since yarn fails finding nx on windows

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
