### PR TITLE
docs(react-native): fix typo in build-ios schema.json

### DIFF
--- a/docs/generated/packages/react-native/executors/build-ios.json
+++ b/docs/generated/packages/react-native/executors/build-ios.json
@@ -37,7 +37,7 @@
         "examples": ["Debug", "Release"],
         "x-priority": "important"
       },
-      "schema": {
+      "scheme": {
         "type": "string",
         "description": "Explicitly set Xcode scheme to use"
       },

--- a/packages/react-native/src/executors/build-ios/schema.json
+++ b/packages/react-native/src/executors/build-ios/schema.json
@@ -43,7 +43,7 @@
       "examples": ["Debug", "Release"],
       "x-priority": "important"
     },
-    "schema": {
+    "scheme": {
       "type": "string",
       "description": "Explicitly set Xcode scheme to use"
     },


### PR DESCRIPTION
The "scheme" property to set the Xcode scheme to use was erroneously named "schema".

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
