### PR TITLE
fix(node): default webpack build to not perform default optimizations for Node

### DIFF
--- a/packages/webpack/src/utils/with-nx.ts
+++ b/packages/webpack/src/utils/with-nx.ts
@@ -139,16 +139,20 @@ export function withNx(pluginOptions?: WithNxOptions): NxWebpackPlugin {
         : undefined,
       target: options.target,
       node: false as const,
-      // When mode is development or production, webpack will automatically
-      // configure DefinePlugin to replace `process.env.NODE_ENV` with the
-      // build-time value. Thus, we need to make sure it's the same value to
-      // avoid conflicts.
-      //
-      // When the NODE_ENV is something else (e.g. test), then set it to none
-      // to prevent extra behavior from webpack.
       mode:
-        process.env.NODE_ENV === 'development' ||
-        process.env.NODE_ENV === 'production'
+        // When the target is Node avoid any optimizations, such as replacing `process.env.NODE_ENV` with build time value.
+        options.target === ('node' as const)
+          ? 'none'
+          : // Otherwise, make sure it matches `process.env.NODE_ENV`.
+          // When mode is development or production, webpack will automatically
+          // configure DefinePlugin to replace `process.env.NODE_ENV` with the
+          // build-time value. Thus, we need to make sure it's the same value to
+          // avoid conflicts.
+          //
+          // When the NODE_ENV is something else (e.g. test), then set it to none
+          // to prevent extra behavior from webpack.
+          process.env.NODE_ENV === 'development' ||
+            process.env.NODE_ENV === 'production'
           ? (process.env.NODE_ENV as 'development' | 'production')
           : ('none' as const),
       devtool:


### PR DESCRIPTION
When the target is Node, we don't want Webpack to perform any optimizations by default, or else things like `process.env.NODE_ENV` gets replaced at build time.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16601 
