### PR TITLE
fix(core): fix nx migrate to the same version

### DIFF
--- a/packages/nx/src/command-line/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate.spec.ts
@@ -254,12 +254,15 @@ describe('Migration', () => {
       });
     });
 
-    it('should skip the versions <= currently installed', async () => {
+    it('should skip the versions < currently installed', async () => {
+      const packageJson = {
+        dependencies: { parent: '1.0.0', child: '2.0.0', grandchild: '3.0.0' },
+      };
       const migrator = new Migrator({
-        packageJson: createPackageJson({
-          dependencies: { child: '1.0.0', grandchild: '2.0.0' },
-        }),
-        getInstalledPackageVersion: () => '1.0.0',
+        packageJson: createPackageJson(packageJson),
+        getInstalledPackageVersion: (name) => {
+          return packageJson.dependencies[name];
+        },
         fetch: (p, _v) => {
           if (p === 'parent') {
             return Promise.resolve({

--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -406,7 +406,7 @@ export class Migrator {
     for (const packageJsonUpdate of Object.values(packageJsonUpdates)) {
       if (
         !packageJsonUpdate.packages ||
-        this.lte(packageJsonUpdate.version, this.getPkgVersion(packageName)) ||
+        this.lt(packageJsonUpdate.version, this.getPkgVersion(packageName)) ||
         this.gt(packageJsonUpdate.version, targetVersion)
       ) {
         continue;
@@ -588,6 +588,10 @@ export class Migrator {
 
   private gt(v1: string, v2: string) {
     return gt(normalizeVersion(v1), normalizeVersion(v2));
+  }
+
+  private lt(v1: string, v2: string) {
+    return lt(normalizeVersion(v1), normalizeVersion(v2));
   }
 
   private lte(v1: string, v2: string) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`nx migrate 16.0.0` when the following packages are installed:

```
nx: 16.0.0
@nrwl/vite: 15.9.3
```

Will not migrate `@nrwl/vite` to `16.0.0`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`nx migrate 16.0.0` when the following packages are installed:

```
nx: 16.0.0
@nrwl/vite: 15.9.3
```

Will migrate `@nrwl/vite` to `16.0.0`.

This is a mechanism to sync up mismatching `@nx` package versions.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
