### PR TITLE
fix(nextjs): show a warning when user uses emotion with appDir layout

### DIFF
--- a/packages/next/src/generators/application/application.ts
+++ b/packages/next/src/generators/application/application.ts
@@ -18,9 +18,12 @@ import { addStyleDependencies } from '../../utils/styles';
 import { addLinting } from './lib/add-linting';
 import { customServerGenerator } from '../custom-server/custom-server';
 import { updateCypressTsConfig } from './lib/update-cypress-tsconfig';
+import { showPossibleWarnings } from './lib/show-possible-warnings';
 
 export async function applicationGenerator(host: Tree, schema: Schema) {
   const options = normalizeOptions(host, schema);
+
+  showPossibleWarnings(host, options);
 
   const nextTask = await nextInitGenerator(host, {
     ...options,

--- a/packages/next/src/generators/application/lib/show-possible-warnings.ts
+++ b/packages/next/src/generators/application/lib/show-possible-warnings.ts
@@ -1,0 +1,10 @@
+import { logger, Tree } from '@nx/devkit';
+import { NormalizedSchema } from './normalize-options';
+
+export function showPossibleWarnings(tree: Tree, options: NormalizedSchema) {
+  if (options.style === '@emotion/styled' && options.appDir) {
+    logger.warn(
+      `Emotion may not work with the experimental appDir layout. See: https://beta.nextjs.org/docs/styling/css-in-js`
+    );
+  }
+}


### PR DESCRIPTION
`appDir` layout and emotion isn't currently supported. See: https://beta.nextjs.org/docs/styling/css-in-js

We still want to generate the app so that when Next.js does add support, users can still generate their app and upgrade to the supported version.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Related #16627
