### PR TITLE
docs(linter): fix outdated rule name for enforce-module-boundaries

### DIFF
--- a/docs/shared/recipes/ban-external-imports.md
+++ b/docs/shared/recipes/ban-external-imports.md
@@ -10,8 +10,8 @@ A common example of this is for backend projects that use NestJS and frontend pr
 {
   // ... more ESLint config here
 
-  // nx-enforce-module-boundaries should already exist at the top-level of your config
-  "nx-enforce-module-boundaries": [
+  // @nx/enforce-module-boundaries should already exist at the top-level of your config
+  "@nx/enforce-module-boundaries": [
     "error",
     {
       "allow": [],
@@ -40,8 +40,8 @@ Another common example is ensuring that util libraries stay framework-free by ba
 ```jsonc {% fileName=".eslintrc.json" %}
 {
   // ... more ESLint config here
-  // nx-enforce-module-boundaries should already exist at the top-level of your config
-  "nx-enforce-module-boundaries": [
+  // @nx/enforce-module-boundaries should already exist at the top-level of your config
+  "@nx/enforce-module-boundaries": [
     "error",
     {
       "allow": [],
@@ -69,8 +69,8 @@ This is useful if you want to enforce separation of concerns _(e.g. keeping your
 {
   // ... more ESLint config here
 
-  // nx-enforce-module-boundaries should already exist at the top-level of your config
-  "nx-enforce-module-boundaries": [
+  // @nx/enforce-module-boundaries should already exist at the top-level of your config
+  "@nx/enforce-module-boundaries": [
     "error",
     {
       "allow": [],

--- a/docs/shared/recipes/resolve-circular-dependencies.md
+++ b/docs/shared/recipes/resolve-circular-dependencies.md
@@ -1,6 +1,6 @@
 # Resolve Circular Dependencies
 
-A circular dependency is when a project transitively depends on itself. This can cause problems in the design of your software and also makes Nx's affected algorithm less effective. The lint rule, `nx-enforce-module-boundaries`, will produce an error if any circular dependencies are created and ensures that any `import` statements going across projects only `import` from the defined public apis in a project's root `index.ts` file.
+A circular dependency is when a project transitively depends on itself. This can cause problems in the design of your software and also makes Nx's affected algorithm less effective. The lint rule, `@nx/enforce-module-boundaries`, will produce an error if any circular dependencies are created and ensures that any `import` statements going across projects only `import` from the defined public apis in a project's root `index.ts` file.
 
 When migrating a new codebase into an nx workspace, you'll likely begin to uncover existing circular dependencies. Let's look at the simplest possible circular dependency, where `projectA` depends on `projectB` and vice versa.
 

--- a/docs/shared/recipes/tag-multiple-dimensions.md
+++ b/docs/shared/recipes/tag-multiple-dimensions.md
@@ -79,8 +79,8 @@ We can now restrict projects within the same group to depend on each other based
 {
   // ... more ESLint config here
 
-  // nx-enforce-module-boundaries should already exist at the top-level of your config
-  "nx-enforce-module-boundaries": [
+  // @nx/enforce-module-boundaries should already exist at the top-level of your config
+  "@nx/enforce-module-boundaries": [
     "error",
     {
       "allow": [],
@@ -132,8 +132,8 @@ Matching just a single source tag is sometimes not enough for solving complex re
 {
   // ... more ESLint config here
 
-  // nx-enforce-module-boundaries should already exist at the top-level of your config
-  "nx-enforce-module-boundaries": [
+  // @nx/enforce-module-boundaries should already exist at the top-level of your config
+  "@nx/enforce-module-boundaries": [
     "error",
     {
       "allow": [],

--- a/packages/nx/src/config/workspace-json-project-json.ts
+++ b/packages/nx/src/config/workspace-json-project-json.ts
@@ -95,7 +95,7 @@ export interface ProjectConfiguration {
   namedInputs?: { [inputName: string]: (string | InputDefinition)[] };
 
   /**
-   * List of tags used by nx-enforce-module-boundaries / project graph
+   * List of tags used by enforce-module-boundaries / project graph
    */
   tags?: string[];
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
