### PR TITLE
feat(bundling): add esbuild migration to correctly set thirdParty option

### DIFF
--- a/packages/esbuild/migrations.json
+++ b/packages/esbuild/migrations.json
@@ -11,6 +11,12 @@
       "version": "16.0.0-beta.1",
       "description": "Replace @nrwl/esbuild with @nx/esbuild",
       "implementation": "./src/migrations/update-16-0-0-add-nx-packages/update-16-0-0-add-nx-packages"
+    },
+    "update-16-0-1-set-thirdparty-true": {
+      "version": "16.0.1",
+      "description": "Set thirdParty to true to maintain the existing behavior of bundling dependencies.",
+      "cli": "nx",
+      "implementation": "./src/migrations/update-16-0-1-set-thirdparty-true/update-16-0-1-set-thirdparty-true"
     }
   },
   "packageJsonUpdates": {

--- a/packages/esbuild/migrations.json
+++ b/packages/esbuild/migrations.json
@@ -13,7 +13,7 @@
       "implementation": "./src/migrations/update-16-0-0-add-nx-packages/update-16-0-0-add-nx-packages"
     },
     "update-16-0-1-set-thirdparty-true": {
-      "version": "16.0.1",
+      "version": "16.0.1-beta.0",
       "description": "Set thirdParty to true to maintain the existing behavior of bundling dependencies.",
       "cli": "nx",
       "implementation": "./src/migrations/update-16-0-1-set-thirdparty-true/update-16-0-1-set-thirdparty-true"

--- a/packages/esbuild/src/migrations/update-16-0-1-set-thirdparty-true/update-16-0-1-set-thirdparty-true.spec.ts
+++ b/packages/esbuild/src/migrations/update-16-0-1-set-thirdparty-true/update-16-0-1-set-thirdparty-true.spec.ts
@@ -1,0 +1,78 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import {
+  addProjectConfiguration,
+  readProjectConfiguration,
+  Tree,
+} from '@nx/devkit';
+
+import update from './update-16-0-1-set-thirdparty-true';
+
+describe('update-16-0-1-set-thirdparty-true', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should add thirdParty property if bundling is enabled', async () => {
+    addProjectConfiguration(tree, 'myapp', {
+      root: 'myapp',
+      targets: {
+        build: {
+          executor: '@nx/esbuild:esbuild',
+          options: {
+            bundle: true,
+          },
+        },
+      },
+    });
+    await update(tree);
+
+    const config = readProjectConfiguration(tree, 'myapp');
+
+    expect(config.targets.build.options).toEqual({
+      bundle: true,
+      thirdParty: true,
+    });
+  });
+  it('should not add thirdParty property if bundling is disabled', async () => {
+    addProjectConfiguration(tree, 'myapp', {
+      root: 'myapp',
+      targets: {
+        build: {
+          executor: '@nx/esbuild:esbuild',
+          options: {
+            bundle: false,
+          },
+        },
+      },
+    });
+    await update(tree);
+
+    const config = readProjectConfiguration(tree, 'myapp');
+
+    expect(config.targets.build.options).toEqual({
+      bundle: false,
+    });
+  });
+  it('should not set thirdParty property if it was already set', async () => {
+    addProjectConfiguration(tree, 'myapp', {
+      root: 'myapp',
+      targets: {
+        build: {
+          executor: '@nx/esbuild:esbuild',
+          options: {
+            thirdParty: false,
+          },
+        },
+      },
+    });
+    await update(tree);
+
+    const config = readProjectConfiguration(tree, 'myapp');
+
+    expect(config.targets.build.options).toEqual({
+      thirdParty: false,
+    });
+  });
+});

--- a/packages/esbuild/src/migrations/update-16-0-1-set-thirdparty-true/update-16-0-1-set-thirdparty-true.spec.ts
+++ b/packages/esbuild/src/migrations/update-16-0-1-set-thirdparty-true/update-16-0-1-set-thirdparty-true.spec.ts
@@ -14,7 +14,24 @@ describe('update-16-0-1-set-thirdparty-true', () => {
     tree = createTreeWithEmptyWorkspace();
   });
 
-  it('should add thirdParty property if bundling is enabled', async () => {
+  it('should add thirdParty property if bundling is enabled implicitly', async () => {
+    addProjectConfiguration(tree, 'myapp', {
+      root: 'myapp',
+      targets: {
+        build: {
+          executor: '@nx/esbuild:esbuild',
+        },
+      },
+    });
+    await update(tree);
+
+    const config = readProjectConfiguration(tree, 'myapp');
+
+    expect(config.targets.build.options).toEqual({
+      thirdParty: true,
+    });
+  });
+  it('should add thirdParty property if bundling is enabled explicitly', async () => {
     addProjectConfiguration(tree, 'myapp', {
       root: 'myapp',
       targets: {

--- a/packages/esbuild/src/migrations/update-16-0-1-set-thirdparty-true/update-16-0-1-set-thirdparty-true.ts
+++ b/packages/esbuild/src/migrations/update-16-0-1-set-thirdparty-true/update-16-0-1-set-thirdparty-true.ts
@@ -1,0 +1,37 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import {
+  formatFiles,
+  getProjects,
+  Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+
+export default async function update(host: Tree) {
+  const projects = getProjects(host);
+
+  projects.forEach((projectConfig, projectName) => {
+    let shouldUpdate = false;
+
+    Object.entries(projectConfig.targets).forEach(
+      ([targetName, targetConfig]) => {
+        if (
+          targetConfig.executor === '@nrwl/esbuild:esbuild' ||
+          targetConfig.executor === '@nx/esbuild:esbuild'
+        ) {
+          projectConfig.targets[targetName].options ??= {};
+          if (projectConfig.targets[targetName].options.bundle === true) {
+            shouldUpdate = true;
+
+            projectConfig.targets[targetName].options.thirdParty ??= true;
+          }
+        }
+      }
+    );
+
+    if (shouldUpdate) {
+      updateProjectConfiguration(host, projectName, projectConfig);
+    }
+  });
+
+  await formatFiles(host);
+}

--- a/packages/esbuild/src/migrations/update-16-0-1-set-thirdparty-true/update-16-0-1-set-thirdparty-true.ts
+++ b/packages/esbuild/src/migrations/update-16-0-1-set-thirdparty-true/update-16-0-1-set-thirdparty-true.ts
@@ -19,7 +19,7 @@ export default async function update(host: Tree) {
           targetConfig.executor === '@nx/esbuild:esbuild'
         ) {
           projectConfig.targets[targetName].options ??= {};
-          if (projectConfig.targets[targetName].options.bundle === true) {
+          if (projectConfig.targets[targetName].options.bundle !== false) {
             shouldUpdate = true;
 
             projectConfig.targets[targetName].options.thirdParty ??= true;


### PR DESCRIPTION
## Current Behavior
`@nx/esbuild:esbuild` behavior has changed with version 16. `thirdParty` is not set to true by default anymore. This could break some users.

## Expected Behavior
We shouldn't break users without offering an explanation or a migration. So to maintain the previous behavior, there is now a migration to set `thirdParty` to true.

