### PR TITLE
docs(testing): add example of extending CT preset

### DIFF
--- a/docs/generated/packages/cypress/documents/cypress-component-testing.md
+++ b/docs/generated/packages/cypress/documents/cypress-component-testing.md
@@ -34,6 +34,21 @@ The build target option can be changed later via updating the `devServerTarget` 
 When using component testing make sure to set `skipServe: true` in the component test target options, otherwise `@nx/cypress` will attempt to run the build first which can slow down your component tests. `skipServe: true` is automatically set when using the `cypress-component-configuration` generator.
 {% /callout %}
 
+## Configuration
+
+When using the `cypress-component-configuration` generator, a helper function is used in the `cypress.config.ts` to setup the ideal settings for your project.
+
+If you need to add additional configuration properties, you can spread the returned object from the helper function.
+
+```ts {%filename="cypress.config.ts"}
+export default defineConfig({
+  component: {
+    ...nxComponentTestingPreset(__filename),
+    // add your own config here
+  },
+});
+```
+
 ## Testing Projects
 
 Run `nx component-test your-lib` to execute the component tests with Cypress.

--- a/docs/shared/packages/cypress/cypress-component-testing.md
+++ b/docs/shared/packages/cypress/cypress-component-testing.md
@@ -34,6 +34,21 @@ The build target option can be changed later via updating the `devServerTarget` 
 When using component testing make sure to set `skipServe: true` in the component test target options, otherwise `@nx/cypress` will attempt to run the build first which can slow down your component tests. `skipServe: true` is automatically set when using the `cypress-component-configuration` generator.
 {% /callout %}
 
+## Configuration
+
+When using the `cypress-component-configuration` generator, a helper function is used in the `cypress.config.ts` to setup the ideal settings for your project.
+
+If you need to add additional configuration properties, you can spread the returned object from the helper function.
+
+```ts {%filename="cypress.config.ts"}
+export default defineConfig({
+  component: {
+    ...nxComponentTestingPreset(__filename),
+    // add your own config here
+  },
+});
+```
+
 ## Testing Projects
 
 Run `nx component-test your-lib` to execute the component tests with Cypress.


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
no example on how to extend generated preset for cypress ct

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
example showing how to extend cypress ct preset

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16635
