### PR TITLE
fix(js): do not depend on nx for typescript utils

### DIFF
--- a/packages/devkit/src/utils/module-federation/share.ts
+++ b/packages/devkit/src/utils/module-federation/share.ts
@@ -6,13 +6,11 @@ import type {
 import { AdditionalSharedConfig, SharedFunction } from './models';
 import { dirname, join, normalize } from 'path';
 import { readRootPackageJson } from './package-json';
-import { readTsPathMappings } from './typescript';
+import { readTsPathMappings, getRootTsConfigPath } from './typescript';
 import {
   collectPackageSecondaryEntryPoints,
   collectWorkspaceLibrarySecondaryEntryPoints,
 } from './secondary-entry-points';
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { getRootTsConfigPath } from 'nx/src/plugins/js/utils/typescript';
 import type { ProjectGraph } from 'nx/src/config/project-graph';
 import { requireNx } from '../../../nx';
 

--- a/packages/devkit/src/utils/module-federation/typescript.ts
+++ b/packages/devkit/src/utils/module-federation/typescript.ts
@@ -1,8 +1,9 @@
 import { existsSync } from 'fs';
 import { ParsedCommandLine } from 'typescript';
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { getRootTsConfigPath } from 'nx/src/plugins/js/utils/typescript';
-import { dirname } from 'path';
+import { dirname, join } from 'path';
+import { requireNx } from '../../../nx';
+
+const { workspaceRoot } = requireNx();
 
 let tsConfig: ParsedCommandLine;
 let tsPathMappings: ParsedCommandLine['options']['paths'];
@@ -47,4 +48,21 @@ export function readTsConfig(tsConfigPath: string): ParsedCommandLine {
     tsModule.sys,
     dirname(tsConfigPath)
   );
+}
+
+export function getRootTsConfigPath(): string | null {
+  const tsConfigFileName = getRootTsConfigFileName();
+
+  return tsConfigFileName ? join(workspaceRoot, tsConfigFileName) : null;
+}
+
+function getRootTsConfigFileName(): string | null {
+  for (const tsConfigName of ['tsconfig.base.json', 'tsconfig.json']) {
+    const tsConfigPath = join(workspaceRoot, tsConfigName);
+    if (existsSync(tsConfigPath)) {
+      return tsConfigName;
+    }
+  }
+
+  return null;
 }

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -19,8 +19,3 @@ export {
 } from 'nx/src/plugins/js/lock-file/lock-file';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 export { createPackageJson } from 'nx/src/plugins/js/package-json/create-package-json';
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
-export {
-  findNodes,
-  getRootTsConfigPath,
-} from 'nx/src/plugins/js/utils/typescript';

--- a/packages/js/src/internal.ts
+++ b/packages/js/src/internal.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
-export { resolveModuleByImport } from 'nx/src/plugins/js/utils/typescript';
+export { resolveModuleByImport } from './utils/typescript/ast-utils';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 export {
   registerTsProject,

--- a/packages/js/src/utils/typescript/ast-utils.ts
+++ b/packages/js/src/utils/typescript/ast-utils.ts
@@ -2,11 +2,84 @@ import type { Tree } from '@nx/devkit';
 import type * as ts from 'typescript';
 // TODO(colum): replace when https://github.com/nrwl/nx/pull/15497 is merged
 import { getSourceNodes } from '@nx/workspace/src/utilities/typescript';
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { findNodes } from 'nx/src/plugins/js/utils/typescript';
 import { ensureTypescript } from './ensure-typescript';
+import { Node, SyntaxKind } from 'typescript';
+import { workspaceRoot } from '@nx/devkit';
+import { dirname } from 'path';
+
+const normalizedAppRoot = workspaceRoot.replace(/\\/g, '/');
 
 let tsModule: typeof import('typescript');
+
+let compilerHost: {
+  host: ts.CompilerHost;
+  options: ts.CompilerOptions;
+  moduleResolutionCache: ts.ModuleResolutionCache;
+};
+
+/**
+ * Find a module based on its import
+ *
+ * @param importExpr Import used to resolve to a module
+ * @param filePath
+ * @param tsConfigPath
+ */
+export function resolveModuleByImport(
+  importExpr: string,
+  filePath: string,
+  tsConfigPath: string
+) {
+  compilerHost = compilerHost || getCompilerHost(tsConfigPath);
+  const { options, host, moduleResolutionCache } = compilerHost;
+
+  const { resolvedModule } = tsModule.resolveModuleName(
+    importExpr,
+    filePath,
+    options,
+    host,
+    moduleResolutionCache
+  );
+
+  if (!resolvedModule) {
+    return;
+  } else {
+    return resolvedModule.resolvedFileName.replace(`${normalizedAppRoot}/`, '');
+  }
+}
+
+function getCompilerHost(tsConfigPath: string) {
+  const options = readTsConfigOptions(tsConfigPath);
+  const host = tsModule.createCompilerHost(options, true);
+  const moduleResolutionCache = tsModule.createModuleResolutionCache(
+    workspaceRoot,
+    host.getCanonicalFileName
+  );
+  return { options, host, moduleResolutionCache };
+}
+
+function readTsConfigOptions(tsConfigPath: string) {
+  if (!tsModule) {
+    tsModule = require('typescript');
+  }
+
+  const readResult = tsModule.readConfigFile(
+    tsConfigPath,
+    tsModule.sys.readFile
+  );
+
+  // we don't need to scan the files, we only care about options
+  const host: Partial<ts.ParseConfigHost> = {
+    readDirectory: () => [],
+    readFile: () => '',
+    fileExists: tsModule.sys.fileExists,
+  };
+
+  return tsModule.parseJsonConfigFileContent(
+    readResult.config,
+    host as ts.ParseConfigHost,
+    dirname(tsConfigPath)
+  ).options;
+}
 
 function nodesByPosition(first: ts.Node, second: ts.Node): number {
   return first.getStart() - second.getStart();
@@ -344,4 +417,39 @@ export function findClass(
   }
 
   return clazz;
+}
+
+export function findNodes(
+  node: Node,
+  kind: SyntaxKind | SyntaxKind[],
+  max = Infinity
+): Node[] {
+  if (!node || max == 0) {
+    return [];
+  }
+
+  const arr: Node[] = [];
+  const hasMatch = Array.isArray(kind)
+    ? kind.includes(node.kind)
+    : node.kind === kind;
+  if (hasMatch) {
+    arr.push(node);
+    max--;
+  }
+  if (max > 0) {
+    for (const child of node.getChildren()) {
+      findNodes(child, kind, max).forEach((node) => {
+        if (max > 0) {
+          arr.push(node);
+        }
+        max--;
+      });
+
+      if (max <= 0) {
+        break;
+      }
+    }
+  }
+
+  return arr;
 }

--- a/packages/js/src/utils/typescript/ts-config.ts
+++ b/packages/js/src/utils/typescript/ts-config.ts
@@ -1,10 +1,4 @@
-import {
-  joinPathFragments,
-  offsetFromRoot,
-  Tree,
-  updateJson,
-  workspaceRoot,
-} from '@nx/devkit';
+import { offsetFromRoot, Tree, updateJson, workspaceRoot } from '@nx/devkit';
 import { existsSync } from 'fs';
 import { dirname, join } from 'path';
 
@@ -40,6 +34,12 @@ export function getRelativePathToRootTsConfig(
   targetPath: string
 ): string {
   return offsetFromRoot(targetPath) + getRootTsConfigPathInTree(tree);
+}
+
+export function getRootTsConfigPath(): string | null {
+  const tsConfigFileName = getRootTsConfigFileName();
+
+  return tsConfigFileName ? join(workspaceRoot, tsConfigFileName) : null;
 }
 
 export function getRootTsConfigFileName(tree?: Tree): string | null {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

There are dependencies to `nx/src/plugins/js/utils/typescript`. This is not available on earlier versions of `nx`. This makes it difficult to add `@nx/react` for earlier versions of Nx which plugins might do.

The following does not work:
```
create-nx-workspace@15.9.3 --preset apps
npm i @nx/react@latest
nx g app app1
~/p/t/empty-repo2 (main|✚2) $ nx g @nx/react:app app1

>  NX  Generating @nx/react:application

✔ Which stylesheet format would you like to use? · css
✔ Would you like to add React Router to this application? (y/N) · false
✔ Which bundler do you want to use to build the application? · vite

 >  NX   Cannot find module 'nx/src/plugins/js/utils/typescript'

   Require stack:
   - /home/jason/projects/triage/empty-repo2/node_modules/.pnpm/@nx+devkit@16.0.0_nx@15.9.3/node_modules/@nx/devkit/src/utils/module-federation/typescript.js
   - /home/jason/projects/triage/empty-repo2/node_modules/.pnpm/@nx+devkit@16.0.0_nx@15.9.3/node_modules/@nx/devkit/src/utils/module-federation/share.js
   - /home/jason/projects/triage/empty-repo2/node_modules/.pnpm/@nx+devkit@16.0.0_nx@15.9.3/node_modules/@nx/devkit/src/utils/module-federation/public-api.js
   - /home/jason/projects/triage/empty-repo2/node_modules/.pnpm/@nx+devkit@16.0.0_nx@15.9.3/node_modules/@nx/devkit/public-api.js
   - /home/jason/projects/triage/empty-repo2/node_modules/.pnpm/@nx+devkit@16.0.0_nx@15.9.3/node_modules/@nx/devkit/index.js
   - /home/jason/projects/triage/empty-repo2/node_modules/.pnpm/@nx+react@16.0.0_nx@15.9.3_typescript@5.0.4_webpack@5.81.0/node_modules/@nx/react/src/utils/lint.js
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

There are no dependencies to `nx/src/plugins/js/utils/typescript`.

The following should work:
```
create-nx-workspace@15.9.3 --preset apps
npm i @nx/react@latest
nx g app app1
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204497133892929