### PR TITLE
fix(angular): do not run migration generator bumping angular cli version when update is skipped

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -150,6 +150,9 @@
     "update-angular-cli-version-15-2-0": {
       "cli": "nx",
       "version": "15.8.0-beta.4",
+      "requires": {
+        "@angular/core": ">=15.2.0"
+      },
       "description": "Update the @angular/cli package version to ~15.2.0.",
       "factory": "./src/migrations/update-15-8-0/update-angular-cli"
     },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When migrating in interactive mode and opting out of the Angular 15.2 update, a migration is wrongly added to bump the Angular CLI to 15.2.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When migrating in interactive mode and opting out of the Angular 15.2 update, no migration related to Angular 15.2 should be generated.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
