### PR TITLE
fix(core): empty exclude pattern should not result in error

### DIFF
--- a/packages/nx/src/utils/find-matching-projects.spec.ts
+++ b/packages/nx/src/utils/find-matching-projects.spec.ts
@@ -54,6 +54,18 @@ describe('findMatchingProjects', () => {
     },
   };
 
+  it('should return no projects when passed no patterns', () => {
+    expect(findMatchingProjects([], projectGraph)).toEqual([]);
+  });
+
+  it('should return no projects when passed empty string', () => {
+    expect(findMatchingProjects([''], projectGraph)).toEqual([]);
+  });
+
+  it('should not throw when a pattern is empty string', () => {
+    expect(findMatchingProjects(['', 'a'], projectGraph)).toEqual(['a']);
+  });
+
   it('should expand "*"', () => {
     expect(findMatchingProjects(['*'], projectGraph)).toEqual([
       'test-project',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
v16 changes cause `nx affected --exclude` to throw when not passing anything after `--exclude`

## Expected Behavior
`nx affected --exclude` excludes nothing and works as normal

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
