### PR TITLE
fix(core): nx report should not display duplicate packages

### DIFF
--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -122,7 +122,7 @@
       "@nrwl/next",
       "@nx/node",
       "@nrwl/node",
-      "@nx/nx-plugin",
+      "@nx/plugin",
       "@nrwl/nx-plugin",
       "@nx/react",
       "@nrwl/react",
@@ -140,11 +140,11 @@
       "@nx/webpack",
       "@nrwl/webpack",
       {
-        "package": "@nrwl/nx-cloud",
+        "package": "nx-cloud",
         "version": "latest"
       },
       {
-        "package": "nx-cloud",
+        "package": "@nrwl/nx-cloud",
         "version": "latest"
       }
     ]

--- a/packages/nx/src/command-line/report.spec.ts
+++ b/packages/nx/src/command-line/report.spec.ts
@@ -197,13 +197,15 @@ describe('report', () => {
   describe('findInstalledPackagesWeCareAbout', () => {
     it('should not list packages that are not installed', () => {
       const installed: [string, packageJsonUtils.PackageJson][] =
-        packagesWeCareAbout.map((x) => [
-          x,
-          {
-            name: x,
-            version: '1.0.0',
-          },
-        ]);
+        packagesWeCareAbout
+          .filter((x) => !x.startsWith('@nrwl'))
+          .map((x) => [
+            x,
+            {
+              name: x,
+              version: '1.0.0',
+            },
+          ]);
       const uninstalled: [string, packageJsonUtils.PackageJson][] = [
         installed.pop(),
         installed.pop(),
@@ -224,6 +226,33 @@ describe('report', () => {
       for (const [pkg] of installed) {
         expect(result).toContain(pkg);
       }
+    });
+
+    it('should not list @nrwl packages that are the same version as their equivalent @nx package', () => {
+      jest.spyOn(packageJsonUtils, 'readModulePackageJson').mockImplementation(
+        provideMockPackages({
+          '@nrwl/nx-plugin': { version: '16.0.0' },
+          '@nx/plugin': { version: '16.0.0' },
+          '@nrwl/linter': { version: '16.0.0' },
+          '@nx/linter': { version: '16.0.0' },
+          '@nrwl/workspace': { version: '16.0.0' },
+          '@nx/workspace': { version: '16.0.2' },
+          '@nrwl/tao': { version: '16.0.0' },
+          '@nrwl/nx-cloud': { version: '16.0.0' },
+          'nx-cloud': { version: '16.0.0' },
+        })
+      );
+
+      const result = findInstalledPackagesWeCareAbout().map((x) => x.package);
+      expect(result).not.toContain('@nrwl/nx-plugin');
+      expect(result).toContain('@nx/plugin');
+      expect(result).not.toContain('@nrwl/linter');
+      expect(result).toContain('@nx/linter');
+      expect(result).toContain('@nrwl/workspace');
+      expect(result).toContain('@nx/workspace');
+      expect(result).toContain('@nrwl/tao');
+      expect(result).toContain('nx-cloud');
+      expect(result).not.toContain('@nrwl/nx-cloud');
     });
   });
 

--- a/packages/nx/src/command-line/report.ts
+++ b/packages/nx/src/command-line/report.ts
@@ -275,11 +275,46 @@ export function findInstalledCommunityPlugins(): PackageJson[] {
   );
 }
 export function findInstalledPackagesWeCareAbout() {
-  return packagesWeCareAbout.reduce((acc, next) => {
-    const v = readPackageVersion(next);
+  const packagesWeMayCareAbout: Record<string, string> = {};
+  // TODO (v17): Remove workaround for hiding @nrwl packages when matching @nx package is found.
+  const packageChangeMap: Record<string, string> = {
+    '@nrwl/nx-plugin': '@nx/plugin',
+    '@nx/plugin': '@nrwl/nx-plugin',
+    '@nrwl/eslint-plugin-nx': '@nx/eslint-plugin',
+    '@nx/eslint-plugin': '@nrwl/eslint-plugin-nx',
+    '@nrwl/nx-cloud': 'nx-cloud',
+  };
+
+  for (const pkg of packagesWeCareAbout) {
+    const v = readPackageVersion(pkg);
     if (v) {
-      acc.push({ package: next, version: v });
+      // If its a @nrwl scoped package, keep the version if there is no
+      // corresponding @nx scoped package, or it has a different version.
+      if (pkg.startsWith('@nrwl/')) {
+        const otherPackage =
+          packageChangeMap[pkg] ?? pkg.replace('@nrwl/', '@nx/');
+        const otherVersion = packagesWeMayCareAbout[otherPackage];
+        if (!otherVersion || v !== otherVersion) {
+          packagesWeMayCareAbout[pkg] = v;
+        }
+        // If its a @nx scoped package, always keep the version, and
+        // remove the corresponding @nrwl scoped package if it exists.
+      } else if (pkg.startsWith('@nx/')) {
+        const otherPackage =
+          packageChangeMap[pkg] ?? pkg.replace('@nx/', '@nrwl/');
+        const otherVersion = packagesWeMayCareAbout[otherPackage];
+        if (otherVersion && v === otherVersion) {
+          delete packagesWeMayCareAbout[otherPackage];
+        }
+        packagesWeMayCareAbout[pkg] = v;
+      } else {
+        packagesWeMayCareAbout[pkg] = v;
+      }
     }
-    return acc;
-  }, [] as { package: string; version: string }[]);
+  }
+
+  return Object.entries(packagesWeMayCareAbout).map(([pkg, version]) => ({
+    package: pkg,
+    version,
+  }));
 }


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`nx report` is currently displaying @nrwl/* and @nx/* both. 

## Expected Behavior
It should only display both version of the package if they are different.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
