### PR TITLE
fix(core): have child process exit properly in case of error

### DIFF
--- a/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
@@ -282,6 +282,27 @@ describe('Run Commands', () => {
       expect(normalize(readFile(f))).toBe(childFolder);
     });
 
+    it('should terminate properly with an error if the cwd is not valid', async () => {
+      const root = dirSync().name;
+      const cwd = 'bla';
+
+      const result = await runCommands(
+        {
+          commands: [
+            {
+              command: `echo "command does not run"`,
+            },
+          ],
+          cwd,
+          parallel: true,
+          __unparsed__: [],
+        },
+        { root } as any
+      );
+
+      expect(result).toEqual(expect.objectContaining({ success: false }));
+    }, 1000);
+
     it('should run the task in the specified absolute cwd', async () => {
       const root = dirSync().name;
       const childFolder = dirSync({ dir: root }).name;

--- a/packages/nx/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.ts
@@ -233,6 +233,10 @@ function createProcess(
         res(true);
       }
     });
+    childProcess.on('error', (err) => {
+      process.stderr.write(addColorAndPrefix(err.toString(), commandConfig));
+      res(false);
+    });
     childProcess.on('exit', (code) => {
       if (!readyWhen) {
         res(code === 0);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

if you pass an invalid path to `cwd` the promise never resolves, therefore the process just keeps waiting. This fixes it.
If we want to we could even provide a more user-friendly message saying the CWD doesn't exist by checking `cwd` passed by the user before invoking the process.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
