### PR TITLE
fix(node): build-esbuild-options.ts code-generated "exactMatch" prope…

### DIFF
--- a/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/build-esbuild-options.ts
@@ -226,7 +226,7 @@ export function getRegisterFileContent(
       // Path specifies a single entry point e.g. "a/b/src/index.ts".
       // This is the default setup.
       const { dir, name } = path.parse(pattern);
-      exactMatch = path.join(dir, `${name}${outExtension}`);
+      exactMatch = joinPathFragments(dir, `${name}${outExtension}`);
     }
     acc.push({ module: k, exactMatch, pattern });
     return acc;


### PR DESCRIPTION
…rty: replace path.join() with hardcoded /

This fixes the issue described in: https://github.com/nrwl/nx/issues/16633

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Entry main.js files generated on a Windows machine were using path.join(), which would use backslashes, and does not work when running the dist code on Linux.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Hardcoded to `/` - which works on any OS.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16633
