### PR TITLE
fix(react): add `app` directory in the default `tailwind.config.js`

### DIFF
--- a/docs/shared/guides/using-tailwind-css-in-react.md
+++ b/docs/shared/guides/using-tailwind-css-in-react.md
@@ -85,7 +85,7 @@ module.exports = {
   content: [
     join(
       __dirname,
-      '{src,pages,components}/**/*!(*.stories|*.spec).{ts,tsx,html}'
+      '{src,pages,components,app}/**/*!(*.stories|*.spec).{ts,tsx,html}'
     ),
     ...createGlobPatternsForDependencies(__dirname),
   ],

--- a/packages/react/src/generators/setup-tailwind/files/tailwind.config.js__tmpl__
+++ b/packages/react/src/generators/setup-tailwind/files/tailwind.config.js__tmpl__
@@ -6,7 +6,7 @@ module.exports = {
   content: [
     join(
       __dirname,
-      '{src,pages,components}/**/*!(*.stories|*.spec).{ts,tsx,html}'
+      '{src,pages,components,app}/**/*!(*.stories|*.spec).{ts,tsx,html}'
     ),
     ...createGlobPatternsForDependencies(__dirname),
   ],


### PR DESCRIPTION
Accommodate the experimental `app` directory in NextJS 13+

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently, when setting up a TailwindCSS in a React/NextJS project using the `nx g @nx/react:setup-tailwind` command, the default tailwind config only accommodating the following directories: `src`, `pages`, `components`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The default `tailwind.config.js` will include the NextJS `app` directory
