### PR TITLE
feat(nx-plugin): execute target for create package

### DIFF
--- a/packages/plugin/src/generators/create-package/create-package.spec.ts
+++ b/packages/plugin/src/generators/create-package/create-package.spec.ts
@@ -57,6 +57,30 @@ describe('NxPlugin Create Package Generator', () => {
         updateBuildableProjectDepsInPackageJson: false,
       },
     });
+    expect(project.targets.execute).toEqual({
+      dependsOn: [
+        'build',
+        {
+          projects: '@proj/my-plugin',
+          target: 'build',
+        },
+      ],
+      executor: 'nx:run-commands',
+      options: {
+        commands: [
+          {
+            command: 'rm -rf',
+            forwardAllArgs: true,
+          },
+          {
+            command:
+              'NX_E2E_PRESET_VERSION=file:../../dist/@proj/my-plugin ts-node ../dist/libs/create-a-workspace/bin/index.js',
+            forwardAllArgs: true,
+          },
+        ],
+        cwd: 'tmp',
+      },
+    });
   });
 
   it('should place the create-package plugin in a directory', async () => {

--- a/packages/plugin/src/generators/create-package/create-package.spec.ts
+++ b/packages/plugin/src/generators/create-package/create-package.spec.ts
@@ -1,4 +1,5 @@
 import {
+  getProjects,
   joinPathFragments,
   readJson,
   readProjectConfiguration,
@@ -61,7 +62,7 @@ describe('NxPlugin Create Package Generator', () => {
       dependsOn: [
         'build',
         {
-          projects: '@proj/my-plugin',
+          projects: 'my-plugin',
           target: 'build',
         },
       ],
@@ -74,7 +75,7 @@ describe('NxPlugin Create Package Generator', () => {
           },
           {
             command:
-              'NX_E2E_PRESET_VERSION=file:../../dist/@proj/my-plugin ts-node ../dist/libs/create-a-workspace/bin/index.js',
+              'NX_E2E_PRESET_VERSION=file:../../dist/libs/my-plugin ts-node ../dist/libs/create-a-workspace/bin/index.js',
             forwardAllArgs: true,
           },
         ],

--- a/packages/plugin/src/generators/create-package/create-package.ts
+++ b/packages/plugin/src/generators/create-package/create-package.ts
@@ -120,14 +120,17 @@ async function createCliPackage(
   projectConfiguration.targets.build.options.updateBuildableProjectDepsInPackageJson =
     false;
 
-  // const pluginProjectConfiguration = readProjectConfiguration(
-  //   host,
-  //   pluginPackageName
-  // );
+  const pluginPackageProjectName = pluginPackageName.includes('/')
+    ? pluginPackageName.substring(pluginPackageName.indexOf('/') + 1)
+    : pluginPackageName;
+  const pluginProjectConfiguration = readProjectConfiguration(
+    host,
+    pluginPackageProjectName
+  );
   const projectOutputPath =
     projectConfiguration.targets.build.options.outputPath;
-  const pluginOutputPath = `dist/${pluginPackageName}`;
-  // pluginProjectConfiguration.targets.build.options.outputPath;
+  const pluginOutputPath =
+    pluginProjectConfiguration.targets.build.options.outputPath;
   projectConfiguration.targets.execute = {
     executor: 'nx:run-commands',
     options: {
@@ -143,7 +146,10 @@ async function createCliPackage(
         },
       ],
     },
-    dependsOn: ['build', { projects: pluginPackageName, target: 'build' }],
+    dependsOn: [
+      'build',
+      { projects: pluginPackageProjectName, target: 'build' },
+    ],
   };
   projectConfiguration.implicitDependencies = [options.project];
   updateProjectConfiguration(host, options.projectName, projectConfiguration);


### PR DESCRIPTION
Adds an execute target for local testing of the create package.

You can run it with `nx execute create-my-plugin some-name`
