### PR TITLE
feat(misc): list should link to nx.dev/community for more plugins

### DIFF
--- a/packages/nx/src/command-line/list.ts
+++ b/packages/nx/src/command-line/list.ts
@@ -1,10 +1,8 @@
 import { workspaceRoot } from '../utils/workspace-root';
 import { output } from '../utils/output';
 import {
-  fetchCommunityPlugins,
   fetchCorePlugins,
   getInstalledPluginsAndCapabilities,
-  listCommunityPlugins,
   listCorePlugins,
   listInstalledPlugins,
   listPluginCapabilities,
@@ -36,14 +34,6 @@ export async function listHandler(args: ListArgs): Promise<void> {
     await listPluginCapabilities(args.plugin);
   } else {
     const corePlugins = fetchCorePlugins();
-    const communityPlugins = await fetchCommunityPlugins().catch(() => {
-      output.warn({
-        title: `Community plugins:`,
-        bodyLines: [`Error fetching plugins.`],
-      });
-
-      return [];
-    });
     const projectGraph = await createProjectGraphAsync({ exitOnError: true });
 
     const localPlugins = await getLocalWorkspacePlugins(
@@ -58,7 +48,15 @@ export async function listHandler(args: ListArgs): Promise<void> {
     }
     listInstalledPlugins(installedPlugins);
     listCorePlugins(installedPlugins, corePlugins);
-    listCommunityPlugins(installedPlugins, communityPlugins);
+
+    output.note({
+      title: 'Community Plugins',
+      bodyLines: [
+        'Looking for a technology / framework not listed above?',
+        'There are many excellent plugins matintained by the Nx community.',
+        'Search for the one you need here: https://nx.dev/community.',
+      ],
+    });
 
     output.note({
       title: `Use "nx list [plugin]" to find out more`,

--- a/packages/nx/src/utils/plugins/community-plugins.ts
+++ b/packages/nx/src/utils/plugins/community-plugins.ts
@@ -1,7 +1,5 @@
 import { get } from 'https';
-import * as chalk from 'chalk';
-import { output } from '../output';
-import type { CommunityPlugin, PluginCapabilities } from './models';
+import type { CommunityPlugin } from './models';
 
 const COMMUNITY_PLUGINS_JSON_URL =
   'https://raw.githubusercontent.com/nrwl/nx/master/community/approved-plugins.json';
@@ -28,23 +26,5 @@ export async function fetchCommunityPlugins(): Promise<CommunityPlugin[]> {
 
     req.on('error', reject);
     req.end();
-  });
-}
-
-export function listCommunityPlugins(
-  installedPlugins: Map<string, PluginCapabilities>,
-  communityPlugins?: CommunityPlugin[]
-): void {
-  if (!communityPlugins) return;
-
-  const availableCommunityPlugins = communityPlugins.filter(
-    (p) => !installedPlugins.has(p.name)
-  );
-
-  output.log({
-    title: `Community plugins:`,
-    bodyLines: availableCommunityPlugins.map((p) => {
-      return `${chalk.bold(p.name)} - ${p.description}`;
-    }),
   });
 }

--- a/packages/nx/src/utils/plugins/index.ts
+++ b/packages/nx/src/utils/plugins/index.ts
@@ -1,7 +1,4 @@
-export {
-  fetchCommunityPlugins,
-  listCommunityPlugins,
-} from './community-plugins';
+export { fetchCommunityPlugins } from './community-plugins';
 export { fetchCorePlugins, listCorePlugins } from './core-plugins';
 export {
   getInstalledPluginsAndCapabilities,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We list **_all_** community plugins in the `nx list` command directly. This list is getting really long which is a good thing, but as such is no longer suitable to display in its entirety

## Expected Behavior
To avoid bias, we can't really display a subsection of the community list in its current form. We don't collect data such as github stars, npm downloads or similar currently, and that would be a bit of a rabbit hole anyways.

Instead, we display a message and link to nx.dev/community:
![image](https://user-images.githubusercontent.com/6933928/235477358-bcb7473c-70a8-495a-9de5-62709c398da7.png)


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
