### PR TITLE
feat(core): support specific project dependency in dependsOn with string syntax

### DIFF
--- a/packages/nx/src/tasks-runner/utils.spec.ts
+++ b/packages/nx/src/tasks-runner/utils.spec.ts
@@ -1,4 +1,5 @@
 import {
+  expandDependencyConfigSyntaxSugar,
   getOutputsForTargetAndConfiguration,
   transformLegacyOutputs,
   validateOutputs,
@@ -396,5 +397,58 @@ describe('utils', () => {
       const result = transformLegacyOutputs('myapp', e);
       expect(result).toEqual(['{projectRoot}/dist']);
     }
+  });
+
+  describe('expandDependencyConfigSyntaxSugar', () => {
+    it('should expand syntax for simple target names', () => {
+      const result = expandDependencyConfigSyntaxSugar('build', {
+        dependencies: {},
+        nodes: {},
+      });
+      expect(result).toEqual({
+        target: 'build',
+      });
+    });
+
+    it('should expand syntax for simple target names targetting dependencies', () => {
+      const result = expandDependencyConfigSyntaxSugar('^build', {
+        dependencies: {},
+        nodes: {},
+      });
+      expect(result).toEqual({
+        target: 'build',
+        dependencies: true,
+      });
+    });
+
+    it('should expand syntax for strings like project:target if project is a valid project', () => {
+      const result = expandDependencyConfigSyntaxSugar('project:build', {
+        dependencies: {},
+        nodes: {
+          project: {
+            name: 'project',
+            type: 'app',
+            data: {
+              root: 'libs/project',
+              files: [],
+            },
+          },
+        },
+      });
+      expect(result).toEqual({
+        target: 'build',
+        projects: ['project'],
+      });
+    });
+
+    it('should expand syntax for strings like target:with:colons', () => {
+      const result = expandDependencyConfigSyntaxSugar('target:with:colons', {
+        dependencies: {},
+        nodes: {},
+      });
+      expect(result).toEqual({
+        target: 'target:with:colons',
+      });
+    });
   });
 });

--- a/packages/nx/src/utils/split-target.ts
+++ b/packages/nx/src/utils/split-target.ts
@@ -37,7 +37,7 @@ function groupJointSegments(segments: string[], validTargetNames: Set<string>) {
   return segments;
 }
 
-function splitByColons(s: string) {
+export function splitByColons(s: string) {
   const parts = [] as string[];
   let currentPart = '';
   for (let i = 0; i < s.length; ++i) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We support specific projects only when using the expanded object syntax 

Example:

```jsonc
{
  "dependsOn": [
    {
      "my-project:build", // doesn't work, trys to run a target called "my-project:build" on the current project
      {
        "target": "build",
        "projects": ["my-project"] // works as intended
      }
    }
  ]
}
```

## Expected Behavior
The `my-project:build` identifier works

## Notes

Will follow up w/ similar for inputs and `my-project:namedInput`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16138
