### PR TITLE
feat(core): support matching projects specifiers in dependsOn

### DIFF
--- a/packages/nx/src/tasks-runner/create-task-graph.spec.ts
+++ b/packages/nx/src/tasks-runner/create-task-graph.spec.ts
@@ -1443,4 +1443,62 @@ describe('createTaskGraph', () => {
       },
     });
   });
+
+  it('should handle glob patterns in dependsOn', () => {
+    const graph: ProjectGraph = {
+      nodes: {
+        app1: {
+          name: 'app1',
+          type: 'app',
+          data: {
+            root: 'app1-root',
+            files: [],
+            targets: {
+              build: {
+                executor: 'nx:run-commands',
+                dependsOn: [{ target: 'build', projects: 'lib*' }],
+              },
+            },
+          },
+        },
+        lib1: {
+          name: 'lib1',
+          type: 'lib',
+          data: {
+            root: 'lib1-root',
+            files: [],
+            targets: {
+              build: {
+                executor: 'nx:run-commands',
+              },
+            },
+          },
+        },
+        lib2: {
+          name: 'lib2',
+          type: 'lib',
+          data: {
+            root: 'lib2-root',
+            files: [],
+            targets: {
+              build: {
+                executor: 'nx:run-commands',
+              },
+            },
+          },
+        },
+      },
+      dependencies: {
+        app1: [],
+      },
+    };
+    const taskGraph = createTaskGraph(graph, {}, ['app1'], ['build'], null, {});
+    expect(taskGraph.tasks).toHaveProperty('app1:build');
+    expect(taskGraph.tasks).toHaveProperty('lib1:build');
+    expect(taskGraph.tasks).toHaveProperty('lib2:build');
+    expect(taskGraph.dependencies['app1:build']).toEqual([
+      'lib1:build',
+      'lib2:build',
+    ]);
+  });
 });

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -32,25 +32,6 @@ export function getDependencyConfigs(
       []
   );
   for (const dependencyConfig of dependencyConfigs) {
-    const specifiers =
-      typeof dependencyConfig.projects === 'string'
-        ? [dependencyConfig.projects]
-        : dependencyConfig.projects;
-    for (const specifier of specifiers ?? []) {
-      if (
-        !(specifier in projectGraph.nodes) &&
-        // Todo(@agentender): Remove the check for self / dependencies in v17
-        !['self', 'dependencies'].includes(specifier)
-      ) {
-        output.error({
-          title: `dependsOn is improperly configured for ${project}:${target}`,
-          bodyLines: [
-            `${specifier} in dependsOn.projects is invalid. It should be "self", "dependencies", or a project name.`,
-          ],
-        });
-        process.exit(1);
-      }
-    }
     if (dependencyConfig.projects && dependencyConfig.dependencies) {
       output.error({
         title: `dependsOn is improperly configured for ${project}:${target}`,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`findMatchingProjects` is used for the `--projects` flag (affected, run-many etc), `--exclude`, and `implicitDependencies`

## Expected Behavior
Anywhere that we allow a field called `projects` supports `findMatchingProjects`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16138
