### PR TITLE
cleanup(misc): add types to getVersion function

### DIFF
--- a/packages/nx/src/plugins/js/package-json/create-package-json.ts
+++ b/packages/nx/src/plugins/js/package-json/create-package-json.ts
@@ -93,8 +93,8 @@ export function createPackageJson(
   }
 
   const getVersion = (
-    packageName,
-    version,
+    packageName: string,
+    version: string,
     section: 'devDependencies' | 'dependencies'
   ) => {
     return (


### PR DESCRIPTION
add types to packageName and version params of getVersion function

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
No types for getVersion

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
getVersion must be typed

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
