### PR TITLE
fix(core): improve touched projects locator performance

### DIFF
--- a/packages/nx/src/project-graph/affected/locators/project-glob-changes.ts
+++ b/packages/nx/src/project-graph/affected/locators/project-glob-changes.ts
@@ -1,9 +1,3 @@
-import {
-  DeletedFileChange,
-  isDeletedFileChange,
-  WholeFileChange,
-} from '../../file-utils';
-import { JsonChange } from '../../../utils/json-diff';
 import { TouchedProjectLocator } from '../affected-project-graph-models';
 import minimatch = require('minimatch');
 import {
@@ -12,40 +6,42 @@ import {
 } from '../../../config/workspaces';
 import { workspaceRoot } from '../../../utils/workspace-root';
 import { getNxRequirePaths } from '../../../utils/installation-directory';
+import { join } from 'path';
+import { existsSync } from 'fs';
 
-export const getTouchedProjectsFromProjectGlobChanges: TouchedProjectLocator<
-  WholeFileChange | JsonChange | DeletedFileChange
-> = async (touchedFiles, projectGraphNodes, nxJson): Promise<string[]> => {
-  const pluginGlobPatterns = await getGlobPatternsFromPluginsAsync(
-    nxJson,
-    getNxRequirePaths(),
-    workspaceRoot
-  );
-  const workspacesGlobPatterns =
-    getGlobPatternsFromPackageManagerWorkspaces(workspaceRoot) || [];
+export const getTouchedProjectsFromProjectGlobChanges: TouchedProjectLocator =
+  async (touchedFiles, projectGraphNodes, nxJson): Promise<string[]> => {
+    const pluginGlobPatterns = await getGlobPatternsFromPluginsAsync(
+      nxJson,
+      getNxRequirePaths(),
+      workspaceRoot
+    );
+    const workspacesGlobPatterns =
+      getGlobPatternsFromPackageManagerWorkspaces(workspaceRoot) || [];
 
-  const patterns = [
-    '**/project.json',
-    ...pluginGlobPatterns,
-    ...workspacesGlobPatterns,
-  ];
-  const combinedGlobPattern =
-    patterns.length === 1 ? '**/project.json' : '{' + patterns.join(',') + '}';
-  const touchedProjects = new Set<string>();
-  for (const touchedFile of touchedFiles) {
-    const isProjectFile = minimatch(touchedFile.file, combinedGlobPattern);
-    if (isProjectFile) {
-      if (
-        touchedFile.getChanges().some((change) => isDeletedFileChange(change))
-      ) {
-        // If any project has been deleted, we must assume all projects were affected
-        return Object.keys(projectGraphNodes);
+    const patterns = [
+      '**/project.json',
+      ...pluginGlobPatterns,
+      ...workspacesGlobPatterns,
+    ];
+    const combinedGlobPattern =
+      patterns.length === 1
+        ? '**/project.json'
+        : '{' + patterns.join(',') + '}';
+    const touchedProjects = new Set<string>();
+    for (const touchedFile of touchedFiles) {
+      const isProjectFile = minimatch(touchedFile.file, combinedGlobPattern);
+      if (isProjectFile) {
+        // If the file no longer exists on disk, then it was deleted
+        if (!existsSync(join(workspaceRoot, touchedFile.file))) {
+          // If any project has been deleted, we must assume all projects were affected
+          return Object.keys(projectGraphNodes);
+        }
+
+        // Modified project config files are under a project's root, and implicitly
+        // mark it as affected. Thus, we don't need to handle it here.
       }
-
-      // Modified project config files are under a project's root, and implicitly
-      // mark it as affected. Thus, we don't need to handle it here.
     }
-  }
 
-  return Array.from(touchedProjects);
-};
+    return Array.from(touchedProjects);
+  };


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Detecting if a project was deleted requires running a git command to get the contents of a .json file which takes a long time.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Detecting if a project was deleted is as simple as checking if the config file is still present on disk.

This brings the time needed to filter affected projects for 22 changed project configs from:
```diff
- filter: 506.884ms
+ filter: 111.389ms
```

These numbers are from the nx repo on my machine.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
