### PR TITLE
docs(angular): update nx and angular version compatibility matrix with angular 16

### DIFF
--- a/docs/generated/packages/angular/documents/angular-nx-version-matrix.md
+++ b/docs/generated/packages/angular/documents/angular-nx-version-matrix.md
@@ -1,6 +1,6 @@
 # Nx and Angular Versions
 
-The latest version of Nx supports the last two major versions of Angular (current and previous). Workspaces in any of those versions are recommended to use the latest version of Nx to benefit from all the new features and fixes.
+The latest version of Nx supports the [actively supported versions of Angular (current and LTS versions)](https://angular.io/guide/releases#actively-supported-versions). Workspaces in any of those versions are recommended to use the latest version of Nx to benefit from all the new features and fixes.
 
 {% callout type="note" title="Older Nx and Angular versions" %}
 The support for multiple versions of Angular in the latest version of Nx was added in **v15.7.0** and started by supporting Angular v14 and v15. If your workspace is in an older version of Angular or you can't update to the latest version of Nx for some reason, please have a look at the next section to know which version of Nx to use.
@@ -14,6 +14,8 @@ We provide a recommended version, and it is usually the latest minor version of 
 
 | Angular Version | **Nx Version _(recommended)_** | Nx Version _(range)_                    |
 | --------------- | ------------------------------ | --------------------------------------- |
+| ~16.0.0         | **latest**                     | 16.1.0 <= latest                        |
+| ~15.2.0         | **latest**                     | 15.8.0 <= latest                        |
 | ~15.1.0         | **latest**                     | 15.5.0 <= latest                        |
 | ~15.0.0         | **latest**                     | 15.2.0 <= 15.4.8 \|\| 15.7.0 <= latest  |
 | ~14.2.0         | **latest**                     | 14.6.0 <= 15.1.1 \|\| 15.7.0 <= latest  |
@@ -26,4 +28,4 @@ We provide a recommended version, and it is usually the latest minor version of 
 | ^9.0.0          | **9.6.0**                      | 8.12.4 <= 9.6.0                         |
 | ^8.0.0          | **8.12.2**                     | 8.7.0 <= 8.12.2                         |
 
-If you would like to see how the supported versions of Node and Typescript for the version of Angular you are using, [Lars Gyrup Brink Nielsen](https://twitter.com/LayZeeDK) has a very good resource for that [here](https://gist.github.com/LayZeeDK/c822cc812f75bb07b7c55d07ba2719b3).
+Additionally, you can check the supported versions of Node and Typescript for the version of Angular you are using in the [Angular docs](https://angular.io/guide/versions#actively-supported-versions).

--- a/docs/shared/packages/angular/angular-nx-version-matrix.md
+++ b/docs/shared/packages/angular/angular-nx-version-matrix.md
@@ -1,6 +1,6 @@
 # Nx and Angular Versions
 
-The latest version of Nx supports the last two major versions of Angular (current and previous). Workspaces in any of those versions are recommended to use the latest version of Nx to benefit from all the new features and fixes.
+The latest version of Nx supports the [actively supported versions of Angular (current and LTS versions)](https://angular.io/guide/releases#actively-supported-versions). Workspaces in any of those versions are recommended to use the latest version of Nx to benefit from all the new features and fixes.
 
 {% callout type="note" title="Older Nx and Angular versions" %}
 The support for multiple versions of Angular in the latest version of Nx was added in **v15.7.0** and started by supporting Angular v14 and v15. If your workspace is in an older version of Angular or you can't update to the latest version of Nx for some reason, please have a look at the next section to know which version of Nx to use.
@@ -14,6 +14,8 @@ We provide a recommended version, and it is usually the latest minor version of 
 
 | Angular Version | **Nx Version _(recommended)_** | Nx Version _(range)_                    |
 | --------------- | ------------------------------ | --------------------------------------- |
+| ~16.0.0         | **latest**                     | 16.1.0 <= latest                        |
+| ~15.2.0         | **latest**                     | 15.8.0 <= latest                        |
 | ~15.1.0         | **latest**                     | 15.5.0 <= latest                        |
 | ~15.0.0         | **latest**                     | 15.2.0 <= 15.4.8 \|\| 15.7.0 <= latest  |
 | ~14.2.0         | **latest**                     | 14.6.0 <= 15.1.1 \|\| 15.7.0 <= latest  |
@@ -26,4 +28,4 @@ We provide a recommended version, and it is usually the latest minor version of 
 | ^9.0.0          | **9.6.0**                      | 8.12.4 <= 9.6.0                         |
 | ^8.0.0          | **8.12.2**                     | 8.7.0 <= 8.12.2                         |
 
-If you would like to see how the supported versions of Node and Typescript for the version of Angular you are using, [Lars Gyrup Brink Nielsen](https://twitter.com/LayZeeDK) has a very good resource for that [here](https://gist.github.com/LayZeeDK/c822cc812f75bb07b7c55d07ba2719b3).
+Additionally, you can check the supported versions of Node and Typescript for the version of Angular you are using in the [Angular docs](https://angular.io/guide/versions#actively-supported-versions).


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The Nx and Angular Version Compatibility Matrix docs don't have an entry for Angular v16 (it's also missing `~15.2.0`).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The Nx and Angular Version Compatibility Matrix docs have an entry for Angular v16.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
