### PR TITLE
fix(expo): expo generator on windows

### DIFF
--- a/packages/expo/src/generators/application/lib/normalize-options.ts
+++ b/packages/expo/src/generators/application/lib/normalize-options.ts
@@ -1,5 +1,4 @@
-import { getWorkspaceLayout, names, Tree } from '@nx/devkit';
-import { join } from 'path';
+import { getWorkspaceLayout, joinPathFragments, names, Tree } from '@nx/devkit';
 import { Schema } from '../schema';
 
 export interface NormalizedSchema extends Schema {
@@ -26,7 +25,7 @@ export function normalizeOptions(
 
   const appProjectName = projectDirectory.replace(new RegExp('/', 'g'), '-');
 
-  const appProjectRoot = join(appsDir, projectDirectory);
+  const appProjectRoot = joinPathFragments(appsDir, projectDirectory);
 
   const parsedTags = options.tags
     ? options.tags.split(',').map((s) => s.trim())


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Running `npx create-nx-workspace --preset=expo` or `nx g @nx/expo:app my-app` on Windows (Node 16) now breaks with the error 'Unexpected token <some char> in JSON at position <some position>`

The reason is that normalize-options for expo uses node's `path.join`, as opposed to most of the other generators that use `@nx/devkit`.

The following Node script:

```
const devkit = require('@nx/devkit')
const path = require('path')

console.log('DEVKIT', devkit.joinPathFragments('apps','my-app'))
console.log('PATH', path.join('apps','my-app'))
```

will output:

```
DEVKIT apps/my-app
PATH apps\my-app
```

The backslash is breaking the `package.json` and causing `JSON.parse` to throw the error. 

## Expected Behavior

The expo generator should work :)

## Related Issue(s)

Fixes #

The fix is to use `devkit.joinPathFragments` instead of `path.join`
