### PR TITLE
fix(core): task runner parallel should read from taskRunnerOptions

### DIFF
--- a/packages/nx/src/tasks-runner/default-tasks-runner.ts
+++ b/packages/nx/src/tasks-runner/default-tasks-runner.ts
@@ -50,7 +50,8 @@ export const defaultTasksRunner: TasksRunner<
   } else if (
     (options as any)['parallel'] === 'true' ||
     (options as any)['parallel'] === true ||
-    (options as any)['parallel'] === undefined
+    (options as any)['parallel'] === undefined ||
+    (options as any)['parallel'] === ''
   ) {
     (options as any)['parallel'] = Number((options as any)['maxParallel'] || 3);
   }

--- a/packages/nx/src/utils/command-line-utils.spec.ts
+++ b/packages/nx/src/utils/command-line-utils.spec.ts
@@ -20,7 +20,6 @@ describe('splitArgs', () => {
       base: 'sha1',
       head: 'sha2',
       skipNxCache: false,
-      parallel: 3,
     });
   });
 
@@ -52,7 +51,6 @@ describe('splitArgs', () => {
     ).toEqual({
       base: 'main',
       skipNxCache: false,
-      parallel: 3,
     });
   });
 
@@ -70,7 +68,6 @@ describe('splitArgs', () => {
     ).toEqual({
       base: 'develop',
       skipNxCache: false,
-      parallel: 3,
     });
   });
 
@@ -88,7 +85,6 @@ describe('splitArgs', () => {
     ).toEqual({
       base: 'main',
       skipNxCache: false,
-      parallel: 3,
     });
   });
 
@@ -178,7 +174,6 @@ describe('splitArgs', () => {
         {} as any
       ).nxArgs
     ).toEqual({
-      parallel: 3,
       projects: ['aaa', 'bbb'],
       skipNxCache: false,
     });
@@ -205,7 +200,6 @@ describe('splitArgs', () => {
           base: 'envVarSha1',
           head: 'envVarSha2',
           skipNxCache: false,
-          parallel: 3,
         });
 
         expect(
@@ -223,7 +217,6 @@ describe('splitArgs', () => {
           base: 'envVarSha1',
           head: 'directlyOnCommandSha1',
           skipNxCache: false,
-          parallel: 3,
         });
 
         expect(
@@ -241,7 +234,6 @@ describe('splitArgs', () => {
           base: 'directlyOnCommandSha2',
           head: 'envVarSha2',
           skipNxCache: false,
-          parallel: 3,
         });
       }
     );
@@ -386,20 +378,6 @@ describe('splitArgs', () => {
       ).nxArgs.parallel;
 
       expect(parallel).toEqual(5);
-    });
-
-    it('should default to 3 when not specified', () => {
-      const parallel = splitArgsIntoNxArgsAndOverrides(
-        {
-          $0: '',
-          __overrides_unparsed__: [],
-        },
-        'affected',
-        {} as any,
-        {} as any
-      ).nxArgs.parallel;
-
-      expect(parallel).toEqual(3);
     });
 
     it('should default to 3 when used with no value specified', () => {

--- a/packages/nx/src/utils/command-line-utils.ts
+++ b/packages/nx/src/utils/command-line-utils.ts
@@ -188,8 +188,7 @@ export function splitArgsIntoNxArgsAndOverrides(
   } else if (
     args['parallel'] === 'true' ||
     args['parallel'] === true ||
-    args['parallel'] === '' ||
-    args['parallel'] === undefined
+    args['parallel'] === ''
   ) {
     nxArgs['parallel'] = Number(
       nxArgs['maxParallel'] || nxArgs['max-parallel'] || 3


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Any parallel flag from `nx.json` task runner options is overridden by the default value set in splitNxArgs.

## Expected Behavior
The default of 3 is handled by the default task runner options, so its only set to the default of 3 when `--parallel` is not passed **_AND_** it is not set in task runner options

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
