### PR TITLE
fix(misc): strip version from preset when generating the preset

### DIFF
--- a/packages/create-nx-workspace/src/create-preset.ts
+++ b/packages/create-nx-workspace/src/create-preset.ts
@@ -44,7 +44,17 @@ export async function createPreset<T extends CreateWorkspaceOptions>(
   ) {
     args = '--quiet ' + args;
   }
-  const command = `g ${preset}:preset ${args}`;
+
+  // Index of last @ sign in `preset`. If it is 0 or -1, then there is no version.
+  const lastAt = preset.lastIndexOf('@');
+
+  let collection =
+    lastAt === 0 || lastAt === -1
+      ? // preset does not contain a version
+        preset
+      : // preset contains a version, so we need to remove it
+        preset.slice(0, lastAt);
+  const command = `g ${collection}:preset ${args}`;
 
   try {
     const [exec, ...args] = pmc.exec.split(' ');


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When calling preset generators we take the entirety of the preset name as the collection name

## Expected Behavior
We strip any version specifier from the preset name first.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
