### PR TITLE
fix(devkit): use the old package dependency version for new package

### DIFF
--- a/packages/devkit/src/utils/replace-package.ts
+++ b/packages/devkit/src/utils/replace-package.ts
@@ -1,7 +1,6 @@
 import type { Tree } from 'nx/src/generators/tree';
 import type { PackageJson } from 'nx/src/utils/package-json';
 import { requireNx } from '../../nx';
-import { NX_VERSION } from './package-json';
 import { visitNotIgnoredFiles } from '../generators/visit-not-ignored-files';
 import { basename } from 'path';
 import { isBinaryPath } from './binary-extensions';
@@ -46,7 +45,7 @@ function replacePackageInDependencies(
         packageJson.optionalDependencies ?? {},
       ]) {
         if (oldPackageName in deps) {
-          deps[newPackageName] = NX_VERSION;
+          deps[newPackageName] = deps[oldPackageName];
           delete deps[oldPackageName];
         }
       }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Anytime, the `replaceNrwlPackageWithNxPackage` is used, it will use the Nx version.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Anytime, the `replaceNrwlPackageWithNxPackage` is used, it will use the same version that the old dependency was set to.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
