### PR TITLE
feat(core): add skipTypeCheck option to rollup plugin options

### DIFF
--- a/docs/generated/packages/rollup/executors/rollup.json
+++ b/docs/generated/packages/rollup/executors/rollup.json
@@ -159,6 +159,11 @@
         "type": "boolean",
         "description": "Generate package.json with 'exports' field. This field defines entry points in the package and is used by Node and the TypeScript compiler.",
         "default": false
+      },
+      "skipTypeCheck": {
+        "type": "boolean",
+        "description": "Whether to skip TypeScript type checking.",
+        "default": false
       }
     },
     "required": ["tsConfig", "main", "outputPath"],

--- a/packages/rollup/src/executors/rollup/lib/normalize.ts
+++ b/packages/rollup/src/executors/rollup/lib/normalize.ts
@@ -44,6 +44,7 @@ export function normalizeRollupExecutorOptions(
     project,
     projectRoot,
     outputPath,
+    skipTypeCheck: options.skipTypeCheck || false,
   };
 }
 

--- a/packages/rollup/src/executors/rollup/rollup.impl.ts
+++ b/packages/rollup/src/executors/rollup/rollup.impl.ts
@@ -214,7 +214,7 @@ export function createRollupOptions(
       json(),
       (useTsc || useBabel) &&
         require('rollup-plugin-typescript2')({
-          check: true,
+          check: !options.skipTypeCheck,
           tsconfig: options.tsConfig,
           tsconfigOverride: {
             compilerOptions: createTsCompilerOptions(

--- a/packages/rollup/src/executors/rollup/schema.d.ts
+++ b/packages/rollup/src/executors/rollup/schema.d.ts
@@ -31,4 +31,5 @@ export interface RollupExecutorOptions {
   compiler?: 'babel' | 'tsc' | 'swc';
   javascriptEnabled?: boolean;
   generateExportsField?: boolean;
+  skipTypeCheck?: boolean;
 }

--- a/packages/rollup/src/executors/rollup/schema.json
+++ b/packages/rollup/src/executors/rollup/schema.json
@@ -146,6 +146,11 @@
       "type": "boolean",
       "description": "Generate package.json with 'exports' field. This field defines entry points in the package and is used by Node and the TypeScript compiler.",
       "default": false
+    },
+    "skipTypeCheck": {
+      "type": "boolean",
+      "description": "Whether to skip TypeScript type checking.",
+      "default": false
     }
   },
   "required": ["tsConfig", "main", "outputPath"],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Can't disable the rollup typescript plugin type checker

## Expected Behavior
Allow users to disable it if needed

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
