### PR TITLE
fix(bundling): handle projects without targets in esbuild thirdParty migration

### DIFF
--- a/packages/esbuild/src/migrations/update-16-0-1-set-thirdparty-true/update-16-0-1-set-thirdparty-true.spec.ts
+++ b/packages/esbuild/src/migrations/update-16-0-1-set-thirdparty-true/update-16-0-1-set-thirdparty-true.spec.ts
@@ -14,6 +14,17 @@ describe('update-16-0-1-set-thirdparty-true', () => {
     tree = createTreeWithEmptyWorkspace();
   });
 
+  it('should skip migration targets are not set on the project', async () => {
+    addProjectConfiguration(tree, 'myapp', {
+      root: 'myapp',
+    });
+    await update(tree);
+
+    const config = readProjectConfiguration(tree, 'myapp');
+
+    expect(config.targets).toBeUndefined();
+  });
+
   it('should add thirdParty property if bundling is enabled implicitly', async () => {
     addProjectConfiguration(tree, 'myapp', {
       root: 'myapp',
@@ -31,6 +42,7 @@ describe('update-16-0-1-set-thirdparty-true', () => {
       thirdParty: true,
     });
   });
+
   it('should add thirdParty property if bundling is enabled explicitly', async () => {
     addProjectConfiguration(tree, 'myapp', {
       root: 'myapp',
@@ -52,6 +64,7 @@ describe('update-16-0-1-set-thirdparty-true', () => {
       thirdParty: true,
     });
   });
+
   it('should not add thirdParty property if bundling is disabled', async () => {
     addProjectConfiguration(tree, 'myapp', {
       root: 'myapp',
@@ -72,6 +85,7 @@ describe('update-16-0-1-set-thirdparty-true', () => {
       bundle: false,
     });
   });
+
   it('should not set thirdParty property if it was already set', async () => {
     addProjectConfiguration(tree, 'myapp', {
       root: 'myapp',

--- a/packages/esbuild/src/migrations/update-16-0-1-set-thirdparty-true/update-16-0-1-set-thirdparty-true.ts
+++ b/packages/esbuild/src/migrations/update-16-0-1-set-thirdparty-true/update-16-0-1-set-thirdparty-true.ts
@@ -10,6 +10,8 @@ export default async function update(host: Tree) {
   const projects = getProjects(host);
 
   projects.forEach((projectConfig, projectName) => {
+    if (!projectConfig.targets) return;
+
     let shouldUpdate = false;
 
     Object.entries(projectConfig.targets).forEach(


### PR DESCRIPTION
Latest esbuild migration failing for projects that don't have targets.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
