### PR TITLE
fix(react): fix external npm packages for rollup

### DIFF
--- a/docs/generated/packages/rollup/executors/rollup.json
+++ b/docs/generated/packages/rollup/executors/rollup.json
@@ -66,7 +66,10 @@
       "external": {
         "type": "array",
         "description": "A list of external modules that will not be bundled (`react`, `react-dom`, etc.).",
-        "items": { "type": "string" }
+        "oneOf": [
+          { "type": "string", "enum": ["all", "none"] },
+          { "type": "array", "items": { "type": "string" } }
+        ]
       },
       "watch": {
         "type": "boolean",

--- a/packages/react/src/generators/library/lib/add-rollup-build-target.ts
+++ b/packages/react/src/generators/library/lib/add-rollup-build-target.ts
@@ -38,7 +38,7 @@ export async function addRollupBuildTarget(
   const { targets } = readProjectConfiguration(host, options.name);
 
   const { libsDir } = getWorkspaceLayout(host);
-  const external: string[] = [];
+  const external: string[] = ['react', 'react-dom'];
 
   if (options.style === '@emotion/styled') {
     external.push('@emotion/react/jsx-runtime');

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -505,7 +505,7 @@ describe('lib', () => {
         executor: '@nx/rollup:rollup',
         outputs: ['{options.outputPath}'],
         options: {
-          external: ['react/jsx-runtime'],
+          external: ['react', 'react-dom', 'react/jsx-runtime'],
           entryFile: 'libs/my-lib/src/index.ts',
           outputPath: 'dist/libs/my-lib',
           project: 'libs/my-lib/package.json',
@@ -544,7 +544,7 @@ describe('lib', () => {
 
       expect(config.targets.build).toMatchObject({
         options: {
-          external: ['react/jsx-runtime'],
+          external: ['react', 'react-dom', 'react/jsx-runtime'],
         },
       });
       expect(babelrc.plugins).toEqual([
@@ -566,7 +566,7 @@ describe('lib', () => {
 
       expect(config.targets.build).toMatchObject({
         options: {
-          external: ['@emotion/react/jsx-runtime'],
+          external: ['react', 'react-dom', '@emotion/react/jsx-runtime'],
         },
       });
       expect(babelrc.plugins).toEqual(['@emotion/babel-plugin']);
@@ -588,7 +588,7 @@ describe('lib', () => {
 
       expect(config.targets.build).toMatchObject({
         options: {
-          external: ['react/jsx-runtime'],
+          external: ['react', 'react-dom', 'react/jsx-runtime'],
         },
       });
       expect(babelrc.plugins).toEqual(['styled-jsx/babel']);
@@ -606,7 +606,7 @@ describe('lib', () => {
 
       expect(config.targets.build).toMatchObject({
         options: {
-          external: ['react/jsx-runtime'],
+          external: ['react', 'react-dom', 'react/jsx-runtime'],
         },
       });
     });

--- a/packages/rollup/src/executors/rollup/rollup.impl.spec.ts
+++ b/packages/rollup/src/executors/rollup/rollup.impl.spec.ts
@@ -150,9 +150,13 @@ describe('rollupExecutor', () => {
       });
     });
 
-    it(`should treat npm dependencies as external`, () => {
+    it(`should treat npm dependencies as external if external is all`, () => {
       const options = createRollupOptions(
-        normalizeRollupExecutorOptions(testOptions, '/root', '/root/src'),
+        normalizeRollupExecutorOptions(
+          { ...testOptions, external: 'all' },
+          '/root',
+          '/root/src'
+        ),
         [],
         context,
         { name: 'example' },
@@ -165,6 +169,48 @@ describe('rollupExecutor', () => {
       expect(external('lodash', '', false)).toBe(true);
       expect(external('lodash/fp', '', false)).toBe(true);
       expect(external('rxjs', '', false)).toBe(false);
+    });
+
+    it(`should not treat npm dependencies as external if external is none`, () => {
+      const options = createRollupOptions(
+        normalizeRollupExecutorOptions(
+          { ...testOptions, external: 'none' },
+          '/root',
+          '/root/src'
+        ),
+        [],
+        context,
+        { name: 'example' },
+        '/root/src',
+        ['lodash']
+      );
+
+      const external = options[0].external as rollup.IsExternal;
+
+      expect(external('lodash', '', false)).toBe(false);
+      expect(external('lodash/fp', '', false)).toBe(false);
+      expect(external('rxjs', '', false)).toBe(false);
+    });
+
+    it(`should set external based on options`, () => {
+      const options = createRollupOptions(
+        normalizeRollupExecutorOptions(
+          { ...testOptions, external: ['rxjs'] },
+          '/root',
+          '/root/src'
+        ),
+        [],
+        context,
+        { name: 'example' },
+        '/root/src',
+        ['lodash']
+      );
+
+      const external = options[0].external as rollup.IsExternal;
+
+      expect(external('lodash', '', false)).toBe(false);
+      expect(external('lodash/fp', '', false)).toBe(false);
+      expect(external('rxjs', '', false)).toBe(true);
     });
   });
 });

--- a/packages/rollup/src/executors/rollup/schema.d.ts
+++ b/packages/rollup/src/executors/rollup/schema.d.ts
@@ -19,7 +19,7 @@ export interface RollupExecutorOptions {
   main: string;
   outputFileName?: string;
   extractCss?: boolean | string;
-  external?: string[];
+  external?: string[] | 'all' | 'none';
   rollupConfig?: string | string[];
   watch?: boolean;
   assets?: any[];

--- a/packages/rollup/src/executors/rollup/schema.json
+++ b/packages/rollup/src/executors/rollup/schema.json
@@ -66,9 +66,18 @@
     "external": {
       "type": "array",
       "description": "A list of external modules that will not be bundled (`react`, `react-dom`, etc.).",
-      "items": {
-        "type": "string"
-      }
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["all", "none"]
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
     },
     "watch": {
       "type": "boolean",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
- when developers want to include a package in the code explicitly, currently there is no way. when that package is not specified from external, it will still treat it as external and not include it in the source code.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
- when external is not specified, it will include the package in the code
- add option all and none for external

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/10405
