### PR TITLE
fix(angular): add jasmine-marbles with a version compatible with installed rxjs version in migration

### DIFF
--- a/packages/angular/src/migrations/update-15-0-0/switch-to-jasmine-marbles.spec.ts
+++ b/packages/angular/src/migrations/update-15-0-0/switch-to-jasmine-marbles.spec.ts
@@ -1,12 +1,13 @@
-import switchToJasmineMarbles from './switch-to-jasmine-marbles';
-import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import {
   addProjectConfiguration,
   DependencyType,
   ProjectGraph,
   readJson,
+  updateJson,
 } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { jasmineMarblesVersion } from '../../utils/versions';
+import switchToJasmineMarbles from './switch-to-jasmine-marbles';
 
 let projectGraph: ProjectGraph;
 jest.mock('@nx/devkit', () => ({
@@ -158,5 +159,43 @@ describe('switchToJasmineMarbles', () => {
       .devDependencies['jasmine-marbles'];
     expect(jasmineMarblesDependency).toBeTruthy();
     expect(jasmineMarblesDependency).toBe(jasmineMarblesVersion);
+  });
+
+  it('should add compatible jasmine-marbles version when rxjs version is <7.0.0', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    projectGraph = {
+      nodes: {},
+      dependencies: {
+        test: [
+          {
+            type: DependencyType.static,
+            source: 'test',
+            target: 'npm:@nrwl/angular',
+          },
+        ],
+      },
+    };
+    addProjectConfiguration(tree, 'test', {
+      name: 'test',
+      root: '',
+    });
+    tree.write(
+      'a/b/mytest.spec.ts',
+      `import {hot, cold, readFirst} from '@nrwl/angular/testing';`
+    );
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { ...json.dependencies, rxjs: '^6.6.7' },
+    }));
+
+    // ACT
+    await switchToJasmineMarbles(tree);
+
+    // ASSERT
+
+    const jasmineMarblesDependency = readJson(tree, 'package.json')
+      .devDependencies['jasmine-marbles'];
+    expect(jasmineMarblesDependency).toBe('~0.8.3');
   });
 });

--- a/packages/angular/src/migrations/update-15-0-0/switch-to-jasmine-marbles.ts
+++ b/packages/angular/src/migrations/update-15-0-0/switch-to-jasmine-marbles.ts
@@ -9,7 +9,12 @@ import {
 } from '@nx/devkit';
 import { extname } from 'path';
 import { tsquery } from '@phenomnomnominal/tsquery';
-import { jasmineMarblesVersion } from '../../utils/versions';
+import {
+  jasmineMarblesVersion as latestJasmineMarblesVersion,
+  rxjsVersion as latestRxjsVersion,
+} from '../../utils/versions';
+import { checkAndCleanWithSemver } from '@nx/devkit/src/utils/semver';
+import { gte } from 'semver';
 
 export default async function switchToJasmineMarbles(tree: Tree) {
   const usesJasmineMarbles = await replaceJasmineMarbleUsagesInFiles(tree);
@@ -144,6 +149,8 @@ function addJasmineMarblesDevDependencyIfUsed(
     return;
   }
 
+  const jasmineMarblesVersion = getJasmineMarblesVersion(tree);
+
   addDependenciesToPackageJson(
     tree,
     {},
@@ -151,4 +158,19 @@ function addJasmineMarblesDevDependencyIfUsed(
       'jasmine-marbles': jasmineMarblesVersion,
     }
   );
+}
+
+function getJasmineMarblesVersion(tree: Tree): string {
+  let rxjsVersion: string;
+  try {
+    const { dependencies, devDependencies } = readJson(tree, 'package.json');
+    rxjsVersion = checkAndCleanWithSemver(
+      'rxjs',
+      dependencies?.rxjs ?? devDependencies?.rxjs
+    );
+  } catch {
+    rxjsVersion = checkAndCleanWithSemver('rxjs', latestRxjsVersion);
+  }
+
+  return gte(rxjsVersion, '7.0.0') ? latestJasmineMarblesVersion : '~0.8.3';
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The migration switching imports to `jasmine-marbles` always adds the latest version of the `jasmine-marbles` package. It doesn't consider the RxJs version installed in the workspace.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The migration switching imports to `jasmine-marbles` adds a version of the `jasmine-marbles` package that is compatible with the RxJs version installed in the workspace.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
