### PR TITLE
fix(core): convert extension to lowercase before comparing extension

### DIFF
--- a/packages/devkit/src/utils/binary-extensions.ts
+++ b/packages/devkit/src/utils/binary-extensions.ts
@@ -266,5 +266,5 @@ const binaryExtensions = new Set([
 ]);
 
 export function isBinaryPath(path: string): boolean {
-  return binaryExtensions.has(extname(path));
+  return binaryExtensions.has(extname(path).toLowerCase());
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
In Windows there may be some files with uppercase extensions and the comparison with binaryExtensions set is done in a case sensitive manner

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Compare the file extension with the set by converting the extension to lowercase

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
