### PR TITLE
fix(angular): throw error when no parent module found

### DIFF
--- a/packages/angular/src/generators/component/lib/module.ts
+++ b/packages/angular/src/generators/component/lib/module.ts
@@ -56,7 +56,7 @@ function findModule(
   tree: Tree,
   generateDir: string,
   projectRoot: string
-): string | null {
+): string {
   let dir = generateDir;
   const projectRootParent = dirname(projectRoot);
 
@@ -80,5 +80,7 @@ function findModule(
     dir = dirname(dir);
   }
 
-  return null;
+  throw new Error(
+    "Could not find a candidate module to add the component to. Please specify which module the component should be added to by using the '--module' option."
+  );
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When there are no parent modules to add a component to, the generator fails with a cryptic error.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should throw a better when a parent module cannot be found

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16689
