### PR TITLE
fix(misc): sort plugin names when displaying them (#16702)

### DIFF
--- a/packages/nx/src/utils/plugins/installed-plugins.ts
+++ b/packages/nx/src/utils/plugins/installed-plugins.ts
@@ -21,7 +21,7 @@ export function findInstalledPlugins(): PackageJson[] {
       result.push(pluginPackageJson);
     }
   }
-  return result;
+  return result.sort((a, b) => a.name.localeCompare(b.name));
 }
 
 function getNxPluginPackageJsonOrNull(pkg: string): PackageJson | null {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
- Plugin collections in the `nx generate` prompt are not sorted, which can make it harder to find the one you are wanting
- Community  plugins listed in `nx report` output are not sorted, which is a bit ugly

## Expected Behavior
We sort plugins when we discover them, resulting in them being sorted everywhere that we use `findInstalledPlugins`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
