### PR TITLE
fix(js): default to analyzing source code and package.json

### DIFF
--- a/packages/nx/src/plugins/js/index.ts
+++ b/packages/nx/src/plugins/js/index.ts
@@ -58,13 +58,18 @@ function writeLastProcessedLockfileHash(hash: string) {
   writeFileSync(lockFileHashFile, hash);
 }
 
-function jsPluginConfig(nxJson: NxJsonConfiguration): NrwlJsPluginConfig {
-  if (nxJson?.pluginsConfig?.['@nx/js']) {
-    return nxJson?.pluginsConfig?.['@nx/js'];
-  }
+function jsPluginConfig(
+  nxJson: NxJsonConfiguration
+): Required<NrwlJsPluginConfig> {
+  const nxJsonConfig: NrwlJsPluginConfig =
+    nxJson?.pluginsConfig?.['@nx/js'] ?? nxJson?.pluginsConfig?.['@nrwl/js'];
 
-  if (nxJson?.pluginsConfig?.['@nrwl/js']) {
-    return nxJson?.pluginsConfig?.['@nrwl/js'];
+  if (nxJsonConfig) {
+    return {
+      analyzePackageJson: true,
+      analyzeSourceFiles: true,
+      ...nxJsonConfig,
+    };
   }
 
   if (!fileExists(join(workspaceRoot, 'package.json'))) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When only the following exists, `analyzePackageJson` is set to false. It should default to true.

```json
  "pluginsConfig": {
    "@nrwl/js": {
      "analyzeSourceFiles": true
    }
  }
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When only the following exists, `analyzePackageJson` is defaulted to true.

```json
  "pluginsConfig": {
    "@nrwl/js": {
      "analyzeSourceFiles": true
    }
  }
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/16513
