### PR TITLE
feat(linter): support custom build targets for buildability check

### DIFF
--- a/packages/eslint-plugin/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin/src/rules/enforce-module-boundaries.ts
@@ -33,7 +33,6 @@ import {
   isComboDepConstraint,
 } from '../utils/runtime-lint-utils';
 import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
-import { TargetProjectLocator } from '@nx/js/src/internal';
 import { basename, dirname, relative } from 'path';
 import {
   getBarrelEntryPointByImportScope,
@@ -46,6 +45,7 @@ import { readProjectGraph } from '../utils/project-graph-utils';
 type Options = [
   {
     allow: string[];
+    buildTargets: string[];
     depConstraints: DepConstraint[];
     enforceBuildableLibDependency: boolean;
     allowCircularSelfDependency: boolean;
@@ -90,6 +90,7 @@ export default createESLintRule<Options, MessageIds>({
           banTransitiveDependencies: { type: 'boolean' },
           checkNestedExternalImports: { type: 'boolean' },
           allow: [{ type: 'string' }],
+          buildTargets: [{ type: 'string' }],
           depConstraints: [
             {
               type: 'object',
@@ -138,6 +139,7 @@ export default createESLintRule<Options, MessageIds>({
   defaultOptions: [
     {
       allow: [],
+      buildTargets: ['build'],
       depConstraints: [],
       enforceBuildableLibDependency: false,
       allowCircularSelfDependency: false,
@@ -151,6 +153,7 @@ export default createESLintRule<Options, MessageIds>({
     [
       {
         allow,
+        buildTargets,
         depConstraints,
         enforceBuildableLibDependency,
         allowCircularSelfDependency,
@@ -479,8 +482,8 @@ export default createESLintRule<Options, MessageIds>({
         targetProject.type === 'lib'
       ) {
         if (
-          hasBuildExecutor(sourceProject) &&
-          !hasBuildExecutor(targetProject)
+          hasBuildExecutor(sourceProject, buildTargets) &&
+          !hasBuildExecutor(targetProject, buildTargets)
         ) {
           context.report({
             node,

--- a/packages/eslint-plugin/src/utils/runtime-lint-utils.ts
+++ b/packages/eslint-plugin/src/utils/runtime-lint-utils.ts
@@ -381,17 +381,21 @@ function parseImportWildcards(importDefinition: string): RegExp {
 }
 
 /**
- * Verifies whether the given node has an architect builder attached
+ * Verifies whether the given node has a builder target
  * @param projectGraph the node to verify
+ * @param buildTargets the list of targets to check for
  */
 export function hasBuildExecutor(
-  projectGraph: ProjectGraphProjectNode
+  projectGraph: ProjectGraphProjectNode,
+  buildTargets = ['build']
 ): boolean {
   return (
-    // can the architect not be defined? real use case?
     projectGraph.data.targets &&
-    projectGraph.data.targets.build &&
-    projectGraph.data.targets.build.executor !== ''
+    buildTargets.some(
+      (target) =>
+        projectGraph.data.targets[target] &&
+        projectGraph.data.targets[target].executor !== ''
+    )
   );
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When checking whether buildable lib is importing non-buildable we are explicitly looking for `build` target.

## Expected Behavior
Names of buildable target should be configurable

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16715
