### PR TITLE
fix(misc): json files should end in a new line by default

### DIFF
--- a/docs/generated/devkit/nx_devkit.md
+++ b/docs/generated/devkit/nx_devkit.md
@@ -2284,12 +2284,12 @@ Updates a JSON value to the file system tree
 
 #### Parameters
 
-| Name       | Type                                                                                                                                                      | Description                                                                                          |
-| :--------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------- |
-| `tree`     | [`Tree`](../../devkit/documents/nx_devkit#tree)                                                                                                           | File system tree                                                                                     |
-| `path`     | `string`                                                                                                                                                  | Path of JSON file in the Tree                                                                        |
-| `updater`  | (`value`: `T`) => `U`                                                                                                                                     | Function that maps the current value of a JSON document to a new value to be written to the document |
-| `options?` | [`JsonParseOptions`](../../devkit/documents/nx_devkit#jsonparseoptions) & [`JsonSerializeOptions`](../../devkit/documents/nx_devkit#jsonserializeoptions) | Optional JSON Parse and Serialize Options                                                            |
+| Name       | Type                                                                                         | Description                                                                                          |
+| :--------- | :------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------- |
+| `tree`     | [`Tree`](../../devkit/documents/nx_devkit#tree)                                              | File system tree                                                                                     |
+| `path`     | `string`                                                                                     | Path of JSON file in the Tree                                                                        |
+| `updater`  | (`value`: `T`) => `U`                                                                        | Function that maps the current value of a JSON document to a new value to be written to the document |
+| `options?` | [`JsonParseOptions`](../../devkit/documents/nx_devkit#jsonparseoptions) & `JsonWriteOptions` | Optional JSON Parse and Serialize Options                                                            |
 
 #### Returns
 
@@ -2430,12 +2430,12 @@ Writes a JSON value to the file system tree
 
 #### Parameters
 
-| Name       | Type                                                                            | Description                     |
-| :--------- | :------------------------------------------------------------------------------ | :------------------------------ |
-| `tree`     | [`Tree`](../../devkit/documents/nx_devkit#tree)                                 | File system tree                |
-| `path`     | `string`                                                                        | Path of JSON file in the Tree   |
-| `value`    | `T`                                                                             | Serializable value to write     |
-| `options?` | [`JsonSerializeOptions`](../../devkit/documents/nx_devkit#jsonserializeoptions) | Optional JSON Serialize Options |
+| Name       | Type                                            | Description                     |
+| :--------- | :---------------------------------------------- | :------------------------------ |
+| `tree`     | [`Tree`](../../devkit/documents/nx_devkit#tree) | File system tree                |
+| `path`     | `string`                                        | Path of JSON file in the Tree   |
+| `value`    | `T`                                             | Serializable value to write     |
+| `options?` | `JsonWriteOptions`                              | Optional JSON Serialize Options |
 
 #### Returns
 

--- a/docs/generated/packages/devkit/documents/nx_devkit.md
+++ b/docs/generated/packages/devkit/documents/nx_devkit.md
@@ -2284,12 +2284,12 @@ Updates a JSON value to the file system tree
 
 #### Parameters
 
-| Name       | Type                                                                                                                                                      | Description                                                                                          |
-| :--------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------- |
-| `tree`     | [`Tree`](../../devkit/documents/nx_devkit#tree)                                                                                                           | File system tree                                                                                     |
-| `path`     | `string`                                                                                                                                                  | Path of JSON file in the Tree                                                                        |
-| `updater`  | (`value`: `T`) => `U`                                                                                                                                     | Function that maps the current value of a JSON document to a new value to be written to the document |
-| `options?` | [`JsonParseOptions`](../../devkit/documents/nx_devkit#jsonparseoptions) & [`JsonSerializeOptions`](../../devkit/documents/nx_devkit#jsonserializeoptions) | Optional JSON Parse and Serialize Options                                                            |
+| Name       | Type                                                                                         | Description                                                                                          |
+| :--------- | :------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------- |
+| `tree`     | [`Tree`](../../devkit/documents/nx_devkit#tree)                                              | File system tree                                                                                     |
+| `path`     | `string`                                                                                     | Path of JSON file in the Tree                                                                        |
+| `updater`  | (`value`: `T`) => `U`                                                                        | Function that maps the current value of a JSON document to a new value to be written to the document |
+| `options?` | [`JsonParseOptions`](../../devkit/documents/nx_devkit#jsonparseoptions) & `JsonWriteOptions` | Optional JSON Parse and Serialize Options                                                            |
 
 #### Returns
 
@@ -2430,12 +2430,12 @@ Writes a JSON value to the file system tree
 
 #### Parameters
 
-| Name       | Type                                                                            | Description                     |
-| :--------- | :------------------------------------------------------------------------------ | :------------------------------ |
-| `tree`     | [`Tree`](../../devkit/documents/nx_devkit#tree)                                 | File system tree                |
-| `path`     | `string`                                                                        | Path of JSON file in the Tree   |
-| `value`    | `T`                                                                             | Serializable value to write     |
-| `options?` | [`JsonSerializeOptions`](../../devkit/documents/nx_devkit#jsonserializeoptions) | Optional JSON Serialize Options |
+| Name       | Type                                            | Description                     |
+| :--------- | :---------------------------------------------- | :------------------------------ |
+| `tree`     | [`Tree`](../../devkit/documents/nx_devkit#tree) | File system tree                |
+| `path`     | `string`                                        | Path of JSON file in the Tree   |
+| `value`    | `T`                                             | Serializable value to write     |
+| `options?` | `JsonWriteOptions`                              | Optional JSON Serialize Options |
 
 #### Returns
 

--- a/e2e/utils/file-utils.ts
+++ b/e2e/utils/file-utils.ts
@@ -56,7 +56,7 @@ export function updateJson<T extends object = any, U extends object = T>(
 ) {
   updateFile(f, (s) => {
     const json = JSON.parse(s);
-    return JSON.stringify(updater(json), null, 2);
+    return JSON.stringify(updater(json), null, 2) + '\n';
   });
 }
 

--- a/packages/linter/src/generators/init/__snapshots__/init.spec.ts.snap
+++ b/packages/linter/src/generators/init/__snapshots__/init.spec.ts.snap
@@ -57,5 +57,6 @@ exports[`@nx/linter:init --linter eslint should generate the global eslint confi
     }
   ]
 }
+
 "
 `;

--- a/packages/nx/src/utils/fileutils.ts
+++ b/packages/nx/src/utils/fileutils.ts
@@ -1,4 +1,4 @@
-import { parseJson, serializeJson } from './json';
+import { JsonWriteOptions, parseJson, serializeJson } from './json';
 import type { JsonParseOptions, JsonSerializeOptions } from './json';
 import {
   createReadStream,
@@ -20,14 +20,6 @@ export interface JsonReadOptions extends JsonParseOptions {
    * @default false
    */
   endsWithNewline?: boolean;
-}
-
-export interface JsonWriteOptions extends JsonSerializeOptions {
-  /**
-   * whether to append new line at the end of JSON file
-   * @default false
-   */
-  appendNewLine?: boolean;
 }
 
 /**
@@ -65,6 +57,9 @@ export function writeJsonFile<T extends object = object>(
   data: T,
   options?: JsonWriteOptions
 ): void {
+  options ??= {};
+  options.appendNewLine ??= true;
+
   mkdirSync(dirname(path), { recursive: true });
   const serializedJson = serializeJson(data, options);
   const content = options?.appendNewLine

--- a/packages/nx/src/utils/json.ts
+++ b/packages/nx/src/utils/json.ts
@@ -31,6 +31,14 @@ export interface JsonSerializeOptions {
   spaces?: number;
 }
 
+export interface JsonWriteOptions extends JsonSerializeOptions {
+  /**
+   * whether to append new line at the end of JSON file
+   * @default false
+   */
+  appendNewLine?: boolean;
+}
+
 /**
  * Parses the given JSON string and returns the object the JSON content represents.
  * By default javascript-style comments and trailing commas are allowed.


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
By default, JSON files don't have a newline at the end

## Expected Behavior
By default, JSON files have a newline at the end

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16741
