### PR TITLE
fix(core): use legacy peer deps during migrate process

### DIFF
--- a/packages/nx/src/command-line/migrate.ts
+++ b/packages/nx/src/command-line/migrate.ts
@@ -1328,6 +1328,11 @@ function showConnectToCloudMessage() {
 
 function runInstall() {
   const pmCommands = getPackageManagerCommand();
+
+  // TODO: remove this
+  if (detectPackageManager() === 'npm') {
+    process.env.npm_config_legacy_peer_deps ??= 'true';
+  }
   output.log({
     title: `Running '${pmCommands.install}' to make sure necessary packages are installed`,
   });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

During the migrate process, there may be invalid peer dependencies which could be resolved during the actual migrations that will run. When running `nx migrate --run-migrations`, we perform an install which might fail due to peer dependencies.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

During the migrate process, the install ignores invalid peer dependencies via `--legacy-peer-deps`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
