### PR TITLE
fix(testing): do not error when no vite config is found

### DIFF
--- a/packages/vite/src/executors/test/vitest.impl.ts
+++ b/packages/vite/src/executors/test/vitest.impl.ts
@@ -117,7 +117,7 @@ async function getSettings(
 
   if (!viteConfigPath || !resolved?.config?.test) {
     logger.warn(stripIndents`Unable to load test config from config file ${
-      resolved.path ?? viteConfigPath
+      resolved?.path ?? viteConfigPath
     }
 Some settings may not be applied as expected.
 You can manually set the config in the project, ${


### PR DESCRIPTION
Currently, if you don't have `vite.config.ts` file in the project, the warning we're trying to log ends up causing an error like this:

```
 >  NX   Cannot read properties of null (reading 'path')
TypeError: Cannot read properties of null (reading 'path')
    at getSettings (/Users/jack/projects/analog/node_modules/@nx/vite/src/executors/test/vitest.impl.js:101:124)
    at async vitestExecutor (/Users/jack/projects/analog/node_modules/@nx/vite/src/executors/test/vitest.impl.js:55:20)
```

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
