### PR TITLE
fix(angular): generate applications with zone.js 0.13.0

### DIFF
--- a/packages/angular/src/utils/versions.ts
+++ b/packages/angular/src/utils/versions.ts
@@ -5,7 +5,7 @@ export const angularDevkitVersion = '~16.0.0';
 export const ngPackagrVersion = '~16.0.0';
 export const ngrxVersion = '~15.3.0';
 export const rxjsVersion = '~7.8.0';
-export const zoneJsVersion = '~0.12.0';
+export const zoneJsVersion = '~0.13.0';
 export const angularJsVersion = '1.7.9';
 export const tsLibVersion = '^2.3.0';
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Angular 16 applications are still generated with `zone.js` `0.12.0`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Angular 16 applications are generated with `zone.js` `0.13.0`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
