### PR TITLE
chore(repo): always log error for runCommandUntil

### DIFF
--- a/e2e/utils/command-utils.ts
+++ b/e2e/utils/command-utils.ts
@@ -247,15 +247,13 @@ export function runCommandUntil(
     p.stderr?.on('data', checkCriteria);
     p.on('exit', (code) => {
       if (!complete) {
-        if (isVerboseE2ERun()) {
-          logError(
-            `Original output:`,
-            output
-              .split('\n')
-              .map((l) => `    ${l}`)
-              .join('\n')
-          );
-        }
+        logError(
+          `Original output:`,
+          output
+            .split('\n')
+            .map((l) => `    ${l}`)
+            .join('\n')
+        );
         rej(`Exited with ${code}`);
       } else {
         res(p);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
when command errors out in CI the error is hidden unless the verbose env var is set

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
always log error to make CI debugging easier

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
