### PR TITLE
fix(angular): update component module error message to suggest standalone

### DIFF
--- a/packages/angular/src/generators/component/lib/module.ts
+++ b/packages/angular/src/generators/component/lib/module.ts
@@ -81,6 +81,6 @@ function findModule(
   }
 
   throw new Error(
-    "Could not find a candidate module to add the component to. Please specify which module the component should be added to by using the '--module' option."
+    "Could not find a candidate module to add the component to. Please specify which module the component should be added to by using the '--module' option, or pass '--standalone' to generate a standalone component."
   );
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When a component is generated without `--standalone` and there is no parent module to add the component to, we through an error.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The error message should include information about generating a standalone component which does not require a module.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
