### PR TITLE
fix(angular): update ngrx parent description to give better info about standalone api usage

### DIFF
--- a/docs/generated/packages/angular/generators/ngrx.json
+++ b/docs/generated/packages/angular/generators/ngrx.json
@@ -10,12 +10,20 @@
     "type": "object",
     "examples": [
       {
-        "command": "nx g @nrwl/angular:ngrx --root --module=apps/my-app/src/app/app.module.ts --facade=false placeholder",
+        "command": "nx g @nrwl/angular:ngrx --root --parent=apps/my-app/src/app/app.module.ts --facade=false placeholder",
         "description": "Add root ngrx configration to the `my-app` application"
       },
       {
-        "command": "nx g @nrwl/angular:ngrx --module=libs/my-lib/src/lib/my-lib.module.ts --facade=true --root=false users",
+        "command": "nx g @nrwl/angular:ngrx --parent=libs/my-lib/src/lib/my-lib.module.ts --facade=true --root=false users",
         "description": "Add a `users` state with a facade to the `my-lib` library. It will be tracked under the default `+state` folder in the lib"
+      },
+      {
+        "command": "nx g @nrwl/angular:ngrx --parent=apps/my-app/src/app/app.config.ts --root",
+        "description": "Add a root state configuration to `my-app` when `my-app` uses Standalone APIs"
+      },
+      {
+        "command": "nx g @nrwl/angular:ngrx --parent=libs/my-lib/src/lib.routes.ts users",
+        "description": "Add a `users` feature state to the Route definition of a library using Standalone APIs"
       }
     ],
     "properties": {
@@ -33,7 +41,7 @@
       },
       "parent": {
         "type": "string",
-        "description": "The path to the `NgModule` or the `Routes` definition file (for Standalone API usage) where the feature state will be registered. The host directory will create/use the new state directory. _Note: The Standalone API usage is only supported in Angular versions >= 14.1.0_.",
+        "description": "The path to the file where the state will be registered. For NgModule usage, this will be your `app.module.ts` for your root state, or your Feature Module for feature state. For Standalone API usage, this will be your `app.config.ts` file for your root state, or the Routes definition file for your feature state. The host directory will create/use the new state directory. _Note: The Standalone API usage is only supported in Angular versions >= 14.1.0_.",
         "x-prompt": "What is the path to the module or Routes definition where this NgRx state should be registered?",
         "x-priority": "important"
       },

--- a/packages/angular/src/generators/ngrx/schema.json
+++ b/packages/angular/src/generators/ngrx/schema.json
@@ -7,12 +7,20 @@
   "type": "object",
   "examples": [
     {
-      "command": "nx g @nrwl/angular:ngrx --root --module=apps/my-app/src/app/app.module.ts --facade=false placeholder",
+      "command": "nx g @nrwl/angular:ngrx --root --parent=apps/my-app/src/app/app.module.ts --facade=false placeholder",
       "description": "Add root ngrx configration to the `my-app` application"
     },
     {
-      "command": "nx g @nrwl/angular:ngrx --module=libs/my-lib/src/lib/my-lib.module.ts --facade=true --root=false users",
+      "command": "nx g @nrwl/angular:ngrx --parent=libs/my-lib/src/lib/my-lib.module.ts --facade=true --root=false users",
       "description": "Add a `users` state with a facade to the `my-lib` library. It will be tracked under the default `+state` folder in the lib"
+    },
+    {
+      "command": "nx g @nrwl/angular:ngrx --parent=apps/my-app/src/app/app.config.ts --root",
+      "description": "Add a root state configuration to `my-app` when `my-app` uses Standalone APIs"
+    },
+    {
+      "command": "nx g @nrwl/angular:ngrx --parent=libs/my-lib/src/lib.routes.ts users",
+      "description": "Add a `users` feature state to the Route definition of a library using Standalone APIs"
     }
   ],
   "properties": {
@@ -33,7 +41,7 @@
     },
     "parent": {
       "type": "string",
-      "description": "The path to the `NgModule` or the `Routes` definition file (for Standalone API usage) where the feature state will be registered. The host directory will create/use the new state directory. _Note: The Standalone API usage is only supported in Angular versions >= 14.1.0_.",
+      "description": "The path to the file where the state will be registered. For NgModule usage, this will be your `app.module.ts` for your root state, or your Feature Module for feature state. For Standalone API usage, this will be your `app.config.ts` file for your root state, or the Routes definition file for your feature state. The host directory will create/use the new state directory. _Note: The Standalone API usage is only supported in Angular versions >= 14.1.0_.",
       "x-prompt": "What is the path to the module or Routes definition where this NgRx state should be registered?",
       "x-priority": "important"
     },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
With Angular 16, there is a new `app.config.ts` file that registers the providers for the `bootstrapApplication` call. 
This is the new expected `parent` for the root state of `NgRx` generator. 

However, the description on the option does not indicate this.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Update the description to reflect this change.
Add a some examples of the standalone api usage


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
