### PR TITLE
fix(angular): ssr distFolder path should be more correctly defined

### DIFF
--- a/packages/angular/src/generators/setup-ssr/files/ngmodule/base/__serverFileName__
+++ b/packages/angular/src/generators/setup-ssr/files/ngmodule/base/__serverFileName__
@@ -11,7 +11,7 @@ import {<%= rootModuleClassName %>} from './src/<%= main.slice(0, -3) %>';
 // The Express app is exported so that it can be used by serverless Functions.
 export function app(): express.Express {
   const server = express();
-  const distFolder = join(process.cwd(), 'dist/apps/<%= project %>/browser');
+  const distFolder = join(process.cwd(), '<%= browserBundleOutputPath %>');
   const indexHtml = existsSync(join(distFolder, 'index.original.html')) ? 'index.original.html' : 'index';
 
   // Our Universal express-engine (found @ https://github.com/angular/universal/tree/main/modules/express-engine)

--- a/packages/angular/src/generators/setup-ssr/files/standalone/__serverFileName__
+++ b/packages/angular/src/generators/setup-ssr/files/standalone/__serverFileName__
@@ -11,7 +11,7 @@ import bootstrap from './src/<%= main.slice(0, -3) %>';
 // The Express app is exported so that it can be used by serverless Functions.
 export function app(): express.Express {
   const server = express();
-  const distFolder = join(process.cwd(), 'dist/apps/<%= project %>/browser');
+  const distFolder = join(process.cwd(), '<%= browserBundleOutputPath %>');
   const indexHtml = existsSync(join(distFolder, 'index.original.html')) ? 'index.original.html' : 'index';
 
   // Our Universal express-engine (found @ https://github.com/angular/universal/tree/main/modules/express-engine)

--- a/packages/angular/src/generators/setup-ssr/lib/generate-files.ts
+++ b/packages/angular/src/generators/setup-ssr/lib/generate-files.ts
@@ -9,7 +9,10 @@ import { getInstalledAngularVersionInfo } from '../../utils/version-utils';
 import type { Schema } from '../schema';
 
 export function generateSSRFiles(tree: Tree, schema: Schema) {
-  const projectRoot = readProjectConfiguration(tree, schema.project).root;
+  const projectConfig = readProjectConfiguration(tree, schema.project);
+  const projectRoot = projectConfig.root;
+  const browserBundleOutputPath =
+    projectConfig.targets.build.options.outputPath;
 
   const pathToFiles = joinPathFragments(__dirname, '..', 'files');
 
@@ -23,14 +26,16 @@ export function generateSSRFiles(tree: Tree, schema: Schema) {
       tree,
       joinPathFragments(pathToFiles, 'standalone'),
       projectRoot,
-      { ...schema, tpl: '' }
+
+      { ...schema, browserBundleOutputPath, tpl: '' }
     );
   } else {
     generateFiles(
       tree,
       joinPathFragments(pathToFiles, 'ngmodule', 'base'),
       projectRoot,
-      { ...schema, tpl: '' }
+
+      { ...schema, browserBundleOutputPath, tpl: '' }
     );
 
     const { major: angularMajorVersion, version: angularVersion } =
@@ -41,7 +46,8 @@ export function generateSSRFiles(tree: Tree, schema: Schema) {
         tree,
         joinPathFragments(pathToFiles, 'ngmodule', 'v14'),
         projectRoot,
-        { ...schema, tpl: '' }
+
+        { ...schema, browserBundleOutputPath, tpl: '' }
       );
     }
     if (lt(angularVersion, '15.2.0')) {
@@ -49,7 +55,8 @@ export function generateSSRFiles(tree: Tree, schema: Schema) {
         tree,
         joinPathFragments(pathToFiles, 'ngmodule', 'pre-v15-2'),
         projectRoot,
-        { ...schema, tpl: '' }
+
+        { ...schema, browserBundleOutputPath, tpl: '' }
       );
     }
   }

--- a/packages/angular/src/generators/setup-ssr/lib/update-project-config.ts
+++ b/packages/angular/src/generators/setup-ssr/lib/update-project-config.ts
@@ -15,8 +15,8 @@ import type { Schema } from '../schema';
 export function updateProjectConfig(tree: Tree, schema: Schema) {
   let projectConfig = readProjectConfiguration(tree, schema.project);
   const buildTarget = projectConfig.targets.build;
-
-  buildTarget.options.outputPath = `dist/apps/${schema.project}/browser`;
+  const baseOutputPath = buildTarget.options.outputPath;
+  buildTarget.options.outputPath = joinPathFragments(baseOutputPath, 'browser');
 
   const buildConfigurations = projectConfig.targets.build.configurations;
   const configurations: Record<string, {}> = {};
@@ -30,7 +30,7 @@ export function updateProjectConfig(tree: Tree, schema: Schema) {
     dependsOn: ['build'],
     executor: '@angular-devkit/build-angular:server',
     options: {
-      outputPath: `dist/${projectConfig.root}/server`,
+      outputPath: joinPathFragments(baseOutputPath, 'server'),
       main: joinPathFragments(projectConfig.root, schema.serverFileName),
       tsConfig: joinPathFragments(projectConfig.root, 'tsconfig.server.json'),
       ...(buildTarget.options ? getServerOptions(buildTarget.options) : {}),

--- a/packages/angular/src/generators/setup-ssr/setup-ssr.ts
+++ b/packages/angular/src/generators/setup-ssr/setup-ssr.ts
@@ -18,13 +18,12 @@ export async function setupSsr(tree: Tree, schema: Schema) {
   validateOptions(tree, schema);
   const options = normalizeOptions(tree, schema);
 
+  updateProjectConfig(tree, options);
   generateSSRFiles(tree, options);
 
   if (!options.standalone) {
     updateAppModule(tree, options);
   }
-
-  updateProjectConfig(tree, options);
 
   const pkgVersions = versions(tree);
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When adding SSR to an Angular App, we rewrite the output path to match integrated monorepo style directory structure. We then assume this value to follow that structure in the template files.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should only modify the output path of the build to add what we need, `/browser` and then pull the value stored in the project's config to use as the path in the template files.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
