### PR TITLE
fix(core): make sure verbose logging is not affecting the cache output in e2e test

### DIFF
--- a/e2e/nx-run/src/cache.test.ts
+++ b/e2e/nx-run/src/cache.test.ts
@@ -1,5 +1,6 @@
 import {
   cleanupProject,
+  isVerboseE2ERun,
   listFiles,
   newProject,
   readFile,
@@ -61,7 +62,7 @@ describe('cache', () => {
       'read the output from the cache'
     );
 
-    if (process.platform != 'linux') {
+    if (process.platform != 'linux' && !isVerboseE2ERun()) {
       // TODO(vsavkin): This should be always be matched output once you fix output watching on linux
       expectMatchedOutput(outputWithBuildApp2Cached, [myapp2]);
     } else {


### PR DESCRIPTION
This is one of the three failing suites on nightly

## Current Behavior
Verbose logging flag added on nightly changes the expected output and causes the test to fail

## Expected Behavior
We should be aware of the verbose output when checking for matches

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
