### PR TITLE
fix(nextjs): with stylus and less support

### DIFF
--- a/e2e/next/src/next-styles.test.ts
+++ b/e2e/next/src/next-styles.test.ts
@@ -18,8 +18,7 @@ describe('Next.js apps', () => {
     process.env.NODE_ENV = originalEnv;
   });
 
-  // TODO (meeroslav): enable when this flaky test is fixed
-  xit('should support different --style options', async () => {
+  it('should support different --style options', async () => {
     const lessApp = uniq('app');
 
     runCLI(`generate @nx/next:app ${lessApp} --no-interactive --style=less`);

--- a/packages/next/plugins/with-less.ts
+++ b/packages/next/plugins/with-less.ts
@@ -1,6 +1,7 @@
 // Adapted from https://raw.githubusercontent.com/elado/next-with-less/main/src/index.js
 import { merge } from 'webpack-merge';
 import { NextConfigFn } from '../src/utils/config';
+import { WithNxOptions } from './with-nx';
 
 const addLessToRegExp = (rx) =>
   new RegExp(rx.source.replace('|sass', '|sass|less'), rx.flags);
@@ -13,9 +14,13 @@ function patchNextCSSWithLess(
 
 patchNextCSSWithLess();
 
-export function withLess(configFn: NextConfigFn): NextConfigFn {
+export function withLess(
+  configOrFn: NextConfigFn | WithNxOptions
+): NextConfigFn {
   return async (phase: string) => {
-    const { lessLoaderOptions = {}, ...nextConfig } = await configFn(phase);
+    const baseConfig =
+      typeof configOrFn === 'function' ? await configOrFn(phase) : configOrFn;
+    const { lessLoaderOptions = {}, ...nextConfig } = baseConfig;
 
     return Object.assign({}, nextConfig, {
       webpack(config, opts) {

--- a/packages/next/plugins/with-stylus.ts
+++ b/packages/next/plugins/with-stylus.ts
@@ -1,6 +1,7 @@
 // Adapted from https://raw.githubusercontent.com/elado/next-with-less/main/src/index.js
 import { merge } from 'webpack-merge';
 import { NextConfigFn } from '../src/utils/config';
+import { WithNxOptions } from './with-nx';
 
 const addStylusToRegExp = (rx) =>
   new RegExp(rx.source.replace('|sass', '|sass|styl'), rx.flags);
@@ -13,9 +14,13 @@ function patchNextCSSWithStylus(
 
 patchNextCSSWithStylus();
 
-export function withStylus(configFn: NextConfigFn): NextConfigFn {
+export function withStylus(
+  configOrFn: WithNxOptions | NextConfigFn
+): NextConfigFn {
   return async (phase: string) => {
-    const { stylusLoaderOptions = {}, ...nextConfig } = await configFn(phase);
+    const baseConfig =
+      typeof configOrFn === 'function' ? await configOrFn(phase) : configOrFn;
+    const { stylusLoaderOptions = {}, ...nextConfig } = baseConfig;
 
     return Object.assign({}, nextConfig, {
       webpack(config, opts) {


### PR DESCRIPTION
`withLess` and `withStylus` plugins are not supporting the new use case of `composePlugins`. Since the e2e tests were disabled previously, this regression was not picked up -- it's re-enabled here.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
