### PR TITLE
fix(repo): fix windows nightly runs

### DIFF
--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -30,9 +30,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install PNPM
-        run: |
-          npm install -g @pnpm/exe@8.3.1
+      - uses: pnpm/action-setup@v2
+        name: Install pnpm
+        with:
+          version: 8.3.1
+          run_install: false
 
       - name: Set node
         uses: actions/setup-node@v3
@@ -49,7 +51,6 @@ jobs:
           key: ${{ runner.os }}-modules-${{ matrix.node_version }}-${{ github.run_id }}
 
       - name: Install packages
-        if: steps.cache-modules.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Cache Cypress
@@ -90,7 +91,7 @@ jobs:
           - e2e-node
           - e2e-nx-init
           - e2e-nx-misc
-          - e2e-nx-plugin
+          - e2e-plugin
           - e2e-nx-run
           - e2e-react-core
           - e2e-react-extensions
@@ -128,7 +129,7 @@ jobs:
             codeowners: 'S04SYHYKGNP'
           - project: e2e-nx-misc
             codeowners: 'S04SYHYKGNP'
-          - project: e2e-nx-plugin
+          - project: e2e-plugin
             codeowners: 'S04SYHYKGNP'
           - project: e2e-nx-run
             codeowners: 'S04SYHYKGNP'
@@ -177,7 +178,7 @@ jobs:
           - node_version: 16
             project: e2e-nx-misc
           - node_version: 16
-            project: e2e-nx-plugin
+            project: e2e-plugin
           - node_version: 16
             project: e2e-lerna-smoke-tests
           - node_version: 16
@@ -219,7 +220,7 @@ jobs:
           - node_version: 19
             project: e2e-nx-misc
           - node_version: 19
-            project: e2e-nx-plugin
+            project: e2e-plugin
           - node_version: 19
             project: e2e-lerna-smoke-tests
           - node_version: 19
@@ -248,9 +249,11 @@ jobs:
       - name: Prepare dir for output
         run: mkdir -p outputs
 
-      - name: Install PNPM
-        run: |
-          npm install -g @pnpm/exe@8.3.1
+      - uses: pnpm/action-setup@v2
+        name: Install pnpm
+        with:
+          version: 8.3.1
+          run_install: false
 
       - name: Use Node.js ${{ matrix.node_version }}
         uses: actions/setup-node@v3
@@ -288,6 +291,7 @@ jobs:
       - name: Run e2e tests
         id: e2e-run
         run: pnpm nx run ${{ matrix.project }}:e2e
+        shell: bash
         timeout-minutes: 120
         env:
           GIT_AUTHOR_EMAIL: test@test.com

--- a/scripts/nx-release.ts
+++ b/scripts/nx-release.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import * as yargs from 'yargs';
 import { execSync } from 'child_process';
-import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { URL } from 'url';
 import { join } from 'path';
 
@@ -26,7 +26,10 @@ function hideFromGitIndex(uncommittedFiles: string[]) {
   const options = parseArgs();
 
   if (options.clearLocalRegistry) {
-    execSync('pnpm local-registry clear');
+    rmSync(join(__dirname, '../build/local-registry/storage'), {
+      recursive: true,
+      force: true,
+    });
   }
 
   const currentLatestVersion = execSync('npm view nx version')


### PR DESCRIPTION
Pnpm standalone does not run properly on windows, causing our nightly run to return false positives.

This PR:
- switches back to standard pnpm on windows run
- fixes outdated `nx-plugin` name
- fixes `nx-release` on windows

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
