### PR TITLE
fix(core): ensure safe removal of folders on daemon reset

### DIFF
--- a/packages/nx/src/command-line/reset.ts
+++ b/packages/nx/src/command-line/reset.ts
@@ -1,4 +1,4 @@
-import { removeSync } from 'fs-extra';
+import { rmSync } from 'fs-extra';
 import { daemonClient } from '../daemon/client/client';
 import { cacheDir, projectGraphCacheDirectory } from '../utils/cache-directory';
 import { output } from '../utils/output';
@@ -10,9 +10,9 @@ export async function resetHandler() {
   });
   await daemonClient.stop();
   output.log({ title: 'Daemon Server - Stopped' });
-  removeSync(cacheDir);
+  rmSync(cacheDir, { recursive: true, force: true });
   if (projectGraphCacheDirectory !== cacheDir) {
-    removeSync(projectGraphCacheDirectory);
+    rmSync(projectGraphCacheDirectory, { recursive: true, force: true });
   }
   output.success({
     title: 'Successfully reset the Nx workspace.',


### PR DESCRIPTION
The `removeSync` sometimes fails if folder is not empty. 
![Screenshot 2023-05-04 at 16 11 10](https://user-images.githubusercontent.com/881612/236233515-7646347d-bba7-4622-ad17-d1e8879763fa.png)

For daemon, we need to mimic the `rm -rf ...` command which is what `rmSync` does. Based on node fs types definition:
![Screenshot 2023-05-04 at 16 12 03](https://user-images.githubusercontent.com/881612/236233781-46e3959d-e716-4c00-883f-8b15f3cedb1f.png)

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
