### PR TITLE
feat(core): allow using project patterns rather than just project names with `nx watch`

### DIFF
--- a/packages/nx/src/daemon/server/file-watching/file-watcher-sockets.ts
+++ b/packages/nx/src/daemon/server/file-watching/file-watcher-sockets.ts
@@ -1,4 +1,5 @@
 import { Socket } from 'net';
+import { findMatchingProjects } from '../../../utils/find-matching-projects';
 import { ProjectGraph } from '../../../config/project-graph';
 import { findAllProjectNodeDependencies } from '../../../utils/project-graph-utils';
 import { PromisedBasedQueue } from '../../../utils/promised-based-queue';
@@ -55,10 +56,15 @@ export function notifyFileWatcherSockets(
             changedFiles.push(...projectFiles);
           }
         } else {
-          const watchedProjects = new Set<string>(config.watchProjects);
+          const watchedProjects = new Set<string>(
+            findMatchingProjects(
+              config.watchProjects,
+              currentProjectGraphCache.nodes
+            )
+          );
 
           if (config.includeDependentProjects) {
-            for (const project of config.watchProjects) {
+            for (const project of watchedProjects) {
               for (const dep of findAllProjectNodeDependencies(
                 project,
                 currentProjectGraphCache as ProjectGraph


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`nx watch` accepts a list of project names via `--projects`, but doesn't use `findMatchingProjects` and thus has inconsistencies with run-many, affected (--exclude), implicitDependencies, dependsOn, and inputs

## Expected Behavior
All `projects` fields use `findMatchingProjects`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16761