### PR TITLE
fix(nest): fix invalid nestjs versions

### DIFF
--- a/packages/nest/migrations.json
+++ b/packages/nest/migrations.json
@@ -47,15 +47,15 @@
       "version": "16.1.0-beta.0",
       "packages": {
         "@nestjs/common": {
-          "version": "^9.1.0",
+          "version": "^9.1.1",
           "alwaysAddToPackageJson": false
         },
         "@nestjs/core": {
-          "version": "^9.1.0",
+          "version": "^9.1.1",
           "alwaysAddToPackageJson": false
         },
         "@nestjs/platform-express": {
-          "version": "^9.1.0",
+          "version": "^9.1.1",
           "alwaysAddToPackageJson": false
         },
         "@nestjs/schematics": {
@@ -67,7 +67,7 @@
           "alwaysAddToPackageJson": false
         },
         "@nestjs/testing": {
-          "version": "^9.1.0",
+          "version": "^9.1.1",
           "alwaysAddToPackageJson": false
         }
       }

--- a/packages/nest/src/generators/init/init.spec.ts
+++ b/packages/nest/src/generators/init/init.spec.ts
@@ -1,7 +1,11 @@
 import type { Tree } from '@nx/devkit';
 import * as devkit from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { nestJsVersion, nxVersion } from '../../utils/versions';
+import {
+  nestJsSchematicsVersion,
+  nestJsVersion,
+  nxVersion,
+} from '../../utils/versions';
 import { initGenerator } from './init';
 
 describe('init generator', () => {
@@ -26,7 +30,7 @@ describe('init generator', () => {
     expect(packageJson.dependencies['tslib']).toBeDefined();
     expect(packageJson.dependencies['@nx/nest']).toBeUndefined();
     expect(packageJson.devDependencies['@nestjs/schematics']).toBe(
-      nestJsVersion
+      nestJsSchematicsVersion
     );
     expect(packageJson.devDependencies['@nestjs/testing']).toBe(nestJsVersion);
     expect(packageJson.devDependencies['@nx/nest']).toBe(nxVersion);

--- a/packages/nest/src/generators/init/lib/add-dependencies.ts
+++ b/packages/nest/src/generators/init/lib/add-dependencies.ts
@@ -1,6 +1,7 @@
 import type { GeneratorCallback, Tree } from '@nx/devkit';
 import { addDependenciesToPackageJson } from '@nx/devkit';
 import {
+  nestJsSchematicsVersion,
   nestJsVersion,
   nxVersion,
   reflectMetadataVersion,
@@ -20,7 +21,7 @@ export function addDependencies(tree: Tree): GeneratorCallback {
       tslib: tsLibVersion,
     },
     {
-      '@nestjs/schematics': nestJsVersion,
+      '@nestjs/schematics': nestJsSchematicsVersion,
       '@nestjs/testing': nestJsVersion,
       '@nx/nest': nxVersion,
     }

--- a/packages/nest/src/utils/versions.ts
+++ b/packages/nest/src/utils/versions.ts
@@ -1,6 +1,7 @@
 export const nxVersion = require('../../package.json').version;
 
-export const nestJsVersion = '^9.1.0';
+export const nestJsVersion = '^9.1.1';
+export const nestJsSchematicsVersion = '^9.1.0';
 export const rxjsVersion = '^7.8.0';
 export const reflectMetadataVersion = '^0.1.13';
 export const tsLibVersion = '^2.3.0';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

In the Angular 16 PR I updated the NestJS version to `^9.1.0` so the `@nestjs/schematics` installed version supported TS 5. This doesn't work correctly because there's no `9.1.0` version for `@nestjs/common` (somehow it was skipped).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The version for `@nestjs/schematics` is handled separately from the rest of `@nestjs/*` packages (they are not in sync). The version for the rest of the packages was bumped to an existing version (`^9.1.1`).

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16752
