### PR TITLE
fix(node): use correct version for @nestjs/common

### DIFF
--- a/packages/nest/src/utils/versions.ts
+++ b/packages/nest/src/utils/versions.ts
@@ -1,6 +1,6 @@
 export const nxVersion = require('../../package.json').version;
 
-export const nestJsVersion = '^9.1.0';
+export const nestJsVersion = '^9.1.1';
 export const rxjsVersion = '^7.8.0';
 export const reflectMetadataVersion = '^0.1.13';
 export const tsLibVersion = '^2.3.0';


### PR DESCRIPTION
The Angular 16 upgrade caused `@nestjs/common` to be installed at version `9.1.0`, which doesn't exist. This updates the version to `~9.1.1` which does exist.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16752
