### PR TITLE
fix(nextjs): add workspace dependencies to transpilePackages automatically

### DIFF
--- a/e2e/next/src/utils.ts
+++ b/e2e/next/src/utils.ts
@@ -14,13 +14,15 @@ export async function checkApp(
     checkLint: boolean;
     checkE2E: boolean;
     checkExport: boolean;
+    appsDir?: string;
   }
 ) {
+  const appsDir = opts.appsDir ?? 'apps';
   const buildResult = runCLI(`build ${appName}`);
   expect(buildResult).toContain(`Compiled successfully`);
-  checkFilesExist(`dist/apps/${appName}/.next/build-manifest.json`);
+  checkFilesExist(`dist/${appsDir}/${appName}/.next/build-manifest.json`);
 
-  const packageJson = readJson(`dist/apps/${appName}/package.json`);
+  const packageJson = readJson(`dist/${appsDir}/${appName}/package.json`);
   expect(packageJson.dependencies.react).toBeDefined();
   expect(packageJson.dependencies['react-dom']).toBeDefined();
   expect(packageJson.dependencies.next).toBeDefined();
@@ -45,6 +47,6 @@ export async function checkApp(
 
   if (opts.checkExport) {
     runCLI(`export ${appName}`);
-    checkFilesExist(`dist/apps/${appName}/exported/index.html`);
+    checkFilesExist(`dist/${appsDir}/${appName}/exported/index.html`);
   }
 }

--- a/packages/js/src/utils/buildable-libs-utils.ts
+++ b/packages/js/src/utils/buildable-libs-utils.ts
@@ -13,6 +13,7 @@ import { unlinkSync } from 'fs';
 import { output } from 'nx/src/utils/output';
 import { isNpmProject } from 'nx/src/project-graph/operators';
 import { ensureTypescript } from './typescript/ensure-typescript';
+import { readTsConfigPaths } from './typescript/ts-config';
 
 let tsModule: typeof import('typescript');
 
@@ -190,38 +191,9 @@ export function computeCompilerOptionsPaths(
   tsConfig: string | ts.ParsedCommandLine,
   dependencies: DependentBuildableProjectNode[]
 ) {
-  const paths = readPaths(tsConfig) || {};
+  const paths = readTsConfigPaths(tsConfig) || {};
   updatePaths(dependencies, paths);
   return paths;
-}
-
-function readPaths(tsConfig: string | ts.ParsedCommandLine) {
-  if (!tsModule) {
-    tsModule = ensureTypescript();
-  }
-  try {
-    let config: ts.ParsedCommandLine;
-    if (typeof tsConfig === 'string') {
-      const configFile = tsModule.readConfigFile(
-        tsConfig,
-        tsModule.sys.readFile
-      );
-      config = tsModule.parseJsonConfigFileContent(
-        configFile.config,
-        tsModule.sys,
-        dirname(tsConfig)
-      );
-    } else {
-      config = tsConfig;
-    }
-    if (config.options?.paths) {
-      return config.options.paths;
-    } else {
-      return null;
-    }
-  } catch (e) {
-    return null;
-  }
 }
 
 export function createTmpTsConfig(

--- a/packages/next/plugins/with-nx.spec.ts
+++ b/packages/next/plugins/with-nx.spec.ts
@@ -1,7 +1,7 @@
 import { NextConfigComplete } from 'next/dist/server/config-shared';
-import { getNextConfig } from './with-nx';
+import { getAliasForProject, getNextConfig } from './with-nx';
 
-describe('withNx', () => {
+describe('getNextConfig', () => {
   describe('svgr', () => {
     it('should be used by default', () => {
       const config = getNextConfig();
@@ -62,5 +62,57 @@ describe('withNx', () => {
         result.module.rules.some((rule) => rule.test?.test('cat.svg'))
       ).toBe(false);
     });
+  });
+});
+
+describe('getAliasForProject', () => {
+  it('should return the matching alias for a project', () => {
+    const paths = {
+      '@x/proj1': ['packages/proj1'],
+      // customized lookup paths with relative path syntax
+      '@x/proj2': ['./something-else', './packages/proj2'],
+    };
+
+    expect(
+      getAliasForProject(
+        {
+          name: 'proj1',
+          type: 'lib',
+          data: {
+            root: 'packages/proj1',
+            files: [],
+          },
+        },
+        paths
+      )
+    ).toEqual('@x/proj1');
+
+    expect(
+      getAliasForProject(
+        {
+          name: 'proj2',
+          type: 'lib',
+          data: {
+            root: 'packages/proj2', // relative path
+            files: [],
+          },
+        },
+        paths
+      )
+    ).toEqual('@x/proj2');
+
+    expect(
+      getAliasForProject(
+        {
+          name: 'no-alias',
+          type: 'lib',
+          data: {
+            root: 'packages/no-alias',
+            files: [],
+          },
+        },
+        paths
+      )
+    ).toEqual(null);
   });
 });

--- a/packages/next/src/utils/config.ts
+++ b/packages/next/src/utils/config.ts
@@ -107,3 +107,12 @@ function isTsRule(r: RuleSetRule): boolean {
 
   return r.test.test('a.ts');
 }
+
+// Runs a function if the Next.js version satisfies the range.
+export function forNextVersion(range: string, fn: () => void) {
+  const semver = require('semver');
+  const nextJsVersion = require('next/package.json').version;
+  if (semver.satisfies(nextJsVersion, range)) {
+    fn();
+  }
+}


### PR DESCRIPTION
There are issues with Next.js not transpiling workspace libraries (i.e. packages with aliases in tsconfig). You can see this problem even without Nx, where you have to manually specify `transpilePackages` if you use aliases.

See: https://github.com/jaysoo/next-with-libs/tree/no-nx

This PR adds a feature where we will automatically add those packages for the user since we know they need to be specified anyway.

Note: This only applies if the user is not using the apps/libs setup.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16658
