### PR TITLE
fix(misc): avoid writing unformatted json if prettier is available

### DIFF
--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -4,3 +4,4 @@
  * These may not be available in certain version of Nx, so be sure to check them first.
  */
 export { createTempNpmDirectory } from './utils/package-manager';
+export { formatChangedFilesWithPrettierIfAvailable } from './generators/internal-utils/format-changed-files-with-prettier-if-available';

--- a/packages/nx/src/generators/internal-utils/format-changed-files-with-prettier-if-available.ts
+++ b/packages/nx/src/generators/internal-utils/format-changed-files-with-prettier-if-available.ts
@@ -1,6 +1,8 @@
 import type { Tree } from '../tree';
 import * as path from 'path';
 import type * as Prettier from 'prettier';
+import { formatFileContentsWithPrettierIfAvailable } from '../../utils/prettier';
+import { readJson } from '../utils/json';
 
 /**
  * Formats all the created or updated files using Prettier
@@ -9,47 +11,39 @@ import type * as Prettier from 'prettier';
 export async function formatChangedFilesWithPrettierIfAvailable(
   tree: Tree
 ): Promise<void> {
-  let prettier: typeof Prettier;
-  try {
-    prettier = await import('prettier');
-  } catch {}
-
-  if (!prettier) return;
-
   const files = new Set(
     tree.listChanges().filter((file) => file.type !== 'DELETE')
   );
+
+  const changedPrettierInTree = getChangedPrettierConfigInTree(tree);
+
   await Promise.all(
     Array.from(files).map(async (file) => {
       const systemPath = path.join(tree.root, file.path);
-      let options: any = {
-        filepath: systemPath,
-      };
-
-      const resolvedOptions = await prettier.resolveConfig(systemPath, {
-        editorconfig: true,
-      });
-      if (!resolvedOptions) {
-        return;
-      }
-      options = {
-        ...options,
-        ...resolvedOptions,
-      };
-
-      const support = await prettier.getFileInfo(systemPath, options);
-      if (support.ignored || !support.inferredParser) {
-        return;
-      }
-
       try {
         tree.write(
           file.path,
-          prettier.format(file.content.toString('utf-8'), options)
+          await formatFileContentsWithPrettierIfAvailable(
+            systemPath,
+            file.content.toString('utf-8'),
+            changedPrettierInTree
+          )
         );
       } catch (e) {
         console.warn(`Could not format ${file.path}. Error: "${e.message}"`);
       }
     })
   );
+}
+
+function getChangedPrettierConfigInTree(tree: Tree): Prettier.Options | null {
+  if (tree.listChanges().find((file) => file.path === '.prettierrc')) {
+    try {
+      return readJson(tree, '.prettierrc');
+    } catch {
+      return null;
+    }
+  } else {
+    return null;
+  }
 }

--- a/packages/nx/src/utils/fileutils.ts
+++ b/packages/nx/src/utils/fileutils.ts
@@ -13,6 +13,10 @@ import {
 import { dirname } from 'path';
 import * as tar from 'tar-stream';
 import { createGunzip } from 'zlib';
+import {
+  formatFileContentsWithPrettierIfAvailable,
+  formatFileContentsWithPrettierIfAvailableSync,
+} from './prettier';
 
 export interface JsonReadOptions extends JsonParseOptions {
   /**
@@ -67,9 +71,10 @@ export function writeJsonFile<T extends object = object>(
 ): void {
   mkdirSync(dirname(path), { recursive: true });
   const serializedJson = serializeJson(data, options);
-  const content = options?.appendNewLine
-    ? `${serializedJson}\n`
-    : serializedJson;
+  const content = formatFileContentsWithPrettierIfAvailableSync(
+    path,
+    options?.appendNewLine ? `${serializedJson}\n` : serializedJson
+  );
   writeFileSync(path, content, { encoding: 'utf-8' });
 }
 

--- a/packages/nx/src/utils/prettier.ts
+++ b/packages/nx/src/utils/prettier.ts
@@ -1,0 +1,67 @@
+import type * as Prettier from 'prettier';
+
+let prettier: typeof Prettier | null;
+export function getPrettierOrNull() {
+  if (prettier === undefined) {
+    try {
+      prettier = require('prettier');
+    } catch (e) {
+      prettier = null;
+    }
+  }
+  return prettier;
+}
+
+export function formatFileContentsWithPrettierIfAvailableSync<
+  T extends string | Buffer
+>(path: string, contents: T, extraOptions?: Prettier.Options): string {
+  const prettier = getPrettierOrNull();
+  const contentsAsString =
+    typeof contents === 'string' ? contents : contents.toString('utf-8');
+  if (!prettier) {
+    return contentsAsString;
+  }
+
+  const resolvedOptions = prettier.resolveConfig.sync(path, {
+    editorconfig: true,
+  });
+  const options: Prettier.Options = {
+    ...resolvedOptions,
+    ...extraOptions,
+    filepath: path,
+  };
+
+  const support = prettier.getFileInfo.sync(path, options as any);
+  if (support.ignored || !support.inferredParser) {
+    return contentsAsString;
+  }
+
+  return prettier.format(contentsAsString, options);
+}
+
+export async function formatFileContentsWithPrettierIfAvailable<
+  T extends string | Buffer
+>(path: string, contents: T, extraOptions?: Prettier.Options): Promise<string> {
+  const prettier = getPrettierOrNull();
+  const contentsAsString =
+    typeof contents === 'string' ? contents : contents.toString('utf-8');
+  if (!prettier) {
+    return contentsAsString;
+  }
+
+  const resolvedOptions = await prettier.resolveConfig(path, {
+    editorconfig: true,
+  });
+  const options: Prettier.Options = {
+    ...resolvedOptions,
+    ...extraOptions,
+    filepath: path,
+  };
+
+  const support = await prettier.getFileInfo(path, options as any);
+  if (support.ignored || !support.inferredParser) {
+    return contentsAsString;
+  }
+
+  return prettier.format(contentsAsString, options);
+}

--- a/packages/plugin/src/generators/create-package/files/create-framework-package/bin/index.ts__tmpl__
+++ b/packages/plugin/src/generators/create-package/files/create-framework-package/bin/index.ts__tmpl__
@@ -12,7 +12,7 @@ async function main() {
 
   // This assumes "<%= preset %>" and "<%= projectName %>" are at the same version
   // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const presetVersion = require('../package.json').version,
+  const presetVersion = require('../package.json').version
 
   // TODO: update below to customize the workspace
   const { directory } = await createWorkspace(`<%= preset %>@${presetVersion}`, {

--- a/packages/workspace/src/migrations/update-16-0-0/move-workspace-generators-to-local-plugin.spec.ts
+++ b/packages/workspace/src/migrations/update-16-0-0/move-workspace-generators-to-local-plugin.spec.ts
@@ -24,7 +24,6 @@ describe('move-workspace-generators-to-local-plugin', () => {
       name: 'my-generator',
     });
     await generator(tree);
-    console.log(getProjects(tree).keys());
     const config = readProjectConfiguration(tree, 'workspace-plugin');
     expect(config.root).toEqual('tools/workspace-plugin');
 

--- a/packages/workspace/src/migrations/update-16-0-0/move-workspace-generators-to-local-plugin.ts
+++ b/packages/workspace/src/migrations/update-16-0-0/move-workspace-generators-to-local-plugin.ts
@@ -187,7 +187,7 @@ async function createNewPlugin(tree: Tree) {
     e2eTestRunner: 'none',
     publishable: false,
   });
-  getCreateGeneratorsJson()(
+  await getCreateGeneratorsJson()(
     tree,
     readProjectConfiguration(tree, PROJECT_NAME).root,
     PROJECT_NAME
@@ -209,6 +209,7 @@ function moveGeneratedPlugin(
       updateImportPath: true,
       destinationRelativeToRoot: true,
       importPath: importPath,
+      skipFormat: true,
     });
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We write JSON files without any kind of formatting in several places (e.g. migrate, nx init, graph --file). 

## Expected Behavior
If prettier is available, its used to format the file.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #8928
