### PR TITLE
fix(core): obey nx.json package manager property

### DIFF
--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -8,6 +8,7 @@ import { writeJsonFile } from './fileutils';
 import { readModulePackageJson } from './package-json';
 import { gte, lt } from 'semver';
 import { workspaceRoot } from './workspace-root';
+import { readNxJson } from '../config/configuration';
 
 const execAsync = promisify(exec);
 
@@ -28,7 +29,8 @@ export interface PackageManagerCommands {
  * Detects which package manager is used in the workspace based on the lock file.
  */
 export function detectPackageManager(dir: string = ''): PackageManager {
-  return existsSync(join(dir, 'yarn.lock'))
+  const nxJson = readNxJson();
+  return nxJson.cli?.packageManager ?? existsSync(join(dir, 'yarn.lock'))
     ? 'yarn'
     : existsSync(join(dir, 'pnpm-lock.yaml'))
     ? 'pnpm'


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`nx.json` has a property, `cli.packageManager`, that we never read. It is documented, but we don't use it opting to instead detect the package manager based on the lock files present.

This is generally safe, and mostly works, but can cause the incorrect package manager to be used in the cases where:
 - There is no lock file
 - There are multiple lock files
 - The lock file is located in a parent directory (the case for #10480)

## Expected Behavior
If `cli.packageManager` is set, we use it. If not (which is the case for **_most_** repos), we use our current detection logic.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #10480
