### PR TITLE
fix(misc): make Nx 16 migration safer when treee throws an exception

### DIFF
--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -1558,7 +1558,7 @@ async function runNxMigration(
     name
   );
   const fn = require(implPath)[fnSymbol];
-  const host = new FsTree(root, false);
+  const host = new FsTree(root, process.env.NX_VERBOSE_LOGGING === 'true');
   await fn(host, {});
   host.lock();
   const changes = host.listChanges();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
