### PR TITLE
fix(core): match all occurences when substituting tokens in targetDef…

### DIFF
--- a/packages/nx/src/config/workspaces.ts
+++ b/packages/nx/src/config/workspaces.ts
@@ -958,8 +958,8 @@ function resolvePathTokensInOptions<T extends Object | Array<unknown>>(
           `${NX_PREFIX} The {workspaceRoot} token is only valid at the beginning of an option. (${key})`
         );
       }
-      value = value.replace('{projectRoot}', project.root);
-      result[opt] = value.replace('{projectName}', project.name);
+      value = value.replace(/\{projectRoot\}/g, project.root);
+      result[opt] = value.replace(/\{projectName\}/g, project.name);
     } else if (typeof value === 'object' && value) {
       result[opt] = resolvePathTokensInOptions(
         value,


### PR DESCRIPTION
…aults

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Target defaults containing this:

```json
    "publish": {
      "executor": "nx:run-commands",
      "options": {
        "commands": [
          "echo first: {projectName} second: {projectName}"
        ],
        "parallel": false
      }
    }
```

Only replace the first occurence of projectName

## Expected Behavior
All occurences of a token are replaced.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15983
