### PR TITLE
feat(misc): migrate nx:run-commands outputPath property to outputs array

### DIFF
--- a/docs/generated/packages/nx/executors/run-commands.json
+++ b/docs/generated/packages/nx/executors/run-commands.json
@@ -103,13 +103,6 @@
         "description": "Use colors when showing output of command.",
         "default": false
       },
-      "outputPath": {
-        "description": "Allows you to specify where the build artifacts are stored. This allows Nx Cloud to pick them up correctly, in the case that the build artifacts are placed somewhere other than the top level dist folder.",
-        "oneOf": [
-          { "type": "string" },
-          { "type": "array", "items": { "type": "string" } }
-        ]
-      },
       "cwd": {
         "type": "string",
         "description": "Current working directory of the commands. If it's not specified the commands will run in the workspace root, if a relative path is specified the commands will run in that path relative to the workspace root and if it's an absolute path the commands will run in that path."

--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -71,6 +71,12 @@
       "version": "16.0.0-beta.0",
       "description": "Replace @nrwl/nx-cloud with nx-cloud",
       "implementation": "./src/migrations/update-16-0-0/update-nx-cloud-runner"
+    },
+    "16.2.0-remove-output-path-from-run-commands": {
+      "cli": "nx",
+      "version": "16.2.0-beta.0",
+      "description": "Remove outputPath from run commands",
+      "implementation": "./src/migrations/update-16-2-0/remove-run-commands-output-path"
     }
   }
 }

--- a/packages/nx/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.ts
@@ -45,7 +45,6 @@ export interface RunCommandsOptions extends Json {
   cwd?: string;
   args?: string;
   envFile?: string;
-  outputPath?: string;
   __unparsed__: string[];
 }
 
@@ -58,7 +57,6 @@ const propKeys = [
   'cwd',
   'args',
   'envFile',
-  'outputPath',
 ];
 
 export interface NormalizedRunCommandsOptions extends RunCommandsOptions {

--- a/packages/nx/src/executors/run-commands/schema.json
+++ b/packages/nx/src/executors/run-commands/schema.json
@@ -111,20 +111,6 @@
       "description": "Use colors when showing output of command.",
       "default": false
     },
-    "outputPath": {
-      "description": "Allows you to specify where the build artifacts are stored. This allows Nx Cloud to pick them up correctly, in the case that the build artifacts are placed somewhere other than the top level dist folder.",
-      "oneOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      ]
-    },
     "cwd": {
       "type": "string",
       "description": "Current working directory of the commands. If it's not specified the commands will run in the workspace root, if a relative path is specified the commands will run in that path relative to the workspace root and if it's an absolute path the commands will run in that path."

--- a/packages/nx/src/migrations/update-16-2-0/remove-run-commands-output-path.spec.ts
+++ b/packages/nx/src/migrations/update-16-2-0/remove-run-commands-output-path.spec.ts
@@ -1,0 +1,81 @@
+import { TargetConfiguration } from '../../config/workspace-json-project-json';
+import { createTreeWithEmptyWorkspace } from '../../generators/testing-utils/create-tree-with-empty-workspace';
+import { readJson, writeJson } from '../../generators/utils/json';
+import {
+  addProjectConfiguration,
+  readProjectConfiguration,
+} from '../../generators/utils/project-configuration';
+import removeRunCommandsOutputPath from './remove-run-commands-output-path';
+
+describe('removeRunCommandsOutputPath', () => {
+  it('should migrate target options correctly', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    const startingTargets: Record<string, TargetConfiguration> = {
+      build: {
+        executor: 'nx:run-commands',
+        outputs: ['{options.outputPath}'],
+        options: {
+          outputPath: 'dist/apps/my-app',
+          commands: [],
+        },
+      },
+      other: {
+        executor: 'nx:run-script',
+        options: {
+          script: 'start',
+        },
+      },
+    };
+    addProjectConfiguration(tree, 'my-app', {
+      root: 'apps/my-app',
+      targets: startingTargets,
+    });
+    removeRunCommandsOutputPath(tree);
+    const migratedTargets = readProjectConfiguration(tree, 'my-app').targets;
+    expect(migratedTargets.build).not.toEqual(startingTargets.build);
+    expect(migratedTargets.build).toEqual({
+      executor: 'nx:run-commands',
+      outputs: ['dist/apps/my-app'],
+      options: {
+        commands: [],
+      },
+    });
+    expect(migratedTargets.other).toEqual(startingTargets.other);
+  });
+
+  it('should migrate target defaults correctly', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    const startingTargetDefaults: Record<string, TargetConfiguration> = {
+      build: {
+        executor: 'nx:run-commands',
+        outputs: ['{options.outputPath}'],
+        options: {
+          outputPath: 'dist/apps/my-app',
+          commands: [],
+        },
+      },
+      other: {
+        executor: 'nx:run-script',
+        options: {
+          script: 'start',
+        },
+      },
+    };
+    writeJson(tree, 'nx.json', {
+      targetDefaults: startingTargetDefaults,
+    });
+    removeRunCommandsOutputPath(tree);
+    const migratedTargetDefaults = readJson(tree, 'nx.json').targetDefaults;
+    expect(migratedTargetDefaults.build).not.toEqual(
+      startingTargetDefaults.build
+    );
+    expect(migratedTargetDefaults.build).toEqual({
+      executor: 'nx:run-commands',
+      outputs: ['dist/apps/my-app'],
+      options: {
+        commands: [],
+      },
+    });
+    expect(migratedTargetDefaults.other).toEqual(startingTargetDefaults.other);
+  });
+});

--- a/packages/nx/src/migrations/update-16-2-0/remove-run-commands-output-path.ts
+++ b/packages/nx/src/migrations/update-16-2-0/remove-run-commands-output-path.ts
@@ -1,0 +1,49 @@
+import { NxJsonConfiguration } from '../../config/nx-json';
+import { TargetConfiguration } from '../../config/workspace-json-project-json';
+import { formatChangedFilesWithPrettierIfAvailable } from '../../generators/internal-utils/format-changed-files-with-prettier-if-available';
+import { Tree } from '../../generators/tree';
+import { updateJson } from '../../generators/utils/json';
+import {
+  getProjects,
+  updateProjectConfiguration,
+} from '../../generators/utils/project-configuration';
+
+export default async function removeRunCommandsOutputPath(tree: Tree) {
+  for (const [project, configuration] of getProjects(tree).entries()) {
+    const targets = configuration.targets ?? {};
+    let changed = false;
+    for (const [, target] of Object.entries(targets)) {
+      changed ||= updateTargetBlock(target);
+    }
+    if (changed) {
+      updateProjectConfiguration(tree, project, configuration);
+    }
+  }
+  if (tree.exists('nx.json')) {
+    updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+      for (const [, target] of Object.entries(json.targetDefaults ?? {})) {
+        updateTargetBlock(target);
+      }
+      return json;
+    });
+  }
+  await formatChangedFilesWithPrettierIfAvailable(tree);
+}
+
+function updateTargetBlock(target: TargetConfiguration): boolean {
+  let changed = false;
+  if (target.executor === 'nx:run-commands' && target.options.outputPath) {
+    changed = true;
+    const outputs = new Set(target.outputs ?? []);
+    outputs.delete('{options.outputPath}');
+    const newOutputs = Array.isArray(target.options.outputPath)
+      ? target.options.outputPath
+      : [target.options.outputPath];
+    for (const outputPath of newOutputs) {
+      outputs.add(outputPath);
+    }
+    delete target.options.outputPath;
+    target.outputs = Array.from(outputs);
+  }
+  return changed;
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`nx:run-commands` supports an `outputPath` property which does absolutely nothing, but can be referenced by outputs

## Expected Behavior
`outputs` is used directly

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
