### PR TITLE
fix(react): remove outdated packages

### DIFF
--- a/packages/react/migrations.json
+++ b/packages/react/migrations.json
@@ -89,6 +89,12 @@
       "version": "16.0.0-beta.1",
       "description": "Replace @nrwl/react with @nx/react",
       "implementation": "./src/migrations/update-16-0-0-add-nx-packages/update-16-0-0-add-nx-packages"
+    },
+    "update-16-1-0-remove-package": {
+      "cli": "nx",
+      "version": "16.1.0-beta.0",
+      "description": "Remove react-test-renderer from package.json",
+      "implementation": "./src/migrations/update-16-1-0-remove-package/update-16-1-0-remove-package"
     }
   },
   "packageJsonUpdates": {

--- a/packages/react/src/generators/init/init.ts
+++ b/packages/react/src/generators/init/init.ts
@@ -16,7 +16,6 @@ import {
   babelPresetReactVersion,
   nxVersion,
   reactDomVersion,
-  reactTestRendererVersion,
   reactVersion,
   testingLibraryReactVersion,
   tsLibVersion,
@@ -63,7 +62,6 @@ function updateDependencies(host: Tree, schema: InitSchema) {
     '@types/react': typesReactVersion,
     '@types/react-dom': typesReactDomVersion,
     '@testing-library/react': testingLibraryReactVersion,
-    'react-test-renderer': reactTestRendererVersion,
   });
 }
 

--- a/packages/react/src/migrations/update-16-1-0-remove-package/update-16-1-0-remove-package.spec.ts
+++ b/packages/react/src/migrations/update-16-1-0-remove-package/update-16-1-0-remove-package.spec.ts
@@ -1,0 +1,23 @@
+import { Tree, readJson, updateJson } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from 'nx/src/devkit-testing-exports';
+import removePackage from './update-16-1-0-remove-package';
+
+describe('update-16-1-0-remove-package', () => {
+  let tree: Tree;
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+
+    updateJson(tree, 'package.json', (json) => {
+      json.devDependencies['react-test-renderer'] = '18.2.0';
+      return json;
+    });
+  });
+
+  it('should remove react-test-renderer from package.json', async () => {
+    await removePackage(tree);
+
+    expect(
+      readJson(tree, 'package.json').devDependencies['react-test-renderer']
+    ).not.toBeDefined();
+  });
+});

--- a/packages/react/src/migrations/update-16-1-0-remove-package/update-16-1-0-remove-package.ts
+++ b/packages/react/src/migrations/update-16-1-0-remove-package/update-16-1-0-remove-package.ts
@@ -1,0 +1,10 @@
+import {
+  Tree,
+  formatFiles,
+  removeDependenciesFromPackageJson,
+} from '@nx/devkit';
+
+export default async function removePackage(tree: Tree): Promise<void> {
+  removeDependenciesFromPackageJson(tree, [], ['react-test-renderer']);
+  await formatFiles(tree);
+}

--- a/packages/web/migrations.json
+++ b/packages/web/migrations.json
@@ -71,6 +71,12 @@
       "version": "16.0.0-beta.4",
       "description": "Replace @nrwl/web executors with @nx/webpack and @nx/rollup",
       "implementation": "./src/migrations/update-16-0-0-update-executors/update-16-0-0-update-executors"
+    },
+    "update-16-1-0-remove-packages": {
+      "cli": "nx",
+      "version": "16.1.0-beta.0",
+      "description": "Remove core-js and regenerator-runtime packages",
+      "implementation": "./src/migrations/update-16-1-0-remove-packages/update-16-1-0-remove-packages"
     }
   },
   "packageJsonUpdates": {

--- a/packages/web/src/generators/init/init.ts
+++ b/packages/web/src/generators/init/init.ts
@@ -29,8 +29,6 @@ function updateDependencies(tree: Tree, schema: Schema) {
   return addDependenciesToPackageJson(
     tree,
     {
-      'core-js': '^3.6.5',
-      'regenerator-runtime': '0.13.7',
       tslib: tsLibVersion,
     },
     devDependencies

--- a/packages/web/src/migrations/update-16-1-0-remove-packages/update-16-1-0-remove-packages.spec.ts
+++ b/packages/web/src/migrations/update-16-1-0-remove-packages/update-16-1-0-remove-packages.spec.ts
@@ -1,0 +1,27 @@
+import { Tree, readJson, updateJson } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from 'nx/src/devkit-testing-exports';
+import removePackages from './update-16-1-0-remove-packages';
+
+describe('update-16-1-0-remove-packages', () => {
+  let tree: Tree;
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+
+    updateJson(tree, 'package.json', (json) => {
+      json.dependencies['core-js'] = '3.6.5';
+      json.dependencies['regenerator-runtime'] = '0.13.7';
+      return json;
+    });
+  });
+
+  it('should remove core-js & regenerator-runtime packages', async () => {
+    await removePackages(tree);
+
+    expect(
+      readJson(tree, 'package.json').dependencies['core-js']
+    ).not.toBeDefined();
+    expect(
+      readJson(tree, 'package.json').dependencies['regenerator-runtime']
+    ).not.toBeDefined();
+  });
+});

--- a/packages/web/src/migrations/update-16-1-0-remove-packages/update-16-1-0-remove-packages.ts
+++ b/packages/web/src/migrations/update-16-1-0-remove-packages/update-16-1-0-remove-packages.ts
@@ -1,0 +1,15 @@
+import {
+  Tree,
+  formatFiles,
+  removeDependenciesFromPackageJson,
+} from '@nx/devkit';
+
+export default async function removePackages(tree: Tree): Promise<void> {
+  removeDependenciesFromPackageJson(
+    tree,
+    ['core-js', 'regenerator-runtime'],
+    []
+  );
+
+  await formatFiles(tree);
+}


### PR DESCRIPTION
The features should be available by default or they are available via a different library.
Example
`react-test-renderer` -> `@testing-library`

closed #11882
