### PR TITLE
fix(repo): remove outdated caching config from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,31 +10,12 @@ orbs:
   browser-tools: circleci/browser-tools@1.4.0
 
 # -------------------------
-#        DEFAULTS
+#        EXECUTORS
 # -------------------------
-machine:
-  pre:
-    - mkdir ~/.pnpm-store
-    - mkdir ~/.cache/Cypress
-    - mkdir ~/Library/Caches/Homebrew
-    - mkdir /usr/local/Homebrew
-
-dependencies:
-  cache_directories:
-    - ~/.pnpm-store
-    - ~/.cache/Cypress
-    - /usr/local/Homebrew
-    - ~/Library/Caches/Homebrew
-  override:
-    - pnpm install
-    - brew install
 
 defaults: &defaults
   working_directory: ~/repo
 
-# -------------------------
-#        EXECUTORS
-# -------------------------
 executors:
   linux:
     <<: *defaults


### PR DESCRIPTION
The CircleCI config contains outdated caching definitions that are no longer utilised.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
