### PR TITLE
fix(core): handle schema property with const value

### DIFF
--- a/packages/nx/src/utils/params.spec.ts
+++ b/packages/nx/src/utils/params.spec.ts
@@ -982,6 +982,27 @@ describe('params', () => {
         ).not.toThrow();
       });
 
+      it('should handle const value', () => {
+        const schema = {
+          properties: {
+            a: {
+              const: 3,
+            },
+          },
+        };
+        expect(() => validateOptsAgainstSchema({ a: 3 }, schema)).not.toThrow();
+        expect(() =>
+          validateOptsAgainstSchema({ a: true }, schema)
+        ).toThrowErrorMatchingInlineSnapshot(
+          `"Property 'a' does not match the schema. 'true' should be '3'."`
+        );
+        expect(() =>
+          validateOptsAgainstSchema({ a: 123 }, schema)
+        ).toThrowErrorMatchingInlineSnapshot(
+          `"Property 'a' does not match the schema. '123' should be '3'."`
+        );
+      });
+
       describe('array', () => {
         it('should handle validating patterns', () => {
           const schema = {

--- a/packages/nx/src/utils/params.ts
+++ b/packages/nx/src/utils/params.ts
@@ -33,6 +33,7 @@ type PropertyDescription = {
     | { $source: 'projectName' }
     | { $source: 'unparsed' };
   additionalProperties?: boolean;
+  const?: any;
   'x-prompt'?:
     | string
     | { message: string; type: string; items?: any[]; multiselect?: boolean };
@@ -359,6 +360,12 @@ function validateProperty(
 
   const isPrimitive = typeof value !== 'object';
   if (isPrimitive) {
+    if (schema.const !== undefined && value !== schema.const) {
+      throw new SchemaError(
+        `Property '${propName}' does not match the schema. '${value}' should be '${schema.const}'.`
+      );
+    }
+
     if (Array.isArray(schema.type)) {
       const passes = schema.type.some((t) => {
         try {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The schema validation doesn't support a property with a `const` value. The validation doesn't throw when a `const` value is specified and it's not matched.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The schema validation should support a property with a `const` value and should throw if specified and the provided value doesn't match.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16790 
