### PR TITLE
fix(nextjs): increase timeout on styles e2e test

### DIFF
--- a/e2e/next/src/next-styles.test.ts
+++ b/e2e/next/src/next-styles.test.ts
@@ -66,5 +66,5 @@ describe('Next.js apps', () => {
       checkE2E: false,
       checkExport: false,
     });
-  }, 300_000);
+  }, 600_000);
 });


### PR DESCRIPTION
Re-enabled test fails with timeout on nightly. This PR increases the timeout for the test.

![Screenshot 2023-05-05 at 11 35 43](https://user-images.githubusercontent.com/881612/236424418-ed0529bc-bd7a-43d7-9bfb-54b1e236ec0a.png)

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
