### PR TITLE
fix(core): register task timings correctly in task profiling life cycle

### DIFF
--- a/packages/nx/src/tasks-runner/life-cycles/task-profiling-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/task-profiling-life-cycle.ts
@@ -26,7 +26,7 @@ export class TaskProfilingLifeCycle implements LifeCycle {
       this.registerGroup(groupId);
     }
     for (let t of tasks) {
-      this.timings[`${t.target.project}:${t.target.target}`] = {
+      this.timings[t.id] = {
         perfStart: performance.now(),
       };
     }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

In the `TaskProfilingLifeCycle` class the task timings are registered with a manually crafted key instead of using the task id. When processing the task results, timings are set with the task id which throws because of the mismatch.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

In the `TaskProfilingLifeCycle` class the task timings should be registered with the task id.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16792 
