### PR TITLE
fix(repo): fix nightly registry failing on windows

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -334,7 +334,6 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
           cache: 'pnpm'
-          registry-url: http://localhost:4872
 
       - name: Cache node_modules
         id: cache-modules

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -260,7 +260,6 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
           cache: 'pnpm'
-          registry-url: http://localhost:4872
 
       - name: Cache node_modules
         id: cache-modules


### PR DESCRIPTION
Local registry on Windows is failing the pnpm installation.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
