### PR TITLE
fix(angular): handle ngrx imports for apps that do not migrate to config file

### DIFF
--- a/packages/angular/src/generators/ngrx/lib/add-imports-to-module.ts
+++ b/packages/angular/src/generators/ngrx/lib/add-imports-to-module.ts
@@ -6,6 +6,7 @@ import type { SourceFile } from 'typescript';
 import {
   addImportToModule,
   addProviderToAppConfig,
+  addProviderToBootstrapApplication,
   addProviderToModule,
 } from '../../../utils/nx-devkit/ast-utils';
 import type { NormalizedNgRxGeneratorOptions } from './normalize-options';
@@ -23,8 +24,11 @@ function addRootStoreImport(
   storeForRoot: string
 ) {
   if (isParentStandalone) {
-    if (tree.read(parentPath, 'utf-8').includes('ApplicationConfig')) {
+    const parentContents = tree.read(parentPath, 'utf-8');
+    if (parentContents.includes('ApplicationConfig')) {
       addProviderToAppConfig(tree, parentPath, provideRootStore);
+    } else if (parentContents.includes('bootstrapApplication')) {
+      addProviderToBootstrapApplication(tree, parentPath, provideRootStore);
     } else {
       addProviderToRoute(tree, parentPath, route, provideRootStore);
     }
@@ -44,8 +48,11 @@ function addRootEffectsImport(
   effectsForEmptyRoot: string
 ) {
   if (isParentStandalone) {
-    if (tree.read(parentPath, 'utf-8').includes('ApplicationConfig')) {
+    const parentContents = tree.read(parentPath, 'utf-8');
+    if (parentContents.includes('ApplicationConfig')) {
       addProviderToAppConfig(tree, parentPath, provideRootEffects);
+    } else if (parentContents.includes('bootstrapApplication')) {
+      addProviderToBootstrapApplication(tree, parentPath, provideRootEffects);
     } else {
       addProviderToRoute(tree, parentPath, route, provideRootEffects);
     }
@@ -91,8 +98,15 @@ function addStoreForFeatureImport(
   storeForFeature: string
 ) {
   if (isParentStandalone) {
-    if (tree.read(parentPath, 'utf-8').includes('ApplicationConfig')) {
+    const parentContents = tree.read(parentPath, 'utf-8');
+    if (parentContents.includes('ApplicationConfig')) {
       addProviderToAppConfig(tree, parentPath, provideStoreForFeature);
+    } else if (parentContents.includes('bootstrapApplication')) {
+      addProviderToBootstrapApplication(
+        tree,
+        parentPath,
+        provideStoreForFeature
+      );
     } else {
       addProviderToRoute(tree, parentPath, route, provideStoreForFeature);
     }
@@ -117,8 +131,15 @@ function addEffectsForFeatureImport(
   effectsForFeature: string
 ) {
   if (isParentStandalone) {
-    if (tree.read(parentPath, 'utf-8').includes('ApplicationConfig')) {
+    const parentContents = tree.read(parentPath, 'utf-8');
+    if (parentContents.includes('ApplicationConfig')) {
       addProviderToAppConfig(tree, parentPath, provideEffectsForFeature);
+    } else if (parentContents.includes('bootstrapApplication')) {
+      addProviderToBootstrapApplication(
+        tree,
+        parentPath,
+        provideEffectsForFeature
+      );
     } else {
       addProviderToRoute(tree, parentPath, route, provideEffectsForFeature);
     }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We assume everyone migrates to the app.config.ts file for the ngrx to function correctly when using standalone apis

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
some users may skip this migration, therefore we should still handle bootstrapApplication

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
