### PR TITLE
fix(misc): update URL to point to live page for plugin registry

### DIFF
--- a/packages/nx/src/command-line/list/list.ts
+++ b/packages/nx/src/command-line/list/list.ts
@@ -54,7 +54,7 @@ export async function listHandler(args: ListArgs): Promise<void> {
       bodyLines: [
         'Looking for a technology / framework not listed above?',
         'There are many excellent plugins matintained by the Nx community.',
-        'Search for the one you need here: https://nx.dev/community.',
+        'Search for the one you need here: https://nx.dev/plugins/registry.',
       ],
     });
 


### PR DESCRIPTION
This PR moved the page: https://github.com/nrwl/nx/pull/16314 
