### PR TITLE
fix(nextjs): enable Next.js 13.4 support

### DIFF
--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -156,6 +156,15 @@ function withNx(
   _nextConfig = {} as WithNxOptions,
   context: WithNxContext = getWithNxContext()
 ): NextConfigFn {
+  // If this is not set user will see compile errors in Next.js 13.4.
+  // See: https://github.com/nrwl/nx/issues/16692, https://github.com/vercel/next.js/issues/49169
+  // TODO(jack): Remove this once Nx is refactored to invoke CLI directly.
+  forNextVersion('>=13.4.0', () => {
+    process.env['__NEXT_PRIVATE_PREBUNDLED_REACT'] =
+      // Not in Next 13.3 or earlier, so need to access config via string
+      _nextConfig.experimental['serverActions'] ? 'experimental' : 'next';
+  });
+
   return async (phase: string) => {
     const { PHASE_PRODUCTION_SERVER } = await import('next/constants');
     if (phase === PHASE_PRODUCTION_SERVER) {


### PR DESCRIPTION
Adds a missing environment variable needed to override `react` and `react-dom` to use the once bundled into Next.js itself. Note: This will not be needed once we invoke Next.js CLI directly.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16692
