### PR TITLE
fix(core): migrate using yarn when nxJson has another package manager configured

### DIFF
--- a/packages/nx/src/utils/package-manager.spec.ts
+++ b/packages/nx/src/utils/package-manager.spec.ts
@@ -1,0 +1,43 @@
+jest.mock('fs');
+import * as fs from 'fs';
+import * as configModule from 'nx/src/config/configuration';
+import { detectPackageManager } from 'nx/src/utils/package-manager';
+
+describe('package-manager', () => {
+  it('should detect package manager in nxJson', () => {
+    jest.spyOn(configModule, 'readNxJson').mockReturnValueOnce({
+      cli: {
+        packageManager: 'pnpm',
+      },
+    });
+    const packageManager = detectPackageManager();
+    expect(packageManager).toEqual('pnpm');
+    expect(fs.existsSync).not.toHaveBeenCalled();
+  });
+
+  it('should detect yarn package manager from yarn.lock', () => {
+    jest.spyOn(configModule, 'readNxJson').mockReturnValueOnce({});
+    (fs.existsSync as jest.Mock).mockReturnValueOnce(true);
+    const packageManager = detectPackageManager();
+    expect(packageManager).toEqual('yarn');
+    expect(fs.existsSync).toHaveBeenNthCalledWith(1, 'yarn.lock');
+  });
+
+  it('should detect pnpm package manager from pnpm-lock.yaml', () => {
+    jest.spyOn(configModule, 'readNxJson').mockReturnValueOnce({});
+    (fs.existsSync as jest.Mock).mockImplementation((path) => {
+      return path === 'pnpm-lock.yaml';
+    });
+    const packageManager = detectPackageManager();
+    expect(packageManager).toEqual('pnpm');
+    expect(fs.existsSync).toHaveBeenCalledTimes(3);
+  });
+
+  it('should use npm package manager as default', () => {
+    jest.spyOn(configModule, 'readNxJson').mockReturnValueOnce({});
+    (fs.existsSync as jest.Mock).mockReturnValue(false);
+    const packageManager = detectPackageManager();
+    expect(packageManager).toEqual('npm');
+    expect(fs.existsSync).toHaveBeenCalledTimes(5);
+  });
+});

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -30,11 +30,14 @@ export interface PackageManagerCommands {
  */
 export function detectPackageManager(dir: string = ''): PackageManager {
   const nxJson = readNxJson();
-  return nxJson.cli?.packageManager ?? existsSync(join(dir, 'yarn.lock'))
-    ? 'yarn'
-    : existsSync(join(dir, 'pnpm-lock.yaml'))
-    ? 'pnpm'
-    : 'npm';
+  return (
+    nxJson.cli?.packageManager ??
+    (existsSync(join(dir, 'yarn.lock'))
+      ? 'yarn'
+      : existsSync(join(dir, 'pnpm-lock.yaml'))
+      ? 'pnpm'
+      : 'npm')
+  );
 }
 
 /**


### PR DESCRIPTION
`nx test nx` now tests the `detectPackageManager` function

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`nx migrate --run-migrations` uses `yarn` despite `nx.json` configuration.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`nx migrate --run-migrations` should respect `nx.json` configuration.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16836
