### PR TITLE
fix(nextjs): error caused by undefined 'serverActions'

### DIFF
--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -162,7 +162,9 @@ function withNx(
   forNextVersion('>=13.4.0', () => {
     process.env['__NEXT_PRIVATE_PREBUNDLED_REACT'] =
       // Not in Next 13.3 or earlier, so need to access config via string
-      _nextConfig.experimental['serverActions'] ? 'experimental' : 'next';
+      _nextConfig.experimental && _nextConfig.experimental['serverActions']
+        ? 'experimental'
+        : 'next';
   });
 
   return async (phase: string) => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
This PR addresses a bug introduced in the PR https://github.com/nrwl/nx/pull/16819, which caused a TypeError when running NextJS 13.4 with the '_nextConfig.experimental' object missing the 'serverActions' property. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The fix involves adding checks to ensure that both the '_nextConfig.experimental' object and 'serverActions' property are defined before attempting to access them. If 'serverActions' is undefined, the code defaults to using 'next'.
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16845