### PR TITLE
feat(angular): update jest-preset-angular to support angular v16

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -1110,6 +1110,22 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "16.1.3-jest": {
+      "version": "16.1.3-beta.0",
+      "requires": {
+        "@angular-devkit/build-angular": ">=13.0.0 <17.0.0",
+        "@angular/compiler-cli": ">=13.0.0 <17.0.0",
+        "@angular/core": ">=13.0.0 <17.0.0",
+        "@angular/platform-browser-dynamic": ">=13.0.0 <17.0.0",
+        "jest": "^29.0.0"
+      },
+      "packages": {
+        "jest-preset-angular": {
+          "version": "~13.1.0",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/angular/src/utils/versions.ts
+++ b/packages/angular/src/utils/versions.ts
@@ -25,6 +25,6 @@ export const postcssUrlVersion = '~10.1.3';
 export const autoprefixerVersion = '^10.4.0';
 export const tsNodeVersion = '10.9.1';
 
-export const jestPresetAngularVersion = '~13.0.0';
+export const jestPresetAngularVersion = '~13.1.0';
 export const typesNodeVersion = '16.11.7';
 export const jasmineMarblesVersion = '^0.9.2';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `jest-preset-angular` version used is not compatible with Angular v16.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `jest-preset-angular` version used should be compatible with Angular v16.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16794 
