### PR TITLE
fix(misc): ensure workspace directory is normalized correctly

### DIFF
--- a/packages/create-nx-workspace/src/create-empty-workspace.ts
+++ b/packages/create-nx-workspace/src/create-empty-workspace.ts
@@ -32,7 +32,8 @@ export async function createEmptyWorkspace<T extends CreateWorkspaceOptions>(
     options.packageManager = packageManager;
   }
 
-  const directory = getFileName(name);
+  options.name = getFileName(name);
+  const directory = options.name;
 
   const args = unparse({
     ...options,
@@ -40,7 +41,7 @@ export async function createEmptyWorkspace<T extends CreateWorkspaceOptions>(
 
   const pmc = getPackageManagerCommand(packageManager);
 
-  const command = `new ${directory} ${args}`;
+  const command = `new ${args}`;
 
   const workingDir = process.cwd().replace(/\\/g, '/');
   let nxWorkspaceRoot = `"${workingDir}"`;

--- a/packages/workspace/src/generators/new/new.ts
+++ b/packages/workspace/src/generators/new/new.ts
@@ -120,7 +120,7 @@ function normalizeOptions(options: Schema): NormalizedSchema {
 
   normalized.name = names(options.name).fileName;
   if (!options.directory) {
-    normalized.directory = options.name;
+    normalized.directory = normalized.name;
   }
 
   const parsed = parsePresetName(options.preset);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When creating a new workspace a providing a repo name with `_` in it, an error is thrown due to a mismatch in the directory name used by the `new` generator vs the `create-nx-workspace` functionality. This mainly happens because the `new` generator is invoked with the non-normalized name and this generator wrongly sets the `directory` to that value instead of setting it with the normalized name.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Creating a new workspace providing a repo name with `_` should not throw an error.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16841 
