### PR TITLE
feat(linter): allow ESLint Flat Config to be opted into manually

### DIFF
--- a/packages/linter/src/executors/eslint/lint.impl.spec.ts
+++ b/packages/linter/src/executors/eslint/lint.impl.spec.ts
@@ -21,7 +21,7 @@ const mockLintFiles = jest.fn().mockImplementation(() => mockReports);
 class MockESLint {
   static version = VALID_ESLINT_VERSION;
   static outputFixes = mockOutputFixes;
-  static getErrorResults = jest.requireActual('ESLint').ESLint.getErrorResults;
+  static getErrorResults = jest.requireActual('eslint').ESLint.getErrorResults;
   loadFormatter = mockLoadFormatter;
   isPathIgnored = mockIsPathIgnored;
   lintFiles = mockLintFiles;

--- a/packages/linter/src/executors/eslint/lint.impl.ts
+++ b/packages/linter/src/executors/eslint/lint.impl.ts
@@ -1,11 +1,10 @@
-import type { ExecutorContext } from '@nx/devkit';
+import { ExecutorContext, joinPathFragments } from '@nx/devkit';
 import { ESLint } from 'eslint';
-
-import { writeFileSync, mkdirSync } from 'fs';
+import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { dirname, join, resolve } from 'path';
 
 import type { Schema } from './schema';
-import { lint, loadESLint } from './utility/eslint-utils';
+import { resolveAndInstantiateESLint } from './utility/eslint-utils';
 
 export default async function run(
   options: Schema,
@@ -28,19 +27,6 @@ export default async function run(
     console.info(`\nLinting ${JSON.stringify(projectName)}...`);
   }
 
-  const projectESLint: { ESLint: typeof ESLint } = await loadESLint();
-  const version = projectESLint.ESLint?.version?.split('.');
-  if (
-    !version ||
-    version.length < 2 ||
-    Number(version[0]) < 7 ||
-    (Number(version[0]) === 7 && Number(version[1]) < 6)
-  ) {
-    throw new Error('ESLint must be version 7.6 or higher.');
-  }
-
-  const eslint = new projectESLint.ESLint({});
-
   /**
    * We want users to have the option of not specifying the config path, and let
    * eslint automatically resolve the `.eslintrc.json` files in each folder.
@@ -53,10 +39,34 @@ export default async function run(
     ? join(options.cacheLocation, projectName)
     : undefined;
 
+  /**
+   * Until ESLint v9 is released and the new so called flat config is the default
+   * we only want to support it if the user has explicitly opted into it by converting
+   * their root ESLint config to use eslint.config.js
+   */
+  const useFlatConfig = existsSync(
+    joinPathFragments(systemRoot, 'eslint.config.js')
+  );
+  const { eslint, ESLint } = await resolveAndInstantiateESLint(
+    eslintConfigPath,
+    options,
+    useFlatConfig
+  );
+
+  const version = ESLint.version?.split('.');
+  if (
+    !version ||
+    version.length < 2 ||
+    Number(version[0]) < 7 ||
+    (Number(version[0]) === 7 && Number(version[1]) < 6)
+  ) {
+    throw new Error('ESLint must be version 7.6 or higher.');
+  }
+
   let lintResults: ESLint.LintResult[] = [];
 
   try {
-    lintResults = await lint(eslintConfigPath, options);
+    lintResults = await eslint.lintFiles(options.lintFilePatterns);
   } catch (err) {
     if (
       err.message.includes(
@@ -108,7 +118,7 @@ Please see https://nx.dev/guides/eslint for full guidance on how to resolve this
   }
 
   // output fixes to disk, if applicable based on the options
-  await projectESLint.ESLint.outputFixes(lintResults);
+  await ESLint.outputFixes(lintResults);
 
   // if quiet, only show errors
   if (options.quiet) {

--- a/packages/linter/src/executors/eslint/utility/eslint-utils.ts
+++ b/packages/linter/src/executors/eslint/utility/eslint-utils.ts
@@ -1,36 +1,43 @@
-import { ESLint } from 'eslint';
+import type { ESLint } from 'eslint';
 import type { Schema } from '../schema';
 
-export async function loadESLint() {
-  let eslint;
+async function resolveESLintClass(
+  useFlatConfig = false
+): Promise<typeof ESLint> {
   try {
-    eslint = await import('eslint');
-    return eslint;
+    if (!useFlatConfig) {
+      return (await import('eslint')).ESLint;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { FlatESLint } = require('eslint/use-at-your-own-risk');
+    return FlatESLint;
   } catch {
     throw new Error('Unable to find ESLint. Ensure ESLint is installed.');
   }
 }
 
-export async function lint(
+export async function resolveAndInstantiateESLint(
   eslintConfigPath: string | undefined,
-  options: Schema
-): Promise<ESLint.LintResult[]> {
-  const projectESLint: { ESLint: typeof ESLint } = await loadESLint();
+  options: Schema,
+  useFlatConfig = false
+) {
+  if (
+    useFlatConfig &&
+    eslintConfigPath &&
+    !eslintConfigPath?.endsWith('eslint.config.js')
+  ) {
+    throw new Error(
+      'When using the new Flat Config with ESLint, all configs must be named eslint.config.js and .eslintrc files may not be used. See https://eslint.org/docs/latest/use/configure/configuration-files-new'
+    );
+  }
+  const ESLint = await resolveESLintClass(useFlatConfig);
 
-  const eslint = new projectESLint.ESLint({
-    /**
-     * If "noEslintrc" is set to `true` (and therefore here "useEslintrc" will be `false`), then ESLint will not
-     * merge the provided config with others it finds automatically.
-     */
-    useEslintrc: !options.noEslintrc,
+  const eslintOptions: ESLint.Options = {
     overrideConfigFile: eslintConfigPath,
-    ignorePath: options.ignorePath || undefined,
     fix: !!options.fix,
     cache: !!options.cache,
     cacheLocation: options.cacheLocation || undefined,
     cacheStrategy: options.cacheStrategy || undefined,
-    resolvePluginsRelativeTo: options.resolvePluginsRelativeTo || undefined,
-    rulePaths: options.rulesdir || [],
     /**
      * Default is `true` and if not overridden the eslint.lintFiles() method will throw an error
      * when no target files are found.
@@ -38,13 +45,46 @@ export async function lint(
      * We don't want ESLint to throw an error if a user has only just created
      * a project and therefore doesn't necessarily have matching files, for example.
      *
-     * An angular generator creates lint pattern for `html` files, but there may
-     * not be any html files in the project, so keeping it true would break linting everytime
+     * Also, the angular generator creates a lint pattern for `html` files, but there may
+     * not be any html files in the project, so keeping it true would break linting every time
      */
     errorOnUnmatchedPattern: false,
     reportUnusedDisableDirectives:
       options.reportUnusedDisableDirectives || undefined,
-  });
+  };
 
-  return await eslint.lintFiles(options.lintFilePatterns);
+  if (useFlatConfig) {
+    if (typeof options.useEslintrc !== 'undefined') {
+      throw new Error(
+        'For Flat Config, the `useEslintrc` option is not applicable. See https://eslint.org/docs/latest/use/configure/configuration-files-new'
+      );
+    }
+    if (options.resolvePluginsRelativeTo !== undefined) {
+      throw new Error(
+        'For Flat Config, ESLint removed `resolvePluginsRelativeTo` and so it is not supported as an option. See https://eslint.org/docs/latest/use/configure/configuration-files-new'
+      );
+    }
+    if (options.ignorePath !== undefined) {
+      throw new Error(
+        'For Flat Config, ESLint removed `ignorePath` and so it is not supported as an option. See https://eslint.org/docs/latest/use/configure/configuration-files-new'
+      );
+    }
+  } else {
+    eslintOptions.rulePaths = options.rulesdir || [];
+    eslintOptions.resolvePluginsRelativeTo =
+      options.resolvePluginsRelativeTo || undefined;
+    eslintOptions.ignorePath = options.ignorePath || undefined;
+    /**
+     * If "noEslintrc" is set to `true` (and therefore here "useEslintrc" will be `false`), then ESLint will not
+     * merge the provided config with others it finds automatically.
+     */
+    eslintOptions.useEslintrc = !options.noEslintrc;
+  }
+
+  const eslint = new ESLint(eslintOptions);
+
+  return {
+    ESLint,
+    eslint,
+  };
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

ESLint's new (not yet default) so called "Flat Config" cannot be used with Nx workspaces.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Users can manually opt into using ESLint's Flat Config style in their Nx workspaces prior to it being the official primary configuration style in ESLint v9 later in the year.

Appropriate migrations and generators will follow on from this once we get much closer to Flat Config being the primary default in ESLint.

https://eslint.org/docs/latest/use/configure/configuration-files-new

P.S. I also took the opportunity to clean up how ESLint is resolved and instantiated, it had become organically a bit messy over time
