### PR TITLE
fix(core): resolve nx against command root if workspace not provided

### DIFF
--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -14,7 +14,6 @@ import { major } from 'semver';
 import { stripIndents } from '../src/utils/strip-indents';
 import { readModulePackageJson } from '../src/utils/package-json';
 import { execSync } from 'child_process';
-import { join } from 'path';
 
 function main() {
   const workspace = findWorkspaceRoot(process.cwd());
@@ -125,25 +124,27 @@ function determineNxVersions(
 
 function resolveNx(workspace: WorkspaceTypeAndRoot | null) {
   // root relative to node_modules/nx/bin/nx,
-  const commandRoot = join(__dirname, '../../..');
+  const workingDirectory = process.cwd();
 
   // prefer Nx installed in .nx/installation
   try {
     return require.resolve('nx/bin/nx.js', {
-      paths: [getNxInstallationPath(workspace ? workspace.dir : commandRoot)],
+      paths: [
+        getNxInstallationPath(workspace ? workspace.dir : workingDirectory),
+      ],
     });
   } catch {}
 
   // check for root install
   try {
     return require.resolve('nx/bin/nx.js', {
-      paths: [workspace ? workspace.dir : commandRoot],
+      paths: [workspace ? workspace.dir : workingDirectory],
     });
   } catch {
     // TODO(v17): Remove this
     // fallback for old CLI install setup
     return require.resolve('@nrwl/cli/bin/nx.js', {
-      paths: [workspace ? workspace.dir : commandRoot],
+      paths: [workspace ? workspace.dir : workingDirectory],
     });
   }
 }

--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -14,6 +14,7 @@ import { major } from 'semver';
 import { stripIndents } from '../src/utils/strip-indents';
 import { readModulePackageJson } from '../src/utils/package-json';
 import { execSync } from 'child_process';
+import { join } from 'path';
 
 function main() {
   const workspace = findWorkspaceRoot(process.cwd());
@@ -123,28 +124,26 @@ function determineNxVersions(
 }
 
 function resolveNx(workspace: WorkspaceTypeAndRoot | null) {
-  // root relative to node_modules/nx/bin/nx,
-  const workingDirectory = process.cwd();
+  // root relative to location of the nx bin
+  const globalsRoot = join(__dirname, '../../../');
 
   // prefer Nx installed in .nx/installation
   try {
     return require.resolve('nx/bin/nx.js', {
-      paths: [
-        getNxInstallationPath(workspace ? workspace.dir : workingDirectory),
-      ],
+      paths: [getNxInstallationPath(workspace ? workspace.dir : globalsRoot)],
     });
   } catch {}
 
   // check for root install
   try {
     return require.resolve('nx/bin/nx.js', {
-      paths: [workspace ? workspace.dir : workingDirectory],
+      paths: [workspace ? workspace.dir : globalsRoot],
     });
   } catch {
     // TODO(v17): Remove this
     // fallback for old CLI install setup
     return require.resolve('@nrwl/cli/bin/nx.js', {
-      paths: [workspace ? workspace.dir : workingDirectory],
+      paths: [workspace ? workspace.dir : globalsRoot],
     });
   }
 }

--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -14,6 +14,7 @@ import { major } from 'semver';
 import { stripIndents } from '../src/utils/strip-indents';
 import { readModulePackageJson } from '../src/utils/package-json';
 import { execSync } from 'child_process';
+import { join } from 'path';
 
 function main() {
   const workspace = findWorkspaceRoot(process.cwd());
@@ -123,23 +124,26 @@ function determineNxVersions(
 }
 
 function resolveNx(workspace: WorkspaceTypeAndRoot | null) {
+  // root relative to node_modules/nx/bin/nx,
+  const commandRoot = join(__dirname, '../../..');
+
   // prefer Nx installed in .nx/installation
   try {
     return require.resolve('nx/bin/nx.js', {
-      paths: workspace ? [getNxInstallationPath(workspace.dir)] : undefined,
+      paths: [getNxInstallationPath(workspace ? workspace.dir : commandRoot)],
     });
   } catch {}
 
   // check for root install
   try {
     return require.resolve('nx/bin/nx.js', {
-      paths: workspace ? [workspace.dir] : undefined,
+      paths: [workspace ? workspace.dir : commandRoot],
     });
   } catch {
     // TODO(v17): Remove this
     // fallback for old CLI install setup
     return require.resolve('@nrwl/cli/bin/nx.js', {
-      paths: workspace ? [workspace.dir] : undefined,
+      paths: [workspace ? workspace.dir : commandRoot],
     });
   }
 }


### PR DESCRIPTION
## Current Behavior
`resolveNx` wrongfully detects nested `nx` as the base one in the workspace with aggressive `no-hoist` setup

## Expected Behavior
`resolveNx` should look for `nx` from the command run location and properly detect local nx location

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16603

cc @AgentEnder 

