### PR TITLE
fix(angular): update import paths relative to app config file location in migration extracting the config

### DIFF
--- a/packages/angular/src/migrations/update-16-1-0/extract-standalone-config-from-bootstrap.spec.ts
+++ b/packages/angular/src/migrations/update-16-1-0/extract-standalone-config-from-bootstrap.spec.ts
@@ -57,7 +57,7 @@ describe('extractStandaloneConfigFromBootstrap', () => {
         provideRouter,
         withEnabledBlockingInitialNavigation,
       } from '@angular/router';
-      import { appRoutes } from './app/app.routes';
+      import { appRoutes } from './app.routes';
       export const appConfig: ApplicationConfig = {
         providers: [provideRouter(appRoutes, withEnabledBlockingInitialNavigation())],
       };
@@ -113,7 +113,7 @@ describe('extractStandaloneConfigFromBootstrap', () => {
         provideRouter,
         withEnabledBlockingInitialNavigation,
       } from '@angular/router';
-      import { appRoutes } from './app/app.routes';
+      import { appRoutes } from './app.routes';
       export const appConfig: ApplicationConfig = {
         providers: [provideRouter(appRoutes, withEnabledBlockingInitialNavigation())],
       };


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The migration extracting the standalone config from the `bootstrapApplication` call into a separate file doesn't rewrite the relative import paths considering the new file location.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The migration extracting the standalone config from the `bootstrapApplication` call into a separate file should rewrite the relative import paths as needed based on the new file location.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16849 
