### PR TITLE
chore(repo): enable enforce-module-boundaries on nx repo

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,6 +35,24 @@
       "rules": {
         "@nx/workspace/valid-schema-description": "error"
       }
+    },
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {
+        "@nx/enforce-module-boundaries": [
+          "error",
+          {
+            "enforceBuildableLibDependency": true,
+            "allow": [],
+            "depConstraints": [
+              {
+                "sourceTag": "*",
+                "onlyDependOnLibsWithTags": ["*"]
+              }
+            ]
+          }
+        ]
+      }
     }
   ]
 }

--- a/graph/client-e2e/src/globals.d.ts
+++ b/graph/client-e2e/src/globals.d.ts
@@ -1,2 +1,3 @@
 // ensure we have the types for the externalApi on window
+// eslint-disable-next-line @nx/enforce-module-boundaries
 export type { global } from 'graph/client/src/globals';

--- a/graph/client/src/app/feature-projects/machines/interfaces.ts
+++ b/graph/client/src/app/feature-projects/machines/interfaces.ts
@@ -1,9 +1,11 @@
 import { GraphPerfReport } from '../../interfaces';
+/* eslint-disable @nx/enforce-module-boundaries */
 // nx-ignore-next-line
 import {
   ProjectGraphDependency,
   ProjectGraphProjectNode,
 } from 'nx/src/config/project-graph';
+/* eslint-enable @nx/enforce-module-boundaries */
 import { ActionObject, ActorRef, State, StateNodeConfig } from 'xstate';
 import { GraphRenderEvents } from '../../machines/interfaces';
 

--- a/graph/client/src/app/feature-projects/machines/project-graph.spec.ts
+++ b/graph/client/src/app/feature-projects/machines/project-graph.spec.ts
@@ -1,8 +1,10 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 // nx-ignore-next-line
 import type {
   ProjectGraphDependency,
   ProjectGraphProjectNode,
 } from '@nx/devkit';
+/* eslint-enable @nx/enforce-module-boundaries */
 import { interpret } from 'xstate';
 import { projectGraphMachine } from './project-graph.machine';
 

--- a/graph/client/src/app/feature-projects/machines/selectors.ts
+++ b/graph/client/src/app/feature-projects/machines/selectors.ts
@@ -1,5 +1,7 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 // nx-ignore-next-line
 import type { ProjectGraphProjectNode } from '@nx/devkit';
+/* eslint-enable @nx/enforce-module-boundaries */
 import { ProjectGraphSelector } from '../hooks/use-project-graph-selector';
 import { GraphPerfReport, WorkspaceLayout } from '../../interfaces';
 import { TracingAlgorithmType } from './interfaces';

--- a/graph/client/src/app/feature-projects/project-list.tsx
+++ b/graph/client/src/app/feature-projects/project-list.tsx
@@ -4,8 +4,10 @@ import {
   FlagIcon,
   MapPinIcon,
 } from '@heroicons/react/24/outline';
+/* eslint-disable @nx/enforce-module-boundaries */
 // nx-ignore-next-line
 import type { ProjectGraphNode } from '@nx/devkit';
+/* eslint-enable @nx/enforce-module-boundaries */
 import { useProjectGraphSelector } from './hooks/use-project-graph-selector';
 import {
   allProjectsSelector,

--- a/graph/client/src/app/feature-projects/projects-sidebar.tsx
+++ b/graph/client/src/app/feature-projects/projects-sidebar.tsx
@@ -23,8 +23,10 @@ import { useEnvironmentConfig } from '../hooks/use-environment-config';
 import { TracingAlgorithmType } from './machines/interfaces';
 import { getProjectGraphService } from '../machines/get-services';
 import { useIntervalWhen } from '../hooks/use-interval-when';
+/* eslint-disable @nx/enforce-module-boundaries */
 // nx-ignore-next-line
 import { ProjectGraphClientResponse } from 'nx/src/command-line/dep-graph';
+/* eslint-enable @nx/enforce-module-boundaries */
 import {
   useNavigate,
   useParams,

--- a/graph/client/src/app/feature-tasks/task-list.tsx
+++ b/graph/client/src/app/feature-tasks/task-list.tsx
@@ -1,5 +1,7 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 // nx-ignore-next-line
 import type { ProjectGraphProjectNode } from '@nx/devkit';
+/* eslint-enable @nx/enforce-module-boundaries */
 import {
   createTaskName,
   getProjectsByType,
@@ -10,7 +12,6 @@ import { ExclamationCircleIcon, EyeIcon } from '@heroicons/react/24/outline';
 import { ReactNode } from 'react';
 import { Tooltip } from '@nx/graph/ui-tooltips';
 import { TaskGraphErrorTooltip } from './task-graph-error-tooltip';
-import { ExperimentalFeature } from '../ui-components/experimental-feature';
 
 interface SidebarProject {
   projectGraphNode: ProjectGraphProjectNode;

--- a/graph/client/src/app/feature-tasks/tasks-sidebar.tsx
+++ b/graph/client/src/app/feature-tasks/tasks-sidebar.tsx
@@ -5,11 +5,13 @@ import {
   useRouteLoaderData,
   useSearchParams,
 } from 'react-router-dom';
+/* eslint-disable @nx/enforce-module-boundaries */
 // nx-ignore-next-line
 import type {
   ProjectGraphClientResponse,
   TaskGraphClientResponse,
 } from 'nx/src/command-line/dep-graph';
+/* eslint-enable @nx/enforce-module-boundaries */
 import { getGraphService } from '../machines/graph.service';
 import { useEffect, useMemo } from 'react';
 import { CheckboxPanel } from '../ui-components/checkbox-panel';

--- a/graph/client/src/app/fetch-project-graph-service.ts
+++ b/graph/client/src/app/fetch-project-graph-service.ts
@@ -1,8 +1,10 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 // nx-ignore-next-line
 import type {
   ProjectGraphClientResponse,
   TaskGraphClientResponse,
 } from 'nx/src/command-line/dep-graph';
+/* eslint-enable @nx/enforce-module-boundaries */
 import { ProjectGraphService } from './interfaces';
 
 export class FetchProjectGraphService implements ProjectGraphService {

--- a/graph/client/src/app/hooks/use-environment-config.ts
+++ b/graph/client/src/app/hooks/use-environment-config.ts
@@ -1,5 +1,7 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 // nx-ignore-next-line
 import type { ProjectGraphClientResponse } from 'nx/src/command-line/dep-graph';
+/* eslint-enable @nx/enforce-module-boundaries */
 import { useRef } from 'react';
 import { AppConfig } from '../interfaces';
 

--- a/graph/client/src/app/interfaces.ts
+++ b/graph/client/src/app/interfaces.ts
@@ -1,8 +1,10 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 // nx-ignore-next-line
 import type {
   ProjectGraphClientResponse,
   TaskGraphClientResponse,
 } from 'nx/src/command-line/dep-graph';
+/* eslint-enable @nx/enforce-module-boundaries */
 
 export interface WorkspaceData {
   id: string;

--- a/graph/client/src/app/local-project-graph-service.ts
+++ b/graph/client/src/app/local-project-graph-service.ts
@@ -1,8 +1,10 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 // nx-ignore-next-line
 import type {
   ProjectGraphClientResponse,
   TaskGraphClientResponse,
 } from 'nx/src/command-line/dep-graph';
+/* eslint-enable @nx/enforce-module-boundaries */
 import { ProjectGraphService } from './interfaces';
 
 export class LocalProjectGraphService implements ProjectGraphService {

--- a/graph/client/src/app/machines/interfaces.ts
+++ b/graph/client/src/app/machines/interfaces.ts
@@ -1,8 +1,10 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 // nx-ignore-next-line
 import type {
   ProjectGraphDependency,
   ProjectGraphProjectNode,
 } from '@nx/devkit';
+/* eslint-enable @nx/enforce-module-boundaries */
 import { TracingAlgorithmType } from '../feature-projects/machines/interfaces';
 
 // The events that the graph actor handles

--- a/graph/client/src/app/mock-project-graph-service.ts
+++ b/graph/client/src/app/mock-project-graph-service.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 // nx-ignore-next-line
 import type {
   DependencyType,
@@ -9,6 +10,7 @@ import type {
   ProjectGraphClientResponse,
   TaskGraphClientResponse,
 } from 'nx/src/command-line/dep-graph';
+/* eslint-enable @nx/enforce-module-boundaries */
 import { ProjectGraphService } from '../app/interfaces';
 
 export class MockProjectGraphService implements ProjectGraphService {

--- a/graph/client/src/app/routes.tsx
+++ b/graph/client/src/app/routes.tsx
@@ -3,10 +3,11 @@ import { redirect, RouteObject } from 'react-router-dom';
 import { ProjectsSidebar } from './feature-projects/projects-sidebar';
 import { TasksSidebar } from './feature-tasks/tasks-sidebar';
 import { getEnvironmentConfig } from './hooks/use-environment-config';
+/* eslint-disable @nx/enforce-module-boundaries */
 // nx-ignore-next-line
 import { ProjectGraphClientResponse } from 'nx/src/command-line/dep-graph';
+/* eslint-enable @nx/enforce-module-boundaries */
 import { getProjectGraphDataService } from './hooks/get-project-graph-data-service';
-import { getProjectGraphService } from './machines/get-services';
 import { TasksSidebarErrorBoundary } from './feature-tasks/tasks-sidebar-error-boundary';
 
 const { appConfig } = getEnvironmentConfig();

--- a/graph/client/src/app/util.ts
+++ b/graph/client/src/app/util.ts
@@ -1,5 +1,7 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 // nx-ignore-next-line
 import { ProjectGraphDependency, ProjectGraphProjectNode } from '@nx/devkit';
+/* eslint-enable @nx/enforce-module-boundaries */
 import { getEnvironmentConfig } from './hooks/use-environment-config';
 import { To, useParams, useSearchParams } from 'react-router-dom';
 

--- a/graph/client/src/globals.d.ts
+++ b/graph/client/src/globals.d.ts
@@ -1,8 +1,10 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 // nx-ignore-next-line
 import type {
   ProjectGraphClientResponse,
   TaskGraphClientResponse,
 } from 'nx/src/command-line/dep-graph';
+/* eslint-enable @nx/enforce-module-boundaries */
 import { AppConfig } from './app/interfaces';
 import { ExternalApi } from './app/external-api';
 

--- a/graph/ui-components/.storybook/preview.js
+++ b/graph/ui-components/.storybook/preview.js
@@ -1,3 +1,3 @@
-import '../../client/.storybook/tailwind-imports.css';
+import 'graph-client/.storybook/tailwind-imports.css';
 
 export const parameters = {};

--- a/graph/ui-graph/src/lib/interfaces.ts
+++ b/graph/ui-graph/src/lib/interfaces.ts
@@ -1,9 +1,11 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 // nx-ignore-next-line
 import type {
   ProjectGraphDependency,
   ProjectGraphProjectNode,
   TaskGraph,
 } from '@nx/devkit';
+/* eslint-enable @nx/enforce-module-boundaries */
 import { VirtualElement } from '@floating-ui/react';
 import {
   ProjectEdgeNodeTooltipProps,

--- a/graph/ui-graph/src/lib/nx-project-graph-viz.tsx
+++ b/graph/ui-graph/src/lib/nx-project-graph-viz.tsx
@@ -1,11 +1,12 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 /* nx-ignore-next-line */
 import type {
   ProjectGraphProjectNode,
   ProjectGraphDependency,
 } from 'nx/src/config/project-graph';
+/* eslint-enable @nx/enforce-module-boundaries */
 import { useEffect, useRef, useState } from 'react';
 import { GraphService } from './graph';
-import { useSyncExternalStore } from 'use-sync-external-store/shim';
 import {
   ProjectEdgeNodeTooltip,
   ProjectNodeToolTip,

--- a/graph/ui-graph/src/lib/nx-task-graph-viz.tsx
+++ b/graph/ui-graph/src/lib/nx-task-graph-viz.tsx
@@ -1,14 +1,11 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 /* nx-ignore-next-line */
 import type { ProjectGraphProjectNode } from 'nx/src/config/project-graph';
+/* eslint-enable @nx/enforce-module-boundaries */
 import { useEffect, useRef, useState } from 'react';
 import { GraphService } from './graph';
 import { TaskGraphRecord, TooltipEvent } from './interfaces';
-import {
-  ProjectEdgeNodeTooltip,
-  ProjectNodeToolTip,
-  TaskNodeTooltip,
-  Tooltip,
-} from '@nx/graph/ui-tooltips';
+import { TaskNodeTooltip, Tooltip } from '@nx/graph/ui-tooltips';
 import { GraphTooltipService } from './tooltip-service';
 
 type Theme = 'light' | 'dark' | 'system';

--- a/graph/ui-graph/src/lib/util-cytoscape/project-edge.ts
+++ b/graph/ui-graph/src/lib/util-cytoscape/project-edge.ts
@@ -1,5 +1,7 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 // nx-ignore-next-line
 import type { ProjectGraphDependency } from '@nx/devkit';
+/* eslint-enable @nx/enforce-module-boundaries */
 import * as cy from 'cytoscape';
 
 export interface ProjectEdgeDataDefinition extends cy.NodeDataDefinition {

--- a/graph/ui-graph/src/lib/util-cytoscape/project-node.ts
+++ b/graph/ui-graph/src/lib/util-cytoscape/project-node.ts
@@ -1,5 +1,7 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 // nx-ignore-next-line
 import type { ProjectGraphProjectNode } from '@nx/devkit';
+/* eslint-enable @nx/enforce-module-boundaries */
 import * as cy from 'cytoscape';
 import { parseParentDirectoriesFromFilePath } from '../util';
 

--- a/graph/ui-graph/src/lib/util-cytoscape/project-traversal-graph.ts
+++ b/graph/ui-graph/src/lib/util-cytoscape/project-traversal-graph.ts
@@ -6,12 +6,13 @@ import cytoscape, {
   NodeSingular,
 } from 'cytoscape';
 
+/* eslint-disable @nx/enforce-module-boundaries */
 // nx-ignore-next-line
 import {
   ProjectGraphDependency,
   ProjectGraphProjectNode,
 } from 'nx/src/config/project-graph';
-import { edgeStyles, nodeStyles } from '../styles-graph';
+/* eslint-enable @nx/enforce-module-boundaries */
 import { ProjectNode } from './project-node';
 import { ProjectEdge } from './project-edge';
 import { ParentNode } from './parent-node';

--- a/graph/ui-graph/src/lib/util-cytoscape/render-graph.ts
+++ b/graph/ui-graph/src/lib/util-cytoscape/render-graph.ts
@@ -5,7 +5,7 @@ import cytoscape, {
   EdgeSingular,
 } from 'cytoscape';
 import { edgeStyles, nodeStyles } from '../styles-graph';
-import { GraphInteractionEvents } from '@nx/graph/ui-graph';
+import { GraphInteractionEvents } from '../graph-interaction-events';
 import { VirtualElement } from '@floating-ui/react';
 import {
   darkModeScratchKey,

--- a/graph/ui-graph/src/lib/util-cytoscape/task-edge.ts
+++ b/graph/ui-graph/src/lib/util-cytoscape/task-edge.ts
@@ -1,5 +1,3 @@
-// nx-ignore-next-line
-import type { ProjectGraphDependency } from '@nx/devkit';
 import * as cy from 'cytoscape';
 
 export interface TaskEdgeDataDefinition extends cy.NodeDataDefinition {

--- a/graph/ui-graph/src/lib/util-cytoscape/task-node.ts
+++ b/graph/ui-graph/src/lib/util-cytoscape/task-node.ts
@@ -1,5 +1,7 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 // nx-ignore-next-line
 import type { ProjectGraphProjectNode, Task } from '@nx/devkit';
+/* eslint-enable @nx/enforce-module-boundaries */
 import * as cy from 'cytoscape';
 
 export interface TaskNodeDataDefinition extends cy.NodeDataDefinition {

--- a/graph/ui-graph/src/lib/util-cytoscape/task-traversal.graph.ts
+++ b/graph/ui-graph/src/lib/util-cytoscape/task-traversal.graph.ts
@@ -1,5 +1,7 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 // nx-ignore-next-line
 import type { ProjectGraphProjectNode } from '@nx/devkit';
+/* eslint-enable @nx/enforce-module-boundaries */
 import { TaskGraphRecord } from '../interfaces';
 import { TaskNode } from './task-node';
 import { TaskEdge } from './task-edge';

--- a/graph/ui-graph/src/lib/util.ts
+++ b/graph/ui-graph/src/lib/util.ts
@@ -1,5 +1,7 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 // nx-ignore-next-line
 import { ProjectGraphDependency } from '@nx/devkit';
+/* eslint-enable @nx/enforce-module-boundaries */
 
 export function trimBackSlash(value: string): string {
   return value.replace(/\/$/, '');

--- a/nx-dev/nx-dev/pages/packages/[name]/documents/index.tsx
+++ b/nx-dev/nx-dev/pages/packages/[name]/documents/index.tsx
@@ -1,4 +1,3 @@
-import { PackageSchemaList } from '@nx/nx-dev/feature-package-schema-viewer';
 import { getPackagesSections } from '@nx/nx-dev/data-access-menu';
 import { sortCorePackagesFirst } from '@nx/nx-dev/data-access-packages';
 import { Menu, MenuItem, MenuSection } from '@nx/nx-dev/models-menu';
@@ -7,7 +6,7 @@ import { DocumentationHeader, SidebarContainer } from '@nx/nx-dev/ui-common';
 import { GetStaticPaths } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect, useRef } from 'react';
-import { PackageSchemaSubList } from '../../../../../feature-package-schema-viewer/src/lib/package-schema-sub-list';
+import { PackageSchemaSubList } from '@nx/nx-dev/feature-package-schema-viewer/src/lib/package-schema-sub-list';
 import { menusApi } from '../../../../lib/menus.api';
 import { useNavToggle } from '../../../../lib/navigation-toggle.effect';
 import { nxPackagesApi } from '../../../../lib/packages.api';

--- a/nx-dev/nx-dev/pages/packages/[name]/executors/index.tsx
+++ b/nx-dev/nx-dev/pages/packages/[name]/executors/index.tsx
@@ -6,7 +6,7 @@ import { DocumentationHeader, SidebarContainer } from '@nx/nx-dev/ui-common';
 import { GetStaticPaths } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect, useRef } from 'react';
-import { PackageSchemaSubList } from '../../../../../feature-package-schema-viewer/src/lib/package-schema-sub-list';
+import { PackageSchemaSubList } from '@nx/nx-dev/feature-package-schema-viewer/src/lib/package-schema-sub-list';
 import { menusApi } from '../../../../lib/menus.api';
 import { useNavToggle } from '../../../../lib/navigation-toggle.effect';
 import { nxPackagesApi } from '../../../../lib/packages.api';

--- a/nx-dev/nx-dev/pages/packages/[name]/generators/index.tsx
+++ b/nx-dev/nx-dev/pages/packages/[name]/generators/index.tsx
@@ -6,7 +6,7 @@ import { DocumentationHeader, SidebarContainer } from '@nx/nx-dev/ui-common';
 import { GetStaticPaths } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect, useRef } from 'react';
-import { PackageSchemaSubList } from '../../../../../feature-package-schema-viewer/src/lib/package-schema-sub-list';
+import { PackageSchemaSubList } from '@nx/nx-dev/feature-package-schema-viewer/src/lib/package-schema-sub-list';
 import { menusApi } from '../../../../lib/menus.api';
 import { useNavToggle } from '../../../../lib/navigation-toggle.effect';
 import { nxPackagesApi } from '../../../../lib/packages.api';

--- a/nx-dev/nx-dev/pages/packages/rspack/documents/index.tsx
+++ b/nx-dev/nx-dev/pages/packages/rspack/documents/index.tsx
@@ -5,7 +5,7 @@ import { ProcessedPackageMetadata } from '@nx/nx-dev/models-package';
 import { DocumentationHeader, SidebarContainer } from '@nx/nx-dev/ui-common';
 import { useRouter } from 'next/router';
 import { useEffect, useRef } from 'react';
-import { PackageSchemaSubList } from '../../../../../feature-package-schema-viewer/src/lib/package-schema-sub-list';
+import { PackageSchemaSubList } from '@nx/nx-dev/feature-package-schema-viewer/src/lib/package-schema-sub-list';
 import { menusApi } from '../../../../lib/menus.api';
 import { useNavToggle } from '../../../../lib/navigation-toggle.effect';
 import { pkg } from '../../../../lib/rspack/pkg';

--- a/nx-dev/nx-dev/pages/packages/rspack/executors/index.tsx
+++ b/nx-dev/nx-dev/pages/packages/rspack/executors/index.tsx
@@ -5,7 +5,7 @@ import { ProcessedPackageMetadata } from '@nx/nx-dev/models-package';
 import { DocumentationHeader, SidebarContainer } from '@nx/nx-dev/ui-common';
 import { useRouter } from 'next/router';
 import { useEffect, useRef } from 'react';
-import { PackageSchemaSubList } from '../../../../../feature-package-schema-viewer/src/lib/package-schema-sub-list';
+import { PackageSchemaSubList } from '@nx/nx-dev/feature-package-schema-viewer/src/lib/package-schema-sub-list';
 import { menusApi } from '../../../../lib/menus.api';
 import { useNavToggle } from '../../../../lib/navigation-toggle.effect';
 import { pkg } from '../../../../lib/rspack/pkg';

--- a/nx-dev/nx-dev/pages/packages/rspack/generators/index.tsx
+++ b/nx-dev/nx-dev/pages/packages/rspack/generators/index.tsx
@@ -5,7 +5,7 @@ import { ProcessedPackageMetadata } from '@nx/nx-dev/models-package';
 import { DocumentationHeader, SidebarContainer } from '@nx/nx-dev/ui-common';
 import { useRouter } from 'next/router';
 import { useEffect, useRef } from 'react';
-import { PackageSchemaSubList } from '../../../../../feature-package-schema-viewer/src/lib/package-schema-sub-list';
+import { PackageSchemaSubList } from '@nx/nx-dev/feature-package-schema-viewer/src/lib/package-schema-sub-list';
 import { menusApi } from '../../../../lib/menus.api';
 import { useNavToggle } from '../../../../lib/navigation-toggle.effect';
 import { pkg } from '../../../../lib/rspack/pkg';

--- a/nx-dev/nx-dev/pages/plugins/registry.tsx
+++ b/nx-dev/nx-dev/pages/plugins/registry.tsx
@@ -27,7 +27,7 @@ interface BrowseProps {
   // segments: string[];
 }
 
-export async function getStaticProps({}): Promise<{ props: BrowseProps }> {
+export async function getStaticProps(): Promise<{ props: BrowseProps }> {
   const res = await fetch(
     'https://raw.githubusercontent.com/nrwl/nx/master/community/approved-plugins.json'
   );

--- a/nx-dev/ui-common/src/lib/sidebar-container.tsx
+++ b/nx-dev/ui-common/src/lib/sidebar-container.tsx
@@ -1,5 +1,5 @@
 import { Menu } from '@nx/nx-dev/models-menu';
-import { Sidebar, SidebarMobile } from '@nx/nx-dev/ui-common';
+import { Sidebar, SidebarMobile } from './sidebar';
 import { useMemo } from 'react';
 
 // TODO(jack): Remove this rspack modification once we move rspack into main repo (when stable).

--- a/packages/angular/src/generators/remote/remote.spec.ts
+++ b/packages/angular/src/generators/remote/remote.spec.ts
@@ -1,4 +1,4 @@
-import { E2eTestRunner } from '@nx/angular/src/utils/test-runners';
+import { E2eTestRunner } from '../../utils/test-runners';
 import {
   getProjects,
   readNxJson,

--- a/packages/devkit/src/utils/get-workspace-layout.spec.ts
+++ b/packages/devkit/src/utils/get-workspace-layout.spec.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @nx/enforce-module-boundaries
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { getWorkspaceLayout } from './get-workspace-layout';
 

--- a/packages/js/src/migrations/update-13-8-5/update-swcrc.spec.ts
+++ b/packages/js/src/migrations/update-13-8-5/update-swcrc.spec.ts
@@ -1,5 +1,4 @@
 import {
-  getProjects,
   ProjectConfiguration,
   readJson,
   readProjectConfiguration,
@@ -7,7 +6,7 @@ import {
   updateProjectConfiguration,
 } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { libraryGenerator } from '@nx/js';
+import { libraryGenerator } from '../../generators/library/library';
 import { defaultExclude } from '../../utils/swc/add-swc-config';
 import update from './update-swcrc';
 

--- a/packages/nx/src/utils/package-manager.spec.ts
+++ b/packages/nx/src/utils/package-manager.spec.ts
@@ -1,7 +1,7 @@
 jest.mock('fs');
 import * as fs from 'fs';
-import * as configModule from 'nx/src/config/configuration';
-import { detectPackageManager } from 'nx/src/utils/package-manager';
+import * as configModule from '../config/configuration';
+import { detectPackageManager } from './package-manager';
 
 describe('package-manager', () => {
   it('should detect package manager in nxJson', () => {

--- a/packages/react/src/migrations/update-13-0-0/webpack5-changes-utils.spec.ts
+++ b/packages/react/src/migrations/update-13-0-0/webpack5-changes-utils.spec.ts
@@ -1,6 +1,6 @@
 import { addProjectConfiguration, Tree, updateJson } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { allReactProjectsWithStorybookConfiguration } from '@nx/react/src/migrations/update-13-0-0/webpack5-changes-utils';
+import { allReactProjectsWithStorybookConfiguration } from './webpack5-changes-utils';
 
 describe('webpack5ChangesUtils', () => {
   let tree: Tree;

--- a/packages/storybook/src/migrations/update-14-0-0/migrate-stories-to-6-2/migrate-stories-to-6-2.spec.ts
+++ b/packages/storybook/src/migrations/update-14-0-0/migrate-stories-to-6-2/migrate-stories-to-6-2.spec.ts
@@ -5,7 +5,7 @@ import {
 } from '@nx/devkit';
 import { joinPathFragments, writeJson } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { storybookVersion } from '@nx/storybook';
+import { storybookVersion } from '../../../utils/versions';
 import { findNodes } from '@nx/js';
 import * as ts from 'typescript';
 import { SyntaxKind } from 'typescript';
@@ -15,7 +15,7 @@ import {
   overrideCollectionResolutionForTesting,
   wrapAngularDevkitSchematic,
 } from '@nx/devkit/ngcli-adapter';
-import { getTsSourceFile } from '@nx/storybook/src/utils/utilities';
+import { getTsSourceFile } from '../../../utils/utilities';
 
 // nested code imports graph from the repo, which might have innacurate graph version
 jest.mock('nx/src/project-graph/project-graph', () => ({

--- a/packages/workspace/src/generators/new/generate-workspace-files.spec.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.spec.ts
@@ -4,7 +4,7 @@ import Ajv from 'ajv';
 import { generateWorkspaceFiles } from './generate-workspace-files';
 import { createTree } from '@nx/devkit/testing';
 import { Preset } from '../utils/presets';
-import * as nxSchema from '../../../../nx/schemas/nx-schema.json';
+import * as nxSchema from 'nx/schemas/nx-schema.json';
 
 describe('@nx/workspace:generateWorkspaceFiles', () => {
   let tree: Tree;

--- a/packages/workspace/src/generators/remove/lib/remove-project.spec.ts
+++ b/packages/workspace/src/generators/remove/lib/remove-project.spec.ts
@@ -1,7 +1,7 @@
 import { readProjectConfiguration, Tree } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { Schema } from '../schema';
-import { removeProject } from '@nx/workspace/src/generators/remove/lib/remove-project';
+import { removeProject } from './remove-project';
 
 // nx-ignore-next-line
 const { libraryGenerator } = require('@nx/js');

--- a/packages/workspace/src/migrations/update-13-6-0/remove-old-task-runner-options.spec.ts
+++ b/packages/workspace/src/migrations/update-13-6-0/remove-old-task-runner-options.spec.ts
@@ -1,6 +1,6 @@
 import { NxJsonConfiguration, readJson, Tree, writeJson } from '@nx/devkit';
 import { createTree } from '@nx/devkit/testing';
-import removeOldTaskRunnerOptions from '@nx/workspace/src/migrations/update-13-6-0/remove-old-task-runner-options';
+import removeOldTaskRunnerOptions from './remove-old-task-runner-options';
 
 describe('removeOldTaskRunnerOptions', () => {
   let tree: Tree;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -66,6 +66,9 @@
       "@nx/nx-dev/feature-package-schema-viewer": [
         "nx-dev/feature-package-schema-viewer/src/index.ts"
       ],
+      "@nx/nx-dev/feature-package-schema-viewer/*": [
+        "nx-dev/feature-package-schema-viewer/*"
+      ],
       "@nx/nx-dev/feature-search": ["nx-dev/feature-search/src/index.ts"],
       "@nx/nx-dev/models-document": ["nx-dev/models-document/src/index.ts"],
       "@nx/nx-dev/models-menu": ["nx-dev/models-menu/src/index.ts"],


### PR DESCRIPTION
Enable `@nx/enforce-module-boundaries` on our repo.

Only default restrictions at the moment.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
