### PR TITLE
docs(repo): update docs/schemas to use nx scoped packages - nx labs

### DIFF
--- a/docs/generated/packages/angular/executors/webpack-dev-server.json
+++ b/docs/generated/packages/angular/executors/webpack-dev-server.json
@@ -6,7 +6,7 @@
     "outputCapture": "direct-nodejs",
     "$schema": "http://json-schema.org/draft-07/schema",
     "title": "Schema for Webpack Dev Server",
-    "description": "The webpack-dev-server executor is very similar to the standard dev server builder provided by the Angular Devkit. It is usually used in tandem with `@nrwl/angular:webpack-browser` when your Angular application uses a custom webpack configuration.",
+    "description": "The webpack-dev-server executor is very similar to the standard dev server builder provided by the Angular Devkit. It is usually used in tandem with `@nx/angular:webpack-browser` when your Angular application uses a custom webpack configuration.",
     "examplesFile": "##### Seving an application with a custom webpack configuration\n\nThis executor should be used along with `@nx/angular:webpack-browser` to serve an application using a custom webpack configuration.\n\nYour `project.json` file should contain a `build` and `serve` target that matches the following:\n\n```json\n\"build\": {\n    \"executor\": \"@nx/angular:webpack-browser\",\n    \"options\": {\n        ...\n        \"customWebpackConfig\": {\n          \"path\": \"apps/appName/webpack.config.js\"\n        }\n    }\n},\n\"serve\": {\n    \"executor\": \"@nx/angular:webpack-dev-server\",\n    \"configurations\": {\n        \"production\": {\n            \"browserTarget\": \"appName:build:production\"\n        },\n        \"development\": {\n            \"browserTarget\": \"appName:build:development\"\n        }\n    },\n    \"defaultConfiguration\": \"development\",\n}\n```\n",
     "type": "object",
     "presets": [

--- a/docs/generated/packages/angular/executors/webpack-server.json
+++ b/docs/generated/packages/angular/executors/webpack-server.json
@@ -6,7 +6,7 @@
     "outputCapture": "direct-nodejs",
     "$schema": "http://json-schema.org/draft-07/schema",
     "title": "Schema for Webpack Server",
-    "description": "The webpack-dev-server executor is very similar to the standard server builder provided by the Angular Devkit. It is usually used in tandem with `@nrwl/angular:webpack-browser` when your Angular application uses a custom webpack configuration and NgUniversal for SSR.",
+    "description": "The webpack-dev-server executor is very similar to the standard server builder provided by the Angular Devkit. It is usually used in tandem with `@nx/angular:webpack-browser` when your Angular application uses a custom webpack configuration and NgUniversal for SSR.",
     "type": "object",
     "properties": {
       "assets": {

--- a/docs/generated/packages/angular/generators/add-linting.json
+++ b/docs/generated/packages/angular/generators/add-linting.json
@@ -10,7 +10,7 @@
     "type": "object",
     "examples": [
       {
-        "command": "nx g @nrwl/angular:add-linting --prefix=cool --projectName=cool-lib --projectRoot=libs/cool-lib",
+        "command": "nx g @nx/angular:add-linting --prefix=cool --projectName=cool-lib --projectRoot=libs/cool-lib",
         "description": "Adds ESLint with Angular-specific rules for an existing project named `cool-lib` with the [prefix](https://angular.io/guide/styleguide#style-02-07) `cool`"
       }
     ],

--- a/docs/generated/packages/angular/generators/convert-to-with-mf.json
+++ b/docs/generated/packages/angular/generators/convert-to-with-mf.json
@@ -11,7 +11,7 @@
     "additionalProperties": false,
     "examples": [
       {
-        "command": "nx g @nrwl/angular:convert-to-with-mf --project mf-app",
+        "command": "nx g @nx/angular:convert-to-with-mf --project mf-app",
         "description": "Convert a Module Federation Project using legacy webpack config to use the `withModuleFederation` helper."
       }
     ],

--- a/docs/generated/packages/angular/generators/host.json
+++ b/docs/generated/packages/angular/generators/host.json
@@ -10,7 +10,7 @@
     "type": "object",
     "examples": [
       {
-        "command": "nx g @nrwl/angular:host appName --remotes=remote1",
+        "command": "nx g @nx/angular:host appName --remotes=remote1",
         "description": "Create an Angular application with configuration in place for Module Federation. If the `remotes` option is provided, attach the remote application to this application's configuration"
       }
     ],

--- a/docs/generated/packages/angular/generators/init.json
+++ b/docs/generated/packages/angular/generators/init.json
@@ -6,12 +6,12 @@
     "$id": "SchematicsAngularModuleInit",
     "cli": "nx",
     "title": "Init Angular Plugin",
-    "description": "Initializes the `@nrwl/angular` plugin. NOTE: Does not work in the `--dry-run` mode.",
+    "description": "Initializes the `@nx/angular` plugin. NOTE: Does not work in the `--dry-run` mode.",
     "type": "object",
     "examples": [
       {
-        "command": "nx g @nrwl/angular:init --style=scss",
-        "description": "Installs angular dependencies and initializes the `@nrwl/angular` plugin with the `scss` stylesheet format."
+        "command": "nx g @nx/angular:init --style=scss",
+        "description": "Installs angular dependencies and initializes the `@nx/angular` plugin with the `scss` stylesheet format."
       }
     ],
     "properties": {
@@ -31,7 +31,7 @@
       },
       "skipInstall": {
         "type": "boolean",
-        "description": "Skip installing after adding `@nrwl/workspace`.",
+        "description": "Skip installing after adding `@nx/workspace`.",
         "default": false,
         "x-priority": "internal"
       },

--- a/docs/generated/packages/angular/generators/move.json
+++ b/docs/generated/packages/angular/generators/move.json
@@ -10,7 +10,7 @@
     "type": "object",
     "examples": [
       {
-        "command": "nx g @nrwl/angular:move --project my-feature-lib --destination shared/my-feature-lib",
+        "command": "nx g @nx/angular:move --project my-feature-lib --destination shared/my-feature-lib",
         "description": "Move libs/my-feature-lib to libs/shared/my-feature-lib."
       }
     ],

--- a/docs/generated/packages/angular/generators/ngrx.json
+++ b/docs/generated/packages/angular/generators/ngrx.json
@@ -10,19 +10,19 @@
     "type": "object",
     "examples": [
       {
-        "command": "nx g @nrwl/angular:ngrx --root --parent=apps/my-app/src/app/app.module.ts --facade=false placeholder",
+        "command": "nx g @nx/angular:ngrx --root --parent=apps/my-app/src/app/app.module.ts --facade=false placeholder",
         "description": "Add root ngrx configration to the `my-app` application"
       },
       {
-        "command": "nx g @nrwl/angular:ngrx --parent=libs/my-lib/src/lib/my-lib.module.ts --facade=true --root=false users",
+        "command": "nx g @nx/angular:ngrx --parent=libs/my-lib/src/lib/my-lib.module.ts --facade=true --root=false users",
         "description": "Add a `users` state with a facade to the `my-lib` library. It will be tracked under the default `+state` folder in the lib"
       },
       {
-        "command": "nx g @nrwl/angular:ngrx --parent=apps/my-app/src/app/app.config.ts --root",
+        "command": "nx g @nx/angular:ngrx --parent=apps/my-app/src/app/app.config.ts --root",
         "description": "Add a root state configuration to `my-app` when `my-app` uses Standalone APIs"
       },
       {
-        "command": "nx g @nrwl/angular:ngrx --parent=libs/my-lib/src/lib.routes.ts users",
+        "command": "nx g @nx/angular:ngrx --parent=libs/my-lib/src/lib.routes.ts users",
         "description": "Add a `users` feature state to the Route definition of a library using Standalone APIs"
       }
     ],

--- a/docs/generated/packages/angular/generators/remote.json
+++ b/docs/generated/packages/angular/generators/remote.json
@@ -10,7 +10,7 @@
     "type": "object",
     "examples": [
       {
-        "command": "nx g @nrwl/angular:remote appName --host=host --port=4201",
+        "command": "nx g @nx/angular:remote appName --host=host --port=4201",
         "description": "Create an Angular app with configuration in place for Module Federation. If host is provided, attach this remote app to host app's configuration."
       }
     ],

--- a/docs/generated/packages/angular/generators/scam-directive.json
+++ b/docs/generated/packages/angular/generators/scam-directive.json
@@ -9,7 +9,7 @@
     "type": "object",
     "examples": [
       {
-        "command": "nx g @nrwl/angular:scam-directive --project=my-lib --flat=false my-sample",
+        "command": "nx g @nx/angular:scam-directive --project=my-lib --flat=false my-sample",
         "description": "Generate a `MySampleDirective` directive in a `my-sample` folder in the `my-lib` library"
       }
     ],

--- a/docs/generated/packages/angular/generators/scam-pipe.json
+++ b/docs/generated/packages/angular/generators/scam-pipe.json
@@ -9,7 +9,7 @@
     "type": "object",
     "examples": [
       {
-        "command": "nx g @nrwl/angular:scam-pipe --project=my-lib --flat=false my-transformation",
+        "command": "nx g @nx/angular:scam-pipe --project=my-lib --flat=false my-transformation",
         "description": "Generates a `MyTransformationPipe` in a `my-transformation` folder in the `my-lib` project"
       }
     ],

--- a/docs/generated/packages/angular/generators/scam.json
+++ b/docs/generated/packages/angular/generators/scam.json
@@ -9,7 +9,7 @@
     "type": "object",
     "examples": [
       {
-        "command": "nx g @nrwl/angular:scam --project=my-lib my-sample",
+        "command": "nx g @nx/angular:scam --project=my-lib my-sample",
         "description": "Generate a `MySampleComponent` component in the `my-lib` library."
       }
     ],

--- a/docs/generated/packages/cypress/generators/cypress-component-configuration.json
+++ b/docs/generated/packages/cypress/generators/cypress-component-configuration.json
@@ -10,7 +10,7 @@
     "type": "object",
     "examples": [
       {
-        "command": "nx g @nrwl/cypress:cypress-component-configuration --project=my-cool-lib ",
+        "command": "nx g @nx/cypress:cypress-component-configuration --project=my-cool-lib ",
         "description": "Add cypress component testing to an existing project named my-cool-lib"
       }
     ],

--- a/docs/generated/packages/cypress/generators/migrate-to-cypress-11.json
+++ b/docs/generated/packages/cypress/generators/migrate-to-cypress-11.json
@@ -10,7 +10,7 @@
     "type": "object",
     "examples": [
       {
-        "command": "nx g @nrwl/cypress:migrate-to-cypress-11",
+        "command": "nx g @nx/cypress:migrate-to-cypress-11",
         "description": "Migrate existing cypress projects to Cypress v11"
       }
     ],

--- a/docs/generated/packages/expo/generators/application.json
+++ b/docs/generated/packages/expo/generators/application.json
@@ -8,11 +8,11 @@
     "description": "Create an Expo Application for Nx.",
     "examples": [
       {
-        "command": "g @nrwl/expo:app myapp --directory=nested",
+        "command": "g @nx/expo:app myapp --directory=nested",
         "description": "Generate apps/nested/myapp"
       },
       {
-        "command": "g @nrwl/expo:app myapp --classComponent",
+        "command": "g @nx/expo:app myapp --classComponent",
         "description": "Use class components instead of functional components"
       }
     ],

--- a/docs/generated/packages/expo/generators/component.json
+++ b/docs/generated/packages/expo/generators/component.json
@@ -9,11 +9,11 @@
     "type": "object",
     "examples": [
       {
-        "command": "g @nrwl/expo:component my-component --project=mylib",
+        "command": "g @nx/expo:component my-component --project=mylib",
         "description": "Generate a component in the mylib library"
       },
       {
-        "command": "g @nrwl/expo:component my-component --project=mylib --classComponent",
+        "command": "g @nx/expo:component my-component --project=mylib --classComponent",
         "description": "Generate a class component in the mylib library"
       }
     ],

--- a/docs/generated/packages/expo/generators/library.json
+++ b/docs/generated/packages/expo/generators/library.json
@@ -9,7 +9,7 @@
     "type": "object",
     "examples": [
       {
-        "command": "g @nrwl/expo:lib mylib --directory=myapp",
+        "command": "g @nx/expo:lib mylib --directory=myapp",
         "description": "Generate libs/myapp/mylib"
       }
     ],

--- a/docs/generated/packages/js/generators/init.json
+++ b/docs/generated/packages/js/generators/init.json
@@ -5,8 +5,8 @@
     "$schema": "http://json-schema.org/schema",
     "$id": "NxTypescriptInit",
     "cli": "nx",
-    "title": "Init nrwl/js",
-    "description": "Init generator placeholder for nrwl/js.",
+    "title": "Init nx/js",
+    "description": "Init generator placeholder for nx/js.",
     "properties": {
       "js": {
         "type": "boolean",

--- a/docs/generated/packages/linter/generators/workspace-rules-project.json
+++ b/docs/generated/packages/linter/generators/workspace-rules-project.json
@@ -10,7 +10,7 @@
     "type": "object",
     "examples": [
       {
-        "command": "nx g @nrwl/linter:workspace-rules-project",
+        "command": "nx g @nx/linter:workspace-rules-project",
         "description": "Create the Workspace Lint Rules Project"
       }
     ],

--- a/docs/generated/packages/next/generators/cypress-component-configuration.json
+++ b/docs/generated/packages/next/generators/cypress-component-configuration.json
@@ -10,11 +10,11 @@
     "type": "object",
     "examples": [
       {
-        "command": "nx g @nrwl/next:cypress-component-configuration --project=my-next-project",
+        "command": "nx g @nx/next:cypress-component-configuration --project=my-next-project",
         "description": "Add component testing to your Next project"
       },
       {
-        "command": "nx g @nrwl/next:cypress-component-configuration --project=my-next-project --generate-tests",
+        "command": "nx g @nx/next:cypress-component-configuration --project=my-next-project --generate-tests",
         "description": "Add component testing to your Next project and generate component tests for your existing components"
       }
     ],

--- a/docs/generated/packages/plugin/generators/preset.json
+++ b/docs/generated/packages/plugin/generators/preset.json
@@ -6,7 +6,7 @@
     "cli": "nx",
     "$id": "NxPluginPreset",
     "title": "Generator ran by create-nx-plugin",
-    "description": "Initializes a workspace with an nx-plugin inside of it. Use as: `create-nx-plugin` or `create-nx-workspace --preset @nrwl/nx-plugin`.",
+    "description": "Initializes a workspace with an nx-plugin inside of it. Use as: `create-nx-plugin` or `create-nx-workspace --preset @nx/nx-plugin`.",
     "type": "object",
     "properties": {
       "pluginName": {

--- a/docs/generated/packages/react-native/generators/application.json
+++ b/docs/generated/packages/react-native/generators/application.json
@@ -9,11 +9,11 @@
     "description": "Create a React Application for Nx.",
     "examples": [
       {
-        "command": "nx g @nrwl/react-native:app myapp --directory=nested",
+        "command": "nx g @nx/react-native:app myapp --directory=nested",
         "description": "Generate `apps/nested/myapp`"
       },
       {
-        "command": "nx g @nrwl/react-native:app myapp --classComponent",
+        "command": "nx g @nx/react-native:app myapp --classComponent",
         "description": "Use class components instead of functional components"
       }
     ],

--- a/docs/generated/packages/react-native/generators/component.json
+++ b/docs/generated/packages/react-native/generators/component.json
@@ -10,11 +10,11 @@
     "type": "object",
     "examples": [
       {
-        "command": "nx g @nrwl/react-native:component my-component --project=mylib",
+        "command": "nx g @nx/react-native:component my-component --project=mylib",
         "description": "Generate a component in the `mylib` library"
       },
       {
-        "command": "nx g @nrwl/react-native:component my-component --project=mylib --classComponent",
+        "command": "nx g @nx/react-native:component my-component --project=mylib --classComponent",
         "description": "Generate a class component in the `mylib` library"
       }
     ],

--- a/docs/generated/packages/react-native/generators/library.json
+++ b/docs/generated/packages/react-native/generators/library.json
@@ -10,7 +10,7 @@
     "type": "object",
     "examples": [
       {
-        "command": "nx g @nrwl/react-native:lib mylib --directory=myapp",
+        "command": "nx g @nx/react-native:lib mylib --directory=myapp",
         "description": "Generate `libs/myapp/mylib`"
       }
     ],

--- a/docs/generated/packages/react/generators/component-test.json
+++ b/docs/generated/packages/react/generators/component-test.json
@@ -10,7 +10,7 @@
     "type": "object",
     "examples": [
       {
-        "command": "nx g @nrwl/react:component-test --project=my-react-project --component-path=src/lib/fancy-component.tsx",
+        "command": "nx g @nx/react:component-test --project=my-react-project --component-path=src/lib/fancy-component.tsx",
         "description": "Create a cypress component test for FancyComponent"
       }
     ],

--- a/docs/generated/packages/react/generators/cypress-component-configuration.json
+++ b/docs/generated/packages/react/generators/cypress-component-configuration.json
@@ -10,11 +10,11 @@
     "type": "object",
     "examples": [
       {
-        "command": "nx g @nrwl/react:cypress-component-configuration --project=my-react-project",
+        "command": "nx g @nx/react:cypress-component-configuration --project=my-react-project",
         "description": "Add component testing to your react project"
       },
       {
-        "command": "nx g @nrwl/react:cypress-component-configuration --project=my-react-project --generate-tests",
+        "command": "nx g @nx/react:cypress-component-configuration --project=my-react-project --generate-tests",
         "description": "Add component testing to your react project and generate component tests for your existing components"
       }
     ],

--- a/docs/generated/packages/vite/generators/configuration.json
+++ b/docs/generated/packages/vite/generators/configuration.json
@@ -40,15 +40,15 @@
       },
       "buildTarget": {
         "type": "string",
-        "description": "The build target of the project to be transformed to use the @nrwl/vite:build executor."
+        "description": "The build target of the project to be transformed to use the @nx/vite:build executor."
       },
       "serveTarget": {
         "type": "string",
-        "description": "The serve target of the project to be transformed to use the @nrwl/vite:dev-server and @nrwl/vite:preview-server executors."
+        "description": "The serve target of the project to be transformed to use the @nx/vite:dev-server and @nrwl/vite:preview-server executors."
       },
       "testTarget": {
         "type": "string",
-        "description": "The test target of the project to be transformed to use the @nrwl/vite:test executor."
+        "description": "The test target of the project to be transformed to use the @nx/vite:test executor."
       },
       "skipFormat": {
         "description": "Skip formatting files.",

--- a/docs/generated/packages/vite/generators/vitest.json
+++ b/docs/generated/packages/vite/generators/vitest.json
@@ -38,7 +38,7 @@
       },
       "testTarget": {
         "type": "string",
-        "description": "The test target of the project to be transformed to use the @nrwl/vite:test executor.",
+        "description": "The test target of the project to be transformed to use the @nx/vite:test executor.",
         "hidden": true
       },
       "skipFormat": {

--- a/docs/generated/packages/workspace/generators/fix-configuration.json
+++ b/docs/generated/packages/workspace/generators/fix-configuration.json
@@ -4,17 +4,17 @@
   "schema": {
     "$schema": "http://json-schema.org/schema",
     "$id": "SchematicsConvertToNxProject",
-    "title": "@nrwl/workspace:fix-configuration",
+    "title": "@nx/workspace:fix-configuration",
     "description": "Migrates v1 config to v2 standalone configuration.",
     "type": "object",
     "cli": "nx",
     "examples": [
       {
-        "command": "nx g @nrwl/workspace:convert-to-nx-project --project my-feature-lib",
+        "command": "nx g @nx/workspace:convert-to-nx-project --project my-feature-lib",
         "description": "Convert the `my-feature-lib` project to use `project.json` file instead of `workspace.json`"
       },
       {
-        "command": "nx g @nrwl/workspace:convert-to-nx-project --all",
+        "command": "nx g @nx/workspace:convert-to-nx-project --all",
         "description": "Convert all projects in `workspace.json` to separate `project.json` files"
       }
     ],

--- a/docs/generated/packages/workspace/generators/move.json
+++ b/docs/generated/packages/workspace/generators/move.json
@@ -10,7 +10,7 @@
     "type": "object",
     "examples": [
       {
-        "command": "nx g @nrwl/workspace:move --project my-feature-lib --destination shared/my-feature-lib",
+        "command": "nx g @nx/workspace:move --project my-feature-lib --destination shared/my-feature-lib",
         "description": "Move `libs/my-feature-lib` to `libs/shared/my-feature-lib`"
       }
     ],

--- a/docs/generated/packages/workspace/generators/remove.json
+++ b/docs/generated/packages/workspace/generators/remove.json
@@ -10,11 +10,11 @@
     "type": "object",
     "examples": [
       {
-        "command": "nx g @nrwl/workspace:remove my-feature-lib",
+        "command": "nx g @nx/workspace:remove my-feature-lib",
         "description": "Remove `my-feature-lib` from the workspace"
       },
       {
-        "command": "nx g @nrwl/workspace:remove my-feature-lib --forceRemove",
+        "command": "nx g @nx/workspace:remove my-feature-lib --forceRemove",
         "description": "Force removal of `my-feature-lib` from the workspace"
       }
     ],

--- a/docs/generated/packages/workspace/generators/run-commands.json
+++ b/docs/generated/packages/workspace/generators/run-commands.json
@@ -10,7 +10,7 @@
     "cli": "nx",
     "examples": [
       {
-        "command": "nx g @nrwl/workspace:run-commands printhello --project my-feature-lib --command 'echo hello'",
+        "command": "nx g @nx/workspace:run-commands printhello --project my-feature-lib --command 'echo hello'",
         "description": "Add the `printhello` target to `my-feature-lib`"
       }
     ],

--- a/docs/shared/recipes/rescope.md
+++ b/docs/shared/recipes/rescope.md
@@ -33,21 +33,27 @@ All other packages keep the same name, but change scope from `@nrwl` to `@nx`.
 | Nx 15 and lower    | Nx 16 and higher |
 | ------------------ | ---------------- |
 | @nrwl/angular      | @nx/angular      |
+| @nrwl/aws-lambda   | @nx/aws-lambda   |
 | @nrwl/cypress      | @nx/cypress      |
+| @nrwl/deno         | @nx/deno         |
 | @nrwl/detox        | @nx/detox        |
 | @nrwl/devkit       | @nx/devkit       |
 | @nrwl/esbuild      | @nx/esbuild      |
 | @nrwl/expo         | @nx/expo         |
 | @nrwl/express      | @nx/express      |
+| @nrwl/gatsby       | @nx/gatsby       |
 | @nrwl/jest         | @nx/jest         |
 | @nrwl/js           | @nx/js           |
 | @nrwl/linter       | @nx/linter       |
 | @nrwl/nest         | @nx/nest         |
+| @nrwl/netlify      | @nx/netlify      |
 | @nrwl/next         | @nx/next         |
 | @nrwl/node         | @nx/node         |
 | @nrwl/react        | @nx/react        |
 | @nrwl/react-native | @nx/react-native |
+| @nrwl/remix        | @nx/remix        |
 | @nrwl/rollup       | @nx/rollup       |
+| @nrwl/rspack       | @nx/rspack       |
 | @nrwl/storybook    | @nx/storybook    |
 | @nrwl/vite         | @nx/vite         |
 | @nrwl/web          | @nx/web          |

--- a/packages/angular/src/builders/webpack-dev-server/schema.json
+++ b/packages/angular/src/builders/webpack-dev-server/schema.json
@@ -3,7 +3,7 @@
   "outputCapture": "direct-nodejs",
   "$schema": "http://json-schema.org/draft-07/schema",
   "title": "Schema for Webpack Dev Server",
-  "description": "The webpack-dev-server executor is very similar to the standard dev server builder provided by the Angular Devkit. It is usually used in tandem with `@nrwl/angular:webpack-browser` when your Angular application uses a custom webpack configuration.",
+  "description": "The webpack-dev-server executor is very similar to the standard dev server builder provided by the Angular Devkit. It is usually used in tandem with `@nx/angular:webpack-browser` when your Angular application uses a custom webpack configuration.",
   "examplesFile": "../../../docs/webpack-dev-server-examples.md",
   "type": "object",
   "presets": [

--- a/packages/angular/src/builders/webpack-server/schema.json
+++ b/packages/angular/src/builders/webpack-server/schema.json
@@ -3,7 +3,7 @@
   "outputCapture": "direct-nodejs",
   "$schema": "http://json-schema.org/draft-07/schema",
   "title": "Schema for Webpack Server",
-  "description": "The webpack-dev-server executor is very similar to the standard server builder provided by the Angular Devkit. It is usually used in tandem with `@nrwl/angular:webpack-browser` when your Angular application uses a custom webpack configuration and NgUniversal for SSR.",
+  "description": "The webpack-dev-server executor is very similar to the standard server builder provided by the Angular Devkit. It is usually used in tandem with `@nx/angular:webpack-browser` when your Angular application uses a custom webpack configuration and NgUniversal for SSR.",
   "type": "object",
   "properties": {
     "assets": {

--- a/packages/angular/src/generators/add-linting/schema.json
+++ b/packages/angular/src/generators/add-linting/schema.json
@@ -7,7 +7,7 @@
   "type": "object",
   "examples": [
     {
-      "command": "nx g @nrwl/angular:add-linting --prefix=cool --projectName=cool-lib --projectRoot=libs/cool-lib",
+      "command": "nx g @nx/angular:add-linting --prefix=cool --projectName=cool-lib --projectRoot=libs/cool-lib",
       "description": "Adds ESLint with Angular-specific rules for an existing project named `cool-lib` with the [prefix](https://angular.io/guide/styleguide#style-02-07) `cool`"
     }
   ],

--- a/packages/angular/src/generators/convert-to-with-mf/schema.json
+++ b/packages/angular/src/generators/convert-to-with-mf/schema.json
@@ -8,7 +8,7 @@
   "additionalProperties": false,
   "examples": [
     {
-      "command": "nx g @nrwl/angular:convert-to-with-mf --project mf-app",
+      "command": "nx g @nx/angular:convert-to-with-mf --project mf-app",
       "description": "Convert a Module Federation Project using legacy webpack config to use the `withModuleFederation` helper."
     }
   ],

--- a/packages/angular/src/generators/host/schema.json
+++ b/packages/angular/src/generators/host/schema.json
@@ -7,7 +7,7 @@
   "type": "object",
   "examples": [
     {
-      "command": "nx g @nrwl/angular:host appName --remotes=remote1",
+      "command": "nx g @nx/angular:host appName --remotes=remote1",
       "description": "Create an Angular application with configuration in place for Module Federation. If the `remotes` option is provided, attach the remote application to this application's configuration"
     }
   ],

--- a/packages/angular/src/generators/init/schema.json
+++ b/packages/angular/src/generators/init/schema.json
@@ -3,12 +3,12 @@
   "$id": "SchematicsAngularModuleInit",
   "cli": "nx",
   "title": "Init Angular Plugin",
-  "description": "Initializes the `@nrwl/angular` plugin. NOTE: Does not work in the `--dry-run` mode.",
+  "description": "Initializes the `@nx/angular` plugin. NOTE: Does not work in the `--dry-run` mode.",
   "type": "object",
   "examples": [
     {
-      "command": "nx g @nrwl/angular:init --style=scss",
-      "description": "Installs angular dependencies and initializes the `@nrwl/angular` plugin with the `scss` stylesheet format."
+      "command": "nx g @nx/angular:init --style=scss",
+      "description": "Installs angular dependencies and initializes the `@nx/angular` plugin with the `scss` stylesheet format."
     }
   ],
   "properties": {
@@ -28,7 +28,7 @@
     },
     "skipInstall": {
       "type": "boolean",
-      "description": "Skip installing after adding `@nrwl/workspace`.",
+      "description": "Skip installing after adding `@nx/workspace`.",
       "default": false,
       "x-priority": "internal"
     },

--- a/packages/angular/src/generators/move/schema.json
+++ b/packages/angular/src/generators/move/schema.json
@@ -7,7 +7,7 @@
   "type": "object",
   "examples": [
     {
-      "command": "nx g @nrwl/angular:move --project my-feature-lib --destination shared/my-feature-lib",
+      "command": "nx g @nx/angular:move --project my-feature-lib --destination shared/my-feature-lib",
       "description": "Move libs/my-feature-lib to libs/shared/my-feature-lib."
     }
   ],

--- a/packages/angular/src/generators/ngrx/schema.json
+++ b/packages/angular/src/generators/ngrx/schema.json
@@ -7,19 +7,19 @@
   "type": "object",
   "examples": [
     {
-      "command": "nx g @nrwl/angular:ngrx --root --parent=apps/my-app/src/app/app.module.ts --facade=false placeholder",
+      "command": "nx g @nx/angular:ngrx --root --parent=apps/my-app/src/app/app.module.ts --facade=false placeholder",
       "description": "Add root ngrx configration to the `my-app` application"
     },
     {
-      "command": "nx g @nrwl/angular:ngrx --parent=libs/my-lib/src/lib/my-lib.module.ts --facade=true --root=false users",
+      "command": "nx g @nx/angular:ngrx --parent=libs/my-lib/src/lib/my-lib.module.ts --facade=true --root=false users",
       "description": "Add a `users` state with a facade to the `my-lib` library. It will be tracked under the default `+state` folder in the lib"
     },
     {
-      "command": "nx g @nrwl/angular:ngrx --parent=apps/my-app/src/app/app.config.ts --root",
+      "command": "nx g @nx/angular:ngrx --parent=apps/my-app/src/app/app.config.ts --root",
       "description": "Add a root state configuration to `my-app` when `my-app` uses Standalone APIs"
     },
     {
-      "command": "nx g @nrwl/angular:ngrx --parent=libs/my-lib/src/lib.routes.ts users",
+      "command": "nx g @nx/angular:ngrx --parent=libs/my-lib/src/lib.routes.ts users",
       "description": "Add a `users` feature state to the Route definition of a library using Standalone APIs"
     }
   ],

--- a/packages/angular/src/generators/remote/schema.json
+++ b/packages/angular/src/generators/remote/schema.json
@@ -7,7 +7,7 @@
   "type": "object",
   "examples": [
     {
-      "command": "nx g @nrwl/angular:remote appName --host=host --port=4201",
+      "command": "nx g @nx/angular:remote appName --host=host --port=4201",
       "description": "Create an Angular app with configuration in place for Module Federation. If host is provided, attach this remote app to host app's configuration."
     }
   ],

--- a/packages/angular/src/generators/scam-directive/schema.json
+++ b/packages/angular/src/generators/scam-directive/schema.json
@@ -6,7 +6,7 @@
   "type": "object",
   "examples": [
     {
-      "command": "nx g @nrwl/angular:scam-directive --project=my-lib --flat=false my-sample",
+      "command": "nx g @nx/angular:scam-directive --project=my-lib --flat=false my-sample",
       "description": "Generate a `MySampleDirective` directive in a `my-sample` folder in the `my-lib` library"
     }
   ],

--- a/packages/angular/src/generators/scam-pipe/schema.json
+++ b/packages/angular/src/generators/scam-pipe/schema.json
@@ -6,7 +6,7 @@
   "type": "object",
   "examples": [
     {
-      "command": "nx g @nrwl/angular:scam-pipe --project=my-lib --flat=false my-transformation",
+      "command": "nx g @nx/angular:scam-pipe --project=my-lib --flat=false my-transformation",
       "description": "Generates a `MyTransformationPipe` in a `my-transformation` folder in the `my-lib` project"
     }
   ],

--- a/packages/angular/src/generators/scam/schema.json
+++ b/packages/angular/src/generators/scam/schema.json
@@ -6,7 +6,7 @@
   "type": "object",
   "examples": [
     {
-      "command": "nx g @nrwl/angular:scam --project=my-lib my-sample",
+      "command": "nx g @nx/angular:scam --project=my-lib my-sample",
       "description": "Generate a `MySampleComponent` component in the `my-lib` library."
     }
   ],

--- a/packages/cypress/src/generators/cypress-component-configuration/schema.json
+++ b/packages/cypress/src/generators/cypress-component-configuration/schema.json
@@ -7,7 +7,7 @@
   "type": "object",
   "examples": [
     {
-      "command": "nx g @nrwl/cypress:cypress-component-configuration --project=my-cool-lib ",
+      "command": "nx g @nx/cypress:cypress-component-configuration --project=my-cool-lib ",
       "description": "Add cypress component testing to an existing project named my-cool-lib"
     }
   ],

--- a/packages/cypress/src/generators/migrate-to-cypress-11/schema.json
+++ b/packages/cypress/src/generators/migrate-to-cypress-11/schema.json
@@ -7,7 +7,7 @@
   "type": "object",
   "examples": [
     {
-      "command": "nx g @nrwl/cypress:migrate-to-cypress-11",
+      "command": "nx g @nx/cypress:migrate-to-cypress-11",
       "description": "Migrate existing cypress projects to Cypress v11"
     }
   ],

--- a/packages/expo/src/generators/application/schema.json
+++ b/packages/expo/src/generators/application/schema.json
@@ -5,11 +5,11 @@
   "description": "Create an Expo Application for Nx.",
   "examples": [
     {
-      "command": "g @nrwl/expo:app myapp --directory=nested",
+      "command": "g @nx/expo:app myapp --directory=nested",
       "description": "Generate apps/nested/myapp"
     },
     {
-      "command": "g @nrwl/expo:app myapp --classComponent",
+      "command": "g @nx/expo:app myapp --classComponent",
       "description": "Use class components instead of functional components"
     }
   ],

--- a/packages/expo/src/generators/component/schema.json
+++ b/packages/expo/src/generators/component/schema.json
@@ -6,11 +6,11 @@
   "type": "object",
   "examples": [
     {
-      "command": "g @nrwl/expo:component my-component --project=mylib",
+      "command": "g @nx/expo:component my-component --project=mylib",
       "description": "Generate a component in the mylib library"
     },
     {
-      "command": "g @nrwl/expo:component my-component --project=mylib --classComponent",
+      "command": "g @nx/expo:component my-component --project=mylib --classComponent",
       "description": "Generate a class component in the mylib library"
     }
   ],

--- a/packages/expo/src/generators/library/schema.json
+++ b/packages/expo/src/generators/library/schema.json
@@ -6,7 +6,7 @@
   "type": "object",
   "examples": [
     {
-      "command": "g @nrwl/expo:lib mylib --directory=myapp",
+      "command": "g @nx/expo:lib mylib --directory=myapp",
       "description": "Generate libs/myapp/mylib"
     }
   ],

--- a/packages/js/src/generators/init/schema.json
+++ b/packages/js/src/generators/init/schema.json
@@ -2,8 +2,8 @@
   "$schema": "http://json-schema.org/schema",
   "$id": "NxTypescriptInit",
   "cli": "nx",
-  "title": "Init nrwl/js",
-  "description": "Init generator placeholder for nrwl/js.",
+  "title": "Init nx/js",
+  "description": "Init generator placeholder for nx/js.",
   "properties": {
     "js": {
       "type": "boolean",

--- a/packages/linter/src/generators/workspace-rules-project/schema.json
+++ b/packages/linter/src/generators/workspace-rules-project/schema.json
@@ -7,7 +7,7 @@
   "type": "object",
   "examples": [
     {
-      "command": "nx g @nrwl/linter:workspace-rules-project",
+      "command": "nx g @nx/linter:workspace-rules-project",
       "description": "Create the Workspace Lint Rules Project"
     }
   ],

--- a/packages/next/src/generators/cypress-component-configuration/schema.json
+++ b/packages/next/src/generators/cypress-component-configuration/schema.json
@@ -7,11 +7,11 @@
   "type": "object",
   "examples": [
     {
-      "command": "nx g @nrwl/next:cypress-component-configuration --project=my-next-project",
+      "command": "nx g @nx/next:cypress-component-configuration --project=my-next-project",
       "description": "Add component testing to your Next project"
     },
     {
-      "command": "nx g @nrwl/next:cypress-component-configuration --project=my-next-project --generate-tests",
+      "command": "nx g @nx/next:cypress-component-configuration --project=my-next-project --generate-tests",
       "description": "Add component testing to your Next project and generate component tests for your existing components"
     }
   ],

--- a/packages/plugin/src/generators/preset/schema.json
+++ b/packages/plugin/src/generators/preset/schema.json
@@ -3,7 +3,7 @@
   "cli": "nx",
   "$id": "NxPluginPreset",
   "title": "Generator ran by create-nx-plugin",
-  "description": "Initializes a workspace with an nx-plugin inside of it. Use as: `create-nx-plugin` or `create-nx-workspace --preset @nrwl/nx-plugin`.",
+  "description": "Initializes a workspace with an nx-plugin inside of it. Use as: `create-nx-plugin` or `create-nx-workspace --preset @nx/nx-plugin`.",
   "type": "object",
   "properties": {
     "pluginName": {

--- a/packages/react-native/src/generators/application/schema.json
+++ b/packages/react-native/src/generators/application/schema.json
@@ -6,11 +6,11 @@
   "description": "Create a React Application for Nx.",
   "examples": [
     {
-      "command": "nx g @nrwl/react-native:app myapp --directory=nested",
+      "command": "nx g @nx/react-native:app myapp --directory=nested",
       "description": "Generate `apps/nested/myapp`"
     },
     {
-      "command": "nx g @nrwl/react-native:app myapp --classComponent",
+      "command": "nx g @nx/react-native:app myapp --classComponent",
       "description": "Use class components instead of functional components"
     }
   ],

--- a/packages/react-native/src/generators/component/schema.json
+++ b/packages/react-native/src/generators/component/schema.json
@@ -7,11 +7,11 @@
   "type": "object",
   "examples": [
     {
-      "command": "nx g @nrwl/react-native:component my-component --project=mylib",
+      "command": "nx g @nx/react-native:component my-component --project=mylib",
       "description": "Generate a component in the `mylib` library"
     },
     {
-      "command": "nx g @nrwl/react-native:component my-component --project=mylib --classComponent",
+      "command": "nx g @nx/react-native:component my-component --project=mylib --classComponent",
       "description": "Generate a class component in the `mylib` library"
     }
   ],

--- a/packages/react-native/src/generators/library/schema.json
+++ b/packages/react-native/src/generators/library/schema.json
@@ -7,7 +7,7 @@
   "type": "object",
   "examples": [
     {
-      "command": "nx g @nrwl/react-native:lib mylib --directory=myapp",
+      "command": "nx g @nx/react-native:lib mylib --directory=myapp",
       "description": "Generate `libs/myapp/mylib`"
     }
   ],

--- a/packages/react/src/generators/application/application.ts
+++ b/packages/react/src/generators/application/application.ts
@@ -145,7 +145,7 @@ export async function applicationGenerator(
     tasks.push(webpackInitTask);
   } else if (options.bundler === 'rspack') {
     const { configurationGenerator } = ensurePackage(
-      '@nrwl/rspack',
+      '@nx/rspack',
       nxRspackVersion
     );
     const rspackTask = await configurationGenerator(host, {
@@ -231,7 +231,7 @@ export async function applicationGenerator(
     host.write(
       joinPathFragments(options.appProjectRoot, 'rspack.config.js'),
       stripIndents`
-        const { composePlugins, withNx, withWeb } = require('@nrwl/rspack');
+        const { composePlugins, withNx, withWeb } = require('@nx/rspack');
         module.exports = composePlugins(withNx(), withWeb(), (config) => {
           config.module.rules.push({
             test: /\\.[jt]sx$/i,

--- a/packages/react/src/generators/component-test/schema.json
+++ b/packages/react/src/generators/component-test/schema.json
@@ -7,7 +7,7 @@
   "type": "object",
   "examples": [
     {
-      "command": "nx g @nrwl/react:component-test --project=my-react-project --component-path=src/lib/fancy-component.tsx",
+      "command": "nx g @nx/react:component-test --project=my-react-project --component-path=src/lib/fancy-component.tsx",
       "description": "Create a cypress component test for FancyComponent"
     }
   ],

--- a/packages/react/src/generators/cypress-component-configuration/schema.json
+++ b/packages/react/src/generators/cypress-component-configuration/schema.json
@@ -7,11 +7,11 @@
   "type": "object",
   "examples": [
     {
-      "command": "nx g @nrwl/react:cypress-component-configuration --project=my-react-project",
+      "command": "nx g @nx/react:cypress-component-configuration --project=my-react-project",
       "description": "Add component testing to your react project"
     },
     {
-      "command": "nx g @nrwl/react:cypress-component-configuration --project=my-react-project --generate-tests",
+      "command": "nx g @nx/react:cypress-component-configuration --project=my-react-project --generate-tests",
       "description": "Add component testing to your react project and generate component tests for your existing components"
     }
   ],

--- a/packages/vite/src/generators/configuration/schema.json
+++ b/packages/vite/src/generators/configuration/schema.json
@@ -40,15 +40,15 @@
     },
     "buildTarget": {
       "type": "string",
-      "description": "The build target of the project to be transformed to use the @nrwl/vite:build executor."
+      "description": "The build target of the project to be transformed to use the @nx/vite:build executor."
     },
     "serveTarget": {
       "type": "string",
-      "description": "The serve target of the project to be transformed to use the @nrwl/vite:dev-server and @nrwl/vite:preview-server executors."
+      "description": "The serve target of the project to be transformed to use the @nx/vite:dev-server and @nrwl/vite:preview-server executors."
     },
     "testTarget": {
       "type": "string",
-      "description": "The test target of the project to be transformed to use the @nrwl/vite:test executor."
+      "description": "The test target of the project to be transformed to use the @nx/vite:test executor."
     },
     "skipFormat": {
       "description": "Skip formatting files.",

--- a/packages/vite/src/generators/vitest/schema.json
+++ b/packages/vite/src/generators/vitest/schema.json
@@ -35,7 +35,7 @@
     },
     "testTarget": {
       "type": "string",
-      "description": "The test target of the project to be transformed to use the @nrwl/vite:test executor.",
+      "description": "The test target of the project to be transformed to use the @nx/vite:test executor.",
       "hidden": true
     },
     "skipFormat": {

--- a/packages/workspace/src/generators/convert-to-nx-project/schema.json
+++ b/packages/workspace/src/generators/convert-to-nx-project/schema.json
@@ -1,17 +1,17 @@
 {
   "$schema": "http://json-schema.org/schema",
   "$id": "SchematicsConvertToNxProject",
-  "title": "@nrwl/workspace:fix-configuration",
+  "title": "@nx/workspace:fix-configuration",
   "description": "Migrates v1 config to v2 standalone configuration.",
   "type": "object",
   "cli": "nx",
   "examples": [
     {
-      "command": "nx g @nrwl/workspace:convert-to-nx-project --project my-feature-lib",
+      "command": "nx g @nx/workspace:convert-to-nx-project --project my-feature-lib",
       "description": "Convert the `my-feature-lib` project to use `project.json` file instead of `workspace.json`"
     },
     {
-      "command": "nx g @nrwl/workspace:convert-to-nx-project --all",
+      "command": "nx g @nx/workspace:convert-to-nx-project --all",
       "description": "Convert all projects in `workspace.json` to separate `project.json` files"
     }
   ],

--- a/packages/workspace/src/generators/move/schema.json
+++ b/packages/workspace/src/generators/move/schema.json
@@ -7,7 +7,7 @@
   "type": "object",
   "examples": [
     {
-      "command": "nx g @nrwl/workspace:move --project my-feature-lib --destination shared/my-feature-lib",
+      "command": "nx g @nx/workspace:move --project my-feature-lib --destination shared/my-feature-lib",
       "description": "Move `libs/my-feature-lib` to `libs/shared/my-feature-lib`"
     }
   ],

--- a/packages/workspace/src/generators/remove/schema.json
+++ b/packages/workspace/src/generators/remove/schema.json
@@ -7,11 +7,11 @@
   "type": "object",
   "examples": [
     {
-      "command": "nx g @nrwl/workspace:remove my-feature-lib",
+      "command": "nx g @nx/workspace:remove my-feature-lib",
       "description": "Remove `my-feature-lib` from the workspace"
     },
     {
-      "command": "nx g @nrwl/workspace:remove my-feature-lib --forceRemove",
+      "command": "nx g @nx/workspace:remove my-feature-lib --forceRemove",
       "description": "Force removal of `my-feature-lib` from the workspace"
     }
   ],

--- a/packages/workspace/src/generators/run-commands/schema.json
+++ b/packages/workspace/src/generators/run-commands/schema.json
@@ -7,7 +7,7 @@
   "cli": "nx",
   "examples": [
     {
-      "command": "nx g @nrwl/workspace:run-commands printhello --project my-feature-lib --command 'echo hello'",
+      "command": "nx g @nx/workspace:run-commands printhello --project my-feature-lib --command 'echo hello'",
       "description": "Add the `printhello` target to `my-feature-lib`"
     }
   ],


### PR DESCRIPTION
nx-labs repo now publishes under the `@nx` scope which should be reflected in the docs<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
references packages from nx-labs as nrwl/<package>

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
nx-labs packages are referred via the @nx scope now. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

also updated all schema.json files that still contained nrwl to nx.

Fixes #
