### PR TITLE
feat(nx-plugin): replace @nx/plugin:e2e with @nx/jest:jest

### DIFF
--- a/docs/generated/packages/plugin/executors/e2e.json
+++ b/docs/generated/packages/plugin/executors/e2e.json
@@ -201,6 +201,7 @@
     "presets": []
   },
   "description": "Creates and runs the E2E tests for an Nx Plugin.",
+  "x-deprecated": "@nx/plugin:e2e is deprecated and will be removed in Nx 18. Use @nx/jest:jest instead.",
   "aliases": [],
   "hidden": false,
   "path": "/packages/plugin/src/executors/e2e/schema.json",

--- a/packages/plugin/executors.json
+++ b/packages/plugin/executors.json
@@ -3,14 +3,16 @@
     "e2e": {
       "implementation": "./src/executors/e2e/compat",
       "schema": "./src/executors/e2e/schema.json",
-      "description": "Creates and runs the E2E tests for an Nx Plugin."
+      "description": "Creates and runs the E2E tests for an Nx Plugin.",
+      "x-deprecated": "@nx/plugin:e2e is deprecated and will be removed in Nx 18. Use @nx/jest:jest instead."
     }
   },
   "executors": {
     "e2e": {
       "implementation": "./src/executors/e2e/e2e.impl",
       "schema": "./src/executors/e2e/schema.json",
-      "description": "Creates and runs the E2E tests for an Nx Plugin."
+      "description": "Creates and runs the E2E tests for an Nx Plugin.",
+      "x-deprecated": "@nx/plugin:e2e is deprecated and will be removed in Nx 18. Use @nx/jest:jest instead."
     }
   }
 }

--- a/packages/plugin/migrations.json
+++ b/packages/plugin/migrations.json
@@ -41,6 +41,12 @@
       "version": "16.0.0-beta.1",
       "description": "Replace @nrwl/nx-plugin with @nx/plugin",
       "implementation": "./src/migrations/update-16-0-0-add-nx-packages/update-16-0-0-add-nx-packages"
+    },
+    "update-16-2-0-replace-e2e-executor": {
+      "cli": "nx",
+      "version": "16.2.0-beta.0",
+      "description": "Replace @nx/plugin:e2e with @nx/jest",
+      "implementation": "./src/migrations/update-16-2-0/replace-e2e-executor"
     }
   }
 }

--- a/packages/plugin/src/generators/e2e-project/e2e.spec.ts
+++ b/packages/plugin/src/generators/e2e-project/e2e.spec.ts
@@ -4,7 +4,6 @@ import {
   readProjectConfiguration,
   readJson,
   getProjects,
-  joinPathFragments,
 } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { e2eProjectGenerator } from './e2e';
@@ -88,7 +87,7 @@ describe('NxPlugin e2e-project Generator', () => {
     expect(project.root).toBe('apps/namespace/my-plugin-e2e');
   });
 
-  it('should update the tags and implicit dependencies', async () => {
+  it('should update the implicit dependencies', async () => {
     await e2eProjectGenerator(tree, {
       pluginName: 'my-plugin',
       pluginOutputPath: `dist/libs/my-plugin`,
@@ -97,7 +96,6 @@ describe('NxPlugin e2e-project Generator', () => {
     const projects = Object.fromEntries(getProjects(tree));
     expect(projects).toMatchObject({
       'my-plugin-e2e': {
-        tags: [],
         implicitDependencies: ['my-plugin'],
       },
     });
@@ -115,10 +113,28 @@ describe('NxPlugin e2e-project Generator', () => {
     expect(project).toBeTruthy();
     expect(project.root).toEqual('apps/my-plugin-e2e');
     expect(project.targets.e2e).toBeTruthy();
-    expect(project.targets.e2e).toMatchObject({
-      executor: '@nx/plugin:e2e',
-      options: expect.objectContaining({ target: 'my-plugin:build' }),
-    });
+    expect(project.targets.e2e).toMatchInlineSnapshot(`
+      {
+        "configurations": {
+          "ci": {
+            "ci": true,
+            "codeCoverage": true,
+          },
+        },
+        "dependsOn": [
+          "^build",
+        ],
+        "executor": "@nx/jest:jest",
+        "options": {
+          "jestConfig": "apps/my-plugin-e2e/jest.config.ts",
+          "passWithNoTests": true,
+          "runInBand": true,
+        },
+        "outputs": [
+          "{workspaceRoot}/coverage/{projectRoot}",
+        ],
+      }
+    `);
   });
 
   it('should add jest support', async () => {

--- a/packages/plugin/src/migrations/update-16-2-0/replace-e2e-executor.spec.ts
+++ b/packages/plugin/src/migrations/update-16-2-0/replace-e2e-executor.spec.ts
@@ -1,0 +1,68 @@
+import {
+  Tree,
+  readJson,
+  updateJson,
+  addProjectConfiguration,
+  readProjectConfiguration,
+} from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import replaceE2EExecutor from './replace-e2e-executor';
+
+describe('update-16-0-0-add-nx-packages', () => {
+  let tree: Tree;
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+
+    addProjectConfiguration(tree, 'proj1', {
+      root: 'proj1',
+      targets: {
+        build: {
+          executor: '@nx/js:rollup',
+        },
+        e2e: {
+          executor: '@nx/plugin:e2e',
+          options: {
+            target: 'proj1:build',
+          },
+          configurations: {
+            ci: {
+              ci: true,
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('should replace @nrwl/nx-plugin:e2e with @nx/jest:jest', async () => {
+    await replaceE2EExecutor(tree);
+
+    expect(readProjectConfiguration(tree, 'proj1')).toMatchInlineSnapshot(`
+      {
+        "$schema": "../node_modules/nx/schemas/project-schema.json",
+        "name": "proj1",
+        "root": "proj1",
+        "targets": {
+          "build": {
+            "executor": "@nx/js:rollup",
+          },
+          "e2e": {
+            "configurations": {
+              "ci": {
+                "ci": true,
+                "runInBand": true,
+              },
+            },
+            "dependsOn": [
+              "proj1:build",
+            ],
+            "executor": "@nx/jest:jest",
+            "options": {
+              "runInBand": true,
+            },
+          },
+        },
+      }
+    `);
+  });
+});

--- a/packages/plugin/src/migrations/update-16-2-0/replace-e2e-executor.ts
+++ b/packages/plugin/src/migrations/update-16-2-0/replace-e2e-executor.ts
@@ -1,0 +1,42 @@
+import {
+  Tree,
+  formatFiles,
+  getProjects,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+import { forEachExecutorOptions } from '@nx/devkit/src/generators/executor-options-utils';
+import type { NxPluginE2EExecutorOptions } from '@nx/plugin/src/executors/e2e/schema';
+
+export default async function replaceE2EExecutor(tree: Tree): Promise<void> {
+  const projects = getProjects(tree);
+  for (const executor of ['@nx/plugin:e2e', '@nrwl/nx-plugin:e2e']) {
+    forEachExecutorOptions<NxPluginE2EExecutorOptions>(
+      tree,
+      executor,
+      (options, project, target, configuration) => {
+        const projectConfiguration = projects.get(project);
+
+        const config = {
+          ...options,
+          target: undefined,
+          runInBand: true,
+        };
+        if (configuration) {
+          projectConfiguration.targets[target].configurations[configuration] =
+            config;
+        } else {
+          projectConfiguration.targets[target].dependsOn = [
+            ...(projectConfiguration.targets[target].dependsOn ?? []),
+            options.target,
+          ];
+          projectConfiguration.targets[target].executor = '@nx/jest:jest';
+          projectConfiguration.targets[target].options = config;
+        }
+
+        updateProjectConfiguration(tree, project, projectConfiguration);
+      }
+    );
+  }
+
+  await formatFiles(tree);
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Nx Plugins use `@nx/plugin:e2e` which is a wrapper around `@nx/jest:jest`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Nx Plugins will now use `@nx/jest:jest` directly. `@nx/plugin:e2e` is deprecated and will be removed in Nx 18.

There is a migration to change over to `@nx/jest:jest` and there is a warning printed when `@nx/plugin::e2e` is used.

There is also a warning on nx.dev

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
