### PR TITLE
fix(nextjs): withNx works with production build

### DIFF
--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -5,7 +5,6 @@
 import * as path from 'path';
 import type { NextConfig } from 'next';
 import type { NextConfigFn } from '../src/utils/config';
-import { forNextVersion } from '../src/utils/config';
 import type { NextBuildBuilderOptions } from '../src/utils/types';
 import type { DependentBuildableProjectNode } from '@nx/js/src/utils/buildable-libs-utils';
 import type { ProjectGraph, ProjectGraphProjectNode, Target } from '@nx/devkit';
@@ -463,6 +462,15 @@ export function getAliasForProject(
   }
 
   return null;
+}
+
+// Runs a function if the Next.js version satisfies the range.
+export function forNextVersion(range: string, fn: () => void) {
+  const semver = require('semver');
+  const nextJsVersion = require('next/package.json').version;
+  if (semver.satisfies(nextJsVersion, range)) {
+    fn();
+  }
 }
 
 // Support for older generated code: `const withNx = require('@nx/next/plugins/with-nx');`

--- a/packages/next/src/utils/config.ts
+++ b/packages/next/src/utils/config.ts
@@ -107,12 +107,3 @@ function isTsRule(r: RuleSetRule): boolean {
 
   return r.test.test('a.ts');
 }
-
-// Runs a function if the Next.js version satisfies the range.
-export function forNextVersion(range: string, fn: () => void) {
-  const semver = require('semver');
-  const nextJsVersion = require('next/package.json').version;
-  if (semver.satisfies(nextJsVersion, range)) {
-    fn();
-  }
-}


### PR DESCRIPTION
Inline `forNextVersion` function in `with-nx.ts` so it can be used in production build.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16850
