### PR TITLE
fix(devkit): catch errors resolving configs while formatting files

### DIFF
--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -29,28 +29,28 @@ export async function formatFiles(tree: Tree): Promise<void> {
 
   await Promise.all(
     Array.from(files).map(async (file) => {
-      const systemPath = path.join(tree.root, file.path);
-
-      const resolvedOptions = await prettier.resolveConfig(systemPath, {
-        editorconfig: true,
-      });
-
-      const options: Prettier.Options = {
-        ...resolvedOptions,
-        ...changedPrettierInTree,
-        filepath: systemPath,
-      };
-
-      if (file.path.endsWith('.swcrc')) {
-        options.parser = 'json';
-      }
-
-      const support = await prettier.getFileInfo(systemPath, options as any);
-      if (support.ignored || !support.inferredParser) {
-        return;
-      }
-
       try {
+        const systemPath = path.join(tree.root, file.path);
+
+        const resolvedOptions = await prettier.resolveConfig(systemPath, {
+          editorconfig: true,
+        });
+
+        const options: Prettier.Options = {
+          ...resolvedOptions,
+          ...changedPrettierInTree,
+          filepath: systemPath,
+        };
+
+        if (file.path.endsWith('.swcrc')) {
+          options.parser = 'json';
+        }
+
+        const support = await prettier.getFileInfo(systemPath, options as any);
+        if (support.ignored || !support.inferredParser) {
+          return;
+        }
+
         tree.write(
           file.path,
           prettier.format(file.content.toString('utf-8'), options)

--- a/packages/nx/src/generators/internal-utils/format-changed-files-with-prettier-if-available.ts
+++ b/packages/nx/src/generators/internal-utils/format-changed-files-with-prettier-if-available.ts
@@ -21,28 +21,28 @@ export async function formatChangedFilesWithPrettierIfAvailable(
   );
   await Promise.all(
     Array.from(files).map(async (file) => {
-      const systemPath = path.join(tree.root, file.path);
-      let options: any = {
-        filepath: systemPath,
-      };
-
-      const resolvedOptions = await prettier.resolveConfig(systemPath, {
-        editorconfig: true,
-      });
-      if (!resolvedOptions) {
-        return;
-      }
-      options = {
-        ...options,
-        ...resolvedOptions,
-      };
-
-      const support = await prettier.getFileInfo(systemPath, options);
-      if (support.ignored || !support.inferredParser) {
-        return;
-      }
-
       try {
+        const systemPath = path.join(tree.root, file.path);
+        let options: any = {
+          filepath: systemPath,
+        };
+
+        const resolvedOptions = await prettier.resolveConfig(systemPath, {
+          editorconfig: true,
+        });
+        if (!resolvedOptions) {
+          return;
+        }
+        options = {
+          ...options,
+          ...resolvedOptions,
+        };
+
+        const support = await prettier.getFileInfo(systemPath, options);
+        if (support.ignored || !support.inferredParser) {
+          return;
+        }
+
         tree.write(
           file.path,
           prettier.format(file.content.toString('utf-8'), options)


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

A malformed `package.json` will cause prettier to fail when trying to resolve a config.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Errors resolving a config are caught when formatting files.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
