### PR TITLE
chore(js): set unitTestRunner default to none for @nx/js:library to reflect actual behavior

### DIFF
--- a/docs/generated/packages/js/generators/library.json
+++ b/docs/generated/packages/js/generators/library.json
@@ -31,7 +31,8 @@
         "type": "string",
         "enum": ["jest", "vitest", "none"],
         "description": "Test runner to use for unit tests.",
-        "x-prompt": "Which unit test runner would you like to use?"
+        "x-prompt": "Which unit test runner would you like to use?",
+        "default": "none"
       },
       "tags": {
         "type": "string",

--- a/packages/js/src/generators/library/schema.json
+++ b/packages/js/src/generators/library/schema.json
@@ -31,7 +31,8 @@
       "type": "string",
       "enum": ["jest", "vitest", "none"],
       "description": "Test runner to use for unit tests.",
-      "x-prompt": "Which unit test runner would you like to use?"
+      "x-prompt": "Which unit test runner would you like to use?",
+      "default": "none"
     },
     "tags": {
       "type": "string",


### PR DESCRIPTION
## Current Behavior
`@nx/js:library`'s `unitTestRunner` doesn't have a default value even though it actually just defaults to `none`. 
In Nx Console, for example, this results in duplicate `empty` and `none` selection options.

## Expected Behavior
Default value should reflect actual behavior


