### PR TITLE
fix(core): provide more info for "findOriginalKeys is not a function" errors

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/yarn-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/yarn-parser.ts
@@ -285,7 +285,13 @@ function mapSnapshots(
 
   // collect snapshots and their matching keys
   Object.values(nodes).forEach((node) => {
-    const [matchedKeys, snapshot] = findOriginalKeys(groupedDependencies, node);
+    const foundOriginalKeys = findOriginalKeys(groupedDependencies, node);
+    if (!foundOriginalKeys) {
+      throw new Error(
+        `Original key(s) not found for "${node.data.packageName}@${node.data.version}" while pruning yarn.lock.`
+      );
+    }
+    const [matchedKeys, snapshot] = foundOriginalKeys;
     snapshotMap.set(snapshot, new Set(matchedKeys));
 
     // separately save keys that still exist


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When pruning fails on `yarn.lock` is often fails with `findOriginalKeys is not a function or its return value is not iterable` because we can't map back to the original key. This gives us no information about which package failed to help us investigate further.

## Expected Behavior
This error should return more information about which package is failing.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Related to #16825 and #16875
