### PR TITLE
fix(nextjs): inline dev-only dependencies and add e2e test to catch issues

### DIFF
--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -177,6 +177,12 @@ describe('Next.js Applications', () => {
       `dist/packages/${appName}/public/shared/ui/hello.txt`
     );
 
+    // Check that compiled next config does not contain bad imports
+    const nextConfigPath = `dist/packages/${appName}/next.config.js`;
+    expect(nextConfigPath).not.toContain(`require("../`); // missing relative paths
+    expect(nextConfigPath).not.toContain(`require("nx/`); // dev-only packages
+    expect(nextConfigPath).not.toContain(`require("@nx/`); // dev-only packages
+
     // Check that `nx serve <app> --prod` works with previous production build (e.g. `nx build <app>`).
     const prodServePort = 4000;
     const prodServeProcess = await runCommandUntil(

--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -8,8 +8,6 @@ import type { NextConfigFn } from '../src/utils/config';
 import type { NextBuildBuilderOptions } from '../src/utils/types';
 import type { DependentBuildableProjectNode } from '@nx/js/src/utils/buildable-libs-utils';
 import type { ProjectGraph, ProjectGraphProjectNode, Target } from '@nx/devkit';
-import { readTsConfigPaths } from '@nx/js';
-import { findAllProjectNodeDependencies } from 'nx/src/utils/project-graph-utils';
 
 export interface WithNxOptions extends NextConfig {
   nx?: {
@@ -222,6 +220,10 @@ function withNx(
       forNextVersion('>=13.1.0', () => {
         if (!graph.dependencies[project]) return;
 
+        const { readTsConfigPaths } = require('@nx/js');
+        const {
+          findAllProjectNodeDependencies,
+        } = require('nx/src/utils/project-graph-utils');
         const paths = readTsConfigPaths();
         const deps = findAllProjectNodeDependencies(project);
         nextConfig.transpilePackages ??= [];


### PR DESCRIPTION
This PR moves the dev-only imports to the dev/build phase only. This prevents the imports from being added to the compiled `next.config.js` file.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16882
