### PR TITLE
chore(nextjs): add lint rule to make sure relative imports or imports of nx packages are disallowed

### DIFF
--- a/packages/next/.eslintrc.json
+++ b/packages/next/.eslintrc.json
@@ -20,6 +20,44 @@
       }
     },
     {
+      "files": ["./plugins/with-nx.ts"],
+      "rules": {
+        "@typescript-eslint/no-restricted-imports": [
+          "error",
+          {
+            "paths": [
+              "@nx/workspace",
+              "@angular-devkit/core",
+              "@angular-devkit/architect",
+              "@angular-devkit/schematics"
+            ],
+            "patterns": [
+              {
+                "group": ["**/src/**/*"],
+                "message": "Inline functions instead of importing relative files. Relative files are not available in dist.",
+                "allowTypeImports": true
+              },
+              {
+                "group": ["./**/*"],
+                "message": "Inline functions instead of importing relative files. Relative files are not available in dist.",
+                "allowTypeImports": true
+              },
+              {
+                "group": ["@nx/**/*"],
+                "message": "Do not import Nx plugins.",
+                "allowTypeImports": true
+              },
+              {
+                "group": ["nx/**/*"],
+                "message": "Do not import Nx package.",
+                "allowTypeImports": true
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
       "files": [
         "./package.json",
         "./generators.json",

--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -166,6 +166,7 @@ function withNx(
     const { PHASE_PRODUCTION_SERVER } = await import('next/constants');
     if (phase === PHASE_PRODUCTION_SERVER) {
       // If we are running an already built production server, just return the configuration.
+      // NOTE: Avoid any `require(...)` or `import(...)` statements here. Development dependencies are not available at production runtime.
       const { nx, ...validNextConfig } = _nextConfig;
       return {
         ...validNextConfig,


### PR DESCRIPTION
This is related to a few issues that popped up in the last few weeks.

e.g. https://github.com/nrwl/nx/issues/16882

The lint rules let's us catch this automatically before code is merged. There is also an e2e tests already added just in case we missed any rules.

<img width="2259" alt="Screenshot 2023-05-09 at 4 00 30 PM" src="https://github.com/nrwl/nx/assets/53559/a7cdb623-c9c2-4350-b110-338589cda637">
<img width="1747" alt="Screenshot 2023-05-09 at 3 59 51 PM" src="https://github.com/nrwl/nx/assets/53559/2fbaa9d4-2b67-403e-bdc6-1d2584533d8f">

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Imports may be added without us realizing there's a regression.

## Expected Behavior
Bad imports prevent PR merge.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
