### PR TITLE
feat(nextjs): Use next.js cli for build and serve targets

### DIFF
--- a/docs/generated/packages/next/executors/build.json
+++ b/docs/generated/packages/next/executors/build.json
@@ -68,8 +68,15 @@
       },
       "debug": {
         "type": "boolean",
-        "description": "Enable Next.js debug build logging",
-        "default": false
+        "description": "Enable Next.js debug build logging"
+      },
+      "profile": {
+        "type": "boolean",
+        "description": "Used to enable React Production Profiling"
+      },
+      "experimentalAppOnly": {
+        "type": "boolean",
+        "description": "Only build 'app' routes"
       }
     },
     "required": ["root", "outputPath"],

--- a/docs/generated/packages/next/executors/export.json
+++ b/docs/generated/packages/next/executors/export.json
@@ -33,6 +33,7 @@
     "presets": []
   },
   "description": "Export a Next.js application. The exported application is located at `dist/$outputPath/exported`.",
+  "x-deprecated": "Use static exports in next.config.js instead. See: https://nextjs.org/docs/pages/building-your-application/deploying/static-exports.",
   "aliases": [],
   "hidden": false,
   "path": "/packages/next/src/executors/export/schema.json",

--- a/docs/generated/packages/next/executors/server.json
+++ b/docs/generated/packages/next/executors/server.json
@@ -53,6 +53,10 @@
         "type": "boolean",
         "description": "Read buildable libraries from source instead of building them separately.",
         "default": true
+      },
+      "keepAliveTimeout": {
+        "type": "number",
+        "description": "Max milliseconds to wait before closing inactive connection."
       }
     },
     "required": ["buildTarget"],

--- a/e2e/next/src/utils.ts
+++ b/e2e/next/src/utils.ts
@@ -1,6 +1,7 @@
+import { execSync } from 'child_process';
 import {
   checkFilesExist,
-  killPorts,
+  killPort,
   readJson,
   runCLI,
   runCLIAsync,
@@ -42,10 +43,10 @@ export async function checkApp(
 
   if (opts.checkE2E && runCypressTests()) {
     const e2eResults = runCLI(
-      `e2e ${appName}-e2e --no-watch --configuration=production`
+      `e2e ${appName}-e2e --no-watch --configuration=production --port=9000`
     );
     expect(e2eResults).toContain('All specs passed!');
-    expect(await killPorts()).toBeTruthy();
+    await killPort(9000);
   }
 
   if (opts.checkExport) {

--- a/packages/next/executors.json
+++ b/packages/next/executors.json
@@ -13,7 +13,8 @@
     "export": {
       "implementation": "./src/executors/export/export.impl",
       "schema": "./src/executors/export/schema.json",
-      "description": "Export a Next.js application. The exported application is located at `dist/$outputPath/exported`."
+      "description": "Export a Next.js application. The exported application is located at `dist/$outputPath/exported`.",
+      "x-deprecated": "Use static exports in next.config.js instead. See: https://nextjs.org/docs/pages/building-your-application/deploying/static-exports."
     }
   },
   "builders": {
@@ -30,7 +31,8 @@
     "export": {
       "implementation": "./src/executors/export/compat",
       "schema": "./src/executors/export/schema.json",
-      "description": "Export a Next.js application. The exported application is located at `dist/$outputPath/exported`."
+      "description": "Export a Next.js application. The exported application is located at `dist/$outputPath/exported`.",
+      "x-deprecated": "Use static exports in next.config.js instead. See: https://nextjs.org/docs/pages/building-your-application/deploying/static-exports."
     }
   }
 }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -31,7 +31,7 @@
     "migrations": "./migrations.json"
   },
   "peerDependencies": {
-    "next": "^13.0.0"
+    "next": ">=13.0.0"
   },
   "dependencies": {
     "@babel/plugin-proposal-decorators": "^7.14.5",

--- a/packages/next/src/executors/build/build.impl.ts
+++ b/packages/next/src/executors/build/build.impl.ts
@@ -4,9 +4,9 @@ import {
   readJsonFile,
   workspaceRoot,
   writeJsonFile,
+  logger,
 } from '@nx/devkit';
 import { createLockFile, createPackageJson, getLockFileName } from '@nx/js';
-import build from 'next/dist/build';
 import { join, resolve } from 'path';
 import { copySync, existsSync, mkdir, writeFileSync } from 'fs-extra';
 import { lt, gte } from 'semver';
@@ -17,6 +17,8 @@ import { updatePackageJson } from './lib/update-package-json';
 import { createNextConfigFile } from './lib/create-next-config-file';
 import { checkPublicDirectory } from './lib/check-project';
 import { NextBuildBuilderOptions } from '../../utils/types';
+import { ExecSyncOptions, execSync } from 'child_process';
+import { createCliOptions } from '../../utils/create-cli-options';
 
 export default async function buildExecutor(
   options: NextBuildBuilderOptions,
@@ -42,22 +44,24 @@ export default async function buildExecutor(
     reactDomVersion &&
     gte(checkAndCleanWithSemver('react-dom', reactDomVersion), '18.0.0');
   if (hasReact18) {
-    (process.env as any).__NEXT_REACT_ROOT ||= 'true';
+    process.env['__NEXT_REACT_ROOT'] ||= 'true';
   }
 
-  // Get the installed Next.js version (will be removed after Nx 16 and Next.js update)
-  const nextVersion = require('next/package.json').version;
+  const { experimentalAppOnly, profile, debug } = options;
 
-  const debug = !!process.env.NX_VERBOSE_LOGGING || options.debug;
-
-  // Check the major and minor version numbers
-  if (lt(nextVersion, '13.2.0')) {
-    // If the version is lower than 13.2.0, use the second parameter as the config object
-    await build(root, null, false, debug);
-  } else {
-    // Otherwise, use the third parameter as a boolean flag for verbose logging
-    // @ts-ignore
-    await build(root, false, debug);
+  const args = createCliOptions({ experimentalAppOnly, profile, debug });
+  const command = `npx next build ${args}`;
+  const execSyncOptions: ExecSyncOptions = {
+    stdio: 'inherit',
+    encoding: 'utf-8',
+    cwd: root,
+  };
+  try {
+    execSync(command, execSyncOptions);
+  } catch (error) {
+    logger.error(`Error occurred while trying to run the ${command}`);
+    logger.error(error);
+    return { success: false };
   }
 
   if (!directoryExists(options.outputPath)) {

--- a/packages/next/src/executors/build/schema.json
+++ b/packages/next/src/executors/build/schema.json
@@ -65,8 +65,15 @@
     },
     "debug": {
       "type": "boolean",
-      "description": "Enable Next.js debug build logging",
-      "default": false
+      "description": "Enable Next.js debug build logging"
+    },
+    "profile": {
+      "type": "boolean",
+      "description": "Used to enable React Production Profiling"
+    },
+    "experimentalAppOnly": {
+      "type": "boolean",
+      "description": "Only build 'app' routes"
     }
   },
   "required": ["root", "outputPath"]

--- a/packages/next/src/executors/export/export.impl.ts
+++ b/packages/next/src/executors/export/export.impl.ts
@@ -16,7 +16,7 @@ import {
   NextBuildBuilderOptions,
   NextExportBuilderOptions,
 } from '../../utils/types';
-import { PHASE_EXPORT } from '../../utils/constants';
+
 import nextTrace = require('next/dist/trace');
 import { platform } from 'os';
 import { execFileSync } from 'child_process';
@@ -25,6 +25,18 @@ import * as chalk from 'chalk';
 // platform specific command name
 const pmCmd = platform() === 'win32' ? `npx.cmd` : 'npx';
 
+/**
+ * @deprecated use output inside of your next.config.js
+ * Example
+ * const nextConfig = {
+  nx: {
+    svgr: false,
+  },
+
+  output: 'export'
+};
+ * Read https://nextjs.org/docs/pages/building-your-application/deploying/static-exports
+ **/
 export default async function exportExecutor(
   options: NextExportBuilderOptions,
   context: ExecutorContext
@@ -41,7 +53,6 @@ export default async function exportExecutor(
     dependencies = result.dependencies;
   }
 
-  const libsDir = join(context.root, workspaceLayout().libsDir);
   const buildTarget = parseTargetString(
     options.buildTarget,
     context.projectGraph

--- a/packages/next/src/executors/server/custom-server.impl.ts
+++ b/packages/next/src/executors/server/custom-server.impl.ts
@@ -1,0 +1,67 @@
+import 'dotenv/config';
+import {
+  ExecutorContext,
+  parseTargetString,
+  readTargetOptions,
+  runExecutor,
+} from '@nx/devkit';
+import { join, resolve } from 'path';
+
+import {
+  NextBuildBuilderOptions,
+  NextServeBuilderOptions,
+} from '../../utils/types';
+
+export default async function* serveExecutor(
+  options: NextServeBuilderOptions,
+  context: ExecutorContext
+) {
+  // Cast to any to overwrite NODE_ENV
+  (process.env as any).NODE_ENV = process.env.NODE_ENV
+    ? process.env.NODE_ENV
+    : options.dev
+    ? 'development'
+    : 'production';
+
+  // Setting port that the custom server should use.
+  (process.env as any).PORT = options.port;
+
+  const buildOptions = readTargetOptions<NextBuildBuilderOptions>(
+    parseTargetString(options.buildTarget, context.projectGraph),
+    context
+  );
+  const root = resolve(context.root, buildOptions.root);
+
+  yield* runCustomServer(root, options, context);
+}
+
+async function* runCustomServer(
+  root: string,
+  options: NextServeBuilderOptions,
+  context: ExecutorContext
+) {
+  process.env.NX_NEXT_DIR = root;
+  process.env.NX_NEXT_PUBLIC_DIR = join(root, 'public');
+
+  const baseUrl = `http://${options.hostname || 'localhost'}:${options.port}`;
+
+  const customServerBuild = await runExecutor(
+    parseTargetString(options.customServerTarget, context.projectGraph),
+    {
+      watch: options.dev ? true : false,
+    },
+    context
+  );
+
+  for await (const result of customServerBuild) {
+    if (!result.success) {
+      return result;
+    }
+    yield {
+      success: true,
+      baseUrl,
+    };
+  }
+
+  return { success: true };
+}

--- a/packages/next/src/executors/server/schema.json
+++ b/packages/next/src/executors/server/schema.json
@@ -50,6 +50,10 @@
       "type": "boolean",
       "description": "Read buildable libraries from source instead of building them separately.",
       "default": true
+    },
+    "keepAliveTimeout": {
+      "type": "number",
+      "description": "Max milliseconds to wait before closing inactive connection."
     }
   },
   "required": ["buildTarget"]

--- a/packages/next/src/utils/config.ts
+++ b/packages/next/src/utils/config.ts
@@ -41,7 +41,7 @@ export function createWebpackConfig(
   ): Configuration {
     const mainFields = ['es2015', 'module', 'main'];
     const extensions = ['.ts', '.tsx', '.mjs', '.js', '.jsx'];
-    let tsConfigPath = join(projectRoot, 'tsconfig.json');
+    let tsConfigPath = join(workspaceRoot, projectRoot, 'tsconfig.json');
     if (dependencies.length > 0) {
       tsConfigPath = createTmpTsConfig(
         join(workspaceRoot, tsConfigPath),

--- a/packages/next/src/utils/create-cli-options.ts
+++ b/packages/next/src/utils/create-cli-options.ts
@@ -1,0 +1,12 @@
+export function createCliOptions(obj: { [key: string]: any }): string {
+  return Object.entries(obj)
+    .reduce((arr, [key, value]) => {
+      if (value !== undefined) {
+        const kebabCase = key.replace(/[A-Z]/g, (m) => '-' + m.toLowerCase());
+        return `${arr}--${kebabCase}=${value} `;
+      } else {
+        return arr;
+      }
+    }, '')
+    .trim();
+}

--- a/packages/next/src/utils/types.ts
+++ b/packages/next/src/utils/types.ts
@@ -38,6 +38,8 @@ export interface NextBuildBuilderOptions {
   generateLockfile?: boolean;
   watch?: boolean;
   debug?: boolean;
+  profile?: boolean;
+  experimentalAppOnly?: boolean;
 }
 
 export interface NextServeBuilderOptions {
@@ -50,6 +52,7 @@ export interface NextServeBuilderOptions {
   hostname?: string;
   proxyConfig?: string;
   buildLibsFromSource?: boolean;
+  keepAliveTimeout?: number;
 }
 
 export interface NextExportBuilderOptions {


### PR DESCRIPTION
This change is to refactor `@nx/next` `executors` from using deeply imported `next.js` build functionality.
Now we will integrate the use of `next.js` CLI which should help bridge the gap between `nx` & `next` commands.

There should be no change to how the commands work for existing users.
