### PR TITLE
feat(core): support third-party packages for surgical hashTarget hashing

### DIFF
--- a/packages/nx/src/hasher/hasher.ts
+++ b/packages/nx/src/hasher/hasher.ts
@@ -351,13 +351,9 @@ class TaskHasher {
       return;
     }
 
-    // we can only vouch for @nrwl packages's executors
     // if it's "run commands" we skip traversing since we have no info what this command depends on
-    // for everything else we take the hash of the @nrwl package dependency tree
-    if (
-      target.executor.startsWith(`@nrwl/`) ||
-      target.executor.startsWith(`@nx/`)
-    ) {
+    // for everything else we take the hash of the executor package's dependency tree
+    if (!target.executor.startsWith(`nx:run-commands`)) {
       const executorPackage = target.executor.split(':')[0];
       const executorNode = `npm:${executorPackage}`;
       if (this.projectGraph.externalNodes?.[executorNode]) {


### PR DESCRIPTION
This is part of the new hashing inputs effort

## Current Behavior
Only `@nrwl/*` and `@nx/*` packages are respected for `hashTarget` executor dependency hashing. All the other third-party packages fall back to full lock file hash.

## Expected Behavior
All explicit executors should be respected for `hashTarget` with their respective dependency tree.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
