### PR TITLE
fix(angular): warn in ng-packagr executors when finding conflicting package export conditions

### DIFF
--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-package.transform.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-package.transform.ts
@@ -397,20 +397,15 @@ function generatePackageExports(
     subpath: string,
     mapping: ConditionalExport
   ) => {
-    if (exports[subpath] === undefined) {
-      exports[subpath] = {};
-    }
-
+    exports[subpath] ??= {};
     const subpathExport = exports[subpath];
 
     // Go through all conditions that should be inserted. If the condition is already
     // manually set of the subpath export, we throw an error. In general, we allow for
     // additional conditions to be set. These will always precede the generated ones.
-    for (const conditionName of Object.keys(mapping) as [
-      keyof ConditionalExport
-    ]) {
+    for (const conditionName of Object.keys(mapping)) {
       if (subpathExport[conditionName] !== undefined) {
-        throw Error(
+        logger.warn(
           `Found a conflicting export condition for "${subpath}". The "${conditionName}" ` +
             `condition would be overridden by ng-packagr. Please unset it.`
         );


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When conflicting package exports are found, an error is thrown.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When conflicting package exports are found, a warning should be logged.

**Note:** This commit is a sync from an upstream change in `ng-packagr`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
