### PR TITLE
cleanup(angular): rearrange validation helper function

### DIFF
--- a/packages/angular/src/generators/component/lib/validate-options.ts
+++ b/packages/angular/src/generators/component/lib/validate-options.ts
@@ -1,6 +1,6 @@
 import type { Tree } from '@nx/devkit';
-import { checkPathUnderProjectRoot } from '../../utils/path';
 import {
+  validatePathIsUnderProjectRoot,
   validateProject,
   validateStandaloneOption,
 } from '../../utils/validations';
@@ -8,6 +8,6 @@ import type { Schema } from '../schema';
 
 export function validateOptions(tree: Tree, options: Schema): void {
   validateProject(tree, options.project);
-  checkPathUnderProjectRoot(tree, options.project, options.path);
+  validatePathIsUnderProjectRoot(tree, options.project, options.path);
   validateStandaloneOption(tree, options.standalone);
 }

--- a/packages/angular/src/generators/directive/lib/validate-options.ts
+++ b/packages/angular/src/generators/directive/lib/validate-options.ts
@@ -1,6 +1,6 @@
 import type { Tree } from '@nx/devkit';
-import { checkPathUnderProjectRoot } from '../../utils/path';
 import {
+  validatePathIsUnderProjectRoot,
   validateProject,
   validateStandaloneOption,
 } from '../../utils/validations';
@@ -8,6 +8,6 @@ import type { Schema } from '../schema';
 
 export function validateOptions(tree: Tree, options: Schema): void {
   validateProject(tree, options.project);
-  checkPathUnderProjectRoot(tree, options.project, options.path);
+  validatePathIsUnderProjectRoot(tree, options.project, options.path);
   validateStandaloneOption(tree, options.standalone);
 }

--- a/packages/angular/src/generators/pipe/lib/validate-options.ts
+++ b/packages/angular/src/generators/pipe/lib/validate-options.ts
@@ -1,6 +1,6 @@
 import type { Tree } from '@nx/devkit';
-import { checkPathUnderProjectRoot } from '../../utils/path';
 import {
+  validatePathIsUnderProjectRoot,
   validateProject,
   validateStandaloneOption,
 } from '../../utils/validations';
@@ -8,6 +8,6 @@ import type { Schema } from '../schema';
 
 export function validateOptions(tree: Tree, options: Schema): void {
   validateProject(tree, options.project);
-  checkPathUnderProjectRoot(tree, options.project, options.path);
+  validatePathIsUnderProjectRoot(tree, options.project, options.path);
   validateStandaloneOption(tree, options.standalone);
 }

--- a/packages/angular/src/generators/scam-directive/lib/validate-options.ts
+++ b/packages/angular/src/generators/scam-directive/lib/validate-options.ts
@@ -1,9 +1,11 @@
 import type { Tree } from '@nx/devkit';
-import { checkPathUnderProjectRoot } from '../../utils/path';
-import { validateProject } from '../../utils/validations';
+import {
+  validatePathIsUnderProjectRoot,
+  validateProject,
+} from '../../utils/validations';
 import type { Schema } from '../schema';
 
 export function validateOptions(tree: Tree, options: Schema): void {
   validateProject(tree, options.project);
-  checkPathUnderProjectRoot(tree, options.project, options.path);
+  validatePathIsUnderProjectRoot(tree, options.project, options.path);
 }

--- a/packages/angular/src/generators/scam-pipe/lib/validate-options.ts
+++ b/packages/angular/src/generators/scam-pipe/lib/validate-options.ts
@@ -1,9 +1,11 @@
 import type { Tree } from '@nx/devkit';
-import { checkPathUnderProjectRoot } from '../../utils/path';
-import { validateProject } from '../../utils/validations';
+import {
+  validatePathIsUnderProjectRoot,
+  validateProject,
+} from '../../utils/validations';
 import type { Schema } from '../schema';
 
 export function validateOptions(tree: Tree, options: Schema): void {
   validateProject(tree, options.project);
-  checkPathUnderProjectRoot(tree, options.project, options.path);
+  validatePathIsUnderProjectRoot(tree, options.project, options.path);
 }

--- a/packages/angular/src/generators/scam/lib/validate-options.ts
+++ b/packages/angular/src/generators/scam/lib/validate-options.ts
@@ -1,9 +1,11 @@
 import type { Tree } from '@nx/devkit';
-import { checkPathUnderProjectRoot } from '../../utils/path';
-import { validateProject } from '../../utils/validations';
+import {
+  validatePathIsUnderProjectRoot,
+  validateProject,
+} from '../../utils/validations';
 import type { Schema } from '../schema';
 
 export function validateOptions(tree: Tree, options: Schema): void {
   validateProject(tree, options.project);
-  checkPathUnderProjectRoot(tree, options.project, options.path);
+  validatePathIsUnderProjectRoot(tree, options.project, options.path);
 }

--- a/packages/angular/src/generators/utils/path.ts
+++ b/packages/angular/src/generators/utils/path.ts
@@ -31,30 +31,6 @@ export function getRelativeImportToFile(
   )}`;
 }
 
-export function checkPathUnderProjectRoot(
-  tree: Tree,
-  projectName: string,
-  path: string
-): void {
-  if (!path) {
-    return;
-  }
-
-  const { root } = readProjectConfiguration(tree, projectName);
-
-  let pathToComponent = normalizePath(path);
-  pathToComponent = pathToComponent.startsWith('/')
-    ? pathToComponent.slice(1)
-    : pathToComponent;
-
-  if (!pathStartsWith(pathToComponent, root)) {
-    throw new Error(
-      `The path provided (${path}) does not exist under the project root (${root}). ` +
-        `Please make sure to provide a path that exists under the project root.`
-    );
-  }
-}
-
 export type PathGenerationOptions = {
   name: string;
   project: string;

--- a/packages/angular/src/generators/utils/validations.ts
+++ b/packages/angular/src/generators/utils/validations.ts
@@ -1,6 +1,12 @@
 import type { Tree } from '@nx/devkit';
-import { getProjects, stripIndents } from '@nx/devkit';
+import {
+  getProjects,
+  normalizePath,
+  readProjectConfiguration,
+  stripIndents,
+} from '@nx/devkit';
 import { lt } from 'semver';
+import { pathStartsWith } from './path';
 import { getInstalledAngularVersionInfo } from './version-utils';
 
 export function validateProject(tree: Tree, projectName: string): void {
@@ -28,5 +34,29 @@ export function validateStandaloneOption(
   if (lt(installedAngularVersion, '14.1.0')) {
     throw new Error(stripIndents`The "standalone" option is only supported in Angular >= 14.1.0. You are currently using "${installedAngularVersion}".
     You can resolve this error by removing the "standalone" option or by migrating to Angular 14.1.0.`);
+  }
+}
+
+export function validatePathIsUnderProjectRoot(
+  tree: Tree,
+  projectName: string,
+  path: string
+): void {
+  if (!path) {
+    return;
+  }
+
+  const { root } = readProjectConfiguration(tree, projectName);
+
+  let pathToComponent = normalizePath(path);
+  pathToComponent = pathToComponent.startsWith('/')
+    ? pathToComponent.slice(1)
+    : pathToComponent;
+
+  if (!pathStartsWith(pathToComponent, root)) {
+    throw new Error(
+      `The path provided (${path}) does not exist under the project root (${root}). ` +
+        `Please make sure to provide a path that exists under the project root.`
+    );
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

A validation helper function called `checkPathUnderProjectRoot` is in the path utils.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `checkPathUnderProjectRoot` is renamed to `validatePathIsUnderProjectRoot` and moved to the validation utils.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
