### PR TITLE
fix(nextjs): read serverActions config safely

### DIFF
--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -159,7 +159,7 @@ function withNx(
   forNextVersion('>=13.4.0', () => {
     process.env['__NEXT_PRIVATE_PREBUNDLED_REACT'] =
       // Not in Next 13.3 or earlier, so need to access config via string
-      _nextConfig.experimental['serverActions'] ? 'experimental' : 'next';
+      _nextConfig.experimental?.['serverActions'] ? 'experimental' : 'next';
   });
 
   return async (phase: string) => {


### PR DESCRIPTION
When using Next.js 13.4, the `experimental.serverActions` feature is being read in without considering that `experimental` may be undefined.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16845
