### PR TITLE
fix(js): use valid file paths on Windows when executing program

### DIFF
--- a/packages/js/src/executors/node/node-with-require-overrides.ts
+++ b/packages/js/src/executors/node/node-with-require-overrides.ts
@@ -1,11 +1,12 @@
 const Module = require('module');
+const url = require('url');
 const originalLoader = Module._load;
 
 const dynamicImport = new Function('specifier', 'return import(specifier)');
 
 const mappings = JSON.parse(process.env.NX_MAPPINGS);
 const keys = Object.keys(mappings);
-const fileToRun = process.env.NX_FILE_TO_RUN;
+const fileToRun = url.pathToFileURL(process.env.NX_FILE_TO_RUN);
 
 Module._load = function (request, parent) {
   if (!parent) return originalLoader.apply(this, arguments);


### PR DESCRIPTION
Absolute paths on Windows are not valid file paths when using dynamic `import(...)` calls. Need to use `pathToFileURL` first before importing.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16834
