### PR TITLE
feat(core): add commandExternalDependencies hash input

### DIFF
--- a/docs/shared/reference/project-configuration.md
+++ b/docs/shared/reference/project-configuration.md
@@ -158,6 +158,17 @@ Examples:
 
 Note the result value is hashed, so it is never displayed.
 
+_External Dependencies_
+
+Examples:
+
+- `{externalDependencies: []}`
+  Specify that a target executor is not affected by any changes in installed packages
+- `{externalDependencies: ["lerna"]}`
+  Specify exact packages that affect a target executor
+
+Note the result value is hashed, so it is never displayed. This override is ignored by `@nx/*` executors.
+
 _Named Inputs_
 
 Examples:

--- a/docs/shared/reference/project-configuration.md
+++ b/docs/shared/reference/project-configuration.md
@@ -160,16 +160,47 @@ Note the result value is hashed, so it is never displayed.
 
 _External Dependencies_
 
-This input is useful for ambiguous executors like `nx:run-commands`.
+For official plugins, Nx intelligently finds a set of external dependencies which it hashes for the target. `nx:run-commands` is an exception to this.
+Because you may specify any command to be run, it is not possible to determine which, if any, external dependencies are used by the target.
+To be safe, Nx assumes that updating any external dependency invalidates the cache for the target.
+
+> Note: Community plugins are also treated like `nx:run-commands`
+
+This input type allows for you to override this cautious behavior by specifying a set of external dependencies to hash for the target.
 
 Examples:
 
-- Specify that a target executor is not affected by any changes in installed packages
-- `{externalDependencies: []}`
-- Specify exact packages that affect a target executor
-- `{externalDependencies: ["lerna"]}`
+Targets that only use commands natively available in the terminal will not depend on any external dependencies. Specify an empty array to not hash any external dependencies.
 
-Note the result value is hashed, so it is never displayed.
+```json
+{
+  "copyFiles": {
+    "inputs": [
+      {
+        "externalDependencies": []
+      }
+    ],
+    "executor": "nx:run-commands",
+    "command": "cp src/assets dist"
+  }
+}
+```
+
+If a target uses a command from a npm package, that package should be listed.
+
+```json
+{
+  "copyFiles": {
+    "inputs": [
+      {
+        "externalDependencies": ["lerna"]
+      }
+    ],
+    "executor": "nx:run-commands",
+    "command": "npx lerna publish"
+  }
+}
+```
 
 _Named Inputs_
 

--- a/docs/shared/reference/project-configuration.md
+++ b/docs/shared/reference/project-configuration.md
@@ -160,14 +160,16 @@ Note the result value is hashed, so it is never displayed.
 
 _External Dependencies_
 
+This input is useful for ambiguous executors like `nx:run-commands`.
+
 Examples:
 
+- Specify that a target executor is not affected by any changes in installed packages
 - `{externalDependencies: []}`
-  Specify that a target executor is not affected by any changes in installed packages
+- Specify exact packages that affect a target executor
 - `{externalDependencies: ["lerna"]}`
-  Specify exact packages that affect a target executor
 
-Note the result value is hashed, so it is never displayed. This override is ignored by `@nx/*` executors.
+Note the result value is hashed, so it is never displayed.
 
 _Named Inputs_
 

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -163,7 +163,7 @@
             "properties": {
               "externalDependencies": {
                 "type": "string",
-                "description": "The list of external dependencies that our target depends on. The `@nx/*` executors will ignore this input."
+                "description": "The list of external dependencies that our target depends on (for ambiguous executors like `nx:run-commands`)."
               }
             },
             "additionalProperties": false

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -157,6 +157,16 @@
               }
             },
             "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "externalDependencies": {
+                "type": "string",
+                "description": "The list of external dependencies that our target depends on. The `@nx/*` executors will ignore this input."
+              }
+            },
+            "additionalProperties": false
           }
         ]
       }

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -163,7 +163,7 @@
             "properties": {
               "externalDependencies": {
                 "type": "string",
-                "description": "The list of external dependencies that our target depends on (for ambiguous executors like `nx:run-commands`)."
+                "description": "The list of external dependencies that our target depends on for `nx:run-commands` and community plugins."
               }
             },
             "additionalProperties": false

--- a/packages/nx/schemas/project-schema.json
+++ b/packages/nx/schemas/project-schema.json
@@ -212,7 +212,7 @@
             "properties": {
               "externalDependencies": {
                 "type": "string",
-                "description": "The list of external dependencies that our target depends on (for ambiguous executors like `nx:run-commands`)."
+                "description": "The list of external dependencies that our target depends on for `nx:run-commands` and community plugins."
               }
             },
             "additionalProperties": false

--- a/packages/nx/schemas/project-schema.json
+++ b/packages/nx/schemas/project-schema.json
@@ -212,7 +212,7 @@
             "properties": {
               "externalDependencies": {
                 "type": "string",
-                "description": "The list of external dependencies that our target depends on. The `@nx/*` executors will ignore this input."
+                "description": "The list of external dependencies that our target depends on (for ambiguous executors like `nx:run-commands`)."
               }
             },
             "additionalProperties": false

--- a/packages/nx/schemas/project-schema.json
+++ b/packages/nx/schemas/project-schema.json
@@ -206,6 +206,16 @@
               }
             },
             "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "externalDependencies": {
+                "type": "string",
+                "description": "The list of external dependencies that our target depends on. The `@nx/*` executors will ignore this input."
+              }
+            },
+            "additionalProperties": false
           }
         ]
       }

--- a/packages/nx/src/config/workspace-json-project-json.ts
+++ b/packages/nx/src/config/workspace-json-project-json.ts
@@ -131,6 +131,7 @@ export type InputDefinition =
   | { input: string }
   | { fileset: string }
   | { runtime: string }
+  | { commandExternalDependencies: string[] }
   | { env: string };
 
 /**

--- a/packages/nx/src/config/workspace-json-project-json.ts
+++ b/packages/nx/src/config/workspace-json-project-json.ts
@@ -131,7 +131,7 @@ export type InputDefinition =
   | { input: string }
   | { fileset: string }
   | { runtime: string }
-  | { commandExternalDependencies: string[] }
+  | { externalDependencies: string[] }
   | { env: string };
 
 /**

--- a/packages/nx/src/hasher/hasher.spec.ts
+++ b/packages/nx/src/hasher/hasher.spec.ts
@@ -1028,7 +1028,73 @@ describe('Hasher', () => {
         overrides: { prop: 'prop-value' },
       });
 
-      console.log(hash);
+      expect(hash.details.nodes['npm:nx']).not.toBeDefined();
+      expect(hash.details.nodes['app']).not.toBeDefined();
+      expect(hash.details.nodes['npm:webpack']).toEqual('5.0.0');
+      expect(hash.details.nodes['npm:react']).toEqual('17.0.0');
+    });
+
+    it('should use commandExternalDependencies with empty array to ignore all deps', async () => {
+      const hasher = new Hasher(
+        {
+          nodes: {
+            app: {
+              name: 'app',
+              type: 'app',
+              data: {
+                root: 'apps/app',
+                targets: {
+                  build: {
+                    executor: 'nx:run-commands',
+                    inputs: [
+                      { fileset: '{projectRoot}/**/*' },
+                      { commandExternalDependencies: [] }, // intentionally empty
+                    ],
+                  },
+                },
+                files: [{ file: '/filea.ts', hash: 'a.hash' }],
+              },
+            },
+          },
+          externalNodes: {
+            'npm:nx': {
+              name: 'npm:nx',
+              type: 'npm',
+              data: {
+                packageName: 'nx',
+                version: '16.0.0',
+              },
+            },
+            'npm:webpack': {
+              name: 'npm:webpack',
+              type: 'npm',
+              data: {
+                packageName: 'webpack',
+                version: '5.0.0',
+              },
+            },
+            'npm:react': {
+              name: 'npm:react',
+              type: 'npm',
+              data: {
+                packageName: 'react',
+                version: '17.0.0',
+              },
+            },
+          },
+          dependencies: {},
+          allWorkspaceFiles,
+        },
+        {} as any,
+        {},
+        createHashing()
+      );
+
+      const hash = await hasher.hashTask({
+        target: { project: 'app', target: 'build' },
+        id: 'app-build',
+        overrides: { prop: 'prop-value' },
+      });
 
       expect(hash.details.nodes['npm:nx']).not.toBeDefined();
       expect(hash.details.nodes['app']).not.toBeDefined();

--- a/packages/nx/src/hasher/hasher.spec.ts
+++ b/packages/nx/src/hasher/hasher.spec.ts
@@ -81,7 +81,7 @@ describe('Hasher', () => {
               root: 'libs/parent',
               targets: {
                 build: {
-                  executor: 'unknown',
+                  executor: 'nx:run-commands',
                   inputs: [
                     'default',
                     '^default',
@@ -136,8 +136,8 @@ describe('Hasher', () => {
     expect(hash.details.command).toEqual('parent|build||{"prop":"prop-value"}');
     expect(hash.details.nodes).toEqual({
       'parent:{projectRoot}/**/*':
-        '/file|file.hash|{"root":"libs/parent","targets":{"build":{"executor":"unknown","inputs":["default","^default",{"runtime":"echo runtime123"},{"env":"TESTENV"},{"env":"NONEXISTENTENV"},{"input":"default","projects":["unrelated"]}]}}}|{"compilerOptions":{"paths":{"@nx/parent":["libs/parent/src/index.ts"],"@nx/child":["libs/child/src/index.ts"]}}}',
-      parent: 'unknown',
+        '/file|file.hash|{"root":"libs/parent","targets":{"build":{"executor":"nx:run-commands","inputs":["default","^default",{"runtime":"echo runtime123"},{"env":"TESTENV"},{"env":"NONEXISTENTENV"},{"input":"default","projects":["unrelated"]}]}}}|{"compilerOptions":{"paths":{"@nx/parent":["libs/parent/src/index.ts"],"@nx/child":["libs/child/src/index.ts"]}}}',
+      parent: 'nx:run-commands',
       'unrelated:{projectRoot}/**/*':
         'libs/unrelated/filec.ts|filec.hash|{"root":"libs/unrelated","targets":{"build":{}}}|{"compilerOptions":{"paths":{"@nx/parent":["libs/parent/src/index.ts"],"@nx/child":["libs/child/src/index.ts"]}}}',
       '{workspaceRoot}/nx.json': 'nx.json.hash',
@@ -159,7 +159,7 @@ describe('Hasher', () => {
             type: 'lib',
             data: {
               root: 'libs/parent',
-              targets: { build: { executor: 'unknown' } },
+              targets: { build: { executor: 'nx:run-commands' } },
               files: [
                 { file: '/filea.ts', hash: 'a.hash' },
                 { file: '/filea.spec.ts', hash: 'a.spec.hash' },
@@ -219,7 +219,7 @@ describe('Hasher', () => {
               targets: {
                 build: {
                   inputs: ['prod', '^prod'],
-                  executor: 'unknown',
+                  executor: 'nx:run-commands',
                 },
               },
               files: [
@@ -236,7 +236,7 @@ describe('Hasher', () => {
               namedInputs: {
                 prod: ['default'],
               },
-              targets: { build: { executor: 'unknown' } },
+              targets: { build: { executor: 'nx:run-commands' } },
               files: [
                 { file: 'libs/child/fileb.ts', hash: 'b.hash' },
                 { file: 'libs/child/fileb.spec.ts', hash: 'b.spec.hash' },
@@ -288,12 +288,12 @@ describe('Hasher', () => {
               targets: {
                 build: {
                   inputs: ['prod'],
-                  executor: 'unknown',
+                  executor: 'nx:run-commands',
                 },
                 test: {
                   inputs: ['default'],
                   dependsOn: ['build'],
-                  executor: 'unknown',
+                  executor: 'nx:run-commands',
                 },
               },
               files: [
@@ -356,7 +356,7 @@ describe('Hasher', () => {
               targets: {
                 test: {
                   inputs: ['default', '^prod'],
-                  executor: 'unknown',
+                  executor: 'nx:run-commands',
                 },
               },
               files: [
@@ -380,7 +380,7 @@ describe('Hasher', () => {
               targets: {
                 test: {
                   inputs: ['default'],
-                  executor: 'unknown',
+                  executor: 'nx:run-commands',
                 },
               },
               files: [

--- a/packages/nx/src/hasher/hasher.spec.ts
+++ b/packages/nx/src/hasher/hasher.spec.ts
@@ -966,7 +966,7 @@ describe('Hasher', () => {
       expect(hash.details.nodes['app']).toEqual('nx:run-commands');
     });
 
-    it('should use commandExternalDependencies to override nx:run-commands', async () => {
+    it('should use externalDependencies to override nx:run-commands', async () => {
       const hasher = new Hasher(
         {
           nodes: {
@@ -980,7 +980,7 @@ describe('Hasher', () => {
                     executor: 'nx:run-commands',
                     inputs: [
                       { fileset: '{projectRoot}/**/*' },
-                      { commandExternalDependencies: ['webpack', 'react'] },
+                      { externalDependencies: ['webpack', 'react'] },
                     ],
                   },
                 },
@@ -1034,7 +1034,7 @@ describe('Hasher', () => {
       expect(hash.details.nodes['npm:react']).toEqual('17.0.0');
     });
 
-    it('should use commandExternalDependencies with empty array to ignore all deps', async () => {
+    it('should use externalDependencies with empty array to ignore all deps', async () => {
       const hasher = new Hasher(
         {
           nodes: {
@@ -1048,7 +1048,7 @@ describe('Hasher', () => {
                     executor: 'nx:run-commands',
                     inputs: [
                       { fileset: '{projectRoot}/**/*' },
-                      { commandExternalDependencies: [] }, // intentionally empty
+                      { externalDependencies: [] }, // intentionally empty
                     ],
                   },
                 },

--- a/packages/nx/src/hasher/hasher.spec.ts
+++ b/packages/nx/src/hasher/hasher.spec.ts
@@ -783,6 +783,7 @@ describe('Hasher', () => {
   });
 
   describe('hashTarget', () => {
+
     it('should hash executor dependencies of @nx packages', async () => {
       const hasher = new Hasher(
         {
@@ -921,6 +922,49 @@ describe('Hasher', () => {
         'npm:@nx/devkit': { contains: '$nx/devkit16$' },
         'npm:nx': { contains: '$nx16$' },
         'npm:webpack': { contains: '5.0.0' },
+      });
+    });
+
+    it('should hash executor dependencies of third party executors', async () => {
+      const hasher = new Hasher(
+        {
+          nodes: {
+            app: {
+              name: 'app',
+              type: 'app',
+              data: {
+                root: 'apps/app',
+                targets: { build: { executor: '@monodon/rust:napi' } },
+                files: [{ file: '/filea.ts', hash: 'a.hash' }],
+              },
+            },
+          },
+          externalNodes: {
+            'npm:@monodon/rust': {
+              name: 'npm:@monodon/rust',
+              type: 'npm',
+              data: {
+                packageName: '@monodon/rust',
+                version: '1.0.0',
+              }
+            },
+          },
+          dependencies: {},
+          allWorkspaceFiles,
+        },
+        {} as any,
+        {},
+        createHashing()
+      );
+
+      const hash = await hasher.hashTask({
+        target: { project: 'app', target: 'build' },
+        id: 'app-build',
+        overrides: { prop: 'prop-value' },
+      });
+
+      assertFilesets(hash, {
+        'npm:@monodon/rust': { contains: '1.0.0' },
       });
     });
 

--- a/packages/nx/src/hasher/hasher.ts
+++ b/packages/nx/src/hasher/hasher.ts
@@ -16,7 +16,7 @@ type ExpandedSelfInput =
   | { fileset: string }
   | { runtime: string }
   | { env: string }
-  | { commandExternalDependencies: string[] };
+  | { externalDependencies: string[] };
 
 /**
  * A data structure returned by the default hasher.
@@ -411,12 +411,11 @@ class TaskHasher {
     const partialHashes: PartialHash[] = [];
     let hasCommandExternalDependencies = false;
     for (const input of selfInputs) {
-      if (input['commandExternalDependencies']) {
-        // if we have commandExternalDependencies with empty array we still want to override the default hash
+      if (input['externalDependencies']) {
+        // if we have externalDependencies with empty array we still want to override the default hash
         hasCommandExternalDependencies = true;
-        const commandExternalDependencies =
-          input['commandExternalDependencies'];
-        for (let dep of commandExternalDependencies) {
+        const externalDependencies = input['externalDependencies'];
+        for (let dep of externalDependencies) {
           if (!dep.startsWith('npm:')) {
             dep = `npm:${dep}`;
           }
@@ -734,7 +733,7 @@ function expandSingleProjectInputs(
         (d as any).fileset ||
         (d as any).env ||
         (d as any).runtime ||
-        (d as any).commandExternalDependencies
+        (d as any).externalDependencies
       ) {
         expanded.push(d);
       } else {


### PR DESCRIPTION
Follow up to [#16903](https://github.com/nrwl/nx/pull/16903)

This PR implements new `commandExternalDependencies` input

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Solution for #15116
