### PR TITLE
fix(web): provide free port to http-server

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "chalk": "^4.1.0",
     "chokidar": "^3.5.1",
+    "detect-port": "^1.5.1",
     "http-server": "^14.1.0",
     "ignore": "^5.0.4",
     "tslib": "^2.3.0",

--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -14,6 +14,7 @@ import { watch } from 'chokidar';
 import { platform } from 'os';
 import { join, resolve } from 'path';
 import { readModulePackageJson } from 'nx/src/utils/package-json';
+import * as detectPort from 'detect-port';
 
 // platform specific command name
 const pmCmd = platform() === 'win32' ? `npx.cmd` : 'npx';
@@ -23,10 +24,6 @@ function getHttpServerArgs(options: Schema) {
 
   if (options.cors) {
     args.push(`--cors`);
-  }
-
-  if (options.port) {
-    args.push(`-p=${options.port}`);
   }
   if (options.host) {
     args.push(`-a=${options.host}`);
@@ -182,6 +179,11 @@ export default async function* fileServerExecutor(
     pathToHttpServerBin
   );
 
+  // detect port as close to when used to prevent port being used by another process
+  // when running in  parallel
+  const port = await detectPort(options.port || 8080);
+  args.push(`-p=${port}`);
+
   const serve = fork(pathToHttpServer, [outputPath, ...args], {
     stdio: 'pipe',
     cwd: context.root,
@@ -203,6 +205,7 @@ export default async function* fileServerExecutor(
   };
   process.on('exit', processExitListener);
   process.on('SIGTERM', processExitListener);
+
   serve.stdout.on('data', (chunk) => {
     if (chunk.toString().indexOf('GET') === -1) {
       process.stdout.write(chunk);
@@ -214,9 +217,7 @@ export default async function* fileServerExecutor(
 
   yield {
     success: true,
-    baseUrl: `${options.ssl ? 'https' : 'http'}://${options.host}:${
-      options.port
-    }`,
+    baseUrl: `${options.ssl ? 'https' : 'http'}://${options.host}:${port}`,
   };
 
   return new Promise<{ success: boolean }>((res) => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
@nx/web:file-server doesn't return the port used by http-server if the port is already in use.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
@nx/web:file-server returns the port value used by http-server by providing a known free port.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16684
