### PR TITLE
fix(core): fix handling of simple dependsOn target string

### DIFF
--- a/packages/nx/src/tasks-runner/utils.spec.ts
+++ b/packages/nx/src/tasks-runner/utils.spec.ts
@@ -410,6 +410,25 @@ describe('utils', () => {
       });
     });
 
+    it('should assume target of self if simple target also matches project name', () => {
+      const result = expandDependencyConfigSyntaxSugar('build', {
+        dependencies: {},
+        nodes: {
+          build: {
+            name: 'build',
+            type: 'lib',
+            data: {
+              root: 'libs/build',
+              files: [],
+            },
+          },
+        },
+      });
+      expect(result).toEqual({
+        target: 'build',
+      });
+    });
+
     it('should expand syntax for simple target names targetting dependencies', () => {
       const result = expandDependencyConfigSyntaxSugar('^build', {
         dependencies: {},

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -69,6 +69,13 @@ export function expandDependencyConfigSyntaxSugar(
 
   // Support for both `project:target` and `target:with:colons` syntax
   const [maybeProject, ...segments] = splitByColons(targetString);
+
+  // if no additional segments are provided, then the string references
+  // a target of the same project
+  if (!segments.length) {
+    return { target: maybeProject };
+  }
+
   return {
     // Only the first segment could be a project. If it is, the rest is a target.
     // If its not, then the whole targetString was a target with colons in its name.


### PR DESCRIPTION
Fixes #16931
- if a project has a `dependsOn` string with only a target that has the same name as another project, it is now treated correctly as a reference to a target in the same project

This was the simplest approach I could think of to fix the issue and ensure the functionality remains the same as is currently documented.