### PR TITLE
fix(react): extracting the tsconfig base should also copy existing paths

### DIFF
--- a/packages/js/src/utils/typescript/create-ts-config.ts
+++ b/packages/js/src/utils/typescript/create-ts-config.ts
@@ -15,6 +15,7 @@ export const tsConfigBaseOptions = {
   skipLibCheck: true,
   skipDefaultLibCheck: true,
   baseUrl: '.',
+  paths: {},
 };
 
 export function extractTsConfigBase(host: Tree) {
@@ -22,6 +23,7 @@ export function extractTsConfigBase(host: Tree) {
 
   const tsconfig = readJson(host, 'tsconfig.json');
   const baseCompilerOptions = {} as any;
+
   for (let compilerOption of Object.keys(tsConfigBaseOptions)) {
     baseCompilerOptions[compilerOption] =
       tsconfig.compilerOptions[compilerOption];


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When adding a react library, we call `extractTsConfigBase` to convert a standalone workspace with a single `tsconfig.json` to have a `tsconfig.base.json` that can be shared among projects.
It does not copy the `compilerOptions.paths` from the tsconfig into the tsconfig.base.json

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should also copy over any configured paths in the tsconfig

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
