### PR TITLE
feat(repo): add test e2e build scripts in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
     "submit-plugin": "node ./scripts/submit-plugin.js",
     "prepare": "is-ci || husky install",
     "echo": "echo 123458",
-    "preinstall": "node ./scripts/preinstall.js"
+    "preinstall": "node ./scripts/preinstall.js",
+    "test":"nx test",
+    "e2e":"nx e2e",
+    "build-project":"nx build"
   },
   "devDependencies": {
     "@actions/core": "^1.10.0",


### PR DESCRIPTION
To be used in `vite-ecosystem-ci`, so that I can call `pnpm test vite`, `pnpm e2e e2e-vite`, `pnpm build vite`.
