### PR TITLE
feat(angular): deprecate ngrx generator

### DIFF
--- a/docs/generated/packages/angular/generators/ngrx.json
+++ b/docs/generated/packages/angular/generators/ngrx.json
@@ -6,6 +6,7 @@
     "$id": "NxNgrxGenerator",
     "title": "Add NgRx support to an application or library.",
     "description": "Adds NgRx support to an application or library.",
+    "x-deprecated": "This generator is deprecated and will be removed in a future version of Nx. Use the 'ngrx-root-store' and 'ngrx-feature-store' generators instead.",
     "cli": "nx",
     "type": "object",
     "examples": [
@@ -101,6 +102,7 @@
     "presets": []
   },
   "description": "Adds NgRx support to an application or library.",
+  "x-deprecated": "This generator is deprecated and will be removed in a future version of Nx. Use the 'ngrx-root-store' and 'ngrx-feature-store' generators instead.",
   "implementation": "/packages/angular/src/generators/ngrx/ngrx.ts",
   "aliases": [],
   "hidden": false,

--- a/packages/angular/generators.json
+++ b/packages/angular/generators.json
@@ -95,7 +95,8 @@
     "ngrx": {
       "factory": "./src/generators/ngrx/compat",
       "schema": "./src/generators/ngrx/schema.json",
-      "description": "Adds NgRx support to an application or library."
+      "description": "Adds NgRx support to an application or library.",
+      "x-deprecated": "This generator is deprecated and will be removed in a future version of Nx. Use the 'ngrx-root-store' and 'ngrx-feature-store' generators instead."
     },
     "scam-to-standalone": {
       "factory": "./src/generators/scam-to-standalone/compat",
@@ -252,7 +253,8 @@
     "ngrx": {
       "factory": "./src/generators/ngrx/ngrx",
       "schema": "./src/generators/ngrx/schema.json",
-      "description": "Adds NgRx support to an application or library."
+      "description": "Adds NgRx support to an application or library.",
+      "x-deprecated": "This generator is deprecated and will be removed in a future version of Nx. Use the 'ngrx-root-store' and 'ngrx-feature-store' generators instead."
     },
     "ngrx-feature-store": {
       "factory": "./src/generators/ngrx-feature-store/ngrx-feature-store",

--- a/packages/angular/src/generators/ngrx/schema.json
+++ b/packages/angular/src/generators/ngrx/schema.json
@@ -3,6 +3,7 @@
   "$id": "NxNgrxGenerator",
   "title": "Add NgRx support to an application or library.",
   "description": "Adds NgRx support to an application or library.",
+  "x-deprecated": "This generator is deprecated and will be removed in a future version of Nx. Use the 'ngrx-root-store' and 'ngrx-feature-store' generators instead.",
   "cli": "nx",
   "type": "object",
   "examples": [


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
NgRx is deprecated since the addition of `ngrx-root-store` and `ngrx-feature-store`.
It is not marked as deprecated.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Mark it as deprecated.

On nx.dev, this will show as deprecated when visiting the actual generator's docs. Ben has a todo task to show a "Deprecated" badge on the plugin's generator list page.
When running the command, a warning is logged about it being deprecated.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
