### PR TITLE
fix(misc): always pass project graph to parseTargetString

### DIFF
--- a/packages/cypress/src/utils/find-target-options.ts
+++ b/packages/cypress/src/utils/find-target-options.ts
@@ -73,7 +73,8 @@ function findInTarget(
   options: FindTargetOptions
 ): TargetConfiguration {
   const { project, target, configuration } = parseTargetString(
-    options.buildTarget
+    options.buildTarget,
+    graph
   );
   const projectConfig = readProjectConfiguration(tree, project);
   const executorName = projectConfig?.targets?.[target]?.executor;

--- a/packages/nx/src/utils/split-target.spec.ts
+++ b/packages/nx/src/utils/split-target.spec.ts
@@ -55,10 +55,8 @@ describe('splitTarget', () => {
   });
 
   it('should targets that contain colons when not provided graph but surrounded by quotes', () => {
-    expect(splitTarget('project:"other:other":configuration')).toEqual([
-      'project',
-      'other:other',
-      'configuration',
-    ]);
+    expect(
+      splitTarget('project:"other:other":configuration', projectGraph)
+    ).toEqual(['project', 'other:other', 'configuration']);
   });
 });

--- a/packages/nx/src/utils/split-target.ts
+++ b/packages/nx/src/utils/split-target.ts
@@ -3,7 +3,7 @@ import { ProjectConfiguration } from '../config/workspace-json-project-json';
 
 export function splitTarget(
   s: string,
-  projectGraph?: ProjectGraph
+  projectGraph: ProjectGraph
 ): [project: string, target?: string, configuration?: string] {
   let [project, ...segments] = splitByColons(s);
   const validTargets = projectGraph?.nodes?.[project]?.data?.targets;

--- a/packages/web/src/generators/static-serve/static-serve-configuration.spec.ts
+++ b/packages/web/src/generators/static-serve/static-serve-configuration.spec.ts
@@ -13,12 +13,12 @@ describe('Static serve configuration generator', () => {
     tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
   });
 
-  it('should add a `serve-static` target to the project', () => {
+  it('should add a `serve-static` target to the project', async () => {
     addReactConfig(tree, 'react-app');
     addAngularConfig(tree, 'angular-app');
     addStorybookConfig(tree, 'storybook');
 
-    webStaticServeGenerator(tree, {
+    await webStaticServeGenerator(tree, {
       buildTarget: 'react-app:build',
     });
 
@@ -31,7 +31,7 @@ describe('Static serve configuration generator', () => {
         },
       }
     `);
-    webStaticServeGenerator(tree, {
+    await webStaticServeGenerator(tree, {
       buildTarget: 'angular-app:build',
     });
 
@@ -80,7 +80,7 @@ describe('Static serve configuration generator', () => {
     `);
   });
 
-  it('should infer outputPath via the buildTarget#outputs', () => {
+  it('should infer outputPath via the buildTarget#outputs', async () => {
     addAngularConfig(tree, 'angular-app');
     const projectConfig = readProjectConfiguration(tree, 'angular-app');
     delete projectConfig.targets.build.options.outputPath;
@@ -89,7 +89,7 @@ describe('Static serve configuration generator', () => {
 
     updateProjectConfiguration(tree, 'angular-app', projectConfig);
 
-    webStaticServeGenerator(tree, {
+    await webStaticServeGenerator(tree, {
       buildTarget: 'angular-app:build',
     });
 
@@ -116,8 +116,8 @@ describe('Static serve configuration generator', () => {
 
     updateProjectConfiguration(tree, 'storybook', pc);
 
-    expect(() => {
-      webStaticServeGenerator(tree, {
+    expect(async () => {
+      await webStaticServeGenerator(tree, {
         buildTarget: 'storybook:build-storybook',
       });
     }).toThrowErrorMatchingInlineSnapshot(`

--- a/packages/web/src/generators/static-serve/static-serve-configuration.ts
+++ b/packages/web/src/generators/static-serve/static-serve-configuration.ts
@@ -1,7 +1,9 @@
 import {
   convertNxGenerator,
+  createProjectGraphAsync,
   logger,
   parseTargetString,
+  ProjectGraph,
   readProjectConfiguration,
   stripIndents,
   TargetConfiguration,
@@ -20,19 +22,21 @@ interface NormalizedWebStaticServeSchema extends WebStaticServeSchema {
   targetName: string;
 }
 
-export function webStaticServeGenerator(
+export async function webStaticServeGenerator(
   tree: Tree,
   options: WebStaticServeSchema
 ) {
-  const opts = normalizeOptions(tree, options);
+  const projectGraph = await createProjectGraphAsync();
+  const opts = normalizeOptions(tree, options, projectGraph);
   addStaticConfig(tree, opts);
 }
 
 function normalizeOptions(
   tree: Tree,
-  options: WebStaticServeSchema
+  options: WebStaticServeSchema,
+  projectGraph: ProjectGraph
 ): NormalizedWebStaticServeSchema {
-  const target = parseTargetString(options.buildTarget);
+  const target = parseTargetString(options.buildTarget, projectGraph);
   const opts: NormalizedWebStaticServeSchema = {
     ...options,
     targetName: options.targetName || 'serve-static',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The project graph is not passed to `parseTargetString` in some places.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The project graph is always passed to `parseTargetString`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
