### PR TITLE
fix(react): do not require webpackConfig for cypress component testing

### DIFF
--- a/packages/react/plugins/component-testing/index.ts
+++ b/packages/react/plugins/component-testing/index.ts
@@ -236,35 +236,36 @@ function buildTargetWebpack(
     buildableProjectConfig.sourceRoot!
   );
 
-  if (options.webpackConfig) {
-    let customWebpack: any;
+  let customWebpack: any;
 
+  if (options.webpackConfig) {
     customWebpack = resolveCustomWebpackConfig(
       options.webpackConfig,
       options.tsConfig
     );
-
-    return async () => {
-      customWebpack = await customWebpack;
-      // TODO(jack): Once webpackConfig is always set in @nx/webpack:webpack, we no longer need this default.
-      const defaultWebpack = getWebpackConfig(context, {
-        ...options,
-        root: workspaceRoot,
-        projectRoot: ctProjectConfig.root,
-        sourceRoot: ctProjectConfig.sourceRoot,
-      });
-
-      if (customWebpack) {
-        return await customWebpack(defaultWebpack, {
-          options,
-          context,
-          configuration: parsed.configuration,
-        });
-      }
-      return defaultWebpack;
-    };
   }
+
+  return async () => {
+    customWebpack = await customWebpack;
+    // TODO(jack): Once webpackConfig is always set in @nx/webpack:webpack, we no longer need this default.
+    const defaultWebpack = getWebpackConfig(context, {
+      ...options,
+      root: workspaceRoot,
+      projectRoot: ctProjectConfig.root,
+      sourceRoot: ctProjectConfig.sourceRoot,
+    });
+
+    if (customWebpack) {
+      return await customWebpack(defaultWebpack, {
+        options,
+        context,
+        configuration: parsed.configuration,
+      });
+    }
+    return defaultWebpack;
+  };
 }
+
 function findViteConfig(projectRootFullPath: string): string {
   const allowsExt = ['js', 'mjs', 'ts', 'cjs', 'mts', 'cts'];
 


### PR DESCRIPTION

## Current Behavior
If a project has no webpackConfig field set, the component-testing preset will set the final webpackConfig to undefined.

This is because webpackConfig was removed as a default from the build target and so now there is no value to load.

If there is no options.webpackConfig, the buildTargetWebpack returns nothing.

## Expected Behavior
When setting up cypress component testing for a library which targets a build in a different application, the application project.json build target should not require setting "webpackConfig".