### PR TITLE
chore(misc): add core codeowners to generated cli doc files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -133,6 +133,7 @@ pnpm-lock.yaml @FrozenPandaz @vsavkin @AgentEnder @jaysoo @JamesHenry
 /e2e/plugin/** @AgentEnder @FrozenPandaz
 
 ## Core
+/docs/generated/cli/** @vsavkin @FrozenPandaz @AgentEnder
 /docs/generated/packages/nx/** @vsavkin @FrozenPandaz @AgentEnder
 /docs/generated/packages/workspace/** @vsavkin @FrozenPandaz @AgentEnder
 /packages/nx/** @vsavkin @FrozenPandaz @AgentEnder


### PR DESCRIPTION
For example, changes to `create-nx-workspace` will affect `docs/generated/cli/create-nx-workspace.md` which should fall under core, which is already correctly setup for `docs/generated/packages/nx/documents/create-nx-workspace.md`

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
