### PR TITLE
fix(react): add ts extension to tailwindcss utility glob

### DIFF
--- a/packages/react/tailwind.ts
+++ b/packages/react/tailwind.ts
@@ -7,7 +7,7 @@ import { createGlobPatternsForDependencies as jsGenerateGlobs } from '@nx/js/src
  */
 export function createGlobPatternsForDependencies(
   dirPath: string,
-  fileGlobPattern: string = '/**/!(*.stories|*.spec).{tsx,jsx,js,html}'
+  fileGlobPattern: string = '/**/!(*.stories|*.spec).{tsx,ts,jsx,js,html}'
 ) {
   try {
     return jsGenerateGlobs(dirPath, fileGlobPattern);


### PR DESCRIPTION
It adds the `ts` extension to the current glob `{tsx,jsx,js,html}`, so `.ts` files are handles by default when using utilities or constants in regular Typescript in a project that uses TailwindCSS with React.