### PR TITLE
feat(nx-plugin): Update executor generator

### DIFF
--- a/docs/generated/devkit/AsyncIteratorExecutor.md
+++ b/docs/generated/devkit/AsyncIteratorExecutor.md
@@ -1,0 +1,26 @@
+# Type alias: AsyncIteratorExecutor\<T\>
+
+Ƭ **AsyncIteratorExecutor**\<`T`\>: (`options`: `T`, `context`: [`ExecutorContext`](../../devkit/documents/ExecutorContext)) => `AsyncIterableIterator`\<\{ `success`: `boolean` }\>
+
+An executor implementation that returns an async iterator
+
+#### Type parameters
+
+| Name | Type  |
+| :--- | :---- |
+| `T`  | `any` |
+
+#### Type declaration
+
+▸ (`options`, `context`): `AsyncIterableIterator`\<\{ `success`: `boolean` }\>
+
+##### Parameters
+
+| Name      | Type                                                        |
+| :-------- | :---------------------------------------------------------- |
+| `options` | `T`                                                         |
+| `context` | [`ExecutorContext`](../../devkit/documents/ExecutorContext) |
+
+##### Returns
+
+`AsyncIterableIterator`\<\{ `success`: `boolean` }\>

--- a/docs/generated/devkit/Executor.md
+++ b/docs/generated/devkit/Executor.md
@@ -1,6 +1,6 @@
 # Type alias: Executor\<T\>
 
-Ƭ **Executor**\<`T`\>: (`options`: `T`, `context`: [`ExecutorContext`](../../devkit/documents/ExecutorContext)) => `Promise`\<\{ `success`: `boolean` }\> \| `AsyncIterableIterator`\<\{ `success`: `boolean` }\>
+Ƭ **Executor**\<`T`\>: [`PromiseExecutor`](../../devkit/documents/PromiseExecutor)\<`T`\> \| [`AsyncIteratorExecutor`](../../devkit/documents/AsyncIteratorExecutor)\<`T`\>
 
 Implementation of a target of a project
 
@@ -9,18 +9,3 @@ Implementation of a target of a project
 | Name | Type  |
 | :--- | :---- |
 | `T`  | `any` |
-
-#### Type declaration
-
-▸ (`options`, `context`): `Promise`\<\{ `success`: `boolean` }\> \| `AsyncIterableIterator`\<\{ `success`: `boolean` }\>
-
-##### Parameters
-
-| Name      | Type                                                        |
-| :-------- | :---------------------------------------------------------- |
-| `options` | `T`                                                         |
-| `context` | [`ExecutorContext`](../../devkit/documents/ExecutorContext) |
-
-##### Returns
-
-`Promise`\<\{ `success`: `boolean` }\> \| `AsyncIterableIterator`\<\{ `success`: `boolean` }\>

--- a/docs/generated/devkit/PromiseExecutor.md
+++ b/docs/generated/devkit/PromiseExecutor.md
@@ -1,0 +1,26 @@
+# Type alias: PromiseExecutor\<T\>
+
+Ƭ **PromiseExecutor**\<`T`\>: (`options`: `T`, `context`: [`ExecutorContext`](../../devkit/documents/ExecutorContext)) => `Promise`\<\{ `success`: `boolean` }\>
+
+An executor implementation that returns a promise
+
+#### Type parameters
+
+| Name | Type  |
+| :--- | :---- |
+| `T`  | `any` |
+
+#### Type declaration
+
+▸ (`options`, `context`): `Promise`\<\{ `success`: `boolean` }\>
+
+##### Parameters
+
+| Name      | Type                                                        |
+| :-------- | :---------------------------------------------------------- |
+| `options` | `T`                                                         |
+| `context` | [`ExecutorContext`](../../devkit/documents/ExecutorContext) |
+
+##### Returns
+
+`Promise`\<\{ `success`: `boolean` }\>

--- a/docs/generated/devkit/README.md
+++ b/docs/generated/devkit/README.md
@@ -64,6 +64,7 @@ It only uses language primitives and immutable objects
 
 ### Type Aliases
 
+- [AsyncIteratorExecutor](../../devkit/documents/AsyncIteratorExecutor)
 - [CreateDependencies](../../devkit/documents/CreateDependencies)
 - [CreateMetadata](../../devkit/documents/CreateMetadata)
 - [CreateMetadataContext](../../devkit/documents/CreateMetadataContext)
@@ -90,6 +91,7 @@ It only uses language primitives and immutable objects
 - [ProjectTargetConfigurator](../../devkit/documents/ProjectTargetConfigurator)
 - [ProjectType](../../devkit/documents/ProjectType)
 - [ProjectsMetadata](../../devkit/documents/ProjectsMetadata)
+- [PromiseExecutor](../../devkit/documents/PromiseExecutor)
 - [RawProjectGraphDependency](../../devkit/documents/RawProjectGraphDependency)
 - [StaticDependency](../../devkit/documents/StaticDependency)
 - [StringChange](../../devkit/documents/StringChange)

--- a/docs/generated/packages/devkit/documents/nx_devkit.md
+++ b/docs/generated/packages/devkit/documents/nx_devkit.md
@@ -64,6 +64,7 @@ It only uses language primitives and immutable objects
 
 ### Type Aliases
 
+- [AsyncIteratorExecutor](../../devkit/documents/AsyncIteratorExecutor)
 - [CreateDependencies](../../devkit/documents/CreateDependencies)
 - [CreateMetadata](../../devkit/documents/CreateMetadata)
 - [CreateMetadataContext](../../devkit/documents/CreateMetadataContext)
@@ -90,6 +91,7 @@ It only uses language primitives and immutable objects
 - [ProjectTargetConfigurator](../../devkit/documents/ProjectTargetConfigurator)
 - [ProjectType](../../devkit/documents/ProjectType)
 - [ProjectsMetadata](../../devkit/documents/ProjectsMetadata)
+- [PromiseExecutor](../../devkit/documents/PromiseExecutor)
 - [RawProjectGraphDependency](../../devkit/documents/RawProjectGraphDependency)
 - [StaticDependency](../../devkit/documents/StaticDependency)
 - [StringChange](../../devkit/documents/StringChange)

--- a/packages/nx/src/config/misc-interfaces.ts
+++ b/packages/nx/src/config/misc-interfaces.ts
@@ -106,17 +106,31 @@ export interface ExecutorConfig {
 }
 
 /**
- * Implementation of a target of a project
+ * An executor implementation that returns a promise
  */
-export type Executor<T = any> = (
+export type PromiseExecutor<T = any> = (
   /**
    * Options that users configure or pass via the command line
    */
   options: T,
   context: ExecutorContext
-) =>
-  | Promise<{ success: boolean }>
-  | AsyncIterableIterator<{ success: boolean }>;
+) => Promise<{ success: boolean }>;
+
+/**
+ * An executor implementation that returns an async iterator
+ */
+export type AsyncIteratorExecutor<T = any> = (
+  /**
+   * Options that users configure or pass via the command line
+   */
+  options: T,
+  context: ExecutorContext
+) => AsyncIterableIterator<{ success: boolean }>;
+
+/**
+ * Implementation of a target of a project
+ */
+export type Executor<T = any> = PromiseExecutor<T> | AsyncIteratorExecutor<T>;
 
 export interface HasherContext {
   hasher: TaskHasher;

--- a/packages/nx/src/devkit-exports.ts
+++ b/packages/nx/src/devkit-exports.ts
@@ -27,6 +27,8 @@ export type {
 export type {
   Generator,
   GeneratorCallback,
+  PromiseExecutor,
+  AsyncIteratorExecutor,
   Executor,
   ExecutorContext,
   TaskGraphExecutor,

--- a/packages/plugin/src/generators/executor/files/executor/executor.spec.ts.template
+++ b/packages/plugin/src/generators/executor/files/executor/executor.spec.ts.template
@@ -1,11 +1,18 @@
+import { ExecutorContext } from '@nx/devkit';
+
 import { <%= className %>ExecutorSchema } from './schema';
 import executor from './executor';
 
 const options: <%= className %>ExecutorSchema = {};
+const context: ExecutorContext = {
+  root: '',
+  cwd: process.cwd(),
+  isVerbose: false,
+};
 
 describe('<%= className %> Executor', () => {
   it('can run', async () => {
-    const output = await executor(options);
+    const output = await executor(options, context);
     expect(output.success).toBe(true);
   });
 });

--- a/packages/plugin/src/generators/executor/files/executor/executor.ts.template
+++ b/packages/plugin/src/generators/executor/files/executor/executor.ts.template
@@ -1,11 +1,11 @@
+import { Executor } from "@nx/devkit";
 import { <%= className %>ExecutorSchema } from './schema';
 
-export default async function runExecutor(
-  options: <%= className %>ExecutorSchema,
-) {
+const runExecutor: Executor<<%= className %>ExecutorSchema> = async (options) => {
   console.log('Executor ran for <%= className %>', options);
   return {
     success: true
   };
 }
 
+export default runExecutor;

--- a/packages/plugin/src/generators/executor/files/executor/executor.ts.template
+++ b/packages/plugin/src/generators/executor/files/executor/executor.ts.template
@@ -1,7 +1,7 @@
-import { Executor } from "@nx/devkit";
+import { PromiseExecutor } from "@nx/devkit";
 import { <%= className %>ExecutorSchema } from './schema';
 
-const runExecutor: Executor<<%= className %>ExecutorSchema> = async (options) => {
+const runExecutor: PromiseExecutor<<%= className %>ExecutorSchema> = async (options) => {
   console.log('Executor ran for <%= className %>', options);
   return {
     success: true


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The executor generator generates

```ts
import { MyPluginExecutorSchema } from "./schema";

export default async function runExecutor(options: MyPluginExecutorSchema) {
  console.log("Executor ran for MyPlugin", options);
  return {
    success: true,
  };
}
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The above code does not make it obvious that an executor has a second `context` argument or that it can return an `AsyncIterableIterator`. By typing the function against the `Executor` type the user will have typesafety to know that they are implementing the interface of their executor correctly and an easy way to view the type definition of an executor

```ts
import { Executor } from "@nx/devkit";

import { MyPluginExecutorSchema } from "./schema";

const runExecutor: Executor<MyPluginExecutorSchema> = async (
  options,
  context
) => {
  console.log("Executor ran for MyPlugin", options);
  return {
    success: true,
  };
};

export default runExecutor;
```