### PR TITLE
fix(core): set max listeners to avoid warning when running high numbers of parallel tasks

### DIFF
--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -1,5 +1,7 @@
-import { Workspaces } from '../config/workspaces';
+import { defaultMaxListeners } from 'events';
 import { performance } from 'perf_hooks';
+
+import { Workspaces } from '../config/workspaces';
 import { Hasher } from '../hasher/hasher';
 import { ForkedProcessTaskRunner } from './forked-process-task-runner';
 import { workspaceRoot } from '../utils/workspace-root';
@@ -64,6 +66,9 @@ export class TaskOrchestrator {
     performance.mark('task-execution-begins');
 
     const threads = [];
+
+    process.stdout.setMaxListeners(this.options.parallel + defaultMaxListeners);
+    process.stderr.setMaxListeners(this.options.parallel + defaultMaxListeners);
 
     // initial seeding of the queue
     for (let i = 0; i < this.options.parallel; ++i) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When running `nx run-many -t {...} --parallel {someHighNumber}` its easy to end up getting warnings from node. 

## Expected Behavior
No warnings

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16788 
