### PR TITLE
fix(linter): import from .tsx file lint fix now works correctly

### DIFF
--- a/packages/eslint-plugin/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin/src/rules/enforce-module-boundaries.ts
@@ -365,7 +365,8 @@ export default createESLintRule<Options, MessageIds>({
 
                       importsToRemap.push({
                         member: importMember,
-                        importPath: importPathResolved.replace('.ts', ''),
+                        // remove .ts or .tsx from the end of the file path
+                        importPath: importPathResolved.replace(/.tsx?$/, ''),
                       });
                     }
                   }


### PR DESCRIPTION
When the `enforce-module-boundaries` lint rule detects that you're using an aliased import path to a file within the same project, it correctly shows an error.

But if the file your importing from is a `.tsx` file, the auto fix adds an `x` to the end of the file path. The auto fix would have also failed if the file name was `'something.tsetse.fly.ts'`.

This PR handles both scenarios correctly.