### PR TITLE
feat(core): add error when root project would be '.'

### DIFF
--- a/packages/nx/src/config/workspaces.ts
+++ b/packages/nx/src/config/workspaces.ts
@@ -762,6 +762,13 @@ function buildProjectConfigurationFromPackageJson(
 ): ProjectConfiguration & { name: string } {
   const normalizedPath = path.split('\\').join('/');
   const directory = dirname(normalizedPath);
+
+  if (!packageJson.name && directory === '.') {
+    throw new Error(
+      'Nx requires the root package.json to specify a name if it is being used as an Nx project.'
+    );
+  }
+
   let name = packageJson.name ?? toProjectName(normalizedPath);
   if (nxJson?.npmScope) {
     const npmPrefix = `@${nxJson.npmScope}/`;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
If the root package.json is an Nx project, and it doesn't contain a name, you end up with a project called "." This is **_technically_** fine, but is pretty confusing behavior wise.

## Expected Behavior
It errors

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
