### PR TITLE
docs(core): document all/none for rollup external

### DIFF
--- a/docs/generated/packages/rollup/executors/rollup.json
+++ b/docs/generated/packages/rollup/executors/rollup.json
@@ -70,7 +70,7 @@
       },
       "external": {
         "type": "array",
-        "description": "A list of external modules that will not be bundled (`react`, `react-dom`, etc.).",
+        "description": "A list of external modules that will not be bundled (`react`, `react-dom`, etc.). Can also be set to `all` (bundle nothing) or `none` (bundle everything).",
         "oneOf": [
           { "type": "string", "enum": ["all", "none"] },
           { "type": "array", "items": { "type": "string" } }

--- a/packages/rollup/src/executors/rollup/schema.json
+++ b/packages/rollup/src/executors/rollup/schema.json
@@ -70,7 +70,7 @@
     },
     "external": {
       "type": "array",
-      "description": "A list of external modules that will not be bundled (`react`, `react-dom`, etc.).",
+      "description": "A list of external modules that will not be bundled (`react`, `react-dom`, etc.). Can also be set to `all` (bundle nothing) or `none` (bundle everything).",
       "oneOf": [
         {
           "type": "string",


### PR DESCRIPTION
This option now supports `"all"/"none"`. **Moreover [the change that added this](https://github.com/nrwl/nx/pull/16713) dramatically changes default packaging behavior of nx:rollup, so it should be clearly documented.**

If authors don't take action and had `"external": [],` (the default) tons of dependencies will suddenly be bundled into the distributed module. For me, that caused a bunch of issues. The least we can do is add this doc, so it's clear how to achieve the previous behavior.