### PR TITLE
fix(core): normalize path in tree when accessing recorded changes

### DIFF
--- a/packages/nx/src/generators/tree.ts
+++ b/packages/nx/src/generators/tree.ts
@@ -223,8 +223,11 @@ export class FsTree implements Tree {
       isDeleted: true,
     };
 
-    // Delete directories when
-    if (this.children(dirname(this.rp(filePath))).length < 1) {
+    // Delete directory when is not root and there are no children
+    if (
+      filePath !== '' &&
+      this.children(dirname(this.rp(filePath))).length < 1
+    ) {
       this.delete(dirname(this.rp(filePath)));
     }
   }
@@ -282,7 +285,7 @@ export class FsTree implements Tree {
 
     res = [...res, ...this.directChildrenOfDir(this.rp(dirPath))];
     res = res.filter((q) => {
-      const r = this.recordedChanges[join(this.rp(dirPath), q)];
+      const r = this.recordedChanges[this.normalize(join(this.rp(dirPath), q))];
       return !r?.isDeleted;
     });
     // Dedupe


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When filtering deleted files in the `children` function of the `Tree`, the paths are not normalized. In Windows, this prevents the files to match so the `children` function returns deleted files.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The paths used to access the recorded changes in the `Tree` should always be normalized. Fixing this caused another issue to surface. The `delete` function was not handling the root dir correctly and causing an infinite loop (an edge case where there are no files in the root).

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17011 
