### PR TITLE
fix(core): add missing await when processing task for batches

### DIFF
--- a/packages/nx/src/tasks-runner/tasks-schedule.ts
+++ b/packages/nx/src/tasks-runner/tasks-schedule.ts
@@ -196,7 +196,12 @@ export class TasksSchedule {
 
     for (const dep of this.reverseTaskDeps[task.id]) {
       const depTask = this.taskGraph.tasks[dep];
-      this.processTaskForBatches(batches, depTask, rootExecutorName, false);
+      await this.processTaskForBatches(
+        batches,
+        depTask,
+        rootExecutorName,
+        false
+      );
     }
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `processTaskForBatches` function in the `TaskSchedule` class was made async in https://github.com/nrwl/nx/pull/15684 but a recursive call was missed and not updated to await the execution.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Calls to the `processTaskForBatches` function in the `TaskSchedule` class that are not meant to execute in parallel should await the execution.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
