### PR TITLE
fix(core): normalize workspace name before creating directory so it matches what downstream generators expect

### DIFF
--- a/packages/workspace/src/generators/new/generate-workspace-files.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.ts
@@ -206,8 +206,10 @@ function addPropertyWithStableKeys(obj: any, key: string, value: string) {
 
 function normalizeOptions(options: NormalizedSchema) {
   let defaultBase = options.defaultBase || deduceDefaultBase();
+  const name = names(options.name).fileName;
   return {
-    npmScope: options.name,
+    name,
+    npmScope: name,
     ...options,
     defaultBase,
   };


### PR DESCRIPTION
This PR fixes an issue when the workspace name is camel-cased. e.g. `npx create-nx-workspace myWorkspace` should create `my-workspace` folder 

Otherwise the `@nx/workspace:preset` generator fails because it normalizes the name: https://github.com/nrwl/nx/blob/master/packages/workspace/src/generators/preset/preset.ts#L170

## Current Behavior
Error occurs because other generators (e.g. `@nx/workspace:preset`) expect the workspace folder to use dashes.

## Expected Behavior
Workspace should create successfully.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16980 
