### PR TITLE
docs(core): add callout for older global nx installations

### DIFF
--- a/docs/shared/guides/global-nx.md
+++ b/docs/shared/guides/global-nx.md
@@ -73,27 +73,33 @@ pnpm list --global nx
 {% /tab %}
 {% /tabs %}
 
+{% callout type="note" title="Older Global Installations" %}
+
+In prior versions, Nx could be installed globally via `@nrwl/cli` or `@nrwl/tao`. If you are seeing these warnings but cannot find other global installations of Nx via the above commands, you should look for these packages as well. In general, you should remove these and install the latest version of `nx` instead.
+
+{% /callout %}
+
 You can then remove the extra global installations by running the following commands for the duplicate installations:
 
 {% tabs %}
 {% tab label="npm" %}
 
 ```shell
-npm rm --global nx
+npm rm --global nx @nrwl/cli @nrwl/tao
 ```
 
 {% /tab %}
 {% tab label="yarn" %}
 
 ```shell
-yarn global remove nx
+yarn global remove nx @nrwl/cli @nrwl/tao
 ```
 
 {% /tab %}
 {% tab label="pnpm" %}
 
 ```shell
-pnpm rm --global nx
+pnpm rm --global nx @nrwl/cli @nrwl/tao
 ```
 
 {% /tab %}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

We used to recommend installing @nrwl/cli or @nrwl/tao globally before we settled on the `nx` package. The global nx page doesn't mention this, so it may be confusing for folks who have them instead of the current `nx` package.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
