### PR TITLE
feat(nx-plugin): generated generators should have a named export

### DIFF
--- a/packages/plugin/src/generators/generator/files/generator/__fileName__/generator.spec.ts.template
+++ b/packages/plugin/src/generators/generator/files/generator/__fileName__/generator.spec.ts.template
@@ -1,19 +1,19 @@
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { Tree, readProjectConfiguration } from '@nx/devkit';
 
-import generator from './generator';
-import { <%= className %>GeneratorSchema } from './schema';
+import { <%= generatorFnName %> } from './generator';
+import { <%= schemaInterfaceName %> } from './schema';
 
 describe('<%= name %> generator', () => {
   let tree: Tree;
-  const options: <%= className %>GeneratorSchema = { name: 'test' };
+  const options: <%= schemaInterfaceName %> = { name: 'test' };
 
   beforeEach(() => {
     tree = createTreeWithEmptyWorkspace();
   });
 
   it('should run successfully', async () => {
-    await generator(tree, options);
+    await <%= generatorFnName %>(tree, options);
     const config = readProjectConfiguration(tree, 'test');
     expect(config).toBeDefined();
   });

--- a/packages/plugin/src/generators/generator/files/generator/__fileName__/generator.ts.template
+++ b/packages/plugin/src/generators/generator/files/generator/__fileName__/generator.ts.template
@@ -7,7 +7,7 @@ import {
 import * as path from 'path';
 import { <%= className %>GeneratorSchema } from './schema';
 
-export default async function (tree: Tree, options: <%= className %>GeneratorSchema) {
+export async function <%= generatorFnName %> (tree: Tree, options: <%= schemaInterfaceName %>) {
   const projectRoot = `libs/${options.name}`;
   addProjectConfiguration(
     tree,
@@ -22,3 +22,5 @@ export default async function (tree: Tree, options: <%= className %>GeneratorSch
   generateFiles(tree, path.join(__dirname, 'files'), projectRoot, options);
   await formatFiles(tree);
 }
+
+export default <%= generatorFnName %>;

--- a/packages/plugin/src/generators/generator/generator.ts
+++ b/packages/plugin/src/generators/generator/generator.ts
@@ -18,18 +18,18 @@ import { hasGenerator } from '../../utils/has-generator';
 import pluginLintCheckGenerator from '../lint-checks/generator';
 import type { Schema } from './schema';
 
-interface NormalizedSchema extends Schema {
-  fileName: string;
-  className: string;
-  projectRoot: string;
-  projectSourceRoot: string;
-  npmScope: string;
-  npmPackageName: string;
-}
+type NormalizedSchema = Schema &
+  ReturnType<typeof names> & {
+    fileName: string;
+    className: string;
+    projectRoot: string;
+    projectSourceRoot: string;
+    npmScope: string;
+    npmPackageName: string;
+  };
 
 function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
   const { npmScope } = getWorkspaceLayout(host);
-  const { fileName, className } = names(options.name);
 
   const { root: projectRoot, sourceRoot: projectSourceRoot } =
     readProjectConfiguration(host, options.project);
@@ -48,8 +48,7 @@ function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
 
   return {
     ...options,
-    fileName,
-    className,
+    ...names(options.name),
     description,
     projectRoot,
     projectSourceRoot,
@@ -69,7 +68,11 @@ function addFiles(host: Tree, options: NormalizedSchema) {
     host,
     path.join(__dirname, './files/generator'),
     `${options.projectSourceRoot}/generators`,
-    options
+    {
+      ...options,
+      generatorFnName: `${options.propertyName}Generator`,
+      schemaInterfaceName: `${options.className}GeneratorSchema`,
+    }
   );
 
   if (options.unitTestRunner === 'none') {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We generate `export default async function()....`

## Expected Behavior
We generate both
- `export async function generatorName()`
- `export default generatorName`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
