### PR TITLE
fix(misc): migration for run-commands output-path should handle null …

### DIFF
--- a/packages/nx/src/migrations/update-16-2-0/remove-run-commands-output-path.spec.ts
+++ b/packages/nx/src/migrations/update-16-2-0/remove-run-commands-output-path.spec.ts
@@ -43,6 +43,24 @@ describe('removeRunCommandsOutputPath', () => {
     expect(migratedTargets.other).toEqual(startingTargets.other);
   });
 
+  it('should handle null options correctly', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    const startingTargets: Record<string, TargetConfiguration> = {
+      build: {
+        executor: 'nx:run-commands',
+        outputs: ['dist/some/path'],
+      },
+    };
+    addProjectConfiguration(tree, 'my-app', {
+      root: 'apps/my-app',
+      targets: startingTargets,
+    });
+    expect(() => removeRunCommandsOutputPath(tree)).not.toThrow();
+    const migratedTargets = readProjectConfiguration(tree, 'my-app').targets;
+    expect(migratedTargets.build).toEqual(startingTargets.build);
+    expect(migratedTargets.other).toEqual(startingTargets.other);
+  });
+
   it('should migrate target defaults correctly', () => {
     const tree = createTreeWithEmptyWorkspace();
     const startingTargetDefaults: Record<string, TargetConfiguration> = {

--- a/packages/nx/src/migrations/update-16-2-0/remove-run-commands-output-path.ts
+++ b/packages/nx/src/migrations/update-16-2-0/remove-run-commands-output-path.ts
@@ -32,7 +32,7 @@ export default async function removeRunCommandsOutputPath(tree: Tree) {
 
 function updateTargetBlock(target: TargetConfiguration): boolean {
   let changed = false;
-  if (target.executor === 'nx:run-commands' && target.options.outputPath) {
+  if (target.executor === 'nx:run-commands' && target.options?.outputPath) {
     changed = true;
     const outputs = new Set(target.outputs ?? []);
     outputs.delete('{options.outputPath}');


### PR DESCRIPTION
…options

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
