### PR TITLE
fix(devkit): uppercase constant name correct transformation

### DIFF
--- a/packages/devkit/src/utils/names.spec.ts
+++ b/packages/devkit/src/utils/names.spec.ts
@@ -47,5 +47,6 @@ describe('names', () => {
     expect(names('foo-@bar').constantName).toEqual('FOO_BAR');
     expect(names(' foo bar').constantName).toEqual('FOO_BAR');
     expect(names('_foo_bar').constantName).toEqual('FOO_BAR');
+    expect(names('FOO_BAR').constantName).toEqual('FOO_BAR');
   });
 });

--- a/packages/devkit/src/utils/names.ts
+++ b/packages/devkit/src/utils/names.ts
@@ -48,7 +48,8 @@ function toPropertyName(s: string): string {
  * Hyphenated to CONSTANT_CASE
  */
 function toConstantName(s: string): string {
-  return toFileName(toPropertyName(s))
+  const normalizedS = s.toUpperCase() === s ? s.toLowerCase() : s;
+  return toFileName(toPropertyName(normalizedS))
     .replace(/([^a-zA-Z0-9])/g, '_')
     .toUpperCase();
 }


### PR DESCRIPTION
closed #12681

## Current Behavior
As described in linked issue, `CONSTANT_NAME` would be transformed to `C_ONSTANTNAME`

## Expected Behavior
`CONSTANT_NAME` is kept as is.

## Related Issue(s)

Fixes #12681
