### PR TITLE
fix(vite): register tsconfig paths for vitest

### DIFF
--- a/packages/vite/src/executors/test/vitest.impl.ts
+++ b/packages/vite/src/executors/test/vitest.impl.ts
@@ -8,8 +8,9 @@ import {
 import { CoverageOptions, File, Reporter } from 'vitest';
 import { loadConfigFromFile } from 'vite';
 import { VitestExecutorOptions } from './schema';
-import { relative } from 'path';
+import { relative, resolve } from 'path';
 import { existsSync } from 'fs';
+import { registerTsConfigPaths } from '@nx/js/src/internal';
 
 class NxReporter implements Reporter {
   deferred: {
@@ -50,6 +51,10 @@ export async function* vitestExecutor(
   options: VitestExecutorOptions,
   context: ExecutorContext
 ) {
+  const projectRoot =
+    context.projectsConfigurations.projects[context.projectName].root;
+  registerTsConfigPaths(resolve(projectRoot, 'tsconfig.json'));
+
   const { startVitest } = await (Function(
     'return import("vitest/node")'
   )() as Promise<typeof import('vitest/node')>);


### PR DESCRIPTION
## Current Behavior
Vitest executor does not register tsconfig paths.

## Expected Behavior
Vitest executor should register tsconfig paths.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Partly fixes #17019

This partly fixes the above issue, since it seems that now even though the paths are resolved correctly, there's the new issue that the lib code cannot be executed (`Unexpected token 'export'`).
