### PR TITLE
fix(nextjs): undo migration to Next.js 13.4

### DIFF
--- a/packages/next/migrations.json
+++ b/packages/next/migrations.json
@@ -316,22 +316,6 @@
           "alwaysAddToPackageJson": false
         }
       }
-    },
-    "16.2.0": {
-      "version": "16.2.0-beta.0",
-      "requires": {
-        "next": ">=13.0.0"
-      },
-      "packages": {
-        "next": {
-          "version": "13.4.1",
-          "alwaysAddToPackageJson": false
-        },
-        "eslint-config-next": {
-          "version": "13.4.1",
-          "alwaysAddToPackageJson": false
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
Updating to Next.js 13.4 still has issues when mixing app layout with pages layout. This should be fixed once we use the Next.js CLI directly without custom server. For now we will support apps with app layout and 13.4, but not when only pages layout is used.

The PR to convert to Next.js CLI is here but won't be in Nx 16.2.0. https://github.com/nrwl/nx/pull/16896