### PR TITLE
fix(react-native):  remove unknown command for build-ios

### DIFF
--- a/packages/react-native/src/executors/build-ios/build-ios.impl.ts
+++ b/packages/react-native/src/executors/build-ios/build-ios.impl.ts
@@ -82,7 +82,7 @@ function runCliBuildIOS(
      */
     childProcess = fork(
       join(workspaceRoot, './node_modules/react-native/cli.js'),
-      ['build-ios', ...createBuildIOSOptions(options), '--no-packager'],
+      ['build-ios', ...createBuildIOSOptions(options)],
       {
         cwd: join(workspaceRoot, projectRoot),
         env: { ...process.env, RCT_METRO_PORT: options.port.toString() },


### PR DESCRIPTION
## Current Behavior
nx run :build-ios is returning this error : error: unknown option '--no-packagr'

## Expected Behavior
no error

## Related Issue(s)
https://github.com/nrwl/nx/issues/17051

Fixes #17051 
