### PR TITLE
fix(nx-dev): copy command when using the terminal fence

### DIFF
--- a/nx-dev/ui-markdoc/src/lib/nodes/fence.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/nodes/fence.component.tsx
@@ -77,7 +77,7 @@ export function Fence({
       <div className="code-block group relative w-full">
         <div>
           <CopyToClipboard
-            text={children}
+            text={command && command !== '' ? command : children}
             onCopy={() => {
               setCopied(true);
             }}


### PR DESCRIPTION
When using the terminal output "fence" in the docs, the copy button should copy the command rather than the output itself

<img width="696" alt="image" src="https://github.com/nrwl/nx/assets/542458/d6cab07b-b82c-4049-ac93-edf1d9b2d23c">

clicking the copy button copies `nx run-many -t test lint e2e`
