### PR TITLE
fix(misc): workspaces using nx wrapper do not contain a package.json, so don't read the scope from it

### DIFF
--- a/packages/js/src/utils/package-json/get-npm-scope.ts
+++ b/packages/js/src/utils/package-json/get-npm-scope.ts
@@ -11,7 +11,9 @@ export function getNpmScope(tree: Tree): string | undefined {
     return nxJson.npmScope;
   }
 
-  const { name } = readJson<{ name?: string }>(tree, 'package.json');
+  const { name } = tree.exists('package.json')
+    ? readJson<{ name?: string }>(tree, 'package.json')
+    : { name: null };
 
   if (name?.startsWith('@')) {
     return name.split('/')[0].substring(1);

--- a/packages/workspace/src/utilities/get-import-path.ts
+++ b/packages/workspace/src/utilities/get-import-path.ts
@@ -17,7 +17,9 @@ function getNpmScope(tree: Tree) {
     return nxJson.npmScope;
   }
 
-  const { name } = readJson<{ name?: string }>(tree, 'package.json');
+  const { name } = tree.exists('package.json')
+    ? readJson<{ name?: string }>(tree, 'package.json')
+    : { name: null };
 
   if (name?.startsWith('@')) {
     return name.split('/')[0].substring(1);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When we deduce the npm scope, we read from the root package.json. If it doesn't exist, this errors.

## Expected Behavior
When we deduce the npm scope, we read from the root package.json. If it doesn't exist, we assume it would have been null.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
