### PR TITLE
feat(nx-dev): add watch to automatically sync docs to nx-dev when developing locally

### DIFF
--- a/nx-dev/nx-dev/copy-docs.js
+++ b/nx-dev/nx-dev/copy-docs.js
@@ -1,0 +1,11 @@
+const { copySync } = require('fs-extra');
+const path = require('path');
+
+/**
+ * Copies the documentation into the proper Next.js public folder
+ */
+copySync(
+  path.resolve(path.join(__dirname, '../../docs')),
+  path.resolve(path.join(__dirname, 'public/documentation')),
+  { overwrite: true }
+);

--- a/nx-dev/nx-dev/next.config.js
+++ b/nx-dev/nx-dev/next.config.js
@@ -1,17 +1,6 @@
 // nx-ignore-next-line
 const { withNx } = require('@nx/next/plugins/with-nx');
-const { copySync } = require('fs-extra');
-const path = require('path');
 const redirectRules = require('./redirect-rules.config');
-
-/**
- * TODO@ben: Use watch method instead.
- */
-copySync(
-  path.resolve(__dirname + '/../../docs'),
-  path.resolve(__dirname + '/public/documentation'),
-  { overwrite: true }
-);
 
 module.exports = withNx({
   // For both client and server

--- a/nx-dev/nx-dev/project.json
+++ b/nx-dev/nx-dev/project.json
@@ -44,6 +44,7 @@
     },
     "build-base": {
       "executor": "@nx/next:build",
+      "dependsOn": ["copy-docs"],
       "outputs": ["{options.outputPath}"],
       "options": {
         "root": "nx-dev/nx-dev",
@@ -56,8 +57,27 @@
         "production": {}
       }
     },
+    "copy-docs": {
+      "inputs": ["{workspaceRoot}/docs/**/*"],
+      "outputs": ["{projectRoot}/public/documentation"],
+      "command": "node ./copy-docs.js",
+      "options": {
+        "cwd": "nx-dev/nx-dev"
+      }
+    },
+    "serve-docs": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          "nx watch --projects=docs -- nx run nx-dev:copy-docs",
+          "nx run nx-dev:serve"
+        ],
+        "parallel": true
+      }
+    },
     "serve": {
       "executor": "@nx/next:server",
+      "dependsOn": ["copy-docs"],
       "options": {
         "buildTarget": "nx-dev:build-base",
         "dev": true

--- a/nx.json
+++ b/nx.json
@@ -20,7 +20,8 @@
           "test",
           "test-native",
           "sitemap",
-          "build-storybook"
+          "build-storybook",
+          "copy-docs"
         ],
         "cacheDirectory": "/tmp/nx-cache",
         "parallel": 1,


### PR DESCRIPTION
uses the `nx watch` to automatically watch the `docs` folder and copy it over to `nx-dev` during development. This helps when writing docs as you automatically see the changes refreshed in the browser without having to continuously restart `nx-dev`.

You can still run
- `nx serve nx-dev` - to serve it as before. This is "safer" as other existing targets (e.g. Cypress e2e) and potential future ones might rely on the `serve` target of the app. And in those situations we don't want to have a watcher running
- `nx serve-docs nx-dev` which runs `nx-dev` but also watches the `docs/` folder for changes and automatically syncs them to the `nx-dev` public/..` folder