### PR TITLE
docs(node): node-standalone should be listed not node-server

### DIFF
--- a/docs/generated/cli/create-nx-workspace.md
+++ b/docs/generated/cli/create-nx-workspace.md
@@ -79,7 +79,7 @@ Default base to use for new projects
 
 Type: `boolean`
 
-Generate a Dockerfile with your node-server
+Generate a Dockerfile with your node-standalone
 
 ### framework
 
@@ -87,7 +87,7 @@ Type: `string`
 
 Choices: [express, fastify, koa, nest]
 
-Framework option to be used when the node-server preset is selected
+Framework option to be used when the node-standalone preset is selected
 
 ### help
 

--- a/docs/generated/packages/nx/documents/create-nx-workspace.md
+++ b/docs/generated/packages/nx/documents/create-nx-workspace.md
@@ -79,7 +79,7 @@ Default base to use for new projects
 
 Type: `boolean`
 
-Generate a Dockerfile with your node-server
+Generate a Dockerfile with your node-standalone
 
 ### framework
 
@@ -87,7 +87,7 @@ Type: `string`
 
 Choices: [express, fastify, koa, nest]
 
-Framework option to be used when the node-server preset is selected
+Framework option to be used when the node-standalone preset is selected
 
 ### help
 

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -98,12 +98,12 @@ export const commandsObject: yargs.Argv<Arguments> = yargs
             type: 'string',
           })
           .option('framework', {
-            describe: chalk.dim`Framework option to be used when the node-server preset is selected`,
+            describe: chalk.dim`Framework option to be used when the node-standalone preset is selected`,
             choices: frameworkList,
             type: 'string',
           })
           .option('docker', {
-            describe: chalk.dim`Generate a Dockerfile with your node-server`,
+            describe: chalk.dim`Generate a Dockerfile with your node-standalone`,
             type: 'boolean',
           })
           .option('nextAppDir', {

--- a/packages/create-nx-workspace/bin/types/framework-list.ts
+++ b/packages/create-nx-workspace/bin/types/framework-list.ts
@@ -1,4 +1,4 @@
-// Framework option to be used when the node-server preset is selected
+// Framework option to be used when the node-standalone preset is selected
 export const frameworkList = ['express', 'fastify', 'koa', 'nest'];
 
 export type Framework = typeof frameworkList[number];


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The `framework` option mentions `node-server` as the preset name when in fact it should be `node-standalone`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Change the `framework` option to say `node-standalone`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17060
