### PR TITLE
feat(nextjs): Add --turbo support

### DIFF
--- a/docs/generated/packages/next/executors/server.json
+++ b/docs/generated/packages/next/executors/server.json
@@ -57,6 +57,10 @@
       "keepAliveTimeout": {
         "type": "number",
         "description": "Max milliseconds to wait before closing inactive connection."
+      },
+      "turbo": {
+        "type": "boolean",
+        "description": "Activate the incremental bundler for Next.js, which is implemented in Rust. Please note, this feature is exclusively available in development mode."
       }
     },
     "required": ["buildTarget"],

--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -463,6 +463,24 @@ describe('Next.js Applications', () => {
       checkExport: false,
     });
   }, 300_000);
+
+  it('should support --turbo to enable Turbopack', async () => {
+    const appName = uniq('app');
+
+    runCLI(
+      `generate @nx/next:app ${appName} --style=css --appDir --no-interactive`
+    );
+
+    const port = 4000;
+    const selfContainedProcess = await runCommandUntil(
+      `run ${appName}:serve --port=${port} --turbo`,
+      (output) => {
+        return output.includes(`TURBOPACK`);
+      }
+    );
+    selfContainedProcess.kill();
+    await killPorts();
+  }, 300_000);
 });
 
 function getData(port, path = ''): Promise<any> {

--- a/packages/next/src/executors/server/schema.json
+++ b/packages/next/src/executors/server/schema.json
@@ -54,6 +54,10 @@
     "keepAliveTimeout": {
       "type": "number",
       "description": "Max milliseconds to wait before closing inactive connection."
+    },
+    "turbo": {
+      "type": "boolean",
+      "description": "Activate the incremental bundler for Next.js, which is implemented in Rust. Please note, this feature is exclusively available in development mode."
     }
   },
   "required": ["buildTarget"]

--- a/packages/next/src/executors/server/server.impl.ts
+++ b/packages/next/src/executors/server/server.impl.ts
@@ -43,10 +43,12 @@ export default async function* serveExecutor(
   const { port, keepAliveTimeout, hostname } = options;
 
   const args = createCliOptions({ port, keepAliveTimeout, hostname });
+
   const nextDir = resolve(context.root, buildOptions.outputPath);
 
-  const command = `npx next ${options.dev ? `dev ${args}` : `start ${args}`}`;
-
+  const mode = options.dev ? 'dev' : 'start';
+  const turbo = options.turbo && options.dev ? '--turbo' : '';
+  const command = `npx next ${mode} ${args} ${turbo}`;
   yield* createAsyncIterable<{ success: boolean; baseUrl: string }>(
     ({ done, next, error }) => {
       // Client to check if server is ready.

--- a/packages/next/src/utils/types.ts
+++ b/packages/next/src/utils/types.ts
@@ -53,6 +53,7 @@ export interface NextServeBuilderOptions {
   proxyConfig?: string;
   buildLibsFromSource?: boolean;
   keepAliveTimeout?: number;
+  turbo?: boolean;
 }
 
 export interface NextExportBuilderOptions {


### PR DESCRIPTION
Passing `--turbo` should enable turbopack. 
This is only available in dev mode

`--turbo` is still experimental and should **not** be used in **Production**

```shell
❯ npx nx start --turbo

> nx run next-turbo:start --turbo

> @next-turbo/source@0.0.0 start
> nx serve --turbo
> nx run next-turbo:serve:development --turbo
>>> TURBOPACK (beta)
Thank you for trying Next.js v13 with Turbopack! As a reminder,
Turbopack is currently in beta and not yet ready for production.
We appreciate your ongoing support as we work to make it ready
for everyone.
```
