### PR TITLE
fix(core): tree should not be changed after committed to disk in migrations

### DIFF
--- a/packages/nx/src/adapter/ngcli-adapter.ts
+++ b/packages/nx/src/adapter/ngcli-adapter.ts
@@ -656,7 +656,11 @@ export async function generate(
   const logger = getLogger(verbose);
   const fsHost = new NxScopeHostUsedForWrappedSchematics(
     root,
-    new FsTree(root, verbose)
+    new FsTree(
+      root,
+      verbose,
+      `ng-cli generator: ${opts.collectionName}:${opts.generatorName}`
+    )
   );
   const workflow = createWorkflow(fsHost, root, opts);
   const collection = getCollection(workflow, opts.collectionName);
@@ -745,7 +749,11 @@ export async function runMigration(
   const logger = getLogger(isVerbose);
   const fsHost = new NxScopeHostUsedForWrappedSchematics(
     root,
-    new FsTree(root, isVerbose)
+    new FsTree(
+      root,
+      isVerbose,
+      `ng-cli migration: ${packageName}:${migrationName}`
+    )
   );
   const workflow = createWorkflow(fsHost, root, {});
   const collection = resolveMigrationsCollection(packageName);

--- a/packages/nx/src/command-line/generate/generate.ts
+++ b/packages/nx/src/command-line/generate/generate.ts
@@ -364,7 +364,11 @@ export async function generate(cwd: string, args: { [k: string]: any }) {
     );
 
     if (ws.isNxGenerator(opts.collectionName, normalizedGeneratorName)) {
-      const host = new FsTree(workspaceRoot, verbose);
+      const host = new FsTree(
+        workspaceRoot,
+        verbose,
+        `generating (${opts.collectionName}:${normalizedGeneratorName})`
+      );
       const implementation = implementationFactory();
 
       // @todo(v17): Remove this, isStandalonePreset property is defunct.

--- a/packages/nx/src/command-line/init/implementation/dot-nx/add-nx-scripts.ts
+++ b/packages/nx/src/command-line/init/implementation/dot-nx/add-nx-scripts.ts
@@ -33,7 +33,7 @@ path_to_root=$(dirname $BASH_SOURCE)
 node ${path.posix.join('$path_to_root', nxWrapperPath(path.posix))} $@`;
 
 export function generateDotNxSetup(version?: string) {
-  const host = new FsTree(process.cwd(), false);
+  const host = new FsTree(process.cwd(), false, '.nx setup');
   writeMinimalNxJson(host, version);
   updateGitIgnore(host);
   host.write(nxWrapperPath(), getNxWrapperContents());

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -1578,7 +1578,11 @@ async function runNxMigration(
     name
   );
   const fn = require(implPath)[fnSymbol];
-  const host = new FsTree(root, process.env.NX_VERBOSE_LOGGING === 'true');
+  const host = new FsTree(
+    root,
+    process.env.NX_VERBOSE_LOGGING === 'true',
+    `migration ${collection.name}:${name}`
+  );
   await fn(host, {});
   host.lock();
   const changes = host.listChanges();

--- a/packages/nx/src/command-line/new/new.ts
+++ b/packages/nx/src/command-line/new/new.ts
@@ -33,7 +33,7 @@ export async function newWorkspace(cwd: string, args: { [k: string]: any }) {
         false
       );
 
-      const host = new FsTree(cwd, false);
+      const host = new FsTree(cwd, false, 'nx new');
       const implementation = implementationFactory();
       const task = await implementation(host, combinedOpts);
       flushChanges(cwd, host.listChanges());

--- a/packages/nx/src/generators/tree.ts
+++ b/packages/nx/src/generators/tree.ts
@@ -138,7 +138,11 @@ export class FsTree implements Tree {
    */
   private locked = false;
 
-  constructor(readonly root: string, private readonly isVerbose: boolean) {}
+  constructor(
+    readonly root: string,
+    private readonly isVerbose: boolean,
+    private readonly logOperationId?: string
+  ) {}
 
   read(filePath: string): Buffer | null;
   read(filePath: string, encoding: BufferEncoding): string | null;
@@ -357,20 +361,15 @@ export class FsTree implements Tree {
 
   private assertUnlocked() {
     if (this.locked) {
-      // TODO (v17): Remove condition
-      if (gt(nxVersion, '17.0.0')) {
-        throw new Error(
-          'The tree has already been committed to disk. It can no longer be modified. Do not modify the tree during a GeneratorCallback and ensure that Promises have resolved before the generator returns or resolves.'
-        );
-      } else {
-        output.warn({
-          title: 'Tree modified after commit to disk.',
-          bodyLines: [
-            'The tree has already been committed to disk. It can no longer be modified. Do not modify the tree during a GeneratorCallback and ensure that Promises have resolved before the generator returns or resolves.',
-            `This will be an error in version 16. Please open an issue on the Nx repo if experiencing this with a first-party plugin, or the plugin's repo if using a community plugin.`,
-          ],
-        });
-      }
+      output.error({
+        title: `File changes have already been written to disk. Further changes were attempted ${
+          this.logOperationId ? ` while running ${this.logOperationId}.` : '.'
+        }`,
+        bodyLines: [
+          'The file system can no longer be modified. This commonly happens when a generator attempts to make further changes in its callback, or an asynchronous operation is still running after the generator completes.',
+        ],
+      });
+      throw new Error('Tree changed after commit to disk.');
     }
   }
 

--- a/packages/nx/src/migrations/update-16-0-0/update-depends-on-to-tokens.ts
+++ b/packages/nx/src/migrations/update-16-0-0/update-depends-on-to-tokens.ts
@@ -63,7 +63,7 @@ export default async function (tree: Tree) {
     }
   }
 
-  formatChangedFilesWithPrettierIfAvailable(tree);
+  await formatChangedFilesWithPrettierIfAvailable(tree);
 }
 function updateDependsOnAndInputsInsideNxJson(tree: Tree) {
   const nxJson = readNxJson(tree);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
It is hard to debug when a migration writes to the tree after it has been committed. This only occurs when an async statement is not awaited or similar issues with promises, and the migration is assumed to be complete. As such, the warning that you get is in the middle of other migrations and its hard to track down which migration actually has the issue.

This changes how the logs are created to include more context to make the experience nicer.

## Expected Behavior

"Changed after committed" warnings include the reason the tree was created.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17064
