### PR TITLE
fix(core): correct require path when pulling in ngcli adapter for generators

### DIFF
--- a/packages/nx/src/command-line/generate/generate.ts
+++ b/packages/nx/src/command-line/generate/generate.ts
@@ -390,7 +390,7 @@ export async function generate(cwd: string, args: { [k: string]: any }) {
         logger.warn(`\nNOTE: The "dryRun" flag means no changes were made.`);
       }
     } else {
-      require('../adapter/compat');
+      require('../../adapter/compat');
       return (await import('../../adapter/ngcli-adapter')).generate(
         workspaceRoot,
         {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
A bad path in `generate.ts` is preventing angular cli compat layer from working for generators

## Expected Behavior
It works as expected

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17086
