### PR TITLE
fix(core): pnpm should not error when fetching migrations with install

### DIFF
--- a/docs/generated/devkit/nx_devkit.md
+++ b/docs/generated/devkit/nx_devkit.md
@@ -1351,7 +1351,7 @@ Returns the list of outputs that will be cached.
 
 ### getPackageManagerCommand
 
-▸ **getPackageManagerCommand**(`packageManager?`): `PackageManagerCommands`
+▸ **getPackageManagerCommand**(`packageManager?`, `root?`): `PackageManagerCommands`
 
 Returns commands for the package manager used in the workspace.
 By default, the package manager is derived based on the lock file,
@@ -1365,9 +1365,10 @@ execSync(`${getPackageManagerCommand().addDev} my-dev-package`);
 
 #### Parameters
 
-| Name             | Type                                                                |
-| :--------------- | :------------------------------------------------------------------ |
-| `packageManager` | [`PackageManager`](../../devkit/documents/nx_devkit#packagemanager) |
+| Name             | Type                                                                | Default value   | Description                                                                                 |
+| :--------------- | :------------------------------------------------------------------ | :-------------- | :------------------------------------------------------------------------------------------ |
+| `packageManager` | [`PackageManager`](../../devkit/documents/nx_devkit#packagemanager) | `undefined`     | The package manager to use. If not provided, it will be detected based on the lock file.    |
+| `root`           | `string`                                                            | `workspaceRoot` | The directory the commands will be ran inside of. Defaults to the current workspace's root. |
 
 #### Returns
 

--- a/docs/generated/packages/devkit/documents/nx_devkit.md
+++ b/docs/generated/packages/devkit/documents/nx_devkit.md
@@ -1351,7 +1351,7 @@ Returns the list of outputs that will be cached.
 
 ### getPackageManagerCommand
 
-▸ **getPackageManagerCommand**(`packageManager?`): `PackageManagerCommands`
+▸ **getPackageManagerCommand**(`packageManager?`, `root?`): `PackageManagerCommands`
 
 Returns commands for the package manager used in the workspace.
 By default, the package manager is derived based on the lock file,
@@ -1365,9 +1365,10 @@ execSync(`${getPackageManagerCommand().addDev} my-dev-package`);
 
 #### Parameters
 
-| Name             | Type                                                                |
-| :--------------- | :------------------------------------------------------------------ |
-| `packageManager` | [`PackageManager`](../../devkit/documents/nx_devkit#packagemanager) |
+| Name             | Type                                                                | Default value   | Description                                                                                 |
+| :--------------- | :------------------------------------------------------------------ | :-------------- | :------------------------------------------------------------------------------------------ |
+| `packageManager` | [`PackageManager`](../../devkit/documents/nx_devkit#packagemanager) | `undefined`     | The package manager to use. If not provided, it will be detected based on the lock file.    |
+| `root`           | `string`                                                            | `workspaceRoot` | The directory the commands will be ran inside of. Defaults to the current workspace's root. |
 
 #### Returns
 

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -1028,7 +1028,7 @@ async function getPackageMigrationsUsingInstall(
   let result: ResolvedMigrationConfiguration;
 
   try {
-    const pmc = getPackageManagerCommand(detectPackageManager(dir));
+    const pmc = getPackageManagerCommand(detectPackageManager(dir), dir);
 
     await execAsync(`${pmc.add} ${packageName}@${packageVersion}`, {
       cwd: dir,

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -50,9 +50,13 @@ export function detectPackageManager(dir: string = ''): PackageManager {
  * ```javascript
  * execSync(`${getPackageManagerCommand().addDev} my-dev-package`);
  * ```
+ *
+ * @param packageManager The package manager to use. If not provided, it will be detected based on the lock file.
+ * @param root The directory the commands will be ran inside of. Defaults to the current workspace's root.
  */
 export function getPackageManagerCommand(
-  packageManager: PackageManager = detectPackageManager()
+  packageManager: PackageManager = detectPackageManager(),
+  root: string = workspaceRoot
 ): PackageManagerCommands {
   const commands: { [pm in PackageManager]: () => PackageManagerCommands } = {
     yarn: () => {
@@ -76,7 +80,7 @@ export function getPackageManagerCommand(
       const pnpmVersion = getPackageManagerVersion('pnpm');
       const useExec = gte(pnpmVersion, '6.13.0');
       const includeDoubleDashBeforeArgs = lt(pnpmVersion, '7.0.0');
-      const isPnpmWorkspace = existsSync('pnpm-workspace.yaml');
+      const isPnpmWorkspace = existsSync(join(root, 'pnpm-workspace.yaml'));
 
       return {
         install: 'pnpm install --no-frozen-lockfile', // explicitly disable in case of CI


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The getPackageManagerCommand parameterizes itself based on the existence of a pnpm-workspace.yaml file at root. This produces incorrect commands when migrating since the temporary workspace doesn't use pnpm workspaces, if the original one does.

## Expected Behavior
The getPackageManagerCommand can look at a target folder

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16899
