### PR TITLE
docs(misc): fix postcss.config.js to not depend on cwd

### DIFF
--- a/nx-dev/nx-dev/postcss.config.js
+++ b/nx-dev/nx-dev/postcss.config.js
@@ -1,8 +1,9 @@
+const { join } = require('path');
 module.exports = {
   plugins: {
     'postcss-import': {},
     tailwindcss: {
-      config: './nx-dev/nx-dev/tailwind.config.js',
+      config: join(__dirname, 'tailwind.config.js'),
     },
     autoprefixer: {},
   },


### PR DESCRIPTION
Once we change `cwd` in the next Nx version, it will not be workspace root but the app root. This change makes it agnostic of location.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
