### PR TITLE
fix(repo): add missing lsof package needed to kill ports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,9 @@ commands:
             equal: [<< parameters.os >>, linux]
           steps:
             - run:
-                command: sudo apt-get install -y ca-certificates
+                command: |
+                  sudo apt-get update
+                  sudo apt-get install -y ca-certificates lsof
             - browser-tools/install-chrome
             - browser-tools/install-chromedriver
       - node/install:

--- a/e2e/next/src/utils.ts
+++ b/e2e/next/src/utils.ts
@@ -46,7 +46,7 @@ export async function checkApp(
       `e2e ${appName}-e2e --no-watch --configuration=production --port=9000`
     );
     expect(e2eResults).toContain('All specs passed!');
-    await killPort(9000);
+    expect(await killPort(9000)).toBeTruthy();
   }
 
   if (opts.checkExport) {


### PR DESCRIPTION
In e2e tests when calling `killPort`, it doesn't do anything because of missing `lsof` command.

Latest CI run looks good:

```
e2e-next: > nx run e2e-next:run-e2e-tests
e2e-next:  E2E  Cypress was not verified. Installing Cypress now.
e2e-next:  E2E   INFO  Attempting to close port 9000
e2e-next:  E2E   SUCCESS  Port 9000 successfully closed
e2e-next:  E2E   INFO  Attempting to close port 4000
e2e-next:  E2E   SUCCESS  Port 4000 successfully closed
e2e-next:  E2E   INFO  Attempting to close port 3000
```

## Current Behavior
Ports cannot be killed and process hangs around.

## Expected Behavior
Ports should be killed correctly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
