### PR TITLE
docs(node): add recipes for various databases w/ node

### DIFF
--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -2739,6 +2739,95 @@
         "disableCollapsible": false
       },
       {
+        "name": "Database",
+        "path": "/recipes/database",
+        "id": "database",
+        "isExternal": false,
+        "children": [
+          {
+            "name": "Using Prisma with NestJS",
+            "path": "/recipes/database/nestjs-prisma",
+            "id": "nestjs-prisma",
+            "isExternal": false,
+            "children": [],
+            "disableCollapsible": false
+          },
+          {
+            "name": "Using Mongo with Fastify",
+            "path": "/recipes/database/mongo-fastify",
+            "id": "mongo-fastify",
+            "isExternal": false,
+            "children": [],
+            "disableCollapsible": false
+          },
+          {
+            "name": "Using Redis with Fastify",
+            "path": "/recipes/database/redis-fastify",
+            "id": "redis-fastify",
+            "isExternal": false,
+            "children": [],
+            "disableCollapsible": false
+          },
+          {
+            "name": "Using Postgres with Fastify",
+            "path": "/recipes/database/postgres-fastify",
+            "id": "postgres-fastify",
+            "isExternal": false,
+            "children": [],
+            "disableCollapsible": false
+          },
+          {
+            "name": "Using PlanetScale with Serverless Fastify",
+            "path": "/recipes/database/serverless-fastify-planetscale",
+            "id": "serverless-fastify-planetscale",
+            "isExternal": false,
+            "children": [],
+            "disableCollapsible": false
+          }
+        ],
+        "disableCollapsible": false
+      },
+      {
+        "name": "Using Prisma with NestJS",
+        "path": "/recipes/database/nestjs-prisma",
+        "id": "nestjs-prisma",
+        "isExternal": false,
+        "children": [],
+        "disableCollapsible": false
+      },
+      {
+        "name": "Using Mongo with Fastify",
+        "path": "/recipes/database/mongo-fastify",
+        "id": "mongo-fastify",
+        "isExternal": false,
+        "children": [],
+        "disableCollapsible": false
+      },
+      {
+        "name": "Using Redis with Fastify",
+        "path": "/recipes/database/redis-fastify",
+        "id": "redis-fastify",
+        "isExternal": false,
+        "children": [],
+        "disableCollapsible": false
+      },
+      {
+        "name": "Using Postgres with Fastify",
+        "path": "/recipes/database/postgres-fastify",
+        "id": "postgres-fastify",
+        "isExternal": false,
+        "children": [],
+        "disableCollapsible": false
+      },
+      {
+        "name": "Using PlanetScale with Serverless Fastify",
+        "path": "/recipes/database/serverless-fastify-planetscale",
+        "id": "serverless-fastify-planetscale",
+        "isExternal": false,
+        "children": [],
+        "disableCollapsible": false
+      },
+      {
         "name": "Enforce Module Boundaries",
         "path": "/recipes/enforce-module-boundaries",
         "id": "enforce-module-boundaries",

--- a/docs/generated/manifests/recipes.json
+++ b/docs/generated/manifests/recipes.json
@@ -1029,6 +1029,117 @@
     "path": "/recipes/deployment/deploy-nextjs-to-vercel",
     "tags": []
   },
+  "/recipes/database": {
+    "id": "database",
+    "name": "Database",
+    "description": "Recipes for using various databases in node apps.",
+    "file": "",
+    "itemList": [
+      {
+        "id": "nestjs-prisma",
+        "name": "Using Prisma with NestJS",
+        "description": "",
+        "file": "shared/recipes/database/nestjs-prisma",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/recipes/database/nestjs-prisma",
+        "tags": ["database", "node"]
+      },
+      {
+        "id": "mongo-fastify",
+        "name": "Using Mongo with Fastify",
+        "description": "",
+        "file": "shared/recipes/database/mongo-fastify",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/recipes/database/mongo-fastify",
+        "tags": ["database", "node"]
+      },
+      {
+        "id": "redis-fastify",
+        "name": "Using Redis with Fastify",
+        "description": "",
+        "file": "shared/recipes/database/redis-fastify",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/recipes/database/redis-fastify",
+        "tags": ["database", "node"]
+      },
+      {
+        "id": "postgres-fastify",
+        "name": "Using Postgres with Fastify",
+        "description": "",
+        "file": "shared/recipes/database/postgres-fastify",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/recipes/database/postgres-fastify",
+        "tags": ["database", "node"]
+      },
+      {
+        "id": "serverless-fastify-planetscale",
+        "name": "Using PlanetScale with Serverless Fastify",
+        "description": "",
+        "file": "shared/recipes/database/serverless-fastify-planetscale",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/recipes/database/serverless-fastify-planetscale",
+        "tags": ["database", "node", "serverless"]
+      }
+    ],
+    "isExternal": false,
+    "path": "/recipes/database",
+    "tags": []
+  },
+  "/recipes/database/nestjs-prisma": {
+    "id": "nestjs-prisma",
+    "name": "Using Prisma with NestJS",
+    "description": "",
+    "file": "shared/recipes/database/nestjs-prisma",
+    "itemList": [],
+    "isExternal": false,
+    "path": "/recipes/database/nestjs-prisma",
+    "tags": ["database", "node"]
+  },
+  "/recipes/database/mongo-fastify": {
+    "id": "mongo-fastify",
+    "name": "Using Mongo with Fastify",
+    "description": "",
+    "file": "shared/recipes/database/mongo-fastify",
+    "itemList": [],
+    "isExternal": false,
+    "path": "/recipes/database/mongo-fastify",
+    "tags": ["database", "node"]
+  },
+  "/recipes/database/redis-fastify": {
+    "id": "redis-fastify",
+    "name": "Using Redis with Fastify",
+    "description": "",
+    "file": "shared/recipes/database/redis-fastify",
+    "itemList": [],
+    "isExternal": false,
+    "path": "/recipes/database/redis-fastify",
+    "tags": ["database", "node"]
+  },
+  "/recipes/database/postgres-fastify": {
+    "id": "postgres-fastify",
+    "name": "Using Postgres with Fastify",
+    "description": "",
+    "file": "shared/recipes/database/postgres-fastify",
+    "itemList": [],
+    "isExternal": false,
+    "path": "/recipes/database/postgres-fastify",
+    "tags": ["database", "node"]
+  },
+  "/recipes/database/serverless-fastify-planetscale": {
+    "id": "serverless-fastify-planetscale",
+    "name": "Using PlanetScale with Serverless Fastify",
+    "description": "",
+    "file": "shared/recipes/database/serverless-fastify-planetscale",
+    "itemList": [],
+    "isExternal": false,
+    "path": "/recipes/database/serverless-fastify-planetscale",
+    "tags": ["database", "node", "serverless"]
+  },
   "/recipes/enforce-module-boundaries": {
     "id": "enforce-module-boundaries",
     "name": "Enforce Module Boundaries",

--- a/docs/generated/manifests/tags.json
+++ b/docs/generated/manifests/tags.json
@@ -858,6 +858,41 @@
       "id": "node-aws-lambda",
       "name": "Deploying AWS lambda in Node.js",
       "path": "/recipes/deployment/node-aws-lambda"
+    },
+    {
+      "description": "",
+      "file": "shared/recipes/database/nestjs-prisma",
+      "id": "nestjs-prisma",
+      "name": "Using Prisma with NestJS",
+      "path": "/recipes/database/nestjs-prisma"
+    },
+    {
+      "description": "",
+      "file": "shared/recipes/database/mongo-fastify",
+      "id": "mongo-fastify",
+      "name": "Using Mongo with Fastify",
+      "path": "/recipes/database/mongo-fastify"
+    },
+    {
+      "description": "",
+      "file": "shared/recipes/database/redis-fastify",
+      "id": "redis-fastify",
+      "name": "Using Redis with Fastify",
+      "path": "/recipes/database/redis-fastify"
+    },
+    {
+      "description": "",
+      "file": "shared/recipes/database/postgres-fastify",
+      "id": "postgres-fastify",
+      "name": "Using Postgres with Fastify",
+      "path": "/recipes/database/postgres-fastify"
+    },
+    {
+      "description": "",
+      "file": "shared/recipes/database/serverless-fastify-planetscale",
+      "id": "serverless-fastify-planetscale",
+      "name": "Using PlanetScale with Serverless Fastify",
+      "path": "/recipes/database/serverless-fastify-planetscale"
     }
   ],
   "deno": [
@@ -874,6 +909,52 @@
       "id": "deno-netlify-functions",
       "name": "Add and Deploy Netlify Edge Functions with Deno",
       "path": "/recipes/deployment/deno-netlify-functions"
+    }
+  ],
+  "database": [
+    {
+      "description": "",
+      "file": "shared/recipes/database/nestjs-prisma",
+      "id": "nestjs-prisma",
+      "name": "Using Prisma with NestJS",
+      "path": "/recipes/database/nestjs-prisma"
+    },
+    {
+      "description": "",
+      "file": "shared/recipes/database/mongo-fastify",
+      "id": "mongo-fastify",
+      "name": "Using Mongo with Fastify",
+      "path": "/recipes/database/mongo-fastify"
+    },
+    {
+      "description": "",
+      "file": "shared/recipes/database/redis-fastify",
+      "id": "redis-fastify",
+      "name": "Using Redis with Fastify",
+      "path": "/recipes/database/redis-fastify"
+    },
+    {
+      "description": "",
+      "file": "shared/recipes/database/postgres-fastify",
+      "id": "postgres-fastify",
+      "name": "Using Postgres with Fastify",
+      "path": "/recipes/database/postgres-fastify"
+    },
+    {
+      "description": "",
+      "file": "shared/recipes/database/serverless-fastify-planetscale",
+      "id": "serverless-fastify-planetscale",
+      "name": "Using PlanetScale with Serverless Fastify",
+      "path": "/recipes/database/serverless-fastify-planetscale"
+    }
+  ],
+  "serverless": [
+    {
+      "description": "",
+      "file": "shared/recipes/database/serverless-fastify-planetscale",
+      "id": "serverless-fastify-planetscale",
+      "name": "Using PlanetScale with Serverless Fastify",
+      "path": "/recipes/database/serverless-fastify-planetscale"
     }
   ],
   "workspace-watching": [

--- a/docs/map.json
+++ b/docs/map.json
@@ -1198,6 +1198,44 @@
           ]
         },
         {
+          "name": "Database",
+          "id": "database",
+          "description": "Recipes for using various databases in node apps.",
+          "itemList": [
+            {
+              "name": "Using Prisma with NestJS",
+              "id": "nestjs-prisma",
+              "tags": ["database", "node"],
+              "file": "shared/recipes/database/nestjs-prisma"
+            },
+            {
+              "name": "Using Mongo with Fastify",
+              "id": "mongo-fastify",
+              "tags": ["database", "node"],
+              "file": "shared/recipes/database/mongo-fastify"
+            },
+            {
+              "name": "Using Redis with Fastify",
+              "id": "redis-fastify",
+              "tags": ["database", "node"],
+              "file": "shared/recipes/database/redis-fastify"
+            },
+            {
+              "name": "Using Postgres with Fastify",
+              "id": "postgres-fastify",
+              "tags": ["database", "node"],
+              "file": "shared/recipes/database/postgres-fastify"
+            },
+            {
+              "name": "Using PlanetScale with Serverless Fastify",
+              "id": "serverless-fastify-planetscale",
+              "tags": ["database", "node", "serverless"],
+              "file": "shared/recipes/database/serverless-fastify-planetscale"
+            }
+          ]
+        },
+
+        {
           "name": "Enforce Module Boundaries",
           "id": "enforce-module-boundaries",
           "description": "Configuring the enforce module boundaries rule",

--- a/docs/shared/recipes/database/mongo-fastify.md
+++ b/docs/shared/recipes/database/mongo-fastify.md
@@ -1,0 +1,8 @@
+# Using MongoDB with Fastify in an Nx Workspace
+
+In this example repo, you’ll learn how to:
+
+- Leverage Nx generators to scaffold out project configurations
+- Setup MongoDB with Fastify
+
+{% github-repository url="https://github.com/nrwl/nx-recipes/tree/main/fastify-mongo#nx--fastify--mongodb" /%}

--- a/docs/shared/recipes/database/nestjs-prisma.md
+++ b/docs/shared/recipes/database/nestjs-prisma.md
@@ -1,0 +1,9 @@
+# Using Prisma with NestJS in an Nx Workspace
+
+In this example repo, you’ll learn how to:
+
+- Leverage Nx generators to scaffold out project configurations
+- Use multiple Prisma schemas in an Nx Workspace
+- Extend the generated Prisma clients for seamless NestJS integration
+
+{% github-repository url="https://github.com/nrwl/nx-recipes/tree/main/nestjs-prisma#nx--nestjs--prisma" /%}

--- a/docs/shared/recipes/database/postgres-fastify.md
+++ b/docs/shared/recipes/database/postgres-fastify.md
@@ -1,0 +1,8 @@
+# Using Postgres with Fastify in an Nx Workspace
+
+In this example repo, you’ll learn how to:
+
+- Setup Fastify to use Postgres
+- Leverage Nx generators to scaffold out projects
+
+{% github-repository url="https://github.com/nrwl/nx-recipes/tree/main/fastify-postgres#nx--fastify--postgres" /%}

--- a/docs/shared/recipes/database/redis-fastify.md
+++ b/docs/shared/recipes/database/redis-fastify.md
@@ -1,0 +1,9 @@
+# Using Redis with Fastify in an Nx Workspace
+
+In this example repo, you’ll learn how to:
+
+- Leverage Nx generators to scaffold out project configurations
+- Use Redis with Fastify
+- Use Redis Modules, like RediSearch
+
+{% github-repository url="https://github.com/nrwl/nx-recipes/tree/main/fastify-redis#nx--fastify--redis" /%}

--- a/docs/shared/recipes/database/serverless-fastify-planetscale.md
+++ b/docs/shared/recipes/database/serverless-fastify-planetscale.md
@@ -1,0 +1,9 @@
+# Using PlanetScale with Serverless Fastify
+
+In this example repo, you’ll learn how to:
+
+- Use Netlify serverless functions
+- Integrate Fastify with Netlify functions
+- Use PlanetScale with Fastify
+
+{% github-repository url="https://github.com/nrwl/nx-recipes/tree/main/serverless-fastify-planetscale#serverless--fastify--planetscale" /%}


### PR DESCRIPTION
add new 'database' section that for the node examples with dbs

unsure if any extra info should go in the docs since the repo REAME covers what would be said.
