### PR TITLE
feat(core): expose the task graph in the executor context

### DIFF
--- a/docs/generated/devkit/nx_devkit.md
+++ b/docs/generated/devkit/nx_devkit.md
@@ -2064,14 +2064,11 @@ Note that the return value is a promise of an iterator, so you need to await bef
 
 #### Parameters
 
-| Name                               | Type                                                                  |
-| :--------------------------------- | :-------------------------------------------------------------------- |
-| `targetDescription`                | `Object`                                                              |
-| `targetDescription.configuration?` | `string`                                                              |
-| `targetDescription.project`        | `string`                                                              |
-| `targetDescription.target`         | `string`                                                              |
-| `overrides`                        | `Object`                                                              |
-| `context`                          | [`ExecutorContext`](../../devkit/documents/nx_devkit#executorcontext) |
+| Name                | Type                                                                  |
+| :------------------ | :-------------------------------------------------------------------- |
+| `targetDescription` | [`Target`](../../devkit/documents/nx_devkit#target)                   |
+| `overrides`         | `Object`                                                              |
+| `context`           | [`ExecutorContext`](../../devkit/documents/nx_devkit#executorcontext) |
 
 #### Returns
 

--- a/docs/generated/packages/devkit/documents/nx_devkit.md
+++ b/docs/generated/packages/devkit/documents/nx_devkit.md
@@ -2064,14 +2064,11 @@ Note that the return value is a promise of an iterator, so you need to await bef
 
 #### Parameters
 
-| Name                               | Type                                                                  |
-| :--------------------------------- | :-------------------------------------------------------------------- |
-| `targetDescription`                | `Object`                                                              |
-| `targetDescription.configuration?` | `string`                                                              |
-| `targetDescription.project`        | `string`                                                              |
-| `targetDescription.target`         | `string`                                                              |
-| `overrides`                        | `Object`                                                              |
-| `context`                          | [`ExecutorContext`](../../devkit/documents/nx_devkit#executorcontext) |
+| Name                | Type                                                                  |
+| :------------------ | :-------------------------------------------------------------------- |
+| `targetDescription` | [`Target`](../../devkit/documents/nx_devkit#target)                   |
+| `overrides`         | `Object`                                                              |
+| `context`           | [`ExecutorContext`](../../devkit/documents/nx_devkit#executorcontext) |
 
 #### Returns
 

--- a/packages/devkit/src/utils/convert-nx-executor.ts
+++ b/packages/devkit/src/utils/convert-nx-executor.ts
@@ -1,10 +1,8 @@
 import type { Observable } from 'rxjs';
 import type { Executor, ExecutorContext } from 'nx/src/config/misc-interfaces';
-import type { ProjectGraph } from 'nx/src/config/project-graph';
 import { requireNx } from '../../nx';
 
-const { createProjectGraphAsync, readCachedProjectGraph, Workspaces } =
-  requireNx();
+const { Workspaces } = requireNx();
 
 /**
  * Convert an Nx Executor into an Angular Devkit Builder
@@ -21,12 +19,6 @@ export function convertNxExecutor(executor: Executor) {
     });
 
     const promise = async () => {
-      let projectGraph: ProjectGraph;
-      try {
-        projectGraph = readCachedProjectGraph();
-      } catch {
-        projectGraph = await createProjectGraphAsync();
-      }
       const context: ExecutorContext = {
         root: builderContext.workspaceRoot,
         projectName: builderContext.target.project,
@@ -36,7 +28,8 @@ export function convertNxExecutor(executor: Executor) {
         projectsConfigurations,
         nxJsonConfiguration,
         cwd: process.cwd(),
-        projectGraph,
+        projectGraph: null,
+        taskGraph: null,
         isVerbose: false,
       };
       return executor(options, context);

--- a/packages/nx/src/command-line/run/run-one.ts
+++ b/packages/nx/src/command-line/run/run-one.ts
@@ -57,9 +57,7 @@ export async function runOne(
     process.env.NX_VERBOSE_LOGGING = 'true';
   }
   if (nxArgs.help) {
-    await (
-      await import('./run')
-    ).run(cwd, workspaceRoot, opts, {}, false, true);
+    await (await import('./run')).printTargetRunHelp(opts, workspaceRoot);
     process.exit(0);
   }
 

--- a/packages/nx/src/command-line/run/run.ts
+++ b/packages/nx/src/command-line/run/run.ts
@@ -20,6 +20,7 @@ import {
   ProjectsConfigurations,
 } from '../../config/workspace-json-project-json';
 import { Executor, ExecutorContext } from '../../config/misc-interfaces';
+import { TaskGraph } from '../../config/task-graph';
 import { serializeOverridesIntoCommandLine } from '../../utils/serialize-overrides-into-command-line';
 import {
   readCachedProjectGraph,
@@ -123,28 +124,13 @@ function createImplicitTargetConfig(
   return buildTargetFromScript(targetName, nx);
 }
 
-async function runExecutorInternal<T extends { success: boolean }>(
-  {
-    project,
-    target,
-    configuration,
-  }: {
-    project: string;
-    target: string;
-    configuration?: string;
-  },
-  overrides: { [k: string]: any },
+async function parseExecutorAndTarget(
+  ws: Workspaces,
+  { project, target, configuration }: Target,
   root: string,
-  cwd: string,
   projectsConfigurations: ProjectsConfigurations,
-  nxJsonConfiguration: NxJsonConfiguration,
-  projectGraph: ProjectGraph,
-  isVerbose: boolean,
-  printHelp: boolean
-): Promise<AsyncIterableIterator<T>> {
-  validateProject(projectsConfigurations, project);
-
-  const ws = new Workspaces(root);
+  nxJsonConfiguration: NxJsonConfiguration
+) {
   const proj = projectsConfigurations.projects[project];
   const targetConfig =
     proj.targets?.[target] ||
@@ -159,21 +145,60 @@ async function runExecutorInternal<T extends { success: boolean }>(
     throw new Error(`Cannot find target '${target}' for project '${project}'`);
   }
 
-  configuration = configuration ?? targetConfig.defaultConfiguration;
-
   const [nodeModule, executor] = targetConfig.executor.split(':');
   const { schema, implementationFactory } = ws.readExecutor(
     nodeModule,
     executor
   );
 
-  if (printHelp) {
-    printRunHelp({ project, target }, schema, {
-      plugin: nodeModule,
-      entity: executor,
-    });
-    process.exit(0);
-  }
+  return { executor, implementationFactory, nodeModule, schema, targetConfig };
+}
+
+async function printTargetRunHelpInternal(
+  { project, target, configuration }: Target,
+  root: string,
+  projectsConfigurations: ProjectsConfigurations,
+  nxJsonConfiguration: NxJsonConfiguration
+) {
+  const ws = new Workspaces(root);
+  const { executor, nodeModule, schema } = await parseExecutorAndTarget(
+    ws,
+    { project, target, configuration },
+    root,
+    projectsConfigurations,
+    nxJsonConfiguration
+  );
+
+  printRunHelp({ project, target }, schema, {
+    plugin: nodeModule,
+    entity: executor,
+  });
+  process.exit(0);
+}
+
+async function runExecutorInternal<T extends { success: boolean }>(
+  { project, target, configuration }: Target,
+  overrides: { [k: string]: any },
+  root: string,
+  cwd: string,
+  projectsConfigurations: ProjectsConfigurations,
+  nxJsonConfiguration: NxJsonConfiguration,
+  projectGraph: ProjectGraph,
+  taskGraph: TaskGraph,
+  isVerbose: boolean
+): Promise<AsyncIterableIterator<T>> {
+  validateProject(projectsConfigurations, project);
+
+  const ws = new Workspaces(root);
+  const { executor, implementationFactory, nodeModule, schema, targetConfig } =
+    await parseExecutorAndTarget(
+      ws,
+      { project, target, configuration },
+      root,
+      projectsConfigurations,
+      nxJsonConfiguration
+    );
+  configuration ??= targetConfig.defaultConfiguration;
 
   const combinedOptions = combineOptionsForExecutor(
     overrides,
@@ -197,6 +222,7 @@ async function runExecutorInternal<T extends { success: boolean }>(
       targetName: target,
       configurationName: configuration,
       projectGraph,
+      taskGraph,
       cwd,
       isVerbose,
     }) as Promise<T> | AsyncIterableIterator<T>;
@@ -254,11 +280,7 @@ async function runExecutorInternal<T extends { success: boolean }>(
  * Note that the return value is a promise of an iterator, so you need to await before iterating over it.
  */
 export async function runExecutor<T extends { success: boolean }>(
-  targetDescription: {
-    project: string;
-    target: string;
-    configuration?: string;
-  },
+  targetDescription: Target,
   overrides: { [k: string]: any },
   context: ExecutorContext
 ): Promise<AsyncIterableIterator<T>> {
@@ -273,22 +295,34 @@ export async function runExecutor<T extends { success: boolean }>(
     context.projectsConfigurations,
     context.nxJsonConfiguration,
     context.projectGraph,
-    context.isVerbose,
-    false
+    context.taskGraph,
+    context.isVerbose
   );
+}
+
+export function printTargetRunHelp(targetDescription: Target, root: string) {
+  const projectGraph = readCachedProjectGraph();
+  return handleErrors(false, async () => {
+    const projectsConfigurations =
+      readProjectsConfigurationFromProjectGraph(projectGraph);
+    const nxJsonConfiguration = readNxJson();
+
+    printTargetRunHelpInternal(
+      targetDescription,
+      root,
+      projectsConfigurations,
+      nxJsonConfiguration
+    );
+  });
 }
 
 export function run(
   cwd: string,
   root: string,
-  targetDescription: {
-    project: string;
-    target: string;
-    configuration?: string;
-  },
+  targetDescription: Target,
   overrides: { [k: string]: any },
   isVerbose: boolean,
-  isHelp: boolean
+  taskGraph: TaskGraph
 ) {
   const projectGraph = readCachedProjectGraph();
   return handleErrors(isVerbose, async () => {
@@ -303,8 +337,8 @@ export function run(
         projectsConfigurations,
         readNxJson(),
         projectGraph,
-        isVerbose,
-        isHelp
+        taskGraph,
+        isVerbose
       )
     );
   });

--- a/packages/nx/src/config/misc-interfaces.ts
+++ b/packages/nx/src/config/misc-interfaces.ts
@@ -211,6 +211,12 @@ export interface ExecutorContext {
   projectGraph?: ProjectGraph;
 
   /**
+   * A snapshot of the task graph as
+   * it existed when the Nx command was kicked off
+   */
+  taskGraph?: TaskGraph;
+
+  /**
    * Deprecated. Use projectsConfigurations or nxJsonConfiguration
    * The full workspace configuration
    * @todo(vsavkin): remove after v17

--- a/packages/nx/src/executors/utils/convert-nx-executor.ts
+++ b/packages/nx/src/executors/utils/convert-nx-executor.ts
@@ -5,11 +5,6 @@
 import type { Observable } from 'rxjs';
 import { Workspaces } from '../../config/workspaces';
 import { Executor, ExecutorContext } from '../../config/misc-interfaces';
-import {
-  createProjectGraphAsync,
-  readCachedProjectGraph,
-} from '../../project-graph/project-graph';
-import { ProjectGraph } from '../../config/project-graph';
 
 /**
  * Convert an Nx Executor into an Angular Devkit Builder
@@ -34,6 +29,7 @@ export function convertNxExecutor(executor: Executor) {
         nxJsonConfiguration,
         cwd: process.cwd(),
         projectGraph: null,
+        taskGraph: null,
         isVerbose: false,
       };
       return executor(options, context);

--- a/packages/nx/src/tasks-runner/batch/batch-messages.ts
+++ b/packages/nx/src/tasks-runner/batch/batch-messages.ts
@@ -8,7 +8,8 @@ export enum BatchMessageType {
 export interface BatchTasksMessage {
   type: BatchMessageType.Tasks;
   executorName: string;
-  taskGraph: TaskGraph;
+  batchTaskGraph: TaskGraph;
+  fullTaskGraph: TaskGraph;
 }
 /**
  * Results of running the batch. Mapped from task id to results

--- a/packages/nx/src/tasks-runner/batch/run-batch.ts
+++ b/packages/nx/src/tasks-runner/batch/run-batch.ts
@@ -20,14 +20,18 @@ function getBatchExecutor(executorName: string) {
   return workspace.readExecutor(nodeModule, exportName);
 }
 
-async function runTasks(executorName: string, taskGraph: TaskGraph) {
+async function runTasks(
+  executorName: string,
+  batchTaskGraph: TaskGraph,
+  fullTaskGraph: TaskGraph
+) {
   const input: Record<string, any> = {};
   const projectGraph = await createProjectGraphAsync();
   const projectsConfigurations =
     readProjectsConfigurationFromProjectGraph(projectGraph);
   const nxJsonConfiguration = readNxJson();
   const batchExecutor = getBatchExecutor(executorName);
-  const tasks = Object.values(taskGraph.tasks);
+  const tasks = Object.values(batchTaskGraph.tasks);
   const context: ExecutorContext = {
     root: workspaceRoot,
     cwd: process.cwd(),
@@ -36,6 +40,7 @@ async function runTasks(executorName: string, taskGraph: TaskGraph) {
     workspace: { ...projectsConfigurations, ...nxJsonConfiguration },
     isVerbose: false,
     projectGraph,
+    taskGraph: fullTaskGraph,
   };
   for (const task of tasks) {
     const projectConfiguration =
@@ -54,7 +59,7 @@ async function runTasks(executorName: string, taskGraph: TaskGraph) {
 
   try {
     const results = await batchExecutor.batchImplementationFactory()(
-      taskGraph,
+      batchTaskGraph,
       input,
       tasks[0].overrides,
       context
@@ -75,7 +80,11 @@ async function runTasks(executorName: string, taskGraph: TaskGraph) {
 process.on('message', async (message: BatchMessage) => {
   switch (message.type) {
     case BatchMessageType.Tasks: {
-      const results = await runTasks(message.executorName, message.taskGraph);
+      const results = await runTasks(
+        message.executorName,
+        message.batchTaskGraph,
+        message.fullTaskGraph
+      );
       process.send({
         type: BatchMessageType.Complete,
         results,

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -229,7 +229,8 @@ export class TaskOrchestrator {
   private async runBatch(batch: Batch) {
     try {
       const results = await this.forkedProcessTaskRunner.forkProcessForBatch(
-        batch
+        batch,
+        this.taskGraph
       );
       const batchResultEntries = Object.entries(results);
       return batchResultEntries.map(([taskId, result]) => ({
@@ -296,6 +297,7 @@ export class TaskOrchestrator {
             {
               temporaryOutputPath,
               streamOutput,
+              taskGraph: this.taskGraph,
             }
           )
         : await this.forkedProcessTaskRunner.forkProcessDirectOutputCapture(
@@ -303,6 +305,7 @@ export class TaskOrchestrator {
             {
               temporaryOutputPath,
               streamOutput,
+              taskGraph: this.taskGraph,
             }
           );
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The task graph of the current execution is not accessible from executors.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The task graph of the current execution is accessible from executors as part of the `ExecutorContext`. This is helpful for accessing already parsed task dependencies and acting on them.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
