### PR TITLE
feat(react): run remote serve in parallel to speed up server startup

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -53,6 +53,7 @@
     "@nx/js": "file:../js",
     "@nx/linter": "file:../linter",
     "@nx/react": "file:../react",
+    "@nx/web": "file:../web",
     "@nx/workspace": "file:../workspace"
   },
   "publishConfig": {

--- a/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -2,11 +2,13 @@ import { ExecutorContext, logger, runExecutor } from '@nx/devkit';
 import devServerExecutor from '@nx/webpack/src/executors/dev-server/dev-server.impl';
 import { WebDevServerOptions } from '@nx/webpack/src/executors/dev-server/schema';
 import { join } from 'path';
-import * as chalk from 'chalk';
 import {
   combineAsyncIterables,
-  tapAsyncIterable,
+  createAsyncIterable,
 } from '@nx/devkit/src/utils/async-iterable';
+import * as chalk from 'chalk';
+import { waitForPortOpen } from '@nx/web/src/utils/wait-for-port-open';
+import { spawn } from 'child_process';
 
 type ModuleFederationDevServerOptions = WebDevServerOptions & {
   devRemotes?: string | string[];
@@ -16,8 +18,8 @@ type ModuleFederationDevServerOptions = WebDevServerOptions & {
 export default async function* moduleFederationDevServer(
   options: ModuleFederationDevServerOptions,
   context: ExecutorContext
-) {
-  let iter = devServerExecutor(options, context);
+): AsyncIterableIterator<{ success: boolean; baseUrl?: string }> {
+  const currIter = devServerExecutor(options, context);
   const p = context.projectsConfigurations.projects[context.projectName];
 
   const moduleFederationConfigPath = join(
@@ -30,9 +32,8 @@ export default async function* moduleFederationDevServer(
   try {
     moduleFederationConfig = require(moduleFederationConfigPath);
   } catch {
-    // TODO(jack): Add a link to guide
     throw new Error(
-      `Could not load ${moduleFederationConfigPath}. Was this project generated with "@nx/react:host"?`
+      `Could not load ${moduleFederationConfigPath}. Was this project generated with "@nx/react:host"?\nSee: https://nx.dev/recipes/module-federation/faster-builds`
     );
   }
 
@@ -41,6 +42,9 @@ export default async function* moduleFederationDevServer(
     const validRemote = Array.isArray(r) ? r[0] : r;
     return !remotesToSkip.has(validRemote);
   });
+  const remotePorts = knownRemotes.map(
+    (r) => context.projectGraph.nodes[r].data.targets['serve'].options.port
+  );
 
   const devServeApps = !options.devRemotes
     ? []
@@ -48,34 +52,98 @@ export default async function* moduleFederationDevServer(
     ? options.devRemotes
     : [options.devRemotes];
 
+  logger.info(
+    `NX Starting module federation dev-server for ${chalk.bold(
+      context.projectName
+    )} with ${knownRemotes.length} remotes`
+  );
+
+  const nxBin = require.resolve('nx');
+  const devRemoteIters: AsyncIterable<{ success: boolean }>[] = [];
+  let isCollectingStaticRemoteOutput = true;
+
   for (const app of knownRemotes) {
-    const [appName] = Array.isArray(app) ? app : [app];
-    const isDev = devServeApps.includes(appName);
-    iter = combineAsyncIterables(
-      iter,
-      await runExecutor(
+    const appName = Array.isArray(app) ? app[0] : app;
+    if (devServeApps.includes(appName)) {
+      devRemoteIters.push(
+        await runExecutor(
+          {
+            project: appName,
+            target: 'serve',
+            configuration: context.configurationName,
+          },
+          {
+            watch: true,
+          },
+          context
+        )
+      );
+    } else {
+      let outWithErr: null | string[] = [];
+      const staticProcess = spawn(
+        `node ${nxBin} run ${appName}:serve-static${
+          context.configurationName ? `:${context.configurationName}` : ''
+        }`,
         {
-          project: appName,
-          target: isDev ? 'serve' : 'serve-static',
-          configuration: context.configurationName,
-        },
-        {
-          watch: isDev,
-        },
-        context
-      )
-    );
+          cwd: context.root,
+          stdio: ['ignore', 'pipe', 'pipe'],
+          shell: true,
+          windowsHide: true,
+        }
+      );
+      staticProcess.stdout.on('data', (data) => {
+        if (isCollectingStaticRemoteOutput) {
+          outWithErr.push(data.toString());
+        } else {
+          outWithErr = null;
+          staticProcess.stdout.removeAllListeners('data');
+        }
+      });
+      staticProcess.stderr.on('data', (data) => logger.info(data.toString()));
+      staticProcess.on('exit', (code) => {
+        if (code !== 0) {
+          logger.info(outWithErr.join(''));
+          throw new Error(`Remote failed to start. See above for errors.`);
+        }
+      });
+      process.on('SIGTERM', () => staticProcess.kill('SIGTERM'));
+      process.on('exit', () => staticProcess.kill('SIGTERM'));
+    }
   }
 
-  let numAwaiting = knownRemotes.length + 1; // remotes + host
-  return yield* tapAsyncIterable(iter, (x) => {
-    numAwaiting--;
-    if (numAwaiting === 0) {
-      logger.info(
-        `[ ${chalk.green('ready')} ] http://${options.host ?? 'localhost'}:${
-          options.port ?? 4200
-        }`
-      );
-    }
-  });
+  return yield* combineAsyncIterables(
+    currIter,
+    ...devRemoteIters,
+    createAsyncIterable<{ success: true; baseUrl: string }>(
+      async ({ next, done }) => {
+        if (remotePorts.length === 0) {
+          done();
+          return;
+        }
+        try {
+          await Promise.all(
+            remotePorts.map((port) =>
+              // Allow 20 minutes for each remote to start, which is plenty of time but we can tweak it later if needed.
+              // Most remotes should start in under 1 minute.
+              waitForPortOpen(port, {
+                retries: 480,
+                retryDelay: 2500,
+              })
+            )
+          );
+          isCollectingStaticRemoteOutput = false;
+          logger.info(
+            `NX All remotes started, server ready at http://localhost:${options.port}`
+          );
+          next({ success: true, baseUrl: `http://localhost:${options.port}` });
+        } catch {
+          throw new Error(
+            `Timed out waiting for remote to start. Check above for any errors.`
+          );
+        } finally {
+          done();
+        }
+      }
+    )
+  );
 }

--- a/packages/web/src/utils/wait-for-port-open.ts
+++ b/packages/web/src/utils/wait-for-port-open.ts
@@ -1,0 +1,38 @@
+import * as net from 'net';
+
+export function waitForPortOpen(
+  port: number,
+  options: { host?: string; retries?: number; retryDelay?: number } = {}
+): Promise<void> {
+  const allowedErrorCodes = ['ECONNREFUSED', 'ECONNRESET'];
+
+  return new Promise((resolve, reject) => {
+    const checkPort = (retries = options.retries ?? 120) => {
+      const client = new net.Socket();
+      const cleanupClient = () => {
+        client.removeAllListeners('connect');
+        client.removeAllListeners('error');
+        client.end();
+        client.destroy();
+        client.unref();
+      };
+      client.once('connect', () => {
+        cleanupClient();
+        resolve();
+      });
+
+      client.once('error', (err) => {
+        if (retries === 0 || !allowedErrorCodes.includes(err['code'])) {
+          cleanupClient();
+          reject(err);
+        } else {
+          setTimeout(() => checkPort(retries - 1), options.retryDelay ?? 1000);
+        }
+      });
+
+      client.connect({ port, host: options.host ?? 'localhost' });
+    };
+
+    checkPort();
+  });
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->

This PR changes the module federation server to start remotes in parallel so startup time is significantly reduced.

TODO:

- [x] Do some local testing around static vs dev remotes and make sure DX is good.

https://github.com/nrwl/nx/assets/53559/2e486cfc-00f2-4ad9-8563-aff74af384c9


<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Closes #12139
