### PR TITLE
fix(web): file watcher should only watch files in its project #17085

### DIFF
--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -5,7 +5,6 @@ import {
   joinPathFragments,
   parseTargetString,
   readTargetOptions,
-  workspaceLayout,
 } from '@nx/devkit';
 import ignore from 'ignore';
 import { copyFileSync, readFileSync, unlinkSync } from 'fs';
@@ -106,21 +105,15 @@ function getIgnoredGlobs(root: string) {
 
 function createFileWatcher(
   root: string,
+  projectRoot: string,
   changeHandler: () => void
 ): () => void {
   const ignoredGlobs = getIgnoredGlobs(root);
-  const layout = workspaceLayout();
 
-  const watcher = watch(
-    [
-      joinPathFragments(layout.appsDir, '**'),
-      joinPathFragments(layout.libsDir, '**'),
-    ],
-    {
-      cwd: root,
-      ignoreInitial: true,
-    }
-  );
+  const watcher = watch([joinPathFragments(projectRoot, '**')], {
+    cwd: root,
+    ignoreInitial: true,
+  });
   watcher.on('all', (_event: string, path: string) => {
     if (ignoredGlobs.ignores(path)) return;
     changeHandler();
@@ -154,7 +147,9 @@ export default async function* fileServerExecutor(
 
   let disposeWatch: () => void;
   if (options.watch) {
-    disposeWatch = createFileWatcher(context.root, run);
+    const projectRoot =
+      context.projectsConfigurations.projects[context.projectName].root;
+    disposeWatch = createFileWatcher(context.root, projectRoot, run);
   }
 
   // perform initial run


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
File Watcher currently sets up a watcher on all files in the layout.appDir and layout.libsDir, essentially the whole repo.

This is too greedy.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Set the File Watcher to only watch files within the project that the executor is being run for.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17085
