### PR TITLE
feat(core): add shard option to run-many and affected

### DIFF
--- a/docs/generated/cli/affected-graph.md
+++ b/docs/generated/cli/affected-graph.md
@@ -123,6 +123,12 @@ Type: `number`
 
 Bind the project graph server to a specific port.
 
+### shard
+
+type: `string`
+
+Split the projects into shards for parallelization in CI via `index/shardCount` (Example: `2/5` splits the project set into 5 pieces, and only returns shard 2)
+
 ### targets
 
 Type: `string`

--- a/docs/generated/cli/affected.md
+++ b/docs/generated/cli/affected.md
@@ -159,6 +159,12 @@ Type: `string`
 
 This is the name of the tasks runner configured in nx.json
 
+### shard
+
+type: `string`
+
+Split the projects into shards for parallelization in CI via `index/shardCount` (Example: `2/5` splits the project set into 5 pieces, and only returns shard 2)
+
 ### skip-nx-cache
 
 Type: `boolean`

--- a/docs/generated/cli/print-affected.md
+++ b/docs/generated/cli/print-affected.md
@@ -91,6 +91,12 @@ Type: `string`
 
 Select the subset of the returned json document (e.g., --select=projects)
 
+### shard
+
+type: `string`
+
+Split the projects into shards for parallelization in CI via `index/shardCount` (Example: `2/5` splits the project set into 5 pieces, and only returns shard 2)
+
 ### targets
 
 Type: `string`

--- a/docs/generated/packages/nx/documents/print-affected.md
+++ b/docs/generated/packages/nx/documents/print-affected.md
@@ -91,6 +91,12 @@ Type: `string`
 
 Select the subset of the returned json document (e.g., --select=projects)
 
+### shard
+
+type: `string`
+
+Split the projects into shards for parallelization in CI via `index/shardCount` (Example: `2/5` splits the project set into 5 pieces, and only returns shard 2)
+
 ### targets
 
 Type: `string`

--- a/packages/nx/src/command-line/affected/affected.ts
+++ b/packages/nx/src/command-line/affected/affected.ts
@@ -15,7 +15,7 @@ import {
   ProjectGraph,
   ProjectGraphProjectNode,
 } from '../../config/project-graph';
-import { projectHasTarget } from '../../utils/project-graph-utils';
+import { projectHasTarget, shard } from '../../utils/project-graph-utils';
 import { filterAffected } from '../../project-graph/affected/affected-project-graph';
 import { TargetDependencyConfig } from '../../config/workspace-json-project-json';
 import { readNxJson } from '../../config/configuration';
@@ -53,9 +53,13 @@ export async function affected(
   await connectToNxCloudIfExplicitlyAsked(nxArgs);
 
   const projectGraph = await createProjectGraphAsync({ exitOnError: true });
-  const projects = await projectsToRun(nxArgs, projectGraph);
+  let projects = await projectsToRun(nxArgs, projectGraph);
 
   try {
+    if (nxArgs.shard) {
+      projects = shard(projects, nxArgs.shard);
+    }
+
     switch (command) {
       case 'graph':
         const projectNames = projects.map((p) => p.name);

--- a/packages/nx/src/command-line/run-many/run-many.spec.ts
+++ b/packages/nx/src/command-line/run-many/run-many.spec.ts
@@ -204,5 +204,18 @@ describe('run-many', () => {
         expect(measure.duration).toBeLessThan(4000);
       });
     });
+
+    it('should select all projects with a target', () => {
+      const projects = projectsToRun(
+        {
+          all: true,
+          targets: ['test'],
+          projects: [],
+        },
+        projectGraph
+      ).map(({ name }) => name);
+      expect(projects).toContain('proj1');
+      expect(projects).toContain('proj2');
+    });
   });
 });

--- a/packages/nx/src/utils/command-line-utils.ts
+++ b/packages/nx/src/utils/command-line-utils.ts
@@ -16,6 +16,7 @@ export interface NxArgs {
   configuration?: string;
   runner?: string;
   parallel?: number;
+  shard?: string;
   untracked?: boolean;
   uncommitted?: boolean;
   all?: boolean;

--- a/packages/nx/src/utils/project-graph-utils.spec.ts
+++ b/packages/nx/src/utils/project-graph-utils.spec.ts
@@ -15,9 +15,27 @@ import { ProjectGraph } from '../config/project-graph';
 import {
   getSourceDirOfDependentProjects,
   mergeNpmScriptsWithTargets,
+  shard,
 } from './project-graph-utils';
 
 describe('project graph utils', () => {
+  describe('shard', () => {
+    const shardable = ['a', 'b', 'c', 'd', 'e', 'f', 'g'];
+
+    it('should split array into shards', () => {
+      expect(shard(shardable, '1/3')).toEqual(['a', 'b', 'c']);
+      expect(shard(shardable, '2/3')).toEqual(['d', 'e', 'f']);
+      expect(shard(shardable, '3/3')).toEqual(['g']);
+    });
+
+    it(`should throw on invalid shard argument`, () => {
+      expect(() => shard(shardable, '4/3')).toThrowError();
+      expect(() => shard(shardable, '')).toThrowError();
+      expect(() => shard(shardable, null)).toThrowError();
+      expect(() => shard(shardable, undefined)).toThrowError();
+    });
+  });
+
   describe('getSourceDirOfDependentProjects', () => {
     const projGraph: ProjectGraph = {
       nodes: {

--- a/packages/nx/src/utils/project-graph-utils.ts
+++ b/packages/nx/src/utils/project-graph-utils.ts
@@ -131,3 +131,17 @@ function collectDependentProjectNodesNames(
     );
   }
 }
+
+export function shard<T>(
+  shardable: T[],
+  shardArg: string
+): T[] {
+  const [indexStr, countStr] = shardArg.split('/');
+  const [index, count] = [Number(indexStr), Number(countStr)];
+  if (isNaN(index) || isNaN(count) || index > count) {
+    throw new Error(`Invalid shard argument format (Usage: {current shard index}/{shard count})`);
+  }
+  const shardSize = Math.ceil(shardable.length / count);
+  const offset = (index - 1) * shardSize;
+  return shardable.slice(offset, offset + shardSize);
+}


### PR DESCRIPTION
`nx run-many|affected --shard=1/5` splits up the set of projects into 5 shards, and only executes the command on shard 1's projects. This makes slicing up a CI job into parallel workers easier.

In GitLab CI for instance, we could now set a `parallel: 5` property and run `nx --shard=$CI_NODE_INDEX/$CI_NODE_TOTAL `.

## Current Behavior

Currently sharding things either depends on "target support" (like Jest) or adding your own special "slicer", which can be a bit hard because nx doesn't always easliy list the targets.

## Expected Behavior

This MR introduces built-in support for sharding, for the `run-many` and `affected` commands.

## Related Issue(s)

Fixes #15040, Relates to #16735

## Discussion

I'm having a hard time navigating the tests for `affected`, I can only find _some_ tests for `print-affected` so unsure how to create tests for my changes here.

In general it's been hard to test the feature at all, installing my fork in my "live" project caused dependency errors. Would love some ideas here.