### PR TITLE
fix(core): do not create empty graph when it is not cached

### DIFF
--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -228,8 +228,8 @@ function copyFileMap(m: ProjectFileMap) {
   return c;
 }
 
-function copyProjectGraph(p: ProjectGraph): ProjectGraph {
-  return { ...p };
+function copyProjectGraph(p: ProjectGraph | null): ProjectGraph | null {
+  return p ? { ...p } : null;
 }
 
 async function createAndSerializeProjectGraph(): Promise<{


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When there's no project graph cached, an invalid and empty project graph is created due to this change https://github.com/nrwl/nx/commit/8b1907afc46457c17fa870ec5f8d5f43652cc3dc#diff-d5bf3c66e62cac1884a071bf07fd1991320a3e62b07bfc03af3b9557b714c892R232. This causes issues because required properties that are expected to exist (e.g. `nodes`) don't exist in that empty graph object. The nightly pipeline tests failed because of this https://github.com/nrwl/nx/actions/runs/5040378157.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The project graph copy should only be created if the project graph is defined and no invalid project graph should be created.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
