### PR TITLE
fix(angular): avoid duplicating RouterModule.forChild import

### DIFF
--- a/packages/angular/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/angular/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -502,6 +502,32 @@ describe('MyLibComponent', () => {
 "
 `;
 
+exports[`lib router lazy should add RouterModule.forChild 1`] = `
+"import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { myDirMyLibRoutes } from './lib.routes';
+
+@NgModule({
+  imports: [CommonModule, RouterModule.forChild(myDirMyLibRoutes)],
+})
+export class MyDirMyLibModule {}
+"
+`;
+
+exports[`lib router lazy should add RouterModule.forChild 2`] = `
+"import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { myLib2Routes } from './lib.routes';
+
+@NgModule({
+  imports: [CommonModule, RouterModule.forChild(myLib2Routes)],
+})
+export class MyLib2Module {}
+"
+`;
+
 exports[`lib router lazy should update the parent module 1`] = `
 "import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';

--- a/packages/angular/src/generators/library/lib/add-lazy-loaded-router-configuration.ts
+++ b/packages/angular/src/generators/library/lib/add-lazy-loaded-router-configuration.ts
@@ -29,13 +29,6 @@ export const ${constName}: Route[] = [/* {path: '', pathMatch: 'full', component
     tsModule.ScriptTarget.Latest,
     true
   );
-  sourceFile = addImportToModule(
-    tree,
-    sourceFile,
-    options.modulePath,
-    `
-    RouterModule.forChild(${constName}) `
-  );
 
   sourceFile = insertImport(
     tree,

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -671,17 +671,18 @@ describe('lib', () => {
           tree.exists('libs/my-dir/my-lib/src/lib/my-dir-my-lib.module.ts')
         ).toBeTruthy();
         expect(
-          tree
-            .read('libs/my-dir/my-lib/src/lib/my-dir-my-lib.module.ts')
-            .toString()
-        ).toContain('RouterModule.forChild');
+          tree.read(
+            'libs/my-dir/my-lib/src/lib/my-dir-my-lib.module.ts',
+            'utf-8'
+          )
+        ).toMatchSnapshot();
 
         expect(
           tree.exists('libs/my-dir/my-lib2/src/lib/my-lib2.module.ts')
         ).toBeTruthy();
         expect(
-          tree.read('libs/my-dir/my-lib2/src/lib/my-lib2.module.ts').toString()
-        ).toContain('RouterModule.forChild');
+          tree.read('libs/my-dir/my-lib2/src/lib/my-lib2.module.ts', 'utf-8')
+        ).toMatchSnapshot();
       });
 
       it('should update the parent module', async () => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17143 
