### PR TITLE
fix(testing): make sure new tsconfig exists before adding ref

### DIFF
--- a/packages/cypress/src/migrations/update-16-2-0/update-cy-tsconfig.ts
+++ b/packages/cypress/src/migrations/update-16-2-0/update-cy-tsconfig.ts
@@ -92,7 +92,11 @@ function updateCyDirTsConfigReferences(
   tree: Tree,
   projectConfig: ProjectConfiguration
 ) {
-  if (!tree.exists(joinPathFragments(projectConfig.root, 'cypress'))) {
+  if (
+    !tree.exists(
+      joinPathFragments(projectConfig.root, 'cypress', 'tsconfig.json')
+    )
+  ) {
     return;
   }
   updateJson(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

nx/cypress v16.2.0 migration might add a project reference to a tsconfig file that doesn't exist

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

migration does not add references to files that don't exist

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17120
