### PR TITLE
feat(testing): add --randomize flag for jest

### DIFF
--- a/docs/generated/packages/jest/executors/jest.json
+++ b/docs/generated/packages/jest/executors/jest.json
@@ -107,6 +107,10 @@
         "description": "Will not fail if no tests are found (for example while using `--testPathPattern`.) (https://jestjs.io/docs/cli#--passwithnotests)",
         "type": "boolean"
       },
+      "randomize": {
+        "description": "Shuffle the order of the tests within a file. The shuffling is based on the seed. This option is only supported using the default jest-circus test runner.",
+        "type": "boolean"
+      },
       "runInBand": {
         "alias": "i",
         "description": "Run all tests serially in the current process (rather than creating a worker pool of child processes that run tests). This is sometimes useful for debugging, but such use cases are pretty rare. Useful for CI. (https://jestjs.io/docs/cli#--runinband)",

--- a/packages/jest/src/executors/jest/jest.impl.ts
+++ b/packages/jest/src/executors/jest/jest.impl.ts
@@ -94,6 +94,7 @@ export async function jestConfigParser(
     useStderr: options.useStderr,
     watch: options.watch,
     watchAll: options.watchAll,
+    randomize: options.randomize,
   };
 
   if (!multiProjects) {

--- a/packages/jest/src/executors/jest/schema.d.ts
+++ b/packages/jest/src/executors/jest/schema.d.ts
@@ -21,6 +21,7 @@ export interface JestExecutorOptions {
   changedSince?: string;
   outputFile?: string;
   passWithNoTests?: boolean;
+  randomize?: boolean;
   runInBand?: boolean;
   showConfig?: boolean;
   silent?: boolean;

--- a/packages/jest/src/executors/jest/schema.json
+++ b/packages/jest/src/executors/jest/schema.json
@@ -123,6 +123,10 @@
       "description": "Will not fail if no tests are found (for example while using `--testPathPattern`.) (https://jestjs.io/docs/cli#--passwithnotests)",
       "type": "boolean"
     },
+    "randomize": {
+      "description": "Shuffle the order of the tests within a file. The shuffling is based on the seed. This option is only supported using the default jest-circus test runner.",
+      "type": "boolean"
+    },
     "runInBand": {
       "alias": "i",
       "description": "Run all tests serially in the current process (rather than creating a worker pool of child processes that run tests). This is sometimes useful for debugging, but such use cases are pretty rare. Useful for CI. (https://jestjs.io/docs/cli#--runinband)",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->
# **Debugging CI issue do not merge**

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
the new --randomize flag is not in the jest executor options

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
--randomize option is an executor option

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17115

TODO: 
- [x] this came in v29.5.0, but we support v29.x what happens for those < v29.5.x 🤔 
   - the flag just does nothing. so should not break anything. also jest-preset-angular has a min of v29.5.0 anyways so most people are probably already there if they are on latest