### PR TITLE
feat(testing): support cypress reporterOptions as objects

### DIFF
--- a/docs/generated/packages/cypress/executors/cypress.json
+++ b/docs/generated/packages/cypress/executors/cypress.json
@@ -113,8 +113,8 @@
         "description": "The reporter used during cypress run."
       },
       "reporterOptions": {
-        "type": "string",
-        "description": "The reporter options used. Supported options depend on the reporter."
+        "oneOf": [{ "type": "string" }, { "type": "object" }],
+        "description": "The reporter options used. Supported options depend on the reporter. https://docs.cypress.io/guides/tooling/reporters#Reporter-Options"
       },
       "skipServe": {
         "type": "boolean",

--- a/packages/cypress/src/executors/cypress/cypress.impl.ts
+++ b/packages/cypress/src/executors/cypress/cypress.impl.ts
@@ -47,7 +47,7 @@ export interface CypressExecutorOptions extends Json {
   group?: string;
   ignoreTestFiles?: string;
   reporter?: string;
-  reporterOptions?: string;
+  reporterOptions?: string | Json;
   skipServe?: boolean;
   testingType?: 'component' | 'e2e';
   tag?: string;

--- a/packages/cypress/src/executors/cypress/schema.json
+++ b/packages/cypress/src/executors/cypress/schema.json
@@ -120,8 +120,15 @@
       "description": "The reporter used during cypress run."
     },
     "reporterOptions": {
-      "type": "string",
-      "description": "The reporter options used. Supported options depend on the reporter."
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object"
+        }
+      ],
+      "description": "The reporter options used. Supported options depend on the reporter. https://docs.cypress.io/guides/tooling/reporters#Reporter-Options"
     },
     "skipServe": {
       "type": "boolean",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
cypress only accepts strings as reporter options but the cypress node api is marked as 'any'

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
pass any object as reporter options to cypress

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
<details><summary>Terminal output from testing</summary>
<p>

```shell
❯ bat apps/demo-e2e/project.json
───────┬─────────────────────────────────────────────────────────────────────────────────────────────
       │ File: apps/demo-e2e/project.json
───────┼─────────────────────────────────────────────────────────────────────────────────────────────
   1   │ {
   2   │   "name": "demo-e2e",
   3   │   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   4   │   "sourceRoot": "apps/demo-e2e/src",
   5   │   "projectType": "application",
   6   │   "targets": {
   7   │     "e2e": {
   8   │       "executor": "@nx/cypress:cypress",
   9   │       "options": {
  10   │         "cypressConfig": "apps/demo-e2e/cypress.config.ts",
  11   │         "devServerTarget": "demo:serve:development",
  12 ~ │         "testingType": "e2e",
  13 ~ │         "reporter": "junit",
  14 ~ │         "reporterOptions": {
  15 ~ │           "mochaFile": "../../dist/cypress/apps/demo-e2e/test-results.[hash].xml",
  16 ~ │           "toConsole": true,
  17 ~ │           "attachments": true
  18 ~ │         }
  19   │       },
  20   │       "configurations": {
  21   │         "production": {
  22   │           "devServerTarget": "demo:serve:production"
  23   │         },
  24   │         "ci": {
  25   │           "devServerTarget": "demo:serve-static"
  26   │         }
  27   │       }
  28   │     },
  29   │     "lint": {
  30   │       "executor": "@nx/linter:eslint",
  31   │       "outputs": ["{options.outputFile}"],
  32   │       "options": {
  33   │         "lintFilePatterns": ["apps/demo-e2e/**/*.{js,ts}"]
  34   │       }
  35   │     }
  36   │   },
  37   │   "tags": [],
  38   │   "implicitDependencies": ["demo"]
  39   │ }
───────┴─────────────────────────────────────────────────────────────────────────────────────────────
❯ nx e2e demo-e2e --skip-nx-cache

> nx run demo-e2e:e2e

  ➜  Local:   http://localhost:4200/
{
  mochaFile: '../../dist/cypress/apps/demo-e2e/test-results.[hash].xml',
  toConsole: true,
  attachments: true
}
DevTools listening on ws://127.0.0.1:50011/devtools/browser/d7e5e34b-fbbf-4976-b579-1fda81128747
Couldn't determine Mocha version
====================================================================================================
  (Run Starting)
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Cypress:        12.12.0                                                                        │
  │ Browser:        Electron 106 (headless)                                                        │
  │ Node Version:   v18.12.1 (/Users/caleb/.nvm/versions/node/v18.12.1/bin/node)                   │
  │ Specs:          1 found (app.cy.ts)                                                            │
  │ Searched:       src/**/*.cy.{js,jsx,ts,tsx}                                                    │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
────────────────────────────────────────────────────────────────────────────────────────────────────

  Running:  app.cy.ts                                                                       (1 of 1)
<?xml version="1.0" encoding="UTF-8"?>
<testsuites name="Mocha Tests" time="0.247" tests="1" failures="0">
  <testsuite name="Root Suite" timestamp="2023-05-22T19:41:20" tests="0" file="src/e2e/app.cy.ts" time="0.000" failures="0">
  </testsuite>
  <testsuite name="demo" timestamp="2023-05-22T19:41:20" tests="1" time="0.231" failures="0">
    <testcase name="demo should display welcome message" time="0.232" classname="should display welcome message">
    </testcase>
  </testsuite>
</testsuites>
  (Results)
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        1                                                                                │
  │ Passing:      1                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        true                                                                             │
  │ Duration:     0 seconds                                                                        │
  │ Spec Ran:     app.cy.ts                                                                        │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
  (Video)
  -  Started processing:  Compressing to 32 CRF
  -  Finished processing: 0 seconds
  -  Video output: /Users/caleb/Work/sandbox/cy-report-options/dist/cypress/apps/demo-e2e/videos/app.cy.ts.mp4
====================================================================================================
  (Run Finished)
       Spec                                              Tests  Passing  Failing  Pending  Skipped
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  app.cy.ts                                245ms        1        1        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        245ms        1        1        -        -        -

 ———————————————————————————————————————————————————————————————————————————————————————————————————

 >  NX   Successfully ran target e2e for project demo-e2e (4s)

❯ tree dist
dist
└── cypress
    └── apps
        └── demo-e2e
            ├── test-results.05b57a3a69ddd45da0cac5fc2fa9f6e7.xml
            └── videos
                └── app.cy.ts.mp4

4 directories, 2 files
```

</p>
</details> 

Fixes #17024
