### PR TITLE
feat(angular): add skipAllRemotes option to module-federation-dev-server

### DIFF
--- a/docs/generated/packages/angular/executors/module-federation-dev-server.json
+++ b/docs/generated/packages/angular/executors/module-federation-dev-server.json
@@ -109,6 +109,11 @@
         "items": { "type": "string" },
         "description": "List of remote applications to not automatically serve, either statically or in development mode. This can be useful for multi-repository module federation setups where the host application uses a remote application from an external repository."
       },
+      "skipAllRemotes": {
+        "type": "boolean",
+        "description": "Skip automatically serving all remote applications. This can be useful for multi-repository module federation setups where the host application does not need any of the remote applications for active development.",
+        "default": false
+      },
       "pathToManifestFile": {
         "type": "string",
         "description": "Path to a Module Federation manifest file (e.g. `my/path/to/module-federation.manifest.json`) containing the dynamic remote applications relative to the workspace root."

--- a/docs/generated/packages/angular/executors/module-federation-dev-ssr.json
+++ b/docs/generated/packages/angular/executors/module-federation-dev-ssr.json
@@ -74,6 +74,11 @@
         "items": { "type": "string" },
         "description": "List of remote applications to not automatically serve, either statically or in development mode. This can be useful for multi-repository module federation setups where the host application uses a remote application from an external repository."
       },
+      "skipAllRemotes": {
+        "type": "boolean",
+        "description": "Skip automatically serving all remote applications. This can be useful for multi-repository module federation setups where the host application does not need any of the remote applications for active development.",
+        "default": false
+      },
       "verbose": {
         "type": "boolean",
         "description": "Adds more details to output logging.",

--- a/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -52,14 +52,16 @@ export function executeModuleFederationDevServerBuilder(
     project,
     context,
     workspaceProjects,
-    remotesToSkip
+    remotesToSkip,
+    options.skipAllRemotes,
   );
   const dynamicRemotes = getDynamicRemotes(
     project,
     context,
     workspaceProjects,
     remotesToSkip,
-    pathToManifestFile
+    options.skipAllRemotes,
+    pathToManifestFile,
   );
   const remotes = [...staticRemotes, ...dynamicRemotes];
 

--- a/packages/angular/src/builders/module-federation-dev-server/schema.d.ts
+++ b/packages/angular/src/builders/module-federation-dev-server/schema.d.ts
@@ -19,5 +19,6 @@ export interface Schema {
   poll?: number;
   devRemotes?: string[];
   skipRemotes?: string[];
+  skipAllRemotes?: boolean;
   pathToManifestFile?: string;
 }

--- a/packages/angular/src/builders/module-federation-dev-server/schema.json
+++ b/packages/angular/src/builders/module-federation-dev-server/schema.json
@@ -119,6 +119,11 @@
       },
       "description": "List of remote applications to not automatically serve, either statically or in development mode. This can be useful for multi-repository module federation setups where the host application uses a remote application from an external repository."
     },
+    "skipAllRemotes": {
+      "type": "boolean",
+      "description": "Skip automatically serving all remote applications. This can be useful for multi-repository module federation setups where the host application does not need any of the remote applications for active development.",,
+      "default": false
+    },
     "pathToManifestFile": {
       "type": "string",
       "description": "Path to a Module Federation manifest file (e.g. `my/path/to/module-federation.manifest.json`) containing the dynamic remote applications relative to the workspace root."

--- a/packages/angular/src/builders/module-federation-dev-ssr/module-federation-dev-ssr.impl.ts
+++ b/packages/angular/src/builders/module-federation-dev-ssr/module-federation-dev-ssr.impl.ts
@@ -54,14 +54,16 @@ export function executeModuleFederationDevSSRBuilder(
     project,
     context,
     workspaceProjects,
-    remotesToSkip
+    remotesToSkip,
+    options.skipAllRemotes,
   );
   const dynamicRemotes = getDynamicRemotes(
     project,
     context,
     workspaceProjects,
     remotesToSkip,
-    pathToManifestFile
+    options.skipAllRemotes,
+    pathToManifestFile,
   );
   const remotes = [...staticRemotes, ...dynamicRemotes];
 

--- a/packages/angular/src/builders/module-federation-dev-ssr/schema.d.ts
+++ b/packages/angular/src/builders/module-federation-dev-ssr/schema.d.ts
@@ -12,6 +12,7 @@ export interface Schema {
   proxyConfig?: string;
   devRemotes?: string[];
   skipRemotes?: string[];
+  skipAllRemotes?: boolean;
   verbose: boolean;
   pathToManifestFile?: string;
 }

--- a/packages/angular/src/builders/module-federation-dev-ssr/schema.json
+++ b/packages/angular/src/builders/module-federation-dev-ssr/schema.json
@@ -75,6 +75,11 @@
       },
       "description": "List of remote applications to not automatically serve, either statically or in development mode. This can be useful for multi-repository module federation setups where the host application uses a remote application from an external repository."
     },
+    "skipAllRemotes": {
+      "type": "boolean",
+      "description": "Skip automatically serving all remote applications. This can be useful for multi-repository module federation setups where the host application does not need any of the remote applications for active development.",
+      "default": false
+    },
     "verbose": {
       "type": "boolean",
       "description": "Adds more details to output logging.",

--- a/packages/angular/src/builders/utilities/module-federation.ts
+++ b/packages/angular/src/builders/utilities/module-federation.ts
@@ -8,6 +8,7 @@ export function getDynamicRemotes(
   context: import('@angular-devkit/architect').BuilderContext,
   workspaceProjects: Record<string, ProjectConfiguration>,
   remotesToSkip: Set<string>,
+  skipAllRemotes: boolean,
   pathToManifestFile = join(
     context.workspaceRoot,
     project.sourceRoot,
@@ -47,7 +48,7 @@ export function getDynamicRemotes(
 
   const dynamicRemotes = Object.entries(parsedManifest)
     .map(([remoteName]) => remoteName)
-    .filter((r) => !remotesToSkip.has(r));
+    .filter((r) => !skipAllRemotes && !remotesToSkip.has(r));
   const invalidDynamicRemotes = dynamicRemotes.filter(
     (remote) => !workspaceProjects[remote]
   );
@@ -68,7 +69,8 @@ export function getStaticRemotes(
   project: ProjectConfiguration,
   context: import('@angular-devkit/architect').BuilderContext,
   workspaceProjects: Record<string, ProjectConfiguration>,
-  remotesToSkip: Set<string>
+  remotesToSkip: Set<string>,
+  skipAllRemotes: boolean,
 ): string[] {
   const mfConfigPath = join(
     context.workspaceRoot,
@@ -93,7 +95,7 @@ export function getStaticRemotes(
     .map((remoteDefinition) =>
       Array.isArray(remoteDefinition) ? remoteDefinition[0] : remoteDefinition
     )
-    .filter((r) => !remotesToSkip.has(r));
+    .filter((r) => !skipAllRemotes && !remotesToSkip.has(r));
 
   const invalidStaticRemotes = staticRemotes.filter(
     (remote) => !workspaceProjects[remote]


### PR DESCRIPTION
## Current Behavior
Currently, if a remotes lives outside the Nx repo of the host, you need to list each of them individually using the `--skipRemotes` option to take advantage of `module-federation-dev-server`.

## Expected Behavior
Allow option to skip all remotes in a setup where there are many remotes and any number of them do not live in the monorepo.

## Related Issue(s)
Fixes #17145

Extension of work done in #13086

React version of this PR: #17152