### PR TITLE
feat(react): add skipAllRemotes option to module-federation-dev-server

### DIFF
--- a/docs/generated/packages/react/executors/module-federation-dev-server.json
+++ b/docs/generated/packages/react/executors/module-federation-dev-server.json
@@ -21,6 +21,12 @@
         "description": "List of remote applications to not automatically serve, either statically or in development mode. This can be useful for multi-repository module federation setups where the host application uses a remote application from an external repository.",
         "x-priority": "important"
       },
+      "skipAllRemotes": {
+        "type": "boolean",
+        "description": "Skip automatically serving all remote applications. This can be useful for multi-repository module federation setups where the host application does not need any of the remote applications for active development.",
+        "x-priority": "important",
+        "default": false
+      },
       "buildTarget": {
         "type": "string",
         "description": "Target which builds the application.",

--- a/docs/generated/packages/react/executors/module-federation-ssr-dev-server.json
+++ b/docs/generated/packages/react/executors/module-federation-ssr-dev-server.json
@@ -37,6 +37,12 @@
         "description": "List of remote applications to not automatically serve, either statically or in development mode. This can be useful for multi-repository module federation setups where the host application uses a remote application from an external repository.",
         "x-priority": "important"
       },
+      "skipAllRemotes": {
+        "type": "boolean",
+        "description": "Skip automatically serving all remote applications. This can be useful for multi-repository module federation setups where the host application does not need any of the remote applications for active development.",
+        "x-priority": "important",
+        "default": false
+      },
       "host": {
         "type": "string",
         "description": "Host to listen on.",

--- a/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -11,6 +11,7 @@ import {
 type ModuleFederationDevServerOptions = WebDevServerOptions & {
   devRemotes?: string | string[];
   skipRemotes?: string[];
+  skipAllRemotes?: boolean;
 };
 
 export default async function* moduleFederationDevServer(
@@ -39,7 +40,7 @@ export default async function* moduleFederationDevServer(
   const remotesToSkip = new Set(options.skipRemotes ?? []);
   const knownRemotes = (moduleFederationConfig.remotes ?? []).filter((r) => {
     const validRemote = Array.isArray(r) ? r[0] : r;
-    return !remotesToSkip.has(validRemote);
+    return !options.skipAllRemotes && !remotesToSkip.has(validRemote);
   });
 
   const devServeApps = !options.devRemotes

--- a/packages/react/src/executors/module-federation-dev-server/schema.json
+++ b/packages/react/src/executors/module-federation-dev-server/schema.json
@@ -22,6 +22,12 @@
       "description": "List of remote applications to not automatically serve, either statically or in development mode. This can be useful for multi-repository module federation setups where the host application uses a remote application from an external repository.",
       "x-priority": "important"
     },
+    "skipAllRemotes": {
+      "type": "boolean",
+      "description": "Skip automatically serving all remote applications. This can be useful for multi-repository module federation setups where the host application does not need any of the remote applications for active development.",
+      "x-priority": "important",
+      "default": false
+    },
     "buildTarget": {
       "type": "string",
       "description": "Target which builds the application.",

--- a/packages/react/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
@@ -19,6 +19,7 @@ import { execSync, fork } from 'child_process';
 type ModuleFederationDevServerOptions = WebSsrDevServerOptions & {
   devRemotes?: string | string[];
   skipRemotes?: string[];
+  skipAllRemotes?: boolean;
   host: string;
 };
 
@@ -47,7 +48,7 @@ export default async function* moduleFederationSsrDevServer(
 
   const remotesToSkip = new Set(options.skipRemotes ?? []);
   const knownRemotes = (moduleFederationConfig.remotes ?? []).filter(
-    (r) => !remotesToSkip.has(r)
+    (r) => !options.skipAllRemotes && !remotesToSkip.has(r)
   );
 
   const devServeApps = !options.devRemotes

--- a/packages/react/src/executors/module-federation-ssr-dev-server/schema.json
+++ b/packages/react/src/executors/module-federation-ssr-dev-server/schema.json
@@ -38,6 +38,12 @@
       "description": "List of remote applications to not automatically serve, either statically or in development mode. This can be useful for multi-repository module federation setups where the host application uses a remote application from an external repository.",
       "x-priority": "important"
     },
+    "skipAllRemotes": {
+      "type": "boolean",
+      "description": "Skip automatically serving all remote applications. This can be useful for multi-repository module federation setups where the host application does not need any of the remote applications for active development.",
+      "x-priority": "important",
+      "default": false
+    },
     "host": {
       "type": "string",
       "description": "Host to listen on.",


### PR DESCRIPTION
## Current Behavior
Currently, if a remotes lives outside the Nx repo of the host, you need to list each of them individually using the `--skipRemotes` option to take advantage of `module-federation-dev-server`.

## Expected Behavior
Allow option to skip all remotes in a setup where there are many remotes and any number of them do not live in the monorepo.

## Related Issue(s)
Fixes #17145

Extension of work done in #13090.

Angular version of this PR: #17150