### PR TITLE
chore(repo): add set-shas step for macos

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,6 +205,8 @@ jobs:
       - setup:
           os: macos
       - rust/install
+      - nx/set-shas:
+          main-branch-name: 'master'
       - run:
           name: Run E2E Tests for macOS
           command: |


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

macos steps show blank args for head/base
![image](https://github.com/nrwl/nx/assets/23272162/3d6d394c-ac8d-402e-8697-9f8d32cb2cc4)


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
head/base are set for macos jobs
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
