### PR TITLE
fix(js): should check for all possible prettierrc formats before creating a default one

### DIFF
--- a/packages/js/src/generators/init/init.spec.ts
+++ b/packages/js/src/generators/init/init.spec.ts
@@ -40,6 +40,20 @@ describe('js init generator', () => {
     expect(prettierignore).toContain('# custom ignore file');
   });
 
+  it('should not overwrite prettier configuration specified in other formats', async () => {
+    tree.delete('.prettierrc');
+    tree.delete('.prettierignore');
+    tree.write('.prettierrc.js', `module.exports = { singleQuote: true };`);
+
+    await init(tree, {});
+
+    expect(tree.exists('.prettierrc')).toBeFalsy();
+    expect(tree.exists('.prettierignore')).toBeTruthy();
+    expect(tree.read('.prettierrc.js', 'utf-8')).toContain(
+      `module.exports = { singleQuote: true };`
+    );
+  });
+
   it('should add prettier vscode extension if .vscode/extensions.json file exists', async () => {
     // No existing recommendations
     writeJson(tree, '.vscode/extensions.json', {});

--- a/packages/js/src/generators/init/init.ts
+++ b/packages/js/src/generators/init/init.ts
@@ -41,7 +41,21 @@ export async function initGenerator(
     devDependencies['typescript'] = typescriptVersion;
   }
 
-  if (!tree.exists(`.prettierrc`)) {
+  // https://prettier.io/docs/en/configuration.html
+  const prettierrcNameOptions = [
+    '.prettierrc',
+    '.prettierrc.json',
+    '.prettierrc.yml',
+    '.prettierrc.yaml',
+    '.prettierrc.json5',
+    '.prettierrc.js',
+    '.prettierrc.cjs',
+    'prettier.config.js',
+    'prettier.config.cjs',
+    '.prettierrc.toml',
+  ];
+
+  if (prettierrcNameOptions.every((name) => !tree.exists(name))) {
     writeJson(tree, '.prettierrc', {
       singleQuote: true,
     });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Prettier can have its config defined in multiple formats https://prettier.io/docs/en/configuration.html. Right now if there's no config defined in default format `.prettierrc`, Nx will create one. This breaks the formatter in the workspace, because "default" one takes priority over other names. 
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Should check for other names of prettier config before creating a default one. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
