### PR TITLE
fix(nextjs): fork Next.js CLI instead of spawn so it reliably exits

### DIFF
--- a/packages/next/src/executors/build/build.impl.ts
+++ b/packages/next/src/executors/build/build.impl.ts
@@ -50,7 +50,7 @@ export default async function buildExecutor(
   const { experimentalAppOnly, profile, debug } = options;
 
   const args = createCliOptions({ experimentalAppOnly, profile, debug });
-  const command = `npx next build ${args}`;
+  const command = `npx next build ${args.join(' ')}`;
   const execSyncOptions: ExecSyncOptions = {
     stdio: 'inherit',
     encoding: 'utf-8',

--- a/packages/next/src/utils/create-cli-options.ts
+++ b/packages/next/src/utils/create-cli-options.ts
@@ -1,12 +1,11 @@
-export function createCliOptions(obj: { [key: string]: any }): string {
-  return Object.entries(obj)
-    .reduce((arr, [key, value]) => {
-      if (value !== undefined) {
-        const kebabCase = key.replace(/[A-Z]/g, (m) => '-' + m.toLowerCase());
-        return `${arr}--${kebabCase}=${value} `;
-      } else {
-        return arr;
-      }
-    }, '')
-    .trim();
+export function createCliOptions(
+  obj: Record<string, string | number | boolean>
+): string[] {
+  return Object.entries(obj).reduce((arr, [key, value]) => {
+    if (value !== undefined) {
+      const kebabCase = key.replace(/[A-Z]/g, (m) => '-' + m.toLowerCase());
+      arr.push(`--${kebabCase}=${value}`);
+    }
+    return arr;
+  }, []);
 }


### PR DESCRIPTION
Using `spawn` is causing the server to sometimes hang around after the Nx CLI has exited. Calling `fork` instead to the server process is killed when Nx CLI exits.

## Current Behavior
Sometimes the server remains running in Linux when Nx CLI exits.

## Expected Behavior
Next.js server should always exit when Nx CLI exits.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
