### PR TITLE
feat(misc): allow patterns matching for dev remotes and skip remotes

### DIFF
--- a/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -10,6 +10,7 @@ import {
 } from '../utilities/module-federation';
 import { existsSync } from 'fs';
 import { extname, join } from 'path';
+import { findMatchingProjects } from 'nx/src/utils/find-matching-projects';
 
 export function executeModuleFederationDevServerBuilder(
   schema: Schema,
@@ -47,7 +48,9 @@ export function executeModuleFederationDevServerBuilder(
 
   validateDevRemotes(options, workspaceProjects);
 
-  const remotesToSkip = new Set(options.skipRemotes ?? []);
+  const remotesToSkip = new Set(
+    findMatchingProjects(options.skipRemotes, projectGraph.nodes) ?? []
+  );
   const staticRemotes = getStaticRemotes(
     project,
     context,
@@ -66,8 +69,8 @@ export function executeModuleFederationDevServerBuilder(
   const devServeRemotes = !options.devRemotes
     ? []
     : Array.isArray(options.devRemotes)
-    ? options.devRemotes
-    : [options.devRemotes];
+    ? findMatchingProjects(options.devRemotes, projectGraph.nodes)
+    : findMatchingProjects([options.devRemotes], projectGraph.nodes);
 
   for (const remote of remotes) {
     const isDev = devServeRemotes.includes(remote);

--- a/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -9,6 +9,7 @@ import {
 import * as chalk from 'chalk';
 import { waitForPortOpen } from '@nx/web/src/utils/wait-for-port-open';
 import { spawn } from 'child_process';
+import { findMatchingProjects } from 'nx/src/utils/find-matching-projects';
 
 type ModuleFederationDevServerOptions = WebDevServerOptions & {
   devRemotes?: string | string[];
@@ -37,7 +38,9 @@ export default async function* moduleFederationDevServer(
     );
   }
 
-  const remotesToSkip = new Set(options.skipRemotes ?? []);
+  const remotesToSkip = new Set(
+    findMatchingProjects(options.skipRemotes ?? [], context.projectGraph.nodes)
+  );
   const knownRemotes = (moduleFederationConfig.remotes ?? []).filter((r) => {
     const validRemote = Array.isArray(r) ? r[0] : r;
     return !remotesToSkip.has(validRemote);
@@ -49,8 +52,8 @@ export default async function* moduleFederationDevServer(
   const devServeApps = !options.devRemotes
     ? []
     : Array.isArray(options.devRemotes)
-    ? options.devRemotes
-    : [options.devRemotes];
+    ? findMatchingProjects(options.devRemotes, context.projectGraph.nodes)
+    : findMatchingProjects([options.devRemotes], context.projectGraph.nodes);
 
   logger.info(
     `NX Starting module federation dev-server for ${chalk.bold(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`--dev-remotes` and `--skip-remotes` require explicit project names

## Expected Behavior
`--dev-remotes` and `--skip-remotes` allow using patterns that work for `--projects`, `--exclude` and other similar functionality.

This allows things like:
`nx serve host --skip-remotes='*'` to skip all remotes

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17145
