### PR TITLE
fix(vite): call registerTsProject for vite executors

### DIFF
--- a/packages/vite/migrations.json
+++ b/packages/vite/migrations.json
@@ -26,6 +26,19 @@
     }
   },
   "packageJsonUpdates": {
+    "16.3.0-beta.8": {
+      "version": "16.3.0-beta.8",
+      "packages": {
+        "@swc-node/register": {
+          "version": "^1.6.5",
+          "alwaysAddToPackageJson": true
+        },
+        "@swc/core": {
+          "version": "^1.3.59",
+          "alwaysAddToPackageJson": true
+        }
+      }
+    },
     "16.1.0-beta.0": {
       "version": "16.1.0-beta.0",
       "packages": {

--- a/packages/vite/src/executors/build/build.impl.ts
+++ b/packages/vite/src/executors/build/build.impl.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import { ExecutorContext, writeJsonFile } from '@nx/devkit';
+import { ExecutorContext, workspaceRoot, writeJsonFile } from '@nx/devkit';
 import { build, InlineConfig, mergeConfig } from 'vite';
 import {
   getViteBuildOptions,
@@ -16,7 +16,7 @@ import { existsSync, writeFileSync } from 'fs';
 import { resolve } from 'path';
 import { createAsyncIterable } from '@nx/devkit/src/utils/async-iterable';
 
-import { registerTsConfigPaths } from '@nx/js/src/internal';
+import { registerTsConfigPaths, registerTsProject } from '@nx/js/src/internal';
 
 export async function* viteBuildExecutor(
   options: ViteBuildExecutorOptions,
@@ -26,6 +26,11 @@ export async function* viteBuildExecutor(
     context.projectsConfigurations.projects[context.projectName].root;
 
   registerTsConfigPaths(resolve(projectRoot, 'tsconfig.json'));
+
+  if (!(global as any).tsProjectRegistered) {
+    registerTsProject(workspaceRoot, 'tsconfig.base.json');
+    (global as any).tsProjectRegistered = true;
+  }
 
   const normalizedOptions = normalizeOptions(options);
 

--- a/packages/vite/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/vite/src/executors/dev-server/dev-server.impl.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import { ExecutorContext } from '@nx/devkit';
+import { ExecutorContext, workspaceRoot } from '@nx/devkit';
 import { createServer, InlineConfig, mergeConfig, ViteDevServer } from 'vite';
 
 import {
@@ -11,7 +11,7 @@ import {
 
 import { ViteDevServerExecutorOptions } from './schema';
 import { ViteBuildExecutorOptions } from '../build/schema';
-import { registerTsConfigPaths } from '@nx/js/src/internal';
+import { registerTsConfigPaths, registerTsProject } from '@nx/js/src/internal';
 import { resolve } from 'path';
 
 export async function* viteDevServerExecutor(
@@ -22,7 +22,10 @@ export async function* viteDevServerExecutor(
     context.projectsConfigurations.projects[context.projectName].root;
 
   registerTsConfigPaths(resolve(projectRoot, 'tsconfig.json'));
-
+  if (!(global as any).tsProjectRegistered) {
+    registerTsProject(workspaceRoot, 'tsconfig.base.json');
+    (global as any).tsProjectRegistered = true;
+  }
   // Retrieve the option for the configured buildTarget.
   const buildTargetOptions: ViteBuildExecutorOptions = getNxTargetOptions(
     options.buildTarget,

--- a/packages/vite/src/executors/test/vitest.impl.ts
+++ b/packages/vite/src/executors/test/vitest.impl.ts
@@ -10,7 +10,7 @@ import { loadConfigFromFile } from 'vite';
 import { VitestExecutorOptions } from './schema';
 import { relative, resolve } from 'path';
 import { existsSync } from 'fs';
-import { registerTsConfigPaths } from '@nx/js/src/internal';
+import { registerTsConfigPaths, registerTsProject } from '@nx/js/src/internal';
 
 class NxReporter implements Reporter {
   deferred: {
@@ -54,6 +54,10 @@ export async function* vitestExecutor(
   const projectRoot =
     context.projectsConfigurations.projects[context.projectName].root;
   registerTsConfigPaths(resolve(projectRoot, 'tsconfig.json'));
+  if (!(global as any).tsProjectRegistered) {
+    registerTsProject(workspaceRoot, 'tsconfig.base.json');
+    (global as any).tsProjectRegistered = true;
+  }
 
   const { startVitest } = await (Function(
     'return import("vitest/node")'

--- a/packages/vite/src/generators/init/init.ts
+++ b/packages/vite/src/generators/init/init.ts
@@ -23,6 +23,7 @@ import {
   viteVersion,
 } from '../../utils/versions';
 import { InitGeneratorSchema } from './schema';
+import { addSwcRegisterDependencies } from '@nx/js/src/utils/swc/add-swc-dependencies';
 
 function checkDependenciesInstalled(host: Tree, schema: InitGeneratorSchema) {
   const packageJson = readJson(host, 'package.json');
@@ -39,6 +40,9 @@ function checkDependenciesInstalled(host: Tree, schema: InitGeneratorSchema) {
   devDependencies['vitest'] = vitestVersion;
   devDependencies['@vitest/ui'] = vitestUiVersion;
   devDependencies['jsdom'] = jsdomVersion;
+
+  // for registerTsProject
+  addSwcRegisterDependencies(host);
 
   if (schema.uiFramework === 'react') {
     devDependencies['@vitejs/plugin-react'] = vitePluginReactVersion;


### PR DESCRIPTION
## Current Behavior

Can't import TypeScript paths in vite.config files. Getting error:
```
 >  NX   Unexpected token 'export'
```

## Expected Behavior

Vite should build workspace libraries before importing.

## Related Issue(s)

https://github.com/nrwl/nx/issues/17019

