### PR TITLE
fix(angular): export a default module for require calls

### DIFF
--- a/e2e/nx-misc/src/misc.test.ts
+++ b/e2e/nx-misc/src/misc.test.ts
@@ -90,8 +90,8 @@ describe('Nx Commands', () => {
 
       // temporarily make it look like this isn't installed
       renameSync(
-        tmpProjPath('node_modules/@nx/angular'),
-        tmpProjPath('node_modules/@nx/angular_tmp')
+        tmpProjPath('node_modules/@nx/next'),
+        tmpProjPath('node_modules/@nx/next_tmp')
       );
 
       listOutput = runCLI('list');
@@ -109,12 +109,20 @@ describe('Nx Commands', () => {
       // check for builders
       expect(listOutput).toContain('run-commands');
 
-      // // look for uninstalled core plugin
       listOutput = runCLI('list @nx/angular');
 
-      expect(listOutput).toContain(
-        'NX   @nx/angular is not currently installed'
-      );
+      expect(listOutput).toContain('Capabilities in @nx/angular');
+
+      expect(listOutput).toContain('library');
+      expect(listOutput).toContain('component');
+
+      // check for builders
+      expect(listOutput).toContain('package');
+
+      // // look for uninstalled core plugin
+      listOutput = runCLI('list @nx/next');
+
+      expect(listOutput).toContain('NX   @nx/next is not currently installed');
 
       // look for an unknown plugin
       listOutput = runCLI('list @wibble/fish');
@@ -125,8 +133,8 @@ describe('Nx Commands', () => {
 
       // put back the @nx/angular module (or all the other e2e tests after this will fail)
       renameSync(
-        tmpProjPath('node_modules/@nx/angular_tmp'),
-        tmpProjPath('node_modules/@nx/angular')
+        tmpProjPath('node_modules/@nx/next_tmp'),
+        tmpProjPath('node_modules/@nx/next')
       );
     }, 120000);
   });

--- a/packages/angular/index.cts
+++ b/packages/angular/index.cts
@@ -1,0 +1,3 @@
+module.exports = {
+  name: '@nx/angular',
+};

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -30,7 +30,10 @@
     "./src/builders/*.impl": "./src/builders/*.impl.js",
     "./src/executors/*/schema.json": "./src/executors/*/schema.json",
     "./src/executors/*.impl": "./src/executors/*.impl.js",
-    "./src/executors/*/compat": "./src/executors/*/compat.js"
+    "./src/executors/*/compat": "./src/executors/*/compat.js",
+    ".": {
+      "require": "./index.cjs"
+    }
   },
   "author": "Victor Savkin",
   "license": "MIT",

--- a/packages/angular/tsconfig.lib.json
+++ b/packages/angular/tsconfig.lib.json
@@ -14,5 +14,5 @@
     "jest.config.ts",
     "test-setup.ts"
   ],
-  "include": ["**/*.ts"]
+  "include": ["**/*.ts", "./index.cts"]
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Running `nx list @nx/angular` or `ensurePackage(@nx/angular)` both result in failures due to trying to require ESM

## Expected Behavior
@nx/angular exports a small entry point for cjs until Nx fully supports ESM plugins.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16696
Fixes #15583
Fixes #