### PR TITLE
fix(web): use 127.0.0.1 loopback address when checking if a port is open

### DIFF
--- a/packages/web/src/utils/wait-for-port-open.ts
+++ b/packages/web/src/utils/wait-for-port-open.ts
@@ -30,7 +30,9 @@ export function waitForPortOpen(
         }
       });
 
-      client.connect({ port, host: options.host ?? 'localhost' });
+      // Node will use IPv6 if it is available, but this can cause issues if the server is only listening on IPv4.
+      // Hard-coding to look on 127.0.0.1 to avoid using the IPv6 loopback address "::1".
+      client.connect({ port, host: options.host ?? '127.0.0.1' });
     };
 
     checkPort();


### PR DESCRIPTION
Node < 20 always prefers IPv6 addresses, so the `localhost` loopback will resolve to `::1`, which no local dev-server listens on. Changing it to `127.0.0.1` is safer.

See: https://github.com/nodejs/node/issues/40537

## Current Behavior
`waitForPortOpen` doesn't work on some OSes (like Mac).

## Expected Behavior
`waitForPortOpen` should work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
