### PR TITLE
fix(react): use fork for module-federation-dev-server so processes are cleaned up correctly

### DIFF
--- a/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -8,8 +8,8 @@ import {
 } from '@nx/devkit/src/utils/async-iterable';
 import * as chalk from 'chalk';
 import { waitForPortOpen } from '@nx/web/src/utils/wait-for-port-open';
-import { spawn } from 'child_process';
 import { findMatchingProjects } from 'nx/src/utils/find-matching-projects';
+import { fork } from 'child_process';
 
 type ModuleFederationDevServerOptions = WebDevServerOptions & {
   devRemotes?: string | string[];
@@ -83,15 +83,17 @@ export default async function* moduleFederationDevServer(
       );
     } else {
       let outWithErr: null | string[] = [];
-      const staticProcess = spawn(
-        `node ${nxBin} run ${appName}:serve-static${
-          context.configurationName ? `:${context.configurationName}` : ''
-        }`,
+      const staticProcess = fork(
+        nxBin,
+        [
+          'run',
+          `${appName}:serve-static${
+            context.configurationName ? `:${context.configurationName}` : ''
+          }`,
+        ],
         {
           cwd: context.root,
-          stdio: ['ignore', 'pipe', 'pipe'],
-          shell: true,
-          windowsHide: true,
+          stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
         }
       );
       staticProcess.stdout.on('data', (data) => {


### PR DESCRIPTION
Similar to https://github.com/nrwl/nx/pull/17179 but for the `@nx/react:module-federation-dev-server`).


## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
