### PR TITLE
fix(nextjs): Generate an unstyled component when --style=none

### DIFF
--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -30,6 +30,20 @@ describe('app', () => {
       );
     });
 
+    it('should generate an unstyled component page', async () => {
+      await applicationGenerator(tree, {
+        name: 'testApp',
+        style: 'none',
+        appDir: false,
+      });
+
+      const content = tree.read('apps/test-app/pages/index.tsx').toString();
+
+      expect(content).not.toContain('import styles from');
+      expect(content).not.toContain('const StyledPage');
+      expect(content).not.toContain('className={styles.page}');
+    });
+
     it('should update tags and implicit dependencies', async () => {
       await applicationGenerator(tree, {
         name: 'myApp',
@@ -490,6 +504,21 @@ describe('app', () => {
         'dist/test-app/.next/types/**/*.ts',
         'next-env.d.ts',
       ]);
+    });
+
+    it('should generate an unstyled component page', async () => {
+      await applicationGenerator(tree, {
+        name: 'testApp',
+        style: 'none',
+        appDir: true,
+        rootProject: true,
+      });
+
+      const content = tree.read('app/page.tsx').toString();
+
+      expect(content).not.toContain('import styles from');
+      expect(content).not.toContain('const StyledPage');
+      expect(content).not.toContain('className={styles.page}');
     });
   });
 });

--- a/packages/next/src/generators/application/files/app/page.tsx__tmpl__
+++ b/packages/next/src/generators/application/files/app/page.tsx__tmpl__
@@ -1,19 +1,20 @@
-<% if (styledModule && (styledModule === 'styled-jsx' || styledModule === 'styled-components'))  {%>
-'use client';
-<% }%> 
-<% if (styledModule && styledModule !== 'styled-jsx') {
-  var wrapper = 'StyledPage';
-%>import styled from '<%= styledModule %>';<% } else {
-  var wrapper = 'div';
-%>
-  <%- style !== 'styled-jsx' ? `import styles from './page.module.${style}';` : '' %>
-<% }
-%>
+<% if (style !== 'none') { %>
+  <% if (styledModule && (styledModule === 'styled-jsx' || styledModule === 'styled-components'))  {%>
+  'use client';
+  <% }%> 
+  <% if (styledModule && styledModule !== 'styled-jsx') {
+    var wrapper = 'StyledPage';
+  %>import styled from '<%= styledModule %>';<% } else {
+    var wrapper = 'div';
+  %>
+    <%- style !== 'styled-jsx' ? `import styles from './page.module.${style}';` : '' %>
+  <% }
+  %>
 
-<% if (styledModule && styledModule !== 'styled-jsx') { %>
-const StyledPage = styled.div`<%- pageStyleContent %>`;
-<% }%>
-
+  <% if (styledModule && styledModule !== 'styled-jsx') { %>
+  const StyledPage = styled.div`<%- pageStyleContent %>`;
+  <% }%>
+<% } %>
 export default async function Index() {
   /*
    * Replace the elements below with your own.
@@ -22,7 +23,7 @@ export default async function Index() {
    */
   return (
     <<%= wrapper %><% if (!styledModule) {%> className={styles.page}<% } %>>
-      <%- styledModule === 'styled-jsx' ? `<style jsx>{\`${pageStyleContent}\`}</style>` : `` %>
+      <%- styledModule === 'styled-jsx' && style !== 'none' ? `<style jsx>{\`${pageStyleContent}\`}</style>` : `` %>
       <%- appContent %>
     </<%= wrapper %>>
   );

--- a/packages/next/src/generators/application/files/pages/__fileName__.tsx__tmpl__
+++ b/packages/next/src/generators/application/files/pages/__fileName__.tsx__tmpl__
@@ -1,15 +1,17 @@
-<% if (styledModule && styledModule !== 'styled-jsx') {
-  var wrapper = 'StyledPage';
-%>import styled from '<%= styledModule %>';<% } else {
-  var wrapper = 'div';
-%>
-  <%- style !== 'styled-jsx' ? `import styles from './${fileName}.module.${style}';` : '' %>
-<% }
-%>
+<% if (style !== 'none') { %>
+  <% if (styledModule && styledModule !== 'styled-jsx') {
+    var wrapper = 'StyledPage';
+  %>import styled from '<%= styledModule %>';<% } else {
+    var wrapper = 'div';
+  %>
+    <%- style !== 'styled-jsx' ? `import styles from './${fileName}.module.${style}';` : '' %>
+  <% }
+  %>
 
-<% if (styledModule && styledModule !== 'styled-jsx') { %>
-const StyledPage = styled.div`<%- pageStyleContent %>`;
-<% }%>
+  <% if (styledModule && styledModule !== 'styled-jsx') { %>
+  const StyledPage = styled.div`<%- pageStyleContent %>`;
+  <% }%>
+<% } %>
 
 export function Index() {
   /*
@@ -19,7 +21,7 @@ export function Index() {
    */
   return (
     <<%= wrapper %><% if (!styledModule) {%> className={styles.page}<% } %>>
-      <%- styledModule === 'styled-jsx' ? `<style jsx>{\`${pageStyleContent}\`}</style>` : `` %>
+      <%- styledModule === 'styled-jsx' && style !== 'none' ? `<style jsx>{\`${pageStyleContent}\`}</style>` : `` %>
       <%- appContent %>
     </<%= wrapper %>>
   );


### PR DESCRIPTION
When you run `nx g @nx/next:app acme --style=none`

Before you would have:
```ts
import styled from 'none';

const StyledPage = styled.div`
  .page {
  }
`;
```

Now those will not be generated