### PR TITLE
feat(core): limit on-screen choices for list-type generator prompts

### DIFF
--- a/packages/nx/src/utils/params.spec.ts
+++ b/packages/nx/src/utils/params.spec.ts
@@ -1654,6 +1654,7 @@ describe('params', () => {
           name: 'pets',
           message: 'What kind of pets do you have?',
           choices: ['Cat', 'Dog', 'Fish'],
+          limit: expect.any(Number),
           validate: expect.any(Function),
         },
       ]);
@@ -1694,6 +1695,7 @@ describe('params', () => {
             { message: 'Dog', name: 'dog' },
             { message: 'Fish', name: 'fish' },
           ],
+          limit: expect.any(Number),
           validate: expect.any(Function),
         },
       ]);
@@ -1735,6 +1737,7 @@ describe('params', () => {
             { message: 'Dog', name: 'dog' },
             { message: 'Fish', name: 'fish' },
           ],
+          limit: expect.any(Number),
           validate: expect.any(Function),
         },
       ]);
@@ -1767,6 +1770,7 @@ describe('params', () => {
             name: 'project',
             message: 'Which project?',
             choices: ['projA', 'projB'],
+            limit: expect.any(Number),
             validate: expect.any(Function),
           },
         ]);
@@ -1798,6 +1802,7 @@ describe('params', () => {
             name: 'projectName',
             message: 'Which project?',
             choices: ['projA', 'projB'],
+            limit: expect.any(Number),
             validate: expect.any(Function),
           },
         ]);
@@ -1830,6 +1835,7 @@ describe('params', () => {
             name: 'projectName',
             message: 'Which project?',
             choices: ['projA', 'projB'],
+            limit: expect.any(Number),
             validate: expect.any(Function),
           },
         ]);
@@ -1864,6 +1870,7 @@ describe('params', () => {
             name: 'yourProject',
             message: 'Which project?',
             choices: ['projA', 'projB'],
+            limit: expect.any(Number),
             validate: expect.any(Function),
           },
         ]);
@@ -1894,6 +1901,7 @@ describe('params', () => {
           name: 'name',
           message: 'What is your name?',
           choices: ['Bob', 'Joe', 'Jeff'],
+          limit: expect.any(Number),
           validate: expect.any(Function),
         },
       ]);
@@ -1925,6 +1933,7 @@ describe('params', () => {
           message: 'What is your name?',
           choices: ['Bob', 'Joe', 'Jeff'],
           initial: 'Joe',
+          limit: expect.any(Number),
           validate: expect.any(Function),
         },
       ]);

--- a/packages/nx/src/utils/params.ts
+++ b/packages/nx/src/utils/params.ts
@@ -6,6 +6,8 @@ import {
 } from '../config/workspace-json-project-json';
 import { output } from './output';
 
+const LIST_CHOICE_DISPLAY_LIMIT = 10;
+
 type PropertyDescription = {
   type?: string | string[];
   required?: string[];
@@ -760,6 +762,7 @@ type Prompt = ConstructorParameters<typeof import('enquirer').Prompt>[0] & {
   type: 'input' | 'autocomplete' | 'multiselect' | 'confirm' | 'numeral';
   message: string;
   initial?: any;
+  limit?: number;
   choices?: (string | { name: string; message: string })[];
 };
 
@@ -801,6 +804,7 @@ export function getPromptsForSchema(
       if (v.type === 'string' && v.enum && Array.isArray(v.enum)) {
         question.type = 'autocomplete';
         question.choices = [...v.enum];
+        question.limit = LIST_CHOICE_DISPLAY_LIMIT;
       } else if (
         v.type === 'string' &&
         (v.$default?.$source === 'projectName' ||
@@ -811,6 +815,7 @@ export function getPromptsForSchema(
       ) {
         question.type = 'autocomplete';
         question.choices = Object.keys(projectsConfigurations.projects);
+        question.limit = LIST_CHOICE_DISPLAY_LIMIT;
       } else if (v.type === 'number' || v['x-prompt'].type == 'number') {
         question.type = 'numeral';
       } else if (
@@ -835,6 +840,7 @@ export function getPromptsForSchema(
               };
             }
           });
+        question.limit = LIST_CHOICE_DISPLAY_LIMIT;
       } else if (v.type === 'boolean') {
         question.type = 'confirm';
       } else {


### PR DESCRIPTION
Limit the number of choices displayed on-screen when using multi-select or autocomplete generator prompts.

## Current Behavior
List prompt choices are currently unlimited. When more choices exist than can be shown, the prompt message is not visible.

## Expected Behavior
A fixed number of choices is displayed which users can cycle through

## Related Issue(s)
Fixes #17191 
