### PR TITLE
fix(core): handle multiple messages

### DIFF
--- a/packages/nx/src/utils/consume-messages-from-socket.ts
+++ b/packages/nx/src/utils/consume-messages-from-socket.ts
@@ -4,7 +4,13 @@ export function consumeMessagesFromSocket(callback: (message: string) => void) {
     const chunk = data.toString();
     if (chunk.codePointAt(chunk.length - 1) === 4) {
       message += chunk.substring(0, chunk.length - 1);
-      callback(message);
+
+      // Server may send multiple messages in one chunk, so splitting by 0x4
+      const messages = message.split('');
+      for (const splitMessage of messages) {
+        callback(splitMessage);
+      }
+
       message = '';
     } else {
       message += chunk;


### PR DESCRIPTION
## Current Behavior

Currently the file watcher for the @nx/js:node executor can fail to read messages when they occur too quickly (rapidly saving)
The error is
```
Watch error: Unexpected token  in JSON at position 157
```

The data it is trying to parse is
```
"{\"changedProjects\":[\"standard-json-schema\"],\"changedFiles\":[{\"path\":\"libs/shared/util-std-json-schema/src/lens-schema/lens-schema.util.ts\",\"type\":\"update\"}]}\u0004{\"changedProjects\":[\"standard-json-schema\"],\"changedFiles\":[{\"path\":\"libs/shared/util-std-json-schema/src/lens-schema/lens-schema.util.ts\",\"type\":\"update\"}]}\u0004{\"changedProjects\":[\"standard-json-schema\"],\"changedFiles\":[{\"path\":\"libs/shared/util-std-json-schema/src/lens-schema/lens-schema.util.ts\",\"type\":\"update\"}]}\u0004{\"changedProjects\":[\"standard-json-schema\"],\"changedFiles\":[{\"path\":\"libs/shared/util-std-json-schema/src/lens-schema/lens-schema.util.ts\",\"type\":\"update\"}]}"
```

This is two messages with a `0004` between.



## Expected Behavior

The file watcher should not get errors when too many messages occur at once.

## Related Issue(s)

A similar change was reverted in 6448274cf86bf3769a2295cf24667615c9a66fe, is there another solution to this issue?
