### PR TITLE
fix(nextjs): support config files with dots in filename

### DIFF
--- a/packages/next/src/executors/build/lib/create-next-config-file.spec.ts
+++ b/packages/next/src/executors/build/lib/create-next-config-file.spec.ts
@@ -73,7 +73,7 @@ describe('Next.js config: getWithNxContent', () => {
     expect(modulePaths).toEqual([
       'nested/a.cjs',
       'nested/b.cjs',
-      'nested-c.cjs',
+      'nested.c.cjs',
     ]);
   });
 

--- a/packages/next/src/executors/build/lib/create-next-config-file.ts
+++ b/packages/next/src/executors/build/lib/create-next-config-file.ts
@@ -221,7 +221,8 @@ export function ensureFileExtensions(
 ): string[] {
   const extensions = ['.js', '.cjs', '.mjs'];
   return files.map((file) => {
-    if (extname(file)) return file;
+    const providedExt = extname(file);
+    if (providedExt && extensions.includes(providedExt)) return file;
 
     const ext = extensions.find((ext) =>
       existsSync(join(absoluteDir, file + ext))

--- a/packages/next/src/executors/build/lib/test-fixtures/config-js/nested/b.cjs
+++ b/packages/next/src/executors/build/lib/test-fixtures/config-js/nested/b.cjs
@@ -1,3 +1,3 @@
 require('./a'); // Circular dependency should be handled
-require('../nested-c'); // one level up
+require('../nested.c'); // one level up
 module.exports = {};


### PR DESCRIPTION
If `next.config.js` requires a file with `.` in the filename, it is erroneously treated as a extension, and the lookup fails.

## Current Behavior
`.` is not supported in file names required in `next.config.js`

## Expected Behavior
`.` is supported in filenames e.g. `foo.bar.js`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
