### PR TITLE
feat(vite): add cssCodeSplit in build options

### DIFF
--- a/docs/generated/packages/vite/executors/build.json
+++ b/docs/generated/packages/vite/executors/build.json
@@ -88,6 +88,10 @@
         "description": "Force the optimizer to ignore the cache and re-bundle",
         "type": "boolean"
       },
+      "cssCodeSplit": {
+        "description": "Enable/disable CSS code splitting. When enabled, CSS imported in async chunks will be inlined into the async chunk itself and inserted when the chunk is loaded.",
+        "type": "boolean"
+      },
       "watch": {
         "description": "Enable re-building when files change.",
         "oneOf": [{ "type": "boolean" }, { "type": "object" }],

--- a/packages/vite/src/executors/build/schema.d.ts
+++ b/packages/vite/src/executors/build/schema.d.ts
@@ -17,4 +17,5 @@ export interface ViteBuildExecutorOptions {
   target?: string | string[];
   generatePackageJson?: boolean;
   includeDevDependenciesInPackageJson?: boolean;
+  cssCodeSplit?: boolean;
 }

--- a/packages/vite/src/executors/build/schema.json
+++ b/packages/vite/src/executors/build/schema.json
@@ -128,6 +128,10 @@
       "description": "Force the optimizer to ignore the cache and re-bundle",
       "type": "boolean"
     },
+    "cssCodeSplit": {
+      "description": "Enable/disable CSS code splitting. When enabled, CSS imported in async chunks will be inlined into the async chunk itself and inserted when the chunk is loaded.",
+      "type": "boolean"
+    },
     "watch": {
       "description": "Enable re-building when files change.",
       "oneOf": [

--- a/packages/vite/src/utils/options-utils.ts
+++ b/packages/vite/src/utils/options-utils.ts
@@ -144,7 +144,7 @@ export function getViteBuildOptions(
     outDir: relative(projectRoot, options.outputPath),
     emptyOutDir: options.emptyOutDir,
     reportCompressedSize: true,
-    cssCodeSplit: true,
+    cssCodeSplit: options.cssCodeSplit,
     target: options.target ?? 'esnext',
     commonjsOptions: {
       transformMixedEsModules: true,


### PR DESCRIPTION
## Current Behavior
Vite `build.cssCodeSplit` is hard-coded to `true`.

## Expected Behavior
Allow setting of `cssCodeSplit` from executor options. If not set, `vite.config.ts` setting is used.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17037
