### PR TITLE
fix(testing): normalize path for react CT spec generator

### DIFF
--- a/packages/react/src/generators/component-test/component-test.ts
+++ b/packages/react/src/generators/component-test/component-test.ts
@@ -26,6 +26,8 @@ export async function componentTestGenerator(
     '@nx/cypress/src/utils/cypress-version'
   );
   assertMinimumCypressVersion(10);
+  // normalize any windows paths
+  options.componentPath = options.componentPath.replace(/\\/g, '/');
 
   const projectConfig = readProjectConfiguration(tree, options.project);
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
files won't be generated on windows if the paths uses windows path separators

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
generator normalized path to the unix/FSTree path separators. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Should fix nightly e2e-cypress on widows.
Fixes #
