### PR TITLE
@nx/react:library - Add simpleName option to remove dir name from generated file names

### DIFF
--- a/docs/generated/packages/react/generators/library.json
+++ b/docs/generated/packages/react/generators/library.json
@@ -183,6 +183,11 @@
         "description": "Create a React library with a minimal setup, no separate test files.",
         "type": "boolean",
         "default": false
+      },
+      "simpleName": {
+        "description": "Don't include the directory in the name of the module of the library.",
+        "type": "boolean",
+        "default": false
       }
     },
     "required": ["name"],

--- a/packages/react/src/generators/library/lib/create-files.ts
+++ b/packages/react/src/generators/library/lib/create-files.ts
@@ -21,6 +21,7 @@ export function createFiles(host: Tree, options: NormalizedSchema) {
     ...names(options.name),
     tmpl: '',
     offsetFromRoot: offsetFromRoot(options.projectRoot),
+    fileName: options.fileName,
   };
 
   generateFiles(

--- a/packages/react/src/generators/library/lib/normalize-options.ts
+++ b/packages/react/src/generators/library/lib/normalize-options.ts
@@ -26,7 +26,7 @@ export function normalizeOptions(
     : name;
 
   const projectName = fullProjectDirectory.replace(new RegExp('/', 'g'), '-');
-  const fileName = projectName;
+  const fileName = options.simpleName ? name : projectName;
   const { libsDir: defaultLibsDir } = getWorkspaceLayout(host);
   const libsDir = layoutDirectory ?? defaultLibsDir;
   const projectRoot = joinPathFragments(libsDir, fullProjectDirectory);

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -29,6 +29,7 @@ describe('lib', () => {
     style: 'css',
     component: true,
     strict: true,
+    simpleName: false,
   };
 
   beforeEach(() => {
@@ -733,6 +734,30 @@ describe('lib', () => {
       expect(eslintConfig.overrides[0].parserOptions.project).toEqual([
         'libs/my-lib/tsconfig.*?.json',
       ]);
+    });
+  });
+
+  describe('--simpleName', () => {
+    it('should generate a library with a simple name', async () => {
+      await libraryGenerator(tree, {
+        ...defaultSchema,
+        simpleName: true,
+        directory: 'myDir',
+      });
+
+      const indexFile = tree.read('libs/my-dir/my-lib/src/index.ts', 'utf-8');
+
+      expect(indexFile).toContain(`export * from './lib/my-lib';`);
+
+      expect(
+        tree.exists('libs/my-dir/my-lib/src/lib/my-lib.module.css')
+      ).toBeTruthy();
+
+      expect(
+        tree.exists('libs/my-dir/my-lib/src/lib/my-lib.spec.tsx')
+      ).toBeTruthy();
+
+      expect(tree.exists('libs/my-dir/my-lib/src/lib/my-lib.tsx')).toBeTruthy();
     });
   });
 

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -128,7 +128,7 @@ export async function libraryGenerator(host: Tree, schema: Schema) {
 
   if (options.component) {
     const componentTask = await componentGenerator(host, {
-      name: options.name,
+      name: options.fileName,
       project: options.name,
       flat: true,
       style: options.style,

--- a/packages/react/src/generators/library/schema.d.ts
+++ b/packages/react/src/generators/library/schema.d.ts
@@ -26,6 +26,7 @@ export interface Schema {
   tags?: string;
   unitTestRunner?: 'jest' | 'vitest' | 'none';
   minimal?: boolean;
+  simpleName?: boolean;
 }
 
 export interface NormalizedSchema extends Schema {

--- a/packages/react/src/generators/library/schema.json
+++ b/packages/react/src/generators/library/schema.json
@@ -186,6 +186,11 @@
       "description": "Create a React library with a minimal setup, no separate test files.",
       "type": "boolean",
       "default": false
+    },
+    "simpleName": {
+      "description": "Don't include the directory in the name of the module of the library.",
+      "type": "boolean",
+      "default": false
     }
   },
   "required": ["name"]


### PR DESCRIPTION
## Current Behavior
Right now if you provide a directory to place your library, it will result in the file name of the library components to include the directory path as a prefix. (IE: MyDirMyLibName.tsx).

## Expected Behavior
Expected behavior would be to allow a way to generate a simple file name only consisting of the name of the lib provided. Just like the `simpleName` option that exists for @nx/angular and was added to @nx/nest

## Related Issue(s)
https://github.com/nrwl/nx/issues/17207
