### PR TITLE
fix(core): handle empty scripts in nx init

### DIFF
--- a/packages/nx/src/command-line/init/implementation/add-nx-to-nest.ts
+++ b/packages/nx/src/command-line/init/implementation/add-nx-to-nest.ts
@@ -71,7 +71,7 @@ export async function addNxToNest(options: Options, packageJson: PackageJson) {
   let scriptOutputs = {};
   let useNxCloud: boolean;
 
-  if (options.interactive) {
+  if (options.interactive && scripts.length > 0) {
     output.log({
       title:
         '🧑‍🔧 Please answer the following questions about the scripts found in your package.json in order to generate task runner configuration',
@@ -103,7 +103,9 @@ export async function addNxToNest(options: Options, packageJson: PackageJson) {
     useNxCloud = options.nxCloud ?? (await askAboutNxCloud());
   } else {
     cacheableOperations = options.cacheable ?? [];
-    useNxCloud = options.nxCloud ?? false;
+    useNxCloud =
+      options.nxCloud ??
+      (options.interactive ? await askAboutNxCloud() : false);
   }
 
   createNxJsonFile(

--- a/packages/nx/src/command-line/init/implementation/add-nx-to-npm-repo.ts
+++ b/packages/nx/src/command-line/init/implementation/add-nx-to-npm-repo.ts
@@ -29,7 +29,7 @@ export async function addNxToNpmRepo(options: Options) {
     (s) => !s.startsWith('pre') && !s.startsWith('post')
   );
 
-  if (options.interactive) {
+  if (options.interactive && scripts.length > 0) {
     output.log({
       title:
         '🧑‍🔧 Please answer the following questions about the scripts found in your package.json in order to generate task runner configuration',
@@ -63,7 +63,9 @@ export async function addNxToNpmRepo(options: Options) {
     useNxCloud = options.nxCloud ?? (await askAboutNxCloud());
   } else {
     cacheableOperations = options.cacheable ?? [];
-    useNxCloud = options.nxCloud ?? false;
+    useNxCloud =
+      options.nxCloud ??
+      (options.interactive ? await askAboutNxCloud() : false);
   }
 
   createNxJsonFile(repoRoot, [], cacheableOperations, {});

--- a/packages/nx/src/command-line/init/implementation/angular/index.ts
+++ b/packages/nx/src/command-line/init/implementation/angular/index.ts
@@ -80,7 +80,7 @@ async function collectCacheableOperations(options: Options): Promise<string[]> {
     (t) => workspaceTargets.includes(t)
   );
 
-  if (options.interactive) {
+  if (options.interactive && workspaceTargets.length > 0) {
     output.log({
       title:
         '🧑‍🔧 Please answer the following questions about the targets found in your angular.json in order to generate task runner configuration',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Running `nx init` in a repo where there are no `scripts` in the `package.json` throws. It also throws in an Angular CLI workspace with no targets (more of an edge case).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Running `nx init` in a repo where there are no `scripts` in the `package.json` should not throw.
Running `nx init` in an Angular CLI workspace with no targets should not throw.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17234 
