### PR TITLE
feat(nextjs): remove the "root" option from Next.js build executor since it can be inferred

### DIFF
--- a/packages/next/migrations.json
+++ b/packages/next/migrations.json
@@ -65,6 +65,12 @@
       "version": "16.0.0-beta.1",
       "description": "Replace @nrwl/next with @nx/next",
       "implementation": "./src/migrations/update-16-0-0-add-nx-packages/update-16-0-0-add-nx-packages"
+    },
+    "update-16-3-0-remove-root-build-option": {
+      "cli": "nx",
+      "version": "16.3.0-beta.9",
+      "description": "Remove root build option from project configurations since it is not needed.",
+      "implementation": "./src/migrations/update-16-3-0/remove-root-build-option"
     }
   },
   "packageJsonUpdates": {

--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -206,7 +206,7 @@ function withNx(
       nextConfig.webpack = (a, b) =>
         createWebpackConfig(
           workspaceRoot,
-          options.root,
+          projectDirectory,
           options.fileReplacements,
           options.assets,
           dependencies,

--- a/packages/next/src/executors/build/build.impl.ts
+++ b/packages/next/src/executors/build/build.impl.ts
@@ -1,15 +1,14 @@
 import 'dotenv/config';
 import {
   ExecutorContext,
-  readJsonFile,
-  workspaceRoot,
-  writeJsonFile,
   logger,
+  readJsonFile,
+  writeJsonFile,
 } from '@nx/devkit';
 import { createLockFile, createPackageJson, getLockFileName } from '@nx/js';
-import { join, resolve } from 'path';
+import { join } from 'path';
 import { copySync, existsSync, mkdir, writeFileSync } from 'fs-extra';
-import { lt, gte } from 'semver';
+import { gte } from 'semver';
 import { directoryExists } from '@nx/workspace/src/utilities/fileutils';
 import { checkAndCleanWithSemver } from '@nx/devkit/src/utils/semver';
 
@@ -17,7 +16,7 @@ import { updatePackageJson } from './lib/update-package-json';
 import { createNextConfigFile } from './lib/create-next-config-file';
 import { checkPublicDirectory } from './lib/check-project';
 import { NextBuildBuilderOptions } from '../../utils/types';
-import { ExecSyncOptions, execSync } from 'child_process';
+import { execSync, ExecSyncOptions } from 'child_process';
 import { createCliOptions } from '../../utils/create-cli-options';
 
 export default async function buildExecutor(
@@ -27,16 +26,16 @@ export default async function buildExecutor(
   // Cast to any to overwrite NODE_ENV
   (process.env as any).NODE_ENV ||= 'production';
 
-  const root = resolve(context.root, options.root);
+  const projectRoot = context.projectGraph.nodes[context.projectName].data.root;
 
-  checkPublicDirectory(root);
+  checkPublicDirectory(projectRoot);
 
   // Set `__NEXT_REACT_ROOT` based on installed ReactDOM version
-  const packageJsonPath = join(root, 'package.json');
+  const packageJsonPath = join(projectRoot, 'package.json');
   const packageJson = existsSync(packageJsonPath)
     ? readJsonFile(packageJsonPath)
     : undefined;
-  const rootPackageJson = readJsonFile(join(workspaceRoot, 'package.json'));
+  const rootPackageJson = readJsonFile(join(context.root, 'package.json'));
   const reactDomVersion =
     packageJson?.dependencies?.['react-dom'] ??
     rootPackageJson.dependencies?.['react-dom'];
@@ -54,7 +53,7 @@ export default async function buildExecutor(
   const execSyncOptions: ExecSyncOptions = {
     stdio: 'inherit',
     encoding: 'utf-8',
-    cwd: root,
+    cwd: projectRoot,
   };
   try {
     execSync(command, execSyncOptions);
@@ -89,7 +88,7 @@ export default async function buildExecutor(
 
   createNextConfigFile(options, context);
 
-  copySync(join(root, 'public'), join(options.outputPath, 'public'), {
+  copySync(join(projectRoot, 'public'), join(options.outputPath, 'public'), {
     dereference: true,
   });
 

--- a/packages/next/src/executors/build/lib/create-next-config-file.ts
+++ b/packages/next/src/executors/build/lib/create-next-config-file.ts
@@ -24,12 +24,13 @@ export function createNextConfigFile(
   options: NextBuildBuilderOptions,
   context: ExecutorContext
 ) {
+  const projectRoot = context.projectGraph.nodes[context.projectName].data.root;
   const configRelativeToProjectRoot = findNextConfigPath(
-    options.root,
+    projectRoot,
     // If user passed a config then it is relative to the workspace root, need to normalize it to be relative to the project root.
-    options.nextConfig ? relative(options.root, options.nextConfig) : undefined
+    options.nextConfig ? relative(projectRoot, options.nextConfig) : undefined
   );
-  const configAbsolutePath = join(options.root, configRelativeToProjectRoot);
+  const configAbsolutePath = join(projectRoot, configRelativeToProjectRoot);
 
   if (!existsSync(configAbsolutePath)) {
     throw new Error('next.config.js not found');
@@ -65,12 +66,12 @@ export function createNextConfigFile(
   // Find all relative imports needed by next.config.js and copy them to the dist folder.
   const moduleFilesToCopy = getRelativeFilesToCopy(
     configRelativeToProjectRoot,
-    options.root
+    projectRoot
   );
   for (const moduleFile of moduleFilesToCopy) {
     ensureDirSync(dirname(join(context.root, options.outputPath, moduleFile)));
     copyFileSync(
-      join(context.root, options.root, moduleFile),
+      join(context.root, projectRoot, moduleFile),
       join(context.root, options.outputPath, moduleFile)
     );
   }

--- a/packages/next/src/executors/build/schema.json
+++ b/packages/next/src/executors/build/schema.json
@@ -7,11 +7,6 @@
   "description": "Build a Next.js app.",
   "type": "object",
   "properties": {
-    "root": {
-      "description": "The source root",
-      "type": "string",
-      "x-priority": "important"
-    },
     "outputPath": {
       "type": "string",
       "description": "The output path of the generated files.",
@@ -76,5 +71,5 @@
       "description": "Only build 'app' routes"
     }
   },
-  "required": ["root", "outputPath"]
+  "required": ["outputPath"]
 }

--- a/packages/next/src/executors/export/export.impl.ts
+++ b/packages/next/src/executors/export/export.impl.ts
@@ -71,14 +71,14 @@ export default async function exportExecutor(
     buildTarget,
     context
   );
-  const root = resolve(context.root, buildOptions.root);
+  const projectRoot = context.projectGraph.nodes[context.projectName].data.root;
 
   // Taken from:
   // https://github.com/vercel/next.js/blob/ead56eaab68409e96c19f7d9139747bac1197aa9/packages/next/cli/next-export.ts#L13
   const nextExportCliSpan = nextTrace.trace('next-export-cli');
 
   await exportApp(
-    root,
+    projectRoot,
     {
       statusMessage: 'Exporting',
       silent: options.silent,

--- a/packages/next/src/executors/server/custom-server.impl.ts
+++ b/packages/next/src/executors/server/custom-server.impl.ts
@@ -30,9 +30,9 @@ export default async function* serveExecutor(
     parseTargetString(options.buildTarget, context.projectGraph),
     context
   );
-  const root = resolve(context.root, buildOptions.root);
+  const projectRoot = context.projectGraph.nodes[context.projectName].data.root;
 
-  yield* runCustomServer(root, options, context);
+  yield* runCustomServer(projectRoot, options, context);
 }
 
 async function* runCustomServer(

--- a/packages/next/src/executors/server/server.impl.ts
+++ b/packages/next/src/executors/server/server.impl.ts
@@ -28,12 +28,12 @@ export default async function* serveExecutor(
     parseTargetString(options.buildTarget, context.projectGraph),
     context
   );
-  const root = resolve(context.root, buildOptions.root);
+  const projectRoot = context.workspace.projects[context.projectName].root;
 
   const { port, keepAliveTimeout, hostname } = options;
 
   // This is required for the default custom server to work. See the @nx/next:app generator.
-  process.env.NX_NEXT_DIR = root;
+  process.env.NX_NEXT_DIR = projectRoot;
 
   // Cast to any to overwrite NODE_ENV
   (process.env as any).NODE_ENV = process.env.NODE_ENV
@@ -56,7 +56,7 @@ export default async function* serveExecutor(
   yield* createAsyncIterable<{ success: boolean; baseUrl: string }>(
     async ({ done, next, error }) => {
       const server = fork(nextBin, [mode, ...args, turbo], {
-        cwd: options.dev ? root : nextDir,
+        cwd: options.dev ? projectRoot : nextDir,
         stdio: 'inherit',
       });
 

--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -256,7 +256,6 @@ describe('app', () => {
       '@nx/next:build'
     );
     expect(projectConfiguration.targets.build.options).toEqual({
-      root: 'apps/my-app',
       outputPath: 'dist/apps/my-app',
     });
   });

--- a/packages/next/src/generators/application/lib/add-project.ts
+++ b/packages/next/src/generators/application/lib/add-project.ts
@@ -13,7 +13,6 @@ export function addProject(host: Tree, options: NormalizedSchema) {
     outputs: ['{options.outputPath}'],
     defaultConfiguration: 'production',
     options: {
-      root: options.appProjectRoot,
       outputPath: options.outputPath,
     },
     configurations: {

--- a/packages/next/src/migrations/update-16-3-0/remove-root-build-option.spec.ts
+++ b/packages/next/src/migrations/update-16-3-0/remove-root-build-option.spec.ts
@@ -1,0 +1,72 @@
+import update from './remove-root-build-option';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing-pre16';
+import {
+  addProjectConfiguration,
+  readProjectConfiguration,
+  Tree,
+} from '@nx/devkit';
+
+describe('remove-root-build-option', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should remove the root option from the build target for @nx/next:build executor', async () => {
+    addProjectConfiguration(tree, 'my-app', {
+      root: 'my-app',
+      targets: {
+        build: {
+          executor: '@nx/next:build',
+          options: {
+            root: 'my-app',
+          },
+        },
+      },
+    });
+
+    await update(tree);
+
+    const updatedConfig = readProjectConfiguration(tree, 'my-app');
+    expect(updatedConfig.targets.build.options.root).toBeUndefined();
+  });
+
+  it('should remove the root option from the build target for @nrwl/next:build executor', async () => {
+    addProjectConfiguration(tree, 'my-app', {
+      root: 'my-app',
+      targets: {
+        build: {
+          executor: '@nrwl/next:build',
+          options: {
+            root: 'my-app',
+          },
+        },
+      },
+    });
+
+    await update(tree);
+
+    const updatedConfig = readProjectConfiguration(tree, 'my-app');
+    expect(updatedConfig.targets.build.options.root).toBeUndefined();
+  });
+
+  it('should leave other executors alone', async () => {
+    addProjectConfiguration(tree, 'my-app', {
+      root: 'my-app',
+      targets: {
+        build: {
+          executor: '@acme/foo:bar',
+          options: {
+            root: 'my-app',
+          },
+        },
+      },
+    });
+
+    await update(tree);
+
+    const updatedConfig = readProjectConfiguration(tree, 'my-app');
+    expect(updatedConfig.targets.build.options.root).toEqual('my-app');
+  });
+});

--- a/packages/next/src/migrations/update-16-3-0/remove-root-build-option.ts
+++ b/packages/next/src/migrations/update-16-3-0/remove-root-build-option.ts
@@ -1,0 +1,27 @@
+import {
+  readProjectConfiguration,
+  Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+import { forEachExecutorOptions } from '@nx/devkit/src/generators/executor-options-utils';
+
+export default async function update(tree: Tree) {
+  forEachExecutorOptions(
+    tree,
+    '@nx/next:build',
+    (options, projectName, targetName) => {
+      const projectConfig = readProjectConfiguration(tree, projectName);
+      delete projectConfig.targets[targetName].options.root;
+      updateProjectConfiguration(tree, projectName, projectConfig);
+    }
+  );
+  forEachExecutorOptions(
+    tree,
+    '@nrwl/next:build',
+    (options, projectName, targetName) => {
+      const projectConfig = readProjectConfiguration(tree, projectName);
+      delete projectConfig.targets[targetName].options.root;
+      updateProjectConfiguration(tree, projectName, projectConfig);
+    }
+  );
+}

--- a/packages/next/src/utils/types.ts
+++ b/packages/next/src/utils/types.ts
@@ -28,7 +28,6 @@ export interface FileReplacement {
 }
 
 export interface NextBuildBuilderOptions {
-  root: string;
   outputPath: string;
   fileReplacements: FileReplacement[];
   assets?: any[];


### PR DESCRIPTION
We never needed the `root` option for `@nx/next:build` executor since we know the project root by reading the graph. This PR:

1. Removes the `root` option from said executor.
2. Update app generator to no longer generate with it.
3. Adds a migration to remove it from existing projects.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
