### PR TITLE
fix(js): set node_env when building with esbuild

### DIFF
--- a/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
+++ b/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
@@ -41,6 +41,8 @@ export async function* esbuildExecutor(
   _options: EsBuildExecutorOptions,
   context: ExecutorContext
 ) {
+  process.env.NODE_ENV ??= context.configurationName;
+
   const options = normalizeOptions(_options, context);
   if (options.deleteOutputPath) removeSync(options.outputPath);
 


### PR DESCRIPTION
closes: #16960
