### PR TITLE
docs(core): add example run-many commands filtering on specific tags

### DIFF
--- a/docs/generated/cli/run-many.md
+++ b/docs/generated/cli/run-many.md
@@ -53,6 +53,18 @@ Test all projects with tags starting with `api-`. Note: your shell may require y
  nx run-many -t test --projects=tag:api-*
 ```
 
+Test all projects with a `type:ui` tag:
+
+```shell
+ nx run-many -t test --projects=tag:type:ui
+```
+
+Test all projects with a `type:feature` or `type:ui` tag:
+
+```shell
+ nx run-many -t test --projects=tag:type:feature,tag:type:ui
+```
+
 Run lint, test, and build targets for all projects. Requires Nx v15.4+:
 
 ```shell

--- a/docs/generated/packages/nx/documents/run-many.md
+++ b/docs/generated/packages/nx/documents/run-many.md
@@ -53,6 +53,18 @@ Test all projects with tags starting with `api-`. Note: your shell may require y
  nx run-many -t test --projects=tag:api-*
 ```
 
+Test all projects with a `type:ui` tag:
+
+```shell
+ nx run-many -t test --projects=tag:type:ui
+```
+
+Test all projects with a `type:feature` or `type:ui` tag:
+
+```shell
+ nx run-many -t test --projects=tag:type:feature,tag:type:ui
+```
+
 Run lint, test, and build targets for all projects. Requires Nx v15.4+:
 
 ```shell

--- a/packages/nx/src/command-line/examples.ts
+++ b/packages/nx/src/command-line/examples.ts
@@ -285,6 +285,14 @@ export const examples: Record<string, Example[]> = {
         'Test all projects with tags starting with `api-`.  Note: your shell may require you to escape the `*` like this: `\\*`',
     },
     {
+      command: 'run-many -t test --projects=tag:type:ui',
+      description: 'Test all projects with a `type:ui` tag',
+    },
+    {
+      command: 'run-many -t test --projects=tag:type:feature,tag:type:ui',
+      description: 'Test all projects with a `type:feature` or `type:ui` tag',
+    },
+    {
       command: 'run-many --targets=lint,test,build --all',
       description:
         'Run lint, test, and build targets for all projects. Requires Nx v15.4+',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
No examples for filtering the `nx run-many` command on specific tags.

## Expected Behavior
Examples for filtering the `nx run-many` command on a specific tag or at least one of 2 specific tags.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes # N/A
