### PR TITLE
fix(js): sourcemaps should work with js:node executor

### DIFF
--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -135,8 +135,9 @@ export async function* nodeExecutor(
             task.promise = new Promise<void>((resolve, reject) => {
               task.childProcess = fork(
                 joinPathFragments(__dirname, 'node-with-require-overrides'),
-                getExecArgv(options),
+                options.runtimeArgs ?? [],
                 {
+                  execArgv: getExecArgv(options),
                   stdio: [0, 1, 'pipe', 'ipc'],
                   env: {
                     ...process.env,
@@ -230,11 +231,7 @@ export async function* nodeExecutor(
 }
 
 function getExecArgv(options: NodeExecutorOptions) {
-  const args = [
-    '-r',
-    require.resolve('source-map-support/register'),
-    ...options.runtimeArgs,
-  ];
+  const args = ['-r', require.resolve('source-map-support/register')];
 
   if (options.inspect === true) {
     options.inspect = InspectType.Inspect;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We are passing node options to the running JS code rather than to node itself when using @nx/js:node

## Expected Behavior
Node options are consumed by node

## Context

You can see this illustrated if you write the following 3 files:

> host.js
```javascript
require('child_process').fork('./file.js', ['-r', './logger.js', 'some-args', ], {
    // execArgv: ['-r', './logger.js']
})
```

> logger.js
```javascript
console.log('HELLO WORLD')
```

> file.js
```javascript
console.log('FROM CP', { argv: process.argv, execArgv: process.execArgv });
```

With the execArgv argument commented out, we never see `HELLO WORLD` and the `-r logger.js` gets consumed by `file.js` rather than `node`.

With `execArgv`, and not passing the `-r` inside the arguments array, we get the behavior we expect.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17258
