### PR TITLE
feat(nextjs): add babel root-mode option to withNx plugin

### DIFF
--- a/docs/generated/packages/next/documents/next-config-setup.md
+++ b/docs/generated/packages/next/documents/next-config-setup.md
@@ -22,11 +22,31 @@ module.exports = withNx({
 });
 ```
 
-This guide contains information on how to compose the Nx plugin with other plugins, such as `@next/mdx`. Note that Nx prior to version 16 is missing the compose utility from the `@nx/next` package, and a workaround will be provided for Nx 15 and prior.
+This guide contains information on how to configure and compose the Nx plugin with other plugins, such as `@next/mdx`. Note that Nx prior to version 16 is missing the compose utility from the `@nx/next` package, and a workaround will be provided for Nx 15 and prior.
 
 {% callout type="warning" title="Avoid next-compose-plugins" %}
 There is a popular package called `next-compose-plugins` that has not been maintained for over two years. This package does not correctly combine plugins in all situations. If you do use it, replace the package with Nx 16's `composePlugins` utility (see below).
 {% /callout %}
+
+## `withNx` plugin
+
+The `withNx` Next.js plugin provides integration with Nx, including support for [workspace libraries](/packages/next/generators/library), SVGR, and more. It is included by default when you generate a Next.js [application](/packages/next/generators/application) with Nx. When you customize your `next.config.js` file, make sure to include the `withNx` plugin.
+
+### Options
+
+#### svgr
+
+Type: `boolean`
+
+Set this to true if you would like to to use SVGR. See: https://react-svgr.com/
+
+#### babelUpwardRootMode
+
+Type: `boolean`
+
+For a monorepo, set to `true` to incorporate `.babelrc` files from individual libraries into the build. Note, however, that doing so will prevent the application's `.babelrc` settings from being applied to its libraries. It is generally recommended not to enable this option, as it can lead to a lack of consistency throughout the workspace. Instead, the application's `.babelrc` file should include the presets and plugins needed by its libraries directly. For more information on babel root-mode, see here: https://babeljs.io/docs/en/options#rootmode
+
+Set this to `true` if you want `.babelrc` from libraries to be used in a monorepo. Note that setting this to `true` means the application's `.babelrc` will not apply to libraries, and it is recommended not to use this option as it may lead to inconsistency in the workspace. Instead, add babel presets/plugins required by libraries directly to the application's `.babelrc` file. See: https://babeljs.io/docs/en/options#rootmode
 
 ## Composing plugins using `composePlugins` utility (Nx 16 and later)
 

--- a/docs/shared/packages/next/next-config-setup.md
+++ b/docs/shared/packages/next/next-config-setup.md
@@ -22,11 +22,31 @@ module.exports = withNx({
 });
 ```
 
-This guide contains information on how to compose the Nx plugin with other plugins, such as `@next/mdx`. Note that Nx prior to version 16 is missing the compose utility from the `@nx/next` package, and a workaround will be provided for Nx 15 and prior.
+This guide contains information on how to configure and compose the Nx plugin with other plugins, such as `@next/mdx`. Note that Nx prior to version 16 is missing the compose utility from the `@nx/next` package, and a workaround will be provided for Nx 15 and prior.
 
 {% callout type="warning" title="Avoid next-compose-plugins" %}
 There is a popular package called `next-compose-plugins` that has not been maintained for over two years. This package does not correctly combine plugins in all situations. If you do use it, replace the package with Nx 16's `composePlugins` utility (see below).
 {% /callout %}
+
+## `withNx` plugin
+
+The `withNx` Next.js plugin provides integration with Nx, including support for [workspace libraries](/packages/next/generators/library), SVGR, and more. It is included by default when you generate a Next.js [application](/packages/next/generators/application) with Nx. When you customize your `next.config.js` file, make sure to include the `withNx` plugin.
+
+### Options
+
+#### svgr
+
+Type: `boolean`
+
+Set this to true if you would like to to use SVGR. See: https://react-svgr.com/
+
+#### babelUpwardRootMode
+
+Type: `boolean`
+
+For a monorepo, set to `true` to incorporate `.babelrc` files from individual libraries into the build. Note, however, that doing so will prevent the application's `.babelrc` settings from being applied to its libraries. It is generally recommended not to enable this option, as it can lead to a lack of consistency throughout the workspace. Instead, the application's `.babelrc` file should include the presets and plugins needed by its libraries directly. For more information on babel root-mode, see here: https://babeljs.io/docs/en/options#rootmode
+
+Set this to `true` if you want `.babelrc` from libraries to be used in a monorepo. Note that setting this to `true` means the application's `.babelrc` will not apply to libraries, and it is recommended not to use this option as it may lead to inconsistency in the workspace. Instead, add babel presets/plugins required by libraries directly to the application's `.babelrc` file. See: https://babeljs.io/docs/en/options#rootmode
 
 ## Composing plugins using `composePlugins` utility (Nx 16 and later)
 

--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -12,6 +12,7 @@ import type { ProjectGraph, ProjectGraphProjectNode, Target } from '@nx/devkit';
 export interface WithNxOptions extends NextConfig {
   nx?: {
     svgr?: boolean;
+    babelUpwardRootMode?: boolean;
   };
 }
 
@@ -110,6 +111,7 @@ function getNxContext(
     );
   }
 }
+
 /**
  * Try to read output dir from project, and default to '.next' if executing outside of Nx (e.g. dist is added to a docker image).
  */
@@ -239,8 +241,10 @@ export function getNextConfig(
        * Update babel to support our monorepo setup.
        * The 'upward' mode allows the root babel.config.json and per-project .babelrc files to be picked up.
        */
-      options.defaultLoaders.babel.options.babelrc = true;
-      options.defaultLoaders.babel.options.rootMode = 'upward';
+      if (nx?.babelUpwardRootMode) {
+        options.defaultLoaders.babel.options.babelrc = true;
+        options.defaultLoaders.babel.options.rootMode = 'upward';
+      }
 
       /*
        * Modify the Next.js webpack config to allow workspace libs to use css modules.


### PR DESCRIPTION
This PR adds the `babelUpwardRootMode` option to `withNx` plugin, for use in `next.config.js` file. This is `false` by default, and users will need to opt into it if they want to maintain the monorepo behavior of loading all individual `.babelrc` files.

Note: We don't want the root mode behavior by default because it can lead to inconsistencies between apps and libs. If a lib needs certain babel plugins to work, then the app need specify it in its own `.babelrc` file.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
