### PR TITLE
fix(core): do not destructure potential null value in watch callback

### DIFF
--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -520,13 +520,13 @@ function debounce(fn: (...args) => void, time: number) {
 function createFileWatcher() {
   return daemonClient.registerFileWatcher(
     { watchProjects: 'all', includeGlobalWorkspaceFiles: true },
-    debounce(async (error, { changedFiles }) => {
+    debounce(async (error, changes) => {
       if (error === 'closed') {
         output.error({ title: `Watch error: Daemon closed the connection` });
         process.exit(1);
       } else if (error) {
         output.error({ title: `Watch error: ${error?.message ?? 'Unknown'}` });
-      } else if (changedFiles.length > 0) {
+      } else if (changes !== null && changes.changedFiles.length > 0) {
         output.note({ title: 'Recalculating project graph...' });
 
         const newGraphClientResponse = await createDepGraphClientResponse();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Using `nx graph --watch`, and then adding a new project that can potentially close the daemon, causes a runtime error in the terminal output because of destructuring a null value. 

## Expected Behavior
Handling of null data should be done properly

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
