### PR TITLE
docs(core): fix wrong option name in watch command examples

### DIFF
--- a/docs/generated/cli/watch.md
+++ b/docs/generated/cli/watch.md
@@ -26,7 +26,7 @@ Watch the "app" project and echo the project name and the files that changed:
 Watch "app1" and "app2" and echo the project name whenever a specified project or its dependencies change:
 
 ```shell
- nx watch --projects=app1,app2 --includeDependencies -- echo \$NX_PROJECT_NAME
+ nx watch --projects=app1,app2 --includeDependentProjects -- echo \$NX_PROJECT_NAME
 ```
 
 Watch all projects (including newly created projects) in the workspace:

--- a/docs/generated/packages/nx/documents/watch.md
+++ b/docs/generated/packages/nx/documents/watch.md
@@ -26,7 +26,7 @@ Watch the "app" project and echo the project name and the files that changed:
 Watch "app1" and "app2" and echo the project name whenever a specified project or its dependencies change:
 
 ```shell
- nx watch --projects=app1,app2 --includeDependencies -- echo \$NX_PROJECT_NAME
+ nx watch --projects=app1,app2 --includeDependentProjects -- echo \$NX_PROJECT_NAME
 ```
 
 Watch all projects (including newly created projects) in the workspace:

--- a/packages/nx/src/command-line/examples.ts
+++ b/packages/nx/src/command-line/examples.ts
@@ -387,7 +387,7 @@ export const examples: Record<string, Example[]> = {
     },
     {
       command:
-        'watch --projects=app1,app2 --includeDependencies -- echo \\$NX_PROJECT_NAME',
+        'watch --projects=app1,app2 --includeDependentProjects -- echo \\$NX_PROJECT_NAME',
       description:
         'Watch "app1" and "app2" and echo the project name whenever a specified project or its dependencies change',
     },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

A wrong `--includeDependencies` option is shown in the `watch` command examples for watching dependent projects.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The watch command examples for watching dependent projects should use the option `--includeDependentProjects`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17285 
