### PR TITLE
chore(core): add load yaml function

### DIFF
--- a/packages/nx/src/config/workspaces.ts
+++ b/packages/nx/src/config/workspaces.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { basename, dirname, extname, join } from 'path';
 import { performance } from 'perf_hooks';
 import { workspaceRoot } from '../utils/workspace-root';
-import { readJsonFile } from '../utils/fileutils';
+import { readJsonFile, readYamlFile } from '../utils/fileutils';
 import { logger, NX_PREFIX } from '../utils/logger';
 import {
   loadNxPlugins,
@@ -12,7 +12,6 @@ import {
   readPluginPackageJson,
   registerPluginTSTranspiler,
 } from '../utils/nx-plugin';
-import * as yaml from 'js-yaml';
 
 import type { NxJsonConfiguration, TargetDefaults } from './nx-json';
 import {
@@ -594,10 +593,10 @@ export function getGlobPatternsFromPackageManagerWorkspaces(
 
     if (existsSync(join(root, 'pnpm-workspace.yaml'))) {
       try {
-        const obj = yaml.load(
-          readFileSync(join(root, 'pnpm-workspace.yaml'), 'utf-8')
-        ) as { packages: string[] };
-        patterns.push(...normalizePatterns(obj.packages || []));
+        const { packages } = readYamlFile<{ packages: string[] }>(
+          join(root, 'pnpm-workspace.yaml')
+        );
+        patterns.push(...normalizePatterns(packages || []));
       } catch (e: unknown) {
         output.warn({
           title: `${NX_PREFIX} Unable to parse pnpm-workspace.yaml`,

--- a/packages/nx/src/utils/fileutils.ts
+++ b/packages/nx/src/utils/fileutils.ts
@@ -53,6 +53,28 @@ export function readJsonFile<T extends object = any>(
   }
 }
 
+interface YamlReadOptions {
+  /**
+   * Compatibility with JSON.parse behaviour. If true, then duplicate keys in a mapping will override values rather than throwing an error.
+   */
+  json?: boolean;
+}
+
+/**
+ * Reads a YAML file and returns the object the YAML content represents.
+ *
+ * @param path A path to a file.
+ * @returns
+ */
+export function readYamlFile<T extends object = any>(
+  path: string,
+  options?: YamlReadOptions
+): T {
+  const content = readFileSync(path, 'utf-8');
+  const { load } = require('js-yaml');
+  return load(content, { ...options, filename: path }) as T;
+}
+
 /**
  * Serializes the given data to JSON and writes it to a file.
  *


### PR DESCRIPTION
Adds `loadYamlFile` function to nx file utils and lazy loads `js-yaml` package.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
