### PR TITLE
feat(angular): add option to ngrx-root-store generator to set up the store devtools

### DIFF
--- a/docs/generated/packages/angular/generators/ngrx-root-store.json
+++ b/docs/generated/packages/angular/generators/ngrx-root-store.json
@@ -43,6 +43,11 @@
         "description": "Create a Facade class for the the feature.",
         "x-prompt": "Would you like to use a Facade with your NgRx state?"
       },
+      "addDevTools": {
+        "type": "boolean",
+        "default": false,
+        "description": "Instrument the Store Devtools."
+      },
       "skipImport": {
         "type": "boolean",
         "default": false,

--- a/packages/angular/src/generators/ngrx-root-store/__snapshots__/ngrx-root-store.spec.ts.snap
+++ b/packages/angular/src/generators/ngrx-root-store/__snapshots__/ngrx-root-store.spec.ts.snap
@@ -393,6 +393,44 @@ export class AppModule {}
 "
 `;
 
+exports[`NgRxRootStoreGenerator NgModule should instrument the store devtools when "addDevTools: true" 1`] = `
+"import { NgModule, isDevMode } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { RouterModule } from '@angular/router';
+import { AppComponent } from './app.component';
+import { appRoutes } from './app.routes';
+import { NxWelcomeComponent } from './nx-welcome.component';
+import { StoreModule } from '@ngrx/store';
+import { EffectsModule } from '@ngrx/effects';
+import { StoreRouterConnectingModule } from '@ngrx/router-store';
+import { StoreDevtoolsModule } from '@ngrx/store-devtools';
+
+@NgModule({
+  declarations: [AppComponent, NxWelcomeComponent],
+  imports: [
+    BrowserModule,
+    RouterModule.forRoot(appRoutes, { initialNavigation: 'enabledBlocking' }),
+    StoreModule.forRoot(
+      {},
+      {
+        metaReducers: [],
+        runtimeChecks: {
+          strictActionImmutability: true,
+          strictStateImmutability: true,
+        },
+      }
+    ),
+    EffectsModule.forRoot([]),
+    StoreRouterConnectingModule.forRoot(),
+    StoreDevtoolsModule.instrument({ logOnly: !isDevMode() }),
+  ],
+  providers: [],
+  bootstrap: [AppComponent],
+})
+export class AppModule {}
+"
+`;
+
 exports[`NgRxRootStoreGenerator Standalone APIs should add a facade when --facade=true 1`] = `
 "import { ApplicationConfig } from '@angular/core';
 import {
@@ -731,6 +769,28 @@ import { provideEffects } from '@ngrx/effects';
 
 export const appConfig: ApplicationConfig = {
   providers: [
+    provideEffects(),
+    provideStore(),
+    provideRouter(appRoutes, withEnabledBlockingInitialNavigation()),
+  ],
+};
+"
+`;
+
+exports[`NgRxRootStoreGenerator Standalone APIs should instrument the store devtools when "addDevTools: true" 1`] = `
+"import { ApplicationConfig, isDevMode } from '@angular/core';
+import {
+  provideRouter,
+  withEnabledBlockingInitialNavigation,
+} from '@angular/router';
+import { appRoutes } from './app.routes';
+import { provideStore } from '@ngrx/store';
+import { provideEffects } from '@ngrx/effects';
+import { provideStoreDevtools } from '@ngrx/store-devtools';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideStoreDevtools({ logOnly: !isDevMode() }),
     provideEffects(),
     provideStore(),
     provideRouter(appRoutes, withEnabledBlockingInitialNavigation()),

--- a/packages/angular/src/generators/ngrx-root-store/lib/add-ngrx-to-package-json.ts
+++ b/packages/angular/src/generators/ngrx-root-store/lib/add-ngrx-to-package-json.ts
@@ -26,7 +26,9 @@ export function addNgRxToPackageJson(
     },
     {
       '@ngrx/schematics': ngrxVersion,
-      '@ngrx/store-devtools': ngrxVersion,
+      ...(options.addDevTools
+        ? { '@ngrx/store-devtools': ngrxVersion }
+        : undefined),
       'jasmine-marbles': jasmineMarblesVersion,
     }
   );

--- a/packages/angular/src/generators/ngrx-root-store/ngrx-root-store.spec.ts
+++ b/packages/angular/src/generators/ngrx-root-store/ngrx-root-store.spec.ts
@@ -1,9 +1,9 @@
 import type { Tree } from '@nx/devkit';
 import { readJson } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import applicationGenerator from '../application/application';
-import ngrxRootStoreGenerator from './ngrx-root-store';
 import { ngrxVersion } from '../../utils/versions';
+import { generateTestApplication } from '../utils/testing';
+import { ngrxRootStoreGenerator } from './ngrx-root-store';
 
 describe('NgRxRootStoreGenerator', () => {
   describe('NgModule', () => {
@@ -127,6 +127,24 @@ describe('NgRxRootStoreGenerator', () => {
       ).toMatchSnapshot();
     });
 
+    it('should instrument the store devtools when "addDevTools: true"', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      await createNgModuleApp(tree);
+
+      // ACT
+      await ngrxRootStoreGenerator(tree, {
+        project: 'my-app',
+        minimal: true,
+        addDevTools: true,
+      });
+
+      // ASSERT
+      expect(
+        tree.read('my-app/src/app/app.module.ts', 'utf-8')
+      ).toMatchSnapshot();
+    });
+
     it('should update package.json', async () => {
       // ARRANGE
       const tree = createTreeWithEmptyWorkspace();
@@ -152,10 +170,29 @@ describe('NgRxRootStoreGenerator', () => {
       expect(packageJson.devDependencies['@ngrx/schematics']).toEqual(
         ngrxVersion
       );
-      expect(packageJson.devDependencies['@ngrx/store-devtools']).toEqual(
+      expect(
+        packageJson.devDependencies['@ngrx/store-devtools']
+      ).toBeUndefined();
+      expect(packageJson.devDependencies['jasmine-marbles']).toBeDefined();
+    });
+
+    it('should add @ngrx/store-devtools when "addDevTools: true"', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      await createNgModuleApp(tree);
+
+      // ACT
+      await ngrxRootStoreGenerator(tree, {
+        project: 'my-app',
+        minimal: true,
+        addDevTools: true,
+      });
+
+      // ASSERT
+      const packageJson = readJson(tree, 'package.json');
+      expect(packageJson.devDependencies['@ngrx/store-devtools']).toBe(
         ngrxVersion
       );
-      expect(packageJson.devDependencies['jasmine-marbles']).toBeDefined();
     });
 
     it('should not update package.json when --skipPackageJson=true', async () => {
@@ -184,6 +221,7 @@ describe('NgRxRootStoreGenerator', () => {
       expect(packageJson.devDependencies['jasmine-marbles']).toBeUndefined();
     });
   });
+
   describe('Standalone APIs', () => {
     it('should error when project does not exist', async () => {
       const tree = createTreeWithEmptyWorkspace();
@@ -305,6 +343,24 @@ describe('NgRxRootStoreGenerator', () => {
       ).toMatchSnapshot();
     });
 
+    it('should instrument the store devtools when "addDevTools: true"', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      await createStandaloneApp(tree);
+
+      // ACT
+      await ngrxRootStoreGenerator(tree, {
+        project: 'my-app',
+        minimal: true,
+        addDevTools: true,
+      });
+
+      // ASSERT
+      expect(
+        tree.read('my-app/src/app/app.config.ts', 'utf-8')
+      ).toMatchSnapshot();
+    });
+
     it('should update package.json', async () => {
       // ARRANGE
       const tree = createTreeWithEmptyWorkspace();
@@ -330,10 +386,29 @@ describe('NgRxRootStoreGenerator', () => {
       expect(packageJson.devDependencies['@ngrx/schematics']).toEqual(
         ngrxVersion
       );
-      expect(packageJson.devDependencies['@ngrx/store-devtools']).toEqual(
+      expect(
+        packageJson.devDependencies['@ngrx/store-devtools']
+      ).toBeUndefined();
+      expect(packageJson.devDependencies['jasmine-marbles']).toBeDefined();
+    });
+
+    it('should add @ngrx/store-devtools when "addDevTools: true"', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      await createStandaloneApp(tree);
+
+      // ACT
+      await ngrxRootStoreGenerator(tree, {
+        project: 'my-app',
+        minimal: true,
+        addDevTools: true,
+      });
+
+      // ASSERT
+      const packageJson = readJson(tree, 'package.json');
+      expect(packageJson.devDependencies['@ngrx/store-devtools']).toBe(
         ngrxVersion
       );
-      expect(packageJson.devDependencies['jasmine-marbles']).toBeDefined();
     });
 
     it('should not update package.json when --skipPackageJson=true', async () => {
@@ -365,7 +440,7 @@ describe('NgRxRootStoreGenerator', () => {
 });
 
 async function createNgModuleApp(tree: Tree, name = 'my-app') {
-  await applicationGenerator(tree, {
+  await generateTestApplication(tree, {
     name,
     standalone: false,
     routing: true,
@@ -373,7 +448,7 @@ async function createNgModuleApp(tree: Tree, name = 'my-app') {
 }
 
 async function createStandaloneApp(tree: Tree, name = 'my-app') {
-  await applicationGenerator(tree, {
+  await generateTestApplication(tree, {
     name,
     standalone: true,
     routing: true,

--- a/packages/angular/src/generators/ngrx-root-store/schema.d.ts
+++ b/packages/angular/src/generators/ngrx-root-store/schema.d.ts
@@ -1,6 +1,7 @@
 export interface Schema {
   project: string;
   minimal: boolean;
+  addDevTools?: boolean;
   name?: string;
   directory?: string;
   facade?: boolean;

--- a/packages/angular/src/generators/ngrx-root-store/schema.json
+++ b/packages/angular/src/generators/ngrx-root-store/schema.json
@@ -43,6 +43,11 @@
       "description": "Create a Facade class for the the feature.",
       "x-prompt": "Would you like to use a Facade with your NgRx state?"
     },
+    "addDevTools": {
+      "type": "boolean",
+      "default": false,
+      "description": "Instrument the Store Devtools."
+    },
     "skipImport": {
       "type": "boolean",
       "default": false,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `@nx/angular:ngrx-root-store` generator doesn't set up the Store Devtools.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `@nx/angular:ngrx-root-store` generator provides the `--add-dev-tools` option to set up the Store Devtools.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17288 
