### PR TITLE
fix(angular): loosen package updates requirements

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -709,8 +709,7 @@
       "version": "15.2.0-beta.0",
       "x-prompt": "Do you want to update the Angular version to v15?",
       "requires": {
-        "@angular/core": "^14.2.0",
-        "typescript": ">=4.8.2 <5.0"
+        "@angular/core": "^14.2.0"
       },
       "packages": {
         "@angular-devkit/architect": {
@@ -842,8 +841,7 @@
       "version": "15.5.0-beta.0",
       "x-prompt": "Do you want to update the Angular version to v15.1?",
       "requires": {
-        "@angular/core": ">=15.0.0 <15.1.0",
-        "typescript": ">=4.8.2 <5.0"
+        "@angular/core": ">=15.0.0 <15.1.0"
       },
       "packages": {
         "@angular-devkit/architect": {
@@ -908,8 +906,7 @@
       "version": "15.8.0-beta.4",
       "x-prompt": "Do you want to update the Angular version to v15.2?",
       "requires": {
-        "@angular/core": ">=15.1.0 <15.2.0",
-        "typescript": ">=4.8.2 <5.0"
+        "@angular/core": ">=15.1.0 <15.2.0"
       },
       "packages": {
         "@angular-devkit/architect": {
@@ -1034,8 +1031,7 @@
       "version": "16.1.0-beta.1",
       "x-prompt": "Do you want to update the Angular version to v16?",
       "requires": {
-        "@angular/core": ">=15.2.0 <16.0.0",
-        "typescript": ">=4.9.3 <5.1"
+        "@angular/core": ">=15.2.0 <16.0.0"
       },
       "packages": {
         "@angular/core": {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Migrating an Nx workspace with Angular with multiple package updates for Typescript collected causes the Angular package updates to not be collected.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Migrating an Nx workspace with Angular should work correctly.

**Note**: removing the Typescript requirement solves the issue and doesn't cause any additional issues. The requirement was too restrictive and provided very little benefit. It was a small layer of protection for folks running in interactive mode, but when running in interactive mode, you're opting out of the Nx-managed automatic updates which means that you're in control and you need to know what you're doing when it comes to dependencies.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17100 
