### PR TITLE
fix(core): remove extraneous appName prompts for Node standalone in CNW; remove invariant check for determining stack

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -369,10 +369,6 @@ async function determineStack(
     },
   ]);
 
-  invariant(stack, {
-    title: 'Invalid stack selection',
-  });
-
   return stack;
 }
 
@@ -503,7 +499,7 @@ async function determineReactOptions(
     const reply = await enquirer.prompt<{ style: string }>([
       {
         name: 'style',
-        message: `Default stylesheet format            `,
+        message: `Default stylesheet format`,
         initial: 'css' as any,
         type: 'autocomplete',
         choices: [
@@ -578,7 +574,7 @@ async function determineAngularOptions(
     const reply = await enquirer.prompt<{ style: string }>([
       {
         name: 'style',
-        message: `Default stylesheet format            `,
+        message: `Default stylesheet format`,
         initial: 'css' as any,
         type: 'autocomplete',
         choices: [
@@ -681,7 +677,6 @@ async function determineNodeOptions(
     const workspaceType = await determineStandAloneOrMonorepo();
     if (workspaceType === 'standalone') {
       preset = Preset.NodeStandalone;
-      appName = await determineAppName(parsedArgs);
       appName = parsedArgs.name;
     } else {
       preset = Preset.NodeMonorepo;


### PR DESCRIPTION
The `appName` prompt isn't needed for Node Standalone since it is just the folder name. Also addressed the PR comment for the stack `invariant` call that isn't needed.

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
