### PR TITLE
docs(core): update terminal prompts for tutorials to match new options

### DIFF
--- a/docs/shared/angular-standalone-tutorial/1-code-generation.md
+++ b/docs/shared/angular-standalone-tutorial/1-code-generation.md
@@ -32,11 +32,12 @@ Run the command `npx create-nx-workspace@latest` and when prompted, provide the 
 
  >  NX   Let's create a new workspace [https://nx.dev/getting-started/intro]
 
-✔ Choose what to create                 · angular
-✔ Application name                      · store
+✔ Where would you like to create your workspace? · store
+✔ Which stack do you want to use? · angular
+✔ Standalone project or integrated monorepo? · standalone
+✔ Default stylesheet format             · css
 ✔ Would you like to use Standalone Components in your application? · No
 ✔ Would you like to add routing? · Yes
-✔ Default stylesheet format             · css
 ✔ Enable distributed caching to make your CI faster · Yes
 ```
 

--- a/docs/shared/angular-tutorial/1-code-generation.md
+++ b/docs/shared/angular-tutorial/1-code-generation.md
@@ -31,11 +31,15 @@ Run the command `npx create-nx-workspace@latest` and when prompted, provide the 
 
 ```{% command="npx create-nx-workspace@latest" path="~" %}
 
-✔ Choose your style                     · integrated
-✔ What to create in the new workspace   · angular
-✔ Repository name                       · myorg
-✔ Application name                      · store
+ >  NX   Let's create a new workspace [https://nx.dev/getting-started/intro]
+
+✔ Where would you like to create your workspace? · myorg
+✔ Which stack do you want to use? · angular
+✔ Standalone project or integrated monorepo? · integrated
+✔ Application name · store
 ✔ Default stylesheet format             · css
+✔ Would you like to use Standalone Components in your application? · No
+✔ Would you like to add routing? · Yes
 ✔ Enable distributed caching to make your CI faster · Yes
 ```
 

--- a/docs/shared/node-server-tutorial/1-code-generation.md
+++ b/docs/shared/node-server-tutorial/1-code-generation.md
@@ -36,9 +36,13 @@ For this tutorial, you'll create an Express API application, a library that the 
 Run the command `npx create-nx-workspace@latest` and when prompted, provide the following responses:
 
 ```{% command="npx create-nx-workspace@latest" path="~" %}
-✔ Choose what to create                 · node-standalone
-✔ Application name                      · products-api
+
+ >  NX   Let's create a new workspace [https://nx.dev/getting-started/intro]
+
+✔ Where would you like to create your workspace? · products-api
+✔ Which stack do you want to use? · node
 ✔ What framework should be used? · express
+✔ Standalone project or integrated monorepo? · standalone
 ✔ Would you like to generate a Dockerfile? [https://docs.docker.com/] · Yes
 ✔ Enable distributed caching to make your CI faster · Yes
 ```

--- a/docs/shared/react-standalone-tutorial/1-code-generation.md
+++ b/docs/shared/react-standalone-tutorial/1-code-generation.md
@@ -33,10 +33,11 @@ Run the command `npx create-nx-workspace@latest` and when prompted, provide the 
 
  >  NX   Let's create a new workspace [https://nx.dev/getting-started/intro]
 
-✔ Choose what to create                 · react
-✔ Application name                      · store
+✔ Where would you like to create your workspace? · store
+✔ Which stack do you want to use? · react
 ✔ What framework would you like to use? · none
-✔ Bundler to be used to build the application · vite
+✔ Standalone project or integrated monorepo? · standalone
+✔ Which bundler would you like to use? · vite
 ✔ Default stylesheet format             · css
 ✔ Enable distributed caching to make your CI faster · Yes
 ```

--- a/docs/shared/react-tutorial/1-code-generation.md
+++ b/docs/shared/react-tutorial/1-code-generation.md
@@ -31,10 +31,14 @@ Run the command `npx create-nx-workspace@latest` and when prompted, provide the 
 
 ```{% command="npx create-nx-workspace@latest" path="~" %}
 
-✔ Choose your style                     · integrated
-✔ What to create in the new workspace   · react
-✔ Repository name                       · myorg
-✔ Application name                      · store
+ >  NX   Let's create a new workspace [https://nx.dev/getting-started/intro]
+
+✔ Where would you like to create your workspace? · myorg
+✔ Which stack do you want to use? · react
+✔ What framework would you like to use? · none
+✔ Standalone project or integrated monorepo? · integrated
+✔ Application name · store
+✔ Which bundler would you like to use? · vite
 ✔ Default stylesheet format             · css
 ✔ Enable distributed caching to make your CI faster · Yes
 ```

--- a/docs/shared/recipes/module-federation-with-ssr.md
+++ b/docs/shared/recipes/module-federation-with-ssr.md
@@ -10,10 +10,12 @@ Run the following command with the options listed to create an empty workspace.
 
 ```{% command="npx create-nx-workspace@latest" path="~" %}
 
-✔ Choose your style                     · integrated
-✔ What to create in the new workspace   · apps
-✔ Repository name                       · myorg
-✔ Enable distributed caching to make your CI faster · No
+ >  NX   Let's create a new workspace [https://nx.dev/getting-started/intro]
+
+✔ Where would you like to create your workspace? · myorg
+✔ Which stack do you want to use? · none
+✔ Package-based or integrated? · integrated
+✔ Enable distributed caching to make your CI faster · Yes
 ```
 
 {% card title="Opting into Nx Cloud" description="You will also be prompted whether to add Nx Cloud to your workspace. We won't address this in this recipe, but you can see the introduction to Nx Cloud for more details." url="/nx-cloud/intro/what-is-nx-cloud" /%}


### PR DESCRIPTION
This PR updates the tutorials to match `create-nx-workspace@16.3.0`.

Note: This should go in after the 16.3.0 release.

- React Standalone Tutorial: https://nx-dev-git-fork-jaysoo-docs-update-cnw-prompts-nrwl.vercel.app/tutorials/react-standalone-tutorial
- Angular Standalone Tutorial: https://nx-dev-git-fork-jaysoo-docs-update-cnw-prompts-nrwl.vercel.app/tutorials/angular-standalone-tutorial
- Node Standalone Tutorial: https://nx-dev-git-fork-jaysoo-docs-update-cnw-prompts-nrwl.vercel.app/tutorials/node-server-tutorial
- React Monorepo Tutorial: https://nx-dev-git-fork-jaysoo-docs-update-cnw-prompts-nrwl.vercel.app/react-tutorial/1-code-generation
- Angular Monorepo Tutorial: https://nx-dev-git-fork-jaysoo-docs-update-cnw-prompts-nrwl.vercel.app/angular-tutorial/1-code-generation
- MF with Angular and React: https://nx-dev-git-fork-jaysoo-docs-update-cnw-prompts-nrwl.vercel.app/recipes/module-federation/module-federation-with-ssr#setup-module-federation-with-ssr-for-angular-and-react