### PR TITLE
fix(core): change "minimal" stack to "none"

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -34,8 +34,8 @@ interface BaseArguments extends CreateWorkspaceOptions {
   preset: Preset;
 }
 
-interface MinimalArguments extends BaseArguments {
-  stack: 'minimal';
+interface NoneArguments extends BaseArguments {
+  stack: 'none';
   workspaceType: 'package-based' | 'integrated';
 }
 
@@ -71,7 +71,7 @@ interface UnknownStackArguments extends BaseArguments {
 }
 
 type Arguments =
-  | MinimalArguments
+  | NoneArguments
   | ReactArguments
   | AngularArguments
   | NodeArguments
@@ -309,7 +309,7 @@ async function determineFolder(
 
 async function determineStack(
   parsedArgs: yargs.Arguments<Arguments>
-): Promise<'minimal' | 'react' | 'angular' | 'node' | 'unknown'> {
+): Promise<'none' | 'react' | 'angular' | 'node' | 'unknown'> {
   if (parsedArgs.preset) {
     switch (parsedArgs.preset) {
       case Preset.Angular:
@@ -331,7 +331,7 @@ async function determineStack(
       case Preset.Empty:
       case Preset.Apps:
       case Preset.NPM:
-        return 'minimal';
+        return 'none';
       case Preset.TS:
       case Preset.WebComponents:
       case Preset.ReactNative:
@@ -342,7 +342,7 @@ async function determineStack(
   }
 
   const { stack } = await enquirer.prompt<{
-    stack: 'minimal' | 'react' | 'angular' | 'node';
+    stack: 'none' | 'react' | 'angular' | 'node';
   }>([
     {
       name: 'stack',
@@ -350,7 +350,7 @@ async function determineStack(
       type: 'autocomplete',
       choices: [
         {
-          name: `minimal`,
+          name: `none`,
           message: `None:          Configures a minimal structure without specific frameworks or technologies.`,
         },
         {
@@ -376,8 +376,8 @@ async function determinePresetOptions(
   parsedArgs: yargs.Arguments<Arguments>
 ): Promise<Partial<Arguments>> {
   switch (parsedArgs.stack) {
-    case 'minimal':
-      return determineMinimalOptions(parsedArgs);
+    case 'none':
+      return determineNoneptions(parsedArgs);
     case 'react':
       return determineReactOptions(parsedArgs);
     case 'angular':
@@ -389,7 +389,7 @@ async function determinePresetOptions(
   }
 }
 
-async function determineMinimalOptions(
+async function determineNoneptions(
   parsedArgs: yargs.Arguments<Arguments>
 ): Promise<Partial<Arguments>> {
   if (parsedArgs.preset) return parsedArgs;


### PR DESCRIPTION
This PR swaps `minimal` with `none` as the preset value, since that is what we put in the description. I just missed it when we reworded the CNW prompts.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
