### PR TITLE
feat(core): load environment variables from configuration name

### DIFF
--- a/docs/shared/guides/define-environment-variables.md
+++ b/docs/shared/guides/define-environment-variables.md
@@ -11,18 +11,22 @@ By default, Nx will load any environment variables you place in the following fi
 
 1. `apps/my-app/.env.[target-name].[configuration-name]`
 2. `apps/my-app/.[target-name].[configuration-name].env`
-3. `apps/my-app/.env.[target-name]`
-4. `apps/my-app/.[target-name].env`
-5. `apps/my-app/.env.local`
-6. `apps/my-app/.local.env`
-7. `apps/my-app/.env`
-8. `.env.[target-name].[configuration-name]`
-9. `.[target-name].[configuration-name].env`
-10. `.env.[target-name]`
-11. `.[target-name].env`
-12. `.local.env`
-13. `.env.local`
-14. `.env`
+3. `apps/my-app/.env.[configuration-name]`
+4. `apps/my-app/.[configuration-name].env`
+5. `apps/my-app/.env.[target-name]`
+6. `apps/my-app/.[target-name].env`
+7. `apps/my-app/.env.local`
+8. `apps/my-app/.local.env`
+9. `apps/my-app/.env`
+10. `.env.[target-name].[configuration-name]`
+11. `.[target-name].[configuration-name].env`
+12. `.env.[configuration-name]`
+13. `.[configuration-name].env`
+14. `.env.[target-name]`
+15. `.[target-name].env`
+16. `.local.env`
+17. `.env.local`
+18. `.env`
 
 {% callout type="warning" title="Order is important" %}
 Nx will move through the above list, ignoring files it can't find, and loading environment variables

--- a/e2e/nx-run/src/run.test.ts
+++ b/e2e/nx-run/src/run.test.ts
@@ -189,6 +189,7 @@ describe('Nx Running Tests', () => {
       const myapp = uniq('app');
       const target = uniq('script');
       const expectedOutput = uniq('myEchoedString');
+      const expectedEnvOutput = uniq('myEnvString');
 
       runCLI(`generate @nx/web:app ${myapp}`);
       updateFile(
@@ -196,12 +197,30 @@ describe('Nx Running Tests', () => {
         JSON.stringify({
           name: myapp,
           scripts: {
-            [target]: `echo ${expectedOutput}`,
+            [target]: `echo ${expectedOutput} $ENV_VAR`,
+          },
+          nx: {
+            targets: {
+              [target]: {
+                configurations: {
+                  production: {},
+                },
+              },
+            },
           },
         })
       );
 
+      updateFile(
+        `apps/${myapp}/.env.production`,
+        `ENV_VAR=${expectedEnvOutput}`
+      );
+
       expect(runCLI(`${target} ${myapp}`)).toContain(expectedOutput);
+      expect(runCLI(`${target} ${myapp}`)).not.toContain(expectedEnvOutput);
+      expect(runCLI(`${target} ${myapp} --configuration production`)).toContain(
+        expectedEnvOutput
+      );
     }, 10000);
 
     it('should run targets inferred from plugin-specified project files', () => {

--- a/packages/nx/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/nx/src/tasks-runner/forked-process-task-runner.ts
@@ -424,10 +424,16 @@ export class ForkedProcessTaskRunner {
         ...parseEnv(`.${task.target.target}.env`),
         ...parseEnv(`.env.${task.target.target}`),
         ...(task.target.configuration
-          ? parseEnv(`.${task.target.target}.${task.target.configuration}.env`)
-          : {}),
-        ...(task.target.configuration
-          ? parseEnv(`.env.${task.target.target}.${task.target.configuration}`)
+          ? {
+              ...parseEnv(`.${task.target.configuration}.env`),
+              ...parseEnv(
+                `.${task.target.target}.${task.target.configuration}.env`
+              ),
+              ...parseEnv(`.env.${task.target.configuration}`),
+              ...parseEnv(
+                `.env.${task.target.target}.${task.target.configuration}`
+              ),
+            }
           : {}),
         ...parseEnv(`${task.projectRoot}/.env`),
         ...parseEnv(`${task.projectRoot}/.local.env`),
@@ -435,14 +441,20 @@ export class ForkedProcessTaskRunner {
         ...parseEnv(`${task.projectRoot}/.${task.target.target}.env`),
         ...parseEnv(`${task.projectRoot}/.env.${task.target.target}`),
         ...(task.target.configuration
-          ? parseEnv(
-              `${task.projectRoot}/.${task.target.target}.${task.target.configuration}.env`
-            )
-          : {}),
-        ...(task.target.configuration
-          ? parseEnv(
-              `${task.projectRoot}/.env.${task.target.target}.${task.target.configuration}`
-            )
+          ? {
+              ...parseEnv(
+                `${task.projectRoot}/.${task.target.configuration}.env`
+              ),
+              ...parseEnv(
+                `${task.projectRoot}/.${task.target.target}.${task.target.configuration}.env`
+              ),
+              ...parseEnv(
+                `${task.projectRoot}/.env.${task.target.configuration}`
+              ),
+              ...parseEnv(
+                `${task.projectRoot}/.env.${task.target.target}.${task.target.configuration}`
+              ),
+            }
           : {}),
       };
     } else {

--- a/packages/nx/src/utils/project-graph-utils.ts
+++ b/packages/nx/src/utils/project-graph-utils.ts
@@ -1,10 +1,9 @@
 import { buildTargetFromScript, PackageJson } from './package-json';
 import { join } from 'path';
 import { ProjectGraph, ProjectGraphProjectNode } from '../config/project-graph';
-import { fileExists, readJsonFile } from './fileutils';
+import { readJsonFile } from './fileutils';
 import { readCachedProjectGraph } from '../project-graph/project-graph';
 import { TargetConfiguration } from '../config/workspace-json-project-json';
-import { workspaceRoot } from './workspace-root';
 
 export function projectHasTarget(
   project: ProjectGraphProjectNode,
@@ -23,28 +22,9 @@ export function projectHasTargetAndConfiguration(
   configuration: string
 ) {
   return (
-    // Explicitly defined target + configuration
-    (projectHasTarget(project, target) &&
-      project.data.targets[target].configurations &&
-      project.data.targets[target].configurations[configuration]) ||
-    // Inferred configuration from presence of .env files
-    (projectHasTarget(project, target) &&
-      [
-        join(workspaceRoot, `.env.${configuration}`),
-        join(workspaceRoot, `.${configuration}.env`),
-        join(workspaceRoot, project.data.root, `.env.${configuration}`),
-        join(workspaceRoot, project.data.root, `.${configuration}.env`),
-        join(
-          workspaceRoot,
-          project.data.root,
-          `.env.${target}.${configuration}`
-        ),
-        join(
-          workspaceRoot,
-          project.data.root,
-          `.${target}.${configuration}.env`
-        ),
-      ].some(fileExists))
+    projectHasTarget(project, target) &&
+    project.data.targets[target].configurations &&
+    project.data.targets[target].configurations[configuration]
   );
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

Adds support for loading environment variables from .env.[configurationName] and .[configurationName].env

Fixes: #17686 