### PR TITLE
feat(core): deprecate print-affected and affected:graph

### DIFF
--- a/docs/generated/cli/affected-graph.md
+++ b/docs/generated/cli/affected-graph.md
@@ -5,6 +5,8 @@ description: 'Graph dependencies affected by changes'
 
 # affected:graph
 
+**Deprecated:** Use `nx graph --affected`, or` nx affected --graph` instead depending on which best suits your use case. The `affected:graph` command will be removed in Nx 18.
+
 Graph dependencies affected by changes
 
 ## Usage

--- a/docs/generated/cli/print-affected.md
+++ b/docs/generated/cli/print-affected.md
@@ -5,6 +5,8 @@ description: 'Prints information about the projects and targets affected by chan
 
 # print-affected
 
+**Deprecated:** Use `nx show --affected`, `nx affected --graph` or `nx graph --affected` depending on which best suits your use case. The `print-affected` command will be removed in Nx 18.
+
 Prints information about the projects and targets affected by changes
 
 ## Usage

--- a/docs/generated/packages/nx/documents/affected-dep-graph.md
+++ b/docs/generated/packages/nx/documents/affected-dep-graph.md
@@ -5,6 +5,8 @@ description: 'Graph dependencies affected by changes'
 
 # affected:graph
 
+**Deprecated:** Use `nx graph --affected`, or` nx affected --graph` instead depending on which best suits your use case. The `affected:graph` command will be removed in Nx 18.
+
 Graph dependencies affected by changes
 
 ## Usage

--- a/docs/generated/packages/nx/documents/print-affected.md
+++ b/docs/generated/packages/nx/documents/print-affected.md
@@ -5,6 +5,8 @@ description: 'Prints information about the projects and targets affected by chan
 
 # print-affected
 
+**Deprecated:** Use `nx show --affected`, `nx affected --graph` or `nx graph --affected` depending on which best suits your use case. The `print-affected` command will be removed in Nx 18.
+
 Prints information about the projects and targets affected by changes
 
 ## Usage

--- a/packages/nx/src/command-line/affected/affected.ts
+++ b/packages/nx/src/command-line/affected/affected.ts
@@ -23,6 +23,8 @@ import { workspaceConfigurationCheck } from '../../utils/workspace-configuration
 import { findMatchingProjects } from '../../utils/find-matching-projects';
 import { generateGraph } from '../graph/graph';
 import { allFileData } from '../../utils/all-file-data';
+import { NX_PREFIX, logger } from '../../utils/logger';
+import { affectedGraphDeprecationMessage } from './command-object';
 
 export async function affected(
   command: 'graph' | 'print-affected' | 'affected',
@@ -59,6 +61,7 @@ export async function affected(
   try {
     switch (command) {
       case 'graph':
+        logger.warn([NX_PREFIX, affectedGraphDeprecationMessage].join(' '));
         const projectNames = projects.map((p) => p.name);
         await generateGraph(args as any, projectNames);
         break;

--- a/packages/nx/src/command-line/affected/command-object.ts
+++ b/packages/nx/src/command-line/affected/command-object.ts
@@ -105,6 +105,11 @@ export const yargsAffectedE2ECommand: CommandModule = {
     }),
 };
 
+export const affectedGraphDeprecationMessage =
+  'Use `nx graph --affected`, or` nx affected --graph` instead depending on which best suits your use case. The `affected:graph` command will be removed in Nx 18.';
+/**
+ * @deprecated 'Use `nx graph --affected`, or` nx affected --graph` instead depending on which best suits your use case. The `affected:graph` command will be removed in Nx 18.'
+ */
 export const yargsAffectedGraphCommand: CommandModule = {
   command: 'affected:graph',
   describe: 'Graph dependencies affected by changes',
@@ -120,8 +125,14 @@ export const yargsAffectedGraphCommand: CommandModule = {
     ).affected('graph', {
       ...args,
     }),
+  deprecated: affectedGraphDeprecationMessage,
 };
 
+export const printAffectedDeprecationMessage =
+  'Use `nx show --affected`, `nx affected --graph` or `nx graph --affected` depending on which best suits your use case. The `print-affected` command will be removed in Nx 18.';
+/**
+ * @deprecated 'Use `nx show --affected`, `nx affected --graph` or `nx graph --affected` depending on which best suits your use case. The `print-affected` command will be removed in Nx 18.'
+ */
 export const yargsPrintAffectedCommand: CommandModule = {
   command: 'print-affected',
   describe:
@@ -148,4 +159,5 @@ export const yargsPrintAffectedCommand: CommandModule = {
     ).affected('print-affected', withOverrides(args));
     process.exit(0);
   },
+  deprecated: printAffectedDeprecationMessage,
 };

--- a/packages/nx/src/command-line/affected/print-affected.ts
+++ b/packages/nx/src/command-line/affected/print-affected.ts
@@ -13,7 +13,12 @@ import { hashTask } from '../../hasher/hash-task';
 import { workspaceRoot } from '../../utils/workspace-root';
 import { getPackageManagerCommand } from '../../utils/package-manager';
 import { fileHasher } from '../../hasher/impl';
+import { printAffectedDeprecationMessage } from './command-object';
+import { logger, NX_PREFIX } from '../../utils/logger';
 
+/**
+ * @deprecated Use showProjectsHandler, generateGraph, or affected (without the print-affected mode) instead.
+ */
 export async function printAffected(
   affectedProjects: ProjectGraphProjectNode[],
   projectGraph: ProjectGraph,
@@ -21,6 +26,7 @@ export async function printAffected(
   nxArgs: NxArgs,
   overrides: yargs.Arguments
 ) {
+  logger.warn([NX_PREFIX, printAffectedDeprecationMessage].join(' '));
   const projectsForType = affectedProjects.filter((p) =>
     nxArgs.type ? p.type === nxArgs.type : true
   );


### PR DESCRIPTION
print-affected and affected:graph have been replaced by:
- `show projects --affected`
- `nx graph --affected`
- `nx affected -t build --graph`