### PR TITLE
fix(js): do not overwrite supported typescript version

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -49,6 +49,7 @@
     "ignore": "^5.0.4",
     "js-tokens": "^4.0.0",
     "minimatch": "3.0.5",
+    "semver": "7.3.4",
     "source-map-support": "0.5.19",
     "tslib": "^2.3.0",
     "@nx/devkit": "file:../devkit",

--- a/packages/js/src/utils/versions.ts
+++ b/packages/js/src/utils/versions.ts
@@ -8,5 +8,13 @@ export const swcHelpersVersion = '~0.5.0';
 export const swcNodeVersion = '~1.4.2';
 export const tsLibVersion = '^2.3.0';
 export const typesNodeVersion = '18.7.1';
-export const typescriptVersion = '~5.0.2';
 export const verdaccioVersion = '^5.0.4';
+
+// Typescript
+export const typescriptVersion = '~5.0.2';
+/**
+ * The minimum version is currently determined from the lowest version
+ * that's supported by the lowest Angular supported version, e.g.
+ * `npm view @angular/compiler-cli@14.0.0 peerDependencies.typescript`
+ */
+export const supportedTypescriptVersions = '>=4.6.2';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `@nx/js:init` generator always sets the `typescript` package version to the latest supported version. This causes issues where an older supported version is needed in the workspace (e.g. when using an older supported version of Angular).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `@nx/js:init` generator should not overwrite the `typescript` package version if it's a supported version.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17344 
