### PR TITLE
fix(angular): do not overwrite ng-packagr version if already installed

### DIFF
--- a/packages/angular/src/generators/library/library.ts
+++ b/packages/angular/src/generators/library/library.ts
@@ -1,10 +1,8 @@
 import {
-  addDependenciesToPackageJson,
   formatFiles,
   GeneratorCallback,
   installPackagesTask,
   joinPathFragments,
-  removeDependenciesFromPackageJson,
   Tree,
 } from '@nx/devkit';
 import { jestProjectGenerator } from '@nx/jest';
@@ -16,6 +14,7 @@ import { E2eTestRunner } from '../../utils/test-runners';
 import addLintingGenerator from '../add-linting/add-linting';
 import setupTailwindGenerator from '../setup-tailwind/setup-tailwind';
 import {
+  addDependenciesToPackageJsonIfDontExist,
   getInstalledAngularVersionInfo,
   versions,
 } from '../utils/version-utils';
@@ -97,8 +96,7 @@ export async function libraryGenerator(
   }
 
   if (libraryOptions.buildable || libraryOptions.publishable) {
-    removeDependenciesFromPackageJson(tree, [], ['ng-packagr']);
-    addDependenciesToPackageJson(
+    addDependenciesToPackageJsonIfDontExist(
       tree,
       {},
       {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Whenever an Angular buildable/publishable library is generated, the `ng-packagr` version is overwritten with the latest supported version. This causes issues where an older supported version is already installed.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Generating a buildable/publishable library should only add `ng-packagr` if it's not installed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
