### PR TITLE
fix(storybook): transform unsupported options to camelCase

### DIFF
--- a/packages/storybook/src/executors/build-storybook/build-storybook.impl.ts
+++ b/packages/storybook/src/executors/build-storybook/build-storybook.impl.ts
@@ -3,6 +3,7 @@ import * as build from '@storybook/core-server';
 import { CLIOptions } from '@storybook/types';
 import 'dotenv/config';
 import {
+  convertKeysToCamelCase,
   pleaseUpgrade,
   storybookConfigExistsCheck,
   storybookMajorVersion,
@@ -17,7 +18,7 @@ export default async function buildStorybookExecutor(
   storybookConfigExistsCheck(options.configDir, context.projectName);
   const storybook7 = storybookMajorVersion() === 7;
   if (storybook7) {
-    const buildOptions: CLIOptions = options;
+    const buildOptions: CLIOptions = convertKeysToCamelCase(options);
     logger.info(`NX Storybook builder starting ...`);
     await runInstance(buildOptions, storybook7);
     logger.info(`NX Storybook builder finished ...`);

--- a/packages/storybook/src/executors/storybook/storybook.impl.ts
+++ b/packages/storybook/src/executors/storybook/storybook.impl.ts
@@ -2,6 +2,7 @@ import { ExecutorContext, logger } from '@nx/devkit';
 import * as build from '@storybook/core-server';
 import 'dotenv/config';
 import {
+  convertKeysToCamelCase,
   pleaseUpgrade,
   storybookConfigExistsCheck,
   storybookMajorVersion,
@@ -20,7 +21,7 @@ export default async function* storybookExecutor(
   const storybook7 = storybookMajorVersion() === 7;
   storybookConfigExistsCheck(options.configDir, context.projectName);
   if (storybook7) {
-    const buildOptions: CLIOptions = options;
+    const buildOptions: CLIOptions = convertKeysToCamelCase(options);
     const result = await runInstance(buildOptions, storybook7);
     yield {
       success: true,

--- a/packages/storybook/src/utils/utilities.spec.ts
+++ b/packages/storybook/src/utils/utilities.spec.ts
@@ -7,6 +7,7 @@ import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import {
   findStorybookAndBuildTargetsAndCompiler,
   isTheFileAStory,
+  convertKeysToCamelCase,
 } from './utilities';
 import { nxVersion, storybookVersion } from './versions';
 import * as targetVariations from './test-configs/different-target-variations.json';
@@ -209,6 +210,30 @@ describe('testing utilities', () => {
         );
         expect(fileIsStory).toBeFalsy();
       });
+    });
+  });
+
+  describe('Test convertKeysToCamelCase', () => {
+    it('should convert keys to camel case', () => {
+      const object = {
+        ['static-dir']: 'static',
+        ['config-dir']: '.storybook',
+        ['webpack-stats-json']: true,
+        ['disable-telemetry']: true,
+        ['debug-webpack']: false,
+        ['smokeTest']: false,
+      };
+
+      const result = {
+        staticDir: 'static',
+        configDir: '.storybook',
+        webpackStatsJson: true,
+        disableTelemetry: true,
+        debugWebpack: false,
+        smokeTest: false,
+      };
+
+      expect(convertKeysToCamelCase(object)).toMatchObject(result);
     });
   });
 

--- a/packages/storybook/src/utils/utilities.ts
+++ b/packages/storybook/src/utils/utilities.ts
@@ -267,3 +267,23 @@ export function pleaseUpgrade(): string {
     https://nx.dev/packages/storybook/generators/migrate-7
     `;
 }
+
+export function convertKeysToCamelCase(options: object): object {
+  if (typeof options !== 'object' || options === null) {
+    return options;
+  }
+
+  if (Array.isArray(options)) {
+    return options.map(convertKeysToCamelCase);
+  }
+
+  return Object.keys(options).reduce((result, key) => {
+    const value = options[key];
+    const camelCaseKey = key.replace(/[-_]([a-zA-Z])/g, (_, letter) =>
+      letter.toUpperCase()
+    );
+
+    result[camelCaseKey] = convertKeysToCamelCase(value);
+    return result;
+  }, {});
+}


### PR DESCRIPTION
Do not merge yet plz. It's ready for review, but I'm not sure yet if it's the best solution. See this PR too: https://github.com/nrwl/nx/pull/17358.  Either this or the other one should be merged. Not both.

## Current Behavior

Extra args are not converted to camelCase ([ref](https://github.com/nrwl/nx/pull/10347)). So, for example, `--webpack-stats-json` will be passed as `webpack-stats-json` to the Storybook builders. This results in the Storybook builders ignoring it, since they expect `webpackStatsJson` instead.

## Expected Behavior

Not sure, but here I am transforming the kebab-case to camelCase. When I say "not sure" I mean that I am not sure if this is indeed the expected behaviour.

