### PR TITLE
fix(storybook): add all Storybook CLI options to schema

### DIFF
--- a/docs/generated/packages/storybook/executors/build.json
+++ b/docs/generated/packages/storybook/executors/build.json
@@ -101,6 +101,19 @@
           "@storybook/svelte"
         ],
         "x-deprecated": "Upgrade to Storybook 7."
+      },
+      "webpackStatsJson": {
+        "type": ["boolean", "string"],
+        "description": "Write Webpack Stats JSON to disk.",
+        "default": false
+      },
+      "debugWebpack": {
+        "type": "boolean",
+        "description": "Display final webpack configurations for debugging purposes."
+      },
+      "disableTelemetry": {
+        "type": "boolean",
+        "description": "Disables Storybook's telemetry."
       }
     },
     "definitions": {

--- a/docs/generated/packages/storybook/executors/storybook.json
+++ b/docs/generated/packages/storybook/executors/storybook.json
@@ -79,6 +79,39 @@
           "@storybook/svelte"
         ],
         "x-deprecated": "Upgrade to Storybook 7."
+      },
+      "webpackStatsJson": {
+        "type": ["boolean", "string"],
+        "description": "Write Webpack Stats JSON to disk.",
+        "default": false
+      },
+      "sslCa": {
+        "type": "string",
+        "description": "Provide an SSL certificate authority. (Optional with --https, required if using a self-signed certificate)."
+      },
+      "sslCert": {
+        "type": "string",
+        "description": "Provide an SSL certificate. (Required with --https)."
+      },
+      "sslKey": {
+        "type": "string",
+        "description": "Provide an SSL key. (Required with --https)."
+      },
+      "smokeTest": {
+        "type": "boolean",
+        "description": "Exit after successful start."
+      },
+      "noOpen": {
+        "type": "boolean",
+        "description": "Do not open Storybook automatically in the browser."
+      },
+      "debugWebpack": {
+        "type": "boolean",
+        "description": "Display final webpack configurations for debugging purposes."
+      },
+      "disableTelemetry": {
+        "type": "boolean",
+        "description": "Disables Storybook's telemetry."
       }
     },
     "additionalProperties": true,

--- a/packages/storybook/src/executors/build-storybook/schema.json
+++ b/packages/storybook/src/executors/build-storybook/schema.json
@@ -81,6 +81,19 @@
         "@storybook/svelte"
       ],
       "x-deprecated": "Upgrade to Storybook 7."
+    },
+    "webpackStatsJson": {
+      "type": ["boolean", "string"],
+      "description": "Write Webpack Stats JSON to disk.",
+      "default": false
+    },
+    "debugWebpack": {
+      "type": "boolean",
+      "description": "Display final webpack configurations for debugging purposes."
+    },
+    "disableTelemetry": {
+      "type": "boolean",
+      "description": "Disables Storybook's telemetry."
     }
   },
   "definitions": {

--- a/packages/storybook/src/executors/storybook/schema.json
+++ b/packages/storybook/src/executors/storybook/schema.json
@@ -84,6 +84,39 @@
         "@storybook/svelte"
       ],
       "x-deprecated": "Upgrade to Storybook 7."
+    },
+    "webpackStatsJson": {
+      "type": ["boolean", "string"],
+      "description": "Write Webpack Stats JSON to disk.",
+      "default": false
+    },
+    "sslCa": {
+      "type": "string",
+      "description": "Provide an SSL certificate authority. (Optional with --https, required if using a self-signed certificate)."
+    },
+    "sslCert": {
+      "type": "string",
+      "description": "Provide an SSL certificate. (Required with --https)."
+    },
+    "sslKey": {
+      "type": "string",
+      "description": "Provide an SSL key. (Required with --https)."
+    },
+    "smokeTest": {
+      "type": "boolean",
+      "description": "Exit after successful start."
+    },
+    "noOpen": {
+      "type": "boolean",
+      "description": "Do not open Storybook automatically in the browser."
+    },
+    "debugWebpack": {
+      "type": "boolean",
+      "description": "Display final webpack configurations for debugging purposes."
+    },
+    "disableTelemetry": {
+      "type": "boolean",
+      "description": "Disables Storybook's telemetry."
     }
   },
   "additionalProperties": true,


### PR DESCRIPTION
Do not merge yet plz. It's ready for review, but I'm not sure yet if it's the best solution. See this PR too: https://github.com/nrwl/nx/pull/17357. Either this or the other one should be merged. Not both.

## Current Behavior

Extra args are not converted to camelCase ([ref](https://github.com/nrwl/nx/pull/10347)). So, for example, `--webpack-stats-json` will be passed as `webpack-stats-json` to the Storybook builders. This results in the Storybook builders ignoring it, since they expect `webpackStatsJson` instead.

## Expected Behavior

Not sure. But here I am adding all of the multi-word (kebab-cased) [Storybook CLI options](https://storybook.js.org/docs/react/api/cli-options) to our schema, just to make sure they will get picked up and transformed. When I say "not sure" I mean that I am not sure if this is indeed the expected behaviour.

