### PR TITLE
fix(core): reorganize global installation check for better clarity

### DIFF
--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -56,7 +56,7 @@ function main() {
     }
 
     if (!workspace) {
-      handleNoWorkspace();
+      handleNoWorkspace(GLOBAL_NX_VERSION);
     }
 
     if (!localNx) {
@@ -79,7 +79,7 @@ function main() {
   }
 }
 
-function handleNoWorkspace() {
+function handleNoWorkspace(globalNxVersion?: string) {
   output.log({
     title: `The current directory isn't part of an Nx workspace.`,
     bodyLines: [
@@ -94,6 +94,9 @@ function handleNoWorkspace() {
   output.note({
     title: `For more information please visit https://nx.dev/`,
   });
+
+  warnIfUsingOutdatedGlobalInstall(globalNxVersion);
+
   process.exit(1);
 }
 
@@ -169,12 +172,10 @@ function warnIfUsingOutdatedGlobalInstall(
     return;
   }
 
-  const isOutdatedGlobalInstall =
-    globalNxVersion &&
-    ((localNxVersion && major(globalNxVersion) < major(localNxVersion)) ||
-      (!localNxVersion &&
-        getLatestVersionOfNx() &&
-        major(globalNxVersion) < major(getLatestVersionOfNx())));
+  const isOutdatedGlobalInstall = checkOutdatedGlobalInstallation(
+    globalNxVersion,
+    localNxVersion
+  );
 
   // Using a global Nx Install
   if (isOutdatedGlobalInstall) {
@@ -191,6 +192,29 @@ function warnIfUsingOutdatedGlobalInstall(
       title: `Its time to update Nx 🎉`,
       bodyLines,
     });
+  }
+}
+
+function checkOutdatedGlobalInstallation(
+  globalNxVersion?: string,
+  localNxVersion?: string
+) {
+  // We aren't running a global install, so we can't know if its outdated.
+  if (!globalNxVersion) {
+    return false;
+  }
+  if (localNxVersion) {
+    // If the global Nx install is at least a major version behind the local install, warn.
+    return major(globalNxVersion) < major(localNxVersion);
+  }
+  // No local installation was detected. This can happen if the user is running a global install
+  // that contains an older version of Nx, which is unable to detect the local installation. The most
+  // recent case where this would have happened would be when we stopped generating workspace.json by default,
+  // as older global installations used it to determine the workspace root. This only be hit in rare cases,
+  // but can provide valuable insights for troubleshooting.
+  const latestVersionOfNx = getLatestVersionOfNx();
+  if (latestVersionOfNx && major(globalNxVersion) < major(latestVersionOfNx)) {
+    return true;
   }
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
- The check for outdated global install when there is not a workspace detected isnt getting hit properly (exit(1) happens before it)
- The condition for `isOutdatedGlobalInstall` is hard to understand and digest since it is a long boolean operation.

## Expected Behavior
- Checks are hit properly
- Its easy to understand how / why / when each branch of the logic is hit.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
