### PR TITLE
fix(angular): dynamic host should not generate webpack.prod.config.js

### DIFF
--- a/packages/angular/src/generators/setup-mf/lib/setup-host-if-dynamic.ts
+++ b/packages/angular/src/generators/setup-mf/lib/setup-host-if-dynamic.ts
@@ -1,5 +1,9 @@
 import type { Tree } from '@nx/devkit';
-import { joinPathFragments, readProjectConfiguration } from '@nx/devkit';
+import {
+  joinPathFragments,
+  readProjectConfiguration,
+  updateProjectConfiguration,
+} from '@nx/devkit';
 import type { Schema } from '../schema';
 
 export function setupHostIfDynamic(tree: Tree, options: Schema) {
@@ -7,12 +11,25 @@ export function setupHostIfDynamic(tree: Tree, options: Schema) {
     return;
   }
 
+  const project = readProjectConfiguration(tree, options.appName);
   const pathToMFManifest = joinPathFragments(
-    readProjectConfiguration(tree, options.appName).sourceRoot,
+    project.sourceRoot,
     'assets/module-federation.manifest.json'
   );
 
   if (!tree.exists(pathToMFManifest)) {
     tree.write(pathToMFManifest, '{}');
   }
+
+  const pathToProdWebpackConfig = joinPathFragments(
+    project.root,
+    'webpack.prod.config.js'
+  );
+  if (tree.exists(pathToProdWebpackConfig)) {
+    tree.delete(pathToProdWebpackConfig);
+  }
+
+  delete project.targets.build.configurations.production?.customWebpackConfig;
+
+  updateProjectConfiguration(tree, options.appName, project);
 }

--- a/packages/angular/src/generators/setup-mf/setup-mf.spec.ts
+++ b/packages/angular/src/generators/setup-mf/setup-mf.spec.ts
@@ -135,6 +135,20 @@ describe('Init MF', () => {
     }
   );
 
+  it('should not generate a webpack prod file for dynamic host', async () => {
+    // ACT
+    await setupMf(tree, {
+      appName: 'app1',
+      mfType: 'host',
+      federationType: 'dynamic',
+    });
+
+    // ASSERT
+    const { build } = readProjectConfiguration(tree, 'app1').targets;
+    expect(tree.exists('apps/app1/webpack.prod.config.js')).toBeFalsy();
+    expect(build.configurations.production.customWebpackConfig).toBeUndefined();
+  });
+
   it('should generate the remote entry module and component correctly', async () => {
     // ACT
     await setupMf(tree, {

--- a/packages/angular/src/generators/setup-mf/setup-mf.ts
+++ b/packages/angular/src/generators/setup-mf/setup-mf.ts
@@ -36,11 +36,6 @@ export async function setupMf(tree: Tree, rawOptions: Schema) {
   const options = normalizeOptions(tree, rawOptions);
   const projectConfig = readProjectConfiguration(tree, options.appName);
 
-  if (options.mfType === 'host') {
-    setupHostIfDynamic(tree, options);
-    updateHostAppRoutes(tree, options);
-  }
-
   let installTask = () => {};
   if (options.mfType === 'remote') {
     addRemoteToHost(tree, options);
@@ -62,6 +57,11 @@ export async function setupMf(tree: Tree, rawOptions: Schema) {
   setupServeTarget(tree, options);
 
   fixBootstrap(tree, projectConfig.root, options);
+
+  if (options.mfType === 'host') {
+    setupHostIfDynamic(tree, options);
+    updateHostAppRoutes(tree, options);
+  }
 
   if (!options.skipE2E) {
     addCypressOnErrorWorkaround(tree, options);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We generate a webpack.prod.config.js for dynamic hosts. It's not necessary. The purpose of the webpack.prod.config.js is to overwrite the remote's locations. With dynamic federation, the module-federation.manifest.json is the source of truth for the remote's location and is fetched at runtime. This will be different per env, removing the need for webpack.prod.config.js.
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Do not generate webpack.prod.config.js for dynamic hosts and change the production configuration to point to the single webpack.config.js

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17378
