### PR TITLE
docs(core): expand json examples

### DIFF
--- a/docs/shared/reference/project-configuration.md
+++ b/docs/shared/reference/project-configuration.md
@@ -174,15 +174,17 @@ Targets that only use commands natively available in the terminal will not depen
 
 ```json
 {
-  "copyFiles": {
-    "inputs": [
-      {
-        "externalDependencies": []
+  "targets": {
+    "copyFiles": {
+      "inputs": [
+        {
+          "externalDependencies": []
+        }
+      ],
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "cp src/assets dist"
       }
-    ],
-    "executor": "nx:run-commands",
-    "options": {
-      "command": "cp src/assets dist"
     }
   }
 }
@@ -192,15 +194,17 @@ If a target uses a command from a npm package, that package should be listed.
 
 ```json
 {
-  "copyFiles": {
-    "inputs": [
-      {
-        "externalDependencies": ["lerna"]
+  "targets": {
+    "copyFiles": {
+      "inputs": [
+        {
+          "externalDependencies": ["lerna"]
+        }
+      ],
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npx lerna publish"
       }
-    ],
-    "executor": "nx:run-commands",
-    "options": {
-      "command": "npx lerna publish"
     }
   }
 }
@@ -227,9 +231,13 @@ Examples:
 Similar to `dependsOn`, the "^" symbols means "dependencies". This is a very important idea, so let's illustrate it with
 an example.
 
-```
-"test": {
-  "inputs": [ "default", "^production" ]
+```json
+{
+  "targets": {
+    "test": {
+      "inputs": ["default", "^production"]
+    }
+  }
 }
 ```
 
@@ -260,11 +268,13 @@ Usually, a target writes to a specific directory or a file. The following instru
 
 ```json
 {
-  "build": {
-    "outputs": [
-      "{workspaceRoot}/dist/libs/mylib",
-      "{workspaceRoot}/build/libs/mylib/main.js"
-    ]
+  "targets": {
+    "build": {
+      "outputs": [
+        "{workspaceRoot}/dist/libs/mylib",
+        "{workspaceRoot}/build/libs/mylib/main.js"
+      ]
+    }
   }
 }
 ```
@@ -275,11 +285,13 @@ Sometimes, multiple targets might write to the same directory. When possible it 
 
 ```json
 {
-  "build-js": {
-    "outputs": ["{workspaceRoot}/dist/libs/mylib/js"]
-  },
-  "build-css": {
-    "outputs": ["{workspaceRoot}/dist/libs/mylib/css"]
+  "targets": {
+    "build-js": {
+      "outputs": ["{workspaceRoot}/dist/libs/mylib/js"]
+    },
+    "build-css": {
+      "outputs": ["{workspaceRoot}/dist/libs/mylib/css"]
+    }
   }
 }
 ```
@@ -288,11 +300,13 @@ But if the above is not possible, globs (parsed with the [minimatch](https://git
 
 ```json
 {
-  "build-js": {
-    "outputs": ["{workspaceRoot}/dist/libs/mylib/**/*.js"]
-  },
-  "build-css": {
-    "outputs": ["{workspaceRoot}/dist/libs/mylib/**/*.css"]
+  "targets": {
+    "build-js": {
+      "outputs": ["{workspaceRoot}/dist/libs/mylib/**/*.js"]
+    },
+    "build-css": {
+      "outputs": ["{workspaceRoot}/dist/libs/mylib/**/*.css"]
+    }
   }
 }
 ```
@@ -302,11 +316,15 @@ But if the above is not possible, globs (parsed with the [minimatch](https://git
 Targets can depend on other targets. This is the relevant portion of the configuration file:
 
 ```json
-"build": {
-  "dependsOn": ["^build"]
-},
-"test": {
-  "dependsOn": ["build"]
+{
+  "targets": {
+    "build": {
+      "dependsOn": ["^build"]
+    },
+    "test": {
+      "dependsOn": ["build"]
+    }
+  }
 }
 ```
 
@@ -328,12 +346,18 @@ You can also express task dependencies with an object syntax:
 {% tab label="Version < 16" %}
 
 ```json
-"build": {
-  "dependsOn": [{
-    "projects": "dependencies", // "dependencies" or "self"
-    "target": "build", // target name
-    "params": "ignore" // "forward" or "ignore", defaults to "ignore"
-  }]
+{
+  "targets": {
+    "build": {
+      "dependsOn": [
+        {
+          "projects": "dependencies", // "dependencies" or "self"
+          "target": "build", // target name
+          "params": "ignore" // "forward" or "ignore", defaults to "ignore"
+        }
+      ]
+    }
+  }
 }
 ```
 
@@ -341,11 +365,17 @@ You can also express task dependencies with an object syntax:
 {% tab label="Version 16+ (self)" %}
 
 ```json
-"build": {
-  "dependsOn": [{
-    "target": "build", // target name
-    "params": "ignore" // "forward" or "ignore", defaults to "ignore"
-  }]
+{
+  "targets": {
+    "build": {
+      "dependsOn": [
+        {
+          "target": "build", // target name
+          "params": "ignore" // "forward" or "ignore", defaults to "ignore"
+        }
+      ]
+    }
+  }
 }
 ```
 
@@ -353,12 +383,18 @@ You can also express task dependencies with an object syntax:
 {% tab label="Version 16+ (dependencies)" %}
 
 ```json
-"build": {
-  "dependsOn": [{
-    "dependencies": true, // Run this target on all dependencies first
-    "target": "build", // target name
-    "params": "ignore" // "forward" or "ignore", defaults to "ignore"
-  }]
+{
+  "targets": {
+    "build": {
+      "dependsOn": [
+        {
+          "dependencies": true, // Run this target on all dependencies first
+          "target": "build", // target name
+          "params": "ignore" // "forward" or "ignore", defaults to "ignore"
+        }
+      ]
+    }
+  }
 }
 ```
 
@@ -366,12 +402,18 @@ You can also express task dependencies with an object syntax:
 {% tab label="Version 16+ (specific projects)" %}
 
 ```json
-"build": {
-  "dependsOn": [{
-    "projects": ["my-app"], // Run build on "my-app" first
-    "target": "build", // target name
-    "params": "ignore" // "forward" or "ignore", defaults to "ignore"
-  }]
+{
+  "targets": {
+    "build": {
+      "dependsOn": [
+        {
+          "projects": ["my-app"], // Run build on "my-app" first
+          "target": "build", // target name
+          "params": "ignore" // "forward" or "ignore", defaults to "ignore"
+        }
+      ]
+    }
+  }
 }
 ```
 
@@ -386,11 +428,15 @@ You can write the shorthand configuration above in the object syntax like this:
 {% tab label="Version < 16" %}
 
 ```json
-"build": {
-  "dependsOn": [{ "projects": "dependencies", "target": "build" }]
-},
-"test": {
-  "dependsOn": [{ "projects": "self", "target": "build" }]
+{
+  "targets": {
+    "build": {
+      "dependsOn": [{ "projects": "dependencies", "target": "build" }]
+    },
+    "test": {
+      "dependsOn": [{ "projects": "self", "target": "build" }]
+    }
+  }
 }
 ```
 
@@ -398,11 +444,15 @@ You can write the shorthand configuration above in the object syntax like this:
 {% tab label="Version 16+" %}
 
 ```json
-"build": {
-  "dependsOn": [{ "dependencies": true, "target": "build" }] // Run build on my dependencies first
-},
-"test": {
-  "dependsOn": [{ "target": "build" }] // Run build on myself first
+{
+  "targets": {
+    "build": {
+      "dependsOn": [{ "dependencies": true, "target": "build" }] // Run build on my dependencies first
+    },
+    "test": {
+      "dependsOn": [{ "target": "build" }] // Run build on myself first
+    }
+  }
 }
 ```
 
@@ -415,17 +465,25 @@ With the expanded syntax, you also have a third option available to configure ho
 {% tab label="Version < 16" %}
 
 ```json
-"build": {
-   // forward params passed to this target to the dependency targets
-  "dependsOn": [{ "projects": "dependencies", "target": "build", "params": "forward" }]
-},
-"test": {
-  // ignore params passed to this target, won't be forwarded to the dependency targets
-  "dependsOn": [{ "projects": "dependencies", "target": "build", "params": "ignore" }]
-}
-"lint": {
-  // ignore params passed to this target, won't be forwarded to the dependency targets
-  "dependsOn": [{ "projects": "dependencies", "target": "build" }]
+{
+  "targets": {
+    "build": {
+      // forward params passed to this target to the dependency targets
+      "dependsOn": [
+        { "projects": "dependencies", "target": "build", "params": "forward" }
+      ]
+    },
+    "test": {
+      // ignore params passed to this target, won't be forwarded to the dependency targets
+      "dependsOn": [
+        { "projects": "dependencies", "target": "build", "params": "ignore" }
+      ]
+    },
+    "lint": {
+      // ignore params passed to this target, won't be forwarded to the dependency targets
+      "dependsOn": [{ "projects": "dependencies", "target": "build" }]
+    }
+  }
 }
 ```
 
@@ -433,17 +491,25 @@ With the expanded syntax, you also have a third option available to configure ho
 {% tab label="Version 16+" %}
 
 ```json
-"build": {
-   // forward params passed to this target to the dependency targets
-  "dependsOn": [{ "projects": "{dependencies}", "target": "build", "params": "forward" }]
-},
-"test": {
-  // ignore params passed to this target, won't be forwarded to the dependency targets
-  "dependsOn": [{ "projects": "{dependencies}", "target": "build", "params": "ignore" }]
-}
-"lint": {
-  // ignore params passed to this target, won't be forwarded to the dependency targets
-  "dependsOn": [{ "projects": "{dependencies}", "target": "build" }]
+{
+  "targets": {
+    "build": {
+      // forward params passed to this target to the dependency targets
+      "dependsOn": [
+        { "projects": "{dependencies}", "target": "build", "params": "forward" }
+      ]
+    },
+    "test": {
+      // ignore params passed to this target, won't be forwarded to the dependency targets
+      "dependsOn": [
+        { "projects": "{dependencies}", "target": "build", "params": "ignore" }
+      ]
+    },
+    "lint": {
+      // ignore params passed to this target, won't be forwarded to the dependency targets
+      "dependsOn": [{ "projects": "{dependencies}", "target": "build" }]
+    }
+  }
 }
 ```
 
@@ -456,9 +522,15 @@ This also works when defining a relation for the target of the project itself us
 {% tab label="Version < 16" %}
 
 ```json
-"build": {
-   // forward params passed to this target to the project target
-  "dependsOn": [{ "projects": "self", "target": "pre-build", "params": "forward" }]
+{
+  "targets": {
+    "build": {
+      // forward params passed to this target to the project target
+      "dependsOn": [
+        { "projects": "self", "target": "pre-build", "params": "forward" }
+      ]
+    }
+  }
 }
 ```
 
@@ -466,9 +538,13 @@ This also works when defining a relation for the target of the project itself us
 {% tab label="Version 16+" %}
 
 ```json
-"build": {
-   // forward params passed to this target to the project target
-  "dependsOn": [{ "target": "pre-build", "params": "forward" }]
+{
+  "targets": {
+    "build": {
+      // forward params passed to this target to the project target
+      "dependsOn": [{ "target": "pre-build", "params": "forward" }]
+    }
+  }
 }
 ```
 
@@ -481,9 +557,15 @@ Additionally, when using the expanded object syntax, you can specify individual 
 {% tab label="Version 16+" %}
 
 ```json
-"build": {
-   // Run is-even:pre-build and is-odd:pre-build before this target
-  "dependsOn": [{ "projects": ["is-even", "is-odd"], "target": "pre-build" }]
+{
+  "targets": {
+    "build": {
+      // Run is-even:pre-build and is-odd:pre-build before this target
+      "dependsOn": [
+        { "projects": ["is-even", "is-odd"], "target": "pre-build" }
+      ]
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
Expands the json examples in the project configuration reference to give people the full context of where the examples are defined.

Fixes #17330 
