### PR TITLE
fix(js): use `export type` for exports from `schema.d.ts` files

### DIFF
--- a/packages/esbuild/index.ts
+++ b/packages/esbuild/index.ts
@@ -1,3 +1,6 @@
-export * from './src/executors/esbuild/schema';
+export type {
+  EsBuildExecutorOptions,
+  NormalizedEsBuildExecutorOptions,
+} from './src/executors/esbuild/schema';
 export * from './src/executors/esbuild/esbuild.impl';
 export * from './src/utils/versions';

--- a/packages/rollup/index.ts
+++ b/packages/rollup/index.ts
@@ -1,4 +1,8 @@
 export * from './src/generators/init/init';
 export * from './src/generators/rollup-project/rollup-project';
-export * from './src/executors/rollup/schema';
+export type {
+  AssetGlobPattern,
+  Globals,
+  RollupExecutorOptions,
+} from './src/executors/rollup/schema';
 export * from './src/executors/rollup/rollup.impl';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
In the rollup and esbuild packages, types held in a `schema.d.ts` are being exported with `export * from`. This export is not removed when TypeScript transforms the file, likely because TypeScript can't be sure that an actual implementation won't be added separately. However, this results in some systems (such as our Jest setup) importing the `schema.d.ts` file and choking on the invalid syntax.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The types should be exported, but the export should not exist at runtime. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
Fixes #17391

A similar problem was brought up before in #12145, and that specific instance was fixed in #12403. In this PR I have fixed the remaining instances. I did a search for other `.d.ts` files that were being exported and this is all of them.
