### PR TITLE
chore(core): fix workspace-lint typo

### DIFF
--- a/packages/nx/src/command-line/workspace-lint/workspace-lint.ts
+++ b/packages/nx/src/command-line/workspace-lint/workspace-lint.ts
@@ -4,7 +4,7 @@ export async function workspaceLint(): Promise<void> {
   output.warn({
     title: `"nx workspace-lint" has been deprecated.`,
     bodyLines: [
-      `Nx has been reworked to make sure that the issues workspace-lint used to catch are not longer possible.`,
+      `Nx has been reworked to make sure that the issues workspace-lint used to catch are no longer possible.`,
       `Remove "nx workspace-lint" from your CI.`,
     ],
   });


### PR DESCRIPTION
Fix typo from cli output.  Thanks to @timelsass

Supercedes #16638
