### PR TITLE
fix(webpack): micro-frontend dev builds in React are not working in S…

### DIFF
--- a/packages/webpack/src/executors/ssr-dev-server/ssr-dev-server.impl.ts
+++ b/packages/webpack/src/executors/ssr-dev-server/ssr-dev-server.impl.ts
@@ -58,7 +58,7 @@ export async function* ssrDevServerExecutor(
 
   for await (const output of combined) {
     if (!output.success) throw new Error('Could not build application');
-    if (output.options.target === 'node') {
+    if (output.options?.target === 'node') {
       nodeStarted = true;
     } else if (output.options?.target === 'web') {
       browserBuilt = true;


### PR DESCRIPTION
…SR mode

[SSR Module Federation - React] - Cannot read properties of undefined (reading 'target')

closed #17246

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
I'm using NX v16.2.2

As suggested in the [documentation](https://nx.dev/recipes/module-federation/module-federation-with-ssr),

- I'm running `npx nx g @nx/react:host host --ssr` command
- To serve the application, I ran `npx nx serve host`

**One I do this, I get following error:**

<img width="1347" alt="image" src="https://github.com/nrwl/nx/assets/8158506/28505d9a-7ac7-4d4d-a11b-4dbfe3af5ddb">

Please note that, when I run the application on http://localhost:4200, it runs properly. However, it doesn't watch for the file changes. This issue only exists in when we configure the host and remote app with "SSR" flag.

## Expected Behavior
NX should successfully serve the application and watch for the file changes.

## Related Issue(s)
#17246 

Fixes #
#17246 