### PR TITLE
fix(core): fix pnpm lockfile parsing in v6.1

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/utils/pnpm-normalizer.ts
+++ b/packages/nx/src/plugins/js/lock-file/utils/pnpm-normalizer.ts
@@ -456,7 +456,7 @@ function revertFromInlineSpecifiersFormat(
 
   let revertedImporters = mapValues(importers, revertProjectSnapshot);
   let packages = lockfile.packages;
-  if (originalVersion === 6) {
+  if (originalVersionStr.startsWith('6.')) {
     revertedImporters = Object.fromEntries(
       Object.entries(revertedImporters ?? {}).map(
         ([importerId, pkgSnapshot]: [string, ProjectSnapshot]) => {
@@ -512,7 +512,7 @@ function revertFromInlineSpecifiersFormat(
     packages,
     importers: revertedImporters,
   };
-  if (originalVersion === 6 && newLockfile.time) {
+  if (originalVersionStr.startsWith('6.') && newLockfile.time) {
     newLockfile.time = Object.fromEntries(
       Object.entries(newLockfile.time).map(([depPath, time]) => [
         convertNewDepPathToOldDepPath(depPath),


### PR DESCRIPTION
Fix the Version check in the pnpm lockfile parsing process from v6.0 to v6.x, as done in the pnpm source, to fix a error in the generatePackageJson Plugin to not find the deps

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
