### PR TITLE
feat(js): add ability to provide custom output filename for cjs build while generating package json

### DIFF
--- a/packages/js/src/utils/package-json/update-package-json.spec.ts
+++ b/packages/js/src/utils/package-json/update-package-json.spec.ts
@@ -186,6 +186,37 @@ describe('getUpdatedPackageJsonContent', () => {
       });
     });
 
+    it('should support different CJS output files', () => {
+      const json = getUpdatedPackageJsonContent(
+        {
+          name: 'test',
+          version: '0.0.1',
+        },
+        {
+          main: 'proj/src/index.ts',
+          outputPath: 'dist/proj',
+          projectRoot: 'proj',
+          format: ['esm', 'cjs'],
+          outputFileExtensionForCjs: '.cjs',
+          generateExportsField: true,
+          outputFileName: 'index.js',
+          outputFileNameForCjs: 'main.cjs',
+        }
+      );
+
+      expect(json).toEqual({
+        name: 'test',
+        main: './main.cjs',
+        module: './index.js',
+        types: './src/index.d.ts',
+        version: '0.0.1',
+        exports: {
+          '.': { default: './main.cjs', import: './index.js' },
+          './package.json': './package.json',
+        },
+      });
+    });
+
     it('should add additional entry-points into package.json', () => {
       // CJS only
       expect(


### PR DESCRIPTION
Edit: by @mandarini : Code has long changed since June, so changes in this PR as they were could not be merged. I tried to replicate the intention.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
In case generating package.json with ESM + CJS format with different filenames, it doesnt allow specifying custom output filename for CJS build.
<!-- This is the behavior we have today -->

## Expected Behavior
User should be able to provide:
- outputFileName: index.js for ESM
- outputFileNameForCjs: main.js for CJS 


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
