### PR TITLE
fix(nx-cloud): allow regenerating nxcloud access token

### DIFF
--- a/packages/nx/src/command-line/connect/command-object.ts
+++ b/packages/nx/src/command-line/connect/command-object.ts
@@ -7,7 +7,7 @@ export const yargsConnectCommand: CommandModule = {
   describe: `Connect workspace to Nx Cloud`,
   builder: (yargs) => linkToNxDevAndExamples(yargs, 'connect-to-nx-cloud'),
   handler: async () => {
-    await (await import('./connect-to-nx-cloud')).connectToNxCloudCommand();
+    await (await import('./connect-to-nx-cloud')).connectToNxCloudCommand(null, false);
     process.exit(0);
   },
 };

--- a/packages/nx/src/command-line/connect/command-object.ts
+++ b/packages/nx/src/command-line/connect/command-object.ts
@@ -7,7 +7,9 @@ export const yargsConnectCommand: CommandModule = {
   describe: `Connect workspace to Nx Cloud`,
   builder: (yargs) => linkToNxDevAndExamples(yargs, 'connect-to-nx-cloud'),
   handler: async () => {
-    await (await import('./connect-to-nx-cloud')).connectToNxCloudCommand(null, false);
+    await (
+      await import('./connect-to-nx-cloud')
+    ).connectToNxCloudCommand(null, false);
     process.exit(0);
   },
 };

--- a/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
@@ -33,10 +33,26 @@ export async function connectToNxCloudIfExplicitlyAsked(opts: {
 }
 
 export async function connectToNxCloudCommand(
-  promptOverride?: string
+  promptOverride?: string,
+  promptForConfirmation = true
 ): Promise<boolean> {
-  const res = await connectToNxCloudPrompt(promptOverride);
-  if (!res) return false;
+  if (promptForConfirmation && isNxCloudUsed()) {
+    output.log({
+      title: '✅ This workspace is already connected to Nx Cloud.',
+      bodyLines: [
+        'This means your workspace can use computation caching, distributed task execution, and show you run analytics.',
+        'Go to https://nx.app to learn more.',
+        ' ',
+        'If you have not done so already, please claim this workspace:',
+        `${getNxCloudUrl()}/orgs/workspace-setup?accessToken=${getNxCloudToken()}`,
+      ],
+    });
+    return false;
+  }
+  if(promptForConfirmation) {
+    const res = await connectToNxCloudPrompt(promptOverride);
+    if (!res) return false;
+  }
   const pmc = getPackageManagerCommand();
   if (pmc) {
     execSync(`${pmc.addDev} nx-cloud@latest`);

--- a/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
@@ -35,20 +35,6 @@ export async function connectToNxCloudIfExplicitlyAsked(opts: {
 export async function connectToNxCloudCommand(
   promptOverride?: string
 ): Promise<boolean> {
-  if (isNxCloudUsed()) {
-    output.log({
-      title: '✅ This workspace is already connected to Nx Cloud.',
-      bodyLines: [
-        'This means your workspace can use computation caching, distributed task execution, and show you run analytics.',
-        'Go to https://nx.app to learn more.',
-        ' ',
-        'If you have not done so already, please claim this workspace:',
-        `${getNxCloudUrl()}/orgs/workspace-setup?accessToken=${getNxCloudToken()}`,
-      ],
-    });
-    return false;
-  }
-
   const res = await connectToNxCloudPrompt(promptOverride);
   if (!res) return false;
   const pmc = getPackageManagerCommand();

--- a/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
@@ -49,7 +49,7 @@ export async function connectToNxCloudCommand(
     });
     return false;
   }
-  if(promptForConfirmation) {
+  if (promptForConfirmation) {
     const res = await connectToNxCloudPrompt(promptOverride);
     if (!res) return false;
   }

--- a/packages/nx/src/utils/nx-cloud-utils.ts
+++ b/packages/nx/src/utils/nx-cloud-utils.ts
@@ -9,11 +9,11 @@ export function isNxCloudUsed() {
 
 export function getNxCloudUrl(): string {
   const taskRunner = isNxCloudUsed();
-  if (!taskRunner) throw new Error('nx-cloud runner not find in nx.json');
+  if (!taskRunner) throw new Error('nx-cloud runner not found in nx.json');
   return taskRunner.options.url || 'https://nx.app';
 }
 export function getNxCloudToken(): string {
   const taskRunner = isNxCloudUsed();
-  if (!taskRunner) throw new Error('nx-cloud runner not find in nx.json');
+  if (!taskRunner) throw new Error('nx-cloud runner not found in nx.json');
   return taskRunner.options.accessToken;
 }


### PR DESCRIPTION
Currently, if someone already has NxCloud enabled, but they'd like to re-generate their access token, or even point nx cloud to a new API URL, using the `NX_CLOUD_API=https://******.nx.app npx nx connect` command - we don't allow them to do this.

This PR re-enables this functionality. We'll be able to use `nx connect` to:
- re-generate an access token
- point NxCloud to a different API URL