### PR TITLE
fix(node): apply migration patch to 16.0.0 and 14.7.6 migrations as well

### DIFF
--- a/packages/node/src/migrations/update-14-7-6/update-webpack-executor.ts
+++ b/packages/node/src/migrations/update-14-7-6/update-webpack-executor.ts
@@ -1,21 +1,23 @@
 import {
   formatFiles,
-  getProjects,
+  readProjectConfiguration,
   Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
+import { forEachExecutorOptions } from '@nx/devkit/src/generators/executor-options-utils';
 
-export default async function update(host: Tree) {
-  const projects = getProjects(host);
-
-  for (const [name, config] of projects.entries()) {
-    if (config?.targets?.build?.executor === '@nrwl/node:webpack') {
-      config.targets.build.executor = '@nrwl/webpack:webpack';
-      config.targets.build.options.target = 'node';
-      config.targets.build.options.compiler = 'tsc';
-      updateProjectConfiguration(host, name, config);
+export default async function update(tree: Tree) {
+  forEachExecutorOptions(
+    tree,
+    '@nrwl/node:webpack',
+    (options, projectName, targetName) => {
+      const projectConfig = readProjectConfiguration(tree, projectName);
+      projectConfig.targets[targetName].executor = '@nrwl/webpack:webpack';
+      projectConfig.targets[targetName].options.compiler = 'tsc';
+      projectConfig.targets[targetName].options.target = 'node';
+      updateProjectConfiguration(tree, projectName, projectConfig);
     }
-  }
+  );
 
-  await formatFiles(host);
+  await formatFiles(tree);
 }

--- a/packages/node/src/migrations/update-16-0-0/update-webpack-executor.spec.ts
+++ b/packages/node/src/migrations/update-16-0-0/update-webpack-executor.spec.ts
@@ -1,0 +1,52 @@
+import { addProjectConfiguration, readProjectConfiguration } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+
+import update from './update-webpack-executor';
+
+describe('Migration: @nrwl/webpack', () => {
+  it(`should update usage of webpack executor`, async () => {
+    let tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+
+    addProjectConfiguration(tree, 'myapp', {
+      root: 'apps/myapp',
+      sourceRoot: 'apps/myapp/src',
+      projectType: 'application',
+      targets: {
+        foo: {
+          executor: '@nrwl/node:webpack',
+          options: {},
+        },
+        bar: {
+          executor: '@nx/node:webpack',
+          options: {},
+        },
+      },
+    });
+
+    await update(tree);
+
+    expect(readProjectConfiguration(tree, 'myapp')).toEqual({
+      $schema: '../../node_modules/nx/schemas/project-schema.json',
+      name: 'myapp',
+      root: 'apps/myapp',
+      sourceRoot: 'apps/myapp/src',
+      projectType: 'application',
+      targets: {
+        foo: {
+          executor: '@nx/webpack:webpack',
+          options: {
+            compiler: 'tsc',
+            target: 'node',
+          },
+        },
+        bar: {
+          executor: '@nx/webpack:webpack',
+          options: {
+            compiler: 'tsc',
+            target: 'node',
+          },
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
Since the previous migrations will rename `@nrwl/node:webpack` -> `@nx/webpack:webpack` we don't have a chance to apply the fix after the rename (we cannot differentiate between web vs node projects at this point). This PR also patches the old migrations so they can run properly.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
