### PR TITLE
docs(misc): ignore dependency on @nx/next and @nx/jest since they are not the workspace packages

### DIFF
--- a/nx-dev/nx-dev/jest.config.ts
+++ b/nx-dev/nx-dev/jest.config.ts
@@ -1,4 +1,6 @@
 /* eslint-disable */
+// Ignore @nx/jest dependency since it is the installed version not the one in the workspace
+// nx-ignore-next-line
 import nxPreset from '@nx/jest/preset';
 
 module.exports = {

--- a/nx-dev/nx-dev/tailwind.config.js
+++ b/nx-dev/nx-dev/tailwind.config.js
@@ -1,4 +1,6 @@
 const path = require('path');
+// Ignore @nx/next dependency since it is the installed version not the one in the workspace
+// nx-ignore-next-line
 const { createGlobPatternsForDependencies } = require('@nx/next/tailwind');
 
 if (!createGlobPatternsForDependencies(__dirname).length)


### PR DESCRIPTION
Having these two dependencies force every PR that touches Nx core, Jest, or Next.js to also run build/test/etc. for nx.dev. This does not make sense since nx.dev cannot be affected until root `package.json` is updated. It's just a side-effect of use dogfooding our own packages, and Nx not understanding that `package.json` and our own workspace packages are two separate things.

Before:
![graph (9)](https://github.com/nrwl/nx/assets/53559/73022af4-448a-4f48-b6aa-4fb916c76802)

After:
![graph (8)](https://github.com/nrwl/nx/assets/53559/ddf62b4a-5817-4e4e-bda6-4d352883a448)



<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

