### PR TITLE
fix(nextjs): Update package.json build scripts

### DIFF
--- a/packages/next/src/executors/build/build.impl.ts
+++ b/packages/next/src/executors/build/build.impl.ts
@@ -76,6 +76,12 @@ export default async function buildExecutor(
       isProduction: !options.includeDevDependenciesInPackageJson, // By default we remove devDependencies since this is a production build.
     }
   );
+
+  // Update `package.json` to reflect how users should run the build artifacts
+  builtPackageJson.scripts = {
+    start: 'next start',
+  };
+
   updatePackageJson(builtPackageJson, context);
   writeJsonFile(`${options.outputPath}/package.json`, builtPackageJson);
 


### PR DESCRIPTION
When nextjs project is built for production inside package.json we will update scripts 

Before
```json
  "scripts": {
    "start": "nx serve",
    "build": "nx build",
    "test": "nx test"
  },
```

After
```json
  "scripts": {
    "start": "next start"
  },
```
closes: #17260

