### PR TITLE
fix(react): mf remote name incorrect with directory option

### DIFF
--- a/packages/react/src/generators/remote/remote.ts
+++ b/packages/react/src/generators/remote/remote.ts
@@ -50,7 +50,7 @@ export async function remoteGenerator(host: Tree, schema: Schema) {
   tasks.push(initAppTask);
 
   if (schema.host) {
-    updateHostWithRemote(host, schema.host, options.name);
+    updateHostWithRemote(host, schema.host, options.projectName);
   }
 
   // Module federation requires bootstrap code to be dynamically imported.


### PR DESCRIPTION
## Current Behavior
When a developer generates a remote via CLI and passes in a directory (e.g. `▶ yarn nx generate @nrwl/react:remote --name=test --host=host-name --directory=apps/host-name/applications`), the remote uses the project name, while the host does not use the project name. 

Then the developer must take the following steps to run their host without error:

- Change their remote name in `apps/host-name/src/remotes.d.ts`.

`declare module "test/Module";` >> `declare module "host-name-applications-test/Module";`

- Change their remote name in `apps/host-name/module-federation.config.ts`.

```ts
const moduleFederationConfig = {
  ...baseConfig,
  name: "host-name",
  remotes: [
    ... other remotes,
    // "," --> delete this line
    // change from this --> "test", to the below:
    "host-name-applications-test",
  ],
  additionalShared: [
    ...baseConfig.additionalShared,
  ],
};
```

This is because Nx uses the directory to prepend the project name, and passing in options.name to the host does not prepend the directory. Therefore passing in a directory to the CLI will mean that the parameter passed in to the `updateHostWithRemote` method will always be incorrect.

## Expected Behavior
When a developer generates a remote via CLI and passes in a directory, the remote and the host both use the project name. There is no need to update either the `remotes.d.ts` or `module-federation.config.ts` files. 

## Related Issue(s)
https://github.com/nrwl/nx/issues/16308

Fixes #
