### PR TITLE
feat(vite): add incremental builds support to Vite plugin build executor

### DIFF
--- a/docs/generated/packages/vite/executors/build.json
+++ b/docs/generated/packages/vite/executors/build.json
@@ -16,6 +16,11 @@
         "x-completion-type": "directory",
         "x-priority": "important"
       },
+      "buildLibsFromSource": {
+        "type": "boolean",
+        "description": "Read buildable libraries from source instead of building them separately.",
+        "default": true
+      },
       "base": {
         "type": "string",
         "description": "Base public path when served in development or production.",

--- a/docs/generated/packages/vite/executors/dev-server.json
+++ b/docs/generated/packages/vite/executors/dev-server.json
@@ -18,6 +18,11 @@
         "description": "Target which builds the application. Only used to retrieve the configuration as the dev-server does not build the code.",
         "x-priority": "important"
       },
+      "buildLibsFromSource": {
+        "type": "boolean",
+        "description": "Read buildable libraries from source instead of building them separately.",
+        "default": true
+      },
       "proxyConfig": {
         "type": "string",
         "description": "Path to the proxy configuration file.",

--- a/packages/vite/src/executors/build/build.impl.ts
+++ b/packages/vite/src/executors/build/build.impl.ts
@@ -4,6 +4,7 @@ import { build, InlineConfig, mergeConfig } from 'vite';
 import {
   getViteBuildOptions,
   getViteSharedConfig,
+  registerPaths,
 } from '../../utils/options-utils';
 import { ViteBuildExecutorOptions } from './schema';
 import {
@@ -15,32 +16,15 @@ import {
 import { existsSync, writeFileSync } from 'fs';
 import { resolve } from 'path';
 import { createAsyncIterable } from '@nx/devkit/src/utils/async-iterable';
-import { registerTsConfigPaths } from '@nx/js/src/internal';
-import { calculateProjectDependencies, createTmpTsConfig } from '@nx/js/src/utils/buildable-libs-utils';
 
 export async function* viteBuildExecutor(
   options: ViteBuildExecutorOptions,
   context: ExecutorContext
 ) {
-  const metadata = context.projectsConfigurations.projects[context.projectName];
-  const projectRoot = metadata.root;
-  const tsConfig = resolve(projectRoot, 'tsconfig.json');
-  options.buildLibsFromSource ??= true;
+  const projectRoot =
+    context.projectsConfigurations.projects[context.projectName].root;
 
-  if (!options.buildLibsFromSource) {
-    const { dependencies } = calculateProjectDependencies(
-      context.projectGraph,
-      context.root,
-      context.projectName,
-      context.targetName,
-      context.configurationName,
-    );
-    const tmpTsConfig = createTmpTsConfig(tsConfig, context.root, projectRoot, dependencies);
-
-    registerTsConfigPaths(tmpTsConfig);
-  } else {
-    registerTsConfigPaths(tsConfig);
-  }
+  registerPaths(projectRoot, options, context);
 
   const normalizedOptions = normalizeOptions(options);
 

--- a/packages/vite/src/executors/build/build.impl.ts
+++ b/packages/vite/src/executors/build/build.impl.ts
@@ -15,17 +15,32 @@ import {
 import { existsSync, writeFileSync } from 'fs';
 import { resolve } from 'path';
 import { createAsyncIterable } from '@nx/devkit/src/utils/async-iterable';
-
 import { registerTsConfigPaths } from '@nx/js/src/internal';
+import { calculateProjectDependencies, createTmpTsConfig } from '@nx/js/src/utils/buildable-libs-utils';
 
 export async function* viteBuildExecutor(
   options: ViteBuildExecutorOptions,
   context: ExecutorContext
 ) {
-  const projectRoot =
-    context.projectsConfigurations.projects[context.projectName].root;
+  const metadata = context.projectsConfigurations.projects[context.projectName];
+  const projectRoot = metadata.root;
+  const tsConfig = resolve(projectRoot, 'tsconfig.json');
+  options.buildLibsFromSource ??= true;
 
-  registerTsConfigPaths(resolve(projectRoot, 'tsconfig.json'));
+  if (!options.buildLibsFromSource) {
+    const { dependencies } = calculateProjectDependencies(
+      context.projectGraph,
+      context.root,
+      context.projectName,
+      context.targetName,
+      context.configurationName,
+    );
+    const tmpTsConfig = createTmpTsConfig(tsConfig, context.root, projectRoot, dependencies);
+
+    registerTsConfigPaths(tmpTsConfig);
+  } else {
+    registerTsConfigPaths(tsConfig);
+  }
 
   const normalizedOptions = normalizeOptions(options);
 

--- a/packages/vite/src/executors/build/schema.d.ts
+++ b/packages/vite/src/executors/build/schema.d.ts
@@ -18,4 +18,5 @@ export interface ViteBuildExecutorOptions {
   generatePackageJson?: boolean;
   includeDevDependenciesInPackageJson?: boolean;
   cssCodeSplit?: boolean;
+  buildLibsFromSource?: boolean;
 }

--- a/packages/vite/src/executors/build/schema.json
+++ b/packages/vite/src/executors/build/schema.json
@@ -18,6 +18,11 @@
       "x-completion-type": "directory",
       "x-priority": "important"
     },
+    "buildLibsFromSource": {
+      "type": "boolean",
+      "description": "Read buildable libraries from source instead of building them separately.",
+      "default": true
+    },
     "base": {
       "type": "string",
       "description": "Base public path when served in development or production.",

--- a/packages/vite/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/vite/src/executors/dev-server/dev-server.impl.ts
@@ -7,12 +7,18 @@ import {
   getNxTargetOptions,
   getViteServerOptions,
   getViteBuildOptions,
+  registerPaths,
 } from '../../utils/options-utils';
 
 import { ViteDevServerExecutorOptions } from './schema';
 import { ViteBuildExecutorOptions } from '../build/schema';
 import { registerTsConfigPaths } from '@nx/js/src/internal';
 import { resolve } from 'path';
+
+import {
+  calculateProjectDependencies,
+  createTmpTsConfig,
+} from '@nx/js/src/utils/buildable-libs-utils';
 
 export async function* viteDevServerExecutor(
   options: ViteDevServerExecutorOptions,
@@ -21,7 +27,7 @@ export async function* viteDevServerExecutor(
   const projectRoot =
     context.projectsConfigurations.projects[context.projectName].root;
 
-  registerTsConfigPaths(resolve(projectRoot, 'tsconfig.json'));
+  registerPaths(projectRoot, options, context);
 
   // Retrieve the option for the configured buildTarget.
   const buildTargetOptions: ViteBuildExecutorOptions = getNxTargetOptions(

--- a/packages/vite/src/executors/dev-server/schema.d.ts
+++ b/packages/vite/src/executors/dev-server/schema.d.ts
@@ -1,5 +1,6 @@
 export interface ViteDevServerExecutorOptions {
   buildTarget: string;
+  buildLibsFromSource?: boolean;
   proxyConfig?: string;
   port?: number;
   host?: string | boolean;

--- a/packages/vite/src/executors/dev-server/schema.json
+++ b/packages/vite/src/executors/dev-server/schema.json
@@ -21,6 +21,11 @@
       "description": "Target which builds the application. Only used to retrieve the configuration as the dev-server does not build the code.",
       "x-priority": "important"
     },
+    "buildLibsFromSource": {
+      "type": "boolean",
+      "description": "Read buildable libraries from source instead of building them separately.",
+      "default": true
+    },
     "proxyConfig": {
       "type": "string",
       "description": "Path to the proxy configuration file.",


### PR DESCRIPTION
closed #17322

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
It appears that the Vite plugin build executor is missing the same `buildLibsFromSource` logic from `@nx/angular:webpack-browser` that enables incremental builds. This logic is what makes it possible for the plugin to rewrite the path mappings referencing the build outputs instead of always referencing the source files.
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
An app built with the "@nx/vite:build" executor should have the ability to reference pre-compiled files of its dependency libraries instead of always rebuilding and consuming the source files. This feature enables incremental builds and should be optional, allowing developers to choose whether or not to utilize it.
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17322
