### PR TITLE
feat(core): add pre-commit-checks generator

### DIFF
--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -6921,6 +6921,14 @@
                 "children": [],
                 "isExternal": false,
                 "disableCollapsible": false
+              },
+              {
+                "id": "pre-commit-checks",
+                "path": "/packages/workspace/generators/pre-commit-checks",
+                "name": "pre-commit-checks",
+                "children": [],
+                "isExternal": false,
+                "disableCollapsible": false
               }
             ],
             "isExternal": false,

--- a/docs/generated/manifests/packages.json
+++ b/docs/generated/manifests/packages.json
@@ -2898,6 +2898,15 @@
         "originalFilePath": "/packages/workspace/src/generators/ci-workflow/schema.json",
         "path": "/packages/workspace/generators/ci-workflow",
         "type": "generator"
+      },
+      "/packages/workspace/generators/pre-commit-checks": {
+        "description": "Generate a configuration to run pre-commit checks using lint-staged.",
+        "file": "generated/packages/workspace/generators/pre-commit-checks.json",
+        "hidden": false,
+        "name": "pre-commit-checks",
+        "originalFilePath": "/packages/workspace/src/generators/pre-commit-checks/schema.json",
+        "path": "/packages/workspace/generators/pre-commit-checks",
+        "type": "generator"
       }
     },
     "path": "/packages/workspace"

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -2867,6 +2867,15 @@
         "originalFilePath": "/packages/workspace/src/generators/ci-workflow/schema.json",
         "path": "workspace/generators/ci-workflow",
         "type": "generator"
+      },
+      {
+        "description": "Generate a configuration to run pre-commit checks using lint-staged.",
+        "file": "generated/packages/workspace/generators/pre-commit-checks.json",
+        "hidden": false,
+        "name": "pre-commit-checks",
+        "originalFilePath": "/packages/workspace/src/generators/pre-commit-checks/schema.json",
+        "path": "workspace/generators/pre-commit-checks",
+        "type": "generator"
       }
     ],
     "githubRoot": "https://github.com/nrwl/nx/blob/master",

--- a/docs/generated/packages/workspace/generators/pre-commit-checks.json
+++ b/docs/generated/packages/workspace/generators/pre-commit-checks.json
@@ -1,0 +1,33 @@
+{
+  "name": "pre-commit-checks",
+  "factory": "./src/generators/pre-commit-checks/generator",
+  "schema": {
+    "$schema": "http://json-schema.org/schema",
+    "$id": "PreCommitChecks",
+    "title": "Generate a lint-staged configuration.",
+    "description": "Generate a configuration to run pre-commit checks using lint-staged.",
+    "type": "object",
+    "properties": {
+      "enableCommitlint": {
+        "type": "boolean",
+        "description": "Enable commitlint",
+        "default": true,
+        "x-priority": "important"
+      },
+      "skipFormat": {
+        "type": "boolean",
+        "description": "Skip formatting files.",
+        "default": false,
+        "x-priority": "internal"
+      }
+    },
+    "required": [],
+    "presets": []
+  },
+  "description":  "Generate a configuration to run pre-commit checks using lint-staged.",
+  "implementation": "/packages/workspace/src/generators/pre-commit-checks/generator.ts",
+  "aliases": [],
+  "hidden": false,
+  "path": "/packages/workspace/src/generators/pre-commit-checks/schema.json",
+  "type": "generator"
+}

--- a/packages/workspace/generators.json
+++ b/packages/workspace/generators.json
@@ -87,6 +87,11 @@
       "factory": "./src/generators/ci-workflow/ci-workflow#ciWorkflowGenerator",
       "schema": "./src/generators/ci-workflow/schema.json",
       "description": "Generate a CI workflow."
+    },
+    "pre-commit-checks": {
+      "factory": "./src/generators/pre-commit-checks/generator",
+      "schema": "./src/generators/pre-commit-checks/schema.json",
+      "description": "Generate a configuration to run pre-commit checks using lint-staged."
     }
   }
 }

--- a/packages/workspace/src/generators/pre-commit-checks/files/commitlint/.commitlintrc.js.template
+++ b/packages/workspace/src/generators/pre-commit-checks/files/commitlint/.commitlintrc.js.template
@@ -1,0 +1,23 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [
+      2,
+      'always',
+      [
+        'build',
+        'chore',
+        'ci',
+        'docs',
+        'feat',
+        'fix',
+        'perf',
+        'refactor',
+        'revert',
+        'security',
+        'style',
+        'test',
+      ],
+    ],
+  },
+};

--- a/packages/workspace/src/generators/pre-commit-checks/files/commitlint/.husky/commit-msg.template
+++ b/packages/workspace/src/generators/pre-commit-checks/files/commitlint/.husky/commit-msg.template
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+<%= execCmd %> commitlint --edit $1

--- a/packages/workspace/src/generators/pre-commit-checks/files/common/.husky/pre-commit.template
+++ b/packages/workspace/src/generators/pre-commit-checks/files/common/.husky/pre-commit.template
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+<%= execCmd %> lint-staged

--- a/packages/workspace/src/generators/pre-commit-checks/files/common/.lintstagedrc.mjs.template
+++ b/packages/workspace/src/generators/pre-commit-checks/files/common/.lintstagedrc.mjs.template
@@ -1,0 +1,4 @@
+export default {
+  '**/*': (f) => `<%= execCmd %> nx format:write --files=${f.join(',')}`,
+  '{apps,libs,packages,tools}/**/*.{ts,tsx,js,jsx}': 'eslint',
+};

--- a/packages/workspace/src/generators/pre-commit-checks/generator.spec.ts
+++ b/packages/workspace/src/generators/pre-commit-checks/generator.spec.ts
@@ -1,0 +1,76 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { Tree, readJson } from '@nx/devkit';
+import * as nxDevkit from '@nx/devkit';
+import * as semver from 'semver';
+
+import { preCommitChecksGenerator } from './generator';
+import { PreCommitChecksGeneratorSchema } from './schema';
+
+describe('pre-commit-checks generator', () => {
+  let tree: Tree;
+  const defaultOptions: PreCommitChecksGeneratorSchema = { skipFormat: true };
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('generating files and installing required dependencies for each package manager', () => {
+    test.each`
+      packageManager | isYarn2  | enableCommitlint
+      ${'npm'}       | ${false} | ${undefined}
+      ${'pnpm'}      | ${false} | ${undefined}
+      ${'yarn'}      | ${false} | ${undefined}
+      ${'yarn'}      | ${true}  | ${undefined}
+      ${'npm'}       | ${false} | ${false}
+      ${'pnpm'}      | ${false} | ${false}
+      ${'yarn'}      | ${false} | ${false}
+      ${'yarn'}      | ${true}  | ${false}
+    `(
+      'should correctly install dependencies when packageManager is $packageManager ($isYarn2) and enableCommitlint is $enableCommitlint',
+      async ({ packageManager, isYarn2, enableCommitlint }) => {
+        jest.spyOn(nxDevkit, 'readNxJson').mockReturnValueOnce({
+          cli: {
+            packageManager,
+          },
+        });
+
+        if (isYarn2) {
+          jest.spyOn(semver, 'gte').mockImplementation((v1, v2) => {
+            if (v2 === '2.0.0') {
+              // trying to assume that current invocation of "gte" is for yarn
+              // as we're checking if yarn's version is greater than 2.0.0
+              return true;
+            }
+            return semver.gte(v1, v2);
+          });
+        }
+
+        await preCommitChecksGenerator(tree, {
+          ...defaultOptions,
+          enableCommitlint,
+        });
+
+        const expectedFiles = ['.husky/pre-commit', '.lintstagedrc.mjs'];
+        const expectedDeps = ['husky', 'lint-staged'];
+
+        if (enableCommitlint !== false) {
+          expectedFiles.push('.husky/commit-msg', '.commitlintrc.js');
+          expectedDeps.push(
+            '@commitlint/cli',
+            '@commitlint/config-conventional'
+          );
+        }
+
+        const { devDependencies } = readJson(tree, 'package.json');
+
+        expect(Object.keys(devDependencies).sort()).toEqual(
+          expectedDeps.sort()
+        );
+        expect(expectedFiles.every((f) => tree.exists(f))).toBeTruthy();
+      }
+    );
+  });
+});

--- a/packages/workspace/src/generators/pre-commit-checks/generator.ts
+++ b/packages/workspace/src/generators/pre-commit-checks/generator.ts
@@ -1,0 +1,151 @@
+import {
+  addDependenciesToPackageJson,
+  detectPackageManager,
+  formatFiles,
+  generateFiles,
+  GeneratorCallback,
+  getPackageManagerCommand,
+  getPackageManagerVersion,
+  joinPathFragments,
+  PackageManager,
+  Tree,
+  updateJson,
+} from '@nx/devkit';
+import { PreCommitChecksGeneratorSchema } from './schema';
+import { PackageJson } from 'nx/src/utils/package-json';
+import {
+  huskyVersion,
+  pinstVersion,
+  commitlintVersion,
+  lintStagedVersion,
+} from '../../utils/versions';
+import { gte } from 'semver';
+
+interface NormalizedSchema extends PreCommitChecksGeneratorSchema {
+  enableCommitlint: boolean;
+}
+
+function normalizeSchema(
+  schema: PreCommitChecksGeneratorSchema
+): NormalizedSchema {
+  return {
+    ...schema,
+    enableCommitlint: schema.enableCommitlint ?? true,
+  };
+}
+
+function appendScriptInPlace(
+  pkg: PackageJson,
+  scriptName: string,
+  cmd: string
+) {
+  pkg.scripts ??= {};
+
+  if (pkg.scripts[scriptName]) {
+    if (!pkg.scripts[scriptName].includes(cmd)) {
+      pkg.scripts[scriptName] += ` && ${cmd}`;
+    }
+  } else {
+    pkg.scripts[scriptName] = cmd;
+  }
+}
+
+function createFiles(
+  tree: Tree,
+  schema: NormalizedSchema,
+  packageManager: PackageManager
+) {
+  const pmc = getPackageManagerCommand(packageManager);
+
+  const options = {
+    execCmd: pmc.exec,
+  };
+
+  generateFiles(
+    tree,
+    joinPathFragments(__dirname, 'files/common'),
+    '',
+    options
+  );
+  updateChmodOnFile(tree, '.husky/pre-commit');
+
+  if (schema.enableCommitlint) {
+    generateFiles(
+      tree,
+      joinPathFragments(__dirname, 'files/commitlint'),
+      '',
+      options
+    );
+    updateChmodOnFile(tree, '.husky/commit-msg');
+  }
+}
+
+function installPreCommitDependencies(
+  tree: Tree,
+  params: { installPinst: boolean; enableCommitlint: boolean }
+): GeneratorCallback {
+  const devDependencies = {
+    husky: huskyVersion,
+    'lint-staged': lintStagedVersion,
+  };
+  if (params.installPinst) {
+    devDependencies['pinst'] = pinstVersion;
+  }
+  if (params.enableCommitlint) {
+    devDependencies['@commitlint/cli'] = commitlintVersion;
+    devDependencies['@commitlint/config-conventional'] = commitlintVersion;
+  }
+  return addDependenciesToPackageJson(tree, {}, devDependencies);
+}
+
+function updateChmodOnFile(tree: Tree, filePath: string) {
+  // making the file executable
+  tree.write(filePath, tree.read(filePath), { mode: '755' });
+}
+
+export async function preCommitChecksGenerator(
+  tree: Tree,
+  opts: PreCommitChecksGeneratorSchema
+) {
+  const normalizedSchema = normalizeSchema(opts);
+
+  const pm = detectPackageManager(tree.root);
+  let isYarn2 = false;
+  let installPinst = false;
+
+  if (pm === 'yarn') {
+    const yarnVersion = getPackageManagerVersion('yarn');
+    isYarn2 = gte(yarnVersion, '2.0.0');
+  }
+
+  updateJson(tree, 'package.json', (packageJson: PackageJson) => {
+    if (isYarn2) {
+      // Yarn 2+ doesn't support prepare lifecycle script,
+      // so husky needs to be installed differently (this doesn't apply to Yarn 1 though).
+      // See https://typicode.github.io/husky/getting-started.html#yarn-2
+      appendScriptInPlace(packageJson, 'postinstall', 'husky install');
+      if (packageJson.private !== true) {
+        appendScriptInPlace(packageJson, 'prepack', 'pinst --disable');
+        appendScriptInPlace(packageJson, 'postpack', 'pinst --enable');
+        installPinst = true;
+      }
+    } else {
+      appendScriptInPlace(packageJson, 'prepare', 'husky install');
+    }
+
+    return packageJson;
+  });
+
+  createFiles(tree, normalizedSchema, pm);
+
+  if (!normalizedSchema.skipFormat) {
+    await formatFiles(tree);
+  }
+
+  return installPreCommitDependencies(tree, {
+    installPinst,
+    enableCommitlint: normalizedSchema.enableCommitlint,
+  });
+}
+
+export default preCommitChecksGenerator;

--- a/packages/workspace/src/generators/pre-commit-checks/schema.d.ts
+++ b/packages/workspace/src/generators/pre-commit-checks/schema.d.ts
@@ -1,0 +1,4 @@
+export interface PreCommitChecksGeneratorSchema {
+  enableCommitlint?: boolean;
+  skipFormat?: boolean;
+}

--- a/packages/workspace/src/generators/pre-commit-checks/schema.json
+++ b/packages/workspace/src/generators/pre-commit-checks/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "$id": "PreCommitChecks",
+  "title": "Generate a lint-staged configuration.",
+  "description": "Generate a configuration to run pre-commit checks using lint-staged.",
+  "type": "object",
+  "properties": {
+    "enableCommitlint": {
+      "type": "boolean",
+      "description": "Enable commitlint",
+      "default": true,
+      "x-priority": "important"
+    },
+    "skipFormat": {
+      "type": "boolean",
+      "description": "Skip formatting files.",
+      "default": false,
+      "x-priority": "internal"
+    }
+  },
+  "required": []
+}

--- a/packages/workspace/src/utils/versions.ts
+++ b/packages/workspace/src/utils/versions.ts
@@ -5,6 +5,11 @@ export const typescriptESLintVersion = '^5.58.0';
 export const eslintVersion = '~8.15.0';
 export const eslintConfigPrettierVersion = '8.1.0';
 
+export const huskyVersion = '^8.0.0';
+export const pinstVersion = '^3.0.0';
+export const commitlintVersion = '^17.6.5';
+export const lintStagedVersion = '^13.2.2';
+
 // TODO: remove when preset generation is reworked and
 // deps are not installed from workspace
 export const angularCliVersion = '~16.0.0';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Nx repositories are very often used together with lint-staged and commitlint. And while Nx provides a good way to structure the repo, there's no  predefined approach on how git flow should look like. 

And even if there's an understanding what should be done, It takes a few annoying steps to bring required configurations in the newly created repository:
- npx husky-init
- install commitlint and lint-staged
- add necessary configs
- update husky hooks
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
This PR introduces a new `@nx/workspace:pre-commit-checks` generator, that standardises the git flow in Nx repositories by performing steps described above
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
