### PR TITLE
fix(react): update setup-tailwind with next app router global style locations

### DIFF
--- a/packages/react/src/generators/setup-tailwind/lib/add-tailwind-style-imports.ts
+++ b/packages/react/src/generators/setup-tailwind/lib/add-tailwind-style-imports.ts
@@ -21,6 +21,13 @@ const knownLocations = [
   'pages/styles.scss',
   'pages/styles.styl',
   'pages/styles.less',
+  
+  // Next.js App Router
+  'app/global.css',
+  'app/global.scss',
+  'app/global.styl',
+  'app/global.less',
+  
 ];
 
 export function addTailwindStyleImports(


### PR DESCRIPTION
Add support for default app router style locations.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
If added to a project using the NextJS 13 App router, tailwind script is not able to complete and requires manually adding the directives to the `app/global.css` file.

## Expected Behavior
Tailwind styles should be added automatically to this file as this is the default/suggested file structure using `@nx/next`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
Takes the four known style endings in the file `.css`, `.scss`, `.styl`, & `.less`, and adds those variations for the file format `app/global.x`