### PR TITLE
fix(core): avoid terminal flickering when doing dynamic rendering

### DIFF
--- a/packages/nx/src/utils/output.ts
+++ b/packages/nx/src/utils/output.ts
@@ -1,5 +1,6 @@
 import * as chalk from 'chalk';
 import { EOL } from 'os';
+import * as readline from 'readline';
 import { isCI } from './is-ci';
 import { TaskStatus } from '../tasks-runner/tasks-runner';
 
@@ -75,6 +76,15 @@ class CLIOutput {
     process.stdout.write(str);
   }
 
+  overwriteLine(lineText: string = '') {
+    // this replaces the existing text up to the new line length
+    process.stdout.write(lineText);
+    // clear whatever text might be left to the right of the cursor (happens
+    // when existing text was longer than new one)
+    readline.clearLine(process.stdout, 1);
+    process.stdout.write(EOL);
+  }
+
   private writeOutputTitle({
     color,
     title,
@@ -118,9 +128,15 @@ class CLIOutput {
   }
 
   addVerticalSeparatorWithoutNewLines(color = 'gray') {
-    this.writeToStdOut(
-      `${this.X_PADDING}${chalk.dim[color](this.VERTICAL_SEPARATOR)}${EOL}`
-    );
+    this.writeToStdOut(`${this.getVerticalSeparator(color)}${EOL}`);
+  }
+
+  getVerticalSeparatorLines(color = 'gray') {
+    return ['', this.getVerticalSeparator(color), ''];
+  }
+
+  private getVerticalSeparator(color: string): string {
+    return `${this.X_PADDING}${chalk.dim[color](this.VERTICAL_SEPARATOR)}`;
   }
 
   error({ title, slug, bodyLines }: CLIErrorMessageConfig) {
@@ -166,7 +182,7 @@ class CLIOutput {
       this.writeToStdOut(
         `${chalk.grey(
           '  Learn more about this warning: '
-        )}https://errors.nx.dev/${slug}\n`
+        )}https://errors.nx.dev/${slug}${EOL}`
       );
     }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When rendering output with the dynamic rendering terminal output lifecycles, there is some flickering in the terminal output.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The terminal output should be smoothly rendered with the dynamic rendering terminal output lifecycles. There should be no flickering.

The current implementation first clears the lines that are going to be replaced/overwritten and then writes the new lines. This seems to produce flickering due to the rendering of the new lines happening in a different rendering cycle than clearing the lines.

The new implementation directly writes over the existing lines and clears the remaining text, if any. Because the clearing now only happens over text that needs to be cleared and not replaced, no flickering occurs.

### run

- **Before:**

https://github.com/nrwl/nx/assets/12051310/9582be13-0ad4-4504-a0fe-b48ab4efe2cd

- **After:**

https://github.com/nrwl/nx/assets/12051310/a199a544-dcd3-4131-a1ee-f534d8855b77

### run-many

- **Before:**

https://github.com/nrwl/nx/assets/12051310/b266de1b-e386-44b8-ac0a-f04b3081a8b4

- **After:**

https://github.com/nrwl/nx/assets/12051310/e9f6ac66-6a58-4b10-9373-4463cdaabba2

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
