### PR TITLE
fix(js): pass buildTargetOptions in executor

### DIFF
--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -43,8 +43,13 @@ export async function* nodeExecutor(
     context.projectGraph
   );
 
-  const buildOptions = project.data.targets[buildTarget.target]?.options;
-  if (!buildOptions) {
+  let buildOptions: Record<string, any>;
+  if (project.data.targets[buildTarget.target]) {
+    buildOptions = {
+      ...project.data.targets[buildTarget.target]?.options,
+      ...options.buildTargetOptions,
+    };
+  } else {
     throw new Error(
       `Cannot find build target ${chalk.bold(
         options.buildTarget


### PR DESCRIPTION
closed #17429

## Current Behavior

Only `project.data.targets[buildTarget.target]?.options` is used and additional options passed through `buildTargetOptions` are ignored.

## Expected Behavior

Pass `buildTargetOptions` too.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17429
