### PR TITLE
fix(core): match tasks by id in run-many terminal output lifecycles

### DIFF
--- a/packages/nx/src/tasks-runner/life-cycles/dynamic-run-many-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/dynamic-run-many-terminal-output-life-cycle.ts
@@ -437,7 +437,7 @@ export async function createRunManyDynamicOutputRenderer({
   lifeCycle.endTasks = (taskResults) => {
     for (let t of taskResults) {
       totalCompletedTasks++;
-      const matchingTaskRow = taskRows.find((r) => r.task === t.task);
+      const matchingTaskRow = taskRows.find((r) => r.task.id === t.task.id);
       if (matchingTaskRow) {
         matchingTaskRow.status = t.status;
       }

--- a/packages/nx/src/tasks-runner/life-cycles/static-run-many-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/static-run-many-terminal-output-life-cycle.ts
@@ -16,7 +16,7 @@ import { formatFlags, formatTargetsAndProjects } from './formatting-utils';
 export class StaticRunManyTerminalOutputLifeCycle implements LifeCycle {
   failedTasks = [] as Task[];
   cachedTasks = [] as Task[];
-  allCompletedTasks = new Set<Task>();
+  allCompletedTasks = new Map<string, Task>();
 
   constructor(
     private readonly projectNames: string[],
@@ -123,14 +123,14 @@ export class StaticRunManyTerminalOutputLifeCycle implements LifeCycle {
   }
 
   private skippedTasks() {
-    return this.tasks.filter((t) => !this.allCompletedTasks.has(t));
+    return this.tasks.filter((t) => !this.allCompletedTasks.has(t.id));
   }
 
   endTasks(
     taskResults: { task: Task; status: TaskStatus; code: number }[]
   ): void {
     for (let t of taskResults) {
-      this.allCompletedTasks.add(t.task);
+      this.allCompletedTasks.set(t.task.id, t.task);
       if (t.status === 'failure') {
         this.failedTasks.push(t.task);
       } else if (t.status === 'local-cache') {

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -144,7 +144,7 @@ export class TaskOrchestrator {
     task: Task;
     status: 'local-cache' | 'local-cache-kept-existing' | 'remote-cache';
   }> {
-    const startTime = new Date().getTime();
+    task.startTime = Date.now();
     const cachedResult = await this.cache.get(task);
     if (!cachedResult || cachedResult.code !== 0) return null;
 
@@ -155,6 +155,7 @@ export class TaskOrchestrator {
     if (shouldCopyOutputsFromCache) {
       await this.cache.copyFilesFromCache(task.hash, cachedResult, outputs);
     }
+    task.endTime = Date.now();
     const status = cachedResult.remote
       ? 'remote-cache'
       : shouldCopyOutputsFromCache
@@ -166,11 +167,7 @@ export class TaskOrchestrator {
       cachedResult.terminalOutput
     );
     return {
-      task: {
-        ...task,
-        startTime,
-        endTime: Date.now(),
-      },
+      task,
       status,
     };
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The run-many terminal rendering is not handling completed tasks correctly.

This happens because it matches the task objects by reference, not by id. It was not an issue until recently because every operation in different parts of the code was mutating the task objects. A PR (https://github.com/nrwl/nx/commit/b6cdf9d9754afa821e63f6350ae00007e72ee2c2#diff-e9bae83332b3d6e57c023959ab2e5f191c97e0a154a8c1d36dd81f8f869e1bdfR243R247) recently created a new task instance which caused the issue to appear.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The run-many terminal rendering should handle completed tasks and match them correctly.

The task matching in the terminal output lifecycles was changed to match by id, which is more resilient to external code handling tasks. Since creating a new task object in the task orchestrator was not needed, I also updated the change made by the previous PR to keep the previous approach of mutating the task object.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
