### PR TITLE
fix(js): dont ignore args option on node executor

### DIFF
--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -141,7 +141,7 @@ export async function* nodeExecutor(
             task.promise = new Promise<void>((resolve, reject) => {
               task.childProcess = fork(
                 joinPathFragments(__dirname, 'node-with-require-overrides'),
-                options.runtimeArgs ?? [],
+                options.args ?? [],
                 {
                   execArgv: getExecArgv(options),
                   stdio: [0, 1, 'pipe', 'ipc'],


### PR DESCRIPTION
closed #17451

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17451
