### PR TITLE
fix(storybook): correctly identify if uses vite-based framework

### DIFF
--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -107,7 +107,7 @@ export async function configurationGenerator(
     projectIsRootProjectInStandaloneWorkspace(root),
     !!nextBuildTarget,
     compiler === 'swc',
-    !!viteBuildTarget,
+    !!viteBuildTarget || schema.uiFramework.endsWith('-vite'),
     viteConfigFilePath
   );
 


### PR DESCRIPTION
## Current Behavior

Storybook configuration generator will only add vite-related builder config in `.storybook/main.js` if project has `vite` build target.


## Expected Behavior

Storybook configuration generator should also add vite-related builder config in `.storybook/main.js` if project uses `vite` based Storybook framework.
