### PR TITLE
fix(core): ensure createPackageJson does not override existing config

### DIFF
--- a/packages/js/src/utils/package-json/update-package-json.spec.ts
+++ b/packages/js/src/utils/package-json/update-package-json.spec.ts
@@ -434,11 +434,15 @@ describe('updatePackageJson', () => {
         "dependencies": {
           "external1": "~1.0.0",
           "external2": "^4.0.0",
+          "lib2": "^0.0.1",
+        },
+        "devDependencies": {
+          "jest": "27",
         },
         "main": "./main.js",
         "name": "@org/lib1",
         "types": "./main.d.ts",
-        "version": "0.0.1",
+        "version": "0.0.3",
       }
     `);
   });

--- a/packages/nx/src/plugins/js/package-json/create-package-json.ts
+++ b/packages/nx/src/plugins/js/package-json/create-package-json.ts
@@ -15,6 +15,7 @@ import {
 } from '../../../hasher/task-hasher';
 import { readNxJson } from '../../../config/configuration';
 import { readProjectFileMapCache } from '../../../project-graph/nx-deps-cache';
+import { join } from 'path';
 
 interface NpmDeps {
   readonly dependencies: Record<string, string>;
@@ -80,11 +81,14 @@ export function createPackageJson(
     name: projectName,
     version: '0.0.1',
   };
-  if (existsSync(`${graph.nodes[projectName].data.root}/package.json`)) {
+  const projectPackageJsonPath = join(
+    options.root || workspaceRoot,
+    projectNode.data.root,
+    'package.json'
+  );
+  if (existsSync(projectPackageJsonPath)) {
     try {
-      packageJson = readJsonFile(
-        `${graph.nodes[projectName].data.root}/package.json`
-      );
+      packageJson = readJsonFile(projectPackageJsonPath);
       // for standalone projects we don't want to include all the root dependencies
       if (graph.nodes[projectName].data.root === '.') {
         // TODO: We should probably think more on this - Nx can't always


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The project's package.json is ignored if `createPackageJson` is invoked in any nested folder.

## Expected Behavior
The project's `package.json` should always be respected when calling `createPackageJson`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
