### PR TITLE
feat(vite): add type check to vite builder

### DIFF
--- a/docs/generated/packages/vite/executors/build.json
+++ b/docs/generated/packages/vite/executors/build.json
@@ -21,6 +21,11 @@
         "description": "Read buildable libraries from source instead of building them separately.",
         "default": true
       },
+      "skipTypeCheck": {
+        "type": "boolean",
+        "description": "Skip type-checking via TypeScript. Skipping type-checking speeds up the build but type errors are not caught.",
+        "default": false
+      },
       "base": {
         "type": "string",
         "description": "Base public path when served in development or production.",

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -1,3 +1,4 @@
+export * from './utils/typescript/add-tslib-dependencies';
 export * from './utils/typescript/load-ts-transformers';
 export * from './utils/typescript/print-diagnostics';
 export * from './utils/typescript/run-type-check';

--- a/packages/vite/src/executors/build/build.impl.ts
+++ b/packages/vite/src/executors/build/build.impl.ts
@@ -2,9 +2,9 @@ import 'dotenv/config';
 import { ExecutorContext, writeJsonFile } from '@nx/devkit';
 import { build, InlineConfig, mergeConfig } from 'vite';
 import {
+  getProjectTsConfigPath,
   getViteBuildOptions,
   getViteSharedConfig,
-  registerPaths,
 } from '../../utils/options-utils';
 import { ViteBuildExecutorOptions } from './schema';
 import {
@@ -16,6 +16,7 @@ import {
 import { existsSync, writeFileSync } from 'fs';
 import { resolve } from 'path';
 import { createAsyncIterable } from '@nx/devkit/src/utils/async-iterable';
+import { registerPaths, validateTypes } from '../../utils/executor-utils';
 
 export async function* viteBuildExecutor(
   options: ViteBuildExecutorOptions,
@@ -34,6 +35,14 @@ export async function* viteBuildExecutor(
       build: getViteBuildOptions(normalizedOptions, context),
     }
   );
+
+  if (!options.skipTypeCheck) {
+    await validateTypes({
+      workspaceRoot: context.root,
+      projectRoot: projectRoot,
+      tsconfig: getProjectTsConfigPath(projectRoot),
+    });
+  }
 
   const watcherOrOutput = await runInstance(buildConfig);
 

--- a/packages/vite/src/executors/build/schema.d.ts
+++ b/packages/vite/src/executors/build/schema.d.ts
@@ -19,4 +19,5 @@ export interface ViteBuildExecutorOptions {
   includeDevDependenciesInPackageJson?: boolean;
   cssCodeSplit?: boolean;
   buildLibsFromSource?: boolean;
+  skipTypeCheck?: boolean;
 }

--- a/packages/vite/src/executors/build/schema.json
+++ b/packages/vite/src/executors/build/schema.json
@@ -23,6 +23,11 @@
       "description": "Read buildable libraries from source instead of building them separately.",
       "default": true
     },
+    "skipTypeCheck": {
+      "type": "boolean",
+      "description": "Skip type-checking via TypeScript. Skipping type-checking speeds up the build but type errors are not caught.",
+      "default": false
+    },
     "base": {
       "type": "string",
       "description": "Base public path when served in development or production.",

--- a/packages/vite/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/vite/src/executors/dev-server/dev-server.impl.ts
@@ -7,18 +7,11 @@ import {
   getNxTargetOptions,
   getViteServerOptions,
   getViteBuildOptions,
-  registerPaths,
 } from '../../utils/options-utils';
 
 import { ViteDevServerExecutorOptions } from './schema';
 import { ViteBuildExecutorOptions } from '../build/schema';
-import { registerTsConfigPaths } from '@nx/js/src/internal';
-import { resolve } from 'path';
-
-import {
-  calculateProjectDependencies,
-  createTmpTsConfig,
-} from '@nx/js/src/utils/buildable-libs-utils';
+import { registerPaths } from '../../utils/executor-utils';
 
 export async function* viteDevServerExecutor(
   options: ViteDevServerExecutorOptions,

--- a/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -6,7 +6,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import viteTsConfigPaths from 'vite-tsconfig-paths';
 import dts from 'vite-plugin-dts';
-import { joinPathFragments } from '@nx/devkit';
+import * as path from 'path';
 
 export default defineConfig({
   cacheDir: '../node_modules/.vite/my-lib',
@@ -14,7 +14,7 @@ export default defineConfig({
   plugins: [
     dts({
       entryRoot: 'src',
-      tsConfigFilePath: joinPathFragments(__dirname, 'tsconfig.lib.json'),
+      tsConfigFilePath: path.join(__dirname, 'tsconfig.lib.json'),
       skipDiagnostics: true,
     }),
     react(),
@@ -59,7 +59,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import viteTsConfigPaths from 'vite-tsconfig-paths';
 import dts from 'vite-plugin-dts';
-import { joinPathFragments } from '@nx/devkit';
+import * as path from 'path';
 
 export default defineConfig({
   cacheDir: '../../node_modules/.vite/react-lib-nonb-jest',
@@ -67,7 +67,7 @@ export default defineConfig({
   plugins: [
     dts({
       entryRoot: 'src',
-      tsConfigFilePath: joinPathFragments(__dirname, 'tsconfig.lib.json'),
+      tsConfigFilePath: path.join(__dirname, 'tsconfig.lib.json'),
       skipDiagnostics: true,
     }),
     react(),
@@ -152,7 +152,7 @@ exports[`@nx/vite:configuration library mode should set up non buildable library
 
 exports[`@nx/vite:configuration library mode should set up non buildable library which already has vite.config.ts correctly 1`] = `
 "import dts from 'vite-plugin-dts';
-import { joinPathFragments } from '@nx/devkit';
+import * as path from 'path';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import viteTsConfigPaths from 'vite-tsconfig-paths';
@@ -185,7 +185,7 @@ export default defineConfig({
     ],
     dts({
       entryRoot: 'src',
-      tsConfigFilePath: joinPathFragments(__dirname, 'tsconfig.lib.json'),
+      tsConfigFilePath: path.join(__dirname, 'tsconfig.lib.json'),
       skipDiagnostics: true,
     }),
   ],

--- a/packages/vite/src/generators/vitest/vitest-generator.ts
+++ b/packages/vite/src/generators/vitest/vitest-generator.ts
@@ -24,6 +24,8 @@ import {
   vitestCoverageIstanbulVersion,
 } from '../../utils/versions';
 
+import { addTsLibDependencies } from '@nx/js';
+
 export async function vitestGenerator(
   tree: Tree,
   schema: VitestGeneratorSchema
@@ -129,6 +131,8 @@ function updateTsConfig(
         }
       );
     }
+
+    addTsLibDependencies(tree);
   }
 }
 

--- a/packages/vite/src/utils/executor-utils.ts
+++ b/packages/vite/src/utils/executor-utils.ts
@@ -1,0 +1,57 @@
+import { printDiagnostics, runTypeCheck } from '@nx/js';
+import { join, resolve } from 'path';
+import { ViteBuildExecutorOptions } from '../executors/build/schema';
+import { ExecutorContext } from '@nx/devkit';
+import { ViteDevServerExecutorOptions } from '../executors/dev-server/schema';
+import {
+  calculateProjectDependencies,
+  createTmpTsConfig,
+} from '@nx/js/src/utils/buildable-libs-utils';
+import { registerTsConfigPaths } from '@nx/js/src/internal';
+
+export async function validateTypes(opts: {
+  workspaceRoot: string;
+  projectRoot: string;
+  tsconfig: string;
+}): Promise<void> {
+  const result = await runTypeCheck({
+    workspaceRoot: opts.workspaceRoot,
+    tsConfigPath: join(opts.workspaceRoot, opts.tsconfig),
+    mode: 'noEmit',
+  });
+
+  await printDiagnostics(result.errors, result.warnings);
+
+  if (result.errors.length > 0) {
+    throw new Error('Found type errors. See above.');
+  }
+}
+
+export function registerPaths(
+  projectRoot: string,
+  options: ViteBuildExecutorOptions | ViteDevServerExecutorOptions,
+  context: ExecutorContext
+) {
+  const tsConfig = resolve(projectRoot, 'tsconfig.json');
+  options.buildLibsFromSource ??= true;
+
+  if (!options.buildLibsFromSource) {
+    const { dependencies } = calculateProjectDependencies(
+      context.projectGraph,
+      context.root,
+      context.projectName,
+      context.targetName,
+      context.configurationName
+    );
+    const tmpTsConfig = createTmpTsConfig(
+      tsConfig,
+      context.root,
+      projectRoot,
+      dependencies
+    );
+
+    registerTsConfigPaths(tmpTsConfig);
+  } else {
+    registerTsConfigPaths(tsConfig);
+  }
+}

--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -519,7 +519,7 @@ export function createOrEditViteConfig(
     : options.includeLib
     ? `dts({
       entryRoot: 'src',
-      tsConfigFilePath: joinPathFragments(__dirname, 'tsconfig.lib.json'),
+      tsConfigFilePath: path.join(__dirname, 'tsconfig.lib.json'),
       skipDiagnostics: true,
     }),`
     : '';
@@ -527,7 +527,7 @@ export function createOrEditViteConfig(
   const dtsImportLine = onlyVitest
     ? ''
     : options.includeLib
-    ? `import dts from 'vite-plugin-dts';\nimport { joinPathFragments } from '@nx/devkit';`
+    ? `import dts from 'vite-plugin-dts';\nimport * as path from 'path';`
     : '';
 
   let viteConfigContent = '';


### PR DESCRIPTION
## Current Behavior

If a project (eg. `my-app`) has invalid TypeScript, and I run `nx build my-app`, the build will succeed, despite the invalid TypeScript.

This is consistent with the native Vite builder behaviour, the result of running `vite build` would be the same, build will succeed despite TypeScript error.

However, on a newly scaffolded pure Vite project (eg. the result of `npm create vite my-app` - see [here](https://vite.new/react-ts)) the `build` script in `package.json` is configured as:

```
"build": "tsc && vite build"
```
which first calls `tsc` and then `vite build`. `tsc` catches the TypeScript error and throws, so the result of `npm run build` in that case is an error.

## Expected Behavior

We would want to keep this behaviour (the behaviour of `npm run build`) in Nx, and throw if there's a TypeScript error, but also allow the user to run the build without catching the error as well, to also keep the `vite build` behaviour.

So, the typechecking will be called, unless the user passes `skipTypeCheck`.

