### PR TITLE
chore(vite): remove typo in the comment / documentation

### DIFF
--- a/docs/generated/packages/vite/documents/set-up-vite-manually.md
+++ b/docs/generated/packages/vite/documents/set-up-vite-manually.md
@@ -189,7 +189,7 @@ export default defineConfig({
       name: 'pure-libs-rlv1',
       fileName: 'index',
       // Change this to the formats you want to support.
-      // Don't forgot to update your package.json as well.
+      // Don't forget to update your package.json as well.
       formats: ['es', 'cjs'],
     },
     rollupOptions: {

--- a/docs/shared/packages/vite/set-up-vite-manually.md
+++ b/docs/shared/packages/vite/set-up-vite-manually.md
@@ -189,7 +189,7 @@ export default defineConfig({
       name: 'pure-libs-rlv1',
       fileName: 'index',
       // Change this to the formats you want to support.
-      // Don't forgot to update your package.json as well.
+      // Don't forget to update your package.json as well.
       formats: ['es', 'cjs'],
     },
     rollupOptions: {

--- a/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -41,7 +41,7 @@ export default defineConfig({
       name: 'my-lib',
       fileName: 'index',
       // Change this to the formats you want to support.
-      // Don't forgot to update your package.json as well.
+      // Don't forget to update your package.json as well.
       formats: ['es', 'cjs'],
     },
     rollupOptions: {
@@ -94,7 +94,7 @@ export default defineConfig({
       name: 'react-lib-nonb-jest',
       fileName: 'index',
       // Change this to the formats you want to support.
-      // Don't forgot to update your package.json as well.
+      // Don't forget to update your package.json as well.
       formats: ['es', 'cjs'],
     },
     rollupOptions: {
@@ -168,7 +168,7 @@ export default defineConfig({
       name: 'react-lib-nonb-vitest',
       fileName: 'index',
       // Change this to the formats you want to support.
-      // Don't forgot to update your package.json as well.
+      // Don't forget to update your package.json as well.
       formats: ['es', 'cjs'],
     },
     rollupOptions: {

--- a/packages/vite/src/utils/__snapshots__/vite-config-edit-utils.spec.ts.snap
+++ b/packages/vite/src/utils/__snapshots__/vite-config-edit-utils.spec.ts.snap
@@ -20,7 +20,7 @@ import { joinPathFragments } from '@nx/devkit';
         name: 'my-app',
         fileName: 'index',
         // Change this to the formats you want to support.
-        // Don't forgot to update your package.json as well.
+        // Don't forget to update your package.json as well.
         formats: ['es', 'cjs']
       },
       rollupOptions: {
@@ -67,7 +67,7 @@ import { defineConfig } from 'vite';
         name: 'my-app',
         fileName: 'index',
         // Change this to the formats you want to support.
-        // Don't forgot to update your package.json as well.
+        // Don't forget to update your package.json as well.
         formats: ['es', 'cjs']
       },
       rollupOptions: {
@@ -119,7 +119,7 @@ import { defineConfig } from 'vite';
         name: 'my-app',
         fileName: 'index',
         // Change this to the formats you want to support.
-        // Don't forgot to update your package.json as well.
+        // Don't forget to update your package.json as well.
         formats: ['es', 'cjs']
       },
       rollupOptions: {
@@ -170,7 +170,7 @@ import { defineConfig } from 'vite';
         name: 'my-app',
         fileName: 'index',
         // Change this to the formats you want to support.
-        // Don't forgot to update your package.json as well.
+        // Don't forget to update your package.json as well.
         formats: ['es', 'cjs']
       },
       rollupOptions: {
@@ -218,7 +218,7 @@ exports[`ensureViteConfigIsCorrect should add build options if it is using condi
         ...{
           my: 'option',
         },
-        ..."\\n    // Configuration for building your library.\\n    // See: https://vitejs.dev/guide/build.html#library-mode\\n    build: {\\n      lib: {\\n        // Could also be a dictionary or array of multiple entry points.\\n        entry: 'src/index.ts',\\n        name: 'my-app',\\n        fileName: 'index',\\n        // Change this to the formats you want to support.\\n        // Don't forgot to update your package.json as well.\\n        formats: ['es', 'cjs']\\n      },\\n      rollupOptions: {\\n        // External packages that should not be bundled into your library.\\n        external: [\\"'react', 'react-dom', 'react/jsx-runtime'\\"]\\n      }\\n    },"
+        ..."\\n    // Configuration for building your library.\\n    // See: https://vitejs.dev/guide/build.html#library-mode\\n    build: {\\n      lib: {\\n        // Could also be a dictionary or array of multiple entry points.\\n        entry: 'src/index.ts',\\n        name: 'my-app',\\n        fileName: 'index',\\n        // Change this to the formats you want to support.\\n        // Don't forget to update your package.json as well.\\n        formats: ['es', 'cjs']\\n      },\\n      rollupOptions: {\\n        // External packages that should not be bundled into your library.\\n        external: [\\"'react', 'react-dom', 'react/jsx-runtime'\\"]\\n      }\\n    },"
      }
       }
     })
@@ -300,7 +300,7 @@ exports[`ensureViteConfigIsCorrect should not do anything if project has everyth
           name: 'pure-libs-react-vite',
           fileName: 'index',
           // Change this to the formats you want to support.
-          // Don't forgot to update your package.json as well.
+          // Don't forget to update your package.json as well.
           formats: ['es', 'cjs'],
         },
         rollupOptions: {

--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -500,7 +500,7 @@ export function createOrEditViteConfig(
           name: '${options.project}',
           fileName: 'index',
           // Change this to the formats you want to support.
-          // Don't forgot to update your package.json as well.
+          // Don't forget to update your package.json as well.
           formats: ['es', 'cjs']
         },
         rollupOptions: {

--- a/packages/vite/src/utils/test-files/test-vite-configs.ts
+++ b/packages/vite/src/utils/test-files/test-vite-configs.ts
@@ -178,7 +178,7 @@ export const hasEverything = `
           name: 'pure-libs-react-vite',
           fileName: 'index',
           // Change this to the formats you want to support.
-          // Don't forgot to update your package.json as well.
+          // Don't forget to update your package.json as well.
           formats: ['es', 'cjs'],
         },
         rollupOptions: {
@@ -208,7 +208,7 @@ export const buildOption = `
         name: 'my-app',
         fileName: 'index',
         // Change this to the formats you want to support.
-        // Don't forgot to update your package.json as well.
+        // Don't forget to update your package.json as well.
         formats: ['es', 'cjs']
       },
       rollupOptions: {


### PR DESCRIPTION
## Current Behavior

There is a typo in the comment generated in the vite.config.ts: `Don't forgot ...`.

## Expected Behavior

There should not be a typo. I have removed it by telling my IDE to replace all occurances. The tests also still pass. 