### PR TITLE
[do not merge] fix(vite): properly replace env variables

### DIFF
--- a/packages/vite/src/executors/build/build.impl.ts
+++ b/packages/vite/src/executors/build/build.impl.ts
@@ -16,7 +16,11 @@ import {
 import { existsSync, writeFileSync } from 'fs';
 import { resolve } from 'path';
 import { createAsyncIterable } from '@nx/devkit/src/utils/async-iterable';
-import { registerPaths, validateTypes } from '../../utils/executor-utils';
+import {
+  registerPaths,
+  validateTypes,
+  replaceEnvVarsWithinEnv,
+} from '../../utils/executor-utils';
 
 export async function* viteBuildExecutor(
   options: ViteBuildExecutorOptions,
@@ -26,6 +30,7 @@ export async function* viteBuildExecutor(
     context.projectsConfigurations.projects[context.projectName].root;
 
   registerPaths(projectRoot, options, context);
+  replaceEnvVarsWithinEnv();
 
   const normalizedOptions = normalizeOptions(options);
 

--- a/packages/vite/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/vite/src/executors/dev-server/dev-server.impl.ts
@@ -11,7 +11,10 @@ import {
 
 import { ViteDevServerExecutorOptions } from './schema';
 import { ViteBuildExecutorOptions } from '../build/schema';
-import { registerPaths } from '../../utils/executor-utils';
+import {
+  replaceEnvVarsWithinEnv,
+  registerPaths,
+} from '../../utils/executor-utils';
 
 export async function* viteDevServerExecutor(
   options: ViteDevServerExecutorOptions,
@@ -21,6 +24,7 @@ export async function* viteDevServerExecutor(
     context.projectsConfigurations.projects[context.projectName].root;
 
   registerPaths(projectRoot, options, context);
+  replaceEnvVarsWithinEnv();
 
   // Retrieve the option for the configured buildTarget.
   const buildTargetOptions: ViteBuildExecutorOptions = getNxTargetOptions(

--- a/packages/vite/src/utils/executor-utils.spec.ts
+++ b/packages/vite/src/utils/executor-utils.spec.ts
@@ -1,0 +1,35 @@
+import { replaceEnvVarsWithinEnv } from './executor-utils';
+
+describe('Test options utils', () => {
+  describe('replaceEnvVarsWithinEnv', () => {
+    let originalProcessEnv;
+
+    beforeEach(() => {
+      originalProcessEnv = { ...process.env };
+    });
+
+    afterEach(() => {
+      process.env = originalProcessEnv;
+    });
+
+    it('should correctly replace environment variables within other environment variables', () => {
+      process.env.VITE_KEY = '123';
+      process.env.VITE_KEY1 = 'test$foo';
+      process.env.VITE_KEY2 = 'test\\$foo';
+      process.env.VITE_KEY3 = 'test$VITE_KEY';
+      process.env.VITE_KEY4 = 'HELLO';
+      process.env.VITE_API_PATH = '/api/v2/$VITE_KEY';
+      process.env.NX_API_PATH = '/api/v2/$VITE_KEY';
+
+      replaceEnvVarsWithinEnv();
+
+      expect(process.env.VITE_KEY).toBe('123');
+      expect(process.env.VITE_KEY1).toBe('test');
+      expect(process.env.VITE_KEY2).toBe('test$foo');
+      expect(process.env.VITE_KEY3).toBe('test123');
+      expect(process.env.VITE_KEY4).toBe('HELLO');
+      expect(process.env.VITE_API_PATH).toBe('/api/v2/123');
+      expect(process.env.NX_API_PATH).toBe('/api/v2/$VITE_KEY');
+    });
+  });
+});

--- a/packages/vite/src/utils/executor-utils.ts
+++ b/packages/vite/src/utils/executor-utils.ts
@@ -55,3 +55,33 @@ export function registerPaths(
     registerTsConfigPaths(tsConfig);
   }
 }
+
+/**
+ * This function makes sure that the behaviour of Vite in replacing variables
+ * that reference other variables is maintained in Nx.
+ */
+export function replaceEnvVarsWithinEnv() {
+  const envVariablePattern = /(?<!\\)\$\{?(\w+)\}?/;
+
+  for (const key in process.env) {
+    if (
+      Object.hasOwnProperty.call(process.env, key) &&
+      key.startsWith('VITE_')
+    ) {
+      let value = process.env[key];
+
+      let match: any;
+      while ((match = envVariablePattern.exec(value))) {
+        const fullMatch = match[0];
+        const referencedKey = match[1];
+
+        const replacement = process.env[referencedKey] || '';
+        value = value.replace(fullMatch, replacement);
+      }
+
+      value = value.replace(/\\\$/g, '$');
+
+      process.env[key] = value;
+    }
+  }
+}


### PR DESCRIPTION
## Current Behavior

Current behaviour is explained in #17461

If I have a `.env` file like this:
```
VITE_KEY=123
VITE_KEY2=test$VITE_KEY
```

the result will be `123` and `test$VITE_KEY`.

## Expected Behavior

The result should be `123` and `test123`, as described in the Vite documentation: https://vitejs.dev/guide/env-and-mode.html

This PR introduces a new function `replaceEnvVarsWithinEnv` that enhances the way we handle environment variables in our Vite Build Executor. Previously, references to other environment variables were not being replaced in the Nx executor as they would be when using `vite build`. With this change, we now scan all environment variables for references to other variables (denoted by a $ prefix) and replace them with their corresponding values. The function handles edge cases such as escaped variable references and cases where the referenced variable is undefined, in consistency with Vite.

## Related Issue(s)

Fixes #17461

## Note

I noticed that the same "issue" exists with webpack, which maybe makes sense, since we're calling these builders programmatically, and the substitution maybe happens one step before, when invoking them directly?
