### PR TITLE
fix(angular): automatically skip remotes not in the current workspace #17473

### DIFF
--- a/docs/generated/packages/angular/executors/module-federation-dev-server.json
+++ b/docs/generated/packages/angular/executors/module-federation-dev-server.json
@@ -107,7 +107,7 @@
       "skipRemotes": {
         "type": "array",
         "items": { "type": "string" },
-        "description": "List of remote applications to not automatically serve, either statically or in development mode. This can be useful for multi-repository module federation setups where the host application uses a remote application from an external repository."
+        "description": "List of remote applications to not automatically serve, either statically or in development mode."
       },
       "pathToManifestFile": {
         "type": "string",

--- a/docs/generated/packages/angular/executors/module-federation-dev-ssr.json
+++ b/docs/generated/packages/angular/executors/module-federation-dev-ssr.json
@@ -72,7 +72,7 @@
       "skipRemotes": {
         "type": "array",
         "items": { "type": "string" },
-        "description": "List of remote applications to not automatically serve, either statically or in development mode. This can be useful for multi-repository module federation setups where the host application uses a remote application from an external repository."
+        "description": "List of remote applications to not automatically serve, either statically or in development mode."
       },
       "verbose": {
         "type": "boolean",

--- a/docs/generated/packages/react/executors/module-federation-dev-server.json
+++ b/docs/generated/packages/react/executors/module-federation-dev-server.json
@@ -18,7 +18,7 @@
       "skipRemotes": {
         "type": "array",
         "items": { "type": "string" },
-        "description": "List of remote applications to not automatically serve, either statically or in development mode. This can be useful for multi-repository module federation setups where the host application uses a remote application from an external repository.",
+        "description": "List of remote applications to not automatically serve, either statically or in development mode.",
         "x-priority": "important"
       },
       "buildTarget": {

--- a/docs/generated/packages/react/executors/module-federation-ssr-dev-server.json
+++ b/docs/generated/packages/react/executors/module-federation-ssr-dev-server.json
@@ -34,7 +34,7 @@
       "skipRemotes": {
         "type": "array",
         "items": { "type": "string" },
-        "description": "List of remote applications to not automatically serve, either statically or in development mode. This can be useful for multi-repository module federation setups where the host application uses a remote application from an external repository.",
+        "description": "List of remote applications to not automatically serve, either statically or in development mode.",
         "x-priority": "important"
       },
       "host": {

--- a/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -1,5 +1,10 @@
 import type { Schema } from './schema';
-import { readCachedProjectGraph, workspaceRoot, Workspaces } from '@nx/devkit';
+import {
+  logger,
+  readCachedProjectGraph,
+  workspaceRoot,
+  Workspaces,
+} from '@nx/devkit';
 import { scheduleTarget } from 'nx/src/adapter/ngcli-adapter';
 import { executeWebpackDevServerBuilder } from '../webpack-dev-server/webpack-dev-server.impl';
 import { readProjectsConfigurationFromProjectGraph } from 'nx/src/project-graph/project-graph';
@@ -51,6 +56,12 @@ export function executeModuleFederationDevServerBuilder(
   const remotesToSkip = new Set(
     findMatchingProjects(options.skipRemotes, projectGraph.nodes) ?? []
   );
+
+  if (remotesToSkip.size > 0) {
+    logger.info(
+      `Remotes not served automatically: ${[...remotesToSkip].join(', ')}`
+    );
+  }
   const staticRemotes = getStaticRemotes(
     project,
     context,

--- a/packages/angular/src/builders/module-federation-dev-server/schema.json
+++ b/packages/angular/src/builders/module-federation-dev-server/schema.json
@@ -117,7 +117,7 @@
       "items": {
         "type": "string"
       },
-      "description": "List of remote applications to not automatically serve, either statically or in development mode. This can be useful for multi-repository module federation setups where the host application uses a remote application from an external repository."
+      "description": "List of remote applications to not automatically serve, either statically or in development mode."
     },
     "pathToManifestFile": {
       "type": "string",

--- a/packages/angular/src/builders/module-federation-dev-ssr/schema.json
+++ b/packages/angular/src/builders/module-federation-dev-ssr/schema.json
@@ -73,7 +73,7 @@
       "items": {
         "type": "string"
       },
-      "description": "List of remote applications to not automatically serve, either statically or in development mode. This can be useful for multi-repository module federation setups where the host application uses a remote application from an external repository."
+      "description": "List of remote applications to not automatically serve, either statically or in development mode."
     },
     "verbose": {
       "type": "boolean",

--- a/packages/nx/src/utils/find-matching-projects.spec.ts
+++ b/packages/nx/src/utils/find-matching-projects.spec.ts
@@ -2,8 +2,8 @@ import {
   findMatchingProjects,
   getMatchingStringsWithCache,
 } from './find-matching-projects';
-import minimatch = require('minimatch');
 import type { ProjectGraphProjectNode } from '../config/project-graph';
+import minimatch = require('minimatch');
 
 describe('findMatchingProjects', () => {
   let projectGraph: Record<string, ProjectGraphProjectNode> = {

--- a/packages/react/src/executors/module-federation-dev-server/schema.json
+++ b/packages/react/src/executors/module-federation-dev-server/schema.json
@@ -19,7 +19,7 @@
       "items": {
         "type": "string"
       },
-      "description": "List of remote applications to not automatically serve, either statically or in development mode. This can be useful for multi-repository module federation setups where the host application uses a remote application from an external repository.",
+      "description": "List of remote applications to not automatically serve, either statically or in development mode.",
       "x-priority": "important"
     },
     "buildTarget": {

--- a/packages/react/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
@@ -46,9 +46,27 @@ export default async function* moduleFederationSsrDevServer(
   }
 
   const remotesToSkip = new Set(options.skipRemotes ?? []);
-  const knownRemotes = (moduleFederationConfig.remotes ?? []).filter(
-    (r) => !remotesToSkip.has(r)
-  );
+  const remotesNotInWorkspace: string[] = [];
+  const knownRemotes = (moduleFederationConfig.remotes ?? []).filter((r) => {
+    const validRemote = Array.isArray(r) ? r[0] : r;
+
+    if (remotesToSkip.has(validRemote)) {
+      return false;
+    } else if (!context.projectGraph.nodes[validRemote]) {
+      remotesNotInWorkspace.push(validRemote);
+      return false;
+    } else {
+      return true;
+    }
+  });
+
+  if (remotesNotInWorkspace.length > 0) {
+    logger.warn(
+      `Skipping serving ${remotesNotInWorkspace.join(
+        ', '
+      )} as they could not be found in the workspace. Ensure they are served correctly.`
+    );
+  }
 
   const devServeApps = !options.devRemotes
     ? []

--- a/packages/react/src/executors/module-federation-ssr-dev-server/schema.json
+++ b/packages/react/src/executors/module-federation-ssr-dev-server/schema.json
@@ -35,7 +35,7 @@
       "items": {
         "type": "string"
       },
-      "description": "List of remote applications to not automatically serve, either statically or in development mode. This can be useful for multi-repository module federation setups where the host application uses a remote application from an external repository.",
+      "description": "List of remote applications to not automatically serve, either statically or in development mode.",
       "x-priority": "important"
     },
     "host": {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We error if we try to serve remotes that are not in the current workspace.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Skip trying to serve remotes that we cannot find in the current workspace

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17473
Fixes #17957 
