### PR TITLE
fix(webpack): add migration for css minimizer plugin

### DIFF
--- a/packages/webpack/migrations.json
+++ b/packages/webpack/migrations.json
@@ -40,6 +40,15 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "16.4.0": {
+      "version": "16.4.0-beta.3",
+      "packages": {
+        "css-minimizer-webpack-plugin": {
+          "version": "^5.0.0",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Added a migration [for the version bump](https://github.com/nrwl/nx/pull/17456).
