### PR TITLE
fix(core): handle string and array parserOptions.project values

### DIFF
--- a/packages/workspace/src/generators/move/lib/update-eslintrc-json.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-eslintrc-json.spec.ts
@@ -200,4 +200,33 @@ describe('updateEslint', () => {
       })
     );
   });
+
+  it('should update .eslintrc.json parserOptions.project as a string', async () => {
+    await libraryGenerator(tree, {
+      name: 'my-lib',
+      linter: Linter.EsLint,
+      setParserOptionsProject: true,
+    });
+
+    // Add another parser project to eslint.json
+    const storybookProject = '.storybook/tsconfig.json';
+    updateJson(tree, '/libs/my-lib/.eslintrc.json', (eslintRcJson) => {
+      eslintRcJson.overrides[0].parserOptions.project = `libs/my-lib/${storybookProject}`;
+      return eslintRcJson;
+    });
+
+    // This step is usually handled elsewhere
+    tree.rename(
+      'libs/my-lib/.eslintrc.json',
+      'libs/shared/my-destination/.eslintrc.json'
+    );
+    const projectConfig = readProjectConfiguration(tree, 'my-lib');
+
+    updateEslintrcJson(tree, schema, projectConfig);
+
+    expect(
+      readJson(tree, '/libs/shared/my-destination/.eslintrc.json').overrides[0]
+        .parserOptions
+    ).toEqual({ project: `libs/shared/my-destination/${storybookProject}` });
+  });
 });

--- a/packages/workspace/src/generators/move/lib/update-eslintrc-json.ts
+++ b/packages/workspace/src/generators/move/lib/update-eslintrc-json.ts
@@ -64,14 +64,20 @@ export function updateEslintrcJson(
       );
     }
 
-    eslintRcJson.overrides?.forEach((o) => {
-      if (o.parserOptions?.project) {
-        o.parserOptions.project = o.parserOptions.project.map((p) =>
-          p.replace(project.root, schema.relativeToRootDestination)
-        );
+    eslintRcJson.overrides?.forEach(
+      (o: { parserOptions?: { project?: string | string[] } }) => {
+        if (o.parserOptions?.project) {
+          o.parserOptions.project = Array.isArray(o.parserOptions.project)
+            ? o.parserOptions.project.map((p) =>
+                p.replace(project.root, schema.relativeToRootDestination)
+              )
+            : o.parserOptions.project.replace(
+                project.root,
+                schema.relativeToRootDestination
+              );
+        }
       }
-    });
-
+    );
     return eslintRcJson;
   });
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`nx g @nx/workspace:move` errors out when moving a file with .eslintrc.json where the parseOptions.project is set to a string instead of an array value, like in [nx-examples](https://github.com/nrwl/nx-examples/blob/f3493f59d4746786c738500cd223d2fea04832bf/apps/products-e2e/.eslintrc.json#L8)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
both string and array values are correctly moved

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
