### PR TITLE
chore(repo): set lerna npmClient to pnpm when necessary

### DIFF
--- a/e2e/utils/create-project-utils.ts
+++ b/e2e/utils/create-project-utils.ts
@@ -449,11 +449,25 @@ export function newLernaWorkspace({
       encoding: 'utf-8',
     });
 
+    if (packageManager === 'pnpm') {
+      // pnpm doesn't use the normal package.json packages field so lerna needs to be told that pnpm is the client.
+      updateJson('lerna.json', (json) => {
+        json.npmClient = 'pnpm';
+        return json;
+      });
+    }
+
     execSync(pm.install, {
       cwd: tmpProjPath(),
       stdio: isVerbose() ? 'inherit' : 'pipe',
       env: { CI: 'true', ...process.env },
       encoding: 'utf-8',
+    });
+
+    // Format files to ensure no changes are made during lerna repair
+    execSync(`${pm.runUninstalledPackage} prettier . --write`, {
+      cwd: tmpProjPath(),
+      stdio: 'ignore',
     });
 
     return projScope;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Lerna v7 needs to know the npmClient when its `pnpm` but we didn't set it.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

We set the npmClient for lerna to run correctly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
