### PR TITLE
fix(js): mark importPath option as important since it is required for publishable libs

### DIFF
--- a/docs/generated/packages/js/generators/library.json
+++ b/docs/generated/packages/js/generators/library.json
@@ -59,10 +59,6 @@
         "description": "The test environment to use if unitTestRunner is set to jest.",
         "default": "jsdom"
       },
-      "importPath": {
-        "type": "string",
-        "description": "The library name used to import it, like @myorg/my-awesome-lib."
-      },
       "pascalCaseFiles": {
         "type": "boolean",
         "description": "Use pascal case file names.",
@@ -83,6 +79,11 @@
         "type": "boolean",
         "default": false,
         "description": "Generate a publishable library.",
+        "x-priority": "important"
+      },
+      "importPath": {
+        "type": "string",
+        "description": "The library name used to import it, like @myorg/my-awesome-lib. Required for publishable library.",
         "x-priority": "important"
       },
       "buildable": {

--- a/packages/js/src/generators/library/schema.json
+++ b/packages/js/src/generators/library/schema.json
@@ -59,10 +59,6 @@
       "description": "The test environment to use if unitTestRunner is set to jest.",
       "default": "jsdom"
     },
-    "importPath": {
-      "type": "string",
-      "description": "The library name used to import it, like @myorg/my-awesome-lib."
-    },
     "pascalCaseFiles": {
       "type": "boolean",
       "description": "Use pascal case file names.",
@@ -83,6 +79,11 @@
       "type": "boolean",
       "default": false,
       "description": "Generate a publishable library.",
+      "x-priority": "important"
+    },
+    "importPath": {
+      "type": "string",
+      "description": "The library name used to import it, like @myorg/my-awesome-lib. Required for publishable library.",
       "x-priority": "important"
     },
     "buildable": {


### PR DESCRIPTION
Currently, in Nx Console we are hiding the `importPath` option, but there is an error when not setting it for publishable libraries. This is confusing for the user because they don't see the options until they expand the hidden options panel.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #

