### PR TITLE
fix(nextjs): Update @nx/next to be a devDependency

### DIFF
--- a/packages/next/migrations.json
+++ b/packages/next/migrations.json
@@ -71,6 +71,12 @@
       "version": "16.3.0-beta.9",
       "description": "Remove root build option from project configurations since it is not needed.",
       "implementation": "./src/migrations/update-16-3-0/remove-root-build-option"
+    },
+    "update-16-4-0-update-next-dependency": {
+      "cli": "nx",
+      "version": "16.4.0-beta.3",
+      "description": "Update package.json moving @nx/next from dependency to devDependency",
+      "implementation": "./src/migrations/update-16-4-0/update-nx-next-dependency"
     }
   },
   "packageJsonUpdates": {

--- a/packages/next/src/generators/init/init.spec.ts
+++ b/packages/next/src/generators/init/init.spec.ts
@@ -14,7 +14,7 @@ describe('init', () => {
     await nextInitGenerator(tree, {});
     const packageJson = readJson(tree, 'package.json');
     expect(packageJson.dependencies['@nx/react']).toBeUndefined();
-    expect(packageJson.dependencies['@nx/next']).toBeDefined();
+    expect(packageJson.devDependencies['@nx/next']).toBeDefined();
     expect(packageJson.dependencies['next']).toBeDefined();
   });
 

--- a/packages/next/src/generators/init/init.ts
+++ b/packages/next/src/generators/init/init.ts
@@ -24,13 +24,13 @@ function updateDependencies(host: Tree) {
   return addDependenciesToPackageJson(
     host,
     {
-      '@nx/next': nxVersion,
       next: nextVersion,
       react: reactVersion,
       'react-dom': reactDomVersion,
       tslib: tsLibVersion,
     },
     {
+      '@nx/next': nxVersion,
       'eslint-config-next': eslintConfigNextVersion,
     }
   );

--- a/packages/next/src/migrations/update-16-4-0/update-nx-next-dependency.spec.ts
+++ b/packages/next/src/migrations/update-16-4-0/update-nx-next-dependency.spec.ts
@@ -1,0 +1,26 @@
+import { Tree, readJson, updateJson } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from 'nx/src/devkit-testing-exports';
+import update from './update-nx-next-dependency';
+
+describe('update-nx-next-dependency', () => {
+  let tree: Tree;
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+
+    updateJson(tree, 'package.json', (json) => {
+      json.dependencies['@nx/next'] = '16.0.0';
+      return json;
+    });
+  });
+
+  it('should move @nx/next from dependencies to devDependencies', async () => {
+    await update(tree);
+
+    expect(
+      readJson(tree, 'package.json').dependencies['@nx/next']
+    ).not.toBeDefined();
+    expect(
+      readJson(tree, 'package.json').devDependencies['@nx/next']
+    ).toBeDefined();
+  });
+});

--- a/packages/next/src/migrations/update-16-4-0/update-nx-next-dependency.ts
+++ b/packages/next/src/migrations/update-16-4-0/update-nx-next-dependency.ts
@@ -1,0 +1,16 @@
+import { Tree, formatFiles, updateJson } from '@nx/devkit';
+import type { PackageJson } from 'nx/src/utils/package-json';
+
+export default async function update(tree: Tree) {
+  if (tree.exists('./package.json')) {
+    updateJson<PackageJson>(tree, 'package.json', (packageJson) => {
+      if (packageJson.dependencies['@nx/next']) {
+        packageJson.devDependencies['@nx/next'] =
+          packageJson.dependencies['@nx/next'];
+        delete packageJson.dependencies['@nx/next'];
+      }
+      return packageJson;
+    });
+  }
+  await formatFiles(tree);
+}


### PR DESCRIPTION
closes: #13732

Since `withNx` has been compiled out into `.nx-helpers` we can move `@nx/next` from a depedency to devDependency
