### PR TITLE
feat(js): add setup-build generator for JS packages

### DIFF
--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -5102,6 +5102,14 @@
                 "children": [],
                 "isExternal": false,
                 "disableCollapsible": false
+              },
+              {
+                "id": "setup-build",
+                "path": "/packages/js/generators/setup-build",
+                "name": "setup-build",
+                "children": [],
+                "isExternal": false,
+                "disableCollapsible": false
               }
             ],
             "isExternal": false,

--- a/docs/generated/manifests/packages.json
+++ b/docs/generated/manifests/packages.json
@@ -1058,6 +1058,15 @@
         "originalFilePath": "/packages/js/src/generators/setup-verdaccio/schema.json",
         "path": "/packages/js/generators/setup-verdaccio",
         "type": "generator"
+      },
+      "/packages/js/generators/setup-build": {
+        "description": "setup-build generator",
+        "file": "generated/packages/js/generators/setup-build.json",
+        "hidden": false,
+        "name": "setup-build",
+        "originalFilePath": "/packages/js/src/generators/setup-build/schema.json",
+        "path": "/packages/js/generators/setup-build",
+        "type": "generator"
       }
     },
     "path": "/packages/js"

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -1042,6 +1042,15 @@
         "originalFilePath": "/packages/js/src/generators/setup-verdaccio/schema.json",
         "path": "js/generators/setup-verdaccio",
         "type": "generator"
+      },
+      {
+        "description": "setup-build generator",
+        "file": "generated/packages/js/generators/setup-build.json",
+        "hidden": false,
+        "name": "setup-build",
+        "originalFilePath": "/packages/js/src/generators/setup-build/schema.json",
+        "path": "js/generators/setup-build",
+        "type": "generator"
       }
     ],
     "githubRoot": "https://github.com/nrwl/nx/blob/master",

--- a/docs/generated/packages/esbuild/generators/esbuild-project.json
+++ b/docs/generated/packages/esbuild/generators/esbuild-project.json
@@ -55,6 +55,11 @@
         "description": "Platform target for outputs.",
         "enum": ["browser", "node", "neutral"],
         "default": "node"
+      },
+      "buildTarget": {
+        "description": "The build target to add.",
+        "type": "string",
+        "default": "build"
       }
     },
     "required": [],

--- a/docs/generated/packages/js/generators/setup-build.json
+++ b/docs/generated/packages/js/generators/setup-build.json
@@ -1,0 +1,51 @@
+{
+  "name": "setup-build",
+  "factory": "./src/generators/setup-build/generator",
+  "schema": {
+    "$schema": "http://json-schema.org/schema",
+    "$id": "SetupBuild",
+    "title": "Setup Build",
+    "description": "Sets up build target for a project.",
+    "type": "object",
+    "properties": {
+      "project": {
+        "type": "string",
+        "description": "Project to add the build target to.",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-prompt": "Which project do you want to add build to?",
+        "x-dropdown": "projects",
+        "x-priority": "important"
+      },
+      "bundler": {
+        "description": "The bundler to use to build the project.",
+        "type": "string",
+        "enum": ["tsc", "swc", "rollup", "vite", "esbuild"],
+        "default": "tsc",
+        "x-prompt": "Which bundler would you like to use to build the project?",
+        "x-priority": "important"
+      },
+      "main": {
+        "description": "The path to the main entry file, relative to workspace root. Defaults to <project>/src/index.ts or <project>/src/main.ts.",
+        "type": "string"
+      },
+      "tsConfig": {
+        "description": "The path to the tsConfig file, relative to workspace root. Defaults to <project>/tsconfig.lib.json or <project>/tsconfig.app.json depending on project type.",
+        "type": "string"
+      },
+      "buildTarget": {
+        "description": "The build target to add.",
+        "type": "string",
+        "default": "build"
+      }
+    },
+    "required": ["project", "bundler"],
+    "presets": []
+  },
+  "alias": ["build"],
+  "description": "setup-build generator",
+  "implementation": "/packages/js/src/generators/setup-build/generator.ts",
+  "aliases": [],
+  "hidden": false,
+  "path": "/packages/js/src/generators/setup-build/schema.json",
+  "type": "generator"
+}

--- a/docs/generated/packages/rollup/generators/rollup-project.json
+++ b/docs/generated/packages/rollup/generators/rollup-project.json
@@ -64,6 +64,11 @@
       "rollupConfig": {
         "type": "string",
         "description": "Path relative to workspace root to a custom rollup file that takes a config object and returns an updated config."
+      },
+      "buildTarget": {
+        "description": "The build target to add.",
+        "type": "string",
+        "default": "build"
       }
     },
     "required": [],

--- a/e2e/js/src/js.test.ts
+++ b/e2e/js/src/js.test.ts
@@ -149,12 +149,15 @@ export function ${lib}Wildcard() {
     runCLI(`test ${consumerLib}`);
   });
 
-  it('should not be able to be built when it has no bundler', () => {
-    const nonBuildable = uniq('buildable');
+  it('should be able to add build to non-buildable projects', () => {
+    const nonBuildable = uniq('nonbuildable');
+
     runCLI(`generate @nx/js:lib ${nonBuildable} --bundler=none`);
-
     expect(() => runCLI(`build ${nonBuildable}`)).toThrow();
+    checkFilesDoNotExist(`dist/libs/${nonBuildable}/src/index.js`);
 
-    checkFilesDoNotExist(`dist/libs/${nonBuildable}/README.md`);
+    runCLI(`generate @nx/js:setup-build ${nonBuildable} --bundler=tsc`);
+    runCLI(`build ${nonBuildable}`);
+    checkFilesExist(`dist/libs/${nonBuildable}/src/index.js`);
   });
 });

--- a/packages/esbuild/index.ts
+++ b/packages/esbuild/index.ts
@@ -1,6 +1,3 @@
-export type {
-  EsBuildExecutorOptions,
-  NormalizedEsBuildExecutorOptions,
-} from './src/executors/esbuild/schema';
-export * from './src/executors/esbuild/esbuild.impl';
+export * from './src/generators/init/init';
+export * from './src/generators/esbuild-project/esbuild-project';
 export * from './src/utils/versions';

--- a/packages/esbuild/src/generators/esbuild-project/esbuild-project.ts
+++ b/packages/esbuild/src/generators/esbuild-project/esbuild-project.ts
@@ -22,6 +22,7 @@ export async function esbuildProjectGenerator(
     ...options,
     skipFormat: true,
   });
+  options.buildTarget ??= 'build';
   checkForTargetConflicts(tree, options);
   addBuildTarget(tree, options);
   await formatFiles(tree);
@@ -31,9 +32,9 @@ export async function esbuildProjectGenerator(
 function checkForTargetConflicts(tree: Tree, options: EsBuildProjectSchema) {
   if (options.skipValidation) return;
   const project = readProjectConfiguration(tree, options.project);
-  if (project.targets?.build) {
+  if (project.targets?.[options.buildTarget]) {
     throw new Error(
-      `Project "${options.project}" already has a build target. Pass --skipValidation to ignore this error.`
+      `Project "${options.project}" already has a ${options.buildTarget} target. Pass --skipValidation to ignore this error.`
     );
   }
 }
@@ -80,7 +81,7 @@ function addBuildTarget(tree: Tree, options: EsBuildProjectSchema) {
     ...project,
     targets: {
       ...project.targets,
-      build: {
+      [options.buildTarget]: {
         executor: '@nx/esbuild:esbuild',
         outputs: ['{options.outputPath}'],
         defaultConfiguration: 'production',

--- a/packages/esbuild/src/generators/esbuild-project/schema.d.ts
+++ b/packages/esbuild/src/generators/esbuild-project/schema.d.ts
@@ -9,4 +9,5 @@ export interface EsBuildProjectSchema {
   importPath?: string;
   esbuildConfig?: string;
   platform?: 'node' | 'browser' | 'neutral';
+  buildTarget?: string;
 }

--- a/packages/esbuild/src/generators/esbuild-project/schema.json
+++ b/packages/esbuild/src/generators/esbuild-project/schema.json
@@ -55,6 +55,11 @@
       "description": "Platform target for outputs.",
       "enum": ["browser", "node", "neutral"],
       "default": "node"
+    },
+    "buildTarget": {
+      "description": "The build target to add.",
+      "type": "string",
+      "default": "build"
     }
   },
   "required": [],

--- a/packages/esbuild/src/generators/init/init.spec.ts
+++ b/packages/esbuild/src/generators/init/init.spec.ts
@@ -16,6 +16,7 @@ describe('esbuildInitGenerator', () => {
 
     const packageJson = readJson(tree, 'package.json');
     expect(packageJson.devDependencies).toEqual({
+      '@nx/esbuild': expect.any(String),
       esbuild: expect.any(String),
     });
   });

--- a/packages/esbuild/src/generators/init/init.ts
+++ b/packages/esbuild/src/generators/init/init.ts
@@ -6,12 +6,14 @@ import {
 } from '@nx/devkit';
 import { Schema } from './schema';
 import { esbuildVersion } from '@nx/js/src/utils/versions';
+import { nxVersion } from '../../utils/versions';
 
 export async function esbuildInitGenerator(tree: Tree, schema: Schema) {
   const task = addDependenciesToPackageJson(
     tree,
     {},
     {
+      '@nx/esbuild': nxVersion,
       esbuild: esbuildVersion,
     }
   );

--- a/packages/js/generators.json
+++ b/packages/js/generators.json
@@ -29,6 +29,12 @@
       "schema": "./src/generators/setup-verdaccio/schema.json",
       "alias": ["verdaccio"],
       "description": "Setup Verdaccio for local package management."
+    },
+    "setup-build": {
+      "factory": "./src/generators/setup-build/generator#setupBuildSchematic",
+      "schema": "./src/generators/setup-build/schema.json",
+      "alias": ["build"],
+      "description": "setup-build generator"
     }
   },
   "generators": {
@@ -59,6 +65,12 @@
       "schema": "./src/generators/setup-verdaccio/schema.json",
       "alias": ["verdaccio"],
       "description": "Setup Verdaccio for local package management."
+    },
+    "setup-build": {
+      "factory": "./src/generators/setup-build/generator",
+      "schema": "./src/generators/setup-build/schema.json",
+      "alias": ["build"],
+      "description": "setup-build generator"
     }
   }
 }

--- a/packages/js/src/generators/setup-build/generator.spec.ts
+++ b/packages/js/src/generators/setup-build/generator.spec.ts
@@ -1,0 +1,222 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import {
+  addProjectConfiguration,
+  readProjectConfiguration,
+  Tree,
+  writeJson,
+} from '@nx/devkit';
+
+import { setupBuildGenerator } from './generator';
+
+describe('setup-build generator', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+    addProjectConfiguration(tree, 'mypkg', {
+      root: 'packages/mypkg',
+      sourceRoot: 'packages/mypkg/src',
+    });
+  });
+
+  it('should find main and tsConfig files automatically', async () => {
+    tree.write('packages/mypkg/src/index.ts', 'console.log("hello world");');
+    writeJson(tree, 'packages/mypkg/tsconfig.lib.json', {});
+
+    await setupBuildGenerator(tree, { project: 'mypkg', bundler: 'tsc' });
+
+    const config = readProjectConfiguration(tree, 'mypkg');
+    expect(config).toMatchObject({
+      targets: {
+        build: {
+          executor: '@nx/js:tsc',
+          options: {
+            outputPath: 'dist/packages/mypkg',
+            main: 'packages/mypkg/src/index.ts',
+            tsConfig: 'packages/mypkg/tsconfig.lib.json',
+          },
+        },
+      },
+    });
+  });
+
+  it('should support user-defined main and tsConfig files', async () => {
+    tree.write(
+      'packages/mypkg/src/custom-main.ts',
+      'console.log("hello world");'
+    );
+    writeJson(tree, 'packages/mypkg/tsconfig.custom.json', {});
+
+    await setupBuildGenerator(tree, {
+      project: 'mypkg',
+      bundler: 'tsc',
+      main: 'packages/mypkg/src/custom-main.ts',
+      tsConfig: 'packages/mypkg/tsconfig.custom.json',
+    });
+
+    const config = readProjectConfiguration(tree, 'mypkg');
+    expect(config).toMatchObject({
+      targets: {
+        build: {
+          executor: '@nx/js:tsc',
+          options: {
+            outputPath: 'dist/packages/mypkg',
+            main: 'packages/mypkg/src/custom-main.ts',
+            tsConfig: 'packages/mypkg/tsconfig.custom.json',
+          },
+        },
+      },
+    });
+  });
+
+  it('should error when eithe main or tsConfig is not found', async () => {
+    expect(
+      setupBuildGenerator(tree, {
+        project: 'mypkg',
+        bundler: 'tsc',
+      })
+    ).rejects.toThrow(/Cannot locate a main file for mypkg/);
+
+    tree.write('packages/mypkg/src/main.ts', 'console.log("hello world");');
+
+    expect(
+      setupBuildGenerator(tree, {
+        project: 'mypkg',
+        bundler: 'tsc',
+      })
+    ).rejects.toThrow(/Cannot locate a tsConfig file for mypkg/);
+
+    expect(
+      setupBuildGenerator(tree, {
+        project: 'mypkg',
+        bundler: 'tsc',
+        main: 'packages/mypkg/src/custom-main.ts',
+      })
+    ).rejects.toThrow(/Cannot locate a main file for mypkg/);
+
+    expect(
+      setupBuildGenerator(tree, {
+        project: 'mypkg',
+        bundler: 'tsc',
+        tsConfig: 'packages/mypkg/tsconfig.custom.json',
+      })
+    ).rejects.toThrow(/Cannot locate a tsConfig file for mypkg/);
+  });
+
+  it('should support --bundler=swc', async () => {
+    tree.write('packages/mypkg/src/main.ts', 'console.log("hello world");');
+    writeJson(tree, 'packages/mypkg/tsconfig.lib.json', {});
+
+    await setupBuildGenerator(tree, {
+      project: 'mypkg',
+      bundler: 'swc',
+    });
+
+    const config = readProjectConfiguration(tree, 'mypkg');
+    expect(config).toMatchObject({
+      targets: {
+        build: {
+          executor: '@nx/js:swc',
+          options: {
+            outputPath: 'dist/packages/mypkg',
+            main: 'packages/mypkg/src/main.ts',
+            tsConfig: 'packages/mypkg/tsconfig.lib.json',
+          },
+        },
+      },
+    });
+  });
+
+  it('should support --bundler=rollup', async () => {
+    tree.write('packages/mypkg/src/main.ts', 'console.log("hello world");');
+    writeJson(tree, 'packages/mypkg/tsconfig.lib.json', {});
+
+    await setupBuildGenerator(tree, {
+      project: 'mypkg',
+      bundler: 'rollup',
+    });
+
+    const config = readProjectConfiguration(tree, 'mypkg');
+    expect(config).toMatchObject({
+      targets: {
+        build: {
+          executor: '@nx/rollup:rollup',
+          options: {
+            outputPath: 'dist/packages/mypkg',
+            main: 'packages/mypkg/src/main.ts',
+            tsConfig: 'packages/mypkg/tsconfig.lib.json',
+          },
+        },
+      },
+    });
+  });
+
+  it('should support --bundler=esbuild', async () => {
+    tree.write('packages/mypkg/src/main.ts', 'console.log("hello world");');
+    writeJson(tree, 'packages/mypkg/tsconfig.lib.json', {});
+
+    await setupBuildGenerator(tree, {
+      project: 'mypkg',
+      bundler: 'esbuild',
+    });
+
+    const config = readProjectConfiguration(tree, 'mypkg');
+    expect(config).toMatchObject({
+      targets: {
+        build: {
+          executor: '@nx/esbuild:esbuild',
+          options: {
+            outputPath: 'dist/packages/mypkg',
+            main: 'packages/mypkg/src/main.ts',
+            tsConfig: 'packages/mypkg/tsconfig.lib.json',
+          },
+        },
+      },
+    });
+  });
+
+  it('should support --bundler=vite', async () => {
+    tree.write('packages/mypkg/src/main.ts', 'console.log("hello world");');
+    writeJson(tree, 'packages/mypkg/tsconfig.lib.json', {});
+
+    await setupBuildGenerator(tree, {
+      project: 'mypkg',
+      bundler: 'vite',
+    });
+
+    const config = readProjectConfiguration(tree, 'mypkg');
+    expect(config).toMatchObject({
+      targets: {
+        build: {
+          executor: '@nx/vite:build',
+          options: {
+            outputPath: 'dist/packages/mypkg',
+          },
+        },
+      },
+    });
+  });
+
+  it('should support different --buildTarget', async () => {
+    tree.write('packages/mypkg/src/main.ts', 'console.log("hello world");');
+    writeJson(tree, 'packages/mypkg/tsconfig.lib.json', {});
+
+    await setupBuildGenerator(tree, {
+      project: 'mypkg',
+      bundler: 'tsc',
+      buildTarget: 'custom-build',
+    });
+
+    const config = readProjectConfiguration(tree, 'mypkg');
+    expect(config).toMatchObject({
+      targets: {
+        'custom-build': {
+          executor: '@nx/js:tsc',
+          options: {
+            outputPath: 'dist/packages/mypkg',
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/js/src/generators/setup-build/generator.ts
+++ b/packages/js/src/generators/setup-build/generator.ts
@@ -1,0 +1,155 @@
+import {
+  convertNxGenerator,
+  ensurePackage,
+  formatFiles,
+  type GeneratorCallback,
+  joinPathFragments,
+  readProjectConfiguration,
+  runTasksInSerial,
+  type Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+import { addSwcConfig } from '../../utils/swc/add-swc-config';
+import { addSwcDependencies } from '../../utils/swc/add-swc-dependencies';
+import { nxVersion } from '../../utils/versions';
+import { SetupBuildGeneratorSchema } from './schema';
+
+export async function setupBuildGenerator(
+  tree: Tree,
+  options: SetupBuildGeneratorSchema
+): Promise<GeneratorCallback> {
+  const tasks: GeneratorCallback[] = [];
+  const project = readProjectConfiguration(tree, options.project);
+  const buildTarget = options.buildTarget ?? 'build';
+
+  project.targets ??= {};
+
+  let mainFile: string;
+  if (options.main) {
+    mainFile = options.main;
+  } else {
+    const root = project.sourceRoot ?? project.root;
+    for (const f of [
+      joinPathFragments(root, 'main.ts'),
+      joinPathFragments(root, 'main.js'),
+      joinPathFragments(root, 'index.ts'),
+      joinPathFragments(root, 'index.js'),
+    ]) {
+      if (tree.exists(f)) {
+        mainFile = f;
+        break;
+      }
+    }
+  }
+  if (!mainFile || !tree.exists(mainFile)) {
+    throw new Error(
+      `Cannot locate a main file for ${options.project}. Please specify one using --main=<file-path>.`
+    );
+  }
+
+  let tsConfigFile: string;
+  if (options.tsConfig) {
+    tsConfigFile = options.tsConfig;
+  } else {
+    for (const f of [
+      'tsconfig.lib.json',
+      'tsconfig.app.json',
+      'tsconfig.json',
+    ]) {
+      const candidate = joinPathFragments(project.root, f);
+      if (tree.exists(candidate)) {
+        tsConfigFile = candidate;
+        break;
+      }
+    }
+  }
+  if (!tsConfigFile || !tree.exists(tsConfigFile)) {
+    throw new Error(
+      `Cannot locate a tsConfig file for ${options.project}. Please specify one using --tsConfig=<file-path>.`
+    );
+  }
+
+  switch (options.bundler) {
+    case 'vite': {
+      const { viteConfigurationGenerator } = ensurePackage(
+        '@nx/vite',
+        nxVersion
+      );
+      const task = await viteConfigurationGenerator(tree, {
+        buildTarget: options.buildTarget,
+        project: options.project,
+        newProject: true,
+        uiFramework: 'none',
+        includeVitest: false,
+        includeLib: true,
+        skipFormat: true,
+      });
+      tasks.push(task);
+      break;
+    }
+    case 'esbuild': {
+      const { esbuildProjectGenerator } = ensurePackage(
+        '@nx/esbuild',
+        nxVersion
+      );
+      const task = await esbuildProjectGenerator(tree, {
+        main: mainFile,
+        buildTarget: options.buildTarget,
+        project: options.project,
+        skipFormat: true,
+      });
+      tasks.push(task);
+      break;
+    }
+    case 'rollup': {
+      const { rollupProjectGenerator } = ensurePackage('@nx/rollup', nxVersion);
+      const task = await rollupProjectGenerator(tree, {
+        buildTarget: options.buildTarget,
+        main: mainFile,
+        project: options.project,
+        skipFormat: true,
+        compiler: 'tsc',
+      });
+      tasks.push(task);
+      break;
+    }
+    case 'tsc': {
+      const outputPath = joinPathFragments('dist', project.root);
+      project.targets[buildTarget] = {
+        executor: `@nx/js:tsc`,
+        outputs: ['{options.outputPath}'],
+        options: {
+          outputPath,
+          main: mainFile,
+          tsConfig: tsConfigFile,
+          assets: [],
+        },
+      };
+      updateProjectConfiguration(tree, options.project, project);
+      break;
+    }
+    case 'swc': {
+      const outputPath = joinPathFragments('dist', project.root);
+      project.targets[buildTarget] = {
+        executor: `@nx/js:swc`,
+        outputs: ['{options.outputPath}'],
+        options: {
+          outputPath,
+          main: mainFile,
+          tsConfig: tsConfigFile,
+          assets: [],
+        },
+      };
+      updateProjectConfiguration(tree, options.project, project);
+      addSwcDependencies(tree);
+      addSwcConfig(tree, project.root, 'es6');
+    }
+  }
+
+  await formatFiles(tree);
+
+  return runTasksInSerial(...tasks);
+}
+
+export default setupBuildGenerator;
+export const setupBuildSchematic = convertNxGenerator(setupBuildGenerator);

--- a/packages/js/src/generators/setup-build/schema.d.ts
+++ b/packages/js/src/generators/setup-build/schema.d.ts
@@ -1,0 +1,7 @@
+export interface SetupBuildGeneratorSchema {
+  project: string;
+  bundler: 'tsc' | 'swc' | 'vite' | 'rollup' | 'esbuild';
+  main?: string;
+  tsConfig?: string;
+  buildTarget?: string;
+}

--- a/packages/js/src/generators/setup-build/schema.json
+++ b/packages/js/src/generators/setup-build/schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "$id": "SetupBuild",
+  "title": "Setup Build",
+  "description": "Sets up build target for a project.",
+  "type": "object",
+  "properties": {
+    "project": {
+      "type": "string",
+      "description": "Project to add the build target to.",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "Which project do you want to add build to?",
+      "x-dropdown": "projects",
+      "x-priority": "important"
+    },
+    "bundler": {
+      "description": "The bundler to use to build the project.",
+      "type": "string",
+      "enum": ["tsc", "swc", "rollup", "vite", "esbuild"],
+      "default": "tsc",
+      "x-prompt": "Which bundler would you like to use to build the project?",
+      "x-priority": "important"
+    },
+    "main": {
+      "description": "The path to the main entry file, relative to workspace root. Defaults to <project>/src/index.ts or <project>/src/main.ts.",
+      "type": "string"
+    },
+    "tsConfig": {
+      "description": "The path to the tsConfig file, relative to workspace root. Defaults to <project>/tsconfig.lib.json or <project>/tsconfig.app.json depending on project type.",
+      "type": "string"
+    },
+    "buildTarget": {
+      "description": "The build target to add.",
+      "type": "string",
+      "default": "build"
+    }
+  },
+  "required": ["project", "bundler"]
+}

--- a/packages/js/src/utils/swc/add-swc-config.ts
+++ b/packages/js/src/utils/swc/add-swc-config.ts
@@ -1,6 +1,4 @@
-// TODO(chau): change back to 2015 when https://github.com/swc-project/swc/issues/1108 is solved
-// target: 'es2015'
-import { logger, readJson, Tree, updateJson } from '@nx/devkit';
+import { type Tree } from '@nx/devkit';
 import { join } from 'path';
 
 export const defaultExclude = [

--- a/packages/rollup/src/generators/rollup-project/rollup-project.ts
+++ b/packages/rollup/src/generators/rollup-project/rollup-project.ts
@@ -21,6 +21,7 @@ export async function rollupProjectGenerator(
     ...options,
     skipFormat: true,
   });
+  options.buildTarget ??= 'build';
   checkForTargetConflicts(tree, options);
   addBuildTarget(tree, options);
   await formatFiles(tree);
@@ -30,9 +31,9 @@ export async function rollupProjectGenerator(
 function checkForTargetConflicts(tree: Tree, options: RollupProjectSchema) {
   if (options.skipValidation) return;
   const project = readProjectConfiguration(tree, options.project);
-  if (project.targets?.build) {
+  if (project.targets?.[options.buildTarget]) {
     throw new Error(
-      `Project "${options.project}" already has a build target. Pass --skipValidation to ignore this error.`
+      `Project "${options.project}" already has a ${options.buildTarget} target. Pass --skipValidation to ignore this error.`
     );
   }
 }
@@ -79,7 +80,7 @@ function addBuildTarget(tree: Tree, options: RollupProjectSchema) {
     ...project,
     targets: {
       ...project.targets,
-      build: {
+      [options.buildTarget]: {
         executor: '@nx/rollup:rollup',
         outputs: ['{options.outputPath}'],
         defaultConfiguration: 'production',

--- a/packages/rollup/src/generators/rollup-project/schema.d.ts
+++ b/packages/rollup/src/generators/rollup-project/schema.d.ts
@@ -9,4 +9,5 @@ export interface RollupProjectSchema {
   importPath?: string;
   external?: string[];
   rollupConfig?: string;
+  buildTarget?: string;
 }

--- a/packages/rollup/src/generators/rollup-project/schema.json
+++ b/packages/rollup/src/generators/rollup-project/schema.json
@@ -66,6 +66,11 @@
     "rollupConfig": {
       "type": "string",
       "description": "Path relative to workspace root to a custom rollup file that takes a config object and returns an updated config."
+    },
+    "buildTarget": {
+      "description": "The build target to add.",
+      "type": "string",
+      "default": "build"
     }
   },
   "required": []


### PR DESCRIPTION
This PR adds the `@nx/js:setup-build` generator for adding a `build` target to an existing project.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Closes #3427
