### PR TITLE
fix(core): ignore ignored .gitignore

### DIFF
--- a/packages/nx/src/daemon/server/watcher.ts
+++ b/packages/nx/src/daemon/server/watcher.ts
@@ -145,7 +145,9 @@ export async function subscribeToWorkspaceChanges(
           path: normalizePath(relative(workspaceRoot, event.path)),
         };
         if (
-          workspaceRelativeEvent.path.endsWith('.gitignore') ||
+          (workspaceRelativeEvent.path &&
+            !ignoreObj.ignores(workspaceRelativeEvent.path) &&
+            workspaceRelativeEvent.path.endsWith('.gitignore')) ||
           workspaceRelativeEvent.path === '.nxignore'
         ) {
           hasIgnoreFileUpdate = true;


### PR DESCRIPTION
## Current Behavior

If a change happens in a `.gitignore` it will kill the daemon.
For example if a `apps/myapp/ios/.gitignore` is changed like `@nx/expo:prebuild` does then the watch server will be killed.

## Expected Behavior

If `apps/myapp/ios` is already ignored then a change to the `.gitignore` in it will not change the actuall ignored files and thus the server should not restart.

