### PR TITLE
fix(bundling): support BABEL_ENV over NODE_ENV for babel config

### DIFF
--- a/packages/webpack/src/utils/with-nx.ts
+++ b/packages/webpack/src/utils/with-nx.ts
@@ -365,7 +365,7 @@ export function createLoaderFromCompiler(
           cwd: path.join(options.root, options.sourceRoot),
           emitDecoratorMetadata: tsConfig.options.emitDecoratorMetadata,
           isModern: true,
-          envName: process.env.NODE_ENV,
+          envName: process.env.BABEL_ENV ?? process.env.NODE_ENV,
           cacheDirectory: true,
           cacheCompression: false,
         },


### PR DESCRIPTION
This PR fixes a regression with our webpack build where `BABEL_ENV` is not used for babel builds.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
