### PR TITLE
feat(linter): allow globs in onlyDependOnLibsWithTags eslint-plugin configuration option

### DIFF
--- a/docs/shared/core-features/enforce-project-boundaries.md
+++ b/docs/shared/core-features/enforce-project-boundaries.md
@@ -94,7 +94,7 @@ First, use your project configuration (in `project.json` or `package.json`) to a
 {% /tab %}
 {% /tabs %}
 
-Next you should update your root lint configuration:
+Next, you should update your root lint configuration:
 
 - If you are using **ESLint** you should look for an existing rule entry in your root `.eslintrc.json` called `"@nx/enforce-module-boundaries"` and you should update the `"depConstraints"`:
 
@@ -129,44 +129,44 @@ Next you should update your root lint configuration:
 }
 ```
 
-With these constraints in place, `scope:client` projects can only depend on other `scope:client` projects or on `scope:shared` projects. And `scope:admin` projects can only depend on other `scope:admin` projects or on `scope:shared` projects. So `scope:client` and `scope:admin` cannot depend on each other.
+With these constraints in place, `scope:client` projects can only depend on projects with `scope:client` or `scope:shared`. And `scope:admin` projects can only depend on projects with `scope:admin` or `scope:shared`. So `scope:client` and `scope:admin` cannot depend on each other.
 
-Projects without any tags cannot depend on any other projects, unless you allow all tags (see below).
-
-If you try to violate the constraints, you will get an error when linting:
+Projects without any tags cannot depend on any other projects. If you try to violate the constraints, you will get an error when linting:
 
 ```shell
 A project tagged with "scope:admin" can only depend on projects
 tagged with "scoped:shared" or "scope:admin".
 ```
 
+The exception to this rule is by explicitly allowing all tags (see below).
+
 ### Tag formats
-
-- `string`: allow exact tags
-
-Example: projects tagged with `scope:client` can only depend on projects tagged `scope:client`
-
-```json
-{
-  "sourceTag": "scope:client",
-  "onlyDependOnLibsWithTags": ["scope:client"]
-}
-```
 
 - `*`: allow all tags
 
 Example: projects with any tags (including untagged) can depend on any other project.
 
-```json
+```jsonc
 {
   "sourceTag": "*",
   "onlyDependOnLibsWithTags": ["*"]
 }
 ```
 
+- `string`: allow exact tags
+
+Example: projects tagged with `scope:client` can only depend on projects tagged with `scope:util`.
+
+```jsonc
+{
+  "sourceTag": "scope:client",
+  "onlyDependOnLibsWithTags": ["scope:util"]
+}
+```
+
 - `regex`: allow tags matching the regular expression
 
-Example: projects tagged with `scope:client` can depend on projects with a tag matching the regular expression `/^scope.*/`. In this case `scope:a`, `scope:b`, etc are all allowed tags for dependencies.
+Example: projects tagged with `scope:client` can depend on projects with a tag matching the regular expression `/^scope.*/`. In this case, the `scope:util`, `scope:client`, etc. are all allowed tags for dependencies.
 
 ```json
 {
@@ -185,3 +185,5 @@ Example: projects with a tag starting with `scope:` can depend on projects with 
   "onlyDependOnLibsWithTags": ["scope:*"]
 }
 ```
+
+Globbing supports only the basic use of `*`. For more complex scenarios use the `regex` above.

--- a/docs/shared/core-features/enforce-project-boundaries.md
+++ b/docs/shared/core-features/enforce-project-boundaries.md
@@ -131,7 +131,31 @@ Next you should update your root lint configuration:
 
 With these constraints in place, `scope:client` projects can only depend on other `scope:client` projects or on `scope:shared` projects. And `scope:admin` projects can only depend on other `scope:admin` projects or on `scope:shared` projects. So `scope:client` and `scope:admin` cannot depend on each other.
 
-Projects without any tags cannot depend on any other projects. If you add the following, projects without any tags will be able to depend on any other project.
+Projects without any tags cannot depend on any other projects, unless you allow all tags (see below).
+
+If you try to violate the constraints, you will get an error when linting:
+
+```shell
+A project tagged with "scope:admin" can only depend on projects
+tagged with "scoped:shared" or "scope:admin".
+```
+
+### Tag formats
+
+- `string`: allow exact tags
+
+Example: projects tagged with `scope:client` can only depend on projects tagged `scope:client`
+
+```json
+{
+  "sourceTag": "scope:client",
+  "onlyDependOnLibsWithTags": ["scope:client"]
+}
+```
+
+- `*`: allow all tags
+
+Example: projects with any tags (including untagged) can depend on any other project.
 
 ```json
 {
@@ -140,9 +164,24 @@ Projects without any tags cannot depend on any other projects. If you add the fo
 }
 ```
 
-If you try to violate the constraints, you will get an error when linting:
+- `regex`: allow tags matching the regular expression
 
-```shell
-A project tagged with "scope:admin" can only depend on projects
-tagged with "scoped:shared" or "scope:admin".
+Example: projects tagged with `scope:client` can depend on projects with a tag matching the regular expression `/^scope.*/`. In this case `scope:a`, `scope:b`, etc are all allowed tags for dependencies.
+
+```json
+{
+  "sourceTag": "scope:client",
+  "onlyDependOnLibsWithTags": ["/^scope.*/"]
+}
+```
+
+- `glob`: allow tags matching the glob
+
+Example: projects with a tag starting with `scope:` can depend on projects with a tag that starts with `scope:*`. In this case `scope:a`, `scope:b`, etc are all allowed tags for dependencies.
+
+```json
+{
+  "sourceTag": "scope:*",
+  "onlyDependOnLibsWithTags": ["scope:*"]
+}
 ```

--- a/packages/eslint-plugin/src/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin/src/rules/enforce-module-boundaries.spec.ts
@@ -877,6 +877,32 @@ Violation detected in:
       expect(failures.length).toEqual(0);
     });
 
+    it('should support globs', () => {
+      const failures = runRule(
+        {
+          depConstraints: [
+            {
+              sourceTag: 'p*',
+              onlyDependOnLibsWithTags: ['domain*'],
+            },
+          ],
+        },
+        `${process.cwd()}/proj/libs/public/src/index.ts`,
+        `
+          import '@mycompany/impl-domain2';
+          import('@mycompany/impl-domain2');
+          import '@mycompany/impl-both-domains';
+          import('@mycompany/impl-both-domains');
+          import '@mycompany/impl';
+          import('@mycompany/impl');
+        `,
+        graph,
+        fileMap
+      );
+
+      expect(failures.length).toEqual(0);
+    });
+
     it('should report errors for combo source tags', () => {
       const failures = runRule(
         {

--- a/packages/eslint-plugin/src/utils/runtime-lint-utils.spec.ts
+++ b/packages/eslint-plugin/src/utils/runtime-lint-utils.spec.ts
@@ -11,6 +11,7 @@ import {
   findTransitiveExternalDependencies,
   hasBannedDependencies,
   hasBannedImport,
+  hasNoneOfTheseTags,
   isAngularSecondaryEntrypoint,
   isTerminalRun,
 } from './runtime-lint-utils';
@@ -79,6 +80,28 @@ describe('findConstraintsFor', () => {
         data: { root: '.', tags: ['baz'] },
       })
     ).toEqual([{ sourceTag: '/a|b/', onlyDependOnLibsWithTags: ['c'] }]);
+  });
+
+  it('should find constraints matching glob', () => {
+    const constriants: DepConstraint[] = [
+      { sourceTag: 'a:*', onlyDependOnLibsWithTags: ['b:*'] },
+      { sourceTag: 'b:*', onlyDependOnLibsWithTags: ['c:*'] },
+      { sourceTag: 'c:*', onlyDependOnLibsWithTags: ['a:*'] },
+    ];
+    expect(
+      findConstraintsFor(constriants, {
+        type: 'lib',
+        name: 'someLib',
+        data: { root: '.', tags: ['a:a'] },
+      })
+    ).toEqual([{ sourceTag: 'a:*', onlyDependOnLibsWithTags: ['b:*'] }]);
+    expect(
+      findConstraintsFor(constriants, {
+        type: 'lib',
+        name: 'someLib',
+        data: { root: '.', tags: ['a:abc'] },
+      })
+    ).toEqual([{ sourceTag: 'a:*', onlyDependOnLibsWithTags: ['b:*'] }]);
   });
 });
 
@@ -473,4 +496,30 @@ describe('isAngularSecondaryEntrypoint', () => {
       )
     ).toBe(false);
   });
+});
+
+describe('hasNoneOfTheseTags', () => {
+  const source: ProjectGraphProjectNode = {
+    type: 'lib',
+    name: 'aLib',
+    data: {
+      tags: ['abc'],
+    } as any,
+  };
+
+  it.each([
+    [true, ['a']],
+    [true, ['b']],
+    [true, ['c']],
+    [true, ['az*']],
+    [true, ['/[A-Z]+/']],
+    [false, ['ab*']],
+    [false, ['*']],
+    [false, ['/[a-z]*/']],
+  ])(
+    'should return %s when project has tags ["abc"] and requested tags are %s',
+    (expected, tags) => {
+      expect(hasNoneOfTheseTags(source, tags)).toBe(expected);
+    }
+  );
 });

--- a/packages/eslint-plugin/src/utils/runtime-lint-utils.ts
+++ b/packages/eslint-plugin/src/utils/runtime-lint-utils.ts
@@ -103,6 +103,12 @@ function hasTag(proj: ProjectGraphProjectNode, tag: string): boolean {
     return (proj.data.tags || []).some((t) => regex.test(t));
   }
 
+  // if the tag is a glob, check if the project matches the glob prefix
+  if (tag.endsWith('*')) {
+    const prefix = tag.substring(0, tag.length - 1);
+    return (proj.data.tags || []).some((t) => t.startsWith(prefix));
+  }
+
   return (proj.data.tags || []).indexOf(tag) > -1;
 }
 

--- a/packages/eslint-plugin/src/utils/runtime-lint-utils.ts
+++ b/packages/eslint-plugin/src/utils/runtime-lint-utils.ts
@@ -104,9 +104,9 @@ function hasTag(proj: ProjectGraphProjectNode, tag: string): boolean {
   }
 
   // if the tag is a glob, check if the project matches the glob prefix
-  if (tag.endsWith('*')) {
-    const prefix = tag.substring(0, tag.length - 1);
-    return (proj.data.tags || []).some((t) => t.startsWith(prefix));
+  if (tag.includes('*')) {
+    const regex = mapGlobToRegExp(tag);
+    return (proj.data.tags || []).some((t) => regex.test(t));
   }
 
   return (proj.data.tags || []).indexOf(tag) > -1;
@@ -242,7 +242,7 @@ function isConstraintBanningProject(
   /* Check if import is banned... */
   if (
     bannedExternalImports?.some((importDefinition) =>
-      parseImportWildcards(importDefinition).test(packageName)
+      mapGlobToRegExp(importDefinition).test(packageName)
     )
   ) {
     return true;
@@ -250,8 +250,7 @@ function isConstraintBanningProject(
 
   /* ... then check if there is a whitelist and if there is a match in the whitelist.  */
   return allowedExternalImports?.every(
-    (importDefinition) =>
-      !parseImportWildcards(importDefinition).test(packageName)
+    (importDefinition) => !mapGlobToRegExp(importDefinition).test(packageName)
   );
 }
 
@@ -381,7 +380,7 @@ function packageExistsInPackageJson(
  * @param importDefinition
  * @returns
  */
-function parseImportWildcards(importDefinition: string): RegExp {
+function mapGlobToRegExp(importDefinition: string): RegExp {
   // we replace all instances of `*`, `**..*` and `.*` with `.*`
   const mappedWildcards = importDefinition.split(/(?:\.\*)|\*+/).join('.*');
   return new RegExp(`^${new RegExp(mappedWildcards).source}$`);


### PR DESCRIPTION
## Current Behavior
`onlyDependOnLibsWithTags` does not handle glob patterns in the tags list.  However, several other options for the `eslint-plugin` do support glob patterns.

## Expected Behavior
Update `onlyDependOnLibsWithTags` to handle glob patterns in tag lists. This allows a tagged package to depend on any packages matching the glob, rather than only specific tags.

Note: this behavior was already available, via Regex support. However, the ability to use regular expressions in the tag list was undocumented. This PR adds documentation for the new glob pattern as well as the existing regex pattern.

## Related Issue(s)

Fixes #15264

## Questions to maintainers

1. When I followed the instructions in the CONTRIBUTING.md file, my pnpm-lock file was modified to version 6.1. Should [this command be updated](https://github.com/nrwl/nx/blob/51cadbd4df23a1324cd1f94660f1480c6900640f/CONTRIBUTING.md?plain=1#L60)?
2. When I first cloned the repo, VSCode automatically prompted me to open in the dev container. Great! It also automatically ran `pnpm i` and it added 10k+ files to a `.pnpm-store` directory. Should this directory be added to `.gitignore`? This didn't happen when I ran `pnpm install` outside of the devcontainer, so I'm not clear where the discrepancy comes from
