### PR TITLE
chore(core): refactor and introduce readProjectsConfigurationsAsync

### DIFF
--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -152,9 +152,9 @@ async function processCollectedUpdatedAndDeletedFiles() {
       'hash-watched-changes-end'
     );
     fileHasher.incrementalUpdate(updatedFiles, deletedFiles);
-    const projectsConfiguration = new Workspaces(
+    const projectsConfiguration = await new Workspaces(
       workspaceRoot
-    ).readProjectsConfigurations();
+    ).readProjectsConfigurationsAsync();
     const workspaceConfigHash = computeWorkspaceConfigHash(
       projectsConfiguration
     );
@@ -237,9 +237,9 @@ async function createAndSerializeProjectGraph(): Promise<{
 }> {
   try {
     performance.mark('create-project-graph-start');
-    const projectsConfigurations = new Workspaces(
+    const projectsConfigurations = await new Workspaces(
       workspaceRoot
-    ).readProjectsConfigurations();
+    ).readProjectsConfigurationsAsync();
     const projectFileMap = copyFileMap(projectFileMapWithFiles.projectFileMap);
     const allWorkspaceFiles = copyFileData(
       projectFileMapWithFiles.allWorkspaceFiles

--- a/packages/nx/src/project-graph/project-graph.ts
+++ b/packages/nx/src/project-graph/project-graph.ts
@@ -72,9 +72,9 @@ export function readProjectsConfigurationFromProjectGraph(
 export async function buildProjectGraphWithoutDaemon() {
   await fileHasher.ensureInitialized();
 
-  const projectConfigurations = new Workspaces(
+  const projectConfigurations = await new Workspaces(
     workspaceRoot
-  ).readProjectsConfigurations();
+  ).readProjectsConfigurationsAsync();
 
   const { projectFileMap, allWorkspaceFiles } = createProjectFileMap(
     projectConfigurations,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`readProjectsConfigurations` is deprecated but there are no recommended way to do it.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`readProjectsConfigurationsAsync` is the new recommended way to do it.

Most of the logic is in a synchronous function which is easier to change.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
