### PR TITLE
fix(core): fix logic for determining if task can be hashed upfront

### DIFF
--- a/packages/nx/src/hasher/hash-task.ts
+++ b/packages/nx/src/hasher/hash-task.ts
@@ -33,8 +33,8 @@ export async function hashTasksThatDoNotDependOnOutputsOfOtherTasks(
         return false;
       }
 
-      return (
-        taskGraph.dependencies[task.id].length === 0 &&
+      return !(
+        taskGraph.dependencies[task.id].length > 0 &&
         !!getInputs(task, projectGraph, nxJson).depsOutputs
       );
     })


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Tasks were being hashed upfront even if they had dependencies on outputs of other tasks. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Tasks are only being hashed upfront if they do not have a custom hasher and they do not depend on outputs of other tasks

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
