### PR TITLE
fix(react): component test regex should not use global

### DIFF
--- a/packages/react/src/utils/ct-utils.ts
+++ b/packages/react/src/utils/ct-utils.ts
@@ -11,8 +11,8 @@ import { getComponentNode } from './ast-utils';
 
 let tsModule: typeof import('typescript');
 
-const allowedFileExt = new RegExp(/\.[jt]sx?/g);
-const isSpecFile = new RegExp(/(spec|test)\./g);
+const allowedFileExt = new RegExp(/\.[jt]sx?/);
+const isSpecFile = new RegExp(/(spec|test)\./);
 
 export interface FoundTarget {
   config?: TargetConfiguration;
@@ -56,6 +56,7 @@ function assertValidConfig(config: unknown) {
     );
   }
 }
+
 export async function getBundlerFromTarget(
   found: FoundTarget,
   tree: Tree


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The regex used to find files that can have cypress component tests generated automatically uses the `/g` global modifier. This means the RegEx object is tracking the location of where it has searched in a body of text.

The regex is not being used with a body of text, it is being used with different filepath, therefore the regex is searching new file paths after a certain index determined by previous searches. This can lead to incorrect results.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Do not use the `/g` modifier when testing filePaths

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
