### PR TITLE
fix(angular): find module from options should support full path #17547

### DIFF
--- a/packages/angular/src/generators/component/lib/module.ts
+++ b/packages/angular/src/generators/component/lib/module.ts
@@ -37,6 +37,7 @@ export function findModuleFromOptions(
     for (const c of candidatesDirs) {
       const candidateFiles = [
         '',
+        moduleBaseName,
         `${moduleBaseName}.ts`,
         `${moduleBaseName}${moduleExt}`,
       ].map((x) => joinPathFragments(c, x));


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When passing a --module to the component generator, if it contains the full path to the app module such that it also contains the file extension, the module is not being found

e.g. `src/app/app.module.ts` results in the following potential files
`src/app`
`src/app.module.ts.ts`
`src/app.module.ts.module.ts`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should allow for people bassing the full filename of the module

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17547
