### PR TITLE
fix(testing): update default webpack config for react CT

### DIFF
--- a/packages/angular/plugins/component-testing.ts
+++ b/packages/angular/plugins/component-testing.ts
@@ -101,7 +101,7 @@ ${e.stack ? e.stack : e}`
   );
 
   return {
-    ...nxBaseCypressPreset(pathToConfig),
+    ...nxBaseCypressPreset(pathToConfig, { testingType: 'component' }),
     // NOTE: cannot use a glob pattern since it will break cypress generated tsconfig.
     specPattern: ['src/**/*.cy.ts', 'src/**/*.cy.js'],
     // cypress defaults to a relative path from the workspaceRoot instead of projectRoot

--- a/packages/cypress/plugins/cypress-preset.ts
+++ b/packages/cypress/plugins/cypress-preset.ts
@@ -21,7 +21,13 @@ export interface NxComponentTestingOptions {
   bundler?: 'vite' | 'webpack';
 }
 
-export function nxBaseCypressPreset(pathToConfig: string): BaseCypressPreset {
+export function nxBaseCypressPreset(
+  pathToConfig: string,
+  options?: { testingType: 'component' | 'e2e' }
+): BaseCypressPreset {
+  // used to set babel settings for react CT.
+  process.env.NX_CYPRESS_COMPONENT_TEST =
+    options?.testingType === 'component' ? 'true' : 'false';
   // prevent from placing path outside the root of the workspace
   // if they pass in a file or directory
   const normalizedPath = lstatSync(pathToConfig).isDirectory()

--- a/packages/js/babel.ts
+++ b/packages/js/babel.ts
@@ -20,6 +20,9 @@ module.exports = function (api: any, options: NxWebBabelPresetOptions = {}) {
 
   const isModern = api.caller((caller) => caller?.isModern);
 
+  // use by @nx/cypress react component testing to prevent core js build issues
+  const isTest = api.caller((caller) => caller?.isTest);
+
   // This is set by `@nx/rollup:rollup` executor
   const isNxPackage = api.caller((caller) => caller?.isNxPackage);
 
@@ -39,7 +42,7 @@ module.exports = function (api: any, options: NxWebBabelPresetOptions = {}) {
         // For Jest tests, NODE_ENV is set as 'test' and we only want to set target as Node.
         // All other options will fail in Jest since Node does not support some ES features
         // such as import syntax.
-        process.env.NODE_ENV === 'test'
+        isTest || process.env.NODE_ENV === 'test'
           ? { targets: { node: 'current' }, loose: true }
           : {
               // Allow importing core-js in entrypoint and use browserslist to select polyfills.

--- a/packages/react/plugins/component-testing/index.ts
+++ b/packages/react/plugins/component-testing/index.ts
@@ -70,9 +70,13 @@ export function nxComponentTestingPreset(
     ? pathToConfig
     : dirname(pathToConfig);
 
+  const basePresetSettings = nxBaseCypressPreset(pathToConfig, {
+    testingType: 'component',
+  });
+
   if (options?.bundler === 'vite') {
     return {
-      ...nxBaseCypressPreset(pathToConfig),
+      ...basePresetSettings,
       specPattern: 'src/**/*.cy.{js,jsx,ts,tsx}',
       devServer: {
         ...({ framework: 'react', bundler: 'vite' } as const),
@@ -156,7 +160,7 @@ export function nxComponentTestingPreset(
   }
 
   return {
-    ...nxBaseCypressPreset(pathToConfig),
+    ...basePresetSettings,
     specPattern: 'src/**/*.cy.{js,jsx,ts,tsx}',
     devServer: {
       // cypress uses string union type,
@@ -252,6 +256,10 @@ function buildTargetWebpack(
     // TODO(jack): Once webpackConfig is always set in @nx/webpack:webpack, we no longer need this default.
     const defaultWebpack = getWebpackConfig(context, {
       ...options,
+      // cypress will generate its own index.html from component-index.html
+      generateIndexHtml: false,
+      // causes issues with buildable libraries with ENOENT: no such file or directory, scandir error
+      extractLicenses: false,
       root: workspaceRoot,
       projectRoot: ctProjectConfig.root,
       sourceRoot: ctProjectConfig.sourceRoot,
@@ -264,6 +272,7 @@ function buildTargetWebpack(
         configuration: parsed.configuration,
       });
     }
+
     return defaultWebpack;
   };
 }

--- a/packages/webpack/src/utils/web-babel-loader.ts
+++ b/packages/webpack/src/utils/web-babel-loader.ts
@@ -1,14 +1,18 @@
 module.exports = require('babel-loader').custom(() => {
   return {
-    customOptions({ isModern, emitDecoratorMetadata, ...loader }) {
+    customOptions({ isTest, isModern, emitDecoratorMetadata, ...loader }) {
       return {
-        custom: { isModern, emitDecoratorMetadata },
+        custom: { isTest, isModern, emitDecoratorMetadata },
         loader,
       };
     },
-    config(cfg, { customOptions: { isModern, emitDecoratorMetadata } }) {
+    config(
+      cfg,
+      { customOptions: { isTest, isModern, emitDecoratorMetadata } }
+    ) {
       // Add hint to our babel preset so it can handle modern vs legacy bundles.
       cfg.options.caller.isModern = isModern;
+      cfg.options.caller.isTest = isTest;
       cfg.options.caller.emitDecoratorMetadata = emitDecoratorMetadata;
       return cfg.options;
     },

--- a/packages/webpack/src/utils/with-nx.ts
+++ b/packages/webpack/src/utils/with-nx.ts
@@ -365,6 +365,7 @@ export function createLoaderFromCompiler(
           cwd: path.join(options.root, options.sourceRoot),
           emitDecoratorMetadata: tsConfig.options.emitDecoratorMetadata,
           isModern: true,
+          isTest: process.env.NX_CYPRESS_COMPONENT_TEST === 'true',
           envName: process.env.BABEL_ENV ?? process.env.NODE_ENV,
           cacheDirectory: true,
           cacheCompression: false,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Running react CT with webpack generated 3 different webpack errors with buildable libraries
1. `ERROR in Conflict: Multiple assets emit different content to the same filename index.html`
1. `Error: Can't resolve 'core-js/modules/es.object.assign.js'`
1. `Error: ENOENT: no such file or directory, scandir` via the license plugin

Most of these seem to only happen on windows, though sporadically happen on macOS at time.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

These errors do not happen when running CT.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

