### PR TITLE
docs(misc): fix link to edit page

### DIFF
--- a/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
@@ -140,10 +140,9 @@ export function DocViewer({
                   aria-hidden="true"
                   href={[
                     'https://github.com/nrwl/nx/blob/master',
-                    document.filePath.replace(
-                      'nx-dev/nx-dev/public/documentation',
-                      'docs'
-                    ),
+                    document.filePath
+                      .replace('nx-dev/nx-dev/public/documentation', 'docs')
+                      .replace('public/documentation', 'docs'),
                   ].join('/')}
                   target="_blank"
                   rel="noreferrer"


### PR DESCRIPTION
## Current Behavior

"Edit this page" link sends you here: https://github.com/nrwl/nx/blob/master/public/documentation/shared/core-tutorial/01-create-blog.md -> `https://github.com/nrwl/nx/blob/master/public/documentation/---`

example: https://nx.dev/core-tutorial/01-create-blog

## Expected Behavior

"Edit this page" link should send you here: https://github.com/nrwl/nx/blob/master/docs/shared/core-tutorial/01-create-blog.md -> `https://github.com/nrwl/nx/blob/master/docs/---`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17544
