### PR TITLE
feat(react): update types to match react version

### DIFF
--- a/graph/client/src/app/feature-tasks/task-list.tsx
+++ b/graph/client/src/app/feature-tasks/task-list.tsx
@@ -44,7 +44,7 @@ function ProjectListItem({
 
       {project.error ? (
         <Tooltip
-          content={<TaskGraphErrorTooltip error={project.error} />}
+          content={(<TaskGraphErrorTooltip error={project.error} />) as any}
           openAction="click"
           strategy="fixed"
         >

--- a/package.json
+++ b/package.json
@@ -114,8 +114,8 @@
     "@types/marked": "^2.0.0",
     "@types/node": "18.16.9",
     "@types/prettier": "^2.6.2",
-    "@types/react": "18.0.25",
-    "@types/react-dom": "18.0.9",
+    "@types/react": "18.2.12",
+    "@types/react-dom": "18.2.5",
     "@types/semver": "^7.3.8",
     "@types/tar-stream": "^2.2.2",
     "@types/tmp": "^0.2.0",
@@ -349,4 +349,3 @@
     ]
   }
 }
-

--- a/packages/next/src/generators/library/library.ts
+++ b/packages/next/src/generators/library/library.ts
@@ -98,6 +98,15 @@ export async function libraryGenerator(host: Tree, rawOptions: Schema) {
         }
         return path;
       });
+      if (!json.compilerOptions) {
+        json.compilerOptions = {
+          types: [],
+        };
+      }
+      if (!json.compilerOptions.types) {
+        json.compilerOptions.types = [];
+      }
+      json.compilerOptions.types.push('next');
       return json;
     }
   );

--- a/packages/react/migrations.json
+++ b/packages/react/migrations.json
@@ -899,6 +899,23 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "16.4.0-beta.7": {
+      "version": "16.4.0-beta.7",
+      "packages": {
+        "@types/react": {
+          "version": "18.2.12",
+          "alwaysAddToPackageJson": false
+        },
+        "@types/react-dom": {
+          "version": "18.2.5",
+          "alwaysAddToPackageJson": false
+        },
+        "@types/react-is": {
+          "version": "18.2.0",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/react/src/utils/versions.ts
+++ b/packages/react/src/utils/versions.ts
@@ -8,9 +8,9 @@ export const reactDomVersion = '18.2.0';
 export const reactIsVersion = '18.2.0';
 export const swcLoaderVersion = '0.1.15';
 export const babelLoaderVersion = '^9.1.2';
-export const typesReactVersion = '18.0.28';
-export const typesReactDomVersion = '18.0.11';
-export const typesReactIsVersion = '17.0.3';
+export const typesReactVersion = '18.2.12';
+export const typesReactDomVersion = '18.2.5';
+export const typesReactIsVersion = '18.2.0';
 
 export const typesNodeVersion = '18.14.2';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ overrides:
 dependencies:
   '@docsearch/react':
     specifier: ^3.3.0
-    version: 3.3.0(@algolia/client-search@4.17.0)(@types/react@18.0.25)(react-dom@18.2.0)(react@18.2.0)
+    version: 3.3.0(@algolia/client-search@4.17.0)(@types/react@18.2.12)(react-dom@18.2.0)(react@18.2.0)
   '@headlessui/react':
     specifier: ^1.7.3
     version: 1.7.3(react-dom@18.2.0)(react@18.2.0)
@@ -16,7 +16,7 @@ dependencies:
     version: 2.0.12(react@18.2.0)
   '@markdoc/markdoc':
     specifier: 0.2.2
-    version: 0.2.2(@types/react@18.0.25)(react@18.2.0)
+    version: 0.2.2(@types/react@18.2.12)(react@18.2.0)
   '@monaco-editor/react':
     specifier: ^4.4.6
     version: 4.4.6(monaco-editor@0.37.1)(react-dom@18.2.0)(react@18.2.0)
@@ -204,7 +204,7 @@ devDependencies:
     version: 7.21.0
   '@floating-ui/react':
     specifier: 0.19.2
-    version: 0.19.2(@types/react@18.0.25)(react-dom@18.2.0)(react@18.2.0)
+    version: 0.19.2(@types/react@18.2.12)(react-dom@18.2.0)(react@18.2.0)
   '@jest/reporters':
     specifier: ^29.4.1
     version: 29.5.0
@@ -404,11 +404,11 @@ devDependencies:
     specifier: ^2.6.2
     version: 2.7.1
   '@types/react':
-    specifier: 18.0.25
-    version: 18.0.25
+    specifier: 18.2.12
+    version: 18.2.12
   '@types/react-dom':
-    specifier: 18.0.9
-    version: 18.0.9
+    specifier: 18.2.5
+    version: 18.2.5
   '@types/semver':
     specifier: ^7.3.8
     version: 7.3.13
@@ -444,7 +444,7 @@ devDependencies:
     version: 0.7.0(ws@8.13.0)(xstate@4.34.0)
   '@xstate/react':
     specifier: 3.0.1
-    version: 3.0.1(@types/react@18.0.25)(react@18.2.0)(xstate@4.34.0)
+    version: 3.0.1(@types/react@18.2.12)(react@18.2.0)(xstate@4.34.0)
   ajv:
     specifier: ^8.11.0
     version: 8.11.0
@@ -738,7 +738,7 @@ devDependencies:
     version: 4.0.2(webpack@5.80.0)
   react-redux:
     specifier: 8.0.5
-    version: 8.0.5(@types/react-dom@18.0.9)(@types/react@18.0.25)(react-dom@18.2.0)(react@18.2.0)(redux@4.2.0)
+    version: 8.0.5(@types/react-dom@18.2.5)(@types/react@18.2.12)(react-dom@18.2.0)(react@18.2.0)(redux@4.2.0)
   react-refresh:
     specifier: ^0.10.0
     version: 0.10.0
@@ -3432,7 +3432,7 @@ packages:
     resolution: {integrity: sha512-rODCdDtGyudLj+Va8b6w6Y85KE85bXRsps/R4Yjwt5vueXKXZQKYw0aA9knxLBT6a/bI/GMrAcmCR75KYOM6hg==}
     dev: false
 
-  /@docsearch/react@3.3.0(@algolia/client-search@4.17.0)(@types/react@18.0.25)(react-dom@18.2.0)(react@18.2.0):
+  /@docsearch/react@3.3.0(@algolia/client-search@4.17.0)(@types/react@18.2.12)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-fhS5adZkae2SSdMYEMVg6pxI5a/cE+tW16ki1V0/ur4Fdok3hBRkmN/H8VvlXnxzggkQIIRIVvYPn00JPjen3A==}
     peerDependencies:
       '@types/react': '>= 16.8.0 < 19.0.0'
@@ -3449,7 +3449,7 @@ packages:
       '@algolia/autocomplete-core': 1.7.2
       '@algolia/autocomplete-preset-algolia': 1.7.2(@algolia/client-search@4.17.0)(algoliasearch@4.14.2)
       '@docsearch/css': 3.3.0
-      '@types/react': 18.0.25
+      '@types/react': 18.2.12
       algoliasearch: 4.14.2
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -3927,14 +3927,14 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: true
 
-  /@floating-ui/react@0.19.2(@types/react@18.0.25)(react-dom@18.2.0)(react@18.2.0):
+  /@floating-ui/react@0.19.2(@types/react@18.2.12)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-JyNk4A0Ezirq8FlXECvRtQOX/iBe5Ize0W/pLkrZjfHW9GUV7Xnq6zm6fyZuQzaHHqEnVizmvlA96e1/CkZv+w==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
       '@floating-ui/react-dom': 1.3.0(react-dom@18.2.0)(react@18.2.0)
-      aria-hidden: 1.2.2(@types/react@18.0.25)(react@18.2.0)
+      aria-hidden: 1.2.2(@types/react@18.2.12)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tabbable: 6.0.1
@@ -4414,7 +4414,7 @@ packages:
     resolution: {integrity: sha512-lYtBcmvHustHQtg4X7TXUu1Xa/tbLC3p2wLvgQI+fWVySguVZJF60Snxijw5EiohumxZbR10kWYFFebh1zotiw==}
     dev: true
 
-  /@markdoc/markdoc@0.2.2(@types/react@18.0.25)(react@18.2.0):
+  /@markdoc/markdoc@0.2.2(@types/react@18.2.12)(react@18.2.0):
     resolution: {integrity: sha512-0TiD9jmA5h5znN4lxo7HECAu3WieU5g5vUsfByeucrdR/x88hEilpt16EydFyJwJddQ/3w5HQgW7Ovy62r4cyw==}
     engines: {node: '>=14.7.0'}
     peerDependencies:
@@ -4426,7 +4426,7 @@ packages:
       react:
         optional: true
     dependencies:
-      '@types/react': 18.0.25
+      '@types/react': 18.2.12
       react: 18.2.0
     optionalDependencies:
       '@types/markdown-it': 12.2.3
@@ -4438,7 +4438,7 @@ packages:
       react: '>=16'
     dependencies:
       '@types/mdx': 2.0.4
-      '@types/react': 18.0.25
+      '@types/react': 18.2.12
       react: 18.2.0
     dev: true
 
@@ -6746,7 +6746,7 @@ packages:
     dependencies:
       immer: 9.0.16
       react: 18.2.0
-      react-redux: 8.0.5(@types/react-dom@18.0.9)(@types/react@18.0.25)(react-dom@18.2.0)(react@18.2.0)(redux@4.2.0)
+      react-redux: 8.0.5(@types/react-dom@18.2.5)(@types/react@18.2.12)(react-dom@18.2.0)(react@18.2.0)(redux@4.2.0)
       redux: 4.2.0
       redux-thunk: 2.4.2(redux@4.2.0)
       reselect: 4.1.7
@@ -8428,7 +8428,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       '@testing-library/dom': 8.19.0
-      '@types/react-dom': 18.0.9
+      '@types/react-dom': 18.2.5
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: true
@@ -8713,7 +8713,7 @@ packages:
   /@types/hoist-non-react-statics@3.3.1:
     resolution: {integrity: sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==}
     dependencies:
-      '@types/react': 18.0.25
+      '@types/react': 18.2.12
       hoist-non-react-statics: 3.3.2
     dev: true
 
@@ -8912,14 +8912,14 @@ packages:
     resolution: {integrity: sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==}
     dev: true
 
-  /@types/react-dom@18.0.9:
-    resolution: {integrity: sha512-qnVvHxASt/H7i+XG1U1xMiY5t+IHcPGUK7TDMDzom08xa7e86eCeKOiLZezwCKVxJn6NEiiy2ekgX8aQssjIKg==}
+  /@types/react-dom@18.2.5:
+    resolution: {integrity: sha512-sRQsOS/sCLnpQhR4DSKGTtWFE3FZjpQa86KPVbhUqdYMRZ9FEFcfAytKhR/vUG2rH1oFbOOej6cuD7MFSobDRQ==}
     dependencies:
-      '@types/react': 18.0.25
+      '@types/react': 18.2.12
     dev: true
 
-  /@types/react@18.0.25:
-    resolution: {integrity: sha512-xD6c0KDT4m7n9uD4ZHi02lzskaiqcBxf4zi+tXZY98a04wvc0hi/TcCPC2FOESZi51Nd7tlUeOJY8RofL799/g==}
+  /@types/react@18.2.12:
+    resolution: {integrity: sha512-ndmBMLCgn38v3SntMeoJaIrO6tGHYKMEBohCUmw8HoLLQdRMOIGXfeYaBTLe2lsFaSB3MOK1VXscYFnmLtTSmw==}
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
@@ -9659,7 +9659,7 @@ packages:
       xstate: 4.34.0
     dev: true
 
-  /@xstate/react@3.0.1(@types/react@18.0.25)(react@18.2.0)(xstate@4.34.0):
+  /@xstate/react@3.0.1(@types/react@18.2.12)(react@18.2.0)(xstate@4.34.0):
     resolution: {integrity: sha512-/tq/gg92P9ke8J+yDNDBv5/PAxBvXJf2cYyGDByzgtl5wKaxKxzDT82Gj3eWlCJXkrBg4J5/V47//gRJuVH2fA==}
     peerDependencies:
       '@xstate/fsm': ^2.0.0
@@ -9672,7 +9672,7 @@ packages:
         optional: true
     dependencies:
       react: 18.2.0
-      use-isomorphic-layout-effect: 1.1.2(@types/react@18.0.25)(react@18.2.0)
+      use-isomorphic-layout-effect: 1.1.2(@types/react@18.2.12)(react@18.2.0)
       use-sync-external-store: 1.2.0(react@18.2.0)
       xstate: 4.34.0
     transitivePeerDependencies:
@@ -10094,7 +10094,7 @@ packages:
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
-  /aria-hidden@1.2.2(@types/react@18.0.25)(react@18.2.0):
+  /aria-hidden@1.2.2(@types/react@18.2.12)(react@18.2.0):
     resolution: {integrity: sha512-6y/ogyDTk/7YAe91T3E2PR1ALVKyM2QbTio5HwM+N1Q6CMlCKhvClyIjkckBswa0f2xJhjsfzIGa1yVSe1UMVA==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -10104,7 +10104,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@types/react': 18.0.25
+      '@types/react': 18.2.12
       react: 18.2.0
       tslib: 2.5.0
     dev: true
@@ -21412,7 +21412,7 @@ packages:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
 
-  /react-redux@8.0.5(@types/react-dom@18.0.9)(@types/react@18.0.25)(react-dom@18.2.0)(react@18.2.0)(redux@4.2.0):
+  /react-redux@8.0.5(@types/react-dom@18.2.5)(@types/react@18.2.12)(react-dom@18.2.0)(react@18.2.0)(redux@4.2.0):
     resolution: {integrity: sha512-Q2f6fCKxPFpkXt1qNRZdEDLlScsDWyrgSj0mliK59qU6W5gvBiKkdMEG2lJzhd1rCctf0hb6EtePPLZ2e0m1uw==}
     peerDependencies:
       '@types/react': ^16.8 || ^17.0 || ^18.0
@@ -21435,8 +21435,8 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       '@types/hoist-non-react-statics': 3.3.1
-      '@types/react': 18.0.25
-      '@types/react-dom': 18.0.9
+      '@types/react': 18.2.12
+      '@types/react-dom': 18.2.5
       '@types/use-sync-external-store': 0.0.3
       hoist-non-react-statics: 3.3.2
       react: 18.2.0
@@ -24515,7 +24515,7 @@ packages:
       requires-port: 1.0.0
     dev: true
 
-  /use-isomorphic-layout-effect@1.1.2(@types/react@18.0.25)(react@18.2.0):
+  /use-isomorphic-layout-effect@1.1.2(@types/react@18.2.12)(react@18.2.0):
     resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==}
     peerDependencies:
       '@types/react': '*'
@@ -24524,7 +24524,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@types/react': 18.0.25
+      '@types/react': 18.2.12
       react: 18.2.0
     dev: true
 


### PR DESCRIPTION
and add next type to next lib

closed #17555

React `@types/*` should match React version. Also, add the `next` type in the `types` array of `tsconfig.lib.json` of Next.js libs.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17555
