### PR TITLE
chore(core): fix list typo

### DIFF
--- a/packages/nx/src/command-line/list/list.ts
+++ b/packages/nx/src/command-line/list/list.ts
@@ -53,7 +53,7 @@ export async function listHandler(args: ListArgs): Promise<void> {
       title: 'Community Plugins',
       bodyLines: [
         'Looking for a technology / framework not listed above?',
-        'There are many excellent plugins matintained by the Nx community.',
+        'There are many excellent plugins maintained by the Nx community.',
         'Search for the one you need here: https://nx.dev/plugins/registry.',
       ],
     });


### PR DESCRIPTION
Fixed typo in `list` output

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`nx list` output, contains typo of `matintained`:
![image](https://github.com/nrwl/nx/assets/7055026/bc3057a5-754f-47e5-9bc7-ccf7993f4e56)


## Expected Behavior
`matintained` changed to `maintained`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
