### PR TITLE
fix(linter): fix relative path detection

### DIFF
--- a/packages/eslint-plugin/src/utils/runtime-lint-utils.ts
+++ b/packages/eslint-plugin/src/utils/runtime-lint-utils.ts
@@ -129,7 +129,7 @@ export function matchImportWithWildcard(
 }
 
 export function isRelative(s: string) {
-  return s.startsWith('.');
+  return s.startsWith('./') || s.startsWith('../');
 }
 
 export function getTargetProjectBasedOnRelativeImport(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Import such as `import { User } from '.package'` are falsely treated as relative imports.

## Expected Behavior
Only imports starting with `./` and `../` should be treated as relative imports

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17201
