### PR TITLE
fix(core): ensure its file before reading

### DIFF
--- a/packages/nx/src/command-line/init/implementation/react/rename-js-to-jsx.ts
+++ b/packages/nx/src/command-line/init/implementation/react/rename-js-to-jsx.ts
@@ -1,5 +1,6 @@
 import { readFileSync, renameSync } from 'fs-extra';
 import { sync } from 'glob';
+import { fileExists } from '../../../../utils/fileutils';
 
 // Vite cannot process JSX like <div> or <Header> unless the file is named .jsx or .tsx
 export function renameJsToJsx(appName: string, isStandalone: boolean) {
@@ -8,11 +9,13 @@ export function renameJsToJsx(appName: string, isStandalone: boolean) {
   );
 
   files.forEach((file) => {
-    const content = readFileSync(file).toString();
-    // Try to detect JSX before renaming to .jsx
-    // Files like setupTests.js from CRA should not be renamed
-    if (/<[a-zA-Z0-9]+/.test(content)) {
-      renameSync(file, `${file}x`);
+    if (fileExists(file)) {
+      const content = readFileSync(file).toString();
+      // Try to detect JSX before renaming to .jsx
+      // Files like setupTests.js from CRA should not be renamed
+      if (/<[a-zA-Z0-9]+/.test(content)) {
+        renameSync(file, `${file}x`);
+      }
     }
   });
 }


### PR DESCRIPTION
Make sure glob match is file and not directory before attempting to read.

Fixes #17545
