### PR TITLE
fix(webpack): update withNx mainFields ordering to support tree-shaking

### DIFF
--- a/packages/webpack/src/utils/with-nx.ts
+++ b/packages/webpack/src/utils/with-nx.ts
@@ -21,7 +21,7 @@ const IGNORED_WEBPACK_WARNINGS = [
 ];
 
 const extensions = ['.ts', '.tsx', '.mjs', '.js', '.jsx'];
-const mainFields = ['main', 'module'];
+const mainFields = ['module', 'main'];
 
 const processed = new Set();
 


### PR DESCRIPTION
fix(webpack): with-nx default webpack resolve mainFields order breaking tree-shaking

___
## Current Behavior
Default webpack config     
`mainFields: [ 'browser', 'main', 'module', ]`

Broken Tree-shake.
`@mui/icons-material` in library package fully included in vendor bundle.


## Expected Behavior
Default webpack config     
`mainFields: [ 'browser', 'module', 'main' ]`


## Related Issue(s)
Closes #9717
Closes #3069

Fixes #
Reorder default resolve.mainFields 
