### PR TITLE
fix(testing): component testing generator should trust user to provide valid build target

### DIFF
--- a/packages/angular/src/generators/cypress-component-configuration/cypress-component-configuration.spec.ts
+++ b/packages/angular/src/generators/cypress-component-configuration/cypress-component-configuration.spec.ts
@@ -4,7 +4,6 @@ import {
   joinPathFragments,
   ProjectGraph,
   readProjectConfiguration,
-  stripIndents,
   Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
@@ -38,6 +37,10 @@ describe('Cypress Component Testing Configuration', () => {
     tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
     tree.write('.gitignore', '');
     mockedInstalledCypressVersion.mockReturnValue(10);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   describe('updateProjectConfig', () => {
@@ -165,7 +168,7 @@ describe('Cypress Component Testing Configuration', () => {
       });
     });
 
-    it('should throw with invalid --build-target', async () => {
+    it('should not throw with invalid --build-target', async () => {
       await generateTestApplication(tree, {
         name: 'fancy-app',
       });
@@ -213,12 +216,11 @@ describe('Cypress Component Testing Configuration', () => {
           buildTarget: 'fancy-app:build',
           generateTests: false,
         });
-      }).rejects.toThrowErrorMatchingInlineSnapshot(`
-        "Error trying to find build configuration. Try manually specifying the build target with the --build-target flag.
-        Provided project? fancy-lib
-        Provided build target? fancy-app:build
-        Provided Executors? @nx/angular:webpack-browser, @nrwl/angular:webpack-browser, @angular-devkit/build-angular:browser"
-      `);
+      }).resolves;
+
+      expect(
+        require('@nx/devkit').createProjectGraphAsync
+      ).not.toHaveBeenCalled();
     });
     it('should use own project config', async () => {
       await generateTestApplication(tree, {
@@ -847,6 +849,7 @@ async function setup(
     }
   }
 }
+
 function getCmpsFromTree(
   tree: Tree,
   options: { basePath: string; name: string }

--- a/packages/angular/src/generators/cypress-component-configuration/cypress-component-configuration.ts
+++ b/packages/angular/src/generators/cypress-component-configuration/cypress-component-configuration.ts
@@ -1,9 +1,12 @@
 import { cypressComponentConfiguration as baseCyCTConfig } from '@nx/cypress';
 import {
-  addMountDefinition,
   addDefaultCTConfig,
+  addMountDefinition,
 } from '@nx/cypress/src/utils/config';
-import { findBuildConfig } from '@nx/cypress/src/utils/find-target-options';
+import {
+  findBuildConfig,
+  FoundTarget,
+} from '@nx/cypress/src/utils/find-target-options';
 import {
   formatFiles,
   joinPathFragments,
@@ -45,6 +48,7 @@ export async function cypressComponentConfiguration(
     installTask();
   };
 }
+
 async function addFiles(
   tree: Tree,
   projectConfig: ProjectConfiguration,
@@ -116,17 +120,21 @@ async function updateProjectConfig(
   tree: Tree,
   options: CypressComponentConfigSchema
 ) {
-  const found = await findBuildConfig(tree, {
-    project: options.project,
-    buildTarget: options.buildTarget,
-    validExecutorNames: new Set<string>([
-      '@nx/angular:webpack-browser',
-      '@nrwl/angular:webpack-browser',
-      '@angular-devkit/build-angular:browser',
-    ]),
-  });
+  let found: FoundTarget = { target: options.buildTarget, config: undefined };
 
-  assertValidConfig(found?.config);
+  if (!options.buildTarget) {
+    found = await findBuildConfig(tree, {
+      project: options.project,
+      buildTarget: options.buildTarget,
+      validExecutorNames: new Set<string>([
+        '@nx/angular:webpack-browser',
+        '@nrwl/angular:webpack-browser',
+        '@angular-devkit/build-angular:browser',
+      ]),
+    });
+
+    assertValidConfig(found?.config);
+  }
 
   const projectConfig = readProjectConfiguration(tree, options.project);
   projectConfig.targets['component-test'].options = {

--- a/packages/cypress/src/utils/find-target-options.ts
+++ b/packages/cypress/src/utils/find-target-options.ts
@@ -27,7 +27,7 @@ interface FindTargetOptions {
   skipGetOptions?: boolean;
 }
 
-interface FoundTarget {
+export interface FoundTarget {
   config?: TargetConfiguration;
   target: string;
 }

--- a/packages/react/src/generators/cypress-component-configuration/cypress-component-configuration.spec.ts
+++ b/packages/react/src/generators/cypress-component-configuration/cypress-component-configuration.spec.ts
@@ -37,6 +37,10 @@ describe('React:CypressComponentTestConfiguration', () => {
     tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should generate cypress config with vite', async () => {
     mockedAssertCypressVersion.mockReturnValue();
 
@@ -395,7 +399,8 @@ describe('React:CypressComponentTestConfiguration', () => {
       tree.exists('libs/some-lib/src/lib/another-cmp/another-cmp.spec.cy.js')
     ).toBeFalsy();
   });
-  it('should throw error when an invalid --build-target is provided', async () => {
+
+  it('should not throw error when an invalid --build-target is provided', async () => {
     mockedAssertCypressVersion.mockReturnValue();
     await applicationGenerator(tree, {
       e2eTestRunner: 'none',
@@ -442,12 +447,10 @@ describe('React:CypressComponentTestConfiguration', () => {
         generateTests: true,
         buildTarget: 'my-app:build',
       });
-    }).rejects.toThrowErrorMatchingInlineSnapshot(`
-      "Error trying to find build configuration. Try manually specifying the build target with the --build-target flag.
-      Provided project? some-lib
-      Provided build target? my-app:build
-      Provided Executors? @nx/webpack:webpack, @nx/vite:build, @nrwl/webpack:webpack, @nrwl/vite:build"
-    `);
+    }).resolves;
+    expect(
+      require('@nx/devkit').createProjectGraphAsync
+    ).not.toHaveBeenCalled();
   });
 
   it('should setup cypress config files correctly', async () => {

--- a/packages/react/src/generators/cypress-component-configuration/cypress-component-configuration.ts
+++ b/packages/react/src/generators/cypress-component-configuration/cypress-component-configuration.ts
@@ -6,7 +6,7 @@ import {
 } from '@nx/devkit';
 import { nxVersion } from '../../utils/versions';
 import { addFiles } from './lib/add-files';
-import { FoundTarget, addCTTargetWithBuildTarget } from '../../utils/ct-utils';
+import { addCTTargetWithBuildTarget } from '../../utils/ct-utils';
 import { CypressComponentConfigurationSchema } from './schema.d';
 
 /**
@@ -27,7 +27,7 @@ export async function cypressComponentConfigGenerator(
     skipFormat: true,
   });
 
-  const found: FoundTarget = await addCTTargetWithBuildTarget(tree, {
+  const found = await addCTTargetWithBuildTarget(tree, {
     project: options.project,
     buildTarget: options.buildTarget,
     validExecutorNames: new Set<string>([

--- a/packages/react/src/generators/cypress-component-configuration/lib/add-files.ts
+++ b/packages/react/src/generators/cypress-component-configuration/lib/add-files.ts
@@ -9,11 +9,8 @@ import {
 import { nxVersion } from 'nx/src/utils/versions';
 import { componentTestGenerator } from '../../component-test/component-test';
 import type { CypressComponentConfigurationSchema } from '../schema';
-import {
-  FoundTarget,
-  getBundlerFromTarget,
-  isComponent,
-} from '../../../utils/ct-utils';
+import { getBundlerFromTarget, isComponent } from '../../../utils/ct-utils';
+import { FoundTarget } from '@nx/cypress/src/utils/find-target-options';
 
 export async function addFiles(
   tree: Tree,
@@ -26,7 +23,12 @@ export async function addFiles(
   const { addMountDefinition, addDefaultCTConfig } = await import(
     '@nx/cypress/src/utils/config'
   );
-  const actualBundler = await getBundlerFromTarget(found, tree);
+
+  // Specifically undefined to allow Remix workaround of passing an empty string
+  const actualBundler =
+    options.buildTarget !== undefined && options.bundler
+      ? options.bundler
+      : await getBundlerFromTarget(found, tree);
 
   if (options.bundler && options.bundler !== actualBundler) {
     logger.warn(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Component Testing Configuration requires a build target to be passed or it tries to find one. This can cause errors to be thrown during the validation step of the build target.
It impacts using the generators in a programatic manner and blocks Remix Component Testing

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Trust that the developer has provided a valid build target

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
