### PR TITLE
chore(repo): fix publishing workflow for freebsd

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -190,7 +190,7 @@ jobs:
              freebsd-version
              mkdir -p /Users/runner/work/_temp/_github_workflow
              echo "{}" > /Users/runner/work/_temp/_github_workflow/event.json
-             pnpm install --frozen-lockfile --dev --ignore-scripts --no-optional
+             pnpm install --frozen-lockfile --dev --ignore-scripts
              pnpm nx run-many --target=build-native -- --target=x86_64-unknown-freebsd
              rm -rf node_modules
        - name: Upload artifact


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

FreeBSD doesn't install optional dependencies.. so Nx says it doesn't have support.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

FreeBSD does install optional dependencies.. and Nx works.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
