### PR TITLE
fix(core): do not build the project graph in nx report if there's no native support

### DIFF
--- a/docs/shared/installation/troubleshoot-installation.md
+++ b/docs/shared/installation/troubleshoot-installation.md
@@ -10,9 +10,10 @@ If you see a message saying that your platform is not supported (or that Nx cann
 are a few reasons why this could potentially happen:
 
 1. Running your install command with `--no-optional` (or the relative flag in yarn, pnpm, etc)
-2. The package-lock.json file was not correctly updated by npm, and missed optional dependencies used by Nx.
+1. Running your install with `--dev` for pnpm.
+1. The package-lock.json file was not correctly updated by npm, and missed optional dependencies used by Nx.
    You can read more about this [issue on the npm repository.](https://github.com/npm/cli/issues/4828)
-3. [Your platform is not supported](#supported-native-module-platforms)
+1. [Your platform is not supported](#supported-native-module-platforms)
 
 {% callout type="note" title="Updating Nx" %}
 When updating Nx that is already on 15.8, the package-lock.json should continue to be updated properly with all the proper optional dependencies.

--- a/packages/nx/src/command-line/report/report.ts
+++ b/packages/nx/src/command-line/report/report.ts
@@ -152,10 +152,12 @@ export async function getReportData(): Promise<ReportData> {
   const communityPlugins = findInstalledCommunityPlugins();
 
   let projectGraphError: Error | null = null;
-  try {
-    await createProjectGraphAsync();
-  } catch (e) {
-    projectGraphError = e;
+  if (isNativeAvailable()) {
+    try {
+      await createProjectGraphAsync();
+    } catch (e) {
+      projectGraphError = e;
+    }
   }
 
   const packageVersionsWeCareAbout = findInstalledPackagesWeCareAbout();
@@ -307,4 +309,13 @@ export function findInstalledPackagesWeCareAbout() {
     package: pkg,
     version,
   }));
+}
+
+function isNativeAvailable() {
+  try {
+    require('../../native');
+    return true;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
If we're on a system that does not have native support, nx report will still try to build the project graph.

Because some dependencies for the project graph uses native code, nx report will output incorrect messages

## Expected Behavior
Nx report does not try to use the project graph when generating the report when there's no native support

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
