### PR TITLE
feat(react): bump emotion packages versions

### DIFF
--- a/packages/react/migrations.json
+++ b/packages/react/migrations.json
@@ -916,6 +916,23 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "16.4.0-beta.8": {
+      "version": "16.4.0-beta.8",
+      "packages": {
+        "@emotion/styled": {
+          "version": "11.11.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@emotion/react": {
+          "version": "11.11.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@emotion/babel-plugin": {
+          "version": "11.11.0",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/react/src/utils/versions.ts
+++ b/packages/react/src/utils/versions.ts
@@ -19,9 +19,9 @@ export const babelPresetReactVersion = '^7.14.5';
 export const styledComponentsVersion = '5.3.6';
 export const typesStyledComponentsVersion = '5.1.26';
 
-export const emotionStyledVersion = '11.10.6';
-export const emotionReactVersion = '11.10.6';
-export const emotionBabelPlugin = '11.10.6';
+export const emotionStyledVersion = '11.11.0';
+export const emotionReactVersion = '11.11.1';
+export const emotionBabelPlugin = '11.11.0';
 
 // WARNING: This needs to be in sync with Next.js' dependency or else there might be issues.
 export const styledJsxVersion = '5.1.2';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The installed `@emotion/react` package version doesn't play well with Typescript 5.1 and React 18. We'll add support for Typescript 5.1 as part of the Angular 16.1 support (https://github.com/nrwl/nx/pull/17155) and this surfaces the issue as can be seen in a failing e2e test https://staging.nx.app/runs/aoiNX1MRz5/task/e2e-next%3Ae2e.

This issue was addressed in `@emotion/react@11.11.1`.

**Note:** I created this in a separate PR to keep it more granular and reduce the size of the Angular 16.1 PR.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The installed `@emotion/react` package version supports TS 5.1.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
