### PR TITLE
fix(core): dedupe project files in rust

### DIFF
--- a/packages/nx/src/native/hasher.rs
+++ b/packages/nx/src/native/hasher.rs
@@ -3,6 +3,7 @@
 use crate::native::parallel_walker::nx_walker;
 use crate::native::types::FileData;
 use crate::native::utils::glob::build_glob_set;
+use crate::native::utils::path::Normalize;
 use anyhow::anyhow;
 use crossbeam_channel::unbounded;
 use globset::{Glob, GlobSetBuilder};
@@ -39,7 +40,10 @@ fn hash_files(workspace_root: String) -> HashMap<String, String> {
     nx_walker(workspace_root, |rec| {
         let mut collection: HashMap<String, String> = HashMap::new();
         for (path, content) in rec {
-            collection.insert(path, xxh3::xxh3_64(&content).to_string());
+            collection.insert(
+                path.to_normalized_string(),
+                xxh3::xxh3_64(&content).to_string(),
+            );
         }
         collection
     })
@@ -57,7 +61,7 @@ fn hash_files_matching_globs(
         for (path, content) in receiver {
             if glob_set.is_match(&path) {
                 collection.push(FileData {
-                    file: path,
+                    file: path.to_normalized_string(),
                     hash: xxh3::xxh3_64(&content).to_string(),
                 });
             }

--- a/packages/nx/src/native/utils/mod.rs
+++ b/packages/nx/src/native/utils/mod.rs
@@ -1,1 +1,2 @@
 pub mod glob;
+pub mod path;

--- a/packages/nx/src/native/utils/path.rs
+++ b/packages/nx/src/native/utils/path.rs
@@ -1,0 +1,14 @@
+pub trait Normalize {
+    fn to_normalized_string(&self) -> String;
+}
+
+impl Normalize for std::path::Path {
+    fn to_normalized_string(&self) -> String {
+        // convert back-slashes in Windows paths, since the js expects only forward-slash path separators
+        if cfg!(windows) {
+            self.display().to_string().replace('\\', "/")
+        } else {
+            self.display().to_string()
+        }
+    }
+}

--- a/packages/nx/src/native/workspace/get_config_files.rs
+++ b/packages/nx/src/native/workspace/get_config_files.rs
@@ -1,17 +1,103 @@
 use crate::native::parallel_walker::nx_walker;
 use crate::native::utils::glob::build_glob_set;
+use crate::native::utils::path::Normalize;
+use globset::GlobSet;
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 
 #[napi]
 /// Get workspace config files based on provided globs
 pub fn get_config_files(workspace_root: String, globs: Vec<String>) -> anyhow::Result<Vec<String>> {
     let globs = build_glob_set(globs)?;
     Ok(nx_walker(workspace_root, move |rec| {
-        let mut config_paths: Vec<String> = vec![];
-        for (path, _) in rec {
-            if globs.is_match(&path) {
-                config_paths.push(path.to_owned());
-            }
+        let mut config_paths: HashMap<PathBuf, (PathBuf, Vec<u8>)> = HashMap::new();
+        for (path, content) in rec {
+            insert_config_file_into_map((path, content), &mut config_paths, &globs);
         }
         config_paths
+            .into_iter()
+            .map(|(_, (val, _))| val.to_normalized_string())
+            .collect()
     }))
+}
+
+pub fn insert_config_file_into_map(
+    (path, content): (PathBuf, Vec<u8>),
+    config_paths: &mut HashMap<PathBuf, (PathBuf, Vec<u8>)>,
+    globs: &GlobSet,
+) {
+    if globs.is_match(&path) {
+        let parent = path.parent().unwrap_or_else(|| Path::new("")).to_path_buf();
+
+        let file_name = path
+            .file_name()
+            .expect("Config paths always have file names");
+        if file_name == "project.json" {
+            config_paths.insert(parent, (path, content));
+        } else if file_name == "package.json" {
+            match config_paths.entry(parent) {
+                Entry::Occupied(mut o) => {
+                    if o.get()
+                        .0
+                        .file_name()
+                        .expect("Config paths always have file names")
+                        != "project.json"
+                    {
+                        o.insert((path, content));
+                    }
+                }
+                Entry::Vacant(v) => {
+                    v.insert((path, content));
+                }
+            }
+        } else {
+            config_paths.entry(parent).or_insert((path, content));
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    #[test]
+    fn should_insert_config_files_properly() {
+        let mut config_paths: HashMap<PathBuf, (PathBuf, Vec<u8>)> = HashMap::new();
+        let globs = build_glob_set(vec!["**/*".into()]).unwrap();
+
+        insert_config_file_into_map(
+            (PathBuf::from("project.json"), vec![]),
+            &mut config_paths,
+            &globs,
+        );
+        insert_config_file_into_map(
+            (PathBuf::from("package.json"), vec![]),
+            &mut config_paths,
+            &globs,
+        );
+        insert_config_file_into_map(
+            (PathBuf::from("lib1/project.json"), vec![]),
+            &mut config_paths,
+            &globs,
+        );
+        insert_config_file_into_map(
+            (PathBuf::from("lib2/package.json"), vec![]),
+            &mut config_paths,
+            &globs,
+        );
+
+        let config_files: Vec<PathBuf> = config_paths
+            .into_iter()
+            .map(|(_, (path, _))| path)
+            .collect();
+
+        assert!(config_files.contains(&PathBuf::from("project.json")));
+        assert!(config_files.contains(&PathBuf::from("lib1/project.json")));
+        assert!(config_files.contains(&PathBuf::from("lib2/package.json")));
+
+        assert!(!config_files.contains(&PathBuf::from("package.json")));
+    }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When getting config files via rust, config files were not deduped.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Getting config files via rust, config files are deduped properly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
