### PR TITLE
fix(js): node executor should always log error

### DIFF
--- a/e2e/js/src/js-node.test.ts
+++ b/e2e/js/src/js-node.test.ts
@@ -1,0 +1,50 @@
+import {
+  cleanupProject,
+  newProject,
+  runCLI,
+  uniq,
+  updateFile,
+  updateProjectConfig,
+} from '@nx/e2e/utils';
+
+describe('js:node error handling', () => {
+  let scope: string;
+
+  beforeEach(() => {
+    scope = newProject();
+  });
+
+  afterEach(() => cleanupProject());
+
+  it('should log out the error', () => {
+    const esbuildLib = uniq('esbuildlib');
+
+    runCLI(
+      `generate @nx/js:lib ${esbuildLib} --bundler=esbuild --no-interactive`
+    );
+
+    updateFile(`libs/${esbuildLib}/src/index.ts`, () => {
+      return `
+        console.log('Hello from my library!');
+        throw new Error('This is an error');
+        `;
+    });
+
+    updateProjectConfig(esbuildLib, (config) => {
+      config.targets['run-node'] = {
+        executor: '@nx/js:node',
+        options: {
+          buildTarget: `${esbuildLib}:build`,
+          watch: false,
+        },
+      };
+      return config;
+    });
+
+    const output = runCLI(`run ${esbuildLib}:run-node`, {
+      redirectStderr: true,
+    });
+    expect(output).toContain('Hello from my library!');
+    expect(output).toContain('This is an error');
+  }, 240_000);
+});

--- a/e2e/utils/command-utils.ts
+++ b/e2e/utils/command-utils.ts
@@ -23,6 +23,7 @@ export interface RunCmdOpts {
   cwd?: string;
   silent?: boolean;
   verbose?: boolean;
+  redirectStderr?: boolean;
 }
 
 /**
@@ -325,26 +326,25 @@ export function runCLI(
     silenceError: false,
     env: undefined,
     verbose: undefined,
+    redirectStderr: undefined,
   }
 ): string {
   try {
     const pm = getPackageManagerCommand();
-    const logs = execSync(
-      `${pm.runNxSilent} ${command} ${
-        opts.verbose ?? isVerboseE2ERun() ? ' --verbose' : ''
-      }`,
-      {
-        cwd: opts.cwd || tmpProjPath(),
-        env: {
-          CI: 'true',
-          ...getStrippedEnvironmentVariables(),
-          ...opts.env,
-        },
-        encoding: 'utf-8',
-        stdio: 'pipe',
-        maxBuffer: 50 * 1024 * 1024,
-      }
-    );
+    const commandToRun = `${pm.runNxSilent} ${command} ${
+      opts.verbose ?? isVerboseE2ERun() ? ' --verbose' : ''
+    }${opts.redirectStderr ? ' 2>&1' : ''}`;
+    const logs = execSync(commandToRun, {
+      cwd: opts.cwd || tmpProjPath(),
+      env: {
+        CI: 'true',
+        ...getStrippedEnvironmentVariables(),
+        ...opts.env,
+      },
+      encoding: 'utf-8',
+      stdio: 'pipe',
+      maxBuffer: 50 * 1024 * 1024,
+    });
 
     if (opts.verbose ?? isVerboseE2ERun()) {
       output.log({


### PR DESCRIPTION
## Current Behavior

When using the `nx/js:node` executor, error is swallowed unless you're in `watch` mode.

## Expected Behavior

Error should always be logged.

Also, we should infer the `outputFileName` from the `main` entrypoint as set in build options.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17595 #17627 #17083
