### PR TITLE
fix(nextjs): cleanup old options for server executor (proxyConfig)

### DIFF
--- a/docs/generated/packages/next/executors/server.json
+++ b/docs/generated/packages/next/executors/server.json
@@ -43,12 +43,6 @@
         "type": "string",
         "description": "Hostname on which the application is served."
       },
-      "proxyConfig": {
-        "type": "string",
-        "description": "Path to the proxy configuration file.",
-        "x-completion-type": "file",
-        "x-deprecated": "Use the built-in rewrite feature from Next.js. See: https://nextjs.org/docs/api-reference/next.config.js/rewrites"
-      },
       "buildLibsFromSource": {
         "type": "boolean",
         "description": "Read buildable libraries from source instead of building them separately.",

--- a/packages/next/src/executors/server/custom-server.impl.ts
+++ b/packages/next/src/executors/server/custom-server.impl.ts
@@ -1,16 +1,8 @@
 import 'dotenv/config';
-import {
-  ExecutorContext,
-  parseTargetString,
-  readTargetOptions,
-  runExecutor,
-} from '@nx/devkit';
-import { join, resolve } from 'path';
+import { ExecutorContext, parseTargetString, runExecutor } from '@nx/devkit';
+import { join } from 'path';
 
-import {
-  NextBuildBuilderOptions,
-  NextServeBuilderOptions,
-} from '../../utils/types';
+import { NextServeBuilderOptions } from '../../utils/types';
 
 export default async function* serveExecutor(
   options: NextServeBuilderOptions,
@@ -26,10 +18,6 @@ export default async function* serveExecutor(
   // Setting port that the custom server should use.
   (process.env as any).PORT = options.port;
 
-  const buildOptions = readTargetOptions<NextBuildBuilderOptions>(
-    parseTargetString(options.buildTarget, context.projectGraph),
-    context
-  );
   const projectRoot = context.projectGraph.nodes[context.projectName].data.root;
 
   yield* runCustomServer(projectRoot, options, context);

--- a/packages/next/src/executors/server/schema.json
+++ b/packages/next/src/executors/server/schema.json
@@ -40,12 +40,6 @@
       "type": "string",
       "description": "Hostname on which the application is served."
     },
-    "proxyConfig": {
-      "type": "string",
-      "description": "Path to the proxy configuration file.",
-      "x-completion-type": "file",
-      "x-deprecated": "Use the built-in rewrite feature from Next.js. See: https://nextjs.org/docs/api-reference/next.config.js/rewrites"
-    },
     "buildLibsFromSource": {
       "type": "boolean",
       "description": "Read buildable libraries from source instead of building them separately.",

--- a/packages/next/src/utils/types.ts
+++ b/packages/next/src/utils/types.ts
@@ -49,7 +49,6 @@ export interface NextServeBuilderOptions {
   buildTarget: string;
   customServerTarget?: string;
   hostname?: string;
-  proxyConfig?: string;
   buildLibsFromSource?: boolean;
   keepAliveTimeout?: number;
   turbo?: boolean;


### PR DESCRIPTION
The implementation for `proxyConfig` was already removed since we are now using Next.js' CLI.

This is just cleaning up and removing the deprecation message,