### PR TITLE
fix(bundling): add skipTypeField back for rollup executor

### DIFF
--- a/docs/generated/packages/rollup/executors/rollup.json
+++ b/docs/generated/packages/rollup/executors/rollup.json
@@ -169,6 +169,11 @@
         "type": "boolean",
         "description": "Whether to skip TypeScript type checking.",
         "default": false
+      },
+      "skipTypeField": {
+        "type": "boolean",
+        "description": "Prevents 'type' field from being added to compiled package.json file. Use this if you are having an issue with this field.",
+        "default": false
       }
     },
     "required": ["tsConfig", "main", "outputPath"],

--- a/packages/rollup/src/executors/rollup/lib/update-package-json.ts
+++ b/packages/rollup/src/executors/rollup/lib/update-package-json.ts
@@ -45,8 +45,9 @@ export function updatePackageJson(
     packageJson.main = './index.cjs';
     exports['.']['require'] = './index.cjs';
   }
-
-  packageJson.type = options.format.includes('esm') ? 'module' : 'commonjs';
+  if (!options.skipTypeField) {
+    packageJson.type = options.format.includes('esm') ? 'module' : 'commonjs';
+  }
 
   // Support for older TS versions < 4.5
   packageJson.types = types;

--- a/packages/rollup/src/executors/rollup/schema.d.ts
+++ b/packages/rollup/src/executors/rollup/schema.d.ts
@@ -33,4 +33,5 @@ export interface RollupExecutorOptions {
   generateExportsField?: boolean;
   skipTypeCheck?: boolean;
   babelUpwardRootMode?: boolean;
+  skipTypeField?: boolean;
 }

--- a/packages/rollup/src/executors/rollup/schema.json
+++ b/packages/rollup/src/executors/rollup/schema.json
@@ -156,6 +156,11 @@
       "type": "boolean",
       "description": "Whether to skip TypeScript type checking.",
       "default": false
+    },
+    "skipTypeField": {
+      "type": "boolean",
+      "description": "Prevents 'type' field from being added to compiled package.json file. Use this if you are having an issue with this field.",
+      "default": false
     }
   },
   "required": ["tsConfig", "main", "outputPath"],


### PR DESCRIPTION
This was previously removed and needs to be readded back since nx should always support esm modules with cjs dependencies. Forcing modern libraries to be not in esm format isn't good practice.
Previously removed here:
https://github.com/nrwl/nx/commit/575c6a152f4d167343bc30e83730cea9ff311c69


## Current Behavior
No skipTypeField and breaking change was implemented - should be added back

## Expected Behavior
Skip type field allows esm modules with cjs dependencies

## Related Issue(s)
https://github.com/nrwl/nx/issues/17595

I just did this quickly so maintainers please edit the schema and regenerate the docs if you agree with me on this one
