### PR TITLE
fix(core): ignore nested node_module paths for findProjectOfResolvedModule in TargetProjectLocator

### DIFF
--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
@@ -181,7 +181,12 @@ export class TargetProjectLocator {
   private findProjectOfResolvedModule(
     resolvedModule: string
   ): string | undefined {
-    if (resolvedModule.startsWith('node_modules/')) return undefined;
+    if (
+      resolvedModule.startsWith('node_modules/') ||
+      resolvedModule.includes('/node_modules/')
+    ) {
+      return undefined;
+    }
     const normalizedResolvedModule = resolvedModule.startsWith('./')
       ? resolvedModule.substring(2)
       : resolvedModule;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
TargetProjectLocator's `findProjectOfResolvedModule` will treat unknown imports as the source project if import is pointing to nested `node_modules`.

## Expected Behavior
The `findProjectOfResolvedModule` should check if module path contains `node_modules` (not only if it starts with one)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15957
