### PR TITLE
fix(linter): improve error message for forbidden imports of lazy-loaded libs

### DIFF
--- a/packages/eslint-plugin/src/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin/src/rules/enforce-module-boundaries.spec.ts
@@ -1221,20 +1221,33 @@ Violation detected in:
                 target: 'otherName',
                 type: DependencyType.dynamic,
               },
+              {
+                source: 'mylibName',
+                target: 'otherName',
+                type: DependencyType.static,
+              },
             ],
           },
         },
         {
-          mylibName: [createFile(`libs/mylib/src/main.ts`)],
+          mylibName: [
+            createFile(`libs/mylib/src/main.ts`, [
+              ['otherName', 'static'],
+              ['otherName', 'dynamic'],
+            ]),
+          ],
           otherName: [createFile(`libs/other/index.ts`)],
         }
       );
       if (importKind === 'type') {
         expect(failures.length).toEqual(0);
       } else {
-        expect(failures[0].message).toEqual(
-          'Imports of lazy-loaded libraries are forbidden'
-        );
+        expect(failures[0].message).toMatchInlineSnapshot(`
+          "Static imports of lazy-loaded libraries are forbidden.
+
+          Library "otherName" is lazy-loaded in these files:
+          - libs/mylib/src/main.ts"
+        `);
       }
     }
   );

--- a/packages/eslint-plugin/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin/src/rules/enforce-module-boundaries.ts
@@ -8,6 +8,7 @@ import {
 import { isRelativePath } from 'nx/src/utils/fileutils';
 import {
   checkCircularPath,
+  findFileByDependency,
   findFilesInCircularPath,
 } from '../utils/graph-utils';
 import {
@@ -125,7 +126,7 @@ export default createESLintRule<Options, MessageIds>({
       noImportsOfE2e: 'Imports of e2e projects are forbidden',
       noImportOfNonBuildableLibraries:
         'Buildable libraries cannot import or export from non-buildable libraries',
-      noImportsOfLazyLoadedLibraries: `Imports of lazy-loaded libraries are forbidden`,
+      noImportsOfLazyLoadedLibraries: `Static imports of lazy-loaded libraries are forbidden.\n\nLibrary "{{targetProjectName}}" is lazy-loaded in these files:\n{{filePaths}}`,
       projectWithoutTagsCannotHaveDependencies: `A project without tags matching at least one constraint cannot depend on any libraries`,
       bannedExternalImportsViolation: `A project tagged with "{{sourceTag}}" is not allowed to import the "{{package}}" package`,
       nestedBannedExternalImportsViolation: `A project tagged with "{{sourceTag}}" is not allowed to import the "{{package}}" package. Nested import found at {{childProjectName}}`,
@@ -515,7 +516,18 @@ export default createESLintRule<Options, MessageIds>({
           []
         )
       ) {
+        const filesWithLazyImports = findFileByDependency(
+          projectFileMap,
+          sourceProject.name,
+          targetProject.name
+        );
         context.report({
+          data: {
+            filePaths: filesWithLazyImports
+              .map(({ file }) => `- ${file}`)
+              .join('\n'),
+            targetProjectName: targetProject.name,
+          },
           node,
           messageId: 'noImportsOfLazyLoadedLibraries',
         });

--- a/packages/eslint-plugin/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin/src/rules/enforce-module-boundaries.ts
@@ -8,7 +8,7 @@ import {
 import { isRelativePath } from 'nx/src/utils/fileutils';
 import {
   checkCircularPath,
-  findFileByDependency,
+  findFilesWithDynamicImports,
   findFilesInCircularPath,
 } from '../utils/graph-utils';
 import {
@@ -516,7 +516,7 @@ export default createESLintRule<Options, MessageIds>({
           []
         )
       ) {
-        const filesWithLazyImports = findFileByDependency(
+        const filesWithLazyImports = findFilesWithDynamicImports(
           projectFileMap,
           sourceProject.name,
           targetProject.name

--- a/packages/eslint-plugin/src/utils/graph-utils.ts
+++ b/packages/eslint-plugin/src/utils/graph-utils.ts
@@ -4,7 +4,11 @@ import type {
   ProjectGraph,
   ProjectGraphProjectNode,
 } from '@nx/devkit';
-import { fileDataDepTarget } from 'nx/src/config/project-graph';
+import {
+  DependencyType,
+  fileDataDepTarget,
+  fileDataDepType,
+} from 'nx/src/config/project-graph';
 
 interface Reach {
   graph: ProjectGraph;
@@ -157,4 +161,18 @@ export function findFilesInCircularPath(
   }
 
   return filePathChain;
+}
+
+export function findFileByDependency(
+  projectFileMap: ProjectFileMap,
+  sourceProjectName: string,
+  targetProjectName: string
+): FileData[] {
+  const isDynamicTargetDep = (dep: string | [string, string]) =>
+    fileDataDepType(dep) === DependencyType.dynamic &&
+    fileDataDepTarget(dep) === targetProjectName;
+
+  return projectFileMap[sourceProjectName].filter((file) =>
+    file.deps?.find(isDynamicTargetDep)
+  );
 }

--- a/packages/eslint-plugin/src/utils/graph-utils.ts
+++ b/packages/eslint-plugin/src/utils/graph-utils.ts
@@ -163,16 +163,24 @@ export function findFilesInCircularPath(
   return filePathChain;
 }
 
-export function findFileByDependency(
+export function findFilesWithDynamicImports(
   projectFileMap: ProjectFileMap,
   sourceProjectName: string,
   targetProjectName: string
 ): FileData[] {
-  const isDynamicTargetDep = (dep: string | [string, string]) =>
-    fileDataDepType(dep) === DependencyType.dynamic &&
-    fileDataDepTarget(dep) === targetProjectName;
+  const files: FileData[] = [];
+  projectFileMap[sourceProjectName].forEach((file) => {
+    if (!file.deps) return;
+    if (
+      file.deps.some(
+        (d) =>
+          fileDataDepTarget(d) === targetProjectName &&
+          fileDataDepType(d) === DependencyType.dynamic
+      )
+    ) {
+      files.push(file);
+    }
+  });
 
-  return projectFileMap[sourceProjectName].filter((file) =>
-    file.deps?.find(isDynamicTargetDep)
-  );
+  return files;
 }


### PR DESCRIPTION
…orts of lazy-loaded libs

* Specify that *static* imports are forbidden
* Include target library name and source file path containing a dynamic import that triggered this rule


## Related Issue(s)

Related to #17425
