### PR TITLE
fix(core): cli option --graph should open graph ui by default

### DIFF
--- a/docs/generated/cli/affected.md
+++ b/docs/generated/cli/affected.md
@@ -107,8 +107,6 @@ Change the way Nx is calculating the affected command by providing directly chan
 
 Type: `string`
 
-Default: `false`
-
 Show the task graph of the command. Pass a file path to save the graph data instead of viewing it in the browser.
 
 ### head

--- a/docs/generated/cli/exec.md
+++ b/docs/generated/cli/exec.md
@@ -33,8 +33,6 @@ Exclude certain projects from being processed
 
 Type: `string`
 
-Default: `false`
-
 Show the task graph of the command. Pass a file path to save the graph data instead of viewing it in the browser.
 
 ### nx-bail

--- a/docs/generated/cli/run-many.md
+++ b/docs/generated/cli/run-many.md
@@ -97,8 +97,6 @@ Exclude certain projects from being processed
 
 Type: `string`
 
-Default: `false`
-
 Show the task graph of the command. Pass a file path to save the graph data instead of viewing it in the browser.
 
 ### help

--- a/docs/generated/packages/nx/documents/affected.md
+++ b/docs/generated/packages/nx/documents/affected.md
@@ -107,8 +107,6 @@ Change the way Nx is calculating the affected command by providing directly chan
 
 Type: `string`
 
-Default: `false`
-
 Show the task graph of the command. Pass a file path to save the graph data instead of viewing it in the browser.
 
 ### head

--- a/docs/generated/packages/nx/documents/exec.md
+++ b/docs/generated/packages/nx/documents/exec.md
@@ -33,8 +33,6 @@ Exclude certain projects from being processed
 
 Type: `string`
 
-Default: `false`
-
 Show the task graph of the command. Pass a file path to save the graph data instead of viewing it in the browser.
 
 ### nx-bail

--- a/docs/generated/packages/nx/documents/run-many.md
+++ b/docs/generated/packages/nx/documents/run-many.md
@@ -97,8 +97,6 @@ Exclude certain projects from being processed
 
 Type: `string`
 
-Default: `false`
-
 Show the task graph of the command. Pass a file path to save the graph data instead of viewing it in the browser.
 
 ### help

--- a/packages/nx/src/command-line/yargs-utils/shared-options.ts
+++ b/packages/nx/src/command-line/yargs-utils/shared-options.ts
@@ -32,9 +32,11 @@ export function withRunOptions(yargs: Argv) {
       type: 'string',
       describe:
         'Show the task graph of the command. Pass a file path to save the graph data instead of viewing it in the browser.',
-      default: false,
       coerce: (value) =>
-        value === 'true' || value === true
+        // when the type of an opt is "string", passing `--opt` comes through as having an empty string value.
+        // this coercion allows `--graph` to be passed through as a boolean directly, and also normalizes the
+        // `--graph=true` to produce the same behaviour as `--graph`.
+        value === '' || value === 'true' || value === true
           ? true
           : value === 'false' || value === false
           ? false


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`--graph` doesn't open the graph UI as expected, instead you have to use `--graph=true`

## Expected Behavior
`--graph` retains previous behavior

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
