### PR TITLE
docs(storybook): fix broken link to storybook package in README

### DIFF
--- a/packages/storybook/README.md
+++ b/packages/storybook/README.md
@@ -8,6 +8,6 @@
 
 Nx is a next generation build system with first class monorepo support and powerful integrations.
 
-This package is a [Storybook plugin for Nx](https://nx.dev/storybook/overview).
+This package is a [Storybook plugin for Nx](https://nx.dev/packages/storybook).
 
 {{content}}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Currently, the link to the Storybook package in the README file is broken.

<!-- This is the behavior we have today -->

## Expected Behavior
With the changes in this PR, the link in the README file should correctly point to the Storybook package.

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->