### PR TITLE
fix(docs): update url for fastify

### DIFF
--- a/docs/shared/recipes/deployment/node-server-fly-io.md
+++ b/docs/shared/recipes/deployment/node-server-fly-io.md
@@ -11,7 +11,7 @@ npx create-nx-workspace@latest my-api \
   --docker
 ```
 
-This example uses [Fastify](https://www.fastify.io/) but you can equally use [Express](https://expressjs.com/), [Koa](https://koajs.com/) or [NestJS](https://nestjs.com/) by selecting those frameworks during project creation.
+This example uses [Fastify](https://www.fastify.dev/) but you can equally use [Express](https://expressjs.com/), [Koa](https://koajs.com/) or [NestJS](https://nestjs.com/) by selecting those frameworks during project creation.
 
 You can also install the `@nx/node` package into an existing Nx monorepo and generate a new Node application.
 

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -939,7 +939,7 @@ async function determineNodeFramework(
         },
         {
           name: 'fastify',
-          message: 'Fastify [ https://www.fastify.io/ ]',
+          message: 'Fastify [ https://www.fastify.dev/ ]',
         },
         {
           name: 'koa',


### PR DESCRIPTION
## Current Behavior
Attach fastify legacy document url `www.fastify.io`

## Expected Behavior
With latest fastify document url `www.fastify.dev`

## Related Issue(s)

Fixes #17668
