### PR TITLE
fix(core): run-commands should not parse strings as numbers

### DIFF
--- a/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
@@ -54,6 +54,26 @@ describe('Run Commands', () => {
     expect(readFile(f)).toEqual('123');
   });
 
+  it.each([
+    [`--key=123`, `args.key`, `123`],
+    [`--key="123.10"`, `args.key`, `123.10`],
+    [`--nested.key="123.10"`, `args.nested.key`, `123.10`],
+  ])(
+    'should interpolate %s into %s as %s',
+    async (cmdLineArg, argKey, expected) => {
+      const f = fileSync().name;
+      const result = await runCommands(
+        {
+          command: `echo {${argKey}} >> ${f}`,
+          __unparsed__: [cmdLineArg],
+        },
+        context
+      );
+      expect(result).toEqual(expect.objectContaining({ success: true }));
+      expect(readFile(f)).toEqual(expected);
+    }
+  );
+
   it('should run commands serially', async () => {
     const f = fileSync().name;
     const result = await runCommands(

--- a/packages/nx/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.ts
@@ -312,7 +312,15 @@ function parseArgs(options: RunCommandsOptions) {
     const unknownOptionsTreatedAsArgs = Object.keys(options)
       .filter((p) => propKeys.indexOf(p) === -1)
       .reduce((m, c) => ((m[c] = options[c]), m), {});
-    return unknownOptionsTreatedAsArgs;
+
+    const unparsedCommandArgs = yargsParser(options.__unparsed__, {
+      configuration: {
+        'parse-numbers': false,
+        'parse-positional-numbers': false,
+        'dot-notation': false,
+      },
+    });
+    return { ...unknownOptionsTreatedAsArgs, ...unparsedCommandArgs };
   }
   return yargsParser(args.replace(/(^"|"$)/g, ''), {
     configuration: { 'camel-case-expansion': false },


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When passing command line args to a target using nx:run-commands whose value resembles a number, it is being parsed as a number. 

This can cause erroneous behaviour when the intention of the value is to be a string.

The main potential of erroneous behaviour here comes from decimal numbers ending in 0, such as `1234.10`. When this is parsed as a number then converted back to a string for interpolation, this value becomes `1234.1`.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Args that are passed to the nx:run-commands via command line should not be parsed as numbers.

We should leave support args that are passed as options in the project.json


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17575
