### PR TITLE
fix(core): prune project graph after affected nodes are found to avoid errors

### DIFF
--- a/e2e/nx-run/src/affected-graph.test.ts
+++ b/e2e/nx-run/src/affected-graph.test.ts
@@ -511,8 +511,8 @@ describe('Nx Affected and Graph Tests', () => {
       expect(model).toHaveProperty('tasks');
     });
 
-    it('affected:graph should include affected projects in environment file', () => {
-      runCLI(`affected:graph --file=project-graph.html`);
+    it('should include affected projects in environment file', () => {
+      runCLI(`graph --affected --file=project-graph.html`);
 
       const environmentJs = readFile('static/environment.js');
       const affectedProjects = environmentJs


### PR DESCRIPTION
We prune external nodes from project graph when outputting JSON so it doesn't get too bloated. However, this erroring out when finding affected nodes since affected logic requires external nodes to be present.

## Current Behavior
`nx graph --affected` errors out

## Expected Behavior
`nx graph --affected` works as expected

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
