### PR TITLE
fix(core): get the client env when calculating the task hash in the daemon

### DIFF
--- a/e2e/nx-run/src/cache.test.ts
+++ b/e2e/nx-run/src/cache.test.ts
@@ -295,9 +295,11 @@ describe('cache', () => {
     updateJson(`nx.json`, (c) => {
       c.targetDefaults = {
         echo: {
-          inputs: {
-            env: 'NAME',
-          },
+          inputs: [
+            {
+              env: 'NAME',
+            },
+          ],
         },
       };
 

--- a/e2e/nx-run/src/cache.test.ts
+++ b/e2e/nx-run/src/cache.test.ts
@@ -293,6 +293,7 @@ describe('cache', () => {
     const lib = uniq('lib');
     runCLI(`generate @nx/js:lib ${lib}`);
     updateJson(`nx.json`, (c) => {
+      c.tasksRunnerOptions.default.options.cacheableOperations.push('echo');
       c.targetDefaults = {
         echo: {
           inputs: [
@@ -333,7 +334,7 @@ describe('cache', () => {
     const fourthRun = runCLI(`echo ${lib}`, {
       env: { NAME: 'change' },
     });
-    expect(thirdRun).toContain('read the output from the cache');
+    expect(fourthRun).toContain('read the output from the cache');
   }, 120000);
 
   function expectCached(

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -128,6 +128,7 @@ export class DaemonClient {
     return this.sendToDaemonViaQueue({
       type: 'HASH_TASKS',
       runnerOptions,
+      env: process.env,
       tasks,
       taskGraph,
     });

--- a/packages/nx/src/daemon/server/handle-hash-tasks.ts
+++ b/packages/nx/src/daemon/server/handle-hash-tasks.ts
@@ -3,6 +3,7 @@ import { getCachedSerializedProjectGraphPromise } from './project-graph-incremen
 import { InProcessTaskHasher } from '../../hasher/task-hasher';
 import { readNxJson } from '../../config/configuration';
 import { fileHasher } from '../../hasher/file-hasher';
+import { setHashEnv } from '../../hasher/set-hash-env';
 
 /**
  * We use this not to recreated hasher for every hash operation
@@ -14,9 +15,12 @@ let storedHasher: InProcessTaskHasher | null = null;
 
 export async function handleHashTasks(payload: {
   runnerOptions: any;
+  env: any;
   tasks: Task[];
   taskGraph: TaskGraph;
 }) {
+  setHashEnv(payload.env);
+
   const { projectGraph, allWorkspaceFiles, projectFileMap } =
     await getCachedSerializedProjectGraphPromise();
   const nxJson = readNxJson();

--- a/packages/nx/src/hasher/set-hash-env.ts
+++ b/packages/nx/src/hasher/set-hash-env.ts
@@ -1,0 +1,19 @@
+// if using without the daemon, the hashEnv is always going to be the process.env.
+// When using the daemon, we'll need to set the hashEnv with `setHashEnv`
+
+let hashEnv = process.env;
+
+/**
+ * Set the environment to be used by the hasher
+ * @param env
+ */
+export function setHashEnv(env: any) {
+  hashEnv = env;
+}
+
+/**
+ * Get the environment used by the hasher
+ */
+export function getHashEnv() {
+  return hashEnv;
+}

--- a/packages/nx/src/hasher/task-hasher.ts
+++ b/packages/nx/src/hasher/task-hasher.ts
@@ -17,6 +17,7 @@ import { findMatchingProjects } from '../utils/find-matching-projects';
 import { FileHasher, hashArray } from './file-hasher';
 import { getOutputsForTargetAndConfiguration } from '../tasks-runner/utils';
 import { join } from 'path';
+import { getHashEnv } from './set-hash-env';
 
 type ExpandedSelfInput =
   | { fileset: string }
@@ -695,7 +696,8 @@ class TaskHasherImpl {
   }
 
   private async hashEnv(envVarName: string): Promise<PartialHash> {
-    const value = hashArray([process.env[envVarName] ?? '']);
+    let env = getHashEnv();
+    const value = hashArray([env[envVarName] ?? '']);
     return {
       details: { [`env:${envVarName}`]: value },
       value,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When the daemon is running, getting the env for tasks with an env input does not get the environment from where the command is run. Because the daemon is in a different process, it always gets the same env when it was first booted up with

## Expected Behavior
When asking the daemon to hash a task, the client will send the current client env so that the daemon gets information relative to the client

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17633
