### PR TITLE
fix(core): load env vars from root .env when running affected commands #17634

### DIFF
--- a/packages/nx/src/command-line/affected/affected.ts
+++ b/packages/nx/src/command-line/affected/affected.ts
@@ -5,6 +5,7 @@ import { printAffected } from './print-affected';
 import { connectToNxCloudIfExplicitlyAsked } from '../connect/connect-to-nx-cloud';
 import type { NxArgs } from '../../utils/command-line-utils';
 import {
+  loadEnvVars,
   parseFiles,
   readGraphFileFromGraphArg,
   splitArgsIntoNxArgsAndOverrides,
@@ -23,7 +24,7 @@ import { workspaceConfigurationCheck } from '../../utils/workspace-configuration
 import { findMatchingProjects } from '../../utils/find-matching-projects';
 import { generateGraph } from '../graph/graph';
 import { allFileData } from '../../utils/all-file-data';
-import { NX_PREFIX, logger } from '../../utils/logger';
+import { logger, NX_PREFIX } from '../../utils/logger';
 import { affectedGraphDeprecationMessage } from './command-object';
 
 export async function affected(
@@ -38,6 +39,7 @@ export async function affected(
   performance.measure('code-loading', 'init-local', 'code-loading:end');
   workspaceConfigurationCheck();
 
+  await loadEnvVars();
   const nxJson = readNxJson();
   const { nxArgs, overrides } = splitArgsIntoNxArgsAndOverrides(
     args,

--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -22,14 +22,16 @@ import {
   createTaskGraph,
   mapTargetDefaultsToDependencies,
 } from '../../tasks-runner/create-task-graph';
-import { TargetDefaults, TargetDependencies } from '../../config/nx-json';
 import { TaskGraph } from '../../config/task-graph';
 import { daemonClient } from '../../daemon/client/client';
 import { Server } from 'net';
 import { readProjectFileMapCache } from '../../project-graph/nx-deps-cache';
 import { fileHasher } from '../../hasher/file-hasher';
 import { getAffectedGraphNodes } from '../affected/affected';
-import { splitArgsIntoNxArgsAndOverrides } from '../../utils/command-line-utils';
+import {
+  loadEnvVars,
+  splitArgsIntoNxArgsAndOverrides,
+} from '../../utils/command-line-utils';
 
 export interface ProjectGraphClientResponse {
   hash: string;
@@ -196,6 +198,7 @@ export async function generateGraph(
   },
   affectedProjects: string[]
 ): Promise<void> {
+  await loadEnvVars();
   if (
     Array.isArray(args.targets) &&
     args.targets.length > 1 &&

--- a/packages/nx/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.ts
@@ -4,21 +4,9 @@ import * as yargsParser from 'yargs-parser';
 import { env as appendLocalEnv } from 'npm-run-path';
 import { ExecutorContext } from '../../config/misc-interfaces';
 import * as chalk from 'chalk';
+import { loadEnvVars } from '../../utils/command-line-utils';
 
 export const LARGE_BUFFER = 1024 * 1000000;
-
-async function loadEnvVars(path?: string) {
-  if (path) {
-    const result = (await import('dotenv')).config({ path });
-    if (result.error) {
-      throw result.error;
-    }
-  } else {
-    try {
-      (await import('dotenv')).config();
-    } catch {}
-  }
-}
 
 export type Json = { [k: string]: any };
 

--- a/packages/nx/src/utils/command-line-utils.ts
+++ b/packages/nx/src/utils/command-line-utils.ts
@@ -37,6 +37,19 @@ export interface NxArgs {
   type?: string;
 }
 
+export async function loadEnvVars(path?: string) {
+  if (path) {
+    const result = (await import('dotenv')).config({ path });
+    if (result.error) {
+      throw result.error;
+    }
+  } else {
+    try {
+      (await import('dotenv')).config();
+    } catch {}
+  }
+}
+
 export function splitArgsIntoNxArgsAndOverrides(
   args: { [k: string]: any },
   mode: 'run-one' | 'run-many' | 'affected' | 'print-affected',


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We do not load ENV vars from dotenv files when running affected commands. This means that people cannot build or create .env files at the root of their repo and have those values picked up when running `affected` commands.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should load dotenv files at the root of the repo when running these commands

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17634

@FrozenPandaz There could be an argument made that this loading of the dotenv files could/should happen earlier in the workflow, when nx is init for example. 
I've limited this to just the affected commands as that is what was raised in the issue linked, but I'm open to suggestions of a best place to do this, if this is something we want to do.
