### PR TITLE
feat(core): add additional patterns for NX to load env variables

### DIFF
--- a/docs/shared/guides/define-environment-variables.md
+++ b/docs/shared/guides/define-environment-variables.md
@@ -20,9 +20,11 @@ By default, Nx will load any environment variables you place in the following fi
 9. `.[target-name].[configuration-name].env`
 10. `.env.[target-name]`
 11. `.[target-name].env`
-12. `.local.env`
-13. `.env.local`
-14. `.env`
+12. `.env.[configuration-name]`
+13. `.[configuration-name].env`
+14. `.local.env`
+15. `.env.local`
+16. `.env`
 
 {% callout type="warning" title="Order is important" %}
 Nx will move through the above list, ignoring files it can't find, and loading environment variables

--- a/packages/nx/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/nx/src/tasks-runner/forked-process-task-runner.ts
@@ -421,6 +421,8 @@ export class ForkedProcessTaskRunner {
     if (process.env.NX_LOAD_DOT_ENV_FILES == 'true') {
       return {
         ...this.getDotenvVariablesForForkedProcess(),
+        ...parseEnv(`.${task.target.configuration}.env`),
+        ...parseEnv(`.env.${task.target.configuration}`),
         ...parseEnv(`.${task.target.target}.env`),
         ...parseEnv(`.env.${task.target.target}`),
         ...(task.target.configuration


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Cannot load env by `.[configuration-name].env` or `.env..[configuration-name]`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Can load with this now

```
.env.[configuration-name]
[configuration-name].env
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17686
