### PR TITLE
fix(core): windows filePaths should be handled in findProjectForPath

### DIFF
--- a/packages/nx/src/project-graph/utils/find-project-for-path.ts
+++ b/packages/nx/src/project-graph/utils/find-project-for-path.ts
@@ -1,6 +1,7 @@
 import { dirname } from 'path';
 import { ProjectGraphProjectNode } from '../../config/project-graph';
 import { ProjectConfiguration } from '../../config/workspace-json-project-json';
+import { normalizePath } from '../../utils/path';
 
 export type ProjectRootMappings = Map<string, string>;
 
@@ -44,7 +45,12 @@ export function findProjectForPath(
   filePath: string,
   projectRootMap: ProjectRootMappings
 ): string | null {
-  let currentPath = filePath;
+  /**
+   * Project Mappings are in UNIX-style file paths
+   * Windows may pass Win-style file paths
+   * Ensure filePath is in UNIX-style
+   */
+  let currentPath = normalizePath(filePath);
   for (
     ;
     currentPath != dirname(currentPath);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Passing a windows file path to `findProjectForPath` errors out as Project Mappings are set up with UNIX style paths

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Passing Unix or Win style file paths should still return correct project.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx-labs/issues/291
