### PR TITLE
chore(react): remove unnecessary type cast

### DIFF
--- a/packages/react/plugins/component-testing/index.ts
+++ b/packages/react/plugins/component-testing/index.ts
@@ -22,6 +22,7 @@ import {
 
 import { existsSync } from 'fs';
 import { dirname, join } from 'path';
+
 type ViteDevServer = {
   framework: 'react';
   bundler: 'vite';
@@ -33,6 +34,7 @@ type WebpackDevServer = {
   bundler: 'webpack';
   webpackConfig?: any;
 };
+
 /**
  * React nx preset for Cypress Component Testing
  *
@@ -78,7 +80,7 @@ export function nxComponentTestingPreset(
           const viteConfigPath = findViteConfig(normalizedProjectRootPath);
 
           const { mergeConfig, loadConfigFromFile, searchForWorkspaceRoot } =
-            (await import('vite')) as typeof import('vite');
+            await import('vite');
 
           const resolved = await loadConfigFromFile(
             {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
There is an unnecessary type cast on the import of vite

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Remove the unnecessary type cast


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
