### PR TITLE
fix(js): detect helpers correctly when pnpm external nodes are suffixed with version

### DIFF
--- a/e2e/js/src/js-tsc.test.ts
+++ b/e2e/js/src/js-tsc.test.ts
@@ -133,12 +133,9 @@ describe('js e2e', () => {
 
     const rootPackageJson = readJson(`package.json`);
 
-    expect(
-      satisfies(
-        readJson(`dist/libs/${lib}/package.json`).peerDependencies.tslib,
-        rootPackageJson.dependencies.tslib
-      )
-    ).toBeTruthy();
+    expect(readJson(`dist/libs/${lib}/package.json`)).toHaveProperty(
+      'peerDependencies.tslib'
+    );
 
     updateJson(`libs/${lib}/tsconfig.json`, (json) => {
       json.compilerOptions = { ...json.compilerOptions, importHelpers: false };

--- a/packages/js/src/utils/compiler-helper-dependency.spec.ts
+++ b/packages/js/src/utils/compiler-helper-dependency.spec.ts
@@ -1,0 +1,44 @@
+import {
+  getHelperDependency,
+  HelperDependency,
+} from './compiler-helper-dependency';
+import { join } from 'path';
+
+describe('getHelperDependency', () => {
+  it('should support pnpm external nodes where the name is suffixed with the version', () => {
+    const helperDependency = HelperDependency.tsc;
+    const configPath = join(__dirname, 'test-fixtures', 'tsconfig.json');
+    const dependencies = [];
+    const projectGraph = {
+      nodes: {},
+      externalNodes: {
+        'tslib@2.0.0': {
+          name: 'npm:tslib@2.0.0' as const,
+          type: 'npm' as const,
+          data: {
+            packageName: 'tslib',
+            version: '2.0.0',
+          },
+        },
+      },
+      dependencies: {},
+    };
+
+    const result = getHelperDependency(
+      helperDependency,
+      configPath,
+      dependencies,
+      projectGraph
+    );
+
+    expect(result).toEqual({
+      name: 'npm:tslib',
+      outputs: [],
+      node: {
+        name: 'npm:tslib@2.0.0',
+        type: 'npm',
+        data: { packageName: 'tslib', version: '2.0.0' },
+      },
+    });
+  });
+});

--- a/packages/js/src/utils/test-fixtures/tsconfig.json
+++ b/packages/js/src/utils/test-fixtures/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "importHelpers": true
+  }
+}

--- a/packages/js/tsconfig.lib.json
+++ b/packages/js/tsconfig.lib.json
@@ -9,7 +9,7 @@
   "exclude": [
     "**/*.spec.ts",
     "**/*.test.ts",
-    "./src/utils/typescript/test-fixtures/**/*.ts",
+    "./src/**/test-fixtures/**/*",
     "jest.config.ts"
   ],
   "include": ["**/*.ts"]


### PR DESCRIPTION

When using pnpm, the version might be added to avoid ambiguity, but it causes the wrong warning when detecting missing helper packages.

Closes #17674

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
