### PR TITLE
fix(bundling): check for browserslist when setting terser ecma #17620

### DIFF
--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -32,6 +32,7 @@
     "@babel/core": "^7.15.0",
     "autoprefixer": "^10.4.9",
     "babel-loader": "^9.1.2",
+    "browserslist": "^4.21.4",
     "chalk": "^4.1.0",
     "chokidar": "^3.5.1",
     "copy-webpack-plugin": "^10.2.4",


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We do not check browserslist files in the `withNx` helper. 

This can lead to outputs that are not compatible with the targetted browsers

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should let browserslist help define the ecma version for terser to use


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17620

## Notes
An improvement could be to find a method to determine the lowest ecma version based on all the browsers matching the browserslist queries
