### PR TITLE
docs(core): fixup outdated nx show example

### DIFF
--- a/docs/generated/cli/show.md
+++ b/docs/generated/cli/show.md
@@ -23,10 +23,10 @@ Show all projects in the workspace:
  nx show projects
 ```
 
-Show all projects with names starting with "api-". The pattern option is useful to see which projects would be selected by run-many.:
+Show all projects with names starting with "api-". The "projects" option is useful to see which projects would be selected by run-many.:
 
 ```shell
- nx show projects --pattern=api-*
+ nx show projects --projects api-*
 ```
 
 Show all projects with a serve target:

--- a/docs/generated/packages/nx/documents/show.md
+++ b/docs/generated/packages/nx/documents/show.md
@@ -23,10 +23,10 @@ Show all projects in the workspace:
  nx show projects
 ```
 
-Show all projects with names starting with "api-". The pattern option is useful to see which projects would be selected by run-many.:
+Show all projects with names starting with "api-". The "projects" option is useful to see which projects would be selected by run-many.:
 
 ```shell
- nx show projects --pattern=api-*
+ nx show projects --projects api-*
 ```
 
 Show all projects with a serve target:

--- a/packages/nx/src/command-line/examples.ts
+++ b/packages/nx/src/command-line/examples.ts
@@ -354,9 +354,9 @@ export const examples: Record<string, Example[]> = {
     },
 
     {
-      command: 'show projects --pattern=api-*',
+      command: 'show projects --projects api-*',
       description:
-        'Show all projects with names starting with "api-". The pattern option is useful to see which projects would be selected by run-many.',
+        'Show all projects with names starting with "api-". The "projects" option is useful to see which projects would be selected by run-many.',
     },
 
     {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
There is an outdated example on the `nx show` docs that reference a `--pattern` option that doesn't exist.

## Expected Behavior
The example uses `-p`, which is short for `--projects`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
