### PR TITLE
fix(core): handle null plugin module when import fails for nx list

### DIFF
--- a/packages/nx/src/utils/plugins/plugin-capabilities.ts
+++ b/packages/nx/src/utils/plugins/plugin-capabilities.ts
@@ -75,8 +75,8 @@ export async function getPluginCapabilities(
           'executors'
         ),
       },
-      projectGraphExtension: !!pluginModule.processProjectGraph,
-      projectInference: !!pluginModule.projectFilePatterns,
+      projectGraphExtension: !!pluginModule?.processProjectGraph,
+      projectInference: !!pluginModule?.projectFilePatterns,
     };
   } catch {
     return null;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`getPluginCapabilities` throws if `loadNxPluginAsync` throws

## Expected Behavior
`getPluginCapabilities` works, assuming there is no runtime plugin code.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
