### PR TITLE
fix(core): load env vars before lifecycle for batch mode

### DIFF
--- a/packages/nx/src/tasks-runner/run-command.spec.ts
+++ b/packages/nx/src/tasks-runner/run-command.spec.ts
@@ -27,7 +27,8 @@ describe('getRunner', () => {
 
     const { tasksRunner, runnerOptions } = getRunner(
       { runner: 'custom' },
-      nxJson
+      nxJson,
+      true
     );
 
     expect(tasksRunner).toEqual(mockRunner);
@@ -49,7 +50,8 @@ describe('getRunner', () => {
 
     const { tasksRunner, runnerOptions } = getRunner(
       { runner: 'custom' },
-      nxJson
+      nxJson,
+      true
     );
     expect(tasksRunner).toBe(mockRunner);
     expect(runnerOptions).toEqual({
@@ -69,8 +71,36 @@ describe('getRunner', () => {
       },
     };
 
-    const { tasksRunner } = getRunner({}, nxJson);
+    const { tasksRunner } = getRunner({}, nxJson, true);
 
     expect(tasksRunner).toEqual(mockRunner);
+  });
+
+  it('should set args via env', () => {
+    jest.mock('custom-default-runner', () => mockRunner, {
+      virtual: true,
+    });
+
+    nxJson.tasksRunnerOptions = {
+      default: {
+        runner: 'custom-default-runner',
+      },
+    };
+    const args: Record<string, any> = {
+      targets: ['test'],
+      parallel: 3,
+      skipNxCache: false,
+      nxBail: false,
+      nxIgnoreCycles: false,
+      all: true,
+      projects: [],
+    };
+    const previousEnv = structuredClone({ ...process.env });
+    process.env.NX_BATCH_MODE = 'true';
+    getRunner(args, nxJson, true);
+    expect(process.env.NX_BATCH_MODE).toEqual('true');
+    expect(args.outputStyle).toEqual('stream');
+    process.env = previousEnv;
+    expect(process.env.NX_BATCH_MODE).toBeUndefined();
   });
 });

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -42,9 +42,10 @@ async function getTerminalOutputLifeCycle(
   tasks: Task[],
   nxArgs: NxArgs,
   nxJson: NxJsonConfiguration,
-  overrides: Record<string, unknown>
+  overrides: Record<string, unknown>,
+  loadDotEnvFiles: boolean
 ): Promise<{ lifeCycle: LifeCycle; renderIsDone: Promise<void> }> {
-  const { runnerOptions } = getRunner(nxArgs, nxJson);
+  const { runnerOptions } = getRunner(nxArgs, nxJson, loadDotEnvFiles);
   const isRunOne = initiatingProject != null;
   const useDynamicOutput =
     shouldUseDynamicLifeCycle(tasks, runnerOptions, nxArgs.outputStyle) &&
@@ -170,7 +171,8 @@ export async function runCommand(
         tasks,
         nxArgs,
         nxJson,
-        overrides
+        overrides,
+        extraOptions.loadDotEnvFiles
       );
 
       const status = await invokeTasksRunner({
@@ -229,9 +231,11 @@ export async function invokeTasksRunner({
   loadDotEnvFiles: boolean;
   initiatingProject: string | null;
 }) {
-  setEnvVarsBasedOnArgs(nxArgs, loadDotEnvFiles);
-
-  const { tasksRunner, runnerOptions } = getRunner(nxArgs, nxJson);
+  const { tasksRunner, runnerOptions } = getRunner(
+    nxArgs,
+    nxJson,
+    loadDotEnvFiles
+  );
 
   let hasher;
   if (daemonClient.enabled()) {
@@ -370,11 +374,13 @@ function shouldUseDynamicLifeCycle(
 
 export function getRunner(
   nxArgs: NxArgs,
-  nxJson: NxJsonConfiguration
+  nxJson: NxJsonConfiguration,
+  loadDotEnvFiles: boolean
 ): {
   tasksRunner: TasksRunner;
   runnerOptions: any;
 } {
+  setEnvVarsBasedOnArgs(nxArgs, loadDotEnvFiles);
   let runner = nxArgs.runner;
   runner = runner || 'default';
   if (!nxJson.tasksRunnerOptions) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

when using batch mode the output style does not change to 'stream' causing odd terminal rendering.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
when using batch mode the output style is set to 'stream'

Note:
these vars are loaded in `getRunner` as it's more testable than using `runCommand`, but loading in `runCommand` would be simpler code wise. Open to switching implementation. using `runCommand` could be used and tested via e2e, but in CI e2e is always static output so it would look like it "always" works with batch mode. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
