### PR TITLE
fix(angular): ensure ngrx runtime utils are available for testing

### DIFF
--- a/packages/angular/index.cts
+++ b/packages/angular/index.cts
@@ -1,3 +1,0 @@
-module.exports = {
-  name: '@nx/angular',
-};

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -30,10 +30,7 @@
     "./src/builders/*.impl": "./src/builders/*.impl.js",
     "./src/executors/*/schema.json": "./src/executors/*/schema.json",
     "./src/executors/*.impl": "./src/executors/*.impl.js",
-    "./src/executors/*/compat": "./src/executors/*/compat.js",
-    ".": {
-      "require": "./index.cjs"
-    }
+    "./src/executors/*/compat": "./src/executors/*/compat.js"
   },
   "author": "Victor Savkin",
   "license": "MIT",

--- a/packages/angular/tsconfig.lib.json
+++ b/packages/angular/tsconfig.lib.json
@@ -14,5 +14,5 @@
     "jest.config.ts",
     "test-setup.ts"
   ],
-  "include": ["**/*.ts", "./index.cts"]
+  "include": ["**/*.ts"]
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The NgRx runtime utils are undefined in test environments.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The NgRx runtime utils are available in test environments.

This reverts the CJS entry point added in https://github.com/nrwl/nx/pull/17189. There's a different workaround already in place that doesn't need this conditional entry point anymore.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17455 
