### PR TITLE
fix(core): determine workspace type when creating workspace passing "angular" or "react" as preset

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -494,7 +494,7 @@ async function determineReactOptions(
   let bundler: undefined | 'webpack' | 'vite' | 'rspack' = undefined;
   let nextAppDir = false;
 
-  if (parsedArgs.preset) {
+  if (parsedArgs.preset && parsedArgs.preset !== Preset.React) {
     preset = parsedArgs.preset;
     if (
       preset === Preset.ReactStandalone ||
@@ -605,7 +605,7 @@ async function determineAngularOptions(
   let standaloneApi: boolean;
   let routing: boolean;
 
-  if (parsedArgs.preset) {
+  if (parsedArgs.preset && parsedArgs.preset !== Preset.Angular) {
     preset = parsedArgs.preset;
 
     if (preset === Preset.AngularStandalone) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When creating a new workspace, if `--preset=angular` or `--preset=react` is provided, an empty workspace is created with no application.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When creating a new workspace, if `--preset=angular` or `--preset=react` is provided, the user should be prompted which workspace type (standalone or integrated) they want to create.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17398 
