### PR TITLE
fix(react): ssr should serve correctly and e2e should function

### DIFF
--- a/packages/react/src/generators/setup-ssr/setup-ssr.ts
+++ b/packages/react/src/generators/setup-ssr/setup-ssr.ts
@@ -115,6 +115,7 @@ export async function setupSsrGenerator(tree: Tree, options: Schema) {
         target: 'node',
         main: `${projectRoot}/server.ts`,
         outputPath: joinPathFragments(originalOutputPath, 'server'),
+        outputFileName: 'server.js',
         tsConfig: `${projectRoot}/tsconfig.server.json`,
         compiler: 'babel',
         externalDependencies: 'all',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
E2E and Serve of React SSR apps not functioning correctly.

The ssr-dev-server is not receiving build options from the js/node executor to be able to determine when the server has been started successfully.
Therefore, it can never set itself to a ready state.

This prevents cypress from being able to run.

The webpack executor also looks for the entry point based on `outputFileName` or else it will default to `main.js`.
The node executor finds the entry point based on `main` in build options. 

Webpack executor is outputting `main.js` as the entrypoint, however, node executor is looking for `server.js` as the main option is `server.ts`.

The setup-ssr generator does not set an `outputFileName`. Make it set an `outputFileName` to ensure consistency and behaviour.
If user's want to change the name of the filename that is output, they can change this option and both executors will still function in unison.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Serving SSR and e2es should work.
setup-ssr generator should set an `outputFileName`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17723 #17706
