### PR TITLE
feat(core): set rust watcher as default

### DIFF
--- a/e2e/nx-misc/src/watch.test.ts
+++ b/e2e/nx-misc/src/watch.test.ts
@@ -55,8 +55,13 @@ describe('Nx Commands', () => {
     createFile(`libs/${proj1}/newfile2.txt`, 'content');
     createFile(`newfile2.txt`, 'content');
 
-    expect(await getOutput()).toEqual([
-      `libs/${proj1}/newfile.txt libs/${proj1}/newfile2.txt libs/${proj2}/newfile.txt`,
+    let output = (await getOutput())[0];
+    let results = output.split(' ').sort();
+
+    expect(results).toEqual([
+      `libs/${proj1}/newfile.txt`,
+      `libs/${proj1}/newfile2.txt`,
+      `libs/${proj2}/newfile.txt`,
     ]);
   });
 
@@ -69,8 +74,14 @@ describe('Nx Commands', () => {
     createFile(`libs/${proj1}/newfile2.txt`, 'content');
     createFile(`newfile2.txt`, 'content');
 
-    expect(await getOutput()).toEqual([
-      `libs/${proj1}/newfile.txt libs/${proj1}/newfile2.txt libs/${proj2}/newfile.txt newfile2.txt`,
+    let output = (await getOutput())[0];
+    let results = output.split(' ').sort();
+
+    expect(results).toEqual([
+      `libs/${proj1}/newfile.txt`,
+      `libs/${proj1}/newfile2.txt`,
+      `libs/${proj2}/newfile.txt`,
+      'newfile2.txt',
     ]);
   });
 
@@ -102,7 +113,7 @@ describe('Nx Commands', () => {
     createFile(`libs/${proj3}/newfile2.txt`, 'content');
     createFile(`newfile2.txt`, 'content');
 
-    expect(await getOutput()).toEqual([proj3, proj1]);
+    expect(await getOutput()).toEqual([proj1, proj3]);
   });
 });
 

--- a/e2e/nx-misc/src/watch.test.ts
+++ b/e2e/nx-misc/src/watch.test.ts
@@ -119,7 +119,10 @@ describe('Nx Commands', () => {
     createFile(`libs/${proj3}/newfile2.txt`, 'content');
     createFile(`newfile2.txt`, 'content');
 
-    expect(await getOutput()).toEqual([proj1, proj3]);
+    let output = await getOutput();
+    let results = output.sort();
+
+    expect(results).toEqual([proj1, proj3]);
   });
 });
 

--- a/e2e/nx-misc/src/watch.test.ts
+++ b/e2e/nx-misc/src/watch.test.ts
@@ -45,7 +45,10 @@ describe('Nx Commands', () => {
     createFile(`libs/${proj3}/newfile2.txt`, 'content');
     createFile(`newfile2.txt`, 'content');
 
-    expect(await getOutput()).toEqual([proj1, proj2, proj3]);
+    let content = await getOutput();
+    let results = content.sort();
+
+    expect(results).toEqual([proj1, proj2, proj3]);
   });
 
   it('should watch for all project changes and output the file name changes', async () => {
@@ -95,7 +98,10 @@ describe('Nx Commands', () => {
     createFile(`libs/${proj3}/newfile2.txt`, 'content');
     createFile(`newfile2.txt`, 'content');
 
-    expect(await getOutput()).toEqual([proj1, proj3]);
+    let output = await getOutput();
+    let results = output.sort();
+
+    expect(results).toEqual([proj1, proj3]);
   });
 
   it('should watch projects including their dependencies', async () => {

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -96,10 +96,6 @@ export interface NxJsonConfiguration<T = '*' | string[]> {
        * Default options for the runner
        */
       options?: any;
-      /**
-       * Enables the Rust watcher within the daemon
-       */
-      nativeWatcher?: boolean;
     };
   };
   /**

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -345,8 +345,10 @@ export class DaemonClient {
     this._out = await open(DAEMON_OUTPUT_LOG_FILE, 'a');
     this._err = await open(DAEMON_OUTPUT_LOG_FILE, 'a');
 
-    if (this.nxJson.tasksRunnerOptions.default?.nativeWatcher) {
-      DAEMON_ENV_SETTINGS['NX_NATIVE_WATCHER'] = true;
+    if (this.nxJson.tasksRunnerOptions.default?.options?.useParcelWatcher) {
+      DAEMON_ENV_SETTINGS['NX_NATIVE_WATCHER'] = 'false';
+    } else {
+      DAEMON_ENV_SETTINGS['NX_NATIVE_WATCHER'] = 'true';
     }
 
     const backgroundProcess = spawn(

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -469,6 +469,7 @@ export async function startServer(): Promise<Server> {
   });
 }
 
+// TODO(cammisuli): remove with nx 16.6 (only our watcher will be supported)
 function useNativeWatcher() {
   return process.env.NX_NATIVE_WATCHER === 'true';
 }

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -17,7 +17,8 @@ export interface FileData {
  */
 export const enum EventType {
   delete = 'delete',
-  update = 'update'
+  update = 'update',
+  create = 'create'
 }
 export interface WatchEvent {
   path: string

--- a/packages/nx/src/native/tests/watcher.spec.ts
+++ b/packages/nx/src/native/tests/watcher.spec.ts
@@ -33,7 +33,7 @@ describe('watcher', () => {
         [
           {
             "path": "app1/main.html",
-            "type": "update",
+            "type": "create",
           },
         ]
       `);

--- a/packages/nx/src/native/tests/watcher.spec.ts
+++ b/packages/nx/src/native/tests/watcher.spec.ts
@@ -118,7 +118,7 @@ describe('watcher', () => {
         [
           {
             "path": "boo.txt",
-            "type": "update",
+            "type": "create",
           },
         ]
       `);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
the rust watcher is optional and is hidden behind a `useNativeWatcher` flag. 

## Expected Behavior
The parcel watcher is now optional, and the rust one is enabled by default. If problems come up with the rust watcher, we have a fallback option to re-enable the parcel watcher by setting `useParcelWatcher` to true in nx.json >`taskRunnerOptions.default.options.useParcelWatcher`

> Note
> Should be merged in after 16.4.0 is released, and put into the 16.5.0 betas
