### PR TITLE
fix(core): store command runs in the correct cache directory

### DIFF
--- a/packages/nx/src/tasks-runner/life-cycles/store-run-information-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/store-run-information-life-cycle.ts
@@ -3,7 +3,7 @@ import { writeFileSync } from 'fs';
 import { LifeCycle } from '../../tasks-runner/life-cycle';
 import { Task } from '../../config/task-graph';
 import { TaskStatus } from '../../tasks-runner/tasks-runner';
-import { projectGraphCacheDirectory } from '../../utils/cache-directory';
+import { cacheDir } from '../../utils/cache-directory';
 
 export class StoreRunInformationLifeCycle implements LifeCycle {
   private startTime: string;
@@ -106,7 +106,7 @@ function parseCommand() {
 
 function storeFileFunction(runDetails: any) {
   writeFileSync(
-    join(projectGraphCacheDirectory, 'run.json'),
+    join(cacheDir, 'run.json'),
     JSON.stringify(runDetails, null, 2)
   );
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Command runs are stored in the project graph cache directory. Apart from being the wrong directory to store that information, it causes an issue in scenarios like fresh clones where the directory is not yet created when storing the information.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Command runs should be stored in the main cache directory.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15468 
