### PR TITLE
fix(nextjs): Respect --nextAppDir when passed during CNW

### DIFF
--- a/e2e/workspace-create/src/create-nx-workspace.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace.test.ts
@@ -213,11 +213,13 @@ describe('create-nx-workspace', () => {
       packageManager,
     });
 
+    checkFilesExist(`apps/${appName}/pages/index.tsx`);
+
     expectNoAngularDevkit();
     expectCodeIsFormatted();
   });
 
-  it('should be able to create a nextjs standalone workspace', () => {
+  it('should be able to create a nextjs standalone workspace using app router', () => {
     const wsName = uniq('next');
     const appName = uniq('app');
     runCreateWorkspace(wsName, {
@@ -227,6 +229,25 @@ describe('create-nx-workspace', () => {
       appName,
       packageManager,
     });
+
+    checkFilesExist('app/page.tsx');
+
+    expectNoAngularDevkit();
+    expectCodeIsFormatted();
+  });
+
+  it('should be able to create a nextjs standalone workspace using pages router', () => {
+    const wsName = uniq('next');
+    const appName = uniq('app');
+    runCreateWorkspace(wsName, {
+      preset: 'nextjs-standalone',
+      style: 'css',
+      nextAppDir: false,
+      appName,
+      packageManager,
+    });
+
+    checkFilesExist('pages/index.tsx');
 
     expectNoAngularDevkit();
     expectCodeIsFormatted();

--- a/packages/workspace/src/generators/new/generate-preset.ts
+++ b/packages/workspace/src/generators/new/generate-preset.ts
@@ -77,7 +77,7 @@ export function generatePreset(host: Tree, opts: NormalizedSchema) {
       opts.framework ? `--framework=${opts.framework}` : null,
       opts.docker ? `--docker=${opts.docker}` : null,
       opts.js ? `--js` : null,
-      opts.nextAppDir ? `--nextAppDir=${opts.nextAppDir}` : null,
+      opts.nextAppDir ? '--nextAppDir=true' : '--nextAppDir=false',
       opts.packageManager ? `--packageManager=${opts.packageManager}` : null,
       opts.standaloneApi !== undefined
         ? `--standaloneApi=${opts.standaloneApi}`

--- a/packages/workspace/src/generators/preset/preset.ts
+++ b/packages/workspace/src/generators/preset/preset.ts
@@ -81,6 +81,7 @@ async function createPreset(tree: Tree, options: Schema) {
       name: options.name,
       style: options.style,
       linter: options.linter,
+      appDir: options.nextAppDir,
       e2eTestRunner: options.e2eTestRunner ?? 'cypress',
     });
   } else if (options.preset === Preset.NextJsStandalone) {


### PR DESCRIPTION
This addresses an issue when you run CNW to create a Next.js app with `--nextAppDir=false` to generate `pages/` it would always generate `app/`.