### PR TITLE
fix(nextjs): Custom server generator root undefined

### DIFF
--- a/packages/next/src/generators/custom-server/custom-server.ts
+++ b/packages/next/src/generators/custom-server/custom-server.ts
@@ -28,7 +28,7 @@ export async function customServerGenerator(
   }
 
   const outputPath = project.targets?.build?.options?.outputPath;
-  const root = project.targets?.build?.options?.root;
+  const root = project.root;
 
   if (
     !root ||


### PR DESCRIPTION
When generating a custom server for a fresh Next.js project, it should work without issues.

Fixes #17673
