### PR TITLE
fix(storybook): dont exclude stories paths for vite builder

### DIFF
--- a/packages/storybook/src/generators/configuration/configuration.spec.ts
+++ b/packages/storybook/src/generators/configuration/configuration.spec.ts
@@ -78,7 +78,7 @@ describe('@nx/storybook:configuration for Storybook v7', () => {
       ).toBeTruthy();
     });
 
-    it('should update `tsconfig.lib.json` file', async () => {
+    it('should update `tsconfig.lib.json` file if project does not use vite', async () => {
       await configurationGenerator(tree, {
         name: 'test-ui-lib',
         standaloneConfig: false,

--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -96,6 +96,9 @@ export async function configurationGenerator(
   });
   tasks.push(initTask);
 
+  const projectUsesVite =
+    !!viteBuildTarget || schema.uiFramework.endsWith('-vite');
+
   createProjectStorybookDir(
     tree,
     schema.name,
@@ -107,11 +110,11 @@ export async function configurationGenerator(
     projectIsRootProjectInStandaloneWorkspace(root),
     !!nextBuildTarget,
     compiler === 'swc',
-    !!viteBuildTarget || schema.uiFramework.endsWith('-vite'),
+    projectUsesVite,
     viteConfigFilePath
   );
 
-  configureTsProjectConfig(tree, schema);
+  configureTsProjectConfig(tree, schema, projectUsesVite);
   configureTsSolutionConfig(tree, schema);
   updateLintConfig(tree, schema);
 


### PR DESCRIPTION
## Current Behavior

See the issues attached and this reproduction: https://github.com/mandarini/storybook-vite-paths

Storybook cannot resolve the import paths and build correctly when using `@storybook/react-vite` and trying to import a workspace library into a story file.

The reason is because Storybook Vite builder uses the project's vite.config.ts file. The project's vite.config.ts file uses the project's tsconfig.json file. Storybook's tsconfig.json file includes the `.stories.*` files, however the project's tsconfig.json excludes the `.stories.*` files. The result is that Storybook's Vite builder, which uses the project's vite.config.ts file, which uses the project's tsconfig.json, will not be able to find the `.stories.*` files.

## Expected Behavior

Storybook can resolve the paths correctly and build.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17257 #17156
