### PR TITLE
fix(react): mf should consider ssl when setting remote urls #16989

### DIFF
--- a/packages/angular/src/utils/mf/utils.ts
+++ b/packages/angular/src/utils/mf/utils.ts
@@ -58,7 +58,9 @@ export function getFunctionDeterminateRemoteUrl(isServer: boolean = false) {
       );
     }
 
-    const host = serveTarget.options?.host ?? 'http://localhost';
+    const host =
+      serveTarget.options?.host ??
+      `http${serveTarget.options.ssl ? 's' : ''}://localhost`;
     const port = serveTarget.options?.port ?? 4201;
     return `${
       host.endsWith('/') ? host.slice(0, -1) : host

--- a/packages/react/src/module-federation/utils.ts
+++ b/packages/react/src/module-federation/utils.ts
@@ -31,7 +31,9 @@ export function getFunctionDeterminateRemoteUrl(isServer: boolean = false) {
       );
     }
 
-    const host = serveTarget.options?.host ?? 'http://localhost';
+    const host =
+      serveTarget.options?.host ??
+      `http${serveTarget.options.ssl ? 's' : ''}://localhost`;
     const port = serveTarget.options?.port ?? 4201;
     return `${
       host.endsWith('/') ? host.slice(0, -1) : host


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
SSL with MF isn't setting the remote urls correctly for both Angular and React

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
SSL should work as expected and set the remote url protocol to https


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16989
Fixes #17058
