### PR TITLE
fix(core): do not pass undefined to hasher

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/npm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/npm-parser.ts
@@ -173,7 +173,11 @@ function createNode(
       hash:
         snapshot.integrity ||
         hashArray(
-          snapshot.resolved ? [snapshot.resolved] : [packageName, version]
+          snapshot.resolved
+            ? [snapshot.resolved]
+            : version
+            ? [packageName, version]
+            : [packageName]
         ),
     },
   };


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Native hasher fails if null or undefined is passed as an argument. Npm parser for V1 lock files (including V2 compatibility mode) doesn't have version in the snapshot which breaks the hasher.

## Expected Behavior
Do not pass undefined to hasher.

## Related Issue(s)
Currently happening only on migrations during the corrupted installs, but still something that should not break.

Fixes #17412
