### PR TITLE
feat(storybook): move tsconfig one level up

### DIFF
--- a/e2e/storybook/src/storybook-nested.test.ts
+++ b/e2e/storybook/src/storybook-nested.test.ts
@@ -42,7 +42,7 @@ describe('Storybook generators and executors for standalone workspaces - using R
       checkFilesExist(
         '.storybook/main.js',
         '.storybook/preview.js',
-        '.storybook/tsconfig.json'
+        'tsconfig.storybook.json'
       );
     });
 

--- a/packages/react-native/src/generators/storybook-configuration/configuration.spec.ts
+++ b/packages/react-native/src/generators/storybook-configuration/configuration.spec.ts
@@ -40,7 +40,7 @@ describe('react-native:storybook-configuration', () => {
         appTree.exists('libs/test-ui-lib/.storybook/main.js')
       ).toBeTruthy();
       expect(
-        appTree.exists('libs/test-ui-lib/.storybook/tsconfig.json')
+        appTree.exists('libs/test-ui-lib/tsconfig.storybook.json')
       ).toBeTruthy();
     });
 
@@ -74,7 +74,7 @@ describe('react-native:storybook-configuration', () => {
         appTree.exists('apps/test-ui-app/.storybook/main.js')
       ).toBeTruthy();
       expect(
-        appTree.exists('apps/test-ui-app/.storybook/tsconfig.json')
+        appTree.exists('apps/test-ui-app/tsconfig.storybook.json')
       ).toBeTruthy();
     });
 

--- a/packages/react/plugins/storybook/index.ts
+++ b/packages/react/plugins/storybook/index.ts
@@ -167,9 +167,9 @@ export const webpack = async (
   }
 
   const { withNx, withWeb } = require('@nx/webpack');
-  const tsconfigPath = join(options.configDir, 'tsconfig.json');
 
   const projectData = await getProjectData(options);
+  const tsconfigPath = join(projectData.projectRoot, 'tsconfig.storybook.json');
 
   fixBabelConfigurationIfNeeded(storybookWebpackConfig, projectData);
 

--- a/packages/react/src/generators/storybook-configuration/configuration.spec.ts
+++ b/packages/react/src/generators/storybook-configuration/configuration.spec.ts
@@ -42,7 +42,7 @@ describe('react:storybook-configuration', () => {
 
     expect(appTree.exists('libs/test-ui-lib/.storybook/main.js')).toBeTruthy();
     expect(
-      appTree.exists('libs/test-ui-lib/.storybook/tsconfig.json')
+      appTree.exists('libs/test-ui-lib/tsconfig.storybook.json')
     ).toBeTruthy();
     expect(
       appTree.exists('apps/test-ui-lib-e2e/cypress.config.ts')
@@ -104,7 +104,7 @@ describe('react:storybook-configuration', () => {
 
     expect(appTree.exists('apps/test-ui-app/.storybook/main.js')).toBeTruthy();
     expect(
-      appTree.exists('apps/test-ui-app/.storybook/tsconfig.json')
+      appTree.exists('apps/test-ui-app/tsconfig.storybook.json')
     ).toBeTruthy();
 
     /**

--- a/packages/storybook/migrations.json
+++ b/packages/storybook/migrations.json
@@ -59,6 +59,12 @@
       "version": "16.1.0-beta.0",
       "description": "Ignore @nx/react/plugins/storybook in Storybook eslint rules.",
       "factory": "./src/migrations/update-16-1-0/eslint-ignore-react-plugin"
+    },
+    "update-16-5-0": {
+      "cli": "nx",
+      "version": "16.5.0-beta.0",
+      "description": "Move .storybook/tsconfig.json to tsconfig.storybook.json for non-Angular projects.",
+      "factory": "./src/migrations/update-16-5-0/move-storybook-tsconfig"
     }
   },
   "packageJsonUpdates": {

--- a/packages/storybook/src/generators/configuration/__snapshots__/configuration-nested.spec.ts.snap
+++ b/packages/storybook/src/generators/configuration/__snapshots__/configuration-nested.spec.ts.snap
@@ -26,30 +26,34 @@ export default config;
 
 exports[`@nx/storybook:configuration for workspaces with Root project basic functionalities should generate Storybook files for nested project only 2`] = `
 "{
-  "extends": "../tsconfig.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "emitDecoratorMetadata": true,
     "outDir": ""
   },
   "files": [
-    "../node_modules/@nx/react/typings/styled-jsx.d.ts",
-    "../node_modules/@nx/react/typings/cssmodule.d.ts",
-    "../node_modules/@nx/react/typings/image.d.ts"
+    "node_modules/@nx/react/typings/styled-jsx.d.ts",
+    "node_modules/@nx/react/typings/cssmodule.d.ts",
+    "node_modules/@nx/react/typings/image.d.ts"
   ],
   "exclude": [
-    "../**/*.spec.ts",
-    "../**/*.spec.js",
-    "../**/*.spec.tsx",
-    "../**/*.spec.jsx"
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.js",
+    "src/**/*.test.js",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.test.js"
   ],
   "include": [
-    "../src/**/*.stories.ts",
-    "../src/**/*.stories.js",
-    "../src/**/*.stories.jsx",
-    "../src/**/*.stories.tsx",
-    "../src/**/*.stories.mdx",
-    "*.ts",
-    "*.js"
+    "src/**/*.stories.ts",
+    "src/**/*.stories.js",
+    "src/**/*.stories.jsx",
+    "src/**/*.stories.tsx",
+    "src/**/*.stories.mdx",
+    ".storybook/*.js",
+    ".storybook/*.ts"
   ]
 }
 "
@@ -79,30 +83,34 @@ export default config;
 
 exports[`@nx/storybook:configuration for workspaces with Root project basic functionalities should generate Storybook files for nested project only 5`] = `
 "{
-  "extends": "../tsconfig.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "emitDecoratorMetadata": true,
     "outDir": ""
   },
   "files": [
-    "../../../node_modules/@nx/react/typings/styled-jsx.d.ts",
-    "../../../node_modules/@nx/react/typings/cssmodule.d.ts",
-    "../../../node_modules/@nx/react/typings/image.d.ts"
+    "../../node_modules/@nx/react/typings/styled-jsx.d.ts",
+    "../../node_modules/@nx/react/typings/cssmodule.d.ts",
+    "../../node_modules/@nx/react/typings/image.d.ts"
   ],
   "exclude": [
-    "../**/*.spec.ts",
-    "../**/*.spec.js",
-    "../**/*.spec.tsx",
-    "../**/*.spec.jsx"
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.js",
+    "src/**/*.test.js",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.test.js"
   ],
   "include": [
-    "../src/**/*.stories.ts",
-    "../src/**/*.stories.js",
-    "../src/**/*.stories.jsx",
-    "../src/**/*.stories.tsx",
-    "../src/**/*.stories.mdx",
-    "*.ts",
-    "*.js"
+    "src/**/*.stories.ts",
+    "src/**/*.stories.js",
+    "src/**/*.stories.jsx",
+    "src/**/*.stories.tsx",
+    "src/**/*.stories.mdx",
+    ".storybook/*.js",
+    ".storybook/*.ts"
   ]
 }
 "

--- a/packages/storybook/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/storybook/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -94,27 +94,6 @@ exports[`@nx/storybook:configuration for Storybook v7 basic functionalities shou
 exports[`@nx/storybook:configuration for Storybook v7 basic functionalities should generate TypeScript Configuration files 2`] = `null`;
 
 exports[`@nx/storybook:configuration for Storybook v7 basic functionalities should generate TypeScript Configuration files 3`] = `
-"{
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "emitDecoratorMetadata": true
-  },
-
-  "exclude": ["../**/*.spec.ts"],
-  "include": [
-    "../src/**/*.stories.ts",
-    "../src/**/*.stories.js",
-    "../src/**/*.stories.jsx",
-    "../src/**/*.stories.tsx",
-    "../src/**/*.stories.mdx",
-    "*.ts",
-    "*.js"
-  ]
-}
-"
-`;
-
-exports[`@nx/storybook:configuration for Storybook v7 basic functionalities should generate TypeScript Configuration files 4`] = `
 "import type { StorybookConfig } from '@storybook/angular';
 
 const config: StorybookConfig = {
@@ -136,29 +115,34 @@ export default config;
 
 exports[`@nx/storybook:configuration for Storybook v7 basic functionalities should have the proper typings 1`] = `
 "{
-  "extends": "../tsconfig.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "emitDecoratorMetadata": true,
     "outDir": ""
   },
   "files": [
-    "../../../node_modules/@nx/react/typings/styled-jsx.d.ts",
-    "../../../node_modules/@nx/react/typings/cssmodule.d.ts",
-    "../../../node_modules/@nx/react/typings/image.d.ts"
+    "../../node_modules/@nx/react/typings/styled-jsx.d.ts",
+    "../../node_modules/@nx/react/typings/cssmodule.d.ts",
+    "../../node_modules/@nx/react/typings/image.d.ts"
   ],
   "exclude": [
-    "../**/*.spec.ts",
-    "../**/*.spec.js",
-    "../**/*.spec.tsx",
-    "../**/*.spec.jsx"
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.js",
+    "src/**/*.test.js",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.test.js"
   ],
   "include": [
-    "../src/**/*.stories.ts",
-    "../src/**/*.stories.js",
-    "../src/**/*.stories.jsx",
-    "../src/**/*.stories.tsx",
-    "../src/**/*.stories.mdx",
-    "*.js"
+    "src/**/*.stories.ts",
+    "src/**/*.stories.js",
+    "src/**/*.stories.jsx",
+    "src/**/*.stories.tsx",
+    "src/**/*.stories.mdx",
+    ".storybook/*.js",
+    ".storybook/*.ts"
   ]
 }
 "
@@ -186,35 +170,7 @@ export default config;
 "
 `;
 
-exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/main-vite/.storybook/" 2`] = `
-"{
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "emitDecoratorMetadata": true,
-    "outDir": ""
-  },
-  "files": [
-    "../../../node_modules/@nx/react/typings/styled-jsx.d.ts",
-    "../../../node_modules/@nx/react/typings/cssmodule.d.ts",
-    "../../../node_modules/@nx/react/typings/image.d.ts"
-  ],
-  "exclude": [
-    "../**/*.spec.ts",
-    "../**/*.spec.js",
-    "../**/*.spec.tsx",
-    "../**/*.spec.jsx"
-  ],
-  "include": [
-    "../src/**/*.stories.ts",
-    "../src/**/*.stories.js",
-    "../src/**/*.stories.jsx",
-    "../src/**/*.stories.tsx",
-    "../src/**/*.stories.mdx",
-    "*.js"
-  ]
-}
-"
-`;
+exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/main-vite/.storybook/" 2`] = `null`;
 
 exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/main-vite-ts/.storybook/" 1`] = `
 "import type { StorybookConfig } from '@storybook/react-vite';
@@ -240,36 +196,7 @@ export default config;
 "
 `;
 
-exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/main-vite-ts/.storybook/" 2`] = `
-"{
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "emitDecoratorMetadata": true,
-    "outDir": ""
-  },
-  "files": [
-    "../../../node_modules/@nx/react/typings/styled-jsx.d.ts",
-    "../../../node_modules/@nx/react/typings/cssmodule.d.ts",
-    "../../../node_modules/@nx/react/typings/image.d.ts"
-  ],
-  "exclude": [
-    "../**/*.spec.ts",
-    "../**/*.spec.js",
-    "../**/*.spec.tsx",
-    "../**/*.spec.jsx"
-  ],
-  "include": [
-    "../src/**/*.stories.ts",
-    "../src/**/*.stories.js",
-    "../src/**/*.stories.jsx",
-    "../src/**/*.stories.tsx",
-    "../src/**/*.stories.mdx",
-    "*.ts",
-    "*.js"
-  ]
-}
-"
-`;
+exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/main-vite-ts/.storybook/" 2`] = `null`;
 
 exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/main-webpack/.storybook/" 1`] = `
 "const config = {
@@ -289,35 +216,7 @@ export default config;
 "
 `;
 
-exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/main-webpack/.storybook/" 2`] = `
-"{
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "emitDecoratorMetadata": true,
-    "outDir": ""
-  },
-  "files": [
-    "../../../node_modules/@nx/react/typings/styled-jsx.d.ts",
-    "../../../node_modules/@nx/react/typings/cssmodule.d.ts",
-    "../../../node_modules/@nx/react/typings/image.d.ts"
-  ],
-  "exclude": [
-    "../**/*.spec.ts",
-    "../**/*.spec.js",
-    "../**/*.spec.tsx",
-    "../**/*.spec.jsx"
-  ],
-  "include": [
-    "../src/**/*.stories.ts",
-    "../src/**/*.stories.js",
-    "../src/**/*.stories.jsx",
-    "../src/**/*.stories.tsx",
-    "../src/**/*.stories.mdx",
-    "*.js"
-  ]
-}
-"
-`;
+exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/main-webpack/.storybook/" 2`] = `null`;
 
 exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/nextapp/.storybook/" 1`] = `
 "const config = {
@@ -337,25 +236,7 @@ export default config;
 "
 `;
 
-exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/nextapp/.storybook/" 2`] = `
-"{
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "emitDecoratorMetadata": true
-  },
-
-  "exclude": ["../**/*.spec.ts"],
-  "include": [
-    "../components/**/*.stories.ts",
-    "../components/**/*.stories.js",
-    "../components/**/*.stories.jsx",
-    "../components/**/*.stories.tsx",
-    "../components/**/*.stories.mdx",
-    "*.js"
-  ]
-}
-"
-`;
+exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/nextapp/.storybook/" 2`] = `null`;
 
 exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/react-swc/.storybook/" 1`] = `
 "const config = {
@@ -375,35 +256,7 @@ export default config;
 "
 `;
 
-exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/react-swc/.storybook/" 2`] = `
-"{
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "emitDecoratorMetadata": true,
-    "outDir": ""
-  },
-  "files": [
-    "../../../node_modules/@nx/react/typings/styled-jsx.d.ts",
-    "../../../node_modules/@nx/react/typings/cssmodule.d.ts",
-    "../../../node_modules/@nx/react/typings/image.d.ts"
-  ],
-  "exclude": [
-    "../**/*.spec.ts",
-    "../**/*.spec.js",
-    "../**/*.spec.tsx",
-    "../**/*.spec.jsx"
-  ],
-  "include": [
-    "../src/**/*.stories.ts",
-    "../src/**/*.stories.js",
-    "../src/**/*.stories.jsx",
-    "../src/**/*.stories.tsx",
-    "../src/**/*.stories.mdx",
-    "*.js"
-  ]
-}
-"
-`;
+exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/react-swc/.storybook/" 2`] = `null`;
 
 exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/reapp/.storybook/" 1`] = `
 "const config = {
@@ -427,35 +280,7 @@ export default config;
 "
 `;
 
-exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/reapp/.storybook/" 2`] = `
-"{
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "emitDecoratorMetadata": true,
-    "outDir": ""
-  },
-  "files": [
-    "../../../node_modules/@nx/react/typings/styled-jsx.d.ts",
-    "../../../node_modules/@nx/react/typings/cssmodule.d.ts",
-    "../../../node_modules/@nx/react/typings/image.d.ts"
-  ],
-  "exclude": [
-    "../**/*.spec.ts",
-    "../**/*.spec.js",
-    "../**/*.spec.tsx",
-    "../**/*.spec.jsx"
-  ],
-  "include": [
-    "../src/**/*.stories.ts",
-    "../src/**/*.stories.js",
-    "../src/**/*.stories.jsx",
-    "../src/**/*.stories.tsx",
-    "../src/**/*.stories.mdx",
-    "*.js"
-  ]
-}
-"
-`;
+exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/reapp/.storybook/" 2`] = `null`;
 
 exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/reappw/.storybook/" 1`] = `
 "const config = {
@@ -475,35 +300,7 @@ export default config;
 "
 `;
 
-exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/reappw/.storybook/" 2`] = `
-"{
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "emitDecoratorMetadata": true,
-    "outDir": ""
-  },
-  "files": [
-    "../../../node_modules/@nx/react/typings/styled-jsx.d.ts",
-    "../../../node_modules/@nx/react/typings/cssmodule.d.ts",
-    "../../../node_modules/@nx/react/typings/image.d.ts"
-  ],
-  "exclude": [
-    "../**/*.spec.ts",
-    "../**/*.spec.js",
-    "../**/*.spec.tsx",
-    "../**/*.spec.jsx"
-  ],
-  "include": [
-    "../src/**/*.stories.ts",
-    "../src/**/*.stories.js",
-    "../src/**/*.stories.jsx",
-    "../src/**/*.stories.tsx",
-    "../src/**/*.stories.mdx",
-    "*.js"
-  ]
-}
-"
-`;
+exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/reappw/.storybook/" 2`] = `null`;
 
 exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/wv1/.storybook/" 1`] = `
 "const config = {
@@ -527,25 +324,7 @@ export default config;
 "
 `;
 
-exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/wv1/.storybook/" 2`] = `
-"{
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "emitDecoratorMetadata": true
-  },
-
-  "exclude": ["../**/*.spec.ts"],
-  "include": [
-    "../src/**/*.stories.ts",
-    "../src/**/*.stories.js",
-    "../src/**/*.stories.jsx",
-    "../src/**/*.stories.tsx",
-    "../src/**/*.stories.mdx",
-    "*.js"
-  ]
-}
-"
-`;
+exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/wv1/.storybook/" 2`] = `null`;
 
 exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/ww1/.storybook/" 1`] = `
 "const config = {
@@ -565,25 +344,7 @@ export default config;
 "
 `;
 
-exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/ww1/.storybook/" 2`] = `
-"{
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "emitDecoratorMetadata": true
-  },
-
-  "exclude": ["../**/*.spec.ts"],
-  "include": [
-    "../src/**/*.stories.ts",
-    "../src/**/*.stories.js",
-    "../src/**/*.stories.jsx",
-    "../src/**/*.stories.tsx",
-    "../src/**/*.stories.mdx",
-    "*.js"
-  ]
-}
-"
-`;
+exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "apps/ww1/.storybook/" 2`] = `null`;
 
 exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "libs/react-rollup/.storybook/" 1`] = `
 "const config = {
@@ -603,35 +364,7 @@ export default config;
 "
 `;
 
-exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "libs/react-rollup/.storybook/" 2`] = `
-"{
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "emitDecoratorMetadata": true,
-    "outDir": ""
-  },
-  "files": [
-    "../../../node_modules/@nx/react/typings/styled-jsx.d.ts",
-    "../../../node_modules/@nx/react/typings/cssmodule.d.ts",
-    "../../../node_modules/@nx/react/typings/image.d.ts"
-  ],
-  "exclude": [
-    "../**/*.spec.ts",
-    "../**/*.spec.js",
-    "../**/*.spec.tsx",
-    "../**/*.spec.jsx"
-  ],
-  "include": [
-    "../src/**/*.stories.ts",
-    "../src/**/*.stories.js",
-    "../src/**/*.stories.jsx",
-    "../src/**/*.stories.tsx",
-    "../src/**/*.stories.mdx",
-    "*.js"
-  ]
-}
-"
-`;
+exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "libs/react-rollup/.storybook/" 2`] = `null`;
 
 exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "libs/react-vite/.storybook/" 1`] = `
 "const config = {
@@ -655,35 +388,7 @@ export default config;
 "
 `;
 
-exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "libs/react-vite/.storybook/" 2`] = `
-"{
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "emitDecoratorMetadata": true,
-    "outDir": ""
-  },
-  "files": [
-    "../../../node_modules/@nx/react/typings/styled-jsx.d.ts",
-    "../../../node_modules/@nx/react/typings/cssmodule.d.ts",
-    "../../../node_modules/@nx/react/typings/image.d.ts"
-  ],
-  "exclude": [
-    "../**/*.spec.ts",
-    "../**/*.spec.js",
-    "../**/*.spec.tsx",
-    "../**/*.spec.jsx"
-  ],
-  "include": [
-    "../src/**/*.stories.ts",
-    "../src/**/*.stories.js",
-    "../src/**/*.stories.jsx",
-    "../src/**/*.stories.tsx",
-    "../src/**/*.stories.mdx",
-    "*.js"
-  ]
-}
-"
-`;
+exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should contain the correct configuration in "libs/react-vite/.storybook/" 2`] = `null`;
 
 exports[`@nx/storybook:configuration for Storybook v7 generate Storybook configuration for all types of projects should have updated all their target configurations correctly 1`] = `
 Map {

--- a/packages/storybook/src/generators/configuration/configuration-nested.spec.ts
+++ b/packages/storybook/src/generators/configuration/configuration-nested.spec.ts
@@ -71,7 +71,7 @@ describe('@nx/storybook:configuration for workspaces with Root project', () => {
             path: './tsconfig.spec.json',
           },
           {
-            path: './.storybook/tsconfig.json',
+            path: './tsconfig.storybook.json',
           },
         ],
       });
@@ -96,7 +96,7 @@ describe('@nx/storybook:configuration for workspaces with Root project', () => {
       });
 
       expect(tree.exists('.storybook/main.js')).toBeTruthy();
-      expect(tree.exists('.storybook/tsconfig.json')).toBeTruthy();
+      expect(tree.exists('tsconfig.storybook.json')).toBeTruthy();
       expect(tree.exists('.storybook/preview.js')).toBeTruthy();
     });
 
@@ -110,11 +110,11 @@ describe('@nx/storybook:configuration for workspaces with Root project', () => {
       });
 
       expect(tree.exists('.storybook/main.ts')).toBeFalsy();
-      expect(tree.exists('.storybook/tsconfig.json')).toBeFalsy();
+      expect(tree.exists('tsconfig.storybook.json')).toBeFalsy();
       expect(tree.exists('.storybook/preview.ts')).toBeFalsy();
 
       expect(tree.exists('apps/reapp/.storybook/main.ts')).toBeTruthy();
-      expect(tree.exists('apps/reapp/.storybook/tsconfig.json')).toBeTruthy();
+      expect(tree.exists('apps/reapp/tsconfig.storybook.json')).toBeTruthy();
       expect(tree.exists('apps/reapp/.storybook/preview.ts')).toBeTruthy();
 
       await configurationGenerator(tree, {
@@ -124,17 +124,17 @@ describe('@nx/storybook:configuration for workspaces with Root project', () => {
       });
 
       expect(tree.exists('.storybook/main.ts')).toBeTruthy();
-      expect(tree.exists('.storybook/tsconfig.json')).toBeTruthy();
+      expect(tree.exists('tsconfig.storybook.json')).toBeTruthy();
       expect(tree.exists('.storybook/preview.ts')).toBeTruthy();
 
       expect(tree.read('.storybook/main.ts', 'utf-8')).toMatchSnapshot();
-      expect(tree.read('.storybook/tsconfig.json', 'utf-8')).toMatchSnapshot();
+      expect(tree.read('tsconfig.storybook.json', 'utf-8')).toMatchSnapshot();
       expect(tree.read('.storybook/preview.ts', 'utf-8')).toMatchSnapshot();
       expect(
         tree.read('apps/reapp/.storybook/main.ts', 'utf-8')
       ).toMatchSnapshot();
       expect(
-        tree.read('apps/reapp/.storybook/tsconfig.json', 'utf-8')
+        tree.read('apps/reapp/tsconfig.storybook.json', 'utf-8')
       ).toMatchSnapshot();
       expect(
         tree.read('apps/reapp/.storybook/preview.ts', 'utf-8')

--- a/packages/storybook/src/generators/configuration/configuration.spec.ts
+++ b/packages/storybook/src/generators/configuration/configuration.spec.ts
@@ -68,8 +68,8 @@ describe('@nx/storybook:configuration for Storybook v7', () => {
 
       expect(tree.read('.storybook/main.ts', 'utf-8')).toMatchSnapshot();
       expect(
-        tree.read('libs/test-ui-lib/.storybook/tsconfig.json', 'utf-8')
-      ).toMatchSnapshot();
+        tree.exists('libs/test-ui-lib/tsconfig.storybook.json')
+      ).toBeFalsy();
       expect(
         tree.read('libs/test-ui-lib/.storybook/main.ts', 'utf-8')
       ).toMatchSnapshot();
@@ -116,7 +116,7 @@ describe('@nx/storybook:configuration for Storybook v7', () => {
             "path": "./tsconfig.spec.json",
           },
           {
-            "path": "./.storybook/tsconfig.json",
+            "path": "./tsconfig.storybook.json",
           },
         ]
       `);
@@ -145,7 +145,7 @@ describe('@nx/storybook:configuration for Storybook v7', () => {
         .toMatchInlineSnapshot(`
         {
           "project": [
-            "libs/test-ui-lib2/.storybook/tsconfig.json",
+            "libs/test-ui-lib2/tsconfig.storybook.json",
           ],
         }
       `);
@@ -164,7 +164,7 @@ describe('@nx/storybook:configuration for Storybook v7', () => {
       });
 
       expect(
-        tree.read('libs/test-ui-lib2/.storybook/tsconfig.json', 'utf-8')
+        tree.read('libs/test-ui-lib2/tsconfig.storybook.json', 'utf-8')
       ).toMatchSnapshot();
     });
 

--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -22,6 +22,7 @@ import {
   configureTsProjectConfig,
   configureTsSolutionConfig,
   createProjectStorybookDir,
+  createStorybookTsconfigFile,
   getE2EProjectName,
   getViteConfigFilePath,
   projectIsRootProjectInStandaloneWorkspace,
@@ -96,6 +97,9 @@ export async function configurationGenerator(
   });
   tasks.push(initTask);
 
+  const mainDir =
+    !!nextBuildTarget && projectType === 'application' ? 'components' : 'src';
+
   createProjectStorybookDir(
     tree,
     schema.name,
@@ -105,12 +109,22 @@ export async function configurationGenerator(
     root,
     projectType,
     projectIsRootProjectInStandaloneWorkspace(root),
+    mainDir,
     !!nextBuildTarget,
     compiler === 'swc',
     !!viteBuildTarget || schema.uiFramework.endsWith('-vite'),
     viteConfigFilePath
   );
 
+  if (schema.uiFramework !== '@storybook/angular') {
+    createStorybookTsconfigFile(
+      tree,
+      root,
+      schema.uiFramework,
+      projectIsRootProjectInStandaloneWorkspace(root),
+      mainDir
+    );
+  }
   configureTsProjectConfig(tree, schema);
   configureTsSolutionConfig(tree, schema);
   updateLintConfig(tree, schema);

--- a/packages/storybook/src/generators/configuration/project-files-ts/.storybook/tsconfig.json__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files-ts/.storybook/tsconfig.json__tmpl__
@@ -2,27 +2,15 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "emitDecoratorMetadata": true
-    <% if(uiFramework === '@storybook/react-webpack5' || uiFramework === '@storybook/react-vite') { %>, "outDir": "" <% } %>
   },
-  <% if(uiFramework === '@storybook/react-webpack5' || uiFramework === '@storybook/react-vite') { %>"files": [
-    "<% if(!isRootProject) { %><%= offsetFromRoot %><% } %>../node_modules/@nx/react/typings/styled-jsx.d.ts",
-    "<% if(!isRootProject) { %><%= offsetFromRoot %><% } %>../node_modules/@nx/react/typings/cssmodule.d.ts",
-    "<% if(!isRootProject) { %><%= offsetFromRoot %><% } %>../node_modules/@nx/react/typings/image.d.ts"
-  ],<% } %>
-  "exclude": ["../**/*.spec.ts" <% if(uiFramework === '@storybook/react-webpack5' || uiFramework === '@storybook/react-vite') { %>, "../**/*.spec.js", "../**/*.spec.tsx", "../**/*.spec.jsx"<% } %>],
-  "include": [<% if(uiFramework === '@storybook/angular' && projectType === 'library') { %>
+  "exclude": ["../**/*.spec.ts"],
+  "include": [
     "../src/**/*.stories.ts",
     "../src/**/*.stories.js",
     "../src/**/*.stories.jsx",
     "../src/**/*.stories.tsx",
     "../src/**/*.stories.mdx",
-    "*.ts",
-    "*.js"<% } else { %>
-    "../<%= mainDir %>/**/*.stories.ts",
-    "../<%= mainDir %>/**/*.stories.js",
-    "../<%= mainDir %>/**/*.stories.jsx",
-    "../<%= mainDir %>/**/*.stories.tsx",
-    "../<%= mainDir %>/**/*.stories.mdx",
-    "*.ts",
-    "*.js"<% if(uiFramework === '@storybook/react-native') { %>, "*.tsx"<% } %><% } %>]
+    "*.js", 
+    "*.ts"
+    ]
 }

--- a/packages/storybook/src/generators/configuration/project-files/.storybook/tsconfig.json__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files/.storybook/tsconfig.json__tmpl__
@@ -2,25 +2,14 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "emitDecoratorMetadata": true
-    <% if(uiFramework === '@storybook/react-webpack5' || uiFramework === '@storybook/react-vite') { %>, "outDir": "" <% } %>
   },
-  <% if(uiFramework === '@storybook/react-webpack5' || uiFramework === '@storybook/react-vite') { %>"files": [
-    "<% if(!isRootProject) { %><%= offsetFromRoot %><% } %>../node_modules/@nx/react/typings/styled-jsx.d.ts",
-    "<% if(!isRootProject) { %><%= offsetFromRoot %><% } %>../node_modules/@nx/react/typings/cssmodule.d.ts",
-    "<% if(!isRootProject) { %><%= offsetFromRoot %><% } %>../node_modules/@nx/react/typings/image.d.ts"
-  ],<% } %>
-  "exclude": ["../**/*.spec.ts" <% if(uiFramework === '@storybook/react-webpack5' || uiFramework === '@storybook/react-vite') { %>, "../**/*.spec.js", "../**/*.spec.tsx", "../**/*.spec.jsx"<% } %>],
-  "include": [<% if(uiFramework === '@storybook/angular' && projectType === 'library') { %>
+  "exclude": ["../**/*.spec.ts"],
+  "include": [
     "../src/**/*.stories.ts",
     "../src/**/*.stories.js",
     "../src/**/*.stories.jsx",
     "../src/**/*.stories.tsx",
     "../src/**/*.stories.mdx",
-    "*.js"<% } else { %>
-    "../<%= mainDir %>/**/*.stories.ts",
-    "../<%= mainDir %>/**/*.stories.js",
-    "../<%= mainDir %>/**/*.stories.jsx",
-    "../<%= mainDir %>/**/*.stories.tsx",
-    "../<%= mainDir %>/**/*.stories.mdx",
-    "*.js"<% if(uiFramework === '@storybook/react-native') { %>, "*.ts", "*.tsx"<% } %><% } %>]
+    "*.js"
+    ]
 }

--- a/packages/storybook/src/migrations/update-14-0-0/migrate-defaults-5-to-6/migrate-defaults-5-to-6.ts
+++ b/packages/storybook/src/migrations/update-14-0-0/migrate-defaults-5-to-6/migrate-defaults-5-to-6.ts
@@ -184,6 +184,9 @@ function migrateProjectLevelStorybookInstance(
   const { nextBuildTarget, compiler } =
     findStorybookAndBuildTargetsAndCompiler(targets);
 
+  const mainDir =
+    !!nextBuildTarget && projectType === 'application' ? 'components' : 'src';
+
   createProjectStorybookDir(
     tree,
     projectName,
@@ -193,6 +196,7 @@ function migrateProjectLevelStorybookInstance(
     root,
     projectType,
     false,
+    mainDir,
     !!nextBuildTarget,
     compiler === 'swc'
   );

--- a/packages/storybook/src/migrations/update-16-5-0/__snapshots__/move-storybook-tsconfig.spec.ts.snap
+++ b/packages/storybook/src/migrations/update-16-5-0/__snapshots__/move-storybook-tsconfig.spec.ts.snap
@@ -1,0 +1,210 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Ignore @nx/react/plugins/storybook in Storybook eslint plugin should update Storybook tsconfig.json 1`] = `
+"{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "emitDecoratorMetadata": true,
+    "outDir": ""
+  },
+  "files": [
+    "../../node_modules/@nx/react/typings/styled-jsx.d.ts",
+    "../../node_modules/@nx/react/typings/cssmodule.d.ts",
+    "../../node_modules/@nx/react/typings/image.d.ts"
+  ],
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/**/*.spec.js",
+    "src/**/*.spec.tsx",
+    "src/**/*.spec.jsx"
+  ],
+  "include": [
+    "src/**/*.stories.ts",
+    "src/**/*.stories.js",
+    "src/**/*.stories.jsx",
+    "src/**/*.stories.tsx",
+    "src/**/*.stories.mdx",
+    ".storybook/*.js"
+  ]
+}
+"
+`;
+
+exports[`Ignore @nx/react/plugins/storybook in Storybook eslint plugin should update Storybook tsconfig.json 2`] = `
+"{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "emitDecoratorMetadata": true,
+    "outDir": ""
+  },
+  "files": [
+    "../../node_modules/@nx/react/typings/styled-jsx.d.ts",
+    "../../node_modules/@nx/react/typings/cssmodule.d.ts",
+    "../../node_modules/@nx/react/typings/image.d.ts"
+  ],
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/**/*.spec.js",
+    "src/**/*.spec.tsx",
+    "src/**/*.spec.jsx"
+  ],
+  "include": [
+    "src/**/*.stories.ts",
+    "src/**/*.stories.js",
+    "src/**/*.stories.jsx",
+    "src/**/*.stories.tsx",
+    "src/**/*.stories.mdx",
+    ".storybook/*.js"
+  ]
+}
+"
+`;
+
+exports[`Ignore @nx/react/plugins/storybook in Storybook eslint plugin should update Storybook tsconfig.json 3`] = `
+"{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "emitDecoratorMetadata": true,
+    "outDir": ""
+  },
+  "files": [
+    "../../../../../node_modules/@nx/react/typings/styled-jsx.d.ts",
+    "../../../../../node_modules/@nx/react/typings/cssmodule.d.ts",
+    "../../../../../node_modules/@nx/react/typings/image.d.ts"
+  ],
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/**/*.spec.js",
+    "src/**/*.spec.tsx",
+    "src/**/*.spec.jsx"
+  ],
+  "include": [
+    "src/**/*.stories.ts",
+    "src/**/*.stories.js",
+    "src/**/*.stories.jsx",
+    "src/**/*.stories.tsx",
+    "src/**/*.stories.mdx",
+    ".storybook/*.js"
+  ]
+}
+"
+`;
+
+exports[`Ignore @nx/react/plugins/storybook in Storybook eslint plugin should update nx.json inputs 1`] = `
+"{
+  "npmScope": "proj",
+  "affected": {
+    "defaultBase": "main"
+  },
+  "tasksRunnerOptions": {
+    "default": {
+      "runner": "nx/tasks-runners/default",
+      "options": {
+        "cacheableOperations": ["build", "lint", "test", "e2e"]
+      }
+    }
+  },
+  "namedInputs": {
+    "production": [
+      "default",
+      "!{projectRoot}/**/*.stories.@(js|jsx|ts|tsx|mdx)",
+      "!{projectRoot}/.storybook/**/*",
+      "!{projectRoot}/tsconfig.storybook.json"
+    ]
+  },
+  "targetDefaults": {
+    "build-storybook": {
+      "inputs": [
+        "default",
+        "^production",
+        "{projectRoot}/.storybook/**/*",
+        "{projectRoot}/tsconfig.storybook.json"
+      ]
+    }
+  }
+}
+"
+`;
+
+exports[`Ignore @nx/react/plugins/storybook in Storybook eslint plugin should update projects tsconfig.json 1`] = `
+"{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "allowJs": false,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.storybook.json"
+    }
+  ],
+  "extends": "../../tsconfig.base.json"
+}
+"
+`;
+
+exports[`Ignore @nx/react/plugins/storybook in Storybook eslint plugin should update projects tsconfig.json 2`] = `
+"{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "allowJs": false,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "types": ["vite/client", "vitest"]
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.storybook.json"
+    }
+  ],
+  "extends": "../../tsconfig.base.json"
+}
+"
+`;
+
+exports[`Ignore @nx/react/plugins/storybook in Storybook eslint plugin should update projects tsconfig.json 3`] = `
+"{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "allowJs": false,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "types": ["vite/client", "vitest"]
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.storybook.json"
+    }
+  ],
+  "extends": "../../../../../tsconfig.base.json"
+}
+"
+`;

--- a/packages/storybook/src/migrations/update-16-5-0/move-storybook-tsconfig.spec.ts
+++ b/packages/storybook/src/migrations/update-16-5-0/move-storybook-tsconfig.spec.ts
@@ -1,0 +1,242 @@
+import {
+  NxJsonConfiguration,
+  ProjectConfiguration,
+  Tree,
+  addProjectConfiguration,
+  updateJson,
+} from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import * as variousProjects from './test-configs/storybook-projects.json';
+import moveStorybookTsconfig from './move-storybook-tsconfig';
+
+describe('Ignore @nx/react/plugins/storybook in Storybook eslint plugin', () => {
+  let tree: Tree;
+
+  beforeEach(async () => {
+    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+      json.namedInputs = {
+        production: ['default'],
+      };
+      return json;
+    });
+    setupProjects(tree);
+    await moveStorybookTsconfig(tree);
+  });
+
+  it('should update projects tsconfig.json', async () => {
+    expect(
+      tree.read(`apps/webpack-app/tsconfig.json`).toString()
+    ).toMatchSnapshot();
+    expect(
+      tree.read(`apps/vite-app/tsconfig.json`).toString()
+    ).toMatchSnapshot();
+    expect(
+      tree.read(`apps/my/custom/place/nested-app/tsconfig.json`).toString()
+    ).toMatchSnapshot();
+  });
+
+  it('should update Storybook tsconfig.json', async () => {
+    expect(
+      tree.read(`apps/webpack-app/tsconfig.storybook.json`).toString()
+    ).toMatchSnapshot();
+    expect(
+      tree.read(`apps/vite-app/tsconfig.storybook.json`).toString()
+    ).toMatchSnapshot();
+    expect(
+      tree
+        .read(`apps/my/custom/place/nested-app/tsconfig.storybook.json`)
+        .toString()
+    ).toMatchSnapshot();
+  });
+
+  it('should delete old Storybook tsconfig.json', async () => {
+    expect(tree.exists(`apps/vite-app/.storybook/tsconfig.json`)).toBeFalsy();
+    expect(
+      tree.exists(`apps/webpack-app/.storybook/tsconfig.json`)
+    ).toBeFalsy();
+    expect(
+      tree.exists(`apps/my/custom/place/nested-app/.storybook/tsconfig.json`)
+    ).toBeFalsy();
+  });
+
+  it('should update nx.json inputs', () => {
+    expect(tree.read(`nx.json`).toString()).toMatchSnapshot();
+  });
+});
+
+function setupProjects(tree: Tree) {
+  for (const [name, project] of Object.entries(variousProjects)) {
+    addProjectConfiguration(tree, name, project as ProjectConfiguration);
+  }
+  tree.write(
+    `apps/my/custom/place/nested-app/tsconfig.json`,
+    JSON.stringify({
+      compilerOptions: {
+        jsx: 'react-jsx',
+        allowJs: false,
+        esModuleInterop: false,
+        allowSyntheticDefaultImports: true,
+        strict: true,
+        types: ['vite/client', 'vitest'],
+      },
+      files: [],
+      include: [],
+      references: [
+        {
+          path: './tsconfig.app.json',
+        },
+        {
+          path: './tsconfig.spec.json',
+        },
+        {
+          path: './.storybook/tsconfig.json',
+        },
+      ],
+      extends: '../../../../../tsconfig.base.json',
+    })
+  );
+  tree.write(
+    `apps/webpack-app/tsconfig.json`,
+    JSON.stringify({
+      compilerOptions: {
+        jsx: 'react-jsx',
+        allowJs: false,
+        esModuleInterop: false,
+        allowSyntheticDefaultImports: true,
+        strict: true,
+      },
+      files: [],
+      include: [],
+      references: [
+        {
+          path: './tsconfig.app.json',
+        },
+        {
+          path: './tsconfig.spec.json',
+        },
+        {
+          path: './.storybook/tsconfig.json',
+        },
+      ],
+      extends: '../../tsconfig.base.json',
+    })
+  );
+  tree.write(
+    'apps/vite-app/tsconfig.json',
+    JSON.stringify({
+      compilerOptions: {
+        jsx: 'react-jsx',
+        allowJs: false,
+        esModuleInterop: false,
+        allowSyntheticDefaultImports: true,
+        strict: true,
+        types: ['vite/client', 'vitest'],
+      },
+      files: [],
+      include: [],
+      references: [
+        {
+          path: './tsconfig.app.json',
+        },
+        {
+          path: './tsconfig.spec.json',
+        },
+        {
+          path: './.storybook/tsconfig.json',
+        },
+      ],
+      extends: '../../tsconfig.base.json',
+    })
+  );
+
+  tree.write(
+    'apps/my/custom/place/nested-app/.storybook/tsconfig.json',
+    JSON.stringify({
+      extends: '../tsconfig.json',
+      compilerOptions: {
+        emitDecoratorMetadata: true,
+        outDir: '',
+      },
+      files: [
+        '../../../../../../node_modules/@nx/react/typings/styled-jsx.d.ts',
+        '../../../../../../node_modules/@nx/react/typings/cssmodule.d.ts',
+        '../../../../../../node_modules/@nx/react/typings/image.d.ts',
+      ],
+      exclude: [
+        '../**/*.spec.ts',
+        '../**/*.spec.js',
+        '../**/*.spec.tsx',
+        '../**/*.spec.jsx',
+      ],
+      include: [
+        '../src/**/*.stories.ts',
+        '../src/**/*.stories.js',
+        '../src/**/*.stories.jsx',
+        '../src/**/*.stories.tsx',
+        '../src/**/*.stories.mdx',
+        '*.js',
+      ],
+    })
+  );
+
+  tree.write(
+    'apps/vite-app/.storybook/tsconfig.json',
+    JSON.stringify({
+      extends: '../tsconfig.json',
+      compilerOptions: {
+        emitDecoratorMetadata: true,
+        outDir: '',
+      },
+      files: [
+        '../../../node_modules/@nx/react/typings/styled-jsx.d.ts',
+        '../../../node_modules/@nx/react/typings/cssmodule.d.ts',
+        '../../../node_modules/@nx/react/typings/image.d.ts',
+      ],
+      exclude: [
+        '../**/*.spec.ts',
+        '../**/*.spec.js',
+        '../**/*.spec.tsx',
+        '../**/*.spec.jsx',
+      ],
+      include: [
+        '../src/**/*.stories.ts',
+        '../src/**/*.stories.js',
+        '../src/**/*.stories.jsx',
+        '../src/**/*.stories.tsx',
+        '../src/**/*.stories.mdx',
+        '*.js',
+      ],
+    })
+  );
+
+  tree.write(
+    'apps/webpack-app/.storybook/tsconfig.json',
+    JSON.stringify({
+      extends: '../tsconfig.json',
+      compilerOptions: {
+        emitDecoratorMetadata: true,
+        outDir: '',
+      },
+      files: [
+        '../../../node_modules/@nx/react/typings/styled-jsx.d.ts',
+        '../../../node_modules/@nx/react/typings/cssmodule.d.ts',
+        '../../../node_modules/@nx/react/typings/image.d.ts',
+      ],
+      exclude: [
+        '../**/*.spec.ts',
+        '../**/*.spec.js',
+        '../**/*.spec.tsx',
+        '../**/*.spec.jsx',
+      ],
+      include: [
+        '../src/**/*.stories.ts',
+        '../src/**/*.stories.js',
+        '../src/**/*.stories.jsx',
+        '../src/**/*.stories.tsx',
+        '../src/**/*.stories.mdx',
+        '*.js',
+      ],
+    })
+  );
+}

--- a/packages/storybook/src/migrations/update-16-5-0/move-storybook-tsconfig.ts
+++ b/packages/storybook/src/migrations/update-16-5-0/move-storybook-tsconfig.ts
@@ -1,0 +1,30 @@
+import { getProjects, joinPathFragments, Tree, formatFiles } from '@nx/devkit';
+import { forEachExecutorOptions } from '@nx/devkit/src/generators/executor-options-utils';
+import {
+  addStorybookToNamedInputs,
+  renameAndMoveOldTsConfig,
+} from '../../generators/configuration/lib/util-functions';
+
+export default async function (tree: Tree) {
+  forEachExecutorOptions(
+    tree,
+    '@nx/storybook:storybook',
+    (options, projectName) => {
+      const projectConfiguration = getProjects(tree).get(projectName);
+      const projectRoot = projectConfiguration.root;
+      if (options?.['configDir'] === undefined) {
+        return;
+      }
+
+      const pathToStorybookConfigFile = joinPathFragments(
+        options?.['configDir'],
+        'tsconfig.json'
+      );
+
+      renameAndMoveOldTsConfig(projectRoot, pathToStorybookConfigFile, tree);
+    }
+  );
+
+  addStorybookToNamedInputs(tree);
+  await formatFiles(tree);
+}

--- a/packages/storybook/src/migrations/update-16-5-0/test-configs/storybook-projects.json
+++ b/packages/storybook/src/migrations/update-16-5-0/test-configs/storybook-projects.json
@@ -1,0 +1,346 @@
+{
+  "my-custom-place-nested-app": {
+    "name": "my-custom-place-nested-app",
+    "$schema": "../../../../../node_modules/nx/schemas/project-schema.json",
+    "sourceRoot": "apps/my/custom/place/nested-app/src",
+    "projectType": "application",
+    "targets": {
+      "build": {
+        "dependsOn": ["^build"],
+        "inputs": ["production", "^production"],
+        "executor": "@nx/vite:build",
+        "outputs": ["{options.outputPath}"],
+        "defaultConfiguration": "production",
+        "options": {
+          "outputPath": "dist/apps/my/custom/place/nested-app",
+          "mode": "production"
+        },
+        "configurations": {
+          "development": { "mode": "development" },
+          "production": { "mode": "production" }
+        }
+      },
+      "serve": {
+        "executor": "@nx/vite:dev-server",
+        "defaultConfiguration": "development",
+        "options": { "buildTarget": "my-custom-place-nested-app:build" },
+        "configurations": {
+          "development": {
+            "buildTarget": "my-custom-place-nested-app:build:development",
+            "hmr": true
+          },
+          "production": {
+            "buildTarget": "my-custom-place-nested-app:build:production",
+            "hmr": false
+          }
+        }
+      },
+      "preview": {
+        "executor": "@nx/vite:preview-server",
+        "defaultConfiguration": "development",
+        "options": { "buildTarget": "my-custom-place-nested-app:build" },
+        "configurations": {
+          "development": {
+            "buildTarget": "my-custom-place-nested-app:build:development"
+          },
+          "production": {
+            "buildTarget": "my-custom-place-nested-app:build:production"
+          }
+        }
+      },
+      "test": {
+        "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"],
+        "executor": "@nx/vite:test",
+        "outputs": ["coverage/apps/my/custom/place/nested-app"],
+        "options": {
+          "passWithNoTests": true,
+          "reportsDirectory": "../../../../../coverage/apps/my/custom/place/nested-app"
+        },
+        "configurations": {}
+      },
+      "lint": {
+        "inputs": [
+          "default",
+          "{workspaceRoot}/.eslintrc.json",
+          "{workspaceRoot}/.eslintignore"
+        ],
+        "executor": "@nx/linter:eslint",
+        "outputs": ["{options.outputFile}"],
+        "options": {
+          "lintFilePatterns": [
+            "apps/my/custom/place/nested-app/**/*.{ts,tsx,js,jsx}"
+          ]
+        },
+        "configurations": {}
+      },
+      "serve-static": {
+        "executor": "@nx/web:file-server",
+        "options": { "buildTarget": "my-custom-place-nested-app:build" }
+      },
+      "storybook": {
+        "executor": "@nx/storybook:storybook",
+        "options": {
+          "port": 4400,
+          "configDir": "apps/my/custom/place/nested-app/.storybook"
+        },
+        "configurations": { "ci": { "quiet": true } }
+      },
+      "build-storybook": {
+        "inputs": ["default", "^production", "!{projectRoot}/.storybook/**/*"],
+        "executor": "@nx/storybook:build",
+        "outputs": ["{options.outputDir}"],
+        "options": {
+          "outputDir": "dist/storybook/my-custom-place-nested-app",
+          "configDir": "apps/my/custom/place/nested-app/.storybook"
+        },
+        "configurations": { "ci": { "quiet": true } }
+      },
+      "static-storybook": {
+        "executor": "@nx/web:file-server",
+        "options": {
+          "buildTarget": "my-custom-place-nested-app:build-storybook",
+          "staticFilePath": "dist/storybook/my-custom-place-nested-app"
+        },
+        "configurations": {
+          "ci": {
+            "buildTarget": "my-custom-place-nested-app:build-storybook:ci"
+          }
+        }
+      }
+    },
+    "tags": [],
+    "root": "apps/my/custom/place/nested-app",
+    "implicitDependencies": []
+  },
+  "webpack-app": {
+    "name": "webpack-app",
+    "$schema": "../../node_modules/nx/schemas/project-schema.json",
+    "sourceRoot": "apps/webpack-app/src",
+    "projectType": "application",
+    "targets": {
+      "build": {
+        "dependsOn": ["^build"],
+        "inputs": ["production", "^production"],
+        "executor": "@nx/webpack:webpack",
+        "outputs": ["{options.outputPath}"],
+        "defaultConfiguration": "production",
+        "options": {
+          "compiler": "babel",
+          "outputPath": "dist/apps/webpack-app",
+          "index": "apps/webpack-app/src/index.html",
+          "baseHref": "/",
+          "main": "apps/webpack-app/src/main.tsx",
+          "tsConfig": "apps/webpack-app/tsconfig.app.json",
+          "assets": [
+            "apps/webpack-app/src/favicon.ico",
+            "apps/webpack-app/src/assets"
+          ],
+          "styles": ["apps/webpack-app/src/styles.css"],
+          "scripts": [],
+          "isolatedConfig": true,
+          "webpackConfig": "apps/webpack-app/webpack.config.js",
+          "fileReplacements": [
+            {
+              "replace": "apps/webpack-app/src/environments/environment.ts",
+              "with": "apps/webpack-app/src/environments/environment.prod.ts"
+            }
+          ],
+          "optimization": true,
+          "outputHashing": "all",
+          "sourceMap": false,
+          "namedChunks": false,
+          "extractLicenses": true,
+          "vendorChunk": false
+        },
+        "configurations": {
+          "development": {
+            "extractLicenses": false,
+            "optimization": false,
+            "sourceMap": true,
+            "vendorChunk": true
+          },
+          "production": {
+            "fileReplacements": [
+              {
+                "replace": "apps/webpack-app/src/environments/environment.ts",
+                "with": "apps/webpack-app/src/environments/environment.prod.ts"
+              }
+            ],
+            "optimization": true,
+            "outputHashing": "all",
+            "sourceMap": false,
+            "namedChunks": false,
+            "extractLicenses": true,
+            "vendorChunk": false
+          }
+        }
+      },
+      "serve": {
+        "executor": "@nx/webpack:dev-server",
+        "defaultConfiguration": "development",
+        "options": { "buildTarget": "webpack-app:build", "hmr": true },
+        "configurations": {
+          "development": { "buildTarget": "webpack-app:build:development" },
+          "production": {
+            "buildTarget": "webpack-app:build:production",
+            "hmr": false
+          }
+        }
+      },
+      "lint": {
+        "inputs": [
+          "default",
+          "{workspaceRoot}/.eslintrc.json",
+          "{workspaceRoot}/.eslintignore"
+        ],
+        "executor": "@nx/linter:eslint",
+        "outputs": ["{options.outputFile}"],
+        "options": {
+          "lintFilePatterns": ["apps/webpack-app/**/*.{ts,tsx,js,jsx}"]
+        },
+        "configurations": {}
+      },
+      "serve-static": {
+        "executor": "@nx/web:file-server",
+        "options": { "buildTarget": "webpack-app:build" }
+      },
+      "test": {
+        "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"],
+        "executor": "@nx/jest:jest",
+        "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+        "options": {
+          "jestConfig": "apps/webpack-app/jest.config.ts",
+          "passWithNoTests": true
+        },
+        "configurations": { "ci": { "ci": true, "codeCoverage": true } }
+      },
+      "storybook": {
+        "executor": "@nx/storybook:storybook",
+        "options": { "port": 4400, "configDir": "apps/webpack-app/.storybook" },
+        "configurations": { "ci": { "quiet": true } }
+      },
+      "build-storybook": {
+        "inputs": ["default", "^production", "!{projectRoot}/.storybook/**/*"],
+        "executor": "@nx/storybook:build",
+        "outputs": ["{options.outputDir}"],
+        "options": {
+          "outputDir": "dist/storybook/webpack-app",
+          "configDir": "apps/webpack-app/.storybook"
+        },
+        "configurations": { "ci": { "quiet": true } }
+      },
+      "static-storybook": {
+        "executor": "@nx/web:file-server",
+        "options": {
+          "buildTarget": "webpack-app:build-storybook",
+          "staticFilePath": "dist/storybook/webpack-app"
+        },
+        "configurations": {
+          "ci": { "buildTarget": "webpack-app:build-storybook:ci" }
+        }
+      }
+    },
+    "tags": [],
+    "root": "apps/webpack-app",
+    "implicitDependencies": []
+  },
+  "vite-app": {
+    "name": "vite-app",
+    "$schema": "../../node_modules/nx/schemas/project-schema.json",
+    "sourceRoot": "apps/vite-app/src",
+    "projectType": "application",
+    "targets": {
+      "build": {
+        "dependsOn": ["^build"],
+        "inputs": ["production", "^production"],
+        "executor": "@nx/vite:build",
+        "outputs": ["{options.outputPath}"],
+        "defaultConfiguration": "production",
+        "options": { "outputPath": "dist/apps/vite-app", "mode": "production" },
+        "configurations": {
+          "development": { "mode": "development" },
+          "production": { "mode": "production" }
+        }
+      },
+      "serve": {
+        "executor": "@nx/vite:dev-server",
+        "defaultConfiguration": "development",
+        "options": { "buildTarget": "vite-app:build" },
+        "configurations": {
+          "development": {
+            "buildTarget": "vite-app:build:development",
+            "hmr": true
+          },
+          "production": {
+            "buildTarget": "vite-app:build:production",
+            "hmr": false
+          }
+        }
+      },
+      "preview": {
+        "executor": "@nx/vite:preview-server",
+        "defaultConfiguration": "development",
+        "options": { "buildTarget": "vite-app:build" },
+        "configurations": {
+          "development": { "buildTarget": "vite-app:build:development" },
+          "production": { "buildTarget": "vite-app:build:production" }
+        }
+      },
+      "test": {
+        "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"],
+        "executor": "@nx/vite:test",
+        "outputs": ["coverage/apps/vite-app"],
+        "options": {
+          "passWithNoTests": true,
+          "reportsDirectory": "../../coverage/apps/vite-app"
+        },
+        "configurations": {}
+      },
+      "lint": {
+        "inputs": [
+          "default",
+          "{workspaceRoot}/.eslintrc.json",
+          "{workspaceRoot}/.eslintignore"
+        ],
+        "executor": "@nx/linter:eslint",
+        "outputs": ["{options.outputFile}"],
+        "options": {
+          "lintFilePatterns": ["apps/vite-app/**/*.{ts,tsx,js,jsx}"]
+        },
+        "configurations": {}
+      },
+      "serve-static": {
+        "executor": "@nx/web:file-server",
+        "options": { "buildTarget": "vite-app:build" }
+      },
+      "storybook": {
+        "executor": "@nx/storybook:storybook",
+        "options": { "port": 4400, "configDir": "apps/vite-app/.storybook" },
+        "configurations": { "ci": { "quiet": true } }
+      },
+      "build-storybook": {
+        "inputs": ["default", "^production", "!{projectRoot}/.storybook/**/*"],
+        "executor": "@nx/storybook:build",
+        "outputs": ["{options.outputDir}"],
+        "options": {
+          "outputDir": "dist/storybook/vite-app",
+          "configDir": "apps/vite-app/.storybook"
+        },
+        "configurations": { "ci": { "quiet": true } }
+      },
+      "static-storybook": {
+        "executor": "@nx/web:file-server",
+        "options": {
+          "buildTarget": "vite-app:build-storybook",
+          "staticFilePath": "dist/storybook/vite-app"
+        },
+        "configurations": {
+          "ci": { "buildTarget": "vite-app:build-storybook:ci" }
+        }
+      }
+    },
+    "tags": [],
+    "root": "apps/vite-app",
+    "implicitDependencies": []
+  }
+}


### PR DESCRIPTION
See this PR for context: https://github.com/nrwl/nx/pull/17745

This solves the vite paths issue.

`vite-tsconfig-paths` plugin will not run `resolversByDir` for the `.storybook` dir, but rather for the project's root. So it does not take into account the paths included in the `.storybook/tsconfig.file`. Then, it looks one level up to find resolvers. 
The `vite-tsconfig-paths` is setting up the resolvers to match the `tsconfig.json` settings under the `.storybook` directory, and different ones for the `tsconfig.*.json` files it’s finding in the project root. Since we're excluding `.stories.*` files in the project's root tsconfig, then it's failing.

Now, if we move the `.storybook/tsconfig.json` file to be `tsconfig.storybook.json` file in the project's root, then the `vite-tsconfig-paths` plugin will be able to resolve the paths, then, since it will be at the root of the project.

### Is it ok to remove `tsconfig.json` from the `.storybook` dir?

Yes, since only `@storybook/angular` is using `.storybook/tsconfig.json`, the other frameworks ignore it. And `@storybook/angular` resolves the paths correctly, so we'll keep it as is for Angular projects

### Why do we need a `tsconfig` file for Storybook anyway?

Because we want to exclude `.stories.*` files from the ts compilation if we're building the actual project. And our builders import specifically the `tsconfig.app|lib.json` file. But of course, we want to include the `.stories.*` files for Storybook builder and server. So, we need this extra file to `include` the stories that the `tsconfig.app|lib.json` file `exludes`.

## TODO (done ✅ ):

- [x] Write migrations
- [x] Test it locally

### Tested the following:
1. React + Vite: app, lib, app that imports lib which imports lib, which imports lib. Story which imports lib which imports lib. Build + Build-Storybook
2. React + Webpack: app, lib, app that imports lib which imports lib, which imports lib. Story which imports lib which imports lib. Build + Build-Storybook
3. Angular: app, lib, all's unchanged
4. Tested migration

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/17257 https://github.com/nrwl/nx/issues/17156
