### PR TITLE
fix(storybook): fix 6.1.0 migration to prevent wiping out eslintrc

### DIFF
--- a/packages/storybook/src/migrations/update-16-1-0/eslint-ignore-react-plugin.spec.ts
+++ b/packages/storybook/src/migrations/update-16-1-0/eslint-ignore-react-plugin.spec.ts
@@ -40,18 +40,37 @@ describe('Ignore @nx/react/plugins/storybook in Storybook eslint plugin', () => 
     );
 
     if (!tree.exists('.eslintrc.json')) {
-      tree.write('.eslintrc.json', '{}');
+      tree.write('.eslintrc.json', `{}`);
     }
-    updateJson(tree, '.eslintrc.json', (json) => {
-      json.extends ??= [];
-      json.extends.push('plugin:storybook/recommended');
-      return json;
-    });
   });
 
   it('should not ignore the plugin if it is not used', async () => {
     await eslintIgnoreReactPlugin(tree);
     const eslintConfig = readJson(tree, '.eslintrc.json');
+    expect(eslintConfig).toEqual({});
+    expect(eslintConfig.rules).toBeUndefined();
+  });
+
+  it('should not ignore the plugin if "plugin:storybook/recommended" is not included', async () => {
+    tree.write('apps/main-webpack/tsconfig.json', `{}`);
+    tree.write(
+      `apps/main-webpack/.storybook/main.js`,
+      `
+      module.exports = {
+        stories: ['../src/lib/**/*.stories.@(mdx|js|jsx|ts|tsx)'],
+        addons: ['@storybook/addon-essentials', '@nx/react/plugins/storybook'],
+        framework: {
+          name: '@storybook/react-webpack5',
+          options: {},
+        },
+      };
+      `
+    );
+
+    await eslintIgnoreReactPlugin(tree);
+
+    const eslintConfig = readJson(tree, '.eslintrc.json');
+    expect(eslintConfig).toEqual({});
     expect(eslintConfig.rules).toBeUndefined();
   });
 
@@ -70,6 +89,12 @@ describe('Ignore @nx/react/plugins/storybook in Storybook eslint plugin', () => 
       };
       `
     );
+
+    updateJson(tree, '.eslintrc.json', (json) => {
+      json.extends ??= [];
+      json.extends.push('plugin:storybook/recommended');
+      return json;
+    });
 
     await eslintIgnoreReactPlugin(tree);
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
6.1.0 storybook migration wipes out `.eslintrc.json` root file if certain condition isn't met within the scope of the updateJson function.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
6.1.0 storybook migration works for all conditions

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17748
