### PR TITLE
feat(repo): allow testing publish workflow manually without real publ…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ env:
   NX_RUN_GROUP: ${{ github.run_id }}-${{ github.run_attempt }}
   NPM_CONFIG_PROVENANCE: true
 on:
+  workflow_dispatch:
   release:
     types: [published]
 jobs:
@@ -200,7 +201,7 @@ jobs:
            path: packages/**/*.node
            if-no-files-found: error
   publish:
-    if: ${{ github.repository_owner == 'nrwl' }}
+    if: ${{ github.event_name == 'release' && github.repository_owner == 'nrwl' }}
     name: Publish
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
…ishing

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

We cannot test the publish pipeline unless we use a fork.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

We can test the publish pipeline without really publishing by triggering it manually via github

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
