### PR TITLE
fix(nextjs): do not kebab-case next.js server cli args #17765

### DIFF
--- a/packages/next/src/executors/server/server.impl.ts
+++ b/packages/next/src/executors/server/server.impl.ts
@@ -4,7 +4,7 @@ import {
   parseTargetString,
   readTargetOptions,
 } from '@nx/devkit';
-import { join, resolve } from 'path';
+import { resolve } from 'path';
 
 import {
   NextBuildBuilderOptions,

--- a/packages/next/src/utils/create-cli-options.ts
+++ b/packages/next/src/utils/create-cli-options.ts
@@ -3,8 +3,7 @@ export function createCliOptions(
 ): string[] {
   return Object.entries(obj).reduce((arr, [key, value]) => {
     if (value !== undefined) {
-      const kebabCase = key.replace(/[A-Z]/g, (m) => '-' + m.toLowerCase());
-      arr.push(`--${kebabCase}=${value}`);
+      arr.push(`--${key}=${value}`);
     }
     return arr;
   }, []);


### PR DESCRIPTION
The args passed to the `next` bin should be camelCase, i.e. left alone. The nx docs and next.js docs already reflect this.

Closes #17765

## Current Behavior

kebab cased args passed to next bin

## Expected Behavior

camel cased passed

## Related Issue(s)

Fixes #17765 
