### PR TITLE
feat(nextjs): allows inferrable build target

### DIFF
--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -106,9 +106,17 @@ function getNxContext(
     const buildTarget = parseTargetString(targetOptions.buildTarget, graph);
     return getNxContext(graph, buildTarget);
   } else {
-    throw new Error(
-      'Could not determine the config for this Next application.'
+    const inferredBuildTargetName = `${target.project}:build`;
+    const inferredBuildTarget = parseTargetString(
+      inferredBuildTargetName,
+      graph
     );
+    if (!inferredBuildTarget) {
+      throw new Error(
+        'Could not determine the config for this Next application.'
+      );
+    }
+    return getNxContext(graph, inferredBuildTarget);
   }
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
See: https://github.com/nrwl/nx/issues/16064 - we currently cannot take advantage of the `withNx` utility unless we're using an Nx executor.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Should be able to infer the current build target if a target named "build" exists in the project being run.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16064

## Notes

@jaysoo I'll reach out when I'm back in the office to see if this fix if this is the right way to go. I think an alternative (or supplemental?) approach might be to support a `buildTarget` option for the `withNx` utility (e.g. in next.config.js: `module.exports = withNx(nextConfig, { buildTarget: 'my-app:build' });`)
