### PR TITLE
fix(nest): do not overwrite tsconfig files with undefined in migration

### DIFF
--- a/packages/nest/src/migrations/update-16-4-0-cache-manager/nestjs-10-updates.ts
+++ b/packages/nest/src/migrations/update-16-4-0-cache-manager/nestjs-10-updates.ts
@@ -113,7 +113,7 @@ export function updateCacheManagerImport(
 export function updateTsConfigTarget(tree: Tree, tsConfigPath: string) {
   updateJson(tree, tsConfigPath, (json) => {
     if (!json.compilerOptions.target) {
-      return;
+      return json;
     }
 
     const normalizedTargetName = json.compilerOptions.target.toUpperCase();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `update-16-4-0-support-nestjs-10` migration wipes out tsconfig files content when there's no `compilerOptions.target` defined.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `update-16-4-0-support-nestjs-10` migration should not modify the tsconfig files content when there's no `compilerOptions.target` defined.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17782 
