### PR TITLE
fix(bundling): update the browsers for es5 terser check

### DIFF
--- a/packages/webpack/src/utils/with-nx.ts
+++ b/packages/webpack/src/utils/with-nx.ts
@@ -20,6 +20,18 @@ import browserslist = require('browserslist');
 
 const VALID_BROWSERSLIST_FILES = ['.browserslistrc', 'browserslist'];
 
+const ES5_BROWSERS = [
+  'ie 10',
+  'ie 11',
+  'safari 11',
+  'safari 11.1',
+  'safari 12',
+  'safari 12.1',
+  'safari 13',
+  'ios_saf 13.0',
+  'ios_saf 13.3',
+];
+
 function getTerserEcmaVersion(projectRoot: string) {
   let pathToBrowserslistFile = '';
   for (const browserslistFile of VALID_BROWSERSLIST_FILES) {
@@ -36,7 +48,7 @@ function getTerserEcmaVersion(projectRoot: string) {
 
   const env = browserslist.loadConfig({ path: pathToBrowserslistFile });
   const browsers = browserslist(env);
-  return browsers.includes('ie 11') ? 5 : 2020;
+  return browsers.some((b) => ES5_BROWSERS.includes(b)) ? 5 : 2020;
 }
 
 const IGNORED_WEBPACK_WARNINGS = [


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We currently set es5 for terser when we detect ie 11 in browserslist

Other browsers also do not support certain features like `??`. Add them to the list of browsers

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Add the other browsers that have versions that may be targetted by developers that only support es5 to the list that should set terser to es5

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17620

Pointed out in #17708
