### PR TITLE
feat(testing): add --force-exit to jest executor

### DIFF
--- a/docs/generated/packages/jest/executors/jest.json
+++ b/docs/generated/packages/jest/executors/jest.json
@@ -81,6 +81,10 @@
         "description": "Find and run the tests that cover a comma separated list of source files that were passed in as arguments. (https://jestjs.io/docs/cli#--findrelatedtests-spaceseparatedlistofsourcefiles)",
         "type": "string"
       },
+      "forceExit": {
+        "description": "Force Jest to exit after all tests have completed running. This is useful when resources set up by test code cannot be adequately cleaned up.This feature is an escape-hatch. If Jest doesn't exit at the end of a test run, it means external resources are still being held on to or timers are still pending in your code. It is advised to tear down external resources after each test to make sure Jest can shut down cleanly. You can use --detectOpenHandles to help track it down.",
+        "type": "boolean"
+      },
       "json": {
         "description": "Prints the test results in `JSON`. This mode will send all other test output and user messages to `stderr`. (https://jestjs.io/docs/cli#--json)",
         "type": "boolean"

--- a/packages/jest/src/executors/jest/jest.impl.ts
+++ b/packages/jest/src/executors/jest/jest.impl.ts
@@ -71,6 +71,7 @@ export async function jestConfigParser(
     ci: options.ci,
     color: options.color,
     detectOpenHandles: options.detectOpenHandles,
+    forceExit: options.forceExit,
     logHeapUsage: options.logHeapUsage,
     detectLeaks: options.detectLeaks,
     json: options.json,

--- a/packages/jest/src/executors/jest/schema.d.ts
+++ b/packages/jest/src/executors/jest/schema.d.ts
@@ -15,6 +15,7 @@ export interface JestExecutorOptions {
   color?: boolean;
   clearCache?: boolean;
   findRelatedTests?: string;
+  forceExit?: boolean;
   json?: boolean;
   maxWorkers?: number | string;
   onlyChanged?: boolean;

--- a/packages/jest/src/executors/jest/schema.json
+++ b/packages/jest/src/executors/jest/schema.json
@@ -90,6 +90,10 @@
       "description": "Find and run the tests that cover a comma separated list of source files that were passed in as arguments. (https://jestjs.io/docs/cli#--findrelatedtests-spaceseparatedlistofsourcefiles)",
       "type": "string"
     },
+    "forceExit": {
+      "description": "Force Jest to exit after all tests have completed running. This is useful when resources set up by test code cannot be adequately cleaned up.This feature is an escape-hatch. If Jest doesn't exit at the end of a test run, it means external resources are still being held on to or timers are still pending in your code. It is advised to tear down external resources after each test to make sure Jest can shut down cleanly. You can use --detectOpenHandles to help track it down.",
+      "type": "boolean"
+    },
     "json": {
       "description": "Prints the test results in `JSON`. This mode will send all other test output and user messages to `stderr`. (https://jestjs.io/docs/cli#--json)",
       "type": "boolean"

--- a/packages/webpack/migrations.json
+++ b/packages/webpack/migrations.json
@@ -41,8 +41,8 @@
         }
       }
     },
-    "16.4.0": {
-      "version": "16.4.0-beta.11",
+    "16.4.1": {
+      "version": "16.4.1-beta.0",
       "packages": {
         "webpack": {
           "version": "^5.80.0",

--- a/packages/webpack/migrations.json
+++ b/packages/webpack/migrations.json
@@ -41,8 +41,8 @@
         }
       }
     },
-    "16.4.1": {
-      "version": "16.4.1-beta.0",
+    "16.4.0": {
+      "version": "16.4.0-beta.11",
       "packages": {
         "webpack": {
           "version": "^5.80.0",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
--force-exit isn't an executor option for jest, but is an arg for the jest cli

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
--force-exit is an option for jest executor

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17574
