### PR TITLE
fix(js): properly identify buildable project

### DIFF
--- a/packages/js/src/utils/buildable-libs-utils.spec.ts
+++ b/packages/js/src/utils/buildable-libs-utils.spec.ts
@@ -160,6 +160,222 @@ describe('calculateProjectDependencies', () => {
       ],
     });
   });
+
+  it('should identify buildable libraries correctly', () => {
+    const graph: ProjectGraph = {
+      nodes: {
+        somejslib1: {
+          name: 'somejslib1',
+          type: 'lib',
+          data: {
+            name: 'somejslib1',
+            sourceRoot: 'libs/somejslib1/src',
+            projectType: 'library',
+            targets: {
+              'my-custom-build-target': {
+                executor: '@nx/js:tsc',
+                outputs: ['{options.outputPath}'],
+                options: {
+                  outputPath: 'dist/libs/somejslib1',
+                  main: 'libs/somejslib1/src/index.ts',
+                },
+              },
+            },
+            tags: [],
+            root: 'libs/somejslib1',
+            implicitDependencies: [],
+          },
+        },
+        somejslib2: {
+          name: 'somejslib2',
+          type: 'lib',
+          data: {
+            name: 'somejslib2',
+            sourceRoot: 'libs/somejslib2/src',
+            projectType: 'library',
+            targets: {
+              'my-other-build-target': {
+                executor: '@nx/js:swc',
+                outputs: ['{options.outputPath}'],
+                options: {
+                  outputPath: 'dist/libs/somejslib2',
+                  main: 'libs/somejslib2/src/index.ts',
+                },
+              },
+            },
+            tags: [],
+            root: 'libs/somejslib2',
+            implicitDependencies: [],
+          },
+        },
+      },
+      externalNodes: {},
+      dependencies: {
+        example: [
+          {
+            source: 'example',
+            target: 'npm:some-lib',
+            type: DependencyType.static,
+          },
+        ],
+        somejslib1: [
+          {
+            source: 'somejslib2',
+            target: 'somejslib2',
+            type: DependencyType.static,
+          },
+        ],
+      },
+    };
+
+    const results = calculateProjectDependencies(
+      graph,
+      'root',
+      'somejslib1',
+      'build',
+      undefined
+    );
+    expect(results).toMatchObject({
+      target: {
+        name: 'somejslib1',
+        type: 'lib',
+        data: {
+          name: 'somejslib1',
+          sourceRoot: 'libs/somejslib1/src',
+          projectType: 'library',
+          targets: {
+            'my-custom-build-target': {
+              executor: '@nx/js:tsc',
+              outputs: ['{options.outputPath}'],
+              options: {
+                outputPath: 'dist/libs/somejslib1',
+                main: 'libs/somejslib1/src/index.ts',
+              },
+            },
+          },
+          tags: [],
+          root: 'libs/somejslib1',
+          implicitDependencies: [],
+        },
+      },
+      dependencies: [
+        {
+          name: 'somejslib2',
+          outputs: ['dist/libs/somejslib2'],
+          node: {
+            name: 'somejslib2',
+            type: 'lib',
+            data: {
+              name: 'somejslib2',
+              sourceRoot: 'libs/somejslib2/src',
+              projectType: 'library',
+              targets: {
+                'my-other-build-target': {
+                  executor: '@nx/js:swc',
+                  outputs: ['{options.outputPath}'],
+                  options: {
+                    outputPath: 'dist/libs/somejslib2',
+                    main: 'libs/somejslib2/src/index.ts',
+                  },
+                },
+              },
+              tags: [],
+              root: 'libs/somejslib2',
+              implicitDependencies: [],
+            },
+          },
+        },
+      ],
+      nonBuildableDependencies: [],
+      topLevelDependencies: [
+        {
+          name: 'somejslib2',
+          outputs: ['dist/libs/somejslib2'],
+          node: {
+            name: 'somejslib2',
+            type: 'lib',
+            data: {
+              name: 'somejslib2',
+              sourceRoot: 'libs/somejslib2/src',
+              projectType: 'library',
+              targets: {
+                'my-other-build-target': {
+                  executor: '@nx/js:swc',
+                  outputs: ['{options.outputPath}'],
+                  options: {
+                    outputPath: 'dist/libs/somejslib2',
+                    main: 'libs/somejslib2/src/index.ts',
+                  },
+                },
+              },
+              tags: [],
+              root: 'libs/somejslib2',
+              implicitDependencies: [],
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  it('should make sure fallback buildable identification based on target name works', async () => {
+    const graph: ProjectGraph = {
+      nodes: {
+        example: {
+          type: 'lib',
+          name: 'example',
+          data: {
+            root: '/root/example',
+            targets: {
+              'my-build-target': {
+                executor: 'x',
+              },
+            },
+          },
+        },
+        example2: {
+          type: 'lib',
+          name: 'example2',
+          data: {
+            root: '/root/example2',
+            targets: {
+              'my-build-target': {
+                executor: 'x',
+              },
+            },
+          },
+        },
+      },
+      externalNodes: {},
+      dependencies: {
+        example: [
+          // when example2 dependency is listed first
+          {
+            source: 'example',
+            target: 'example2',
+            type: DependencyType.static,
+          },
+        ],
+      },
+    };
+
+    const results = calculateProjectDependencies(
+      graph,
+      'root',
+      'example',
+      'my-build-target',
+      undefined
+    );
+    expect(results).toMatchObject({
+      target: {
+        name: 'example',
+      },
+      topLevelDependencies: [
+        // expect example2
+        expect.objectContaining({ name: 'example2' }),
+      ],
+    });
+  });
 });
 
 describe('missingDependencies', () => {

--- a/packages/workspace/src/utilities/buildable-libs-utils.ts
+++ b/packages/workspace/src/utilities/buildable-libs-utils.ts
@@ -16,12 +16,46 @@ import { ensureTypescript } from './typescript';
 
 let tsModule: typeof import('typescript');
 
-function isBuildable(target: string, node: ProjectGraphProjectNode): boolean {
-  return (
-    node.data.targets &&
-    node.data.targets[target] &&
-    node.data.targets[target].executor !== ''
-  );
+function isBuildable(node: ProjectGraphProjectNode, target: string): string {
+  let buildTargetName: string | undefined = undefined;
+  // TODO(katerina): Remove @nrwl/* for Nx 17
+  const listOfBuildExecutors = [
+    '@nx/js:swc',
+    '@nx/js:tsc',
+    '@nx/rollup:rollup',
+    '@nx/rspack:rspack',
+    '@nx/vite:build',
+    '@nx/esbuild:esbuild',
+    '@nx/webpack:webpack',
+    '@nx/angular:ng-packagr-lite',
+    '@nx/angular:package',
+    '@nx/next:build',
+    '@nrwl/js:swc',
+    '@nrwl/js:tsc',
+    '@nrwl/rollup:rollup',
+    '@nrwl/rspack:rspack',
+    '@nrwl/vite:build',
+    '@nrwl/esbuild:esbuild',
+    '@nrwl/webpack:webpack',
+    '@nrwl/angular:ng-packagr-lite',
+    '@nrwl/angular:package',
+    '@nrwl/next:build',
+  ];
+  for (const targetName of Object.keys(node.data.targets ?? {})) {
+    const target = node.data.targets[targetName];
+    if (listOfBuildExecutors.includes(target.executor)) {
+      buildTargetName = targetName;
+      break;
+    }
+  }
+  if (!buildTargetName) {
+    return node.data.targets &&
+      node.data.targets[target] &&
+      node.data.targets[target].executor !== ''
+      ? target
+      : undefined;
+  }
+  return buildTargetName;
 }
 
 /**
@@ -78,7 +112,8 @@ export function calculateProjectDependencies(
       let project: DependentBuildableProjectNode = null;
       const depNode = projGraph.nodes[dep] || projGraph.externalNodes[dep];
       if (depNode.type === 'lib') {
-        if (isBuildable(targetName, depNode)) {
+        const dependencyTargetName = isBuildable(depNode, targetName);
+        if (dependencyTargetName) {
           const libPackageJsonPath = join(
             root,
             depNode.data.root,
@@ -94,7 +129,7 @@ export function calculateProjectDependencies(
                 overrides: {},
                 target: {
                   project: projectName,
-                  target: targetName,
+                  target: dependencyTargetName,
                   configuration: configurationName,
                 },
               },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

Right now, we identify if a project is buildable like this:
```
function isBuildable(target: string, node: ProjectGraphProjectNode): boolean {
  return (
    node.data.targets &&
    node.data.targets[target] &&
    node.data.targets[target].executor !== ''
  );
```

The `target` there is the name of the build target of a parent project. In that function, we try to understand if a project's dependency is buildable. This technique is flawed, since we cannot know for sure the name of the `build` target, and we cannot assume it's the same as the parent project's build target name.

This results in this:  If one project imports another project, both projects' build targets need to have the same name. If projects have different names for the build target, then you get an irrelevant error.

## Expected Behavior

`isBuildable` should not rely on a parent project's build target name, but rather look through the child project's executors, and find if it has an executor which is a build executor.

Retain existing behaviour to avoid breaking changes, and also allow it to work for build executors of other plugins (not `@nx/*`).

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17764
