### PR TITLE
fix(js): workspace lib devDependencies should not be added to package.json

### DIFF
--- a/packages/js/src/utils/package-json/update-package-json.ts
+++ b/packages/js/src/utils/package-json/update-package-json.ts
@@ -134,8 +134,13 @@ function addMissingDependencies(
       packageJson[propType][packageName] = version;
     } else {
       const packageName = entry.name;
+      if (!!workspacePackageJson.devDependencies?.[packageName]) {
+        return;
+      }
+
       if (
         !packageJson.dependencies?.[packageName] &&
+        !packageJson.devDependencies?.[packageName] &&
         !packageJson.peerDependencies?.[packageName]
       ) {
         const outputs = getOutputsForTargetAndConfiguration(


### PR DESCRIPTION
Fix a regression where libraries with dependencies on other libraries in your Nx workspace would list those dependencies in the "dependencies" output of package.json, even when explicitly listed in "devDependencies"

**Note:** there should probably be a test for this, which I tried to write but couldn't figure out how to get the structure of the "dependencies" argument correct. All the existing tests just pass an empty array here.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Nx incorrectly outputs library dependencies in "dependencies" section of package.json even when listed in the "devDependencies" explicitly
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The packages should not be listed in "dependencies". This fixes a regression introduced by this PR:
https://github.com/nrwl/nx/pull/13968

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17758

