### PR TITLE
fix(core): fix globbing in rust

### DIFF
--- a/packages/nx/src/native/utils/glob.rs
+++ b/packages/nx/src/native/utils/glob.rs
@@ -1,10 +1,44 @@
-use globset::{Glob, GlobSet, GlobSetBuilder};
+use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
 
 pub(crate) fn build_glob_set(globs: Vec<String>) -> anyhow::Result<GlobSet> {
-    let mut glob_builder = GlobSetBuilder::new();
+    let mut glob_set_builder = GlobSetBuilder::new();
     for glob in globs {
-        glob_builder.add(Glob::new(&glob).map_err(anyhow::Error::from)?);
+        let glob = GlobBuilder::new(&glob)
+            .literal_separator(true)
+            .build()
+            .map_err(anyhow::Error::from)?;
+        glob_set_builder.add(glob);
     }
 
-    glob_builder.build().map_err(anyhow::Error::from)
+    glob_set_builder.build().map_err(anyhow::Error::from)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn should_detect_package_json() {
+        let glob_set = build_glob_set(vec![String::from("packages/*/package.json")]).unwrap();
+        assert!(glob_set.is_match("packages/nx/package.json"))
+    }
+
+    #[test]
+    fn should_not_detect_deeply_nested_package_json() {
+        let glob_set = build_glob_set(vec![String::from("packages/*/package.json")]).unwrap();
+        assert!(!glob_set.is_match("packages/nx/test-files/package.json"))
+    }
+
+    #[test]
+    fn should_detect_deeply_nested_package_json() {
+        let glob_set = build_glob_set(vec![String::from("packages/**/package.json")]).unwrap();
+        assert!(glob_set.is_match("packages/nx/test-files/package.json"))
+    }
+
+    #[test]
+    fn should_detect_node_modules() {
+        let glob_set = build_glob_set(vec![String::from("**/node_modules")]).unwrap();
+        assert!(glob_set.is_match("node_modules"));
+        assert!(glob_set.is_match("packages/nx/node_modules"));
+    }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The globbing in rust did not handle `packages/*/package.json` the same way that `fast-glob` handled it.

Nested `node_modules` were not ignored as they were before.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The globbing in rust handles `packages/*/package.json` and other globs with literal separators the same way.

Nested `node_modules` are ignored as they were before.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/17797
Fixes https://github.com/nrwl/nx/issues/17774
