### PR TITLE
fix(misc): prevent unexpected targets from root package.json when setting up root project

### DIFF
--- a/packages/js/src/generators/setup-verdaccio/generator.ts
+++ b/packages/js/src/generators/setup-verdaccio/generator.ts
@@ -37,6 +37,14 @@ export async function setupVerdaccio(
   };
   if (!tree.exists('project.json')) {
     const { name } = readJson(tree, 'package.json');
+    updateJson(tree, 'package.json', (json) => {
+      if (!json.nx) {
+        json.nx = {
+          includedScripts: [],
+        };
+      }
+      return json;
+    });
     addProjectConfiguration(tree, name, {
       root: '.',
       targets: {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Setting up verdaccio for an existing repo enables all scripts from package.json as root targets

## Expected Behavior
Setting up verdaccio only enables a "local-registry" target

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17779
