### PR TITLE
fix(nextjs): Custom server should run on fresh apps without errors

### DIFF
--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -73,9 +73,19 @@ export async function* nodeExecutor(
 
   // Re-map buildable workspace projects to their output directory.
   const mappings = calculateResolveMappings(context, options);
+  let outputFileName =
+    buildOptions.outputFileName || `${path.parse(buildOptions.main).name}.js`;
 
-  const outputFileName =
-    buildOptions.outputFileName ?? `${path.parse(buildOptions.main).name}.js`;
+  if (!buildOptions.outputFileName) {
+    const matches = buildOptions.main.match(/^(?!.*src)(.*)\/([^/]*)$/); //ignore strings that contain src and split paths into [folders before main, main.ts]
+    if (matches) {
+      const [mainFolder, mainFileName] = matches.slice(1);
+      outputFileName = path.join(
+        mainFolder,
+        `${path.parse(mainFileName).name}.js`
+      );
+    }
+  }
 
   const fileToRun = join(context.root, buildOptions.outputPath, outputFileName);
   const tasks: ActiveTask[] = [];


### PR DESCRIPTION
Before when we ran custom server it would result in a error for fresh NextJs Apps
```
 throw new Error(`Could not find ${fileToRun}. Make sure your build succeeded.`);
 ```

This was because the server code was generated `./server/main.ts` while the `@nx/js:node` executor expects it from the root of the project.


This change should address this issue.
