### PR TITLE
docs(core): workspace-lint cli links to web

### DIFF
--- a/docs/generated/cli/workspace-lint.md
+++ b/docs/generated/cli/workspace-lint.md
@@ -5,7 +5,7 @@ description: 'Lint nx specific workspace files (nx.json, workspace.json)'
 
 # workspace-lint
 
-**Deprecated:** workspace-lint is deprecated, and will be removed in v17. The checks it used to perform are no longer relevant.
+**Deprecated:** workspace-lint is deprecated, and will be removed in v17. The checks it used to perform are no longer relevant. See: https://nx.dev/deprecated/workspace-lint
 
 Lint nx specific workspace files (nx.json, workspace.json)
 

--- a/docs/generated/packages/nx/documents/workspace-lint.md
+++ b/docs/generated/packages/nx/documents/workspace-lint.md
@@ -5,7 +5,7 @@ description: 'Lint nx specific workspace files (nx.json, workspace.json)'
 
 # workspace-lint
 
-**Deprecated:** workspace-lint is deprecated, and will be removed in v17. The checks it used to perform are no longer relevant.
+**Deprecated:** workspace-lint is deprecated, and will be removed in v17. The checks it used to perform are no longer relevant. See: https://nx.dev/deprecated/workspace-lint
 
 Lint nx specific workspace files (nx.json, workspace.json)
 

--- a/packages/nx/src/command-line/workspace-lint/command-object.ts
+++ b/packages/nx/src/command-line/workspace-lint/command-object.ts
@@ -7,7 +7,7 @@ export const yargsWorkspaceLintCommand: CommandModule = {
   command: 'workspace-lint [files..]',
   describe: 'Lint nx specific workspace files (nx.json, workspace.json)',
   deprecated:
-    'workspace-lint is deprecated, and will be removed in v17. The checks it used to perform are no longer relevant.',
+    'workspace-lint is deprecated, and will be removed in v17. The checks it used to perform are no longer relevant.  See: https://nx.dev/deprecated/workspace-lint',
   handler: async () => {
     await (await import('./workspace-lint')).workspaceLint();
     process.exit(0);


### PR DESCRIPTION
`workspace-lint` cli command links to the newly created deprecation page on the docs.