### PR TITLE
fix(misc): nx view-logs should open the nx-cloud link when connected …

### DIFF
--- a/packages/nx/src/command-line/connect/view-logs.ts
+++ b/packages/nx/src/command-line/connect/view-logs.ts
@@ -5,60 +5,68 @@ import { output } from '../../utils/output';
 import { runNxSync } from '../../utils/child-process';
 
 export async function viewLogs(): Promise<number> {
+  const cloudUsed = isNxCloudUsed();
+  if (cloudUsed) {
+    output.error({
+      title: 'Your workspace is already connected to Nx Cloud',
+      bodyLines: [
+        `Refer to the output of the last command to find the Nx Cloud link to view the run details.`,
+      ],
+    });
+    return 1;
+  }
+
+  const installCloud = await (
+    await import('enquirer')
+  )
+    .prompt([
+      {
+        name: 'NxCloud',
+        message: `To view the logs, Nx needs to connect your workspace to Nx Cloud and upload the most recent run details.`,
+        type: 'autocomplete',
+        choices: [
+          {
+            name: 'Yes',
+            hint: 'Connect to Nx Cloud and upload the run details',
+          },
+          {
+            name: 'No',
+          },
+        ],
+        initial: 'Yes' as any,
+      },
+    ])
+    .then((a: { NxCloud: 'Yes' | 'No' }) => a.NxCloud === 'Yes');
+
+  if (!installCloud) return;
+
   const pmc = getPackageManagerCommand();
-  const cloudUsed = isNxCloudUsed() && false;
-  if (!cloudUsed) {
-    const installCloud = await (
-      await import('enquirer')
-    )
-      .prompt([
-        {
-          name: 'NxCloud',
-          message: `To view the logs, Nx needs to connect your workspace to Nx Cloud and upload the most recent run details.`,
-          type: 'autocomplete',
-          choices: [
-            {
-              name: 'Yes',
-              hint: 'Connect to Nx Cloud and upload the run details',
-            },
-            {
-              name: 'No',
-            },
-          ],
-          initial: 'Yes' as any,
-        },
-      ])
-      .then((a: { NxCloud: 'Yes' | 'No' }) => a.NxCloud === 'Yes');
+  try {
+    output.log({
+      title: 'Installing nx-cloud',
+    });
+    execSync(`${pmc.addDev} nx-cloud@latest`, { stdio: 'ignore' });
+  } catch (e) {
+    output.log({
+      title: 'Installation failed',
+    });
+    console.log(e);
+    return 1;
+  }
 
-    if (!installCloud) return;
-
-    try {
-      output.log({
-        title: 'Installing nx-cloud',
-      });
-      execSync(`${pmc.addDev} nx-cloud@latest`, { stdio: 'ignore' });
-    } catch (e) {
-      output.log({
-        title: 'Installation failed',
-      });
-      console.log(e);
-      return 1;
-    }
-
-    try {
-      output.log({
-        title: 'Connecting to Nx Cloud',
-      });
-      runNxSync(`g nx-cloud:init --installation-source=view-logs`, {
-        stdio: 'ignore',
-      });
-    } catch (e) {
-      output.log({
-        title: 'Failed to connect to Nx Cloud',
-      });
-      console.log(e);
-      return 1;
-    }
+  try {
+    output.log({
+      title: 'Connecting to Nx Cloud',
+    });
+    runNxSync(`g nx-cloud:init --installation-source=view-logs`, {
+      stdio: 'ignore',
+    });
+  } catch (e) {
+    output.log({
+      title: 'Failed to connect to Nx Cloud',
+    });
+    console.log(e);
+    return 1;
   }
 
   execSync(`${pmc.exec} nx-cloud upload-and-show-run-details`, {


### PR DESCRIPTION
…to cloud

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When the user is connected to cloud, they can run `nx view-logs`, it asks them to connect to cloud (they are already connected).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When the user is connected to cloud, they can run `nx view-logs` and it should open up the run in a browser so that they can view the logs.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
