### PR TITLE
chore(misc): patch lerna 6.6.2 to catch additional publish conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -347,6 +347,10 @@
       "depcheck",
       "documentation"
     ]
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "lerna@6.6.2": "patches/lerna@6.6.2.patch"
+    }
   }
 }
-

--- a/patches/lerna@6.6.2.patch
+++ b/patches/lerna@6.6.2.patch
@@ -14,3 +14,35 @@ index 8cd49ff1e99dca8241a75bc412c669a85475fce2..8f081b7ee0769a493b11f22c5d5d0752
                    tracker.warn("publish", `Package is already published: ${pkg.name}@${pkg.version}`);
                    tracker.completeWork(1);
                    return pkg;
+diff --git a/dist/commands/publish/index.js b/dist/commands/publish/index.js
+index 34fe8f496af5e7adaf58a7f9c4c3a11d812608c3..bbab4d70c044729b174208b2f1250f54ab69e56d 100644
+--- a/dist/commands/publish/index.js
++++ b/dist/commands/publish/index.js
+@@ -6094,7 +6094,10 @@ var require_src2 = __commonJS({
+                 logPacked(pkg.packed);
+                 return pkg;
+               }).catch((err) => {
+-                if (err.code === "EPUBLISHCONFLICT") {
++                if (
++                  err.code === "EPUBLISHCONFLICT" ||
++                  (err.code === "E403" &&
++                    err.body?.error?.includes("You cannot publish over the previously published versions"))) {
+                   tracker.warn("publish", `Package is already published: ${pkg.name}@${pkg.version}`);
+                   tracker.completeWork(1);
+                   return pkg;
+diff --git a/dist/index.js b/dist/index.js
+index a1f83a569598efc7f129d8de7d004f45177514f4..86364db7a267c0fa3eaafc9b1bc51838a41f4f4f 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -7932,7 +7932,10 @@ var require_src10 = __commonJS({
+                 logPacked(pkg2.packed);
+                 return pkg2;
+               }).catch((err) => {
+-                if (err.code === "EPUBLISHCONFLICT") {
++                if (
++                  err.code === "EPUBLISHCONFLICT" ||
++                  (err.code === "E403" &&
++                    err.body?.error?.includes("You cannot publish over the previously published versions"))) {
+                   tracker.warn("publish", `Package is already published: ${pkg2.name}@${pkg2.version}`);
+                   tracker.completeWork(1);
+                   return pkg2;

--- a/patches/lerna@6.6.2.patch
+++ b/patches/lerna@6.6.2.patch
@@ -1,0 +1,16 @@
+diff --git a/dist/cli.js b/dist/cli.js
+index 8cd49ff1e99dca8241a75bc412c669a85475fce2..8f081b7ee0769a493b11f22c5d5d0752e8285629 100755
+--- a/dist/cli.js
++++ b/dist/cli.js
+@@ -7933,7 +7933,10 @@ var require_src10 = __commonJS({
+                 logPacked(pkg.packed);
+                 return pkg;
+               }).catch((err) => {
+-                if (err.code === "EPUBLISHCONFLICT") {
++                if (
++                  err.code === "EPUBLISHCONFLICT" ||
++                  (err.code === "E403" &&
++                    err.body?.error?.includes("You cannot publish over the previously published versions"))) {
+                   tracker.warn("publish", `Package is already published: ${pkg.name}@${pkg.version}`);
+                   tracker.completeWork(1);
+                   return pkg;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ overrides:
 
 patchedDependencies:
   lerna@6.6.2:
-    hash: 5hb52wr3vthig2xaukazqbwjua
+    hash: 3yvbdpztnf4grjjp7nswmjw3mi
     path: patches/lerna@6.6.2.patch
 
 dependencies:
@@ -653,7 +653,7 @@ devDependencies:
     version: 1.6.1
   lerna:
     specifier: 6.6.2
-    version: 6.6.2(patch_hash=5hb52wr3vthig2xaukazqbwjua)(@swc-node/register@1.5.4)(@swc/core@1.3.51)
+    version: 6.6.2(patch_hash=3yvbdpztnf4grjjp7nswmjw3mi)(@swc-node/register@1.5.4)(@swc/core@1.3.51)
   less:
     specifier: 4.1.3
     version: 4.1.3
@@ -18881,7 +18881,7 @@ packages:
       dotenv-expand: 10.0.0
     dev: true
 
-  /lerna@6.6.2(patch_hash=5hb52wr3vthig2xaukazqbwjua)(@swc-node/register@1.5.4)(@swc/core@1.3.51):
+  /lerna@6.6.2(patch_hash=3yvbdpztnf4grjjp7nswmjw3mi)(@swc-node/register@1.5.4)(@swc/core@1.3.51):
     resolution: {integrity: sha512-W4qrGhcdutkRdHEaDf9eqp7u4JvI+1TwFy5woX6OI8WPe4PYBdxuILAsvhp614fUG41rKSGDKlOh+AWzdSidTg==}
     engines: {node: ^14.17.0 || >=16.0.0}
     hasBin: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ overrides:
   minimist: ^1.2.6
   underscore: ^1.12.1
 
+patchedDependencies:
+  lerna@6.6.2:
+    hash: 5hb52wr3vthig2xaukazqbwjua
+    path: patches/lerna@6.6.2.patch
+
 dependencies:
   '@docsearch/react':
     specifier: ^3.3.0
@@ -648,7 +653,7 @@ devDependencies:
     version: 1.6.1
   lerna:
     specifier: 6.6.2
-    version: 6.6.2(@swc-node/register@1.5.4)(@swc/core@1.3.51)
+    version: 6.6.2(patch_hash=5hb52wr3vthig2xaukazqbwjua)(@swc-node/register@1.5.4)(@swc/core@1.3.51)
   less:
     specifier: 4.1.3
     version: 4.1.3
@@ -18876,7 +18881,7 @@ packages:
       dotenv-expand: 10.0.0
     dev: true
 
-  /lerna@6.6.2(@swc-node/register@1.5.4)(@swc/core@1.3.51):
+  /lerna@6.6.2(patch_hash=5hb52wr3vthig2xaukazqbwjua)(@swc-node/register@1.5.4)(@swc/core@1.3.51):
     resolution: {integrity: sha512-W4qrGhcdutkRdHEaDf9eqp7u4JvI+1TwFy5woX6OI8WPe4PYBdxuILAsvhp614fUG41rKSGDKlOh+AWzdSidTg==}
     engines: {node: ^14.17.0 || >=16.0.0}
     hasBin: true
@@ -18965,6 +18970,7 @@ packages:
       - encoding
       - supports-color
     dev: true
+    patched: true
 
   /less-loader@11.1.0(less@4.1.3)(webpack@5.86.0):
     resolution: {integrity: sha512-C+uDBV7kS7W5fJlUjq5mPBeBVhYpTIm5gB09APT9o3n/ILeaXVsiSFTbZpTJCJwQ/Crczfn3DmfQFwxYusWFug==}


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Lerna 6.6.2 will not catch all publish conflicts - specifically those where npm returns E403 instead of EPUBLISHCONFLICT.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Lerna 6.6.2, in the Nx repo, will catch E403 publish conflicts.