### PR TITLE
fix(misc): fix misc issues with move generators

### DIFF
--- a/packages/angular/src/generators/move/lib/index.ts
+++ b/packages/angular/src/generators/move/lib/index.ts
@@ -1,0 +1,4 @@
+export * from './normalize-schema';
+export * from './update-module-name';
+export * from './update-ng-package';
+export * from './update-secondary-entry-points';

--- a/packages/angular/src/generators/move/lib/normalize-schema.ts
+++ b/packages/angular/src/generators/move/lib/normalize-schema.ts
@@ -1,0 +1,15 @@
+import type { Tree } from '@nx/devkit';
+import { readProjectConfiguration } from '@nx/devkit';
+import type { NormalizedSchema, Schema } from '../schema';
+import { getNewProjectName } from '../../utils/get-new-project-name';
+
+export function normalizeSchema(tree: Tree, schema: Schema): NormalizedSchema {
+  const newProjectName = getNewProjectName(schema.destination);
+  const { root } = readProjectConfiguration(tree, schema.projectName);
+
+  return {
+    ...schema,
+    newProjectName,
+    oldProjectRoot: root,
+  };
+}

--- a/packages/angular/src/generators/move/lib/update-module-name.spec.ts
+++ b/packages/angular/src/generators/move/lib/update-module-name.spec.ts
@@ -4,7 +4,7 @@ import { Linter } from '@nx/linter';
 import { moveGenerator } from '@nx/workspace/generators';
 import { UnitTestRunner } from '../../../utils/test-runners';
 import { generateTestLibrary } from '../../utils/testing';
-import { Schema } from '../schema';
+import { NormalizedSchema } from '../schema';
 import { updateModuleName } from './update-module-name';
 
 describe('updateModuleName Rule', () => {
@@ -20,17 +20,19 @@ describe('updateModuleName Rule', () => {
       name: 'my-first',
       simpleName: true,
     });
-    const schema: Schema = {
+    const schema: NormalizedSchema = {
       projectName: 'my-first',
       destination: 'my/first',
       updateImportPath: true,
+      newProjectName: 'my-first',
+      oldProjectRoot: 'libs/my-first',
     };
     await moveGenerator(tree, schema);
 
     updateModuleName(tree, { ...schema, destination: 'my/first' });
 
     expect(tree.exists(updatedModulePath)).toBe(true);
-    const moduleFile = tree.read(updatedModulePath).toString('utf-8');
+    const moduleFile = tree.read(updatedModulePath, 'utf-8');
     expect(moduleFile).toContain(`export class MyFirstModule {}`);
   });
 
@@ -42,10 +44,12 @@ describe('updateModuleName Rule', () => {
     const indexPath = '/libs/shared/my-first/src/index.ts';
     const secondModulePath = '/libs/my-second/src/lib/my-second.module.ts';
 
-    const schema: Schema = {
+    const schema: NormalizedSchema = {
       projectName: 'my-first',
       destination: 'shared/my-first',
       updateImportPath: true,
+      newProjectName: 'shared-my-first',
+      oldProjectRoot: 'libs/my-first',
     };
 
     beforeEach(async () => {
@@ -111,10 +115,10 @@ describe('updateModuleName Rule', () => {
       expect(tree.exists(updatedModulePath)).toBe(true);
       expect(tree.exists(updatedModuleSpecPath)).toBe(true);
 
-      const moduleFile = tree.read(updatedModulePath).toString('utf-8');
+      const moduleFile = tree.read(updatedModulePath, 'utf-8');
       expect(moduleFile).toContain(`export class SharedMyFirstModule {}`);
 
-      const moduleSpecFile = tree.read(updatedModuleSpecPath).toString('utf-8');
+      const moduleSpecFile = tree.read(updatedModuleSpecPath, 'utf-8');
       expect(moduleSpecFile).toContain(
         `import { SharedMyFirstModule } from './shared-my-first.module';`
       );
@@ -130,7 +134,7 @@ describe('updateModuleName Rule', () => {
     it('should update any references to the module', async () => {
       updateModuleName(tree, schema);
 
-      const importerFile = tree.read(secondModulePath).toString('utf-8');
+      const importerFile = tree.read(secondModulePath, 'utf-8');
       expect(importerFile).toContain(
         `import { SharedMyFirstModule } from '@proj/shared/my-first';`
       );
@@ -142,7 +146,7 @@ describe('updateModuleName Rule', () => {
     it('should update the index.ts file which exports the module', async () => {
       updateModuleName(tree, schema);
 
-      const indexFile = tree.read(indexPath).toString('utf-8');
+      const indexFile = tree.read(indexPath, 'utf-8');
       expect(indexFile).toContain(
         `export * from './lib/shared-my-first.module';`
       );
@@ -150,10 +154,12 @@ describe('updateModuleName Rule', () => {
   });
 
   describe('rename', () => {
-    const schema: Schema = {
+    const schema: NormalizedSchema = {
       projectName: 'my-source',
       destination: 'my-destination',
       updateImportPath: true,
+      newProjectName: 'my-destination',
+      oldProjectRoot: 'libs/my-source',
     };
 
     const modulePath = '/libs/my-destination/src/lib/my-destination.module.ts';
@@ -233,10 +239,10 @@ describe('updateModuleName Rule', () => {
       expect(tree.exists(modulePath)).toBe(true);
       expect(tree.exists(moduleSpecPath)).toBe(true);
 
-      const moduleFile = tree.read(modulePath).toString('utf-8');
+      const moduleFile = tree.read(modulePath, 'utf-8');
       expect(moduleFile).toContain(`export class MyDestinationModule {}`);
 
-      const moduleSpecFile = tree.read(moduleSpecPath).toString('utf-8');
+      const moduleSpecFile = tree.read(moduleSpecPath, 'utf-8');
       expect(moduleSpecFile).toContain(
         `import { MyDestinationModule } from './my-destination.module';`
       );
@@ -252,7 +258,7 @@ describe('updateModuleName Rule', () => {
     it('should update any references to the module', async () => {
       updateModuleName(tree, schema);
 
-      const importerFile = tree.read(importerPath).toString('utf-8');
+      const importerFile = tree.read(importerPath, 'utf-8');
       expect(importerFile).toContain(
         `import { MyDestinationModule } from '@proj/my-destination';`
       );
@@ -264,10 +270,32 @@ describe('updateModuleName Rule', () => {
     it('should update the index.ts file which exports the module', async () => {
       updateModuleName(tree, schema);
 
-      const indexFile = tree.read(indexPath).toString('utf-8');
+      const indexFile = tree.read(indexPath, 'utf-8');
       expect(indexFile).toContain(
         `export * from './lib/my-destination.module';`
       );
+    });
+
+    it('should not rename unrelated symbols with similar name in different projects', async () => {
+      // create different project whose main module name starts with the same
+      // name of the project we're moving
+      await generateTestLibrary(tree, {
+        name: 'my-source-demo',
+        buildable: false,
+        linter: Linter.EsLint,
+        publishable: false,
+        simpleName: true,
+        skipFormat: false,
+        unitTestRunner: UnitTestRunner.Jest,
+      });
+
+      updateModuleName(tree, schema);
+
+      const moduleFile = tree.read(
+        '/libs/my-source-demo/src/lib/my-source-demo.module.ts',
+        'utf-8'
+      );
+      expect(moduleFile).toContain(`export class MySourceDemoModule {}`);
     });
   });
 });

--- a/packages/angular/src/generators/move/lib/update-module-name.ts
+++ b/packages/angular/src/generators/move/lib/update-module-name.ts
@@ -1,13 +1,12 @@
 import {
   getProjects,
+  joinPathFragments,
   names,
   readProjectConfiguration,
   Tree,
   visitNotIgnoredFiles,
 } from '@nx/devkit';
-import { getNewProjectName } from '../../utils/get-new-project-name';
-import { join } from 'path';
-import { Schema } from '../schema';
+import type { NormalizedSchema } from '../schema';
 
 /**
  * Updates the Angular module name (including the spec file and index.ts)
@@ -19,10 +18,8 @@ import { Schema } from '../schema';
  */
 export function updateModuleName(
   tree: Tree,
-  { projectName, destination }: Schema
+  { projectName: oldProjectName, newProjectName }: NormalizedSchema
 ): void {
-  const newProjectName = getNewProjectName(destination);
-
   const project = readProjectConfiguration(tree, newProjectName);
 
   if (project.projectType === 'application') {
@@ -32,14 +29,14 @@ export function updateModuleName(
   }
 
   const moduleName = {
-    from: names(projectName).className,
-    to: names(newProjectName).className,
+    from: `${names(oldProjectName).className}Module`,
+    to: `${names(newProjectName).className}Module`,
   };
 
   const findModuleName = new RegExp(`\\b${moduleName.from}`, 'g');
 
   const moduleFile = {
-    from: `${projectName}.module`,
+    from: `${oldProjectName}.module`,
     to: `${newProjectName}.module`,
   };
 
@@ -81,7 +78,7 @@ export function updateModuleName(
   });
 
   // update index file
-  const indexFile = join(project.sourceRoot, 'index.ts');
+  const indexFile = joinPathFragments(project.sourceRoot, 'index.ts');
   if (tree.exists(indexFile)) {
     updateFileContent(tree, replacements, indexFile);
   }

--- a/packages/angular/src/generators/move/lib/update-ng-package.ts
+++ b/packages/angular/src/generators/move/lib/update-ng-package.ts
@@ -6,13 +6,11 @@ import {
   updateJson,
   workspaceRoot,
 } from '@nx/devkit';
-import { getNewProjectName } from '../../utils/get-new-project-name';
 import { join, relative } from 'path';
-import { Schema } from '../schema';
+import type { NormalizedSchema } from '../schema';
 
-export function updateNgPackage(tree: Tree, schema: Schema): void {
-  const newProjectName = getNewProjectName(schema.destination);
-  const project = readProjectConfiguration(tree, newProjectName);
+export function updateNgPackage(tree: Tree, schema: NormalizedSchema): void {
+  const project = readProjectConfiguration(tree, schema.newProjectName);
 
   if (project.projectType === 'application') {
     return;
@@ -29,13 +27,13 @@ export function updateNgPackage(tree: Tree, schema: Schema): void {
   const outputs = getOutputsForTargetAndConfiguration(
     {
       target: {
-        project: newProjectName,
+        project: schema.newProjectName,
         target: 'build',
       },
       overrides: {},
     },
     {
-      name: newProjectName,
+      name: schema.newProjectName,
       type: 'lib',
       data: {
         root: project.root,

--- a/packages/angular/src/generators/move/lib/update-secondary-entry-points.ts
+++ b/packages/angular/src/generators/move/lib/update-secondary-entry-points.ts
@@ -1,0 +1,71 @@
+import type { Tree } from '@nx/devkit';
+import {
+  joinPathFragments,
+  normalizePath,
+  readProjectConfiguration,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import { basename, dirname } from 'path';
+import type { NormalizedSchema } from '../schema';
+
+const libraryExecutors = [
+  '@angular-devkit/build-angular:ng-packagr',
+  '@nx/angular:ng-packagr-lite',
+  '@nx/angular:package',
+  // TODO(v17): remove when @nrwl/* scope is removed
+  '@nrwl/angular:ng-packagr-lite',
+  '@nrwl/angular:package',
+];
+
+export function updateSecondaryEntryPoints(
+  tree: Tree,
+  schema: NormalizedSchema
+): void {
+  const project = readProjectConfiguration(tree, schema.newProjectName);
+
+  if (project.projectType !== 'library') {
+    return;
+  }
+
+  if (
+    !Object.values(project.targets ?? {}).some((target) =>
+      libraryExecutors.includes(target.executor)
+    )
+  ) {
+    return;
+  }
+
+  visitNotIgnoredFiles(tree, project.root, (filePath) => {
+    if (
+      basename(filePath) !== 'ng-package.json' ||
+      normalizePath(filePath) ===
+        joinPathFragments(project.root, 'ng-package.json')
+    ) {
+      return;
+    }
+
+    updateReadme(
+      tree,
+      dirname(filePath),
+      schema.projectName,
+      schema.newProjectName
+    );
+  });
+}
+
+function updateReadme(
+  tree: Tree,
+  dir: string,
+  oldProjectName: string,
+  newProjectName: string
+) {
+  const readmePath = joinPathFragments(dir, 'README.md');
+  if (!tree.exists(readmePath)) {
+    return;
+  }
+
+  const findName = new RegExp(`${oldProjectName}`, 'g');
+  const oldContent = tree.read(readmePath, 'utf-8');
+  const newContent = oldContent.replace(findName, newProjectName);
+  tree.write(readmePath, newContent);
+}

--- a/packages/angular/src/generators/move/move.spec.ts
+++ b/packages/angular/src/generators/move/move.spec.ts
@@ -3,6 +3,7 @@ import { readJson, Tree } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { Linter } from '@nx/linter';
 import { UnitTestRunner } from '../../utils/test-runners';
+import librarySecondaryEntryPointGenerator from '../library-secondary-entry-point/library-secondary-entry-point';
 import { generateTestLibrary } from '../utils/testing';
 import { angularMoveGenerator } from './move';
 
@@ -48,6 +49,28 @@ describe('@nx/angular:move', () => {
 
     const ngPackageJson = readJson(tree, 'libs/mynewlib2/ng-package.json');
     expect(ngPackageJson.dest).toEqual('../../dist/libs/mynewlib2');
+  });
+
+  it('should update secondary entry points readme file', async () => {
+    await generateTestLibrary(tree, { name: 'mylib2', buildable: true });
+    await librarySecondaryEntryPointGenerator(tree, {
+      library: 'mylib2',
+      name: 'testing',
+    });
+
+    await angularMoveGenerator(tree, {
+      projectName: 'mylib2',
+      destination: 'mynewlib2',
+      updateImportPath: true,
+    });
+
+    const readme = tree.read('libs/mynewlib2/testing/README.md', 'utf-8');
+    expect(readme).toMatchInlineSnapshot(`
+      "# @proj/mynewlib2/testing
+
+      Secondary entry point of \`@proj/mynewlib2\`. It can be used by importing from \`@proj/mynewlib2/testing\`.
+      "
+    `);
   });
 
   it('should format files', async () => {

--- a/packages/angular/src/generators/move/move.ts
+++ b/packages/angular/src/generators/move/move.ts
@@ -1,8 +1,12 @@
 import { formatFiles, Tree } from '@nx/devkit';
 import { moveGenerator } from '@nx/workspace/generators';
-import { updateModuleName } from './lib/update-module-name';
-import { updateNgPackage } from './lib/update-ng-package';
-import { Schema } from './schema';
+import {
+  normalizeSchema,
+  updateModuleName,
+  updateNgPackage,
+  updateSecondaryEntryPoints,
+} from './lib';
+import type { Schema } from './schema';
 
 /**
  * Moves an Angular lib/app to another folder (and renames it in the process)
@@ -15,11 +19,14 @@ export async function angularMoveGenerator(
   tree: Tree,
   schema: Schema
 ): Promise<void> {
-  await moveGenerator(tree, { ...schema, skipFormat: true });
-  updateModuleName(tree, schema);
-  updateNgPackage(tree, schema);
+  const normalizedSchema = normalizeSchema(tree, schema);
 
-  if (!schema.skipFormat) {
+  await moveGenerator(tree, { ...schema, skipFormat: true });
+  updateModuleName(tree, normalizedSchema);
+  updateNgPackage(tree, normalizedSchema);
+  updateSecondaryEntryPoints(tree, normalizedSchema);
+
+  if (!normalizedSchema.skipFormat) {
     await formatFiles(tree);
   }
 }

--- a/packages/angular/src/generators/move/schema.d.ts
+++ b/packages/angular/src/generators/move/schema.d.ts
@@ -5,3 +5,8 @@ export interface Schema {
   importPath?: string;
   skipFormat?: boolean;
 }
+
+export interface NormalizedSchema extends Schema {
+  oldProjectRoot: string;
+  newProjectName: string;
+}

--- a/packages/angular/src/generators/utils/get-new-project-name.ts
+++ b/packages/angular/src/generators/utils/get-new-project-name.ts
@@ -1,8 +1,15 @@
+import { normalizePath } from '@nx/devkit';
+
 /**
- * Replaces slashes with dashes
+ * Joins path segments replacing slashes with dashes
  *
  * @param path
  */
 export function getNewProjectName(path: string): string {
-  return path.replace(/\//g, '-');
+  // strip leading '/' or './' or '../' and trailing '/' and replaces '/' with '-'
+  return normalizePath(path)
+    .replace(/(^\.{0,2}\/|\.{1,2}\/|\/$)/g, '')
+    .split('/')
+    .filter((x) => !!x)
+    .join('-');
 }

--- a/packages/workspace/src/generators/move/lib/normalize-schema.spec.ts
+++ b/packages/workspace/src/generators/move/lib/normalize-schema.spec.ts
@@ -46,6 +46,25 @@ describe('normalizeSchema', () => {
     expect(result).toEqual(expected);
   });
 
+  it('should normalize destination and derive projectName correctly', () => {
+    const expected: NormalizedSchema = {
+      destination: 'my/library',
+      importPath: '@proj/my/library',
+      newProjectName: 'my-library',
+      projectName: 'my-library',
+      relativeToRootDestination: 'libs/my/library',
+      updateImportPath: true,
+    };
+
+    const result = normalizeSchema(
+      tree,
+      { ...schema, destination: './my/library' },
+      projectConfiguration
+    );
+
+    expect(result).toEqual(expected);
+  });
+
   it('should use provided import path', () => {
     const expected: NormalizedSchema = {
       destination: 'my/library',

--- a/packages/workspace/src/generators/move/lib/normalize-schema.ts
+++ b/packages/workspace/src/generators/move/lib/normalize-schema.ts
@@ -1,6 +1,10 @@
 import { ProjectConfiguration, Tree } from '@nx/devkit';
 import type { NormalizedSchema, Schema } from '../schema';
-import { getDestination, getNewProjectName, normalizeSlashes } from './utils';
+import {
+  getDestination,
+  getNewProjectName,
+  normalizePathSlashes,
+} from './utils';
 import { getImportPath } from '../../../utilities/get-import-path';
 
 export function normalizeSchema(
@@ -8,9 +12,7 @@ export function normalizeSchema(
   schema: Schema,
   projectConfiguration: ProjectConfiguration
 ): NormalizedSchema {
-  const destination = schema.destination.startsWith('/')
-    ? normalizeSlashes(schema.destination.slice(1))
-    : schema.destination;
+  const destination = normalizePathSlashes(schema.destination);
   const newProjectName =
     schema.newProjectName ?? getNewProjectName(destination);
 
@@ -18,7 +20,8 @@ export function normalizeSchema(
     ...schema,
     destination,
     importPath:
-      schema.importPath ?? normalizeSlashes(getImportPath(tree, destination)),
+      schema.importPath ??
+      normalizePathSlashes(getImportPath(tree, destination)),
     newProjectName,
     relativeToRootDestination: getDestination(
       tree,

--- a/packages/workspace/src/generators/move/lib/utils.ts
+++ b/packages/workspace/src/generators/move/lib/utils.ts
@@ -1,10 +1,10 @@
 import {
   getWorkspaceLayout,
   joinPathFragments,
+  normalizePath,
   ProjectConfiguration,
   Tree,
 } from '@nx/devkit';
-
 import { Schema } from '../schema';
 
 /**
@@ -35,12 +35,17 @@ export function getDestination(
 }
 
 /**
- * Replaces slashes with dashes
+ * Joins path segments replacing slashes with dashes
  *
  * @param path
  */
 export function getNewProjectName(path: string): string {
-  return path.replace(/\//g, '-');
+  // strip leading '/' or './' or '../' and trailing '/' and replaces '/' with '-'
+  return normalizePath(path)
+    .replace(/(^\.{0,2}\/|\.{1,2}\/|\/$)/g, '')
+    .split('/')
+    .filter((x) => !!x)
+    .join('-');
 }
 
 /**
@@ -48,9 +53,13 @@ export function getNewProjectName(path: string): string {
  *
  * @param input
  */
-export function normalizeSlashes(input: string): string {
-  return input
-    .split('/')
-    .filter((x) => !!x)
-    .join('/');
+export function normalizePathSlashes(input: string): string {
+  return (
+    normalizePath(input)
+      // strip leading ./ or /
+      .replace(/^\.?\//, '')
+      .split('/')
+      .filter((x) => !!x)
+      .join('/')
+  );
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

- When `--destination` is provided with a leading `./` a wrong project name is generated
- Secondary entry points TS path mappings and imports are not updated
- Secondary entry point README files are not updated
- Some symbols not meant to change are renamed

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The mentioned issues above shouldn't occur.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15354
