### PR TITLE
feat(nextjs): allow withNx to be used with other executors such as run-commands

### DIFF
--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -296,7 +296,7 @@ describe('Next.js Applications', () => {
     await killPorts();
   }, 300_000);
 
-  it('should support custom next.config.js and output it in dist', async () => {
+  it('should support custom webpack and run-commands using withNx', async () => {
     const appName = uniq('app');
 
     runCLI(
@@ -306,7 +306,7 @@ describe('Next.js Applications', () => {
     updateFile(
       `apps/${appName}/next.config.js`,
       `
-        const { withNx } = require('@nx/next/plugins/with-nx');
+        const { withNx } = require('@nx/next');
         const nextConfig = {
           nx: {
             svgr: false,
@@ -341,18 +341,32 @@ describe('Next.js Applications', () => {
     updateFile(
       `apps/${appName}/next.config.js`,
       `
-        const { withNx } = require('@nx/next/plugins/with-nx');
+        const { withNx } = require('@nx/next');
         // Not including "nx" entry should still work.
         const nextConfig = {};
 
         module.exports = withNx(nextConfig);
       `
     );
-
     rmDist();
     runCLI(`build ${appName}`);
-
     checkFilesExist(`dist/apps/${appName}/next.config.js`);
+
+    // Make sure withNx works with run-commands.
+    updateProjectConfig(appName, (json) => {
+      json.targets.build = {
+        command: 'npx next build',
+        outputs: [`apps/${appName}/.next`],
+        options: {
+          cwd: `apps/${appName}`,
+        },
+      };
+      return json;
+    });
+    expect(() => {
+      runCLI(`build ${appName}`);
+    }).not.toThrow();
+    checkFilesExist(`apps/${appName}/.next/build-manifest.json`);
   }, 300_000);
 
   it('should support --js flag', async () => {
@@ -421,7 +435,7 @@ describe('Next.js Applications', () => {
       checkUnitTest: false,
       checkLint: false,
       checkE2E: false,
-      checkExport: true,
+      checkExport: false,
     });
   }, 300_000);
 


### PR DESCRIPTION
This PR allows `withNx` plugin to be used without `@nx/next:build` or `@nx/next:server` executors. As long as the command runs through Nx we can read the run information (e.g. project node, options, config) from the project graph.

**Why?**

There are legit cases where users may not use `@nx/next:build` or other expected executors.

1. They wrap out `@nx/next:build` into their own custom plugin, say `@acme/next:build`.
2. They use `run-commands` to execute `npx next build` directly.

After some thought, they only special case is that `buildTarget` or `devServerTarget` may be present, which requires additional reading of those target configurations. These special cases could be `@nx/next:server` that specify `buildTarget`, which defines the `outputPath` for example. Or when Cypress defines a `devServerTarget`, which then defines a `buildTarget`, so we need to follow that target chain fully.

In all other cases, we can safely fallback to the default behavior, which is to return the configuration for the current target. This could be either `@nx/next:build`, `run-commands`, or a custom executor.

## Current Behavior
Using `run-commands` or `command` breaks with `withNx`.

## Expected Behavior
Using `run-commands` or `command` does not break with `withNx`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16064, #16277
