### PR TITLE
fix(core): cli option --graph should work with scoped package names

### DIFF
--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -400,9 +400,7 @@ export async function generateGraph(
     } else if (args.projects) {
       url.searchParams.append(
         'projects',
-        args.projects
-          .map((projectName) => encodeURIComponent(projectName))
-          .join(' ')
+        args.projects.map((projectName) => projectName).join(' ')
       );
     } else if (args.affected) {
       url.pathname += '/affected';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Running `nx build @scoped/package --graph` fails. This is because we use the URL class when building up our URL, but also manually invoke encodeURIComponent on the project names. We don't need to manually encode the URL, as the URL class handles that. 

This results in the `@` and `/` characters being encoded once by us, and then the `%` signs being encoded by the URL class which results in an invalid URL

## Expected Behavior
Running `nx build @scoped/package --graph` works

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
