### PR TITLE
fix(core): fix workspace validation for implicitDependencies that are…

### DIFF
--- a/packages/nx/src/utils/assert-workspace-validity.spec.ts
+++ b/packages/nx/src/utils/assert-workspace-validity.spec.ts
@@ -30,17 +30,18 @@ describe('assertWorkspaceValidity', () => {
 
   it('should throw for an invalid project-level implicit dependency', () => {
     mockWorkspaceJson.projects.app2.implicitDependencies = ['invalidproj'];
+    mockWorkspaceJson.projects.lib1.implicitDependencies = '*';
 
-    try {
-      assertWorkspaceValidity(mockWorkspaceJson, {});
-      fail('should not reach');
-    } catch (e) {
-      expect(e.message).toContain(
-        'The following implicitDependencies point to non-existent project(s)'
-      );
-      expect(e.message).toContain('invalidproj');
-      expect(e.message).toContain('invalidproj');
-    }
+    expect(() => assertWorkspaceValidity(mockWorkspaceJson, {}))
+      .toThrowErrorMatchingInlineSnapshot(`
+      "Configuration Error
+      The following implicitDependencies should be an array of strings:
+        lib1.implicitDependencies: "*"
+
+      The following implicitDependencies point to non-existent project(s):
+        app2
+          invalidproj"
+    `);
   });
 
   it('should throw for an invalid project-level implicit dependency with glob', () => {


### PR DESCRIPTION
… not arrays

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When a project is configured to use `'*'` or anything that is not an array as implicitDependencies, a cryptic error is thrown:

```
>  NX   desiredImplicitDeps.filter is not a function
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When a project is configured to use `'*'` or anything that is not an array as implicitDependencies, a clear error is thrown:

```
Configuration Error
  The following implicitDependencies should be an array of strings:
    lib1.implicitDependencies: "*"
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/17355
