### PR TITLE
fix(core): point to daemon logs when daemon closes unexpectedly

### DIFF
--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -238,6 +238,7 @@ export class DaemonClient {
             title: 'Daemon process terminated and closed the connection',
             bodyLines: [
               'Please rerun the command, which will restart the daemon.',
+              `If you get this error again, check for any errors in the daemon process logs found in: ${DAEMON_OUTPUT_LOG_FILE}`,
             ],
           });
           process.exit(1);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When an error causes the daemon to exit unexpectedly, the user gets an error when running their next command. This error doesn't really help, and just tells them to run the command again to restart the daemon.

## Expected Behavior
The error points to the daemon log, which can provide more useful information.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
