### PR TITLE
Update how-caching-works.md: .gitignore and .nxignore affect how fileset caching works

### DIFF
--- a/docs/shared/concepts/how-caching-works.md
+++ b/docs/shared/concepts/how-caching-works.md
@@ -90,6 +90,43 @@ dependencies. The test script will also consider the jest config file at the roo
 
 For more information about modifying `inputs` and `namedInputs` for your own repo, read [Customizing Inputs](/more-concepts/customizing-inputs)
 
+### Filesets
+
+By default a value in `inputs` refers to either a `namedInput` or a `fileset`.
+
+```json {% fileName="project.json"%}
+{
+  "targets": {
+    "some-target": {
+      "inputs": ["{workspaceRoot}/cache-file-input"]
+    }
+  }
+}
+```
+
+**is equivalent to**
+
+```json {% fileName="project.json"%}
+{
+  "targets": {
+    "some-target": {
+      "inputs": [{ "fileset": "{workspaceRoot}/cache-file-input" }]
+    }
+  }
+}
+```
+
+<!-- prettier-ignore-start -->
+{% callout type="note" title="Ignored Files" %}
+
+By default any file that is ignored by either a `.gitignore` or `.nxignore` file will not be considered
+as an input to the cache. 
+
+You could consider using a runtime hash input if a file ignored by one of these files is needed as an
+input to the hash.
+{% /callout %}
+<!-- prettier-ignore-end -->
+
 ## Runtime Hash Inputs
 
 Your targets can also depend on runtime values.


### PR DESCRIPTION
Add callout to mention filesets and namedInputs are the default values to a cache input and that any file ignored by .gitignore or .nxignore will not be considered as a cacheable input.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

filesets and their interaction with the .gitignore and .nxignore files are not mentioned anywhere in the docs that I could find other than here: https://github.com/nrwl/nx/blob/2941ddc6a2da13e8e373c423438c061eea52eda5/docs/shared/using-nx/affected.md?plain=1#L55

## Related Issue(s)

https://github.com/nrwl/nx/issues/16270
