### PR TITLE
chore(repo): bump webpack version

### DIFF
--- a/package.json
+++ b/package.json
@@ -267,7 +267,7 @@
     "use-sync-external-store": "^1.2.0",
     "verdaccio": "^5.0.4",
     "vite": "^4.3.4",
-    "webpack": "5.86.0",
+    "webpack": "5.88.0",
     "webpack-dev-server": "^4.9.3",
     "webpack-merge": "^5.8.0",
     "webpack-node-externals": "^3.0.0",

--- a/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
+++ b/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
@@ -109,6 +109,7 @@ export function executeWebpackBrowserBuilder(
               );
 
               baseWebpackConfig.plugins.push(
+                // @ts-expect-error - difference between angular and webpack plugin definitions bc of webpack versions
                 new WebpackNxBuildCoordinationPlugin(
                   `nx run-many --target=${
                     context.target.target

--- a/packages/angular/src/builders/webpack-dev-server/webpack-dev-server.impl.ts
+++ b/packages/angular/src/builders/webpack-dev-server/webpack-dev-server.impl.ts
@@ -129,6 +129,7 @@ export function executeWebpackDevServerBuilder(
             // This will occur when workspaceDependencies = []
             if (workspaceDependencies.length > 0) {
               baseWebpackConfig.plugins.push(
+                // @ts-expect-error - difference between angular and webpack plugin definitions bc of webpack versions
                 new WebpackNxBuildCoordinationPlugin(
                   `nx run-many --target=${
                     parsedBrowserTarget.target

--- a/packages/react/plugins/storybook/index.ts
+++ b/packages/react/plugins/storybook/index.ts
@@ -135,7 +135,7 @@ const fixBabelConfigurationIfNeeded = (
   let babelRuleItem;
   for (const rule of webpackConfig.module.rules) {
     if (typeof rule === 'string') continue;
-    if (!Array.isArray(rule.use)) continue;
+    if (!rule || !Array.isArray(rule.use)) continue;
     for (const item of rule.use) {
       if (typeof item !== 'string' && item['loader'].includes('babel-loader')) {
         babelRuleItem = item;
@@ -229,8 +229,8 @@ export const webpack = async (
       new DefinePlugin(
         getClientEnvironment(storybookWebpackConfig.mode).stringified
       ),
-      ...(storybookWebpackConfig.plugins ?? []),
-      ...(finalConfig.plugins ?? [])
+      ...((storybookWebpackConfig.plugins as WebpackPluginInstance[]) ?? []),
+      ...((finalConfig.plugins as WebpackPluginInstance[]) ?? [])
     ) as WebpackPluginInstance[],
   };
 };

--- a/packages/react/plugins/with-react.ts
+++ b/packages/react/plugins/with-react.ts
@@ -13,6 +13,7 @@ function addHotReload(config: Configuration) {
     // add `react-refresh/babel` to babel loader plugin
     const babelLoader = config.module.rules.find(
       (rule) =>
+        rule &&
         typeof rule !== 'string' &&
         rule.loader?.toString().includes('babel-loader')
     );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 overrides:
   minimist: ^1.2.6
   underscore: ^1.12.1
@@ -282,10 +278,10 @@ devDependencies:
     version: 16.5.0-beta.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(eslint@8.15.0)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)
   '@nx/next':
     specifier: 16.5.0-beta.0
-    version: 16.5.0-beta.0(@babel/core@7.19.0)(@swc-node/register@1.5.4)(@swc/core@1.3.51)(@types/express@4.17.14)(@types/node@18.16.9)(eslint@8.15.0)(file-loader@6.2.0)(next@13.3.4)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)(webpack@5.86.0)
+    version: 16.5.0-beta.0(@babel/core@7.19.0)(@swc-node/register@1.5.4)(@swc/core@1.3.51)(@types/express@4.17.14)(@types/node@18.16.9)(eslint@8.15.0)(file-loader@6.2.0)(next@13.3.4)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)(webpack@5.88.0)
   '@nx/react':
     specifier: 16.5.0-beta.0
-    version: 16.5.0-beta.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(eslint@8.15.0)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)(webpack@5.86.0)
+    version: 16.5.0-beta.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(eslint@8.15.0)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)(webpack@5.88.0)
   '@nx/storybook':
     specifier: 16.5.0-beta.0
     version: 16.5.0-beta.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(cypress@12.16.0)(eslint@8.15.0)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)
@@ -303,7 +299,7 @@ devDependencies:
     version: 5.0.1(typescript@5.1.3)
   '@pmmmwh/react-refresh-webpack-plugin':
     specifier: ^0.5.7
-    version: 0.5.8(react-refresh@0.10.0)(webpack-dev-server@4.11.1)(webpack@5.86.0)
+    version: 0.5.8(react-refresh@0.10.0)(webpack-dev-server@4.11.1)(webpack@5.88.0)
   '@pnpm/lockfile-types':
     specifier: ^5.0.0
     version: 5.0.0
@@ -369,7 +365,7 @@ devDependencies:
     version: 13.4.0(react-dom@18.2.0)(react@18.2.0)
   '@types/css-minimizer-webpack-plugin':
     specifier: ^3.2.1
-    version: 3.2.1(esbuild@0.17.5)(webpack@5.86.0)
+    version: 3.2.1(esbuild@0.17.5)(webpack@5.88.0)
   '@types/cytoscape':
     specifier: ^3.18.2
     version: 3.19.9
@@ -465,7 +461,7 @@ devDependencies:
     version: 29.4.3(@babel/core@7.19.0)
   babel-loader:
     specifier: ^9.1.2
-    version: 9.1.2(@babel/core@7.19.0)(webpack@5.86.0)
+    version: 9.1.2(@babel/core@7.19.0)(webpack@5.88.0)
   babel-plugin-transform-async-to-promises:
     specifier: ^0.8.15
     version: 0.8.18
@@ -495,10 +491,10 @@ devDependencies:
     version: 2.0.0
   copy-webpack-plugin:
     specifier: ^10.2.4
-    version: 10.2.4(webpack@5.86.0)
+    version: 10.2.4(webpack@5.88.0)
   css-minimizer-webpack-plugin:
     specifier: ^5.0.0
-    version: 5.0.0(esbuild@0.17.5)(webpack@5.86.0)
+    version: 5.0.0(esbuild@0.17.5)(webpack@5.88.0)
   cypress:
     specifier: 12.16.0
     version: 12.16.0
@@ -573,7 +569,7 @@ devDependencies:
     version: 3.2.0
   file-loader:
     specifier: ^6.2.0
-    version: 6.2.0(webpack@5.86.0)
+    version: 6.2.0(webpack@5.88.0)
   file-type:
     specifier: ^16.2.0
     version: 16.5.4
@@ -585,13 +581,13 @@ devDependencies:
     version: 5.0.2
   fork-ts-checker-webpack-plugin:
     specifier: 7.2.13
-    version: 7.2.13(typescript@5.1.3)(webpack@5.86.0)
+    version: 7.2.13(typescript@5.1.3)(webpack@5.88.0)
   fs-extra:
     specifier: ^11.1.0
     version: 11.1.0
   html-webpack-plugin:
     specifier: 5.5.0
-    version: 5.5.0(webpack@5.86.0)
+    version: 5.5.0(webpack@5.88.0)
   http-server:
     specifier: 14.1.0
     version: 14.1.0
@@ -663,10 +659,10 @@ devDependencies:
     version: 4.1.3
   less-loader:
     specifier: 11.1.0
-    version: 11.1.0(less@4.1.3)(webpack@5.86.0)
+    version: 11.1.0(less@4.1.3)(webpack@5.88.0)
   license-webpack-plugin:
     specifier: ^4.0.2
-    version: 4.0.2(webpack@5.86.0)
+    version: 4.0.2(webpack@5.88.0)
   lines-and-columns:
     specifier: ~2.0.3
     version: 2.0.3
@@ -687,7 +683,7 @@ devDependencies:
     version: 0.74.1
   mini-css-extract-plugin:
     specifier: ~2.4.7
-    version: 2.4.7(webpack@5.86.0)
+    version: 2.4.7(webpack@5.88.0)
   minimatch:
     specifier: 3.0.5
     version: 3.0.5
@@ -744,7 +740,7 @@ devDependencies:
     version: 3.1.3(prettier@2.7.1)
   raw-loader:
     specifier: ^4.0.2
-    version: 4.0.2(webpack@5.86.0)
+    version: 4.0.2(webpack@5.88.0)
   react-redux:
     specifier: 8.0.5
     version: 8.0.5(@types/react-dom@18.2.6)(@types/react@18.2.13)(react-dom@18.2.0)(react@18.2.0)(redux@4.2.0)
@@ -780,7 +776,7 @@ devDependencies:
     version: 1.55.0
   sass-loader:
     specifier: ^12.2.0
-    version: 12.6.0(sass@1.55.0)(webpack@5.86.0)
+    version: 12.6.0(sass@1.55.0)(webpack@5.88.0)
   semver:
     specifier: 7.5.3
     version: 7.5.3
@@ -789,7 +785,7 @@ devDependencies:
     version: 0.7.3
   source-map-loader:
     specifier: ^3.0.0
-    version: 3.0.2(webpack@5.86.0)
+    version: 3.0.2(webpack@5.88.0)
   source-map-support:
     specifier: 0.5.19
     version: 0.5.19
@@ -798,7 +794,7 @@ devDependencies:
     version: 3.0.0(react-dom@18.2.0)(react@18.2.0)
   style-loader:
     specifier: ^3.3.0
-    version: 3.3.1(webpack@5.86.0)
+    version: 3.3.1(webpack@5.88.0)
   styled-components:
     specifier: 5.3.6
     version: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
@@ -807,7 +803,7 @@ devDependencies:
     version: 0.59.0
   stylus-loader:
     specifier: 7.1.0
-    version: 7.1.0(stylus@0.59.0)(webpack@5.86.0)
+    version: 7.1.0(stylus@0.59.0)(webpack@5.88.0)
   tar-fs:
     specifier: ^2.1.1
     version: 2.1.1
@@ -819,7 +815,7 @@ devDependencies:
     version: 1.0.2
   terser-webpack-plugin:
     specifier: ^5.3.3
-    version: 5.3.6(@swc/core@1.3.51)(esbuild@0.17.5)(webpack@5.86.0)
+    version: 5.3.6(@swc/core@1.3.51)(esbuild@0.17.5)(webpack@5.88.0)
   tmp:
     specifier: ~0.2.1
     version: 0.2.1
@@ -831,7 +827,7 @@ devDependencies:
     version: 29.1.0(@babel/core@7.19.0)(@jest/types@29.5.0)(babel-jest@29.4.3)(esbuild@0.17.5)(jest@29.4.3)(typescript@5.1.3)
   ts-loader:
     specifier: ^9.3.1
-    version: 9.4.1(typescript@5.1.3)(webpack@5.86.0)
+    version: 9.4.1(typescript@5.1.3)(webpack@5.88.0)
   ts-node:
     specifier: 10.9.1
     version: 10.9.1(@swc/core@1.3.51)(@types/node@18.16.9)(typescript@5.1.3)
@@ -858,7 +854,7 @@ devDependencies:
     version: 0.10.11
   url-loader:
     specifier: ^4.1.1
-    version: 4.1.1(file-loader@6.2.0)(webpack@5.86.0)
+    version: 4.1.1(file-loader@6.2.0)(webpack@5.88.0)
   use-sync-external-store:
     specifier: ^1.2.0
     version: 1.2.0(react@18.2.0)
@@ -869,11 +865,11 @@ devDependencies:
     specifier: ^4.3.4
     version: 4.3.4(@types/node@18.16.9)(less@4.1.3)(sass@1.55.0)(stylus@0.59.0)
   webpack:
-    specifier: 5.86.0
-    version: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.5)
+    specifier: 5.88.0
+    version: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
   webpack-dev-server:
     specifier: ^4.9.3
-    version: 4.11.1(webpack@5.86.0)
+    version: 4.11.1(webpack@5.88.0)
   webpack-merge:
     specifier: ^5.8.0
     version: 5.8.0
@@ -885,7 +881,7 @@ devDependencies:
     version: 3.2.3
   webpack-subresource-integrity:
     specifier: ^5.1.0
-    version: 5.1.0(html-webpack-plugin@5.5.0)(webpack@5.86.0)
+    version: 5.1.0(html-webpack-plugin@5.5.0)(webpack@5.88.0)
   xstate:
     specifier: 4.34.0
     version: 4.34.0
@@ -5745,7 +5741,7 @@ packages:
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       jest-haste-map: 29.5.0
       jest-regex-util: 29.4.3
       jest-util: 29.5.0
@@ -5805,7 +5801,6 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.18
-    dev: true
 
   /@jridgewell/sourcemap-codec@1.4.14:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
@@ -6888,42 +6883,6 @@ packages:
       - typescript
     dev: true
 
-  /@nrwl/js@15.8.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(nx@15.8.0)(prettier@2.7.1)(typescript@5.1.3):
-    resolution: {integrity: sha512-l2Q7oFpzx6ul7G0nKpMkrvnIEaOY+X8fc2g2Db5WqpnnBdfkrtWXZPg/O4DQ1p9O6BXrZ+Q2AK9bfgnliiwyEg==}
-    dependencies:
-      '@babel/core': 7.22.5
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.22.5)
-      '@babel/plugin-proposal-decorators': 7.21.0(@babel/core@7.22.5)
-      '@babel/plugin-transform-runtime': 7.22.5(@babel/core@7.22.5)
-      '@babel/preset-env': 7.22.5(@babel/core@7.22.5)
-      '@babel/preset-typescript': 7.21.4(@babel/core@7.22.5)
-      '@babel/runtime': 7.22.5
-      '@nrwl/devkit': 15.8.0(nx@15.8.0)(typescript@5.1.3)
-      '@nrwl/workspace': 15.8.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(eslint@8.15.0)(prettier@2.7.1)(typescript@5.1.3)
-      '@phenomnomnominal/tsquery': 4.1.1(typescript@5.1.3)
-      babel-plugin-const-enum: 1.2.0(@babel/core@7.22.5)
-      babel-plugin-macros: 2.8.0
-      babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.22.5)
-      chalk: 4.1.2
-      fast-glob: 3.2.7
-      fs-extra: 11.1.1
-      ignore: 5.2.0
-      js-tokens: 4.0.0
-      minimatch: 3.0.5
-      source-map-support: 0.5.19
-      tree-kill: 1.2.2
-      tslib: 2.5.3
-    transitivePeerDependencies:
-      - '@babel/traverse'
-      - '@swc-node/register'
-      - '@swc/core'
-      - debug
-      - nx
-      - prettier
-      - supports-color
-      - typescript
-    dev: true
-
   /@nrwl/js@16.5.0-beta.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4):
     resolution: {integrity: sha512-pEOPv/atGYWoP+AetXxQ5Is1TBakWPFUDSUw2IZXIhQtulkSNYs3DTQLGZdTHXc5voh4o/FScrbKL6ayCjdwAw==}
     dependencies:
@@ -6948,7 +6907,7 @@ packages:
         optional: true
     dependencies:
       '@nrwl/devkit': 15.8.0(nx@15.8.0)(typescript@5.1.3)
-      '@nrwl/js': 15.8.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(nx@15.8.0)(prettier@2.7.1)(typescript@5.1.3)
+      '@nrwl/js': 15.8.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(eslint@8.15.0)(nx@16.5.0-beta.0)(prettier@2.7.1)(typescript@5.1.3)
       '@phenomnomnominal/tsquery': 4.1.1(typescript@5.1.3)
       eslint: 8.15.0
       tmp: 0.2.1
@@ -6980,10 +6939,10 @@ packages:
       - verdaccio
     dev: true
 
-  /@nrwl/next@16.5.0-beta.0(@babel/core@7.19.0)(@swc-node/register@1.5.4)(@swc/core@1.3.51)(@types/express@4.17.14)(@types/node@18.16.9)(eslint@8.15.0)(file-loader@6.2.0)(next@13.3.4)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)(webpack@5.86.0):
+  /@nrwl/next@16.5.0-beta.0(@babel/core@7.19.0)(@swc-node/register@1.5.4)(@swc/core@1.3.51)(@types/express@4.17.14)(@types/node@18.16.9)(eslint@8.15.0)(file-loader@6.2.0)(next@13.3.4)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)(webpack@5.88.0):
     resolution: {integrity: sha512-9V9rKDgVEecoIiKapxl2Mrq4LozOn9Wnq+4+vSRuHWByCf6GJfRDTXNlLCt74oO7KlPjKdwUYSVDXle4yZLgew==}
     dependencies:
-      '@nx/next': 16.5.0-beta.0(@babel/core@7.19.0)(@swc-node/register@1.5.4)(@swc/core@1.3.51)(@types/express@4.17.14)(@types/node@18.16.9)(eslint@8.15.0)(file-loader@6.2.0)(next@13.3.4)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)(webpack@5.86.0)
+      '@nx/next': 16.5.0-beta.0(@babel/core@7.19.0)(@swc-node/register@1.5.4)(@swc/core@1.3.51)(@types/express@4.17.14)(@types/node@18.16.9)(eslint@8.15.0)(file-loader@6.2.0)(next@13.3.4)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)(webpack@5.88.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/traverse'
@@ -7173,10 +7132,10 @@ packages:
     dev: true
     optional: true
 
-  /@nrwl/react@16.5.0-beta.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(eslint@8.15.0)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)(webpack@5.86.0):
+  /@nrwl/react@16.5.0-beta.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(eslint@8.15.0)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)(webpack@5.88.0):
     resolution: {integrity: sha512-l0t35KfOm7hy62RMY1DvwR58hifLATp8y0clNDmWEqMyuKktERs+TUZ1B07BLJeaVDZQutyY7zBgAa+a76bTog==}
     dependencies:
-      '@nx/react': 16.5.0-beta.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(eslint@8.15.0)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)(webpack@5.86.0)
+      '@nx/react': 16.5.0-beta.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(eslint@8.15.0)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)(webpack@5.88.0)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -7525,22 +7484,22 @@ packages:
       - verdaccio
     dev: true
 
-  /@nx/next@16.5.0-beta.0(@babel/core@7.19.0)(@swc-node/register@1.5.4)(@swc/core@1.3.51)(@types/express@4.17.14)(@types/node@18.16.9)(eslint@8.15.0)(file-loader@6.2.0)(next@13.3.4)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)(webpack@5.86.0):
+  /@nx/next@16.5.0-beta.0(@babel/core@7.19.0)(@swc-node/register@1.5.4)(@swc/core@1.3.51)(@types/express@4.17.14)(@types/node@18.16.9)(eslint@8.15.0)(file-loader@6.2.0)(next@13.3.4)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)(webpack@5.88.0):
     resolution: {integrity: sha512-4ut8Bd4xJaHvNEcb5iWzoTMLfDkZFZ+qr4KIR062CeJJtzII2GfKIrDbaGElUY3PyaEWxIlPfQbok+UHq/npAg==}
     peerDependencies:
       next: '>=13.0.0'
     dependencies:
       '@babel/plugin-proposal-decorators': 7.21.0(@babel/core@7.19.0)
-      '@nrwl/next': 16.5.0-beta.0(@babel/core@7.19.0)(@swc-node/register@1.5.4)(@swc/core@1.3.51)(@types/express@4.17.14)(@types/node@18.16.9)(eslint@8.15.0)(file-loader@6.2.0)(next@13.3.4)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)(webpack@5.86.0)
+      '@nrwl/next': 16.5.0-beta.0(@babel/core@7.19.0)(@swc-node/register@1.5.4)(@swc/core@1.3.51)(@types/express@4.17.14)(@types/node@18.16.9)(eslint@8.15.0)(file-loader@6.2.0)(next@13.3.4)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)(webpack@5.88.0)
       '@nx/devkit': 16.5.0-beta.0(nx@16.5.0-beta.0)
       '@nx/js': 16.5.0-beta.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)
       '@nx/linter': 16.5.0-beta.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(eslint@8.15.0)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)
-      '@nx/react': 16.5.0-beta.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(eslint@8.15.0)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)(webpack@5.86.0)
+      '@nx/react': 16.5.0-beta.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(eslint@8.15.0)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)(webpack@5.88.0)
       '@nx/web': 16.5.0-beta.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)
       '@nx/workspace': 16.5.0-beta.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)
       '@svgr/webpack': 8.0.1
       chalk: 4.1.2
-      copy-webpack-plugin: 10.2.4(webpack@5.86.0)
+      copy-webpack-plugin: 10.2.4(webpack@5.88.0)
       dotenv: 10.0.0
       express: 4.18.2
       fs-extra: 11.1.1
@@ -7550,7 +7509,7 @@ packages:
       semver: 7.5.3
       ts-node: 10.9.1(@swc/core@1.3.51)(@types/node@18.16.9)(typescript@5.1.3)
       tsconfig-paths: 4.1.2
-      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.86.0)
+      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.88.0)
       webpack-merge: 5.9.0
     transitivePeerDependencies:
       - '@babel/core'
@@ -7660,10 +7619,10 @@ packages:
     dev: true
     optional: true
 
-  /@nx/react@16.5.0-beta.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(eslint@8.15.0)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)(webpack@5.86.0):
+  /@nx/react@16.5.0-beta.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(eslint@8.15.0)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)(webpack@5.88.0):
     resolution: {integrity: sha512-6oxmI6mnU8U6NVtqntPJ7o3sY5QcyOyimi/Y9uJ5E2ly+D63m9bNN/Ko8iiR5dZptA45NYDoJKrBUE/zc1ct8g==}
     dependencies:
-      '@nrwl/react': 16.5.0-beta.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(eslint@8.15.0)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)(webpack@5.86.0)
+      '@nrwl/react': 16.5.0-beta.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(eslint@8.15.0)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)(webpack@5.88.0)
       '@nx/devkit': 16.5.0-beta.0(nx@16.5.0-beta.0)
       '@nx/js': 16.5.0-beta.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)
       '@nx/linter': 16.5.0-beta.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(eslint@8.15.0)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)
@@ -7671,7 +7630,7 @@ packages:
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.1.3)
       '@svgr/webpack': 8.0.1
       chalk: 4.1.2
-      file-loader: 6.2.0(webpack@5.86.0)
+      file-loader: 6.2.0(webpack@5.88.0)
       minimatch: 3.0.5
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -7742,42 +7701,42 @@ packages:
       '@nx/devkit': 16.5.0-beta.0(nx@16.5.0-beta.0)
       '@nx/js': 16.5.0-beta.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4)
       autoprefixer: 10.4.13(postcss@8.4.19)
-      babel-loader: 9.1.2(@babel/core@7.22.5)(webpack@5.86.0)
+      babel-loader: 9.1.2(@babel/core@7.22.5)(webpack@5.88.0)
       browserslist: 4.21.7
       chalk: 4.1.2
       chokidar: 3.5.3
-      copy-webpack-plugin: 10.2.4(webpack@5.86.0)
-      css-loader: 6.8.1(webpack@5.86.0)
-      css-minimizer-webpack-plugin: 5.0.0(esbuild@0.17.5)(webpack@5.86.0)
+      copy-webpack-plugin: 10.2.4(webpack@5.88.0)
+      css-loader: 6.8.1(webpack@5.88.0)
+      css-minimizer-webpack-plugin: 5.0.0(esbuild@0.17.5)(webpack@5.88.0)
       dotenv: 10.0.0
-      fork-ts-checker-webpack-plugin: 7.2.13(typescript@5.1.3)(webpack@5.86.0)
+      fork-ts-checker-webpack-plugin: 7.2.13(typescript@5.1.3)(webpack@5.88.0)
       ignore: 5.2.0
       less: 4.1.3
-      less-loader: 11.1.0(less@4.1.3)(webpack@5.86.0)
-      license-webpack-plugin: 4.0.2(webpack@5.86.0)
+      less-loader: 11.1.0(less@4.1.3)(webpack@5.88.0)
+      license-webpack-plugin: 4.0.2(webpack@5.88.0)
       loader-utils: 2.0.3
-      mini-css-extract-plugin: 2.4.7(webpack@5.86.0)
+      mini-css-extract-plugin: 2.4.7(webpack@5.88.0)
       parse5: 4.0.0
       postcss: 8.4.19
       postcss-import: 14.1.0(postcss@8.4.19)
-      postcss-loader: 6.2.1(postcss@8.4.19)(webpack@5.86.0)
+      postcss-loader: 6.2.1(postcss@8.4.19)(webpack@5.88.0)
       rxjs: 7.8.1
       sass: 1.55.0
-      sass-loader: 12.6.0(sass@1.55.0)(webpack@5.86.0)
-      source-map-loader: 3.0.2(webpack@5.86.0)
-      style-loader: 3.3.1(webpack@5.86.0)
+      sass-loader: 12.6.0(sass@1.55.0)(webpack@5.88.0)
+      source-map-loader: 3.0.2(webpack@5.88.0)
+      style-loader: 3.3.1(webpack@5.88.0)
       stylus: 0.59.0
-      stylus-loader: 7.1.0(stylus@0.59.0)(webpack@5.86.0)
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.51)(esbuild@0.17.5)(webpack@5.86.0)
-      ts-loader: 9.4.1(typescript@5.1.3)(webpack@5.86.0)
+      stylus-loader: 7.1.0(stylus@0.59.0)(webpack@5.88.0)
+      terser-webpack-plugin: 5.3.9(@swc/core@1.3.51)(esbuild@0.17.5)(webpack@5.88.0)
+      ts-loader: 9.4.1(typescript@5.1.3)(webpack@5.88.0)
       ts-node: 10.9.1(@swc/core@1.3.51)(@types/node@18.16.9)(typescript@5.1.3)
       tsconfig-paths: 4.1.2
       tsconfig-paths-webpack-plugin: 4.0.0
       tslib: 2.5.3
-      webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.5)
-      webpack-dev-server: 4.15.0(webpack@5.86.0)
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
+      webpack-dev-server: 4.15.0(webpack@5.88.0)
       webpack-node-externals: 3.0.0
-      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.5.0)(webpack@5.86.0)
+      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.5.0)(webpack@5.88.0)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@parcel/css'
@@ -8209,7 +8168,7 @@ packages:
       tslib: 2.5.3
     dev: true
 
-  /@pmmmwh/react-refresh-webpack-plugin@0.5.10(react-refresh@0.11.0)(webpack-dev-server@4.11.1)(webpack@5.86.0):
+  /@pmmmwh/react-refresh-webpack-plugin@0.5.10(react-refresh@0.11.0)(webpack-dev-server@4.11.1)(webpack@5.88.0):
     resolution: {integrity: sha512-j0Ya0hCFZPd4x40qLzbhGsh9TMtdb+CJQiso+WxLOPNasohq9cc5SNUcwsZaRH6++Xh91Xkm/xHCkuIiIu0LUA==}
     engines: {node: '>= 10.13'}
     peerDependencies:
@@ -8245,11 +8204,11 @@ packages:
       react-refresh: 0.11.0
       schema-utils: 3.2.0
       source-map: 0.7.3
-      webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.5)
-      webpack-dev-server: 4.11.1(webpack@5.86.0)
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
+      webpack-dev-server: 4.11.1(webpack@5.88.0)
     dev: true
 
-  /@pmmmwh/react-refresh-webpack-plugin@0.5.8(react-refresh@0.10.0)(webpack-dev-server@4.11.1)(webpack@5.86.0):
+  /@pmmmwh/react-refresh-webpack-plugin@0.5.8(react-refresh@0.10.0)(webpack-dev-server@4.11.1)(webpack@5.88.0):
     resolution: {integrity: sha512-wxXRwf+IQ6zvHSJZ+5T2RQNEsq+kx4jKRXfFvdt3nBIUzJUAvXEFsUeoaohDe/Kr84MTjGwcuIUPNcstNJORsA==}
     engines: {node: '>= 10.13'}
     peerDependencies:
@@ -8285,8 +8244,8 @@ packages:
       react-refresh: 0.10.0
       schema-utils: 3.1.2
       source-map: 0.7.4
-      webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.5)
-      webpack-dev-server: 4.11.1(webpack@5.86.0)
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
+      webpack-dev-server: 4.11.1(webpack@5.88.0)
     dev: true
 
   /@pnpm/lockfile-types@5.0.0:
@@ -8929,28 +8888,28 @@ packages:
       '@storybook/theming': 7.0.24(react-dom@18.2.0)(react@18.2.0)
       '@types/node': 16.18.36
       '@types/semver': 7.5.0
-      babel-loader: 9.1.2(@babel/core@7.22.5)(webpack@5.86.0)
+      babel-loader: 9.1.2(@babel/core@7.22.5)(webpack@5.88.0)
       babel-plugin-named-exports-order: 0.0.2
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
-      css-loader: 6.8.1(webpack@5.86.0)
+      css-loader: 6.8.1(webpack@5.88.0)
       express: 4.18.2
-      fork-ts-checker-webpack-plugin: 7.2.13(typescript@5.1.3)(webpack@5.86.0)
+      fork-ts-checker-webpack-plugin: 7.2.13(typescript@5.1.3)(webpack@5.88.0)
       fs-extra: 11.1.1
-      html-webpack-plugin: 5.5.0(webpack@5.86.0)
+      html-webpack-plugin: 5.5.0(webpack@5.88.0)
       path-browserify: 1.0.1
       process: 0.11.10
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       semver: 7.5.3
-      style-loader: 3.3.1(webpack@5.86.0)
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.51)(esbuild@0.17.5)(webpack@5.86.0)
+      style-loader: 3.3.1(webpack@5.88.0)
+      terser-webpack-plugin: 5.3.9(@swc/core@1.3.51)(esbuild@0.17.5)(webpack@5.88.0)
       ts-dedent: 2.2.0
       typescript: 5.1.3
       util: 0.12.5
       util-deprecate: 1.0.2
-      webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.5)
-      webpack-dev-middleware: 5.3.3(webpack@5.86.0)
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
+      webpack-dev-middleware: 5.3.3(webpack@5.88.0)
       webpack-hot-middleware: 2.25.3
       webpack-virtual-modules: 0.4.6
     transitivePeerDependencies:
@@ -9317,12 +9276,12 @@ packages:
       '@babel/core': 7.19.0
       '@babel/preset-flow': 7.21.4(@babel/core@7.19.0)
       '@babel/preset-react': 7.18.6(@babel/core@7.19.0)
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.10(react-refresh@0.11.0)(webpack-dev-server@4.11.1)(webpack@5.86.0)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.10(react-refresh@0.11.0)(webpack-dev-server@4.11.1)(webpack@5.88.0)
       '@storybook/core-webpack': 7.0.24
       '@storybook/docs-tools': 7.0.24
       '@storybook/node-logger': 7.0.24
       '@storybook/react': 7.0.24(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.1.3)(webpack@5.86.0)
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.1.3)(webpack@5.88.0)
       '@types/node': 16.18.36
       '@types/semver': 7.5.0
       babel-plugin-add-react-displayname: 0.0.5
@@ -9333,7 +9292,7 @@ packages:
       react-refresh: 0.11.0
       semver: 7.5.3
       typescript: 5.1.3
-      webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.5)
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
     transitivePeerDependencies:
       - '@swc/core'
       - '@types/webpack'
@@ -9393,7 +9352,7 @@ packages:
     resolution: {integrity: sha512-rej4Wz8Qy4gVuyvg4cpQGkR4wJc3b+0Uv6EYylbmpdj2585cOhFtRBykagDVZteVU4xaLMT7YHIZRnoLmJKIgw==}
     dev: true
 
-  /@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.1.3)(webpack@5.86.0):
+  /@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.1.3)(webpack@5.88.0):
     resolution: {integrity: sha512-KUqXC3oa9JuQ0kZJLBhVdS4lOneKTOopnNBK4tUAgoxWQ3u/IjzdueZjFr7gyBrXMoU6duutk3RQR9u8ZpYJ4Q==}
     peerDependencies:
       typescript: '>= 4.x'
@@ -9407,7 +9366,7 @@ packages:
       react-docgen-typescript: 2.2.2(typescript@5.1.3)
       tslib: 2.5.3
       typescript: 5.1.3
-      webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.5)
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10158,11 +10117,11 @@ packages:
       '@types/node': 18.16.9
     dev: true
 
-  /@types/css-minimizer-webpack-plugin@3.2.1(esbuild@0.17.5)(webpack@5.86.0):
+  /@types/css-minimizer-webpack-plugin@3.2.1(esbuild@0.17.5)(webpack@5.88.0):
     resolution: {integrity: sha512-MIlnEVQDTX0Y1/ZBY0RyD+F6+ZHlG42qCeSoCVhxI5N1atm+RnmDLQWUCWrdNqebFozUTRLDZJ04v5aYzGG5CA==}
     deprecated: This is a stub types definition. css-minimizer-webpack-plugin provides its own type definitions, so you do not need this installed.
     dependencies:
-      css-minimizer-webpack-plugin: 5.0.0(esbuild@0.17.5)(webpack@5.86.0)
+      css-minimizer-webpack-plugin: 5.0.0(esbuild@0.17.5)(webpack@5.88.0)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/css'
@@ -12001,7 +11960,7 @@ packages:
       - supports-color
     dev: true
 
-  /babel-loader@9.1.2(@babel/core@7.19.0)(webpack@5.86.0):
+  /babel-loader@9.1.2(@babel/core@7.19.0)(webpack@5.88.0):
     resolution: {integrity: sha512-mN14niXW43tddohGl8HPu5yfQq70iUThvFL/4QzESA7GcZoC0eVOhvWdQ8+3UlSjaDE9MVtsW9mxDY07W7VpVA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -12011,7 +11970,7 @@ packages:
       '@babel/core': 7.19.0
       find-cache-dir: 3.3.2
       schema-utils: 4.0.0
-      webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.5)
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
     dev: true
 
   /babel-loader@9.1.2(@babel/core@7.22.5)(webpack@5.86.0):
@@ -12025,6 +11984,19 @@ packages:
       find-cache-dir: 3.3.2
       schema-utils: 4.0.0
       webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.19)
+    dev: true
+
+  /babel-loader@9.1.2(@babel/core@7.22.5)(webpack@5.88.0):
+    resolution: {integrity: sha512-mN14niXW43tddohGl8HPu5yfQq70iUThvFL/4QzESA7GcZoC0eVOhvWdQ8+3UlSjaDE9MVtsW9mxDY07W7VpVA==}
+    engines: {node: '>= 14.15.0'}
+    peerDependencies:
+      '@babel/core': ^7.12.0
+      webpack: '>=5'
+    dependencies:
+      '@babel/core': 7.22.5
+      find-cache-dir: 3.3.2
+      schema-utils: 4.0.0
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
     dev: true
 
   /babel-plugin-add-react-displayname@0.0.5:
@@ -12661,7 +12633,6 @@ packages:
 
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
-    dev: true
 
   /buffer-indexof-polyfill@1.0.2:
     resolution: {integrity: sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==}
@@ -13234,7 +13205,6 @@ packages:
 
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
-    dev: true
 
   /commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -13624,7 +13594,7 @@ packages:
       toggle-selection: 1.0.6
     dev: false
 
-  /copy-webpack-plugin@10.2.4(webpack@5.86.0):
+  /copy-webpack-plugin@10.2.4(webpack@5.88.0):
     resolution: {integrity: sha512-xFVltahqlsRcyyJqQbDY6EYTtyQZF9rf+JPjwHObLdPFMEISqkFkr7mFoVOC6BfYS/dNThyoQKvziugm+OnwBg==}
     engines: {node: '>= 12.20.0'}
     peerDependencies:
@@ -13636,7 +13606,7 @@ packages:
       normalize-path: 3.0.0
       schema-utils: 4.0.0
       serialize-javascript: 6.0.1
-      webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.5)
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
     dev: true
 
   /copy-webpack-plugin@11.0.0(webpack@5.86.0):
@@ -13846,7 +13816,24 @@ packages:
       webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.19)
     dev: true
 
-  /css-minimizer-webpack-plugin@5.0.0(esbuild@0.17.5)(webpack@5.86.0):
+  /css-loader@6.8.1(webpack@5.88.0):
+    resolution: {integrity: sha512-xDAXtEVGlD0gJ07iclwWVkLoZOpEvAWaSyf6W18S2pOC//K8+qUDIx8IIT3D+HjnmkJPQeesOPv5aiUaJsCM2g==}
+    engines: {node: '>= 12.13.0'}
+    peerDependencies:
+      webpack: ^5.0.0
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.4.24)
+      postcss: 8.4.24
+      postcss-modules-extract-imports: 3.0.0(postcss@8.4.24)
+      postcss-modules-local-by-default: 4.0.3(postcss@8.4.24)
+      postcss-modules-scope: 3.0.0(postcss@8.4.24)
+      postcss-modules-values: 4.0.0(postcss@8.4.24)
+      postcss-value-parser: 4.2.0
+      semver: 7.5.3
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
+    dev: true
+
+  /css-minimizer-webpack-plugin@5.0.0(esbuild@0.17.5)(webpack@5.88.0):
     resolution: {integrity: sha512-1wZ/PYvg+ZKwi5FX6YrvbB31jMAdurS+CmRQLwWCVSlfzJC85l/a6RVICqUHFa+jXyhilfnCyjafzJGbmz5tcA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -13878,7 +13865,7 @@ packages:
       schema-utils: 4.0.1
       serialize-javascript: 6.0.1
       source-map: 0.6.1
-      webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.5)
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
     dev: true
 
   /css-prefers-color-scheme@6.0.3(postcss@8.4.19):
@@ -15936,7 +15923,7 @@ packages:
       flat-cache: 3.0.4
     dev: true
 
-  /file-loader@6.2.0(webpack@5.86.0):
+  /file-loader@6.2.0(webpack@5.88.0):
     resolution: {integrity: sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -15944,7 +15931,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.2
-      webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.5)
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
     dev: true
 
   /file-system-cache@2.3.0:
@@ -16130,7 +16117,7 @@ packages:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
     dev: true
 
-  /fork-ts-checker-webpack-plugin@7.2.13(typescript@5.1.3)(webpack@5.86.0):
+  /fork-ts-checker-webpack-plugin@7.2.13(typescript@5.1.3)(webpack@5.88.0):
     resolution: {integrity: sha512-fR3WRkOb4bQdWB/y7ssDUlVdrclvwtyCUIHCfivAoYxq9dF7XfrDKbMdZIfwJ7hxIAqkYSGeU7lLJE6xrxIBdg==}
     engines: {node: '>=12.13.0', yarn: '>=1.0.0'}
     peerDependencies:
@@ -16154,7 +16141,7 @@ packages:
       semver: 7.5.3
       tapable: 2.2.1
       typescript: 5.1.3
-      webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.5)
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
     dev: true
 
   /fork-ts-checker-webpack-plugin@7.2.14(typescript@4.9.4)(webpack@5.75.0):
@@ -17047,7 +17034,7 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /html-webpack-plugin@5.5.0(webpack@5.86.0):
+  /html-webpack-plugin@5.5.0(webpack@5.88.0):
     resolution: {integrity: sha512-sy88PC2cRTVxvETRgUHFrL4No3UxvcH8G1NepGhqaTT+GXN2kTamqasot0inS5hXeg1cMbFDt27zzo9p35lZVw==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
@@ -17058,7 +17045,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.5)
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
     dev: true
 
   /htmlparser2@6.1.0:
@@ -18241,7 +18228,7 @@ packages:
       '@jest/types': 29.5.0
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       micromatch: 4.0.5
       pretty-format: 29.5.0
       slash: 3.0.0
@@ -19017,7 +19004,19 @@ packages:
     dependencies:
       klona: 2.0.5
       less: 4.1.3
-      webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.5)
+      webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.19)
+    dev: true
+
+  /less-loader@11.1.0(less@4.1.3)(webpack@5.88.0):
+    resolution: {integrity: sha512-C+uDBV7kS7W5fJlUjq5mPBeBVhYpTIm5gB09APT9o3n/ILeaXVsiSFTbZpTJCJwQ/Crczfn3DmfQFwxYusWFug==}
+    engines: {node: '>= 14.15.0'}
+    peerDependencies:
+      less: ^3.5.0 || ^4.0.0
+      webpack: ^5.0.0
+    dependencies:
+      klona: 2.0.5
+      less: 4.1.3
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
     dev: true
 
   /less@4.1.3:
@@ -19117,7 +19116,21 @@ packages:
       webpack-sources:
         optional: true
     dependencies:
-      webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.5)
+      webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.19)
+      webpack-sources: 3.2.3
+    dev: true
+
+  /license-webpack-plugin@4.0.2(webpack@5.88.0):
+    resolution: {integrity: sha512-771TFWFD70G1wLTC4oU2Cw4qvtmNrIw+wRvBtn+okgHl7slJVi7zfNcdmqDL72BojM30VNJ2UHylr1o77U37Jw==}
+    peerDependencies:
+      webpack: '*'
+    peerDependenciesMeta:
+      webpack:
+        optional: true
+      webpack-sources:
+        optional: true
+    dependencies:
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
       webpack-sources: 3.2.3
     dev: true
 
@@ -19753,14 +19766,14 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /mini-css-extract-plugin@2.4.7(webpack@5.86.0):
+  /mini-css-extract-plugin@2.4.7(webpack@5.88.0):
     resolution: {integrity: sha512-euWmddf0sk9Nv1O0gfeeUAvAkoSlWncNLF77C0TP2+WoPvy8mAHKOzMajcCz2dzvyt3CNgxb1obIEVFIRxaipg==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
       schema-utils: 4.0.0
-      webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.5)
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
     dev: true
 
   /mini-css-extract-plugin@2.7.6(webpack@5.86.0):
@@ -21931,7 +21944,7 @@ packages:
       ts-node: 10.9.1(@swc/core@1.3.51)(@types/node@18.16.9)(typescript@5.1.3)
       yaml: 1.10.2
 
-  /postcss-loader@6.2.1(postcss@8.4.19)(webpack@5.86.0):
+  /postcss-loader@6.2.1(postcss@8.4.19)(webpack@5.88.0):
     resolution: {integrity: sha512-WbbYpmAaKcux/P66bZ40bpWsBucjx/TTgVVzRZ9yUO8yQfVBlameJ0ZGVaPfH64hNSBh63a+ICP5nqOpBA0w+Q==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -21942,7 +21955,7 @@ packages:
       klona: 2.0.6
       postcss: 8.4.19
       semver: 7.5.3
-      webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.5)
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
     dev: true
 
   /postcss-loader@7.3.2(postcss@8.4.24)(webpack@5.86.0):
@@ -23014,7 +23027,7 @@ packages:
       unpipe: 1.0.0
     dev: true
 
-  /raw-loader@4.0.2(webpack@5.86.0):
+  /raw-loader@4.0.2(webpack@5.88.0):
     resolution: {integrity: sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -23022,7 +23035,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.2
-      webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.5)
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
     dev: true
 
   /react-colorful@5.6.1(react-dom@18.2.0)(react@18.2.0):
@@ -23887,7 +23900,7 @@ packages:
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  /sass-loader@12.6.0(sass@1.55.0)(webpack@5.86.0):
+  /sass-loader@12.6.0(sass@1.55.0)(webpack@5.88.0):
     resolution: {integrity: sha512-oLTaH0YCtX4cfnJZxKSLAyglED0naiYfNG1iXfU5w1LNZ+ukoA5DtyDIN5zmKVZwYNJP4KRc5Y3hkWga+7tYfA==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -23909,7 +23922,7 @@ packages:
       klona: 2.0.5
       neo-async: 2.6.2
       sass: 1.55.0
-      webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.5)
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
     dev: true
 
   /sass-loader@13.3.1(sass@1.63.2)(webpack@5.86.0):
@@ -23964,7 +23977,6 @@ packages:
       chokidar: 3.5.3
       immutable: 4.1.0
       source-map-js: 1.0.2
-    dev: true
 
   /sax@1.2.4:
     resolution: {integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==}
@@ -24518,7 +24530,7 @@ packages:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
 
-  /source-map-loader@3.0.2(webpack@5.86.0):
+  /source-map-loader@3.0.2(webpack@5.88.0):
     resolution: {integrity: sha512-BokxPoLjyl3iOrgkWaakaxqnelAJSS+0V+De0kKIq6lyWrXuiPgYTGp6z3iHmqljKAaLXwZa+ctD8GccRJeVvg==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -24527,7 +24539,7 @@ packages:
       abab: 2.0.6
       iconv-lite: 0.6.3
       source-map-js: 1.0.2
-      webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.5)
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
     dev: true
 
   /source-map-loader@4.0.1(webpack@5.86.0):
@@ -24561,7 +24573,6 @@ packages:
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1
-    dev: true
 
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
@@ -24959,13 +24970,13 @@ packages:
     resolution: {integrity: sha512-IezA2qp+vcdlhJaVm5SOdPPTUu0FCEqfNSli2vRuSIBbu5Nq5UvygTk/VzeCqfLz2Atj3dVII5QBKGZRZ0edzw==}
     dev: true
 
-  /style-loader@3.3.1(webpack@5.86.0):
+  /style-loader@3.3.1(webpack@5.88.0):
     resolution: {integrity: sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.5)
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
     dev: true
 
   /style-value-types@4.1.4:
@@ -25038,7 +25049,7 @@ packages:
       postcss-selector-parser: 6.0.11
     dev: true
 
-  /stylus-loader@7.1.0(stylus@0.59.0)(webpack@5.86.0):
+  /stylus-loader@7.1.0(stylus@0.59.0)(webpack@5.88.0):
     resolution: {integrity: sha512-gNUEjjozR+oZ8cuC/Fx4LVXqZOgDKvpW9t2hpXHcxjfPYqSjQftaGwZUK+wL9B0QJ26uS6p1EmoWHmvld1dF7g==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -25049,7 +25060,7 @@ packages:
       klona: 2.0.5
       normalize-path: 3.0.0
       stylus: 0.59.0
-      webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.5)
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
     dev: true
 
   /stylus@0.59.0:
@@ -25287,7 +25298,7 @@ packages:
       unique-string: 2.0.0
     dev: true
 
-  /terser-webpack-plugin@5.3.6(@swc/core@1.3.51)(esbuild@0.17.5)(webpack@5.86.0):
+  /terser-webpack-plugin@5.3.6(@swc/core@1.3.51)(esbuild@0.17.5)(webpack@5.88.0):
     resolution: {integrity: sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -25310,7 +25321,7 @@ packages:
       schema-utils: 3.1.2
       serialize-javascript: 6.0.1
       terser: 5.17.1
-      webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.5)
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
     dev: true
 
   /terser-webpack-plugin@5.3.9(@swc/core@1.3.51)(esbuild@0.17.19)(webpack@5.86.0):
@@ -25365,7 +25376,7 @@ packages:
       webpack: 5.75.0(@swc/core@1.3.51)(esbuild@0.17.5)
     dev: true
 
-  /terser-webpack-plugin@5.3.9(@swc/core@1.3.51)(esbuild@0.17.5)(webpack@5.86.0):
+  /terser-webpack-plugin@5.3.9(@swc/core@1.3.51)(esbuild@0.17.5)(webpack@5.88.0):
     resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -25388,7 +25399,7 @@ packages:
       schema-utils: 3.2.0
       serialize-javascript: 6.0.1
       terser: 5.18.0
-      webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.5)
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
     dev: true
 
   /terser@5.17.1:
@@ -25411,7 +25422,6 @@ packages:
       acorn: 8.8.2
       commander: 2.20.3
       source-map-support: 0.5.21
-    dev: true
 
   /terser@5.18.0:
     resolution: {integrity: sha512-pdL757Ig5a0I+owA42l6tIuEycRuM7FPY4n62h44mRLRfnOxJkkOHd6i89dOpwZlpF6JXBwaAHF6yWzFrt+QyA==}
@@ -25700,7 +25710,7 @@ packages:
       yargs-parser: 21.1.1
     dev: true
 
-  /ts-loader@9.4.1(typescript@5.1.3)(webpack@5.86.0):
+  /ts-loader@9.4.1(typescript@5.1.3)(webpack@5.88.0):
     resolution: {integrity: sha512-384TYAqGs70rn9F0VBnh6BPTfhga7yFNdC5gXbQpDrBj9/KsT4iRkGqKXhziofHOlE2j6YEaiTYVGKKvPhGWvw==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -25712,7 +25722,7 @@ packages:
       micromatch: 4.0.5
       semver: 7.5.3
       typescript: 5.1.3
-      webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.5)
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
     dev: true
 
   /ts-node@10.9.1(@swc/core@1.3.51)(@types/node@18.16.9)(typescript@5.1.3):
@@ -26249,7 +26259,7 @@ packages:
     resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
     dev: true
 
-  /url-loader@4.1.1(file-loader@6.2.0)(webpack@5.86.0):
+  /url-loader@4.1.1(file-loader@6.2.0)(webpack@5.88.0):
     resolution: {integrity: sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -26259,11 +26269,11 @@ packages:
       file-loader:
         optional: true
     dependencies:
-      file-loader: 6.2.0(webpack@5.86.0)
+      file-loader: 6.2.0(webpack@5.88.0)
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.1.2
-      webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.5)
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
     dev: true
 
   /url-parse@1.5.10:
@@ -26498,7 +26508,7 @@ packages:
       mlly: 1.2.0
       pathe: 1.1.0
       picocolors: 1.0.0
-      vite: 4.3.9(@types/node@18.16.9)(less@4.1.3)(sass@1.55.0)(stylus@0.59.0)
+      vite: 4.3.9(@types/node@18.16.9)(less@4.1.3)(sass@1.63.2)(stylus@0.59.0)(terser@5.17.7)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -26544,42 +26554,6 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
 
-  /vite@4.3.9(@types/node@18.16.9)(less@4.1.3)(sass@1.55.0)(stylus@0.59.0):
-    resolution: {integrity: sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 18.16.9
-      esbuild: 0.17.19
-      less: 4.1.3
-      postcss: 8.4.24
-      rollup: 3.21.0
-      sass: 1.55.0
-      stylus: 0.59.0
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: false
-
   /vite@4.3.9(@types/node@18.16.9)(less@4.1.3)(sass@1.63.2)(stylus@0.59.0)(terser@5.17.7):
     resolution: {integrity: sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -26615,7 +26589,6 @@ packages:
       terser: 5.17.7
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
 
   /vitest@0.32.0(less@4.1.3)(sass@1.55.0)(stylus@0.59.0):
     resolution: {integrity: sha512-SW83o629gCqnV3BqBnTxhB10DAwzwEx3z+rqYZESehUB+eWsJxwcBQx7CKy0otuGMJTYh7qCVuUX23HkftGl/Q==}
@@ -26783,6 +26756,20 @@ packages:
       webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.19)
     dev: true
 
+  /webpack-dev-middleware@5.3.3(webpack@5.88.0):
+    resolution: {integrity: sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==}
+    engines: {node: '>= 12.13.0'}
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.0.0
+    dependencies:
+      colorette: 2.0.19
+      memfs: 3.5.0
+      mime-types: 2.1.35
+      range-parser: 1.2.1
+      schema-utils: 4.1.0
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
+    dev: true
+
   /webpack-dev-middleware@6.1.1(webpack@5.86.0):
     resolution: {integrity: sha512-y51HrHaFeeWir0YO4f0g+9GwZawuigzcAdRNon6jErXy/SqV/+O6eaVAzDqE6t3e3NpGeR5CS+cCDaTC+V3yEQ==}
     engines: {node: '>= 14.15.0'}
@@ -26800,7 +26787,7 @@ packages:
       webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.19)
     dev: true
 
-  /webpack-dev-server@4.11.1(webpack@5.86.0):
+  /webpack-dev-server@4.11.1(webpack@5.88.0):
     resolution: {integrity: sha512-lILVz9tAUy1zGFwieuaQtYiadImb5M3d+H+L1zDYalYoDl0cksAB1UNyuE5MMWJrG6zR1tXkCP2fitl7yoUJiw==}
     engines: {node: '>= 12.13.0'}
     hasBin: true
@@ -26838,8 +26825,8 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.5)
-      webpack-dev-middleware: 5.3.3(webpack@5.86.0)
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
+      webpack-dev-middleware: 5.3.3(webpack@5.88.0)
       ws: 8.12.0
     transitivePeerDependencies:
       - bufferutil
@@ -26899,6 +26886,57 @@ packages:
       - utf-8-validate
     dev: true
 
+  /webpack-dev-server@4.15.0(webpack@5.88.0):
+    resolution: {integrity: sha512-HmNB5QeSl1KpulTBQ8UT4FPrByYyaLxpJoQ0+s7EvUrMc16m0ZS1sgb1XGqzmgCPk0c9y+aaXxn11tbLzuM7NQ==}
+    engines: {node: '>= 12.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack: ^4.37.0 || ^5.0.0
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack:
+        optional: true
+      webpack-cli:
+        optional: true
+    dependencies:
+      '@types/bonjour': 3.5.10
+      '@types/connect-history-api-fallback': 1.3.5
+      '@types/express': 4.17.14
+      '@types/serve-index': 1.9.1
+      '@types/serve-static': 1.15.0
+      '@types/sockjs': 0.3.33
+      '@types/ws': 8.5.3
+      ansi-html-community: 0.0.8
+      bonjour-service: 1.0.14
+      chokidar: 3.5.3
+      colorette: 2.0.19
+      compression: 1.7.4
+      connect-history-api-fallback: 2.0.0
+      default-gateway: 6.0.3
+      express: 4.18.2
+      graceful-fs: 4.2.11
+      html-entities: 2.3.3
+      http-proxy-middleware: 2.0.6(@types/express@4.17.14)
+      ipaddr.js: 2.0.1
+      launch-editor: 2.6.0
+      open: 8.4.2
+      p-retry: 4.6.2
+      rimraf: 3.0.2
+      schema-utils: 4.1.0
+      selfsigned: 2.1.1
+      serve-index: 1.9.1
+      sockjs: 0.3.24
+      spdy: 4.0.2
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
+      webpack-dev-middleware: 5.3.3(webpack@5.88.0)
+      ws: 8.13.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+    dev: true
+
   /webpack-hot-middleware@2.25.3:
     resolution: {integrity: sha512-IK/0WAHs7MTu1tzLTjio73LjS3Ov+VvBKQmE8WPlJutgG5zT6Urgq/BbAdRrHTRpyzK0dvAvFh1Qg98akxgZpA==}
     dependencies:
@@ -26943,9 +26981,24 @@ packages:
       html-webpack-plugin:
         optional: true
     dependencies:
-      html-webpack-plugin: 5.5.0(webpack@5.86.0)
+      html-webpack-plugin: 5.5.0(webpack@5.88.0)
       typed-assert: 1.0.9
       webpack: 5.86.0(@swc/core@1.3.51)(esbuild@0.17.19)
+    dev: true
+
+  /webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.5.0)(webpack@5.88.0):
+    resolution: {integrity: sha512-sacXoX+xd8r4WKsy9MvH/q/vBtEHr86cpImXwyg74pFIpERKt6FmB8cXpeuh0ZLgclOlHI4Wcll7+R5L02xk9Q==}
+    engines: {node: '>= 12'}
+    peerDependencies:
+      html-webpack-plugin: '>= 5.0.0-beta.1 < 6'
+      webpack: ^5.12.0
+    peerDependenciesMeta:
+      html-webpack-plugin:
+        optional: true
+    dependencies:
+      html-webpack-plugin: 5.5.0(webpack@5.88.0)
+      typed-assert: 1.0.9
+      webpack: 5.88.0(@swc/core@1.3.51)(esbuild@0.17.5)
     dev: true
 
   /webpack-virtual-modules@0.4.6:
@@ -27032,8 +27085,8 @@ packages:
       - uglify-js
     dev: true
 
-  /webpack@5.86.0(@swc/core@1.3.51)(esbuild@0.17.5):
-    resolution: {integrity: sha512-3BOvworZ8SO/D4GVP+GoRC3fVeg5MO4vzmq8TJJEkdmopxyazGDxN8ClqN12uzrZW9Tv8EED8v5VSb6Sqyi0pg==}
+  /webpack@5.88.0(@swc/core@1.3.51)(esbuild@0.17.5):
+    resolution: {integrity: sha512-O3jDhG5e44qIBSi/P6KpcCcH7HD+nYIHVBhdWFxcLOcIGN8zGo5nqF3BjyNCxIh4p1vFdNnreZv2h2KkoAw3lw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -27063,7 +27116,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.2.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.51)(esbuild@0.17.5)(webpack@5.86.0)
+      terser-webpack-plugin: 5.3.9(@swc/core@1.3.51)(esbuild@0.17.5)(webpack@5.88.0)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -27512,3 +27565,7 @@ packages:
     dependencies:
       tslib: 2.5.3
     dev: true
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

going to latest v5.88.0 of webpack causes type issues with nx

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
nx webpack usage updates to handle v5.88.0 issues where plugin values can be falsy 
from this webpack change: https://github.com/webpack/webpack/commit/3dc2bb8488cc92b8af12257ab8bf2653f32662cb


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
