### PR TITLE
docs(core): finish changelog

### DIFF
--- a/docs/changelog/14_5_0.md
+++ b/docs/changelog/14_5_0.md
@@ -1,0 +1,9 @@
+# Nx 14.5
+
+[Read the 14.5 release blog post](https://blog.nrwl.io/nx-14-5-cypess-v10-output-globs-linter-perf-react-tailwind-support-c15f0b5dc2fc)
+
+Here are some of our feature highlights:
+
+{% cards cols="2" %}
+{% card title="Support for Cypress 10"  type="video" url="https://youtu.be/QDWN4C7T-Ck" /%}
+{% /cards %}

--- a/docs/changelog/15_0_0.md
+++ b/docs/changelog/15_0_0.md
@@ -1,4 +1,16 @@
+# Nx 15.0
+
+[Read the 15.0 release blog post](https://blog.nrwl.io/whats-new-in-nx-15-7e14e1ff282d)
+
+Here are some of our feature highlights:
+
+{% cards cols="2" %}
+{% card title="Combine the Power of Nx Graph and Nx Console"  type="video" url="https://youtu.be/ZST_rmhzRXI" /%}
+{% /cards %}
+
 ## Breaking Changes
+
+Use [the `nx migrate` command](/core-features/automate-updating-dependencies) to automatically account for these breaking changes.
 
 {% cards cols="2" %}
 {% card title="Removed UMD format support for rollup" type="external" url="https://github.com/nrwl/nx/pull/12426" /%}

--- a/docs/changelog/15_3_0.md
+++ b/docs/changelog/15_3_0.md
@@ -1,0 +1,17 @@
+# Nx 15.3
+
+[Read the 15.3 release blog post](https://blog.nrwl.io/nx-15-3-standalone-projects-vite-task-graph-and-more-3ed23f7827ed)
+
+{% youtube
+src="https://www.youtube.com/embed/KBFQZw5ynFs"
+title="What&#39;s new in Nx 15.3?"
+width="100%" /%}
+Here are some of our feature highlights:
+
+{% cards cols="2" %}
+{% card title="Introducing the Nx Task Graph Visualization"  type="video" url="https://youtu.be/wOE3r4299fs" /%}
+{% card title="Standalone Applications with Nx"  type="video" url="https://youtu.be/qEaVzh-oBBc" /%}
+{% card title="Add Nx to any Project"  type="video" url="https://youtu.be/VmGCZ77ao_I" /%}
+{% card title="Run Root-level NPM Scripts with Nx"  type="video" url="https://youtu.be/PRURABLaS8s" /%}
+{% card title="Wrap Any Command with Nx Run-Commands"  type="video" url="https://youtu.be/iygb-KhAeik" /%}
+{% /cards %}

--- a/docs/changelog/15_4_0.md
+++ b/docs/changelog/15_4_0.md
@@ -1,0 +1,13 @@
+# Nx 15.4
+
+[Read the 15.4 release blog post](https://blog.nrwl.io/nx-15-4-vite-4-support-a-new-nx-watch-command-and-more-77cbf6c9a711)
+
+{% youtube
+src="https://www.youtube.com/embed/G02THNy3PcE"
+title="Nx 15.4 is out! Here&#39;s all you need to know"
+width="100%" /%}
+Here are some of our feature highlights:
+
+{% cards cols="2" %}
+{% card title="One Command to Run Multiple Tasks in Parallel"  type="video" url="https://youtu.be/ROTO89i5m_4" /%}
+{% /cards %}

--- a/docs/changelog/15_7_0.md
+++ b/docs/changelog/15_7_0.md
@@ -1,0 +1,16 @@
+# Nx 15.7
+
+[Read the 15.7 release blog post](https://blog.nrwl.io/nx-15-7-node-support-angular-lts-lockfile-pruning-46f067090711)
+
+{% youtube
+src="https://www.youtube.com/embed/IStJODzZSoc"
+title="What's new in Nx 15.7?"
+width="100%" /%}
+Here are some of our feature highlights:
+
+{% cards cols="2" %}
+{% card title="Build Node Backends - The Easy Way!"  type="video" url="https://youtu.be/K4f-fMuAoRY" /%}
+{% card title="Angular LTS Support Starting with Nx 15.7"  type="video" url="https://youtu.be/AQV4WFldwlY" /%}
+{% card title="Create NgModule Free Angular Apps"  type="video" url="https://youtu.be/Hi3aJ0Rlkls" /%}
+{% card title="More Flexible Webpack Configs"  type="video" url="https://youtu.be/CIT4MFMraXg" /%}
+{% /cards %}

--- a/docs/changelog/15_8_0.md
+++ b/docs/changelog/15_8_0.md
@@ -1,0 +1,16 @@
+# Nx 15.8
+
+[Read the 15.8 release blog post](https://blog.nrwl.io/nx-15-8-rust-hasher-nx-console-for-intellij-deno-node-and-storybook-aa2b8585772e)
+
+{% youtube
+src="https://www.youtube.com/embed/4XdHT5Y7zj4"
+title="Nx 15.8 - All you need to know!"
+width="100%" /%}
+Here are some of our feature highlights:
+
+{% cards cols="2" %}
+{% card title="NEW!!! Nx Deno Plugin"  type="video" url="https://youtu.be/NpH8cFSp51E" /%}
+{% card title="Nx Console Goes Poly-IDE"  type="video" url="https://youtu.be/xUTm6GDqwJM" /%}
+{% card title="Prioritized Params in Nx Console"  type="video" url="https://youtu.be/JJ12zKedwIs" /%}
+{% card title="Easy, Modular Node Applications!"  type="video" url="https://youtu.be/LHLW0b4fr2w" /%}
+{% /cards %}

--- a/docs/changelog/16_0_0.md
+++ b/docs/changelog/16_0_0.md
@@ -20,7 +20,7 @@ Here are some of our feature highlights:
 ## Deprecations
 
 {% cards cols="2" %}
-{% card title="workspace-lint" type="external" url="https://github.com/nrwl/nx/pull/16385" /%}
+{% card title="workspace-lint" type="document" url="/deprecated/workspace-lint" /%}
 {% card title="module federation utils from devkit public api" type="external" url="https://github.com/nrwl/nx/pull/16574" /%}
 {% card title="Global implicitDependencies" url="/deprecated/global-implicit-dependencies" /%}
 {% card title="stylus style option for react and next" type="external" url="https://github.com/nrwl/nx/pull/16135" /%}
@@ -28,6 +28,8 @@ Here are some of our feature highlights:
 {% /cards %}
 
 ## Breaking Changes
+
+Use [the `nx migrate` command](/core-features/automate-updating-dependencies) to automatically account for these breaking changes.
 
 {% cards cols="2" %}
 {% card title="Removed @nrwl/cypress/plugins/preprocessor" type="external" url="https://github.com/nrwl/nx/pull/16170" /%}

--- a/docs/changelog/16_4_0.md
+++ b/docs/changelog/16_4_0.md
@@ -1,0 +1,7 @@
+## Deprecations
+
+{% cards cols="2" %}
+{% card title="cypress tsconfig option" type="external" url="https://github.com/nrwl/nx/pull/17165" /%}
+{% card title="print-affected" type="external" url="https://github.com/nrwl/nx/pull/17341" /%}
+{% card title="affected:graph" type="external" url="https://github.com/nrwl/nx/pull/17341" /%}
+{% /cards %}

--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -1443,6 +1443,14 @@
             "isExternal": false,
             "children": [],
             "disableCollapsible": false
+          },
+          {
+            "name": "Changelog",
+            "path": "/reference/changelog",
+            "id": "changelog",
+            "isExternal": true,
+            "children": [],
+            "disableCollapsible": false
           }
         ],
         "disableCollapsible": false
@@ -1508,6 +1516,14 @@
         "path": "/reference/glossary",
         "id": "glossary",
         "isExternal": false,
+        "children": [],
+        "disableCollapsible": false
+      },
+      {
+        "name": "Changelog",
+        "path": "/reference/changelog",
+        "id": "changelog",
+        "isExternal": true,
         "children": [],
         "disableCollapsible": false
       },

--- a/docs/generated/manifests/nx.json
+++ b/docs/generated/manifests/nx.json
@@ -1796,6 +1796,16 @@
         "isExternal": false,
         "path": "/reference/glossary",
         "tags": []
+      },
+      {
+        "id": "changelog",
+        "name": "Changelog",
+        "description": "",
+        "file": "",
+        "itemList": [],
+        "isExternal": true,
+        "path": "/reference/changelog",
+        "tags": []
       }
     ],
     "isExternal": false,
@@ -1880,6 +1890,16 @@
     "itemList": [],
     "isExternal": false,
     "path": "/reference/glossary",
+    "tags": []
+  },
+  "/reference/changelog": {
+    "id": "changelog",
+    "name": "Changelog",
+    "description": "",
+    "file": "",
+    "itemList": [],
+    "isExternal": true,
+    "path": "/reference/changelog",
     "tags": []
   },
   "/deprecated": {

--- a/docs/map.json
+++ b/docs/map.json
@@ -583,6 +583,13 @@
               "id": "glossary",
               "tags": [],
               "file": "shared/reference/glossary"
+            },
+            {
+              "name": "Changelog",
+              "id": "changelog",
+              "file": "",
+              "path": "/reference/changelog",
+              "isExternal": true
             }
           ]
         },

--- a/nx-dev/nx-dev/pages/[...segments].tsx
+++ b/nx-dev/nx-dev/pages/[...segments].tsx
@@ -80,7 +80,12 @@ export default function NxDocumentation({
 }
 
 export const getStaticPaths: GetStaticPaths = () => {
-  const reservedPaths = ['/recipes', '/nx-cloud', '/packages'];
+  const reservedPaths = [
+    '/recipes',
+    '/nx-cloud',
+    '/packages',
+    '/reference/changelog',
+  ];
   return {
     paths: nxDocumentationApi
       .getSlugsStaticDocumentPaths()


### PR DESCRIPTION
https://nx-dev-git-fork-isaacplmann-docs-finish-changelog-nrwl.vercel.app/reference/changelog
- Adds all our release blog post content to the changelog
- Swaps out the changelog header to match the documentation header
- Adds breadcrumbs to the changelog
- Hides the sidebar menu for the changelog in desktop width, but the menu still shows in mobile
- Adds the changelog to the reference area on the Nx menu

<img width="200" alt="Screenshot 2023-06-28 at 4 11 54 PM" src="https://github.com/nrwl/nx/assets/861504/a41eda48-8223-4e29-be44-7acef4f349ba">
