### PR TITLE
docs(misc): remove outdated nx console docs concerning running tasks

### DIFF
--- a/docs/shared/recipes/console-run-command.md
+++ b/docs/shared/recipes/console-run-command.md
@@ -1,15 +1,7 @@
 # Nx Console Run Command
 
-The `Run` action allows you to choose an executor command and then opens a form listing out all the options for that executor. The frequently used executor commands `build`, `serve`, `test`, `e2e` and `lint` also have their own dedicated actions.
-
-{% youtube
-src="https://www.youtube.com/embed/rNImFxo9gYs"
-title="Nx Console Run UI Form"
-width="100%" /%}
-
-**From the Command Palette**
-
-You can also construct the executor command options while staying entirely within the Command Palette. Use `⇧⌘P` to open the Command Palette, then select `nx: test`. After choosing a project, select any of the listed options to modify the executor command options. When you're satisfied with the constructed command, choose the `Execute` command at the top of the list.
+You can construct the executor command options while staying entirely within the Command Palette. Use `⇧⌘P` to open the Command Palette, then select `Nx: Run`. After choosing a project, select a target and any of the listed options to modify the executor command options. When you're satisfied with the constructed command, choose the `Execute` command at the top of the list.
+You can also use `Nx: Run Target` to select a target first and then a matching project.
 
 {% youtube
 src="https://www.youtube.com/embed/CsUkSyQcxwQ"


### PR DESCRIPTION
The current nx console docs are outdated, this form doesn't exist anymore.