### PR TITLE
fix(core): fix lockfile remapping for yarn berry with aliases

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/yarn-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/yarn-parser.ts
@@ -348,7 +348,10 @@ function mapSnapshots(
           .slice(0, key.indexOf('#'))
           .replace(`@patch:${packageName}@`, '@npm:');
       }
-      if (!existingKeys.get(packageName).has(normalizedKey)) {
+      if (
+        !existingKeys.get(packageName) ||
+        !existingKeys.get(packageName).has(normalizedKey)
+      ) {
         keysSet.delete(key);
       }
     }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Pruned lock file remapping from the original lock file is failing if we import only the alias package, but not the full package

e.g. we import `string-width-cjs` (which is an alias to `string-width`) but not `string-width`.

Removal of the keys would fail as `string-width` would not be found in the pruned graph.

## Expected Behavior
Lock file generation should succeed even if someone imports an alias over the standard package name. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17440
Fixes #17816