### PR TITLE
fix(core): remove check for taskGraph equality

### DIFF
--- a/packages/nx/src/daemon/server/handle-hash-tasks.ts
+++ b/packages/nx/src/daemon/server/handle-hash-tasks.ts
@@ -25,10 +25,7 @@ export async function handleHashTasks(payload: {
     await getCachedSerializedProjectGraphPromise();
   const nxJson = readNxJson();
 
-  if (
-    projectGraph !== storedProjectGraph ||
-    payload.taskGraph !== storedTaskGraph
-  ) {
+  if (projectGraph !== storedProjectGraph) {
     storedProjectGraph = projectGraph;
     storedTaskGraph = payload.taskGraph;
     storedHasher = new InProcessTaskHasher(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When ever the daemon tries to hash tasks, there is a check to see if the taskGraph is different from the stored one. This will always be false because the taskGraph is always going to be a new object from the payload

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Removing the taskGraph equality check allows the taskhasher to be properly cached 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
