### PR TITLE
feat(core): Allow specifying daemon socket dir

### DIFF
--- a/docs/shared/daemon.md
+++ b/docs/shared/daemon.md
@@ -36,3 +36,8 @@ When using Nx in a CI environment, the Nx Daemon is disabled by default. Whether
 ## Logs
 
 To see information about the running Nx Daemon (such as its background process ID and log output file), run `nx daemon`. Once you have the path to that log file, you could either open it in your IDE or stream updates in a separate terminal window by running `tail -f {REPLACE_WITH_LOG_PATH}`, for example.
+
+## Customizing the socket location
+
+The Nx Daemon uses a unix socket to communicate between the daemon and the Nx processes. By default this socket gets placed in a temp directory. If you are using Nx in a docker-compose environment, however, you may want to run the daemon manually
+and control its location to enable sharing the daemon among your docker containers. To do so, simply set the NX_DAEMON_SOCKET_DIR environment variable to a shared directory.

--- a/packages/nx/src/daemon/tmp-dir.ts
+++ b/packages/nx/src/daemon/tmp-dir.ts
@@ -21,7 +21,7 @@ export const DAEMON_OUTPUT_LOG_FILE = join(
   'daemon.log'
 );
 
-const socketDir = createSocketDir();
+const socketDir = process.env.NX_DAEMON_SOCKET_DIR || createSocketDir();
 
 export const DAEMON_SOCKET_PATH = join(
   socketDir,


### PR DESCRIPTION
Setting NX_DAEMON_SOCKET_DIR will place the daemon socket in the specified directory

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The NX daemon socket is placed in a random temp folder, uncontrollable by the user

## Expected Behavior
Should allow controlling the placement of the socket

## Related Issue(s)
Fixes #17770

