### PR TITLE
fix(angular): normalize path in move generator

### DIFF
--- a/packages/angular/src/generators/move/lib/update-module-name.ts
+++ b/packages/angular/src/generators/move/lib/update-module-name.ts
@@ -2,6 +2,7 @@ import {
   getProjects,
   joinPathFragments,
   names,
+  normalizePath,
   readProjectConfiguration,
   Tree,
   visitNotIgnoredFiles,
@@ -88,13 +89,14 @@ export function updateModuleName(
   // Update any files which import the module
   for (const [, definition] of getProjects(tree)) {
     visitNotIgnoredFiles(tree, definition.root, (file) => {
-      // skip files that were already modified
+      const normalizedFile = normalizePath(file);
 
-      if (skipFiles.includes(file)) {
+      // skip files that were already modified
+      if (skipFiles.includes(normalizedFile)) {
         return;
       }
 
-      updateFileContent(tree, replacements, file);
+      updateFileContent(tree, replacements, normalizedFile);
     });
   }
 }
@@ -105,7 +107,7 @@ function updateFileContent(
   fileName: string,
   newFileName?: string
 ): void {
-  let content = tree.read(fileName)?.toString('utf-8');
+  let content = tree.read(fileName, 'utf-8');
 
   if (content) {
     let updated = false;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

https://github.com/nrwl/nx/pull/17814 introduced a regression in Windows due to a mismatch in path formats. This causes the `index.ts` file in libraries to be processed twice and, in some cases, produce an invalid result.

The issue can be seen in the Windows nightly runs: https://github.com/nrwl/nx/actions/runs/5417890221/jobs/9849457813#step:11:1580

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The move generator should work correctly in Windows.

Successful run of this fix in Windows: https://github.com/leosvelperez/nx/actions/runs/5420883781/jobs/9855680586#step:11:1609

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
