### PR TITLE
fix(linter): create-package-json should omit non-npm and ignored packages

### DIFF
--- a/packages/eslint-plugin/src/rules/dependency-checks.ts
+++ b/packages/eslint-plugin/src/rules/dependency-checks.ts
@@ -45,7 +45,7 @@ export default createESLintRule<Options, MessageIds>({
         type: 'object',
         properties: {
           buildTargets: [{ type: 'string' }],
-          ignoreDependencies: [{ type: 'string' }],
+          ignoredDependencies: [{ type: 'string' }],
           checkMissingDependencies: { type: 'boolean' },
           checkObsoleteDependencies: { type: 'boolean' },
           checkVersionMismatches: { type: 'boolean' },


### PR DESCRIPTION
This PR fixes several issues that are blocking adoption of the `dependency-checks` rule:
- Schema typo for `ignoredDependencies`
- Ignore peer dependencies of ignored packages when collecting project dependencies
- Ignore non-npm dependencies (this is a bug also for `createPackageJson` if project contains also non-JS code like `nx` package does)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
