### PR TITLE
fix(js): js:node executor resolves main.js and build options correctly

### DIFF
--- a/e2e/js/src/js-node.test.ts
+++ b/e2e/js/src/js-node.test.ts
@@ -47,4 +47,112 @@ describe('js:node error handling', () => {
     expect(output).toContain('Hello from my library!');
     expect(output).toContain('This is an error');
   }, 240_000);
+
+  it('should execute library compiled with rollup', () => {
+    const rollupLib = uniq('rolluplib');
+
+    runCLI(
+      `generate @nx/js:lib ${rollupLib} --bundler=rollup --no-interactive`
+    );
+
+    updateFile(`libs/${rollupLib}/src/index.ts`, () => {
+      return `
+        console.log('Hello from my library!');
+        `;
+    });
+
+    updateProjectConfig(rollupLib, (config) => {
+      config.targets['run-node'] = {
+        executor: '@nx/js:node',
+        options: {
+          buildTarget: `${rollupLib}:build`,
+          watch: false,
+        },
+      };
+      return config;
+    });
+
+    const output = runCLI(`run ${rollupLib}:run-node`);
+    expect(output).toContain('Hello from my library!');
+  }, 240_000);
+
+  it('should execute library compiled with tsc', () => {
+    const tscLib = uniq('tsclib');
+
+    runCLI(`generate @nx/js:lib ${tscLib} --bundler=tsc --no-interactive`);
+
+    updateFile(`libs/${tscLib}/src/index.ts`, () => {
+      return `
+        console.log('Hello from my tsc library!');
+        `;
+    });
+
+    updateProjectConfig(tscLib, (config) => {
+      config.targets['run-node'] = {
+        executor: '@nx/js:node',
+        options: {
+          buildTarget: `${tscLib}:build`,
+          watch: false,
+        },
+      };
+      return config;
+    });
+
+    const output = runCLI(`run ${tscLib}:run-node`);
+    expect(output).toContain('Hello from my tsc library!');
+  }, 240_000);
+
+  it('should execute library compiled with swc', () => {
+    const swcLib = uniq('swclib');
+
+    runCLI(`generate @nx/js:lib ${swcLib} --bundler=swc --no-interactive`);
+
+    updateFile(`libs/${swcLib}/src/index.ts`, () => {
+      return `
+        console.log('Hello from my swc library!');
+        `;
+    });
+
+    updateProjectConfig(swcLib, (config) => {
+      config.targets['run-node'] = {
+        executor: '@nx/js:node',
+        options: {
+          buildTarget: `${swcLib}:build`,
+          watch: false,
+        },
+      };
+      return config;
+    });
+
+    const output = runCLI(`run ${swcLib}:run-node`);
+    expect(output).toContain('Hello from my swc library!');
+  }, 240_000);
+
+  it('should execute webpack app', () => {
+    const webpackProject = uniq('webpackproject');
+
+    runCLI(
+      `generate @nx/node:application ${webpackProject} --bundler=webpack --no-interactive`
+    );
+
+    updateFile(`apps/${webpackProject}/src/main.ts`, () => {
+      return `
+        console.log('Hello from my webpack app!');
+        `;
+    });
+
+    updateProjectConfig(webpackProject, (config) => {
+      config.targets['run-node'] = {
+        executor: '@nx/js:node',
+        options: {
+          buildTarget: `${webpackProject}:build`,
+          watch: false,
+        },
+      };
+      return config;
+    });
+
+    const output = runCLI(`run ${webpackProject}:run-node`);
+    expect(output).toContain('Hello from my webpack app!');
+  }, 240_000);
 });

--- a/e2e/js/src/js-node.test.ts
+++ b/e2e/js/src/js-node.test.ts
@@ -149,6 +149,17 @@ describe('js:node error handling', () => {
           watch: false,
         },
       };
+      config.targets.build = {
+        ...config.targets.build,
+        configurations: {
+          development: {
+            outputPath: 'dist/packages/api-dev',
+          },
+          production: {
+            outputPath: 'dist/packages/api-prod',
+          },
+        },
+      };
       return config;
     });
 

--- a/packages/js/src/executors/swc/swc.impl.ts
+++ b/packages/js/src/executors/swc/swc.impl.ts
@@ -1,4 +1,4 @@
-import { ExecutorContext, readJsonFile, writeJsonFile } from '@nx/devkit';
+import { ExecutorContext } from '@nx/devkit';
 import { assetGlobsToFiles, FileInputOutput } from '../../utils/assets/assets';
 import { removeSync } from 'fs-extra';
 import { dirname, join, relative, resolve } from 'path';
@@ -21,7 +21,6 @@ import {
 import { compileSwc, compileSwcWatch } from '../../utils/swc/compile-swc';
 import { getSwcrcPath } from '../../utils/swc/get-swcrc-path';
 import { generateTmpSwcrc } from '../../utils/swc/inline';
-import type { Options } from '@swc/core';
 
 export function normalizeOptions(
   options: SwcExecutorOptions,

--- a/packages/js/src/utils/get-main-file-dir.ts
+++ b/packages/js/src/utils/get-main-file-dir.ts
@@ -1,0 +1,11 @@
+import { dirname, relative } from 'path';
+import { normalizePath } from 'nx/src/utils/path';
+
+export function getMainFileDirRelativeToProjectRoot(
+  main: string,
+  projectRoot: string
+): string {
+  const mainFileDir = dirname(main);
+  const relativeDir = normalizePath(relative(projectRoot, mainFileDir));
+  return relativeDir === '' ? `./` : `./${relativeDir}/`;
+}

--- a/packages/js/src/utils/package-json/update-package-json.ts
+++ b/packages/js/src/utils/package-json/update-package-json.ts
@@ -9,7 +9,6 @@ import {
   ExecutorContext,
   getOutputsForTargetAndConfiguration,
   joinPathFragments,
-  normalizePath,
   ProjectFileMap,
   ProjectGraphProjectNode,
   readJsonFile,
@@ -17,7 +16,7 @@ import {
   writeJsonFile,
 } from '@nx/devkit';
 import { DependentBuildableProjectNode } from '../buildable-libs-utils';
-import { basename, dirname, join, parse, relative } from 'path';
+import { basename, join, parse } from 'path';
 import { writeFileSync } from 'fs-extra';
 import { isNpmProject } from 'nx/src/project-graph/operators';
 import { fileExists } from 'nx/src/utils/fileutils';
@@ -25,14 +24,7 @@ import type { PackageJson } from 'nx/src/utils/package-json';
 import { existsSync } from 'fs';
 import { readProjectFileMapCache } from 'nx/src/project-graph/nx-deps-cache';
 
-function getMainFileDirRelativeToProjectRoot(
-  main: string,
-  projectRoot: string
-): string {
-  const mainFileDir = dirname(main);
-  const relativeDir = normalizePath(relative(projectRoot, mainFileDir));
-  return relativeDir === '' ? `./` : `./${relativeDir}/`;
-}
+import { getMainFileDirRelativeToProjectRoot } from '../get-main-file-dir';
 
 export type SupportedFormat = 'cjs' | 'esm';
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
An error is thrown if @nx/js:node executor is used in combination of a @nx/js:tsc compiled library.
```
/tmp/nx-e2e/nx/proj7641326/node_modules/@nx/js/src/executors/node/node.impl.js:242
                    throw new Error(`Could not find ${fileToRun}. Make sure your build succeeded.`);
                          ^

Error: Could not find /tmp/nx-e2e/nx/proj7641326/dist/libs/swclib1317971/index.js. Make sure your build succeeded.
```


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Using @nx/js:node executor with  @nx/js:tsc compiled library should work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
