### PR TITLE
fix(js): normalize tsconfig paths used as correlation keys in batch implementation

### DIFF
--- a/packages/js/src/executors/tsc/lib/batch/build-task-info-per-tsconfig-map.ts
+++ b/packages/js/src/executors/tsc/lib/batch/build-task-info-per-tsconfig-map.ts
@@ -54,7 +54,7 @@ function processTasksAndPopulateTsConfigTaskInfoMap(
       const tsConfigPath = join(
         context.root,
         relative(context.root, taskOptions.tsConfig)
-      );
+      ).replace(/\\/g, '/');
 
       tsConfigTaskInfoMap[tsConfigPath] = taskInfo;
       taskTsConfigCache.add(taskName);

--- a/packages/js/src/executors/tsc/lib/get-tsconfig.ts
+++ b/packages/js/src/executors/tsc/lib/get-tsconfig.ts
@@ -249,7 +249,7 @@ function getInMemoryTsConfig(
       },
       references: allProjectReferences.map((pr) => ({ path: pr })),
     }),
-    path: tsConfig,
+    path: tsConfig.replace(/\\/g, '/'),
   };
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Running a build with `@nx/js:tsc` batch execution fails on Windows. It happens due to TS reporting the tsconfig paths in POSIX while we use an OS-specific path for those same files as the correlation key of our config objects.

Failing run in Windows nightly: https://github.com/nrwl/nx/actions/runs/5417890221/jobs/9849458168#step:11:122

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Running a build with `@nx/js:tsc` batch execution should work on Windows.

Successful run of this fix in Windows: https://github.com/leosvelperez/nx/actions/runs/5423423474/jobs/9861396587#step:11:122

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
