### PR TITLE
cleanup(bundling): fix esbuild e2e test case

### DIFF
--- a/e2e/esbuild/src/esbuild.test.ts
+++ b/e2e/esbuild/src/esbuild.test.ts
@@ -190,10 +190,18 @@ describe('EsBuild Plugin', () => {
       return json;
     });
 
-    runCommand(`build ${myPkg}`);
+    runCLI(`build ${myPkg}`);
 
-    expect(runCommand(`node dist/libs/${myPkg}/main.js`)).toMatch(/main/);
-    expect(runCommand(`node dist/libs/${myPkg}/extra.js`)).toMatch(/extra/);
+    checkFilesExist(
+      `dist/libs/${myPkg}/index.js`,
+      `dist/libs/${myPkg}/extra.js`
+    );
+    expect(
+      runCommand(`node dist/libs/${myPkg}/index.js`, { failOnError: true })
+    ).toMatch(/main/);
+    expect(
+      runCommand(`node dist/libs/${myPkg}/extra.js`, { failOnError: true })
+    ).toMatch(/extra/);
   }, 120_000);
 
   it('should support external esbuild.config.js file', async () => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

A wrong utility is used to run an Nx command in an E2E test case for esbuild and a wrong path in an expectation is used.

Also, the test failure has been occurring for a long time, but it's not reported because `runCommand` doesn't fail by default. This can be seen in any previous run. Jest reports the test as a success https://staging.nx.app/runs/g4sVD6EWCm/task/e2e-esbuild%3Ae2e even though it's failing.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The E2E test cases should succeed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
