### PR TITLE
fix(js): ignore watch errors when a process is already killed on Windows

### DIFF
--- a/packages/js/src/executors/node/lib/kill-tree.ts
+++ b/packages/js/src/executors/node/lib/kill-tree.ts
@@ -18,7 +18,11 @@ export async function killTree(pid: number, signal: NodeJS.Signals) {
 
     switch (process.platform) {
       case 'win32':
-        exec('taskkill /pid ' + pid + ' /T /F', callback);
+        exec('taskkill /pid ' + pid + ' /T /F', (error) => {
+          // Ignore Fatal errors (128) because it might be due to the process already being killed.
+          // On Linux/Mac we can check ESRCH (no such process), but on Windows we can't.
+          callback(error?.code !== 128 ? error : null);
+        });
         break;
       case 'darwin':
         buildProcessTree(


### PR DESCRIPTION
On Windows, the `taskkill` command can fail if the process we're trying to kill has already exited. On the Linx/Mac side, we ignore `ESRCH` errors (process not found), so this is the same logic for Windows on fatal errors during `taskkill`.

This is related to #17070 for the Windows issues being mentioned.

## Current Behavior
Running `nx serve` can fail on Windows if a process is already killed.

## Expected Behavior
Running `nx serve` should not fail on Windows.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
