### PR TITLE
docs(nx-dev): rename menu items for getting started

### DIFF
--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -3,13 +3,13 @@
     "id": "nx",
     "menu": [
       {
-        "name": "Start Here",
+        "name": "Getting Started",
         "path": "/getting-started",
         "id": "getting-started",
         "isExternal": false,
         "children": [
           {
-            "name": "Getting Started",
+            "name": "Intro to Nx",
             "path": "/getting-started/intro",
             "id": "intro",
             "isExternal": false,
@@ -36,7 +36,7 @@
         "disableCollapsible": false
       },
       {
-        "name": "Getting Started",
+        "name": "Intro to Nx",
         "path": "/getting-started/intro",
         "id": "intro",
         "isExternal": false,

--- a/docs/generated/manifests/nx.json
+++ b/docs/generated/manifests/nx.json
@@ -1,13 +1,13 @@
 {
   "/getting-started": {
     "id": "getting-started",
-    "name": "Start Here",
+    "name": "Getting Started",
     "description": "Get started with basic information, concepts and tutorials.",
     "file": "",
     "itemList": [
       {
         "id": "intro",
-        "name": "Getting Started",
+        "name": "Intro to Nx",
         "description": "",
         "file": "shared/getting-started/intro",
         "itemList": [],
@@ -42,7 +42,7 @@
   },
   "/getting-started/intro": {
     "id": "intro",
-    "name": "Getting Started",
+    "name": "Intro to Nx",
     "description": "",
     "file": "shared/getting-started/intro",
     "itemList": [],

--- a/docs/map.json
+++ b/docs/map.json
@@ -9,12 +9,12 @@
       "description": "Nx documentation for you to discover!",
       "itemList": [
         {
-          "name": "Start Here",
+          "name": "Getting Started",
           "id": "getting-started",
           "description": "Get started with basic information, concepts and tutorials.",
           "itemList": [
             {
-              "name": "Getting Started",
+              "name": "Intro to Nx",
               "id": "intro",
               "file": "shared/getting-started/intro"
             },

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -1,7 +1,7 @@
 - Nx
 
-  - [Start Here](/getting-started)
-    - [Getting Started](/getting-started/intro)
+  - [Getting Started](/getting-started)
+    - [Intro to Nx](/getting-started/intro)
     - [Installation](/getting-started/installation)
     - [Why Nx?](/getting-started/why-nx)
   - [5 min Tutorials](/tutorials)


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->
![Screenshot 2023-07-03 at 16 43 10](https://github.com/nrwl/nx/assets/881612/f2bed45e-e6ea-4ee1-9bd7-02b5b7d5cc8d)

## Current Behavior
Getting started section is called "Start here" in the menu and "Intro to Nx" is called "Getting started"
![Screenshot 2023-06-30 at 23 33 14](https://github.com/nrwl/nx/assets/881612/c2577e10-00ce-4698-a5ad-453ffbaf11ca)

## Expected Behavior
Menu item name should match or resemble the page name
![Screenshot 2023-06-30 at 23 33 51](https://github.com/nrwl/nx/assets/881612/59663db6-f0d6-4af6-b381-ce9b4ec44c33)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
