### PR TITLE
docs(nx-dev): fix broken link in workspace-lint deprecation

### DIFF
--- a/docs/shared/deprecated/workspace-lint.md
+++ b/docs/shared/deprecated/workspace-lint.md
@@ -6,7 +6,7 @@ Before Nx 15, the `workspace-lint` command performed workspace wide lint checks 
 2. Checking for files that do not belong to a project
 3. Ensuring that all the versions of Nx packages are in sync
 
-Checks (1) and (2) are no longer necessary because [Nx no longer uses a `workspace.json` file](../workspace-json) to define project locations. Instead, Nx dynamically detects projects anywhere in the workspace based on the presence of `package.json` or `project.json` files.
+Checks (1) and (2) are no longer necessary because [Nx no longer uses a `workspace.json` file](/deprecated/workspace-json) to define project locations. Instead, Nx dynamically detects projects anywhere in the workspace based on the presence of `package.json` or `project.json` files.
 
 Check (3) is now accomplished manually with the [`nx report` command](/packages/nx/documents/report).
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
On [the `workspace-lint` deprecation page](https://nx.dev/deprecated/workspace-lint), the link to [the `workspace.json` deprecation page](https://nx.dev/deprecated/workspace-json) is broken.

## Expected Behavior
On [the `workspace-lint` deprecation page](https://nx.dev/deprecated/workspace-lint), the link to [the `workspace.json` deprecation page](https://nx.dev/deprecated/workspace-json) works.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17899
