### PR TITLE
fix(nextjs): updated 0.0.0.0 as default hostname (#17902)

### DIFF
--- a/docs/generated/packages/next/executors/server.json
+++ b/docs/generated/packages/next/executors/server.json
@@ -42,7 +42,7 @@
       "hostname": {
         "type": "string",
         "description": "Hostname on which the application is served.",
-        "default": "localhost"
+        "default": "0.0.0.0"
       },
       "buildLibsFromSource": {
         "type": "boolean",

--- a/packages/next/src/executors/server/schema.json
+++ b/packages/next/src/executors/server/schema.json
@@ -39,7 +39,7 @@
     "hostname": {
       "type": "string",
       "description": "Hostname on which the application is served.",
-      "default": "localhost"
+      "default": "0.0.0.0"
     },
     "buildLibsFromSource": {
       "type": "boolean",

--- a/packages/next/src/executors/server/server.impl.ts
+++ b/packages/next/src/executors/server/server.impl.ts
@@ -30,7 +30,7 @@ export default async function* serveExecutor(
   );
   const projectRoot = context.workspace.projects[context.projectName].root;
 
-  const { port, keepAliveTimeout, hostname = 'localhost' } = options;
+  const { port, keepAliveTimeout, hostname = '0.0.0.0' } = options;
 
   // This is required for the default custom server to work. See the @nx/next:app generator.
   process.env.NX_NEXT_DIR = projectRoot;


### PR DESCRIPTION
## Current Behavior
The nx workspace opensource project has an issue with serving the nx next application locally. The default hostname used is "localhost."

## Expected Behavior
After the changes in this PR, the nx workspace should be able to serve the nx next application locally without any issues. The default hostname will be changed to "0.0.0.0" to ensure proper local serving.

Fixes #17902