### PR TITLE
feat(testing): add test-setup.ts to ignored prod inputs

### DIFF
--- a/packages/jest/migrations.json
+++ b/packages/jest/migrations.json
@@ -95,6 +95,12 @@
       "version": "16.0.0-beta.1",
       "description": "Replace @nrwl/jest with @nx/jest",
       "implementation": "./src/migrations/update-16-0-0-add-nx-packages/update-16-0-0-add-nx-packages"
+    },
+    "add-test-setup-to-inputs-ignore": {
+      "cli": "nx",
+      "version": "16.5.0-beta.2",
+      "description": "Add test-setup.ts to ignored files in production input",
+      "implementation": "./src/migrations/update-16-5-0/add-test-setup-to-inputs-ignore"
     }
   },
   "packageJsonUpdates": {

--- a/packages/jest/src/generators/init/init.spec.ts
+++ b/packages/jest/src/generators/init/init.spec.ts
@@ -86,6 +86,7 @@ export default {
     );
     expect(productionFileSet).toContain('!{projectRoot}/tsconfig.spec.json');
     expect(productionFileSet).toContain('!{projectRoot}/jest.config.[jt]s');
+    expect(productionFileSet).toContain('!{projectRoot}/src/test-setup.[jt]s');
     expect(testDefaults).toEqual({
       inputs: ['default', '^production', '{workspaceRoot}/jest.preset.js'],
     });

--- a/packages/jest/src/generators/init/init.ts
+++ b/packages/jest/src/generators/init/init.ts
@@ -124,7 +124,9 @@ function addTestInputs(tree: Tree) {
       // Remove tsconfig.spec.json
       '!{projectRoot}/tsconfig.spec.json',
       // Remove jest.config.js/ts
-      '!{projectRoot}/jest.config.[jt]s'
+      '!{projectRoot}/jest.config.[jt]s',
+      // Remove test-setup.js/ts
+      '!{projectRoot}/src/test-setup.[jt]s'
     );
     // Dedupe and set
     nxJson.namedInputs.production = Array.from(new Set(productionFileSet));

--- a/packages/jest/src/migrations/update-16-5-0/add-test-setup-to-inputs-ignore.spec.ts
+++ b/packages/jest/src/migrations/update-16-5-0/add-test-setup-to-inputs-ignore.spec.ts
@@ -1,0 +1,51 @@
+import { Tree, readNxJson, updateNxJson } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import addTestSetupToIgnoredInputs from './add-test-setup-to-inputs-ignore';
+
+describe('Jest Migration - jest 29 mocked usage in tests', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  });
+
+  it('should add inputs configuration for test-setup if missing', async () => {
+    updateNxJson(tree, {
+      namedInputs: {
+        default: ['{projectRoot}/**/*', 'sharedGlobals'],
+        sharedGlobals: [],
+        production: ['default'],
+      },
+    });
+
+    await addTestSetupToIgnoredInputs(tree);
+
+    const updated = readNxJson(tree);
+    expect(updated.namedInputs.production).toMatchInlineSnapshot(`
+      [
+        "default",
+        "!{projectRoot}/src/test-setup.[jt]s",
+      ]
+    `);
+  });
+
+  it('should not add inputs configuration for test-setup if existing', async () => {
+    updateNxJson(tree, {
+      namedInputs: {
+        default: ['{projectRoot}/**/*', 'sharedGlobals'],
+        sharedGlobals: [],
+        production: ['!{projectRoot}/src/test-setup.[jt]s', 'default'],
+      },
+    });
+
+    await addTestSetupToIgnoredInputs(tree);
+
+    const updated = readNxJson(tree);
+    expect(updated.namedInputs.production).toMatchInlineSnapshot(`
+      [
+        "!{projectRoot}/src/test-setup.[jt]s",
+        "default",
+      ]
+    `);
+  });
+});

--- a/packages/jest/src/migrations/update-16-5-0/add-test-setup-to-inputs-ignore.ts
+++ b/packages/jest/src/migrations/update-16-5-0/add-test-setup-to-inputs-ignore.ts
@@ -1,0 +1,28 @@
+import {
+  NxJsonConfiguration,
+  Tree,
+  formatFiles,
+  readNxJson,
+  updateNxJson,
+} from '@nx/devkit';
+
+export async function addTestSetupToIgnoredInputs(tree: Tree) {
+  const nxJson: NxJsonConfiguration = readNxJson(tree);
+
+  if (!nxJson) {
+    return;
+  }
+  if (
+    nxJson.namedInputs?.production &&
+    !nxJson.namedInputs.production.includes(
+      '!{projectRoot}/src/test-setup.[jt]s'
+    )
+  ) {
+    nxJson.namedInputs.production.push('!{projectRoot}/src/test-setup.[jt]s');
+    updateNxJson(tree, nxJson);
+  }
+
+  await formatFiles(tree);
+}
+
+export default addTestSetupToIgnoredInputs;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
All dependencies of `test-setup` are now taking into account when collecting dependencies for `createPackageJson`

## Expected Behavior
The `test-setup.ts` should be treated as other testing/linting helpers and ignored for production input.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Related to #17905 (partial fix)
