### PR TITLE
feat(misc): change updateBuildableProjectDepsInPackageJson option default value to false

### DIFF
--- a/docs/generated/packages/angular/executors/ng-packagr-lite.json
+++ b/docs/generated/packages/angular/executors/ng-packagr-lite.json
@@ -43,7 +43,7 @@
       "updateBuildableProjectDepsInPackageJson": {
         "type": "boolean",
         "description": "Whether to update the buildable project dependencies in the build output package.json.",
-        "default": true
+        "default": false
       },
       "buildableProjectDepsInPackageJsonType": {
         "type": "string",

--- a/docs/generated/packages/angular/executors/package.json
+++ b/docs/generated/packages/angular/executors/package.json
@@ -46,7 +46,7 @@
       "updateBuildableProjectDepsInPackageJson": {
         "type": "boolean",
         "description": "Whether to update the buildable project dependencies in the build output package.json.",
-        "default": true
+        "default": false
       },
       "buildableProjectDepsInPackageJsonType": {
         "type": "string",

--- a/docs/generated/packages/js/executors/swc.json
+++ b/docs/generated/packages/js/executors/swc.json
@@ -98,7 +98,7 @@
       "updateBuildableProjectDepsInPackageJson": {
         "type": "boolean",
         "description": "Whether to update the buildable project dependencies in the build output package.json.",
-        "default": true
+        "default": false
       },
       "buildableProjectDepsInPackageJsonType": {
         "type": "string",

--- a/docs/generated/packages/js/executors/tsc.json
+++ b/docs/generated/packages/js/executors/tsc.json
@@ -98,7 +98,7 @@
       "updateBuildableProjectDepsInPackageJson": {
         "type": "boolean",
         "description": "Whether to update the buildable project dependencies in the build output package.json.",
-        "default": true
+        "default": false
       },
       "buildableProjectDepsInPackageJsonType": {
         "type": "string",

--- a/docs/generated/packages/rollup/executors/rollup.json
+++ b/docs/generated/packages/rollup/executors/rollup.json
@@ -84,7 +84,7 @@
       "updateBuildableProjectDepsInPackageJson": {
         "type": "boolean",
         "description": "Update buildable project dependencies in `package.json`.",
-        "default": true
+        "default": false
       },
       "buildableProjectDepsInPackageJsonType": {
         "type": "string",

--- a/e2e/js/src/js-swc.test.ts
+++ b/e2e/js/src/js-swc.test.ts
@@ -91,7 +91,9 @@ describe('js e2e', () => {
       return json;
     });
 
-    runCLI(`build ${lib} --generateLockfile=true`);
+    runCLI(
+      `build ${lib} --generateLockfile=true --updateBuildableProjectDepsInPackageJson`
+    );
     checkFilesExist(
       `dist/libs/${lib}/package.json`,
       `dist/libs/${lib}/${

--- a/e2e/js/src/js-tsc.test.ts
+++ b/e2e/js/src/js-tsc.test.ts
@@ -129,9 +129,7 @@ describe('js e2e', () => {
       return json;
     });
 
-    runCLI(`build ${lib}`);
-
-    const rootPackageJson = readJson(`package.json`);
+    runCLI(`build ${lib} --updateBuildableProjectDepsInPackageJson`);
 
     expect(readJson(`dist/libs/${lib}/package.json`)).toHaveProperty(
       'peerDependencies.tslib'
@@ -221,7 +219,7 @@ describe('package.json updates', () => {
     `;
     });
 
-    runCLI(`build ${lib}`);
+    runCLI(`build ${lib} --updateBuildableProjectDepsInPackageJson`);
 
     // Check that only 'react' exists, don't care about version
     expect(readJson(`dist/libs/${lib}/package.json`).dependencies).toEqual({

--- a/e2e/react-core/src/react-package.test.ts
+++ b/e2e/react-core/src/react-package.test.ts
@@ -129,7 +129,7 @@ describe('Build React libraries and apps', () => {
       /*
        * 2. With dependencies
        */
-      runCLI(`build ${parentLib}`);
+      runCLI(`build ${parentLib} --updateBuildableProjectDepsInPackageJson`);
 
       checkFilesExist(`dist/libs/${parentLib}/index.js`);
 

--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -263,6 +263,12 @@
       },
       "description": "Update the @angular/cli package version to ~16.1.0.",
       "factory": "./src/migrations/update-16-4-0/update-angular-cli"
+    },
+    "explicitly-set-projects-to-update-buildable-deps": {
+      "cli": "nx",
+      "version": "16.6.0-beta.0",
+      "description": "Explicitly set 'updateBuildableProjectDepsInPackageJson' to 'true' in targets that rely on that value as the default.",
+      "factory": "./src/migrations/update-16-6-0/explicitly-set-projects-to-update-buildable-deps"
     }
   },
   "packageJsonUpdates": {

--- a/packages/angular/src/executors/ng-packagr-lite/schema.json
+++ b/packages/angular/src/executors/ng-packagr-lite/schema.json
@@ -40,7 +40,7 @@
     "updateBuildableProjectDepsInPackageJson": {
       "type": "boolean",
       "description": "Whether to update the buildable project dependencies in the build output package.json.",
-      "default": true
+      "default": false
     },
     "buildableProjectDepsInPackageJsonType": {
       "type": "string",

--- a/packages/angular/src/executors/package/schema.json
+++ b/packages/angular/src/executors/package/schema.json
@@ -40,7 +40,7 @@
     "updateBuildableProjectDepsInPackageJson": {
       "type": "boolean",
       "description": "Whether to update the buildable project dependencies in the build output package.json.",
-      "default": true
+      "default": false
     },
     "buildableProjectDepsInPackageJsonType": {
       "type": "string",

--- a/packages/angular/src/migrations/update-16-6-0/explicitly-set-projects-to-update-buildable-deps.spec.ts
+++ b/packages/angular/src/migrations/update-16-6-0/explicitly-set-projects-to-update-buildable-deps.spec.ts
@@ -1,0 +1,86 @@
+import {
+  ProjectConfiguration,
+  Tree,
+  addProjectConfiguration,
+  readProjectConfiguration,
+} from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration from './explicitly-set-projects-to-update-buildable-deps';
+
+describe('explicitly-set-projects-to-update-buildable-deps migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  });
+
+  it.each([
+    '@nx/angular:ng-packagr-lite',
+    '@nrwl/angular:ng-packagr-lite',
+    '@nx/angular:package',
+    '@nrwl/angular:package',
+  ])(
+    'should set updateBuildableProjectDepsInPackageJson option to "true" when not specified in target using "%s"',
+    async (executor) => {
+      addProjectConfiguration(tree, 'lib1', {
+        root: 'libs/lib1',
+        projectType: 'library',
+        targets: { build: { executor, options: {} } },
+      });
+
+      await migration(tree);
+
+      const project = readProjectConfiguration(tree, 'lib1');
+      expect(
+        project.targets.build.options.updateBuildableProjectDepsInPackageJson
+      ).toBe(true);
+    }
+  );
+
+  it.each([
+    '@nx/angular:ng-packagr-lite',
+    '@nrwl/angular:ng-packagr-lite',
+    '@nx/angular:package',
+    '@nrwl/angular:package',
+  ])(
+    'should not overwrite updateBuildableProjectDepsInPackageJson option when it is specified in target using "%s"',
+    async (executor) => {
+      addProjectConfiguration(tree, 'lib1', {
+        root: 'libs/lib1',
+        projectType: 'library',
+        targets: {
+          build: {
+            executor,
+            options: { updateBuildableProjectDepsInPackageJson: false },
+          },
+        },
+      });
+
+      await migration(tree);
+
+      const project = readProjectConfiguration(tree, 'lib1');
+      expect(
+        project.targets.build.options.updateBuildableProjectDepsInPackageJson
+      ).toBe(false);
+    }
+  );
+
+  it('should not update targets using other executors', async () => {
+    const originalProjectConfig: ProjectConfiguration = {
+      root: 'libs/lib1',
+      projectType: 'library',
+      targets: {
+        build: {
+          executor: 'some-executor',
+          options: {},
+        },
+      },
+    };
+    addProjectConfiguration(tree, 'lib1', originalProjectConfig);
+
+    await migration(tree);
+
+    const project = readProjectConfiguration(tree, 'lib1');
+    expect(project.targets).toStrictEqual(originalProjectConfig.targets);
+  });
+});

--- a/packages/angular/src/migrations/update-16-6-0/explicitly-set-projects-to-update-buildable-deps.ts
+++ b/packages/angular/src/migrations/update-16-6-0/explicitly-set-projects-to-update-buildable-deps.ts
@@ -1,0 +1,44 @@
+import {
+  formatFiles,
+  getProjects,
+  Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+
+const executors = new Set([
+  '@nx/angular:ng-packagr-lite',
+  '@nrwl/angular:ng-packagr-lite',
+  '@nx/angular:package',
+  '@nrwl/angular:package',
+]);
+
+export default async function (tree: Tree) {
+  const projects = getProjects(tree);
+
+  for (const [projectName, project] of projects) {
+    if (project.projectType !== 'library') {
+      continue;
+    }
+
+    let updated = false;
+    for (const [, target] of Object.entries(project.targets || {})) {
+      if (!executors.has(target.executor)) {
+        continue;
+      }
+
+      if (
+        target.options &&
+        target.options.updateBuildableProjectDepsInPackageJson === undefined
+      ) {
+        target.options.updateBuildableProjectDepsInPackageJson = true;
+        updated = true;
+      }
+    }
+
+    if (updated) {
+      updateProjectConfiguration(tree, projectName, project);
+    }
+  }
+
+  await formatFiles(tree);
+}

--- a/packages/js/migrations.json
+++ b/packages/js/migrations.json
@@ -41,6 +41,12 @@
       "version": "16.0.0-beta.1",
       "description": "Replace @nrwl/js with @nx/js",
       "implementation": "./src/migrations/update-16-0-0-add-nx-packages/update-16-0-0-add-nx-packages"
+    },
+    "explicitly-set-projects-to-update-buildable-deps": {
+      "cli": "nx",
+      "version": "16.6.0-beta.0",
+      "description": "Explicitly set 'updateBuildableProjectDepsInPackageJson' to 'true' in targets that rely on that value as the default.",
+      "factory": "./src/migrations/update-16-6-0/explicitly-set-projects-to-update-buildable-deps"
     }
   },
   "packageJsonUpdates": {

--- a/packages/js/src/executors/swc/schema.json
+++ b/packages/js/src/executors/swc/schema.json
@@ -69,7 +69,7 @@
     "updateBuildableProjectDepsInPackageJson": {
       "type": "boolean",
       "description": "Whether to update the buildable project dependencies in the build output package.json.",
-      "default": true
+      "default": false
     },
     "buildableProjectDepsInPackageJsonType": {
       "type": "string",

--- a/packages/js/src/executors/tsc/schema.json
+++ b/packages/js/src/executors/tsc/schema.json
@@ -57,7 +57,7 @@
     "updateBuildableProjectDepsInPackageJson": {
       "type": "boolean",
       "description": "Whether to update the buildable project dependencies in the build output package.json.",
-      "default": true
+      "default": false
     },
     "buildableProjectDepsInPackageJsonType": {
       "type": "string",

--- a/packages/js/src/migrations/update-16-6-0/explicitly-set-projects-to-update-buildable-deps.spec.ts
+++ b/packages/js/src/migrations/update-16-6-0/explicitly-set-projects-to-update-buildable-deps.spec.ts
@@ -1,0 +1,76 @@
+import {
+  ProjectConfiguration,
+  Tree,
+  addProjectConfiguration,
+  readProjectConfiguration,
+} from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration from './explicitly-set-projects-to-update-buildable-deps';
+
+describe('explicitly-set-projects-to-update-buildable-deps migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  });
+
+  it.each(['@nx/js:swc', '@nrwl/js:swc', '@nx/js:tsc', '@nrwl/js:tsc'])(
+    'should set updateBuildableProjectDepsInPackageJson option to "true" when not specified in target using "%s"',
+    async (executor) => {
+      addProjectConfiguration(tree, 'lib1', {
+        root: 'libs/lib1',
+        projectType: 'library',
+        targets: { build: { executor, options: {} } },
+      });
+
+      await migration(tree);
+
+      const project = readProjectConfiguration(tree, 'lib1');
+      expect(
+        project.targets.build.options.updateBuildableProjectDepsInPackageJson
+      ).toBe(true);
+    }
+  );
+
+  it.each(['@nx/js:swc', '@nrwl/js:swc', '@nx/js:tsc', '@nrwl/js:tsc'])(
+    'should not overwrite updateBuildableProjectDepsInPackageJson option when it is specified in target using "%s"',
+    async (executor) => {
+      addProjectConfiguration(tree, 'lib1', {
+        root: 'libs/lib1',
+        projectType: 'library',
+        targets: {
+          build: {
+            executor,
+            options: { updateBuildableProjectDepsInPackageJson: false },
+          },
+        },
+      });
+
+      await migration(tree);
+
+      const project = readProjectConfiguration(tree, 'lib1');
+      expect(
+        project.targets.build.options.updateBuildableProjectDepsInPackageJson
+      ).toBe(false);
+    }
+  );
+
+  it('should not update targets using other executors', async () => {
+    const originalProjectConfig: ProjectConfiguration = {
+      root: 'libs/lib1',
+      projectType: 'library',
+      targets: {
+        build: {
+          executor: 'some-executor',
+          options: {},
+        },
+      },
+    };
+    addProjectConfiguration(tree, 'lib1', originalProjectConfig);
+
+    await migration(tree);
+
+    const project = readProjectConfiguration(tree, 'lib1');
+    expect(project.targets).toStrictEqual(originalProjectConfig.targets);
+  });
+});

--- a/packages/js/src/migrations/update-16-6-0/explicitly-set-projects-to-update-buildable-deps.ts
+++ b/packages/js/src/migrations/update-16-6-0/explicitly-set-projects-to-update-buildable-deps.ts
@@ -1,0 +1,44 @@
+import {
+  formatFiles,
+  getProjects,
+  Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+
+const executors = new Set([
+  '@nx/js:swc',
+  '@nrwl/js:swc',
+  '@nx/js:tsc',
+  '@nrwl/js:tsc',
+]);
+
+export default async function (tree: Tree) {
+  const projects = getProjects(tree);
+
+  for (const [projectName, project] of projects) {
+    if (project.projectType !== 'library') {
+      continue;
+    }
+
+    let updated = false;
+    for (const [, target] of Object.entries(project.targets || {})) {
+      if (!executors.has(target.executor)) {
+        continue;
+      }
+
+      if (
+        target.options &&
+        target.options.updateBuildableProjectDepsInPackageJson === undefined
+      ) {
+        target.options.updateBuildableProjectDepsInPackageJson = true;
+        updated = true;
+      }
+    }
+
+    if (updated) {
+      updateProjectConfiguration(tree, projectName, project);
+    }
+  }
+
+  await formatFiles(tree);
+}

--- a/packages/rollup/migrations.json
+++ b/packages/rollup/migrations.json
@@ -17,6 +17,12 @@
       "version": "16-3-3-beta.0",
       "description": "Add babelUpwardRootMode if not already defined",
       "implementation": "./src/migrations/update-16-3-3-add-babel-upward-root-mode-flag/update-16-3-3-add-babel-upward-root-mode-flag"
+    },
+    "explicitly-set-projects-to-update-buildable-deps": {
+      "cli": "nx",
+      "version": "16.6.0-beta.0",
+      "description": "Explicitly set 'updateBuildableProjectDepsInPackageJson' to 'true' in targets that rely on that value as the default.",
+      "factory": "./src/migrations/update-16-6-0/explicitly-set-projects-to-update-buildable-deps"
     }
   },
   "packageJsonUpdates": {}

--- a/packages/rollup/src/executors/rollup/schema.json
+++ b/packages/rollup/src/executors/rollup/schema.json
@@ -92,7 +92,7 @@
     "updateBuildableProjectDepsInPackageJson": {
       "type": "boolean",
       "description": "Update buildable project dependencies in `package.json`.",
-      "default": true
+      "default": false
     },
     "buildableProjectDepsInPackageJsonType": {
       "type": "string",

--- a/packages/rollup/src/migrations/update-16-6-0/explicitly-set-projects-to-update-buildable-deps.spec.ts
+++ b/packages/rollup/src/migrations/update-16-6-0/explicitly-set-projects-to-update-buildable-deps.spec.ts
@@ -1,0 +1,76 @@
+import {
+  ProjectConfiguration,
+  Tree,
+  addProjectConfiguration,
+  readProjectConfiguration,
+} from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration from './explicitly-set-projects-to-update-buildable-deps';
+
+describe('explicitly-set-projects-to-update-buildable-deps migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  });
+
+  it.each(['@nx/rollup:rollup', '@nrwl/rollup:rollup'])(
+    'should set updateBuildableProjectDepsInPackageJson option to "true" when not specified in target using "%s"',
+    async (executor) => {
+      addProjectConfiguration(tree, 'lib1', {
+        root: 'libs/lib1',
+        projectType: 'library',
+        targets: { build: { executor, options: {} } },
+      });
+
+      await migration(tree);
+
+      const project = readProjectConfiguration(tree, 'lib1');
+      expect(
+        project.targets.build.options.updateBuildableProjectDepsInPackageJson
+      ).toBe(true);
+    }
+  );
+
+  it.each(['@nx/js:swc', '@nrwl/js:swc', '@nx/js:tsc', '@nrwl/js:tsc'])(
+    'should not overwrite updateBuildableProjectDepsInPackageJson option when it is specified in target using "%s"',
+    async (executor) => {
+      addProjectConfiguration(tree, 'lib1', {
+        root: 'libs/lib1',
+        projectType: 'library',
+        targets: {
+          build: {
+            executor,
+            options: { updateBuildableProjectDepsInPackageJson: false },
+          },
+        },
+      });
+
+      await migration(tree);
+
+      const project = readProjectConfiguration(tree, 'lib1');
+      expect(
+        project.targets.build.options.updateBuildableProjectDepsInPackageJson
+      ).toBe(false);
+    }
+  );
+
+  it('should not update targets using other executors', async () => {
+    const originalProjectConfig: ProjectConfiguration = {
+      root: 'libs/lib1',
+      projectType: 'library',
+      targets: {
+        build: {
+          executor: 'some-executor',
+          options: {},
+        },
+      },
+    };
+    addProjectConfiguration(tree, 'lib1', originalProjectConfig);
+
+    await migration(tree);
+
+    const project = readProjectConfiguration(tree, 'lib1');
+    expect(project.targets).toStrictEqual(originalProjectConfig.targets);
+  });
+});

--- a/packages/rollup/src/migrations/update-16-6-0/explicitly-set-projects-to-update-buildable-deps.ts
+++ b/packages/rollup/src/migrations/update-16-6-0/explicitly-set-projects-to-update-buildable-deps.ts
@@ -1,0 +1,39 @@
+import {
+  formatFiles,
+  getProjects,
+  Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+
+const executors = new Set(['@nx/rollup:rollup', '@nrwl/rollup:rollup']);
+
+export default async function (tree: Tree) {
+  const projects = getProjects(tree);
+
+  for (const [projectName, project] of projects) {
+    if (project.projectType !== 'library') {
+      continue;
+    }
+
+    let updated = false;
+    for (const [, target] of Object.entries(project.targets || {})) {
+      if (!executors.has(target.executor)) {
+        continue;
+      }
+
+      if (
+        target.options &&
+        target.options.updateBuildableProjectDepsInPackageJson === undefined
+      ) {
+        target.options.updateBuildableProjectDepsInPackageJson = true;
+        updated = true;
+      }
+    }
+
+    if (updated) {
+      updateProjectConfiguration(tree, projectName, project);
+    }
+  }
+
+  await formatFiles(tree);
+}


### PR DESCRIPTION
This is the first step to moving from using the current package.json generation in executors to using the new `@nx/dependency-checks` EsLint rule instead. In a follow-up PR, the options will be deprecated.

The PR comes with migrations for targets using the relevant executors and are relying on the default value for the `updateBuildableProjectDepsInPackageJson`. In those cases, the option will be explicitly set to `true` in the target configuration to keep the existing behavior.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `updateBuildableProjectDepsInPackageJson` option of several executors has a default value of `true`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `updateBuildableProjectDepsInPackageJson` option of several executors should have a default value of `false`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
