### PR TITLE
feat(misc): deprecate executor options to generate package.json for libraries

### DIFF
--- a/docs/generated/packages/angular/executors/ng-packagr-lite.json
+++ b/docs/generated/packages/angular/executors/ng-packagr-lite.json
@@ -16,11 +16,7 @@
       },
       {
         "name": "Updating Project Dependencies for Buildable Library",
-        "keys": [
-          "project",
-          "updateBuildableProjectDepsInPackageJson",
-          "buildableProjectDepsInPackageJsonType"
-        ]
+        "keys": ["project"]
       }
     ],
     "properties": {
@@ -43,13 +39,15 @@
       "updateBuildableProjectDepsInPackageJson": {
         "type": "boolean",
         "description": "Whether to update the buildable project dependencies in the build output package.json.",
-        "default": false
+        "default": false,
+        "x-deprecated": "Configure the project to use the '@nx/dependency-checks' ESLint rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks). It will be removed in v17."
       },
       "buildableProjectDepsInPackageJsonType": {
         "type": "string",
         "description": "When `updateBuildableProjectDepsInPackageJson` is `true`, this adds dependencies to either `peerDependencies` or `dependencies`.",
         "enum": ["dependencies", "peerDependencies"],
-        "default": "peerDependencies"
+        "default": "peerDependencies",
+        "x-deprecated": "Configure the '@nx/dependency-checks' ESLint rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks). It will be removed in v17."
       },
       "tailwindConfig": {
         "type": "string",

--- a/docs/generated/packages/angular/executors/package.json
+++ b/docs/generated/packages/angular/executors/package.json
@@ -20,9 +20,7 @@
       {
         "name": "Updating Project Dependencies for Publishable Library",
         "keys": [
-          "project",
-          "updateBuildableProjectDepsInPackageJson",
-          "buildableProjectDepsInPackageJsonType"
+          "project"
         ]
       }
     ],
@@ -46,7 +44,8 @@
       "updateBuildableProjectDepsInPackageJson": {
         "type": "boolean",
         "description": "Whether to update the buildable project dependencies in the build output package.json.",
-        "default": false
+        "default": false,
+        "x-deprecated": "Configure the project to use the '@nx/dependency-checks' ESLint rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks). It will be removed in v17."
       },
       "buildableProjectDepsInPackageJsonType": {
         "type": "string",
@@ -55,7 +54,8 @@
           "dependencies",
           "peerDependencies"
         ],
-        "default": "peerDependencies"
+        "default": "peerDependencies",
+        "x-deprecated": "Configure the project to use the '@nx/dependency-checks' ESLint rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks). It will be removed in v17."
       },
       "tailwindConfig": {
         "type": "string",

--- a/docs/generated/packages/js/executors/swc.json
+++ b/docs/generated/packages/js/executors/swc.json
@@ -98,13 +98,15 @@
       "updateBuildableProjectDepsInPackageJson": {
         "type": "boolean",
         "description": "Whether to update the buildable project dependencies in the build output package.json.",
-        "default": false
+        "default": false,
+        "x-deprecated": "Configure the project to use the '@nx/dependency-checks' ESLint rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks). It will be removed in v17."
       },
       "buildableProjectDepsInPackageJsonType": {
         "type": "string",
         "description": "When `updateBuildableProjectDepsInPackageJson` is `true`, this adds dependencies to either `peerDependencies` or `dependencies`.",
         "enum": ["dependencies", "peerDependencies"],
-        "default": "peerDependencies"
+        "default": "peerDependencies",
+        "x-deprecated": "Configure the project to use the '@nx/dependency-checks' ESLint rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks). It will be removed in v17."
       },
       "external": {
         "description": "A list projects to be treated as external. This feature is experimental",

--- a/docs/generated/packages/js/executors/tsc.json
+++ b/docs/generated/packages/js/executors/tsc.json
@@ -98,13 +98,15 @@
       "updateBuildableProjectDepsInPackageJson": {
         "type": "boolean",
         "description": "Whether to update the buildable project dependencies in the build output package.json.",
-        "default": false
+        "default": false,
+        "x-deprecated": "Configure the project to use the '@nx/dependency-checks' ESLint rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks). It will be removed in v17."
       },
       "buildableProjectDepsInPackageJsonType": {
         "type": "string",
         "description": "When `updateBuildableProjectDepsInPackageJson` is `true`, this adds dependencies to either `peerDependencies` or `dependencies`.",
         "enum": ["dependencies", "peerDependencies"],
-        "default": "peerDependencies"
+        "default": "peerDependencies",
+        "x-deprecated": "Configure the project to use the '@nx/dependency-checks' ESLint rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks). It will be removed in v17."
       },
       "external": {
         "description": "A list projects to be treated as external. This feature is experimental",

--- a/docs/generated/packages/rollup/executors/rollup.json
+++ b/docs/generated/packages/rollup/executors/rollup.json
@@ -8,19 +8,6 @@
     "description": "Packages a library for different web usages (ESM, CommonJS).",
     "cli": "nx",
     "type": "object",
-    "presets": [
-      {
-        "name": "Including Dependencies in package.json",
-        "keys": [
-          "main",
-          "outputPath",
-          "project",
-          "tsConfig",
-          "buildableProjectDepsInPackageJsonType",
-          "updateBuildableProjectDepsInPackageJson"
-        ]
-      }
-    ],
     "properties": {
       "project": {
         "type": "string",
@@ -84,13 +71,15 @@
       "updateBuildableProjectDepsInPackageJson": {
         "type": "boolean",
         "description": "Update buildable project dependencies in `package.json`.",
-        "default": false
+        "default": false,
+        "x-deprecated": "Configure the project to use the '@nx/dependency-checks' ESLint rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks). It will be removed in v17."
       },
       "buildableProjectDepsInPackageJsonType": {
         "type": "string",
         "description": "When `updateBuildableProjectDepsInPackageJson` is `true`, this adds dependencies to either `peerDependencies` or `dependencies`.",
         "enum": ["dependencies", "peerDependencies"],
-        "default": "peerDependencies"
+        "default": "peerDependencies",
+        "x-deprecated": "Configure the project to use the '@nx/dependency-checks' ESLint rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks). It will be removed in v17."
       },
       "rollupConfig": {
         "oneOf": [
@@ -203,7 +192,8 @@
         ]
       }
     },
-    "examplesFile": "{% tabs %}\n{% tab label=\"Including Dependencies\" %}\nTo include dependencies in the output `package.json`, the dependencies must be installed as a **dependencies** in the root `package.json`\n\n```json {% fileName=\"package.json\" %}\n{\n  \"dependencies\": {\n    \"some-dependency\": \"^1.0.0\"\n  }\n}\n```\n\nTo have dependencies in the be listed in the final `package.json` of your project, set the `updateBuildableProjectDepsInPackageJson` option to `true`. After than dependencies will be added to the `peerDependencies` field of the output `package.json`. You can use `buildableProjectDepsInPackageJsonType` option to change which field the dependencies are output to.\n\n```json {% fileName=\"project.json\" %}\n{\n  \"targets\": {\n    \"build\": {\n      \"executor\": \"@nx/rollup:rollup\",\n      \"options\": {\n        \"buildableProjectDepsInPackageJsonType\": \"dependencies\",\n        \"updateBuildableProjectDepsInPackageJson\": true\n      }\n    }\n  }\n}\n```\n\n{% /tab %}\n\n{% tab label=\"Using `babelUpwardRootMode`\" %}\n\nCopying from the [Babel documentation](https://babeljs.io/docs/config-files#root-babelconfigjson-file):\n\n> [...] if you are running your Babel compilation process from within a subpackage, you need to tell Babel where to look for the config. There are a few ways to do that, but the recommended way is the \"rootMode\" option with \"upward\", which will make Babel search from the working directory upward looking for your babel.config.json file, and will use its location as the \"root\" value.\n\nSetting `babelUpwardRootMode` to `true` in your `project.json` will set `rootMode` option to `upward` in the Babel config. You may want the `upward` mode in a monorepo when projects must apply their individual `.babelrc` file. We recommend that you don't set it at all, so it will use the default to `false` as the `upward` mode brings additional complexity to the build process.\n\n```json\n//...\n\"my-app\": {\n  \"targets\": {\n    \"build\": {\n      \"executor\": \"@nx/rollup:rollup\",\n      \"options\": {\n          \"babelUpwardRootMode\": true,\n          //...\n      },\n      //...\n    },\n    //...\n  },\n  //...\n}\n```\n\nWhen `babelUpwardRootMode` is `true`, Babel will look for a root `babel.config.json` at the root of the workspace, which should look something like this to include all packages:\n\n```json\n{ \"babelrcRoots\": [\"*\"] }\n```\n\nThen for each package, you must have a `.babelrc` file that will be applied to that package. For example:\n\n```json\n{\n  \"presets\": [\"@babel/preset-env\", \"@babel/preset-typescript\"]\n}\n```\n\nAll packages will use its own `.babelrc` file, thus you must ensure the right presets and plugins are set in each config file. This behavior can lead to build discrepancies between packages, so we recommend that you don't set `babelUpwardRootMode` at all.\n\n```treeview\n├── packages\n│   ├── a\n│   │   └── .babelrc\n│   └── b\n│       └── .babelrc\n└── babel.config.json\n```\n\nIn workspace above, if `a` imports `b`, it will apply the config `packages/b/.babelrc` and not apply its own `packages/a/.babelrc` to `b`. Anything in `babel.config.json` will apply to all packages.\n\n{% /tab %}\n\n{% /tabs %}\n"
+    "examplesFile": "{% tabs %}\n{% tab label=\"Including Dependencies\" %}\nTo include dependencies in the output `package.json`, the dependencies must be installed as a **dependencies** in the root `package.json`\n\n```json {% fileName=\"package.json\" %}\n{\n  \"dependencies\": {\n    \"some-dependency\": \"^1.0.0\"\n  }\n}\n```\n\nTo have dependencies in the be listed in the final `package.json` of your project, set the `updateBuildableProjectDepsInPackageJson` option to `true`. After than dependencies will be added to the `peerDependencies` field of the output `package.json`. You can use `buildableProjectDepsInPackageJsonType` option to change which field the dependencies are output to.\n\n```json {% fileName=\"project.json\" %}\n{\n  \"targets\": {\n    \"build\": {\n      \"executor\": \"@nx/rollup:rollup\",\n      \"options\": {\n        \"buildableProjectDepsInPackageJsonType\": \"dependencies\",\n        \"updateBuildableProjectDepsInPackageJson\": true\n      }\n    }\n  }\n}\n```\n\n{% /tab %}\n\n{% tab label=\"Using `babelUpwardRootMode`\" %}\n\nCopying from the [Babel documentation](https://babeljs.io/docs/config-files#root-babelconfigjson-file):\n\n> [...] if you are running your Babel compilation process from within a subpackage, you need to tell Babel where to look for the config. There are a few ways to do that, but the recommended way is the \"rootMode\" option with \"upward\", which will make Babel search from the working directory upward looking for your babel.config.json file, and will use its location as the \"root\" value.\n\nSetting `babelUpwardRootMode` to `true` in your `project.json` will set `rootMode` option to `upward` in the Babel config. You may want the `upward` mode in a monorepo when projects must apply their individual `.babelrc` file. We recommend that you don't set it at all, so it will use the default to `false` as the `upward` mode brings additional complexity to the build process.\n\n```json\n//...\n\"my-app\": {\n  \"targets\": {\n    \"build\": {\n      \"executor\": \"@nx/rollup:rollup\",\n      \"options\": {\n          \"babelUpwardRootMode\": true,\n          //...\n      },\n      //...\n    },\n    //...\n  },\n  //...\n}\n```\n\nWhen `babelUpwardRootMode` is `true`, Babel will look for a root `babel.config.json` at the root of the workspace, which should look something like this to include all packages:\n\n```json\n{ \"babelrcRoots\": [\"*\"] }\n```\n\nThen for each package, you must have a `.babelrc` file that will be applied to that package. For example:\n\n```json\n{\n  \"presets\": [\"@babel/preset-env\", \"@babel/preset-typescript\"]\n}\n```\n\nAll packages will use its own `.babelrc` file, thus you must ensure the right presets and plugins are set in each config file. This behavior can lead to build discrepancies between packages, so we recommend that you don't set `babelUpwardRootMode` at all.\n\n```treeview\n├── packages\n│   ├── a\n│   │   └── .babelrc\n│   └── b\n│       └── .babelrc\n└── babel.config.json\n```\n\nIn workspace above, if `a` imports `b`, it will apply the config `packages/b/.babelrc` and not apply its own `packages/a/.babelrc` to `b`. Anything in `babel.config.json` will apply to all packages.\n\n{% /tab %}\n\n{% /tabs %}\n",
+    "presets": []
   },
   "description": "Bundle a package using Rollup.",
   "aliases": [],

--- a/packages/angular/src/executors/ng-packagr-lite/schema.json
+++ b/packages/angular/src/executors/ng-packagr-lite/schema.json
@@ -13,11 +13,7 @@
     },
     {
       "name": "Updating Project Dependencies for Buildable Library",
-      "keys": [
-        "project",
-        "updateBuildableProjectDepsInPackageJson",
-        "buildableProjectDepsInPackageJsonType"
-      ]
+      "keys": ["project"]
     }
   ],
   "properties": {
@@ -40,13 +36,15 @@
     "updateBuildableProjectDepsInPackageJson": {
       "type": "boolean",
       "description": "Whether to update the buildable project dependencies in the build output package.json.",
-      "default": false
+      "default": false,
+      "x-deprecated": "Configure the project to use the '@nx/dependency-checks' ESLint rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks). It will be removed in v17."
     },
     "buildableProjectDepsInPackageJsonType": {
       "type": "string",
       "description": "When `updateBuildableProjectDepsInPackageJson` is `true`, this adds dependencies to either `peerDependencies` or `dependencies`.",
       "enum": ["dependencies", "peerDependencies"],
-      "default": "peerDependencies"
+      "default": "peerDependencies",
+      "x-deprecated": "Configure the '@nx/dependency-checks' ESLint rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks). It will be removed in v17."
     },
     "tailwindConfig": {
       "type": "string",

--- a/packages/angular/src/executors/package/schema.d.ts
+++ b/packages/angular/src/executors/package/schema.d.ts
@@ -1,8 +1,18 @@
 export interface BuildAngularLibraryExecutorOptions {
   project: string;
+  /**
+   * @deprecated Configure the project to use the `@nx/dependency-checks` ESLint
+   * rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks).
+   * It will be removed in v17.
+   */
   buildableProjectDepsInPackageJsonType?: 'dependencies' | 'peerDependencies';
   tailwindConfig?: string;
   tsConfig?: string;
+  /**
+   * @deprecated Configure the project to use the `@nx/dependency-checks` ESLint
+   * rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks).
+   * It will be removed in v17.
+   */
   updateBuildableProjectDepsInPackageJson?: boolean;
   watch?: boolean;
 }

--- a/packages/angular/src/executors/package/schema.json
+++ b/packages/angular/src/executors/package/schema.json
@@ -13,11 +13,7 @@
     },
     {
       "name": "Updating Project Dependencies for Publishable Library",
-      "keys": [
-        "project",
-        "updateBuildableProjectDepsInPackageJson",
-        "buildableProjectDepsInPackageJsonType"
-      ]
+      "keys": ["project"]
     }
   ],
   "properties": {
@@ -40,13 +36,15 @@
     "updateBuildableProjectDepsInPackageJson": {
       "type": "boolean",
       "description": "Whether to update the buildable project dependencies in the build output package.json.",
-      "default": false
+      "default": false,
+      "x-deprecated": "Configure the project to use the '@nx/dependency-checks' ESLint rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks). It will be removed in v17."
     },
     "buildableProjectDepsInPackageJsonType": {
       "type": "string",
       "description": "When `updateBuildableProjectDepsInPackageJson` is `true`, this adds dependencies to either `peerDependencies` or `dependencies`.",
       "enum": ["dependencies", "peerDependencies"],
-      "default": "peerDependencies"
+      "default": "peerDependencies",
+      "x-deprecated": "Configure the project to use the '@nx/dependency-checks' ESLint rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks). It will be removed in v17."
     },
     "tailwindConfig": {
       "type": "string",

--- a/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
+++ b/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
@@ -1,7 +1,7 @@
 import 'dotenv/config';
 import * as chalk from 'chalk';
 import type { ExecutorContext } from '@nx/devkit';
-import { cacheDir, joinPathFragments, logger } from '@nx/devkit';
+import { cacheDir, joinPathFragments, logger, stripIndents } from '@nx/devkit';
 import {
   copyAssets,
   copyPackageJson,
@@ -74,6 +74,13 @@ export async function* esbuildExecutor(
 
   let packageJsonResult;
   if (options.generatePackageJson) {
+    if (context.projectGraph.nodes[context.projectName].type !== 'app') {
+      logger.warn(
+        stripIndents`The project ${context.projectName} is using the 'generatePackageJson' option which is deprecated for library projects. It should only be used for applications.
+        For libraries, configure the project to use the '@nx/dependency-checks' ESLint rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks).`
+      );
+    }
+
     const cpjOptions: CopyPackageJsonOptions = {
       ...options,
       // TODO(jack): make types generate with esbuild

--- a/packages/js/src/executors/swc/schema.json
+++ b/packages/js/src/executors/swc/schema.json
@@ -69,13 +69,15 @@
     "updateBuildableProjectDepsInPackageJson": {
       "type": "boolean",
       "description": "Whether to update the buildable project dependencies in the build output package.json.",
-      "default": false
+      "default": false,
+      "x-deprecated": "Configure the project to use the '@nx/dependency-checks' ESLint rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks). It will be removed in v17."
     },
     "buildableProjectDepsInPackageJsonType": {
       "type": "string",
       "description": "When `updateBuildableProjectDepsInPackageJson` is `true`, this adds dependencies to either `peerDependencies` or `dependencies`.",
       "enum": ["dependencies", "peerDependencies"],
-      "default": "peerDependencies"
+      "default": "peerDependencies",
+      "x-deprecated": "Configure the project to use the '@nx/dependency-checks' ESLint rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks). It will be removed in v17."
     },
     "external": {
       "description": "A list projects to be treated as external. This feature is experimental",

--- a/packages/js/src/executors/tsc/schema.json
+++ b/packages/js/src/executors/tsc/schema.json
@@ -57,13 +57,15 @@
     "updateBuildableProjectDepsInPackageJson": {
       "type": "boolean",
       "description": "Whether to update the buildable project dependencies in the build output package.json.",
-      "default": false
+      "default": false,
+      "x-deprecated": "Configure the project to use the '@nx/dependency-checks' ESLint rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks). It will be removed in v17."
     },
     "buildableProjectDepsInPackageJsonType": {
       "type": "string",
       "description": "When `updateBuildableProjectDepsInPackageJson` is `true`, this adds dependencies to either `peerDependencies` or `dependencies`.",
       "enum": ["dependencies", "peerDependencies"],
-      "default": "peerDependencies"
+      "default": "peerDependencies",
+      "x-deprecated": "Configure the project to use the '@nx/dependency-checks' ESLint rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks). It will be removed in v17."
     },
     "external": {
       "description": "A list projects to be treated as external. This feature is experimental",

--- a/packages/js/src/utils/schema.d.ts
+++ b/packages/js/src/utils/schema.d.ts
@@ -42,7 +42,17 @@ export interface ExecutorOptions {
   watch: boolean;
   clean?: boolean;
   transformers: TransformerEntry[];
+  /**
+   * @deprecated Configure the project to use the `@nx/dependency-checks` ESLint
+   * rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks).
+   * It will be removed in v17.
+   */
   updateBuildableProjectDepsInPackageJson?: boolean;
+  /**
+   * @deprecated Configure the project to use the `@nx/dependency-checks` ESLint
+   * rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks).
+   * It will be removed in v17.
+   */
   buildableProjectDepsInPackageJsonType?: 'dependencies' | 'peerDependencies';
   external?: 'all' | 'none' | string[];
   externalBuildTargets?: string[];

--- a/packages/rollup/src/executors/rollup/schema.d.ts
+++ b/packages/rollup/src/executors/rollup/schema.d.ts
@@ -24,7 +24,17 @@ export interface RollupExecutorOptions {
   rollupConfig?: string | string[];
   watch?: boolean;
   assets?: any[];
+  /**
+   * @deprecated Configure the project to use the `@nx/dependency-checks` ESLint
+   * rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks).
+   * It will be removed in v17.
+   */
   updateBuildableProjectDepsInPackageJson?: boolean;
+  /**
+   * @deprecated Configure the project to use the `@nx/dependency-checks` ESLint
+   * rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks).
+   * It will be removed in v17.
+   */
   buildableProjectDepsInPackageJsonType?: 'dependencies' | 'peerDependencies';
   deleteOutputPath?: boolean;
   format?: string[];

--- a/packages/rollup/src/executors/rollup/schema.json
+++ b/packages/rollup/src/executors/rollup/schema.json
@@ -5,19 +5,6 @@
   "description": "Packages a library for different web usages (ESM, CommonJS).",
   "cli": "nx",
   "type": "object",
-  "presets": [
-    {
-      "name": "Including Dependencies in package.json",
-      "keys": [
-        "main",
-        "outputPath",
-        "project",
-        "tsConfig",
-        "buildableProjectDepsInPackageJsonType",
-        "updateBuildableProjectDepsInPackageJson"
-      ]
-    }
-  ],
   "properties": {
     "project": {
       "type": "string",
@@ -92,13 +79,15 @@
     "updateBuildableProjectDepsInPackageJson": {
       "type": "boolean",
       "description": "Update buildable project dependencies in `package.json`.",
-      "default": false
+      "default": false,
+      "x-deprecated": "Configure the project to use the '@nx/dependency-checks' ESLint rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks). It will be removed in v17."
     },
     "buildableProjectDepsInPackageJsonType": {
       "type": "string",
       "description": "When `updateBuildableProjectDepsInPackageJson` is `true`, this adds dependencies to either `peerDependencies` or `dependencies`.",
       "enum": ["dependencies", "peerDependencies"],
-      "default": "peerDependencies"
+      "default": "peerDependencies",
+      "x-deprecated": "Configure the project to use the '@nx/dependency-checks' ESLint rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks). It will be removed in v17."
     },
     "rollupConfig": {
       "oneOf": [

--- a/packages/vite/src/executors/build/build.impl.ts
+++ b/packages/vite/src/executors/build/build.impl.ts
@@ -1,5 +1,10 @@
 import 'dotenv/config';
-import { ExecutorContext, writeJsonFile } from '@nx/devkit';
+import {
+  ExecutorContext,
+  logger,
+  stripIndents,
+  writeJsonFile,
+} from '@nx/devkit';
 import { build, InlineConfig, mergeConfig } from 'vite';
 import {
   getProjectTsConfigPath,
@@ -52,6 +57,13 @@ export async function* viteBuildExecutor(
 
   // Generate a package.json if option has been set.
   if (options.generatePackageJson) {
+    if (context.projectGraph.nodes[context.projectName].type !== 'app') {
+      logger.warn(
+        stripIndents`The project ${context.projectName} is using the 'generatePackageJson' option which is deprecated for library projects. It should only be used for applications.
+        For libraries, configure the project to use the '@nx/dependency-checks' ESLint rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks).`
+      );
+    }
+
     const builtPackageJson = createPackageJson(
       context.projectName,
       context.projectGraph,

--- a/packages/webpack/src/executors/webpack/webpack.impl.ts
+++ b/packages/webpack/src/executors/webpack/webpack.impl.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import { ExecutorContext, logger } from '@nx/devkit';
+import { ExecutorContext, logger, stripIndents } from '@nx/devkit';
 import { eachValueFrom } from '@nx/devkit/src/utils/rxjs-for-await';
 import type { Configuration, Stats } from 'webpack';
 import { from, of } from 'rxjs';
@@ -139,6 +139,13 @@ export async function* webpackExecutor(
   // Delete output path before bundling
   if (options.deleteOutputPath) {
     deleteOutputDir(context.root, options.outputPath);
+  }
+
+  if (options.generatePackageJson && metadata.projectType !== 'application') {
+    logger.warn(
+      stripIndents`The project ${context.projectName} is using the 'generatePackageJson' option which is deprecated for library projects. It should only be used for applications.
+        For libraries, configure the project to use the '@nx/dependency-checks' ESLint rule instead (https://nx.dev/packages/eslint-plugin/documents/dependency-checks).`
+    );
   }
 
   const configs = await getWebpackConfigs(options, context);


### PR DESCRIPTION
- Deprecates `updateBuildableProjectDepsInPackageJson` option.
- Executors exposing a `generatePackageJson` will warn when the option is set to `true` on a library project.
- In both cases, it's suggested to use the `@nx/dependency-checks` ESLint rule and the link to the docs is shown.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Several executors have options to enable generating a `package.json` when the target is executed.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Generating a `package.json` for library projects during target executions should be deprecated in favor of using the `@nx/dependency-checks` ESLint rule instead.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
