### PR TITLE
feat(devkit): allow to customize overwrite mode in generateFiles

### DIFF
--- a/docs/generated/devkit/OverwriteStrategy.md
+++ b/docs/generated/devkit/OverwriteStrategy.md
@@ -1,0 +1,29 @@
+# Enumeration: OverwriteStrategy
+
+Specify what should be done when a file is generated but already exists on the system
+
+## Table of contents
+
+### Enumeration Members
+
+- [KeepExisting](../../devkit/documents/OverwriteStrategy#keepexisting)
+- [Overwrite](../../devkit/documents/OverwriteStrategy#overwrite)
+- [ThrowIfExisting](../../devkit/documents/OverwriteStrategy#throwifexisting)
+
+## Enumeration Members
+
+### KeepExisting
+
+• **KeepExisting** = `"keepExisting"`
+
+---
+
+### Overwrite
+
+• **Overwrite** = `"overwrite"`
+
+---
+
+### ThrowIfExisting
+
+• **ThrowIfExisting** = `"throwIfExisting"`

--- a/docs/generated/devkit/README.md
+++ b/docs/generated/devkit/README.md
@@ -15,6 +15,7 @@ It only uses language primitives and immutable objects
 
 - [ChangeType](../../devkit/documents/ChangeType)
 - [DependencyType](../../devkit/documents/DependencyType)
+- [OverwriteStrategy](../../devkit/documents/OverwriteStrategy)
 
 ### Classes
 

--- a/docs/generated/devkit/generateFiles.md
+++ b/docs/generated/devkit/generateFiles.md
@@ -1,6 +1,6 @@
 # Function: generateFiles
 
-▸ **generateFiles**(`tree`, `srcFolder`, `target`, `substitutions`): `void`
+▸ **generateFiles**(`tree`, `srcFolder`, `target`, `substitutions`, `overwriteStrategy?`): `void`
 
 Generates a folder of files based on provided templates.
 
@@ -26,12 +26,13 @@ doesn't get confused about incorrect TypeScript files.
 
 #### Parameters
 
-| Name            | Type                                  | Description                                   |
-| :-------------- | :------------------------------------ | :-------------------------------------------- |
-| `tree`          | [`Tree`](../../devkit/documents/Tree) | the file system tree                          |
-| `srcFolder`     | `string`                              | the source folder of files (absolute path)    |
-| `target`        | `string`                              | the target folder (relative to the tree root) |
-| `substitutions` | `Object`                              | an object of key-value pairs                  |
+| Name                 | Type                                                            | Description                                                          |
+| :------------------- | :-------------------------------------------------------------- | :------------------------------------------------------------------- |
+| `tree`               | [`Tree`](../../devkit/documents/Tree)                           | the file system tree                                                 |
+| `srcFolder`          | `string`                                                        | the source folder of files (absolute path)                           |
+| `target`             | `string`                                                        | the target folder (relative to the tree root)                        |
+| `substitutions`      | `Object`                                                        | an object of key-value pairs                                         |
+| `overwriteStrategy?` | [`OverwriteStrategy`](../../devkit/documents/OverwriteStrategy) | behaviour when the target file already exists. Defaults to Overwrite |
 
 #### Returns
 

--- a/docs/generated/packages/devkit/documents/nx_devkit.md
+++ b/docs/generated/packages/devkit/documents/nx_devkit.md
@@ -15,6 +15,7 @@ It only uses language primitives and immutable objects
 
 - [ChangeType](../../devkit/documents/ChangeType)
 - [DependencyType](../../devkit/documents/DependencyType)
+- [OverwriteStrategy](../../devkit/documents/OverwriteStrategy)
 
 ### Classes
 

--- a/docs/shared/recipes/generators/creating-files.md
+++ b/docs/shared/recipes/generators/creating-files.md
@@ -101,6 +101,16 @@ Hello, my name is mylib!
 
 If you want the generated file or folder name to contain variable values, use `__variable__`. So `NOTES-for-__name__.md` would be resolved to `NOTES_for_mylib.md` in the above example.
 
+## Overwrite mode
+
+By default, generators overwrite files when they already exist.
+
+You can customize this behaviour with an optional argument to `generateFiles` that can take one of three values:
+
+- `OverwriteStrategy.Overwrite` (default): all generated files are created and overwrite existing target files if any.
+- `OverwriteStrategy.KeepExisting`: generated files are created only when target file does not exist. Existing target files are kept as is.
+- `OverwriteStrategy.ThrowIfExisting`: if a target file already exists, an exception is thrown. Suitable when a pristine target environment is expected.
+
 ## EJS Syntax Quickstart
 
 The [EJS syntax](https://ejs.co/) can do much more than replace variable names with values. Here are some common techniques.

--- a/packages/devkit/public-api.ts
+++ b/packages/devkit/public-api.ts
@@ -16,7 +16,10 @@ export { formatFiles } from './src/generators/format-files';
 /**
  * @category Generators
  */
-export { generateFiles } from './src/generators/generate-files';
+export {
+  generateFiles,
+  OverwriteStrategy,
+} from './src/generators/generate-files';
 
 /**
  * @category Generators

--- a/packages/devkit/src/generators/__snapshots__/generate-files.spec.ts.snap
+++ b/packages/devkit/src/generators/__snapshots__/generate-files.spec.ts.snap
@@ -10,6 +10,11 @@ exports[`generateFiles should copy files from a directory into the tree 1`] = `
 "
 `;
 
+exports[`generateFiles should overwrite files when option is overwrite 1`] = `
+"file in directory contents
+"
+`;
+
 exports[`generateFiles should remove ".template" from paths 1`] = `
 "file with template suffix contents
 "

--- a/packages/devkit/src/generators/generate-files.spec.ts
+++ b/packages/devkit/src/generators/generate-files.spec.ts
@@ -1,8 +1,8 @@
-import type { Tree } from 'nx/src/generators/tree';
-import { createTree } from 'nx/src/generators/testing-utils/create-tree';
-import { generateFiles } from './generate-files';
-import { join } from 'path';
 import * as FileType from 'file-type';
+import { createTree } from 'nx/src/generators/testing-utils/create-tree';
+import type { Tree } from 'nx/src/generators/tree';
+import { join } from 'path';
+import { OverwriteStrategy, generateFiles } from './generate-files';
 
 describe('generateFiles', () => {
   let tree: Tree;
@@ -78,5 +78,76 @@ describe('generateFiles', () => {
       ext: 'png',
       mime: 'image/png',
     });
+  });
+
+  it('should throw if overwrite is treated as an error', async () => {
+    expect(() => {
+      generateFiles(
+        tree,
+        join(__dirname, './test-files'),
+        '.',
+        {
+          foo: 'bar',
+          name: 'my-project',
+          projectName: 'my-project-name',
+          dot: '.',
+        },
+        OverwriteStrategy.ThrowIfExisting
+      );
+    }).toThrowError(
+      'Generated file already exists, not allowed by overwrite strategy in generator (directory/file-in-directory.txt)'
+    );
+  });
+
+  it('should overwrite files when option is overwrite', async () => {
+    // Write a custom file that will be overwritten
+    tree.write(
+      'directory/file-in-directory.txt',
+      'placeholder text to overwrite'
+    );
+
+    // Run generation again
+    generateFiles(
+      tree,
+      join(__dirname, './test-files'),
+      '.',
+      {
+        foo: 'bar',
+        name: 'my-project',
+        projectName: 'my-project-name',
+        dot: '.',
+      },
+      OverwriteStrategy.Overwrite
+    );
+
+    // File must have been overwritten
+    expect(
+      tree.read('directory/file-in-directory.txt', 'utf-8')
+    ).toMatchSnapshot();
+  });
+
+  it('should keep files when option is to keep existing files', async () => {
+    // Write a custom file that will stay the same
+    const placeholder = 'placeholder text to keep';
+    tree.write('directory/file-in-directory.txt', placeholder);
+
+    // Run generation again
+    generateFiles(
+      tree,
+      join(__dirname, './test-files'),
+      '.',
+      {
+        foo: 'bar',
+        name: 'my-project',
+        projectName: 'my-project-name',
+        dot: '.',
+      },
+      OverwriteStrategy.KeepExisting
+    );
+
+    // File must have been kept
+    expect(tree.read('directory/file-in-directory.txt', 'utf-8')).toEqual(
+      placeholder
+    );
   });
 });


### PR DESCRIPTION
Adds a new capability to choose how to handle already existing target files when using a generator.

## Current Behavior
If a target file already exists, `generateFiles` overwrites existing files. It is not always the intended behaviour, forcing to have custom code in generators to check for already existing files.

## Expected Behavior
A new (optional) argument to generateFiles allows to choose the behavior when a target file already exists: overwrite (current & still default behavior), keep, throw.

Note: `nx affected` fails on my setup, so could only check by hand and all tests including new tests pass ok on devkit.