### PR TITLE
fix(core): ensure external dependency hashes are resolved in a deterministic way

### DIFF
--- a/packages/nx/src/hasher/task-hasher.ts
+++ b/packages/nx/src/hasher/task-hasher.ts
@@ -332,10 +332,7 @@ class TaskHasherImpl {
                     visited
                   );
                 } else {
-                  const hash = this.hashExternalDependency(
-                    task.target.target,
-                    d.target
-                  );
+                  const hash = this.hashExternalDependency(d.source, d.target);
                   return {
                     value: hash,
                     details: {
@@ -445,20 +442,22 @@ class TaskHasherImpl {
         partialHashes.push(node.data.version);
       }
       // we want to calculate the hash of the entire dependency tree
-      this.projectGraph.dependencies[targetProjectName]?.forEach((d) => {
-        if (
-          !visited.has(
-            this.computeExternalDependencyIdentifier(
-              targetProjectName,
-              d.target
+      if (this.projectGraph.dependencies[targetProjectName]) {
+        this.projectGraph.dependencies[targetProjectName].forEach((d) => {
+          if (
+            !visited.has(
+              this.computeExternalDependencyIdentifier(
+                targetProjectName,
+                d.target
+              )
             )
-          )
-        ) {
-          partialHashes.push(
-            this.hashExternalDependency(targetProjectName, d.target, visited)
-          );
-        }
-      });
+          ) {
+            partialHashes.push(
+              this.hashExternalDependency(targetProjectName, d.target, visited)
+            );
+          }
+        });
+      }
 
       partialHash = hashArray(partialHashes);
     } else {
@@ -494,7 +493,7 @@ class TaskHasherImpl {
       const executorPackage = target.executor.split(':')[0];
       const executorNodeName =
         this.findExternalDependencyNodeName(executorPackage);
-      hash = this.hashExternalDependency(targetName, executorNodeName);
+      hash = this.hashExternalDependency(projectName, executorNodeName);
     } else {
       // use command external dependencies if available to construct the hash
       const partialHashes: string[] = [];
@@ -506,7 +505,7 @@ class TaskHasherImpl {
           const externalDependencies = input['externalDependencies'];
           for (let dep of externalDependencies) {
             dep = this.findExternalDependencyNodeName(dep);
-            partialHashes.push(this.hashExternalDependency(targetName, dep));
+            partialHashes.push(this.hashExternalDependency(projectName, dep));
           }
         }
       }

--- a/packages/nx/src/hasher/task-hasher.ts
+++ b/packages/nx/src/hasher/task-hasher.ts
@@ -429,13 +429,14 @@ class TaskHasherImpl {
         partialHashes.push(node.data.version);
       }
       // we want to calculate the hash of the entire dependency tree
-      if (this.projectGraph.dependencies[projectName]) {
-        this.projectGraph.dependencies[projectName].forEach((d) => {
-          if (!visited.has(d.target)) {
-            partialHashes.push(this.hashExternalDependency(d.target, visited));
-          }
-        });
-      }
+      this.projectGraph.dependencies[projectName]?.forEach((d) => {
+        if (!visited.has(d.target)) {
+          partialHashes.push(
+            this.hashExternalDependency(d.target, new Set(visited))
+          );
+        }
+      });
+
       partialHash = hashArray(partialHashes);
     } else {
       // unknown dependency


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
External dependency hashes are not deterministic and could cause cache misses, since the hash is dependent on which task was hashed when. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Task hashes should not depend on which task have been hashed earlier.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17917
