### PR TITLE
chore(angular): check for main.js instead of index.html

### DIFF
--- a/e2e/angular-core/src/projects.test.ts
+++ b/e2e/angular-core/src/projects.test.ts
@@ -82,7 +82,7 @@ describe('Angular Projects', () => {
     );
     checkFilesExist(`dist/apps/${app1}/main.js`);
     checkFilesExist(`dist/apps/my-dir/${standaloneApp}/main.js`);
-    checkFilesExist(`dist/apps/my-dir/${esbuildApp}/index.html`);
+    checkFilesExist(`dist/apps/my-dir/${esbuildApp}/main.js`);
     // This is a loose requirement because there are a lot of
     // influences external from this project that affect this.
     const es2015BundleSize = getSize(tmpProjPath(`dist/apps/${app1}/main.js`));


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Our e2e test is looking for the index.html file, while the other apps are being checked for main.js

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Stay consistent and look for main.js 

Output Hashing is not applied in the test so there's no worry about a Chunk ID being appended to that file 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
