### PR TITLE
docs(nx-dev): fix link titles to Advanced Update Process

### DIFF
--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -3101,7 +3101,7 @@
             "disableCollapsible": false
           },
           {
-            "name": "Advanced Update Nx",
+            "name": "Advanced Update Process",
             "path": "/recipes/other/advanced-update",
             "id": "advanced-update",
             "isExternal": false,
@@ -3312,7 +3312,7 @@
         "disableCollapsible": false
       },
       {
-        "name": "Advanced Update Nx",
+        "name": "Advanced Update Process",
         "path": "/recipes/other/advanced-update",
         "id": "advanced-update",
         "isExternal": false,

--- a/docs/generated/manifests/recipes.json
+++ b/docs/generated/manifests/recipes.json
@@ -1360,7 +1360,7 @@
       },
       {
         "id": "advanced-update",
-        "name": "Advanced Update Nx",
+        "name": "Advanced Update Process",
         "description": "",
         "file": "shared/recipes/advanced-update",
         "itemList": [],
@@ -1625,7 +1625,7 @@
   },
   "/recipes/other/advanced-update": {
     "id": "advanced-update",
-    "name": "Advanced Update Nx",
+    "name": "Advanced Update Process",
     "description": "",
     "file": "shared/recipes/advanced-update",
     "itemList": [],

--- a/docs/generated/manifests/tags.json
+++ b/docs/generated/manifests/tags.json
@@ -303,7 +303,7 @@
       "description": "",
       "file": "shared/recipes/advanced-update",
       "id": "advanced-update",
-      "name": "Advanced Update Nx",
+      "name": "Advanced Update Process",
       "path": "/recipes/other/advanced-update"
     },
     {

--- a/docs/map.json
+++ b/docs/map.json
@@ -1334,7 +1334,7 @@
               "file": "shared/recipes/workspace-watching"
             },
             {
-              "name": "Advanced Update Nx",
+              "name": "Advanced Update Process",
               "id": "advanced-update",
               "tags": ["automate-updating-dependencies"],
               "file": "shared/recipes/advanced-update"

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -196,7 +196,7 @@
     - [Run Root-Level NPM Scripts with Nx](/recipes/other/root-level-scripts)
     - [Disable Graph Links Created from Analyzing Source Files](/recipes/other/analyze-source-files)
     - [Workspace Watching](/recipes/other/workspace-watching)
-    - [Advanced Update Nx](/recipes/other/advanced-update)
+    - [Advanced Update Process](/recipes/other/advanced-update)
     - [JavaScript and TypeScript](/recipes/other/js-and-ts)
     - [React Native with Nx](/recipes/other/react-native)
     - [Remix with Nx](/recipes/other/remix)


### PR DESCRIPTION
Link titles should match the target page's headline or be a shorter variant of it

## Current Behavior
<!-- This is the behavior we have today -->
![Screenshot 2023-07-04 at 14 43 36](https://github.com/nrwl/nx/assets/881612/25eb022e-499c-40c7-af44-8cd69edc0dc1)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
![Screenshot 2023-07-04 at 14 44 44](https://github.com/nrwl/nx/assets/881612/ca0623ce-0a34-4f86-9898-d86b7025480f)


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
