### PR TITLE
fix(nextjs): Respect CLI output path when provided

### DIFF
--- a/e2e/next/src/next.test.ts
+++ b/e2e/next/src/next.test.ts
@@ -227,6 +227,19 @@ describe('Next.js Applications', () => {
     });
   }, 1_000_000);
 
+  it('should build app and .next artifacts at the outputPath if provided by the CLI', () => {
+    const appName = uniq('app');
+    runCLI(`generate @nx/next:app ${appName} --no-interactive --style=css`);
+
+    runCLI(`build ${appName} --outputPath="dist/foo"`);
+
+    checkFilesExist('dist/foo/package.json');
+    checkFilesExist('dist/foo/next.config.js');
+    // Next Files
+    checkFilesExist('dist/foo/.next/package.json');
+    checkFilesExist('dist/foo/.next/build-manifest.json');
+  }, 600_000);
+
   // TODO(jack): re-enable this test
   xit('should be able to serve with a proxy configuration', async () => {
     const appName = uniq('app');

--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -171,6 +171,10 @@ function withNx(
         }
       });
 
+      // process.env.NX_NEXT_OUTPUT_PATH is set when running @nx/next:build
+      options.outputPath =
+        process.env.NX_NEXT_OUTPUT_PATH || options.outputPath;
+
       // outputPath may be undefined if using run-commands or other executors other than @nx/next:build.
       // In this case, the user should set distDir in their next.config.js.
       if (options.outputPath) {

--- a/packages/next/src/executors/build/build.impl.ts
+++ b/packages/next/src/executors/build/build.impl.ts
@@ -46,7 +46,11 @@ export default async function buildExecutor(
     process.env['__NEXT_REACT_ROOT'] ||= 'true';
   }
 
-  const { experimentalAppOnly, profile, debug } = options;
+  const { experimentalAppOnly, profile, debug, outputPath } = options;
+
+  // Set output path here since it can also be set via CLI
+  // We can retrieve it inside plugins/with-nx
+  process.env.NX_NEXT_OUTPUT_PATH ??= outputPath;
 
   const args = createCliOptions({ experimentalAppOnly, profile, debug });
   const command = `npx next build ${args.join(' ')}`;


### PR DESCRIPTION
When we pass `--outputPath` for building Next.js apps all the build artifacts should be inside that directory.

For example

`nx build acme --outputPath='dist/sub'`

Should have the following

```
dist
└── sub
    ├── next.config.js
    ├── package.json
    └── public
    └── .next
        └── ...
etc...
```
closes: #17881

