### PR TITLE
fix(core): ignore root projects for project inference

### DIFF
--- a/packages/nx/src/config/workspaces.ts
+++ b/packages/nx/src/config/workspaces.ts
@@ -546,7 +546,7 @@ export function getGlobPatternsFromPlugins(
       continue;
     }
     for (const filePattern of plugin.projectFilePatterns) {
-      patterns.push('**/' + filePattern);
+      patterns.push('*/**/' + filePattern);
     }
   }
 
@@ -566,7 +566,7 @@ export async function getGlobPatternsFromPluginsAsync(
       continue;
     }
     for (const filePattern of plugin.projectFilePatterns) {
-      patterns.push('**/' + filePattern);
+      patterns.push('*/**/' + filePattern);
     }
   }
 

--- a/packages/nx/src/native/utils/glob.rs
+++ b/packages/nx/src/native/utils/glob.rs
@@ -41,4 +41,16 @@ mod test {
         assert!(glob_set.is_match("node_modules"));
         assert!(glob_set.is_match("packages/nx/node_modules"));
     }
+
+    #[test]
+    fn should_not_detect_root_plugin_configs() {
+        let glob_set = build_glob_set(vec![
+            // String::from("!(Cargo.toml)"),
+            String::from("*/**/Cargo.toml"),
+        ])
+        .unwrap();
+        assert!(glob_set.is_match("packages/a/Cargo.toml"));
+        assert!(glob_set.is_match("a/Cargo.toml"));
+        assert!(!glob_set.is_match("Cargo.toml"))
+    }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When we moved from `fast-glob` (Node) to `globset` (Rust), we started to pick up root project configurations. This creates an issue where the root project which would contain `jest.config.js` would only be defined by a project created by a plugin's project graph plugin. The JS code analysis would try to draw dependencies to a node which will only be defined when the plugin's projecft graph plugin runs resulting in a error.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

For now, we will recreate the same behavior as `fast-glob` using `globset`. Plugins inference APIs will not be able to define root projects just like before.

In the near future, we will change the project graph logic to allow for plugin inference APIs to define root projects but that is out of scope for this fix.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/Cammisuli/monodon/issues/23#issuecomment-1615107389
