### PR TITLE
fix(js): correct fileToRun path

### DIFF
--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -10,7 +10,6 @@ import {
 import { daemonClient } from 'nx/src/daemon/client/client';
 import { randomUUID } from 'crypto';
 import * as path from 'path';
-import { join } from 'path';
 
 import { InspectType, NodeExecutorOptions } from './schema';
 import { createAsyncIterable } from '@nx/devkit/src/utils/async-iterable';
@@ -41,6 +40,9 @@ export async function* nodeExecutor(
 ) {
   process.env.NODE_ENV ??= context?.configurationName ?? 'development';
   const project = context.projectGraph.nodes[context.projectName];
+  const projectRoot =
+    context.projectsConfigurations.projects[context.projectName].root;
+
   const buildTarget = parseTargetString(
     options.buildTarget,
     context.projectGraph
@@ -84,10 +86,15 @@ export async function* nodeExecutor(
         mainFolder,
         `${path.parse(mainFileName).name}.js`
       );
+      outputFileName = outputFileName.replace(projectRoot, '');
     }
   }
 
-  const fileToRun = join(context.root, buildOptions.outputPath, outputFileName);
+  const fileToRun = joinPathFragments(
+    context.root,
+    buildOptions.outputPath,
+    outputFileName
+  );
   const tasks: ActiveTask[] = [];
   let currentTask: ActiveTask = null;
 


### PR DESCRIPTION
closed #17429, #17946


## Current Behavior

File to run path renders as `dist/apps/my-app/apps/my-app/main.js`

## Expected Behavior

File to run path renders as `dist/apps/my-app/main.js`. Do not add project root twice.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17429, #17946
