### PR TITLE
fix(js): add watchIgnore and runBuildTargetDependencies options to speed up build

### DIFF
--- a/docs/generated/packages/js/executors/node.json
+++ b/docs/generated/packages/js/executors/node.json
@@ -28,12 +28,14 @@
       "host": {
         "type": "string",
         "default": "localhost",
-        "description": "The host to inspect the process on."
+        "description": "The host to inspect the process on.",
+        "x-priority": "important"
       },
       "port": {
         "type": "number",
         "default": 9229,
-        "description": "The port to inspect the process on. Setting port to 0 will assign random free ports to all forked processes."
+        "description": "The port to inspect the process on. Setting port to 0 will assign random free ports to all forked processes.",
+        "x-priority": "important"
       },
       "inspect": {
         "oneOf": [
@@ -41,33 +43,44 @@
           { "type": "boolean" }
         ],
         "description": "Ensures the app is starting with debugging.",
-        "default": "inspect"
+        "default": "inspect",
+        "x-priority": "important"
       },
       "runtimeArgs": {
         "type": "array",
         "description": "Extra args passed to the node process.",
         "default": [],
-        "items": { "type": "string" }
+        "items": { "type": "string" },
+        "x-priority": "important"
       },
       "args": {
         "type": "array",
         "description": "Extra args when starting the app.",
         "default": [],
-        "items": { "type": "string" }
+        "items": { "type": "string" },
+        "x-priority": "important"
       },
       "watch": {
         "type": "boolean",
         "description": "Enable re-building when files change.",
-        "default": true
+        "default": true,
+        "x-priority": "important"
       },
       "debounce": {
         "type": "number",
         "description": "Delay in milliseconds to wait before restarting. Useful to batch multiple file changes events together. Set to zero (0) to disable.",
-        "default": 500
+        "default": 500,
+        "x-priority": "important"
+      },
+      "runBuildTargetDependencies": {
+        "type": "boolean",
+        "description": "Whether to run dependencies before running the build. Set this to true if the project does not build libraries from source (e.g. 'buildLibsFromSource: false').",
+        "default": false
       }
     },
     "additionalProperties": false,
     "required": ["buildTarget"],
+    "examplesFile": "---\ntitle: JS Node executor examples\ndescription: This page contains examples for the @nx/js:node executor.\n---\n\nThe `@nx/js:node` executor runs the output of a build target. For example, an application uses esbuild ([`@nx/esbuild:esbuild`](/packages/esbuild/executors/esbuild)) to output the bundle to `dist/my-app` folder, which can then be executed by `@nx/js:node`.\n\n`project.json`:\n\n```json\n\"my-app\": {\n  \"targets\": {\n    \"serve\": {\n      \"executor\": \"@nx/js:node\",\n      \"options\": {\n        \"buildTarget\": \"my-app:build\"\n      }\n    },\n    \"build\": {\n      \"executor\": \"@nx/esbuild:esbuild\",\n      \"options\": {\n        \"main\": \"my-app/src/main.ts\",\n        \"output\": [\"dist/my-app\"],\n        //...\n      }\n    },\n  }\n}\n```\n\n```bash\nnpx nx serve my-app\n```\n\n## Examples\n\n{% tabs %}\n{% tab label=\"Pass extra Node CLI arguments\" %}\n\nUsing `runtimeArgs`, you can pass arguments to the underlying `node` command. For example, if you want to set [`--no-warnings`](https://nodejs.org/api/cli.html#--no-warnings) to silence all Node warnings, then add the following to the `project.json` file.\n\n```json\n\"my-app\": {\n  \"targets\": {\n    \"serve\": {\n      \"executor\": \"@nx/js:node\",\n      \"options\": {\n        \"runtimeArgs\": [\"--no-warnings\"],\n        //...\n      },\n    },\n  }\n}\n```\n\n{% /tab %}\n\n{% tab label=\"Run all task dependencies\" %}\n\nIf your application build depends on other tasks, and you want those tasks to also be executed, then set the `runBuildTargetDependencies` to `true`. For example, a library may have a task to generate GraphQL schemas, which is consume by the application. In this case, you want to run the generate task before building and running the application.\n\nThis option is also useful when the build consumes a library from its output, not its source. For example, if an executor that supports `buildLibsFromSource` option has it set to `false` (e.g. [`@nx/webpack:webpack`](/packages/webpack/executors/webpack)).\n\nNote that this option will increase the build time, so use it only when necessary.\n\n```json\n\"my-app\": {\n  \"targets\": {\n    \"serve\": {\n      \"executor\": \"@nx/js:node\",\n      \"options\": {\n        \"runBuildTargetDependencies\": true,\n        //...\n      },\n    },\n  }\n}\n```\n\n{% /tab %}\n\n{% /tabs %}\n",
     "presets": []
   },
   "description": "Execute a Node application.",

--- a/packages/js/docs/node-examples.md
+++ b/packages/js/docs/node-examples.md
@@ -1,0 +1,82 @@
+---
+title: JS Node executor examples
+description: This page contains examples for the @nx/js:node executor.
+---
+
+The `@nx/js:node` executor runs the output of a build target. For example, an application uses esbuild ([`@nx/esbuild:esbuild`](/packages/esbuild/executors/esbuild)) to output the bundle to `dist/my-app` folder, which can then be executed by `@nx/js:node`.
+
+`project.json`:
+
+```json
+"my-app": {
+  "targets": {
+    "serve": {
+      "executor": "@nx/js:node",
+      "options": {
+        "buildTarget": "my-app:build"
+      }
+    },
+    "build": {
+      "executor": "@nx/esbuild:esbuild",
+      "options": {
+        "main": "my-app/src/main.ts",
+        "output": ["dist/my-app"],
+        //...
+      }
+    },
+  }
+}
+```
+
+```bash
+npx nx serve my-app
+```
+
+## Examples
+
+{% tabs %}
+{% tab label="Pass extra Node CLI arguments" %}
+
+Using `runtimeArgs`, you can pass arguments to the underlying `node` command. For example, if you want to set [`--no-warnings`](https://nodejs.org/api/cli.html#--no-warnings) to silence all Node warnings, then add the following to the `project.json` file.
+
+```json
+"my-app": {
+  "targets": {
+    "serve": {
+      "executor": "@nx/js:node",
+      "options": {
+        "runtimeArgs": ["--no-warnings"],
+        //...
+      },
+    },
+  }
+}
+```
+
+{% /tab %}
+
+{% tab label="Run all task dependencies" %}
+
+If your application build depends on other tasks, and you want those tasks to also be executed, then set the `runBuildTargetDependencies` to `true`. For example, a library may have a task to generate GraphQL schemas, which is consume by the application. In this case, you want to run the generate task before building and running the application.
+
+This option is also useful when the build consumes a library from its output, not its source. For example, if an executor that supports `buildLibsFromSource` option has it set to `false` (e.g. [`@nx/webpack:webpack`](/packages/webpack/executors/webpack)).
+
+Note that this option will increase the build time, so use it only when necessary.
+
+```json
+"my-app": {
+  "targets": {
+    "serve": {
+      "executor": "@nx/js:node",
+      "options": {
+        "runBuildTargetDependencies": true,
+        //...
+      },
+    },
+  }
+}
+```
+
+{% /tab %}
+
+{% /tabs %}

--- a/packages/js/src/executors/node/schema.d.ts
+++ b/packages/js/src/executors/node/schema.d.ts
@@ -14,4 +14,5 @@ export interface NodeExecutorOptions {
   port: number;
   watch?: boolean;
   debounce?: number;
+  runBuildTargetDependencies?: boolean;
 }

--- a/packages/js/src/executors/node/schema.json
+++ b/packages/js/src/executors/node/schema.json
@@ -27,12 +27,14 @@
     "host": {
       "type": "string",
       "default": "localhost",
-      "description": "The host to inspect the process on."
+      "description": "The host to inspect the process on.",
+      "x-priority": "important"
     },
     "port": {
       "type": "number",
       "default": 9229,
-      "description": "The port to inspect the process on. Setting port to 0 will assign random free ports to all forked processes."
+      "description": "The port to inspect the process on. Setting port to 0 will assign random free ports to all forked processes.",
+      "x-priority": "important"
     },
     "inspect": {
       "oneOf": [
@@ -45,7 +47,8 @@
         }
       ],
       "description": "Ensures the app is starting with debugging.",
-      "default": "inspect"
+      "default": "inspect",
+      "x-priority": "important"
     },
     "runtimeArgs": {
       "type": "array",
@@ -53,7 +56,8 @@
       "default": [],
       "items": {
         "type": "string"
-      }
+      },
+      "x-priority": "important"
     },
     "args": {
       "type": "array",
@@ -61,19 +65,28 @@
       "default": [],
       "items": {
         "type": "string"
-      }
+      },
+      "x-priority": "important"
     },
     "watch": {
       "type": "boolean",
       "description": "Enable re-building when files change.",
-      "default": true
+      "default": true,
+      "x-priority": "important"
     },
     "debounce": {
       "type": "number",
       "description": "Delay in milliseconds to wait before restarting. Useful to batch multiple file changes events together. Set to zero (0) to disable.",
-      "default": 500
+      "default": 500,
+      "x-priority": "important"
+    },
+    "runBuildTargetDependencies": {
+      "type": "boolean",
+      "description": "Whether to run dependencies before running the build. Set this to true if the project does not build libraries from source (e.g. 'buildLibsFromSource: false').",
+      "default": false
     }
   },
   "additionalProperties": false,
-  "required": ["buildTarget"]
+  "required": ["buildTarget"],
+  "examplesFile": "../../../docs/node-examples.md"
 }


### PR DESCRIPTION
This PR addresses the slowness issues introduced when we updated the Node executor. Two additional options have been added.

1. ~~`watchIgnore` - A list of glob patterns to skip rebuilds (when the only changed files are ignored).~~
2. `watchRunBuildTargetDependencies` - When set to `true`, the rebuild will rerun dependency tasks. Default is `false`.

~~(1) lets users ignore files they know cannot affect the application. The alternative is to add to `.gitignore` or `.nxignore`, but this provides more granular control that is specific to the application.~~

Instead of (1), users should add files to their `.nxignore`.

(2) is for advanced usage where the application may not be bundled (thus dependencies must be rebuilt).

## Current Behavior
Node executor is slow for everyone.

## Expected Behavior
Node executor is fast for the normal use cases, with and advanced option to opt-into the slower but more correct build behavior (rerunning all dependency targets).

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17070 
