### PR TITLE
docs(misc): fix typo in nx usage at enterprises doc

### DIFF
--- a/docs/shared/monorepo-nx-enterprise.md
+++ b/docs/shared/monorepo-nx-enterprise.md
@@ -23,7 +23,7 @@ starting point not the definite list of what you must and must not do.
 
 - Apps configure dependency injection and wire up libraries. They should not contain any components, services, or
   business logic.
-- Libs contain services, components, utilities, etc. They have well-≠defined public API.
+- Libs contain services, components, utilities, etc. They have well-defined public API.
 
 A typical Nx workspace has many more libs than apps, so pay especially careful attention to the organization of the libs
 directory.


### PR DESCRIPTION
Preview of doc changed: https://nx-dev-git-fork-leosvelperez-docs-typo-nrwl.vercel.app/more-concepts/monorepo-nx-enterprise#apps-and-libs

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

In https://nx.dev/more-concepts/monorepo-nx-enterprise#apps-and-libs there's a typo in `They have well-≠defined public API.`. Note the `-≠`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

https://nx.dev/more-concepts/monorepo-nx-enterprise#apps-and-libs should have no typo.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17939 
