### PR TITLE
docs(core): fix wording in update dependencies page

### DIFF
--- a/docs/shared/core-features/automate-updating-dependencies.md
+++ b/docs/shared/core-features/automate-updating-dependencies.md
@@ -1,8 +1,8 @@
 # Automate Updating Dependencies
 
-Keeping a codebase updated with the latest changes in your framework of choice and tooling can be challenging. Not to mention that "tooling maintenance work" is usually hard to squeeze into your feature sprint.
+Keeping a codebase updated with the latest changes in your framework of choice can be challenging. Not to mention that "tooling maintenance work" is usually hard to squeeze into your feature sprint.
 
-The `nx migrate` helps by automating the process of updating:
+The `nx migrate` command helps by automating the process of updating:
 
 - package versions in your `package.json`
 - configuration files (e.g. your Jest, ESLint or Nx config)
@@ -10,15 +10,15 @@ The `nx migrate` helps by automating the process of updating:
 
 ## How does it work?
 
-Nx knows where its configuration files are and can therefore make sure they match the expected format or can alternatively adjust them. This automated update process, commonly referred to as "migration," becomes even more powerful when you leverage [Nx plugins](/packages). Nx plugins, which are NPM packages with a range of capabilities (code generation, task automation...), offer targeted updates based on their specific areas of responsibility.
+Nx knows where its configuration files are and can therefore make sure they match the expected format. This automated update process, commonly referred to as "migration," becomes even more powerful when you leverage [Nx plugins](/packages). Nx plugins, which are NPM packages with a range of capabilities (code generation, task automation...), offer targeted updates based on their specific areas of responsibility.
 
 For example, the [Nx ESLint plugin](/packages/linter) excels at configuring linting in your workspace. With its understanding of the configuration file locations, this plugin can provide precise migration scripts to update ESLint packages in your `package.json` and corresponding configuration files in your workspace when a new version is released.
 
 Updating happens in three steps:
 
 - The installed dependencies are updated including the `package.json` (and `node_modules`).
-- The source code in the repo is updated to match the new versions of packages according to set of instructions specified in `migrations.json` file.
-- Optionally remove the `migrations.json` file or keep it to re-run it in different Git branches
+- The source code in the repo is updated to match the new versions of packages according to the set of instructions specified in `migrations.json` file.
+- Optionally remove the `migrations.json` file or keep it to re-run the migration in different Git branches
 
 ### Step 1: Updating dependencies and generating migrations
 


### PR DESCRIPTION
Fixes some grammar and wording in the Automate Updating Dependencies page