### PR TITLE
chore(repo): bump versions of ci images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ version: 2.1
 # -------------------------
 orbs:
   nx: nrwl/nx@1.6.1
-  node: circleci/node@5.1.0
   rust: circleci/rust@1.6.0
   browser-tools: circleci/browser-tools@1.4.0
 
@@ -20,14 +19,14 @@ executors:
   linux:
     <<: *defaults
     docker:
-      - image: cimg/rust:1.66.1-browsers
+      - image: cimg/rust:1.70.0-browsers
     resource_class: medium+
 
   macos:
     <<: *defaults
     resource_class: macos.x86.medium.gen2
     macos:
-      xcode: &_XCODE_VERSION '13.0.0'
+      xcode: &_XCODE_VERSION '14.3.1'
 
 # -------------------------
 #        COMMANDS
@@ -95,9 +94,6 @@ commands:
                   sudo apt-get install -y ca-certificates lsof
             - browser-tools/install-chrome
             - browser-tools/install-chromedriver
-      - node/install:
-          # Use LTS version
-          node-version: ''
       - run-pnpm-install:
           os: << parameters.os >>
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ commands:
       - run:
           name: Install pnpm package manager
           command: |
-            npm install -g @pnpm/exe@8.3.1
+            npm install --prefix=$HOME/.local -g @pnpm/exe@8.3.1
       - run:
           name: Install Dependencies
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ executors:
     <<: *defaults
     resource_class: macos.x86.medium.gen2
     macos:
-      xcode: &_XCODE_VERSION '14.3.1'
+      xcode: '14.2.0'
 
 # -------------------------
 #        COMMANDS
@@ -41,10 +41,22 @@ commands:
           name: Restore pnpm Package Cache
           keys:
             - node-deps-{{ arch }}-v3-{{ checksum "pnpm-lock.yaml" }}
-      - run:
-          name: Install pnpm package manager
-          command: |
-            npm install --prefix=$HOME/.local -g @pnpm/exe@8.3.1
+      - when:
+          condition:
+            equal: [<< parameters.os >>, linux]
+          steps:
+            - run:
+                name: Install pnpm package manager (linux)
+                command: |
+                  npm install --prefix=$HOME/.local -g @pnpm/exe@8.3.1
+      - when:
+          condition:
+            equal: [<< parameters.os >>, macos]
+          steps:
+            - run:
+                name: Install pnpm package manager (macos)
+                command: |
+                  npm install -g @pnpm/exe@8.3.1
       - run:
           name: Install Dependencies
           command: |


### PR DESCRIPTION
There are currently some issues with node images on CircleCI.

The latest `cimg/rust-browsers` and `macos.x86.medium.gen2` already come with fresh Node v18, so there's no need to use extra installation via orb.

This also speeds up our pipeline because we skip expensive step of downloading node image and installing it.

## Current Behavior
We use `circleci/node` orb to set up latest node version on top of the existing node installed with executor docker image.

## Expected Behavior
We should use the node bundled within the executor docker image.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
