### PR TITLE
docs(core): set env vars from the command line

### DIFF
--- a/docs/shared/guides/use-environment-variables-in-angular.md
+++ b/docs/shared/guides/use-environment-variables-in-angular.md
@@ -106,7 +106,8 @@ Alternatively, you can set the variable when running a terminal command by using
 
 - MacOS & Linux: `NX_API_URL=http://localhost:9999 npm run build-prod`
 - Windows: `set NX_API_URL=http://localhost:9999 & npm run build-prod`
-  {% /callout %}
+
+{% /callout %}
 
 Finally, We can use environment variables in our code. For example,
 

--- a/docs/shared/guides/use-environment-variables-in-angular.md
+++ b/docs/shared/guides/use-environment-variables-in-angular.md
@@ -101,6 +101,13 @@ Now, when we define variables in our `.env` file, such as...
 NX_API_URL=http://localhost:3333
 ```
 
+{% callout type="note" title="Set environment variables from the terminal" %}
+Alternatively, you can set the variable when running a terminal command by using:
+
+- MacOS & Linux: `NX_API_URL=http://localhost:9999 npm run build-prod`
+- Windows: `set NX_API_URL=http://localhost:9999 & npm run build-prod`
+  {% /callout %}
+
 Finally, We can use environment variables in our code. For example,
 
 ```typescript {% fileName="apps/myapp/src/main.ts" %}


### PR DESCRIPTION
Reformated version of #17934

A snippet for how to add environment variable + running some nx command for all OS platforms.


https://nx-dev-git-fork-isaacplmann-docs-use-env-vars-angul-0030e9-nrwl.vercel.app/recipes/environment-variables/use-environment-variables-in-angular