### PR TITLE
fix(core): ensure target-only argument is rewritten correctly to be forwarded

### DIFF
--- a/packages/nx/bin/init-local.ts
+++ b/packages/nx/bin/init-local.ts
@@ -91,7 +91,7 @@ function rewritePositionalArguments(args: string[]) {
   for (let i = 2; i < args.length; i++) {
     if (!args[i].startsWith('-')) {
       relevantPositionalArgs.push(args[i]);
-      if (relevantPositionalArgs.length === 2) {
+      if (relevantPositionalArgs.length <= 2) {
         rest.push(...args.slice(i + 1));
         break;
       }

--- a/packages/nx/bin/init-local.ts
+++ b/packages/nx/bin/init-local.ts
@@ -89,9 +89,12 @@ function rewritePositionalArguments(args: string[]) {
   const relevantPositionalArgs = [];
   const rest = [];
   for (let i = 2; i < args.length; i++) {
-    if (!args[i].startsWith('-')) {
+    if (args[i] === '--') {
+      rest.push(...args.slice(i + 1));
+      break;
+    } else if (!args[i].startsWith('-')) {
       relevantPositionalArgs.push(args[i]);
-      if (relevantPositionalArgs.length <= 2) {
+      if (relevantPositionalArgs.length === 2) {
         rest.push(...args.slice(i + 1));
         break;
       }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When running with target only and attempting to forward args to commands, you are forced to provide both target and project.

e.g.

```shell
nx build -- arg1 -t ./some/path
```

Results in `Cannot find project 'arg1'`. This worked as expected prior to https://github.com/nrwl/nx/pull/15193

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When using `--` to designate where you want to start passing args

```shell
nx build -- arg1 -t ./some/path
```

Will correctly translate to 

```shell
nx run build arg1 -t ./some/path
```

Rather than

```shell
nx run arg1:build -t ./some/path
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16499
