### PR TITLE
fix(js): remove duplicate alias

### DIFF
--- a/packages/js/generators.json
+++ b/packages/js/generators.json
@@ -12,7 +12,6 @@
     "init": {
       "factory": "./src/generators/init/init#initSchematic",
       "schema": "./src/generators/init/schema.json",
-      "aliases": ["lib"],
       "x-type": "init",
       "description": "Initialize a TS/JS workspace.",
       "hidden": true


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

When combining @nx/js with Angular schematics, a `SchematicNameCollisionException` could occur due to duplicate aliases from library and init.

## Expected Behavior

Prevents the collision.

/cc @AgentEnder 
