### PR TITLE
fix(core): ensure yarn runs install with correct version

### DIFF
--- a/packages/create-nx-workspace/src/create-sandbox.ts
+++ b/packages/create-nx-workspace/src/create-sandbox.ts
@@ -23,7 +23,7 @@ export async function createSandbox(packageManager: PackageManager) {
     `Installing dependencies with ${packageManager}`
   ).start();
 
-  const { install } = getPackageManagerCommand(packageManager);
+  const { install, preInstall } = getPackageManagerCommand(packageManager);
 
   const tmpDir = dirSync().name;
   try {
@@ -38,6 +38,10 @@ export async function createSandbox(packageManager: PackageManager) {
       })
     );
     generatePackageManagerFiles(tmpDir, packageManager);
+
+    if (preInstall) {
+      await execAndWait(preInstall, tmpDir);
+    }
 
     await execAndWait(install, tmpDir);
 

--- a/packages/create-nx-workspace/src/utils/package-manager.ts
+++ b/packages/create-nx-workspace/src/utils/package-manager.ts
@@ -36,6 +36,7 @@ export function getPackageManagerCommand(
 ): {
   install: string;
   exec: string;
+  preInstall?: string;
 } {
   const [pmMajor, pmMinor] =
     getPackageManagerVersion(packageManager).split('.');
@@ -45,6 +46,9 @@ export function getPackageManagerCommand(
       const useBerry = +pmMajor >= 2;
       const installCommand = 'yarn install --silent';
       return {
+        preInstall: useBerry
+          ? 'yarn set version stable'
+          : 'yarn set version classic',
         install: useBerry
           ? installCommand
           : `${installCommand} --ignore-scripts`,

--- a/packages/devkit/src/utils/package-json.ts
+++ b/packages/devkit/src/utils/package-json.ts
@@ -464,12 +464,20 @@ export function ensurePackage<T extends any = any>(
 
   console.log(`Fetching ${pkg}...`);
   const packageManager = detectPackageManager();
+  const isVerbose = process.env.NX_VERBOSE_LOGGING === 'true';
+  const preInstallCommand = getPackageManagerCommand(packageManager).preInstall;
+  if (preInstallCommand) {
+    // ensure package.json and repo in tmp folder is set to a proper package manager state
+    execSync(preInstallCommand, {
+      cwd: tempDir,
+      stdio: isVerbose ? 'inherit' : 'ignore',
+    });
+  }
   let addCommand = getPackageManagerCommand(packageManager).addDev;
   if (packageManager === 'pnpm') {
     addCommand = 'pnpm add -D'; // we need to ensure that we are not using workspace command
   }
 
-  const isVerbose = process.env.NX_VERBOSE_LOGGING === 'true';
   execSync(`${addCommand} ${pkg}@${requiredVersion}`, {
     cwd: tempDir,
     stdio: isVerbose ? 'inherit' : 'ignore',

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -15,6 +15,7 @@ const execAsync = promisify(exec);
 export type PackageManager = 'yarn' | 'pnpm' | 'npm';
 
 export interface PackageManagerCommands {
+  preInstall?: string;
   install: string;
   ciInstall: string;
   add: string;
@@ -64,6 +65,9 @@ export function getPackageManagerCommand(
       const useBerry = gte(yarnVersion, '2.0.0');
 
       return {
+        preInstall: useBerry
+          ? 'yarn set version stable'
+          : 'yarn set version classic',
         install: 'yarn',
         ciInstall: useBerry
           ? 'yarn install --immutable'


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

Installation of packages using `ensurePackage` and `create-nx-workspace` fail for Yarn Berry because they create temp folder that might be targeting different yarn version

Let's assume this folder structure:
```
$HOME 
  - my-berry-projects // subfolder with 
      .yarnrc.yaml // berry version set
      - my-project
        package.json // <- this is our project
  .yarnrc.yaml // classic version set
```

If we run `yarn install` in the `my-project` folder we would be using yarn berry. But our CNW and `ensurePackage` generate a temp folder outside of the $HOME, so running `yarn` would end up in using yarn classic which then causes issues.

## Expected Behavior
Before running `yarn install` or `yarn add` in the temp folder we need to run `yarn set version classic/berry` according to the local version of our project to make sure two versions are in-sync.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
