### PR TITLE
fix(storybook): properly identify file as story

### DIFF
--- a/packages/storybook/src/utils/utilities.spec.ts
+++ b/packages/storybook/src/utils/utilities.spec.ts
@@ -89,6 +89,24 @@ describe('testing utilities', () => {
       );
 
       appTree.write(
+        `test-ui-lib/src/lib/button/button.other.stories.ts`,
+        `
+        import type { Meta } from '@storybook/react';
+        import { Button } from './button';
+        
+        const Story: Meta<typeof Button> = {
+          component: Button,
+          title: 'Layout/Texts/Button',
+        };
+        export default Story;
+        
+        export const Primary = {
+          args: {},
+        };
+        `
+      );
+
+      appTree.write(
         `test-ui-lib/src/lib/button/button.component.other.ts`,
         `
         import { Button } from './button';
@@ -151,6 +169,14 @@ describe('testing utilities', () => {
         const fileIsStory = isTheFileAStory(
           appTree,
           'test-ui-lib/src/lib/button/button.component.stories.ts'
+        );
+        expect(fileIsStory).toBeTruthy();
+      });
+
+      it('should verify it is story when using Meta', () => {
+        const fileIsStory = isTheFileAStory(
+          appTree,
+          'test-ui-lib/src/lib/button/button.other.stories.ts'
         );
         expect(fileIsStory).toBeTruthy();
       });

--- a/packages/storybook/src/utils/utilities.ts
+++ b/packages/storybook/src/utils/utilities.ts
@@ -221,6 +221,7 @@ export function isTheFileAStory(tree: Tree, path: string): boolean {
       importSpecifiers.forEach((importSpecifier: ts.ImportSpecifier) => {
         if (
           importSpecifier.getText() === 'Story' ||
+          importSpecifier.getText() === 'Meta' ||
           importSpecifier.getText() === 'storiesOf' ||
           importSpecifier.getText() === 'ComponentStory'
         ) {


### PR DESCRIPTION
closed #17965

## Current Behavior

`import type { Meta } from '@storybook/react';` is not recognized as a Story import.

## Expected Behavior

`import type { Meta } from '@storybook/react';` should be recognized as a Story import. No need to `import {Story}` any more, `Meta` suffices.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17965
