### PR TITLE
fix(core): do not cache external dependency hashes if they are not fully resolved

### DIFF
--- a/packages/nx/src/hasher/task-hasher.spec.ts
+++ b/packages/nx/src/hasher/task-hasher.spec.ts
@@ -1161,7 +1161,7 @@ describe('TaskHasher', () => {
       expect(hash.value).toContain('|5.0.0|');
     });
 
-    it('should hash entire subtree of dependencies', async () => {
+    it('should hash entire subtree in a deterministic way', async () => {
       const createHasher = () =>
         new InProcessTaskHasher(
           {},
@@ -1217,44 +1217,51 @@ describe('TaskHasher', () => {
             dependencies: {
               appA: [
                 {
-                  source: 'app',
+                  source: 'appA',
                   target: 'npm:packageA',
                   type: DependencyType.static,
                 },
                 {
-                  source: 'app',
+                  source: 'appA',
                   target: 'npm:packageB',
                   type: DependencyType.static,
                 },
                 {
-                  source: 'app',
+                  source: 'appA',
                   target: 'npm:packageC',
                   type: DependencyType.static,
                 },
               ],
               appB: [
                 {
-                  source: 'app',
+                  source: 'appB',
                   target: 'npm:packageC',
                   type: DependencyType.static,
                 },
               ],
               'npm:packageC': [
                 {
-                  source: 'app',
+                  source: 'npm:packageC',
                   target: 'npm:packageA',
                   type: DependencyType.static,
                 },
                 {
-                  source: 'app',
+                  source: 'npm:packageC',
                   target: 'npm:packageB',
                   type: DependencyType.static,
                 },
               ],
               'npm:packageB': [
                 {
-                  source: 'app',
+                  source: 'npm:packageB',
                   target: 'npm:packageA',
+                  type: DependencyType.static,
+                },
+              ],
+              'npm:packageA': [
+                {
+                  source: 'npm:packageA',
+                  target: 'npm:packageC',
                   type: DependencyType.static,
                 },
               ],
@@ -1288,15 +1295,16 @@ describe('TaskHasher', () => {
 
       const hasher1 = createHasher();
 
-      await computeTaskHash(hasher1, 'appA');
+      const hasAppA1 = await computeTaskHash(hasher1, 'appA');
       const hashAppB1 = await computeTaskHash(hasher1, 'appB');
 
       const hasher2 = createHasher();
 
       const hashAppB2 = await computeTaskHash(hasher2, 'appB');
-      await computeTaskHash(hasher2, 'appA');
+      const hasAppA2 = await computeTaskHash(hasher2, 'appA');
 
       expect(hashAppB1).toEqual(hashAppB2);
+      expect(hasAppA1).toEqual(hasAppA2);
     });
 
     it('should not hash when nx:run-commands executor', async () => {


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
External dependency hashes are not deterministic and could cause cache misses, since the hash is dependent on which task was hashed when.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Task hashes should not depend on which task have been hashed earlier.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17917
