### PR TITLE
fix(storybook): dont throw if no project-level tsconfig

### DIFF
--- a/packages/storybook/src/generators/configuration/lib/util-functions.ts
+++ b/packages/storybook/src/generators/configuration/lib/util-functions.ts
@@ -675,7 +675,7 @@ export function renameAndMoveOldTsConfig(
   pathToStorybookConfigFile: string,
   tree: Tree
 ) {
-  if (pathToStorybookConfigFile) {
+  if (pathToStorybookConfigFile && tree.exists(pathToStorybookConfigFile)) {
     updateJson(tree, pathToStorybookConfigFile, (json) => {
       if (json.extends?.startsWith('../')) {
         // drop one level of nesting
@@ -718,6 +718,11 @@ export function renameAndMoveOldTsConfig(
   }
 
   const projectTsConfig = joinPathFragments(projectRoot, 'tsconfig.json');
+
+  if (!tree.exists(projectTsConfig)) {
+    return;
+  }
+
   updateJson(tree, projectTsConfig, (json) => {
     for (let i = 0; i < json.references?.length; i++) {
       if (json.references[i].path === './.storybook/tsconfig.json') {


### PR DESCRIPTION

## Current Behavior

Throws if it does not find `.storybook/tsconfig.json` or project's tsconfig.json.

## Expected Behavior
Should not throw.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18014
