### PR TITLE
chore(react): Remove swcLoaderVersion import in application generator

### DIFF
--- a/packages/react/src/generators/application/application.ts
+++ b/packages/react/src/generators/application/application.ts
@@ -32,7 +32,7 @@ import { mapLintPattern } from '@nx/linter/src/generators/lint-project/lint-proj
 import {
   babelLoaderVersion,
   nxRspackVersion,
-  nxVersion
+  nxVersion,
 } from '../../utils/versions';
 import { installCommonDependencies } from './lib/install-common-dependencies';
 import { extractTsConfigBase } from '../../utils/create-ts-config';

--- a/packages/react/src/generators/application/application.ts
+++ b/packages/react/src/generators/application/application.ts
@@ -32,8 +32,7 @@ import { mapLintPattern } from '@nx/linter/src/generators/lint-project/lint-proj
 import {
   babelLoaderVersion,
   nxRspackVersion,
-  nxVersion,
-  swcLoaderVersion,
+  nxVersion
 } from '../../utils/versions';
 import { installCommonDependencies } from './lib/install-common-dependencies';
 import { extractTsConfigBase } from '../../utils/create-ts-config';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The `swcLoaderVersion` constant in react app generator is imported but not used

## Expected Behavior

Remove swcLoaderVersion import in application generator

## Related Issue(s)

Fixes #
