### PR TITLE
fix(core): add missing perf_hooks import in tasks-runner/cache

### DIFF
--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -1,6 +1,7 @@
 import { workspaceRoot } from '../utils/workspace-root';
 import { mkdir, mkdirSync, pathExists, readFile, writeFile } from 'fs-extra';
 import { join } from 'path';
+import { performance } from 'perf_hooks';
 import { DefaultTasksRunnerOptions } from './default-tasks-runner';
 import { spawn } from 'child_process';
 import { cacheDir } from '../utils/cache-directory';


### PR DESCRIPTION
## Current Behavior
task-runner's cache is using nodejs's global `performance`, which only introduce in node@16. 
This broke any code that still depend on node@14

## Expected Behavior
Other place in the code base is import performance from perf_hooks modules.
```import { performance } from 'perf_hooks';```

## Related Issue(s)

Fixes #17986
