### PR TITLE
fix(core): handle undefined target defaults

### DIFF
--- a/packages/nx/src/tasks-runner/create-task-graph.ts
+++ b/packages/nx/src/tasks-runner/create-task-graph.ts
@@ -388,10 +388,10 @@ export function createTaskGraph(
 }
 
 export function mapTargetDefaultsToDependencies(
-  defaults: TargetDefaults
+  defaults: TargetDefaults | undefined
 ): TargetDependencies {
   const res = {};
-  Object.keys(defaults).forEach((k) => {
+  Object.keys(defaults ?? {}).forEach((k) => {
     res[k] = defaults[k].dependsOn;
   });
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Some commands (e.g. `nx graph`) fail when `targetDefaults` is not defined in `nx.json`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `targetDefaults` option in `nx.json` is optional and should be handled correctly when not defined.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18038 
