### PR TITLE
feat(vite): server executor `https` prop as object

### DIFF
--- a/docs/generated/packages/vite/executors/dev-server.json
+++ b/docs/generated/packages/vite/executors/dev-server.json
@@ -37,7 +37,10 @@
         "description": "Specify which IP addresses the server should listen on.",
         "oneOf": [{ "type": "boolean" }, { "type": "string" }]
       },
-      "https": { "type": "boolean", "description": "Serve using HTTPS." },
+      "https": {
+        "oneOf": [{ "type": "boolean" }, { "type": "object" }],
+        "description": "Serve using HTTPS. https://vitejs.dev/config/server-options.html#server-https"
+      },
       "hmr": {
         "description": "Enable hot module replacement. For more options, use the 'hmr' option in the Vite configuration file.",
         "type": "boolean"

--- a/docs/generated/packages/vite/executors/preview-server.json
+++ b/docs/generated/packages/vite/executors/preview-server.json
@@ -27,7 +27,10 @@
         "description": "Specify which IP addresses the server should listen on.",
         "oneOf": [{ "type": "boolean" }, { "type": "string" }]
       },
-      "https": { "type": "boolean", "description": "Serve using HTTPS." },
+      "https": {
+        "oneOf": [{ "type": "boolean" }, { "type": "object" }],
+        "description": "Serve using HTTPS. https://vitejs.dev/config/server-options.html#server-https"
+      },
       "open": {
         "description": "Automatically open the app in the browser on server start. When the value is a string, it will be used as the URL's pathname.",
         "oneOf": [{ "type": "boolean" }, { "type": "string" }]

--- a/packages/vite/src/executors/dev-server/schema.d.ts
+++ b/packages/vite/src/executors/dev-server/schema.d.ts
@@ -4,7 +4,7 @@ export interface ViteDevServerExecutorOptions {
   proxyConfig?: string;
   port?: number;
   host?: string | boolean;
-  https?: boolean;
+  https?: boolean | Json;
   hmr?: boolean;
   open?: string | boolean;
   cors?: boolean;

--- a/packages/vite/src/executors/dev-server/schema.json
+++ b/packages/vite/src/executors/dev-server/schema.json
@@ -48,8 +48,15 @@
       ]
     },
     "https": {
-      "type": "boolean",
-      "description": "Serve using HTTPS."
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object"
+        }
+      ],
+      "description": "Serve using HTTPS. https://vitejs.dev/config/server-options.html#server-https"
     },
     "hmr": {
       "description": "Enable hot module replacement. For more options, use the 'hmr' option in the Vite configuration file.",

--- a/packages/vite/src/executors/preview-server/schema.d.ts
+++ b/packages/vite/src/executors/preview-server/schema.d.ts
@@ -3,7 +3,7 @@ export interface VitePreviewServerExecutorOptions {
   proxyConfig?: string;
   port?: number;
   host?: string | boolean;
-  https?: boolean;
+  https?: boolean | Json;
   open?: string | boolean;
   logLevel?: 'info' | 'warn' | 'error' | 'silent';
   mode?: string;

--- a/packages/vite/src/executors/preview-server/schema.json
+++ b/packages/vite/src/executors/preview-server/schema.json
@@ -41,8 +41,15 @@
       ]
     },
     "https": {
-      "type": "boolean",
-      "description": "Serve using HTTPS."
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object"
+        }
+      ],
+      "description": "Serve using HTTPS. https://vitejs.dev/config/server-options.html#server-https"
     },
     "open": {
       "description": "Automatically open the app in the browser on server start. When the value is a string, it will be used as the URL's pathname.",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Vite's "dev-server" and "preview-server" property `https` accept only a boolean.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Vite's "dev-server" and "preview-server" property `https` accept a boolean or an object.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17835
