### PR TITLE
fix(angular): explicitly depend on find-cache-dir to avoid npm resolution conflict

### DIFF
--- a/packages-legacy/angular/ng-package.json
+++ b/packages-legacy/angular/ng-package.json
@@ -26,7 +26,8 @@
     "webpack",
     "http-server",
     "magic-string",
-    "enquirer"
+    "enquirer",
+    "find-cache-dir"
   ],
   "keepLifecycleScripts": true
 }

--- a/packages/angular/ng-package.json
+++ b/packages/angular/ng-package.json
@@ -25,7 +25,8 @@
     "webpack",
     "http-server",
     "magic-string",
-    "enquirer"
+    "enquirer",
+    "find-cache-dir"
   ],
   "keepLifecycleScripts": true
 }

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -49,6 +49,7 @@
     "@typescript-eslint/type-utils": "^5.36.1",
     "chalk": "^4.1.0",
     "chokidar": "^3.5.1",
+    "find-cache-dir": "^3.3.2",
     "http-server": "^14.1.0",
     "ignore": "^5.0.4",
     "magic-string": "~0.26.2",

--- a/scripts/depcheck/missing.ts
+++ b/scripts/depcheck/missing.ts
@@ -36,7 +36,6 @@ const IGNORE_MATCHES_IN_PACKAGE = {
     'injection-js',
     'browserslist',
     'cacache',
-    'find-cache-dir',
     'less',
     'node-sass',
     'node-sass-tilde-importer',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

A recent version of `babel-loader` (a dependency of `@nx/webpack` which is a dependency of `@nx/angular`) depends on a version of `find-cache-dir` distributed as ESM. This causes the `ng-packagr` executors to throw because the `@nx/angular` package does not depend directly on that package and the package manager can resolve the unexpected version at the root.

This was caught by the Nigthly E2E tests: https://github.com/nrwl/nx/actions/runs/5502618546/jobs/10027062285#step:16:195

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `ng-packagr` executors work correctly.

**Note:** Doing a dynamic import in this case is not possible because the code using that package needs to be synchronous and using a dynamic import would make it async.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
