### PR TITLE
fix(core): ensure proper yarn version detection even for nested projects

### DIFF
--- a/docs/generated/devkit/nx_devkit.md
+++ b/docs/generated/devkit/nx_devkit.md
@@ -1397,7 +1397,7 @@ execSync(`${getPackageManagerCommand().addDev} my-dev-package`);
 
 ### getPackageManagerVersion
 
-▸ **getPackageManagerVersion**(`packageManager?`): `string`
+▸ **getPackageManagerVersion**(`packageManager?`, `cwd?`): `string`
 
 Returns the version of the package manager used in the workspace.
 By default, the package manager is derived based on the lock file,
@@ -1408,6 +1408,7 @@ but it can also be passed in explicitly.
 | Name             | Type                                                                |
 | :--------------- | :------------------------------------------------------------------ |
 | `packageManager` | [`PackageManager`](../../devkit/documents/nx_devkit#packagemanager) |
+| `cwd`            | `string`                                                            |
 
 #### Returns
 

--- a/docs/generated/packages/devkit/documents/nx_devkit.md
+++ b/docs/generated/packages/devkit/documents/nx_devkit.md
@@ -1397,7 +1397,7 @@ execSync(`${getPackageManagerCommand().addDev} my-dev-package`);
 
 ### getPackageManagerVersion
 
-▸ **getPackageManagerVersion**(`packageManager?`): `string`
+▸ **getPackageManagerVersion**(`packageManager?`, `cwd?`): `string`
 
 Returns the version of the package manager used in the workspace.
 By default, the package manager is derived based on the lock file,
@@ -1408,6 +1408,7 @@ but it can also be passed in explicitly.
 | Name             | Type                                                                |
 | :--------------- | :------------------------------------------------------------------ |
 | `packageManager` | [`PackageManager`](../../devkit/documents/nx_devkit#packagemanager) |
+| `cwd`            | `string`                                                            |
 
 #### Returns
 

--- a/e2e/workspace-create/src/create-nx-workspace.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace.test.ts
@@ -446,6 +446,7 @@ describe('create-nx-workspace yarn berry', () => {
     runCommand('yarn set version stable', { cwd: tmpDir });
     // previous command creates a package.json file which we don't want
     rmSync(`${tmpDir}/package.json`);
+    process.env.YARN_ENABLE_IMMUTABLE_INSTALLS = 'false';
   });
 
   afterEach(() => cleanupProject({ cwd: `${tmpDir}/${wsName}` }));
@@ -462,7 +463,12 @@ describe('create-nx-workspace yarn berry', () => {
     expect(existsSync(`${tmpDir}/${wsName}/.yarnrc.yml`)).toBeTruthy();
     expect(
       readFileSync(`${tmpDir}/${wsName}/.yarnrc.yml`, { encoding: 'utf-8' })
-    ).toMatchInlineSnapshot();
+    ).toMatchInlineSnapshot(`
+      "nodeLinker: node-modules
+
+      yarnPath: .yarn/releases/yarn-3.6.1.cjs
+      "
+    `);
   });
 
   it('should create a js workspace with yarn berry', () => {
@@ -477,6 +483,11 @@ describe('create-nx-workspace yarn berry', () => {
     expect(existsSync(`${tmpDir}/${wsName}/.yarnrc.yml`)).toBeTruthy();
     expect(
       readFileSync(`${tmpDir}/${wsName}/.yarnrc.yml`, { encoding: 'utf-8' })
-    ).toMatchInlineSnapshot();
+    ).toMatchInlineSnapshot(`
+      "nodeLinker: node-modules
+
+      yarnPath: .yarn/releases/yarn-3.6.1.cjs
+      "
+    `);
   });
 });

--- a/e2e/workspace-create/src/create-nx-workspace.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace.test.ts
@@ -13,7 +13,7 @@ import {
   runCreateWorkspace,
   uniq,
 } from '@nx/e2e/utils';
-import { existsSync, mkdirSync, readdirSync, rmSync } from 'fs-extra';
+import { existsSync, mkdirSync, rmSync } from 'fs-extra';
 
 describe('create-nx-workspace', () => {
   const packageManager = getSelectedPackageManager() || 'pnpm';
@@ -441,7 +441,8 @@ describe('create-nx-workspace yarn berry', () => {
 
   beforeAll(() => {
     mkdirSync(tmpDir, { recursive: true });
-    runCommand('yarn set version berry', { cwd: tmpDir });
+    runCommand('corepack prepare yarn@3 --activate', { cwd: tmpDir });
+    runCommand('yarn set version stable', { cwd: tmpDir });
     // previous command creates a package.json file which we don't want
     rmSync(`${tmpDir}/package.json`);
   });
@@ -458,7 +459,8 @@ describe('create-nx-workspace yarn berry', () => {
     });
 
     expect(existsSync(`${tmpDir}/${wsName}/package.json`)).toBeTruthy();
-    console.log(readdirSync(`${tmpDir}/${wsName}`));
+    const packageJson = readJson('package.json');
+    expect(packageJson.packageManager).toMatch(/yarn@3/);
   });
 
   it('should create a js workspace with yarn berry', () => {
@@ -471,6 +473,7 @@ describe('create-nx-workspace yarn berry', () => {
     });
 
     expect(existsSync(`${tmpDir}/${wsName}/package.json`)).toBeTruthy();
-    console.log(readdirSync(`${tmpDir}/${wsName}`));
+    const packageJson = readJson('package.json');
+    expect(packageJson.packageManager).toMatch(/yarn@3/);
   });
 });

--- a/e2e/workspace-create/src/create-nx-workspace.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace.test.ts
@@ -441,7 +441,7 @@ describe('create-nx-workspace yarn berry', () => {
 
   beforeAll(() => {
     mkdirSync(tmpDir, { recursive: true });
-    runCommand('corepack prepare yarn@3 --activate', { cwd: tmpDir });
+    runCommand('corepack prepare yarn@stable --activate', { cwd: tmpDir });
     runCommand('yarn set version stable', { cwd: tmpDir });
     // previous command creates a package.json file which we don't want
     rmSync(`${tmpDir}/package.json`);

--- a/e2e/workspace-create/src/create-nx-workspace.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace.test.ts
@@ -13,6 +13,7 @@ import {
   runCreateWorkspace,
   uniq,
 } from '@nx/e2e/utils';
+import { readFileSync } from 'fs';
 import { existsSync, mkdirSync, rmSync } from 'fs-extra';
 
 describe('create-nx-workspace', () => {
@@ -458,9 +459,10 @@ describe('create-nx-workspace yarn berry', () => {
       cwd: tmpDir,
     });
 
-    expect(existsSync(`${tmpDir}/${wsName}/package.json`)).toBeTruthy();
-    const packageJson = readJson('package.json');
-    expect(packageJson.packageManager).toMatch(/yarn@3/);
+    expect(existsSync(`${tmpDir}/${wsName}/.yarnrc.yml`)).toBeTruthy();
+    expect(
+      readFileSync(`${tmpDir}/${wsName}/.yarnrc.yml`, { encoding: 'utf-8' })
+    ).toMatchInlineSnapshot();
   });
 
   it('should create a js workspace with yarn berry', () => {
@@ -472,8 +474,9 @@ describe('create-nx-workspace yarn berry', () => {
       cwd: tmpDir,
     });
 
-    expect(existsSync(`${tmpDir}/${wsName}/package.json`)).toBeTruthy();
-    const packageJson = readJson('package.json');
-    expect(packageJson.packageManager).toMatch(/yarn@3/);
+    expect(existsSync(`${tmpDir}/${wsName}/.yarnrc.yml`)).toBeTruthy();
+    expect(
+      readFileSync(`${tmpDir}/${wsName}/.yarnrc.yml`, { encoding: 'utf-8' })
+    ).toMatchInlineSnapshot();
   });
 });

--- a/e2e/workspace-create/src/create-nx-workspace.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace.test.ts
@@ -9,10 +9,11 @@ import {
   getSelectedPackageManager,
   packageManagerLockFile,
   readJson,
+  runCommand,
   runCreateWorkspace,
   uniq,
 } from '@nx/e2e/utils';
-import { existsSync, mkdirSync } from 'fs-extra';
+import { existsSync, mkdirSync, readdirSync, rmSync } from 'fs-extra';
 
 describe('create-nx-workspace', () => {
   const packageManager = getSelectedPackageManager() || 'pnpm';
@@ -414,7 +415,7 @@ describe('create-nx-workspace', () => {
   });
 });
 
-describe('create-nx-workspace custom parent folder', () => {
+describe('create-nx-workspace parent folder', () => {
   const tmpDir = `${e2eCwd}/${uniq('with space')}`;
   const wsName = uniq('parent');
   const packageManager = getSelectedPackageManager() || 'pnpm';
@@ -431,5 +432,45 @@ describe('create-nx-workspace custom parent folder', () => {
     });
 
     expect(existsSync(`${tmpDir}/${wsName}/package.json`)).toBeTruthy();
+  });
+});
+
+describe('create-nx-workspace yarn berry', () => {
+  const tmpDir = `${e2eCwd}/${uniq('yarn-berry')}`;
+  let wsName: string;
+
+  beforeAll(() => {
+    mkdirSync(tmpDir, { recursive: true });
+    runCommand('yarn set version berry', { cwd: tmpDir });
+    // previous command creates a package.json file which we don't want
+    rmSync(`${tmpDir}/package.json`);
+  });
+
+  afterEach(() => cleanupProject({ cwd: `${tmpDir}/${wsName}` }));
+
+  it('should create a workspace with yarn berry', () => {
+    wsName = uniq('apps');
+
+    runCreateWorkspace(wsName, {
+      preset: 'apps',
+      packageManager: 'yarn',
+      cwd: tmpDir,
+    });
+
+    expect(existsSync(`${tmpDir}/${wsName}/package.json`)).toBeTruthy();
+    console.log(readdirSync(`${tmpDir}/${wsName}`));
+  });
+
+  it('should create a js workspace with yarn berry', () => {
+    wsName = uniq('ts');
+
+    runCreateWorkspace(wsName, {
+      preset: 'ts',
+      packageManager: 'yarn',
+      cwd: tmpDir,
+    });
+
+    expect(existsSync(`${tmpDir}/${wsName}/package.json`)).toBeTruthy();
+    console.log(readdirSync(`${tmpDir}/${wsName}`));
   });
 });

--- a/packages/create-nx-workspace/src/create-empty-workspace.ts
+++ b/packages/create-nx-workspace/src/create-empty-workspace.ts
@@ -53,7 +53,9 @@ export async function createEmptyWorkspace<T extends CreateWorkspaceOptions>(
     /\s/.test(nxWorkspaceRoot) &&
     packageManager === 'npm'
   ) {
-    const pmVersion = +getPackageManagerVersion(packageManager).split('.')[0];
+    const pmVersion = +getPackageManagerVersion(packageManager, tmpDir).split(
+      '.'
+    )[0];
     if (pmVersion < 7) {
       nxWorkspaceRoot = `\\"${nxWorkspaceRoot.slice(1, -1)}\\"`;
     }

--- a/packages/create-nx-workspace/src/create-preset.ts
+++ b/packages/create-nx-workspace/src/create-preset.ts
@@ -33,7 +33,10 @@ export async function createPreset<T extends CreateWorkspaceOptions>(
     /\s/.test(nxWorkspaceRoot) &&
     packageManager === 'npm'
   ) {
-    const pmVersion = +getPackageManagerVersion(packageManager).split('.')[0];
+    const pmVersion = +getPackageManagerVersion(
+      packageManager,
+      workingDir
+    ).split('.')[0];
     if (pmVersion < 7) {
       nxWorkspaceRoot = `\\"${nxWorkspaceRoot.slice(1, -1)}\\"`;
     }

--- a/packages/create-nx-workspace/src/create-sandbox.ts
+++ b/packages/create-nx-workspace/src/create-sandbox.ts
@@ -23,7 +23,7 @@ export async function createSandbox(packageManager: PackageManager) {
     `Installing dependencies with ${packageManager}`
   ).start();
 
-  const { install } = getPackageManagerCommand(packageManager);
+  const { install, preInstall } = getPackageManagerCommand(packageManager);
 
   const tmpDir = dirSync().name;
   try {
@@ -38,6 +38,10 @@ export async function createSandbox(packageManager: PackageManager) {
       })
     );
     generatePackageManagerFiles(tmpDir, packageManager);
+
+    if (preInstall) {
+      await execAndWait(preInstall, tmpDir);
+    }
 
     await execAndWait(install, tmpDir);
 

--- a/packages/create-nx-workspace/src/create-sandbox.ts
+++ b/packages/create-nx-workspace/src/create-sandbox.ts
@@ -4,7 +4,7 @@ import * as ora from 'ora';
 import { join } from 'path';
 
 import {
-  updatePackageManagerFiles,
+  generatePackageManagerFiles,
   getPackageManagerCommand,
   PackageManager,
 } from './utils/package-manager';
@@ -29,19 +29,15 @@ export async function createSandbox(packageManager: PackageManager) {
   try {
     writeFileSync(
       join(tmpDir, 'package.json'),
-      JSON.stringify(
-        {
-          dependencies: {
-            nx: nxVersion,
-            '@nx/workspace': nxVersion,
-          },
-          license: 'MIT',
+      JSON.stringify({
+        dependencies: {
+          nx: nxVersion,
+          '@nx/workspace': nxVersion,
         },
-        null,
-        2
-      )
+        license: 'MIT',
+      })
     );
-    updatePackageManagerFiles(tmpDir, packageManager);
+    generatePackageManagerFiles(tmpDir, packageManager);
 
     await execAndWait(install, tmpDir);
 

--- a/packages/create-nx-workspace/src/create-sandbox.ts
+++ b/packages/create-nx-workspace/src/create-sandbox.ts
@@ -6,6 +6,7 @@ import { join } from 'path';
 import {
   generatePackageManagerFiles,
   getPackageManagerCommand,
+  getPackageManagerVersion,
   PackageManager,
 } from './utils/package-manager';
 import { execAndWait } from './utils/child-process-utils';
@@ -25,17 +26,25 @@ export async function createSandbox(packageManager: PackageManager) {
 
   const { install, preInstall } = getPackageManagerCommand(packageManager);
 
+  const packageJson: any = {
+    dependencies: {
+      nx: nxVersion,
+      '@nx/workspace': nxVersion,
+    },
+    license: 'MIT',
+  };
+
+  // if it's yarn, we want to add the version information to the package.json
+  if (packageManager === 'yarn') {
+    const yarnVersion = getPackageManagerVersion(packageManager);
+    packageJson.packageManager = `yarn@${yarnVersion}`;
+  }
+
   const tmpDir = dirSync().name;
   try {
     writeFileSync(
       join(tmpDir, 'package.json'),
-      JSON.stringify({
-        dependencies: {
-          nx: nxVersion,
-          '@nx/workspace': nxVersion,
-        },
-        license: 'MIT',
-      })
+      JSON.stringify(packageJson, null, 2)
     );
     generatePackageManagerFiles(tmpDir, packageManager);
 

--- a/packages/create-nx-workspace/src/utils/package-manager.ts
+++ b/packages/create-nx-workspace/src/utils/package-manager.ts
@@ -75,7 +75,7 @@ export function updatePackageManagerFiles(
 ) {
   switch (packageManager) {
     case 'yarn':
-      const yarnVersion = getPackageManagerVersion(packageManager);
+      const yarnVersion = getPackageManagerVersion(packageManager, root);
       const [pmMajor] = yarnVersion.split('.');
       const packageJson = JSON.parse(
         readFileSync(join(root, 'package.json'), 'utf-8')
@@ -98,12 +98,13 @@ export function updatePackageManagerFiles(
 const pmVersionCache = new Map<PackageManager, string>();
 
 export function getPackageManagerVersion(
-  packageManager: PackageManager
+  packageManager: PackageManager,
+  cwd = process.cwd()
 ): string {
   if (pmVersionCache.has(packageManager)) {
     return pmVersionCache.get(packageManager) as string;
   }
-  const version = execSync(`${packageManager} --version`)
+  const version = execSync(`${packageManager} --version`, { cwd })
     .toString('utf-8')
     .trim();
   pmVersionCache.set(packageManager, version);

--- a/packages/create-nx-workspace/src/utils/package-manager.ts
+++ b/packages/create-nx-workspace/src/utils/package-manager.ts
@@ -48,7 +48,8 @@ export function getPackageManagerCommand(
         install: useBerry
           ? installCommand
           : `${installCommand} --ignore-scripts`,
-        exec: 'yarn',
+        // using npx is necessary to avoid yarn classic manipulating the version detection when using berry
+        exec: useBerry ? 'npx' : 'yarn',
       };
 
     case 'pnpm':

--- a/packages/create-nx-workspace/src/utils/package-manager.ts
+++ b/packages/create-nx-workspace/src/utils/package-manager.ts
@@ -70,7 +70,7 @@ export function getPackageManagerCommand(
   }
 }
 
-export function updatePackageManagerFiles(
+export function generatePackageManagerFiles(
   root: string,
   packageManager: PackageManager = detectPackageManager()
 ) {
@@ -82,10 +82,7 @@ export function updatePackageManagerFiles(
         readFileSync(join(root, 'package.json'), 'utf-8')
       );
       packageJson.packageManager = `yarn@${yarnVersion}`;
-      writeFileSync(
-        join(root, 'package.json'),
-        JSON.stringify(packageJson, null, 2)
-      );
+      writeFileSync(join(root, 'package.json'), JSON.stringify(packageJson));
       if (+pmMajor >= 2) {
         writeFileSync(
           join(root, '.yarnrc.yml'),

--- a/packages/devkit/src/tasks/install-packages-task.ts
+++ b/packages/devkit/src/tasks/install-packages-task.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { type ExecSyncOptions, execSync } from 'child_process';
 import { join } from 'path';
 import { requireNx } from '../../nx';
 
@@ -38,9 +38,13 @@ export function installPackagesTask(
   if (storedPackageJsonValue != packageJsonValue || alwaysRun) {
     global['__packageJsonInstallCache__'] = packageJsonValue;
     const pmc = getPackageManagerCommand(packageManager);
-    execSync(pmc.install, {
+    const execSyncOptions: ExecSyncOptions = {
       cwd: join(tree.root, cwd),
       stdio: process.env.NX_GENERATE_QUIET === 'true' ? 'ignore' : 'inherit',
-    });
+    };
+    if (pmc.preInstall) {
+      execSync(pmc.preInstall, execSyncOptions);
+    }
+    execSync(pmc.install, execSyncOptions);
   }
 }

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -129,7 +129,10 @@ export function getPackageManagerVersion(
   packageManager: PackageManager = detectPackageManager(),
   cwd = process.cwd()
 ): string {
-  return execSync(`${packageManager} --version`, { cwd })
+  delete process.env.npm_config_user_agent;
+  delete process.env.npm_execpath;
+
+  return execSync(`${packageManager} --version`, { cwd, env: process.env })
     .toString('utf-8')
     .trim();
 }

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -129,12 +129,10 @@ export function getPackageManagerVersion(
   packageManager: PackageManager = detectPackageManager(),
   cwd = process.cwd()
 ): string {
-  delete process.env.npm_config_user_agent;
-  delete process.env.npm_execpath;
-
-  return execSync(`${packageManager} --version`, { cwd, env: process.env })
-    .toString('utf-8')
-    .trim();
+  return execSync(`${packageManager} --version`, {
+    cwd,
+    encoding: 'utf-8',
+  }).trim();
 }
 
 /**

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -61,7 +61,7 @@ export function getPackageManagerCommand(
 ): PackageManagerCommands {
   const commands: { [pm in PackageManager]: () => PackageManagerCommands } = {
     yarn: () => {
-      const yarnVersion = getPackageManagerVersion('yarn');
+      const yarnVersion = getPackageManagerVersion('yarn', root);
       const useBerry = gte(yarnVersion, '2.0.0');
 
       return {
@@ -81,7 +81,7 @@ export function getPackageManagerCommand(
       };
     },
     pnpm: () => {
-      const pnpmVersion = getPackageManagerVersion('pnpm');
+      const pnpmVersion = getPackageManagerVersion('pnpm', root);
       const useExec = gte(pnpmVersion, '6.13.0');
       const includeDoubleDashBeforeArgs = lt(pnpmVersion, '7.0.0');
       const isPnpmWorkspace = existsSync(join(root, 'pnpm-workspace.yaml'));
@@ -126,9 +126,12 @@ export function getPackageManagerCommand(
  * but it can also be passed in explicitly.
  */
 export function getPackageManagerVersion(
-  packageManager: PackageManager = detectPackageManager()
+  packageManager: PackageManager = detectPackageManager(),
+  cwd = process.cwd()
 ): string {
-  return execSync(`${packageManager} --version`).toString('utf-8').trim();
+  return execSync(`${packageManager} --version`, { cwd })
+    .toString('utf-8')
+    .trim();
 }
 
 /**

--- a/packages/workspace/src/generators/new/generate-workspace-files.spec.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.spec.ts
@@ -11,6 +11,8 @@ describe('@nx/workspace:generateWorkspaceFiles', () => {
 
   beforeEach(() => {
     tree = createTree();
+    // we need an actual path for the package manager version check
+    tree.root = process.cwd();
   });
 
   it('should create files', async () => {

--- a/packages/workspace/src/generators/new/generate-workspace-files.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.ts
@@ -44,6 +44,8 @@ export async function generateWorkspaceFiles(
       json.packageManager = `yarn@${packageManagerVersion}`;
       return json;
     });
+    // avoids errors when using nested yarn projects
+    tree.write(join(options.directory, 'yarn.lock'), '');
   }
   setPresetProperty(tree, options);
   addNpmScripts(tree, options);

--- a/packages/workspace/src/generators/new/generate-workspace-files.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.ts
@@ -27,13 +27,20 @@ export async function generateWorkspaceFiles(
   createFiles(tree, options);
   createNxJson(tree, options);
 
-  const [packageMajor] = getPackageManagerVersion(
+  const packageManagerVersion = getPackageManagerVersion(
     options.packageManager as PackageManager
-  ).split('.');
+  );
+  const [packageMajor] = packageManagerVersion.split('.');
   if (options.packageManager === 'pnpm' && +packageMajor >= 7) {
     createNpmrc(tree, options);
-  } else if (options.packageManager === 'yarn' && +packageMajor >= 2) {
-    createYarnrcYml(tree, options);
+  } else if (options.packageManager === 'yarn') {
+    if (+packageMajor >= 2) {
+      createYarnrcYml(tree, options);
+    }
+    updateJson(tree, join(options.directory, 'package.json'), (json) => {
+      json.packageManager = `yarn@${packageManagerVersion}`;
+      return json;
+    });
   }
   setPresetProperty(tree, options);
   addNpmScripts(tree, options);

--- a/packages/workspace/src/generators/new/generate-workspace-files.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.ts
@@ -39,13 +39,9 @@ export async function generateWorkspaceFiles(
   } else if (options.packageManager === 'yarn') {
     if (+packageMajor >= 2) {
       createYarnrcYml(tree, options);
+      // avoids errors when using nested yarn projects
+      tree.write(join(options.directory, 'yarn.lock'), '');
     }
-    updateJson(tree, join(options.directory, 'package.json'), (json) => {
-      json.packageManager = `yarn@${packageManagerVersion}`;
-      return json;
-    });
-    // avoids errors when using nested yarn projects
-    tree.write(join(options.directory, 'yarn.lock'), '');
   }
   setPresetProperty(tree, options);
   addNpmScripts(tree, options);

--- a/packages/workspace/src/generators/new/generate-workspace-files.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.ts
@@ -10,7 +10,7 @@ import {
   writeJson,
 } from '@nx/devkit';
 import { nxVersion } from '../../utils/versions';
-import { join, join as pathJoin } from 'path';
+import { join } from 'path';
 import { Preset } from '../utils/presets';
 import { deduceDefaultBase } from '../../utilities/default-base';
 import { NormalizedSchema } from './new';
@@ -22,14 +22,17 @@ export async function generateWorkspaceFiles(
   if (!options.name) {
     throw new Error(`Invalid options, "name" is required.`);
   }
+  // we need to check package manager version before the package.json is generated
+  // since it might influence the version report
+  const packageManagerVersion = getPackageManagerVersion(
+    options.packageManager as PackageManager,
+    tree.root
+  );
   options = normalizeOptions(options);
   createReadme(tree, options);
   createFiles(tree, options);
   createNxJson(tree, options);
 
-  const packageManagerVersion = getPackageManagerVersion(
-    options.packageManager as PackageManager
-  );
   const [packageMajor] = packageManagerVersion.split('.');
   if (options.packageManager === 'pnpm' && +packageMajor >= 7) {
     createNpmrc(tree, options);
@@ -140,7 +143,7 @@ function createFiles(tree: Tree, options: NormalizedSchema) {
       : options.preset === Preset.NPM || options.preset === Preset.Core
       ? './files-package-based-repo'
       : './files-integrated-repo';
-  generateFiles(tree, pathJoin(__dirname, filesDirName), options.directory, {
+  generateFiles(tree, join(__dirname, filesDirName), options.directory, {
     formattedNames,
     dot: '.',
     tmpl: '',

--- a/packages/workspace/src/generators/new/new.spec.ts
+++ b/packages/workspace/src/generators/new/new.spec.ts
@@ -32,6 +32,8 @@ describe('new', () => {
 
   beforeEach(() => {
     tree = createTree();
+    // we need an actual path for the package manager version check
+    tree.root = process.cwd();
   });
 
   it('should generate an empty nx.json', async () => {


### PR DESCRIPTION
This PR solves the `yarn` version detection for `create-nx-workspace` when user has multiple versions of `yarn` set up.

The yarn version should be detected from the nearest parent folder or the global config when none-found.

This fix also allows us to test changes with E2E tests.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
