### PR TITLE
feat(testing): update jest to v29.6.1

### DIFF
--- a/packages/jest/migrations.json
+++ b/packages/jest/migrations.json
@@ -285,6 +285,39 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "16.5.2": {
+      "version": "16.5.2-beta.0",
+      "packages": {
+        "jest": {
+          "version": "~29.6.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@types/jest": {
+          "version": "~29.5.3",
+          "alwaysAddToPackageJson": false
+        },
+        "expect": {
+          "version": "~29.6.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@jest/globals": {
+          "version": "~29.6.1",
+          "alwaysAddToPackageJson": false
+        },
+        "jest-jasmine2": {
+          "version": "~29.6.1",
+          "alwaysAddToPackageJson": false
+        },
+        "jest-environment-jsdom": {
+          "version": "~29.6.1",
+          "alwaysAddToPackageJson": false
+        },
+        "babel-jest": {
+          "version": "~29.6.1",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/jest/src/utils/versions.ts
+++ b/packages/jest/src/utils/versions.ts
@@ -1,7 +1,7 @@
 export const nxVersion = require('../../package.json').version;
-export const jestVersion = '^29.4.1';
-export const babelJestVersion = '^29.4.1';
-export const jestTypesVersion = '^29.4.0';
+export const jestVersion = '^29.6.1';
+export const babelJestVersion = '^29.6.1';
+export const jestTypesVersion = '^29.5.3';
 export const tsJestVersion = '^29.1.0';
 export const tslibVersion = '^2.3.0';
 export const swcJestVersion = '0.2.20';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
jest v29.6.0 contains bug fixes that benefit nx users but users most likely won't bump versions until v30 with a jest migration

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

migrate workspaces to use jest v29.6.1

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #15752
