### PR TITLE
fix(misc): fix migrations updating target options to consider target defaults

### DIFF
--- a/packages/angular/src/migrations/update-16-6-0/explicitly-set-projects-to-update-buildable-deps.ts
+++ b/packages/angular/src/migrations/update-16-6-0/explicitly-set-projects-to-update-buildable-deps.ts
@@ -1,6 +1,7 @@
 import {
+  createProjectGraphAsync,
   formatFiles,
-  getProjects,
+  readProjectConfiguration,
   Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
@@ -13,30 +14,36 @@ const executors = new Set([
 ]);
 
 export default async function (tree: Tree) {
-  const projects = getProjects(tree);
+  // use project graph to get the expanded target configurations
+  const projectGraph = await createProjectGraphAsync();
 
-  for (const [projectName, project] of projects) {
-    if (project.projectType !== 'library') {
+  for (const [projectName, { data: projectData }] of Object.entries(
+    projectGraph.nodes
+  )) {
+    if (projectData.projectType !== 'library') {
       continue;
     }
 
-    let updated = false;
-    for (const [, target] of Object.entries(project.targets || {})) {
+    for (const [targetName, target] of Object.entries(
+      projectData.targets || {}
+    )) {
       if (!executors.has(target.executor)) {
         continue;
       }
 
       if (
-        target.options &&
+        !target.options ||
         target.options.updateBuildableProjectDepsInPackageJson === undefined
       ) {
-        target.options.updateBuildableProjectDepsInPackageJson = true;
-        updated = true;
+        // read the project configuration to write the explicit project configuration
+        // and avoid writing the expanded target configuration
+        const project = readProjectConfiguration(tree, projectName);
+        project.targets[targetName].options ??= {};
+        project.targets[
+          targetName
+        ].options.updateBuildableProjectDepsInPackageJson = true;
+        updateProjectConfiguration(tree, projectName, project);
       }
-    }
-
-    if (updated) {
-      updateProjectConfiguration(tree, projectName, project);
     }
   }
 

--- a/packages/js/src/migrations/update-16-6-0/explicitly-set-projects-to-update-buildable-deps.spec.ts
+++ b/packages/js/src/migrations/update-16-6-0/explicitly-set-projects-to-update-buildable-deps.spec.ts
@@ -1,11 +1,18 @@
 import {
   ProjectConfiguration,
+  ProjectGraph,
   Tree,
   addProjectConfiguration,
   readProjectConfiguration,
 } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import migration from './explicitly-set-projects-to-update-buildable-deps';
+
+let projectGraph: ProjectGraph;
+jest.mock('@nx/devkit', () => ({
+  ...jest.requireActual('@nx/devkit'),
+  createProjectGraphAsync: () => Promise.resolve(projectGraph),
+}));
 
 describe('explicitly-set-projects-to-update-buildable-deps migration', () => {
   let tree: Tree;
@@ -17,7 +24,7 @@ describe('explicitly-set-projects-to-update-buildable-deps migration', () => {
   it.each(['@nx/js:swc', '@nrwl/js:swc', '@nx/js:tsc', '@nrwl/js:tsc'])(
     'should set updateBuildableProjectDepsInPackageJson option to "true" when not specified in target using "%s"',
     async (executor) => {
-      addProjectConfiguration(tree, 'lib1', {
+      addProject(tree, 'lib1', {
         root: 'libs/lib1',
         projectType: 'library',
         targets: { build: { executor, options: {} } },
@@ -33,9 +40,27 @@ describe('explicitly-set-projects-to-update-buildable-deps migration', () => {
   );
 
   it.each(['@nx/js:swc', '@nrwl/js:swc', '@nx/js:tsc', '@nrwl/js:tsc'])(
+    'should set updateBuildableProjectDepsInPackageJson option to "true" when target has no options object defined using "%s"',
+    async (executor) => {
+      addProject(tree, 'lib1', {
+        root: 'libs/lib1',
+        projectType: 'library',
+        targets: { build: { executor } },
+      });
+
+      await migration(tree);
+
+      const project = readProjectConfiguration(tree, 'lib1');
+      expect(
+        project.targets.build.options.updateBuildableProjectDepsInPackageJson
+      ).toBe(true);
+    }
+  );
+
+  it.each(['@nx/js:swc', '@nrwl/js:swc', '@nx/js:tsc', '@nrwl/js:tsc'])(
     'should not overwrite updateBuildableProjectDepsInPackageJson option when it is specified in target using "%s"',
     async (executor) => {
-      addProjectConfiguration(tree, 'lib1', {
+      addProject(tree, 'lib1', {
         root: 'libs/lib1',
         projectType: 'library',
         targets: {
@@ -66,7 +91,7 @@ describe('explicitly-set-projects-to-update-buildable-deps migration', () => {
         },
       },
     };
-    addProjectConfiguration(tree, 'lib1', originalProjectConfig);
+    addProject(tree, 'lib1', originalProjectConfig);
 
     await migration(tree);
 
@@ -74,3 +99,21 @@ describe('explicitly-set-projects-to-update-buildable-deps migration', () => {
     expect(project.targets).toStrictEqual(originalProjectConfig.targets);
   });
 });
+
+function addProject(
+  tree: Tree,
+  projectName: string,
+  config: ProjectConfiguration
+): void {
+  projectGraph = {
+    dependencies: {},
+    nodes: {
+      [projectName]: {
+        data: config,
+        name: projectName,
+        type: config.projectType === 'application' ? 'app' : 'lib',
+      },
+    },
+  };
+  addProjectConfiguration(tree, projectName, config);
+}

--- a/packages/js/src/migrations/update-16-6-0/explicitly-set-projects-to-update-buildable-deps.ts
+++ b/packages/js/src/migrations/update-16-6-0/explicitly-set-projects-to-update-buildable-deps.ts
@@ -1,6 +1,7 @@
 import {
+  createProjectGraphAsync,
   formatFiles,
-  getProjects,
+  readProjectConfiguration,
   Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
@@ -13,30 +14,36 @@ const executors = new Set([
 ]);
 
 export default async function (tree: Tree) {
-  const projects = getProjects(tree);
+  // use project graph to get the expanded target configurations
+  const projectGraph = await createProjectGraphAsync();
 
-  for (const [projectName, project] of projects) {
-    if (project.projectType !== 'library') {
+  for (const [projectName, { data: projectData }] of Object.entries(
+    projectGraph.nodes
+  )) {
+    if (projectData.projectType !== 'library') {
       continue;
     }
 
-    let updated = false;
-    for (const [, target] of Object.entries(project.targets || {})) {
+    for (const [targetName, target] of Object.entries(
+      projectData.targets || {}
+    )) {
       if (!executors.has(target.executor)) {
         continue;
       }
 
       if (
-        target.options &&
+        !target.options ||
         target.options.updateBuildableProjectDepsInPackageJson === undefined
       ) {
-        target.options.updateBuildableProjectDepsInPackageJson = true;
-        updated = true;
+        // read the project configuration to write the explicit project configuration
+        // and avoid writing the expanded target configuration
+        const project = readProjectConfiguration(tree, projectName);
+        project.targets[targetName].options ??= {};
+        project.targets[
+          targetName
+        ].options.updateBuildableProjectDepsInPackageJson = true;
+        updateProjectConfiguration(tree, projectName, project);
       }
-    }
-
-    if (updated) {
-      updateProjectConfiguration(tree, projectName, project);
     }
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The migrations introduced in https://github.com/nrwl/nx/pull/17920 switching the default value for the `updateBuildableProjectDepsInPackageJson` option don't consider the possible target defaults in `nx.json`. Also, they don't explicitly set the option when the `options` property is not defined in the project configuration.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The migrations introduced in https://github.com/nrwl/nx/pull/17920 switching the default value for the `updateBuildableProjectDepsInPackageJson` option should consider the possible target defaults in `nx.json`. They should also explicitly set the option when the `options` property is not defined in the project configuration.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
