### PR TITLE
fix(core): use concat in buildAllWorkspaceFiles to avoid Maximum call stack size exceeded

### DIFF
--- a/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
+++ b/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
@@ -109,7 +109,7 @@ function buildAllWorkspaceFiles(
   performance.mark('get-all-workspace-files:start');
   let fileData = Object.values(projectFileMap).flat();
 
-  fileData.push(...globalFiles);
+  fileData = fileData.concat(globalFiles);
   performance.mark('get-all-workspace-files:end');
   performance.measure(
     'get-all-workspace-files',


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

Use `.concat` instead of `.push(...arr)` to avoid `Maximum call stack size exceeded`.

## Current Behavior
<!-- This is the behavior we have today -->

Got this error in an large monorepo:

```
/home/********/project/node_modules/.pnpm/nx@16.5.0/node_modules/nx/src/project-graph/utils/retrieve-workspace-files.js:68
    fileData.push(...globalFiles);
             ^

RangeError: Maximum call stack size exceeded
    at buildAllWorkspaceFiles (/home/********/project/node_modules/.pnpm/nx@16.5.0/node_modules/nx/src/project-graph/utils/retrieve-workspace-files.js:68:14)
    at /home/********/project/node_modules/.pnpm/nx@16.5.0/node_modules/nx/src/project-graph/utils/retrieve-workspace-files.js:43:32
    at Generator.next (<anonymous>)
    at fulfilled (/home/********/project/node_modules/.pnpm/tslib@2.6.0/node_modules/tslib/tslib.js:166:62)
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Do not throw `RangeError: Maximum call stack size exceeded`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
