### PR TITLE
docs(core): mixing package-based and integrated

### DIFF
--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -2030,6 +2030,22 @@
             "isExternal": false,
             "children": [
               {
+                "name": "Add a Package-based Project in an Integrated Repo",
+                "path": "/recipes/tips-n-tricks/package-based-in-integrated",
+                "id": "package-based-in-integrated",
+                "isExternal": false,
+                "children": [],
+                "disableCollapsible": false
+              },
+              {
+                "name": "Add an Integrated Project in a Package-based Repo",
+                "path": "/recipes/tips-n-tricks/integrated-in-package-based",
+                "id": "integrated-in-package-based",
+                "isExternal": false,
+                "children": [],
+                "disableCollapsible": false
+              },
+              {
                 "name": "Configuring ESLint with Typescript",
                 "path": "/recipes/tips-n-tricks/eslint",
                 "id": "eslint",
@@ -3054,6 +3070,22 @@
         "isExternal": false,
         "children": [
           {
+            "name": "Add a Package-based Project in an Integrated Repo",
+            "path": "/recipes/tips-n-tricks/package-based-in-integrated",
+            "id": "package-based-in-integrated",
+            "isExternal": false,
+            "children": [],
+            "disableCollapsible": false
+          },
+          {
+            "name": "Add an Integrated Project in a Package-based Repo",
+            "path": "/recipes/tips-n-tricks/integrated-in-package-based",
+            "id": "integrated-in-package-based",
+            "isExternal": false,
+            "children": [],
+            "disableCollapsible": false
+          },
+          {
             "name": "Configuring ESLint with Typescript",
             "path": "/recipes/tips-n-tricks/eslint",
             "id": "eslint",
@@ -3158,6 +3190,22 @@
             "disableCollapsible": false
           }
         ],
+        "disableCollapsible": false
+      },
+      {
+        "name": "Add a Package-based Project in an Integrated Repo",
+        "path": "/recipes/tips-n-tricks/package-based-in-integrated",
+        "id": "package-based-in-integrated",
+        "isExternal": false,
+        "children": [],
+        "disableCollapsible": false
+      },
+      {
+        "name": "Add an Integrated Project in a Package-based Repo",
+        "path": "/recipes/tips-n-tricks/integrated-in-package-based",
+        "id": "integrated-in-package-based",
+        "isExternal": false,
+        "children": [],
         "disableCollapsible": false
       },
       {

--- a/docs/generated/manifests/nx.json
+++ b/docs/generated/manifests/nx.json
@@ -2530,6 +2530,26 @@
         "file": "",
         "itemList": [
           {
+            "id": "package-based-in-integrated",
+            "name": "Add a Package-based Project in an Integrated Repo",
+            "description": "",
+            "file": "shared/recipes/repo-types/package-based-in-integrated",
+            "itemList": [],
+            "isExternal": false,
+            "path": "/recipes/tips-n-tricks/package-based-in-integrated",
+            "tags": ["repository-types"]
+          },
+          {
+            "id": "integrated-in-package-based",
+            "name": "Add an Integrated Project in a Package-based Repo",
+            "description": "",
+            "file": "shared/recipes/repo-types/integrated-in-package-based",
+            "itemList": [],
+            "isExternal": false,
+            "path": "/recipes/tips-n-tricks/integrated-in-package-based",
+            "tags": ["repository-types"]
+          },
+          {
             "id": "eslint",
             "name": "Configuring ESLint with Typescript",
             "description": "",
@@ -3808,6 +3828,26 @@
     "file": "",
     "itemList": [
       {
+        "id": "package-based-in-integrated",
+        "name": "Add a Package-based Project in an Integrated Repo",
+        "description": "",
+        "file": "shared/recipes/repo-types/package-based-in-integrated",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/recipes/tips-n-tricks/package-based-in-integrated",
+        "tags": ["repository-types"]
+      },
+      {
+        "id": "integrated-in-package-based",
+        "name": "Add an Integrated Project in a Package-based Repo",
+        "description": "",
+        "file": "shared/recipes/repo-types/integrated-in-package-based",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/recipes/tips-n-tricks/integrated-in-package-based",
+        "tags": ["repository-types"]
+      },
+      {
         "id": "eslint",
         "name": "Configuring ESLint with Typescript",
         "description": "",
@@ -3941,6 +3981,26 @@
     "isExternal": false,
     "path": "/recipes/tips-n-tricks",
     "tags": []
+  },
+  "/recipes/tips-n-tricks/package-based-in-integrated": {
+    "id": "package-based-in-integrated",
+    "name": "Add a Package-based Project in an Integrated Repo",
+    "description": "",
+    "file": "shared/recipes/repo-types/package-based-in-integrated",
+    "itemList": [],
+    "isExternal": false,
+    "path": "/recipes/tips-n-tricks/package-based-in-integrated",
+    "tags": ["repository-types"]
+  },
+  "/recipes/tips-n-tricks/integrated-in-package-based": {
+    "id": "integrated-in-package-based",
+    "name": "Add an Integrated Project in a Package-based Repo",
+    "description": "",
+    "file": "shared/recipes/repo-types/integrated-in-package-based",
+    "itemList": [],
+    "isExternal": false,
+    "path": "/recipes/tips-n-tricks/integrated-in-package-based",
+    "tags": ["repository-types"]
   },
   "/recipes/tips-n-tricks/eslint": {
     "id": "eslint",

--- a/docs/generated/manifests/tags.json
+++ b/docs/generated/manifests/tags.json
@@ -612,6 +612,20 @@
     },
     {
       "description": "",
+      "file": "shared/recipes/repo-types/package-based-in-integrated",
+      "id": "package-based-in-integrated",
+      "name": "Add a Package-based Project in an Integrated Repo",
+      "path": "/recipes/tips-n-tricks/package-based-in-integrated"
+    },
+    {
+      "description": "",
+      "file": "shared/recipes/repo-types/integrated-in-package-based",
+      "id": "integrated-in-package-based",
+      "name": "Add an Integrated Project in a Package-based Repo",
+      "path": "/recipes/tips-n-tricks/integrated-in-package-based"
+    },
+    {
+      "description": "",
       "file": "shared/recipes/repo-types/standalone-to-integrated",
       "id": "standalone-to-integrated",
       "name": "Convert from a Standalone Repository to an Integrated Repository",

--- a/docs/map.json
+++ b/docs/map.json
@@ -810,6 +810,18 @@
               "description": "Various tips and tricks for using Nx.",
               "itemList": [
                 {
+                  "name": "Add a Package-based Project in an Integrated Repo",
+                  "id": "package-based-in-integrated",
+                  "tags": ["repository-types"],
+                  "file": "shared/recipes/repo-types/package-based-in-integrated"
+                },
+                {
+                  "name": "Add an Integrated Project in a Package-based Repo",
+                  "id": "integrated-in-package-based",
+                  "tags": ["repository-types"],
+                  "file": "shared/recipes/repo-types/integrated-in-package-based"
+                },
+                {
                   "name": "Configuring ESLint with Typescript",
                   "id": "eslint",
                   "file": "shared/eslint"

--- a/docs/shared/recipes/repo-types/integrated-in-package-based.md
+++ b/docs/shared/recipes/repo-types/integrated-in-package-based.md
@@ -5,7 +5,7 @@ In a package-based repository, you've intentionally opted out of some of Nx's fe
 To add an integrated project:
 
 1. Install the plugin you want to use (i.e. `npm install @nx/react`)
-2. Generate an application using that plugin (i.e. `nx g @nx/react:app`)
+2. Generate an application or library using that plugin (i.e. `nx g @nx/react:app`)
 
 The integrated project is now ready to use. Next, we'll discuss some of the changes that were applied to your codebase.
 
@@ -15,15 +15,15 @@ All the dependencies that are required for an integrated project are maintained 
 
 ## tsconfig.base.json
 
-Even if the project you added only uses javascript, a `tsconfig.base.json` file is generated in the root of the repo. This file is needed for the tooling that Nx provides.
-
-## .eslintrc.json
-
-Most Nx plugins will set up `eslint` for you so you can [Enforce Module Boundaries](/core-features/enforce-project-boundaries) between projects.
+Even if the project you added only uses javascript, a `tsconfig.base.json` file is generated in the root of the repo. This file is needed for the tooling that Nx provides.  Nx creates a typescript `path` alias for each library and then uses that path (rather than npm/yarn/pnpm workspaces) to allow local projects to reference the library.
 
 ## project.json
 
 The project itself will have a `project.json` file that defines all the tasks that can be run on the project. This includes tasks like `build`, `serve` and `test`. See [Use Task Executors](/plugin-features/use-task-executors) for more information.
+
+## Other Configuration Files
+
+Depending on the type of integrated project you created, there may be other configuration files.  These could include files like `.eslintrc.json`, `jest.config.ts` and a project-level `tsconfig.json`.
 
 ## Code Generators
 

--- a/docs/shared/recipes/repo-types/integrated-in-package-based.md
+++ b/docs/shared/recipes/repo-types/integrated-in-package-based.md
@@ -11,23 +11,23 @@ The integrated project is now ready to use. Next, we'll discuss some of the chan
 
 ## package.json dependencies
 
-All the dependencies that are required for an integrated project are maintained in the root `package.json` file. In order to use the plugin's [Automate Updating Framework Dependencies](/core-features/automate-updating-dependencies) feature, we recommend using a [Single Version Policy](/more-concepts/dependency-management#single-version-policy) for integrated projects.
+All the dependencies that are required for an integrated project are maintained in the root `package.json` file. In order to use the plugin's [Automate Updating Framework Dependencies](/core-features/automate-updating-dependencies) feature, we recommend using a [Single Version Policy](/concepts/more-concepts/dependency-management#single-version-policy) for integrated projects.
 
 ## tsconfig.base.json
 
-Even if the project you added only uses javascript, a `tsconfig.base.json` file is generated in the root of the repo. This file is needed for the tooling that Nx provides.  Nx creates a typescript `path` alias for each library and then uses that path (rather than npm/yarn/pnpm workspaces) to allow local projects to reference the library.
+Even if the project you added only uses javascript, a `tsconfig.base.json` file is generated in the root of the repo. This file is needed for the tooling that Nx provides. Nx creates a typescript `path` alias for each library and then uses that path (rather than npm/yarn/pnpm workspaces) to allow local projects to reference the library.
 
 ## project.json
 
-The project itself will have a `project.json` file that defines all the tasks that can be run on the project. This includes tasks like `build`, `serve` and `test`. See [Use Task Executors](/plugin-features/use-task-executors) for more information.
+The project itself will have a `project.json` file that defines all the tasks that can be run on the project. This includes tasks like `build`, `serve` and `test`. See [Use Task Executors](/core-features/plugin-features/use-task-executors) for more information.
 
 ## Other Configuration Files
 
-Depending on the type of integrated project you created, there may be other configuration files.  These could include files like `.eslintrc.json`, `jest.config.ts` and a project-level `tsconfig.json`.
+Depending on the type of integrated project you created, there may be other configuration files. These could include files like `.eslintrc.json`, `jest.config.ts` and a project-level `tsconfig.json`.
 
 ## Code Generators
 
-The Nx plugin you installed provides code generators that you can use to scaffold out your application quickly and in a consistent way. See [Use Code Generators](/plugin-features/use-code-generators) for more information.
+The Nx plugin you installed provides code generators that you can use to scaffold out your application quickly and in a consistent way. See [Use Code Generators](/core-features/plugin-features/use-code-generators) for more information.
 
 ## Summary
 

--- a/docs/shared/recipes/repo-types/integrated-in-package-based.md
+++ b/docs/shared/recipes/repo-types/integrated-in-package-based.md
@@ -1,0 +1,34 @@
+# Add an Integrated Project in a Package-based Repository
+
+In a package-based repository, you've intentionally opted out of some of Nx's features in order to give yourself more flexibility. If you decide to add a new project using the integrated style, the process is straight-forward.
+
+To add an integrated project:
+
+1. Install the plugin you want to use (i.e. `npm install @nx/react`)
+2. Generate an application using that plugin (i.e. `nx g @nx/react:app`)
+
+The integrated project is now ready to use. Next, we'll discuss some of the changes that were applied to your codebase.
+
+## package.json dependencies
+
+All the dependencies that are required for an integrated project are maintained in the root `package.json` file. In order to use the plugin's [Automate Updating Framework Dependencies](/core-features/automate-updating-dependencies) feature, we recommend using a [Single Version Policy](/more-concepts/dependency-management#single-version-policy) for integrated projects.
+
+## tsconfig.base.json
+
+Even if the project you added only uses javascript, a `tsconfig.base.json` file is generated in the root of the repo. This file is needed for the tooling that Nx provides.
+
+## .eslintrc.json
+
+Most Nx plugins will set up `eslint` for you so you can [Enforce Module Boundaries](/core-features/enforce-project-boundaries) between projects.
+
+## project.json
+
+The project itself will have a `project.json` file that defines all the tasks that can be run on the project. This includes tasks like `build`, `serve` and `test`. See [Use Task Executors](/plugin-features/use-task-executors) for more information.
+
+## Code Generators
+
+The Nx plugin you installed provides code generators that you can use to scaffold out your application quickly and in a consistent way. See [Use Code Generators](/plugin-features/use-code-generators) for more information.
+
+## Summary
+
+You can opt in to using Nx's integrated features on a per project basis. This allows you to experiment with the functionality to see if the value those features provide is worth giving up some of the flexibility a package-based repository gives you.

--- a/docs/shared/recipes/repo-types/package-based-in-integrated.md
+++ b/docs/shared/recipes/repo-types/package-based-in-integrated.md
@@ -1,0 +1,45 @@
+# Add a Package-Based Project in an Integrated Repository
+
+An integrated repo offers a lot of features at the cost of some flexibility, but sometimes you want to take back control of your build system or dependency management for a single project in the repo. This recipe shows you how to do that.
+
+A package-based project in an integrated repository is a project that has at least one of these characteristics:
+
+1. Maintains its own dependencies with a separate package.json file
+2. Runs tasks without the use of an Nx plugin
+3. Scaffolds code without the use of Nx generators
+
+For this example, we'll implement all three, but you can also have a project that has only one of these characteristics and falls back to an integrated style for the others.
+
+## Create Your Project
+
+Because this is a package-based project, we won't use Nx to generate the project. We can create the project in whatever way is typical for the framework you're trying to add. This could mean using the framework's own CLI or manually adding files yourself.
+
+For Nx to be aware of your project, it needs:
+
+1. npm, yarn or pnpm workspaces set up in the root `package.json` file
+2. A `package.json` file in the project folder with a `name` specified
+3. Some scripts defined in the project's `package.json` file for Nx to run
+
+## Maintain Separate Dependencies
+
+If you choose to have this project define its own dependencies separately from the root `package.json` file, simply define those `dependencies` and `devDependencies` in the project's `package.json` file.
+
+With [npm](https://docs.npmjs.com/cli/v7/using-npm/workspaces)/[yarn](https://classic.yarnpkg.com/lang/en/docs/workspaces/)/[pnpm](https://pnpm.io/workspaces) workspaces set up, you can run the install command at the root of the repository and every project will have its dependencies installed.
+
+There are difficulties with code sharing when you maintain separate dependencies. See the [Dependency Management Strategies](/more-concepts/dependency-management) guide for more information.
+
+## Run Tasks Without the Use of an Nx Plugin
+
+Any task you define in the scripts section of the project's `package.json` can be executed by Nx. These scripts can be cached and orchestrated in the same way a `target` defined in `project.json` is. If you want to define some tasks in `project.json` and some tasks in `package.json`, Nx will read both and merge the configurations.
+
+## Scaffold Code Without the Use of Nx Generators
+
+Whatever tools you want to use to help scaffold out code should work just fine in an Nx repo. You can even call other code mod tools from within an Nx generator (see [Using jscodeshift Codemods](/plugins/recipes/composing-generators#using-jscodeshift-codemods)).
+
+## Updating Dependencies
+
+Because this is a package-based project, you'll be managing your own updates for this project. In addition, you'll need to be careful when running the `nx migrate` command on the rest of the repo. There may be times where a migration changes code in this package-based project when it shouldn't. You'll need to manually revert those changes before committing.
+
+## Summary
+
+An integrated Nx repo does not lock you into only using Nx plugins for all of your projects. You can always opt-out of using certain features and take on the responsibility of managing that functionality yourself.

--- a/docs/shared/recipes/repo-types/package-based-in-integrated.md
+++ b/docs/shared/recipes/repo-types/package-based-in-integrated.md
@@ -4,9 +4,8 @@ An integrated repo offers a lot of features at the cost of some flexibility, but
 
 A package-based project in an integrated repository is a project that has at least one of these characteristics:
 
-1. Maintains its own dependencies with a separate package.json file
-2. Runs tasks without the use of an Nx plugin
-3. Scaffolds code without the use of Nx generators
+1. Maintains its own dependencies with a separate `package.json` file
+2. Defines tasks in a `package.json` file that don't use Nx executors
 
 For this example, we'll implement all three, but you can also have a project that has only one of these characteristics and falls back to an integrated style for the others.
 
@@ -20,11 +19,13 @@ For Nx to be aware of your project, it needs:
 2. A `package.json` file in the project folder with a `name` specified
 3. Some scripts defined in the project's `package.json` file for Nx to run
 
-## Maintain Separate Dependencies
+## Setup NPM/Yarn/PNPM Workspaces
 
-If you choose to have this project define its own dependencies separately from the root `package.json` file, simply define those `dependencies` and `devDependencies` in the project's `package.json` file.
+If you choose to have this project define its dependencies separately from the root `package.json` file, simply define those `dependencies` and `devDependencies` in the project's `package.json` file.
 
 With [npm](https://docs.npmjs.com/cli/v7/using-npm/workspaces)/[yarn](https://classic.yarnpkg.com/lang/en/docs/workspaces/)/[pnpm](https://pnpm.io/workspaces) workspaces set up, you can run the install command at the root of the repository and every project will have its dependencies installed.
+
+When you manage dependencies this way, you can still hoist dependencies to the root-level `package.json` file, but you have to make the explicit decision for each dependency.
 
 There are difficulties with code sharing when you maintain separate dependencies. See the [Dependency Management Strategies](/more-concepts/dependency-management) guide for more information.
 
@@ -32,9 +33,46 @@ There are difficulties with code sharing when you maintain separate dependencies
 
 Any task you define in the scripts section of the project's `package.json` can be executed by Nx. These scripts can be cached and orchestrated in the same way a `target` defined in `project.json` is. If you want to define some tasks in `project.json` and some tasks in `package.json`, Nx will read both and merge the configurations.
 
-## Scaffold Code Without the Use of Nx Generators
+A typical set up where the `test` task depends on the `build` task could look like this:
 
-Whatever tools you want to use to help scaffold out code should work just fine in an Nx repo. You can even call other code mod tools from within an Nx generator (see [Using jscodeshift Codemods](/plugins/recipes/composing-generators#using-jscodeshift-codemods)).
+{% tabs %}
+{% tab label="package.json" %}
+
+```jsonc {% fileName="package.json"%}
+{
+  "scripts": {
+    "build": "tsc",
+    "test": "jest"
+  },
+  "nx": {
+    "targets": {
+      "test": {
+        "dependsOn": ["build"]
+      }
+    }
+  }
+}
+```
+
+{% /tab %}
+{% tab label="project.json" %}
+
+```jsonc {% fileName="project.json"%}
+{
+  "targets": {
+    "build": {
+      "command": "tsc"
+    },
+    "test": {
+      "command": "jest",
+      "dependsOn": ["build"]
+    }
+  }
+}
+```
+
+{% /tab %}
+{% /tabs %}
 
 ## Updating Dependencies
 

--- a/docs/shared/recipes/repo-types/package-based-in-integrated.md
+++ b/docs/shared/recipes/repo-types/package-based-in-integrated.md
@@ -27,7 +27,7 @@ With [npm](https://docs.npmjs.com/cli/v7/using-npm/workspaces)/[yarn](https://cl
 
 When you manage dependencies this way, you can still hoist dependencies to the root-level `package.json` file, but you have to make the explicit decision for each dependency.
 
-There are difficulties with code sharing when you maintain separate dependencies. See the [Dependency Management Strategies](/more-concepts/dependency-management) guide for more information.
+There are difficulties with code sharing when you maintain separate dependencies. See the [Dependency Management Strategies](/concepts/more-concepts/dependency-management) guide for more information.
 
 ## Run Tasks Without the Use of an Nx Plugin
 

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -141,6 +141,8 @@
       - [Setting up GitLab](/recipes/ci/monorepo-ci-gitlab)
       - [Setting up Bitbucket](/recipes/ci/monorepo-ci-bitbucket-pipelines)
     - [Tips and tricks](/recipes/tips-n-tricks)
+      - [Add a Package-based Project in an Integrated Repo](/recipes/tips-n-tricks/package-based-in-integrated)
+      - [Add an Integrated Project in a Package-based Repo](/recipes/tips-n-tricks/integrated-in-package-based)
       - [Configuring ESLint with Typescript](/recipes/tips-n-tricks/eslint)
       - [Define Environment Variables](/recipes/tips-n-tricks/define-environment-variables)
       - [Configuring Browser Support](/recipes/tips-n-tricks/browser-support)


### PR DESCRIPTION
Adds two recipes:
    - [Add a Package-based Project in an Integrated Repo](https://nx-dev-git-fork-isaacplmann-docs-package-based-in-i-d80774-nrwl.vercel.app//recipes/managing-repository/package-based-in-integrated)
    - [Add an Integrated Project in a Package-based Repo](https://nx-dev-git-fork-isaacplmann-docs-package-based-in-i-d80774-nrwl.vercel.app//recipes/managing-repository/integrated-in-package-based)
