### PR TITLE
fix(misc): prompt for workspace name when creating it using nx init

### DIFF
--- a/packages/nx/src/command-line/init/init.ts
+++ b/packages/nx/src/command-line/init/init.ts
@@ -25,7 +25,8 @@ export interface InitArgs {
 }
 
 export async function initHandler(options: InitArgs) {
-  const args = process.argv.slice(2).join(' ');
+  // strip the 'init' command itself so we don't forward it
+  const args = process.argv.slice(3).join(' ');
   const flags = parser(args, {
     boolean: ['useDotNxInstallation'],
     alias: {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When running `nx init` for creating a new workspace, there's no prompt for the workspace name and the generated workspace is named `init`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Running `nx init` for creating a new workspace should prompt for the workspace name if not provided.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
