### PR TITLE
fix(core): do not duplicate output of tasks executed in batch mode

### DIFF
--- a/packages/nx/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/nx/src/tasks-runner/forked-process-task-runner.ts
@@ -78,30 +78,9 @@ export class ForkedProcessTaskRunner {
           }
         });
 
-        const printedTasks = new Set<string>();
         p.on('message', (message: BatchMessage) => {
           switch (message.type) {
-            case BatchMessageType.CompleteTask: {
-              this.options.lifeCycle.printTaskTerminalOutput(
-                batchTaskGraph.tasks[message.task],
-                message.result.success ? 'success' : 'failure',
-                message.result.terminalOutput
-              );
-              printedTasks.add(message.task);
-
-              break;
-            }
             case BatchMessageType.CompleteBatchExecution: {
-              Object.entries(message.results).forEach(([taskName, result]) => {
-                if (!printedTasks.has(taskName)) {
-                  this.options.lifeCycle.printTaskTerminalOutput(
-                    batchTaskGraph.tasks[taskName],
-                    result.success ? 'success' : 'failure',
-                    result.terminalOutput
-                  );
-                }
-              });
-
               res(message.results);
               break;
             }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When running tasks in batch mode, their output is duplicated. This happens because the batch execution process prints the output and the runner also prints the terminal output for each task on completion. Printing the terminal output using the lifecycle object should only be done when not streaming the output, but batch execution only supports streaming the outputs as of now.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When running tasks in batch mode, their output should not be duplicated.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
