### PR TITLE
fix(expo): Correct schema for export executor

### DIFF
--- a/docs/generated/packages/expo/executors/export.json
+++ b/docs/generated/packages/expo/executors/export.json
@@ -34,11 +34,11 @@
         "description": "Maximum number of tasks to allow Metro to spawn"
       },
       "dumpAssetmap": {
-        "type": "string",
+        "type": "boolean",
         "description": "Dump the asset map for further processing"
       },
       "dumpSourcemap": {
-        "type": "string",
+        "type": "boolean",
         "description": "Dump the source map for debugging the JS bundle"
       },
       "bundler": {

--- a/packages/expo/src/executors/export/schema.json
+++ b/packages/expo/src/executors/export/schema.json
@@ -31,11 +31,11 @@
       "description": "Maximum number of tasks to allow Metro to spawn"
     },
     "dumpAssetmap": {
-      "type": "string",
+      "type": "boolean",
       "description": "Dump the asset map for further processing"
     },
     "dumpSourcemap": {
-      "type": "string",
+      "type": "boolean",
       "description": "Dump the source map for debugging the JS bundle"
     },
     "bundler": {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Cannot provide the dumpSourcemap or dumpAssetmap args to expo export executor

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

You can provide the dumpSourcemap and dumpAssetmap args to expo executor

Expo CLI reference: https://github.com/expo/expo-cli/blob/9250eefb151ff17a6873093c7ff33b20597d03d6/packages/expo-cli/src/commands/export/exportAppAsync.ts#L57C1-L57C1

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
