### PR TITLE
Revert "feat(testing): update jest to v29.6.1 (#18061)"

### DIFF
--- a/packages/jest/migrations.json
+++ b/packages/jest/migrations.json
@@ -285,39 +285,6 @@
           "alwaysAddToPackageJson": false
         }
       }
-    },
-    "16.5.2": {
-      "version": "16.5.2-beta.0",
-      "packages": {
-        "jest": {
-          "version": "~29.6.1",
-          "alwaysAddToPackageJson": false
-        },
-        "@types/jest": {
-          "version": "~29.5.3",
-          "alwaysAddToPackageJson": false
-        },
-        "expect": {
-          "version": "~29.6.1",
-          "alwaysAddToPackageJson": false
-        },
-        "@jest/globals": {
-          "version": "~29.6.1",
-          "alwaysAddToPackageJson": false
-        },
-        "jest-jasmine2": {
-          "version": "~29.6.1",
-          "alwaysAddToPackageJson": false
-        },
-        "jest-environment-jsdom": {
-          "version": "~29.6.1",
-          "alwaysAddToPackageJson": false
-        },
-        "babel-jest": {
-          "version": "~29.6.1",
-          "alwaysAddToPackageJson": false
-        }
-      }
     }
   }
 }

--- a/packages/jest/src/utils/versions.ts
+++ b/packages/jest/src/utils/versions.ts
@@ -1,7 +1,7 @@
 export const nxVersion = require('../../package.json').version;
-export const jestVersion = '^29.6.1';
-export const babelJestVersion = '^29.6.1';
-export const jestTypesVersion = '^29.5.3';
+export const jestVersion = '^29.4.1';
+export const babelJestVersion = '^29.4.1';
+export const jestTypesVersion = '^29.4.0';
 export const tsJestVersion = '^29.1.0';
 export const tslibVersion = '^2.3.0';
 export const swcJestVersion = '0.2.20';


### PR DESCRIPTION
This reverts commit 90172c579c70f3e793b9eb2867e7428a869f954a.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

jest v29.6.1 appears to be having a memory leak of some kinds causing CI to crash with OOM when testing angular

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
nx own tests should not start failing in CI with jest version bumps

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
maybe related: 
https://github.com/jestjs/jest/issues/14042


some extra notes while investigating:
1. seems like tests that contain more imports that require transformations use more memory (obviously), but that memory is never freed. it just keeps growing. I would expect it to start going down after the transformed code is consumed and saved to cache?
2. --detectLeaks (beta feature of jest) shows ever test has a leak, so maybe something there in our code setup might be doing something weird?
3. did not see anything with --detectOpenHandles for the angular tests
4. switching to another transformer (swc/jest) required refactoring all tests with mocks to make sure the import order is loading correctly (about 150 tests) but even when those tests weren't running heap usage was around 2 GB, when CI was dying around 1.8 GB (locally with ts-jest showing 2.8-3 GB of memory usage) and those last 150 tests might still reach the same usage?
5. usage of jest v29.4.3 is around 800MB with a spike around 2GB (then drops back down pretty quick)
