### PR TITLE
docs(angular): document PNPM workaround for ngcc

### DIFF
--- a/docs/shared/guides/setup-incremental-builds-angular.md
+++ b/docs/shared/guides/setup-incremental-builds-angular.md
@@ -26,8 +26,24 @@ installation. You can check your `package.json` and make sure you have the follo
 }
 ```
 
-{% callout type="warning" title="ngcc limitations" %}
-Please note that `ngcc` doesn’t support `pnpm` ([#32087](https://github.com/angular/angular/issues/32087#issuecomment-523225437) and [#38023](https://github.com/angular/angular/issues/38023#issuecomment-732423078)), so you need to use either `yarn` or `npm`.
+{% callout type="warning" title="PNPM support" %}
+To use `ngcc` with `pnpm`, set [`node-linker=hoisted` in `.npmrc`](https://pnpm.io/npmrc#node-linker) ([angular/angular#50735](https://github.com/angular/angular/issues/50735)) and explicitly declare `node-gyp-build` in `package.json` ([#16319](https://github.com/nrwl/nx/issues/16319) and [parcel-bundler/watcher#142](https://github.com/parcel-bundler/watcher/issues/142)), e.g.
+
+```ini {% fileName=".npmrc" %}
+node-linker=hoisted
+```
+
+```jsonc {% fileName="package.json" %}
+{
+  ...
+  "devDependencies": {
+    ...
+    "node-gyp-build": "4.6.0",
+    ...
+  }
+  ...
+}
+```
 {% /callout %}
 
 ## Use buildable libraries


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Currently, https://nx.dev/recipes/other/setup-incremental-builds-angular#requirements still warns that `ngcc` doesn't support PNPM.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

While `ngcc` doesn't support PNPM out-of-the-box, PNPM has since added a [node-linker=hoisted](https://pnpm.io/npmrc#node-linker) mode that creates flat `node_modules` without symlinks, similar to the `node_modules` created by NPM, allowing `ngcc` to work with PNPM (angular/angular#50735).

Unfortunately, using `node-link=hoisted` breaks `@parcel/watcher` that is used by NX (#16319 and parcel-bundler/watcher#142). A workaround is to explicitly declare `node-gyp-build` in `package.json`, e.g.
```jsonc
{
  ...
  "devDependencies": {
    ...
    "node-gyp-build": "4.6.0",
    ...
  }
  ...
}
```

This PR documents the workarounds to use `ngcc` with PNPM.

p.s. Huge thanks to @DzmVasileusky for discovering the workarounds.