### PR TITLE
fix(storybook): change storybook tsconfig path in eslint file too

### DIFF
--- a/packages/storybook/src/generators/configuration/lib/util-functions.ts
+++ b/packages/storybook/src/generators/configuration/lib/util-functions.ts
@@ -721,17 +721,29 @@ export function renameAndMoveOldTsConfig(
 
   const projectTsConfig = joinPathFragments(projectRoot, 'tsconfig.json');
 
-  if (!tree.exists(projectTsConfig)) {
-    return;
+  if (tree.exists(projectTsConfig)) {
+    updateJson(tree, projectTsConfig, (json) => {
+      for (let i = 0; i < json.references?.length; i++) {
+        if (json.references[i].path === './.storybook/tsconfig.json') {
+          json.references[i].path = './tsconfig.storybook.json';
+          break;
+        }
+      }
+      return json;
+    });
   }
 
-  updateJson(tree, projectTsConfig, (json) => {
-    for (let i = 0; i < json.references?.length; i++) {
-      if (json.references[i].path === './.storybook/tsconfig.json') {
-        json.references[i].path = './tsconfig.storybook.json';
-        break;
-      }
-    }
-    return json;
-  });
+  const projectEsLintFile = joinPathFragments(projectRoot, '.eslintrc.json');
+
+  if (tree.exists(projectEsLintFile)) {
+    updateJson(tree, projectEsLintFile, (json) => {
+      const jsonString = JSON.stringify(json);
+      const newJsonString = jsonString.replace(
+        /\.storybook\/tsconfig\.json/g,
+        'tsconfig.storybook.json'
+      );
+      json = JSON.parse(newJsonString);
+      return json;
+    });
+  }
 }


### PR DESCRIPTION
Migrator should change the path to storybook tsconfig in eslint, too, if it exists. Adding to existing migration, since this is not a super common use case, it seems.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18014
