### PR TITLE
docs(misc): replace mention of old @nx/node:package with @nx/js:tsc

### DIFF
--- a/docs/shared/recipes/include-assets-in-build.md
+++ b/docs/shared/recipes/include-assets-in-build.md
@@ -9,7 +9,7 @@ There are two ways to identify assets to be copied into the output bundle:
 
 ```jsonc {% fileName="project.json" %}
 "build": {
-  "executor": "@nx/node:package",
+  "executor": "@nx/js:tsc", // or any other Nx executor that supports the `assets` option
   "options": {
     // shortened...
     "assets": [


### PR DESCRIPTION
Updated doc: https://nx-dev-git-fork-leosvelperez-docs-wrong-executor-nrwl.vercel.app/recipes/other/include-assets-in-build#including-assets-in-your-build

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Docs about including assets in builds mention the non-existent `@nx/node:package` in the example project config.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Docs should not mention the non-existent `@nx/node:package` in the example project config. They should mention a valid executor, like `@nx/js:tsc`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18088 
