### PR TITLE
docs(core): add video embed for module boundaries

### DIFF
--- a/docs/shared/core-features/enforce-project-boundaries.md
+++ b/docs/shared/core-features/enforce-project-boundaries.md
@@ -4,6 +4,11 @@ If you partition your code into well-defined cohesive units, even a small organi
 
 To help with that Nx uses code analysis to make sure projects can only depend on each other's well-defined public API. It also allows you to declaratively impose constraints on how projects can depend on each other.
 
+{% youtube
+src="https://www.youtube.com/embed/q0en5vlOsWY"
+title="Applying Module Boundaries"
+width="100%" /%}
+
 ## Project APIs
 
 Nx provides an `enforce-module-boundaries` eslint rule that enforces the public API of projects in the repo. Each project defines its public API in an `index.ts` (or `index.js`) file. If another project tries to import a variable from a file deep within a different project, an error will be thrown during linting.


### PR DESCRIPTION
Embeds video in: https://nx-dev-git-fork-juristr-docs-video-module-boundaries-nrwl.vercel.app/core-features/enforce-project-boundaries