### PR TITLE
feat(vite): add v8 coverage support to vitest generator

### DIFF
--- a/docs/generated/packages/vite/generators/vitest.json
+++ b/docs/generated/packages/vite/generators/vitest.json
@@ -32,8 +32,8 @@
       },
       "coverageProvider": {
         "type": "string",
-        "enum": ["c8", "istanbul"],
-        "default": "c8",
+        "enum": ["v8", "c8", "istanbul"],
+        "default": "v8",
         "description": "Coverage provider to use."
       },
       "testTarget": {

--- a/packages/vite/src/generators/vitest/schema.d.ts
+++ b/packages/vite/src/generators/vitest/schema.d.ts
@@ -1,7 +1,7 @@
 export interface VitestGeneratorSchema {
   project: string;
   uiFramework: 'react' | 'none';
-  coverageProvider: 'c8' | 'istanbul';
+  coverageProvider: 'v8' | 'c8' | 'istanbul';
   inSourceTests?: boolean;
   skipViteConfig?: boolean;
   testTarget?: string;

--- a/packages/vite/src/generators/vitest/schema.json
+++ b/packages/vite/src/generators/vitest/schema.json
@@ -9,7 +9,9 @@
     "project": {
       "type": "string",
       "description": "The name of the project to test.",
-      "$default": { "$source": "projectName" }
+      "$default": {
+        "$source": "projectName"
+      }
     },
     "uiFramework": {
       "type": "string",
@@ -29,8 +31,8 @@
     },
     "coverageProvider": {
       "type": "string",
-      "enum": ["c8", "istanbul"],
-      "default": "c8",
+      "enum": ["v8", "c8", "istanbul"],
+      "default": "v8",
       "description": "Coverage provider to use."
     },
     "testTarget": {

--- a/packages/vite/src/generators/vitest/vitest-generator.ts
+++ b/packages/vite/src/generators/vitest/vitest-generator.ts
@@ -22,6 +22,7 @@ import initGenerator from '../init/init';
 import {
   vitestCoverageC8Version,
   vitestCoverageIstanbulVersion,
+  vitestCoverageV8Version,
 } from '../../utils/versions';
 
 import { addTsLibDependencies } from '@nx/js';
@@ -64,16 +65,14 @@ export async function vitestGenerator(
   createFiles(tree, schema, root);
   updateTsConfig(tree, schema, root);
 
+  const coverageProviderDependency = getCoverageProviderDependency(
+    schema.coverageProvider
+  );
+
   const installCoverageProviderTask = addDependenciesToPackageJson(
     tree,
     {},
-    schema.coverageProvider === 'istanbul'
-      ? {
-          '@vitest/coverage-istanbul': vitestCoverageIstanbulVersion,
-        }
-      : {
-          '@vitest/coverage-c8': vitestCoverageC8Version,
-        }
+    coverageProviderDependency
   );
   tasks.push(installCoverageProviderTask);
 
@@ -148,6 +147,25 @@ function createFiles(
     projectRoot,
     offsetFromRoot: offsetFromRoot(projectRoot),
   });
+}
+
+function getCoverageProviderDependency(
+  coverageProvider: VitestGeneratorSchema['coverageProvider']
+) {
+  switch (coverageProvider) {
+    case 'c8':
+      return {
+        '@vitest/coverage-c8': vitestCoverageC8Version,
+      };
+    case 'istanbul':
+      return {
+        '@vitest/coverage-istanbul': vitestCoverageIstanbulVersion,
+      };
+    default:
+      return {
+        '@vitest/coverage-v8': vitestCoverageV8Version,
+      };
+  }
 }
 
 export default vitestGenerator;

--- a/packages/vite/src/utils/versions.ts
+++ b/packages/vite/src/utils/versions.ts
@@ -11,4 +11,5 @@ export const edgeRuntimeVmVersion = '~3.0.2';
 
 // Coverage providers
 export const vitestCoverageC8Version = '~0.32.0';
+export const vitestCoverageV8Version = '~0.32.0';
 export const vitestCoverageIstanbulVersion = '~0.32.0';


### PR DESCRIPTION
## Current Behavior
Vitest generator has no option for v8 coverage and defaults to c8

## Expected Behavior
Vitest generator should allow (and default to) v8 coverage 

## Related Issue(s)
Fixes #17886
