### PR TITLE
fix(core): check if socketMessenger is null before using

### DIFF
--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -37,6 +37,12 @@ export type ChangedFile = {
   type: 'create' | 'update' | 'delete';
 };
 
+enum DaemonStatus {
+  CONNECTING,
+  DISCONNECTED,
+  CONNECTED,
+}
+
 export class DaemonClient {
   constructor(private readonly nxJson: NxJsonConfiguration) {
     this.reset();
@@ -50,7 +56,9 @@ export class DaemonClient {
   private currentReject;
 
   private _enabled: boolean | undefined;
-  private _connected: boolean;
+  private _daemonStatus: DaemonStatus = DaemonStatus.DISCONNECTED;
+  private _waitForDaemonReady: Promise<void> | null = null;
+  private _daemonReady: () => void | null = null;
   private _out: FileHandle = null;
   private _err: FileHandle = null;
 
@@ -104,7 +112,10 @@ export class DaemonClient {
     this._out = null;
     this._err = null;
 
-    this._connected = false;
+    this._daemonStatus = DaemonStatus.DISCONNECTED;
+    this._waitForDaemonReady = new Promise<void>(
+      (resolve) => (this._daemonReady = resolve)
+    );
   }
 
   async requestShutdown(): Promise<void> {
@@ -149,27 +160,28 @@ export class DaemonClient {
     ) => void
   ): Promise<UnregisterCallback> {
     await this.getProjectGraph();
-    const messenger = new SocketMessenger(connect(FULL_OS_SOCKET_PATH)).listen(
-      (message) => {
-        try {
-          const parsedMessage = JSON.parse(message);
-          callback(null, parsedMessage);
-        } catch (e) {
-          callback(e, null);
-        }
-      },
-      () => {
-        callback('closed', null);
-      },
-      (err) => callback(err, null)
-    );
+    let messenger: SocketMessenger | undefined;
 
-    await this.queue.sendToQueue(() =>
-      messenger?.sendMessage({ type: 'REGISTER_FILE_WATCHER', config })
-    );
+    await this.queue.sendToQueue(() => {
+      messenger = new SocketMessenger(connect(FULL_OS_SOCKET_PATH)).listen(
+        (message) => {
+          try {
+            const parsedMessage = JSON.parse(message);
+            callback(null, parsedMessage);
+          } catch (e) {
+            callback(e, null);
+          }
+        },
+        () => {
+          callback('closed', null);
+        },
+        (err) => callback(err, null)
+      );
+      return messenger.sendMessage({ type: 'REGISTER_FILE_WATCHER', config });
+    });
 
     return () => {
-      messenger.close();
+      messenger?.close();
     };
   }
 
@@ -232,7 +244,7 @@ export class DaemonClient {
         // it's ok for the daemon to terminate if the client doesn't wait on
         // any messages from the daemon
         if (this.queue.isEmpty()) {
-          this._connected = false;
+          this.reset();
         } else {
           output.error({
             title: 'Daemon process terminated and closed the connection',
@@ -280,12 +292,17 @@ export class DaemonClient {
   }
 
   private async sendMessageToDaemon(message: Message): Promise<any> {
-    if (!this._connected) {
-      this._connected = true;
+    if (this._daemonStatus == DaemonStatus.DISCONNECTED) {
+      this._daemonStatus = DaemonStatus.CONNECTING;
+
       if (!(await this.isServerAvailable())) {
         await this.startInBackground();
       }
       this.setUpConnection();
+      this._daemonStatus = DaemonStatus.CONNECTED;
+      this._daemonReady();
+    } else if (this._daemonStatus == DaemonStatus.CONNECTING) {
+      await this._waitForDaemonReady;
     }
 
     return new Promise((resolve, reject) => {
@@ -295,7 +312,7 @@ export class DaemonClient {
       this.currentResolve = resolve;
       this.currentReject = reject;
 
-      this.socketMessenger?.sendMessage(message);
+      this.socketMessenger.sendMessage(message);
     });
   }
 

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -165,7 +165,7 @@ export class DaemonClient {
     );
 
     await this.queue.sendToQueue(() =>
-      messenger.sendMessage({ type: 'REGISTER_FILE_WATCHER', config })
+      messenger?.sendMessage({ type: 'REGISTER_FILE_WATCHER', config })
     );
 
     return () => {
@@ -295,7 +295,7 @@ export class DaemonClient {
       this.currentResolve = resolve;
       this.currentReject = reject;
 
-      this.socketMessenger.sendMessage(message);
+      this.socketMessenger?.sendMessage(message);
     });
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
In certain scenarios in Nx Console, the daemon gets reset while a request was about to be sent through with the socketmessenger. When the daemon resets, SocketMessenger is set to null, and we get `TypeError: Cannot read properties of null ("sendMessage")`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We now use the `?` operator to make sure we don't call sendMessage on a null messenger

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
