### PR TITLE
fix(core): remove `fatal: no path specified` logs from daemon

### DIFF
--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -137,6 +137,10 @@ function computeWorkspaceConfigHash(
  * TODO(Cammisuli): remove after 16.4 - Rust watcher handles nested gitignores
  */
 function filterUpdatedFiles(files: string[]) {
+  if (files.length === 0) {
+    return files;
+  }
+
   try {
     const quoted = files.map((f) => '"' + f + '"');
     const ignored = execSync(`git check-ignore ${quoted.join(' ')}`, {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When checking to see if files are ignored, we call git. But when the daemon first starts, there's no specific files that are changed, and we get a fatal call from git

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Check to see if the files array is empty before trying to call git

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
