### PR TITLE
fix(core): write file directly instead of using `fs-extra.outputFileSync`

### DIFF
--- a/packages/nx/src/utils/testing/temp-fs.ts
+++ b/packages/nx/src/utils/testing/temp-fs.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { basename, dirname, join } from 'path';
 import { tmpdir } from 'os';
 import {
   mkdtempSync,
@@ -8,9 +8,10 @@ import {
   emptyDirSync,
   outputFileSync,
   unlinkSync,
+  mkdirpSync,
 } from 'fs-extra';
 import { joinPathFragments } from '../path';
-import { appendFileSync, writeFileSync, renameSync } from 'fs';
+import { appendFileSync, writeFileSync, renameSync, existsSync } from 'fs';
 
 type NestedFiles = {
   [fileName: string]: string;
@@ -44,7 +45,11 @@ export class TempFs {
   }
 
   createFileSync(filePath: string, content: string) {
-    outputFileSync(joinPathFragments(this.tempDir, filePath), content);
+    let dir = joinPathFragments(this.tempDir, dirname(filePath));
+    if (!existsSync(dir)) {
+      mkdirpSync(dir);
+    }
+    writeFileSync(joinPathFragments(this.tempDir, filePath), content);
   }
 
   async readFile(filePath: string): Promise<string> {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Unit tests for watcher are using `outputFileSync` to create a file. This sometimes outputs a create and update event 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Use writeFileSync directly so that we can avoid two events

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
