### PR TITLE
fix(angular): removed additionalProperties flag from customWebpackConfig in schema

### DIFF
--- a/packages/angular/src/builders/webpack-browser/schema.json
+++ b/packages/angular/src/builders/webpack-browser/schema.json
@@ -455,8 +455,7 @@
           "type": "string"
         }
       },
-      "x-priority": "important",
-      "additionalProperties": false
+      "x-priority": "important"
     },
     "indexFileTransformer": {
       "description": "Path to transformer function to transform the index.html",


### PR DESCRIPTION
## Current Behavior
If set additional property in customWebpackConfig, project.json becomes invalid.

## Expected Behavior
Support additional properties in customWebpackConfig.

## Cause
Some other packages uses customWebpackConfig for configuration. This flag makes json invalid if application using configuration which needed by other package, e.g. single-spa-angular ('cause in this block it's need additional property libraryName for normal work)

## Related Issue(s)

Fixes #
