### PR TITLE
fix(nx-dev): hide toc on reference pages

### DIFF
--- a/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
@@ -20,9 +20,11 @@ export function DocViewer({
   relatedDocuments: RelatedDocument[];
 }): JSX.Element {
   const router = useRouter();
-  const isIntroPage =
+  const hideTableOfContent =
     router.asPath.includes('/getting-started/intro') ||
-    router.asPath.includes('/plugins/intro/getting-started');
+    router.asPath.includes('/plugins/intro/getting-started') ||
+    router.asPath.includes('/packages/devkit') ||
+    router.asPath.includes('/reference/glossary');
   const ref = useRef<HTMLDivElement | null>(null);
 
   const { metadata, node, treeNode } = renderMarkdown(
@@ -92,12 +94,12 @@ export function DocViewer({
                 data-document="main"
                 className={cx(
                   'prose prose-slate dark:prose-invert w-full max-w-none 2xl:max-w-4xl',
-                  { 'xl:max-w-2xl': !isIntroPage }
+                  { 'xl:max-w-2xl': !hideTableOfContent }
                 )}
               >
                 {vm.content}
               </div>
-              {!isIntroPage && (
+              {!hideTableOfContent && (
                 <div
                   className={cx(
                     'fixed top-36 right-[max(2rem,calc(50%-55rem))] z-20 hidden w-60 overflow-y-auto bg-white py-10 text-sm dark:bg-slate-900 xl:block'


### PR DESCRIPTION
It hides the TOC panel on reference pages.