### PR TITLE
fix(misc): use caret for semver version

### DIFF
--- a/package.json
+++ b/package.json
@@ -264,7 +264,7 @@
     "rxjs": "^7.8.0",
     "sass": "1.55.0",
     "sass-loader": "^12.2.0",
-    "semver": "7.5.3",
+    "semver": "^7.5.3",
     "source-map": "0.7.3",
     "source-map-loader": "^3.0.0",
     "source-map-support": "0.5.19",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -53,7 +53,7 @@
     "ignore": "^5.0.4",
     "magic-string": "~0.30.2",
     "minimatch": "9.0.3",
-    "semver": "7.5.3",
+    "semver": "^7.5.3",
     "tslib": "^2.3.0",
     "webpack": "^5.80.0",
     "webpack-merge": "^5.8.0",

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -39,7 +39,7 @@
     "@nx/js": "file:../js",
     "@phenomnomnominal/tsquery": "~5.0.1",
     "detect-port": "^1.5.1",
-    "semver": "7.5.3",
+    "semver": "^7.5.3",
     "tslib": "^2.3.0"
   },
   "peerDependencies": {

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -33,7 +33,7 @@
     "ignore": "^5.0.4",
     "tmp": "~0.2.1",
     "tslib": "^2.3.0",
-    "semver": "7.5.3",
+    "semver": "^7.5.3",
     "yargs-parser": "21.1.1"
   },
   "peerDependencies": {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -40,7 +40,7 @@
     "chalk": "^4.1.0",
     "confusing-browser-globals": "^1.0.9",
     "jsonc-eslint-parser": "^2.1.0",
-    "semver": "7.5.3",
+    "semver": "^7.5.3",
     "tslib": "^2.3.0"
   },
   "publishConfig": {

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -54,7 +54,7 @@
     "js-tokens": "^4.0.0",
     "minimatch": "9.0.3",
     "ora": "5.3.0",
-    "semver": "7.5.3",
+    "semver": "^7.5.3",
     "source-map-support": "0.5.19",
     "tslib": "^2.3.0",
     "@nx/devkit": "file:../devkit",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -41,7 +41,7 @@
     "copy-webpack-plugin": "^10.2.4",
     "fs-extra": "^11.1.0",
     "ignore": "^5.0.4",
-    "semver": "7.5.3",
+    "semver": "^7.5.3",
     "url-loader": "^4.1.1",
     "tslib": "^2.3.0",
     "webpack-merge": "^5.8.0",

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -55,7 +55,7 @@
     "minimatch": "9.0.3",
     "npm-run-path": "^4.0.1",
     "open": "^8.4.0",
-    "semver": "7.5.3",
+    "semver": "^7.5.3",
     "string-width": "^4.2.3",
     "strong-log-transformer": "^2.1.0",
     "tar-stream": "~2.2.0",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@nx/devkit": "file:../devkit",
     "@phenomnomnominal/tsquery": "~5.0.1",
-    "semver": "7.5.3",
+    "semver": "^7.5.3",
     "tslib": "^2.3.0",
     "@nx/cypress": "file:../cypress",
     "@nx/js": "file:../js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -860,7 +860,7 @@ devDependencies:
     specifier: ^12.2.0
     version: 12.6.0(sass@1.55.0)(webpack@5.88.0)
   semver:
-    specifier: 7.5.3
+    specifier: ^7.5.3
     version: 7.5.3
   source-map:
     specifier: 0.7.3


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently, the `semver` package has a locked version, whereas most of the other dependencies seem to be prefixed with either caret or a tilde to allow library consumers to update the version they use.
Am I missing something, but having this dependency locked to this specific version does not seem to be required for any specific reason?

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Having such a common package not locked to a specific version would avoid the requirement of having multiple dependencies for even the same major version as can be observed here:
- https://github.com/mui/mui-x/pull/9640/files
- https://github.com/mui/mui-x/pull/9692/files

Related PR: #17759

