### PR TITLE
fix(graph): increase dropdown indicator padding

### DIFF
--- a/graph/client/tailwind.config.js
+++ b/graph/client/tailwind.config.js
@@ -36,5 +36,10 @@ module.exports = {
       translate: ['group-hover'],
     },
   },
-  plugins: [require('@tailwindcss/typography')],
+  plugins: [
+    require('@tailwindcss/typography'),
+    require('@tailwindcss/forms')({
+      strategy: 'class',
+    }),
+  ],
 };

--- a/graph/ui-components/src/lib/dropdown.tsx
+++ b/graph/ui-components/src/lib/dropdown.tsx
@@ -9,7 +9,7 @@ export function Dropdown(props: DropdownProps) {
   const { className, children, ...rest } = props;
   return (
     <select
-      className={`flex items-center rounded-md rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 hover:dark:bg-slate-700 ${className}`}
+      className={`form-select flex items-center rounded-md rounded-md border border-slate-300 bg-white pl-4 pr-8 py-2 text-sm font-medium text-slate-700 shadow-sm hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 hover:dark:bg-slate-700 ${className}`}
       {...rest}
     >
       {children}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The current dropdown in the graph looks a bit cramped right now: 
![image](https://github.com/nrwl/nx/assets/34165455/df1466c1-545f-4f77-add3-38fbc8f2f621)

## Expected Behavior
Should probably have a bit more space so I updated it:
![image](https://github.com/nrwl/nx/assets/34165455/ad4be7ec-8db1-49a9-ad6e-4e630312322e)


