### PR TITLE
cleanup(misc): remove outdated run-e2e-tests targets

### DIFF
--- a/e2e/angular-core/project.json
+++ b/e2e/angular-core/project.json
@@ -4,8 +4,7 @@
   "sourceRoot": "e2e/angular-core",
   "projectType": "application",
   "targets": {
-    "e2e": {},
-    "run-e2e-tests": {}
+    "e2e": {}
   },
   "implicitDependencies": ["angular"]
 }

--- a/e2e/angular-extensions/project.json
+++ b/e2e/angular-extensions/project.json
@@ -4,8 +4,7 @@
   "sourceRoot": "e2e/angular-extensions",
   "projectType": "application",
   "targets": {
-    "e2e": {},
-    "run-e2e-tests": {}
+    "e2e": {}
   },
   "implicitDependencies": ["angular"]
 }

--- a/e2e/cypress/project.json
+++ b/e2e/cypress/project.json
@@ -4,8 +4,7 @@
   "sourceRoot": "e2e/cypress",
   "projectType": "application",
   "targets": {
-    "e2e": {},
-    "run-e2e-tests": {}
+    "e2e": {}
   },
   "implicitDependencies": ["cypress", "react"]
 }

--- a/e2e/detox/project.json
+++ b/e2e/detox/project.json
@@ -4,8 +4,7 @@
   "sourceRoot": "e2e/detox",
   "projectType": "application",
   "targets": {
-    "e2e-macos": {},
-    "run-e2e-tests": {}
+    "e2e-macos": {}
   },
   "implicitDependencies": ["detox"]
 }

--- a/e2e/esbuild/project.json
+++ b/e2e/esbuild/project.json
@@ -4,8 +4,7 @@
   "sourceRoot": "e2e/esbuild",
   "projectType": "application",
   "targets": {
-    "e2e": {},
-    "run-e2e-tests": {}
+    "e2e": {}
   },
   "implicitDependencies": ["esbuild"]
 }

--- a/e2e/expo/project.json
+++ b/e2e/expo/project.json
@@ -4,8 +4,7 @@
   "sourceRoot": "e2e/expo",
   "projectType": "application",
   "targets": {
-    "e2e-macos": {},
-    "run-e2e-tests": {}
+    "e2e-macos": {}
   },
   "implicitDependencies": ["expo"]
 }

--- a/e2e/jest/project.json
+++ b/e2e/jest/project.json
@@ -4,8 +4,7 @@
   "sourceRoot": "e2e/jest",
   "projectType": "application",
   "targets": {
-    "e2e": {},
-    "run-e2e-tests": {}
+    "e2e": {}
   },
   "implicitDependencies": ["jest"]
 }

--- a/e2e/js/project.json
+++ b/e2e/js/project.json
@@ -4,8 +4,7 @@
   "sourceRoot": "e2e/js",
   "projectType": "application",
   "targets": {
-    "e2e": {},
-    "run-e2e-tests": {}
+    "e2e": {}
   },
   "implicitDependencies": ["jest"]
 }

--- a/e2e/lerna-smoke-tests/project.json
+++ b/e2e/lerna-smoke-tests/project.json
@@ -4,8 +4,7 @@
   "sourceRoot": "e2e/lerna-smoke-tests",
   "projectType": "application",
   "targets": {
-    "e2e": {},
-    "run-e2e-tests": {}
+    "e2e": {}
   },
   "implicitDependencies": ["nx", "devkit"]
 }

--- a/e2e/next/project.json
+++ b/e2e/next/project.json
@@ -4,8 +4,7 @@
   "sourceRoot": "e2e/next",
   "projectType": "application",
   "targets": {
-    "e2e": {},
-    "run-e2e-tests": {}
+    "e2e": {}
   },
   "implicitDependencies": ["next"]
 }

--- a/e2e/node/project.json
+++ b/e2e/node/project.json
@@ -4,8 +4,7 @@
   "sourceRoot": "e2e/node",
   "projectType": "application",
   "targets": {
-    "e2e": {},
-    "run-e2e-tests": {}
+    "e2e": {}
   },
   "implicitDependencies": ["node", "nest"]
 }

--- a/e2e/nx-init/project.json
+++ b/e2e/nx-init/project.json
@@ -4,8 +4,7 @@
   "sourceRoot": "e2e/nx-init",
   "projectType": "application",
   "targets": {
-    "e2e": {},
-    "run-e2e-tests": {}
+    "e2e": {}
   },
   "implicitDependencies": ["nx"]
 }

--- a/e2e/nx-misc/project.json
+++ b/e2e/nx-misc/project.json
@@ -4,8 +4,7 @@
   "sourceRoot": "e2e/nx-misc",
   "projectType": "application",
   "targets": {
-    "e2e": {},
-    "run-e2e-tests": {}
+    "e2e": {}
   },
   "implicitDependencies": ["js"]
 }

--- a/e2e/nx-run/project.json
+++ b/e2e/nx-run/project.json
@@ -4,8 +4,7 @@
   "sourceRoot": "e2e/nx-run",
   "projectType": "application",
   "targets": {
-    "e2e": {},
-    "run-e2e-tests": {}
+    "e2e": {}
   },
   "implicitDependencies": ["js"]
 }

--- a/e2e/playwright/project.json
+++ b/e2e/playwright/project.json
@@ -4,8 +4,7 @@
   "sourceRoot": "e2e/playwright",
   "projectType": "application",
   "targets": {
-    "e2e": {},
-    "run-e2e-tests": {}
+    "e2e": {}
   },
   "implicitDependencies": ["playwright"]
 }

--- a/e2e/plugin/project.json
+++ b/e2e/plugin/project.json
@@ -4,8 +4,7 @@
   "sourceRoot": "e2e/plugin",
   "projectType": "application",
   "targets": {
-    "e2e": {},
-    "run-e2e-tests": {}
+    "e2e": {}
   },
   "implicitDependencies": ["create-nx-plugin"]
 }

--- a/e2e/react-core/project.json
+++ b/e2e/react-core/project.json
@@ -4,8 +4,7 @@
   "sourceRoot": "e2e/react-core",
   "projectType": "application",
   "targets": {
-    "e2e": {},
-    "run-e2e-tests": {}
+    "e2e": {}
   },
   "implicitDependencies": ["react"]
 }

--- a/e2e/react-extensions/project.json
+++ b/e2e/react-extensions/project.json
@@ -4,8 +4,7 @@
   "sourceRoot": "e2e/react-extensions",
   "projectType": "application",
   "targets": {
-    "e2e": {},
-    "run-e2e-tests": {}
+    "e2e": {}
   },
   "implicitDependencies": ["react"]
 }

--- a/e2e/react-native/project.json
+++ b/e2e/react-native/project.json
@@ -4,8 +4,7 @@
   "sourceRoot": "e2e/react-native",
   "projectType": "application",
   "targets": {
-    "e2e-macos": {},
-    "run-e2e-tests": {}
+    "e2e-macos": {}
   },
   "implicitDependencies": ["react-native"]
 }

--- a/e2e/rollup/project.json
+++ b/e2e/rollup/project.json
@@ -4,8 +4,7 @@
   "sourceRoot": "e2e/rollup",
   "projectType": "application",
   "targets": {
-    "e2e": {},
-    "run-e2e-tests": {}
+    "e2e": {}
   },
   "implicitDependencies": ["rollup", "js"]
 }

--- a/e2e/storybook-angular/project.json
+++ b/e2e/storybook-angular/project.json
@@ -4,8 +4,7 @@
   "sourceRoot": "e2e/storybook-angular",
   "projectType": "application",
   "targets": {
-    "e2e": {},
-    "run-e2e-tests": {}
+    "e2e": {}
   },
   "implicitDependencies": ["storybook"]
 }

--- a/e2e/storybook/project.json
+++ b/e2e/storybook/project.json
@@ -4,8 +4,7 @@
   "sourceRoot": "e2e/storybook",
   "projectType": "application",
   "targets": {
-    "e2e": {},
-    "run-e2e-tests": {}
+    "e2e": {}
   },
   "implicitDependencies": ["storybook"]
 }

--- a/e2e/vite/project.json
+++ b/e2e/vite/project.json
@@ -4,8 +4,7 @@
   "sourceRoot": "e2e/vite",
   "projectType": "application",
   "targets": {
-    "e2e": {},
-    "run-e2e-tests": {}
+    "e2e": {}
   },
   "implicitDependencies": ["vite"]
 }

--- a/e2e/web/project.json
+++ b/e2e/web/project.json
@@ -4,8 +4,7 @@
   "sourceRoot": "e2e/web",
   "projectType": "application",
   "targets": {
-    "e2e": {},
-    "run-e2e-tests": {}
+    "e2e": {}
   },
   "implicitDependencies": ["web"]
 }

--- a/e2e/webpack/project.json
+++ b/e2e/webpack/project.json
@@ -4,8 +4,7 @@
   "sourceRoot": "e2e/webpack",
   "projectType": "application",
   "targets": {
-    "e2e": {},
-    "run-e2e-tests": {}
+    "e2e": {}
   },
   "implicitDependencies": ["webpack"]
 }

--- a/e2e/workspace-create-npm/project.json
+++ b/e2e/workspace-create-npm/project.json
@@ -4,8 +4,7 @@
   "sourceRoot": "e2e/workspace-create-npm",
   "projectType": "application",
   "targets": {
-    "e2e": {},
-    "run-e2e-tests": {}
+    "e2e": {}
   },
   "implicitDependencies": ["create-nx-workspace"]
 }

--- a/e2e/workspace-create/project.json
+++ b/e2e/workspace-create/project.json
@@ -4,8 +4,7 @@
   "sourceRoot": "e2e/workspace-create",
   "projectType": "application",
   "targets": {
-    "e2e": {},
-    "run-e2e-tests": {}
+    "e2e": {}
   },
   "implicitDependencies": ["create-nx-workspace"]
 }


### PR DESCRIPTION
`e2e-linter` still has a useful `run-e2e-tests` target, but it's not used in CI or anywhere else... so it's probably safe to remove it? 
