### PR TITLE
fix(core): generate npm preset correctly

### DIFF
--- a/e2e/workspace-create-npm/src/create-nx-workspace-npm.test.ts
+++ b/e2e/workspace-create-npm/src/create-nx-workspace-npm.test.ts
@@ -37,6 +37,17 @@ describe('create-nx-workspace --preset=npm', () => {
     cleanupProject({ skipReset: true });
   });
 
+  it('should setup package-based workspace', () => {
+    const packageJson = readJson('package.json');
+    expect(packageJson.dependencies).toEqual({});
+
+    if (getSelectedPackageManager() === 'pnpm') {
+      checkFilesExist('pnpm-workspace.yaml');
+    } else {
+      expect(packageJson.workspaces).toEqual(['packages/*']);
+    }
+  });
+
   it('should add angular application', () => {
     packageInstall('@nx/angular', wsName);
     const appName = uniq('my-app');

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -412,7 +412,6 @@ async function determineNoneOptions(
     } else {
       preset = Preset.NPM;
     }
-    preset = workspaceType === 'standalone' ? Preset.TsStandalone : Preset.TS;
   }
 
   if (parsedArgs.js !== undefined) {


### PR DESCRIPTION
This PR fixes a bug where `--preset=npm` is being overwritten by recent changes to the prompts.  Users will get `--preset=ts` instead.

## Current Behavior
`--preset=npm` is being overwritten

## Expected Behavior
`--preset=npm` should work

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
