### PR TITLE
docs(misc): update intro page to clarify tutorial links

### DIFF
--- a/docs/shared/getting-started/intro.md
+++ b/docs/shared/getting-started/intro.md
@@ -22,17 +22,17 @@ If instead you want to jump right into it, run the following command. It will gu
 {% /tab %}
 {% /tabs %}
 
-You can use Nx to quickly scaffold a new standalone project or even an entire monorepo. It can be incrementally adopted and will grow with your project as it scales.
+You can use Nx to quickly scaffold a new project or even an entire monorepo. It can be incrementally adopted and will grow with your project as it scales.
 
 {% cards cols="3" %}
 
-{% title-card title="New Monorepo" url="#start-a-new-monorepo" /%}
-{% title-card title="New Standalone Project" url="#start-a-new-standalone-project" /%}
-{% title-card title="Add to an Existing Project or Monorepo" url="#adding-nx-to-an-existing-project-or-monorepo" /%}
+{% title-card title="New Monorepo" url="#get-started-with-the-basics" /%}
+{% title-card title="Choose a Stack" url="#learn-about-nx-and-your-favorite-stack" /%}
+{% title-card title="Add to an Existing Project" url="#http://localhost:4200/getting-started/intro#adding-nx-to-an-existing-project" /%}
 
 {% /cards %}
 
-## Start a New Monorepo
+## Get Started with the Basics
 
 Its modular architecture lets you adopt Nx for package-based monorepos in combination with NPM, Yarn or PNPM, or create a fully integrated monorepo using Nx plugins. Learn more with the tutorials below.
 
@@ -56,39 +56,39 @@ Get a pre-configured setup. Nx configures your favorite frameworks and lets you 
 
 {% /cards %}
 
-## Start a New Standalone Project
+## Learn About Nx and Your Favorite Stack
 
-Nx works well not just for monorepos. Nx plugins help you scaffold new standalone projects with pre-configured tooling and modularize your codebase with local libraries.
+Nx works well not just for monorepos. Nx plugins help you scaffold new projects with pre-configured tooling and modularize your codebase with local libraries.
 
 {% cards cols="3" %}
 
-{% persona type="react" title="Create a Standalone React app" url="/getting-started/tutorials/react-standalone-tutorial" %}
+{% persona type="react" title="Create a React app" url="/getting-started/tutorials/react-standalone-tutorial" %}
 
 A modern React setup with built-in support for Vite, ESLint, Cypress, and more. Think CRA but modern, always up-to-date and scalable.
 
-- [Create a Standalone React app](/getting-started/tutorials/react-standalone-tutorial)
+- [Create a React app](/getting-started/tutorials/react-standalone-tutorial)
 
 {% /persona %}
 
-{% persona type="angular" title="Create a Standalone Angular app" url="/getting-started/tutorials/angular-standalone-tutorial" %}
+{% persona type="angular" title="Create an Angular app" url="/getting-started/tutorials/angular-standalone-tutorial" %}
 
 A modern Angular development experience powered by advanced generators and integrations with modern tooling.
 
-- [Create a Standalone Angular app](/getting-started/tutorials/angular-standalone-tutorial)
+- [Create an Angular app](/getting-started/tutorials/angular-standalone-tutorial)
 
 {% /persona %}
 
-{% persona type="node" title="Create a Standalone Node server" url="/getting-started/tutorials/node-server-tutorial" %}
+{% persona type="node" title="Create a Node server" url="/getting-started/tutorials/node-server-tutorial" %}
 
 A modern Node server with scaffolding for Express, Fastify or Koa. There's also Docker support built-in.
 
-- [Create a Standalone Node server](/getting-started/tutorials/node-server-tutorial)
+- [Create a Node server](/getting-started/tutorials/node-server-tutorial)
 
 {% /persona %}
 
 {% /cards %}
 
-## Adding Nx to an Existing Project or Monorepo
+## Adding Nx to an Existing Project
 
 If you have an existing project and want to adopt Nx or migrate to Nx just run the following command which guides you through the migration process:
 
@@ -103,7 +103,7 @@ Add Nx to your existing NPM/YARN/PNPM workspace
 {% /persona %}
 
 {% persona title="Add to any Project" type="extend" url="/recipes/adopting-nx/adding-to-existing-project" %}
-Add Nx to a standalone project
+Add Nx to a project
 {% /persona %}
 
 {% persona title="Migrate from CRA" type="react" url="/recipes/adopting-nx/migration-cra" %}


### PR DESCRIPTION
This PR updates the language used on the intro page, but not the structure. It seeks to clarify a few things:

- Remove the word "standalone" to make it clear that the decision is the stack, not workspace type. Also, people don't know what "standalone" means.
- Reword the heading  `Start a New Monorepo` to `Get Started with the Basics` so users know it's the starting point that is agnostic of the stack.
- Reword the heading `Start a New Standalone Project`to `Learn About Nx and Your Favorite Stack` so users know that these are the tutorials for a given stack.
- Reword the top-level button links to better match decision points: do you want a monorepo, a specific stack, or adding to an existing project?

Preview: https://nx-dev-git-fork-jaysoo-docs-intro-page-nrwl.vercel.app/getting-started/intro


**Note:** Changes to the tutorials themselves is a separate discussion and out of scope for this PR

---

### Before
<img width="884" alt="Screenshot 2023-07-18 at 12 37 16 PM" src="https://github.com/nrwl/nx/assets/53559/e9355c65-31f2-42b6-ba16-a54607aa13b9">


### After
<img width="846" alt="Screenshot 2023-07-18 at 12 37 26 PM" src="https://github.com/nrwl/nx/assets/53559/e4ce19f1-c366-4d78-bf27-76ca2e6c75fb">
