### PR TITLE
fix(core): correctly output created and update events for the watcher on macos

### DIFF
--- a/packages/nx/src/native/tests/watcher.spec.ts
+++ b/packages/nx/src/native/tests/watcher.spec.ts
@@ -27,7 +27,7 @@ describe('watcher', () => {
   });
 
   it('should trigger the callback for files that are not ignored', (done) => {
-    watcher = new Watcher(realpathSync(temp.tempDir));
+    watcher = new Watcher(temp.tempDir);
     watcher.watch((error, paths) => {
       expect(paths).toMatchInlineSnapshot(`
         [
@@ -48,7 +48,7 @@ describe('watcher', () => {
   });
 
   it('should trigger the callback when files are updated', (done) => {
-    watcher = new Watcher(realpathSync(temp.tempDir));
+    watcher = new Watcher(temp.tempDir);
 
     watcher.watch((err, paths) => {
       expect(paths).toMatchInlineSnapshot(`
@@ -62,7 +62,7 @@ describe('watcher', () => {
       done();
     });
 
-    wait().then(() => {
+    wait(1000).then(() => {
       // nxignored file should not trigger a callback
       temp.appendFile('app2/main.js', 'update');
       temp.appendFile('app1/main.js', 'update');
@@ -70,7 +70,7 @@ describe('watcher', () => {
   });
 
   it('should watch file renames', (done) => {
-    watcher = new Watcher(realpathSync(temp.tempDir));
+    watcher = new Watcher(temp.tempDir);
 
     watcher.watch((err, paths) => {
       expect(paths.length).toBe(2);
@@ -91,7 +91,7 @@ describe('watcher', () => {
   });
 
   it('should trigger on deletes', (done) => {
-    watcher = new Watcher(realpathSync(temp.tempDir));
+    watcher = new Watcher(temp.tempDir);
 
     watcher.watch((err, paths) => {
       expect(paths).toMatchInlineSnapshot(`
@@ -111,7 +111,7 @@ describe('watcher', () => {
   });
 
   it('should ignore nested gitignores', (done) => {
-    watcher = new Watcher(realpathSync(temp.tempDir));
+    watcher = new Watcher(temp.tempDir);
 
     watcher.watch((err, paths) => {
       expect(paths).toMatchInlineSnapshot(`
@@ -133,10 +133,10 @@ describe('watcher', () => {
   });
 });
 
-function wait() {
+function wait(timeout = 500) {
   return new Promise<void>((res) => {
     setTimeout(() => {
       res();
-    }, 500);
+    }, timeout);
   });
 }

--- a/packages/nx/src/native/tests/watcher.spec.ts
+++ b/packages/nx/src/native/tests/watcher.spec.ts
@@ -74,14 +74,18 @@ describe('watcher', () => {
 
     watcher.watch((err, paths) => {
       expect(paths.length).toBe(2);
-      expect(paths.find((p) => p.type === 'update')).toMatchObject({
-        path: 'app1/rename.js',
-        type: 'update',
-      });
-      expect(paths.find((p) => p.type === 'delete')).toMatchObject({
-        path: 'app1/main.js',
-        type: 'delete',
-      });
+      expect(paths.find((p) => p.type === 'create')).toMatchInlineSnapshot(`
+        {
+          "path": "app1/rename.js",
+          "type": "create",
+        }
+      `);
+      expect(paths.find((p) => p.type === 'delete')).toMatchInlineSnapshot(`
+        {
+          "path": "app1/main.js",
+          "type": "delete",
+        }
+      `);
       done();
     });
 

--- a/packages/nx/src/native/watch/types.rs
+++ b/packages/nx/src/native/watch/types.rs
@@ -76,15 +76,13 @@ impl From<&Event> for WatchEventInternal {
 
                 let t = fs::metadata(path_ref).expect("metadata should be available");
 
-                let access_time = t.st_atime();
                 let modified_time = t.st_mtime();
                 let birth_time = t.st_birthtime();
 
                 // if a file is created and updated near the same time, we always get a create event
                 // so we need to check the timestamps to see if it was created or updated
-                // if the access_time is the same as the modified_time, and modified time is the same as birth_time
-                // then it was created
-                if access_time == modified_time && modified_time == birth_time {
+                // if the modified time is the same as birth_time then it was created
+                if modified_time == birth_time {
                     EventType::create
                 } else {
                     EventType::update

--- a/packages/nx/src/native/watch/types.rs
+++ b/packages/nx/src/native/watch/types.rs
@@ -2,6 +2,8 @@ use napi::bindgen_prelude::*;
 
 use std::path::PathBuf;
 use tracing::trace;
+use watchexec_events::filekind::ModifyKind::Name;
+use watchexec_events::filekind::RenameMode;
 use watchexec_events::{Event, Tag};
 
 #[napi(string_enum)]
@@ -95,6 +97,8 @@ impl From<&Event> for WatchEventInternal {
 
                 match event_kind {
                     FileEventKind::Create(_) => EventType::create,
+                    FileEventKind::Modify(Name(RenameMode::To)) => EventType::create,
+                    FileEventKind::Modify(Name(RenameMode::From)) => EventType::delete,
                     FileEventKind::Modify(_) => EventType::update,
                     _ => EventType::update,
                 }

--- a/packages/nx/src/native/watch/types.rs
+++ b/packages/nx/src/native/watch/types.rs
@@ -68,23 +68,26 @@ impl From<&Event> for WatchEventInternal {
         let event_type = if matches!(path.1, None) && !path_ref.exists() {
             EventType::delete
         } else if cfg!(target_os = "macos") {
+            #[cfg(target_os = "macos")]
             use std::fs;
-            use std::os::macos::fs::MetadataExt;
+            {
+                use std::os::macos::fs::MetadataExt;
 
-            let t = fs::metadata(path_ref).expect("metadata should be available");
+                let t = fs::metadata(path_ref).expect("metadata should be available");
 
-            let access_time = t.st_atime();
-            let modified_time = t.st_mtime();
-            let birth_time = t.st_birthtime();
+                let access_time = t.st_atime();
+                let modified_time = t.st_mtime();
+                let birth_time = t.st_birthtime();
 
-            // if a file is created and updated near the same time, we always get a create event
-            // so we need to check the timestamps to see if it was created or updated
-            // if the access_time is the same as the modified_time, and modified time is the same as birth_time
-            // then it was created
-            if access_time == modified_time && modified_time == birth_time {
-                EventType::create
-            } else {
-                EventType::update
+                // if a file is created and updated near the same time, we always get a create event
+                // so we need to check the timestamps to see if it was created or updated
+                // if the access_time is the same as the modified_time, and modified time is the same as birth_time
+                // then it was created
+                if access_time == modified_time && modified_time == birth_time {
+                    EventType::create
+                } else {
+                    EventType::update
+                }
             }
         } else {
             match event_kind {

--- a/packages/nx/src/native/watch/types.rs
+++ b/packages/nx/src/native/watch/types.rs
@@ -69,19 +69,19 @@ impl From<&Event> for WatchEventInternal {
             EventType::delete
         } else if cfg!(target_os = "macos") {
             use std::fs;
-            use std::os::unix::prelude::MetadataExt;
+            use std::os::macos::fs::MetadataExt;
 
             let t = fs::metadata(path_ref).expect("metadata should be available");
 
-            let access_time = t.atime();
-            let modified_time = t.mtime();
-            let status_time = t.ctime();
+            let access_time = t.st_atime();
+            let modified_time = t.st_mtime();
+            let birth_time = t.st_birthtime();
 
             // if a file is created and updated near the same time, we always get a create event
             // so we need to check the timestamps to see if it was created or updated
-            // if the access time is the same as the modified time, and modified time is the same as status time
+            // if the access_time is the same as the modified_time, and modified time is the same as birth_time
             // then it was created
-            if access_time == modified_time && modified_time == status_time {
+            if access_time == modified_time && modified_time == birth_time {
                 EventType::create
             } else {
                 EventType::update

--- a/packages/nx/src/native/watch/types.rs
+++ b/packages/nx/src/native/watch/types.rs
@@ -69,8 +69,8 @@ impl From<&Event> for WatchEventInternal {
             EventType::delete
         } else if cfg!(target_os = "macos") {
             #[cfg(target_os = "macos")]
-            use std::fs;
             {
+                use std::fs;
                 use std::os::macos::fs::MetadataExt;
 
                 let t = fs::metadata(path_ref).expect("metadata should be available");

--- a/packages/nx/src/native/watch/watch_config.rs
+++ b/packages/nx/src/native/watch/watch_config.rs
@@ -2,7 +2,6 @@ use crate::native::watch::utils::get_ignore_files;
 use crate::native::watch::watch_filterer::WatchFilterer;
 use ignore_files::IgnoreFilter;
 use std::sync::Arc;
-use std::time::Duration;
 use tracing::trace;
 use watchexec::config::RuntimeConfig;
 use watchexec_filterer_ignore::IgnoreFilterer;

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -5,7 +5,6 @@ use std::path::MAIN_SEPARATOR;
 use std::sync::Arc;
 
 use crate::native::watch::types::{EventType, WatchEvent, WatchEventInternal};
-use itertools::Itertools;
 use napi::bindgen_prelude::*;
 use napi::threadsafe_function::{
     ThreadSafeCallContext, ThreadsafeFunction, ThreadsafeFunctionCallMode,

--- a/packages/nx/src/utils/testing/temp-fs.ts
+++ b/packages/nx/src/utils/testing/temp-fs.ts
@@ -37,8 +37,6 @@ export class TempFs {
   createFilesSync(fileObject: NestedFiles) {
     for (let path of Object.keys(fileObject)) {
       this.createFileSync(path, fileObject[path]);
-      // update the file after creating it to ensure the mtime is different
-      this.appendFile(path, '\n');
     }
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When creating a file and then immediately updating it, the underlying FSEvents event for macos will have a cache of created and update. This means that when we expect an update event, we got a create

## Expected Behavior
This now checks the file metadata to see if the status time, modified time and access time were all the same. If they were, then we 100%know that this event is only a create. Otherwise it's an update. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
