### PR TITLE
fix(core): migrate old invalid glob syntax in target outputs

### DIFF
--- a/docs/shared/reference/project-configuration.md
+++ b/docs/shared/reference/project-configuration.md
@@ -313,13 +313,13 @@ Sometimes, multiple targets might write to the same directory. When possible it 
 }
 ```
 
-But if the above is not possible, globs (parsed with the [minimatch](https://github.com/isaacs/minimatch) library) can be specified as outputs to only cache a set of files rather than the whole directory.
+But if the above is not possible, globs (parsed by the [GlobSet](https://docs.rs/globset/0.4.5/globset/#syntax) Rust library) can be specified as outputs to only cache a set of files rather than the whole directory.
 
 ```json
 {
   "targets": {
     "build-js": {
-      "outputs": ["{workspaceRoot}/dist/libs/mylib/**/*.js"]
+      "outputs": ["{workspaceRoot}/dist/libs/mylib/**/*.{js,map}"]
     },
     "build-css": {
       "outputs": ["{workspaceRoot}/dist/libs/mylib/**/*.css"]

--- a/e2e/nx-run/src/cache.test.ts
+++ b/e2e/nx-run/src/cache.test.ts
@@ -157,7 +157,7 @@ describe('cache', () => {
     updateProjectConfig(mylib, (c) => {
       c.targets.build = {
         executor: 'nx:run-commands',
-        outputs: ['{workspaceRoot}/dist/*.txt'],
+        outputs: ['{workspaceRoot}/dist/*.{txt,md}'],
         options: {
           commands: [
             'rm -rf dist',
@@ -167,7 +167,8 @@ describe('cache', () => {
             'echo c > dist/c.txt',
             'echo d > dist/d.txt',
             'echo e > dist/e.txt',
-            'echo f > dist/f.txt',
+            'echo f > dist/f.md',
+            'echo g > dist/g.html',
           ],
           parallel: false,
         },
@@ -188,7 +189,8 @@ describe('cache', () => {
     expect(outputsWithUntouchedOutputs).toContain('c.txt');
     expect(outputsWithUntouchedOutputs).toContain('d.txt');
     expect(outputsWithUntouchedOutputs).toContain('e.txt');
-    expect(outputsWithUntouchedOutputs).toContain('f.txt');
+    expect(outputsWithUntouchedOutputs).toContain('f.md');
+    expect(outputsWithUntouchedOutputs).toContain('g.html');
 
     // Create a file in the dist that does not match output glob
     updateFile('dist/c.ts', '');
@@ -202,7 +204,8 @@ describe('cache', () => {
     expect(outputsAfterAddingUntouchedFileAndRerunning).toContain('c.txt');
     expect(outputsAfterAddingUntouchedFileAndRerunning).toContain('d.txt');
     expect(outputsAfterAddingUntouchedFileAndRerunning).toContain('e.txt');
-    expect(outputsAfterAddingUntouchedFileAndRerunning).toContain('f.txt');
+    expect(outputsAfterAddingUntouchedFileAndRerunning).toContain('f.md');
+    expect(outputsAfterAddingUntouchedFileAndRerunning).toContain('g.html');
     expect(outputsAfterAddingUntouchedFileAndRerunning).toContain('c.ts');
 
     // Clear Dist
@@ -217,8 +220,9 @@ describe('cache', () => {
     expect(outputsWithoutOutputs).toContain('c.txt');
     expect(outputsWithoutOutputs).toContain('d.txt');
     expect(outputsWithoutOutputs).toContain('e.txt');
-    expect(outputsWithoutOutputs).toContain('f.txt');
+    expect(outputsWithoutOutputs).toContain('f.md');
     expect(outputsWithoutOutputs).not.toContain('c.ts');
+    expect(outputsWithoutOutputs).not.toContain('g.html');
   });
 
   it('should use consider filesets when hashing', async () => {

--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -77,6 +77,12 @@
       "version": "16.2.0-beta.0",
       "description": "Remove outputPath from run commands",
       "implementation": "./src/migrations/update-16-2-0/remove-run-commands-output-path"
+    },
+    "16.5.4-update-output-globs": {
+      "cli": "nx",
+      "version": "16.5.4-beta.0",
+      "description": "Update outdated non-standard globs to unix standard",
+      "implementation": "./src/migrations/update-16-5-4/update-output-globs"
     }
   }
 }

--- a/packages/nx/src/migrations/update-16-5-4/update-output-globs.spec.ts
+++ b/packages/nx/src/migrations/update-16-5-4/update-output-globs.spec.ts
@@ -5,6 +5,8 @@ import {
   readProjectConfiguration,
 } from '../../generators/utils/project-configuration';
 import updateOutputsGlobs from './update-output-globs';
+import { readJson, updateJson } from '../../generators/utils/json';
+import { NxJsonConfiguration } from '../../config/nx-json';
 
 describe('update output globs', () => {
   it('should update output globs', () => {
@@ -24,6 +26,15 @@ describe('update output globs', () => {
     addProjectConfiguration(tree, 'my-app', {
       root: 'apps/my-app',
       targets,
+    });
+
+    updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+      json.targetDefaults = {
+        lint: {
+          outputs: ['dist/apps/my-app', '*.(js|map|ts)'],
+        },
+      };
+      return json;
     });
 
     updateOutputsGlobs(tree);
@@ -46,6 +57,18 @@ describe('update output globs', () => {
         "test": {
           "outputs": [
             "dist/apps/my-app/main.{js,map,ts}",
+          ],
+        },
+      }
+    `);
+
+    const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+    expect(nxJson.targetDefaults).toMatchInlineSnapshot(`
+      {
+        "lint": {
+          "outputs": [
+            "dist/apps/my-app",
+            "*.{js,map,ts}",
           ],
         },
       }

--- a/packages/nx/src/migrations/update-16-5-4/update-output-globs.spec.ts
+++ b/packages/nx/src/migrations/update-16-5-4/update-output-globs.spec.ts
@@ -1,0 +1,54 @@
+import { createTreeWithEmptyWorkspace } from '../../generators/testing-utils/create-tree-with-empty-workspace';
+import { TargetConfiguration } from '../../config/workspace-json-project-json';
+import {
+  addProjectConfiguration,
+  readProjectConfiguration,
+} from '../../generators/utils/project-configuration';
+import updateOutputsGlobs from './update-output-globs';
+
+describe('update output globs', () => {
+  it('should update output globs', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    const targets: Record<string, TargetConfiguration> = {
+      build: {
+        outputs: ['{options.outputPath}', 'dist/apps/my-app/*.(js|map|ts)'],
+      },
+      lint: {},
+      test: {
+        outputs: ['dist/apps/my-app/main.(js|map|ts)'],
+      },
+      run: {
+        outputs: ['dist/apps/my-app'],
+      },
+    };
+    addProjectConfiguration(tree, 'my-app', {
+      root: 'apps/my-app',
+      targets,
+    });
+
+    updateOutputsGlobs(tree);
+
+    const migratedTargets = readProjectConfiguration(tree, 'my-app').targets;
+    expect(migratedTargets).toMatchInlineSnapshot(`
+      {
+        "build": {
+          "outputs": [
+            "{options.outputPath}",
+            "dist/apps/my-app/*.{js,map,ts}",
+          ],
+        },
+        "lint": {},
+        "run": {
+          "outputs": [
+            "dist/apps/my-app",
+          ],
+        },
+        "test": {
+          "outputs": [
+            "dist/apps/my-app/main.{js,map,ts}",
+          ],
+        },
+      }
+    `);
+  });
+});

--- a/packages/nx/src/migrations/update-16-5-4/update-output-globs.ts
+++ b/packages/nx/src/migrations/update-16-5-4/update-output-globs.ts
@@ -4,6 +4,24 @@ import {
   updateProjectConfiguration,
 } from '../../generators/utils/project-configuration';
 import { formatChangedFilesWithPrettierIfAvailable } from '../../generators/internal-utils/format-changed-files-with-prettier-if-available';
+import { TargetConfiguration } from '../../config/workspace-json-project-json';
+import { updateJson } from '../../generators/utils/json';
+import { NxJsonConfiguration } from '../../config/nx-json';
+
+function replaceOutputs(targetConfiguration: TargetConfiguration<any>) {
+  let outputs = [];
+  for (const output of targetConfiguration.outputs ?? []) {
+    // replace {projectRoot}/folder/*.(js|map|ts) to {projectRoot}/folder/*.{js,map,ts}
+    const regex = /\(([^)]+)\)/g;
+    const newOutput = output.replace(regex, (match, group1) => {
+      let replacements = group1.split('|').join(',');
+      return `{${replacements}}`;
+    });
+
+    outputs.push(newOutput);
+  }
+  return outputs;
+}
 
 export default async function updateOutputsGlobs(tree: Tree) {
   for (const [projectName, projectConfiguration] of getProjects(
@@ -16,21 +34,25 @@ export default async function updateOutputsGlobs(tree: Tree) {
         continue;
       }
 
-      let outputs = [];
-      for (const output of targetConfiguration.outputs ?? []) {
-        // replace {projectRoot}/folder/*.(js|map|ts) to {projectRoot}/folder/*.{js,map,ts}
-        const regex = /\(([^)]+)\)/g;
-        const newOutput = output.replace(regex, (match, group1) => {
-          let replacements = group1.split('|').join(',');
-          return `{${replacements}}`;
-        });
-
-        outputs.push(newOutput);
-      }
-
-      targetConfiguration.outputs = outputs;
+      targetConfiguration.outputs = replaceOutputs(targetConfiguration);
     }
     updateProjectConfiguration(tree, projectName, projectConfiguration);
   }
+
+  if (tree.exists('nx.json')) {
+    updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+      for (const [, targetConfiguration] of Object.entries(
+        json.targetDefaults ?? {}
+      )) {
+        if (!Array.isArray(targetConfiguration.outputs)) {
+          continue;
+        }
+
+        targetConfiguration.outputs = replaceOutputs(targetConfiguration);
+      }
+      return json;
+    });
+  }
+
   await formatChangedFilesWithPrettierIfAvailable(tree);
 }

--- a/packages/nx/src/migrations/update-16-5-4/update-output-globs.ts
+++ b/packages/nx/src/migrations/update-16-5-4/update-output-globs.ts
@@ -3,6 +3,7 @@ import {
   getProjects,
   updateProjectConfiguration,
 } from '../../generators/utils/project-configuration';
+import { formatChangedFilesWithPrettierIfAvailable } from '../../generators/internal-utils/format-changed-files-with-prettier-if-available';
 
 export default async function updateOutputsGlobs(tree: Tree) {
   for (const [projectName, projectConfiguration] of getProjects(
@@ -31,4 +32,5 @@ export default async function updateOutputsGlobs(tree: Tree) {
     }
     updateProjectConfiguration(tree, projectName, projectConfiguration);
   }
+  await formatChangedFilesWithPrettierIfAvailable(tree);
 }

--- a/packages/nx/src/native/cache/expand_outputs.rs
+++ b/packages/nx/src/native/cache/expand_outputs.rs
@@ -59,6 +59,10 @@ mod test {
             .child("nx.darwin-arm64.node")
             .touch()
             .unwrap();
+        temp.child("multi").child("file.js").touch().unwrap();
+        temp.child("multi").child("src.ts").touch().unwrap();
+        temp.child("multi").child("file.map").touch().unwrap();
+        temp.child("multi").child("file.txt").touch().unwrap();
         temp
     }
     #[test]
@@ -78,6 +82,18 @@ mod test {
                 "packages/nx/src/native/nx.darwin-arm64.node",
                 "test.txt"
             ]
+        );
+    }
+
+    #[test]
+    fn should_handle_multiple_extensions() {
+        let temp = setup_fs();
+        let entries = vec!["multi/*.{js,map,ts}".to_string()];
+        let mut result = expand_outputs(temp.display().to_string(), entries).unwrap();
+        result.sort();
+        assert_eq!(
+            result,
+            vec!["multi/file.js", "multi/file.map", "multi/src.ts"]
         );
     }
 }

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -184,7 +184,8 @@ export function getOutputsForTargetAndConfiguration(
       })
       .filter(
         (output) =>
-          !!output && !output.match(/{(projectRoot|workspaceRoot|(options.*))}/)
+          !!output &&
+          !output.match(/{(projectRoot|workspaceRoot|(options\.*))}/)
       );
   }
 

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -182,7 +182,10 @@ export function getOutputsForTargetAndConfiguration(
           options,
         });
       })
-      .filter((output) => !!output && !output.match(/{.*}/));
+      .filter(
+        (output) =>
+          !!output && !output.match(/{(projectRoot|workspaceRoot|(options.*))}/)
+      );
   }
 
   // Keep backwards compatibility in case `outputs` doesn't exist

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -184,8 +184,7 @@ export function getOutputsForTargetAndConfiguration(
       })
       .filter(
         (output) =>
-          !!output &&
-          !output.match(/{(projectRoot|workspaceRoot|(options\.*))}/)
+          !!output && !output.match(/{(projectRoot|workspaceRoot|(options.*))}/)
       );
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Invalid glob syntax in target outputs do not work (ie. `dist/*.(js|map|ts)`. This was because our older glob utility allowed this.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
This migrates outputs that have the invalid syntax to `dist/*.{js,map,ts}`. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18075
