### PR TITLE
fix(core): normalizing key of patched packages with its actual resolved version and not the one from the key

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/yarn-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/yarn-parser.ts
@@ -398,20 +398,21 @@ function mapSnapshots(
   });
 
   // remove keys that match version ranges that have been pruned away
-  snapshotMap.forEach((keysSet) => {
-    for (const key of keysSet.values()) {
+  snapshotMap.forEach((snapshotValue, snapshotKey) => {
+    for (const key of snapshotValue.values()) {
       const packageName = key.slice(0, key.indexOf('@', 1));
       let normalizedKey = key;
       if (isBerry && key.includes('@patch:') && key.includes('#')) {
         normalizedKey = key
           .slice(0, key.indexOf('#'))
-          .replace(`@patch:${packageName}@`, '@npm:');
+          .replace(`@patch:${packageName}@`, '@npm:')
+          .replace(/:.*$/u, ':' + snapshotKey.version);
       }
       if (
         !existingKeys.get(packageName) ||
         !existingKeys.get(packageName).has(normalizedKey)
       ) {
-        keysSet.delete(key);
+        snapshotValue.delete(key);
       }
     }
   });


### PR DESCRIPTION
## Current Behavior
As described in #17873

My understanding of the sitatuion is that it is an edge case. The issue can be replicated in [the repo](https://github.com/ganlhi/nx-next-lockfile-issue) from @ganlhi where the following happens:
1. In the `package.json` there is the definition ["typescript": "~5.1.3"](https://github.com/ganlhi/nx-next-lockfile-issue/blob/main/package.json#L38) but in the lock file it is resolved with [5.1.6](https://github.com/ganlhi/nx-next-lockfile-issue/blob/main/yarn.lock#L10688-L10689)
2. When [generating the keys](https://github.com/nrwl/nx/blob/master/packages/nx/src/plugins/js/lock-file/yarn-parser.ts#L355) for the `yarn.lock` it uses, not the version from the string defined by the user (5.1.3), but the actual version resolved by `yarn` (5.1.6)
3. Then we go an prepare the objects to be pruned. For the specific case of the packages that have `patch` in `berry` we use its nomalised key to prune the lock file . [This normalised key](https://github.com/nrwl/nx/blob/master/packages/nx/src/plugins/js/lock-file/yarn-parser.ts#L408) uses the version from the string, and not the resolved from `yarn`, which then in [this bit](https://github.com/nrwl/nx/blob/master/packages/nx/src/plugins/js/lock-file/yarn-parser.ts#L412) is trigerred as a deletion because it does not match the version.
4. This effectively [deletes the key](https://github.com/nrwl/nx/blob/master/packages/nx/src/plugins/js/lock-file/yarn-parser.ts#L414) giving the issue described in #17873 with an empty `""` key for the value of the `typescript` package. It can seen better in the screenshot

<img width="1019" alt="image" src="https://github.com/nrwl/nx/assets/4464739/75953180-38f7-4dae-b26d-c4171f54b43a"> 

This PR solves the issue but calculating the `normalizedKey` by using the resolved version of `yarn` and fixes the issue.

That said, perhaps there is a better way of fixing this because I do not have in-depth knowledge on the matter. Hopefully will give some info to the dev that can fix it 😄 

## Expected Behavior
It generates a valid `yarn.lock` 

## Related Issue(s)
#17873
(Maybe) #17853 done by @meeroslav 

Fixes #17873
