### PR TITLE
feat(testing): add playwright e2e preset

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@nx/webpack": "16.6.0-beta.2",
     "@parcel/watcher": "2.0.4",
     "@phenomnomnominal/tsquery": "~5.0.1",
+    "@playwright/test": "^1.36.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",
     "@pnpm/lockfile-types": "^5.0.0",
     "@reduxjs/toolkit": "1.9.0",

--- a/packages/playwright/src/generators/configuration/files/playwright.config.ts.template
+++ b/packages/playwright/src/generators/configuration/files/playwright.config.ts.template
@@ -1,4 +1,6 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig } from '@playwright/test';
+import { nxE2EPreset } from '@nx/playwright'
+import { workspaceRoot } from '@nx/devkit';
 
 /**
  * Read environment variables from file.
@@ -10,82 +12,17 @@ import { defineConfig, devices } from '@playwright/test';
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-  testDir: './<%= directory %>',
-  /* When updating this path, make sure to update the outputs in the project.json */
-  outputDir: '<%= offsetFromRoot %>dist/.playwright/<%= projectRoot %>/test-output',
-  /* Run tests in files in parallel */
-  fullyParallel: true,
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-    reporter: [
-    [
-      'html',
-      {
-        outputFolder:
-          '<%= offsetFromRoot %>dist/playwright/<%= projectRoot %>/playwright-report',
-      },
-    ],
-  ],
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
-  use: {
-    /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://127.0.0.1:3000',
-
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
-  },
-
-  /* Configure projects for major browsers */
-  projects: [
-    {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
-    },
-
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
-
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
-
-    /* Test against mobile viewports. */
-    // {
-    //   name: 'Mobile Chrome',
-    //   use: { ...devices['Pixel 5'] },
-    // },
-    // {
-    //   name: 'Mobile Safari',
-    //   use: { ...devices['iPhone 12'] },
-    // },
-
-    /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    // },
-  ],
-
+  ...nxE2EPreset(__filename, { testDir: './<%= directory %>' }),
   /* Run your local dev server before starting the tests */<% if(webServerCommand && webServerAddress) {%> 
    webServer: {
      command: '<%= webServerCommand %>',
      url: '<%= webServerAddress %>',
      reuseExistingServer: !process.env.CI,
+     cwd: workspaceRoot
    },<% } else {%>// webServer: {
   //   command: 'npm run start',
   //   url: 'http://127.0.0.1:3000',
   //   reuseExistingServer: !process.env.CI,
+  //   cwd: workspaceRoot
   // },<% } %>
 });

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -4,3 +4,4 @@ export {
 } from './executors/playwright/playwright';
 export { initGenerator } from './generators/init/init';
 export { configurationGenerator } from './generators/configuration/configuration';
+export { nxE2EPreset, NxPlaywrightOptions } from './utils/preset';

--- a/packages/playwright/src/utils/preset.ts
+++ b/packages/playwright/src/utils/preset.ts
@@ -1,0 +1,143 @@
+import { workspaceRoot } from '@nx/devkit';
+import { lstatSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { PlaywrightTestProject, defineConfig, devices } from '@playwright/test';
+
+export interface NxPlaywrightOptions {
+  /**
+   * The directory where the e2e tests are located.
+   * @default './src'
+   **/
+  testDir?: string;
+  /**
+   * Include Mobile Chome and Mobile Safari browsers in test projects
+   * @default false
+   **/
+  includeMobileBrowsers?: boolean;
+
+  /**
+   * Include Microsoft Edge and Google Chrome browsers in test projects
+   * @default false
+   **/
+  includeBrandedBrowsers?: boolean;
+}
+
+/**
+ * nx E2E Preset for Playwright
+ * @description
+ * this preset contains the base configuration
+ * for your e2e tests that nx recommends.
+ * By default html reporter is configured
+ * along with the following browsers:
+ * - chromium
+ * - firefox
+ * - webkit
+ *
+ * you can easily extend this within your playwright config via spreading the preset
+ * @example
+ * export default defineConfig({
+ *   ...nxE2EPreset(__filename, options)
+ *   // add your own config here
+ * })
+ *
+ * @param pathToConfig will be used to construct the output paths for reporters and test results
+ * @param options optional confiuration options
+ */
+export function nxE2EPreset(
+  pathToConfig: string,
+  options?: NxPlaywrightOptions
+) {
+  const normalizedPath = lstatSync(pathToConfig).isDirectory()
+    ? pathToConfig
+    : dirname(pathToConfig);
+  const projectPath = relative(workspaceRoot, normalizedPath);
+  const offset = relative(normalizedPath, workspaceRoot);
+
+  const testResultOuputDir = join(
+    offset,
+    'dist',
+    '.playwright',
+    projectPath,
+    'test-output'
+  );
+  const reporterOutputDir = join(
+    offset,
+    'dist',
+    '.playwright',
+    projectPath,
+    'playwright-report'
+  );
+  const projects: PlaywrightTestProject[] = [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+  ];
+  if (options?.includeMobileBrowsers) {
+    projects.push(
+      ...[
+        {
+          name: 'Mobile Chrome',
+          use: { ...devices['Pixel 5'] },
+        },
+        {
+          name: 'Mobile Safari',
+          use: { ...devices['iPhone 12'] },
+        },
+      ]
+    );
+  }
+
+  if (options?.includeBrandedBrowsers) {
+    projects.push(
+      ...[
+        {
+          name: 'Microsoft Edge',
+          use: { ...devices['Desktop Edge'], channel: 'msedge' },
+        },
+        {
+          name: 'Google Chrome',
+          use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+        },
+      ]
+    );
+  }
+
+  return defineConfig({
+    testDir: options.testDir ?? './src',
+    outputDir: testResultOuputDir,
+    /* Run tests in files in parallel */
+    fullyParallel: true,
+    /* Fail the build on CI if you accidentally left test.only in the source code. */
+    forbidOnly: !!process.env.CI,
+    /* Retry on CI only */
+    retries: process.env.CI ? 2 : 0,
+    /* Opt out of parallel tests on CI. */
+    workers: process.env.CI ? 1 : undefined,
+    /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+    reporter: [
+      [
+        'html',
+        {
+          outputFolder: reporterOutputDir,
+        },
+      ],
+    ],
+    /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+    use: {
+      /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+      trace: 'on-first-retry',
+    },
+    projects,
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,6 +300,9 @@ devDependencies:
   '@phenomnomnominal/tsquery':
     specifier: ~5.0.1
     version: 5.0.1(typescript@5.1.3)
+  '@playwright/test':
+    specifier: ^1.36.1
+    version: 1.36.1
   '@pmmmwh/react-refresh-webpack-plugin':
     specifier: ^0.5.7
     version: 0.5.8(react-refresh@0.10.0)(webpack-dev-server@4.11.1)(webpack@5.88.0)
@@ -8304,6 +8307,17 @@ packages:
       picocolors: 1.0.0
       tiny-glob: 0.2.9
       tslib: 2.5.3
+    dev: true
+
+  /@playwright/test@1.36.1:
+    resolution: {integrity: sha512-YK7yGWK0N3C2QInPU6iaf/L3N95dlGdbsezLya4n0ZCh3IL7VgPGxC6Gnznh9ApWdOmkJeleT2kMTcWPRZvzqg==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dependencies:
+      '@types/node': 18.16.9
+      playwright-core: 1.36.1
+    optionalDependencies:
+      fsevents: 2.3.2
     dev: true
 
   /@pmmmwh/react-refresh-webpack-plugin@0.5.10(react-refresh@0.11.0)(webpack-dev-server@4.11.1)(webpack@5.88.0):
@@ -22364,6 +22378,12 @@ packages:
   /pkginfo@0.4.1:
     resolution: {integrity: sha512-8xCNE/aT/EXKenuMDZ+xTVwkT8gsoHN2z/Q29l80u0ppGEXVvsKRzNMbtKhg8LS8k1tJLAHHylf6p4VFmP6XUQ==}
     engines: {node: '>= 0.4.0'}
+    dev: true
+
+  /playwright-core@1.36.1:
+    resolution: {integrity: sha512-7+tmPuMcEW4xeCL9cp9KxmYpQYHKkyjwoXRnoeTowaeNat8PoBMk/HwCYhqkH2fRkshfKEOiVus/IhID2Pg8kg==}
+    engines: {node: '>=16'}
+    hasBin: true
     dev: true
 
   /please-upgrade-node@3.2.0:


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
playwright configs are all userland, while cypress configs have a helper preset

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
playwright should expose a configuration preset like cypress

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
