### PR TITLE
fix(testing): run playwright from workspaceRoot

### DIFF
--- a/packages/playwright/src/executors/playwright/playwright.ts
+++ b/packages/playwright/src/executors/playwright/playwright.ts
@@ -64,7 +64,7 @@ export async function playwrightExecutor(
     );
   }
   const args = createArgs(options);
-  const p = runPlaywright(args, join(context.root, projectRoot));
+  const p = runPlaywright(args, context.root);
 
   return new Promise<{ success: boolean }>((resolve) => {
     p.on('close', (code) => {

--- a/packages/playwright/src/generators/configuration/configuration.ts
+++ b/packages/playwright/src/generators/configuration/configuration.ts
@@ -73,7 +73,11 @@ Rename or remove the existing e2e target.`);
   projectConfig.targets.e2e = {
     executor: '@nx/playwright:playwright',
     outputs: [`dist/.playwright/${projectConfig.root}`],
-    options: {},
+    options: {
+      config: `${projectConfig.root}/playwright.config.${
+        options.js ? 'js' : 'ts'
+      }`,
+    },
   };
   updateProjectConfiguration(tree, options.project, projectConfig);
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
playwright runs from projectRoot, which results in paths having to be from projectRoot causing extra pathing '../../' for many options.
Also doesn't align with most other executor behaviors defining paths from the workspaceRoot.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

run playwright from workspaceRoot making pathing align with other executors

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
