### PR TITLE
fix(js): generate ts standalone project with better import path

### DIFF
--- a/e2e/storybook/src/storybook-nested.test.ts
+++ b/e2e/storybook/src/storybook-nested.test.ts
@@ -79,7 +79,7 @@ describe('Storybook generators and executors for standalone workspaces - using R
       writeFileSync(
         tmpProjPath(`src/app/test-button.tsx`),
         `
-          import { MyLib } from '@${appName}/my-lib';
+          import { MyLib } from 'my-lib';
 
           export function TestButton() {
             return (

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -383,6 +383,33 @@ describe('lib', () => {
 
         expect.assertions(1);
       });
+
+      it('should provide a default import path using npm scope', async () => {
+        await libraryGenerator(tree, {
+          ...defaultOptions,
+          name: 'myLib',
+        });
+
+        const tsconfigJson = readJson(tree, '/tsconfig.base.json');
+        expect(
+          tsconfigJson.compilerOptions.paths['@proj/my-lib']
+        ).toBeDefined();
+      });
+
+      it('should read import path from existing name in package.json', async () => {
+        updateJson(tree, 'package.json', (json) => {
+          json.name = '@acme/core';
+          return json;
+        });
+        await libraryGenerator(tree, {
+          ...defaultOptions,
+          rootProject: true,
+          name: 'myLib',
+        });
+
+        const tsconfigJson = readJson(tree, '/tsconfig.base.json');
+        expect(tsconfigJson.compilerOptions.paths['@acme/core']).toBeDefined();
+      });
     });
 
     describe('--pascalCaseFiles', () => {

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -12,6 +12,7 @@ import {
   names,
   offsetFromRoot,
   ProjectConfiguration,
+  readJson,
   runTasksInSerial,
   toJS,
   Tree,
@@ -35,8 +36,6 @@ import {
   swcHelpersVersion,
   tsLibVersion,
   typesNodeVersion,
-  swcNodeVersion,
-  swcCoreVersion,
 } from '../../utils/versions';
 import jsInitGenerator from '../init/init';
 import { type PackageJson } from 'nx/src/utils/package-json';
@@ -539,8 +538,9 @@ function normalizeOptions(
     ? options.tags.split(',').map((s) => s.trim())
     : [];
 
-  const importPath =
-    options.importPath || getImportPath(tree, projectDirectory);
+  const importPath = options.rootProject
+    ? readJson(tree, 'package.json').name ?? getImportPath(tree, 'core')
+    : options.importPath || getImportPath(tree, projectDirectory);
 
   options.minimal ??= false;
 

--- a/packages/workspace/src/generators/new/files-root-app/package.json__tmpl__
+++ b/packages/workspace/src/generators/new/files-root-app/package.json__tmpl__
@@ -1,5 +1,5 @@
 {
-  "name": "@<%= formattedNames.fileName %>/source",
+  "name": "<%= formattedNames.fileName %>",
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
This PR fixes an issue with standalone TS projects (`npx create-nx-workspace --preset=ts-standalone`) where the `name` in `package.json` is invalid.

## Current Behavior
The name is something like `@acme/.`

## Expected Behavior
The name should be the name of the folder (e.g. `acme`).

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
