### PR TITLE
fix(testing): add playwright secondary entrypoint for preset

### DIFF
--- a/packages/playwright/index.ts
+++ b/packages/playwright/index.ts
@@ -1,0 +1,7 @@
+export {
+  playwrightExecutor,
+  PlaywrightExecutorSchema,
+} from './src/executors/playwright/playwright';
+export { initGenerator } from './src/generators/init/init';
+export { configurationGenerator } from './src/generators/configuration/configuration';
+export { nxE2EPreset, NxPlaywrightOptions } from './src/utils/preset';

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -16,8 +16,8 @@
     "Playwright",
     "CLI"
   ],
-  "main": "./src/index",
-  "typings": "./src/index.d.ts",
+  "main": "./index.js",
+  "typings": "./index.d.ts",
   "author": "Victor Savkin",
   "license": "MIT",
   "bugs": {

--- a/packages/playwright/preset.ts
+++ b/packages/playwright/preset.ts
@@ -1,0 +1,1 @@
+export * from './src/utils/preset';

--- a/packages/playwright/project.json
+++ b/packages/playwright/project.json
@@ -1,7 +1,7 @@
 {
   "name": "playwright",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
-  "sourceRoot": "packages/playwright/src",
+  "sourceRoot": "packages/playwright",
   "projectType": "library",
   "targets": {
     "build": {
@@ -15,30 +15,38 @@
       "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
-        "outputPath": "build/packages/playwright",
-        "main": "packages/playwright/src/index.ts",
-        "tsConfig": "packages/playwright/tsconfig.lib.json",
         "assets": [
-          "packages/playwright/*.md",
           {
-            "input": "./packages/playwright/src",
-            "glob": "**/!(*.ts)",
-            "output": "./src"
+            "input": "packages/playwright",
+            "glob": "**/files/**",
+            "output": "/"
           },
           {
-            "input": "./packages/playwright/src",
+            "input": "packages/playwright",
+            "glob": "**/files/**/.gitkeep",
+            "output": "/"
+          },
+          {
+            "input": "packages/playwright",
+            "glob": "**/*.json",
+            "ignore": ["**/tsconfig*.json", "project.json", ".eslintrc.json"],
+            "output": "/"
+          },
+          {
+            "input": "packages/playwright",
+            "glob": "**/*.js",
+            "ignore": ["**/jest.config.js"],
+            "output": "/"
+          },
+          {
+            "input": "packages/playwright",
             "glob": "**/*.d.ts",
-            "output": "./src"
+            "output": "/"
           },
           {
-            "input": "./packages/playwright",
-            "glob": "generators.json",
-            "output": "."
-          },
-          {
-            "input": "./packages/playwright",
-            "glob": "executors.json",
-            "output": "."
+            "input": "",
+            "glob": "LICENSE",
+            "output": "/"
           }
         ]
       }

--- a/packages/playwright/src/generators/configuration/files/playwright.config.ts.template
+++ b/packages/playwright/src/generators/configuration/files/playwright.config.ts.template
@@ -1,5 +1,5 @@
 import { defineConfig } from '@playwright/test';
-import { nxE2EPreset } from '@nx/playwright'
+import { nxE2EPreset } from '@nx/playwright/preset';
 import { workspaceRoot } from '@nx/devkit';
 
 /**

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -1,7 +1,0 @@
-export {
-  playwrightExecutor,
-  PlaywrightExecutorSchema,
-} from './executors/playwright/playwright';
-export { initGenerator } from './generators/init/init';
-export { configurationGenerator } from './generators/configuration/configuration';
-export { nxE2EPreset, NxPlaywrightOptions } from './utils/preset';

--- a/packages/playwright/tsconfig.lib.json
+++ b/packages/playwright/tsconfig.lib.json
@@ -5,6 +5,6 @@
     "declaration": true,
     "types": ["node"]
   },
-  "include": ["src/**/*.ts"],
+  "include": ["**/*.ts"],
   "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

https://github.com/microsoft/playwright/issues/19798

when importing from @playwright/test, expect is overridden causing issues with global jest expect.
therefore test start failing with 

```
•app > -mlnlmal > should sklp "nx-welcome.component.ts" flle and references for standalone apps wlth routlng
toMatchsnapshot() must be called durlng the test
700 1
701 1
> 702 1
// check to see if the workspace configuration has been updated to turn off
// strict mode by default in future 8ppIic8tions
const nxJson re8dJson<NxJsonConf igur8tion>(appTree, ' nx. j son, ).
703 1
704 1 i)
705 1 1),
expect(nxJson.generators [, @nx/8ngular: appllcatlon, ]. strlct). toBe(f alse).
at Object.toMatchSnapshot ( .. I.. /node_modules/. pnpm/@pl8ywright+test@1.36. 1/node_module @playwright/test/lib/matchers/toMatchsnapshot. j s
4.24)
at EXTERNAL MATCHER TRAP ( .. /.. /node_modules/. pnpm/expect@29. 5.0/node_modules/expect/build/index. j s: 317: 30)
at Ob j ect.throwingMatcher ( . / . /node_modules/. pnpm/expect@29. 5.O/node_modules/expect/build/index. js: 318: 15)
at src/generators/application/application. spec.ts: 702.82
at f ulf illed ( .. / .. /node_modules/. pnpm/tslib@2.4.0/node_modules/tslib/tslib. j s: 115: 62)
```

This happens because the playwright e2e preset file imports from @playwright/test; therfore, 
importing from the main index.ts causing @playwright/test to be imported into jest program

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

a secondary entrypoint for the playwright preset should be used instead of the main index file.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
