### PR TITLE
fix(storybook): make sure skipLibCheck is true

### DIFF
--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -23,6 +23,7 @@ import {
   configureTsSolutionConfig,
   createProjectStorybookDir,
   createStorybookTsconfigFile,
+  editTsconfigBaseJson,
   getE2EProjectName,
   getViteConfigFilePath,
   projectIsRootProjectInStandaloneWorkspace,
@@ -128,6 +129,7 @@ export async function configurationGenerator(
     );
   }
   configureTsProjectConfig(tree, schema);
+  editTsconfigBaseJson(tree);
   configureTsSolutionConfig(tree, schema);
   updateLintConfig(tree, schema);
 

--- a/packages/storybook/src/generators/configuration/lib/util-functions.ts
+++ b/packages/storybook/src/generators/configuration/lib/util-functions.ts
@@ -28,6 +28,7 @@ import {
 import { StorybookConfigureSchema } from '../schema';
 import { UiFramework7 } from '../../../utils/models';
 import { nxVersion } from '../../../utils/versions';
+import ts = require('typescript');
 
 const DEFAULT_PORT = 4400;
 
@@ -257,6 +258,23 @@ export function createStorybookTsconfigFile(
   };
 
   writeJson(tree, storybookTsConfigPath, storybookTsConfig);
+}
+
+export function editTsconfigBaseJson(tree: Tree) {
+  let tsconfigBasePath = 'tsconfig.base.json';
+
+  // standalone workspace maybe
+  if (!tree.exists(tsconfigBasePath)) tsconfigBasePath = 'tsconfig.json';
+
+  if (!tree.exists(tsconfigBasePath)) return;
+
+  const tsconfigBaseContent = readJson<TsConfig>(tree, tsconfigBasePath);
+
+  if (!tsconfigBaseContent.compilerOptions)
+    tsconfigBaseContent.compilerOptions = {};
+  tsconfigBaseContent.compilerOptions.skipLibCheck = true;
+
+  writeJson(tree, tsconfigBasePath, tsconfigBaseContent);
 }
 
 export function configureTsProjectConfig(


### PR DESCRIPTION
closed #18153 

## Current Behavior

If you create an Angular app with `ng new` and then you do `nx init` in that app, `skipLibCheck` is not added in root tsconfig.json (or tsconfig.base.json). This results in some type errors when running Storybook.

## Expected Behavior

If a user configures Storybook, make sure `skipLibCheck` is true in their root tsconfig.json.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18153
