### PR TITLE
feat(bundling): generate type definitions in esbuild executor

### DIFF
--- a/e2e/esbuild/src/esbuild.test.ts
+++ b/e2e/esbuild/src/esbuild.test.ts
@@ -54,6 +54,15 @@ describe('EsBuild Plugin', () => {
     checkFilesExist(`dist/libs/${myPkg}/package.json`);
     expect(runCommand(`node dist/libs/${myPkg}`)).toMatch(/Hello/);
 
+    // types field should be set correctly in package.json and types should be generated
+    expect(readJson(`dist/libs/${myPkg}/package.json`).types).toEqual(
+      './src/index.d.ts'
+    );
+    checkFilesExist(
+      `dist/libs/${myPkg}/src/index.d.ts`,
+      `dist/libs/${myPkg}/src/lib/${myPkg}.d.ts`
+    );
+
     expect(runCommand(`node dist/libs/${myPkg}/index.cjs`)).toMatch(/Hello/);
     // main field should be set correctly in package.json
 
@@ -78,6 +87,10 @@ describe('EsBuild Plugin', () => {
     expect(() => runCLI(`build ${myPkg}`)).toThrow();
     expect(() => runCLI(`build ${myPkg} --skipTypeCheck`)).not.toThrow();
     expect(runCommand(`node dist/libs/${myPkg}/index.cjs`)).toMatch(/Bye/);
+    checkFilesDoNotExist(
+      `dist/libs/${myPkg}/src/index.d.ts`,
+      `dist/libs/${myPkg}/src/lib/${myPkg}.d.ts`
+    );
     // Reset file
     updateFile(
       `libs/${myPkg}/src/index.ts`,

--- a/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
+++ b/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
@@ -83,8 +83,7 @@ export async function* esbuildExecutor(
 
     const cpjOptions: CopyPackageJsonOptions = {
       ...options,
-      // TODO(jack): make types generate with esbuild
-      skipTypings: true,
+      skipTypings: options.skipTypeCheck,
       outputFileExtensionForCjs: getOutExtension('cjs', options),
       excludeLibsInPackageJson: !options.thirdParty,
       updateBuildableProjectDepsInPackageJson: externalDependencies.length > 0,
@@ -208,12 +207,11 @@ function getTypeCheckOptions(
   const { watch, tsConfig, outputPath } = options;
 
   const typeCheckOptions: TypeCheckOptions = {
-    // TODO(jack): Add support for d.ts declaration files -- once the `@nx/js:tsc` changes are in we can use the same logic.
-    mode: 'noEmit',
+    mode: 'emitDeclarationOnly',
     tsConfigPath: tsConfig,
-    // outDir: outputPath,
+    outDir: outputPath,
     workspaceRoot: context.root,
-    rootDir: context.root,
+    rootDir: context.projectsConfigurations.projects[context.projectName].root,
   };
 
   if (watch) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `@nx/esbuild:esbuild` executor doesn't generate type definitions.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `@nx/esbuild:esbuild` executor should generate type definitions unless `--skip-type-check` is set.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
