### PR TITLE
fix(misc): fix error handling for create-nx-workspace

### DIFF
--- a/packages/create-nx-workspace/.eslintrc.json
+++ b/packages/create-nx-workspace/.eslintrc.json
@@ -32,7 +32,8 @@
         "@nx/dependency-checks": [
           "error",
           {
-            "buildTargets": ["build-base"]
+            "buildTargets": ["build-base"],
+            "ignoredDependencies": ["nx"]
           }
         ]
       }

--- a/packages/create-nx-workspace/src/create-sandbox.ts
+++ b/packages/create-nx-workspace/src/create-sandbox.ts
@@ -40,10 +40,12 @@ export async function createSandbox(packageManager: PackageManager) {
     generatePackageManagerFiles(tmpDir, packageManager);
 
     if (preInstall) {
-      await execAndWait(preInstall, tmpDir);
+      const [preInstallFile, ...preInstallArgs] = preInstall.split(' ');
+      await execAndWait(preInstallFile, preInstallArgs, tmpDir);
     }
 
-    await execAndWait(install, tmpDir);
+    const [file, ...args] = install.split(' ');
+    await execAndWait(file, args, tmpDir);
 
     installSpinner.succeed();
   } catch (e) {

--- a/packages/create-nx-workspace/src/create-workspace.ts
+++ b/packages/create-nx-workspace/src/create-workspace.ts
@@ -50,12 +50,7 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
     nxCloudInstallRes = await setupNxCloud(directory, packageManager);
 
     if (nxCloud !== 'yes') {
-      await setupCI(
-        directory,
-        nxCloud,
-        packageManager,
-        nxCloudInstallRes?.code === 0
-      );
+      await setupCI(directory, nxCloud, nxCloudInstallRes?.code === 0);
     }
   }
   if (!skipGit && commit) {

--- a/packages/create-nx-workspace/src/utils/ci/setup-ci.ts
+++ b/packages/create-nx-workspace/src/utils/ci/setup-ci.ts
@@ -8,7 +8,6 @@ import { getPackageManagerCommand, PackageManager } from '../package-manager';
 export async function setupCI(
   directory: string,
   ci: string,
-  packageManager: PackageManager,
   nxCloudSuccessfullyInstalled: boolean
 ) {
   if (!nxCloudSuccessfullyInstalled) {
@@ -22,9 +21,12 @@ export async function setupCI(
   }
   const ciSpinner = ora(`Generating CI workflow`).start();
   try {
-    const pmc = getPackageManagerCommand(packageManager);
+    const nx = require.resolve('nx', {
+      paths: [directory],
+    });
     const res = await execAndWait(
-      `${pmc.exec} nx g @nx/workspace:ci-workflow --ci=${ci}`,
+      `node`,
+      [nx, 'g', '@nx/workspace:ci-workflow', `--ci=${ci}`],
       directory
     );
     ciSpinner.succeed('CI workflow has been generated successfully');

--- a/packages/create-nx-workspace/src/utils/error-utils.ts
+++ b/packages/create-nx-workspace/src/utils/error-utils.ts
@@ -1,7 +1,7 @@
 export class CreateNxWorkspaceError extends Error {
   constructor(
     public logMessage: string,
-    public code: number | null | undefined,
+    public code: string | number | null | undefined,
     public logFile: string
   ) {
     super(logMessage);

--- a/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
+++ b/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
@@ -12,9 +12,18 @@ export async function setupNxCloud(
 ) {
   const nxCloudSpinner = ora(`Setting up Nx Cloud`).start();
   try {
-    const pmc = getPackageManagerCommand(packageManager);
+    const nx = require.resolve('nx', {
+      paths: [directory],
+    });
     const res = await execAndWait(
-      `${pmc.exec} nx g nx:connect-to-nx-cloud --no-interactive --quiet`,
+      `node`,
+      [
+        nx,
+        'g',
+        'nx-cloud:init',
+        '--no-analytics',
+        '--installationSource=create-nx-workspace',
+      ],
       directory
     );
     nxCloudSpinner.succeed('Nx Cloud has been set up successfully');

--- a/packages/create-nx-workspace/src/utils/package-manager.ts
+++ b/packages/create-nx-workspace/src/utils/package-manager.ts
@@ -40,11 +40,14 @@ export function getPackageManagerCommand(
 } {
   const pmVersion = getPackageManagerVersion(packageManager);
   const [pmMajor, pmMinor] = pmVersion.split('.');
+  const isWindows = process.platform === 'win32';
 
   switch (packageManager) {
     case 'yarn':
       const useBerry = +pmMajor >= 2;
-      const installCommand = 'yarn install --silent';
+      const installCommand = `${
+        isWindows ? 'yarn.cmd' : 'yarn'
+      } install --silent`;
       return {
         preInstall: `yarn set version ${pmVersion}`,
         install: useBerry
@@ -60,13 +63,17 @@ export function getPackageManagerCommand(
         useExec = true;
       }
       return {
-        install: 'pnpm install --no-frozen-lockfile --silent --ignore-scripts',
+        install: `${
+          isWindows ? 'pnpm.cmd' : 'pnpm'
+        } install --no-frozen-lockfile --silent --ignore-scripts`,
         exec: useExec ? 'pnpm exec' : 'pnpx',
       };
 
     case 'npm':
       return {
-        install: 'npm install --silent --ignore-scripts',
+        install: `${
+          isWindows ? 'npm.cmd' : 'npm'
+        } install --silent --ignore-scripts`,
         exec: 'npx',
       };
   }

--- a/packages/nx/src/command-line/new/command-object.ts
+++ b/packages/nx/src/command-line/new/command-object.ts
@@ -6,24 +6,14 @@ export const yargsNewCommand: CommandModule = {
   builder: (yargs) => withNewOptions(yargs),
   handler: async (args) => {
     args._ = args._.slice(1);
-    process.exit(
-      await (
-        await import('./new')
-      ).newWorkspace(args['nxWorkspaceRoot'] as string, args)
-    );
+    process.exit(await (await import('./new')).newWorkspace(args));
   },
 };
 
 function withNewOptions(yargs: Argv) {
-  return yargs
-    .option('nxWorkspaceRoot', {
-      describe: 'The folder where the new workspace is going to be created',
-      type: 'string',
-      required: true,
-    })
-    .option('interactive', {
-      describe: 'When false disables interactive input prompts for options',
-      type: 'boolean',
-      default: true,
-    });
+  return yargs.option('interactive', {
+    describe: 'When false disables interactive input prompts for options',
+    type: 'boolean',
+    default: true,
+  });
 }

--- a/packages/nx/src/command-line/new/new.ts
+++ b/packages/nx/src/command-line/new/new.ts
@@ -10,7 +10,8 @@ function removeSpecialFlags(generatorOptions: { [p: string]: any }): void {
   delete generatorOptions['$0'];
 }
 
-export async function newWorkspace(cwd: string, args: { [k: string]: any }) {
+export async function newWorkspace(args: { [k: string]: any }) {
+  const cwd = process.env.NX_WORKSPACE_ROOT;
   return handleErrors(
     process.env.NX_VERBOSE_LOGGING === 'true' || args.verbose,
     async () => {
@@ -19,7 +20,7 @@ export async function newWorkspace(cwd: string, args: { [k: string]: any }) {
         getGeneratorInformation(
           '@nx/workspace/generators.json',
           'new',
-          null,
+          cwd,
           {}
         );
       removeSpecialFlags(args);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When using a nightly build of Node, node will print a warning to `stderr` which is normal.

If there is a `stderr`, we will ignore `stdout`, which.. seems okay. However, `nx` prints its errors to `stderr`.. which is a separate issue.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The error log should be a combination of the `stdout` and `stderr`. Also, it should be interleaved the way that the user would usually see it if that command was run directly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes: https://github.com/nrwl/nx/issues/17846
