### PR TITLE
feat(core): add monorepo generator to convert from standalone projects

### DIFF
--- a/packages/workspace/generators.json
+++ b/packages/workspace/generators.json
@@ -14,6 +14,11 @@
       "aliases": ["rm"],
       "description": "Remove an application or library."
     },
+    "monorepo": {
+      "factory": "./src/generators/monorepo/monorepo#monorepoSchematic",
+      "schema": "./src/generators/monorepo/schema.json",
+      "description": "Convert a Nx project to a monorepo."
+    },
     "workspace-generator": {
       "factory": "./src/generators/workspace-generator/workspace-generator",
       "schema": "./src/generators/workspace-generator/schema.json",
@@ -52,6 +57,11 @@
       "schema": "./src/generators/remove/schema.json",
       "aliases": ["rm"],
       "description": "Remove an application or library."
+    },
+    "monorepo": {
+      "factory": "./src/generators/monorepo/monorepo",
+      "schema": "./src/generators/monorepo/schema.json",
+      "description": "Convert a Nx project to a monorepo."
     },
     "new": {
       "factory": "./src/generators/new/new#newGenerator",

--- a/packages/workspace/src/generators/monorepo/monorepo.spec.ts
+++ b/packages/workspace/src/generators/monorepo/monorepo.spec.ts
@@ -1,0 +1,149 @@
+import { readJson, Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { monorepoGenerator } from './monorepo';
+
+// nx-ignore-next-line
+const { libraryGenerator } = require('@nx/js');
+// nx-ignore-next-line
+const { applicationGenerator: reactAppGenerator } = require('@nx/react');
+// nx-ignore-next-line
+const { applicationGenerator: nextAppGenerator } = require('@nx/next');
+
+describe('monorepo generator', () => {
+  let tree: Tree;
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should convert root JS lib', async () => {
+    // Files that should not move
+    tree.write('.gitignore', '');
+    tree.write('README.md', '');
+    tree.write('tools/scripts/custom_script.sh', '');
+
+    await libraryGenerator(tree, { name: 'my-lib', rootProject: true });
+    await libraryGenerator(tree, { name: 'other-lib' });
+
+    await monorepoGenerator(tree, {
+      appsDir: 'apps',
+      libsDir: 'packages',
+    });
+
+    expect(readJson(tree, 'packages/my-lib/project.json')).toMatchObject({
+      sourceRoot: 'packages/my-lib/src',
+      targets: {
+        build: {
+          executor: '@nx/js:tsc',
+          options: {
+            main: 'packages/my-lib/src/index.ts',
+            tsConfig: 'packages/my-lib/tsconfig.lib.json',
+          },
+        },
+      },
+    });
+    expect(readJson(tree, 'packages/other-lib/project.json')).toMatchObject({
+      sourceRoot: 'packages/other-lib/src',
+    });
+
+    // Did not move files that don't belong to root project
+    expect(tree.exists('.gitignore')).toBeTruthy();
+    expect(tree.exists('README.md')).toBeTruthy();
+    expect(tree.exists('tools/scripts/custom_script.sh')).toBeTruthy();
+
+    // Extracted base config files
+    expect(tree.exists('tsconfig.base.json')).toBeTruthy();
+  });
+
+  it('should convert root React app (Vite, Vitest)', async () => {
+    await reactAppGenerator(tree, {
+      name: 'demo',
+      style: 'css',
+      bundler: 'vite',
+      unitTestRunner: 'vitest',
+      e2eTestRunner: 'none',
+      linter: 'eslint',
+      rootProject: true,
+    });
+
+    await monorepoGenerator(tree, {
+      appsDir: 'apps',
+      libsDir: 'libs',
+    });
+
+    expect(readJson(tree, 'apps/demo/project.json')).toMatchObject({
+      sourceRoot: 'apps/demo/src',
+    });
+
+    // Extracted base config files
+    expect(tree.exists('tsconfig.base.json')).toBeTruthy();
+    expect(tree.exists('.eslintrc.base.json')).toBeTruthy();
+  });
+
+  it('should convert root React app (Webpack, Jest)', async () => {
+    await reactAppGenerator(tree, {
+      name: 'demo',
+      style: 'css',
+      bundler: 'webpack',
+      unitTestRunner: 'jest',
+      e2eTestRunner: 'none',
+      linter: 'eslint',
+      rootProject: true,
+    });
+
+    await monorepoGenerator(tree, {
+      appsDir: 'apps',
+      libsDir: 'libs',
+    });
+
+    expect(readJson(tree, 'apps/demo/project.json')).toMatchObject({
+      sourceRoot: 'apps/demo/src',
+      targets: {
+        build: {
+          executor: '@nx/webpack:webpack',
+          options: {
+            main: 'apps/demo/src/main.tsx',
+            tsConfig: 'apps/demo/tsconfig.app.json',
+            webpackConfig: 'apps/demo/webpack.config.js',
+          },
+        },
+      },
+    });
+
+    // Extracted base config files
+    expect(tree.exists('tsconfig.base.json')).toBeTruthy();
+    expect(tree.exists('.eslintrc.base.json')).toBeTruthy();
+    expect(tree.exists('jest.config.app.ts')).toBeTruthy();
+  });
+
+  it('should convert root Next.js app with existing libraries', async () => {
+    await nextAppGenerator(tree, {
+      name: 'demo',
+      style: 'css',
+      unitTestRunner: 'jest',
+      e2eTestRunner: 'none',
+      appDir: true,
+      linter: 'eslint',
+      rootProject: true,
+    });
+    await libraryGenerator(tree, { name: 'util' });
+
+    await monorepoGenerator(tree, {
+      appsDir: 'apps',
+      libsDir: 'libs',
+    });
+
+    expect(readJson(tree, 'apps/demo/project.json')).toMatchObject({
+      sourceRoot: 'apps/demo',
+    });
+    expect(tree.read('apps/demo/app/page.tsx', 'utf-8')).toContain('demo');
+    expect(readJson(tree, 'libs/util/project.json')).toMatchObject({
+      sourceRoot: 'libs/util/src',
+    });
+    expect(tree.read('libs/util/src/lib/util.ts', 'utf-8')).toContain('util');
+
+    // Extracted base config files
+    expect(tree.exists('tsconfig.base.json')).toBeTruthy();
+    expect(tree.exists('.eslintrc.base.json')).toBeTruthy();
+    expect(tree.exists('jest.config.app.ts')).toBeTruthy();
+  });
+});

--- a/packages/workspace/src/generators/monorepo/monorepo.ts
+++ b/packages/workspace/src/generators/monorepo/monorepo.ts
@@ -1,0 +1,76 @@
+import {
+  convertNxGenerator,
+  getProjects,
+  joinPathFragments,
+  ProjectConfiguration,
+  readNxJson,
+  Tree,
+  updateNxJson,
+} from '@nx/devkit';
+import { moveGenerator } from '../move/move';
+import { Schema } from './schema';
+
+export async function monorepoGenerator(tree: Tree, options: Schema) {
+  const projects = getProjects(tree);
+  const { extractTsConfigBase } = require('@nx/' + 'js');
+  extractTsConfigBase(tree);
+
+  maybeExtractJestConfigBase(tree);
+
+  const nxJson = readNxJson(tree);
+  nxJson.workspaceLayout = {
+    // normalize paths without trailing slash
+    appsDir: joinPathFragments(options.appsDir),
+    libsDir: joinPathFragments(options.libsDir),
+  };
+
+  updateNxJson(tree, nxJson);
+
+  for (const [_name, project] of projects) {
+    maybeExtractEslintConfigIfRootProject(tree, project);
+    await moveGenerator(tree, {
+      projectName: project.name,
+      destination: project.name,
+      updateImportPath: project.projectType === 'library',
+    });
+  }
+}
+
+function maybeExtractJestConfigBase(tree: Tree): void {
+  let jestInitGenerator: any;
+  try {
+    jestInitGenerator = require('@nx/' + 'jest').jestInitGenerator;
+  } catch {
+    // not installed
+  }
+  jestInitGenerator?.(tree, {});
+}
+
+function maybeExtractEslintConfigIfRootProject(
+  tree: Tree,
+  rootProject: ProjectConfiguration
+): void {
+  if (rootProject.root !== '.') return;
+  if (tree.exists('.eslintrc.base.json')) return;
+  let migrateConfigToMonorepoStyle: any;
+  try {
+    migrateConfigToMonorepoStyle = require('@nx/' +
+      'linter/src/generators/init/init-migration').migrateConfigToMonorepoStyle;
+  } catch {
+    // linter not install
+  }
+  // Only need to handle migrating the root rootProject.
+  // If other libs/apps exist, then this migration is already done by `@nx/linter:lint-rootProject` generator.
+  migrateConfigToMonorepoStyle?.(
+    [rootProject.name],
+    tree,
+    tree.exists(joinPathFragments(rootProject.root, 'jest.config.ts')) ||
+      tree.exists(joinPathFragments(rootProject.root, 'jest.config.js'))
+      ? 'jest'
+      : 'none'
+  );
+}
+
+export default monorepoGenerator;
+
+export const monorepoSchematic = convertNxGenerator(monorepoGenerator);

--- a/packages/workspace/src/generators/monorepo/schema.d.ts
+++ b/packages/workspace/src/generators/monorepo/schema.d.ts
@@ -1,0 +1,4 @@
+export interface Schema {
+  appsDir: string;
+  libsDir: string;
+}

--- a/packages/workspace/src/generators/monorepo/schema.json
+++ b/packages/workspace/src/generators/monorepo/schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "$id": "NxWorkspaceMonorepo",
+  "cli": "nx",
+  "title": "Nx Monorepo",
+  "description": "Convert a Nx project to a monorepo.",
+  "type": "object",
+  "examples": [
+    {
+      "command": "nx g @nx/workspace:monorepo --appsDir=apps --libsDir=packages",
+      "description": "Convert to a monorepo with apps and libs directories."
+    }
+  ],
+  "properties": {
+    "appsDir": {
+      "type": "string",
+      "description": "The directory where apps are placed.",
+      "default": "apps"
+    },
+    "libsDir": {
+      "type": "string",
+      "alias": "packagesDir",
+      "description": "The directory where libs are placed.",
+      "default": "libs"
+    }
+  },
+  "required": ["appsDir", "libsDir"]
+}

--- a/packages/workspace/src/generators/move/lib/create-project-configuration-in-new-destination.ts
+++ b/packages/workspace/src/generators/move/lib/create-project-configuration-in-new-destination.ts
@@ -1,5 +1,6 @@
 import {
   addProjectConfiguration,
+  joinPathFragments,
   ProjectConfiguration,
   Tree,
 } from '@nx/devkit';
@@ -11,20 +12,57 @@ export function createProjectConfigurationInNewDestination(
   projectConfig: ProjectConfiguration
 ) {
   projectConfig.name = schema.newProjectName;
+  const isRootProject = projectConfig.root === '.';
 
   // Subtle bug if project name === path, where the updated name was being overrideen.
   const { name, ...rest } = projectConfig;
 
   // replace old root path with new one
-  const projectString = JSON.stringify(rest);
-  const newProjectString = projectString.replace(
-    new RegExp(projectConfig.root, 'g'),
-    schema.relativeToRootDestination
-  );
+  let newProjectString = JSON.stringify(rest);
+  if (isRootProject) {
+    // Don't replace . with new root since it'll match all characters.
+    // Only look for "./" and replace with new root.
+    newProjectString = newProjectString.replace(
+      /\.\//g,
+      schema.relativeToRootDestination + '/'
+    );
+    newProjectString = newProjectString.replace(
+      /"(tsconfig\..*\.json)"/g,
+      `"${schema.relativeToRootDestination}/$1"`
+    );
+    newProjectString = newProjectString.replace(
+      /"(webpack\..*\.[jt]s)"/g,
+      `"${schema.relativeToRootDestination}/$1"`
+    );
+    newProjectString = newProjectString.replace(
+      /"(vite\..*\.[jt]s)"/g,
+      `"${schema.relativeToRootDestination}/$1"`
+    );
+    newProjectString = newProjectString.replace(
+      /"(\.\/)?src\/([^"]+)"/g,
+      `"${schema.relativeToRootDestination}/src/$1"`
+    );
+  } else {
+    newProjectString = newProjectString.replace(
+      new RegExp(projectConfig.root, 'g'),
+      schema.relativeToRootDestination
+    );
+  }
   const newProject: ProjectConfiguration = {
     name,
     ...JSON.parse(newProjectString),
   };
+
+  newProject.root = schema.relativeToRootDestination;
+
+  // Original sourceRoot is typically 'src' or 'app', but it could be any folder.
+  // Make sure it is updated to be under the new destination.
+  if (isRootProject && projectConfig.sourceRoot) {
+    newProject.sourceRoot = joinPathFragments(
+      schema.relativeToRootDestination,
+      projectConfig.sourceRoot
+    );
+  }
 
   // Create a new project with the root replaced
   addProjectConfiguration(tree, schema.newProjectName, newProject);

--- a/packages/workspace/src/generators/move/lib/move-project-files.ts
+++ b/packages/workspace/src/generators/move/lib/move-project-files.ts
@@ -1,5 +1,10 @@
-import { ProjectConfiguration, Tree, visitNotIgnoredFiles } from '@nx/devkit';
-import { join, relative } from 'path';
+import {
+  ProjectConfiguration,
+  ProjectGraph,
+  Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import { dirname, join, relative, sep } from 'path';
 import { NormalizedSchema } from '../schema';
 
 /**
@@ -10,16 +15,66 @@ import { NormalizedSchema } from '../schema';
 export function moveProjectFiles(
   tree: Tree,
   schema: NormalizedSchema,
-  project: ProjectConfiguration
+  project: ProjectConfiguration,
+  graph: ProjectGraph
 ) {
+  const seen = new Set<string>();
+
+  // We don't want to move configuration files and other folders that we don't know about.
+  // Moving the wrong files is worse than not moving them, because there might be
+  // a lot of work to undo it.
+  const knownRootProjectFiles = [
+    // Config files
+    'project.json',
+    'tsconfig.json',
+    'tsconfig.app.json',
+    'tsconfig.lib.json',
+    'tsconfig.spec.json',
+    '.babelrc',
+    '.eslintrc.json',
+    'jest.config.js',
+    'jest.config.ts',
+    'vite.config.ts',
+    /^webpack.*\.js$/,
+    'index.html', // Vite
+  ];
+  const knownRootProjectFolders = [
+    'src', // Most apps/libs
+    'app', // Remix, Next.js
+    'pages', // Next.js
+    'public', // Vite, Remix, Next.js
+  ];
+
+  const isKnownRootProjectFile = (file) => {
+    const baseDir = dirname(file).split(sep)[0];
+    if (baseDir === '.') {
+      // Not nested, check file matches
+      return knownRootProjectFiles.some((stringOrRegex) =>
+        typeof stringOrRegex === 'string'
+          ? file === stringOrRegex
+          : stringOrRegex.test(file)
+      );
+    } else {
+      // Nested, check base dir matches
+      return knownRootProjectFolders.includes(baseDir);
+    }
+  };
+
   visitNotIgnoredFiles(tree, project.root, (file) => {
+    if (project.root === '.' && !isKnownRootProjectFile(file)) return;
+
     // This is a rename but Angular Devkit isn't capable of writing to a file after it's renamed so this is a workaround
-    const content = tree.read(file);
     const relativeFromOriginalSource = relative(project.root, file);
     const newFilePath = join(
       schema.relativeToRootDestination,
       relativeFromOriginalSource
     );
+
+    // Prevents moving the same file infinitely for root projects
+    if (seen.has(file)) return;
+    seen.add(newFilePath);
+
+    const content = tree.read(file);
     tree.write(newFilePath, content);
     tree.delete(file);
   });

--- a/packages/workspace/src/generators/move/lib/update-eslintrc-json.ts
+++ b/packages/workspace/src/generators/move/lib/update-eslintrc-json.ts
@@ -58,7 +58,7 @@ export function updateEslintrcJson(
         eslintRcJson.extends,
         offset
       );
-    } else {
+    } else if (eslintRcJson.extends) {
       eslintRcJson.extends = eslintRcJson.extends.map((extend: string) =>
         offsetFilePath(project, extend, offset)
       );

--- a/packages/workspace/src/generators/move/lib/update-project-root-files.ts
+++ b/packages/workspace/src/generators/move/lib/update-project-root-files.ts
@@ -1,9 +1,19 @@
-import { ProjectConfiguration, Tree } from '@nx/devkit';
+import {
+  updateJson,
+  ProjectConfiguration,
+  Tree,
+  joinPathFragments,
+} from '@nx/devkit';
 import { workspaceRoot } from '@nx/devkit';
 import * as path from 'path';
 import { extname, join } from 'path';
 import { NormalizedSchema } from '../schema';
 const allowedExt = ['.ts', '.js', '.json'];
+function shouldUpdate(file: string): boolean {
+  const ext = extname(file);
+  return allowedExt.includes(ext) && file !== '.eslintrc.json';
+}
+
 /**
  * Updates the files in the root of the project
  *
@@ -15,7 +25,60 @@ export function updateProjectRootFiles(
   tree: Tree,
   schema: NormalizedSchema,
   project: ProjectConfiguration
-) {
+): void {
+  if (project.root === '.') {
+    // Need to handle root project differently since replacing '.' with 'dir',
+    // for example, // will change '../../' to 'dirdir/dirdir/'.
+    updateFilesForRootProjects(tree, schema, project);
+  } else {
+    updateFilesForNonRootProjects(tree, schema, project);
+  }
+}
+
+export function updateFilesForRootProjects(
+  tree: Tree,
+  schema: NormalizedSchema,
+  project: ProjectConfiguration
+): void {
+  // Skip updating "path" and "extends" for tsconfig files since they are mostly
+  // relative to the project root. The only exception is tsconfig.json that
+  // should extend from ../../tsconfig.base.json. We'll handle this separately.
+  const regex = /(?<!"path".+)(?<!"extends".+)(?<=['"])\.\/(?=[a-zA-Z0-9])/g;
+  const newRelativeRoot =
+    // Normalize separators
+    path
+      .relative(
+        path.join(workspaceRoot, schema.relativeToRootDestination),
+        workspaceRoot
+      )
+      .split(path.sep)
+      // Include trailing slash because the regex matches the trailing slash in "./"
+      .join('/') + '/';
+
+  for (const file of tree.children(schema.relativeToRootDestination)) {
+    if (!shouldUpdate(file)) continue;
+
+    const oldContent = tree.read(
+      join(schema.relativeToRootDestination, file),
+      'utf-8'
+    );
+    let newContent = oldContent.replace(regex, newRelativeRoot);
+    if (file === 'tsconfig.json') {
+      // Since we skipped updating "extends" earlier, need to point to the base config.
+      newContent = newContent.replace(
+        `./tsconfig.base.json`,
+        newRelativeRoot + `tsconfig.base.json`
+      );
+    }
+    tree.write(join(schema.relativeToRootDestination, file), newContent);
+  }
+}
+
+export function updateFilesForNonRootProjects(
+  tree: Tree,
+  schema: NormalizedSchema,
+  project: ProjectConfiguration
+): void {
   const newRelativeRoot = path
     .relative(
       path.join(workspaceRoot, schema.relativeToRootDestination),
@@ -23,10 +86,13 @@ export function updateProjectRootFiles(
     )
     .split(path.sep)
     .join('/');
-  const oldRelativeRoot = path
-    .relative(path.join(workspaceRoot, project.root), workspaceRoot)
-    .split(path.sep)
-    .join('/');
+  const oldRelativeRoot =
+    project.root === '.'
+      ? './'
+      : path
+          .relative(path.join(workspaceRoot, project.root), workspaceRoot)
+          .split(path.sep)
+          .join('/');
 
   if (newRelativeRoot === oldRelativeRoot) {
     // nothing to do
@@ -39,13 +105,7 @@ export function updateProjectRootFiles(
     'g'
   );
   for (const file of tree.children(schema.relativeToRootDestination)) {
-    const ext = extname(file);
-    if (!allowedExt.includes(ext)) {
-      continue;
-    }
-    if (file === '.eslintrc.json') {
-      continue;
-    }
+    if (!shouldUpdate(file)) continue;
 
     const oldContent = tree.read(
       join(schema.relativeToRootDestination, file),

--- a/packages/workspace/src/generators/move/move.spec.ts
+++ b/packages/workspace/src/generators/move/move.spec.ts
@@ -1,4 +1,4 @@
-import { readJson, Tree } from '@nx/devkit';
+import { readJson, Tree, updateJson } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { moveGenerator } from './move';
 
@@ -66,5 +66,117 @@ describe('move', () => {
     expect(projectJson['$schema']).toEqual(
       '../../../node_modules/nx/schemas/project-schema.json'
     );
+  });
+
+  it('should support moving root projects', async () => {
+    // Test that these are not moved
+    tree.write('.gitignore', '');
+    tree.write('README.md', '');
+
+    await libraryGenerator(tree, {
+      name: 'my-lib',
+      rootProject: true,
+      bundler: 'tsc',
+      buildable: true,
+      unitTestRunner: 'vitest',
+      linter: 'eslint',
+    });
+
+    updateJson(tree, 'tsconfig.json', (json) => {
+      json.extends = './tsconfig.base.json';
+      json.files = ['./node_modules/@foo/bar/index.d.ts'];
+      return json;
+    });
+
+    let projectJson = readJson(tree, 'project.json');
+    expect(projectJson['$schema']).toEqual(
+      'node_modules/nx/schemas/project-schema.json'
+    );
+    // Test that this does not get moved
+    tree.write('other-lib/index.ts', '');
+    const projectGraph = {
+      nodes: {
+        'my-lib': {
+          name: 'my-lib',
+          type: 'lib' as const,
+          data: {
+            root: '.',
+          },
+        },
+        'other-lib': {
+          name: 'other-lib',
+          type: 'lib' as const,
+          data: {
+            root: 'other-lib',
+          },
+        },
+      },
+      externalNodes: {},
+      dependencies: {},
+    };
+
+    await moveGenerator(
+      tree,
+      {
+        projectName: 'my-lib',
+        importPath: '@proj/my-lib',
+        updateImportPath: true,
+        destination: 'my-lib',
+      },
+      projectGraph
+    );
+
+    expect(readJson(tree, 'libs/my-lib/project.json')).toMatchObject({
+      name: 'my-lib',
+      $schema: '../../node_modules/nx/schemas/project-schema.json',
+      sourceRoot: 'libs/my-lib/src',
+      projectType: 'library',
+      targets: {
+        build: {
+          executor: '@nx/js:tsc',
+          outputs: ['{options.outputPath}'],
+          options: {
+            outputPath: 'dist/my-lib',
+            main: 'libs/my-lib/src/index.ts',
+            tsConfig: 'libs/my-lib/tsconfig.lib.json',
+          },
+        },
+        lint: {
+          executor: '@nx/linter:eslint',
+          outputs: ['{options.outputFile}'],
+          options: {
+            lintFilePatterns: ['libs/my-lib/**/*.ts'],
+          },
+        },
+        test: {
+          executor: '@nx/vite:test',
+          outputs: ['coverage/my-lib'],
+        },
+      },
+    });
+
+    expect(readJson(tree, 'libs/my-lib/tsconfig.json')).toMatchObject({
+      extends: '../../tsconfig.base.json',
+      files: ['../../node_modules/@foo/bar/index.d.ts'],
+      references: [
+        { path: './tsconfig.lib.json' },
+        { path: './tsconfig.spec.json' },
+      ],
+    });
+
+    const viteConfig = tree.read('libs/my-lib/vite.config.ts', 'utf-8');
+    expect(viteConfig).toContain('../../node_modules/.vitest');
+    expect(viteConfig).toContain('../../node_modules/.vite/my-lib');
+
+    expect(tree.exists('libs/my-lib/tsconfig.lib.json')).toBeTruthy();
+    expect(tree.exists('libs/my-lib/tsconfig.spec.json')).toBeTruthy();
+    expect(tree.exists('libs/my-lib/.eslintrc.json')).toBeTruthy();
+    expect(tree.exists('libs/my-lib/src/index.ts')).toBeTruthy();
+
+    // Test that other libs and workspace files are not moved.
+    expect(tree.exists('package.json')).toBeTruthy();
+    expect(tree.exists('README.md')).toBeTruthy();
+    expect(tree.exists('.gitignore')).toBeTruthy();
+    expect(tree.exists('other-lib/index.ts')).toBeTruthy();
   });
 });

--- a/packages/workspace/src/generators/move/move.ts
+++ b/packages/workspace/src/generators/move/move.ts
@@ -1,6 +1,8 @@
 import {
   convertNxGenerator,
+  createProjectGraphAsync,
   formatFiles,
+  ProjectGraph,
   readProjectConfiguration,
   removeProjectConfiguration,
   Tree,
@@ -22,13 +24,19 @@ import { updateReadme } from './lib/update-readme';
 import { updateStorybookConfig } from './lib/update-storybook-config';
 import { Schema } from './schema';
 
-export async function moveGenerator(tree: Tree, rawSchema: Schema) {
+export async function moveGenerator(
+  tree: Tree,
+  rawSchema: Schema,
+  projectGraph?: ProjectGraph // Passed in from unit tests (instantiated in body for real use)
+) {
+  projectGraph ??= await createProjectGraphAsync();
+
   const projectConfig = readProjectConfiguration(tree, rawSchema.projectName);
   checkDestination(tree, rawSchema, projectConfig);
   const schema = normalizeSchema(tree, rawSchema, projectConfig);
 
   removeProjectConfiguration(tree, schema.projectName);
-  moveProjectFiles(tree, schema, projectConfig);
+  moveProjectFiles(tree, schema, projectConfig, projectGraph);
   createProjectConfigurationInNewDestination(tree, schema, projectConfig);
   updateImports(tree, schema, projectConfig);
   updateProjectRootFiles(tree, schema, projectConfig);


### PR DESCRIPTION
This PR adds a new `@nx/workspace:monorepo` generator that converts standalone projects to a monorepo.

For example:

```shelll
npx create-nx-workspace react-app
cd react-app
nx g monorepo
```

Then users will see:

```treeview
.
├── apps
│   ├── e2e
│   │   ├── cypress.config.ts
│   │   ├── project.json
│   │   ├── src
│   │   │   ├── ...
│   │   │   └── support
│   │   └── tsconfig.json
│   └── react2
│       ├── index.html
│       ├── project.json
│       ├── public
│       │   └── favicon.ico
│       ├── src
│       │   ├── app
│       │   ├── assets
│       │   ├── main.tsx
│       │   └── styles.css
│       ├── tsconfig.app.json
│       ├── tsconfig.json
│       ├── tsconfig.spec.json
│       └── vite.config.ts
├── nx.json
├── README.md
├── package.json
└── tsconfig.base.json
```


https://github.com/nrwl/nx/assets/53559/4487746d-e0c5-4d0f-90a1-cb784dc96381


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
