### PR TITLE
feat(core): add monorepo generator to convert from standalone projects

### DIFF
--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -7890,6 +7890,14 @@
                 "disableCollapsible": false
               },
               {
+                "id": "convert-to-monorepo",
+                "path": "/packages/workspace/generators/convert-to-monorepo",
+                "name": "convert-to-monorepo",
+                "children": [],
+                "isExternal": false,
+                "disableCollapsible": false
+              },
+              {
                 "id": "new",
                 "path": "/packages/workspace/generators/new",
                 "name": "new",

--- a/docs/generated/manifests/packages.json
+++ b/docs/generated/manifests/packages.json
@@ -2873,6 +2873,15 @@
         "path": "/packages/workspace/generators/remove",
         "type": "generator"
       },
+      "/packages/workspace/generators/convert-to-monorepo": {
+        "description": "Convert a Nx project to a monorepo.",
+        "file": "generated/packages/workspace/generators/convert-to-monorepo.json",
+        "hidden": false,
+        "name": "convert-to-monorepo",
+        "originalFilePath": "/packages/workspace/src/generators/convert-to-monorepo/schema.json",
+        "path": "/packages/workspace/generators/convert-to-monorepo",
+        "type": "generator"
+      },
       "/packages/workspace/generators/new": {
         "description": "Create a workspace.",
         "file": "generated/packages/workspace/generators/new.json",

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -2843,6 +2843,15 @@
         "type": "generator"
       },
       {
+        "description": "Convert a Nx project to a monorepo.",
+        "file": "generated/packages/workspace/generators/convert-to-monorepo.json",
+        "hidden": false,
+        "name": "convert-to-monorepo",
+        "originalFilePath": "/packages/workspace/src/generators/convert-to-monorepo/schema.json",
+        "path": "workspace/generators/convert-to-monorepo",
+        "type": "generator"
+      },
+      {
         "description": "Create a workspace.",
         "file": "generated/packages/workspace/generators/new.json",
         "hidden": true,

--- a/docs/generated/packages/workspace/generators/convert-to-monorepo.json
+++ b/docs/generated/packages/workspace/generators/convert-to-monorepo.json
@@ -1,0 +1,27 @@
+{
+  "name": "convert-to-monorepo",
+  "factory": "./src/generators/convert-to-monorepo/convert-to-monorepo",
+  "schema": {
+    "$schema": "http://json-schema.org/schema",
+    "$id": "NxWorkspaceConvertToMonorepo",
+    "cli": "nx",
+    "title": "Nx Convert to Monorepo",
+    "description": "Convert an Nx project to a monorepo.",
+    "type": "object",
+    "examples": [
+      {
+        "command": "nx g @nx/workspace:monorepo",
+        "description": "Convert an Nx standalone project to a monorepo."
+      }
+    ],
+    "properties": {},
+    "required": [],
+    "presets": []
+  },
+  "description": "Convert a Nx project to a monorepo.",
+  "implementation": "/packages/workspace/src/generators/convert-to-monorepo/convert-to-monorepo.ts",
+  "aliases": [],
+  "hidden": false,
+  "path": "/packages/workspace/src/generators/convert-to-monorepo/schema.json",
+  "type": "generator"
+}

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -612,6 +612,7 @@
       - [preset](/packages/workspace/generators/preset)
       - [move](/packages/workspace/generators/move)
       - [remove](/packages/workspace/generators/remove)
+      - [convert-to-monorepo](/packages/workspace/generators/convert-to-monorepo)
       - [new](/packages/workspace/generators/new)
       - [workspace-generator](/packages/workspace/generators/workspace-generator)
       - [run-commands](/packages/workspace/generators/run-commands)

--- a/e2e/nx-misc/src/workspace.test.ts
+++ b/e2e/nx-misc/src/workspace.test.ts
@@ -19,6 +19,32 @@ import {
 
 let proj: string;
 
+describe('@nx/workspace:convert-to-monorepo', () => {
+  beforeEach(() => {
+    proj = newProject();
+  });
+
+  afterEach(() => cleanupProject());
+
+  it('should convert a standalone project to a monorepo', async () => {
+    const reactApp = uniq('reactapp');
+    runCLI(
+      `generate @nx/react:app ${reactApp} --rootProject=true --bundler=webpack --unitTestRunner=jest --e2eTestRunner=cypress --no-interactive`
+    );
+
+    runCLI('generate @nx/workspace:convert-to-monorepo --no-interactive');
+
+    checkFilesExist(
+      `apps/${reactApp}/src/main.tsx`,
+      `apps/e2e/cypress.config.ts`
+    );
+
+    expect(() => runCLI(`build ${reactApp}`)).not.toThrow();
+    expect(() => runCLI(`test ${reactApp}`)).not.toThrow();
+    expect(() => runCLI(`e2e e2e`)).not.toThrow();
+  });
+});
+
 describe('Workspace Tests', () => {
   beforeAll(() => {
     proj = newProject();

--- a/packages/jest/src/generators/init/init.spec.ts
+++ b/packages/jest/src/generators/init/init.spec.ts
@@ -211,6 +211,7 @@ export default {
       addProjectConfiguration(tree, 'my-project', {
         root: '.',
         name: 'my-project',
+        projectType: 'application',
         sourceRoot: 'src',
         targets: {
           test: {
@@ -261,6 +262,7 @@ projects: getJestProjects()
         root: '.',
         name: 'my-project',
         sourceRoot: 'src',
+        projectType: 'application',
         targets: {
           test: {
             executor: '@nx/jest:jest',

--- a/packages/jest/src/generators/init/init.ts
+++ b/packages/jest/src/generators/init/init.ts
@@ -4,6 +4,7 @@ import {
   GeneratorCallback,
   getProjects,
   readNxJson,
+  readProjectConfiguration,
   removeDependenciesFromPackageJson,
   runTasksInSerial,
   stripIndents,
@@ -100,10 +101,12 @@ function createJestConfig(tree: Tree, options: NormalizedSchema) {
       const isProjectConfig = jestTarget?.options?.jestConfig === rootJestPath;
       // if root project doesn't have jest target, there's nothing to migrate
       if (isProjectConfig) {
-        const jestAppConfig = `jest.config.app.${options.js ? 'js' : 'ts'}`;
+        const jestProjectConfig = `jest.config.${
+          rootProjectConfig.projectType === 'application' ? 'app' : 'lib'
+        }.${options.js ? 'js' : 'ts'}`;
 
-        tree.rename(rootJestPath, jestAppConfig);
-        jestTarget.options.jestConfig = jestAppConfig;
+        tree.rename(rootJestPath, jestProjectConfig);
+        jestTarget.options.jestConfig = jestProjectConfig;
         updateProjectConfiguration(tree, rootProject, rootProjectConfig);
       }
       // generate new global config as it was move to project config or is missing

--- a/packages/workspace/generators.json
+++ b/packages/workspace/generators.json
@@ -14,6 +14,11 @@
       "aliases": ["rm"],
       "description": "Remove an application or library."
     },
+    "convert-to-monorepo": {
+      "factory": "./src/generators/convert-to-monorepo/convert-to-monorepo#monorepoSchematic",
+      "schema": "./src/generators/convert-to-monorepo/schema.json",
+      "description": "Convert a Nx project to a monorepo."
+    },
     "workspace-generator": {
       "factory": "./src/generators/workspace-generator/workspace-generator",
       "schema": "./src/generators/workspace-generator/schema.json",
@@ -52,6 +57,11 @@
       "schema": "./src/generators/remove/schema.json",
       "aliases": ["rm"],
       "description": "Remove an application or library."
+    },
+    "convert-to-monorepo": {
+      "factory": "./src/generators/convert-to-monorepo/convert-to-monorepo",
+      "schema": "./src/generators/convert-to-monorepo/schema.json",
+      "description": "Convert a Nx project to a monorepo."
     },
     "new": {
       "factory": "./src/generators/new/new#newGenerator",

--- a/packages/workspace/src/generators/convert-to-monorepo/convert-to-monorepo.spec.ts
+++ b/packages/workspace/src/generators/convert-to-monorepo/convert-to-monorepo.spec.ts
@@ -1,0 +1,146 @@
+import { readJson, readProjectConfiguration, Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { monorepoGenerator } from './convert-to-monorepo';
+
+// nx-ignore-next-line
+const { libraryGenerator } = require('@nx/js');
+// nx-ignore-next-line
+const { applicationGenerator: reactAppGenerator } = require('@nx/react');
+// nx-ignore-next-line
+const { applicationGenerator: nextAppGenerator } = require('@nx/next');
+
+describe('monorepo generator', () => {
+  let tree: Tree;
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should convert root JS lib', async () => {
+    // Files that should not move
+    tree.write('.gitignore', '');
+    tree.write('README.md', '');
+    tree.write('tools/scripts/custom_script.sh', '');
+
+    await libraryGenerator(tree, { name: 'my-lib', rootProject: true });
+    await libraryGenerator(tree, { name: 'other-lib' });
+
+    await monorepoGenerator(tree, {
+      appsDir: 'apps',
+      libsDir: 'packages',
+    });
+
+    expect(readJson(tree, 'packages/my-lib/project.json')).toMatchObject({
+      sourceRoot: 'packages/my-lib/src',
+      targets: {
+        build: {
+          executor: '@nx/js:tsc',
+          options: {
+            main: 'packages/my-lib/src/index.ts',
+            tsConfig: 'packages/my-lib/tsconfig.lib.json',
+          },
+        },
+      },
+    });
+    expect(readJson(tree, 'packages/other-lib/project.json')).toMatchObject({
+      sourceRoot: 'packages/other-lib/src',
+    });
+
+    // Did not move files that don't belong to root project
+    expect(tree.exists('.gitignore')).toBeTruthy();
+    expect(tree.exists('README.md')).toBeTruthy();
+    expect(tree.exists('tools/scripts/custom_script.sh')).toBeTruthy();
+
+    // Extracted base config files
+    expect(tree.exists('tsconfig.base.json')).toBeTruthy();
+  });
+
+  it('should convert root React app (Vite, Vitest)', async () => {
+    await reactAppGenerator(tree, {
+      name: 'demo',
+      style: 'css',
+      bundler: 'vite',
+      unitTestRunner: 'vitest',
+      e2eTestRunner: 'none',
+      linter: 'eslint',
+      rootProject: true,
+    });
+
+    await monorepoGenerator(tree, {});
+
+    expect(readJson(tree, 'apps/demo/project.json')).toMatchObject({
+      sourceRoot: 'apps/demo/src',
+    });
+
+    // Extracted base config files
+    expect(tree.exists('tsconfig.base.json')).toBeTruthy();
+    expect(tree.exists('.eslintrc.base.json')).toBeTruthy();
+  });
+
+  it('should convert root React app (Webpack, Jest)', async () => {
+    await reactAppGenerator(tree, {
+      name: 'demo',
+      style: 'css',
+      bundler: 'webpack',
+      unitTestRunner: 'jest',
+      e2eTestRunner: 'none',
+      linter: 'eslint',
+      rootProject: true,
+    });
+
+    await monorepoGenerator(tree, {});
+
+    expect(readJson(tree, 'apps/demo/project.json')).toMatchObject({
+      sourceRoot: 'apps/demo/src',
+      targets: {
+        build: {
+          executor: '@nx/webpack:webpack',
+          options: {
+            main: 'apps/demo/src/main.tsx',
+            tsConfig: 'apps/demo/tsconfig.app.json',
+            webpackConfig: 'apps/demo/webpack.config.js',
+          },
+        },
+        test: {
+          executor: '@nx/jest:jest',
+          options: {
+            jestConfig: 'apps/demo/jest.config.app.ts',
+          },
+        },
+      },
+    });
+
+    // Extracted base config files
+    expect(tree.exists('tsconfig.base.json')).toBeTruthy();
+    expect(tree.exists('.eslintrc.base.json')).toBeTruthy();
+    expect(tree.exists('jest.config.ts')).toBeTruthy();
+  });
+
+  it('should convert root Next.js app with existing libraries', async () => {
+    await nextAppGenerator(tree, {
+      name: 'demo',
+      style: 'css',
+      unitTestRunner: 'jest',
+      e2eTestRunner: 'none',
+      appDir: true,
+      linter: 'eslint',
+      rootProject: true,
+    });
+    await libraryGenerator(tree, { name: 'util' });
+
+    await monorepoGenerator(tree, {});
+
+    expect(readJson(tree, 'apps/demo/project.json')).toMatchObject({
+      sourceRoot: 'apps/demo',
+    });
+    expect(tree.read('apps/demo/app/page.tsx', 'utf-8')).toContain('demo');
+    expect(readJson(tree, 'libs/util/project.json')).toMatchObject({
+      sourceRoot: 'libs/util/src',
+    });
+    expect(tree.read('libs/util/src/lib/util.ts', 'utf-8')).toContain('util');
+
+    // Extracted base config files
+    expect(tree.exists('tsconfig.base.json')).toBeTruthy();
+    expect(tree.exists('.eslintrc.base.json')).toBeTruthy();
+    expect(tree.exists('jest.config.ts')).toBeTruthy();
+  });
+});

--- a/packages/workspace/src/generators/convert-to-monorepo/convert-to-monorepo.ts
+++ b/packages/workspace/src/generators/convert-to-monorepo/convert-to-monorepo.ts
@@ -1,0 +1,50 @@
+import {
+  convertNxGenerator,
+  getProjects,
+  joinPathFragments,
+  ProjectConfiguration,
+  readNxJson,
+  Tree,
+  updateNxJson,
+} from '@nx/devkit';
+import { moveGenerator } from '../move/move';
+
+export async function monorepoGenerator(tree: Tree, options: {}) {
+  const projects = getProjects(tree);
+
+  const nxJson = readNxJson(tree);
+  updateNxJson(tree, nxJson);
+
+  let rootProject: ProjectConfiguration;
+  const projectsToMove: ProjectConfiguration[] = [];
+
+  // Need to determine libs vs packages directory base on the type of root project.
+  for (const [, project] of projects) {
+    if (project.root === '.') rootProject = project;
+    projectsToMove.push(project);
+  }
+
+  // Currently, Nx only handles apps+libs or packages. You cannot mix and match them.
+  // If the standalone project is an app (React, Angular, etc), then use apps+libs.
+  // Otherwise, for TS standalone (lib), use packages.
+  const isRootProjectApp = rootProject.projectType === 'application';
+  const appsDir = isRootProjectApp ? 'apps' : 'packages';
+  const libsDir = isRootProjectApp ? 'libs' : 'packages';
+
+  for (const project of projectsToMove) {
+    await moveGenerator(tree, {
+      projectName: project.name,
+      newProjectName: project.name,
+      destination:
+        project.projectType === 'application'
+          ? joinPathFragments(appsDir, project.name)
+          : joinPathFragments(libsDir, project.name),
+      destinationRelativeToRoot: true,
+      updateImportPath: project.projectType === 'library',
+    });
+  }
+}
+
+export default monorepoGenerator;
+
+export const monorepoSchematic = convertNxGenerator(monorepoGenerator);

--- a/packages/workspace/src/generators/convert-to-monorepo/schema.json
+++ b/packages/workspace/src/generators/convert-to-monorepo/schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "$id": "NxWorkspaceConvertToMonorepo",
+  "cli": "nx",
+  "title": "Nx Convert to Monorepo",
+  "description": "Convert an Nx project to a monorepo.",
+  "type": "object",
+  "examples": [
+    {
+      "command": "nx g @nx/workspace:monorepo",
+      "description": "Convert an Nx standalone project to a monorepo."
+    }
+  ],
+  "properties": {},
+  "required": []
+}

--- a/packages/workspace/src/generators/move/lib/create-project-configuration-in-new-destination.ts
+++ b/packages/workspace/src/generators/move/lib/create-project-configuration-in-new-destination.ts
@@ -1,5 +1,6 @@
 import {
   addProjectConfiguration,
+  joinPathFragments,
   ProjectConfiguration,
   Tree,
 } from '@nx/devkit';
@@ -11,20 +12,68 @@ export function createProjectConfigurationInNewDestination(
   projectConfig: ProjectConfiguration
 ) {
   projectConfig.name = schema.newProjectName;
+  const isRootProject = projectConfig.root === '.';
 
   // Subtle bug if project name === path, where the updated name was being overrideen.
   const { name, ...rest } = projectConfig;
 
   // replace old root path with new one
-  const projectString = JSON.stringify(rest);
-  const newProjectString = projectString.replace(
-    new RegExp(projectConfig.root, 'g'),
-    schema.relativeToRootDestination
-  );
+  let newProjectString = JSON.stringify(rest);
+  if (isRootProject) {
+    // Don't replace . with new root since it'll match all characters.
+    // Only look for "./" and replace with new root.
+    newProjectString = newProjectString.replace(
+      /\.\//g,
+      schema.relativeToRootDestination + '/'
+    );
+    newProjectString = newProjectString.replace(
+      /"((tsconfig|jest|webpack|vite)\..*?\.(ts|js|json))"/g,
+      `"${schema.relativeToRootDestination}/$1"`
+    );
+    newProjectString = newProjectString.replace(
+      /"(\.\/)?src\/(.*?)"/g,
+      `"${schema.relativeToRootDestination}/src/$2"`
+    );
+  } else {
+    newProjectString = newProjectString.replace(
+      new RegExp(projectConfig.root, 'g'),
+      schema.relativeToRootDestination
+    );
+  }
+
   const newProject: ProjectConfiguration = {
     name,
     ...JSON.parse(newProjectString),
   };
+
+  newProject.root = schema.relativeToRootDestination;
+
+  // Correct "e2e" target and config since part of the rename will be wrong unless we make the project name "e2e" more unique.
+  // e.g. my-app-e2e is safer to search and replace than "e2e".
+  if (projectConfig.name === 'e2e') {
+    for (const [targetName, targetConfig] of Object.entries(
+      newProject.targets
+    )) {
+      const wrongName = schema.relativeToRootDestination;
+      if (targetName !== wrongName) continue;
+
+      if (targetConfig.options?.testingType === wrongName) {
+        targetConfig.options.testingType = 'e2e';
+      }
+
+      newProject.targets['e2e'] = targetConfig;
+      delete newProject.targets[targetName];
+    }
+  }
+
+  // Original sourceRoot is typically 'src' or 'app', but it could be any folder.
+  // Make sure it is updated to be under the new destination.
+  if (isRootProject && projectConfig.sourceRoot) {
+    newProject.sourceRoot = joinPathFragments(
+      schema.relativeToRootDestination,
+      projectConfig.sourceRoot
+    );
+  }
 
   // Create a new project with the root replaced
   addProjectConfiguration(tree, schema.newProjectName, newProject);

--- a/packages/workspace/src/generators/move/lib/extract-base-configs.ts
+++ b/packages/workspace/src/generators/move/lib/extract-base-configs.ts
@@ -1,0 +1,48 @@
+import { joinPathFragments, ProjectConfiguration, Tree } from '@nx/devkit';
+
+export function maybeExtractTsConfigBase(tree: Tree): void {
+  let extractTsConfigBase: any;
+  try {
+    extractTsConfigBase = require('@nx/' + 'js').extractTsConfigBase;
+  } catch {
+    // Not installed, skip
+    return;
+  }
+  extractTsConfigBase(tree);
+}
+
+export async function maybeExtractJestConfigBase(tree: Tree): Promise<void> {
+  let jestInitGenerator: any;
+  try {
+    jestInitGenerator = require('@nx/' + 'jest').jestInitGenerator;
+  } catch {
+    // Not installed, skip
+    return;
+  }
+  await jestInitGenerator(tree, {});
+}
+
+export function maybeExtractEslintConfigIfRootProject(
+  tree: Tree,
+  rootProject: ProjectConfiguration
+): void {
+  if (rootProject.root !== '.') return;
+  if (tree.exists('.eslintrc.base.json')) return;
+  let migrateConfigToMonorepoStyle: any;
+  try {
+    migrateConfigToMonorepoStyle = require('@nx/' +
+      'linter/src/generators/init/init-migration').migrateConfigToMonorepoStyle;
+  } catch {
+    // linter not install
+  }
+  // Only need to handle migrating the root rootProject.
+  // If other libs/apps exist, then this migration is already done by `@nx/linter:lint-rootProject` generator.
+  migrateConfigToMonorepoStyle?.(
+    [rootProject.name],
+    tree,
+    tree.exists(joinPathFragments(rootProject.root, 'jest.config.ts')) ||
+      tree.exists(joinPathFragments(rootProject.root, 'jest.config.js'))
+      ? 'jest'
+      : 'none'
+  );
+}

--- a/packages/workspace/src/generators/move/lib/move-project-files.ts
+++ b/packages/workspace/src/generators/move/lib/move-project-files.ts
@@ -1,5 +1,5 @@
 import { ProjectConfiguration, Tree, visitNotIgnoredFiles } from '@nx/devkit';
-import { join, relative } from 'path';
+import { dirname, join, relative, sep } from 'path';
 import { NormalizedSchema } from '../schema';
 
 /**
@@ -12,14 +12,56 @@ export function moveProjectFiles(
   schema: NormalizedSchema,
   project: ProjectConfiguration
 ) {
+  // We don't want to move configuration files and other folders that we don't know about.
+  // Moving the wrong files is worse than not moving them, because there might be
+  // a lot of work to undo it.
+  const knownRootProjectFiles = [
+    // Config files
+    'project.json',
+    'tsconfig.json',
+    'tsconfig.app.json',
+    'tsconfig.lib.json',
+    'tsconfig.spec.json',
+    '.babelrc',
+    '.eslintrc.json',
+    /^jest\.config\.(app|lib)\.[jt]s$/,
+    'vite.config.ts',
+    /^webpack.*\.js$/,
+    'index.html', // Vite
+  ];
+  const knownRootProjectFolders = [
+    'src', // Most apps/libs
+    'app', // Remix, Next.js
+    'pages', // Next.js
+    'public', // Vite, Remix, Next.js
+  ];
+
+  const isKnownRootProjectFile = (file) => {
+    const baseDir = dirname(file).split(sep)[0];
+    if (baseDir === '.') {
+      // Not nested, check file matches
+      return knownRootProjectFiles.some((stringOrRegex) =>
+        typeof stringOrRegex === 'string'
+          ? file === stringOrRegex
+          : stringOrRegex.test(file)
+      );
+    } else {
+      // Nested, check base dir matches
+      return knownRootProjectFolders.includes(baseDir);
+    }
+  };
+
   visitNotIgnoredFiles(tree, project.root, (file) => {
+    if (project.root === '.' && !isKnownRootProjectFile(file)) return;
+
     // This is a rename but Angular Devkit isn't capable of writing to a file after it's renamed so this is a workaround
-    const content = tree.read(file);
     const relativeFromOriginalSource = relative(project.root, file);
     const newFilePath = join(
       schema.relativeToRootDestination,
       relativeFromOriginalSource
     );
+
+    const content = tree.read(file);
     tree.write(newFilePath, content);
     tree.delete(file);
   });

--- a/packages/workspace/src/generators/move/lib/update-cypress-config.ts
+++ b/packages/workspace/src/generators/move/lib/update-cypress-config.ts
@@ -51,7 +51,9 @@ export function updateCypressConfig(
     schema.relativeToRootDestination,
     'cypress.config.ts'
   );
-  if (tree.exists(cypressConfigPath)) {
+  // Search and replace for "e2e" directory is not safe, and will result in an invalid config file.
+  // Leave it and let users fix the config if needed.
+  if (project.root !== 'e2e' && tree.exists(cypressConfigPath)) {
     const oldContent = tree.read(cypressConfigPath, 'utf-8');
     const findName = new RegExp(`'${schema.projectName}'`, 'g');
     const findDir = new RegExp(project.root, 'g');

--- a/packages/workspace/src/generators/move/lib/update-eslintrc-json.ts
+++ b/packages/workspace/src/generators/move/lib/update-eslintrc-json.ts
@@ -58,7 +58,7 @@ export function updateEslintrcJson(
         eslintRcJson.extends,
         offset
       );
-    } else {
+    } else if (eslintRcJson.extends) {
       eslintRcJson.extends = eslintRcJson.extends.map((extend: string) =>
         offsetFilePath(project, extend, offset)
       );

--- a/packages/workspace/src/generators/move/lib/update-project-root-files.ts
+++ b/packages/workspace/src/generators/move/lib/update-project-root-files.ts
@@ -1,9 +1,15 @@
-import { ProjectConfiguration, Tree } from '@nx/devkit';
+import {
+  updateJson,
+  ProjectConfiguration,
+  Tree,
+  joinPathFragments,
+} from '@nx/devkit';
 import { workspaceRoot } from '@nx/devkit';
 import * as path from 'path';
 import { extname, join } from 'path';
 import { NormalizedSchema } from '../schema';
 const allowedExt = ['.ts', '.js', '.json'];
+
 /**
  * Updates the files in the root of the project
  *
@@ -15,7 +21,66 @@ export function updateProjectRootFiles(
   tree: Tree,
   schema: NormalizedSchema,
   project: ProjectConfiguration
-) {
+): void {
+  if (project.root === '.') {
+    // Need to handle root project differently since replacing '.' with 'dir',
+    // for example, // will change '../../' to 'dirdir/dirdir/'.
+    updateFilesForRootProjects(tree, schema, project);
+  } else {
+    updateFilesForNonRootProjects(tree, schema, project);
+  }
+}
+
+export function updateFilesForRootProjects(
+  tree: Tree,
+  schema: NormalizedSchema,
+  project: ProjectConfiguration
+): void {
+  // Skip updating "path" and "extends" for tsconfig files since they are mostly
+  // relative to the project root. The only exception is tsconfig.json that
+  // should extend from ../../tsconfig.base.json. We'll handle this separately.
+  const regex = /(?<!"path".+)(?<!"extends".+)(?<=['"])\.\/(?=[a-zA-Z0-9])/g;
+  const newRelativeRoot =
+    // Normalize separators
+    path
+      .relative(
+        path.join(workspaceRoot, schema.relativeToRootDestination),
+        workspaceRoot
+      )
+      .split(path.sep)
+      // Include trailing slash because the regex matches the trailing slash in "./"
+      .join('/') + '/';
+
+  for (const file of tree.children(schema.relativeToRootDestination)) {
+    const ext = extname(file);
+    if (!allowedExt.includes(ext)) {
+      continue;
+    }
+    if (file === '.eslintrc.json') {
+      continue;
+    }
+
+    const oldContent = tree.read(
+      join(schema.relativeToRootDestination, file),
+      'utf-8'
+    );
+    let newContent = oldContent.replace(regex, newRelativeRoot);
+    if (file === 'tsconfig.json') {
+      // Since we skipped updating "extends" earlier, need to point to the base config.
+      newContent = newContent.replace(
+        `./tsconfig.base.json`,
+        newRelativeRoot + `tsconfig.base.json`
+      );
+    }
+    tree.write(join(schema.relativeToRootDestination, file), newContent);
+  }
+}
+
+export function updateFilesForNonRootProjects(
+  tree: Tree,
+  schema: NormalizedSchema,
+  project: ProjectConfiguration
+): void {
   const newRelativeRoot = path
     .relative(
       path.join(workspaceRoot, schema.relativeToRootDestination),


### PR DESCRIPTION
This PR adds a new `@nx/workspace:monorepo` generator that converts standalone projects to a monorepo.

For example:

```shelll
npx create-nx-workspace react-app
cd react-app
nx g monorepo
```

Then users will see:

```treeview
.
├── apps
│   ├── e2e
│   │   ├── cypress.config.ts
│   │   ├── project.json
│   │   ├── src
│   │   │   ├── ...
│   │   │   └── support
│   │   └── tsconfig.json
│   └── react2
│       ├── index.html
│       ├── project.json
│       ├── public
│       │   └── favicon.ico
│       ├── src
│       │   ├── app
│       │   ├── assets
│       │   ├── main.tsx
│       │   └── styles.css
│       ├── tsconfig.app.json
│       ├── tsconfig.json
│       ├── tsconfig.spec.json
│       └── vite.config.ts
├── nx.json
├── README.md
├── package.json
└── tsconfig.base.json
```


https://github.com/nrwl/nx/assets/53559/4487746d-e0c5-4d0f-90a1-cb784dc96381

## Test Cases

1. Convert a clean standalone project (i.e. one from `create-nx-workspace` without any changes). Test with React, Next.js, Angular, Node servers, TS.
2. Convert a standalone project with libs already added.
3. Convert a standalone project with other apps added.
4. Convert a standalone project with some apps and libs already in `apps` and `libs` directories.
5. Convert a standalone TS project 'my-lib', but `packages/my-lib` or `libs/my-lib` already exists.
6. Convert a monorepo (idempotency)

## Notes

- It's hard to move all root project files to their new location under `apps`since there are workspace files such as `nx.json`, or even custom files that users create that may or may not belong to the root project. The safest way to handle  it is to whitelist the root files we do move, and leave the rest for users to handle.
- The existing `e2e` project is problematic since it is not easy to replace `"e2e"` string in configuration files with `apps/e2e` without messing options like `"target": "e2e"` that should be left untouched. We  may need to handle these cases specifically.