### PR TITLE
feat(linter): Support --print-config feature of ESLint

### DIFF
--- a/docs/generated/packages/linter/executors/eslint.json
+++ b/docs/generated/packages/linter/executors/eslint.json
@@ -128,6 +128,11 @@
         "type": "string",
         "enum": ["off", "warn", "error"],
         "description": "The equivalent of the `--report-unused-disable-directives` flag on the ESLint CLI."
+      },
+      "printConfig": {
+        "type": "string",
+        "description": "The equivalent of the `--print-config` flag on the ESLint CLI.",
+        "x-completion-type": "file"
       }
     },
     "required": ["lintFilePatterns"],

--- a/e2e/linter/src/linter.test.ts
+++ b/e2e/linter/src/linter.test.ts
@@ -246,6 +246,21 @@ describe('Linter', () => {
           'A project tagged with "validtag" can only depend on libs tagged with "validtag"'
         );
       }, 1000000);
+
+      it('should print the effective configuration for a file specified using --printConfig', () => {
+        const eslint = readJson('.eslintrc.json');
+        eslint.overrides.push({
+          files: ['src/index.ts'],
+          rules: {
+            'specific-rule': 'off',
+          },
+        });
+        updateFile('.eslintrc.json', JSON.stringify(eslint, null, 2));
+        const out = runCLI(`lint ${myapp} --printConfig src/index.ts`, {
+          silenceError: true,
+        });
+        expect(out).toContain('"specific-rule": [');
+      }, 1000000);
     });
 
     describe('workspace boundary rules', () => {

--- a/packages/linter/src/executors/eslint/lint.impl.spec.ts
+++ b/packages/linter/src/executors/eslint/lint.impl.spec.ts
@@ -25,6 +25,9 @@ class MockESLint {
   loadFormatter = mockLoadFormatter;
   isPathIgnored = mockIsPathIgnored;
   lintFiles = mockLintFiles;
+  calculateConfigForFile(file: string) {
+    return { file: file };
+  }
 }
 
 const mockResolveAndInstantiateESLint = jest.fn().mockReturnValue(
@@ -65,6 +68,7 @@ function createValidRunBuilderOptions(
     rulesdir: [],
     resolvePluginsRelativeTo: null,
     reportUnusedDisableDirectives: null,
+    printConfig: null,
     ...additionalOptions,
   };
 }
@@ -618,5 +622,31 @@ Please see https://nx.dev/guides/eslint for full guidance on how to resolve this
       mockContext
     );
     expect(fs.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it('should print the ESLint configuration for a specified file if printConfiguration is specified', async () => {
+    setupMocks();
+    jest.spyOn(console, 'log');
+    const result = await lintExecutor(
+      createValidRunBuilderOptions({
+        lintFilePatterns: [],
+        eslintConfig: './.eslintrc.json',
+        fix: true,
+        cache: true,
+        cacheLocation: 'cacheLocation1',
+        format: 'stylish',
+        force: false,
+        silent: false,
+        ignorePath: null,
+        maxWarnings: null,
+        outputFile: null,
+        quiet: false,
+        reportUnusedDisableDirectives: null,
+        printConfig: 'test-source.ts',
+      }),
+      mockContext
+    );
+    expect(console.log).toHaveBeenCalledWith('{\n "file": "test-source.ts"\n}');
+    expect(result).toEqual({ success: true });
   });
 });

--- a/packages/linter/src/executors/eslint/schema.d.ts
+++ b/packages/linter/src/executors/eslint/schema.d.ts
@@ -20,6 +20,7 @@ export interface Schema extends JsonObject {
   rulesdir: string[];
   resolvePluginsRelativeTo: string | null;
   reportUnusedDisableDirectives: Linter.RuleLevel | null;
+  printConfig?: string | null;
 }
 
 type Formatter =

--- a/packages/linter/src/executors/eslint/schema.json
+++ b/packages/linter/src/executors/eslint/schema.json
@@ -132,6 +132,11 @@
       "type": "string",
       "enum": ["off", "warn", "error"],
       "description": "The equivalent of the `--report-unused-disable-directives` flag on the ESLint CLI."
+    },
+    "printConfig": {
+      "type": "string",
+      "description": "The equivalent of the `--print-config` flag on the ESLint CLI.",
+      "x-completion-type": "file"
     }
   },
   "required": ["lintFilePatterns"],


### PR DESCRIPTION
The change introduces a new option to the linter plugin schema: `printConfig`, accepting a file name for which the plugin to output its applicable ESLint configuration.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
There is no support for `--print-config`.

## Expected Behavior
When `--printConfig` is passed on the command line as a parameter to `nx lint ...` or `printConfig` is specified in the _project.json_ the linter will show the effective ESLint configuration applicable to the specified file and not proceed with linting the project. Operation would complete successfully.

## Related Issue(s)
none

Fixes #
