### PR TITLE
feat(core): nx cmd command

### DIFF
--- a/docs/generated/cli/cmd.md
+++ b/docs/generated/cli/cmd.md
@@ -1,0 +1,60 @@
+---
+title: 'cmd - CLI command'
+description: 'Executes a command in the root directory of projects'
+---
+
+# cmd
+
+Executes a command in the root directory of projects
+
+## Usage
+
+```shell
+nx cmd
+```
+
+Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpm nx`.
+
+## Options
+
+### all
+
+Type: `boolean`
+
+Watch all projects.
+
+### exclude
+
+Type: `string`
+
+Exclude certain projects from being processed
+
+### help
+
+Type: `boolean`
+
+Show help
+
+### parallel
+
+Type: `string`
+
+Max number of parallel commands [default is 3]
+
+### projects
+
+Type: `string`
+
+Projects on which to execute the command (comma/space delimited).
+
+### verbose
+
+Type: `boolean`
+
+Run in verbose mode, where the arguments and projects to run are logged before execution.
+
+### version
+
+Type: `boolean`
+
+Show version number

--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -5995,6 +5995,14 @@
                 "disableCollapsible": false
               },
               {
+                "name": "cmd",
+                "path": "/packages/nx/documents/cmd",
+                "id": "cmd",
+                "isExternal": false,
+                "children": [],
+                "disableCollapsible": false
+              },
+              {
                 "name": "show",
                 "path": "/packages/nx/documents/show",
                 "id": "show",

--- a/docs/generated/manifests/packages.json
+++ b/docs/generated/manifests/packages.json
@@ -1776,6 +1776,17 @@
         "tags": ["workspace-watching"],
         "originalFilePath": "generated/cli/watch"
       },
+      "/packages/nx/documents/cmd": {
+        "id": "cmd",
+        "name": "cmd",
+        "description": "The core Nx plugin contains the core functionality of Nx like the project graph, nx commands and task orchestration.",
+        "file": "generated/packages/nx/documents/cmd",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/packages/nx/documents/cmd",
+        "tags": [],
+        "originalFilePath": "generated/cli/cmd"
+      },
       "/packages/nx/documents/show": {
         "id": "show",
         "name": "show",

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -1758,6 +1758,17 @@
         "originalFilePath": "generated/cli/watch"
       },
       {
+        "id": "cmd",
+        "name": "cmd",
+        "description": "The core Nx plugin contains the core functionality of Nx like the project graph, nx commands and task orchestration.",
+        "file": "generated/packages/nx/documents/cmd",
+        "itemList": [],
+        "isExternal": false,
+        "path": "nx/documents/cmd",
+        "tags": [],
+        "originalFilePath": "generated/cli/cmd"
+      },
+      {
         "id": "show",
         "name": "show",
         "description": "The core Nx plugin contains the core functionality of Nx like the project graph, nx commands and task orchestration.",

--- a/docs/generated/packages/nx/documents/cmd.md
+++ b/docs/generated/packages/nx/documents/cmd.md
@@ -1,0 +1,60 @@
+---
+title: 'cmd - CLI command'
+description: 'Executes a command in the root directory of projects'
+---
+
+# cmd
+
+Executes a command in the root directory of projects
+
+## Usage
+
+```shell
+nx cmd
+```
+
+Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpm nx`.
+
+## Options
+
+### all
+
+Type: `boolean`
+
+Watch all projects.
+
+### exclude
+
+Type: `string`
+
+Exclude certain projects from being processed
+
+### help
+
+Type: `boolean`
+
+Show help
+
+### parallel
+
+Type: `string`
+
+Max number of parallel commands [default is 3]
+
+### projects
+
+Type: `string`
+
+Projects on which to execute the command (comma/space delimited).
+
+### verbose
+
+Type: `boolean`
+
+Run in verbose mode, where the arguments and projects to run are logged before execution.
+
+### version
+
+Type: `boolean`
+
+Show version number

--- a/docs/map.json
+++ b/docs/map.json
@@ -1772,6 +1772,11 @@
               "file": "generated/cli/watch"
             },
             {
+              "name": "cmd",
+              "id": "cmd",
+              "file": "generated/cli/cmd"
+            },
+            {
               "name": "show",
               "id": "show",
               "file": "generated/cli/show"

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -491,6 +491,7 @@
       - [repair](/packages/nx/documents/repair)
       - [exec](/packages/nx/documents/exec)
       - [watch](/packages/nx/documents/watch)
+      - [cmd](/packages/nx/documents/cmd)
       - [show](/packages/nx/documents/show)
       - [view-logs](/packages/nx/documents/view-logs)
     - [executors](/packages/nx/executors)

--- a/e2e/nx-cmd/jest.config.ts
+++ b/e2e/nx-cmd/jest.config.ts
@@ -1,0 +1,13 @@
+/* eslint-disable */
+export default {
+  transform: {
+    '^.+\\.[tj]sx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
+  maxWorkers: 1,
+  globals: {},
+  globalSetup: '../utils/global-setup.ts',
+  globalTeardown: '../utils/global-teardown.ts',
+  displayName: 'e2e-nx-cmd',
+  preset: '../../jest.preset.js',
+};

--- a/e2e/nx-cmd/project.json
+++ b/e2e/nx-cmd/project.json
@@ -1,0 +1,11 @@
+{
+  "name": "e2e-nx-cmd",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "e2e/nx-cmd",
+  "projectType": "application",
+  "targets": {
+    "e2e": {},
+    "run-e2e-tests": {}
+  },
+  "implicitDependencies": ["js"]
+}

--- a/e2e/nx-cmd/src/cmd.test.ts
+++ b/e2e/nx-cmd/src/cmd.test.ts
@@ -1,0 +1,139 @@
+import {
+  cleanupProject,
+  newProject,
+  runCLI,
+  tmpProjPath,
+  uniq,
+  updateFile,
+} from '@nx/e2e/utils';
+
+describe('nx cmd', () => {
+  let proj: string;
+  const projects: string[] = [
+    uniq('zero-'),
+    uniq('one-'),
+    uniq('two-'),
+    uniq('three-'),
+    uniq('four-'),
+    uniq('five-'),
+    uniq('six-'),
+    uniq('seven-'),
+  ];
+
+  const addDependency = (src: string, dep: string) =>
+    updateFile(
+      `libs/${src}/src/index.ts`,
+      (content) => `import "@${proj}/${dep}";\n${content}`
+    );
+
+  beforeAll(() => {
+    proj = newProject();
+
+    projects.forEach((proj) => runCLI(`generate @nx/js:lib ${proj}`));
+
+    addDependency(projects[0], projects[1]);
+    addDependency(projects[1], projects[2]);
+    addDependency(projects[2], projects[0]);
+
+    addDependency(projects[3], projects[4]);
+    addDependency(projects[3], projects[5]);
+    addDependency(projects[4], projects[6]);
+  });
+  afterAll(() => cleanupProject());
+
+  describe('with --all', () => {
+    it('should run command on all projects, respecting dependencies', () => {
+      const output = runCLI(`cmd --all --parallel 1 -- basename "\\$(pwd)"`, {
+        env: { ...process.env, NX_DAEMON: 'false' },
+      });
+      projects.forEach((proj) => expect(output).toContain(proj));
+
+      expect(output.indexOf(projects[6])).toBeLessThan(
+        output.indexOf(projects[4])
+      );
+      expect(output.indexOf(projects[5])).toBeLessThan(
+        output.indexOf(projects[3])
+      );
+      expect(output.indexOf(projects[4])).toBeLessThan(
+        output.indexOf(projects[3])
+      );
+    });
+
+    describe('with --exclude', () => {
+      it('should run command on all projects except excluded ones', () => {
+        const excluded = [projects[0], projects[4], projects[7]];
+        const included = projects.filter((proj) => !excluded.includes(proj));
+
+        const output = runCLI(
+          `cmd --all --exclude ${excluded.join(',')} -- basename "\\$(pwd)"`,
+          {
+            env: { ...process.env, NX_DAEMON: 'false' },
+          }
+        );
+
+        included.forEach((proj) => expect(output).toContain(proj));
+        excluded.forEach((proj) => expect(output).not.toContain(proj));
+      });
+    });
+  });
+
+  describe('with --projects', () => {
+    it('should run command on specified projects', () => {
+      const included = [projects[1], projects[3], projects[6]];
+      const excluded = projects.filter((p) => !included.includes(p));
+
+      const output = runCLI(
+        `cmd --projects ${included.join(',')} -- basename "\\$(pwd)"`,
+        {
+          env: { ...process.env, NX_DAEMON: 'false' },
+        }
+      );
+
+      included.forEach((proj) => expect(output).toContain(proj));
+      excluded.forEach((proj) => expect(output).not.toContain(proj));
+    });
+
+    describe('with --exclude', () => {
+      it('should run command on all projects except excluded ones', () => {
+        const included = [projects[1], projects[3]];
+        const excluded = projects.filter((p) => !included.includes(p));
+
+        const output = runCLI(
+          `cmd --projects ${[...included, projects[6]].join(',')} --exclude ${
+            projects[6]
+          } -- basename "\\$(pwd)"`,
+          {
+            env: { ...process.env, NX_DAEMON: 'false' },
+          }
+        );
+
+        included.forEach((proj) => expect(output).toContain(proj));
+        excluded.forEach((proj) => expect(output).not.toContain(proj));
+      });
+    });
+
+    it('should run command and replace workspaceRoot, projectRoot, and projectName', () => {
+      const included = [projects[2], projects[5], projects[7]];
+
+      const output = runCLI(
+        `cmd --projects ${included.join(
+          ','
+        )} --parallel 1 -- echo "\\$(basename \\$(pwd)) {workspaceRoot} {projectName} {projectRoot}"`,
+        {
+          env: { ...process.env, NX_DAEMON: 'false' },
+        }
+      );
+
+      const strippedOutput = output.replace(/private\//g, '');
+      expect(strippedOutput).toContain(
+        `${projects[2]} ${tmpProjPath()} ${projects[2]} libs/${projects[2]}`
+      );
+      expect(strippedOutput).toContain(
+        `${projects[5]} ${tmpProjPath()} ${projects[5]} libs/${projects[5]}`
+      );
+      expect(strippedOutput).toContain(
+        `${projects[7]} ${tmpProjPath()} ${projects[7]} libs/${projects[7]}`
+      );
+    });
+  });
+});

--- a/e2e/nx-cmd/tsconfig.json
+++ b/e2e/nx-cmd/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node", "jest"]
+  },
+  "include": [],
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/e2e/nx-cmd/tsconfig.spec.json
+++ b/e2e/nx-cmd/tsconfig.spec.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.test.tsx",
+    "**/*.spec.js",
+    "**/*.test.js",
+    "**/*.spec.jsx",
+    "**/*.test.jsx",
+    "**/*.d.ts",
+    "jest.config.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -219,6 +219,7 @@
     "octokit": "^2.0.14",
     "open": "^8.4.0",
     "openai": "~3.3.0",
+    "p-queue": "^6.6.2",
     "ora": "5.3.0",
     "parse-markdown-links": "^1.0.4",
     "parse5": "4.0.0",

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -55,6 +55,7 @@
     "minimatch": "3.0.5",
     "npm-run-path": "^4.0.1",
     "open": "^8.4.0",
+    "p-queue": "^6.6.2",
     "semver": "7.5.3",
     "string-width": "^4.2.3",
     "strong-log-transformer": "^2.1.0",

--- a/packages/nx/src/command-line/cmd/cmd-command.ts
+++ b/packages/nx/src/command-line/cmd/cmd-command.ts
@@ -1,0 +1,88 @@
+import { execSync } from 'child_process';
+import { readNxJson } from '../../config/configuration';
+import {
+  ProjectGraph,
+  ProjectGraphProjectNode,
+} from '../../config/project-graph';
+import { TargetDependencyConfig } from '../../config/workspace-json-project-json';
+import { createProjectGraphAsync } from '../../project-graph/project-graph';
+import {
+  NxArgs,
+  splitArgsIntoNxArgsAndOverrides,
+} from '../../utils/command-line-utils';
+import { findMatchingProjects } from '../../utils/find-matching-projects';
+import { output } from '../../utils/output';
+import { workspaceConfigurationCheck } from '../../utils/workspace-configuration-check';
+import { runProjectsTopologically } from './run-projects-topologically';
+
+export async function cmdCommand(
+  args: { [k: string]: any },
+  extraTargetDependencies: Record<
+    string,
+    (TargetDependencyConfig | string)[]
+  > = {},
+  extraOptions = { excludeTaskDependencies: false, loadDotEnvFiles: true } as {
+    excludeTaskDependencies: boolean;
+    loadDotEnvFiles: boolean;
+  }
+) {
+  workspaceConfigurationCheck();
+  const nxJson = readNxJson();
+  const { nxArgs, overrides } = splitArgsIntoNxArgsAndOverrides(
+    args,
+    'run-many',
+    { printWarnings: args.graph !== 'stdout' },
+    nxJson
+  );
+
+  args.verbose &&
+    output.logSingleLine('running with args: ' + JSON.stringify(args));
+
+  const projectGraph = await createProjectGraphAsync({ exitOnError: true });
+  const projects = projectsToRun(nxArgs, projectGraph);
+
+  args.verbose &&
+    output.log({
+      title: 'running on projects:',
+      bodyLines: projects.map((p) => p.name),
+    });
+
+  const runner: (node: ProjectGraphProjectNode) => Promise<unknown> = async (
+    node
+  ) => execSync(args.command, { cwd: node.data.root, stdio: 'inherit' });
+
+  await runProjectsTopologically(projects, projectGraph, runner, {
+    concurrency: nxArgs.parallel ?? 3,
+  });
+}
+
+function projectsToRun(
+  nxArgs: NxArgs,
+  projectGraph: ProjectGraph
+): ProjectGraphProjectNode[] {
+  const selectedProjects: Record<string, ProjectGraphProjectNode> = {};
+  if (nxArgs.all && nxArgs.projects.length === 0) {
+    for (const projectName of Object.keys(projectGraph.nodes)) {
+      selectedProjects[projectName] = projectGraph.nodes[projectName];
+    }
+  } else {
+    const matchingProjects = findMatchingProjects(
+      nxArgs.projects,
+      projectGraph.nodes
+    );
+    for (const project of matchingProjects) {
+      selectedProjects[project] = projectGraph.nodes[project];
+    }
+  }
+
+  const excludedProjects = findMatchingProjects(
+    nxArgs.exclude,
+    selectedProjects
+  );
+
+  for (const excludedProject of excludedProjects) {
+    delete selectedProjects[excludedProject];
+  }
+
+  return Object.values(selectedProjects);
+}

--- a/packages/nx/src/command-line/cmd/command-object.ts
+++ b/packages/nx/src/command-line/cmd/command-object.ts
@@ -1,0 +1,64 @@
+import { CommandModule } from 'yargs';
+import {
+  parseCSV,
+  withExcludeOption,
+  withOverrides,
+} from '../yargs-utils/shared-options';
+
+export const yargsCmdCommand: CommandModule = {
+  command: 'cmd',
+  describe: 'Executes a command in the root directory of projects',
+  builder: (yargs) =>
+    withExcludeOption(yargs)
+      .parserConfiguration({
+        'strip-dashed': true,
+        'populate--': true,
+      })
+      .option('projects', {
+        type: 'string',
+        alias: 'p',
+        coerce: parseCSV,
+        description:
+          'Projects on which to execute the command (comma/space delimited).',
+      })
+      .option('all', {
+        type: 'boolean',
+        description: 'Watch all projects.',
+      })
+      .option('verbose', {
+        type: 'boolean',
+        description:
+          'Run in verbose mode, where the arguments and projects to run are logged before execution.',
+      })
+      .option('parallel', {
+        describe: 'Max number of parallel commands [default is 3]',
+        type: 'string',
+      })
+      .conflicts({
+        all: 'projects',
+      })
+      .check((args) => {
+        if (!args.all && !args.projects) {
+          throw Error('Please specify either --all or --projects');
+        }
+
+        return true;
+      })
+      .middleware((args) => {
+        const { '--': doubledash } = args;
+        if (doubledash && Array.isArray(doubledash)) {
+          args.command = (doubledash as string[]).join(' ');
+        } else {
+          throw Error('Please specify a command to run with --');
+        }
+      }, true),
+  handler: async (args) => {
+    try {
+      await (await import('./cmd-command')).cmdCommand(withOverrides(args));
+      process.exit(0);
+    } catch (e) {
+      console.error(e);
+      process.exit(1);
+    }
+  },
+};

--- a/packages/nx/src/command-line/cmd/cycles/get-cycles.spec.ts
+++ b/packages/nx/src/command-line/cmd/cycles/get-cycles.spec.ts
@@ -1,0 +1,96 @@
+import { ProjectGraphDependency } from '../../../config/project-graph';
+import { getCycles } from './get-cycles';
+
+function projectGraphDependency(
+  dep: Partial<ProjectGraphDependency>
+): ProjectGraphDependency {
+  return dep as ProjectGraphDependency;
+}
+
+describe('getCycles', () => {
+  it('should find a single cycle', () => {
+    const projectGraphDependencies: Record<string, ProjectGraphDependency[]> = {
+      'package-1': [
+        projectGraphDependency({ source: 'package-1', target: 'package-2' }),
+      ],
+      'package-2': [
+        projectGraphDependency({ source: 'package-2', target: 'package-3' }),
+      ],
+      'package-3': [
+        projectGraphDependency({ source: 'package-3', target: 'package-2' }),
+      ],
+    };
+
+    expect(getCycles(projectGraphDependencies)).toEqual([
+      ['package-2', 'package-3'],
+    ]);
+  });
+
+  it('should find two independent cycles', () => {
+    const projectGraphDependencies: Record<string, ProjectGraphDependency[]> = {
+      'package-a': [
+        projectGraphDependency({ source: 'package-a', target: 'package-b' }),
+      ],
+      'package-b': [
+        projectGraphDependency({ source: 'package-b', target: 'package-c' }),
+      ],
+      'package-c': [
+        projectGraphDependency({ source: 'package-c', target: 'package-a' }),
+      ],
+      'package-1': [
+        projectGraphDependency({ source: 'package-1', target: 'package-2' }),
+      ],
+      'package-2': [
+        projectGraphDependency({ source: 'package-2', target: 'package-3' }),
+      ],
+      'package-3': [
+        projectGraphDependency({ source: 'package-3', target: 'package-1' }),
+      ],
+      'package-x': [
+        projectGraphDependency({ source: 'package-x', target: 'package-xx' }),
+      ],
+      'package-xx': [
+        projectGraphDependency({ source: 'package-xx', target: 'package-b' }),
+        projectGraphDependency({ source: 'package-xx', target: 'package-3' }),
+      ],
+    };
+
+    expect(getCycles(projectGraphDependencies)).toEqual([
+      ['package-a', 'package-b', 'package-c'],
+      ['package-1', 'package-2', 'package-3'],
+    ]);
+  });
+
+  it('should find two cycles with overlapping nodes', () => {
+    const projectGraphDependencies: Record<string, ProjectGraphDependency[]> = {
+      'package-1': [
+        projectGraphDependency({ source: 'package-1', target: 'package-2' }),
+        projectGraphDependency({ source: 'package-1', target: 'package-7' }),
+      ],
+      'package-2': [
+        projectGraphDependency({ source: 'package-2', target: 'package-3' }),
+      ],
+      'package-3': [
+        projectGraphDependency({ source: 'package-3', target: 'package-4' }),
+        projectGraphDependency({ source: 'package-3', target: 'package-5' }),
+      ],
+      'package-4': [
+        projectGraphDependency({ source: 'package-4', target: 'package-2' }),
+      ],
+      'package-5': [
+        projectGraphDependency({ source: 'package-5', target: 'package-6' }),
+      ],
+      'package-6': [
+        projectGraphDependency({ source: 'package-6', target: 'package-3' }),
+      ],
+      'package-7': [
+        projectGraphDependency({ source: 'package-7', target: 'package-5' }),
+      ],
+    };
+
+    expect(getCycles(projectGraphDependencies)).toEqual([
+      ['package-2', 'package-3', 'package-4'],
+      ['package-3', 'package-5', 'package-6'],
+    ]);
+  });
+});

--- a/packages/nx/src/command-line/cmd/cycles/get-cycles.ts
+++ b/packages/nx/src/command-line/cmd/cycles/get-cycles.ts
@@ -1,0 +1,37 @@
+import { ProjectGraphDependency } from '../../../config/project-graph';
+
+/**
+ * Get all cycles within the given dependencies.
+ * @param dependencies project dependencies grouped by source
+ * @returns a list of cycles, where each cycle is a list of project names
+ */
+export function getCycles(
+  dependencies: Record<string, ProjectGraphDependency[]>
+): string[][] {
+  const cycles: string[][] = [];
+  const visited: Set<string> = new Set();
+
+  function dfs(next: string, path: string[]) {
+    visited.add(next);
+    path.push(next);
+
+    for (const dep of dependencies[next] || []) {
+      if (path.includes(dep.target)) {
+        const cycle = path.slice(path.indexOf(dep.target));
+        cycles.push(cycle);
+      } else if (!visited.has(dep.target)) {
+        dfs(dep.target, path);
+      }
+    }
+
+    path.pop();
+  }
+
+  for (const next of Object.keys(dependencies)) {
+    if (!visited.has(next)) {
+      dfs(next, []);
+    }
+  }
+
+  return cycles;
+}

--- a/packages/nx/src/command-line/cmd/cycles/index.ts
+++ b/packages/nx/src/command-line/cmd/cycles/index.ts
@@ -1,0 +1,2 @@
+export * from './get-cycles';
+export * from './merge-overlapping-cycles';

--- a/packages/nx/src/command-line/cmd/cycles/merge-overlapping-cycles.spec.ts
+++ b/packages/nx/src/command-line/cmd/cycles/merge-overlapping-cycles.spec.ts
@@ -1,0 +1,28 @@
+import { mergeOverlappingCycles } from './merge-overlapping-cycles';
+
+describe('mergeOverlappingCycles', () => {
+  it('should merge multiple overlapping cycles into one', () => {
+    const cycles: string[][] = [
+      ['package-a', 'package-b'],
+      ['package-2', 'package-3', 'package-4'],
+      ['package-3', 'package-5', 'package-6'],
+      ['package-x', 'package-xx', 'package-xxx'],
+      ['package-y', 'package-yy', 'package-yyy', 'package-xxx'],
+      ['package-z', 'package-zz', 'package-zzz', 'package-zzzz'],
+    ];
+
+    expect(mergeOverlappingCycles(cycles)).toEqual([
+      ['package-a', 'package-b'],
+      ['package-2', 'package-3', 'package-4', 'package-5', 'package-6'],
+      [
+        'package-x',
+        'package-xx',
+        'package-xxx',
+        'package-y',
+        'package-yy',
+        'package-yyy',
+      ],
+      ['package-z', 'package-zz', 'package-zzz', 'package-zzzz'],
+    ]);
+  });
+});

--- a/packages/nx/src/command-line/cmd/cycles/merge-overlapping-cycles.ts
+++ b/packages/nx/src/command-line/cmd/cycles/merge-overlapping-cycles.ts
@@ -1,0 +1,33 @@
+/**
+ * Merges all cycles that share nodes into a single cycle, then returns all merged cycles. This allows all cycle nodes to be traversed without repeating any nodes.
+ * @param cycles a list of cycles, with each cycle being a list of project names
+ * @returns a list of cycles that do not share any nodes with any other cycles
+ */
+export function mergeOverlappingCycles(cycles: string[][]): string[][] {
+  const mergedCycles: string[][] = [];
+  cycles.forEach((cycle) => {
+    let intersectionNodes: string[] = [];
+    const mergedCycle = mergedCycles.find((mergedCycle) => {
+      intersectionNodes = intersection(mergedCycle, cycle);
+      return intersectionNodes.length > 0;
+    });
+
+    if (mergedCycle) {
+      mergedCycle.push(...difference(cycle, intersectionNodes));
+    } else {
+      mergedCycles.push(cycle);
+    }
+  });
+  return mergedCycles;
+}
+
+function intersection(arr1: string[], arr2: string[]): string[] {
+  return arr1.filter((item) => arr2.includes(item));
+}
+
+function difference(arr1: string[], arr2: string[]): string[] {
+  return [
+    ...arr1.filter((item) => !arr2.includes(item)),
+    ...arr2.filter((item) => !arr1.includes(item)),
+  ];
+}

--- a/packages/nx/src/command-line/cmd/run-projects-topologically.spec.ts
+++ b/packages/nx/src/command-line/cmd/run-projects-topologically.spec.ts
@@ -1,0 +1,724 @@
+import {
+  ProjectGraph,
+  ProjectGraphDependency,
+  ProjectGraphProjectNode,
+} from '../../config/project-graph';
+import { runProjectsTopologically } from './run-projects-topologically';
+
+function projectNode(
+  projectNode: Partial<ProjectGraphProjectNode>
+): ProjectGraphProjectNode {
+  return projectNode as ProjectGraphProjectNode;
+}
+
+function projectGraphDependency(
+  dep: Partial<ProjectGraphDependency>
+): ProjectGraphDependency {
+  return dep as ProjectGraphDependency;
+}
+
+function createProjectGraph<T extends ProjectGraphProjectNode>({
+  projects,
+  dependencies,
+}: {
+  projects: T[];
+  dependencies: ProjectGraphDependency[];
+}): ProjectGraph {
+  return {
+    nodes: projects.reduce(
+      (acc, project) => ({ ...acc, [project.name]: project }),
+      {}
+    ),
+    dependencies: dependencies.reduce(
+      (prev, next) => ({
+        ...prev,
+        [next.source]: [...(prev[next.source] || []), next],
+      }),
+      {} as Record<string, ProjectGraphDependency[]>
+    ),
+  };
+}
+
+describe('runProjectsTopologically', () => {
+  it('should run projects in order by depth of tree with leaves first', async () => {
+    const projects: ProjectGraphProjectNode[] = [
+      projectNode({
+        name: 'ppp2',
+        type: 'lib',
+        data: {
+          root: 'packages-other/eee2',
+        },
+      }),
+      projectNode({
+        name: 'ooo1',
+        type: 'lib',
+        data: {
+          root: 'packages-other/ooo1',
+        },
+      }),
+      projectNode({
+        name: 'ooo2',
+        type: 'lib',
+        data: {
+          root: 'packages-other/ooo2',
+        },
+      }),
+      projectNode({
+        name: 'other-1',
+        type: 'lib',
+        data: {
+          root: 'packages/other-1',
+        },
+      }),
+      projectNode({
+        name: 'other-2',
+        type: 'lib',
+        data: {
+          root: 'packages/other-2',
+        },
+      }),
+      projectNode({
+        name: 'other-with-scope',
+        type: 'lib',
+        data: {
+          root: 'packages/other-with-scope',
+        },
+      }),
+      projectNode({
+        name: 'package-1',
+        type: 'lib',
+        data: {
+          root: 'packages/package-1',
+        },
+      }),
+      projectNode({
+        name: 'package-2',
+        type: 'lib',
+        data: {
+          root: 'packages/package-2',
+        },
+      }),
+      projectNode({
+        name: 'package-base',
+        type: 'lib',
+        data: {
+          root: 'packages/package-base',
+        },
+      }),
+    ];
+    const dependencies: ProjectGraphDependency[] = [
+      projectGraphDependency({
+        source: 'other-1',
+        target: 'other-2',
+      }),
+      projectGraphDependency({
+        source: 'package-1',
+        target: 'package-2',
+      }),
+      projectGraphDependency({
+        source: 'package-1',
+        target: 'package-base',
+      }),
+      projectGraphDependency({
+        source: 'package-2',
+        target: 'package-base',
+      }),
+      projectGraphDependency({
+        source: 'ooo1',
+        target: 'ooo2',
+      }),
+      projectGraphDependency({
+        source: 'ooo1',
+        target: 'ppp2',
+      }),
+    ];
+
+    const projectGraph = createProjectGraph({ projects, dependencies });
+
+    const result: string[] = [];
+    const runner = (node: ProjectGraphProjectNode) => {
+      result.push(node.name);
+      return Promise.resolve();
+    };
+
+    await runProjectsTopologically(projects, projectGraph, runner, {
+      concurrency: 4,
+    });
+
+    expect(result).toEqual([
+      'ppp2',
+      'ooo2',
+      'other-2',
+      'other-with-scope',
+      'package-base',
+      'ooo1',
+      'other-1',
+      'package-2',
+      'package-1',
+    ]);
+  });
+
+  it('should order projects by depth of the tree with leaves first, ignoring dependencies of projects that are not provided', async () => {
+    const projects: ProjectGraphProjectNode[] = [
+      projectNode({
+        name: 'package-1',
+        type: 'lib',
+        data: {
+          root: 'packages/package-1',
+        },
+      }),
+      projectNode({
+        name: 'package-2',
+        type: 'lib',
+        data: {
+          root: 'packages/package-2',
+        },
+      }),
+      projectNode({
+        name: 'package-3',
+        type: 'lib',
+        data: {
+          root: 'packages/package-3',
+        },
+      }),
+      projectNode({
+        name: 'package-4',
+        type: 'lib',
+        data: {
+          root: 'packages/package-4',
+        },
+      }),
+      projectNode({
+        name: 'package-5',
+        type: 'lib',
+        data: {
+          root: 'packages/package-5',
+        },
+      }),
+      projectNode({
+        name: 'package-6',
+        type: 'lib',
+        data: {
+          root: 'packages/package-6',
+        },
+      }),
+    ];
+    const dependencies: ProjectGraphDependency[] = [
+      projectGraphDependency({
+        source: 'package-1',
+        target: 'package-2',
+      }),
+      projectGraphDependency({
+        source: 'package-2',
+        target: 'package-3',
+      }),
+      projectGraphDependency({
+        source: 'package-3',
+        target: 'package-4',
+      }),
+      projectGraphDependency({
+        source: 'package-4',
+        target: 'package-5',
+      }),
+      projectGraphDependency({
+        source: 'package-5',
+        target: 'package-6',
+      }),
+    ];
+
+    const projectGraph = createProjectGraph({ projects, dependencies });
+
+    const projectsToRun = [
+      projectGraph.nodes['package-2'],
+      projectGraph.nodes['package-3'],
+      projectGraph.nodes['package-4'],
+    ];
+
+    const result: string[] = [];
+    const runner = (node: ProjectGraphProjectNode) => {
+      result.push(node.name);
+      return Promise.resolve();
+    };
+
+    await runProjectsTopologically(projectsToRun, projectGraph, runner, {
+      concurrency: 4,
+    });
+
+    expect(result).toEqual(['package-4', 'package-3', 'package-2']);
+  });
+
+  it('should order projects by depth of the tree with leaves first, ignoring and skipping dependencies of projects that are not provided', async () => {
+    const projects: ProjectGraphProjectNode[] = [
+      projectNode({
+        name: 'package-1',
+        type: 'lib',
+        data: {
+          root: 'packages/package-1',
+        },
+      }),
+      projectNode({
+        name: 'package-2',
+        type: 'lib',
+        data: {
+          root: 'packages/package-2',
+        },
+      }),
+      projectNode({
+        name: 'package-3',
+        type: 'lib',
+        data: {
+          root: 'packages/package-3',
+        },
+      }),
+      projectNode({
+        name: 'package-4',
+        type: 'lib',
+        data: {
+          root: 'packages/package-4',
+        },
+      }),
+      projectNode({
+        name: 'package-5',
+        type: 'lib',
+        data: {
+          root: 'packages/package-5',
+        },
+      }),
+      projectNode({
+        name: 'package-6',
+        type: 'lib',
+        data: {
+          root: 'packages/package-6',
+        },
+      }),
+    ];
+    const dependencies: ProjectGraphDependency[] = [
+      projectGraphDependency({
+        source: 'package-1',
+        target: 'package-2',
+      }),
+      projectGraphDependency({
+        source: 'package-2',
+        target: 'package-3',
+      }),
+      projectGraphDependency({
+        source: 'package-3',
+        target: 'package-4',
+      }),
+      projectGraphDependency({
+        source: 'package-4',
+        target: 'package-5',
+      }),
+      projectGraphDependency({
+        source: 'package-5',
+        target: 'package-6',
+      }),
+    ];
+
+    const projectGraph = createProjectGraph({ projects, dependencies });
+
+    const projectsToRun = [
+      projectGraph.nodes['package-2'],
+      projectGraph.nodes['package-4'],
+    ];
+
+    const result: string[] = [];
+    const runner = (node: ProjectGraphProjectNode) => {
+      result.push(node.name);
+      return Promise.resolve();
+    };
+
+    await runProjectsTopologically(projectsToRun, projectGraph, runner, {
+      concurrency: 4,
+    });
+
+    // does not recognize the dependency chain of package-2 -> package-3 -> package-4
+    // because package-3 is not in the set of projects to run.
+    expect(result).toEqual(['package-2', 'package-4']);
+  });
+
+  it('should handle cycles', async () => {
+    const projects: ProjectGraphProjectNode[] = [
+      projectNode({
+        name: 'ppp2',
+        type: 'lib',
+        data: {
+          root: 'packages-other/eee2',
+        },
+      }),
+      projectNode({
+        name: 'ooo1',
+        type: 'lib',
+        data: {
+          root: 'packages-other/ooo1',
+        },
+      }),
+      projectNode({
+        name: 'ooo2',
+        type: 'lib',
+        data: {
+          root: 'packages-other/ooo2',
+        },
+      }),
+      projectNode({
+        name: 'cycle-1',
+        type: 'lib',
+        data: {
+          root: 'packages/cycle-1',
+        },
+      }),
+      projectNode({
+        name: 'cycle-2',
+        type: 'lib',
+        data: {
+          root: 'packages/cycle-2',
+        },
+      }),
+      projectNode({
+        name: 'cycle-3',
+        type: 'lib',
+        data: {
+          root: 'packages/cycle-3',
+        },
+      }),
+      projectNode({
+        name: 'other-1',
+        type: 'lib',
+        data: {
+          root: 'packages/other-1',
+        },
+      }),
+      projectNode({
+        name: 'other-2',
+        type: 'lib',
+        data: {
+          root: 'packages/other-2',
+        },
+      }),
+      projectNode({
+        name: 'other-with-scope',
+        type: 'lib',
+        data: {
+          root: 'packages/other-with-scope',
+        },
+      }),
+      projectNode({
+        name: 'package-1',
+        type: 'lib',
+        data: {
+          root: 'packages/package-1',
+        },
+      }),
+      projectNode({
+        name: 'package-2',
+        type: 'lib',
+        data: {
+          root: 'packages/package-2',
+        },
+      }),
+      projectNode({
+        name: 'package-base',
+        type: 'lib',
+        data: {
+          root: 'packages/package-base',
+        },
+      }),
+    ];
+    const dependencies: ProjectGraphDependency[] = [
+      projectGraphDependency({
+        source: 'cycle-1',
+        target: 'cycle-2',
+      }),
+      projectGraphDependency({
+        source: 'cycle-1',
+        target: 'ooo1',
+      }),
+      projectGraphDependency({
+        source: 'cycle-2',
+        target: 'cycle-3',
+      }),
+      projectGraphDependency({
+        source: 'cycle-2',
+        target: 'ooo1',
+      }),
+      projectGraphDependency({
+        source: 'cycle-3',
+        target: 'cycle-1',
+      }),
+      projectGraphDependency({
+        source: 'other-1',
+        target: 'other-2',
+      }),
+      projectGraphDependency({
+        source: 'package-1',
+        target: 'package-2',
+      }),
+      projectGraphDependency({
+        source: 'package-1',
+        target: 'package-base',
+      }),
+      projectGraphDependency({
+        source: 'package-2',
+        target: 'package-base',
+      }),
+      projectGraphDependency({
+        source: 'package-2',
+        target: 'cycle-1',
+      }),
+      projectGraphDependency({
+        source: 'ooo1',
+        target: 'ooo2',
+      }),
+      projectGraphDependency({
+        source: 'ooo1',
+        target: 'ppp2',
+      }),
+    ];
+
+    const projectGraph = createProjectGraph({ projects, dependencies });
+
+    const result: string[] = [];
+    const runner = (node: ProjectGraphProjectNode) => {
+      result.push(node.name);
+      return Promise.resolve();
+    };
+
+    await runProjectsTopologically(projects, projectGraph, runner, {
+      concurrency: 4,
+    });
+
+    expect(result).toEqual([
+      'ppp2',
+      'ooo2',
+      'other-2',
+      'other-with-scope',
+      'package-base',
+      'ooo1',
+      'other-1',
+      'cycle-1',
+      'cycle-2',
+      'cycle-3',
+      'package-2',
+      'package-1',
+    ]);
+  });
+
+  it('should handle nested cycles', async () => {
+    const projects: ProjectGraphProjectNode[] = [
+      projectNode({
+        name: 'package-1',
+        type: 'lib',
+        data: {
+          root: 'packages/package-1',
+        },
+      }),
+      projectNode({
+        name: 'package-2',
+        type: 'lib',
+        data: {
+          root: 'packages/package-2',
+        },
+      }),
+      projectNode({
+        name: 'package-3',
+        type: 'lib',
+        data: {
+          root: 'packages/package-3',
+        },
+      }),
+      projectNode({
+        name: 'package-4',
+        type: 'lib',
+        data: {
+          root: 'packages/package-4',
+        },
+      }),
+      projectNode({
+        name: 'package-5',
+        type: 'lib',
+        data: {
+          root: 'packages/package-5',
+        },
+      }),
+      projectNode({
+        name: 'package-6',
+        type: 'lib',
+        data: {
+          root: 'packages/package-6',
+        },
+      }),
+      projectNode({
+        name: 'package-7',
+        type: 'lib',
+        data: {
+          root: 'packages/package-7',
+        },
+      }),
+      projectNode({
+        name: 'package-8',
+        type: 'lib',
+        data: {
+          root: 'packages/package-8',
+        },
+      }),
+      projectNode({
+        name: 'package-9',
+        type: 'lib',
+        data: {
+          root: 'packages/package-9',
+        },
+      }),
+    ];
+    const dependencies: ProjectGraphDependency[] = [
+      projectGraphDependency({
+        source: 'package-1',
+        target: 'package-2',
+      }),
+      projectGraphDependency({
+        source: 'package-1',
+        target: 'package-7',
+      }),
+      projectGraphDependency({
+        source: 'package-2',
+        target: 'package-3',
+      }),
+      projectGraphDependency({
+        source: 'package-3',
+        target: 'package-4',
+      }),
+      projectGraphDependency({
+        source: 'package-3',
+        target: 'package-5',
+      }),
+      projectGraphDependency({
+        source: 'package-4',
+        target: 'package-2',
+      }),
+      projectGraphDependency({
+        source: 'package-5',
+        target: 'package-6',
+      }),
+      projectGraphDependency({
+        source: 'package-6',
+        target: 'package-3',
+      }),
+      projectGraphDependency({
+        source: 'package-7',
+        target: 'package-5',
+      }),
+      projectGraphDependency({
+        source: 'package-8',
+        target: 'package-9',
+      }),
+    ];
+
+    const projectGraph = createProjectGraph({ projects, dependencies });
+
+    const result: string[] = [];
+    const runner = (node: ProjectGraphProjectNode) => {
+      result.push(node.name);
+      return Promise.resolve();
+    };
+
+    await runProjectsTopologically(projects, projectGraph, runner, {
+      concurrency: 4,
+    });
+
+    expect(result).toEqual([
+      'package-9',
+      'package-8',
+      'package-2',
+      'package-3',
+      'package-4',
+      'package-5',
+      'package-6',
+      'package-7',
+      'package-1',
+    ]);
+  });
+
+  it('should handle cycles with dependencies', async () => {
+    const projects: ProjectGraphProjectNode[] = [
+      projectNode({
+        name: 'a',
+      }),
+      projectNode({
+        name: 'b',
+      }),
+      projectNode({
+        name: 'c',
+      }),
+      projectNode({
+        name: 'd',
+      }),
+      projectNode({
+        name: 'e',
+      }),
+      projectNode({
+        name: 'f',
+      }),
+      projectNode({
+        name: 'g',
+      }),
+      projectNode({
+        name: 'h',
+      }),
+    ];
+    const dependencies: ProjectGraphDependency[] = [
+      projectGraphDependency({
+        source: 'a',
+        target: 'b',
+      }),
+      projectGraphDependency({
+        source: 'a',
+        target: 'h',
+      }),
+      projectGraphDependency({
+        source: 'b',
+        target: 'c',
+      }),
+      projectGraphDependency({
+        source: 'c',
+        target: 'd',
+      }),
+      projectGraphDependency({
+        source: 'd',
+        target: 'b',
+      }),
+      projectGraphDependency({
+        source: 'h',
+        target: 'e',
+      }),
+      projectGraphDependency({
+        source: 'd',
+        target: 'g',
+      }),
+      projectGraphDependency({
+        source: 'g',
+        target: 'e',
+      }),
+      projectGraphDependency({
+        source: 'e',
+        target: 'f',
+      }),
+      projectGraphDependency({
+        source: 'f',
+        target: 'g',
+      }),
+    ];
+
+    const projectGraph = createProjectGraph({ projects, dependencies });
+
+    const result: string[] = [];
+    const runner = (node: ProjectGraphProjectNode) => {
+      result.push(node.name);
+      return Promise.resolve();
+    };
+
+    await runProjectsTopologically(projects, projectGraph, runner, {
+      concurrency: 4,
+    });
+
+    expect(result).toEqual(['g', 'e', 'f', 'b', 'c', 'd', 'h', 'a']);
+  });
+});

--- a/packages/nx/src/command-line/cmd/run-projects-topologically.ts
+++ b/packages/nx/src/command-line/cmd/run-projects-topologically.ts
@@ -1,0 +1,128 @@
+import PQueue from 'p-queue';
+import {
+  ProjectGraph,
+  ProjectGraphProjectNode,
+} from '../../config/project-graph';
+import { getCycles, mergeOverlappingCycles } from './cycles';
+
+interface TopologicalConfig {
+  concurrency?: number;
+}
+
+/**
+ * Run callback in maximally-saturated topological order.
+ */
+export async function runProjectsTopologically<T>(
+  projects: ProjectGraphProjectNode[],
+  projectGraph: ProjectGraph,
+  runner: (node: ProjectGraphProjectNode) => Promise<T>,
+  { concurrency }: TopologicalConfig = {}
+): Promise<T[]> {
+  const queue = new PQueue({ concurrency });
+
+  const returnValues: T[] = [];
+
+  const projectsMap = new Map(projects.map((p) => [p.name, p]));
+  const localDependencies = projectGraph.dependencies;
+  const flattenedLocalDependencies = flatten(Object.values(localDependencies));
+
+  const getProject = (name: string) => {
+    const project = projectsMap.get(name);
+    if (!project) {
+      throw new Error(
+        `Failed to find project ${name}. This is likely a bug in Nx.`
+      );
+    }
+    return project;
+  };
+
+  const dependenciesBySource: Record<string, Set<string>> = projects.reduce(
+    (prev, next) => ({
+      ...prev,
+      [next.name]: new Set<string>(),
+    }),
+    {}
+  );
+
+  flattenedLocalDependencies.forEach((dep) => {
+    if (dependenciesBySource[dep.source] && projectsMap.has(dep.target)) {
+      dependenciesBySource[dep.source].add(dep.target);
+    }
+  });
+
+  const unmergedCycles = getCycles(localDependencies);
+  const cycles = new Set(mergeOverlappingCycles(unmergedCycles));
+
+  const seen: Set<string> = new Set();
+
+  const errors: Error[] = [];
+
+  const queueNextPackages = () => {
+    if (seen.size === projects.length) {
+      return;
+    }
+    let batch = Object.keys(dependenciesBySource)
+      .filter((p) => dependenciesBySource[p].size === 0)
+      .filter((p) => !seen.has(p));
+
+    if (batch.length === 0) {
+      const cycle = Array.from(cycles.values()).find((cycle) => {
+        // only process the cycle if it has NO nodes with dependencies outside this same cycle
+        const cycleHasExternalDependencies = cycle.some((project) => {
+          const projectDeps = dependenciesBySource[project];
+          const depIsNotInCycle = (dep: string) => cycle.indexOf(dep) === -1;
+          return Array.from(projectDeps).filter(depIsNotInCycle).length > 0;
+        });
+        return !cycleHasExternalDependencies;
+      });
+
+      if (cycle) {
+        cycles.delete(cycle);
+        batch = cycle.filter((p) => projectsMap.has(p));
+      }
+    }
+
+    batch.forEach((p) => {
+      const project = getProject(p);
+      seen.add(p);
+
+      queue
+        .add(() =>
+          runner(project).then((value) => {
+            returnValues.push(value);
+
+            delete dependenciesBySource[p];
+
+            Object.keys(dependenciesBySource).forEach((dep) =>
+              dependenciesBySource[dep].delete(p)
+            );
+
+            queueNextPackages();
+          })
+        )
+        .catch((err) => {
+          // capture the inner error to throw later, since queue.onIdle will not throw it
+          errors.push(err);
+        });
+    });
+  };
+
+  queueNextPackages();
+
+  await queue.onIdle();
+
+  if (errors.length) {
+    // throw the first error that was captured above
+    throw errors[0];
+  }
+
+  if (seen.size !== projects.length) {
+    throw new Error('Not all tasks were run. This is likely a bug in Nx.');
+  }
+
+  return returnValues;
+}
+
+function flatten<T>(arr: T[][]): T[] {
+  return arr.reduce((acc, next) => [...acc, ...next], []);
+}

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -10,12 +10,12 @@ import {
   yargsAffectedTestCommand,
   yargsPrintAffectedCommand,
 } from './affected/command-object';
+import { yargsCmdCommand } from './cmd/command-object';
 import {
   yargsConnectCommand,
   yargsViewLogsCommand,
 } from './connect/command-object';
 import { yargsDaemonCommand } from './daemon/command-object';
-import { yargsDepGraphCommand } from './graph/command-object';
 import { yargsExecCommand } from './exec/command-object';
 import {
   yargsFormatCheckCommand,
@@ -25,6 +25,7 @@ import {
   yargsGenerateCommand,
   yargsWorkspaceGeneratorCommand,
 } from './generate/command-object';
+import { yargsDepGraphCommand } from './graph/command-object';
 import { yargsInitCommand } from './init/command-object';
 import { yargsListCommand } from './list/command-object';
 import {
@@ -34,12 +35,12 @@ import {
 import { yargsNewCommand } from './new/command-object';
 import { yargsRepairCommand } from './repair/command-object';
 import { yargsReportCommand } from './report/command-object';
-import { yargsRunCommand } from './run/command-object';
+import { yargsResetCommand } from './reset/command-object';
 import { yargsRunManyCommand } from './run-many/command-object';
+import { yargsRunCommand } from './run/command-object';
 import { yargsShowCommand } from './show/command-object';
 import { yargsWatchCommand } from './watch/command-object';
 import { yargsWorkspaceLintCommand } from './workspace-lint/command-object';
-import { yargsResetCommand } from './reset/command-object';
 
 // Ensure that the output takes up the available width of the terminal.
 yargs.wrap(yargs.terminalWidth());
@@ -88,6 +89,7 @@ export const commandsObject = yargs
   .command(yargsWatchCommand)
   .command(yargsWorkspaceGeneratorCommand)
   .command(yargsWorkspaceLintCommand)
+  .command(yargsCmdCommand)
   .scriptName('nx')
   .help()
   // NOTE: we handle --version in nx.ts, this just tells yargs that the option exists

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -732,6 +732,9 @@ devDependencies:
   ora:
     specifier: 5.3.0
     version: 5.3.0
+  p-queue:
+    specifier: ^6.6.2
+    version: 6.6.2
   parse-markdown-links:
     specifier: ^1.0.4
     version: 1.0.4


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Adds a `nx cmd` command to Nx that will execute an arbitrary command from the root directory of the specified projects. 
- specify projects via `--all` or `--projects`
- exclude projects with `--exclude`
- specify inner command with `--`
- interpolate project and workspace details in the inner command via `{workspaceRoot}`, `{projectRoot}`, and `{projectName}`

A couple examples:

Print the name of all project directories except for projects prefixed with `test-`
`nx cmd --all --exclude "test-*" -- basename "\$(pwd)"`

Copy files from package `dist` folders to root `dist` folder
`nx cmd --projects my-package1,my-package-2 -- cp -R dist {workspaceRoot}/dist/{projectName}`
