### PR TITLE
feat(nx-dev): remove unnecessary breadcrumbs

### DIFF
--- a/nx-dev/ui-common/src/lib/breadcrumbs.tsx
+++ b/nx-dev/ui-common/src/lib/breadcrumbs.tsx
@@ -20,6 +20,10 @@ export function Breadcrumbs({ path }: { path: string }): JSX.Element {
   ];
   const hasRef = path.includes('?') ? path.slice(0, path.indexOf('?')) : '';
 
+  if (pages.length === 1) {
+    return <></>;
+  }
+
   return (
     <div>
       <nav className="flex" aria-labelledby="breadcrumb">


### PR DESCRIPTION
Base pages should not have breadcrumbs as they double the existing heading.

## Current Behavior
![Screenshot 2023-07-24 at 13 56 10](https://github.com/nrwl/nx/assets/881612/28393f47-3b0c-4265-89c4-cb70afa9d747)

## Expected Behavior
![Screenshot 2023-07-24 at 13 56 36](https://github.com/nrwl/nx/assets/881612/0c375f7d-0ca2-43b5-be02-8710db068d19)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
