### PR TITLE
fix(nx-dev): fix official plugin badge background

### DIFF
--- a/nx-dev/ui-common/src/lib/plugin-card.tsx
+++ b/nx-dev/ui-common/src/lib/plugin-card.tsx
@@ -40,7 +40,7 @@ export function PluginCard({
           {isOfficial ? (
             <span
               title="Official plugins are maintained by the Nx Team"
-              className="bg-green-nx-base absolute bottom-3 right-4 rounded-full px-3 py-0.5 text-xs font-medium capitalize text-white"
+              className="bg-green-500 absolute bottom-3 right-4 rounded-full px-3 py-0.5 text-xs font-medium capitalize text-white"
             >
               Official
             </span>


### PR DESCRIPTION
https://nx-dev-git-fork-meeroslav-fix-official-nrwl.vercel.app/plugins/registry

Badge now works in both light and dark mode

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
