### PR TITLE
chore(repo): increase Verdaccio fail limits

### DIFF
--- a/.verdaccio/config.yml
+++ b/.verdaccio/config.yml
@@ -10,9 +10,13 @@ uplinks:
   npmjs:
     url: https://registry.npmjs.org/
     maxage: 60m
+    max_fails: 20
+    fail_timeout: 2m
   yarn:
     url: https://registry.yarnpkg.com
     maxage: 60m
+    max_fails: 20
+    fail_timeout: 2m
 
 packages:
   '@*/*':


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

So that if you're on a shitty connection your Verdaccio uplink doesn't just go offline immediately 😅

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
