### PR TITLE
chore(core): remove globForProjectFiles

### DIFF
--- a/packages/nx/src/generators/utils/project-configuration.ts
+++ b/packages/nx/src/generators/utils/project-configuration.ts
@@ -6,8 +6,6 @@ import {
 import {
   buildProjectsConfigurationsFromProjectPaths,
   deduplicateProjectFiles,
-  getGlobPatternsFromPlugins,
-  globForProjectFiles,
   renamePropertyWithStableKeys,
 } from '../../config/workspaces';
 import { joinPathFragments, normalizePath } from '../../utils/path';
@@ -18,7 +16,7 @@ import { readJson, writeJson } from './json';
 import { PackageJson } from '../../utils/package-json';
 import { readNxJson } from './nx-json';
 import { output } from '../../utils/output';
-import { getNxRequirePaths } from '../../utils/installation-directory';
+import { retrieveProjectConfigurationPaths } from '../../project-graph/utils/retrieve-workspace-files';
 
 export { readNxJson, updateNxJson } from './nx-json';
 export {
@@ -183,11 +181,7 @@ function readAndCombineAllProjectConfigurations(tree: Tree): {
 } {
   const nxJson = readNxJson(tree);
 
-  const globbedFiles = globForProjectFiles(
-    tree.root,
-    getGlobPatternsFromPlugins(nxJson, getNxRequirePaths(tree.root), tree.root),
-    nxJson
-  ).map(normalizePath);
+  const globbedFiles = retrieveProjectConfigurationPaths(tree.root, nxJson);
   const createdFiles = findCreatedProjectFiles(tree);
   const deletedFiles = findDeletedProjectFiles(tree);
   const projectFiles = [...globbedFiles, ...createdFiles].filter(

--- a/packages/nx/src/migrations/update-15-1-0/set-project-names.ts
+++ b/packages/nx/src/migrations/update-15-1-0/set-project-names.ts
@@ -1,25 +1,13 @@
 import { Tree } from '../../generators/tree';
 import { readNxJson } from '../../generators/utils/nx-json';
-import {
-  getGlobPatternsFromPluginsAsync,
-  globForProjectFiles,
-} from '../../config/workspaces';
 import { dirname } from 'path';
 import { readJson, writeJson } from '../../generators/utils/json';
 import { formatChangedFilesWithPrettierIfAvailable } from '../../generators/internal-utils/format-changed-files-with-prettier-if-available';
-import { getNxRequirePaths } from '../../utils/installation-directory';
+import { retrieveProjectConfigurationPaths } from '../../project-graph/utils/retrieve-workspace-files';
 
 export default async function (tree: Tree) {
   const nxJson = readNxJson(tree);
-  const projectFiles = globForProjectFiles(
-    tree.root,
-    await getGlobPatternsFromPluginsAsync(
-      nxJson,
-      getNxRequirePaths(tree.root),
-      tree.root
-    ),
-    nxJson
-  );
+  const projectFiles = retrieveProjectConfigurationPaths(tree.root, nxJson);
   const projectJsons = projectFiles.filter((f) => f.endsWith('project.json'));
 
   for (let f of projectJsons) {

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -38,6 +38,8 @@ export const enum WorkspaceErrors {
   Generic = 'Generic'
 }
 /** Get workspace config files based on provided globs */
+export function getProjectConfigurationFiles(workspaceRoot: string, globs: Array<string>): Array<string>
+/** Get workspace config files based on provided globs */
 export function getProjectConfigurations(workspaceRoot: string, globs: Array<string>, parseConfigurations: (arg0: Array<string>) => Record<string, object>): Record<string, object>
 export interface NxWorkspaceFiles {
   projectFileMap: Record<string, Array<FileData>>

--- a/packages/nx/src/native/index.js
+++ b/packages/nx/src/native/index.js
@@ -246,7 +246,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { expandOutputs, remove, copy, hashArray, hashFile, hashFiles, hashFilesMatchingGlobs, ImportResult, findImports, EventType, Watcher, WorkspaceErrors, getProjectConfigurations, getWorkspaceFilesNative } = nativeBinding
+const { expandOutputs, remove, copy, hashArray, hashFile, hashFiles, hashFilesMatchingGlobs, ImportResult, findImports, EventType, Watcher, WorkspaceErrors, getProjectConfigurationFiles, getProjectConfigurations, getWorkspaceFilesNative } = nativeBinding
 
 module.exports.expandOutputs = expandOutputs
 module.exports.remove = remove
@@ -260,5 +260,6 @@ module.exports.findImports = findImports
 module.exports.EventType = EventType
 module.exports.Watcher = Watcher
 module.exports.WorkspaceErrors = WorkspaceErrors
+module.exports.getProjectConfigurationFiles = getProjectConfigurationFiles
 module.exports.getProjectConfigurations = getProjectConfigurations
 module.exports.getWorkspaceFilesNative = getWorkspaceFilesNative

--- a/packages/nx/src/native/workspace/get_config_files.rs
+++ b/packages/nx/src/native/workspace/get_config_files.rs
@@ -9,6 +9,28 @@ use std::path::{Path, PathBuf};
 
 #[napi]
 /// Get workspace config files based on provided globs
+pub fn get_project_configuration_files(
+    workspace_root: String,
+    globs: Vec<String>,
+) -> napi::Result<Vec<String>> {
+    let globs = build_glob_set(&globs)?;
+    let config_paths: Vec<String> = nx_walker(workspace_root, move |rec| {
+        let mut config_paths: HashMap<PathBuf, PathBuf> = HashMap::new();
+        for (path, _) in rec {
+            insert_config_file_into_map(path, &mut config_paths, &globs);
+        }
+
+        config_paths
+            .into_values()
+            .map(|p| p.to_normalized_string())
+            .collect()
+    });
+
+    Ok(config_paths)
+}
+
+#[napi]
+/// Get workspace config files based on provided globs
 pub fn get_project_configurations<ConfigurationParser>(
     workspace_root: String,
     globs: Vec<String>,

--- a/packages/nx/src/project-graph/utils/retrieve-workspace-files.spec.ts
+++ b/packages/nx/src/project-graph/utils/retrieve-workspace-files.spec.ts
@@ -1,10 +1,10 @@
-import { TempFs } from '../utils/testing/temp-fs';
-import { globForProjectFiles } from './workspaces';
+import { TempFs } from '../../utils/testing/temp-fs';
+import { retrieveProjectConfigurationPaths } from './retrieve-workspace-files';
 
-describe('globForProjectFiles', () => {
+describe('retrieveProjectConfigurationPaths', () => {
   let fs: TempFs;
   beforeAll(() => {
-    fs = new TempFs('glob-for-project-files');
+    fs = new TempFs('retrieveProjectConfigurationPaths');
   });
   afterAll(() => {
     fs.cleanup();
@@ -24,10 +24,10 @@ describe('globForProjectFiles', () => {
         name: 'project-1',
       })
     );
-    expect(globForProjectFiles(fs.tempDir, [])).not.toContain(
+    expect(retrieveProjectConfigurationPaths(fs.tempDir, {})).not.toContain(
       'not-projects/project.json'
     );
-    expect(globForProjectFiles(fs.tempDir, [])).toContain(
+    expect(retrieveProjectConfigurationPaths(fs.tempDir, {})).toContain(
       'projects/project.json'
     );
   });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

There is a function called `globForProjects` which duplicates the behavior in `retrieveProjectConfigurations`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`globForProjects` is removed and globbing is done via Rust.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
