### PR TITLE
feat(vite): include env files in sharedGlobals for vite projects

### DIFF
--- a/packages/vite/src/generators/init/__snapshots__/init.spec.ts.snap
+++ b/packages/vite/src/generators/init/__snapshots__/init.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`@nx/vite:init dependencies for package.json should add required packages 1`] = `
+exports[`@nx/vite:init vite basic setup should add required packages 1`] = `
 {
   "dependencies": {
     "existing": "1.0.0",

--- a/packages/vite/src/generators/init/init.spec.ts
+++ b/packages/vite/src/generators/init/init.spec.ts
@@ -22,7 +22,6 @@ import { initGenerator } from './init';
 
 describe('@nx/vite:init', () => {
   let tree: Tree;
-
   beforeEach(() => {
     tree = createTreeWithEmptyWorkspace();
     projectGraph = {
@@ -31,7 +30,7 @@ describe('@nx/vite:init', () => {
     };
   });
 
-  describe('dependencies for package.json', () => {
+  describe('vite basic setup', () => {
     it('should add required packages', async () => {
       const existing = 'existing';
       const existingVersion = '1.0.0';
@@ -44,8 +43,20 @@ describe('@nx/vite:init', () => {
         addPlugin: true,
       });
       const packageJson = readJson(tree, 'package.json');
-
       expect(packageJson).toMatchSnapshot();
+    });
+
+    it('should add sharedGlobals for .env if sharedGlobals is defined', async () => {
+      updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+        json.namedInputs ??= {};
+        json.namedInputs.sharedGlobals = [];
+        return json;
+      });
+      await initGenerator(tree, {});
+      const sharedGlobalsNamedInputs = readJson(tree, 'nx.json').namedInputs
+        .sharedGlobals;
+      console.log(sharedGlobalsNamedInputs);
+      expect(sharedGlobalsNamedInputs).toContain('{workspaceRoot}/.env?(.*)');
     });
   });
 

--- a/packages/vite/src/generators/init/init.ts
+++ b/packages/vite/src/generators/init/init.ts
@@ -42,6 +42,11 @@ export function updateNxJsonSettings(tree: Tree) {
     ];
   }
 
+  const sharedGlobalsFileSet = nxJson.namedInputs?.sharedGlobals;
+  if (sharedGlobalsFileSet) {
+    sharedGlobalsFileSet.push('{workspaceRoot}/.env?(.*)');
+  }
+
   updateNxJson(tree, nxJson);
 }
 


### PR DESCRIPTION
Vite will take env vars from envDir https://vitejs.dev/config/shared-options.html#envdir which defaults to `root`, which defaults to `process.cwd()`, which in the case of an nx project is the `{workspaceRoot}`.

This PR adds `'{workspaceRoot}/.env?(.*)'` to the `namedInputs.sharedGlobals` in the vite init generator.

From the [vite docs on env files](https://vitejs.dev/guide/env-and-mode.html#env-files):

> ```
> .env                # loaded in all cases
> .env.local          # loaded in all cases, ignored by git
> .env.[mode]         # only loaded in specified mode
> .env.[mode].local   # only loaded in specified mode, ignored by git
> ```

The `'{workspaceRoot}/.env?(.*)'` pattern will work for all patterns listed above, but not for example with a filed named `.envrc`.

## Current Behavior

`.env` files are not watched for affected detection even though vite depends on these

## Expected Behavior

`.env` files should be considered as inputs when using vite