### PR TITLE
feat(core): expand support for projectRoot token to include project.json

### DIFF
--- a/e2e/nx-run/src/run.test.ts
+++ b/e2e/nx-run/src/run.test.ts
@@ -115,6 +115,73 @@ describe('Nx Running Tests', () => {
 
       updateProjectConfig(mylib, (c) => original);
     }, 1000000);
+
+    describe('tokens support', () => {
+      let app: string;
+
+      beforeAll(() => {
+        app = uniq('myapp');
+        runCLI(`generate @nx/web:app ${app}`);
+      });
+
+      it('should support using {projectRoot} in options blocks in project.json', async () => {
+        updateProjectConfig(app, (c) => {
+          c.targets['echo'] = {
+            command: `node -e 'console.log("{projectRoot}")'`,
+          };
+          return c;
+        });
+
+        const output = runCLI(`echo ${app}`);
+        expect(output).toContain(`apps/${app}`);
+      });
+
+      it('should support using {projectName} in options blocks in project.json', async () => {
+        updateProjectConfig(app, (c) => {
+          c.targets['echo'] = {
+            command: `node -e 'console.log("{projectName}")'`,
+          };
+          return c;
+        });
+
+        const output = runCLI(`echo ${app}`);
+        expect(output).toContain(app);
+      });
+
+      it('should support using {projectRoot} in targetDefaults', async () => {
+        updateJson(`nx.json`, (json) => {
+          json.targetDefaults = {
+            echo: {
+              command: `node -e 'console.log("{projectRoot}")'`,
+            },
+          };
+          return json;
+        });
+        updateProjectConfig(app, (c) => {
+          c.targets['echo'] = {};
+          return c;
+        });
+        const output = runCLI(`echo ${app}`);
+        expect(output).toContain(`apps/${app}`);
+      });
+
+      it('should support using {projectName} in targetDefaults', async () => {
+        updateJson(`nx.json`, (json) => {
+          json.targetDefaults = {
+            echo: {
+              command: `node -e 'console.log("{projectName}")'`,
+            },
+          };
+          return json;
+        });
+        updateProjectConfig(app, (c) => {
+          c.targets['echo'] = {};
+          return c;
+        });
+        const output = runCLI(`echo ${app}`);
+        expect(output).toContain(app);
+      });
+    });
   });
 
   describe('Nx Bail', () => {

--- a/packages/nx/src/config/workspaces.spec.ts
+++ b/packages/nx/src/config/workspaces.spec.ts
@@ -256,30 +256,6 @@ describe('Workspaces', () => {
           ).options
         ).toEqual({ a: 'project-value' });
       });
-
-      it('should resolve workspaceRoot and projectRoot tokens', () => {
-        expect(
-          mergeTargetConfigurations(
-            {
-              root: 'my/project',
-              targets: {
-                build: {
-                  options: {
-                    a: '{workspaceRoot}',
-                  },
-                },
-              },
-            },
-            'build',
-            {
-              executor: 'target',
-              options: {
-                b: '{workspaceRoot}/dist/{projectRoot}',
-              },
-            }
-          ).options
-        ).toEqual({ a: '{workspaceRoot}', b: 'dist/my/project' });
-      });
     });
 
     describe('configurations', () => {
@@ -391,37 +367,6 @@ describe('Workspaces', () => {
             }
           ).configurations
         ).toEqual(projectConfigurations);
-      });
-
-      it('should resolve workspaceRoot and projectRoot tokens', () => {
-        expect(
-          mergeTargetConfigurations(
-            {
-              root: 'my/project',
-              targets: {
-                build: {
-                  configurations: {
-                    dev: {
-                      a: '{workspaceRoot}',
-                    },
-                  },
-                },
-              },
-            },
-            'build',
-            {
-              executor: 'target',
-              configurations: {
-                prod: {
-                  a: '{workspaceRoot}/dist/{projectRoot}',
-                },
-              },
-            }
-          ).configurations
-        ).toEqual({
-          dev: { a: '{workspaceRoot}' },
-          prod: { a: 'dist/my/project' },
-        });
       });
     });
 

--- a/packages/nx/src/project-graph/build-nodes/workspace-projects.spec.ts
+++ b/packages/nx/src/project-graph/build-nodes/workspace-projects.spec.ts
@@ -1,5 +1,8 @@
 import { ProjectGraphProjectNode } from '../../config/project-graph';
-import { normalizeImplicitDependencies } from './workspace-projects';
+import {
+  normalizeImplicitDependencies,
+  normalizeProjectTargets,
+} from './workspace-projects';
 
 describe('workspace-projects', () => {
   let projectGraph: Record<string, ProjectGraphProjectNode> = {
@@ -73,6 +76,230 @@ describe('workspace-projects', () => {
       expect(
         normalizeImplicitDependencies('test-project', ['b*'], projectGraphMod)
       ).toEqual(['b', 'b-1', 'b-2']);
+    });
+  });
+
+  describe('normalizeTargets', () => {
+    it('should apply target defaults', () => {
+      expect(
+        normalizeProjectTargets(
+          {
+            root: 'my/project',
+            targets: {
+              build: {
+                executor: 'target',
+                options: {
+                  a: 'a',
+                },
+              },
+            },
+          },
+          {
+            build: {
+              executor: 'target',
+              options: {
+                b: 'b',
+              },
+            },
+          },
+          'build'
+        ).build.options
+      ).toEqual({ a: 'a', b: 'b' });
+    });
+
+    it('should overwrite target defaults when type doesnt match or provided an array', () => {
+      expect(
+        normalizeProjectTargets(
+          {
+            root: 'my/project',
+            targets: {
+              build: {
+                executor: 'target',
+                options: {
+                  a: 'a',
+                  b: ['project-value'],
+                  c: 'project-value',
+                },
+              },
+            },
+          },
+          {
+            build: {
+              executor: 'target',
+              options: {
+                a: 1,
+                b: ['default-value'],
+                c: ['default-value'],
+              },
+            },
+          },
+          'build'
+        ).build.options
+      ).toEqual({ a: 'a', b: ['project-value'], c: 'project-value' });
+    });
+
+    it('should overwrite object options from target defaults', () => {
+      expect(
+        normalizeProjectTargets(
+          {
+            root: 'my/project',
+            targets: {
+              build: {
+                executor: 'target',
+                options: {
+                  a: 'a',
+                  b: {
+                    a: 'a',
+                    b: 'project-value',
+                  },
+                },
+              },
+            },
+          },
+          {
+            build: {
+              executor: 'target',
+              options: {
+                b: {
+                  b: 'default-value',
+                  c: 'c',
+                },
+              },
+            },
+          },
+          'build'
+        ).build.options
+      ).toEqual({
+        a: 'a',
+        b: {
+          a: 'a',
+          b: 'project-value',
+        },
+      });
+    });
+
+    it('should convert command property to run-commands executor', () => {
+      expect(
+        normalizeProjectTargets(
+          {
+            root: 'my/project',
+            targets: {
+              build: {
+                command: 'echo',
+              },
+            },
+          },
+          {},
+          'build'
+        ).build
+      ).toEqual({
+        executor: 'nx:run-commands',
+        options: {
+          command: 'echo',
+        },
+      });
+    });
+
+    it('should support {projectRoot}, {workspaceRoot}, and {projectName} tokens', () => {
+      expect(
+        normalizeProjectTargets(
+          {
+            name: 'project',
+            root: 'my/project',
+            targets: {
+              build: {
+                executor: 'target',
+                options: {
+                  a: '{projectRoot}',
+                  b: '{workspaceRoot}',
+                  c: '{projectName}',
+                },
+              },
+            },
+          },
+          {},
+          'build'
+        ).build.options
+      ).toEqual({ a: 'my/project', b: '', c: 'project' });
+    });
+
+    it('should suppport {projectRoot} token in targetDefaults', () => {
+      expect(
+        normalizeProjectTargets(
+          {
+            name: 'project',
+            root: 'my/project',
+            targets: {
+              build: {
+                executor: 'target',
+                options: {
+                  a: 'a',
+                },
+              },
+            },
+          },
+          {
+            build: {
+              executor: 'target',
+              options: {
+                b: '{projectRoot}',
+              },
+            },
+          },
+          'build'
+        ).build.options
+      ).toEqual({ a: 'a', b: 'my/project' });
+    });
+
+    it('should not merge options when targets use different executors', () => {
+      expect(
+        normalizeProjectTargets(
+          {
+            root: 'my/project',
+            targets: {
+              build: {
+                executor: 'target',
+                options: {
+                  a: 'a',
+                },
+              },
+            },
+          },
+          {
+            build: {
+              executor: 'different-target',
+              options: {
+                b: 'c',
+              },
+            },
+          },
+          'build'
+        ).build.options
+      ).toEqual({ a: 'a' });
+    });
+
+    it('should not merge options when either target or target defaults use `command`', () => {
+      expect(
+        normalizeProjectTargets(
+          {
+            root: 'my/project',
+            targets: {
+              build: {
+                command: 'echo',
+              },
+            },
+          },
+          {
+            build: {
+              executor: 'target',
+              options: {
+                b: 'c',
+              },
+            },
+          },
+          'build'
+        ).build.options
+      ).toEqual({ command: 'echo' });
     });
   });
 });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`{projectRoot}`, `{projectName}`, and `{workspaceRoot}` only work inside options or configurations blocks as part of `targetDefaults` in `nx.json`, but works in `inputs` / `outputs` in `project.json` already.

## Expected Behavior
`{projectRoot}`, `{projectName}`, and `{workspaceRoot}` only work inside `inputs`, `outputs`, `options`, and `configurations` everywhere.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #13272
