### PR TITLE
chore(misc): remove usage of deprecated updateBuildableProjectDepsInPackageJson option

### DIFF
--- a/packages-legacy/angular/project.json
+++ b/packages-legacy/angular/project.json
@@ -20,7 +20,6 @@
         "main": "packages-legacy/angular/index.ts",
         "tsConfig": "packages-legacy/angular/tsconfig.json",
         "outputPath": "build/packages/angular-legacy",
-        "updateBuildableProjectDepsInPackageJson": false,
         "assets": [
           {
             "input": "packages-legacy/angular",

--- a/packages-legacy/cypress/project.json
+++ b/packages-legacy/cypress/project.json
@@ -14,7 +14,6 @@
         "main": "packages-legacy/cypress/index.ts",
         "tsConfig": "packages-legacy/cypress/tsconfig.json",
         "outputPath": "build/packages/cypress-legacy",
-        "updateBuildableProjectDepsInPackageJson": false,
         "assets": [
           {
             "input": "packages-legacy/cypress",

--- a/packages-legacy/detox/project.json
+++ b/packages-legacy/detox/project.json
@@ -14,7 +14,6 @@
         "main": "packages-legacy/detox/index.ts",
         "tsConfig": "packages-legacy/detox/tsconfig.json",
         "outputPath": "build/packages/detox-legacy",
-        "updateBuildableProjectDepsInPackageJson": false,
         "assets": [
           {
             "input": "packages-legacy/detox",

--- a/packages-legacy/devkit/project.json
+++ b/packages-legacy/devkit/project.json
@@ -14,7 +14,6 @@
         "main": "packages-legacy/devkit/index.ts",
         "tsConfig": "packages-legacy/devkit/tsconfig.json",
         "outputPath": "build/packages/devkit-legacy",
-        "updateBuildableProjectDepsInPackageJson": false,
         "assets": [
           {
             "input": "packages-legacy/devkit",

--- a/packages-legacy/esbuild/project.json
+++ b/packages-legacy/esbuild/project.json
@@ -14,7 +14,6 @@
         "main": "packages-legacy/esbuild/index.ts",
         "tsConfig": "packages-legacy/esbuild/tsconfig.json",
         "outputPath": "build/packages/esbuild-legacy",
-        "updateBuildableProjectDepsInPackageJson": false,
         "assets": [
           {
             "input": "packages-legacy/esbuild",

--- a/packages-legacy/eslint-plugin-nx/project.json
+++ b/packages-legacy/eslint-plugin-nx/project.json
@@ -14,7 +14,6 @@
         "main": "packages-legacy/eslint-plugin-nx/index.ts",
         "tsConfig": "packages-legacy/eslint-plugin-nx/tsconfig.json",
         "outputPath": "build/packages/eslint-plugin-nx-legacy",
-        "updateBuildableProjectDepsInPackageJson": false,
         "assets": [
           {
             "input": "packages-legacy/eslint-plugin-nx",

--- a/packages-legacy/expo/project.json
+++ b/packages-legacy/expo/project.json
@@ -14,7 +14,6 @@
         "main": "packages-legacy/expo/index.ts",
         "tsConfig": "packages-legacy/expo/tsconfig.json",
         "outputPath": "build/packages/expo-legacy",
-        "updateBuildableProjectDepsInPackageJson": false,
         "assets": [
           {
             "input": "packages-legacy/expo",

--- a/packages-legacy/express/project.json
+++ b/packages-legacy/express/project.json
@@ -14,7 +14,6 @@
         "main": "packages-legacy/express/index.ts",
         "tsConfig": "packages-legacy/express/tsconfig.json",
         "outputPath": "build/packages/express-legacy",
-        "updateBuildableProjectDepsInPackageJson": false,
         "assets": [
           {
             "input": "packages-legacy/express",

--- a/packages-legacy/jest/project.json
+++ b/packages-legacy/jest/project.json
@@ -14,7 +14,6 @@
         "main": "packages-legacy/jest/index.ts",
         "tsConfig": "packages-legacy/jest/tsconfig.json",
         "outputPath": "build/packages/jest-legacy",
-        "updateBuildableProjectDepsInPackageJson": false,
         "assets": [
           {
             "input": "packages-legacy/jest",

--- a/packages-legacy/js/project.json
+++ b/packages-legacy/js/project.json
@@ -14,7 +14,6 @@
         "main": "packages-legacy/js/index.ts",
         "tsConfig": "packages-legacy/js/tsconfig.json",
         "outputPath": "build/packages/js-legacy",
-        "updateBuildableProjectDepsInPackageJson": false,
         "assets": [
           {
             "input": "packages-legacy/js",

--- a/packages-legacy/linter/project.json
+++ b/packages-legacy/linter/project.json
@@ -14,7 +14,6 @@
         "main": "packages-legacy/linter/index.ts",
         "tsConfig": "packages-legacy/linter/tsconfig.json",
         "outputPath": "build/packages/linter-legacy",
-        "updateBuildableProjectDepsInPackageJson": false,
         "assets": [
           {
             "input": "packages-legacy/linter",

--- a/packages-legacy/nest/project.json
+++ b/packages-legacy/nest/project.json
@@ -14,7 +14,6 @@
         "main": "packages-legacy/nest/index.ts",
         "tsConfig": "packages-legacy/nest/tsconfig.json",
         "outputPath": "build/packages/nest-legacy",
-        "updateBuildableProjectDepsInPackageJson": false,
         "assets": [
           {
             "input": "packages-legacy/nest",

--- a/packages-legacy/next/project.json
+++ b/packages-legacy/next/project.json
@@ -14,7 +14,6 @@
         "main": "packages-legacy/next/index.ts",
         "tsConfig": "packages-legacy/next/tsconfig.json",
         "outputPath": "build/packages/next-legacy",
-        "updateBuildableProjectDepsInPackageJson": false,
         "assets": [
           {
             "input": "packages-legacy/next",

--- a/packages-legacy/node/project.json
+++ b/packages-legacy/node/project.json
@@ -14,7 +14,6 @@
         "main": "packages-legacy/node/index.ts",
         "tsConfig": "packages-legacy/node/tsconfig.json",
         "outputPath": "build/packages/node-legacy",
-        "updateBuildableProjectDepsInPackageJson": false,
         "assets": [
           {
             "input": "packages-legacy/node",

--- a/packages-legacy/nx-plugin/project.json
+++ b/packages-legacy/nx-plugin/project.json
@@ -14,7 +14,6 @@
         "main": "packages-legacy/nx-plugin/index.ts",
         "tsConfig": "packages-legacy/nx-plugin/tsconfig.json",
         "outputPath": "build/packages/nx-plugin-legacy",
-        "updateBuildableProjectDepsInPackageJson": false,
         "assets": [
           {
             "input": "packages-legacy/nx-plugin",

--- a/packages-legacy/react-native/project.json
+++ b/packages-legacy/react-native/project.json
@@ -14,7 +14,6 @@
         "main": "packages-legacy/react-native/index.ts",
         "tsConfig": "packages-legacy/react-native/tsconfig.json",
         "outputPath": "build/packages/react-native-legacy",
-        "updateBuildableProjectDepsInPackageJson": false,
         "assets": [
           {
             "input": "packages-legacy/react-native",

--- a/packages-legacy/react/project.json
+++ b/packages-legacy/react/project.json
@@ -14,7 +14,6 @@
         "main": "packages-legacy/react/index.ts",
         "tsConfig": "packages-legacy/react/tsconfig.json",
         "outputPath": "build/packages/react-legacy",
-        "updateBuildableProjectDepsInPackageJson": false,
         "assets": [
           {
             "input": "packages-legacy/react",

--- a/packages-legacy/rollup/project.json
+++ b/packages-legacy/rollup/project.json
@@ -14,7 +14,6 @@
         "main": "packages-legacy/rollup/index.ts",
         "tsConfig": "packages-legacy/rollup/tsconfig.json",
         "outputPath": "build/packages/rollup-legacy",
-        "updateBuildableProjectDepsInPackageJson": false,
         "assets": [
           {
             "input": "packages-legacy/rollup",

--- a/packages-legacy/storybook/project.json
+++ b/packages-legacy/storybook/project.json
@@ -14,7 +14,6 @@
         "main": "packages-legacy/storybook/index.ts",
         "tsConfig": "packages-legacy/storybook/tsconfig.json",
         "outputPath": "build/packages/storybook-legacy",
-        "updateBuildableProjectDepsInPackageJson": false,
         "assets": [
           {
             "input": "packages-legacy/storybook",

--- a/packages-legacy/vite/project.json
+++ b/packages-legacy/vite/project.json
@@ -14,7 +14,6 @@
         "main": "packages-legacy/vite/index.ts",
         "tsConfig": "packages-legacy/vite/tsconfig.json",
         "outputPath": "build/packages/vite-legacy",
-        "updateBuildableProjectDepsInPackageJson": false,
         "assets": [
           {
             "input": "packages-legacy/vite",

--- a/packages-legacy/web/project.json
+++ b/packages-legacy/web/project.json
@@ -14,7 +14,6 @@
         "main": "packages-legacy/web/index.ts",
         "tsConfig": "packages-legacy/web/tsconfig.json",
         "outputPath": "build/packages/web-legacy",
-        "updateBuildableProjectDepsInPackageJson": false,
         "assets": [
           {
             "input": "packages-legacy/web",

--- a/packages-legacy/webpack/project.json
+++ b/packages-legacy/webpack/project.json
@@ -14,7 +14,6 @@
         "main": "packages-legacy/webpack/index.ts",
         "tsConfig": "packages-legacy/webpack/tsconfig.json",
         "outputPath": "build/packages/webpack-legacy",
-        "updateBuildableProjectDepsInPackageJson": false,
         "assets": [
           {
             "input": "packages-legacy/webpack",

--- a/packages-legacy/workspace/project.json
+++ b/packages-legacy/workspace/project.json
@@ -14,7 +14,6 @@
         "main": "packages-legacy/workspace/index.ts",
         "tsConfig": "packages-legacy/workspace/tsconfig.json",
         "outputPath": "build/packages/workspace-legacy",
-        "updateBuildableProjectDepsInPackageJson": false,
         "assets": [
           {
             "input": "packages-legacy/workspace",

--- a/packages/vite/project.json
+++ b/packages/vite/project.json
@@ -18,7 +18,6 @@
         "outputPath": "build/packages/vite",
         "tsConfig": "packages/vite/tsconfig.lib.json",
         "main": "packages/vite/index.ts",
-        "updateBuildableProjectDepsInPackageJson": false,
         "assets": [
           {
             "input": "packages/vite",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Building the packages in the repo log a warning about using the deprecated `updateBuildableProjectDepsInPackageJson` option. The projects in the repo set that option to `false` which is no longer needed because that's the default value for that option.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Building the packages in the repo should not log a warning about using the deprecated `updateBuildableProjectDepsInPackageJson` option.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
