### PR TITLE
fix(core): fix migration and warn for invalid outputs

### DIFF
--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -77,6 +77,12 @@
       "version": "16.2.0-beta.0",
       "description": "Remove outputPath from run commands",
       "implementation": "./src/migrations/update-16-2-0/remove-run-commands-output-path"
+    },
+    "16.6.0-prefix-outputs": {
+      "cli": "nx",
+      "version": "16.6.0-beta.6",
+      "description": "Prefix outputs with {workspaceRoot}/{projectRoot} if needed",
+      "implementation": "./src/migrations/update-15-0-0/prefix-outputs"
     }
   }
 }

--- a/packages/nx/src/migrations/update-15-0-0/prefix-outputs.spec.ts
+++ b/packages/nx/src/migrations/update-15-0-0/prefix-outputs.spec.ts
@@ -91,7 +91,7 @@ describe('15.0.0 migration (prefix-outputs)', () => {
       nx: {
         targets: {
           build: {
-            outputs: ['dist/proj'],
+            outputs: ['dist/proj', 'proj/build'],
           },
         },
       },
@@ -101,7 +101,7 @@ describe('15.0.0 migration (prefix-outputs)', () => {
     await prefixOutputs(tree);
 
     expect(readJson(tree, 'proj/package.json').nx.targets.build).toEqual({
-      outputs: ['dist/proj'],
+      outputs: ['{workspaceRoot}/dist/proj', '{projectRoot}/build'],
     });
   });
 

--- a/packages/nx/src/migrations/update-15-0-0/prefix-outputs.ts
+++ b/packages/nx/src/migrations/update-15-0-0/prefix-outputs.ts
@@ -23,11 +23,7 @@ export default async function (tree: Tree) {
   const nxJson = readNxJson(tree);
 
   for (const [projectName, project] of getProjects(tree)) {
-    if (!project.targets) {
-      continue;
-    }
-
-    for (const [_, target] of Object.entries(project.targets)) {
+    for (const [_, target] of Object.entries(project.targets ?? {})) {
       if (!target.outputs) {
         continue;
       }
@@ -46,8 +42,15 @@ export default async function (tree: Tree) {
           tree,
           join(project.root, 'package.json'),
           (json) => {
-            json.nx ??= {};
-            json.nx.targets ??= project.targets;
+            for (const target of Object.values(json.nx?.targets ?? {})) {
+              if (target.outputs) {
+                try {
+                  validateOutputs(target.outputs);
+                } catch (e) {
+                  target.outputs = transformLegacyOutputs(project.root, e);
+                }
+              }
+            }
 
             return json;
           }

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -164,7 +164,8 @@ export function getOutputsForTargetAndConfiguration(
       validateOutputs(targetConfiguration.outputs);
     } catch (error) {
       if (error instanceof InvalidOutputsError) {
-        // TODO(v16): start warning for invalid outputs
+        // TODO(@FrozenPandaz): In v17, throw this error and do not transform.
+        console.warn(error.message);
         targetConfiguration.outputs = transformLegacyOutputs(
           node.data.root,
           error


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Invalid outputs (without the `{projectRoot}` or `{workspaceRoot}` are silently transformed and could be transformed incorrectly. This results in users not really knowing why caching is not working.

There was a migration for this way back in Nx `15.0.0` but it does not work for `package.json` projects.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Invalid outputs (without the `{projectRoot}` or `{workspaceRoot}` will now result in a warning. This will turn into an error in v17. The warning will instruct users to run `nx repair` to easily fix it.

The migration is rerun again and it works properly for `package.json`.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/18289
