### PR TITLE
feat(graph): add more graph to editor communication

### DIFF
--- a/graph/client/src/app/external-api.ts
+++ b/graph/client/src/app/external-api.ts
@@ -26,6 +26,7 @@ export class ExternalApi {
   private openProjectConfigCallbackListeners: ((
     projectName: string
   ) => void)[] = [];
+  private runTaskCallbackListeners: ((taskId: string) => void)[] = [];
 
   get depGraphService() {
     return this.projectGraphService;
@@ -41,6 +42,9 @@ export class ExternalApi {
         this.openProjectConfigCallbackListeners.forEach((cb) =>
           cb(event.projectName)
         );
+      }
+      if (event.type === 'RunTaskClick') {
+        this.runTaskCallbackListeners.forEach((cb) => cb(event.taskId));
       }
     });
   }
@@ -68,6 +72,9 @@ export class ExternalApi {
   }
   registerOpenProjectConfigCallback(callback: (projectName: string) => void) {
     this.openProjectConfigCallbackListeners.push(callback);
+  }
+  registerRunTaskCallback(callback: (taskId: string) => void) {
+    this.runTaskCallbackListeners.push(callback);
   }
 
   private handleLegacyProjectGraphEvent(event: ProjectGraphMachineEvents) {

--- a/graph/client/src/app/external-api.ts
+++ b/graph/client/src/app/external-api.ts
@@ -23,6 +23,9 @@ export class ExternalApi {
   };
 
   private fileClickCallbackListeners: ((url: string) => void)[] = [];
+  private openProjectConfigCallbackListeners: ((
+    projectName: string
+  ) => void)[] = [];
 
   get depGraphService() {
     return this.projectGraphService;
@@ -33,6 +36,11 @@ export class ExternalApi {
       if (event.type === 'FileLinkClick') {
         const url = `${event.sourceRoot}/${event.file}`;
         this.fileClickCallbackListeners.forEach((cb) => cb(url));
+      }
+      if (event.type === 'ProjectOpenConfigClick') {
+        this.openProjectConfigCallbackListeners.forEach((cb) =>
+          cb(event.projectName)
+        );
       }
     });
   }
@@ -57,6 +65,9 @@ export class ExternalApi {
 
   registerFileClickCallback(callback: (url: string) => void) {
     this.fileClickCallbackListeners.push(callback);
+  }
+  registerOpenProjectConfigCallback(callback: (projectName: string) => void) {
+    this.openProjectConfigCallbackListeners.push(callback);
   }
 
   private handleLegacyProjectGraphEvent(event: ProjectGraphMachineEvents) {

--- a/graph/ui-graph/src/lib/graph-interaction-events.ts
+++ b/graph/ui-graph/src/lib/graph-interaction-events.ts
@@ -38,10 +38,16 @@ interface FileLinkClickEvent {
   file: string;
 }
 
+interface ProjectOpenConfigClickEvent {
+  type: 'ProjectOpenConfigClick';
+  projectName: string;
+}
+
 export type GraphInteractionEvents =
   | ProjectNodeClickEvent
   | EdgeClickEvent
   | GraphRegeneratedEvent
   | TaskNodeClickEvent
   | BackgroundClickEvent
-  | FileLinkClickEvent;
+  | FileLinkClickEvent
+  | ProjectOpenConfigClickEvent;

--- a/graph/ui-graph/src/lib/graph-interaction-events.ts
+++ b/graph/ui-graph/src/lib/graph-interaction-events.ts
@@ -43,6 +43,11 @@ interface ProjectOpenConfigClickEvent {
   projectName: string;
 }
 
+interface RunTaskClickEvent {
+  type: 'RunTaskClick';
+  taskId: string;
+}
+
 export type GraphInteractionEvents =
   | ProjectNodeClickEvent
   | EdgeClickEvent
@@ -50,4 +55,5 @@ export type GraphInteractionEvents =
   | TaskNodeClickEvent
   | BackgroundClickEvent
   | FileLinkClickEvent
-  | ProjectOpenConfigClickEvent;
+  | ProjectOpenConfigClickEvent
+  | RunTaskClickEvent;

--- a/graph/ui-graph/src/lib/tooltip-service.ts
+++ b/graph/ui-graph/src/lib/tooltip-service.ts
@@ -37,8 +37,17 @@ export class GraphTooltipService {
           });
           break;
         case 'TaskNodeClick':
+          const runTaskCallback =
+            graph.renderMode === 'nx-console'
+              ? () =>
+                  graph.broadcast({
+                    type: 'RunTaskClick',
+                    taskId: event.data.id,
+                  })
+              : undefined;
           this.openTaskNodeTooltip(event.ref, {
             ...event.data,
+            runTaskCallback,
           });
           break;
         case 'EdgeClick':

--- a/graph/ui-graph/src/lib/tooltip-service.ts
+++ b/graph/ui-graph/src/lib/tooltip-service.ts
@@ -20,11 +20,20 @@ export class GraphTooltipService {
           this.hideAll();
           break;
         case 'ProjectNodeClick':
+          const openConfigCallback =
+            graph.renderMode === 'nx-console'
+              ? () =>
+                  graph.broadcast({
+                    type: 'ProjectOpenConfigClick',
+                    projectName: event.data.id,
+                  })
+              : undefined;
           this.openProjectNodeToolTip(event.ref, {
             id: event.data.id,
             tags: event.data.tags,
             type: event.data.type,
             description: event.data.description,
+            openConfigCallback,
           });
           break;
         case 'TaskNodeClick':

--- a/graph/ui-tooltips/src/lib/project-node-tooltip.tsx
+++ b/graph/ui-tooltips/src/lib/project-node-tooltip.tsx
@@ -22,7 +22,7 @@ export function ProjectNodeToolTip({
 }: ProjectNodeToolTipProps) {
   return (
     <div className="text-sm text-slate-700 dark:text-slate-400">
-      <h4 className="flex justify-between items-center">
+      <h4 className="flex justify-between items-center gap-4">
         <div className="flex items-center">
           <Tag className="mr-3">{type}</Tag>
           <span className="font-mono">{id}</span>

--- a/graph/ui-tooltips/src/lib/project-node-tooltip.tsx
+++ b/graph/ui-tooltips/src/lib/project-node-tooltip.tsx
@@ -1,3 +1,4 @@
+import { PencilSquareIcon } from '@heroicons/react/24/outline';
 import { Tag } from '@nx/graph/ui-components';
 import { ReactNode } from 'react';
 
@@ -6,6 +7,7 @@ export interface ProjectNodeToolTipProps {
   id: string;
   tags: string[];
   description?: string;
+  openConfigCallback?: () => void;
 
   children?: ReactNode | ReactNode[];
 }
@@ -16,12 +18,24 @@ export function ProjectNodeToolTip({
   tags,
   children,
   description,
+  openConfigCallback,
 }: ProjectNodeToolTipProps) {
   return (
     <div className="text-sm text-slate-700 dark:text-slate-400">
-      <h4>
-        <Tag className="mr-3">{type}</Tag>
-        <span className="font-mono">{id}</span>
+      <h4 className="flex justify-between items-center">
+        <div className="flex items-center">
+          <Tag className="mr-3">{type}</Tag>
+          <span className="font-mono">{id}</span>
+        </div>
+        {openConfigCallback ? (
+          <button
+            className=" flex items-center rounded-md border-slate-300 bg-white p-1 font-medium text-slate-500 shadow-sm ring-1 transition hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-400 dark:ring-slate-600 hover:dark:bg-slate-700"
+            title="Edit project.json in editor"
+            onClick={openConfigCallback}
+          >
+            <PencilSquareIcon className="h-5 w-5" />
+          </button>
+        ) : undefined}
       </h4>
       {tags.length > 0 ? (
         <p className="my-2">

--- a/graph/ui-tooltips/src/lib/task-node-tooltip.tsx
+++ b/graph/ui-tooltips/src/lib/task-node-tooltip.tsx
@@ -1,8 +1,10 @@
+import { PlayIcon } from '@heroicons/react/24/outline';
 import { Tag } from '@nx/graph/ui-components';
 
 export interface TaskNodeTooltipProps {
   id: string;
   executor: string;
+  runTaskCallback?: () => void;
   description?: string;
 }
 
@@ -10,13 +12,26 @@ export function TaskNodeTooltip({
   id,
   executor,
   description,
+  runTaskCallback: runTargetCallback,
 }: TaskNodeTooltipProps) {
   return (
     <div className="text-sm text-slate-700 dark:text-slate-400">
-      <h4>
-        <Tag className="mr-3">{executor}</Tag>
-        <span className="font-mono">{id}</span>
+      <h4 className="flex justify-between items-center gap-4">
+        <div className="flex items-center">
+          <Tag className="mr-3">{executor}</Tag>
+          <span className="font-mono">{id}</span>
+        </div>
+        {runTargetCallback ? (
+          <button
+            className=" flex items-center rounded-md border-slate-300 bg-white p-1 font-medium text-slate-500 shadow-sm ring-1 transition hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-400 dark:ring-slate-600 hover:dark:bg-slate-700"
+            title="Run Task"
+            onClick={runTargetCallback}
+          >
+            <PlayIcon className="h-5 w-5" />
+          </button>
+        ) : undefined}
       </h4>
+      <h4></h4>
       {description ? <p className="mt-4">{description}</p> : null}
     </div>
   );


### PR DESCRIPTION
Building on https://github.com/nrwl/nx/pull/18113, this PR introduces two things that are only visible when rendered in  Nx Console.

1. A new `Edit` button 
Nx Console can consume the events from that button click and open the corresponding `project.json` file.

![image](https://github.com/nrwl/nx/assets/34165455/23e5b997-a34a-4bc5-a174-cefdb06d1810)

I'm not 100% sure about the styles, maybe @bcabanes can weigh in. Alternatively, we could make the project name in the tooltip header clickable (with some hover link styling) but I feel like the button is a lot more discoverable.
So I'm worried that if it's not immediately obvious, noone will use it.

2. A `Run Task` button on the task tooltip 
Nx Console can consume the events and run the task
![image](https://github.com/nrwl/nx/assets/34165455/f46f91f1-5743-4b4a-8c16-36a2a12a3641)


Corresponding Nx Console PR: https://github.com/nrwl/nx-console/pull/1841


