### PR TITLE
fix(core): eslint dep check rule should check prereleases correctly

### DIFF
--- a/packages/eslint-plugin/src/rules/dependency-checks.ts
+++ b/packages/eslint-plugin/src/rules/dependency-checks.ts
@@ -2,12 +2,7 @@ import { join } from 'path';
 import { satisfies } from 'semver';
 import { AST } from 'jsonc-eslint-parser';
 import { type JSONLiteral } from 'jsonc-eslint-parser/lib/parser/ast';
-import {
-  normalizePath,
-  ProjectGraphProjectNode,
-  FileData,
-  workspaceRoot,
-} from '@nx/devkit';
+import { normalizePath, workspaceRoot } from '@nx/devkit';
 import { findNpmDependencies } from '@nx/js/src/utils/find-npm-dependencies';
 
 import { createESLintRule } from '../utils/create-eslint-rule';
@@ -209,7 +204,9 @@ export default createESLintRule<Options, MessageIds>({
       if (
         npmDependencies[packageName] === '*' ||
         packageRange === '*' ||
-        satisfies(npmDependencies[packageName], packageRange)
+        satisfies(npmDependencies[packageName], packageRange, {
+          includePrerelease: true,
+        })
       ) {
         return;
       }


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The dep check rule does not check pre-releases correctly 

This surfaced with #17879
You can see the error here: https://staging.nx.app/runs/21ueB3TkiN/task/angular%3lint
The package versions are here: https://github.com/nrwl/nx/blob/4bae74c060bc29336072aba2a0e4c3a4132fb999/packages/angular/package.json#L71

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Pre-release version should be picked up correctly

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
