### PR TITLE
fix(js): ensure compile swc uses current package manager

### DIFF
--- a/packages/js/src/executors/swc/swc.impl.ts
+++ b/packages/js/src/executors/swc/swc.impl.ts
@@ -120,13 +120,11 @@ export async function* swcExecutor(
   if (!isInlineGraphEmpty(inlineProjectGraph)) {
     options.projectRoot = '.'; // set to root of workspace to include other libs for type check
 
-    // remap paths for SWC compilation
-    options.swcCliOptions.srcPath = options.swcCliOptions.swcCwd;
-    options.swcCliOptions.swcCwd = '.';
-    options.swcCliOptions.destPath = options.swcCliOptions.destPath
-      .split('../')
-      .at(-1)
-      .concat('/', options.swcCliOptions.srcPath);
+    options.swcCliOptions.srcPath = root.split('/').slice(0, -1).join('/'); // set to root of libraries to include other libs
+    options.swcCliOptions.destPath = join(
+      _options.outputPath,
+      options.swcCliOptions.srcPath
+    ); // new destPath is dist/{libs}/{parentLib}/{libs}
 
     // tmp swcrc with dependencies to exclude
     // - buildable libraries

--- a/packages/js/src/utils/swc/compile-swc.ts
+++ b/packages/js/src/utils/swc/compile-swc.ts
@@ -55,8 +55,8 @@ export async function compileSwc(
   }
 
   const swcCmdLog = execSync(getSwcCmd(normalizedOptions.swcCliOptions), {
-    cwd: normalizedOptions.swcCliOptions.swcCwd,
-  }).toString();
+    encoding: 'utf8',
+  });
   logger.log(swcCmdLog.replace(/\n/, ''));
   const isCompileSuccess = swcCmdLog.includes('Successfully compiled');
 

--- a/packages/js/src/utils/swc/compile-swc.ts
+++ b/packages/js/src/utils/swc/compile-swc.ts
@@ -1,4 +1,9 @@
-import { cacheDir, ExecutorContext, logger } from '@nx/devkit';
+import {
+  cacheDir,
+  ExecutorContext,
+  getPackageManagerCommand,
+  logger,
+} from '@nx/devkit';
 import { exec, execSync } from 'child_process';
 import { removeSync } from 'fs-extra';
 import { createAsyncIterable } from '@nx/devkit/src/utils/async-iterable';
@@ -10,7 +15,8 @@ function getSwcCmd(
   { swcrcPath, srcPath, destPath }: SwcCliOptions,
   watch = false
 ) {
-  let swcCmd = `npx swc ${
+  const packageManager = getPackageManagerCommand();
+  let swcCmd = `${packageManager.exec} swc ${
     // TODO(jack): clean this up when we remove inline module support
     // Handle root project
     srcPath === '.' ? 'src' : srcPath
@@ -42,8 +48,6 @@ export async function compileSwc(
   normalizedOptions: NormalizedSwcExecutorOptions,
   postCompilationCallback: () => Promise<void>
 ) {
-  const isRootProject =
-    context.projectGraph.nodes[context.projectName].data.root === '.';
   logger.log(`Compiling with SWC for ${context.projectName}...`);
 
   if (normalizedOptions.clean) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Using Swc compilation on PnP repos fails due to usage of `npx` command.

## Expected Behavior
We should use the original package manager when invoking `swc`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
