### PR TITLE
fix(core): shell script invocation should use yarn for berry

### DIFF
--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -75,7 +75,7 @@ export function getPackageManagerCommand(
         add: useBerry ? 'yarn add' : 'yarn add -W',
         addDev: useBerry ? 'yarn add -D' : 'yarn add -D -W',
         rm: 'yarn remove',
-        exec: useBerry ? 'yarn exec' : 'yarn',
+        exec: 'yarn',
         run: (script: string, args: string) => `yarn ${script} ${args}`,
         list: useBerry ? 'yarn info --name-only' : 'yarn list',
       };


### PR DESCRIPTION
For yarn PnP running `yarn exec` fails since there is no `.bin` in node_modules/

## Current Behavior


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
