### PR TITLE
fix(testing): check if target exists before adding target for jest

### DIFF
--- a/packages/jest/src/generators/configuration/configuration.spec.ts
+++ b/packages/jest/src/generators/configuration/configuration.spec.ts
@@ -3,6 +3,7 @@ import {
   readJson,
   readProjectConfiguration,
   Tree,
+  updateProjectConfiguration,
   writeJson,
 } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
@@ -58,6 +59,19 @@ describe('jestProject', () => {
     expect(tree.exists('libs/lib1/jest.config.ts')).toBeTruthy();
     expect(tree.exists('libs/lib1/tsconfig.spec.json')).toBeTruthy();
     expect(tree.read('libs/lib1/jest.config.ts', 'utf-8')).toMatchSnapshot();
+  });
+
+  it('should add target if there are no targets', async () => {
+    const pc = readProjectConfiguration(tree, 'lib1');
+    delete pc.targets;
+    updateProjectConfiguration(tree, 'lib1', pc);
+    expect(async () => {
+      await configurationGenerator(tree, {
+        ...defaultOptions,
+        project: 'lib1',
+        setupFile: 'angular',
+      });
+    }).not.toThrow();
   });
 
   it('should alter project configuration', async () => {

--- a/packages/jest/src/generators/configuration/lib/update-workspace.ts
+++ b/packages/jest/src/generators/configuration/lib/update-workspace.ts
@@ -12,6 +12,10 @@ export function updateWorkspace(
   options: NormalizedJestProjectSchema
 ) {
   const projectConfig = readProjectConfiguration(tree, options.project);
+  if (!projectConfig.targets) {
+    projectConfig.targets = {};
+  }
+
   projectConfig.targets.test = {
     executor: '@nx/jest:jest',
     outputs: [


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

jest generator assumes there will be a target object when adding test target

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

jest generator defaults targets object before adding test target if it does not exist

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17776
