### PR TITLE
fix(repo): fix silent yarn run on e2e for berry

### DIFF
--- a/e2e/utils/command-utils.ts
+++ b/e2e/utils/command-utils.ts
@@ -6,6 +6,7 @@ import {
   getNpmMajorVersion,
   getPublishedVersion,
   getStrippedEnvironmentVariables,
+  getYarnMajorVersion,
   isVerboseE2ERun,
 } from './get-env-info';
 import { TargetConfiguration } from '@nx/devkit';
@@ -119,6 +120,7 @@ export function getPackageManagerCommand({
   runLerna: string;
 } {
   const npmMajorVersion = getNpmMajorVersion();
+  const yarnMajorVersion = getYarnMajorVersion(path);
   const publishedVersion = getPublishedVersion();
   const isYarnWorkspace = fileExists(join(path, 'package.json'))
     ? readJson('package.json').workspaces
@@ -147,14 +149,14 @@ export function getPackageManagerCommand({
       } create-nx-workspace@${publishedVersion}`,
       run: (script: string, args: string) => `yarn ${script} ${args}`,
       runNx: `yarn nx`,
-      runNxSilent: `yarn --silent nx`,
+      runNxSilent: +yarnMajorVersion >= 2 ? 'yarn nx' : `yarn --silent nx`,
       runUninstalledPackage: 'npx --yes',
       install: 'yarn',
       ciInstall: 'yarn --frozen-lockfile',
       addProd: isYarnWorkspace ? 'yarn add -W' : 'yarn add',
       addDev: isYarnWorkspace ? 'yarn add -DW' : 'yarn add -D',
       list: 'yarn list --pattern',
-      runLerna: `yarn --silent lerna`,
+      runLerna: +yarnMajorVersion >= 2 ? 'yarn lerna' : `yarn --silent lerna`,
     },
     // Pnpm 3.5+ adds nx to
     pnpm: {

--- a/e2e/utils/get-env-info.ts
+++ b/e2e/utils/get-env-info.ts
@@ -76,16 +76,16 @@ export function getNpmMajorVersion(): string {
 export function getYarnMajorVersion(path: string): string {
   try {
     // this fails if path is not yet created
-    const [npmMajorVersion] = execSync(`yarn -v`, {
+    const [yarnMajorVersion] = execSync(`yarn -v`, {
       cwd: path,
       encoding: 'utf-8',
     }).split('.');
-    return npmMajorVersion;
+    return yarnMajorVersion;
   } catch {
-    const [npmMajorVersion] = execSync(`yarn -v`, { encoding: 'utf-8' }).split(
+    const [yarnMajorVersion] = execSync(`yarn -v`, { encoding: 'utf-8' }).split(
       '.'
     );
-    return npmMajorVersion;
+    return yarnMajorVersion;
   }
 }
 

--- a/e2e/utils/get-env-info.ts
+++ b/e2e/utils/get-env-info.ts
@@ -73,6 +73,22 @@ export function getNpmMajorVersion(): string {
   return npmMajorVersion;
 }
 
+export function getYarnMajorVersion(path: string): string {
+  try {
+    // this fails if path is not yet created
+    const [npmMajorVersion] = execSync(`yarn -v`, {
+      cwd: path,
+      encoding: 'utf-8',
+    }).split('.');
+    return npmMajorVersion;
+  } catch {
+    const [npmMajorVersion] = execSync(`yarn -v`, { encoding: 'utf-8' }).split(
+      '.'
+    );
+    return npmMajorVersion;
+  }
+}
+
 export function getLatestLernaVersion(): string {
   const lernaVersion = execSync(`npm view lerna version`, {
     encoding: 'utf-8',


### PR DESCRIPTION
Yarn berry has no `--silent` flag and would fail the command.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
