### PR TITLE
feat(repo): enable custom version publish on e2e

### DIFF
--- a/e2e/utils/global-setup.ts
+++ b/e2e/utils/global-setup.ts
@@ -24,8 +24,9 @@ export default async function (globalConfig: Config.ConfigGlobals) {
     !existsSync('./build')
   ) {
     console.log('Publishing packages to local registry');
+    const publishVersion = process.env.PUBLISHED_VERSION ?? 'major';
     await new Promise<void>((res, rej) => {
-      const publishProcess = exec('pnpm nx-release --local major', {
+      const publishProcess = exec(`pnpm nx-release --local ${publishVersion}`, {
         env: process.env,
       });
       let logs = Buffer.from('');


### PR DESCRIPTION
Enable calling e2e tests like:
```
PUBLISHED_VERSION=17.1.0 pnpm nx e2e e2e-...
```

This helps with running several tests one after another without the need to clean up the local cache (yarn keeps hoarding the installed packages)

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
