### PR TITLE
fix(bundling): add missing main export for @nx/vite

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -45,9 +45,8 @@
     "access": "public"
   },
   "exports": {
-    "./package.json": {
-      "require": "./package.json"
-    },
+    ".": "./index.js",
+    "./package.json": "./package.json",
     "./migrations.json": "./migrations.json",
     "./generators.json": "./generators.json",
     "./executors.json": "./executors.json",


### PR DESCRIPTION
The missing main export is causing issues when fetching the package sometimes.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
