### PR TITLE
fix(webpack): enable in memory caching when building for node in watch mode

### DIFF
--- a/packages/webpack/src/utils/with-nx.ts
+++ b/packages/webpack/src/utils/with-nx.ts
@@ -191,6 +191,12 @@ export function withNx(pluginOptions?: WithNxOptions): NxWebpackPlugin {
             process.env.NODE_ENV === 'production'
           ? (process.env.NODE_ENV as 'development' | 'production')
           : ('none' as const),
+      // When target is Node, the Webpack mode will be set to 'none' which disables in memory caching and causes a full rebuild on every change.
+      // So to mitigate this we enable in memory caching when target is Node and in watch mode.
+      cache:
+        options.target === ('node' as const) && options.watch
+          ? { type: 'memory' as const }
+          : undefined,
       devtool:
         options.sourceMap === 'hidden'
           ? 'hidden-source-map'


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Using `@nx/webpack` for building node apps in watch mode is slow.

After checking all nx versions we found the root cause was this PR: https://github.com/nrwl/nx/pull/16625

Setting `mode: 'none'` has the side effect of disabling webpack's in memory caching:
https://github.com/webpack/webpack/blob/main/lib/config/defaults.js#L198-L200

Which in turn makes incremental rebuilds with large node apps have poor performance due to webpack re-compiling every file on change instead of just the affected files.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Using `@nx/webpack` for building node apps in watch mode is fast

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
N/A

