### PR TITLE
fix(linter): do not report obsolete devDependencies since they are not used in production files

### DIFF
--- a/packages/eslint-plugin/src/rules/dependency-checks.ts
+++ b/packages/eslint-plugin/src/rules/dependency-checks.ts
@@ -331,7 +331,7 @@ export default createESLintRule<Options, MessageIds>({
       ) {
         validateMissingDependencies(node);
       },
-      ['JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.value=/^(dev|peer|optional)?dependencies$/i] > JSONObjectExpression > JSONProperty'](
+      ['JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.value=/^(peer|optional)?dependencies$/i] > JSONObjectExpression > JSONProperty'](
         node: AST.JSONProperty
       ) {
         const packageName = (node.key as any).value;


### PR DESCRIPTION
This PR fixes an issue where we report `devDependencies` as obsolete for standalone projects. This happens because they are not used in production files. This means `nx` and all `@nx/*` packages are obsolete, and `--fix` will remove them from the workspaces.

In general, we do not care what users put into their `devDependencies`, we only need to check the ones that affect their consumers.

## Current Behavior
Standalone projects will report things like this for `nx lint`.

```
  14:5  error  The "@nx/eslint-plugin" package is not used by "my-awesome-package"                                                            @nx/dependency-checks
  15:5  error  The "@nx/js" package is not used by "my-awesome-package"                                                                       @nx/dependency-checks
  16:5  error  The "@nx/linter" package is not used by "my-awesome-package"                                                                   @nx/dependency-checks
  18:5  error  The "@nx/workspace" package is not used by "my-awesome-package"                                                                @nx/dependency-checks
  19:5  error  The "@types/node" package is not used by "my-awesome-package"                                                                  @nx/dependency-checks
  20:5  error  The "@typescript-eslint/eslint-plugin" package is not used by "my-awesome-package"                                             @nx/dependency-checks
  21:5  error  The "@typescript-eslint/parser" package is not used by "my-awesome-package"                                                    @nx/dependency-checks
  22:5  error  The "@vitest/coverage-c8" package is not used by "my-awesome-package"                                                          @nx/dependency-checks
  23:5  error  The "@vitest/ui" package is not used by "my-awesome-package"                                                                   @nx/dependency-checks
  24:5  error  The "eslint" package is not used by "my-awesome-package"                                                                       @nx/dependency-checks
  25:5  error  The "eslint-config-prettier" package is not used by "my-awesome-package"                                                       @nx/dependency-checks
  26:5  error  The "nx" package is not used by "my-awesome-package"                                                                           @nx/dependency-checks
  27:5  error  The "nx-cloud" package is not used by "my-awesome-package"                                                                     @nx/dependency-checks
  28:5  error  The "prettier" package is not used by "my-awesome-package"                                                                     @nx/dependency-checks
  29:5  error  The "typescript" package is not used by "my-awesome-package"                                                                   @nx/dependency-checks
  31:5  error  The "vitest" package is not used by "my-awesome-package"                                                                       @nx/dependency-checks
```

## Expected Behavior
Standalone projects should not report errors on legit dev dependencies.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
