### PR TITLE
fix(js): resolve imports as native node apis before npm modules

### DIFF
--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
@@ -60,6 +60,11 @@ export class TargetProjectLocator {
       }
     }
 
+    if (builtInModuleSet.has(normalizedImportExpr)) {
+      this.npmResolutionCache.set(normalizedImportExpr, null);
+      return null;
+    }
+
     // try to find npm package before using expensive typescript resolution
     const npmProject = this.findNpmPackage(normalizedImportExpr);
     if (npmProject) {
@@ -77,11 +82,6 @@ export class TargetProjectLocator {
       if (resolvedProject) {
         return resolvedProject;
       }
-    }
-
-    if (builtInModuleSet.has(normalizedImportExpr)) {
-      this.npmResolutionCache.set(normalizedImportExpr, null);
-      return null;
     }
 
     try {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`import { URL } from 'url';` As the `'url'` is resolved as a dependency to the npm package which differs from node which will resolve it as the builtin url.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`import { URL } from 'url';` As the `'url'` is resolved as a dependency to the node builtin module which matches the behavior from node.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
