### PR TITLE
fix(core): fix performance of hashing external dependencies up front

### DIFF
--- a/packages/nx/src/hasher/__snapshots__/task-hasher.spec.ts.snap
+++ b/packages/nx/src/hasher/__snapshots__/task-hasher.spec.ts.snap
@@ -63,7 +63,7 @@ exports[`TaskHasher hashTarget should hash entire subtree of dependencies 1`] = 
     },
     "runtime": {},
   },
-  "value": "17607022607820563118",
+  "value": "14419327228911184578",
 }
 `;
 
@@ -83,7 +83,7 @@ exports[`TaskHasher hashTarget should hash executor dependencies of @nx packages
     },
     "runtime": {},
   },
-  "value": "15096054768893599383",
+  "value": "379625642227035180",
 }
 `;
 
@@ -105,7 +105,7 @@ exports[`TaskHasher hashTarget should use externalDependencies to override nx:ru
     },
     "runtime": {},
   },
-  "value": "18142315317355318287",
+  "value": "14779270419297346086",
 }
 `;
 
@@ -239,7 +239,7 @@ exports[`TaskHasher should hash missing dependent npm project versions 1`] = `
     },
     "runtime": {},
   },
-  "value": "3668827038634092448",
+  "value": "13210933885500739919",
 }
 `;
 
@@ -321,7 +321,7 @@ exports[`TaskHasher should hash npm project versions 1`] = `
     },
     "runtime": {},
   },
-  "value": "3668827038634092448",
+  "value": "13210933885500739919",
 }
 `;
 

--- a/packages/nx/src/hasher/task-hasher.spec.ts
+++ b/packages/nx/src/hasher/task-hasher.spec.ts
@@ -976,23 +976,23 @@ describe('TaskHasher', () => {
       const hasher1 = createHasher();
       const hasher2 = createHasher();
 
-      const hashA1 = hasher1.hashTask({
+      const hashA1 = await hasher1.hashTask({
         id: 'a-build',
         target: { project: 'a', target: 'build' },
         overrides: {},
       });
-      const hashB1 = hasher1.hashTask({
+      const hashB1 = await hasher1.hashTask({
         id: 'b-build',
         target: { project: 'b', target: 'build' },
         overrides: {},
       });
 
-      const hashB2 = hasher2.hashTask({
+      const hashB2 = await hasher2.hashTask({
         id: 'b-build',
         target: { project: 'b', target: 'build' },
         overrides: {},
       });
-      const hashA2 = hasher2.hashTask({
+      const hashA2 = await hasher2.hashTask({
         id: 'a-build',
         target: { project: 'a', target: 'build' },
         overrides: {},


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Combining the partial hashes when calculating the external node hashes takes a lot of time.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Partial hashes of the external nodes are calculated up front and combined later.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
