### PR TITLE
docs react standalone update video enhancements

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -170,6 +170,14 @@ title="Nx Console Run UI Form"
 width="100%" /%}
 ```
 
+#### Youtube Section Link
+
+Have a more decent button-like widget that you can place below sections of a tutorial with a link to a specific point in a Youtube video.
+
+```markdown
+{% video-link link="https://youtu.be/OQ-Zc5tcxJE?t=64" /%}
+```
+
 #### Graph
 
 Embed an Nx Graph visualization that can be panned by the user.

--- a/docs/shared/react-standalone-tutorial/react-standalone.md
+++ b/docs/shared/react-standalone-tutorial/react-standalone.md
@@ -19,6 +19,8 @@ Note, this tutorial sets up a repo with a single application at the root level t
 
 {% /callout %}
 
+Note, while you could easily use Nx together with your manually set up React application, we're going to use the `@nx/react` plugin for this tutorial which provides some nice enhancements when working with React. [Visit our "Why Nx" page](/getting-started/why-nx) to learn more about plugins and what role they play in the Nx architecture.
+
 ## Warm Up
 
 Here's the source code of the final result for this tutorial.
@@ -26,6 +28,11 @@ Here's the source code of the final result for this tutorial.
 {% github-repository url="https://github.com/nrwl/nx-recipes/tree/main/react-standalone" /%}
 
 {% stackblitz-button url="github.com/nrwl/nx-recipes/tree/main/react-standalone?file=README.md" /%}
+
+{% youtube
+src="https://www.youtube.com/embed/OQ-Zc5tcxJE"
+title="Tutorial: Standalone React Application"
+width="100%" /%}
 
 ## Creating a new React App
 
@@ -213,6 +220,16 @@ Note that all of these targets are automatically cached by Nx. If you re-run a s
 ```
 
 Not all tasks might be cacheable though. You can configure `cacheableOperations` in the `nx.json` file. You can also [learn more about how caching works](/core-features/cache-task-results).
+
+## Nx Plugins? Why?
+
+One thing you might be curious about is the project.json. You may wonder why we define tasks inside the `project.json` file instead of using the `package.json` file with scripts that directly launch Vite.
+
+Nx understands and supports both approaches, allowing you to define targets either in your `package.json` or `project.json` files. While both serve a similar purpose, the `project.json` file can be seen as an advanced form of `package.json` scripts, providing additional metadata and capabilities. In this tutorial, we utilize the `project.json` approach primarily because we take advantage of Nx Plugins.
+
+So, what are Nx Plugins? Nx Plugins are optional packages that extend the capabilities of Nx, catering to various specific technologies. For instance, we have plugins tailored to React (e.g., `@nx/react`), Vite (`@nx/vite`), Cypress (`@nx/cypress`), and more. These plugins offer additional features, making your development experience more efficient and enjoyable when working with specific tech stacks.
+
+[visit our "Why Nx" page](/getting-started/why-nx) for more deails.
 
 ## Creating New Components
 

--- a/docs/shared/react-standalone-tutorial/react-standalone.md
+++ b/docs/shared/react-standalone-tutorial/react-standalone.md
@@ -36,6 +36,8 @@ width="100%" /%}
 
 ## Creating a new React App
 
+{% video-link link="https://youtu.be/OQ-Zc5tcxJE?t=64" /%}
+
 Create a new standalone React application with the following command:
 
 ```shell {% command="npx create-nx-workspace@latest myreactapp --preset=react-standalone" path="~" %}
@@ -89,6 +91,8 @@ Let me explain a couple of things that might be new to you.
 | `project.json` | This file contains the targets that can be invoked for the `myreactapp` project. It is like a more evolved version of simple `package.json` scripts with more metadata attached. You can read more about it [here](/reference/project-configuration). |
 
 ## Serving the App
+
+{% video-link link="https://youtu.be/OQ-Zc5tcxJE?t=207" /%}
 
 The most common tasks are already mapped in the `package.json` file:
 
@@ -177,6 +181,8 @@ Learn more about how to [run tasks with Nx](/core-features/run-tasks).
 
 ## Testing and Linting - Running Multiple Tasks
 
+{% video-link link="https://youtu.be/OQ-Zc5tcxJE?t=410" /%}
+
 Our current setup doesn't just come with targets for serving and building the React application, but also has targets for unit testing, e2e testing and linting. Again, these are defined in the `project.json` file. We can use the same syntax as before to run these tasks:
 
 ```bash
@@ -223,6 +229,8 @@ Not all tasks might be cacheable though. You can configure `cacheableOperations`
 
 ## Nx Plugins? Why?
 
+{% video-link link="https://youtu.be/OQ-Zc5tcxJE?t=598" /%}
+
 One thing you might be curious about is the project.json. You may wonder why we define tasks inside the `project.json` file instead of using the `package.json` file with scripts that directly launch Vite.
 
 Nx understands and supports both approaches, allowing you to define targets either in your `package.json` or `project.json` files. While both serve a similar purpose, the `project.json` file can be seen as an advanced form of `package.json` scripts, providing additional metadata and capabilities. In this tutorial, we utilize the `project.json` approach primarily because we take advantage of Nx Plugins.
@@ -232,6 +240,8 @@ So, what are Nx Plugins? Nx Plugins are optional packages that extend the capabi
 [visit our "Why Nx" page](/getting-started/why-nx) for more deails.
 
 ## Creating New Components
+
+{% video-link link="https://youtu.be/OQ-Zc5tcxJE?t=706" /%}
 
 You can just create new React components as you normally would. However, Nx plugins usually also ship [generators](/core-features/plugin-features/use-code-generators). They allow you to easily scaffold code, configuration or entire projects. To see what capabilities the `@nx/react` plugin ships, run the following command and inspect the output:
 
@@ -306,6 +316,8 @@ export default HelloWorld;
 
 ## Building the App for Deployment
 
+{% video-link link="https://youtu.be/OQ-Zc5tcxJE?t=856" /%}
+
 If you're ready and want to ship your application, you can build it using
 
 ```shell {% command="npx nx build" path="myreactapp" %}
@@ -325,6 +337,8 @@ All the required files will be placed in the `dist/myreactapp` folder and can be
 
 ## You're ready to go!
 
+{% video-link link="https://youtu.be/OQ-Zc5tcxJE?t=906" /%}
+
 In the previous sections you learned about the basics of using Nx, running tasks and navigating an Nx workspace. You're ready to ship features now!
 
 But there's more to learn. You have two possibilities here:
@@ -333,6 +347,8 @@ But there's more to learn. You have two possibilities here:
 - keep reading and learn some more about what makes Nx unique when working with React.
 
 ## Modularizing your React App with Local Libraries
+
+{% video-link link="https://youtu.be/OQ-Zc5tcxJE?t=986" /%}
 
 When you develop your React application, usually all your logic sits in the `app` folder. Ideally separated by various folder names which represent your "domains". As your app grows, this becomes more and more monolithic though.
 
@@ -362,6 +378,8 @@ Nx allows you to separate this logic into "local libraries". The main benefits i
 - better scalability in your teams by allowing different teams to work on separate libraries
 
 ### Creating Local Libraries
+
+{% video-link link="https://youtu.be/OQ-Zc5tcxJE?t=1041" /%}
 
 Let's assume our domain areas include `products`, `orders` and some more generic design system components, called `ui`. We can generate a new library for each of these areas using the React library generator:
 
@@ -426,6 +444,8 @@ Each of these libraries
 - is mapped in the `tsconfig.base.json` at the root of the workspace
 
 ### Importing Libraries into the React Application
+
+{% video-link link="https://youtu.be/OQ-Zc5tcxJE?t=1245" /%}
 
 All libraries that we generate automatically have aliases created in the root-level `tsconfig.base.json`.
 
@@ -561,6 +581,8 @@ export default App;
 
 ## Visualizing your Project Structure
 
+{% video-link link="https://youtu.be/OQ-Zc5tcxJE?t=1416" /%}
+
 Nx automatically detects the dependencies between the various parts of your workspace and builds a [project graph](/core-features/explore-graph). This graph is used by Nx to perform various optimizations such as determining the correct order of execution when running tasks like `nx build`, identifying [affected projects](/core-features/run-tasks#run-tasks-affected-by-a-pr) and more. Interestingly you can also visualize it.
 
 Just run:
@@ -637,6 +659,8 @@ Notice how `modules-shared-ui` is not yet connected to anything because we didn'
 Exercise for you: change the codebase such that `modules-shared-ui` is used by `modules-orders` and `modules-products`. Note: you need to restart the `nx graph` command to update the graph visualization or run the CLI command with the `--watch` flag.
 
 ## Imposing Constraints with Module Boundary Rules
+
+{% video-link link="https://youtu.be/OQ-Zc5tcxJE?t=1456" /%}
 
 Once you modularize your codebase you want to make sure that the modules are not coupled to each other in an uncontrolled way. Here are some examples of how we might want to guard our small demo workspace:
 

--- a/nx-dev/ui-markdoc/src/index.ts
+++ b/nx-dev/ui-markdoc/src/index.ts
@@ -43,6 +43,7 @@ import {
   TerminalCommand,
   terminalCommand,
 } from './lib/tags/terminal-command.component';
+import { VideoLink, videoLink } from './lib/tags/video-link.component';
 
 // TODO fix this export
 export { GithubRepository } from './lib/tags/github-repository.component';
@@ -75,6 +76,7 @@ export const getMarkdocCustomConfig = (
       'title-card': titleCard,
       youtube,
       'terminal-command': terminalCommand,
+      'video-link': videoLink,
     },
   },
   components: {
@@ -98,6 +100,7 @@ export const getMarkdocCustomConfig = (
     TitleCard,
     YouTube,
     TerminalCommand,
+    VideoLink,
   },
 });
 

--- a/nx-dev/ui-markdoc/src/lib/tags/video-link.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/video-link.component.tsx
@@ -1,0 +1,47 @@
+import { Schema } from '@markdoc/markdoc';
+
+export const videoLink: Schema = {
+  render: 'VideoLink',
+  attributes: {
+    link: {
+      type: 'String',
+      required: true,
+    },
+    text: {
+      type: 'String',
+      required: false,
+    },
+  },
+};
+
+const youtubeIcon = (
+  <svg
+    fill="currentColor"
+    role="img"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+    className="w-6 h-6"
+  >
+    <path d="M23.5 6.19a3.02 3.02 0 0 0-2.12-2.14c-1.88-.5-9.38-.5-9.38-.5s-7.5 0-9.38.5A3.02 3.02 0 0 0 .5 6.19C0 8.07 0 12 0 12s0 3.93.5 5.81a3.02 3.02 0 0 0 2.12 2.14c1.87.5 9.38.5 9.38.5s7.5 0 9.38-.5a3.02 3.02 0 0 0 2.12-2.14C24 15.93 24 12 24 12s0-3.93-.5-5.81zM9.54 15.57V8.43L15.82 12l-6.28 3.57z" />
+  </svg>
+);
+
+export function VideoLink({ text, link }: { text: string; link: string }) {
+  return (
+    <div className="flex no-prose">
+      <a
+        href={link}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center no-underline space-x-2 border-transparent"
+      >
+        <div className="flex items-center justify-between pl-2 pr-2 space-x-2 border rounded-md border-slate-200 py-1 pl-3 transition hover:border-slate-500 dark:border-slate-700/40 dark:hover:border-slate-700">
+          {youtubeIcon}
+          <span className="font-semibold text-md hover:text-slate-900 dark:hover:text-sky-400">
+            {text || 'Jump to section in video'}
+          </span>
+        </div>
+      </a>
+    </div>
+  );
+}


### PR DESCRIPTION
- adds the video embed of the new React standalone tutorial video
- adds a section about Nx Plugins which might be a point that comes up for a React developer
- adds a new video-link component and adds that to the corresponding tutorial sections s.t. readers can jump from a section right into the video

![image](https://github.com/nrwl/nx/assets/542458/ee06b12e-aaa8-43b4-9e11-7ff1ae6db65e)

Link: https://nx-dev-git-fork-juristr-docs-react-standalone-updat-bdc148-nrwl.vercel.app/getting-started/tutorials/react-standalone-tutorial