### PR TITLE
fix(react-native): update generated jest config to be in sync w/cache

### DIFF
--- a/packages/react-native/src/generators/application/application.spec.ts
+++ b/packages/react-native/src/generators/application/application.spec.ts
@@ -60,6 +60,21 @@ describe('app', () => {
     expect(tsconfig.extends).toEqual('../../tsconfig.base.json');
 
     expect(appTree.exists('apps/my-app/.eslintrc.json')).toBe(true);
+    expect(appTree.read('apps/my-app/jest.config.ts', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "module.exports = {
+        displayName: 'my-app',
+        preset: 'react-native',
+        resolver: '@nx/jest/plugins/resolver',
+        moduleFileExtensions: ['ts', 'js', 'html', 'tsx', 'jsx'],
+        setupFilesAfterEnv: ['<rootDir>/test-setup.ts'],
+        moduleNameMapper: {
+          '\\\\.svg$': '@nx/react-native/plugins/jest/svg-mock',
+        },
+        coverageDirectory: '../../coverage/apps/my-app',
+      };
+      "
+    `);
   });
 
   it('should generate targets', async () => {
@@ -71,7 +86,6 @@ describe('app', () => {
       install: false,
     });
     const targets = readProjectConfiguration(appTree, 'my-app').targets;
-    console.log(targets.test);
     expect(targets.test).toBeDefined();
   });
 

--- a/packages/react-native/src/generators/library/library.spec.ts
+++ b/packages/react-native/src/generators/library/library.spec.ts
@@ -242,6 +242,72 @@ describe('lib', () => {
         outputs: ['{options.outputFile}'],
       });
     });
+
+    it('should generate test configuration', async () => {
+      await libraryGenerator(appTree, {
+        ...defaultSchema,
+        unitTestRunner: 'jest',
+      });
+
+      expect(appTree.read('libs/my-lib/tsconfig.spec.json', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "{
+          "extends": "./tsconfig.json",
+          "compilerOptions": {
+            "outDir": "../../dist/out-tsc",
+            "module": "commonjs",
+            "types": ["jest", "node"]
+          },
+          "include": [
+            "jest.config.ts",
+            "src/**/*.test.ts",
+            "src/**/*.spec.ts",
+            "src/**/*.test.tsx",
+            "src/**/*.spec.tsx",
+            "src/**/*.test.js",
+            "src/**/*.spec.js",
+            "src/**/*.test.jsx",
+            "src/**/*.spec.jsx",
+            "src/**/*.d.ts"
+          ]
+        }
+        "
+      `);
+      expect(appTree.read('libs/my-lib/jest.config.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "module.exports = {
+          displayName: 'my-lib',
+          preset: 'react-native',
+          resolver: '@nx/jest/plugins/resolver',
+          moduleFileExtensions: ['ts', 'js', 'html', 'tsx', 'jsx'],
+          setupFilesAfterEnv: ['<rootDir>/test-setup.ts'],
+          moduleNameMapper: {
+            '\\\\.svg$': '@nx/react-native/plugins/jest/svg-mock',
+          },
+          coverageDirectory: '../../coverage/libs/my-lib',
+        };
+        "
+      `);
+      const projectConfiguration = readProjectConfiguration(appTree, 'my-lib');
+      expect(projectConfiguration.targets.test).toMatchInlineSnapshot(`
+        {
+          "configurations": {
+            "ci": {
+              "ci": true,
+              "codeCoverage": true,
+            },
+          },
+          "executor": "@nx/jest:jest",
+          "options": {
+            "jestConfig": "libs/my-lib/jest.config.ts",
+            "passWithNoTests": true,
+          },
+          "outputs": [
+            "{workspaceRoot}/coverage/{projectRoot}",
+          ],
+        }
+      `);
+    });
   });
 
   describe('--buildable', () => {

--- a/packages/react-native/src/utils/add-jest.ts
+++ b/packages/react-native/src/utils/add-jest.ts
@@ -1,4 +1,4 @@
-import { Tree } from '@nx/devkit';
+import { Tree, offsetFromRoot } from '@nx/devkit';
 import { configurationGenerator } from '@nx/jest';
 
 export async function addJest(
@@ -34,7 +34,10 @@ export async function addJest(
   setupFilesAfterEnv: ['<rootDir>/test-setup.${js ? 'js' : 'ts'}'],
   moduleNameMapper: {
     '\\\\.svg$': '@nx/react-native/plugins/jest/svg-mock'
-  }
+  },
+  coverageDirectory: '${offsetFromRoot(
+    appProjectRoot
+  )}coverage/${appProjectRoot}'
 };`;
   host.write(configPath, content);
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Jest config generates coverage reports in the project root, which does not match executor outputs nor the other existing project outputs

jest config doesn't transform common deps

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
jest config is updated to support the above 2

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
