### PR TITLE
fix(core): do not error when hashing executors which are local plugins

### DIFF
--- a/packages/nx/src/hasher/__snapshots__/task-hasher.spec.ts.snap
+++ b/packages/nx/src/hasher/__snapshots__/task-hasher.spec.ts.snap
@@ -44,6 +44,52 @@ exports[`TaskHasher dependentTasksOutputFiles should work with dependent tasks w
 }
 `;
 
+exports[`TaskHasher hashTarget should hash entire subtree in a deterministic way 1`] = `
+{
+  "details": {
+    "command": "81188892120010785",
+    "implicitDeps": {},
+    "nodes": {
+      "ProjectConfiguration": "8474322003863204060",
+      "TsConfig": "8767608672024750088",
+      "appA:{projectRoot}/**/*": "3244421341483603138",
+      "npm:@nx/webpack": "$@nx/webpack0.0.0$",
+      "npm:packageA": "$packageA0.0.0$",
+      "npm:packageB": "$packageB0.0.0$",
+      "npm:packageC": "$packageC0.0.0$",
+      "{workspaceRoot}/.gitignore": "3244421341483603138",
+      "{workspaceRoot}/.nxignore": "3244421341483603138",
+      "{workspaceRoot}/nx.json": "8942239360311677987",
+    },
+    "runtime": {},
+  },
+  "value": "12756041818139421941",
+}
+`;
+
+exports[`TaskHasher hashTarget should hash entire subtree in a deterministic way 2`] = `
+{
+  "details": {
+    "command": "9096392622609675764",
+    "implicitDeps": {},
+    "nodes": {
+      "ProjectConfiguration": "17724470359684527282",
+      "TsConfig": "8767608672024750088",
+      "appB:{projectRoot}/**/*": "3244421341483603138",
+      "npm:@nx/webpack": "$@nx/webpack0.0.0$",
+      "npm:packageA": "$packageA0.0.0$",
+      "npm:packageB": "$packageB0.0.0$",
+      "npm:packageC": "$packageC0.0.0$",
+      "{workspaceRoot}/.gitignore": "3244421341483603138",
+      "{workspaceRoot}/.nxignore": "3244421341483603138",
+      "{workspaceRoot}/nx.json": "8942239360311677987",
+    },
+    "runtime": {},
+  },
+  "value": "15326312070983573452",
+}
+`;
+
 exports[`TaskHasher hashTarget should hash entire subtree of dependencies 1`] = `
 {
   "details": {

--- a/packages/nx/src/hasher/task-hasher.spec.ts
+++ b/packages/nx/src/hasher/task-hasher.spec.ts
@@ -1257,6 +1257,9 @@ describe('TaskHasher', () => {
 
       expect(hashAppB1).toEqual(hashAppB2);
       expect(hashAppA1).toEqual(hashAppA2);
+
+      expect(hashAppA1).toMatchSnapshot();
+      expect(hashAppB1).toMatchSnapshot();
     });
 
     it('should not hash when nx:run-commands executor', async () => {

--- a/packages/nx/src/utils/project-graph-utils.ts
+++ b/packages/nx/src/utils/project-graph-utils.ts
@@ -75,21 +75,24 @@ export function getSourceDirOfDependentProjects(
 
 /**
  * Find all internal project dependencies.
- * All the external (npm) dependencies will be filtered out
+ * All the external (npm) dependencies will be filtered out unless includeExternalDependencies is set to true
  * @param {string} parentNodeName
  * @param {ProjectGraph} projectGraph
+ * @param includeExternalDependencies
  * @returns {string[]}
  */
 export function findAllProjectNodeDependencies(
   parentNodeName: string,
-  projectGraph = readCachedProjectGraph()
+  projectGraph = readCachedProjectGraph(),
+  includeExternalDependencies = false
 ): string[] {
   const dependencyNodeNames = new Set<string>();
 
   collectDependentProjectNodesNames(
     projectGraph as ProjectGraph,
     dependencyNodeNames,
-    parentNodeName
+    parentNodeName,
+    includeExternalDependencies
   );
 
   return Array.from(dependencyNodeNames);
@@ -99,7 +102,8 @@ export function findAllProjectNodeDependencies(
 function collectDependentProjectNodesNames(
   nxDeps: ProjectGraph,
   dependencyNodeNames: Set<string>,
-  parentNodeName: string
+  parentNodeName: string,
+  includeExternalDependencies: boolean
 ) {
   const dependencies = nxDeps.dependencies[parentNodeName];
   if (!dependencies) {
@@ -111,14 +115,18 @@ function collectDependentProjectNodesNames(
   for (const dependency of dependencies) {
     const dependencyName = dependency.target;
 
-    // we're only interested in internal nodes, not external
-    if (nxDeps.externalNodes?.[dependencyName]) {
-      continue;
-    }
-
     // skip dependencies already added (avoid circular dependencies)
     if (dependencyNodeNames.has(dependencyName)) {
       continue;
+    }
+
+    // we're only interested in internal nodes, not external
+    if (nxDeps.externalNodes?.[dependencyName]) {
+      if (includeExternalDependencies) {
+        dependencyNodeNames.add(dependencyName);
+      } else {
+        continue;
+      }
     }
 
     dependencyNodeNames.add(dependencyName);
@@ -127,7 +135,8 @@ function collectDependentProjectNodesNames(
     collectDependentProjectNodesNames(
       nxDeps,
       dependencyNodeNames,
-      dependencyName
+      dependencyName,
+      includeExternalDependencies
     );
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When Nx hashes the executor for `angular:build`, it cannot find an external dependency for `@nx/angular` because it is a local plugin and errors.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When Nx hashes the executor for `angular:build`, it cannot find an external dependency for `@nx/angular` because it is a local plugin, it will return null like it does today. This should be fixed later.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
