### PR TITLE
fix(linter): eslint flat config not working correctly

### DIFF
--- a/packages/linter/src/executors/eslint/lint.impl.spec.ts
+++ b/packages/linter/src/executors/eslint/lint.impl.spec.ts
@@ -43,6 +43,7 @@ jest.mock('./utility/eslint-utils', () => {
   };
 });
 import lintExecutor from './lint.impl';
+import { resolve } from 'path';
 
 let mockChdir = jest.fn().mockImplementation(() => {});
 
@@ -150,7 +151,7 @@ describe('Linter Builder', () => {
       mockContext
     );
     expect(mockResolveAndInstantiateESLint).toHaveBeenCalledWith(
-      '/root/.eslintrc.json',
+      resolve('/root', '.eslintrc.json'),
       {
         lintFilePatterns: [],
         eslintConfig: './.eslintrc.json',
@@ -648,5 +649,34 @@ Please see https://nx.dev/guides/eslint for full guidance on how to resolve this
     );
     expect(console.log).toHaveBeenCalledWith('{\n "file": "test-source.ts"\n}');
     expect(result).toEqual({ success: true });
+  });
+
+  it('should pass path to eslint.config.js to resolveAndInstantiateESLint if it is unspecified and we are using flag configuration', async () => {
+    setupMocks();
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    await lintExecutor(createValidRunBuilderOptions(), mockContext);
+    expect(mockResolveAndInstantiateESLint).toHaveBeenCalledWith(
+      'apps/proj/eslint.config.js',
+      {
+        lintFilePatterns: [],
+        eslintConfig: null,
+        fix: true,
+        cache: true,
+        cacheLocation: 'cacheLocation1/proj',
+        cacheStrategy: 'content',
+        format: 'stylish',
+        force: false,
+        silent: false,
+        ignorePath: null,
+        maxWarnings: -1,
+        outputFile: null,
+        quiet: false,
+        noEslintrc: false,
+        rulesdir: [],
+        resolvePluginsRelativeTo: null,
+        reportUnusedDisableDirectives: null,
+      },
+      true
+    );
   });
 });

--- a/packages/linter/src/executors/eslint/lint.impl.ts
+++ b/packages/linter/src/executors/eslint/lint.impl.ts
@@ -1,7 +1,7 @@
 import { ExecutorContext, joinPathFragments } from '@nx/devkit';
 import { ESLint } from 'eslint';
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
-import { dirname, join, resolve } from 'path';
+import { dirname, resolve } from 'path';
 
 import type { Schema } from './schema';
 import { resolveAndInstantiateESLint } from './utility/eslint-utils';
@@ -31,12 +31,12 @@ export default async function run(
    * We want users to have the option of not specifying the config path, and let
    * eslint automatically resolve the `.eslintrc.json` files in each folder.
    */
-  const eslintConfigPath = options.eslintConfig
+  let eslintConfigPath = options.eslintConfig
     ? resolve(systemRoot, options.eslintConfig)
     : undefined;
 
   options.cacheLocation = options.cacheLocation
-    ? join(options.cacheLocation, projectName)
+    ? joinPathFragments(options.cacheLocation, projectName)
     : undefined;
 
   const { printConfig, ...normalizedOptions } = options;
@@ -49,6 +49,13 @@ export default async function run(
   const useFlatConfig = existsSync(
     joinPathFragments(systemRoot, 'eslint.config.js')
   );
+
+  if (!eslintConfigPath && useFlatConfig) {
+    const projectRoot =
+      context.projectsConfigurations.projects[context.projectName].root;
+    eslintConfigPath = joinPathFragments(projectRoot, 'eslint.config.js');
+  }
+
   const { eslint, ESLint } = await resolveAndInstantiateESLint(
     eslintConfigPath,
     normalizedOptions,
@@ -158,7 +165,10 @@ Please see https://nx.dev/guides/eslint for full guidance on how to resolve this
   const formattedResults = await formatter.format(lintResults);
 
   if (normalizedOptions.outputFile) {
-    const pathToOutputFile = join(context.root, normalizedOptions.outputFile);
+    const pathToOutputFile = joinPathFragments(
+      context.root,
+      normalizedOptions.outputFile
+    );
     mkdirSync(dirname(pathToOutputFile), { recursive: true });
     writeFileSync(pathToOutputFile, formattedResults);
   } else {


### PR DESCRIPTION
the new eslint flat doesn't resolve the config from the linted file location, but rather it always it resolve it from the current working directory, and since nx linter always uses the root of the project to execute linter, it will always use the root `eslint.config.js` file and ignore each project individual configurations.

this is mentioned in the [docs](https://eslint.org/docs/latest/use/configure/configuration-files-new#configuration-file-resolution), and in [their blog](https://eslint.org/blog/2022/08/new-config-system-part-2/#the-new-config-file%3A-eslint.config.js) it's explained more the difference between old and new behavior

also since I'm working from windows, there were multiple tests failing, to fix them I replace all `resolve` and `join` with `joinPathFragments`.

## Current Behavior
in the [reprod repo](https://github.com/robertIsaac/nx-eslint-flat-config)
```
> nx run ui:lint


Linting "ui"...

Error: You have attempted to use a lint rule which requires the full TypeScript type-checker to be available, but you do not have `parserOptions.project` configured to point at your project tsconfig.json files in the relevant TypeScript file "overrides" block of your project ESLint config `ui/.eslintrc.json`

Please see https://nx.dev/guides/eslint for full guidance on how to resolve this issue.


 —————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————— 

 >  NX   Ran target lint for project ui (983ms)

    ×    1/1 failed
    √    0/1 succeeded [0 read from cache]

   View structured, searchable error logs at https://nx.app/runs/StmuqY5spk
```

## Expected Behavior
```
> nx run ui:lint


Linting "ui"...

All files pass linting.


 —————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————— 

 >  NX   Successfully ran target lint for project ui (2s)

   View logs and investigate cache misses at https://nx.app/runs/sRJOSmyj8b
```

## Related Issue(s)
Fixes #18285