### PR TITLE
chore(repo): re-enable macos e2e caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ jobs:
     executor: macos
     environment:
       NX_E2E_CI_CACHE_KEY: e2e-circleci-macos
-      NX_DAEMON: 'true'
+      NX_DAEMON: 'false' # TODO: Fix the hashing issue and re-enable this
       NX_PERF_LOGGING: 'false'
       SELECTED_PM: 'npm' # explicitly define npm for macOS tests
       NX_SKIP_NX_CACHE: 'true' # TODO: Figure out what is going on with the cache and renable it

--- a/nx.json
+++ b/nx.json
@@ -6,7 +6,6 @@
   "tasksRunnerOptions": {
     "default": {
       "runner": "nx-cloud",
-      "nativeWatcher": true,
       "options": {
         "accessToken": "NDg1NTA3MTAtOGFmZC00YmIwLTk2Y2MtOTkzNzc4ZTczYTlkfHJlYWQtb25seQ==",
         "cacheableOperations": [

--- a/scripts/copy-local-native.js
+++ b/scripts/copy-local-native.js
@@ -7,6 +7,5 @@ const p = process.argv[2];
 const nativeFiles = glob.sync(`packages/${p}/**/*.node`);
 
 nativeFiles.forEach((file) => {
-  console.log('COPY', file, '=>', `build/${file}`);
   fs.copyFileSync(file, `build/${file}`);
 });

--- a/scripts/nx-release.ts
+++ b/scripts/nx-release.ts
@@ -51,9 +51,6 @@ function hideFromGitIndex(uncommittedFiles: string[]) {
   execSync(buildCommand, {
     stdio: [0, 1, 2],
   });
-  execSync(`ls -lah build/packages/nx/src/native`, {
-    stdio: [0, 1, 2],
-  });
 
   if (options.local) {
     updateLernaJsonVersion(currentLatestVersion);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Caching for the macOS e2e tests were disabled due to an issue with caching. The issue is localized to when the daemon.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Caching is re-enabled for macOS tests but the daemon is disabled.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
