### PR TITLE
fix(angular): update magic-string dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
     "license-webpack-plugin": "^4.0.2",
     "lines-and-columns": "~2.0.3",
     "loader-utils": "2.0.3",
-    "magic-string": "~0.26.2",
+    "magic-string": "~0.30.2",
     "markdown-factory": "^0.0.6",
     "memfs": "^3.0.1",
     "metro-config": "0.76.7",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -50,7 +50,7 @@
     "chalk": "^4.1.0",
     "find-cache-dir": "^3.3.2",
     "ignore": "^5.0.4",
-    "magic-string": "~0.26.2",
+    "magic-string": "~0.30.2",
     "minimatch": "3.0.5",
     "semver": "7.5.3",
     "tslib": "^2.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -689,8 +689,8 @@ devDependencies:
     specifier: 2.0.3
     version: 2.0.3
   magic-string:
-    specifier: ~0.26.2
-    version: 0.26.2
+    specifier: ~0.30.2
+    version: 0.30.2
   markdown-factory:
     specifier: ^0.0.6
     version: 0.0.6
@@ -11144,7 +11144,7 @@ packages:
   /@vitest/snapshot@0.32.0:
     resolution: {integrity: sha512-yCKorPWjEnzpUxQpGlxulujTcSPgkblwGzAUEL+z01FTUg/YuCDZ8dxr9sHA08oO2EwxzHXNLjQKWJ2zc2a19Q==}
     dependencies:
-      magic-string: 0.30.0
+      magic-string: 0.30.2
       pathe: 1.1.0
       pretty-format: 27.5.1
     dev: false
@@ -11189,7 +11189,7 @@ packages:
       '@vue/reactivity-transform': 3.3.4
       '@vue/shared': 3.3.4
       estree-walker: 2.0.2
-      magic-string: 0.30.0
+      magic-string: 0.30.2
       postcss: 8.4.19
       source-map-js: 1.0.2
     dev: true
@@ -11208,7 +11208,7 @@ packages:
       '@vue/compiler-core': 3.3.4
       '@vue/shared': 3.3.4
       estree-walker: 2.0.2
-      magic-string: 0.30.0
+      magic-string: 0.30.2
     dev: true
 
   /@vue/reactivity@3.3.4:
@@ -19884,13 +19884,6 @@ packages:
       sourcemap-codec: 1.4.8
     dev: true
 
-  /magic-string@0.26.2:
-    resolution: {integrity: sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==}
-    engines: {node: '>=12'}
-    dependencies:
-      sourcemap-codec: 1.4.8
-    dev: true
-
   /magic-string@0.26.7:
     resolution: {integrity: sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==}
     engines: {node: '>=12'}
@@ -19907,6 +19900,13 @@ packages:
 
   /magic-string@0.30.0:
     resolution: {integrity: sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
+
+  /magic-string@0.30.2:
+    resolution: {integrity: sha512-lNZdu7pewtq/ZvWUp9Wpf/x7WzMTsR26TWV03BRZrXFsv+BI6dy8RAiKgm1uM/kyR0rCfUcqvOlXKG66KhIGug==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
@@ -27510,7 +27510,7 @@ packages:
       concordance: 5.0.4
       debug: 4.3.4(supports-color@5.5.0)
       local-pkg: 0.4.3
-      magic-string: 0.30.0
+      magic-string: 0.30.2
       pathe: 1.1.0
       picocolors: 1.0.0
       std-env: 3.3.3


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`@nx/angular` depends on `magic-string@0.26.2` which depends on the deprecated `sourcemap-codec` package.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`@nx/angular` should depend on a newer version of `magic-string` that no longer depends on the deprecated `sourcemap-codec` package.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
