### PR TITLE
fix(core): fix schema links

### DIFF
--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://nx.dev/reference/project-configuration#nxjson",
+  "$id": "https://nx.dev/reference/nx-json",
   "title": "JSON schema for Nx configuration",
   "type": "object",
   "properties": {

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://nx.dev/core-concepts/configuration#nxjson",
+  "$id": "https://nx.dev/reference/project-configuration#nxjson",
   "title": "JSON schema for Nx configuration",
   "type": "object",
   "properties": {

--- a/packages/nx/schemas/project-schema.json
+++ b/packages/nx/schemas/project-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://nx.dev/project-schema",
+  "$id": "https://nx.dev/reference/project-configuration",
   "title": "JSON schema for Nx projects",
   "type": "object",
   "properties": {


### PR DESCRIPTION
This issue is blocking the flat config since config reports error

## Current Behavior
Schema links point to non-existent pages

## Expected Behavior
Schema links should point to active pages

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
