### PR TITLE
feat(core): make processing typescript dependencies in rust the default

### DIFF
--- a/e2e/nx-run/src/affected-graph.test.ts
+++ b/e2e/nx-run/src/affected-graph.test.ts
@@ -384,7 +384,6 @@ describe('Nx Affected and Graph Tests', () => {
               target: mylib,
               type: 'static',
             },
-            { source: myapp, target: mylib2, type: 'dynamic' },
           ],
           [myappE2e]: [
             {

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/build-dependencies.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/build-dependencies.ts
@@ -24,8 +24,7 @@ export function buildExplicitDependencies(
   // to be able to use at least 2 workers (1 worker per CPU and
   // 1 CPU for the main thread)
   if (
-    (process.env.NX_NATIVE_TS_DEPS &&
-      process.env.NX_NATIVE_TS_DEPS !== 'false') ||
+    process.env.NX_NATIVE_TS_DEPS !== 'false' ||
     jsPluginConfig.analyzeSourceFiles === false ||
     totalNumOfFilesToProcess < 100 ||
     getNumberOfWorkers() <= 2

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.spec.ts
@@ -36,7 +36,7 @@ describe('explicit project dependencies', () => {
       });
 
       const res = buildExplicitTypeScriptDependencies(
-        builder.graph,
+        builder.getUpdatedProjectGraph(),
         ctx.filesToProcess
       );
 
@@ -50,12 +50,6 @@ describe('explicit project dependencies', () => {
         {
           sourceProjectName,
           sourceProjectFile: 'libs/proj/index.ts',
-          targetProjectName: 'proj3a',
-          type: 'dynamic',
-        },
-        {
-          sourceProjectName,
-          sourceProjectFile: 'libs/proj/index.ts',
           targetProjectName: 'proj4ab',
           type: 'static',
         },
@@ -64,6 +58,12 @@ describe('explicit project dependencies', () => {
           sourceProjectFile: 'libs/proj/index.ts',
           targetProjectName: 'npm:npm-package',
           type: 'static',
+        },
+        {
+          sourceProjectName,
+          sourceProjectFile: 'libs/proj/index.ts',
+          targetProjectName: 'proj3a',
+          type: 'dynamic',
         },
       ]);
     });
@@ -380,6 +380,19 @@ describe('explicit project dependencies', () => {
 
               nx-ignore-next-line */
               import { foo } from '@proj/proj4ab';
+              
+              /*
+
+              nx-ignore-next-line */
+              import { foo } from '@proj/proj4ab'; import { foo } from '@proj/project-3';
+              
+              /* eslint-ignore */ /* nx-ignore-next-line */
+              import { foo } from '@proj/proj4ab'; import { foo } from '@proj/project-3';
+              
+              const obj = {
+                // nx-ignore-next-line
+                a: import('@proj/proj4ab')
+              }
             `,
           },
         ],
@@ -455,123 +468,6 @@ describe('explicit project dependencies', () => {
           //     \`import { A } from '@proj/my-second-proj'\`;
           //     \`import { B, C, D } from '@proj/project-3'\`;
           //     \`require('@proj/proj4ab')\`;
-          //   `,
-          // },
-        ],
-      });
-
-      const res = buildExplicitTypeScriptDependencies(
-        builder.graph,
-        ctx.filesToProcess
-      );
-
-      expect(res).toEqual([]);
-    });
-  });
-
-  /**
-   * In version 8, Angular deprecated the loadChildren string syntax in favor of using dynamic imports, but it is still
-   * fully supported by the framework:
-   *
-   * https://angular.io/guide/deprecations#loadchildren-string-syntax
-   */
-  describe('legacy Angular loadChildren string syntax', () => {
-    it('should build explicit dependencies for legacy Angular loadChildren string syntax', async () => {
-      const sourceProjectName = 'proj';
-      const { ctx, builder } = await createVirtualWorkspace({
-        sourceProjectName,
-        sourceProjectFiles: [
-          {
-            path: 'libs/proj/file-1.ts',
-            content: `
-              const a = { loadChildren: '@proj/proj4ab#a' };
-            `,
-          },
-          {
-            path: 'libs/proj/file-2.ts',
-            content: `
-              const routes: Routes = [{
-                path: 'lazy',
-                loadChildren: '@proj/project-3#LazyModule',
-              }];
-            `,
-          },
-          /**
-           * TODO: This case, where a no subsitution template literal is used, is not working
-           */
-          // {
-          //   path: 'libs/proj/no-substitution-template-literal.ts',
-          //   content: `
-          //     const a = {
-          //       loadChildren: \`@proj/my-second-proj\`
-          //     };
-          //   `,
-          // },
-        ],
-      });
-
-      const res = buildExplicitTypeScriptDependencies(
-        builder.graph,
-        ctx.filesToProcess
-      );
-
-      expect(res).toEqual([
-        {
-          sourceProjectName,
-          sourceProjectFile: 'libs/proj/file-1.ts',
-          targetProjectName: 'proj4ab',
-          type: 'dynamic',
-        },
-        {
-          sourceProjectName,
-          sourceProjectFile: 'libs/proj/file-2.ts',
-          targetProjectName: 'proj3a',
-          type: 'dynamic',
-        },
-      ]);
-    });
-
-    it('should not build explicit dependencies when nx-ignore-next-line comments are present', async () => {
-      const sourceProjectName = 'proj';
-      const { ctx, builder } = await createVirtualWorkspace({
-        sourceProjectName,
-        sourceProjectFiles: [
-          {
-            path: 'libs/proj/file-1.ts',
-            content: `
-              const a = {
-                // nx-ignore-next-line
-                loadChildren: '@proj/proj4ab#a'
-              };
-            `,
-          },
-          /**
-           * TODO: This case, where a multi-line comment is used, is not working
-           */
-          // {
-          //   path: 'libs/proj/file-2.ts',
-          //   content: `
-          //     const a = {
-          //       /* nx-ignore-next-line */
-          //       loadChildren: '@proj/proj4ab#a'
-          //     };
-          //   `,
-          // },
-          /**
-           * TODO: These cases, where loadChildren is on the same line as the variable declaration, are not working
-           */
-          // {
-          //   path: 'libs/proj/file-3.ts',
-          //   content: `
-          //     // nx-ignore-next-line
-          //     const a = { loadChildren: '@proj/proj4ab#a' };
-          //   `,
-          // },
-          // {
-          //   path: 'libs/proj/file-4.ts',
-          //   content: `
-          //     /* nx-ignore-next-line */
-          //     const a = { loadChildren: '@proj/proj4ab#a' };
           //   `,
           // },
         ],

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.ts
@@ -5,6 +5,8 @@ import {
   ProjectFileMap,
   ProjectGraph,
 } from '../../../../config/project-graph';
+import { join, relative } from 'path';
+import { workspaceRoot } from '../../../../utils/workspace-root';
 
 export type ExplicitDependency = {
   sourceProjectName: string;
@@ -18,10 +20,7 @@ export function buildExplicitTypeScriptDependencies(
   filesToProcess: ProjectFileMap
 ): ExplicitDependency[] {
   let results: ExplicitDependency[];
-  if (
-    process.env.NX_NATIVE_TS_DEPS &&
-    process.env.NX_NATIVE_TS_DEPS !== 'false'
-  ) {
+  if (process.env.NX_NATIVE_TS_DEPS !== 'false') {
     results = buildExplicitTypeScriptDependenciesWithSwc(filesToProcess, graph);
   } else {
     results = buildExplicitTypeScriptDependenciesWithTs(filesToProcess, graph);
@@ -109,7 +108,7 @@ function buildExplicitTypeScriptDependenciesWithSwc(
     filesToProcess[project] ??= [];
     for (const { file } of fileData) {
       if (moduleExtensions.some((ext) => file.endsWith(ext))) {
-        filesToProcess[project].push(file);
+        filesToProcess[project].push(join(workspaceRoot, file));
       }
     }
   }
@@ -127,7 +126,7 @@ function buildExplicitTypeScriptDependenciesWithSwc(
     for (const importExpr of staticImportExpressions) {
       const dependency = convertImportToDependency(
         importExpr,
-        file,
+        relative(workspaceRoot, file),
         sourceProject,
         DependencyType.static,
         targetProjectLocator
@@ -143,7 +142,7 @@ function buildExplicitTypeScriptDependenciesWithSwc(
     for (const importExpr of dynamicImportExpressions) {
       const dependency = convertImportToDependency(
         importExpr,
-        file,
+        relative(workspaceRoot, file),
         sourceProject,
         DependencyType.dynamic,
         targetProjectLocator


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Processing of typescript dependencies defaults to the typescript implementation.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Processing of typescript dependencies defaults to the faster, more accurate Rust implementation.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Related to #17976 