### PR TITLE
fix(core): update e2e tsconfig extends to be mapped to the correct root tsconfig

### DIFF
--- a/e2e/nx-misc/src/workspace.test.ts
+++ b/e2e/nx-misc/src/workspace.test.ts
@@ -26,8 +26,7 @@ describe('@nx/workspace:convert-to-monorepo', () => {
 
   afterEach(() => cleanupProject());
 
-  // TODO(@ndcunningham): Re-enable this once it is passing again
-  xit('should convert a standalone project to a monorepo', async () => {
+  it('should convert a standalone project to a monorepo', async () => {
     const reactApp = uniq('reactapp');
     runCLI(
       `generate @nx/react:app ${reactApp} --rootProject=true --bundler=webpack --unitTestRunner=jest --e2eTestRunner=cypress --no-interactive`

--- a/packages/workspace/src/generators/move/lib/update-project-root-files.ts
+++ b/packages/workspace/src/generators/move/lib/update-project-root-files.ts
@@ -116,7 +116,10 @@ export function updateFilesForNonRootProjects(
       join(schema.relativeToRootDestination, file),
       'utf-8'
     );
-    const newContent = oldContent.replace(regex, newRelativeRoot);
+    let newContent = oldContent.replace(regex, newRelativeRoot);
+    if (file == 'tsconfig.json') {
+      newContent = newContent.replace('tsconfig.json', 'tsconfig.base.json');
+    }
     tree.write(join(schema.relativeToRootDestination, file), newContent);
   }
 }


### PR DESCRIPTION
### What has changed:
- When we update non root projects ensures that the `tsconfig` extends to the `tsconfig.base.json`