### PR TITLE
fix(core): provide taskGraph for every task calculation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,10 +208,9 @@ jobs:
     executor: macos
     environment:
       NX_E2E_CI_CACHE_KEY: e2e-circleci-macos
-      NX_DAEMON: 'false' # TODO: Fix the hashing issue and re-enable this
+      NX_DAEMON: 'true'
       NX_PERF_LOGGING: 'false'
       SELECTED_PM: 'npm' # explicitly define npm for macOS tests
-      NX_SKIP_NX_CACHE: 'true' # TODO: Figure out what is going on with the cache and renable it
     steps:
       - run:
           name: Set dynamic nx run variable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,9 +208,10 @@ jobs:
     executor: macos
     environment:
       NX_E2E_CI_CACHE_KEY: e2e-circleci-macos
-      NX_DAEMON: 'true'
+      NX_DAEMON: 'false' # TODO: set to true after #18410
       NX_PERF_LOGGING: 'false'
       SELECTED_PM: 'npm' # explicitly define npm for macOS tests
+      NX_SKIP_NX_CACHE: 'true' # TODO: Remove after #18410
     steps:
       - run:
           name: Set dynamic nx run variable

--- a/packages/linter/src/executors/eslint/hasher.ts
+++ b/packages/linter/src/executors/eslint/hasher.ts
@@ -17,7 +17,7 @@ export default async function run(
     projectsConfigurations: ProjectsConfigurations;
   }
 ): Promise<Hash> {
-  const res = await context.hasher.hashTask(task);
+  const res = await context.hasher.hashTask(task, context.taskGraph);
   if (task.overrides['hasTypeAwareRules'] === true) {
     return res;
   }

--- a/packages/nx/src/command-line/affected/print-affected.ts
+++ b/packages/nx/src/command-line/affected/print-affected.ts
@@ -76,7 +76,6 @@ async function createTasks(
     {},
     [],
     projectGraph,
-    taskGraph,
     nxJson,
     {},
     fileHasher
@@ -85,7 +84,7 @@ async function createTasks(
   const tasks = Object.values(taskGraph.tasks);
 
   await Promise.all(
-    tasks.map((t) => hashTask(hasher, projectGraph, {} as any, t))
+    tasks.map((t) => hashTask(hasher, projectGraph, taskGraph, t))
   );
 
   return tasks.map((task) => ({

--- a/packages/nx/src/daemon/server/handle-hash-tasks.ts
+++ b/packages/nx/src/daemon/server/handle-hash-tasks.ts
@@ -10,7 +10,6 @@ import { setHashEnv } from '../../hasher/set-hash-env';
  * TaskHasher has a cache inside, so keeping it around results in faster performance
  */
 let storedProjectGraph: any = null;
-let storedTaskGraph: any = null;
 let storedHasher: InProcessTaskHasher | null = null;
 
 export async function handleHashTasks(payload: {
@@ -27,18 +26,18 @@ export async function handleHashTasks(payload: {
 
   if (projectGraph !== storedProjectGraph) {
     storedProjectGraph = projectGraph;
-    storedTaskGraph = payload.taskGraph;
     storedHasher = new InProcessTaskHasher(
       projectFileMap,
       allWorkspaceFiles,
       projectGraph,
-      payload.taskGraph,
       nxJson,
       payload.runnerOptions,
       fileHasher
     );
   }
-  const response = JSON.stringify(await storedHasher.hashTasks(payload.tasks));
+  const response = JSON.stringify(
+    await storedHasher.hashTasks(payload.tasks, payload.taskGraph)
+  );
   return {
     response,
     description: 'handleHashTasks',

--- a/packages/nx/src/hasher/hash-task.ts
+++ b/packages/nx/src/hasher/hash-task.ts
@@ -34,7 +34,7 @@ export async function hashTasksThatDoNotDependOnOutputsOfOtherTasks(
     })
     .map((t) => t.task);
 
-  const hashes = await hasher.hashTasks(tasksToHash);
+  const hashes = await hasher.hashTasks(tasksToHash, taskGraph);
   for (let i = 0; i < tasksToHash.length; i++) {
     tasksToHash[i].hash = hashes[i].value;
     tasksToHash[i].hashDetails = hashes[i].details;
@@ -59,7 +59,7 @@ export async function hashTask(
         projectsConfigurations,
         nxJsonConfiguration: readNxJson(),
       } as any)
-    : hasher.hashTask(task));
+    : hasher.hashTask(task, taskGraph));
   task.hash = value;
   task.hashDetails = details;
 }

--- a/packages/nx/src/hasher/task-hasher.ts
+++ b/packages/nx/src/hasher/task-hasher.ts
@@ -59,8 +59,19 @@ export interface Hash {
 }
 
 export interface TaskHasher {
-  hashTask(task: Task, taskGraph?: TaskGraph): Promise<Hash>;
-  hashTasks(tasks: Task[], taskGraph?: TaskGraph): Promise<Hash[]>;
+  /**
+   * @deprecated use hashTask(task:Task, taskGraph: TaskGraph)
+   * @param task
+   */
+  hashTask(task: Task): Promise<Hash>;
+  hashTask(task: Task, taskGraph: TaskGraph): Promise<Hash>;
+
+  /**
+   * @deprecated use hashTasks(tasks:Task[], taskGraph: TaskGraph)
+   * @param tasks
+   */
+  hashTasks(tasks: Task[]): Promise<Hash[]>;
+  hashTasks(tasks: Task[], taskGraph: TaskGraph): Promise<Hash[]>;
 }
 
 export type Hasher = TaskHasher;
@@ -71,11 +82,11 @@ export class DaemonBasedTaskHasher implements TaskHasher {
     private readonly runnerOptions: any
   ) {}
 
-  async hashTasks(tasks: Task[], taskGraph: TaskGraph): Promise<Hash[]> {
+  async hashTasks(tasks: Task[], taskGraph?: TaskGraph): Promise<Hash[]> {
     return this.daemonClient.hashTasks(this.runnerOptions, tasks, taskGraph);
   }
 
-  async hashTask(task: Task, taskGraph: TaskGraph): Promise<Hash> {
+  async hashTask(task: Task, taskGraph?: TaskGraph): Promise<Hash> {
     return (
       await this.daemonClient.hashTasks(this.runnerOptions, [task], taskGraph)
     )[0];
@@ -124,11 +135,11 @@ export class InProcessTaskHasher implements TaskHasher {
     );
   }
 
-  async hashTasks(tasks: Task[], taskGraph: TaskGraph): Promise<Hash[]> {
+  async hashTasks(tasks: Task[], taskGraph?: TaskGraph): Promise<Hash[]> {
     return await Promise.all(tasks.map((t) => this.hashTask(t, taskGraph)));
   }
 
-  async hashTask(task: Task, taskGraph: TaskGraph): Promise<Hash> {
+  async hashTask(task: Task, taskGraph?: TaskGraph): Promise<Hash> {
     const res = await this.taskHasher.hashTask(task, taskGraph, [
       task.target.project,
     ]);

--- a/packages/nx/src/hasher/task-hasher.ts
+++ b/packages/nx/src/hasher/task-hasher.ts
@@ -59,8 +59,8 @@ export interface Hash {
 }
 
 export interface TaskHasher {
-  hashTask(task: Task, taskGraph: TaskGraph): Promise<Hash>;
-  hashTasks(tasks: Task[], taskGraph: TaskGraph): Promise<Hash[]>;
+  hashTask(task: Task, taskGraph?: TaskGraph): Promise<Hash>;
+  hashTasks(tasks: Task[], taskGraph?: TaskGraph): Promise<Hash[]>;
 }
 
 export type Hasher = TaskHasher;

--- a/packages/nx/src/hasher/task-hasher.ts
+++ b/packages/nx/src/hasher/task-hasher.ts
@@ -59,8 +59,8 @@ export interface Hash {
 }
 
 export interface TaskHasher {
-  hashTask(task: Task): Promise<Hash>;
-  hashTasks(tasks: Task[]): Promise<Hash[]>;
+  hashTask(task: Task, taskGraph: TaskGraph): Promise<Hash>;
+  hashTasks(tasks: Task[], taskGraph: TaskGraph): Promise<Hash[]>;
 }
 
 export type Hasher = TaskHasher;
@@ -68,25 +68,16 @@ export type Hasher = TaskHasher;
 export class DaemonBasedTaskHasher implements TaskHasher {
   constructor(
     private readonly daemonClient: DaemonClient,
-    private readonly taskGraph: TaskGraph,
     private readonly runnerOptions: any
   ) {}
 
-  async hashTasks(tasks: Task[]): Promise<Hash[]> {
-    return this.daemonClient.hashTasks(
-      this.runnerOptions,
-      tasks,
-      this.taskGraph
-    );
+  async hashTasks(tasks: Task[], taskGraph: TaskGraph): Promise<Hash[]> {
+    return this.daemonClient.hashTasks(this.runnerOptions, tasks, taskGraph);
   }
 
-  async hashTask(task: Task): Promise<Hash> {
+  async hashTask(task: Task, taskGraph: TaskGraph): Promise<Hash> {
     return (
-      await this.daemonClient.hashTasks(
-        this.runnerOptions,
-        [task],
-        this.taskGraph
-      )
+      await this.daemonClient.hashTasks(this.runnerOptions, [task], taskGraph)
     )[0];
   }
 }
@@ -99,7 +90,6 @@ export class InProcessTaskHasher implements TaskHasher {
     private readonly projectFileMap: ProjectFileMap,
     private readonly allWorkspaceFiles: FileData[],
     private readonly projectGraph: ProjectGraph,
-    private readonly taskGraph: TaskGraph,
     private readonly nxJson: NxJsonConfiguration,
     private readonly options: any,
     private readonly fileHasher: FileHasher
@@ -129,18 +119,19 @@ export class InProcessTaskHasher implements TaskHasher {
       this.projectFileMap,
       this.allWorkspaceFiles,
       this.projectGraph,
-      this.taskGraph,
       this.fileHasher,
       { selectivelyHashTsConfig: this.options.selectivelyHashTsConfig ?? false }
     );
   }
 
-  async hashTasks(tasks: Task[]): Promise<Hash[]> {
-    return await Promise.all(tasks.map((t) => this.hashTask(t)));
+  async hashTasks(tasks: Task[], taskGraph: TaskGraph): Promise<Hash[]> {
+    return await Promise.all(tasks.map((t) => this.hashTask(t, taskGraph)));
   }
 
-  async hashTask(task: Task): Promise<Hash> {
-    const res = await this.taskHasher.hashTask(task, [task.target.project]);
+  async hashTask(task: Task, taskGraph: TaskGraph): Promise<Hash> {
+    const res = await this.taskHasher.hashTask(task, taskGraph, [
+      task.target.project,
+    ]);
     const command = this.hashCommand(task);
     return {
       value: hashArray([res.value, command]),
@@ -203,7 +194,6 @@ class TaskHasherImpl {
     private readonly projectFileMap: ProjectFileMap,
     private readonly allWorkspaceFiles: FileData[],
     private readonly projectGraph: ProjectGraph,
-    private readonly taskGraph: TaskGraph,
     private readonly fileHasher: FileHasher,
     private readonly options: { selectivelyHashTsConfig: boolean }
   ) {
@@ -211,7 +201,11 @@ class TaskHasherImpl {
     this.calculateExternalDependencyHashes();
   }
 
-  async hashTask(task: Task, visited: string[]): Promise<PartialHash> {
+  async hashTask(
+    task: Task,
+    taskGraph: TaskGraph,
+    visited: string[]
+  ): Promise<PartialHash> {
     return Promise.resolve().then(async () => {
       const { selfInputs, depsInputs, depsOutputs, projectInputs } = getInputs(
         task,
@@ -226,6 +220,7 @@ class TaskHasherImpl {
         depsInputs,
         depsOutputs,
         projectInputs,
+        taskGraph,
         visited
       );
 
@@ -245,6 +240,7 @@ class TaskHasherImpl {
     projectName: string,
     task: Task,
     namedInput: string,
+    taskGraph: TaskGraph,
     visited: string[]
   ): Promise<PartialHash> {
     const projectNode = this.projectGraph.nodes[projectName];
@@ -265,6 +261,7 @@ class TaskHasherImpl {
       depsInputs,
       depsOutputs,
       [],
+      taskGraph,
       visited
     );
   }
@@ -276,6 +273,7 @@ class TaskHasherImpl {
     depsInputs: { input: string; dependencies: true }[],
     depsOutputs: ExpandedDepsOutput[],
     projectInputs: { input: string; projects: string[] }[],
+    taskGraph: TaskGraph,
     visited: string[]
   ) {
     const projectGraphDeps = this.projectGraph.dependencies[projectName] ?? [];
@@ -287,9 +285,10 @@ class TaskHasherImpl {
       task,
       depsInputs,
       projectGraphDeps,
+      taskGraph,
       visited
     );
-    const depsOut = await this.hashDepsOutputs(task, depsOutputs);
+    const depsOut = await this.hashDepsOutputs(task, depsOutputs, taskGraph);
     const projects = await this.hashProjectInputs(projectInputs);
 
     return this.combinePartialHashes([
@@ -319,6 +318,7 @@ class TaskHasherImpl {
     task: Task,
     inputs: { input: string }[],
     projectGraphDeps: ProjectGraphDependency[],
+    taskGraph: TaskGraph,
     visited: string[]
   ): Promise<PartialHash[]> {
     return (
@@ -335,6 +335,7 @@ class TaskHasherImpl {
                     d.target,
                     task,
                     input.input || 'default',
+                    taskGraph,
                     visited
                   );
                 } else {
@@ -352,7 +353,8 @@ class TaskHasherImpl {
 
   private async hashDepsOutputs(
     task: Task,
-    depsOutputs: ExpandedDepsOutput[]
+    depsOutputs: ExpandedDepsOutput[],
+    taskGraph: TaskGraph
   ): Promise<PartialHash[]> {
     if (depsOutputs.length === 0) {
       return [];
@@ -363,6 +365,7 @@ class TaskHasherImpl {
         ...(await this.hashDepOuputs(
           task,
           dependentTasksOutputFiles,
+          taskGraph,
           transitive
         ))
       );
@@ -373,16 +376,17 @@ class TaskHasherImpl {
   private async hashDepOuputs(
     task: Task,
     dependentTasksOutputFiles: string,
+    taskGraph: TaskGraph,
     transitive?: boolean
   ): Promise<PartialHash[]> {
     // task has no dependencies
-    if (!this.taskGraph.dependencies[task.id]) {
+    if (!taskGraph.dependencies[task.id]) {
       return [];
     }
 
     const partialHashes: PartialHash[] = [];
-    for (const d of this.taskGraph.dependencies[task.id]) {
-      const childTask = this.taskGraph.tasks[d];
+    for (const d of taskGraph.dependencies[task.id]) {
+      const childTask = taskGraph.tasks[d];
       const outputs = getOutputsForTargetAndConfiguration(
         childTask,
         this.projectGraph.nodes[childTask.target.project]
@@ -413,6 +417,7 @@ class TaskHasherImpl {
           ...(await this.hashDepOuputs(
             childTask,
             dependentTasksOutputFiles,
+            taskGraph,
             transitive
           ))
         );

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -233,14 +233,13 @@ export async function invokeTasksRunner({
 
   let hasher;
   if (daemonClient.enabled()) {
-    hasher = new DaemonBasedTaskHasher(daemonClient, taskGraph, runnerOptions);
+    hasher = new DaemonBasedTaskHasher(daemonClient, runnerOptions);
   } else {
     const { projectFileMap, allWorkspaceFiles } = getProjectFileMap();
     hasher = new InProcessTaskHasher(
       projectFileMap,
       allWorkspaceFiles,
       projectGraph,
-      taskGraph,
       nxJson,
       runnerOptions,
       fileHasher

--- a/packages/plugin/src/generators/executor/executor.spec.ts
+++ b/packages/plugin/src/generators/executor/executor.spec.ts
@@ -158,7 +158,7 @@ describe('NxPlugin Executor Generator', () => {
          * you can consume workspace details from the context.
          */
         export const myExecutorHasher: CustomHasher = async (task, context) => {
-          return context.hasher.hashTask(task);
+          return context.hasher.hashTask(task, context.taskGraph);
         };
 
         export default myExecutorHasher;

--- a/packages/plugin/src/generators/executor/files/hasher/__fileName__/hasher.ts__tmpl__
+++ b/packages/plugin/src/generators/executor/files/hasher/__fileName__/hasher.ts__tmpl__
@@ -6,7 +6,7 @@ import { CustomHasher } from '@nx/devkit';
  * you can consume workspace details from the context.
  */
 export const <%=propertyName%>Hasher: CustomHasher = async (task, context) => {
-    return context.hasher.hashTask(task);
+    return context.hasher.hashTask(task, context.taskGraph);
 };
 
 export default <%=propertyName%>Hasher;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When using the daemon - the taskGraph was not updated while recalculating the inputs for the task hashes.  

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The taskGraph is now passed and used for every call to the `hashTask` function, so the latest version of the taskGraph is used. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
