### PR TITLE
feat(core): support multiple "withTarget" options in nx show

### DIFF
--- a/packages/nx/src/command-line/show/command-object.ts
+++ b/packages/nx/src/command-line/show/command-object.ts
@@ -14,7 +14,7 @@ export type ShowProjectsOptions = NxShowArgs & {
   head: string;
   affected: boolean;
   projects: string[];
-  withTarget: string;
+  withTarget: string[];
 };
 
 export type ShowProjectOptions = NxShowArgs & {
@@ -73,6 +73,7 @@ const showProjectsCommand: CommandModule<NxShowArgs, ShowProjectsOptions> = {
         type: 'string',
         alias: ['t'],
         description: 'Show only projects that have a specific target',
+        coerce: parseCSV,
       })
       .implies('untracked', 'affected')
       .implies('uncommitted', 'affected')

--- a/packages/nx/src/command-line/show/show.ts
+++ b/packages/nx/src/command-line/show/show.ts
@@ -40,7 +40,7 @@ export async function showProjectsHandler(
 
   if (args.withTarget) {
     graph.nodes = Object.entries(graph.nodes).reduce((acc, [name, node]) => {
-      if (node.data.targets?.[args.withTarget]) {
+      if (args.withTarget.some((t) => node.data.targets?.[t])) {
         acc[name] = node;
       }
       return acc;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The new API `nx show projects` only supports one target for `--withTarget` flag. Previously it was possible to run something like `nx print-affected --target=target1,target2 --select=projects` and it would print all projects that has either `target1` or `target2`
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
This change brings an ability to run `nx show projects --withTarget=target1,target2` which just mimics the behavior of deprecated API
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
