### PR TITLE
fix(storybook): do not set default host as localhost

### DIFF
--- a/docs/generated/packages/storybook/executors/storybook.json
+++ b/docs/generated/packages/storybook/executors/storybook.json
@@ -18,11 +18,7 @@
         "default": 9009
       },
       "previewUrl": { "type": "string", "description": "Preview URL." },
-      "host": {
-        "type": "string",
-        "description": "Host to listen on.",
-        "default": "localhost"
-      },
+      "host": { "type": "string", "description": "Host to listen on." },
       "staticDir": {
         "type": "array",
         "description": "Directory where to load static files from, array of strings.",

--- a/packages/storybook/src/executors/storybook/schema.json
+++ b/packages/storybook/src/executors/storybook/schema.json
@@ -23,8 +23,7 @@
     },
     "host": {
       "type": "string",
-      "description": "Host to listen on.",
-      "default": "localhost"
+      "description": "Host to listen on."
     },
     "staticDir": {
       "type": "array",


### PR DESCRIPTION
## Current Behavior

`host` defaults to localhost, overriding native behaviour.

## Expected Behavior

`host` should not default to anything (if not set, leave undefined)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18376
