### PR TITLE
fix(core): add verbose logging for CNW

### DIFF
--- a/packages/create-nx-workspace/src/utils/output.ts
+++ b/packages/create-nx-workspace/src/utils/output.ts
@@ -204,6 +204,14 @@ class CLIOutput {
 
     this.addNewline();
   }
+
+  verbose(...args: string[]) {
+    if (process.env.NX_VERBOSE_LOGGING === 'true') {
+      this.addNewline();
+      this.writeOptionalOutputBody(args);
+      this.addNewline();
+    }
+  }
 }
 
 export const output = new CLIOutput();


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
when CNW errors out in the sub process its hard to know what happened in some instances.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

using NX_VERBOSE_LOGGING=true will log out the sub commands being ran during CNW.
also log error file contents if in CI
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
