### PR TITLE
feat(nx-dev): plugin quality indicators

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/COMMUNITY_PLUGIN.MD
+++ b/.github/PULL_REQUEST_TEMPLATE/COMMUNITY_PLUGIN.MD
@@ -5,6 +5,27 @@ _[Please make sure you have read the submission guidelines before posting an PR]
 
 Thanks for submitting your Nx Plugin to our community plugins list. Make sure to follow these steps to ensure that your PR is approved in a timely manner.
 
+## Plugin Requirements
+
+Before you submit your plugin to be listed in our registry, it needs to meet the following requirements:
+- Run some kind of automated e2e tests in your repository
+- Include `@nx/devkit` as a `dependency` in the plugin's `package.json`
+- List a `repository.url` in the plugin's `package.json`
+
+i.e.
+
+```
+{
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nrwl/nx.git",
+    "directory": "packages/web"
+  }
+}
+```
+
+Note: We reserve the right to remove unmaintained plugins from the registry.  If the plugins become maintained again, they can be resubmitted to the registry.
+
 ## Steps to Submit Your Plugin
 - Use the following commit message template: `chore(core): nx plugin submission [PLUGIN_NAME]`
 - Update the `community/approved-plugins.json` file with a new entry for your plugin that includes `name`, `url`, `description`:
@@ -21,7 +42,7 @@ Example:
 }]
 ```
 
-Once merged, your will plugin will be available when running the `nx list` command, and will also be available in the Plugin browser on [nx.dev](https://nx.dev)
+Once merged, your plugin will be available when running the `nx list` command, and will also be available in the Plugin Registry on [nx.dev](https://nx.dev/extending-nx/registry)
 -->
 
 # Community Plugin Submission

--- a/community/approved-plugins.json
+++ b/community/approved-plugins.json
@@ -45,11 +45,6 @@
     "url": "https://nx-plugins.netlify.app/"
   },
   {
-    "name": "@codebrew/nx-aws-cdk",
-    "description": "An Nx plugin for aws cdk develop.",
-    "url": "https://github.com/codebrewlab/nx-plugins/tree/main/packages/nx-aws-cdk"
-  },
-  {
     "name": "@ago-dev/nx-aws-cdk-v2",
     "description": "An nx plugin for the aws-cdk v2.",
     "url": "https://github.com/adrian-goe/nx-aws-cdk-v2"
@@ -90,19 +85,9 @@
     "url": "https://github.com/nxext/nx-extensions/tree/main/packages/capacitor"
   },
   {
-    "name": "@nxtend/firebase",
-    "description": "An Nx plugin for developing applications using Firebase",
-    "url": "https://github.com/nxtend-team/nxtend/tree/main/packages/firebase"
-  },
-  {
     "name": "@angular-architects/ddd",
     "description": "Nx plugin for structuring a monorepo with domains and layers",
     "url": "https://github.com/angular-architects/nx-ddd-plugin"
-  },
-  {
-    "name": "@offeringsolutions/nx-karma-to-jest",
-    "description": "Nx plugin for replacing karma with jest in an Nx workspace",
-    "url": "https://github.com/FabianGosebrink/nx-karma-to-jest"
   },
   {
     "name": "@flowaccount/nx-serverless",
@@ -123,21 +108,6 @@
     "name": "@ns3/nx-playwright",
     "description": "Nx plugin to run playwright e2e tests in an Nx workspace",
     "url": "https://github.com/Bielik20/nx-plugins/tree/master/packages/nx-playwright"
-  },
-  {
-    "name": "@dev-thought/nx-deploy-it",
-    "description": "Nx plugin to deploy applications on your favorite cloud provider",
-    "url": "https://github.com/Dev-Thought/nx-plugins/tree/master/libs/nx-deploy-it"
-  },
-  {
-    "name": "@offeringsolutions/nx-protractor-to-cypress",
-    "description": "Nx plugin to replace protractor with cypress in an nx workspace",
-    "url": "https://github.com/FabianGosebrink/nx-protractor-to-cypress"
-  },
-  {
-    "name": "@angular-custom-builders/lite-serve",
-    "description": "Nx plugin to run the e2e test on an existing dist folder",
-    "url": "https://github.com/mauriziovitale/angular-plugins/tree/master/libs/lite-serve"
   },
   {
     "name": "@nx-plus/nuxt",

--- a/community/approved-plugins.json
+++ b/community/approved-plugins.json
@@ -25,8 +25,23 @@
     "url": "https://github.com/nxkit/nxkit"
   },
   {
-    "name": "nx-plugins",
-    "description": "Nx plugin integrations with ESBuild / Vite / Snowpack / Prisma, with derived ESBuild / Snowpack / ... plugins.",
+    "name": "nx-plugin-esbuild",
+    "description": "Nx plugin integrations with ESBuild.",
+    "url": "https://nx-plugins.netlify.app/"
+  },
+  {
+    "name": "nx-plugin-vite",
+    "description": "Nx plugin integrations with Vite.",
+    "url": "https://nx-plugins.netlify.app/"
+  },
+  {
+    "name": "nx-plugin-snowpack",
+    "description": "Nx plugin integrations with Snowpack.",
+    "url": "https://nx-plugins.netlify.app/"
+  },
+  {
+    "name": "nx-plugin-prisma",
+    "description": "Nx plugin integrations with Snowpack.",
     "url": "https://nx-plugins.netlify.app/"
   },
   {
@@ -235,7 +250,7 @@
     "url": "https://github.com/trafilea/nx-shopify"
   },
   {
-    "name": "nx-dotnet",
+    "name": "@nx-dotnet/core",
     "description": "Nx plugin for developing and housing .NET projects within an Nx workspace.",
     "url": "https://github.com/nx-dotnet/nx-dotnet"
   },

--- a/docs/shared/plugins/maintain-published-plugin.md
+++ b/docs/shared/plugins/maintain-published-plugin.md
@@ -19,7 +19,27 @@ After that, you can then install your plugin like any other npm package,
 
 ## List your Nx Plugin
 
-Nx provides a utility (`nx list`) that lists both core and community plugins. To submit your plugin, please follow the steps below:
+Nx provides a utility (`nx list`) that lists both core and community plugins. You can submit your plugin to be added to this list, but it needs to meet a few criteria first:
+
+- Run some kind of automated e2e tests in your repository
+- Include `@nx/devkit` as a `dependency` in the plugin's `package.json`
+- List a `repository.url` in the plugin's `package.json`
+
+```jsonc {% fileName="package.json" %}
+{
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nrwl/nx.git",
+    "directory": "packages/web"
+  }
+}
+```
+
+{% callout type="warning" title="Unmaintained Plugins" %}
+We reserve the right to remove unmaintained plugins from the registry. If the plugins become maintained again, they can be resubmitted to the registry.
+{% /callout %}
+
+Once those criteria are met, you can submit your plugin by following the steps below:
 
 - Fork the [Nx repo](https://github.com/nrwl/nx/fork) (if you haven't already)
 - Update the [`community/approved-plugins.json` file](https://github.com/nrwl/nx/blob/master/community/approved-plugins.json) with a new entry for your plugin that includes name, url and description

--- a/nx-dev/nx-dev/pages/extending-nx/quality-indicators.json
+++ b/nx-dev/nx-dev/pages/extending-nx/quality-indicators.json
@@ -1,594 +1,676 @@
 {
+  "@nx/angular": {
+    "lastPublishedDate": "2023-07-31T13:26:25.163Z",
+    "npmDownloads": 433284,
+    "githubStars": 18536
+  },
+  "@nx/cypress": {
+    "lastPublishedDate": "2023-07-31T13:26:10.027Z",
+    "npmDownloads": 1155708,
+    "githubStars": 18536
+  },
+  "@nx/detox": {
+    "lastPublishedDate": "2023-07-31T13:26:44.703Z",
+    "npmDownloads": 72037,
+    "githubStars": 18536
+  },
+  "@nx/devkit": {
+    "lastPublishedDate": "2023-07-31T13:25:14.034Z",
+    "npmDownloads": 4436007,
+    "githubStars": 18536
+  },
+  "@nx/esbuild": {
+    "lastPublishedDate": "2023-07-31T13:25:35.264Z",
+    "npmDownloads": 222196,
+    "githubStars": 18536
+  },
+  "@nx/eslint-plugin": {
+    "lastPublishedDate": "2023-07-31T13:25:37.806Z",
+    "npmDownloads": 1518752,
+    "githubStars": 18536
+  },
+  "@nx/expo": {
+    "lastPublishedDate": "2023-07-31T13:26:57.711Z",
+    "npmDownloads": 27833,
+    "githubStars": 18536
+  },
+  "@nx/express": {
+    "lastPublishedDate": "2023-07-31T13:26:32.209Z",
+    "npmDownloads": 136341,
+    "githubStars": 18536
+  },
+  "@nx/jest": {
+    "lastPublishedDate": "2023-07-31T13:25:46.305Z",
+    "npmDownloads": 1710746,
+    "githubStars": 18536
+  },
+  "@nx/js": {
+    "lastPublishedDate": "2023-07-31T13:25:30.195Z",
+    "npmDownloads": 2456765,
+    "githubStars": 18536
+  },
+  "@nx/linter": {
+    "lastPublishedDate": "2023-07-31T13:25:53.612Z",
+    "npmDownloads": 1891220,
+    "githubStars": 18536
+  },
+  "@nx/nest": {
+    "lastPublishedDate": "2023-07-31T13:26:35.646Z",
+    "npmDownloads": 468574,
+    "githubStars": 18536
+  },
+  "@nx/next": {
+    "lastPublishedDate": "2023-07-31T13:26:54.477Z",
+    "npmDownloads": 370856,
+    "githubStars": 18536
+  },
+  "@nx/node": {
+    "lastPublishedDate": "2023-07-31T13:26:12.510Z",
+    "npmDownloads": 789085,
+    "githubStars": 18536
+  },
+  "nx": {
+    "lastPublishedDate": "2023-07-31T13:25:19.774Z",
+    "npmDownloads": 15701158,
+    "githubStars": 18536
+  },
+  "@nx/playwright": {
+    "lastPublishedDate": "",
+    "npmDownloads": "",
+    "githubStars": 18536
+  },
+  "@nx/plugin": {
+    "lastPublishedDate": "2023-07-31T13:26:17.005Z",
+    "npmDownloads": 584062,
+    "githubStars": 18536
+  },
+  "@nx/react": {
+    "lastPublishedDate": "2023-07-31T13:26:19.350Z",
+    "npmDownloads": 792182,
+    "githubStars": 18536
+  },
+  "@nx/react-native": {
+    "lastPublishedDate": "2023-07-31T13:27:02.407Z",
+    "npmDownloads": 43926,
+    "githubStars": 18536
+  },
+  "@nx/rollup": {
+    "lastPublishedDate": "2023-07-31T13:25:56.293Z",
+    "npmDownloads": 137473,
+    "githubStars": 18536
+  },
+  "@nx/storybook": {
+    "lastPublishedDate": "2023-07-31T13:26:41.485Z",
+    "npmDownloads": 562080,
+    "githubStars": 18536
+  },
+  "@nx/vite": {
+    "lastPublishedDate": "2023-07-31T13:25:59.567Z",
+    "npmDownloads": 291173,
+    "githubStars": 18536
+  },
+  "@nx/web": {
+    "lastPublishedDate": "2023-07-31T13:26:02.010Z",
+    "npmDownloads": 985271,
+    "githubStars": 18536
+  },
+  "@nx/webpack": {
+    "lastPublishedDate": "2023-07-31T13:26:06.719Z",
+    "npmDownloads": 1143030,
+    "githubStars": 18536
+  },
+  "@nx/workspace": {
+    "lastPublishedDate": "2023-07-31T13:25:27.694Z",
+    "npmDownloads": 2498807,
+    "githubStars": 18536
+  },
   "@ahryman40k/nx-vitepress": {
     "lastPublishedDate": "2022-12-23T01:15:39.916Z",
-    "npmDownloads": 556,
-    "githubStars": 0,
-    "nxVersion": "15.4.0"
+    "npmDownloads": 45,
+    "githubStars": 0
   },
   "@nightwatch/nx": {
     "lastPublishedDate": "2022-12-05T21:50:17.172Z",
-    "githubDirectory": "packages/nightwatch",
-    "npmDownloads": 14,
-    "githubStars": 2,
-    "nxVersion": "15.2.4"
+    "npmDownloads": 57,
+    "githubStars": 2
   },
   "@nxkit/playwright": {
     "lastPublishedDate": "2023-06-06T17:50:01.235Z",
-    "githubDirectory": "packages/playwright",
-    "npmDownloads": 14223,
-    "githubStars": 36,
-    "nxVersion": "16.3.2"
+    "npmDownloads": 16049,
+    "githubStars": 36
   },
   "qwik-nx": {
     "lastPublishedDate": "2023-07-27T04:27:50.074Z",
-    "npmDownloads": 6809,
+    "npmDownloads": 4038,
     "githubStars": 113,
-    "nxVersion": "16.4.0"
+    "nxVersion": ">= 15 <= 17"
   },
   "@nxkit/style-dictionary": {
     "lastPublishedDate": "2023-06-06T17:50:01.313Z",
-    "githubDirectory": "packages/style-dictionary",
-    "npmDownloads": 8764,
-    "githubStars": 36,
-    "nxVersion": "16.3.2"
+    "npmDownloads": 8395,
+    "githubStars": 36
   },
   "nx-plugin-esbuild": {
     "lastPublishedDate": "2021-10-02T13:53:16.067Z",
-    "npmDownloads": 1220,
+    "npmDownloads": 480,
     "githubStars": -1,
-    "nxVersion": ""
+    "nxVersion": "12.7.2"
   },
   "nx-plugin-vite": {
     "lastPublishedDate": "2022-07-09T09:40:02.353Z",
-    "npmDownloads": 701,
-    "githubStars": 94,
-    "nxVersion": ""
+    "npmDownloads": 541,
+    "githubStars": 94
   },
   "nx-plugin-snowpack": {
     "lastPublishedDate": "2021-10-04T02:55:28.868Z",
-    "npmDownloads": 44,
+    "npmDownloads": 38,
     "githubStars": -1,
-    "nxVersion": ""
+    "nxVersion": "12.7.2"
   },
   "nx-plugin-prisma": {
     "lastPublishedDate": "2021-09-30T04:07:48.904Z",
-    "npmDownloads": 19,
+    "npmDownloads": 13,
     "githubStars": -1,
-    "nxVersion": ""
+    "nxVersion": "12.7.2"
   },
   "@codebrew/nx-aws-cdk": {
     "lastPublishedDate": "2022-01-28T05:22:43.508Z",
-    "npmDownloads": 3994,
+    "npmDownloads": 1542,
     "githubStars": 20,
-    "nxVersion": "12.5.8"
+    "nxVersion": ""
   },
   "@ago-dev/nx-aws-cdk-v2": {
     "lastPublishedDate": "2023-05-08T11:33:02.618Z",
-    "npmDownloads": 8745,
+    "npmDownloads": 35737,
     "githubStars": 30,
-    "nxVersion": "16.6.0"
+    "nxVersion": ""
   },
   "@berenddeboer/nx-sst": {
     "lastPublishedDate": "2023-07-28T02:12:51.950Z",
-    "npmDownloads": 452,
+    "npmDownloads": 1198,
     "githubStars": 4,
-    "nxVersion": "^16.5.2"
+    "nxVersion": ">= 15 <= 17"
   },
   "@rxap/plugin-localazy": {
     "lastPublishedDate": "2022-12-14T13:23:03.536Z",
-    "npmDownloads": 200,
+    "npmDownloads": 456,
     "githubStars": -1,
-    "nxVersion": ""
+    "nxVersion": ">= 14 <= 16"
   },
   "nx-electron": {
     "lastPublishedDate": "2023-06-22T13:23:58.845Z",
-    "npmDownloads": 16152,
+    "npmDownloads": 14764,
     "githubStars": 273,
-    "nxVersion": "15.9.2"
+    "nxVersion": ">= 14.1 <= 16"
   },
   "nx-stylelint": {
     "lastPublishedDate": "2023-02-16T14:16:46.275Z",
-    "npmDownloads": 114683,
+    "npmDownloads": 117383,
     "githubStars": 64,
-    "nxVersion": "15.9.2"
+    "nxVersion": ">= 14 <= 16"
   },
   "@nxext/ionic-react": {
     "lastPublishedDate": "2023-05-26T12:53:11.721Z",
-    "npmDownloads": 619,
-    "githubStars": -1,
-    "nxVersion": ""
+    "npmDownloads": 658,
+    "githubStars": -1
   },
   "@nxext/ionic-angular": {
     "lastPublishedDate": "2023-05-26T12:52:58.419Z",
-    "npmDownloads": 26969,
-    "githubStars": 190,
-    "nxVersion": "13.7.2"
+    "npmDownloads": 32188,
+    "githubStars": 190
   },
   "@nxext/capacitor": {
     "lastPublishedDate": "2023-06-12T07:43:34.104Z",
-    "npmDownloads": 48090,
-    "githubStars": 393,
-    "nxVersion": "16.5.5"
+    "npmDownloads": 50162,
+    "githubStars": 394,
+    "nxVersion": ">= 15 <= 17"
   },
   "@nxtend/firebase": {
     "lastPublishedDate": "2021-12-02T15:22:22.629Z",
-    "npmDownloads": 462,
+    "npmDownloads": 246,
     "githubStars": 190,
-    "nxVersion": "13.7.2"
+    "nxVersion": "12.0.0"
   },
   "@angular-architects/ddd": {
     "lastPublishedDate": "2023-05-20T19:52:32.293Z",
-    "npmDownloads": 17299,
-    "githubStars": 276,
-    "nxVersion": "16.2.1"
+    "npmDownloads": 19786,
+    "githubStars": 276
   },
   "@offeringsolutions/nx-karma-to-jest": {
     "lastPublishedDate": "2020-03-08T19:29:18.913Z",
-    "npmDownloads": 33,
-    "githubStars": 9,
-    "nxVersion": ""
+    "npmDownloads": 19,
+    "githubStars": 9
   },
   "@flowaccount/nx-serverless": {
     "lastPublishedDate": "2023-07-10T19:06:16.916Z",
-    "npmDownloads": 6734,
+    "npmDownloads": 7177,
     "githubStars": -1,
-    "nxVersion": ""
+    "nxVersion": ">= 13.10 <= 15"
   },
   "@ns3/nx-serverless": {
     "lastPublishedDate": "2023-07-12T07:08:25.829Z",
-    "npmDownloads": 56427,
-    "githubStars": 59,
-    "nxVersion": "16.0.3"
+    "npmDownloads": 53411,
+    "githubStars": 59
   },
   "@ns3/nx-jest-playwright": {
     "lastPublishedDate": "2023-05-03T07:05:36.802Z",
-    "npmDownloads": 7989,
-    "githubStars": 59,
-    "nxVersion": "16.0.3"
+    "npmDownloads": 6750,
+    "githubStars": 59
   },
   "@ns3/nx-playwright": {
     "lastPublishedDate": "2023-05-03T07:05:36.629Z",
-    "npmDownloads": 2181,
-    "githubStars": 59,
-    "nxVersion": "16.0.3"
+    "npmDownloads": 4583,
+    "githubStars": 59
   },
   "@dev-thought/nx-deploy-it": {
     "lastPublishedDate": "2021-02-12T21:12:18.923Z",
-    "npmDownloads": 265,
-    "githubStars": 77,
-    "nxVersion": "^11.2.12"
+    "npmDownloads": 212,
+    "githubStars": 77
   },
   "@offeringsolutions/nx-protractor-to-cypress": {
     "lastPublishedDate": "2021-03-04T15:12:40.394Z",
-    "npmDownloads": 12,
+    "npmDownloads": 11,
     "githubStars": 4,
-    "nxVersion": "11.4.0"
+    "nxVersion": ""
   },
   "@angular-custom-builders/lite-serve": {
     "lastPublishedDate": "2021-03-08T14:21:34.424Z",
-    "npmDownloads": 1627,
-    "githubStars": 6,
-    "nxVersion": ""
+    "npmDownloads": 1619,
+    "githubStars": 6
   },
   "@nx-plus/nuxt": {
     "lastPublishedDate": "2022-07-02T16:45:19.149Z",
-    "npmDownloads": 2685,
-    "githubStars": 297,
-    "nxVersion": "15.2.4"
+    "npmDownloads": 3245,
+    "githubStars": 298,
+    "nxVersion": ">= 13.10 <= 15"
   },
   "@nx-plus/vue": {
     "lastPublishedDate": "2022-12-05T02:51:23.682Z",
-    "npmDownloads": 10648,
-    "githubStars": 297,
-    "nxVersion": "15.2.4"
+    "npmDownloads": 9254,
+    "githubStars": 298,
+    "nxVersion": ">= 14 <= 16"
   },
   "@nx-plus/docusaurus": {
     "lastPublishedDate": "2022-12-05T02:51:37.534Z",
-    "npmDownloads": 53130,
-    "githubStars": 297,
-    "nxVersion": "15.2.4"
+    "npmDownloads": 59902,
+    "githubStars": 298,
+    "nxVersion": ">= 14 <= 16"
   },
   "@twittwer/compodoc": {
     "lastPublishedDate": "2023-06-25T12:35:20.159Z",
-    "npmDownloads": 18466,
+    "npmDownloads": 17456,
     "githubStars": 40,
-    "nxVersion": "16.4.0"
+    "nxVersion": ">= 15 <= 17"
   },
   "@enio.ai/nx-install": {
     "lastPublishedDate": "2023-03-05T20:18:09.761Z",
-    "npmDownloads": 421,
+    "npmDownloads": 50,
     "githubStars": 22,
-    "nxVersion": ""
+    "nxVersion": ">= 14.1 <= 16"
   },
   "@enio.ai/typedoc": {
     "lastPublishedDate": "2023-03-05T20:17:20.752Z",
-    "npmDownloads": 5513,
+    "npmDownloads": 3599,
     "githubStars": 22,
-    "nxVersion": ""
+    "nxVersion": ">= 14.1 <= 16"
   },
   "@nxext/svelte": {
     "lastPublishedDate": "2023-05-26T12:47:54.560Z",
-    "npmDownloads": 4047,
-    "githubStars": 393,
-    "nxVersion": "16.5.5"
+    "npmDownloads": 4976,
+    "githubStars": 394
   },
   "@nxext/stencil": {
     "lastPublishedDate": "2023-06-21T09:20:15.486Z",
-    "npmDownloads": 10979,
-    "githubStars": 393,
-    "nxVersion": "16.5.5"
+    "npmDownloads": 10950,
+    "githubStars": 394,
+    "nxVersion": ">= 15 <= 17"
   },
   "@nxext/vite": {
     "lastPublishedDate": "2023-02-28T19:05:21.436Z",
-    "npmDownloads": 22434,
-    "githubStars": 393,
-    "nxVersion": "16.5.5"
+    "npmDownloads": 22988,
+    "githubStars": 394,
+    "nxVersion": ">= 14.1 <= 16"
   },
   "@nxext/solid": {
     "lastPublishedDate": "2023-05-26T12:47:38.232Z",
-    "npmDownloads": 1013,
-    "githubStars": 393,
-    "nxVersion": "16.5.5"
+    "npmDownloads": 1560,
+    "githubStars": 394
   },
   "@joelcode/gcp-function": {
     "lastPublishedDate": "2021-09-15T16:46:35.377Z",
-    "npmDownloads": 66,
-    "githubStars": -1,
-    "nxVersion": ""
+    "npmDownloads": 29,
+    "githubStars": -1
   },
   "@nx-go/nx-go": {
     "lastPublishedDate": "2022-10-17T07:48:25.180Z",
-    "npmDownloads": 232218,
-    "githubStars": -1,
-    "nxVersion": ""
+    "npmDownloads": 234870,
+    "githubStars": -1
   },
   "@nx-golang/gin": {
     "lastPublishedDate": "2023-01-04T14:57:24.660Z",
-    "npmDownloads": 117,
-    "githubStars": 0,
-    "nxVersion": "15.4.2"
+    "npmDownloads": 37,
+    "githubStars": 0
   },
   "@angular-architects/module-federation": {
     "lastPublishedDate": "2023-06-20T16:52:19.205Z",
-    "npmDownloads": 427558,
-    "githubStars": 577,
-    "nxVersion": "14.5.2"
+    "npmDownloads": 425479,
+    "githubStars": 577
   },
   "@nxrocks/nx-spring-boot": {
     "lastPublishedDate": "2023-05-12T16:58:52.743Z",
-    "githubDirectory": "packages/nx-spring-boot",
-    "npmDownloads": 5671,
+    "npmDownloads": 6675,
     "githubStars": 232,
-    "nxVersion": "16.5.0"
+    "nxVersion": ">= 15 <= 17"
   },
   "@trumbitta/nx-plugin-openapi": {
     "lastPublishedDate": "2022-08-28T20:54:50.978Z",
-    "npmDownloads": 22814,
+    "npmDownloads": 25483,
     "githubStars": -1,
-    "nxVersion": ""
+    "nxVersion": "13.0.0"
   },
   "@trumbitta/nx-plugin-unused-deps": {
     "lastPublishedDate": "2022-08-28T20:55:11.226Z",
-    "npmDownloads": 57757,
+    "npmDownloads": 64540,
     "githubStars": -1,
-    "nxVersion": ""
+    "nxVersion": "13.0.0"
   },
   "@nxrocks/nx-flutter": {
     "lastPublishedDate": "2023-05-12T16:59:33.230Z",
-    "githubDirectory": "packages/nx-flutter",
-    "npmDownloads": 10609,
+    "npmDownloads": 8304,
     "githubStars": 232,
-    "nxVersion": "16.5.0"
+    "nxVersion": ">= 15 <= 17"
   },
   "@srleecode/domain": {
     "lastPublishedDate": "2023-06-22T13:44:39.620Z",
-    "npmDownloads": 1370,
+    "npmDownloads": 379,
     "githubStars": -1,
     "nxVersion": ""
   },
   "@jscutlery/semver": {
     "lastPublishedDate": "2023-07-31T06:50:30.918Z",
-    "npmDownloads": 464113,
+    "npmDownloads": 506545,
     "githubStars": 618,
-    "nxVersion": "16.6.0"
+    "nxVersion": ">= 15 <= 17"
   },
   "ngx-deploy-npm": {
     "lastPublishedDate": "2023-05-15T07:18:38.684Z",
-    "npmDownloads": 275957,
+    "npmDownloads": 278141,
     "githubStars": 99,
-    "nxVersion": "16.4.0"
+    "nxVersion": ">= 15 <= 17"
   },
   "@trafilea/nx-shopify": {
     "lastPublishedDate": "2021-06-02T19:51:43.707Z",
-    "npmDownloads": 127,
+    "npmDownloads": 105,
     "githubStars": 42,
     "nxVersion": "12.0.8"
   },
   "@nx-dotnet/core": {
     "lastPublishedDate": "2023-04-12T17:54:41.139Z",
-    "npmDownloads": 53584,
+    "npmDownloads": 56204,
     "githubStars": 214,
-    "nxVersion": "15.8.5"
+    "nxVersion": ">= 14.1 <= 16"
   },
   "@nxrocks/nx-quarkus": {
     "lastPublishedDate": "2023-05-12T16:59:55.758Z",
-    "githubDirectory": "packages/nx-quarkus",
-    "npmDownloads": 6001,
+    "npmDownloads": 9422,
     "githubStars": 232,
-    "nxVersion": "16.5.0"
+    "nxVersion": ">= 15 <= 17"
   },
   "@nx-extend/gcp-secrets": {
     "lastPublishedDate": "2023-06-22T17:40:46.440Z",
-    "npmDownloads": 219,
+    "npmDownloads": 95,
     "githubStars": 98,
-    "nxVersion": "16.3.2"
+    "nxVersion": ">= 15 <= 17"
   },
   "@nx-extend/gcp-storage": {
     "lastPublishedDate": "2023-06-22T17:40:53.943Z",
-    "npmDownloads": 1982,
+    "npmDownloads": 950,
     "githubStars": 98,
-    "nxVersion": "16.3.2"
+    "nxVersion": ">= 15 <= 17"
   },
   "@nx-extend/gcp-functions": {
     "lastPublishedDate": "2023-07-22T09:38:42.753Z",
-    "npmDownloads": 3585,
+    "npmDownloads": 3962,
     "githubStars": 98,
-    "nxVersion": "16.3.2"
+    "nxVersion": ">= 15 <= 17"
   },
   "@nx-extend/gcp-deployment-manager": {
     "lastPublishedDate": "2023-06-22T17:40:40.176Z",
-    "npmDownloads": 163,
+    "npmDownloads": 106,
     "githubStars": 98,
-    "nxVersion": "16.3.2"
+    "nxVersion": ">= 15 <= 17"
   },
   "@nx-extend/gcp-cloud-run": {
     "lastPublishedDate": "2023-06-22T17:40:52.218Z",
-    "npmDownloads": 1529,
+    "npmDownloads": 2093,
     "githubStars": 98,
-    "nxVersion": "16.3.2"
+    "nxVersion": ">= 15 <= 17"
   },
   "@nx-extend/translations": {
     "lastPublishedDate": "2023-06-22T17:40:44.178Z",
-    "npmDownloads": 357,
+    "npmDownloads": 236,
     "githubStars": 98,
-    "nxVersion": "16.3.2"
+    "nxVersion": ">= 15 <= 17"
   },
   "@nx-extend/firebase-hosting": {
     "lastPublishedDate": "2023-07-13T10:38:12.436Z",
-    "npmDownloads": 1007,
+    "npmDownloads": 1305,
     "githubStars": 98,
-    "nxVersion": "16.3.2"
+    "nxVersion": ">= 15 <= 17"
   },
   "@nx-extend/e2e-runner": {
     "lastPublishedDate": "2023-07-21T20:54:54.000Z",
-    "npmDownloads": 8086,
+    "npmDownloads": 6223,
     "githubStars": 98,
-    "nxVersion": "16.3.2"
+    "nxVersion": ">= 15 <= 17"
   },
   "@nx-extend/vercel": {
     "lastPublishedDate": "2023-07-28T08:36:42.305Z",
-    "npmDownloads": 1141,
+    "npmDownloads": 814,
     "githubStars": 98,
-    "nxVersion": "16.3.2"
+    "nxVersion": ">= 15 <= 17"
   },
   "@nx-extend/strapi": {
     "lastPublishedDate": "2023-07-12T07:02:19.604Z",
-    "npmDownloads": 8150,
+    "npmDownloads": 8787,
     "githubStars": 98,
-    "nxVersion": "16.3.2"
+    "nxVersion": ">= 15 <= 17"
   },
   "@nx-extend/playwright": {
     "lastPublishedDate": "2023-06-22T17:40:55.663Z",
-    "npmDownloads": 10326,
+    "npmDownloads": 7417,
     "githubStars": 98,
-    "nxVersion": "16.3.2"
+    "nxVersion": ">= 15 <= 17"
   },
   "@nx-extend/terraform": {
     "lastPublishedDate": "2023-06-22T17:40:57.454Z",
-    "npmDownloads": 1030,
+    "npmDownloads": 567,
     "githubStars": 98,
-    "nxVersion": "16.3.2"
+    "nxVersion": ">= 15 <= 17"
   },
   "@nx-extend/pulumi": {
     "lastPublishedDate": "2023-06-22T17:40:59.131Z",
-    "npmDownloads": 451,
+    "npmDownloads": 483,
     "githubStars": 98,
-    "nxVersion": "16.3.2"
+    "nxVersion": ">= 15 <= 17"
   },
   "@nativescript/nx": {
     "lastPublishedDate": "2023-07-05T22:55:56.178Z",
-    "npmDownloads": 6852,
+    "npmDownloads": 10198,
     "githubStars": 58,
-    "nxVersion": "16.5.0"
+    "nxVersion": ">= 15 <= 17"
   },
   "@nx-clean/plugin-core": {
     "lastPublishedDate": "2022-03-10T15:36:11.690Z",
-    "npmDownloads": 147,
+    "npmDownloads": 138,
     "githubStars": 65,
-    "nxVersion": "16.5.0"
+    "nxVersion": ""
   },
   "@jnxplus/nx-boot-gradle": {
     "lastPublishedDate": "2023-07-28T16:33:38.123Z",
-    "npmDownloads": 10018,
+    "npmDownloads": 2421,
     "githubStars": -1,
-    "nxVersion": ""
+    "nxVersion": ">= 15 <= 17"
   },
   "@jnxplus/nx-boot-maven": {
     "lastPublishedDate": "2023-07-28T16:34:00.918Z",
-    "npmDownloads": 7619,
+    "npmDownloads": 7233,
     "githubStars": -1,
-    "nxVersion": ""
+    "nxVersion": ">= 15 <= 17"
   },
   "@nxtensions/astro": {
     "lastPublishedDate": "2023-07-30T14:40:23.494Z",
-    "githubDirectory": "packages/astro",
-    "npmDownloads": 3111,
+    "npmDownloads": 4679,
     "githubStars": 43,
-    "nxVersion": "16.5.5"
+    "nxVersion": ">= 15 <= 17"
   },
   "@nxrs/cargo": {
     "lastPublishedDate": "2022-05-25T02:55:50.238Z",
-    "npmDownloads": 1489,
-    "githubStars": 101,
-    "nxVersion": "13.4.3"
+    "npmDownloads": 2625,
+    "githubStars": 101
   },
   "nx-uvu": {
     "lastPublishedDate": "2023-06-16T16:07:57.812Z",
-    "npmDownloads": 856,
+    "npmDownloads": 554,
     "githubStars": -1,
-    "nxVersion": ""
+    "nxVersion": ">= 15 <= 17"
   },
   "@ndrsg/nx-http": {
     "lastPublishedDate": "2022-06-07T13:16:25.323Z",
-    "npmDownloads": 33,
+    "npmDownloads": 18,
     "githubStars": 6,
-    "nxVersion": "14.1.9"
+    "nxVersion": "14.0.0"
   },
   "@diogovcs/graphql-mesh": {
     "lastPublishedDate": "2023-01-22T11:38:26.303Z",
-    "npmDownloads": 697,
-    "githubStars": -1,
-    "nxVersion": ""
+    "npmDownloads": 594,
+    "githubStars": -1
   },
   "@computas/nx-yarn": {
     "lastPublishedDate": "2022-05-30T07:04:03.376Z",
-    "npmDownloads": 237,
+    "npmDownloads": 463,
     "githubStars": -1,
-    "nxVersion": ""
+    "nxVersion": ">= 13.10 <= 15"
   },
   "@theunderscorer/nx-semantic-release": {
     "lastPublishedDate": "2023-07-16T18:50:55.453Z",
-    "npmDownloads": 14548,
-    "githubStars": 58,
-    "nxVersion": "16.0.0"
+    "npmDownloads": 17137,
+    "githubStars": 61,
+    "nxVersion": ">= 15 <= 17"
   },
   "nx-pwm": {
     "lastPublishedDate": "2022-12-03T18:41:17.623Z",
-    "githubDirectory": "packages/nx-pwm",
-    "npmDownloads": 86,
+    "npmDownloads": 19,
     "githubStars": 4,
-    "nxVersion": "15.2.4"
+    "nxVersion": ">= 14 <= 16"
   },
   "@nxrocks/nx-micronaut": {
     "lastPublishedDate": "2023-05-12T16:59:13.295Z",
-    "githubDirectory": "packages/nx-micronaut",
-    "npmDownloads": 185,
+    "npmDownloads": 201,
     "githubStars": 232,
-    "nxVersion": "16.5.0"
+    "nxVersion": ">= 15 <= 17"
   },
   "@koliveira15/nx-sonarqube": {
-    "lastPublishedDate": "2023-06-28T18:41:40.138Z",
-    "npmDownloads": 39901,
-    "githubStars": 21,
-    "nxVersion": "16.2.2"
+    "lastPublishedDate": "2023-08-02T00:25:44.844Z",
+    "npmDownloads": 41340,
+    "githubStars": 21
   },
   "@mands/nx-playwright": {
     "lastPublishedDate": "2023-05-16T10:59:21.495Z",
-    "npmDownloads": 64051,
-    "githubStars": 58,
-    "nxVersion": "16.1.4"
+    "npmDownloads": 61666,
+    "githubStars": 58
   },
   "@diogovcs/stryker-mutator": {
     "lastPublishedDate": "2023-03-18T12:51:54.214Z",
-    "npmDownloads": 1383,
+    "npmDownloads": 2376,
     "githubStars": -1,
     "nxVersion": ""
   },
   "@spaceribs/nx-web-ext": {
     "lastPublishedDate": "2023-07-16T15:45:19.229Z",
-    "npmDownloads": 187,
+    "npmDownloads": 255,
     "githubStars": 5,
-    "nxVersion": "16.3.2"
+    "nxVersion": ">= 15 <= 17"
   },
   "@spaceribs/nx-betterer": {
     "lastPublishedDate": "2023-07-16T15:45:12.663Z",
-    "npmDownloads": 251,
+    "npmDownloads": 173,
     "githubStars": 5,
-    "nxVersion": "16.3.2"
+    "nxVersion": ">= 15 <= 17"
   },
   "@nx-tools/nx-container": {
     "lastPublishedDate": "2023-06-21T06:38:36.059Z",
-    "npmDownloads": 97180,
+    "npmDownloads": 100493,
     "githubStars": 261,
-    "nxVersion": "16.5.5"
+    "nxVersion": ">= 15 <= 17"
   },
   "@nxrocks/nx-melos": {
     "lastPublishedDate": "2023-05-12T17:00:25.890Z",
-    "githubDirectory": "packages/nx-melos",
-    "npmDownloads": 201,
+    "npmDownloads": 165,
     "githubStars": 232,
-    "nxVersion": "16.5.0"
+    "nxVersion": ">= 15 <= 17"
   },
   "@monodon/rust": {
     "lastPublishedDate": "2023-06-30T16:35:58.528Z",
-    "npmDownloads": 6405,
+    "npmDownloads": 7087,
     "githubStars": 15,
-    "nxVersion": "16.4.1"
+    "nxVersion": ">= 15 <= 17"
   },
   "nx-mesh": {
     "lastPublishedDate": "2023-04-26T20:23:43.825Z",
-    "githubDirectory": "packages/nx-mesh",
-    "npmDownloads": 1944,
+    "npmDownloads": 2068,
     "githubStars": 19,
-    "nxVersion": "^15.7.1"
+    "nxVersion": ">= 14.1 <= 16"
   },
   "@nxazure/func": {
     "lastPublishedDate": "2023-06-17T22:19:57.878Z",
-    "npmDownloads": 2351,
-    "githubStars": 9,
-    "nxVersion": "16.1.3"
+    "npmDownloads": 2016,
+    "githubStars": 9
   },
   "@rbnx/webdriverio": {
     "lastPublishedDate": "2023-05-05T06:51:41.339Z",
-    "githubDirectory": "packages/webdriverio",
-    "npmDownloads": 198,
+    "npmDownloads": 232,
     "githubStars": 7,
-    "nxVersion": "16.1.0"
+    "nxVersion": ">= 15 <= 17"
   },
   "nx-ngrok": {
     "lastPublishedDate": "2023-04-17T21:34:27.110Z",
-    "githubDirectory": "packages/nx-ngrok",
-    "npmDownloads": 283,
+    "npmDownloads": 244,
     "githubStars": 0,
-    "nxVersion": "^15.7.1"
+    "nxVersion": ">= 14.1 <= 16"
   },
   "@nxrocks/nx-ktor": {
     "lastPublishedDate": "2023-05-25T05:35:48.467Z",
-    "githubDirectory": "packages/nx-ktor",
-    "npmDownloads": 38,
+    "npmDownloads": 27,
     "githubStars": 232,
-    "nxVersion": "16.5.0"
+    "nxVersion": ">= 15 <= 17"
   },
   "nx-size-limit": {
     "lastPublishedDate": "2023-04-22T07:50:24.764Z",
-    "githubDirectory": "packages/nx-size-limit",
-    "npmDownloads": 466,
-    "githubStars": 7,
-    "nxVersion": "15.9.2"
+    "npmDownloads": 320,
+    "githubStars": 7
   },
   "@jnxplus/nx-quarkus-gradle": {
     "lastPublishedDate": "2023-07-28T16:33:30.811Z",
-    "npmDownloads": 1504,
+    "npmDownloads": 803,
     "githubStars": -1,
-    "nxVersion": ""
+    "nxVersion": ">= 15 <= 17"
   },
   "@jnxplus/nx-quarkus-maven": {
     "lastPublishedDate": "2023-07-28T16:33:52.833Z",
-    "npmDownloads": 1468,
+    "npmDownloads": 750,
     "githubStars": -1,
-    "nxVersion": ""
+    "nxVersion": ">= 15 <= 17"
   },
   "@loft-orbital/terraform": {
     "lastPublishedDate": "2023-03-25T21:03:22.028Z",
-    "npmDownloads": 43,
-    "githubStars": -1,
-    "nxVersion": ""
+    "npmDownloads": 475,
+    "githubStars": -1
   },
   "@nxlv/python": {
     "lastPublishedDate": "2023-07-06T13:05:49.453Z",
-    "githubDirectory": "packages/nx-python",
-    "npmDownloads": 9764,
-    "githubStars": 41,
-    "nxVersion": "16.3.2"
+    "npmDownloads": 9227,
+    "githubStars": 43,
+    "nxVersion": ">= 15 <= 17"
   }
 }

--- a/nx-dev/nx-dev/pages/extending-nx/quality-indicators.json
+++ b/nx-dev/nx-dev/pages/extending-nx/quality-indicators.json
@@ -1,0 +1,594 @@
+{
+  "@ahryman40k/nx-vitepress": {
+    "lastPublishedDate": "2022-12-23T01:15:39.916Z",
+    "npmDownloads": 556,
+    "githubStars": 0,
+    "nxVersion": "15.4.0"
+  },
+  "@nightwatch/nx": {
+    "lastPublishedDate": "2022-12-05T21:50:17.172Z",
+    "githubDirectory": "packages/nightwatch",
+    "npmDownloads": 14,
+    "githubStars": 2,
+    "nxVersion": "15.2.4"
+  },
+  "@nxkit/playwright": {
+    "lastPublishedDate": "2023-06-06T17:50:01.235Z",
+    "githubDirectory": "packages/playwright",
+    "npmDownloads": 14223,
+    "githubStars": 36,
+    "nxVersion": "16.3.2"
+  },
+  "qwik-nx": {
+    "lastPublishedDate": "2023-07-27T04:27:50.074Z",
+    "npmDownloads": 6809,
+    "githubStars": 113,
+    "nxVersion": "16.4.0"
+  },
+  "@nxkit/style-dictionary": {
+    "lastPublishedDate": "2023-06-06T17:50:01.313Z",
+    "githubDirectory": "packages/style-dictionary",
+    "npmDownloads": 8764,
+    "githubStars": 36,
+    "nxVersion": "16.3.2"
+  },
+  "nx-plugin-esbuild": {
+    "lastPublishedDate": "2021-10-02T13:53:16.067Z",
+    "npmDownloads": 1220,
+    "githubStars": -1,
+    "nxVersion": ""
+  },
+  "nx-plugin-vite": {
+    "lastPublishedDate": "2022-07-09T09:40:02.353Z",
+    "npmDownloads": 701,
+    "githubStars": 94,
+    "nxVersion": ""
+  },
+  "nx-plugin-snowpack": {
+    "lastPublishedDate": "2021-10-04T02:55:28.868Z",
+    "npmDownloads": 44,
+    "githubStars": -1,
+    "nxVersion": ""
+  },
+  "nx-plugin-prisma": {
+    "lastPublishedDate": "2021-09-30T04:07:48.904Z",
+    "npmDownloads": 19,
+    "githubStars": -1,
+    "nxVersion": ""
+  },
+  "@codebrew/nx-aws-cdk": {
+    "lastPublishedDate": "2022-01-28T05:22:43.508Z",
+    "npmDownloads": 3994,
+    "githubStars": 20,
+    "nxVersion": "12.5.8"
+  },
+  "@ago-dev/nx-aws-cdk-v2": {
+    "lastPublishedDate": "2023-05-08T11:33:02.618Z",
+    "npmDownloads": 8745,
+    "githubStars": 30,
+    "nxVersion": "16.6.0"
+  },
+  "@berenddeboer/nx-sst": {
+    "lastPublishedDate": "2023-07-28T02:12:51.950Z",
+    "npmDownloads": 452,
+    "githubStars": 4,
+    "nxVersion": "^16.5.2"
+  },
+  "@rxap/plugin-localazy": {
+    "lastPublishedDate": "2022-12-14T13:23:03.536Z",
+    "npmDownloads": 200,
+    "githubStars": -1,
+    "nxVersion": ""
+  },
+  "nx-electron": {
+    "lastPublishedDate": "2023-06-22T13:23:58.845Z",
+    "npmDownloads": 16152,
+    "githubStars": 273,
+    "nxVersion": "15.9.2"
+  },
+  "nx-stylelint": {
+    "lastPublishedDate": "2023-02-16T14:16:46.275Z",
+    "npmDownloads": 114683,
+    "githubStars": 64,
+    "nxVersion": "15.9.2"
+  },
+  "@nxext/ionic-react": {
+    "lastPublishedDate": "2023-05-26T12:53:11.721Z",
+    "npmDownloads": 619,
+    "githubStars": -1,
+    "nxVersion": ""
+  },
+  "@nxext/ionic-angular": {
+    "lastPublishedDate": "2023-05-26T12:52:58.419Z",
+    "npmDownloads": 26969,
+    "githubStars": 190,
+    "nxVersion": "13.7.2"
+  },
+  "@nxext/capacitor": {
+    "lastPublishedDate": "2023-06-12T07:43:34.104Z",
+    "npmDownloads": 48090,
+    "githubStars": 393,
+    "nxVersion": "16.5.5"
+  },
+  "@nxtend/firebase": {
+    "lastPublishedDate": "2021-12-02T15:22:22.629Z",
+    "npmDownloads": 462,
+    "githubStars": 190,
+    "nxVersion": "13.7.2"
+  },
+  "@angular-architects/ddd": {
+    "lastPublishedDate": "2023-05-20T19:52:32.293Z",
+    "npmDownloads": 17299,
+    "githubStars": 276,
+    "nxVersion": "16.2.1"
+  },
+  "@offeringsolutions/nx-karma-to-jest": {
+    "lastPublishedDate": "2020-03-08T19:29:18.913Z",
+    "npmDownloads": 33,
+    "githubStars": 9,
+    "nxVersion": ""
+  },
+  "@flowaccount/nx-serverless": {
+    "lastPublishedDate": "2023-07-10T19:06:16.916Z",
+    "npmDownloads": 6734,
+    "githubStars": -1,
+    "nxVersion": ""
+  },
+  "@ns3/nx-serverless": {
+    "lastPublishedDate": "2023-07-12T07:08:25.829Z",
+    "npmDownloads": 56427,
+    "githubStars": 59,
+    "nxVersion": "16.0.3"
+  },
+  "@ns3/nx-jest-playwright": {
+    "lastPublishedDate": "2023-05-03T07:05:36.802Z",
+    "npmDownloads": 7989,
+    "githubStars": 59,
+    "nxVersion": "16.0.3"
+  },
+  "@ns3/nx-playwright": {
+    "lastPublishedDate": "2023-05-03T07:05:36.629Z",
+    "npmDownloads": 2181,
+    "githubStars": 59,
+    "nxVersion": "16.0.3"
+  },
+  "@dev-thought/nx-deploy-it": {
+    "lastPublishedDate": "2021-02-12T21:12:18.923Z",
+    "npmDownloads": 265,
+    "githubStars": 77,
+    "nxVersion": "^11.2.12"
+  },
+  "@offeringsolutions/nx-protractor-to-cypress": {
+    "lastPublishedDate": "2021-03-04T15:12:40.394Z",
+    "npmDownloads": 12,
+    "githubStars": 4,
+    "nxVersion": "11.4.0"
+  },
+  "@angular-custom-builders/lite-serve": {
+    "lastPublishedDate": "2021-03-08T14:21:34.424Z",
+    "npmDownloads": 1627,
+    "githubStars": 6,
+    "nxVersion": ""
+  },
+  "@nx-plus/nuxt": {
+    "lastPublishedDate": "2022-07-02T16:45:19.149Z",
+    "npmDownloads": 2685,
+    "githubStars": 297,
+    "nxVersion": "15.2.4"
+  },
+  "@nx-plus/vue": {
+    "lastPublishedDate": "2022-12-05T02:51:23.682Z",
+    "npmDownloads": 10648,
+    "githubStars": 297,
+    "nxVersion": "15.2.4"
+  },
+  "@nx-plus/docusaurus": {
+    "lastPublishedDate": "2022-12-05T02:51:37.534Z",
+    "npmDownloads": 53130,
+    "githubStars": 297,
+    "nxVersion": "15.2.4"
+  },
+  "@twittwer/compodoc": {
+    "lastPublishedDate": "2023-06-25T12:35:20.159Z",
+    "npmDownloads": 18466,
+    "githubStars": 40,
+    "nxVersion": "16.4.0"
+  },
+  "@enio.ai/nx-install": {
+    "lastPublishedDate": "2023-03-05T20:18:09.761Z",
+    "npmDownloads": 421,
+    "githubStars": 22,
+    "nxVersion": ""
+  },
+  "@enio.ai/typedoc": {
+    "lastPublishedDate": "2023-03-05T20:17:20.752Z",
+    "npmDownloads": 5513,
+    "githubStars": 22,
+    "nxVersion": ""
+  },
+  "@nxext/svelte": {
+    "lastPublishedDate": "2023-05-26T12:47:54.560Z",
+    "npmDownloads": 4047,
+    "githubStars": 393,
+    "nxVersion": "16.5.5"
+  },
+  "@nxext/stencil": {
+    "lastPublishedDate": "2023-06-21T09:20:15.486Z",
+    "npmDownloads": 10979,
+    "githubStars": 393,
+    "nxVersion": "16.5.5"
+  },
+  "@nxext/vite": {
+    "lastPublishedDate": "2023-02-28T19:05:21.436Z",
+    "npmDownloads": 22434,
+    "githubStars": 393,
+    "nxVersion": "16.5.5"
+  },
+  "@nxext/solid": {
+    "lastPublishedDate": "2023-05-26T12:47:38.232Z",
+    "npmDownloads": 1013,
+    "githubStars": 393,
+    "nxVersion": "16.5.5"
+  },
+  "@joelcode/gcp-function": {
+    "lastPublishedDate": "2021-09-15T16:46:35.377Z",
+    "npmDownloads": 66,
+    "githubStars": -1,
+    "nxVersion": ""
+  },
+  "@nx-go/nx-go": {
+    "lastPublishedDate": "2022-10-17T07:48:25.180Z",
+    "npmDownloads": 232218,
+    "githubStars": -1,
+    "nxVersion": ""
+  },
+  "@nx-golang/gin": {
+    "lastPublishedDate": "2023-01-04T14:57:24.660Z",
+    "npmDownloads": 117,
+    "githubStars": 0,
+    "nxVersion": "15.4.2"
+  },
+  "@angular-architects/module-federation": {
+    "lastPublishedDate": "2023-06-20T16:52:19.205Z",
+    "npmDownloads": 427558,
+    "githubStars": 577,
+    "nxVersion": "14.5.2"
+  },
+  "@nxrocks/nx-spring-boot": {
+    "lastPublishedDate": "2023-05-12T16:58:52.743Z",
+    "githubDirectory": "packages/nx-spring-boot",
+    "npmDownloads": 5671,
+    "githubStars": 232,
+    "nxVersion": "16.5.0"
+  },
+  "@trumbitta/nx-plugin-openapi": {
+    "lastPublishedDate": "2022-08-28T20:54:50.978Z",
+    "npmDownloads": 22814,
+    "githubStars": -1,
+    "nxVersion": ""
+  },
+  "@trumbitta/nx-plugin-unused-deps": {
+    "lastPublishedDate": "2022-08-28T20:55:11.226Z",
+    "npmDownloads": 57757,
+    "githubStars": -1,
+    "nxVersion": ""
+  },
+  "@nxrocks/nx-flutter": {
+    "lastPublishedDate": "2023-05-12T16:59:33.230Z",
+    "githubDirectory": "packages/nx-flutter",
+    "npmDownloads": 10609,
+    "githubStars": 232,
+    "nxVersion": "16.5.0"
+  },
+  "@srleecode/domain": {
+    "lastPublishedDate": "2023-06-22T13:44:39.620Z",
+    "npmDownloads": 1370,
+    "githubStars": -1,
+    "nxVersion": ""
+  },
+  "@jscutlery/semver": {
+    "lastPublishedDate": "2023-07-31T06:50:30.918Z",
+    "npmDownloads": 464113,
+    "githubStars": 618,
+    "nxVersion": "16.6.0"
+  },
+  "ngx-deploy-npm": {
+    "lastPublishedDate": "2023-05-15T07:18:38.684Z",
+    "npmDownloads": 275957,
+    "githubStars": 99,
+    "nxVersion": "16.4.0"
+  },
+  "@trafilea/nx-shopify": {
+    "lastPublishedDate": "2021-06-02T19:51:43.707Z",
+    "npmDownloads": 127,
+    "githubStars": 42,
+    "nxVersion": "12.0.8"
+  },
+  "@nx-dotnet/core": {
+    "lastPublishedDate": "2023-04-12T17:54:41.139Z",
+    "npmDownloads": 53584,
+    "githubStars": 214,
+    "nxVersion": "15.8.5"
+  },
+  "@nxrocks/nx-quarkus": {
+    "lastPublishedDate": "2023-05-12T16:59:55.758Z",
+    "githubDirectory": "packages/nx-quarkus",
+    "npmDownloads": 6001,
+    "githubStars": 232,
+    "nxVersion": "16.5.0"
+  },
+  "@nx-extend/gcp-secrets": {
+    "lastPublishedDate": "2023-06-22T17:40:46.440Z",
+    "npmDownloads": 219,
+    "githubStars": 98,
+    "nxVersion": "16.3.2"
+  },
+  "@nx-extend/gcp-storage": {
+    "lastPublishedDate": "2023-06-22T17:40:53.943Z",
+    "npmDownloads": 1982,
+    "githubStars": 98,
+    "nxVersion": "16.3.2"
+  },
+  "@nx-extend/gcp-functions": {
+    "lastPublishedDate": "2023-07-22T09:38:42.753Z",
+    "npmDownloads": 3585,
+    "githubStars": 98,
+    "nxVersion": "16.3.2"
+  },
+  "@nx-extend/gcp-deployment-manager": {
+    "lastPublishedDate": "2023-06-22T17:40:40.176Z",
+    "npmDownloads": 163,
+    "githubStars": 98,
+    "nxVersion": "16.3.2"
+  },
+  "@nx-extend/gcp-cloud-run": {
+    "lastPublishedDate": "2023-06-22T17:40:52.218Z",
+    "npmDownloads": 1529,
+    "githubStars": 98,
+    "nxVersion": "16.3.2"
+  },
+  "@nx-extend/translations": {
+    "lastPublishedDate": "2023-06-22T17:40:44.178Z",
+    "npmDownloads": 357,
+    "githubStars": 98,
+    "nxVersion": "16.3.2"
+  },
+  "@nx-extend/firebase-hosting": {
+    "lastPublishedDate": "2023-07-13T10:38:12.436Z",
+    "npmDownloads": 1007,
+    "githubStars": 98,
+    "nxVersion": "16.3.2"
+  },
+  "@nx-extend/e2e-runner": {
+    "lastPublishedDate": "2023-07-21T20:54:54.000Z",
+    "npmDownloads": 8086,
+    "githubStars": 98,
+    "nxVersion": "16.3.2"
+  },
+  "@nx-extend/vercel": {
+    "lastPublishedDate": "2023-07-28T08:36:42.305Z",
+    "npmDownloads": 1141,
+    "githubStars": 98,
+    "nxVersion": "16.3.2"
+  },
+  "@nx-extend/strapi": {
+    "lastPublishedDate": "2023-07-12T07:02:19.604Z",
+    "npmDownloads": 8150,
+    "githubStars": 98,
+    "nxVersion": "16.3.2"
+  },
+  "@nx-extend/playwright": {
+    "lastPublishedDate": "2023-06-22T17:40:55.663Z",
+    "npmDownloads": 10326,
+    "githubStars": 98,
+    "nxVersion": "16.3.2"
+  },
+  "@nx-extend/terraform": {
+    "lastPublishedDate": "2023-06-22T17:40:57.454Z",
+    "npmDownloads": 1030,
+    "githubStars": 98,
+    "nxVersion": "16.3.2"
+  },
+  "@nx-extend/pulumi": {
+    "lastPublishedDate": "2023-06-22T17:40:59.131Z",
+    "npmDownloads": 451,
+    "githubStars": 98,
+    "nxVersion": "16.3.2"
+  },
+  "@nativescript/nx": {
+    "lastPublishedDate": "2023-07-05T22:55:56.178Z",
+    "npmDownloads": 6852,
+    "githubStars": 58,
+    "nxVersion": "16.5.0"
+  },
+  "@nx-clean/plugin-core": {
+    "lastPublishedDate": "2022-03-10T15:36:11.690Z",
+    "npmDownloads": 147,
+    "githubStars": 65,
+    "nxVersion": "16.5.0"
+  },
+  "@jnxplus/nx-boot-gradle": {
+    "lastPublishedDate": "2023-07-28T16:33:38.123Z",
+    "npmDownloads": 10018,
+    "githubStars": -1,
+    "nxVersion": ""
+  },
+  "@jnxplus/nx-boot-maven": {
+    "lastPublishedDate": "2023-07-28T16:34:00.918Z",
+    "npmDownloads": 7619,
+    "githubStars": -1,
+    "nxVersion": ""
+  },
+  "@nxtensions/astro": {
+    "lastPublishedDate": "2023-07-30T14:40:23.494Z",
+    "githubDirectory": "packages/astro",
+    "npmDownloads": 3111,
+    "githubStars": 43,
+    "nxVersion": "16.5.5"
+  },
+  "@nxrs/cargo": {
+    "lastPublishedDate": "2022-05-25T02:55:50.238Z",
+    "npmDownloads": 1489,
+    "githubStars": 101,
+    "nxVersion": "13.4.3"
+  },
+  "nx-uvu": {
+    "lastPublishedDate": "2023-06-16T16:07:57.812Z",
+    "npmDownloads": 856,
+    "githubStars": -1,
+    "nxVersion": ""
+  },
+  "@ndrsg/nx-http": {
+    "lastPublishedDate": "2022-06-07T13:16:25.323Z",
+    "npmDownloads": 33,
+    "githubStars": 6,
+    "nxVersion": "14.1.9"
+  },
+  "@diogovcs/graphql-mesh": {
+    "lastPublishedDate": "2023-01-22T11:38:26.303Z",
+    "npmDownloads": 697,
+    "githubStars": -1,
+    "nxVersion": ""
+  },
+  "@computas/nx-yarn": {
+    "lastPublishedDate": "2022-05-30T07:04:03.376Z",
+    "npmDownloads": 237,
+    "githubStars": -1,
+    "nxVersion": ""
+  },
+  "@theunderscorer/nx-semantic-release": {
+    "lastPublishedDate": "2023-07-16T18:50:55.453Z",
+    "npmDownloads": 14548,
+    "githubStars": 58,
+    "nxVersion": "16.0.0"
+  },
+  "nx-pwm": {
+    "lastPublishedDate": "2022-12-03T18:41:17.623Z",
+    "githubDirectory": "packages/nx-pwm",
+    "npmDownloads": 86,
+    "githubStars": 4,
+    "nxVersion": "15.2.4"
+  },
+  "@nxrocks/nx-micronaut": {
+    "lastPublishedDate": "2023-05-12T16:59:13.295Z",
+    "githubDirectory": "packages/nx-micronaut",
+    "npmDownloads": 185,
+    "githubStars": 232,
+    "nxVersion": "16.5.0"
+  },
+  "@koliveira15/nx-sonarqube": {
+    "lastPublishedDate": "2023-06-28T18:41:40.138Z",
+    "npmDownloads": 39901,
+    "githubStars": 21,
+    "nxVersion": "16.2.2"
+  },
+  "@mands/nx-playwright": {
+    "lastPublishedDate": "2023-05-16T10:59:21.495Z",
+    "npmDownloads": 64051,
+    "githubStars": 58,
+    "nxVersion": "16.1.4"
+  },
+  "@diogovcs/stryker-mutator": {
+    "lastPublishedDate": "2023-03-18T12:51:54.214Z",
+    "npmDownloads": 1383,
+    "githubStars": -1,
+    "nxVersion": ""
+  },
+  "@spaceribs/nx-web-ext": {
+    "lastPublishedDate": "2023-07-16T15:45:19.229Z",
+    "npmDownloads": 187,
+    "githubStars": 5,
+    "nxVersion": "16.3.2"
+  },
+  "@spaceribs/nx-betterer": {
+    "lastPublishedDate": "2023-07-16T15:45:12.663Z",
+    "npmDownloads": 251,
+    "githubStars": 5,
+    "nxVersion": "16.3.2"
+  },
+  "@nx-tools/nx-container": {
+    "lastPublishedDate": "2023-06-21T06:38:36.059Z",
+    "npmDownloads": 97180,
+    "githubStars": 261,
+    "nxVersion": "16.5.5"
+  },
+  "@nxrocks/nx-melos": {
+    "lastPublishedDate": "2023-05-12T17:00:25.890Z",
+    "githubDirectory": "packages/nx-melos",
+    "npmDownloads": 201,
+    "githubStars": 232,
+    "nxVersion": "16.5.0"
+  },
+  "@monodon/rust": {
+    "lastPublishedDate": "2023-06-30T16:35:58.528Z",
+    "npmDownloads": 6405,
+    "githubStars": 15,
+    "nxVersion": "16.4.1"
+  },
+  "nx-mesh": {
+    "lastPublishedDate": "2023-04-26T20:23:43.825Z",
+    "githubDirectory": "packages/nx-mesh",
+    "npmDownloads": 1944,
+    "githubStars": 19,
+    "nxVersion": "^15.7.1"
+  },
+  "@nxazure/func": {
+    "lastPublishedDate": "2023-06-17T22:19:57.878Z",
+    "npmDownloads": 2351,
+    "githubStars": 9,
+    "nxVersion": "16.1.3"
+  },
+  "@rbnx/webdriverio": {
+    "lastPublishedDate": "2023-05-05T06:51:41.339Z",
+    "githubDirectory": "packages/webdriverio",
+    "npmDownloads": 198,
+    "githubStars": 7,
+    "nxVersion": "16.1.0"
+  },
+  "nx-ngrok": {
+    "lastPublishedDate": "2023-04-17T21:34:27.110Z",
+    "githubDirectory": "packages/nx-ngrok",
+    "npmDownloads": 283,
+    "githubStars": 0,
+    "nxVersion": "^15.7.1"
+  },
+  "@nxrocks/nx-ktor": {
+    "lastPublishedDate": "2023-05-25T05:35:48.467Z",
+    "githubDirectory": "packages/nx-ktor",
+    "npmDownloads": 38,
+    "githubStars": 232,
+    "nxVersion": "16.5.0"
+  },
+  "nx-size-limit": {
+    "lastPublishedDate": "2023-04-22T07:50:24.764Z",
+    "githubDirectory": "packages/nx-size-limit",
+    "npmDownloads": 466,
+    "githubStars": 7,
+    "nxVersion": "15.9.2"
+  },
+  "@jnxplus/nx-quarkus-gradle": {
+    "lastPublishedDate": "2023-07-28T16:33:30.811Z",
+    "npmDownloads": 1504,
+    "githubStars": -1,
+    "nxVersion": ""
+  },
+  "@jnxplus/nx-quarkus-maven": {
+    "lastPublishedDate": "2023-07-28T16:33:52.833Z",
+    "npmDownloads": 1468,
+    "githubStars": -1,
+    "nxVersion": ""
+  },
+  "@loft-orbital/terraform": {
+    "lastPublishedDate": "2023-03-25T21:03:22.028Z",
+    "npmDownloads": 43,
+    "githubStars": -1,
+    "nxVersion": ""
+  },
+  "@nxlv/python": {
+    "lastPublishedDate": "2023-07-06T13:05:49.453Z",
+    "githubDirectory": "packages/nx-python",
+    "npmDownloads": 9764,
+    "githubStars": 41,
+    "nxVersion": "16.3.2"
+  }
+}

--- a/nx-dev/nx-dev/pages/extending-nx/quality-indicators.json
+++ b/nx-dev/nx-dev/pages/extending-nx/quality-indicators.json
@@ -1,153 +1,153 @@
 {
   "@nx/angular": {
     "lastPublishedDate": "2023-07-31T13:26:25.163Z",
-    "npmDownloads": 433284,
-    "githubStars": 18536
+    "npmDownloads": 451513,
+    "githubStars": 18547
   },
   "@nx/cypress": {
     "lastPublishedDate": "2023-07-31T13:26:10.027Z",
-    "npmDownloads": 1155708,
-    "githubStars": 18536
+    "npmDownloads": 1206854,
+    "githubStars": 18547
   },
   "@nx/detox": {
     "lastPublishedDate": "2023-07-31T13:26:44.703Z",
-    "npmDownloads": 72037,
-    "githubStars": 18536
+    "npmDownloads": 74541,
+    "githubStars": 18547
   },
   "@nx/devkit": {
     "lastPublishedDate": "2023-07-31T13:25:14.034Z",
-    "npmDownloads": 4436007,
-    "githubStars": 18536
+    "npmDownloads": 4620584,
+    "githubStars": 18547
   },
   "@nx/esbuild": {
     "lastPublishedDate": "2023-07-31T13:25:35.264Z",
-    "npmDownloads": 222196,
-    "githubStars": 18536
+    "npmDownloads": 229089,
+    "githubStars": 18547
   },
   "@nx/eslint-plugin": {
     "lastPublishedDate": "2023-07-31T13:25:37.806Z",
-    "npmDownloads": 1518752,
-    "githubStars": 18536
+    "npmDownloads": 1588081,
+    "githubStars": 18547
   },
   "@nx/expo": {
     "lastPublishedDate": "2023-07-31T13:26:57.711Z",
-    "npmDownloads": 27833,
-    "githubStars": 18536
+    "npmDownloads": 28596,
+    "githubStars": 18547
   },
   "@nx/express": {
     "lastPublishedDate": "2023-07-31T13:26:32.209Z",
-    "npmDownloads": 136341,
-    "githubStars": 18536
+    "npmDownloads": 141777,
+    "githubStars": 18547
   },
   "@nx/jest": {
     "lastPublishedDate": "2023-07-31T13:25:46.305Z",
-    "npmDownloads": 1710746,
-    "githubStars": 18536
+    "npmDownloads": 1786802,
+    "githubStars": 18547
   },
   "@nx/js": {
     "lastPublishedDate": "2023-07-31T13:25:30.195Z",
-    "npmDownloads": 2456765,
-    "githubStars": 18536
+    "npmDownloads": 2560691,
+    "githubStars": 18547
   },
   "@nx/linter": {
     "lastPublishedDate": "2023-07-31T13:25:53.612Z",
-    "npmDownloads": 1891220,
-    "githubStars": 18536
+    "npmDownloads": 1975637,
+    "githubStars": 18547
   },
   "@nx/nest": {
     "lastPublishedDate": "2023-07-31T13:26:35.646Z",
-    "npmDownloads": 468574,
-    "githubStars": 18536
+    "npmDownloads": 490567,
+    "githubStars": 18547
   },
   "@nx/next": {
     "lastPublishedDate": "2023-07-31T13:26:54.477Z",
-    "npmDownloads": 370856,
-    "githubStars": 18536
+    "npmDownloads": 384056,
+    "githubStars": 18547
   },
   "@nx/node": {
     "lastPublishedDate": "2023-07-31T13:26:12.510Z",
-    "npmDownloads": 789085,
-    "githubStars": 18536
+    "npmDownloads": 830340,
+    "githubStars": 18547
   },
   "nx": {
     "lastPublishedDate": "2023-07-31T13:25:19.774Z",
-    "npmDownloads": 15701158,
-    "githubStars": 18536
+    "npmDownloads": 16270290,
+    "githubStars": 18547
   },
   "@nx/playwright": {
-    "lastPublishedDate": "",
+    "lastPublishedDate": "2023-08-03T03:30:49.402Z",
     "npmDownloads": "",
-    "githubStars": 18536
+    "githubStars": 18547
   },
   "@nx/plugin": {
     "lastPublishedDate": "2023-07-31T13:26:17.005Z",
-    "npmDownloads": 584062,
-    "githubStars": 18536
+    "npmDownloads": 615978,
+    "githubStars": 18547
   },
   "@nx/react": {
     "lastPublishedDate": "2023-07-31T13:26:19.350Z",
-    "npmDownloads": 792182,
-    "githubStars": 18536
+    "npmDownloads": 828724,
+    "githubStars": 18547
   },
   "@nx/react-native": {
     "lastPublishedDate": "2023-07-31T13:27:02.407Z",
-    "npmDownloads": 43926,
-    "githubStars": 18536
+    "npmDownloads": 45656,
+    "githubStars": 18547
   },
   "@nx/rollup": {
     "lastPublishedDate": "2023-07-31T13:25:56.293Z",
-    "npmDownloads": 137473,
-    "githubStars": 18536
+    "npmDownloads": 143102,
+    "githubStars": 18547
   },
   "@nx/storybook": {
     "lastPublishedDate": "2023-07-31T13:26:41.485Z",
-    "npmDownloads": 562080,
-    "githubStars": 18536
+    "npmDownloads": 589880,
+    "githubStars": 18547
   },
   "@nx/vite": {
     "lastPublishedDate": "2023-07-31T13:25:59.567Z",
-    "npmDownloads": 291173,
-    "githubStars": 18536
+    "npmDownloads": 302208,
+    "githubStars": 18547
   },
   "@nx/web": {
     "lastPublishedDate": "2023-07-31T13:26:02.010Z",
-    "npmDownloads": 985271,
-    "githubStars": 18536
+    "npmDownloads": 1029649,
+    "githubStars": 18547
   },
   "@nx/webpack": {
     "lastPublishedDate": "2023-07-31T13:26:06.719Z",
-    "npmDownloads": 1143030,
-    "githubStars": 18536
+    "npmDownloads": 1197589,
+    "githubStars": 18547
   },
   "@nx/workspace": {
     "lastPublishedDate": "2023-07-31T13:25:27.694Z",
-    "npmDownloads": 2498807,
-    "githubStars": 18536
+    "npmDownloads": 2602643,
+    "githubStars": 18547
   },
   "@ahryman40k/nx-vitepress": {
     "lastPublishedDate": "2022-12-23T01:15:39.916Z",
-    "npmDownloads": 45,
+    "npmDownloads": 51,
     "githubStars": 0
   },
   "@nightwatch/nx": {
     "lastPublishedDate": "2022-12-05T21:50:17.172Z",
-    "npmDownloads": 57,
+    "npmDownloads": 59,
     "githubStars": 2
   },
   "@nxkit/playwright": {
     "lastPublishedDate": "2023-06-06T17:50:01.235Z",
-    "npmDownloads": 16049,
+    "npmDownloads": 16854,
     "githubStars": 36
   },
   "qwik-nx": {
     "lastPublishedDate": "2023-07-27T04:27:50.074Z",
-    "npmDownloads": 4038,
+    "npmDownloads": 3896,
     "githubStars": 113,
     "nxVersion": ">= 15 <= 17"
   },
   "@nxkit/style-dictionary": {
     "lastPublishedDate": "2023-06-06T17:50:01.313Z",
-    "npmDownloads": 8395,
+    "npmDownloads": 8575,
     "githubStars": 36
   },
   "nx-plugin-esbuild": {
@@ -158,113 +158,113 @@
   },
   "nx-plugin-vite": {
     "lastPublishedDate": "2022-07-09T09:40:02.353Z",
-    "npmDownloads": 541,
+    "npmDownloads": 560,
     "githubStars": 94
   },
   "nx-plugin-snowpack": {
     "lastPublishedDate": "2021-10-04T02:55:28.868Z",
-    "npmDownloads": 38,
+    "npmDownloads": 39,
     "githubStars": -1,
     "nxVersion": "12.7.2"
   },
   "nx-plugin-prisma": {
     "lastPublishedDate": "2021-09-30T04:07:48.904Z",
-    "npmDownloads": 13,
+    "npmDownloads": 12,
     "githubStars": -1,
     "nxVersion": "12.7.2"
   },
   "@codebrew/nx-aws-cdk": {
     "lastPublishedDate": "2022-01-28T05:22:43.508Z",
-    "npmDownloads": 1542,
+    "npmDownloads": 1576,
     "githubStars": 20,
     "nxVersion": ""
   },
   "@ago-dev/nx-aws-cdk-v2": {
     "lastPublishedDate": "2023-05-08T11:33:02.618Z",
-    "npmDownloads": 35737,
+    "npmDownloads": 37529,
     "githubStars": 30,
     "nxVersion": ""
   },
   "@berenddeboer/nx-sst": {
     "lastPublishedDate": "2023-07-28T02:12:51.950Z",
-    "npmDownloads": 1198,
+    "npmDownloads": 1222,
     "githubStars": 4,
     "nxVersion": ">= 15 <= 17"
   },
   "@rxap/plugin-localazy": {
     "lastPublishedDate": "2022-12-14T13:23:03.536Z",
-    "npmDownloads": 456,
+    "npmDownloads": 511,
     "githubStars": -1,
     "nxVersion": ">= 14 <= 16"
   },
   "nx-electron": {
     "lastPublishedDate": "2023-06-22T13:23:58.845Z",
-    "npmDownloads": 14764,
+    "npmDownloads": 15276,
     "githubStars": 273,
     "nxVersion": ">= 14.1 <= 16"
   },
   "nx-stylelint": {
     "lastPublishedDate": "2023-02-16T14:16:46.275Z",
-    "npmDownloads": 117383,
+    "npmDownloads": 120338,
     "githubStars": 64,
     "nxVersion": ">= 14 <= 16"
   },
   "@nxext/ionic-react": {
     "lastPublishedDate": "2023-05-26T12:53:11.721Z",
-    "npmDownloads": 658,
+    "npmDownloads": 689,
     "githubStars": -1
   },
   "@nxext/ionic-angular": {
     "lastPublishedDate": "2023-05-26T12:52:58.419Z",
-    "npmDownloads": 32188,
+    "npmDownloads": 33272,
     "githubStars": 190
   },
   "@nxext/capacitor": {
     "lastPublishedDate": "2023-06-12T07:43:34.104Z",
-    "npmDownloads": 50162,
-    "githubStars": 394,
+    "npmDownloads": 51591,
+    "githubStars": 395,
     "nxVersion": ">= 15 <= 17"
   },
   "@nxtend/firebase": {
     "lastPublishedDate": "2021-12-02T15:22:22.629Z",
-    "npmDownloads": 246,
+    "npmDownloads": 291,
     "githubStars": 190,
     "nxVersion": "12.0.0"
   },
   "@angular-architects/ddd": {
     "lastPublishedDate": "2023-05-20T19:52:32.293Z",
-    "npmDownloads": 19786,
+    "npmDownloads": 20613,
     "githubStars": 276
   },
   "@offeringsolutions/nx-karma-to-jest": {
     "lastPublishedDate": "2020-03-08T19:29:18.913Z",
-    "npmDownloads": 19,
+    "npmDownloads": 18,
     "githubStars": 9
   },
   "@flowaccount/nx-serverless": {
     "lastPublishedDate": "2023-07-10T19:06:16.916Z",
-    "npmDownloads": 7177,
+    "npmDownloads": 7236,
     "githubStars": -1,
     "nxVersion": ">= 13.10 <= 15"
   },
   "@ns3/nx-serverless": {
     "lastPublishedDate": "2023-07-12T07:08:25.829Z",
-    "npmDownloads": 53411,
+    "npmDownloads": 55611,
     "githubStars": 59
   },
   "@ns3/nx-jest-playwright": {
     "lastPublishedDate": "2023-05-03T07:05:36.802Z",
-    "npmDownloads": 6750,
+    "npmDownloads": 7036,
     "githubStars": 59
   },
   "@ns3/nx-playwright": {
     "lastPublishedDate": "2023-05-03T07:05:36.629Z",
-    "npmDownloads": 4583,
+    "npmDownloads": 4907,
     "githubStars": 59
   },
   "@dev-thought/nx-deploy-it": {
     "lastPublishedDate": "2021-02-12T21:12:18.923Z",
-    "npmDownloads": 212,
+    "npmDownloads": 218,
     "githubStars": 77
   },
   "@offeringsolutions/nx-protractor-to-cypress": {
@@ -275,66 +275,66 @@
   },
   "@angular-custom-builders/lite-serve": {
     "lastPublishedDate": "2021-03-08T14:21:34.424Z",
-    "npmDownloads": 1619,
+    "npmDownloads": 1682,
     "githubStars": 6
   },
   "@nx-plus/nuxt": {
     "lastPublishedDate": "2022-07-02T16:45:19.149Z",
-    "npmDownloads": 3245,
+    "npmDownloads": 3343,
     "githubStars": 298,
     "nxVersion": ">= 13.10 <= 15"
   },
   "@nx-plus/vue": {
     "lastPublishedDate": "2022-12-05T02:51:23.682Z",
-    "npmDownloads": 9254,
+    "npmDownloads": 9789,
     "githubStars": 298,
     "nxVersion": ">= 14 <= 16"
   },
   "@nx-plus/docusaurus": {
     "lastPublishedDate": "2022-12-05T02:51:37.534Z",
-    "npmDownloads": 59902,
+    "npmDownloads": 61760,
     "githubStars": 298,
     "nxVersion": ">= 14 <= 16"
   },
   "@twittwer/compodoc": {
     "lastPublishedDate": "2023-06-25T12:35:20.159Z",
-    "npmDownloads": 17456,
+    "npmDownloads": 18068,
     "githubStars": 40,
     "nxVersion": ">= 15 <= 17"
   },
   "@enio.ai/nx-install": {
     "lastPublishedDate": "2023-03-05T20:18:09.761Z",
-    "npmDownloads": 50,
+    "npmDownloads": 61,
     "githubStars": 22,
     "nxVersion": ">= 14.1 <= 16"
   },
   "@enio.ai/typedoc": {
     "lastPublishedDate": "2023-03-05T20:17:20.752Z",
-    "npmDownloads": 3599,
+    "npmDownloads": 3643,
     "githubStars": 22,
     "nxVersion": ">= 14.1 <= 16"
   },
   "@nxext/svelte": {
     "lastPublishedDate": "2023-05-26T12:47:54.560Z",
-    "npmDownloads": 4976,
-    "githubStars": 394
+    "npmDownloads": 5277,
+    "githubStars": 395
   },
   "@nxext/stencil": {
     "lastPublishedDate": "2023-06-21T09:20:15.486Z",
-    "npmDownloads": 10950,
-    "githubStars": 394,
+    "npmDownloads": 11402,
+    "githubStars": 395,
     "nxVersion": ">= 15 <= 17"
   },
   "@nxext/vite": {
     "lastPublishedDate": "2023-02-28T19:05:21.436Z",
-    "npmDownloads": 22988,
-    "githubStars": 394,
+    "npmDownloads": 24063,
+    "githubStars": 395,
     "nxVersion": ">= 14.1 <= 16"
   },
   "@nxext/solid": {
     "lastPublishedDate": "2023-05-26T12:47:38.232Z",
-    "npmDownloads": 1560,
-    "githubStars": 394
+    "npmDownloads": 1555,
+    "githubStars": 395
   },
   "@joelcode/gcp-function": {
     "lastPublishedDate": "2021-09-15T16:46:35.377Z",
@@ -343,7 +343,7 @@
   },
   "@nx-go/nx-go": {
     "lastPublishedDate": "2022-10-17T07:48:25.180Z",
-    "npmDownloads": 234870,
+    "npmDownloads": 242857,
     "githubStars": -1
   },
   "@nx-golang/gin": {
@@ -353,67 +353,67 @@
   },
   "@angular-architects/module-federation": {
     "lastPublishedDate": "2023-06-20T16:52:19.205Z",
-    "npmDownloads": 425479,
+    "npmDownloads": 445713,
     "githubStars": 577
   },
   "@nxrocks/nx-spring-boot": {
     "lastPublishedDate": "2023-05-12T16:58:52.743Z",
-    "npmDownloads": 6675,
-    "githubStars": 232,
+    "npmDownloads": 6938,
+    "githubStars": 231,
     "nxVersion": ">= 15 <= 17"
   },
   "@trumbitta/nx-plugin-openapi": {
     "lastPublishedDate": "2022-08-28T20:54:50.978Z",
-    "npmDownloads": 25483,
+    "npmDownloads": 27028,
     "githubStars": -1,
     "nxVersion": "13.0.0"
   },
   "@trumbitta/nx-plugin-unused-deps": {
     "lastPublishedDate": "2022-08-28T20:55:11.226Z",
-    "npmDownloads": 64540,
+    "npmDownloads": 65267,
     "githubStars": -1,
     "nxVersion": "13.0.0"
   },
   "@nxrocks/nx-flutter": {
     "lastPublishedDate": "2023-05-12T16:59:33.230Z",
-    "npmDownloads": 8304,
-    "githubStars": 232,
+    "npmDownloads": 8587,
+    "githubStars": 231,
     "nxVersion": ">= 15 <= 17"
   },
   "@srleecode/domain": {
     "lastPublishedDate": "2023-06-22T13:44:39.620Z",
-    "npmDownloads": 379,
+    "npmDownloads": 381,
     "githubStars": -1,
     "nxVersion": ""
   },
   "@jscutlery/semver": {
     "lastPublishedDate": "2023-07-31T06:50:30.918Z",
-    "npmDownloads": 506545,
-    "githubStars": 618,
+    "npmDownloads": 523358,
+    "githubStars": 619,
     "nxVersion": ">= 15 <= 17"
   },
   "ngx-deploy-npm": {
     "lastPublishedDate": "2023-05-15T07:18:38.684Z",
-    "npmDownloads": 278141,
+    "npmDownloads": 287616,
     "githubStars": 99,
     "nxVersion": ">= 15 <= 17"
   },
   "@trafilea/nx-shopify": {
     "lastPublishedDate": "2021-06-02T19:51:43.707Z",
-    "npmDownloads": 105,
+    "npmDownloads": 102,
     "githubStars": 42,
     "nxVersion": "12.0.8"
   },
   "@nx-dotnet/core": {
     "lastPublishedDate": "2023-04-12T17:54:41.139Z",
-    "npmDownloads": 56204,
+    "npmDownloads": 58546,
     "githubStars": 214,
     "nxVersion": ">= 14.1 <= 16"
   },
   "@nxrocks/nx-quarkus": {
     "lastPublishedDate": "2023-05-12T16:59:55.758Z",
-    "npmDownloads": 9422,
-    "githubStars": 232,
+    "npmDownloads": 10003,
+    "githubStars": 231,
     "nxVersion": ">= 15 <= 17"
   },
   "@nx-extend/gcp-secrets": {
@@ -424,114 +424,114 @@
   },
   "@nx-extend/gcp-storage": {
     "lastPublishedDate": "2023-06-22T17:40:53.943Z",
-    "npmDownloads": 950,
+    "npmDownloads": 987,
     "githubStars": 98,
     "nxVersion": ">= 15 <= 17"
   },
   "@nx-extend/gcp-functions": {
     "lastPublishedDate": "2023-07-22T09:38:42.753Z",
-    "npmDownloads": 3962,
+    "npmDownloads": 4113,
     "githubStars": 98,
     "nxVersion": ">= 15 <= 17"
   },
   "@nx-extend/gcp-deployment-manager": {
     "lastPublishedDate": "2023-06-22T17:40:40.176Z",
-    "npmDownloads": 106,
+    "npmDownloads": 107,
     "githubStars": 98,
     "nxVersion": ">= 15 <= 17"
   },
   "@nx-extend/gcp-cloud-run": {
     "lastPublishedDate": "2023-06-22T17:40:52.218Z",
-    "npmDownloads": 2093,
+    "npmDownloads": 2142,
     "githubStars": 98,
     "nxVersion": ">= 15 <= 17"
   },
   "@nx-extend/translations": {
     "lastPublishedDate": "2023-06-22T17:40:44.178Z",
-    "npmDownloads": 236,
+    "npmDownloads": 233,
     "githubStars": 98,
     "nxVersion": ">= 15 <= 17"
   },
   "@nx-extend/firebase-hosting": {
     "lastPublishedDate": "2023-07-13T10:38:12.436Z",
-    "npmDownloads": 1305,
+    "npmDownloads": 1382,
     "githubStars": 98,
     "nxVersion": ">= 15 <= 17"
   },
   "@nx-extend/e2e-runner": {
     "lastPublishedDate": "2023-07-21T20:54:54.000Z",
-    "npmDownloads": 6223,
+    "npmDownloads": 6501,
     "githubStars": 98,
     "nxVersion": ">= 15 <= 17"
   },
   "@nx-extend/vercel": {
     "lastPublishedDate": "2023-07-28T08:36:42.305Z",
-    "npmDownloads": 814,
+    "npmDownloads": 820,
     "githubStars": 98,
     "nxVersion": ">= 15 <= 17"
   },
   "@nx-extend/strapi": {
     "lastPublishedDate": "2023-07-12T07:02:19.604Z",
-    "npmDownloads": 8787,
+    "npmDownloads": 9188,
     "githubStars": 98,
     "nxVersion": ">= 15 <= 17"
   },
   "@nx-extend/playwright": {
     "lastPublishedDate": "2023-06-22T17:40:55.663Z",
-    "npmDownloads": 7417,
+    "npmDownloads": 7561,
     "githubStars": 98,
     "nxVersion": ">= 15 <= 17"
   },
   "@nx-extend/terraform": {
     "lastPublishedDate": "2023-06-22T17:40:57.454Z",
-    "npmDownloads": 567,
+    "npmDownloads": 570,
     "githubStars": 98,
     "nxVersion": ">= 15 <= 17"
   },
   "@nx-extend/pulumi": {
     "lastPublishedDate": "2023-06-22T17:40:59.131Z",
-    "npmDownloads": 483,
+    "npmDownloads": 467,
     "githubStars": 98,
     "nxVersion": ">= 15 <= 17"
   },
   "@nativescript/nx": {
     "lastPublishedDate": "2023-07-05T22:55:56.178Z",
-    "npmDownloads": 10198,
+    "npmDownloads": 10409,
     "githubStars": 58,
     "nxVersion": ">= 15 <= 17"
   },
   "@nx-clean/plugin-core": {
     "lastPublishedDate": "2022-03-10T15:36:11.690Z",
-    "npmDownloads": 138,
+    "npmDownloads": 145,
     "githubStars": 65,
     "nxVersion": ""
   },
   "@jnxplus/nx-boot-gradle": {
     "lastPublishedDate": "2023-07-28T16:33:38.123Z",
-    "npmDownloads": 2421,
+    "npmDownloads": 2384,
     "githubStars": -1,
     "nxVersion": ">= 15 <= 17"
   },
   "@jnxplus/nx-boot-maven": {
     "lastPublishedDate": "2023-07-28T16:34:00.918Z",
-    "npmDownloads": 7233,
+    "npmDownloads": 7475,
     "githubStars": -1,
     "nxVersion": ">= 15 <= 17"
   },
   "@nxtensions/astro": {
     "lastPublishedDate": "2023-07-30T14:40:23.494Z",
-    "npmDownloads": 4679,
+    "npmDownloads": 4841,
     "githubStars": 43,
     "nxVersion": ">= 15 <= 17"
   },
   "@nxrs/cargo": {
     "lastPublishedDate": "2022-05-25T02:55:50.238Z",
-    "npmDownloads": 2625,
+    "npmDownloads": 2601,
     "githubStars": 101
   },
   "nx-uvu": {
     "lastPublishedDate": "2023-06-16T16:07:57.812Z",
-    "npmDownloads": 554,
+    "npmDownloads": 563,
     "githubStars": -1,
     "nxVersion": ">= 15 <= 17"
   },
@@ -543,7 +543,7 @@
   },
   "@diogovcs/graphql-mesh": {
     "lastPublishedDate": "2023-01-22T11:38:26.303Z",
-    "npmDownloads": 594,
+    "npmDownloads": 633,
     "githubStars": -1
   },
   "@computas/nx-yarn": {
@@ -554,7 +554,7 @@
   },
   "@theunderscorer/nx-semantic-release": {
     "lastPublishedDate": "2023-07-16T18:50:55.453Z",
-    "npmDownloads": 17137,
+    "npmDownloads": 17537,
     "githubStars": 61,
     "nxVersion": ">= 15 <= 17"
   },
@@ -567,69 +567,69 @@
   "@nxrocks/nx-micronaut": {
     "lastPublishedDate": "2023-05-12T16:59:13.295Z",
     "npmDownloads": 201,
-    "githubStars": 232,
+    "githubStars": 231,
     "nxVersion": ">= 15 <= 17"
   },
   "@koliveira15/nx-sonarqube": {
     "lastPublishedDate": "2023-08-02T00:25:44.844Z",
-    "npmDownloads": 41340,
+    "npmDownloads": 43559,
     "githubStars": 21
   },
   "@mands/nx-playwright": {
     "lastPublishedDate": "2023-05-16T10:59:21.495Z",
-    "npmDownloads": 61666,
+    "npmDownloads": 63690,
     "githubStars": 58
   },
   "@diogovcs/stryker-mutator": {
     "lastPublishedDate": "2023-03-18T12:51:54.214Z",
-    "npmDownloads": 2376,
+    "npmDownloads": 2414,
     "githubStars": -1,
     "nxVersion": ""
   },
   "@spaceribs/nx-web-ext": {
     "lastPublishedDate": "2023-07-16T15:45:19.229Z",
-    "npmDownloads": 255,
+    "npmDownloads": 256,
     "githubStars": 5,
     "nxVersion": ">= 15 <= 17"
   },
   "@spaceribs/nx-betterer": {
     "lastPublishedDate": "2023-07-16T15:45:12.663Z",
-    "npmDownloads": 173,
+    "npmDownloads": 176,
     "githubStars": 5,
     "nxVersion": ">= 15 <= 17"
   },
   "@nx-tools/nx-container": {
     "lastPublishedDate": "2023-06-21T06:38:36.059Z",
-    "npmDownloads": 100493,
+    "npmDownloads": 103868,
     "githubStars": 261,
     "nxVersion": ">= 15 <= 17"
   },
   "@nxrocks/nx-melos": {
     "lastPublishedDate": "2023-05-12T17:00:25.890Z",
-    "npmDownloads": 165,
-    "githubStars": 232,
+    "npmDownloads": 166,
+    "githubStars": 231,
     "nxVersion": ">= 15 <= 17"
   },
   "@monodon/rust": {
     "lastPublishedDate": "2023-06-30T16:35:58.528Z",
-    "npmDownloads": 7087,
+    "npmDownloads": 7138,
     "githubStars": 15,
     "nxVersion": ">= 15 <= 17"
   },
   "nx-mesh": {
     "lastPublishedDate": "2023-04-26T20:23:43.825Z",
-    "npmDownloads": 2068,
+    "npmDownloads": 2113,
     "githubStars": 19,
     "nxVersion": ">= 14.1 <= 16"
   },
   "@nxazure/func": {
     "lastPublishedDate": "2023-06-17T22:19:57.878Z",
-    "npmDownloads": 2016,
+    "npmDownloads": 2041,
     "githubStars": 9
   },
   "@rbnx/webdriverio": {
     "lastPublishedDate": "2023-05-05T06:51:41.339Z",
-    "npmDownloads": 232,
+    "npmDownloads": 233,
     "githubStars": 7,
     "nxVersion": ">= 15 <= 17"
   },
@@ -642,34 +642,34 @@
   "@nxrocks/nx-ktor": {
     "lastPublishedDate": "2023-05-25T05:35:48.467Z",
     "npmDownloads": 27,
-    "githubStars": 232,
+    "githubStars": 231,
     "nxVersion": ">= 15 <= 17"
   },
   "nx-size-limit": {
     "lastPublishedDate": "2023-04-22T07:50:24.764Z",
-    "npmDownloads": 320,
+    "npmDownloads": 313,
     "githubStars": 7
   },
   "@jnxplus/nx-quarkus-gradle": {
     "lastPublishedDate": "2023-07-28T16:33:30.811Z",
-    "npmDownloads": 803,
+    "npmDownloads": 750,
     "githubStars": -1,
     "nxVersion": ">= 15 <= 17"
   },
   "@jnxplus/nx-quarkus-maven": {
     "lastPublishedDate": "2023-07-28T16:33:52.833Z",
-    "npmDownloads": 750,
+    "npmDownloads": 725,
     "githubStars": -1,
     "nxVersion": ">= 15 <= 17"
   },
   "@loft-orbital/terraform": {
     "lastPublishedDate": "2023-03-25T21:03:22.028Z",
-    "npmDownloads": 475,
+    "npmDownloads": 432,
     "githubStars": -1
   },
   "@nxlv/python": {
     "lastPublishedDate": "2023-07-06T13:05:49.453Z",
-    "npmDownloads": 9227,
+    "npmDownloads": 9584,
     "githubStars": 43,
     "nxVersion": ">= 15 <= 17"
   }

--- a/nx-dev/nx-dev/pages/extending-nx/registry.tsx
+++ b/nx-dev/nx-dev/pages/extending-nx/registry.tsx
@@ -51,6 +51,7 @@ export async function getStaticProps(): Promise<{ props: BrowseProps }> {
           name: plugin.packageName,
           description: plugin.description ?? '',
           url: plugin.path,
+          ...qualityIndicators[plugin.packageName],
           isOfficial: true,
         })),
         ...pluginList.map((plugin) => ({

--- a/nx-dev/nx-dev/pages/extending-nx/registry.tsx
+++ b/nx-dev/nx-dev/pages/extending-nx/registry.tsx
@@ -44,7 +44,6 @@ export async function getStaticProps(): Promise<{ props: BrowseProps }> {
       m.name !== 'tao'
   );
 
-  console.log(qualityIndicators);
   return {
     props: {
       pluginList: [

--- a/nx-dev/nx-dev/pages/extending-nx/registry.tsx
+++ b/nx-dev/nx-dev/pages/extending-nx/registry.tsx
@@ -52,6 +52,7 @@ export async function getStaticProps(): Promise<{ props: BrowseProps }> {
           description: plugin.description ?? '',
           url: plugin.path,
           ...qualityIndicators[plugin.packageName],
+          nxVersion: 'official',
           isOfficial: true,
         })),
         ...pluginList.map((plugin) => ({

--- a/nx-dev/nx-dev/pages/extending-nx/registry.tsx
+++ b/nx-dev/nx-dev/pages/extending-nx/registry.tsx
@@ -13,6 +13,7 @@ import { useRef } from 'react';
 import { menusApi } from '../../lib/menus.api';
 import { useNavToggle } from '../../lib/navigation-toggle.effect';
 import { nxPackagesApi } from '../../lib/packages.api';
+import * as qualityIndicators from './quality-indicators.json';
 
 declare const fetch: any;
 
@@ -43,6 +44,7 @@ export async function getStaticProps(): Promise<{ props: BrowseProps }> {
       m.name !== 'tao'
   );
 
+  console.log(qualityIndicators);
   return {
     props: {
       pluginList: [
@@ -54,6 +56,7 @@ export async function getStaticProps(): Promise<{ props: BrowseProps }> {
         })),
         ...pluginList.map((plugin) => ({
           ...plugin,
+          ...qualityIndicators[plugin.name],
           isOfficial: false,
         })),
       ],

--- a/nx-dev/ui-common/src/lib/plugin-card.tsx
+++ b/nx-dev/ui-common/src/lib/plugin-card.tsx
@@ -1,18 +1,8 @@
 import {
-  ArrowDownCircleIcon,
   ArrowDownIcon,
-  ArrowDownOnSquareIcon,
-  ArrowDownOnSquareStackIcon,
-  ArrowDownTrayIcon,
-  ArrowSmallDownIcon,
-  ChevronDownIcon,
   ClockIcon,
-  CloudArrowDownIcon,
-  DocumentArrowDownIcon,
-  InboxArrowDownIcon,
   StarIcon,
 } from '@heroicons/react/24/outline';
-import { lightFormat } from 'date-fns';
 
 export interface PluginCardProps {
   name: string;
@@ -91,7 +81,8 @@ function lastPublishedWidget(lastPublishedDate: string | undefined) {
   return (
     <abbr title="Most Recent Release Date">
       <ClockIcon className="h-4 w-4 inline-block mx-0.5 align-bottom"></ClockIcon>
-      <span>{lightFormat(new Date(lastPublishedDate), 'yyyy-MM-dd')}</span>
+      {/* yyyy-MM-dd */}
+      <span>{new Date(lastPublishedDate).toISOString().slice(0, 10)}</span>
     </abbr>
   );
 }

--- a/nx-dev/ui-common/src/lib/plugin-card.tsx
+++ b/nx-dev/ui-common/src/lib/plugin-card.tsx
@@ -1,8 +1,28 @@
+import {
+  ArrowDownCircleIcon,
+  ArrowDownIcon,
+  ArrowDownOnSquareIcon,
+  ArrowDownOnSquareStackIcon,
+  ArrowDownTrayIcon,
+  ArrowSmallDownIcon,
+  ChevronDownIcon,
+  ClockIcon,
+  CloudArrowDownIcon,
+  DocumentArrowDownIcon,
+  InboxArrowDownIcon,
+  StarIcon,
+} from '@heroicons/react/24/outline';
+import { lightFormat } from 'date-fns';
+
 export interface PluginCardProps {
   name: string;
   description: string;
   url: string;
   isOfficial: boolean;
+  lastPublishedDate?: string;
+  npmDownloads?: string;
+  githubStars?: string;
+  nxVersion?: string;
 }
 
 export function PluginCard({
@@ -10,6 +30,10 @@ export function PluginCard({
   description,
   url,
   isOfficial,
+  lastPublishedDate,
+  npmDownloads,
+  githubStars,
+  nxVersion,
 }: PluginCardProps): JSX.Element {
   return (
     <div className="focus-within:ring-focus-within:ring-blue-500 relative flex w-full overflow-hidden rounded-lg border border border-slate-200 bg-white shadow-sm transition hover:bg-slate-50 dark:border-slate-900 dark:bg-slate-800/60 dark:focus-within:ring-sky-500 dark:hover:bg-slate-800">
@@ -35,18 +59,96 @@ export function PluginCard({
           className="focus:outline-none"
         >
           <span className="absolute inset-0" aria-hidden="true" />
-          <p className="line-clamp-3 mb-6 text-sm">{description}</p>
+          <p className="line-clamp-3 mb-8 text-sm">{description}</p>
 
           {isOfficial ? (
             <span
               title="Official plugins are maintained by the Nx Team"
-              className="bg-green-500 absolute bottom-3 right-4 rounded-full px-3 py-0.5 text-xs font-medium capitalize text-white"
+              className="border bg-green-50 border-green-300 text-green-600 dark:border-green-900 dark:bg-green-900/30 dark:text-green-400 absolute bottom-3 right-4 rounded-full px-3 py-0.5 text-xs font-medium capitalize"
             >
               Official
             </span>
-          ) : null}
+          ) : (
+            <div className="absolute bottom-3 right-0 left-0 flex justify-between px-3 py-0.5 text-xs font-medium capitalize">
+              <div className="mx-1">
+                {lastPublishedWidget(lastPublishedDate)}
+              </div>
+              <div className="mx-1">{npmDownloadsWidget(npmDownloads)}</div>
+              <div className="mx-1">{githubStarsWidget(githubStars)}</div>
+              <div className="mx-1">{nxVersionWidget(nxVersion)}</div>
+            </div>
+          )}
         </a>
       </div>
     </div>
+  );
+}
+
+function lastPublishedWidget(lastPublishedDate: string | undefined) {
+  if (!lastPublishedDate) {
+    return <div className="w-16"></div>;
+  }
+  return (
+    <abbr title="Most Recent Release Date">
+      <ClockIcon className="h-4 w-4 inline-block mx-0.5 align-bottom"></ClockIcon>
+      <span>{lightFormat(new Date(lastPublishedDate), 'yyyy-MM-dd')}</span>
+    </abbr>
+  );
+}
+
+function npmDownloadsWidget(npmDownloads: string | undefined) {
+  if (!npmDownloads) {
+    return <></>;
+  }
+  return (
+    <abbr title="Total NPM Downloads">
+      <ArrowDownIcon className="h-4 w-4 inline-block mx-0.5 align-bottom"></ArrowDownIcon>
+      {shortenNumber(npmDownloads)}
+    </abbr>
+  );
+}
+
+function githubStarsWidget(githubStars: string | undefined) {
+  if (!githubStars || githubStars == '-1') {
+    return <div className="w-6"></div>;
+  }
+  return (
+    <abbr title="GitHub Stars">
+      <StarIcon className="h-4 w-4 inline-block mx-0.5 align-bottom"></StarIcon>
+      {shortenNumber(githubStars)}
+    </abbr>
+  );
+}
+
+function shortenNumber(number: string | number): string {
+  const num = Number.parseInt(number + '');
+  if (num > 1000000) {
+    return Math.floor(num / 1000000) + 'M';
+  }
+  if (num > 1000) {
+    return Math.floor(num / 1000) + 'k';
+  }
+  return num + '';
+}
+
+function nxVersionWidget(nxVersion: string | undefined) {
+  if (!nxVersion) {
+    return <div className="w-12"></div>;
+  }
+  return (
+    <abbr title="Highest Supported Nx Version">
+      {/* Nx Logo */}
+      <svg
+        role="img"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+        className="h-4 w-4 inline-block mx-0.5 align-bottom"
+        fill="currentColor"
+      >
+        <title>Nx</title>
+        <path d="M11.987 14.138l-3.132 4.923-5.193-8.427-.012 8.822H0V4.544h3.691l5.247 8.833.005-3.998 3.044 4.759zm.601-5.761c.024-.048 0-3.784.008-3.833h-3.65c.002.059-.005 3.776-.003 3.833h3.645zm5.634 4.134a2.061 2.061 0 0 0-1.969 1.336 1.963 1.963 0 0 1 2.343-.739c.396.161.917.422 1.33.283a2.1 2.1 0 0 0-1.704-.88zm3.39 1.061c-.375-.13-.8-.277-1.109-.681-.06-.08-.116-.17-.176-.265a2.143 2.143 0 0 0-.533-.642c-.294-.216-.68-.322-1.18-.322a2.482 2.482 0 0 0-2.294 1.536 2.325 2.325 0 0 1 4.002.388.75.75 0 0 0 .836.334c.493-.105.46.36 1.203.518v-.133c-.003-.446-.246-.55-.75-.733zm2.024 1.266a.723.723 0 0 0 .347-.638c-.01-2.957-2.41-5.487-5.37-5.487a5.364 5.364 0 0 0-4.487 2.418c-.01-.026-1.522-2.39-1.538-2.418H8.943l3.463 5.423-3.379 5.32h3.54l1.54-2.366 1.568 2.366h3.541l-3.21-5.052a.7.7 0 0 1-.084-.32 2.69 2.69 0 0 1 2.69-2.691h.001c1.488 0 1.736.89 2.057 1.308.634.826 1.9.464 1.9 1.541a.707.707 0 0 0 1.066.596zm.35.133c-.173.372-.56.338-.755.639-.176.271.114.412.114.412s.337.156.538-.311c.104-.231.14-.488.103-.74z" />
+      </svg>
+      {nxVersion}
+    </abbr>
   );
 }

--- a/nx-dev/ui-common/src/lib/plugin-card.tsx
+++ b/nx-dev/ui-common/src/lib/plugin-card.tsx
@@ -46,10 +46,10 @@ export function PluginCard({
           target="_blank"
           rel="noreferrer"
           title={name}
-          className="focus:outline-none"
+          className="focus:outline-none flex flex-col grow"
         >
           <span className="absolute inset-0" aria-hidden="true" />
-          <p className="line-clamp-3 mb-2 text-sm">{description}</p>
+          <p className="line-clamp-3 mb-2 text-sm grow">{description}</p>
 
           <div className="flex flex-wrap justify-between items-center py-0.5 text-xs font-medium capitalize">
             <div className="mr-1 my-1">

--- a/nx-dev/ui-common/src/lib/plugin-card.tsx
+++ b/nx-dev/ui-common/src/lib/plugin-card.tsx
@@ -49,64 +49,98 @@ export function PluginCard({
           className="focus:outline-none"
         >
           <span className="absolute inset-0" aria-hidden="true" />
-          <p className="line-clamp-3 mb-8 text-sm">{description}</p>
+          <p className="line-clamp-3 mb-2 text-sm">{description}</p>
 
-          {isOfficial ? (
-            <span
-              title="Official plugins are maintained by the Nx Team"
-              className="border bg-green-50 border-green-300 text-green-600 dark:border-green-900 dark:bg-green-900/30 dark:text-green-400 absolute bottom-3 right-4 rounded-full px-3 py-0.5 text-xs font-medium capitalize"
-            >
-              Official
-            </span>
-          ) : (
-            <div className="absolute bottom-3 right-0 left-0 flex justify-between px-3 py-0.5 text-xs font-medium capitalize">
-              <div className="mx-1">
-                {lastPublishedWidget(lastPublishedDate)}
-              </div>
-              <div className="mx-1">{npmDownloadsWidget(npmDownloads)}</div>
-              <div className="mx-1">{githubStarsWidget(githubStars)}</div>
-              <div className="mx-1">{nxVersionWidget(nxVersion)}</div>
+          <div className="flex flex-wrap justify-between items-center py-0.5 text-xs font-medium capitalize">
+            <div className="mr-1 my-1">
+              <LastPublishedWidget
+                lastPublishedDate={lastPublishedDate}
+              ></LastPublishedWidget>
             </div>
-          )}
+            <div className="mx-1 my-1">
+              <NpmDownloadsWidget
+                npmDownloads={npmDownloads}
+              ></NpmDownloadsWidget>
+            </div>
+            <div className="mx-1 my-1">
+              <GithubStarsWidget githubStars={githubStars}></GithubStarsWidget>
+            </div>
+            {isOfficial ? (
+              <div
+                title="Official plugins are maintained by the Nx Team"
+                className="ml-1 my-1 border bg-green-50 border-green-300 text-green-600 dark:border-green-900 dark:bg-green-900/30 dark:text-green-400 rounded-full px-3 py-0.5 text-xs font-medium capitalize"
+              >
+                Official
+              </div>
+            ) : (
+              <div className="ml-1 my-1">
+                <NxVersionWidget nxVersion={nxVersion}></NxVersionWidget>
+              </div>
+            )}
+          </div>
         </a>
       </div>
     </div>
   );
 }
 
-function lastPublishedWidget(lastPublishedDate: string | undefined) {
+export function LastPublishedWidget({
+  lastPublishedDate,
+}: {
+  lastPublishedDate: string | undefined;
+}) {
   if (!lastPublishedDate) {
-    return <div className="w-16"></div>;
+    return <div className="w-20"></div>;
   }
   return (
     <abbr title="Most Recent Release Date">
       <ClockIcon className="h-4 w-4 inline-block mx-0.5 align-bottom"></ClockIcon>
       {/* yyyy-MM-dd */}
       <span>{new Date(lastPublishedDate).toISOString().slice(0, 10)}</span>
+      <span className="md:hidden">
+        <br />
+        <small>Most Recent Release Date</small>
+      </span>
     </abbr>
   );
 }
 
-function npmDownloadsWidget(npmDownloads: string | undefined) {
+function NpmDownloadsWidget({
+  npmDownloads,
+}: {
+  npmDownloads: string | undefined;
+}) {
   if (!npmDownloads) {
-    return <></>;
+    return <div className="w-8"></div>;
   }
   return (
-    <abbr title="Total NPM Downloads">
+    <abbr title="Monthly NPM Downloads">
       <ArrowDownIcon className="h-4 w-4 inline-block mx-0.5 align-bottom"></ArrowDownIcon>
       {shortenNumber(npmDownloads)}
+      <span className="md:hidden">
+        <br />
+        <small>Monthly NPM Downloads</small>
+      </span>
     </abbr>
   );
 }
 
-function githubStarsWidget(githubStars: string | undefined) {
+function GithubStarsWidget({
+  githubStars,
+}: {
+  githubStars: string | undefined;
+}) {
   if (!githubStars || githubStars == '-1') {
-    return <div className="w-6"></div>;
+    return <div className="w-8"></div>;
   }
   return (
     <abbr title="GitHub Stars">
       <StarIcon className="h-4 w-4 inline-block mx-0.5 align-bottom"></StarIcon>
       {shortenNumber(githubStars)}
+      <span className="md:hidden">
+        <br />
+        <small>GitHub Stars</small>
+      </span>
     </abbr>
   );
 }
@@ -122,12 +156,12 @@ function shortenNumber(number: string | number): string {
   return num + '';
 }
 
-function nxVersionWidget(nxVersion: string | undefined) {
+function NxVersionWidget({ nxVersion }: { nxVersion: string | undefined }) {
   if (!nxVersion) {
-    return <div className="w-12"></div>;
+    return <div className="w-20"></div>;
   }
   return (
-    <abbr title="Highest Supported Nx Version">
+    <abbr title="Supported Nx Versions">
       {/* Nx Logo */}
       <svg
         role="img"
@@ -140,6 +174,10 @@ function nxVersionWidget(nxVersion: string | undefined) {
         <path d="M11.987 14.138l-3.132 4.923-5.193-8.427-.012 8.822H0V4.544h3.691l5.247 8.833.005-3.998 3.044 4.759zm.601-5.761c.024-.048 0-3.784.008-3.833h-3.65c.002.059-.005 3.776-.003 3.833h3.645zm5.634 4.134a2.061 2.061 0 0 0-1.969 1.336 1.963 1.963 0 0 1 2.343-.739c.396.161.917.422 1.33.283a2.1 2.1 0 0 0-1.704-.88zm3.39 1.061c-.375-.13-.8-.277-1.109-.681-.06-.08-.116-.17-.176-.265a2.143 2.143 0 0 0-.533-.642c-.294-.216-.68-.322-1.18-.322a2.482 2.482 0 0 0-2.294 1.536 2.325 2.325 0 0 1 4.002.388.75.75 0 0 0 .836.334c.493-.105.46.36 1.203.518v-.133c-.003-.446-.246-.55-.75-.733zm2.024 1.266a.723.723 0 0 0 .347-.638c-.01-2.957-2.41-5.487-5.37-5.487a5.364 5.364 0 0 0-4.487 2.418c-.01-.026-1.522-2.39-1.538-2.418H8.943l3.463 5.423-3.379 5.32h3.54l1.54-2.366 1.568 2.366h3.541l-3.21-5.052a.7.7 0 0 1-.084-.32 2.69 2.69 0 0 1 2.69-2.691h.001c1.488 0 1.736.89 2.057 1.308.634.826 1.9.464 1.9 1.541a.707.707 0 0 0 1.066.596zm.35.133c-.173.372-.56.338-.755.639-.176.271.114.412.114.412s.337.156.538-.311c.104-.231.14-.488.103-.74z" />
       </svg>
       {nxVersion}
+      <span className="md:hidden">
+        <br />
+        <small>Supported Nx Versions</small>
+      </span>
     </abbr>
   );
 }

--- a/nx-dev/ui-common/src/lib/plugin-card.tsx
+++ b/nx-dev/ui-common/src/lib/plugin-card.tsx
@@ -26,7 +26,7 @@ export function PluginCard({
   nxVersion,
 }: PluginCardProps): JSX.Element {
   return (
-    <div className="focus-within:ring-focus-within:ring-blue-500 relative flex w-full overflow-hidden rounded-lg border border border-slate-200 bg-white shadow-sm transition hover:bg-slate-50 dark:border-slate-900 dark:bg-slate-800/60 dark:focus-within:ring-sky-500 dark:hover:bg-slate-800">
+    <div className="focus-within:ring-focus-within:ring-blue-500 relative flex w-full rounded-lg border border border-slate-200 bg-white shadow-sm transition hover:bg-slate-50 dark:border-slate-900 dark:bg-slate-800/60 dark:focus-within:ring-sky-500 dark:hover:bg-slate-800">
       <div className="flex w-full flex-col px-4 py-3">
         <h3 className="mb-4 flex items-center font-semibold leading-tight">
           <svg
@@ -45,7 +45,6 @@ export function PluginCard({
           href={url}
           target="_blank"
           rel="noreferrer"
-          title={name}
           className="focus:outline-none flex flex-col grow"
         >
           <span className="absolute inset-0" aria-hidden="true" />
@@ -67,10 +66,10 @@ export function PluginCard({
             </div>
             {isOfficial ? (
               <div
-                title="Official plugins are maintained by the Nx Team"
+                data-tooltip="Maintained by the Nx Team"
                 className="ml-1 my-1 border bg-green-50 border-green-300 text-green-600 dark:border-green-900 dark:bg-green-900/30 dark:text-green-400 rounded-full px-3 py-0.5 text-xs font-medium capitalize"
               >
-                Official
+                Nx Team
               </div>
             ) : (
               <div className="ml-1 my-1">
@@ -93,7 +92,7 @@ export function LastPublishedWidget({
     return <div className="w-20"></div>;
   }
   return (
-    <abbr title="Most Recent Release Date">
+    <abbr data-tooltip="Most Recent Release Date">
       <ClockIcon className="h-4 w-4 inline-block mx-0.5 align-bottom"></ClockIcon>
       {/* yyyy-MM-dd */}
       <span>{new Date(lastPublishedDate).toISOString().slice(0, 10)}</span>
@@ -114,7 +113,7 @@ function NpmDownloadsWidget({
     return <div className="w-8"></div>;
   }
   return (
-    <abbr title="Monthly NPM Downloads">
+    <abbr data-tooltip="Monthly NPM Downloads">
       <ArrowDownIcon className="h-4 w-4 inline-block mx-0.5 align-bottom"></ArrowDownIcon>
       {shortenNumber(npmDownloads)}
       <span className="md:hidden">
@@ -134,7 +133,7 @@ function GithubStarsWidget({
     return <div className="w-8"></div>;
   }
   return (
-    <abbr title="GitHub Stars">
+    <abbr data-tooltip="GitHub Stars">
       <StarIcon className="h-4 w-4 inline-block mx-0.5 align-bottom"></StarIcon>
       {shortenNumber(githubStars)}
       <span className="md:hidden">
@@ -161,7 +160,7 @@ function NxVersionWidget({ nxVersion }: { nxVersion: string | undefined }) {
     return <div className="w-20"></div>;
   }
   return (
-    <abbr title="Supported Nx Versions">
+    <abbr data-tooltip="Supported Nx Versions">
       {/* Nx Logo */}
       <svg
         role="img"

--- a/nx-dev/ui-common/src/lib/plugin-card.tsx
+++ b/nx-dev/ui-common/src/lib/plugin-card.tsx
@@ -64,18 +64,20 @@ export function PluginCard({
             <div className="mx-1 my-1">
               <GithubStarsWidget githubStars={githubStars}></GithubStarsWidget>
             </div>
-            {isOfficial ? (
-              <div
-                data-tooltip="Maintained by the Nx Team"
-                className="ml-1 my-1 border bg-green-50 border-green-300 text-green-600 dark:border-green-900 dark:bg-green-900/30 dark:text-green-400 rounded-full px-3 py-0.5 text-xs font-medium capitalize"
-              >
-                Nx Team
-              </div>
-            ) : (
-              <div className="ml-1 my-1">
-                <NxVersionWidget nxVersion={nxVersion}></NxVersionWidget>
-              </div>
-            )}
+            <div className="flex-grow flex justify-end">
+              {isOfficial ? (
+                <div
+                  data-tooltip="Maintained by the Nx Team"
+                  className="ml-1 my-1 border inline-block bg-green-50 border-green-300 text-green-600 dark:border-green-900 dark:bg-green-900/30 dark:text-green-400 rounded-full px-3 py-0.5 text-xs font-medium capitalize"
+                >
+                  Nx Team
+                </div>
+              ) : (
+                <div className="ml-1 my-1">
+                  <NxVersionWidget nxVersion={nxVersion}></NxVersionWidget>
+                </div>
+              )}
+            </div>
           </div>
         </a>
       </div>

--- a/nx-dev/ui-community/src/lib/plugin-directory.tsx
+++ b/nx-dev/ui-community/src/lib/plugin-directory.tsx
@@ -7,6 +7,18 @@ interface Plugin {
   name: string;
   url: string;
   isOfficial: boolean;
+  lastPublishedDate?: string;
+  npmDownloads?: string;
+  githubStars?: string;
+  nxVersion?: string;
+}
+
+interface Filters {
+  term: string;
+  officialStatus: 'official' | 'community' | undefined;
+  minimumDownloads: number | undefined;
+  minimumStars: number | undefined;
+  minimumNxVersion: string | undefined;
 }
 
 export function PluginDirectory({
@@ -14,7 +26,13 @@ export function PluginDirectory({
 }: {
   pluginList: Plugin[];
 }): JSX.Element {
-  const [searchTerm, setSearchTerm] = useState('');
+  const [filters, setFilters] = useState<Filters>({
+    term: '',
+    officialStatus: undefined,
+    minimumDownloads: undefined,
+    minimumStars: undefined,
+    minimumNxVersion: undefined,
+  });
   return (
     <div id="plugin-directory">
       <div className="flex w-full flex-col justify-between gap-8 md:flex-row ">
@@ -34,7 +52,9 @@ export function PluginDirectory({
               name="search"
               className="block w-full rounded-md border border-slate-300 bg-white py-2 pl-10 pr-3 text-sm placeholder-slate-500 transition focus:placeholder-slate-400 dark:border-slate-900 dark:bg-slate-700"
               placeholder="Quick search"
-              onChange={(event) => setSearchTerm(event.target.value)}
+              onChange={(event) =>
+                setFilters({ ...filters, term: event.target.value })
+              }
               type="search"
             />
           </div>
@@ -43,11 +63,13 @@ export function PluginDirectory({
       <div className="my-12 grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
         {pluginList
           .filter((plugin) =>
-            !!searchTerm
-              ? plugin.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+            !!filters.term
+              ? plugin.name
+                  .toLowerCase()
+                  .includes(filters.term.toLowerCase()) ||
                 plugin.description
                   .toLowerCase()
-                  .includes(searchTerm.toLowerCase())
+                  .includes(filters.term.toLowerCase())
               : true
           )
           .map((plugin) => (
@@ -56,6 +78,10 @@ export function PluginDirectory({
               name={plugin.name}
               description={plugin.description}
               isOfficial={plugin.isOfficial}
+              lastPublishedDate={plugin.lastPublishedDate}
+              npmDownloads={plugin.npmDownloads}
+              githubStars={plugin.githubStars}
+              nxVersion={plugin.nxVersion}
               url={plugin.url}
             />
           ))}

--- a/nx-dev/ui-community/src/lib/plugin-directory.tsx
+++ b/nx-dev/ui-community/src/lib/plugin-directory.tsx
@@ -1,3 +1,10 @@
+import {
+  ArrowDownIcon,
+  ArrowLongDownIcon,
+  ArrowLongUpIcon,
+  ClockIcon,
+  StarIcon,
+} from '@heroicons/react/24/outline';
 import { MagnifyingGlassIcon } from '@heroicons/react/24/solid';
 import { PluginCard, SectionHeading } from '@nx/nx-dev/ui-common';
 import { useState } from 'react';
@@ -13,12 +20,20 @@ interface Plugin {
   nxVersion?: string;
 }
 
-interface Filters {
+type OrderByStatus =
+  | 'lastPublishDate'
+  | 'npmDownloads'
+  | 'githubStars'
+  | 'nxVersion'
+  | undefined;
+interface Modifiers {
   term: string;
   officialStatus: 'official' | 'community' | undefined;
   minimumDownloads: number | undefined;
   minimumStars: number | undefined;
   minimumNxVersion: string | undefined;
+  orderBy: OrderByStatus;
+  orderDirection: 'ASC' | 'DESC';
 }
 
 export function PluginDirectory({
@@ -26,18 +41,33 @@ export function PluginDirectory({
 }: {
   pluginList: Plugin[];
 }): JSX.Element {
-  const [filters, setFilters] = useState<Filters>({
+  const [modifiers, setModifiers] = useState<Modifiers>({
     term: '',
     officialStatus: undefined,
     minimumDownloads: undefined,
     minimumStars: undefined,
     minimumNxVersion: undefined,
+    orderBy: undefined,
+    orderDirection: 'ASC',
   });
+  function setOrderBy(status: OrderByStatus) {
+    if (modifiers.orderBy === status) {
+      setModifiers({
+        ...modifiers,
+        orderDirection: modifiers.orderDirection === 'ASC' ? 'DESC' : 'ASC',
+      });
+    } else {
+      setModifiers({
+        ...modifiers,
+        orderBy: status,
+      });
+    }
+  }
   return (
     <div id="plugin-directory">
       <div className="flex w-full flex-col justify-between gap-8 md:flex-row ">
         <SectionHeading as="h2" variant="display" id="plugins-registry">
-          Nx Plugins Registry
+          <span className="whitespace-nowrap">Nx Plugins</span> Registry
         </SectionHeading>
         <div>
           <label htmlFor="search" className="sr-only">
@@ -53,25 +83,149 @@ export function PluginDirectory({
               className="block w-full rounded-md border border-slate-300 bg-white py-2 pl-10 pr-3 text-sm placeholder-slate-500 transition focus:placeholder-slate-400 dark:border-slate-900 dark:bg-slate-700"
               placeholder="Quick search"
               onChange={(event) =>
-                setFilters({ ...filters, term: event.target.value })
+                setModifiers({ ...modifiers, term: event.target.value })
               }
               type="search"
             />
+          </div>
+          <div className="text-xs my-2 flex whitespace-nowrap">
+            <div className="py-1 mr-1">Order by:</div>
+            <div className="flex flex-wrap gap-1">
+              <button
+                className="rounded-sm border border-slate-200 bg-white py-1 px-1 font-semibold transition hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-800 dark:hover:bg-slate-700"
+                onClick={() => setOrderBy('lastPublishDate')}
+              >
+                <ClockIcon className="h-4 w-4 inline-block mr-0.5 align-bottom"></ClockIcon>
+                Release Date
+                {modifiers.orderBy === 'lastPublishDate' &&
+                modifiers.orderDirection === 'DESC' ? (
+                  <ArrowLongUpIcon className="h-4 w-4 inline-block ml-0.5 align-bottom"></ArrowLongUpIcon>
+                ) : null}
+                {modifiers.orderBy === 'lastPublishDate' &&
+                modifiers.orderDirection === 'ASC' ? (
+                  <ArrowLongDownIcon className="h-4 w-4 inline-block ml-0.5 align-bottom"></ArrowLongDownIcon>
+                ) : null}
+              </button>
+              <button
+                className="rounded-sm border border-slate-200 bg-white py-1 px-1 font-semibold transition hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-800 dark:hover:bg-slate-700"
+                onClick={() => setOrderBy('npmDownloads')}
+              >
+                <ArrowDownIcon className="h-4 w-4 inline-block mr-0.5 align-bottom"></ArrowDownIcon>
+                Downloads
+                {modifiers.orderBy === 'npmDownloads' &&
+                modifiers.orderDirection === 'DESC' ? (
+                  <ArrowLongUpIcon className="h-4 w-4 inline-block ml-0.5 align-bottom"></ArrowLongUpIcon>
+                ) : null}
+                {modifiers.orderBy === 'npmDownloads' &&
+                modifiers.orderDirection === 'ASC' ? (
+                  <ArrowLongDownIcon className="h-4 w-4 inline-block ml-0.5 align-bottom"></ArrowLongDownIcon>
+                ) : null}
+              </button>
+              <button
+                className="rounded-sm border border-slate-200 bg-white py-1 px-1 font-semibold transition hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-800 dark:hover:bg-slate-700"
+                onClick={() => setOrderBy('githubStars')}
+              >
+                <StarIcon className="h-4 w-4 inline-block mr-0.5 align-bottom"></StarIcon>
+                GH Stars
+                {modifiers.orderBy === 'githubStars' &&
+                modifiers.orderDirection === 'DESC' ? (
+                  <ArrowLongUpIcon className="h-4 w-4 inline-block ml-0.5 align-bottom"></ArrowLongUpIcon>
+                ) : null}
+                {modifiers.orderBy === 'githubStars' &&
+                modifiers.orderDirection === 'ASC' ? (
+                  <ArrowLongDownIcon className="h-4 w-4 inline-block ml-0.5 align-bottom"></ArrowLongDownIcon>
+                ) : null}
+              </button>
+              <button
+                className="rounded-sm border border-slate-200 bg-white py-1 px-1 font-semibold transition hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-800 dark:hover:bg-slate-700"
+                onClick={() => setOrderBy('nxVersion')}
+              >
+                {/* Nx Logo */}
+                <svg
+                  role="img"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-4 w-4 inline-block mx-0.5 align-bottom"
+                  fill="currentColor"
+                >
+                  <title>Nx</title>
+                  <path d="M11.987 14.138l-3.132 4.923-5.193-8.427-.012 8.822H0V4.544h3.691l5.247 8.833.005-3.998 3.044 4.759zm.601-5.761c.024-.048 0-3.784.008-3.833h-3.65c.002.059-.005 3.776-.003 3.833h3.645zm5.634 4.134a2.061 2.061 0 0 0-1.969 1.336 1.963 1.963 0 0 1 2.343-.739c.396.161.917.422 1.33.283a2.1 2.1 0 0 0-1.704-.88zm3.39 1.061c-.375-.13-.8-.277-1.109-.681-.06-.08-.116-.17-.176-.265a2.143 2.143 0 0 0-.533-.642c-.294-.216-.68-.322-1.18-.322a2.482 2.482 0 0 0-2.294 1.536 2.325 2.325 0 0 1 4.002.388.75.75 0 0 0 .836.334c.493-.105.46.36 1.203.518v-.133c-.003-.446-.246-.55-.75-.733zm2.024 1.266a.723.723 0 0 0 .347-.638c-.01-2.957-2.41-5.487-5.37-5.487a5.364 5.364 0 0 0-4.487 2.418c-.01-.026-1.522-2.39-1.538-2.418H8.943l3.463 5.423-3.379 5.32h3.54l1.54-2.366 1.568 2.366h3.541l-3.21-5.052a.7.7 0 0 1-.084-.32 2.69 2.69 0 0 1 2.69-2.691h.001c1.488 0 1.736.89 2.057 1.308.634.826 1.9.464 1.9 1.541a.707.707 0 0 0 1.066.596zm.35.133c-.173.372-.56.338-.755.639-.176.271.114.412.114.412s.337.156.538-.311c.104-.231.14-.488.103-.74z" />
+                </svg>
+                Nx Version
+                {modifiers.orderBy === 'nxVersion' &&
+                modifiers.orderDirection === 'DESC' ? (
+                  <ArrowLongUpIcon className="h-4 w-4 inline-block ml-0.5 align-bottom"></ArrowLongUpIcon>
+                ) : null}
+                {modifiers.orderBy === 'nxVersion' &&
+                modifiers.orderDirection === 'ASC' ? (
+                  <ArrowLongDownIcon className="h-4 w-4 inline-block ml-0.5 align-bottom"></ArrowLongDownIcon>
+                ) : null}
+              </button>
+            </div>
           </div>
         </div>
       </div>
       <div className="my-12 grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
         {pluginList
           .filter((plugin) =>
-            !!filters.term
+            !!modifiers.term
               ? plugin.name
                   .toLowerCase()
-                  .includes(filters.term.toLowerCase()) ||
+                  .includes(modifiers.term.toLowerCase()) ||
                 plugin.description
                   .toLowerCase()
-                  .includes(filters.term.toLowerCase())
+                  .includes(modifiers.term.toLowerCase())
               : true
           )
+          .sort((a, b) => {
+            if (modifiers.orderBy === 'lastPublishDate') {
+              return (
+                (modifiers.orderDirection === 'ASC' ? 1 : -1) *
+                (new Date(a.lastPublishedDate || '').getTime() -
+                  new Date(b.lastPublishedDate || '').getTime())
+              );
+            } else if (modifiers.orderBy === 'npmDownloads') {
+              return (
+                (modifiers.orderDirection === 'ASC' ? 1 : -1) *
+                (Number.parseInt(a.npmDownloads || '0') -
+                  Number.parseInt(b.npmDownloads || '0'))
+              );
+            } else if (modifiers.orderBy === 'githubStars') {
+              return (
+                (modifiers.orderDirection === 'ASC' ? 1 : -1) *
+                (Number.parseInt(a.githubStars || '0') -
+                  Number.parseInt(b.githubStars || '0'))
+              );
+            } else if (modifiers.orderBy === 'nxVersion') {
+              const versionValueMap: Record<string, number> = {
+                unknown: 0,
+                '12': 12,
+                '13': 13,
+                '14': 14,
+                '15': 15,
+                '16': 16,
+                '17': 17,
+                '18': 18,
+                '>= 15': 17,
+                '>= 14': 16,
+                '>= 13': 15,
+                official: 1000,
+              };
+              function getValueFromVersion(version: string = 'unknown') {
+                const mapKey =
+                  Object.keys(versionValueMap).find((key) =>
+                    version.startsWith(key)
+                  ) || 'unknown';
+                return versionValueMap[mapKey];
+              }
+              return (
+                (modifiers.orderDirection === 'ASC' ? 1 : -1) *
+                (getValueFromVersion(a.nxVersion) -
+                  getValueFromVersion(b.nxVersion))
+              );
+            }
+            return 0;
+          })
           .map((plugin) => (
             <PluginCard
               key={plugin.name}

--- a/scripts/documentation/plugin-quality-indicators.ts
+++ b/scripts/documentation/plugin-quality-indicators.ts
@@ -1,0 +1,156 @@
+import { Interval, lightFormat } from 'date-fns';
+import { writeFileSync } from 'fs';
+import axios from 'axios';
+
+interface PluginRegistry {
+  name: string;
+  description: string;
+  url: string;
+}
+
+const plugins =
+  require('../../community/approved-plugins.json') as PluginRegistry[];
+
+async function main() {
+  const qualityIndicators: any = {};
+  for (let i = 0; i < plugins.length; i++) {
+    const plugin = plugins[i];
+    const npmData = await getNpmData(plugin);
+    const npmDownloads = await getNpmDownloads(plugin);
+    const githubStars = await getGithubStars(npmData.githubRepo);
+    const nxVersion = await getNxVersion(
+      npmData.githubRepo,
+      npmData.githubDirectory
+    );
+    qualityIndicators[plugin.name] = {
+      lastPublishedDate: npmData.lastPublishedDate,
+      githubDirectory: npmData.githubDirectory,
+      npmDownloads,
+      githubStars,
+      nxVersion,
+    };
+    console.log(qualityIndicators[plugin.name]);
+  }
+
+  writeFileSync(
+    '../../nx-dev/nx-dev/pages/extending-nx/quality-indicators.json',
+    JSON.stringify(qualityIndicators, null, 2)
+  );
+}
+main();
+
+// Publish date (and github directory, readme content)
+// i.e. https://registry.npmjs.org/@nxkit/playwright
+async function getNpmData(plugin: PluginRegistry) {
+  const { data } = await axios.get(`https://registry.npmjs.org/${plugin.name}`);
+  console.log(plugin.name);
+  const lastPublishedDate = data.time[data['dist-tags'].latest];
+  if (!data.repository) {
+    console.log('!!! No repository!');
+    return { lastPublishedDate, githubRepo: '' };
+  }
+  const url: String = data.repository.url;
+  const githubRepo = url
+    .slice(url.indexOf('github.com/') + 11)
+    .replace('.git', '');
+  return {
+    lastPublishedDate,
+    githubDirectory: data.repository.directory,
+    githubRepo,
+    // readmeContent: plugin.name
+  };
+}
+
+// Download count
+// i.e. https://api.npmjs.org/downloads/point/2023-06-01:2023-07-01/@nxkit/playwright
+async function getNpmDownloads(plugin: PluginRegistry) {
+  const lastMonth = getLastMonth();
+  const { data } = await axios.get(
+    `https://api.npmjs.org/downloads/point/${stringifyIntervalForUrl(
+      lastMonth
+    )}/${plugin.name}`
+  );
+  return data.downloads;
+}
+
+export function getLastMonth() {
+  const now = new Date();
+  const thisYear = now.getFullYear();
+  const thisMonth = now.getMonth();
+  return {
+    start: new Date(`${thisYear}-${thisMonth - 1}-01`),
+    end: new Date(`${thisYear}-${thisMonth}-01`),
+  };
+}
+
+export function stringifyIntervalForUrl(interval: Interval): string {
+  return `${stringifyDate(interval.start)}:${stringifyDate(interval.end)}`;
+}
+
+export function stringifyDate(date: number | Date) {
+  const dateFormat = 'yyyy-MM-dd';
+  return lightFormat(date, dateFormat);
+}
+
+// Stars
+// i.e. https://api.github.com/repos/nxkit/nxkit
+async function getGithubStars(repo: String) {
+  try {
+    const { data } = await axios.get(`https://api.github.com/repos/${repo}`, {
+      headers: {
+        Authorization: `Bearer ${process.env.GITHUB_PAT}`,
+      },
+    });
+    return data.stargazers_count;
+  } catch (ex) {
+    return -1;
+  }
+}
+
+// Nx Version
+// i.e. https://raw.githubusercontent.com/nxkit/nxkit/HEAD/packages/playwright/package.json
+// i.e. https://raw.githubusercontent.com/nxkit/nxkit/HEAD/package.json
+async function getNxVersion(githubRepo: String, githubDirectory?: String) {
+  if (!githubRepo) {
+    return '';
+  }
+  if (githubDirectory) {
+    try {
+      const { data } = await axios.get(
+        `https://raw.githubusercontent.com/${githubRepo}/HEAD/${githubDirectory}/package.json`
+      );
+      const nxVersion = findNxVersion(data);
+      if (nxVersion) {
+        return nxVersion;
+      }
+    } catch (ex) {}
+  }
+  try {
+    const { data } = await axios.get(
+      `https://raw.githubusercontent.com/${githubRepo}/HEAD/package.json`
+    );
+    return findNxVersion(data);
+  } catch (ex) {
+    return '';
+  }
+}
+
+function findNxVersion(packageJsonContent: any): string {
+  let nxVersion = '';
+  const nxPackages = ['@nrwl/devkit', 'nx', '@nx/devkit'];
+  nxPackages.forEach((packageName) => {
+    if (
+      packageJsonContent.dependencies &&
+      packageJsonContent.dependencies[packageName]
+    ) {
+      nxVersion = packageJsonContent.dependencies[packageName];
+    }
+    if (
+      packageJsonContent.devDependencies &&
+      packageJsonContent.devDependencies[packageName]
+    ) {
+      nxVersion = packageJsonContent.devDependencies[packageName];
+    }
+  });
+  return nxVersion;
+}

--- a/scripts/documentation/plugin-quality-indicators.ts
+++ b/scripts/documentation/plugin-quality-indicators.ts
@@ -1,6 +1,10 @@
-import { Interval, lightFormat } from 'date-fns';
 import { writeFileSync } from 'fs';
 import axios from 'axios';
+
+interface Interval {
+  start: Date;
+  end: Date;
+}
 
 interface PluginRegistry {
   name: string;
@@ -87,9 +91,9 @@ export function stringifyIntervalForUrl(interval: Interval): string {
   return `${stringifyDate(interval.start)}:${stringifyDate(interval.end)}`;
 }
 
-export function stringifyDate(date: number | Date) {
-  const dateFormat = 'yyyy-MM-dd';
-  return lightFormat(date, dateFormat);
+export function stringifyDate(date: Date) {
+  // yyyy-MM-dd
+  return date.toISOString().slice(0, 10);
 }
 
 // Stars


### PR DESCRIPTION
Adds quality indicators to the plugin registry.
https://nx-dev-git-docs-plugin-registry-nrwl.vercel.app/extending-nx/registry

![Screenshot 2023-08-02 at 2 38 07 PM](https://github.com/nrwl/nx/assets/861504/d2e02047-390d-4054-84c2-b0780f54e308)

Now the PR also includes sorting buttons.  It seemed like filters weren't necessary once the sorting was available.

This PR is functional as is, but more work is planned in future PRs:
- Update the quality indicators in CI
- Display README content for plugins in their own dedicated page