### PR TITLE
fix(misc): respect cwd when adding node_modules/.bin to PATH in run-commands

### DIFF
--- a/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
@@ -345,6 +345,32 @@ describe('Run Commands', () => {
       expect(result).toEqual(expect.objectContaining({ success: true }));
       expect(normalize(readFile(f))).toBe(childFolder);
     });
+
+    it('should add node_modules/.bins to the env for the cwd', async () => {
+      const root = dirSync().name;
+      const childFolder = dirSync({ dir: root }).name;
+      const f = fileSync().name;
+
+      const result = await runCommands(
+        {
+          commands: [
+            {
+              command: `echo $PATH >> ${f}`,
+            },
+          ],
+          cwd: childFolder,
+          parallel: true,
+          __unparsed__: [],
+        },
+        { root } as any
+      );
+
+      expect(result).toEqual(expect.objectContaining({ success: true }));
+      expect(normalize(readFile(f))).toContain(
+        `${childFolder}/node_modules/.bin`
+      );
+      expect(normalize(readFile(f))).toContain(`${root}/node_modules/.bin`);
+    });
   });
 
   describe('dotenv', () => {

--- a/packages/nx/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.ts
@@ -205,7 +205,7 @@ function createProcess(
   return new Promise((res) => {
     const childProcess = exec(commandConfig.command, {
       maxBuffer: LARGE_BUFFER,
-      env: processEnv(color),
+      env: processEnv(color, cwd),
       cwd,
     });
     /**
@@ -277,10 +277,10 @@ function calculateCwd(
   return path.join(context.root, cwd);
 }
 
-function processEnv(color: boolean) {
+function processEnv(color: boolean, cwd: string) {
   const env = {
     ...process.env,
-    ...appendLocalEnv(),
+    ...appendLocalEnv({ cwd: cwd ?? process.cwd() }),
   };
 
   if (color) {


### PR DESCRIPTION
Provide the cwd to the npm-run-path library so that the PATH additions include the cwd

closed #18428

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
