### PR TITLE
fix(angular): update `getComponentsInfo` to filter null values

### DIFF
--- a/packages/angular/src/generators/stories/__snapshots__/stories-app.spec.ts.snap
+++ b/packages/angular/src/generators/stories/__snapshots__/stories-app.spec.ts.snap
@@ -83,3 +83,31 @@ export const Heading: Story = {
 };
 "
 `;
+
+exports[`angularStories generator: applications should ignore a path when using a routing module 1`] = `
+"import type { Meta, StoryObj } from '@storybook/angular';
+import { ComponentComponent } from './component.component';
+
+import { within } from '@storybook/testing-library';
+import { expect } from '@storybook/jest';
+
+const meta: Meta<ComponentComponent> = {
+  component: ComponentComponent,
+  title: 'ComponentComponent',
+};
+export default meta;
+type Story = StoryObj<ComponentComponent>;
+
+export const Primary: Story = {
+  args: {},
+};
+
+export const Heading: Story = {
+  args: {},
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByText(/component works!/gi)).toBeTruthy();
+  },
+};
+"
+`;

--- a/packages/angular/src/generators/stories/stories-app.spec.ts
+++ b/packages/angular/src/generators/stories/stories-app.spec.ts
@@ -5,6 +5,8 @@ import { componentGenerator } from '../component/component';
 import { scamGenerator } from '../scam/scam';
 import { generateTestApplication } from '../utils/testing';
 import { angularStoriesGenerator } from './stories';
+import { readProjectConfiguration, stripIndents } from '@nx/devkit';
+import { indentBy } from '@angular-devkit/core/src/utils/literals';
 
 // need to mock cypress otherwise it'll use the nx installed version from package.json
 //  which is v9 while we are testing for the new v10 version
@@ -101,6 +103,53 @@ describe('angularStories generator: applications', () => {
       tree.exists(
         `apps/${appName}/src/app/component-a/component-a.component.stories.ts`
       )
+    ).toBeFalsy();
+  });
+
+  it('should ignore a path when using a routing module', async () => {
+    tree.write(
+      `apps/${appName}/src/app/component/component.module.ts`,
+      stripIndents`
+      import { NgModule } from '@angular/core';
+      
+      @NgModule({})
+      export class ComponentModule {}
+      `
+    );
+    tree.write(
+      `apps/${appName}/src/app/component/component-routing.module.ts`,
+      stripIndents`
+      import { NgModule } from '@angular/core';
+      import { RouterModule, Routes } from '@angular/router';
+      
+      const routes: Routes = [];
+      
+      @NgModule({
+        imports: [RouterModule.forChild(routes)],
+        exports: [RouterModule],
+      })
+      export class ComponentRoutingModule {}
+      `
+    );
+    await componentGenerator(tree, {
+      name: 'component/component',
+      project: appName,
+      flat: true,
+    });
+
+    await angularStoriesGenerator(tree, {
+      name: appName,
+      ignorePaths: [`apps/${appName}/src/app/app.component.ts`],
+    });
+
+    expect(
+      tree.read(
+        `apps/${appName}/src/app/component/component.component.stories.ts`,
+        'utf-8'
+      )
+    ).toMatchSnapshot();
+    expect(
+      tree.exists(`apps/${appName}/src/app/app.component.stories.ts`)
     ).toBeFalsy();
   });
 

--- a/packages/angular/src/generators/stories/stories-app.spec.ts
+++ b/packages/angular/src/generators/stories/stories-app.spec.ts
@@ -5,8 +5,7 @@ import { componentGenerator } from '../component/component';
 import { scamGenerator } from '../scam/scam';
 import { generateTestApplication } from '../utils/testing';
 import { angularStoriesGenerator } from './stories';
-import { readProjectConfiguration, stripIndents } from '@nx/devkit';
-import { indentBy } from '@angular-devkit/core/src/utils/literals';
+import { stripIndents } from '@nx/devkit';
 
 // need to mock cypress otherwise it'll use the nx installed version from package.json
 //  which is v9 while we are testing for the new v10 version

--- a/packages/angular/src/generators/utils/storybook-ast/component-info.ts
+++ b/packages/angular/src/generators/utils/storybook-ast/component-info.ts
@@ -30,37 +30,39 @@ export function getComponentsInfo(
   moduleFilePaths: string[],
   projectName: string
 ): ComponentInfo[] {
-  return moduleFilePaths.flatMap((moduleFilePath) => {
-    const file = getTsSourceFile(tree, moduleFilePath);
-    const declaredComponents = getModuleDeclaredComponents(
-      file,
-      moduleFilePath,
-      projectName
-    );
-    if (declaredComponents.length === 0) {
-      return undefined;
-    }
-
-    if (!tsModule) {
-      tsModule = ensureTypescript();
-    }
-    const imports = file.statements.filter(
-      (statement) => statement.kind === tsModule.SyntaxKind.ImportDeclaration
-    );
-
-    const componentsInfo = declaredComponents.map((componentName) =>
-      getComponentInfo(
-        tree,
-        entryPoint,
+  return moduleFilePaths
+    .flatMap((moduleFilePath) => {
+      const file = getTsSourceFile(tree, moduleFilePath);
+      const declaredComponents = getModuleDeclaredComponents(
         file,
-        imports,
         moduleFilePath,
-        componentName
-      )
-    );
+        projectName
+      );
+      if (declaredComponents.length === 0) {
+        return undefined;
+      }
 
-    return componentsInfo;
-  });
+      if (!tsModule) {
+        tsModule = ensureTypescript();
+      }
+      const imports = file.statements.filter(
+        (statement) => statement.kind === tsModule.SyntaxKind.ImportDeclaration
+      );
+
+      const componentsInfo = declaredComponents.map((componentName) =>
+        getComponentInfo(
+          tree,
+          entryPoint,
+          file,
+          imports,
+          moduleFilePath,
+          componentName
+        )
+      );
+
+      return componentsInfo;
+    })
+    .filter((f) => f !== undefined);
 }
 
 export function getStandaloneComponentsInfo(


### PR DESCRIPTION
Fixes the `ignorePaths` option in `@nx/angular:stories` generator.

closed #18430

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Running e.g. `nx g @nx/angular:stories --name=example-app --ignorePaths='**/app.component.ts' --dry-run` throws the error ` >  NX   Cannot read properties of undefined (reading 'moduleFolderPath')`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
No error and the generator works.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18430
