### PR TITLE
fix(vite): do not set default target

### DIFF
--- a/packages/vite/src/utils/options-utils.ts
+++ b/packages/vite/src/utils/options-utils.ts
@@ -157,7 +157,7 @@ export function getViteBuildOptions(
     emptyOutDir: options.emptyOutDir,
     reportCompressedSize: true,
     cssCodeSplit: options.cssCodeSplit,
-    target: options.target ?? 'esnext',
+    target: options.target,
     commonjsOptions: {
       transformMixedEsModules: true,
     },


### PR DESCRIPTION
closed #18148

## Current Behavior

Our vite executor sets `esnext` as default target. That behaviour overrides any target set by the user in vite.config, and does not let vite use its default one.

## Expected Behavior

Our vite executor should not force a default value for target.

## Related Issue(s)
Fixes #18148
