### PR TITLE
fix(react): add babel/core when babel/preset-react is preset

### DIFF
--- a/packages/react-native/src/generators/init/init.ts
+++ b/packages/react-native/src/generators/init/init.ts
@@ -12,7 +12,10 @@ import { Schema } from './schema';
 
 import { jestInitGenerator } from '@nx/jest';
 import { detoxInitGenerator } from '@nx/detox';
-import { babelPresetReactVersion } from '@nx/react/src/utils/versions';
+import {
+  babelCoreVersion,
+  babelPresetReactVersion,
+} from '@nx/react/src/utils/versions';
 import { initGenerator as jsInitGenerator } from '@nx/js';
 
 import {
@@ -109,6 +112,7 @@ export function updateDependencies(host: Tree) {
       'react-native-svg-transformer': reactNativeSvgTransformerVersion,
       'react-native-svg': reactNativeSvgVersion,
       '@babel/preset-react': babelPresetReactVersion,
+      '@babel/core': babelCoreVersion,
       ...(isPnpm
         ? {
             '@babel/runtime': babelRuntimeVersion, // @babel/runtime is used by react-native-svg

--- a/packages/react/migrations.json
+++ b/packages/react/migrations.json
@@ -98,6 +98,12 @@
     },
     "remove-types-react-router-dom": {
       "cli": "nx",
+      "version": "16.7.0-beta.2",
+      "description": "Add @babel/core to package.json if @babel/preset-react is present",
+      "implementation": "./src/migrations/update-16-7-0/add-babel-core"
+    },
+    "add-babel-core": {
+      "cli": "nx",
       "version": "16.3.0-beta.2",
       "description": "Remove @types/react-router-dom from package.json",
       "implementation": "./src/migrations/update-16-3-0/remove-types-react-router-dom-package"

--- a/packages/react/src/generators/application/lib/install-common-dependencies.ts
+++ b/packages/react/src/generators/application/lib/install-common-dependencies.ts
@@ -1,5 +1,6 @@
 import { addDependenciesToPackageJson, Tree } from '@nx/devkit';
 import {
+  babelCoreVersion,
   babelPresetReactVersion,
   lessVersion,
   sassVersion,
@@ -37,6 +38,7 @@ export function installCommonDependencies(
       // babel-loader is currently included in @nx/webpack
       // TODO(jack): Install babel-loader and other babel packages only as needed
       devDependencies['@babel/preset-react'] = babelPresetReactVersion;
+      devDependencies['@babel/core'] = babelCoreVersion;
     }
   }
 

--- a/packages/react/src/generators/library/lib/install-common-dependencies.ts
+++ b/packages/react/src/generators/library/lib/install-common-dependencies.ts
@@ -6,6 +6,7 @@ import {
 } from '@nx/devkit';
 import { addSwcDependencies } from '@nx/js/src/utils/swc/add-swc-dependencies';
 import {
+  babelCoreVersion,
   babelPresetReactVersion,
   lessVersion,
   reactDomVersion,
@@ -56,7 +57,10 @@ export function installCommonDependencies(
       addDependenciesToPackageJson(
         host,
         {},
-        { '@babel/preset-react': babelPresetReactVersion }
+        {
+          '@babel/preset-react': babelPresetReactVersion,
+          '@babel/core': babelCoreVersion,
+        }
       )
     );
   }

--- a/packages/react/src/migrations/update-16-7-0/add-babel-core.spec.ts
+++ b/packages/react/src/migrations/update-16-7-0/add-babel-core.spec.ts
@@ -1,0 +1,32 @@
+import { Tree, readJson, updateJson } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import addBabelCore from './add-babel-core';
+
+describe('update-16-7-0-add-babel-core', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should add @babel/core to package.json', async () => {
+    updateJson(tree, 'package.json', (json) => {
+      json.devDependencies['@babel/preset-react'] = '*';
+      return json;
+    });
+
+    await addBabelCore(tree);
+
+    expect(
+      readJson(tree, 'package.json').devDependencies['@babel/core']
+    ).toBeDefined();
+  });
+
+  it('should not add @babel/core to package.json if preset-react is not available', async () => {
+    await addBabelCore(tree);
+
+    expect(
+      readJson(tree, 'package.json').devDependencies['@babel/core']
+    ).not.toBeDefined();
+  });
+});

--- a/packages/react/src/migrations/update-16-7-0/add-babel-core.ts
+++ b/packages/react/src/migrations/update-16-7-0/add-babel-core.ts
@@ -1,0 +1,21 @@
+import {
+  Tree,
+  addDependenciesToPackageJson,
+  formatFiles,
+  readJson,
+} from '@nx/devkit';
+import { babelCoreVersion } from '../../utils/versions';
+
+export default async function addBabelCore(tree: Tree): Promise<void> {
+  const packageJson = readJson(tree, 'package.json');
+  if (packageJson?.devDependencies['@babel/preset-react']) {
+    addDependenciesToPackageJson(
+      tree,
+      {},
+      {
+        '@babel/core': babelCoreVersion,
+      }
+    );
+    await formatFiles(tree);
+  }
+}

--- a/packages/react/src/utils/versions.ts
+++ b/packages/react/src/utils/versions.ts
@@ -15,6 +15,7 @@ export const typesReactIsVersion = '18.2.1';
 export const typesNodeVersion = '18.14.2';
 
 export const babelPresetReactVersion = '^7.14.5';
+export const babelCoreVersion = '^7.14.5';
 
 export const styledComponentsVersion = '5.3.6';
 export const typesStyledComponentsVersion = '5.1.26';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Our app generators add `@babel/preset-react` which has dependencies with peer deps to `@babel/core`, but this fails with `PnP` because the `@babel/core` ends up being nested.

## Expected Behavior
The `@babel/core` needs to be added to package.json when using `babel`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
