### PR TITLE
chore(eslint-plugin): remove unused extend of @angular-eslint/recommended--extra config

### DIFF
--- a/packages/eslint-plugin/src/configs/angular.ts
+++ b/packages/eslint-plugin/src/configs/angular.ts
@@ -1,10 +1,3 @@
-import type AngularEslintPlugin from '@angular-eslint/eslint-plugin';
-
-let angularEslintPlugin: typeof AngularEslintPlugin;
-try {
-  angularEslintPlugin = require('@angular-eslint/eslint-plugin');
-} catch {}
-
 /**
  * This configuration is intended to be applied to ALL .ts files in Angular
  * projects within an Nx workspace.
@@ -23,16 +16,7 @@ export default {
     node: true,
   },
   plugins: ['@angular-eslint'],
-  extends: [
-    'plugin:@angular-eslint/recommended',
-    /**
-     * TODO: Consider dropping this extends and explicitly carrying over rules we care about
-     * into our typescript preset in v13
-     */
-    ...(angularEslintPlugin?.configs?.['recommended--extra']
-      ? ['plugin:@angular-eslint/recommended--extra']
-      : []),
-  ],
+  extends: ['plugin:@angular-eslint/recommended'],
   parserOptions: {
     // Unset the default value for parserOptions.project that is found in earlier versions of @angular-eslint
     project: [],


### PR DESCRIPTION
The `@angular-eslint/recommended--extra` config has been removed in [@angular-eslint@v16.0.0](https://github.com/angular-eslint/angular-eslint/releases?q=recommended--extra&expanded=true)

Fixes #5259

