### PR TITLE
fix(core): add target options for .nx nx.json

### DIFF
--- a/packages/nx/src/command-line/init/implementation/dot-nx/add-nx-scripts.ts
+++ b/packages/nx/src/command-line/init/implementation/dot-nx/add-nx-scripts.ts
@@ -56,8 +56,13 @@ export function writeMinimalNxJson(host: Tree, version: string) {
         default: {
           runner: 'nx/tasks-runners/default',
           options: {
-            cacheableOperations: [],
+            cacheableOperations: ['build', 'lint', 'test', 'e2e'],
           },
+        },
+      },
+      targetDefaults: {
+        build: {
+          dependsOn: ['^build'],
         },
       },
       installation: {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When setting up a `.nx` installation, the `nx.json` doesn't have `cacheableOperations` or `targetDefaults` set.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When setting up a `.nx` installation, the `nx.json` has the same setup as the `create-nx-workspace` flow.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
