### PR TITLE
fix(react): remove hard-coded typings inside tsconfig and add them to the app

### DIFF
--- a/e2e/react-core/src/react.test.ts
+++ b/e2e/react-core/src/react.test.ts
@@ -265,6 +265,9 @@ describe('React Applications', () => {
       expect(readFile(`dist/apps/${appName}/styles.css`)).toMatch(
         /Comic Sans MS/
       );
+      // Check typings exist
+      checkFilesExist(`apps/${appName}/src/typings/cssmodule.d.ts`);
+      checkFilesExist(`apps/${appName}/src/typings/image.d.ts`);
     });
   });
 

--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -584,6 +584,7 @@ describe('app', () => {
             ],
             "ignorePatterns": [
               "!**/*",
+              "**/*.d.ts",
               ".next/**/*",
             ],
             "overrides": [

--- a/packages/next/src/generators/library/library.spec.ts
+++ b/packages/next/src/generators/library/library.spec.ts
@@ -29,17 +29,10 @@ describe('next library', () => {
       ...baseOptions,
       name: 'myLib',
     });
-    const tsconfigFiles = readJson(
-      appTree,
-      'libs/my-lib/tsconfig.lib.json'
-    ).files;
 
-    expect(tsconfigFiles).toContain(
-      '../../node_modules/@nx/next/typings/image.d.ts'
-    );
-    expect(tsconfigFiles).not.toContain(
-      '../../node_modules/@nx/react/typings/image.d.ts'
-    );
+    expect(
+      appTree.exists('libs/my-lib/src/lib/typings/image.d.ts')
+    ).toBeTruthy();
   });
 
   it('should add jsxImportSource in tsconfig.json for @emotion/styled', async () => {

--- a/packages/next/src/generators/library/library.ts
+++ b/packages/next/src/generators/library/library.ts
@@ -89,15 +89,6 @@ export async function libraryGenerator(host: Tree, rawOptions: Schema) {
       if (!json.files) {
         json.files = [];
       }
-      json.files = json.files.map((path: string) => {
-        if (path.endsWith('react/typings/image.d.ts')) {
-          return path.replace(
-            '@nx/react/typings/image.d.ts',
-            '@nx/next/typings/image.d.ts'
-          );
-        }
-        return path;
-      });
       if (!json.compilerOptions) {
         json.compilerOptions = {
           types: [],
@@ -109,6 +100,24 @@ export async function libraryGenerator(host: Tree, rawOptions: Schema) {
       json.compilerOptions.types.push('next');
       return json;
     }
+  );
+
+  // add image.d.ts to lib src/typings
+  host.write(
+    joinPathFragments(options.projectRoot, 'src/lib', 'typings/image.d.ts'),
+    `
+   /// <reference types="next/image-types/global" />
+
+  declare module '*.svg' {
+    import * as React from 'react';
+
+    export const ReactComponent: React.FunctionComponent<
+      React.SVGProps<SVGSVGElement> & { title?: string }
+    >;
+
+    const content: any;
+    export default content;
+  }`
   );
 
   if (!options.skipFormat) {

--- a/packages/react/migrations.json
+++ b/packages/react/migrations.json
@@ -107,6 +107,12 @@
       "version": "16.7.0-beta.2",
       "description": "Add @babel/core to package.json if @babel/preset-react is present",
       "implementation": "./src/migrations/update-16-7-0/add-babel-core"
+    },
+    "update-16-7-0-add-typings": {
+      "cli": "nx",
+      "version": "16.7.0-beta.2",
+      "description": "Add cssmodule.d.ts and image.d.ts to support css modules and images and remove hardcoded types from tsconfig",
+      "implementation": "./src/migrations/update-16-7-0-add-typings/update-16-7-0-add-typings"
     }
   },
   "packageJsonUpdates": {

--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -590,6 +590,7 @@ describe('app', () => {
         ],
         "ignorePatterns": [
           "!**/*",
+          "**/*.d.ts",
         ],
         "overrides": [
           {

--- a/packages/react/src/generators/application/files/base-rspack/tsconfig.app.json__tmpl__
+++ b/packages/react/src/generators/application/files/base-rspack/tsconfig.app.json__tmpl__
@@ -4,11 +4,6 @@
     "outDir": "<%= offsetFromRoot %>dist/out-tsc",
     "types": ["node"]
   },
-  "files": [
-    <% if (style === 'styled-jsx') { %>"<%= offsetFromRoot %>node_modules/@nx/react/typings/styled-jsx.d.ts",<% } %>
-    "<%= offsetFromRoot %>node_modules/@nx/react/typings/cssmodule.d.ts",
-    "<%= offsetFromRoot %>node_modules/@nx/react/typings/image.d.ts"
-  ],
   "exclude": ["jest.config.ts","src/**/*.spec.ts", "src/**/*.test.ts", "src/**/*.spec.tsx", "src/**/*.test.tsx", "src/**/*.spec.js", "src/**/*.test.js", "src/**/*.spec.jsx", "src/**/*.test.jsx"],
   "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/react/src/generators/application/files/base-vite/tsconfig.app.json__tmpl__
+++ b/packages/react/src/generators/application/files/base-vite/tsconfig.app.json__tmpl__
@@ -4,11 +4,6 @@
     "outDir": "<%= offsetFromRoot %>dist/out-tsc",
     "types": ["node"]
   },
-  "files": [
-    <% if (style === 'styled-jsx') { %>"<%= offsetFromRoot %>node_modules/@nx/react/typings/styled-jsx.d.ts",<% } %>
-    "<%= offsetFromRoot %>node_modules/@nx/react/typings/cssmodule.d.ts",
-    "<%= offsetFromRoot %>node_modules/@nx/react/typings/image.d.ts"
-  ],
   "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts", "src/**/*.spec.tsx", "src/**/*.test.tsx", "src/**/*.spec.js", "src/**/*.test.js", "src/**/*.spec.jsx", "src/**/*.test.jsx"],
   "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/react/src/generators/application/files/base-webpack/tsconfig.app.json__tmpl__
+++ b/packages/react/src/generators/application/files/base-webpack/tsconfig.app.json__tmpl__
@@ -4,11 +4,6 @@
     "outDir": "<%= offsetFromRoot %>dist/out-tsc",
     "types": ["node"]
   },
-  "files": [
-    <% if (style === 'styled-jsx') { %>"<%= offsetFromRoot %>node_modules/@nx/react/typings/styled-jsx.d.ts",<% } %>
-    "<%= offsetFromRoot %>node_modules/@nx/react/typings/cssmodule.d.ts",
-    "<%= offsetFromRoot %>node_modules/@nx/react/typings/image.d.ts"
-  ],
   "exclude": ["jest.config.ts","src/**/*.spec.ts", "src/**/*.test.ts", "src/**/*.spec.tsx", "src/**/*.test.tsx", "src/**/*.spec.js", "src/**/*.test.js", "src/**/*.spec.jsx", "src/**/*.test.jsx"],
   "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/react/src/generators/application/files/base/src/typings/cssmodule.d.ts
+++ b/packages/react/src/generators/application/files/base/src/typings/cssmodule.d.ts
@@ -1,0 +1,24 @@
+declare module '*.module.css' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}
+
+declare module '*.module.scss' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}
+
+declare module '*.module.sass' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}
+
+declare module '*.module.less' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}
+
+declare module '*.module.styl' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}

--- a/packages/react/src/generators/application/files/base/src/typings/image.d.ts
+++ b/packages/react/src/generators/application/files/base/src/typings/image.d.ts
@@ -1,0 +1,48 @@
+/// <reference types="react" />
+/// <reference types="react-dom" />
+
+declare module '*.svg' {
+  import * as React from 'react';
+
+  export const ReactComponent: React.FunctionComponent<
+    React.SVGProps<SVGSVGElement> & { title?: string }
+  >;
+
+  const src: string;
+  export default src;
+}
+
+declare module '*.bmp' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.gif' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.jpg' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.jpeg' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.png' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.avif' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.webp' {
+  const src: string;
+  export default src;
+}

--- a/packages/react/src/generators/application/files/style-styled-jsx/src/typings/styled-jsx.d.ts
+++ b/packages/react/src/generators/application/files/style-styled-jsx/src/typings/styled-jsx.d.ts
@@ -1,0 +1,8 @@
+import 'react';
+
+declare module 'react' {
+  interface StyleHTMLAttributes<T> extends React.HTMLAttributes<T> {
+    jsx?: boolean;
+    global?: boolean;
+  }
+}

--- a/packages/react/src/generators/application/lib/create-application-files.ts
+++ b/packages/react/src/generators/application/lib/create-application-files.ts
@@ -139,6 +139,13 @@ export function createApplicationFiles(host: Tree, options: NormalizedSchema) {
       templateVariables
     );
   }
+  // Add typings
+  generateFiles(
+    host,
+    join(__dirname, '../files/base'),
+    options.appProjectRoot,
+    templateVariables
+  );
 
   generateFiles(
     host,

--- a/packages/react/src/generators/application/lib/update-jest-config.ts
+++ b/packages/react/src/generators/application/lib/update-jest-config.ts
@@ -1,34 +1,14 @@
 import { updateJestConfigContent } from '../../../utils/jest-utils';
 import { NormalizedSchema } from '../schema';
-import { offsetFromRoot, Tree, updateJson } from '@nx/devkit';
+import { Tree } from '@nx/devkit';
 
 export function updateSpecConfig(host: Tree, options: NormalizedSchema) {
-  if (options.unitTestRunner === 'none') {
-    return;
+  if (options.unitTestRunner === 'jest') {
+    const configPath = `${options.appProjectRoot}/jest.config.${
+      options.js ? 'js' : 'ts'
+    }`;
+    const originalContent = host.read(configPath, 'utf-8');
+    const content = updateJestConfigContent(originalContent);
+    host.write(configPath, content);
   }
-
-  updateJson(host, `${options.appProjectRoot}/tsconfig.spec.json`, (json) => {
-    const offset = offsetFromRoot(options.appProjectRoot);
-    json.files = [
-      `${offset}node_modules/@nx/react/typings/cssmodule.d.ts`,
-      `${offset}node_modules/@nx/react/typings/image.d.ts`,
-    ];
-    if (options.style === 'styled-jsx') {
-      json.files.unshift(
-        `${offset}node_modules/@nx/react/typings/styled-jsx.d.ts`
-      );
-    }
-    return json;
-  });
-
-  if (options.unitTestRunner !== 'jest') {
-    return;
-  }
-
-  const configPath = `${options.appProjectRoot}/jest.config.${
-    options.js ? 'js' : 'ts'
-  }`;
-  const originalContent = host.read(configPath, 'utf-8');
-  const content = updateJestConfigContent(originalContent);
-  host.write(configPath, content);
 }

--- a/packages/react/src/generators/library/files/common/src/typings/cssmodule.d.ts
+++ b/packages/react/src/generators/library/files/common/src/typings/cssmodule.d.ts
@@ -1,0 +1,24 @@
+declare module '*.module.css' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}
+
+declare module '*.module.scss' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}
+
+declare module '*.module.sass' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}
+
+declare module '*.module.less' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}
+
+declare module '*.module.styl' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}

--- a/packages/react/src/generators/library/files/common/src/typings/image.d.ts
+++ b/packages/react/src/generators/library/files/common/src/typings/image.d.ts
@@ -1,0 +1,50 @@
+/// <reference types="react" />
+/// <reference types="react-dom" />
+
+declare module '*.svg' {
+  import * as React from 'react';
+
+  export const ReactComponent: React.FunctionComponent<
+    React.SVGProps<SVGSVGElement> & { title?: string }
+  >;
+
+  const src: string;
+  export default src;
+}
+
+declare module '*.bmp' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.gif' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.jpg' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.jpeg' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.png' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.avif' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.webp' {
+  const src: string;
+  export default src;
+}
+
+// convert everything above as a string

--- a/packages/react/src/generators/library/files/common/tsconfig.lib.json__tmpl__
+++ b/packages/react/src/generators/library/files/common/tsconfig.lib.json__tmpl__
@@ -4,11 +4,6 @@
     "outDir": "<%= offsetFromRoot %>dist/out-tsc",
     "types": ["node"]
   },
-  "files": [<% if (style === 'styled-jsx') { %>
-    "<%= offsetFromRoot %>node_modules/@nx/react/typings/styled-jsx.d.ts",<% } %>
-    "<%= offsetFromRoot %>node_modules/@nx/react/typings/cssmodule.d.ts",
-    "<%= offsetFromRoot %>node_modules/@nx/react/typings/image.d.ts"
-  ],
   "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts", "src/**/*.spec.tsx", "src/**/*.test.tsx", "src/**/*.spec.js", "src/**/*.test.js", "src/**/*.spec.jsx", "src/**/*.test.jsx"],
   "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/react/src/generators/library/files/styled-jsx/src/typings/styled-jsx.d.ts
+++ b/packages/react/src/generators/library/files/styled-jsx/src/typings/styled-jsx.d.ts
@@ -1,0 +1,8 @@
+import 'react';
+
+declare module 'react' {
+  interface StyleHTMLAttributes<T> extends React.HTMLAttributes<T> {
+    jsx?: boolean;
+    global?: boolean;
+  }
+}

--- a/packages/react/src/generators/library/lib/create-files.ts
+++ b/packages/react/src/generators/library/lib/create-files.ts
@@ -41,6 +41,15 @@ export function createFiles(host: Tree, options: NormalizedSchema) {
     );
   }
 
+  if (options.style === 'styled-jsx') {
+    generateFiles(
+      host,
+      joinPathFragments(__dirname, '../files/styled-jsx'),
+      options.projectRoot,
+      substitutions
+    );
+  }
+
   if (options.compiler === 'babel') {
     writeJson(host, joinPathFragments(options.projectRoot, '.babelrc'), {
       presets: [

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -189,41 +189,42 @@ describe('lib', () => {
 
     const eslintJson = readJson(tree, 'libs/my-lib/.eslintrc.json');
     expect(eslintJson).toMatchInlineSnapshot(`
-        {
-          "extends": [
-            "plugin:@nx/react",
-            "../../.eslintrc.json",
-          ],
-          "ignorePatterns": [
-            "!**/*",
-          ],
-          "overrides": [
-            {
-              "files": [
-                "*.ts",
-                "*.tsx",
-                "*.js",
-                "*.jsx",
-              ],
-              "rules": {},
-            },
-            {
-              "files": [
-                "*.ts",
-                "*.tsx",
-              ],
-              "rules": {},
-            },
-            {
-              "files": [
-                "*.js",
-                "*.jsx",
-              ],
-              "rules": {},
-            },
-          ],
-        }
-      `);
+      {
+        "extends": [
+          "plugin:@nx/react",
+          "../../.eslintrc.json",
+        ],
+        "ignorePatterns": [
+          "!**/*",
+          "**/*.d.ts",
+        ],
+        "overrides": [
+          {
+            "files": [
+              "*.ts",
+              "*.tsx",
+              "*.js",
+              "*.jsx",
+            ],
+            "rules": {},
+          },
+          {
+            "files": [
+              "*.ts",
+              "*.tsx",
+            ],
+            "rules": {},
+          },
+          {
+            "files": [
+              "*.js",
+              "*.jsx",
+            ],
+            "rules": {},
+          },
+        ],
+      }
+    `);
   });
   it('should update jest.config.ts for babel', async () => {
     await libraryGenerator(tree, {

--- a/packages/react/src/migrations/update-16-7-0-add-typings/update-16-7-0-add-typings.spec.ts
+++ b/packages/react/src/migrations/update-16-7-0-add-typings/update-16-7-0-add-typings.spec.ts
@@ -1,0 +1,34 @@
+import { Tree, addProjectConfiguration } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from 'nx/src/devkit-testing-exports';
+import addTypings from './update-16-7-0-add-typings';
+
+describe('Add typings file and remove typings from tsconfig', () => {
+  let tree: Tree;
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should add typings file', async () => {
+    tree.write(
+      'package.json',
+      JSON.stringify({
+        dependencies: {},
+        devDependencies: {},
+      })
+    );
+
+    addProjectConfiguration(tree, 'myapp', {
+      root: 'myapp',
+      targets: {
+        build: {
+          executor: '@nx/webpack:webpack',
+        },
+      },
+    });
+
+    await addTypings(tree);
+
+    expect(tree.exists('myapp/src/typings/cssmodule.d.ts')).toBeTruthy();
+    expect(tree.exists('myapp/src/typings/image.d.ts')).toBeTruthy();
+  });
+});

--- a/packages/react/src/migrations/update-16-7-0-add-typings/update-16-7-0-add-typings.ts
+++ b/packages/react/src/migrations/update-16-7-0-add-typings/update-16-7-0-add-typings.ts
@@ -1,0 +1,132 @@
+import {
+  Tree,
+  formatFiles,
+  getProjects,
+  joinPathFragments,
+  updateJson,
+} from '@nx/devkit';
+
+export default async function addTypings(tree: Tree) {
+  const projects = getProjects(tree);
+
+  const buildExecutors = [
+    '@nx/webpack:webpack',
+    '@nx/vite:build',
+    '@nx/rspack:rspack',
+  ];
+
+  for (const [, config] of projects) {
+    if (buildExecutors.includes(config.targets?.build?.executor)) {
+      if (
+        !tree.exists(
+          joinPathFragments(config.root, 'src/typings/cssmodule.d.ts')
+        )
+      ) {
+        tree.write(
+          `${config.root}/src/typings/cssmodule.d.ts`,
+          `
+          declare module '*.module.css' {
+            const classes: { readonly [key: string]: string };
+            export default classes;
+          }
+          
+          declare module '*.module.scss' {
+            const classes: { readonly [key: string]: string };
+            export default classes;
+          }
+          
+          declare module '*.module.sass' {
+            const classes: { readonly [key: string]: string };
+            export default classes;
+          }
+          
+          declare module '*.module.less' {
+            const classes: { readonly [key: string]: string };
+            export default classes;
+          }
+          
+          declare module '*.module.styl' {
+            const classes: { readonly [key: string]: string };
+            export default classes;
+          }
+          `
+        );
+      }
+      if (
+        !tree.exists(joinPathFragments(config.root, 'src/typings/image.d.ts'))
+      ) {
+        tree.write(
+          `${config.root}/src/typings/image.d.ts`,
+          `
+          /// <reference types="react" />
+          /// <reference types="react-dom" />
+
+          declare module '*.svg' {
+            import * as React from 'react';
+
+            export const ReactComponent: React.FunctionComponent<
+              React.SVGProps<SVGSVGElement> & { title?: string }
+            >;
+
+            const src: string;
+            export default src;
+          }
+
+          declare module '*.bmp' {
+            const src: string;
+            export default src;
+          }
+
+          declare module '*.gif' {
+            const src: string;
+            export default src;
+          }
+
+          declare module '*.jpg' {
+            const src: string;
+            export default src;
+          }
+
+          declare module '*.jpeg' {
+            const src: string;
+            export default src;
+          }
+
+          declare module '*.png' {
+            const src: string;
+            export default src;
+          }
+
+          declare module '*.avif' {
+            const src: string;
+            export default src;
+          }
+
+          declare module '*.webp' {
+            const src: string;
+            export default src;
+          }`
+        );
+      }
+      // remove typings from cssmodule.d.ts and image.d.ts
+      ['tsconfig.app.json', 'tsconfig.spec.json'].forEach((tsconfigPath) => {
+        if (tree.exists(joinPathFragments(config.root, tsconfigPath))) {
+          updateJson(
+            tree,
+            joinPathFragments(config.root, tsconfigPath),
+            (tsconfig) => {
+              if (tsconfig.files?.length > 0) {
+                tsconfig.files = tsconfig.files.filter(
+                  (file: string) =>
+                    !['cssmodule.d.ts', 'image.d.ts'].includes(file)
+                );
+              }
+              return tsconfig;
+            }
+          );
+        }
+      });
+    }
+  }
+  await formatFiles(tree);
+}

--- a/packages/react/src/utils/lint.ts
+++ b/packages/react/src/utils/lint.ts
@@ -1,4 +1,3 @@
-import { offsetFromRoot } from '@nx/devkit';
 import type { Linter } from 'eslint';
 import {
   eslintPluginImportVersion,
@@ -18,10 +17,11 @@ export const extraEslintDependencies = {
 };
 
 export const extendReactEslintJson = (json: Linter.Config) => {
-  const { extends: pluginExtends, ...config } = json;
+  const { extends: pluginExtends, ignorePatterns, ...config } = json;
 
   return {
     extends: ['plugin:@nx/react', ...(pluginExtends || [])],
+    ignorePatterns: [...(ignorePatterns || []), '**/*.d.ts'],
     ...config,
   };
 };


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When you create a react app inside `tsconfig.app.json` and `tsconfig.spec.json` there are hardcoded references to typings inside `node_modules`.

If you use Yarn PnP these hardcoded references would fail since `node_modules` do not exist.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

This PR removes the references from `tsconfig` and adds them directly to the app.
That way there would be no need to have hardcoded references and they would be automatically picked up during bundling without the need to anything additional.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
