### PR TITLE
chore(testing): try catch the pm command detection

### DIFF
--- a/e2e/utils/command-utils.ts
+++ b/e2e/utils/command-utils.ts
@@ -131,7 +131,7 @@ export function getPackageManagerCommand({
   return {
     npm: {
       createWorkspace: `npx ${
-        +npmMajorVersion >= 7 ? '--yes' : ''
+        npmMajorVersion && +npmMajorVersion >= 7 ? '--yes' : ''
       } create-nx-workspace@${publishedVersion}`,
       run: (script: string, args: string) => `npm run ${script} -- ${args}`,
       runNx: `npx nx`,
@@ -146,18 +146,24 @@ export function getPackageManagerCommand({
     },
     yarn: {
       createWorkspace: `npx ${
-        +npmMajorVersion >= 7 ? '--yes' : ''
+        npmMajorVersion && +npmMajorVersion >= 7 ? '--yes' : ''
       } create-nx-workspace@${publishedVersion}`,
       run: (script: string, args: string) => `yarn ${script} ${args}`,
       runNx: `yarn nx`,
-      runNxSilent: +yarnMajorVersion >= 2 ? 'yarn nx' : `yarn --silent nx`,
+      runNxSilent:
+        yarnMajorVersion && +yarnMajorVersion >= 2
+          ? 'yarn nx'
+          : `yarn --silent nx`,
       runUninstalledPackage: 'npx --yes',
       install: 'yarn',
       ciInstall: 'yarn --frozen-lockfile',
       addProd: isYarnWorkspace ? 'yarn add -W' : 'yarn add',
       addDev: isYarnWorkspace ? 'yarn add -DW' : 'yarn add -D',
       list: 'yarn list --pattern',
-      runLerna: +yarnMajorVersion >= 2 ? 'yarn lerna' : `yarn --silent lerna`,
+      runLerna:
+        yarnMajorVersion && +yarnMajorVersion >= 2
+          ? 'yarn lerna'
+          : `yarn --silent lerna`,
     },
     // Pnpm 3.5+ adds nx to
     pnpm: {

--- a/e2e/utils/get-env-info.ts
+++ b/e2e/utils/get-env-info.ts
@@ -68,12 +68,16 @@ export function getSelectedPackageManager(): 'npm' | 'yarn' | 'pnpm' {
   return (process.env.SELECTED_PM as 'npm' | 'yarn' | 'pnpm') || 'npm';
 }
 
-export function getNpmMajorVersion(): string {
-  const [npmMajorVersion] = execSync(`npm -v`).toString().split('.');
-  return npmMajorVersion;
+export function getNpmMajorVersion(): string | undefined {
+  try {
+    const [npmMajorVersion] = execSync(`npm -v`).toString().split('.');
+    return npmMajorVersion;
+  } catch {
+    return undefined;
+  }
 }
 
-export function getYarnMajorVersion(path: string): string {
+export function getYarnMajorVersion(path: string): string | undefined {
   try {
     // this fails if path is not yet created
     const [yarnMajorVersion] = execSync(`yarn -v`, {
@@ -82,10 +86,14 @@ export function getYarnMajorVersion(path: string): string {
     }).split('.');
     return yarnMajorVersion;
   } catch {
-    const [yarnMajorVersion] = execSync(`yarn -v`, { encoding: 'utf-8' }).split(
-      '.'
-    );
-    return yarnMajorVersion;
+    try {
+      const [yarnMajorVersion] = execSync(`yarn -v`, {
+        encoding: 'utf-8',
+      }).split('.');
+      return yarnMajorVersion;
+    } catch {
+      return undefined;
+    }
   }
 }
 


### PR DESCRIPTION
In CI (observed in vite-ecosystem-ci) when trying to do `yarn -v` it says `Usage Error: This project is configured to use pnpm`. So adding a try catch saves us from this error.