### PR TITLE
fix(core): do not mix UNIX and performance API timestamps in profiles

### DIFF
--- a/packages/nx/src/tasks-runner/life-cycles/task-profiling-life-cycle.spec.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/task-profiling-life-cycle.spec.ts
@@ -1,0 +1,121 @@
+import { Task } from '../../config/task-graph';
+import { TaskProfilingLifeCycle } from './task-profiling-life-cycle';
+import { performance } from 'perf_hooks';
+
+describe('TaskProfilingLifeCycle', () => {
+  let originalNow: any;
+  let mockPerfValue = 0;
+
+  beforeAll(() => {
+    originalNow = performance.now;
+    Object.defineProperty(performance, 'now', {
+      value: jest.fn(),
+      configurable: true,
+      writable: true,
+    });
+    jest.spyOn(performance, 'now').mockImplementation(() => mockPerfValue);
+  });
+
+  afterAll(() => {
+    Object.defineProperty(performance, 'now', {
+      value: originalNow,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it('should produce a profile for 3 different tasks in 2 groups', () => {
+    const lifecycle = new TaskProfilingLifeCycle('profile.json');
+
+    const task1: Task = {
+      id: 'task-1',
+      overrides: undefined,
+      target: { project: 'proj-1', target: 'lint' },
+    };
+    const task2: Task = {
+      id: 'task-2',
+      overrides: undefined,
+      target: { project: 'proj-2', target: 'lint' },
+    };
+    const task3: Task = {
+      id: 'task-3',
+      overrides: undefined,
+      target: { project: 'proj-1', target: 'test' },
+    };
+    const group0 = { groupId: 0 };
+    const group1 = { groupId: 1 };
+
+    mockPerfValue = 110;
+    lifecycle.startTasks([task1], group0);
+    lifecycle.startTasks([task2], group1);
+
+    mockPerfValue = 240;
+    lifecycle.startTasks([task3], group0);
+    lifecycle.endTasks([{ task: task1, status: 'success', code: 0 }], group0);
+
+    mockPerfValue = 300;
+    lifecycle.endTasks([{ task: task2, status: 'success', code: 0 }], group1);
+    lifecycle.endTasks([{ task: task3, status: 'failure', code: 1 }], group0);
+
+    expect((lifecycle as any).profile).toEqual([
+      {
+        args: { name: 'Group #1' },
+        name: 'thread_name',
+        ph: 'M',
+        pid: process.pid,
+        tid: 0,
+        ts: 0,
+      },
+      {
+        args: { name: 'Group #2' },
+        name: 'thread_name',
+        ph: 'M',
+        pid: process.pid,
+        tid: 1,
+        ts: 0,
+      },
+      {
+        args: {
+          status: 'success',
+          target: { project: 'proj-1', target: 'lint' },
+        },
+        cat: 'proj-1,lint',
+        dur: 130000,
+        name: 'task-1',
+        ph: 'X',
+        pid: process.pid,
+        tid: 0,
+        ts: 110000,
+      },
+      {
+        args: {
+          status: 'success',
+          target: { project: 'proj-2', target: 'lint' },
+        },
+        cat: 'proj-2,lint',
+        dur: 190000,
+        name: 'task-2',
+        ph: 'X',
+        pid: process.pid,
+        tid: 1,
+        ts: 110000,
+      },
+      {
+        args: {
+          status: 'failure',
+          target: {
+            project: 'proj-1',
+            target: 'test',
+          },
+        },
+        cat: 'proj-1,test',
+        dur: 60000,
+        name: 'task-3',
+        ph: 'X',
+        pid: process.pid,
+        tid: 0,
+        ts: 240000,
+      },
+    ]);
+  });
+});

--- a/packages/nx/src/tasks-runner/life-cycles/task-profiling-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/task-profiling-life-cycle.ts
@@ -7,6 +7,10 @@ import { Task } from '../../config/task-graph';
 import { writeJsonFile } from '../../utils/fileutils';
 
 export class TaskProfilingLifeCycle implements LifeCycle {
+  /**
+   * Task timings. High-res timestamps provided by perf_hooks, where 0
+   * represents the start of the current node process.
+   */
   private timings: {
     [target: string]: {
       perfStart: number;
@@ -37,14 +41,7 @@ export class TaskProfilingLifeCycle implements LifeCycle {
     metadata: TaskMetadata
   ): void {
     for (let tr of taskResults) {
-      if (tr.task.startTime) {
-        this.timings[tr.task.id].perfStart = tr.task.startTime;
-      }
-      if (tr.task.endTime) {
-        this.timings[tr.task.id].perfEnd = tr.task.endTime;
-      } else {
-        this.timings[tr.task.id].perfEnd = performance.now();
-      }
+      this.timings[tr.task.id].perfEnd = performance.now();
     }
     this.recordTaskCompletions(taskResults, metadata);
   }


### PR DESCRIPTION
## Current Behavior

`TaskProfilingLifeCycle` calculates profile timestamps and durations based on a mix of performance timestamps (coming from `performance.now()`) and UNIX ones (coming from tasks).

The problem comes when the two types of values are mixed - e.g. `perfStart` comes from the task and `perfEnd` comes from the performance API, or vice-versa. Since performance timestamps are relative to the process start and UNIX timestamps are relative to the UNIX epoch, such cases would result in wrong calculations - e.g. an enormous negative value if `perfStart` is a UNIX timestamps and `perfEnd` is a performance timestamp.

## Expected Behavior

`TaskProfilingLifeCycle` should produce profiles with correct durations.

## Change overview

Do not store UNIX timestamps at all. Instead, use only performance ones for the calculations.

## Related Issue(s)

Fixes #18388
