### PR TITLE
docs(core): add nx overview video to Nx docs

### DIFF
--- a/docs/shared/core-features/enforce-module-boundaries.md
+++ b/docs/shared/core-features/enforce-module-boundaries.md
@@ -138,7 +138,7 @@ With these constraints in place, `scope:client` projects can only depend on proj
 
 Projects without any tags cannot depend on any other projects. If you try to violate the constraints, you will get an error when linting:
 
-```shell
+```plaintext
 A project tagged with "scope:admin" can only depend on projects
 tagged with "scoped:shared" or "scope:admin".
 ```

--- a/docs/shared/core-tutorial/02-create-cli.md
+++ b/docs/shared/core-tutorial/02-create-cli.md
@@ -101,7 +101,7 @@ func main() {
 
 `packages/cli/src/cow.txt`:
 
-```shell
+```plaintext
  _____
 < moo >
  -----

--- a/docs/shared/core-tutorial/03-share-assets.md
+++ b/docs/shared/core-tutorial/03-share-assets.md
@@ -18,7 +18,7 @@ Then move `cow.txt` out of the `cli` project to:
 
 `packages/ascii/assets/cow.txt`:
 
-```shell
+```plaintext
  _____
 < moo >
  -----

--- a/docs/shared/core-tutorial/04-build-affected-projects.md
+++ b/docs/shared/core-tutorial/04-build-affected-projects.md
@@ -46,7 +46,7 @@ git checkout .
 
 Update `packages/ascii/assets/cow.txt`:
 
-```shell
+```plaintext
  _____
 < Hi! >
  -----

--- a/docs/shared/core-tutorial/05-auto-detect-dependencies.md
+++ b/docs/shared/core-tutorial/05-auto-detect-dependencies.md
@@ -90,11 +90,10 @@ console.log(
 
 Now if you run `nx serve cow`, you'll see this:
 
-```shell
-$ node index.js
- ______________________________________________________
+```shell {% command="node index.js" %}
+______________________________________________________
 < Welcome to the Restaurant at the End of the Universe >
- ------------------------------------------------------
+------------------------------------------------------
         \   ^__^
          \  (oo)\_______
             (__)\       )\/\

--- a/docs/shared/getting-started/why-nx.md
+++ b/docs/shared/getting-started/why-nx.md
@@ -1,5 +1,10 @@
 # Why Nx?
 
+{% youtube
+src="https://www.youtube.com/embed/-_4WMl-Fn0w"
+title="What is Nx?"
+width="100%" /%}
+
 We created Nx because developers struggle to configure, maintain and especially integrate various tools and frameworks. Setting up a system that works well for a handful of developers and at the same time, easily scales up to an entire organization is hard. This includes setting up low-level build tooling, configuring fast CI, and keeping your codebase healthy, up-to-date, and maintainable.
 
 We wanted to provide a solution that is easy to adopt and scale.

--- a/docs/shared/monorepo-nx-enterprise.md
+++ b/docs/shared/monorepo-nx-enterprise.md
@@ -159,7 +159,7 @@ Since Nx allows us to group apps and libs in directories, those directories can 
 why the structure of an Nx workspace often reflects the structure of an organization. GitHub users can use
 the `CODEOWNERS` file for that.
 
-```shell
+```plaintext
 /libs/happynrwlapp          julie-happynrwlapp-lead
 /apps/happynrwlapp          julie-happynrwlapp-lead
 /libs/shared/ui             hank-the-ui-guy


### PR DESCRIPTION
Embeds the new "What is Nx" video: 
https://nx-dev-git-fork-juristr-docs-include-what-nx-video-nrwl.vercel.app/getting-started/why-nx