### PR TITLE
fix(react): add typings to types instead of files

### DIFF
--- a/packages/next/src/generators/library/library.spec.ts
+++ b/packages/next/src/generators/library/library.spec.ts
@@ -29,17 +29,10 @@ describe('next library', () => {
       ...baseOptions,
       name: 'myLib',
     });
-    const tsconfigFiles = readJson(
-      appTree,
-      'libs/my-lib/tsconfig.lib.json'
-    ).files;
+    const tsconfigTypes = readJson(appTree, 'libs/my-lib/tsconfig.lib.json')
+      .compilerOptions.types;
 
-    expect(tsconfigFiles).toContain(
-      '../../node_modules/@nx/next/typings/image.d.ts'
-    );
-    expect(tsconfigFiles).not.toContain(
-      '../../node_modules/@nx/react/typings/image.d.ts'
-    );
+    expect(tsconfigTypes).toContain('@nx/next/typings/image.d.ts');
   });
 
   it('should add jsxImportSource in tsconfig.json for @emotion/styled', async () => {

--- a/packages/next/src/generators/library/library.ts
+++ b/packages/next/src/generators/library/library.ts
@@ -86,18 +86,6 @@ export async function libraryGenerator(host: Tree, rawOptions: Schema) {
     host,
     joinPathFragments(options.projectRoot, 'tsconfig.lib.json'),
     (json) => {
-      if (!json.files) {
-        json.files = [];
-      }
-      json.files = json.files.map((path: string) => {
-        if (path.endsWith('react/typings/image.d.ts')) {
-          return path.replace(
-            '@nx/react/typings/image.d.ts',
-            '@nx/next/typings/image.d.ts'
-          );
-        }
-        return path;
-      });
       if (!json.compilerOptions) {
         json.compilerOptions = {
           types: [],
@@ -106,7 +94,11 @@ export async function libraryGenerator(host: Tree, rawOptions: Schema) {
       if (!json.compilerOptions.types) {
         json.compilerOptions.types = [];
       }
-      json.compilerOptions.types.push('next');
+      json.compilerOptions.types = [
+        ...json.compilerOptions.types,
+        'next',
+        '@nx/next/typings/image.d.ts',
+      ];
       return json;
     }
   );

--- a/packages/react/migrations.json
+++ b/packages/react/migrations.json
@@ -107,6 +107,12 @@
       "version": "16.7.0-beta.2",
       "description": "Add @babel/core to package.json if @babel/preset-react is present",
       "implementation": "./src/migrations/update-16-7-0/add-babel-core"
+    },
+    "update-16-7-0-add-typings": {
+      "cli": "nx",
+      "version": "16.7.0-beta.2",
+      "description": "Add @nx/react types to tsconfig types array",
+      "implementation": "./src/migrations/update-16-7-0-add-typings/update-16-7-0-add-typings"
     }
   },
   "packageJsonUpdates": {

--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -52,6 +52,8 @@ describe('app', () => {
       const tsconfigApp = readJson(appTree, 'apps/my-app/tsconfig.app.json');
       expect(tsconfigApp.compilerOptions.types).toEqual([
         'node',
+        '@nx/react/typings/cssmodule.d.ts',
+        '@nx/react/typings/image.d.ts',
         'vite/client',
       ]);
       const tsconfigSpec = readJson(appTree, 'apps/my-app/tsconfig.spec.json');

--- a/packages/react/src/generators/application/files/base-rspack/tsconfig.app.json__tmpl__
+++ b/packages/react/src/generators/application/files/base-rspack/tsconfig.app.json__tmpl__
@@ -2,13 +2,13 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "<%= offsetFromRoot %>dist/out-tsc",
-    "types": ["node"]
+    "types": [
+      "node",
+      <% if (style === 'styled-jsx') { %>"@nx/react/typings/styled-jsx.d.ts",<% } %>
+      "@nx/react/typings/cssmodule.d.ts",
+      "@nx/react/typings/image.d.ts"
+      ]
   },
-  "files": [
-    <% if (style === 'styled-jsx') { %>"<%= offsetFromRoot %>node_modules/@nx/react/typings/styled-jsx.d.ts",<% } %>
-    "<%= offsetFromRoot %>node_modules/@nx/react/typings/cssmodule.d.ts",
-    "<%= offsetFromRoot %>node_modules/@nx/react/typings/image.d.ts"
-  ],
   "exclude": ["jest.config.ts","src/**/*.spec.ts", "src/**/*.test.ts", "src/**/*.spec.tsx", "src/**/*.test.tsx", "src/**/*.spec.js", "src/**/*.test.js", "src/**/*.spec.jsx", "src/**/*.test.jsx"],
   "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/react/src/generators/application/files/base-vite/tsconfig.app.json__tmpl__
+++ b/packages/react/src/generators/application/files/base-vite/tsconfig.app.json__tmpl__
@@ -2,13 +2,13 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "<%= offsetFromRoot %>dist/out-tsc",
-    "types": ["node"]
+    "types": [
+      "node",
+      <% if (style === 'styled-jsx') { %>"@nx/react/typings/styled-jsx.d.ts",<% } %>
+      "@nx/react/typings/cssmodule.d.ts",
+      "@nx/react/typings/image.d.ts"
+      ]
   },
-  "files": [
-    <% if (style === 'styled-jsx') { %>"<%= offsetFromRoot %>node_modules/@nx/react/typings/styled-jsx.d.ts",<% } %>
-    "<%= offsetFromRoot %>node_modules/@nx/react/typings/cssmodule.d.ts",
-    "<%= offsetFromRoot %>node_modules/@nx/react/typings/image.d.ts"
-  ],
   "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts", "src/**/*.spec.tsx", "src/**/*.test.tsx", "src/**/*.spec.js", "src/**/*.test.js", "src/**/*.spec.jsx", "src/**/*.test.jsx"],
   "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/react/src/generators/application/files/base-webpack/tsconfig.app.json__tmpl__
+++ b/packages/react/src/generators/application/files/base-webpack/tsconfig.app.json__tmpl__
@@ -2,13 +2,13 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "<%= offsetFromRoot %>dist/out-tsc",
-    "types": ["node"]
+    "types": [
+      "node",
+      <% if (style === 'styled-jsx') { %>"@nx/react/typings/styled-jsx.d.ts",<% } %>
+      "@nx/react/typings/cssmodule.d.ts",
+      "@nx/react/typings/image.d.ts"
+      ]
   },
-  "files": [
-    <% if (style === 'styled-jsx') { %>"<%= offsetFromRoot %>node_modules/@nx/react/typings/styled-jsx.d.ts",<% } %>
-    "<%= offsetFromRoot %>node_modules/@nx/react/typings/cssmodule.d.ts",
-    "<%= offsetFromRoot %>node_modules/@nx/react/typings/image.d.ts"
-  ],
   "exclude": ["jest.config.ts","src/**/*.spec.ts", "src/**/*.test.ts", "src/**/*.spec.tsx", "src/**/*.test.tsx", "src/**/*.spec.js", "src/**/*.test.js", "src/**/*.spec.jsx", "src/**/*.test.jsx"],
   "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/react/src/generators/application/lib/update-jest-config.ts
+++ b/packages/react/src/generators/application/lib/update-jest-config.ts
@@ -8,16 +8,15 @@ export function updateSpecConfig(host: Tree, options: NormalizedSchema) {
   }
 
   updateJson(host, `${options.appProjectRoot}/tsconfig.spec.json`, (json) => {
-    const offset = offsetFromRoot(options.appProjectRoot);
-    json.files = [
-      `${offset}node_modules/@nx/react/typings/cssmodule.d.ts`,
-      `${offset}node_modules/@nx/react/typings/image.d.ts`,
-    ];
+    json.types = json.types || [];
     if (options.style === 'styled-jsx') {
-      json.files.unshift(
-        `${offset}node_modules/@nx/react/typings/styled-jsx.d.ts`
-      );
+      json.types.push('@nx/react/typings/styled-jsx.d.ts');
     }
+    json.types = [
+      ...json.types,
+      '@nx/react/typings/cssmodule.d.ts',
+      '@nx/react/typings/image.d.ts',
+    ];
     return json;
   });
 

--- a/packages/react/src/migrations/update-16-7-0-add-typings/update-16-7-0-add-typings.spec.ts
+++ b/packages/react/src/migrations/update-16-7-0-add-typings/update-16-7-0-add-typings.spec.ts
@@ -1,0 +1,48 @@
+import { Tree, addProjectConfiguration } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from 'nx/src/devkit-testing-exports';
+import addTypings from './update-16-7-0-add-typings';
+
+describe('Add typings to react projects', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  });
+
+  it('should update tsconfig to include react typings', async () => {
+    tree.write(
+      'package.json',
+      JSON.stringify({
+        dependencies: {},
+        devDependencies: {},
+      })
+    );
+
+    addProjectConfiguration(tree, 'myapp', {
+      root: 'myapp',
+      targets: {
+        build: {
+          executor: '@nx/webpack:webpack',
+        },
+      },
+    });
+    tree.write(
+      'myapp/tsconfig.app.json',
+      JSON.stringify({
+        compilerOptions: {},
+      })
+    );
+
+    await addTypings(tree);
+    const tsconfigTypes = JSON.parse(
+      tree.read('myapp/tsconfig.app.json', 'utf-8')
+    );
+
+    expect(tsconfigTypes.compilerOptions.types).toContain(
+      '@nx/react/typings/cssmodule.d.ts'
+    );
+    expect(tsconfigTypes.compilerOptions.types).toContain(
+      '@nx/react/typings/image.d.ts'
+    );
+  });
+});

--- a/packages/react/src/migrations/update-16-7-0-add-typings/update-16-7-0-add-typings.ts
+++ b/packages/react/src/migrations/update-16-7-0-add-typings/update-16-7-0-add-typings.ts
@@ -1,0 +1,51 @@
+import {
+  Tree,
+  formatFiles,
+  getProjects,
+  joinPathFragments,
+  updateJson,
+} from '@nx/devkit';
+
+export default async function addTypings(tree: Tree) {
+  const projects = getProjects(tree);
+  const buildExecutors = [
+    '@nx/webpack:webpack',
+    '@nx/vite:build',
+    '@nx/rspack:rspack',
+  ];
+  const relatedTsConfigs = [
+    'tsconfig.app.json',
+    'tsconfig.lib.json',
+    'tsconfig.spec.json',
+  ];
+
+  const typesToAdd = [
+    '@nx/react/typings/cssmodule.d.ts',
+    '@nx/react/typings/image.d.ts',
+  ];
+
+  for (const [, config] of projects) {
+    if (buildExecutors.includes(config?.targets?.build?.executor)) {
+      const rootPath = config.root;
+      relatedTsConfigs.forEach((tsConfig) => {
+        const tsConfigPath = joinPathFragments(rootPath, tsConfig);
+        if (tree.exists(tsConfigPath)) {
+          updateJson(tree, tsConfigPath, (json) => {
+            const compilerOptions = json.compilerOptions || {};
+            compilerOptions.types = [
+              ...new Set([...(compilerOptions.types || []), ...typesToAdd]),
+            ];
+            if (json.files?.length > 0) {
+              json.files = json.files.filter(
+                (file: string) =>
+                  !['cssmodule.d.ts', 'image.d.ts'].includes(file)
+              );
+            }
+            return { ...json, compilerOptions };
+          });
+        }
+      });
+    }
+  }
+  await formatFiles(tree);
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When you create a react app inside `tsconfig.app.json` and `tsconfig.spec.json` there are hardcoded references to typings inside `node_modules`.

If you use Yarn PnP these hardcoded references would fail since `node_modules` do not exist.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

This PR removes the references from `tsconfig` and adds them to `compilerOptions.types` .
That way there would be no need to have hardcoded references and they would be automatically picked up during bundling since they are declared in `types`.

