### PR TITLE
feat(core): allow multiple targets in show projects commmand

### DIFF
--- a/packages/nx/src/command-line/show/command-object.ts
+++ b/packages/nx/src/command-line/show/command-object.ts
@@ -14,7 +14,7 @@ export type ShowProjectsOptions = NxShowArgs & {
   head: string;
   affected: boolean;
   projects: string[];
-  withTarget: string;
+  withTarget: string[];
 };
 
 export type ShowProjectOptions = NxShowArgs & {
@@ -73,6 +73,7 @@ const showProjectsCommand: CommandModule<NxShowArgs, ShowProjectsOptions> = {
         type: 'string',
         alias: ['t'],
         description: 'Show only projects that have a specific target',
+        coerce: parseCSV,
       })
       .implies('untracked', 'affected')
       .implies('uncommitted', 'affected')

--- a/packages/nx/src/command-line/show/show.ts
+++ b/packages/nx/src/command-line/show/show.ts
@@ -40,7 +40,7 @@ export async function showProjectsHandler(
 
   if (args.withTarget) {
     graph.nodes = Object.entries(graph.nodes).reduce((acc, [name, node]) => {
-      if (args.withTarget.some(target => node.data.targets?.[target])) {
+      if (args.withTarget.some((target) => node.data.targets?.[target])) {
         acc[name] = node;
       }
       return acc;

--- a/packages/nx/src/command-line/show/show.ts
+++ b/packages/nx/src/command-line/show/show.ts
@@ -40,7 +40,7 @@ export async function showProjectsHandler(
 
   if (args.withTarget) {
     graph.nodes = Object.entries(graph.nodes).reduce((acc, [name, node]) => {
-      if (node.data.targets?.[args.withTarget]) {
+      if (args.withTarget.some(target => node.data.targets?.[target])) {
         acc[name] = node;
       }
       return acc;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When using the new `nx show projects --affected` command the `--t` flag only accepts a single target.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

We should be able to pass multiple targets to the command to see all projects affected by one or more of those targets (like you can with the other Nx commands like `run-many`)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
