### PR TITLE
fix(vite): default vitest provider to v8

### DIFF
--- a/packages/vite/src/executors/test/vitest.impl.ts
+++ b/packages/vite/src/executors/test/vitest.impl.ts
@@ -2,13 +2,14 @@ import {
   ExecutorContext,
   joinPathFragments,
   logger,
+  readJsonFile,
   stripIndents,
   workspaceRoot,
 } from '@nx/devkit';
 import { CoverageOptions, File, Reporter } from 'vitest';
 import { loadConfigFromFile } from 'vite';
 import { VitestExecutorOptions } from './schema';
-import { relative, resolve } from 'path';
+import { join, relative, resolve } from 'path';
 import { existsSync } from 'fs';
 import { registerTsConfigPaths } from '@nx/js/src/internal';
 
@@ -99,6 +100,17 @@ async function getSettings(
   context: ExecutorContext,
   projectRoot: string
 ) {
+  const packageJsonPath = join(workspaceRoot, 'package.json');
+  const packageJson = existsSync(packageJsonPath)
+    ? readJsonFile(packageJsonPath)
+    : undefined;
+  let provider: 'v8' | 'c8' = 'v8';
+  if (
+    packageJson?.dependencies?.['@vitest/coverage-c8'] ||
+    packageJson?.devDependencies?.['@vitest/coverage-c8']
+  ) {
+    provider = 'c8';
+  }
   const offset = relative(workspaceRoot, context.cwd);
   // if reportsDirectory is not provided vitest will remove all files in the project root
   // when coverage is enabled in the vite.config.ts
@@ -106,7 +118,7 @@ async function getSettings(
     ? {
         enabled: options.coverage,
         reportsDirectory: options.reportsDirectory,
-        provider: 'c8',
+        provider,
       }
     : ({} as CoverageOptions);
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

`vitest` provider defaults to `c8`.

## Expected Behavior

`vitest` generator defaults to `v8`. Executor should default to `v8`, but if `c8` is installed then use `c8`. User can override these options in `vite.config.ts`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18505
