### PR TITLE
cleanup(misc): enable prettier-plugin-tailwindcss

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
-  "endOfLine": "lf"
+  "endOfLine": "lf",
+  "plugins": ["prettier-plugin-tailwindcss"]
 }

--- a/nx-dev/feature-ai/src/lib/feed-container.tsx
+++ b/nx-dev/feature-ai/src/lib/feed-container.tsx
@@ -84,7 +84,7 @@ export function FeedContainer(): JSX.Element {
                 {isLoading && !startedReply && <LoadingState />}
                 {error && <ErrorMessage error={error} />}
 
-                <div className="sticky bottom-0 left-0 right-0 w-full pt-6 pb-4 bg-gradient-to-t from-white via-white dark:from-slate-900 dark:via-slate-900">
+                <div className="sticky bottom-0 left-0 right-0 w-full bg-gradient-to-t from-white via-white pt-6 pb-4 dark:from-slate-900 dark:via-slate-900">
                   <Prompt
                     handleSubmit={handleSubmit}
                     handleInputChange={handleInputChange}

--- a/nx-dev/feature-ai/src/lib/feed/feed-answer.tsx
+++ b/nx-dev/feature-ai/src/lib/feed/feed-answer.tsx
@@ -33,7 +33,7 @@ export function FeedAnswer({
 
   return (
     <>
-      <div className="grid h-12 w-12 items-center justify-center rounded-full bg-white dark:bg-slate-900 ring-1 ring-slate-200 dark:ring-slate-700 text-slate-900 dark:text-white">
+      <div className="grid h-12 w-12 items-center justify-center rounded-full bg-white text-slate-900 ring-1 ring-slate-200 dark:bg-slate-900 dark:text-white dark:ring-slate-700">
         <svg
           role="img"
           viewBox="0 0 24 24"
@@ -47,9 +47,9 @@ export function FeedAnswer({
       </div>
       <div className="min-w-0 flex-1">
         <div>
-          <div className="text-lg flex gap-2 items-center text-slate-900 dark:text-slate-100">
+          <div className="flex items-center gap-2 text-lg text-slate-900 dark:text-slate-100">
             Nx Assistant{' '}
-            <span className="rounded-md bg-red-50 dark:bg-red-900/30 px-1.5 py-0.5 text-xs font-medium text-red-600 dark:text-red-400">
+            <span className="rounded-md bg-red-50 px-1.5 py-0.5 text-xs font-medium text-red-600 dark:bg-red-900/30 dark:text-red-400">
               alpha
             </span>
           </div>
@@ -61,12 +61,12 @@ export function FeedAnswer({
             AI powered
           </p>
         </div>
-        <div className="mt-2 prose prose-slate dark:prose-invert w-full max-w-none 2xl:max-w-4xl">
+        <div className="prose prose-slate dark:prose-invert mt-2 w-full max-w-none 2xl:max-w-4xl">
           {!isFirst && renderMarkdown(callout, { filePath: '' }).node}
           <ReactMarkdown children={content} />
         </div>
         {!isFirst && (
-          <div className="group text-xs flex-1 md:flex md:justify-end gap-4 md:items-center text-slate-400 hover:text-slate-500 transition">
+          <div className="group flex-1 gap-4 text-xs text-slate-400 transition hover:text-slate-500 md:flex md:items-center md:justify-end">
             {feedbackStatement ? (
               <p className="italic group-hover:flex">
                 {feedbackStatement === 'good'
@@ -81,7 +81,7 @@ export function FeedAnswer({
             <div className="flex gap-4">
               <button
                 className={cx(
-                  'hover:rotate-12 hover:text-blue-500 dark:hover:text-sky-500 transition-all p-1 disabled:cursor-not-allowed',
+                  'p-1 transition-all hover:rotate-12 hover:text-blue-500 disabled:cursor-not-allowed dark:hover:text-sky-500',
                   { 'text-blue-500': feedbackStatement === 'bad' }
                 )}
                 disabled={!!feedbackStatement}
@@ -93,7 +93,7 @@ export function FeedAnswer({
               </button>
               <button
                 className={cx(
-                  'hover:rotate-12 hover:text-blue-500 dark:hover:text-sky-500 transition-all p-1 disabled:cursor-not-allowed',
+                  'p-1 transition-all hover:rotate-12 hover:text-blue-500 disabled:cursor-not-allowed dark:hover:text-sky-500',
                   { 'text-blue-500': feedbackStatement === 'good' }
                 )}
                 disabled={!!feedbackStatement}

--- a/nx-dev/feature-ai/src/lib/feed/feed.tsx
+++ b/nx-dev/feature-ai/src/lib/feed/feed.tsx
@@ -10,12 +10,12 @@ export function Feed({
   handleFeedback: (statement: 'bad' | 'good', chatItemUid: string) => void;
 }) {
   return (
-    <div className="flow-root my-12">
+    <div className="my-12 flow-root">
       <ul role="list" className="-mb-8 space-y-12">
         {activity.map((activityItem, activityItemIdx) => (
           <li
             key={[activityItem.role, activityItem.id].join('-')}
-            className="pt-12 relative flex items-start space-x-3 feed-item"
+            className="feed-item relative flex items-start space-x-3 pt-12"
           >
             {activityItem.role === 'assistant' ? (
               <FeedAnswer

--- a/nx-dev/feature-ai/src/lib/prompt.tsx
+++ b/nx-dev/feature-ai/src/lib/prompt.tsx
@@ -33,9 +33,9 @@ export function Prompt({
     <form
       ref={formRef}
       onSubmit={handleSubmit}
-      className="relative flex gap-2 max-w-2xl mx-auto py-0 px-2 shadow-lg rounded-md border border-slate-300 bg-white dark:border-slate-900 dark:bg-slate-700"
+      className="relative mx-auto flex max-w-2xl gap-2 rounded-md border border-slate-300 bg-white py-0 px-2 shadow-lg dark:border-slate-900 dark:bg-slate-700"
     >
-      <div className="overflow-y-auto w-full h-full max-h-[300px]">
+      <div className="h-full max-h-[300px] w-full overflow-y-auto">
         <Textarea
           onKeyDown={(event) => {
             if (
@@ -53,7 +53,7 @@ export function Prompt({
           id="query-prompt"
           name="query"
           disabled={isDisabled}
-          className="block w-full p-0 resize-none bg-transparent text-sm placeholder-slate-500 pl-2 py-[1.3rem] focus-within:outline-none focus:placeholder-slate-400 dark:focus:placeholder-slate-300 dark:text-white focus:outline-none focus:ring-0 border-none disabled:cursor-not-allowed"
+          className="block w-full resize-none border-none bg-transparent p-0 py-[1.3rem] pl-2 text-sm placeholder-slate-500 focus-within:outline-none focus:placeholder-slate-400 focus:outline-none focus:ring-0 disabled:cursor-not-allowed dark:text-white dark:focus:placeholder-slate-300"
           placeholder="How does caching work?"
           rows={1}
         />
@@ -64,7 +64,7 @@ export function Prompt({
           size="small"
           type="submit"
           disabled={isDisabled}
-          className="self-end w-12 h-12 disabled:cursor-not-allowed"
+          className="h-12 w-12 self-end disabled:cursor-not-allowed"
         >
           <div hidden className="sr-only">
             Ask

--- a/nx-dev/ui-common/src/lib/documentation-header.tsx
+++ b/nx-dev/ui-common/src/lib/documentation-header.tsx
@@ -184,7 +184,7 @@ export function DocumentationHeader({
           </Link>
           <Link
             href="/getting-started/intro"
-            className="hidden lg:flex ml-2 items-center px-4 text-slate-900 dark:text-white lg:px-0"
+            className="ml-2 hidden items-center px-4 text-slate-900 dark:text-white lg:flex lg:px-0"
           >
             <span className="text-xl font-bold uppercase tracking-wide">
               Docs

--- a/nx-dev/ui-community/src/lib/connect-with-us.tsx
+++ b/nx-dev/ui-community/src/lib/connect-with-us.tsx
@@ -20,7 +20,7 @@ export function ConnectWithUs(): JSX.Element {
             Looking for community plugins? Find them listed in the{' '}
             <a
               href="/extending-nx/registry"
-              className="underline font-semibold"
+              className="font-semibold underline"
             >
               plugin registry
             </a>

--- a/nx-dev/ui-markdoc/src/lib/icons.tsx
+++ b/nx-dev/ui-markdoc/src/lib/icons.tsx
@@ -9,7 +9,7 @@ export const frameworkIcons: Record<
       <svg
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 48 49"
       >
         <path
@@ -24,7 +24,7 @@ export const frameworkIcons: Record<
       <svg
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 52 54"
       >
         <path
@@ -59,7 +59,7 @@ export const frameworkIcons: Record<
       <svg
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 132 134"
       >
         <path fill="#F7DF1E" d="M0 0h60v60H0V0z" />
@@ -85,7 +85,7 @@ export const frameworkIcons: Record<
       <svg
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 47 48"
       >
         <path
@@ -100,7 +100,7 @@ export const frameworkIcons: Record<
       <svg
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 196 205"
       >
         <path fill="#fff" d="M117.167 31h61v69h-61z" />
@@ -138,7 +138,7 @@ export const frameworkIcons: Record<
       <svg
         xmlns="http://www.w3.org/2000/svg"
         fill="#3178C6"
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 24 24"
       >
         <rect width="24" height="24" fill="#fff" rx="2" ry="2" />
@@ -151,7 +151,7 @@ export const frameworkIcons: Record<
       <svg
         xmlns="http://www.w3.org/2000/svg"
         fill="red"
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 24 24"
       >
         <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814z" />
@@ -165,7 +165,7 @@ export const frameworkIcons: Record<
         xmlns="http://www.w3.org/2000/svg"
         stroke="currentColor"
         fill="transparent"
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 24 24"
       >
         <path d="M22.167 7.167v-2.5a2.5 2.5 0 0 0-2.5-2.5h-15a2.5 2.5 0 0 0-2.5 2.5v15a2.5 2.5 0 0 0 2.5 2.5h2.5m15-15c-2.76 0-5 2.24-5 5s-2.24 5-5 5-5 2.24-5 5m15-15V19.59a2.577 2.577 0 0 1-2.576 2.576H7.167" />
@@ -176,8 +176,8 @@ export const frameworkIcons: Record<
     image: (
       <svg
         fill="currentColor"
-        className="w-full h-full"
-        className="w-full h-full"
+        className="h-full w-full"
+        className="h-full w-full"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
@@ -190,7 +190,7 @@ export const frameworkIcons: Record<
       <svg
         fill="#339933"
         role="img"
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
@@ -203,7 +203,7 @@ export const frameworkIcons: Record<
     image: (
       <svg
         fill="#000000"
-        className="adaptive-icon w-full h-full"
+        className="adaptive-icon h-full w-full"
         role="img"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
@@ -218,7 +218,7 @@ export const frameworkIcons: Record<
       <svg
         fill="#E0234E"
         role="img"
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
@@ -231,7 +231,7 @@ export const frameworkIcons: Record<
     image: (
       <svg
         xmlns="http://www.w3.org/2000/svg"
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="20 0 350 339.32"
       >
         <path
@@ -261,7 +261,7 @@ export const frameworkIcons: Record<
     image: (
       <svg
         xmlns="http://www.w3.org/2000/svg"
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="100 150 450 450"
       >
         <path
@@ -315,7 +315,7 @@ export const frameworkIcons: Record<
       <svg
         fill="#000000"
         role="img"
-        className="adaptive-icon w-full h-full"
+        className="adaptive-icon h-full w-full"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
@@ -328,7 +328,7 @@ export const frameworkIcons: Record<
     image: (
       <svg
         fill="#000000"
-        className="adaptive-icon w-full h-full"
+        className="adaptive-icon h-full w-full"
         role="img"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
@@ -343,7 +343,7 @@ export const frameworkIcons: Record<
       <svg
         fill="#FF4785"
         role="img"
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
@@ -357,7 +357,7 @@ export const frameworkIcons: Record<
       <svg
         xmlns="http://www.w3.org/2000/svg"
         role="img"
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 166 155.3"
       >
         <defs>
@@ -454,7 +454,7 @@ export const frameworkIcons: Record<
       <svg
         fill="#324FFF"
         role="img"
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
@@ -468,7 +468,7 @@ export const frameworkIcons: Record<
       <svg
         viewBox="0 0 410 404"
         role="img"
-        className="w-full h-full"
+        className="h-full w-full"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
       >
@@ -514,7 +514,7 @@ export const frameworkIcons: Record<
       <svg
         fill="#2596BE"
         role="img"
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
@@ -528,7 +528,7 @@ export const frameworkIcons: Record<
       <svg
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 800 800"
       >
         <path fill="#212121" d="M0 0H800V800H0z"></path>
@@ -590,7 +590,7 @@ export const frameworkIcons: Record<
   dotnet: {
     image: (
       <svg
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 456 456"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
@@ -620,7 +620,7 @@ export const frameworkIcons: Record<
       <svg
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 60 64"
       >
         <path
@@ -644,7 +644,7 @@ export const frameworkIcons: Record<
         id="Layer_1"
         data-name="Layer 1"
         xmlns="http://www.w3.org/2000/svg"
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 90 66.06"
       >
         <defs>
@@ -671,7 +671,7 @@ export const frameworkIcons: Record<
   go: {
     image: (
       <svg
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 32 32"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
@@ -700,7 +700,7 @@ export const frameworkIcons: Record<
   vue: {
     image: (
       <svg
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 -17.5 256 256"
         xmlns="http://www.w3.org/2000/svg"
         preserveAspectRatio="xMinYMin meet"
@@ -725,7 +725,7 @@ export const frameworkIcons: Record<
       <svg
         version="1.1"
         viewBox="0 0 108 108"
-        className="adaptive-icon w-full h-full"
+        className="adaptive-icon h-full w-full"
         xmlns="http://www.w3.org/2000/svg"
         xmlnsXlink="http://www.w3.org/1999/xlink"
       >
@@ -809,7 +809,7 @@ export const frameworkIcons: Record<
   nuxt: {
     image: (
       <svg
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 900 900"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
@@ -825,7 +825,7 @@ export const frameworkIcons: Record<
     image: (
       <svg
         xmlns="http://www.w3.org/2000/svg"
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 98.1 118"
       >
         <path
@@ -851,7 +851,7 @@ export const frameworkIcons: Record<
   gatsby: {
     image: (
       <svg
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 32 32"
         xmlns="http://www.w3.org/2000/svg"
       >
@@ -872,7 +872,7 @@ export const frameworkIcons: Record<
       <svg
         fill="#FF5D01"
         role="img"
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
@@ -884,7 +884,7 @@ export const frameworkIcons: Record<
   deno: {
     image: (
       <svg
-        className="adaptive-icon w-full h-full"
+        className="adaptive-icon h-full w-full"
         fill="#000000"
         role="img"
         viewBox="0 0 24 24"
@@ -900,7 +900,7 @@ export const frameworkIcons: Record<
       <svg
         fill="#2EAD33"
         role="img"
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
@@ -914,7 +914,7 @@ export const frameworkIcons: Record<
       <svg
         fill="#F69220"
         role="img"
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
@@ -928,7 +928,7 @@ export const frameworkIcons: Record<
       <svg
         xmlns="http://www.w3.org/2000/svg"
         fill="currentColor"
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 340 340"
       >
         <path
@@ -949,7 +949,7 @@ export const frameworkIcons: Record<
     image: (
       <svg
         xmlns="http://www.w3.org/2000/svg"
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 630 630"
       >
         <title>JavaScript Unofficial Logo</title>
@@ -963,7 +963,7 @@ export const frameworkIcons: Record<
       <svg
         xmlns="http://www.w3.org/2000/svg"
         fill="#09D3AC"
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 24 24"
       >
         <path d="M21.92 10.846c0-1.223-1.44-2.308-3.655-2.97.533-2.25.3-4.04-.76-4.645a1.695 1.695 0 00-.85-.213c-.989 0-2.239.69-3.501 1.886-1.262-1.186-2.509-1.873-3.496-1.873a1.68 1.68 0 00-.863.216c-1.054.607-1.273 2.386-.747 4.625-2.203.659-3.636 1.735-3.64 2.953-.003 1.218 1.442 2.308 3.656 2.968-.533 2.251-.302 4.04.76 4.645.259.145.552.218.848.213.991 0 2.241-.69 3.503-1.886 1.26 1.186 2.507 1.873 3.496 1.873a1.703 1.703 0 00.863-.216c1.054-.607 1.271-2.386.747-4.616 2.204-.668 3.636-1.744 3.638-2.96zm-7.953-5.541c1.454-1.301 2.363-1.442 2.686-1.442a.836.836 0 01.43.103c.508.29.71 1.31.549 2.663a10.075 10.075 0 01-.178 1.028 17.347 17.347 0 00-2.233-.367 17.49 17.49 0 00-1.463-1.79c.065-.065.136-.131.21-.195zm-4.401 6.548c.138.266.286.532.438.8.153.268.313.54.49.808-.48-.07-.948-.156-1.391-.259.124-.451.282-.895.463-1.35zm-.492-3.38c.45-.105.92-.192 1.408-.26-.177.263-.33.533-.49.815-.16.282-.3.533-.437.802a20.901 20.901 0 01-.48-1.358zM10 10.84c.22-.465.462-.93.726-1.396.267-.465.552-.918.847-1.35a20.569 20.569 0 013.176.004c.295.428.577.886.844 1.34.266.452.511.926.731 1.39a20.079 20.079 0 01-1.571 2.746 20.309 20.309 0 01-3.176-.004 19.91 19.91 0 01-.845-1.34 20.831 20.831 0 01-.725-1.39H10zm5.834-2.623c.483.068.95.155 1.392.258-.131.438-.288.888-.469 1.34-.14-.266-.285-.532-.44-.8a37.617 37.617 0 00-.476-.798h-.007zm.49 4.425c.153-.269.298-.537.437-.805.177.462.355.917.48 1.36-.448.105-.919.19-1.407.258.172-.263.337-.534.497-.813h-.007zm-3.165-6.54c.32.342.633.711.94 1.107a22.694 22.694 0 00-.928-.021c-.314 0-.636 0-.946.021a15 15 0 01.934-1.106zM9.22 3.974a.856.856 0 01.438-.099 2.328 2.328 0 01.922.233 6.937 6.937 0 011.775 1.203l.208.19a17.477 17.477 0 00-1.449 1.776 17.553 17.553 0 00-2.246.365 9.036 9.036 0 01-.177-1.006c-.185-1.34.028-2.363.527-2.655l.002-.007zm-.94 9.002a10.4 10.4 0 01-.983-.355c-1.26-.533-2.042-1.216-2.042-1.8 0-.585.785-1.265 2.044-1.788a10.232 10.232 0 01.966-.345 17.382 17.382 0 00.81 2.155 17.534 17.534 0 00-.794 2.133zm4.084 3.39c-1.454 1.302-2.363 1.44-2.688 1.44a.832.832 0 01-.43-.102c-.507-.29-.71-1.31-.548-2.663a9.957 9.957 0 01.177-1.027c.736.17 1.482.292 2.234.366.447.629.936 1.227 1.463 1.79l-.208.197zm.811-.8c-.32-.34-.634-.71-.942-1.106.305.014.616.021.93.021.314 0 .636 0 .946-.02-.307.395-.62.764-.935 1.105h.001zm3.938 2.13a.856.856 0 01-.44.105c-.323 0-1.243-.142-2.692-1.438l-.207-.19a17.466 17.466 0 001.447-1.775 17.236 17.236 0 002.247-.366c.078.345.14.682.178 1.007.176 1.338-.029 2.361-.535 2.65l.002.008zm1.918-5.049c-.304.125-.625.24-.966.343a17.487 17.487 0 00-.812-2.155c.312-.692.579-1.404.798-2.13.333.1.662.22.983.354 1.259.533 2.042 1.216 2.04 1.8-.002.585-.785 1.257-2.045 1.781l.002.007zm-5.873-.18c.322 0 .637-.096.905-.274a1.63 1.63 0 00.601-.731 1.63 1.63 0 00.094-.942 1.63 1.63 0 00-.445-.835 1.63 1.63 0 00-.834-.447 1.63 1.63 0 00-.942.092 1.63 1.63 0 00-.732.6 1.63 1.63 0 00-.276.905 1.628 1.628 0 00.123.624 1.63 1.63 0 001.506 1.007zM2.328 1.011v19.645H24V1.012H2.328zm20.825 18.8H3.176V1.859h19.977v17.953zm-15.09-6.019c-.533 2.251-.303 4.04.759 4.645.259.145.552.218.849.213.99 0 2.24-.69 3.503-1.886 1.26 1.186 2.506 1.873 3.495 1.873.302.006.6-.069.863-.216 1.055-.607 1.271-2.386.748-4.616 2.203-.66 3.636-1.737 3.637-2.953.002-1.216-1.44-2.308-3.653-2.97.532-2.25.3-4.04-.76-4.645a1.695 1.695 0 00-.85-.213c-.99 0-2.24.69-3.502 1.886-1.262-1.186-2.508-1.873-3.496-1.873a1.68 1.68 0 00-.862.216C7.739 3.862 7.52 5.64 8.046 7.88c-2.203.659-3.636 1.735-3.64 2.953-.003 1.218 1.444 2.297 3.658 2.961h-.002zm4.297 2.573c-1.454 1.301-2.363 1.44-2.688 1.44a.832.832 0 01-.43-.103c-.507-.29-.71-1.31-.548-2.663a9.957 9.957 0 01.178-1.027 17.68 17.68 0 002.233.366c.447.629.936 1.227 1.463 1.79l-.208.197zm4.402-6.55a24.03 24.03 0 00-.44-.8c-.155-.269-.32-.533-.484-.798.483.068.95.155 1.392.258-.13.438-.286.888-.467 1.34h-.001zm.483 3.373c-.448.105-.918.19-1.407.258a20.514 20.514 0 00.927-1.617c.187.47.348.921.476 1.368l.004-.008zm-.925-2.37a20.06 20.06 0 01-1.572 2.747 20.256 20.256 0 01-3.176-.004 19.938 19.938 0 01-1.576-2.73c.22-.465.462-.93.726-1.396.266-.465.552-.918.847-1.35a20.571 20.571 0 013.176.004c.294.428.577.886.843 1.34.266.452.513.935.733 1.398l-.001-.009zm-5.826 2.642c-.48-.07-.948-.156-1.391-.259.13-.437.289-.888.47-1.34.138.266.286.532.438.8.153.268.306.531.483.8zM10 9.023c-.154.266-.3.532-.437.802a17.869 17.869 0 01-.488-1.353c.45-.104.92-.191 1.408-.259-.165.263-.323.534-.483.81zm3.175 6.542c-.32-.34-.634-.71-.943-1.106.305.014.616.021.93.021.314 0 .636 0 .946-.02a16.35 16.35 0 01-.933 1.105zm3.937 2.13a.856.856 0 01-.44.105c-.323 0-1.243-.142-2.691-1.438l-.208-.19a17.479 17.479 0 001.447-1.775 17.234 17.234 0 002.247-.366c.079.344.14.682.178 1.007.178 1.338-.027 2.361-.533 2.65v.008zm.938-8.994c.333.102.662.22.983.355 1.26.533 2.042 1.216 2.04 1.8-.001.585-.783 1.272-2.043 1.796-.304.124-.625.24-.966.342a17.487 17.487 0 00-.811-2.155c.312-.697.578-1.413.797-2.145v.007zm-4.084-3.389c1.454-1.301 2.363-1.442 2.687-1.442a.836.836 0 01.43.103c.507.29.71 1.31.548 2.663a10.076 10.076 0 01-.178 1.028 17.345 17.345 0 00-2.233-.367 17.476 17.476 0 00-1.463-1.79c.067-.072.138-.138.211-.202l-.002.007zm-.807.792c.32.34.633.71.94 1.106a22.694 22.694 0 00-.928-.021c-.314 0-.636 0-.946.02a15 15 0 01.934-1.105zM9.22 3.974a.856.856 0 01.438-.1 2.328 2.328 0 01.922.233 6.937 6.937 0 011.775 1.203l.208.19a17.477 17.477 0 00-1.449 1.776 17.553 17.553 0 00-2.246.365 9.036 9.036 0 01-.177-1.006c-.185-1.34.028-2.363.527-2.655l.002-.007zM7.299 9.031a10.232 10.232 0 01.966-.345 17.382 17.382 0 00.81 2.155 17.536 17.536 0 00-.798 2.13 10.426 10.426 0 01-.984-.354c-1.26-.533-2.041-1.216-2.041-1.8 0-.584.788-1.263 2.047-1.786zm5.859.177a1.63 1.63 0 00-.906.274 1.63 1.63 0 00-.601.73 1.63 1.63 0 00-.094.942 1.63 1.63 0 003.229-.314 1.627 1.627 0 00-.12-.627 1.63 1.63 0 00-.353-.533 1.63 1.63 0 00-.53-.356 1.628 1.628 0 00-.625-.125v.01za1.63 1.63 0 00-.906.274 1.63 1.63 0 00-.601.73 1.63 1.63 0 00-.094.942 1.63 1.63 0 003.229-.314 1.627 1.627 0 00-.12-.627 1.63 1.63 0 00-.353-.533 1.63 1.63 0 00-.53-.356 1.628 1.628 0 00-.625-.125v.01za1.63 1.63 0 00-.906.274 1.63 1.63 0 00-.601.73 1.63 1.63 0 00-.094.942 1.63 1.63 0 003.229-.314 1.627 1.627 0 00-.12-.627 1.63 1.63 0 00-.353-.533 1.63 1.63 0 00-.53-.356 1.628 1.628 0 00-.625-.125v.01zm8.761 1.64c0-1.223-1.44-2.307-3.654-2.97.533-2.25.3-4.039-.76-4.644a1.695 1.695 0 00-.85-.213c-.989 0-2.239.69-3.501 1.885-1.262-1.186-2.509-1.873-3.496-1.873a1.68 1.68 0 00-.863.217c-1.054.607-1.273 2.386-.747 4.625-2.203.658-3.636 1.734-3.64 2.952-.003 1.218 1.442 2.308 3.656 2.969-.533 2.25-.302 4.039.76 4.644.259.145.552.219.848.213.991 0 2.241-.69 3.503-1.885 1.26 1.186 2.507 1.873 3.496 1.873.302.005.6-.07.863-.217 1.054-.607 1.271-2.386.747-4.616 2.204-.671 3.636-1.747 3.638-2.963v.004zm-7.952-5.544c1.454-1.301 2.363-1.442 2.686-1.442a.836.836 0 01.43.103c.508.29.71 1.31.549 2.663a10.075 10.075 0 01-.178 1.028 17.347 17.347 0 00-2.233-.367 17.49 17.49 0 00-1.463-1.79c.065-.065.136-.131.21-.195zm-4.401 6.548c.138.266.286.532.438.8.153.268.313.54.49.808-.48-.07-.948-.156-1.391-.259.124-.451.282-.895.463-1.35zm-.492-3.38c.45-.105.92-.192 1.408-.26-.177.263-.33.533-.49.815-.16.282-.3.533-.437.802a20.901 20.901 0 01-.48-1.358zM10 10.84c.22-.465.462-.93.726-1.396.267-.465.552-.918.847-1.35a20.569 20.569 0 013.176.004c.295.428.577.886.844 1.34.266.452.511.926.731 1.39a20.079 20.079 0 01-1.571 2.746 20.309 20.309 0 01-3.176-.004 19.91 19.91 0 01-.845-1.34 20.831 20.831 0 01-.725-1.39H10zm5.834-2.623c.483.068.95.155 1.392.258-.131.438-.288.888-.469 1.34-.14-.266-.285-.532-.44-.8a37.617 37.617 0 00-.476-.798h-.007zm.49 4.425c.153-.269.298-.537.437-.805.177.462.355.917.48 1.36-.448.105-.919.19-1.407.258.172-.263.337-.534.497-.813h-.007zm-3.165-6.54c.32.342.633.711.94 1.107a22.694 22.694 0 00-.928-.021c-.314 0-.636 0-.946.021a15 15 0 01.934-1.106zM9.22 3.974a.856.856 0 01.438-.099 2.328 2.328 0 01.922.233 6.937 6.937 0 011.775 1.203l.208.19a17.477 17.477 0 00-1.449 1.776 17.553 17.553 0 00-2.246.365 9.036 9.036 0 01-.177-1.006c-.185-1.34.028-2.363.527-2.655l.002-.007zm-.94 9.002a10.4 10.4 0 01-.983-.355c-1.26-.533-2.042-1.216-2.042-1.8 0-.585.785-1.265 2.044-1.788a10.232 10.232 0 01.966-.345 17.382 17.382 0 00.81 2.155 17.534 17.534 0 00-.794 2.133zm4.084 3.39c-1.454 1.302-2.363 1.44-2.688 1.44a.832.832 0 01-.43-.102c-.507-.29-.71-1.31-.548-2.663a9.957 9.957 0 01.177-1.027c.736.17 1.482.292 2.234.366.447.629.936 1.227 1.463 1.79l-.208.197zm.811-.8c-.32-.34-.634-.71-.942-1.106.305.014.616.021.93.021.314 0 .636 0 .946-.02-.307.395-.62.764-.935 1.105h.001zm3.938 2.13a.856.856 0 01-.44.105c-.323 0-1.243-.142-2.692-1.438l-.207-.19a17.466 17.466 0 001.447-1.775 17.236 17.236 0 002.247-.366c.078.345.14.682.178 1.007.176 1.338-.029 2.361-.535 2.65l.002.008zm1.918-5.049c-.304.125-.625.24-.966.343a17.487 17.487 0 00-.812-2.155c.312-.692.579-1.404.798-2.13.333.1.662.22.983.354 1.259.533 2.042 1.216 2.04 1.8-.002.585-.785 1.257-2.045 1.781l.002.007zm-5.873-.18c.322 0 .637-.096.905-.274a1.63 1.63 0 00.601-.731 1.63 1.63 0 00.094-.942 1.63 1.63 0 00-.445-.835 1.63 1.63 0 00-.834-.447 1.63 1.63 0 00-.942.092 1.63 1.63 0 00-.732.6 1.63 1.63 0 00-.276.905 1.628 1.628 0 00.123.624 1.63 1.63 0 001.506 1.007zM.85 22.14V2.49L0 3.341v19.647h21.669l.849-.847H.85z"></path>
@@ -976,7 +976,7 @@ export const frameworkIcons: Record<
         xmlns="http://www.w3.org/2000/svg"
         enableBackground="new 0 0 250 250"
         version="1.1"
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 250 250"
         xmlSpace="preserve"
       >
@@ -1000,7 +1000,7 @@ export const frameworkIcons: Record<
     image: (
       <svg
         xmlns="http://www.w3.org/2000/svg"
-        className="adaptive-icon w-full h-full"
+        className="adaptive-icon h-full w-full"
         viewBox="0 0 24 24"
       >
         <title>Cypress</title>
@@ -1012,7 +1012,7 @@ export const frameworkIcons: Record<
     image: (
       <svg
         xmlns="http://www.w3.org/2000/svg"
-        className="adaptive-icon w-full h-full"
+        className="adaptive-icon h-full w-full"
         fill="#000020"
         viewBox="0 0 24 24"
       >
@@ -1026,7 +1026,7 @@ export const frameworkIcons: Record<
       <svg
         fill="#61DAFB"
         role="img"
-        className="w-full h-full"
+        className="h-full w-full"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >

--- a/nx-dev/ui-markdoc/src/lib/nodes/fence.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/nodes/fence.component.tsx
@@ -167,7 +167,7 @@ export function Fence({
                 <button
                   type="button"
                   className={
-                    'opacity-0 transition-opacity group-hover:opacity-100 not-prose flex border border-slate-200 bg-slate-50/50 p-2 dark:border-slate-700 dark:bg-slate-800/60' +
+                    'not-prose flex border border-slate-200 bg-slate-50/50 p-2 opacity-0 transition-opacity group-hover:opacity-100 dark:border-slate-700 dark:bg-slate-800/60' +
                     (highlightOptions && highlightOptions[0]
                       ? ''
                       : ' rounded-tr-lg')
@@ -188,7 +188,7 @@ export function Fence({
                 selected={selectedOption}
                 onChange={highlightChange}
               >
-                <SparklesIcon className="h-5 w-5 mr-1"></SparklesIcon>
+                <SparklesIcon className="mr-1 h-5 w-5"></SparklesIcon>
               </Selector>
             )}
           </div>

--- a/nx-dev/ui-markdoc/src/lib/nodes/fences/terminal-output.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/nodes/fences/terminal-output.component.tsx
@@ -15,8 +15,8 @@ export function TerminalOutput({
   const commandLines = command.split('\n').filter(Boolean);
   return (
     <TerminalShellWrapper isMessageBelow={isMessageBelow}>
-      <div className="p-4 pt-2 overflow-x-auto">
-        <div className="flex flex-col items-left">
+      <div className="overflow-x-auto p-4 pt-2">
+        <div className="items-left flex flex-col">
           {commandLines.map((line, index) => {
             return (
               <div key={index} className="flex items-center">
@@ -35,7 +35,7 @@ export function TerminalOutput({
             );
           })}
         </div>
-        <div className="flex not-prose">{content}</div>
+        <div className="not-prose flex">{content}</div>
       </div>
     </TerminalShellWrapper>
   );

--- a/nx-dev/ui-markdoc/src/lib/tags/cards.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/cards.component.tsx
@@ -38,9 +38,9 @@ export function Cards({
     >
       {children}
       {moreLink && (
-        <div className="flex justify-end mt-2 col-span-full">
+        <div className="col-span-full mt-2 flex justify-end">
           <a
-            className="transition-all duration-200 ease-in-out flex items-center no-underline text-sm px-4 py-0 border-transparent hover:text-slate-900 dark:hover:text-sky-400 whitespace-nowrap font-semibold group"
+            className="group flex items-center whitespace-nowrap border-transparent px-4 py-0 text-sm font-semibold no-underline transition-all duration-200 ease-in-out hover:text-slate-900 dark:hover:text-sky-400"
             href={moreLink}
           >
             Browse more
@@ -80,7 +80,7 @@ export function LinkCard({
       {icon && (
         <div
           className={cx(
-            'flex items-center justify-center w-24 h-24 rounded-lg mb-2',
+            'mb-2 flex h-24 w-24 items-center justify-center rounded-lg',
             {
               'h-12 w-12': appearance === 'small',
             }
@@ -91,13 +91,13 @@ export function LinkCard({
       )}
       <div className={cx('pt-4', { 'pt-2': appearance === 'small' })}>
         {appearance === 'small' && type ? null : (
-          <div className="text-xs font-medium text-slate-600 dark:text-slate-300 uppercase mb-1">
+          <div className="mb-1 text-xs font-medium uppercase text-slate-600 dark:text-slate-300">
             {type}
           </div>
         )}
         <h3
           className={cx(
-            'text-lg font-semibold text-slate-900 dark:text-white m-0',
+            'm-0 text-lg font-semibold text-slate-900 dark:text-white',
             { 'text-sm font-normal': appearance === 'small' }
           )}
         >

--- a/nx-dev/ui-markdoc/src/lib/tags/youtube.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/youtube.component.tsx
@@ -62,10 +62,10 @@ export function YouTube(props: {
         width={props.width || '100%'}
         allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; fullscreen"
         loading="lazy"
-        className="rounded-lg shadow-lg mb-1"
+        className="mb-1 rounded-lg shadow-lg"
       />
       {props.caption && (
-        <p className="md:w-1/2 mx-auto pt-0 text-slate-500 dark:text-slate-400">
+        <p className="mx-auto pt-0 text-slate-500 dark:text-slate-400 md:w-1/2">
           {props.caption}
         </p>
       )}


### PR DESCRIPTION
sorting tailwind classes makes it easier to see what's going on because classes are ordered consistently. 
It looks like this was already done in https://github.com/nrwl/nx/pull/8856 but only once. 

I now added the already-installed plugin to `.prettierrc`