### PR TITLE
fix(react): fix createGlobPAtternsForDependencies path

### DIFF
--- a/packages/react/tailwind.ts
+++ b/packages/react/tailwind.ts
@@ -7,7 +7,7 @@ import { createGlobPatternsForDependencies as jsGenerateGlobs } from '@nx/js/src
  */
 export function createGlobPatternsForDependencies(
   dirPath: string,
-  fileGlobPattern: string = '/**/!(*.stories|*.spec).{tsx,ts,jsx,js,html}'
+  fileGlobPattern: string = '/**/*!(*.stories|*.spec).{tsx,ts,jsx,js,html}'
 ) {
   try {
     return jsGenerateGlobs(dirPath, fileGlobPattern);


### PR DESCRIPTION
Added missing * where was needed for libraries.

## Current Behavior
patterns for tailwind content are missing `*`

## Expected Behavior
patterns to fit all files as shown here https://github.com/nrwl/nx/blob/master/packages/react/src/generators/setup-tailwind/files/tailwind.config.js__tmpl__#L9