### PR TITLE
fix(js): fix rust typescript analysis paths for windows

### DIFF
--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.ts
@@ -7,6 +7,7 @@ import {
 } from '../../../../config/project-graph';
 import { join, relative } from 'path';
 import { workspaceRoot } from '../../../../utils/workspace-root';
+import { normalizePath } from '../../../../utils/path';
 
 export type ExplicitDependency = {
   sourceProjectName: string;
@@ -123,10 +124,11 @@ function buildExplicitTypeScriptDependenciesWithSwc(
     staticImportExpressions,
     dynamicImportExpressions,
   } of imports) {
+    const normalizedFilePath = normalizePath(relative(workspaceRoot, file));
     for (const importExpr of staticImportExpressions) {
       const dependency = convertImportToDependency(
         importExpr,
-        relative(workspaceRoot, file),
+        normalizedFilePath,
         sourceProject,
         DependencyType.static,
         targetProjectLocator
@@ -142,7 +144,7 @@ function buildExplicitTypeScriptDependenciesWithSwc(
     for (const importExpr of dynamicImportExpressions) {
       const dependency = convertImportToDependency(
         importExpr,
-        relative(workspaceRoot, file),
+        normalizedFilePath,
         sourceProject,
         DependencyType.dynamic,
         targetProjectLocator


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The paths for creating typescript dependencies when using the rust typescript analyzer are not normalized and cause an error on windows.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The paths for creating typescript dependencies when using the rust typescript analyzer are normalized and do not cause errors.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
