### PR TITLE
fix(linter): bump eslint-plugin-cypress

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "eslint": "8.46.0",
     "eslint-config-next": "13.1.1",
     "eslint-config-prettier": "^8.1.0",
-    "eslint-plugin-cypress": "^2.10.3",
+    "eslint-plugin-cypress": "^2.13.4",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-jsx-a11y": "6.6.1",
     "eslint-plugin-react": "7.31.11",

--- a/packages/cypress/migrations.json
+++ b/packages/cypress/migrations.json
@@ -85,6 +85,15 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "16.7.0": {
+      "version": "16.7.0-beta.3",
+      "packages": {
+        "eslint-plugin-cypress": {
+          "version": "^2.13.4",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/cypress/src/generators/convert-tslint-to-eslint/__snapshots__/convert-tslint-to-eslint.spec.ts.snap
+++ b/packages/cypress/src/generators/convert-tslint-to-eslint/__snapshots__/convert-tslint-to-eslint.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`convert-tslint-to-eslint should work for Cypress applications 1`] = `
     "@typescript-eslint/parser": "^5.60.1",
     "eslint": "~8.46.0",
     "eslint-config-prettier": "8.1.0",
-    "eslint-plugin-cypress": "^2.10.3",
+    "eslint-plugin-cypress": "^2.13.4",
     "eslint-plugin-import": "latest",
   },
   "name": "test-name",

--- a/packages/cypress/src/utils/versions.ts
+++ b/packages/cypress/src/utils/versions.ts
@@ -1,5 +1,5 @@
 export const nxVersion = require('../../package.json').version;
-export const eslintPluginCypressVersion = '^2.10.3';
+export const eslintPluginCypressVersion = '^2.13.4';
 export const typesNodeVersion = '16.11.7';
 export const cypressViteDevServerVersion = '^2.2.1';
 export const cypressVersion = '^12.16.0';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -562,8 +562,8 @@ devDependencies:
     specifier: ^8.1.0
     version: 8.5.0(eslint@8.46.0)
   eslint-plugin-cypress:
-    specifier: ^2.10.3
-    version: 2.12.1(eslint@8.46.0)
+    specifier: ^2.13.4
+    version: 2.13.4(eslint@8.46.0)
   eslint-plugin-import:
     specifier: 2.26.0
     version: 2.26.0(@typescript-eslint/parser@5.60.1)(eslint-import-resolver-typescript@3.5.2)(eslint@8.46.0)
@@ -14300,13 +14300,13 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-cypress@2.12.1(eslint@8.46.0):
-    resolution: {integrity: sha512-c2W/uPADl5kospNDihgiLc7n87t5XhUbFDoTl6CfVkmG+kDAb5Ux10V9PoLPu9N+r7znpc+iQlcmAqT1A/89HA==}
+  /eslint-plugin-cypress@2.13.4(eslint@8.46.0):
+    resolution: {integrity: sha512-A6CMdzFkGMkIWwVmS7DOBJfO1L2V5qcU2svlueycMJHn4MpoIhASxnDt+rI8zeA7qy9ExEGrMj1WhHcde1VrPQ==}
     peerDependencies:
       eslint: '>= 3.2.1'
     dependencies:
       eslint: 8.46.0
-      globals: 11.12.0
+      globals: 13.20.0
     dev: true
 
   /eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.60.1)(eslint-import-resolver-typescript@3.5.2)(eslint@8.46.0):


### PR DESCRIPTION
This version includes this fix: https://github.com/cypress-io/eslint-plugin-cypress/pull/138, which is necessary for the FlatConfig to work for cypress projects.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
