### PR TITLE
docs(core): Add vue documentation for nx-recipe

### DIFF
--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -3632,6 +3632,14 @@
                 "disableCollapsible": false
               },
               {
+                "name": "Add a Vue Project",
+                "path": "/showcase/example-repos/add-vue",
+                "id": "add-vue",
+                "isExternal": false,
+                "children": [],
+                "disableCollapsible": false
+              },
+              {
                 "name": "Powering Up React Development With Nx",
                 "path": "/showcase/example-repos/react-nx",
                 "id": "react-nx",
@@ -3756,6 +3764,14 @@
             "disableCollapsible": false
           },
           {
+            "name": "Add a Vue Project",
+            "path": "/showcase/example-repos/add-vue",
+            "id": "add-vue",
+            "isExternal": false,
+            "children": [],
+            "disableCollapsible": false
+          },
+          {
             "name": "Powering Up React Development With Nx",
             "path": "/showcase/example-repos/react-nx",
             "id": "react-nx",
@@ -3866,6 +3882,14 @@
         "name": "Add an Astro Project",
         "path": "/showcase/example-repos/add-astro",
         "id": "add-astro",
+        "isExternal": false,
+        "children": [],
+        "disableCollapsible": false
+      },
+      {
+        "name": "Add a Vue Project",
+        "path": "/showcase/example-repos/add-vue",
+        "id": "add-vue",
         "isExternal": false,
         "children": [],
         "disableCollapsible": false

--- a/docs/generated/manifests/nx.json
+++ b/docs/generated/manifests/nx.json
@@ -4528,6 +4528,16 @@
             "tags": []
           },
           {
+            "id": "add-vue",
+            "name": "Add a Vue Project",
+            "description": "Add a Vue project to your repo",
+            "file": "shared/recipes/add-stack/add-vue",
+            "itemList": [],
+            "isExternal": false,
+            "path": "/showcase/example-repos/add-vue",
+            "tags": []
+          },
+          {
             "id": "react-nx",
             "name": "Powering Up React Development With Nx",
             "description": "",
@@ -4684,6 +4694,16 @@
         "tags": []
       },
       {
+        "id": "add-vue",
+        "name": "Add a Vue Project",
+        "description": "Add a Vue project to your repo",
+        "file": "shared/recipes/add-stack/add-vue",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/showcase/example-repos/add-vue",
+        "tags": []
+      },
+      {
         "id": "react-nx",
         "name": "Powering Up React Development With Nx",
         "description": "",
@@ -4826,6 +4846,16 @@
     "itemList": [],
     "isExternal": false,
     "path": "/showcase/example-repos/add-astro",
+    "tags": []
+  },
+  "/showcase/example-repos/add-vue": {
+    "id": "add-vue",
+    "name": "Add a Vue Project",
+    "description": "Add a Vue project to your repo",
+    "file": "shared/recipes/add-stack/add-vue",
+    "itemList": [],
+    "isExternal": false,
+    "path": "/showcase/example-repos/add-vue",
     "tags": []
   },
   "/showcase/example-repos/react-nx": {

--- a/docs/map.json
+++ b/docs/map.json
@@ -1053,6 +1053,12 @@
                   "file": "shared/recipes/add-stack/add-astro"
                 },
                 {
+                  "name": "Add a Vue Project",
+                  "id": "add-vue",
+                  "description": "Add a Vue project to your repo",
+                  "file": "shared/recipes/add-stack/add-vue"
+                },
+                {
                   "name": "Powering Up React Development With Nx",
                   "id": "react-nx",
                   "file": "shared/examples/react-nx"

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -180,6 +180,7 @@
       - [Add a Solid Project](/showcase/example-repos/add-solid)
       - [Add a Qwik Project](/showcase/example-repos/add-qwik)
       - [Add an Astro Project](/showcase/example-repos/add-astro)
+      - [Add a Vue Project](/showcase/example-repos/add-vue)
       - [Powering Up React Development With Nx](/showcase/example-repos/react-nx)
       - [Using Apollo GraphQL](/showcase/example-repos/apollo-react)
       - [Using Prisma with NestJS](/showcase/example-repos/nestjs-prisma)


### PR DESCRIPTION
Adds documentation that is related to vue-recipe which can be found: https://github.com/nrwl/nx-recipes/tree/main/vue

Nx-dev preview: https://nx-dev-git-fork-ndcunningham-docs-vue-recipe-example-nrwl.vercel.app/showcase/example-repos/add-vue