### PR TITLE
fix(misc): set the correct dependency range for dotenv in plugins

### DIFF
--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "chalk": "^4.1.0",
-    "dotenv": "~10.0.0",
+    "dotenv": "~16.3.1",
     "fast-glob": "3.2.7",
     "fs-extra": "^11.1.0",
     "tslib": "^2.3.0",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -38,7 +38,7 @@
     "@svgr/webpack": "^8.0.1",
     "chalk": "^4.1.0",
     "copy-webpack-plugin": "^10.2.4",
-    "dotenv": "~10.0.0",
+    "dotenv": "~16.3.1",
     "fs-extra": "^11.1.0",
     "ignore": "^5.0.4",
     "semver": "7.5.3",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@phenomnomnominal/tsquery": "~5.0.1",
-    "dotenv": "~10.0.0",
+    "dotenv": "~16.3.1",
     "fs-extra": "^11.1.0",
     "tslib": "^2.3.0",
     "@nx/devkit": "file:../devkit",

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -37,7 +37,7 @@
     "autoprefixer": "^10.4.9",
     "babel-plugin-transform-async-to-promises": "^0.8.15",
     "chalk": "^4.1.0",
-    "dotenv": "~10.0.0",
+    "dotenv": "~16.3.1",
     "fast-glob": "^3.2.7",
     "postcss": "^8.4.14",
     "rollup": "^2.56.2",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -30,7 +30,7 @@
     "migrations": "./migrations.json"
   },
   "dependencies": {
-    "dotenv": "~10.0.0",
+    "dotenv": "~16.3.1",
     "@phenomnomnominal/tsquery": "~5.0.1",
     "semver": "7.5.3",
     "tslib": "^2.3.0",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@phenomnomnominal/tsquery": "~5.0.1",
     "@swc/helpers": "~0.5.0",
-    "dotenv": "~10.0.0",
+    "dotenv": "~16.3.1",
     "enquirer": "~2.3.6",
     "@nx/devkit": "file:../devkit",
     "@nx/js": "file:../js",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -38,7 +38,7 @@
     "copy-webpack-plugin": "^10.2.4",
     "css-loader": "^6.4.0",
     "css-minimizer-webpack-plugin": "^5.0.0",
-    "dotenv": "~10.0.0",
+    "dotenv": "~16.3.1",
     "fork-ts-checker-webpack-plugin": "7.2.13",
     "ignore": "^5.0.4",
     "less": "4.1.3",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `@nx/dependency-checks` ESLint rule fails due to a version mismatch with the `dotenv` dependency.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `dotenv` dependency version range should match the installed version in the workspace.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
