### PR TITLE
fix(core): use Date.now() everywhere for tasks start and end times to avoid negative durations

### DIFF
--- a/packages/nx/src/tasks-runner/life-cycles/task-profiling-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/task-profiling-life-cycle.ts
@@ -27,7 +27,7 @@ export class TaskProfilingLifeCycle implements LifeCycle {
     }
     for (let t of tasks) {
       this.timings[t.id] = {
-        perfStart: performance.now(),
+        perfStart: Date.now(),
       };
     }
   }
@@ -43,7 +43,7 @@ export class TaskProfilingLifeCycle implements LifeCycle {
       if (tr.task.endTime) {
         this.timings[tr.task.id].perfEnd = tr.task.endTime;
       } else {
-        this.timings[tr.task.id].perfEnd = performance.now();
+        this.timings[tr.task.id].perfEnd = Date.now();
       }
     }
     this.recordTaskCompletions(taskResults, metadata);


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

We use `performance.now` for start time and end time of tasks in the perf lifecycle hook, unless the tasks specify it (which is important for batch mode, when multiple tasks are reported at the same time but with different start and end times). Batch mode tasks report via `Date.now` instead, which can cause negative durations

## Expected Behavior
No negative durations

## Additional info
We decided to move away from `performance.now` here, partially because jest reports start and end time relative to UTC and it would be harder to compute.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Closes #18388