### PR TITLE
docs(nx-plugin): remove typo of duplicate "--project=your-app-name"

### DIFF
--- a/docs/generated/packages/playwright/documents/overview.md
+++ b/docs/generated/packages/playwright/documents/overview.md
@@ -47,7 +47,7 @@ nx g @nx/web:app frontend --e2eTestRunner=playwright
 To generate an E2E project for an existing project, run the following generator
 
 ```shell
-nx g @nx/playwright:configuration --project=your-app-name --project=your-app-name
+nx g @nx/playwright:configuration --project=your-app-name
 ```
 
 Optionally, you can use the `--webServerCommand` and `--webServerAddress` option, to auto setup the [web server option](https://playwright.dev/docs/test-webserver) in the playwright config

--- a/docs/shared/packages/playwright/playwright-plugin.md
+++ b/docs/shared/packages/playwright/playwright-plugin.md
@@ -47,7 +47,7 @@ nx g @nx/web:app frontend --e2eTestRunner=playwright
 To generate an E2E project for an existing project, run the following generator
 
 ```shell
-nx g @nx/playwright:configuration --project=your-app-name --project=your-app-name
+nx g @nx/playwright:configuration --project=your-app-name
 ```
 
 Optionally, you can use the `--webServerCommand` and `--webServerAddress` option, to auto setup the [web server option](https://playwright.dev/docs/test-webserver) in the playwright config


### PR DESCRIPTION
Reviewed https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr ✅ 

## Current Behavior
When viewing documentation on the packages/playwright page, there is a command code snippet with a duplicate option included for "--project=your-app-name" 
https://nx.dev/packages/playwright

<img width="1172" alt="Screenshot 2023-08-11 at 9 07 54 PM" src="https://github.com/nrwl/nx/assets/718718/4ac0fd3b-e1ac-47b2-95d7-528f28ce99e0">


## Expected Behavior
No duplicate option is included in the code snippet when viewing documentation on the packages/playwright page. 

## Related Issue(s)
https://github.com/nrwl/nx/issues/18599

Fixes #18599
https://github.com/nrwl/nx/issues/18599