### PR TITLE
fix(linter): Normalize paths when in getSourceFilePath

### DIFF
--- a/packages/eslint-plugin/src/utils/runtime-lint-utils.spec.ts
+++ b/packages/eslint-plugin/src/utils/runtime-lint-utils.spec.ts
@@ -9,6 +9,7 @@ import {
   DepConstraint,
   findConstraintsFor,
   findTransitiveExternalDependencies,
+  getSourceFilePath,
   hasBannedDependencies,
   hasBannedImport,
   hasNoneOfTheseTags,
@@ -555,6 +556,22 @@ describe('hasNoneOfTheseTags', () => {
     'should return %s when project has tags ["abc"] and requested tags are %s',
     (expected, tags) => {
       expect(hasNoneOfTheseTags(source, tags)).toBe(expected);
+    }
+  );
+});
+
+describe('getSourceFilePath', () => {
+  it.each([
+    ['/root/libs/dev-kit/package.json', '/root'],
+    ['/root/libs/dev-kit/package.json', 'C:\\root'],
+    ['C:\\root\\libs\\dev-kit\\package.json', '/root'],
+    ['C:\\root\\libs\\dev-kit\\package.json', 'C:\\root'],
+  ])(
+    'should return "libs/dev-kit/package.json" when sourceFileName is "%s" and projectPath is "%s"',
+    (sourceFileName, projectPath) => {
+      expect(getSourceFilePath(sourceFileName, projectPath)).toBe(
+        'libs/dev-kit/package.json'
+      );
     }
   );
 });

--- a/packages/eslint-plugin/src/utils/runtime-lint-utils.ts
+++ b/packages/eslint-plugin/src/utils/runtime-lint-utils.ts
@@ -222,8 +222,9 @@ export function onlyLoadChildren(
 }
 
 export function getSourceFilePath(sourceFileName: string, projectPath: string) {
-  const relativePath = sourceFileName.slice(projectPath.length + 1);
-  return normalizePath(relativePath);
+  const normalizedProjectPath = normalizePath(projectPath);
+  const normalizedSourceFileName = normalizePath(sourceFileName);
+  return normalizedSourceFileName.slice(normalizedProjectPath.length + 1);
 }
 
 /**


### PR DESCRIPTION
## Current Behavior
When running the linting rule `@nx/dependency-checks` for a project on a Windows machine, it doesn't fail even if the list of packages is not valid.

The `projectPath` provided to the utility function `getSourceFilePath` in `packages/eslint-plugin/src/utils/runtime-lint-utils.ts` is not normalized:

<img width="966" alt="image" src="https://github.com/nrwl/nx/assets/954509/29cdc7a4-1a63-49ba-8c60-ccfa12bb1275">

## Expected Behavior
The linting rule `@nx/dependency-checks` should work in the same way on Windows or UNIX paths.

## Fixes
To prevent future issues, I decided to make the `getSourceFilePath` compatible with any type of path instead of fixing the `@nx/dependency-checks` code.

Tests are covering that utility function `@nx/dependency-checks`
