### PR TITLE
fix(react): fix remote generation devServerPort

### DIFF
--- a/docs/generated/packages/react/generators/remote.json
+++ b/docs/generated/packages/react/generators/remote.json
@@ -147,7 +147,6 @@
       "devServerPort": {
         "type": "number",
         "description": "The port for the dev server of the remote app.",
-        "default": 4200,
         "x-priority": "important"
       },
       "ssr": {

--- a/e2e/react-core/src/react-module-federation.test.ts
+++ b/e2e/react-core/src/react-module-federation.test.ts
@@ -44,6 +44,11 @@ describe('React Module Federation', () => {
       combinedOutput: expect.stringContaining('Test Suites: 1 passed, 1 total'),
     });
 
+    expect(readPort(shell)).toEqual(4200);
+    expect(readPort(remote1)).toEqual(4201);
+    expect(readPort(remote2)).toEqual(4202);
+    expect(readPort(remote3)).toEqual(4203);
+
     updateFile(
       `apps/${shell}/webpack.config.js`,
       stripIndents`

--- a/packages/react/src/generators/remote/schema.json
+++ b/packages/react/src/generators/remote/schema.json
@@ -153,7 +153,6 @@
     "devServerPort": {
       "type": "number",
       "description": "The port for the dev server of the remote app.",
-      "default": 4200,
       "x-priority": "important"
     },
     "ssr": {


### PR DESCRIPTION
Removed the default 4200 value from the remote generator.

It was being used for all remotes instead of using the calculation.

## Current Behavior
running `nx g react:remote some-app --host=some-host` will always result with the devServerPort being set on `4200`.

## Expected Behavior
running `nx g react:remote some-app --host=some-host` will result with the devServerPort being set on `420x` dependent on the latest port available.