### PR TITLE
docs(angular): add angular v16.2.0 to the version compatibility matrix

### DIFF
--- a/docs/generated/packages/angular/documents/angular-nx-version-matrix.md
+++ b/docs/generated/packages/angular/documents/angular-nx-version-matrix.md
@@ -14,6 +14,7 @@ We provide a recommended version, and it is usually the latest minor version of 
 
 | Angular Version | **Nx Version _(recommended)_** | Nx Version _(range)_                    |
 | --------------- | ------------------------------ | --------------------------------------- |
+| ~16.2.0         | **latest**                     | 16.7.0 <= latest                        |
 | ~16.1.0         | **latest**                     | 16.4.0 <= latest                        |
 | ~16.0.0         | **latest**                     | 16.1.0 <= latest                        |
 | ~15.2.0         | **latest**                     | 15.8.0 <= latest                        |

--- a/docs/shared/packages/angular/angular-nx-version-matrix.md
+++ b/docs/shared/packages/angular/angular-nx-version-matrix.md
@@ -14,6 +14,7 @@ We provide a recommended version, and it is usually the latest minor version of 
 
 | Angular Version | **Nx Version _(recommended)_** | Nx Version _(range)_                    |
 | --------------- | ------------------------------ | --------------------------------------- |
+| ~16.2.0         | **latest**                     | 16.7.0 <= latest                        |
 | ~16.1.0         | **latest**                     | 16.4.0 <= latest                        |
 | ~16.0.0         | **latest**                     | 16.1.0 <= latest                        |
 | ~15.2.0         | **latest**                     | 15.8.0 <= latest                        |


### PR DESCRIPTION
Updated doc: https://nx-dev-git-fork-leosvelperez-docs-add-angular-1620-890f1c-nrwl.vercel.app/packages/angular/documents/angular-nx-version-matrix#nx-and-angular-version-compatibility-matrix

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The Angular and Nx versions compatibility matrix does not have an entry for Angular 16.2.0.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The Angular and Nx versions compatibility matrix should have an entry for Angular 16.2.0.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
