### PR TITLE
fix(nx-dev): fix regex

### DIFF
--- a/typedoc-theme/src/lib/theme.ts
+++ b/typedoc-theme/src/lib/theme.ts
@@ -19,7 +19,7 @@ export default class NxMarkdownTheme extends MarkdownTheme {
     return (
       super
         .render(page, template)
-        .replace(/.md/gi, '')
+        .replace(/\.md/gi, '')
         /**
          * Hack: This is the simplest way to update the urls and make them work
          * in the `/packages/[name]/documents/[index|ngcli_adapter] context.


### PR DESCRIPTION
Fixes a regex that was replacing `readNxJsonFromDisk` with `readNxJsonFrisk`