### PR TITLE
docs(nx-cloud): fix old pricing reference

### DIFF
--- a/docs/shared/concepts/improve-worst-case-ci-times.md
+++ b/docs/shared/concepts/improve-worst-case-ci-times.md
@@ -123,6 +123,6 @@ Because Nx uses distributed computation caching to replay all the tasks back on 
 
 If your repo is starting to grow large enough that CI times are suffering, or if your parallelization strategy is growing too complex to manage effectively, try [setting up Nx Cloud with Distributed Task Execution](/core-features/distribute-task-execution). You can generate a simple workflow for common CI providers with a single command and then customize from there.
 
-Nx Cloud is [free for up to 500 hours](https://nx.app/pricing/) of time saved per month. Most organizations do not exceed the free tier. If you're working on an open source repo, we'll give you a coupon for unlimited free use of Nx Cloud.
+Nx Cloud is [free for up to 300 CI Pipeline Executions](https://nx.app/pricing/) per month. Most organizations do not exceed the free tier. If you're working on an open source repo, we'll give you a coupon for unlimited free use of Nx Cloud.
 
 Organizations that want extra help setting up Nx Cloud or getting the most out of Nx can [sign up for Nx Enterprise](https://nx.app/enterprise/). This package comes with extra support from the Nx team and the option to host Nx Cloud on your own servers.


### PR DESCRIPTION
## Current Behavior
Old pricing model is referenced

## Expected Behavior
New pricing model is referenced
