### PR TITLE
fix(nx-dev): ensure long titles on og images have line breaks

### DIFF
--- a/scripts/documentation/open-graph/generate-images.ts
+++ b/scripts/documentation/open-graph/generate-images.ts
@@ -81,6 +81,9 @@ packages.map((pkg) => {
   });
 });
 
+const TITLE_LINE_HEIGHT = 60;
+const SUB_LINE_HEIGHT = 38;
+
 function createOpenGraphImage(
   backgroundImagePath: string,
   targetFolder: string,
@@ -106,7 +109,10 @@ function createOpenGraphImage(
     context.textAlign = 'center';
     context.textBaseline = 'top';
     context.fillStyle = '#0F172A';
-    context.fillText(title.toUpperCase(), 600, 220);
+    const titleLines = splitLines(context, title.toUpperCase(), 1100);
+    titleLines.forEach((line, index) => {
+      context.fillText(line, 600, 220 + index * TITLE_LINE_HEIGHT);
+    });
 
     context.font = 'normal 32px system-ui';
     context.textAlign = 'center';
@@ -115,7 +121,11 @@ function createOpenGraphImage(
 
     const lines = splitLines(context, content, 1100);
     lines.forEach((line, index) => {
-      context.fillText(line, 600, 310 + index * 55);
+      context.fillText(
+        line,
+        600,
+        310 + index * SUB_LINE_HEIGHT + titleLines.length * TITLE_LINE_HEIGHT
+      );
     });
 
     console.log('Generating: ', `${filename}.jpg`);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Long titles get truncated from both sides

## Expected Behavior
Long titles should have line breaks just like description

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
