### PR TITLE
fix(core): all graph nodes should have targets block, even if its empty

### DIFF
--- a/packages/nx/plugins/package-json-workspaces.spec.ts
+++ b/packages/nx/plugins/package-json-workspaces.spec.ts
@@ -1,0 +1,58 @@
+import * as memfs from 'memfs';
+
+import '../src/utils/testing/mock-fs';
+import { getNxPackageJsonWorkspacesPlugin } from './package-json-workspaces';
+
+describe('nx package.json workspaces plugin', () => {
+  it('should build projects from package.json files', () => {
+    memfs.vol.fromJSON(
+      {
+        'package.json': JSON.stringify({
+          name: 'root',
+          scripts: { echo: 'echo root project' },
+        }),
+        'packages/lib-a/package.json': JSON.stringify({
+          name: 'lib-a',
+          scripts: { test: 'jest' },
+        }),
+      },
+      '/root'
+    );
+
+    const plugin = getNxPackageJsonWorkspacesPlugin('/root');
+
+    // Targets from package.json files are handled outside of `createNodes`,
+    // because they are recognized even if the package.json file is not included
+    // in the package manager workspaces configuration.
+    //
+    // If any project has a package.json file in its root directory, those scripts
+    // are targets regardless of this plugin. As such, all we have to do here is identify
+    // that the package.json represents an Nx project, and `normalizeProjectNodes`
+    // will handle the rest.
+    expect(plugin.createNodes[1]('package.json', null)).toMatchInlineSnapshot(`
+      {
+        "projects": {
+          "root": {
+            "name": "root",
+            "projectType": "library",
+            "root": ".",
+            "sourceRoot": ".",
+          },
+        },
+      }
+    `);
+    expect(plugin.createNodes[1]('packages/lib-a/package.json', null))
+      .toMatchInlineSnapshot(`
+      {
+        "projects": {
+          "lib-a": {
+            "name": "lib-a",
+            "projectType": "library",
+            "root": "packages/lib-a",
+            "sourceRoot": "packages/lib-a",
+          },
+        },
+      }
+    `);
+  });
+});

--- a/packages/nx/plugins/project-json.spec.ts
+++ b/packages/nx/plugins/project-json.spec.ts
@@ -1,0 +1,55 @@
+import * as memfs from 'memfs';
+
+import '../src/utils/testing/mock-fs';
+import { getNxProjectJsonPlugin } from './project-json';
+
+describe('nx project.json plugin', () => {
+  it('should build projects from project.json', () => {
+    memfs.vol.fromJSON(
+      {
+        'project.json': JSON.stringify({
+          name: 'root',
+          targets: { command: 'echo root project' },
+        }),
+        'packages/lib-a/project.json': JSON.stringify({
+          name: 'lib-a',
+          targets: {
+            executor: 'nx:run-commands',
+            options: {},
+          },
+        }),
+      },
+      '/root'
+    );
+
+    const plugin = getNxProjectJsonPlugin('/root');
+    expect(plugin.createNodes[1]('project.json', null)).toMatchInlineSnapshot(`
+      {
+        "projects": {
+          "root": {
+            "name": "root",
+            "root": ".",
+            "targets": {
+              "command": "echo root project",
+            },
+          },
+        },
+      }
+    `);
+    expect(plugin.createNodes[1]('packages/lib-a/project.json', null))
+      .toMatchInlineSnapshot(`
+      {
+        "projects": {
+          "lib-a": {
+            "name": "lib-a",
+            "root": "packages/lib-a",
+            "targets": {
+              "executor": "nx:run-commands",
+              "options": {},
+            },
+          },
+        },
+      }
+    `);
+  });
+});

--- a/packages/nx/src/project-graph/build-nodes/workspace-projects.ts
+++ b/packages/nx/src/project-graph/build-nodes/workspace-projects.ts
@@ -127,13 +127,18 @@ export function normalizeProjectTargets(
   targetDefaults: NxJsonConfiguration['targetDefaults'],
   projectName: string
 ): Record<string, TargetConfiguration> {
-  const targets = project.targets;
+  // Any node on the graph will have a targets object, it just may be empty
+  const targets = project.targets ?? {};
+
   for (const target in targets) {
+    // We need to know the executor for use in readTargetDefaultsForTarget,
+    // but we haven't resolved the `command` syntactic sugar yet.
     const executor =
       targets[target].executor ?? targets[target].command
         ? 'nx:run-commands'
         : null;
 
+    // Allows things like { targetDefaults: { build: { command: tsc } } }
     const defaults = resolveCommandSyntacticSugar(
       readTargetDefaultsForTarget(target, targetDefaults, executor),
       `targetDefaults:${target}`


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
After #18032 project nodes on the graph may not have a `targets` block. We've always supported projects having undefined targets in generators when a project is defined by package.json or similar, but once they are in the graph they have generally had the targets block. This was a result of the `mergePluginTargets` function which assigned targets from nx plugin's `registerProjectTargets` method.

In #18032 we removed that method entirely, and didn't notice that it was essentially doing `node.data.targets ??= {}`.

In our own code, this resulted in `nx graph` failing when it tried to build the task graphs for the UI to display but it would not be unrealistic to say that there would be other cases that this would crop up in the Nx codebase or user's custom scripts.

## Expected Behavior
Project nodes have a `targets` block, even if it may be empty and all `createNodes` functions returned undefined targets.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
