### PR TITLE
fix(core): project inference plugins should be ran when reading project configuration

### DIFF
--- a/packages/nx/src/config/workspaces.ts
+++ b/packages/nx/src/config/workspaces.ts
@@ -1,6 +1,7 @@
 import { dirname, join } from 'path';
 import { workspaceRoot } from '../utils/workspace-root';
 import { readJsonFile } from '../utils/fileutils';
+import { getNxRequirePaths } from '../utils/installation-directory';
 import { loadNxPlugins, loadNxPluginsSync } from '../utils/nx-plugin';
 
 import type { NxJsonConfiguration } from './nx-json';
@@ -43,7 +44,11 @@ export class Workspaces {
       buildProjectsConfigurationsFromProjectPathsAndPlugins(
         nxJson,
         projectPaths,
-        loadNxPluginsSync(),
+        loadNxPluginsSync(
+          nxJson.plugins,
+          getNxRequirePaths(this.root),
+          this.root
+        ),
         this.root
       ).projects;
     if (
@@ -59,10 +64,7 @@ export class Workspaces {
     }
     this.cachedProjectsConfig = {
       version: 2,
-      projects: this.mergeTargetDefaultsIntoProjectDescriptions(
-        projectsConfigurations,
-        nxJson
-      ),
+      projects: projectsConfigurations,
     };
     return this.cachedProjectsConfig;
   }

--- a/packages/nx/src/utils/nx-plugin.ts
+++ b/packages/nx/src/utils/nx-plugin.ts
@@ -209,7 +209,7 @@ function loadNxPluginSync(moduleName: string, paths: string[], root: string) {
  * @deprecated Use loadNxPlugins instead.
  */
 export function loadNxPluginsSync(
-  plugins?: string[],
+  plugins: string[],
   paths = getNxRequirePaths(),
   root = workspaceRoot
 ): (NxPluginV2 & Pick<NxPluginV1, 'processProjectGraph'>)[] {
@@ -240,7 +240,7 @@ export function loadNxPluginsSync(
 }
 
 export async function loadNxPlugins(
-  plugins?: string[],
+  plugins: string[],
   paths = getNxRequirePaths(),
   root = workspaceRoot
 ): Promise<(NxPluginV2 & Pick<NxPluginV1, 'processProjectGraph'>)[]> {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
One spot isn't loading plugins properly

## Expected Behavior
Plugins are read when reading project configuration

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
