### PR TITLE
docs(core): update nx.json schema

### DIFF
--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -6,7 +6,8 @@
   "properties": {
     "implicitDependencies": {
       "type": "object",
-      "description": "Map of files to projects that implicitly depend on them."
+      "description": "Map of files to projects that implicitly depend on them.",
+      "deprecated": "Use named inputs instead.  See https://nx.dev/deprecated/global-implicit-dependencies"
     },
     "affected": {
       "type": "object",
@@ -199,7 +200,7 @@
         },
         "defaultCollection": {
           "type": "string",
-          "description": "The default schematics collection to use."
+          "description": "The default generator collection to use."
         }
       }
     },


### PR DESCRIPTION
Updates the nx.json schema

- implicitDependencies should be marked as deprecated
- defaultCollection should use generator instead of schematic in the description