### PR TITLE
fix(core): handle symlinks on debian for watch events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,6 +1353,7 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "once_cell",
+ "os_type",
  "rayon",
  "regex",
  "swc_common",
@@ -1377,6 +1378,15 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "os_type"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e24d44c0eea30167516ed8f6daca4b5e3eebcde1bde1e4e6e08b809fb02c7ba5"
+dependencies = [
+ "regex",
+]
 
 [[package]]
 name = "overload"

--- a/packages/nx/Cargo.toml
+++ b/packages/nx/Cargo.toml
@@ -14,6 +14,7 @@ ignore = '0.4'
 ignore-files = "1.3.0"
 itertools = "0.10.5"
 once_cell = "1.18.0"
+os_type = "2.6.0"
 napi = { version = '2.12.6', default-features = false, features = ['anyhow', 'napi4', 'tokio_rt'] }
 napi-derive = '2.9.3'
 regex = "1.9.1"

--- a/packages/nx/src/native/watch/types.rs
+++ b/packages/nx/src/native/watch/types.rs
@@ -4,6 +4,8 @@ use std::path::PathBuf;
 use tracing::trace;
 use watchexec_events::{Event, Tag};
 
+use crate::native::watch::utils::transform_event;
+
 #[napi(string_enum)]
 #[derive(Debug)]
 /// Newly created files will have the `update` EventType as well.
@@ -52,6 +54,9 @@ pub(super) struct WatchEventInternal {
 
 impl From<&Event> for WatchEventInternal {
     fn from(value: &Event) -> Self {
+        let transformed = transform_event(value);
+        let value = transformed.as_ref().unwrap_or(value);
+
         let path = value.paths().next().expect("there should always be a path");
 
         let event_kind = value

--- a/packages/nx/src/native/watch/utils.rs
+++ b/packages/nx/src/native/watch/utils.rs
@@ -1,6 +1,10 @@
 use ignore::WalkBuilder;
 use ignore_files::IgnoreFile;
-use std::path::PathBuf;
+use once_cell::sync::Lazy;
+use os_type::{OSInformation, OSType};
+use std::{fs, path::PathBuf};
+use tracing::trace;
+use watchexec_events::{Event, Tag};
 
 pub(super) fn get_ignore_files<T: AsRef<str>>(root: T) -> Vec<IgnoreFile> {
     let root = root.as_ref();
@@ -45,3 +49,34 @@ pub(super) fn get_ignore_files<T: AsRef<str>>(root: T) -> Vec<IgnoreFile> {
 //         .map(|result| result.path().into())
 //         .collect()
 // }
+
+static OS_PLATFORM: Lazy<OSInformation> = Lazy::new(os_type::current_platform);
+
+pub(super) fn transform_event(watch_event: &Event) -> Option<Event> {
+    if OS_PLATFORM.os_type == OSType::Debian {
+        let tags = watch_event
+            .tags
+            .clone()
+            .into_iter()
+            .map(|tag| match tag {
+                Tag::Path { path, file_type } => {
+                    trace!("canonicalizing {:?}", path);
+                    let real_path = fs::canonicalize(&path).unwrap_or(path);
+                    trace!("real path {:?}", real_path);
+                    Tag::Path {
+                        path: real_path,
+                        file_type,
+                    }
+                }
+                _ => tag,
+            })
+            .collect();
+
+        Some(Event {
+            tags,
+            metadata: watch_event.metadata.clone(),
+        })
+    } else {
+        None
+    }
+}

--- a/packages/nx/src/native/watch/watch_filterer.rs
+++ b/packages/nx/src/native/watch/watch_filterer.rs
@@ -6,6 +6,8 @@ use watchexec_events::filekind::{CreateKind, FileEventKind, ModifyKind, RemoveKi
 use watchexec_events::{Event, FileType, Priority, Source, Tag};
 use watchexec_filterer_ignore::IgnoreFilterer;
 
+use crate::native::watch::utils::transform_event;
+
 #[derive(Debug)]
 pub struct WatchFilterer {
     pub inner: IgnoreFilterer,
@@ -13,7 +15,10 @@ pub struct WatchFilterer {
 
 /// Used to filter out events that that come from watchexec
 impl Filterer for WatchFilterer {
-    fn check_event(&self, event: &Event, priority: Priority) -> Result<bool, RuntimeError> {
+    fn check_event(&self, watch_event: &Event, priority: Priority) -> Result<bool, RuntimeError> {
+        let transformed = transform_event(watch_event);
+        let event = transformed.as_ref().unwrap_or(watch_event);
+
         if !self.inner.check_event(event, priority)? {
             return Ok(false);
         }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When running a yarn/pnpm workspace dependant libraries are symlinked in node_modules. On debian, when watch events are triggered from these dependent libraries, the symlink path is used (ie, `workspace/pkgs/a/node_modules/pkgs/b/lib.ts`) instead of their real path (`workspace/pkgs/b/lib.ts`). Because we implicity ignore all events from node_modules, these events never get pass the filter and we are never notified. 

## Expected Behavior
Paths are canonicalize to their real paths (only on debian)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18218
