### PR TITLE
chore(devkit): move all internal nx imports to requireNx

### DIFF
--- a/packages/devkit/src/executors/parse-target-string.ts
+++ b/packages/devkit/src/executors/parse-target-string.ts
@@ -1,10 +1,11 @@
 import type { Target } from 'nx/src/command-line/run/run';
 import type { ProjectGraph } from 'nx/src/config/project-graph';
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { splitTarget } from 'nx/src/utils/split-target';
 import { requireNx } from '../../nx';
 
-const { readCachedProjectGraph } = requireNx();
+let { readCachedProjectGraph, splitTarget } = requireNx();
+
+// TODO: Remove this in Nx 18 when Nx 16.7.0 is no longer supported
+splitTarget = splitTarget ?? require('nx/src/utils/split-target').splitTarget;
 
 /**
  * @deprecated(v17) A project graph should be passed to parseTargetString for best accuracy.

--- a/packages/devkit/src/executors/read-target-options.ts
+++ b/packages/devkit/src/executors/read-target-options.ts
@@ -1,12 +1,19 @@
 import type { Target } from 'nx/src/command-line/run/run';
 import type { ExecutorContext } from 'nx/src/config/misc-interfaces';
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { combineOptionsForExecutor } from 'nx/src/utils/params';
 import { requireNx } from '../../nx';
 import { relative } from 'path';
 
-const { Workspaces, getExecutorInformation, calculateDefaultProjectName } =
-  requireNx();
+let {
+  Workspaces,
+  getExecutorInformation,
+  calculateDefaultProjectName,
+  combineOptionsForExecutor,
+} = requireNx();
+
+// TODO: Remove this in Nx 18 when Nx 16.7.0 is no longer supported
+combineOptionsForExecutor =
+  combineOptionsForExecutor ??
+  require('nx/src/utils/params').combineOptionsForExecutor;
 
 /**
  * Reads and combines options for a given target.

--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -1,11 +1,13 @@
 import type { Tree } from 'nx/src/generators/tree';
 import * as path from 'path';
 import type * as Prettier from 'prettier';
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { sortObjectByKeys } from 'nx/src/utils/object-sort';
 import { requireNx } from '../../nx';
 
-const { updateJson, readJson } = requireNx();
+let { updateJson, readJson, sortObjectByKeys } = requireNx();
+
+// TODO: Remove this in Nx 18 when Nx 16.7.0 is no longer supported
+sortObjectByKeys =
+  sortObjectByKeys ?? require('nx/src/utils/object-sort').sortObjectByKeys;
 
 /**
  * Formats all the created or updated files using Prettier

--- a/packages/devkit/src/utils/get-workspace-layout.spec.ts
+++ b/packages/devkit/src/utils/get-workspace-layout.spec.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @nx/enforce-module-boundaries
-import { createTreeWithEmptyWorkspace } from 'nx/src/generators/testing-utils/create-tree-with-empty-workspace';
+import { createTreeWithEmptyWorkspace } from 'nx/src/devkit-testing-exports';
 import { getWorkspaceLayout } from './get-workspace-layout';
 
 describe('getWorkspaceLayout', () => {

--- a/packages/devkit/src/utils/invoke-nx-generator.ts
+++ b/packages/devkit/src/utils/invoke-nx-generator.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { stripIndent } from 'nx/src/utils/logger';
 import type {
   FileChange,
   Tree,
@@ -13,7 +11,10 @@ import { join, relative } from 'path';
 import type { Mode } from 'fs';
 import { requireNx } from '../../nx';
 
-const { logger } = requireNx();
+let { logger, stripIndent } = requireNx();
+
+// TODO: Remove this in Nx 18 when Nx 16.7.0 is no longer supported
+stripIndent = stripIndent ?? require('nx/src/utils/logger').stripIndent;
 
 class RunCallbackTask {
   constructor(private callback: GeneratorCallback) {}

--- a/packages/devkit/src/utils/module-federation/secondary-entry-points.ts
+++ b/packages/devkit/src/utils/module-federation/secondary-entry-points.ts
@@ -3,11 +3,16 @@ import { WorkspaceLibrarySecondaryEntryPoint } from './models';
 import { dirname, join, relative } from 'path';
 import { existsSync, lstatSync, readdirSync } from 'fs';
 
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { PackageJson, readModulePackageJson } from 'nx/src/utils/package-json';
+import type { PackageJson } from 'nx/src/utils/package-json';
 import { requireNx } from '../../../nx';
 
-const { readJsonFile, joinPathFragments, workspaceRoot } = requireNx();
+let { readJsonFile, joinPathFragments, workspaceRoot, readModulePackageJson } =
+  requireNx();
+
+// TODO: Remove this in Nx 18 when Nx 16.7.0 is no longer supported
+readModulePackageJson =
+  readModulePackageJson ??
+  require('nx/src/utils/package-json').readModulePackageJson;
 
 export function collectWorkspaceLibrarySecondaryEntryPoints(
   library: WorkspaceLibrary,

--- a/packages/nx/src/adapter/compat.ts
+++ b/packages/nx/src/adapter/compat.ts
@@ -1,4 +1,3 @@
-import { logger } from '../utils/logger';
 import {
   createProjectGraphAsync,
   readProjectsConfigurationFromProjectGraph,

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -8,3 +8,8 @@ export { getExecutorInformation } from './command-line/run/executor-utils';
 export { readNxJson as readNxJsonFromDisk } from './config/nx-json';
 export { calculateDefaultProjectName } from './config/calculate-default-project-name';
 export { retrieveProjectConfigurationsWithAngularProjects } from './project-graph/utils/retrieve-workspace-files';
+export { splitTarget } from './utils/split-target';
+export { combineOptionsForExecutor } from './utils/params';
+export { sortObjectByKeys } from './utils/object-sort';
+export { stripIndent } from './utils/logger';
+export { readModulePackageJson } from './utils/package-json';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Some imports from devkit to nx are still deep imports which means those paths cannot change.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Imports from devkit to nx are now all through the dedicated barrel files so that underlying paths can change.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
