### PR TITLE
fix(core): set consistent working directory when calculating runtime hash inputs

### DIFF
--- a/packages/nx/src/hasher/task-hasher.ts
+++ b/packages/nx/src/hasher/task-hasher.ts
@@ -743,6 +743,7 @@ class TaskHasherImpl {
           runtime,
           {
             windowsHide: true,
+            cwd: workspaceRoot,
           },
           (err, stdout, stderr) => {
             if (err) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Runtime hash inputs inherit the parent process's current working directory. This can cause them to fail if they utilize any relative paths.

Consider for instance, a runtime input that consists of `node ./tools/calculate-local-env.js`

If you are cd'd into a project's root instead of the workspace root, this would fail since the path is meant to be relative to the workspace root.

Here's an example in this repo, if adding a runtime input of `cat README.md` to the lint target and running in the `packages` directory:
![image](https://github.com/nrwl/nx/assets/6933928/0aeeae3e-d7db-4dbb-aeca-3f70eca88bd0)

It's also worth noting that this behavior also is inconsistent between if the daemon is enabled or disabled, since when hashing on the daemon the cwd is **_already_** workspaceRoot, since the daemon's cwd is workspaceRoot


## Expected Behavior
Runtime inputs behave in a consistent manner

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
