### PR TITLE
feat(core): support prettier v3 as a formatter

### DIFF
--- a/packages/nx/src/command-line/format/format.ts
+++ b/packages/nx/src/command-line/format/format.ts
@@ -12,6 +12,7 @@ import * as yargs from 'yargs';
 
 import * as prettier from 'prettier';
 import { sortObjectByKeys } from '../../utils/object-sort';
+import { readModulePackageJson } from '../../utils/package-json';
 import {
   getRootTsConfigFileName,
   getRootTsConfigPath,
@@ -22,8 +23,9 @@ import { readNxJson } from '../../config/configuration';
 import { ProjectGraph } from '../../config/project-graph';
 import { chunkify } from '../../utils/chunkify';
 import { allFileData } from '../../utils/all-file-data';
+import { gte } from 'semver';
 
-const PRETTIER_PATH = require.resolve('prettier/bin-prettier');
+const PRETTIER_PATH = getPrettierPath();
 
 export async function format(
   command: 'check' | 'write',
@@ -201,4 +203,12 @@ function sortTsConfig() {
   } catch (e) {
     // catch noop
   }
+}
+
+function getPrettierPath() {
+  const prettierVersion = readModulePackageJson('prettier').packageJson.version;
+  if (gte(prettierVersion, '3.0.0')) {
+    return require.resolve('prettier/bin/prettier.cjs');
+  }
+  return require.resolve('prettier/bin-prettier');
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Nx crashes when used with prettier v3.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Nx works with all prettier versions up to the newly released v3.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17990
