### PR TITLE
feat(repo): add pm version field to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -53,6 +53,13 @@ body:
       label: Failure Logs
       description: Please include any relevant log snippets or files here. This will be automatically formatted into code, so no need for backticks.
       render: shell
+  - type: input
+    id: repo
+    attributes:
+      label: Package Manager Version
+      description: |
+        If `nx report` doesn't work, please provide the name and the version of your package manager.
+        You can get version information by running `yarn --version`, `pnpm --version` or `npm --version`, depending on the package manager used.
   - type: checkboxes
     id: os
     attributes:


### PR DESCRIPTION
When `nx report` fails, we don't know which package manager (or version) the user is using. This is often essential to debugging why things are not working.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
