### PR TITLE
fix(core): apply target defaults properly for executors defaults

### DIFF
--- a/packages/nx/src/project-graph/build-nodes/workspace-projects.spec.ts
+++ b/packages/nx/src/project-graph/build-nodes/workspace-projects.spec.ts
@@ -312,6 +312,32 @@ describe('workspace-projects', () => {
       ).toEqual({ a: 'a', b: 'my/project' });
     });
 
+    it('should merge options when targets use executors with defaults', () => {
+      expect(
+        normalizeProjectTargets(
+          {
+            root: 'my/project',
+            targets: {
+              build: {
+                executor: '@nx/jest:jest',
+                options: {
+                  a: 'a',
+                },
+              },
+            },
+          },
+          {
+            '@nx/jest:jest': {
+              options: {
+                b: 'b',
+              },
+            },
+          },
+          'build'
+        ).build.options
+      ).toEqual({ a: 'a', b: 'b' });
+    });
+
     it('should not merge options when targets use different executors', () => {
       expect(
         normalizeProjectTargets(

--- a/packages/nx/src/project-graph/build-nodes/workspace-projects.ts
+++ b/packages/nx/src/project-graph/build-nodes/workspace-projects.ts
@@ -134,9 +134,8 @@ export function normalizeProjectTargets(
     // We need to know the executor for use in readTargetDefaultsForTarget,
     // but we haven't resolved the `command` syntactic sugar yet.
     const executor =
-      targets[target].executor ?? targets[target].command
-        ? 'nx:run-commands'
-        : null;
+      targets[target].executor ??
+      (targets[target].command ? 'nx:run-commands' : null);
 
     // Allows things like { targetDefaults: { build: { command: tsc } } }
     const defaults = resolveCommandSyntacticSugar(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Target defaults setup like the following are not applied:

```

  "targetDefaults": {
    "@nx/jest:jest": {
      "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"],
      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
      "options": {
        "jestConfig": "{projectRoot}/jest.config.ts",
        "passWithNoTests": true
      }
    },
 ```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Target defaults like the above are applied

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/18650
