### PR TITLE
docs(core): remove references to --all for run-many

### DIFF
--- a/docs/generated/cli/affected.md
+++ b/docs/generated/cli/affected.md
@@ -29,12 +29,6 @@ Run tests in parallel:
  nx affected -t test --parallel=5
 ```
 
-Run the test target for all projects:
-
-```shell
- nx affected -t test --all
-```
-
 Run lint, test, and build targets for affected projects. Requires Nx v15.4+:
 
 ```shell

--- a/docs/generated/cli/run-many.md
+++ b/docs/generated/cli/run-many.md
@@ -68,7 +68,7 @@ Test all projects with a `type:feature` or `type:ui` tag:
 Run lint, test, and build targets for all projects. Requires Nx v15.4+:
 
 ```shell
- nx run-many --targets=lint,test,build --all
+ nx run-many --targets=lint,test,build
 ```
 
 ## Options
@@ -79,7 +79,7 @@ Type: `boolean`
 
 Default: `true`
 
-[deprecated] Run the target on all projects in the workspace
+[deprecated] `run-many` runs all targets on all projects in the workspace if no projects are provided. This option is no longer required.
 
 ### configuration
 

--- a/docs/generated/packages/nx/documents/affected.md
+++ b/docs/generated/packages/nx/documents/affected.md
@@ -29,12 +29,6 @@ Run tests in parallel:
  nx affected -t test --parallel=5
 ```
 
-Run the test target for all projects:
-
-```shell
- nx affected -t test --all
-```
-
 Run lint, test, and build targets for affected projects. Requires Nx v15.4+:
 
 ```shell

--- a/docs/generated/packages/nx/documents/run-many.md
+++ b/docs/generated/packages/nx/documents/run-many.md
@@ -68,7 +68,7 @@ Test all projects with a `type:feature` or `type:ui` tag:
 Run lint, test, and build targets for all projects. Requires Nx v15.4+:
 
 ```shell
- nx run-many --targets=lint,test,build --all
+ nx run-many --targets=lint,test,build
 ```
 
 ## Options
@@ -79,7 +79,7 @@ Type: `boolean`
 
 Default: `true`
 
-[deprecated] Run the target on all projects in the workspace
+[deprecated] `run-many` runs all targets on all projects in the workspace if no projects are provided. This option is no longer required.
 
 ### configuration
 

--- a/docs/nx-cloud/reference/config.md
+++ b/docs/nx-cloud/reference/config.md
@@ -25,7 +25,7 @@ Only operations listed in `cacheableOperations` can be cached using Nx Cloud and
 By default, Nx Cloud requests will time out after 10 seconds. `NX_CLOUD_NO_TIMEOUTS` disables the timeout.
 
 ```shell
-NX_CLOUD_NO_TIMEOUTS=true nx run-many -t build --all
+NX_CLOUD_NO_TIMEOUTS=true nx run-many -t build
 ```
 
 ## Logging

--- a/docs/shared/mental-model.md
+++ b/docs/shared/mental-model.md
@@ -122,7 +122,7 @@ When you run `nx run-many -t test -p app1 lib`, you are telling Nx to do the sam
 tasks `app1:test`
 and `lib:test`.
 
-When you run `nx run-many -t test --all`, you are telling Nx to do this for all the projects.
+When you run `nx run-many -t test`, you are telling Nx to do this for all the projects.
 
 As your workspace grows, retesting all projects becomes too slow. To address this Nx implements code change analysis to
 get the min set of projects that need to be retested. How does it work?

--- a/docs/shared/reference/nx-json.md
+++ b/docs/shared/reference/nx-json.md
@@ -213,7 +213,7 @@ pass `--buildable=true` when creating new libraries.
 > A task is an invocation of a target.
 
 Tasks runners are invoked when you run `nx test`, `nx build`, `nx run-many`, `nx affected`, and so on. The tasks runner
-named "default" is used by default. Specify a different one like this `nx run-many -t build --all --runner=another`.
+named "default" is used by default. Specify a different one like this `nx run-many -t build --runner=another`.
 
 Tasks runners can accept different options. The following are the options supported
 by `"nx/tasks-runners/default"` and `"nx-cloud"`.

--- a/e2e/nx-run/src/run.test.ts
+++ b/e2e/nx-run/src/run.test.ts
@@ -206,7 +206,7 @@ describe('Nx Running Tests', () => {
         return c;
       });
 
-      let withoutBail = runCLI(`run-many --target=error --all --parallel=1`, {
+      let withoutBail = runCLI(`run-many --target=error --parallel=1`, {
         silenceError: true,
       })
         .split('\n')
@@ -217,12 +217,9 @@ describe('Nx Running Tests', () => {
       expect(withoutBail).toContain(`- ${myapp1}:error`);
       expect(withoutBail).toContain(`- ${myapp2}:error`);
 
-      let withBail = runCLI(
-        `run-many --target=error --all --parallel=1 --nx-bail`,
-        {
-          silenceError: true,
-        }
-      )
+      let withBail = runCLI(`run-many --target=error --parallel=1 --nx-bail`, {
+        silenceError: true,
+      })
         .split('\n')
         .map((r) => r.trim())
         .filter((r) => r);

--- a/e2e/web/src/web.test.ts
+++ b/e2e/web/src/web.test.ts
@@ -391,7 +391,7 @@ describe('CLI - Environment Variables', () => {
     updateFile(main2, `${newCode2}\n${content2}`);
 
     runCLI(
-      `run-many --target build --all --outputHashing=none --optimization=false`,
+      `run-many --target build --outputHashing=none --optimization=false`,
       {
         env: {
           ...process.env,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://nx.dev",
   "private": true,
   "scripts": {
-    "build": "nx run-many --target build --all --parallel 8 --exclude nx-dev,typedoc-theme",
+    "build": "nx run-many --target build --parallel 8 --exclude nx-dev,typedoc-theme",
     "commit": "czg",
     "check-commit": "node ./scripts/commit-lint.js",
     "check-format": "nx format:check --all",

--- a/packages/nx/src/command-line/examples.ts
+++ b/packages/nx/src/command-line/examples.ts
@@ -41,10 +41,6 @@ export const examples: Record<string, Example[]> = {
       description: 'Run tests in parallel',
     },
     {
-      command: 'affected -t test --all',
-      description: 'Run the test target for all projects',
-    },
-    {
       command: 'affected -t lint test build',
       description:
         'Run lint, test, and build targets for affected projects. Requires Nx v15.4+',
@@ -79,10 +75,6 @@ export const examples: Record<string, Example[]> = {
       description: 'Run tests in parallel',
     },
     {
-      command: 'affected:test --all',
-      description: 'Run the test target for all projects',
-    },
-    {
       command: 'affected:test --files=libs/mylib/src/index.ts',
       description:
         'Run tests for all the projects affected by changing the index.ts file',
@@ -102,10 +94,6 @@ export const examples: Record<string, Example[]> = {
     {
       command: 'affected:build --parallel=5',
       description: 'Run build in parallel',
-    },
-    {
-      command: 'affected:build --all',
-      description: 'Run the build target for all projects',
     },
     {
       command: 'affected:build --files=libs/mylib/src/index.ts',
@@ -129,10 +117,6 @@ export const examples: Record<string, Example[]> = {
       description: 'Run tests in parallel',
     },
     {
-      command: 'affected:e2e --all',
-      description: 'Run the test target for all projects',
-    },
-    {
       command: 'affected:e2e --files=libs/mylib/src/index.ts',
       description:
         'Run tests for all the projects affected by changing the index.ts file',
@@ -152,10 +136,6 @@ export const examples: Record<string, Example[]> = {
     {
       command: 'affected:lint --parallel=5',
       description: 'Run lint in parallel',
-    },
-    {
-      command: 'affected:lint --all',
-      description: 'Run the lint target for all projects',
     },
     {
       command: 'affected:lint --files=libs/mylib/src/index.ts',
@@ -293,7 +273,7 @@ export const examples: Record<string, Example[]> = {
       description: 'Test all projects with a `type:feature` or `type:ui` tag',
     },
     {
-      command: 'run-many --targets=lint,test,build --all',
+      command: 'run-many --targets=lint,test,build',
       description:
         'Run lint, test, and build targets for all projects. Requires Nx v15.4+',
     },

--- a/packages/nx/src/command-line/yargs-utils/shared-options.ts
+++ b/packages/nx/src/command-line/yargs-utils/shared-options.ts
@@ -161,7 +161,8 @@ export function withRunManyOptions(yargs: Argv) {
         'Projects to run. (comma/space delimited project names and/or patterns)',
     })
     .option('all', {
-      describe: '[deprecated] Run the target on all projects in the workspace',
+      describe:
+        '[deprecated] `run-many` runs all targets on all projects in the workspace if no projects are provided. This option is no longer required.',
       type: 'boolean',
       default: true,
     });

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 rm -rf build
-nx run-many --target=build --all --parallel
+nx run-many --target=build --parallel


### PR DESCRIPTION
## Current Behavior

- `--all` for `run-many` is marked as deprecated with no explanation of an alternative
- Examples still reference the `--all` CLI flag for `run-many`
- Repo scripts still use `--all`
- e2e tests still use `--all`

## Expected Behavior
- `--all` for `run-many` is documented as being default behavior without the flag now
- Examples do not reference the `--all` CLI flag for `run-many`
- Repo scripts do not use `--all`
- e2e tests do not use `--all`
