### PR TITLE
fix(misc): don't interpolate arg as `undefined`

### DIFF
--- a/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
@@ -179,6 +179,34 @@ describe('Run Commands', () => {
         )
       ).toEqual('echo one -a=b');
     });
+
+    it("shouldn't add literal `undefined` if arg is not provided", () => {
+      expect(
+        interpolateArgsIntoCommand(
+          'echo {args.someValue}',
+          {
+            parsedArgs: {},
+            __unparsed__: [],
+          },
+          false
+        )
+      ).not.toContain('undefined');
+    });
+
+    it('should interpolate provided values', () => {
+      expect(
+        interpolateArgsIntoCommand(
+          'echo {args.someValue}',
+          {
+            parsedArgs: {
+              someValue: '"hello world"',
+            },
+            __unparsed__: [],
+          },
+          false
+        )
+      ).toEqual('echo "hello world"');
+    });
   });
 
   describe('--color', () => {

--- a/packages/nx/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.ts
@@ -291,12 +291,14 @@ function processEnv(color: boolean, cwd: string) {
 
 export function interpolateArgsIntoCommand(
   command: string,
-  opts: NormalizedRunCommandsOptions,
+  opts: Pick<NormalizedRunCommandsOptions, 'parsedArgs' | '__unparsed__'>,
   forwardAllArgs: boolean
 ) {
   if (command.indexOf('{args.') > -1) {
     const regex = /{args\.([^}]+)}/g;
-    return command.replace(regex, (_, group: string) => opts.parsedArgs[group]);
+    return command.replace(regex, (_, group: string) =>
+      opts.parsedArgs[group] !== undefined ? opts.parsedArgs[group] : ''
+    );
   } else if (forwardAllArgs) {
     return `${command}${
       opts.__unparsed__.length > 0 ? ' ' + opts.__unparsed__.join(' ') : ''


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
If a command in run-commands specifies `{args.value}` and `--value` is not provided, we interpolate a literal `undefined` value in, which seems really unexpected.

## Expected Behavior
Args with no value are replaced with an empty string

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #16166
