### PR TITLE
fix(core): use existing version when calling "yarn set version"

### DIFF
--- a/packages/create-nx-workspace/src/utils/package-manager.ts
+++ b/packages/create-nx-workspace/src/utils/package-manager.ts
@@ -38,17 +38,15 @@ export function getPackageManagerCommand(
   exec: string;
   preInstall?: string;
 } {
-  const [pmMajor, pmMinor] =
-    getPackageManagerVersion(packageManager).split('.');
+  const pmVersion = getPackageManagerVersion(packageManager);
+  const [pmMajor, pmMinor] = pmVersion.split('.');
 
   switch (packageManager) {
     case 'yarn':
       const useBerry = +pmMajor >= 2;
       const installCommand = 'yarn install --silent';
       return {
-        preInstall: useBerry
-          ? 'yarn set version stable'
-          : 'yarn set version classic',
+        preInstall: `yarn set version ${pmVersion}`,
         install: useBerry
           ? installCommand
           : `${installCommand} --ignore-scripts`,

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -65,9 +65,7 @@ export function getPackageManagerCommand(
       const useBerry = gte(yarnVersion, '2.0.0');
 
       return {
-        preInstall: useBerry
-          ? 'yarn set version stable'
-          : 'yarn set version classic',
+        preInstall: `yarn set version ${yarnVersion}`,
         install: 'yarn',
         ciInstall: useBerry
           ? 'yarn install --immutable'


### PR DESCRIPTION


## Current Behavior
Package manager's `preInstall` command attempts to always install the latest classic/berry version

## Expected Behavior
Package manager's `preInstall` command should use the detected version

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
