### PR TITLE
fix(core): ensure preinstall is only run once on repo

### DIFF
--- a/packages/devkit/src/tasks/install-packages-task.ts
+++ b/packages/devkit/src/tasks/install-packages-task.ts
@@ -4,7 +4,6 @@ import { requireNx } from '../../nx';
 
 import type { Tree } from 'nx/src/generators/tree';
 import type { PackageManager } from 'nx/src/utils/package-manager';
-import { existsSync } from 'fs';
 const { detectPackageManager, getPackageManagerCommand, joinPathFragments } =
   requireNx();
 
@@ -43,11 +42,6 @@ export function installPackagesTask(
       cwd: join(tree.root, cwd),
       stdio: process.env.NX_GENERATE_QUIET === 'true' ? 'ignore' : 'inherit',
     };
-    // only run preinstall if install hasn't been run yet
-    // this only happens during CNW when preset is adding its dependencies
-    if (pmc.preInstall && !existsSync(joinPathFragments(cwd, 'node_modules'))) {
-      execSync(pmc.preInstall, execSyncOptions);
-    }
     execSync(pmc.install, execSyncOptions);
   }
 }

--- a/packages/devkit/src/tasks/install-packages-task.ts
+++ b/packages/devkit/src/tasks/install-packages-task.ts
@@ -4,6 +4,7 @@ import { requireNx } from '../../nx';
 
 import type { Tree } from 'nx/src/generators/tree';
 import type { PackageManager } from 'nx/src/utils/package-manager';
+import { existsSync } from 'fs';
 const { detectPackageManager, getPackageManagerCommand, joinPathFragments } =
   requireNx();
 
@@ -42,7 +43,9 @@ export function installPackagesTask(
       cwd: join(tree.root, cwd),
       stdio: process.env.NX_GENERATE_QUIET === 'true' ? 'ignore' : 'inherit',
     };
-    if (pmc.preInstall) {
+    // only run preinstall if install hasn't been run yet
+    // this only happens during CNW when preset is adding its dependencies
+    if (pmc.preInstall && !existsSync(joinPathFragments(cwd, 'node_modules'))) {
       execSync(pmc.preInstall, execSyncOptions);
     }
     execSync(pmc.install, execSyncOptions);

--- a/packages/workspace/src/generators/new/new.ts
+++ b/packages/workspace/src/generators/new/new.ts
@@ -1,6 +1,8 @@
 import {
   addDependenciesToPackageJson,
+  getPackageManagerCommand,
   installPackagesTask,
+  joinPathFragments,
   names,
   PackageManager,
   Tree,
@@ -11,6 +13,7 @@ import { Preset } from '../utils/presets';
 import { Linter } from '../../utils/lint';
 import { generateWorkspaceFiles } from './generate-workspace-files';
 import { addPresetDependencies, generatePreset } from './generate-preset';
+import { execSync } from 'child_process';
 
 interface Schema {
   directory: string;
@@ -48,6 +51,13 @@ export async function newGenerator(host: Tree, opts: Schema) {
   addCloudDependencies(host, options);
 
   return async () => {
+    const pmc = getPackageManagerCommand(options.packageManager);
+    if (pmc.preInstall) {
+      execSync(pmc.preInstall, {
+        cwd: joinPathFragments(host.root, options.directory),
+        stdio: process.env.NX_GENERATE_QUIET === 'true' ? 'ignore' : 'inherit',
+      });
+    }
     installPackagesTask(host, false, options.directory, options.packageManager);
     // TODO: move all of these into create-nx-workspace
     if (


### PR DESCRIPTION


## Current Behavior
The preinstall step runs every time we call `installPackagesTask` (on every generator and migration that added packages)

## Expected Behavior
The preinstall step should only run once, during the CNW to ensure install is run with the proper pm version.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
