### PR TITLE
feat(express): use helper to determine project name and root in application generator

### DIFF
--- a/docs/generated/packages/express/generators/application.json
+++ b/docs/generated/packages/express/generators/application.json
@@ -1,6 +1,6 @@
 {
   "name": "application",
-  "factory": "./src/generators/application/application#applicationGenerator",
+  "factory": "./src/generators/application/application#applicationGeneratorInternal",
   "schema": {
     "$schema": "http://json-schema.org/schema",
     "cli": "nx",
@@ -14,11 +14,16 @@
         "type": "string",
         "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use for the node application?",
-        "pattern": "^[a-zA-Z].*$"
+        "pattern": "^[a-zA-Z][^:]*$"
       },
       "directory": {
         "description": "The directory of the new application.",
         "type": "string"
+      },
+      "projectNameAndRootFormat": {
+        "description": "Whether to generate the project name and root directory as provided (`as-provided`) or generate them composing their values and taking the configured layout into account (`derived`).",
+        "type": "string",
+        "enum": ["as-provided", "derived"]
       },
       "skipFormat": {
         "description": "Skip formatting files.",
@@ -90,7 +95,7 @@
   "aliases": ["app"],
   "x-type": "application",
   "description": "Create an Express application.",
-  "implementation": "/packages/express/src/generators/application/application#applicationGenerator.ts",
+  "implementation": "/packages/express/src/generators/application/application#applicationGeneratorInternal.ts",
   "hidden": false,
   "path": "/packages/express/src/generators/application/schema.json",
   "type": "generator"

--- a/packages/express/generators.json
+++ b/packages/express/generators.json
@@ -12,7 +12,7 @@
     },
 
     "application": {
-      "factory": "./src/generators/application/application#applicationGenerator",
+      "factory": "./src/generators/application/application#applicationGeneratorInternal",
       "schema": "./src/generators/application/schema.json",
       "aliases": ["app"],
       "x-type": "application",

--- a/packages/express/src/generators/application/application.ts
+++ b/packages/express/src/generators/application/application.ts
@@ -1,20 +1,13 @@
-import {
-  convertNxGenerator,
-  extractLayoutDirectory,
-  formatFiles,
-  getWorkspaceLayout,
-  joinPathFragments,
-  names,
-  toJS,
-  updateJson,
-} from '@nx/devkit';
 import type { Tree } from '@nx/devkit';
+import { convertNxGenerator, formatFiles, toJS, updateJson } from '@nx/devkit';
+import { determineProjectNameAndRootOptions } from '@nx/devkit/src/generators/project-name-and-root-utils';
 import { applicationGenerator as nodeApplicationGenerator } from '@nx/node';
 import { join } from 'path';
 import { initGenerator } from '../init/init';
 import type { Schema } from './schema';
 
 interface NormalizedSchema extends Schema {
+  appProjectName: string;
   appProjectRoot: string;
 }
 
@@ -45,7 +38,7 @@ const app = express();
 app.use('/assets', express.static(path.join(__dirname, 'assets')));
 
 app.get('/api', (req, res) => {
-  res.send({ message: 'Welcome to ${options.name}!' });
+  res.send({ message: 'Welcome to ${options.appProjectName}!' });
 });
 
 const port = process.env.PORT || 3333;
@@ -62,7 +55,14 @@ server.on('error', console.error);
 }
 
 export async function applicationGenerator(tree: Tree, schema: Schema) {
-  const options = normalizeOptions(tree, schema);
+  return await applicationGeneratorInternal(tree, {
+    projectNameAndRootFormat: 'derived',
+    ...schema,
+  });
+}
+
+export async function applicationGeneratorInternal(tree: Tree, schema: Schema) {
+  const options = await normalizeOptions(tree, schema);
   const initTask = await initGenerator(tree, { ...options, skipFormat: true });
   const applicationTask = await nodeApplicationGenerator(tree, {
     ...schema,
@@ -85,19 +85,26 @@ export async function applicationGenerator(tree: Tree, schema: Schema) {
 export default applicationGenerator;
 export const applicationSchematic = convertNxGenerator(applicationGenerator);
 
-function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
-  const { layoutDirectory, projectDirectory } = extractLayoutDirectory(
-    options.directory
-  );
-  const appDirectory = projectDirectory
-    ? `${names(projectDirectory).fileName}/${names(options.name).fileName}`
-    : names(options.name).fileName;
-
-  const appsDir = layoutDirectory ?? getWorkspaceLayout(host).appsDir;
-  const appProjectRoot = joinPathFragments(appsDir, appDirectory);
+async function normalizeOptions(
+  host: Tree,
+  options: Schema
+): Promise<NormalizedSchema> {
+  // TODO(leo): uncomment things below
+  const {
+    projectName: appProjectName,
+    projectRoot: appProjectRoot,
+    // projectNameAndRootFormat,
+  } = await determineProjectNameAndRootOptions(host, {
+    name: options.name,
+    projectType: 'application',
+    directory: options.directory,
+    projectNameAndRootFormat: options.projectNameAndRootFormat,
+  });
+  // options.projectNameAndRootFormat = projectNameAndRootFormat;
 
   return {
     ...options,
+    appProjectName,
     appProjectRoot,
   };
 }

--- a/packages/express/src/generators/application/application.ts
+++ b/packages/express/src/generators/application/application.ts
@@ -98,6 +98,7 @@ async function normalizeOptions(
     projectType: 'application',
     directory: options.directory,
     projectNameAndRootFormat: options.projectNameAndRootFormat,
+    callingGenerator: '@nx/express:application',
   });
   options.projectNameAndRootFormat = projectNameAndRootFormat;
 

--- a/packages/express/src/generators/application/application.ts
+++ b/packages/express/src/generators/application/application.ts
@@ -89,18 +89,17 @@ async function normalizeOptions(
   host: Tree,
   options: Schema
 ): Promise<NormalizedSchema> {
-  // TODO(leo): uncomment things below
   const {
     projectName: appProjectName,
     projectRoot: appProjectRoot,
-    // projectNameAndRootFormat,
+    projectNameAndRootFormat,
   } = await determineProjectNameAndRootOptions(host, {
     name: options.name,
     projectType: 'application',
     directory: options.directory,
     projectNameAndRootFormat: options.projectNameAndRootFormat,
   });
-  // options.projectNameAndRootFormat = projectNameAndRootFormat;
+  options.projectNameAndRootFormat = projectNameAndRootFormat;
 
   return {
     ...options,

--- a/packages/express/src/generators/application/schema.d.ts
+++ b/packages/express/src/generators/application/schema.d.ts
@@ -1,11 +1,13 @@
-import { UnitTestRunner } from '../../utils/test-runners';
+import type { ProjectNameAndRootFormat } from '@nx/devkit/src/generators/project-name-directory-utils';
 import type { Linter } from '@nx/linter';
+import type { UnitTestRunner } from '../../utils/test-runners';
 
 export interface Schema {
   name: string;
   skipFormat: boolean;
   skipPackageJson: boolean;
   directory?: string;
+  projectNameAndRootFormat?: ProjectNameAndRootFormat;
   unitTestRunner: UnitTestRunner;
   tags?: string;
   linter: Linter;

--- a/packages/express/src/generators/application/schema.d.ts
+++ b/packages/express/src/generators/application/schema.d.ts
@@ -1,4 +1,4 @@
-import type { ProjectNameAndRootFormat } from '@nx/devkit/src/generators/project-name-directory-utils';
+import type { ProjectNameAndRootFormat } from '@nx/devkit/src/generators/project-name-and-root-utils';
 import type { Linter } from '@nx/linter';
 import type { UnitTestRunner } from '../../utils/test-runners';
 

--- a/packages/express/src/generators/application/schema.json
+++ b/packages/express/src/generators/application/schema.json
@@ -14,11 +14,16 @@
         "index": 0
       },
       "x-prompt": "What name would you like to use for the node application?",
-      "pattern": "^[a-zA-Z].*$"
+      "pattern": "^[a-zA-Z][^:]*$"
     },
     "directory": {
       "description": "The directory of the new application.",
       "type": "string"
+    },
+    "projectNameAndRootFormat": {
+      "description": "Whether to generate the project name and root directory as provided (`as-provided`) or generate them composing their values and taking the configured layout into account (`derived`).",
+      "type": "string",
+      "enum": ["as-provided", "derived"]
     },
     "skipFormat": {
       "description": "Skip formatting files.",


### PR DESCRIPTION
Updates the Express plugin application generator to use the helper to determine the project name and root.

For more context on the changes, see: https://github.com/nrwl/nx/pull/18420

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
