### PR TITLE
fix(js): fail silently on missing .modules.yaml file

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/utils/pnpm-normalizer.ts
+++ b/packages/nx/src/plugins/js/lock-file/utils/pnpm-normalizer.ts
@@ -10,8 +10,8 @@ import type {
   ResolvedDependencies,
 } from '@pnpm/lockfile-types';
 import { existsSync, readFileSync } from 'fs';
-import { workspaceRoot } from '../../../../utils/workspace-root';
 import { valid } from 'semver';
+import { workspaceRoot } from '../../../../utils/workspace-root';
 
 export function isV6Lockfile(data: InlineSpecifiersLockfile | Lockfile) {
   return data.lockfileVersion.toString().startsWith('6.');
@@ -25,7 +25,7 @@ export function loadPnpmHoistedDepsDefinition() {
     const { load } = require('@zkochan/js-yaml');
     return load(content)?.hoistedDependencies ?? {};
   } else {
-    throw new Error(`Could not find ".modules.yaml" at "${fullPath}"`);
+    return {};
   }
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Nx throws an error if `.modules.yaml` is missing in `node_modules`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Nx fails silently if `.modules.yaml` is missing in `node_modules`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
https://github.com/lerna/lerna/issues/3807

