### PR TITLE
fix(devkit): convert-nx-executor should read projectNodes

### DIFF
--- a/packages/devkit/src/utils/convert-nx-executor.ts
+++ b/packages/devkit/src/utils/convert-nx-executor.ts
@@ -1,5 +1,7 @@
 import type { Observable } from 'rxjs';
 import type { Executor, ExecutorContext } from 'nx/src/config/misc-interfaces';
+import type { ProjectsConfigurations } from 'nx/src/devkit-exports';
+
 import { requireNx } from '../../nx';
 
 const {
@@ -23,14 +25,14 @@ export function convertNxExecutor(executor: Executor) {
         (workspaces as any).readNxJson();
 
     const promise = async () => {
-      const projectsConfigurations =
+      const projectsConfigurations: ProjectsConfigurations =
         retrieveProjectConfigurationsWithAngularProjects
           ? {
               version: 2,
               projects: await retrieveProjectConfigurationsWithAngularProjects(
                 builderContext.workspaceRoot,
                 nxJsonConfiguration
-              ),
+              ).then((p) => p.projectNodes),
             }
           : // TODO(v18): remove retrieveProjectConfigurations. This is to be backwards compatible with Nx 16.5 and below.
             (workspaces as any).readProjectsConfigurations({


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The ExecutorContext.projectsConfigurations contains a projectNodes object that has the actual configs

## Expected Behavior
The ExecutorContext.projectsConfigurations contains the actual configs

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
