### PR TITLE
fix(core): nx should not break if packages were not installed

### DIFF
--- a/packages/nx/src/plugins/js/index.ts
+++ b/packages/nx/src/plugins/js/index.ts
@@ -34,11 +34,15 @@ export const processProjectGraph: ProjectGraphProcessor = async (
       let parsedLockFile: ProjectGraph;
       if (lockFileNeedsReprocessing(lockHash)) {
         parsedLockFile = parseLockFile();
-        writeLastProcessedLockfileHash(lockHash, parsedLockFile);
+        if (parsedLockFile) {
+          writeLastProcessedLockfileHash(lockHash, parsedLockFile);
+        }
       } else {
         parsedLockFile = readParsedLockFile();
       }
-      builder.mergeProjectGraph(parsedLockFile);
+      if (parsedLockFile) {
+        builder.mergeProjectGraph(parsedLockFile);
+      }
     }
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Nx fails if lock file parsing returns undefined because parsing lock file failed

## Expected Behavior
Nx should recover from lock file parsing failure

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/lerna/lerna/issues/3807
