### PR TITLE
feat(nest): use helper to determine project name and root in project generators

### DIFF
--- a/docs/generated/packages/nest/generators/application.json
+++ b/docs/generated/packages/nest/generators/application.json
@@ -1,6 +1,6 @@
 {
   "name": "application",
-  "factory": "./src/generators/application/application",
+  "factory": "./src/generators/application/application#applicationGeneratorInternal",
   "schema": {
     "$schema": "http://json-schema.org/schema",
     "$id": "NxNestApplicationGenerator",
@@ -13,11 +13,17 @@
         "description": "The name of the application.",
         "type": "string",
         "$default": { "$source": "argv", "index": 0 },
-        "x-prompt": "What name would you like to use for the node application?"
+        "x-prompt": "What name would you like to use for the node application?",
+        "pattern": "^[a-zA-Z][^:]*$"
       },
       "directory": {
         "description": "The directory of the new application.",
         "type": "string"
+      },
+      "projectNameAndRootFormat": {
+        "description": "Whether to generate the project name and root directory as provided (`as-provided`) or generate them composing their values and taking the configured layout into account (`derived`).",
+        "type": "string",
+        "enum": ["as-provided", "derived"]
       },
       "skipFormat": {
         "description": "Skip formatting files.",
@@ -82,7 +88,7 @@
   "aliases": ["app"],
   "x-type": "application",
   "description": "Create a NestJS application.",
-  "implementation": "/packages/nest/src/generators/application/application.ts",
+  "implementation": "/packages/nest/src/generators/application/application#applicationGeneratorInternal.ts",
   "hidden": false,
   "path": "/packages/nest/src/generators/application/schema.json",
   "type": "generator"

--- a/docs/generated/packages/nest/generators/library.json
+++ b/docs/generated/packages/nest/generators/library.json
@@ -1,6 +1,6 @@
 {
   "name": "library",
-  "factory": "./src/generators/library/library",
+  "factory": "./src/generators/library/library#libraryGeneratorInternal",
   "schema": {
     "$schema": "http://json-schema.org/schema",
     "$id": "NxNestLibraryGenerator",
@@ -19,12 +19,18 @@
         "description": "Library name.",
         "type": "string",
         "$default": { "$source": "argv", "index": 0 },
-        "x-prompt": "What name would you like to use for the library?"
+        "x-prompt": "What name would you like to use for the library?",
+        "pattern": "(?:^@[a-zA-Z0-9-*~][a-zA-Z0-9-*._~]*\\/[a-zA-Z0-9-~][a-zA-Z0-9-._~]*|^[a-zA-Z][^:]*)$"
       },
       "directory": {
         "description": "A directory where the library is placed.",
         "type": "string",
         "alias": "dir"
+      },
+      "projectNameAndRootFormat": {
+        "description": "Whether to generate the project name and root directory as provided (`as-provided`) or generate them composing their values and taking the configured layout into account (`derived`).",
+        "type": "string",
+        "enum": ["as-provided", "derived"]
       },
       "linter": {
         "description": "The tool to use for running lint checks.",
@@ -143,7 +149,7 @@
   "aliases": ["lib"],
   "x-type": "library",
   "description": "Create a new NestJS library.",
-  "implementation": "/packages/nest/src/generators/library/library.ts",
+  "implementation": "/packages/nest/src/generators/library/library#libraryGeneratorInternal.ts",
   "hidden": false,
   "path": "/packages/nest/src/generators/library/schema.json",
   "type": "generator"

--- a/packages/nest/generators.json
+++ b/packages/nest/generators.json
@@ -108,7 +108,7 @@
   },
   "generators": {
     "application": {
-      "factory": "./src/generators/application/application",
+      "factory": "./src/generators/application/application#applicationGeneratorInternal",
       "schema": "./src/generators/application/schema.json",
       "aliases": ["app"],
       "x-type": "application",

--- a/packages/nest/generators.json
+++ b/packages/nest/generators.json
@@ -128,7 +128,7 @@
       "hidden": true
     },
     "library": {
-      "factory": "./src/generators/library/library",
+      "factory": "./src/generators/library/library#libraryGeneratorInternal",
       "schema": "./src/generators/library/schema.json",
       "aliases": ["lib"],
       "x-type": "library",

--- a/packages/nest/src/generators/application/application.ts
+++ b/packages/nest/src/generators/application/application.ts
@@ -15,7 +15,17 @@ export async function applicationGenerator(
   tree: Tree,
   rawOptions: ApplicationGeneratorOptions
 ): Promise<GeneratorCallback> {
-  const options = normalizeOptions(tree, rawOptions);
+  return await applicationGeneratorInternal(tree, {
+    projectNameAndRootFormat: 'derived',
+    ...rawOptions,
+  });
+}
+
+export async function applicationGeneratorInternal(
+  tree: Tree,
+  rawOptions: ApplicationGeneratorOptions
+): Promise<GeneratorCallback> {
+  const options = await normalizeOptions(tree, rawOptions);
   const initTask = await initGenerator(tree, {
     skipPackageJson: options.skipPackageJson,
     unitTestRunner: options.unitTestRunner,

--- a/packages/nest/src/generators/application/lib/create-files.ts
+++ b/packages/nest/src/generators/application/lib/create-files.ts
@@ -9,7 +9,7 @@ export function createFiles(tree: Tree, options: NormalizedOptions): void {
     joinPathFragments(options.appProjectRoot, 'src'),
     {
       tmpl: '',
-      name: options.name,
+      name: options.appProjectName,
       root: options.appProjectRoot,
     }
   );

--- a/packages/nest/src/generators/application/lib/normalize-options.ts
+++ b/packages/nest/src/generators/application/lib/normalize-options.ts
@@ -8,20 +8,20 @@ export async function normalizeOptions(
   tree: Tree,
   options: ApplicationGeneratorOptions
 ): Promise<NormalizedOptions> {
-  // TODO(leo): uncomment things below
   const {
     projectName: appProjectName,
     projectRoot: appProjectRoot,
-    // projectNameAndRootFormat,
+    projectNameAndRootFormat,
   } = await determineProjectNameAndRootOptions(tree, {
     name: options.name,
     projectType: 'application',
     directory: options.directory,
     projectNameAndRootFormat: options.projectNameAndRootFormat,
     rootProject: options.rootProject,
+    callingGenerator: '@nx/nest:application',
   });
   options.rootProject = appProjectRoot === '.';
-  // options.projectNameAndRootFormat = projectNameAndRootFormat;
+  options.projectNameAndRootFormat = projectNameAndRootFormat;
 
   return {
     ...options,

--- a/packages/nest/src/generators/application/lib/normalize-options.ts
+++ b/packages/nest/src/generators/application/lib/normalize-options.ts
@@ -1,31 +1,32 @@
-import { extractLayoutDirectory, Tree } from '@nx/devkit';
-import { getWorkspaceLayout, joinPathFragments, names } from '@nx/devkit';
+import { Tree } from '@nx/devkit';
+import { determineProjectNameAndRootOptions } from '@nx/devkit/src/generators/project-name-and-root-utils';
 import { Linter } from '@nx/linter';
 import type { Schema as NodeApplicationGeneratorOptions } from '@nx/node/src/generators/application/schema';
 import type { ApplicationGeneratorOptions, NormalizedOptions } from '../schema';
 
-export function normalizeOptions(
+export async function normalizeOptions(
   tree: Tree,
   options: ApplicationGeneratorOptions
-): NormalizedOptions {
-  const { layoutDirectory, projectDirectory } = extractLayoutDirectory(
-    options.directory
-  );
-
-  const appDirectory = projectDirectory
-    ? `${names(projectDirectory).fileName}/${names(options.name).fileName}`
-    : names(options.name).fileName;
-
-  const appProjectRoot = options.rootProject
-    ? '.'
-    : joinPathFragments(
-        layoutDirectory ?? getWorkspaceLayout(tree).appsDir,
-        appDirectory
-      );
+): Promise<NormalizedOptions> {
+  // TODO(leo): uncomment things below
+  const {
+    projectName: appProjectName,
+    projectRoot: appProjectRoot,
+    // projectNameAndRootFormat,
+  } = await determineProjectNameAndRootOptions(tree, {
+    name: options.name,
+    projectType: 'application',
+    directory: options.directory,
+    projectNameAndRootFormat: options.projectNameAndRootFormat,
+    rootProject: options.rootProject,
+  });
+  options.rootProject = appProjectRoot === '.';
+  // options.projectNameAndRootFormat = projectNameAndRootFormat;
 
   return {
     ...options,
     strict: options.strict ?? false,
+    appProjectName,
     appProjectRoot,
     linter: options.linter ?? Linter.EsLint,
     unitTestRunner: options.unitTestRunner ?? 'jest',

--- a/packages/nest/src/generators/application/schema.d.ts
+++ b/packages/nest/src/generators/application/schema.d.ts
@@ -1,8 +1,10 @@
-import { Linter } from '@nx/linter';
+import type { ProjectNameAndRootFormat } from '@nx/devkit/src/generators/project-name-directory-utils';
+import type { Linter } from '@nx/linter';
 
 export interface ApplicationGeneratorOptions {
   name: string;
   directory?: string;
+  projectNameAndRootFormat?: ProjectNameAndRootFormat;
   frontendProject?: string;
   linter?: Linter;
   skipFormat?: boolean;
@@ -17,5 +19,6 @@ export interface ApplicationGeneratorOptions {
 }
 
 interface NormalizedOptions extends ApplicationGeneratorOptions {
+  appProjectName: string;
   appProjectRoot: Path;
 }

--- a/packages/nest/src/generators/application/schema.d.ts
+++ b/packages/nest/src/generators/application/schema.d.ts
@@ -1,4 +1,4 @@
-import type { ProjectNameAndRootFormat } from '@nx/devkit/src/generators/project-name-directory-utils';
+import type { ProjectNameAndRootFormat } from '@nx/devkit/src/generators/project-name-and-root-utils';
 import type { Linter } from '@nx/linter';
 
 export interface ApplicationGeneratorOptions {

--- a/packages/nest/src/generators/application/schema.json
+++ b/packages/nest/src/generators/application/schema.json
@@ -13,11 +13,17 @@
         "$source": "argv",
         "index": 0
       },
-      "x-prompt": "What name would you like to use for the node application?"
+      "x-prompt": "What name would you like to use for the node application?",
+      "pattern": "^[a-zA-Z][^:]*$"
     },
     "directory": {
       "description": "The directory of the new application.",
       "type": "string"
+    },
+    "projectNameAndRootFormat": {
+      "description": "Whether to generate the project name and root directory as provided (`as-provided`) or generate them composing their values and taking the configured layout into account (`derived`).",
+      "type": "string",
+      "enum": ["as-provided", "derived"]
     },
     "skipFormat": {
       "description": "Skip formatting files.",

--- a/packages/nest/src/generators/library/lib/add-project.ts
+++ b/packages/nest/src/generators/library/lib/add-project.ts
@@ -15,10 +15,7 @@ export function addProject(tree: Tree, options: NormalizedOptions): void {
     executor: '@nx/js:tsc',
     outputs: ['{options.outputPath}'],
     options: {
-      outputPath:
-        options.libsDir && options.libsDir !== '.'
-          ? `dist/${options.libsDir}/${options.projectDirectory}`
-          : `dist/${options.projectDirectory}`,
+      outputPath: `dist/${options.projectRoot}`,
       tsConfig: `${options.projectRoot}/tsconfig.lib.json`,
       packageJson: `${options.projectRoot}/package.json`,
       main: `${options.projectRoot}/src/index.ts`,

--- a/packages/nest/src/generators/library/lib/normalize-options.ts
+++ b/packages/nest/src/generators/library/lib/normalize-options.ts
@@ -20,6 +20,7 @@ export async function normalizeOptions(
     directory: options.directory,
     importPath: options.importPath,
     projectNameAndRootFormat: options.projectNameAndRootFormat,
+    callingGenerator: '@nx/nest:library',
   });
 
   const fileName = options.simpleName

--- a/packages/nest/src/generators/library/library.ts
+++ b/packages/nest/src/generators/library/library.ts
@@ -17,7 +17,17 @@ export async function libraryGenerator(
   tree: Tree,
   rawOptions: LibraryGeneratorOptions
 ): Promise<GeneratorCallback> {
-  const options = normalizeOptions(tree, rawOptions);
+  return await libraryGeneratorInternal(tree, {
+    projectNameAndRootFormat: 'derived',
+    ...rawOptions,
+  });
+}
+
+export async function libraryGeneratorInternal(
+  tree: Tree,
+  rawOptions: LibraryGeneratorOptions
+): Promise<GeneratorCallback> {
+  const options = await normalizeOptions(tree, rawOptions);
   await jsLibraryGenerator(tree, toJsLibraryGeneratorOptions(options));
   const installDepsTask = addDependencies(tree);
   deleteFiles(tree, options);

--- a/packages/nest/src/generators/library/schema.d.ts
+++ b/packages/nest/src/generators/library/schema.d.ts
@@ -1,4 +1,4 @@
-import type { ProjectNameAndRootFormat } from '@nx/devkit/src/generators/project-name-directory-utils';
+import type { ProjectNameAndRootFormat } from '@nx/devkit/src/generators/project-name-and-root-utils';
 import type { Linter } from '@nx/linter';
 import type { UnitTestRunner } from '../utils';
 

--- a/packages/nest/src/generators/library/schema.d.ts
+++ b/packages/nest/src/generators/library/schema.d.ts
@@ -1,11 +1,13 @@
-import { Linter } from '@nx/linter';
-import { UnitTestRunner } from '../utils';
+import type { ProjectNameAndRootFormat } from '@nx/devkit/src/generators/project-name-directory-utils';
+import type { Linter } from '@nx/linter';
+import type { UnitTestRunner } from '../utils';
 
 export interface LibraryGeneratorOptions {
   name: string;
   buildable?: boolean;
   controller?: boolean;
   directory?: string;
+  projectNameAndRootFormat?: ProjectNameAndRootFormat;
   global?: boolean;
   importPath?: string;
   linter?: Linter;
@@ -38,8 +40,6 @@ export interface NormalizedOptions extends LibraryGeneratorOptions {
   fileName: string;
   parsedTags: string[];
   prefix: string;
-  projectDirectory: string;
   projectName: string;
   projectRoot: Path;
-  libsDir: string;
 }

--- a/packages/nest/src/generators/library/schema.json
+++ b/packages/nest/src/generators/library/schema.json
@@ -19,12 +19,18 @@
         "$source": "argv",
         "index": 0
       },
-      "x-prompt": "What name would you like to use for the library?"
+      "x-prompt": "What name would you like to use for the library?",
+      "pattern": "(?:^@[a-zA-Z0-9-*~][a-zA-Z0-9-*._~]*\\/[a-zA-Z0-9-~][a-zA-Z0-9-._~]*|^[a-zA-Z][^:]*)$"
     },
     "directory": {
       "description": "A directory where the library is placed.",
       "type": "string",
       "alias": "dir"
+    },
+    "projectNameAndRootFormat": {
+      "description": "Whether to generate the project name and root directory as provided (`as-provided`) or generate them composing their values and taking the configured layout into account (`derived`).",
+      "type": "string",
+      "enum": ["as-provided", "derived"]
     },
     "linter": {
       "description": "The tool to use for running lint checks.",


### PR DESCRIPTION
Updates the Nest plugin project generators (application and library) to use the helper to determine the project name and root.

For more context on the changes, see: https://github.com/nrwl/nx/pull/18420

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
