### PR TITLE
chore(repo): fix version of berry for e2e tests

### DIFF
--- a/e2e/workspace-create/src/create-nx-workspace.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace.test.ts
@@ -15,7 +15,6 @@ import {
 } from '@nx/e2e/utils';
 import { readFileSync } from 'fs';
 import { existsSync, mkdirSync, rmSync } from 'fs-extra';
-import { getPackageManagerVersion } from '@nx/devkit';
 
 describe('create-nx-workspace', () => {
   const packageManager = getSelectedPackageManager() || 'pnpm';
@@ -455,8 +454,8 @@ describe('create-nx-workspace yarn berry', () => {
 
   beforeAll(() => {
     mkdirSync(tmpDir, { recursive: true });
-    runCommand('corepack prepare yarn@stable --activate', { cwd: tmpDir });
-    runCommand('yarn set version stable', { cwd: tmpDir });
+    runCommand('corepack prepare yarn@3.6.1 --activate', { cwd: tmpDir });
+    runCommand('yarn set version 3.6.1', { cwd: tmpDir });
     yarnVersion = runCommand('yarn --version', { cwd: tmpDir }).trim();
     // previous command creates a package.json file which we don't want
     rmSync(`${tmpDir}/package.json`);


### PR DESCRIPTION
The Berry version 4 is coming out. We want to test this separately.

Our code no longer uses `stable` but rather the local berry version, so fixing the version is closer to the actual situation.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
