### PR TITLE
feat(core): add NX_IGNORE_CYCLES environment variable

### DIFF
--- a/docs/shared/reference/environment-variables.md
+++ b/docs/shared/reference/environment-variables.md
@@ -23,6 +23,7 @@ The following environment variables are ones that you can set to change the beha
 | NX_INTERACTIVE                   | boolean | If set to `true`, will allow Nx to prompt you in the terminal to answer some further questions when running generators.                                                                                                                |
 | NX_GENERATE_QUIET                | boolean | If set to `true`, will prevent Nx logging file operations during generate                                                                                                                                                              |
 | NX_PREFER_TS_NODE                | boolean | If set to `true`, Nx will use ts-node for local execution of plugins even if `@swc-node/register` is installed.                                                                                                                        |
+| NX_IGNORE_CYCLES                 | boolean | If set to `true`, Nx will ignore errors created by a task graph circular dependency. Can be overriden on the command line with `--nxIgnoreCycles`                                                                                      |
 
 Nx will set the following environment variables so they can be accessible within the process even outside of executors and generators
 

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -117,7 +117,7 @@ function createTaskGraphAndValidateCycles(
 
   const cycle = findCycle(taskGraph);
   if (cycle) {
-    if (nxArgs.nxIgnoreCycles) {
+    if (process.env.NX_IGNORE_CYCLES === 'true' || nxArgs.nxIgnoreCycles) {
       output.warn({
         title: `The task graph has a circular dependency`,
         bodyLines: [`${cycle.join(' --> ')}`],


### PR DESCRIPTION
- Add NX_IGNORE_CYCLES environment variable to make it easier to run build commands if there are multiple commands where you need to ignore circular dependency errors, to save having to pass it through each time.
