### PR TITLE
feat(devkit): warn users the project name and root will not be derived

### DIFF
--- a/packages/devkit/src/generators/project-name-and-root-utils.spec.ts
+++ b/packages/devkit/src/generators/project-name-and-root-utils.spec.ts
@@ -322,7 +322,7 @@ describe('determineProjectNameAndRootOptions', () => {
           message: `Derived:
     Name: shared-lib-name
     Root: shared/lib-name`,
-          name: 'shared-lib-name @ shared/lib-name (This was derived from the folder structure. Please provide the exact name and directory in the future)',
+          name: 'shared-lib-name @ shared/lib-name',
         },
       ]);
 
@@ -680,7 +680,7 @@ describe('determineProjectNameAndRootOptions', () => {
           message: `Derived:
     Name: shared-lib-name
     Root: libs/shared/lib-name`,
-          name: 'shared-lib-name @ libs/shared/lib-name (This was derived from the folder structure. Please provide the exact name and directory in the future)',
+          name: 'shared-lib-name @ libs/shared/lib-name',
         },
       ]);
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The prompt to set the project name and root to as-provided defaults to false.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The prompt to set the project name and root to as-provided defaults to true. Users are also warned that in Nx 18, derived will be deprecated and they are urged to switch to it.

![image](https://github.com/nrwl/nx/assets/8104246/4754565a-34c7-4609-b741-3eca7a0f71aa)


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
