### PR TITLE
fix(js): fix swc opens swc.js instead of compiling on windows

### DIFF
--- a/packages/js/src/utils/swc/compile-swc.ts
+++ b/packages/js/src/utils/swc/compile-swc.ts
@@ -11,7 +11,7 @@ function getSwcCmd(
   watch = false
 ) {
   const swcCLI = require.resolve('@swc/cli/bin/swc.js');
-  let swcCmd = `${swcCLI} ${
+  let swcCmd = `node ${swcCLI} ${
     // TODO(jack): clean this up when we remove inline module support
     // Handle root project
     srcPath === '.' ? 'src' : srcPath


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Run build with swc open sw.js instead of compiling

## Expected Behavior
Run build with swc should not open file sw.js

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/18673
