### PR TITLE
fix(testing): make playwright nxE2EPreset  options optional

### DIFF
--- a/packages/playwright/src/utils/preset.ts
+++ b/packages/playwright/src/utils/preset.ts
@@ -114,7 +114,7 @@ export function nxE2EPreset(
   }
 
   return defineConfig({
-    testDir: options.testDir ?? './src',
+    testDir: options?.testDir ?? './src',
     outputDir: testResultOuputDir,
     /* Run tests in files in parallel */
     fullyParallel: true,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The options argument is optional and therefore the following should work:
```ts
nxE2EPreset(__filename)
```
When running the code you get:
```
TypeError: Cannot read properties of undefined (reading 'testDir')
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`nxE2EPreset(__filename)` should work as expected.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
