### PR TITLE
feat(nx-plugin): use helper to determine project name and root in project generators

### DIFF
--- a/docs/generated/packages/plugin/generators/create-package.json
+++ b/docs/generated/packages/plugin/generators/create-package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-package",
-  "factory": "./src/generators/create-package/create-package",
+  "factory": "./src/generators/create-package/create-package#createPackageGeneratorInternal",
   "schema": {
     "$schema": "http://json-schema.org/schema",
     "cli": "nx",
@@ -34,6 +34,11 @@
       "directory": {
         "type": "string",
         "description": "A directory where the app is placed."
+      },
+      "projectNameAndRootFormat": {
+        "description": "Whether to generate the project name and root directory as provided (`as-provided`) or generate them composing their values and taking the configured layout into account (`derived`).",
+        "type": "string",
+        "enum": ["as-provided", "derived"]
       },
       "linter": {
         "description": "The tool to use for running lint checks.",
@@ -70,7 +75,7 @@
     "presets": []
   },
   "description": "Create a package which can be used by npx to create a new workspace",
-  "implementation": "/packages/plugin/src/generators/create-package/create-package.ts",
+  "implementation": "/packages/plugin/src/generators/create-package/create-package#createPackageGeneratorInternal.ts",
   "aliases": [],
   "hidden": false,
   "path": "/packages/plugin/src/generators/create-package/schema.json",

--- a/docs/generated/packages/plugin/generators/e2e-project.json
+++ b/docs/generated/packages/plugin/generators/e2e-project.json
@@ -1,6 +1,6 @@
 {
   "name": "e2e-project",
-  "factory": "./src/generators/e2e-project/e2e",
+  "factory": "./src/generators/e2e-project/e2e#e2eProjectGeneratorInternal",
   "schema": {
     "$schema": "http://json-schema.org/schema",
     "cli": "nx",
@@ -23,6 +23,11 @@
       "projectDirectory": {
         "type": "string",
         "description": "the directory where the plugin is placed."
+      },
+      "projectNameAndRootFormat": {
+        "description": "Whether to generate the project name and root directory as provided (`as-provided`) or generate them composing their values and taking the configured layout into account (`derived`).",
+        "type": "string",
+        "enum": ["as-provided", "derived"]
       },
       "pluginOutputPath": {
         "type": "string",
@@ -52,7 +57,7 @@
     "presets": []
   },
   "description": "Create a E2E application for a Nx Plugin.",
-  "implementation": "/packages/plugin/src/generators/e2e-project/e2e.ts",
+  "implementation": "/packages/plugin/src/generators/e2e-project/e2e#e2eProjectGeneratorInternal.ts",
   "aliases": [],
   "hidden": false,
   "path": "/packages/plugin/src/generators/e2e-project/schema.json",

--- a/docs/generated/packages/plugin/generators/plugin.json
+++ b/docs/generated/packages/plugin/generators/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin",
-  "factory": "./src/generators/plugin/plugin",
+  "factory": "./src/generators/plugin/plugin#pluginGeneratorInternal",
   "schema": {
     "$schema": "http://json-schema.org/schema",
     "cli": "nx",
@@ -20,11 +20,17 @@
         "description": "Plugin name",
         "$default": { "$source": "argv", "index": 0 },
         "x-prompt": "What name would you like to use for the plugin?",
-        "x-priority": "important"
+        "x-priority": "important",
+        "pattern": "(?:^@[a-zA-Z0-9-*~][a-zA-Z0-9-*._~]*\\/[a-zA-Z0-9-~][a-zA-Z0-9-._~]*|^[a-zA-Z][^:]*)$"
       },
       "directory": {
         "type": "string",
         "description": "A directory where the plugin is placed."
+      },
+      "projectNameAndRootFormat": {
+        "description": "Whether to generate the project name and root directory as provided (`as-provided`) or generate them composing their values and taking the configured layout into account (`derived`).",
+        "type": "string",
+        "enum": ["as-provided", "derived"]
       },
       "importPath": {
         "type": "string",
@@ -98,7 +104,7 @@
     "presets": []
   },
   "description": "Create a Nx Plugin.",
-  "implementation": "/packages/plugin/src/generators/plugin/plugin.ts",
+  "implementation": "/packages/plugin/src/generators/plugin/plugin#pluginGeneratorInternal.ts",
   "aliases": [],
   "hidden": false,
   "path": "/packages/plugin/src/generators/plugin/schema.json",

--- a/e2e/plugin/src/nx-plugin.test.ts
+++ b/e2e/plugin/src/nx-plugin.test.ts
@@ -434,4 +434,43 @@ describe('Nx Plugin', () => {
       )
     ).toThrow();
   });
+
+  it('should support the new name and root format', async () => {
+    const plugin = uniq('plugin');
+    const createAppName = `create-${plugin}-app`;
+
+    runCLI(
+      `generate @nx/plugin:plugin ${plugin} --e2eTestRunner jest --publishable --project-name-and-root-format=as-provided`
+    );
+
+    // check files are generated without the layout directory ("libs/") and
+    // using the project name as the directory when no directory is provided
+    checkFilesExist(`${plugin}/src/index.ts`);
+    // check build works
+    expect(runCLI(`build ${plugin}`)).toContain(
+      `Successfully ran target build for project ${plugin}`
+    );
+    // check tests pass
+    const appTestResult = runCLI(`test ${plugin}`);
+    expect(appTestResult).toContain(
+      `Successfully ran target test for project ${plugin}`
+    );
+
+    runCLI(
+      `generate @nx/plugin:create-package ${createAppName} --project=${plugin} --e2eProject=${plugin}-e2e --project-name-and-root-format=as-provided`
+    );
+
+    // check files are generated without the layout directory ("libs/") and
+    // using the project name as the directory when no directory is provided
+    checkFilesExist(`${plugin}/src/generators/preset`, `${createAppName}`);
+    // check build works
+    expect(runCLI(`build ${createAppName}`)).toContain(
+      `Successfully ran target build for project ${createAppName}`
+    );
+    // check tests pass
+    const libTestResult = runCLI(`test ${createAppName}`);
+    expect(libTestResult).toContain(
+      `Successfully ran target test for project ${createAppName}`
+    );
+  });
 });

--- a/packages/plugin/generators.json
+++ b/packages/plugin/generators.json
@@ -9,7 +9,7 @@
       "description": "Create a Nx Plugin."
     },
     "create-package": {
-      "factory": "./src/generators/create-package/create-package",
+      "factory": "./src/generators/create-package/create-package#createPackageGeneratorInternal",
       "schema": "./src/generators/create-package/schema.json",
       "description": "Create a package which can be used by npx to create a new workspace"
     },

--- a/packages/plugin/generators.json
+++ b/packages/plugin/generators.json
@@ -4,7 +4,7 @@
   "extends": ["@nx/workspace"],
   "generators": {
     "plugin": {
-      "factory": "./src/generators/plugin/plugin",
+      "factory": "./src/generators/plugin/plugin#pluginGeneratorInternal",
       "schema": "./src/generators/plugin/schema.json",
       "description": "Create a Nx Plugin."
     },
@@ -14,7 +14,7 @@
       "description": "Create a package which can be used by npx to create a new workspace"
     },
     "e2e-project": {
-      "factory": "./src/generators/e2e-project/e2e",
+      "factory": "./src/generators/e2e-project/e2e#e2eProjectGeneratorInternal",
       "schema": "./src/generators/e2e-project/schema.json",
       "description": "Create a E2E application for a Nx Plugin."
     },

--- a/packages/plugin/src/generators/create-package/create-package.ts
+++ b/packages/plugin/src/generators/create-package/create-package.ts
@@ -27,9 +27,19 @@ export async function createPackageGenerator(
   host: Tree,
   schema: CreatePackageSchema
 ) {
+  return await createPackageGeneratorInternal(host, {
+    projectNameAndRootFormat: 'derived',
+    ...schema,
+  });
+}
+
+export async function createPackageGeneratorInternal(
+  host: Tree,
+  schema: CreatePackageSchema
+) {
   const tasks: GeneratorCallback[] = [];
 
-  const options = normalizeSchema(host, schema);
+  const options = await normalizeSchema(host, schema);
   const pluginPackageName = await addPresetGenerator(host, options);
 
   const installTask = addDependenciesToPackageJson(

--- a/packages/plugin/src/generators/create-package/schema.d.ts
+++ b/packages/plugin/src/generators/create-package/schema.d.ts
@@ -1,3 +1,4 @@
+import type { ProjectNameAndRootFormat } from '@nx/devkit/src/generators/project-name-directory-utils';
 import type { Linter } from '@nx/linter';
 
 export interface CreatePackageSchema {
@@ -6,6 +7,7 @@ export interface CreatePackageSchema {
 
   // options to create cli package, passed to js library generator
   directory?: string;
+  projectNameAndRootFormat?: ProjectNameAndRootFormat;
   skipFormat: boolean;
   tags?: string;
   unitTestRunner: 'jest' | 'none';

--- a/packages/plugin/src/generators/create-package/schema.json
+++ b/packages/plugin/src/generators/create-package/schema.json
@@ -37,6 +37,11 @@
       "type": "string",
       "description": "A directory where the app is placed."
     },
+    "projectNameAndRootFormat": {
+      "description": "Whether to generate the project name and root directory as provided (`as-provided`) or generate them composing their values and taking the configured layout into account (`derived`).",
+      "type": "string",
+      "enum": ["as-provided", "derived"]
+    },
     "linter": {
       "description": "The tool to use for running lint checks.",
       "type": "string",

--- a/packages/plugin/src/generators/create-package/utils/normalize-schema.ts
+++ b/packages/plugin/src/generators/create-package/utils/normalize-schema.ts
@@ -1,42 +1,36 @@
-import {
-  extractLayoutDirectory,
-  getWorkspaceLayout,
-  joinPathFragments,
-  names,
-  Tree,
-} from '@nx/devkit';
+import { Tree } from '@nx/devkit';
+import { determineProjectNameAndRootOptions } from '@nx/devkit/src/generators/project-name-and-root-utils';
 import { CreatePackageSchema } from '../schema';
 
 export interface NormalizedSchema extends CreatePackageSchema {
   bundler: 'swc' | 'tsc';
-  libsDir: string;
   projectName: string;
   projectRoot: string;
-  projectDirectory: string;
 }
 
-export function normalizeSchema(
+export async function normalizeSchema(
   host: Tree,
   schema: CreatePackageSchema
-): NormalizedSchema {
-  const { layoutDirectory, projectDirectory } = extractLayoutDirectory(
-    schema.directory
-  );
-  const { libsDir: defaultLibsDir } = getWorkspaceLayout(host);
-  const libsDir = layoutDirectory ?? defaultLibsDir;
-  const name = names(schema.name).fileName;
-  const fullProjectDirectory = projectDirectory
-    ? `${names(projectDirectory).fileName}/${name}`
-    : name;
-  const projectName = fullProjectDirectory.replace(new RegExp('/', 'g'), '-');
-  const projectRoot = joinPathFragments(libsDir, fullProjectDirectory);
+): Promise<NormalizedSchema> {
+  const {
+    projectName,
+    names: projectNames,
+    projectRoot,
+    projectNameAndRootFormat,
+  } = await determineProjectNameAndRootOptions(host, {
+    name: schema.name,
+    projectType: 'library',
+    directory: schema.directory,
+    projectNameAndRootFormat: schema.projectNameAndRootFormat,
+    callingGenerator: '@nx/plugin:create-package',
+  });
+  schema.projectNameAndRootFormat = projectNameAndRootFormat;
+
   return {
     ...schema,
     bundler: schema.compiler ?? 'tsc',
-    libsDir,
     projectName,
     projectRoot,
-    name,
-    projectDirectory: fullProjectDirectory,
+    name: projectNames.projectSimpleName,
   };
 }

--- a/packages/plugin/src/generators/e2e-project/e2e.ts
+++ b/packages/plugin/src/generators/e2e-project/e2e.ts
@@ -45,11 +45,10 @@ async function normalizeOptions(
       {
         name: projectName,
         projectType: 'application',
-        directory: options.rootProject
-          ? projectName
-          : options.projectDirectory
-          ? `${options.projectDirectory}-e2e`
-          : `${options.pluginName}-e2e`,
+        directory:
+          options.rootProject || !options.projectDirectory
+            ? projectName
+            : `${options.projectDirectory}-e2e`,
         projectNameAndRootFormat: `as-provided`,
         callingGenerator: '@nx/plugin:e2e-project',
       }
@@ -62,12 +61,11 @@ async function normalizeOptions(
     const { appsDir: defaultAppsDir } = getWorkspaceLayout(host);
     const appsDir = layoutDirectory ?? defaultAppsDir;
 
-    projectRoot =
-      projectDirectory && !options.rootProject
-        ? joinPathFragments(appsDir, `${projectDirectory}-e2e`)
-        : options.rootProject
-        ? projectName
-        : joinPathFragments(appsDir, projectName);
+    projectRoot = options.rootProject
+      ? projectName
+      : projectDirectory
+      ? joinPathFragments(appsDir, `${projectDirectory}-e2e`)
+      : joinPathFragments(appsDir, projectName);
   }
 
   const pluginPropertyName = names(options.pluginName).propertyName;

--- a/packages/plugin/src/generators/e2e-project/schema.d.ts
+++ b/packages/plugin/src/generators/e2e-project/schema.d.ts
@@ -1,9 +1,11 @@
-import { Linter } from '@nx/linter';
+import type { ProjectNameAndRootFormat } from '@nx/devkit/src/generators/project-name-directory-utils';
+import type { Linter } from '@nx/linter';
 
 export interface Schema {
   pluginName: string;
   npmPackageName: string;
   projectDirectory?: string;
+  projectNameAndRootFormat?: ProjectNameAndRootFormat;
   pluginOutputPath?: string;
   jestConfig?: string;
   linter?: Linter;

--- a/packages/plugin/src/generators/e2e-project/schema.json
+++ b/packages/plugin/src/generators/e2e-project/schema.json
@@ -21,6 +21,11 @@
       "type": "string",
       "description": "the directory where the plugin is placed."
     },
+    "projectNameAndRootFormat": {
+      "description": "Whether to generate the project name and root directory as provided (`as-provided`) or generate them composing their values and taking the configured layout into account (`derived`).",
+      "type": "string",
+      "enum": ["as-provided", "derived"]
+    },
     "pluginOutputPath": {
       "type": "string",
       "description": "the output path of the plugin after it builds.",

--- a/packages/plugin/src/generators/plugin/plugin.ts
+++ b/packages/plugin/src/generators/plugin/plugin.ts
@@ -4,6 +4,7 @@ import {
   formatFiles,
   generateFiles,
   GeneratorCallback,
+  joinPathFragments,
   normalizePath,
   readProjectConfiguration,
   runTasksInSerial,
@@ -74,7 +75,14 @@ function updatePluginConfig(host: Tree, options: NormalizedSchema) {
 }
 
 export async function pluginGenerator(host: Tree, schema: Schema) {
-  const options = normalizeOptions(host, schema);
+  return await pluginGeneratorInternal(host, {
+    projectNameAndRootFormat: 'derived',
+    ...schema,
+  });
+}
+
+export async function pluginGeneratorInternal(host: Tree, schema: Schema) {
+  const options = await normalizeOptions(host, schema);
   const tasks: GeneratorCallback[] = [];
 
   tasks.push(
@@ -119,10 +127,14 @@ export async function pluginGenerator(host: Tree, schema: Schema) {
       await e2eProjectGenerator(host, {
         pluginName: options.name,
         projectDirectory: options.projectDirectory,
-        pluginOutputPath: `dist/${options.libsDir}/${options.projectDirectory}`,
+        pluginOutputPath: joinPathFragments(
+          'dist',
+          options.rootProject ? options.name : options.projectRoot
+        ),
         npmPackageName: options.npmPackageName,
         skipFormat: true,
         rootProject: options.rootProject,
+        projectNameAndRootFormat: options.projectNameAndRootFormat,
       })
     );
   }

--- a/packages/plugin/src/generators/plugin/schema.d.ts
+++ b/packages/plugin/src/generators/plugin/schema.d.ts
@@ -1,8 +1,10 @@
-import { Linter } from '@nx/linter';
+import type { ProjectNameAndRootFormat } from '@nx/devkit/src/generators/project-name-directory-utils';
+import type { Linter } from '@nx/linter';
 
 export interface Schema {
   name: string;
   directory?: string;
+  projectNameAndRootFormat?: ProjectNameAndRootFormat;
   importPath?: string;
   skipTsConfig?: boolean; // default is false
   skipFormat?: boolean; // default is false

--- a/packages/plugin/src/generators/plugin/schema.json
+++ b/packages/plugin/src/generators/plugin/schema.json
@@ -20,11 +20,17 @@
         "index": 0
       },
       "x-prompt": "What name would you like to use for the plugin?",
-      "x-priority": "important"
+      "x-priority": "important",
+      "pattern": "(?:^@[a-zA-Z0-9-*~][a-zA-Z0-9-*._~]*\\/[a-zA-Z0-9-~][a-zA-Z0-9-._~]*|^[a-zA-Z][^:]*)$"
     },
     "directory": {
       "type": "string",
       "description": "A directory where the plugin is placed."
+    },
+    "projectNameAndRootFormat": {
+      "description": "Whether to generate the project name and root directory as provided (`as-provided`) or generate them composing their values and taking the configured layout into account (`derived`).",
+      "type": "string",
+      "enum": ["as-provided", "derived"]
     },
     "importPath": {
       "type": "string",


### PR DESCRIPTION
Updates the Nx plugin project generators (create-package and plugin) to use the helper to determine the project name and root.

For more context on the changes, see: https://github.com/nrwl/nx/pull/18420

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
