### PR TITLE
fix(linter): fixes usages of lintProjectGenerator without eslintFilePatterns provided

### DIFF
--- a/packages/linter/src/generators/lint-project/lint-project.ts
+++ b/packages/linter/src/generators/lint-project/lint-project.ts
@@ -50,7 +50,7 @@ export async function lintProjectGenerator(
   });
   const projectConfig = readProjectConfiguration(tree, options.project);
 
-  const lintFilePatterns = options.eslintFilePatterns;
+  const lintFilePatterns = options.eslintFilePatterns ?? [];
   if (isBuildableLibraryProject(projectConfig)) {
     lintFilePatterns.push(`${projectConfig.root}/package.json`);
   }


### PR DESCRIPTION
Previous change broke usages of the lintProjectGenerator which did not include an eslintFilePatterns array option. This resolves by first checking for the arrays existence before pushing to it

closed #18740

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18740 
