### PR TITLE
feat(js): carry-over known build options (main, tsConfig, etc.) when running setup-build generator

### DIFF
--- a/docs/generated/manifests/packages.json
+++ b/docs/generated/manifests/packages.json
@@ -663,7 +663,7 @@
       "/packages/esbuild/generators/configuration": {
         "description": "Add esbuild configuration to a project.",
         "file": "generated/packages/esbuild/generators/configuration.json",
-        "hidden": true,
+        "hidden": false,
         "name": "configuration",
         "originalFilePath": "/packages/esbuild/src/generators/configuration/schema.json",
         "path": "/packages/esbuild/generators/configuration",
@@ -2410,7 +2410,7 @@
       "/packages/rollup/generators/configuration": {
         "description": "Add rollup configuration to a project.",
         "file": "generated/packages/rollup/generators/configuration.json",
-        "hidden": true,
+        "hidden": false,
         "name": "configuration",
         "originalFilePath": "/packages/rollup/src/generators/configuration/schema.json",
         "path": "/packages/rollup/generators/configuration",

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -652,7 +652,7 @@
       {
         "description": "Add esbuild configuration to a project.",
         "file": "generated/packages/esbuild/generators/configuration.json",
-        "hidden": true,
+        "hidden": false,
         "name": "configuration",
         "originalFilePath": "/packages/esbuild/src/generators/configuration/schema.json",
         "path": "esbuild/generators/configuration",
@@ -2384,7 +2384,7 @@
       {
         "description": "Add rollup configuration to a project.",
         "file": "generated/packages/rollup/generators/configuration.json",
-        "hidden": true,
+        "hidden": false,
         "name": "configuration",
         "originalFilePath": "/packages/rollup/src/generators/configuration/schema.json",
         "path": "rollup/generators/configuration",

--- a/docs/generated/packages/esbuild/generators/configuration.json
+++ b/docs/generated/packages/esbuild/generators/configuration.json
@@ -68,8 +68,8 @@
     "presets": []
   },
   "description": "Add esbuild configuration to a project.",
-  "hidden": true,
   "implementation": "/packages/esbuild/src/generators/configuration/configuration.ts",
+  "hidden": false,
   "path": "/packages/esbuild/src/generators/configuration/schema.json",
   "type": "generator"
 }

--- a/docs/generated/packages/rollup/generators/configuration.json
+++ b/docs/generated/packages/rollup/generators/configuration.json
@@ -70,14 +70,20 @@
         "description": "The build target to add.",
         "type": "string",
         "default": "build"
+      },
+      "format": {
+        "description": "The format to build the library (esm or cjs).",
+        "type": "array",
+        "items": { "type": "string", "enum": ["esm", "cjs"] },
+        "default": ["esm"]
       }
     },
     "required": [],
     "presets": []
   },
   "description": "Add rollup configuration to a project.",
-  "hidden": true,
   "implementation": "/packages/rollup/src/generators/configuration/configuration.ts",
+  "hidden": false,
   "path": "/packages/rollup/src/generators/configuration/schema.json",
   "type": "generator"
 }

--- a/e2e/rollup/src/rollup.test.ts
+++ b/e2e/rollup/src/rollup.test.ts
@@ -47,7 +47,7 @@ describe('Rollup Plugin', () => {
       `generate @nx/rollup:configuration ${myPkg} --target=node --tsConfig=libs/${myPkg}/tsconfig.lib.json --main=libs/${myPkg}/src/index.ts --compiler=swc`
     );
     rmDist();
-    runCLI(`build ${myPkg}`);
+    runCLI(`build ${myPkg} --format=cjs,esm --generateExportsField`);
     output = runCommand(`node dist/libs/${myPkg}/index.cjs.js`);
     expect(output).toMatch(/Hello/);
 
@@ -61,7 +61,7 @@ describe('Rollup Plugin', () => {
       `generate @nx/rollup:configuration ${myPkg} --target=node --tsConfig=libs/${myPkg}/tsconfig.lib.json --main=libs/${myPkg}/src/index.ts --compiler=tsc`
     );
     rmDist();
-    runCLI(`build ${myPkg}`);
+    runCLI(`build ${myPkg} --format=cjs,esm --generateExportsField`);
     output = runCommand(`node dist/libs/${myPkg}/index.cjs.js`);
     expect(output).toMatch(/Hello/);
   }, 500000);

--- a/packages/esbuild/generators.json
+++ b/packages/esbuild/generators.json
@@ -12,8 +12,7 @@
       "aliases": ["esbuild-project"],
       "factory": "./src/generators/configuration/configuration#compat",
       "schema": "./src/generators/configuration/schema.json",
-      "description": "Add esbuild configuration to a project.",
-      "hidden": true
+      "description": "Add esbuild configuration to a project."
     }
   },
   "generators": {
@@ -28,8 +27,7 @@
       "aliases": ["esbuild-project"],
       "factory": "./src/generators/configuration/configuration",
       "schema": "./src/generators/configuration/schema.json",
-      "description": "Add esbuild configuration to a project.",
-      "hidden": true
+      "description": "Add esbuild configuration to a project."
     }
   }
 }

--- a/packages/esbuild/src/generators/configuration/configuration.ts
+++ b/packages/esbuild/src/generators/configuration/configuration.ts
@@ -51,14 +51,19 @@ function addBuildTarget(tree: Tree, options: EsBuildProjectSchema) {
       version: '0.0.1',
     });
   }
-  const tsConfig = getTsConfigFile(tree, options);
+
+  const prevBuildOptions = project.targets?.[options.buildTarget]?.options;
+
+  const tsConfig = prevBuildOptions?.tsConfig ?? getTsConfigFile(tree, options);
 
   const buildOptions: EsBuildExecutorOptions = {
-    main: getMainFile(tree, options),
-    outputPath: joinPathFragments(
-      'dist',
-      project.root === '.' ? options.project : project.root
-    ),
+    main: prevBuildOptions?.main ?? getMainFile(tree, options),
+    outputPath:
+      prevBuildOptions?.outputPath ??
+      joinPathFragments(
+        'dist',
+        project.root === '.' ? options.project : project.root
+      ),
     outputFileName: 'main.js',
     tsConfig,
     assets: [],

--- a/packages/js/src/generators/setup-build/generator.ts
+++ b/packages/js/src/generators/setup-build/generator.ts
@@ -21,11 +21,14 @@ export async function setupBuildGenerator(
   const tasks: GeneratorCallback[] = [];
   const project = readProjectConfiguration(tree, options.project);
   const buildTarget = options.buildTarget ?? 'build';
+  const prevBuildOptions = project.targets?.[buildTarget]?.options;
 
   project.targets ??= {};
 
   let mainFile: string;
-  if (options.main) {
+  if (prevBuildOptions?.main) {
+    mainFile = prevBuildOptions.main;
+  } else if (options.main) {
     mainFile = options.main;
   } else {
     const root = project.sourceRoot ?? project.root;
@@ -48,7 +51,9 @@ export async function setupBuildGenerator(
   }
 
   let tsConfigFile: string;
-  if (options.tsConfig) {
+  if (prevBuildOptions?.tsConfig) {
+    tsConfigFile = prevBuildOptions.tsConfig;
+  } else if (options.tsConfig) {
     tsConfigFile = options.tsConfig;
   } else {
     for (const f of [
@@ -97,6 +102,7 @@ export async function setupBuildGenerator(
         buildTarget: options.buildTarget,
         project: options.project,
         skipFormat: true,
+        skipValidation: true,
       });
       tasks.push(task);
       break;
@@ -106,9 +112,12 @@ export async function setupBuildGenerator(
       const task = await configurationGenerator(tree, {
         buildTarget: options.buildTarget,
         main: mainFile,
+        tsConfig: tsConfigFile,
         project: options.project,
-        skipFormat: true,
         compiler: 'tsc',
+        format: ['cjs', 'esm'],
+        skipFormat: true,
+        skipValidation: true,
       });
       tasks.push(task);
       break;

--- a/packages/rollup/generators.json
+++ b/packages/rollup/generators.json
@@ -12,8 +12,7 @@
       "aliases": ["rollup-project"],
       "factory": "./src/generators/configuration/configuration#compat",
       "schema": "./src/generators/configuration/schema.json",
-      "description": "Add rollup configuration to a project.",
-      "hidden": true
+      "description": "Add rollup configuration to a project."
     }
   },
   "generators": {
@@ -28,8 +27,7 @@
       "aliases": ["rollup-project"],
       "factory": "./src/generators/configuration/configuration",
       "schema": "./src/generators/configuration/schema.json",
-      "description": "Add rollup configuration to a project.",
-      "hidden": true
+      "description": "Add rollup configuration to a project."
     }
   }
 }

--- a/packages/rollup/src/generators/configuration/configuration.ts
+++ b/packages/rollup/src/generators/configuration/configuration.ts
@@ -50,19 +50,30 @@ function addBuildTarget(tree: Tree, options: RollupProjectSchema) {
       version: '0.0.1',
     });
   }
-  const tsConfig =
-    options.tsConfig ?? joinPathFragments(project.root, 'tsconfig.lib.json');
+
+  const prevBuildOptions = project.targets?.[options.buildTarget]?.options;
 
   const buildOptions: RollupExecutorOptions = {
-    main: options.main ?? joinPathFragments(project.root, 'src/main.ts'),
-    outputPath: joinPathFragments(
-      'dist',
-      project.root === '.' ? project.name : project.root
-    ),
+    main:
+      options.main ??
+      prevBuildOptions?.main ??
+      joinPathFragments(project.root, 'src/main.ts'),
+    outputPath:
+      prevBuildOptions?.outputPath ??
+      joinPathFragments(
+        'dist',
+        project.root === '.' ? project.name : project.root
+      ),
+    tsConfig:
+      options.tsConfig ??
+      prevBuildOptions?.tsConfig ??
+      joinPathFragments(project.root, 'tsconfig.lib.json'),
+    additionalEntryPoints: prevBuildOptions?.additionalEntryPoints,
+    generateExportsField: prevBuildOptions?.generateExportsField,
     compiler: options.compiler ?? 'babel',
-    tsConfig,
     project: `${project.root}/package.json`,
     external: options.external,
+    format: options.format,
   };
 
   if (options.rollupConfig) {

--- a/packages/rollup/src/generators/configuration/schema.d.ts
+++ b/packages/rollup/src/generators/configuration/schema.d.ts
@@ -10,4 +10,5 @@ export interface RollupProjectSchema {
   external?: string[];
   rollupConfig?: string;
   buildTarget?: string;
+  format?: ('cjs' | 'esm')[];
 }

--- a/packages/rollup/src/generators/configuration/schema.json
+++ b/packages/rollup/src/generators/configuration/schema.json
@@ -71,6 +71,15 @@
       "description": "The build target to add.",
       "type": "string",
       "default": "build"
+    },
+    "format": {
+      "description": "The format to build the library (esm or cjs).",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["esm", "cjs"]
+      },
+      "default": ["esm"]
     }
   },
   "required": []


### PR DESCRIPTION
This PR allows known build options to carry-over when running the @nx/js:setup-build generator. Options are:

- main 
- tsConfig
- outputPath
- additionalEntryPoints
- generateExportsField

This helps when converting from tsc to Rollup, for example, and the shared options should remain intact.

https://github.com/nrwl/nx/assets/53559/184a5450-05b0-48c4-a8f3-ffdd2ca1c06b



## Current Behavior
Existing build options are overridden

## Expected Behavior
Known build options that work between our build/bundle executors should remain.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
