### PR TITLE
fix(storybook): dont fail if targets dont exist

### DIFF
--- a/packages/storybook/src/generators/configuration/lib/util-functions.ts
+++ b/packages/storybook/src/generators/configuration/lib/util-functions.ts
@@ -371,7 +371,7 @@ export function updateLintConfig(tree: Tree, schema: StorybookConfigureSchema) {
   const { name: projectName } = schema;
 
   const { targets, root } = readProjectConfiguration(tree, projectName);
-  const tslintTargets = Object.values(targets).filter(
+  const tslintTargets = Object.values(targets ?? {}).filter(
     (target) => target.executor === '@angular-devkit/build-angular:tslint'
   );
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

If there is no `targets` object in `project.json` then generator fails.

## Expected Behavior

If there is no `targets` object in `project.json` generator should not fail.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18725
