### PR TITLE
fix(core): load .env after .env.local

### DIFF
--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -108,7 +108,7 @@ function main() {
  * - .env.local
  */
 function loadDotEnvFiles() {
-  for (const file of ['.env', '.local.env', '.env.local']) {
+  for (const file of ['.local.env', '.env.local', '.env']) {
     loadDotEnvFile({
       path: file,
     });

--- a/packages/nx/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/nx/src/tasks-runner/forked-process-task-runner.ts
@@ -437,9 +437,9 @@ export class ForkedProcessTaskRunner {
       `.${task.target.target}.env`,
 
       // Load base DotEnv Files at workspace root
-      `.env`,
       `.local.env`,
       `.env.local`,
+      `.env`,
     ];
 
     for (const file of dotEnvFiles) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`.env.local` at root isn't overriding `.env`, despite the docs saying it should

## Expected Behavior
`.env.local` at root overrides `.env`, as the docs saying it should

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18712
Fixes #18707
