### PR TITLE
fix(core): projects within folders that start with a `.` should be found

### DIFF
--- a/packages/nx/src/generators/utils/project-configuration.ts
+++ b/packages/nx/src/generators/utils/project-configuration.ts
@@ -252,7 +252,11 @@ function findCreatedProjectFiles(tree: Tree, globPatterns: string[]) {
   for (const change of tree.listChanges()) {
     if (change.type === 'CREATE') {
       const fileName = basename(change.path);
-      if (globPatterns.some((pattern) => minimatch(change.path, pattern))) {
+      if (
+        globPatterns.some((pattern) =>
+          minimatch(change.path, pattern, { dot: true })
+        )
+      ) {
         createdProjectFiles.push(change.path);
       } else if (fileName === 'package.json') {
         try {

--- a/packages/nx/src/hasher/task-hasher.ts
+++ b/packages/nx/src/hasher/task-hasher.ts
@@ -408,7 +408,7 @@ class TaskHasherImpl {
       const filteredFiles = outputFiles.filter(
         (p) =>
           p === dependentTasksOutputFiles ||
-          minimatch(p, dependentTasksOutputFiles)
+          minimatch(p, dependentTasksOutputFiles, { dot: true })
       );
       const hashDetails = {};
       const hashes: string[] = [];

--- a/packages/nx/src/project-graph/affected/locators/project-glob-changes.ts
+++ b/packages/nx/src/project-graph/affected/locators/project-glob-changes.ts
@@ -23,7 +23,9 @@ export const getTouchedProjectsFromProjectGlobChanges: TouchedProjectLocator =
 
     const touchedProjects = new Set<string>();
     for (const touchedFile of touchedFiles) {
-      const isProjectFile = minimatch(touchedFile.file, globPattern);
+      const isProjectFile = minimatch(touchedFile.file, globPattern, {
+        dot: true,
+      });
       if (isProjectFile) {
         // If the file no longer exists on disk, then it was deleted
         if (!existsSync(join(workspaceRoot, touchedFile.file))) {

--- a/packages/nx/src/project-graph/affected/locators/workspace-projects.ts
+++ b/packages/nx/src/project-graph/affected/locators/workspace-projects.ts
@@ -49,7 +49,7 @@ export const getImplicitlyTouchedProjects: TouchedProjectLocator = (
 
   for (const [pattern, projects] of Object.entries(implicits)) {
     const implicitDependencyWasChanged = fileChanges.some((f) =>
-      minimatch(f.file, pattern)
+      minimatch(f.file, pattern, { dot: true })
     );
     if (!implicitDependencyWasChanged) {
       continue;

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -103,7 +103,7 @@ export function buildProjectsConfigurationsFromProjectPathsAndPlugins(
       continue;
     }
     for (const file of projectFiles) {
-      if (minimatch(file, pattern)) {
+      if (minimatch(file, pattern, { dot: true })) {
         const { projects: projectNodes, externalNodes: pluginExternalNodes } =
           configurationConstructor(file, {
             nxJsonConfiguration: nxJson,

--- a/packages/nx/src/utils/find-matching-projects.ts
+++ b/packages/nx/src/utils/find-matching-projects.ts
@@ -245,7 +245,7 @@ export const getMatchingStringsWithCache = (() => {
     }
     const patternCache = minimatchCache.get(pattern)!;
     if (!regexCache.has(pattern)) {
-      const regex = minimatch.makeRe(pattern);
+      const regex = minimatch.makeRe(pattern, { dot: true });
       if (regex) {
         regexCache.set(pattern, regex);
       } else {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`project.json` files within a dot folder (e.g. `.github`, `.circleci` etc) are ignored. This is a regression from behavior prior to Nx 16.6

## Expected Behavior
Files and projects within dot folders are matched by minimatch in Nx's core where applicable, including during project location

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18692
