### PR TITLE
bugfix(react): fix await read port for react module federation

### DIFF
--- a/e2e/react-core/src/react-module-federation.test.ts
+++ b/e2e/react-core/src/react-module-federation.test.ts
@@ -43,10 +43,10 @@ describe('React Module Federation', () => {
       combinedOutput: expect.stringContaining('Test Suites: 1 passed, 1 total'),
     });
 
-    expect(readPort(shell)).toEqual(4200);
-    expect(readPort(remote1)).toEqual(4201);
-    expect(readPort(remote2)).toEqual(4202);
-    expect(readPort(remote3)).toEqual(4203);
+    expect(await readPort(shell)).toEqual(4200);
+    expect(await readPort(remote1)).toEqual(4201);
+    expect(await readPort(remote2)).toEqual(4202);
+    expect(await readPort(remote3)).toEqual(4203);
 
     updateFile(
       `apps/${shell}/webpack.config.js`,
@@ -62,10 +62,10 @@ describe('React Module Federation', () => {
           ...baseConfig,
               remotes: [
                 '${remote1}',
-                ['${remote2}', 'http://localhost:${readPort(
+                ['${remote2}', 'http://localhost:${await readPort(
         remote2
       )}/remoteEntry.js'],
-                ['${remote3}', 'http://localhost:${readPort(remote3)}'],
+                ['${remote3}', 'http://localhost:${await readPort(remote3)}'],
               ],
         };
 
@@ -109,10 +109,10 @@ describe('React Module Federation', () => {
     //   expect(e2eResults).toContain('All specs passed!');
     //   expect(
     //     await killPorts([
-    //       readPort(shell),
-    //       readPort(remote1),
-    //       readPort(remote2),
-    //       readPort(remote3),
+    //       await readPort(shell),
+    //       await readPort(remote1),
+    //       await readPort(remote2),
+    //       await readPort(remote3),
     //     ])
     //   ).toBeTruthy();
     // }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
