### PR TITLE
fix(core): do not use joinPathFragments for generating files

### DIFF
--- a/docs/generated/devkit/joinPathFragments.md
+++ b/docs/generated/devkit/joinPathFragments.md
@@ -2,7 +2,8 @@
 
 ▸ **joinPathFragments**(`...fragments`): `string`
 
-Normalized path fragments and joins them
+Normalized path fragments and joins them. Use this when writing paths to config files.
+This should not be used to read files on disk because of the removal of Windows drive letters.
 
 #### Parameters
 

--- a/docs/generated/devkit/normalizePath.md
+++ b/docs/generated/devkit/normalizePath.md
@@ -2,7 +2,8 @@
 
 ▸ **normalizePath**(`osSpecificPath`): `string`
 
-Coverts an os specific path to a unix style path
+Coverts an os specific path to a unix style path. Use this when writing paths to config files.
+This should not be used to read files on disk because of the removal of Windows drive letters.
 
 #### Parameters
 

--- a/docs/shared/recipes/generators/creating-files.md
+++ b/docs/shared/recipes/generators/creating-files.md
@@ -120,7 +120,7 @@ function uppercase(val: string) {
 
 // later
 
-generateFiles(tree, joinPathFragments(__dirname, './files'), libraryRoot, {
+generateFiles(tree, join(__dirname, './files'), libraryRoot, {
   uppercase,
   name: schema.name,
 });
@@ -141,7 +141,7 @@ This is the short version.
 
 ```typescript
 // typescript file
-generateFiles(tree, joinPathFragments(__dirname, './files'), libraryRoot, {
+generateFiles(tree, join(__dirname, './files'), libraryRoot, {
   shortVersion: false,
   numRepetitions: 3,
 });

--- a/packages/angular/src/generators/host/lib/add-ssr.ts
+++ b/packages/angular/src/generators/host/lib/add-ssr.ts
@@ -16,6 +16,7 @@ import {
   typesCorsVersion,
   typesExpressVersion,
 } from '../../../utils/versions';
+import { join } from 'path';
 
 export async function addSsr(tree: Tree, options: Schema, appName: string) {
   let project = readProjectConfiguration(tree, appName);
@@ -34,7 +35,7 @@ export async function addSsr(tree: Tree, options: Schema, appName: string) {
     "import('./src/main.server');"
   );
 
-  generateFiles(tree, joinPathFragments(__dirname, '../files'), project.root, {
+  generateFiles(tree, join(__dirname, '../files'), project.root, {
     appName,
     standalone: options.standalone,
     tmpl: '',

--- a/packages/angular/src/generators/ng-add/utilities/workspace.ts
+++ b/packages/angular/src/generators/ng-add/utilities/workspace.ts
@@ -21,6 +21,7 @@ import { angularDevkitVersion, nxVersion } from '../../../utils/versions';
 import type { ProjectMigrator } from '../migrators';
 import type { GeneratorOptions } from '../schema';
 import type { WorkspaceRootFileTypesInfo } from './types';
+import { join } from 'path';
 
 export function validateWorkspace(tree: Tree): void {
   const errors: string[] = [];
@@ -274,7 +275,7 @@ export async function createWorkspaceFiles(tree: Tree): Promise<void> {
 
   await jsInitGenerator(tree, { skipFormat: true });
 
-  generateFiles(tree, joinPathFragments(__dirname, '../files/root'), '.', {
+  generateFiles(tree, join(__dirname, '../files/root'), '.', {
     tmpl: '',
     dot: '.',
     rootTsConfigPath: getRootTsConfigPathInTree(tree),

--- a/packages/angular/src/generators/setup-ssr/lib/generate-files.ts
+++ b/packages/angular/src/generators/setup-ssr/lib/generate-files.ts
@@ -7,6 +7,7 @@ import {
 import { lt } from 'semver';
 import { getInstalledAngularVersionInfo } from '../../utils/version-utils';
 import type { Schema } from '../schema';
+import { join } from 'path';
 
 export function generateSSRFiles(tree: Tree, schema: Schema) {
   const projectConfig = readProjectConfiguration(tree, schema.project);
@@ -16,7 +17,7 @@ export function generateSSRFiles(tree: Tree, schema: Schema) {
 
   const pathToFiles = joinPathFragments(__dirname, '..', 'files');
 
-  generateFiles(tree, joinPathFragments(pathToFiles, 'base'), projectRoot, {
+  generateFiles(tree, join(pathToFiles, 'base'), projectRoot, {
     ...schema,
     tpl: '',
   });

--- a/packages/expo/src/generators/component/component.ts
+++ b/packages/expo/src/generators/component/component.ts
@@ -12,6 +12,7 @@ import {
 } from '@nx/devkit';
 import { NormalizedSchema, normalizeOptions } from './lib/normalize-options';
 import { addImport } from './lib/add-import';
+import { join } from 'path';
 
 export async function expoComponentGenerator(host: Tree, schema: Schema) {
   const options = await normalizeOptions(host, schema);
@@ -30,7 +31,7 @@ function createComponentFiles(host: Tree, options: NormalizedSchema) {
     options.directory
   );
 
-  generateFiles(host, joinPathFragments(__dirname, './files'), componentDir, {
+  generateFiles(host, join(__dirname, './files'), componentDir, {
     ...options,
     tmpl: '',
   });

--- a/packages/js/src/generators/init/init.ts
+++ b/packages/js/src/generators/init/init.ts
@@ -23,6 +23,7 @@ import {
   typescriptVersion,
 } from '../../utils/versions';
 import { InitSchema } from './schema';
+import { join } from 'path';
 
 async function getInstalledTypescriptVersion(
   tree: Tree
@@ -65,7 +66,7 @@ export async function initGenerator(
   const tasks: GeneratorCallback[] = [];
   // add tsconfig.base.json
   if (!getRootTsConfigFileName(tree)) {
-    generateFiles(tree, joinPathFragments(__dirname, './files'), '.', {
+    generateFiles(tree, join(__dirname, './files'), '.', {
       fileName: schema.tsConfigName ?? 'tsconfig.base.json',
     });
   }

--- a/packages/next/src/generators/custom-server/custom-server.ts
+++ b/packages/next/src/generators/custom-server/custom-server.ts
@@ -10,6 +10,7 @@ import {
   updateProjectConfiguration,
 } from '@nx/devkit';
 import { CustomServerSchema } from './schema';
+import { join } from 'path';
 
 export async function customServerGenerator(
   host: Tree,
@@ -52,7 +53,7 @@ export async function customServerGenerator(
     return;
   }
 
-  generateFiles(host, joinPathFragments(__dirname, 'files'), project.root, {
+  generateFiles(host, join(__dirname, 'files'), project.root, {
     ...options,
     offsetFromRoot: offsetFromRoot(project.root),
     projectRoot: project.root,

--- a/packages/node/src/generators/setup-docker/setup-docker.ts
+++ b/packages/node/src/generators/setup-docker/setup-docker.ts
@@ -13,6 +13,7 @@ import {
 } from '@nx/devkit';
 
 import { SetUpDockerOptions } from './schema';
+import { join } from 'path';
 
 function normalizeOptions(
   tree: Tree,
@@ -39,7 +40,7 @@ function addDocker(tree: Tree, options: SetUpDockerOptions) {
   } else {
     const outputPath =
       project.targets[`${options.buildTarget}`]?.options.outputPath;
-    generateFiles(tree, joinPathFragments(__dirname, './files'), project.root, {
+    generateFiles(tree, join(__dirname, './files'), project.root, {
       tmpl: '',
       app: project.sourceRoot,
       buildLocation: outputPath,

--- a/packages/nx/src/utils/path.ts
+++ b/packages/nx/src/utils/path.ts
@@ -5,14 +5,16 @@ function removeWindowsDriveLetter(osSpecificPath: string): string {
 }
 
 /**
- * Coverts an os specific path to a unix style path
+ * Coverts an os specific path to a unix style path. Use this when writing paths to config files.
+ * This should not be used to read files on disk because of the removal of Windows drive letters.
  */
 export function normalizePath(osSpecificPath: string): string {
   return removeWindowsDriveLetter(osSpecificPath).split('\\').join('/');
 }
 
 /**
- * Normalized path fragments and joins them
+ * Normalized path fragments and joins them. Use this when writing paths to config files.
+ * This should not be used to read files on disk because of the removal of Windows drive letters.
  */
 export function joinPathFragments(...fragments: string[]): string {
   return normalizePath(path.join(...fragments));

--- a/packages/react-native/src/generators/component/component.ts
+++ b/packages/react-native/src/generators/component/component.ts
@@ -12,6 +12,7 @@ import {
 import { NormalizedSchema, normalizeOptions } from './lib/normalize-options';
 import { addImport } from './lib/add-import';
 import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
+import { join } from 'path';
 
 export async function reactNativeComponentGenerator(
   host: Tree,
@@ -31,7 +32,7 @@ function createComponentFiles(host: Tree, options: NormalizedSchema) {
     options.directory
   );
 
-  generateFiles(host, joinPathFragments(__dirname, './files'), componentDir, {
+  generateFiles(host, join(__dirname, './files'), componentDir, {
     ...options,
     tmpl: '',
   });

--- a/packages/react/src/generators/component-test/component-test.ts
+++ b/packages/react/src/generators/component-test/component-test.ts
@@ -5,7 +5,7 @@ import {
   readProjectConfiguration,
   Tree,
 } from '@nx/devkit';
-import { basename, dirname, extname, relative } from 'path';
+import { basename, dirname, extname, join, relative } from 'path';
 import {
   findExportDeclarationsForJsx,
   getComponentNode,
@@ -100,7 +100,7 @@ function generateSpecsForComponents(tree: Tree, filePath: string) {
     const namedImportStatement =
       namedImports.length > 0 ? `, { ${namedImports} }` : '';
 
-    generateFiles(tree, joinPathFragments(__dirname, 'files'), componentDir, {
+    generateFiles(tree, join(__dirname, 'files'), componentDir, {
       fileName,
       components,
       importStatement: defaultExport

--- a/packages/react/src/generators/component/component.ts
+++ b/packages/react/src/generators/component/component.ts
@@ -23,6 +23,7 @@ import { getComponentTests } from './get-component-tests';
 import { NormalizedSchema } from './noramlized-schema';
 import { Schema } from './schema';
 import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
+import { join } from 'path';
 
 export async function componentGenerator(host: Tree, schema: Schema) {
   const options = await normalizeOptions(host, schema);
@@ -58,7 +59,7 @@ function createComponentFiles(host: Tree, options: NormalizedSchema) {
   );
 
   const componentTests = getComponentTests(options);
-  generateFiles(host, joinPathFragments(__dirname, './files'), componentDir, {
+  generateFiles(host, join(__dirname, './files'), componentDir, {
     ...options,
     componentTests,
     inSourceVitestTests: getInSourceVitestTestsTemplate(componentTests),

--- a/packages/react/src/generators/hook/hook.ts
+++ b/packages/react/src/generators/hook/hook.ts
@@ -15,6 +15,7 @@ import {
 import { Schema } from './schema';
 import { addImport } from '../../utils/ast-utils';
 import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
+import { join } from 'path';
 
 interface NormalizedSchema extends Schema {
   projectSourceRoot: string;
@@ -38,7 +39,7 @@ function createFiles(host: Tree, options: NormalizedSchema) {
     options.directory
   );
 
-  generateFiles(host, joinPathFragments(__dirname, './files'), hookDir, {
+  generateFiles(host, join(__dirname, './files'), hookDir, {
     ...options,
     tmpl: '',
   });

--- a/packages/react/src/generators/setup-ssr/setup-ssr.ts
+++ b/packages/react/src/generators/setup-ssr/setup-ssr.ts
@@ -24,6 +24,7 @@ import {
 } from '../../utils/versions';
 import { addStaticRouter } from '../../utils/ast-utils';
 import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
+import { join } from 'path';
 
 let tsModule: typeof import('typescript');
 
@@ -192,7 +193,7 @@ export async function setupSsrGenerator(tree: Tree, options: Schema) {
     ];
   }
 
-  generateFiles(tree, joinPathFragments(__dirname, 'files'), projectRoot, {
+  generateFiles(tree, join(__dirname, 'files'), projectRoot, {
     tmpl: '',
     extraInclude:
       options.extraInclude?.length > 0

--- a/packages/react/src/generators/setup-tailwind/setup-tailwind.ts
+++ b/packages/react/src/generators/setup-tailwind/setup-tailwind.ts
@@ -18,6 +18,7 @@ import {
 import type { SetupTailwindOptions } from './schema';
 import { addTailwindStyleImports } from './lib/add-tailwind-style-imports';
 import { updateProject } from './lib/update-project';
+import { join } from 'path';
 
 export async function setupTailwindGenerator(
   tree: Tree,
@@ -36,7 +37,7 @@ export async function setupTailwindGenerator(
     return;
   }
 
-  generateFiles(tree, joinPathFragments(__dirname, './files'), project.root, {
+  generateFiles(tree, join(__dirname, './files'), project.root, {
     tmpl: '',
   });
 

--- a/packages/storybook/src/generators/cypress-project/cypress-project.ts
+++ b/packages/storybook/src/generators/cypress-project/cypress-project.ts
@@ -108,7 +108,7 @@ function addBaseUrlToCypressConfig(tree: Tree, projectName: string) {
   } else if (tree.exists(cypressTs)) {
     // cypress >= v10
     tree.delete(cypressTs);
-    generateFiles(tree, joinPathFragments(__dirname, 'files'), projectRoot, {
+    generateFiles(tree, join(__dirname, 'files'), projectRoot, {
       tpl: '',
     });
   }

--- a/packages/storybook/src/generators/migrate-7/helper-functions.ts
+++ b/packages/storybook/src/generators/migrate-7/helper-functions.ts
@@ -686,7 +686,7 @@ export function logResult(
     color: 'green',
   });
 
-  generateFiles(tree, joinPathFragments(__dirname, 'files'), '.', {
+  generateFiles(tree, join(__dirname, 'files'), '.', {
     tmpl: '',
     successfulProjects: Object.entries(
       migrationSummary?.successfulProjects

--- a/packages/vite/src/generators/vitest/vitest-generator.ts
+++ b/packages/vite/src/generators/vitest/vitest-generator.ts
@@ -26,6 +26,7 @@ import {
 } from '../../utils/versions';
 
 import { addTsLibDependencies } from '@nx/js';
+import { join } from 'path';
 
 export async function vitestGenerator(
   tree: Tree,
@@ -141,7 +142,7 @@ function createFiles(
   options: VitestGeneratorSchema,
   projectRoot: string
 ) {
-  generateFiles(tree, joinPathFragments(__dirname, 'files'), projectRoot, {
+  generateFiles(tree, join(__dirname, 'files'), projectRoot, {
     tmpl: '',
     ...options,
     projectRoot,

--- a/packages/workspace/src/generators/ci-workflow/ci-workflow.ts
+++ b/packages/workspace/src/generators/ci-workflow/ci-workflow.ts
@@ -10,6 +10,7 @@ import {
   writeJson,
 } from '@nx/devkit';
 import { deduceDefaultBase } from '../../utilities/default-base';
+import { join } from 'path';
 
 export interface Schema {
   name: string;
@@ -32,7 +33,7 @@ export async function ciWorkflowGenerator(host: Tree, schema: Schema) {
     writeJson(host, 'nx.json', appendOriginPrefix(nxJson));
   }
 
-  generateFiles(host, joinPathFragments(__dirname, 'files', ci), '', options);
+  generateFiles(host, join(__dirname, 'files', ci), '', options);
   await formatFiles(host);
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When running `npx create-nx-workspace` on a drive that is not `C:`, the process fails because we strip out the drive letter before trying to gather file information. This failure happens during `create-nx-workspace` and `ensurePackage` because those two functions will create a temporary directory (usually in `%LOCALAPPDATA%`, ie - `C:\Users\user\AppData\Local`), and run nx generators from there. If we try to use `readdirSync` without the drive letter, it will default to looking at the current working directory. So if the working directory is `D:\dev`, and a generator file is in `C:\Users\user\AppData\Local\etc`, Nx will "normalize" the windows path and remove the drive letter, and node will try to look for the file in `D:\Users\user\AppData\Local\etc`.

## Expected Behavior
Generating files do not remove the drive letter, and we just use a regular `join`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18677
fixes #18727

