### PR TITLE
fix(misc): fix normalizing e2e project name and root

### DIFF
--- a/packages/angular/src/generators/application/lib/normalize-options.ts
+++ b/packages/angular/src/generators/application/lib/normalize-options.ts
@@ -26,20 +26,8 @@ export async function normalizeOptions(
   options.rootProject = appProjectRoot === '.';
   options.projectNameAndRootFormat = projectNameAndRootFormat;
 
-  let e2eProjectName = 'e2e';
-  let e2eProjectRoot = 'e2e';
-  if (!options.rootProject) {
-    const projectNameAndRoot = await determineProjectNameAndRootOptions(host, {
-      name: `${options.name}-e2e`,
-      projectType: 'application',
-      directory: options.directory,
-      projectNameAndRootFormat: options.projectNameAndRootFormat,
-      rootProject: options.rootProject,
-      callingGenerator: '@nx/angular:application',
-    });
-    e2eProjectName = projectNameAndRoot.projectName;
-    e2eProjectRoot = projectNameAndRoot.projectRoot;
-  }
+  const e2eProjectName = options.rootProject ? 'e2e' : `${appProjectName}-e2e`;
+  const e2eProjectRoot = options.rootProject ? 'e2e' : `${appProjectRoot}-e2e`;
 
   const parsedTags = options.tags
     ? options.tags.split(',').map((s) => s.trim())

--- a/packages/next/src/generators/application/lib/normalize-options.ts
+++ b/packages/next/src/generators/application/lib/normalize-options.ts
@@ -35,20 +35,8 @@ export async function normalizeOptions(
   options.rootProject = appProjectRoot === '.';
   options.projectNameAndRootFormat = projectNameAndRootFormat;
 
-  let e2eProjectName = 'e2e';
-  let e2eProjectRoot = 'e2e';
-  if (!options.rootProject) {
-    const projectNameAndRoot = await determineProjectNameAndRootOptions(host, {
-      name: `${options.name}-e2e`,
-      projectType: 'application',
-      directory: options.directory,
-      projectNameAndRootFormat: options.projectNameAndRootFormat,
-      rootProject: options.rootProject,
-      callingGenerator: '@nx/next:application',
-    });
-    e2eProjectName = projectNameAndRoot.projectName;
-    e2eProjectRoot = projectNameAndRoot.projectRoot;
-  }
+  const e2eProjectName = options.rootProject ? 'e2e' : `${appProjectName}-e2e`;
+  const e2eProjectRoot = options.rootProject ? 'e2e' : `${appProjectRoot}-e2e`;
 
   const name = names(options.name).fileName;
 

--- a/packages/react/src/generators/application/lib/normalize-options.ts
+++ b/packages/react/src/generators/application/lib/normalize-options.ts
@@ -36,20 +36,8 @@ export async function normalizeOptions<T extends Schema = Schema>(
   options.rootProject = appProjectRoot === '.';
   options.projectNameAndRootFormat = projectNameAndRootFormat;
 
-  let e2eProjectName = 'e2e';
-  let e2eProjectRoot = 'e2e';
-  if (!options.rootProject) {
-    const projectNameAndRoot = await determineProjectNameAndRootOptions(host, {
-      name: `${options.name}-e2e`,
-      projectType: 'application',
-      directory: options.directory,
-      projectNameAndRootFormat: options.projectNameAndRootFormat,
-      rootProject: options.rootProject,
-      callingGenerator,
-    });
-    e2eProjectName = projectNameAndRoot.projectName;
-    e2eProjectRoot = projectNameAndRoot.projectRoot;
-  }
+  const e2eProjectName = options.rootProject ? 'e2e' : `${appProjectName}-e2e`;
+  const e2eProjectRoot = options.rootProject ? 'e2e' : `${appProjectRoot}-e2e`;
 
   const parsedTags = options.tags
     ? options.tags.split(',').map((s) => s.trim())


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Some project generators that generate an e2e test project when using the new project name and root format (`as-provided`) and providing a directory throw an error. It happens because the directory provided to the helper function is the directory of the app. With the `as-provided` format, that's where the project is going to be generated, but the app project is there.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Project generators that generate an e2e test project should normalize the e2e project name and root correctly and not throw.

When the e2e project name and root is determined we already know the fully normalized app name and root. So, the e2e project name and root can be easily determined without using the helper.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
