### PR TITLE
fix(nx-dev): add algolia search on smaller screens

### DIFF
--- a/nx-dev/ui-common/src/lib/header.tsx
+++ b/nx-dev/ui-common/src/lib/header.tsx
@@ -304,6 +304,7 @@ export function Header(): JSX.Element {
           </div>
         </div>
         <div className="items-justified flex flex-shrink-0 justify-center space-x-1 text-sm">
+          <AlgoliaSearch tiny={true} />
           <ThemeSwitcher />
           <a
             title="Nx is open source, check the code on GitHub"


### PR DESCRIPTION
On smaller screens, the algolia search button is missing, even though there's enough space for it in the header.
It's still accessible via the `Cmd K` shortcut but not with the mouse. That means on mobile there's no way to open the search from the home page.

One caveat is that the button label `CmdK` doesn't really make sense on mobile phones since it's just there to be clickable.
We could change the button to a maginifying glass icon if the user agent string matches mobile phones.