### PR TITLE
fix(angular): mark esbuild as optional peer dep #18526

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -77,6 +77,9 @@
   "peerDependenciesMeta": {
     "@nguniversal/builders": {
       "optional": true
+    },
+    "esbuild": {
+      "optional": true
     }
   },
   "publishConfig": {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
esbuild package is not considered an optional peer dependency

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
esbuild package should be considered an optional peer dependency

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18526
