### PR TITLE
docs(nx-cloud): misc vcs docs update

### DIFF
--- a/docs/nx-cloud/set-up/bitbucket-cloud.md
+++ b/docs/nx-cloud/set-up/bitbucket-cloud.md
@@ -31,5 +31,5 @@ To use an app password for authentication, one must be generated with proper per
 Once the app password is created, verify the username is correct, paste the value, and then click "Connect". This will verify that Nx Cloud can connect to your repo. Upon a successful test, your configuration is saved, and setup is complete.
 
 {% callout type="note" title="Use the correct username" %}
-Make sure that you are using your Bitbucket username, found on the [account settings](https://bitbucket.org/account/settings) screen, and not your email address.
+Make sure that you are using your Bitbucket username, found on the [account settings](https://bitbucket.org/account/settings/) screen, and not your email address.
 {% /callout %}

--- a/docs/nx-cloud/set-up/github.md
+++ b/docs/nx-cloud/set-up/github.md
@@ -35,6 +35,10 @@ To use a Personal Access Token for authentication, one must be generated with pr
 
 Once this token is created, select the radio button for providing a personal access token, paste the value, and then click "Connect". This will verify that Nx Cloud can connect to your repo. Upon a successful test, your configuration is saved. Check the "_CI Platform Considerations_" section below, and if there are no additional instructions for your platform of choice, setup is complete.
 
+### Advanced Configuration
+
+If your company runs a self-hosted GitHub installation, you may need to override the default URL that Nx Cloud uses to connect to the GitHub API. To do so, check the box labeled "Override GitHub API URL" and enter the correct URL for your organization.
+
 ## CI Platform Considerations
 
 If you are using CircleCI, TravisCI, GitHub Actions or GitHub, there is nothing else you need to do. If you are using other CI providers, you need to set the `NX_BRANCH` environment variable in your CI configuration. The variable has to be set to a PR number.


### PR DESCRIPTION
- Update Bitbucket account/settings link with trailing slash. Without trailing slash, link is redirected to a repository (no access)
- Update Github VCS setup with `Advanced Configuration` section to mention `override Github API URL`