### PR TITLE
fix(linter): error on dependencies that are only in devDependencies instead of production dependencies

### DIFF
--- a/packages/eslint-plugin/src/utils/package-json-utils.ts
+++ b/packages/eslint-plugin/src/utils/package-json-utils.ts
@@ -13,6 +13,16 @@ export function getAllDependencies(
   };
 }
 
+export function getProductionDependencies(
+  packageJson: PackageJson
+): Record<string, string> {
+  return {
+    ...packageJson.dependencies,
+    ...packageJson.peerDependencies,
+    ...packageJson.optionalDependencies,
+  };
+}
+
 export function getPackageJson(path: string): PackageJson {
   if (existsSync(path)) {
     return readJsonFile(path);


### PR DESCRIPTION
This PR makes it so that packages listed under `devDependencies` are not counted as correct. User must add the dependency to `dependencies`, `peerDependencies`, or `optionalDependencies` since `devDependencies` are not installed for the end user (consumer of the published project).

For example, say I have a project with this `package.json`:

```json5
{
  // ...
  "devDependencies": {
    "foo": "1.0.0"
  }
}
```

And in my project I have `import 'foo'` somewhere in the source code.

In the existing version of the dep checks rule, it will not error out. However, if a consumer installed my published package, they will get an error because `foo` package is not installed. The fix in this PR will force the user to move `foo` to `dependencies`, `peerDependencies`, or `optionalDependencies`.

## Current Behavior
Adding a dependency to `devDependencies` satisfies the dep check.

## Expected Behavior
Dependency cannot only be in `devDependencies`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
