### PR TITLE
Revert "fix(core): nx should not break if packages were not installed…

### DIFF
--- a/packages/nx/src/plugins/js/index.ts
+++ b/packages/nx/src/plugins/js/index.ts
@@ -34,15 +34,11 @@ export const processProjectGraph: ProjectGraphProcessor = async (
       let parsedLockFile: ProjectGraph;
       if (lockFileNeedsReprocessing(lockHash)) {
         parsedLockFile = parseLockFile();
-        if (parsedLockFile) {
-          writeLastProcessedLockfileHash(lockHash, parsedLockFile);
-        }
+        writeLastProcessedLockfileHash(lockHash, parsedLockFile);
       } else {
         parsedLockFile = readParsedLockFile();
       }
-      if (parsedLockFile) {
-        builder.mergeProjectGraph(parsedLockFile);
-      }
+      builder.mergeProjectGraph(parsedLockFile);
     }
   }
 


### PR DESCRIPTION
… (#18687)"

This reverts commit 20acfbe68140c11468900fb07db3d43a56e60917.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

There is an issue for `pnpm` users where the project graph being calculated without `node_modules` appears to be successful even though the results differ from the project graph which would be calculated when `node_modules` are not present. The `npm` nodes are basically not added to the graph and the dependencies are drawn anyways.

1. When a file has a import which doesn't match the package name such as a deep import (`import 'dotenv/config'`), the file is deemed to have a dependency to `npm:dotenv/config` when it should actually depend on `npm:dotenv`.
  1. With the new create nodes and create dependencies APIs this ideally shouldn't be possible because all dependencies should be drawn between 2 nodes. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

There needs to be another solution for this. If the _correct_ graph cannot be produced without `node_modules` then the creation should fail. If we want the project graph to succeed without `node_modules` then we need to produce the right project graph without the `node_modules`. 

This command should produce the same correct dependencies:

```
 pnpm store prune && nx reset && rm -rf node_modules && pnpm i && node -e "JSON.parse(require('fs').readFileSync('node_modules/.cache/nx/file-map.json').toString()).projectFileMap.nx.filter(f => f.file === 'packages/nx/src/adapter/ngcli-adapter.ts').forEach(f => console.log(f))"
 ```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
