### PR TITLE
chore(core): nx plugin submission @nxext/vue

### DIFF
--- a/community/approved-plugins.json
+++ b/community/approved-plugins.json
@@ -135,9 +135,9 @@
     "url": "https://github.com/nxext/nx-extensions/tree/master/packages/stencil"
   },
   {
-    "name": "@nxext/vite",
-    "description": "Nx plugin to use ViteJS within nx workspaces",
-    "url": "https://github.com/nxext/nx-extensions/tree/master/packages/vite"
+    "name": "@nxext/vue",
+    "description": "Nx plugin to use VueJS 3 within nx workspaces",
+    "url": "https://github.com/nxext/nx-extensions/tree/master/packages/vue"
   },
   {
     "name": "@nxext/solid",


### PR DESCRIPTION
# Community Plugin Submission

## @nxext/vue

I want to add the new @nxext/vue plugin to the registry. I changed the entry for @nxext/vite because we don't support it anymore and marked it with the release of @nx/vite as deprecated
