### PR TITLE
fix(js): use normalized tsConfig path for generating tmpTscConfig

### DIFF
--- a/packages/js/src/executors/tsc/tsc.impl.ts
+++ b/packages/js/src/executors/tsc/tsc.impl.ts
@@ -64,7 +64,7 @@ export async function* tscExecutor(
 
   const { projectRoot, tmpTsConfig, target, dependencies } = checkDependencies(
     context,
-    _options.tsConfig
+    options.tsConfig
   );
 
   if (tmpTsConfig) {


### PR DESCRIPTION
Using the normalized (full) tsConfig path means there is no implicit usage of cwd when generating the temp tsconfig file. So a the @nx/js:tsc executor can be triggered from a different project/directory than the one being built.

## Current Behavior
Assume we have a setup that looks something like this:

```
nx.json
packages/
    foo/
        project.json
        tsconfig.json
    bar/
        project.json
        tsconfig.json
```

Contents of `nx.json`:
```
{
  "targetDefaults": {
    "build": {
      "executor": "@nx/js:tsc",
      "options": {
        "main": "{projectRoot}/index.ts",
        "outputPath": "{projectRoot}/dist",
        "tsConfig": "{projectRoot}/tsconfig.json"
      },
}
```
contents of each `project.json`:
```
{
  "targets": {
    "build": {}
  }
}
```

If the `cwd` is `packages/foo`, running `nx run foo:build` works as expected.

_However_ if `cwd` is any other director, running that command will not find the tsconfig file.

There is a separate issue I believe that not finding a tsconfig file _should_ result in failure (instead of building nothing and acting like success).

## Expected Behavior

Running `nx run foo:build` should work anywhere inside the workspace, regardless of cwd or other packages.
