### PR TITLE
fix(core): convert to monorepo generator should respect nested libs

### DIFF
--- a/packages/workspace/src/generators/convert-to-monorepo/convert-to-monorepo.spec.ts
+++ b/packages/workspace/src/generators/convert-to-monorepo/convert-to-monorepo.spec.ts
@@ -76,6 +76,34 @@ describe('monorepo generator', () => {
     expect(tree.exists('.eslintrc.base.json')).toBeTruthy();
   });
 
+  it('should respect nested libraries', async () => {
+    await reactAppGenerator(tree, {
+      name: 'demo',
+      style: 'css',
+      bundler: 'vite',
+      unitTestRunner: 'vitest',
+      e2eTestRunner: 'none',
+      linter: 'eslint',
+      rootProject: true,
+    });
+
+    await libraryGenerator(tree, {
+      name: 'my-lib',
+      directory: 'inner',
+      style: 'css',
+      bundler: 'vite',
+      unitTestRunner: 'none',
+      e2eTestRunner: 'none',
+      linter: 'eslint',
+      rootProject: true,
+    });
+
+    await monorepoGenerator(tree, {});
+
+    expect(tree.exists('libs/inner/my-lib/tsconfig.json')).toBeTruthy();
+    expect(tree.exists('libs/inner/my-lib/src/index.ts')).toBeTruthy();
+  });
+
   it('should convert root React app (Webpack, Jest)', async () => {
     await reactAppGenerator(tree, {
       name: 'demo',

--- a/packages/workspace/src/generators/convert-to-monorepo/convert-to-monorepo.ts
+++ b/packages/workspace/src/generators/convert-to-monorepo/convert-to-monorepo.ts
@@ -34,11 +34,15 @@ export async function monorepoGenerator(tree: Tree, options: {}) {
   for (const project of projectsToMove) {
     await moveGenerator(tree, {
       projectName: project.name,
-      newProjectName: project.name,
+      newProjectName:
+        project.projectType === 'application' ? project.name : project.root,
       destination:
         project.projectType === 'application'
           ? joinPathFragments(appsDir, project.name)
-          : joinPathFragments(libsDir, project.name),
+          : joinPathFragments(
+              libsDir,
+              project.root === '.' ? project.name : project.root
+            ),
       destinationRelativeToRoot: true,
       updateImportPath: project.projectType === 'library',
     });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Currently when we run `nx g @nx/workspace:convert-to-monorepo` while having a nested lib
```
apis/login/src/login.ts
```

it would generate
```
libs/apis-login/
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Expected it to generate 
```
libs/apis/login/
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
