### PR TITLE
fix(vite): support incremental building when running 'serve'

### DIFF
--- a/packages/vite/src/utils/executor-utils.ts
+++ b/packages/vite/src/utils/executor-utils.ts
@@ -40,7 +40,9 @@ export function createBuildableTsConfig(
       context.projectGraph,
       context.root,
       context.projectName,
-      context.targetName,
+      // When using incremental building and the serve target is called
+      // we need to get the deps for the 'build' target instead.
+      context.targetName === 'serve' ? 'build' : context.targetName,
       context.configurationName
     );
     // this tsconfig is used via the vite ts paths plugin


### PR DESCRIPTION
closed #18458

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

when using incremental building with vite `buildLibsFromSource: false`, vite would still reference the source code when running 'serve'.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
incremental building works with serve as well as build.

> Note: serve will need to depend on '^build' in order for it to work without manually building first. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18458
