### PR TITLE
docs(nextjs): fix formatting issue with install command

### DIFF
--- a/docs/generated/packages/next/documents/overview.md
+++ b/docs/generated/packages/next/documents/overview.md
@@ -12,15 +12,22 @@ To create a new Nx workspace with Next.js, run `npx create-nx-workspace@latest -
 
 To add Next.js to an existing Nx workspace, install the `@nx/next` package. Make sure to install the version that matches your `@nx/workspace` version.
 
+{% tabs %}
+{% tab label="npm" %}
+
 ```shell
-#yarn
+npm install --save-dev @nx/next
+```
+
+{% /tab %}
+{% tab label="yarn" %}
+
+```shell
 yarn add --dev @nx/next
 ```
 
-```shell
-#npm
-npm install --save-dev @nx/next
-```
+{% /tab %}
+{% /tabs %}
 
 ### Creating Applications
 

--- a/docs/shared/packages/next/plugin-overview.md
+++ b/docs/shared/packages/next/plugin-overview.md
@@ -12,15 +12,22 @@ To create a new Nx workspace with Next.js, run `npx create-nx-workspace@latest -
 
 To add Next.js to an existing Nx workspace, install the `@nx/next` package. Make sure to install the version that matches your `@nx/workspace` version.
 
+{% tabs %}
+{% tab label="npm" %}
+
 ```shell
-#yarn
+npm install --save-dev @nx/next
+```
+
+{% /tab %}
+{% tab label="yarn" %}
+
+```shell
 yarn add --dev @nx/next
 ```
 
-```shell
-#npm
-npm install --save-dev @nx/next
-```
+{% /tab %}
+{% /tabs %}
 
 ### Creating Applications
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
shell commands are formatted into a single line causing the terminal output to be incorrect

![WkMacM1-4PT4Gvln_08231410](https://github.com/nrwl/nx/assets/23272162/f51aa35d-a473-4bac-86d5-a0907cfa589a)



## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
correct commands are shown
![WkMacM1-DuvpdqEj_08231410](https://github.com/nrwl/nx/assets/23272162/613a48b6-91b0-454b-bb4d-a2648304ba7c)


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
