### PR TITLE
chore(core): move project-json plugin to src

### DIFF
--- a/packages/nx/src/generators/utils/project-configuration.ts
+++ b/packages/nx/src/generators/utils/project-configuration.ts
@@ -4,7 +4,7 @@ import {
   buildProjectConfigurationFromPackageJson,
   getGlobPatternsFromPackageManagerWorkspaces,
 } from '../../../plugins/package-json-workspaces';
-import { buildProjectFromProjectJson } from '../../../plugins/project-json';
+import { buildProjectFromProjectJson } from '../../plugins/project-json/build-nodes/project-json';
 import { renamePropertyWithStableKeys } from '../../adapter/angular-json';
 import {
   ProjectConfiguration,

--- a/packages/nx/src/plugins/project-json/build-nodes/project-json.spec.ts
+++ b/packages/nx/src/plugins/project-json/build-nodes/project-json.spec.ts
@@ -1,15 +1,25 @@
 import * as memfs from 'memfs';
 
-import '../src/utils/testing/mock-fs';
+import '../../../utils/testing/mock-fs';
 
-import { PackageJson } from '../src/utils/package-json';
+import { PackageJson } from '../../../utils/package-json';
 
 import {
-  getNxProjectJsonPlugin,
+  CreateProjectJsonProjectsPlugin,
   mergeNpmScriptsWithTargets,
 } from './project-json';
+import { CreateNodesContext } from '../../../utils/nx-plugin';
+const { createNodes } = CreateProjectJsonProjectsPlugin;
 
 describe('nx project.json plugin', () => {
+  let context: CreateNodesContext;
+  beforeEach(() => {
+    context = {
+      nxJsonConfiguration: {},
+      workspaceRoot: '/root',
+    };
+  });
+
   it('should build projects from project.json', () => {
     memfs.vol.fromJSON(
       {
@@ -37,8 +47,7 @@ describe('nx project.json plugin', () => {
       '/root'
     );
 
-    const plugin = getNxProjectJsonPlugin('/root');
-    expect(plugin.createNodes[1]('project.json', null)).toMatchInlineSnapshot(`
+    expect(createNodes[1]('project.json', context)).toMatchInlineSnapshot(`
       {
         "projects": {
           "root": {
@@ -51,7 +60,7 @@ describe('nx project.json plugin', () => {
         },
       }
     `);
-    expect(plugin.createNodes[1]('packages/lib-a/project.json', null))
+    expect(createNodes[1]('packages/lib-a/project.json', context))
       .toMatchInlineSnapshot(`
       {
         "projects": {

--- a/packages/nx/src/plugins/project-json/build-nodes/project-json.ts
+++ b/packages/nx/src/plugins/project-json/build-nodes/project-json.ts
@@ -4,33 +4,32 @@ import { existsSync } from 'node:fs';
 import {
   ProjectConfiguration,
   TargetConfiguration,
-} from '../src/config/workspace-json-project-json';
-import { toProjectName } from '../src/config/workspaces';
-import { readJsonFile } from '../src/utils/fileutils';
-import { NxPluginV2 } from '../src/utils/nx-plugin';
+} from '../../../config/workspace-json-project-json';
+import { toProjectName } from '../../../config/workspaces';
+import { readJsonFile } from '../../../utils/fileutils';
+import { NxPluginV2 } from '../../../utils/nx-plugin';
 import {
   PackageJson,
   readTargetsFromPackageJson,
-} from '../src/utils/package-json';
+} from '../../../utils/package-json';
 
-export function getNxProjectJsonPlugin(root: string): NxPluginV2 {
-  return {
-    name: 'nx-core-build-project-json-nodes',
-    createNodes: [
-      '{project.json,**/project.json}',
-      (file) => {
-        const json = readJsonFile<ProjectConfiguration>(join(root, file));
-        const project = buildProjectFromProjectJson(json, file);
-        mergePackageJsonConfigurationWithProjectJson(project, root);
-        return {
-          projects: {
-            [project.name]: project,
-          },
-        };
-      },
-    ],
-  };
-}
+export const CreateProjectJsonProjectsPlugin: NxPluginV2 = {
+  name: 'nx-core-build-project-json-nodes',
+  createNodes: [
+    '{project.json,**/project.json}',
+    (file, context) => {
+      const root = context.workspaceRoot;
+      const json = readJsonFile<ProjectConfiguration>(join(root, file));
+      const project = buildProjectFromProjectJson(json, file);
+      mergePackageJsonConfigurationWithProjectJson(project, root);
+      return {
+        projects: {
+          [project.name]: project,
+        },
+      };
+    },
+  ],
+};
 
 export function buildProjectFromProjectJson(
   json: Partial<ProjectConfiguration>,

--- a/packages/nx/src/project-graph/build-nodes/index.ts
+++ b/packages/nx/src/project-graph/build-nodes/index.ts
@@ -1,1 +1,0 @@
-export * from './workspace-projects';

--- a/packages/nx/src/project-graph/build-project-graph.ts
+++ b/packages/nx/src/project-graph/build-project-graph.ts
@@ -11,7 +11,7 @@ import {
   writeCache,
 } from './nx-deps-cache';
 import { buildImplicitProjectDependencies } from './build-dependencies';
-import { normalizeProjectNodes } from './build-nodes';
+import { normalizeProjectNodes } from './utils/normalize-project-nodes';
 import { isNxPluginV1, isNxPluginV2, loadNxPlugins } from '../utils/nx-plugin';
 import { getRootTsConfigPath } from '../plugins/js/utils/typescript';
 import {

--- a/packages/nx/src/project-graph/utils/normalize-project-nodes.spec.ts
+++ b/packages/nx/src/project-graph/utils/normalize-project-nodes.spec.ts
@@ -2,7 +2,7 @@ import { ProjectGraphProjectNode } from '../../config/project-graph';
 import {
   normalizeImplicitDependencies,
   normalizeProjectTargets,
-} from './workspace-projects';
+} from './normalize-project-nodes';
 
 describe('workspace-projects', () => {
   let projectGraph: Record<string, ProjectGraphProjectNode> = {

--- a/packages/nx/src/project-graph/utils/normalize-project-nodes.ts
+++ b/packages/nx/src/project-graph/utils/normalize-project-nodes.ts
@@ -1,5 +1,3 @@
-import { join } from 'path';
-import { workspaceRoot } from '../../utils/workspace-root';
 import {
   ProjectGraphProcessorContext,
   ProjectGraphProjectNode,

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -1,7 +1,7 @@
 import { basename } from 'node:path';
 
 import { getNxPackageJsonWorkspacesPlugin } from '../../../plugins/package-json-workspaces';
-import { getNxProjectJsonPlugin } from '../../../plugins/project-json';
+import { CreateProjectJsonProjectsPlugin } from '../../plugins/project-json/build-nodes/project-json';
 import { NxJsonConfiguration, TargetDefaults } from '../../config/nx-json';
 import { ProjectGraphExternalNode } from '../../config/project-graph';
 import {
@@ -93,19 +93,19 @@ export function buildProjectsConfigurationsFromProjectPathsAndPlugins(
   // We push the nx core node builder onto the end, s.t. it overwrites any user specified behavior
   plugins.push(
     getNxPackageJsonWorkspacesPlugin(root),
-    getNxProjectJsonPlugin(root)
+    CreateProjectJsonProjectsPlugin
   );
 
   // We iterate over plugins first - this ensures that plugins specified first take precedence.
   for (const plugin of plugins) {
-    const [pattern, configurationConstructor] = plugin.createNodes ?? [];
+    const [pattern, createNodes] = plugin.createNodes ?? [];
     if (!pattern) {
       continue;
     }
     for (const file of projectFiles) {
       if (minimatch(file, pattern, { dot: true })) {
         const { projects: projectNodes, externalNodes: pluginExternalNodes } =
-          configurationConstructor(file, {
+          createNodes(file, {
             nxJsonConfiguration: nxJson,
             workspaceRoot: root,
           });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The project-json plugin is at `nx/plugins` which may be mistaken as being something people can import.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The project-json plugin is in `src` which indicates that it is something people should not import.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
