### PR TITLE
chore(js): convert typescript dependency processing to a createDepend…

### DIFF
--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.spec.ts
@@ -4,6 +4,7 @@ const tempFs = new TempFs('explicit-project-deps');
 import { ProjectGraphBuilder } from '../../../../project-graph/project-graph-builder';
 import { buildExplicitTypeScriptDependencies } from './explicit-project-dependencies';
 import { retrieveWorkspaceFiles } from '../../../../project-graph/utils/retrieve-workspace-files';
+import { CreateDependenciesContext } from '../../../../utils/nx-plugin';
 
 // projectName => tsconfig import path
 const dependencyProjectNamesToImportPaths = {
@@ -19,9 +20,9 @@ describe('explicit project dependencies', () => {
 
   describe('static imports, dynamic imports, and commonjs requires', () => {
     it('should build explicit dependencies for static imports, and top-level dynamic imports and commonjs requires', async () => {
-      const sourceProjectName = 'proj';
-      const { ctx, builder } = await createVirtualWorkspace({
-        sourceProjectName,
+      const source = 'proj';
+      const ctx = await createContext({
+        source,
         sourceProjectFiles: [
           {
             path: 'libs/proj/index.ts',
@@ -35,43 +36,40 @@ describe('explicit project dependencies', () => {
         ],
       });
 
-      const res = buildExplicitTypeScriptDependencies(
-        builder.getUpdatedProjectGraph(),
-        ctx.filesToProcess
-      );
+      const res = buildExplicitTypeScriptDependencies(ctx);
 
       expect(res).toEqual([
         {
-          sourceProjectName,
-          sourceProjectFile: 'libs/proj/index.ts',
-          targetProjectName: 'proj2',
-          type: 'static',
+          source,
+          sourceFile: 'libs/proj/index.ts',
+          target: 'proj2',
+          dependencyType: 'static',
         },
         {
-          sourceProjectName,
-          sourceProjectFile: 'libs/proj/index.ts',
-          targetProjectName: 'proj4ab',
-          type: 'static',
+          source,
+          sourceFile: 'libs/proj/index.ts',
+          target: 'proj4ab',
+          dependencyType: 'static',
         },
         {
-          sourceProjectName,
-          sourceProjectFile: 'libs/proj/index.ts',
-          targetProjectName: 'npm:npm-package',
-          type: 'static',
+          source,
+          sourceFile: 'libs/proj/index.ts',
+          target: 'npm:npm-package',
+          dependencyType: 'static',
         },
         {
-          sourceProjectName,
-          sourceProjectFile: 'libs/proj/index.ts',
-          targetProjectName: 'proj3a',
-          type: 'dynamic',
+          source,
+          sourceFile: 'libs/proj/index.ts',
+          target: 'proj3a',
+          dependencyType: 'dynamic',
         },
       ]);
     });
 
     it('should build explicit dependencies for static exports', async () => {
-      const sourceProjectName = 'proj';
-      const { ctx, builder } = await createVirtualWorkspace({
-        sourceProjectName,
+      const source = 'proj';
+      const ctx = await createContext({
+        source,
         sourceProjectFiles: [
           {
             path: 'libs/proj/index.ts',
@@ -84,37 +82,34 @@ describe('explicit project dependencies', () => {
         ],
       });
 
-      const res = buildExplicitTypeScriptDependencies(
-        builder.graph,
-        ctx.filesToProcess
-      );
+      const res = buildExplicitTypeScriptDependencies(ctx);
 
       expect(res).toEqual([
         {
-          sourceProjectName,
-          sourceProjectFile: 'libs/proj/index.ts',
-          targetProjectName: 'proj2',
-          type: 'static',
+          source,
+          sourceFile: 'libs/proj/index.ts',
+          target: 'proj2',
+          dependencyType: 'static',
         },
         {
-          sourceProjectName,
-          sourceProjectFile: 'libs/proj/index.ts',
-          targetProjectName: 'proj3a',
-          type: 'static',
+          source,
+          sourceFile: 'libs/proj/index.ts',
+          target: 'proj3a',
+          dependencyType: 'static',
         },
         {
-          sourceProjectName,
-          sourceProjectFile: 'libs/proj/index.ts',
-          targetProjectName: 'proj4ab',
-          type: 'static',
+          source,
+          sourceFile: 'libs/proj/index.ts',
+          target: 'proj4ab',
+          dependencyType: 'static',
         },
       ]);
     });
 
     it('should build explicit dependencies for static exports in .mts files', async () => {
-      const sourceProjectName = 'proj';
-      const { ctx, builder } = await createVirtualWorkspace({
-        sourceProjectName,
+      const source = 'proj';
+      const ctx = await createContext({
+        source,
         sourceProjectFiles: [
           {
             path: 'libs/proj/index.mts',
@@ -127,36 +122,33 @@ describe('explicit project dependencies', () => {
         ],
       });
 
-      const res = buildExplicitTypeScriptDependencies(
-        builder.graph,
-        ctx.filesToProcess
-      );
+      const res = buildExplicitTypeScriptDependencies(ctx);
       expect(res).toEqual([
         {
-          sourceProjectName,
-          sourceProjectFile: 'libs/proj/index.mts',
-          targetProjectName: 'proj2',
-          type: 'static',
+          source,
+          sourceFile: 'libs/proj/index.mts',
+          target: 'proj2',
+          dependencyType: 'static',
         },
         {
-          sourceProjectName,
-          sourceProjectFile: 'libs/proj/index.mts',
-          targetProjectName: 'proj3a',
-          type: 'static',
+          source,
+          sourceFile: 'libs/proj/index.mts',
+          target: 'proj3a',
+          dependencyType: 'static',
         },
         {
-          sourceProjectName,
-          sourceProjectFile: 'libs/proj/index.mts',
-          targetProjectName: 'proj4ab',
-          type: 'static',
+          source,
+          sourceFile: 'libs/proj/index.mts',
+          target: 'proj4ab',
+          dependencyType: 'static',
         },
       ]);
     });
 
     it(`should build explicit dependencies for TypeScript's import/export require syntax, and side-effectful import`, async () => {
-      const sourceProjectName = 'proj';
-      const { ctx, builder } = await createVirtualWorkspace({
-        sourceProjectName,
+      const source = 'proj';
+      const ctx = await createContext({
+        source,
         sourceProjectFiles: [
           {
             path: 'libs/proj/index.ts',
@@ -169,37 +161,34 @@ describe('explicit project dependencies', () => {
         ],
       });
 
-      const res = buildExplicitTypeScriptDependencies(
-        builder.graph,
-        ctx.filesToProcess
-      );
+      const res = buildExplicitTypeScriptDependencies(ctx);
 
       expect(res).toEqual([
         {
-          sourceProjectName,
-          sourceProjectFile: 'libs/proj/index.ts',
-          targetProjectName: 'proj2',
-          type: 'static',
+          source,
+          sourceFile: 'libs/proj/index.ts',
+          target: 'proj2',
+          dependencyType: 'static',
         },
         {
-          sourceProjectName,
-          sourceProjectFile: 'libs/proj/index.ts',
-          targetProjectName: 'proj3a',
-          type: 'static',
+          source,
+          sourceFile: 'libs/proj/index.ts',
+          target: 'proj3a',
+          dependencyType: 'static',
         },
         {
-          sourceProjectName,
-          sourceProjectFile: 'libs/proj/index.ts',
-          targetProjectName: 'proj4ab',
-          type: 'static',
+          source,
+          sourceFile: 'libs/proj/index.ts',
+          target: 'proj4ab',
+          dependencyType: 'static',
         },
       ]);
     });
 
     it('should build explicit dependencies for nested dynamic imports and commonjs requires', async () => {
-      const sourceProjectName = 'proj';
-      const { ctx, builder } = await createVirtualWorkspace({
-        sourceProjectName,
+      const source = 'proj';
+      const ctx = await createContext({
+        source,
         sourceProjectFiles: [
           {
             path: 'libs/proj/nested-dynamic-import.ts',
@@ -233,37 +222,34 @@ describe('explicit project dependencies', () => {
         ],
       });
 
-      const res = buildExplicitTypeScriptDependencies(
-        builder.graph,
-        ctx.filesToProcess
-      );
+      const res = buildExplicitTypeScriptDependencies(ctx);
 
       expect(res).toEqual([
         {
-          sourceProjectName,
-          sourceProjectFile: 'libs/proj/component.tsx',
-          targetProjectName: 'proj2',
-          type: 'dynamic',
+          source,
+          sourceFile: 'libs/proj/component.tsx',
+          target: 'proj2',
+          dependencyType: 'dynamic',
         },
         {
-          sourceProjectName,
-          sourceProjectFile: 'libs/proj/nested-dynamic-import.ts',
-          targetProjectName: 'proj3a',
-          type: 'dynamic',
+          source,
+          sourceFile: 'libs/proj/nested-dynamic-import.ts',
+          target: 'proj3a',
+          dependencyType: 'dynamic',
         },
         {
-          sourceProjectName,
-          sourceProjectFile: 'libs/proj/nested-require.ts',
-          targetProjectName: 'proj4ab',
-          type: 'static',
+          source,
+          sourceFile: 'libs/proj/nested-require.ts',
+          target: 'proj4ab',
+          dependencyType: 'static',
         },
       ]);
     });
 
     it('should build explicit dependencies when relative paths are used', async () => {
-      const sourceProjectName = 'proj';
-      const { ctx, builder } = await createVirtualWorkspace({
-        sourceProjectName,
+      const source = 'proj';
+      const ctx = await createContext({
+        source,
         sourceProjectFiles: [
           {
             path: 'libs/proj/absolute-path.ts',
@@ -280,31 +266,28 @@ describe('explicit project dependencies', () => {
         ],
       });
 
-      const res = buildExplicitTypeScriptDependencies(
-        builder.graph,
-        ctx.filesToProcess
-      );
+      const res = buildExplicitTypeScriptDependencies(ctx);
 
       expect(res).toEqual([
         {
-          sourceProjectName,
-          sourceProjectFile: 'libs/proj/absolute-path.ts',
-          targetProjectName: 'proj3a',
-          type: 'dynamic',
+          source,
+          sourceFile: 'libs/proj/absolute-path.ts',
+          target: 'proj3a',
+          dependencyType: 'dynamic',
         },
         {
-          sourceProjectName,
-          sourceProjectFile: 'libs/proj/relative-path.ts',
-          targetProjectName: 'proj4ab',
-          type: 'dynamic',
+          source,
+          sourceFile: 'libs/proj/relative-path.ts',
+          target: 'proj4ab',
+          dependencyType: 'dynamic',
         },
       ]);
     });
 
     it('should not build explicit dependencies when nx-ignore-next-line comments are present', async () => {
-      const sourceProjectName = 'proj';
-      const { ctx, builder } = await createVirtualWorkspace({
-        sourceProjectName,
+      const source = 'proj';
+      const ctx = await createContext({
+        source,
         sourceProjectFiles: [
           {
             path: 'libs/proj/static-import-1.ts',
@@ -398,18 +381,15 @@ describe('explicit project dependencies', () => {
         ],
       });
 
-      const res = buildExplicitTypeScriptDependencies(
-        builder.graph,
-        ctx.filesToProcess
-      );
+      const res = buildExplicitTypeScriptDependencies(ctx);
 
       expect(res).toEqual([]);
     });
 
     it('should not build explicit dependencies for stringified or templatized import/require statements', async () => {
-      const sourceProjectName = 'proj';
-      const { ctx, builder } = await createVirtualWorkspace({
-        sourceProjectName,
+      const source = 'proj';
+      const ctx = await createContext({
+        source,
         sourceProjectFiles: [
           {
             path: 'libs/proj/stringified-imports-and-require.ts',
@@ -473,10 +453,7 @@ describe('explicit project dependencies', () => {
         ],
       });
 
-      const res = buildExplicitTypeScriptDependencies(
-        builder.graph,
-        ctx.filesToProcess
-      );
+      const res = buildExplicitTypeScriptDependencies(ctx);
 
       expect(res).toEqual([]);
     });
@@ -484,7 +461,7 @@ describe('explicit project dependencies', () => {
 });
 
 interface VirtualWorkspaceConfig {
-  sourceProjectName: string;
+  source: string;
   sourceProjectFiles: {
     path: string;
     content: string;
@@ -495,14 +472,16 @@ interface VirtualWorkspaceConfig {
  * Prepares a minimal workspace and virtual file-system for the given files and dependency
  * projects in order to be able to execute `buildExplicitTypeScriptDependencies()` in the tests.
  */
-async function createVirtualWorkspace(config: VirtualWorkspaceConfig) {
+async function createContext(
+  config: VirtualWorkspaceConfig
+): Promise<CreateDependenciesContext> {
   const nxJson = {
     npmScope: 'proj',
   };
   const projectsFs = {
-    [`./libs/${config.sourceProjectName}/project.json`]: JSON.stringify({
-      name: config.sourceProjectName,
-      sourceRoot: `libs/${config.sourceProjectName}`,
+    [`./libs/${config.source}/project.json`]: JSON.stringify({
+      name: config.source,
+      sourceRoot: `libs/${config.source}`,
     }),
   };
 
@@ -527,19 +506,17 @@ async function createVirtualWorkspace(config: VirtualWorkspaceConfig) {
     compilerOptions: {
       baseUrl: '.',
       paths: {
-        [`@proj/${config.sourceProjectName}`]: [
-          `libs/${config.sourceProjectName}/index.ts`,
-        ],
+        [`@proj/${config.source}`]: [`libs/${config.source}/index.ts`],
       },
     },
   };
 
   const builder = new ProjectGraphBuilder();
   builder.addNode({
-    name: config.sourceProjectName,
+    name: config.source,
     type: 'lib',
     data: {
-      root: `libs/${config.sourceProjectName}`,
+      root: `libs/${config.source}`,
       files: config.sourceProjectFiles.map(({ path }) => ({
         file: path,
       })),
@@ -586,14 +563,10 @@ async function createVirtualWorkspace(config: VirtualWorkspaceConfig) {
     await retrieveWorkspaceFiles(tempFs.tempDir, nxJson);
 
   return {
-    ctx: {
-      projectsConfigurations: {
-        version: 2,
-        projectConfigurations: projectConfigurations,
-      },
-      nxJsonConfiguration: nxJson,
-      filesToProcess: projectFileMap,
-    },
-    builder,
+    graph: builder.getUpdatedProjectGraph(),
+    projectsConfigurations: projectConfigurations,
+    nxJsonConfiguration: nxJson,
+    filesToProcess: projectFileMap,
+    fileMap: projectFileMap,
   };
 }


### PR DESCRIPTION
…encies plugin

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Typescript analysis is implemented as a `processProjectGraph` plugin.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Typescript analysis is implemented as a `createDependencies` plugin. It is still exposed as part of the `processProjectGraph` plugin though. This will change once the rest of the plugin is converted.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
