### PR TITLE
fix(core): bring back setWorkspaceRoot util

### DIFF
--- a/packages/nx/src/utils/workspace-root.ts
+++ b/packages/nx/src/utils/workspace-root.ts
@@ -6,6 +6,7 @@ import { fileExists } from './fileutils';
  */
 export let workspaceRoot = workspaceRootInner(process.cwd(), process.cwd());
 
+// Required for integration tests in projects which depend on Nx at runtime, such as lerna and angular-eslint
 export function setWorkspaceRoot(root: string): void {
   workspaceRoot = root;
 }

--- a/packages/nx/src/utils/workspace-root.ts
+++ b/packages/nx/src/utils/workspace-root.ts
@@ -6,6 +6,10 @@ import { fileExists } from './fileutils';
  */
 export let workspaceRoot = workspaceRootInner(process.cwd(), process.cwd());
 
+export function setWorkspaceRoot(root: string): void {
+  workspaceRoot = root;
+}
+
 export function workspaceRootInner(
   dir: string,
   candidateRoot: string | null


### PR DESCRIPTION
This is needed for integration testing in multiple projects such as lerna and angular-eslint and cannot be removed.

