### PR TITLE
fix(core): load core plugins as part of loading plugins

### DIFF
--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -1,7 +1,5 @@
 import { basename } from 'node:path';
 
-import { getNxPackageJsonWorkspacesPlugin } from '../../../plugins/package-json-workspaces';
-import { CreateProjectJsonProjectsPlugin } from '../../plugins/project-json/build-nodes/project-json';
 import { NxJsonConfiguration, TargetDefaults } from '../../config/nx-json';
 import { ProjectGraphExternalNode } from '../../config/project-graph';
 import {
@@ -89,12 +87,6 @@ export function buildProjectsConfigurationsFromProjectPathsAndPlugins(
 } {
   const projectRootMap: Map<string, ProjectConfiguration> = new Map();
   const externalNodes: Record<string, ProjectGraphExternalNode> = {};
-
-  // We push the nx core node builder onto the end, s.t. it overwrites any user specified behavior
-  plugins.push(
-    getNxPackageJsonWorkspacesPlugin(root),
-    CreateProjectJsonProjectsPlugin
-  );
 
   // We iterate over plugins first - this ensures that plugins specified first take precedence.
   for (const plugin of plugins) {

--- a/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
+++ b/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
@@ -16,14 +16,17 @@ import {
   ProjectGraphExternalNode,
 } from '../../config/project-graph';
 import type { NxWorkspaceFiles } from '../../native';
-import { getGlobPatternsFromPackageManagerWorkspaces } from '../../../plugins/package-json-workspaces';
+import {
+  getGlobPatternsFromPackageManagerWorkspaces,
+  getNxPackageJsonWorkspacesPlugin,
+} from '../../../plugins/package-json-workspaces';
 import { buildProjectsConfigurationsFromProjectPathsAndPlugins } from './project-configuration-utils';
 import {
   loadNxPlugins,
   loadNxPluginsSync,
-  NxPlugin,
   NxPluginV2,
 } from '../../utils/nx-plugin';
+import { CreateProjectJsonProjectsPlugin } from '../../plugins/project-json/build-nodes/project-json';
 
 /**
  * Walks the workspace directory to create the `projectFileMap`, `ProjectConfigurations` and `allWorkspaceFiles`
@@ -229,12 +232,10 @@ export function retrieveProjectConfigurationsWithoutPluginInference(
     root,
     projectGlobPatterns,
     (configs: string[]) => {
-      const { projects } = createProjectConfigurations(
-        root,
-        nxJson,
-        configs,
-        []
-      );
+      const { projects } = createProjectConfigurations(root, nxJson, configs, [
+        getNxPackageJsonWorkspacesPlugin(root),
+        CreateProjectJsonProjectsPlugin,
+      ]);
       return {
         projectNodes: projects,
         externalNodes: {},

--- a/packages/nx/src/utils/nx-plugin.ts
+++ b/packages/nx/src/utils/nx-plugin.ts
@@ -41,6 +41,8 @@ import {
   NxAngularJsonPlugin,
   shouldMergeAngularProjects,
 } from '../adapter/angular-json';
+import { getNxPackageJsonWorkspacesPlugin } from '../../plugins/package-json-workspaces';
+import { CreateProjectJsonProjectsPlugin } from '../plugins/project-json/build-nodes/project-json';
 
 /**
  * Context for {@link CreateNodesFunction}
@@ -225,6 +227,10 @@ export function loadNxPluginsSync(
   jsPlugin.name = 'nx-js-graph-plugin';
   result.push(jsPlugin as NxPlugin);
 
+  if (shouldMergeAngularProjects(root, false)) {
+    result.push(NxAngularJsonPlugin);
+  }
+
   plugins ??= [];
   for (const plugin of plugins) {
     try {
@@ -238,6 +244,12 @@ export function loadNxPluginsSync(
       throw e;
     }
   }
+
+  // We push the nx core node plugins onto the end, s.t. it overwrites any other plugins
+  result.push(
+    getNxPackageJsonWorkspacesPlugin(root),
+    CreateProjectJsonProjectsPlugin
+  );
 
   return result.map(ensurePluginIsV2);
 }
@@ -264,6 +276,12 @@ export async function loadNxPlugins(
   for (const plugin of plugins) {
     result.push(await loadNxPluginAsync(plugin, paths, root));
   }
+
+  // We push the nx core node plugins onto the end, s.t. it overwrites any other plugins
+  result.push(
+    getNxPackageJsonWorkspacesPlugin(root),
+    CreateProjectJsonProjectsPlugin
+  );
 
   return result.map(ensurePluginIsV2);
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`angular.json` is never loaded when using `loadNxPluginsSync`.

The core plugins are not loaded during `loadNxPlugins` and `loadNxPluginsSync`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`angular.json` is loaded when using `loadNxPluginsSync`.

The core plugins are loaded during `loadNxPlugins` and `loadNxPluginsSync`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
