### PR TITLE
fix(core): handle empty lines in dotenv files

### DIFF
--- a/packages/nx/src/migrations/update-16-8-0/escape-dollar-sign-env-variables.ts
+++ b/packages/nx/src/migrations/update-16-8-0/escape-dollar-sign-env-variables.ts
@@ -64,6 +64,11 @@ function parseEnvFile(tree: Tree, envFilePath: string) {
     .split('\n')
     .map((line) => {
       line = line.trim();
+
+      if (!line.includes('$')) {
+        return line;
+      }
+
       const declarations = line.split('=');
       if (declarations[1].includes('$') && !declarations[1].includes(`\\$`)) {
         declarations[1] = declarations[1].replace('$', `\\$`);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Empty lines in .env files will cause the migration to error.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Empty lines in .env files are handled during the migration.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
