### PR TITLE
fix(storybook): increase timeout of angular e2e

### DIFF
--- a/e2e/storybook-angular/src/storybook-angular.test.ts
+++ b/e2e/storybook-angular/src/storybook-angular.test.ts
@@ -35,9 +35,10 @@ describe('Storybook executors for Angular', () => {
       p.kill();
     }, 200_000);
 
+    // Increased timeout because 92% sealing asset processing TerserPlugin
     it('shoud build an Angular based storybook', () => {
       runCLI(`run ${angularStorybookLib}:build-storybook`);
       checkFilesExist(`dist/storybook/${angularStorybookLib}/index.html`);
-    }, 300_000);
+    }, 600_000);
   });
 });


### PR DESCRIPTION
Increase timeout of e2e even more, because it times out at 92% TerserPlugin.
