### PR TITLE
fix(angular): style=none should not create file #18785

### DIFF
--- a/packages/angular/src/generators/component/component.spec.ts
+++ b/packages/angular/src/generators/component/component.spec.ts
@@ -161,6 +161,51 @@ describe('component Generator', () => {
     );
   });
 
+  it('should not create a style file when --style=none', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    addProjectConfiguration(tree, 'lib1', {
+      projectType: 'library',
+      sourceRoot: 'libs/lib1/src',
+      root: 'libs/lib1',
+    });
+    tree.write(
+      'libs/lib1/src/lib/lib.module.ts',
+      `
+    import { NgModule } from '@angular/core';
+    
+    @NgModule({
+      declarations: [],
+      exports: []
+    })
+    export class LibModule {}`
+    );
+    tree.write('libs/lib1/src/index.ts', '');
+
+    // ACT
+    await componentGenerator(tree, {
+      name: 'example',
+      project: 'lib1',
+      style: 'none',
+    });
+
+    // ASSERT
+    expect(
+      tree.exists('libs/lib1/src/lib/example/example.component.none')
+    ).toBeFalsy();
+    expect(tree.read('libs/lib1/src/lib/example/example.component.ts', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "import { Component } from '@angular/core';
+
+      @Component({
+        selector: 'proj-example',
+        templateUrl: './example.component.html',
+      })
+      export class ExampleComponent {}
+      "
+    `);
+  });
+
   it('should create the component correctly and export it in the entry point when "export=true"', async () => {
     // ARRANGE
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });

--- a/packages/angular/src/generators/component/component.ts
+++ b/packages/angular/src/generators/component/component.ts
@@ -61,7 +61,7 @@ export async function componentGenerator(tree: Tree, rawOptions: Schema) {
     tree.delete(pathToTemplateFile);
   }
 
-  if (options.inlineStyle) {
+  if (options.style === 'none' || options.inlineStyle) {
     const pathToStyleFile = joinPathFragments(
       options.directory,
       `${componentNames.fileName}.${typeNames.fileName}.${options.style}`


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When `--style=none` is passed, we are creating a `component.none` file containing styles.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should not create this file when `--style=none`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18785
