### PR TITLE
fix(angular): buildable libs should lint correctly #18802

### DIFF
--- a/packages/angular/src/generators/add-linting/__snapshots__/add-linting.spec.ts.snap
+++ b/packages/angular/src/generators/add-linting/__snapshots__/add-linting.spec.ts.snap
@@ -10,6 +10,13 @@ exports[`addLinting generator should correctly generate the .eslintrc.json file 
   ],
   "overrides": [
     {
+      "files": [
+        "*.json",
+      ],
+      "parser": "jsonc-eslint-parser",
+      "rules": {},
+    },
+    {
       "extends": [
         "plugin:@nx/angular",
         "plugin:@angular-eslint/template/process-inline-templates",
@@ -58,6 +65,13 @@ exports[`addLinting generator support angular v14 should correctly generate the 
     "!**/*",
   ],
   "overrides": [
+    {
+      "files": [
+        "*.json",
+      ],
+      "parser": "jsonc-eslint-parser",
+      "rules": {},
+    },
     {
       "extends": [
         "plugin:@nx/angular",

--- a/packages/angular/src/generators/add-linting/add-linting.ts
+++ b/packages/angular/src/generators/add-linting/add-linting.ts
@@ -48,6 +48,11 @@ export async function addLintingGenerator(
 
     replaceOverridesInLintConfig(tree, options.projectRoot, [
       {
+        files: ['*.json'],
+        parser: 'jsonc-eslint-parser',
+        rules: {},
+      },
+      {
         files: ['*.ts'],
         ...(hasParserOptions
           ? {

--- a/packages/angular/src/generators/add-linting/lib/add-angular-eslint-dependencies.ts
+++ b/packages/angular/src/generators/add-linting/lib/add-angular-eslint-dependencies.ts
@@ -4,6 +4,8 @@ import { versions } from '../../utils/version-utils';
 
 export function addAngularEsLintDependencies(tree: Tree): GeneratorCallback {
   const angularEslintVersionToInstall = versions(tree).angularEslintVersion;
+  const jsoncEslintParserVersionToInstall =
+    versions(tree).jsoncEslintParserVersion;
   return addDependenciesToPackageJson(
     tree,
     {},
@@ -11,6 +13,7 @@ export function addAngularEsLintDependencies(tree: Tree): GeneratorCallback {
       '@angular-eslint/eslint-plugin': angularEslintVersionToInstall,
       '@angular-eslint/eslint-plugin-template': angularEslintVersionToInstall,
       '@angular-eslint/template-parser': angularEslintVersionToInstall,
+      'jsonc-eslint-parser': jsoncEslintParserVersionToInstall,
     }
   );
 }

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -513,6 +513,13 @@ describe('app', () => {
             ],
             "overrides": [
               {
+                "files": [
+                  "*.json",
+                ],
+                "parser": "jsonc-eslint-parser",
+                "rules": {},
+              },
+              {
                 "extends": [
                   "plugin:@nx/angular",
                   "plugin:@angular-eslint/template/process-inline-templates",

--- a/packages/angular/src/generators/convert-tslint-to-eslint/__snapshots__/convert-tslint-to-eslint.spec.ts.snap
+++ b/packages/angular/src/generators/convert-tslint-to-eslint/__snapshots__/convert-tslint-to-eslint.spec.ts.snap
@@ -254,6 +254,13 @@ exports[`convert-tslint-to-eslint should not override .eslint config if migratio
   ],
   "overrides": [
     {
+      "files": [
+        "*.json",
+      ],
+      "parser": "jsonc-eslint-parser",
+      "rules": {},
+    },
+    {
       "extends": [
         "plugin:@nx/angular",
         "plugin:@angular-eslint/template/process-inline-templates",
@@ -561,6 +568,7 @@ exports[`convert-tslint-to-eslint should work for Angular applications 1`] = `
     "eslint": "~8.46.0",
     "eslint-config-prettier": "8.1.0",
     "eslint-plugin-import": "latest",
+    "jsonc-eslint-parser": "^2.1.0",
   },
   "name": "test-name",
 }
@@ -844,6 +852,13 @@ exports[`convert-tslint-to-eslint should work for Angular applications 4`] = `
   ],
   "overrides": [
     {
+      "files": [
+        "*.json",
+      ],
+      "parser": "jsonc-eslint-parser",
+      "rules": {},
+    },
+    {
       "extends": [
         "plugin:@nx/angular",
         "plugin:@angular-eslint/template/process-inline-templates",
@@ -913,6 +928,7 @@ exports[`convert-tslint-to-eslint should work for Angular libraries 1`] = `
     "eslint": "~8.46.0",
     "eslint-config-prettier": "8.1.0",
     "eslint-plugin-import": "latest",
+    "jsonc-eslint-parser": "^2.1.0",
   },
   "name": "test-name",
 }
@@ -1195,6 +1211,13 @@ exports[`convert-tslint-to-eslint should work for Angular libraries 4`] = `
     "!**/*",
   ],
   "overrides": [
+    {
+      "files": [
+        "*.json",
+      ],
+      "parser": "jsonc-eslint-parser",
+      "rules": {},
+    },
     {
       "extends": [
         "plugin:@nx/angular",

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -591,6 +591,52 @@ describe('lib', () => {
         expect(tree.exists(path)).toBeTruthy();
       });
 
+      expect(tree.read('my-dir/my-lib/.eslintrc.json', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "{
+          "extends": ["../../.eslintrc.json"],
+          "ignorePatterns": ["!**/*"],
+          "overrides": [
+            {
+              "files": ["*.json"],
+              "parser": "jsonc-eslint-parser",
+              "rules": {}
+            },
+            {
+              "files": ["*.ts"],
+              "extends": [
+                "plugin:@nx/angular",
+                "plugin:@angular-eslint/template/process-inline-templates"
+              ],
+              "rules": {
+                "@angular-eslint/directive-selector": [
+                  "error",
+                  {
+                    "type": "attribute",
+                    "prefix": "proj",
+                    "style": "camelCase"
+                  }
+                ],
+                "@angular-eslint/component-selector": [
+                  "error",
+                  {
+                    "type": "element",
+                    "prefix": "proj",
+                    "style": "kebab-case"
+                  }
+                ]
+              }
+            },
+            {
+              "files": ["*.html"],
+              "extends": ["plugin:@nx/angular-template"],
+              "rules": {}
+            }
+          ]
+        }
+        "
+      `);
+
       // Make sure these have properties
       [
         {
@@ -1111,6 +1157,13 @@ describe('lib', () => {
               "!**/*",
             ],
             "overrides": [
+              {
+                "files": [
+                  "*.json",
+                ],
+                "parser": "jsonc-eslint-parser",
+                "rules": {},
+              },
               {
                 "extends": [
                   "plugin:@nx/angular",

--- a/packages/angular/src/utils/backward-compatible-versions.ts
+++ b/packages/angular/src/utils/backward-compatible-versions.ts
@@ -37,6 +37,7 @@ export const backwardCompatibleVersions: Record<
     jestPresetAngularVersion: '~12.2.3',
     typesNodeVersion: '16.11.7',
     jasmineMarblesVersion: '^0.9.2',
+    jsoncEslintParserVersion: '^2.1.0',
   },
   angularV15: {
     angularVersion: '~15.2.0',
@@ -64,5 +65,6 @@ export const backwardCompatibleVersions: Record<
     jestPresetAngularVersion: '~13.0.0',
     typesNodeVersion: '16.11.7',
     jasmineMarblesVersion: '^0.9.2',
+    jsoncEslintParserVersion: '^2.1.0',
   },
 };

--- a/packages/angular/src/utils/versions.ts
+++ b/packages/angular/src/utils/versions.ts
@@ -28,3 +28,5 @@ export const tsNodeVersion = '10.9.1';
 export const jestPresetAngularVersion = '~13.1.0';
 export const typesNodeVersion = '16.11.7';
 export const jasmineMarblesVersion = '^0.9.2';
+
+export const jsoncEslintParserVersion = '^2.1.0';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Creating a buildable library in angular creates a setup that fails `nx lint`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Creating a buildable library in angular should create a setup that does not fail `nx lint`

## Notes
There is more work to do here. 
Angular projects do not set up the dependency checks eslint rule. We need to figure out the best approach to adding this support across both the angular package and linter package.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18802
