### PR TITLE
chore(js): clean-up js e2e tests and improve speed

### DIFF
--- a/e2e/js/src/js-executor-node.test.ts
+++ b/e2e/js/src/js-executor-node.test.ts
@@ -8,14 +8,14 @@ import {
   updateProjectConfig,
 } from '@nx/e2e/utils';
 
-describe('js:node error handling', () => {
+describe('js:node executor', () => {
   let scope: string;
 
-  beforeEach(() => {
+  beforeAll(() => {
     scope = newProject();
   });
 
-  afterEach(() => cleanupProject());
+  afterAll(() => cleanupProject());
 
   it('should log out the error', async () => {
     const esbuildLib = uniq('esbuildlib');

--- a/e2e/js/src/js-inlining.test.ts
+++ b/e2e/js/src/js-inlining.test.ts
@@ -12,11 +12,11 @@ import { execSync } from 'child_process';
 describe('inlining', () => {
   let scope: string;
 
-  beforeEach(() => {
+  beforeAll(() => {
     scope = newProject();
   });
 
-  afterEach(() => cleanupProject());
+  afterAll(() => cleanupProject());
 
   it.each(['tsc', 'swc'])(
     'should inline libraries with --bundler=%s',

--- a/e2e/js/src/js-packaging.test.ts
+++ b/e2e/js/src/js-packaging.test.ts
@@ -13,9 +13,8 @@ import {
   updateFile,
 } from '@nx/e2e/utils';
 import { join } from 'path';
-import { ensureDirSync } from 'fs-extra';
 
-describe('bundling libs', () => {
+describe('packaging libs', () => {
   let scope: string;
 
   beforeEach(() => {
@@ -24,7 +23,7 @@ describe('bundling libs', () => {
 
   afterEach(() => cleanupProject());
 
-  it('should support esbuild, rollup, vite bundlers for building libs', () => {
+  it('should bundle libs using esbuild, vite, rollup and be used in CJS/ESM projects', () => {
     const esbuildLib = uniq('esbuildlib');
     const viteLib = uniq('vitelib');
     const rollupLib = uniq('rolluplib');
@@ -123,7 +122,7 @@ describe('bundling libs', () => {
     expect(output).toContain(rollupLib);
   }, 500_000);
 
-  it('should support tsc and swc for building libs', async () => {
+  it('should build with tsc, swc and be used in CJS/ESM projects', async () => {
     const tscLib = uniq('tsclib');
     const swcLib = uniq('swclib');
     const tscEsmLib = uniq('tscesmlib');


### PR DESCRIPTION
This PR cleans up the JS e2e tests and make it faster.

- Names are more descriptive of what's being tested
- Use `beforeAll` and `afterAll` to reuse workspace when possible
- 
## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
