### PR TITLE
fix(js): add a production-only mode to finding npm dependencies for package.json handilng

### DIFF
--- a/packages/eslint-plugin/src/rules/dependency-checks.ts
+++ b/packages/eslint-plugin/src/rules/dependency-checks.ts
@@ -133,6 +133,7 @@ export default createESLintRule<Options, MessageIds>({
       buildTarget, // TODO: What if child library has a build target different from the parent?
       {
         includeTransitiveDependencies,
+        productionOnly: true,
       }
     );
     const expectedDependencyNames = Object.keys(npmDependencies);

--- a/packages/js/src/utils/find-npm-dependencies.spec.ts
+++ b/packages/js/src/utils/find-npm-dependencies.spec.ts
@@ -397,4 +397,80 @@ describe('findNpmDependencies', () => {
       '@acme/lib3': '*',
     });
   });
+
+  it('should supports production-only dependencies', () => {
+    vol.fromJSON(
+      {
+        './libs/lib1/package.json': JSON.stringify({
+          name: '@acme/lib1',
+          version: '0.0.1',
+        }),
+        './nx.json': JSON.stringify(nxJson),
+      },
+      '/root'
+    );
+    const lib1 = {
+      name: 'lib1',
+      type: 'lib' as const,
+      data: {
+        root: 'libs/lib1',
+        targets: { build: {} },
+      },
+    };
+    const projectGraph = {
+      nodes: {
+        lib1: lib1,
+      },
+      externalNodes: {
+        'npm:dev-only': {
+          name: 'npm:dev-only' as const,
+          type: 'npm' as const,
+          data: {
+            packageName: 'dev-only',
+            version: '1.0.0',
+          },
+        },
+      },
+      dependencies: {},
+    };
+    const projectFileMap = {
+      lib1: [
+        { file: 'libs/lib1/index.ts', hash: '123', deps: [] },
+        { file: 'libs/lib1/package.json', hash: '124', deps: ['npm:dev-only'] },
+        {
+          file: 'libs/lib1/esbuild.config.js',
+          hash: '125',
+          deps: ['npm:dev-only'],
+        },
+        {
+          file: 'libs/lib1/webpack.config.js',
+          hash: '125',
+          deps: ['npm:dev-only'],
+        },
+        {
+          file: 'libs/lib1/rollup.config.js',
+          hash: '125',
+          deps: ['npm:dev-only'],
+        },
+        {
+          file: 'libs/lib1/vite.config.ts',
+          hash: '125',
+          deps: ['npm:dev-only'],
+        },
+      ],
+    };
+
+    expect(
+      findNpmDependencies(
+        '/root',
+        lib1,
+        projectGraph,
+        projectFileMap,
+        'build',
+        {
+          productionOnly: true,
+        }
+      )
+    ).toEqual({});
+  });
 });


### PR DESCRIPTION
Currently, if `vite.config.ts` or other similar build configuration exists, and user runs `nx lint` with `@nx/dependency-checks`, it will error out on dev-only dependencies. This is because we correctly mark those `vite.config.ts` files as production build files (i.e. they affect the hashing/caching of the build target), but for detecting dependencies it is incorrect.

This PR excludes these configuration files from being read when linting with `@nx/dependency-checks`.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
