### PR TITLE
feat(linter): add option to ignore files based on pattern

### DIFF
--- a/packages/eslint-plugin/src/rules/dependency-checks.ts
+++ b/packages/eslint-plugin/src/rules/dependency-checks.ts
@@ -22,6 +22,7 @@ export type Options = [
     checkVersionMismatches?: boolean;
     checkMissingPackageJson?: boolean;
     ignoredDependencies?: string[];
+    ignoredFiles?: string[];
     includeTransitiveDependencies?: boolean;
   }
 ];
@@ -49,6 +50,7 @@ export default createESLintRule<Options, MessageIds>({
         properties: {
           buildTargets: [{ type: 'string' }],
           ignoredDependencies: [{ type: 'string' }],
+          ignoredFiles: [{ type: 'string' }],
           checkMissingDependencies: { type: 'boolean' },
           checkObsoleteDependencies: { type: 'boolean' },
           checkVersionMismatches: { type: 'boolean' },
@@ -71,6 +73,7 @@ export default createESLintRule<Options, MessageIds>({
       checkObsoleteDependencies: true,
       checkVersionMismatches: true,
       ignoredDependencies: [],
+      ignoredFiles: [],
       includeTransitiveDependencies: false,
     },
   ],
@@ -80,6 +83,7 @@ export default createESLintRule<Options, MessageIds>({
       {
         buildTargets,
         ignoredDependencies,
+        ignoredFiles,
         checkMissingDependencies,
         checkObsoleteDependencies,
         checkVersionMismatches,
@@ -133,6 +137,7 @@ export default createESLintRule<Options, MessageIds>({
       buildTarget, // TODO: What if child library has a build target different from the parent?
       {
         includeTransitiveDependencies,
+        ignoredFiles,
       }
     );
     const expectedDependencyNames = Object.keys(npmDependencies);

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -1137,6 +1137,20 @@ describe('lib', () => {
         executor: '@nx/vite:test',
       });
       expect(tree.exists('libs/my-lib/vite.config.ts')).toBeTruthy();
+      expect(
+        readJson(tree, 'libs/my-lib/.eslintrc.json').overrides
+      ).toContainEqual({
+        files: ['*.json'],
+        parser: 'jsonc-eslint-parser',
+        rules: {
+          '@nx/dependency-checks': [
+            'error',
+            {
+              ignoredFiles: ['{projectRoot}/vite.config.{js,ts,mjs,mts}'],
+            },
+          ],
+        },
+      });
     });
 
     it.each`
@@ -1157,6 +1171,66 @@ describe('lib', () => {
         expect(project.targets.test?.executor).toEqual(executor);
       }
     );
+  });
+
+  describe('--bundler=esbuild', () => {
+    it('should add build with esbuild', async () => {
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        name: 'myLib',
+        bundler: 'esbuild',
+        unitTestRunner: 'none',
+      });
+
+      const project = readProjectConfiguration(tree, 'my-lib');
+      expect(project.targets.build).toMatchObject({
+        executor: '@nx/esbuild:esbuild',
+      });
+      expect(
+        readJson(tree, 'libs/my-lib/.eslintrc.json').overrides
+      ).toContainEqual({
+        files: ['*.json'],
+        parser: 'jsonc-eslint-parser',
+        rules: {
+          '@nx/dependency-checks': [
+            'error',
+            {
+              ignoredFiles: ['{projectRoot}/esbuild.config.{js,ts,mjs,mts}'],
+            },
+          ],
+        },
+      });
+    });
+  });
+
+  describe('--bundler=rollup', () => {
+    it('should add build with rollup', async () => {
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        name: 'myLib',
+        bundler: 'rollup',
+        unitTestRunner: 'none',
+      });
+
+      const project = readProjectConfiguration(tree, 'my-lib');
+      expect(project.targets.build).toMatchObject({
+        executor: '@nx/rollup:rollup',
+      });
+      expect(
+        readJson(tree, 'libs/my-lib/.eslintrc.json').overrides
+      ).toContainEqual({
+        files: ['*.json'],
+        parser: 'jsonc-eslint-parser',
+        rules: {
+          '@nx/dependency-checks': [
+            'error',
+            {
+              ignoredFiles: ['{projectRoot}/rollup.config.{js,ts,mjs,mts}'],
+            },
+          ],
+        },
+      });
+    });
   });
 
   describe('--minimal', () => {

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -10,6 +10,7 @@ import {
   names,
   offsetFromRoot,
   ProjectConfiguration,
+  readProjectConfiguration,
   runTasksInSerial,
   toJS,
   Tree,
@@ -236,12 +237,14 @@ export type AddLintOptions = Pick<
   | 'js'
   | 'setParserOptionsProject'
   | 'rootProject'
+  | 'bundler'
 >;
 export async function addLint(
   tree: Tree,
   options: AddLintOptions
 ): Promise<GeneratorCallback> {
   const { lintProjectGenerator } = ensurePackage('@nx/linter', nxVersion);
+  const projectConfiguration = readProjectConfiguration(tree, options.name);
   const task = lintProjectGenerator(tree, {
     project: options.name,
     linter: options.linter,
@@ -256,15 +259,17 @@ export async function addLint(
     setParserOptionsProject: options.setParserOptionsProject,
     rootProject: options.rootProject,
   });
+  const {
+    addOverrideToLintConfig,
+    lintConfigHasOverride,
+    isEslintConfigSupported,
+    updateOverrideInLintConfig,
+    // nx-ignore-next-line
+  } = require('@nx/linter/src/generators/utils/eslint-file');
+
   // Also update the root ESLint config. The lintProjectGenerator will not generate it for root projects.
   // But we need to set the package.json checks.
   if (options.rootProject) {
-    const {
-      addOverrideToLintConfig,
-      isEslintConfigSupported,
-      // nx-ignore-next-line
-    } = require('@nx/linter/src/generators/utils/eslint-file');
-
     if (isEslintConfigSupported(tree)) {
       addOverrideToLintConfig(tree, '', {
         files: ['*.json'],
@@ -274,6 +279,56 @@ export async function addLint(
         },
       });
     }
+  }
+
+  // If project lints package.json with @nx/dependency-checks, then add ignore files for
+  // build configuration files such as vite.config.ts. These config files need to be
+  // ignored, otherwise we will errors on missing dependencies that are for dev only.
+  if (
+    lintConfigHasOverride(
+      tree,
+      projectConfiguration.root,
+      (o) =>
+        Array.isArray(o.files)
+          ? o.files.some((f) => f.match(/\.json$/))
+          : !!o.files?.match(/\.json$/),
+      true
+    )
+  ) {
+    updateOverrideInLintConfig(
+      tree,
+      projectConfiguration.root,
+      (o) => o.rules?.['@nx/dependency-checks'],
+      (o) => {
+        const value = o.rules['@nx/dependency-checks'];
+        let ruleSeverity: string;
+        let ruleOptions: any;
+        if (Array.isArray(value)) {
+          ruleSeverity = value[0];
+          ruleOptions = value[1];
+        } else {
+          ruleSeverity = value;
+          ruleOptions = {};
+        }
+        if (options.bundler === 'vite' || options.unitTestRunner === 'vitest') {
+          ruleOptions.ignoredFiles = [
+            '{projectRoot}/vite.config.{js,ts,mjs,mts}',
+          ];
+          o.rules['@nx/dependency-checks'] = [ruleSeverity, ruleOptions];
+        } else if (options.bundler === 'rollup') {
+          ruleOptions.ignoredFiles = [
+            '{projectRoot}/rollup.config.{js,ts,mjs,mts}',
+          ];
+          o.rules['@nx/dependency-checks'] = [ruleSeverity, ruleOptions];
+        } else if (options.bundler === 'esbuild') {
+          ruleOptions.ignoredFiles = [
+            '{projectRoot}/esbuild.config.{js,ts,mjs,mts}',
+          ];
+          o.rules['@nx/dependency-checks'] = [ruleSeverity, ruleOptions];
+        }
+        return o;
+      }
+    );
   }
   return task;
 }

--- a/packages/js/src/utils/find-npm-dependencies.spec.ts
+++ b/packages/js/src/utils/find-npm-dependencies.spec.ts
@@ -397,4 +397,57 @@ describe('findNpmDependencies', () => {
       '@acme/lib3': '*',
     });
   });
+
+  it('should support ignoring extra file patterns in addition to task input', () => {
+    vol.fromJSON(
+      {
+        './nx.json': JSON.stringify(nxJson),
+      },
+      '/root'
+    );
+    const lib = {
+      name: 'my-lib',
+      type: 'lib' as const,
+      data: {
+        root: 'libs/my-lib',
+        targets: { build: {} },
+      },
+    };
+    const projectGraph = {
+      nodes: {
+        'my-lib': lib,
+      },
+      externalNodes: {
+        'npm:foo': {
+          name: 'npm:foo' as const,
+          type: 'npm' as const,
+          data: {
+            packageName: 'foo',
+            version: '1.0.0',
+          },
+        },
+      },
+      dependencies: {},
+    };
+    const projectFileMap = {
+      'my-lib': [
+        {
+          file: 'libs/my-lib/vite.config.ts',
+          hash: '123',
+          deps: ['npm:foo'],
+        },
+      ],
+    };
+
+    const results = findNpmDependencies(
+      '/root',
+      lib,
+      projectGraph,
+      projectFileMap,
+      'build',
+      { ignoredFiles: ['{projectRoot}/vite.config.ts'] }
+    );
+
+    expect(results).toEqual({});
+  });
 });

--- a/packages/js/src/utils/find-npm-dependencies.ts
+++ b/packages/js/src/utils/find-npm-dependencies.ts
@@ -27,6 +27,7 @@ export function findNpmDependencies(
   buildTarget: string,
   options: {
     includeTransitiveDependencies?: boolean;
+    ignoredFiles?: string[];
   } = {}
 ): Record<string, string> {
   let seen: null | Set<string> = null;
@@ -41,6 +42,7 @@ export function findNpmDependencies(
     collectedDeps: Record<string, string>
   ): void {
     if (seen?.has(currentProject.name)) return;
+    seen?.add(currentProject.name);
 
     collectDependenciesFromFileMap(
       workspaceRoot,
@@ -48,6 +50,7 @@ export function findNpmDependencies(
       projectGraph,
       projectFileMap,
       buildTarget,
+      options.ignoredFiles,
       collectedDeps
     );
 
@@ -82,19 +85,22 @@ function collectDependenciesFromFileMap(
   projectGraph: ProjectGraph,
   projectFileMap: ProjectFileMap,
   buildTarget: string,
+  ignoredFiles: string[],
   npmDeps: Record<string, string>
 ): void {
   const rawFiles = projectFileMap[sourceProject.name];
   if (!rawFiles) return;
 
-  // Cannot read inputs if the target does not exist on the project.
-  if (!sourceProject.data.targets[buildTarget]) return;
-
-  const inputs = getTargetInputs(
-    readNxJson(),
-    sourceProject,
-    buildTarget
-  ).selfInputs;
+  // If build target does not exist in project, use all files as input.
+  // This is needed for transitive dependencies for apps -- where libs may not be buildable.
+  const inputs = sourceProject.data.targets[buildTarget]
+    ? getTargetInputs(readNxJson(), sourceProject, buildTarget).selfInputs
+    : ['{projectRoot}/**/*'];
+  if (ignoredFiles) {
+    for (const pattern of ignoredFiles) {
+      inputs.push(`!${pattern}`);
+    }
+  }
   const files = filterUsingGlobPatterns(
     sourceProject.data.root,
     projectFileMap[sourceProject.name] || [],
@@ -128,7 +134,12 @@ function collectDependenciesFromFileMap(
         npmDeps[cached.name] = cached.version;
       } else {
         const packageJson = readPackageJson(workspaceDep, workspaceRoot);
-        if (packageJson) {
+        if (
+          // Check that this is a buildable project, otherwise it cannot be a dependency in package.json.
+          workspaceDep.data.targets[buildTarget] &&
+          // Make sure package.json exists and has a valid name.
+          packageJson?.name
+        ) {
           // This is a workspace lib so we can't reliably read in a specific version since it depends on how the workspace is set up.
           // ASSUMPTION: Most users will use '*' for workspace lib versions. Otherwise, they can manually update it.
           npmDeps[packageJson.name] = '*';


### PR DESCRIPTION
This PR adds a `ignoredFiles` option to the `@nx/dependency-checks` rule. Useful for build config files that import dev-only dependencies.

The `@nx/js:lib` generator that adds the checks for `package.json` will also ignore build configuration files such that packges imported in them will not count towards production dependencies.

e.g. `vite.config.ts` imports `vite`, which is not a production dependency so should not be reported as a missing dependency.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
