### PR TITLE
fix(nx-dev): improve mobile documentation header

### DIFF
--- a/nx-dev/ui-common/src/lib/documentation-header.tsx
+++ b/nx-dev/ui-common/src/lib/documentation-header.tsx
@@ -161,7 +161,7 @@ export function DocumentationHeader({
           </button>
 
           {/*SEARCH*/}
-          <div className="mx-4 w-full">
+          <div className="mx-4 w-auto">
             <AlgoliaSearch />
           </div>
         </div>
@@ -169,7 +169,7 @@ export function DocumentationHeader({
         <div className="flex items-center">
           <Link
             href="/"
-            className="flex items-center px-4 text-slate-900 dark:text-white lg:px-0"
+            className="flex flex-grow items-center px-4 text-slate-900 dark:text-white lg:px-0"
           >
             <svg
               role="img"
@@ -184,7 +184,7 @@ export function DocumentationHeader({
           </Link>
           <Link
             href="/getting-started/intro"
-            className="flex ml-2 items-center px-4 text-slate-900 dark:text-white lg:px-0"
+            className="hidden lg:flex ml-2 items-center px-4 text-slate-900 dark:text-white lg:px-0"
           >
             <span className="text-xl font-bold uppercase tracking-wide">
               Docs


### PR DESCRIPTION
The documentation header in `nx-dev` has been updated to improve the mobile user experience. Changes include adjusting the width of a container to auto and modifying the visibility and positioning of items within flex containers.

<img width="374" alt="mobile" src="https://github.com/nrwl/nx/assets/3447705/faa30ff9-1f1e-4972-b854-4b8785d459ee">
