### PR TITLE
fix(core): use correct break line char in deprecated generator message printed by the generate command

### DIFF
--- a/packages/nx/src/command-line/generate/generate.ts
+++ b/packages/nx/src/command-line/generate/generate.ts
@@ -336,7 +336,7 @@ export async function generate(cwd: string, args: { [k: string]: any }) {
         [
           `${NX_PREFIX}: ${opts.collectionName}:${normalizedGeneratorName} is deprecated`,
           `${deprecated}`,
-        ].join('/n')
+        ].join('\n')
       );
     }
     if (!opts.quiet && !opts.help) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
