### PR TITLE
fix(nx-plugin): fix explicity obsolete type

### DIFF
--- a/packages/plugin/src/generators/create-package/files/e2e/__cliName__.spec.ts__tmpl__
+++ b/packages/plugin/src/generators/create-package/files/e2e/__cliName__.spec.ts__tmpl__
@@ -29,7 +29,7 @@ describe('<%= cliName %>', () => {
  * Creates a test project with create-nx-workspace and installs the plugin
  * @returns The directory where the test project was created
  */
-function createTestProject(extraArgs: string = '') {
+function createTestProject(extraArgs = '') {
   const projectName = 'test-project';
   const projectDirectory = join(process.cwd(), 'tmp', projectName);
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Generated plugin fails on lint with `Type string trivially inferred from a string literal, remove type annotation.` due to `@typescript-eslint/no-inferrable-types`


## Expected Behavior
Freshly generated plugin should not fail on lint

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
