### PR TITLE
fix(nx-plugin): install missing tslib dependencies in create-package generator

### DIFF
--- a/packages/js/src/utils/typescript/add-tslib-dependencies.ts
+++ b/packages/js/src/utils/typescript/add-tslib-dependencies.ts
@@ -1,12 +1,17 @@
-import { addDependenciesToPackageJson, Tree } from '@nx/devkit';
+import {
+  addDependenciesToPackageJson,
+  joinPathFragments,
+  Tree,
+} from '@nx/devkit';
 import { tsLibVersion } from '../versions';
 
-export function addTsLibDependencies(tree: Tree) {
+export function addTsLibDependencies(tree: Tree, root: string = '') {
   return addDependenciesToPackageJson(
     tree,
     {
       tslib: tsLibVersion,
     },
-    {}
+    {},
+    joinPathFragments(root, 'package.json')
   );
 }

--- a/packages/plugin/src/generators/create-package/create-package.ts
+++ b/packages/plugin/src/generators/create-package/create-package.ts
@@ -15,7 +15,10 @@ import {
   detectPackageManager,
   getPackageManagerCommand,
 } from '@nx/devkit';
-import { libraryGenerator as jsLibraryGenerator } from '@nx/js';
+import {
+  addTsLibDependencies,
+  libraryGenerator as jsLibraryGenerator,
+} from '@nx/js';
 import { nxVersion } from 'nx/src/utils/versions';
 import generatorGenerator from '../generator/generator';
 import { CreatePackageSchema } from './schema';
@@ -118,6 +121,10 @@ async function createCliPackage(
       return packageJson;
     }
   );
+
+  if (options.compiler === 'tsc') {
+    addTsLibDependencies(host, options.projectRoot);
+  }
 
   // update project build target to use the bin entry
   const projectConfiguration = readProjectConfiguration(


### PR DESCRIPTION
ESLint is erroring on a freshly created `create-nx-plugin` workspace: 
<img width="988" alt="image" src="https://github.com/nrwl/nx/assets/34165455/57e53ff6-a453-4084-8eaf-f59b6b2a6564">

I made sure `tslib` is added to the project from the beginning so folks don't have to run `lint --fix` first