### PR TITLE
fix(node): pass projectNameAndRootFormat to js lib generator from nest lib generator

### DIFF
--- a/packages/express/src/generators/application/application.spec.ts
+++ b/packages/express/src/generators/application/application.spec.ts
@@ -7,24 +7,25 @@ describe('app', () => {
   let appTree: Tree;
 
   beforeEach(() => {
-    appTree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    appTree = createTreeWithEmptyWorkspace();
   });
 
   it('should generate files', async () => {
     await applicationGenerator(appTree, {
       name: 'myNodeApp',
+      projectNameAndRootFormat: 'as-provided',
     } as Schema);
 
-    const mainFile = appTree.read('apps/my-node-app/src/main.ts').toString();
+    const mainFile = appTree.read('my-node-app/src/main.ts').toString();
     expect(mainFile).toContain(`import express from 'express';`);
 
-    const tsconfig = readJson(appTree, 'apps/my-node-app/tsconfig.json');
+    const tsconfig = readJson(appTree, 'my-node-app/tsconfig.json');
     expect(tsconfig).toMatchInlineSnapshot(`
       {
         "compilerOptions": {
           "esModuleInterop": true,
         },
-        "extends": "../../tsconfig.base.json",
+        "extends": "../tsconfig.base.json",
         "files": [],
         "include": [],
         "references": [
@@ -38,11 +39,11 @@ describe('app', () => {
       }
     `);
 
-    const eslintrcJson = readJson(appTree, 'apps/my-node-app/.eslintrc.json');
+    const eslintrcJson = readJson(appTree, 'my-node-app/.eslintrc.json');
     expect(eslintrcJson).toMatchInlineSnapshot(`
       {
         "extends": [
-          "../../.eslintrc.json",
+          "../.eslintrc.json",
         ],
         "ignorePatterns": [
           "!**/*",
@@ -79,14 +80,15 @@ describe('app', () => {
   it('should add types to the tsconfig.app.json', async () => {
     await applicationGenerator(appTree, {
       name: 'myNodeApp',
+      projectNameAndRootFormat: 'as-provided',
     } as Schema);
-    const tsconfig = readJson(appTree, 'apps/my-node-app/tsconfig.app.json');
+    const tsconfig = readJson(appTree, 'my-node-app/tsconfig.app.json');
     expect(tsconfig.compilerOptions.types).toContain('express');
     expect(tsconfig).toMatchInlineSnapshot(`
       {
         "compilerOptions": {
           "module": "commonjs",
-          "outDir": "../../dist/out-tsc",
+          "outDir": "../dist/out-tsc",
           "types": [
             "node",
             "express",
@@ -110,23 +112,21 @@ describe('app', () => {
       await applicationGenerator(appTree, {
         name: 'myNodeApp',
         js: true,
+        projectNameAndRootFormat: 'as-provided',
       } as Schema);
 
-      expect(appTree.exists('apps/my-node-app/src/main.js')).toBeTruthy();
-      expect(appTree.read('apps/my-node-app/src/main.js').toString()).toContain(
+      expect(appTree.exists('my-node-app/src/main.js')).toBeTruthy();
+      expect(appTree.read('my-node-app/src/main.js').toString()).toContain(
         `import express from 'express';`
       );
 
-      const tsConfig = readJson(appTree, 'apps/my-node-app/tsconfig.json');
+      const tsConfig = readJson(appTree, 'my-node-app/tsconfig.json');
       expect(tsConfig.compilerOptions).toEqual({
         allowJs: true,
         esModuleInterop: true,
       });
 
-      const tsConfigApp = readJson(
-        appTree,
-        'apps/my-node-app/tsconfig.app.json'
-      );
+      const tsConfigApp = readJson(appTree, 'my-node-app/tsconfig.app.json');
       expect(tsConfigApp.include).toEqual(['src/**/*.ts', 'src/**/*.js']);
       expect(tsConfigApp.exclude).toEqual([
         'jest.config.ts',

--- a/packages/express/src/generators/init/init.spec.ts
+++ b/packages/express/src/generators/init/init.spec.ts
@@ -1,9 +1,4 @@
-import {
-  addDependenciesToPackageJson,
-  readJson,
-  NxJsonConfiguration,
-  Tree,
-} from '@nx/devkit';
+import { addDependenciesToPackageJson, readJson, Tree } from '@nx/devkit';
 import { expressVersion } from '../../utils/versions';
 import initGenerator from './init';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
@@ -12,7 +7,7 @@ describe('init', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should add dependencies', async () => {

--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -9,12 +9,15 @@ describe('application generator', () => {
   const appDirectory = 'my-node-app';
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
     jest.clearAllMocks();
   });
 
   it('should generate project configurations', async () => {
-    await applicationGenerator(tree, { name: appName });
+    await applicationGenerator(tree, {
+      name: appName,
+      projectNameAndRootFormat: 'as-provided',
+    });
 
     const projectConfigurations = devkit.getProjects(tree);
 
@@ -23,33 +26,32 @@ describe('application generator', () => {
   });
 
   it('should generate files', async () => {
-    await applicationGenerator(tree, { name: appName });
+    await applicationGenerator(tree, {
+      name: appName,
+      projectNameAndRootFormat: 'as-provided',
+    });
 
-    expect(tree.exists(`apps/${appDirectory}/src/main.ts`)).toBeTruthy();
+    expect(tree.exists(`${appDirectory}/src/main.ts`)).toBeTruthy();
     expect(
-      tree.exists(`apps/${appDirectory}/src/app/app.controller.spec.ts`)
+      tree.exists(`${appDirectory}/src/app/app.controller.spec.ts`)
     ).toBeTruthy();
     expect(
-      tree.exists(`apps/${appDirectory}/src/app/app.controller.ts`)
+      tree.exists(`${appDirectory}/src/app/app.controller.ts`)
     ).toBeTruthy();
+    expect(tree.exists(`${appDirectory}/src/app/app.module.ts`)).toBeTruthy();
     expect(
-      tree.exists(`apps/${appDirectory}/src/app/app.module.ts`)
+      tree.exists(`${appDirectory}/src/app/app.service.spec.ts`)
     ).toBeTruthy();
-    expect(
-      tree.exists(`apps/${appDirectory}/src/app/app.service.spec.ts`)
-    ).toBeTruthy();
-    expect(
-      tree.exists(`apps/${appDirectory}/src/app/app.service.ts`)
-    ).toBeTruthy();
+    expect(tree.exists(`${appDirectory}/src/app/app.service.ts`)).toBeTruthy();
   });
 
   it('should configure tsconfig correctly', async () => {
-    await applicationGenerator(tree, { name: appName });
+    await applicationGenerator(tree, {
+      name: appName,
+      projectNameAndRootFormat: 'as-provided',
+    });
 
-    const tsConfig = devkit.readJson(
-      tree,
-      `apps/${appDirectory}/tsconfig.app.json`
-    );
+    const tsConfig = devkit.readJson(tree, `${appDirectory}/tsconfig.app.json`);
     expect(tsConfig.compilerOptions.emitDecoratorMetadata).toBe(true);
     expect(tsConfig.compilerOptions.target).toBe('es2021');
     expect(tsConfig.exclude).toEqual([
@@ -60,11 +62,12 @@ describe('application generator', () => {
   });
 
   it('should add strict checks with --strict', async () => {
-    await applicationGenerator(tree, { name: appName, strict: true });
-    const tsConfig = devkit.readJson(
-      tree,
-      `apps/${appDirectory}/tsconfig.app.json`
-    );
+    await applicationGenerator(tree, {
+      name: appName,
+      strict: true,
+      projectNameAndRootFormat: 'as-provided',
+    });
+    const tsConfig = devkit.readJson(tree, `${appDirectory}/tsconfig.app.json`);
 
     expect(tsConfig.compilerOptions.strictNullChecks).toBeTruthy();
     expect(tsConfig.compilerOptions.noImplicitAny).toBeTruthy();
@@ -79,7 +82,10 @@ describe('application generator', () => {
     it('should format files', async () => {
       jest.spyOn(devkit, 'formatFiles');
 
-      await applicationGenerator(tree, { name: appName });
+      await applicationGenerator(tree, {
+        name: appName,
+        projectNameAndRootFormat: 'as-provided',
+      });
 
       expect(devkit.formatFiles).toHaveBeenCalled();
     });
@@ -87,7 +93,11 @@ describe('application generator', () => {
     it('should not format files when --skipFormat=true', async () => {
       jest.spyOn(devkit, 'formatFiles');
 
-      await applicationGenerator(tree, { name: appName, skipFormat: true });
+      await applicationGenerator(tree, {
+        name: appName,
+        skipFormat: true,
+        projectNameAndRootFormat: 'as-provided',
+      });
 
       expect(devkit.formatFiles).not.toHaveBeenCalled();
     });
@@ -98,6 +108,7 @@ describe('application generator', () => {
       await applicationGenerator(tree, {
         name: appName,
         e2eTestRunner: 'none',
+        projectNameAndRootFormat: 'as-provided',
       });
 
       const projectConfigurations = devkit.getProjects(tree);

--- a/packages/nest/src/generators/convert-tslint-to-eslint/__snapshots__/convert-tslint-to-eslint.spec.ts.snap
+++ b/packages/nest/src/generators/convert-tslint-to-eslint/__snapshots__/convert-tslint-to-eslint.spec.ts.snap
@@ -18,16 +18,16 @@ exports[`convert-tslint-to-eslint should work for NestJS applications 1`] = `
 
 exports[`convert-tslint-to-eslint should work for NestJS applications 2`] = `
 {
-  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "$schema": "../node_modules/nx/schemas/project-schema.json",
   "name": "nest-app-1",
   "projectType": "application",
-  "root": "apps/nest-app-1",
+  "root": "nest-app-1",
   "targets": {
     "lint": {
       "executor": "@nx/linter:eslint",
       "options": {
         "lintFilePatterns": [
-          "apps/nest-app-1/**/*.ts",
+          "nest-app-1/**/*.ts",
         ],
       },
       "outputs": [
@@ -246,7 +246,7 @@ exports[`convert-tslint-to-eslint should work for NestJS applications 3`] = `
 exports[`convert-tslint-to-eslint should work for NestJS applications 4`] = `
 {
   "extends": [
-    "../../.eslintrc.json",
+    "../.eslintrc.json",
   ],
   "ignorePatterns": [
     "!**/*",

--- a/packages/nest/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.spec.ts
+++ b/packages/nest/src/generators/convert-tslint-to-eslint/convert-tslint-to-eslint.spec.ts
@@ -12,7 +12,7 @@ import { exampleRootTslintJson } from '@nx/linter';
 import { conversionGenerator } from './convert-tslint-to-eslint';
 
 const appProjectName = 'nest-app-1';
-const appProjectRoot = `apps/${appProjectName}`;
+const appProjectRoot = `${appProjectName}`;
 const appProjectTSLintJsonPath = joinPathFragments(
   appProjectRoot,
   'tslint.json'
@@ -98,7 +98,7 @@ describe('convert-tslint-to-eslint', () => {
 
   beforeEach(async () => {
     jest.spyOn(devkit, 'installPackagesTask');
-    host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    host = createTreeWithEmptyWorkspace();
 
     writeJson(host, 'tslint.json', exampleRootTslintJson.raw);
 
@@ -114,8 +114,8 @@ describe('convert-tslint-to-eslint', () => {
         lint: {
           executor: '@angular-devkit/build-angular:tslint',
           options: {
-            exclude: ['**/node_modules/**', '!apps/nest-app-1/**/*'],
-            tsConfig: ['apps/nest-app-1/tsconfig.app.json'],
+            exclude: ['**/node_modules/**', '!nest-app-1/**/*'],
+            tsConfig: ['nest-app-1/tsconfig.app.json'],
           },
         },
       },
@@ -143,7 +143,7 @@ describe('convert-tslint-to-eslint', () => {
     /**
      * Existing tslint.json file for the app project
      */
-    writeJson(host, 'apps/nest-app-1/tslint.json', projectTslintJsonData.raw);
+    writeJson(host, 'nest-app-1/tslint.json', projectTslintJsonData.raw);
     /**
      * Existing tslint.json file for the lib project
      */

--- a/packages/nest/src/generators/init/init.spec.ts
+++ b/packages/nest/src/generators/init/init.spec.ts
@@ -12,7 +12,7 @@ describe('init generator', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
     jest.clearAllMocks();
   });
 

--- a/packages/nest/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/nest/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -4,12 +4,12 @@ exports[`lib --testEnvironment should set target jest testEnvironment to jsdom 1
 "/* eslint-disable */
 export default {
   displayName: 'my-lib',
-  preset: '../../jest.preset.js',
+  preset: '../jest.preset.js',
   transform: {
     '^.+\\\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
-  coverageDirectory: '../../coverage/libs/my-lib',
+  coverageDirectory: '../coverage/my-lib',
 };
 "
 `;
@@ -18,13 +18,13 @@ exports[`lib --testEnvironment should set target jest testEnvironment to node by
 "/* eslint-disable */
 export default {
   displayName: 'my-lib',
-  preset: '../../jest.preset.js',
+  preset: '../jest.preset.js',
   testEnvironment: 'node',
   transform: {
     '^.+\\\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
-  coverageDirectory: '../../coverage/libs/my-lib',
+  coverageDirectory: '../coverage/my-lib',
 };
 "
 `;
@@ -40,7 +40,7 @@ exports[`lib --unit-test-runner none should not generate test configuration 1`] 
     "noPropertyAccessFromIndexSignature": true,
     "strict": true,
   },
-  "extends": "../../tsconfig.base.json",
+  "extends": "../tsconfig.base.json",
   "files": [],
   "include": [],
   "references": [
@@ -56,7 +56,7 @@ exports[`lib --unit-test-runner none should not generate test configuration 2`] 
   "executor": "@nx/linter:eslint",
   "options": {
     "lintFilePatterns": [
-      "libs/my-lib/**/*.ts",
+      "my-lib/**/*.ts",
     ],
   },
   "outputs": [
@@ -76,7 +76,7 @@ exports[`lib nested should create a local tsconfig.json 1`] = `
     "noPropertyAccessFromIndexSignature": true,
     "strict": true,
   },
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../tsconfig.base.json",
   "files": [],
   "include": [],
   "references": [
@@ -114,7 +114,7 @@ exports[`lib not nested should create a local tsconfig.json 1`] = `
     "noPropertyAccessFromIndexSignature": true,
     "strict": true,
   },
-  "extends": "../../tsconfig.base.json",
+  "extends": "../tsconfig.base.json",
   "files": [],
   "include": [],
   "references": [
@@ -131,7 +131,7 @@ exports[`lib not nested should create a local tsconfig.json 1`] = `
 exports[`lib not nested should generate files 1`] = `
 {
   "extends": [
-    "../../.eslintrc.json",
+    "../.eslintrc.json",
   ],
   "ignorePatterns": [
     "!**/*",

--- a/packages/nest/src/generators/library/lib/normalize-options.ts
+++ b/packages/nest/src/generators/library/lib/normalize-options.ts
@@ -69,5 +69,6 @@ export function toJsLibraryGeneratorOptions(
     unitTestRunner: options.unitTestRunner,
     config: options.standaloneConfig ? 'project' : 'workspace',
     setParserOptionsProject: options.setParserOptionsProject,
+    projectNameAndRootFormat: options.projectNameAndRootFormat,
   };
 }

--- a/packages/nest/src/generators/library/library.spec.ts
+++ b/packages/nest/src/generators/library/library.spec.ts
@@ -6,33 +6,34 @@ import { libraryGenerator } from './library';
 
 describe('lib', () => {
   let tree: Tree;
-  const libFileName = 'my-lib';
-  const libName = 'myLib';
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
     jest.clearAllMocks();
   });
 
   describe('not nested', () => {
     it('should update project configuration', async () => {
-      await libraryGenerator(tree, { name: libName });
+      await libraryGenerator(tree, {
+        name: 'myLib',
+        projectNameAndRootFormat: 'as-provided',
+      });
 
-      const config = readProjectConfiguration(tree, libFileName);
-      expect(config.root).toEqual(`libs/${libFileName}`);
+      const config = readProjectConfiguration(tree, 'my-lib');
+      expect(config.root).toEqual(`my-lib`);
       expect(config.targets.build).toBeUndefined();
       expect(config.targets.lint).toEqual({
         executor: '@nx/linter:eslint',
         outputs: ['{options.outputFile}'],
         options: {
-          lintFilePatterns: [`libs/${libFileName}/**/*.ts`],
+          lintFilePatterns: [`my-lib/**/*.ts`],
         },
       });
       expect(config.targets.test).toEqual({
         executor: '@nx/jest:jest',
         outputs: [`{workspaceRoot}/coverage/{projectRoot}`],
         options: {
-          jestConfig: `libs/${libFileName}/jest.config.ts`,
+          jestConfig: `my-lib/jest.config.ts`,
           passWithNoTests: true,
         },
         configurations: {
@@ -45,111 +46,119 @@ describe('lib', () => {
     });
 
     it('should include a controller', async () => {
-      await libraryGenerator(tree, { name: libName, controller: true });
+      await libraryGenerator(tree, {
+        name: 'myLib',
+        controller: true,
+        projectNameAndRootFormat: 'as-provided',
+      });
 
-      expect(
-        tree.exists(`libs/${libFileName}/src/lib/${libFileName}.controller.ts`)
-      ).toBeTruthy();
+      expect(tree.exists(`my-lib/src/lib/my-lib.controller.ts`)).toBeTruthy();
     });
 
     it('should include a service', async () => {
-      await libraryGenerator(tree, { name: libName, service: true });
+      await libraryGenerator(tree, {
+        name: 'myLib',
+        service: true,
+        projectNameAndRootFormat: 'as-provided',
+      });
 
-      expect(
-        tree.exists(`libs/${libFileName}/src/lib/${libFileName}.service.ts`)
-      ).toBeTruthy();
+      expect(tree.exists(`my-lib/src/lib/my-lib.service.ts`)).toBeTruthy();
     });
 
     it('should add the @Global decorator', async () => {
-      await libraryGenerator(tree, { name: libName, global: true });
+      await libraryGenerator(tree, {
+        name: 'myLib',
+        global: true,
+        projectNameAndRootFormat: 'as-provided',
+      });
 
       expect(
-        tree.read(
-          `libs/${libFileName}/src/lib/${libFileName}.module.ts`,
-          'utf-8'
-        )
+        tree.read(`my-lib/src/lib/my-lib.module.ts`, 'utf-8')
       ).toMatchSnapshot();
     });
 
     it('should remove the default file from @nx/node:lib', async () => {
-      await libraryGenerator(tree, { name: libName, global: true });
+      await libraryGenerator(tree, {
+        name: 'myLib',
+        global: true,
+        projectNameAndRootFormat: 'as-provided',
+      });
 
-      expect(
-        tree.exists(`libs/${libFileName}/src/lib/${libFileName}.spec.ts`)
-      ).toBeFalsy();
-      expect(
-        tree.exists(`libs/${libFileName}/src/lib/${libFileName}.ts`)
-      ).toBeFalsy();
+      expect(tree.exists(`my-lib/src/lib/my-lib.spec.ts`)).toBeFalsy();
+      expect(tree.exists(`my-lib/src/lib/my-lib.ts`)).toBeFalsy();
     });
 
     it('should provide the controller and service', async () => {
       await libraryGenerator(tree, {
-        name: libName,
+        name: 'myLib',
         controller: true,
         service: true,
+        projectNameAndRootFormat: 'as-provided',
       });
 
       expect(
-        tree.read(
-          `libs/${libFileName}/src/lib/${libFileName}.module.ts`,
-          'utf-8'
-        )
+        tree.read(`my-lib/src/lib/my-lib.module.ts`, 'utf-8')
       ).toMatchSnapshot();
       expect(
-        tree.read(
-          `libs/${libFileName}/src/lib/${libFileName}.controller.ts`,
-          'utf-8'
-        )
+        tree.read(`my-lib/src/lib/my-lib.controller.ts`, 'utf-8')
       ).toMatchSnapshot();
-      expect(
-        tree.read(`libs/${libFileName}/src/index.ts`, 'utf-8')
-      ).toMatchSnapshot();
+      expect(tree.read(`my-lib/src/index.ts`, 'utf-8')).toMatchSnapshot();
     });
 
     it('should update tags', async () => {
-      await libraryGenerator(tree, { name: libName, tags: 'one,two' });
+      await libraryGenerator(tree, {
+        name: 'myLib',
+        tags: 'one,two',
+        projectNameAndRootFormat: 'as-provided',
+      });
 
       const projects = Object.fromEntries(devkit.getProjects(tree));
       expect(projects).toEqual({
-        [libFileName]: expect.objectContaining({
+        ['my-lib']: expect.objectContaining({
           tags: ['one', 'two'],
         }),
       });
     });
 
     it('should update root tsconfig.json', async () => {
-      await libraryGenerator(tree, { name: libName });
+      await libraryGenerator(tree, {
+        name: 'myLib',
+        projectNameAndRootFormat: 'as-provided',
+      });
 
       const tsconfigJson = readJson(tree, '/tsconfig.base.json');
-      expect(
-        tsconfigJson.compilerOptions.paths[`@proj/${libFileName}`]
-      ).toEqual([`libs/${libFileName}/src/index.ts`]);
+      expect(tsconfigJson.compilerOptions.paths[`@proj/my-lib`]).toEqual([
+        `my-lib/src/index.ts`,
+      ]);
     });
 
     it('should create a local tsconfig.json', async () => {
-      await libraryGenerator(tree, { name: libName });
+      await libraryGenerator(tree, {
+        name: 'myLib',
+        projectNameAndRootFormat: 'as-provided',
+      });
 
-      const tsconfigJson = readJson(tree, `libs/${libFileName}/tsconfig.json`);
+      const tsconfigJson = readJson(tree, `my-lib/tsconfig.json`);
       expect(tsconfigJson).toMatchSnapshot();
     });
 
     it('should extend the local tsconfig.json with tsconfig.spec.json', async () => {
-      await libraryGenerator(tree, { name: libName });
+      await libraryGenerator(tree, {
+        name: 'myLib',
+        projectNameAndRootFormat: 'as-provided',
+      });
 
-      const tsconfigJson = readJson(
-        tree,
-        `libs/${libFileName}/tsconfig.spec.json`
-      );
+      const tsconfigJson = readJson(tree, `my-lib/tsconfig.spec.json`);
       expect(tsconfigJson.extends).toEqual('./tsconfig.json');
     });
 
     it('should extend the local tsconfig.json with tsconfig.lib.json', async () => {
-      await libraryGenerator(tree, { name: libName });
+      await libraryGenerator(tree, {
+        name: 'myLib',
+        projectNameAndRootFormat: 'as-provided',
+      });
 
-      const tsconfigJson = readJson(
-        tree,
-        `libs/${libFileName}/tsconfig.lib.json`
-      );
+      const tsconfigJson = readJson(tree, `my-lib/tsconfig.lib.json`);
       expect(tsconfigJson.extends).toEqual('./tsconfig.json');
       expect(tsconfigJson.exclude).toEqual([
         'jest.config.ts',
@@ -159,95 +168,99 @@ describe('lib', () => {
     });
 
     it('should generate files', async () => {
-      await libraryGenerator(tree, { name: libName });
+      await libraryGenerator(tree, {
+        name: 'myLib',
+        projectNameAndRootFormat: 'as-provided',
+      });
 
-      expect(tree.exists(`libs/${libFileName}/jest.config.ts`)).toBeTruthy();
-      expect(tree.exists(`libs/${libFileName}/src/index.ts`)).toBeTruthy();
-      expect(
-        tree.exists(`libs/${libFileName}/src/lib/${libFileName}.spec.ts`)
-      ).toBeFalsy();
-      expect(
-        readJson(tree, `libs/${libFileName}/.eslintrc.json`)
-      ).toMatchSnapshot();
+      expect(tree.exists(`my-lib/jest.config.ts`)).toBeTruthy();
+      expect(tree.exists(`my-lib/src/index.ts`)).toBeTruthy();
+      expect(tree.exists(`my-lib/src/lib/my-lib.spec.ts`)).toBeFalsy();
+      expect(readJson(tree, `my-lib/.eslintrc.json`)).toMatchSnapshot();
     });
   });
 
   describe('nested', () => {
-    const dirName = 'myDir';
-    const dirFileName = 'my-dir';
-    const nestedLibFileName = `${dirFileName}-${libFileName}`;
-
     it('should update tags', async () => {
       await libraryGenerator(tree, {
-        name: libName,
-        directory: dirName,
+        name: 'myLib',
+        directory: 'my-dir/my-lib',
         tags: 'one,two',
+        projectNameAndRootFormat: 'as-provided',
       });
 
       const projects = Object.fromEntries(devkit.getProjects(tree));
       expect(projects).toEqual({
-        [nestedLibFileName]: expect.objectContaining({ tags: ['one', 'two'] }),
+        [`my-lib`]: expect.objectContaining({
+          tags: ['one', 'two'],
+        }),
       });
     });
 
     it('should generate files', async () => {
-      await libraryGenerator(tree, { name: libName, directory: dirName });
+      await libraryGenerator(tree, {
+        name: 'myLib',
+        directory: 'my-dir/my-lib',
+        projectNameAndRootFormat: 'as-provided',
+      });
 
-      expect(
-        tree.exists(`libs/${dirFileName}/${libFileName}/jest.config.ts`)
-      ).toBeTruthy();
-      expect(
-        tree.exists(`libs/${dirFileName}/${libFileName}/src/index.ts`)
-      ).toBeTruthy();
-      expect(
-        tree.exists(
-          `libs/${dirFileName}/${libFileName}/src/lib/${libFileName}.spec.ts`
-        )
-      ).toBeFalsy();
+      expect(tree.exists(`my-dir/my-lib/jest.config.ts`)).toBeTruthy();
+      expect(tree.exists(`my-dir/my-lib/src/index.ts`)).toBeTruthy();
+      expect(tree.exists(`my-dir/my-lib/src/lib/my-lib.spec.ts`)).toBeFalsy();
     });
 
     it('should update workspace.json', async () => {
-      await libraryGenerator(tree, { name: libName, directory: dirName });
+      await libraryGenerator(tree, {
+        name: 'myLib',
+        directory: 'my-dir/my-lib',
+        projectNameAndRootFormat: 'as-provided',
+      });
 
-      const project = readProjectConfiguration(tree, nestedLibFileName);
-      expect(project.root).toEqual(`libs/${dirFileName}/${libFileName}`);
+      const project = readProjectConfiguration(tree, `my-lib`);
+      expect(project.root).toEqual(`my-dir/my-lib`);
       expect(project.targets.lint).toEqual({
         executor: '@nx/linter:eslint',
         outputs: ['{options.outputFile}'],
         options: {
-          lintFilePatterns: [`libs/${dirFileName}/${libFileName}/**/*.ts`],
+          lintFilePatterns: [`my-dir/my-lib/**/*.ts`],
         },
       });
     });
 
     it('should update tsconfig.json', async () => {
-      await libraryGenerator(tree, { name: libName, directory: dirName });
+      await libraryGenerator(tree, {
+        name: 'myLib',
+        directory: 'my-dir/my-lib',
+        projectNameAndRootFormat: 'as-provided',
+      });
 
       const tsconfigJson = readJson(tree, '/tsconfig.base.json');
-      expect(
-        tsconfigJson.compilerOptions.paths[
-          `@proj/${dirFileName}/${libFileName}`
-        ]
-      ).toEqual([`libs/${dirFileName}/${libFileName}/src/index.ts`]);
-      expect(
-        tsconfigJson.compilerOptions.paths[`${nestedLibFileName}/*`]
-      ).toBeUndefined();
+      expect(tsconfigJson.compilerOptions.paths[`@proj/my-lib`]).toEqual([
+        `my-dir/my-lib/src/index.ts`,
+      ]);
+      expect(tsconfigJson.compilerOptions.paths[`my-lib/*`]).toBeUndefined();
     });
 
     it('should create a local tsconfig.json', async () => {
-      await libraryGenerator(tree, { name: libName, directory: dirName });
+      await libraryGenerator(tree, {
+        name: 'myLib',
+        directory: 'my-dir/my-lib',
+        projectNameAndRootFormat: 'as-provided',
+      });
 
-      expect(
-        readJson(tree, `libs/${dirFileName}/${libFileName}/tsconfig.json`)
-      ).toMatchSnapshot();
+      expect(readJson(tree, `my-dir/my-lib/tsconfig.json`)).toMatchSnapshot();
     });
   });
 
   describe('--strict', () => {
     it('should update the projects tsconfig with strict true', async () => {
-      await libraryGenerator(tree, { name: libName, strict: true });
+      await libraryGenerator(tree, {
+        name: 'myLib',
+        strict: true,
+        projectNameAndRootFormat: 'as-provided',
+      });
 
-      const tsConfig = readJson(tree, `/libs/${libFileName}/tsconfig.lib.json`);
+      const tsConfig = readJson(tree, `/my-lib/tsconfig.lib.json`);
       expect(tsConfig.compilerOptions.strictNullChecks).toBeTruthy();
       expect(tsConfig.compilerOptions.noImplicitAny).toBeTruthy();
       expect(tsConfig.compilerOptions.strictBindCallApply).toBeTruthy();
@@ -260,17 +273,17 @@ describe('lib', () => {
 
   describe('--unit-test-runner none', () => {
     it('should not generate test configuration', async () => {
-      await libraryGenerator(tree, { name: libName, unitTestRunner: 'none' });
+      await libraryGenerator(tree, {
+        name: 'myLib',
+        unitTestRunner: 'none',
+        projectNameAndRootFormat: 'as-provided',
+      });
 
-      expect(tree.exists(`libs/${libFileName}/tsconfig.spec.json`)).toBeFalsy();
-      expect(tree.exists(`libs/${libFileName}/jest.config.ts`)).toBeFalsy();
-      expect(
-        tree.exists(`libs/${libFileName}/lib/${libFileName}.spec.ts`)
-      ).toBeFalsy();
-      expect(
-        readJson(tree, `libs/${libFileName}/tsconfig.json`)
-      ).toMatchSnapshot();
-      const project = readProjectConfiguration(tree, libFileName);
+      expect(tree.exists(`my-lib/tsconfig.spec.json`)).toBeFalsy();
+      expect(tree.exists(`my-lib/jest.config.ts`)).toBeFalsy();
+      expect(tree.exists(`my-lib/lib/my-lib.spec.ts`)).toBeFalsy();
+      expect(readJson(tree, `my-lib/tsconfig.json`)).toMatchSnapshot();
+      const project = readProjectConfiguration(tree, 'my-lib');
       expect(project.targets.test).toBeUndefined();
       expect(project.targets.lint).toMatchSnapshot();
     });
@@ -278,37 +291,39 @@ describe('lib', () => {
 
   describe('publishable package', () => {
     it('should update package.json', async () => {
-      const importPath = `@proj/${libName}`;
+      const importPath = `@proj/myLib`;
 
       await libraryGenerator(tree, {
-        name: libName,
+        name: 'myLib',
         publishable: true,
         importPath,
+        projectNameAndRootFormat: 'as-provided',
       });
 
-      const packageJson = readJson(tree, `libs/${libFileName}/package.json`);
+      const packageJson = readJson(tree, `my-lib/package.json`);
       expect(packageJson.name).toEqual(importPath);
     });
   });
 
   describe('compiler options target', () => {
     it('should set target to es6 in tsconfig.lib.json by default', async () => {
-      await libraryGenerator(tree, { name: libName });
+      await libraryGenerator(tree, {
+        name: 'myLib',
+        projectNameAndRootFormat: 'as-provided',
+      });
 
-      const tsconfigJson = readJson(
-        tree,
-        `libs/${libFileName}/tsconfig.lib.json`
-      );
+      const tsconfigJson = readJson(tree, `my-lib/tsconfig.lib.json`);
       expect(tsconfigJson.compilerOptions.target).toEqual('es6');
     });
 
     it('should set target to es2021 in tsconfig.lib.json', async () => {
-      await libraryGenerator(tree, { name: libName, target: 'es2021' });
+      await libraryGenerator(tree, {
+        name: 'myLib',
+        target: 'es2021',
+        projectNameAndRootFormat: 'as-provided',
+      });
 
-      const tsconfigJson = readJson(
-        tree,
-        `libs/${libFileName}/tsconfig.lib.json`
-      );
+      const tsconfigJson = readJson(tree, `my-lib/tsconfig.lib.json`);
       expect(tsconfigJson.compilerOptions.target).toEqual('es2021');
     });
   });
@@ -317,7 +332,10 @@ describe('lib', () => {
     it('should format files by default', async () => {
       jest.spyOn(devkit, 'formatFiles');
 
-      await libraryGenerator(tree, { name: libName });
+      await libraryGenerator(tree, {
+        name: 'myLib',
+        projectNameAndRootFormat: 'as-provided',
+      });
 
       expect(devkit.formatFiles).toHaveBeenCalled();
     });
@@ -325,7 +343,11 @@ describe('lib', () => {
     it('should not format files when --skipFormat=true', async () => {
       jest.spyOn(devkit, 'formatFiles');
 
-      await libraryGenerator(tree, { name: libName, skipFormat: true });
+      await libraryGenerator(tree, {
+        name: 'myLib',
+        skipFormat: true,
+        projectNameAndRootFormat: 'as-provided',
+      });
 
       expect(devkit.formatFiles).not.toHaveBeenCalled();
     });
@@ -333,56 +355,56 @@ describe('lib', () => {
 
   describe('--testEnvironment', () => {
     it('should set target jest testEnvironment to node by default', async () => {
-      await libraryGenerator(tree, { name: libName });
+      await libraryGenerator(tree, {
+        name: 'myLib',
+        projectNameAndRootFormat: 'as-provided',
+      });
 
-      expect(
-        tree.read(`libs/${libFileName}/jest.config.ts`, 'utf-8')
-      ).toMatchSnapshot();
+      expect(tree.read(`my-lib/jest.config.ts`, 'utf-8')).toMatchSnapshot();
     });
 
     it('should set target jest testEnvironment to jsdom', async () => {
-      await libraryGenerator(tree, { name: libName, testEnvironment: 'jsdom' });
+      await libraryGenerator(tree, {
+        name: 'myLib',
+        testEnvironment: 'jsdom',
+        projectNameAndRootFormat: 'as-provided',
+      });
 
-      expect(
-        tree.read(`libs/${libFileName}/jest.config.ts`, 'utf-8')
-      ).toMatchSnapshot();
+      expect(tree.read(`my-lib/jest.config.ts`, 'utf-8')).toMatchSnapshot();
     });
   });
 
   describe('--simpleName', () => {
     it('should generate a library with a simple name', async () => {
       await libraryGenerator(tree, {
-        name: libName,
+        name: 'myLib',
         simpleName: true,
-        directory: 'api',
+        directory: 'api/my-lib',
         service: true,
         controller: true,
+        projectNameAndRootFormat: 'as-provided',
       });
 
-      const indexFile = tree.read('libs/api/my-lib/src/index.ts', 'utf-8');
+      const indexFile = tree.read('api/my-lib/src/index.ts', 'utf-8');
 
       expect(indexFile).toContain(`export * from './lib/my-lib.module';`);
       expect(indexFile).toContain(`export * from './lib/my-lib.service';`);
       expect(indexFile).toContain(`export * from './lib/my-lib.controller';`);
 
+      expect(tree.exists('api/my-lib/src/lib/my-lib.module.ts')).toBeTruthy();
+
+      expect(tree.exists('api/my-lib/src/lib/my-lib.service.ts')).toBeTruthy();
+
       expect(
-        tree.exists('libs/api/my-lib/src/lib/my-lib.module.ts')
+        tree.exists('api/my-lib/src/lib/my-lib.service.spec.ts')
       ).toBeTruthy();
 
       expect(
-        tree.exists('libs/api/my-lib/src/lib/my-lib.service.ts')
+        tree.exists('api/my-lib/src/lib/my-lib.controller.ts')
       ).toBeTruthy();
 
       expect(
-        tree.exists('libs/api/my-lib/src/lib/my-lib.service.spec.ts')
-      ).toBeTruthy();
-
-      expect(
-        tree.exists('libs/api/my-lib/src/lib/my-lib.controller.ts')
-      ).toBeTruthy();
-
-      expect(
-        tree.exists('libs/api/my-lib/src/lib/my-lib.controller.spec.ts')
+        tree.exists('api/my-lib/src/lib/my-lib.controller.spec.ts')
       ).toBeTruthy();
     });
   });

--- a/packages/nest/src/generators/utils/testing.ts
+++ b/packages/nest/src/generators/utils/testing.ts
@@ -2,10 +2,10 @@ import { addProjectConfiguration, Tree } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 
 export function createTreeWithNestApplication(appName: string): Tree {
-  const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  const tree = createTreeWithEmptyWorkspace();
   addProjectConfiguration(tree, appName, {
-    root: `apps/${appName}`,
-    sourceRoot: `apps/${appName}/src`,
+    root: `${appName}`,
+    sourceRoot: `${appName}/src`,
     projectType: 'application',
     targets: {},
   });

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -26,6 +26,7 @@ describe('app', () => {
       await applicationGenerator(tree, {
         name: 'myNodeApp',
         bundler: 'webpack',
+        projectNameAndRootFormat: 'as-provided',
       });
       const project = readProjectConfiguration(tree, 'my-node-app');
       expect(project.root).toEqual('my-node-app');
@@ -83,6 +84,7 @@ describe('app', () => {
       await applicationGenerator(tree, {
         name: 'myNodeApp',
         tags: 'one,two',
+        projectNameAndRootFormat: 'as-provided',
       });
       const projects = Object.fromEntries(getProjects(tree));
       expect(projects).toMatchObject({
@@ -95,6 +97,7 @@ describe('app', () => {
     it('should generate files', async () => {
       await applicationGenerator(tree, {
         name: 'myNodeApp',
+        projectNameAndRootFormat: 'as-provided',
       });
       expect(tree.exists(`my-node-app/jest.config.ts`)).toBeTruthy();
       expect(tree.exists('my-node-app/src/main.ts')).toBeTruthy();
@@ -170,6 +173,7 @@ describe('app', () => {
 
       await applicationGenerator(tree, {
         name: 'myNodeApp',
+        projectNameAndRootFormat: 'as-provided',
       });
 
       const tsconfig = readJson(tree, 'my-node-app/tsconfig.json');
@@ -181,9 +185,10 @@ describe('app', () => {
     it('should update project config', async () => {
       await applicationGenerator(tree, {
         name: 'myNodeApp',
-        directory: 'myDir',
+        directory: 'my-dir/my-node-app',
+        projectNameAndRootFormat: 'as-provided',
       });
-      const project = readProjectConfiguration(tree, 'my-dir-my-node-app');
+      const project = readProjectConfiguration(tree, 'my-node-app');
 
       expect(project.root).toEqual('my-dir/my-node-app');
 
@@ -196,7 +201,7 @@ describe('app', () => {
       });
 
       expect(() =>
-        readProjectConfiguration(tree, 'my-dir-my-node-app-e2e')
+        readProjectConfiguration(tree, 'my-node-app-e2e')
       ).not.toThrow();
     });
 

--- a/packages/node/src/generators/e2e-project/e2e-project.spec.ts
+++ b/packages/node/src/generators/e2e-project/e2e-project.spec.ts
@@ -14,6 +14,7 @@ describe('e2eProjectGenerator', () => {
       name: 'api',
       framework: 'express',
       e2eTestRunner: 'none',
+      projectNameAndRootFormat: 'as-provided',
     });
     await e2eProjectGenerator(tree, {
       projectType: 'server',
@@ -29,6 +30,7 @@ describe('e2eProjectGenerator', () => {
       framework: 'express',
       e2eTestRunner: 'none',
       rootProject: true,
+      projectNameAndRootFormat: 'as-provided',
     });
     await e2eProjectGenerator(tree, {
       projectType: 'server',
@@ -44,6 +46,7 @@ describe('e2eProjectGenerator', () => {
       name: 'api',
       framework: 'none',
       e2eTestRunner: 'none',
+      projectNameAndRootFormat: 'as-provided',
     });
     await e2eProjectGenerator(tree, {
       projectType: 'cli',

--- a/packages/node/src/generators/init/init.spec.ts
+++ b/packages/node/src/generators/init/init.spec.ts
@@ -13,7 +13,7 @@ describe('init', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should add dependencies', async () => {

--- a/packages/node/src/generators/setup-docker/setup-docker.spec.ts
+++ b/packages/node/src/generators/setup-docker/setup-docker.spec.ts
@@ -14,6 +14,7 @@ describe('setupDockerGenerator', () => {
         framework: 'express',
         e2eTestRunner: 'none',
         docker: true,
+        projectNameAndRootFormat: 'as-provided',
       });
 
       const project = readProjectConfiguration(tree, 'api');
@@ -37,6 +38,7 @@ describe('setupDockerGenerator', () => {
         framework: 'fastify',
         rootProject: true,
         docker: true,
+        projectNameAndRootFormat: 'as-provided',
       });
 
       const project = readProjectConfiguration(tree, 'api');


### PR DESCRIPTION
Chain the `projectNameAndRootFormat` option from `@nx/nest:lib` to `@nx/js:lib`, otherwise the generator errors out when `as-provided` is used. Also updates unit tests to use `projectNameAndRootFormat: 'as-provided'`.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
