### PR TITLE
chore(js): update js plugin unit tests to use "as-provided" option when generating apps/libs

### DIFF
--- a/packages/js/src/generators/convert-to-swc/convert-to-swc.spec.ts
+++ b/packages/js/src/generators/convert-to-swc/convert-to-swc.spec.ts
@@ -22,9 +22,9 @@ describe('convert to swc', () => {
   };
 
   beforeAll(() => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-    tree.write('/apps/.gitignore', '');
-    tree.write('/libs/.gitignore', '');
+    tree = createTreeWithEmptyWorkspace();
+    tree.write('/.gitignore', '');
+    tree.write('/.gitignore', '');
   });
 
   it('should convert tsc to swc', async () => {
@@ -32,6 +32,7 @@ describe('convert to swc', () => {
       ...defaultLibGenerationOptions,
       name: 'tsc-lib',
       bundler: 'tsc',
+      projectNameAndRootFormat: 'as-provided',
     });
 
     expect(
@@ -49,7 +50,7 @@ describe('convert to swc', () => {
       )
     ).toEqual(true);
     expect(tree.read('package.json', 'utf-8')).toContain('@swc/core');
-    expect(tree.read('libs/tsc-lib/package.json', 'utf-8')).toContain(
+    expect(tree.read('tsc-lib/package.json', 'utf-8')).toContain(
       '@swc/helpers'
     );
   });

--- a/packages/js/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/js/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -23,13 +23,13 @@ if (swcJestConfig.swcrc === undefined) {
 
 module.exports = {
   displayName: 'my-lib',
-  preset: '../../jest.preset.js',
+  preset: '../jest.preset.js',
   transform: {
     '^.+\\\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'jsdom',
-  coverageDirectory: '../../coverage/libs/my-lib',
+  coverageDirectory: '../coverage/my-lib',
 };
 "
 `;

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -25,9 +25,9 @@ describe('lib', () => {
   };
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-    tree.write('/apps/.gitignore', '');
-    tree.write('/libs/.gitignore', '');
+    tree = createTreeWithEmptyWorkspace();
+    tree.write('/.gitignore', '');
+    tree.write('/.gitignore', '');
   });
 
   describe('configs', () => {
@@ -36,8 +36,9 @@ describe('lib', () => {
         ...defaultOptions,
         name: 'myLib',
         config: 'npm-scripts',
+        projectNameAndRootFormat: 'as-provided',
       });
-      expect(readJson(tree, '/libs/my-lib/package.json')).toEqual({
+      expect(readJson(tree, '/my-lib/package.json')).toEqual({
         name: '@proj/my-lib',
         version: '0.0.1',
         type: 'commonjs',
@@ -48,12 +49,12 @@ describe('lib', () => {
         dependencies: {},
       });
 
-      expect(tree.exists('libs/my-lib/src/index.ts')).toBeTruthy();
-      expect(tree.exists('libs/my-lib/src/lib/my-lib.ts')).toBeTruthy();
+      expect(tree.exists('my-lib/src/index.ts')).toBeTruthy();
+      expect(tree.exists('my-lib/src/lib/my-lib.ts')).toBeTruthy();
 
       // unitTestRunner property is ignored.
       // It only works with our executors.
-      expect(tree.exists('libs/my-lib/src/lib/my-lib.spec.ts')).toBeFalsy();
+      expect(tree.exists('my-lib/src/lib/my-lib.spec.ts')).toBeFalsy();
     });
 
     it('should generate an empty ts lib using --config=project', async () => {
@@ -61,9 +62,10 @@ describe('lib', () => {
         ...defaultOptions,
         name: 'my-lib',
         config: 'project',
+        projectNameAndRootFormat: 'as-provided',
       });
       const projectConfig = readProjectConfiguration(tree, 'my-lib');
-      expect(projectConfig.root).toEqual('libs/my-lib');
+      expect(projectConfig.root).toEqual('my-lib');
     });
 
     it('should generate an empty ts lib using --config=workspace', async () => {
@@ -71,9 +73,10 @@ describe('lib', () => {
         ...defaultOptions,
         name: 'my-lib',
         config: 'workspace',
+        projectNameAndRootFormat: 'as-provided',
       });
       const projectConfig = readProjectConfiguration(tree, 'my-lib');
-      expect(projectConfig.root).toEqual('libs/my-lib');
+      expect(projectConfig.root).toEqual('my-lib');
     });
   });
 
@@ -84,6 +87,7 @@ describe('lib', () => {
           ...defaultOptions,
           name: 'myLib',
           tags: 'one,two',
+          projectNameAndRootFormat: 'as-provided',
         });
         const projects = Object.fromEntries(getProjects(tree));
         expect(projects).toMatchObject({
@@ -94,21 +98,29 @@ describe('lib', () => {
       });
 
       it('should update root tsconfig.base.json', async () => {
-        await libraryGenerator(tree, { ...defaultOptions, name: 'myLib' });
+        await libraryGenerator(tree, {
+          ...defaultOptions,
+          name: 'myLib',
+          projectNameAndRootFormat: 'as-provided',
+        });
         const tsconfigJson = readJson(tree, '/tsconfig.base.json');
         expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-          'libs/my-lib/src/index.ts',
+          'my-lib/src/index.ts',
         ]);
       });
 
       it('should update root tsconfig.json when no tsconfig.base.json', async () => {
         tree.rename('tsconfig.base.json', 'tsconfig.json');
 
-        await libraryGenerator(tree, { ...defaultOptions, name: 'myLib' });
+        await libraryGenerator(tree, {
+          ...defaultOptions,
+          name: 'myLib',
+          projectNameAndRootFormat: 'as-provided',
+        });
 
         const tsconfigJson = readJson(tree, 'tsconfig.json');
         expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-          'libs/my-lib/src/index.ts',
+          'my-lib/src/index.ts',
         ]);
       });
 
@@ -118,16 +130,24 @@ describe('lib', () => {
           return json;
         });
 
-        await libraryGenerator(tree, { ...defaultOptions, name: 'myLib' });
+        await libraryGenerator(tree, {
+          ...defaultOptions,
+          name: 'myLib',
+          projectNameAndRootFormat: 'as-provided',
+        });
         const tsconfigJson = readJson(tree, '/tsconfig.base.json');
         expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-          'libs/my-lib/src/index.ts',
+          'my-lib/src/index.ts',
         ]);
       });
 
       it('should create a local tsconfig.json', async () => {
-        await libraryGenerator(tree, { ...defaultOptions, name: 'myLib' });
-        const tsconfigJson = readJson(tree, 'libs/my-lib/tsconfig.json');
+        await libraryGenerator(tree, {
+          ...defaultOptions,
+          name: 'myLib',
+          projectNameAndRootFormat: 'as-provided',
+        });
+        const tsconfigJson = readJson(tree, 'my-lib/tsconfig.json');
         expect(tsconfigJson).toMatchInlineSnapshot(`
           {
             "compilerOptions": {
@@ -139,7 +159,7 @@ describe('lib', () => {
               "noPropertyAccessFromIndexSignature": true,
               "strict": true,
             },
-            "extends": "../../tsconfig.base.json",
+            "extends": "../tsconfig.base.json",
             "files": [],
             "include": [],
             "references": [
@@ -157,10 +177,14 @@ describe('lib', () => {
       it('should extend from root tsconfig.json when no tsconfig.base.json', async () => {
         tree.rename('tsconfig.base.json', 'tsconfig.json');
 
-        await libraryGenerator(tree, { ...defaultOptions, name: 'myLib' });
+        await libraryGenerator(tree, {
+          ...defaultOptions,
+          name: 'myLib',
+          projectNameAndRootFormat: 'as-provided',
+        });
 
-        const tsconfigJson = readJson(tree, 'libs/my-lib/tsconfig.json');
-        expect(tsconfigJson.extends).toBe('../../tsconfig.json');
+        const tsconfigJson = readJson(tree, 'my-lib/tsconfig.json');
+        expect(tsconfigJson.extends).toBe('../tsconfig.json');
       });
     });
 
@@ -169,12 +193,13 @@ describe('lib', () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
-          directory: 'myDir',
+          directory: 'my-dir/my-lib',
           tags: 'one',
+          projectNameAndRootFormat: 'as-provided',
         });
         let projects = Object.fromEntries(getProjects(tree));
         expect(projects).toMatchObject({
-          'my-dir-my-lib': {
+          'my-lib': {
             tags: ['one'],
           },
         });
@@ -182,15 +207,16 @@ describe('lib', () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib2',
-          directory: 'myDir',
+          directory: 'my-dir/my-lib-2',
           tags: 'one,two',
+          projectNameAndRootFormat: 'as-provided',
         });
         projects = Object.fromEntries(getProjects(tree));
         expect(projects).toMatchObject({
-          'my-dir-my-lib': {
+          'my-lib': {
             tags: ['one'],
           },
-          'my-dir-my-lib2': {
+          'my-lib2': {
             tags: ['one', 'two'],
           },
         });
@@ -200,31 +226,31 @@ describe('lib', () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
-          directory: 'myDir',
+          directory: 'my-dir/my-lib',
+          projectNameAndRootFormat: 'as-provided',
         });
-        expect(tree.exists(`libs/my-dir/my-lib/jest.config.ts`)).toBeTruthy();
-        expect(tree.exists('libs/my-dir/my-lib/src/index.ts')).toBeTruthy();
+        expect(tree.exists(`my-dir/my-lib/jest.config.ts`)).toBeTruthy();
+        expect(tree.exists('my-dir/my-lib/src/index.ts')).toBeTruthy();
+        expect(tree.exists('my-dir/my-lib/src/lib/my-lib.ts')).toBeTruthy();
         expect(
-          tree.exists('libs/my-dir/my-lib/src/lib/my-dir-my-lib.ts')
+          tree.exists('my-dir/my-lib/src/lib/my-lib.spec.ts')
         ).toBeTruthy();
-        expect(
-          tree.exists('libs/my-dir/my-lib/src/lib/my-dir-my-lib.spec.ts')
-        ).toBeTruthy();
-        expect(tree.exists('libs/my-dir/my-lib/src/index.ts')).toBeTruthy();
-        expect(tree.exists(`libs/my-dir/my-lib/.eslintrc.json`)).toBeTruthy();
-        expect(tree.exists(`libs/my-dir/my-lib/package.json`)).toBeTruthy();
+        expect(tree.exists('my-dir/my-lib/src/index.ts')).toBeTruthy();
+        expect(tree.exists(`my-dir/my-lib/.eslintrc.json`)).toBeTruthy();
+        expect(tree.exists(`my-dir/my-lib/package.json`)).toBeTruthy();
       });
 
       it('should update project configuration', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
-          directory: 'myDir',
+          directory: 'my-dir/my-lib',
           config: 'workspace',
+          projectNameAndRootFormat: 'as-provided',
         });
 
-        expect(readProjectConfiguration(tree, 'my-dir-my-lib').root).toEqual(
-          'libs/my-dir/my-lib'
+        expect(readProjectConfiguration(tree, 'my-lib').root).toEqual(
+          'my-dir/my-lib'
         );
       });
 
@@ -232,15 +258,14 @@ describe('lib', () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
-          directory: 'myDir',
+          directory: 'my-dir/my-lib',
+          projectNameAndRootFormat: 'as-provided',
         });
         const tsconfigJson = readJson(tree, '/tsconfig.base.json');
-        expect(
-          tsconfigJson.compilerOptions.paths['@proj/my-dir/my-lib']
-        ).toEqual(['libs/my-dir/my-lib/src/index.ts']);
-        expect(
-          tsconfigJson.compilerOptions.paths['my-dir-my-lib/*']
-        ).toBeUndefined();
+        expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
+          'my-dir/my-lib/src/index.ts',
+        ]);
+        expect(tsconfigJson.compilerOptions.paths['my-lib/*']).toBeUndefined();
       });
 
       it('should update root tsconfig.json when no tsconfig.base.json', async () => {
@@ -249,26 +274,26 @@ describe('lib', () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
-          directory: 'myDir',
+          directory: 'my-dir/my-lib',
+          projectNameAndRootFormat: 'as-provided',
         });
 
         const tsconfigJson = readJson(tree, '/tsconfig.json');
-        expect(
-          tsconfigJson.compilerOptions.paths['@proj/my-dir/my-lib']
-        ).toEqual(['libs/my-dir/my-lib/src/index.ts']);
-        expect(
-          tsconfigJson.compilerOptions.paths['my-dir-my-lib/*']
-        ).toBeUndefined();
+        expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
+          'my-dir/my-lib/src/index.ts',
+        ]);
+        expect(tsconfigJson.compilerOptions.paths['my-lib/*']).toBeUndefined();
       });
 
       it('should create a local tsconfig.json', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
-          directory: 'myDir',
+          directory: 'my-dir/my-lib',
+          projectNameAndRootFormat: 'as-provided',
         });
 
-        const tsconfigJson = readJson(tree, 'libs/my-dir/my-lib/tsconfig.json');
+        const tsconfigJson = readJson(tree, 'my-dir/my-lib/tsconfig.json');
         expect(tsconfigJson.references).toEqual([
           {
             path: './tsconfig.lib.json',
@@ -283,11 +308,12 @@ describe('lib', () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
-          directory: 'myDir',
+          directory: 'my-dir/my-lib',
+          projectNameAndRootFormat: 'as-provided',
         });
 
-        const tsconfigJson = readJson(tree, 'libs/my-dir/my-lib/tsconfig.json');
-        expect(tsconfigJson.extends).toBe('../../../tsconfig.base.json');
+        const tsconfigJson = readJson(tree, 'my-dir/my-lib/tsconfig.json');
+        expect(tsconfigJson.extends).toBe('../../tsconfig.base.json');
       });
 
       it('should extend from root tsconfig.json when no tsconfig.base.json', async () => {
@@ -296,11 +322,12 @@ describe('lib', () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
-          directory: 'myDir',
+          directory: 'my-dir/my-lib',
+          projectNameAndRootFormat: 'as-provided',
         });
 
-        const tsconfigJson = readJson(tree, 'libs/my-dir/my-lib/tsconfig.json');
-        expect(tsconfigJson.extends).toBe('../../../tsconfig.json');
+        const tsconfigJson = readJson(tree, 'my-dir/my-lib/tsconfig.json');
+        expect(tsconfigJson.extends).toBe('../../tsconfig.json');
       });
     });
 
@@ -310,8 +337,9 @@ describe('lib', () => {
           ...defaultOptions,
           name: 'myLib',
           strict: false,
+          projectNameAndRootFormat: 'as-provided',
         });
-        const tsconfigJson = readJson(tree, '/libs/my-lib/tsconfig.json');
+        const tsconfigJson = readJson(tree, '/my-lib/tsconfig.json');
 
         expect(
           tsconfigJson.compilerOptions?.forceConsistentCasingInFileNames
@@ -335,8 +363,9 @@ describe('lib', () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
+          projectNameAndRootFormat: 'as-provided',
         });
-        const tsconfigJson = readJson(tree, '/libs/my-lib/tsconfig.json');
+        const tsconfigJson = readJson(tree, '/my-lib/tsconfig.json');
 
         expect(tsconfigJson.compilerOptions.strict).toBeTruthy();
         expect(
@@ -354,8 +383,9 @@ describe('lib', () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
-          directory: 'myDir',
+          directory: 'my-dir/my-lib',
           importPath: '@myorg/lib',
+          projectNameAndRootFormat: 'as-provided',
         });
         const tsconfigJson = readJson(tree, '/tsconfig.base.json');
 
@@ -367,6 +397,7 @@ describe('lib', () => {
           ...defaultOptions,
           name: 'myLib1',
           importPath: '@myorg/lib',
+          projectNameAndRootFormat: 'as-provided',
         });
 
         try {
@@ -374,6 +405,7 @@ describe('lib', () => {
             ...defaultOptions,
             name: 'myLib2',
             importPath: '@myorg/lib',
+            projectNameAndRootFormat: 'as-provided',
           });
         } catch (e) {
           expect(e.message).toContain(
@@ -388,6 +420,7 @@ describe('lib', () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
+          projectNameAndRootFormat: 'as-provided',
         });
 
         const tsconfigJson = readJson(tree, '/tsconfig.base.json');
@@ -405,6 +438,7 @@ describe('lib', () => {
           ...defaultOptions,
           rootProject: true,
           name: 'myLib',
+          projectNameAndRootFormat: 'as-provided',
         });
 
         const tsconfigJson = readJson(tree, '/tsconfig.base.json');
@@ -418,24 +452,22 @@ describe('lib', () => {
           ...defaultOptions,
           name: 'myLib',
           pascalCaseFiles: true,
+          projectNameAndRootFormat: 'as-provided',
         });
-        expect(tree.exists('libs/my-lib/src/lib/MyLib.ts')).toBeTruthy();
-        expect(tree.exists('libs/my-lib/src/lib/MyLib.spec.ts')).toBeTruthy();
+        expect(tree.exists('my-lib/src/lib/MyLib.ts')).toBeTruthy();
+        expect(tree.exists('my-lib/src/lib/MyLib.spec.ts')).toBeTruthy();
       });
 
       it('should generate files with upper case names for nested libs as well', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
-          directory: 'myDir',
+          directory: 'my-dir/my-lib',
           pascalCaseFiles: true,
+          projectNameAndRootFormat: 'as-provided',
         });
-        expect(
-          tree.exists('libs/my-dir/my-lib/src/lib/MyDirMyLib.ts')
-        ).toBeTruthy();
-        expect(
-          tree.exists('libs/my-dir/my-lib/src/lib/MyDirMyLib.spec.ts')
-        ).toBeTruthy();
+        expect(tree.exists('my-dir/my-lib/src/lib/MyLib.ts')).toBeTruthy();
+        expect(tree.exists('my-dir/my-lib/src/lib/MyLib.spec.ts')).toBeTruthy();
       });
     });
   });
@@ -445,6 +477,7 @@ describe('lib', () => {
       await libraryGenerator(tree, {
         ...defaultOptions,
         name: 'myLib',
+        projectNameAndRootFormat: 'as-provided',
       });
 
       const packageJson = readJson(tree, 'package.json');
@@ -458,15 +491,13 @@ describe('lib', () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
+          projectNameAndRootFormat: 'as-provided',
         });
         expect(readProjectConfiguration(tree, 'my-lib').targets.lint).toEqual({
           executor: '@nx/linter:eslint',
           outputs: ['{options.outputFile}'],
           options: {
-            lintFilePatterns: [
-              'libs/my-lib/**/*.ts',
-              'libs/my-lib/package.json',
-            ],
+            lintFilePatterns: ['my-lib/**/*.ts', 'my-lib/package.json'],
           },
         });
       });
@@ -475,13 +506,14 @@ describe('lib', () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
+          projectNameAndRootFormat: 'as-provided',
         });
 
-        const eslintJson = readJson(tree, 'libs/my-lib/.eslintrc.json');
+        const eslintJson = readJson(tree, 'my-lib/.eslintrc.json');
         expect(eslintJson).toMatchInlineSnapshot(`
           {
             "extends": [
-              "../../.eslintrc.json",
+              "../.eslintrc.json",
             ],
             "ignorePatterns": [
               "!**/*",
@@ -530,18 +562,17 @@ describe('lib', () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
-          directory: 'myDir',
+          directory: 'my-dir/my-lib',
+          projectNameAndRootFormat: 'as-provided',
         });
 
-        expect(
-          readProjectConfiguration(tree, 'my-dir-my-lib').targets.lint
-        ).toEqual({
+        expect(readProjectConfiguration(tree, 'my-lib').targets.lint).toEqual({
           executor: '@nx/linter:eslint',
           outputs: ['{options.outputFile}'],
           options: {
             lintFilePatterns: [
-              'libs/my-dir/my-lib/**/*.ts',
-              'libs/my-dir/my-lib/package.json',
+              'my-dir/my-lib/**/*.ts',
+              'my-dir/my-lib/package.json',
             ],
           },
         });
@@ -551,14 +582,15 @@ describe('lib', () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
-          directory: 'myDir',
+          directory: 'my-dir/my-lib',
+          projectNameAndRootFormat: 'as-provided',
         });
 
-        const eslintJson = readJson(tree, 'libs/my-dir/my-lib/.eslintrc.json');
+        const eslintJson = readJson(tree, 'my-dir/my-lib/.eslintrc.json');
         expect(eslintJson).toMatchInlineSnapshot(`
           {
             "extends": [
-              "../../../.eslintrc.json",
+              "../../.eslintrc.json",
             ],
             "ignorePatterns": [
               "!**/*",
@@ -608,11 +640,12 @@ describe('lib', () => {
           ...defaultOptions,
           name: 'myLib',
           js: true,
+          projectNameAndRootFormat: 'as-provided',
         });
-        expect(tree.exists(`libs/my-lib/jest.config.js`)).toBeTruthy();
-        expect(tree.exists('libs/my-lib/src/index.js')).toBeTruthy();
-        expect(tree.exists('libs/my-lib/src/lib/my-lib.js')).toBeTruthy();
-        expect(tree.exists('libs/my-lib/src/lib/my-lib.spec.js')).toBeTruthy();
+        expect(tree.exists(`my-lib/jest.config.js`)).toBeTruthy();
+        expect(tree.exists('my-lib/src/index.js')).toBeTruthy();
+        expect(tree.exists('my-lib/src/lib/my-lib.js')).toBeTruthy();
+        expect(tree.exists('my-lib/src/lib/my-lib.spec.js')).toBeTruthy();
       });
 
       it('should update tsconfig.json with compilerOptions.allowJs: true', async () => {
@@ -620,9 +653,10 @@ describe('lib', () => {
           ...defaultOptions,
           name: 'myLib',
           js: true,
+          projectNameAndRootFormat: 'as-provided',
         });
         expect(
-          readJson(tree, 'libs/my-lib/tsconfig.json').compilerOptions.allowJs
+          readJson(tree, 'my-lib/tsconfig.json').compilerOptions.allowJs
         ).toBeTruthy();
       });
 
@@ -631,10 +665,12 @@ describe('lib', () => {
           ...defaultOptions,
           name: 'myLib',
           js: true,
+          projectNameAndRootFormat: 'as-provided',
         });
-        expect(readJson(tree, 'libs/my-lib/tsconfig.lib.json').include).toEqual(
-          ['src/**/*.ts', 'src/**/*.js']
-        );
+        expect(readJson(tree, 'my-lib/tsconfig.lib.json').include).toEqual([
+          'src/**/*.ts',
+          'src/**/*.js',
+        ]);
       });
 
       it('should update root tsconfig.json with a js file path', async () => {
@@ -642,10 +678,11 @@ describe('lib', () => {
           ...defaultOptions,
           name: 'myLib',
           js: true,
+          projectNameAndRootFormat: 'as-provided',
         });
         const tsconfigJson = readJson(tree, '/tsconfig.base.json');
         expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-          'libs/my-lib/src/index.js',
+          'my-lib/src/index.js',
         ]);
       });
 
@@ -653,39 +690,36 @@ describe('lib', () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
-          directory: 'myDir',
+          directory: 'my-dir/my-lib',
           js: true,
+          projectNameAndRootFormat: 'as-provided',
         });
-        expect(tree.exists(`libs/my-dir/my-lib/jest.config.js`)).toBeTruthy();
-        expect(tree.exists('libs/my-dir/my-lib/src/index.js')).toBeTruthy();
+        expect(tree.exists(`my-dir/my-lib/jest.config.js`)).toBeTruthy();
+        expect(tree.exists('my-dir/my-lib/src/index.js')).toBeTruthy();
+        expect(tree.exists('my-dir/my-lib/src/lib/my-lib.js')).toBeTruthy();
         expect(
-          tree.exists('libs/my-dir/my-lib/src/lib/my-dir-my-lib.js')
+          tree.exists('my-dir/my-lib/src/lib/my-lib.spec.js')
         ).toBeTruthy();
-        expect(
-          tree.exists('libs/my-dir/my-lib/src/lib/my-dir-my-lib.spec.js')
-        ).toBeTruthy();
-        expect(tree.exists('libs/my-dir/my-lib/src/index.js')).toBeTruthy();
+        expect(tree.exists('my-dir/my-lib/src/index.js')).toBeTruthy();
       });
 
       it('should configure the project for linting js files', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
-          directory: 'myDir',
+          directory: 'my-dir/my-lib',
           js: true,
+          projectNameAndRootFormat: 'as-provided',
         });
         expect(
-          readProjectConfiguration(tree, 'my-dir-my-lib').targets.lint.options
+          readProjectConfiguration(tree, 'my-lib').targets.lint.options
             .lintFilePatterns
-        ).toEqual([
-          'libs/my-dir/my-lib/**/*.js',
-          'libs/my-dir/my-lib/package.json',
-        ]);
-        expect(readJson(tree, 'libs/my-dir/my-lib/.eslintrc.json'))
+        ).toEqual(['my-dir/my-lib/**/*.js', 'my-dir/my-lib/package.json']);
+        expect(readJson(tree, 'my-dir/my-lib/.eslintrc.json'))
           .toMatchInlineSnapshot(`
           {
             "extends": [
-              "../../../.eslintrc.json",
+              "../../.eslintrc.json",
             ],
             "ignorePatterns": [
               "!**/*",
@@ -736,31 +770,32 @@ describe('lib', () => {
         ...defaultOptions,
         name: 'myLib',
         unitTestRunner: 'jest',
+        projectNameAndRootFormat: 'as-provided',
       });
 
-      expect(tree.exists('libs/my-lib/tsconfig.spec.json')).toBeTruthy();
-      expect(tree.exists('libs/my-lib/jest.config.ts')).toBeTruthy();
-      expect(tree.exists('libs/my-lib/src/lib/my-lib.spec.ts')).toBeTruthy();
+      expect(tree.exists('my-lib/tsconfig.spec.json')).toBeTruthy();
+      expect(tree.exists('my-lib/jest.config.ts')).toBeTruthy();
+      expect(tree.exists('my-lib/src/lib/my-lib.spec.ts')).toBeTruthy();
 
       const projectConfig = readProjectConfiguration(tree, 'my-lib');
       expect(projectConfig.targets.test).toBeDefined();
 
-      expect(tree.exists(`libs/my-lib/jest.config.ts`)).toBeTruthy();
-      expect(tree.read(`libs/my-lib/jest.config.ts`, 'utf-8'))
+      expect(tree.exists(`my-lib/jest.config.ts`)).toBeTruthy();
+      expect(tree.read(`my-lib/jest.config.ts`, 'utf-8'))
         .toMatchInlineSnapshot(`
         "/* eslint-disable */
         export default {
           displayName: 'my-lib',
-          preset: '../../jest.preset.js',
+          preset: '../jest.preset.js',
           transform: {
             '^.+\\\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
           },
           moduleFileExtensions: ['ts', 'js', 'html'],
-          coverageDirectory: '../../coverage/libs/my-lib',
+          coverageDirectory: '../coverage/my-lib',
         };
         "
       `);
-      const readme = tree.read('libs/my-lib/README.md', 'utf-8');
+      const readme = tree.read('my-lib/README.md', 'utf-8');
       expect(readme).toContain('nx test my-lib');
     });
 
@@ -771,20 +806,19 @@ describe('lib', () => {
         unitTestRunner: 'jest',
         bundler: 'swc',
         js: true,
+        projectNameAndRootFormat: 'as-provided',
       });
 
-      expect(tree.exists('libs/my-lib/tsconfig.spec.json')).toBeTruthy();
-      expect(tree.exists('libs/my-lib/jest.config.js')).toBeTruthy();
-      expect(tree.exists('libs/my-lib/src/lib/my-lib.spec.js')).toBeTruthy();
+      expect(tree.exists('my-lib/tsconfig.spec.json')).toBeTruthy();
+      expect(tree.exists('my-lib/jest.config.js')).toBeTruthy();
+      expect(tree.exists('my-lib/src/lib/my-lib.spec.js')).toBeTruthy();
 
       const projectConfig = readProjectConfiguration(tree, 'my-lib');
       expect(projectConfig.targets.test).toBeDefined();
 
-      expect(tree.exists(`libs/my-lib/jest.config.js`)).toBeTruthy();
-      expect(
-        tree.read(`libs/my-lib/jest.config.js`, 'utf-8')
-      ).toMatchSnapshot();
-      const readme = tree.read('libs/my-lib/README.md', 'utf-8');
+      expect(tree.exists(`my-lib/jest.config.js`)).toBeTruthy();
+      expect(tree.read(`my-lib/jest.config.js`, 'utf-8')).toMatchSnapshot();
+      const readme = tree.read('my-lib/README.md', 'utf-8');
       expect(readme).toContain('nx test my-lib');
     });
 
@@ -794,6 +828,7 @@ describe('lib', () => {
           ...defaultOptions,
           name: 'myLib',
           bundler: 'none',
+          projectNameAndRootFormat: 'as-provided',
         });
 
         const config = readProjectConfiguration(tree, 'my-lib');
@@ -804,6 +839,7 @@ describe('lib', () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           name: 'myLib',
+          projectNameAndRootFormat: 'as-provided',
         });
 
         const config = readProjectConfiguration(tree, 'my-lib');
@@ -815,16 +851,17 @@ describe('lib', () => {
           ...defaultOptions,
           name: 'myLib',
           bundler: 'tsc',
+          projectNameAndRootFormat: 'as-provided',
         });
 
         const config = readProjectConfiguration(tree, 'my-lib');
         expect(config.targets.build).toEqual({
           executor: '@nx/js:tsc',
           options: {
-            assets: ['libs/my-lib/*.md'],
-            main: 'libs/my-lib/src/index.ts',
-            outputPath: 'dist/libs/my-lib',
-            tsConfig: 'libs/my-lib/tsconfig.lib.json',
+            assets: ['my-lib/*.md'],
+            main: 'my-lib/src/index.ts',
+            outputPath: 'dist/my-lib',
+            tsConfig: 'my-lib/tsconfig.lib.json',
           },
           outputs: ['{options.outputPath}'],
         });
@@ -835,16 +872,17 @@ describe('lib', () => {
           ...defaultOptions,
           name: 'myLib',
           bundler: 'swc',
+          projectNameAndRootFormat: 'as-provided',
         });
 
         const config = readProjectConfiguration(tree, 'my-lib');
         expect(config.targets.build).toEqual({
           executor: '@nx/js:swc',
           options: {
-            assets: ['libs/my-lib/*.md'],
-            main: 'libs/my-lib/src/index.ts',
-            outputPath: 'dist/libs/my-lib',
-            tsConfig: 'libs/my-lib/tsconfig.lib.json',
+            assets: ['my-lib/*.md'],
+            main: 'my-lib/src/index.ts',
+            outputPath: 'dist/my-lib',
+            tsConfig: 'my-lib/tsconfig.lib.json',
           },
           outputs: ['{options.outputPath}'],
         });
@@ -855,9 +893,10 @@ describe('lib', () => {
           ...defaultOptions,
           name: 'myLib',
           bundler: 'swc',
+          projectNameAndRootFormat: 'as-provided',
         });
 
-        expect(tree.exists('libs/my-lib/.swcrc')).toBeTruthy();
+        expect(tree.exists('my-lib/.swcrc')).toBeTruthy();
       });
 
       it('should setup jest project using swc', async () => {
@@ -865,9 +904,10 @@ describe('lib', () => {
           ...defaultOptions,
           name: 'myLib',
           bundler: 'swc',
+          projectNameAndRootFormat: 'as-provided',
         });
 
-        const jestConfig = tree.read('libs/my-lib/jest.config.ts').toString();
+        const jestConfig = tree.read('my-lib/jest.config.ts').toString();
         expect(jestConfig).toContain('@swc/jest');
       });
 
@@ -876,9 +916,10 @@ describe('lib', () => {
           ...defaultOptions,
           name: 'myLib',
           bundler: 'tsc',
+          projectNameAndRootFormat: 'as-provided',
         });
 
-        expect(tree.exists('libs/my-lib/package.json')).toBeTruthy();
+        expect(tree.exists('my-lib/package.json')).toBeTruthy();
       });
     });
 
@@ -889,16 +930,17 @@ describe('lib', () => {
           name: 'myLib',
           buildable: true,
           compiler: 'tsc',
+          projectNameAndRootFormat: 'as-provided',
         });
 
         const config = readProjectConfiguration(tree, 'my-lib');
         expect(config.targets.build).toEqual({
           executor: '@nx/js:tsc',
           options: {
-            assets: ['libs/my-lib/*.md'],
-            main: 'libs/my-lib/src/index.ts',
-            outputPath: 'dist/libs/my-lib',
-            tsConfig: 'libs/my-lib/tsconfig.lib.json',
+            assets: ['my-lib/*.md'],
+            main: 'my-lib/src/index.ts',
+            outputPath: 'dist/my-lib',
+            tsConfig: 'my-lib/tsconfig.lib.json',
           },
           outputs: ['{options.outputPath}'],
         });
@@ -910,16 +952,17 @@ describe('lib', () => {
           name: 'myLib',
           buildable: true,
           compiler: 'swc',
+          projectNameAndRootFormat: 'as-provided',
         });
 
         const config = readProjectConfiguration(tree, 'my-lib');
         expect(config.targets.build).toEqual({
           executor: '@nx/js:swc',
           options: {
-            assets: ['libs/my-lib/*.md'],
-            main: 'libs/my-lib/src/index.ts',
-            outputPath: 'dist/libs/my-lib',
-            tsConfig: 'libs/my-lib/tsconfig.lib.json',
+            assets: ['my-lib/*.md'],
+            main: 'my-lib/src/index.ts',
+            outputPath: 'dist/my-lib',
+            tsConfig: 'my-lib/tsconfig.lib.json',
           },
           outputs: ['{options.outputPath}'],
         });
@@ -931,9 +974,10 @@ describe('lib', () => {
           name: 'myLib',
           buildable: true,
           compiler: 'swc',
+          projectNameAndRootFormat: 'as-provided',
         });
 
-        expect(tree.exists('libs/my-lib/.swcrc')).toBeTruthy();
+        expect(tree.exists('my-lib/.swcrc')).toBeTruthy();
       });
 
       it('should setup jest project using swc', async () => {
@@ -942,9 +986,10 @@ describe('lib', () => {
           name: 'myLib',
           buildable: true,
           compiler: 'swc',
+          projectNameAndRootFormat: 'as-provided',
         });
 
-        const jestConfig = tree.read('libs/my-lib/jest.config.ts').toString();
+        const jestConfig = tree.read('my-lib/jest.config.ts').toString();
         expect(jestConfig).toContain('@swc/jest');
       });
 
@@ -954,9 +999,10 @@ describe('lib', () => {
           name: 'myLib',
           buildable: true,
           compiler: 'tsc',
+          projectNameAndRootFormat: 'as-provided',
         });
 
-        expect(tree.exists('libs/my-lib/package.json')).toBeTruthy();
+        expect(tree.exists('my-lib/package.json')).toBeTruthy();
       });
     });
 
@@ -966,11 +1012,12 @@ describe('lib', () => {
           ...defaultOptions,
           name: 'myLib',
           bundler: 'rollup',
+          projectNameAndRootFormat: 'as-provided',
         });
 
         const config = readProjectConfiguration(tree, 'my-lib');
         expect(config.targets.build.options.project).toEqual(
-          `libs/my-lib/package.json`
+          `my-lib/package.json`
         );
       });
 
@@ -979,6 +1026,7 @@ describe('lib', () => {
           ...defaultOptions,
           name: 'myLib',
           bundler: 'rollup',
+          projectNameAndRootFormat: 'as-provided',
         });
 
         const config = readProjectConfiguration(tree, 'my-lib');
@@ -994,16 +1042,17 @@ describe('lib', () => {
           publishable: true,
           importPath: '@proj/my-lib',
           bundler: 'tsc',
+          projectNameAndRootFormat: 'as-provided',
         });
 
         const config = readProjectConfiguration(tree, 'my-lib');
         expect(config.targets.build).toEqual({
           executor: '@nx/js:tsc',
           options: {
-            assets: ['libs/my-lib/*.md'],
-            main: 'libs/my-lib/src/index.ts',
-            outputPath: 'dist/libs/my-lib',
-            tsConfig: 'libs/my-lib/tsconfig.lib.json',
+            assets: ['my-lib/*.md'],
+            main: 'my-lib/src/index.ts',
+            outputPath: 'dist/my-lib',
+            tsConfig: 'my-lib/tsconfig.lib.json',
           },
           outputs: ['{options.outputPath}'],
         });
@@ -1016,6 +1065,7 @@ describe('lib', () => {
           publishable: true,
           importPath: '@proj/my-lib',
           bundler: 'tsc',
+          projectNameAndRootFormat: 'as-provided',
         });
 
         const config = readProjectConfiguration(tree, 'my-lib');
@@ -1033,6 +1083,7 @@ describe('lib', () => {
           publishable: true,
           importPath: '@proj/my-lib',
           bundler: 'tsc',
+          projectNameAndRootFormat: 'as-provided',
         });
 
         expect(tree.exists('tools/scripts/publish.mjs')).toBeTruthy();
@@ -1045,9 +1096,10 @@ describe('lib', () => {
           ...defaultOptions,
           name: 'myLib',
           includeBabelRc: true,
+          projectNameAndRootFormat: 'as-provided',
         });
 
-        expect(tree.exists('libs/my-lib/.babelrc')).toBeTruthy();
+        expect(tree.exists('my-lib/.babelrc')).toBeTruthy();
       });
 
       it('should not generate a .babelrc when flag is set to false', async () => {
@@ -1055,9 +1107,10 @@ describe('lib', () => {
           ...defaultOptions,
           name: 'myLib',
           includeBabelRc: false,
+          projectNameAndRootFormat: 'as-provided',
         });
 
-        expect(tree.exists('libs/my-lib/.babelrc')).toBeFalsy();
+        expect(tree.exists('my-lib/.babelrc')).toBeFalsy();
       });
 
       it('should not generate a .babelrc when bundler is swc (even if flag is set to true)', async () => {
@@ -1066,9 +1119,10 @@ describe('lib', () => {
           name: 'myLib',
           bundler: 'swc',
           includeBabelRc: true,
+          projectNameAndRootFormat: 'as-provided',
         });
 
-        expect(tree.exists('libs/my-lib/.babelrc')).toBeFalsy();
+        expect(tree.exists('my-lib/.babelrc')).toBeFalsy();
       });
 
       it('should generate a .babelrc when flag is set to true (even if there is no `@nx/web` plugin installed)', async () => {
@@ -1081,11 +1135,12 @@ describe('lib', () => {
           ...defaultOptions,
           name: 'myLib',
           includeBabelRc: true,
+          projectNameAndRootFormat: 'as-provided',
         });
 
-        expect(tree.exists('libs/my-lib/.babelrc')).toBeTruthy();
+        expect(tree.exists('my-lib/.babelrc')).toBeTruthy();
 
-        const babelRc = readJson(tree, 'libs/my-lib/.babelrc');
+        const babelRc = readJson(tree, 'my-lib/.babelrc');
         expect(babelRc).toMatchInlineSnapshot(`
           {
             "presets": [
@@ -1113,9 +1168,10 @@ describe('lib', () => {
           ...defaultOptions,
           name: 'myLib',
           includeBabelRc: undefined,
+          projectNameAndRootFormat: 'as-provided',
         });
 
-        expect(tree.exists('libs/my-lib/.babelrc')).toBeFalsy();
+        expect(tree.exists('my-lib/.babelrc')).toBeFalsy();
       });
     });
   });
@@ -1127,6 +1183,7 @@ describe('lib', () => {
         name: 'myLib',
         bundler: 'vite',
         unitTestRunner: undefined,
+        projectNameAndRootFormat: 'as-provided',
       });
 
       const project = readProjectConfiguration(tree, 'my-lib');
@@ -1136,10 +1193,8 @@ describe('lib', () => {
       expect(project.targets.test).toMatchObject({
         executor: '@nx/vite:test',
       });
-      expect(tree.exists('libs/my-lib/vite.config.ts')).toBeTruthy();
-      expect(
-        readJson(tree, 'libs/my-lib/.eslintrc.json').overrides
-      ).toContainEqual({
+      expect(tree.exists('my-lib/vite.config.ts')).toBeTruthy();
+      expect(readJson(tree, 'my-lib/.eslintrc.json').overrides).toContainEqual({
         files: ['*.json'],
         parser: 'jsonc-eslint-parser',
         rules: {
@@ -1165,6 +1220,7 @@ describe('lib', () => {
           name: 'myLib',
           bundler: 'vite',
           unitTestRunner,
+          projectNameAndRootFormat: 'as-provided',
         });
 
         const project = readProjectConfiguration(tree, 'my-lib');
@@ -1180,15 +1236,14 @@ describe('lib', () => {
         name: 'myLib',
         bundler: 'esbuild',
         unitTestRunner: 'none',
+        projectNameAndRootFormat: 'as-provided',
       });
 
       const project = readProjectConfiguration(tree, 'my-lib');
       expect(project.targets.build).toMatchObject({
         executor: '@nx/esbuild:esbuild',
       });
-      expect(
-        readJson(tree, 'libs/my-lib/.eslintrc.json').overrides
-      ).toContainEqual({
+      expect(readJson(tree, 'my-lib/.eslintrc.json').overrides).toContainEqual({
         files: ['*.json'],
         parser: 'jsonc-eslint-parser',
         rules: {
@@ -1210,15 +1265,14 @@ describe('lib', () => {
         name: 'myLib',
         bundler: 'rollup',
         unitTestRunner: 'none',
+        projectNameAndRootFormat: 'as-provided',
       });
 
       const project = readProjectConfiguration(tree, 'my-lib');
       expect(project.targets.build).toMatchObject({
         executor: '@nx/rollup:rollup',
       });
-      expect(
-        readJson(tree, 'libs/my-lib/.eslintrc.json').overrides
-      ).toContainEqual({
+      expect(readJson(tree, 'my-lib/.eslintrc.json').overrides).toContainEqual({
         files: ['*.json'],
         parser: 'jsonc-eslint-parser',
         rules: {
@@ -1239,9 +1293,10 @@ describe('lib', () => {
         ...defaultOptions,
         name: 'myLib',
         minimal: false,
+        projectNameAndRootFormat: 'as-provided',
       });
 
-      expect(tree.exists('libs/my-lib/README.md')).toBeTruthy();
+      expect(tree.exists('my-lib/README.md')).toBeTruthy();
     });
 
     it('should not generate a README.md when minimal is set to true', async () => {
@@ -1249,9 +1304,10 @@ describe('lib', () => {
         ...defaultOptions,
         name: 'myLib',
         minimal: true,
+        projectNameAndRootFormat: 'as-provided',
       });
 
-      expect(tree.exists('libs/my-lib/README.md')).toBeFalsy();
+      expect(tree.exists('my-lib/README.md')).toBeFalsy();
     });
 
     it('should generate a README.md and add it to the build assets when buildable is true and minimal is false', async () => {
@@ -1260,13 +1316,14 @@ describe('lib', () => {
         name: 'myLib',
         bundler: 'tsc',
         minimal: false,
+        projectNameAndRootFormat: 'as-provided',
       });
 
-      expect(tree.exists('libs/my-lib/README.md')).toBeTruthy();
+      expect(tree.exists('my-lib/README.md')).toBeTruthy();
 
       const project = readProjectConfiguration(tree, 'my-lib');
       expect(project.targets.build.options.assets).toStrictEqual([
-        'libs/my-lib/*.md',
+        'my-lib/*.md',
       ]);
     });
 
@@ -1276,9 +1333,10 @@ describe('lib', () => {
         name: 'myLib',
         bundler: 'tsc',
         minimal: true,
+        projectNameAndRootFormat: 'as-provided',
       });
 
-      expect(tree.exists('libs/my-lib/README.md')).toBeFalsy();
+      expect(tree.exists('my-lib/README.md')).toBeFalsy();
 
       const project = readProjectConfiguration(tree, 'my-lib');
       expect(project.targets.build.options.assets).toEqual([]);
@@ -1291,13 +1349,14 @@ describe('lib', () => {
         ...defaultOptions,
         name: 'myLib',
         simpleName: true,
-        directory: 'web',
+        directory: 'web/my-lib',
+        projectNameAndRootFormat: 'as-provided',
       });
 
-      expect(tree.read('libs/web/my-lib/src/index.ts', 'utf-8')).toContain(
+      expect(tree.read('web/my-lib/src/index.ts', 'utf-8')).toContain(
         `export * from './lib/my-lib';`
       );
-      expect(tree.exists('libs/web/my-lib/src/lib/my-lib.ts')).toBeTruthy();
+      expect(tree.exists('web/my-lib/src/lib/my-lib.ts')).toBeTruthy();
     });
   });
 });

--- a/packages/js/src/migrations/update-16-6-0/explicitly-set-projects-to-update-buildable-deps.spec.ts
+++ b/packages/js/src/migrations/update-16-6-0/explicitly-set-projects-to-update-buildable-deps.spec.ts
@@ -18,14 +18,14 @@ describe('explicitly-set-projects-to-update-buildable-deps migration', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it.each(['@nx/js:swc', '@nrwl/js:swc', '@nx/js:tsc', '@nrwl/js:tsc'])(
     'should set updateBuildableProjectDepsInPackageJson option to "true" when not specified in target using "%s"',
     async (executor) => {
       addProject(tree, 'lib1', {
-        root: 'libs/lib1',
+        root: 'lib1',
         projectType: 'library',
         targets: { build: { executor, options: {} } },
       });
@@ -43,7 +43,7 @@ describe('explicitly-set-projects-to-update-buildable-deps migration', () => {
     'should set updateBuildableProjectDepsInPackageJson option to "true" when target has no options object defined using "%s"',
     async (executor) => {
       addProject(tree, 'lib1', {
-        root: 'libs/lib1',
+        root: 'lib1',
         projectType: 'library',
         targets: { build: { executor } },
       });
@@ -61,7 +61,7 @@ describe('explicitly-set-projects-to-update-buildable-deps migration', () => {
     'should not overwrite updateBuildableProjectDepsInPackageJson option when it is specified in target using "%s"',
     async (executor) => {
       addProject(tree, 'lib1', {
-        root: 'libs/lib1',
+        root: 'lib1',
         projectType: 'library',
         targets: {
           build: {
@@ -82,7 +82,7 @@ describe('explicitly-set-projects-to-update-buildable-deps migration', () => {
 
   it('should not update targets using other executors', async () => {
     const originalProjectConfig: ProjectConfiguration = {
-      root: 'libs/lib1',
+      root: 'lib1',
       projectType: 'library',
       targets: {
         build: {


### PR DESCRIPTION
This PR updates js plugin unit tests to use `as-provided` option when generating apps/libs, which will be the only option in Nx 18. This is for unit tests only, no affect on production code. 

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
