### PR TITLE
feat(core): support for 3rd party package managers

### DIFF
--- a/docs/generated/devkit/NxJsonConfiguration.md
+++ b/docs/generated/devkit/NxJsonConfiguration.md
@@ -51,11 +51,11 @@ Default generator collection. It is used when no collection is provided.
 
 #### Type declaration
 
-| Name                  | Type                                                      | Description                                                            |
-| :-------------------- | :-------------------------------------------------------- | :--------------------------------------------------------------------- |
-| `defaultCollection?`  | `string`                                                  | **`Deprecated`** - defaultCollection is deprecated and will be removed |
-| `defaultProjectName?` | `string`                                                  | -                                                                      |
-| `packageManager?`     | [`PackageManager`](../../devkit/documents/PackageManager) | -                                                                      |
+| Name                  | Type     | Description                                                            |
+| :-------------------- | :------- | :--------------------------------------------------------------------- |
+| `defaultCollection?`  | `string` | **`Deprecated`** - defaultCollection is deprecated and will be removed |
+| `defaultProjectName?` | `string` | -                                                                      |
+| `packageManager?`     | `string` | -                                                                      |
 
 ---
 

--- a/docs/generated/devkit/NxPluginV2.md
+++ b/docs/generated/devkit/NxPluginV2.md
@@ -6,8 +6,9 @@ A plugin for Nx which creates nodes and dependencies for the [ProjectGraph](../.
 
 #### Type declaration
 
-| Name                  | Type                                                              | Description                                                                                                                                   |
-| :-------------------- | :---------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------- |
-| `createDependencies?` | [`CreateDependencies`](../../devkit/documents/CreateDependencies) | Provides a function to analyze files to create dependencies for the [ProjectGraph](../../devkit/documents/ProjectGraph)                       |
-| `createNodes?`        | [`CreateNodes`](../../devkit/documents/CreateNodes)               | Provides a file pattern and function that retrieves configuration info from those files. e.g. { '\*_/_.csproj': buildProjectsFromCsProjFile } |
-| `name`                | `string`                                                          | -                                                                                                                                             |
+| Name                       | Type                                                              | Description                                                                                                                                   |
+| :------------------------- | :---------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------- |
+| `createDependencies?`      | [`CreateDependencies`](../../devkit/documents/CreateDependencies) | Provides a function to analyze files to create dependencies for the [ProjectGraph](../../devkit/documents/ProjectGraph)                       |
+| `createNodes?`             | [`CreateNodes`](../../devkit/documents/CreateNodes)               | Provides a file pattern and function that retrieves configuration info from those files. e.g. { '\*_/_.csproj': buildProjectsFromCsProjFile } |
+| `name`                     | `string`                                                          | -                                                                                                                                             |
+| `providesPackageManagers?` | () => `Record`<`string`, `PackageManagerCommands`\>               | This is used to provide a custom packageManager for nx.                                                                                       |

--- a/docs/generated/devkit/PackageManager.md
+++ b/docs/generated/devkit/PackageManager.md
@@ -1,3 +1,3 @@
 # Type alias: PackageManager
 
-Ƭ **PackageManager**: `"yarn"` \| `"pnpm"` \| `"npm"`
+Ƭ **PackageManager**: `CorePackageManager` \| `string`

--- a/docs/generated/devkit/README.md
+++ b/docs/generated/devkit/README.md
@@ -122,6 +122,7 @@ It only uses language primitives and immutable objects
 - [getNpmPackageSharedConfig](../../devkit/documents/getNpmPackageSharedConfig)
 - [getOutputsForTargetAndConfiguration](../../devkit/documents/getOutputsForTargetAndConfiguration)
 - [getPackageManagerCommand](../../devkit/documents/getPackageManagerCommand)
+- [getPackageManagerCommandAsync](../../devkit/documents/getPackageManagerCommandAsync)
 - [getPackageManagerVersion](../../devkit/documents/getPackageManagerVersion)
 - [getProjects](../../devkit/documents/getProjects)
 - [getWorkspaceLayout](../../devkit/documents/getWorkspaceLayout)

--- a/docs/generated/devkit/Workspace.md
+++ b/docs/generated/devkit/Workspace.md
@@ -55,11 +55,11 @@ Default generator collection. It is used when no collection is provided.
 
 #### Type declaration
 
-| Name                  | Type                                                      | Description                                                            |
-| :-------------------- | :-------------------------------------------------------- | :--------------------------------------------------------------------- |
-| `defaultCollection?`  | `string`                                                  | **`Deprecated`** - defaultCollection is deprecated and will be removed |
-| `defaultProjectName?` | `string`                                                  | -                                                                      |
-| `packageManager?`     | [`PackageManager`](../../devkit/documents/PackageManager) | -                                                                      |
+| Name                  | Type     | Description                                                            |
+| :-------------------- | :------- | :--------------------------------------------------------------------- |
+| `defaultCollection?`  | `string` | **`Deprecated`** - defaultCollection is deprecated and will be removed |
+| `defaultProjectName?` | `string` | -                                                                      |
+| `packageManager?`     | `string` | -                                                                      |
 
 #### Inherited from
 

--- a/docs/generated/devkit/detectPackageManager.md
+++ b/docs/generated/devkit/detectPackageManager.md
@@ -2,8 +2,6 @@
 
 ▸ **detectPackageManager**(`dir?`): [`PackageManager`](../../devkit/documents/PackageManager)
 
-Detects which package manager is used in the workspace based on the lock file.
-
 #### Parameters
 
 | Name  | Type     | Default value |

--- a/docs/generated/devkit/getPackageManagerCommandAsync.md
+++ b/docs/generated/devkit/getPackageManagerCommandAsync.md
@@ -1,6 +1,6 @@
-# Function: getPackageManagerCommand
+# Function: getPackageManagerCommandAsync
 
-▸ **getPackageManagerCommand**(`packageManager?`, `root?`): `PackageManagerCommands`
+▸ **getPackageManagerCommandAsync**(`packageManager?`, `root?`): `Promise`<`PackageManagerCommands`\>
 
 Returns commands for the package manager used in the workspace.
 By default, the package manager is derived based on the lock file,
@@ -21,4 +21,4 @@ execSync(`${getPackageManagerCommand().addDev} my-dev-package`);
 
 #### Returns
 
-`PackageManagerCommands`
+`Promise`<`PackageManagerCommands`\>

--- a/docs/generated/devkit/getPackageManagerVersion.md
+++ b/docs/generated/devkit/getPackageManagerVersion.md
@@ -8,10 +8,10 @@ but it can also be passed in explicitly.
 
 #### Parameters
 
-| Name             | Type                                                      |
-| :--------------- | :-------------------------------------------------------- |
-| `packageManager` | [`PackageManager`](../../devkit/documents/PackageManager) |
-| `cwd`            | `string`                                                  |
+| Name             | Type     |
+| :--------------- | :------- |
+| `packageManager` | `string` |
+| `cwd`            | `string` |
 
 #### Returns
 

--- a/docs/generated/devkit/installPackagesTask.md
+++ b/docs/generated/devkit/installPackagesTask.md
@@ -1,19 +1,19 @@
 # Function: installPackagesTask
 
-▸ **installPackagesTask**(`tree`, `alwaysRun?`, `cwd?`, `packageManager?`): `void`
+▸ **installPackagesTask**(`tree`, `alwaysRun?`, `cwd?`, `packageManager?`): `Promise`<`void`\>
 
 Runs `npm install` or `yarn install`. It will skip running the install if
 `package.json` hasn't changed at all or it hasn't changed since the last invocation.
 
 #### Parameters
 
-| Name              | Type                                                      | Description                                                   |
-| :---------------- | :-------------------------------------------------------- | :------------------------------------------------------------ |
-| `tree`            | [`Tree`](../../devkit/documents/Tree)                     | the file system tree                                          |
-| `alwaysRun?`      | `boolean`                                                 | always run the command even if `package.json` hasn't changed. |
-| `cwd?`            | `string`                                                  | -                                                             |
-| `packageManager?` | [`PackageManager`](../../devkit/documents/PackageManager) | -                                                             |
+| Name              | Type                                  | Description                                                   |
+| :---------------- | :------------------------------------ | :------------------------------------------------------------ |
+| `tree`            | [`Tree`](../../devkit/documents/Tree) | the file system tree                                          |
+| `alwaysRun?`      | `boolean`                             | always run the command even if `package.json` hasn't changed. |
+| `cwd?`            | `string`                              | -                                                             |
+| `packageManager?` | `string`                              | -                                                             |
 
 #### Returns
 
-`void`
+`Promise`<`void`\>

--- a/docs/generated/packages/devkit/documents/nx_devkit.md
+++ b/docs/generated/packages/devkit/documents/nx_devkit.md
@@ -122,6 +122,7 @@ It only uses language primitives and immutable objects
 - [getNpmPackageSharedConfig](../../devkit/documents/getNpmPackageSharedConfig)
 - [getOutputsForTargetAndConfiguration](../../devkit/documents/getOutputsForTargetAndConfiguration)
 - [getPackageManagerCommand](../../devkit/documents/getPackageManagerCommand)
+- [getPackageManagerCommandAsync](../../devkit/documents/getPackageManagerCommandAsync)
 - [getPackageManagerVersion](../../devkit/documents/getPackageManagerVersion)
 - [getProjects](../../devkit/documents/getProjects)
 - [getWorkspaceLayout](../../devkit/documents/getWorkspaceLayout)

--- a/packages/devkit/src/tasks/install-packages-task.ts
+++ b/packages/devkit/src/tasks/install-packages-task.ts
@@ -4,8 +4,11 @@ import { requireNx } from '../../nx';
 
 import type { Tree } from 'nx/src/generators/tree';
 import type { PackageManager } from 'nx/src/utils/package-manager';
-const { detectPackageManager, getPackageManagerCommand, joinPathFragments } =
-  requireNx();
+const {
+  detectPackageManager,
+  getPackageManagerCommandAsync,
+  joinPathFragments,
+} = requireNx();
 
 /**
  * Runs `npm install` or `yarn install`. It will skip running the install if
@@ -14,12 +17,12 @@ const { detectPackageManager, getPackageManagerCommand, joinPathFragments } =
  * @param tree - the file system tree
  * @param alwaysRun - always run the command even if `package.json` hasn't changed.
  */
-export function installPackagesTask(
+export async function installPackagesTask(
   tree: Tree,
   alwaysRun: boolean = false,
   cwd: string = '',
   packageManager: PackageManager = detectPackageManager(cwd)
-): void {
+): Promise<void> {
   if (
     !tree
       .listChanges()
@@ -37,7 +40,7 @@ export function installPackagesTask(
   // Don't install again if install was already executed with package.json
   if (storedPackageJsonValue != packageJsonValue || alwaysRun) {
     global['__packageJsonInstallCache__'] = packageJsonValue;
-    const pmc = getPackageManagerCommand(packageManager);
+    const pmc = await getPackageManagerCommandAsync(packageManager);
     const execSyncOptions: ExecSyncOptions = {
       cwd: join(tree.root, cwd),
       stdio: process.env.NX_GENERATE_QUIET === 'true' ? 'ignore' : 'inherit',

--- a/packages/nx/src/devkit-exports.ts
+++ b/packages/nx/src/devkit-exports.ts
@@ -92,6 +92,7 @@ export type { PackageManager } from './utils/package-manager';
  */
 export {
   getPackageManagerCommand,
+  getPackageManagerCommandAsync,
   detectPackageManager,
   getPackageManagerVersion,
 } from './utils/package-manager';

--- a/packages/nx/src/executors/run-script/run-script.impl.ts
+++ b/packages/nx/src/executors/run-script/run-script.impl.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'child_process';
-import { getPackageManagerCommand } from '../../utils/package-manager';
+import { getPackageManagerCommandAsync } from '../../utils/package-manager';
 import type { ExecutorContext } from '../../config/misc-interfaces';
 import * as path from 'path';
 import { env as appendLocalEnv } from 'npm-run-path';
@@ -13,7 +13,7 @@ export default async function (
   options: RunScriptOptions,
   context: ExecutorContext
 ) {
-  const pm = getPackageManagerCommand();
+  const pm = await getPackageManagerCommandAsync();
   try {
     execSync(pm.run(options.script, options.__unparsed__.join(' ')), {
       stdio: ['inherit', 'inherit', 'inherit'],

--- a/packages/nx/src/utils/nx-plugin.ts
+++ b/packages/nx/src/utils/nx-plugin.ts
@@ -43,6 +43,7 @@ import {
 } from '../adapter/angular-json';
 import { getNxPackageJsonWorkspacesPlugin } from '../../plugins/package-json-workspaces';
 import { CreateProjectJsonProjectsPlugin } from '../plugins/project-json/build-nodes/project-json';
+import { PackageManagerCommands } from './package-manager';
 
 /**
  * Context for {@link CreateNodesFunction}
@@ -129,6 +130,12 @@ export type NxPluginV2 = {
    * Provides a function to analyze files to create dependencies for the {@link ProjectGraph}
    */
   createDependencies?: CreateDependencies;
+
+  /**
+   * This is used to provide a custom packageManager for nx.
+   * @returns PackageManager
+   */
+  providesPackageManagers?: () => Record<string, PackageManagerCommands>;
 };
 
 export * from './nx-plugin.deprecated';

--- a/packages/workspace/src/generators/new/new.ts
+++ b/packages/workspace/src/generators/new/new.ts
@@ -1,6 +1,6 @@
 import {
   addDependenciesToPackageJson,
-  getPackageManagerCommand,
+  getPackageManagerCommandAsync,
   installPackagesTask,
   joinPathFragments,
   names,
@@ -51,14 +51,19 @@ export async function newGenerator(host: Tree, opts: Schema) {
   addCloudDependencies(host, options);
 
   return async () => {
-    const pmc = getPackageManagerCommand(options.packageManager);
+    const pmc = await getPackageManagerCommandAsync(options.packageManager);
     if (pmc.preInstall) {
       execSync(pmc.preInstall, {
         cwd: joinPathFragments(host.root, options.directory),
         stdio: process.env.NX_GENERATE_QUIET === 'true' ? 'ignore' : 'inherit',
       });
     }
-    installPackagesTask(host, false, options.directory, options.packageManager);
+    await installPackagesTask(
+      host,
+      false,
+      options.directory,
+      options.packageManager
+    );
     // TODO: move all of these into create-nx-workspace
     if (
       options.preset !== Preset.NPM &&


### PR DESCRIPTION
## Current Behavior
Currently you are limited to only the packages provided by NX repo and it does not allow for extending without NX support.

Major change is installPackagesTask now returns a promise instead of a void.

## Expected Behavior
You can now create a plugin that manages package. Such as deno, bun and china package managers

## Related Issue(s)
Fixes #15622

