### PR TITLE
fix(core): merge implicit project dependencies only if found on new and matching projects

### DIFF
--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -51,7 +51,7 @@ export function mergeProjectConfigurationIntoRootMap(
     );
   }
 
-  if (project.implicitDependencies && matchingProject.tags) {
+  if (project.implicitDependencies && matchingProject.implicitDependencies) {
     updatedProjectConfiguration.implicitDependencies =
       matchingProject.implicitDependencies.concat(project.implicitDependencies);
   }


### PR DESCRIPTION
## Current Behavior
A typo when merging project nodes may cause an error when `implicitDependencies` is not specified on one of them, as a null check checks the wrong property.

## Expected Behavior
The merge only happens if both sides have the property

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
