### PR TITLE
chore(expo): update expo plugin unit tests to use "as-provided"

### DIFF
--- a/packages/expo/src/generators/application/application.spec.ts
+++ b/packages/expo/src/generators/application/application.spec.ts
@@ -12,7 +12,7 @@ describe('app', () => {
   let appTree: Tree;
 
   beforeEach(() => {
-    appTree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    appTree = createTreeWithEmptyWorkspace();
     appTree.write('.gitignore', '');
   });
 
@@ -25,10 +25,11 @@ describe('app', () => {
       skipFormat: false,
       js: false,
       unitTestRunner: 'none',
+      projectNameAndRootFormat: 'as-provided',
     });
     const projects = getProjects(appTree);
 
-    expect(projects.get('my-app').root).toEqual('apps/my-app');
+    expect(projects.get('my-app').root).toEqual('my-app');
   });
 
   it('should update nx.json', async () => {
@@ -41,6 +42,7 @@ describe('app', () => {
       skipFormat: false,
       js: false,
       unitTestRunner: 'none',
+      projectNameAndRootFormat: 'as-provided',
     });
 
     const projectConfiguration = readProjectConfiguration(appTree, 'my-app');
@@ -58,14 +60,15 @@ describe('app', () => {
       skipFormat: false,
       js: false,
       unitTestRunner: 'jest',
+      projectNameAndRootFormat: 'as-provided',
     });
-    expect(appTree.exists('apps/my-app/src/app/App.tsx')).toBeTruthy();
-    expect(appTree.exists('apps/my-app/src/app/App.spec.tsx')).toBeTruthy();
+    expect(appTree.exists('my-app/src/app/App.tsx')).toBeTruthy();
+    expect(appTree.exists('my-app/src/app/App.spec.tsx')).toBeTruthy();
 
-    const tsconfig = readJson(appTree, 'apps/my-app/tsconfig.json');
-    expect(tsconfig.extends).toEqual('../../tsconfig.base.json');
+    const tsconfig = readJson(appTree, 'my-app/tsconfig.json');
+    expect(tsconfig.extends).toEqual('../tsconfig.base.json');
 
-    expect(appTree.exists('apps/my-app/.eslintrc.json')).toBe(true);
+    expect(appTree.exists('my-app/.eslintrc.json')).toBe(true);
   });
 
   it('should generate js files', async () => {
@@ -77,14 +80,15 @@ describe('app', () => {
       skipFormat: false,
       js: true,
       unitTestRunner: 'jest',
+      projectNameAndRootFormat: 'as-provided',
     });
-    expect(appTree.exists('apps/my-app/src/app/App.js')).toBeTruthy();
-    expect(appTree.exists('apps/my-app/src/app/App.spec.js')).toBeTruthy();
+    expect(appTree.exists('my-app/src/app/App.js')).toBeTruthy();
+    expect(appTree.exists('my-app/src/app/App.spec.js')).toBeTruthy();
 
-    const tsconfig = readJson(appTree, 'apps/my-app/tsconfig.json');
-    expect(tsconfig.extends).toEqual('../../tsconfig.base.json');
+    const tsconfig = readJson(appTree, 'my-app/tsconfig.json');
+    expect(tsconfig.extends).toEqual('../tsconfig.base.json');
 
-    expect(appTree.exists('apps/my-app/.eslintrc.json')).toBe(true);
+    expect(appTree.exists('my-app/.eslintrc.json')).toBe(true);
   });
 
   describe('detox', () => {
@@ -97,18 +101,12 @@ describe('app', () => {
         js: false,
         skipFormat: false,
         unitTestRunner: 'none',
+        projectNameAndRootFormat: 'as-provided',
       });
 
-      const projects = getProjects(appTree);
-      expect(projects.get('my-dir-my-app').root).toEqual('apps/my-dir/my-app');
+      expect(appTree.exists('my-dir-e2e/.detoxrc.json')).toBeTruthy();
+      const detoxrc = appTree.read('my-dir-e2e/.detoxrc.json', 'utf-8');
 
-      expect(
-        appTree.exists('apps/my-dir/my-app-e2e/.detoxrc.json')
-      ).toBeTruthy();
-      const detoxrc = appTree.read(
-        'apps/my-dir/my-app-e2e/.detoxrc.json',
-        'utf-8'
-      );
       // Strip trailing commas
       const detoxrcJson = JSON.parse(
         detoxrc.replace(/(?<=(true|false|null|["\d}\]])\s*),(?=\s*[}\]])/g, '')
@@ -116,42 +114,42 @@ describe('app', () => {
       expect(detoxrcJson.apps).toEqual({
         'android.debug': {
           binaryPath:
-            '../../../apps/my-dir/my-app/android/app/build/outputs/apk/debug/app-debug.apk',
+            '../my-dir/android/app/build/outputs/apk/debug/app-debug.apk',
           build:
-            'cd ../../../apps/my-dir/my-app/android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
+            'cd ../my-dir/android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
           type: 'android.apk',
         },
         'android.local': {
-          binaryPath: '../../../apps/my-dir/my-app/dist/MyApp.apk',
+          binaryPath: '../my-dir/dist/MyApp.apk',
           build:
-            'npx nx run my-app:build --platform android --profile preview --wait --local --no-interactive --output=../../../apps/my-dir/my-app/dist/MyApp.apk',
+            'npx nx run my-app:build --platform android --profile preview --wait --local --no-interactive --output=../my-dir/dist/MyApp.apk',
           type: 'android.apk',
         },
         'android.release': {
           binaryPath:
-            '../../../apps/my-dir/my-app/android/app/build/outputs/apk/release/app-release.apk',
+            '../my-dir/android/app/build/outputs/apk/release/app-release.apk',
           build:
-            'cd ../../../apps/my-dir/my-app/android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release',
+            'cd ../my-dir/android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release',
           type: 'android.apk',
         },
         'ios.debug': {
           binaryPath:
-            '../../../apps/my-dir/my-app/ios/build/Build/Products/Debug-iphonesimulator/MyApp.app',
+            '../my-dir/ios/build/Build/Products/Debug-iphonesimulator/MyApp.app',
           build:
-            "cd ../../../apps/my-dir/my-app/ios && xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
+            "cd ../my-dir/ios && xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
           type: 'ios.app',
         },
         'ios.local': {
-          binaryPath: '../../../apps/my-dir/my-app/dist/MyApp.app',
+          binaryPath: '../my-dir/dist/MyApp.app',
           build:
-            'npx nx run my-app:build --platform ios --profile preview --wait --local --no-interactive --output=../../../apps/my-dir/my-app/dist/MyApp.tar.gz',
+            'npx nx run my-app:build --platform ios --profile preview --wait --local --no-interactive --output=../my-dir/dist/MyApp.tar.gz',
           type: 'ios.app',
         },
         'ios.release': {
           binaryPath:
-            '../../../apps/my-dir/my-app/ios/build/Build/Products/Release-iphonesimulator/MyApp.app',
+            '../my-dir/ios/build/Build/Products/Release-iphonesimulator/MyApp.app',
           build:
-            "cd ../../../apps/my-dir/my-app/ios && xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
+            "cd ../my-dir/ios && xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
           type: 'ios.app',
         },
       });
@@ -165,13 +163,11 @@ describe('app', () => {
         js: false,
         skipFormat: false,
         unitTestRunner: 'none',
+        projectNameAndRootFormat: 'as-provided',
       });
 
-      const projects = getProjects(appTree);
-      expect(projects.get('my-app').root).toEqual('apps/my-app');
-
-      expect(appTree.exists('apps/my-app-e2e/.detoxrc.json')).toBeTruthy();
-      const detoxrc = appTree.read('apps/my-app-e2e/.detoxrc.json', 'utf-8');
+      expect(appTree.exists('my-app-e2e/.detoxrc.json')).toBeTruthy();
+      const detoxrc = appTree.read('my-app-e2e/.detoxrc.json', 'utf-8');
       // Strip trailing commas
       const detoxrcJson = JSON.parse(
         detoxrc.replace(/(?<=(true|false|null|["\d}\]])\s*),(?=\s*[}\]])/g, '')
@@ -179,42 +175,42 @@ describe('app', () => {
       expect(detoxrcJson.apps).toEqual({
         'android.debug': {
           binaryPath:
-            '../../apps/my-app/android/app/build/outputs/apk/debug/app-debug.apk',
+            '../my-app/android/app/build/outputs/apk/debug/app-debug.apk',
           build:
-            'cd ../../apps/my-app/android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
+            'cd ../my-app/android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
           type: 'android.apk',
         },
         'android.local': {
-          binaryPath: '../../apps/my-app/dist/MyApp.apk',
+          binaryPath: '../my-app/dist/MyApp.apk',
           build:
-            'npx nx run my-app:build --platform android --profile preview --wait --local --no-interactive --output=../../apps/my-app/dist/MyApp.apk',
+            'npx nx run my-app:build --platform android --profile preview --wait --local --no-interactive --output=../my-app/dist/MyApp.apk',
           type: 'android.apk',
         },
         'android.release': {
           binaryPath:
-            '../../apps/my-app/android/app/build/outputs/apk/release/app-release.apk',
+            '../my-app/android/app/build/outputs/apk/release/app-release.apk',
           build:
-            'cd ../../apps/my-app/android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release',
+            'cd ../my-app/android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release',
           type: 'android.apk',
         },
         'ios.debug': {
           binaryPath:
-            '../../apps/my-app/ios/build/Build/Products/Debug-iphonesimulator/MyApp.app',
+            '../my-app/ios/build/Build/Products/Debug-iphonesimulator/MyApp.app',
           build:
-            "cd ../../apps/my-app/ios && xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
+            "cd ../my-app/ios && xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
           type: 'ios.app',
         },
         'ios.local': {
-          binaryPath: '../../apps/my-app/dist/MyApp.app',
+          binaryPath: '../my-app/dist/MyApp.app',
           build:
-            'npx nx run my-app:build --platform ios --profile preview --wait --local --no-interactive --output=../../apps/my-app/dist/MyApp.tar.gz',
+            'npx nx run my-app:build --platform ios --profile preview --wait --local --no-interactive --output=../my-app/dist/MyApp.tar.gz',
           type: 'ios.app',
         },
         'ios.release': {
           binaryPath:
-            '../../apps/my-app/ios/build/Build/Products/Release-iphonesimulator/MyApp.app',
+            '../my-app/ios/build/Build/Products/Release-iphonesimulator/MyApp.app',
           build:
-            "cd ../../apps/my-app/ios && xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
+            "cd ../my-app/ios && xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
           type: 'ios.app',
         },
       });
@@ -232,10 +228,10 @@ describe('app', () => {
       });
 
       const projects = getProjects(appTree);
-      expect(projects.get('my-app').root).toEqual('apps/my-app');
+      expect(projects.get('my-app').root).toEqual('my-app');
 
-      expect(appTree.exists('apps/my-app-e2e/.detoxrc.json')).toBeTruthy();
-      const detoxrc = appTree.read('apps/my-app-e2e/.detoxrc.json', 'utf-8');
+      expect(appTree.exists('my-app-e2e/.detoxrc.json')).toBeTruthy();
+      const detoxrc = appTree.read('my-app-e2e/.detoxrc.json', 'utf-8');
       // Strip trailing commas
       const detoxrcJson = JSON.parse(
         detoxrc.replace(/(?<=(true|false|null|["\d}\]])\s*),(?=\s*[}\]])/g, '')
@@ -243,42 +239,42 @@ describe('app', () => {
       expect(detoxrcJson.apps).toEqual({
         'android.debug': {
           binaryPath:
-            '../../apps/my-app/android/app/build/outputs/apk/debug/app-debug.apk',
+            '../my-app/android/app/build/outputs/apk/debug/app-debug.apk',
           build:
-            'cd ../../apps/my-app/android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
+            'cd ../my-app/android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
           type: 'android.apk',
         },
         'android.local': {
-          binaryPath: '../../apps/my-app/dist/myappname.apk',
+          binaryPath: '../my-app/dist/myappname.apk',
           build:
-            'npx nx run my-app:build --platform android --profile preview --wait --local --no-interactive --output=../../apps/my-app/dist/myappname.apk',
+            'npx nx run my-app:build --platform android --profile preview --wait --local --no-interactive --output=../my-app/dist/myappname.apk',
           type: 'android.apk',
         },
         'android.release': {
           binaryPath:
-            '../../apps/my-app/android/app/build/outputs/apk/release/app-release.apk',
+            '../my-app/android/app/build/outputs/apk/release/app-release.apk',
           build:
-            'cd ../../apps/my-app/android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release',
+            'cd ../my-app/android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release',
           type: 'android.apk',
         },
         'ios.debug': {
           binaryPath:
-            '../../apps/my-app/ios/build/Build/Products/Debug-iphonesimulator/MyApp.app',
+            '../my-app/ios/build/Build/Products/Debug-iphonesimulator/MyApp.app',
           build:
-            "cd ../../apps/my-app/ios && xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
+            "cd ../my-app/ios && xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
           type: 'ios.app',
         },
         'ios.local': {
-          binaryPath: '../../apps/my-app/dist/myappname.app',
+          binaryPath: '../my-app/dist/myappname.app',
           build:
-            'npx nx run my-app:build --platform ios --profile preview --wait --local --no-interactive --output=../../apps/my-app/dist/myappname.tar.gz',
+            'npx nx run my-app:build --platform ios --profile preview --wait --local --no-interactive --output=../my-app/dist/myappname.tar.gz',
           type: 'ios.app',
         },
         'ios.release': {
           binaryPath:
-            '../../apps/my-app/ios/build/Build/Products/Release-iphonesimulator/MyApp.app',
+            '../my-app/ios/build/Build/Products/Release-iphonesimulator/MyApp.app',
           build:
-            "cd ../../apps/my-app/ios && xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
+            "cd ../my-app/ios && xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
           type: 'ios.app',
         },
       });

--- a/packages/expo/src/generators/application/lib/nomalize-options.spec.ts
+++ b/packages/expo/src/generators/application/lib/nomalize-options.spec.ts
@@ -8,7 +8,7 @@ describe('Normalize Options', () => {
   let appTree: Tree;
 
   beforeEach(() => {
-    appTree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    appTree = createTreeWithEmptyWorkspace();
   });
 
   it('should normalize options with name in kebab case', async () => {
@@ -19,17 +19,18 @@ describe('Normalize Options', () => {
       skipFormat: false,
       js: true,
       unitTestRunner: 'jest',
+      projectNameAndRootFormat: 'as-provided',
     };
     const options = await normalizeOptions(appTree, schema);
     expect(options).toEqual({
-      appProjectRoot: 'apps/my-app',
+      appProjectRoot: 'my-app',
       className: 'MyApp',
       displayName: 'MyApp',
       lowerCaseName: 'myapp',
       name: 'my-app',
       parsedTags: [],
       projectName: 'my-app',
-      projectNameAndRootFormat: 'derived',
+      projectNameAndRootFormat: 'as-provided',
       linter: Linter.EsLint,
       e2eTestRunner: 'none',
       unitTestRunner: 'jest',
@@ -46,17 +47,18 @@ describe('Normalize Options', () => {
       skipFormat: false,
       js: true,
       unitTestRunner: 'jest',
+      projectNameAndRootFormat: 'as-provided',
     };
     const options = await normalizeOptions(appTree, schema);
     expect(options).toEqual({
-      appProjectRoot: 'apps/my-app',
+      appProjectRoot: 'my-app',
       className: 'MyApp',
       displayName: 'MyApp',
       lowerCaseName: 'myapp',
       name: 'my-app',
       parsedTags: [],
       projectName: 'my-app',
-      projectNameAndRootFormat: 'derived',
+      projectNameAndRootFormat: 'as-provided',
       linter: Linter.EsLint,
       e2eTestRunner: 'none',
       skipFormat: false,
@@ -74,18 +76,19 @@ describe('Normalize Options', () => {
       skipFormat: false,
       js: true,
       unitTestRunner: 'jest',
+      projectNameAndRootFormat: 'as-provided',
     };
     const options = await normalizeOptions(appTree, schema);
     expect(options).toEqual({
-      appProjectRoot: 'apps/directory/my-app',
+      appProjectRoot: 'directory',
       className: 'MyApp',
       displayName: 'MyApp',
       lowerCaseName: 'myapp',
       name: 'my-app',
       directory: 'directory',
       parsedTags: [],
-      projectName: 'directory-my-app',
-      projectNameAndRootFormat: 'derived',
+      projectName: 'my-app',
+      projectNameAndRootFormat: 'as-provided',
       e2eTestRunner: 'none',
       unitTestRunner: 'jest',
       linter: Linter.EsLint,
@@ -102,17 +105,18 @@ describe('Normalize Options', () => {
       skipFormat: false,
       js: true,
       unitTestRunner: 'jest',
+      projectNameAndRootFormat: 'as-provided',
     };
     const options = await normalizeOptions(appTree, schema);
     expect(options).toEqual({
-      appProjectRoot: 'apps/directory/my-app',
+      appProjectRoot: 'directory/my-app',
       className: 'DirectoryMyApp',
       displayName: 'DirectoryMyApp',
       lowerCaseName: 'directorymyapp',
       name: 'directory/my-app',
       parsedTags: [],
-      projectName: 'directory-my-app',
-      projectNameAndRootFormat: 'derived',
+      projectName: 'directory/my-app',
+      projectNameAndRootFormat: 'as-provided',
       e2eTestRunner: 'none',
       unitTestRunner: 'jest',
       linter: Linter.EsLint,
@@ -130,17 +134,18 @@ describe('Normalize Options', () => {
       skipFormat: false,
       js: true,
       unitTestRunner: 'jest',
+      projectNameAndRootFormat: 'as-provided',
     };
     const options = await normalizeOptions(appTree, schema);
     expect(options).toEqual({
-      appProjectRoot: 'apps/my-app',
+      appProjectRoot: 'my-app',
       className: 'MyApp',
       displayName: 'My App',
       lowerCaseName: 'myapp',
       name: 'my-app',
       parsedTags: [],
       projectName: 'my-app',
-      projectNameAndRootFormat: 'derived',
+      projectNameAndRootFormat: 'as-provided',
       e2eTestRunner: 'none',
       unitTestRunner: 'jest',
       linter: Linter.EsLint,

--- a/packages/expo/src/generators/component/component.spec.ts
+++ b/packages/expo/src/generators/component/component.spec.ts
@@ -14,7 +14,7 @@ describe('component', () => {
 
   beforeEach(async () => {
     projectName = 'my-lib';
-    appTree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    appTree = createTreeWithEmptyWorkspace();
     appTree.write('.gitignore', '');
     defaultSchema = {
       name: 'hello',
@@ -35,6 +35,7 @@ describe('component', () => {
       skipFormat: false,
       js: true,
       unitTestRunner: 'jest',
+      projectNameAndRootFormat: 'as-provided',
     });
     await expoLibraryGenerator(appTree, {
       name: projectName,
@@ -44,6 +45,7 @@ describe('component', () => {
       unitTestRunner: 'jest',
       strict: true,
       js: false,
+      projectNameAndRootFormat: 'as-provided',
     });
     jest.spyOn(logger, 'warn').mockImplementation(() => {});
     jest.spyOn(logger, 'debug').mockImplementation(() => {});
@@ -56,10 +58,8 @@ describe('component', () => {
   it('should generate files', async () => {
     await expoComponentGenerator(appTree, defaultSchema);
 
-    expect(appTree.exists('libs/my-lib/src/lib/hello/hello.tsx')).toBeTruthy();
-    expect(
-      appTree.exists('libs/my-lib/src/lib/hello/hello.spec.tsx')
-    ).toBeTruthy();
+    expect(appTree.exists('my-lib/src/lib/hello/hello.tsx')).toBeTruthy();
+    expect(appTree.exists('my-lib/src/lib/hello/hello.spec.tsx')).toBeTruthy();
   });
 
   it('should generate files for an app', async () => {
@@ -68,10 +68,8 @@ describe('component', () => {
       project: 'my-app',
     });
 
-    expect(appTree.exists('apps/my-app/src/app/hello/hello.tsx')).toBeTruthy();
-    expect(
-      appTree.exists('apps/my-app/src/app/hello/hello.spec.tsx')
-    ).toBeTruthy();
+    expect(appTree.exists('my-app/src/app/hello/hello.tsx')).toBeTruthy();
+    expect(appTree.exists('my-app/src/app/hello/hello.spec.tsx')).toBeTruthy();
   });
 
   describe('--export', () => {
@@ -81,7 +79,7 @@ describe('component', () => {
         export: true,
       });
 
-      const indexContent = appTree.read('libs/my-lib/src/index.ts', 'utf-8');
+      const indexContent = appTree.read('my-lib/src/index.ts', 'utf-8');
 
       expect(indexContent).toMatch(/lib\/hello/);
     });
@@ -93,7 +91,7 @@ describe('component', () => {
         export: true,
       });
 
-      const indexContent = appTree.read('libs/my-lib/src/index.ts', 'utf-8');
+      const indexContent = appTree.read('my-lib/src/index.ts', 'utf-8');
 
       expect(indexContent).not.toMatch(/lib\/hello/);
     });
@@ -105,11 +103,9 @@ describe('component', () => {
         ...defaultSchema,
         pascalCaseFiles: true,
       });
+      expect(appTree.exists('my-lib/src/lib/hello/Hello.tsx')).toBeTruthy();
       expect(
-        appTree.exists('libs/my-lib/src/lib/hello/Hello.tsx')
-      ).toBeTruthy();
-      expect(
-        appTree.exists('libs/my-lib/src/lib/hello/Hello.spec.tsx')
+        appTree.exists('my-lib/src/lib/hello/Hello.spec.tsx')
       ).toBeTruthy();
     });
   });
@@ -121,7 +117,7 @@ describe('component', () => {
         directory: 'components',
       });
 
-      expect(appTree.exists('/libs/my-lib/src/components/hello/hello.tsx'));
+      expect(appTree.exists('my-lib/src/components/hello/hello.tsx'));
     });
 
     it('should create with nested directories', async () => {
@@ -131,9 +127,7 @@ describe('component', () => {
         directory: 'lib/foo',
       });
 
-      expect(
-        appTree.exists('/libs/my-lib/src/lib/foo/hello-world/hello-world.tsx')
-      );
+      expect(appTree.exists('my-lib/src/lib/foo/hello-world/hello-world.tsx'));
     });
   });
 
@@ -144,7 +138,7 @@ describe('component', () => {
         flat: true,
       });
 
-      expect(appTree.exists('/libs/my-lib/src/lib/hello.tsx'));
+      expect(appTree.exists('my-lib/src/lib/hello.tsx'));
     });
     it('should work with custom directory path', async () => {
       await expoComponentGenerator(appTree, {
@@ -153,7 +147,7 @@ describe('component', () => {
         directory: 'components',
       });
 
-      expect(appTree.exists('/libs/my-lib/src/components/hello.tsx'));
+      expect(appTree.exists('my-lib/src/components/hello.tsx'));
     });
   });
 });

--- a/packages/expo/src/generators/init/init.spec.ts
+++ b/packages/expo/src/generators/init/init.spec.ts
@@ -6,7 +6,7 @@ describe('init', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
     tree.write('.gitignore', '');
   });
 

--- a/packages/expo/src/generators/library/library.spec.ts
+++ b/packages/expo/src/generators/library/library.spec.ts
@@ -22,10 +22,11 @@ describe('lib', () => {
     unitTestRunner: 'jest',
     strict: true,
     js: false,
+    projectNameAndRootFormat: 'as-provided',
   };
 
   beforeEach(() => {
-    appTree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    appTree = createTreeWithEmptyWorkspace();
     appTree.write('.gitignore', '');
   });
 
@@ -36,13 +37,13 @@ describe('lib', () => {
         tags: 'one,two',
       });
       const projectConfiguration = readProjectConfiguration(appTree, 'my-lib');
-      expect(projectConfiguration.root).toEqual('libs/my-lib');
+      expect(projectConfiguration.root).toEqual('my-lib');
       expect(projectConfiguration.targets.build).toBeUndefined();
       expect(projectConfiguration.targets.lint).toEqual({
         executor: '@nx/linter:eslint',
         outputs: ['{options.outputFile}'],
         options: {
-          lintFilePatterns: ['libs/my-lib/**/*.{ts,tsx,js,jsx}'],
+          lintFilePatterns: ['my-lib/**/*.{ts,tsx,js,jsx}'],
         },
       });
       expect(projectConfiguration.tags).toEqual(['one', 'two']);
@@ -52,7 +53,7 @@ describe('lib', () => {
       await expoLibraryGenerator(appTree, defaultSchema);
       const tsconfigJson = readJson(appTree, '/tsconfig.base.json');
       expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-        'libs/my-lib/src/index.ts',
+        'my-lib/src/index.ts',
       ]);
     });
 
@@ -65,13 +66,13 @@ describe('lib', () => {
       await expoLibraryGenerator(appTree, defaultSchema);
       const tsconfigJson = readJson(appTree, '/tsconfig.base.json');
       expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-        'libs/my-lib/src/index.ts',
+        'my-lib/src/index.ts',
       ]);
     });
 
     it('should create a local tsconfig.json', async () => {
       await expoLibraryGenerator(appTree, defaultSchema);
-      const tsconfigJson = readJson(appTree, 'libs/my-lib/tsconfig.json');
+      const tsconfigJson = readJson(appTree, 'my-lib/tsconfig.json');
       expect(tsconfigJson.references).toEqual([
         {
           path: './tsconfig.lib.json',
@@ -92,24 +93,26 @@ describe('lib', () => {
 
     it('should extend the local tsconfig.json with tsconfig.spec.json', async () => {
       await expoLibraryGenerator(appTree, defaultSchema);
-      const tsconfigJson = readJson(appTree, 'libs/my-lib/tsconfig.spec.json');
+      const tsconfigJson = readJson(appTree, 'my-lib/tsconfig.spec.json');
       expect(tsconfigJson.extends).toEqual('./tsconfig.json');
     });
 
     it('should extend the local tsconfig.json with tsconfig.lib.json', async () => {
       await expoLibraryGenerator(appTree, defaultSchema);
-      const tsconfigJson = readJson(appTree, 'libs/my-lib/tsconfig.lib.json');
+      const tsconfigJson = readJson(appTree, 'my-lib/tsconfig.lib.json');
       expect(tsconfigJson.extends).toEqual('./tsconfig.json');
     });
   });
 
   describe('nested', () => {
-    it('should update project.json', async () => {
+    it('should update project.json with two libs', async () => {
       await expoLibraryGenerator(appTree, {
         ...defaultSchema,
+        projectNameAndRootFormat: 'derived',
         directory: 'myDir',
         tags: 'one',
       });
+
       const projectConfiguration = readProjectConfiguration(
         appTree,
         'my-dir-my-lib'
@@ -123,6 +126,7 @@ describe('lib', () => {
         name: 'myLib2',
         directory: 'myDir',
         tags: 'one,two',
+        projectNameAndRootFormat: 'derived',
       });
 
       const lib2ProjectConfiguration = readProjectConfiguration(
@@ -138,6 +142,7 @@ describe('lib', () => {
       await expoLibraryGenerator(appTree, {
         ...defaultSchema,
         directory: 'myDir',
+        projectNameAndRootFormat: 'derived',
       });
       const projectConfiguration = readProjectConfiguration(
         appTree,
@@ -147,7 +152,7 @@ describe('lib', () => {
         executor: '@nx/linter:eslint',
         outputs: ['{options.outputFile}'],
         options: {
-          lintFilePatterns: ['libs/my-dir/my-lib/**/*.{ts,tsx,js,jsx}'],
+          lintFilePatterns: ['my-dir/my-lib/**/*.{ts,tsx,js,jsx}'],
         },
       });
     });
@@ -158,12 +163,10 @@ describe('lib', () => {
         directory: 'myDir',
       });
       const tsconfigJson = readJson(appTree, '/tsconfig.base.json');
-      expect(tsconfigJson.compilerOptions.paths['@proj/my-dir/my-lib']).toEqual(
-        ['libs/my-dir/my-lib/src/index.ts']
-      );
-      expect(
-        tsconfigJson.compilerOptions.paths['my-dir-my-lib/*']
-      ).toBeUndefined();
+      expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
+        'my-dir/src/index.ts',
+      ]);
+      expect(tsconfigJson.compilerOptions.paths['my-dir/*']).toBeUndefined();
     });
 
     it('should create a local tsconfig.json', async () => {
@@ -172,10 +175,7 @@ describe('lib', () => {
         directory: 'myDir',
       });
 
-      const tsconfigJson = readJson(
-        appTree,
-        'libs/my-dir/my-lib/tsconfig.json'
-      );
+      const tsconfigJson = readJson(appTree, 'my-dir/tsconfig.json');
       expect(tsconfigJson.references).toEqual([
         {
           path: './tsconfig.lib.json',
@@ -194,14 +194,14 @@ describe('lib', () => {
         unitTestRunner: 'none',
       });
 
-      expect(appTree.exists('libs/my-lib/tsconfig.spec.json')).toBeFalsy();
-      expect(appTree.exists('libs/my-lib/jest.config.ts')).toBeFalsy();
+      expect(appTree.exists('my-lib/tsconfig.spec.json')).toBeFalsy();
+      expect(appTree.exists('my-lib/jest.config.ts')).toBeFalsy();
       const projectConfiguration = readProjectConfiguration(appTree, 'my-lib');
       expect(projectConfiguration.targets.test).toBeUndefined();
       expect(projectConfiguration.targets.lint).toMatchObject({
         executor: '@nx/linter:eslint',
         options: {
-          lintFilePatterns: ['libs/my-lib/**/*.{ts,tsx,js,jsx}'],
+          lintFilePatterns: ['my-lib/**/*.{ts,tsx,js,jsx}'],
         },
         outputs: ['{options.outputFile}'],
       });
@@ -236,10 +236,10 @@ describe('lib', () => {
         outputs: ['{options.outputPath}'],
         options: {
           external: ['react/jsx-runtime', 'react-native', 'react', 'react-dom'],
-          entryFile: 'libs/my-lib/src/index.ts',
-          outputPath: 'dist/libs/my-lib',
-          project: 'libs/my-lib/package.json',
-          tsConfig: 'libs/my-lib/tsconfig.lib.json',
+          entryFile: 'my-lib/src/index.ts',
+          outputPath: 'dist/my-lib',
+          project: 'my-lib/package.json',
+          tsConfig: 'my-lib/tsconfig.lib.json',
           rollupConfig: '@nx/react/plugins/bundle-rollup',
         },
       });
@@ -268,9 +268,9 @@ describe('lib', () => {
         importPath: '@proj/my-lib',
       });
 
-      const packageJson = readJson(appTree, '/libs/my-lib/package.json');
+      const packageJson = readJson(appTree, 'my-lib/package.json');
       expect(packageJson.name).toEqual('@proj/my-lib');
-      expect(appTree.exists('/libs/my-lib/.babelrc'));
+      expect(appTree.exists('my-lib/.babelrc'));
     });
   });
 
@@ -281,7 +281,7 @@ describe('lib', () => {
         js: true,
       });
 
-      expect(appTree.exists('/libs/my-lib/src/index.js')).toBe(true);
+      expect(appTree.exists('my-lib/src/index.js')).toBe(true);
     });
   });
 
@@ -293,7 +293,7 @@ describe('lib', () => {
         directory: 'myDir',
         importPath: '@myorg/lib',
       });
-      const packageJson = readJson(appTree, 'libs/my-dir/my-lib/package.json');
+      const packageJson = readJson(appTree, 'my-dir/package.json');
       const tsconfigJson = readJson(appTree, '/tsconfig.base.json');
 
       expect(packageJson.name).toBe('@myorg/lib');
@@ -333,7 +333,7 @@ describe('lib', () => {
         ...defaultSchema,
         strict: false,
       });
-      const tsconfigJson = readJson(appTree, '/libs/my-lib/tsconfig.json');
+      const tsconfigJson = readJson(appTree, 'my-lib/tsconfig.json');
 
       expect(
         tsconfigJson.compilerOptions.forceConsistentCasingInFileNames

--- a/packages/expo/src/utils/add-linting.spec.ts
+++ b/packages/expo/src/utils/add-linting.spec.ts
@@ -8,10 +8,11 @@ describe('Add Linting', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
     await libraryGenerator(tree, {
       name: 'my-lib',
       linter: Linter.None,
+      projectNameAndRootFormat: 'as-provided',
     });
   });
 
@@ -19,8 +20,8 @@ describe('Add Linting', () => {
     addLinting(tree, {
       projectName: 'my-lib',
       linter: Linter.EsLint,
-      tsConfigPaths: ['libs/my-lib/tsconfig.lib.json'],
-      projectRoot: 'libs/my-lib',
+      tsConfigPaths: ['my-lib/tsconfig.lib.json'],
+      projectRoot: 'my-lib',
     });
     const project = readProjectConfiguration(tree, 'my-lib');
 
@@ -32,8 +33,8 @@ describe('Add Linting', () => {
     addLinting(tree, {
       projectName: 'my-lib',
       linter: Linter.None,
-      tsConfigPaths: ['libs/my-lib/tsconfig.lib.json'],
-      projectRoot: 'libs/my-lib',
+      tsConfigPaths: ['my-lib/tsconfig.lib.json'],
+      projectRoot: 'my-lib',
     });
     const project = readProjectConfiguration(tree, 'my-lib');
 


### PR DESCRIPTION
This PR updates the expo plugin's unit test to:
- Create a standalone workspace
- Use `as-provided` for creating libs/apps