### PR TITLE
chore(core): prepare Angular specific error only before throwing it

### DIFF
--- a/packages/nx/src/project-graph/project-graph.ts
+++ b/packages/nx/src/project-graph/project-graph.ts
@@ -24,14 +24,15 @@ import { readNxJson } from '../config/nx-json';
  */
 export function readCachedProjectGraph(): ProjectGraph {
   const projectGraphCache: ProjectGraph = readProjectGraphCache();
-  const angularSpecificError = fileExists(`${workspaceRoot}/angular.json`)
-    ? stripIndents`
+  if (!projectGraphCache) {
+    const angularSpecificError = fileExists(`${workspaceRoot}/angular.json`)
+      ? stripIndents`
       Make sure invoke 'node ./decorate-angular-cli.js' in your postinstall script.
       The decorated CLI will compute the project graph.
       'ng --help' should say 'Smart, Fast and Extensible Build System'.
       `
-    : '';
-  if (!projectGraphCache) {
+      : '';
+
     throw new Error(stripIndents`
       [readCachedProjectGraph] ERROR: No cached ProjectGraph is available.
 


### PR DESCRIPTION
This commit updates the implementation of the `readCachedProjectGraph` function and checks whether the `angular.json` file exists only when it's required, throwing the error afterward. This removes the redundant call to `statSync` if we encounter a cached graph.