### PR TITLE
fix(angular): use the correct output path for mf ssr #18849

### DIFF
--- a/packages/angular/src/generators/host/__snapshots__/host.spec.ts.snap
+++ b/packages/angular/src/generators/host/__snapshots__/host.spec.ts.snap
@@ -51,7 +51,7 @@ import { AppServerModule } from './bootstrap.server';
 // The Express app is exported so that it can be used by serverless Functions.
 export function app(): express.Express {
   const server = express();
-  const browserBundles = join(process.cwd(), 'dist/apps/test/browser');
+  const browserBundles = join(process.cwd(), 'dist/test/browser');
 
   server.use(cors());
   const indexHtml = existsSync(join(browserBundles, 'index.original.html'))
@@ -223,7 +223,7 @@ import bootstrap from './bootstrap.server';
 // The Express app is exported so that it can be used by serverless Functions.
 export function app(): express.Express {
   const server = express();
-  const browserBundles = join(process.cwd(), 'dist/apps/test/browser');
+  const browserBundles = join(process.cwd(), 'dist/test/browser');
 
   server.use(cors());
   const indexHtml = existsSync(join(browserBundles, 'index.original.html'))

--- a/packages/angular/src/generators/host/files/src/main.server.ts__tmpl__
+++ b/packages/angular/src/generators/host/files/src/main.server.ts__tmpl__
@@ -12,7 +12,7 @@ import<% if(standalone) { %> bootstrap <% } else { %> { AppServerModule } <% } %
 // The Express app is exported so that it can be used by serverless Functions.
 export function app(): express.Express {
   const server = express();
-  const browserBundles = join(process.cwd(), 'dist/apps/<%= appName %>/browser');
+  const browserBundles = join(process.cwd(), '<%= browserBundleOutput %>');
 
   server.use(cors());
   const indexHtml = existsSync(join(browserBundles, 'index.original.html'))

--- a/packages/angular/src/generators/host/lib/add-ssr.ts
+++ b/packages/angular/src/generators/host/lib/add-ssr.ts
@@ -35,8 +35,14 @@ export async function addSsr(tree: Tree, options: Schema, appName: string) {
     "import('./src/main.server');"
   );
 
+  const browserBundleOutput = joinPathFragments(
+    project.targets.build.options.outputPath,
+    'browser'
+  );
+
   generateFiles(tree, join(__dirname, '../files'), project.root, {
     appName,
+    browserBundleOutput,
     standalone: options.standalone,
     tmpl: '',
   });

--- a/packages/angular/src/generators/remote/__snapshots__/remote.spec.ts.snap
+++ b/packages/angular/src/generators/remote/__snapshots__/remote.spec.ts.snap
@@ -60,8 +60,8 @@ import { AppServerModule } from './bootstrap.server';
 // The Express app is exported so that it can be used by serverless Functions.
 export function app(): express.Express {
   const server = express();
-  const browserBundles = join(process.cwd(), 'dist/apps/test/browser');
-  const serverBundles = join(process.cwd(), 'dist/apps/test/server');
+  const browserBundles = join(process.cwd(), 'dist/test/browser');
+  const serverBundles = join(process.cwd(), 'dist/test/server');
 
   server.use(cors());
   const indexHtml = existsSync(join(browserBundles, 'index.original.html'))

--- a/packages/angular/src/generators/remote/files/base/src/main.server.ts__tmpl__
+++ b/packages/angular/src/generators/remote/files/base/src/main.server.ts__tmpl__
@@ -12,8 +12,8 @@ import<% if(standalone) { %> bootstrap <% } else { %> { AppServerModule } <% } %
 // The Express app is exported so that it can be used by serverless Functions.
 export function app(): express.Express {
   const server = express();
-  const browserBundles = join(process.cwd(), 'dist/apps/<%= appName %>/browser');
-  const serverBundles = join(process.cwd(), 'dist/apps/<%= appName %>/server');
+  const browserBundles = join(process.cwd(), '<%= browserBundleOutput %>');
+  const serverBundles = join(process.cwd(), '<%= serverBundleOutput %>');
 
   server.use(cors());
   const indexHtml = existsSync(join(browserBundles, 'index.original.html'))

--- a/packages/angular/src/generators/remote/lib/add-ssr.ts
+++ b/packages/angular/src/generators/remote/lib/add-ssr.ts
@@ -41,12 +41,23 @@ export async function addSsr(
     "import('./src/main.server');"
   );
 
+  const browserBundleOutput = joinPathFragments(
+    project.targets.build.options.outputPath,
+    'browser'
+  );
+  const serverBundleOutput = joinPathFragments(
+    project.targets.build.options.outputPath,
+    'server'
+  );
+
   generateFiles(
     tree,
     joinPathFragments(__dirname, '../files/base'),
     project.root,
     {
       appName,
+      browserBundleOutput,
+      serverBundleOutput,
       standalone,
       tmpl: '',
     }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We hardcode the path to the built bundles when we generate an SSR setup for MF

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Use the correct path from the project.json for the bundle paths

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18849
