### PR TITLE
fix(nx-dev): rspack link in getting-started section

### DIFF
--- a/docs/shared/getting-started/intro.md
+++ b/docs/shared/getting-started/intro.md
@@ -81,7 +81,7 @@ npx create-nx-workspace@latest
 {% link-card title="Vite" appearance="small" url="/packages/vite" icon="vite" /%}
 {% link-card title="Storybook" appearance="small" url="/packages/storybook" icon="storybook" /%}
 {% link-card title="Jest" appearance="small" url="/packages/jest" icon="jest" /%}
-{% link-card title="Rspack" appearance="small" url="packages/rspack" icon="rspack" /%}
+{% link-card title="Rspack" appearance="small" url="/packages/rspack" icon="rspack" /%}
 
 {% /cards %}
 


### PR DESCRIPTION
## Current Behavior

https://nx.dev/getting-started/intro#pick-your-stack

Click rspack -> you get 404 (you're transfered to https://nx.dev/getting-started/packages/rspack)

## Expected Behavior

https://nx-dev-git-fork-mandarini-fix-rspack-link-nrwl.vercel.app/getting-started/intro#pick-your-stack!

Click rspack -> you go to rspack page (you're transfered to https://nx.dev/packages/rspack)

