### PR TITLE
fix(core): keep existing name when converting project to a monorepo

### DIFF
--- a/packages/workspace/src/generators/convert-to-monorepo/convert-to-monorepo.spec.ts
+++ b/packages/workspace/src/generators/convert-to-monorepo/convert-to-monorepo.spec.ts
@@ -29,7 +29,7 @@ describe('monorepo generator', () => {
       libsDir: 'packages',
     });
 
-    expect(readJson(tree, 'packages/my-lib/project.json')).toMatchObject({
+    expect(readProjectConfiguration(tree, 'my-lib')).toMatchObject({
       sourceRoot: 'packages/my-lib/src',
       targets: {
         build: {
@@ -41,7 +41,8 @@ describe('monorepo generator', () => {
         },
       },
     });
-    expect(readJson(tree, 'packages/other-lib/project.json')).toMatchObject({
+    expect(readProjectConfiguration(tree, 'other-lib')).toMatchObject({
+      name: 'other-lib',
       sourceRoot: 'packages/other-lib/src',
     });
 
@@ -67,7 +68,7 @@ describe('monorepo generator', () => {
 
     await monorepoGenerator(tree, {});
 
-    expect(readJson(tree, 'apps/demo/project.json')).toMatchObject({
+    expect(readProjectConfiguration(tree, 'demo')).toMatchObject({
       sourceRoot: 'apps/demo/src',
     });
 
@@ -117,7 +118,7 @@ describe('monorepo generator', () => {
 
     await monorepoGenerator(tree, {});
 
-    expect(readJson(tree, 'apps/demo/project.json')).toMatchObject({
+    expect(readProjectConfiguration(tree, 'demo')).toMatchObject({
       sourceRoot: 'apps/demo/src',
       targets: {
         build: {
@@ -157,11 +158,11 @@ describe('monorepo generator', () => {
 
     await monorepoGenerator(tree, {});
 
-    expect(readJson(tree, 'apps/demo/project.json')).toMatchObject({
+    expect(readProjectConfiguration(tree, 'demo')).toMatchObject({
       sourceRoot: 'apps/demo',
     });
     expect(tree.read('apps/demo/app/page.tsx', 'utf-8')).toContain('demo');
-    expect(readJson(tree, 'libs/util/project.json')).toMatchObject({
+    expect(readProjectConfiguration(tree, 'util')).toMatchObject({
       sourceRoot: 'libs/util/src',
     });
     expect(tree.read('libs/util/src/lib/util.ts', 'utf-8')).toContain('util');

--- a/packages/workspace/src/generators/convert-to-monorepo/convert-to-monorepo.ts
+++ b/packages/workspace/src/generators/convert-to-monorepo/convert-to-monorepo.ts
@@ -34,13 +34,13 @@ export async function monorepoGenerator(tree: Tree, options: {}) {
   for (const project of projectsToMove) {
     await moveGenerator(tree, {
       projectName: project.name,
-      newProjectName:
-        project.projectType === 'application' || project.root === '.'
-          ? project.name
-          : project.root,
+      newProjectName: project.name,
       destination:
         project.projectType === 'application'
-          ? joinPathFragments(appsDir, project.name)
+          ? joinPathFragments(
+              appsDir,
+              project.root === '.' ? project.name : project.root
+            )
           : joinPathFragments(
               libsDir,
               project.root === '.' ? project.name : project.root


### PR DESCRIPTION
This PR updates the `convert-to-monorepo` generator to keep existing names intact.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
