### PR TITLE
chore(detox): update detox plugin unit tests to use "as-provided"

### DIFF
--- a/packages/detox/src/generators/application/application.spec.ts
+++ b/packages/detox/src/generators/application/application.spec.ts
@@ -13,7 +13,7 @@ describe('detox application generator', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
     tree.write('.gitignore', '');
   });
 
@@ -28,14 +28,15 @@ describe('detox application generator', () => {
         appProject: 'my-app',
         linter: Linter.None,
         framework: 'react-native',
+        projectNameAndRootFormat: 'as-provided',
       });
     });
 
     it('should generate files', () => {
-      expect(tree.exists('apps/my-app-e2e/.detoxrc.json')).toBeTruthy();
-      expect(tree.exists('apps/my-app-e2e/src/app.spec.ts')).toBeTruthy();
+      expect(tree.exists('my-app-e2e/.detoxrc.json')).toBeTruthy();
+      expect(tree.exists('my-app-e2e/src/app.spec.ts')).toBeTruthy();
 
-      const detoxrc = tree.read('apps/my-app-e2e/.detoxrc.json').toString();
+      const detoxrc = tree.read('my-app-e2e/.detoxrc.json').toString();
       // Strip trailing commas
       const detoxrcJson = JSON.parse(
         detoxrc.replace(/(?<=(true|false|null|["\d}\]])\s*),(?=\s*[}\]])/g, '')
@@ -44,30 +45,30 @@ describe('detox application generator', () => {
       expect(appsDetoxrcJson).toEqual({
         'android.debug': {
           binaryPath:
-            '../../my-app/android/app/build/outputs/apk/debug/app-debug.apk',
+            '../my-app/android/app/build/outputs/apk/debug/app-debug.apk',
           build:
-            'cd ../../my-app/android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
+            'cd ../my-app/android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
           type: 'android.apk',
         },
         'android.release': {
           binaryPath:
-            '../../my-app/android/app/build/outputs/apk/release/app-release.apk',
+            '../my-app/android/app/build/outputs/apk/release/app-release.apk',
           build:
-            'cd ../../my-app/android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release',
+            'cd ../my-app/android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release',
           type: 'android.apk',
         },
         'ios.debug': {
           binaryPath:
-            '../../my-app/ios/build/Build/Products/Debug-iphonesimulator/MyApp.app',
+            '../my-app/ios/build/Build/Products/Debug-iphonesimulator/MyApp.app',
           build:
-            "cd ../../my-app/ios && xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
+            "cd ../my-app/ios && xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
           type: 'ios.app',
         },
         'ios.release': {
           binaryPath:
-            '../../my-app/ios/build/Build/Products/Release-iphonesimulator/MyApp.app',
+            '../my-app/ios/build/Build/Products/Release-iphonesimulator/MyApp.app',
           build:
-            "cd ../../my-app/ios && xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
+            "cd ../my-app/ios && xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
           type: 'ios.app',
         },
       });
@@ -76,7 +77,7 @@ describe('detox application generator', () => {
     it('should update configuration', async () => {
       const project = readProjectConfiguration(tree, 'my-app-e2e');
 
-      expect(project.root).toEqual('apps/my-app-e2e');
+      expect(project.root).toEqual('my-app-e2e');
     });
 
     it('should update nx.json', async () => {
@@ -98,18 +99,15 @@ describe('detox application generator', () => {
         appProject: 'my-dir-my-app',
         linter: Linter.None,
         framework: 'react-native',
+        projectNameAndRootFormat: 'as-provided',
       });
     });
 
     it('should generate files', () => {
-      expect(tree.exists('apps/my-dir/my-app-e2e/.detoxrc.json')).toBeTruthy();
-      expect(
-        tree.exists('apps/my-dir/my-app-e2e/src/app.spec.ts')
-      ).toBeTruthy();
+      expect(tree.exists('my-dir/.detoxrc.json')).toBeTruthy();
+      expect(tree.exists('my-dir/src/app.spec.ts')).toBeTruthy();
 
-      const detoxrc = tree
-        .read('apps/my-dir/my-app-e2e/.detoxrc.json')
-        .toString();
+      const detoxrc = tree.read('my-dir/.detoxrc.json').toString();
       // Strip trailing commas
       const detoxrcJson = JSON.parse(
         detoxrc.replace(/(?<=(true|false|null|["\d}\]])\s*),(?=\s*[}\]])/g, '')
@@ -118,43 +116,43 @@ describe('detox application generator', () => {
       expect(appsDetoxrcJson).toEqual({
         'android.debug': {
           binaryPath:
-            '../../../my-dir/my-app/android/app/build/outputs/apk/debug/app-debug.apk',
+            '../my-dir/my-app/android/app/build/outputs/apk/debug/app-debug.apk',
           build:
-            'cd ../../../my-dir/my-app/android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
+            'cd ../my-dir/my-app/android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
           type: 'android.apk',
         },
         'android.release': {
           binaryPath:
-            '../../../my-dir/my-app/android/app/build/outputs/apk/release/app-release.apk',
+            '../my-dir/my-app/android/app/build/outputs/apk/release/app-release.apk',
           build:
-            'cd ../../../my-dir/my-app/android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release',
+            'cd ../my-dir/my-app/android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release',
           type: 'android.apk',
         },
         'ios.debug': {
           binaryPath:
-            '../../../my-dir/my-app/ios/build/Build/Products/Debug-iphonesimulator/MyDirMyApp.app',
+            '../my-dir/my-app/ios/build/Build/Products/Debug-iphonesimulator/MyDirMyApp.app',
           build:
-            "cd ../../../my-dir/my-app/ios && xcodebuild -workspace MyDirMyApp.xcworkspace -scheme MyDirMyApp -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
+            "cd ../my-dir/my-app/ios && xcodebuild -workspace MyDirMyApp.xcworkspace -scheme MyDirMyApp -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
           type: 'ios.app',
         },
         'ios.release': {
           binaryPath:
-            '../../../my-dir/my-app/ios/build/Build/Products/Release-iphonesimulator/MyDirMyApp.app',
+            '../my-dir/my-app/ios/build/Build/Products/Release-iphonesimulator/MyDirMyApp.app',
           build:
-            "cd ../../../my-dir/my-app/ios && xcodebuild -workspace MyDirMyApp.xcworkspace -scheme MyDirMyApp -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
+            "cd ../my-dir/my-app/ios && xcodebuild -workspace MyDirMyApp.xcworkspace -scheme MyDirMyApp -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
           type: 'ios.app',
         },
       });
     });
 
     it('should update configuration', async () => {
-      const project = readProjectConfiguration(tree, 'my-dir-my-app-e2e');
+      const project = readProjectConfiguration(tree, 'my-app-e2e');
 
-      expect(project.root).toEqual('apps/my-dir/my-app-e2e');
+      expect(project.root).toEqual('my-dir');
     });
 
     it('should update nx.json', async () => {
-      const project = readProjectConfiguration(tree, 'my-dir-my-app-e2e');
+      const project = readProjectConfiguration(tree, 'my-app-e2e');
       expect(project.tags).toEqual([]);
       expect(project.implicitDependencies).toEqual(['my-dir-my-app']);
     });
@@ -172,18 +170,15 @@ describe('detox application generator', () => {
         appProject: 'my-dir-my-app',
         linter: Linter.None,
         framework: 'react-native',
+        projectNameAndRootFormat: 'as-provided',
       });
     });
 
     it('should generate files', () => {
-      expect(tree.exists('apps/e2e-dir/my-app-e2e/.detoxrc.json')).toBeTruthy();
-      expect(
-        tree.exists('apps/e2e-dir/my-app-e2e/src/app.spec.ts')
-      ).toBeTruthy();
+      expect(tree.exists('e2e-dir/.detoxrc.json')).toBeTruthy();
+      expect(tree.exists('e2e-dir/src/app.spec.ts')).toBeTruthy();
 
-      const detoxrc = tree
-        .read('apps/e2e-dir/my-app-e2e/.detoxrc.json')
-        .toString();
+      const detoxrc = tree.read('e2e-dir/.detoxrc.json').toString();
       // Strip trailing commas
       const detoxrcJson = JSON.parse(
         detoxrc.replace(/(?<=(true|false|null|["\d}\]])\s*),(?=\s*[}\]])/g, '')
@@ -192,43 +187,43 @@ describe('detox application generator', () => {
       expect(appsDetoxrcJson).toEqual({
         'android.debug': {
           binaryPath:
-            '../../../my-dir/my-app/android/app/build/outputs/apk/debug/app-debug.apk',
+            '../my-dir/my-app/android/app/build/outputs/apk/debug/app-debug.apk',
           build:
-            'cd ../../../my-dir/my-app/android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
+            'cd ../my-dir/my-app/android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
           type: 'android.apk',
         },
         'android.release': {
           binaryPath:
-            '../../../my-dir/my-app/android/app/build/outputs/apk/release/app-release.apk',
+            '../my-dir/my-app/android/app/build/outputs/apk/release/app-release.apk',
           build:
-            'cd ../../../my-dir/my-app/android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release',
+            'cd ../my-dir/my-app/android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release',
           type: 'android.apk',
         },
         'ios.debug': {
           binaryPath:
-            '../../../my-dir/my-app/ios/build/Build/Products/Debug-iphonesimulator/MyDirMyApp.app',
+            '../my-dir/my-app/ios/build/Build/Products/Debug-iphonesimulator/MyDirMyApp.app',
           build:
-            "cd ../../../my-dir/my-app/ios && xcodebuild -workspace MyDirMyApp.xcworkspace -scheme MyDirMyApp -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
+            "cd ../my-dir/my-app/ios && xcodebuild -workspace MyDirMyApp.xcworkspace -scheme MyDirMyApp -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
           type: 'ios.app',
         },
         'ios.release': {
           binaryPath:
-            '../../../my-dir/my-app/ios/build/Build/Products/Release-iphonesimulator/MyDirMyApp.app',
+            '../my-dir/my-app/ios/build/Build/Products/Release-iphonesimulator/MyDirMyApp.app',
           build:
-            "cd ../../../my-dir/my-app/ios && xcodebuild -workspace MyDirMyApp.xcworkspace -scheme MyDirMyApp -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
+            "cd ../my-dir/my-app/ios && xcodebuild -workspace MyDirMyApp.xcworkspace -scheme MyDirMyApp -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
           type: 'ios.app',
         },
       });
     });
 
     it('should update configuration', async () => {
-      const project = readProjectConfiguration(tree, 'e2e-dir-my-app-e2e');
+      const project = readProjectConfiguration(tree, 'my-app-e2e');
 
-      expect(project.root).toEqual('apps/e2e-dir/my-app-e2e');
+      expect(project.root).toEqual('e2e-dir');
     });
 
     it('should update nx.json', async () => {
-      const project = readProjectConfiguration(tree, 'e2e-dir-my-app-e2e');
+      const project = readProjectConfiguration(tree, 'my-app-e2e');
       expect(project.tags).toEqual([]);
       expect(project.implicitDependencies).toEqual(['my-dir-my-app']);
     });
@@ -245,18 +240,15 @@ describe('detox application generator', () => {
         appProject: 'my-dir-my-app',
         linter: Linter.None,
         framework: 'react-native',
+        projectNameAndRootFormat: 'as-provided',
       });
     });
 
     it('should generate files', () => {
-      expect(tree.exists('apps/my-dir/my-app-e2e/.detoxrc.json')).toBeTruthy();
-      expect(
-        tree.exists('apps/my-dir/my-app-e2e/src/app.spec.ts')
-      ).toBeTruthy();
+      expect(tree.exists('my-dir/my-app-e2e/.detoxrc.json')).toBeTruthy();
+      expect(tree.exists('my-dir/my-app-e2e/src/app.spec.ts')).toBeTruthy();
 
-      const detoxrc = tree
-        .read('apps/my-dir/my-app-e2e/.detoxrc.json')
-        .toString();
+      const detoxrc = tree.read('my-dir/my-app-e2e/.detoxrc.json').toString();
       // Strip trailing commas
       const detoxrcJson = JSON.parse(
         detoxrc.replace(/(?<=(true|false|null|["\d}\]])\s*),(?=\s*[}\]])/g, '')
@@ -265,42 +257,42 @@ describe('detox application generator', () => {
       expect(appsDetoxrcJson).toEqual({
         'android.debug': {
           binaryPath:
-            '../../../my-dir/my-app/android/app/build/outputs/apk/debug/app-debug.apk',
+            '../../my-dir/my-app/android/app/build/outputs/apk/debug/app-debug.apk',
           build:
-            'cd ../../../my-dir/my-app/android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
+            'cd ../../my-dir/my-app/android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
           type: 'android.apk',
         },
         'android.release': {
           binaryPath:
-            '../../../my-dir/my-app/android/app/build/outputs/apk/release/app-release.apk',
+            '../../my-dir/my-app/android/app/build/outputs/apk/release/app-release.apk',
           build:
-            'cd ../../../my-dir/my-app/android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release',
+            'cd ../../my-dir/my-app/android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release',
           type: 'android.apk',
         },
         'ios.debug': {
           binaryPath:
-            '../../../my-dir/my-app/ios/build/Build/Products/Debug-iphonesimulator/MyDirMyApp.app',
+            '../../my-dir/my-app/ios/build/Build/Products/Debug-iphonesimulator/MyDirMyApp.app',
           build:
-            "cd ../../../my-dir/my-app/ios && xcodebuild -workspace MyDirMyApp.xcworkspace -scheme MyDirMyApp -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
+            "cd ../../my-dir/my-app/ios && xcodebuild -workspace MyDirMyApp.xcworkspace -scheme MyDirMyApp -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
           type: 'ios.app',
         },
         'ios.release': {
           binaryPath:
-            '../../../my-dir/my-app/ios/build/Build/Products/Release-iphonesimulator/MyDirMyApp.app',
+            '../../my-dir/my-app/ios/build/Build/Products/Release-iphonesimulator/MyDirMyApp.app',
           build:
-            "cd ../../../my-dir/my-app/ios && xcodebuild -workspace MyDirMyApp.xcworkspace -scheme MyDirMyApp -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
+            "cd ../../my-dir/my-app/ios && xcodebuild -workspace MyDirMyApp.xcworkspace -scheme MyDirMyApp -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
           type: 'ios.app',
         },
       });
     });
 
     it('should update configuration', async () => {
-      const project = readProjectConfiguration(tree, 'my-dir-my-app-e2e');
-      expect(project.root).toEqual('apps/my-dir/my-app-e2e');
+      const project = readProjectConfiguration(tree, 'my-dir/my-app-e2e');
+      expect(project.root).toEqual('my-dir/my-app-e2e');
     });
 
     it('should update nx.json', async () => {
-      const project = readProjectConfiguration(tree, 'my-dir-my-app-e2e');
+      const project = readProjectConfiguration(tree, 'my-dir/my-app-e2e');
       expect(project.tags).toEqual([]);
       expect(project.implicitDependencies).toEqual(['my-dir-my-app']);
     });
@@ -317,18 +309,15 @@ describe('detox application generator', () => {
         appProject: 'my-dir-my-app',
         linter: Linter.None,
         framework: 'expo',
+        projectNameAndRootFormat: 'as-provided',
       });
     });
 
     it('should generate files', () => {
-      expect(tree.exists('apps/my-dir/my-app-e2e/.detoxrc.json')).toBeTruthy();
-      expect(
-        tree.exists('apps/my-dir/my-app-e2e/src/app.spec.ts')
-      ).toBeTruthy();
+      expect(tree.exists('my-dir/my-app-e2e/.detoxrc.json')).toBeTruthy();
+      expect(tree.exists('my-dir/my-app-e2e/src/app.spec.ts')).toBeTruthy();
 
-      const detoxrc = tree
-        .read('apps/my-dir/my-app-e2e/.detoxrc.json')
-        .toString();
+      const detoxrc = tree.read('my-dir/my-app-e2e/.detoxrc.json').toString();
       // Strip trailing commas
       const detoxrcJson = JSON.parse(
         detoxrc.replace(/(?<=(true|false|null|["\d}\]])\s*),(?=\s*[}\]])/g, '')
@@ -337,55 +326,55 @@ describe('detox application generator', () => {
       expect(appsDetoxrcJson).toEqual({
         'android.debug': {
           binaryPath:
-            '../../../my-dir/my-app/android/app/build/outputs/apk/debug/app-debug.apk',
+            '../../my-dir/my-app/android/app/build/outputs/apk/debug/app-debug.apk',
           build:
-            'cd ../../../my-dir/my-app/android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
+            'cd ../../my-dir/my-app/android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
           type: 'android.apk',
         },
         'android.local': {
-          binaryPath: '../../../my-dir/my-app/dist/MyDirMyApp.apk',
+          binaryPath: '../../my-dir/my-app/dist/MyDirMyApp.apk',
           build:
-            'npx nx run my-dir-my-app:build --platform android --profile preview --wait --local --no-interactive --output=../../../my-dir/my-app/dist/MyDirMyApp.apk',
+            'npx nx run my-dir-my-app:build --platform android --profile preview --wait --local --no-interactive --output=../../my-dir/my-app/dist/MyDirMyApp.apk',
           type: 'android.apk',
         },
         'android.release': {
           binaryPath:
-            '../../../my-dir/my-app/android/app/build/outputs/apk/release/app-release.apk',
+            '../../my-dir/my-app/android/app/build/outputs/apk/release/app-release.apk',
           build:
-            'cd ../../../my-dir/my-app/android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release',
+            'cd ../../my-dir/my-app/android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release',
           type: 'android.apk',
         },
         'ios.debug': {
           binaryPath:
-            '../../../my-dir/my-app/ios/build/Build/Products/Debug-iphonesimulator/MyDirMyApp.app',
+            '../../my-dir/my-app/ios/build/Build/Products/Debug-iphonesimulator/MyDirMyApp.app',
           build:
-            "cd ../../../my-dir/my-app/ios && xcodebuild -workspace MyDirMyApp.xcworkspace -scheme MyDirMyApp -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
+            "cd ../../my-dir/my-app/ios && xcodebuild -workspace MyDirMyApp.xcworkspace -scheme MyDirMyApp -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
           type: 'ios.app',
         },
         'ios.local': {
-          binaryPath: '../../../my-dir/my-app/dist/MyDirMyApp.app',
+          binaryPath: '../../my-dir/my-app/dist/MyDirMyApp.app',
           build:
-            'npx nx run my-dir-my-app:build --platform ios --profile preview --wait --local --no-interactive --output=../../../my-dir/my-app/dist/MyDirMyApp.tar.gz',
+            'npx nx run my-dir-my-app:build --platform ios --profile preview --wait --local --no-interactive --output=../../my-dir/my-app/dist/MyDirMyApp.tar.gz',
           type: 'ios.app',
         },
         'ios.release': {
           binaryPath:
-            '../../../my-dir/my-app/ios/build/Build/Products/Release-iphonesimulator/MyDirMyApp.app',
+            '../../my-dir/my-app/ios/build/Build/Products/Release-iphonesimulator/MyDirMyApp.app',
           build:
-            "cd ../../../my-dir/my-app/ios && xcodebuild -workspace MyDirMyApp.xcworkspace -scheme MyDirMyApp -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
+            "cd ../../my-dir/my-app/ios && xcodebuild -workspace MyDirMyApp.xcworkspace -scheme MyDirMyApp -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
           type: 'ios.app',
         },
       });
     });
 
     it('should update configuration', async () => {
-      const project = readProjectConfiguration(tree, 'my-dir-my-app-e2e');
+      const project = readProjectConfiguration(tree, 'my-dir/my-app-e2e');
 
-      expect(project.root).toEqual('apps/my-dir/my-app-e2e');
+      expect(project.root).toEqual('my-dir/my-app-e2e');
     });
 
     it('should update nx.json', async () => {
-      const project = readProjectConfiguration(tree, 'my-dir-my-app-e2e');
+      const project = readProjectConfiguration(tree, 'my-dir/my-app-e2e');
       expect(project.tags).toEqual([]);
       expect(project.implicitDependencies).toEqual(['my-dir-my-app']);
     });
@@ -404,8 +393,8 @@ describe('detox application generator', () => {
         framework: 'react-native',
       });
 
-      const tsConfig = readJson(tree, 'apps/my-app-e2e/tsconfig.json');
-      expect(tsConfig.extends).toEqual('../../tsconfig.base.json');
+      const tsConfig = readJson(tree, 'my-app-e2e/tsconfig.json');
+      expect(tsConfig.extends).toEqual('../tsconfig.base.json');
     });
 
     it('should support a root tsconfig.json instead of tsconfig.base.json', async () => {
@@ -418,8 +407,8 @@ describe('detox application generator', () => {
         framework: 'react-native',
       });
 
-      const tsConfig = readJson(tree, 'apps/my-app-e2e/tsconfig.json');
-      expect(tsConfig.extends).toEqual('../../tsconfig.json');
+      const tsConfig = readJson(tree, 'my-app-e2e/tsconfig.json');
+      expect(tsConfig.extends).toEqual('../tsconfig.json');
     });
   });
 });

--- a/packages/detox/src/generators/init/init.spec.ts
+++ b/packages/detox/src/generators/init/init.spec.ts
@@ -6,7 +6,7 @@ describe('init', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should add detox dependencies', async () => {


### PR DESCRIPTION
This PR updates the detox plugin's unit test to:
- Be standalone by default
- use `"as-provided"` when creating `libs/apps`