### PR TITLE
fix(bundling): add faux-ESM files so "import" in Node works with both named and default exports

### DIFF
--- a/e2e/rollup/src/rollup.test.ts
+++ b/e2e/rollup/src/rollup.test.ts
@@ -29,7 +29,8 @@ describe('Rollup Plugin', () => {
     checkFilesExist(`dist/libs/${myPkg}/index.cjs.d.ts`);
     expect(readJson(`dist/libs/${myPkg}/package.json`).exports).toEqual({
       '.': {
-        import: './index.esm.js',
+        module: './index.esm.js',
+        import: './index.cjs.mjs',
         default: './index.cjs.js',
       },
       './package.json': './package.json',
@@ -95,15 +96,18 @@ describe('Rollup Plugin', () => {
     expect(readJson(`dist/libs/${myPkg}/package.json`).exports).toEqual({
       './package.json': './package.json',
       '.': {
-        import: './index.esm.js',
+        module: './index.esm.js',
+        import: './index.cjs.mjs',
         default: './index.cjs.js',
       },
       './bar': {
-        import: './bar.esm.js',
+        module: './bar.esm.js',
+        import: './bar.cjs.mjs',
         default: './bar.cjs.js',
       },
       './foo': {
-        import: './foo.esm.js',
+        module: './foo.esm.js',
+        import: './foo.cjs.mjs',
         default: './foo.cjs.js',
       },
     });

--- a/packages/rollup/src/executors/rollup/lib/update-package-json.spec.ts
+++ b/packages/rollup/src/executors/rollup/lib/update-package-json.spec.ts
@@ -98,7 +98,8 @@ describe('updatePackageJson', () => {
         exports: {
           './package.json': './package.json',
           '.': {
-            import: './index.esm.js',
+            module: './index.esm.js',
+            import: './index.cjs.mjs',
             default: './index.cjs.js',
           },
         },


### PR DESCRIPTION
This PR address an issue with packaging dual formats with Rollup, where using `import` in Node is causes issues.

- Since `type: module` is not specified (intentional), ESM files _must_ have `.mjs` file extension
- Default exports in Node are broken due to bundlers writing to `exports.default` but Node uses `exports` object as the default export when using CJS in ESM

The updated e2e test has an example in Rollup to ensure dual format works correctly when using ESM in Node.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18912
