### PR TITLE
feat(core): ensure @nx/js plugin is installed for all JS workspaces

### DIFF
--- a/e2e/nx-misc/src/workspace.test.ts
+++ b/e2e/nx-misc/src/workspace.test.ts
@@ -759,7 +759,7 @@ describe('Workspace Tests', () => {
 
       expect(error).toBeDefined();
       expect(error.stdout.toString()).toContain(
-        `${lib1} is still depended on by the following projects`
+        `${lib1} is still a dependency of the following projects`
       );
       expect(error.stdout.toString()).toContain(lib2);
 

--- a/e2e/utils/create-project-utils.ts
+++ b/e2e/utils/create-project-utils.ts
@@ -47,7 +47,7 @@ export function newProject({
 
     if (!directoryExists(tmpBackupProjPath())) {
       runCreateWorkspace(projScope, {
-        preset: 'empty',
+        preset: 'apps',
         packageManager,
       });
 

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -171,7 +171,14 @@ export const commandsObject: yargs.Argv<Arguments> = yargs
         throw error;
       });
     },
-    [normalizeArgsMiddleware as yargs.MiddlewareFunction<{}>]
+    [
+      normalizeArgsMiddleware,
+      normalizeAndWarnOnDeprecatedPreset({
+        // TODO(v18): Remove Empty and Core presets
+        [Preset.Core]: Preset.NPM,
+        [Preset.Empty]: Preset.Apps,
+      }),
+    ] as yargs.MiddlewareFunction<{}>[]
   )
   .help('help', chalk.dim`Show help`)
   .updateLocale(yargsDecorator)
@@ -215,6 +222,28 @@ async function main(parsedArgs: yargs.Arguments<Arguments>) {
       title: `Successfully applied preset: ${parsedArgs.preset}`,
     });
   }
+}
+
+function normalizeAndWarnOnDeprecatedPreset(
+  deprecatedPresets: Partial<Record<Preset, Preset>>
+): (argv: yargs.Arguments<Arguments>) => Promise<void> {
+  return async (args: yargs.Arguments<Arguments>): Promise<void> => {
+    if (!args.preset) return;
+    if (deprecatedPresets[args.preset]) {
+      args.preset = deprecatedPresets[args.preset] as Preset;
+      output.addVerticalSeparator();
+      output.note({
+        title: `The "${args.preset}" preset is deprecated.`,
+        bodyLines: [
+          `The "${
+            args.preset
+          }" preset will be removed in a future Nx release. Use the "${
+            deprecatedPresets[args.preset]
+          }" preset instead.`,
+        ],
+      });
+    }
+  };
 }
 
 /**
@@ -336,8 +365,6 @@ async function determineStack(
       case Preset.NodeStandalone:
       case Preset.Express:
         return 'node';
-      case Preset.Core:
-      case Preset.Empty:
       case Preset.Apps:
       case Preset.NPM:
       case Preset.TS:
@@ -782,6 +809,7 @@ async function determinePackageBasedOrIntegratedOrStandalone(): Promise<
 
   return workspaceType;
 }
+
 async function determineStandaloneOrMonorepo(): Promise<
   'integrated' | 'standalone'
 > {

--- a/packages/create-nx-workspace/src/utils/preset/point-to-tutorial-and-course.ts
+++ b/packages/create-nx-workspace/src/utils/preset/point-to-tutorial-and-course.ts
@@ -4,10 +4,8 @@ import { Preset } from './preset';
 export function pointToTutorialAndCourse(preset: Preset) {
   const title = `First time using Nx? Check out this interactive Nx tutorial.`;
   switch (preset) {
-    case Preset.Empty:
     case Preset.NPM:
     case Preset.Apps:
-    case Preset.Core:
       output.addVerticalSeparator();
       output.note({
         title,

--- a/packages/workspace/src/generators/new/__snapshots__/new.spec.ts.snap
+++ b/packages/workspace/src/generators/new/__snapshots__/new.spec.ts.snap
@@ -4,6 +4,7 @@ exports[`new --preset should generate necessary npm dependencies for empty prese
 {
   "dependencies": {},
   "devDependencies": {
+    "@nx/js": "0.0.1",
     "@nx/workspace": "0.0.1",
     "nx": "0.0.1",
   },

--- a/packages/workspace/src/generators/new/generate-preset.ts
+++ b/packages/workspace/src/generators/new/generate-preset.ts
@@ -16,14 +16,6 @@ import * as yargsParser from 'yargs-parser';
 import { spawn, SpawnOptions } from 'child_process';
 
 export function addPresetDependencies(host: Tree, options: NormalizedSchema) {
-  if (
-    options.preset === Preset.Apps ||
-    options.preset === Preset.Core ||
-    options.preset === Preset.Empty ||
-    options.preset === Preset.NPM
-  ) {
-    return;
-  }
   const { dependencies, dev } = getPresetDependencies(options);
   return addDependenciesToPackageJson(
     host,
@@ -98,6 +90,8 @@ function getPresetDependencies({
   e2eTestRunner,
 }: NormalizedSchema) {
   switch (preset) {
+    case Preset.Apps:
+    case Preset.NPM:
     case Preset.TS:
     case Preset.TsStandalone:
       return { dependencies: {}, dev: { '@nx/js': nxVersion } };

--- a/packages/workspace/src/generators/new/generate-workspace-files.spec.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.spec.ts
@@ -19,7 +19,7 @@ describe('@nx/workspace:generateWorkspaceFiles', () => {
     await generateWorkspaceFiles(tree, {
       name: 'proj',
       directory: 'proj',
-      preset: Preset.Empty,
+      preset: Preset.Apps,
       defaultBase: 'main',
       isCustomPreset: false,
     });
@@ -80,7 +80,7 @@ describe('@nx/workspace:generateWorkspaceFiles', () => {
     await generateWorkspaceFiles(tree, {
       name: 'proj',
       directory: 'proj',
-      preset: Preset.Empty,
+      preset: Preset.Apps,
       defaultBase: 'main',
       isCustomPreset: false,
     });
@@ -88,10 +88,24 @@ describe('@nx/workspace:generateWorkspaceFiles', () => {
     expect(nxJson).toMatchInlineSnapshot(`
       {
         "$schema": "./node_modules/nx/schemas/nx-schema.json",
+        "namedInputs": {
+          "default": [
+            "{projectRoot}/**/*",
+            "sharedGlobals",
+          ],
+          "production": [
+            "default",
+          ],
+          "sharedGlobals": [],
+        },
         "targetDefaults": {
           "build": {
             "dependsOn": [
               "^build",
+            ],
+            "inputs": [
+              "production",
+              "^production",
             ],
           },
         },
@@ -168,7 +182,7 @@ describe('@nx/workspace:generateWorkspaceFiles', () => {
     await generateWorkspaceFiles(tree, {
       name: 'proj',
       directory: 'proj',
-      preset: Preset.Empty,
+      preset: Preset.Apps,
       defaultBase: 'main',
       isCustomPreset: false,
     });
@@ -184,7 +198,7 @@ describe('@nx/workspace:generateWorkspaceFiles', () => {
     await generateWorkspaceFiles(tree, {
       name: 'proj',
       directory: 'proj',
-      preset: Preset.Empty,
+      preset: Preset.Apps,
       defaultBase: 'main',
       isCustomPreset: false,
     });

--- a/packages/workspace/src/generators/new/generate-workspace-files.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.ts
@@ -53,7 +53,7 @@ export async function generateWorkspaceFiles(
 
 function setPresetProperty(tree: Tree, options: NormalizedSchema) {
   updateJson(tree, join(options.directory, 'nx.json'), (json) => {
-    if (options.preset === Preset.Core || options.preset === Preset.NPM) {
+    if (options.preset === Preset.NPM) {
       addPropertyWithStableKeys(json, 'extends', 'nx/presets/npm.json');
       delete json.implicitDependencies;
       delete json.targetDefaults;
@@ -64,11 +64,7 @@ function setPresetProperty(tree: Tree, options: NormalizedSchema) {
 }
 
 function createAppsAndLibsFolders(tree: Tree, options: NormalizedSchema) {
-  if (
-    options.preset === Preset.Core ||
-    options.preset === Preset.TS ||
-    options.preset === Preset.NPM
-  ) {
+  if (options.preset === Preset.TS || options.preset === Preset.NPM) {
     tree.write(join(options.directory, 'packages/.gitkeep'), '');
   } else if (
     options.preset === Preset.AngularStandalone ||
@@ -113,11 +109,7 @@ function createNxJson(
   if (defaultBase === 'main') {
     delete nxJson.affected;
   }
-  if (
-    preset !== Preset.Core &&
-    preset !== Preset.NPM &&
-    preset !== Preset.Empty
-  ) {
+  if (preset !== Preset.NPM) {
     nxJson.namedInputs = {
       default: ['{projectRoot}/**/*', 'sharedGlobals'],
       production: ['default'],
@@ -138,7 +130,7 @@ function createFiles(tree: Tree, options: NormalizedSchema) {
     options.preset === Preset.NextJsStandalone ||
     options.preset === Preset.TsStandalone
       ? './files-root-app'
-      : options.preset === Preset.NPM || options.preset === Preset.Core
+      : options.preset === Preset.NPM
       ? './files-package-based-repo'
       : './files-integrated-repo';
   generateFiles(tree, join(__dirname, filesDirName), options.directory, {
@@ -233,7 +225,7 @@ function normalizeOptions(options: NormalizedSchema) {
 }
 
 function setUpWorkspacesInPackageJson(tree: Tree, options: NormalizedSchema) {
-  if (options.preset === Preset.NPM || options.preset === Preset.Core) {
+  if (options.preset === Preset.NPM) {
     if (options.packageManager === 'pnpm') {
       tree.write(
         join(options.directory, 'pnpm-workspace.yaml'),

--- a/packages/workspace/src/generators/new/new.spec.ts
+++ b/packages/workspace/src/generators/new/new.spec.ts
@@ -53,7 +53,7 @@ describe('new', () => {
         name: 'my-workspace',
         directory: 'my-workspace',
         appName: 'app',
-        preset: Preset.Empty,
+        preset: Preset.Apps,
       });
 
       expect(readJson(tree, 'my-workspace/package.json')).toMatchSnapshot();

--- a/packages/workspace/src/generators/new/new.ts
+++ b/packages/workspace/src/generators/new/new.ts
@@ -60,11 +60,7 @@ export async function newGenerator(host: Tree, opts: Schema) {
     }
     installPackagesTask(host, false, options.directory, options.packageManager);
     // TODO: move all of these into create-nx-workspace
-    if (
-      options.preset !== Preset.NPM &&
-      options.preset !== Preset.Core &&
-      !options.isCustomPreset
-    ) {
+    if (options.preset !== Preset.NPM && !options.isCustomPreset) {
       await generatePreset(host, options);
     }
   };
@@ -76,9 +72,7 @@ function validateOptions(options: Schema, host: Tree) {
   if (
     options.skipInstall &&
     options.preset !== Preset.Apps &&
-    options.preset !== Preset.Core &&
     options.preset !== Preset.TS &&
-    options.preset !== Preset.Empty &&
     options.preset !== Preset.NPM
   ) {
     throw new Error(`Cannot select a preset when skipInstall is set to true.`);

--- a/packages/workspace/src/generators/preset/preset.ts
+++ b/packages/workspace/src/generators/preset/preset.ts
@@ -20,7 +20,7 @@ export async function presetGenerator(tree: Tree, options: Schema) {
 export default presetGenerator;
 
 async function createPreset(tree: Tree, options: Schema) {
-  if (options.preset === Preset.Empty || options.preset === Preset.Apps) {
+  if (options.preset === Preset.Apps) {
     return;
   } else if (options.preset === Preset.AngularMonorepo) {
     const {

--- a/packages/workspace/src/generators/utils/presets.ts
+++ b/packages/workspace/src/generators/utils/presets.ts
@@ -1,7 +1,12 @@
 export enum Preset {
   Apps = 'apps',
-  Empty = 'empty', // same as apps, deprecated
-  Core = 'core', // same as npm, deprecated
+  // TODO(v18): Remove Empty and Core presets
+  /** @deprecated Use Apps instead
+   */
+  Empty = 'empty',
+  /** @deprecated Use NPM instead
+   */
+  Core = 'core',
   NPM = 'npm',
   TS = 'ts',
   WebComponents = 'web-components',


### PR DESCRIPTION
When running `create-nx-workspace` and choosing either packaged-based or TS integrated monorepo, the user does not get `@nx/js` plugin, which is wrong. In the future, code analysis for TS/JS files will be moved to `@nx/js` from `nx` core, so this plugin has to exist. Furthermore, not installing `@nx/js` automatically means users cannot generate JS libs even though that was the whole point of choosing the TS/JS stack.

This PR also deprecates the `Core` and `Empty` presets. They have both been deprecated for over a year, and we just missed removing them. They are now scheduled for removal in Nx 18.

<img width="1149" alt="Screenshot 2023-08-30 at 3 02 26 PM" src="https://github.com/nrwl/nx/assets/53559/290d0694-2156-4402-9b40-8cfb7ca4b0c5">

Lastly, the `@nx/workspace:remove` changes [here](https://github.com/nrwl/nx/commit/70d3728457f6ecf1c764ffef14e4a317e4d941bb) is causing e2e test failure. Not sure how it passed originally, but this is fixed in this PR as well.
