### PR TITLE
fix(misc): deprecated unnecessary plugin generator options and use as…

### DIFF
--- a/docs/generated/packages/plugin/generators/e2e-project.json
+++ b/docs/generated/packages/plugin/generators/e2e-project.json
@@ -32,7 +32,7 @@
       "pluginOutputPath": {
         "type": "string",
         "description": "the output path of the plugin after it builds.",
-        "x-priority": "important"
+        "x-deprecated": "This option is no longer used and will be removed in Nx 18."
       },
       "jestConfig": { "type": "string", "description": "Jest config file." },
       "linter": {

--- a/e2e/nx-misc/src/misc.test.ts
+++ b/e2e/nx-misc/src/misc.test.ts
@@ -26,7 +26,11 @@ import { major } from 'semver';
 import { join } from 'path';
 
 describe('Nx Commands', () => {
-  beforeAll(() => newProject());
+  beforeAll(() => {
+    newProject({
+      unsetProjectNameAndRootFormat: false,
+    });
+  });
 
   afterAll(() => cleanupProject());
 
@@ -40,7 +44,7 @@ describe('Nx Commands', () => {
 
       runCLI(`generate @nx/web:app ${app1} --tags e2etag`);
       runCLI(`generate @nx/web:app ${app2}`);
-      setMaxWorkers(join('apps', app1, 'project.json'));
+      setMaxWorkers(join(app1, 'project.json'));
 
       const s = runCLI('show projects').split('\n');
 
@@ -150,40 +154,40 @@ describe('Nx Commands', () => {
 
     beforeAll(async () => {
       runCLI(`generate @nx/web:app ${myapp}`);
-      setMaxWorkers(join('apps', myapp, 'project.json'));
+      setMaxWorkers(join(myapp, 'project.json'));
       runCLI(`generate @nx/js:lib ${mylib}`);
     });
 
     beforeEach(() => {
       updateFile(
-        `apps/${myapp}/src/main.ts`,
+        `${myapp}/src/main.ts`,
         `
        const x = 1111;
   `
       );
 
       updateFile(
-        `apps/${myapp}/src/app/app.element.spec.ts`,
+        `${myapp}/src/app/app.element.spec.ts`,
         `
        const y = 1111;
   `
       );
 
       updateFile(
-        `apps/${myapp}/src/app/app.element.ts`,
+        `${myapp}/src/app/app.element.ts`,
         `
        const z = 1111;
   `
       );
 
       updateFile(
-        `libs/${mylib}/index.ts`,
+        `${mylib}/index.ts`,
         `
        const x = 1111;
   `
       );
       updateFile(
-        `libs/${mylib}/src/${mylib}.spec.ts`,
+        `${mylib}/src/${mylib}.spec.ts`,
         `
        const y = 1111;
   `
@@ -200,12 +204,12 @@ describe('Nx Commands', () => {
     it('should check libs and apps specific files', async () => {
       if (isNotWindows()) {
         const stdout = runCLI(
-          `format:check --files="libs/${mylib}/index.ts,package.json" --libs-and-apps`,
+          `format:check --files="${mylib}/index.ts,package.json" --libs-and-apps`,
           { silenceError: true }
         );
-        expect(stdout).toContain(path.normalize(`libs/${mylib}/index.ts`));
+        expect(stdout).toContain(path.normalize(`${mylib}/index.ts`));
         expect(stdout).toContain(
-          path.normalize(`libs/${mylib}/src/${mylib}.spec.ts`)
+          path.normalize(`${mylib}/src/${mylib}.spec.ts`)
         );
         expect(stdout).not.toContain(path.normalize(`README.md`)); // It will be contained only in case of exception, that we fallback to all
       }
@@ -216,16 +220,16 @@ describe('Nx Commands', () => {
         const stdout = runCLI(`format:check --projects=${myapp}`, {
           silenceError: true,
         });
-        expect(stdout).toContain(path.normalize(`apps/${myapp}/src/main.ts`));
+        expect(stdout).toContain(path.normalize(`${myapp}/src/main.ts`));
         expect(stdout).toContain(
-          path.normalize(`apps/${myapp}/src/app/app.element.ts`)
+          path.normalize(`${myapp}/src/app/app.element.ts`)
         );
         expect(stdout).toContain(
-          path.normalize(`apps/${myapp}/src/app/app.element.spec.ts`)
+          path.normalize(`${myapp}/src/app/app.element.spec.ts`)
         );
-        expect(stdout).not.toContain(path.normalize(`libs/${mylib}/index.ts`));
+        expect(stdout).not.toContain(path.normalize(`${mylib}/index.ts`));
         expect(stdout).not.toContain(
-          path.normalize(`libs/${mylib}/src/${mylib}.spec.ts`)
+          path.normalize(`${mylib}/src/${mylib}.spec.ts`)
         );
         expect(stdout).not.toContain(path.normalize(`README.md`));
       }
@@ -236,16 +240,16 @@ describe('Nx Commands', () => {
         const stdout = runCLI(`format:check --projects=${myapp},${mylib}`, {
           silenceError: true,
         });
-        expect(stdout).toContain(path.normalize(`apps/${myapp}/src/main.ts`));
+        expect(stdout).toContain(path.normalize(`${myapp}/src/main.ts`));
         expect(stdout).toContain(
-          path.normalize(`apps/${myapp}/src/app/app.element.spec.ts`)
+          path.normalize(`${myapp}/src/app/app.element.spec.ts`)
         );
         expect(stdout).toContain(
-          path.normalize(`apps/${myapp}/src/app/app.element.ts`)
+          path.normalize(`${myapp}/src/app/app.element.ts`)
         );
-        expect(stdout).toContain(path.normalize(`libs/${mylib}/index.ts`));
+        expect(stdout).toContain(path.normalize(`${mylib}/index.ts`));
         expect(stdout).toContain(
-          path.normalize(`libs/${mylib}/src/${mylib}.spec.ts`)
+          path.normalize(`${mylib}/src/${mylib}.spec.ts`)
         );
         expect(stdout).not.toContain(path.normalize(`README.md`));
       }
@@ -254,16 +258,16 @@ describe('Nx Commands', () => {
     it('should check all', async () => {
       if (isNotWindows()) {
         const stdout = runCLI(`format:check --all`, { silenceError: true });
-        expect(stdout).toContain(path.normalize(`apps/${myapp}/src/main.ts`));
+        expect(stdout).toContain(path.normalize(`${myapp}/src/main.ts`));
         expect(stdout).toContain(
-          path.normalize(`apps/${myapp}/src/app/app.element.spec.ts`)
+          path.normalize(`${myapp}/src/app/app.element.spec.ts`)
         );
         expect(stdout).toContain(
-          path.normalize(`apps/${myapp}/src/app/app.element.ts`)
+          path.normalize(`${myapp}/src/app/app.element.ts`)
         );
-        expect(stdout).toContain(path.normalize(`libs/${mylib}/index.ts`));
+        expect(stdout).toContain(path.normalize(`${mylib}/index.ts`));
         expect(stdout).toContain(
-          path.normalize(`libs/${mylib}/src/${mylib}.spec.ts`)
+          path.normalize(`${mylib}/src/${mylib}.spec.ts`)
         );
         expect(stdout).toContain(path.normalize(`README.md`));
       }
@@ -286,20 +290,20 @@ describe('Nx Commands', () => {
     it('should reformat the code', async () => {
       if (isNotWindows()) {
         runCLI(
-          `format:write --files="apps/${myapp}/src/app/app.element.spec.ts,apps/${myapp}/src/app/app.element.ts"`
+          `format:write --files="${myapp}/src/app/app.element.spec.ts,${myapp}/src/app/app.element.ts"`
         );
         const stdout = runCLI('format:check --all', { silenceError: true });
-        expect(stdout).toContain(path.normalize(`apps/${myapp}/src/main.ts`));
+        expect(stdout).toContain(path.normalize(`${myapp}/src/main.ts`));
         expect(stdout).not.toContain(
-          path.normalize(`apps/${myapp}/src/app/app.element.spec.ts`)
+          path.normalize(`${myapp}/src/app/app.element.spec.ts`)
         );
         expect(stdout).not.toContain(
-          path.normalize(`apps/${myapp}/src/app/app.element.ts`)
+          path.normalize(`${myapp}/src/app/app.element.ts`)
         );
 
         runCLI('format:write --all');
         expect(runCLI('format:check --all')).not.toContain(
-          path.normalize(`apps/${myapp}/src/main.ts`)
+          path.normalize(`${myapp}/src/main.ts`)
         );
       }
     }, 300000);

--- a/e2e/nx-misc/src/nxw.test.ts
+++ b/e2e/nx-misc/src/nxw.test.ts
@@ -97,7 +97,11 @@ describe('nx wrapper / .nx installation', () => {
       j.installation.plugins['@nx/workspace'] = getPublishedVersion();
       return j;
     });
-    expect(() => runNxWrapper(`g npm-package ${uniq('pkg')}`)).not.toThrow();
+    expect(() =>
+      runNxWrapper(
+        `g npm-package ${uniq('pkg')} --projectNameAndRootFormat as-provided`
+      )
+    ).not.toThrow();
     expect(() => checkFilesExist());
   });
 

--- a/e2e/nx-misc/src/watch.test.ts
+++ b/e2e/nx-misc/src/watch.test.ts
@@ -25,10 +25,12 @@ describe('Nx Commands', () => {
   let proj2 = uniq('proj2');
   let proj3 = uniq('proj3');
   beforeAll(() => {
-    newProject();
-    runCLI(`generate @nx/js:lib ${proj1}`);
-    runCLI(`generate @nx/js:lib ${proj2}`);
-    runCLI(`generate @nx/js:lib ${proj3}`);
+    newProject({
+      unsetProjectNameAndRootFormat: false,
+    });
+    runCLI(`generate @nx/js:lib ${proj1} --directory libs/${proj1}`);
+    runCLI(`generate @nx/js:lib ${proj2} --directory libs/${proj2}`);
+    runCLI(`generate @nx/js:lib ${proj3} --directory libs/${proj3}`);
   });
 
   afterEach(() => {

--- a/e2e/nx-misc/src/workspace.test.ts
+++ b/e2e/nx-misc/src/workspace.test.ts
@@ -19,7 +19,9 @@ let proj: string;
 
 describe('@nx/workspace:convert-to-monorepo', () => {
   beforeEach(() => {
-    proj = newProject();
+    proj = newProject({
+      unsetProjectNameAndRootFormat: false,
+    });
   });
 
   afterEach(() => cleanupProject());
@@ -45,7 +47,9 @@ describe('@nx/workspace:convert-to-monorepo', () => {
 
 describe('Workspace Tests', () => {
   beforeAll(() => {
-    proj = newProject();
+    proj = newProject({
+      unsetProjectNameAndRootFormat: false,
+    });
   });
 
   afterAll(() => cleanupProject());
@@ -54,11 +58,13 @@ describe('Workspace Tests', () => {
     it('should create a minimal npm package', () => {
       const npmPackage = uniq('npm-package');
 
-      runCLI(`generate @nx/workspace:npm-package ${npmPackage}`);
+      runCLI(
+        `generate @nx/workspace:npm-package ${npmPackage} --directory packages/${npmPackage}`
+      );
 
       updateFile('package.json', (content) => {
         const json = JSON.parse(content);
-        json.workspaces = ['libs/*'];
+        json.workspaces = ['packages/*'];
         return JSON.stringify(json);
       });
 
@@ -82,7 +88,7 @@ describe('Workspace Tests', () => {
       const lib2 = uniq('mylib');
       const lib3 = uniq('mylib');
       runCLI(
-        `generate @nx/js:lib ${lib1}-data-access --directory=${lib1}/data-access --unitTestRunner=jest --project-name-and-root-format=as-provided`
+        `generate @nx/js:lib ${lib1}-data-access --directory=${lib1}/data-access --unitTestRunner=jest`
       );
 
       updateFile(
@@ -100,7 +106,7 @@ describe('Workspace Tests', () => {
        */
 
       runCLI(
-        `generate @nx/js:lib ${lib2}-ui --directory=${lib2}/ui --unitTestRunner=jest --project-name-and-root-format=as-provided`
+        `generate @nx/js:lib ${lib2}-ui --directory=${lib2}/ui --unitTestRunner=jest`
       );
 
       updateFile(
@@ -114,9 +120,7 @@ describe('Workspace Tests', () => {
        * Create a library which has an implicit dependency on lib1
        */
 
-      runCLI(
-        `generate @nx/js:lib ${lib3} --unitTestRunner=jest --project-name-and-root-format=as-provided`
-      );
+      runCLI(`generate @nx/js:lib ${lib3} --unitTestRunner=jest`);
       updateFile(join(lib3, 'project.json'), (content) => {
         const data = JSON.parse(content);
         data.implicitDependencies = [`${lib1}-data-access`];
@@ -128,7 +132,7 @@ describe('Workspace Tests', () => {
        */
 
       const moveOutput = runCLI(
-        `generate @nx/workspace:move --project ${lib1}-data-access shared/${lib1}/data-access --newProjectName=shared-${lib1}-data-access --project-name-and-root-format=as-provided`
+        `generate @nx/workspace:move --project ${lib1}-data-access shared/${lib1}/data-access --newProjectName=shared-${lib1}-data-access`
       );
 
       expect(moveOutput).toContain(`DELETE ${lib1}/data-access`);
@@ -225,7 +229,7 @@ describe('Workspace Tests', () => {
       const lib2 = uniq('mylib');
       const lib3 = uniq('mylib');
       runCLI(
-        `generate @nx/js:lib ${lib1}-data-access --directory=${lib1}/data-access --importPath=${importPath} --unitTestRunner=jest --project-name-and-root-format=as-provided`
+        `generate @nx/js:lib ${lib1}-data-access --directory=${lib1}/data-access --importPath=${importPath} --unitTestRunner=jest`
       );
 
       updateFile(
@@ -243,7 +247,7 @@ describe('Workspace Tests', () => {
        */
 
       runCLI(
-        `generate @nx/js:lib ${lib2}-ui --directory=${lib2}/ui --unitTestRunner=jest --project-name-and-root-format=as-provided`
+        `generate @nx/js:lib ${lib2}-ui --directory=${lib2}/ui --unitTestRunner=jest`
       );
 
       updateFile(
@@ -257,9 +261,7 @@ describe('Workspace Tests', () => {
        * Create a library which has an implicit dependency on lib1
        */
 
-      runCLI(
-        `generate @nx/js:lib ${lib3} --unitTestRunner=jest --project-name-and-root-format=as-provided`
-      );
+      runCLI(`generate @nx/js:lib ${lib3} --unitTestRunner=jest`);
       updateFile(join(lib3, 'project.json'), (content) => {
         const data = JSON.parse(content);
         data.implicitDependencies = [`${lib1}-data-access`];
@@ -271,7 +273,7 @@ describe('Workspace Tests', () => {
        */
 
       const moveOutput = runCLI(
-        `generate @nx/workspace:move --project ${lib1}-data-access shared/${lib1}/data-access --newProjectName=shared-${lib1}-data-access --project-name-and-root-format=as-provided`
+        `generate @nx/workspace:move --project ${lib1}-data-access shared/${lib1}/data-access --newProjectName=shared-${lib1}-data-access`
       );
 
       expect(moveOutput).toContain(`DELETE ${lib1}/data-access`);
@@ -361,7 +363,10 @@ describe('Workspace Tests', () => {
       const lib3 = uniq('mylib');
 
       let nxJson = readJson('nx.json');
-      nxJson.workspaceLayout = { libsDir: 'packages' };
+      nxJson.workspaceLayout = {
+        ...nxJson.workspaceLayout,
+        libsDir: 'packages',
+      };
       updateFile('nx.json', JSON.stringify(nxJson));
 
       runCLI(
@@ -492,7 +497,10 @@ describe('Workspace Tests', () => {
       );
 
       nxJson = readJson('nx.json');
-      delete nxJson.workspaceLayout;
+      nxJson.workspaceLayout = {
+        ...nxJson.workspaceLayout,
+        libsDir: undefined,
+      };
       updateFile('nx.json', JSON.stringify(nxJson));
     });
 
@@ -500,9 +508,7 @@ describe('Workspace Tests', () => {
       const lib1 = uniq('lib1');
       const lib2 = uniq('lib2');
       const lib3 = uniq('lib3');
-      runCLI(
-        `generate @nx/js:lib ${lib1} --unitTestRunner=jest --project-name-and-root-format=as-provided`
-      );
+      runCLI(`generate @nx/js:lib ${lib1} --unitTestRunner=jest`);
 
       updateFile(
         `${lib1}/src/lib/${lib1}.ts`,
@@ -516,7 +522,7 @@ describe('Workspace Tests', () => {
        */
 
       runCLI(
-        `generate @nx/js:lib ${lib2}-ui --directory=${lib2}/ui --unitTestRunner=jest --project-name-and-root-format=as-provided`
+        `generate @nx/js:lib ${lib2}-ui --directory=${lib2}/ui --unitTestRunner=jest`
       );
 
       updateFile(
@@ -530,9 +536,7 @@ describe('Workspace Tests', () => {
        * Create a library which has an implicit dependency on lib1
        */
 
-      runCLI(
-        `generate @nx/js:lib ${lib3} --unitTestRunner=jest --project-name-and-root-format=as-provided`
-      );
+      runCLI(`generate @nx/js:lib ${lib3} --unitTestRunner=jest`);
       updateFile(join(lib3, 'project.json'), (content) => {
         const data = JSON.parse(content);
         data.implicitDependencies = [lib1];
@@ -544,7 +548,7 @@ describe('Workspace Tests', () => {
        */
 
       const moveOutput = runCLI(
-        `generate @nx/workspace:move --project ${lib1} ${lib1}/data-access --newProjectName=${lib1}-data-access --project-name-and-root-format=as-provided`
+        `generate @nx/workspace:move --project ${lib1} ${lib1}/data-access --newProjectName=${lib1}-data-access`
       );
 
       expect(moveOutput).toContain(`DELETE ${lib1}/project.json`);
@@ -636,7 +640,7 @@ describe('Workspace Tests', () => {
       const lib2 = uniq('mylib');
       const lib3 = uniq('mylib');
       runCLI(
-        `generate @nx/js:lib ${lib1}-data-access --directory=${lib1}/data-access --unitTestRunner=jest --project-name-and-root-format=as-provided`
+        `generate @nx/js:lib ${lib1}-data-access --directory=${lib1}/data-access --unitTestRunner=jest`
       );
       let rootTsConfig = readJson('tsconfig.base.json');
       expect(
@@ -661,7 +665,7 @@ describe('Workspace Tests', () => {
        */
 
       runCLI(
-        `generate @nx/js:lib ${lib2}-ui --directory=${lib2}/ui --unitTestRunner=jest --project-name-and-root-format=as-provided`
+        `generate @nx/js:lib ${lib2}-ui --directory=${lib2}/ui --unitTestRunner=jest`
       );
 
       updateFile(
@@ -675,9 +679,7 @@ describe('Workspace Tests', () => {
        * Create a library which has an implicit dependency on lib1
        */
 
-      runCLI(
-        `generate @nx/js:lib ${lib3} --unitTestRunner=jest --project-name-and-root-format=as-provided`
-      );
+      runCLI(`generate @nx/js:lib ${lib3} --unitTestRunner=jest`);
       updateFile(join(lib3, 'project.json'), (content) => {
         const data = JSON.parse(content);
         data.implicitDependencies = [`${lib1}-data-access`];
@@ -689,7 +691,7 @@ describe('Workspace Tests', () => {
        */
 
       const moveOutput = runCLI(
-        `generate @nx/workspace:move --project ${lib1}-data-access shared/${lib1}/data-access --newProjectName=shared-${lib1}-data-access --project-name-and-root-format=as-provided`
+        `generate @nx/workspace:move --project ${lib1}-data-access shared/${lib1}/data-access --newProjectName=shared-${lib1}-data-access`
       );
 
       expect(moveOutput).toContain(`DELETE ${lib1}/data-access`);
@@ -758,14 +760,14 @@ describe('Workspace Tests', () => {
       const lib2 = uniq('mylibb');
 
       runCLI(`generate @nx/js:lib ${lib1} --unitTestRunner=jest`);
-      expect(exists(tmpProjPath(`libs/${lib1}`))).toBeTruthy();
+      expect(exists(tmpProjPath(`${lib1}`))).toBeTruthy();
 
       /**
        * Create a library which has an implicit dependency on lib1
        */
 
       runCLI(`generate @nx/js:lib ${lib2} --unitTestRunner=jest`);
-      updateFile(join('libs', lib2, 'project.json'), (content) => {
+      updateFile(join(lib2, 'project.json'), (content) => {
         const data = JSON.parse(content);
         data.implicitDependencies = [lib1];
         return JSON.stringify(data, null, 2);
@@ -796,13 +798,13 @@ describe('Workspace Tests', () => {
         `generate @nx/workspace:remove --project ${lib1} --forceRemove`
       );
 
-      expect(removeOutputForced).toContain(`DELETE libs/${lib1}`);
-      expect(exists(tmpProjPath(`libs/${lib1}`))).toBeFalsy();
+      expect(removeOutputForced).toContain(`DELETE ${lib1}`);
+      expect(exists(tmpProjPath(`${lib1}`))).toBeFalsy();
 
       expect(removeOutputForced).not.toContain(`UPDATE nx.json`);
       const projects = runCLI('show projects').split('\n');
       expect(projects).not.toContain(lib1);
-      const lib2Config = readJson(join('libs', lib2, 'project.json'));
+      const lib2Config = readJson(join(lib2, 'project.json'));
       expect(lib2Config.implicitDependencies).toEqual([]);
 
       expect(projects[`${lib1}`]).toBeUndefined();

--- a/e2e/plugin/src/nx-plugin.test.ts
+++ b/e2e/plugin/src/nx-plugin.test.ts
@@ -23,7 +23,9 @@ describe('Nx Plugin', () => {
   let npmScope: string;
 
   beforeAll(() => {
-    npmScope = newProject();
+    npmScope = newProject({
+      unsetProjectNameAndRootFormat: false,
+    });
   });
 
   afterAll(() => cleanupProject());
@@ -32,7 +34,7 @@ describe('Nx Plugin', () => {
     const plugin = uniq('plugin');
 
     runCLI(
-      `generate @nx/plugin:plugin ${plugin} --linter=eslint --e2eTestRunner=jest --publishable`
+      `generate @nx/plugin:plugin ${plugin} --directory packages/${plugin} --linter=eslint --e2eTestRunner=jest --publishable`
     );
     const lintResults = runCLI(`lint ${plugin}`);
     expect(lintResults).toContain('All files pass linting.');
@@ -40,10 +42,10 @@ describe('Nx Plugin', () => {
     const buildResults = runCLI(`build ${plugin}`);
     expect(buildResults).toContain('Done compiling TypeScript files');
     checkFilesExist(
-      `dist/libs/${plugin}/package.json`,
-      `dist/libs/${plugin}/src/index.js`
+      `dist/packages/${plugin}/package.json`,
+      `dist/packages/${plugin}/src/index.js`
     );
-    const project = readJson(`libs/${plugin}/project.json`);
+    const project = readJson(`packages/${plugin}/project.json`);
     expect(project).toMatchObject({
       tags: [],
     });
@@ -54,7 +56,9 @@ describe('Nx Plugin', () => {
     const plugin = uniq('plugin');
     const version = '1.0.0';
 
-    runCLI(`generate @nx/plugin:plugin ${plugin} --linter=eslint`);
+    runCLI(
+      `generate @nx/plugin:plugin ${plugin} --directory packages/${plugin} --linter=eslint`
+    );
     runCLI(
       `generate @nx/plugin:migration --project=${plugin} --packageVersion=${version} --packageJsonUpdates=false`
     );
@@ -67,10 +71,10 @@ describe('Nx Plugin', () => {
     const buildResults = runCLI(`build ${plugin}`);
     expect(buildResults).toContain('Done compiling TypeScript files');
     checkFilesExist(
-      `dist/libs/${plugin}/src/migrations/update-${version}/update-${version}.js`,
-      `libs/${plugin}/src/migrations/update-${version}/update-${version}.ts`
+      `dist/packages/${plugin}/src/migrations/update-${version}/update-${version}.js`,
+      `packages/${plugin}/src/migrations/update-${version}/update-${version}.ts`
     );
-    const migrationsJson = readJson(`libs/${plugin}/migrations.json`);
+    const migrationsJson = readJson(`packages/${plugin}/migrations.json`);
     expect(migrationsJson).toMatchObject({
       generators: expect.objectContaining({
         [`update-${version}`]: {
@@ -86,7 +90,9 @@ describe('Nx Plugin', () => {
     const plugin = uniq('plugin');
     const generator = uniq('generator');
 
-    runCLI(`generate @nx/plugin:plugin ${plugin} --linter=eslint`);
+    runCLI(
+      `generate @nx/plugin:plugin ${plugin} --directory packages/${plugin} --linter=eslint`
+    );
     runCLI(`generate @nx/plugin:generator ${generator} --project=${plugin}`);
 
     const lintResults = runCLI(`lint ${plugin}`);
@@ -97,15 +103,15 @@ describe('Nx Plugin', () => {
     const buildResults = runCLI(`build ${plugin}`);
     expect(buildResults).toContain('Done compiling TypeScript files');
     checkFilesExist(
-      `libs/${plugin}/src/generators/${generator}/schema.d.ts`,
-      `libs/${plugin}/src/generators/${generator}/schema.json`,
-      `libs/${plugin}/src/generators/${generator}/generator.ts`,
-      `libs/${plugin}/src/generators/${generator}/generator.spec.ts`,
-      `dist/libs/${plugin}/src/generators/${generator}/schema.d.ts`,
-      `dist/libs/${plugin}/src/generators/${generator}/schema.json`,
-      `dist/libs/${plugin}/src/generators/${generator}/generator.js`
+      `packages/${plugin}/src/generators/${generator}/schema.d.ts`,
+      `packages/${plugin}/src/generators/${generator}/schema.json`,
+      `packages/${plugin}/src/generators/${generator}/generator.ts`,
+      `packages/${plugin}/src/generators/${generator}/generator.spec.ts`,
+      `dist/packages/${plugin}/src/generators/${generator}/schema.d.ts`,
+      `dist/packages/${plugin}/src/generators/${generator}/schema.json`,
+      `dist/packages/${plugin}/src/generators/${generator}/generator.js`
     );
-    const generatorJson = readJson(`libs/${plugin}/generators.json`);
+    const generatorJson = readJson(`packages/${plugin}/generators.json`);
     expect(generatorJson).toMatchObject({
       generators: expect.objectContaining({
         [generator]: {
@@ -121,7 +127,9 @@ describe('Nx Plugin', () => {
     const plugin = uniq('plugin');
     const executor = uniq('executor');
 
-    runCLI(`generate @nx/plugin:plugin ${plugin} --linter=eslint`);
+    runCLI(
+      `generate @nx/plugin:plugin ${plugin} --directory packages/${plugin} --linter=eslint`
+    );
     runCLI(
       `generate @nx/plugin:executor ${executor} --project=${plugin} --includeHasher`
     );
@@ -134,17 +142,17 @@ describe('Nx Plugin', () => {
     const buildResults = runCLI(`build ${plugin}`);
     expect(buildResults).toContain('Done compiling TypeScript files');
     checkFilesExist(
-      `libs/${plugin}/src/executors/${executor}/schema.d.ts`,
-      `libs/${plugin}/src/executors/${executor}/schema.json`,
-      `libs/${plugin}/src/executors/${executor}/executor.ts`,
-      `libs/${plugin}/src/executors/${executor}/hasher.ts`,
-      `libs/${plugin}/src/executors/${executor}/executor.spec.ts`,
-      `dist/libs/${plugin}/src/executors/${executor}/schema.d.ts`,
-      `dist/libs/${plugin}/src/executors/${executor}/schema.json`,
-      `dist/libs/${plugin}/src/executors/${executor}/executor.js`,
-      `dist/libs/${plugin}/src/executors/${executor}/hasher.js`
+      `packages/${plugin}/src/executors/${executor}/schema.d.ts`,
+      `packages/${plugin}/src/executors/${executor}/schema.json`,
+      `packages/${plugin}/src/executors/${executor}/executor.ts`,
+      `packages/${plugin}/src/executors/${executor}/hasher.ts`,
+      `packages/${plugin}/src/executors/${executor}/executor.spec.ts`,
+      `dist/packages/${plugin}/src/executors/${executor}/schema.d.ts`,
+      `dist/packages/${plugin}/src/executors/${executor}/schema.json`,
+      `dist/packages/${plugin}/src/executors/${executor}/executor.js`,
+      `dist/packages/${plugin}/src/executors/${executor}/hasher.js`
     );
-    const executorsJson = readJson(`libs/${plugin}/executors.json`);
+    const executorsJson = readJson(`packages/${plugin}/executors.json`);
     expect(executorsJson).toMatchObject({
       executors: expect.objectContaining({
         [executor]: {
@@ -167,9 +175,9 @@ describe('Nx Plugin', () => {
     const badMigrationVersion = uniq('bad-version');
     const missingMigrationVersion = uniq('missing-version');
 
-    // Generating the plugin results in a generator also called {plugin},
-    // as well as an executor called "build"
-    runCLI(`generate @nx/plugin:plugin ${plugin} --linter=eslint`);
+    runCLI(
+      `generate @nx/plugin:plugin ${plugin} --directory packages/${plugin} --linter=eslint`
+    );
 
     runCLI(
       `generate @nx/plugin:generator ${goodGenerator} --project=${plugin}`
@@ -197,7 +205,7 @@ describe('Nx Plugin', () => {
       `generate @nx/plugin:migration ${goodMigration} --project=${plugin} --packageVersion="0.1.0"`
     );
 
-    updateFile(`libs/${plugin}/generators.json`, (f) => {
+    updateFile(`packages/${plugin}/generators.json`, (f) => {
       const json = JSON.parse(f);
       // @proj/plugin:plugin has an invalid implementation path
       json.generators[
@@ -208,7 +216,7 @@ describe('Nx Plugin', () => {
       return JSON.stringify(json);
     });
 
-    updateFile(`libs/${plugin}/executors.json`, (f) => {
+    updateFile(`packages/${plugin}/executors.json`, (f) => {
       const json = JSON.parse(f);
       // @proj/plugin:badExecutorBadImplPath has an invalid implementation path
       json.executors[badExecutorBadImplPath].implementation =
@@ -218,7 +226,7 @@ describe('Nx Plugin', () => {
       return JSON.stringify(json);
     });
 
-    updateFile(`libs/${plugin}/migrations.json`, (f) => {
+    updateFile(`packages/${plugin}/migrations.json`, (f) => {
       const json = JSON.parse(f);
       delete json.generators[missingMigrationVersion].version;
       return JSON.stringify(json);
@@ -256,17 +264,73 @@ describe('Nx Plugin', () => {
     expect(results).not.toContain(goodMigration);
   });
 
+  it('should be able to add nodes and dependencies to the project graph', () => {
+    const plugin = uniq('plugin');
+
+    runCLI(
+      `generate @nx/plugin:plugin ${plugin} --directory packages/${plugin} --linter=eslint`
+    );
+    updateFile(
+      `packages/${plugin}/src/index.ts`,
+      `
+      import { ProjectConfiguration, CreateNodes, CreateDependencies } from '@nx/devkit';
+      import { dirname, basename } from 'path';
+      import { readFileSync } from 'fs';
+      export const createNodes: CreateNodes = ['**/project.nx', (file) => {
+        const name = basename(dirname(file));
+        const project: ProjectConfiguration = {
+          root: dirname(file),
+          name: name
+        };
+        return {
+          projects: {
+            [name]: project,
+          },
+        };
+      }];
+      export const createDependencies: CreateDependencies = () => {
+        return [
+          {
+            source: 'lib1',
+            target: 'lib2',
+            type: 'implicit',
+          }
+        ]
+      };
+    `
+    );
+
+    const nxJson = readJson('nx.json');
+    nxJson.plugins = [`@${npmScope}/${plugin}`];
+    updateFile('nx.json', JSON.stringify(nxJson));
+
+    createFile('projects/lib1/project.nx', '');
+    createFile('projects/lib2/project.nx', '');
+
+    runCLI('graph --file project-graph.json');
+    const projectGraphJson = readJson('project-graph.json');
+    expect(projectGraphJson.graph.nodes['lib1']).toBeDefined();
+    expect(projectGraphJson.graph.nodes['lib2']).toBeDefined();
+    expect(projectGraphJson.graph.dependencies['lib1']).toContainEqual({
+      type: 'implicit',
+      source: 'lib1',
+      target: 'lib2',
+    });
+  });
+
   describe('local plugins', () => {
     let plugin: string;
     beforeEach(() => {
       plugin = uniq('plugin');
-      runCLI(`generate @nx/plugin:plugin ${plugin} --linter=eslint`);
+      runCLI(
+        `generate @nx/plugin:plugin ${plugin} --directory tools/plugins/${plugin} --linter=eslint`
+      );
     });
 
     it('should be able to infer projects and targets', async () => {
       // Setup project inference + target inference
       updateFile(
-        `libs/${plugin}/src/index.ts`,
+        `tools/plugins/${plugin}/src/index.ts`,
         `import {basename} from 'path'
 
   export function registerProjectTargets(f) {
@@ -295,7 +359,7 @@ describe('Nx Plugin', () => {
 
       // Create project that should be inferred by Nx
       const inferredProject = uniq('inferred');
-      createFile(`libs/${inferredProject}/my-project-file`);
+      createFile(`tools/plugins/${inferredProject}/my-project-file`);
 
       // Attempt to use inferred project w/ Nx
       expect(runCLI(`build ${inferredProject}`)).toContain(
@@ -313,13 +377,15 @@ describe('Nx Plugin', () => {
       runCLI(`generate @nx/plugin:executor ${executor} --project=${plugin}`);
 
       updateFile(
-        `libs/${plugin}/src/executors/${executor}/executor.ts`,
+        `tools/plugins/${plugin}/src/executors/${executor}/executor.ts`,
         ASYNC_GENERATOR_EXECUTOR_CONTENTS
       );
 
       runCLI(
         `generate @${npmScope}/${plugin}:${generator} --name ${generatedProject}`
       );
+
+      checkFilesExist(`libs/${generatedProject}`);
 
       updateFile(`libs/${generatedProject}/project.json`, (f) => {
         const project: ProjectConfiguration = JSON.parse(f);
@@ -329,7 +395,6 @@ describe('Nx Plugin', () => {
         return JSON.stringify(project, null, 2);
       });
 
-      expect(() => checkFilesExist(`libs/${generatedProject}`)).not.toThrow();
       expect(() => runCLI(`execute ${generatedProject}`)).not.toThrow();
     });
 
@@ -364,7 +429,9 @@ describe('Nx Plugin', () => {
     it('should work with generate wrapper', () => {
       custom = uniq('custom');
       const project = uniq('generated-project');
-      runCLI(`g @nx/plugin:plugin workspace-plugin --no-interactive`);
+      runCLI(
+        `g @nx/plugin:plugin workspace-plugin --directory tools/workspace-plugin --no-interactive`
+      );
       runCLI(
         `g @nx/plugin:generator ${custom} --project workspace-plugin --no-interactive`
       );
@@ -384,14 +451,14 @@ describe('Nx Plugin', () => {
     it('should create a plugin in the specified directory', async () => {
       const plugin = uniq('plugin');
       runCLI(
-        `generate @nx/plugin:plugin ${plugin} --linter=eslint --directory subdir --e2eTestRunner=jest`
+        `generate @nx/plugin:plugin ${plugin} --directory packages/subdir/${plugin} --linter=eslint --e2eTestRunner=jest`
       );
-      checkFilesExist(`libs/subdir/${plugin}/package.json`);
+      checkFilesExist(`packages/subdir/${plugin}/package.json`);
       const pluginProject = readJson(
-        join('libs', 'subdir', plugin, 'project.json')
+        join('packages/subdir', plugin, 'project.json')
       );
       const pluginE2EProject = readJson(
-        join('apps', 'subdir', `${plugin}-e2e`, 'project.json')
+        join('packages/subdir', `${plugin}-e2e`, 'project.json')
       );
       expect(pluginProject.targets).toBeDefined();
       expect(pluginE2EProject).toBeTruthy();
@@ -401,9 +468,9 @@ describe('Nx Plugin', () => {
     it('should add tags to project configuration', () => {
       const plugin = uniq('plugin');
       runCLI(
-        `generate @nx/plugin:plugin ${plugin} --linter=eslint --tags=e2etag,e2ePackage `
+        `generate @nx/plugin:plugin ${plugin} --directory packages/${plugin} --linter=eslint --tags=e2etag,e2ePackage `
       );
-      const pluginProject = readJson(join('libs', plugin, 'project.json'));
+      const pluginProject = readJson(join('packages', plugin, 'project.json'));
       expect(pluginProject.tags).toEqual(['e2etag', 'e2ePackage']);
     }, 90000);
   });
@@ -412,19 +479,19 @@ describe('Nx Plugin', () => {
     const plugin = uniq('plugin');
     const createAppName = `create-${plugin}-app`;
     runCLI(
-      `generate @nx/plugin:plugin ${plugin} --e2eTestRunner jest --publishable`
+      `generate @nx/plugin:plugin ${plugin} --directory packages/${plugin} --e2eTestRunner jest --publishable`
     );
     runCLI(
-      `generate @nx/plugin:create-package ${createAppName} --project=${plugin} --e2eProject=${plugin}-e2e`
+      `generate @nx/plugin:create-package ${createAppName} --directory packages/${createAppName} --project=${plugin} --e2eProject=${plugin}-e2e`
     );
 
     const buildResults = runCLI(`build ${createAppName}`);
     expect(buildResults).toContain('Done compiling TypeScript files');
 
     checkFilesExist(
-      `libs/${plugin}/src/generators/preset`,
-      `libs/${createAppName}`,
-      `dist/libs/${createAppName}/bin/index.js`
+      `packages/${plugin}/src/generators/preset`,
+      `packages/${createAppName}`,
+      `dist/packages/${createAppName}/bin/index.js`
     );
 
     runCLI(`e2e ${plugin}-e2e`);
@@ -432,24 +499,25 @@ describe('Nx Plugin', () => {
 
   it('should throw an error when run create-package for an invalid plugin ', async () => {
     const plugin = uniq('plugin');
+    const createAppName = `create-${plugin}-app`;
     expect(() =>
       runCLI(
-        `generate @nx/plugin:create-package ${plugin} --project=invalid-plugin`
+        `generate @nx/plugin:create-package ${createAppName} --project=invalid-plugin`
       )
     ).toThrow();
   });
 
-  it('should support the new name and root format', async () => {
+  it('should support the old name and root format', async () => {
     const plugin = uniq('plugin');
     const createAppName = `create-${plugin}-app`;
 
     runCLI(
-      `generate @nx/plugin:plugin ${plugin} --e2eTestRunner jest --publishable --project-name-and-root-format=as-provided`
+      `generate @nx/plugin:plugin ${plugin} --projectNameAndRootFormat derived --e2eTestRunner jest --publishable`
     );
 
     // check files are generated without the layout directory ("libs/") and
     // using the project name as the directory when no directory is provided
-    checkFilesExist(`${plugin}/src/index.ts`);
+    checkFilesExist(`libs/${plugin}/src/index.ts`);
     // check build works
     expect(runCLI(`build ${plugin}`)).toContain(
       `Successfully ran target build for project ${plugin}`
@@ -461,12 +529,12 @@ describe('Nx Plugin', () => {
     );
 
     runCLI(
-      `generate @nx/plugin:create-package ${createAppName} --project=${plugin} --e2eProject=${plugin}-e2e --project-name-and-root-format=as-provided`
+      `generate @nx/plugin:create-package ${createAppName} --project=${plugin} --e2eProject=${plugin}-e2e`
     );
 
     // check files are generated without the layout directory ("libs/") and
     // using the project name as the directory when no directory is provided
-    checkFilesExist(`${plugin}/src/generators/preset`, `${createAppName}`);
+    checkFilesExist(`libs/${plugin}/src/generators/preset`, `${createAppName}`);
     // check build works
     expect(runCLI(`build ${createAppName}`)).toContain(
       `Successfully ran target build for project ${createAppName}`

--- a/packages/plugin/src/generators/create-package/create-package.spec.ts
+++ b/packages/plugin/src/generators/create-package/create-package.spec.ts
@@ -15,6 +15,8 @@ const getSchema: (
   overrides?: Partial<CreatePackageSchema>
 ) => CreatePackageSchema = (overrides = {}) => ({
   name: 'create-a-workspace',
+  directory: 'packages/create-a-workspace',
+  projectNameAndRootFormat: 'as-provided',
   project: 'my-plugin',
   compiler: 'tsc',
   skipTsConfig: false,
@@ -32,6 +34,8 @@ describe('NxPlugin Create Package Generator', () => {
     tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
     await pluginGenerator(tree, {
       name: 'my-plugin',
+      directory: 'packages/my-plugin',
+      projectNameAndRootFormat: 'as-provided',
       compiler: 'tsc',
       skipTsConfig: false,
       skipFormat: false,
@@ -44,16 +48,16 @@ describe('NxPlugin Create Package Generator', () => {
   it('should update the project.json file', async () => {
     await createPackageGenerator(tree, getSchema());
     const project = readProjectConfiguration(tree, 'create-a-workspace');
-    expect(project.root).toEqual('libs/create-a-workspace');
-    expect(project.sourceRoot).toEqual('libs/create-a-workspace/bin');
+    expect(project.root).toEqual('packages/create-a-workspace');
+    expect(project.sourceRoot).toEqual('packages/create-a-workspace/bin');
     expect(project.targets.build).toEqual({
       executor: '@nx/js:tsc',
       outputs: ['{options.outputPath}'],
       options: {
-        outputPath: 'dist/libs/create-a-workspace',
-        tsConfig: 'libs/create-a-workspace/tsconfig.lib.json',
-        main: 'libs/create-a-workspace/bin/index.ts',
-        assets: ['libs/create-a-workspace/*.md'],
+        outputPath: 'dist/packages/create-a-workspace',
+        tsConfig: 'packages/create-a-workspace/tsconfig.lib.json',
+        main: 'packages/create-a-workspace/bin/index.ts',
+        assets: ['packages/create-a-workspace/*.md'],
         updateBuildableProjectDepsInPackageJson: false,
       },
     });
@@ -63,14 +67,11 @@ describe('NxPlugin Create Package Generator', () => {
     await createPackageGenerator(
       tree,
       getSchema({
-        directory: 'plugins',
+        directory: 'packages/create-a-workspace',
       } as Partial<CreatePackageSchema>)
     );
-    const project = readProjectConfiguration(
-      tree,
-      'plugins-create-a-workspace'
-    );
-    expect(project.root).toEqual('libs/plugins/create-a-workspace');
+    const project = readProjectConfiguration(tree, 'create-a-workspace');
+    expect(project.root).toEqual('packages/create-a-workspace');
   });
 
   it('should specify tsc as compiler', async () => {

--- a/packages/plugin/src/generators/e2e-project/e2e.spec.ts
+++ b/packages/plugin/src/generators/e2e-project/e2e.spec.ts
@@ -12,14 +12,14 @@ import { e2eProjectGenerator } from './e2e';
 describe('NxPlugin e2e-project Generator', () => {
   let tree: Tree;
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
 
     // add a plugin project to the workspace for validations
     addProjectConfiguration(tree, 'my-plugin', {
-      root: 'libs/my-plugin',
+      root: 'plugins/my-plugin',
       targets: {},
     });
-    writeJson(tree, 'libs/my-plugin/package.json', {
+    writeJson(tree, 'plugins/my-plugin/package.json', {
       name: 'my-plugin',
     });
   });
@@ -28,16 +28,15 @@ describe('NxPlugin e2e-project Generator', () => {
     await expect(
       e2eProjectGenerator(tree, {
         pluginName: 'my-plugin',
-        pluginOutputPath: `dist/libs/my-plugin`,
-        npmPackageName: '@proj/my-plugin',
+        projectDirectory: 'plugins/my-plugin-e2e',
+        projectNameAndRootFormat: 'as-provided',
       })
     ).resolves.toBeDefined();
 
     await expect(
       e2eProjectGenerator(tree, {
         pluginName: 'my-nonexistentplugin',
-        pluginOutputPath: `dist/libs/my-nonexistentplugin`,
-        npmPackageName: '@proj/my-nonexistentplugin',
+        projectNameAndRootFormat: 'as-provided',
       })
     ).rejects.toThrow();
   });
@@ -45,24 +44,22 @@ describe('NxPlugin e2e-project Generator', () => {
   it('should add files related to e2e', async () => {
     await e2eProjectGenerator(tree, {
       pluginName: 'my-plugin',
-      pluginOutputPath: `dist/libs/my-plugin`,
-      npmPackageName: '@proj/my-plugin',
+      projectNameAndRootFormat: 'as-provided',
     });
 
-    expect(tree.exists('apps/my-plugin-e2e/tsconfig.json')).toBeTruthy();
+    expect(tree.exists('plugins/my-plugin-e2e/tsconfig.json')).toBeTruthy();
     expect(
-      tree.exists('apps/my-plugin-e2e/tests/my-plugin.spec.ts')
+      tree.exists('plugins/my-plugin-e2e/tests/my-plugin.spec.ts')
     ).toBeTruthy();
   });
 
   it('should extend from root tsconfig.base.json', async () => {
     await e2eProjectGenerator(tree, {
       pluginName: 'my-plugin',
-      pluginOutputPath: `dist/libs/my-plugin`,
-      npmPackageName: '@proj/my-plugin',
+      projectNameAndRootFormat: 'as-provided',
     });
 
-    const tsConfig = readJson(tree, 'apps/my-plugin-e2e/tsconfig.json');
+    const tsConfig = readJson(tree, 'plugins/my-plugin-e2e/tsconfig.json');
     expect(tsConfig.extends).toEqual('../../tsconfig.base.json');
   });
 
@@ -71,31 +68,28 @@ describe('NxPlugin e2e-project Generator', () => {
 
     await e2eProjectGenerator(tree, {
       pluginName: 'my-plugin',
-      pluginOutputPath: `dist/libs/my-plugin`,
-      npmPackageName: '@proj/my-plugin',
+      projectNameAndRootFormat: 'as-provided',
     });
 
-    const tsConfig = readJson(tree, 'apps/my-plugin-e2e/tsconfig.json');
+    const tsConfig = readJson(tree, 'plugins/my-plugin-e2e/tsconfig.json');
     expect(tsConfig.extends).toEqual('../../tsconfig.json');
   });
 
   it('should set project root with the directory option', async () => {
     await e2eProjectGenerator(tree, {
       pluginName: 'my-plugin',
-      pluginOutputPath: `dist/libs/namespace/my-plugin`,
-      npmPackageName: '@proj/namespace-my-plugin',
-      projectDirectory: 'namespace/my-plugin',
+      projectDirectory: 'plugins/namespace/my-plugin-e2e',
+      projectNameAndRootFormat: 'as-provided',
     });
 
     const project = readProjectConfiguration(tree, 'my-plugin-e2e');
-    expect(project.root).toBe('apps/namespace/my-plugin-e2e');
+    expect(project.root).toBe('plugins/namespace/my-plugin-e2e');
   });
 
   it('should update the implicit dependencies', async () => {
     await e2eProjectGenerator(tree, {
       pluginName: 'my-plugin',
-      pluginOutputPath: `dist/libs/my-plugin`,
-      npmPackageName: '@proj/my-plugin',
+      projectNameAndRootFormat: 'as-provided',
     });
     const projects = Object.fromEntries(getProjects(tree));
     expect(projects).toMatchObject({
@@ -108,14 +102,13 @@ describe('NxPlugin e2e-project Generator', () => {
   it('should update the workspace', async () => {
     await e2eProjectGenerator(tree, {
       pluginName: 'my-plugin',
-      pluginOutputPath: `dist/libs/my-plugin`,
-      npmPackageName: '@proj/my-plugin',
+      projectNameAndRootFormat: 'as-provided',
     });
 
     const project = readProjectConfiguration(tree, 'my-plugin-e2e');
 
     expect(project).toBeTruthy();
-    expect(project.root).toEqual('apps/my-plugin-e2e');
+    expect(project.root).toEqual('plugins/my-plugin-e2e');
     expect(project.targets.e2e).toBeTruthy();
     expect(project.targets.e2e).toMatchInlineSnapshot(`
       {
@@ -130,7 +123,7 @@ describe('NxPlugin e2e-project Generator', () => {
         ],
         "executor": "@nx/jest:jest",
         "options": {
-          "jestConfig": "apps/my-plugin-e2e/jest.config.ts",
+          "jestConfig": "plugins/my-plugin-e2e/jest.config.ts",
           "passWithNoTests": true,
           "runInBand": true,
         },
@@ -144,27 +137,27 @@ describe('NxPlugin e2e-project Generator', () => {
   it('should add jest support', async () => {
     await e2eProjectGenerator(tree, {
       pluginName: 'my-plugin',
-      pluginOutputPath: `dist/libs/my-plugin`,
-      npmPackageName: '@proj/my-plugin',
+      projectNameAndRootFormat: 'as-provided',
     });
 
     const project = readProjectConfiguration(tree, 'my-plugin-e2e');
 
     expect(project.targets.e2e).toMatchObject({
       options: expect.objectContaining({
-        jestConfig: 'apps/my-plugin-e2e/jest.config.ts',
+        jestConfig: 'plugins/my-plugin-e2e/jest.config.ts',
       }),
     });
 
-    expect(tree.exists('apps/my-plugin-e2e/tsconfig.spec.json')).toBeTruthy();
-    expect(tree.exists('apps/my-plugin-e2e/jest.config.ts')).toBeTruthy();
+    expect(
+      tree.exists('plugins/my-plugin-e2e/tsconfig.spec.json')
+    ).toBeTruthy();
+    expect(tree.exists('plugins/my-plugin-e2e/jest.config.ts')).toBeTruthy();
   });
 
   it('should setup the eslint builder', async () => {
     await e2eProjectGenerator(tree, {
       pluginName: 'my-plugin',
-      pluginOutputPath: `dist/libs/my-plugin`,
-      npmPackageName: '@proj/my-plugin',
+      projectNameAndRootFormat: 'as-provided',
     });
 
     const projectsConfigurations = getProjects(tree);
@@ -172,7 +165,7 @@ describe('NxPlugin e2e-project Generator', () => {
       executor: '@nx/linter:eslint',
       outputs: ['{options.outputFile}'],
       options: {
-        lintFilePatterns: ['apps/my-plugin-e2e/**/*.ts'],
+        lintFilePatterns: ['plugins/my-plugin-e2e/**/*.ts'],
       },
     });
   });

--- a/packages/plugin/src/generators/e2e-project/schema.d.ts
+++ b/packages/plugin/src/generators/e2e-project/schema.d.ts
@@ -3,9 +3,15 @@ import type { Linter } from '@nx/linter';
 
 export interface Schema {
   pluginName: string;
-  npmPackageName: string;
+  /**
+   * @deprecated This option does nothing now and will be removed in Nx 18.
+   */
+  npmPackageName?: string;
   projectDirectory?: string;
   projectNameAndRootFormat?: ProjectNameAndRootFormat;
+  /**
+   * @deprecated This option does nothing now and will be removed in Nx 18.
+   */
   pluginOutputPath?: string;
   jestConfig?: string;
   linter?: Linter;

--- a/packages/plugin/src/generators/e2e-project/schema.json
+++ b/packages/plugin/src/generators/e2e-project/schema.json
@@ -29,7 +29,7 @@
     "pluginOutputPath": {
       "type": "string",
       "description": "the output path of the plugin after it builds.",
-      "x-priority": "important"
+      "x-deprecated": "This option is no longer used and will be removed in Nx 18."
     },
     "jestConfig": {
       "type": "string",

--- a/packages/plugin/src/generators/executor/executor.spec.ts
+++ b/packages/plugin/src/generators/executor/executor.spec.ts
@@ -1,8 +1,8 @@
 import { Tree, readJson, readProjectConfiguration } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { executorGenerator } from './executor';
-import { pluginGenerator } from '../plugin/plugin';
 import { libraryGenerator as jsLibraryGenerator } from '@nx/js';
+import pluginGenerator from '../plugin/plugin';
 
 describe('NxPlugin Executor Generator', () => {
   let tree: Tree;
@@ -10,10 +10,12 @@ describe('NxPlugin Executor Generator', () => {
 
   beforeEach(async () => {
     projectName = 'my-plugin';
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
 
     await pluginGenerator(tree, {
       name: projectName,
+      directory: `plugins/${projectName}`,
+      projectNameAndRootFormat: 'as-provided',
     } as any);
   });
 
@@ -26,16 +28,18 @@ describe('NxPlugin Executor Generator', () => {
     });
 
     expect(
-      tree.exists('libs/my-plugin/src/executors/my-executor/schema.d.ts')
+      tree.exists('plugins/my-plugin/src/executors/my-executor/schema.d.ts')
     ).toBeTruthy();
     expect(
-      tree.exists('libs/my-plugin/src/executors/my-executor/schema.json')
+      tree.exists('plugins/my-plugin/src/executors/my-executor/schema.json')
     ).toBeTruthy();
     expect(
-      tree.exists('libs/my-plugin/src/executors/my-executor/executor.ts')
+      tree.exists('plugins/my-plugin/src/executors/my-executor/executor.ts')
     ).toBeTruthy();
     expect(
-      tree.exists('libs/my-plugin/src/executors/my-executor/executor.spec.ts')
+      tree.exists(
+        'plugins/my-plugin/src/executors/my-executor/executor.spec.ts'
+      )
     ).toBeTruthy();
   });
 
@@ -48,7 +52,7 @@ describe('NxPlugin Executor Generator', () => {
       includeHasher: false,
     });
 
-    const executorJson = readJson(tree, 'libs/my-plugin/executors.json');
+    const executorJson = readJson(tree, 'plugins/my-plugin/executors.json');
 
     expect(executorJson.executors['my-executor'].implementation).toEqual(
       './src/executors/my-executor/executor'
@@ -69,7 +73,7 @@ describe('NxPlugin Executor Generator', () => {
       includeHasher: false,
     });
 
-    const executorsJson = readJson(tree, 'libs/my-plugin/executors.json');
+    const executorsJson = readJson(tree, 'plugins/my-plugin/executors.json');
 
     expect(executorsJson.executors['my-executor'].description).toEqual(
       'my-executor executor'
@@ -85,7 +89,7 @@ describe('NxPlugin Executor Generator', () => {
       includeHasher: false,
     });
 
-    const executorsJson = readJson(tree, 'libs/my-plugin/executors.json');
+    const executorsJson = readJson(tree, 'plugins/my-plugin/executors.json');
 
     expect(executorsJson.executors['my-executor'].description).toEqual(
       'my-executor custom description'
@@ -143,11 +147,13 @@ describe('NxPlugin Executor Generator', () => {
         unitTestRunner: 'jest',
       });
       expect(
-        tree.exists('libs/my-plugin/src/executors/my-executor/hasher.spec.ts')
+        tree.exists(
+          'plugins/my-plugin/src/executors/my-executor/hasher.spec.ts'
+        )
       ).toBeTruthy();
       expect(
         tree
-          .read('libs/my-plugin/src/executors/my-executor/hasher.ts')
+          .read('plugins/my-plugin/src/executors/my-executor/hasher.ts')
           .toString()
       ).toMatchInlineSnapshot(`
         "import { CustomHasher } from '@nx/devkit';
@@ -174,7 +180,7 @@ describe('NxPlugin Executor Generator', () => {
         unitTestRunner: 'jest',
       });
 
-      const executorsJson = readJson(tree, 'libs/my-plugin/executors.json');
+      const executorsJson = readJson(tree, 'plugins/my-plugin/executors.json');
       expect(executorsJson.executors['my-executor'].hasher).toEqual(
         './src/executors/my-executor/hasher'
       );

--- a/packages/plugin/src/generators/generator/generator.spec.ts
+++ b/packages/plugin/src/generators/generator/generator.spec.ts
@@ -15,9 +15,11 @@ describe('NxPlugin Generator Generator', () => {
 
   beforeEach(async () => {
     projectName = 'my-plugin';
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
     await pluginGenerator(tree, {
       name: projectName,
+      directory: `plugins/${projectName}`,
+      projectNameAndRootFormat: 'as-provided',
     } as any);
   });
 
@@ -29,17 +31,17 @@ describe('NxPlugin Generator Generator', () => {
     });
 
     expect(
-      tree.exists('libs/my-plugin/src/generators/my-generator/schema.d.ts')
+      tree.exists('plugins/my-plugin/src/generators/my-generator/schema.d.ts')
     ).toBeTruthy();
     expect(
-      tree.exists('libs/my-plugin/src/generators/my-generator/schema.json')
+      tree.exists('plugins/my-plugin/src/generators/my-generator/schema.json')
     ).toBeTruthy();
     expect(
-      tree.exists('libs/my-plugin/src/generators/my-generator/generator.ts')
+      tree.exists('plugins/my-plugin/src/generators/my-generator/generator.ts')
     ).toBeTruthy();
     expect(
       tree.exists(
-        'libs/my-plugin/src/generators/my-generator/generator.spec.ts'
+        'plugins/my-plugin/src/generators/my-generator/generator.spec.ts'
       )
     ).toBeTruthy();
   });
@@ -52,7 +54,7 @@ describe('NxPlugin Generator Generator', () => {
       unitTestRunner: 'jest',
     });
 
-    const generatorJson = readJson(tree, 'libs/my-plugin/generators.json');
+    const generatorJson = readJson(tree, 'plugins/my-plugin/generators.json');
 
     expect(generatorJson.generators['my-generator'].factory).toEqual(
       './src/generators/my-generator/generator'
@@ -91,11 +93,11 @@ describe('NxPlugin Generator Generator', () => {
       unitTestRunner: 'jest',
     });
 
-    const generatorJson = readJson(tree, 'libs/my-plugin/generators.json');
+    const generatorJson = readJson(tree, 'plugins/my-plugin/generators.json');
 
     expect(
       tree.exists(
-        `libs/my-plugin/src/generators/${generatorFileName}/schema.d.ts`
+        `plugins/my-plugin/src/generators/${generatorFileName}/schema.d.ts`
       )
     ).toBeTruthy();
 
@@ -137,7 +139,7 @@ describe('NxPlugin Generator Generator', () => {
       unitTestRunner: 'jest',
     });
 
-    const generatorJson = readJson(tree, 'libs/my-plugin/generators.json');
+    const generatorJson = readJson(tree, 'plugins/my-plugin/generators.json');
 
     expect(generatorJson.generators['my-generator'].description).toEqual(
       'my-generator generator'
@@ -152,7 +154,7 @@ describe('NxPlugin Generator Generator', () => {
       unitTestRunner: 'jest',
     });
 
-    const generatorJson = readJson(tree, 'libs/my-plugin/generators.json');
+    const generatorJson = readJson(tree, 'plugins/my-plugin/generators.json');
 
     expect(generatorJson.generators['my-generator'].description).toEqual(
       'my-generator custom description'
@@ -170,11 +172,13 @@ describe('NxPlugin Generator Generator', () => {
         });
 
         expect(
-          tree.exists('libs/my-plugin/src/generators/my-generator/generator.ts')
+          tree.exists(
+            'plugins/my-plugin/src/generators/my-generator/generator.ts'
+          )
         ).toBeTruthy();
         expect(
           tree.exists(
-            'libs/my-plugin/src/generators/my-generator/generator.spec.ts'
+            'plugins/my-plugin/src/generators/my-generator/generator.spec.ts'
           )
         ).toBeFalsy();
       });
@@ -191,7 +195,7 @@ describe('NxPlugin Generator Generator', () => {
 
       const generatorJson = readJson<GeneratorsJson>(
         tree,
-        'libs/my-plugin/generators.json'
+        'plugins/my-plugin/generators.json'
       );
 
       expect(

--- a/packages/plugin/src/generators/lint-checks/generator.spec.ts
+++ b/packages/plugin/src/generators/lint-checks/generator.spec.ts
@@ -23,9 +23,11 @@ describe('lint-checks generator', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
     await pluginGenerator(tree, {
       name: 'plugin',
+      directory: `plugins/plugin`,
+      projectNameAndRootFormat: 'as-provided',
       importPath: '@acme/plugin',
       compiler: 'tsc',
       linter: Linter.EsLint,

--- a/packages/plugin/src/generators/migration/migration.spec.ts
+++ b/packages/plugin/src/generators/migration/migration.spec.ts
@@ -13,6 +13,8 @@ describe('NxPlugin migration generator', () => {
 
     await pluginGenerator(tree, {
       name: projectName,
+      directory: `plugins/${projectName}`,
+      projectNameAndRootFormat: 'as-provided',
     } as any);
   });
 
@@ -23,9 +25,9 @@ describe('NxPlugin migration generator', () => {
     });
 
     const project = readProjectConfiguration(tree, projectName);
-    expect(project.root).toEqual('libs/my-plugin');
+    expect(project.root).toEqual('plugins/my-plugin');
     expect(project.targets.build.options.assets).toContainEqual({
-      input: './libs/my-plugin',
+      input: './plugins/my-plugin',
       glob: 'migrations.json',
       output: '.',
     });
@@ -39,11 +41,13 @@ describe('NxPlugin migration generator', () => {
       packageVersion: '1.0.0',
     });
 
-    const migrationsJson = readJson(tree, 'libs/my-plugin/migrations.json');
-    const packageJson = readJson(tree, 'libs/my-plugin/package.json');
+    const migrationsJson = readJson(tree, 'plugins/my-plugin/migrations.json');
+    const packageJson = readJson(tree, 'plugins/my-plugin/package.json');
 
     expect(
-      tree.exists('libs/my-plugin/src/migrations/my-migration/my-migration.ts')
+      tree.exists(
+        'plugins/my-plugin/src/migrations/my-migration/my-migration.ts'
+      )
     ).toBeTruthy();
 
     expect(migrationsJson.generators['my-migration'].version).toEqual('1.0.0');
@@ -67,10 +71,12 @@ describe('NxPlugin migration generator', () => {
       packageVersion: '1.0.0',
     });
 
-    const migrationsJson = readJson(tree, 'libs/my-plugin/migrations.json');
+    const migrationsJson = readJson(tree, 'plugins/my-plugin/migrations.json');
 
     expect(
-      tree.exists('libs/my-plugin/src/migrations/update-1.0.0/update-1.0.0.ts')
+      tree.exists(
+        'plugins/my-plugin/src/migrations/update-1.0.0/update-1.0.0.ts'
+      )
     ).toBeTruthy();
 
     expect(migrationsJson.generators['update-1.0.0'].implementation).toEqual(
@@ -85,7 +91,7 @@ describe('NxPlugin migration generator', () => {
       packageVersion: '1.0.0',
     });
 
-    const migrationsJson = readJson(tree, 'libs/my-plugin/migrations.json');
+    const migrationsJson = readJson(tree, 'plugins/my-plugin/migrations.json');
 
     expect(migrationsJson.generators['my-migration'].description).toEqual(
       'my-migration'
@@ -100,7 +106,7 @@ describe('NxPlugin migration generator', () => {
       packageJsonUpdates: true,
     });
 
-    const migrationsJson = readJson(tree, 'libs/my-plugin/migrations.json');
+    const migrationsJson = readJson(tree, 'plugins/my-plugin/migrations.json');
 
     expect(migrationsJson.packageJsonUpdates).toEqual({
       ['1.0.0']: {

--- a/packages/plugin/src/generators/plugin/plugin.ts
+++ b/packages/plugin/src/generators/plugin/plugin.ts
@@ -22,6 +22,7 @@ import { addTsLibDependencies } from '@nx/js/src/utils/typescript/add-tslib-depe
 import { addSwcRegisterDependencies } from '@nx/js/src/utils/swc/add-swc-dependencies';
 
 import type { Schema } from './schema';
+import { basename, join } from 'path';
 
 const nxVersion = require('../../../package.json').version;
 
@@ -126,15 +127,14 @@ export async function pluginGeneratorInternal(host: Tree, schema: Schema) {
     tasks.push(
       await e2eProjectGenerator(host, {
         pluginName: options.name,
-        projectDirectory: options.projectDirectory,
-        pluginOutputPath: joinPathFragments(
-          'dist',
-          options.rootProject ? options.name : options.projectRoot
-        ),
-        npmPackageName: options.npmPackageName,
+        projectDirectory: options.rootProject
+          ? 'e2e'
+          : join(
+              options.projectDirectory,
+              `../${basename(options.projectDirectory)}-e2e`
+            ),
         skipFormat: true,
-        rootProject: options.rootProject,
-        projectNameAndRootFormat: options.projectNameAndRootFormat,
+        projectNameAndRootFormat: 'as-provided',
       })
     );
   }

--- a/packages/plugin/src/generators/preset/generator.spec.ts
+++ b/packages/plugin/src/generators/preset/generator.spec.ts
@@ -8,7 +8,7 @@ describe('preset generator', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should create a plugin', async () => {
@@ -19,6 +19,29 @@ describe('preset generator', () => {
     expect(config).toBeDefined();
     const packageJson = readJson<PackageJson>(tree, 'package.json');
     expect(packageJson.dependencies).toHaveProperty('@nx/devkit');
+    expect(readJson(tree, 'nx.json').npmScope).not.toBeDefined();
+  });
+
+  it('should create a plugin and a create-cli', async () => {
+    await generator(tree, {
+      pluginName: 'my-plugin',
+      createPackageName: 'create-a-workspace',
+    });
+    const config = readProjectConfiguration(tree, 'my-plugin');
+    expect(config).toBeDefined();
+    const packageJson = readJson<PackageJson>(
+      tree,
+      'packages/my-plugin/package.json'
+    );
+    expect(packageJson.dependencies).toHaveProperty('@nx/devkit');
+    const createPackageJson = readJson<PackageJson>(
+      tree,
+      'packages/create-a-workspace/package.json'
+    );
+    expect(createPackageJson.dependencies).toHaveProperty(
+      'create-nx-workspace'
+    );
+
     expect(readJson(tree, 'nx.json').npmScope).not.toBeDefined();
   });
 });

--- a/packages/plugin/src/generators/preset/generator.ts
+++ b/packages/plugin/src/generators/preset/generator.ts
@@ -7,6 +7,7 @@ import {
   runTasksInSerial,
   GeneratorCallback,
   names,
+  joinPathFragments,
 } from '@nx/devkit';
 import { Linter } from '@nx/linter';
 import { PackageJson } from 'nx/src/utils/package-json';
@@ -37,9 +38,9 @@ export default async function (tree: Tree, options: PresetGeneratorSchema) {
     // when creating a CLI package, the plugin will be in the packages folder
     directory:
       options.createPackageName && options.createPackageName !== 'false'
-        ? 'packages'
-        : undefined,
-    rootProject: options.createPackageName ? false : true,
+        ? joinPathFragments('packages', options.pluginName)
+        : '.',
+    projectNameAndRootFormat: 'as-provided',
   });
   tasks.push(pluginTask);
 

--- a/packages/workspace/src/generators/move/lib/check-destination.spec.ts
+++ b/packages/workspace/src/generators/move/lib/check-destination.spec.ts
@@ -1,8 +1,4 @@
-import {
-  ProjectConfiguration,
-  readProjectConfiguration,
-  Tree,
-} from '@nx/devkit';
+import { Tree } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { NormalizedSchema } from '../schema';
 import { checkDestination } from './check-destination';
@@ -12,30 +8,27 @@ const { libraryGenerator } = require('@nx/js');
 
 describe('checkDestination', () => {
   let tree: Tree;
-  let projectConfig: ProjectConfiguration;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
     await libraryGenerator(tree, {
       name: 'my-lib',
       projectNameAndRootFormat: 'as-provided',
     });
-    projectConfig = readProjectConfiguration(tree, 'my-lib');
   });
 
   it('should throw an error if the path is not explicit', async () => {
     const schema: NormalizedSchema = {
       projectName: 'my-lib',
-      destination: '../apps/not-an-app',
       importPath: undefined,
       updateImportPath: true,
       relativeToRootDestination: '',
     };
 
     expect(() => {
-      checkDestination(tree, schema, schema.destination);
+      checkDestination(tree, schema, '../apps/not-an-app');
     }).toThrow(
-      `Invalid destination: [${schema.destination}] - Please specify explicit path.`
+      `Invalid destination: [../apps/not-an-app] - Please specify explicit path.`
     );
   });
 
@@ -47,30 +40,26 @@ describe('checkDestination', () => {
 
     const schema: NormalizedSchema = {
       projectName: 'my-lib',
-      destination: 'my-other-lib',
       importPath: undefined,
       updateImportPath: true,
       relativeToRootDestination: 'my-other-lib',
     };
 
     expect(() => {
-      checkDestination(tree, schema, schema.destination);
-    }).toThrow(
-      `Invalid destination: [${schema.destination}] - Path is not empty.`
-    );
+      checkDestination(tree, schema, 'my-other-lib');
+    }).toThrow(`Invalid destination: [my-other-lib] - Path is not empty.`);
   });
 
   it('should NOT throw an error if the path is available', async () => {
     const schema: NormalizedSchema = {
       projectName: 'my-lib',
-      destination: 'my-other-lib',
       importPath: undefined,
       updateImportPath: true,
       relativeToRootDestination: 'my-other-lib',
     };
 
     expect(() => {
-      checkDestination(tree, schema, schema.destination);
+      checkDestination(tree, schema, 'my-other-lib');
     }).not.toThrow();
   });
 });

--- a/packages/workspace/src/generators/move/lib/create-project-configuration-in-new-destination.spec.ts
+++ b/packages/workspace/src/generators/move/lib/create-project-configuration-in-new-destination.spec.ts
@@ -13,20 +13,16 @@ describe('moveProjectConfiguration', () => {
   let projectConfig: ProjectConfiguration;
   let schema: NormalizedSchema;
 
-  const setupWorkspace = (version: 1 | 2 = 1) => {
+  beforeEach(() => {
     schema = {
       projectName: 'my-source',
-      destination: 'subfolder/my-destination',
-      importPath: '@proj/subfolder-my-destination',
-      updateImportPath: true,
+      projectNameAndRootFormat: 'as-provided',
+      updateImportPath: false,
       newProjectName: 'subfolder-my-destination',
-      relativeToRootDestination: 'apps/subfolder/my-destination',
+      relativeToRootDestination: 'subfolder/my-destination',
     };
 
-    tree =
-      version === 1
-        ? createTreeWithEmptyWorkspace()
-        : createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
 
     addProjectConfiguration(tree, 'my-source', {
       projectType: 'application',
@@ -150,11 +146,9 @@ describe('moveProjectConfiguration', () => {
     });
 
     projectConfig = readProjectConfiguration(tree, 'my-source');
-  };
+  });
 
   it('should rename the project', async () => {
-    setupWorkspace();
-
     createProjectConfigurationInNewDestination(tree, schema, projectConfig);
 
     expect(
@@ -163,8 +157,6 @@ describe('moveProjectConfiguration', () => {
   });
 
   it('should update paths in only the intended project', async () => {
-    setupWorkspace();
-
     createProjectConfigurationInNewDestination(tree, schema, projectConfig);
 
     const actualProject = readProjectConfiguration(
@@ -172,8 +164,8 @@ describe('moveProjectConfiguration', () => {
       'subfolder-my-destination'
     );
     expect(actualProject).toBeDefined();
-    expect(actualProject.root).toBe('apps/subfolder/my-destination');
-    expect(actualProject.sourceRoot).toBe('apps/subfolder/my-destination/src');
+    expect(actualProject.root).toBe('subfolder/my-destination');
+    expect(actualProject.sourceRoot).toBe('subfolder/my-destination/src');
 
     const similarProject = readProjectConfiguration(tree, 'my-source-e2e');
     expect(similarProject).toBeDefined();
@@ -181,7 +173,6 @@ describe('moveProjectConfiguration', () => {
   });
 
   it('should update tags and implicitDependencies', () => {
-    setupWorkspace();
     createProjectConfigurationInNewDestination(tree, schema, projectConfig);
 
     const actualProject = readProjectConfiguration(
@@ -193,8 +184,6 @@ describe('moveProjectConfiguration', () => {
   });
 
   it('should support moving a standalone project', () => {
-    setupWorkspace(2);
-
     const projectName = 'standalone';
     const newProjectName = 'parent-standalone';
     addProjectConfiguration(
@@ -209,10 +198,9 @@ describe('moveProjectConfiguration', () => {
     );
     const moveSchema: NormalizedSchema = {
       projectName: 'standalone',
-      destination: 'parent/standalone',
       importPath: '@proj/parent-standalone',
       newProjectName,
-      relativeToRootDestination: 'libs/parent/standalone',
+      relativeToRootDestination: 'parent/standalone',
       updateImportPath: true,
     };
 

--- a/packages/workspace/src/generators/move/lib/move-project-files.spec.ts
+++ b/packages/workspace/src/generators/move/lib/move-project-files.spec.ts
@@ -15,7 +15,7 @@ describe('moveProject', () => {
   let projectConfig: ProjectConfiguration;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
     await libraryGenerator(tree, {
       name: 'my-lib',
       projectNameAndRootFormat: 'as-provided',
@@ -26,9 +26,7 @@ describe('moveProject', () => {
   it('should copy all files and delete the source folder', async () => {
     const schema: NormalizedSchema = {
       projectName: 'my-lib',
-      destination: 'my-destination',
-      importPath: '@proj/my-destination',
-      updateImportPath: true,
+      updateImportPath: false,
       newProjectName: 'my-destination',
       relativeToRootDestination: 'my-destination',
     };

--- a/packages/workspace/src/generators/move/lib/normalize-schema.spec.ts
+++ b/packages/workspace/src/generators/move/lib/normalize-schema.spec.ts
@@ -16,11 +16,12 @@ describe('normalizeSchema', () => {
   const schema: Schema = {
     destination: '/my/library',
     projectName: 'my-library',
+    projectNameAndRootFormat: 'as-provided',
     updateImportPath: true,
   };
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
 
     addProjectConfiguration(tree, schema.projectName, {
       root: 'libs/my-library',
@@ -33,12 +34,11 @@ describe('normalizeSchema', () => {
 
   it('should calculate importPath, projectName and relativeToRootDestination correctly', async () => {
     const expected: NormalizedSchema = {
-      destination: 'my/library',
-      importPath: '@proj/my/library',
       newProjectName: 'my-library',
       projectName: 'my-library',
-      relativeToRootDestination: 'libs/my/library',
-      updateImportPath: true,
+      relativeToRootDestination: 'my/library',
+      projectNameAndRootFormat: 'as-provided',
+      updateImportPath: false,
     };
 
     const result = await normalizeSchema(tree, schema, projectConfiguration);
@@ -48,12 +48,11 @@ describe('normalizeSchema', () => {
 
   it('should normalize destination and derive projectName correctly', async () => {
     const expected: NormalizedSchema = {
-      destination: 'my/library',
-      importPath: '@proj/my/library',
       newProjectName: 'my-library',
       projectName: 'my-library',
-      relativeToRootDestination: 'libs/my/library',
-      updateImportPath: true,
+      relativeToRootDestination: 'my/library',
+      projectNameAndRootFormat: 'as-provided',
+      updateImportPath: false,
     };
 
     const result = await normalizeSchema(
@@ -67,11 +66,11 @@ describe('normalizeSchema', () => {
 
   it('should use provided import path', async () => {
     const expected: NormalizedSchema = {
-      destination: 'my/library',
       importPath: '@proj/my-awesome-library',
       newProjectName: 'my-library',
       projectName: 'my-library',
-      relativeToRootDestination: 'libs/my/library',
+      relativeToRootDestination: 'my/library',
+      projectNameAndRootFormat: 'as-provided',
       updateImportPath: true,
     };
 
@@ -90,7 +89,11 @@ describe('normalizeSchema', () => {
       return json;
     });
 
-    const result = await normalizeSchema(tree, schema, projectConfiguration);
+    const result = await normalizeSchema(
+      tree,
+      { ...schema, projectNameAndRootFormat: 'derived' },
+      projectConfiguration
+    );
 
     expect(result.relativeToRootDestination).toEqual('packages/my/library');
   });

--- a/packages/workspace/src/generators/move/lib/normalize-schema.ts
+++ b/packages/workspace/src/generators/move/lib/normalize-schema.ts
@@ -31,9 +31,10 @@ export async function normalizeSchema(
 
   return {
     ...schema,
-    destination: normalizePathSlashes(schema.destination),
     importPath,
+    updateImportPath: schema.updateImportPath && !!importPath,
     newProjectName,
+    destination: undefined,
     relativeToRootDestination: destination,
   };
 }
@@ -64,8 +65,10 @@ async function determineProjectNameAndRootOptions(
     options,
     projectConfiguration
   );
+  const nxJson = readNxJson(tree);
   const format =
     options.projectNameAndRootFormat ??
+    nxJson.workspaceLayout?.projectNameAndRootFormat ??
     (await determineFormat(tree, formats, options));
 
   return formats[format];

--- a/packages/workspace/src/generators/move/lib/run-angular-plugin.ts
+++ b/packages/workspace/src/generators/move/lib/run-angular-plugin.ts
@@ -1,12 +1,12 @@
 import type { Tree } from '@nx/devkit';
-import type { Schema } from '../schema';
+import type { NormalizedSchema, Schema } from '../schema';
 
 type PluginOptions = {
   oldProjectName: string;
   newProjectName: string;
 };
 
-export async function runAngularPlugin(tree: Tree, schema: Schema) {
+export async function runAngularPlugin(tree: Tree, schema: NormalizedSchema) {
   let move: (tree: Tree, schema: PluginOptions) => Promise<void>;
   try {
     // nx-ignore-next-line

--- a/packages/workspace/src/generators/move/lib/update-build-targets.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-build-targets.spec.ts
@@ -7,7 +7,6 @@ import * as nxDevkit from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { NormalizedSchema } from '../schema';
 import { updateBuildTargets } from './update-build-targets';
-import { array } from 'yargs';
 
 describe('updateBuildTargets', () => {
   let tree: Tree;
@@ -16,13 +15,11 @@ describe('updateBuildTargets', () => {
   beforeEach(async () => {
     schema = {
       projectName: 'my-source',
-      destination: 'subfolder/my-destination',
-      importPath: '@proj/subfolder-my-destination',
-      updateImportPath: true,
+      updateImportPath: false,
       newProjectName: 'subfolder-my-destination',
-      relativeToRootDestination: 'libs/subfolder/my-destination',
+      relativeToRootDestination: 'subfolder/my-destination',
     };
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'my-source', {
       root: 'libs/my-source',
       targets: {

--- a/packages/workspace/src/generators/move/lib/update-cypress-config.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-cypress-config.spec.ts
@@ -20,14 +20,13 @@ describe('updateCypressConfig', () => {
   beforeEach(async () => {
     schema = {
       projectName: 'my-lib',
-      destination: 'my-destination',
       importPath: '@proj/my-destination',
       updateImportPath: true,
       newProjectName: 'my-destination',
       relativeToRootDestination: 'my-destination',
     };
 
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
     await libraryGenerator(tree, {
       name: 'my-lib',
       projectNameAndRootFormat: 'as-provided',

--- a/packages/workspace/src/generators/move/lib/update-default-project.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-default-project.spec.ts
@@ -12,7 +12,7 @@ describe('updateDefaultProject', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'my-source', {
       root: 'libs/my-source',
       targets: {},
@@ -29,11 +29,10 @@ describe('updateDefaultProject', () => {
   it('should update the default project', async () => {
     const schema: NormalizedSchema = {
       projectName: 'my-source',
-      destination: 'subfolder/my-destination',
       importPath: '@proj/subfolder-my-destination',
       updateImportPath: true,
       newProjectName: 'subfolder-my-destination',
-      relativeToRootDestination: 'libs/subfolder/my-destination',
+      relativeToRootDestination: 'subfolder/my-destination',
     };
 
     updateDefaultProject(tree, schema);

--- a/packages/workspace/src/generators/move/lib/update-eslint-config.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-eslint-config.spec.ts
@@ -21,14 +21,13 @@ describe('updateEslint', () => {
   beforeEach(async () => {
     schema = {
       projectName: 'my-lib',
-      destination: 'shared/my-destination',
       importPath: '@proj/shared-my-destination',
       updateImportPath: true,
       newProjectName: 'shared-my-destination',
       relativeToRootDestination: 'shared/my-destination',
     };
 
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should handle .eslintrc.json not existing', async () => {
@@ -80,7 +79,6 @@ describe('updateEslint', () => {
 
     const newSchema = {
       projectName: 'api-test',
-      destination: 'test',
       importPath: '@proj/test',
       updateImportPath: true,
       newProjectName: 'test',
@@ -239,14 +237,13 @@ describe('updateEslint (flat config)', () => {
   beforeEach(async () => {
     schema = {
       projectName: 'my-lib',
-      destination: 'shared/my-destination',
       importPath: '@proj/shared-my-destination',
       updateImportPath: true,
       newProjectName: 'shared-my-destination',
       relativeToRootDestination: 'shared/my-destination',
     };
 
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
     tree.delete('.eslintrc.json');
     tree.write('eslint.config.js', `module.exports = [];`);
   });
@@ -301,7 +298,6 @@ describe('updateEslint (flat config)', () => {
 
     const newSchema = {
       projectName: 'api-test',
-      destination: 'test',
       importPath: '@proj/test',
       updateImportPath: true,
       newProjectName: 'test',

--- a/packages/workspace/src/generators/move/lib/update-implicit-dependencies.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-implicit-dependencies.spec.ts
@@ -14,14 +14,13 @@ describe('updateImplicitDepenencies', () => {
   beforeEach(async () => {
     schema = {
       projectName: 'my-lib',
-      destination: 'my-destination',
       importPath: '@proj/my-destination',
       updateImportPath: true,
       newProjectName: 'my-destination',
-      relativeToRootDestination: 'libs/my-destination',
+      relativeToRootDestination: 'my-destination',
     };
 
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
 
     addProjectConfiguration(tree, 'my-lib', {
       root: 'libs/my-lib',

--- a/packages/workspace/src/generators/move/lib/update-imports.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-imports.spec.ts
@@ -17,7 +17,7 @@ describe('updateImports', () => {
   let schema: Schema;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
 
     schema = {
       projectName: 'my-source',
@@ -100,7 +100,6 @@ describe('updateImports', () => {
       tree,
       {
         projectName: 'tab',
-        destination: 'tabs',
         importPath: '@proj/tabs',
         updateImportPath: true,
         newProjectName: 'tabs',
@@ -148,7 +147,6 @@ describe('updateImports', () => {
       tree,
       {
         projectName: 'tab',
-        destination: 'tabs',
         importPath: '@proj/tabs',
         updateImportPath: true,
         newProjectName: 'tabs',
@@ -195,7 +193,6 @@ describe('updateImports', () => {
       tree,
       {
         projectName: 'tab',
-        destination: 'tabs',
         importPath: '@proj/tabs',
         updateImportPath: true,
         newProjectName: 'tabs',
@@ -248,7 +245,6 @@ describe('updateImports', () => {
       tree,
       {
         projectName: 'tab',
-        destination: 'tabs',
         importPath: '@proj/tabs',
         updateImportPath: true,
         newProjectName: 'tabs',

--- a/packages/workspace/src/generators/move/lib/update-imports.ts
+++ b/packages/workspace/src/generators/move/lib/update-imports.ts
@@ -27,7 +27,6 @@ let tsModule: typeof import('typescript');
 /**
  * Updates all the imports in the workspace and modifies the tsconfig appropriately.
  *
- * @param schema The options provided to the schematic
  */
 export function updateImports(
   tree: Tree,

--- a/packages/workspace/src/generators/move/lib/update-jest-config.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-jest-config.spec.ts
@@ -10,7 +10,7 @@ describe('updateJestConfig', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should handle jest config not existing', async () => {
@@ -21,7 +21,6 @@ describe('updateJestConfig', () => {
     const projectConfig = readProjectConfiguration(tree, 'my-source');
     const schema: NormalizedSchema = {
       projectName: 'my-source',
-      destination: 'my-destination',
       importPath: '@proj/my-destination',
       updateImportPath: true,
       newProjectName: 'my-destination',
@@ -51,7 +50,6 @@ describe('updateJestConfig', () => {
     tree.write(jestConfigPath, jestConfig);
     const schema: NormalizedSchema = {
       projectName: 'my-source',
-      destination: 'my-destination',
       importPath: '@proj/my-destination',
       updateImportPath: true,
       newProjectName: 'my-destination',
@@ -88,7 +86,6 @@ describe('updateJestConfig', () => {
     tree.write(jestConfigPath, jestConfig);
     const schema: NormalizedSchema = {
       projectName: 'my-source',
-      destination: 'my-source/data-access',
       importPath: '@proj/my-soource-data-access',
       updateImportPath: true,
       newProjectName: 'my-source-data-access',
@@ -128,7 +125,6 @@ describe('updateJestConfig', () => {
     tree.write(jestConfigPath, jestConfig);
     const schema: NormalizedSchema = {
       projectName: 'some-test-dir-my-source',
-      destination: 'other/test/dir/my-destination',
       importPath: '@proj/other-test-dir-my-destination',
       updateImportPath: true,
       newProjectName: 'other-test-dir-my-destination',
@@ -165,7 +161,6 @@ describe('updateJestConfig', () => {
     );
     const schema: NormalizedSchema = {
       projectName: 'some-test-dir-my-source',
-      destination: 'other/test/dir/my-destination',
       importPath: '@proj/other-test-dir-my-destination',
       updateImportPath: true,
       newProjectName: 'other-test-dir-my-destination',
@@ -205,7 +200,6 @@ module.exports = {
     );
     const schema: NormalizedSchema = {
       projectName: 'some-test-dir-my-source',
-      destination: 'other/test/dir/my-destination',
       importPath: '@proj/other-test-dir-my-destination',
       updateImportPath: true,
       newProjectName: 'other-test-dir-my-destination',
@@ -246,7 +240,6 @@ module.exports = {
     );
     const schema: NormalizedSchema = {
       projectName: 'some-test-dir-my-source',
-      destination: 'other/test/dir/my-destination',
       importPath: '@proj/other-test-dir-my-destination',
       updateImportPath: true,
       newProjectName: 'other-test-dir-my-destination',

--- a/packages/workspace/src/generators/move/lib/update-package-json.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-package-json.spec.ts
@@ -13,14 +13,13 @@ describe('updatePackageJson', () => {
   beforeEach(async () => {
     schema = {
       projectName: 'my-lib',
-      destination: 'my-destination',
       importPath: '@proj/my-destination',
       updateImportPath: true,
       newProjectName: 'my-destination',
       relativeToRootDestination: 'my-destination',
     };
 
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
     await libraryGenerator(tree, {
       name: 'my-lib',
       projectNameAndRootFormat: 'as-provided',

--- a/packages/workspace/src/generators/move/lib/update-project-root-files.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-project-root-files.spec.ts
@@ -10,7 +10,7 @@ describe('updateProjectRootFiles', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should update the relative root in files at the root of the project', async () => {
@@ -32,7 +32,6 @@ describe('updateProjectRootFiles', () => {
     tree.write(testFilePath, testFile);
     const schema: NormalizedSchema = {
       projectName: 'my-source',
-      destination: 'subfolder/my-destination',
       importPath: '@proj/subfolder-my-destination',
       updateImportPath: true,
       newProjectName: 'subfolder-my-destination',

--- a/packages/workspace/src/generators/move/lib/update-readme.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-readme.spec.ts
@@ -14,14 +14,13 @@ describe('updateReadme', () => {
   beforeEach(async () => {
     schema = {
       projectName: 'my-lib',
-      destination: 'shared/my-destination',
       importPath: '@proj/shared-my-destination',
       updateImportPath: true,
       newProjectName: 'shared-my-destination',
       relativeToRootDestination: 'shared/my-destination',
     };
 
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should handle README.md not existing', async () => {

--- a/packages/workspace/src/generators/move/lib/update-storybook-config.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-storybook-config.spec.ts
@@ -10,7 +10,7 @@ describe('updateStorybookConfig', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should handle storybook config not existing', async () => {
@@ -21,7 +21,6 @@ describe('updateStorybookConfig', () => {
     const projectConfig = readProjectConfiguration(tree, 'my-source');
     const schema: NormalizedSchema = {
       projectName: 'my-source',
-      destination: 'my-destination',
       importPath: '@proj/my-destination',
       updateImportPath: true,
       newProjectName: 'my-destination',
@@ -48,7 +47,6 @@ describe('updateStorybookConfig', () => {
     tree.write(storybookMainPath, storybookMain);
     const schema: NormalizedSchema = {
       projectName: 'my-source',
-      destination: 'namespace/my-destination',
       importPath: '@proj/namespace-my-destination',
       updateImportPath: true,
       newProjectName: 'namespace-my-destination',
@@ -77,7 +75,6 @@ describe('updateStorybookConfig', () => {
     tree.write(storybookWebpackConfigPath, storybookWebpackConfig);
     const schema: NormalizedSchema = {
       projectName: 'my-source',
-      destination: 'namespace/my-destination',
       importPath: '@proj/namespace-my-destination',
       updateImportPath: true,
       newProjectName: 'namespace-my-destination',
@@ -119,7 +116,6 @@ describe('updateStorybookConfig', () => {
       tree.write(storybookNestedMainPath, storybookNestedMain);
       const schema: NormalizedSchema = {
         projectName: 'my-source',
-        destination: 'namespace/my-destination',
         importPath: '@proj/namespace-my-destination',
         updateImportPath: true,
         newProjectName: 'namespace-my-destination',
@@ -166,7 +162,6 @@ describe('updateStorybookConfig', () => {
       );
       const schema: NormalizedSchema = {
         projectName: 'my-source',
-        destination: 'namespace/my-destination',
         importPath: '@proj/namespace-my-destination',
         updateImportPath: true,
         newProjectName: 'namespace-my-destination',

--- a/packages/workspace/src/generators/move/move.spec.ts
+++ b/packages/workspace/src/generators/move/move.spec.ts
@@ -8,7 +8,7 @@ const { libraryGenerator } = require('@nx/js');
 describe('move', () => {
   let tree: Tree;
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should update jest config when moving down directories', async () => {
@@ -178,6 +178,8 @@ describe('move', () => {
   });
 
   it('should move project correctly when --project-name-and-root-format=derived', async () => {
+    tree.write('/apps/.gitignore', '');
+    tree.write('/libs/.gitignore', '');
     await libraryGenerator(tree, {
       name: 'my-lib',
       projectNameAndRootFormat: 'derived',

--- a/packages/workspace/src/generators/move/schema.d.ts
+++ b/packages/workspace/src/generators/move/schema.d.ts
@@ -12,4 +12,5 @@ export interface Schema {
 
 export interface NormalizedSchema extends Schema {
   relativeToRootDestination: string;
+  destination?: undefined;
 }

--- a/packages/workspace/src/generators/npm-package/npm-package.spec.ts
+++ b/packages/workspace/src/generators/npm-package/npm-package.spec.ts
@@ -1,9 +1,7 @@
 import {
   readJson,
-  readNxJson,
   readProjectConfiguration,
   Tree,
-  updateNxJson,
   writeJson,
 } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
@@ -12,19 +10,14 @@ import { npmPackageGenerator } from './npm-package';
 describe('@nx/workspace:npm-package', () => {
   let tree: Tree;
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-
-    const nxJson = readNxJson(tree);
-    nxJson.workspaceLayout = {
-      appsDir: 'packages',
-      libsDir: 'packages',
-    };
-    updateNxJson(tree, nxJson);
+    tree = createTreeWithEmptyWorkspace();
   });
 
   it('should generate a minimal package', async () => {
     await npmPackageGenerator(tree, {
       name: 'my-package',
+      directory: 'packages/my-package',
+      projectNameAndRootFormat: 'as-provided',
     });
 
     const project = readProjectConfiguration(tree, 'my-package');
@@ -40,6 +33,8 @@ describe('@nx/workspace:npm-package', () => {
   it('should only generate package.json and index.js', async () => {
     await npmPackageGenerator(tree, {
       name: 'my-package',
+      directory: 'packages/my-package',
+      projectNameAndRootFormat: 'as-provided',
     });
 
     expect(tree.read('packages/my-package/package.json').toString())
@@ -75,6 +70,8 @@ describe('@nx/workspace:npm-package', () => {
 
       await npmPackageGenerator(tree, {
         name: 'my-package',
+        directory: 'packages/my-package',
+        projectNameAndRootFormat: 'as-provided',
       });
 
       expect(readJson(tree, 'packages/my-package/package.json')).toEqual(


### PR DESCRIPTION
…-provided in tests

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`npm-package` and plugin tests still use the derived project name and root.

There are some flags that do nothing for the `@nx/plugin:plugin` generator.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`npm-package` and plugins test use the project name and root as provided.

There are some flags that do nothing for the `@nx/plugin:plugin` generator.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
