### PR TITLE
fix(misc): calculate cwd relative path correctly for generators and executors

### DIFF
--- a/packages/devkit/src/executors/read-target-options.ts
+++ b/packages/devkit/src/executors/read-target-options.ts
@@ -57,6 +57,6 @@ export function readTargetOptions<T = any>(
     targetConfiguration,
     schema,
     defaultProject,
-    relative(context.cwd, context.root)
+    relative(context.root, context.cwd)
   ) as T;
 }

--- a/packages/nx/src/command-line/generate/generate.ts
+++ b/packages/nx/src/command-line/generate/generate.ts
@@ -364,7 +364,7 @@ export async function generate(cwd: string, args: { [k: string]: any }) {
         projectsConfigurations,
         nxJsonConfiguration
       ),
-      relative(cwd, workspaceRoot),
+      relative(workspaceRoot, cwd),
       verbose
     );
 

--- a/packages/nx/src/command-line/run/run.ts
+++ b/packages/nx/src/command-line/run/run.ts
@@ -150,7 +150,7 @@ async function runExecutorInternal<T extends { success: boolean }>(
     targetConfig,
     schema,
     project,
-    relative(cwd, root),
+    relative(root, cwd),
     isVerbose
   );
 


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/nrwl/nx/pull/18229 where the arguments passed to `relative` were inverted.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18805 
