### PR TITLE
fix(linter): fix dep-checks projPackageJsonDeps caching for IDE

### DIFF
--- a/packages/eslint-plugin/src/rules/dependency-checks.ts
+++ b/packages/eslint-plugin/src/rules/dependency-checks.ts
@@ -148,11 +148,8 @@ export default createESLintRule<Options, MessageIds>({
       'package.json'
     );
 
-    globalThis.projPackageJsonDeps ??= getProductionDependencies(
-      getPackageJson(projPackageJsonPath)
-    );
     const projPackageJsonDeps: Record<string, string> =
-      globalThis.projPackageJsonDeps;
+      getProductionDependencies(projPackageJsonPath);
     const rootPackageJsonDeps = getAllDependencies(rootPackageJson);
 
     function validateMissingDependencies(node: AST.JSONProperty) {

--- a/packages/eslint-plugin/src/utils/package-json-utils.ts
+++ b/packages/eslint-plugin/src/utils/package-json-utils.ts
@@ -1,6 +1,7 @@
-import { ProjectFileMap, readJsonFile } from '@nx/devkit';
+import { readJsonFile } from '@nx/devkit';
 import { existsSync } from 'fs';
 import { PackageJson } from 'nx/src/utils/package-json';
+import { isTerminalRun } from './runtime-lint-utils';
 
 export function getAllDependencies(
   packageJson: PackageJson
@@ -14,13 +15,18 @@ export function getAllDependencies(
 }
 
 export function getProductionDependencies(
-  packageJson: PackageJson
+  packageJsonPath: string
 ): Record<string, string> {
-  return {
-    ...packageJson.dependencies,
-    ...packageJson.peerDependencies,
-    ...packageJson.optionalDependencies,
-  };
+  if (!globalThis.projPackageJsonDeps || !isTerminalRun()) {
+    const packageJson = getPackageJson(packageJsonPath);
+    globalThis.projPackageJsonDeps = {
+      ...packageJson.dependencies,
+      ...packageJson.peerDependencies,
+      ...packageJson.optionalDependencies,
+    };
+  }
+
+  return globalThis.projPackageJsonDeps;
 }
 
 export function getPackageJson(path: string): PackageJson {

--- a/packages/eslint-plugin/src/utils/project-graph-utils.ts
+++ b/packages/eslint-plugin/src/utils/project-graph-utils.ts
@@ -19,13 +19,13 @@ export function ensureGlobalProjectGraph(ruleName: string) {
    * Enforce every IDE change to get a fresh nxdeps.json
    */
   if (
-    !(global as any).projectGraph ||
-    !(global as any).projectRootMappings ||
-    !(global as any).projectFileMap ||
+    !globalThis.projectGraph ||
+    !globalThis.projectRootMappings ||
+    !globalThis.projectFileMap ||
     !isTerminalRun()
   ) {
     const nxJson = readNxJson();
-    (global as any).workspaceLayout = nxJson.workspaceLayout;
+    globalThis.workspaceLayout = nxJson.workspaceLayout;
 
     /**
      * Because there are a number of ways in which the rule can be invoked (executor vs ESLint CLI vs IDE Plugin),
@@ -33,12 +33,12 @@ export function ensureGlobalProjectGraph(ruleName: string) {
      */
     try {
       const projectGraph = readCachedProjectGraph();
-      (global as any).projectGraph = projectGraph;
-      (global as any).projectRootMappings = createProjectRootMappings(
+      globalThis.projectGraph = projectGraph;
+      globalThis.projectRootMappings = createProjectRootMappings(
         projectGraph.nodes
       );
-      (global as any).projectFileMap = readProjectFileMapCache().projectFileMap;
-      (global as any).targetProjectLocator = new TargetProjectLocator(
+      globalThis.projectFileMap = readProjectFileMapCache().projectFileMap;
+      globalThis.targetProjectLocator = new TargetProjectLocator(
         projectGraph.nodes,
         projectGraph.externalNodes
       );
@@ -61,9 +61,9 @@ export function readProjectGraph(ruleName: string): {
 } {
   ensureGlobalProjectGraph(ruleName);
   return {
-    projectGraph: (global as any).projectGraph,
-    projectFileMap: (global as any).projectFileMap,
-    projectRootMappings: (global as any).projectRootMappings,
-    targetProjectLocator: (global as any).targetProjectLocator,
+    projectGraph: globalThis.projectGraph,
+    projectFileMap: globalThis.projectFileMap,
+    projectRootMappings: globalThis.projectRootMappings,
+    targetProjectLocator: globalThis.targetProjectLocator,
   };
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The `projPackageJsonDeps` is cached per runtime, which causes false failures on IDE when switching between projects.

## Expected Behavior
The  `projPackageJsonDeps` should not be cached for IDE runs.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
