### PR TITLE
fix(angular): use production build for static-serve for MF

### DIFF
--- a/packages/angular/src/generators/setup-mf/lib/setup-serve-target.ts
+++ b/packages/angular/src/generators/setup-mf/lib/setup-serve-target.ts
@@ -24,7 +24,7 @@ export function setupServeTarget(host: Tree, options: Schema) {
   if (options.mfType === 'remote') {
     appConfig.targets['serve-static'] = {
       executor: '@nx/web:file-server',
-      defaultConfiguration: 'development',
+      defaultConfiguration: 'production',
       options: {
         buildTarget: `${options.appName}:build`,
         port: options.port,

--- a/packages/react/src/rules/update-module-federation-project.ts
+++ b/packages/react/src/rules/update-module-federation-project.ts
@@ -35,7 +35,7 @@ export function updateModuleFederationProject(
   // `serve-static` for remotes that don't need to be in development mode
   projectConfig.targets['serve-static'] = {
     executor: '@nx/web:file-server',
-    defaultConfiguration: 'development',
+    defaultConfiguration: 'production',
     options: {
       buildTarget: `${options.projectName}:build`,
       port: options.devServerPort,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We currently use development build configuration when serving the static file-server for remotes.
As this uses the development configuration, there's a strong chance that no cache currently exists for these remotes.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Switch to production build configuration when serving the static file-server for remotes.

The result is two-fold:

1. Increased probability of cache hits as CI will produce cache that can be used.
2. These remotes that are served statically are supposed to emulate the real remote. They're not intended to be changed and worked on during local dev. They do not need to be served in development, and it is more correct and accurate to serve them as production.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
