### PR TITLE
chore(react-native): update react-native plugin unit tests to use "as-provided"

### DIFF
--- a/packages/react-native/src/generators/application/application.spec.ts
+++ b/packages/react-native/src/generators/application/application.spec.ts
@@ -12,7 +12,7 @@ describe('app', () => {
   let appTree: Tree;
 
   beforeEach(() => {
-    appTree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    appTree = createTreeWithEmptyWorkspace();
     appTree.write('.gitignore', '');
   });
 
@@ -23,10 +23,11 @@ describe('app', () => {
       linter: Linter.EsLint,
       e2eTestRunner: 'none',
       install: false,
+      projectNameAndRootFormat: 'as-provided',
     });
     const projects = getProjects(appTree);
 
-    expect(projects.get('my-app').root).toEqual('apps/my-app');
+    expect(projects.get('my-app').root).toEqual('my-app');
   });
 
   it('should update nx.json', async () => {
@@ -37,6 +38,7 @@ describe('app', () => {
       linter: Linter.EsLint,
       e2eTestRunner: 'none',
       install: false,
+      projectNameAndRootFormat: 'as-provided',
     });
 
     const projectConfiguration = readProjectConfiguration(appTree, 'my-app');
@@ -52,15 +54,16 @@ describe('app', () => {
       linter: Linter.EsLint,
       e2eTestRunner: 'none',
       install: false,
+      projectNameAndRootFormat: 'as-provided',
     });
-    expect(appTree.exists('apps/my-app/src/app/App.tsx')).toBeTruthy();
-    expect(appTree.exists('apps/my-app/src/main.tsx')).toBeTruthy();
+    expect(appTree.exists('my-app/src/app/App.tsx')).toBeTruthy();
+    expect(appTree.exists('my-app/src/main.tsx')).toBeTruthy();
 
-    const tsconfig = readJson(appTree, 'apps/my-app/tsconfig.json');
-    expect(tsconfig.extends).toEqual('../../tsconfig.base.json');
+    const tsconfig = readJson(appTree, 'my-app/tsconfig.json');
+    expect(tsconfig.extends).toEqual('../tsconfig.base.json');
 
-    expect(appTree.exists('apps/my-app/.eslintrc.json')).toBe(true);
-    expect(appTree.read('apps/my-app/jest.config.ts', 'utf-8'))
+    expect(appTree.exists('my-app/.eslintrc.json')).toBe(true);
+    expect(appTree.read('my-app/jest.config.ts', 'utf-8'))
       .toMatchInlineSnapshot(`
       "module.exports = {
         displayName: 'my-app',
@@ -71,7 +74,7 @@ describe('app', () => {
         moduleNameMapper: {
           '\\\\.svg$': '@nx/react-native/plugins/jest/svg-mock',
         },
-        coverageDirectory: '../../coverage/apps/my-app',
+        coverageDirectory: '../coverage/my-app',
       };
       "
     `);
@@ -84,6 +87,7 @@ describe('app', () => {
       linter: Linter.EsLint,
       e2eTestRunner: 'none',
       install: false,
+      projectNameAndRootFormat: 'as-provided',
     });
     const targets = readProjectConfiguration(appTree, 'my-app').targets;
     expect(targets.test).toBeDefined();
@@ -98,10 +102,11 @@ describe('app', () => {
       linter: Linter.EsLint,
       e2eTestRunner: 'none',
       install: false,
+      projectNameAndRootFormat: 'as-provided',
     });
 
-    const tsconfig = readJson(appTree, 'apps/my-app/tsconfig.json');
-    expect(tsconfig.extends).toEqual('../../tsconfig.json');
+    const tsconfig = readJson(appTree, 'my-app/tsconfig.json');
+    expect(tsconfig.extends).toEqual('../tsconfig.json');
   });
 
   describe('detox', () => {
@@ -112,18 +117,14 @@ describe('app', () => {
         linter: Linter.EsLint,
         e2eTestRunner: 'detox',
         install: false,
+        projectNameAndRootFormat: 'as-provided',
       });
 
       const projects = getProjects(appTree);
-      expect(projects.get('my-dir-my-app').root).toEqual('apps/my-dir/my-app');
+      expect(projects.get('my-app').root).toEqual('my-dir');
 
-      expect(
-        appTree.exists('apps/my-dir/my-app-e2e/.detoxrc.json')
-      ).toBeTruthy();
-      const detoxrc = appTree.read(
-        'apps/my-dir/my-app-e2e/.detoxrc.json',
-        'utf-8'
-      );
+      expect(appTree.exists('my-dir-e2e/.detoxrc.json')).toBeTruthy();
+      const detoxrc = appTree.read('my-dir-e2e/.detoxrc.json', 'utf-8');
       // Strip trailing commas
       const detoxrcJson = JSON.parse(
         detoxrc.replace(/(?<=(true|false|null|["\d}\]])\s*),(?=\s*[}\]])/g, '')
@@ -131,30 +132,30 @@ describe('app', () => {
       expect(detoxrcJson.apps).toEqual({
         'android.debug': {
           binaryPath:
-            '../../../apps/my-dir/my-app/android/app/build/outputs/apk/debug/app-debug.apk',
+            '../my-dir/android/app/build/outputs/apk/debug/app-debug.apk',
           build:
-            'cd ../../../apps/my-dir/my-app/android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
+            'cd ../my-dir/android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
           type: 'android.apk',
         },
         'android.release': {
           binaryPath:
-            '../../../apps/my-dir/my-app/android/app/build/outputs/apk/release/app-release.apk',
+            '../my-dir/android/app/build/outputs/apk/release/app-release.apk',
           build:
-            'cd ../../../apps/my-dir/my-app/android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release',
+            'cd ../my-dir/android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release',
           type: 'android.apk',
         },
         'ios.debug': {
           binaryPath:
-            '../../../apps/my-dir/my-app/ios/build/Build/Products/Debug-iphonesimulator/MyApp.app',
+            '../my-dir/ios/build/Build/Products/Debug-iphonesimulator/MyApp.app',
           build:
-            "cd ../../../apps/my-dir/my-app/ios && xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
+            "cd ../my-dir/ios && xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
           type: 'ios.app',
         },
         'ios.release': {
           binaryPath:
-            '../../../apps/my-dir/my-app/ios/build/Build/Products/Release-iphonesimulator/MyApp.app',
+            '../my-dir/ios/build/Build/Products/Release-iphonesimulator/MyApp.app',
           build:
-            "cd ../../../apps/my-dir/my-app/ios && xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
+            "cd ../my-dir/ios && xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
           type: 'ios.app',
         },
       });
@@ -166,12 +167,13 @@ describe('app', () => {
         linter: Linter.EsLint,
         e2eTestRunner: 'detox',
         install: false,
+        projectNameAndRootFormat: 'as-provided',
       });
 
       const projects = getProjects(appTree);
-      expect(projects.get('my-app').root).toEqual('apps/my-app');
+      expect(projects.get('my-app').root).toEqual('my-app');
 
-      const detoxrc = appTree.read('apps/my-app-e2e/.detoxrc.json', 'utf-8');
+      const detoxrc = appTree.read('my-app-e2e/.detoxrc.json', 'utf-8');
       // Strip trailing commas
       const detoxrcJson = JSON.parse(
         detoxrc.replace(/(?<=(true|false|null|["\d}\]])\s*),(?=\s*[}\]])/g, '')
@@ -179,30 +181,30 @@ describe('app', () => {
       expect(detoxrcJson.apps).toEqual({
         'android.debug': {
           binaryPath:
-            '../../apps/my-app/android/app/build/outputs/apk/debug/app-debug.apk',
+            '../my-app/android/app/build/outputs/apk/debug/app-debug.apk',
           build:
-            'cd ../../apps/my-app/android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
+            'cd ../my-app/android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
           type: 'android.apk',
         },
         'android.release': {
           binaryPath:
-            '../../apps/my-app/android/app/build/outputs/apk/release/app-release.apk',
+            '../my-app/android/app/build/outputs/apk/release/app-release.apk',
           build:
-            'cd ../../apps/my-app/android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release',
+            'cd ../my-app/android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release',
           type: 'android.apk',
         },
         'ios.debug': {
           binaryPath:
-            '../../apps/my-app/ios/build/Build/Products/Debug-iphonesimulator/MyApp.app',
+            '../my-app/ios/build/Build/Products/Debug-iphonesimulator/MyApp.app',
           build:
-            "cd ../../apps/my-app/ios && xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
+            "cd ../my-app/ios && xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
           type: 'ios.app',
         },
         'ios.release': {
           binaryPath:
-            '../../apps/my-app/ios/build/Build/Products/Release-iphonesimulator/MyApp.app',
+            '../my-app/ios/build/Build/Products/Release-iphonesimulator/MyApp.app',
           build:
-            "cd ../../apps/my-app/ios && xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
+            "cd ../my-app/ios && xcodebuild -workspace MyApp.xcworkspace -scheme MyApp -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath ./build -quiet",
           type: 'ios.app',
         },
       });
@@ -220,6 +222,7 @@ describe('app', () => {
         e2eTestRunner: 'none',
         install: false,
         skipPackageJson: true,
+        projectNameAndRootFormat: 'as-provided',
       });
 
       expect(readJson(appTree, 'package.json')).toEqual(packageJsonBefore);

--- a/packages/react-native/src/generators/application/lib/nomalize-options.spec.ts
+++ b/packages/react-native/src/generators/application/lib/nomalize-options.spec.ts
@@ -8,7 +8,7 @@ describe('Normalize Options', () => {
   let appTree: Tree;
 
   beforeEach(() => {
-    appTree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    appTree = createTreeWithEmptyWorkspace();
   });
 
   it('should normalize options with name in kebab case', async () => {
@@ -17,19 +17,20 @@ describe('Normalize Options', () => {
       linter: Linter.EsLint,
       e2eTestRunner: 'none',
       install: false,
+      projectNameAndRootFormat: 'as-provided',
     };
     const options = await normalizeOptions(appTree, schema);
     expect(options).toEqual({
-      androidProjectRoot: 'apps/my-app/android',
-      appProjectRoot: 'apps/my-app',
+      androidProjectRoot: 'my-app/android',
+      appProjectRoot: 'my-app',
       className: 'MyApp',
       displayName: 'MyApp',
-      iosProjectRoot: 'apps/my-app/ios',
+      iosProjectRoot: 'my-app/ios',
       lowerCaseName: 'myapp',
       name: 'my-app',
       parsedTags: [],
       projectName: 'my-app',
-      projectNameAndRootFormat: 'derived',
+      projectNameAndRootFormat: 'as-provided',
       linter: Linter.EsLint,
       entryFile: 'src/main.tsx',
       e2eTestRunner: 'none',
@@ -43,19 +44,20 @@ describe('Normalize Options', () => {
       name: 'myApp',
       e2eTestRunner: 'none',
       install: false,
+      projectNameAndRootFormat: 'as-provided',
     };
     const options = await normalizeOptions(appTree, schema);
     expect(options).toEqual({
-      androidProjectRoot: 'apps/my-app/android',
-      appProjectRoot: 'apps/my-app',
+      androidProjectRoot: 'my-app/android',
+      appProjectRoot: 'my-app',
       className: 'MyApp',
       displayName: 'MyApp',
-      iosProjectRoot: 'apps/my-app/ios',
+      iosProjectRoot: 'my-app/ios',
       lowerCaseName: 'myapp',
       name: 'my-app',
       parsedTags: [],
       projectName: 'my-app',
-      projectNameAndRootFormat: 'derived',
+      projectNameAndRootFormat: 'as-provided',
       entryFile: 'src/main.tsx',
       e2eTestRunner: 'none',
       unitTestRunner: 'jest',
@@ -66,23 +68,24 @@ describe('Normalize Options', () => {
   it('should normalize options with directory', async () => {
     const schema: Schema = {
       name: 'my-app',
-      directory: 'directory',
+      directory: 'directory/my-app',
       e2eTestRunner: 'none',
       install: false,
+      projectNameAndRootFormat: 'as-provided',
     };
     const options = await normalizeOptions(appTree, schema);
     expect(options).toEqual({
-      androidProjectRoot: 'apps/directory/my-app/android',
-      appProjectRoot: 'apps/directory/my-app',
+      androidProjectRoot: 'directory/my-app/android',
+      appProjectRoot: 'directory/my-app',
       className: 'MyApp',
       displayName: 'MyApp',
-      iosProjectRoot: 'apps/directory/my-app/ios',
+      iosProjectRoot: 'directory/my-app/ios',
       lowerCaseName: 'myapp',
       name: 'my-app',
-      directory: 'directory',
+      directory: 'directory/my-app',
       parsedTags: [],
-      projectName: 'directory-my-app',
-      projectNameAndRootFormat: 'derived',
+      projectName: 'my-app',
+      projectNameAndRootFormat: 'as-provided',
       entryFile: 'src/main.tsx',
       e2eTestRunner: 'none',
       unitTestRunner: 'jest',
@@ -95,19 +98,20 @@ describe('Normalize Options', () => {
       name: 'directory/my-app',
       e2eTestRunner: 'none',
       install: false,
+      projectNameAndRootFormat: 'as-provided',
     };
     const options = await normalizeOptions(appTree, schema);
     expect(options).toEqual({
-      androidProjectRoot: 'apps/directory/my-app/android',
-      appProjectRoot: 'apps/directory/my-app',
+      androidProjectRoot: 'directory/my-app/android',
+      appProjectRoot: 'directory/my-app',
       className: 'DirectoryMyApp',
       displayName: 'DirectoryMyApp',
-      iosProjectRoot: 'apps/directory/my-app/ios',
+      iosProjectRoot: 'directory/my-app/ios',
       lowerCaseName: 'directorymyapp',
       name: 'directory/my-app',
       parsedTags: [],
-      projectName: 'directory-my-app',
-      projectNameAndRootFormat: 'derived',
+      projectName: 'directory/my-app',
+      projectNameAndRootFormat: 'as-provided',
       entryFile: 'src/main.tsx',
       e2eTestRunner: 'none',
       unitTestRunner: 'jest',
@@ -121,19 +125,20 @@ describe('Normalize Options', () => {
       displayName: 'My App',
       e2eTestRunner: 'none',
       install: false,
+      projectNameAndRootFormat: 'as-provided',
     };
     const options = await normalizeOptions(appTree, schema);
     expect(options).toEqual({
-      androidProjectRoot: 'apps/my-app/android',
-      appProjectRoot: 'apps/my-app',
+      androidProjectRoot: 'my-app/android',
+      appProjectRoot: 'my-app',
       className: 'MyApp',
       displayName: 'My App',
-      iosProjectRoot: 'apps/my-app/ios',
+      iosProjectRoot: 'my-app/ios',
       lowerCaseName: 'myapp',
       name: 'my-app',
       parsedTags: [],
       projectName: 'my-app',
-      projectNameAndRootFormat: 'derived',
+      projectNameAndRootFormat: 'as-provided',
       entryFile: 'src/main.tsx',
       e2eTestRunner: 'none',
       unitTestRunner: 'jest',

--- a/packages/react-native/src/generators/component-story/component-story.spec.ts
+++ b/packages/react-native/src/generators/component-story/component-story.spec.ts
@@ -9,9 +9,8 @@ import componentGenerator from '../component/component';
 
 describe('react-native:component-story', () => {
   let appTree: Tree;
-  let cmpPath = 'libs/test-ui-lib/src/lib/test-ui-lib/test-ui-lib.tsx';
-  let storyFilePath =
-    'libs/test-ui-lib/src/lib/test-ui-lib/test-ui-lib.stories.tsx';
+  let cmpPath = 'test-ui-lib/src/lib/test-ui-lib/test-ui-lib.tsx';
+  let storyFilePath = 'test-ui-lib/src/lib/test-ui-lib/test-ui-lib.stories.tsx';
 
   describe('default setup', () => {
     beforeEach(async () => {
@@ -34,7 +33,7 @@ describe('react-native:component-story', () => {
           });
         } catch (e) {
           expect(e.message).toContain(
-            'Could not find any React Native component in file libs/test-ui-lib/src/lib/test-ui-lib/test-ui-lib.tsx'
+            'Could not find any React Native component in file test-ui-lib/src/lib/test-ui-lib/test-ui-lib.tsx'
           );
         }
       });
@@ -70,11 +69,11 @@ describe('react-native:component-story', () => {
 
     describe('when using plain JS components', () => {
       let storyFilePathPlain =
-        'libs/test-ui-lib/src/lib/test-ui-libplain.stories.jsx';
+        'test-ui-lib/src/lib/test-ui-libplain.stories.jsx';
 
       beforeEach(async () => {
         appTree.write(
-          'libs/test-ui-lib/src/lib/test-ui-libplain.jsx',
+          'test-ui-lib/src/lib/test-ui-libplain.jsx',
           `import React from 'react';
   
           import './test.scss';
@@ -400,7 +399,7 @@ describe('react-native:component-story', () => {
 });
 
 export async function createTestUILib(libName: string): Promise<Tree> {
-  let appTree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  let appTree = createTreeWithEmptyWorkspace();
   appTree.write('.gitignore', '');
 
   await libraryGenerator(appTree, {
@@ -409,6 +408,7 @@ export async function createTestUILib(libName: string): Promise<Tree> {
     skipFormat: true,
     skipTsConfig: false,
     unitTestRunner: 'jest',
+    projectNameAndRootFormat: 'as-provided',
   });
 
   await componentGenerator(appTree, {

--- a/packages/react-native/src/generators/component/component.spec.ts
+++ b/packages/react-native/src/generators/component/component.spec.ts
@@ -9,7 +9,7 @@ describe('component', () => {
 
   beforeEach(async () => {
     projectName = 'my-lib';
-    appTree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    appTree = createTreeWithEmptyWorkspace();
     appTree.write('.gitignore', '');
     await createApp(appTree, 'my-app');
     await createLib(appTree, projectName);
@@ -21,16 +21,14 @@ describe('component', () => {
     jest.restoreAllMocks();
   });
 
-  it('should generate files', async () => {
+  it('should generate component files', async () => {
     await reactNativeComponentGenerator(appTree, {
       name: 'hello',
       project: projectName,
     });
 
-    expect(appTree.exists('libs/my-lib/src/lib/hello/hello.tsx')).toBeTruthy();
-    expect(
-      appTree.exists('libs/my-lib/src/lib/hello/hello.spec.tsx')
-    ).toBeTruthy();
+    expect(appTree.exists('my-lib/src/lib/hello/hello.tsx')).toBeTruthy();
+    expect(appTree.exists('my-lib/src/lib/hello/hello.spec.tsx')).toBeTruthy();
   });
 
   it('should generate files for an app', async () => {
@@ -39,10 +37,8 @@ describe('component', () => {
       project: 'my-app',
     });
 
-    expect(appTree.exists('apps/my-app/src/app/hello/hello.tsx')).toBeTruthy();
-    expect(
-      appTree.exists('apps/my-app/src/app/hello/hello.spec.tsx')
-    ).toBeTruthy();
+    expect(appTree.exists('my-app/src/app/hello/hello.tsx')).toBeTruthy();
+    expect(appTree.exists('my-app/src/app/hello/hello.spec.tsx')).toBeTruthy();
   });
 
   describe('--export', () => {
@@ -53,7 +49,7 @@ describe('component', () => {
         export: true,
       });
 
-      const indexContent = appTree.read('libs/my-lib/src/index.ts', 'utf-8');
+      const indexContent = appTree.read('my-lib/src/index.ts', 'utf-8');
 
       expect(indexContent).toMatch(/lib\/hello/);
     });
@@ -65,7 +61,7 @@ describe('component', () => {
         export: true,
       });
 
-      const indexContent = appTree.read('libs/my-lib/src/index.ts', 'utf-8');
+      const indexContent = appTree.read('my-lib/src/index.ts', 'utf-8');
 
       expect(indexContent).not.toMatch(/lib\/hello/);
     });
@@ -78,11 +74,9 @@ describe('component', () => {
         project: projectName,
         pascalCaseFiles: true,
       });
+      expect(appTree.exists('my-lib/src/lib/hello/Hello.tsx')).toBeTruthy();
       expect(
-        appTree.exists('libs/my-lib/src/lib/hello/Hello.tsx')
-      ).toBeTruthy();
-      expect(
-        appTree.exists('libs/my-lib/src/lib/hello/Hello.spec.tsx')
+        appTree.exists('my-lib/src/lib/hello/Hello.spec.tsx')
       ).toBeTruthy();
     });
   });
@@ -95,7 +89,7 @@ describe('component', () => {
         directory: 'components',
       });
 
-      expect(appTree.exists('/libs/my-lib/src/components/hello/hello.tsx'));
+      expect(appTree.exists('my-lib/src/components/hello/hello.tsx'));
     });
 
     it('should create with nested directories', async () => {
@@ -105,9 +99,7 @@ describe('component', () => {
         directory: 'lib/foo',
       });
 
-      expect(
-        appTree.exists('/libs/my-lib/src/lib/foo/hello-world/hello-world.tsx')
-      );
+      expect(appTree.exists('my-lib/src/lib/foo/hello-world/hello-world.tsx'));
     });
   });
 
@@ -119,7 +111,7 @@ describe('component', () => {
         flat: true,
       });
 
-      expect(appTree.exists('/libs/my-lib/src/lib/hello.tsx'));
+      expect(appTree.exists('my-lib/src/lib/hello.tsx'));
     });
     it('should work with custom directory path', async () => {
       await reactNativeComponentGenerator(appTree, {
@@ -129,7 +121,7 @@ describe('component', () => {
         directory: 'components',
       });
 
-      expect(appTree.exists('/libs/my-lib/src/components/hello.tsx'));
+      expect(appTree.exists('my-lib/src/components/hello.tsx'));
     });
   });
 });

--- a/packages/react-native/src/generators/init/init.spec.ts
+++ b/packages/react-native/src/generators/init/init.spec.ts
@@ -7,7 +7,7 @@ describe('init', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
     tree.write('.gitignore', '');
   });
 

--- a/packages/react-native/src/generators/stories/stories-app.spec.ts
+++ b/packages/react-native/src/generators/stories/stories-app.spec.ts
@@ -21,14 +21,10 @@ describe('react:stories for applications', () => {
       project: 'test-ui-app',
     });
 
-    expect(appTree.exists('apps/test-ui-app/src/app/App.tsx')).toBeTruthy();
+    expect(appTree.exists('test-ui-app/src/app/App.tsx')).toBeTruthy();
+    expect(appTree.exists('test-ui-app/src/app/App.stories.tsx')).toBeTruthy();
     expect(
-      appTree.exists('apps/test-ui-app/src/app/App.stories.tsx')
-    ).toBeTruthy();
-    expect(
-      appTree.exists(
-        'apps/test-ui-app/src/app/another-cmp/another-cmp.stories.tsx'
-      )
+      appTree.exists('test-ui-app/src/app/another-cmp/another-cmp.stories.tsx')
     ).toBeTruthy();
   });
 
@@ -39,17 +35,13 @@ describe('react:stories for applications', () => {
     });
     await storiesGenerator(appTree, {
       project: 'test-ui-app',
-      ignorePaths: ['apps/test-ui-app/src/app/**'],
+      ignorePaths: ['test-ui-app/src/app/**'],
     });
 
-    expect(appTree.exists('apps/test-ui-app/src/app/App.tsx')).toBeTruthy();
+    expect(appTree.exists('test-ui-app/src/app/App.tsx')).toBeTruthy();
+    expect(appTree.exists('test-ui-app/src/app/App.stories.tsx')).toBeFalsy();
     expect(
-      appTree.exists('apps/test-ui-app/src/app/App.stories.tsx')
-    ).toBeFalsy();
-    expect(
-      appTree.exists(
-        'apps/test-ui-app/src/app/another-cmp/another-cmp.stories.tsx'
-      )
+      appTree.exists('test-ui-app/src/app/another-cmp/another-cmp.stories.tsx')
     ).toBeFalsy();
   });
 
@@ -61,18 +53,14 @@ describe('react:stories for applications', () => {
 
     await storiesGenerator(appTree, {
       project: 'test-ui-app',
-      ignorePaths: [
-        'apps/test-ui-app/src/app/another-new-cmp/another-new-cmp.tsx',
-      ],
+      ignorePaths: ['test-ui-app/src/app/another-new-cmp/another-new-cmp.tsx'],
     });
 
-    expect(appTree.exists('apps/test-ui-app/src/app/App.tsx')).toBeTruthy();
-    expect(
-      appTree.exists('apps/test-ui-app/src/app/App.stories.tsx')
-    ).toBeTruthy();
+    expect(appTree.exists('test-ui-app/src/app/App.tsx')).toBeTruthy();
+    expect(appTree.exists('test-ui-app/src/app/App.stories.tsx')).toBeTruthy();
     expect(
       appTree.exists(
-        'apps/test-ui-app/src/app/another-new-cmp/another-new-cmp.stories.tsx'
+        'test-ui-app/src/app/another-new-cmp/another-new-cmp.stories.tsx'
       )
     ).toBeFalsy();
   });
@@ -89,23 +77,19 @@ describe('react:stories for applications', () => {
     });
     await storiesGenerator(appTree, {
       project: 'test-ui-app',
-      ignorePaths: [
-        'apps/test-ui-app/src/app/another-new-cmp/another-new-cmp.tsx',
-      ],
+      ignorePaths: ['test-ui-app/src/app/another-new-cmp/another-new-cmp.tsx'],
     });
 
-    expect(appTree.exists('apps/test-ui-app/src/app/App.tsx')).toBeTruthy();
-    expect(
-      appTree.exists('apps/test-ui-app/src/app/App.stories.tsx')
-    ).toBeTruthy();
+    expect(appTree.exists('test-ui-app/src/app/App.tsx')).toBeTruthy();
+    expect(appTree.exists('test-ui-app/src/app/App.stories.tsx')).toBeTruthy();
     expect(
       appTree.exists(
-        'apps/test-ui-app/src/app/another-new-cmp/comp-a/comp-a.stories.tsx'
+        'test-ui-app/src/app/another-new-cmp/comp-a/comp-a.stories.tsx'
       )
     ).toBeTruthy();
     expect(
       appTree.exists(
-        'apps/test-ui-app/src/app/another-new-cmp/another-new-cmp.stories.tsx'
+        'test-ui-app/src/app/another-new-cmp/another-new-cmp.stories.tsx'
       )
     ).toBeFalsy();
   });
@@ -113,7 +97,7 @@ describe('react:stories for applications', () => {
   it('should ignore files that do not contain components', async () => {
     // create another component
     appTree.write(
-      'apps/test-ui-app/src/app/some-utils.js',
+      'test-ui-app/src/app/some-utils.js',
       `export const add = (a: number, b: number) => a + b;`
     );
 
@@ -123,14 +107,12 @@ describe('react:stories for applications', () => {
 
     // should just create the story and not error, even though there's a js file
     // not containing any react component
-    expect(
-      appTree.exists('apps/test-ui-app/src/app/App.stories.tsx')
-    ).toBeTruthy();
+    expect(appTree.exists('test-ui-app/src/app/App.stories.tsx')).toBeTruthy();
   });
 });
 
 export async function createTestUIApp(libName: string): Promise<Tree> {
-  let appTree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  let appTree = createTreeWithEmptyWorkspace();
   appTree.write('.gitignore', '');
 
   await applicationGenerator(appTree, {
@@ -140,6 +122,7 @@ export async function createTestUIApp(libName: string): Promise<Tree> {
     unitTestRunner: 'none',
     name: libName,
     install: false,
+    projectNameAndRootFormat: 'as-provided',
   });
   return appTree;
 }

--- a/packages/react-native/src/generators/stories/stories-lib.spec.ts
+++ b/packages/react-native/src/generators/stories/stories-lib.spec.ts
@@ -27,14 +27,10 @@ describe('react-native:stories for libraries', () => {
     });
 
     expect(
-      appTree.exists(
-        'libs/test-ui-lib/src/lib/test-ui-lib/test-ui-lib.stories.tsx'
-      )
+      appTree.exists('test-ui-lib/src/lib/test-ui-lib/test-ui-lib.stories.tsx')
     ).toBeTruthy();
     expect(
-      appTree.exists(
-        'libs/test-ui-lib/src/lib/another-cmp/another-cmp.stories.tsx'
-      )
+      appTree.exists('test-ui-lib/src/lib/another-cmp/another-cmp.stories.tsx')
     ).toBeTruthy();
   });
 
@@ -49,18 +45,14 @@ describe('react-native:stories for libraries', () => {
     });
     await storiesGenerator(appTree, {
       project: 'test-ui-lib',
-      ignorePaths: ['libs/test-ui-lib/src/lib/another-cmp/**'],
+      ignorePaths: ['test-ui-lib/src/lib/another-cmp/**'],
     });
 
     expect(
-      appTree.exists(
-        'libs/test-ui-lib/src/lib/test-ui-lib/test-ui-lib.stories.tsx'
-      )
+      appTree.exists('test-ui-lib/src/lib/test-ui-lib/test-ui-lib.stories.tsx')
     ).toBeTruthy();
     expect(
-      appTree.exists(
-        'libs/test-ui-lib/src/lib/another-cmp/another-cmp.stories.tsx'
-      )
+      appTree.exists('test-ui-lib/src/lib/another-cmp/another-cmp.stories.tsx')
     ).toBeFalsy();
   });
 
@@ -71,7 +63,7 @@ describe('react-native:stories for libraries', () => {
     });
     // create another component
     appTree.write(
-      'libs/test-ui-lib/src/lib/some-command-line-utils.ts',
+      'test-ui-lib/src/lib/some-command-line-utils.ts',
       `export const add = (a: number, b: number) => a + b;`
     );
 
@@ -82,15 +74,13 @@ describe('react-native:stories for libraries', () => {
     // should just create the story and not error, even though there's a js file
     // not containing any react component
     expect(
-      appTree.exists(
-        'libs/test-ui-lib/src/lib/test-ui-lib/test-ui-lib.stories.tsx'
-      )
+      appTree.exists('test-ui-lib/src/lib/test-ui-lib/test-ui-lib.stories.tsx')
     ).toBeTruthy();
   });
 });
 
 export async function createTestUILib(libName: string): Promise<Tree> {
-  let appTree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  let appTree = createTreeWithEmptyWorkspace();
   appTree.write('.gitignore', '');
 
   await libraryGenerator(appTree, {
@@ -99,6 +89,7 @@ export async function createTestUILib(libName: string): Promise<Tree> {
     skipTsConfig: false,
     unitTestRunner: 'none',
     name: libName,
+    projectNameAndRootFormat: 'as-provided',
   });
 
   await applicationGenerator(appTree, {
@@ -108,6 +99,7 @@ export async function createTestUILib(libName: string): Promise<Tree> {
     unitTestRunner: 'none',
     name: `${libName}-e2e`,
     install: false,
+    projectNameAndRootFormat: 'as-provided',
   });
   return appTree;
 }

--- a/packages/react-native/src/generators/storybook-configuration/configuration.spec.ts
+++ b/packages/react-native/src/generators/storybook-configuration/configuration.spec.ts
@@ -36,11 +36,9 @@ describe('react-native:storybook-configuration', () => {
         name: 'test-ui-lib',
       });
 
+      expect(appTree.exists('test-ui-lib/.storybook/main.js')).toBeTruthy();
       expect(
-        appTree.exists('libs/test-ui-lib/.storybook/main.js')
-      ).toBeTruthy();
-      expect(
-        appTree.exists('libs/test-ui-lib/tsconfig.storybook.json')
+        appTree.exists('test-ui-lib/tsconfig.storybook.json')
       ).toBeTruthy();
     });
 
@@ -57,7 +55,7 @@ describe('react-native:storybook-configuration', () => {
 
       expect(
         appTree.exists(
-          'libs/test-ui-lib/src/lib/test-ui-lib/test-ui-lib.stories.tsx'
+          'test-ui-lib/src/lib/test-ui-lib/test-ui-lib.stories.tsx'
         )
       ).toBeTruthy();
     });
@@ -70,11 +68,9 @@ describe('react-native:storybook-configuration', () => {
         name: 'test-ui-app',
       });
 
+      expect(appTree.exists('test-ui-app/.storybook/main.js')).toBeTruthy();
       expect(
-        appTree.exists('apps/test-ui-app/.storybook/main.js')
-      ).toBeTruthy();
-      expect(
-        appTree.exists('apps/test-ui-app/tsconfig.storybook.json')
+        appTree.exists('test-ui-app/tsconfig.storybook.json')
       ).toBeTruthy();
     });
 
@@ -90,7 +86,7 @@ describe('react-native:storybook-configuration', () => {
       // under the specified 'lib' directory
       expect(
         appTree.exists(
-          'apps/test-ui-app/src/app/my-component/my-component.stories.tsx'
+          'test-ui-app/src/app/my-component/my-component.stories.tsx'
         )
       ).toBeTruthy();
     });
@@ -98,7 +94,7 @@ describe('react-native:storybook-configuration', () => {
 });
 
 export async function createTestUILib(libName: string): Promise<Tree> {
-  let appTree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  let appTree = createTreeWithEmptyWorkspace();
 
   await libraryGenerator(appTree, {
     linter: Linter.EsLint,
@@ -106,6 +102,7 @@ export async function createTestUILib(libName: string): Promise<Tree> {
     skipTsConfig: false,
     unitTestRunner: 'none',
     name: libName,
+    projectNameAndRootFormat: 'as-provided',
   });
   return appTree;
 }
@@ -114,7 +111,7 @@ export async function createTestAppLib(
   libName: string,
   plainJS = false
 ): Promise<Tree> {
-  let appTree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  let appTree = createTreeWithEmptyWorkspace();
 
   await applicationGenerator(appTree, {
     e2eTestRunner: 'none',
@@ -125,6 +122,7 @@ export async function createTestAppLib(
     name: libName,
     js: plainJS,
     install: false,
+    projectNameAndRootFormat: 'as-provided',
   });
 
   await componentGenerator(appTree, {

--- a/packages/react-native/src/generators/storybook-configuration/lib/add-resolver-main-fields-to-metro-config.spec.ts
+++ b/packages/react-native/src/generators/storybook-configuration/lib/add-resolver-main-fields-to-metro-config.spec.ts
@@ -9,17 +9,17 @@ describe('addResolverMainFieldsToMetroConfig', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
 
     addProjectConfiguration(tree, 'products', {
-      root: 'apps/products',
-      sourceRoot: 'apps/products/src',
+      root: 'products',
+      sourceRoot: 'products/src',
     });
   });
 
   it(`should update metro.config.js and add key projectRoot`, async () => {
     tree.write(
-      'apps/products/metro.config.js',
+      'products/metro.config.js',
       formatFile`
 const { withNxMetro } = require('@nx/react-native');
 const { getDefaultConfig } = require('metro-config');
@@ -55,7 +55,7 @@ module.exports = (async () => {
     });
 
     expect(
-      formatFile`${tree.read('apps/products/metro.config.js', 'utf-8')}`
+      formatFile`${tree.read('products/metro.config.js', 'utf-8')}`
     ).toEqual(
       formatFile`
 const { withNxMetro } = require('@nx/react-native');
@@ -91,7 +91,7 @@ module.exports = (async () => {
 
   it(`should not udpate metro.config.js if projectRoot already exists`, async () => {
     tree.write(
-      'apps/products/metro.config.js',
+      'products/metro.config.js',
       `
 const { withNxMetro } = require('@nx/react-native');
 const { getDefaultConfig } = require('metro-config');
@@ -126,7 +126,7 @@ module.exports = (async () => {
       name: 'products',
     });
 
-    expect(tree.read('apps/products/metro.config.js', 'utf-8')).toEqual(
+    expect(tree.read('products/metro.config.js', 'utf-8')).toEqual(
       `
 const { withNxMetro } = require('@nx/react-native');
 const { getDefaultConfig } = require('metro-config');

--- a/packages/react-native/src/generators/storybook-configuration/lib/replace-app-import-with-storybook-toggle.spec.ts
+++ b/packages/react-native/src/generators/storybook-configuration/lib/replace-app-import-with-storybook-toggle.spec.ts
@@ -9,17 +9,17 @@ describe('replaceAppImportWithStorybookToggle', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace();
 
     addProjectConfiguration(tree, 'products', {
-      root: 'apps/products',
-      sourceRoot: 'apps/products/src',
+      root: 'products',
+      sourceRoot: 'products/src',
     });
   });
 
   it('should update the main file with import from storybook', async () => {
     tree.write(
-      '/apps/products/src/main.tsx',
+      'products/src/main.tsx',
       formatFile`import { AppRegistry } from 'react-native';
       import App from './app/App';
       
@@ -31,7 +31,7 @@ describe('replaceAppImportWithStorybookToggle', () => {
       js: false,
     });
 
-    const mainFile = tree.read('apps/products/src/main.tsx', 'utf-8');
+    const mainFile = tree.read('products/src/main.tsx', 'utf-8');
     expect(formatFile`${mainFile}`).toEqual(
       formatFile`import { AppRegistry } from 'react-native';
       import App from './storybook/toggle-storybook';
@@ -42,7 +42,7 @@ describe('replaceAppImportWithStorybookToggle', () => {
 
   it('should not update the main file if import is already updated', async () => {
     tree.write(
-      '/apps/products/src/main.tsx',
+      'products/src/main.tsx',
       formatFile`import { AppRegistry } from 'react-native';
       import App from './app/App';
       
@@ -54,7 +54,7 @@ describe('replaceAppImportWithStorybookToggle', () => {
       js: false,
     });
 
-    const mainFile = tree.read('apps/products/src/main.tsx', 'utf-8');
+    const mainFile = tree.read('products/src/main.tsx', 'utf-8');
     expect(formatFile`${mainFile}`).toEqual(
       formatFile`import { AppRegistry } from 'react-native';
       import App from './storybook/toggle-storybook';

--- a/packages/react-native/src/utils/testing-generators.ts
+++ b/packages/react-native/src/utils/testing-generators.ts
@@ -11,19 +11,20 @@ export async function createApp(tree: Tree, appName: string): Promise<void> {
     name: appName,
     e2eTestRunner: 'none',
     install: false,
+    projectNameAndRootFormat: 'as-provided',
   });
 }
 
 export async function createLib(tree: Tree, libName: string): Promise<void> {
   const { fileName } = names(libName);
 
-  tree.write(`/libs/${fileName}/src/index.ts`, `import React from 'react';\n`);
+  tree.write(`${fileName}/src/index.ts`, `import React from 'react';\n`);
 
   addProjectConfiguration(tree, fileName, {
     tags: [],
-    root: `libs/${fileName}`,
+    root: `${fileName}`,
     projectType: 'library',
-    sourceRoot: `libs/${fileName}/src`,
+    sourceRoot: `${fileName}/src`,
     targets: {},
   });
 }


### PR DESCRIPTION
This PR contains updates to the react-native plugin's unit test to:
- Use standalone projects
- Use `as-provided` when creating `apps/libs`