### PR TITLE
fix(testing): include ts/js files in tsconfig.spec.json

### DIFF
--- a/packages/jest/src/generators/configuration/configuration.spec.ts
+++ b/packages/jest/src/generators/configuration/configuration.spec.ts
@@ -139,6 +139,8 @@ describe('jestProject', () => {
         'jest.config.ts',
         'src/**/*.test.ts',
         'src/**/*.spec.ts',
+        'src/**/*.js',
+        'src/**/*.ts',
         'src/**/*.d.ts',
       ],
     });

--- a/packages/jest/src/generators/configuration/files-angular/tsconfig.spec.json__tmpl__
+++ b/packages/jest/src/generators/configuration/files-angular/tsconfig.spec.json__tmpl__
@@ -17,6 +17,8 @@
     "src/**/*.spec.js",
     "src/**/*.test.jsx",
     "src/**/*.spec.jsx",<% } %>
+    "src/**/*.js",
+    "src/**/*.ts",
     "src/**/*.d.ts"
 ]
 }

--- a/packages/jest/src/generators/configuration/files/tsconfig.spec.json__tmpl__
+++ b/packages/jest/src/generators/configuration/files/tsconfig.spec.json__tmpl__
@@ -16,6 +16,8 @@
     "src/**/*.spec.js",
     "src/**/*.test.jsx",
     "src/**/*.spec.jsx",<% } %>
+    "src/**/*.ts",
+    "src/**/*.js",
     "src/**/*.d.ts"
   ]
 }

--- a/packages/linter/src/generators/workspace-rules-project/__snapshots__/workspace-rules-project.spec.ts.snap
+++ b/packages/linter/src/generators/workspace-rules-project/__snapshots__/workspace-rules-project.spec.ts.snap
@@ -72,7 +72,14 @@ exports[`@nx/linter:workspace-rules-project should generate the required files 4
     "module": "commonjs",
     "types": ["jest", "node"]
   },
-  "include": ["jest.config.ts", "**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+  "include": [
+    "jest.config.ts",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.ts",
+    "**/*.js",
+    "**/*.d.ts"
+  ]
 }
 "
 `;

--- a/packages/react-native/src/generators/library/library.spec.ts
+++ b/packages/react-native/src/generators/library/library.spec.ts
@@ -258,6 +258,8 @@ describe('lib', () => {
             "src/**/*.spec.js",
             "src/**/*.test.jsx",
             "src/**/*.spec.jsx",
+            "src/**/*.ts",
+            "src/**/*.js",
             "src/**/*.d.ts"
           ]
         }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

ts and js prod files aren't included in the tsconfig.spec.json. 
which prevents editors from being able to auto import from within spec files.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
ts and js prod files are included in the tsconfig.spec.json to improve DX

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18434
