### PR TITLE
chore(testing): update nightly ci to ensure cy is available

### DIFF
--- a/e2e/cypress/src/cypress.test.ts
+++ b/e2e/cypress/src/cypress.test.ts
@@ -94,16 +94,17 @@ describe('env vars', () => {
 });`
       );
 
-      // contains the correct output and works
-      const run1 = runCLI(
-        `e2e ${myapp}-e2e --no-watch --env.cliArg="i am from the cli args"`
-      );
-      expect(run1).toContain('All specs passed!');
-      await killPort(4200);
-      // tests should not fail because of a config change
-      updateFile(
-        `apps/${myapp}-e2e/cypress.config.ts`,
-        `
+      if (runE2ETests()) {
+        // contains the correct output and works
+        const run1 = runCLI(
+          `e2e ${myapp}-e2e --no-watch --env.cliArg="i am from the cli args"`
+        );
+        expect(run1).toContain('All specs passed!');
+        await killPort(4200);
+        // tests should not fail because of a config change
+        updateFile(
+          `apps/${myapp}-e2e/cypress.config.ts`,
+          `
 import { defineConfig } from 'cypress';
 import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
 
@@ -113,18 +114,18 @@ export default defineConfig({
   fixturesFolder: undefined,
   },
 });`
-      );
+        );
 
-      const run2 = runCLI(
-        `e2e ${myapp}-e2e --no-watch --env.cliArg="i am from the cli args"`
-      );
-      expect(run2).toContain('All specs passed!');
-      await killPort(4200);
+        const run2 = runCLI(
+          `e2e ${myapp}-e2e --no-watch --env.cliArg="i am from the cli args"`
+        );
+        expect(run2).toContain('All specs passed!');
+        await killPort(4200);
 
-      // make sure project.json env vars also work
-      updateFile(
-        `apps/${myapp}-e2e/src/e2e/env.cy.ts`,
-        `
+        // make sure project.json env vars also work
+        updateFile(
+          `apps/${myapp}-e2e/src/e2e/env.cy.ts`,
+          `
 describe('env vars', () => {
   it('should not have cli args', () => {
     assert.equal(Cypress.env('cliArg'), undefined);
@@ -144,11 +145,12 @@ describe('env vars', () => {
     );
   });
 });`
-      );
-      const run3 = runCLI(`e2e ${myapp}-e2e --no-watch`);
-      expect(run3).toContain('All specs passed!');
+        );
+        const run3 = runCLI(`e2e ${myapp}-e2e --no-watch`);
+        expect(run3).toContain('All specs passed!');
 
-      expect(await killPort(4200)).toBeTruthy();
+        expect(await killPort(4200)).toBeTruthy();
+      }
     },
     TEN_MINS_MS
   );
@@ -164,16 +166,18 @@ describe('env vars', () => {
         `generate @nx/angular:app ${ngAppName} --e2eTestRunner=cypress --linter=eslint --no-interactive`
       );
 
-      const results = runCLI(
-        `run-many --target=e2e --parallel=2 --port=cypress-auto --output-style=stream`
-      );
-      expect(results).toContain('Using port 4200');
-      expect(results).toContain('Using port 4201');
-      expect(results).toContain('Successfully ran target e2e for 2 projects');
-      checkFilesDoNotExist(
-        `node_modules/@nx/cypress/src/executors/cypress/4200.txt`,
-        `node_modules/@nx/cypress/src/executors/cypress/4201.txt`
-      );
+      if (runE2ETests()) {
+        const results = runCLI(
+          `run-many --target=e2e --parallel=2 --port=cypress-auto --output-style=stream`
+        );
+        expect(results).toContain('Using port 4200');
+        expect(results).toContain('Using port 4201');
+        expect(results).toContain('Successfully ran target e2e for 2 projects');
+        checkFilesDoNotExist(
+          `node_modules/@nx/cypress/src/executors/cypress/4200.txt`,
+          `node_modules/@nx/cypress/src/executors/cypress/4201.txt`
+        );
+      }
     },
     TEN_MINS_MS
   );


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
cypress e2e is failing for nightly due to cypress binary not being installed, even though half the tests pass running cypress?
https://github.com/nrwl/nx/actions/runs/6031310292/job/16364919305

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

wrap test runs with `if(runE2ETests())` which makes sure cypress is installed before running the e2e tests just to be extra sure it's available

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
