### PR TITLE
chore(misc): fix lockfile check in nightly

### DIFF
--- a/e2e/esbuild/src/esbuild.test.ts
+++ b/e2e/esbuild/src/esbuild.test.ts
@@ -2,13 +2,16 @@ import {
   checkFilesDoNotExist,
   checkFilesExist,
   cleanupProject,
+  detectPackageManager,
   newProject,
   packageInstall,
+  packageManagerLockFile,
   readFile,
   readJson,
   runCLI,
   runCommand,
   runCommandUntil,
+  tmpProjPath,
   uniq,
   updateFile,
   updateProjectConfig,
@@ -52,7 +55,9 @@ describe('EsBuild Plugin', () => {
     // main field should be set correctly in package.json
     checkFilesExist(
       `dist/libs/${myPkg}/package.json`,
-      `dist/libs/${myPkg}/pnpm-lock.yaml`
+      `dist/libs/${myPkg}/${
+        packageManagerLockFile[detectPackageManager(tmpProjPath())]
+      }`
     );
     expect(runCommand(`node dist/libs/${myPkg}`)).toMatch(/Hello/);
 


### PR DESCRIPTION
In nightly we may not be using pnpm to install packages. This PR updates the test to work in nightly.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
