### PR TITLE
chore(recipes): update example code

### DIFF
--- a/docs/shared/recipes/reduce-repetitive-configuration.md
+++ b/docs/shared/recipes/reduce-repetitive-configuration.md
@@ -260,6 +260,9 @@ Now the `project.json` files can be reduced to this:
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/lib3/src",
   "projectType": "library",
+  "targets": {
+    "test": {}
+  },
   "tags": []
 }
 ```


### PR DESCRIPTION
## Current Behavior
The lib3 example code in the "reduce repetitive configurations" recipe is missing an empty test target in the project.json

## Expected Behavior
The lib has to have at least an empty target defined in order to have the targetDefaults running.

## Related Issue(s)
https://github.com/nrwl/nx/issues/18934

Fixes #
https://github.com/nrwl/nx/issues/18934