### PR TITLE
feat(nx-dev): get the correct query for ai feedback

### DIFF
--- a/nx-dev/feature-ai/src/lib/feed/feed.tsx
+++ b/nx-dev/feature-ai/src/lib/feed/feed.tsx
@@ -1,27 +1,27 @@
-import { ChatItem } from '@nx/nx-dev/util-ai';
 import { FeedAnswer } from './feed-answer';
 import { FeedQuestion } from './feed-question';
+import { Message } from 'ai/react';
 
 export function Feed({
   activity,
   handleFeedback,
 }: {
-  activity: ChatItem[];
-  handleFeedback: (statement: 'bad' | 'good', chatItemIndex: number) => void;
+  activity: Message[];
+  handleFeedback: (statement: 'bad' | 'good', chatItemUid: string) => void;
 }) {
   return (
     <div className="flow-root my-12">
       <ul role="list" className="-mb-8 space-y-12">
         {activity.map((activityItem, activityItemIdx) => (
           <li
-            key={[activityItem.role, activityItemIdx].join('-')}
+            key={[activityItem.role, activityItem.id].join('-')}
             className="pt-12 relative flex items-start space-x-3 feed-item"
           >
             {activityItem.role === 'assistant' ? (
               <FeedAnswer
                 content={activityItem.content}
                 feedbackButtonCallback={(statement) =>
-                  handleFeedback(statement, activityItemIdx)
+                  handleFeedback(statement, activityItem.id)
                 }
                 isFirst={activityItemIdx === 0}
               />

--- a/nx-dev/util-ai/src/index.ts
+++ b/nx-dev/util-ai/src/index.ts
@@ -1,4 +1,5 @@
 export * from './lib/utils';
+export * from './lib/history';
 export * from './lib/constants';
 export * from './lib/moderation';
 export * from './lib/chat-utils';

--- a/nx-dev/util-ai/src/lib/chat-utils.ts
+++ b/nx-dev/util-ai/src/lib/chat-utils.ts
@@ -127,25 +127,6 @@ export function toMarkdownList(
   return finalSections;
 }
 
-export function extractLinksFromSourcesSection(markdown: string): string[] {
-  const sectionRegex = /### Sources\n\n([\s\S]*?)(?:\n##|$)/;
-  const sectionMatch = sectionRegex.exec(markdown);
-
-  if (!sectionMatch) return [];
-
-  const sourcesSection = sectionMatch[1];
-
-  const linkRegex = /\]\((.*?)\)/g;
-  const links: string[] = [];
-  let match;
-
-  while ((match = linkRegex.exec(sourcesSection)) !== null) {
-    links.push(match[1]);
-  }
-
-  return links;
-}
-
 export function removeSourcesSection(markdown: string): string {
   const sectionRegex = /### Sources\n\n([\s\S]*?)(?:\n###|$)/;
   return markdown.replace(sectionRegex, '').trim();

--- a/nx-dev/util-ai/src/lib/history.ts
+++ b/nx-dev/util-ai/src/lib/history.ts
@@ -1,0 +1,13 @@
+const history: { [key: string]: string } = {};
+
+export function storeQueryForUid(uid: string, query: string) {
+  history[uid] = query;
+}
+
+export function getQueryFromUid(uid: string) {
+  return history[uid];
+}
+
+export function getHistory() {
+  return history;
+}


### PR DESCRIPTION
## Current Behavior

We have a list of messages, and each one has an index, which is generated by the loop that renders the messages. The messages are Queries (by the user) and Responses (by the assistant).

The 👍 / 👎 feedback buttons are "attached" to the Response message. So, whenever a user clicks on the feedback button, we know that they clicked on the message with index `X`. Using that index `X` we assume that the Query that resulted in that Response is the message with index `X-1`. Since this logic is based on an assumption that the messages list will always be consistent and "correct" and sorted, we think that it is brittle.

## Expected Behavior

Now that we use the `useChat` from `ai/react` package, we get back a list of messages, and each message has its own `id`. So, when we get a Response, we tie the `id` of the Response with the Query that gave that Response. That way, we can be sure that when a user clicks the feedback button, their feedback will be for the correct Query.

@bcabanes 
