### PR TITLE
fix(js): properly throw error when processing lockfile during postins…

### DIFF
--- a/packages/nx/src/plugins/js/index.ts
+++ b/packages/nx/src/plugins/js/index.ts
@@ -38,7 +38,7 @@ export const createNodes: CreateNodes = [
   combineGlobPatterns(LOCKFILES),
   (lockFile, context) => {
     const pluginConfig = jsPluginConfig(context.nxJsonConfiguration);
-    if (!pluginConfig.analyzePackageJson) {
+    if (!pluginConfig.analyzeLockfile) {
       return {};
     }
 
@@ -83,7 +83,7 @@ export const createDependencies: CreateDependencies = (
   let lockfileDependencies: ProjectGraphDependencyWithFile[] = [];
   // lockfile may not exist yet
   if (
-    pluginConfig.analyzePackageJson &&
+    pluginConfig.analyzeLockfile &&
     lockFileExists(packageManager) &&
     parsedLockFile
   ) {

--- a/packages/nx/src/plugins/js/lock-file/lock-file.ts
+++ b/packages/nx/src/plugins/js/lock-file/lock-file.ts
@@ -76,7 +76,7 @@ export function getLockFileNodes(
         bodyLines: errorBodyLines(e),
       });
     }
-    return;
+    throw e;
   }
   throw new Error(`Unknown package manager: ${packageManager}`);
 }
@@ -107,7 +107,7 @@ export function getLockFileDependencies(
         bodyLines: errorBodyLines(e),
       });
     }
-    return;
+    throw e;
   }
   throw new Error(`Unknown package manager: ${packageManager}`);
 }


### PR DESCRIPTION
…tall

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When lockfile parsing fails, it writes an empty cache which gets reused by later project graph calculations.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When lockfile parsing fails, no cache is written and the project graph fails.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
