### PR TITLE
chore(core): remove fast-glob from core nx

### DIFF
--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -44,7 +44,6 @@
     "dotenv": "~16.3.1",
     "dotenv-expand": "~10.0.0",
     "enquirer": "~2.3.6",
-    "fast-glob": "3.2.7",
     "figures": "3.2.0",
     "flat": "^5.0.2",
     "fs-extra": "^11.1.0",

--- a/packages/nx/src/utils/ignore.ts
+++ b/packages/nx/src/utils/ignore.ts
@@ -6,7 +6,6 @@ import { workspaceRoot } from './workspace-root';
 
 /**
  * An array of glob patterns that should always be ignored.
- * Uses path/posix, since fast-glob requires unix paths.
  */
 export const ALWAYS_IGNORE = getAlwaysIgnore();
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
There was a usage of fast-glob in the daemon code. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
fast-glob is removed for the native function

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
