### PR TITLE
fix(js): change TS standalone preset to generate at the root

### DIFF
--- a/packages/workspace/src/generators/preset/preset.ts
+++ b/packages/workspace/src/generators/preset/preset.ts
@@ -169,7 +169,7 @@ async function createPreset(tree: Tree, options: Schema) {
     const { libraryGenerator } = require('@nx' + '/js');
     return libraryGenerator(tree, {
       name: options.name,
-      directory: join('packages', options.name),
+      directory: '.',
       projectNameAndRootFormat: 'as-provided',
       bundler: 'tsc',
       unitTestRunner: 'vitest',


### PR DESCRIPTION
The TS standalone is supposed to generate the project at the root, this PR changes it back.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
