### PR TITLE
docs(react): Fix typo for react libs

### DIFF
--- a/docs/generated/packages/webpack/documents/overview.md
+++ b/docs/generated/packages/webpack/documents/overview.md
@@ -27,7 +27,7 @@ npx create-nx-workspace@latest --preset=react-monorepo --bundler=webpack
 
 ## Generate a new project using Webpack
 
-You can generate a [React](/packages/react) application or library or a [Web](/packages/web) application that uses Webpack in an existing Nx workspace. The [`@nx/react:app`](/packages/react/generators/application), [`@nx/node:app`](/packages/node/generators/application) and [`@nx/web:app`](/packages/web/generators/application) generators accept the `bundler` option, where you can pass `webpack`. This will generate a new application configured to use Webpack, and it will also install all the necessary dependencies, including the `@nx/webpack` plugin.
+You can generate a [React](/packages/react) application or a [Web](/packages/web) application that uses Webpack in an existing Nx workspace. The [`@nx/react:app`](/packages/react/generators/application), [`@nx/node:app`](/packages/node/generators/application) and [`@nx/web:app`](/packages/web/generators/application) generators accept the `bundler` option, where you can pass `webpack`. This will generate a new application configured to use Webpack, and it will also install all the necessary dependencies, including the `@nx/webpack` plugin.
 
 To generate a React application using Webpack, run the following:
 

--- a/docs/shared/packages/webpack/plugin-overview.md
+++ b/docs/shared/packages/webpack/plugin-overview.md
@@ -27,7 +27,7 @@ npx create-nx-workspace@latest --preset=react-monorepo --bundler=webpack
 
 ## Generate a new project using Webpack
 
-You can generate a [React](/packages/react) application or library or a [Web](/packages/web) application that uses Webpack in an existing Nx workspace. The [`@nx/react:app`](/packages/react/generators/application), [`@nx/node:app`](/packages/node/generators/application) and [`@nx/web:app`](/packages/web/generators/application) generators accept the `bundler` option, where you can pass `webpack`. This will generate a new application configured to use Webpack, and it will also install all the necessary dependencies, including the `@nx/webpack` plugin.
+You can generate a [React](/packages/react) application or a [Web](/packages/web) application that uses Webpack in an existing Nx workspace. The [`@nx/react:app`](/packages/react/generators/application), [`@nx/node:app`](/packages/node/generators/application) and [`@nx/web:app`](/packages/web/generators/application) generators accept the `bundler` option, where you can pass `webpack`. This will generate a new application configured to use Webpack, and it will also install all the necessary dependencies, including the `@nx/webpack` plugin.
 
 To generate a React application using Webpack, run the following:
 


### PR DESCRIPTION
`@nx/react:lib` does not support webpack as a bundler. We should update the docs to represent this as well

closes: #19001
