### PR TITLE
fix(nx): yarn exec command

### DIFF
--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -73,7 +73,7 @@ export function getPackageManagerCommand(
         add: useBerry ? 'yarn add' : 'yarn add -W',
         addDev: useBerry ? 'yarn add -D' : 'yarn add -D -W',
         rm: 'yarn remove',
-        exec: 'yarn',
+        exec: 'yarn exec',
         run: (script: string, args: string) => `yarn ${script} ${args}`,
         list: useBerry ? 'yarn info --name-only' : 'yarn list',
       };


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently, the detected package manager `exec` command for `yarn` is wrong, it can end up trying to run a script instead.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
It should use [`yarn exec`](https://yarnpkg.com/cli/exec).

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
