### PR TITLE
fix(misc): loader-utils Dependabot Alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "less": "3.12.2",
     "less-loader": "^10.1.0",
     "license-webpack-plugin": "^4.0.2",
-    "loader-utils": "1.2.3",
+    "loader-utils": "^1.4.2",
     "memfs": "^3.0.1",
     "metro-resolver": "^0.69.1",
     "mime": "2.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15077,6 +15077,15 @@ loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
     emojis-list "^3.0.0"
     json5 "^1.0.1"
 
+loader-utils@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.2.tgz#29a957f3a63973883eb684f10ffd3d151fec01a3"
+  integrity sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^1.0.1"
+
 loader-utils@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.2.tgz#d6e3b4fb81870721ae4e0868ab11dd638368c129"


### PR DESCRIPTION
incrementing loader utils so that dependabot alerts are addressed

## Current Behavior
- 13.10.x has a critical dependabot alert around loader-utils versions under <1.4.2

## Expected Behavior
- 13.10.x no longer has a critical dependabot alert around loader-utils since it will be version 1.4.2

## Related Issue(s)
- https://github.com/nrwl/nx/issues/19025
