### PR TITLE
fix(linter): handle non-JSON eslintrc files when updating overrides

### DIFF
--- a/e2e/node/src/node.test.ts
+++ b/e2e/node/src/node.test.ts
@@ -142,7 +142,7 @@ describe('Node Applications', () => {
       }
     ).toString();
     expect(additionalResult).toContain('Hello Additional World!');
-  }, 60000);
+  }, 300_000);
 
   it('should be able to generate an empty application with variable in .env file', async () => {
     const originalEnvPort = process.env.PORT;

--- a/packages/linter/src/generators/utils/eslint-file.spec.ts
+++ b/packages/linter/src/generators/utils/eslint-file.spec.ts
@@ -2,6 +2,7 @@ import {
   baseEsLintConfigFile,
   eslintConfigFileWhitelist,
   findEslintFile,
+  lintConfigHasOverride,
 } from './eslint-file';
 
 import { Tree } from '@nx/devkit';
@@ -35,5 +36,41 @@ describe('@nx/linter:eslint-file', () => {
         expect(findEslintFile(tree)).toBe(baseEsLintConfigFile);
       }
     );
+  });
+
+  describe('lintConfigHasOverride', () => {
+    it('should return true when override exists in eslintrc format', () => {
+      tree.write(
+        '.eslintrc.json',
+        '{"overrides": [{ "files": ["*.ts"], "rules": {} }]}'
+      );
+      expect(
+        lintConfigHasOverride(
+          tree,
+          '.',
+          (o) => {
+            return o.files?.includes('*.ts');
+          },
+          false
+        )
+      ).toBe(true);
+    });
+
+    it('should return false when eslintrc is not in JSON format', () => {
+      tree.write(
+        '.eslintrc.js',
+        'module.exports = {overrides: [{ files: ["*.ts"], rules: {} }]};'
+      );
+      expect(
+        lintConfigHasOverride(
+          tree,
+          '.',
+          (o) => {
+            return o.files?.includes('*.ts');
+          },
+          false
+        )
+      ).toBe(false);
+    });
   });
 });

--- a/packages/linter/src/generators/utils/eslint-file.ts
+++ b/packages/linter/src/generators/utils/eslint-file.ts
@@ -247,7 +247,10 @@ export function lintConfigHasOverride(
       root,
       isBase ? baseEsLintConfigFile : '.eslintrc.json'
     );
-    return readJson(tree, fileName).overrides?.some(lookup) || false;
+
+    return tree.exists(fileName)
+      ? readJson(tree, fileName).overrides?.some(lookup) || false
+      : false;
   }
 }
 


### PR DESCRIPTION
The new ESLint overrides update logic only works if the config is:
1. `.esilntrc.json` -- we assume config is JSON when updating old config format
2. `eslint.config.js` -- we support new flat config format, but it is different from existing `.eslintrc.js` format 

For other formats like `.eslintrc.js`, `.eslintrc.yaml`, etc., we should ignore updating the overrides entry since they are not in the expected format .

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #19020
