### PR TITLE
fix(core): register ts transpiler when running .ts backed plugins

### DIFF
--- a/packages/nx/src/utils/nx-plugin.ts
+++ b/packages/nx/src/utils/nx-plugin.ts
@@ -172,8 +172,16 @@ function getPluginPathAndName(
   }
   const packageJsonPath = path.join(pluginPath, 'package.json');
 
+  const extension = path.extname(pluginPath);
+
+  // Register the ts-transpiler if we are pointing to a
+  // plain ts file that's not part of a plugin project
+  if (extension === '.ts' && !tsNodeAndPathsRegistered) {
+    registerPluginTSTranspiler();
+  }
+
   const { name } =
-    !['.ts', '.js'].some((x) => x === path.extname(pluginPath)) && // Not trying to point to a ts or js file
+    !['.ts', '.js'].some((x) => x === extension) && // Not trying to point to a ts or js file
     existsSync(packageJsonPath) // plugin has a package.json
       ? readJsonFile(packageJsonPath) // read name from package.json
       : { name: moduleName };


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We resolve .ts based plugins correctly, but they error on valid TS syntax if it isn't valid JS syntax.

## Expected Behavior
We transpile TS in memory before running the plugin

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
