### PR TITLE
fix(bundling): consider index/folder imports in manual file resolution

### DIFF
--- a/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
+++ b/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
@@ -163,9 +163,14 @@ There should at least be a tsconfig.base.json or tsconfig.json in the root of th
 
   function findFile(path: string): string {
     for (const ext of options.extensions) {
-      const r = resolve(path + ext);
-      if (existsSync(r)) {
-        return r;
+      const resolvedPath = resolve(path + ext);
+      if (existsSync(resolvedPath)) {
+        return resolvedPath;
+      }
+
+      const resolvedIndexPath = resolve(path, `index${ext}`);
+      if (existsSync(resolvedIndexPath)) {
+        return resolvedIndexPath;
       }
     }
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`nxViteTsPaths` manual fallback resolution does not take index/folder imports into account.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`nxViteTsPaths` manual fallback resolution should be able to resolve index/folder imports when importing via a configured TS path with placeholder.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #19028
