### PR TITLE
fix(getOutputsForTargetAndConfiguration): default node.data.targets to{}

### DIFF
--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -142,8 +142,8 @@ export function getOutputsForTargetAndConfiguration(
   node: ProjectGraphProjectNode
 ): string[] {
   const { target, configuration } = task.target;
-
-  const targetConfiguration = node.data.targets[target];
+  // @ts-ignore
+  const targetConfiguration = node.data.targets ? node.data.targets[target] : {};
 
   const options = {
     ...targetConfiguration.options,


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
NX is crashing when using the (monodon) rust plugin because node.data.targets is undefined

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
This PR fixes that by using a empty object as the default value

This might be a bad solution, i just did this patch on my node_modules and it worked, feel free to beat me up in the comments :sweat_smile: 
