### PR TITLE
chore(repo): change codeowner for community plugins to docs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -156,7 +156,7 @@ pnpm-lock.yaml @nrwl/nx-core-reviewers
 # Misc
 /e2e/lerna-smoke-tests/** @vsavkin @JamesHenry
 /e2e/utils/** @meeroslav @nrwl/nx-testing-tools-reviewers @vsavkin @mandarini
-/community @nrwl/nx-devkit-reviewers
+/community @nrwl/nx-docs-reviewers
 /CONTRIBUTING.md @FrozenPandaz @isaacplmann
 /CODE_OF_CONDUCT.md @FrozenPandaz @isaacplmann
 /CODEOWNERS @FrozenPandaz @AgentEnder


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The devkit team owns the community plugins.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The docs team owns the community plugins.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
