### PR TITLE
fix(linter): ensure config manipulations are run only if config is supported

### DIFF
--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -267,18 +267,21 @@ export async function addLint(
     // nx-ignore-next-line
   } = require('@nx/linter/src/generators/utils/eslint-file');
 
+  // if config is not supported, we don't need to do anything
+  if (!isEslintConfigSupported(tree)) {
+    return task;
+  }
+
   // Also update the root ESLint config. The lintProjectGenerator will not generate it for root projects.
   // But we need to set the package.json checks.
   if (options.rootProject) {
-    if (isEslintConfigSupported(tree)) {
-      addOverrideToLintConfig(tree, '', {
-        files: ['*.json'],
-        parser: 'jsonc-eslint-parser',
-        rules: {
-          '@nx/dependency-checks': 'error',
-        },
-      });
-    }
+    addOverrideToLintConfig(tree, '', {
+      files: ['*.json'],
+      parser: 'jsonc-eslint-parser',
+      rules: {
+        '@nx/dependency-checks': 'error',
+      },
+    });
   }
 
   // If project lints package.json with @nx/dependency-checks, then add ignore files for

--- a/packages/linter/src/generators/utils/eslint-file.ts
+++ b/packages/linter/src/generators/utils/eslint-file.ts
@@ -55,7 +55,7 @@ export function findEslintFile(tree: Tree, projectRoot = ''): string | null {
 export function isEslintConfigSupported(tree: Tree, projectRoot = ''): boolean {
   const eslintFile = findEslintFile(tree, projectRoot);
   if (!eslintFile) {
-    return;
+    return false;
   }
   return eslintFile.endsWith('.json') || eslintFile.endsWith('.config.js');
 }

--- a/packages/linter/src/generators/utils/eslint-file.ts
+++ b/packages/linter/src/generators/utils/eslint-file.ts
@@ -233,6 +233,9 @@ export function lintConfigHasOverride(
   lookup: (override: Linter.ConfigOverride<Linter.RulesRecord>) => boolean,
   checkBaseConfig = false
 ): boolean {
+  if (!isEslintConfigSupported(tree, root)) {
+    return false;
+  }
   const isBase =
     checkBaseConfig && findEslintFile(tree, root).includes('.base');
   if (useFlatConfig(tree)) {
@@ -248,9 +251,7 @@ export function lintConfigHasOverride(
       isBase ? baseEsLintConfigFile : '.eslintrc.json'
     );
 
-    return tree.exists(fileName)
-      ? readJson(tree, fileName).overrides?.some(lookup) || false
-      : false;
+    return readJson(tree, fileName).overrides?.some(lookup) || false;
   }
 }
 

--- a/packages/linter/src/migrations/update-16-8-0-add-ignored-files/update-16-8-0-add-ignored-files.spec.ts
+++ b/packages/linter/src/migrations/update-16-8-0-add-ignored-files/update-16-8-0-add-ignored-files.spec.ts
@@ -8,6 +8,7 @@ describe('update-16-8-0-add-ignored-files migration', () => {
 
   beforeEach(() => {
     tree = createTreeWithEmptyWorkspace();
+    tree.write('.eslintrc.json', '{}');
   });
 
   it('should run successfully when eslint config is not present', async () => {

--- a/packages/linter/src/migrations/update-16-8-0-add-ignored-files/update-16-8-0-add-ignored-files.ts
+++ b/packages/linter/src/migrations/update-16-8-0-add-ignored-files/update-16-8-0-add-ignored-files.ts
@@ -17,8 +17,12 @@ export default function update(tree: Tree) {
   const addIgnorePattern =
     (ignorePattern: string) => (_options: unknown, projectName: string) => {
       const project = projects.get(projectName);
-      if (!findEslintFile(tree, project.root) || !isEslintConfigSupported(tree))
+      if (
+        !findEslintFile(tree, project.root) ||
+        !isEslintConfigSupported(tree)
+      ) {
         return;
+      }
       if (
         lintConfigHasOverride(
           tree,

--- a/packages/linter/src/migrations/update-16-8-0-add-ignored-files/update-16-8-0-add-ignored-files.ts
+++ b/packages/linter/src/migrations/update-16-8-0-add-ignored-files/update-16-8-0-add-ignored-files.ts
@@ -2,6 +2,7 @@ import { getProjects, Tree } from '@nx/devkit';
 import { forEachExecutorOptions } from '@nx/devkit/src/generators/executor-options-utils';
 import {
   findEslintFile,
+  isEslintConfigSupported,
   lintConfigHasOverride,
   updateOverrideInLintConfig,
 } from '../../generators/utils/eslint-file';
@@ -16,7 +17,8 @@ export default function update(tree: Tree) {
   const addIgnorePattern =
     (ignorePattern: string) => (_options: unknown, projectName: string) => {
       const project = projects.get(projectName);
-      if (!findEslintFile(tree, project.root)) return;
+      if (!findEslintFile(tree, project.root) || !isEslintConfigSupported(tree))
+        return;
       if (
         lintConfigHasOverride(
           tree,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We do ad hoc checks for existence of eslint config when we detect error

## Expected Behavior
We should use central `isEslintConfigSupported` function, which will help us to potentially add support for more config types and we would need to change just one function.

E.g. migrating from yaml and classic js is fairly trivial after support of json.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Related to https://github.com/nrwl/nx/pull/19026 and https://github.com/nrwl/nx/issues/19020
