### PR TITLE
fix(node): explicitly check that project is a library before updating imports

### DIFF
--- a/packages/node/src/generators/e2e-project/e2e-project.ts
+++ b/packages/node/src/generators/e2e-project/e2e-project.ts
@@ -45,6 +45,7 @@ export async function e2eProjectGeneratorInternal(
   addProjectConfiguration(host, options.e2eProjectName, {
     root: options.e2eProjectRoot,
     implicitDependencies: [options.project],
+    projectType: 'application',
     targets: {
       e2e: {
         executor: '@nx/jest:jest',

--- a/packages/workspace/src/generators/move/lib/update-imports.ts
+++ b/packages/workspace/src/generators/move/lib/update-imports.ts
@@ -34,7 +34,7 @@ export function updateImports(
   schema: NormalizedSchema,
   project: ProjectConfiguration
 ) {
-  if (project.projectType === 'application') {
+  if (project.projectType !== 'library') {
     return;
   }
 


### PR DESCRIPTION
This PR fixes an issue where projects that have no type (e.g. `application` or `library`) cause the move/convert-to-monorepo generator to fail. You will see an error like this:

```
>  NX  Generating @nx/workspace:convert-to-monorepo


 >  NX   unable to find "" in tsconfig.base.json compilerOptions.paths


Error: unable to find "" in tsconfig.base.json compilerOptions.paths
    at updateImports (/Users/zackderose/standalone-example/node_modules/@nx/workspace/src/generators/move/lib/update-imports.js:75:23)
    at moveGeneratorInternal (/Users/zackderose/standalone-example/node_modules/@nx/workspace/src/generators/move/move.js:43:40)
    at async moveGenerator (/Users/zackderose/standalone-example/node_modules/@nx/workspace/src/generators/move/move.js:23:5)
    at async monorepoGenerator (/Users/zackderose/standalone-example/node_modules/@nx/workspace/src/generators/convert-to-monorepo/convert-to-monorepo.js:25:9)
    at async /Users/zackderose/standalone-example/node_modules/nx/src/command-line/generate/generate.js:248:26
    at async handleErrors (/Users/zackderose/standalone-example/node_modules/nx/src/utils/params.js:9:16)
    at async Object.handler (/Users/zackderose/standalone-example/node_modules/nx/src/command-line/generate/command-object.js:13:22)
```

This happens because non-library projects don't have an entry in tsconfig paths, so let's check that `projectType === 'library'` instead of `projectType !== 'application'`.

---

Also, update the node app generator to set `e2e` project as `type: 'application'`, which caused this issue to surface.

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
move and convert-to-monorepo generators fail when project type is undefined.

## Expected Behavior
move and convert-to-monorepo generators work even if project type is undefined.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
