### PR TITLE
fix(core): prettier 3 shouldn't cause errors due to esm + compile cache

### DIFF
--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -51,7 +51,17 @@ function main() {
     process.env.NX_DAEMON = 'false';
     require('nx/src/command-line/nx-commands').commandsObject.argv;
   } else {
-    if (workspace && workspace.type === 'nx') {
+    // v8-compile-cache doesn't support ESM. Attempting to import ESM
+    // with it enabled results in an error that reads "Invalid host options".
+    //
+    // Angular CLI, and prettier both use ESM so we need to disable it in these cases.
+    if (
+      workspace &&
+      workspace.type === 'nx' &&
+      !['format', 'format:check', 'format:write', 'g', 'generate'].some(
+        (cmd) => process.argv[3] === cmd
+      )
+    ) {
       require('v8-compile-cache');
     }
     // polyfill rxjs observable to avoid issues with multiple version of Observable installed in node_modules


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Folks receive a weird invalid host options received error when trying to run prettier v3 or other ESM packages during generators or `format`

## Expected Behavior
These errors don't happen.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18974 
Fixes #18721
