### PR TITLE
feat(js): support finding imports in .vue files

### DIFF
--- a/packages/nx/src/native/plugins/js/ts_import_locators.rs
+++ b/packages/nx/src/native/plugins/js/ts_import_locators.rs
@@ -817,6 +817,121 @@ import 'a4'; import 'a5';
     }
 
     #[test]
+    fn should_find_imports_in_vue_files() {
+        let temp_dir = TempDir::new().unwrap();
+        temp_dir
+            .child("test.vue")
+            .write_str(
+                r#"
+
+                <script setup lang="ts">
+import { VueComponent } from './component.vue'
+import('./dynamic-import.vue')
+</script>
+
+<template>
+  <WelcomeItem>
+    <template #icon>
+      <DocumentationIcon />
+    </template>
+    <template #heading>Documentation</template>
+
+    Vue’s
+    <a href="https://vuejs.org/" target="_blank" rel="noopener">official documentation</a>
+    provides you with all information you need to get started.
+  </WelcomeItem>
+
+  <WelcomeItem>
+    <template #icon>
+      <ToolingIcon />
+    </template>
+    <template #heading>Tooling</template>
+
+    This project is served and bundled with
+    <a href="https://vitejs.dev/guide/features.html" target="_blank" rel="noopener">Vite</a>. The
+    recommended IDE setup is
+    <a href="https://code.visualstudio.com/" target="_blank" rel="noopener">VSCode</a> +
+    <a href="https://github.com/johnsoncodehk/volar" target="_blank" rel="noopener">Volar</a>. If
+    you need to test your components and web pages, check out
+    <a href="https://www.cypress.io/" target="_blank" rel="noopener">Cypress</a> and
+    <a href="https://on.cypress.io/component" target="_blank">Cypress Component Testing</a>.
+
+    <br />
+
+    More instructions are available in <code>README.md</code>.
+  </WelcomeItem>
+
+  <WelcomeItem>
+    <template #icon>
+      <EcosystemIcon />
+    </template>
+    <template #heading>Ecosystem</template>
+
+    Get official tools and libraries for your project:
+    <a href="https://pinia.vuejs.org/" target="_blank" rel="noopener">Pinia</a>,
+    <a href="https://router.vuejs.org/" target="_blank" rel="noopener">Vue Router</a>,
+    <a href="https://test-utils.vuejs.org/" target="_blank" rel="noopener">Vue Test Utils</a>, and
+    <a href="https://github.com/vuejs/devtools" target="_blank" rel="noopener">Vue Dev Tools</a>. If
+    you need more resources, we suggest paying
+    <a href="https://github.com/vuejs/awesome-vue" target="_blank" rel="noopener">Awesome Vue</a>
+    a visit.
+  </WelcomeItem>
+
+  <WelcomeItem>
+    <template #icon>
+      <CommunityIcon />
+    </template>
+    <template #heading>Community</template>
+
+    Got stuck? Ask your question on
+    <a href="https://chat.vuejs.org" target="_blank" rel="noopener">Vue Land</a>, our official
+    Discord server, or
+    <a href="https://stackoverflow.com/questions/tagged/vue.js" target="_blank" rel="noopener"
+      >StackOverflow</a
+    >. You should also subscribe to
+    <a href="https://news.vuejs.org" target="_blank" rel="noopener">our mailing list</a> and follow
+    the official
+    <a href="https://twitter.com/vuejs" target="_blank" rel="noopener">@vuejs</a>
+    twitter account for latest news in the Vue world.
+  </WelcomeItem>
+
+  <WelcomeItem>
+    <template #icon>
+      <SupportIcon />
+    </template>
+    <template #heading>Support Vue</template>
+
+    As an independent project, Vue relies on community backing for its sustainability. You can help
+    us by
+    <a href="https://vuejs.org/sponsor/" target="_blank" rel="noopener">becoming a sponsor</a>.
+  </WelcomeItem>
+</template>
+
+
+            "#,
+            )
+            .unwrap();
+
+        let test_file_path = temp_dir.display().to_string() + "/test.vue";
+
+        let results = find_imports(HashMap::from([(
+            String::from("a"),
+            vec![test_file_path.clone()],
+        )]));
+
+        let result = results.get(0).unwrap();
+
+        assert_eq!(
+            result.static_import_expressions,
+            vec![String::from("./component.vue")]
+        );
+        assert_eq!(
+            result.dynamic_import_expressions,
+            vec![String::from("./dynamic-import.vue")]
+        );
+    }
+
+    #[test]
     fn should_find_imports_in_all_sorts_of_import_statements() {
         let temp_dir = TempDir::new().unwrap();
         temp_dir

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.ts
@@ -46,6 +46,11 @@ export function buildExplicitTypeScriptDependencies({
 
   const moduleExtensions = ['.ts', '.js', '.tsx', '.jsx', '.mts', '.mjs'];
 
+  // TODO: This can be removed when vue is stable
+  if (isVuePluginInstalled()) {
+    moduleExtensions.push('.vue');
+  }
+
   for (const [project, fileData] of Object.entries(fileMap)) {
     filesToProcess[project] ??= [];
     for (const { file } of fileData) {
@@ -102,4 +107,14 @@ export function buildExplicitTypeScriptDependencies({
   }
 
   return res;
+}
+
+function isVuePluginInstalled() {
+  try {
+    // nx-ignore-next-line
+    require.resolve('@nx/vue');
+    return true;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The Nx Typescript Analysis Plugin does not support `.vue` files.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The Nx Typescript Analysis Plugin supports `.vue` files if the `@nx/vue` plugin (which isn't published yet) is installed

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
