### PR TITLE
fix(react): set "watch: false" on module federation serve-static options

### DIFF
--- a/packages/react/src/rules/update-module-federation-project.ts
+++ b/packages/react/src/rules/update-module-federation-project.ts
@@ -38,6 +38,7 @@ export function updateModuleFederationProject(
     defaultConfiguration: 'production',
     options: {
       buildTarget: `${options.projectName}:build`,
+      watch: false,
       port: options.devServerPort,
     },
     configurations: {


### PR DESCRIPTION
file-server watches for changes by default, which defeats the purpose of static serve

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Static remotes are also reloaded on changes.

## Expected Behavior
Static remotes should not reload on changes.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
