### PR TITLE
docs(misc): run nx-dev e2e only through Chrome to speed up the test suite

### DIFF
--- a/nx-dev/nx-dev-e2e/project.json
+++ b/nx-dev/nx-dev-e2e/project.json
@@ -15,7 +15,8 @@
       "executor": "@nx/playwright:playwright",
       "outputs": ["{workspaceRoot}/dist/.playwright/nx-dev/nx-dev-e2e"],
       "options": {
-        "config": "nx-dev/nx-dev-e2e/playwright.config.ts"
+        "config": "nx-dev/nx-dev-e2e/playwright.config.ts",
+        "project": ["chromium"]
       }
     }
   },


### PR DESCRIPTION
We're just checking links and static content, so running through Chrome, Firefox, and Safari is overkill and makes each PR unnecessarily slow.


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
