### PR TITLE
feat(react): Add versioning for workspace libraries

### DIFF
--- a/packages/angular/src/utils/mf/utils.ts
+++ b/packages/angular/src/utils/mf/utils.ts
@@ -124,7 +124,9 @@ export async function getModuleFederationConfig(
   });
 
   const sharedDependencies = {
-    ...sharedLibraries.getLibraries(),
+    ...sharedLibraries.getLibraries(
+      projectGraph.nodes[mfConfig.name].data.root
+    ),
     ...npmPackages,
   };
 

--- a/packages/react/src/module-federation/utils.ts
+++ b/packages/react/src/module-federation/utils.ts
@@ -84,7 +84,7 @@ export async function getModuleFederationConfig(
   const npmPackages = sharePackages(dependencies.npmPackages);
 
   const sharedDependencies = {
-    ...sharedLibraries.getLibraries(),
+    ...sharedLibraries.getLibraries(project.root),
     ...npmPackages,
   };
 

--- a/packages/webpack/src/utils/module-federation/models/index.ts
+++ b/packages/webpack/src/utils/module-federation/models/index.ts
@@ -1,6 +1,7 @@
 import type { NormalModuleReplacementPlugin } from 'webpack';
 
 export type ModuleFederationLibrary = { type: string; name: string };
+
 export type WorkspaceLibrary = {
   name: string;
   root: string;
@@ -9,7 +10,10 @@ export type WorkspaceLibrary = {
 
 export type SharedWorkspaceLibraryConfig = {
   getAliases: () => Record<string, string>;
-  getLibraries: (eager?: boolean) => Record<string, SharedLibraryConfig>;
+  getLibraries: (
+    projectRoot: string,
+    eager?: boolean
+  ) => Record<string, SharedLibraryConfig>;
   getReplacementPlugin: () => NormalModuleReplacementPlugin;
 };
 


### PR DESCRIPTION
This PR grants users the ability to add versioning for their workspace libraries.

At build time inside `withModuleFederation` get each workspace library's version by:

1. Looking at the parent's `package.json` to get the version range
2. If not found in the root we look at the library's `package.json` to get the fixed version
3. If neither is found, we do not do any versioning and the functionality remains as is currently.

If the need arises where you do not want this functionality (since it is the current default) you can override it by using the `shared` API inside of the `module-federation.config.js`.

When your code is built you can check the build artifact's `remoteEntry.js` for your `host`/`remote` and you should see your workspace library registered with a version.
