### PR TITLE
fix(linter): sync @eslint/js with the eslintVersion instead of the eslintrc

### DIFF
--- a/packages/linter/src/generators/convert-to-flat-config/converters/json-converter.ts
+++ b/packages/linter/src/generators/convert-to-flat-config/converters/json-converter.ts
@@ -7,7 +7,7 @@ import {
 import { join } from 'path';
 import { ESLint } from 'eslint';
 import * as ts from 'typescript';
-import { eslintrcVersion } from '../../../utils/versions';
+import { eslintVersion, eslintrcVersion } from '../../../utils/versions';
 import {
   createNodeList,
   generateAst,
@@ -255,7 +255,7 @@ function addExtends(
         tree,
         {},
         {
-          '@eslint/js': eslintrcVersion,
+          '@eslint/js': eslintVersion,
         }
       );
 
@@ -279,7 +279,7 @@ function addExtends(
       tree,
       {},
       {
-        '@eslint/js': eslintrcVersion,
+        '@eslint/js': eslintVersion,
       }
     );
 

--- a/packages/linter/src/generators/init/init-migration.ts
+++ b/packages/linter/src/generators/init/init-migration.ts
@@ -15,7 +15,7 @@ import {
   getGlobalFlatEslintConfiguration,
 } from './global-eslint-config';
 import { useFlatConfig } from '../../utils/flat-config';
-import { eslintrcVersion } from '../../utils/versions';
+import { eslintVersion } from '../../utils/versions';
 import {
   addBlockToFlatConfigExport,
   addImportToFlatConfig,
@@ -35,7 +35,7 @@ export function migrateConfigToMonorepoStyle(
       tree,
       {},
       {
-        '@eslint/js': eslintrcVersion,
+        '@eslint/js': eslintVersion,
       }
     );
     tree.write(


### PR DESCRIPTION
## Current Behavior

Running the command `nx g @nx/linter:convert-to-flat-config`, adds the dependency@eslint/js with version 2.1.1 (synced with the eslintrc version)

## Expected Behavior

Running the command `nx g @nx/linter:convert-to-flat-config`, adds the dependency@eslint/js with version 8.46.0 (synced with the eslint version)

## Related Issue(s)

Fixes #19064 
