### PR TITLE
fix(core): prettier 3 shouldn't cause errors due to v8 compile cache

### DIFF
--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -59,7 +59,7 @@ function main() {
       workspace &&
       workspace.type === 'nx' &&
       !['format', 'format:check', 'format:write', 'g', 'generate'].some(
-        (cmd) => process.argv[3] === cmd
+        (cmd) => process.argv[2] === cmd
       )
     ) {
       require('v8-compile-cache');


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->


<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

After fix #19042 the errors remain

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Theses errors should no longer appear

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18721 
