### PR TITLE
cleanup(js): upgrade to @babel/plugin-transform-class-properties from 'proposal' version

### DIFF
--- a/docs/shared/mental-model/large-tasks.json
+++ b/docs/shared/mental-model/large-tasks.json
@@ -21176,8 +21176,8 @@
             "hash": "22b0c37a15a16aed47c139ff98f611f33df757be",
             "deps": [
               "npm:@babel/core",
-              "npm:@babel/plugin-proposal-class-properties",
               "npm:@babel/plugin-proposal-decorators",
+              "npm:@babel/plugin-transform-class-properties",
               "npm:@babel/plugin-transform-runtime",
               "npm:@babel/preset-env",
               "npm:@babel/preset-typescript",

--- a/packages/js/.eslintrc.json
+++ b/packages/js/.eslintrc.json
@@ -45,8 +45,8 @@
               // require.resolve is used for these packages
               "source-map-support",
               "@babel/core",
-              "@babel/plugin-proposal-class-properties",
               "@babel/plugin-proposal-decorators",
+              "@babel/plugin-transform-class-properties",
               "@babel/plugin-transform-runtime",
               "@babel/preset-env",
               "@babel/preset-typescript",

--- a/packages/js/babel.ts
+++ b/packages/js/babel.ts
@@ -30,7 +30,7 @@ module.exports = function (api: any, options: NxWebBabelPresetOptions = {}) {
     (caller) => caller?.emitDecoratorMetadata ?? true
   );
 
-  // Determine settings  for `@babel/plugin-proposal-class-properties`,
+  // Determine settings  for `@babel/plugin-transform-class-properties`,
   // so that we can sync the `loose` option with `@babel/preset-env`.
   const classProperties = options.classProperties ?? { loose: true };
 
@@ -54,7 +54,7 @@ module.exports = function (api: any, options: NxWebBabelPresetOptions = {}) {
               bugfixes: true,
               // Exclude transforms that make all code slower
               exclude: ['transform-typeof-symbol'],
-              // This must match the setting for `@babel/plugin-proposal-class-properties`
+              // This must match the setting for `@babel/plugin-proposal-transform-properties`
               loose: classProperties.loose,
             },
       ],
@@ -90,7 +90,7 @@ module.exports = function (api: any, options: NxWebBabelPresetOptions = {}) {
         options.decorators ?? { legacy: true },
       ],
       [
-        require.resolve('@babel/plugin-proposal-class-properties'),
+        require.resolve('@babel/plugin-transform-class-properties'),
         classProperties,
       ],
     ].filter(Boolean),

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -33,8 +33,8 @@
   "builders": "./executors.json",
   "dependencies": {
     "@babel/core": "^7.22.9",
-    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-decorators": "^7.22.7",
+    "@babel/plugin-transform-class-properties": "^7.22.5",
     "@babel/plugin-transform-runtime": "^7.22.9",
     "@babel/preset-env": "^7.22.9",
     "@babel/preset-typescript": "^7.22.5",


### PR DESCRIPTION
## Current Behavior

Installing `@nx/js` results in the following warning message:

```
npm WARN deprecated @babel/plugin-proposal-class-properties@7.18.6: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
```

## Expected Behavior

`@nx/js` should install with no warnings.

## Notes

`pnpm-lock.yaml` [already contains references](https://github.com/nrwl/nx/blob/41551a3197f077e0b12ce4137b39f37f625c1692/pnpm-lock.yaml#L2428-L2437) to the latest `@babel/plugin-transform-class-properties`, so this PR does not include any changes to it.

There are still some references to the older `proposal` version of this dependency in a couple of places:

1. Other dependency paths in the `pnpm` lockfile (expected, since it contains entries such as `metro-react-native-babel-preset` that still depend on the old `proposal` version)
2. Lockfiles used in test fixtures (which I left unmodified in the interest of keeping the changes minimal for this PR)

However, the `@nx/js` package file and code now refer only to the new `transform` version of the dependency. I verified using a local package repository that installing a freshly-built `@nx/js` results in a `package-lock.json` that correctly depends on `@babel/plugin-transform-class-properties`.

## Related Issue(s)

Fixes #19016
