### PR TITLE
chore(repo): update nightly node versions

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -24,15 +24,12 @@ jobs:
           - ubuntu-latest
           - macos-latest
         node_version:
-          - 19
+          - 20
           - 18
-          - 16
         exclude:
           # run just node v18 on macos
           - os: macos-latest
-            node_version: 19
-          - os: macos-latest
-            node_version: 16
+            node_version: 20
 
     name: Cache install (${{ matrix.os }}, node v${{ matrix.node_version }})
     steps:
@@ -100,9 +97,8 @@ jobs:
           - ubuntu-latest
           - macos-latest
         node_version:
-          - 19
+          - 20
           - 18
-          - 16
         package_manager:
           - npm
           - yarn
@@ -210,101 +206,53 @@ jobs:
           - os: ubuntu-latest
             project: e2e-expo
           # exclude non-CNW/Lerna tests from non-LTS node versions
-          - node_version: 16
+          - node_version: 20
             project: e2e-angular-core
-          - node_version: 16
+          - node_version: 20
             project: e2e-angular-extensions
-          - node_version: 16
+          - node_version: 20
             project: e2e-cypress
-          - node_version: 16
+          - node_version: 20
             project: e2e-detox
-          - node_version: 16
+          - node_version: 20
             project: e2e-esbuild
-          - node_version: 16
+          - node_version: 20
             project: e2e-expo
-          - node_version: 16
+          - node_version: 20
             project: e2e-jest
-          - node_version: 16
+          - node_version: 20
             project: e2e-js
-          - node_version: 16
+          - node_version: 20
             project: e2e-linter
-          - node_version: 16
+          - node_version: 20
             project: e2e-next
-          - node_version: 16
+          - node_version: 20
             project: e2e-node
-          - node_version: 16
+          - node_version: 20
             project: e2e-nx-init
-          - node_version: 16
+          - node_version: 20
             project: e2e-nx-misc
-          - node_version: 16
+          - node_version: 20
             project: e2e-nx-plugin
-          - node_version: 16
+          - node_version: 20
             project: e2e-lerna-smoke-tests
-          - node_version: 16
+          - node_version: 20
             project: e2e-react-core
-          - node_version: 16
+          - node_version: 20
             project: e2e-react-extensions
-          - node_version: 16
+          - node_version: 20
             project: e2e-react-native
-          - node_version: 16
+          - node_version: 20
             project: e2e-web
-          - node_version: 16
+          - node_version: 20
             project: e2e-rollup
-          - node_version: 16
+          - node_version: 20
             project: e2e-storybook
-          - node_version: 16
+          - node_version: 20
             project: e2e-storybook-angular
-          - node_version: 16
+          - node_version: 20
             project: e2e-vite
-          - node_version: 16
-            project: e2e-webpack
-          - node_version: 19
-            project: e2e-angular-core
-          - node_version: 19
-            project: e2e-angular-extensions
-          - node_version: 19
-            project: e2e-cypress
-          - node_version: 19
-            project: e2e-detox
-          - node_version: 19
-            project: e2e-esbuild
-          - node_version: 19
-            project: e2e-expo
-          - node_version: 19
-            project: e2e-jest
-          - node_version: 19
-            project: e2e-js
-          - node_version: 19
-            project: e2e-linter
-          - node_version: 19
-            project: e2e-next
-          - node_version: 19
-            project: e2e-node
-          - node_version: 19
-            project: e2e-nx-init
-          - node_version: 19
-            project: e2e-nx-misc
-          - node_version: 19
-            project: e2e-nx-plugin
-          - node_version: 19
-            project: e2e-lerna-smoke-tests
-          - node_version: 19
-            project: e2e-react-core
-          - node_version: 19
-            project: e2e-react-extensions
-          - node_version: 19
-            project: e2e-react-native
-          - node_version: 19
-            project: e2e-web
-          - node_version: 19
-            project: e2e-rollup
-          - node_version: 19
-            project: e2e-storybook
-          - node_version: 19
-            project: e2e-storybook-angular
-          - node_version: 19
-            project: e2e-vite
-          - node_version: 19
+          - node_version: 20
             project: e2e-webpack
           # run just npm v18 on macos
           - os: macos-latest
@@ -312,9 +260,7 @@ jobs:
           - os: macos-latest
             package_manager: pnpm
           - os: macos-latest
-            node_version: 16
-          - os: macos-latest
-            node_version: 19
+            node_version: 20
       fail-fast: false
 
     name: ${{ matrix.os_name }}/${{ matrix.package_manager }}/${{ matrix.node_version }} ${{ join(matrix.project) }}

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -26,10 +26,13 @@ jobs:
         node_version:
           - 20
           - 18
+          - 16
         exclude:
           # run just node v18 on macos
           - os: macos-latest
             node_version: 20
+          - os: macos-latest
+            node_version: 16
 
     name: Cache install (${{ matrix.os }}, node v${{ matrix.node_version }})
     steps:
@@ -99,6 +102,7 @@ jobs:
         node_version:
           - 20
           - 18
+          - 16
         package_manager:
           - npm
           - yarn
@@ -206,6 +210,54 @@ jobs:
           - os: ubuntu-latest
             project: e2e-expo
           # exclude non-CNW/Lerna tests from non-LTS node versions
+          - node_version: 16
+            project: e2e-angular-core
+          - node_version: 16
+            project: e2e-angular-extensions
+          - node_version: 16
+            project: e2e-cypress
+          - node_version: 16
+            project: e2e-detox
+          - node_version: 16
+            project: e2e-esbuild
+          - node_version: 16
+            project: e2e-expo
+          - node_version: 16
+            project: e2e-jest
+          - node_version: 16
+            project: e2e-js
+          - node_version: 16
+            project: e2e-linter
+          - node_version: 16
+            project: e2e-next
+          - node_version: 16
+            project: e2e-node
+          - node_version: 16
+            project: e2e-nx-init
+          - node_version: 16
+            project: e2e-nx-misc
+          - node_version: 16
+            project: e2e-nx-plugin
+          - node_version: 16
+            project: e2e-lerna-smoke-tests
+          - node_version: 16
+            project: e2e-react-core
+          - node_version: 16
+            project: e2e-react-extensions
+          - node_version: 16
+            project: e2e-react-native
+          - node_version: 16
+            project: e2e-web
+          - node_version: 16
+            project: e2e-rollup
+          - node_version: 16
+            project: e2e-storybook
+          - node_version: 16
+            project: e2e-storybook-angular
+          - node_version: 16
+            project: e2e-vite
+          - node_version: 16
+            project: e2e-webpack
           - node_version: 20
             project: e2e-angular-core
           - node_version: 20
@@ -259,6 +311,8 @@ jobs:
             package_manager: yarn
           - os: macos-latest
             package_manager: pnpm
+          - os: macos-latest
+            node_version: 16
           - os: macos-latest
             node_version: 20
       fail-fast: false

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -23,6 +23,7 @@ jobs:
         node_version:
           - 20
           - 18
+          - 16
 
     name: Cache install (node v${{ matrix.node_version }})
     steps:
@@ -74,6 +75,7 @@ jobs:
         node_version:
           - 20
           - 18
+          - 16
         package_manager:
           - npm
         project:
@@ -153,6 +155,48 @@ jobs:
             codeowners: 'S04SYHYKGNP'
         exclude:
           # exclude non-CNW/Lerna tests from non-LTS node versions
+          - node_version: 16
+            project: e2e-angular-core
+          - node_version: 16
+            project: e2e-angular-extensions
+          - node_version: 16
+            project: e2e-cypress
+          - node_version: 16
+            project: e2e-esbuild
+          - node_version: 16
+            project: e2e-jest
+          - node_version: 16
+            project: e2e-js
+          - node_version: 16
+            project: e2e-linter
+          - node_version: 16
+            project: e2e-next
+          - node_version: 16
+            project: e2e-node
+          - node_version: 16
+            project: e2e-nx-init
+          - node_version: 16
+            project: e2e-nx-misc
+          - node_version: 16
+            project: e2e-plugin
+          - node_version: 16
+            project: e2e-lerna-smoke-tests
+          - node_version: 16
+            project: e2e-react-core
+          - node_version: 16
+            project: e2e-react-extensions
+          - node_version: 16
+            project: e2e-web
+          - node_version: 16
+            project: e2e-rollup
+          - node_version: 16
+            project: e2e-storybook
+          - node_version: 16
+            project: e2e-storybook-angular
+          - node_version: 16
+            project: e2e-vite
+          - node_version: 16
+            project: e2e-webpack
           - node_version: 20
             project: e2e-angular-core
           - node_version: 20

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -21,9 +21,8 @@ jobs:
     strategy:
       matrix:
         node_version:
-          - 19
+          - 20
           - 18
-          - 16
 
     name: Cache install (node v${{ matrix.node_version }})
     steps:
@@ -73,9 +72,8 @@ jobs:
     strategy:
       matrix:
         node_version:
-          - 19
+          - 20
           - 18
-          - 16
         package_manager:
           - npm
         project:
@@ -155,89 +153,47 @@ jobs:
             codeowners: 'S04SYHYKGNP'
         exclude:
           # exclude non-CNW/Lerna tests from non-LTS node versions
-          - node_version: 16
+          - node_version: 20
             project: e2e-angular-core
-          - node_version: 16
+          - node_version: 20
             project: e2e-angular-extensions
-          - node_version: 16
+          - node_version: 20
             project: e2e-cypress
-          - node_version: 16
+          - node_version: 20
             project: e2e-esbuild
-          - node_version: 16
+          - node_version: 20
             project: e2e-jest
-          - node_version: 16
+          - node_version: 20
             project: e2e-js
-          - node_version: 16
+          - node_version: 20
             project: e2e-linter
-          - node_version: 16
+          - node_version: 20
             project: e2e-next
-          - node_version: 16
+          - node_version: 20
             project: e2e-node
-          - node_version: 16
+          - node_version: 20
             project: e2e-nx-init
-          - node_version: 16
+          - node_version: 20
             project: e2e-nx-misc
-          - node_version: 16
+          - node_version: 20
             project: e2e-plugin
-          - node_version: 16
+          - node_version: 20
             project: e2e-lerna-smoke-tests
-          - node_version: 16
+          - node_version: 20
             project: e2e-react-core
-          - node_version: 16
+          - node_version: 20
             project: e2e-react-extensions
-          - node_version: 16
+          - node_version: 20
             project: e2e-web
-          - node_version: 16
+          - node_version: 20
             project: e2e-rollup
-          - node_version: 16
+          - node_version: 20
             project: e2e-storybook
-          - node_version: 16
+          - node_version: 20
             project: e2e-storybook-angular
-          - node_version: 16
+          - node_version: 20
             project: e2e-vite
-          - node_version: 16
-            project: e2e-webpack
-          - node_version: 19
-            project: e2e-angular-core
-          - node_version: 19
-            project: e2e-angular-extensions
-          - node_version: 19
-            project: e2e-cypress
-          - node_version: 19
-            project: e2e-esbuild
-          - node_version: 19
-            project: e2e-jest
-          - node_version: 19
-            project: e2e-js
-          - node_version: 19
-            project: e2e-linter
-          - node_version: 19
-            project: e2e-next
-          - node_version: 19
-            project: e2e-node
-          - node_version: 19
-            project: e2e-nx-init
-          - node_version: 19
-            project: e2e-nx-misc
-          - node_version: 19
-            project: e2e-plugin
-          - node_version: 19
-            project: e2e-lerna-smoke-tests
-          - node_version: 19
-            project: e2e-react-core
-          - node_version: 19
-            project: e2e-react-extensions
-          - node_version: 19
-            project: e2e-web
-          - node_version: 19
-            project: e2e-rollup
-          - node_version: 19
-            project: e2e-storybook
-          - node_version: 19
-            project: e2e-storybook-angular
-          - node_version: 19
-            project: e2e-vite
-          - node_version: 19
+          - node_version: 20
             project: e2e-webpack
       fail-fast: false
 


### PR DESCRIPTION
## Current

Node v16 expires soon and v19 has been dead for a while.

Meanwhile, we don't test for v20.

## Expected
Nightly should run on v18 and v20

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
