### PR TITLE
feat(js): warn users when additionalEntryPoints do not match any files

### DIFF
--- a/packages/js/src/executors/tsc/tsc.batch-impl.ts
+++ b/packages/js/src/executors/tsc/tsc.batch-impl.ts
@@ -4,10 +4,7 @@ import type { BatchExecutorTaskResult } from 'nx/src/config/misc-interfaces';
 import { getLastValueFromAsyncIterableIterator } from 'nx/src/utils/async-iterator';
 import { updatePackageJson } from '../../utils/package-json/update-package-json';
 import type { ExecutorOptions } from '../../utils/schema';
-import {
-  createEntryPoints,
-  determineModuleFormatFromTsConfig,
-} from './tsc.impl';
+import { determineModuleFormatFromTsConfig } from './tsc.impl';
 import {
   TypescripCompilationLogger,
   TypescriptCompilationResult,
@@ -23,6 +20,7 @@ import {
   watchTaskProjectsFileChangesForAssets,
   watchTaskProjectsPackageJsonFileChanges,
 } from './lib/batch';
+import { createEntryPoints } from '../../utils/package-json/create-entry-points';
 
 export async function* tscBatchExecutor(
   taskGraph: TaskGraph,
@@ -87,7 +85,10 @@ export async function* tscBatchExecutor(
       updatePackageJson(
         {
           ...taskInfo.options,
-          additionalEntryPoints: createEntryPoints(taskInfo.options, context),
+          additionalEntryPoints: createEntryPoints(
+            taskInfo.options.additionalEntryPoints,
+            context.root
+          ),
           format: [determineModuleFormatFromTsConfig(tsConfig)],
           // As long as d.ts files match their .js counterparts, we don't need to emit them.
           // TSC can match them correctly based on file names.
@@ -127,7 +128,10 @@ export async function* tscBatchExecutor(
             updatePackageJson(
               {
                 ...t.options,
-                additionalEntryPoints: createEntryPoints(t.options, context),
+                additionalEntryPoints: createEntryPoints(
+                  t.options.additionalEntryPoints,
+                  context.root
+                ),
                 format: [determineModuleFormatFromTsConfig(t.options.tsConfig)],
                 // As long as d.ts files match their .js counterparts, we don't need to emit them.
                 // TSC can match them correctly based on file names.

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -10,6 +10,7 @@ export * from './utils/typescript/ast-utils';
 export * from './utils/package-json';
 export * from './utils/assets';
 export * from './utils/package-json/update-package-json';
+export * from './utils/package-json/create-entry-points';
 export { libraryGenerator } from './generators/library/library';
 export { initGenerator } from './generators/init/init';
 

--- a/packages/js/src/utils/package-json/create-entry-points.ts
+++ b/packages/js/src/utils/package-json/create-entry-points.ts
@@ -1,0 +1,22 @@
+import { sync as globSync } from 'fast-glob';
+import { logger } from '@nx/devkit';
+
+export function createEntryPoints(
+  additionalEntryPoints: undefined | string[],
+  root: string
+): string[] {
+  if (!additionalEntryPoints?.length) return [];
+  const files = [];
+  // NOTE: calling globSync for each pattern is slower than calling it all at once.
+  // We're doing it this way in order to show a warning for unmatched patterns.
+  // If a pattern is unmatched, it is very likely a mistake by the user.
+  // Performance impact should be negligible since there shouldn't be that many entry points.
+  // Benchmarks show only 1-3% difference in execution time.
+  for (const pattern of additionalEntryPoints) {
+    const matched = globSync([pattern], { cwd: root });
+    if (!matched.length)
+      logger.warn(`The pattern ${pattern} did not match any files.`);
+    files.push(...matched);
+  }
+  return files;
+}

--- a/packages/rollup/src/executors/rollup/lib/normalize.ts
+++ b/packages/rollup/src/executors/rollup/lib/normalize.ts
@@ -4,6 +4,7 @@ import { statSync } from 'fs';
 import { ExecutorContext, normalizePath } from '@nx/devkit';
 
 import type { AssetGlobPattern, RollupExecutorOptions } from '../schema';
+import { createEntryPoints } from '@nx/js';
 
 export interface NormalizedRollupExecutorOptions extends RollupExecutorOptions {
   entryRoot: string;
@@ -47,7 +48,10 @@ export function normalizeRollupExecutorOptions(
     projectRoot,
     outputPath,
     skipTypeCheck: options.skipTypeCheck || false,
-    additionalEntryPoints: createEntryPoints(options, context),
+    additionalEntryPoints: createEntryPoints(
+      options.additionalEntryPoints,
+      context.root
+    ),
   };
 }
 
@@ -106,15 +110,5 @@ export function normalizeAssets(
         output: asset.output.replace(/^\//, ''),
       };
     }
-  });
-}
-
-function createEntryPoints(
-  options: { additionalEntryPoints?: string[] },
-  context: ExecutorContext
-): string[] {
-  if (!options.additionalEntryPoints?.length) return [];
-  return globSync(options.additionalEntryPoints, {
-    cwd: context.root,
   });
 }


### PR DESCRIPTION
When files in `additionalEntryPoints` do not match any files, it is very likely a mistake by the user. The warning will allow them to correct the pattern or remove it if it is unused.


## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
