### PR TITLE
cleanup(devkit): improve error messaging when project doesnt exist for readTargetOptions

### DIFF
--- a/packages/devkit/src/executors/read-target-options.ts
+++ b/packages/devkit/src/executors/read-target-options.ts
@@ -27,6 +27,11 @@ export function readTargetOptions<T = any>(
   const projectConfiguration = (
     context.workspace || context.projectsConfigurations
   ).projects[project];
+
+  if (!projectConfiguration) {
+    throw new Error(`Unable to find project ${project}`);
+  }
+
   const targetConfiguration = projectConfiguration.targets[target];
 
   // TODO(v18): remove Workspaces.

--- a/packages/nx/src/utils/split-target.ts
+++ b/packages/nx/src/utils/split-target.ts
@@ -1,5 +1,4 @@
 import { ProjectGraph } from '../config/project-graph';
-import { ProjectConfiguration } from '../config/workspace-json-project-json';
 
 export function splitTarget(
   s: string,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Invalid project passed to `buildTarget` results in a "cannot read properties of undefined, reading `targets`" message

## Expected Behavior
Invalid project passed to `buildTarget` results in a "Unable to find project {project}" message

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
