### PR TITLE
feat(devkit): update `parseTargetString` to allow referencing targets on the current project

### DIFF
--- a/docs/generated/devkit/parseTargetString.md
+++ b/docs/generated/devkit/parseTargetString.md
@@ -35,3 +35,27 @@ parseTargetString('proj:test:production', graph); // returns { project: "proj", 
 #### Returns
 
 [`Target`](../../devkit/documents/Target)
+
+▸ **parseTargetString**(`targetString`, `ctx`): [`Target`](../../devkit/documents/Target)
+
+Parses a target string into {project, target, configuration}. Passing a full
+[ExecutorContext](../../devkit/documents/ExecutorContext) enables the targetString to reference the current project.
+
+Examples:
+
+```typescript
+parseTargetString('test', executorContext); // returns { project: "proj", target: "test" }
+parseTargetString('proj:test', executorContext); // returns { project: "proj", target: "test" }
+parseTargetString('proj:test:production', executorContext); // returns { project: "proj", target: "test", configuration: "production" }
+```
+
+#### Parameters
+
+| Name           | Type                                                        |
+| :------------- | :---------------------------------------------------------- |
+| `targetString` | `string`                                                    |
+| `ctx`          | [`ExecutorContext`](../../devkit/documents/ExecutorContext) |
+
+#### Returns
+
+[`Target`](../../devkit/documents/Target)

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -13,3 +13,4 @@ export { combineOptionsForExecutor } from './utils/params';
 export { sortObjectByKeys } from './utils/object-sort';
 export { stripIndent } from './utils/logger';
 export { readModulePackageJson } from './utils/package-json';
+export { splitByColons } from './utils/split-target';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When an executor takes a `buildTarget` option, it frequently is a target on the current project. Currently, folks must reference the **_full_** target string, starting with the project. This means that the option is filled in with something like: `my-project:build`, even inside of `my-project`'s `project.json` file.

## Expected Behavior
When filling in parameters with a `buildTarget` or similar fields, you can omit the project name if referencing a target on the same project.

> [!NOTE]  
> This PR only updates the helper - follow up PRs will be required for each plugin to pass in the executor context instead of the graph.
