### PR TITLE
feat(core): add bun package manager

### DIFF
--- a/docs/generated/devkit/PackageManager.md
+++ b/docs/generated/devkit/PackageManager.md
@@ -1,3 +1,3 @@
 # Type alias: PackageManager
 
-Ƭ **PackageManager**: `"yarn"` \| `"pnpm"` \| `"npm"`
+Ƭ **PackageManager**: `"yarn"` \| `"pnpm"` \| `"npm"` \| `"bun"`

--- a/packages/expo/src/generators/application/lib/create-application-files.ts
+++ b/packages/expo/src/generators/application/lib/create-application-files.ts
@@ -15,6 +15,7 @@ export function createApplicationFiles(host: Tree, options: NormalizedSchema) {
     npm: 'package-lock.json',
     yarn: 'yarn.lock',
     pnpm: 'pnpm-lock.yaml',
+    bun: 'bun.lockb',
   };
   const packageManager = detectPackageManager(host.root);
   const packageLockFile = packageManagerLockFile[packageManager];

--- a/packages/expo/src/migrations/update-16-1-4/update-eas-scripts.ts
+++ b/packages/expo/src/migrations/update-16-1-4/update-eas-scripts.ts
@@ -19,6 +19,7 @@ export default function update(tree: Tree) {
     npm: 'package-lock.json',
     yarn: 'yarn.lock',
     pnpm: 'pnpm-lock.yaml',
+    bun: 'bun.lockb',
   };
 
   for (const [name, config] of projects.entries()) {

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -201,7 +201,7 @@
         "packageManager": {
           "type": "string",
           "description": "The default package manager to use.",
-          "enum": ["yarn", "pnpm", "npm"]
+          "enum": ["yarn", "pnpm", "npm", "bun"]
         },
         "defaultCollection": {
           "type": "string",

--- a/packages/nx/src/plugins/js/index.ts
+++ b/packages/nx/src/plugins/js/index.ts
@@ -24,6 +24,7 @@ import { hashArray } from '../../hasher/file-hasher';
 import { detectPackageManager } from '../../utils/package-manager';
 import { workspaceRoot } from '../../utils/workspace-root';
 import { nxVersion } from '../../utils/versions';
+import { execSync } from 'child_process';
 
 export const name = 'nx-js-graph-plugin';
 
@@ -50,7 +51,10 @@ export const createNodes: CreateNodes = [
     }
 
     const lockFilePath = join(workspaceRoot, lockFile);
-    const lockFileContents = readFileSync(lockFilePath).toString();
+    const lockFileContents =
+      packageManager !== 'bun'
+        ? readFileSync(lockFilePath).toString()
+        : execSync(lockFilePath).toString();
     const lockFileHash = getLockFileHash(lockFileContents);
 
     if (!lockFileNeedsReprocessing(lockFileHash)) {
@@ -88,7 +92,10 @@ export const createDependencies: CreateDependencies = (
     parsedLockFile
   ) {
     const lockFilePath = join(workspaceRoot, getLockFileName(packageManager));
-    const lockFileContents = readFileSync(lockFilePath).toString();
+    const lockFileContents =
+      packageManager !== 'bun'
+        ? readFileSync(lockFilePath).toString()
+        : execSync(lockFilePath).toString();
     const lockFileHash = getLockFileHash(lockFileContents);
 
     if (!lockFileNeedsReprocessing(lockFileHash)) {

--- a/packages/nx/src/utils/package-manager.spec.ts
+++ b/packages/nx/src/utils/package-manager.spec.ts
@@ -66,13 +66,15 @@ describe('package-manager', () => {
             return false;
           case 'package-lock.json':
             return false;
+          case 'bun.lockb':
+            return false;
           default:
             return jest.requireActual('fs').existsSync(p);
         }
       });
       const packageManager = detectPackageManager();
       expect(packageManager).toEqual('npm');
-      expect(fs.existsSync).toHaveBeenCalledTimes(5);
+      expect(fs.existsSync).toHaveBeenCalledTimes(6);
     });
   });
 


### PR DESCRIPTION
Bun uses yarn lock for it's binary file. Running the binary will produce the content of a yarn lock file (v1)

Other option is to use the -y command on add and install. This will create a yarn lock file and then createLockFile can just modify the yarn.lock file instead?