### PR TITLE
fix(core): detect dependencies in .cjs and .cts files

### DIFF
--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.ts
@@ -63,7 +63,16 @@ export function buildExplicitTypeScriptDependencies(
 
   const filesToProcess: Record<string, string[]> = {};
 
-  const moduleExtensions = ['.ts', '.js', '.tsx', '.jsx', '.mts', '.mjs'];
+  const moduleExtensions = [
+    '.ts',
+    '.js',
+    '.tsx',
+    '.jsx',
+    '.mts',
+    '.mjs',
+    '.cjs',
+    '.cts',
+  ];
 
   // TODO: This can be removed when vue is stable
   if (isVuePluginInstalled()) {


### PR DESCRIPTION
This PR allows dependencies in`.cjs` and `.cts` files to also be detected. It causes issues with `@nx/dependency-checks` among other things.

## Current Behavior
Dependencies from `.cjs` and `.cts` files are missing.

## Expected Behavior
Dependencies from `.cjs` and `.cts` files are picked up.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
