### PR TITLE
chore(angular): move parseTargetString to pass executor context

### DIFF
--- a/packages/angular/src/builders/webpack-dev-server/webpack-dev-server.impl.ts
+++ b/packages/angular/src/builders/webpack-dev-server/webpack-dev-server.impl.ts
@@ -2,6 +2,7 @@ import {
   joinPathFragments,
   parseTargetString,
   readCachedProjectGraph,
+  readNxJson,
 } from '@nx/devkit';
 import { WebpackNxBuildCoordinationPlugin } from '@nx/webpack/src/plugins/webpack-nx-build-coordination-plugin';
 import { DependentBuildableProjectNode } from '@nx/js/src/utils/buildable-libs-utils';
@@ -34,10 +35,13 @@ export function executeWebpackDevServerBuilder(
 
   const options = normalizeOptions(rawOptions);
 
-  const parsedBrowserTarget = parseTargetString(
-    options.browserTarget,
-    readCachedProjectGraph()
-  );
+  const parsedBrowserTarget = parseTargetString(options.browserTarget, {
+    cwd: context.currentDirectory,
+    projectGraph: readCachedProjectGraph(),
+    projectName: context.target.project,
+    root: context.workspaceRoot,
+    isVerbose: false,
+  });
   const browserTargetProjectConfiguration = readCachedProjectConfiguration(
     parsedBrowserTarget.project
   );

--- a/packages/angular/src/executors/delegate-build/delegate-build.impl.ts
+++ b/packages/angular/src/executors/delegate-build/delegate-build.impl.ts
@@ -39,7 +39,7 @@ export async function* delegateBuildExecutor(
   }
 
   const { buildTarget, ...targetOptions } = options;
-  const delegateTarget = parseTargetString(buildTarget, context.projectGraph);
+  const delegateTarget = parseTargetString(buildTarget, context);
 
   yield* await runExecutor(delegateTarget, targetOptions, context);
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When calling `parseTargetString` we pass a project graph, which means that the full target string is required

## Expected Behavior
When calling `parseTargetString` we pass an executor context, which allows using `build` to reference `{projectName}:build`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
