### PR TITLE
chore(testing): move cypress invocations of parseTargetString to pass executor context

### DIFF
--- a/packages/cypress/src/executors/cypress/cypress.impl.ts
+++ b/packages/cypress/src/executors/cypress/cypress.impl.ts
@@ -168,7 +168,7 @@ async function* startDevServer(
 
   const parsedDevServerTarget = parseTargetString(
     opts.devServerTarget,
-    context.projectGraph
+    context
   );
 
   const [targetSupportsWatchOpt] = getValueFromSchema(

--- a/packages/cypress/src/utils/find-target-options.ts
+++ b/packages/cypress/src/utils/find-target-options.ts
@@ -77,7 +77,8 @@ function findInTarget(
   options: FindTargetOptions
 ): TargetConfiguration {
   const { project, target, configuration } = parseTargetString(
-    options.buildTarget
+    options.buildTarget,
+    graph
   );
   const projectConfig = readProjectConfiguration(tree, project);
   const executorName = projectConfig?.targets?.[target]?.executor;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When calling `parseTargetString` we pass a project graph, which means that the full target string is required

## Expected Behavior
When calling `parseTargetString` we pass an executor context, which allows using `build` to reference `{projectName}:build`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
