### PR TITLE
chore(react-native): pass full context to parseTargetString

### DIFF
--- a/packages/detox/src/executors/test/test.impl.ts
+++ b/packages/detox/src/executors/test/test.impl.ts
@@ -27,10 +27,7 @@ export default async function* detoxTestExecutor(
 
   try {
     if (!options.reuse && options.buildTarget) {
-      const buildTarget = parseTargetString(
-        options.buildTarget,
-        context.projectGraph
-      );
+      const buildTarget = parseTargetString(options.buildTarget, context);
       const buildOptions = readTargetOptions<DetoxBuildOptions>(
         buildTarget,
         context


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When calling `parseTargetString` we pass a project graph, which means that the full target string is required

## Expected Behavior
When calling `parseTargetString` we pass an executor context, which allows using `build` to reference `{projectName}:build`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
