### PR TITLE
chore(js): pass full context to parseTargetString

### DIFF
--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -45,10 +45,7 @@ export async function* nodeExecutor(
 ) {
   process.env.NODE_ENV ??= context?.configurationName ?? 'development';
   const project = context.projectGraph.nodes[context.projectName];
-  const buildTarget = parseTargetString(
-    options.buildTarget,
-    context.projectGraph
-  );
+  const buildTarget = parseTargetString(options.buildTarget, context);
 
   if (!project.data.targets[buildTarget.target]) {
     throw new Error(
@@ -313,7 +310,7 @@ function calculateResolveMappings(
   context: ExecutorContext,
   options: NodeExecutorOptions
 ) {
-  const parsed = parseTargetString(options.buildTarget, context.projectGraph);
+  const parsed = parseTargetString(options.buildTarget, context);
   const { dependencies } = calculateProjectBuildableDependencies(
     context.taskGraph,
     context.projectGraph,
@@ -336,7 +333,7 @@ function runWaitUntilTargets(
 ): Promise<{ success: boolean }[]> {
   return Promise.all(
     options.waitUntilTargets.map(async (waitUntilTarget) => {
-      const target = parseTargetString(waitUntilTarget, context.projectGraph);
+      const target = parseTargetString(waitUntilTarget, context);
       const output = await runExecutor(target, {}, context);
       return new Promise<{ success: boolean }>(async (resolve) => {
         let event = await output.next();

--- a/packages/js/src/executors/tsc/lib/batch/build-task-info-per-tsconfig-map.ts
+++ b/packages/js/src/executors/tsc/lib/batch/build-task-info-per-tsconfig-map.ts
@@ -75,7 +75,7 @@ function createTaskInfo(
   context: ExecutorContext,
   tsConfig: TypescriptInMemoryTsConfig
 ): TaskInfo {
-  const target = parseTargetString(taskName, context.projectGraph);
+  const target = parseTargetString(taskName, context);
 
   const taskContext = {
     ...context,

--- a/packages/js/src/executors/tsc/lib/batch/normalize-tasks-options.ts
+++ b/packages/js/src/executors/tsc/lib/batch/normalize-tasks-options.ts
@@ -11,7 +11,7 @@ export function normalizeTasksOptions(
   context: ExecutorContext
 ): Record<string, NormalizedExecutorOptions> {
   return Object.entries(inputs).reduce((tasksOptions, [taskName, options]) => {
-    const { project } = parseTargetString(taskName, context.projectGraph);
+    const { project } = parseTargetString(taskName, context);
     const { sourceRoot, root } =
       context.projectsConfigurations.projects[project];
     tasksOptions[taskName] = normalizeOptions(

--- a/packages/js/src/executors/tsc/lib/get-tsconfig.ts
+++ b/packages/js/src/executors/tsc/lib/get-tsconfig.ts
@@ -39,7 +39,7 @@ function generateTaskProjectTsConfig(
   context: ExecutorContext,
   taskInMemoryTsConfigMap: Record<string, TypescriptInMemoryTsConfig>
 ): string {
-  const { project } = parseTargetString(task, context.projectGraph);
+  const { project } = parseTargetString(task, context);
   if (projectTsConfigCache.has(project)) {
     const { tsConfig, tsConfigPath } = projectTsConfigCache.get(project);
     taskInMemoryTsConfigMap[task] = tsConfig;
@@ -104,9 +104,7 @@ function getDependencyTasksInOtherProjects(
   context: ExecutorContext
 ): string[] {
   return context.taskGraph.dependencies[task].filter(
-    (t) =>
-      t !== task &&
-      parseTargetString(t, context.projectGraph).project !== project
+    (t) => t !== task && parseTargetString(t, context).project !== project
   );
 }
 
@@ -114,15 +112,10 @@ function getDependencyTasksInSameProject(
   task: string,
   context: ExecutorContext
 ): string[] {
-  const { project: taskProject } = parseTargetString(
-    task,
-    context.projectGraph
-  );
+  const { project: taskProject } = parseTargetString(task, context);
 
   return Object.keys(context.taskGraph.tasks).filter(
-    (t) =>
-      t !== task &&
-      parseTargetString(t, context.projectGraph).project === taskProject
+    (t) => t !== task && parseTargetString(t, context).project === taskProject
   );
 }
 
@@ -167,7 +160,7 @@ function getInMemoryTsConfig(
 }
 
 function hasTscExecutor(task: string, context: ExecutorContext): boolean {
-  const { project, target } = parseTargetString(task, context.projectGraph);
+  const { project, target } = parseTargetString(task, context);
 
   return (
     context.projectGraph.nodes[project].data.targets[target].executor ===

--- a/packages/js/src/executors/tsc/tsc.batch-impl.ts
+++ b/packages/js/src/executors/tsc/tsc.batch-impl.ts
@@ -265,7 +265,7 @@ function createTypescriptCompilationContext(
   Object.entries(taskInMemoryTsConfigMap).forEach(([task, tsConfig]) => {
     if (!tsCompilationContext[tsConfig.path]) {
       tsCompilationContext[tsConfig.path] = {
-        project: parseTargetString(task, context.projectGraph).project,
+        project: parseTargetString(task, context).project,
         transformers: [],
         tsConfig: tsConfig,
       };


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When calling `parseTargetString` we pass a project graph, which means that the full target string is required

## Expected Behavior
When calling `parseTargetString` we pass an executor context, which allows using `build` to reference `{projectName}:build`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
