### PR TITLE
chore(nextjs): pass full executor context where available to parseTargetOptions

### DIFF
--- a/packages/next/plugins/component-testing.ts
+++ b/packages/next/plugins/component-testing.ts
@@ -12,6 +12,7 @@ import {
   readCachedProjectGraph,
   readTargetOptions,
   stripIndents,
+  workspaceRoot,
 } from '@nx/devkit';
 import { withReact } from '@nx/react';
 import {
@@ -57,7 +58,13 @@ export function nxComponentTestingPreset(
   let buildFileReplacements = [];
   let buildOuputPath = `dist/${ctProjectName}/.next`;
   if (buildTarget) {
-    const parsedBuildTarget = parseTargetString(buildTarget, graph);
+    const parsedBuildTarget = parseTargetString(buildTarget, {
+      cwd: process.cwd(),
+      root: workspaceRoot,
+      isVerbose: false,
+      projectName: ctProjectName,
+      projectGraph: graph,
+    });
     const buildProjectConfig = graph.nodes[parsedBuildTarget.project]?.data;
     const buildExecutorContext = createExecutorContext(
       graph,

--- a/packages/next/src/executors/export/export.impl.ts
+++ b/packages/next/src/executors/export/export.impl.ts
@@ -53,10 +53,7 @@ export default async function exportExecutor(
     dependencies = result.dependencies;
   }
 
-  const buildTarget = parseTargetString(
-    options.buildTarget,
-    context.projectGraph
-  );
+  const buildTarget = parseTargetString(options.buildTarget, context);
 
   try {
     const args = getBuildTargetCommand(options);

--- a/packages/next/src/executors/server/custom-server.impl.ts
+++ b/packages/next/src/executors/server/custom-server.impl.ts
@@ -33,7 +33,7 @@ async function* runCustomServer(
   const baseUrl = `http://${options.hostname || 'localhost'}:${options.port}`;
 
   const customServerBuild = await runExecutor(
-    parseTargetString(options.customServerTarget, context.projectGraph),
+    parseTargetString(options.customServerTarget, context),
     {
       watch: options.dev ? true : false,
     },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When calling `parseTargetString` we pass a project graph, which means that the full target string is required

## Expected Behavior
When calling `parseTargetString` we pass an executor context, which allows using `build` to reference `{projectName}:build`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
