### PR TITLE
docs(angular): fix snippet typo in advanced micro frontends guide (#1…

### DIFF
--- a/docs/shared/guides/module-federation/dynamic-mfe-angular.md
+++ b/docs/shared/guides/module-federation/dynamic-mfe-angular.md
@@ -155,7 +155,7 @@ This will scaffold a new library for us to use.
 We need an Angular Service that we will use to hold state:
 
 ```shell
-nx g @nx/angular:service user --project=shared-data-access-user
+nx g @nx/angular:service user --project=shared/data-access-user
 ```
 
 This will create a file `user.service.ts` under the `shared/data-access-user` library. Change its contents to match:


### PR DESCRIPTION
…9137)

closed #19137

## Current Behavior
in the [dynamic module federation with angular guide](https://nx.dev/recipes/angular/dynamic-module-federation-with-angular), the step to create a user service provides a snippet with a typo. pasting and running the command in the snippet will not work as expected.

## Expected Behavior
the command snippet, when pasted, will execute as expected and create an angular user service.

## Related Issue(s)

Fixes #19137
