### PR TITLE
docs(devkit): add link to docs

### DIFF
--- a/docs/generated/manifests/nx-api.json
+++ b/docs/generated/manifests/nx-api.json
@@ -566,12 +566,12 @@
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
     "name": "devkit",
     "packageName": "@nx/devkit",
-    "description": "The Nx Devkit is used to customize Nx for different technologies and use cases. It contains many utility functions for reading and writing files, updating configuration, working with Abstract Syntax Trees(ASTs), and more.",
+    "description": "The Nx Devkit is used to customize Nx for different technologies and use cases. It contains many utility functions for reading and writing files, updating configuration, working with Abstract Syntax Trees(ASTs), and more. Learn more about [extending Nx by leveraging the Nx Devkit](https://nx.dev/extending-nx/intro/getting-started) on our docs.",
     "documents": {
       "/nx-api/devkit/documents/nx_devkit": {
         "id": "nx_devkit",
         "name": "Overview",
-        "description": "The Nx Devkit is used to customize Nx for different technologies and use cases. It contains many utility functions for reading and writing files, updating configuration, working with Abstract Syntax Trees(ASTs), and more.",
+        "description": "The Nx Devkit is used to customize Nx for different technologies and use cases. It contains many utility functions for reading and writing files, updating configuration, working with Abstract Syntax Trees(ASTs), and more. Learn more about [extending Nx by leveraging the Nx Devkit](https://nx.dev/extending-nx/intro/getting-started) on our docs.",
         "file": "generated/packages/devkit/documents/nx_devkit",
         "itemList": [],
         "isExternal": false,
@@ -582,7 +582,7 @@
       "/nx-api/devkit/documents/ngcli_adapter": {
         "id": "ngcli_adapter",
         "name": "Ng CLI Adapter",
-        "description": "The Nx Devkit is used to customize Nx for different technologies and use cases. It contains many utility functions for reading and writing files, updating configuration, working with Abstract Syntax Trees(ASTs), and more.",
+        "description": "The Nx Devkit is used to customize Nx for different technologies and use cases. It contains many utility functions for reading and writing files, updating configuration, working with Abstract Syntax Trees(ASTs), and more. Learn more about [extending Nx by leveraging the Nx Devkit](https://nx.dev/extending-nx/intro/getting-started) on our docs.",
         "file": "generated/packages/devkit/documents/ngcli_adapter",
         "itemList": [],
         "isExternal": false,

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -558,12 +558,12 @@
     "source": "/packages/detox/src"
   },
   {
-    "description": "The Nx Devkit is used to customize Nx for different technologies and use cases. It contains many utility functions for reading and writing files, updating configuration, working with Abstract Syntax Trees(ASTs), and more.",
+    "description": "The Nx Devkit is used to customize Nx for different technologies and use cases. It contains many utility functions for reading and writing files, updating configuration, working with Abstract Syntax Trees(ASTs), and more. Learn more about [extending Nx by leveraging the Nx Devkit](https://nx.dev/extending-nx/intro/getting-started) on our docs.",
     "documents": [
       {
         "id": "nx_devkit",
         "name": "Overview",
-        "description": "The Nx Devkit is used to customize Nx for different technologies and use cases. It contains many utility functions for reading and writing files, updating configuration, working with Abstract Syntax Trees(ASTs), and more.",
+        "description": "The Nx Devkit is used to customize Nx for different technologies and use cases. It contains many utility functions for reading and writing files, updating configuration, working with Abstract Syntax Trees(ASTs), and more. Learn more about [extending Nx by leveraging the Nx Devkit](https://nx.dev/extending-nx/intro/getting-started) on our docs.",
         "file": "generated/packages/devkit/documents/nx_devkit",
         "itemList": [],
         "isExternal": false,
@@ -574,7 +574,7 @@
       {
         "id": "ngcli_adapter",
         "name": "Ng CLI Adapter",
-        "description": "The Nx Devkit is used to customize Nx for different technologies and use cases. It contains many utility functions for reading and writing files, updating configuration, working with Abstract Syntax Trees(ASTs), and more.",
+        "description": "The Nx Devkit is used to customize Nx for different technologies and use cases. It contains many utility functions for reading and writing files, updating configuration, working with Abstract Syntax Trees(ASTs), and more. Learn more about [extending Nx by leveraging the Nx Devkit](https://nx.dev/extending-nx/intro/getting-started) on our docs.",
         "file": "generated/packages/devkit/documents/ngcli_adapter",
         "itemList": [],
         "isExternal": false,

--- a/docs/packages.json
+++ b/docs/packages.json
@@ -92,7 +92,7 @@
   {
     "name": "devkit",
     "packageName": "devkit",
-    "description": "The Nx Devkit is used to customize Nx for different technologies and use cases. It contains many utility functions for reading and writing files, updating configuration, working with Abstract Syntax Trees(ASTs), and more.",
+    "description": "The Nx Devkit is used to customize Nx for different technologies and use cases. It contains many utility functions for reading and writing files, updating configuration, working with Abstract Syntax Trees(ASTs), and more. Learn more about [extending Nx by leveraging the Nx Devkit](https://nx.dev/extending-nx/intro/getting-started) on our docs.",
     "path": "generated/packages/devkit.json",
     "schemas": { "executors": [], "generators": [] }
   },

--- a/packages-legacy/devkit/package.json
+++ b/packages-legacy/devkit/package.json
@@ -2,7 +2,7 @@
   "name": "@nrwl/devkit",
   "version": "0.0.1",
   "private": false,
-  "description": "The Nx Devkit is used to customize Nx for different technologies and use cases. It contains many utility functions for reading and writing files, updating configuration, working with Abstract Syntax Trees(ASTs), and more.",
+  "description": "The Nx Devkit is used to customize Nx for different technologies and use cases. It contains many utility functions for reading and writing files, updating configuration, working with Abstract Syntax Trees(ASTs), and more. Learn more about [extending Nx by leveraging the Nx Devkit](https://nx.dev/extending-nx/intro/getting-started) on our docs.",
   "repository": {
     "type": "git",
     "url": "https://github.com/nrwl/nx.git",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -2,7 +2,7 @@
   "name": "@nx/devkit",
   "version": "0.0.1",
   "private": false,
-  "description": "The Nx Devkit is used to customize Nx for different technologies and use cases. It contains many utility functions for reading and writing files, updating configuration, working with Abstract Syntax Trees(ASTs), and more.",
+  "description": "The Nx Devkit is used to customize Nx for different technologies and use cases. It contains many utility functions for reading and writing files, updating configuration, working with Abstract Syntax Trees(ASTs), and more. Learn more about [extending Nx by leveraging the Nx Devkit](https://nx.dev/extending-nx/intro/getting-started) on our docs.",
   "repository": {
     "type": "git",
     "url": "https://github.com/nrwl/nx.git",


### PR DESCRIPTION
Small improvement to add a link for folks to the extending Nx part of the docs.

https://nx-dev-git-fork-juristr-docs-link-nx-devkit-nrwl.vercel.app/packages/devkit