### PR TITLE
feat(react): allow setting react preset to production when using custom BABEL_ENV

### DIFF
--- a/packages/react/babel.ts
+++ b/packages/react/babel.ts
@@ -3,6 +3,7 @@
  */
 
 interface NxReactBabelOptions {
+  development?: boolean;
   runtime?: string;
   importSource?: string;
   useBuiltIns?: boolean | string;
@@ -51,10 +52,16 @@ module.exports = function (api: any, options: NxReactBabelOptions) {
   };
 };
 
-function getReactPresetOptions({ presetOptions, env }) {
+function getReactPresetOptions({
+  presetOptions,
+  env,
+}: {
+  env: string;
+  presetOptions: NxReactBabelOptions;
+}) {
   const reactPresetOptions: Record<string, string | boolean> = {
     runtime: presetOptions.runtime ?? 'automatic',
-    development: env !== 'production',
+    development: presetOptions.development ?? env !== 'production',
   };
 
   // JSX spread is transformed into object spread in `@babel/plugin-transform-react-jsx`

--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -70,7 +70,7 @@ function getBuildTargetOutputPath(options: Schema, context: ExecutorContext) {
 
   let buildOptions;
   try {
-    const target = parseTargetString(options.buildTarget, context.projectGraph);
+    const target = parseTargetString(options.buildTarget, context);
     buildOptions = readTargetOptions(target, context);
   } catch (e) {
     throw new Error(`Invalid buildTarget: ${options.buildTarget}`);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When setting a custom BABEL_ENV, the @nx/react babel preset will pass `development: true` to the react babel preset. This may not be desirable, if you know that you are running webpack in production mode as it can cause errors.

## Expected Behavior
You can pass an option to force `development: false`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
