### PR TITLE
chore(nx-plugin): pass full context into parseTargetString

### DIFF
--- a/packages/plugin/src/executors/e2e/e2e.impl.ts
+++ b/packages/plugin/src/executors/e2e/e2e.impl.ts
@@ -1,7 +1,6 @@
 import type { ExecutorContext } from '@nx/devkit';
 
 import {
-  createProjectGraphAsync,
   logger,
   output,
   parseTargetString,
@@ -44,10 +43,9 @@ async function* runBuildTarget(
   buildTarget: string,
   context: ExecutorContext
 ): AsyncGenerator<boolean> {
-  const graph = await createProjectGraphAsync();
   const { project, target, configuration } = parseTargetString(
     buildTarget,
-    graph
+    context
   );
   const buildTargetOptions = readTargetOptions(
     { project, target, configuration },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When calling `parseTargetString` we pass a project graph, which means that the full target string is required

## Expected Behavior
When calling `parseTargetString` we pass an executor context, which allows using `build` to reference `{projectName}:build`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
