### PR TITLE
chore(react): pass full context to parseTargetString

### DIFF
--- a/packages/react/plugins/component-testing/index.ts
+++ b/packages/react/plugins/component-testing/index.ts
@@ -145,7 +145,11 @@ export function nxComponentTestingPreset(
       );
     }
 
-    webpackConfig = buildTargetWebpack(graph, buildTarget, ctProjectName);
+    webpackConfig = buildTargetWebpack(
+      ctExecutorContext,
+      buildTarget,
+      ctProjectName
+    );
   } catch (e) {
     logger.warn(
       stripIndents`Unable to build a webpack config with the project graph. 
@@ -202,10 +206,11 @@ function withSchemaDefaults(target: Target, context: ExecutorContext) {
 }
 
 function buildTargetWebpack(
-  graph: ProjectGraph,
+  ctx: ExecutorContext,
   buildTarget: string,
   componentTestingProjectName: string
 ) {
+  const graph = ctx.projectGraph;
   const parsed = parseTargetString(buildTarget, graph);
 
   const buildableProjectConfig = graph.nodes[parsed.project]?.data;

--- a/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -25,7 +25,7 @@ type ModuleFederationDevServerOptions = WebDevServerOptions & {
 };
 
 function getBuildOptions(buildTarget: string, context: ExecutorContext) {
-  const target = parseTargetString(buildTarget, context.projectGraph);
+  const target = parseTargetString(buildTarget, context);
 
   const buildOptions = readTargetOptions(target, context);
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When calling `parseTargetString` we pass a project graph, which means that the full target string is required

## Expected Behavior
When calling `parseTargetString` we pass an executor context, which allows using `build` to reference `{projectName}:build`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
