### PR TITLE
chore(bundling): pass full context to parseTargetString

### DIFF
--- a/packages/vite/src/executors/preview-server/preview-server.impl.ts
+++ b/packages/vite/src/executors/preview-server/preview-server.impl.ts
@@ -17,7 +17,7 @@ export async function* vitePreviewServerExecutor(
   options: VitePreviewServerExecutorOptions,
   context: ExecutorContext
 ) {
-  const target = parseTargetString(options.buildTarget, context.projectGraph);
+  const target = parseTargetString(options.buildTarget, context);
   const targetConfiguration =
     context.projectsConfigurations.projects[target.project]?.targets[
       target.target

--- a/packages/vite/src/utils/options-utils.ts
+++ b/packages/vite/src/utils/options-utils.ts
@@ -197,6 +197,6 @@ export function getVitePreviewOptions(
 }
 
 export function getNxTargetOptions(target: string, context: ExecutorContext) {
-  const targetObj = parseTargetString(target, context.projectGraph);
+  const targetObj = parseTargetString(target, context);
   return readTargetOptions(targetObj, context);
 }

--- a/packages/webpack/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/webpack/src/executors/dev-server/dev-server.impl.ts
@@ -97,7 +97,7 @@ function getBuildOptions(
   options: WebDevServerOptions,
   context: ExecutorContext
 ): WebpackExecutorOptions {
-  const target = parseTargetString(options.buildTarget, context.projectGraph);
+  const target = parseTargetString(options.buildTarget, context);
 
   const overrides: Partial<WebpackExecutorOptions> = {
     watch: false,

--- a/packages/webpack/src/executors/ssr-dev-server/ssr-dev-server.impl.ts
+++ b/packages/webpack/src/executors/ssr-dev-server/ssr-dev-server.impl.ts
@@ -19,10 +19,7 @@ export async function* ssrDevServerExecutor(
     options.browserTarget,
     context.projectGraph
   );
-  const serverTarget = parseTargetString(
-    options.serverTarget,
-    context.projectGraph
-  );
+  const serverTarget = parseTargetString(options.serverTarget, context);
   const browserOptions = readTargetOptions<WebpackExecutorOptions>(
     browserTarget,
     context


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When calling `parseTargetString` we pass a project graph, which means that the full target string is required

## Expected Behavior
When calling `parseTargetString` we pass an executor context, which allows using `build` to reference `{projectName}:build`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
