### PR TITLE
fix(nextjs): add missing base NX env var to the list

### DIFF
--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -36,6 +36,10 @@ const baseNXEnvironmentVariables = [
   'NX_WORKSPACE_ROOT',
   'NX_TASK_HASH',
   'NX_NEXT_DIR',
+  'NX_NEXT_OUTPUT_PATH',
+  'NX_INVOKED_BY_RUNNER',
+  'NX_E2E_CI_CACHE_KEY',
+  'NX_E2E_RUN_E2E',
 ];
 
 export interface WithNxOptions extends NextConfig {


### PR DESCRIPTION
## Current Behavior

When building the project, this message appears in the console:

> Please rename the following environment variables: NX_INVOKED_BY_RUNNER, NX_NEXT_OUTPUT_PATH using Next.js' built-in support for environment variables. Reference https://nextjs.org/docs/pages/api-reference/next-config-js/env

While launching the project, this message appears:

> Please rename the following environment variables: NX_INVOKED_BY_RUNNER using Next.js' built-in support for environment variables. Reference https://nextjs.org/docs/pages/api-reference/next-config-js/env

## Expected Behavior

Those messages shouldn't appear as those variables are internal to NX.

## Related Issue(s)

Fixes #19044 
