### PR TITLE
feat(react-native): add useTransformReactJSX babel config to generators

### DIFF
--- a/packages/react-native/src/generators/application/files/app/babel.config.json.template
+++ b/packages/react-native/src/generators/application/files/app/babel.config.json.template
@@ -1,3 +1,10 @@
 {
-  "presets": ["module:metro-react-native-babel-preset"]
+  "presets": [
+    [
+      "module:metro-react-native-babel-preset",
+      {
+        "useTransformReactJSX": true
+      }
+    ]
+  ]
 }

--- a/packages/react-native/src/generators/library/files/lib/babel.config.json.template
+++ b/packages/react-native/src/generators/library/files/lib/babel.config.json.template
@@ -11,7 +11,9 @@
   "plugins": [],
   "env": {
     "test": {
-      "presets": ["module:metro-react-native-babel-preset"]
+      "presets": [
+        ["module:metro-react-native-babel-preset", { "useTransformReactJSX": true }]
+      ]
     }
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Jest tests require import React from 'react' even though  this is not required is the component after react 17 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
you don't have to **import React from 'react**' in your jest tests. should be more consistent with modern react development
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
