### PR TITLE
fix(core): use cached project graph on batch mode runner

### DIFF
--- a/packages/nx/src/tasks-runner/batch/run-batch.ts
+++ b/packages/nx/src/tasks-runner/batch/run-batch.ts
@@ -11,6 +11,7 @@ import { TaskGraph } from '../../config/task-graph';
 import { ExecutorContext } from '../../config/misc-interfaces';
 import {
   createProjectGraphAsync,
+  readCachedProjectGraph,
   readProjectsConfigurationFromProjectGraph,
 } from '../../project-graph/project-graph';
 import { readNxJson } from '../../config/configuration';
@@ -28,7 +29,7 @@ async function runTasks(
   fullTaskGraph: TaskGraph
 ) {
   const input: Record<string, any> = {};
-  const projectGraph = await createProjectGraphAsync();
+  const projectGraph = readCachedProjectGraph();
   const projectsConfigurations =
     readProjectsConfigurationFromProjectGraph(projectGraph);
   const nxJsonConfiguration = readNxJson();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We use `createProjectGraphAsync` when running a batch executor. This is not only different from `runExecutor`, but also causes issues in the following circumstance:
- Running jest tests
- NX_BATCH_MODE=true (or default soon)
- NX_DAEMON=false || CI=true
- @swc-node/register is installed

This is caused by the `createProjectGraphAsync` call registering a TS transpiler on the process and finding swc-node. Jest uses ts-node under the hood.  This results in both ts-node and swc-node being registered at the same time, and weird compilation issues cropping up.

## Expected Behavior
`runExecutor` and `runBatch` read the project graph in the same way, and ts-node and swc-node don't end up registered simultaneously.

## Workaround

Using `NX_PREFER_TS_NODE=true` or uninstalling @swc-node/register are workarounds for the issue.

## Related Issue(s)

Originally discovered when enabling batch mode by default on https://github.com/nrwl/nx/pull/19122, brought to @barbados-clemens attention and then debugged together.
