### PR TITLE
chore(repo): upgrade deprecated mac ci image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ executors:
 
   macos:
     <<: *defaults
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
     macos:
       xcode: '14.2.0'
 


### PR DESCRIPTION
The macos image we use on CI is now deprecated and will be removed in January

https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
