### PR TITLE
docs(core): fix social image for community page

### DIFF
--- a/nx-dev/nx-dev/pages/community.tsx
+++ b/nx-dev/nx-dev/pages/community.tsx
@@ -25,7 +25,7 @@ export default function Community(): JSX.Element {
             'There are many ways you can connect with the open-source Nx community. The community is rich and dynamic offering Nx plugins and help on multiple platforms like GitHub, Discord and Twitter',
           images: [
             {
-              url: 'https://nx.dev/images/nx-media.webp',
+              url: 'https://nx.dev/socials/nx-media.png',
               width: 800,
               height: 421,
               alt: 'Nx: Smart, Fast and Extensible Build System',


### PR DESCRIPTION
Fix the social image for the [/community](https://github.com/nrwl/nx/pull/19188) page

![Screenshot 2023-09-15 at 9 51 58 AM](https://github.com/nrwl/nx/assets/861504/76c10f14-b14c-4cae-a70a-22a43484c291)
