### PR TITLE
feat(nx-dev): remove emojis from heading ID

### DIFF
--- a/nx-dev/feature-ai/src/lib/feed/feed-answer.tsx
+++ b/nx-dev/feature-ai/src/lib/feed/feed-answer.tsx
@@ -19,6 +19,7 @@ interface RehypeNode {
   children?: RehypeNode[];
   value?: string;
 }
+
 function openLinksInNewTab() {
   function walk(node: RehypeNode, callback: (node: RehypeNode) => void): void {
     callback(node);
@@ -30,7 +31,6 @@ function openLinksInNewTab() {
   return (tree: RehypeNode) => {
     walk(tree, (node) => {
       if (node.type === 'element' && node.tagName === 'a') {
-        console.log(node);
         const props = node.properties ?? {};
         const href = props?.['href'] as string;
         props.target = '_blank';

--- a/nx-dev/ui-markdoc/src/lib/nodes/heading.schema.spec.ts
+++ b/nx-dev/ui-markdoc/src/lib/nodes/heading.schema.spec.ts
@@ -1,0 +1,10 @@
+import { generateID } from './heading.schema';
+
+describe('heading schema: generateID', () => {
+  it('should create ID with ony ASCII characters', () => {
+    expect(generateID(['Hello', 'World'], {})).toEqual('hello-world');
+    expect(generateID(['🎉 Pro: Simple Setup'], {})).toEqual(
+      'pro-simple-setup'
+    );
+  });
+});

--- a/nx-dev/ui-markdoc/src/lib/nodes/heading.schema.ts
+++ b/nx-dev/ui-markdoc/src/lib/nodes/heading.schema.ts
@@ -1,6 +1,6 @@
 import { RenderableTreeNode, Schema, Tag } from '@markdoc/markdoc';
 
-function generateID(
+export function generateID(
   children: RenderableTreeNode[],
   attributes: Record<string, any>
 ) {
@@ -10,9 +10,12 @@ function generateID(
   return children
     .filter((child) => typeof child === 'string')
     .join(' ')
-    .replace(/[?]/g, '')
-    .replace(/\s+/g, '-')
-    .toLowerCase();
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9 ]/g, '')
+    .trim()
+    .replace(/\s+/g, '-');
 }
 
 export const heading: Schema = {


### PR DESCRIPTION
Having emojis in the deep-link URIs can be problematic when processing the page. For example, when generating embeddings for AI Chat `https://nx.dev/concepts/dte#%F0%9F%8E%89-pro:-build-artifacts` becomes `https://nx.dev/concepts/dte#-pro-build-artifacts`.

Better to leave off non-ASCII characters. Side-effect of this PR is that any previous deep-link that contains emojis will no longer work, but it's a small use-case and users are on the right page still (just not deep-linked to specific section).

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
