### PR TITLE
feat(nx-dev): improve auto-scrolling so it does not interfere with users reading the content

### DIFF
--- a/nx-dev/nx-dev/pages/ai-chat/index.tsx
+++ b/nx-dev/nx-dev/pages/ai-chat/index.tsx
@@ -2,6 +2,7 @@ import { FeedContainer } from '@nx/nx-dev/feature-ai';
 import { DocumentationHeader } from '@nx/nx-dev/ui-common';
 import { NextSeo } from 'next-seo';
 import { useNavToggle } from '../../lib/navigation-toggle.effect';
+import { cx } from '@nx/nx-dev/ui-primitives';
 
 export default function AiDocs(): JSX.Element {
   const { toggleNav, navIsOpen } = useNavToggle();
@@ -21,7 +22,14 @@ export default function AiDocs(): JSX.Element {
           maxVideoPreview: -1,
         }}
       />
-      <div id="shell" className="flex h-full flex-col">
+      <div
+        id="shell"
+        className={cx(
+          'flex flex-col',
+          // Adjust dynamically to mobile viewport height (e.g. when navigational tabs are open).
+          'h-[calc(100dvh)]'
+        )}
+      >
         <div className="w-full flex-shrink-0">
           <DocumentationHeader isNavOpen={navIsOpen} toggleNav={toggleNav} />
         </div>


### PR DESCRIPTION
This PR improves auto-scrolling, so we check if the user is close to the bottom of the content before scrolling them down. It prevents problems where users can lose the position of where they are reading.

Drastically improves the mobile experience as well where the screen no longer jumps around all the time when typing or reading.

**Before:**


https://github.com/nrwl/nx/assets/53559/a380cc7e-16a2-4111-a9ea-d7cbff8ca0cc



**After:**



https://github.com/nrwl/nx/assets/53559/0fcbf1a0-ea00-459a-bc52-ba6e58b74721


