### PR TITLE
docs(webpack): fix incorrect type for svgr option in withReact example

### DIFF
--- a/docs/shared/packages/webpack/webpack-plugins.md
+++ b/docs/shared/packages/webpack/webpack-plugins.md
@@ -150,7 +150,7 @@ module.exports = composePlugins(
   withNx(), // always pass withNx() first
   withReact({
     styles: ['my-app/src/styles.css'],
-    svgr: true,
+    svgr: false,
     postcssConfig: 'my-app/postcss',
   }),
   (config) => {


### PR DESCRIPTION
`withReact`'s `svgr` option accepts `undefined|false`, the example should specify `false` instead of `true` which is invalid.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

![image](https://github.com/nrwl/nx/assets/5217789/3e289c2d-0e72-4141-ab36-d34229ddaf86)

## Expected Behavior

<img width="714" alt="Screenshot 2023-09-15 at 10 29 20 AM" src="https://github.com/nrwl/nx/assets/5217789/c9a7cae5-1a7c-4064-b54a-0142919c37a7">


