### PR TITLE
fix(nextjs): Add missing env to base Nx Env

### DIFF
--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -42,6 +42,9 @@ const baseNXEnvironmentVariables = [
   'NX_WORKSPACE_ROOT',
   'NX_TASK_HASH',
   'NX_NEXT_DIR',
+  'NX_NEXT_OUTPUT_PATH',
+  'NX_E2E_RUN_E2E',
+  'NX_E2E_CI_CACHE_KEY',
 ];
 
 export interface WithNxOptions extends NextConfig {


### PR DESCRIPTION
closes: #19044

