### PR TITLE
fix(core): support prettier v3 when run nx format

### DIFF
--- a/packages/nx/src/command-line/format/format.ts
+++ b/packages/nx/src/command-line/format/format.ts
@@ -12,6 +12,7 @@ import { calculateFileChanges, FileData } from '../../project-graph/file-utils';
 import * as yargs from 'yargs';
 
 import * as prettier from 'prettier';
+import type { SupportInfo } from 'prettier';
 import { sortObjectByKeys } from '../../utils/object-sort';
 import { readModulePackageJson } from '../../utils/package-json';
 import {
@@ -81,9 +82,11 @@ async function getPatterns(
 
     const p = parseFiles(args);
 
-    const supportedExtensions = prettier
-      .getSupportInfo()
-      .languages.flatMap((language) => language.extensions)
+    // In prettier v3 the getSupportInfo result is a promise
+    const supportedExtensions = (
+      await (prettier.getSupportInfo() as Promise<SupportInfo> | SupportInfo)
+    ).languages
+      .flatMap((language) => language.extensions)
       .filter((extension) => !!extension)
       // Prettier supports ".swcrc" as a file instead of an extension
       // So we add ".swcrc" as a supported extension manually


### PR DESCRIPTION
After prettier upgrade to v3, the `prettier.getSupportInfo` will return promise

ref: [Prettier doc](https://prettier.io/blog/2023/07/05/3.0.0.html#change-public-apis-to-asynchronous-12574httpsgithubcomprettierprettierpull12574-12788httpsgithubcomprettierprettierpull12788-12790httpsgithubcomprettierprettierpull12790-13265httpsgithubcomprettierprettierpull13265-by-fiskerhttpsgithubcomfisker)

Closes #18992

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When running `nx format:check` will always fallback to `-files=.`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
It should only run prettier on those changed files.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18992
