### PR TITLE
fix(webpack): set `module: true` for swcMinify

### DIFF
--- a/e2e/web/src/web.test.ts
+++ b/e2e/web/src/web.test.ts
@@ -25,8 +25,7 @@ describe('Web Components Applications', () => {
   beforeEach(() => newProject());
   afterEach(() => cleanupProject());
 
-  // TODO Re-enable this when it is passing.
-  xit('should be able to generate a web app', async () => {
+  it('should be able to generate a web app', async () => {
     const appName = uniq('app');
     runCLI(
       `generate @nx/web:app ${appName} --bundler=webpack --no-interactive`

--- a/packages/webpack/src/utils/with-nx.ts
+++ b/packages/webpack/src/utils/with-nx.ts
@@ -271,6 +271,7 @@ export function withNx(pluginOptions?: WithNxOptions): NxWebpackPlugin {
                 minify: TerserPlugin.swcMinify,
                 // `terserOptions` options will be passed to `swc`
                 terserOptions: {
+                  module: true,
                   mangle: false,
                 },
               }),


### PR DESCRIPTION
Since `module` is defaulted to `false` starting in `@swc/core@1.3.85`, we need to explicitly set it to true when minifying with SWC.



## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
