### PR TITLE
feat(core): include non-project files on fileMap and filesToProcess

### DIFF
--- a/docs/generated/devkit/CreateDependenciesContext.md
+++ b/docs/generated/devkit/CreateDependenciesContext.md
@@ -7,8 +7,8 @@ Context for [CreateDependencies](../../devkit/documents/CreateDependencies)
 ### Properties
 
 - [externalNodes](../../devkit/documents/CreateDependenciesContext#externalnodes): Record&lt;string, ProjectGraphExternalNode&gt;
-- [fileMap](../../devkit/documents/CreateDependenciesContext#filemap): ProjectFileMap
-- [filesToProcess](../../devkit/documents/CreateDependenciesContext#filestoprocess): ProjectFileMap
+- [fileMap](../../devkit/documents/CreateDependenciesContext#filemap): FileMap
+- [filesToProcess](../../devkit/documents/CreateDependenciesContext#filestoprocess): FileMap
 - [nxJsonConfiguration](../../devkit/documents/CreateDependenciesContext#nxjsonconfiguration): NxJsonConfiguration&lt;string[] | &quot;\*&quot;&gt;
 - [projects](../../devkit/documents/CreateDependenciesContext#projects): Record&lt;string, ProjectConfiguration&gt;
 - [workspaceRoot](../../devkit/documents/CreateDependenciesContext#workspaceroot): string
@@ -25,7 +25,7 @@ The external nodes that have been added to the graph.
 
 ### fileMap
 
-• `Readonly` **fileMap**: [`ProjectFileMap`](../../devkit/documents/ProjectFileMap)
+• `Readonly` **fileMap**: `FileMap`
 
 All files in the workspace
 
@@ -33,7 +33,7 @@ All files in the workspace
 
 ### filesToProcess
 
-• `Readonly` **filesToProcess**: [`ProjectFileMap`](../../devkit/documents/ProjectFileMap)
+• `Readonly` **filesToProcess**: `FileMap`
 
 Files changes since last invocation
 

--- a/docs/generated/devkit/FileData.md
+++ b/docs/generated/devkit/FileData.md
@@ -6,7 +6,7 @@ Some metadata about a file
 
 ### Properties
 
-- [deps](../../devkit/documents/FileData#deps): (string | [string, string])[]
+- [deps](../../devkit/documents/FileData#deps): FileDataDependency[]
 - [file](../../devkit/documents/FileData#file): string
 - [hash](../../devkit/documents/FileData#hash): string
 
@@ -14,7 +14,13 @@ Some metadata about a file
 
 ### deps
 
-• `Optional` **deps**: (`string` \| [`string`, `string`])[]
+• `Optional` **deps**: `FileDataDependency`[]
+
+An array of dependencies. If an element is just a string,
+the dependency is assumed to be a static dependency targetting
+that string. If the element is a tuple with two elements, the first element
+inside of it is the target project, with the second element being the type of dependency.
+If the tuple has 3 elements, the first is preceded by a source.
 
 ---
 

--- a/docs/generated/devkit/ProjectGraphBuilder.md
+++ b/docs/generated/devkit/ProjectGraphBuilder.md
@@ -15,6 +15,7 @@ The ProjectGraphProcessor has been deprecated. Use a [CreateNodes](../../devkit/
 ### Properties
 
 - [graph](../../devkit/documents/ProjectGraphBuilder#graph): ProjectGraph
+- [nonProjectFiles](../../devkit/documents/ProjectGraphBuilder#nonprojectfiles): FileData[]
 - [projectFileMap](../../devkit/documents/ProjectGraphBuilder#projectfilemap): ProjectFileMap
 - [removedEdges](../../devkit/documents/ProjectGraphBuilder#removededges): Object
 
@@ -40,20 +41,27 @@ The ProjectGraphProcessor has been deprecated. Use a [CreateNodes](../../devkit/
 
 ### constructor
 
-• **new ProjectGraphBuilder**(`graph?`, `fileMap?`)
+• **new ProjectGraphBuilder**(`graph?`, `projectFileMap?`, `nonProjectFiles?`)
 
 #### Parameters
 
-| Name       | Type                                                      |
-| :--------- | :-------------------------------------------------------- |
-| `graph?`   | [`ProjectGraph`](../../devkit/documents/ProjectGraph)     |
-| `fileMap?` | [`ProjectFileMap`](../../devkit/documents/ProjectFileMap) |
+| Name               | Type                                                      |
+| :----------------- | :-------------------------------------------------------- |
+| `graph?`           | [`ProjectGraph`](../../devkit/documents/ProjectGraph)     |
+| `projectFileMap?`  | [`ProjectFileMap`](../../devkit/documents/ProjectFileMap) |
+| `nonProjectFiles?` | [`FileData`](../../devkit/documents/FileData)[]           |
 
 ## Properties
 
 ### graph
 
 • `Readonly` **graph**: [`ProjectGraph`](../../devkit/documents/ProjectGraph)
+
+---
+
+### nonProjectFiles
+
+• `Private` `Readonly` **nonProjectFiles**: [`FileData`](../../devkit/documents/FileData)[]
 
 ---
 

--- a/docs/generated/devkit/ProjectGraphBuilder.md
+++ b/docs/generated/devkit/ProjectGraphBuilder.md
@@ -14,8 +14,8 @@ The ProjectGraphProcessor has been deprecated. Use a [CreateNodes](../../devkit/
 
 ### Properties
 
-- [fileMap](../../devkit/documents/ProjectGraphBuilder#filemap): ProjectFileMap
 - [graph](../../devkit/documents/ProjectGraphBuilder#graph): ProjectGraph
+- [projectFileMap](../../devkit/documents/ProjectGraphBuilder#projectfilemap): ProjectFileMap
 - [removedEdges](../../devkit/documents/ProjectGraphBuilder#removededges): Object
 
 ### Methods
@@ -51,15 +51,15 @@ The ProjectGraphProcessor has been deprecated. Use a [CreateNodes](../../devkit/
 
 ## Properties
 
-### fileMap
-
-• `Private` `Readonly` **fileMap**: [`ProjectFileMap`](../../devkit/documents/ProjectFileMap)
-
----
-
 ### graph
 
 • `Readonly` **graph**: [`ProjectGraph`](../../devkit/documents/ProjectGraph)
+
+---
+
+### projectFileMap
+
+• `Private` `Readonly` **projectFileMap**: [`ProjectFileMap`](../../devkit/documents/ProjectFileMap)
 
 ---
 

--- a/packages/angular/src/migrations/update-16-2-0/switch-data-persistence-operators-imports-to-ngrx-router-store.ts
+++ b/packages/angular/src/migrations/update-16-2-0/switch-data-persistence-operators-imports-to-ngrx-router-store.ts
@@ -9,7 +9,7 @@ import type { ImportDeclaration, ImportSpecifier, Node } from 'typescript';
 import { FileChangeRecorder } from '../../utils/file-change-recorder';
 import { ngrxVersion } from '../../utils/versions';
 import { getProjectsFilteredByDependencies } from '../utils/projects';
-import { readProjectFileMapCache } from 'nx/src/project-graph/nx-deps-cache';
+import { readFileMapCache } from 'nx/src/project-graph/nx-deps-cache';
 import { fileDataDepTarget } from 'nx/src/config/project-graph';
 
 let tsquery: typeof import('@phenomnomnominal/tsquery').tsquery;
@@ -35,7 +35,7 @@ export default async function (tree: Tree): Promise<void> {
 
   ensureTypescript();
   tsquery = require('@phenomnomnominal/tsquery').tsquery;
-  const cachedFileMap = readProjectFileMapCache().projectFileMap;
+  const cachedFileMap = readFileMapCache().fileMap.projectFileMap;
 
   const filesWithNxAngularImports: FileData[] = [];
   for (const { graphNode } of projects) {

--- a/packages/eslint-plugin/src/rules/dependency-checks.spec.ts
+++ b/packages/eslint-plugin/src/rules/dependency-checks.spec.ts
@@ -15,6 +15,7 @@ import {
   ProjectGraphExternalNode,
 } from '@nx/devkit';
 import { Linter } from 'eslint';
+import { FileDataDependency } from 'nx/src/config/project-graph';
 
 jest.mock('@nx/devkit', () => ({
   ...jest.requireActual<any>('@nx/devkit'),
@@ -1652,7 +1653,7 @@ it('should require swc if @nx/js:swc executor', () => {
   expect(failures[0].line).toEqual(3);
 });
 
-function createFile(f: string, deps?: (string | [string, string])[]): FileData {
+function createFile(f: string, deps?: FileDataDependency[]): FileData {
   return { file: f, hash: '', deps };
 }
 

--- a/packages/eslint-plugin/src/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin/src/rules/enforce-module-boundaries.spec.ts
@@ -10,6 +10,7 @@ import enforceModuleBoundaries, {
   RULE_NAME as enforceModuleBoundariesRuleName,
 } from '../../src/rules/enforce-module-boundaries';
 import { createProjectRootMappings } from 'nx/src/project-graph/utils/find-project-for-path';
+import { FileDataDependency } from 'nx/src/config/project-graph';
 
 jest.mock('@nx/devkit', () => ({
   ...jest.requireActual<any>('@nx/devkit'),
@@ -1303,8 +1304,8 @@ Violation detected in:
         {
           mylibName: [
             createFile(`libs/mylib/src/main.ts`, [
-              ['otherName', 'static'],
-              ['otherName', 'dynamic'],
+              ['otherName', DependencyType.static],
+              ['otherName', DependencyType.dynamic],
             ]),
           ],
           otherName: [createFile(`libs/other/index.ts`)],
@@ -2250,7 +2251,7 @@ const baseConfig = {
 linter.defineParser('@typescript-eslint/parser', parser);
 linter.defineRule(enforceModuleBoundariesRuleName, enforceModuleBoundaries);
 
-function createFile(f: string, deps?: (string | [string, string])[]): FileData {
+function createFile(f: string, deps?: FileDataDependency[]): FileData {
   return { file: f, hash: '', deps };
 }
 

--- a/packages/eslint-plugin/src/utils/graph-utils.ts
+++ b/packages/eslint-plugin/src/utils/graph-utils.ts
@@ -149,7 +149,7 @@ export function findFilesInCircularPath(
 
   for (let i = 0; i < circularPath.length - 1; i++) {
     const next = circularPath[i + 1].name;
-    const files: FileData[] = projectFileMap[circularPath[i].name] || [];
+    const files = projectFileMap[circularPath[i].name] || [];
     filePathChain.push(
       files
         .filter(

--- a/packages/eslint-plugin/src/utils/project-graph-utils.ts
+++ b/packages/eslint-plugin/src/utils/project-graph-utils.ts
@@ -11,7 +11,7 @@ import {
 } from 'nx/src/project-graph/utils/find-project-for-path';
 import { readNxJson } from 'nx/src/config/configuration';
 import { TargetProjectLocator } from '@nx/js/src/internal';
-import { readProjectFileMapCache } from 'nx/src/project-graph/nx-deps-cache';
+import { readFileMapCache } from 'nx/src/project-graph/nx-deps-cache';
 
 export function ensureGlobalProjectGraph(ruleName: string) {
   /**
@@ -37,7 +37,7 @@ export function ensureGlobalProjectGraph(ruleName: string) {
       globalThis.projectRootMappings = createProjectRootMappings(
         projectGraph.nodes
       );
-      globalThis.projectFileMap = readProjectFileMapCache().projectFileMap;
+      globalThis.projectFileMap = readFileMapCache().fileMap.projectFileMap;
       globalThis.targetProjectLocator = new TargetProjectLocator(
         projectGraph.nodes,
         projectGraph.externalNodes

--- a/packages/js/src/utils/package-json/update-package-json.ts
+++ b/packages/js/src/utils/package-json/update-package-json.ts
@@ -25,7 +25,7 @@ import { writeFileSync } from 'fs-extra';
 import { fileExists } from 'nx/src/utils/fileutils';
 import type { PackageJson } from 'nx/src/utils/package-json';
 import { existsSync } from 'fs';
-import { readProjectFileMapCache } from 'nx/src/project-graph/nx-deps-cache';
+import { readFileMapCache } from 'nx/src/project-graph/nx-deps-cache';
 
 import { getRelativeDirectoryToProjectRoot } from '../get-main-file-dir';
 
@@ -57,7 +57,7 @@ export function updatePackageJson(
 ): void {
   let packageJson: PackageJson;
   if (fileMap == null) {
-    fileMap = readProjectFileMapCache()?.projectFileMap || {};
+    fileMap = readFileMapCache()?.fileMap?.projectFileMap || {};
   }
 
   if (options.updateBuildableProjectDepsInPackageJson) {

--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -25,7 +25,7 @@ import {
 import { TaskGraph } from '../../config/task-graph';
 import { daemonClient } from '../../daemon/client/client';
 import { Server } from 'net';
-import { readProjectFileMapCache } from '../../project-graph/nx-deps-cache';
+import { readFileMapCache } from '../../project-graph/nx-deps-cache';
 import { getAffectedGraphNodes } from '../affected/affected';
 import { splitArgsIntoNxArgsAndOverrides } from '../../utils/command-line-utils';
 
@@ -576,7 +576,7 @@ async function createDepGraphClientResponse(
   let graph = pruneExternalNodes(
     await createProjectGraphAsync({ exitOnError: true })
   );
-  let fileMap = readProjectFileMapCache().projectFileMap;
+  let fileMap = readFileMapCache().fileMap.projectFileMap;
   performance.mark('project graph watch calculation:end');
   performance.mark('project graph response generation:start');
 

--- a/packages/nx/src/config/project-graph.ts
+++ b/packages/nx/src/config/project-graph.ts
@@ -22,6 +22,11 @@ export function fileDataDepType(dep: string | [string, string]) {
   return typeof dep === 'string' ? 'static' : dep[1];
 }
 
+export interface FileMap {
+  nonProjectFiles: FileData[];
+  projectFileMap: ProjectFileMap;
+}
+
 /**
  * A list of files separated by the project they belong to
  */

--- a/packages/nx/src/config/project-graph.ts
+++ b/packages/nx/src/config/project-graph.ts
@@ -11,15 +11,42 @@ import { NxJsonConfiguration } from './nx-json';
 export interface FileData {
   file: string;
   hash: string;
-  deps?: (string | [string, string])[];
+  /**
+   * An array of dependencies. If an element is just a string,
+   * the dependency is assumed to be a static dependency targetting
+   * that string. If the element is a tuple with two elements, the first element
+   * inside of it is the target project, with the second element being the type of dependency.
+   * If the tuple has 3 elements, the first is preceded by a source.
+   */
+  deps?: FileDataDependency[];
 }
 
-export function fileDataDepTarget(dep: string | [string, string]) {
-  return typeof dep === 'string' ? dep : dep[0];
+/**
+ * A file data dependency, as stored in the cache. If just a string,
+ * the dependency is assumed to be a static dependency targetting
+ * that string. If it is a tuple with two elements, the first element
+ * inside of it is the target project, with the second element being the type of dependency.
+ * If the tuple has 3 elements, the first is preceded by a source.
+ */
+export type FileDataDependency =
+  | string
+  | [target: string, type: DependencyType]
+  | [source: string, target: string, type: DependencyType];
+
+export function fileDataDepTarget(dep: FileDataDependency) {
+  return typeof dep === 'string'
+    ? dep
+    : Array.isArray(dep) && dep.length === 2
+    ? dep[0]
+    : dep[1];
 }
 
-export function fileDataDepType(dep: string | [string, string]) {
-  return typeof dep === 'string' ? 'static' : dep[1];
+export function fileDataDepType(dep: FileDataDependency) {
+  return typeof dep === 'string'
+    ? 'static'
+    : Array.isArray(dep) && dep.length === 2
+    ? dep[1]
+    : dep[2];
 }
 
 export interface FileMap {

--- a/packages/nx/src/daemon/server/file-watching/changed-projects.ts
+++ b/packages/nx/src/daemon/server/file-watching/changed-projects.ts
@@ -1,5 +1,5 @@
 import { performance } from 'perf_hooks';
-import { projectFileMapWithFiles } from '../project-graph-incremental-recomputation';
+import { fileMapWithFiles } from '../project-graph-incremental-recomputation';
 
 export type ChangedFile = {
   path: string;
@@ -38,7 +38,7 @@ export function getProjectsAndGlobalChanges(
 
   const fileToProjectMap: Record<string, string> = {};
   for (const [projectName, projectFiles] of Object.entries(
-    projectFileMapWithFiles?.projectFileMap ?? {}
+    fileMapWithFiles?.fileMap?.projectFileMap ?? {}
   )) {
     for (const projectFile of projectFiles) {
       fileToProjectMap[projectFile.file] = projectName;

--- a/packages/nx/src/daemon/server/handle-hash-tasks.ts
+++ b/packages/nx/src/daemon/server/handle-hash-tasks.ts
@@ -19,14 +19,14 @@ export async function handleHashTasks(payload: {
 }) {
   setHashEnv(payload.env);
 
-  const { projectGraph, allWorkspaceFiles, projectFileMap } =
+  const { projectGraph, allWorkspaceFiles, fileMap } =
     await getCachedSerializedProjectGraphPromise();
   const nxJson = readNxJson();
 
   if (projectGraph !== storedProjectGraph) {
     storedProjectGraph = projectGraph;
     storedHasher = new InProcessTaskHasher(
-      projectFileMap,
+      fileMap?.projectFileMap,
       allWorkspaceFiles,
       projectGraph,
       nxJson,

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -247,7 +247,7 @@ async function processFilesAndCreateAndSerializeProjectGraph() {
   }
 }
 
-function copyFileData(d: FileData[]) {
+function copyFileData<T extends FileData>(d: T[]) {
   return d.map((t) => ({ ...t }));
 }
 
@@ -257,7 +257,7 @@ function copyFileMap(m: FileMap) {
     projectFileMap: {},
   };
   for (let p of Object.keys(m.projectFileMap)) {
-    c[p] = copyFileData(m.projectFileMap[p]);
+    c.projectFileMap[p] = copyFileData(m.projectFileMap[p]);
   }
   return c;
 }

--- a/packages/nx/src/native/workspace/workspace_files.rs
+++ b/packages/nx/src/native/workspace/workspace_files.rs
@@ -20,6 +20,11 @@ pub struct NxWorkspaceFiles {
     pub external_nodes: HashMap<String, JsObject>,
 }
 
+pub struct FileMap {
+    pub project_file_map: HashMap<String, Vec<FileData>>,
+    pub non_project_files: Vec<FileData>
+}
+
 pub(super) fn get_files<ConfigurationParser>(
     globs: Vec<String>,
     parse_configurations: ConfigurationParser,

--- a/packages/nx/src/native/workspace/workspace_files.rs
+++ b/packages/nx/src/native/workspace/workspace_files.rs
@@ -20,11 +20,6 @@ pub struct NxWorkspaceFiles {
     pub external_nodes: HashMap<String, JsObject>,
 }
 
-pub struct FileMap {
-    pub project_file_map: HashMap<String, Vec<FileData>>,
-    pub non_project_files: Vec<FileData>
-}
-
 pub(super) fn get_files<ConfigurationParser>(
     globs: Vec<String>,
     parse_configurations: ConfigurationParser,

--- a/packages/nx/src/plugins/js/lock-file/npm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/npm-parser.spec.ts
@@ -40,8 +40,14 @@ describe('NPM lock file utility', () => {
       const ctx: CreateDependenciesContext = {
         projects: {},
         externalNodes,
-        fileMap: {},
-        filesToProcess: {},
+        fileMap: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
+        filesToProcess: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
@@ -96,8 +102,14 @@ describe('NPM lock file utility', () => {
       const ctx: CreateDependenciesContext = {
         projects: {},
         externalNodes,
-        fileMap: {},
-        filesToProcess: {},
+        fileMap: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
+        filesToProcess: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
@@ -175,8 +187,14 @@ describe('NPM lock file utility', () => {
       const ctx: CreateDependenciesContext = {
         projects: {},
         externalNodes,
-        fileMap: {},
-        filesToProcess: {},
+        fileMap: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
+        filesToProcess: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
@@ -265,8 +283,14 @@ describe('NPM lock file utility', () => {
       const ctx: CreateDependenciesContext = {
         projects: {},
         externalNodes,
-        fileMap: {},
-        filesToProcess: {},
+        fileMap: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
+        filesToProcess: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
@@ -395,8 +419,14 @@ describe('NPM lock file utility', () => {
       const ctx: CreateDependenciesContext = {
         projects: {},
         externalNodes,
-        fileMap: {},
-        filesToProcess: {},
+        fileMap: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
+        filesToProcess: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
@@ -514,8 +544,14 @@ describe('NPM lock file utility', () => {
       const ctx: CreateDependenciesContext = {
         projects: {},
         externalNodes,
-        fileMap: {},
-        filesToProcess: {},
+        fileMap: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
+        filesToProcess: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
@@ -557,8 +593,14 @@ describe('NPM lock file utility', () => {
       const ctx: CreateDependenciesContext = {
         projects: {},
         externalNodes,
-        fileMap: {},
-        filesToProcess: {},
+        fileMap: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
+        filesToProcess: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
@@ -604,8 +646,14 @@ describe('NPM lock file utility', () => {
       const ctx: CreateDependenciesContext = {
         projects: {},
         externalNodes,
-        fileMap: {},
-        filesToProcess: {},
+        fileMap: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
+        filesToProcess: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
@@ -662,8 +710,14 @@ describe('NPM lock file utility', () => {
       const ctx: CreateDependenciesContext = {
         projects: {},
         externalNodes,
-        fileMap: {},
-        filesToProcess: {},
+        fileMap: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
+        filesToProcess: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
@@ -722,8 +776,14 @@ describe('NPM lock file utility', () => {
       const ctx: CreateDependenciesContext = {
         projects: {},
         externalNodes,
-        fileMap: {},
-        filesToProcess: {},
+        fileMap: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
+        filesToProcess: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
@@ -151,8 +151,14 @@ describe('pnpm LockFile utility', () => {
         const ctx: CreateDependenciesContext = {
           projects: {},
           externalNodes,
-          fileMap: {},
-          filesToProcess: {},
+          fileMap: {
+            nonProjectFiles: [],
+            projectFileMap: {},
+          },
+          filesToProcess: {
+            nonProjectFiles: [],
+            projectFileMap: {},
+          },
           nxJsonConfiguration: null,
           workspaceRoot: '/virtual',
         };
@@ -212,8 +218,14 @@ describe('pnpm LockFile utility', () => {
         const ctx: CreateDependenciesContext = {
           projects: {},
           externalNodes,
-          fileMap: {},
-          filesToProcess: {},
+          fileMap: {
+            nonProjectFiles: [],
+            projectFileMap: {},
+          },
+          filesToProcess: {
+            nonProjectFiles: [],
+            projectFileMap: {},
+          },
           nxJsonConfiguration: null,
           workspaceRoot: '/virtual',
         };
@@ -259,8 +271,14 @@ describe('pnpm LockFile utility', () => {
         const appCtx: CreateDependenciesContext = {
           projects: {},
           externalNodes,
-          fileMap: {},
-          filesToProcess: {},
+          fileMap: {
+            nonProjectFiles: [],
+            projectFileMap: {},
+          },
+          filesToProcess: {
+            nonProjectFiles: [],
+            projectFileMap: {},
+          },
           nxJsonConfiguration: null,
           workspaceRoot: '/virtual',
         };
@@ -337,8 +355,14 @@ describe('pnpm LockFile utility', () => {
       const ctx: CreateDependenciesContext = {
         projects: {},
         externalNodes,
-        fileMap: {},
-        filesToProcess: {},
+        fileMap: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
+        filesToProcess: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
@@ -448,8 +472,14 @@ describe('pnpm LockFile utility', () => {
       const ctx: CreateDependenciesContext = {
         projects: {},
         externalNodes,
-        fileMap: {},
-        filesToProcess: {},
+        fileMap: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
+        filesToProcess: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
@@ -516,8 +546,14 @@ describe('pnpm LockFile utility', () => {
       const ctx: CreateDependenciesContext = {
         projects: {},
         externalNodes,
-        fileMap: {},
-        filesToProcess: {},
+        fileMap: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
+        filesToProcess: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
@@ -571,8 +607,14 @@ describe('pnpm LockFile utility', () => {
       const ctx: CreateDependenciesContext = {
         projects: {},
         externalNodes,
-        fileMap: {},
-        filesToProcess: {},
+        fileMap: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
+        filesToProcess: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
@@ -639,8 +681,14 @@ describe('pnpm LockFile utility', () => {
         const ctx: CreateDependenciesContext = {
           projects: {},
           externalNodes,
-          fileMap: {},
-          filesToProcess: {},
+          fileMap: {
+            nonProjectFiles: [],
+            projectFileMap: {},
+          },
+          filesToProcess: {
+            nonProjectFiles: [],
+            projectFileMap: {},
+          },
           nxJsonConfiguration: null,
           workspaceRoot: '/virtual',
         };
@@ -718,8 +766,14 @@ describe('pnpm LockFile utility', () => {
         const ctx: CreateDependenciesContext = {
           projects: {},
           externalNodes,
-          fileMap: {},
-          filesToProcess: {},
+          fileMap: {
+            nonProjectFiles: [],
+            projectFileMap: {},
+          },
+          filesToProcess: {
+            nonProjectFiles: [],
+            projectFileMap: {},
+          },
           nxJsonConfiguration: null,
           workspaceRoot: '/virtual',
         };

--- a/packages/nx/src/plugins/js/lock-file/yarn-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/yarn-parser.spec.ts
@@ -192,8 +192,14 @@ describe('yarn LockFile utility', () => {
       const ctx: CreateDependenciesContext = {
         projects: {},
         externalNodes,
-        fileMap: {},
-        filesToProcess: {},
+        fileMap: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
+        filesToProcess: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
@@ -510,8 +516,14 @@ describe('yarn LockFile utility', () => {
       const ctx: CreateDependenciesContext = {
         projects: {},
         externalNodes,
-        fileMap: {},
-        filesToProcess: {},
+        fileMap: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
+        filesToProcess: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
@@ -577,8 +589,14 @@ describe('yarn LockFile utility', () => {
       const ctx: CreateDependenciesContext = {
         projects: {},
         externalNodes,
-        fileMap: {},
-        filesToProcess: {},
+        fileMap: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
+        filesToProcess: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
@@ -716,8 +734,14 @@ describe('yarn LockFile utility', () => {
       const ctx: CreateDependenciesContext = {
         projects: {},
         externalNodes,
-        fileMap: {},
-        filesToProcess: {},
+        fileMap: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
+        filesToProcess: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
@@ -793,8 +817,14 @@ __metadata:
         const ctx: CreateDependenciesContext = {
           projects: {},
           externalNodes,
-          fileMap: {},
-          filesToProcess: {},
+          fileMap: {
+            nonProjectFiles: [],
+            projectFileMap: {},
+          },
+          filesToProcess: {
+            nonProjectFiles: [],
+            projectFileMap: {},
+          },
           nxJsonConfiguration: null,
           workspaceRoot: '/virtual',
         };
@@ -1267,8 +1297,14 @@ nx-cloud@latest:
       const ctx: CreateDependenciesContext = {
         projects: {},
         externalNodes,
-        fileMap: {},
-        filesToProcess: {},
+        fileMap: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
+        filesToProcess: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
@@ -1476,8 +1512,14 @@ nx-cloud@latest:
       const ctx: CreateDependenciesContext = {
         projects: {},
         externalNodes,
-        fileMap: {},
-        filesToProcess: {},
+        fileMap: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
+        filesToProcess: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
@@ -1533,8 +1575,14 @@ nx-cloud@latest:
       const ctx: CreateDependenciesContext = {
         projects: {},
         externalNodes,
-        fileMap: {},
-        filesToProcess: {},
+        fileMap: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
+        filesToProcess: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
@@ -1676,8 +1724,14 @@ type-fest@^0.20.2:
       const ctx: CreateDependenciesContext = {
         projects: {},
         externalNodes,
-        fileMap: {},
-        filesToProcess: {},
+        fileMap: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
+        filesToProcess: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
@@ -1789,8 +1843,14 @@ __metadata:
       const ctx: CreateDependenciesContext = {
         projects: {},
         externalNodes,
-        fileMap: {},
-        filesToProcess: {},
+        fileMap: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
+        filesToProcess: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
@@ -1912,8 +1972,14 @@ __metadata:
       const ctx: CreateDependenciesContext = {
         projects: {},
         externalNodes,
-        fileMap: {},
-        filesToProcess: {},
+        fileMap: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
+        filesToProcess: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
@@ -2149,8 +2215,14 @@ __metadata:
       const ctx: CreateDependenciesContext = {
         projects: {},
         externalNodes,
-        fileMap: {},
-        filesToProcess: {},
+        fileMap: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
+        filesToProcess: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
@@ -2536,8 +2608,14 @@ __metadata:
       const ctx: CreateDependenciesContext = {
         projects: {},
         externalNodes,
-        fileMap: {},
-        filesToProcess: {},
+        fileMap: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
+        filesToProcess: {
+          nonProjectFiles: [],
+          projectFileMap: {},
+        },
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };

--- a/packages/nx/src/plugins/js/package-json/create-package-json.ts
+++ b/packages/nx/src/plugins/js/package-json/create-package-json.ts
@@ -14,7 +14,7 @@ import {
   getTargetInputs,
 } from '../../../hasher/task-hasher';
 import { readNxJson } from '../../../config/configuration';
-import { readProjectFileMapCache } from '../../../project-graph/nx-deps-cache';
+import { readFileMapCache } from '../../../project-graph/nx-deps-cache';
 import { join } from 'path';
 
 interface NpmDeps {
@@ -193,7 +193,7 @@ export function findProjectsNpmDependencies(
   fileMap?: ProjectFileMap
 ): NpmDeps {
   if (fileMap == null) {
-    fileMap = readProjectFileMapCache()?.projectFileMap || {};
+    fileMap = readFileMapCache()?.fileMap?.projectFileMap || {};
   }
 
   const { selfInputs, dependencyInputs } = target

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/build-dependencies.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/build-dependencies.ts
@@ -43,7 +43,7 @@ export function buildExplicitDependencies(
 
 function totalNumberOfFilesToProcess(ctx: CreateDependenciesContext) {
   let totalNumOfFilesToProcess = 0;
-  Object.values(ctx.filesToProcess).forEach(
+  Object.values(ctx.filesToProcess.projectFileMap).forEach(
     (t) => (totalNumOfFilesToProcess += t.length)
   );
   return totalNumOfFilesToProcess;

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-package-json-dependencies.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-package-json-dependencies.spec.ts
@@ -5,7 +5,7 @@ import { buildExplicitPackageJsonDependencies } from './explicit-package-json-de
 
 import { ProjectGraphProjectNode } from '../../../../config/project-graph';
 import { ProjectGraphBuilder } from '../../../../project-graph/project-graph-builder';
-import { createProjectFileMap } from '../../../../project-graph/file-map-utils';
+import { createFileMap } from '../../../../project-graph/file-map-utils';
 import { CreateDependenciesContext } from '../../../../utils/nx-plugin';
 import { getAllFileDataInContext } from '../../../../utils/workspace-context';
 
@@ -71,12 +71,12 @@ describe('explicit package json dependencies', () => {
       },
     };
 
-    const projectFileMap = createProjectFileMap(
+    const fileMap = createFileMap(
       projectsConfigurations as any,
       getAllFileDataInContext(tempFs.tempDir)
-    ).projectFileMap;
+    ).fileMap;
 
-    const builder = new ProjectGraphBuilder(undefined, projectFileMap);
+    const builder = new ProjectGraphBuilder(undefined, fileMap.projectFileMap);
     Object.values(projects).forEach((p) => {
       builder.addNode(p);
     });
@@ -90,11 +90,11 @@ describe('explicit package json dependencies', () => {
     });
 
     ctx = {
-      fileMap: projectFileMap,
+      fileMap: fileMap,
       externalNodes: builder.getUpdatedProjectGraph().externalNodes,
       projects: projectsConfigurations.projects,
       nxJsonConfiguration,
-      filesToProcess: projectFileMap,
+      filesToProcess: fileMap,
       workspaceRoot: tempFs.tempDir,
     };
   });

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-package-json-dependencies.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-package-json-dependencies.ts
@@ -21,8 +21,8 @@ export function buildExplicitPackageJsonDependencies(
   const res: RawProjectGraphDependency[] = [];
   let packageNameMap = undefined;
   const nodes = Object.values(ctx.projects);
-  Object.keys(ctx.filesToProcess).forEach((source) => {
-    Object.values(ctx.filesToProcess[source]).forEach((f) => {
+  Object.keys(ctx.filesToProcess.projectFileMap).forEach((source) => {
+    Object.values(ctx.filesToProcess.projectFileMap[source]).forEach((f) => {
       if (isPackageJsonAtProjectRoot(nodes, f.file)) {
         // we only create the package name map once and only if a package.json file changes
         packageNameMap =

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.spec.ts
@@ -562,15 +562,17 @@ async function createContext(
 
   setupWorkspaceContext(tempFs.tempDir);
 
-  const { projectFileMap, projectConfigurations } =
-    await retrieveWorkspaceFiles(tempFs.tempDir, nxJson);
+  const { fileMap, projectConfigurations } = await retrieveWorkspaceFiles(
+    tempFs.tempDir,
+    nxJson
+  );
 
   return {
     externalNodes: builder.getUpdatedProjectGraph().externalNodes,
     projects: projectConfigurations.projects,
     nxJsonConfiguration: nxJson,
-    filesToProcess: projectFileMap,
-    fileMap: projectFileMap,
+    filesToProcess: fileMap,
+    fileMap: fileMap,
     workspaceRoot: tempFs.tempDir,
   };
 }

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.ts
@@ -79,7 +79,9 @@ export function buildExplicitTypeScriptDependencies(
     moduleExtensions.push('.vue');
   }
 
-  for (const [project, fileData] of Object.entries(ctx.fileMap)) {
+  for (const [project, fileData] of Object.entries(
+    ctx.fileMap.projectFileMap
+  )) {
     filesToProcess[project] ??= [];
     for (const { file } of fileData) {
       if (moduleExtensions.some((ext) => file.endsWith(ext))) {

--- a/packages/nx/src/project-graph/file-map-utils.spec.ts
+++ b/packages/nx/src/project-graph/file-map-utils.spec.ts
@@ -1,5 +1,5 @@
 import { ProjectType } from '../config/workspace-json-project-json';
-import { createProjectFileMap, updateProjectFileMap } from './file-map-utils';
+import { createFileMap, updateFileMap } from './file-map-utils';
 
 describe('fileMapUtils', () => {
   describe('createFileMap', () => {
@@ -31,15 +31,18 @@ describe('fileMapUtils', () => {
         { file: 'tools/myfile.txt', hash: 'some-hash' },
       ];
 
-      const result = createProjectFileMap(projectsConfigurations, files);
+      const result = createFileMap(projectsConfigurations, files);
 
       expect(result).toEqual({
-        projectFileMap: {
-          demo: [{ file: 'apps/demo/src/main.ts', hash: 'some-hash' }],
-          'demo-e2e': [
-            { file: 'apps/demo-e2e/src/main.ts', hash: 'some-hash' },
-          ],
-          ui: [{ file: 'libs/ui/src/index.ts', hash: 'some-hash' }],
+        fileMap: {
+          projectFileMap: {
+            demo: [{ file: 'apps/demo/src/main.ts', hash: 'some-hash' }],
+            'demo-e2e': [
+              { file: 'apps/demo-e2e/src/main.ts', hash: 'some-hash' },
+            ],
+            ui: [{ file: 'libs/ui/src/index.ts', hash: 'some-hash' }],
+          },
+          nonProjectFiles: [{ file: 'tools/myfile.txt', hash: 'some-hash' }],
         },
         allWorkspaceFiles: [
           { file: 'apps/demo/src/main.ts', hash: 'some-hash' },
@@ -76,6 +79,7 @@ describe('fileMapUtils', () => {
         { file: 'libs/ui/src/index.ts', hash: 'some-hash' },
         { file: 'libs/ui/src/second.ts', hash: 'some-hash' },
         { file: 'tools/myfile.txt', hash: 'some-hash' },
+        { file: 'tools/secondfile.txt', hash: 'some-hash' },
       ];
 
       const projectFileMap = {
@@ -86,33 +90,47 @@ describe('fileMapUtils', () => {
           { file: 'libs/ui/src/second.ts', hash: 'some-hash' },
         ],
       };
-      const result = updateProjectFileMap(
-        projectsConfigurations,
+
+      const fileMap = {
         projectFileMap,
+        allWorkspaceFiles: files,
+        nonProjectFiles: files.filter(
+          (f) =>
+            !Object.values(projectFileMap).some((arr) =>
+              arr.some((projectFile) => projectFile.file === f.file)
+            )
+        ),
+      };
+      const result = updateFileMap(
+        projectsConfigurations,
+        fileMap,
         files,
         new Map([
           ['apps/demo/src/main.ts', 'demo-main-update'],
           ['apps/demo/src/new-main.ts', 'new-main-hash'],
         ]),
-        ['libs/ui/src/second.ts']
+        ['libs/ui/src/second.ts', 'tools/secondfile.txt']
       );
 
       expect(result).toEqual({
-        projectFileMap: {
-          demo: [
-            {
-              file: 'apps/demo/src/main.ts',
-              hash: 'demo-main-update',
-            },
-            {
-              file: 'apps/demo/src/new-main.ts',
-              hash: 'new-main-hash',
-            },
-          ],
-          'demo-e2e': [
-            { file: 'apps/demo-e2e/src/main.ts', hash: 'some-hash' },
-          ],
-          ui: [{ file: 'libs/ui/src/index.ts', hash: 'some-hash' }],
+        fileMap: {
+          projectFileMap: {
+            demo: [
+              {
+                file: 'apps/demo/src/main.ts',
+                hash: 'demo-main-update',
+              },
+              {
+                file: 'apps/demo/src/new-main.ts',
+                hash: 'new-main-hash',
+              },
+            ],
+            'demo-e2e': [
+              { file: 'apps/demo-e2e/src/main.ts', hash: 'some-hash' },
+            ],
+            ui: [{ file: 'libs/ui/src/index.ts', hash: 'some-hash' }],
+          },
+          nonProjectFiles: [{ file: 'tools/myfile.txt', hash: 'some-hash' }],
         },
         allWorkspaceFiles: [
           { file: 'apps/demo/src/main.ts', hash: 'demo-main-update' },

--- a/packages/nx/src/project-graph/nx-deps-cache.spec.ts
+++ b/packages/nx/src/project-graph/nx-deps-cache.spec.ts
@@ -1,7 +1,7 @@
 import {
   createProjectFileMapCache as _createCache,
   extractCachedFileData,
-  ProjectFileMapCache,
+  FileMapCache,
   shouldRecomputeWholeGraph,
 } from './nx-deps-cache';
 import { ProjectConfiguration } from '../config/workspace-json-project-json';
@@ -52,9 +52,12 @@ describe('nx deps utils', () => {
       expect(
         shouldRecomputeWholeGraph(
           createCache({
-            projectFileMap: {
-              'renamed-mylib': [],
-            } as any,
+            fileMap: {
+              projectFileMap: {
+                'renamed-mylib': [],
+              } as any,
+              nonProjectFiles: [],
+            },
           }),
           createPackageJsonDeps({}),
           createProjectsConfiguration({}),
@@ -119,14 +122,7 @@ describe('nx deps utils', () => {
     it('should return the cache project graph when nothing has changed', () => {
       const r = extractCachedFileData(
         {
-          mylib: [
-            {
-              file: 'index.ts',
-              hash: 'hash1',
-            },
-          ],
-        },
-        createCache({
+          nonProjectFiles: [],
           projectFileMap: {
             mylib: [
               {
@@ -135,14 +131,33 @@ describe('nx deps utils', () => {
               },
             ],
           },
+        },
+        createCache({
+          fileMap: {
+            nonProjectFiles: [],
+            projectFileMap: {
+              mylib: [
+                {
+                  file: 'index.ts',
+                  hash: 'hash1',
+                },
+              ],
+            },
+          },
         })
       );
-      expect(r.filesToProcess).toEqual({});
+      expect(r.filesToProcess).toEqual({
+        projectFileMap: {},
+        nonProjectFiles: [],
+      });
       expect(r.cachedFileData).toEqual({
-        mylib: {
-          'index.ts': {
-            file: 'index.ts',
-            hash: 'hash1',
+        nonProjectFiles: {},
+        projectFileMap: {
+          mylib: {
+            'index.ts': {
+              file: 'index.ts',
+              hash: 'hash1',
+            },
           },
         },
       });
@@ -151,20 +166,7 @@ describe('nx deps utils', () => {
     it('should handle cases when new projects are added', () => {
       const r = extractCachedFileData(
         {
-          mylib: [
-            {
-              file: 'index.ts',
-              hash: 'hash1',
-            },
-          ],
-          secondlib: [
-            {
-              file: 'index.ts',
-              hash: 'hash2',
-            },
-          ],
-        },
-        createCache({
+          nonProjectFiles: [],
           projectFileMap: {
             mylib: [
               {
@@ -172,38 +174,99 @@ describe('nx deps utils', () => {
                 hash: 'hash1',
               },
             ],
+            secondlib: [
+              {
+                file: 'index.ts',
+                hash: 'hash2',
+              },
+            ],
+          },
+        },
+        createCache({
+          fileMap: {
+            nonProjectFiles: [],
+            projectFileMap: {
+              mylib: [
+                {
+                  file: 'index.ts',
+                  hash: 'hash1',
+                },
+              ],
+            },
           },
         })
       );
       expect(r.filesToProcess).toEqual({
-        secondlib: [
-          {
-            file: 'index.ts',
-            hash: 'hash2',
-          },
-        ],
+        projectFileMap: {
+          secondlib: [
+            {
+              file: 'index.ts',
+              hash: 'hash2',
+            },
+          ],
+        },
+        nonProjectFiles: [],
       });
       expect(r.cachedFileData).toEqual({
-        mylib: {
-          'index.ts': {
-            file: 'index.ts',
-            hash: 'hash1',
+        nonProjectFiles: {},
+        projectFileMap: {
+          mylib: {
+            'index.ts': {
+              file: 'index.ts',
+              hash: 'hash1',
+            },
           },
         },
-      });
-      expect(r.filesToProcess).toEqual({
-        secondlib: [{ file: 'index.ts', hash: 'hash2' }],
       });
     });
 
     it('should handle cases when files change', () => {
       const r = extractCachedFileData(
         {
-          mylib: [
-            {
-              file: 'index1.ts',
-              hash: 'hash1',
+          nonProjectFiles: [],
+          projectFileMap: {
+            mylib: [
+              {
+                file: 'index1.ts',
+                hash: 'hash1',
+              },
+              {
+                file: 'index2.ts',
+                hash: 'hash2b',
+              },
+              {
+                file: 'index4.ts',
+                hash: 'hash4',
+              },
+            ],
+          },
+        },
+        createCache({
+          fileMap: {
+            nonProjectFiles: [],
+            projectFileMap: {
+              mylib: [
+                {
+                  file: 'index1.ts',
+                  hash: 'hash1',
+                },
+                {
+                  file: 'index2.ts',
+                  hash: 'hash2',
+                },
+                {
+                  file: 'index3.ts',
+                  hash: 'hash3',
+                },
+              ],
             },
+          },
+        })
+      );
+      expect(r.filesToProcess).toEqual({
+        nonProjectFiles: [],
+        projectFileMap: {
+          mylib: [
             {
               file: 'index2.ts',
               hash: 'hash2b',
@@ -214,42 +277,15 @@ describe('nx deps utils', () => {
             },
           ],
         },
-        createCache({
-          projectFileMap: {
-            mylib: [
-              {
-                file: 'index1.ts',
-                hash: 'hash1',
-              },
-              {
-                file: 'index2.ts',
-                hash: 'hash2',
-              },
-              {
-                file: 'index3.ts',
-                hash: 'hash3',
-              },
-            ],
-          },
-        })
-      );
-      expect(r.filesToProcess).toEqual({
-        mylib: [
-          {
-            file: 'index2.ts',
-            hash: 'hash2b',
-          },
-          {
-            file: 'index4.ts',
-            hash: 'hash4',
-          },
-        ],
       });
       expect(r.cachedFileData).toEqual({
-        mylib: {
-          'index1.ts': {
-            file: 'index1.ts',
-            hash: 'hash1',
+        nonProjectFiles: {},
+        projectFileMap: {
+          mylib: {
+            'index1.ts': {
+              file: 'index1.ts',
+              hash: 'hash1',
+            },
           },
         },
       });
@@ -273,8 +309,8 @@ describe('nx deps utils', () => {
     });
   });
 
-  function createCache(p: Partial<ProjectFileMapCache>): ProjectFileMapCache {
-    const defaults: ProjectFileMapCache = {
+  function createCache(p: Partial<FileMapCache>): FileMapCache {
+    const defaults: FileMapCache = {
       version: '6.0',
       nxVersion: nxVersion,
       deps: {},
@@ -282,8 +318,11 @@ describe('nx deps utils', () => {
         mylib: ['libs/mylib/index.ts'],
       },
       nxJsonPlugins: [{ name: 'plugin', version: '1.0.0' }],
-      projectFileMap: {
-        mylib: [],
+      fileMap: {
+        nonProjectFiles: [],
+        projectFileMap: {
+          mylib: [],
+        },
       },
     };
     return { ...defaults, ...p };

--- a/packages/nx/src/project-graph/nx-deps-cache.ts
+++ b/packages/nx/src/project-graph/nx-deps-cache.ts
@@ -231,7 +231,7 @@ export function shouldRecomputeWholeGraph(
   return false;
 }
 
-type CachedFileData = {
+export type CachedFileData = {
   nonProjectFiles: Record<string, FileData>;
   projectFileMap: { [project: string]: Record<string, FileData> };
 };
@@ -291,11 +291,11 @@ function processNonProjectFiles(
 ) {
   const cachedHashMap = new Map(cachedFiles.map((f) => [f.file, f]));
   for (const f of nonProjectFiles) {
-    const cachedHash = cachedHashMap.get(f.file)?.hash;
-    if (!cachedHash || cachedHash !== f.hash) {
+    const cachedFile = cachedHashMap.get(f.file);
+    if (!cachedFile || cachedFile.hash !== f.hash) {
       filesToProcess.push(f);
     } else {
-      cachedFileData[f.file] = f;
+      cachedFileData[f.file] = cachedFile;
     }
   }
 }

--- a/packages/nx/src/project-graph/nx-deps-cache.ts
+++ b/packages/nx/src/project-graph/nx-deps-cache.ts
@@ -5,6 +5,7 @@ import { performance } from 'perf_hooks';
 import { NxJsonConfiguration } from '../config/nx-json';
 import {
   FileData,
+  FileMap,
   ProjectFileMap,
   ProjectGraph,
 } from '../config/project-graph';
@@ -18,14 +19,14 @@ import {
 } from '../utils/fileutils';
 import { nxVersion } from '../utils/versions';
 
-export interface ProjectFileMapCache {
+export interface FileMapCache {
   version: string;
   nxVersion: string;
   deps: Record<string, string>;
   pathMappings: Record<string, any>;
   nxJsonPlugins: { name: string; version: string }[];
   pluginsConfig?: any;
-  projectFileMap: ProjectFileMap;
+  fileMap: FileMap;
 }
 
 export const nxProjectGraph = join(
@@ -58,7 +59,7 @@ export function ensureCacheDirectory(): void {
   }
 }
 
-export function readProjectFileMapCache(): null | ProjectFileMapCache {
+export function readFileMapCache(): null | FileMapCache {
   performance.mark('read cache:start');
   ensureCacheDirectory();
 
@@ -107,14 +108,14 @@ export function readProjectGraphCache(): null | ProjectGraph {
 export function createProjectFileMapCache(
   nxJson: NxJsonConfiguration<'*' | string[]>,
   packageJsonDeps: Record<string, string>,
-  projectFileMap: ProjectFileMap,
+  fileMap: FileMap,
   tsConfig: { compilerOptions?: { paths?: { [p: string]: any } } }
 ) {
   const nxJsonPlugins = (nxJson?.plugins || []).map((p) => ({
     name: p,
     version: packageJsonDeps[p],
   }));
-  const newValue: ProjectFileMapCache = {
+  const newValue: FileMapCache = {
     version: '6.0',
     nxVersion: nxVersion,
     deps: packageJsonDeps, // TODO(v18): We can remove this in favor of nxVersion
@@ -122,13 +123,13 @@ export function createProjectFileMapCache(
     pathMappings: tsConfig?.compilerOptions?.paths || {},
     nxJsonPlugins,
     pluginsConfig: nxJson?.pluginsConfig,
-    projectFileMap,
+    fileMap,
   };
   return newValue;
 }
 
 export function writeCache(
-  cache: ProjectFileMapCache,
+  cache: FileMapCache,
   projectGraph: ProjectGraph
 ): void {
   performance.mark('write cache:start');
@@ -169,7 +170,7 @@ export function writeCache(
 }
 
 export function shouldRecomputeWholeGraph(
-  cache: ProjectFileMapCache,
+  cache: FileMapCache,
   packageJsonDeps: Record<string, string>,
   projects: Record<string, ProjectConfiguration>,
   nxJson: NxJsonConfiguration,
@@ -183,7 +184,7 @@ export function shouldRecomputeWholeGraph(
   }
 
   // we have a cached project that is no longer present
-  const cachedNodes = Object.keys(cache.projectFileMap);
+  const cachedNodes = Object.keys(cache.fileMap.projectFileMap);
   if (cachedNodes.some((p) => projects[p] === undefined)) {
     return true;
   }
@@ -230,32 +231,51 @@ export function shouldRecomputeWholeGraph(
   return false;
 }
 
+type CachedFileData = {
+  nonProjectFiles: Record<string, FileData>;
+  projectFileMap: { [project: string]: Record<string, FileData> };
+};
+
 /*
 This can only be invoked when the list of projects is either the same
 or new projects have been added, so every project in the cache has a corresponding
 project in fileMap
 */
 export function extractCachedFileData(
-  fileMap: ProjectFileMap,
-  c: ProjectFileMapCache
+  fileMap: FileMap,
+  c: FileMapCache
 ): {
-  filesToProcess: ProjectFileMap;
-  cachedFileData: { [project: string]: { [file: string]: FileData } };
+  filesToProcess: FileMap;
+  cachedFileData: CachedFileData;
 } {
-  const filesToProcess: ProjectFileMap = {};
-  const cachedFileData: Record<string, Record<string, FileData>> = {};
-  const currentProjects = Object.keys(fileMap).filter(
-    (name) => fileMap[name].length > 0
+  const filesToProcess: FileMap = {
+    nonProjectFiles: [],
+    projectFileMap: {},
+  };
+  const cachedFileData: CachedFileData = {
+    nonProjectFiles: {},
+    projectFileMap: {},
+  };
+
+  const currentProjects = Object.keys(fileMap.projectFileMap).filter(
+    (name) => fileMap.projectFileMap[name].length > 0
   );
   currentProjects.forEach((p) => {
     processProjectNode(
       p,
-      c.projectFileMap,
-      cachedFileData,
-      filesToProcess,
+      c.fileMap.projectFileMap,
+      cachedFileData.projectFileMap,
+      filesToProcess.projectFileMap,
       fileMap
     );
   });
+
+  processNonProjectFiles(
+    c.fileMap.nonProjectFiles,
+    fileMap.nonProjectFiles,
+    filesToProcess.nonProjectFiles,
+    cachedFileData.nonProjectFiles
+  );
 
   return {
     filesToProcess,
@@ -263,15 +283,32 @@ export function extractCachedFileData(
   };
 }
 
+function processNonProjectFiles(
+  cachedFiles: FileData[],
+  nonProjectFiles: FileData[],
+  filesToProcess: FileMap['nonProjectFiles'],
+  cachedFileData: CachedFileData['nonProjectFiles']
+) {
+  const cachedHashMap = new Map(cachedFiles.map((f) => [f.file, f]));
+  for (const f of nonProjectFiles) {
+    const cachedHash = cachedHashMap.get(f.file)?.hash;
+    if (!cachedHash || cachedHash !== f.hash) {
+      filesToProcess.push(f);
+    } else {
+      cachedFileData[f.file] = f;
+    }
+  }
+}
+
 function processProjectNode(
   projectName: string,
   cachedFileMap: ProjectFileMap,
   cachedFileData: { [project: string]: { [file: string]: FileData } },
   filesToProcess: ProjectFileMap,
-  fileMap: ProjectFileMap
+  { projectFileMap }: FileMap
 ) {
   if (!cachedFileMap[projectName]) {
-    filesToProcess[projectName] = fileMap[projectName];
+    filesToProcess[projectName] = projectFileMap[projectName];
     return;
   }
 
@@ -284,7 +321,7 @@ function processProjectNode(
     cachedFileData[projectName] = {};
   }
 
-  for (let f of fileMap[projectName]) {
+  for (let f of projectFileMap[projectName]) {
     const fromCache = fileDataFromCache[f.file];
     if (fromCache && fromCache.hash == f.hash) {
       cachedFileData[projectName][f.file] = fromCache;

--- a/packages/nx/src/project-graph/project-graph-builder.ts
+++ b/packages/nx/src/project-graph/project-graph-builder.ts
@@ -3,8 +3,11 @@
  */
 import {
   DependencyType,
+  FileData,
+  FileDataDependency,
   fileDataDepTarget,
   fileDataDepType,
+  FileMap,
   ProjectFileMap,
   ProjectGraph,
   ProjectGraphDependency,
@@ -22,19 +25,34 @@ import { getFileMap } from './build-project-graph';
 export class ProjectGraphBuilder {
   // TODO(FrozenPandaz): make this private
   readonly graph: ProjectGraph;
+
   private readonly projectFileMap: ProjectFileMap;
+  private readonly nonProjectFiles: FileData[];
+
   readonly removedEdges: { [source: string]: Set<string> } = {};
-  constructor(graph?: ProjectGraph, fileMap?: ProjectFileMap) {
+
+  constructor(
+    graph?: ProjectGraph,
+    projectFileMap?: ProjectFileMap,
+    nonProjectFiles?: FileMap['nonProjectFiles']
+  ) {
+    if (!projectFileMap || !nonProjectFiles) {
+      const fileMap = getFileMap().fileMap;
+      projectFileMap ??= fileMap.projectFileMap;
+      nonProjectFiles ??= fileMap.nonProjectFiles;
+    }
     if (graph) {
       this.graph = graph;
-      this.projectFileMap = fileMap || getFileMap().fileMap?.projectFileMap;
+      this.projectFileMap = projectFileMap;
+      this.nonProjectFiles = nonProjectFiles;
     } else {
       this.graph = {
         nodes: {},
         externalNodes: {},
         dependencies: {},
       };
-      this.projectFileMap = fileMap || {};
+      this.projectFileMap = projectFileMap || {};
+      this.nonProjectFiles = nonProjectFiles || [];
     }
   }
 
@@ -234,6 +252,28 @@ export class ProjectGraphBuilder {
         }
       }
     }
+    for (const file of this.nonProjectFiles) {
+      if (file.deps) {
+        for (const dep of file.deps) {
+          if (!Array.isArray(dep)) {
+            throw new Error(
+              'Cached data on non project files should be a tuple'
+            );
+          }
+          const [source, target, type] = dep;
+          if (!source || !target || !type) {
+            throw new Error(
+              'Cached dependencies for non project files should be a tuple of length 3.'
+            );
+          }
+          this.graph.dependencies[source].push({
+            source,
+            target,
+            type,
+          });
+        }
+      }
+    }
     return this.graph;
   }
 
@@ -257,8 +297,8 @@ export class ProjectGraphBuilder {
       {
         externalNodes: this.graph.externalNodes,
         fileMap: {
-          projectFileMap: { ...this.projectFileMap },
-          nonProjectFiles: [],
+          projectFileMap: this.projectFileMap,
+          nonProjectFiles: this.nonProjectFiles,
         },
         // the validators only really care about the keys on this.
         projects: this.graph.nodes as any,
@@ -276,23 +316,28 @@ export class ProjectGraphBuilder {
     );
 
     if (sourceFile) {
-      const fileData = getFileData(
+      let fileData = getProjectFileData(
         source,
         sourceFile,
-        this.graph.nodes,
         this.projectFileMap
       );
+      const isProjectFileData = !!fileData;
+      fileData ??= getNonProjectFileData(sourceFile, this.nonProjectFiles);
 
       if (!fileData.deps) {
         fileData.deps = [];
       }
+
       if (
         !fileData.deps.find(
           (t) => fileDataDepTarget(t) === target && fileDataDepType(t) === type
         )
       ) {
-        const dep: string | [string, string] =
-          type === 'static' ? target : [target, type];
+        const dep: FileDataDependency = isProjectFileData
+          ? type === 'static'
+            ? target
+            : [target, type]
+          : [source, target, type];
         fileData.deps.push(dep);
       }
     } else if (!isDuplicate) {
@@ -491,8 +536,19 @@ function validateCommonDependencyRules(
     throw new Error(`External projects can't depend on internal projects`);
   }
   if ('sourceFile' in d && d.sourceFile) {
-    // Throws if source file is not a valid file within the source project.
-    getFileData(d.source, d.sourceFile, projects, fileMap.projectFileMap);
+    if (projects[d.source]) {
+      // Throws if source file is not a valid file within the source project.
+      // We can pass empty array for all workspace files here, since its not checked by the impl.
+      // We need all workspace files in here for the TODO comment though, so lets figure that out.
+      getFileData(
+        d.source,
+        d.sourceFile,
+        projects,
+        externalNodes,
+        fileMap.projectFileMap,
+        fileMap.nonProjectFiles
+      );
+    }
   }
 }
 
@@ -531,21 +587,44 @@ function validateStaticDependency(
   }
 }
 
+function getProjectFileData(
+  source: string,
+  sourceFile: string,
+  fileMap: ProjectFileMap
+) {
+  let fileData = (fileMap[source] || []).find((f) => f.file === sourceFile);
+  if (fileData) {
+    return fileData;
+  }
+}
+
+function getNonProjectFileData(sourceFile: string, files: FileData[]) {
+  const fileData = files.find((f) => f.file === sourceFile);
+  if (!fileData) {
+    throw new Error(
+      `Source file "${sourceFile}" does not exist in the workspace.`
+    );
+  }
+  return fileData;
+}
+
 function getFileData(
   source: string,
   sourceFile: string,
   projects: Record<string, ProjectGraphProjectNode | ProjectConfiguration>,
-  fileMap: ProjectFileMap
+  externalNodes: Record<string, ProjectGraphExternalNode>,
+  fileMap: ProjectFileMap,
+  nonProjectFiles: FileData[]
 ) {
   const sourceProject = projects[source];
-  if (!sourceProject) {
+  const matchingExternalNode = externalNodes[source];
+
+  if (!sourceProject && !matchingExternalNode) {
     throw new Error(`Source project is not a project node: ${sourceProject}`);
   }
-  const fileData = (fileMap[source] || []).find((f) => f.file === sourceFile);
-  if (!fileData) {
-    throw new Error(
-      `Source project ${source} does not have a file: ${sourceFile}`
-    );
-  }
-  return fileData;
+
+  return (
+    getProjectFileData(source, sourceFile, fileMap) ??
+    getNonProjectFileData(sourceFile, nonProjectFiles)
+  );
 }

--- a/packages/nx/src/project-graph/project-graph.ts
+++ b/packages/nx/src/project-graph/project-graph.ts
@@ -1,7 +1,4 @@
-import {
-  readProjectFileMapCache,
-  readProjectGraphCache,
-} from './nx-deps-cache';
+import { readFileMapCache, readProjectGraphCache } from './nx-deps-cache';
 import { buildProjectGraphUsingProjectFileMap } from './build-project-graph';
 import { output } from '../utils/output';
 import { markDaemonAsDisabled, writeDaemonLogs } from '../daemon/tmp-dir';
@@ -74,21 +71,17 @@ export function readProjectsConfigurationFromProjectGraph(
 export async function buildProjectGraphWithoutDaemon() {
   const nxJson = readNxJson();
 
-  const {
-    allWorkspaceFiles,
-    projectFileMap,
-    projectConfigurations,
-    externalNodes,
-  } = await retrieveWorkspaceFiles(workspaceRoot, nxJson);
+  const { allWorkspaceFiles, fileMap, projectConfigurations, externalNodes } =
+    await retrieveWorkspaceFiles(workspaceRoot, nxJson);
 
   const cacheEnabled = process.env.NX_CACHE_PROJECT_GRAPH !== 'false';
   return (
     await buildProjectGraphUsingProjectFileMap(
       projectConfigurations.projects,
       externalNodes,
-      projectFileMap,
+      fileMap,
       allWorkspaceFiles,
-      cacheEnabled ? readProjectFileMapCache() : null,
+      cacheEnabled ? readFileMapCache() : null,
       cacheEnabled
     )
   ).projectGraph;

--- a/packages/nx/src/project-graph/utils/implicit-project-dependencies.spec.ts
+++ b/packages/nx/src/project-graph/utils/implicit-project-dependencies.spec.ts
@@ -26,10 +26,7 @@ describe('implicit project dependencies', () => {
 
     applyImplicitDependencies(
       {
-        version: 2,
-        projects: {
-          proj1: { root: '', implicitDependencies: ['proj2'] },
-        },
+        proj1: { root: '', implicitDependencies: ['proj2'] },
       },
       builder
     );
@@ -57,10 +54,7 @@ describe('implicit project dependencies', () => {
 
     applyImplicitDependencies(
       {
-        version: 2,
-        projects: {
-          proj1: { root: '', implicitDependencies: ['!proj2'] },
-        },
+        proj1: { root: '', implicitDependencies: ['!proj2'] },
       },
       builder
     );

--- a/packages/nx/src/project-graph/utils/implicit-project-dependencies.ts
+++ b/packages/nx/src/project-graph/utils/implicit-project-dependencies.ts
@@ -1,12 +1,12 @@
-import { ProjectsConfigurations } from '../../config/workspace-json-project-json';
+import { ProjectConfiguration } from '../../config/workspace-json-project-json';
 import { ProjectGraphBuilder } from '../project-graph-builder';
 
 export function applyImplicitDependencies(
-  projectsConfigurations: ProjectsConfigurations,
+  projects: Record<string, ProjectConfiguration>,
   builder: ProjectGraphBuilder
 ) {
-  Object.keys(projectsConfigurations.projects).forEach((source) => {
-    const p = projectsConfigurations.projects[source];
+  Object.keys(projects).forEach((source) => {
+    const p = projects[source];
     if (p.implicitDependencies && p.implicitDependencies.length > 0) {
       p.implicitDependencies.forEach((target) => {
         if (target.startsWith('!')) {

--- a/packages/nx/src/project-graph/utils/normalize-project-nodes.ts
+++ b/packages/nx/src/project-graph/utils/normalize-project-nodes.ts
@@ -15,18 +15,19 @@ import {
   readTargetDefaultsForTarget,
   resolveNxTokensInOptions,
 } from '../utils/project-configuration-utils';
+import { CreateDependenciesContext } from '../../utils/nx-plugin';
 
 export async function normalizeProjectNodes(
-  ctx: ProjectGraphProcessorContext,
+  ctx: CreateDependenciesContext,
   builder: ProjectGraphBuilder,
   nxJson: NxJsonConfiguration
 ) {
   const toAdd = [];
-  const projects = Object.keys(ctx.projectsConfigurations.projects);
+  const projects = Object.keys(ctx.projects);
 
   // Used for expanding implicit dependencies (e.g. `@proj/*` or `tag:foo`)
   const partialProjectGraphNodes = projects.reduce((graph, project) => {
-    const projectConfiguration = ctx.projectsConfigurations.projects[project];
+    const projectConfiguration = ctx.projects[project];
     graph[project] = {
       name: project,
       type: projectConfiguration.projectType === 'library' ? 'lib' : 'app', // missing fallback to `e2e`
@@ -38,7 +39,7 @@ export async function normalizeProjectNodes(
   }, {} as Record<string, ProjectGraphProjectNode>);
 
   for (const key of projects) {
-    const p = ctx.projectsConfigurations.projects[key];
+    const p = ctx.projects[key];
 
     p.implicitDependencies = normalizeImplicitDependencies(
       key,
@@ -55,7 +56,7 @@ export async function normalizeProjectNodes(
           ? 'e2e'
           : 'app'
         : 'lib';
-    const tags = ctx.projectsConfigurations.projects?.[key]?.tags || [];
+    const tags = ctx.projects?.[key]?.tags || [];
 
     toAdd.push({
       name: key,

--- a/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
+++ b/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
@@ -255,7 +255,7 @@ function buildAllWorkspaceFiles(
   globalFiles: FileData[]
 ): FileData[] {
   performance.mark('get-all-workspace-files:start');
-  let fileData = Object.values(projectFileMap).flat();
+  let fileData: FileData[] = Object.values(projectFileMap).flat();
 
   fileData = fileData.concat(globalFiles);
   performance.mark('get-all-workspace-files:end');

--- a/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
+++ b/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
@@ -86,7 +86,10 @@ export async function retrieveWorkspaceFiles(
 
   return {
     allWorkspaceFiles: buildAllWorkspaceFiles(projectFileMap, globalFiles),
-    projectFileMap,
+    fileMap: {
+      projectFileMap,
+      nonProjectFiles: globalFiles,
+    },
     projectConfigurations: {
       version: 2,
       projects: projectConfigurations,

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -32,7 +32,7 @@ import {
 import { hashTasksThatDoNotDependOnOutputsOfOtherTasks } from '../hasher/hash-task';
 import { daemonClient } from '../daemon/client/client';
 import { StoreRunInformationLifeCycle } from './life-cycles/store-run-information-life-cycle';
-import { getProjectFileMap } from '../project-graph/build-project-graph';
+import { getFileMap } from '../project-graph/build-project-graph';
 import { performance } from 'perf_hooks';
 
 async function getTerminalOutputLifeCycle(
@@ -233,9 +233,9 @@ export async function invokeTasksRunner({
   if (daemonClient.enabled()) {
     hasher = new DaemonBasedTaskHasher(daemonClient, runnerOptions);
   } else {
-    const { projectFileMap, allWorkspaceFiles } = getProjectFileMap();
+    const { fileMap, allWorkspaceFiles } = getFileMap();
     hasher = new InProcessTaskHasher(
-      projectFileMap,
+      fileMap?.projectFileMap,
       allWorkspaceFiles,
       projectGraph,
       nxJson,

--- a/packages/nx/src/utils/nx-plugin.ts
+++ b/packages/nx/src/utils/nx-plugin.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'fs';
 import * as path from 'path';
 import {
   FileData,
+  FileMap,
   ProjectFileMap,
   ProjectGraph,
   ProjectGraphExternalNode,
@@ -95,12 +96,12 @@ export interface CreateDependenciesContext {
   /**
    * All files in the workspace
    */
-  readonly fileMap: ProjectFileMap;
+  readonly fileMap: FileMap;
 
   /**
    * Files changes since last invocation
    */
-  readonly filesToProcess: ProjectFileMap;
+  readonly filesToProcess: FileMap;
 
   readonly workspaceRoot: string;
 }

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -15,7 +15,6 @@ export {
   readWorkspaceConfig,
   readPackageJson,
 } from 'nx/src/project-graph/file-utils';
-export { ProjectFileMapCache } from 'nx/src/project-graph/nx-deps-cache';
 
 export {
   getWorkspacePath,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`filesToProcess` doesn't include non project files, so there is no indication inside of `createDependencies` if one has changed. This leads to requiring custom caching and hashing behavior on the plugin side to avoid extra work.

## Expected Behavior
`filesToProcess` includes non project files

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
