### PR TITLE
fix(js): node executor now correctly kills tasks when exiting

### DIFF
--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -209,6 +209,27 @@ export async function* nodeExecutor(
       tasks.push(task);
     };
 
+    const stopAllTasks = async (signal: NodeJS.Signals = 'SIGTERM') => {
+      additionalExitHandler?.();
+      await currentTask?.stop(signal);
+      for (const task of tasks) {
+        await task.stop(signal);
+      }
+    };
+
+    process.on('SIGTERM', async () => {
+      await stopAllTasks('SIGTERM');
+      process.exit(128 + 15);
+    });
+    process.on('SIGINT', async () => {
+      await stopAllTasks('SIGINT');
+      process.exit(128 + 2);
+    });
+    process.on('SIGHUP', async () => {
+      await stopAllTasks('SIGHUP');
+      process.exit(128 + 1);
+    });
+
     if (options.runBuildTargetDependencies) {
       // If a all dependencies need to be rebuild on changes, then register with watcher
       // and run through CLI, otherwise only the current project will rebuild.
@@ -276,26 +297,6 @@ export async function* nodeExecutor(
         }
       }
     }
-
-    const stopAllTasks = (signal: NodeJS.Signals = 'SIGTERM') => {
-      additionalExitHandler?.();
-      for (const task of tasks) {
-        task.stop(signal);
-      }
-    };
-
-    process.on('SIGTERM', async () => {
-      stopAllTasks('SIGTERM');
-      process.exit(128 + 15);
-    });
-    process.on('SIGINT', async () => {
-      stopAllTasks('SIGINT');
-      process.exit(128 + 2);
-    });
-    process.on('SIGHUP', async () => {
-      stopAllTasks('SIGHUP');
-      process.exit(128 + 1);
-    });
   });
 }
 


### PR DESCRIPTION
Previously, the node executor od @nx/js did not kill spawned processes due to not awaiting finishing of killing and infinite loop.
This fix allows for seemless running nx in docker containers with support for signals

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When killing nx running `@nx/js:node`, child processes are not killed

## Expected Behavior
Child processes should be killed

