### PR TITLE
feat(misc): do not prompt for project name and root format when they produce the same result

### DIFF
--- a/packages/devkit/src/generators/project-name-and-root-utils.spec.ts
+++ b/packages/devkit/src/generators/project-name-and-root-utils.spec.ts
@@ -394,6 +394,33 @@ describe('determineProjectNameAndRootOptions', () => {
       // restore original interactive mode
       restoreOriginalInteractiveMode();
     });
+
+    it('should not prompt when the resulting name and root are the same for both formats', async () => {
+      // simulate interactive mode
+      ensureInteractiveMode();
+      const promptSpy = jest.spyOn(enquirer, 'prompt');
+
+      const result = await determineProjectNameAndRootOptions(tree, {
+        name: 'libName',
+        projectType: 'library',
+        callingGenerator: '',
+      });
+
+      expect(promptSpy).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        projectName: 'lib-name',
+        names: {
+          projectSimpleName: 'lib-name',
+          projectFileName: 'lib-name',
+        },
+        importPath: '@proj/lib-name',
+        projectRoot: 'lib-name',
+        projectNameAndRootFormat: 'as-provided',
+      });
+
+      // restore original interactive mode
+      restoreOriginalInteractiveMode();
+    });
   });
 
   describe('with layout', () => {

--- a/packages/devkit/src/generators/project-name-and-root-utils.ts
+++ b/packages/devkit/src/generators/project-name-and-root-utils.ts
@@ -155,6 +155,10 @@ async function determineFormat(
     Root: ${formats['derived'].projectRoot}`;
   const derivedSelectedValue = `${formats['derived'].projectName} @ ${formats['derived'].projectRoot}`;
 
+  if (asProvidedSelectedValue === derivedSelectedValue) {
+    return 'as-provided';
+  }
+
   const result = await prompt<{ format: ProjectNameAndRootFormat }>({
     type: 'select',
     name: 'format',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When generating a project, the user is prompted to choose the project name and root format, even if both formats produce the same results.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When generating a project, the user should not be prompted to choose the project name and root format if both formats produce the same results.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
