### PR TITLE
fix(core): set SWC_NODE_PROJECT before registering `@swc-node/register`

### DIFF
--- a/packages/nx/src/plugins/js/utils/register.ts
+++ b/packages/nx/src/plugins/js/utils/register.ts
@@ -1,6 +1,8 @@
 import { dirname, join } from 'path';
 import type { CompilerOptions } from 'typescript';
 import { logger, NX_PREFIX, stripIndent } from '../../../utils/logger';
+import { existsSync } from 'fs';
+import { workspaceRoot } from '../../../utils/workspace-root';
 
 const swcNodeInstalled = packageIsInstalled('@swc-node/register');
 const tsNodeInstalled = packageIsInstalled('ts-node/register');
@@ -43,6 +45,10 @@ export function getSwcTranspiler(
   // These are requires to prevent it from registering when it shouldn't
   const register = require('@swc-node/register/register')
     .register as ISwcRegister;
+
+  if (existsSync(join(workspaceRoot, 'tsconfig.base.json'))) {
+    process.env.SWC_NODE_PROJECT = 'tsconfig.base.json';
+  }
 
   const cleanupFn = register(compilerOptions);
 

--- a/packages/nx/src/plugins/js/utils/register.ts
+++ b/packages/nx/src/plugins/js/utils/register.ts
@@ -46,8 +46,9 @@ export function getSwcTranspiler(
   const register = require('@swc-node/register/register')
     .register as ISwcRegister;
 
-  if (existsSync(join(workspaceRoot, 'tsconfig.base.json'))) {
-    process.env.SWC_NODE_PROJECT = 'tsconfig.base.json';
+  let rootTsConfig = join(workspaceRoot, 'tsconfig.base.json');
+  if (existsSync(rootTsConfig)) {
+    process.env.SWC_NODE_PROJECT = rootTsConfig;
   }
 
   const cleanupFn = register(compilerOptions);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
swc does not use the `tsconfig.base.json` file in integrated repos for use in in-process transpilation

## Expected Behavior
Set `SWC_NODE_PROJECT` to `tsconfig.base.json` if it exists. (Otherwise swc will just use tsconfig.json anyway)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
