### PR TITLE
fix(core): handle negative star glob better

### DIFF
--- a/packages/nx/src/native/utils/glob.rs
+++ b/packages/nx/src/native/utils/glob.rs
@@ -128,7 +128,7 @@ fn convert_glob(glob: &str) -> anyhow::Result<Vec<String>> {
         globs.push(format!(
             "!{}",
             SINGLE_PATTERN_REGEX
-                .replace(&glob, |caps: &regex::Captures| { caps[1].to_string() })
+                .replace(&glob, |caps: &regex::Captures| { format!("{}*", &caps[1]) })
                 .replace('!', "")
         ));
     } else {
@@ -197,7 +197,7 @@ mod test {
     #[test]
     fn convert_globs_single_negative() {
         let negative_single_dir = convert_glob("packages/!(package-a)*").unwrap();
-        assert_eq!(negative_single_dir, ["packages/*", "!packages/package-a"]);
+        assert_eq!(negative_single_dir, ["packages/*", "!packages/package-a*"]);
     }
 
     #[test]
@@ -318,6 +318,8 @@ mod test {
         assert!(glob_set.is_match("packages/package-c"));
         // no matches
         assert!(!glob_set.is_match("packages/package-a"));
+        assert!(!glob_set.is_match("packages/package-a-b"));
+        assert!(!glob_set.is_match("packages/package-a-b/nested"));
         assert!(!glob_set.is_match("packages/package-b/nested"));
     }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
the glob `packages/!(package-a)*` expands to `['packages/*', '!packages/package-a']`

## Expected Behavior
`packages/!(package-a)*` is expanded to `['packages/*', '!packages/package-a*']`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
