### PR TITLE
feat(react): add support for transitive serve of remotes

### DIFF
--- a/docs/generated/packages/angular/executors/module-federation-dev-server.json
+++ b/docs/generated/packages/angular/executors/module-federation-dev-server.json
@@ -112,6 +112,16 @@
       "pathToManifestFile": {
         "type": "string",
         "description": "Path to a Module Federation manifest file (e.g. `my/path/to/module-federation.manifest.json`) containing the dynamic remote applications relative to the workspace root."
+      },
+      "static": {
+        "type": "boolean",
+        "description": "Whether to use a static file server instead of the webpack-dev-server. This should be used for remote applications that are also host applications."
+      },
+      "isInitialHost": {
+        "type": "boolean",
+        "description": "Whether the host that is running this executor is the first in the project tree to do so.",
+        "default": false,
+        "x-priority": "internal"
       }
     },
     "additionalProperties": false,

--- a/docs/generated/packages/react/executors/module-federation-dev-server.json
+++ b/docs/generated/packages/react/executors/module-federation-dev-server.json
@@ -90,6 +90,16 @@
       "baseHref": {
         "type": "string",
         "description": "Base url for the application being built."
+      },
+      "static": {
+        "type": "boolean",
+        "description": "Whether to use a static file server instead of the webpack-dev-server. This should be used for remote applications that are also host applications."
+      },
+      "isInitialHost": {
+        "type": "boolean",
+        "description": "Whether the host that is running this executor is the first in the project tree to do so.",
+        "default": false,
+        "x-priority": "internal"
       }
     },
     "presets": []

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -63,6 +63,7 @@
     "@nx/jest": "file:../jest",
     "@nx/js": "file:../js",
     "@nx/linter": "file:../linter",
+    "@nx/web": "file:../web",
     "@nx/webpack": "file:../webpack",
     "@nx/workspace": "file:../workspace"
   },

--- a/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -1,5 +1,10 @@
 import type { Schema } from './schema';
-import { logger, readCachedProjectGraph, workspaceRoot } from '@nx/devkit';
+import {
+  logger,
+  readCachedProjectGraph,
+  readNxJson,
+  workspaceRoot,
+} from '@nx/devkit';
 import { scheduleTarget } from 'nx/src/adapter/ngcli-adapter';
 import { executeWebpackDevServerBuilder } from '../webpack-dev-server/webpack-dev-server.impl';
 import { readProjectsConfigurationFromProjectGraph } from 'nx/src/project-graph/project-graph';
@@ -12,11 +17,22 @@ import {
 import { existsSync } from 'fs';
 import { extname, join } from 'path';
 import { findMatchingProjects } from 'nx/src/utils/find-matching-projects';
+import {
+  catchError,
+  combineLatest,
+  concatMap,
+  from,
+  iif,
+  Observable,
+  of,
+} from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { checkPortIsActive } from '@nx/js/src/utils/check-port-is-active';
 
 export function executeModuleFederationDevServerBuilder(
   schema: Schema,
   context: import('@angular-devkit/architect').BuilderContext
-): ReturnType<typeof executeWebpackDevServerBuilder> {
+): ReturnType<typeof executeWebpackDevServerBuilder | any> {
   const { ...options } = schema;
   const projectGraph = readCachedProjectGraph();
   const { projects: workspaceProjects } =
@@ -78,6 +94,7 @@ export function executeModuleFederationDevServerBuilder(
     ? findMatchingProjects(options.devRemotes, projectGraph.nodes)
     : findMatchingProjects([options.devRemotes], projectGraph.nodes);
 
+  const obs: Observable<any>[] = [];
   for (const remote of remotes) {
     const isDev = devServeRemotes.includes(remote);
     const target = isDev ? 'serve' : 'serve-static';
@@ -92,40 +109,104 @@ export function executeModuleFederationDevServerBuilder(
       );
     }
 
-    const runOptions: { verbose?: boolean } = {};
+    const runOptions: { verbose?: boolean; isInitialHost?: boolean } = {};
+    const [collection, executor] =
+      workspaceProjects[remote].targets[target].executor.split(':');
+    const { schema } = getExecutorInformation(
+      collection,
+      executor,
+      workspaceRoot
+    );
     if (options.verbose) {
-      const [collection, executor] =
-        workspaceProjects[remote].targets[target].executor.split(':');
-      const { schema } = getExecutorInformation(
-        collection,
-        executor,
-        workspaceRoot
-      );
-
       if (schema.additionalProperties || 'verbose' in schema.properties) {
         runOptions.verbose = options.verbose;
       }
     }
 
-    scheduleTarget(
-      context.workspaceRoot,
-      {
-        project: remote,
-        target,
-        configuration: context.target.configuration,
-        runOptions,
-      },
-      options.verbose
-    ).then((obs) => {
-      obs.toPromise().catch((err) => {
-        throw new Error(
-          `Remote '${remote}' failed to serve correctly due to the following: \r\n${err.toString()}`
-        );
-      });
-    });
+    if (executor === 'module-federation-dev-server') {
+      runOptions.isInitialHost = false;
+    }
+
+    const serveObs = from(
+      options.isInitialHost
+        ? Promise.resolve()
+        : checkPortIsActive({
+            port: workspaceProjects[remote].targets[target].options.port,
+            host:
+              workspaceProjects[remote].targets[target].options.host ??
+              'localhost',
+          })
+    ).pipe(
+      catchError((error) => of(false)),
+      switchMap((portIsActive) =>
+        from(
+          portIsActive
+            ? Promise.resolve()
+            : scheduleTarget(
+                context.workspaceRoot,
+                {
+                  project: remote,
+                  target,
+                  configuration: context.target.configuration,
+                  runOptions,
+                },
+                options.verbose
+              ).then((obs) => {
+                obs.toPromise().catch((err) => {
+                  throw new Error(
+                    `Remote '${remote}' failed to serve correctly due to the following: \r\n${err.toString()}`
+                  );
+                });
+              })
+        )
+      )
+    );
+
+    obs.push(serveObs);
   }
 
-  return executeWebpackDevServerBuilder(options, context);
+  const staticFileServer = from(
+    import('@nx/web/src/executors/file-server/file-server.impl')
+  ).pipe(
+    switchMap((fileServerExecutor) =>
+      fileServerExecutor.default(
+        {
+          port: options.port,
+          host: options.host,
+          ssl: options.ssl,
+          buildTarget: options.browserTarget,
+          parallel: false,
+          spa: false,
+          withDeps: false,
+          cors: true,
+        },
+        {
+          projectGraph,
+          root: context.workspaceRoot,
+          target:
+            projectGraph.nodes[context.target.project].data.targets[
+              context.target.target
+            ],
+          targetName: context.target.target,
+          projectName: context.target.project,
+          configurationName: context.target.configuration,
+          cwd: context.currentDirectory,
+          isVerbose: options.verbose,
+          projectsConfigurations:
+            readProjectsConfigurationFromProjectGraph(projectGraph),
+          nxJsonConfiguration: readNxJson(),
+        }
+      )
+    )
+  );
+
+  const webpackDevServer = executeWebpackDevServerBuilder(options, context);
+
+  return combineLatest([...obs]).pipe(
+    concatMap(() =>
+      iif(() => options.static, staticFileServer, webpackDevServer)
+    )
+  );
 }
 
 export default require('@angular-devkit/architect').createBuilder(

--- a/packages/angular/src/builders/module-federation-dev-server/schema.d.ts
+++ b/packages/angular/src/builders/module-federation-dev-server/schema.d.ts
@@ -20,4 +20,6 @@ export interface Schema {
   devRemotes?: string[];
   skipRemotes?: string[];
   pathToManifestFile?: string;
+  static?: boolean;
+  isInitialHost?: boolean;
 }

--- a/packages/angular/src/builders/module-federation-dev-server/schema.json
+++ b/packages/angular/src/builders/module-federation-dev-server/schema.json
@@ -122,6 +122,16 @@
     "pathToManifestFile": {
       "type": "string",
       "description": "Path to a Module Federation manifest file (e.g. `my/path/to/module-federation.manifest.json`) containing the dynamic remote applications relative to the workspace root."
+    },
+    "static": {
+      "type": "boolean",
+      "description": "Whether to use a static file server instead of the webpack-dev-server. This should be used for remote applications that are also host applications."
+    },
+    "isInitialHost": {
+      "type": "boolean",
+      "description": "Whether the host that is running this executor is the first in the project tree to do so.",
+      "default": false,
+      "x-priority": "internal"
     }
   },
   "additionalProperties": false,

--- a/packages/js/src/utils/check-port-is-active.ts
+++ b/packages/js/src/utils/check-port-is-active.ts
@@ -1,0 +1,55 @@
+import * as net from 'net';
+
+/**
+ * Check if a port is currently active.
+ * Retries and Retry Delay options are present for circumstances where a project may be built before the server is started.
+ * This is useful to prevent multiple builds and an incorrect port conflict check.
+ *
+ * NOTE: The difference between `checkPortIsActive` and `waitForPortOpen` is that the latter expects the port to eventually be opened
+ * and if it isn't, it will error.
+ * `checkPortIsActive` should have the opposite logic, it should return false if the port is not open, and true if it is.
+ * @param options
+ */
+export function checkPortIsActive(options: {
+  port: number;
+  host?: string;
+  retries?: number;
+  retryDelay?: number;
+}): Promise<boolean> {
+  const allowedErrorCodes = ['ECONNREFUSED', 'ECONNRESET'];
+
+  return new Promise((resolve, reject) => {
+    const checkPort = (retries = options.retries ?? 60) => {
+      const client = new net.Socket();
+      const cleanupClient = () => {
+        client.removeAllListeners('connect');
+        client.removeAllListeners('error');
+        client.end();
+        client.destroy();
+        client.unref();
+      };
+      client.once('connect', () => {
+        cleanupClient();
+        resolve(true);
+      });
+
+      client.once('error', (err) => {
+        if (retries === 0 && allowedErrorCodes.includes(err['code'])) {
+          cleanupClient();
+          resolve(false);
+        } else if (retries === 0 && !allowedErrorCodes.includes(err['code'])) {
+          cleanupClient();
+          reject(err);
+        } else {
+          setTimeout(() => checkPort(retries - 1), options.retryDelay ?? 1000);
+        }
+      });
+
+      // Node will use IPv6 if it is available, but this can cause issues if the server is only listening on IPv4.
+      // Hard-coding to look on 127.0.0.1 to avoid using the IPv6 loopback address "::1".
+      client.connect({ port: options.port, host: options.host ?? '127.0.0.1' });
+    };
+
+    checkPort();
+  });
+}

--- a/packages/react/src/executors/module-federation-dev-server/schema.json
+++ b/packages/react/src/executors/module-federation-dev-server/schema.json
@@ -91,6 +91,16 @@
     "baseHref": {
       "type": "string",
       "description": "Base url for the application being built."
+    },
+    "static": {
+      "type": "boolean",
+      "description": "Whether to use a static file server instead of the webpack-dev-server. This should be used for remote applications that are also host applications."
+    },
+    "isInitialHost": {
+      "type": "boolean",
+      "description": "Whether the host that is running this executor is the first in the project tree to do so.",
+      "default": false,
+      "x-priority": "internal"
     }
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We do not currently support serving remotes from remote applications that are also hosts automatically.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Add transitive serve support for remotes.

This means that if we have a host, that depends on `remoteA` and `remoteA` depends on `remoteB`, we will now also serve `remoteB` when we run `nx serve host`.

The code here is subject to change, especially when we merge parallelized startup of remotes support to Angular.

Another thing to note is that the `checkPortIsActive` _does_ introduce a slowdown to startup when we have remotes that are also hosts, as they are checking to see if their dependent remotes are already built and served.

I'm open to suggestions on how to reduce this slowdown.

cc @jaysoo

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
