### PR TITLE
fix(nextjs): do not warn on NX_INVOKED_BY_RUNNER and only show warning once

### DIFF
--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -18,6 +18,7 @@ const baseNXEnvironmentVariables = [
   'NX_PERF_LOGGING',
   'NX_PROFILE',
   'NX_PROJECT_GRAPH_CACHE_DIRECTORY',
+  'NX_INVOKED_BY_RUNNER', // This is from nx cloud runner
   'NX_PROJECT_GRAPH_MAX_WORKERS',
   'NX_RUNNER',
   'NX_SKIP_NX_CACHE',
@@ -408,6 +409,9 @@ function getNxEnvironmentVariables() {
       return env;
     }, {});
 }
+
+let hasWarnedAboutDeprecatedEnvVariables = false;
+
 /**
  * TODO(v18)
  * @deprecated Use Next.js 9.4+ built-in support for environment variables. Reference https://nextjs.org/docs/pages/api-reference/next-config-js/env
@@ -428,7 +432,8 @@ function addNxEnvVariables(config: any) {
       );
 
     const vars = getNonBaseVariables(env);
-    if (vars.length > 0) {
+    if (vars.length > 0 && !hasWarnedAboutDeprecatedEnvVariables) {
+      hasWarnedAboutDeprecatedEnvVariables = true;
       console.warn(
         `Warning, in Nx 18 environment variables starting with NX_ will not be available in the browser, and currently will not work with @nx/next:server executor.\nPlease rename the following environment variables: ${vars.join(
           ', '


### PR DESCRIPTION
We added a deprecation warning for environment variables prefixed with `NX_` (that are not set by Nx or Nx Cloud). Since Next.js apps run both in server and browser, any environment variables should only be used by the server (in RSC or API route), to prevent security leaks.

However, our warnings did not exclude `NX_INVOKED_BY_RUNNER`, which is set by the Nx Cloud runner. This is causing user confusion. We are also warning too many times, since Next.js build/serve can load webpack config up to three times (browser, server, edge).

This PR makes the warning go away unless user explicitly sets a custom `NX_` variable, thinking that it will be available for use in the browser. When the warning does show up, it will only show once.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
