### PR TITLE
docs(core): rename example repos menu item

### DIFF
--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -4252,7 +4252,7 @@
         "isExternal": false,
         "children": [
           {
-            "name": "Example Repos",
+            "name": "Nx with your favorite tech",
             "path": "/showcase/example-repos",
             "id": "example-repos",
             "isExternal": false,
@@ -4449,7 +4449,7 @@
         "disableCollapsible": false
       },
       {
-        "name": "Example Repos",
+        "name": "Nx with your favorite tech",
         "path": "/showcase/example-repos",
         "id": "example-repos",
         "isExternal": false,

--- a/docs/generated/manifests/nx.json
+++ b/docs/generated/manifests/nx.json
@@ -5303,8 +5303,8 @@
     "itemList": [
       {
         "id": "example-repos",
-        "name": "Example Repos",
-        "description": "Examples of different ways to use Nx",
+        "name": "Nx with your favorite tech",
+        "description": "Examples of different ways to use Nx with your favorite tech",
         "file": "",
         "itemList": [
           {
@@ -5550,8 +5550,8 @@
   },
   "/showcase/example-repos": {
     "id": "example-repos",
-    "name": "Example Repos",
-    "description": "Examples of different ways to use Nx",
+    "name": "Nx with your favorite tech",
+    "description": "Examples of different ways to use Nx with your favorite tech",
     "file": "",
     "itemList": [
       {

--- a/docs/map.json
+++ b/docs/map.json
@@ -1211,9 +1211,9 @@
           "description": "Discover our selection of examples and benchmarks.",
           "itemList": [
             {
-              "name": "Example Repos",
+              "name": "Nx with your favorite tech",
               "id": "example-repos",
-              "description": "Examples of different ways to use Nx",
+              "description": "Examples of different ways to use Nx with your favorite tech",
               "itemList": [
                 {
                   "name": "Add an Express Project",

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -204,7 +204,7 @@
     - [Other](/recipes/other)
       - [Rescope Packages from @nrwl to @nx](/recipes/other/rescope)
   - [Showcase](/showcase)
-    - [Example Repos](/showcase/example-repos)
+    - [Nx with your favorite tech](/showcase/example-repos)
       - [Add an Express Project](/showcase/example-repos/add-express)
       - [Add a Lit Project](/showcase/example-repos/add-lit)
       - [Add a Solid Project](/showcase/example-repos/add-solid)


### PR DESCRIPTION
Renames "Example Repos" menu to make it more inviting

![image](https://github.com/nrwl/nx/assets/542458/80e1d34c-af8c-4321-8046-f53809ebd0c0)
