### PR TITLE
feat(nx-dev): add link to AI Chat beta in docs header

### DIFF
--- a/nx-dev/feature-ai/src/lib/feed/feed-answer.tsx
+++ b/nx-dev/feature-ai/src/lib/feed/feed-answer.tsx
@@ -67,8 +67,8 @@ export function FeedAnswer({
         <div>
           <div className="text-lg flex gap-2 items-center text-slate-900 dark:text-slate-100">
             Nx Assistant{' '}
-            <span className="rounded-md bg-red-50 dark:bg-red-900/30 px-1.5 py-0.5 text-xs font-medium text-red-600 dark:text-red-400">
-              alpha
+            <span className="rounded-md bg-yellow-50 dark:bg-yellow-900/30 px-1.5 py-0.5 text-xs font-medium text-yellow-600 dark:text-yellow-400">
+              beta
             </span>
           </div>
           <p className="mt-0.5 flex items-center gap-x-1 text-sm text-slate-500">

--- a/nx-dev/nx-dev/pages/ai-chat/index.tsx
+++ b/nx-dev/nx-dev/pages/ai-chat/index.tsx
@@ -9,7 +9,7 @@ export default function AiDocs(): JSX.Element {
   return (
     <>
       <NextSeo
-        title="Nx AI Chat (Alpha)"
+        title="Nx AI Chat (Beta)"
         description="AI chat powered by Nx docs."
         noindex={true}
         robotsProps={{

--- a/nx-dev/ui-common/src/lib/documentation-header.tsx
+++ b/nx-dev/ui-common/src/lib/documentation-header.tsx
@@ -1,3 +1,4 @@
+import { type JSX } from 'react';
 import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
 import { AlgoliaSearch } from '@nx/nx-dev/feature-search';
 import { ThemeSwitcher } from '@nx/nx-dev/ui-theme';
@@ -22,7 +23,7 @@ function Menu({ tabs }: { tabs: any[] }): JSX.Element {
             )}
             aria-current={tab.current ? 'page' : undefined}
           >
-            {tab.name}
+            {tab.content ?? tab.name}
           </Link>
         ))}
       </nav>
@@ -44,8 +45,14 @@ export function DocumentationHeader({
   const isExtendingNx: boolean = routerPath.startsWith('/extending-nx');
   const isPlugins: boolean = routerPath.startsWith('/plugin-registry');
   const isChangelog: boolean = routerPath.startsWith('/changelog');
+  const isAiChat: boolean = router.asPath.startsWith('/ai-chat');
   const isNx: boolean =
-    !isNxCloud && !isAPI && !isExtendingNx && !isPlugins && !isChangelog;
+    !isNxCloud &&
+    !isAPI &&
+    !isExtendingNx &&
+    !isPlugins &&
+    !isChangelog &&
+    !isAiChat;
 
   const sections = [
     { name: 'Nx', href: '/getting-started/intro', current: isNx },
@@ -73,6 +80,19 @@ export function DocumentationHeader({
       name: 'Changelog',
       href: '/changelog',
       current: isChangelog,
+    },
+    {
+      name: 'AI Chat',
+      href: '/ai-chat',
+      current: isAiChat,
+      content: (
+        <>
+          <span>AI Chat</span>
+          <span className="ml-1 rounded-md bg-yellow-50 dark:bg-yellow-900/30 px-1.5 py-0.5 text-xs font-medium text-yellow-600 dark:text-yellow-400">
+            beta
+          </span>
+        </>
+      ),
     },
   ];
 


### PR DESCRIPTION
This PR sets AI Chat as public beta, and adds the link to docs header.

This should not be merged until Nx Conf.

<img width="1456" alt="Screenshot 2023-09-20 at 1 40 37 PM" src="https://github.com/nrwl/nx/assets/53559/89024fe5-87c3-4b56-a8cf-4586f6fe8700">
