### PR TITLE
fix(core): update the native runtime input to include the cpu architecture

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -52,7 +52,7 @@
       "{projectRoot}/**/*.rs",
       "{projectRoot}/**/Cargo.*",
       {
-        "runtime": "node -p 'process.platform'"
+        "runtime": "node -p '`${process.platform}_${process.arch}`'"
       }
     ]
   },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We currently have a runtime input for native builds that include the platform only. This case fails if trying to run on darwin x64, when a cache artifact was uploaded with darwin arm.

## Expected Behavior
The runtime input now includes the cpu architecture to make sure arm and x64 machines don't get the wrong cache. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
