### PR TITLE
fix(misc): adds nx cloud access token to agent workflow

### DIFF
--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -13,6 +13,7 @@ env:
   SELECTED_PM: 'pnpm'
   NX_E2E_RUN_E2E: 'true'
   NPM_CONFIG_PREFIX: '/home/workflows/.npm-global'
+  NX_CLOUD_ACCESS_TOKEN: '{{secrets.NX_CLOUD_ACCESS_TOKEN}}'
 steps:
   - name: Git Clone
     script: |


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We are currently seeing issues fetching cached task outputs when using Nx Cloud Workflows to run agents for DTE. This is due to the agents using the access token defined in nx.json.

## Expected Behavior
This PR updates the agent workflow to use a read-write token stored within the workspace environment variables in nx cloud.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
