### PR TITLE
feat(release): add 'git-tag' currentVersionResolver and conventional commits support

### DIFF
--- a/docs/generated/packages/js/generators/release-version.json
+++ b/docs/generated/packages/js/generators/release-version.json
@@ -20,7 +20,17 @@
       },
       "specifier": {
         "type": "string",
-        "description": "Exact version or semver keyword to apply to the selected release group. NOTE: This should be set on the release group level, not the project level."
+        "description": "Exact version or semver keyword to apply to the selected release group. Overrides specifierSource."
+      },
+      "releaseGroupName": {
+        "type": "string",
+        "description": "The name of the release group being versioned in the current execution."
+      },
+      "specifierSource": {
+        "type": "string",
+        "default": "prompt",
+        "description": "Which approach to use to determine the semver specifier used to bump the version of the project.",
+        "enum": ["prompt", "conventional-commits"]
       },
       "preid": {
         "type": "string",
@@ -34,7 +44,7 @@
         "type": "string",
         "default": "disk",
         "description": "Which approach to use to determine the current version of the project.",
-        "enum": ["registry", "disk"]
+        "enum": ["registry", "disk", "git-tag"]
       },
       "currentVersionResolverMetadata": {
         "type": "object",
@@ -42,7 +52,7 @@
         "default": {}
       }
     },
-    "required": ["projects", "projectGraph", "specifier"],
+    "required": ["projects", "projectGraph", "releaseGroupName"],
     "presets": []
   },
   "description": "DO NOT INVOKE DIRECTLY WITH `nx generate`. Use `nx release version` instead.",

--- a/docs/generated/packages/js/generators/release-version.json
+++ b/docs/generated/packages/js/generators/release-version.json
@@ -22,9 +22,9 @@
         "type": "string",
         "description": "Exact version or semver keyword to apply to the selected release group. Overrides specifierSource."
       },
-      "releaseGroupName": {
-        "type": "string",
-        "description": "The name of the release group being versioned in the current execution."
+      "releaseGroup": {
+        "type": "object",
+        "description": "The resolved release group configuration, including name, relevant to all projects in the current execution."
       },
       "specifierSource": {
         "type": "string",
@@ -52,7 +52,7 @@
         "default": {}
       }
     },
-    "required": ["projects", "projectGraph", "releaseGroupName"],
+    "required": ["projects", "projectGraph", "releaseGroup"],
     "presets": []
   },
   "description": "DO NOT INVOKE DIRECTLY WITH `nx generate`. Use `nx release version` instead.",

--- a/e2e/release/src/release.test.ts
+++ b/e2e/release/src/release.test.ts
@@ -9,6 +9,7 @@ import {
   runCLI,
   runCommandAsync,
   runCommandUntil,
+  tmpProjPath,
   uniq,
   updateJson,
 } from '@nx/e2e/utils';
@@ -639,5 +640,152 @@ describe('nx release', () => {
 
     // port and process cleanup
     await killProcessAndPorts(process.pid, verdaccioPort);
+
+    // Add custom nx release config to control version resolution
+    updateJson<NxJsonConfiguration>('nx.json', (nxJson) => {
+      nxJson.release = {
+        groups: {
+          default: {
+            // @proj/source will be added as a project by the verdaccio setup, but we aren't versioning or publishing it, so we exclude it here
+            projects: ['*', '!@proj/source'],
+            version: {
+              generator: '@nx/js:release-version',
+              generatorOptions: {
+                // Resolve the latest version from the git tag
+                currentVersionResolver: 'git-tag',
+                currentVersionResolverMetadata: {
+                  tagVersionPrefix: 'xx',
+                },
+              },
+            },
+          },
+        },
+      };
+      return nxJson;
+    });
+
+    // Add a git tag to the repo
+    execSync(`git tag -a xx1100.0.0 -m xx1100.0.0`, {
+      cwd: tmpProjPath(),
+    });
+
+    const versionOutput3 = runCLI(`release version minor`);
+    expect(
+      versionOutput3.match(/Running release version for project: my-pkg-\d*/g)
+        .length
+    ).toEqual(3);
+    expect(
+      versionOutput3.match(
+        /Reading data for package "@proj\/my-pkg-\d*" from my-pkg-\d*\/package.json/g
+      ).length
+    ).toEqual(3);
+
+    // It should resolve the current version from the git tag once...
+    expect(
+      versionOutput3.match(
+        new RegExp(
+          `Resolved the current version as 1100.0.0 from git tag "xx1100.0.0"`,
+          'g'
+        )
+      ).length
+    ).toEqual(1);
+    // ...and then reuse it twice
+    expect(
+      versionOutput3.match(
+        new RegExp(
+          `Using the current version 1100.0.0 already resolved from git tag "xx1100.0.0"`,
+          'g'
+        )
+      ).length
+    ).toEqual(2);
+
+    expect(
+      versionOutput3.match(
+        /New version 1100.1.0 written to my-pkg-\d*\/package.json/g
+      ).length
+    ).toEqual(3);
+
+    // Only one dependency relationship exists, so this log should only match once
+    expect(
+      versionOutput3.match(
+        /Applying new version 1100.1.0 to 1 package which depends on my-pkg-\d*/g
+      ).length
+    ).toEqual(1);
+
+    createFile(
+      `${pkg1}/my-file.txt`,
+      'update for conventional-commits testing'
+    );
+
+    // Add custom nx release config to control version resolution
+    updateJson<NxJsonConfiguration>('nx.json', (nxJson) => {
+      nxJson.release = {
+        groups: {
+          default: {
+            // @proj/source will be added as a project by the verdaccio setup, but we aren't versioning or publishing it, so we exclude it here
+            projects: ['*', '!@proj/source'],
+            version: {
+              generator: '@nx/js:release-version',
+              generatorOptions: {
+                specifierSource: 'conventional-commits',
+                currentVersionResolver: 'git-tag',
+                currentVersionResolverMetadata: {
+                  tagVersionPrefix: 'xx',
+                },
+              },
+            },
+          },
+        },
+      };
+      return nxJson;
+    });
+
+    const versionOutput4 = runCLI(`release version`);
+
+    expect(
+      versionOutput4.match(/Running release version for project: my-pkg-\d*/g)
+        .length
+    ).toEqual(3);
+    expect(
+      versionOutput4.match(
+        /Reading data for package "@proj\/my-pkg-\d*" from my-pkg-\d*\/package.json/g
+      ).length
+    ).toEqual(3);
+
+    // It should resolve the current version from the git tag once...
+    expect(
+      versionOutput4.match(
+        new RegExp(
+          `Resolved the current version as 1100.0.0 from git tag "xx1100.0.0"`,
+          'g'
+        )
+      ).length
+    ).toEqual(1);
+    // ...and then reuse it twice
+    expect(
+      versionOutput4.match(
+        new RegExp(
+          `Using the current version 1100.0.0 already resolved from git tag "xx1100.0.0"`,
+          'g'
+        )
+      ).length
+    ).toEqual(2);
+
+    expect(versionOutput4.match(/Skipping versioning/g).length).toEqual(3);
+
+    execSync(
+      `git add ${pkg1}/my-file.txt && git commit -m "feat!: add new file"`,
+      {
+        cwd: tmpProjPath(),
+      }
+    );
+
+    const versionOutput5 = runCLI(`release version`);
+
+    expect(
+      versionOutput5.match(
+        /New version 1101.0.0 written to my-pkg-\d*\/package.json/g
+      ).length
+    ).toEqual(3);
   }, 500000);
 });

--- a/e2e/release/src/release.test.ts
+++ b/e2e/release/src/release.test.ts
@@ -9,7 +9,6 @@ import {
   runCLI,
   runCommandAsync,
   runCommandUntil,
-  tmpProjPath,
   uniq,
   updateJson,
 } from '@nx/e2e/utils';
@@ -663,9 +662,7 @@ describe('nx release', () => {
     });
 
     // Add a git tag to the repo
-    execSync(`git tag -a xx1100.0.0 -m xx1100.0.0`, {
-      cwd: tmpProjPath(),
-    });
+    await runCommandAsync(`git tag xx1100.0.0`);
 
     const versionOutput3 = runCLI(`release version minor`);
     expect(
@@ -769,11 +766,8 @@ describe('nx release', () => {
 
     expect(versionOutput4.match(/Skipping versioning/g).length).toEqual(3);
 
-    execSync(
-      `git add ${pkg1}/my-file.txt && git commit -m "feat!: add new file"`,
-      {
-        cwd: tmpProjPath(),
-      }
+    await runCommandAsync(
+      `git add ${pkg1}/my-file.txt && git commit -m "feat!: add new file"`
     );
 
     const versionOutput5 = runCLI(`release version`);

--- a/e2e/release/src/release.test.ts
+++ b/e2e/release/src/release.test.ts
@@ -648,14 +648,12 @@ describe('nx release', () => {
           default: {
             // @proj/source will be added as a project by the verdaccio setup, but we aren't versioning or publishing it, so we exclude it here
             projects: ['*', '!@proj/source'],
+            releaseTagPattern: 'xx{version}',
             version: {
               generator: '@nx/js:release-version',
               generatorOptions: {
                 // Resolve the latest version from the git tag
                 currentVersionResolver: 'git-tag',
-                currentVersionResolverMetadata: {
-                  tagVersionPrefix: 'xx',
-                },
               },
             },
           },
@@ -724,14 +722,12 @@ describe('nx release', () => {
           default: {
             // @proj/source will be added as a project by the verdaccio setup, but we aren't versioning or publishing it, so we exclude it here
             projects: ['*', '!@proj/source'],
+            releaseTagPattern: 'xx{version}',
             version: {
               generator: '@nx/js:release-version',
               generatorOptions: {
                 specifierSource: 'conventional-commits',
                 currentVersionResolver: 'git-tag',
-                currentVersionResolverMetadata: {
-                  tagVersionPrefix: 'xx',
-                },
               },
             },
           },

--- a/packages/js/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.ts
@@ -33,13 +33,13 @@ export default async function runExecutor(
 
   const packageJsonPath = joinPathFragments(packageRoot, 'package.json');
   const projectPackageJson = readJsonFile(packageJsonPath);
-  const name = projectPackageJson.name;
+  const packageName = projectPackageJson.name;
 
   // If package and project name match, we can make log messages terser
   let packageTxt =
-    name === context.projectName
-      ? `package "${name}"`
-      : `package "${name}" from project "${context.projectName}"`;
+    packageName === context.projectName
+      ? `package "${packageName}"`
+      : `package "${packageName}" from project "${context.projectName}"`;
 
   if (projectPackageJson.private === true) {
     console.warn(
@@ -80,7 +80,7 @@ export default async function runExecutor(
     const stdoutData = JSON.parse(output.toString());
 
     // If npm workspaces are in use, the publish output will nest the data under the package name, so we normalize it first
-    const normalizedStdoutData = stdoutData[context.projectName!] ?? stdoutData;
+    const normalizedStdoutData = stdoutData[packageName] ?? stdoutData;
     logTar(normalizedStdoutData);
 
     if (options.dryRun) {

--- a/packages/js/src/generators/release-version/release-version.spec.ts
+++ b/packages/js/src/generators/release-version/release-version.spec.ts
@@ -58,6 +58,7 @@ describe('release-version', () => {
       projectGraph,
       specifier: 'major',
       currentVersionResolver: 'disk',
+      releaseGroupName: 'default',
     });
     expect(readJson(tree, 'libs/my-lib/package.json').version).toEqual('1.0.0');
 
@@ -66,6 +67,7 @@ describe('release-version', () => {
       projectGraph,
       specifier: 'minor',
       currentVersionResolver: 'disk',
+      releaseGroupName: 'default',
     });
     expect(readJson(tree, 'libs/my-lib/package.json').version).toEqual('1.1.0');
 
@@ -74,6 +76,7 @@ describe('release-version', () => {
       projectGraph,
       specifier: 'patch',
       currentVersionResolver: 'disk',
+      releaseGroupName: 'default',
     });
     expect(readJson(tree, 'libs/my-lib/package.json').version).toEqual('1.1.1');
 
@@ -82,6 +85,7 @@ describe('release-version', () => {
       projectGraph,
       specifier: '1.2.3', // exact version
       currentVersionResolver: 'disk',
+      releaseGroupName: 'default',
     });
     expect(readJson(tree, 'libs/my-lib/package.json').version).toEqual('1.2.3');
   });
@@ -92,6 +96,7 @@ describe('release-version', () => {
       projectGraph,
       specifier: 'major',
       currentVersionResolver: 'disk',
+      releaseGroupName: 'default',
     });
 
     expect(readJson(tree, 'libs/my-lib/package.json')).toMatchInlineSnapshot(`
@@ -137,6 +142,7 @@ describe('release-version', () => {
           projectGraph,
           specifier: 'major',
           currentVersionResolver: 'disk',
+          releaseGroupName: 'default',
         })
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
         "The project "my-lib" does not have a package.json available at libs/my-lib/package.json.

--- a/packages/js/src/generators/release-version/release-version.spec.ts
+++ b/packages/js/src/generators/release-version/release-version.spec.ts
@@ -1,5 +1,6 @@
 import { ProjectGraph, Tree, readJson } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { ReleaseGroupWithName } from 'nx/src/command-line/release/config/filter-release-groups';
 import { releaseVersionGenerator } from './release-version';
 import { createWorkspaceWithPackageDependencies } from './test-utils/create-workspace-with-package-dependencies';
 
@@ -58,7 +59,7 @@ describe('release-version', () => {
       projectGraph,
       specifier: 'major',
       currentVersionResolver: 'disk',
-      releaseGroupName: 'default',
+      releaseGroup: createReleaseGroup(),
     });
     expect(readJson(tree, 'libs/my-lib/package.json').version).toEqual('1.0.0');
 
@@ -67,7 +68,7 @@ describe('release-version', () => {
       projectGraph,
       specifier: 'minor',
       currentVersionResolver: 'disk',
-      releaseGroupName: 'default',
+      releaseGroup: createReleaseGroup(),
     });
     expect(readJson(tree, 'libs/my-lib/package.json').version).toEqual('1.1.0');
 
@@ -76,7 +77,7 @@ describe('release-version', () => {
       projectGraph,
       specifier: 'patch',
       currentVersionResolver: 'disk',
-      releaseGroupName: 'default',
+      releaseGroup: createReleaseGroup(),
     });
     expect(readJson(tree, 'libs/my-lib/package.json').version).toEqual('1.1.1');
 
@@ -85,7 +86,7 @@ describe('release-version', () => {
       projectGraph,
       specifier: '1.2.3', // exact version
       currentVersionResolver: 'disk',
-      releaseGroupName: 'default',
+      releaseGroup: createReleaseGroup(),
     });
     expect(readJson(tree, 'libs/my-lib/package.json').version).toEqual('1.2.3');
   });
@@ -96,7 +97,7 @@ describe('release-version', () => {
       projectGraph,
       specifier: 'major',
       currentVersionResolver: 'disk',
-      releaseGroupName: 'default',
+      releaseGroup: createReleaseGroup(),
     });
 
     expect(readJson(tree, 'libs/my-lib/package.json')).toMatchInlineSnapshot(`
@@ -142,7 +143,7 @@ describe('release-version', () => {
           projectGraph,
           specifier: 'major',
           currentVersionResolver: 'disk',
-          releaseGroupName: 'default',
+          releaseGroup: createReleaseGroup(),
         })
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
         "The project "my-lib" does not have a package.json available at libs/my-lib/package.json.
@@ -152,3 +153,13 @@ describe('release-version', () => {
     });
   });
 });
+
+function createReleaseGroup(
+  partialGroup: Partial<ReleaseGroupWithName> = {}
+): ReleaseGroupWithName {
+  return {
+    name: 'default',
+    releaseTagPattern: '{projectName}@v{version}',
+    ...partialGroup,
+  } as ReleaseGroupWithName;
+}

--- a/packages/js/src/generators/release-version/release-version.ts
+++ b/packages/js/src/generators/release-version/release-version.ts
@@ -184,6 +184,10 @@ To fix this you will either need to add a package.json file at that location, or
         );
     }
 
+    if (options.specifier) {
+      log(`📄 Using the provided version specifier "${options.specifier}".`);
+    }
+
     // if specifier is null, then we determined previously via conventional commits that no changes are necessary
     if (specifier === undefined) {
       const specifierSource = options.specifierSource;
@@ -195,6 +199,19 @@ To fix this you will either need to add a package.json file at that location, or
             );
           }
 
+          specifier = await resolveSemverSpecifierFromConventionalCommits(
+            latestMatchingGitTag.tag,
+            options.projectGraph,
+            projects.map((p) => p.name)
+          );
+
+          if (!specifier) {
+            log(
+              `🚫 No changes were detected using git history and the conventional commits standard.`
+            );
+            break;
+          }
+
           // Always assume that if the current version is a prerelease, then the next version should be a prerelease.
           // Users must manually graduate from a prerelease to a release by providing an explicit specifier.
           if (prerelease(currentVersion)) {
@@ -202,22 +219,9 @@ To fix this you will either need to add a package.json file at that location, or
             log(
               `📄 Resolved the specifier as "${specifier}" since the current version is a prerelease.`
             );
-            break;
-          }
-
-          specifier = await resolveSemverSpecifierFromConventionalCommits(
-            latestMatchingGitTag.tag,
-            options.projectGraph,
-            projects.map((p) => p.name)
-          );
-
-          if (specifier) {
-            log(
-              `📄 Resolved the specifier as "${specifier}" using git history and the conventional commits standard.`
-            );
           } else {
             log(
-              `🚫 No changes were detected using git history and the conventional commits standard.`
+              `📄 Resolved the specifier as "${specifier}" using git history and the conventional commits standard.`
             );
           }
           break;

--- a/packages/js/src/generators/release-version/release-version.ts
+++ b/packages/js/src/generators/release-version/release-version.ts
@@ -80,7 +80,7 @@ export async function releaseVersionGenerator(
       if (!tree.exists(packageJsonPath)) {
         throw new Error(
           `The project "${projectName}" does not have a package.json available at ${workspaceRelativePackageJsonPath}.
-        
+
 To fix this you will either need to add a package.json file at that location, or configure "release" within your nx.json to exclude "${projectName}" from the current release group, or amend the packageRoot configuration to point to where the package.json should be.`
         );
       }

--- a/packages/js/src/generators/release-version/release-version.ts
+++ b/packages/js/src/generators/release-version/release-version.ts
@@ -27,281 +27,297 @@ export async function releaseVersionGenerator(
   tree: Tree,
   options: ReleaseVersionGeneratorSchema
 ) {
-  // If the user provided a specifier, validate it
-  if (options.specifier && !isValidSemverSpecifier(options.specifier)) {
-    throw new Error(
-      `The given version specifier "${options.specifier}" is not valid. You provide an exact version or a valid semver keyword such as "major", "minor", "patch", etc.`
-    );
-  }
-
-  const projects = options.projects;
-
-  // Resolve any custom package roots for each project upfront as they will need to be reused during dependency resolution
-  const projectNameToPackageRootMap = new Map<string, string>();
-  for (const project of projects) {
-    projectNameToPackageRootMap.set(
-      project.name,
-      // Default to the project root if no custom packageRoot
-      !options.packageRoot
-        ? project.data.root
-        : interpolate(options.packageRoot, {
-            workspaceRoot: '',
-            projectRoot: project.data.root,
-            projectName: project.name,
-          })
-    );
-  }
-
-  let currentVersion: string;
-
-  // only used for options.currentVersionResolver === 'git-tag', but
-  // must be declared here in order to reuse it for additional projects
-  let latestMatchingGitTag: { tag: string; extractedVersion: string };
-
-  // if specifier is undefined, then we haven't resolved it yet
-  // if specifier is null, then it has been resolved and no changes are necessary
-  let specifier = options.specifier ? options.specifier : undefined;
-
-  for (const project of projects) {
-    const projectName = project.name;
-    const packageRoot = projectNameToPackageRootMap.get(projectName);
-    const packageJsonPath = joinPathFragments(packageRoot, 'package.json');
-    const workspaceRelativePackageJsonPath = relative(
-      workspaceRoot,
-      packageJsonPath
-    );
-
-    const color = getColor(projectName);
-    const log = (msg: string) => {
-      console.log(color.instance.bold(projectName) + ' ' + msg);
-    };
-
-    if (!tree.exists(packageJsonPath)) {
+  try {
+    // If the user provided a specifier, validate that it is valid semver or a relative semver keyword
+    if (options.specifier && !isValidSemverSpecifier(options.specifier)) {
       throw new Error(
-        `The project "${projectName}" does not have a package.json available at ${workspaceRelativePackageJsonPath}.
-        
-To fix this you will either need to add a package.json file at that location, or configure "release" within your nx.json to exclude "${projectName}" from the current release group, or amend the packageRoot configuration to point to where the package.json should be.`
+        `The given version specifier "${options.specifier}" is not valid. You provide an exact version or a valid semver keyword such as "major", "minor", "patch", etc.`
       );
     }
 
-    output.logSingleLine(
-      `Running release version for project: ${color.instance.bold(
-        project.name
-      )}`
-    );
+    const projects = options.projects;
 
-    const projectPackageJson = readJson(tree, packageJsonPath);
-    log(
-      `🔍 Reading data for package "${projectPackageJson.name}" from ${workspaceRelativePackageJsonPath}`
-    );
-
-    const { name: packageName, version: currentVersionFromDisk } =
-      projectPackageJson;
-
-    switch (options.currentVersionResolver) {
-      case 'registry': {
-        const metadata = options.currentVersionResolverMetadata;
-        const registry =
-          metadata?.registry ??
-          (await getNpmRegistry()) ??
-          'https://registry.npmjs.org';
-        const tag = metadata?.tag ?? 'latest';
-
-        // If the currentVersionResolver is set to registry, we only want to make the request once for the whole batch of projects
-        if (!currentVersion) {
-          const spinner = ora(
-            `${Array.from(new Array(projectName.length + 3)).join(
-              ' '
-            )}Resolving the current version for tag "${tag}" on ${registry}`
-          );
-          spinner.color =
-            color.spinnerColor as typeof colors[number]['spinnerColor'];
-          spinner.start();
-
-          // Must be non-blocking async to allow spinner to render
-          currentVersion = await new Promise<string>((resolve, reject) => {
-            exec(
-              `npm view ${packageName} version --registry=${registry} --tag=${tag}`,
-              (error, stdout, stderr) => {
-                if (error) {
-                  return reject(error);
-                }
-                if (stderr) {
-                  return reject(stderr);
-                }
-                return resolve(stdout.trim());
-              }
-            );
-          });
-
-          spinner.stop();
-
-          log(
-            `📄 Resolved the current version as ${currentVersion} for tag "${tag}" from registry ${registry}`
-          );
-        } else {
-          log(
-            `📄 Using the current version ${currentVersion} already resolved from the registry ${registry}`
-          );
-        }
-        break;
-      }
-      case 'disk':
-        currentVersion = currentVersionFromDisk;
-        log(
-          `📄 Resolved the current version as ${currentVersion} from ${packageJsonPath}`
-        );
-        break;
-      case 'git-tag': {
-        if (!currentVersion) {
-          const releaseTagPattern = options.releaseGroup.releaseTagPattern;
-          latestMatchingGitTag = await getLatestGitTagForPattern(
-            releaseTagPattern,
-            {
+    // Resolve any custom package roots for each project upfront as they will need to be reused during dependency resolution
+    const projectNameToPackageRootMap = new Map<string, string>();
+    for (const project of projects) {
+      projectNameToPackageRootMap.set(
+        project.name,
+        // Default to the project root if no custom packageRoot
+        !options.packageRoot
+          ? project.data.root
+          : interpolate(options.packageRoot, {
+              workspaceRoot: '',
+              projectRoot: project.data.root,
               projectName: project.name,
-            }
-          );
-          if (!latestMatchingGitTag) {
-            throw new Error(
-              `No git tags matching pattern "${releaseTagPattern}" for project "${project.name}" were found.`
-            );
-          }
+            })
+      );
+    }
 
-          currentVersion = latestMatchingGitTag.extractedVersion;
-          log(
-            `📄 Resolved the current version as ${currentVersion} from git tag "${latestMatchingGitTag.tag}".`
-          );
-        } else {
-          log(
-            `📄 Using the current version ${currentVersion} already resolved from git tag "${latestMatchingGitTag.tag}".`
-          );
-        }
-        break;
-      }
-      default:
+    let currentVersion: string;
+
+    // only used for options.currentVersionResolver === 'git-tag', but
+    // must be declared here in order to reuse it for additional projects
+    let latestMatchingGitTag: { tag: string; extractedVersion: string };
+
+    // if specifier is undefined, then we haven't resolved it yet
+    // if specifier is null, then it has been resolved and no changes are necessary
+    let specifier = options.specifier ? options.specifier : undefined;
+
+    for (const project of projects) {
+      const projectName = project.name;
+      const packageRoot = projectNameToPackageRootMap.get(projectName);
+      const packageJsonPath = joinPathFragments(packageRoot, 'package.json');
+      const workspaceRelativePackageJsonPath = relative(
+        workspaceRoot,
+        packageJsonPath
+      );
+
+      const color = getColor(projectName);
+      const log = (msg: string) => {
+        console.log(color.instance.bold(projectName) + ' ' + msg);
+      };
+
+      if (!tree.exists(packageJsonPath)) {
         throw new Error(
-          `Invalid value for options.currentVersionResolver: ${options.currentVersionResolver}`
+          `The project "${projectName}" does not have a package.json available at ${workspaceRelativePackageJsonPath}.
+        
+To fix this you will either need to add a package.json file at that location, or configure "release" within your nx.json to exclude "${projectName}" from the current release group, or amend the packageRoot configuration to point to where the package.json should be.`
         );
-    }
+      }
 
-    if (options.specifier) {
-      log(`📄 Using the provided version specifier "${options.specifier}".`);
-    }
+      output.logSingleLine(
+        `Running release version for project: ${color.instance.bold(
+          project.name
+        )}`
+      );
 
-    // if specifier is null, then we determined previously via conventional commits that no changes are necessary
-    if (specifier === undefined) {
-      const specifierSource = options.specifierSource;
-      switch (specifierSource) {
-        case 'conventional-commits':
-          if (options.currentVersionResolver !== 'git-tag') {
-            throw new Error(
-              `Invalid currentVersionResolver "${options.currentVersionResolver}" provided for release group "${options.releaseGroup.name}". Must be "git-tag" when "specifierSource" is "conventional-commits"`
+      const projectPackageJson = readJson(tree, packageJsonPath);
+      log(
+        `🔍 Reading data for package "${projectPackageJson.name}" from ${workspaceRelativePackageJsonPath}`
+      );
+
+      const { name: packageName, version: currentVersionFromDisk } =
+        projectPackageJson;
+
+      switch (options.currentVersionResolver) {
+        case 'registry': {
+          const metadata = options.currentVersionResolverMetadata;
+          const registry =
+            metadata?.registry ??
+            (await getNpmRegistry()) ??
+            'https://registry.npmjs.org';
+          const tag = metadata?.tag ?? 'latest';
+
+          // If the currentVersionResolver is set to registry, we only want to make the request once for the whole batch of projects
+          if (!currentVersion) {
+            const spinner = ora(
+              `${Array.from(new Array(projectName.length + 3)).join(
+                ' '
+              )}Resolving the current version for tag "${tag}" on ${registry}`
             );
-          }
+            spinner.color =
+              color.spinnerColor as typeof colors[number]['spinnerColor'];
+            spinner.start();
 
-          specifier = await resolveSemverSpecifierFromConventionalCommits(
-            latestMatchingGitTag.tag,
-            options.projectGraph,
-            projects.map((p) => p.name)
-          );
+            // Must be non-blocking async to allow spinner to render
+            currentVersion = await new Promise<string>((resolve, reject) => {
+              exec(
+                `npm view ${packageName} version --registry=${registry} --tag=${tag}`,
+                (error, stdout, stderr) => {
+                  if (error) {
+                    return reject(error);
+                  }
+                  if (stderr) {
+                    return reject(stderr);
+                  }
+                  return resolve(stdout.trim());
+                }
+              );
+            });
 
-          if (!specifier) {
+            spinner.stop();
+
             log(
-              `🚫 No changes were detected using git history and the conventional commits standard.`
-            );
-            break;
-          }
-
-          // Always assume that if the current version is a prerelease, then the next version should be a prerelease.
-          // Users must manually graduate from a prerelease to a release by providing an explicit specifier.
-          if (prerelease(currentVersion)) {
-            specifier = 'prerelease';
-            log(
-              `📄 Resolved the specifier as "${specifier}" since the current version is a prerelease.`
+              `📄 Resolved the current version as ${currentVersion} for tag "${tag}" from registry ${registry}`
             );
           } else {
             log(
-              `📄 Resolved the specifier as "${specifier}" using git history and the conventional commits standard.`
+              `📄 Using the current version ${currentVersion} already resolved from the registry ${registry}`
             );
           }
           break;
-        case 'prompt':
-          specifier = await resolveSemverSpecifierFromPrompt(
-            `What kind of change is this for the ${projects.length} matched projects(s) within release group "${options.releaseGroup.name}"?`,
-            `What is the exact version for the ${projects.length} matched project(s) within release group "${options.releaseGroup.name}"?`
+        }
+        case 'disk':
+          currentVersion = currentVersionFromDisk;
+          log(
+            `📄 Resolved the current version as ${currentVersion} from ${packageJsonPath}`
           );
           break;
+        case 'git-tag': {
+          if (!currentVersion) {
+            const releaseTagPattern = options.releaseGroup.releaseTagPattern;
+            latestMatchingGitTag = await getLatestGitTagForPattern(
+              releaseTagPattern,
+              {
+                projectName: project.name,
+              }
+            );
+            if (!latestMatchingGitTag) {
+              throw new Error(
+                `No git tags matching pattern "${releaseTagPattern}" for project "${project.name}" were found.`
+              );
+            }
+
+            currentVersion = latestMatchingGitTag.extractedVersion;
+            log(
+              `📄 Resolved the current version as ${currentVersion} from git tag "${latestMatchingGitTag.tag}".`
+            );
+          } else {
+            log(
+              `📄 Using the current version ${currentVersion} already resolved from git tag "${latestMatchingGitTag.tag}".`
+            );
+          }
+          break;
+        }
         default:
           throw new Error(
-            `Invalid specifierSource "${specifierSource}" provided. Must be one of "prompt" or "conventional-commits"`
+            `Invalid value for options.currentVersionResolver: ${options.currentVersionResolver}`
           );
       }
-    }
 
-    if (!specifier) {
-      log(
-        `🚫 Skipping versioning "${projectPackageJson.name}" as no changes were detected.`
-      );
-      continue;
-    }
+      if (options.specifier) {
+        log(`📄 Using the provided version specifier "${options.specifier}".`);
+      }
 
-    // Resolve any local package dependencies for this project (before applying the new version)
-    const localPackageDependencies = resolveLocalPackageDependencies(
-      tree,
-      options.projectGraph,
-      projects,
-      projectNameToPackageRootMap
-    );
+      // if specifier is null, then we determined previously via conventional commits that no changes are necessary
+      if (specifier === undefined) {
+        const specifierSource = options.specifierSource;
+        switch (specifierSource) {
+          case 'conventional-commits':
+            if (options.currentVersionResolver !== 'git-tag') {
+              throw new Error(
+                `Invalid currentVersionResolver "${options.currentVersionResolver}" provided for release group "${options.releaseGroup.name}". Must be "git-tag" when "specifierSource" is "conventional-commits"`
+              );
+            }
 
-    const newVersion = deriveNewSemverVersion(
-      currentVersion,
-      specifier,
-      options.preid
-    );
+            specifier = await resolveSemverSpecifierFromConventionalCommits(
+              latestMatchingGitTag.tag,
+              options.projectGraph,
+              projects.map((p) => p.name)
+            );
 
-    writeJson(tree, packageJsonPath, {
-      ...projectPackageJson,
-      version: newVersion,
-    });
+            if (!specifier) {
+              log(
+                `🚫 No changes were detected using git history and the conventional commits standard.`
+              );
+              break;
+            }
 
-    log(
-      `✍️  New version ${newVersion} written to ${workspaceRelativePackageJsonPath}`
-    );
-
-    const dependentProjects = Object.values(localPackageDependencies)
-      .filter((localPackageDependencies) => {
-        return localPackageDependencies.some(
-          (localPackageDependency) =>
-            localPackageDependency.target === project.name
-        );
-      })
-      .flat();
-
-    if (dependentProjects.length > 0) {
-      log(
-        `✍️  Applying new version ${newVersion} to ${
-          dependentProjects.length
-        } ${
-          dependentProjects.length > 1
-            ? 'packages which depend'
-            : 'package which depends'
-        } on ${project.name}`
-      );
-    }
-
-    for (const dependentProject of dependentProjects) {
-      updateJson(
-        tree,
-        joinPathFragments(
-          projectNameToPackageRootMap.get(dependentProject.source),
-          'package.json'
-        ),
-        (json) => {
-          json[dependentProject.dependencyCollection][packageName] = newVersion;
-          return json;
+            // Always assume that if the current version is a prerelease, then the next version should be a prerelease.
+            // Users must manually graduate from a prerelease to a release by providing an explicit specifier.
+            if (prerelease(currentVersion)) {
+              specifier = 'prerelease';
+              log(
+                `📄 Resolved the specifier as "${specifier}" since the current version is a prerelease.`
+              );
+            } else {
+              log(
+                `📄 Resolved the specifier as "${specifier}" using git history and the conventional commits standard.`
+              );
+            }
+            break;
+          case 'prompt':
+            specifier = await resolveSemverSpecifierFromPrompt(
+              `What kind of change is this for the ${projects.length} matched projects(s) within release group "${options.releaseGroup.name}"?`,
+              `What is the exact version for the ${projects.length} matched project(s) within release group "${options.releaseGroup.name}"?`
+            );
+            break;
+          default:
+            throw new Error(
+              `Invalid specifierSource "${specifierSource}" provided. Must be one of "prompt" or "conventional-commits"`
+            );
         }
+      }
+
+      if (!specifier) {
+        log(
+          `🚫 Skipping versioning "${projectPackageJson.name}" as no changes were detected.`
+        );
+        continue;
+      }
+
+      // Resolve any local package dependencies for this project (before applying the new version)
+      const localPackageDependencies = resolveLocalPackageDependencies(
+        tree,
+        options.projectGraph,
+        projects,
+        projectNameToPackageRootMap
       );
+
+      const newVersion = deriveNewSemverVersion(
+        currentVersion,
+        specifier,
+        options.preid
+      );
+
+      writeJson(tree, packageJsonPath, {
+        ...projectPackageJson,
+        version: newVersion,
+      });
+
+      log(
+        `✍️  New version ${newVersion} written to ${workspaceRelativePackageJsonPath}`
+      );
+
+      const dependentProjects = Object.values(localPackageDependencies)
+        .filter((localPackageDependencies) => {
+          return localPackageDependencies.some(
+            (localPackageDependency) =>
+              localPackageDependency.target === project.name
+          );
+        })
+        .flat();
+
+      if (dependentProjects.length > 0) {
+        log(
+          `✍️  Applying new version ${newVersion} to ${
+            dependentProjects.length
+          } ${
+            dependentProjects.length > 1
+              ? 'packages which depend'
+              : 'package which depends'
+          } on ${project.name}`
+        );
+      }
+
+      for (const dependentProject of dependentProjects) {
+        updateJson(
+          tree,
+          joinPathFragments(
+            projectNameToPackageRootMap.get(dependentProject.source),
+            'package.json'
+          ),
+          (json) => {
+            json[dependentProject.dependencyCollection][packageName] =
+              newVersion;
+            return json;
+          }
+        );
+      }
     }
+  } catch (e) {
+    if (process.env.NX_VERBOSE_LOGGING === 'true') {
+      output.error({
+        title: e.message,
+      });
+      // Dump the full stack trace in verbose mode
+      console.error(e);
+    } else {
+      output.error({
+        title: e.message,
+      });
+    }
+    process.exit(1);
   }
 }
 

--- a/packages/js/src/generators/release-version/release-version.ts
+++ b/packages/js/src/generators/release-version/release-version.ts
@@ -211,9 +211,15 @@ To fix this you will either need to add a package.json file at that location, or
             projects.map((p) => p.name)
           );
 
-          log(
-            `📄 Resolved the specifier as "${specifier}" using git history and the conventional commits standard.`
-          );
+          if (specifier) {
+            log(
+              `📄 Resolved the specifier as "${specifier}" using git history and the conventional commits standard.`
+            );
+          } else {
+            log(
+              `🚫 No changes were detected using git history and the conventional commits standard.`
+            );
+          }
           break;
         case 'prompt':
           specifier = await resolveSemverSpecifierFromPrompt(

--- a/packages/js/src/generators/release-version/schema.json
+++ b/packages/js/src/generators/release-version/schema.json
@@ -19,7 +19,17 @@
     },
     "specifier": {
       "type": "string",
-      "description": "Exact version or semver keyword to apply to the selected release group. NOTE: This should be set on the release group level, not the project level."
+      "description": "Exact version or semver keyword to apply to the selected release group. Overrides specifierSource."
+    },
+    "releaseGroupName": {
+      "type": "string",
+      "description": "The name of the release group being versioned in the current execution."
+    },
+    "specifierSource": {
+      "type": "string",
+      "default": "prompt",
+      "description": "Which approach to use to determine the semver specifier used to bump the version of the project.",
+      "enum": ["prompt", "conventional-commits"]
     },
     "preid": {
       "type": "string",
@@ -33,7 +43,7 @@
       "type": "string",
       "default": "disk",
       "description": "Which approach to use to determine the current version of the project.",
-      "enum": ["registry", "disk"]
+      "enum": ["registry", "disk", "git-tag"]
     },
     "currentVersionResolverMetadata": {
       "type": "object",
@@ -41,5 +51,5 @@
       "default": {}
     }
   },
-  "required": ["projects", "projectGraph", "specifier"]
+  "required": ["projects", "projectGraph", "releaseGroupName"]
 }

--- a/packages/js/src/generators/release-version/schema.json
+++ b/packages/js/src/generators/release-version/schema.json
@@ -21,9 +21,9 @@
       "type": "string",
       "description": "Exact version or semver keyword to apply to the selected release group. Overrides specifierSource."
     },
-    "releaseGroupName": {
-      "type": "string",
-      "description": "The name of the release group being versioned in the current execution."
+    "releaseGroup": {
+      "type": "object",
+      "description": "The resolved release group configuration, including name, relevant to all projects in the current execution."
     },
     "specifierSource": {
       "type": "string",
@@ -51,5 +51,5 @@
       "default": {}
     }
   },
-  "required": ["projects", "projectGraph", "releaseGroupName"]
+  "required": ["projects", "projectGraph", "releaseGroup"]
 }

--- a/packages/nx/changelog-renderer/index.spec.ts
+++ b/packages/nx/changelog-renderer/index.spec.ts
@@ -27,6 +27,7 @@ describe('defaultChangelogRenderer()', () => {
         },
       ],
       isBreaking: false,
+      affectedFiles: [],
     },
     {
       message: 'feat(pkg-b): and another new capability',
@@ -52,6 +53,7 @@ describe('defaultChangelogRenderer()', () => {
         },
       ],
       isBreaking: false,
+      affectedFiles: [],
     },
     {
       message: 'feat(pkg-a): new hotness',
@@ -77,6 +79,7 @@ describe('defaultChangelogRenderer()', () => {
         },
       ],
       isBreaking: false,
+      affectedFiles: [],
     },
     {
       message: 'feat(pkg-b): brand new thing',
@@ -102,6 +105,7 @@ describe('defaultChangelogRenderer()', () => {
         },
       ],
       isBreaking: false,
+      affectedFiles: [],
     },
     {
       message: 'fix(pkg-a): squashing bugs',
@@ -127,6 +131,7 @@ describe('defaultChangelogRenderer()', () => {
         },
       ],
       isBreaking: false,
+      affectedFiles: [],
     },
   ];
 

--- a/packages/nx/src/command-line/release/changelog.ts
+++ b/packages/nx/src/command-line/release/changelog.ts
@@ -78,9 +78,6 @@ export async function changelogHandler(args: ChangelogOptions): Promise<void> {
     process.env.NX_VERBOSE_LOGGING = 'true';
   }
 
-  /**
-   * TODO: validate releaseTagPattern contains exactly one instance of {version}
-   */
   // Apply default configuration to any optional user configuration
   const { error: configError, nxReleaseConfig } = await createNxReleaseConfig(
     projectGraph,

--- a/packages/nx/src/command-line/release/changelog.ts
+++ b/packages/nx/src/command-line/release/changelog.ts
@@ -107,7 +107,7 @@ export async function changelogHandler(args: ChangelogOptions): Promise<void> {
     releaseTagPattern: nxReleaseConfig.releaseTagPattern,
   });
 
-  const from = args.from || (await getLastGitTag());
+  const from = args.from || (await getLastGitTag(tagMatchingPattern));
   if (!from) {
     output.error({
       title: `Unable to determine the previous git tag, please provide an explicit git reference using --from`,

--- a/packages/nx/src/command-line/release/changelog.ts
+++ b/packages/nx/src/command-line/release/changelog.ts
@@ -24,7 +24,7 @@ import { filterReleaseGroups } from './config/filter-release-groups';
 import {
   GitCommit,
   getGitDiff,
-  getLastGitTag,
+  getLatestGitTagForPattern,
   parseCommits,
 } from './utils/git';
 import {
@@ -78,6 +78,9 @@ export async function changelogHandler(args: ChangelogOptions): Promise<void> {
     process.env.NX_VERBOSE_LOGGING = 'true';
   }
 
+  /**
+   * TODO: validate releaseTagPattern contains exactly one instance of {version}
+   */
   // Apply default configuration to any optional user configuration
   const { error: configError, nxReleaseConfig } = await createNxReleaseConfig(
     projectGraph,
@@ -107,7 +110,9 @@ export async function changelogHandler(args: ChangelogOptions): Promise<void> {
     releaseTagPattern: nxReleaseConfig.releaseTagPattern,
   });
 
-  const from = args.from || (await getLastGitTag(tagMatchingPattern));
+  const from =
+    args.from ||
+    (await getLatestGitTagForPattern(nxReleaseConfig.releaseTagPattern))?.tag;
   if (!from) {
     output.error({
       title: `Unable to determine the previous git tag, please provide an explicit git reference using --from`,

--- a/packages/nx/src/command-line/release/config/config.spec.ts
+++ b/packages/nx/src/command-line/release/config/config.spec.ts
@@ -945,5 +945,49 @@ describe('createNxReleaseConfig()', () => {
         }
       `);
     });
+
+    it("should return an error if a group's releaseTagPattern has no {version} placeholder", async () => {
+      const res = await createNxReleaseConfig(projectGraph, {
+        groups: {
+          'group-1': {
+            projects: '*',
+            releaseTagPattern: 'v',
+          },
+        },
+      });
+      expect(res).toMatchInlineSnapshot(`
+        {
+          "error": {
+            "code": "RELEASE_GROUP_RELEASE_TAG_PATTERN_VERSION_PLACEHOLDER_MISSING_OR_EXCESSIVE",
+            "data": {
+              "releaseGroupName": "group-1",
+            },
+          },
+          "nxReleaseConfig": null,
+        }
+      `);
+    });
+
+    it("should return an error if a group's releaseTagPattern has more than one {version} placeholder", async () => {
+      const res = await createNxReleaseConfig(projectGraph, {
+        groups: {
+          'group-1': {
+            projects: '*',
+            releaseTagPattern: '{version}v{version}',
+          },
+        },
+      });
+      expect(res).toMatchInlineSnapshot(`
+        {
+          "error": {
+            "code": "RELEASE_GROUP_RELEASE_TAG_PATTERN_VERSION_PLACEHOLDER_MISSING_OR_EXCESSIVE",
+            "data": {
+              "releaseGroupName": "group-1",
+            },
+          },
+          "nxReleaseConfig": null,
+        }
+      `);
+    });
   });
 });

--- a/packages/nx/src/command-line/release/config/config.spec.ts
+++ b/packages/nx/src/command-line/release/config/config.spec.ts
@@ -729,6 +729,101 @@ describe('createNxReleaseConfig()', () => {
         }
       `);
     });
+
+    it('should return an error if no projects can be resolved for a group', async () => {
+      const res = await createNxReleaseConfig(projectGraph, {
+        groups: {
+          'group-1': {
+            projects: ['lib-does-not-exist'],
+          },
+        },
+      });
+      expect(res).toMatchInlineSnapshot(`
+        {
+          "error": {
+            "code": "RELEASE_GROUP_MATCHES_NO_PROJECTS",
+            "data": {
+              "releaseGroupName": "group-1",
+            },
+          },
+          "nxReleaseConfig": null,
+        }
+      `);
+    });
+
+    it('should return an error if any matched projects do not have the required target specified', async () => {
+      const res = await createNxReleaseConfig(
+        {
+          ...projectGraph,
+          nodes: {
+            ...projectGraph.nodes,
+            'project-without-target': {
+              name: 'project-without-target',
+              type: 'lib',
+              data: {
+                root: 'libs/project-without-target',
+                targets: {},
+              } as any,
+            },
+          },
+        },
+        {
+          groups: {
+            'group-1': {
+              projects: '*', // using string form to ensure that is supported in addition to array form
+            },
+          },
+        },
+        'nx-release-publish'
+      );
+      expect(res).toMatchInlineSnapshot(`
+        {
+          "error": {
+            "code": "PROJECTS_MISSING_TARGET",
+            "data": {
+              "projects": [
+                "project-without-target",
+              ],
+              "targetName": "nx-release-publish",
+            },
+          },
+          "nxReleaseConfig": null,
+        }
+      `);
+
+      const res2 = await createNxReleaseConfig(
+        {
+          ...projectGraph,
+          nodes: {
+            ...projectGraph.nodes,
+            'another-project-without-target': {
+              name: 'another-project-without-target',
+              type: 'lib',
+              data: {
+                root: 'libs/another-project-without-target',
+                targets: {},
+              } as any,
+            },
+          },
+        },
+        {},
+        'nx-release-publish'
+      );
+      expect(res2).toMatchInlineSnapshot(`
+        {
+          "error": {
+            "code": "PROJECTS_MISSING_TARGET",
+            "data": {
+              "projects": [
+                "another-project-without-target",
+              ],
+              "targetName": "nx-release-publish",
+            },
+          },
+          "nxReleaseConfig": null,
+        }
+      `);
+    });
   });
 
   describe('release group config errors', () => {

--- a/packages/nx/src/command-line/release/config/filter-release-groups.ts
+++ b/packages/nx/src/command-line/release/config/filter-release-groups.ts
@@ -3,7 +3,7 @@ import { findMatchingProjects } from '../../../utils/find-matching-projects';
 import { output } from '../../../utils/output';
 import { CATCH_ALL_RELEASE_GROUP, NxReleaseConfig } from './config';
 
-type ReleaseGroupWithName = NxReleaseConfig['groups'][string] & {
+export type ReleaseGroupWithName = NxReleaseConfig['groups'][string] & {
   name: string;
 };
 

--- a/packages/nx/src/command-line/release/utils/exec-command.ts
+++ b/packages/nx/src/command-line/release/utils/exec-command.ts
@@ -1,0 +1,32 @@
+import { spawn } from 'node:child_process';
+
+export async function execCommand(
+  cmd: string,
+  args: string[],
+  options?: any
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      ...options,
+      stdio: ['pipe', 'pipe', 'pipe'], // stdin, stdout, stderr
+      encoding: 'utf-8',
+    });
+
+    let stdout = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+
+    child.on('error', (error) => {
+      reject(error);
+    });
+
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(`Command failed with exit code ${code}`));
+      } else {
+        resolve(stdout);
+      }
+    });
+  });
+}

--- a/packages/nx/src/command-line/release/utils/git.spec.ts
+++ b/packages/nx/src/command-line/release/utils/git.spec.ts
@@ -4,6 +4,7 @@ jest.mock('./exec-command', () => ({
   execCommand: jest.fn(() =>
     Promise.resolve(`
 x5.0.0
+release/4.😐2.2
 release/4.2.1
 release/my-lib-1@v4.2.1
 v4.0.1

--- a/packages/nx/src/command-line/release/utils/git.spec.ts
+++ b/packages/nx/src/command-line/release/utils/git.spec.ts
@@ -84,8 +84,12 @@ const releaseTagPatternTestCases = [
 ];
 
 describe('getLatestGitTagForPattern', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it.each(releaseTagPatternTestCases)(
-    'Returns tag $expectedTag for pattern $pattern',
+    'should return tag $expectedTag for pattern $pattern',
     async ({ pattern, projectName, expectedTag, expectedVersion }) => {
       const result = await getLatestGitTagForPattern(pattern, {
         projectName,
@@ -96,7 +100,20 @@ describe('getLatestGitTagForPattern', () => {
     }
   );
 
-  it('Returns null if no tags match the pattern', async () => {
+  it('should return null if execCommand throws an error', async () => {
+    // should return null if execCommand throws an error
+    (require('./exec-command').execCommand as jest.Mock).mockImplementationOnce(
+      () => {
+        throw new Error('error');
+      }
+    );
+    const result = await getLatestGitTagForPattern('#{version}', {
+      projectName: 'my-lib-1',
+    });
+    expect(result).toEqual(null);
+  });
+
+  it('should return null if no tags match the pattern', async () => {
     const result = await getLatestGitTagForPattern('#{version}', {
       projectName: 'my-lib-1',
     });

--- a/packages/nx/src/command-line/release/utils/git.spec.ts
+++ b/packages/nx/src/command-line/release/utils/git.spec.ts
@@ -1,0 +1,105 @@
+import { getLatestGitTagForPattern } from './git';
+
+jest.mock('./exec-command', () => ({
+  execCommand: jest.fn(() =>
+    Promise.resolve(`
+x5.0.0
+release/4.2.1
+release/my-lib-1@v4.2.1
+v4.0.1
+4.0.0-rc.1+build.1
+v4.0.0-beta.1
+my-lib-1@v4.0.0-beta.1
+my-lib-2v4.0.0-beta.1
+my-lib-34.0.0-beta.1
+4.0.0-beta.0-my-lib-1
+3.0.0-beta.0-alpha
+1.0.0
+`)
+  ),
+}));
+
+const releaseTagPatternTestCases = [
+  {
+    pattern: 'v{version}',
+    projectName: 'my-lib-1',
+    expectedTag: 'v4.0.1',
+    expectedVersion: '4.0.1',
+  },
+  {
+    pattern: 'x{version}',
+    projectName: 'my-lib-1',
+    expectedTag: 'x5.0.0',
+    expectedVersion: '5.0.0',
+  },
+  {
+    pattern: 'release/{version}',
+    projectName: 'my-lib-1',
+    expectedTag: 'release/4.2.1',
+    expectedVersion: '4.2.1',
+  },
+  {
+    pattern: 'release/{projectName}@v{version}',
+    projectName: 'my-lib-1',
+    expectedTag: 'release/my-lib-1@v4.2.1',
+    expectedVersion: '4.2.1',
+  },
+  {
+    pattern: '{version}',
+    projectName: 'my-lib-1',
+    expectedTag: '4.0.0-rc.1+build.1',
+    expectedVersion: '4.0.0-rc.1+build.1',
+  },
+  {
+    pattern: '{projectName}@v{version}',
+    projectName: 'my-lib-1',
+    expectedTag: 'my-lib-1@v4.0.0-beta.1',
+    expectedVersion: '4.0.0-beta.1',
+  },
+  {
+    pattern: '{projectName}v{version}',
+    projectName: 'my-lib-2',
+    expectedTag: 'my-lib-2v4.0.0-beta.1',
+    expectedVersion: '4.0.0-beta.1',
+  },
+  {
+    pattern: '{projectName}{version}',
+    projectName: 'my-lib-3',
+    expectedTag: 'my-lib-34.0.0-beta.1',
+    expectedVersion: '4.0.0-beta.1',
+  },
+  {
+    pattern: '{version}-{projectName}',
+    projectName: 'my-lib-1',
+    expectedTag: '4.0.0-beta.0-my-lib-1',
+    expectedVersion: '4.0.0-beta.0',
+  },
+  {
+    pattern: '{version}-{projectName}',
+    projectName: 'alpha',
+    expectedTag: '3.0.0-beta.0-alpha',
+    expectedVersion: '3.0.0-beta.0',
+  },
+];
+
+describe('getLatestGitTagForPattern', () => {
+  it.each(releaseTagPatternTestCases)(
+    'Returns tag $expectedTag for pattern $pattern',
+    async ({ pattern, projectName, expectedTag, expectedVersion }) => {
+      const result = await getLatestGitTagForPattern(pattern, {
+        projectName,
+      });
+
+      expect(result.tag).toEqual(expectedTag);
+      expect(result.extractedVersion).toEqual(expectedVersion);
+    }
+  );
+
+  it('Returns null if no tags match the pattern', async () => {
+    const result = await getLatestGitTagForPattern('#{version}', {
+      projectName: 'my-lib-1',
+    });
+
+    expect(result).toEqual(null);
+  });
+});

--- a/packages/nx/src/command-line/release/utils/git.ts
+++ b/packages/nx/src/command-line/release/utils/git.ts
@@ -28,13 +28,25 @@ export interface GitCommit extends RawGitCommit {
   references: Reference[];
   authors: GitCommitAuthor[];
   isBreaking: boolean;
+  affectedFiles: string[];
 }
 
-export async function getLastGitTag() {
-  const r = await execCommand('git', ['describe', '--tags', '--abbrev=0'])
-    .then((r) => r.split('\n').filter(Boolean))
-    .catch(() => []);
-  return r.at(-1);
+export async function getLastGitTag(matchingPattern: string) {
+  const matchingTags = await execCommand('git', [
+    'tag',
+    '-l',
+    matchingPattern,
+    '--sort',
+    '-v:refname',
+  ]).then((r) =>
+    r
+      .trim()
+      .split('\n')
+      .map((t) => t.trim())
+      .filter(Boolean)
+  );
+
+  return matchingTags.length ? matchingTags[0] : null;
 }
 
 export async function getGitDiff(
@@ -77,6 +89,7 @@ const ConventionalCommitRegex =
 const CoAuthoredByRegex = /co-authored-by:\s*(?<name>.+)(<(?<email>.+)>)/gim;
 const PullRequestRE = /\([ a-z]*(#\d+)\s*\)/gm;
 const IssueRE = /(#\d+)/gm;
+const ChangedFileRegex = /(A|M|D|R\d*|C\d*)\t([^\t\n]*)\t?(.*)?/gm;
 
 export function parseGitCommit(commit: RawGitCommit): GitCommit | null {
   const match = commit.message.match(ConventionalCommitRegex);
@@ -115,6 +128,19 @@ export function parseGitCommit(commit: RawGitCommit): GitCommit | null {
     });
   }
 
+  // Extract file changes from commit body
+  const affectedFiles = Array.from(
+    commit.body.matchAll(ChangedFileRegex)
+  ).reduce(
+    (
+      prev,
+      [fullLine, changeType, file1, file2]: [string, string, string, string?]
+    ) =>
+      // file2 only exists for some change types, such as renames
+      file2 ? [...prev, file1, file2] : [...prev, file1],
+    [] as string[]
+  );
+
   return {
     ...commit,
     authors,
@@ -123,6 +149,7 @@ export function parseGitCommit(commit: RawGitCommit): GitCommit | null {
     scope,
     references,
     isBreaking,
+    affectedFiles,
   };
 }
 

--- a/packages/nx/src/command-line/release/utils/git.ts
+++ b/packages/nx/src/command-line/release/utils/git.ts
@@ -63,6 +63,10 @@ export async function getLatestGitTagForPattern(
   )}`;
   const latestTag = tags[0];
   const matchingTags = tags.filter((tag) => !!tag.match(tagRegexp));
+
+  if (!matchingTags.length) {
+    return null;
+  }
   const [, version] = matchingTags[0].match(tagRegexp);
 
   return {

--- a/packages/nx/src/command-line/release/utils/git.ts
+++ b/packages/nx/src/command-line/release/utils/git.ts
@@ -3,7 +3,7 @@
  * https://github.com/unjs/changelogen
  */
 import { spawn } from 'node:child_process';
-import { interpolate } from 'nx/src/tasks-runner/utils';
+import { interpolate } from '../../../tasks-runner/utils';
 
 export interface GitCommitAuthor {
   name: string;

--- a/packages/nx/src/command-line/release/utils/resolve-nx-json-error-message.ts
+++ b/packages/nx/src/command-line/release/utils/resolve-nx-json-error-message.ts
@@ -14,7 +14,10 @@ export async function resolveNxJsonConfigErrorMessage(
     joinPathFragments(workspaceRoot, 'nx.json')
   )}`;
   if (errorLines) {
-    nxJsonMessage += `, lines ${errorLines.startLine}-${errorLines.endLine}`;
+    nxJsonMessage +=
+      errorLines.startLine === errorLines.endLine
+        ? `, line ${errorLines.startLine}`
+        : `, lines ${errorLines.startLine}-${errorLines.endLine}`;
   }
   return nxJsonMessage;
 }

--- a/packages/nx/src/command-line/release/utils/resolve-semver-specifier.ts
+++ b/packages/nx/src/command-line/release/utils/resolve-semver-specifier.ts
@@ -1,0 +1,86 @@
+import { prompt } from 'enquirer';
+import { RELEASE_TYPES, valid } from 'semver';
+import { ProjectGraph } from '../../../config/project-graph';
+import { createProjectFileMapUsingProjectGraph } from '../../../project-graph/file-map-utils';
+import { getGitDiff, parseCommits } from './git';
+import { ConventionalCommitsConfig, determineSemverChange } from './semver';
+
+// TODO: Extract config to nx.json configuration when adding changelog customization
+const CONVENTIONAL_COMMITS_CONFIG: ConventionalCommitsConfig = {
+  types: {
+    feat: {
+      semver: 'minor',
+    },
+    fix: {
+      semver: 'patch',
+    },
+  },
+};
+
+export async function resolveSemverSpecifierFromConventionalCommits(
+  from: string,
+  projectGraph: ProjectGraph,
+  projectNames: string[]
+): Promise<string> {
+  const commits = await getGitDiff(from);
+  const parsedCommits = parseCommits(commits);
+  const projectFileMap = await createProjectFileMapUsingProjectGraph(
+    projectGraph
+  );
+  const filesInReleaseGroup = new Set<string>(
+    projectNames.reduce(
+      (files, p) => [...files, ...projectFileMap[p].map((f) => f.file)],
+      [] as string[]
+    )
+  );
+
+  const relevantCommits = parsedCommits.filter((c) =>
+    c.affectedFiles.some((f) => filesInReleaseGroup.has(f))
+  );
+
+  return determineSemverChange(relevantCommits, CONVENTIONAL_COMMITS_CONFIG);
+}
+
+export async function resolveSemverSpecifierFromPrompt(
+  selectionMessage: string,
+  customVersionMessage: string
+): Promise<string> {
+  try {
+    const reply = await prompt<{ specifier: string }>([
+      {
+        name: 'specifier',
+        message: selectionMessage,
+        type: 'select',
+        choices: [
+          ...RELEASE_TYPES.map((t) => ({ name: t, message: t })),
+          {
+            name: 'custom',
+            message: 'Custom exact version',
+          },
+        ],
+      },
+    ]);
+    if (reply.specifier !== 'custom') {
+      return reply.specifier;
+    } else {
+      const reply = await prompt<{ specifier: string }>([
+        {
+          name: 'specifier',
+          message: customVersionMessage,
+          type: 'input',
+          validate: (input) => {
+            if (valid(input)) {
+              return true;
+            }
+            return 'Please enter a valid semver version';
+          },
+        },
+      ]);
+      return reply.specifier;
+    }
+  } catch {
+    // TODO: log the error to the user?
+    // We need to catch the error from enquirer prompt, otherwise yargs will print its help
+    process.exit(1);
+  }
+}

--- a/packages/nx/src/command-line/release/utils/resolve-semver-specifier.ts
+++ b/packages/nx/src/command-line/release/utils/resolve-semver-specifier.ts
@@ -21,7 +21,7 @@ export async function resolveSemverSpecifierFromConventionalCommits(
   from: string,
   projectGraph: ProjectGraph,
   projectNames: string[]
-): Promise<string> {
+): Promise<string | null> {
   const commits = await getGitDiff(from);
   const parsedCommits = parseCommits(commits);
   const projectFileMap = await createProjectFileMapUsingProjectGraph(

--- a/packages/nx/src/command-line/release/utils/semver.spec.ts
+++ b/packages/nx/src/command-line/release/utils/semver.spec.ts
@@ -1,70 +1,163 @@
-import { deriveNewSemverVersion } from './semver';
+import { GitCommit } from './git';
+import {
+  ConventionalCommitsConfig,
+  deriveNewSemverVersion,
+  determineSemverChange,
+} from './semver';
 
-describe('deriveNewSemverVersion()', () => {
-  const testCases = [
-    {
-      input: {
-        currentVersion: '1.0.0',
-        specifier: 'major',
+describe('semver', () => {
+  describe('deriveNewSemverVersion()', () => {
+    const testCases = [
+      {
+        input: {
+          currentVersion: '1.0.0',
+          specifier: 'major',
+        },
+        expected: '2.0.0',
       },
-      expected: '2.0.0',
-    },
-    {
-      input: {
-        currentVersion: '1.0.0',
-        specifier: 'minor',
+      {
+        input: {
+          currentVersion: '1.0.0',
+          specifier: 'minor',
+        },
+        expected: '1.1.0',
       },
-      expected: '1.1.0',
-    },
-    {
-      input: {
-        currentVersion: '1.0.0',
-        specifier: 'patch',
+      {
+        input: {
+          currentVersion: '1.0.0',
+          specifier: 'patch',
+        },
+        expected: '1.0.1',
       },
-      expected: '1.0.1',
-    },
-    {
-      input: {
-        currentVersion: '1.0.0',
-        specifier: '99.9.9', // exact version
+      {
+        input: {
+          currentVersion: '1.0.0',
+          specifier: '99.9.9', // exact version
+        },
+        expected: '99.9.9',
       },
-      expected: '99.9.9',
-    },
-    {
-      input: {
-        currentVersion: '1.0.0',
-        specifier: '99.9.9', // exact version
+      {
+        input: {
+          currentVersion: '1.0.0',
+          specifier: '99.9.9', // exact version
+        },
+        expected: '99.9.9',
       },
-      expected: '99.9.9',
-    },
-  ];
+    ];
 
-  testCases.forEach((c, i) => {
-    it(`should derive an appropriate semver version, CASE: ${i}`, () => {
-      expect(
-        deriveNewSemverVersion(c.input.currentVersion, c.input.specifier)
-      ).toEqual(c.expected);
+    testCases.forEach((c, i) => {
+      it(`should derive an appropriate semver version, CASE: ${i}`, () => {
+        expect(
+          deriveNewSemverVersion(c.input.currentVersion, c.input.specifier)
+        ).toEqual(c.expected);
+      });
+    });
+
+    it('should throw if the current version is not a valid semver version', () => {
+      expect(() =>
+        deriveNewSemverVersion('not-a-valid-semver-version', 'minor')
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Invalid semver version "not-a-valid-semver-version" provided."`
+      );
+      expect(() =>
+        deriveNewSemverVersion('major', 'minor')
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Invalid semver version "major" provided."`
+      );
+    });
+
+    it('should throw if the new version specifier is not a valid semver version or semver keyword', () => {
+      expect(() =>
+        deriveNewSemverVersion('1.0.0', 'foo')
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Invalid semver version specifier "foo" provided. Please provide either a valid semver version or a valid semver version keyword."`
+      );
     });
   });
+  // tests for determineSemverChange()
+  describe('determineSemverChange()', () => {
+    const config: ConventionalCommitsConfig = {
+      types: {
+        feat: {
+          semver: 'minor',
+        },
+        fix: {
+          semver: 'patch',
+        },
+        chore: {
+          semver: 'patch',
+        },
+      },
+    };
 
-  it('should throw if the current version is not a valid semver version', () => {
-    expect(() =>
-      deriveNewSemverVersion('not-a-valid-semver-version', 'minor')
-    ).toThrowErrorMatchingInlineSnapshot(
-      `"Invalid semver version "not-a-valid-semver-version" provided."`
-    );
-    expect(() =>
-      deriveNewSemverVersion('major', 'minor')
-    ).toThrowErrorMatchingInlineSnapshot(
-      `"Invalid semver version "major" provided."`
-    );
-  });
+    const featNonBreakingCommit: GitCommit = {
+      type: 'feat',
+      isBreaking: false,
+    } as GitCommit;
+    const featBreakingCommit: GitCommit = {
+      type: 'feat',
+      isBreaking: true,
+    } as GitCommit;
+    const fixCommit: GitCommit = {
+      type: 'fix',
+      isBreaking: false,
+    } as GitCommit;
+    const choreCommit: GitCommit = {
+      type: 'chore',
+      isBreaking: false,
+    } as GitCommit;
+    const unknownTypeCommit: GitCommit = {
+      type: 'perf',
+      isBreaking: false,
+    } as GitCommit;
+    const unknownTypeBreakingCommit: GitCommit = {
+      type: 'perf',
+      isBreaking: true,
+    } as GitCommit;
 
-  it('should throw if the new version specifier is not a valid semver version or semver keyword', () => {
-    expect(() =>
-      deriveNewSemverVersion('1.0.0', 'foo')
-    ).toThrowErrorMatchingInlineSnapshot(
-      `"Invalid semver version specifier "foo" provided. Please provide either a valid semver version or a valid semver version keyword."`
-    );
+    it('should return the highest bump level of all commits', () => {
+      expect(
+        determineSemverChange(
+          [fixCommit, featNonBreakingCommit, choreCommit],
+          config
+        )
+      ).toEqual('minor');
+    });
+
+    it('should return major if any commits are breaking', () => {
+      expect(
+        determineSemverChange(
+          [fixCommit, featBreakingCommit, featNonBreakingCommit, choreCommit],
+          config
+        )
+      ).toEqual('major');
+    });
+
+    it('should return major if any commits (including unknown types) are breaking', () => {
+      expect(
+        determineSemverChange(
+          [
+            fixCommit,
+            unknownTypeBreakingCommit,
+            featNonBreakingCommit,
+            choreCommit,
+          ],
+          config
+        )
+      ).toEqual('major');
+    });
+
+    it('should return patch when given only patch commits, ignoring unknown types', () => {
+      expect(
+        determineSemverChange(
+          [fixCommit, choreCommit, unknownTypeCommit],
+          config
+        )
+      ).toEqual('patch');
+    });
+
+    it('should return null when given only unknown type commits', () => {
+      expect(determineSemverChange([unknownTypeCommit], config)).toEqual(null);
+    });
   });
 });

--- a/packages/nx/src/command-line/release/version.ts
+++ b/packages/nx/src/command-line/release/version.ts
@@ -1,8 +1,6 @@
 import * as chalk from 'chalk';
-import * as enquirer from 'enquirer';
 import { readFileSync } from 'node:fs';
 import { relative } from 'node:path';
-import { RELEASE_TYPES, valid } from 'semver';
 import { Generator } from '../../config/misc-interfaces';
 import { readNxJson } from '../../config/nx-json';
 import {
@@ -32,7 +30,6 @@ import {
 } from './config/config';
 import { filterReleaseGroups } from './config/filter-release-groups';
 import { printDiff } from './utils/print-changes';
-import { isRelativeVersionKeyword } from './utils/semver';
 
 // Reexport for use in plugin release-version generator implementations
 export { deriveNewSemverVersion } from './utils/semver';
@@ -40,11 +37,13 @@ export { deriveNewSemverVersion } from './utils/semver';
 export interface ReleaseVersionGeneratorSchema {
   // The projects being versioned in the current execution
   projects: ProjectGraphProjectNode[];
+  releaseGroupName: string;
   projectGraph: ProjectGraph;
-  specifier: string;
+  specifier?: string;
+  specifierSource?: 'prompt' | 'conventional-commits';
   preid?: string;
   packageRoot?: string;
-  currentVersionResolver?: 'registry' | 'disk';
+  currentVersionResolver?: 'registry' | 'disk' | 'git-tag';
   currentVersionResolverMetadata?: Record<string, unknown>;
 }
 
@@ -99,14 +98,8 @@ export async function versionHandler(args: VersionOptions): Promise<void> {
         configGeneratorOptions: releaseGroup.version.generatorOptions,
       });
 
-      const semverSpecifier = await resolveSemverSpecifier(
-        args.specifier,
-        `What kind of change is this for the ${
-          releaseGroupToFilteredProjects.get(releaseGroup).size
-        } matched project(s) within release group "${releaseGroupName}"?`,
-        `What is the exact version for the ${
-          releaseGroupToFilteredProjects.get(releaseGroup).size
-        } matched project(s) within release group "${releaseGroupName}"?`
+      const releaseGroupProjectNames = Array.from(
+        releaseGroupToFilteredProjects.get(releaseGroup)
       );
 
       await runVersionOnProjects(
@@ -115,8 +108,8 @@ export async function versionHandler(args: VersionOptions): Promise<void> {
         args,
         tree,
         generatorData,
-        Array.from(releaseGroupToFilteredProjects.get(releaseGroup)),
-        semverSpecifier
+        releaseGroupProjectNames,
+        releaseGroupName
       );
     }
 
@@ -140,16 +133,6 @@ export async function versionHandler(args: VersionOptions): Promise<void> {
       configGeneratorOptions: releaseGroup.version.generatorOptions,
     });
 
-    const semverSpecifier = await resolveSemverSpecifier(
-      args.specifier,
-      releaseGroupName === CATCH_ALL_RELEASE_GROUP
-        ? `What kind of change is this for all packages?`
-        : `What kind of change is this for release group "${releaseGroupName}"?`,
-      releaseGroupName === CATCH_ALL_RELEASE_GROUP
-        ? `What is the exact version for all packages?`
-        : `What is the exact version for release group "${releaseGroupName}"?`
-    );
-
     await runVersionOnProjects(
       projectGraph,
       nxJson,
@@ -157,7 +140,7 @@ export async function versionHandler(args: VersionOptions): Promise<void> {
       tree,
       generatorData,
       releaseGroup.projects,
-      semverSpecifier
+      releaseGroupName
     );
   }
 
@@ -173,30 +156,16 @@ async function runVersionOnProjects(
   tree: Tree,
   generatorData: GeneratorData,
   projectNames: string[],
-  newVersionSpecifier: string
+  releaseGroupName: string
 ) {
-  // Should be impossible state
-  if (!newVersionSpecifier) {
-    output.error({
-      title: `No version or semver keyword could be determined`,
-    });
-    process.exit(1);
-  }
-  // Specifier could be user provided so we need to validate it
-  if (
-    !valid(newVersionSpecifier) &&
-    !isRelativeVersionKeyword(newVersionSpecifier)
-  ) {
-    output.error({
-      title: `The given version specifier "${newVersionSpecifier}" is not valid. You provide an exact version or a valid semver keyword such as "major", "minor", "patch", etc.`,
-    });
-    process.exit(1);
-  }
-
   const generatorOptions: ReleaseVersionGeneratorSchema = {
     projects: projectNames.map((p) => projectGraph.nodes[p]),
     projectGraph,
-    specifier: newVersionSpecifier,
+    releaseGroupName:
+      releaseGroupName === CATCH_ALL_RELEASE_GROUP
+        ? 'default'
+        : releaseGroupName,
+    specifier: args.specifier ?? '',
     preid: args.preid,
     ...generatorData.configGeneratorOptions,
   };
@@ -256,55 +225,6 @@ function printChanges(tree: Tree, isDryRun: boolean) {
 
   if (isDryRun) {
     logger.warn(`\nNOTE: The "dryRun" flag means no changes were made.`);
-  }
-}
-
-async function resolveSemverSpecifier(
-  cliArgSpecifier: string,
-  selectionMessage: string,
-  customVersionMessage: string
-): Promise<string> {
-  try {
-    let newVersionSpecifier = cliArgSpecifier;
-    // If the user didn't provide a new version specifier directly on the CLI, prompt for one
-    if (!newVersionSpecifier) {
-      const reply = await enquirer.prompt<{ specifier: string }>([
-        {
-          name: 'specifier',
-          message: selectionMessage,
-          type: 'select',
-          choices: [
-            ...RELEASE_TYPES.map((t) => ({ name: t, message: t })),
-            {
-              name: 'custom',
-              message: 'Custom exact version',
-            },
-          ],
-        },
-      ]);
-      if (reply.specifier !== 'custom') {
-        newVersionSpecifier = reply.specifier;
-      } else {
-        const reply = await enquirer.prompt<{ specifier: string }>([
-          {
-            name: 'specifier',
-            message: customVersionMessage,
-            type: 'input',
-            validate: (input) => {
-              if (valid(input)) {
-                return true;
-              }
-              return 'Please enter a valid semver version';
-            },
-          },
-        ]);
-        newVersionSpecifier = reply.specifier;
-      }
-    }
-    return newVersionSpecifier;
-  } catch {
-    // We need to catch the error from enquirer prompt, otherwise yargs will print its help
-    process.exit(1);
   }
 }
 

--- a/packages/nx/src/command-line/release/version.ts
+++ b/packages/nx/src/command-line/release/version.ts
@@ -24,11 +24,13 @@ import { parseGeneratorString } from '../generate/generate';
 import { getGeneratorInformation } from '../generate/generator-utils';
 import { VersionOptions } from './command-object';
 import {
-  CATCH_ALL_RELEASE_GROUP,
   createNxReleaseConfig,
   handleNxReleaseConfigError,
 } from './config/config';
-import { filterReleaseGroups } from './config/filter-release-groups';
+import {
+  ReleaseGroupWithName,
+  filterReleaseGroups,
+} from './config/filter-release-groups';
 import { printDiff } from './utils/print-changes';
 
 // Reexport for use in plugin release-version generator implementations
@@ -37,7 +39,7 @@ export { deriveNewSemverVersion } from './utils/semver';
 export interface ReleaseVersionGeneratorSchema {
   // The projects being versioned in the current execution
   projects: ProjectGraphProjectNode[];
-  releaseGroupName: string;
+  releaseGroup: ReleaseGroupWithName;
   projectGraph: ProjectGraph;
   specifier?: string;
   specifierSource?: 'prompt' | 'conventional-commits';
@@ -109,7 +111,7 @@ export async function versionHandler(args: VersionOptions): Promise<void> {
         tree,
         generatorData,
         releaseGroupProjectNames,
-        releaseGroupName
+        releaseGroup
       );
     }
 
@@ -140,7 +142,7 @@ export async function versionHandler(args: VersionOptions): Promise<void> {
       tree,
       generatorData,
       releaseGroup.projects,
-      releaseGroupName
+      releaseGroup
     );
   }
 
@@ -156,15 +158,12 @@ async function runVersionOnProjects(
   tree: Tree,
   generatorData: GeneratorData,
   projectNames: string[],
-  releaseGroupName: string
+  releaseGroup: ReleaseGroupWithName
 ) {
   const generatorOptions: ReleaseVersionGeneratorSchema = {
     projects: projectNames.map((p) => projectGraph.nodes[p]),
     projectGraph,
-    releaseGroupName:
-      releaseGroupName === CATCH_ALL_RELEASE_GROUP
-        ? 'default'
-        : releaseGroupName,
+    releaseGroup,
     specifier: args.specifier ?? '',
     preid: args.preid,
     ...generatorData.configGeneratorOptions,

--- a/packages/nx/src/command-line/release/version.ts
+++ b/packages/nx/src/command-line/release/version.ts
@@ -164,6 +164,7 @@ async function runVersionOnProjects(
     projects: projectNames.map((p) => projectGraph.nodes[p]),
     projectGraph,
     releaseGroup,
+    // Always ensure a string to avoid generator schema validation errors
     specifier: args.specifier ?? '',
     preid: args.preid,
     ...generatorData.configGeneratorOptions,


### PR DESCRIPTION
- Adds `git-tag` as a `currentVersionResolver` option for `nx release version`. This option will cause the current version for the release group to be taken from the most recent matching release tag, as configured with `releaseTagPattern`.

- Adds support for using conventional commits to determine the `specifier` for the version bump. In this case, the `nx release version` command will look at git tags to determine which git ref to use as a base. Commits since the base will be parsed and any commits that touched files within any lib in the release group will be used to help determine the next version. Right now, only `fix(...)` and `feat(...)` are recognized, but breaking changes are recognized (`fix(...)!: ...`). If the previous version (from the git tag) is determined to be a prerelease, the bump type will always be `prerelease`. The user will need to promote prereleases to regular releases manually by passing an explicit specifier, which will override that obtained from conventional commits standards.

- Uses `npm config get registry` to determine the default registry before falling back on https://registry.npmjs.org

- Moves the specifier prompting into the version generator. This allows the current version determined in the generator to be used to determine the specifier when using conventional commits.