### PR TITLE
Revert "chore(repo): increate npm fetch retires count and timeout (#1…

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,0 @@
-fetch-retries=5
-fetch-retry-mintimeout=60000
-fetch-retry-maxtimeout=120000
-fetch-timeout=300000

--- a/.verdaccio/config.yml
+++ b/.verdaccio/config.yml
@@ -12,13 +12,11 @@ uplinks:
     maxage: 60m
     max_fails: 20
     fail_timeout: 2m
-    timeout: 5m
   yarn:
     url: https://registry.yarnpkg.com
     maxage: 60m
     max_fails: 20
     fail_timeout: 2m
-    timeout: 5m
 
 packages:
   '@*/*':


### PR DESCRIPTION
…9191)"

This reverts commit ed0456e798e3e60a4e3d0936d2cf04d8a5c9ec12.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The e2e tests take a LONG time to npm install things...

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The e2e tests should not take a LONG time

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
