### PR TITLE
fix(core): adjust how findMatchingProjects works when provided additive patterns after an exclusion to be more intuitive

### DIFF
--- a/packages/nx/src/utils/find-matching-projects.spec.ts
+++ b/packages/nx/src/utils/find-matching-projects.spec.ts
@@ -78,7 +78,7 @@ describe('findMatchingProjects', () => {
       'c',
       'nested',
     ]);
-    expect(findMatchingProjects(['!*', 'a'], projectGraph)).toEqual([]);
+    expect(findMatchingProjects(['a', '!*'], projectGraph)).toEqual([]);
   });
 
   it('should expand generic glob patterns', () => {
@@ -124,10 +124,14 @@ describe('findMatchingProjects', () => {
   });
 
   it('should support negation "!" for tags', () => {
-    expect(findMatchingProjects(['*', '!tag:api'], projectGraph)).toEqual([
-      'b',
-      'nested',
-    ]);
+    // Picks everything, except things tagged API, unless those also
+    // have the tag theme2 in which case we still want them.
+    const matches = findMatchingProjects(
+      ['*', '!tag:api', 'tag:theme2'],
+      projectGraph
+    );
+    expect(matches).toEqual(expect.arrayContaining(['a', 'b', 'nested']));
+    expect(matches.length).toEqual(3);
   });
 
   it('should expand generic glob patterns for tags', () => {


### PR DESCRIPTION
## Current Behavior
A list of patterns such as `['*', '!packages/*', 'my-package']` will not include `'my-package'` as a result. This behavior feels weird though, as intuitively the patterns are parsed as:

- Select everything
- Remove anything under packages directory
- Add my-package

However, mechanically, we currently handle exclusions at the very end of processing patterns. This means we parse it as:
- Select everything
- Add my-package
- Remove everything under packages directory

## Expected Behavior
Pattern parsing is intuitive.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #19210
