### PR TITLE
fix(vite): provide correct root directory when building a root project

### DIFF
--- a/packages/vite/src/utils/options-utils.ts
+++ b/packages/vite/src/utils/options-utils.ts
@@ -89,10 +89,10 @@ export function getViteSharedConfig(
   const projectRoot =
     context.projectsConfigurations.projects[context.projectName].root;
 
-  const root = relative(
-    context.cwd,
-    joinPathFragments(context.root, projectRoot)
-  );
+  const root =
+    projectRoot === '.'
+      ? process.cwd()
+      : relative(context.cwd, joinPathFragments(context.root, projectRoot));
 
   return {
     mode: options.mode,


### PR DESCRIPTION
There is an issue where our Vite executors are passing `''` as the root directory to Vite, which results in it not finding `package.json` to detect `type: 'module'`. This means that root apps which use ESM-only packages will fail to build.

You can see the issue here: https://github.com/jaysoo/nx-vite-root-issue

```
> nx run root-app:serve:development

failed to load config from /private/tmp/vite1/vite.config.ts
Error [ERR_REQUIRE_ESM]: require() of ES Module /private/tmp/vite1/foo/index.js from /private/tmp/vite1/vite.config.ts not supported.
Instead change the require of index.js in /private/tmp/vite1/vite.config.ts to a dynamic import() which is available in all CommonJS modules.
    at _require.extensions.<computed> [as .js] (file:///private/tmp/vite1/node_modules/vite/dist/node/chunks/dep-e8f070e8.js:64527:17)
    at Object.<anonymous> (/private/tmp/vite1/vite.config.ts:36:26)
    at _require.extensions.<computed> [as .js] (file:///private/tmp/vite1/node_modules/vite/dist/node/chunks/dep-e8f070e8.js:64524:24)
    at loadConfigFromBundledFile (file:///private/tmp/vite1/node_modules/vite/dist/node/chunks/dep-e8f070e8.js:64532:21)
    at async loadConfigFromFile (file:///private/tmp/vite1/node_modules/vite/dist/node/chunks/dep-e8f070e8.js:64388:28)
    at async resolveConfig (file:///private/tmp/vite1/node_modules/vite/dist/node/chunks/dep-e8f070e8.js:63993:28)
    at async _createServer (file:///private/tmp/vite1/node_modules/vite/dist/node/chunks/dep-e8f070e8.js:63274:20)
    at async viteDevServerExecutor (/private/tmp/vite1/node_modules/@nx/vite/src/executors/dev-server/dev-server.impl.js:34:24)
    at async getLastValueFromAsyncIterableIterator (/private/tmp/vite1/node_modules/nx/src/utils/async-iterator.js:13:19)
    at async iteratorToProcessStatusCode (/private/tmp/vite1/node_modules/nx/src/command-line/run/run.js:41:29)
    at async handleErrors (/private/tmp/vite1/node_modules/nx/src/utils/params.js:9:16)
    at async process.<anonymous> (/private/tmp/vite1/node_modules/nx/bin/run-executor.js:59:28) {
  code: 'ERR_REQUIRE_ESM'
}
```
## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
