### PR TITLE
feat(linter): add app import exception for remotes

### DIFF
--- a/packages/eslint-plugin/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin/src/rules/enforce-module-boundaries.ts
@@ -32,6 +32,7 @@ import {
   onlyLoadChildren,
   stringifyTags,
   isComboDepConstraint,
+  appIsMFERemote,
 } from '../utils/runtime-lint-utils';
 import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
 import { basename, dirname, relative } from 'path';
@@ -477,7 +478,7 @@ export default createESLintRule<Options, MessageIds>({
       }
 
       // cannot import apps
-      if (targetProject.type === 'app') {
+      if (targetProject.type === 'app' && !appIsMFERemote(targetProject)) {
         context.report({
           node,
           messageId: 'noImportsOfApps',

--- a/packages/eslint-plugin/src/utils/runtime-lint-utils.spec.ts
+++ b/packages/eslint-plugin/src/utils/runtime-lint-utils.spec.ts
@@ -7,6 +7,7 @@ import {
 } from '@nx/devkit';
 import {
   DepConstraint,
+  appIsMFERemote,
   findConstraintsFor,
   findTransitiveExternalDependencies,
   getSourceFilePath,
@@ -574,4 +575,70 @@ describe('getSourceFilePath', () => {
       );
     }
   );
+});
+
+describe('appIsMFERemote', () => {
+  const targetJs: ProjectGraphProjectNode = {
+    type: 'lib',
+    name: 'aApp',
+    data: {
+      tags: ['abc'],
+      root: 'apps/remote1',
+    } as any,
+  };
+  const targetTs: ProjectGraphProjectNode = {
+    type: 'lib',
+    name: 'bApp',
+    data: {
+      tags: ['abc'],
+      root: 'apps/remote2',
+    } as any,
+  };
+  const targetNoExposes: ProjectGraphProjectNode = {
+    type: 'lib',
+    name: 'cApp',
+    data: {
+      tags: ['abc'],
+      root: 'apps/remote3',
+    } as any,
+  };
+  const targetNone: ProjectGraphProjectNode = {
+    type: 'lib',
+    name: 'dApp',
+    data: {
+      tags: ['abc'],
+      root: 'apps/nonremote',
+    } as any,
+  };
+  const fsJson = {
+    'apps/remote1/module-federation.config.js': JSON.stringify({
+      name: 'remote1',
+      exposes: {
+        './Module': './apps/remote1/src/app/remote-entry/entry.module.ts',
+      },
+    }),
+    'apps/remote2/module-federation.config.ts': JSON.stringify({
+      name: 'remote2',
+      exposes: {
+        './Module': './apps/remote2/src/app/remote-entry/entry.module.ts',
+      },
+    }),
+    'apps/remote3/module-federation.config.js': JSON.stringify({
+      name: 'remote3',
+    }),
+  };
+  vol.fromJSON(fsJson, '/root');
+
+  it('should return true for remote apps with JS mfe config', () => {
+    expect(appIsMFERemote(targetJs)).toBe(true);
+  });
+  it('should return true for remote apps with TS mfe config', () => {
+    expect(appIsMFERemote(targetTs)).toBe(true);
+  });
+  it('should return true for remote apps with no exposes mfe config', () => {
+    expect(appIsMFERemote(targetNoExposes)).toBe(false);
+  });
+  it('should return true for remote apps with no mfe config', () => {
+    expect(appIsMFERemote(targetNone)).toBe(false);
+  });
 });

--- a/packages/eslint-plugin/src/utils/runtime-lint-utils.ts
+++ b/packages/eslint-plugin/src/utils/runtime-lint-utils.ts
@@ -501,3 +501,30 @@ function fileIsSecondaryEntryPoint(file: string, projectRoot: string): boolean {
   }
   return false;
 }
+
+/**
+ * Returns true if the given project contains MFE config with "exposes:" section
+ */
+export function appIsMFERemote(project: ProjectGraphProjectNode): boolean {
+  const mfeConfig =
+    readFileIfExisting(
+      joinPathFragments(
+        workspaceRoot,
+        project.data.root,
+        'module-federation.config.js'
+      )
+    ) ||
+    readFileIfExisting(
+      joinPathFragments(
+        workspaceRoot,
+        project.data.root,
+        'module-federation.config.ts'
+      )
+    );
+
+  if (mfeConfig) {
+    return !!mfeConfig.match(/('|")?exposes('|")?:/);
+  }
+
+  return false;
+}


### PR DESCRIPTION
This PR unblocks the new Type Safety for Module Federation.

In MFE setup, one app (or even a lib) can import resources from another remote.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
