### PR TITLE
chore(js): re-enable tsc tests and increase timeout for watch mode before erroring out

### DIFF
--- a/e2e/esbuild/src/esbuild.test.ts
+++ b/e2e/esbuild/src/esbuild.test.ts
@@ -106,8 +106,9 @@ describe('EsBuild Plugin', () => {
     readFile(`dist/libs/${myPkg}/assets/a.md`).includes('initial a');
     updateFile(`libs/${myPkg}/assets/a.md`, 'updated a');
     await expect(
-      waitUntil(() =>
-        readFile(`dist/libs/${myPkg}/assets/a.md`).includes('updated a')
+      waitUntil(
+        () => readFile(`dist/libs/${myPkg}/assets/a.md`).includes('updated a'),
+        { timeout: 15_000, ms: 1000 }
       )
     ).resolves.not.toThrow();
     watchProcess.kill();

--- a/e2e/js/src/js-executor-tsc.test.ts
+++ b/e2e/js/src/js-executor-tsc.test.ts
@@ -27,8 +27,7 @@ describe('js:tsc executor', () => {
   beforeAll(() => (scope = newProject()));
   afterAll(() => cleanupProject());
 
-  // TODO: Re-enable this when it is passing again
-  xit('should create libs with js executors (--compiler=tsc)', async () => {
+  it('xxxx should create libs with js executors (--compiler=tsc)', async () => {
     const lib = uniq('lib');
     runCLI(`generate @nx/js:lib ${lib} --bundler=tsc --no-interactive`);
     const libPackageJson = readJson(`libs/${lib}/package.json`);
@@ -71,20 +70,27 @@ describe('js:tsc executor', () => {
     });
     updateFile(`libs/${lib}/docs/a/b/nested.md`, 'Nested File');
     await expect(
-      waitUntil(() =>
-        readFile(`dist/libs/${lib}/README.md`).includes(`Hello, World!`)
+      waitUntil(
+        () => readFile(`dist/libs/${lib}/README.md`).includes(`Hello, World!`),
+        { timeout: 15_000, ms: 1000 }
       )
     ).resolves.not.toThrow();
     await expect(
-      waitUntil(() =>
-        readFile(`dist/libs/${lib}/docs/a/b/nested.md`).includes(`Nested File`)
+      waitUntil(
+        () =>
+          readFile(`dist/libs/${lib}/docs/a/b/nested.md`).includes(
+            `Nested File`
+          ),
+        { timeout: 15_000, ms: 1000 }
       )
     ).resolves.not.toThrow();
     await expect(
-      waitUntil(() =>
-        readFile(`dist/libs/${lib}/package.json`).includes(
-          `"version": "999.9.9"`
-        )
+      waitUntil(
+        () =>
+          readFile(`dist/libs/${lib}/package.json`).includes(
+            `"version": "999.9.9"`
+          ),
+        { timeout: 15_000, ms: 1000 }
       )
     ).resolves.not.toThrow();
     libBuildProcess.kill();


### PR DESCRIPTION
This PR increases the timeout when checking file updates (watch mode) so tests don't flake out as often.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
