### PR TITLE
fix(angular): throw an error when generating a component and the specified module can't be found

### DIFF
--- a/packages/angular/src/generators/component/component.spec.ts
+++ b/packages/angular/src/generators/component/component.spec.ts
@@ -781,6 +781,37 @@ describe('component Generator', () => {
       `);
     });
 
+    it('should throw an error when the module is not found', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+      addProjectConfiguration(tree, 'lib1', {
+        projectType: 'library',
+        sourceRoot: 'libs/lib1/src',
+        root: 'libs/lib1',
+      });
+      tree.write(
+        'libs/lib1/src/lib/lib.module.ts',
+        `
+    import { NgModule } from '@angular/core';
+    
+    @NgModule({
+      declarations: [],
+      exports: []
+    })
+    export class LibModule {}`
+      );
+
+      // ACT & ASSERT
+      await expect(
+        componentGenerator(tree, {
+          name: 'example',
+          project: 'lib1',
+          path: 'libs/lib1/src/lib',
+          module: 'not-found',
+        })
+      ).rejects.toThrow();
+    });
+
     it('should throw an error when there are more than one candidate modules that the component can be added to', async () => {
       // ARRANGE
       const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });

--- a/packages/angular/src/generators/component/lib/module.ts
+++ b/packages/angular/src/generators/component/lib/module.ts
@@ -3,9 +3,8 @@ import { joinPathFragments, normalizePath } from '@nx/devkit';
 import { basename, dirname } from 'path';
 import type { NormalizedSchema } from '../schema';
 
-// Adapted from https://github.com/angular/angular-cli/blob/main/packages/schematics/angular/utility/find-module.ts#L29
-// to match the logic in the component schematic. It doesn't throw if it can't
-// find a module since the schematic would have thrown before getting here.
+// Adapted from https://github.com/angular/angular-cli/blob/732aab5fa7e63618c89dfbbb6f78753f706d7014/packages/schematics/angular/utility/find-module.ts#L29
+// to match the logic from the Angular CLI component schematic.
 const moduleExt = '.module.ts';
 const routingModuleExt = '-routing.module.ts';
 
@@ -13,7 +12,7 @@ export function findModuleFromOptions(
   tree: Tree,
   options: NormalizedSchema,
   projectRoot: string
-): string | null {
+): string {
   if (!options.module) {
     return normalizePath(findModule(tree, options.directory, projectRoot));
   } else {
@@ -49,7 +48,12 @@ export function findModuleFromOptions(
       }
     }
 
-    return null;
+    throw new Error(
+      `Specified module '${options.module}' does not exist.\n` +
+        `Looked in the following directories:\n    ${candidatesDirs.join(
+          '\n    '
+        )}`
+    );
   }
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When generating a component, a cryptic error is thrown if the specified `module` can't be found.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When generating a component, a meaningful error should be thrown if the specified `module` can't be found.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #19182 
