### PR TITLE
feat(react): support typescript webpack config file

### DIFF
--- a/docs/generated/packages/react/generators/application.json
+++ b/docs/generated/packages/react/generators/application.json
@@ -188,6 +188,11 @@
         "description": "Generate a React app with a minimal setup, no separate test files.",
         "type": "boolean",
         "default": false
+      },
+      "typescriptConfiguration": {
+        "type": "boolean",
+        "description": "Whether the module federation configuration and webpack configuration files should use TS.",
+        "default": false
       }
     },
     "required": ["name"],

--- a/e2e/react-core/src/react.test.ts
+++ b/e2e/react-core/src/react.test.ts
@@ -363,6 +363,26 @@ describe('React Applications', () => {
       expect(buildResults.combinedOutput).not.toMatch(/HELLO FROM LIB/);
     }, 250_000);
   });
+
+  it('should generate a react app with webpack typescript enabled', async () => {
+    const appName = uniq('app');
+    runCLI(
+      `generate @nx/react:app ${appName} --bundler=webpack --style=scss --typescriptConfiguration=true --no-interactive`
+    );
+
+    checkFilesExist(`apps/${appName}/webpack.config.ts`);
+
+    // Check build works
+    expect(runCLI(`build ${appName}`)).toContain(
+      `Successfully ran target build for project ${appName}`
+    );
+
+    // check tests pass
+    const appTestResult = runCLI(`test ${appName}`);
+    expect(appTestResult).toContain(
+      `Successfully ran target test for project ${appName}`
+    );
+  });
 });
 
 async function testGeneratedApp(

--- a/packages/react/src/generators/application/files/base-webpack/webpack.config.js__tmpl__
+++ b/packages/react/src/generators/application/files/base-webpack/webpack.config.js__tmpl__
@@ -1,9 +1,0 @@
-const { composePlugins, withNx } = require('@nx/webpack');
-const { withReact } = require('@nx/react');
-
-// Nx plugins for webpack.
-module.exports = composePlugins(withNx(), withReact(), (config) => {
-  // Update the webpack config as needed here.
-  // e.g. `config.plugins.push(new MyPlugin())`
-  return config;
-});

--- a/packages/react/src/generators/application/lib/add-project.ts
+++ b/packages/react/src/generators/application/lib/add-project.ts
@@ -70,7 +70,9 @@ function createBuildTarget(options: NormalizedSchema): TargetConfiguration {
       isolatedConfig: true,
       webpackConfig: joinPathFragments(
         options.appProjectRoot,
-        'webpack.config.js'
+        options.typescriptConfiguration
+          ? 'webpack.config.ts'
+          : 'webpack.config.js'
       ),
     },
     configurations: {

--- a/packages/react/src/generators/application/lib/create-application-files.ts
+++ b/packages/react/src/generators/application/lib/create-application-files.ts
@@ -1,5 +1,6 @@
 import {
   generateFiles,
+  joinPathFragments,
   names,
   offsetFromRoot,
   toJS,
@@ -55,6 +56,31 @@ export function createApplicationFiles(host: Tree, options: NormalizedSchema) {
       options.appProjectRoot,
       templateVariables
     );
+
+    const configFileName = joinPathFragments(
+      options.appProjectRoot,
+      options.typescriptConfiguration
+        ? 'webpack.config.ts'
+        : 'webpack.config.js'
+    );
+
+    const configContent = options.typescriptConfiguration
+      ? `
+import { composePlugins, withNx } from '@nx/webpack';
+import { withReact } from '@nx/react';
+
+export default composePlugins(withNx(), withReact());
+`
+      : `
+const { composePlugins, withNx } = require('@nx/webpack');
+const { withReact } = require('@nx/react');
+
+module.exports = composePlugins(withNx(), withReact(), (config) => {
+  return config; // Update config as needed.
+});
+`;
+    host.write(configFileName, configContent);
+
     if (options.compiler === 'babel') {
       writeJson(host, `${options.appProjectRoot}/.babelrc`, {
         presets: [

--- a/packages/react/src/generators/application/lib/normalize-options.ts
+++ b/packages/react/src/generators/application/lib/normalize-options.ts
@@ -80,6 +80,8 @@ export async function normalizeOptions<T extends Schema = Schema>(
   normalized.inSourceTests = normalized.minimal || normalized.inSourceTests;
   normalized.devServerPort ??= findFreePort(host);
   normalized.minimal = normalized.minimal ?? false;
+  normalized.typescriptConfiguration =
+    normalized.typescriptConfiguration ?? false;
 
   return normalized;
 }

--- a/packages/react/src/generators/application/schema.d.ts
+++ b/packages/react/src/generators/application/schema.d.ts
@@ -40,4 +40,5 @@ export interface NormalizedSchema<T extends Schema = Schema> extends T {
   styledModule: null | SupportedStyles;
   hasStyles: boolean;
   unitTestRunner: 'jest' | 'vitest' | 'none';
+  typescriptConfiguration: boolean;
 }

--- a/packages/react/src/generators/application/schema.json
+++ b/packages/react/src/generators/application/schema.json
@@ -194,6 +194,11 @@
       "description": "Generate a React app with a minimal setup, no separate test files.",
       "type": "boolean",
       "default": false
+    },
+    "typescriptConfiguration": {
+      "type": "boolean",
+      "description": "Whether the module federation configuration and webpack configuration files should use TS.",
+      "default": false
     }
   },
   "required": ["name"],


### PR DESCRIPTION
## What has been changed

This PR updates our react generator option `--typescriptConfiguration` this option when set to `true` will generate a `webpack.config.ts` instead of a `webpack.config.js`.

It also updates the `project.json` to point to the typescript webpack config.