### PR TITLE
fix(nx): fix Sentry example in plugin docs

### DIFF
--- a/docs/shared/packages/next/next-config-setup.md
+++ b/docs/shared/packages/next/next-config-setup.md
@@ -125,7 +125,8 @@ module.exports = async (phase, context) => {
 
   // If you have plugins that has to be added after Nx you can do that here.
   // For example, Sentry needs to be added last.
-  updatedConfig = require('@sentry/nextjs')(updatedConfig, { silent: true });
+  const { withSentryConfig } = require('@sentry/nextjs');
+  updatedConfig = withSentryConfig(updatedConfig, { silent: true });
 
   return updatedConfig;
 };

--- a/docs/shared/packages/next/next-config-setup.md
+++ b/docs/shared/packages/next/next-config-setup.md
@@ -126,7 +126,7 @@ module.exports = async (phase, context) => {
   // If you have plugins that has to be added after Nx you can do that here.
   // For example, Sentry needs to be added last.
   const { withSentryConfig } = require('@sentry/nextjs');
-  updatedConfig = withSentryConfig(updatedConfig, { silent: true });
+  updatedConfig = withSentryConfig(updatedConfig);
 
   return updatedConfig;
 };


### PR DESCRIPTION
I noticed that the current Sentry example in the plugin documentation is a bit wrong. This PR fixes that.
