### PR TITLE
fix(core): add quotes to args with spaces

### DIFF
--- a/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
@@ -179,6 +179,16 @@ describe('Run Commands', () => {
         )
       ).toEqual('echo one -a=b');
     });
+
+    it('should wrap unparsed args with spaces if necessary', () => {
+      expect(
+        interpolateArgsIntoCommand(
+          'react-native',
+          { __unparsed__: ['run-ios', '--simulator=iPhone 14 Pro'] } as any,
+          true
+        )
+      ).toEqual('react-native run-ios "--simulator=iPhone 14 Pro"');
+    });
   });
 
   describe('--color', () => {

--- a/packages/nx/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.ts
@@ -299,11 +299,17 @@ export function interpolateArgsIntoCommand(
     return command.replace(regex, (_, group: string) => opts.parsedArgs[group]);
   } else if (forwardAllArgs) {
     return `${command}${
-      opts.__unparsed__.length > 0 ? ' ' + opts.__unparsed__.join(' ') : ''
+      opts.__unparsed__.length > 0
+        ? ' ' + opts.__unparsed__.map(wrapInQuotesIfNeeded).join(' ')
+        : ''
     }`;
   } else {
     return command;
   }
+}
+
+function wrapInQuotesIfNeeded(arg: string) {
+  return arg.indexOf(' ') > -1 ? `"${arg}"` : arg;
 }
 
 function parseArgs(options: RunCommandsOptions) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Running a command and providing additional arguments fails if the arguments contain spaces, even if they're properly surrounded in quotes.

For example:

```
nx build-ios --simulator="iPhone 14 Pro"
```

fails, because the executed command is actually:

```
<command> --simulator=iPhone 14 Pro
```

which isn't correct.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

I would've expected the original quotes be preserved, like:

```
<command> --simulator="iPhone 14 Pro"
```

but apparently that's not possible. Node doesn't have the quotes in the `process.argv` object, and apparently that's because [the shell itself removes them](https://stackoverflow.com/questions/10830418/how-to-prevent-losing-double-quotes-in-argv).

So instead, I might expect that args are automatically wrapped in quotes if deemed necessary, like:

```
<command> "--simulator=iPhone 14 Pro"
```

which does have the desired behaviour.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

I didn't make an issue yet unfortunately 😅 let me know if this is necessary

<!-- Fixes # -->
