### PR TITLE
fix(core): set prerelease on Github request for nx release changelog

### DIFF
--- a/packages/nx/src/command-line/release/utils/github.ts
+++ b/packages/nx/src/command-line/release/utils/github.ts
@@ -53,7 +53,7 @@ export function getGitHubRemote(remoteName = 'origin') {
 
 export async function createOrUpdateGithubRelease(
   githubRequestConfig: GithubRequestConfig,
-  release: { version: string; body: string },
+  release: { version: string; body: string; prerelease: boolean },
   existingGithubReleaseForVersion?: GithubRelease
 ) {
   const result = await syncGithubRelease(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

All Github releases created by `nx release changelog` are a latest/full release.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Github releases created by `nx release changelog` are a latest/full release if they are a non-prerelease version, otherwise they are marked as a prerelease.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
