### PR TITLE
fix(react): make typescript configuration for mf false by default

### DIFF
--- a/docs/generated/packages/react/generators/host.json
+++ b/docs/generated/packages/react/generators/host.json
@@ -164,7 +164,7 @@
       "typescriptConfiguration": {
         "type": "boolean",
         "description": "Whether the module federation configuration and webpack configuration files should use TS.",
-        "default": true
+        "default": false
       }
     },
     "required": ["name"],

--- a/docs/generated/packages/react/generators/remote.json
+++ b/docs/generated/packages/react/generators/remote.json
@@ -162,7 +162,7 @@
       "typescriptConfiguration": {
         "type": "boolean",
         "description": "Whether the module federation configuration and webpack configuration files should use TS.",
-        "default": true
+        "default": false
       }
     },
     "required": ["name"],

--- a/e2e/react-core/src/react-module-federation.test.ts
+++ b/e2e/react-core/src/react-module-federation.test.ts
@@ -39,10 +39,10 @@ describe('React Module Federation', () => {
       `generate @nx/react:remote ${remote3} --style=css --host=${shell} --no-interactive`
     );
 
-    checkFilesExist(`apps/${shell}/module-federation.config.ts`);
-    checkFilesExist(`apps/${remote1}/module-federation.config.ts`);
-    checkFilesExist(`apps/${remote2}/module-federation.config.ts`);
-    checkFilesExist(`apps/${remote3}/module-federation.config.ts`);
+    checkFilesExist(`apps/${shell}/module-federation.config.js`);
+    checkFilesExist(`apps/${remote1}/module-federation.config.js`);
+    checkFilesExist(`apps/${remote2}/module-federation.config.js`);
+    checkFilesExist(`apps/${remote3}/module-federation.config.js`);
 
     await expect(runCLIAsync(`test ${shell}`)).resolves.toMatchObject({
       combinedOutput: expect.stringContaining('Test Suites: 1 passed, 1 total'),
@@ -54,7 +54,7 @@ describe('React Module Federation', () => {
     expect(readPort(remote3)).toEqual(4203);
 
     updateFile(
-      `apps/${shell}/webpack.config.ts`,
+      `apps/${shell}/webpack.config.js`,
       stripIndents`
         import { composePlugins, withNx, ModuleFederationConfig } from '@nx/webpack';
         import { withReact } from '@nx/react';
@@ -135,8 +135,8 @@ describe('React Module Federation', () => {
 
     // check files are generated without the layout directory ("apps/") and
     // using the project name as the directory when no directory is provided
-    checkFilesExist(`${shell}/module-federation.config.ts`);
-    checkFilesExist(`${remote}/module-federation.config.ts`);
+    checkFilesExist(`${shell}/module-federation.config.js`);
+    checkFilesExist(`${remote}/module-federation.config.js`);
 
     // check default generated host is built successfully
     const buildOutput = runCLI(`run ${shell}:build:development`);
@@ -292,45 +292,27 @@ describe('React Module Federation', () => {
 
     // update host and remote to use library type var
     updateFile(
-      `${shell}/module-federation.config.ts`,
+      `${shell}/module-federation.config.js`,
       stripIndents`
-      import { ModuleFederationConfig } from '@nx/webpack';
-
-      const config: ModuleFederationConfig = {
+      module.exports = {
         name: '${shell}',
         library: { type: 'var', name: '${shell}' },
         remotes: ['${remote}'],
       };
-
-      export default config;
       `
     );
 
     updateFile(
-      `${shell}/webpack.config.prod.ts`,
-      `export { default } from './webpack.config';`
-    );
-
-    updateFile(
-      `${remote}/module-federation.config.ts`,
+      `${remote}/module-federation.config.js`,
       stripIndents`
-      import { ModuleFederationConfig } from '@nx/webpack';
-
-      const config: ModuleFederationConfig = {
+      module.exports = {
         name: '${remote}',
         library: { type: 'var', name: '${remote}' },
         exposes: {
           './Module': './src/remote-entry.ts',
         },
       };
-
-      export default config;
       `
-    );
-
-    updateFile(
-      `${remote}/webpack.config.prod.ts`,
-      `export { default } from './webpack.config';`
     );
 
     // Update host e2e test to check that the remote works with library type var via navigation

--- a/packages/react/src/generators/host/host.ts
+++ b/packages/react/src/generators/host/host.ts
@@ -32,7 +32,7 @@ export async function hostGeneratorInternal(host: Tree, schema: Schema) {
   const tasks: GeneratorCallback[] = [];
   const options: NormalizedSchema = {
     ...(await normalizeOptions<Schema>(host, schema, '@nx/react:host')),
-    typescriptConfiguration: schema.typescriptConfiguration ?? true,
+    typescriptConfiguration: schema.typescriptConfiguration ?? false,
   };
 
   const initTask = await applicationGenerator(host, {

--- a/packages/react/src/generators/host/schema.json
+++ b/packages/react/src/generators/host/schema.json
@@ -170,7 +170,7 @@
     "typescriptConfiguration": {
       "type": "boolean",
       "description": "Whether the module federation configuration and webpack configuration files should use TS.",
-      "default": true
+      "default": false
     }
   },
   "required": ["name"],

--- a/packages/react/src/generators/remote/remote.ts
+++ b/packages/react/src/generators/remote/remote.ts
@@ -70,7 +70,7 @@ export async function remoteGeneratorInternal(host: Tree, schema: Schema) {
   const tasks: GeneratorCallback[] = [];
   const options: NormalizedSchema<Schema> = {
     ...(await normalizeOptions<Schema>(host, schema, '@nx/react:remote')),
-    typescriptConfiguration: schema.typescriptConfiguration ?? true,
+    typescriptConfiguration: schema.typescriptConfiguration ?? false,
   };
   const initAppTask = await applicationGenerator(host, {
     ...options,

--- a/packages/react/src/generators/remote/schema.json
+++ b/packages/react/src/generators/remote/schema.json
@@ -168,7 +168,7 @@
     "typescriptConfiguration": {
       "type": "boolean",
       "description": "Whether the module federation configuration and webpack configuration files should use TS.",
-      "default": true
+      "default": false
     }
   },
   "required": ["name"],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`--devRemotes` is throwing a transpilation error when using typescript configuration true 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Make `typescriptConfiguration` false by default to prevent users encountering this issue for the time being

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
