### PR TITLE
docs(core): commands link under reference

### DIFF
--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -4630,6 +4630,14 @@
         "isExternal": false,
         "children": [
           {
+            "name": "Commands",
+            "path": "/nx-api/nx",
+            "id": "commands",
+            "isExternal": true,
+            "children": [],
+            "disableCollapsible": false
+          },
+          {
             "name": "Nx Configuration",
             "path": "/reference/nx-json",
             "id": "nx-json",
@@ -4670,6 +4678,14 @@
             "disableCollapsible": false
           }
         ],
+        "disableCollapsible": false
+      },
+      {
+        "name": "Commands",
+        "path": "/nx-api/nx",
+        "id": "commands",
+        "isExternal": true,
+        "children": [],
         "disableCollapsible": false
       },
       {

--- a/docs/generated/manifests/nx.json
+++ b/docs/generated/manifests/nx.json
@@ -5774,6 +5774,16 @@
     "file": "",
     "itemList": [
       {
+        "id": "commands",
+        "name": "Commands",
+        "description": "",
+        "file": "",
+        "itemList": [],
+        "isExternal": true,
+        "path": "/nx-api/nx",
+        "tags": []
+      },
+      {
         "id": "nx-json",
         "name": "Nx Configuration",
         "description": "",
@@ -5826,6 +5836,16 @@
     ],
     "isExternal": false,
     "path": "/reference",
+    "tags": []
+  },
+  "/nx-api/nx": {
+    "id": "commands",
+    "name": "Commands",
+    "description": "",
+    "file": "",
+    "itemList": [],
+    "isExternal": true,
+    "path": "/nx-api/nx",
     "tags": []
   },
   "/reference/nx-json": {

--- a/docs/map.json
+++ b/docs/map.json
@@ -1279,6 +1279,13 @@
           "description": "Understand how to use Nx functionalities, what arguments and options are available for each component.",
           "itemList": [
             {
+              "name": "Commands",
+              "id": "commands",
+              "file": "",
+              "path": "/nx-api/nx",
+              "isExternal": true
+            },
+            {
               "name": "Nx Configuration",
               "id": "nx-json",
               "file": "shared/reference/nx-json"


### PR DESCRIPTION
Adds a link to the Nx commands under the reference section