### PR TITLE
fix(angular): update tsconfig included and excluded files when generating a library secondary entry point

### DIFF
--- a/packages/angular/src/generators/library-secondary-entry-point/lib/index.ts
+++ b/packages/angular/src/generators/library-secondary-entry-point/lib/index.ts
@@ -2,3 +2,4 @@ export * from './add-files';
 export * from './add-path-mapping';
 export * from './normalize-options';
 export * from './update-linting-file-patterns';
+export * from './update-tsconfig-included-files';

--- a/packages/angular/src/generators/library-secondary-entry-point/lib/update-tsconfig-included-files.ts
+++ b/packages/angular/src/generators/library-secondary-entry-point/lib/update-tsconfig-included-files.ts
@@ -1,0 +1,37 @@
+import { joinPathFragments, updateJson, type Tree } from '@nx/devkit';
+import type { NormalizedGeneratorOptions } from '../schema';
+
+export function updateTsConfigIncludedFiles(
+  tree: Tree,
+  options: NormalizedGeneratorOptions
+): void {
+  const candidateTsConfigPaths = [
+    options.libraryProject.targets?.build?.options?.tsConfig,
+    joinPathFragments(options.libraryProject.root, 'tsconfig.lib.json'),
+    joinPathFragments(options.libraryProject.root, 'tsconfig.json'),
+  ];
+
+  const tsConfigPath = candidateTsConfigPaths.find(
+    (path) => path && tree.exists(path)
+  );
+  if (!tsConfigPath) {
+    // ignore if the library has a custom tsconfig setup
+    return;
+  }
+
+  updateJson(tree, tsConfigPath, (json) => {
+    if (json.include?.length) {
+      json.include = json.include.map((path: string) =>
+        path.replace(/^(?:\.\/)?src\//, '')
+      );
+    }
+
+    if (json.exclude?.length) {
+      json.exclude = json.exclude.map((path: string) =>
+        path.replace(/^(?:\.\/)?src\//, '')
+      );
+    }
+
+    return json;
+  });
+}

--- a/packages/angular/src/generators/library-secondary-entry-point/library-secondary-entry-point.spec.ts
+++ b/packages/angular/src/generators/library-secondary-entry-point/library-secondary-entry-point.spec.ts
@@ -6,6 +6,7 @@ import {
   Tree,
 } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { generateTestLibrary } from '../utils/testing';
 import { librarySecondaryEntryPointGenerator } from './library-secondary-entry-point';
 
 describe('librarySecondaryEntryPoint generator', () => {
@@ -178,6 +179,38 @@ describe('librarySecondaryEntryPoint generator', () => {
         'libs/lib1/testing/**/*.html',
       ])
     );
+  });
+
+  it('should update the tsconfig "include" and "exclude" options', async () => {
+    await generateTestLibrary(tree, {
+      name: 'lib1',
+      directory: 'libs/lib1',
+      importPath: '@my-org/lib1',
+      publishable: true,
+    });
+    // verify initial state
+    let tsConfig = readJson(tree, 'libs/lib1/tsconfig.lib.json');
+    expect(tsConfig.include).toStrictEqual(['src/**/*.ts']);
+    expect(tsConfig.exclude).toStrictEqual([
+      'src/**/*.spec.ts',
+      'src/test-setup.ts',
+      'jest.config.ts',
+      'src/**/*.test.ts',
+    ]);
+
+    await librarySecondaryEntryPointGenerator(tree, {
+      name: 'testing',
+      library: 'lib1',
+    });
+
+    tsConfig = readJson(tree, 'libs/lib1/tsconfig.lib.json');
+    expect(tsConfig.include).toStrictEqual(['**/*.ts']);
+    expect(tsConfig.exclude).toStrictEqual([
+      '**/*.spec.ts',
+      'test-setup.ts',
+      'jest.config.ts',
+      '**/*.test.ts',
+    ]);
   });
 
   it('should format files', async () => {

--- a/packages/angular/src/generators/library-secondary-entry-point/library-secondary-entry-point.ts
+++ b/packages/angular/src/generators/library-secondary-entry-point/library-secondary-entry-point.ts
@@ -4,6 +4,7 @@ import {
   addPathMapping,
   normalizeOptions,
   updateLintingFilePatterns,
+  updateTsConfigIncludedFiles,
 } from './lib';
 import { GeneratorOptions } from './schema';
 
@@ -15,6 +16,7 @@ export async function librarySecondaryEntryPointGenerator(
 
   addFiles(tree, options);
   addPathMapping(tree, options);
+  updateTsConfigIncludedFiles(tree, options);
   updateLintingFilePatterns(tree, options);
 
   await formatFiles(tree);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Generating a library secondary entry point doesn't update the tsconfig included and excluded file patterns.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Generating a library secondary entry point should update the relevant tsconfig included and excluded file patterns.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #19038 
