### PR TITLE
docs(core): fix typos

### DIFF
--- a/.github/workflows/do-not-merge.yml
+++ b/.github/workflows/do-not-merge.yml
@@ -1,4 +1,4 @@
-name: Unmergaeble Labels Check
+name: Unmergeable Labels Check
 
 on:
   pull_request:

--- a/.github/workflows/do-not-merge.yml
+++ b/.github/workflows/do-not-merge.yml
@@ -1,4 +1,4 @@
-name: Unmergable Labels Check
+name: Unmergaeble Labels Check
 
 on:
   pull_request:


### PR DESCRIPTION
## Description
It changes the name of `.github/workflows/do-not-merge.yaml` Github Workflow from `Unmergable Labels Check` to `Unmergeable Labels Check`.

## Current Behavior
A running workflow with a typo on its name.

## Expected Behavior
A running workflow without typos on its name.

## Related Issue(s)
No related issues.

Fixes #
It doesn't fix an specific issue. At most, fixes a typo.
