### PR TITLE
fix(linter): resolved @nx/dependency-checks ignoring devDependencies

### DIFF
--- a/packages/eslint-plugin/src/rules/dependency-checks.spec.ts
+++ b/packages/eslint-plugin/src/rules/dependency-checks.spec.ts
@@ -1538,7 +1538,7 @@ describe('Dependency checks (eslint)', () => {
     expect(failures[0].line).toEqual(3);
   });
 
-  it('should report missing package if it is in devDependencies', () => {
+  it("shouldn't report missing package if it is in devDependencies", () => {
     const packageJson = {
       name: '@mycompany/liba',
       dependencies: {},
@@ -1583,11 +1583,7 @@ describe('Dependency checks (eslint)', () => {
         ],
       }
     );
-    expect(failures.length).toEqual(1);
-    expect(failures[0].message).toMatchInlineSnapshot(`
-      "The "liba" project uses the following packages, but they are missing from "dependencies":
-          - external1"
-    `);
+    expect(failures.length).toEqual(0);
   });
 });
 

--- a/packages/eslint-plugin/src/utils/package-json-utils.ts
+++ b/packages/eslint-plugin/src/utils/package-json-utils.ts
@@ -21,6 +21,7 @@ export function getProductionDependencies(
     const packageJson = getPackageJson(packageJsonPath);
     globalThis.projPackageJsonDeps = {
       ...packageJson.dependencies,
+      ...packageJson.devDependencies,
       ...packageJson.peerDependencies,
       ...packageJson.optionalDependencies,
     };


### PR DESCRIPTION
closes #19307

## Current Behavior
As pointed out in the issue, the plugin gave an error for not including the package in the `package.json` file while it was present in the `devDependencies`.

## Expected Behavior
If the package is present in the `devDependencies`, the error should not occur.
