### PR TITLE
docs(nx-plugin): made code example for extending project graph match the current api

### DIFF
--- a/docs/shared/recipes/plugins/project-graph-plugins.md
+++ b/docs/shared/recipes/plugins/project-graph-plugins.md
@@ -57,7 +57,7 @@ A simplified version of Nx's built-in `project.json` plugin is shown below, whic
 
 ```typescript {% fileName="/my-plugin/index.ts" %}
 export const createNodes: CreateNodes = [
-  'project.json',
+  '**/project.json',
   (projectConfigurationFile: string, context: CreateNodesContext) => {
     const projectConfiguration = readJson(projectConfigurationFile);
     const projectRoot = dirname(projectConfigurationFile);


### PR DESCRIPTION
Currently, the code example is to match all project.json in the workspace, however the api requires a glob to match all files, and thus, this example was only matching the project.json at the root instead of, like described in the docs, all project.json. This PR aim is to fix it.

Source:
Nx conf 2023, with exact timestamp: https://youtu.be/IQ5YyEYZw68?t=9052
Internal usage : https://github.com/nrwl/nx/blob/e29e9f90b6c5cf2a5b686327d68de15b873c7c4c/packages/nx/plugins/package-json.ts#L5-L8


## Current Behavior
The docs example for the new inference api is wrong for the `CreateNodes` example (see (here)[https://nx.dev/extending-nx/recipes/project-graph-plugins#example]) 

## Expected Behavior
This should use a glob instead of the file name


**Disclamer**
While generating the docs locally, this command failed :
```
Error: Command failed: rm -rf docs/generated/devkit && pnpm typedoc build/packages/devkit/index.d.ts --tsconfig build/packages/devkit/tsconfig.lib.json --out ./docs/generated/devkit --plugin typedoc-plugin-markdown --plugin @nx/typedoc-theme --hideBreadcrumbs true --disableSources --allReflectionsHaveOwnDocument --publicPath ../../devkit/ --theme nx-markdown-theme --excludePrivate --readme none
```

because typescript was not compiling the `nx` package (see logs). I don't think this affect my changes, but I wanted to raise this just in case.

<details><summary>TS Error log</summary>

```

[info] Loaded plugin typedoc-plugin-markdown
[info] Loaded plugin @nx/typedoc-theme
packages/nx/src/utils/command-line-utils.ts:49:18 - error TS2339: Property '_' does not exist on type '{}'.

49   if (!overrides._ || overrides._.length === 0) {
                    ~

packages/nx/src/utils/command-line-utils.ts:49:33 - error TS2339: Property '_' does not exist on type '{}'.

49   if (!overrides._ || overrides._.length === 0) {
                                   ~

packages/nx/src/utils/command-line-utils.ts:50:22 - error TS2339: Property '_' does not exist on type '{}'.

50     delete overrides._;
                        ~

packages/nx/src/utils/command-line-utils.ts:53:13 - error TS2339: Property '__overrides_unparsed__' does not exist on type '{}'.

53   overrides.__overrides_unparsed__ = __overrides_unparsed__;
               ~~~~~~~~~~~~~~~~~~~~~~

Error: Command failed: rm -rf docs/generated/devkit && pnpm typedoc build/packages/devkit/index.d.ts --tsconfig build/packages/devkit/tsconfig.lib.json --out ./docs/generated/devkit --plugin typedoc-plugin-markdown --plugin @nx/typedoc-theme --hideBreadcrumbs true --disableSources --allReflectionsHaveOwnDocument --publicPath ../../devkit/ --theme nx-markdown-theme --excludePrivate --readme none

```

</details>

