### PR TITLE
fix(angular): do not set less math option in ng-packagr executors

### DIFF
--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/styles/stylesheet-processor.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/styles/stylesheet-processor.ts
@@ -277,7 +277,6 @@ export class StylesheetProcessor {
           await import('less')
         ).render(css, {
           filename: filePath,
-          math: 'always',
           javascriptEnabled: true,
           paths: this.styleIncludePaths,
         });

--- a/packages/angular/src/executors/package/ng-packagr-adjustments/styles/stylesheet-processor.ts
+++ b/packages/angular/src/executors/package/ng-packagr-adjustments/styles/stylesheet-processor.ts
@@ -270,7 +270,6 @@ export class StylesheetProcessor {
           await import('less')
         ).render(css, {
           filename: filePath,
-          math: 'always',
           javascriptEnabled: true,
           paths: this.styleIncludePaths,
         });


### PR DESCRIPTION
Align the implementation with that of the Angular CLI ng-packagr builder.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
