### PR TITLE
fix(testing): install devkit when init playwright

### DIFF
--- a/packages/playwright/src/generators/init/init.ts
+++ b/packages/playwright/src/generators/init/init.ts
@@ -23,6 +23,8 @@ export async function initGenerator(tree: Tree, options: InitGeneratorSchema) {
         {},
         {
           '@nx/playwright': nxVersion,
+          // required since used in playwright config
+          '@nx/devkit': nxVersion,
           '@playwright/test': playwrightVersion,
         }
       )


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->


playwright generated config uses `@nx/devkit` which is not installed via playwright plugin
This usually works bc devkit is installed, but when using nx global install with pnpm
playwright an error is through saying it cannot find devkit
```
❯ nx e2e demo-e2e --skip-nx-cache

> nx run demo-e2e:e2e

 >  NX   Ensuring Playwright is installed.
   use --skipInstall to skip installation.
Error: Cannot find module '@nx/devkit'
Require stack:
- /Users/caleb/Work/sandbox/playwright-devkit/apps/demo-e2e/playwright.config.ts
- /Users/caleb/Work/sandbox/playwright-devkit/node_modules/.pnpm/@playwright+test@1.36.0/node_modules/@playwright/test/lib/transform/transform.js
- /Users/caleb/Work/sandbox/playwright-devkit/node_modules/.pnpm/@playwright+test@1.36.0/node_modules/@playwright/test/lib/common/config.js
- /Users/caleb/Work/sandbox/playwright-devkit/node_modules/.pnpm/@playwright+test@1.36.0/node_modules/@playwright/test/lib/reporters/json.js
- /Users/caleb/Work/sandbox/playwright-devkit/node_modules/.pnpm/@playwright+test@1.36.0/node_modules/@playwright/test/lib/reporters/raw.js
- /Users/caleb/Work/sandbox/playwright-devkit/node_modules/.pnpm/@playwright+test@1.36.0/node_modules/@playwright/test/lib/reporters/html.js
- /Users/caleb/Work/sandbox/playwright-devkit/node_modules/.pnpm/@playwright+test@1.36.0/node_modules/@playwright/test/lib/runner/reporters.js
- /Users/caleb/Work/sandbox/playwright-devkit/node_modules/.pnpm/@playwright+test@1.36.0/node_modules/@playwright/test/lib/runner/runner.js
- /Users/caleb/Work/sandbox/playwright-devkit/node_modules/.pnpm/@playwright+test@1.36.0/node_modules/@playwright/test/lib/cli.js
- /Users/caleb/Work/sandbox/playwright-devkit/node_modules/.pnpm/@playwright+test@1.36.0/node_modules/@playwright/test/cli.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:1075:15)
    at Function.resolveFilename (/Users/caleb/Work/sandbox/playwright-devkit/node_modules/.pnpm/@playwright+test@1.36.0/node_modules/@playwright/test/lib/transform/transform.js:191:36)
    at Function.Module._load (node:internal/modules/cjs/loader:920:27)
    at Module.require (node:internal/modules/cjs/loader:1141:19)
    at require (node:internal/modules/cjs/helpers:110:18)
    at Object.<anonymous> (/Users/caleb/Work/sandbox/playwright-devkit/apps/demo-e2e/playwright.config.ts:4:1)
    at Module._compile (node:internal/modules/cjs/loader:1254:14)
    at Module.f._compile (/Users/caleb/Work/sandbox/playwright-devkit/node_modules/.pnpm/@playwright+test@1.36.0/node_modules/@playwright/test/lib/utilsBundleImpl.js:16:994)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Object.i.<computed>.ut._extensions.<computed> (/Users/caleb/Work/sandbox/playwright-devkit/node_modules/.pnpm/@playwright+test@1.36.0/node_modules/@playwright/test/lib/utilsBundleImpl.js:16:1010)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Function.Module._load (node:internal/modules/cjs/loader:958:12)
    at Module.require (node:internal/modules/cjs/loader:1141:19)
    at require (node:internal/modules/cjs/helpers:110:18)
    at requireOrImport (/Users/caleb/Work/sandbox/playwright-devkit/node_modules/.pnpm/@playwright+test@1.36.0/node_modules/@playwright/test/lib/transform/transform.js:172:20)
    at requireOrImportDefaultObject (/Users/caleb/Work/sandbox/playwright-devkit/node_modules/.pnpm/@playwright+test@1.36.0/node_modules/@playwright/test/lib/common/configLoader.js:83:53)
    at ConfigLoader.loadConfigFile (/Users/caleb/Work/sandbox/playwright-devkit/node_modules/.pnpm/@playwright+test@1.36.0/node_modules/@playwright/test/lib/common/configLoader.js:56:26)
    at runTests (/Users/caleb/Work/sandbox/playwright-devkit/node_modules/.pnpm/@playwright+test@1.36.0/node_modules/@playwright/test/lib/cli.js:120:55)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at qr.<anonymous> (/Users/caleb/Work/sandbox/playwright-devkit/node_modules/.pnpm/@playwright+test@1.36.0/node_modules/@playwright/test/lib/cli.js:40:7) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/caleb/Work/sandbox/playwright-devkit/apps/demo-e2e/playwright.config.ts',
    '/Users/caleb/Work/sandbox/playwright-devkit/node_modules/.pnpm/@playwright+test@1.36.0/node_modules/@playwright/test/lib/transform/transform.js',
    '/Users/caleb/Work/sandbox/playwright-devkit/node_modules/.pnpm/@playwright+test@1.36.0/node_modules/@playwright/test/lib/common/config.js',
    '/Users/caleb/Work/sandbox/playwright-devkit/node_modules/.pnpm/@playwright+test@1.36.0/node_modules/@playwright/test/lib/reporters/json.js',
    '/Users/caleb/Work/sandbox/playwright-devkit/node_modules/.pnpm/@playwright+test@1.36.0/node_modules/@playwright/test/lib/reporters/raw.js',
    '/Users/caleb/Work/sandbox/playwright-devkit/node_modules/.pnpm/@playwright+test@1.36.0/node_modules/@playwright/test/lib/reporters/html.js',
    '/Users/caleb/Work/sandbox/playwright-devkit/node_modules/.pnpm/@playwright+test@1.36.0/node_modules/@playwright/test/lib/runner/reporters.js',
    '/Users/caleb/Work/sandbox/playwright-devkit/node_modules/.pnpm/@playwright+test@1.36.0/node_modules/@playwright/test/lib/runner/runner.js',
    '/Users/caleb/Work/sandbox/playwright-devkit/node_modules/.pnpm/@playwright+test@1.36.0/node_modules/@playwright/test/lib/cli.js',
    '/Users/caleb/Work/sandbox/playwright-devkit/node_modules/.pnpm/@playwright+test@1.36.0/node_modules/@playwright/test/cli.js'
  ]
}

 ———————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 >  NX   Ran target e2e for project demo-e2e (999ms)

    ✖    1/1 failed
    ✔    0/1 succeeded [0 read from cache]

```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

playwright runs from both local and global installs

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
