### PR TITLE
fix(core): prettier getSupportInfo use promises

### DIFF
--- a/packages/nx/src/command-line/format/format.ts
+++ b/packages/nx/src/command-line/format/format.ts
@@ -81,9 +81,8 @@ async function getPatterns(
 
     const p = parseFiles(args);
 
-    const supportedExtensions = (await prettier
-      .getSupportInfo())
-      .languages.flatMap((language) => language.extensions)
+    const supportedExtensions = (await prettier.getSupportInfo()).languages
+      .flatMap((language) => language.extensions)
       .filter((extension) => !!extension)
       // Prettier supports ".swcrc" as a file instead of an extension
       // So we add ".swcrc" as a supported extension manually

--- a/packages/nx/src/command-line/format/format.ts
+++ b/packages/nx/src/command-line/format/format.ts
@@ -81,8 +81,8 @@ async function getPatterns(
 
     const p = parseFiles(args);
 
-    const supportedExtensions = prettier
-      .getSupportInfo()
+    const supportedExtensions = (await prettier
+      .getSupportInfo())
       .languages.flatMap((language) => language.extensions)
       .filter((extension) => !!extension)
       // Prettier supports ".swcrc" as a file instead of an extension

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true


### PR DESCRIPTION
In prettier 3 the `getSupportInfo` method now is a promise

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Now, when you try to run "format:write" it fails, and jumps into the "catch", it uses "all files".

You can't specify the files you want to "format" (if you use format:write in lint-staged this will format all other files, not only staged ones)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Only the desired files in format:write should be formated

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

https://github.com/nrwl/nx/pull/19075

Fixes #

Add await in `getSupportInfo` method