### PR TITLE
chore(js): re-enable skipped test

### DIFF
--- a/e2e/esbuild/src/esbuild.test.ts
+++ b/e2e/esbuild/src/esbuild.test.ts
@@ -106,8 +106,12 @@ describe('EsBuild Plugin', () => {
     readFile(`dist/libs/${myPkg}/assets/a.md`).includes('initial a');
     updateFile(`libs/${myPkg}/assets/a.md`, 'updated a');
     await expect(
-      waitUntil(() =>
-        readFile(`dist/libs/${myPkg}/assets/a.md`).includes('updated a')
+      waitUntil(
+        () => readFile(`dist/libs/${myPkg}/assets/a.md`).includes('updated a'),
+        {
+          timeout: 20_000,
+          ms: 500,
+        }
       )
     ).resolves.not.toThrow();
     watchProcess.kill();

--- a/e2e/js/src/js-executor-tsc.test.ts
+++ b/e2e/js/src/js-executor-tsc.test.ts
@@ -27,8 +27,7 @@ describe('js:tsc executor', () => {
   beforeAll(() => (scope = newProject()));
   afterAll(() => cleanupProject());
 
-  // TODO: Re-enable this when it is passing again
-  xit('should create libs with js executors (--compiler=tsc)', async () => {
+  it('should create libs with js executors (--compiler=tsc)', async () => {
     const lib = uniq('lib');
     runCLI(`generate @nx/js:lib ${lib} --bundler=tsc --no-interactive`);
     const libPackageJson = readJson(`libs/${lib}/package.json`);
@@ -71,20 +70,36 @@ describe('js:tsc executor', () => {
     });
     updateFile(`libs/${lib}/docs/a/b/nested.md`, 'Nested File');
     await expect(
-      waitUntil(() =>
-        readFile(`dist/libs/${lib}/README.md`).includes(`Hello, World!`)
+      waitUntil(
+        () => readFile(`dist/libs/${lib}/README.md`).includes(`Hello, World!`),
+        {
+          timeout: 20_000,
+          ms: 500,
+        }
       )
     ).resolves.not.toThrow();
     await expect(
-      waitUntil(() =>
-        readFile(`dist/libs/${lib}/docs/a/b/nested.md`).includes(`Nested File`)
+      waitUntil(
+        () =>
+          readFile(`dist/libs/${lib}/docs/a/b/nested.md`).includes(
+            `Nested File`
+          ),
+        {
+          timeout: 20_000,
+          ms: 500,
+        }
       )
     ).resolves.not.toThrow();
     await expect(
-      waitUntil(() =>
-        readFile(`dist/libs/${lib}/package.json`).includes(
-          `"version": "999.9.9"`
-        )
+      waitUntil(
+        () =>
+          readFile(`dist/libs/${lib}/package.json`).includes(
+            `"version": "999.9.9"`
+          ),
+        {
+          timeout: 20_000,
+          ms: 500,
+        }
       )
     ).resolves.not.toThrow();
     libBuildProcess.kill();


### PR DESCRIPTION
This test was skipped previously due to flakiness. I bumped the timeout for watched file changes so it should work better on CI.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
