### PR TITLE
fix(repo): ensure cypress is installed on agents

### DIFF
--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -36,6 +36,9 @@ steps:
     script: |
       pnpm install --frozen-lockfile
 
+  - name: Install Cypress
+    script: pnpm exec cypress install
+
   - name: Install Rust
     script: |
       curl --proto '=https' --tlsv1.3 https://sh.rustup.rs -sSf | sh -s -- -y


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Cypress is sometimes not installed properly on agents.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Cypress should be installed properly on agents.

If the cypress installation is cached properly. then this command will be pretty fast and skip actual installation. If the cypress isn't installed properly, this will tell us and run the install. We should somehow fix the the caching though 🤔 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
