### PR TITLE
docs(core): add migrate to monorepo sections

### DIFF
--- a/docs/shared/angular-standalone-tutorial/angular-standalone.md
+++ b/docs/shared/angular-standalone-tutorial/angular-standalone.md
@@ -813,7 +813,9 @@ Learn more about how to [enforce module boundaries](/core-features/enforce-modul
 
 ## Migrating to a Monorepo
 
-If you want to move `myngapp` out of the root, you can run the [`convert-to-monorepo` generator](/nx-api/workspace/generators/convert-to-monorepo) or [manually move the configuration files](/recipes/tips-n-tricks/standalone-to-integrated).
+When you are ready to add another application to the repo, you'll probably want to move `myngapp` to its own folder. To do this, you can run the [`convert-to-monorepo` generator](/nx-api/workspace/generators/convert-to-monorepo) or [manually move the configuration files](/recipes/tips-n-tricks/standalone-to-integrated).
+
+You can also go through the full [Angular monorepo tutorial](/getting-started/tutorials/angular-monorepo-tutorial)
 
 ## Next Steps
 

--- a/docs/shared/angular-standalone-tutorial/angular-standalone.md
+++ b/docs/shared/angular-standalone-tutorial/angular-standalone.md
@@ -811,6 +811,10 @@ If you have the ESLint plugin installed in your IDE you should immediately see a
 
 Learn more about how to [enforce module boundaries](/core-features/enforce-module-boundaries).
 
+## Migrating to a Monorepo
+
+If you want to move `myngapp` out of the root, you can run the [`convert-to-monorepo` generator](/nx-api/workspace/generators/convert-to-monorepo) or [manually move the configuration files](/recipes/tips-n-tricks/standalone-to-integrated).
+
 ## Next Steps
 
 Congrats, you made it!! You now know how to leverage the Nx standalone applications preset to build modular Angular applications.

--- a/docs/shared/react-standalone-tutorial/react-standalone.md
+++ b/docs/shared/react-standalone-tutorial/react-standalone.md
@@ -821,7 +821,9 @@ Learn more about how to [enforce module boundaries](/core-features/enforce-modul
 
 ## Migrating to a Monorepo
 
-If you want to move `myreactapp` out of the root, you can run the [`convert-to-monorepo` generator](/nx-api/workspace/generators/convert-to-monorepo) or [manually move the configuration files](/recipes/tips-n-tricks/standalone-to-integrated).
+When you are ready to add another application to the repo, you'll probably want to move `myreactapp` to its own folder. To do this, you can run the [`convert-to-monorepo` generator](/nx-api/workspace/generators/convert-to-monorepo) or [manually move the configuration files](/recipes/tips-n-tricks/standalone-to-integrated).
+
+You can also go through the full [React monorepo tutorial](/getting-started/tutorials/react-monorepo-tutorial)
 
 ## Next Steps
 

--- a/docs/shared/react-standalone-tutorial/react-standalone.md
+++ b/docs/shared/react-standalone-tutorial/react-standalone.md
@@ -819,6 +819,10 @@ If you have the ESLint plugin installed in your IDE you should immediately see a
 
 Learn more about how to [enforce module boundaries](/core-features/enforce-module-boundaries).
 
+## Migrating to a Monorepo
+
+If you want to move `myreactapp` out of the root, you can run the [`convert-to-monorepo` generator](/nx-api/workspace/generators/convert-to-monorepo) or [manually move the configuration files](/recipes/tips-n-tricks/standalone-to-integrated).
+
 ## Next Steps
 
 Here's some more things you can dive into next:


### PR DESCRIPTION
Migrate to monorepo sections for angular standalone tutorial and react standalone tutorial