### PR TITLE
chore(testing): enable playwright e2e tests

### DIFF
--- a/e2e/playwright/src/playwright.test.ts
+++ b/e2e/playwright/src/playwright.test.ts
@@ -9,8 +9,8 @@ import {
 } from '@nx/e2e/utils';
 
 const TEN_MINS_MS = 600_000;
-// TODO: re-enable this when tests are passing again
-xdescribe('Playwright E2E Test runner', () => {
+
+describe('Playwright E2E Test runner', () => {
   const pmc = getPackageManagerCommand({
     packageManager: getSelectedPackageManager(),
   });


### PR DESCRIPTION
This PR re-enables Playwright tests that were disabled in https://github.com/nrwl/nx/pull/19175. The previous failures were only in CI (failure due to libsoup in the image), and seem to be working now. For reference, I also tried pulling the `cimg/rust:1.70.0-browsers` locally and running the tests, but were never able to produce the failure.
