### PR TITLE
feat(react): remove stylus option from generators

### DIFF
--- a/docs/generated/packages/next/generators/application.json
+++ b/docs/generated/packages/next/generators/application.json
@@ -58,11 +58,7 @@
               "value": "styled-jsx",
               "label": "styled-jsx        [ https://www.npmjs.com/package/styled-jsx ]"
             },
-            { "value": "none", "label": "None" },
-            {
-              "value": "styl",
-              "label": "Stylus(.styl)     [ http://stylus-lang.com        ] (DEPRECATED)"
-            }
+            { "value": "none", "label": "None" }
           ]
         }
       },

--- a/docs/generated/packages/next/generators/component.json
+++ b/docs/generated/packages/next/generators/component.json
@@ -54,11 +54,7 @@
               "value": "styled-jsx",
               "label": "styled-jsx        [ https://www.npmjs.com/package/styled-jsx ]"
             },
-            { "value": "none", "label": "None" },
-            {
-              "value": "styl",
-              "label": "Stylus(.styl)     [ http://stylus-lang.com        ] (DEPRECATED)"
-            }
+            { "value": "none", "label": "None" }
           ]
         }
       },

--- a/docs/generated/packages/next/generators/library.json
+++ b/docs/generated/packages/next/generators/library.json
@@ -58,11 +58,7 @@
               "value": "styled-jsx",
               "label": "styled-jsx        [ https://www.npmjs.com/package/styled-jsx ]"
             },
-            { "value": "none", "label": "None" },
-            {
-              "value": "styl",
-              "label": "Stylus(.styl)     [ http://stylus-lang.com        ] (DEPRECATED)"
-            }
+            { "value": "none", "label": "None" }
           ]
         }
       },

--- a/docs/generated/packages/next/generators/page.json
+++ b/docs/generated/packages/next/generators/page.json
@@ -60,11 +60,7 @@
               "value": "styled-jsx",
               "label": "styled-jsx        [ https://www.npmjs.com/package/styled-jsx ]"
             },
-            { "value": "none", "label": "None" },
-            {
-              "value": "styl",
-              "label": "Stylus(.styl)     [ http://stylus-lang.com        ] (DEPRECATED)"
-            }
+            { "value": "none", "label": "None" }
           ]
         },
         "x-priority": "important"

--- a/docs/generated/packages/react/generators/application.json
+++ b/docs/generated/packages/react/generators/application.json
@@ -71,11 +71,7 @@
               "value": "styled-jsx",
               "label": "styled-jsx        [ https://www.npmjs.com/package/styled-jsx ]"
             },
-            { "value": "none", "label": "None" },
-            {
-              "value": "styl",
-              "label": "Stylus(.styl)     [ http://stylus-lang.com                   ] (DEPRECATED)"
-            }
+            { "value": "none", "label": "None" }
           ]
         }
       },

--- a/docs/generated/packages/react/generators/component.json
+++ b/docs/generated/packages/react/generators/component.json
@@ -64,11 +64,7 @@
               "value": "styled-jsx",
               "label": "styled-jsx        [ https://www.npmjs.com/package/styled-jsx ]"
             },
-            { "value": "none", "label": "None" },
-            {
-              "value": "styl",
-              "label": "Stylus(.styl)     [ http://stylus-lang.com        ] (DEPRECATED)"
-            }
+            { "value": "none", "label": "None" }
           ]
         }
       },

--- a/docs/generated/packages/react/generators/host.json
+++ b/docs/generated/packages/react/generators/host.json
@@ -58,11 +58,7 @@
               "value": "styled-jsx",
               "label": "styled-jsx        [ https://www.npmjs.com/package/styled-jsx ]"
             },
-            { "value": "none", "label": "None" },
-            {
-              "value": "styl",
-              "label": "Stylus(.styl)     [ http://stylus-lang.com                   ] (DEPRECATED)"
-            }
+            { "value": "none", "label": "None" }
           ]
         }
       },

--- a/docs/generated/packages/react/generators/library.json
+++ b/docs/generated/packages/react/generators/library.json
@@ -68,11 +68,7 @@
               "value": "styled-jsx",
               "label": "styled-jsx        [ https://www.npmjs.com/package/styled-jsx ]"
             },
-            { "value": "none", "label": "None" },
-            {
-              "value": "styl",
-              "label": "Stylus(.styl)     [ http://stylus-lang.com        ] (DEPRECATED)"
-            }
+            { "value": "none", "label": "None" }
           ]
         }
       },

--- a/docs/generated/packages/react/generators/remote.json
+++ b/docs/generated/packages/react/generators/remote.json
@@ -58,10 +58,6 @@
               "value": "styled-jsx",
               "label": "styled-jsx        [ https://www.npmjs.com/package/styled-jsx ]"
             },
-            {
-              "value": "styl",
-              "label": "DEPRECATD: Stylus(.styl) [ http://stylus-lang.com            ]"
-            },
             { "value": "none", "label": "None" }
           ]
         }

--- a/e2e/next-extensions/src/next-styles.test.ts
+++ b/e2e/next-extensions/src/next-styles.test.ts
@@ -32,19 +32,6 @@ describe('Next.js Styles', () => {
       checkExport: false,
     });
 
-    const stylusApp = uniq('app');
-
-    runCLI(
-      `generate @nx/next:app ${stylusApp} --no-interactive --style=styl --appDir=false`
-    );
-
-    await checkApp(stylusApp, {
-      checkUnitTest: false,
-      checkLint: false,
-      checkE2E: false,
-      checkExport: false,
-    });
-
     const scApp = uniq('app');
 
     runCLI(

--- a/e2e/react-core/src/react.test.ts
+++ b/e2e/react-core/src/react.test.ts
@@ -328,7 +328,6 @@ describe('React Applications', () => {
       ${'css'}
       ${'scss'}
       ${'less'}
-      ${'styl'}
     `('should support global and css modules', async ({ style }) => {
       const appName = uniq('app');
       runCLI(

--- a/nx-dev/nx-dev/lib/rspack/schema/generators/application.ts
+++ b/nx-dev/nx-dev/lib/rspack/schema/generators/application.ts
@@ -59,11 +59,6 @@ export const schema = {
                 'LESS              [ http://lesscss.org                       ]',
             },
             {
-              value: 'styl',
-              label:
-                'DEPRECATED: Stylus(.styl) [ http://stylus-lang.com           ]',
-            },
-            {
               value: 'none',
               label: 'None',
             },

--- a/package.json
+++ b/package.json
@@ -268,8 +268,6 @@
     "storybook-dark-mode": "^3.0.0",
     "style-loader": "^3.3.0",
     "styled-components": "5.3.6",
-    "stylus": "0.59.0",
-    "stylus-loader": "7.1.0",
     "tar-fs": "^2.1.1",
     "tar-stream": "~2.2.0",
     "tcp-port-used": "^1.0.2",

--- a/packages-legacy/react/typings/cssmodule.d.ts
+++ b/packages-legacy/react/typings/cssmodule.d.ts
@@ -17,8 +17,3 @@ declare module '*.module.less' {
   const classes: { readonly [key: string]: string };
   export default classes;
 }
-
-declare module '*.module.styl' {
-  const classes: { readonly [key: string]: string };
-  export default classes;
-}

--- a/packages-legacy/react/typings/style.d.ts
+++ b/packages-legacy/react/typings/style.d.ts
@@ -1,7 +1,6 @@
 export type SupportedStyles =
   | 'css'
   | 'scss'
-  | 'styl'
   | 'less'
   | 'styled-components'
   | '@emotion/styled'

--- a/packages/jest/plugins/resolver.ts
+++ b/packages/jest/plugins/resolver.ts
@@ -40,13 +40,7 @@ function getCompilerSetup(rootDir: string) {
 
 module.exports = function (path: string, options: ResolveOptions) {
   const ext = extname(path);
-  if (
-    ext === '.css' ||
-    ext === '.scss' ||
-    ext === '.sass' ||
-    ext === '.less' ||
-    ext === '.styl'
-  ) {
+  if (ext === '.css' || ext === '.scss' || ext === '.sass' || ext === '.less') {
     return require.resolve('identity-obj-proxy');
   }
   try {

--- a/packages/next/plugins/with-stylus.ts
+++ b/packages/next/plugins/with-stylus.ts
@@ -1,99 +1,14 @@
-// Adapted from https://raw.githubusercontent.com/elado/next-with-less/main/src/index.js
-import { merge } from 'webpack-merge';
 import { NextConfigFn } from '../src/utils/config';
 import { WithNxOptions } from './with-nx';
 
-const addStylusToRegExp = (rx) =>
-  new RegExp(rx.source.replace('|sass', '|sass|styl'), rx.flags);
-
+// TODO(v18): Remove file, it is here until users migrate over to SASS manually.
 export function withStylus(
   configOrFn: WithNxOptions | NextConfigFn
 ): NextConfigFn {
   return async (phase: string) => {
-    const baseConfig =
-      typeof configOrFn === 'function' ? await configOrFn(phase) : configOrFn;
-    const { stylusLoaderOptions = {}, ...nextConfig } = baseConfig;
-
-    return Object.assign({}, nextConfig, {
-      webpack(config, opts) {
-        // there are 2 relevant sass rules in next.js - css modules and global css
-        let sassModuleRule;
-        // global sass rule (does not exist in server builds)
-        let sassGlobalRule;
-
-        const cssRule = config.module.rules.find((rule) =>
-          rule.oneOf?.find((r) => r?.[Symbol.for('__next_css_remove')])
-        );
-
-        const addStylusRuleToTest = (test) => {
-          if (Array.isArray(test)) {
-            return test.map((rx) => addStylusToRegExp(rx));
-          } else {
-            return addStylusToRegExp(test);
-          }
-        };
-
-        cssRule.oneOf.forEach((rule) => {
-          if (rule.options?.__next_css_remove) return;
-
-          if (rule.use?.loader === 'error-loader') {
-            rule.test = addStylusRuleToTest(rule.test);
-          } else if (rule.use?.loader?.includes('file-loader')) {
-            rule.issuer = addStylusRuleToTest(rule.issuer);
-          } else if (rule.use?.includes?.('ignore-loader')) {
-            rule.test = addStylusRuleToTest(rule.test);
-          } else if (rule.test?.source === '\\.module\\.(scss|sass)$') {
-            sassModuleRule = rule;
-          } else if (rule.test?.source === '(?<!\\.module)\\.(scss|sass)$') {
-            sassGlobalRule = rule;
-          }
-        });
-
-        const stylusLoader = {
-          loader: 'stylus-loader',
-          options: {
-            ...stylusLoaderOptions,
-            stylusOptions: {
-              javascriptEnabled: true,
-              ...stylusLoaderOptions.stylusOptions,
-            },
-          },
-        };
-
-        let stylusModuleRule = merge({}, sassModuleRule);
-
-        const configureStylusRule = (rule) => {
-          rule.test = new RegExp(
-            rule.test.source.replace('(scss|sass)', 'styl')
-          );
-          // replace sass-loader (last entry) with stylus-loader
-          rule.use.splice(-1, 1, stylusLoader);
-        };
-
-        configureStylusRule(stylusModuleRule);
-        cssRule.oneOf.splice(
-          cssRule.oneOf.indexOf(sassModuleRule) + 1,
-          0,
-          stylusModuleRule
-        );
-
-        if (sassGlobalRule) {
-          let stylusGlobalRule = merge({}, sassGlobalRule);
-          configureStylusRule(stylusGlobalRule);
-          cssRule.oneOf.splice(
-            cssRule.oneOf.indexOf(sassGlobalRule) + 1,
-            0,
-            stylusGlobalRule
-          );
-        }
-
-        if (typeof nextConfig.webpack === 'function') {
-          return nextConfig.webpack(config, opts);
-        }
-
-        return config;
-      },
-    });
+    throw new Error(
+      `Stylus support has been removed and you should use the built-in SASS support. Remove the "withStylus" plugin from your Next.js config, and rename your files from .styl to .scss.`
+    );
   };
 }
 

--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -254,23 +254,6 @@ describe('app', () => {
     });
   });
 
-  describe('--style styl', () => {
-    it('should generate styl styles', async () => {
-      const name = uniq();
-      await applicationGenerator(tree, {
-        name,
-        style: 'styl',
-        projectNameAndRootFormat: 'as-provided',
-      });
-
-      expect(tree.exists(`${name}/app/page.module.styl`)).toBeTruthy();
-      expect(tree.exists(`${name}/app/global.styl`)).toBeTruthy();
-
-      const indexContent = tree.read(`${name}/app/page.tsx`, 'utf-8');
-      expect(indexContent).toContain(`import styles from './page.module.styl'`);
-    });
-  });
-
   describe('--style styled-components', () => {
     it('should generate styled-components styles', async () => {
       const name = uniq();

--- a/packages/next/src/generators/application/files/common/index.d.ts__tmpl__
+++ b/packages/next/src/generators/application/files/common/index.d.ts__tmpl__
@@ -10,9 +10,4 @@ declare module '*.module.less' {
   const classes: { readonly [key: string]: string };
   export default classes;
 }
-<% } else if (style === 'styl') { %>
-declare module '*.module.styl' {
-  const classes: { readonly [key: string]: string };
-  export default classes;
-}
 <% } %>

--- a/packages/next/src/generators/application/files/common/next.config.js__tmpl__
+++ b/packages/next/src/generators/application/files/common/next.config.js__tmpl__
@@ -26,27 +26,6 @@ const plugins = [
 ];
 
 module.exports = composePlugins(...plugins)(nextConfig);
-<% } else if (style === 'styl') { %>
-const { withStylus } = require('@nx/next/plugins/with-stylus');
-
-/**
- * @type {import('@nx/next/plugins/with-nx').WithNxOptions}
- **/
-const nextConfig = {
-  nx: {
-    // Set this to true if you would like to to use SVGR
-    // See: https://github.com/gregberge/svgr
-    svgr: false,
-  },
-};
-
-const plugins = [
-  // Add more Next.js plugins to this list if needed.
-  withStylus,
-  withNx,
-];
-
-module.exports = composePlugins(...plugins)(nextConfig);
 <% } else if (
   style === 'styled-components'
   ||style === '@emotion/styled'

--- a/packages/next/src/generators/application/lib/create-application-files.ts
+++ b/packages/next/src/generators/application/lib/create-application-files.ts
@@ -45,10 +45,7 @@ export function createApplicationFiles(host: Tree, options: NormalizedSchema) {
     styleContent: createStyleRules(),
     pageStyleContent: `.page {}`,
 
-    stylesExt:
-      options.style === 'less' || options.style === 'styl'
-        ? options.style
-        : 'css',
+    stylesExt: options.style === 'less' ? options.style : 'css',
   };
 
   generateFiles(

--- a/packages/next/src/generators/application/lib/normalize-options.ts
+++ b/packages/next/src/generators/application/lib/normalize-options.ts
@@ -54,7 +54,7 @@ export async function normalizeOptions(
 
   const appDir = options.appDir ?? true;
 
-  const styledModule = /^(css|scss|less|styl)$/.test(options.style)
+  const styledModule = /^(css|scss|less)$/.test(options.style)
     ? null
     : options.style;
 

--- a/packages/next/src/generators/application/schema.json
+++ b/packages/next/src/generators/application/schema.json
@@ -61,10 +61,6 @@
           {
             "value": "none",
             "label": "None"
-          },
-          {
-            "value": "styl",
-            "label": "Stylus(.styl)     [ http://stylus-lang.com        ] (DEPRECATED)"
           }
         ]
       }

--- a/packages/next/src/generators/component/component.ts
+++ b/packages/next/src/generators/component/component.ts
@@ -36,7 +36,7 @@ function getDirectory(host: Tree, options: Schema) {
 
 /*
  * This schematic is basically the React one, but for Next we need
- * extra dependencies for css, sass, less, styl style options.
+ * extra dependencies for css, sass, less style options.
  */
 export async function componentGenerator(host: Tree, options: Schema) {
   const project = readProjectConfiguration(host, options.project);

--- a/packages/next/src/generators/component/schema.json
+++ b/packages/next/src/generators/component/schema.json
@@ -59,10 +59,6 @@
           {
             "value": "none",
             "label": "None"
-          },
-          {
-            "value": "styl",
-            "label": "Stylus(.styl)     [ http://stylus-lang.com        ] (DEPRECATED)"
           }
         ]
       }

--- a/packages/next/src/generators/library/schema.json
+++ b/packages/next/src/generators/library/schema.json
@@ -61,10 +61,6 @@
           {
             "value": "none",
             "label": "None"
-          },
-          {
-            "value": "styl",
-            "label": "Stylus(.styl)     [ http://stylus-lang.com        ] (DEPRECATED)"
           }
         ]
       }

--- a/packages/next/src/generators/page/page.ts
+++ b/packages/next/src/generators/page/page.ts
@@ -13,7 +13,7 @@ import { Schema } from './schema';
 
 /*
  * This schematic is basically the React component one, but for Next we need
- * extra dependencies for css, sass, less, styl style options, and make sure
+ * extra dependencies for css, sass, less style options, and make sure
  * it is under `pages` folder.
  */
 export async function pageGenerator(host: Tree, schema: Schema) {

--- a/packages/next/src/generators/page/schema.json
+++ b/packages/next/src/generators/page/schema.json
@@ -65,10 +65,6 @@
           {
             "value": "none",
             "label": "None"
-          },
-          {
-            "value": "styl",
-            "label": "Stylus(.styl)     [ http://stylus-lang.com        ] (DEPRECATED)"
           }
         ]
       },

--- a/packages/next/src/migrations/update-15-8-8/add-style-packages.spec.ts
+++ b/packages/next/src/migrations/update-15-8-8/add-style-packages.spec.ts
@@ -2,7 +2,7 @@ import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { writeJson, readJson, Tree, addProjectConfiguration } from '@nx/devkit';
 import update from './add-style-packages';
 
-describe('Add less and stylus if needed', () => {
+describe('Add less if needed', () => {
   let tree: Tree;
 
   beforeEach(() => {
@@ -36,34 +36,7 @@ describe('Add less and stylus if needed', () => {
     });
   });
 
-  it('should add stylus if used', async () => {
-    writeJson(tree, 'package.json', {
-      dependencies: {},
-      devDependencies: {},
-    });
-    addProjectConfiguration(tree, 'myapp', {
-      root: 'myapp',
-      targets: {
-        build: {
-          executor: '@nrwl/next:build',
-        },
-      },
-    });
-    tree.write(
-      `myapp/next.config.js`,
-      `require('@nrwl/next/plugins/with-stylus')`
-    );
-
-    await update(tree);
-
-    const packageJson = readJson(tree, 'package.json');
-    expect(packageJson).toEqual({
-      dependencies: {},
-      devDependencies: { stylus: '^0.55.0' },
-    });
-  });
-
-  it('should not add anything if less/stylus not used by Next.js app', async () => {
+  it('should not add anything if less not used by Next.js app', async () => {
     writeJson(tree, 'package.json', {
       dependencies: {},
       devDependencies: {},

--- a/packages/next/src/utils/styles.ts
+++ b/packages/next/src/utils/styles.ts
@@ -2,10 +2,9 @@ import {
   addDependenciesToPackageJson,
   GeneratorCallback,
   Tree,
-  updateJson,
 } from '@nx/devkit';
 
-import { lessVersion, stylusVersion } from '@nx/react/src/utils/versions';
+import { lessVersion } from '@nx/react/src/utils/versions';
 import {
   cssInJsDependenciesBabel,
   cssInJsDependenciesSwc,
@@ -15,7 +14,6 @@ import {
   emotionServerVersion,
   lessLoader,
   sassVersion,
-  stylusLoader,
 } from './versions';
 
 const nextSpecificStyleDependenciesCommon = {
@@ -33,13 +31,6 @@ const nextSpecificStyleDependenciesCommon = {
       less: lessVersion,
       'less-loader': lessLoader,
     },
-  },
-  styl: {
-    dependencies: {
-      stylus: stylusVersion,
-      'stylus-loader': stylusLoader,
-    },
-    devDependencies: {},
   },
 };
 
@@ -88,25 +79,11 @@ export function addStyleDependencies(
     ? nextSpecificStyleDependenciesSwc[options.style]
     : nextSpecificStyleDependenciesBabel[options.style];
 
-  if (!extraDependencies) return () => {};
-
-  const installTask = addDependenciesToPackageJson(
-    host,
-    extraDependencies.dependencies,
-    extraDependencies.devDependencies
-  );
-
-  // @zeit/next-less & @zeit/next-stylus internal configuration is working only
-  // for specific CSS loader version, causing PNPM resolution to fail.
-  if (
-    host.exists('pnpm-lock.yaml') &&
-    (options.style === 'less' || options.style === 'styl')
-  ) {
-    updateJson(host, `package.json`, (json) => {
-      json.resolutions = { ...json.resolutions, 'css-loader': '1.0.1' };
-      return json;
-    });
-  }
-
-  return installTask;
+  return extraDependencies
+    ? addDependenciesToPackageJson(
+        host,
+        extraDependencies.dependencies,
+        extraDependencies.devDependencies
+      )
+    : () => {};
 }

--- a/packages/next/src/utils/versions.ts
+++ b/packages/next/src/utils/versions.ts
@@ -4,7 +4,6 @@ export const nextVersion = '13.4.1';
 export const eslintConfigNextVersion = '13.4.1';
 export const sassVersion = '1.62.1';
 export const lessLoader = '11.1.0';
-export const stylusLoader = '7.1.0';
 export const emotionServerVersion = '11.11.0';
 export const babelPluginStyledComponentsVersion = '1.10.7';
 export const tsLibVersion = '^2.3.0';

--- a/packages/react/plugins/component-testing/webpack-fallback.ts
+++ b/packages/react/plugins/component-testing/webpack-fallback.ts
@@ -99,7 +99,7 @@ const commonLoaders = [
 ];
 
 const CSS_MODULES_LOADER = {
-  test: /\.css$|\.scss$|\.sass$|\.less$|\.styl$/,
+  test: /\.css$|\.scss$|\.sass$|\.less$/,
   oneOf: [
     {
       test: /\.module\.css$/,
@@ -127,15 +127,6 @@ const CSS_MODULES_LOADER = {
         ...commonLoaders,
         {
           loader: require.resolve('less-loader'),
-        },
-      ],
-    },
-    {
-      test: /\.module\.styl$/,
-      use: [
-        ...commonLoaders,
-        {
-          loader: require.resolve('stylus-loader'),
         },
       ],
     },

--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -641,10 +641,8 @@ describe('app', () => {
       expect(appTree.exists('my-app/src/app/app.spec.tsx')).toBeTruthy();
       expect(appTree.exists('my-app/src/app/app.css')).toBeFalsy();
       expect(appTree.exists('my-app/src/app/app.scss')).toBeFalsy();
-      expect(appTree.exists('my-app/src/app/app.styl')).toBeFalsy();
       expect(appTree.exists('my-app/src/app/app.module.css')).toBeFalsy();
       expect(appTree.exists('my-app/src/app/app.module.scss')).toBeFalsy();
-      expect(appTree.exists('my-app/src/app/app.module.styl')).toBeFalsy();
 
       const content = appTree.read('my-app/src/app/app.tsx').toString();
       expect(content).not.toContain('styled-components');
@@ -653,10 +651,8 @@ describe('app', () => {
       expect(content).not.toContain('<StyledApp>');
 
       //for imports
-      expect(content).not.toContain('app.styl');
       expect(content).not.toContain('app.css');
       expect(content).not.toContain('app.scss');
-      expect(content).not.toContain('app.module.styl');
       expect(content).not.toContain('app.module.css');
       expect(content).not.toContain('app.module.scss');
     });
@@ -1070,7 +1066,6 @@ describe('app', () => {
       style     | pkg
       ${'less'} | ${'less'}
       ${'scss'} | ${'sass'}
-      ${'styl'} | ${'stylus'}
     `(
       'should add style preprocessor when vite is used',
       async ({ style, pkg }) => {

--- a/packages/react/src/generators/application/lib/install-common-dependencies.ts
+++ b/packages/react/src/generators/application/lib/install-common-dependencies.ts
@@ -4,7 +4,6 @@ import {
   babelPresetReactVersion,
   lessVersion,
   sassVersion,
-  stylusVersion,
   swcLoaderVersion,
 } from '../../../utils/versions';
 import { NormalizedSchema } from '../schema';
@@ -24,9 +23,6 @@ export function installCommonDependencies(
         break;
       case 'less':
         devDependencies['less'] = lessVersion;
-        break;
-      case 'styl': // @TODO(17): deprecated, going to be removed in Nx 17
-        devDependencies['stylus'] = stylusVersion;
         break;
     }
   }

--- a/packages/react/src/generators/application/lib/normalize-options.ts
+++ b/packages/react/src/generators/application/lib/normalize-options.ts
@@ -45,7 +45,7 @@ export async function normalizeOptions<T extends Schema = Schema>(
 
   const fileName = options.pascalCaseFiles ? 'App' : 'app';
 
-  const styledModule = /^(css|scss|less|styl|none)$/.test(options.style)
+  const styledModule = /^(css|scss|less|none)$/.test(options.style)
     ? null
     : options.style;
 

--- a/packages/react/src/generators/application/schema.json
+++ b/packages/react/src/generators/application/schema.json
@@ -77,10 +77,6 @@
           {
             "value": "none",
             "label": "None"
-          },
-          {
-            "value": "styl",
-            "label": "Stylus(.styl)     [ http://stylus-lang.com                   ] (DEPRECATED)"
           }
         ]
       }

--- a/packages/react/src/generators/component/component.spec.ts
+++ b/packages/react/src/generators/component/component.spec.ts
@@ -194,15 +194,11 @@ describe('component', () => {
       ).toBeTruthy();
       expect(appTree.exists('my-lib/src/lib/hello/hello.css')).toBeFalsy();
       expect(appTree.exists('my-lib/src/lib/hello/hello.scss')).toBeFalsy();
-      expect(appTree.exists('my-lib/src/lib/hello/hello.styl')).toBeFalsy();
       expect(
         appTree.exists('my-lib/src/lib/hello/hello.module.css')
       ).toBeFalsy();
       expect(
         appTree.exists('my-lib/src/lib/hello/hello.module.scss')
-      ).toBeFalsy();
-      expect(
-        appTree.exists('my-lib/src/lib/hello/hello.module.styl')
       ).toBeFalsy();
 
       const content = appTree.read('my-lib/src/lib/hello/hello.tsx').toString();
@@ -212,10 +208,8 @@ describe('component', () => {
       expect(content).not.toContain('<StyledHello>');
 
       //for imports
-      expect(content).not.toContain('hello.styl');
       expect(content).not.toContain('hello.css');
       expect(content).not.toContain('hello.scss');
-      expect(content).not.toContain('hello.module.styl');
       expect(content).not.toContain('hello.module.css');
       expect(content).not.toContain('hello.module.scss');
     });

--- a/packages/react/src/generators/component/component.ts
+++ b/packages/react/src/generators/component/component.ts
@@ -160,7 +160,7 @@ async function normalizeOptions(
 
   const directory = await getDirectory(host, options);
 
-  const styledModule = /^(css|scss|less|styl|none)$/.test(options.style)
+  const styledModule = /^(css|scss|less|none)$/.test(options.style)
     ? null
     : options.style;
 

--- a/packages/react/src/generators/component/schema.json
+++ b/packages/react/src/generators/component/schema.json
@@ -69,10 +69,6 @@
           {
             "value": "none",
             "label": "None"
-          },
-          {
-            "value": "styl",
-            "label": "Stylus(.styl)     [ http://stylus-lang.com        ] (DEPRECATED)"
           }
         ]
       }

--- a/packages/react/src/generators/host/schema.json
+++ b/packages/react/src/generators/host/schema.json
@@ -64,10 +64,6 @@
           {
             "value": "none",
             "label": "None"
-          },
-          {
-            "value": "styl",
-            "label": "Stylus(.styl)     [ http://stylus-lang.com                   ] (DEPRECATED)"
           }
         ]
       }

--- a/packages/react/src/generators/library/lib/install-common-dependencies.ts
+++ b/packages/react/src/generators/library/lib/install-common-dependencies.ts
@@ -12,7 +12,6 @@ import {
   reactDomVersion,
   reactVersion,
   sassVersion,
-  stylusVersion,
 } from '../../../utils/versions';
 import { NormalizedSchema } from '../schema';
 
@@ -33,9 +32,6 @@ export function installCommonDependencies(
         break;
       case 'less':
         devDependencies['less'] = lessVersion;
-        break;
-      case 'styl': // @TODO(17): deprecated, going to be removed in Nx 17
-        devDependencies['stylus'] = stylusVersion;
         break;
     }
   }

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -367,10 +367,8 @@ describe('lib', () => {
       expect(tree.exists('my-lib/src/lib/my-lib.spec.tsx')).toBeTruthy();
       expect(tree.exists('my-lib/src/lib/my-lib.css')).toBeFalsy();
       expect(tree.exists('my-lib/src/lib/my-lib.scss')).toBeFalsy();
-      expect(tree.exists('my-lib/src/lib/my-lib.styl')).toBeFalsy();
       expect(tree.exists('my-lib/src/lib/my-lib.module.css')).toBeFalsy();
       expect(tree.exists('my-lib/src/lib/my-lib.module.scss')).toBeFalsy();
-      expect(tree.exists('my-lib/src/lib/my-lib.module.styl')).toBeFalsy();
 
       const content = tree.read('my-lib/src/lib/my-lib.tsx', 'utf-8');
       expect(content).not.toContain('styled-components');
@@ -379,10 +377,8 @@ describe('lib', () => {
       expect(content).not.toContain('<StyledApp>');
 
       //for imports
-      expect(content).not.toContain('app.styl');
       expect(content).not.toContain('app.css');
       expect(content).not.toContain('app.scss');
-      expect(content).not.toContain('app.module.styl');
       expect(content).not.toContain('app.module.css');
       expect(content).not.toContain('app.module.scss');
     });
@@ -797,7 +793,6 @@ describe('lib', () => {
     style     | pkg
     ${'less'} | ${'less'}
     ${'scss'} | ${'sass'}
-    ${'styl'} | ${'stylus'}
   `(
     'should add style preprocessor when vite is used',
     async ({ style, pkg }) => {

--- a/packages/react/src/generators/library/schema.json
+++ b/packages/react/src/generators/library/schema.json
@@ -71,10 +71,6 @@
           {
             "value": "none",
             "label": "None"
-          },
-          {
-            "value": "styl",
-            "label": "Stylus(.styl)     [ http://stylus-lang.com        ] (DEPRECATED)"
           }
         ]
       }

--- a/packages/react/src/generators/remote/schema.json
+++ b/packages/react/src/generators/remote/schema.json
@@ -62,10 +62,6 @@
             "label": "styled-jsx        [ https://www.npmjs.com/package/styled-jsx ]"
           },
           {
-            "value": "styl",
-            "label": "DEPRECATD: Stylus(.styl) [ http://stylus-lang.com            ]"
-          },
-          {
             "value": "none",
             "label": "None"
           }

--- a/packages/react/src/generators/setup-tailwind/lib/add-tailwind-style-imports.ts
+++ b/packages/react/src/generators/setup-tailwind/lib/add-tailwind-style-imports.ts
@@ -13,13 +13,11 @@ const knownLocations = [
   // Plain React
   'src/styles.css',
   'src/styles.scss',
-  'src/styles.styl',
   'src/styles.less',
 
   // Next.js
   'pages/styles.css',
   'pages/styles.scss',
-  'pages/styles.styl',
   'pages/styles.less',
 ];
 

--- a/packages/react/src/generators/setup-tailwind/setup-tailwind.spec.ts
+++ b/packages/react/src/generators/setup-tailwind/setup-tailwind.spec.ts
@@ -14,11 +14,9 @@ describe('setup-tailwind', () => {
     ${`src/styles.css`}
     ${`src/styles.scss`}
     ${`src/styles.less`}
-    ${`src/styles.styl`}
     ${`pages/styles.css`}
     ${`pages/styles.scss`}
     ${`pages/styles.less`}
-    ${`pages/styles.styl`}
   `('should update stylesheet', async ({ stylesPath }) => {
     const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'example', {

--- a/packages/react/src/utils/assertion.ts
+++ b/packages/react/src/utils/assertion.ts
@@ -2,12 +2,12 @@ const VALID_STYLES = [
   'css',
   'scss',
   'less',
-  'styl', // @TODO(17): deprecated, going to be removed in Nx 17
   'styled-components',
   '@emotion/styled',
   'styled-jsx',
   'none',
 ];
+
 export function assertValidStyle(style: string): void {
   if (VALID_STYLES.indexOf(style) === -1) {
     throw new Error(

--- a/packages/react/src/utils/versions.ts
+++ b/packages/react/src/utils/versions.ts
@@ -59,7 +59,6 @@ export const moduleFederationNodeVersion = '~0.9.9';
 // style preprocessors
 export const lessVersion = '3.12.2';
 export const sassVersion = '^1.55.0';
-export const stylusVersion = '^0.59.0';
 
 // rollup plugins (if needed)
 export const rollupPluginUrlVersion = '^7.0.0';

--- a/packages/react/typings/cssmodule.d.ts
+++ b/packages/react/typings/cssmodule.d.ts
@@ -17,8 +17,3 @@ declare module '*.module.less' {
   const classes: { readonly [key: string]: string };
   export default classes;
 }
-
-declare module '*.module.styl' {
-  const classes: { readonly [key: string]: string };
-  export default classes;
-}

--- a/packages/react/typings/style.d.ts
+++ b/packages/react/typings/style.d.ts
@@ -1,7 +1,6 @@
 export type SupportedStyles =
   | 'css'
   | 'scss'
-  | 'styl' // @TODO(17): deprecated, going to be removed in Nx 17
   | 'less'
   | 'styled-components'
   | '@emotion/styled'

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -52,8 +52,6 @@
     "sass-loader": "^12.2.0",
     "source-map-loader": "^3.0.0",
     "style-loader": "^3.3.0",
-    "stylus": "^0.59.0",
-    "stylus-loader": "^7.1.0",
     "terser-webpack-plugin": "^5.3.3",
     "ts-loader": "^9.3.1",
     "tsconfig-paths-webpack-plugin": "4.0.0",

--- a/packages/webpack/src/utils/get-css-module-local-ident.ts
+++ b/packages/webpack/src/utils/get-css-module-local-ident.ts
@@ -9,7 +9,7 @@ export function getCSSModuleLocalIdent(
 ) {
   // Use the filename or folder name, based on some uses the index.js / index.module.(css|scss|sass) project style
   const fileNameOrFolder = ctx.resourcePath.match(
-    /index\.module\.(css|scss|sass|styl)$/
+    /index\.module\.(css|scss|sass)$/
   )
     ? '[folder]'
     : '[name]';

--- a/packages/webpack/src/utils/with-web.ts
+++ b/packages/webpack/src/utils/with-web.ts
@@ -106,7 +106,7 @@ export function withWeb(pluginOptions: WithWebOptions = {}): NxWebpackPlugin {
     if (stylesOptimization) {
       minimizer.push(
         new CssMinimizerPlugin({
-          test: /\.(?:css|scss|sass|less|styl)$/,
+          test: /\.(?:css|scss|sass|less)$/,
         })
       );
     }
@@ -199,21 +199,6 @@ export function withWeb(pluginOptions: WithWebOptions = {}): NxWebpackPlugin {
           },
         ],
       },
-      {
-        test: /\.module\.styl$/,
-        exclude: globalStylePaths,
-        use: [
-          ...getCommonLoadersForCssModules(mergedOptions, includePaths),
-          {
-            loader: require.resolve('stylus-loader'),
-            options: {
-              stylusOptions: {
-                include: includePaths,
-              },
-            },
-          },
-        ],
-      },
     ];
 
     const globalCssRules: RuleSetRule[] = [
@@ -254,22 +239,6 @@ export function withWeb(pluginOptions: WithWebOptions = {}): NxWebpackPlugin {
               lessOptions: {
                 javascriptEnabled: true,
                 ...lessPathOptions,
-              },
-            },
-          },
-        ],
-      },
-      {
-        test: /\.styl$/,
-        exclude: globalStylePaths,
-        use: [
-          ...getCommonLoadersForGlobalCss(mergedOptions, includePaths),
-          {
-            loader: require.resolve('stylus-loader'),
-            options: {
-              sourceMap: !!mergedOptions.sourceMap,
-              stylusOptions: {
-                include: includePaths,
               },
             },
           },
@@ -320,27 +289,11 @@ export function withWeb(pluginOptions: WithWebOptions = {}): NxWebpackPlugin {
           },
         ],
       },
-      {
-        test: /\.styl$/,
-        include: globalStylePaths,
-        use: [
-          ...getCommonLoadersForGlobalStyle(mergedOptions, includePaths),
-          {
-            loader: require.resolve('stylus-loader'),
-            options: {
-              sourceMap: !!mergedOptions.sourceMap,
-              stylusOptions: {
-                include: includePaths,
-              },
-            },
-          },
-        ],
-      },
     ];
 
     const rules: RuleSetRule[] = [
       {
-        test: /\.css$|\.scss$|\.sass$|\.less$|\.styl$/,
+        test: /\.css$|\.scss$|\.sass$|\.less$/,
         oneOf: [...cssModuleRules, ...globalCssRules, ...globalStyleRules],
       },
     ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -878,12 +878,6 @@ devDependencies:
   styled-components:
     specifier: 5.3.6
     version: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-  stylus:
-    specifier: 0.59.0
-    version: 0.59.0
-  stylus-loader:
-    specifier: 7.1.0
-    version: 7.1.0(stylus@0.59.0)(webpack@5.88.0)
   tar-fs:
     specifier: ^2.1.1
     version: 2.1.1


### PR DESCRIPTION
This PR removes the Stylus option from React and Next.js apps. They've been deprecated since Nx 15, and will no longer be an option starting in Nx 17. Note that existing Stylus setup will continue to work until Nx 18, and we will provide guidance on switching to Sass before then.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
