### PR TITLE
chore(react): enable e2e testes for module federation

### DIFF
--- a/e2e/react-core/src/react-module-federation.test.ts
+++ b/e2e/react-core/src/react-module-federation.test.ts
@@ -1,6 +1,7 @@
 import { stripIndents } from '@nx/devkit';
 import {
   checkFilesExist,
+  ensureCypressInstallation,
   cleanupProject,
   killProcessAndPorts,
   newProject,
@@ -12,6 +13,7 @@ import {
   uniq,
   updateFile,
   updateJson,
+  killPorts,
 } from '@nx/e2e/utils';
 import { join } from 'path';
 
@@ -58,7 +60,7 @@ describe('React Module Federation', () => {
       stripIndents`
         import { composePlugins, withNx, ModuleFederationConfig } from '@nx/webpack';
         import { withReact } from '@nx/react';
-        import { withModuleFederation } from '@nx/react/module-federation');
+        import { withModuleFederation } from '@nx/react/module-federation';
         
         const baseConfig = require('./module-federation.config');
         
@@ -106,20 +108,15 @@ describe('React Module Federation', () => {
         });
       `
     );
-    // TODO(caleb): cypress isn't able to find the element and then throws error with an address already in use error.
-    // https://staging.nx.app/runs/ASAokpXhnE/task/e2e-react:e2e
-    // if (runCypressTests()) {
-    //   const e2eResults = runCLI(`e2e ${shell}-e2e --no-watch --verbose`);
-    //   expect(e2eResults).toContain('All specs passed!');
-    //   expect(
-    //     await killPorts([
-    //       readPort(shell),
-    //       readPort(remote1),
-    //       readPort(remote2),
-    //       readPort(remote3),
-    //     ])
-    //   ).toBeTruthy();
-    // }
+
+    if (runE2ETests()) {
+      const e2eResults = runCLI(`e2e ${shell}-e2e --no-watch --verbose`);
+      expect(e2eResults).toContain('All specs passed!');
+      await killPorts(readPort(shell));
+      await killPorts(readPort(remote1));
+      await killPorts(readPort(remote2));
+      await killPorts(readPort(remote3));
+    }
   }, 500_000);
 
   it('should should support generating host and remote apps with the new name and root format', async () => {


### PR DESCRIPTION
Re-enable disabled tests so we can prevent regression on React module federation feature.