### PR TITLE
fix(misc): pass full path to tsconfig when registering transpiler

### DIFF
--- a/docs/generated/packages/jest/documents/overview.md
+++ b/docs/generated/packages/jest/documents/overview.md
@@ -140,7 +140,7 @@ Nx provides a helper function that you can import within your setup/teardown fil
 
 ```typescript {% fileName="global-setup.ts" %}
 import { registerTsProject } from '@nx/js/src/internal';
-const cleanupRegisteredPaths = registerTsProject('.', 'tsconfig.base.json');
+const cleanupRegisteredPaths = registerTsProject('./tsconfig.base.json');
 
 import { yourFancyFunction } from '@some-org/my-util-library';
 export default async function () {
@@ -184,7 +184,7 @@ export default {
 
 ```typescript {% fileName="global-setup-swc.ts" %}
 import { registerTsProject } from '@nx/js/src/internal';
-const cleanupRegisteredPaths = registerTsProject('.', 'tsconfig.base.json');
+const cleanupRegisteredPaths = registerTsProject('./tsconfig.base.json');
 
 export default async function () {
   // swc will hoist all imports, and we need to make sure the register happens first

--- a/docs/shared/packages/jest/jest-plugin.md
+++ b/docs/shared/packages/jest/jest-plugin.md
@@ -140,7 +140,7 @@ Nx provides a helper function that you can import within your setup/teardown fil
 
 ```typescript {% fileName="global-setup.ts" %}
 import { registerTsProject } from '@nx/js/src/internal';
-const cleanupRegisteredPaths = registerTsProject('.', 'tsconfig.base.json');
+const cleanupRegisteredPaths = registerTsProject('./tsconfig.base.json');
 
 import { yourFancyFunction } from '@some-org/my-util-library';
 export default async function () {
@@ -184,7 +184,7 @@ export default {
 
 ```typescript {% fileName="global-setup-swc.ts" %}
 import { registerTsProject } from '@nx/js/src/internal';
-const cleanupRegisteredPaths = registerTsProject('.', 'tsconfig.base.json');
+const cleanupRegisteredPaths = registerTsProject('./tsconfig.base.json');
 
 export default async function () {
   // swc will hoist all imports, and we need to make sure the register happens first

--- a/e2e/jest/src/jest.test.ts
+++ b/e2e/jest/src/jest.test.ts
@@ -53,7 +53,7 @@ describe('Jest', () => {
       `libs/${mylib}/setup.ts`,
       stripIndents`
       const { registerTsProject } = require('@nx/js/src/internal');
-      const cleanup = registerTsProject('.', 'tsconfig.base.json');
+      const cleanup = registerTsProject('./tsconfig.base.json');
 
       import {setup} from '@global-fun/globals';
       export default async function() {setup();}
@@ -66,7 +66,7 @@ describe('Jest', () => {
       `libs/${mylib}/teardown.ts`,
       stripIndents`
       const { registerTsProject } = require('@nx/js/src/internal');
-      const cleanup = registerTsProject('.', 'tsconfig.base.json');
+      const cleanup = registerTsProject('./tsconfig.base.json');
 
       import {teardown} from '@global-fun/globals';
       export default async function() {teardown();}

--- a/packages/angular/src/builders/utilities/module-federation.ts
+++ b/packages/angular/src/builders/utilities/module-federation.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { basename, dirname, join } from 'path';
 import { existsSync, readFileSync } from 'fs';
 import { logger, ProjectConfiguration } from '@nx/devkit';
 import { registerTsProject } from '@nx/js/src/internal';
@@ -92,10 +92,7 @@ function getModuleFederationConfig(
 
   let cleanupTranspiler = () => {};
   if (existsSync(moduleFederationConfigPathTS)) {
-    cleanupTranspiler = registerTsProject(
-      moduleFederationConfigPathTS,
-      tsconfigPath
-    );
+    cleanupTranspiler = registerTsProject(join(workspaceRoot, tsconfigPath));
     moduleFederationConfigPath = moduleFederationConfigPathTS;
   }
 

--- a/packages/angular/src/builders/utilities/webpack.ts
+++ b/packages/angular/src/builders/utilities/webpack.ts
@@ -1,5 +1,7 @@
 import { merge } from 'webpack-merge';
 import { registerTsProject } from '@nx/js/src/internal';
+import { workspaceRoot } from '@nx/devkit';
+import { join } from 'path';
 
 export async function mergeCustomWebpackConfig(
   baseWebpackConfig: any,
@@ -9,7 +11,7 @@ export async function mergeCustomWebpackConfig(
 ) {
   const customWebpackConfiguration = resolveCustomWebpackConfig(
     pathToWebpackConfig,
-    options.tsConfig
+    join(workspaceRoot, options.tsConfig)
   );
   // The extra Webpack configuration file can also export a Promise, for instance:
   // `module.exports = new Promise(...)`. If it exports a single object, but not a Promise,
@@ -26,7 +28,7 @@ export async function mergeCustomWebpackConfig(
 }
 
 export function resolveCustomWebpackConfig(path: string, tsConfig: string) {
-  const cleanupTranspiler = registerTsProject(path, tsConfig);
+  const cleanupTranspiler = registerTsProject(tsConfig);
   const customWebpackConfig = require(path);
   cleanupTranspiler();
   // If the user provides a configuration in TS file
@@ -42,7 +44,7 @@ export function resolveIndexHtmlTransformer(
   tsConfig: string,
   target: import('@angular-devkit/architect').Target
 ) {
-  const cleanupTranspiler = registerTsProject(path, tsConfig);
+  const cleanupTranspiler = registerTsProject(tsConfig);
   const indexTransformer = require(path);
   cleanupTranspiler();
 

--- a/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
+++ b/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
@@ -9,6 +9,7 @@ import { existsSync } from 'fs';
 import { readNxJson } from 'nx/src/config/configuration';
 import { isNpmProject } from 'nx/src/project-graph/operators';
 import { getDependencyConfigs } from 'nx/src/tasks-runner/utils';
+import { join } from 'path';
 import { from, Observable } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { createTmpTsConfigForBuildableLibs } from '../utilities/buildable-libs';
@@ -135,7 +136,7 @@ export function executeWebpackBrowserBuilder(
           ? {
               indexHtml: resolveIndexHtmlTransformer(
                 pathToIndexFileTransformer,
-                delegateBuilderOptions.tsConfig,
+                join(context.workspaceRoot, delegateBuilderOptions.tsConfig),
                 context.target
               ),
             }

--- a/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
+++ b/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
@@ -136,7 +136,7 @@ export function executeWebpackBrowserBuilder(
           ? {
               indexHtml: resolveIndexHtmlTransformer(
                 pathToIndexFileTransformer,
-                join(context.workspaceRoot, delegateBuilderOptions.tsConfig),
+                delegateBuilderOptions.tsConfig,
                 context.target
               ),
             }

--- a/packages/angular/src/builders/webpack-dev-server/webpack-dev-server.impl.ts
+++ b/packages/angular/src/builders/webpack-dev-server/webpack-dev-server.impl.ts
@@ -19,6 +19,7 @@ import { createTmpTsConfigForBuildableLibs } from '../utilities/buildable-libs';
 import { from } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { getRootTsConfigPath } from '@nx/js';
+import { join } from 'path';
 
 type BuildTargetOptions = {
   tsConfig: string;
@@ -159,7 +160,7 @@ export function executeWebpackDevServerBuilder(
           ? {
               indexHtml: resolveIndexHtmlTransformer(
                 pathToIndexFileTransformer,
-                buildTargetOptions.tsConfig,
+                join(context.workspaceRoot, buildTargetOptions.tsConfig),
                 context.target
               ),
             }

--- a/packages/angular/src/builders/webpack-dev-server/webpack-dev-server.impl.ts
+++ b/packages/angular/src/builders/webpack-dev-server/webpack-dev-server.impl.ts
@@ -160,7 +160,7 @@ export function executeWebpackDevServerBuilder(
           ? {
               indexHtml: resolveIndexHtmlTransformer(
                 pathToIndexFileTransformer,
-                join(context.workspaceRoot, buildTargetOptions.tsConfig),
+                buildTargetOptions.tsConfig,
                 context.target
               ),
             }

--- a/packages/eslint-plugin/src/resolve-workspace-rules.ts
+++ b/packages/eslint-plugin/src/resolve-workspace-rules.ts
@@ -2,6 +2,7 @@ import type { TSESLint } from '@typescript-eslint/utils';
 import { existsSync } from 'fs';
 import { registerTsProject } from '@nx/js/src/internal';
 import { WORKSPACE_PLUGIN_DIR, WORKSPACE_RULE_NAMESPACE } from './constants';
+import { join } from 'path';
 
 type ESLintRules = Record<string, TSESLint.RuleModule<string, unknown[]>>;
 
@@ -11,7 +12,9 @@ export const workspaceRules = ((): ESLintRules => {
     return {};
   }
   // Register `tools/eslint-rules` for TS transpilation
-  const registrationCleanup = registerTsProject(WORKSPACE_PLUGIN_DIR);
+  const registrationCleanup = registerTsProject(
+    join(WORKSPACE_PLUGIN_DIR, 'tsconfig.json')
+  );
   try {
     /**
      * Currently we only support applying the rules from the user's workspace plugin object

--- a/packages/eslint-plugin/src/rules/nx-plugin-checks.ts
+++ b/packages/eslint-plugin/src/rules/nx-plugin-checks.ts
@@ -14,6 +14,7 @@ import * as path from 'path';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { readProjectGraph } from '../utils/project-graph-utils';
 import { valid } from 'semver';
+import { join } from 'path';
 
 type Options = [
   {
@@ -147,7 +148,7 @@ export default createESLintRule<Options, MessageIds>({
     }
 
     if (!(global as any).tsProjectRegistered) {
-      registerTsProject(workspaceRoot, 'tsconfig.base.json');
+      registerTsProject(join(workspaceRoot, 'tsconfig.base.json'));
       (global as any).tsProjectRegistered = true;
     }
 

--- a/packages/nx/src/plugins/js/utils/register.ts
+++ b/packages/nx/src/plugins/js/utils/register.ts
@@ -18,11 +18,24 @@ let ts: typeof import('typescript');
  *
  * @returns cleanup function
  */
-export const registerTsProject = (
+export function registerTsProject(tsConfigPath: string): () => void;
+/**
+ * Optionally, if swc-node and tsconfig-paths are available in the current workspace, apply the require
+ * register hooks so that .ts files can be used for writing custom workspace projects.
+ *
+ * If ts-node and tsconfig-paths are not available, the user can still provide an index.js file in
+ * the root of their project and the fundamentals will still work (but
+ * workspace path mapping will not, for example).
+ *
+ * @returns cleanup function
+ * @deprecated This signature will be removed in Nx v18. You should pass the full path to the tsconfig in the first argument.
+ */
+export function registerTsProject(path: string, configFilename: string);
+export function registerTsProject(
   path: string,
-  configFilename = 'tsconfig.json'
-): (() => void) => {
-  const tsConfigPath = join(path, configFilename);
+  configFilename?: string
+): () => void {
+  const tsConfigPath = configFilename ? join(path, configFilename) : path;
   const compilerOptions: CompilerOptions = readCompilerOptions(tsConfigPath);
 
   const cleanupFunctions: ((...args: unknown[]) => unknown)[] = [
@@ -35,7 +48,7 @@ export const registerTsProject = (
       fn();
     }
   };
-};
+}
 
 export function getSwcTranspiler(
   compilerOptions: CompilerOptions

--- a/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -56,10 +56,7 @@ function getModuleFederationConfig(
   // create a no-op so this can be called with issue
   let cleanupTranspiler = () => {};
   if (existsSync(moduleFederationConfigPathTS)) {
-    cleanupTranspiler = registerTsProject(
-      moduleFederationConfigPathTS,
-      tsconfigPath
-    );
+    cleanupTranspiler = registerTsProject(join(workspaceRoot, tsconfigPath));
     moduleFederationConfigPath = moduleFederationConfigPathTS;
   }
 

--- a/packages/webpack/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/webpack/src/executors/dev-server/dev-server.impl.ts
@@ -19,6 +19,7 @@ import { resolveCustomWebpackConfig } from '../../utils/webpack/custom-webpack';
 import { normalizeOptions } from '../webpack/lib/normalize-options';
 import { WebpackExecutorOptions } from '../webpack/schema';
 import { WebDevServerOptions } from './schema';
+import { join } from 'path';
 
 export async function* devServerExecutor(
   serveOptions: WebDevServerOptions,
@@ -64,7 +65,7 @@ export async function* devServerExecutor(
   if (buildOptions.webpackConfig) {
     let customWebpack = resolveCustomWebpackConfig(
       buildOptions.webpackConfig,
-      buildOptions.tsConfig
+      join(context.root, buildOptions.tsConfig)
     );
 
     if (typeof customWebpack.then === 'function') {

--- a/packages/webpack/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/webpack/src/executors/dev-server/dev-server.impl.ts
@@ -63,9 +63,12 @@ export async function* devServerExecutor(
   let config = getDevServerConfig(context, buildOptions, serveOptions);
 
   if (buildOptions.webpackConfig) {
+    let tsconfigPath = buildOptions.tsConfig.startsWith(context.root)
+      ? buildOptions.tsConfig
+      : join(context.root, buildOptions.tsConfig);
     let customWebpack = resolveCustomWebpackConfig(
       buildOptions.webpackConfig,
-      join(context.root, buildOptions.tsConfig)
+      tsconfigPath
     );
 
     if (typeof customWebpack.then === 'function') {

--- a/packages/webpack/src/executors/webpack/webpack.impl.ts
+++ b/packages/webpack/src/executors/webpack/webpack.impl.ts
@@ -45,7 +45,7 @@ async function getWebpackConfigs(
   if (options.webpackConfig) {
     customWebpack = resolveCustomWebpackConfig(
       options.webpackConfig,
-      join(workspaceRoot, options.tsConfig)
+      options.tsConfig
     );
 
     if (typeof customWebpack.then === 'function') {

--- a/packages/webpack/src/executors/webpack/webpack.impl.ts
+++ b/packages/webpack/src/executors/webpack/webpack.impl.ts
@@ -1,4 +1,9 @@
-import { ExecutorContext, logger, stripIndents } from '@nx/devkit';
+import {
+  ExecutorContext,
+  logger,
+  stripIndents,
+  workspaceRoot,
+} from '@nx/devkit';
 import { eachValueFrom } from '@nx/devkit/src/utils/rxjs-for-await';
 import type { Configuration, Stats } from 'webpack';
 import { from, of } from 'rxjs';
@@ -9,7 +14,7 @@ import {
   switchMap,
   tap,
 } from 'rxjs/operators';
-import { resolve } from 'path';
+import { join, resolve } from 'path';
 import {
   calculateProjectBuildableDependencies,
   createTmpTsConfig,
@@ -40,7 +45,7 @@ async function getWebpackConfigs(
   if (options.webpackConfig) {
     customWebpack = resolveCustomWebpackConfig(
       options.webpackConfig,
-      options.tsConfig
+      join(workspaceRoot, options.tsConfig)
     );
 
     if (typeof customWebpack.then === 'function') {

--- a/packages/webpack/src/utils/webpack/custom-webpack.ts
+++ b/packages/webpack/src/utils/webpack/custom-webpack.ts
@@ -1,7 +1,7 @@
 import { registerTsProject } from '@nx/js/src/internal';
 
 export function resolveCustomWebpackConfig(path: string, tsConfig: string) {
-  const cleanupTranspiler = registerTsProject(path, tsConfig);
+  const cleanupTranspiler = registerTsProject(tsConfig);
   const customWebpackConfig = require(path);
   cleanupTranspiler();
 


### PR DESCRIPTION
Currently when invoking registerTsProject you are meant to pass two arguments:
- The root directory that the tsconfig name is relative to
- The name of the tsconfig

This would look something like: `registerTsProject('path/to/my-project', 'tsconfig.app.json')`. There are a few places in the codebase where I found that the first path was not to this root, and we never used that arg without also joining on the tsconfig name at the end.

This updates the helper function to take a singular arg, the path to the tsconfig. The original signature is deprecated and will be removed in v18, since we had a docs page that referenced it. We could add a migration for this if anyone thinks its worth it, but I think the deprecation notice should suffice.

The bad method calls surfaced as a warning that tsconfig-paths wasn't installed, which was clearly wrong. This was because we tried to invoke tsconfig paths on a bad path (it looked something like 'path/to/my-project/module-federation.config.ts/tsconfig.json'). This PR also updates the relevant places that called the helper to use the new signature

Fixes https://github.com/nrwl/nx/issues/19460
