### PR TITLE
feat(react): use TS config files for module federation

### DIFF
--- a/docs/generated/packages/react/generators/host.json
+++ b/docs/generated/packages/react/generators/host.json
@@ -164,7 +164,7 @@
       "typescriptConfiguration": {
         "type": "boolean",
         "description": "Whether the module federation configuration and webpack configuration files should use TS.",
-        "default": false
+        "default": true
       }
     },
     "required": ["name"],

--- a/docs/generated/packages/react/generators/remote.json
+++ b/docs/generated/packages/react/generators/remote.json
@@ -162,7 +162,7 @@
       "typescriptConfiguration": {
         "type": "boolean",
         "description": "Whether the module federation configuration and webpack configuration files should use TS.",
-        "default": false
+        "default": true
       }
     },
     "required": ["name"],

--- a/e2e/react-core/src/react-module-federation.test.ts
+++ b/e2e/react-core/src/react-module-federation.test.ts
@@ -64,9 +64,9 @@ describe('React Module Federation', () => {
       stripIndents`
         import { composePlugins, withNx, ModuleFederationConfig } from '@nx/webpack';
         import { withReact } from '@nx/react';
-        import { withModuleFederation } from '@nx/react/module-federation');
+        import { withModuleFederation } from '@nx/react/module-federation';
         
-        const baseConfig = require('./module-federation.config');
+        import baseConfig from './module-federation.config';
         
         const config: ModuleFederationConfig = {
           ...baseConfig,

--- a/e2e/react-core/src/react-module-federation.test.ts
+++ b/e2e/react-core/src/react-module-federation.test.ts
@@ -2,6 +2,7 @@ import { Tree, stripIndents } from '@nx/devkit';
 import {
   checkFilesExist,
   cleanupProject,
+  killPorts,
   killProcessAndPorts,
   newProject,
   readJson,
@@ -111,20 +112,15 @@ describe('React Module Federation', () => {
         });
       `
     );
-    // TODO(caleb): cypress isn't able to find the element and then throws error with an address already in use error.
-    // https://staging.nx.app/runs/ASAokpXhnE/task/e2e-react:e2e
-    // if (runCypressTests()) {
-    //   const e2eResults = runCLI(`e2e ${shell}-e2e --no-watch --verbose`);
-    //   expect(e2eResults).toContain('All specs passed!');
-    //   expect(
-    //     await killPorts([
-    //       readPort(shell),
-    //       readPort(remote1),
-    //       readPort(remote2),
-    //       readPort(remote3),
-    //     ])
-    //   ).toBeTruthy();
-    // }
+
+    if (runE2ETests()) {
+      const e2eResults = runCLI(`e2e ${shell}-e2e --no-watch --verbose`);
+      expect(e2eResults).toContain('All specs passed!');
+      await killPorts(readPort(shell));
+      await killPorts(readPort(remote1));
+      await killPorts(readPort(remote2));
+      await killPorts(readPort(remote3));
+    }
   }, 500_000);
 
   it('should should support generating host and remote apps with the new name and root format', async () => {

--- a/e2e/react-core/src/react-module-federation.test.ts
+++ b/e2e/react-core/src/react-module-federation.test.ts
@@ -2,7 +2,6 @@ import { Tree, stripIndents } from '@nx/devkit';
 import {
   checkFilesExist,
   cleanupProject,
-  killPorts,
   killProcessAndPorts,
   newProject,
   readJson,
@@ -45,10 +44,10 @@ describe('React Module Federation', () => {
       `generate @nx/react:remote ${remote3} --style=css --host=${shell} --no-interactive`
     );
 
-    checkFilesExist(`apps/${shell}/module-federation.config.js`);
-    checkFilesExist(`apps/${remote1}/module-federation.config.js`);
-    checkFilesExist(`apps/${remote2}/module-federation.config.js`);
-    checkFilesExist(`apps/${remote3}/module-federation.config.js`);
+    checkFilesExist(`apps/${shell}/module-federation.config.ts`);
+    checkFilesExist(`apps/${remote1}/module-federation.config.ts`);
+    checkFilesExist(`apps/${remote2}/module-federation.config.ts`);
+    checkFilesExist(`apps/${remote3}/module-federation.config.ts`);
 
     await expect(runCLIAsync(`test ${shell}`)).resolves.toMatchObject({
       combinedOutput: expect.stringContaining('Test Suites: 1 passed, 1 total'),
@@ -60,15 +59,15 @@ describe('React Module Federation', () => {
     expect(readPort(remote3)).toEqual(4203);
 
     updateFile(
-      `apps/${shell}/webpack.config.js`,
+      `apps/${shell}/webpack.config.ts`,
       stripIndents`
-        const { composePlugins, withNx, ModuleFederationConfig } = require('@nx/webpack');
-        const { withReact } = require('@nx/react');
-        const { withModuleFederation } = require('@nx/react/module-federation');
+        import { composePlugins, withNx, ModuleFederationConfig } from '@nx/webpack';
+        import { withReact } from '@nx/react';
+        import { withModuleFederation } from '@nx/react/module-federation');
         
         const baseConfig = require('./module-federation.config');
         
-        const config = {
+        const config: ModuleFederationConfig = {
           ...baseConfig,
               remotes: [
                 '${remote1}',
@@ -112,15 +111,20 @@ describe('React Module Federation', () => {
         });
       `
     );
-
-    if (runE2ETests()) {
-      const e2eResults = runCLI(`e2e ${shell}-e2e --no-watch --verbose`);
-      expect(e2eResults).toContain('All specs passed!');
-      await killPorts(readPort(shell));
-      await killPorts(readPort(remote1));
-      await killPorts(readPort(remote2));
-      await killPorts(readPort(remote3));
-    }
+    // TODO(caleb): cypress isn't able to find the element and then throws error with an address already in use error.
+    // https://staging.nx.app/runs/ASAokpXhnE/task/e2e-react:e2e
+    // if (runCypressTests()) {
+    //   const e2eResults = runCLI(`e2e ${shell}-e2e --no-watch --verbose`);
+    //   expect(e2eResults).toContain('All specs passed!');
+    //   expect(
+    //     await killPorts([
+    //       readPort(shell),
+    //       readPort(remote1),
+    //       readPort(remote2),
+    //       readPort(remote3),
+    //     ])
+    //   ).toBeTruthy();
+    // }
   }, 500_000);
 
   it('should should support generating host and remote apps with the new name and root format', async () => {
@@ -137,8 +141,8 @@ describe('React Module Federation', () => {
 
     // check files are generated without the layout directory ("apps/") and
     // using the project name as the directory when no directory is provided
-    checkFilesExist(`${shell}/module-federation.config.js`);
-    checkFilesExist(`${remote}/module-federation.config.js`);
+    checkFilesExist(`${shell}/module-federation.config.ts`);
+    checkFilesExist(`${remote}/module-federation.config.ts`);
 
     // check default generated host is built successfully
     const buildOutput = runCLI(`run ${shell}:build:development`);
@@ -305,31 +309,31 @@ describe('React Module Federation', () => {
 
     // update host and remote to use library type var
     updateFile(
-      `${shell}/module-federation.config.js`,
+      `${shell}/module-federation.config.ts`,
       stripIndents`
-      const { ModuleFederationConfig } = require('@nx/webpack');
+      import { ModuleFederationConfig } from '@nx/webpack';
 
-      const config = {
+      const config: ModuleFederationConfig = {
         name: '${shell}',
         library: { type: 'var', name: '${shell}' },
         remotes: ['${remote}'],
       };
 
-      module.exports = config;
+      export default config;
       `
     );
 
     updateFile(
-      `${shell}/webpack.config.prod.js`,
-      `module.exports = require('./webpack.config');`
+      `${shell}/webpack.config.prod.ts`,
+      `export { default } from './webpack.config';`
     );
 
     updateFile(
-      `${remote}/module-federation.config.js`,
+      `${remote}/module-federation.config.ts`,
       stripIndents`
-      const { ModuleFederationConfig } = require('@nx/webpack');
+      import { ModuleFederationConfig } from '@nx/webpack';
 
-      const config = {
+      const config: ModuleFederationConfig = {
         name: '${remote}',
         library: { type: 'var', name: '${remote}' },
         exposes: {
@@ -337,13 +341,13 @@ describe('React Module Federation', () => {
         },
       };
 
-      module.exports = config;
+      export default config;
       `
     );
 
     updateFile(
-      `${remote}/webpack.config.prod.js`,
-      `module.exports = require('./webpack.config');`
+      `${remote}/webpack.config.prod.ts`,
+      `export { default } from './webpack.config';`
     );
 
     // Update host e2e test to check that the remote works with library type var via navigation

--- a/e2e/utils/command-utils.ts
+++ b/e2e/utils/command-utils.ts
@@ -229,7 +229,10 @@ export function runCommandAsync(
 
 export function runCommandUntil(
   command: string,
-  criteria: (output: string) => boolean
+  criteria: (output: string) => boolean,
+  opts: RunCmdOpts = {
+    env: undefined,
+  }
 ): Promise<ChildProcess> {
   const pm = getPackageManagerCommand();
   const p = exec(`${pm.runNx} ${command}`, {
@@ -238,6 +241,7 @@ export function runCommandUntil(
     env: {
       CI: 'true',
       ...getStrippedEnvironmentVariables(),
+      ...opts.env,
       FORCE_COLOR: 'false',
     },
   });

--- a/packages/react/plugins/component-testing/index.ts
+++ b/packages/react/plugins/component-testing/index.ts
@@ -253,7 +253,9 @@ function buildTargetWebpack(
   if (options.webpackConfig) {
     customWebpack = resolveCustomWebpackConfig(
       options.webpackConfig,
-      options.tsConfig
+      options.tsConfig.startsWith(context.root)
+        ? options.tsConfig
+        : join(context.root, options.tsConfig)
     );
   }
 

--- a/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -54,9 +54,12 @@ function getModuleFederationConfig(
   let moduleFederationConfigPath = moduleFederationConfigPathJS;
 
   // create a no-op so this can be called with issue
+  const fullTSconfigPath = tsconfigPath.startsWith(workspaceRoot)
+    ? tsconfigPath
+    : join(workspaceRoot, tsconfigPath);
   let cleanupTranspiler = () => {};
   if (existsSync(moduleFederationConfigPathTS)) {
-    cleanupTranspiler = registerTsProject(join(workspaceRoot, tsconfigPath));
+    cleanupTranspiler = registerTsProject(fullTSconfigPath);
     moduleFederationConfigPath = moduleFederationConfigPathTS;
   }
 

--- a/packages/react/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
@@ -2,6 +2,8 @@ import {
   ExecutorContext,
   getPackageManagerCommand,
   logger,
+  parseTargetString,
+  readTargetOptions,
   runExecutor,
   workspaceRoot,
 } from '@nx/devkit';
@@ -16,6 +18,8 @@ import {
   tapAsyncIterable,
 } from '@nx/devkit/src/utils/async-iterable';
 import { execSync, fork } from 'child_process';
+import { existsSync } from 'fs';
+import { registerTsProject } from '@nx/js/src/internal';
 
 type ModuleFederationDevServerOptions = WebSsrDevServerOptions & {
   devRemotes?: string | string[];
@@ -23,28 +27,69 @@ type ModuleFederationDevServerOptions = WebSsrDevServerOptions & {
   host: string;
 };
 
+function getBuildOptions(buildTarget: string, context: ExecutorContext) {
+  const target = parseTargetString(buildTarget, context);
+
+  const buildOptions = readTargetOptions(target, context);
+
+  return {
+    ...buildOptions,
+  };
+}
+
+function getModuleFederationConfig(
+  tsconfigPath: string,
+  workspaceRoot: string,
+  projectRoot: string
+) {
+  const moduleFederationConfigPathJS = join(
+    workspaceRoot,
+    projectRoot,
+    'module-federation.config.js'
+  );
+
+  const moduleFederationConfigPathTS = join(
+    workspaceRoot,
+    projectRoot,
+    'module-federation.config.ts'
+  );
+
+  let moduleFederationConfigPath = moduleFederationConfigPathJS;
+
+  const fullTSconfigPath = tsconfigPath.startsWith(workspaceRoot)
+    ? tsconfigPath
+    : join(workspaceRoot, tsconfigPath);
+  // create a no-op so this can be called with issue
+  let cleanupTranspiler = () => {};
+  if (existsSync(moduleFederationConfigPathTS)) {
+    cleanupTranspiler = registerTsProject(fullTSconfigPath);
+    moduleFederationConfigPath = moduleFederationConfigPathTS;
+  }
+
+  try {
+    const config = require(moduleFederationConfigPath);
+    cleanupTranspiler();
+
+    return config.default || config;
+  } catch {
+    throw new Error(
+      `Could not load ${moduleFederationConfigPath}. Was this project generated with "@nx/react:host"?\nSee: https://nx.dev/concepts/more-concepts/faster-builds-with-module-federation`
+    );
+  }
+}
+
 export default async function* moduleFederationSsrDevServer(
   options: ModuleFederationDevServerOptions,
   context: ExecutorContext
 ) {
   let iter: any = ssrDevServerExecutor(options, context);
   const p = context.projectsConfigurations.projects[context.projectName];
-
-  const moduleFederationConfigPath = join(
+  const buildOptions = getBuildOptions(options.browserTarget, context);
+  const moduleFederationConfig = getModuleFederationConfig(
+    buildOptions.tsConfig,
     context.root,
-    p.root,
-    'module-federation.config.js'
+    p.root
   );
-
-  let moduleFederationConfig: any;
-  try {
-    moduleFederationConfig = require(moduleFederationConfigPath);
-  } catch {
-    // TODO(jack): Add a link to guide
-    throw new Error(
-      `Could not load ${moduleFederationConfigPath}. Was this project generated with "@nx/react:host"?`
-    );
-  }
 
   const remotesToSkip = new Set(options.skipRemotes ?? []);
   const remotesNotInWorkspace: string[] = [];

--- a/packages/react/src/generators/federate-module/lib/utils.ts
+++ b/packages/react/src/generators/federate-module/lib/utils.ts
@@ -32,7 +32,9 @@ export function addPathToExposes(
 ) {
   const moduleFederationConfigPath = joinPathFragments(
     projectPath,
-    'module-federation.config.js'
+    tree.exists(joinPathFragments(projectPath, 'module-federation.config.ts'))
+      ? 'module-federation.config.ts'
+      : 'module-federation.config.js'
   );
 
   updateExposesProperty(
@@ -51,9 +53,11 @@ export function addPathToExposes(
 export function checkRemoteExists(tree: Tree, remoteName: string) {
   const remote = getRemote(tree, remoteName);
   if (!remote) return false;
-  const hasModuleFederationConfig = tree.exists(
-    joinPathFragments(remote.root, 'module-federation.config.js')
-  );
+  const hasModuleFederationConfig =
+    tree.exists(
+      joinPathFragments(remote.root, 'module-federation.config.js')
+    ) ||
+    tree.exists(joinPathFragments(remote.root, 'module-federation.config.ts'));
 
   return hasModuleFederationConfig ? remote : false;
 }

--- a/packages/react/src/generators/host/schema.json
+++ b/packages/react/src/generators/host/schema.json
@@ -170,7 +170,7 @@
     "typescriptConfiguration": {
       "type": "boolean",
       "description": "Whether the module federation configuration and webpack configuration files should use TS.",
-      "default": false
+      "default": true
     }
   },
   "required": ["name"],

--- a/packages/react/src/generators/remote/schema.json
+++ b/packages/react/src/generators/remote/schema.json
@@ -168,7 +168,7 @@
     "typescriptConfiguration": {
       "type": "boolean",
       "description": "Whether the module federation configuration and webpack configuration files should use TS.",
-      "default": false
+      "default": true
     }
   },
   "required": ["name"],

--- a/packages/webpack/src/executors/webpack/webpack.impl.ts
+++ b/packages/webpack/src/executors/webpack/webpack.impl.ts
@@ -32,6 +32,7 @@ import { normalizeOptions } from './lib/normalize-options';
 
 async function getWebpackConfigs(
   options: NormalizedWebpackExecutorOptions,
+  projectRoot: string,
   context: ExecutorContext
 ): Promise<Configuration | Configuration[]> {
   if (options.isolatedConfig && !options.webpackConfig) {
@@ -41,11 +42,12 @@ async function getWebpackConfigs(
   }
 
   let customWebpack = null;
-
   if (options.webpackConfig) {
     customWebpack = resolveCustomWebpackConfig(
       options.webpackConfig,
-      options.tsConfig
+      options.tsConfig.startsWith(context.root)
+        ? options.tsConfig
+        : join(context.root, options.tsConfig)
     );
 
     if (typeof customWebpack.then === 'function') {
@@ -153,7 +155,7 @@ export async function* webpackExecutor(
     );
   }
 
-  const configs = await getWebpackConfigs(options, context);
+  const configs = await getWebpackConfigs(options, metadata.root, context);
 
   return yield* eachValueFrom(
     of(configs).pipe(

--- a/packages/webpack/src/utils/module-federation/models/index.ts
+++ b/packages/webpack/src/utils/module-federation/models/index.ts
@@ -17,7 +17,7 @@ export type SharedWorkspaceLibraryConfig = {
   getReplacementPlugin: () => NormalModuleReplacementPlugin;
 };
 
-export type Remotes = string[] | [remoteName: string, remoteUrl: string][];
+export type Remotes = Array<string | [remoteName: string, remoteUrl: string]>;
 
 export interface SharedLibraryConfig {
   singleton?: boolean;

--- a/packages/webpack/src/utils/webpack/custom-webpack.ts
+++ b/packages/webpack/src/utils/webpack/custom-webpack.ts
@@ -2,15 +2,24 @@ import { registerTsProject } from '@nx/js/src/internal';
 
 export function resolveCustomWebpackConfig(path: string, tsConfig: string) {
   const cleanupTranspiler = registerTsProject(tsConfig);
-  const customWebpackConfig = require(path);
+  const maybeCustomWebpackConfig = require(path);
   cleanupTranspiler();
 
   // If the user provides a configuration in TS file
-  // then there are 2 cases for exporing an object. The first one is:
+  // then there are 3 cases for exporing an object. The first one is:
   // `module.exports = { ... }`. And the second one is:
   // `export default { ... }`. The ESM format is compiled into:
   // `{ default: { ... } }`
-  return customWebpackConfig.default || customWebpackConfig;
+  // There is also a case of
+  // `{ default: { default: { ... } }`
+  const customWebpackConfig =
+    'default' in maybeCustomWebpackConfig
+      ? 'default' in maybeCustomWebpackConfig.default
+        ? maybeCustomWebpackConfig.default.default
+        : maybeCustomWebpackConfig.default
+      : maybeCustomWebpackConfig;
+
+  return customWebpackConfig;
 }
 
 export function isRegistered() {


### PR DESCRIPTION
- Revert "feat(react): use JS webpack config files for module federation (#19452)"
- chore(react): enable module federation cypress test
- chore(react): check ts-node in e2es

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently using JS Config Files as default for Module Federation
ts-node is not being checked in e2es as a transpiler for the TS Config Files

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Make TS Config Files default for Module Federation
Ensure ts-node is being used in the e2es as a transpiler for the TS Config Files

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
