### PR TITLE
chore(bundling): bump up timeout on e2e test for esbuild watcher

### DIFF
--- a/e2e/esbuild/src/esbuild.test.ts
+++ b/e2e/esbuild/src/esbuild.test.ts
@@ -109,8 +109,8 @@ describe('EsBuild Plugin', () => {
       waitUntil(
         () => readFile(`dist/libs/${myPkg}/assets/a.md`).includes('updated a'),
         {
-          timeout: 20_000,
-          ms: 500,
+          timeout: 60_000,
+          ms: 1000,
         }
       )
     ).resolves.not.toThrow();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
