### PR TITLE
Fix custom local angular executors not being transpiled

### DIFF
--- a/docs/generated/devkit/ngcli_adapter/NxScopedHost.md
+++ b/docs/generated/devkit/ngcli_adapter/NxScopedHost.md
@@ -16,6 +16,7 @@
 
 - [\_delegate](../../devkit/documents/ngcli_adapter/NxScopedHost#_delegate): Host&lt;any&gt;
 - [\_root](../../devkit/documents/ngcli_adapter/NxScopedHost#_root): Path
+- [projectGraph](../../devkit/documents/ngcli_adapter/NxScopedHost#projectgraph): ProjectGraph
 - [root](../../devkit/documents/ngcli_adapter/NxScopedHost#root): string
 
 ### Accessors
@@ -44,13 +45,14 @@
 
 ### constructor
 
-• **new NxScopedHost**(`root`)
+• **new NxScopedHost**(`root`, `projectGraph?`)
 
 #### Parameters
 
-| Name   | Type     |
-| :----- | :------- |
-| `root` | `string` |
+| Name            | Type           |
+| :-------------- | :------------- |
+| `root`          | `string`       |
+| `projectGraph?` | `ProjectGraph` |
 
 #### Overrides
 
@@ -78,9 +80,15 @@ virtualFs.ScopedHost.\_root
 
 ---
 
+### projectGraph
+
+• `Private` `Optional` `Readonly` **projectGraph**: `ProjectGraph`
+
+---
+
 ### root
 
-• `Private` **root**: `string`
+• `Private` `Readonly` **root**: `string`
 
 ## Accessors
 

--- a/docs/generated/devkit/ngcli_adapter/wrapAngularDevkitSchematic.md
+++ b/docs/generated/devkit/ngcli_adapter/wrapAngularDevkitSchematic.md
@@ -1,6 +1,6 @@
 # Function: wrapAngularDevkitSchematic
 
-▸ **wrapAngularDevkitSchematic**(`collectionName`, `generatorName`): (`host`: `Tree`, `generatorOptions`: { `[k: string]`: `any`; }) => `Promise`<`any`\>
+▸ **wrapAngularDevkitSchematic**(`collectionName`, `generatorName`): (`host`: `Tree`, `projectGraph`: `ProjectGraph`, `generatorOptions`: { `[k: string]`: `any`; }) => `Promise`<`any`\>
 
 #### Parameters
 
@@ -13,14 +13,15 @@
 
 `fn`
 
-▸ (`host`, `generatorOptions`): `Promise`<`any`\>
+▸ (`host`, `projectGraph`, `generatorOptions`): `Promise`<`any`\>
 
 ##### Parameters
 
-| Name               | Type     |
-| :----------------- | :------- |
-| `host`             | `Tree`   |
-| `generatorOptions` | `Object` |
+| Name               | Type           |
+| :----------------- | :------------- |
+| `host`             | `Tree`         |
+| `projectGraph`     | `ProjectGraph` |
+| `generatorOptions` | `Object`       |
 
 ##### Returns
 

--- a/packages/nx/src/adapter/ngcli-adapter.spec.ts
+++ b/packages/nx/src/adapter/ngcli-adapter.spec.ts
@@ -26,7 +26,11 @@ describe('ngcli-adapter', () => {
     );
 
     // ACT
-    await wrappedSchematic(tree, { name: 'test', project: 'test' });
+    await wrappedSchematic(
+      tree,
+      { nodes: {}, externalNodes: {}, dependencies: {} },
+      { name: 'test', project: 'test' }
+    );
 
     // ASSERT
     expect(tree.exists('src/lib/test.ts')).toBeTruthy();

--- a/packages/nx/src/command-line/generate/generate.ts
+++ b/packages/nx/src/command-line/generate/generate.ts
@@ -408,6 +408,7 @@ export async function generate(cwd: string, args: { [k: string]: any }) {
       require('../../adapter/compat');
       return (await import('../../adapter/ngcli-adapter')).generate(
         workspaceRoot,
+        projectGraph,
         {
           ...opts,
           generatorOptions: combinedOpts,

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -59,6 +59,7 @@ import { readNxJson } from '../../config/configuration';
 import { runNxSync } from '../../utils/child-process';
 import { daemonClient } from '../../daemon/client/client';
 import { isNxCloudUsed } from '../../utils/nx-cloud-utils';
+import { createProjectGraphAsync } from '../../project-graph/project-graph';
 
 export interface ResolvedMigrationConfiguration extends MigrationsJson {
   packageGroup?: ArrayPackageGroup;
@@ -1404,6 +1405,7 @@ export async function executeMigrations(
         const ngCliAdapter = await getNgCompatLayer();
         const { madeChanges, loggingQueue } = await ngCliAdapter.runMigration(
           root,
+          await createProjectGraphAsync(),
           m.package,
           m.name,
           isVerbose

--- a/packages/nx/src/command-line/run/run.ts
+++ b/packages/nx/src/command-line/run/run.ts
@@ -185,6 +185,7 @@ async function runExecutorInternal<T extends { success: boolean }>(
       await import('../../adapter/ngcli-adapter')
     ).scheduleTarget(
       root,
+      projectGraph,
       {
         project,
         target,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->
Avoid calling createProjectGraphAsync in readMergedWorkspaceConfiguration since it is already available.

## Current Behavior
<!-- This is the behavior we have today -->
Custom angular build executor no longer works if used in combination with useDaemonProcess: false.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Custom angular builder should work even if useDaemonProcess: false is set to false.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #19475
