### PR TITLE
chore(repo): publish minor by default when running nx-release

### DIFF
--- a/scripts/nx-release.ts
+++ b/scripts/nx-release.ts
@@ -203,6 +203,7 @@ function parseArgs() {
       type: 'string',
       description:
         'The version to publish. This does not need to be passed and can be inferred.',
+      default: 'minor',
     })
     .option('gitRemote', {
       type: 'string',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `nx-release` script needs a version argument.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `nx-release` script publishes a `minor` version by default for local developlment

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
