### PR TITLE
fix(core): use typescript to get compiler options for ts-node

### DIFF
--- a/packages/nx/src/plugins/js/utils/register.ts
+++ b/packages/nx/src/plugins/js/utils/register.ts
@@ -151,7 +151,9 @@ export function registerTsConfigPaths(tsConfigPath): () => void {
 }
 
 function readCompilerOptions(tsConfigPath): CompilerOptions {
-  if (swcNodeInstalled) {
+  const preferTsNode = process.env.NX_PREFER_TS_NODE === 'true';
+
+  if (swcNodeInstalled && !preferTsNode) {
     const {
       readDefaultTsConfig,
     }: typeof import('@swc-node/register/read-default-tsconfig') = require('@swc-node/register/read-default-tsconfig');


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When ts-node is used as the `transpiler`, it still fetches options from `swc` if it's installed (using `PREFER_TS_NODE`), which causes an error as the response from `swc` is incompatible with `ts-node`.



## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
When `NX_PREFER_TS_NODE` is `true`, we should use `ts` to get the `compilerOptions`, regardless of whether `swc` is installed or not

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
