### PR TITLE
fix(vue): enforce multiword component name

### DIFF
--- a/packages/vue/src/generators/component/__snapshots__/component.spec.ts.snap
+++ b/packages/vue/src/generators/component/__snapshots__/component.spec.ts.snap
@@ -1,9 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`component --export should add to index.ts barrel 1`] = `
-"export { default as Hello } from './components/hello/hello.vue';
+"export { default as MyLibHello } from './components/hello/hello.vue';
 "
 `;
+
+exports[`component --export should not export from an app 1`] = `null`;
 
 exports[`component should generate files with jest 1`] = `
 "<script setup lang="ts">
@@ -11,7 +13,7 @@ defineProps<{}>();
 </script>
 
 <template>
-  <p>Welcome to Hello!</p>
+  <p>Welcome to MyLibHello!</p>
 </template>
 
 <style scoped></style>
@@ -20,12 +22,12 @@ defineProps<{}>();
 
 exports[`component should generate files with jest 2`] = `
 "import { mount } from '@vue/test-utils';
-import Hello from './hello.vue';
+import MyLibHello from './hello.vue';
 
-describe('Hello', () => {
+describe('MyLibHello', () => {
   it('renders properly', () => {
-    const wrapper = mount(Hello, {});
-    expect(wrapper.text()).toContain('Welcome to Hello');
+    const wrapper = mount(MyLibHello, {});
+    expect(wrapper.text()).toContain('Welcome to MyLibHello');
   });
 });
 "
@@ -37,7 +39,7 @@ defineProps<{}>();
 </script>
 
 <template>
-  <p>Welcome to Hello!</p>
+  <p>Welcome to MyLibHello!</p>
 </template>
 
 <style scoped></style>
@@ -48,12 +50,12 @@ exports[`component should generate files with vitest 2`] = `
 "import { describe, it, expect } from 'vitest';
 
 import { mount } from '@vue/test-utils';
-import Hello from './hello.vue';
+import MyLibHello from './hello.vue';
 
-describe('Hello', () => {
+describe('MyLibHello', () => {
   it('renders properly', () => {
-    const wrapper = mount(Hello, {});
-    expect(wrapper.text()).toContain('Welcome to Hello');
+    const wrapper = mount(MyLibHello, {});
+    expect(wrapper.text()).toContain('Welcome to MyLibHello');
   });
 });
 "

--- a/packages/vue/src/generators/component/component.ts
+++ b/packages/vue/src/generators/component/component.ts
@@ -1,28 +1,28 @@
 import {
-  applyChangesToString,
   formatFiles,
   generateFiles,
   GeneratorCallback,
   getProjects,
   joinPathFragments,
-  logger,
-  names,
   runTasksInSerial,
   toJS,
   Tree,
 } from '@nx/devkit';
 import { NormalizedSchema, Schema } from './schema';
-import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
 import { join } from 'path';
-import { addImport } from '../../utils/ast-utils';
+import { addExportsToBarrel, normalizeOptions } from './lib/utils';
 
 export async function componentGenerator(host: Tree, schema: Schema) {
-  const options = await normalizeOptions(host, schema);
+  const workspace = getProjects(host);
+  const isApp = workspace.get(schema.project).projectType === 'application';
+
+  const options = await normalizeOptions(host, schema, isApp);
+
   createComponentFiles(host, options);
 
   const tasks: GeneratorCallback[] = [];
 
-  addExportsToBarrel(host, options);
+  addExportsToBarrel(host, options, isApp);
 
   if (!options.skipFormat) {
     await formatFiles(host);
@@ -59,103 +59,6 @@ function createComponentFiles(host: Tree, options: NormalizedSchema) {
   }
 
   if (options.js) toJS(host);
-}
-
-let tsModule: typeof import('typescript');
-
-function addExportsToBarrel(host: Tree, options: NormalizedSchema) {
-  if (!tsModule) {
-    tsModule = ensureTypescript();
-  }
-  const workspace = getProjects(host);
-  const isApp = workspace.get(options.project).projectType === 'application';
-
-  if (options.export && !isApp) {
-    const indexFilePath = joinPathFragments(
-      options.projectSourceRoot,
-      options.js ? 'index.js' : 'index.ts'
-    );
-    const indexSource = host.read(indexFilePath, 'utf-8');
-    if (indexSource !== null) {
-      const indexSourceFile = tsModule.createSourceFile(
-        indexFilePath,
-        indexSource,
-        tsModule.ScriptTarget.Latest,
-        true
-      );
-      const changes = applyChangesToString(
-        indexSource,
-        addImport(
-          indexSourceFile,
-          `export { default as ${options.className} } from './${options.directory}/${options.fileName}.vue';`
-        )
-      );
-      host.write(indexFilePath, changes);
-    }
-  }
-}
-
-async function normalizeOptions(
-  host: Tree,
-  options: Schema
-): Promise<NormalizedSchema> {
-  assertValidOptions(options);
-
-  const { className, fileName } = names(options.name);
-  const componentFileName =
-    options.fileName ?? (options.pascalCaseFiles ? className : fileName);
-  const project = getProjects(host).get(options.project);
-
-  if (!project) {
-    throw new Error(
-      `Cannot find the ${options.project} project. Please double check the project name.`
-    );
-  }
-
-  const { sourceRoot: projectSourceRoot, projectType } = project;
-
-  const directory = await getDirectory(options);
-
-  if (options.export && projectType === 'application') {
-    logger.warn(
-      `The "--export" option should not be used with applications and will do nothing.`
-    );
-  }
-
-  options.routing = options.routing ?? false;
-  options.inSourceTests = options.inSourceTests ?? false;
-
-  return {
-    ...options,
-    directory,
-    className,
-    fileName: componentFileName,
-    projectSourceRoot,
-  };
-}
-
-async function getDirectory(options: Schema) {
-  if (options.directory) return options.directory;
-  if (options.flat) return 'components';
-  const { className, fileName } = names(options.name);
-  const nestedDir = options.pascalCaseDirectory === true ? className : fileName;
-  return joinPathFragments('components', nestedDir);
-}
-
-function assertValidOptions(options: Schema) {
-  const slashes = ['/', '\\'];
-  slashes.forEach((s) => {
-    if (options.name.indexOf(s) !== -1) {
-      const [name, ...rest] = options.name.split(s).reverse();
-      let suggestion = rest.map((x) => x.toLowerCase()).join(s);
-      if (options.directory) {
-        suggestion = `${options.directory}${s}${suggestion}`;
-      }
-      throw new Error(
-        `Found "${s}" in the component name. Did you mean to use the --directory option (e.g. \`nx g c ${name} --directory ${suggestion}\`)?`
-      );
-    }
-  });
 }
 
 export default componentGenerator;

--- a/packages/vue/src/generators/component/lib/utils.spec.ts
+++ b/packages/vue/src/generators/component/lib/utils.spec.ts
@@ -1,0 +1,33 @@
+import { getComponentClassName } from './utils';
+
+describe('getComponentClassName', () => {
+  it('should return correct component name if no directory and isApp', () => {
+    expect(getComponentClassName('HelloWorld', true, 'main-app')).toEqual(
+      'AppHelloWorld'
+    );
+  });
+
+  it('should return correct component name if no directory and isApp is false', () => {
+    expect(
+      getComponentClassName('HelloWorld', false, 'my-shared-feature')
+    ).toEqual('MySharedFeatureHelloWorld');
+  });
+
+  it('should return correct component name if directory provided - case 1', () => {
+    expect(
+      getComponentClassName('HelloWorld', false, 'my-other-lib', 'ui/feat')
+    ).toEqual('UiFeatHelloWorld');
+  });
+
+  it('should return correct component name if directory provided - case 2', () => {
+    expect(
+      getComponentClassName('Hello', false, 'my-other-lib', 'ui/feat/other')
+    ).toEqual('UiFeatOtherHello');
+  });
+
+  it('should return correct component name if directory provided - case 3', () => {
+    expect(getComponentClassName('Hello', true, 'my-other-lib', 'ui')).toEqual(
+      'UiHello'
+    );
+  });
+});

--- a/packages/vue/src/generators/component/lib/utils.ts
+++ b/packages/vue/src/generators/component/lib/utils.ts
@@ -1,0 +1,143 @@
+import {
+  applyChangesToString,
+  getProjects,
+  joinPathFragments,
+  logger,
+  names,
+  Tree,
+} from '@nx/devkit';
+import { NormalizedSchema, Schema } from '../schema';
+import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
+import { addImport } from '../../../utils/ast-utils';
+
+let tsModule: typeof import('typescript');
+
+export async function normalizeOptions(
+  host: Tree,
+  options: Schema,
+  isApp: boolean
+): Promise<NormalizedSchema> {
+  assertValidOptions(options);
+
+  let { className, fileName } = names(options.name);
+  const componentFileName =
+    options.fileName ?? (options.pascalCaseFiles ? className : fileName);
+  const project = getProjects(host).get(options.project);
+
+  if (!project) {
+    throw new Error(
+      `Cannot find the ${options.project} project. Please double check the project name.`
+    );
+  }
+
+  const { sourceRoot: projectSourceRoot, projectType } = project;
+
+  className = getComponentClassName(
+    className,
+    isApp,
+    options.project,
+    options.directory
+  );
+
+  const directory = await getDirectory(options);
+
+  if (options.export && projectType === 'application') {
+    logger.warn(
+      `The "--export" option should not be used with applications and will do nothing.`
+    );
+  }
+
+  options.routing = options.routing ?? false;
+  options.inSourceTests = options.inSourceTests ?? false;
+
+  return {
+    ...options,
+    directory,
+    className,
+    fileName: componentFileName,
+    projectSourceRoot,
+  };
+}
+
+export function getComponentClassName(
+  componentName: string,
+  isApp: boolean,
+  projectName: string,
+  directory?: string
+): string {
+  const { className } = names(projectName);
+
+  let prefix = isApp ? 'App' : className;
+
+  if (directory?.length > 0) {
+    prefix = directory
+      .split('/')
+      .map((segment) =>
+        segment
+          .split('-')
+          .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+          .join('')
+      )
+      .join('');
+  }
+
+  return `${prefix}${componentName}`;
+}
+
+export function addExportsToBarrel(
+  host: Tree,
+  options: NormalizedSchema,
+  isApp: boolean
+) {
+  if (!tsModule) {
+    tsModule = ensureTypescript();
+  }
+
+  if (options.export && !isApp) {
+    const indexFilePath = joinPathFragments(
+      options.projectSourceRoot,
+      options.js ? 'index.js' : 'index.ts'
+    );
+    const indexSource = host.read(indexFilePath, 'utf-8');
+    if (indexSource !== null) {
+      const indexSourceFile = tsModule.createSourceFile(
+        indexFilePath,
+        indexSource,
+        tsModule.ScriptTarget.Latest,
+        true
+      );
+      const changes = applyChangesToString(
+        indexSource,
+        addImport(
+          indexSourceFile,
+          `export { default as ${options.className} } from './${options.directory}/${options.fileName}.vue';`
+        )
+      );
+      host.write(indexFilePath, changes);
+    }
+  }
+}
+
+export async function getDirectory(options: Schema) {
+  if (options.directory) return options.directory;
+  if (options.flat) return 'components';
+  const { className, fileName } = names(options.name);
+  const nestedDir = options.pascalCaseDirectory === true ? className : fileName;
+  return joinPathFragments('components', nestedDir);
+}
+
+export function assertValidOptions(options: Schema) {
+  const slashes = ['/', '\\'];
+  slashes.forEach((s) => {
+    if (options.name.indexOf(s) !== -1) {
+      const [name, ...rest] = options.name.split(s).reverse();
+      let suggestion = rest.map((x) => x.toLowerCase()).join(s);
+      if (options.directory) {
+        suggestion = `${options.directory}${s}${suggestion}`;
+      }
+      throw new Error(
+        `Found "${s}" in the component name. Did you mean to use the --directory option (e.g. \`nx g c ${name} --directory ${suggestion}\`)?`
+      );
+    }
+  });
+}


### PR DESCRIPTION
Make sure component names for Vue are multiword (https://vuejs.org/style-guide/rules-essential.html#use-multi-word-component-names).

So, the rule is the following:
* If component is not in a custom directory, prefix it with `App` if it's an app, prefix it with the lib's name if it's a lib
* If component is in a custom directory, the name should be prepended with the directory: `foo/bar/hello.vue` --> `FooBarHello`

@meeroslav @juristr 
