### PR TITLE
fix(linter): check if circular dependency resolves to a separate angular entrypoint

### DIFF
--- a/packages/eslint-plugin/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin/src/rules/enforce-module-boundaries.ts
@@ -26,7 +26,7 @@ import {
   hasBuildExecutor,
   hasNoneOfTheseTags,
   isAbsoluteImportIntoAnotherProject,
-  isAngularSecondaryEntrypoint,
+  isSeparateAngularEntryPoint,
   isDirectDependency,
   matchImportWithWildcard,
   onlyLoadChildren,
@@ -351,16 +351,12 @@ export default createESLintRule<Options, MessageIds>({
       }
 
       // we only allow relative paths within the same project
-      // and if it's not a secondary entrypoint in an angular lib
+      // and if it's not a separate entrypoint in an angular lib
       if (sourceProject === targetProject) {
         if (
           !allowCircularSelfDependency &&
           !isRelativePath(imp) &&
-          !isAngularSecondaryEntrypoint(
-            imp,
-            sourceFilePath,
-            sourceProject.data.root
-          )
+          !isSeparateAngularEntryPoint(imp, sourceFilePath)
         ) {
           context.report({
             node,

--- a/packages/eslint-plugin/src/utils/runtime-lint-utils.spec.ts
+++ b/packages/eslint-plugin/src/utils/runtime-lint-utils.spec.ts
@@ -14,8 +14,8 @@ import {
   hasBannedDependencies,
   hasBannedImport,
   hasNoneOfTheseTags,
-  isAngularSecondaryEntrypoint,
   isTerminalRun,
+  isSeparateAngularEntryPoint,
 } from './runtime-lint-utils';
 import { vol } from 'memfs';
 
@@ -445,7 +445,7 @@ describe('is terminal run', () => {
   });
 });
 
-describe('isAngularSecondaryEntrypoint', () => {
+describe('isSeparateAngularEntryPoint', () => {
   beforeEach(() => {
     const tsConfig = {
       compilerOptions: {
@@ -468,7 +468,11 @@ describe('isAngularSecondaryEntrypoint', () => {
     const fsJson = {
       'tsconfig.base.json': JSON.stringify(tsConfig),
       'apps/app.ts': '',
+      'libs/standard/src/index.ts': 'const bla = "foo"',
       'libs/standard/package.json': '{ "version": "0.0.0" }',
+      'libs/standard/ng-package.json': JSON.stringify({
+        lib: { entryFile: 'src/index.ts' },
+      }),
       'libs/standard/secondary/ng-package.json': JSON.stringify({
         lib: { entryFile: 'src/index.ts' },
       }),
@@ -477,7 +481,11 @@ describe('isAngularSecondaryEntrypoint', () => {
         lib: { entryFile: 'src/public_api.ts' },
       }),
       'libs/standard/tertiary/src/public_api.ts': 'const bla = "foo"',
+      'libs/features/src/index.ts': 'const bla = "foo"',
       'libs/features/package.json': '{ "version": "0.0.0" }',
+      'libs/features/ng-package.json': JSON.stringify({
+        lib: { entryFile: 'src/index.ts' },
+      }),
       'libs/features/secondary/ng-package.json': JSON.stringify({
         lib: { entryFile: 'random/folder/api.ts' },
       }),
@@ -489,47 +497,47 @@ describe('isAngularSecondaryEntrypoint', () => {
     vol.fromJSON(fsJson, '/root');
   });
 
-  it('should return true for secondary entrypoints', () => {
+  it('should return true for separate entrypoints', () => {
     expect(
-      isAngularSecondaryEntrypoint(
+      isSeparateAngularEntryPoint(
         '@project/standard',
-        'apps/app.ts',
-        'libs/standard'
+        'libs/standard/apps/app.ts'
       )
     ).toBe(false);
     expect(
-      isAngularSecondaryEntrypoint(
+      isSeparateAngularEntryPoint(
         '@project/standard/secondary',
-        'apps/app.ts',
-        'libs/standard'
+        'libs/standard/apps/app.ts'
       )
     ).toBe(true);
     expect(
-      isAngularSecondaryEntrypoint(
+      isSeparateAngularEntryPoint(
+        '@project/standard',
+        'libs/standard/secondary/apps/app.ts'
+      )
+    ).toBe(true);
+    expect(
+      isSeparateAngularEntryPoint(
         '@project/standard/tertiary',
-        'apps/app.ts',
-        'libs/standard'
+        'libs/standard/apps/app.ts'
       )
     ).toBe(true);
     expect(
-      isAngularSecondaryEntrypoint(
+      isSeparateAngularEntryPoint(
         '@project/features',
-        'apps/app.ts',
-        'libs/features'
+        'libs/features/apps/app.ts'
       )
     ).toBe(false);
     expect(
-      isAngularSecondaryEntrypoint(
+      isSeparateAngularEntryPoint(
         '@project/features/secondary',
-        'apps/app.ts',
-        'libs/features'
+        'libs/features/apps/app.ts'
       )
     ).toBe(true);
     expect(
-      isAngularSecondaryEntrypoint(
+      isSeparateAngularEntryPoint(
         '@project/buildable',
-        'apps/app.ts',
-        'libs/buildable'
+        'libs/buildable/apps/app.ts'
       )
     ).toBe(false);
   });


### PR DESCRIPTION

Instead of checking for secondary entrypoint, check if for different entrypoint to allow importing main entrypoint in secondary entrypoint. Like @angular/core/testing imports from @angular/core.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Importing main entrypoint in secondary entrypoint is not allowed.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Importing main entrypoint in secondary entrypoint should work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
