### PR TITLE
fix(linter): fix validateDependenciesSectionExistance fixer

### DIFF
--- a/packages/eslint-plugin/src/rules/dependency-checks.spec.ts
+++ b/packages/eslint-plugin/src/rules/dependency-checks.spec.ts
@@ -329,6 +329,7 @@ describe('Dependency checks (eslint)', () => {
       "{
         "name": "@mycompany/liba",
         "dependencies": {
+          "external1": "~16.1.2"
         }
       }"
     `);

--- a/packages/eslint-plugin/src/rules/dependency-checks.ts
+++ b/packages/eslint-plugin/src/rules/dependency-checks.ts
@@ -299,14 +299,14 @@ export default createESLintRule<Options, MessageIds>({
               .join(),
           },
           fix: (fixer) => {
-            const dependencies = Object.keys(projPackageJsonDeps)
-              .map((d) => `\n    "${d}": "${projPackageJsonDeps[d]}"`)
-              .join(',');
-
             expectedDependencyNames.sort().reduce((acc, d) => {
               acc[d] = rootPackageJsonDeps[d] || dependencies[d];
               return acc;
             }, projPackageJsonDeps);
+
+            const dependencies = Object.keys(projPackageJsonDeps)
+              .map((d) => `\n    "${d}": "${projPackageJsonDeps[d]}"`)
+              .join(',');
 
             if (!node.properties.length) {
               return fixer.replaceText(


### PR DESCRIPTION
The #18058 accidentally introduced a bug in the `dependency-checks` fixer. This PR reverts the broken code block to the previous state.

The reverted order of operations was causing the section to be created without the packages.

cc @jaysoo @juristr 

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
