### PR TITLE
feat(core): allow marking targets hidden

### DIFF
--- a/docs/generated/devkit/TargetConfiguration.md
+++ b/docs/generated/devkit/TargetConfiguration.md
@@ -17,6 +17,7 @@ Target's configuration
 - [defaultConfiguration](../../devkit/documents/TargetConfiguration#defaultconfiguration): string
 - [dependsOn](../../devkit/documents/TargetConfiguration#dependson): (string | TargetDependencyConfig)[]
 - [executor](../../devkit/documents/TargetConfiguration#executor): string
+- [hidden](../../devkit/documents/TargetConfiguration#hidden): boolean
 - [inputs](../../devkit/documents/TargetConfiguration#inputs): (string | InputDefinition)[]
 - [options](../../devkit/documents/TargetConfiguration#options): T
 - [outputs](../../devkit/documents/TargetConfiguration#outputs): string[]
@@ -66,6 +67,14 @@ This describes other targets that a target depends on.
 The executor/builder used to implement the target.
 
 Example: '@nx/rollup:rollup'
+
+---
+
+### hidden
+
+• `Optional` **hidden**: `boolean`
+
+If true, the target will not show up in Nx Console or `nx show`
 
 ---
 

--- a/packages/nx/src/command-line/show/show.ts
+++ b/packages/nx/src/command-line/show/show.ts
@@ -80,8 +80,9 @@ export async function showProjectHandler(
   } else {
     const chalk = require('chalk') as typeof import('chalk');
     const logIfExists = (label, key: keyof typeof node['data']) => {
-      if (node.data[key]) {
-        console.log(`${chalk.bold(label)}: ${node.data[key]}`);
+      const value = node.data[key];
+      if (value && (!Array.isArray(value) || value.length)) {
+        console.log(`${chalk.bold(label)}: ${value}`);
       }
     };
 
@@ -100,6 +101,8 @@ export async function showProjectHandler(
     if (targets.length > 0) {
       console.log(`${chalk.bold('Targets')}: `);
       for (const [target, targetConfig] of targets) {
+        if (targetConfig.hidden) continue;
+
         console.log(
           `- ${chalk.bold((target + ':').padEnd(maxTargetNameLength + 2))} ${(
             targetConfig?.executor ?? ''

--- a/packages/nx/src/config/workspace-json-project-json.ts
+++ b/packages/nx/src/config/workspace-json-project-json.ts
@@ -181,4 +181,9 @@ export interface TargetConfiguration<T = any> {
    * A default named configuration to use when a target configuration is not provided.
    */
   defaultConfiguration?: string;
+
+  /**
+   * If true, the target will not show up in Nx Console or `nx show`
+   */
+  hidden?: boolean;
 }

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -148,6 +148,7 @@ export function readTargetsFromPackageJson({ scripts, nx }: PackageJson) {
       dependsOn: ['^nx-release-publish'],
       executor: '@nx/js:release-publish',
       options: {},
+      hidden: true,
     };
   }
 


### PR DESCRIPTION
Sometimes it doesn't make sense for a target to show up in nx console or nx show. The main case for this currently is `nx-release-publish`, which should never be manually invoked. Its worth generalizing this though, as I can see it making sense for other targets if they shouldn't be manually invoked under normal circumstances. For example, if setting up code generation as a dependency of build, it may make sense to hide the codegen target since it should always be called during builds