### PR TITLE
fix(devkit): pass filepath to ejs for include statements

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "@testing-library/react": "13.4.0",
     "@types/cytoscape": "^3.18.2",
     "@types/detect-port": "^1.3.2",
+    "@types/ejs": "3.1.2",
     "@types/eslint": "~8.44.2",
     "@types/express": "4.17.14",
     "@types/flat": "^5.0.1",

--- a/packages/devkit/src/generators/generate-files.ts
+++ b/packages/devkit/src/generators/generate-files.ts
@@ -34,7 +34,7 @@ export function generateFiles(
   target: string,
   substitutions: { [k: string]: any }
 ): void {
-  const ejs = require('ejs');
+  const ejs: typeof import('ejs') = require('ejs');
 
   const files = allFilesInDir(srcFolder);
   if (files.length === 0) {
@@ -56,7 +56,9 @@ export function generateFiles(
       } else {
         const template = readFileSync(filePath, 'utf-8');
         try {
-          newContent = ejs.render(template, substitutions, {});
+          newContent = ejs.render(template, substitutions, {
+            filename: filePath,
+          });
         } catch (e) {
           logger.error(`Error in ${filePath.replace(`${tree.root}/`, '')}:`);
           throw e;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -400,6 +400,9 @@ devDependencies:
   '@types/detect-port':
     specifier: ^1.3.2
     version: 1.3.2
+  '@types/ejs':
+    specifier: 3.1.2
+    version: 3.1.2
   '@types/eslint':
     specifier: ~8.44.2
     version: 8.44.2


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
EJS fails to render templates that include relative include paths since we do not pass in the path to the file that we load the template from.

## Expected Behavior
EJS is able to render templates that include relative includes

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #19516 
