### PR TITLE
fix(linter): remove consistent-type-assertions rule from config

### DIFF
--- a/packages/eslint-plugin/src/configs/react-typescript.ts
+++ b/packages/eslint-plugin/src/configs/react-typescript.ts
@@ -18,7 +18,6 @@ export default {
     'no-undef': 'off',
 
     // Add TypeScript specific rules (and turn off ESLint equivalents)
-    '@typescript-eslint/consistent-type-assertions': 'warn',
     'no-array-constructor': 'off',
     '@typescript-eslint/no-array-constructor': 'warn',
     '@typescript-eslint/no-namespace': 'error',


### PR DESCRIPTION
Remove rule that is causing all projects importing `@nx/react` eslint plugin to request `typescript` parser after updating repo to use `@typescript-eslint@v6`

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Blocks to #19548

Related to #18641
