### PR TITLE
feat(core): allow using nx cloud task runner without nx-cloud installed

### DIFF
--- a/docs/generated/cli/connect.md
+++ b/docs/generated/cli/connect.md
@@ -23,6 +23,14 @@ Type: `boolean`
 
 Show help
 
+### interactive
+
+Type: `boolean`
+
+Default: `true`
+
+Prompt for confirmation
+
 ### version
 
 Type: `boolean`

--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -7714,6 +7714,23 @@
             ],
             "isExternal": false,
             "disableCollapsible": false
+          },
+          {
+            "id": "generators",
+            "path": "/nx-api/nx/generators",
+            "name": "generators",
+            "children": [
+              {
+                "id": "connect-to-nx-cloud",
+                "path": "/nx-api/nx/generators/connect-to-nx-cloud",
+                "name": "connect-to-nx-cloud",
+                "children": [],
+                "isExternal": false,
+                "disableCollapsible": false
+              }
+            ],
+            "isExternal": false,
+            "disableCollapsible": false
           }
         ],
         "isExternal": false,

--- a/docs/generated/manifests/nx-api.json
+++ b/docs/generated/manifests/nx-api.json
@@ -1815,7 +1815,17 @@
         "type": "executor"
       }
     },
-    "generators": {},
+    "generators": {
+      "/nx-api/nx/generators/connect-to-nx-cloud": {
+        "description": "Connect a workspace to Nx Cloud",
+        "file": "generated/packages/nx/generators/connect-to-nx-cloud.json",
+        "hidden": false,
+        "name": "connect-to-nx-cloud",
+        "originalFilePath": "/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/schema.json",
+        "path": "/nx-api/nx/generators/connect-to-nx-cloud",
+        "type": "generator"
+      }
+    },
     "path": "/nx-api/nx"
   },
   "playwright": {

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -1794,7 +1794,17 @@
         "type": "executor"
       }
     ],
-    "generators": [],
+    "generators": [
+      {
+        "description": "Connect a workspace to Nx Cloud",
+        "file": "generated/packages/nx/generators/connect-to-nx-cloud.json",
+        "hidden": false,
+        "name": "connect-to-nx-cloud",
+        "originalFilePath": "/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/schema.json",
+        "path": "nx/generators/connect-to-nx-cloud",
+        "type": "generator"
+      }
+    ],
     "githubRoot": "https://github.com/nrwl/nx/blob/master",
     "name": "nx",
     "packageName": "nx",

--- a/docs/generated/packages/nx/documents/connect-to-nx-cloud.md
+++ b/docs/generated/packages/nx/documents/connect-to-nx-cloud.md
@@ -23,6 +23,14 @@ Type: `boolean`
 
 Show help
 
+### interactive
+
+Type: `boolean`
+
+Default: `true`
+
+Prompt for confirmation
+
 ### version
 
 Type: `boolean`

--- a/docs/generated/packages/nx/generators/connect-to-nx-cloud.json
+++ b/docs/generated/packages/nx/generators/connect-to-nx-cloud.json
@@ -1,0 +1,34 @@
+{
+  "name": "connect-to-nx-cloud",
+  "factory": "./src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud",
+  "schema": {
+    "$schema": "http://json-schema.org/schema",
+    "id": "NxCloudInit",
+    "title": "Add Nx Cloud Configuration to the workspace",
+    "description": "Connect a workspace to Nx Cloud.",
+    "type": "object",
+    "cli": "nx",
+    "properties": {
+      "analytics": {
+        "type": "boolean",
+        "description": "Anonymously store hashed machine ID for task runs",
+        "default": false
+      },
+      "installationSource": {
+        "type": "string",
+        "description": "Name of Nx Cloud installation invoker (ex. user, add-nx-to-monorepo, create-nx-workspace, nx-upgrade",
+        "default": "user"
+      }
+    },
+    "additionalProperties": false,
+    "required": [],
+    "presets": []
+  },
+  "description": "Connect a workspace to Nx Cloud",
+  "x-hidden": true,
+  "implementation": "/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts",
+  "aliases": [],
+  "hidden": false,
+  "path": "/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/schema.json",
+  "type": "generator"
+}

--- a/docs/generated/packages/workspace/generators/new.json
+++ b/docs/generated/packages/workspace/generators/new.json
@@ -44,11 +44,6 @@
         "type": "string"
       },
       "appName": { "type": "string", "description": "Application name." },
-      "nxCloud": {
-        "description": "Connect the workspace to the free tier of the distributed cache provided by Nx Cloud.",
-        "type": "boolean",
-        "default": false
-      },
       "linter": {
         "description": "The tool to use for running lint checks.",
         "type": "string",

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -513,6 +513,8 @@
       - [noop](/nx-api/nx/executors/noop)
       - [run-commands](/nx-api/nx/executors/run-commands)
       - [run-script](/nx-api/nx/executors/run-script)
+    - [generators](/nx-api/nx/generators)
+      - [connect-to-nx-cloud](/nx-api/nx/generators/connect-to-nx-cloud)
   - [playwright](/nx-api/playwright)
     - [documents](/nx-api/playwright/documents)
       - [Overview](/nx-api/playwright/documents/overview)

--- a/e2e/nx-run/src/nx-cloud.test.ts
+++ b/e2e/nx-run/src/nx-cloud.test.ts
@@ -1,0 +1,37 @@
+import { cleanupProject, newProject, runCLI } from '@nx/e2e/utils';
+
+describe('Nx Cloud', () => {
+  beforeAll(() =>
+    newProject({
+      unsetProjectNameAndRootFormat: false,
+    })
+  );
+
+  const libName = 'test-lib';
+  beforeAll(() => {
+    runCLI('connect --no-interactive', {
+      env: {
+        ...process.env,
+        NX_CLOUD_API: 'https://staging.nx.app',
+      },
+    });
+    runCLI(`generate @nx/js:lib ${libName} --no-interactive`);
+  });
+
+  afterAll(() => cleanupProject());
+
+  it('should cache tests', async () => {
+    // Should be able to view logs with Nx Cloud
+    expect(runCLI(`test ${libName}`)).toContain(
+      `View logs and investigate cache misses at https://staging.nx.app`
+    );
+
+    // Reset Local cache
+    runCLI(`reset`);
+
+    // Should be pull cache from Nx Cloud
+    expect(runCLI(`test ${libName}`)).toContain(
+      `Nx Cloud made it possible to reuse test-lib: https://staging.nx.app`
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -4,10 +4,6 @@
   "homepage": "https://nx.dev",
   "private": true,
   "scripts": {
-    "import-nx-cloud": "npm run copy-files && git add . && git commit -am 'feat(core): import nx-cloud code'",
-    "copy-files": "cp -r ../ocean/libs/nx-packages/nx-cloud/bin packages/nx && cp -r ../ocean/libs/nx-packages/nx-cloud/lib/light-client packages/nx/src/nx-cloud && npm run copy-utilities && npm run copy-generators",
-    "copy-utilities": "mkdir packages/nx/src/nx-cloud/utilities && cp ../ocean/libs/nx-packages/nx-cloud/lib/utilities/axios.ts ../ocean/libs/nx-packages/nx-cloud/lib/utilities/get-cloud-options.ts ../ocean/libs/nx-packages/nx-cloud/lib/utilities/environment.ts packages/nx/src/nx-cloud/utilities",
-    "copy-generators": "mkdir packages/nx/src/nx-cloud/generators && cp -r ../ocean/libs/nx-packages/nx-cloud/lib/generators/init packages/nx/src/nx-cloud/generators",
     "build": "nx run-many --target build --parallel 8 --exclude nx-dev,typedoc-theme,tools-documentation-create-embeddings",
     "commit": "czg",
     "check-commit": "node ./scripts/commit-lint.js",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "homepage": "https://nx.dev",
   "private": true,
   "scripts": {
+    "import-nx-cloud": "npm run copy-files && git add . && git commit -am 'feat(core): import nx-cloud code'",
+    "copy-files": "cp -r ../ocean/libs/nx-packages/nx-cloud/bin packages/nx && cp -r ../ocean/libs/nx-packages/nx-cloud/lib/light-client packages/nx/src/nx-cloud && npm run copy-utilities && npm run copy-generators",
+    "copy-utilities": "mkdir packages/nx/src/nx-cloud/utilities && cp ../ocean/libs/nx-packages/nx-cloud/lib/utilities/axios.ts ../ocean/libs/nx-packages/nx-cloud/lib/utilities/get-cloud-options.ts ../ocean/libs/nx-packages/nx-cloud/lib/utilities/environment.ts packages/nx/src/nx-cloud/utilities",
+    "copy-generators": "mkdir packages/nx/src/nx-cloud/generators && cp -r ../ocean/libs/nx-packages/nx-cloud/lib/generators/init packages/nx/src/nx-cloud/generators",
     "build": "nx run-many --target build --parallel 8 --exclude nx-dev,typedoc-theme,tools-documentation-create-embeddings",
     "commit": "czg",
     "check-commit": "node ./scripts/commit-lint.js",

--- a/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
+++ b/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
@@ -13,7 +13,7 @@ export async function setupNxCloud(
   try {
     const pmc = getPackageManagerCommand(packageManager);
     const res = await execAndWait(
-      `${pmc.exec} nx g nx-cloud:init --no-analytics --installationSource=create-nx-workspace`,
+      `${pmc.exec} nx g nx:connect-to-nx-cloud --no-interactive --quiet`,
       directory
     );
     nxCloudSpinner.succeed('NxCloud has been set up successfully');

--- a/packages/nx/bin/nx-cloud.ts
+++ b/packages/nx/bin/nx-cloud.ts
@@ -1,59 +1,65 @@
 #!/usr/bin/env node
 
-import { findAncestorNodeModules } from '../lib/light-client/resolution-helpers';
-import { getCloudOptions } from '../lib/utilities/get-cloud-options';
+import { findAncestorNodeModules } from '../src/nx-cloud/resolution-helpers';
+import { getCloudOptions } from '../src/nx-cloud/utilities/get-cloud-options';
+import {
+  NxCloudClientUnavailableError,
+  NxCloudEnterpriseOutdatedError,
+  verifyOrUpdateNxCloudClient,
+} from '../src/nx-cloud/update-manager';
+import type { CloudTaskRunnerOptions } from '../src/nx-cloud/nx-cloud-tasks-runner-shell';
+import { output } from '../src/utils/output';
 
 const command = process.argv[2];
 
-const { nxCloudOptions: options } = getCloudOptions();
+const options = getCloudOptions();
 
-Promise.resolve().then(async () => invokeCommandWithLightRunner(options));
+Promise.resolve().then(async () => invokeCommandWithNxCloudClient(options));
 
-async function invokeCommandWithLightRunner(options) {
-  const { debugLog } = require('../lib/light-client/debug-logger');
-  debugLog('Verifying current cloud bundle');
-  const {
-    verifyOrUpdateCloudBundle,
-  } = require('../lib/light-client/update-manager');
-  const cloudBundleInstall = await verifyOrUpdateCloudBundle(options);
+async function invokeCommandWithNxCloudClient(options: CloudTaskRunnerOptions) {
+  try {
+    const { nxCloudClient } = await verifyOrUpdateNxCloudClient(options);
 
-  if (cloudBundleInstall === null) {
-    console.log(
-      '[Nx Cloud] Error: Unable to retrieve Nx Cloud bundle. Cannot run commands from the `nx-cloud` package.'
-    );
-    process.exit(1);
-  }
+    const paths = findAncestorNodeModules(__dirname, []);
+    nxCloudClient.configureLightClientRequire()(paths);
 
-  if (cloudBundleInstall.version === 'NX_ENTERPRISE_OUTDATED_IMAGE') {
-    throw new Error('Update Enterprise');
-  }
-
-  debugLog('Done: ', cloudBundleInstall.fullPath);
-
-  const lightClient = require(cloudBundleInstall.fullPath);
-
-  const paths = findAncestorNodeModules(__dirname, []);
-  lightClient.configureLightClientRequire()(paths);
-
-  // Detect partial installs from early release enterprise images
-  if (lightClient.commands === undefined) {
-    throw new Error('Update Enterprise');
-  }
-
-  if (command in lightClient.commands) {
-    lightClient.commands[command]()
-      .then(() => process.exit(0))
-      .catch((e) => {
-        console.error(e);
-        process.exit(1);
+    if (command in nxCloudClient.commands) {
+      nxCloudClient.commands[command]()
+        .then(() => process.exit(0))
+        .catch((e) => {
+          console.error(e);
+          process.exit(1);
+        });
+    } else {
+      output.error({
+        title: `Unknown Command "${command}"`,
       });
-  } else {
-    console.log(`[Nx Cloud] Error: Unknown Command "${command}"`);
-    console.log('----------------------------------------------');
-    console.log(
-      `Available Commands:\n> ${Object.keys(lightClient.commands).join('\n> ')}`
-    );
-    console.log('----------------------------------------------');
+      output.log({
+        title: 'Available Commands:',
+        bodyLines: Object.keys(nxCloudClient.commands).map((c) => `- ${c}`),
+      });
+      process.exit(1);
+    }
+  } catch (e: any) {
+    const body = ['Cannot run commands from the `nx-cloud` CLI.'];
+
+    if (e instanceof NxCloudEnterpriseOutdatedError) {
+      body.push(
+        'If you are an Nx Enterprise customer, please reach out to your assigned Developer Productivity Engineer.',
+        'If you are NOT an Nx Enterprise customer but are seeing this message, please reach out to cloud-support@nrwl.io.'
+      );
+    }
+
+    if (e instanceof NxCloudClientUnavailableError) {
+      body.unshift(
+        'You may be offline. Please try again when you are back online.'
+      );
+    }
+
+    output.error({
+      title: e.message,
+      bodyLines: body,
+    });
     process.exit(1);
   }
 }

--- a/packages/nx/bin/nx-cloud.ts
+++ b/packages/nx/bin/nx-cloud.ts
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+import { findAncestorNodeModules } from '../lib/light-client/resolution-helpers';
+import { getCloudOptions } from '../lib/utilities/get-cloud-options';
+
+const command = process.argv[2];
+
+const { nxCloudOptions: options } = getCloudOptions();
+
+Promise.resolve().then(async () => invokeCommandWithLightRunner(options));
+
+async function invokeCommandWithLightRunner(options) {
+  const { debugLog } = require('../lib/light-client/debug-logger');
+  debugLog('Verifying current cloud bundle');
+  const {
+    verifyOrUpdateCloudBundle,
+  } = require('../lib/light-client/update-manager');
+  const cloudBundleInstall = await verifyOrUpdateCloudBundle(options);
+
+  if (cloudBundleInstall === null) {
+    console.log(
+      '[Nx Cloud] Error: Unable to retrieve Nx Cloud bundle. Cannot run commands from the `nx-cloud` package.'
+    );
+    process.exit(1);
+  }
+
+  if (cloudBundleInstall.version === 'NX_ENTERPRISE_OUTDATED_IMAGE') {
+    throw new Error('Update Enterprise');
+  }
+
+  debugLog('Done: ', cloudBundleInstall.fullPath);
+
+  const lightClient = require(cloudBundleInstall.fullPath);
+
+  const paths = findAncestorNodeModules(__dirname, []);
+  lightClient.configureLightClientRequire()(paths);
+
+  // Detect partial installs from early release enterprise images
+  if (lightClient.commands === undefined) {
+    throw new Error('Update Enterprise');
+  }
+
+  if (command in lightClient.commands) {
+    lightClient.commands[command]()
+      .then(() => process.exit(0))
+      .catch((e) => {
+        console.error(e);
+        process.exit(1);
+      });
+  } else {
+    console.log(`[Nx Cloud] Error: Unknown Command "${command}"`);
+    console.log('----------------------------------------------');
+    console.log(
+      `Available Commands:\n> ${Object.keys(lightClient.commands).join('\n> ')}`
+    );
+    console.log('----------------------------------------------');
+    process.exit(1);
+  }
+}

--- a/packages/nx/generators.json
+++ b/packages/nx/generators.json
@@ -1,0 +1,10 @@
+{
+  "generators": {
+    "connect-to-nx-cloud": {
+      "factory": "./src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud",
+      "schema": "./src/nx-cloud/generators/connect-to-nx-cloud/schema.json",
+      "description": "Connect a workspace to Nx Cloud",
+      "x-hidden": true
+    }
+  }
+}

--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -68,7 +68,7 @@
     },
     "17.0.0-use-minimal-config-for-tasks-runner-options": {
       "cli": "nx",
-      "version": "17.0.0-beta.2",
+      "version": "17.0.0-beta.3",
       "description": "Use minimal config for tasksRunnerOptions",
       "implementation": "./src/migrations/update-17-0-0/use-minimal-config-for-tasks-runner-options"
     }

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -23,7 +23,8 @@
     "CLI"
   ],
   "bin": {
-    "nx": "./bin/nx.js"
+    "nx": "./bin/nx.js",
+    "nx-cloud": "./bin/nx-cloud.js"
   },
   "author": "Victor Savkin",
   "license": "MIT",
@@ -153,6 +154,7 @@
       }
     ]
   },
+  "generators": "./generators.json",
   "executors": "./executors.json",
   "builders": "./executors.json",
   "publishConfig": {

--- a/packages/nx/src/command-line/connect/command-object.ts
+++ b/packages/nx/src/command-line/connect/command-object.ts
@@ -1,13 +1,24 @@
 import { CommandModule } from 'yargs';
 import { linkToNxDevAndExamples } from '../yargs-utils/documentation';
+import type { ConnectToNxCloudOptions } from './connect-to-nx-cloud';
 
-export const yargsConnectCommand: CommandModule = {
+export const yargsConnectCommand: CommandModule<{}, ConnectToNxCloudOptions> = {
   command: 'connect',
   aliases: ['connect-to-nx-cloud'],
   describe: `Connect workspace to Nx Cloud`,
-  builder: (yargs) => linkToNxDevAndExamples(yargs, 'connect-to-nx-cloud'),
-  handler: async () => {
-    await (await import('./connect-to-nx-cloud')).connectToNxCloudCommand();
+  builder: (yargs) =>
+    linkToNxDevAndExamples(
+      yargs.option('interactive', {
+        type: 'boolean',
+        description: 'Prompt for confirmation',
+        default: true,
+      }),
+      'connect-to-nx-cloud'
+    ),
+  handler: async (options) => {
+    await (
+      await import('./connect-to-nx-cloud')
+    ).connectToNxCloudCommand(options);
     process.exit(0);
   },
 };

--- a/packages/nx/src/command-line/connect/view-logs.ts
+++ b/packages/nx/src/command-line/connect/view-logs.ts
@@ -42,26 +42,17 @@ export async function viewLogs(): Promise<number> {
   if (!installCloud) return;
 
   const pmc = getPackageManagerCommand();
-  try {
-    output.log({
-      title: 'Installing nx-cloud',
-    });
-    execSync(`${pmc.addDev} nx-cloud@latest`, { stdio: 'ignore' });
-  } catch (e) {
-    output.log({
-      title: 'Installation failed',
-    });
-    console.log(e);
-    return 1;
-  }
 
   try {
     output.log({
       title: 'Connecting to Nx Cloud',
     });
-    runNxSync(`g nx-cloud:init --installation-source=view-logs`, {
-      stdio: 'ignore',
-    });
+    runNxSync(
+      `g nx:connect-to-nx-cloud --installation-source=view-logs --quiet --no-interactive`,
+      {
+        stdio: 'ignore',
+      }
+    );
   } catch (e) {
     output.log({
       title: 'Failed to connect to Nx Cloud',

--- a/packages/nx/src/command-line/init/implementation/add-nx-to-monorepo.ts
+++ b/packages/nx/src/command-line/init/implementation/add-nx-to-monorepo.ts
@@ -88,7 +88,7 @@ export async function addNxToMonorepo(options: Options) {
     scriptOutputs
   );
 
-  addDepsToPackageJson(repoRoot, useNxCloud);
+  addDepsToPackageJson(repoRoot);
 
   output.log({ title: '📦 Installing dependencies' });
   runInstall(repoRoot);

--- a/packages/nx/src/command-line/init/implementation/add-nx-to-nest.ts
+++ b/packages/nx/src/command-line/init/implementation/add-nx-to-nest.ts
@@ -117,7 +117,7 @@ export async function addNxToNest(options: Options, packageJson: PackageJson) {
 
   const pmc = getPackageManagerCommand();
 
-  addDepsToPackageJson(repoRoot, useNxCloud);
+  addDepsToPackageJson(repoRoot);
   addNestPluginToPackageJson(repoRoot);
   markRootPackageJsonAsNxProject(
     repoRoot,

--- a/packages/nx/src/command-line/init/implementation/add-nx-to-npm-repo.ts
+++ b/packages/nx/src/command-line/init/implementation/add-nx-to-npm-repo.ts
@@ -72,7 +72,7 @@ export async function addNxToNpmRepo(options: Options) {
 
   const pmc = getPackageManagerCommand();
 
-  addDepsToPackageJson(repoRoot, useNxCloud);
+  addDepsToPackageJson(repoRoot);
   markRootPackageJsonAsNxProject(
     repoRoot,
     cacheableOperations,

--- a/packages/nx/src/command-line/init/implementation/angular/index.ts
+++ b/packages/nx/src/command-line/init/implementation/angular/index.ts
@@ -54,7 +54,7 @@ export async function addNxToAngularCliRepo(options: Options) {
     options.nxCloud ?? (options.interactive ? await askAboutNxCloud() : false);
 
   output.log({ title: '📦 Installing dependencies' });
-  installDependencies(useNxCloud);
+  installDependencies();
 
   output.log({ title: '📝 Setting up workspace' });
   await setupWorkspace(cacheableOperations, options.integrated);
@@ -107,8 +107,8 @@ async function collectCacheableOperations(options: Options): Promise<string[]> {
   return cacheableOperations;
 }
 
-function installDependencies(useNxCloud: boolean): void {
-  addDepsToPackageJson(repoRoot, useNxCloud);
+function installDependencies(): void {
+  addDepsToPackageJson(repoRoot);
   addPluginDependencies();
   runInstall(repoRoot);
 }

--- a/packages/nx/src/command-line/init/implementation/angular/legacy-angular-versions.ts
+++ b/packages/nx/src/command-line/init/implementation/angular/legacy-angular-versions.ts
@@ -140,14 +140,6 @@ async function installDependencies(
     json.devDependencies[`${pkgInfo.pkgScope}/tao`] = pkgInfo.pkgVersion;
   }
 
-  if (useNxCloud) {
-    // get the latest nx-cloud version compatible with the Nx major
-    // version being installed
-    json.devDependencies['nx-cloud'] = await resolvePackageVersion(
-      'nx-cloud',
-      `^${major(pkgInfo.pkgVersion)}.0.0`
-    );
-  }
   json.devDependencies = sortObjectByKeys(json.devDependencies);
 
   if (pkgInfo.unscopedPkgName === 'angular') {

--- a/packages/nx/src/command-line/init/implementation/utils.ts
+++ b/packages/nx/src/command-line/init/implementation/utils.ts
@@ -113,14 +113,11 @@ function deduceDefaultBase() {
   }
 }
 
-export function addDepsToPackageJson(repoRoot: string, useCloud: boolean) {
+export function addDepsToPackageJson(repoRoot: string) {
   const path = joinPathFragments(repoRoot, `package.json`);
   const json = readJsonFile(path);
   if (!json.devDependencies) json.devDependencies = {};
   json.devDependencies['nx'] = nxVersion;
-  if (useCloud) {
-    json.devDependencies['nx-cloud'] = 'latest';
-  }
   writeJsonFile(path, json);
 }
 
@@ -140,10 +137,13 @@ export function initCloud(
     | 'nx-init-nest'
     | 'nx-init-npm-repo'
 ) {
-  runNxSync(`g nx-cloud:init --installationSource=${installationSource}`, {
-    stdio: [0, 1, 2],
-    cwd: repoRoot,
-  });
+  runNxSync(
+    `g nx:connect-to-nx-cloud --installationSource=${installationSource} --quiet --no-interactive`,
+    {
+      stdio: [0, 1, 2],
+      cwd: repoRoot,
+    }
+  );
 }
 
 export function addVsCodeRecommendedExtensions(

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -1218,9 +1218,10 @@ async function generateMigrationsJsonAndUpdatePackageJson(
         !isCI() &&
         !isNxCloudUsed(originalNxJson)
       ) {
-        const useCloud = await connectToNxCloudCommand(
-          messages.getPromptMessage('nxCloudMigration')
-        );
+        const useCloud = await connectToNxCloudCommand({
+          promptOverride: messages.getPromptMessage('nxCloudMigration'),
+          interactive: true,
+        });
         await recordStat({
           command: 'migrate',
           nxVersion,

--- a/packages/nx/src/command-line/yargs-utils/documentation.ts
+++ b/packages/nx/src/command-line/yargs-utils/documentation.ts
@@ -2,7 +2,10 @@ import chalk = require('chalk');
 import yargs = require('yargs');
 import { examples } from '../examples';
 
-export function linkToNxDevAndExamples(yargs: yargs.Argv, command: string) {
+export function linkToNxDevAndExamples<T>(
+  yargs: yargs.Argv<T>,
+  command: string
+) {
   (examples[command] || []).forEach((t) => {
     yargs = yargs.example(t.command, t.description);
   });

--- a/packages/nx/src/migrations/update-17-0-0/use-minimal-config-for-tasks-runner-options.spec.ts
+++ b/packages/nx/src/migrations/update-17-0-0/use-minimal-config-for-tasks-runner-options.spec.ts
@@ -81,6 +81,12 @@ describe('use-minimal-config-for-tasks-runner-options migration', () => {
         },
       },
     });
+    writeJson(tree, 'package.json', {
+      devDependencies: {
+        'nx-cloud': 'latest',
+        nx: 'latest',
+      },
+    });
 
     await migrate(tree);
 
@@ -89,6 +95,10 @@ describe('use-minimal-config-for-tasks-runner-options migration', () => {
     expect(nxJson.nxCloudUrl).toEqual('https://nx.app');
     expect(nxJson.nxCloudEncryptionKey).toEqual('secret');
     expect(nxJson.tasksRunnerOptions).not.toBeDefined();
+
+    expect(readJson(tree, 'package.json').devDependencies).toEqual({
+      nx: 'latest',
+    });
   });
 
   it('should move nxCloudAccessToken and nxCloudUrl for @nrwl/nx-cloud', async () => {

--- a/packages/nx/src/nx-cloud/debug-logger.ts
+++ b/packages/nx/src/nx-cloud/debug-logger.ts
@@ -1,0 +1,5 @@
+export function debugLog(...args: any[]) {
+  if (process.env['NX_VERBOSE_LOGGING'] === 'true') {
+    console.log('[NX CLOUD]', ...args);
+  }
+}

--- a/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/schema.json
+++ b/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/schema.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/schema",
   "id": "NxCloudInit",
   "title": "Add Nx Cloud Configuration to the workspace",
+  "description": "Connect a workspace to Nx Cloud.",
   "type": "object",
   "cli": "nx",
   "properties": {

--- a/packages/nx/src/nx-cloud/generators/init/init.ts
+++ b/packages/nx/src/nx-cloud/generators/init/init.ts
@@ -1,0 +1,159 @@
+import { execSync } from 'child_process';
+import { readFileSync } from 'fs';
+import { printCloudConnectionDisabledMessage } from '../../utilities/print-cloud-connection-disabled-message';
+
+function updateNxJson(json, token: string) {
+  const alreadySetOptions = json.tasksRunnerOptions?.default?.options ?? {};
+
+  const options = {
+    ...alreadySetOptions,
+    accessToken: token,
+  };
+
+  if (process.env.NX_CLOUD_API) {
+    options.url = process.env.NX_CLOUD_API;
+  }
+
+  json.tasksRunnerOptions = {
+    default: {
+      runner: isNxVersion16OrHigher() ? 'nx-cloud' : '@nrwl/nx-cloud',
+      options,
+    },
+  };
+}
+
+function readNxJsonUsingNx(host: any): any {
+  try {
+    const jsonUtils = require('nx/src/utils/json');
+    return jsonUtils.parseJson(host.read('nx.json', 'utf-8'));
+  } catch (ee) {
+    return JSON.parse(host.read('nx.json', 'utf-8'));
+  }
+}
+
+function writeNxJsonUsingNx(host: any, json: any, token: string) {
+  updateNxJson(json, token);
+  try {
+    const jsonUtils = require('nx/src/utils/json');
+    host.write('nx.json', jsonUtils.serializeJson(json));
+  } catch (ee) {
+    host.write('nx.json', JSON.stringify(json, null, 2));
+  }
+}
+
+function getRootPackageName(): string {
+  let packageJson;
+  try {
+    packageJson = JSON.parse(readFileSync('package.json').toString());
+  } catch (e) {}
+  return packageJson?.name ?? 'my-workspace';
+}
+
+function isNxVersion16OrHigher(): boolean {
+  try {
+    const packageJson = JSON.parse(readFileSync('package.json').toString());
+    const deps = {
+      ...(packageJson.dependencies || {}),
+      ...(packageJson.devDependencies || {}),
+    };
+    if (
+      deps['nx'].startsWith('15.') ||
+      deps['nx'].startsWith('14.') ||
+      deps['nx'].startsWith('13.') ||
+      deps['nx'].startsWith('12.')
+    ) {
+      return false;
+    } else {
+      return true;
+    }
+  } catch (e) {
+    return true;
+  }
+}
+
+function removeTrailingSlash(apiUrl: string) {
+  return apiUrl[apiUrl.length - 1] === '/'
+    ? apiUrl.substr(0, apiUrl.length - 1)
+    : apiUrl;
+}
+
+function getNxInitDate(): string | null {
+  try {
+    const nxInitIso = execSync(
+      'git log --diff-filter=A --follow --format=%aI -- nx.json | tail -1',
+      { stdio: 'pipe' }
+    )
+      .toString()
+      .trim();
+    const nxInitDate = new Date(nxInitIso);
+    return nxInitDate.toISOString();
+  } catch (e) {
+    return null;
+  }
+}
+
+async function createNxCloudWorkspace(
+  workspaceName: string,
+  installationSource: string,
+  nxInitDate: string | null
+): Promise<{ token: string; url: string }> {
+  const apiUrl = removeTrailingSlash(
+    process.env.NX_CLOUD_API || process.env.NRWL_API || `https://cloud.nx.app`
+  );
+  const response = await require('axios').post(
+    `${apiUrl}/nx-cloud/create-org-and-workspace`,
+    {
+      workspaceName,
+      installationSource,
+      nxInitDate,
+    }
+  );
+
+  if (response.data.message) {
+    throw new Error(response.data.message);
+  }
+
+  return response.data;
+}
+
+function printSuccessMessage(url: string) {
+  const { output } = require('../../utilities/nx-imports-light');
+
+  let host = 'nx.app';
+  try {
+    host = new (require('url').URL)(url).host;
+  } catch (e) {}
+
+  output.note({
+    title: `Distributed caching via Nx Cloud has been enabled`,
+    bodyLines: [
+      `In addition to the caching, Nx Cloud provides config-free distributed execution,`,
+      `UI for viewing complex runs and GitHub integration. Learn more at https://nx.app`,
+      ``,
+      `Your workspace is currently unclaimed. Run details from unclaimed workspaces can be viewed on ${host} by anyone`,
+      `with the link. Claim your workspace at the following link to restrict access.`,
+      ``,
+      `${url}`,
+    ],
+  });
+}
+
+export async function generator(host, schema) {
+  const nxJson = readNxJsonUsingNx(host);
+
+  if (nxJson.neverConnectToCloud) {
+    return () => {
+      printCloudConnectionDisabledMessage();
+    };
+  } else {
+    // TODO: Change to using loading light client when that is enabled by default
+    const r = await createNxCloudWorkspace(
+      getRootPackageName(),
+      schema.installationSource,
+      getNxInitDate()
+    );
+
+    writeNxJsonUsingNx(host, nxJson, r.token);
+    return () => printSuccessMessage(r.url);
+  }
+}

--- a/packages/nx/src/nx-cloud/generators/init/schema.json
+++ b/packages/nx/src/nx-cloud/generators/init/schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "NxCloudInit",
+  "title": "Add Nx Cloud Configuration to the workspace",
+  "type": "object",
+  "cli": "nx",
+  "properties": {
+    "analytics": {
+      "type": "boolean",
+      "description": "Anonymously store hashed machine ID for task runs",
+      "default": false
+    },
+    "installationSource": {
+      "type": "string",
+      "description": "Name of Nx Cloud installation invoker (ex. user, add-nx-to-monorepo, create-nx-workspace, nx-upgrade",
+      "default": "user"
+    }
+  },
+  "additionalProperties": false,
+  "required": []
+}

--- a/packages/nx/src/nx-cloud/nx-cloud-tasks-runner-shell.ts
+++ b/packages/nx/src/nx-cloud/nx-cloud-tasks-runner-shell.ts
@@ -1,40 +1,68 @@
-import { CloudTaskRunnerOptions } from '../core/models/cloud-task-runner-options';
-import { debugLog } from './debug-logger';
 import { findAncestorNodeModules } from './resolution-helpers';
-import { verifyOrUpdateCloudBundle } from './update-manager';
+import {
+  NxCloudClientUnavailableError,
+  NxCloudEnterpriseOutdatedError,
+  verifyOrUpdateNxCloudClient,
+} from './update-manager';
+import {
+  defaultTasksRunner,
+  DefaultTasksRunnerOptions,
+} from '../tasks-runner/default-tasks-runner';
+import { TasksRunner } from '../tasks-runner/tasks-runner';
+import { output } from '../utils/output';
+import { Task } from '../config/task-graph';
 
-export const nxCloudTasksRunnerShell: any = async (
-  tasks: any[],
-  options: CloudTaskRunnerOptions,
-  context: any = {}
-) => {
-  debugLog('Using light client');
-  const cloudBundleInstall = await verifyOrUpdateCloudBundle(options);
+export interface CloudTaskRunnerOptions extends DefaultTasksRunnerOptions {
+  accessToken?: string;
+  canTrackAnalytics?: boolean;
+  encryptionKey?: string;
+  maskedProperties?: string[];
+  showUsageWarnings?: boolean;
+  customProxyConfigPath?: string;
+  useLatestApi?: boolean;
+  url?: string;
+  useLightClient?: boolean;
+  clientVersion?: string;
+}
 
-  if (cloudBundleInstall === null) {
-    // Disable cloud entirely if unable to download light client
-    if (context.nxArgs) {
-      context.nxArgs.cloud = false;
-    } else {
-      context.nxArgs = { cloud: false };
+export const nxCloudTasksRunnerShell: TasksRunner<
+  CloudTaskRunnerOptions
+> = async (tasks: Task[], options: CloudTaskRunnerOptions, context) => {
+  try {
+    const { nxCloudClient, version } = await verifyOrUpdateNxCloudClient(
+      options
+    );
+
+    options.clientVersion = version;
+
+    const paths = findAncestorNodeModules(__dirname, []);
+    nxCloudClient.configureLightClientRequire()(paths);
+
+    return nxCloudClient.nxCloudTasksRunner(tasks, options, context);
+  } catch (e: any) {
+    const body =
+      e instanceof NxCloudEnterpriseOutdatedError
+        ? [
+            'If you are an Nx Enterprise customer, please reach out to your assigned Developer Productivity Engineer.',
+            'If you are NOT an Nx Enterprise customer but are seeing this message, please reach out to cloud-support@nrwl.io.',
+          ]
+        : e instanceof NxCloudClientUnavailableError
+        ? [
+            'You might be offline. Nx Cloud will be re-enabled when you are back online.',
+          ]
+        : [];
+
+    if (e instanceof NxCloudEnterpriseOutdatedError) {
+      output.warn({
+        title: e.message,
+        bodyLines: ['Nx Cloud will not used for this command.', ...body],
+      });
     }
-
-    throw new Error('TODO implement this');
-    // return nxCloudTasksRunner(tasks, options, context);
+    const results = await defaultTasksRunner(tasks, options, context);
+    output.warn({
+      title: e.message,
+      bodyLines: ['Nx Cloud was not used for this command.', ...body],
+    });
+    return results;
   }
-
-  debugLog('Using bundle path: ', cloudBundleInstall);
-
-  options.clientVersion = cloudBundleInstall.version;
-
-  const lightClient = require(cloudBundleInstall.fullPath);
-
-  const paths = findAncestorNodeModules(__dirname, []);
-  lightClient.configureLightClientRequire()(paths);
-
-  if (!lightClient.commands) {
-    throw new Error('Update Enterprise');
-  }
-
-  return lightClient.nxCloudTasksRunner(tasks, options, context);
 };

--- a/packages/nx/src/nx-cloud/nx-cloud-tasks-runner-shell.ts
+++ b/packages/nx/src/nx-cloud/nx-cloud-tasks-runner-shell.ts
@@ -1,0 +1,40 @@
+import { CloudTaskRunnerOptions } from '../core/models/cloud-task-runner-options';
+import { debugLog } from './debug-logger';
+import { findAncestorNodeModules } from './resolution-helpers';
+import { verifyOrUpdateCloudBundle } from './update-manager';
+
+export const nxCloudTasksRunnerShell: any = async (
+  tasks: any[],
+  options: CloudTaskRunnerOptions,
+  context: any = {}
+) => {
+  debugLog('Using light client');
+  const cloudBundleInstall = await verifyOrUpdateCloudBundle(options);
+
+  if (cloudBundleInstall === null) {
+    // Disable cloud entirely if unable to download light client
+    if (context.nxArgs) {
+      context.nxArgs.cloud = false;
+    } else {
+      context.nxArgs = { cloud: false };
+    }
+
+    throw new Error('TODO implement this');
+    // return nxCloudTasksRunner(tasks, options, context);
+  }
+
+  debugLog('Using bundle path: ', cloudBundleInstall);
+
+  options.clientVersion = cloudBundleInstall.version;
+
+  const lightClient = require(cloudBundleInstall.fullPath);
+
+  const paths = findAncestorNodeModules(__dirname, []);
+  lightClient.configureLightClientRequire()(paths);
+
+  if (!lightClient.commands) {
+    throw new Error('Update Enterprise');
+  }
+
+  return lightClient.nxCloudTasksRunner(tasks, options, context);
+};

--- a/packages/nx/src/nx-cloud/resolution-helpers.ts
+++ b/packages/nx/src/nx-cloud/resolution-helpers.ts
@@ -1,0 +1,21 @@
+import { existsSync } from 'fs';
+import { dirname, isAbsolute, join, resolve } from 'path';
+
+export function findAncestorNodeModules(startPath, collector) {
+  let currentPath = isAbsolute(startPath) ? startPath : resolve(startPath);
+
+  while (currentPath !== dirname(currentPath)) {
+    const potentialNodeModules = join(currentPath, 'node_modules');
+    if (existsSync(potentialNodeModules)) {
+      collector.push(potentialNodeModules);
+    }
+
+    if (existsSync(join(currentPath, 'nx.json'))) {
+      break;
+    }
+
+    currentPath = dirname(currentPath);
+  }
+
+  return collector;
+}

--- a/packages/nx/src/nx-cloud/update-manager.ts
+++ b/packages/nx/src/nx-cloud/update-manager.ts
@@ -1,0 +1,342 @@
+import { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+import { createHash } from 'crypto';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'fs';
+import { dirname, isAbsolute, join, resolve } from 'path';
+import { CloudTaskRunnerOptions } from '../core/models/cloud-task-runner-options';
+import { createApiAxiosInstance } from '../utilities/axios';
+import { debugLog } from './debug-logger';
+
+interface CloudBundleInstall {
+  version: string;
+  fullPath: string;
+}
+
+type ValidVerifyClientBundleResponse = {
+  valid: true;
+  url: null;
+  version: null;
+};
+
+type InvalidVerifyClientBundleResponse = {
+  valid: false;
+  url: string;
+  version: string;
+};
+
+type VerifyClientBundleResponse =
+  | ValidVerifyClientBundleResponse
+  | InvalidVerifyClientBundleResponse;
+
+export async function verifyOrUpdateCloudBundle(
+  options: CloudTaskRunnerOptions
+): Promise<CloudBundleInstall | null> {
+  const runnerBundleInstallDirectory = getRunnerBundleInstallDirectory(options);
+  const currentBundle = getLatestInstalledRunnerBundle(
+    runnerBundleInstallDirectory
+  );
+
+  if (
+    shouldVerifyInstalledRunnerBundle(
+      runnerBundleInstallDirectory,
+      currentBundle
+    )
+  ) {
+    const axios = createApiAxiosInstance(options);
+
+    let verifyBundleResponse: AxiosResponse<VerifyClientBundleResponse>;
+    try {
+      verifyBundleResponse = await verifyCurrentBundle(axios, currentBundle);
+    } catch (e: any) {
+      // Enterprise image compatibility, to be removed
+      if (e.message === 'Request failed with status code 404' && options.url) {
+        console.warn(
+          '[WARNING] Nx Cloud was unable to fetch or verify its bundle from the instance hosted at: ',
+          options.url
+        );
+        console.warn(
+          '[WARNING] Nx Cloud will continue to function as expected, but your installation should be updated'
+        );
+        console.warn('[WARNING] soon for the best experience.');
+        console.warn('[WARNING] ');
+        console.warn(
+          '[WARNING] If you are an Nx Enterprise customer, please reach out to your assigned Developer Productivity Engineer.'
+        );
+        console.warn('[WARNING] ');
+        console.warn(
+          '[WARNING] If you are NOT an Nx Enterprise customer but are seeing this message, please reach out to cloud-support@nrwl.io.'
+        );
+        console.warn('[WARNING] ');
+        console.warn(
+          '[WARNING] To prevent this check on startup, set `useLightClient: false` in your task runner options found in `nx.json`.'
+        );
+
+        return {
+          version: 'NX_ENTERPRISE_OUTDATED_IMAGE',
+          fullPath: '',
+        };
+      }
+
+      debugLog(
+        'Could not verify bundle. Resetting validation timer and using previously installed or default runner. Error: ',
+        e
+      );
+      writeBundleVerificationLock(runnerBundleInstallDirectory);
+
+      return currentBundle;
+    }
+
+    if (verifyBundleResponse.data.valid) {
+      debugLog('Currently installed bundle is valid');
+      writeBundleVerificationLock(runnerBundleInstallDirectory);
+      return currentBundle!!;
+    }
+
+    const { version, url } = verifyBundleResponse.data;
+    debugLog(
+      'Currently installed bundle is invalid, downloading version',
+      version,
+      ' from ',
+      url
+    );
+    return {
+      version,
+      fullPath: await downloadAndExtractClientBundle(
+        axios,
+        runnerBundleInstallDirectory,
+        version,
+        url
+      ),
+    };
+  }
+
+  return currentBundle!!;
+}
+
+function findWorkspaceRoot(startPath) {
+  let currentPath = isAbsolute(startPath) ? startPath : resolve(startPath);
+
+  while (currentPath !== dirname(currentPath)) {
+    const potentialFile = join(currentPath, 'nx.json');
+    if (existsSync(potentialFile)) {
+      return currentPath;
+    }
+    currentPath = dirname(currentPath);
+  }
+
+  return null;
+}
+
+function getRunnerBundleInstallDirectory(
+  options: CloudTaskRunnerOptions
+): string {
+  const cacheDirectory =
+    (process.env.NX_CACHE_DIRECTORY || options.cacheDirectory) ??
+    join('node_modules', '.cache', 'nx');
+  const runnerBundlePath = join(cacheDirectory, 'cloud');
+
+  if (isAbsolute(runnerBundlePath)) {
+    return runnerBundlePath;
+  } else {
+    const workspaceRoot = findWorkspaceRoot(process.cwd());
+    return join(workspaceRoot, runnerBundlePath);
+  }
+}
+
+function getLatestInstalledRunnerBundle(
+  runnerBundleInstallDirectory: string
+): CloudBundleInstall | null {
+  if (!existsSync(runnerBundleInstallDirectory)) {
+    mkdirSync(runnerBundleInstallDirectory, { recursive: true });
+  }
+
+  try {
+    const installedBundles: CloudBundleInstall[] = readdirSync(
+      runnerBundleInstallDirectory
+    )
+      .filter((potentialDirectory) => {
+        return statSync(
+          join(runnerBundleInstallDirectory, potentialDirectory)
+        ).isDirectory();
+      })
+      .map((fileOrDirectory) => ({
+        version: fileOrDirectory,
+        fullPath: join(runnerBundleInstallDirectory, fileOrDirectory),
+      }));
+
+    if (installedBundles.length === 0) {
+      // No installed bundles
+      return null;
+    }
+
+    return installedBundles[0];
+  } catch (e: any) {
+    console.log('Could not read runner bundle path:', e.message);
+    return null;
+  }
+}
+
+function shouldVerifyInstalledRunnerBundle(
+  runnerBundleInstallDirectory: string,
+  currentBundle: CloudBundleInstall | null
+): boolean {
+  if (process.env.NX_CLOUD_FORCE_REVALIDATE === 'true') {
+    return true;
+  }
+
+  // No bundle, need to download anyway
+  if (currentBundle != null) {
+    debugLog('A local bundle currently exists: ', currentBundle);
+    const lastVerification = getLatestBundleVerificationTimestamp(
+      runnerBundleInstallDirectory
+    );
+    // Never been verified, need to verify
+    if (lastVerification != null) {
+      // If last verification was less than 30 minutes ago, return the current installed bundle
+      const THIRTY_MINUTES = 30 * 60 * 1000;
+      if (Date.now() - lastVerification < THIRTY_MINUTES) {
+        debugLog(
+          'Last verification was within the past 30 minutes, will not verify this time'
+        );
+        return false;
+      }
+      debugLog(
+        'Last verification was more than 30 minutes ago, verifying bundle is still valid'
+      );
+    }
+  }
+  return true;
+}
+
+async function verifyCurrentBundle(
+  axios: AxiosInstance,
+  currentBundle: CloudBundleInstall | null
+): Promise<AxiosResponse<VerifyClientBundleResponse>> {
+  const contentHash = getBundleContentHash(currentBundle);
+  const queryParams =
+    currentBundle && contentHash
+      ? `?${new URLSearchParams({
+          version: currentBundle.version,
+          contentHash: contentHash,
+        }).toString()}`
+      : '';
+  return axios.get('/nx-cloud/client/verify' + queryParams);
+}
+
+function getLatestBundleVerificationTimestamp(
+  runnerBundleInstallDirectory: string
+): number | null {
+  const lockfilePath = join(runnerBundleInstallDirectory, 'verify.lock');
+
+  if (existsSync(lockfilePath)) {
+    const timestampAsString = readFileSync(lockfilePath, 'utf-8');
+
+    let timestampAsNumber: number;
+    try {
+      timestampAsNumber = Number(timestampAsString);
+      return timestampAsNumber;
+    } catch (e) {
+      return null;
+    }
+  }
+  return null;
+}
+
+function writeBundleVerificationLock(runnerBundleInstallDirectory: string) {
+  const lockfilePath = join(runnerBundleInstallDirectory, 'verify.lock');
+
+  writeFileSync(lockfilePath, new Date().getTime().toString(), 'utf-8');
+}
+
+function getBundleContentHash(
+  bundle: CloudBundleInstall | null
+): string | null {
+  if (bundle == null) {
+    return null;
+  }
+
+  return hashDirectory(bundle.fullPath);
+}
+
+function hashDirectory(dir) {
+  const files = readdirSync(dir).sort();
+  const hashes = files.map((file) => {
+    const filePath = join(dir, file);
+    const stat = statSync(filePath);
+
+    // If the current path is a directory, recursively hash the contents
+    if (stat.isDirectory()) {
+      return hashDirectory(filePath);
+    }
+
+    // If it's a file, hash the file contents
+    const content = readFileSync(filePath);
+    return createHash('sha256').update(content).digest('hex');
+  });
+
+  // Hash the combined hashes of the directory's contents
+  const combinedHashes = hashes.sort().join('');
+  return createHash('sha256').update(combinedHashes).digest('hex');
+}
+
+async function downloadAndExtractClientBundle(
+  axios: AxiosInstance,
+  runnerBundleInstallDirectory: string,
+  version: string,
+  url: string
+): Promise<string> {
+  let resp;
+  try {
+    resp = await axios.get(url, {
+      responseType: 'stream',
+    } as AxiosRequestConfig);
+  } catch (e: any) {
+    console.error('Error while updating Nx Cloud client bundle');
+    throw e;
+  }
+
+  const bundleExtractLocation = join(runnerBundleInstallDirectory, version);
+
+  if (!existsSync(bundleExtractLocation)) {
+    mkdirSync(bundleExtractLocation);
+  }
+
+  const tar = require('tar');
+  const extractStream = resp.data.pipe(
+    tar.x({
+      cwd: bundleExtractLocation,
+    })
+  );
+  return new Promise((res, rej) => {
+    extractStream.on('error', (e) => {
+      rej(e);
+    });
+    extractStream.on('close', () => {
+      removeOldClientBundles(runnerBundleInstallDirectory, version);
+      writeBundleVerificationLock(runnerBundleInstallDirectory);
+      res(bundleExtractLocation);
+    });
+  });
+}
+
+function removeOldClientBundles(
+  runnerBundleInstallDirectory: string,
+  currentInstallVersion: string
+) {
+  const filesAndFolders = readdirSync(runnerBundleInstallDirectory);
+
+  for (let fileOrFolder of filesAndFolders) {
+    const fileOrFolderPath = join(runnerBundleInstallDirectory, fileOrFolder);
+
+    if (fileOrFolder !== currentInstallVersion) {
+      rmSync(fileOrFolderPath, { recursive: true });
+    }
+  }
+}

--- a/packages/nx/src/nx-cloud/utilities/axios.ts
+++ b/packages/nx/src/nx-cloud/utilities/axios.ts
@@ -1,0 +1,123 @@
+import { AxiosRequestConfig } from 'axios';
+import { join } from 'path';
+import { CloudTaskRunnerOptions } from '../core/models/cloud-task-runner-options';
+import {
+  ACCESS_TOKEN,
+  NUMBER_OF_AXIOS_RETRIES,
+  NX_CLOUD_NO_TIMEOUTS,
+  UNLIMITED_TIMEOUT,
+  VERBOSE_LOGGING,
+} from './environment';
+import { wait } from './waiter';
+
+const { output } = require('./nx-imports-light');
+
+const axios = require('axios');
+
+export class AxiosException {
+  constructor(
+    public readonly type: 'timeout' | 'failure',
+    public readonly message: string,
+    public readonly axiosException: any
+  ) {}
+}
+
+export function createApiAxiosInstance(options: CloudTaskRunnerOptions) {
+  let axiosConfigBuilder = (axiosConfig: AxiosRequestConfig) => axiosConfig;
+  const baseUrl =
+    process.env.NX_CLOUD_API || options.url || 'https://cloud.nx.app';
+  const accessToken = ACCESS_TOKEN ? ACCESS_TOKEN : options.accessToken!;
+
+  if (!accessToken) {
+    throw new Error(
+      `Unable to authenticate. Either define accessToken in nx.json or set the NX_CLOUD_ACCESS_TOKEN env variable.`
+    );
+  }
+
+  if (options.customProxyConfigPath) {
+    const { nxCloudProxyConfig } = require(join(
+      process.cwd(),
+      options.customProxyConfigPath
+    ));
+    axiosConfigBuilder = nxCloudProxyConfig ?? axiosConfigBuilder;
+  }
+
+  return axios.create(
+    axiosConfigBuilder({
+      baseURL: baseUrl,
+      timeout: NX_CLOUD_NO_TIMEOUTS ? UNLIMITED_TIMEOUT : 10000,
+      headers: { authorization: accessToken },
+    })
+  );
+}
+
+export async function printDuration(description: string, callback: Function) {
+  const b = new Date();
+  const res = await callback();
+  const a = new Date();
+
+  if (VERBOSE_LOGGING) {
+    console.log(`${description}: ${a.getTime() - b.getTime()}`);
+  }
+
+  return res;
+}
+
+let error429Promise: Promise<unknown> | null = null;
+
+export async function axiosMultipleTries(
+  axiosCallCreator: () => Promise<any>,
+  retriesLeft = NUMBER_OF_AXIOS_RETRIES
+) {
+  try {
+    return await axiosCallCreator();
+  } catch (e: any) {
+    const code = (e.response && e.response.status) || e.code;
+
+    // Do not retry if we receive an unauthorized or forbidden response
+    if (code === 401 || code === 403) {
+      retriesLeft = 0;
+    }
+    let message = e.response
+      ? e.response.data.message
+        ? e.response.data.message
+        : e.response.data
+      : e.message;
+    if (retriesLeft === 0) {
+      if (typeof message !== 'string') {
+        message = e.message;
+      }
+      throw new AxiosException(
+        'failure',
+        `Error when connecting to Nx Cloud. Code: ${code}. Error: ${message}`,
+        e
+      );
+    } else {
+      if (code == 429) {
+        // this logic helps us not print the same message over and over again
+        if (!error429Promise) {
+          const retryAfter =
+            10000 +
+            (NUMBER_OF_AXIOS_RETRIES + 1 - retriesLeft) * 60000 * Math.random();
+          output.note({
+            title: `Received Code ${code}. ${message} Retrying in ${retryAfter}ms.`,
+          });
+          error429Promise = wait(retryAfter);
+        }
+        await error429Promise;
+        error429Promise = null;
+      } else {
+        const retryAfter =
+          1000 +
+          (NUMBER_OF_AXIOS_RETRIES + 1 - retriesLeft) * 4000 * Math.random();
+        if (VERBOSE_LOGGING) {
+          output.note({
+            title: `Received Code ${code}. Retrying in ${retryAfter}ms.`,
+          });
+        }
+        await wait(retryAfter);
+      }
+      return axiosMultipleTries(axiosCallCreator, retriesLeft - 1);
+    }
+  }
+}

--- a/packages/nx/src/nx-cloud/utilities/axios.ts
+++ b/packages/nx/src/nx-cloud/utilities/axios.ts
@@ -1,26 +1,13 @@
 import { AxiosRequestConfig } from 'axios';
 import { join } from 'path';
-import { CloudTaskRunnerOptions } from '../core/models/cloud-task-runner-options';
 import {
   ACCESS_TOKEN,
-  NUMBER_OF_AXIOS_RETRIES,
   NX_CLOUD_NO_TIMEOUTS,
   UNLIMITED_TIMEOUT,
-  VERBOSE_LOGGING,
 } from './environment';
-import { wait } from './waiter';
-
-const { output } = require('./nx-imports-light');
+import { CloudTaskRunnerOptions } from '../nx-cloud-tasks-runner-shell';
 
 const axios = require('axios');
-
-export class AxiosException {
-  constructor(
-    public readonly type: 'timeout' | 'failure',
-    public readonly message: string,
-    public readonly axiosException: any
-  ) {}
-}
 
 export function createApiAxiosInstance(options: CloudTaskRunnerOptions) {
   let axiosConfigBuilder = (axiosConfig: AxiosRequestConfig) => axiosConfig;
@@ -49,75 +36,4 @@ export function createApiAxiosInstance(options: CloudTaskRunnerOptions) {
       headers: { authorization: accessToken },
     })
   );
-}
-
-export async function printDuration(description: string, callback: Function) {
-  const b = new Date();
-  const res = await callback();
-  const a = new Date();
-
-  if (VERBOSE_LOGGING) {
-    console.log(`${description}: ${a.getTime() - b.getTime()}`);
-  }
-
-  return res;
-}
-
-let error429Promise: Promise<unknown> | null = null;
-
-export async function axiosMultipleTries(
-  axiosCallCreator: () => Promise<any>,
-  retriesLeft = NUMBER_OF_AXIOS_RETRIES
-) {
-  try {
-    return await axiosCallCreator();
-  } catch (e: any) {
-    const code = (e.response && e.response.status) || e.code;
-
-    // Do not retry if we receive an unauthorized or forbidden response
-    if (code === 401 || code === 403) {
-      retriesLeft = 0;
-    }
-    let message = e.response
-      ? e.response.data.message
-        ? e.response.data.message
-        : e.response.data
-      : e.message;
-    if (retriesLeft === 0) {
-      if (typeof message !== 'string') {
-        message = e.message;
-      }
-      throw new AxiosException(
-        'failure',
-        `Error when connecting to Nx Cloud. Code: ${code}. Error: ${message}`,
-        e
-      );
-    } else {
-      if (code == 429) {
-        // this logic helps us not print the same message over and over again
-        if (!error429Promise) {
-          const retryAfter =
-            10000 +
-            (NUMBER_OF_AXIOS_RETRIES + 1 - retriesLeft) * 60000 * Math.random();
-          output.note({
-            title: `Received Code ${code}. ${message} Retrying in ${retryAfter}ms.`,
-          });
-          error429Promise = wait(retryAfter);
-        }
-        await error429Promise;
-        error429Promise = null;
-      } else {
-        const retryAfter =
-          1000 +
-          (NUMBER_OF_AXIOS_RETRIES + 1 - retriesLeft) * 4000 * Math.random();
-        if (VERBOSE_LOGGING) {
-          output.note({
-            title: `Received Code ${code}. Retrying in ${retryAfter}ms.`,
-          });
-        }
-        await wait(retryAfter);
-      }
-      return axiosMultipleTries(axiosCallCreator, retriesLeft - 1);
-    }
-  }
 }

--- a/packages/nx/src/nx-cloud/utilities/environment.ts
+++ b/packages/nx/src/nx-cloud/utilities/environment.ts
@@ -1,0 +1,261 @@
+import { execSync } from 'child_process';
+import { createHash } from 'crypto';
+import * as dotenv from 'dotenv';
+import { readFileSync } from 'fs';
+import { machineIdSync } from 'node-machine-id';
+import { join, parse } from 'path';
+import { MachineInfo } from '../core/models/machine-info.model';
+import { isCI } from './is-ci';
+import { isConnectedToPrivateCloud } from './is-private-cloud';
+
+const { workspaceRoot } = require('./nx-imports-light');
+
+// Set once
+export const UNLIMITED_TIMEOUT = 9999999;
+export const NO_MESSAGES_TIMEOUT = process.env.NX_CLOUD_AGENT_TIMEOUT_MS
+  ? Number(process.env.NX_CLOUD_AGENT_TIMEOUT_MS)
+  : 3600000; // 60 minutes
+export const NO_COMPLETED_TASKS_TIMEOUT = process.env
+  .NX_CLOUD_ORCHESTRATOR_TIMEOUT_MS
+  ? Number(process.env.NX_CLOUD_ORCHESTRATOR_TIMEOUT_MS)
+  : 3600000; // 60 minutes
+export const UNLIMITED_FILE_SIZE = 1000 * 1000 * 10000;
+export const NX_CLOUD_UNLIMITED_OUTPUT =
+  process.env.NX_CLOUD_UNLIMITED_OUTPUT === 'true';
+export const DEFAULT_FILE_SIZE_LIMIT = 1000 * 1000 * 300;
+export const DISTRIBUTED_TASK_EXECUTION_INTERNAL_ERROR_STATUS_CODE = 166;
+export const NX_CLOUD_DISTRIBUTED_EXECUTION_AGENT_COUNT = process.env
+  .NX_CLOUD_DISTRIBUTED_EXECUTION_AGENT_COUNT
+  ? Number(process.env.NX_CLOUD_DISTRIBUTED_EXECUTION_AGENT_COUNT)
+  : null;
+export const NX_CLOUD_DISTRIBUTED_EXECUTION_STOP_AGENTS_ON_FAILURE =
+  process.env.NX_CLOUD_DISTRIBUTED_EXECUTION_STOP_AGENTS_ON_FAILURE != 'false';
+export const NX_CLOUD_FORCE_METRICS =
+  process.env.NX_CLOUD_FORCE_METRICS === 'true';
+export const NUMBER_OF_AXIOS_RETRIES = process.env.NX_CLOUD_NUMBER_OF_RETRIES
+  ? Number(process.env.NX_CLOUD_NUMBER_OF_RETRIES)
+  : isCI()
+  ? 10
+  : 1;
+export const NX_NO_CLOUD = process.env.NX_NO_CLOUD === 'true';
+
+export let ACCESS_TOKEN;
+export let ENCRYPTION_KEY;
+export let VERBOSE_LOGGING;
+export let NX_CLOUD_NO_TIMEOUTS;
+
+loadEnvVars();
+
+export function agentRunningInDistributedExecution(
+  distributedExecutionId: string | undefined
+) {
+  return !!distributedExecutionId;
+}
+
+export function nxInvokedByRunner() {
+  return (
+    process.env.NX_INVOKED_BY_RUNNER === 'true' ||
+    process.env.NX_CLOUD === 'false'
+  );
+}
+
+export function extractGitSha() {
+  try {
+    return execSync(`git rev-parse HEAD`, { stdio: 'pipe' }).toString().trim();
+  } catch (e) {
+    return undefined;
+  }
+}
+
+export function extractGitRef() {
+  try {
+    return execSync(`git rev-parse --symbolic-full-name HEAD`, {
+      stdio: 'pipe',
+    })
+      .toString()
+      .trim();
+  } catch (e) {
+    return undefined;
+  }
+}
+
+function parseEnv() {
+  try {
+    const envContents = readFileSync(join(workspaceRoot, 'nx-cloud.env'));
+    return dotenv.parse(envContents);
+  } catch (e) {
+    return {};
+  }
+}
+
+function loadEnvVars() {
+  const parsed = parseEnv();
+  ACCESS_TOKEN =
+    process.env.NX_CLOUD_AUTH_TOKEN ||
+    process.env.NX_CLOUD_ACCESS_TOKEN ||
+    parsed.NX_CLOUD_AUTH_TOKEN ||
+    parsed.NX_CLOUD_ACCESS_TOKEN;
+  ENCRYPTION_KEY =
+    process.env.NX_CLOUD_ENCRYPTION_KEY || parsed.NX_CLOUD_ENCRYPTION_KEY;
+  VERBOSE_LOGGING =
+    process.env.NX_VERBOSE_LOGGING === 'true' ||
+    parsed.NX_VERBOSE_LOGGING === 'true';
+  NX_CLOUD_NO_TIMEOUTS =
+    process.env.NX_CLOUD_NO_TIMEOUTS === 'true' ||
+    parsed.NX_CLOUD_NO_TIMEOUTS === 'true';
+}
+
+export function getCIExecutionId(): string | null {
+  if (isConnectedToPrivateCloud()) return undefined as any;
+  return _ciExecutionId();
+}
+
+function _ciExecutionId() {
+  if (process.env.NX_CI_EXECUTION_ID !== undefined) {
+    return process.env.NX_CI_EXECUTION_ID;
+  }
+
+  // for backwards compat
+  if (process.env.NX_RUN_GROUP !== undefined) {
+    return process.env.NX_RUN_GROUP;
+  }
+
+  if (process.env.CIRCLECI !== undefined && process.env.CIRCLE_WORKFLOW_ID) {
+    return process.env.CIRCLE_WORKFLOW_ID;
+  }
+
+  if (process.env.TRAVIS_BUILD_ID !== undefined) {
+    return process.env.TRAVIS_BUILD_ID;
+  }
+
+  if (process.env.GITHUB_ACTIONS && process.env.GITHUB_RUN_ID) {
+    return `${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT}`;
+  }
+
+  if (process.env.BUILD_BUILDID) {
+    return process.env.BUILD_BUILDID;
+  }
+
+  if (process.env.BITBUCKET_BUILD_NUMBER !== undefined) {
+    return process.env.BITBUCKET_BUILD_NUMBER;
+  }
+
+  if (process.env.VERCEL_GIT_COMMIT_SHA !== undefined) {
+    return process.env.VERCEL_GIT_COMMIT_SHA;
+  }
+
+  if (process.env.CI_PIPELINE_ID) {
+    return process.env.CI_PIPELINE_ID;
+  }
+
+  // Jenkins
+  if (process.env.BUILD_TAG) {
+    return process.env.BUILD_TAG;
+  }
+  return null;
+}
+
+export function getCIExecutionEnv() {
+  if (isConnectedToPrivateCloud()) return undefined as any;
+  return process.env.NX_CI_EXECUTION_ENV ?? '';
+}
+
+export function getRunGroup(): string {
+  if (process.env.NX_RUN_GROUP !== undefined) {
+    return process.env.NX_RUN_GROUP;
+  }
+
+  const ciExecutionId = _ciExecutionId();
+  if (ciExecutionId) {
+    if (getCIExecutionEnv()) {
+      return `${ciExecutionId}-${getCIExecutionEnv()}`;
+    } else {
+      return ciExecutionId;
+    }
+  }
+
+  return extractGitSha()!!;
+}
+
+export function getBranch(): string | null {
+  if (process.env.NX_BRANCH !== undefined) {
+    return process.env.NX_BRANCH;
+  }
+
+  if (process.env.CIRCLECI !== undefined) {
+    if (process.env.CIRCLE_PR_NUMBER !== undefined) {
+      return process.env.CIRCLE_PR_NUMBER;
+    } else if (process.env.CIRCLE_PULL_REQUEST !== undefined) {
+      const p = process.env.CIRCLE_PULL_REQUEST.split('/');
+      return p[p.length - 1];
+    } else if (process.env.CIRCLE_BRANCH !== undefined) {
+      return process.env.CIRCLE_BRANCH;
+    }
+  }
+
+  if (process.env.TRAVIS_PULL_REQUEST !== undefined) {
+    return process.env.TRAVIS_PULL_REQUEST;
+  }
+
+  // refs/pull/78/merge
+  if (process.env.GITHUB_ACTIONS) {
+    if (process.env.GITHUB_REF) {
+      const ref = process.env.GITHUB_REF.match(/refs\/pull\/(\d+)\/merge/);
+      if (ref) {
+        return ref[1];
+      }
+    }
+    return process.env.GITHUB_HEAD_REF ?? '';
+  }
+
+  if (process.env.BITBUCKET_PR_ID !== undefined) {
+    return process.env.BITBUCKET_PR_ID;
+  }
+
+  if (process.env.VERCEL_GIT_COMMIT_REF !== undefined) {
+    return process.env.VERCEL_GIT_COMMIT_REF;
+  }
+
+  // Gitlab, merge request flow only
+  // For support: Users must have their pipeline configured as merge requests
+  // ONLY to have this variable appear.
+  // https://docs.gitlab.com/ee/ci/pipelines/merge_request_pipelines.html#use-only-to-add-jobs
+  if (process.env.CI_MERGE_REQUEST_IID) {
+    return process.env.CI_MERGE_REQUEST_IID;
+  }
+
+  // Gitlab, branch pipeline flow only
+  // Will not work with bot comments
+  if (process.env.CI_COMMIT_BRANCH) {
+    return process.env.CI_COMMIT_BRANCH;
+  }
+
+  // Jenkins, this will only be populated in MULTIBRANCH pipelines.
+  // Remember that if someone asks in support :)
+  if (process.env.GIT_BRANCH) {
+    return process.env.GIT_BRANCH;
+  }
+
+  return null;
+}
+
+export function getMachineInfo(): MachineInfo {
+  const os = require('os');
+
+  const hasher = createHash('md5');
+  hasher.update(machineIdSync());
+  const machineId = hasher.digest('base64');
+
+  return {
+    machineId,
+    platform: os.platform(),
+    version: (os as any).version ? (os as any).version() : '',
+    cpuCores: os.cpus().length,
+  };
+}
+
+export function parseCommand() {
+  const cmdBase = parse(process.argv[1]).name;
+  const args = `${process.argv.slice(2).join(' ')}`;
+  return `${cmdBase} ${args}`;
+}

--- a/packages/nx/src/nx-cloud/utilities/environment.ts
+++ b/packages/nx/src/nx-cloud/utilities/environment.ts
@@ -1,84 +1,31 @@
-import { execSync } from 'child_process';
-import { createHash } from 'crypto';
 import * as dotenv from 'dotenv';
 import { readFileSync } from 'fs';
-import { machineIdSync } from 'node-machine-id';
-import { join, parse } from 'path';
-import { MachineInfo } from '../core/models/machine-info.model';
-import { isCI } from './is-ci';
-import { isConnectedToPrivateCloud } from './is-private-cloud';
-
-const { workspaceRoot } = require('./nx-imports-light');
+import { join } from 'path';
+import { isCI } from '../../utils/is-ci';
+import { workspaceRoot } from '../../utils/workspace-root';
 
 // Set once
 export const UNLIMITED_TIMEOUT = 9999999;
-export const NO_MESSAGES_TIMEOUT = process.env.NX_CLOUD_AGENT_TIMEOUT_MS
+process.env.NX_CLOUD_AGENT_TIMEOUT_MS
   ? Number(process.env.NX_CLOUD_AGENT_TIMEOUT_MS)
-  : 3600000; // 60 minutes
-export const NO_COMPLETED_TASKS_TIMEOUT = process.env
-  .NX_CLOUD_ORCHESTRATOR_TIMEOUT_MS
+  : 3600000;
+// 60 minutes
+process.env.NX_CLOUD_ORCHESTRATOR_TIMEOUT_MS
   ? Number(process.env.NX_CLOUD_ORCHESTRATOR_TIMEOUT_MS)
-  : 3600000; // 60 minutes
-export const UNLIMITED_FILE_SIZE = 1000 * 1000 * 10000;
-export const NX_CLOUD_UNLIMITED_OUTPUT =
-  process.env.NX_CLOUD_UNLIMITED_OUTPUT === 'true';
-export const DEFAULT_FILE_SIZE_LIMIT = 1000 * 1000 * 300;
-export const DISTRIBUTED_TASK_EXECUTION_INTERNAL_ERROR_STATUS_CODE = 166;
-export const NX_CLOUD_DISTRIBUTED_EXECUTION_AGENT_COUNT = process.env
-  .NX_CLOUD_DISTRIBUTED_EXECUTION_AGENT_COUNT
+  : 3600000;
+// 60 minutes
+process.env.NX_CLOUD_DISTRIBUTED_EXECUTION_AGENT_COUNT
   ? Number(process.env.NX_CLOUD_DISTRIBUTED_EXECUTION_AGENT_COUNT)
   : null;
-export const NX_CLOUD_DISTRIBUTED_EXECUTION_STOP_AGENTS_ON_FAILURE =
-  process.env.NX_CLOUD_DISTRIBUTED_EXECUTION_STOP_AGENTS_ON_FAILURE != 'false';
-export const NX_CLOUD_FORCE_METRICS =
-  process.env.NX_CLOUD_FORCE_METRICS === 'true';
-export const NUMBER_OF_AXIOS_RETRIES = process.env.NX_CLOUD_NUMBER_OF_RETRIES
+process.env.NX_CLOUD_NUMBER_OF_RETRIES
   ? Number(process.env.NX_CLOUD_NUMBER_OF_RETRIES)
   : isCI()
   ? 10
   : 1;
-export const NX_NO_CLOUD = process.env.NX_NO_CLOUD === 'true';
-
 export let ACCESS_TOKEN;
-export let ENCRYPTION_KEY;
-export let VERBOSE_LOGGING;
 export let NX_CLOUD_NO_TIMEOUTS;
 
 loadEnvVars();
-
-export function agentRunningInDistributedExecution(
-  distributedExecutionId: string | undefined
-) {
-  return !!distributedExecutionId;
-}
-
-export function nxInvokedByRunner() {
-  return (
-    process.env.NX_INVOKED_BY_RUNNER === 'true' ||
-    process.env.NX_CLOUD === 'false'
-  );
-}
-
-export function extractGitSha() {
-  try {
-    return execSync(`git rev-parse HEAD`, { stdio: 'pipe' }).toString().trim();
-  } catch (e) {
-    return undefined;
-  }
-}
-
-export function extractGitRef() {
-  try {
-    return execSync(`git rev-parse --symbolic-full-name HEAD`, {
-      stdio: 'pipe',
-    })
-      .toString()
-      .trim();
-  } catch (e) {
-    return undefined;
-  }
-}
-
 function parseEnv() {
   try {
     const envContents = readFileSync(join(workspaceRoot, 'nx-cloud.env'));
@@ -95,167 +42,7 @@ function loadEnvVars() {
     process.env.NX_CLOUD_ACCESS_TOKEN ||
     parsed.NX_CLOUD_AUTH_TOKEN ||
     parsed.NX_CLOUD_ACCESS_TOKEN;
-  ENCRYPTION_KEY =
-    process.env.NX_CLOUD_ENCRYPTION_KEY || parsed.NX_CLOUD_ENCRYPTION_KEY;
-  VERBOSE_LOGGING =
-    process.env.NX_VERBOSE_LOGGING === 'true' ||
-    parsed.NX_VERBOSE_LOGGING === 'true';
   NX_CLOUD_NO_TIMEOUTS =
     process.env.NX_CLOUD_NO_TIMEOUTS === 'true' ||
     parsed.NX_CLOUD_NO_TIMEOUTS === 'true';
-}
-
-export function getCIExecutionId(): string | null {
-  if (isConnectedToPrivateCloud()) return undefined as any;
-  return _ciExecutionId();
-}
-
-function _ciExecutionId() {
-  if (process.env.NX_CI_EXECUTION_ID !== undefined) {
-    return process.env.NX_CI_EXECUTION_ID;
-  }
-
-  // for backwards compat
-  if (process.env.NX_RUN_GROUP !== undefined) {
-    return process.env.NX_RUN_GROUP;
-  }
-
-  if (process.env.CIRCLECI !== undefined && process.env.CIRCLE_WORKFLOW_ID) {
-    return process.env.CIRCLE_WORKFLOW_ID;
-  }
-
-  if (process.env.TRAVIS_BUILD_ID !== undefined) {
-    return process.env.TRAVIS_BUILD_ID;
-  }
-
-  if (process.env.GITHUB_ACTIONS && process.env.GITHUB_RUN_ID) {
-    return `${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT}`;
-  }
-
-  if (process.env.BUILD_BUILDID) {
-    return process.env.BUILD_BUILDID;
-  }
-
-  if (process.env.BITBUCKET_BUILD_NUMBER !== undefined) {
-    return process.env.BITBUCKET_BUILD_NUMBER;
-  }
-
-  if (process.env.VERCEL_GIT_COMMIT_SHA !== undefined) {
-    return process.env.VERCEL_GIT_COMMIT_SHA;
-  }
-
-  if (process.env.CI_PIPELINE_ID) {
-    return process.env.CI_PIPELINE_ID;
-  }
-
-  // Jenkins
-  if (process.env.BUILD_TAG) {
-    return process.env.BUILD_TAG;
-  }
-  return null;
-}
-
-export function getCIExecutionEnv() {
-  if (isConnectedToPrivateCloud()) return undefined as any;
-  return process.env.NX_CI_EXECUTION_ENV ?? '';
-}
-
-export function getRunGroup(): string {
-  if (process.env.NX_RUN_GROUP !== undefined) {
-    return process.env.NX_RUN_GROUP;
-  }
-
-  const ciExecutionId = _ciExecutionId();
-  if (ciExecutionId) {
-    if (getCIExecutionEnv()) {
-      return `${ciExecutionId}-${getCIExecutionEnv()}`;
-    } else {
-      return ciExecutionId;
-    }
-  }
-
-  return extractGitSha()!!;
-}
-
-export function getBranch(): string | null {
-  if (process.env.NX_BRANCH !== undefined) {
-    return process.env.NX_BRANCH;
-  }
-
-  if (process.env.CIRCLECI !== undefined) {
-    if (process.env.CIRCLE_PR_NUMBER !== undefined) {
-      return process.env.CIRCLE_PR_NUMBER;
-    } else if (process.env.CIRCLE_PULL_REQUEST !== undefined) {
-      const p = process.env.CIRCLE_PULL_REQUEST.split('/');
-      return p[p.length - 1];
-    } else if (process.env.CIRCLE_BRANCH !== undefined) {
-      return process.env.CIRCLE_BRANCH;
-    }
-  }
-
-  if (process.env.TRAVIS_PULL_REQUEST !== undefined) {
-    return process.env.TRAVIS_PULL_REQUEST;
-  }
-
-  // refs/pull/78/merge
-  if (process.env.GITHUB_ACTIONS) {
-    if (process.env.GITHUB_REF) {
-      const ref = process.env.GITHUB_REF.match(/refs\/pull\/(\d+)\/merge/);
-      if (ref) {
-        return ref[1];
-      }
-    }
-    return process.env.GITHUB_HEAD_REF ?? '';
-  }
-
-  if (process.env.BITBUCKET_PR_ID !== undefined) {
-    return process.env.BITBUCKET_PR_ID;
-  }
-
-  if (process.env.VERCEL_GIT_COMMIT_REF !== undefined) {
-    return process.env.VERCEL_GIT_COMMIT_REF;
-  }
-
-  // Gitlab, merge request flow only
-  // For support: Users must have their pipeline configured as merge requests
-  // ONLY to have this variable appear.
-  // https://docs.gitlab.com/ee/ci/pipelines/merge_request_pipelines.html#use-only-to-add-jobs
-  if (process.env.CI_MERGE_REQUEST_IID) {
-    return process.env.CI_MERGE_REQUEST_IID;
-  }
-
-  // Gitlab, branch pipeline flow only
-  // Will not work with bot comments
-  if (process.env.CI_COMMIT_BRANCH) {
-    return process.env.CI_COMMIT_BRANCH;
-  }
-
-  // Jenkins, this will only be populated in MULTIBRANCH pipelines.
-  // Remember that if someone asks in support :)
-  if (process.env.GIT_BRANCH) {
-    return process.env.GIT_BRANCH;
-  }
-
-  return null;
-}
-
-export function getMachineInfo(): MachineInfo {
-  const os = require('os');
-
-  const hasher = createHash('md5');
-  hasher.update(machineIdSync());
-  const machineId = hasher.digest('base64');
-
-  return {
-    machineId,
-    platform: os.platform(),
-    version: (os as any).version ? (os as any).version() : '',
-    cpuCores: os.cpus().length,
-  };
-}
-
-export function parseCommand() {
-  const cmdBase = parse(process.argv[1]).name;
-  const args = `${process.argv.slice(2).join(' ')}`;
-  return `${cmdBase} ${args}`;
 }

--- a/packages/nx/src/nx-cloud/utilities/get-cloud-options.ts
+++ b/packages/nx/src/nx-cloud/utilities/get-cloud-options.ts
@@ -1,54 +1,10 @@
-import { readFileSync } from 'fs';
+import { CloudTaskRunnerOptions } from '../nx-cloud-tasks-runner-shell';
+import { readNxJson } from '../../config/nx-json';
+import { getRunnerOptions } from '../../tasks-runner/run-command';
 
-import * as stripJsonComments from 'strip-json-comments';
-import { CloudTaskRunnerOptions } from '../core/models/cloud-task-runner-options';
+export function getCloudOptions(): CloudTaskRunnerOptions {
+  const nxJson = readNxJson();
 
-const { workspaceRoot } = require('./nx-imports-light');
-
-export function getCloudOptions(): {
-  nxJson: any;
-  nxCloudOptions: CloudTaskRunnerOptions;
-} {
-  const nxJson = JSON.parse(
-    stripJsonComments(readFileSync(`${workspaceRoot}/nx.json`).toString())
-  );
-  const result: Partial<CloudTaskRunnerOptions> = {};
-
-  const defaultCacheableOperations: string[] = [];
-  for (const key in nxJson.targetDefaults) {
-    if (nxJson.targetDefaults[key].cache) {
-      defaultCacheableOperations.push(key);
-    }
-  }
-
-  if (nxJson.nxCloudAccessToken) {
-    result.accessToken ??= nxJson.nxCloudAccessToken;
-  }
-  if (nxJson.nxCloudUrl) {
-    result.url ??= nxJson.nxCloudUrl;
-  }
-  if (nxJson.nxCloudEncryptionKey) {
-    result.encryptionKey = nxJson.nxCloudEncryptionKey;
-  }
-  if (nxJson.parallel) {
-    result.parallel ??= nxJson.parallel;
-  }
-
-  if (nxJson.cacheDirectory) {
-    result.cacheDirectory ??= nxJson.cacheDirectory;
-  }
-
-  if (defaultCacheableOperations.length) {
-    result.cacheableOperations ??= defaultCacheableOperations;
-  }
-
-  return {
-    nxJson,
-    nxCloudOptions: {
-      ...result,
-      // TODO: The default is not always cloud? But it's not handled at the moment
-      ...(nxJson.tasksRunnerOptions?.default
-        ?.options as CloudTaskRunnerOptions),
-    },
-  };
+  // TODO: The default is not always cloud? But it's not handled at the moment
+  return getRunnerOptions('default', nxJson, {}, true);
 }

--- a/packages/nx/src/nx-cloud/utilities/get-cloud-options.ts
+++ b/packages/nx/src/nx-cloud/utilities/get-cloud-options.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'fs';
+
+import * as stripJsonComments from 'strip-json-comments';
+import { CloudTaskRunnerOptions } from '../core/models/cloud-task-runner-options';
+
+const { workspaceRoot } = require('./nx-imports-light');
+
+export function getCloudOptions(): {
+  nxJson: any;
+  nxCloudOptions: CloudTaskRunnerOptions;
+} {
+  const nxJson = JSON.parse(
+    stripJsonComments(readFileSync(`${workspaceRoot}/nx.json`).toString())
+  );
+  const result: Partial<CloudTaskRunnerOptions> = {};
+
+  const defaultCacheableOperations: string[] = [];
+  for (const key in nxJson.targetDefaults) {
+    if (nxJson.targetDefaults[key].cache) {
+      defaultCacheableOperations.push(key);
+    }
+  }
+
+  if (nxJson.nxCloudAccessToken) {
+    result.accessToken ??= nxJson.nxCloudAccessToken;
+  }
+  if (nxJson.nxCloudUrl) {
+    result.url ??= nxJson.nxCloudUrl;
+  }
+  if (nxJson.nxCloudEncryptionKey) {
+    result.encryptionKey = nxJson.nxCloudEncryptionKey;
+  }
+  if (nxJson.parallel) {
+    result.parallel ??= nxJson.parallel;
+  }
+
+  if (nxJson.cacheDirectory) {
+    result.cacheDirectory ??= nxJson.cacheDirectory;
+  }
+
+  if (defaultCacheableOperations.length) {
+    result.cacheableOperations ??= defaultCacheableOperations;
+  }
+
+  return {
+    nxJson,
+    nxCloudOptions: {
+      ...result,
+      // TODO: The default is not always cloud? But it's not handled at the moment
+      ...(nxJson.tasksRunnerOptions?.default
+        ?.options as CloudTaskRunnerOptions),
+    },
+  };
+}

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -419,6 +419,27 @@ function shouldUseDynamicLifeCycle(
   return !tasks.find((t) => shouldStreamOutput(t, null));
 }
 
+function loadTasksRunner(modulePath: string) {
+  try {
+    const maybeTasksRunner = require(modulePath) as
+      | TasksRunner
+      | { default: TasksRunner };
+    // to support both babel and ts formats
+    return 'default' in maybeTasksRunner
+      ? maybeTasksRunner.default
+      : maybeTasksRunner;
+  } catch (e) {
+    if (
+      e.code === 'MODULE_NOT_FOUND' &&
+      (modulePath === 'nx-cloud' || modulePath === '@nrwl/nx-cloud')
+    ) {
+      return require('../nx-cloud/nx-cloud-tasks-runner-shell')
+        .nxCloudTasksRunnerShell;
+    }
+    throw e;
+  }
+}
+
 export function getRunner(
   nxArgs: NxArgs,
   nxJson: NxJsonConfiguration
@@ -435,21 +456,21 @@ export function getRunner(
 
   const modulePath: string = getTasksRunnerPath(runner, nxJson);
 
-  let tasksRunner = require(modulePath);
-  // to support both babel and ts formats
-  if (tasksRunner.default) {
-    tasksRunner = tasksRunner.default;
-  }
+  try {
+    const tasksRunner = loadTasksRunner(modulePath);
 
-  return {
-    tasksRunner,
-    runnerOptions: getRunnerOptions(
-      runner,
-      nxJson,
-      nxArgs,
-      modulePath === 'nx-cloud'
-    ),
-  };
+    return {
+      tasksRunner,
+      runnerOptions: getRunnerOptions(
+        runner,
+        nxJson,
+        nxArgs,
+        modulePath === 'nx-cloud'
+      ),
+    };
+  } catch {
+    throw new Error(`Could not find runner configuration for ${runner}`);
+  }
 }
 function getTasksRunnerPath(
   runner: string,
@@ -473,7 +494,7 @@ function getTasksRunnerPath(
   return isCloudRunner ? 'nx-cloud' : require.resolve('./default-tasks-runner');
 }
 
-function getRunnerOptions(
+export function getRunnerOptions(
   runner: string,
   nxJson: NxJsonConfiguration<string[] | '*'>,
   nxArgs: NxArgs,

--- a/packages/workspace/src/generators/new/new.ts
+++ b/packages/workspace/src/generators/new/new.ts
@@ -1,5 +1,4 @@
 import {
-  addDependenciesToPackageJson,
   getPackageManagerCommand,
   installPackagesTask,
   joinPathFragments,
@@ -21,7 +20,6 @@ interface Schema {
   appName?: string;
   skipInstall?: boolean;
   style?: string;
-  nxCloud?: boolean;
   preset: string;
   defaultBase: string;
   framework?: string;
@@ -49,8 +47,6 @@ export async function newGenerator(tree: Tree, opts: Schema) {
 
   addPresetDependencies(tree, options);
 
-  addCloudDependencies(tree, options);
-
   return async () => {
     const pmc = getPackageManagerCommand(options.packageManager);
     if (pmc.preInstall) {
@@ -77,9 +73,6 @@ function validateOptions(options: Schema, host: Tree) {
     options.preset !== Preset.NPM
   ) {
     throw new Error(`Cannot select a preset when skipInstall is set to true.`);
-  }
-  if (options.skipInstall && options.nxCloud) {
-    throw new Error(`Cannot select nxCloud when skipInstall is set to true.`);
   }
 
   if (
@@ -143,15 +136,4 @@ function normalizeOptions(options: Schema): NormalizedSchema {
   );
 
   return normalized as NormalizedSchema;
-}
-
-function addCloudDependencies(host: Tree, options: Schema) {
-  if (options.nxCloud) {
-    return addDependenciesToPackageJson(
-      host,
-      {},
-      { 'nx-cloud': 'latest' },
-      join(options.directory, 'package.json')
-    );
-  }
 }

--- a/packages/workspace/src/generators/new/schema.json
+++ b/packages/workspace/src/generators/new/schema.json
@@ -47,11 +47,6 @@
       "type": "string",
       "description": "Application name."
     },
-    "nxCloud": {
-      "description": "Connect the workspace to the free tier of the distributed cache provided by Nx Cloud.",
-      "type": "boolean",
-      "default": false
-    },
     "linter": {
       "description": "The tool to use for running lint checks.",
       "type": "string",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `nx-cloud` package needs to be installed to use Nx Cloud

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Nx Cloud can be used without installing a separate `nx-cloud` package.

Users still have to opt into Nx Cloud but doing so will not involve installing a separate `nx-cloud` package.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
