### PR TITLE
feat(react): Add support for promise based remotes

### DIFF
--- a/packages/webpack/src/utils/module-federation/remotes.ts
+++ b/packages/webpack/src/utils/module-federation/remotes.ts
@@ -58,7 +58,13 @@ function handleArrayRemote(
     ? `${remoteName.replace(/-/g, '_')}@`
     : '';
 
-  return `${globalPrefix}${baseRemote}/remoteEntry.${remoteEntryExt}`;
+  // if the remote is defined with anything other than http then we assume it's a promise based remote
+  // In that case we should use what the user provides as the remote location
+  if (remoteLocation.startsWith('http')) {
+    return `${globalPrefix}${baseRemote}/remoteEntry.${remoteEntryExt}`;
+  } else {
+    return remoteLocation;
+  }
 }
 
 // Helper function to deal with remotes that are strings


### PR DESCRIPTION
## Description

This pr contains support for promise based remotes.

What this means is that now you can define your remote from your host using a promise.
Example:
```js
// webpack.config.prod.js
// ignored above for brevity
{
  library: { type: 'var', name: 'acme' }, // This is necessary
  remotes: [['acme-remote',`promise new Promise(resolve => {})`]]
}
```

With this change the remote will be evaluated at runtime