### PR TITLE
chore(core): publish docs when nx release runs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -229,16 +229,16 @@ jobs:
       - name: List artifacts
         run: ls -R artifacts
         shell: bash
-      - name: Trigger Docs Release
-        run: |
-          git rebase $GITHUB_REF_NAME latest
-          git push
-          git checkout -
       - name: Publish
         run: |
           git checkout -b publish/$GITHUB_REF_NAME
           npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
           pnpm nx-release --local=false $GITHUB_REF_NAME
+      - name: Trigger Docs Release
+        if: "!github.event.release.prerelease"
+        run: |
+          git branch -f latest
+          git push -f origin latest
     env:
       GH_TOKEN: ${{ github.token }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -237,6 +237,7 @@ jobs:
       - name: Trigger Docs Release
         if: "!github.event.release.prerelease"
         run: |
+          # We force recreate the branch in order to always be up to date and avoid merge conflicts within the automated workflow
           git branch -f latest
           git push -f origin latest
     env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -235,7 +235,7 @@ jobs:
           npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
           pnpm nx-release --local=false $GITHUB_REF_NAME
       - name: Trigger Docs Release
-        if: "!github.event.release.prerelease"
+        if: ${{ !github.event.release.prerelease }}
         run: |
           # We force recreate the branch in order to always be up to date and avoid merge conflicts within the automated workflow
           git branch -f latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -229,6 +229,11 @@ jobs:
       - name: List artifacts
         run: ls -R artifacts
         shell: bash
+      - name: Trigger Docs Release
+        run: |
+          git rebase $GITHUB_REF_NAME latest
+          git push
+          git checkout -
       - name: Publish
         run: |
           git checkout -b publish/$GITHUB_REF_NAME

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -238,8 +238,8 @@ jobs:
         if: ${{ !github.event.release.prerelease }}
         run: |
           # We force recreate the branch in order to always be up to date and avoid merge conflicts within the automated workflow
-          git branch -f latest
-          git push -f origin latest
+          git branch -f website
+          git push -f origin website
     env:
       GH_TOKEN: ${{ github.token }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/scripts/nx-release.ts
+++ b/scripts/nx-release.ts
@@ -158,18 +158,6 @@ const LARGE_BUFFER = 1024 * 1000000;
       stdio: [0, 1, 2],
       maxBuffer: LARGE_BUFFER,
     });
-    // execSync(`git rebase master latest`, {
-    //   stdio: [0, 1, 2],
-    //   maxBuffer: LARGE_BUFFER,
-    // });
-    // execSync(`git push`, {
-    //   stdio: [0, 1, 2],
-    //   maxBuffer: LARGE_BUFFER,
-    // });
-    // execSync(`git checkout -`, {
-    //   stdio: [0, 1, 2],
-    //   maxBuffer: LARGE_BUFFER,
-    // });
   }
 
   process.exit(0);

--- a/scripts/nx-release.ts
+++ b/scripts/nx-release.ts
@@ -158,6 +158,18 @@ const LARGE_BUFFER = 1024 * 1000000;
       stdio: [0, 1, 2],
       maxBuffer: LARGE_BUFFER,
     });
+    // execSync(`git rebase master latest`, {
+    //   stdio: [0, 1, 2],
+    //   maxBuffer: LARGE_BUFFER,
+    // });
+    // execSync(`git push`, {
+    //   stdio: [0, 1, 2],
+    //   maxBuffer: LARGE_BUFFER,
+    // });
+    // execSync(`git checkout -`, {
+    //   stdio: [0, 1, 2],
+    //   maxBuffer: LARGE_BUFFER,
+    // });
   }
 
   process.exit(0);


### PR DESCRIPTION
Force pushes `master` onto `website` when a new nx release is created.

Currently, any change to the `website` branch triggers a new deploy to https://next.nx.dev
Once we're happy with the way this works, I'll switch the Vercel set up to have `master` deploy to `next.nx.dev` and `website` deploy to the main `nx.dev`.