### PR TITLE
Add functions to copy pnpm and packageManager sections

### DIFF
--- a/packages/nx/src/plugins/js/package-json/create-package-json.spec.ts
+++ b/packages/nx/src/plugins/js/package-json/create-package-json.spec.ts
@@ -3,7 +3,11 @@ import * as fs from 'fs';
 import * as configModule from '../../../config/configuration';
 import { DependencyType, ProjectGraph } from '../../../config/project-graph';
 import * as hashModule from '../../../hasher/task-hasher';
-import { copyPackageManagerSection, copyPnpmSection, createPackageJson } from './create-package-json';
+import {
+  copyPackageManagerSection,
+  copyPnpmSection,
+  createPackageJson,
+} from './create-package-json';
 import * as fileutilsModule from '../../../utils/fileutils';
 import { PackageJson } from '../../../utils/package-json';
 
@@ -12,12 +16,11 @@ jest.mock('../../../utils/workspace-root', () => ({
 }));
 
 describe('createPackageJson', () => {
-  it('should create a package.json', () => { });
+  it('should create a package.json', () => {});
 });
 
 describe('copyPnpmSection', () => {
   it('should copy pnpm section if it exists', () => {
-
     const rootPackageJson: PackageJson = {
       name: 'root',
       version: '0.0.0',
@@ -26,8 +29,8 @@ describe('copyPnpmSection', () => {
           readPackage: 'echo "readPackage"',
         },
         patchedDependencies: {
-          '@nrwl/workspace@1.2.3': 'patches/@nrwl__workspace@1.2.3.patch'
-        }
+          '@nrwl/workspace@1.2.3': 'patches/@nrwl__workspace@1.2.3.patch',
+        },
       },
     };
 
@@ -46,7 +49,7 @@ describe('copyPnpmSection', () => {
   it('should not create pnpm section if root does not have it', () => {
     const rootPackageJsonWithoutPnpm: PackageJson = {
       name: 'root',
-      version: '0.0.0'
+      version: '0.0.0',
     };
 
     let packageJson = rootPackageJsonWithoutPnpm;
@@ -59,7 +62,6 @@ describe('copyPnpmSection', () => {
 
 describe('copyPackageManagerSection', () => {
   it('should copy packageManager section if it is exists and is valid', () => {
-
     const rootPackageJson: PackageJson = {
       name: 'root',
       version: '0.0.0',
@@ -77,7 +79,6 @@ describe('copyPackageManagerSection', () => {
   });
 
   it('should not copy packageManager section if it is exists but is invalid', () => {
-
     const rootPackageJson: PackageJson = {
       name: 'root',
       version: '0.0.0',
@@ -94,7 +95,6 @@ describe('copyPackageManagerSection', () => {
   });
 
   it('should not create packageManager section if it does not exist', () => {
-
     const rootPackageJson: PackageJson = {
       name: 'root',
       version: '0.0.0',

--- a/packages/nx/src/plugins/js/package-json/create-package-json.spec.ts
+++ b/packages/nx/src/plugins/js/package-json/create-package-json.spec.ts
@@ -3,15 +3,111 @@ import * as fs from 'fs';
 import * as configModule from '../../../config/configuration';
 import { DependencyType, ProjectGraph } from '../../../config/project-graph';
 import * as hashModule from '../../../hasher/task-hasher';
-import { createPackageJson } from './create-package-json';
+import { copyPackageManagerSection, copyPnpmSection, createPackageJson } from './create-package-json';
 import * as fileutilsModule from '../../../utils/fileutils';
+import { PackageJson } from '../../../utils/package-json';
 
 jest.mock('../../../utils/workspace-root', () => ({
   workspaceRoot: '/root',
 }));
 
 describe('createPackageJson', () => {
-  it('should create a package.json', () => {});
+  it('should create a package.json', () => { });
+});
+
+describe('copyPnpmSection', () => {
+  it('should copy pnpm section if it exists', () => {
+
+    const rootPackageJson: PackageJson = {
+      name: 'root',
+      version: '0.0.0',
+      pnpm: {
+        hooks: {
+          readPackage: 'echo "readPackage"',
+        },
+        patchedDependencies: {
+          '@nrwl/workspace@1.2.3': 'patches/@nrwl__workspace@1.2.3.patch'
+        }
+      },
+    };
+
+    let packageJson: PackageJson = {
+      name: 'root',
+      version: '0.0.0',
+    };
+
+    copyPnpmSection(rootPackageJson, packageJson);
+    expect(packageJson).toHaveProperty('pnpm');
+    expect(packageJson.pnpm).toHaveProperty('hooks');
+    expect(packageJson.pnpm.hooks).toHaveProperty('readPackage');
+    expect(packageJson.pnpm).toHaveProperty('patchedDependencies');
+  });
+
+  it('should not create pnpm section if root does not have it', () => {
+    const rootPackageJsonWithoutPnpm: PackageJson = {
+      name: 'root',
+      version: '0.0.0'
+    };
+
+    let packageJson = rootPackageJsonWithoutPnpm;
+
+    copyPnpmSection(rootPackageJsonWithoutPnpm, packageJson);
+
+    expect(packageJson).not.toHaveProperty('pnpm');
+  });
+});
+
+describe('copyPackageManagerSection', () => {
+  it('should copy packageManager section if it is exists and is valid', () => {
+
+    const rootPackageJson: PackageJson = {
+      name: 'root',
+      version: '0.0.0',
+      packageManager: 'pnpm@8.9.0',
+    };
+
+    let packageJson: PackageJson = {
+      name: 'root',
+      version: '0.0.0',
+    };
+
+    copyPackageManagerSection(rootPackageJson, packageJson);
+    expect(packageJson).toHaveProperty('packageManager');
+    expect(packageJson.packageManager).toEqual('pnpm@8.9.0');
+  });
+
+  it('should not copy packageManager section if it is exists but is invalid', () => {
+
+    const rootPackageJson: PackageJson = {
+      name: 'root',
+      version: '0.0.0',
+      packageManager: 'pnpm',
+    };
+
+    let packageJson: PackageJson = {
+      name: 'root',
+      version: '0.0.0',
+    };
+
+    copyPackageManagerSection(rootPackageJson, packageJson);
+    expect(packageJson).not.toHaveProperty('packageManager');
+  });
+
+  it('should not create packageManager section if it does not exist', () => {
+
+    const rootPackageJson: PackageJson = {
+      name: 'root',
+      version: '0.0.0',
+    };
+
+    let packageJson: PackageJson = {
+      name: 'root',
+      version: '0.0.0',
+    };
+
+    copyPackageManagerSection(rootPackageJson, packageJson);
+    expect(packageJson).not.toHaveProperty('packageManager');
+  });
 });
 
 // describe('createPackageJson', () => {

--- a/packages/nx/src/plugins/js/package-json/create-package-json.ts
+++ b/packages/nx/src/plugins/js/package-json/create-package-json.ts
@@ -20,7 +20,7 @@ import { join } from 'path';
 interface NpmDeps {
   readonly dependencies: Record<string, string>;
   readonly peerDependencies: Record<string, string>;
-  readonly peerDependenciesMeta: Record<string, { optional: boolean }>;
+  readonly peerDependenciesMeta: Record<string, { optional: boolean; }>;
 }
 
 /**
@@ -85,7 +85,7 @@ export function createPackageJson(
         delete packageJson.dependencies;
         delete packageJson.devDependencies;
       }
-    } catch (e) {}
+    } catch (e) { }
   }
 
   const getVersion = (
@@ -177,7 +177,31 @@ export function createPackageJson(
     packageJson.peerDependenciesMeta
   );
 
+  copyPnpmSection(rootPackageJson, packageJson);
+  copyPackageManagerSection(rootPackageJson, packageJson);
+
   return packageJson;
+}
+
+function copyPnpmSection(
+  rootPackageJson: PackageJson,
+  packageJson: PackageJson
+) {
+  if (rootPackageJson.pnpm) {
+    packageJson.pnpm = rootPackageJson.pnpm;
+  }
+}
+
+function copyPackageManagerSection(
+  rootPackageJson: PackageJson,
+  packageJson: PackageJson
+) {
+  const packageManagerRegEx = new RegExp('(npm|pnpm|yarn)@\d+\.\d+\.\d+(-.+)?');
+
+  if (rootPackageJson.packageManager
+    && packageManagerRegEx.test(rootPackageJson.packageManager)) {
+    packageJson.packageManager = rootPackageJson.packageManager;
+  }
 }
 
 export function findProjectsNpmDependencies(
@@ -219,9 +243,9 @@ export function findProjectsNpmDependencies(
   const ignoredDependencies =
     options.isProduction && rootPackageJson.devDependencies
       ? [
-          ...(options.ignoredDependencies || []),
-          ...Object.keys(rootPackageJson.devDependencies),
-        ]
+        ...(options.ignoredDependencies || []),
+        ...Object.keys(rootPackageJson.devDependencies),
+      ]
       : options.ignoredDependencies || [];
 
   findAllNpmDeps(

--- a/packages/nx/src/plugins/js/package-json/create-package-json.ts
+++ b/packages/nx/src/plugins/js/package-json/create-package-json.ts
@@ -20,7 +20,7 @@ import { join } from 'path';
 interface NpmDeps {
   readonly dependencies: Record<string, string>;
   readonly peerDependencies: Record<string, string>;
-  readonly peerDependenciesMeta: Record<string, { optional: boolean; }>;
+  readonly peerDependenciesMeta: Record<string, { optional: boolean }>;
 }
 
 /**
@@ -85,7 +85,7 @@ export function createPackageJson(
         delete packageJson.dependencies;
         delete packageJson.devDependencies;
       }
-    } catch (e) { }
+    } catch (e) {}
   }
 
   const getVersion = (
@@ -222,9 +222,9 @@ export function findProjectsNpmDependencies(
   const ignoredDependencies =
     options.isProduction && rootPackageJson.devDependencies
       ? [
-        ...(options.ignoredDependencies || []),
-        ...Object.keys(rootPackageJson.devDependencies),
-      ]
+          ...(options.ignoredDependencies || []),
+          ...Object.keys(rootPackageJson.devDependencies),
+        ]
       : options.ignoredDependencies || [];
 
   findAllNpmDeps(
@@ -368,7 +368,10 @@ export function copyPackageManagerSection(
   const isValid = packageManagerRegEx.test(rootPackageJson?.packageManager);
 
   if (rootPackageJson?.packageManager && !isValid) {
-    console.warn('Invalid package manager setting', rootPackageJson.packageManager);
+    console.warn(
+      'Invalid package manager setting',
+      rootPackageJson.packageManager
+    );
   }
   if (rootPackageJson.packageManager && isValid) {
     packageJson.packageManager = rootPackageJson.packageManager;

--- a/packages/nx/src/plugins/js/package-json/create-package-json.ts
+++ b/packages/nx/src/plugins/js/package-json/create-package-json.ts
@@ -183,27 +183,6 @@ export function createPackageJson(
   return packageJson;
 }
 
-function copyPnpmSection(
-  rootPackageJson: PackageJson,
-  packageJson: PackageJson
-) {
-  if (rootPackageJson.pnpm) {
-    packageJson.pnpm = rootPackageJson.pnpm;
-  }
-}
-
-function copyPackageManagerSection(
-  rootPackageJson: PackageJson,
-  packageJson: PackageJson
-) {
-  const packageManagerRegEx = new RegExp('(npm|pnpm|yarn)@\d+\.\d+\.\d+(-.+)?');
-
-  if (rootPackageJson.packageManager
-    && packageManagerRegEx.test(rootPackageJson.packageManager)) {
-    packageJson.packageManager = rootPackageJson.packageManager;
-  }
-}
-
 export function findProjectsNpmDependencies(
   projectNode: ProjectGraphProjectNode,
   graph: ProjectGraph,
@@ -369,5 +348,29 @@ function recursivelyCollectPeerDependencies(
     return npmDeps;
   } catch (e) {
     return npmDeps;
+  }
+}
+
+export function copyPnpmSection(
+  rootPackageJson: PackageJson,
+  packageJson: PackageJson
+) {
+  if (rootPackageJson.pnpm) {
+    packageJson.pnpm = rootPackageJson.pnpm;
+  }
+}
+
+export function copyPackageManagerSection(
+  rootPackageJson: PackageJson,
+  packageJson: PackageJson
+) {
+  console.log('rootPackageJson', rootPackageJson);
+  const packageManagerRegEx = /(npm|pnpm|yarn)@\d+\.\d+\.\d+(-.+)?/;
+  const isValid = packageManagerRegEx.test(rootPackageJson?.packageManager);
+  if (rootPackageJson?.packageManager && !isValid) {
+    console.warn('Invalid package manager setting', rootPackageJson.packageManager);
+  }
+  if (rootPackageJson.packageManager && isValid) {
+    packageJson.packageManager = rootPackageJson.packageManager;
   }
 }

--- a/packages/nx/src/plugins/js/package-json/create-package-json.ts
+++ b/packages/nx/src/plugins/js/package-json/create-package-json.ts
@@ -364,9 +364,9 @@ export function copyPackageManagerSection(
   rootPackageJson: PackageJson,
   packageJson: PackageJson
 ) {
-  console.log('rootPackageJson', rootPackageJson);
   const packageManagerRegEx = /(npm|pnpm|yarn)@\d+\.\d+\.\d+(-.+)?/;
   const isValid = packageManagerRegEx.test(rootPackageJson?.packageManager);
+
   if (rootPackageJson?.packageManager && !isValid) {
     console.warn('Invalid package manager setting', rootPackageJson.packageManager);
   }

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -15,14 +15,14 @@ export type PackageJsonTargetConfiguration = Omit<
 export interface NxProjectPackageJsonConfiguration {
   implicitDependencies?: string[];
   tags?: string[];
-  namedInputs?: { [inputName: string]: (string | InputDefinition)[] };
+  namedInputs?: { [inputName: string]: (string | InputDefinition)[]; };
   targets?: Record<string, PackageJsonTargetConfiguration>;
   includedScripts?: string[];
 }
 
-export type ArrayPackageGroup = { package: string; version: string }[];
+export type ArrayPackageGroup = { package: string; version: string; }[];
 export type MixedPackageGroup =
-  | (string | { package: string; version: string })[]
+  | (string | { package: string; version: string; })[]
   | Record<string, string>;
 export type PackageGroup = MixedPackageGroup | ArrayPackageGroup;
 
@@ -31,7 +31,7 @@ export interface NxMigrationsConfiguration {
   packageGroup?: PackageGroup;
 }
 
-type PackageOverride = { [key: string]: string | PackageOverride };
+type PackageOverride = { [key: string]: string | PackageOverride; };
 
 export interface PackageJson {
   // Generic Package.Json Configuration
@@ -45,24 +45,24 @@ export interface PackageJson {
   types?: string;
   module?: string;
   exports?:
-    | string
-    | Record<
-        string,
-        string | { types?: string; require?: string; import?: string }
-      >;
+  | string
+  | Record<
+    string,
+    string | { types?: string; require?: string; import?: string; }
+  >;
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
   optionalDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
-  peerDependenciesMeta?: Record<string, { optional: boolean }>;
+  peerDependenciesMeta?: Record<string, { optional: boolean; }>;
   resolutions?: Record<string, string>;
   overrides?: PackageOverride;
   bin?: Record<string, string> | string;
   workspaces?:
-    | string[]
-    | {
-        packages: string[];
-      };
+  | string[]
+  | {
+    packages: string[];
+  };
 
   // Nx Project Configuration
   nx?: NxProjectPackageJsonConfiguration;
@@ -74,6 +74,8 @@ export interface PackageJson {
   executors?: string;
   'nx-migrations'?: string | NxMigrationsConfiguration;
   'ng-update'?: string | NxMigrationsConfiguration;
+  pnpm?: Record<string, unknown>;
+  packageManager?: string;
 }
 
 export function normalizePackageGroup(
@@ -81,20 +83,20 @@ export function normalizePackageGroup(
 ): ArrayPackageGroup {
   return Array.isArray(packageGroup)
     ? packageGroup.map((x) =>
-        typeof x === 'string' ? { package: x, version: '*' } : x
-      )
+      typeof x === 'string' ? { package: x, version: '*' } : x
+    )
     : Object.entries(packageGroup).map(([pkg, version]) => ({
-        package: pkg,
-        version,
-      }));
+      package: pkg,
+      version,
+    }));
 }
 
 export function readNxMigrateConfig(
   json: Partial<PackageJson>
-): NxMigrationsConfiguration & { packageGroup?: ArrayPackageGroup } {
+): NxMigrationsConfiguration & { packageGroup?: ArrayPackageGroup; } {
   const parseNxMigrationsConfig = (
     fromJson?: string | NxMigrationsConfiguration
-  ): NxMigrationsConfiguration & { packageGroup?: ArrayPackageGroup } => {
+  ): NxMigrationsConfiguration & { packageGroup?: ArrayPackageGroup; } => {
     if (!fromJson) {
       return {};
     }

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -15,14 +15,14 @@ export type PackageJsonTargetConfiguration = Omit<
 export interface NxProjectPackageJsonConfiguration {
   implicitDependencies?: string[];
   tags?: string[];
-  namedInputs?: { [inputName: string]: (string | InputDefinition)[]; };
+  namedInputs?: { [inputName: string]: (string | InputDefinition)[] };
   targets?: Record<string, PackageJsonTargetConfiguration>;
   includedScripts?: string[];
 }
 
-export type ArrayPackageGroup = { package: string; version: string; }[];
+export type ArrayPackageGroup = { package: string; version: string }[];
 export type MixedPackageGroup =
-  | (string | { package: string; version: string; })[]
+  | (string | { package: string; version: string })[]
   | Record<string, string>;
 export type PackageGroup = MixedPackageGroup | ArrayPackageGroup;
 
@@ -31,7 +31,7 @@ export interface NxMigrationsConfiguration {
   packageGroup?: PackageGroup;
 }
 
-type PackageOverride = { [key: string]: string | PackageOverride; };
+type PackageOverride = { [key: string]: string | PackageOverride };
 
 export interface PackageJson {
   // Generic Package.Json Configuration
@@ -45,24 +45,24 @@ export interface PackageJson {
   types?: string;
   module?: string;
   exports?:
-  | string
-  | Record<
-    string,
-    string | { types?: string; require?: string; import?: string; }
-  >;
+    | string
+    | Record<
+        string,
+        string | { types?: string; require?: string; import?: string }
+      >;
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
   optionalDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
-  peerDependenciesMeta?: Record<string, { optional: boolean; }>;
+  peerDependenciesMeta?: Record<string, { optional: boolean }>;
   resolutions?: Record<string, string>;
   overrides?: PackageOverride;
   bin?: Record<string, string> | string;
   workspaces?:
-  | string[]
-  | {
-    packages: string[];
-  };
+    | string[]
+    | {
+        packages: string[];
+      };
 
   // Nx Project Configuration
   nx?: NxProjectPackageJsonConfiguration;
@@ -83,20 +83,20 @@ export function normalizePackageGroup(
 ): ArrayPackageGroup {
   return Array.isArray(packageGroup)
     ? packageGroup.map((x) =>
-      typeof x === 'string' ? { package: x, version: '*' } : x
-    )
+        typeof x === 'string' ? { package: x, version: '*' } : x
+      )
     : Object.entries(packageGroup).map(([pkg, version]) => ({
-      package: pkg,
-      version,
-    }));
+        package: pkg,
+        version,
+      }));
 }
 
 export function readNxMigrateConfig(
   json: Partial<PackageJson>
-): NxMigrationsConfiguration & { packageGroup?: ArrayPackageGroup; } {
+): NxMigrationsConfiguration & { packageGroup?: ArrayPackageGroup } {
   const parseNxMigrationsConfig = (
     fromJson?: string | NxMigrationsConfiguration
-  ): NxMigrationsConfiguration & { packageGroup?: ArrayPackageGroup; } => {
+  ): NxMigrationsConfiguration & { packageGroup?: ArrayPackageGroup } => {
     if (!fromJson) {
       return {};
     }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`pnpm` and `packageManager` sections in package.json aren't copied when a new package.json is created, meaning pnpm patchedDependencies are ignored.

## Expected Behavior
`pnpm` and `packageManager` sections should be carried over to any newly generated package.json files so as to easily support `patchedDependencies`.

## Related Issue(s)
https://github.com/nrwl/nx/issues/18402

Fixes #18402 
