### PR TITLE
fix(core): avoid accessing index out of bounds

### DIFF
--- a/packages/nx/src/native/utils/glob.rs
+++ b/packages/nx/src/native/utils/glob.rs
@@ -108,7 +108,7 @@ fn convert_glob(glob: &str) -> anyhow::Result<Vec<String>> {
                 let capture = caps.get(0);
                 match capture {
                     Some(capture) => {
-                        let char = glob.as_bytes()[capture.end()] as char;
+                        let char = glob.as_bytes()[capture.end() - 1] as char;
                         if char == '*' {
                             "".to_string()
                         } else {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Started from v16.9, we can't build our apps due to the following error: 

```
thread '<unnamed>' panicked at 'index out of bounds: the len is 43 but the index is 43', packages/nx/src/native/utils/glob.rs:111:36
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
fatal runtime error: failed to initiate panic, error 5
```

I believe it's related to this PR: https://github.com/nrwl/nx/pull/18242

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

No error.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
