### PR TITLE
fix(webpack): only register TS transpiler for config files ending with .ts, .mts, or .cts

### DIFF
--- a/packages/webpack/src/utils/webpack/custom-webpack.ts
+++ b/packages/webpack/src/utils/webpack/custom-webpack.ts
@@ -1,6 +1,12 @@
 import { registerTsProject } from '@nx/js/src/internal';
 
 export function resolveCustomWebpackConfig(path: string, tsConfig: string) {
+  // Don't transpile non-TS files. This prevents workspaces libs from being registered via tsconfig-paths.
+  // There's an issue here with Nx workspace where loading plugins from source (via tsconfig-paths) can lead to errors.
+  if (!/\.(ts|mts|cts)$/.test(path)) {
+    return require(path);
+  }
+
   const cleanupTranspiler = registerTsProject(tsConfig);
   const maybeCustomWebpackConfig = require(path);
   cleanupTranspiler();


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Using webpack build in Nx repo itself throws errors because we are loading `nx` and `@nx/*` plugins from source.

## Expected Behavior
Webpack builds should work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
