### PR TITLE
feat(vue): set @nx/vue as public

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -410,11 +410,10 @@ async function determineStack(
           name: `react`,
           message: `React:         Configures a React application with your framework of choice.`,
         },
-        // TODO(v17): Enable when @nx/vue is released.
-        // {
-        //   name: `vue`,
-        //   message: `Vue:           Configures a Vue application with modern tooling.`,
-        // },
+        {
+          name: `vue`,
+          message: `Vue:           Configures a Vue application with modern tooling.`,
+        },
         {
           name: `angular`,
           message: `Angular:       Configures a Angular application with modern tooling.`,

--- a/packages/vue/docs/application-examples.md
+++ b/packages/vue/docs/application-examples.md
@@ -1,0 +1,47 @@
+## Examples
+
+{% tabs %}
+{% tab label="Simple Application" %}
+
+Create an application named `my-app`:
+
+```shell
+nx g @nx/vue:application my-app
+```
+
+{% /tab %}
+
+{% tab label="Application using Vite as bundler" %}
+
+Create an application named `my-app`:
+
+```shell
+nx g @nx/vue:app my-app
+```
+
+{% /tab %}
+
+{% tab label="Specify directory and style extension" %}
+
+Create an application named `my-app` in the `my-dir` directory and use `scss` for styles:
+
+{% callout type="note" title="Directory Flag Behavior Changes" %}
+The command below uses the `as-provided` directory flag behavior, which is the default in Nx 16.8.0. If you're on an earlier version of Nx or using the `derived` option, use `--directory=my-dir`. See the [workspace layout documentation](/reference/nx-json#workspace-layout) for more details.
+{% /callout %}
+
+```shell
+nx g @nx/vue:app my-app --directory=apps/my-dir/my-app --style=scss
+```
+
+{% /tab %}
+
+{% tab label="Add tags" %}
+
+Add tags to the application (used for linting).
+
+```shell
+nx g @nx/vue:app my-app --tags=scope:admin,type:ui
+```
+
+{% /tab %}
+{% /tabs %}

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nx/vue",
   "version": "0.0.1",
-  "private": true,
+  "private": false,
   "description": "The Vue plugin for Nx contains executors and generators for managing Vue applications and libraries within an Nx workspace. It provides:\n\n\n- Integration with libraries such as Jest, Cypress, and Storybook.\n\n- Generators for applications, libraries, and more.\n\n- Library build support for publishing packages to npm or other registries.\n\n- Utilities for automatic workspace refactoring.",
   "repository": {
     "type": "git",

--- a/scripts/documentation/package-schemas/package-metadata.ts
+++ b/scripts/documentation/package-schemas/package-metadata.ts
@@ -120,6 +120,10 @@ export function findPackageMetadataList(
   return sync(`${packagesDir}/*`, { ignore: [`${packagesDir}/cli`] })
     .map((folderPath: string): PackageData => {
       const folderName = folderPath.substring(packagesDir.length + 1);
+
+      // TODO(v17): Remove this once @nx/vue is published
+      if (folderName === 'vue') return null;
+
       const relativeFolderPath = folderPath.replace(absoluteRoot, '');
       const packageJson = readJsonSync(
         join(folderPath, 'package.json'),


### PR DESCRIPTION
This PR sets `@nx/vue` to public. It will be in the v17 release.

**Changes:**
- Set `private: false` in `packages/vue/package.json`
- Exclude vue docs from being generated


