### PR TITLE
feat(core): add standard way to pass plugin options

### DIFF
--- a/docs/generated/devkit/CreateDependencies.md
+++ b/docs/generated/devkit/CreateDependencies.md
@@ -1,19 +1,26 @@
-# Type alias: CreateDependencies
+# Type alias: CreateDependencies<T\>
 
-Ƭ **CreateDependencies**: (`context`: [`CreateDependenciesContext`](../../devkit/documents/CreateDependenciesContext)) => [`RawProjectGraphDependency`](../../devkit/documents/RawProjectGraphDependency)[] \| `Promise`<[`RawProjectGraphDependency`](../../devkit/documents/RawProjectGraphDependency)[]\>
+Ƭ **CreateDependencies**<`T`\>: (`context`: [`CreateDependenciesContext`](../../devkit/documents/CreateDependenciesContext), `pluginConfig`: `T`) => [`RawProjectGraphDependency`](../../devkit/documents/RawProjectGraphDependency)[] \| `Promise`<[`RawProjectGraphDependency`](../../devkit/documents/RawProjectGraphDependency)[]\>
+
+#### Type parameters
+
+| Name | Type                                                                    |
+| :--- | :---------------------------------------------------------------------- |
+| `T`  | extends `Record`<`string`, `unknown`\> = `Record`<`string`, `unknown`\> |
 
 #### Type declaration
 
-▸ (`context`): [`RawProjectGraphDependency`](../../devkit/documents/RawProjectGraphDependency)[] \| `Promise`<[`RawProjectGraphDependency`](../../devkit/documents/RawProjectGraphDependency)[]\>
+▸ (`context`, `pluginConfig`): [`RawProjectGraphDependency`](../../devkit/documents/RawProjectGraphDependency)[] \| `Promise`<[`RawProjectGraphDependency`](../../devkit/documents/RawProjectGraphDependency)[]\>
 
 A function which parses files in the workspace to create dependencies in the [ProjectGraph](../../devkit/documents/ProjectGraph)
 Use [validateDependency](../../devkit/documents/validateDependency) to validate dependencies
 
 ##### Parameters
 
-| Name      | Type                                                                            |
-| :-------- | :------------------------------------------------------------------------------ |
-| `context` | [`CreateDependenciesContext`](../../devkit/documents/CreateDependenciesContext) |
+| Name           | Type                                                                            |
+| :------------- | :------------------------------------------------------------------------------ |
+| `context`      | [`CreateDependenciesContext`](../../devkit/documents/CreateDependenciesContext) |
+| `pluginConfig` | `T`                                                                             |
 
 ##### Returns
 

--- a/docs/generated/devkit/CreateDependencies.md
+++ b/docs/generated/devkit/CreateDependencies.md
@@ -1,6 +1,6 @@
 # Type alias: CreateDependencies<T\>
 
-Ƭ **CreateDependencies**<`T`\>: (`context`: [`CreateDependenciesContext`](../../devkit/documents/CreateDependenciesContext), `pluginConfig`: `T`) => [`RawProjectGraphDependency`](../../devkit/documents/RawProjectGraphDependency)[] \| `Promise`<[`RawProjectGraphDependency`](../../devkit/documents/RawProjectGraphDependency)[]\>
+Ƭ **CreateDependencies**<`T`\>: (`options`: `T` \| `undefined`, `context`: [`CreateDependenciesContext`](../../devkit/documents/CreateDependenciesContext)) => [`RawProjectGraphDependency`](../../devkit/documents/RawProjectGraphDependency)[] \| `Promise`<[`RawProjectGraphDependency`](../../devkit/documents/RawProjectGraphDependency)[]\>
 
 #### Type parameters
 
@@ -10,17 +10,17 @@
 
 #### Type declaration
 
-▸ (`context`, `pluginConfig`): [`RawProjectGraphDependency`](../../devkit/documents/RawProjectGraphDependency)[] \| `Promise`<[`RawProjectGraphDependency`](../../devkit/documents/RawProjectGraphDependency)[]\>
+▸ (`options`, `context`): [`RawProjectGraphDependency`](../../devkit/documents/RawProjectGraphDependency)[] \| `Promise`<[`RawProjectGraphDependency`](../../devkit/documents/RawProjectGraphDependency)[]\>
 
 A function which parses files in the workspace to create dependencies in the [ProjectGraph](../../devkit/documents/ProjectGraph)
 Use [validateDependency](../../devkit/documents/validateDependency) to validate dependencies
 
 ##### Parameters
 
-| Name           | Type                                                                            |
-| :------------- | :------------------------------------------------------------------------------ |
-| `context`      | [`CreateDependenciesContext`](../../devkit/documents/CreateDependenciesContext) |
-| `pluginConfig` | `T`                                                                             |
+| Name      | Type                                                                            |
+| :-------- | :------------------------------------------------------------------------------ |
+| `options` | `T` \| `undefined`                                                              |
+| `context` | [`CreateDependenciesContext`](../../devkit/documents/CreateDependenciesContext) |
 
 ##### Returns
 

--- a/docs/generated/devkit/CreateNodes.md
+++ b/docs/generated/devkit/CreateNodes.md
@@ -1,5 +1,11 @@
-# Type alias: CreateNodes
+# Type alias: CreateNodes<T\>
 
-Ƭ **CreateNodes**: readonly [projectFilePattern: string, createNodesFunction: CreateNodesFunction]
+Ƭ **CreateNodes**<`T`\>: readonly [projectFilePattern: string, createNodesFunction: CreateNodesFunction<T\>]
 
 A pair of file patterns and [CreateNodesFunction](../../devkit/documents/CreateNodesFunction)
+
+#### Type parameters
+
+| Name | Type                                                                    |
+| :--- | :---------------------------------------------------------------------- |
+| `T`  | extends `Record`<`string`, `unknown`\> = `Record`<`string`, `unknown`\> |

--- a/docs/generated/devkit/CreateNodesFunction.md
+++ b/docs/generated/devkit/CreateNodesFunction.md
@@ -1,10 +1,16 @@
-# Type alias: CreateNodesFunction
+# Type alias: CreateNodesFunction<T\>
 
-Ƭ **CreateNodesFunction**: (`projectConfigurationFile`: `string`, `context`: [`CreateNodesContext`](../../devkit/documents/CreateNodesContext)) => { `externalNodes?`: `Record`<`string`, [`ProjectGraphExternalNode`](../../devkit/documents/ProjectGraphExternalNode)\> ; `projects?`: `Record`<`string`, [`ProjectConfiguration`](../../devkit/documents/ProjectConfiguration)\> }
+Ƭ **CreateNodesFunction**<`T`\>: (`projectConfigurationFile`: `string`, `context`: [`CreateNodesContext`](../../devkit/documents/CreateNodesContext), `pluginConfiguration`: `T`) => { `externalNodes?`: `Record`<`string`, [`ProjectGraphExternalNode`](../../devkit/documents/ProjectGraphExternalNode)\> ; `projects?`: `Record`<`string`, [`ProjectConfiguration`](../../devkit/documents/ProjectConfiguration)\> }
+
+#### Type parameters
+
+| Name | Type                                                                    |
+| :--- | :---------------------------------------------------------------------- |
+| `T`  | extends `Record`<`string`, `unknown`\> = `Record`<`string`, `unknown`\> |
 
 #### Type declaration
 
-▸ (`projectConfigurationFile`, `context`): `Object`
+▸ (`projectConfigurationFile`, `context`, `pluginConfiguration`): `Object`
 
 A function which parses a configuration file into a set of nodes.
 Used for creating nodes for the [ProjectGraph](../../devkit/documents/ProjectGraph)
@@ -15,6 +21,7 @@ Used for creating nodes for the [ProjectGraph](../../devkit/documents/ProjectGra
 | :------------------------- | :---------------------------------------------------------------- |
 | `projectConfigurationFile` | `string`                                                          |
 | `context`                  | [`CreateNodesContext`](../../devkit/documents/CreateNodesContext) |
+| `pluginConfiguration`      | `T`                                                               |
 
 ##### Returns
 

--- a/docs/generated/devkit/CreateNodesFunction.md
+++ b/docs/generated/devkit/CreateNodesFunction.md
@@ -1,6 +1,6 @@
 # Type alias: CreateNodesFunction<T\>
 
-Ƭ **CreateNodesFunction**<`T`\>: (`projectConfigurationFile`: `string`, `context`: [`CreateNodesContext`](../../devkit/documents/CreateNodesContext), `pluginConfiguration`: `T`) => { `externalNodes?`: `Record`<`string`, [`ProjectGraphExternalNode`](../../devkit/documents/ProjectGraphExternalNode)\> ; `projects?`: `Record`<`string`, [`ProjectConfiguration`](../../devkit/documents/ProjectConfiguration)\> }
+Ƭ **CreateNodesFunction**<`T`\>: (`projectConfigurationFile`: `string`, `options`: `T` \| `undefined`, `context`: [`CreateNodesContext`](../../devkit/documents/CreateNodesContext)) => { `externalNodes?`: `Record`<`string`, [`ProjectGraphExternalNode`](../../devkit/documents/ProjectGraphExternalNode)\> ; `projects?`: `Record`<`string`, [`ProjectConfiguration`](../../devkit/documents/ProjectConfiguration)\> }
 
 #### Type parameters
 
@@ -10,7 +10,7 @@
 
 #### Type declaration
 
-▸ (`projectConfigurationFile`, `context`, `pluginConfiguration`): `Object`
+▸ (`projectConfigurationFile`, `options`, `context`): `Object`
 
 A function which parses a configuration file into a set of nodes.
 Used for creating nodes for the [ProjectGraph](../../devkit/documents/ProjectGraph)
@@ -20,8 +20,8 @@ Used for creating nodes for the [ProjectGraph](../../devkit/documents/ProjectGra
 | Name                       | Type                                                              |
 | :------------------------- | :---------------------------------------------------------------- |
 | `projectConfigurationFile` | `string`                                                          |
+| `options`                  | `T` \| `undefined`                                                |
 | `context`                  | [`CreateNodesContext`](../../devkit/documents/CreateNodesContext) |
-| `pluginConfiguration`      | `T`                                                               |
 
 ##### Returns
 

--- a/docs/generated/devkit/NxJsonConfiguration.md
+++ b/docs/generated/devkit/NxJsonConfiguration.md
@@ -32,8 +32,8 @@ Nx.json configuration
 - [nxCloudEncryptionKey](../../devkit/documents/NxJsonConfiguration#nxcloudencryptionkey): string
 - [nxCloudUrl](../../devkit/documents/NxJsonConfiguration#nxcloudurl): string
 - [parallel](../../devkit/documents/NxJsonConfiguration#parallel): number
-- [plugins](../../devkit/documents/NxJsonConfiguration#plugins): string[]
-- [pluginsConfig](../../devkit/documents/NxJsonConfiguration#pluginsconfig): Record&lt;string, unknown&gt;
+- [plugins](../../devkit/documents/NxJsonConfiguration#plugins): PluginDefinition[]
+- [pluginsConfig](../../devkit/documents/NxJsonConfiguration#pluginsconfig): Record&lt;string, Record&lt;string, unknown&gt;&gt;
 - [release](../../devkit/documents/NxJsonConfiguration#release): NxReleaseConfiguration
 - [targetDefaults](../../devkit/documents/NxJsonConfiguration#targetdefaults): TargetDefaults
 - [tasksRunnerOptions](../../devkit/documents/NxJsonConfiguration#tasksrunneroptions): Object
@@ -198,7 +198,7 @@ Specifies how many tasks can be run in parallel.
 
 ### plugins
 
-• `Optional` **plugins**: `string`[]
+• `Optional` **plugins**: `PluginDefinition`[]
 
 Plugins for extending the project graph
 
@@ -206,7 +206,7 @@ Plugins for extending the project graph
 
 ### pluginsConfig
 
-• `Optional` **pluginsConfig**: `Record`<`string`, `unknown`\>
+• `Optional` **pluginsConfig**: `Record`<`string`, `Record`<`string`, `unknown`\>\>
 
 Configuration for Nx Plugins
 

--- a/docs/generated/devkit/NxPluginV2.md
+++ b/docs/generated/devkit/NxPluginV2.md
@@ -1,13 +1,19 @@
-# Type alias: NxPluginV2
+# Type alias: NxPluginV2<T\>
 
-Ƭ **NxPluginV2**: `Object`
+Ƭ **NxPluginV2**<`T`\>: `Object`
 
 A plugin for Nx which creates nodes and dependencies for the [ProjectGraph](../../devkit/documents/ProjectGraph)
 
+#### Type parameters
+
+| Name | Type                                                                    |
+| :--- | :---------------------------------------------------------------------- |
+| `T`  | extends `Record`<`string`, `unknown`\> = `Record`<`string`, `unknown`\> |
+
 #### Type declaration
 
-| Name                  | Type                                                              | Description                                                                                                                                   |
-| :-------------------- | :---------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------- |
-| `createDependencies?` | [`CreateDependencies`](../../devkit/documents/CreateDependencies) | Provides a function to analyze files to create dependencies for the [ProjectGraph](../../devkit/documents/ProjectGraph)                       |
-| `createNodes?`        | [`CreateNodes`](../../devkit/documents/CreateNodes)               | Provides a file pattern and function that retrieves configuration info from those files. e.g. { '\*_/_.csproj': buildProjectsFromCsProjFile } |
-| `name`                | `string`                                                          | -                                                                                                                                             |
+| Name                  | Type                                                                    | Description                                                                                                                                   |
+| :-------------------- | :---------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------- |
+| `createDependencies?` | [`CreateDependencies`](../../devkit/documents/CreateDependencies)<`T`\> | Provides a function to analyze files to create dependencies for the [ProjectGraph](../../devkit/documents/ProjectGraph)                       |
+| `createNodes?`        | [`CreateNodes`](../../devkit/documents/CreateNodes)<`T`\>               | Provides a file pattern and function that retrieves configuration info from those files. e.g. { '\*_/_.csproj': buildProjectsFromCsProjFile } |
+| `name`                | `string`                                                                | -                                                                                                                                             |

--- a/docs/generated/devkit/Workspace.md
+++ b/docs/generated/devkit/Workspace.md
@@ -30,8 +30,8 @@ use ProjectsConfigurations or NxJsonConfiguration
 - [nxCloudEncryptionKey](../../devkit/documents/Workspace#nxcloudencryptionkey): string
 - [nxCloudUrl](../../devkit/documents/Workspace#nxcloudurl): string
 - [parallel](../../devkit/documents/Workspace#parallel): number
-- [plugins](../../devkit/documents/Workspace#plugins): string[]
-- [pluginsConfig](../../devkit/documents/Workspace#pluginsconfig): Record&lt;string, unknown&gt;
+- [plugins](../../devkit/documents/Workspace#plugins): PluginDefinition[]
+- [pluginsConfig](../../devkit/documents/Workspace#pluginsconfig): Record&lt;string, Record&lt;string, unknown&gt;&gt;
 - [projects](../../devkit/documents/Workspace#projects): Record&lt;string, ProjectConfiguration&gt;
 - [release](../../devkit/documents/Workspace#release): NxReleaseConfiguration
 - [targetDefaults](../../devkit/documents/Workspace#targetdefaults): TargetDefaults
@@ -254,7 +254,7 @@ Specifies how many tasks can be run in parallel.
 
 ### plugins
 
-• `Optional` **plugins**: `string`[]
+• `Optional` **plugins**: `PluginDefinition`[]
 
 Plugins for extending the project graph
 
@@ -266,7 +266,7 @@ Plugins for extending the project graph
 
 ### pluginsConfig
 
-• `Optional` **pluginsConfig**: `Record`<`string`, `unknown`\>
+• `Optional` **pluginsConfig**: `Record`<`string`, `Record`<`string`, `unknown`\>\>
 
 Configuration for Nx Plugins
 

--- a/e2e/plugin/src/nx-plugin.fixtures.ts
+++ b/e2e/plugin/src/nx-plugin.fixtures.ts
@@ -28,7 +28,7 @@ type PluginOptions = {
 
 export const createNodes: CreateNodes<PluginOptions> = [
     "**/my-project-file",
-    (f, ctx, options) => {
+    (f, options, ctx) => {
         // f = path/to/my/file/my-project-file
         const root = dirname(f);
         // root = path/to/my/file

--- a/e2e/plugin/src/nx-plugin.fixtures.ts
+++ b/e2e/plugin/src/nx-plugin.fixtures.ts
@@ -18,3 +18,39 @@ export default async function* execute(
   yield* asyncGenerator();
 }
 `;
+
+export const NX_PLUGIN_V2_CONTENTS = `import { basename, dirname } from "path";
+import { CreateNodes } from "@nx/devkit";
+
+type PluginOptions = {
+    inferredTags: string[]
+}
+
+export const createNodes: CreateNodes<PluginOptions> = [
+    "**/my-project-file",
+    (f, ctx, options) => {
+        // f = path/to/my/file/my-project-file
+        const root = dirname(f);
+        // root = path/to/my/file
+        const name = basename(root);
+        // name = file
+
+        return {
+            projects: {
+                [name]: {
+                    root,
+                    targets: {
+                        build: {
+                            executor: "nx:run-commands",
+                            options: {
+                                command: "echo 'custom registered target'",
+                            },
+                        },
+                    },
+                    tags: options.inferredTags
+                },
+            },
+        };
+    },
+];
+`;

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -75,7 +75,7 @@
       "type": "array",
       "description": "Plugins for extending the project graph.",
       "items": {
-        "type": "string"
+        "$ref": "#/definitions/plugins"
       }
     },
     "defaultProject": {
@@ -382,6 +382,27 @@
         }
       },
       "additionalProperties": false
+    },
+    "plugins": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "A plugin module to load with default options"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "plugin": {
+              "type": "string",
+              "description": "The plugin module to load"
+            },
+            "options": {
+              "type": "object",
+              "description": "The options passed to the plugin when creating nodes and dependencies"
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/packages/nx/src/adapter/angular-json.ts
+++ b/packages/nx/src/adapter/angular-json.ts
@@ -10,7 +10,7 @@ export const NxAngularJsonPlugin: NxPluginV2 = {
   name: NX_ANGULAR_JSON_PLUGIN_NAME,
   createNodes: [
     'angular.json',
-    (f, ctx) => ({
+    (f, _, ctx) => ({
       projects: readAngularJson(ctx.workspaceRoot),
     }),
   ],

--- a/packages/nx/src/adapter/angular-json.ts
+++ b/packages/nx/src/adapter/angular-json.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'fs';
 import * as path from 'path';
 import { readJsonFile } from '../utils/fileutils';
 import { ProjectsConfigurations } from '../config/workspace-json-project-json';
-import { NxPluginV2 } from '../devkit-exports';
+import { NxPluginV2 } from '../utils/nx-plugin';
 
 export const NX_ANGULAR_JSON_PLUGIN_NAME = 'nx-angular-json-plugin';
 

--- a/packages/nx/src/command-line/init/implementation/add-nx-to-nest.ts
+++ b/packages/nx/src/command-line/init/implementation/add-nx-to-nest.ts
@@ -367,7 +367,7 @@ function addNrwlJsPluginsConfig(repoRoot: string) {
     json.pluginsConfig = {
       '@nx/js': {
         analyzeSourceFiles: true,
-      } as NrwlJsPluginConfig,
+      },
     };
   }
 

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -176,12 +176,12 @@ export interface NxJsonConfiguration<T = '*' | string[]> {
   /**
    * Plugins for extending the project graph
    */
-  plugins?: string[];
+  plugins?: PluginDefinition[];
 
   /**
    * Configuration for Nx Plugins
    */
-  pluginsConfig?: Record<string, unknown>;
+  pluginsConfig?: Record<string, Record<string, unknown>>;
 
   /**
    * Default project. When project isn't provided, the default project
@@ -233,6 +233,10 @@ export interface NxJsonConfiguration<T = '*' | string[]> {
    */
   useDaemonProcess?: boolean;
 }
+
+export type PluginDefinition =
+  | string
+  | { plugin: string; options?: Record<string, unknown> };
 
 export function readNxJson(root: string = workspaceRoot): NxJsonConfiguration {
   const nxJson = join(root, 'nx.json');

--- a/packages/nx/src/generators/utils/project-configuration.ts
+++ b/packages/nx/src/generators/utils/project-configuration.ts
@@ -213,7 +213,7 @@ function readAndCombineAllProjectConfigurations(tree: Tree): {
     if (basename(projectFile) === 'project.json') {
       const json = readJson(tree, projectFile);
       const config = buildProjectFromProjectJson(json, projectFile);
-      mergeProjectConfigurationIntoRootMap(rootMap, config, projectFile);
+      mergeProjectConfigurationIntoRootMap(rootMap, config);
     } else {
       const packageJson = readJson<PackageJson>(tree, projectFile);
       const config = buildProjectConfigurationFromPackageJson(
@@ -228,8 +228,7 @@ function readAndCombineAllProjectConfigurations(tree: Tree): {
         {
           name: config.name,
           root: config.root,
-        },
-        projectFile
+        }
       );
     }
   }

--- a/packages/nx/src/plugins/js/index.ts
+++ b/packages/nx/src/plugins/js/index.ts
@@ -36,7 +36,7 @@ let parsedLockFile: ParsedLockFile = {};
 export const createNodes: CreateNodes = [
   // Look for all lockfiles
   combineGlobPatterns(LOCKFILES),
-  (lockFile, context) => {
+  (lockFile, _, context) => {
     const pluginConfig = jsPluginConfig(context.nxJsonConfiguration);
     if (!pluginConfig.analyzeLockfile) {
       return {};
@@ -74,6 +74,7 @@ export const createNodes: CreateNodes = [
 ];
 
 export const createDependencies: CreateDependencies = (
+  _,
   ctx: CreateDependenciesContext
 ) => {
   const pluginConfig = jsPluginConfig(ctx.nxJsonConfiguration);

--- a/packages/nx/src/plugins/project-json/build-nodes/project-json.spec.ts
+++ b/packages/nx/src/plugins/project-json/build-nodes/project-json.spec.ts
@@ -55,7 +55,7 @@ describe('nx project.json plugin', () => {
       '/root'
     );
 
-    expect(createNodes[1]('project.json', context, null))
+    expect(createNodes[1]('project.json', undefined, context))
       .toMatchInlineSnapshot(`
       {
         "projects": {
@@ -69,7 +69,7 @@ describe('nx project.json plugin', () => {
         },
       }
     `);
-    expect(createNodes[1]('packages/lib-a/project.json', context, null))
+    expect(createNodes[1]('packages/lib-a/project.json', undefined, context))
       .toMatchInlineSnapshot(`
       {
         "projects": {

--- a/packages/nx/src/plugins/project-json/build-nodes/project-json.spec.ts
+++ b/packages/nx/src/plugins/project-json/build-nodes/project-json.spec.ts
@@ -55,7 +55,8 @@ describe('nx project.json plugin', () => {
       '/root'
     );
 
-    expect(createNodes[1]('project.json', context)).toMatchInlineSnapshot(`
+    expect(createNodes[1]('project.json', context, null))
+      .toMatchInlineSnapshot(`
       {
         "projects": {
           "root": {
@@ -68,7 +69,7 @@ describe('nx project.json plugin', () => {
         },
       }
     `);
-    expect(createNodes[1]('packages/lib-a/project.json', context))
+    expect(createNodes[1]('packages/lib-a/project.json', context, null))
       .toMatchInlineSnapshot(`
       {
         "projects": {

--- a/packages/nx/src/plugins/project-json/build-nodes/project-json.ts
+++ b/packages/nx/src/plugins/project-json/build-nodes/project-json.ts
@@ -17,7 +17,7 @@ export const CreateProjectJsonProjectsPlugin: NxPluginV2 = {
   name: 'nx-core-build-project-json-nodes',
   createNodes: [
     '{project.json,**/project.json}',
-    (file, context) => {
+    (file, _, context) => {
       const root = context.workspaceRoot;
       const json = readJsonFile<ProjectConfiguration>(join(root, file));
       const project = buildProjectFromProjectJson(json, file);

--- a/packages/nx/src/project-graph/build-project-graph.ts
+++ b/packages/nx/src/project-graph/build-project-graph.ts
@@ -19,6 +19,7 @@ import {
   isNxPluginV1,
   isNxPluginV2,
   loadNxPlugins,
+  readPluginsOptions,
 } from '../utils/nx-plugin';
 import { getRootTsConfigPath } from '../plugins/js/utils/typescript';
 import {
@@ -233,6 +234,7 @@ async function updateProjectGraphWithPlugins(
   initProjectGraph: ProjectGraph
 ) {
   const plugins = await loadNxPlugins(context.nxJsonConfiguration?.plugins);
+  const pluginsOptions = readPluginsOptions(context.nxJsonConfiguration);
   let graph = initProjectGraph;
   for (const plugin of plugins) {
     try {
@@ -285,9 +287,12 @@ async function updateProjectGraphWithPlugins(
   await Promise.all(
     createDependencyPlugins.map(async (plugin) => {
       try {
-        const dependencies = await plugin.createDependencies({
-          ...context,
-        });
+        const dependencies = await plugin.createDependencies(
+          {
+            ...context,
+          },
+          pluginsOptions[plugin.name] ?? {}
+        );
 
         for (const dep of dependencies) {
           builder.addDependency(

--- a/packages/nx/src/project-graph/nx-deps-cache.spec.ts
+++ b/packages/nx/src/project-graph/nx-deps-cache.spec.ts
@@ -111,7 +111,7 @@ describe('nx deps utils', () => {
           createCache({}),
           createPackageJsonDeps({ plugin: '2.0.0' }),
           createProjectsConfiguration({}),
-          createNxJson({ pluginsConfig: { one: 1 } }),
+          createNxJson({ pluginsConfig: { somePlugin: { one: 1 } } }),
           createTsConfigJson()
         )
       ).toEqual(true);

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -371,19 +371,15 @@ describe('mergeProjectConfigurationIntoRootMap', () => {
         },
       })
       .getRootMap();
-    mergeProjectConfigurationIntoRootMap(
-      rootMap,
-      {
-        root: 'libs/lib-a',
-        name: 'lib-a',
-        targets: {
-          build: {
-            command: 'tsc',
-          },
+    mergeProjectConfigurationIntoRootMap(rootMap, {
+      root: 'libs/lib-a',
+      name: 'lib-a',
+      targets: {
+        build: {
+          command: 'tsc',
         },
       },
-      'inferred-project-config-file.ts'
-    );
+    });
     expect(rootMap.get('libs/lib-a')).toMatchInlineSnapshot(`
       {
         "name": "lib-a",
@@ -398,33 +394,6 @@ describe('mergeProjectConfigurationIntoRootMap', () => {
         },
       }
     `);
-  });
-
-  it("shouldn't overwrite project name, unless merging project from project.json", () => {
-    const rootMap = new RootMapBuilder()
-      .addProject({
-        name: 'bad-name',
-        root: 'libs/lib-a',
-      })
-      .getRootMap();
-    mergeProjectConfigurationIntoRootMap(
-      rootMap,
-      {
-        name: 'other-bad-name',
-        root: 'libs/lib-a',
-      },
-      'libs/lib-a/package.json'
-    );
-    expect(rootMap.get('libs/lib-a').name).toEqual('bad-name');
-    mergeProjectConfigurationIntoRootMap(
-      rootMap,
-      {
-        name: 'lib-a',
-        root: 'libs/lib-a',
-      },
-      'libs/lib-a/project.json'
-    );
-    expect(rootMap.get('libs/lib-a').name).toEqual('lib-a');
   });
 });
 

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -5,7 +5,7 @@ import {
   TargetConfiguration,
 } from '../../config/workspace-json-project-json';
 import { NX_PREFIX } from '../../utils/logger';
-import { LoadedNxPlugin, readPluginsOptions } from '../../utils/nx-plugin';
+import { LoadedNxPlugin } from '../../utils/nx-plugin';
 import { workspaceRoot } from '../../utils/workspace-root';
 
 import minimatch = require('minimatch');
@@ -74,10 +74,9 @@ export function buildProjectsConfigurationsFromProjectPathsAndPlugins(
 } {
   const projectRootMap: Map<string, ProjectConfiguration> = new Map();
   const externalNodes: Record<string, ProjectGraphExternalNode> = {};
-  const pluginOptions = readPluginsOptions(nxJson);
 
   // We iterate over plugins first - this ensures that plugins specified first take precedence.
-  for (const plugin of plugins) {
+  for (const { plugin, options } of plugins) {
     const [pattern, createNodes] = plugin.createNodes ?? [];
     if (!pattern) {
       continue;
@@ -85,14 +84,10 @@ export function buildProjectsConfigurationsFromProjectPathsAndPlugins(
     for (const file of projectFiles) {
       if (minimatch(file, pattern, { dot: true })) {
         const { projects: projectNodes, externalNodes: pluginExternalNodes } =
-          createNodes(
-            file,
-            {
-              nxJsonConfiguration: nxJson,
-              workspaceRoot: root,
-            },
-            pluginOptions[plugin.name] ?? {}
-          );
+          createNodes(file, options, {
+            nxJsonConfiguration: nxJson,
+            workspaceRoot: root,
+          });
         for (const node in projectNodes) {
           projectNodes[node].name ??= node;
           mergeProjectConfigurationIntoRootMap(

--- a/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
+++ b/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
@@ -138,9 +138,9 @@ export async function retrieveProjectConfigurationsWithAngularProjects(
 
   if (
     shouldMergeAngularProjects(workspaceRoot, true) &&
-    !plugins.some((p) => p.name === NX_ANGULAR_JSON_PLUGIN_NAME)
+    !plugins.some((p) => p.plugin.name === NX_ANGULAR_JSON_PLUGIN_NAME)
   ) {
-    plugins.push(NxAngularJsonPlugin);
+    plugins.push({ plugin: NxAngularJsonPlugin });
   }
 
   const globs = configurationGlobs(workspaceRoot, plugins);
@@ -237,8 +237,8 @@ export function retrieveProjectConfigurationsWithoutPluginInference(
     projectGlobPatterns,
     (configs: string[]) => {
       const { projects } = createProjectConfigurations(root, nxJson, configs, [
-        getNxPackageJsonWorkspacesPlugin(root),
-        CreateProjectJsonProjectsPlugin,
+        { plugin: getNxPackageJsonWorkspacesPlugin(root) },
+        { plugin: CreateProjectJsonProjectsPlugin },
       ]);
       return {
         projectNodes: projects,
@@ -306,11 +306,11 @@ export function createProjectConfigurations(
 
 export function configurationGlobs(
   workspaceRoot: string,
-  plugins: NxPluginV2[]
+  plugins: LoadedNxPlugin[]
 ): string[] {
   const globPatterns: string[] =
     configurationGlobsWithoutPlugins(workspaceRoot);
-  for (const plugin of plugins) {
+  for (const { plugin } of plugins) {
     if (plugin.createNodes) {
       globPatterns.push(plugin.createNodes[0]);
     }

--- a/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
+++ b/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
@@ -22,6 +22,7 @@ import {
 } from '../../../plugins/package-json-workspaces';
 import { buildProjectsConfigurationsFromProjectPathsAndPlugins } from './project-configuration-utils';
 import {
+  LoadedNxPlugin,
   loadNxPlugins,
   loadNxPluginsSync,
   NxPluginV2,
@@ -169,7 +170,7 @@ export function retrieveProjectConfigurationsSync(
 function _retrieveProjectConfigurations(
   workspaceRoot: string,
   nxJson: NxJsonConfiguration,
-  plugins: NxPluginV2[],
+  plugins: LoadedNxPlugin[],
   globs: string[]
 ): {
   externalNodes: Record<string, ProjectGraphExternalNode>;
@@ -273,7 +274,7 @@ export function createProjectConfigurations(
   workspaceRoot: string,
   nxJson: NxJsonConfiguration,
   configFiles: string[],
-  plugins: NxPluginV2[]
+  plugins: LoadedNxPlugin[]
 ): {
   projects: Record<string, ProjectConfiguration>;
   externalNodes: Record<string, ProjectGraphExternalNode>;

--- a/packages/nx/src/utils/plugins/local-plugins.ts
+++ b/packages/nx/src/utils/plugins/local-plugins.ts
@@ -21,7 +21,7 @@ export async function getLocalWorkspacePlugins(
     if (existsSync(packageJsonPath)) {
       const packageJson: PackageJson = readJsonFile(packageJsonPath);
       const includeRuntimeCapabilities = nxJson?.plugins?.some((p) =>
-        p.startsWith(packageJson.name)
+        (typeof p === 'string' ? p : p.plugin).startsWith(packageJson.name)
       );
       const capabilities = await getPluginCapabilities(
         workspaceRoot,

--- a/packages/nx/src/utils/plugins/plugin-capabilities.ts
+++ b/packages/nx/src/utils/plugins/plugin-capabilities.ts
@@ -103,11 +103,13 @@ async function tryGetModule(
       packageJson['nx-migrations'] ??
       packageJson['schematics'] ??
       packageJson['builders']
-      ? await loadNxPluginAsync(
-          packageJson.name,
-          getNxRequirePaths(workspaceRoot),
-          workspaceRoot
-        )
+      ? (
+          await loadNxPluginAsync(
+            packageJson.name,
+            getNxRequirePaths(workspaceRoot),
+            workspaceRoot
+          )
+        ).plugin
       : ({
           name: packageJson.name,
         } as NxPlugin);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
There's not a standardized way to provide options for a graph / inference plugin

## Expected Behavior
Plugins can be specified as an object, with options provided.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
