### PR TITLE
chore(repo): temporarily allow linking to vue

### DIFF
--- a/nx-dev/nx-dev/next-sitemap.config.js
+++ b/nx-dev/nx-dev/next-sitemap.config.js
@@ -3,7 +3,7 @@ const path = require('path');
 module.exports = {
   siteUrl: process.env.SITE_URL || 'https://nx.dev',
   generateRobotsTxt: true,
-  exclude: ['/ai'],
+  exclude: [],
   sourceDir: path.resolve(__dirname, '../../dist/nx-dev/nx-dev/.next'),
   outDir: path.resolve(__dirname, '../../dist/nx-dev/nx-dev/public'),
 };

--- a/scripts/documentation/internal-link-checker.ts
+++ b/scripts/documentation/internal-link-checker.ts
@@ -97,6 +97,11 @@ function checkLinkIsForPrivatePackage(link: string) {
   }
   const pathSegments = link.split('/').filter(Boolean);
   if (pathSegments[0] === 'nx-api') {
+    // TODO(v17): Remove this once vue is public or once this logic is fixed
+    if (pathSegments[1] === 'vue') {
+      return true;
+    }
+
     const packageJsonPath = join(
       workspaceRoot,
       'packages',
@@ -119,6 +124,7 @@ const sitemapLinks = readSiteMapIndex(
 const errors: Array<{ file: string; link: string }> = [];
 for (let file in documentLinks) {
   for (let link of documentLinks[file]) {
+    // TODO(@isaacplmann): This ignores errors which are links TO private packages. It allows links FROM public packages (public docs) TO private packages (404 links)
     if (
       !sitemapLinks.includes(['https://nx.dev', link].join('')) &&
       !checkLinkIsForPrivatePackage(link)


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`master` is red right now and all PRs fail.

The vue package is no longer marked as private which means linking to it is apparently an error. The logic is incorrect.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The vue package is no longer marked as private which means linking to it is apparently an error. The logic is incorrect.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
