### PR TITLE
chore(misc): uses the nx-cloud-workflows templated step for git checkout

### DIFF
--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -16,11 +16,7 @@ env:
   NX_CLOUD_ACCESS_TOKEN: '{{secrets.NX_CLOUD_ACCESS_TOKEN}}'
 steps:
   - name: Git Clone
-    script: |
-      git init .
-      git remote add origin $GIT_REPOSITORY_URL
-      git fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +{{nxCommitSha}}:{{nxCommitRef}}
-      git checkout --progress --force -B {{nxBranch}} {{nxCommitRef}}
+    uses: 'nrwl/nx-cloud-workflows/v1.1/workflow-steps/checkout/main.yaml'
 
   - name: Restore cache
     script: |


### PR DESCRIPTION
## Current Behavior
Previously the repository was using a script style step to perform git checkout when using nx-cloud-workflows. This is currently failing due to some directory permission changes in the workflow agents.

## Expected Behavior
The repository should use the "official" templated step for git checkout when using nx-cloud-workflows. This will ensure better support for nx-cloud-workflows as we can ensure the templated step is kept up to date.