### PR TITLE
feat(core): add support for wildcards in dependsOn

### DIFF
--- a/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
+++ b/packages/angular/src/builders/webpack-browser/webpack-browser.impl.ts
@@ -25,10 +25,19 @@ function shouldSkipInitialTargetRun(
   project: string,
   target: string
 ): boolean {
+  const allTargetNames = new Set<string>();
+  for (const projectName in projectGraph.nodes) {
+    const project = projectGraph.nodes[projectName];
+    for (const targetName in project.data.targets ?? {}) {
+      allTargetNames.add(targetName);
+    }
+  }
+
   const projectDependencyConfigs = getDependencyConfigs(
     { project, target },
     {},
-    projectGraph
+    projectGraph,
+    Array.from(allTargetNames)
   );
 
   // if the task runner already ran the target, skip the initial run

--- a/packages/nx/src/tasks-runner/utils.spec.ts
+++ b/packages/nx/src/tasks-runner/utils.spec.ts
@@ -443,17 +443,19 @@ describe('utils', () => {
 
   describe('expandDependencyConfigSyntaxSugar', () => {
     it('should expand syntax for simple target names', () => {
-      const result = expandDependencyConfigSyntaxSugar('build', {
+      const result = expandDependencyConfigSyntaxSugar('build', 'any', {
         dependencies: {},
         nodes: {},
       });
-      expect(result).toEqual({
-        target: 'build',
-      });
+      expect(result).toEqual([
+        {
+          target: 'build',
+        },
+      ]);
     });
 
     it('should assume target of self if simple target also matches project name', () => {
-      const result = expandDependencyConfigSyntaxSugar('build', {
+      const result = expandDependencyConfigSyntaxSugar('build', 'any', {
         dependencies: {},
         nodes: {
           build: {
@@ -465,24 +467,28 @@ describe('utils', () => {
           },
         },
       });
-      expect(result).toEqual({
-        target: 'build',
-      });
+      expect(result).toEqual([
+        {
+          target: 'build',
+        },
+      ]);
     });
 
     it('should expand syntax for simple target names targetting dependencies', () => {
-      const result = expandDependencyConfigSyntaxSugar('^build', {
+      const result = expandDependencyConfigSyntaxSugar('^build', 'any', {
         dependencies: {},
         nodes: {},
       });
-      expect(result).toEqual({
-        target: 'build',
-        dependencies: true,
-      });
+      expect(result).toEqual([
+        {
+          target: 'build',
+          dependencies: true,
+        },
+      ]);
     });
 
     it('should expand syntax for strings like project:target if project is a valid project', () => {
-      const result = expandDependencyConfigSyntaxSugar('project:build', {
+      const result = expandDependencyConfigSyntaxSugar('project:build', 'any', {
         dependencies: {},
         nodes: {
           project: {
@@ -494,20 +500,59 @@ describe('utils', () => {
           },
         },
       });
-      expect(result).toEqual({
-        target: 'build',
-        projects: ['project'],
-      });
+      expect(result).toEqual([
+        {
+          target: 'build',
+          projects: ['project'],
+        },
+      ]);
     });
 
     it('should expand syntax for strings like target:with:colons', () => {
-      const result = expandDependencyConfigSyntaxSugar('target:with:colons', {
+      const result = expandDependencyConfigSyntaxSugar(
+        'target:with:colons',
+        'any',
+        {
+          dependencies: {},
+          nodes: {},
+        }
+      );
+      expect(result).toEqual([
+        {
+          target: 'target:with:colons',
+        },
+      ]);
+    });
+
+    it('supports wildcards in targets', () => {
+      const result = expandDependencyConfigSyntaxSugar('build-*', 'project', {
         dependencies: {},
-        nodes: {},
+        nodes: {
+          project: {
+            name: 'project',
+            type: 'app',
+            data: {
+              root: 'libs/project',
+              targets: {
+                build: {},
+                'build-css': {},
+                'build-js': {},
+                'then-build-something-else': {},
+              },
+            },
+          },
+        },
       });
-      expect(result).toEqual({
-        target: 'target:with:colons',
-      });
+      expect(result).toEqual([
+        {
+          target: 'build-css',
+          projects: ['project'],
+        },
+        {
+          target: 'build-js',
+          projects: ['project'],
+        },
+      ]);
     });
   });
 

--- a/packages/nx/src/utils/find-matching-projects.ts
+++ b/packages/nx/src/utils/find-matching-projects.ts
@@ -18,7 +18,10 @@ interface ProjectPattern {
   value: string;
 }
 
-const globCharacters = ['*', '|', '{', '}', '(', ')'];
+/**
+ * The presence of these characters in a string indicates that it might be a glob pattern.
+ */
+export const GLOB_CHARACTERS = ['*', '|', '{', '}', '(', ')'];
 
 /**
  * Find matching project names given a list of potential project names or globs.
@@ -166,7 +169,7 @@ function addMatchingProjectsByName(
     return;
   }
 
-  if (!globCharacters.some((c) => pattern.value.includes(c))) {
+  if (!GLOB_CHARACTERS.some((c) => pattern.value.includes(c))) {
     return;
   }
 
@@ -201,7 +204,7 @@ function addMatchingProjectsByTag(
       continue;
     }
 
-    if (!globCharacters.some((c) => pattern.value.includes(c))) {
+    if (!GLOB_CHARACTERS.some((c) => pattern.value.includes(c))) {
       continue;
     }
 


### PR DESCRIPTION
Now it is possible to define targets like this:

```
{
  "targets": {
    "build-css": {},
    "build-js": {},
    "test": {
      "dependsOn": ["build-*"]
    },
  }
}
```

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
No support for wildcard target dependencies.

## Expected Behavior
This PR is an example of what I described here: https://github.com/nrwl/nx/issues/19414.

## Related Issue(s)
Closes #19414
