### PR TITLE
fix(misc): remove projectNameAndRootFormat from nx.json schema

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -3,9 +3,6 @@
   "affected": {
     "defaultBase": "master"
   },
-  "workspaceLayout": {
-    "projectNameAndRootFormat": "as-provided"
-  },
   "namedInputs": {
     "default": ["{projectRoot}/**/*", "sharedGlobals"],
     "production": [

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -56,11 +56,6 @@
         "appsDir": {
           "type": "string",
           "description": "Default folder name for apps."
-        },
-        "projectNameAndRootFormat": {
-          "type": "string",
-          "description": "Default method of handling arguments for generating projects",
-          "enum": ["as-provided", "derived"]
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `nx.json` schema still contains a definition for `workspaceLayout.projectNameAndRootFormat` even though it was meant to be removed in https://github.com/nrwl/nx/pull/19218.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `nx.json` schema should not contain a definition for `workspaceLayout.projectNameAndRootFormat`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #19525 
