### PR TITLE
fix(testing): fix flaky test

### DIFF
--- a/e2e/cypress/src/cypress.test.ts
+++ b/e2e/cypress/src/cypress.test.ts
@@ -160,6 +160,7 @@ describe('env vars', () => {
     async () => {
       // ensure ports are free before running tests
       await killPort(4200);
+      await killPort(4201);
 
       const ngAppName = uniq('ng-app');
       runCLI(


### PR DESCRIPTION
This test assumes both 4200 and 4201 are free but only kills 4200 before the test.
If 4201 is not cleaned up, it can cause test to fail.

The fix ensures both are cleared.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
