### PR TITLE
fix(misc): update re-exports when updating imports during move

### DIFF
--- a/packages/workspace/src/generators/move/lib/__snapshots__/update-imports.spec.ts.snap
+++ b/packages/workspace/src/generators/move/lib/__snapshots__/update-imports.spec.ts.snap
@@ -29,6 +29,15 @@ exports[`updateImports should update dynamic imports 1`] = `
       "
 `;
 
+exports[`updateImports should update imports and reexports 1`] = `
+"
+        import { MyClass } from '@proj/my-destination';
+        export { MyOtherClass } from '@proj/my-destination';
+        
+        export class MyExtendedClass extends MyClass {};
+      "
+`;
+
 exports[`updateImports should update project refs 1`] = `
 "
         import { MyClass } from '@proj/my-destination';

--- a/packages/workspace/src/generators/move/lib/update-imports.ts
+++ b/packages/workspace/src/generators/move/lib/update-imports.ts
@@ -1,26 +1,26 @@
 import {
-  applyChangesToString,
   ChangeType,
-  getProjects,
-  getWorkspaceLayout,
-  joinPathFragments,
   ProjectConfiguration,
   StringChange,
   Tree,
+  applyChangesToString,
+  getProjects,
+  getWorkspaceLayout,
+  joinPathFragments,
+  readJson,
   visitNotIgnoredFiles,
   writeJson,
-  readJson,
 } from '@nx/devkit';
+import { relative } from 'path';
 import type * as ts from 'typescript';
+import { getImportPath } from '../../../utilities/get-import-path';
 import {
-  getRootTsConfigPathInTree,
   findNodes,
+  getRootTsConfigPathInTree,
 } from '../../../utilities/ts-config';
+import { ensureTypescript } from '../../../utilities/typescript';
 import { NormalizedSchema } from '../schema';
 import { normalizePathSlashes } from './utils';
-import { relative } from 'path';
-import { ensureTypescript } from '../../../utilities/typescript';
-import { getImportPath } from '../../../utilities/get-import-path';
 
 let tsModule: typeof import('typescript');
 
@@ -187,10 +187,10 @@ function updateImportDeclarations(
   if (!tsModule) {
     tsModule = ensureTypescript();
   }
-  const importDecls = findNodes(
-    sourceFile,
-    tsModule.SyntaxKind.ImportDeclaration
-  ) as ts.ImportDeclaration[];
+  const importDecls = findNodes(sourceFile, [
+    tsModule.SyntaxKind.ImportDeclaration,
+    tsModule.SyntaxKind.ExportDeclaration,
+  ]) as ts.ImportDeclaration[];
 
   const changes: StringChange[] = [];
 


### PR DESCRIPTION

## Current Behavior
When using `workspace:move` generator to move the project and update import path, re exports are not updated

## Expected Behavior
When updating import paths while moving projects, re-exports will also be updated

## Related Issue(s)
Fixes #19634
