### PR TITLE
fix(misc): do not normalize project name and root when using as-provided format

### DIFF
--- a/e2e/angular-core/src/projects.test.ts
+++ b/e2e/angular-core/src/projects.test.ts
@@ -52,12 +52,12 @@ describe('Angular Projects', () => {
   it('should successfully generate apps and libs and work correctly', async () => {
     const standaloneApp = uniq('standalone-app');
     runCLI(
-      `generate @nx/angular:app ${standaloneApp} --directory=myDir/${standaloneApp} --standalone=true --project-name-and-root-format=as-provided --no-interactive`
+      `generate @nx/angular:app ${standaloneApp} --directory=my-dir/${standaloneApp} --standalone=true --project-name-and-root-format=as-provided --no-interactive`
     );
 
     const esbuildApp = uniq('esbuild-app');
     runCLI(
-      `generate @nx/angular:app ${esbuildApp} --bundler=esbuild --directory=myDir/${esbuildApp} --project-name-and-root-format=as-provided --no-interactive`
+      `generate @nx/angular:app ${esbuildApp} --bundler=esbuild --directory=my-dir/${esbuildApp} --project-name-and-root-format=as-provided --no-interactive`
     );
 
     updateFile(

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -82,7 +82,7 @@ describe('app', () => {
 
     it('should update tags + implicit dependencies', async () => {
       // ACT
-      await generateApp(appTree, 'myApp', { tags: 'one,two,my-app' });
+      await generateApp(appTree, 'my-app', { tags: 'one,two,my-app' });
 
       // ASSERT
       const projects = devkit.getProjects(appTree);
@@ -193,14 +193,14 @@ describe('app', () => {
 
   describe('nested', () => {
     it('should create project configs', async () => {
-      await generateApp(appTree, 'myApp', { directory: 'myDir/myApp' });
+      await generateApp(appTree, 'my-app', { directory: 'my-dir/my-app' });
       expect(readProjectConfiguration(appTree, 'my-app')).toMatchSnapshot();
       expect(readProjectConfiguration(appTree, 'my-app-e2e')).toMatchSnapshot();
     });
 
     it('should update tags + implicit dependencies', async () => {
-      await generateApp(appTree, 'myApp', {
-        directory: 'myDir/myApp',
+      await generateApp(appTree, 'my-app', {
+        directory: 'my-dir/my-app',
         tags: 'one,two,my-app',
       });
       const projects = devkit.getProjects(appTree);
@@ -225,7 +225,7 @@ describe('app', () => {
 
         expect(lookupFn(content)).toEqual(expectedValue);
       };
-      await generateApp(appTree, 'myApp', { directory: 'myDir/myApp' });
+      await generateApp(appTree, 'my-app', { directory: 'my-dir/my-app' });
 
       const appModulePath = 'my-dir/my-app/src/app/app.module.ts';
       expect(appTree.read(appModulePath, 'utf-8')).toContain('class AppModule');
@@ -267,7 +267,7 @@ describe('app', () => {
 
     it('should extend from tsconfig.base.json', async () => {
       // ACT
-      await generateApp(appTree, 'app', { directory: 'myDir/app' });
+      await generateApp(appTree, 'app', { directory: 'my-dir/app' });
 
       // ASSERT
       const appTsConfig = readJson(appTree, 'my-dir/app/tsconfig.json');
@@ -279,7 +279,7 @@ describe('app', () => {
       appTree.rename('tsconfig.base.json', 'tsconfig.json');
 
       // ACT
-      await generateApp(appTree, 'app', { directory: 'myDir/app' });
+      await generateApp(appTree, 'app', { directory: 'my-dir/app' });
 
       // ASSERT
       const appTsConfig = readJson(appTree, 'my-dir/app/tsconfig.json');
@@ -298,7 +298,7 @@ describe('app', () => {
 
     it('should accept numbers in the path', async () => {
       // ACT
-      await generateApp(appTree, 'myApp', {
+      await generateApp(appTree, 'my-app', {
         directory: 'src/9-websites/my-app',
       });
 
@@ -315,7 +315,7 @@ describe('app', () => {
 
         expect(lookupFn(content)).toEqual(expectedValue);
       };
-      await generateApp(appTree, 'myApp', { directory: 'myDir/myApp' });
+      await generateApp(appTree, 'my-app', { directory: 'my-dir/my-app' });
 
       const appModulePath = 'my-dir/my-app/src/app/app.module.ts';
       expect(appTree.read(appModulePath, 'utf-8')).toContain('class AppModule');
@@ -358,8 +358,8 @@ describe('app', () => {
 
   describe('routing', () => {
     it('should include RouterTestingModule', async () => {
-      await generateApp(appTree, 'myApp', {
-        directory: 'myDir/myApp',
+      await generateApp(appTree, 'my-app', {
+        directory: 'my-dir/my-app',
         routing: true,
       });
       expect(
@@ -371,8 +371,8 @@ describe('app', () => {
     });
 
     it('should not modify tests when --skip-tests is set', async () => {
-      await generateApp(appTree, 'myApp', {
-        directory: 'myDir/myApp',
+      await generateApp(appTree, 'my-app', {
+        directory: 'my-dir/my-app',
         routing: true,
         skipTests: true,
       });
@@ -384,15 +384,15 @@ describe('app', () => {
 
   describe('template generation mode', () => {
     it('should create Nx specific `app.component.html` template', async () => {
-      await generateApp(appTree, 'myApp', { directory: 'myDir/myApp' });
+      await generateApp(appTree, 'my-app', { directory: 'my-dir/my-app' });
       expect(
         appTree.read('my-dir/my-app/src/app/app.component.html', 'utf-8')
       ).toContain('<proj-nx-welcome></proj-nx-welcome>');
     });
 
     it("should update `template`'s property of AppComponent with Nx content", async () => {
-      await generateApp(appTree, 'myApp', {
-        directory: 'myDir/myApp',
+      await generateApp(appTree, 'my-app', {
+        directory: 'my-dir/my-app',
         inlineTemplate: true,
       });
       expect(
@@ -401,15 +401,15 @@ describe('app', () => {
     });
 
     it('should create Nx specific `nx-welcome.component.ts` file', async () => {
-      await generateApp(appTree, 'myApp', { directory: 'myDir/myApp' });
+      await generateApp(appTree, 'my-app', { directory: 'my-dir/my-app' });
       expect(
         appTree.read('my-dir/my-app/src/app/nx-welcome.component.ts', 'utf-8')
       ).toContain('Hello there');
     });
 
     it('should update the AppComponent spec to target Nx content', async () => {
-      await generateApp(appTree, 'myApp', {
-        directory: 'myDir/myApp',
+      await generateApp(appTree, 'my-app', {
+        directory: 'my-dir/my-app',
         inlineTemplate: true,
       });
       const testFileContent = appTree.read(
@@ -424,21 +424,21 @@ describe('app', () => {
 
   describe('--style scss', () => {
     it('should generate scss styles', async () => {
-      await generateApp(appTree, 'myApp', { style: 'scss' });
+      await generateApp(appTree, 'my-app', { style: 'scss' });
       expect(appTree.exists('my-app/src/app/app.component.scss')).toEqual(true);
     });
   });
 
   describe('--style sass', () => {
     it('should generate sass styles', async () => {
-      await generateApp(appTree, 'myApp', { style: 'sass' });
+      await generateApp(appTree, 'my-app', { style: 'sass' });
       expect(appTree.exists('my-app/src/app/app.component.sass')).toEqual(true);
     });
   });
 
   describe('--style less', () => {
     it('should generate less styles', async () => {
-      await generateApp(appTree, 'myApp', { style: 'less' });
+      await generateApp(appTree, 'my-app', { style: 'less' });
       expect(appTree.exists('my-app/src/app/app.component.less')).toEqual(true);
     });
   });
@@ -458,7 +458,7 @@ describe('app', () => {
     xit('should skip format when set to true', async () => {
       const spy = jest.spyOn(devkit, 'formatFiles');
 
-      await generateApp(appTree, 'myApp', { skipFormat: true });
+      await generateApp(appTree, 'my-app', { skipFormat: true });
 
       expect(spy).not.toHaveBeenCalled();
     });
@@ -467,7 +467,7 @@ describe('app', () => {
   describe('--linter', () => {
     describe('eslint', () => {
       it('should add lint target', async () => {
-        await generateApp(appTree, 'myApp', { linter: Linter.EsLint });
+        await generateApp(appTree, 'my-app', { linter: Linter.EsLint });
         expect(readProjectConfiguration(appTree, 'my-app').targets.lint)
           .toMatchInlineSnapshot(`
           {
@@ -500,7 +500,7 @@ describe('app', () => {
       });
 
       it('should add valid eslint JSON configuration which extends from Nx presets', async () => {
-        await generateApp(appTree, 'myApp', { linter: Linter.EsLint });
+        await generateApp(appTree, 'my-app', { linter: Linter.EsLint });
 
         const eslintConfig = readJson(appTree, 'my-app/.eslintrc.json');
         expect(eslintConfig).toMatchInlineSnapshot(`
@@ -556,7 +556,7 @@ describe('app', () => {
 
     describe('none', () => {
       it('should add no lint target', async () => {
-        await generateApp(appTree, 'myApp', { linter: Linter.None });
+        await generateApp(appTree, 'my-app', { linter: Linter.None });
         expect(
           readProjectConfiguration(appTree, 'my-app').targets.lint
         ).toBeUndefined();
@@ -594,7 +594,7 @@ describe('app', () => {
 
     describe('none', () => {
       it('should not generate test configuration', async () => {
-        await generateApp(appTree, 'myApp', {
+        await generateApp(appTree, 'my-app', {
           unitTestRunner: UnitTestRunner.None,
         });
         expect(appTree.exists('my-app/src/test-setup.ts')).toBeFalsy();
@@ -620,7 +620,7 @@ describe('app', () => {
   describe('--e2e-test-runner', () => {
     describe('none', () => {
       it('should not generate test configuration', async () => {
-        await generateApp(appTree, 'myApp', {
+        await generateApp(appTree, 'my-app', {
           e2eTestRunner: E2eTestRunner.None,
         });
         expect(appTree.exists('my-app-e2e')).toBeFalsy();
@@ -1083,7 +1083,7 @@ describe('app', () => {
 
 async function generateApp(
   appTree: Tree,
-  name: string = 'myApp',
+  name: string = 'my-app',
   options: Partial<Schema> = {}
 ) {
   await generateTestApplication(appTree, {

--- a/packages/angular/src/generators/host/host.spec.ts
+++ b/packages/angular/src/generators/host/host.spec.ts
@@ -86,7 +86,7 @@ describe('Host App Generator', () => {
     // ACT
 
     await generateTestHostApplication(tree, {
-      name: 'hostApp',
+      name: 'host-app',
       remotes: ['remote1', 'remote2'],
       typescriptConfiguration: false,
     });
@@ -116,7 +116,7 @@ describe('Host App Generator', () => {
     // ACT
 
     await generateTestHostApplication(tree, {
-      name: 'hostApp',
+      name: 'host-app',
       remotes: ['remote1', 'remote2'],
       typescriptConfiguration: true,
     });
@@ -149,7 +149,7 @@ describe('Host App Generator', () => {
 
     // ACT
     await generateTestHostApplication(tree, {
-      name: 'hostApp',
+      name: 'host-app',
       remotes: ['remote1', 'remote2', 'remote3'],
       typescriptConfiguration: false,
     });
@@ -173,7 +173,7 @@ describe('Host App Generator', () => {
 
     // ACT
     await generateTestHostApplication(tree, {
-      name: 'hostApp',
+      name: 'host-app',
       remotes: ['remote1', 'remote2', 'remote3'],
       typescriptConfiguration: true,
     });
@@ -197,8 +197,8 @@ describe('Host App Generator', () => {
 
     // ACT
     await generateTestHostApplication(tree, {
-      name: 'hostApp',
-      directory: 'foo/hostApp',
+      name: 'host-app',
+      directory: 'foo/host-app',
       remotes: ['remote1', 'remote2', 'remote3'],
       typescriptConfiguration: false,
     });
@@ -222,8 +222,8 @@ describe('Host App Generator', () => {
 
     // ACT
     await generateTestHostApplication(tree, {
-      name: 'hostApp',
-      directory: 'foo/hostApp',
+      name: 'host-app',
+      directory: 'foo/host-app',
       remotes: ['remote1', 'remote2', 'remote3'],
       typescriptConfiguration: true,
     });

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -34,7 +34,7 @@ describe('lib', () => {
 
   async function runLibraryGeneratorWithOpts(opts: Partial<Schema> = {}) {
     await generateTestLibrary(tree, {
-      name: 'myLib',
+      name: 'my-lib',
       publishable: false,
       buildable: false,
       linter: Linter.EsLint,
@@ -415,8 +415,8 @@ describe('lib', () => {
         directory: 'my-dir/my-lib',
       });
       await runLibraryGeneratorWithOpts({
-        name: 'myLib2',
-        directory: 'myDir/my-lib2',
+        name: 'my-lib2',
+        directory: 'my-dir/my-lib2',
         tags: 'one,two',
       });
 
@@ -440,8 +440,8 @@ describe('lib', () => {
         directory: 'my-dir/my-lib',
       });
       await runLibraryGeneratorWithOpts({
-        name: 'myLib2',
-        directory: 'myDir/myLib2',
+        name: 'my-lib2',
+        directory: 'my-dir/my-lib2',
         simpleName: true,
       });
 
@@ -488,7 +488,7 @@ describe('lib', () => {
     it('should update ng-package.json', async () => {
       // ACT
       await runLibraryGeneratorWithOpts({
-        directory: 'myDir/myLib',
+        directory: 'my-dir/my-lib',
         publishable: true,
         importPath: '@myorg/lib',
       });
@@ -500,7 +500,7 @@ describe('lib', () => {
 
     it('should generate project configuration', async () => {
       // ACT
-      await runLibraryGeneratorWithOpts({ directory: 'myDir/myLib' });
+      await runLibraryGeneratorWithOpts({ directory: 'my-dir/my-lib' });
 
       // ASSERT
       expect(readProjectConfiguration(tree, 'my-lib').root).toEqual(
@@ -510,7 +510,7 @@ describe('lib', () => {
 
     it('should update tsconfig.json', async () => {
       // ACT
-      await runLibraryGeneratorWithOpts({ directory: 'myDir/myLib' });
+      await runLibraryGeneratorWithOpts({ directory: 'my-dir/my-lib' });
 
       // ASSERT
       const tsconfigJson = readJson(tree, '/tsconfig.base.json');
@@ -528,7 +528,7 @@ describe('lib', () => {
       });
 
       // ACT
-      await runLibraryGeneratorWithOpts({ directory: 'myDir/myLib' });
+      await runLibraryGeneratorWithOpts({ directory: 'my-dir/my-lib' });
 
       // ASSERT
       const tsconfigJson = readJson(tree, '/tsconfig.base.json');
@@ -558,7 +558,7 @@ describe('lib', () => {
     });
 
     it('should have root relative routes', async () => {
-      await runLibraryGeneratorWithOpts({ directory: 'myDir/myLib' });
+      await runLibraryGeneratorWithOpts({ directory: 'my-dir/my-lib' });
       const projectConfig = readProjectConfiguration(tree, 'my-lib');
       expect(projectConfig.root).toEqual('my-dir/my-lib');
     });
@@ -570,7 +570,7 @@ describe('lib', () => {
         expect(lookupFn(content)).toEqual(expectedValue);
       };
       await runLibraryGeneratorWithOpts({
-        directory: 'myDir/myLib',
+        directory: 'my-dir/my-lib',
         simpleName: true,
         publishable: true,
         importPath: '@myorg/lib',
@@ -682,14 +682,14 @@ describe('lib', () => {
       it('should add RouterModule.forChild', async () => {
         // ACT
         await runLibraryGeneratorWithOpts({
-          directory: 'myDir/myLib',
+          directory: 'my-dir/my-lib',
           routing: true,
           lazy: true,
         });
 
         await runLibraryGeneratorWithOpts({
-          name: 'myLib2',
-          directory: 'myDir/myLib2',
+          name: 'my-lib2',
+          directory: 'my-dir/my-lib2',
           routing: true,
           lazy: true,
           simpleName: true,
@@ -717,7 +717,7 @@ describe('lib', () => {
 
         // ACT
         await runLibraryGeneratorWithOpts({
-          directory: 'myDir/myLib',
+          directory: 'my-dir/my-lib',
           routing: true,
           lazy: true,
           parent: 'myapp/src/app/app.module.ts',
@@ -731,8 +731,8 @@ describe('lib', () => {
         );
 
         await runLibraryGeneratorWithOpts({
-          name: 'myLib2',
-          directory: 'myDir/myLib2',
+          name: 'my-lib2',
+          directory: 'my-dir/my-lib2',
           routing: true,
           lazy: true,
           simpleName: true,
@@ -747,8 +747,8 @@ describe('lib', () => {
         );
 
         await runLibraryGeneratorWithOpts({
-          name: 'myLib3',
-          directory: 'myDir/myLib3',
+          name: 'my-lib3',
+          directory: 'my-dir/my-lib3',
           routing: true,
           lazy: true,
           simpleName: true,
@@ -839,7 +839,7 @@ describe('lib', () => {
 
         // ACT
         await runLibraryGeneratorWithOpts({
-          directory: 'myDir/myLib',
+          directory: 'my-dir/my-lib',
           routing: true,
           lazy: true,
           parent: 'myapp/src/app/app.module.ts',
@@ -858,13 +858,13 @@ describe('lib', () => {
       it('should add RouterModule and define an array of routes', async () => {
         // ACT
         await runLibraryGeneratorWithOpts({
-          directory: 'myDir/myLib',
+          directory: 'my-dir/my-lib',
           routing: true,
         });
 
         await runLibraryGeneratorWithOpts({
-          name: 'myLib2',
-          directory: 'myDir/myLib2',
+          name: 'my-lib2',
+          directory: 'my-dir/my-lib2',
           simpleName: true,
           routing: true,
         });
@@ -896,8 +896,8 @@ describe('lib', () => {
 
         // ACT
         await runLibraryGeneratorWithOpts({
-          name: 'myLib',
-          directory: 'myDir/myLib',
+          name: 'my-lib',
+          directory: 'my-dir/my-lib',
           routing: true,
           parent: 'myapp/src/app/app.module.ts',
         });
@@ -907,8 +907,8 @@ describe('lib', () => {
           .toString();
 
         await runLibraryGeneratorWithOpts({
-          name: 'myLib2',
-          directory: 'myDir/myLib2',
+          name: 'my-lib2',
+          directory: 'my-dir/my-lib2',
           simpleName: true,
           routing: true,
           parent: 'myapp/src/app/app.module.ts',
@@ -919,8 +919,8 @@ describe('lib', () => {
           .toString();
 
         await runLibraryGeneratorWithOpts({
-          name: 'myLib3',
-          directory: 'myDir/myLib3',
+          name: 'my-lib3',
+          directory: 'my-dir/my-lib3',
           routing: true,
           parent: 'myapp/src/app/app.module.ts',
           simpleName: true,
@@ -983,8 +983,8 @@ describe('lib', () => {
 
         // ACT
         await runLibraryGeneratorWithOpts({
-          name: 'myLib',
-          directory: 'myDir/myLib',
+          name: 'my-lib',
+          directory: 'my-dir/my-lib',
           routing: true,
           parent: 'myapp/src/app/app.module.ts',
         });
@@ -1023,7 +1023,7 @@ describe('lib', () => {
     it('should update the package.json & tsconfig with the given import path', async () => {
       // ACT
       await runLibraryGeneratorWithOpts({
-        directory: 'myDir/myLib',
+        directory: 'my-dir/my-lib',
         publishable: true,
         importPath: '@myorg/lib',
       });
@@ -1048,7 +1048,7 @@ describe('lib', () => {
       // ACT & ASSERT
       await expect(
         runLibraryGeneratorWithOpts({
-          name: 'myLib2',
+          name: 'my-lib2',
           publishable: true,
           importPath: '@myorg/lib',
         })

--- a/packages/angular/src/generators/setup-mf/setup-mf.spec.ts
+++ b/packages/angular/src/generators/setup-mf/setup-mf.spec.ts
@@ -411,7 +411,7 @@ describe('Init MF', () => {
   it('should modify the associated cypress project to add the workaround correctly', async () => {
     // ARRANGE
     await generateTestApplication(tree, {
-      name: 'testApp',
+      name: 'test-app',
       routing: true,
     });
 

--- a/packages/devkit/src/generators/project-name-and-root-utils.spec.ts
+++ b/packages/devkit/src/generators/project-name-and-root-utils.spec.ts
@@ -46,12 +46,12 @@ describe('determineProjectNameAndRootOptions', () => {
       });
 
       expect(result).toStrictEqual({
-        projectName: 'lib-name',
+        projectName: 'libName',
         names: {
-          projectSimpleName: 'lib-name',
-          projectFileName: 'lib-name',
+          projectSimpleName: 'libName',
+          projectFileName: 'libName',
         },
-        importPath: '@proj/lib-name',
+        importPath: '@proj/libName',
         projectRoot: 'shared',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -67,13 +67,13 @@ describe('determineProjectNameAndRootOptions', () => {
       });
 
       expect(result).toStrictEqual({
-        projectName: 'lib-name',
+        projectName: 'libName',
         names: {
-          projectSimpleName: 'lib-name',
-          projectFileName: 'lib-name',
+          projectSimpleName: 'libName',
+          projectFileName: 'libName',
         },
-        importPath: '@proj/lib-name',
-        projectRoot: 'shared/lib-name',
+        importPath: '@proj/libName',
+        projectRoot: 'shared/libName',
         projectNameAndRootFormat: 'as-provided',
       });
     });
@@ -88,12 +88,12 @@ describe('determineProjectNameAndRootOptions', () => {
       });
 
       expect(result).toEqual({
-        projectName: '@scope/lib-name',
+        projectName: '@scope/libName',
         names: {
-          projectSimpleName: 'lib-name',
-          projectFileName: 'lib-name',
+          projectSimpleName: 'libName',
+          projectFileName: 'libName',
         },
-        importPath: '@scope/lib-name',
+        importPath: '@scope/libName',
         projectRoot: 'shared',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -110,10 +110,10 @@ describe('determineProjectNameAndRootOptions', () => {
       });
 
       expect(result).toEqual({
-        projectName: '@scope/lib-name',
+        projectName: '@scope/libName',
         names: {
-          projectSimpleName: 'lib-name',
-          projectFileName: 'lib-name',
+          projectSimpleName: 'libName',
+          projectFileName: 'libName',
         },
         importPath: '@custom-scope/lib-name',
         projectRoot: 'shared',
@@ -134,13 +134,13 @@ describe('determineProjectNameAndRootOptions', () => {
       });
 
       expect(result).toEqual({
-        projectName: '@scope/lib-name',
+        projectName: '@scope/libName',
         names: {
-          projectSimpleName: 'lib-name',
-          projectFileName: 'lib-name',
+          projectSimpleName: 'libName',
+          projectFileName: 'libName',
         },
-        importPath: '@scope/lib-name',
-        projectRoot: '@scope/lib-name',
+        importPath: '@scope/libName',
+        projectRoot: '@scope/libName',
         projectNameAndRootFormat: 'as-provided',
       });
     });
@@ -159,12 +159,12 @@ describe('determineProjectNameAndRootOptions', () => {
       });
 
       expect(result).toEqual({
-        projectName: 'lib-name',
+        projectName: 'libName',
         names: {
-          projectSimpleName: 'lib-name',
-          projectFileName: 'lib-name',
+          projectSimpleName: 'libName',
+          projectFileName: 'libName',
         },
-        importPath: '@proj/lib-name',
+        importPath: '@proj/libName',
         projectRoot: 'some/path/nested/lib-name',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -191,12 +191,12 @@ describe('determineProjectNameAndRootOptions', () => {
       });
 
       expect(result).toEqual({
-        projectName: 'lib-name',
+        projectName: 'libName',
         names: {
-          projectSimpleName: 'lib-name',
-          projectFileName: 'lib-name',
+          projectSimpleName: 'libName',
+          projectFileName: 'libName',
         },
-        importPath: '@proj/lib-name',
+        importPath: '@proj/libName',
         projectRoot: 'some/path/nested/lib-name',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -222,13 +222,13 @@ describe('determineProjectNameAndRootOptions', () => {
       });
 
       expect(result).toEqual({
-        projectName: 'lib-name',
+        projectName: 'libName',
         names: {
-          projectSimpleName: 'lib-name',
-          projectFileName: 'lib-name',
+          projectSimpleName: 'libName',
+          projectFileName: 'libName',
         },
-        importPath: '@proj/lib-name',
-        projectRoot: 'some/path/lib-name',
+        importPath: '@proj/libName',
+        projectRoot: 'some/path/libName',
         projectNameAndRootFormat: 'as-provided',
       });
 
@@ -243,7 +243,7 @@ describe('determineProjectNameAndRootOptions', () => {
     it('should not duplicate project name in the directory when directory is not provided and format is "as-provided"', async () => {
       // simulate running in a subdirectory
       const originalInitCwd = process.env.INIT_CWD;
-      process.env.INIT_CWD = join(workspaceRoot, 'some/path/lib-name');
+      process.env.INIT_CWD = join(workspaceRoot, 'some/path/libName');
 
       const result = await determineProjectNameAndRootOptions(tree, {
         name: 'libName',
@@ -253,13 +253,13 @@ describe('determineProjectNameAndRootOptions', () => {
       });
 
       expect(result).toEqual({
-        projectName: 'lib-name',
+        projectName: 'libName',
         names: {
-          projectSimpleName: 'lib-name',
-          projectFileName: 'lib-name',
+          projectSimpleName: 'libName',
+          projectFileName: 'libName',
         },
-        importPath: '@proj/lib-name',
-        projectRoot: 'some/path/lib-name',
+        importPath: '@proj/libName',
+        projectRoot: 'some/path/libName',
         projectNameAndRootFormat: 'as-provided',
       });
 
@@ -273,7 +273,7 @@ describe('determineProjectNameAndRootOptions', () => {
 
     it('should return the project name and directory as provided for root projects', async () => {
       updateJson(tree, 'package.json', (json) => {
-        json.name = 'lib-name';
+        json.name = 'libName';
         return json;
       });
 
@@ -286,12 +286,12 @@ describe('determineProjectNameAndRootOptions', () => {
       });
 
       expect(result).toEqual({
-        projectName: 'lib-name',
+        projectName: 'libName',
         names: {
-          projectSimpleName: 'lib-name',
-          projectFileName: 'lib-name',
+          projectSimpleName: 'libName',
+          projectFileName: 'libName',
         },
-        importPath: 'lib-name',
+        importPath: 'libName',
         projectRoot: '.',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -311,7 +311,7 @@ describe('determineProjectNameAndRootOptions', () => {
         callingGenerator: '',
       });
 
-      expect(result.importPath).toBe('@proj/lib-name');
+      expect(result.importPath).toBe('@proj/libName');
     });
 
     it('should throw when an invalid name is provided', async () => {
@@ -393,7 +393,7 @@ describe('determineProjectNameAndRootOptions', () => {
       const result = await determineProjectNameAndRootOptions(tree, {
         name: 'libName',
         projectType: 'library',
-        projectNameAndRootFormat: 'as-provided',
+        projectNameAndRootFormat: 'derived',
         rootProject: true,
         callingGenerator: '',
       });
@@ -441,9 +441,9 @@ describe('determineProjectNameAndRootOptions', () => {
       expect(promptCallOptions.choices).toStrictEqual([
         {
           message: `As provided:
-    Name: lib-name
+    Name: libName
     Root: shared`,
-          name: 'lib-name @ shared',
+          name: 'libName @ shared',
         },
         {
           message: `Derived:
@@ -471,12 +471,12 @@ describe('determineProjectNameAndRootOptions', () => {
 
       expect(promptSpy).not.toHaveBeenCalled();
       expect(result).toEqual({
-        projectName: '@scope/lib-name',
+        projectName: '@scope/libName',
         names: {
-          projectSimpleName: 'lib-name',
-          projectFileName: 'lib-name',
+          projectSimpleName: 'libName',
+          projectFileName: 'libName',
         },
-        importPath: '@scope/lib-name',
+        importPath: '@scope/libName',
         projectRoot: 'shared',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -491,7 +491,7 @@ describe('determineProjectNameAndRootOptions', () => {
       const promptSpy = jest.spyOn(enquirer, 'prompt');
 
       const result = await determineProjectNameAndRootOptions(tree, {
-        name: 'libName',
+        name: 'lib-name',
         projectType: 'library',
         callingGenerator: '',
       });
@@ -529,12 +529,12 @@ describe('determineProjectNameAndRootOptions', () => {
       });
 
       expect(result).toEqual({
-        projectName: 'lib-name',
+        projectName: 'libName',
         names: {
-          projectSimpleName: 'lib-name',
-          projectFileName: 'lib-name',
+          projectSimpleName: 'libName',
+          projectFileName: 'libName',
         },
-        importPath: '@proj/lib-name',
+        importPath: '@proj/libName',
         projectRoot: 'shared',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -550,13 +550,13 @@ describe('determineProjectNameAndRootOptions', () => {
       });
 
       expect(result).toStrictEqual({
-        projectName: 'lib-name',
+        projectName: 'libName',
         names: {
-          projectSimpleName: 'lib-name',
-          projectFileName: 'lib-name',
+          projectSimpleName: 'libName',
+          projectFileName: 'libName',
         },
-        importPath: '@proj/lib-name',
-        projectRoot: 'shared/lib-name',
+        importPath: '@proj/libName',
+        projectRoot: 'shared/libName',
         projectNameAndRootFormat: 'as-provided',
       });
     });
@@ -571,12 +571,12 @@ describe('determineProjectNameAndRootOptions', () => {
       });
 
       expect(result).toEqual({
-        projectName: '@scope/lib-name',
+        projectName: '@scope/libName',
         names: {
-          projectSimpleName: 'lib-name',
-          projectFileName: 'lib-name',
+          projectSimpleName: 'libName',
+          projectFileName: 'libName',
         },
-        importPath: '@scope/lib-name',
+        importPath: '@scope/libName',
         projectRoot: 'shared',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -593,10 +593,10 @@ describe('determineProjectNameAndRootOptions', () => {
       });
 
       expect(result).toEqual({
-        projectName: '@scope/lib-name',
+        projectName: '@scope/libName',
         names: {
-          projectSimpleName: 'lib-name',
-          projectFileName: 'lib-name',
+          projectSimpleName: 'libName',
+          projectFileName: 'libName',
         },
         importPath: '@custom-scope/lib-name',
         projectRoot: 'shared',
@@ -605,11 +605,6 @@ describe('determineProjectNameAndRootOptions', () => {
     });
 
     it('should return the directory as the project name when directory is not provided and format is "as-provided"', async () => {
-      updateJson(tree, 'package.json', (json) => {
-        json.name = 'lib-name';
-        return json;
-      });
-
       const result = await determineProjectNameAndRootOptions(tree, {
         name: '@scope/libName',
         projectType: 'library',
@@ -618,20 +613,20 @@ describe('determineProjectNameAndRootOptions', () => {
       });
 
       expect(result).toEqual({
-        projectName: '@scope/lib-name',
+        projectName: '@scope/libName',
         names: {
-          projectSimpleName: 'lib-name',
-          projectFileName: 'lib-name',
+          projectSimpleName: 'libName',
+          projectFileName: 'libName',
         },
-        importPath: '@scope/lib-name',
-        projectRoot: '@scope/lib-name',
+        importPath: '@scope/libName',
+        projectRoot: '@scope/libName',
         projectNameAndRootFormat: 'as-provided',
       });
     });
 
     it('should return the project name and directory as provided for root projects', async () => {
       updateJson(tree, 'package.json', (json) => {
-        json.name = 'lib-name';
+        json.name = 'libName';
         return json;
       });
 
@@ -644,12 +639,12 @@ describe('determineProjectNameAndRootOptions', () => {
       });
 
       expect(result).toEqual({
-        projectName: 'lib-name',
+        projectName: 'libName',
         names: {
-          projectSimpleName: 'lib-name',
-          projectFileName: 'lib-name',
+          projectSimpleName: 'libName',
+          projectFileName: 'libName',
         },
-        importPath: 'lib-name',
+        importPath: 'libName',
         projectRoot: '.',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -669,7 +664,7 @@ describe('determineProjectNameAndRootOptions', () => {
         callingGenerator: '',
       });
 
-      expect(result.importPath).toBe('@proj/lib-name');
+      expect(result.importPath).toBe('@proj/libName');
     });
 
     it('should throw when an invalid name is provided', async () => {
@@ -773,7 +768,7 @@ describe('determineProjectNameAndRootOptions', () => {
       const result = await determineProjectNameAndRootOptions(tree, {
         name: 'libName',
         projectType: 'library',
-        projectNameAndRootFormat: 'as-provided',
+        projectNameAndRootFormat: 'derived',
         rootProject: true,
         callingGenerator: '',
       });
@@ -800,9 +795,9 @@ describe('determineProjectNameAndRootOptions', () => {
       expect(promptCallOptions.choices).toStrictEqual([
         {
           message: `As provided:
-    Name: lib-name
+    Name: libName
     Root: shared`,
-          name: 'lib-name @ shared',
+          name: 'libName @ shared',
         },
         {
           message: `Derived:
@@ -830,12 +825,12 @@ describe('determineProjectNameAndRootOptions', () => {
 
       expect(promptSpy).not.toHaveBeenCalled();
       expect(result).toEqual({
-        projectName: '@scope/lib-name',
+        projectName: '@scope/libName',
         names: {
-          projectSimpleName: 'lib-name',
-          projectFileName: 'lib-name',
+          projectSimpleName: 'libName',
+          projectFileName: 'libName',
         },
-        importPath: '@scope/lib-name',
+        importPath: '@scope/libName',
         projectRoot: 'shared',
         projectNameAndRootFormat: 'as-provided',
       });

--- a/packages/devkit/src/generators/project-name-and-root-utils.ts
+++ b/packages/devkit/src/generators/project-name-and-root-utils.ts
@@ -184,12 +184,11 @@ function getProjectNameAndRootFormats(
   tree: Tree,
   options: ProjectGenerationOptions
 ): ProjectNameAndRootFormats {
-  const name = names(options.name).fileName;
   const directory = options.directory
     ? normalizePath(options.directory.replace(/^\.?\//, ''))
     : undefined;
 
-  const asProvidedProjectName = name;
+  const asProvidedProjectName = options.name;
 
   let asProvidedProjectDirectory: string;
   const relativeCwd = normalizePath(relative(workspaceRoot, getCwd())).replace(
@@ -199,12 +198,9 @@ function getProjectNameAndRootFormats(
   if (directory) {
     // append the directory to the current working directory if it doesn't start with it
     if (directory === relativeCwd || directory.startsWith(`${relativeCwd}/`)) {
-      asProvidedProjectDirectory = names(directory).fileName;
+      asProvidedProjectDirectory = directory;
     } else {
-      asProvidedProjectDirectory = joinPathFragments(
-        relativeCwd,
-        names(directory).fileName
-      );
+      asProvidedProjectDirectory = joinPathFragments(relativeCwd, directory);
     }
   } else if (options.rootProject) {
     asProvidedProjectDirectory = '.';
@@ -222,7 +218,7 @@ function getProjectNameAndRootFormats(
     }
   }
 
-  if (name.startsWith('@')) {
+  if (asProvidedProjectName.startsWith('@')) {
     const nameWithoutScope = asProvidedProjectName.split('/')[1];
     return {
       'as-provided': {
@@ -251,6 +247,7 @@ function getProjectNameAndRootFormats(
     }
   }
 
+  const name = names(options.name).fileName;
   let { projectDirectory, layoutDirectory } = getDirectories(
     tree,
     directory,

--- a/packages/expo/src/generators/application/application.spec.ts
+++ b/packages/expo/src/generators/application/application.spec.ts
@@ -18,7 +18,7 @@ describe('app', () => {
 
   it('should update workspace', async () => {
     await expoApplicationGenerator(appTree, {
-      name: 'myApp',
+      name: 'my-app',
       displayName: 'myApp',
       linter: Linter.EsLint,
       e2eTestRunner: 'none',
@@ -34,7 +34,7 @@ describe('app', () => {
 
   it('should update nx.json', async () => {
     await expoApplicationGenerator(appTree, {
-      name: 'myApp',
+      name: 'my-app',
       displayName: 'myApp',
       tags: 'one,two',
       linter: Linter.EsLint,
@@ -53,7 +53,7 @@ describe('app', () => {
 
   it('should generate files', async () => {
     await expoApplicationGenerator(appTree, {
-      name: 'myApp',
+      name: 'my-app',
       displayName: 'myApp',
       linter: Linter.EsLint,
       e2eTestRunner: 'none',
@@ -73,7 +73,7 @@ describe('app', () => {
 
   it('should generate js files', async () => {
     await expoApplicationGenerator(appTree, {
-      name: 'myApp',
+      name: 'my-app',
       displayName: 'myApp',
       linter: Linter.EsLint,
       e2eTestRunner: 'none',
@@ -94,8 +94,8 @@ describe('app', () => {
   describe('detox', () => {
     it('should create e2e app with directory', async () => {
       await expoApplicationGenerator(appTree, {
-        name: 'myApp',
-        directory: 'myDir',
+        name: 'my-app',
+        directory: 'my-dir',
         linter: Linter.EsLint,
         e2eTestRunner: 'detox',
         js: false,
@@ -157,7 +157,7 @@ describe('app', () => {
 
     it('should create e2e app without directory', async () => {
       await expoApplicationGenerator(appTree, {
-        name: 'myApp',
+        name: 'my-app',
         linter: Linter.EsLint,
         e2eTestRunner: 'detox',
         js: false,
@@ -218,7 +218,7 @@ describe('app', () => {
 
     it('should create e2e app with display name', async () => {
       await expoApplicationGenerator(appTree, {
-        name: 'myApp',
+        name: 'my-app',
         displayName: 'my app name',
         linter: Linter.EsLint,
         e2eTestRunner: 'detox',

--- a/packages/expo/src/generators/application/lib/normalize-options.spec.ts
+++ b/packages/expo/src/generators/application/lib/normalize-options.spec.ts
@@ -16,106 +16,112 @@ describe('Normalize Options', () => {
       name: 'my-app',
       linter: Linter.EsLint,
       e2eTestRunner: 'none',
-      install: false,
+      skipFormat: false,
+      js: true,
+      unitTestRunner: 'jest',
       projectNameAndRootFormat: 'as-provided',
     };
     const options = await normalizeOptions(appTree, schema);
     expect(options).toEqual({
-      androidProjectRoot: 'my-app/android',
       appProjectRoot: 'my-app',
       className: 'MyApp',
       displayName: 'MyApp',
-      iosProjectRoot: 'my-app/ios',
       lowerCaseName: 'myapp',
       name: 'my-app',
       parsedTags: [],
       projectName: 'my-app',
       projectNameAndRootFormat: 'as-provided',
       linter: Linter.EsLint,
-      entryFile: 'src/main.tsx',
       e2eTestRunner: 'none',
       unitTestRunner: 'jest',
-      install: false,
+      skipFormat: false,
+      js: true,
     });
   });
 
   it('should normalize options with name in camel case', async () => {
     const schema: Schema = {
       name: 'myApp',
+      linter: Linter.EsLint,
       e2eTestRunner: 'none',
-      install: false,
+      skipFormat: false,
+      js: true,
+      unitTestRunner: 'jest',
       projectNameAndRootFormat: 'as-provided',
     };
     const options = await normalizeOptions(appTree, schema);
     expect(options).toEqual({
-      androidProjectRoot: 'my-app/android',
-      appProjectRoot: 'my-app',
+      appProjectRoot: 'myApp',
       className: 'MyApp',
       displayName: 'MyApp',
-      iosProjectRoot: 'my-app/ios',
       lowerCaseName: 'myapp',
-      name: 'my-app',
+      name: 'myApp',
       parsedTags: [],
-      projectName: 'my-app',
+      projectName: 'myApp',
       projectNameAndRootFormat: 'as-provided',
-      entryFile: 'src/main.tsx',
+      linter: Linter.EsLint,
       e2eTestRunner: 'none',
+      skipFormat: false,
+      js: true,
       unitTestRunner: 'jest',
-      install: false,
     });
   });
 
   it('should normalize options with directory', async () => {
     const schema: Schema = {
       name: 'my-app',
-      directory: 'directory/my-app',
+      directory: 'directory',
+      linter: Linter.EsLint,
       e2eTestRunner: 'none',
-      install: false,
+      skipFormat: false,
+      js: true,
+      unitTestRunner: 'jest',
       projectNameAndRootFormat: 'as-provided',
     };
     const options = await normalizeOptions(appTree, schema);
     expect(options).toEqual({
-      androidProjectRoot: 'directory/my-app/android',
-      appProjectRoot: 'directory/my-app',
+      appProjectRoot: 'directory',
       className: 'MyApp',
       displayName: 'MyApp',
-      iosProjectRoot: 'directory/my-app/ios',
       lowerCaseName: 'myapp',
       name: 'my-app',
-      directory: 'directory/my-app',
+      directory: 'directory',
       parsedTags: [],
       projectName: 'my-app',
       projectNameAndRootFormat: 'as-provided',
-      entryFile: 'src/main.tsx',
       e2eTestRunner: 'none',
       unitTestRunner: 'jest',
-      install: false,
+      linter: Linter.EsLint,
+      skipFormat: false,
+      js: true,
     });
   });
 
   it('should normalize options that has directory in its name', async () => {
     const schema: Schema = {
       name: 'directory/my-app',
+      linter: Linter.EsLint,
       e2eTestRunner: 'none',
-      install: false,
+      skipFormat: false,
+      js: true,
+      unitTestRunner: 'jest',
       projectNameAndRootFormat: 'as-provided',
     };
     const options = await normalizeOptions(appTree, schema);
     expect(options).toEqual({
-      androidProjectRoot: 'directory/my-app/android',
       appProjectRoot: 'directory/my-app',
       className: 'DirectoryMyApp',
       displayName: 'DirectoryMyApp',
-      iosProjectRoot: 'directory/my-app/ios',
       lowerCaseName: 'directorymyapp',
       name: 'directory/my-app',
       parsedTags: [],
       projectName: 'directory/my-app',
       projectNameAndRootFormat: 'as-provided',
-      entryFile: 'src/main.tsx',
       e2eTestRunner: 'none',
       unitTestRunner: 'jest',
-      install: false,
+      linter: Linter.EsLint,
+      skipFormat: false,
+      js: true,
     });
   });
 
@@ -123,26 +129,28 @@ describe('Normalize Options', () => {
     const schema: Schema = {
       name: 'my-app',
       displayName: 'My App',
+      linter: Linter.EsLint,
       e2eTestRunner: 'none',
-      install: false,
+      skipFormat: false,
+      js: true,
+      unitTestRunner: 'jest',
       projectNameAndRootFormat: 'as-provided',
     };
     const options = await normalizeOptions(appTree, schema);
     expect(options).toEqual({
-      androidProjectRoot: 'my-app/android',
       appProjectRoot: 'my-app',
       className: 'MyApp',
       displayName: 'My App',
-      iosProjectRoot: 'my-app/ios',
       lowerCaseName: 'myapp',
       name: 'my-app',
       parsedTags: [],
       projectName: 'my-app',
       projectNameAndRootFormat: 'as-provided',
-      entryFile: 'src/main.tsx',
       e2eTestRunner: 'none',
       unitTestRunner: 'jest',
-      install: false,
+      linter: Linter.EsLint,
+      skipFormat: false,
+      js: true,
     });
   });
 });

--- a/packages/expo/src/generators/library/library.spec.ts
+++ b/packages/expo/src/generators/library/library.spec.ts
@@ -15,7 +15,7 @@ describe('lib', () => {
   let appTree: Tree;
 
   const defaultSchema: Schema = {
-    name: 'myLib',
+    name: 'my-lib',
     linter: Linter.EsLint,
     skipFormat: false,
     skipTsConfig: false,
@@ -109,7 +109,7 @@ describe('lib', () => {
       await expoLibraryGenerator(appTree, {
         ...defaultSchema,
         projectNameAndRootFormat: 'derived',
-        directory: 'myDir',
+        directory: 'my-dir',
         tags: 'one',
       });
 
@@ -123,8 +123,8 @@ describe('lib', () => {
 
       await expoLibraryGenerator(appTree, {
         ...defaultSchema,
-        name: 'myLib2',
-        directory: 'myDir',
+        name: 'my-lib2',
+        directory: 'my-dir',
         tags: 'one,two',
         projectNameAndRootFormat: 'derived',
       });
@@ -141,7 +141,7 @@ describe('lib', () => {
     it('should update project.json', async () => {
       await expoLibraryGenerator(appTree, {
         ...defaultSchema,
-        directory: 'myDir',
+        directory: 'my-dir',
         projectNameAndRootFormat: 'derived',
       });
       const projectConfiguration = readProjectConfiguration(
@@ -160,7 +160,7 @@ describe('lib', () => {
     it('should update tsconfig.base.json', async () => {
       await expoLibraryGenerator(appTree, {
         ...defaultSchema,
-        directory: 'myDir',
+        directory: 'my-dir',
       });
       const tsconfigJson = readJson(appTree, '/tsconfig.base.json');
       expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
@@ -172,7 +172,7 @@ describe('lib', () => {
     it('should create a local tsconfig.json', async () => {
       await expoLibraryGenerator(appTree, {
         ...defaultSchema,
-        directory: 'myDir',
+        directory: 'my-dir',
       });
 
       const tsconfigJson = readJson(appTree, 'my-dir/tsconfig.json');
@@ -251,7 +251,7 @@ describe('lib', () => {
       try {
         await expoLibraryGenerator(appTree, {
           ...defaultSchema,
-          directory: 'myDir',
+          directory: 'my-dir',
           publishable: true,
         });
       } catch (e) {
@@ -290,7 +290,7 @@ describe('lib', () => {
       await expoLibraryGenerator(appTree, {
         ...defaultSchema,
         publishable: true,
-        directory: 'myDir',
+        directory: 'my-dir',
         importPath: '@myorg/lib',
       });
       const packageJson = readJson(appTree, 'my-dir/package.json');
@@ -305,7 +305,7 @@ describe('lib', () => {
     it('should fail if the same importPath has already been used', async () => {
       await expoLibraryGenerator(appTree, {
         ...defaultSchema,
-        name: 'myLib1',
+        name: 'my-lib1',
         publishable: true,
         importPath: '@myorg/lib',
       });
@@ -313,7 +313,7 @@ describe('lib', () => {
       try {
         await expoLibraryGenerator(appTree, {
           ...defaultSchema,
-          name: 'myLib2',
+          name: 'my-lib2',
           publishable: true,
           importPath: '@myorg/lib',
         });

--- a/packages/express/src/generators/application/application.spec.ts
+++ b/packages/express/src/generators/application/application.spec.ts
@@ -12,7 +12,7 @@ describe('app', () => {
 
   it('should generate files', async () => {
     await applicationGenerator(appTree, {
-      name: 'myNodeApp',
+      name: 'my-node-app',
       projectNameAndRootFormat: 'as-provided',
     } as Schema);
 
@@ -79,7 +79,7 @@ describe('app', () => {
 
   it('should add types to the tsconfig.app.json', async () => {
     await applicationGenerator(appTree, {
-      name: 'myNodeApp',
+      name: 'my-node-app',
       projectNameAndRootFormat: 'as-provided',
     } as Schema);
     const tsconfig = readJson(appTree, 'my-node-app/tsconfig.app.json');
@@ -110,7 +110,7 @@ describe('app', () => {
   describe('--js flag', () => {
     it('should generate js files instead of ts files', async () => {
       await applicationGenerator(appTree, {
-        name: 'myNodeApp',
+        name: 'my-node-app',
         js: true,
         projectNameAndRootFormat: 'as-provided',
       } as Schema);

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -34,7 +34,7 @@ describe('lib', () => {
     it('should generate an empty ts lib using --config=npm-scripts', async () => {
       await libraryGenerator(tree, {
         ...defaultOptions,
-        name: 'myLib',
+        name: 'my-lib',
         config: 'npm-scripts',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -85,7 +85,7 @@ describe('lib', () => {
       it('should update tags', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           tags: 'one,two',
           projectNameAndRootFormat: 'as-provided',
         });
@@ -100,7 +100,7 @@ describe('lib', () => {
       it('should update root tsconfig.base.json', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           projectNameAndRootFormat: 'as-provided',
         });
         const tsconfigJson = readJson(tree, '/tsconfig.base.json');
@@ -114,7 +114,7 @@ describe('lib', () => {
 
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           projectNameAndRootFormat: 'as-provided',
         });
 
@@ -132,7 +132,7 @@ describe('lib', () => {
 
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           projectNameAndRootFormat: 'as-provided',
         });
         const tsconfigJson = readJson(tree, '/tsconfig.base.json');
@@ -144,7 +144,7 @@ describe('lib', () => {
       it('should create a local tsconfig.json', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           projectNameAndRootFormat: 'as-provided',
         });
         const tsconfigJson = readJson(tree, 'my-lib/tsconfig.json');
@@ -179,7 +179,7 @@ describe('lib', () => {
 
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           projectNameAndRootFormat: 'as-provided',
         });
 
@@ -192,7 +192,7 @@ describe('lib', () => {
       it('should update tags', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           directory: 'my-dir/my-lib',
           tags: 'one',
           projectNameAndRootFormat: 'as-provided',
@@ -206,7 +206,7 @@ describe('lib', () => {
 
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib2',
+          name: 'my-lib2',
           directory: 'my-dir/my-lib-2',
           tags: 'one,two',
           projectNameAndRootFormat: 'as-provided',
@@ -225,7 +225,7 @@ describe('lib', () => {
       it('should generate files', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           directory: 'my-dir/my-lib',
           projectNameAndRootFormat: 'as-provided',
         });
@@ -243,7 +243,7 @@ describe('lib', () => {
       it('should update project configuration', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           directory: 'my-dir/my-lib',
           config: 'workspace',
           projectNameAndRootFormat: 'as-provided',
@@ -257,7 +257,7 @@ describe('lib', () => {
       it('should update root tsconfig.base.json', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           directory: 'my-dir/my-lib',
           projectNameAndRootFormat: 'as-provided',
         });
@@ -273,7 +273,7 @@ describe('lib', () => {
 
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           directory: 'my-dir/my-lib',
           projectNameAndRootFormat: 'as-provided',
         });
@@ -288,7 +288,7 @@ describe('lib', () => {
       it('should create a local tsconfig.json', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           directory: 'my-dir/my-lib',
           projectNameAndRootFormat: 'as-provided',
         });
@@ -307,7 +307,7 @@ describe('lib', () => {
       it('should extend from root tsconfig.base.json', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           directory: 'my-dir/my-lib',
           projectNameAndRootFormat: 'as-provided',
         });
@@ -321,7 +321,7 @@ describe('lib', () => {
 
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           directory: 'my-dir/my-lib',
           projectNameAndRootFormat: 'as-provided',
         });
@@ -335,7 +335,7 @@ describe('lib', () => {
       it('should update the projects tsconfig with strict false', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           strict: false,
           projectNameAndRootFormat: 'as-provided',
         });
@@ -362,7 +362,7 @@ describe('lib', () => {
       it('should default to strict true', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           projectNameAndRootFormat: 'as-provided',
         });
         const tsconfigJson = readJson(tree, '/my-lib/tsconfig.json');
@@ -382,7 +382,7 @@ describe('lib', () => {
       it('should update the tsconfig with the given import path', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           directory: 'my-dir/my-lib',
           importPath: '@myorg/lib',
           projectNameAndRootFormat: 'as-provided',
@@ -419,7 +419,7 @@ describe('lib', () => {
       it('should provide a default import path using npm scope', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           projectNameAndRootFormat: 'as-provided',
         });
 
@@ -437,7 +437,7 @@ describe('lib', () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
           rootProject: true,
-          name: 'myLib',
+          name: 'my-lib',
           projectNameAndRootFormat: 'as-provided',
         });
 
@@ -450,7 +450,7 @@ describe('lib', () => {
       it('should generate files with upper case names', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           pascalCaseFiles: true,
           projectNameAndRootFormat: 'as-provided',
         });
@@ -461,7 +461,7 @@ describe('lib', () => {
       it('should generate files with upper case names for nested libs as well', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           directory: 'my-dir/my-lib',
           pascalCaseFiles: true,
           projectNameAndRootFormat: 'as-provided',
@@ -476,7 +476,7 @@ describe('lib', () => {
     it('should add eslint dependencies', async () => {
       await libraryGenerator(tree, {
         ...defaultOptions,
-        name: 'myLib',
+        name: 'my-lib',
         projectNameAndRootFormat: 'as-provided',
       });
 
@@ -490,7 +490,7 @@ describe('lib', () => {
       it('should update configuration', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           projectNameAndRootFormat: 'as-provided',
         });
         expect(readProjectConfiguration(tree, 'my-lib').targets.lint).toEqual({
@@ -505,7 +505,7 @@ describe('lib', () => {
       it('should create a local .eslintrc.json', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           projectNameAndRootFormat: 'as-provided',
         });
 
@@ -561,7 +561,7 @@ describe('lib', () => {
       it('should update configuration', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           directory: 'my-dir/my-lib',
           projectNameAndRootFormat: 'as-provided',
         });
@@ -581,7 +581,7 @@ describe('lib', () => {
       it('should create a local .eslintrc.json', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           directory: 'my-dir/my-lib',
           projectNameAndRootFormat: 'as-provided',
         });
@@ -638,7 +638,7 @@ describe('lib', () => {
       it('should generate js files instead of ts files', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           js: true,
           projectNameAndRootFormat: 'as-provided',
         });
@@ -651,7 +651,7 @@ describe('lib', () => {
       it('should update tsconfig.json with compilerOptions.allowJs: true', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           js: true,
           projectNameAndRootFormat: 'as-provided',
         });
@@ -663,7 +663,7 @@ describe('lib', () => {
       it('should update tsconfig.lib.json include with src/**/*.js glob', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           js: true,
           projectNameAndRootFormat: 'as-provided',
         });
@@ -676,7 +676,7 @@ describe('lib', () => {
       it('should update root tsconfig.json with a js file path', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           js: true,
           projectNameAndRootFormat: 'as-provided',
         });
@@ -689,7 +689,7 @@ describe('lib', () => {
       it('should generate js files for nested libs as well', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           directory: 'my-dir/my-lib',
           js: true,
           projectNameAndRootFormat: 'as-provided',
@@ -706,7 +706,7 @@ describe('lib', () => {
       it('should configure the project for linting js files', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           directory: 'my-dir/my-lib',
           js: true,
           projectNameAndRootFormat: 'as-provided',
@@ -768,7 +768,7 @@ describe('lib', () => {
     it('should generate test configuration', async () => {
       await libraryGenerator(tree, {
         ...defaultOptions,
-        name: 'myLib',
+        name: 'my-lib',
         unitTestRunner: 'jest',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -802,7 +802,7 @@ describe('lib', () => {
     it('should generate test configuration with swc and js', async () => {
       await libraryGenerator(tree, {
         ...defaultOptions,
-        name: 'myLib',
+        name: 'my-lib',
         unitTestRunner: 'jest',
         bundler: 'swc',
         js: true,
@@ -826,7 +826,7 @@ describe('lib', () => {
       it('should NOT generate the build target if bundler is none', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           bundler: 'none',
           projectNameAndRootFormat: 'as-provided',
         });
@@ -838,7 +838,7 @@ describe('lib', () => {
       it('should still generate the build target if bundler is undefined', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           projectNameAndRootFormat: 'as-provided',
         });
 
@@ -849,7 +849,7 @@ describe('lib', () => {
       it('should generate the build target', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           bundler: 'tsc',
           projectNameAndRootFormat: 'as-provided',
         });
@@ -870,7 +870,7 @@ describe('lib', () => {
       it('should generate the build target for swc', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           bundler: 'swc',
           projectNameAndRootFormat: 'as-provided',
         });
@@ -891,7 +891,7 @@ describe('lib', () => {
       it('should generate swcrc for swc', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           bundler: 'swc',
           projectNameAndRootFormat: 'as-provided',
         });
@@ -902,7 +902,7 @@ describe('lib', () => {
       it('should setup jest project using swc', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           bundler: 'swc',
           projectNameAndRootFormat: 'as-provided',
         });
@@ -914,7 +914,7 @@ describe('lib', () => {
       it('should generate a package.json file', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           bundler: 'tsc',
           projectNameAndRootFormat: 'as-provided',
         });
@@ -927,7 +927,7 @@ describe('lib', () => {
       it('should generate the build target', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           buildable: true,
           compiler: 'tsc',
           projectNameAndRootFormat: 'as-provided',
@@ -949,7 +949,7 @@ describe('lib', () => {
       it('should generate the build target for swc', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           buildable: true,
           compiler: 'swc',
           projectNameAndRootFormat: 'as-provided',
@@ -971,7 +971,7 @@ describe('lib', () => {
       it('should generate swcrc for swc', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           buildable: true,
           compiler: 'swc',
           projectNameAndRootFormat: 'as-provided',
@@ -983,7 +983,7 @@ describe('lib', () => {
       it('should setup jest project using swc', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           buildable: true,
           compiler: 'swc',
           projectNameAndRootFormat: 'as-provided',
@@ -996,7 +996,7 @@ describe('lib', () => {
       it('should generate a package.json file', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           buildable: true,
           compiler: 'tsc',
           projectNameAndRootFormat: 'as-provided',
@@ -1010,7 +1010,7 @@ describe('lib', () => {
       it('should generate correct options for build', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           bundler: 'rollup',
           projectNameAndRootFormat: 'as-provided',
         });
@@ -1024,7 +1024,7 @@ describe('lib', () => {
       it('should always set compiler to swc if bundler is rollup', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           bundler: 'rollup',
           projectNameAndRootFormat: 'as-provided',
         });
@@ -1038,7 +1038,7 @@ describe('lib', () => {
       it('should generate the build target', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           publishable: true,
           importPath: '@proj/my-lib',
           bundler: 'tsc',
@@ -1061,7 +1061,7 @@ describe('lib', () => {
       it('should generate the publish target', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           publishable: true,
           importPath: '@proj/my-lib',
           bundler: 'tsc',
@@ -1079,7 +1079,7 @@ describe('lib', () => {
       it('should generate publish script', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           publishable: true,
           importPath: '@proj/my-lib',
           bundler: 'tsc',
@@ -1094,7 +1094,7 @@ describe('lib', () => {
       it('should generate a .babelrc when flag is set to true', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           includeBabelRc: true,
           projectNameAndRootFormat: 'as-provided',
         });
@@ -1105,7 +1105,7 @@ describe('lib', () => {
       it('should not generate a .babelrc when flag is set to false', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           includeBabelRc: false,
           projectNameAndRootFormat: 'as-provided',
         });
@@ -1116,7 +1116,7 @@ describe('lib', () => {
       it('should not generate a .babelrc when bundler is swc (even if flag is set to true)', async () => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           bundler: 'swc',
           includeBabelRc: true,
           projectNameAndRootFormat: 'as-provided',
@@ -1133,7 +1133,7 @@ describe('lib', () => {
 
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           includeBabelRc: true,
           projectNameAndRootFormat: 'as-provided',
         });
@@ -1166,7 +1166,7 @@ describe('lib', () => {
 
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           includeBabelRc: undefined,
           projectNameAndRootFormat: 'as-provided',
         });
@@ -1180,7 +1180,7 @@ describe('lib', () => {
     it('should add build and test targets with vite and vitest', async () => {
       await libraryGenerator(tree, {
         ...defaultOptions,
-        name: 'myLib',
+        name: 'my-lib',
         bundler: 'vite',
         unitTestRunner: undefined,
         projectNameAndRootFormat: 'as-provided',
@@ -1217,7 +1217,7 @@ describe('lib', () => {
       async ({ unitTestRunner, executor }) => {
         await libraryGenerator(tree, {
           ...defaultOptions,
-          name: 'myLib',
+          name: 'my-lib',
           bundler: 'vite',
           unitTestRunner,
           projectNameAndRootFormat: 'as-provided',
@@ -1233,7 +1233,7 @@ describe('lib', () => {
     it('should add build with esbuild', async () => {
       await libraryGenerator(tree, {
         ...defaultOptions,
-        name: 'myLib',
+        name: 'my-lib',
         bundler: 'esbuild',
         unitTestRunner: 'none',
         projectNameAndRootFormat: 'as-provided',
@@ -1262,7 +1262,7 @@ describe('lib', () => {
     it('should add build with rollup', async () => {
       await libraryGenerator(tree, {
         ...defaultOptions,
-        name: 'myLib',
+        name: 'my-lib',
         bundler: 'rollup',
         unitTestRunner: 'none',
         projectNameAndRootFormat: 'as-provided',
@@ -1291,7 +1291,7 @@ describe('lib', () => {
     it('should generate a README.md when minimal is set to false', async () => {
       await libraryGenerator(tree, {
         ...defaultOptions,
-        name: 'myLib',
+        name: 'my-lib',
         minimal: false,
         projectNameAndRootFormat: 'as-provided',
       });
@@ -1302,7 +1302,7 @@ describe('lib', () => {
     it('should not generate a README.md when minimal is set to true', async () => {
       await libraryGenerator(tree, {
         ...defaultOptions,
-        name: 'myLib',
+        name: 'my-lib',
         minimal: true,
         projectNameAndRootFormat: 'as-provided',
       });
@@ -1313,7 +1313,7 @@ describe('lib', () => {
     it('should generate a README.md and add it to the build assets when buildable is true and minimal is false', async () => {
       await libraryGenerator(tree, {
         ...defaultOptions,
-        name: 'myLib',
+        name: 'my-lib',
         bundler: 'tsc',
         minimal: false,
         projectNameAndRootFormat: 'as-provided',
@@ -1330,7 +1330,7 @@ describe('lib', () => {
     it('should not generate a README.md when both bundler and minimal are set', async () => {
       await libraryGenerator(tree, {
         ...defaultOptions,
-        name: 'myLib',
+        name: 'my-lib',
         bundler: 'tsc',
         minimal: true,
         projectNameAndRootFormat: 'as-provided',
@@ -1347,7 +1347,7 @@ describe('lib', () => {
     it('should generate a simple name', async () => {
       await libraryGenerator(tree, {
         ...defaultOptions,
-        name: 'myLib',
+        name: 'my-lib',
         simpleName: true,
         directory: 'web/my-lib',
         projectNameAndRootFormat: 'as-provided',

--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -5,7 +5,7 @@ import { applicationGenerator } from './application';
 
 describe('application generator', () => {
   let tree: Tree;
-  const appName = 'myNodeApp';
+  const appName = 'my-node-app';
   const appDirectory = 'my-node-app';
 
   beforeEach(() => {

--- a/packages/nest/src/generators/library/library.spec.ts
+++ b/packages/nest/src/generators/library/library.spec.ts
@@ -15,7 +15,7 @@ describe('lib', () => {
   describe('not nested', () => {
     it('should update project configuration', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         projectNameAndRootFormat: 'as-provided',
       });
 
@@ -47,7 +47,7 @@ describe('lib', () => {
 
     it('should include a controller', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         controller: true,
         projectNameAndRootFormat: 'as-provided',
       });
@@ -57,7 +57,7 @@ describe('lib', () => {
 
     it('should include a service', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         service: true,
         projectNameAndRootFormat: 'as-provided',
       });
@@ -67,7 +67,7 @@ describe('lib', () => {
 
     it('should add the @Global decorator', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         global: true,
         projectNameAndRootFormat: 'as-provided',
       });
@@ -79,7 +79,7 @@ describe('lib', () => {
 
     it('should remove the default file from @nx/node:lib', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         global: true,
         projectNameAndRootFormat: 'as-provided',
       });
@@ -90,7 +90,7 @@ describe('lib', () => {
 
     it('should provide the controller and service', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         controller: true,
         service: true,
         projectNameAndRootFormat: 'as-provided',
@@ -107,7 +107,7 @@ describe('lib', () => {
 
     it('should update tags', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         tags: 'one,two',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -122,7 +122,7 @@ describe('lib', () => {
 
     it('should update root tsconfig.json', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         projectNameAndRootFormat: 'as-provided',
       });
 
@@ -134,7 +134,7 @@ describe('lib', () => {
 
     it('should create a local tsconfig.json', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         projectNameAndRootFormat: 'as-provided',
       });
 
@@ -144,7 +144,7 @@ describe('lib', () => {
 
     it('should extend the local tsconfig.json with tsconfig.spec.json', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         projectNameAndRootFormat: 'as-provided',
       });
 
@@ -154,7 +154,7 @@ describe('lib', () => {
 
     it('should extend the local tsconfig.json with tsconfig.lib.json', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         projectNameAndRootFormat: 'as-provided',
       });
 
@@ -169,7 +169,7 @@ describe('lib', () => {
 
     it('should generate files', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         projectNameAndRootFormat: 'as-provided',
       });
 
@@ -183,7 +183,7 @@ describe('lib', () => {
   describe('nested', () => {
     it('should update tags', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         directory: 'my-dir/my-lib',
         tags: 'one,two',
         projectNameAndRootFormat: 'as-provided',
@@ -199,7 +199,7 @@ describe('lib', () => {
 
     it('should generate files', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         directory: 'my-dir/my-lib',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -211,7 +211,7 @@ describe('lib', () => {
 
     it('should update workspace.json', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         directory: 'my-dir/my-lib',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -229,7 +229,7 @@ describe('lib', () => {
 
     it('should update tsconfig.json', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         directory: 'my-dir/my-lib',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -243,7 +243,7 @@ describe('lib', () => {
 
     it('should create a local tsconfig.json', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         directory: 'my-dir/my-lib',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -255,7 +255,7 @@ describe('lib', () => {
   describe('--strict', () => {
     it('should update the projects tsconfig with strict true', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         strict: true,
         projectNameAndRootFormat: 'as-provided',
       });
@@ -274,7 +274,7 @@ describe('lib', () => {
   describe('--unit-test-runner none', () => {
     it('should not generate test configuration', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         unitTestRunner: 'none',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -294,7 +294,7 @@ describe('lib', () => {
       const importPath = `@proj/myLib`;
 
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         publishable: true,
         importPath,
         projectNameAndRootFormat: 'as-provided',
@@ -308,7 +308,7 @@ describe('lib', () => {
   describe('compiler options target', () => {
     it('should set target to es6 in tsconfig.lib.json by default', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         projectNameAndRootFormat: 'as-provided',
       });
 
@@ -318,7 +318,7 @@ describe('lib', () => {
 
     it('should set target to es2021 in tsconfig.lib.json', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         target: 'es2021',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -333,7 +333,7 @@ describe('lib', () => {
       jest.spyOn(devkit, 'formatFiles');
 
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         projectNameAndRootFormat: 'as-provided',
       });
 
@@ -344,7 +344,7 @@ describe('lib', () => {
       jest.spyOn(devkit, 'formatFiles');
 
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         skipFormat: true,
         projectNameAndRootFormat: 'as-provided',
       });
@@ -356,7 +356,7 @@ describe('lib', () => {
   describe('--testEnvironment', () => {
     it('should set target jest testEnvironment to node by default', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         projectNameAndRootFormat: 'as-provided',
       });
 
@@ -365,7 +365,7 @@ describe('lib', () => {
 
     it('should set target jest testEnvironment to jsdom', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         testEnvironment: 'jsdom',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -377,7 +377,7 @@ describe('lib', () => {
   describe('--simpleName', () => {
     it('should generate a library with a simple name', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         simpleName: true,
         directory: 'api/my-lib',
         service: true,

--- a/packages/next/src/generators/library/library.spec.ts
+++ b/packages/next/src/generators/library/library.spec.ts
@@ -28,7 +28,7 @@ describe('next library', () => {
 
     await libraryGenerator(appTree, {
       ...baseOptions,
-      name: 'myLib',
+      name: 'my-lib',
     });
     const tsconfigTypes = readJson(appTree, 'my-lib/tsconfig.lib.json')
       .compilerOptions.types;
@@ -52,11 +52,11 @@ describe('next library', () => {
 
     await libraryGenerator(appTree, {
       ...baseOptions,
-      name: 'myLib',
+      name: 'my-lib',
     });
     await libraryGenerator(appTree, {
       ...baseOptions,
-      name: 'myLib2',
+      name: 'my-lib2',
       style: '@emotion/styled',
     });
 
@@ -72,7 +72,7 @@ describe('next library', () => {
     const appTree = createTreeWithEmptyWorkspace();
 
     await libraryGenerator(appTree, {
-      name: 'myLib',
+      name: 'my-lib',
       linter: Linter.EsLint,
       skipFormat: false,
       skipTsConfig: false,
@@ -100,7 +100,7 @@ describe('next library', () => {
     const appTree = createTreeWithEmptyWorkspace();
 
     await libraryGenerator(appTree, {
-      name: 'myLib',
+      name: 'my-lib',
       linter: Linter.EsLint,
       skipFormat: false,
       skipTsConfig: false,

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -24,7 +24,7 @@ describe('app', () => {
   describe('not nested', () => {
     it('should update project config', async () => {
       await applicationGenerator(tree, {
-        name: 'myNodeApp',
+        name: 'my-node-app',
         bundler: 'webpack',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -82,7 +82,7 @@ describe('app', () => {
 
     it('should update tags', async () => {
       await applicationGenerator(tree, {
-        name: 'myNodeApp',
+        name: 'my-node-app',
         tags: 'one,two',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -96,7 +96,7 @@ describe('app', () => {
 
     it('should generate files', async () => {
       await applicationGenerator(tree, {
-        name: 'myNodeApp',
+        name: 'my-node-app',
         projectNameAndRootFormat: 'as-provided',
       });
       expect(tree.exists(`my-node-app/jest.config.ts`)).toBeTruthy();
@@ -172,7 +172,7 @@ describe('app', () => {
       tree.rename('tsconfig.base.json', 'tsconfig.json');
 
       await applicationGenerator(tree, {
-        name: 'myNodeApp',
+        name: 'my-node-app',
         projectNameAndRootFormat: 'as-provided',
       });
 
@@ -184,7 +184,7 @@ describe('app', () => {
   describe('nested', () => {
     it('should update project config', async () => {
       await applicationGenerator(tree, {
-        name: 'myNodeApp',
+        name: 'my-node-app',
         directory: 'my-dir/my-node-app',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -207,7 +207,7 @@ describe('app', () => {
 
     it('should update tags', async () => {
       await applicationGenerator(tree, {
-        name: 'myNodeApp',
+        name: 'my-node-app',
         directory: 'myDir',
         tags: 'one,two',
       });
@@ -226,7 +226,7 @@ describe('app', () => {
         expect(lookupFn(config)).toEqual(expectedValue);
       };
       await applicationGenerator(tree, {
-        name: 'myNodeApp',
+        name: 'my-node-app',
         directory: 'myDir',
       });
 
@@ -271,7 +271,7 @@ describe('app', () => {
   describe('--unit-test-runner none', () => {
     it('should not generate test configuration', async () => {
       await applicationGenerator(tree, {
-        name: 'myNodeApp',
+        name: 'my-node-app',
         unitTestRunner: 'none',
       });
       expect(tree.exists('jest.config.ts')).toBeFalsy();
@@ -302,7 +302,7 @@ describe('app', () => {
       await angularApplicationGenerator(tree, { name: 'my-frontend' });
 
       await applicationGenerator(tree, {
-        name: 'myNodeApp',
+        name: 'my-node-app',
         frontendProject: 'my-frontend',
       });
 
@@ -337,7 +337,7 @@ describe('app', () => {
       await angularApplicationGenerator(tree, { name: 'myFrontend' });
 
       await applicationGenerator(tree, {
-        name: 'myNodeApp',
+        name: 'my-node-app',
         frontendProject: 'myFrontend',
       });
 
@@ -351,7 +351,7 @@ describe('app', () => {
   describe('--swcJest', () => {
     it('should use @swc/jest for jest', async () => {
       await applicationGenerator(tree, {
-        name: 'myNodeApp',
+        name: 'my-node-app',
         tags: 'one,two',
         swcJest: true,
       } as Schema);
@@ -377,7 +377,7 @@ describe('app', () => {
   describe('--babelJest (deprecated)', () => {
     it('should use babel for jest', async () => {
       await applicationGenerator(tree, {
-        name: 'myNodeApp',
+        name: 'my-node-app',
         tags: 'one,two',
         babelJest: true,
       } as Schema);
@@ -403,7 +403,7 @@ describe('app', () => {
   describe('--js flag', () => {
     it('should generate js files instead of ts files', async () => {
       await applicationGenerator(tree, {
-        name: 'myNodeApp',
+        name: 'my-node-app',
         js: true,
       } as Schema);
 
@@ -429,7 +429,7 @@ describe('app', () => {
 
     it('should add project config', async () => {
       await applicationGenerator(tree, {
-        name: 'myNodeApp',
+        name: 'my-node-app',
         js: true,
       } as Schema);
       const project = readProjectConfiguration(tree, 'my-node-app');
@@ -440,7 +440,7 @@ describe('app', () => {
 
     it('should generate js files for nested libs as well', async () => {
       await applicationGenerator(tree, {
-        name: 'myNodeApp',
+        name: 'my-node-app',
         directory: 'myDir',
         js: true,
       } as Schema);
@@ -452,7 +452,7 @@ describe('app', () => {
   describe('--pascalCaseFiles', () => {
     it(`should notify that this flag doesn't do anything`, async () => {
       await applicationGenerator(tree, {
-        name: 'myNodeApp',
+        name: 'my-node-app',
         pascalCaseFiles: true,
       } as Schema);
 
@@ -465,7 +465,7 @@ describe('app', () => {
     it('should format files by default', async () => {
       jest.spyOn(devkit, 'formatFiles');
 
-      await applicationGenerator(tree, { name: 'myNodeApp' });
+      await applicationGenerator(tree, { name: 'my-node-app' });
 
       expect(devkit.formatFiles).toHaveBeenCalled();
     });
@@ -473,7 +473,10 @@ describe('app', () => {
     it('should not format files when --skipFormat=true', async () => {
       jest.spyOn(devkit, 'formatFiles');
 
-      await applicationGenerator(tree, { name: 'myNodeApp', skipFormat: true });
+      await applicationGenerator(tree, {
+        name: 'my-node-app',
+        skipFormat: true,
+      });
 
       expect(devkit.formatFiles).not.toHaveBeenCalled();
     });

--- a/packages/node/src/generators/library/library.spec.ts
+++ b/packages/node/src/generators/library/library.spec.ts
@@ -10,7 +10,7 @@ import { Schema } from './schema.d';
 import { libraryGenerator } from './library';
 
 const baseLibraryConfig = {
-  name: 'myLib',
+  name: 'my-lib',
   compiler: 'tsc' as const,
   projectNameAndRootFormat: 'as-provided' as const,
 };
@@ -196,7 +196,7 @@ describe('lib', () => {
 
       await libraryGenerator(tree, {
         ...baseLibraryConfig,
-        name: 'myLib2',
+        name: 'my-lib2',
         directory: 'my-dir/my-lib-2',
         tags: 'one,two',
       });
@@ -423,7 +423,7 @@ describe('lib', () => {
     it('should fail if the same importPath has already been used', async () => {
       await libraryGenerator(tree, {
         ...baseLibraryConfig,
-        name: 'myLib1',
+        name: 'my-lib1',
         publishable: true,
         importPath: '@myorg/lib',
       });
@@ -431,7 +431,7 @@ describe('lib', () => {
       try {
         await libraryGenerator(tree, {
           ...baseLibraryConfig,
-          name: 'myLib2',
+          name: 'my-lib2',
           publishable: true,
           importPath: '@myorg/lib',
         });
@@ -448,7 +448,7 @@ describe('lib', () => {
   describe(`--babelJest`, () => {
     it('should use babel for jest', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         babelJest: true,
       } as Schema);
 
@@ -472,7 +472,7 @@ describe('lib', () => {
   describe('--js flag', () => {
     it('should generate js files instead of ts files', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         js: true,
       } as Schema);
 
@@ -499,7 +499,7 @@ describe('lib', () => {
     });
 
     it('should update root tsconfig.json with a js file path', async () => {
-      await libraryGenerator(tree, { name: 'myLib', js: true } as Schema);
+      await libraryGenerator(tree, { name: 'my-lib', js: true } as Schema);
       const tsconfigJson = readJson(tree, '/tsconfig.base.json');
       expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
         'my-lib/src/index.js',
@@ -508,7 +508,7 @@ describe('lib', () => {
 
     it('should update architect builder when --buildable', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         buildable: true,
         js: true,
       } as Schema);
@@ -523,7 +523,7 @@ describe('lib', () => {
 
     it('should generate js files for nested libs as well', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         directory: 'my-dir/my-lib',
         js: true,
         projectNameAndRootFormat: 'as-provided',
@@ -538,7 +538,7 @@ describe('lib', () => {
   describe('--pascalCaseFiles', () => {
     it('should generate files with upper case names', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         pascalCaseFiles: true,
         projectNameAndRootFormat: 'as-provided',
       } as Schema);
@@ -550,7 +550,7 @@ describe('lib', () => {
 
     it('should generate files with upper case names for nested libs as well', async () => {
       await libraryGenerator(tree, {
-        name: 'myLib',
+        name: 'my-lib',
         directory: 'my-dir/my-lib',
         pascalCaseFiles: true,
         projectNameAndRootFormat: 'as-provided',

--- a/packages/react-native/src/generators/application/application.spec.ts
+++ b/packages/react-native/src/generators/application/application.spec.ts
@@ -18,7 +18,7 @@ describe('app', () => {
 
   it('should update configuration', async () => {
     await reactNativeApplicationGenerator(appTree, {
-      name: 'myApp',
+      name: 'my-app',
       displayName: 'myApp',
       linter: Linter.EsLint,
       e2eTestRunner: 'none',
@@ -32,7 +32,7 @@ describe('app', () => {
 
   it('should update nx.json', async () => {
     await reactNativeApplicationGenerator(appTree, {
-      name: 'myApp',
+      name: 'my-app',
       displayName: 'myApp',
       tags: 'one,two',
       linter: Linter.EsLint,
@@ -49,7 +49,7 @@ describe('app', () => {
 
   it('should generate files', async () => {
     await reactNativeApplicationGenerator(appTree, {
-      name: 'myApp',
+      name: 'my-app',
       displayName: 'myApp',
       linter: Linter.EsLint,
       e2eTestRunner: 'none',
@@ -82,7 +82,7 @@ describe('app', () => {
 
   it('should generate targets', async () => {
     await reactNativeApplicationGenerator(appTree, {
-      name: 'myApp',
+      name: 'my-app',
       displayName: 'myApp',
       linter: Linter.EsLint,
       e2eTestRunner: 'none',
@@ -97,7 +97,7 @@ describe('app', () => {
     appTree.rename('tsconfig.base.json', 'tsconfig.json');
 
     await reactNativeApplicationGenerator(appTree, {
-      name: 'myApp',
+      name: 'my-app',
       displayName: 'myApp',
       linter: Linter.EsLint,
       e2eTestRunner: 'none',
@@ -112,8 +112,8 @@ describe('app', () => {
   describe('detox', () => {
     it('should create e2e app with directory', async () => {
       await reactNativeApplicationGenerator(appTree, {
-        name: 'myApp',
-        directory: 'myDir',
+        name: 'my-app',
+        directory: 'my-dir',
         linter: Linter.EsLint,
         e2eTestRunner: 'detox',
         install: false,
@@ -163,7 +163,7 @@ describe('app', () => {
 
     it('should create e2e app without directory', async () => {
       await reactNativeApplicationGenerator(appTree, {
-        name: 'myApp',
+        name: 'my-app',
         linter: Linter.EsLint,
         e2eTestRunner: 'detox',
         install: false,
@@ -216,7 +216,7 @@ describe('app', () => {
       const packageJsonBefore = readJson(appTree, 'package.json');
 
       await reactNativeApplicationGenerator(appTree, {
-        name: 'myApp',
+        name: 'my-app',
         displayName: 'myApp',
         linter: Linter.EsLint,
         e2eTestRunner: 'none',

--- a/packages/react-native/src/generators/application/lib/normalize-options.spec.ts
+++ b/packages/react-native/src/generators/application/lib/normalize-options.spec.ts
@@ -16,112 +16,106 @@ describe('Normalize Options', () => {
       name: 'my-app',
       linter: Linter.EsLint,
       e2eTestRunner: 'none',
-      skipFormat: false,
-      js: true,
-      unitTestRunner: 'jest',
+      install: false,
       projectNameAndRootFormat: 'as-provided',
     };
     const options = await normalizeOptions(appTree, schema);
     expect(options).toEqual({
+      androidProjectRoot: 'my-app/android',
       appProjectRoot: 'my-app',
       className: 'MyApp',
       displayName: 'MyApp',
+      iosProjectRoot: 'my-app/ios',
       lowerCaseName: 'myapp',
       name: 'my-app',
       parsedTags: [],
       projectName: 'my-app',
       projectNameAndRootFormat: 'as-provided',
       linter: Linter.EsLint,
+      entryFile: 'src/main.tsx',
       e2eTestRunner: 'none',
       unitTestRunner: 'jest',
-      skipFormat: false,
-      js: true,
+      install: false,
     });
   });
 
   it('should normalize options with name in camel case', async () => {
     const schema: Schema = {
       name: 'myApp',
-      linter: Linter.EsLint,
       e2eTestRunner: 'none',
-      skipFormat: false,
-      js: true,
-      unitTestRunner: 'jest',
+      install: false,
       projectNameAndRootFormat: 'as-provided',
     };
     const options = await normalizeOptions(appTree, schema);
     expect(options).toEqual({
-      appProjectRoot: 'my-app',
+      androidProjectRoot: 'myApp/android',
+      appProjectRoot: 'myApp',
       className: 'MyApp',
       displayName: 'MyApp',
+      iosProjectRoot: 'myApp/ios',
       lowerCaseName: 'myapp',
-      name: 'my-app',
+      name: 'myApp',
       parsedTags: [],
-      projectName: 'my-app',
+      projectName: 'myApp',
       projectNameAndRootFormat: 'as-provided',
-      linter: Linter.EsLint,
+      entryFile: 'src/main.tsx',
       e2eTestRunner: 'none',
-      skipFormat: false,
-      js: true,
       unitTestRunner: 'jest',
+      install: false,
     });
   });
 
   it('should normalize options with directory', async () => {
     const schema: Schema = {
       name: 'my-app',
-      directory: 'directory',
-      linter: Linter.EsLint,
+      directory: 'directory/my-app',
       e2eTestRunner: 'none',
-      skipFormat: false,
-      js: true,
-      unitTestRunner: 'jest',
+      install: false,
       projectNameAndRootFormat: 'as-provided',
     };
     const options = await normalizeOptions(appTree, schema);
     expect(options).toEqual({
-      appProjectRoot: 'directory',
+      androidProjectRoot: 'directory/my-app/android',
+      appProjectRoot: 'directory/my-app',
       className: 'MyApp',
       displayName: 'MyApp',
+      iosProjectRoot: 'directory/my-app/ios',
       lowerCaseName: 'myapp',
       name: 'my-app',
-      directory: 'directory',
+      directory: 'directory/my-app',
       parsedTags: [],
       projectName: 'my-app',
       projectNameAndRootFormat: 'as-provided',
+      entryFile: 'src/main.tsx',
       e2eTestRunner: 'none',
       unitTestRunner: 'jest',
-      linter: Linter.EsLint,
-      skipFormat: false,
-      js: true,
+      install: false,
     });
   });
 
   it('should normalize options that has directory in its name', async () => {
     const schema: Schema = {
       name: 'directory/my-app',
-      linter: Linter.EsLint,
       e2eTestRunner: 'none',
-      skipFormat: false,
-      js: true,
-      unitTestRunner: 'jest',
+      install: false,
       projectNameAndRootFormat: 'as-provided',
     };
     const options = await normalizeOptions(appTree, schema);
     expect(options).toEqual({
+      androidProjectRoot: 'directory/my-app/android',
       appProjectRoot: 'directory/my-app',
       className: 'DirectoryMyApp',
       displayName: 'DirectoryMyApp',
+      iosProjectRoot: 'directory/my-app/ios',
       lowerCaseName: 'directorymyapp',
       name: 'directory/my-app',
       parsedTags: [],
       projectName: 'directory/my-app',
       projectNameAndRootFormat: 'as-provided',
+      entryFile: 'src/main.tsx',
       e2eTestRunner: 'none',
       unitTestRunner: 'jest',
-      linter: Linter.EsLint,
-      skipFormat: false,
-      js: true,
+      install: false,
     });
   });
 
@@ -129,28 +123,26 @@ describe('Normalize Options', () => {
     const schema: Schema = {
       name: 'my-app',
       displayName: 'My App',
-      linter: Linter.EsLint,
       e2eTestRunner: 'none',
-      skipFormat: false,
-      js: true,
-      unitTestRunner: 'jest',
+      install: false,
       projectNameAndRootFormat: 'as-provided',
     };
     const options = await normalizeOptions(appTree, schema);
     expect(options).toEqual({
+      androidProjectRoot: 'my-app/android',
       appProjectRoot: 'my-app',
       className: 'MyApp',
       displayName: 'My App',
+      iosProjectRoot: 'my-app/ios',
       lowerCaseName: 'myapp',
       name: 'my-app',
       parsedTags: [],
       projectName: 'my-app',
       projectNameAndRootFormat: 'as-provided',
+      entryFile: 'src/main.tsx',
       e2eTestRunner: 'none',
       unitTestRunner: 'jest',
-      linter: Linter.EsLint,
-      skipFormat: false,
-      js: true,
+      install: false,
     });
   });
 });

--- a/packages/react-native/src/generators/library/library.spec.ts
+++ b/packages/react-native/src/generators/library/library.spec.ts
@@ -13,7 +13,7 @@ describe('lib', () => {
   let appTree: Tree;
 
   const defaultSchema: Schema = {
-    name: 'myLib',
+    name: 'my-lib',
     linter: Linter.EsLint,
     skipFormat: false,
     skipTsConfig: false,
@@ -124,7 +124,7 @@ describe('lib', () => {
     it('should update nx.json', async () => {
       await libraryGenerator(appTree, {
         ...defaultSchema,
-        directory: 'myDir',
+        directory: 'my-dir',
         tags: 'one',
       });
 
@@ -135,8 +135,8 @@ describe('lib', () => {
 
       await libraryGenerator(appTree, {
         ...defaultSchema,
-        name: 'myLib2',
-        directory: 'myDir2',
+        name: 'my-lib2',
+        directory: 'my-dir2',
         tags: 'one,two',
       });
 
@@ -150,7 +150,10 @@ describe('lib', () => {
     });
 
     it('should update project.json', async () => {
-      await libraryGenerator(appTree, { ...defaultSchema, directory: 'myDir' });
+      await libraryGenerator(appTree, {
+        ...defaultSchema,
+        directory: 'my-dir',
+      });
       const projectConfiguration = readProjectConfiguration(appTree, 'my-lib');
 
       expect(projectConfiguration.root).toEqual('my-dir');
@@ -164,7 +167,10 @@ describe('lib', () => {
     });
 
     it('should update root tsconfig.base.json', async () => {
-      await libraryGenerator(appTree, { ...defaultSchema, directory: 'myDir' });
+      await libraryGenerator(appTree, {
+        ...defaultSchema,
+        directory: 'my-dir',
+      });
       const tsconfigJson = readJson(appTree, '/tsconfig.base.json');
       expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
         'my-dir/src/index.ts',
@@ -177,7 +183,10 @@ describe('lib', () => {
     it('should update root tsconfig.json when no tsconfig.base.json', async () => {
       appTree.rename('tsconfig.base.json', 'tsconfig.json');
 
-      await libraryGenerator(appTree, { ...defaultSchema, directory: 'myDir' });
+      await libraryGenerator(appTree, {
+        ...defaultSchema,
+        directory: 'my-dir',
+      });
 
       const tsconfigJson = readJson(appTree, '/tsconfig.json');
       expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
@@ -189,7 +198,10 @@ describe('lib', () => {
     });
 
     it('should create a local tsconfig.json', async () => {
-      await libraryGenerator(appTree, { ...defaultSchema, directory: 'myDir' });
+      await libraryGenerator(appTree, {
+        ...defaultSchema,
+        directory: 'my-dir',
+      });
 
       const tsconfigJson = readJson(appTree, 'my-dir/tsconfig.json');
       expect(tsconfigJson.extends).toBe('../tsconfig.base.json');
@@ -206,7 +218,10 @@ describe('lib', () => {
     it('should extend from root tsconfig.json when no tsconfig.base.json', async () => {
       appTree.rename('tsconfig.base.json', 'tsconfig.json');
 
-      await libraryGenerator(appTree, { ...defaultSchema, directory: 'myDir' });
+      await libraryGenerator(appTree, {
+        ...defaultSchema,
+        directory: 'my-dir',
+      });
 
       const tsconfigJson = readJson(appTree, 'my-dir/tsconfig.json');
       expect(tsconfigJson.extends).toBe('../tsconfig.json');
@@ -343,7 +358,7 @@ describe('lib', () => {
       try {
         await libraryGenerator(appTree, {
           ...defaultSchema,
-          directory: 'myDir',
+          directory: 'my-dir',
           publishable: true,
         });
       } catch (e) {
@@ -382,7 +397,7 @@ describe('lib', () => {
       await libraryGenerator(appTree, {
         ...defaultSchema,
         publishable: true,
-        directory: 'myDir',
+        directory: 'my-dir',
         importPath: '@myorg/lib',
       });
       const packageJson = readJson(appTree, 'my-dir/package.json');
@@ -397,7 +412,7 @@ describe('lib', () => {
     it('should fail if the same importPath has already been used', async () => {
       await libraryGenerator(appTree, {
         ...defaultSchema,
-        name: 'myLib1',
+        name: 'my-lib1',
         publishable: true,
         importPath: '@myorg/lib',
       });
@@ -405,7 +420,7 @@ describe('lib', () => {
       try {
         await libraryGenerator(appTree, {
           ...defaultSchema,
-          name: 'myLib2',
+          name: 'my-lib2',
           publishable: true,
           importPath: '@myorg/lib',
         });

--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -20,7 +20,7 @@ describe('app', () => {
     compiler: 'babel',
     e2eTestRunner: 'cypress',
     skipFormat: false,
-    name: 'myApp',
+    name: 'my-app',
     linter: Linter.EsLint,
     style: 'css',
     strict: true,

--- a/packages/react/src/generators/host/host.spec.ts
+++ b/packages/react/src/generators/host/host.spec.ts
@@ -164,8 +164,8 @@ describe('hostGenerator', () => {
     const tree = createTreeWithEmptyWorkspace();
 
     await hostGenerator(tree, {
-      name: 'hostApp',
-      directory: 'foo/hostApp',
+      name: 'host-app',
+      directory: 'foo/host-app',
       remotes: ['remote1', 'remote2', 'remote3'],
       projectNameAndRootFormat: 'as-provided',
       e2eTestRunner: 'none',
@@ -187,8 +187,8 @@ describe('hostGenerator', () => {
     const tree = createTreeWithEmptyWorkspace();
 
     await hostGenerator(tree, {
-      name: 'hostApp',
-      directory: 'foo/hostApp',
+      name: 'host-app',
+      directory: 'foo/host-app',
       remotes: ['remote1', 'remote2', 'remote3'],
       projectNameAndRootFormat: 'as-provided',
       e2eTestRunner: 'none',

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -21,7 +21,7 @@ describe('lib', () => {
     ReturnType<typeof installedCypressVersion>
   > = installedCypressVersion as never;
   let defaultSchema: Schema = {
-    name: 'myLib',
+    name: 'my-lib',
     linter: Linter.EsLint,
     skipFormat: false,
     skipTsConfig: false,
@@ -449,7 +449,7 @@ describe('lib', () => {
         linter: Linter.EsLint,
         skipFormat: true,
         unitTestRunner: 'jest',
-        name: 'myApp',
+        name: 'my-app',
         routing: true,
         style: 'css',
         bundler: 'webpack',
@@ -478,7 +478,7 @@ describe('lib', () => {
         linter: Linter.EsLint,
         skipFormat: true,
         unitTestRunner: 'jest',
-        name: 'myApp',
+        name: 'my-app',
         style: 'css',
         bundler: 'webpack',
         projectNameAndRootFormat: 'as-provided',

--- a/packages/web/src/generators/application/application.spec.ts
+++ b/packages/web/src/generators/application/application.spec.ts
@@ -28,7 +28,7 @@ describe('app', () => {
   describe('not nested', () => {
     it('should update configuration', async () => {
       await applicationGenerator(tree, {
-        name: 'myApp',
+        name: 'my-app',
         projectNameAndRootFormat: 'as-provided',
       });
       expect(readProjectConfiguration(tree, 'my-app').root).toEqual('my-app');
@@ -39,7 +39,7 @@ describe('app', () => {
 
     it('should update tags and implicit dependencies', async () => {
       await applicationGenerator(tree, {
-        name: 'myApp',
+        name: 'my-app',
         tags: 'one,two',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -57,7 +57,7 @@ describe('app', () => {
 
     it('should generate files', async () => {
       await applicationGenerator(tree, {
-        name: 'myApp',
+        name: 'my-app',
         projectNameAndRootFormat: 'as-provided',
       });
       expect(tree.exists('my-app/src/main.ts')).toBeTruthy();
@@ -165,7 +165,7 @@ describe('app', () => {
 
     it('should generate files if bundler is vite', async () => {
       await applicationGenerator(tree, {
-        name: 'myApp',
+        name: 'my-app',
         bundler: 'vite',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -199,7 +199,7 @@ describe('app', () => {
       tree.rename('tsconfig.base.json', 'tsconfig.json');
 
       await applicationGenerator(tree, {
-        name: 'myApp',
+        name: 'my-app',
         projectNameAndRootFormat: 'as-provided',
       });
 
@@ -211,7 +211,7 @@ describe('app', () => {
   describe('nested', () => {
     it('should update configuration', async () => {
       await applicationGenerator(tree, {
-        name: 'myApp',
+        name: 'my-app',
         directory: 'my-dir/my-app',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -225,7 +225,7 @@ describe('app', () => {
 
     it('should update tags and implicit dependencies', async () => {
       await applicationGenerator(tree, {
-        name: 'myApp',
+        name: 'my-app',
         directory: 'my-dir/my-app',
         tags: 'one,two',
         projectNameAndRootFormat: 'as-provided',
@@ -249,7 +249,7 @@ describe('app', () => {
         expect(lookupFn(config)).toEqual(expectedValue);
       };
       await applicationGenerator(tree, {
-        name: 'myApp',
+        name: 'my-app',
         directory: 'my-dir/my-app',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -286,7 +286,7 @@ describe('app', () => {
 
     it('should extend from root tsconfig.base.json', async () => {
       await applicationGenerator(tree, {
-        name: 'myApp',
+        name: 'my-app',
         directory: 'my-dir/my-app',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -299,7 +299,7 @@ describe('app', () => {
       tree.rename('tsconfig.base.json', 'tsconfig.json');
 
       await applicationGenerator(tree, {
-        name: 'myApp',
+        name: 'my-app',
         directory: 'my-dir/my-app',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -310,7 +310,7 @@ describe('app', () => {
 
     it('should create Nx specific template', async () => {
       await applicationGenerator(tree, {
-        name: 'myApp',
+        name: 'my-app',
         directory: 'my-dir/my-app',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -326,7 +326,7 @@ describe('app', () => {
   describe('--style scss', () => {
     it('should generate scss styles', async () => {
       await applicationGenerator(tree, {
-        name: 'myApp',
+        name: 'my-app',
         style: 'scss',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -336,7 +336,7 @@ describe('app', () => {
 
   it('should setup jest without serializers', async () => {
     await applicationGenerator(tree, {
-      name: 'my-App',
+      name: 'my-app',
       projectNameAndRootFormat: 'as-provided',
     });
 
@@ -347,7 +347,7 @@ describe('app', () => {
 
   it('should setup the nrwl web build builder', async () => {
     await applicationGenerator(tree, {
-      name: 'my-App',
+      name: 'my-app',
       projectNameAndRootFormat: 'as-provided',
     });
     const targets = readProjectConfiguration(tree, 'my-app').targets;
@@ -383,7 +383,7 @@ describe('app', () => {
 
   it('should setup the nrwl web dev server builder', async () => {
     await applicationGenerator(tree, {
-      name: 'my-App',
+      name: 'my-app',
       projectNameAndRootFormat: 'as-provided',
     });
     const targets = readProjectConfiguration(tree, 'my-app').targets;
@@ -398,7 +398,7 @@ describe('app', () => {
 
   it('should setup the nrwl vite:build builder if bundler is vite', async () => {
     await applicationGenerator(tree, {
-      name: 'my-App',
+      name: 'my-app',
 
       bundler: 'vite',
       projectNameAndRootFormat: 'as-provided',
@@ -413,7 +413,7 @@ describe('app', () => {
 
   it('should setup the nrwl vite:dev-server builder if bundler is vite', async () => {
     await applicationGenerator(tree, {
-      name: 'my-App',
+      name: 'my-app',
 
       bundler: 'vite',
       projectNameAndRootFormat: 'as-provided',
@@ -431,7 +431,7 @@ describe('app', () => {
 
   it('should setup the eslint builder', async () => {
     await applicationGenerator(tree, {
-      name: 'my-App',
+      name: 'my-app',
       projectNameAndRootFormat: 'as-provided',
     });
     expect(readProjectConfiguration(tree, 'my-app').targets.lint).toEqual({
@@ -446,7 +446,7 @@ describe('app', () => {
   describe('--prefix', () => {
     it('should use the prefix in the index.html', async () => {
       await applicationGenerator(tree, {
-        name: 'myApp',
+        name: 'my-app',
         prefix: 'prefix',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -460,7 +460,7 @@ describe('app', () => {
   describe('--unit-test-runner', () => {
     it('--unit-test-runner=none', async () => {
       await applicationGenerator(tree, {
-        name: 'myApp',
+        name: 'my-app',
         unitTestRunner: 'none',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -564,7 +564,7 @@ describe('app', () => {
   describe('--e2e-test-runner none', () => {
     it('should not generate test configuration', async () => {
       await applicationGenerator(tree, {
-        name: 'myApp',
+        name: 'my-app',
         e2eTestRunner: 'none',
         projectNameAndRootFormat: 'as-provided',
       });
@@ -575,7 +575,7 @@ describe('app', () => {
   describe('--compiler', () => {
     it('should support babel compiler', async () => {
       await applicationGenerator(tree, {
-        name: 'myApp',
+        name: 'my-app',
         compiler: 'babel',
         projectNameAndRootFormat: 'as-provided',
       } as Schema);
@@ -602,7 +602,7 @@ describe('app', () => {
 
     it('should support swc compiler', async () => {
       await applicationGenerator(tree, {
-        name: 'myApp',
+        name: 'my-app',
         compiler: 'swc',
         projectNameAndRootFormat: 'as-provided',
       } as Schema);
@@ -633,7 +633,7 @@ describe('app', () => {
     beforeAll(async () => {
       viteAppTree = createTreeWithEmptyWorkspace();
       await applicationGenerator(viteAppTree, {
-        name: 'myApp',
+        name: 'my-app',
         bundler: 'vite',
         projectNameAndRootFormat: 'as-provided',
       });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When generating projects using the `as-provided` format, the provided project name and directory are normalized (converted to kebab-case).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When generating projects using the `as-provided` format, the provided project name and directory should be used exactly as provided without any processing/transformation.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
