### PR TITLE
fix(linter): add @nx/linter in nx packageGroup

### DIFF
--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -100,6 +100,7 @@
       "@nrwl/js",
       "@nx/jest",
       "@nrwl/jest",
+      "@nx/linter",
       "@nx/eslint",
       "@nrwl/linter",
       "@nx/workspace",


### PR DESCRIPTION
Excluding it in `packageGroup` means its migrations won't be applied. This makes our `@nx/linter` -> `@nx/eslint` migration not run.

<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
