### PR TITLE
fix(core): setup the nx cloud client during postinstall

### DIFF
--- a/packages/nx/bin/post-install.ts
+++ b/packages/nx/bin/post-install.ts
@@ -4,24 +4,36 @@ import { fileExists } from '../src/utils/fileutils';
 import { join } from 'path';
 import { daemonClient } from '../src/daemon/client/client';
 import { assertSupportedPlatform } from '../src/native/assert-supported-platform';
+import { verifyOrUpdateNxCloudClient } from '../src/nx-cloud/update-manager';
+import { getCloudOptions } from '../src/nx-cloud/utilities/get-cloud-options';
+import { isNxCloudUsed } from '../src/utils/nx-cloud-utils';
+import { readNxJson } from '../src/config/nx-json';
 
 (async () => {
   try {
     if (isMainNxPackage() && fileExists(join(workspaceRoot, 'nx.json'))) {
+      const b = new Date();
       assertSupportedPlatform();
 
       try {
         await daemonClient.stop();
       } catch (e) {}
-      const b = new Date();
-      await buildProjectGraphWithoutDaemon();
-      const a = new Date();
+      const tasks: Array<Promise<any>> = [buildProjectGraphWithoutDaemon()];
+      if (isNxCloudUsed(readNxJson())) {
+        tasks.push(verifyOrUpdateNxCloudClient(getCloudOptions()));
+      }
+      await Promise.all(
+        tasks.map((promise) => {
+          promise.catch((e) => {
+            if (process.env.NX_VERBOSE_LOGGING === 'true') {
+              console.warn(e);
+            }
+          });
+        })
+      );
       if (process.env.NX_VERBOSE_LOGGING === 'true') {
-        console.log(
-          `Nx project graph has been precomputed in ${
-            a.getTime() - b.getTime()
-          }ms`
-        );
+        const a = new Date();
+        console.log(`Nx postinstall steps took ${a.getTime() - b.getTime()}ms`);
       }
     }
   } catch (e) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The Nx Cloud client is setup when running a nx-cloud command or running a task.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The Nx Cloud client is setup after `nx` is installed and if the workspace uses Nx Cloud.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
