### PR TITLE
feat(nx-dev): mark internal properties

### DIFF
--- a/nx-dev/feature-package-schema-viewer/src/lib/parameter-view.tsx
+++ b/nx-dev/feature-package-schema-viewer/src/lib/parameter-view.tsx
@@ -39,6 +39,14 @@ export const ParameterView = (props: {
             Deprecated
           </span>
         )}
+        {props.schema['x-priority'] === 'internal' && (
+          <span
+            data-tooltip="Intended for use by other generators"
+            className="relative -top-0.5 inline-flex rounded-md bg-yellow-300 px-2 text-xs font-semibold uppercase leading-5 text-yellow-800 dark:bg-yellow-800 dark:text-yellow-100"
+          >
+            Internal
+          </span>
+        )}
         {((props.schema as any)['hidden'] as boolean) && (
           <span className="relative -top-0.5 inline-flex rounded-md bg-yellow-300 px-2 text-xs font-semibold uppercase leading-5 text-yellow-800 dark:bg-yellow-800 dark:text-yellow-100">
             Hidden


### PR DESCRIPTION
Shows a flag for internal properties of a generator/executor

[Example](https://nx-dev-git-fork-isaacplmann-nx-dev-internal-properties-nrwl.vercel.app/nx-api/angular/generators/add-linting)

![Screenshot 2023-10-17 at 1 31 11 PM](https://github.com/nrwl/nx/assets/861504/4f23aa34-960d-42b7-8853-dfb62a5cf0ab)
