### PR TITLE
fix(vue): update standalone setup so tsconfig.base.json is not generated

### DIFF
--- a/packages/vite/src/generators/configuration/configuration.ts
+++ b/packages/vite/src/generators/configuration/configuration.ts
@@ -159,6 +159,7 @@ export async function viteConfigurationGenerator(
     includeLib: schema.includeLib,
     compiler: schema.compiler,
     testEnvironment: schema.testEnvironment,
+    rootProject: root === '.',
   });
   tasks.push(initTask);
 

--- a/packages/vite/src/generators/init/init.ts
+++ b/packages/vite/src/generators/init/init.ts
@@ -12,16 +12,16 @@ import {
 import { initGenerator as jsInitGenerator } from '@nx/js';
 
 import {
+  edgeRuntimeVmVersion,
+  happyDomVersion,
   jsdomVersion,
   nxVersion,
   vitePluginDtsVersion,
-  vitePluginReactVersion,
   vitePluginReactSwcVersion,
+  vitePluginReactVersion,
   vitestUiVersion,
   vitestVersion,
   viteVersion,
-  happyDomVersion,
-  edgeRuntimeVmVersion,
 } from '../../utils/versions';
 import { InitGeneratorSchema } from './schema';
 
@@ -111,6 +111,7 @@ export async function initGenerator(tree: Tree, schema: InitGeneratorSchema) {
     await jsInitGenerator(tree, {
       ...schema,
       skipFormat: true,
+      tsConfigName: schema.rootProject ? 'tsconfig.json' : 'tsconfig.base.json',
     })
   );
 

--- a/packages/vite/src/generators/init/schema.d.ts
+++ b/packages/vite/src/generators/init/schema.d.ts
@@ -3,4 +3,5 @@ export interface InitGeneratorSchema {
   compiler?: 'babel' | 'swc';
   includeLib?: boolean;
   testEnvironment?: 'node' | 'jsdom' | 'happy-dom' | 'edge-runtime' | string;
+  rootProject?: boolean;
 }

--- a/packages/vue/src/generators/application/application.ts
+++ b/packages/vue/src/generators/application/application.ts
@@ -38,7 +38,9 @@ export async function applicationGenerator(
     })
   );
 
-  extractTsConfigBase(tree);
+  if (!options.rootProject) {
+    extractTsConfigBase(tree);
+  }
 
   createApplicationFiles(tree, options);
 

--- a/packages/vue/src/generators/component/lib/utils.ts
+++ b/packages/vue/src/generators/component/lib/utils.ts
@@ -19,8 +19,6 @@ export async function normalizeOptions(
   host: Tree,
   options: Schema
 ): Promise<NormalizedSchema> {
-  assertValidOptions(options);
-
   const {
     artifactName: name,
     directory,
@@ -106,20 +104,4 @@ function getRelativeImportToFile(indexPath: string, filePath: string) {
   const { base, dir } = parse(filePath);
   const relativeDirToTarget = relative(dirname(indexPath), dir);
   return `./${joinPathFragments(relativeDirToTarget, base)}`;
-}
-
-export function assertValidOptions(options: Schema) {
-  const slashes = ['/', '\\'];
-  slashes.forEach((s) => {
-    if (options.name.indexOf(s) !== -1) {
-      const [name, ...rest] = options.name.split(s).reverse();
-      let suggestion = rest.map((x) => x.toLowerCase()).join(s);
-      if (options.directory) {
-        suggestion = `${options.directory}${s}${suggestion}`;
-      }
-      throw new Error(
-        `Found "${s}" in the component name. Did you mean to use the --directory option (e.g. \`nx g c ${name} --directory ${suggestion}\`)?`
-      );
-    }
-  });
 }

--- a/packages/vue/src/generators/init/schema.json
+++ b/packages/vue/src/generators/init/schema.json
@@ -24,7 +24,7 @@
     "routing": {
       "type": "boolean",
       "description": "Generate application with routes.",
-      "x-prompt": "Would you like to add React Router to this application?",
+      "x-prompt": "Would you like to add Vue Router to this application?",
       "default": false
     },
     "style": {

--- a/packages/vue/src/utils/create-ts-config.ts
+++ b/packages/vue/src/utils/create-ts-config.ts
@@ -8,7 +8,6 @@ export function createTsConfig(
   options: {
     strict?: boolean;
     style?: string;
-    bundler?: string;
     rootProject?: boolean;
     unitTestRunner?: string;
   },
@@ -56,7 +55,7 @@ export function createTsConfig(
   writeJson(host, `${projectRoot}/tsconfig.json`, json);
 
   const tsconfigProjectPath = `${projectRoot}/tsconfig.${type}.json`;
-  if (options.bundler === 'vite' && host.exists(tsconfigProjectPath)) {
+  if (host.exists(tsconfigProjectPath)) {
     updateJson(host, tsconfigProjectPath, (json) => {
       json.compilerOptions ??= {};
 


### PR DESCRIPTION
This PR fixes an issue where new standalone Vue projects are generated with `tsconfig.base.json` file.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
