### PR TITLE
feat(storybook): add missing react dependency for nextjs

### DIFF
--- a/packages/storybook/src/generators/init/init.ts
+++ b/packages/storybook/src/generators/init/init.ts
@@ -18,6 +18,7 @@ import {
   storybookVersion,
   storybookReactNativeVersion,
   viteVersion,
+  reactRefreshVersion,
 } from '../../utils/versions';
 import { Schema } from './schema';
 import {
@@ -116,6 +117,15 @@ function checkDependenciesInstalled(host: Tree, schema: Schema) {
         storybookReactNativeVersion;
       devDependencies['@storybook/addon-ondevice-notes'] =
         storybookReactNativeVersion;
+    }
+
+    if (schema.uiFramework === '@storybook/nextjs') {
+      if (
+        !packageJson.dependencies['react-refresh'] &&
+        !packageJson.devDependencies['react-refresh']
+      ) {
+        devDependencies['react-refresh'] = reactRefreshVersion;
+      }
     }
 
     if (schema.uiFramework.endsWith('-vite')) {

--- a/packages/storybook/src/utils/versions.ts
+++ b/packages/storybook/src/utils/versions.ts
@@ -11,4 +11,6 @@ export const storybookVersion = '^7.2.1';
 export const reactVersion = '^18.2.0';
 export const viteVersion = '~4.3.9';
 
+export const reactRefreshVersion = '^0.14.0';
+
 export const coreJsVersion = '^3.6.5';


### PR DESCRIPTION
Added missing react dependency.

This PR fixes [this issue](https://staging.nx.app/runs/NRgfljDoua), but it should not be an issue in the first place, because it seems that it's not happening on Nx `next` version, so when I generate a new workspace with `@next` version and I test it out, Storybook builds successfully without that dependency. When I run the e2e tests on latest `master`, and then I also try to `build-storybook` on the generated project, like manually, the tests only pass (storybook only builds) if `react-refresh` is installed.