### PR TITLE
feat(core): generate standalone projects with scoped package names

### DIFF
--- a/e2e/storybook/src/storybook-nested.test.ts
+++ b/e2e/storybook/src/storybook-nested.test.ts
@@ -80,7 +80,7 @@ describe('Storybook generators and executors for standalone workspaces - using R
       writeFileSync(
         tmpProjPath(`src/app/test-button.tsx`),
         `
-          import { MyLib } from 'my-lib';
+          import { MyLib } from '@${appName}/my-lib';
 
           export function TestButton() {
             return (

--- a/packages/workspace/src/generators/new/files-root-app/package.json__tmpl__
+++ b/packages/workspace/src/generators/new/files-root-app/package.json__tmpl__
@@ -1,5 +1,5 @@
 {
-  "name": "<%= formattedNames.fileName %>",
+  "name": "@<%= formattedNames.fileName %>/source",
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Use `@acme/source` rather than `acme` in `package.json`. This scope is used for subsequent projects, so if you do `nx g lib ui` you get `@acme/ui` instead of `ui`.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
