### PR TITLE
fix(vue): remove unitTestRunner option from component generator

### DIFF
--- a/packages/vue/src/generators/component/component.spec.ts
+++ b/packages/vue/src/generators/component/component.spec.ts
@@ -26,44 +26,6 @@ describe('component', () => {
     await componentGenerator(appTree, {
       name: 'hello',
       project: libName,
-      unitTestRunner: 'vitest',
-    });
-
-    expect(appTree.read(`${libName}/src/lib/hello/hello.vue`, 'utf-8'))
-      .toMatchInlineSnapshot(`
-      "<script setup lang="ts">
-      defineProps<{}>();
-      </script>
-
-      <template>
-        <p>Welcome to Hello!</p>
-      </template>
-
-      <style scoped></style>
-      "
-    `);
-    expect(appTree.read(`${libName}/src/lib/hello/hello.spec.ts`, 'utf-8'))
-      .toMatchInlineSnapshot(`
-      "import { describe, it, expect } from 'vitest';
-
-      import { mount } from '@vue/test-utils';
-      import Hello from './hello.vue';
-
-      describe('Hello', () => {
-        it('renders properly', () => {
-          const wrapper = mount(Hello, {});
-          expect(wrapper.text()).toContain('Welcome to Hello');
-        });
-      });
-      "
-    `);
-  });
-
-  it('should generate files with jest', async () => {
-    await componentGenerator(appTree, {
-      name: 'hello',
-      project: libName,
-      unitTestRunner: 'jest',
     });
 
     expect(appTree.read(`${libName}/src/lib/hello/hello.vue`, 'utf-8'))
@@ -98,7 +60,6 @@ describe('component', () => {
     await componentGenerator(appTree, {
       name: 'hello-world',
       project: libName,
-      unitTestRunner: 'none',
       directory: 'foo/bar',
     });
 
@@ -114,7 +75,6 @@ describe('component', () => {
     await componentGenerator(appTree, {
       name: 'helloWorld',
       project: libName,
-      unitTestRunner: 'none',
       directory: 'foo/bar-baz',
     });
 
@@ -130,7 +90,6 @@ describe('component', () => {
     await componentGenerator(appTree, {
       name: 'hello',
       project: appName,
-      unitTestRunner: 'vitest',
     });
 
     expect(

--- a/packages/vue/src/generators/component/component.ts
+++ b/packages/vue/src/generators/component/component.ts
@@ -25,7 +25,6 @@ function createComponentFiles(host: Tree, options: NormalizedSchema) {
   generateFiles(host, join(__dirname, './files'), options.directory, {
     ...options,
     tmpl: '',
-    unitTestRunner: options.unitTestRunner,
   });
 
   for (const c of host.listChanges()) {

--- a/packages/vue/src/generators/component/files/__fileName__.spec.ts__tmpl__
+++ b/packages/vue/src/generators/component/files/__fileName__.spec.ts__tmpl__
@@ -1,7 +1,3 @@
-<% if ( unitTestRunner === 'vitest' ) { %>
-import { describe, it, expect } from 'vitest'
-<% } %>
-
 import { mount } from '@vue/test-utils'
 import <%= className %> from './<%= fileName %>.vue';
 

--- a/packages/vue/src/generators/component/schema.d.ts
+++ b/packages/vue/src/generators/component/schema.d.ts
@@ -8,7 +8,6 @@ export interface Schema {
   fileName?: string;
   inSourceTests?: boolean;
   skipFormat?: boolean;
-  unitTestRunner?: 'jest' | 'vitest' | 'none';
   nameAndDirectoryFormat?: 'as-provided' | 'derived';
 
   /**


### PR DESCRIPTION
This prompt was for adding `import {describe, ...} from 'vitest` into our spec files, but we already include `vitest/globals` in `tsconfig.config.spec.json`, so there is no reason to prompt. We don't have this option for any other component/artifact generator, so it's weird to have it here.


## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
