### PR TITLE
fix(linter): handle string extends property in config

### DIFF
--- a/packages/eslint/src/generators/utils/eslint-file.ts
+++ b/packages/eslint/src/generators/utils/eslint-file.ts
@@ -299,7 +299,11 @@ export function addExtendsToLintConfig(
   } else {
     const fileName = joinPathFragments(root, '.eslintrc.json');
     updateJson(tree, fileName, (json) => {
-      json.extends = [...plugins, ...(json.extends ?? [])];
+      json.extends ??= [];
+      json.extends = [
+        ...plugins,
+        ...(Array.isArray(json.extends) ? json.extends : [json.extends]),
+      ];
       return json;
     });
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
linter spreads the string if the extends property is a string instead of array

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
linter should handle string or array extends properties

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
