### PR TITLE
fix(nest): add deprecated messages to generator js schema and fix casing

### DIFF
--- a/docs/generated/packages/nest/generators/class.json
+++ b/docs/generated/packages/nest/generators/class.json
@@ -46,7 +46,7 @@
       },
       "flat": {
         "description": "Flag to indicate if a directory is created.",
-        "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+        "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
         "type": "boolean",
         "default": true
       },

--- a/docs/generated/packages/nest/generators/controller.json
+++ b/docs/generated/packages/nest/generators/controller.json
@@ -46,7 +46,7 @@
       },
       "flat": {
         "description": "Flag to indicate if a directory is created.",
-        "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+        "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
         "type": "boolean",
         "default": false
       },

--- a/docs/generated/packages/nest/generators/decorator.json
+++ b/docs/generated/packages/nest/generators/decorator.json
@@ -40,7 +40,7 @@
       },
       "flat": {
         "description": "Flag to indicate if a directory is created.",
-        "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+        "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
         "type": "boolean",
         "default": true
       },

--- a/docs/generated/packages/nest/generators/filter.json
+++ b/docs/generated/packages/nest/generators/filter.json
@@ -46,7 +46,7 @@
       },
       "flat": {
         "description": "Flag to indicate if a directory is created.",
-        "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+        "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
         "type": "boolean",
         "default": true
       },

--- a/docs/generated/packages/nest/generators/gateway.json
+++ b/docs/generated/packages/nest/generators/gateway.json
@@ -46,7 +46,7 @@
       },
       "flat": {
         "description": "Flag to indicate if a directory is created.",
-        "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+        "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
         "type": "boolean",
         "default": true
       },

--- a/docs/generated/packages/nest/generators/guard.json
+++ b/docs/generated/packages/nest/generators/guard.json
@@ -46,7 +46,7 @@
       },
       "flat": {
         "description": "Flag to indicate if a directory is created.",
-        "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+        "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
         "type": "boolean",
         "default": true
       },

--- a/docs/generated/packages/nest/generators/interceptor.json
+++ b/docs/generated/packages/nest/generators/interceptor.json
@@ -46,7 +46,7 @@
       },
       "flat": {
         "description": "Flag to indicate if a directory is created.",
-        "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+        "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
         "type": "boolean",
         "default": true
       },

--- a/docs/generated/packages/nest/generators/interface.json
+++ b/docs/generated/packages/nest/generators/interface.json
@@ -40,7 +40,7 @@
       },
       "flat": {
         "description": "Flag to indicate if a directory is created.",
-        "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+        "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
         "type": "boolean",
         "default": true
       }

--- a/docs/generated/packages/nest/generators/middleware.json
+++ b/docs/generated/packages/nest/generators/middleware.json
@@ -46,7 +46,7 @@
       },
       "flat": {
         "description": "Flag to indicate if a directory is created.",
-        "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+        "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
         "type": "boolean",
         "default": true
       },

--- a/docs/generated/packages/nest/generators/module.json
+++ b/docs/generated/packages/nest/generators/module.json
@@ -40,7 +40,7 @@
       },
       "flat": {
         "description": "Flag to indicate if a directory is created.",
-        "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+        "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
         "type": "boolean",
         "default": false
       },

--- a/docs/generated/packages/nest/generators/pipe.json
+++ b/docs/generated/packages/nest/generators/pipe.json
@@ -46,7 +46,7 @@
       },
       "flat": {
         "description": "Flag to indicate if a directory is created.",
-        "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+        "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
         "type": "boolean",
         "default": true
       },

--- a/docs/generated/packages/nest/generators/provider.json
+++ b/docs/generated/packages/nest/generators/provider.json
@@ -46,7 +46,7 @@
       },
       "flat": {
         "description": "Flag to indicate if a directory is created.",
-        "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+        "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
         "type": "boolean",
         "default": true
       },

--- a/docs/generated/packages/nest/generators/resolver.json
+++ b/docs/generated/packages/nest/generators/resolver.json
@@ -41,7 +41,7 @@
       },
       "flat": {
         "description": "Flag to indicate if a directory is created.",
-        "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+        "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
         "type": "boolean",
         "default": false
       },

--- a/docs/generated/packages/nest/generators/resource.json
+++ b/docs/generated/packages/nest/generators/resource.json
@@ -41,7 +41,7 @@
       },
       "flat": {
         "description": "Flag to indicate if a directory is created.",
-        "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+        "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
         "type": "boolean",
         "default": false
       },

--- a/docs/generated/packages/nest/generators/service.json
+++ b/docs/generated/packages/nest/generators/service.json
@@ -46,7 +46,7 @@
       },
       "flat": {
         "description": "Flag to indicate if a directory is created.",
-        "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+        "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
         "type": "boolean",
         "default": false
       },

--- a/packages/nest/src/generators/class/schema.json
+++ b/packages/nest/src/generators/class/schema.json
@@ -48,7 +48,7 @@
     },
     "flat": {
       "description": "Flag to indicate if a directory is created.",
-      "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+      "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
       "type": "boolean",
       "default": true
     },

--- a/packages/nest/src/generators/controller/schema.json
+++ b/packages/nest/src/generators/controller/schema.json
@@ -48,7 +48,7 @@
     },
     "flat": {
       "description": "Flag to indicate if a directory is created.",
-      "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+      "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
       "type": "boolean",
       "default": false
     },

--- a/packages/nest/src/generators/decorator/schema.json
+++ b/packages/nest/src/generators/decorator/schema.json
@@ -42,7 +42,7 @@
     },
     "flat": {
       "description": "Flag to indicate if a directory is created.",
-      "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+      "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
       "type": "boolean",
       "default": true
     },

--- a/packages/nest/src/generators/filter/schema.json
+++ b/packages/nest/src/generators/filter/schema.json
@@ -48,7 +48,7 @@
     },
     "flat": {
       "description": "Flag to indicate if a directory is created.",
-      "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+      "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
       "type": "boolean",
       "default": true
     },

--- a/packages/nest/src/generators/gateway/schema.json
+++ b/packages/nest/src/generators/gateway/schema.json
@@ -48,7 +48,7 @@
     },
     "flat": {
       "description": "Flag to indicate if a directory is created.",
-      "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+      "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
       "type": "boolean",
       "default": true
     },

--- a/packages/nest/src/generators/guard/schema.json
+++ b/packages/nest/src/generators/guard/schema.json
@@ -48,7 +48,7 @@
     },
     "flat": {
       "description": "Flag to indicate if a directory is created.",
-      "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+      "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
       "type": "boolean",
       "default": true
     },

--- a/packages/nest/src/generators/interceptor/schema.json
+++ b/packages/nest/src/generators/interceptor/schema.json
@@ -48,7 +48,7 @@
     },
     "flat": {
       "description": "Flag to indicate if a directory is created.",
-      "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+      "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
       "type": "boolean",
       "default": true
     },

--- a/packages/nest/src/generators/interface/schema.json
+++ b/packages/nest/src/generators/interface/schema.json
@@ -42,7 +42,7 @@
     },
     "flat": {
       "description": "Flag to indicate if a directory is created.",
-      "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+      "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
       "type": "boolean",
       "default": true
     }

--- a/packages/nest/src/generators/middleware/schema.json
+++ b/packages/nest/src/generators/middleware/schema.json
@@ -48,7 +48,7 @@
     },
     "flat": {
       "description": "Flag to indicate if a directory is created.",
-      "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+      "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
       "type": "boolean",
       "default": true
     },

--- a/packages/nest/src/generators/module/schema.json
+++ b/packages/nest/src/generators/module/schema.json
@@ -42,7 +42,7 @@
     },
     "flat": {
       "description": "Flag to indicate if a directory is created.",
-      "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+      "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
       "type": "boolean",
       "default": false
     },

--- a/packages/nest/src/generators/pipe/schema.json
+++ b/packages/nest/src/generators/pipe/schema.json
@@ -48,7 +48,7 @@
     },
     "flat": {
       "description": "Flag to indicate if a directory is created.",
-      "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+      "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
       "type": "boolean",
       "default": true
     },

--- a/packages/nest/src/generators/provider/schema.json
+++ b/packages/nest/src/generators/provider/schema.json
@@ -48,7 +48,7 @@
     },
     "flat": {
       "description": "Flag to indicate if a directory is created.",
-      "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+      "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
       "type": "boolean",
       "default": true
     },

--- a/packages/nest/src/generators/resolver/schema.json
+++ b/packages/nest/src/generators/resolver/schema.json
@@ -43,7 +43,7 @@
     },
     "flat": {
       "description": "Flag to indicate if a directory is created.",
-      "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+      "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
       "type": "boolean",
       "default": false
     },

--- a/packages/nest/src/generators/resource/schema.json
+++ b/packages/nest/src/generators/resource/schema.json
@@ -43,7 +43,7 @@
     },
     "flat": {
       "description": "Flag to indicate if a directory is created.",
-      "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+      "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
       "type": "boolean",
       "default": false
     },

--- a/packages/nest/src/generators/service/schema.json
+++ b/packages/nest/src/generators/service/schema.json
@@ -48,7 +48,7 @@
     },
     "flat": {
       "description": "Flag to indicate if a directory is created.",
-      "x-deprecated": "provide the `directory` option instead and use the `as-provided` format. it will be removed in nx v18.",
+      "x-deprecated": "Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.",
       "type": "boolean",
       "default": false
     },

--- a/packages/nest/src/generators/utils/types.ts
+++ b/packages/nest/src/generators/utils/types.ts
@@ -27,11 +27,18 @@ export type TransportLayer =
 
 export type NestGeneratorOptions = {
   name: string;
-  project: string;
   directory?: string;
-  flat?: boolean;
   skipFormat?: boolean;
   nameAndDirectoryFormat?: NameAndDirectoryFormat;
+
+  /**
+   * @deprecated Provide the `directory` option instead and use the `as-provided` format. It will be removed in Nx v18.
+   */
+  flat?: boolean;
+  /**
+   * @deprecated Provide the `directory` option instead and use the `as-provided` format. The project will be determined from the directory provided. It will be removed in Nx v18.
+   */
+  project?: string;
 };
 
 export type NestGeneratorWithLanguageOption = NestGeneratorOptions & {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Some deprecated options are not reflected as such in the JS schema, which is used when invoking generators programmatically. Also, some deprecated messages have the wrong casing.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

All deprecated options should be marked as such in the JS schema, and their deprecated messages should be correctly cased.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
