### PR TITLE
fix(angular): install swc/helpers when generating remote applications

### DIFF
--- a/packages/angular/src/generators/remote/remote.ts
+++ b/packages/angular/src/generators/remote/remote.ts
@@ -1,4 +1,5 @@
 import {
+  addDependenciesToPackageJson,
   formatFiles,
   getProjects,
   runTasksInSerial,
@@ -13,6 +14,7 @@ import { setupMf } from '../setup-mf/setup-mf';
 import { getInstalledAngularVersionInfo } from '../utils/version-utils';
 import { addSsr, findNextAvailablePort } from './lib';
 import type { Schema } from './schema';
+import { swcHelpersVersion } from '@nx/js/src/utils/versions';
 
 export async function remote(tree: Tree, options: Schema) {
   return await remoteInternal(tree, {
@@ -76,7 +78,15 @@ export async function remoteInternal(tree: Tree, schema: Schema) {
     typescriptConfiguration,
   });
 
-  let installTasks = [appInstallTask];
+  const installSwcHelpersTask = addDependenciesToPackageJson(
+    tree,
+    {},
+    {
+      '@swc/helpers': swcHelpersVersion,
+    }
+  );
+
+  let installTasks = [appInstallTask, installSwcHelpersTask];
   if (options.ssr) {
     let ssrInstallTask = await addSsr(tree, {
       appName: remoteProjectName,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Trying to build a remote app in a fresh Angular workspace results in an error of missing a package "@swc/helpers"


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Ensure "@swc/helpers" is installed when generating an Angular Remote

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
