### PR TITLE
fix(vue): comment out unused defineProps function

### DIFF
--- a/packages/vue/src/generators/component/component.spec.ts
+++ b/packages/vue/src/generators/component/component.spec.ts
@@ -31,7 +31,7 @@ describe('component', () => {
     expect(appTree.read(`${libName}/src/lib/hello/hello.vue`, 'utf-8'))
       .toMatchInlineSnapshot(`
       "<script setup lang="ts">
-      defineProps<{}>();
+      // defineProps<{}>()
       </script>
 
       <template>

--- a/packages/vue/src/generators/component/files/__fileName__.vue__tmpl__
+++ b/packages/vue/src/generators/component/files/__fileName__.vue__tmpl__
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-defineProps<{}>()
+// defineProps<{}>()
 </script>
 
 <template>


### PR DESCRIPTION
Comment out the `defineProps` function in the vue component, to avoid ts errors if no props are defined.