### PR TITLE
fix(devkit): correct nx-json typing after plugin tweaks

### DIFF
--- a/docs/generated/devkit/NxJsonConfiguration.md
+++ b/docs/generated/devkit/NxJsonConfiguration.md
@@ -32,7 +32,7 @@ Nx.json configuration
 - [nxCloudEncryptionKey](../../devkit/documents/NxJsonConfiguration#nxcloudencryptionkey): string
 - [nxCloudUrl](../../devkit/documents/NxJsonConfiguration#nxcloudurl): string
 - [parallel](../../devkit/documents/NxJsonConfiguration#parallel): number
-- [plugins](../../devkit/documents/NxJsonConfiguration#plugins): PluginDefinition[]
+- [plugins](../../devkit/documents/NxJsonConfiguration#plugins): PluginConfiguration[]
 - [pluginsConfig](../../devkit/documents/NxJsonConfiguration#pluginsconfig): Record&lt;string, Record&lt;string, unknown&gt;&gt;
 - [release](../../devkit/documents/NxJsonConfiguration#release): NxReleaseConfiguration
 - [targetDefaults](../../devkit/documents/NxJsonConfiguration#targetdefaults): TargetDefaults
@@ -198,7 +198,7 @@ Specifies how many tasks can be run in parallel.
 
 ### plugins
 
-• `Optional` **plugins**: `PluginDefinition`[]
+• `Optional` **plugins**: [`PluginConfiguration`](../../devkit/documents/PluginConfiguration)[]
 
 Plugins for extending the project graph
 

--- a/docs/generated/devkit/PluginConfiguration.md
+++ b/docs/generated/devkit/PluginConfiguration.md
@@ -1,0 +1,3 @@
+# Type alias: PluginConfiguration
+
+Ƭ **PluginConfiguration**: `string` \| { `options?`: `unknown` ; `plugin`: `string` }

--- a/docs/generated/devkit/README.md
+++ b/docs/generated/devkit/README.md
@@ -77,6 +77,7 @@ It only uses language primitives and immutable objects
 - [NxPluginV1](../../devkit/documents/NxPluginV1)
 - [NxPluginV2](../../devkit/documents/NxPluginV2)
 - [PackageManager](../../devkit/documents/PackageManager)
+- [PluginConfiguration](../../devkit/documents/PluginConfiguration)
 - [ProjectGraphNode](../../devkit/documents/ProjectGraphNode)
 - [ProjectTargetConfigurator](../../devkit/documents/ProjectTargetConfigurator)
 - [ProjectType](../../devkit/documents/ProjectType)

--- a/docs/generated/devkit/Workspace.md
+++ b/docs/generated/devkit/Workspace.md
@@ -30,7 +30,7 @@ use ProjectsConfigurations or NxJsonConfiguration
 - [nxCloudEncryptionKey](../../devkit/documents/Workspace#nxcloudencryptionkey): string
 - [nxCloudUrl](../../devkit/documents/Workspace#nxcloudurl): string
 - [parallel](../../devkit/documents/Workspace#parallel): number
-- [plugins](../../devkit/documents/Workspace#plugins): PluginDefinition[]
+- [plugins](../../devkit/documents/Workspace#plugins): PluginConfiguration[]
 - [pluginsConfig](../../devkit/documents/Workspace#pluginsconfig): Record&lt;string, Record&lt;string, unknown&gt;&gt;
 - [projects](../../devkit/documents/Workspace#projects): Record&lt;string, ProjectConfiguration&gt;
 - [release](../../devkit/documents/Workspace#release): NxReleaseConfiguration
@@ -254,7 +254,7 @@ Specifies how many tasks can be run in parallel.
 
 ### plugins
 
-• `Optional` **plugins**: `PluginDefinition`[]
+• `Optional` **plugins**: [`PluginConfiguration`](../../devkit/documents/PluginConfiguration)[]
 
 Plugins for extending the project graph
 

--- a/docs/generated/packages/devkit/documents/nx_devkit.md
+++ b/docs/generated/packages/devkit/documents/nx_devkit.md
@@ -77,6 +77,7 @@ It only uses language primitives and immutable objects
 - [NxPluginV1](../../devkit/documents/NxPluginV1)
 - [NxPluginV2](../../devkit/documents/NxPluginV2)
 - [PackageManager](../../devkit/documents/PackageManager)
+- [PluginConfiguration](../../devkit/documents/PluginConfiguration)
 - [ProjectGraphNode](../../devkit/documents/ProjectGraphNode)
 - [ProjectTargetConfigurator](../../devkit/documents/ProjectTargetConfigurator)
 - [ProjectType](../../devkit/documents/ProjectType)

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -167,7 +167,7 @@ export interface NxJsonConfiguration<T = '*' | string[]> {
   /**
    * Plugins for extending the project graph
    */
-  plugins?: PluginDefinition[];
+  plugins?: PluginConfiguration[];
 
   /**
    * Configuration for Nx Plugins
@@ -225,9 +225,9 @@ export interface NxJsonConfiguration<T = '*' | string[]> {
   useDaemonProcess?: boolean;
 }
 
-export type PluginDefinition =
+export type PluginConfiguration =
   | string
-  | { plugin: string; options?: Record<string, unknown> };
+  | { plugin: string; options?: unknown };
 
 export function readNxJson(root: string = workspaceRoot): NxJsonConfiguration {
   const nxJson = join(root, 'nx.json');

--- a/packages/nx/src/devkit-exports.ts
+++ b/packages/nx/src/devkit-exports.ts
@@ -69,6 +69,7 @@ export type {
   ImplicitDependencyEntry,
   ImplicitJsonSubsetDependency,
   NxJsonConfiguration,
+  PluginConfiguration,
   TargetDefaults,
   NxAffectedConfig,
 } from './config/nx-json';

--- a/packages/nx/src/project-graph/nx-deps-cache.ts
+++ b/packages/nx/src/project-graph/nx-deps-cache.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'fs';
 import { ensureDirSync, renameSync } from 'fs-extra';
 import { join } from 'path';
 import { performance } from 'perf_hooks';
-import { NxJsonConfiguration, PluginDefinition } from '../config/nx-json';
+import { NxJsonConfiguration, PluginConfiguration } from '../config/nx-json';
 import {
   FileData,
   FileMap,
@@ -328,7 +328,7 @@ function processProjectNode(
 type PluginData = {
   name: string;
   version: string;
-  options?: Record<string, unknown>;
+  options?: unknown;
 };
 
 function getNxJsonPluginsData(

--- a/packages/nx/src/utils/nx-plugin.ts
+++ b/packages/nx/src/utils/nx-plugin.ts
@@ -27,7 +27,7 @@ import { normalizePath } from './path';
 import { dirname, join } from 'path';
 import { getNxRequirePaths } from './installation-directory';
 import { readTsConfig } from '../plugins/js/utils/typescript';
-import { NxJsonConfiguration, PluginDefinition } from '../config/nx-json';
+import { NxJsonConfiguration, PluginConfiguration } from '../config/nx-json';
 
 import type * as ts from 'typescript';
 import { retrieveProjectConfigurationsWithoutPluginInference } from '../project-graph/utils/retrieve-workspace-files';
@@ -194,14 +194,14 @@ function getPluginPathAndName(
 }
 
 export async function loadNxPluginAsync(
-  pluginDefinition: PluginDefinition,
+  pluginConfiguration: PluginConfiguration,
   paths: string[],
   root: string
 ): Promise<LoadedNxPlugin> {
   const { plugin: moduleName, options } =
-    typeof pluginDefinition === 'object'
-      ? pluginDefinition
-      : { plugin: pluginDefinition, options: undefined };
+    typeof pluginConfiguration === 'object'
+      ? pluginConfiguration
+      : { plugin: pluginConfiguration, options: undefined };
   let pluginModule = nxPluginCache.get(moduleName);
   if (pluginModule) {
     return { plugin: pluginModule, options };
@@ -217,14 +217,14 @@ export async function loadNxPluginAsync(
 }
 
 function loadNxPluginSync(
-  pluginDefinition: PluginDefinition,
+  pluginConfiguration: PluginConfiguration,
   paths: string[],
   root: string
 ): LoadedNxPlugin {
   const { plugin: moduleName, options } =
-    typeof pluginDefinition === 'object'
-      ? pluginDefinition
-      : { plugin: pluginDefinition, options: undefined };
+    typeof pluginConfiguration === 'object'
+      ? pluginConfiguration
+      : { plugin: pluginConfiguration, options: undefined };
   let pluginModule = nxPluginCache.get(moduleName);
   if (pluginModule) {
     return { plugin: pluginModule, options };
@@ -280,7 +280,7 @@ export function loadNxPluginsSync(
 }
 
 export async function loadNxPlugins(
-  plugins: PluginDefinition[],
+  plugins: PluginConfiguration[],
   paths = getNxRequirePaths(),
   root = workspaceRoot
 ): Promise<LoadedNxPlugin[]> {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The options typing in NxJsonConfiguration doesn't match the typing from LoadedNxPlugin / CreateNodes / etc

## Expected Behavior
The options typing in NxJsonConfiguration matches the typing from LoadedNxPlugin / CreateNodes / etc

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
