### PR TITLE
fix(core): only show cloud messaging when migrating if not using cloud

### DIFF
--- a/docs/generated/devkit/NxJsonConfiguration.md
+++ b/docs/generated/devkit/NxJsonConfiguration.md
@@ -236,7 +236,7 @@ Available Task Runners
 
 #### Index signature
 
-▪ [tasksRunnerName: `string`]: { `options?`: `any` ; `runner`: `string` }
+▪ [tasksRunnerName: `string`]: { `options?`: `any` ; `runner?`: `string` }
 
 ---
 

--- a/docs/generated/devkit/Workspace.md
+++ b/docs/generated/devkit/Workspace.md
@@ -320,7 +320,7 @@ Available Task Runners
 
 #### Index signature
 
-▪ [tasksRunnerName: `string`]: { `options?`: `any` ; `runner`: `string` }
+▪ [tasksRunnerName: `string`]: { `options?`: `any` ; `runner?`: `string` }
 
 #### Inherited from
 

--- a/packages/nx/src/command-line/connect/connect-to-nx-cloud.spec.ts
+++ b/packages/nx/src/command-line/connect/connect-to-nx-cloud.spec.ts
@@ -1,0 +1,70 @@
+import { onlyDefaultRunnerIsUsed } from './connect-to-nx-cloud';
+
+describe('connect-to-nx-cloud', () => {
+  describe('onlyDefaultRunnerIsUsed', () => {
+    it('should say no if tasks runner options is undefined and nxCloudAccessToken is set', () => {
+      expect(
+        onlyDefaultRunnerIsUsed({
+          nxCloudAccessToken: 'xxx-xx-xxx',
+        })
+      ).toBe(false);
+    });
+
+    it('should say yes if tasks runner options is undefined and nxCloudAccessToken is not set', () => {
+      expect(onlyDefaultRunnerIsUsed({})).toBe(true);
+    });
+
+    it('should say yes if tasks runner options is set to default runner', () => {
+      expect(
+        onlyDefaultRunnerIsUsed({
+          tasksRunnerOptions: {
+            default: {
+              runner: 'nx/tasks-runners/default',
+            },
+          },
+        })
+      ).toBeTruthy();
+    });
+
+    it('should say no if tasks runner is set to a custom runner', () => {
+      expect(
+        onlyDefaultRunnerIsUsed({
+          tasksRunnerOptions: {
+            default: {
+              runner: 'custom-runner',
+            },
+          },
+        })
+      ).toBeFalsy();
+    });
+
+    it('should say yes if tasks runner has options, but no runner and not using cloud', () => {
+      expect(
+        onlyDefaultRunnerIsUsed({
+          tasksRunnerOptions: {
+            default: {
+              options: {
+                foo: 'bar',
+              },
+            },
+          },
+        })
+      ).toBeTruthy();
+    });
+
+    it('should say no if tasks runner has options, but no runner and using cloud', () => {
+      expect(
+        onlyDefaultRunnerIsUsed({
+          tasksRunnerOptions: {
+            default: {
+              options: {
+                foo: 'bar',
+              },
+            },
+          },
+          nxCloudAccessToken: 'xxx-xx-xxx',
+        })
+      ).toBeFalsy();
+    });
+  });
+});

--- a/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
@@ -10,20 +10,16 @@ import { NxJsonConfiguration } from '../../config/nx-json';
 import { NxArgs } from '../../utils/command-line-utils';
 
 export function onlyDefaultRunnerIsUsed(nxJson: NxJsonConfiguration) {
-  if (!nxJson.tasksRunnerOptions) {
-    // No tasks runner options:
+  const defaultRunner = nxJson.tasksRunnerOptions?.default?.runner;
+
+  if (!defaultRunner) {
+    // No tasks runner options OR no default runner defined:
     // - If access token defined, uses cloud runner
     // - If no access token defined, uses default
     return !nxJson.nxCloudAccessToken;
   }
-  const defaultRunner = nxJson.tasksRunnerOptions?.default;
-  if (
-    !defaultRunner.runner ||
-    defaultRunner.runner === 'nx/tasks-runners/default'
-  ) {
-    return true;
-  }
-  return false;
+
+  return defaultRunner === 'nx/tasks-runners/default';
 }
 
 export async function connectToNxCloudIfExplicitlyAsked(

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -126,7 +126,7 @@ export interface NxJsonConfiguration<T = '*' | string[]> {
       /**
        * Path to resolve the runner
        */
-      runner: string;
+      runner?: string;
       /**
        * Default options for the runner
        */


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
nx migrate shows some messaging about cloud even if already connected

## Expected Behavior
nx migrate only shows messaging if not connected.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
