### PR TITLE
fix(nx-plugin): add nameAndDirectoryFormat to schema for generator,ex…

### DIFF
--- a/docs/generated/packages/plugin/generators/executor.json
+++ b/docs/generated/packages/plugin/generators/executor.json
@@ -51,7 +51,7 @@
         "description": "Do not add an eslint configuration for plugin json files."
       },
       "nameAndDirectoryFormat": {
-        "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
+        "description": "Whether to generate the executor in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
         "type": "string",
         "enum": ["as-provided", "derived"]
       },

--- a/docs/generated/packages/plugin/generators/generator.json
+++ b/docs/generated/packages/plugin/generators/generator.json
@@ -56,6 +56,11 @@
         "default": false,
         "description": "Do not format files with prettier.",
         "x-priority": "internal"
+      },
+      "nameAndDirectoryFormat": {
+        "description": "Whether to generate the generator in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
+        "type": "string",
+        "enum": ["as-provided", "derived"]
       }
     },
     "required": ["name"],

--- a/docs/generated/packages/plugin/generators/migration.json
+++ b/docs/generated/packages/plugin/generators/migration.json
@@ -54,6 +54,11 @@
         "type": "boolean",
         "default": false,
         "description": "Do not eslint configuration for plugin json files."
+      },
+      "nameAndDirectoryFormat": {
+        "description": "Whether to generate the migration in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
+        "type": "string",
+        "enum": ["as-provided", "derived"]
       }
     },
     "required": ["packageVersion"],

--- a/packages/plugin/src/generators/executor/schema.json
+++ b/packages/plugin/src/generators/executor/schema.json
@@ -51,7 +51,7 @@
       "description": "Do not add an eslint configuration for plugin json files."
     },
     "nameAndDirectoryFormat": {
-      "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
+      "description": "Whether to generate the executor in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
       "type": "string",
       "enum": ["as-provided", "derived"]
     },

--- a/packages/plugin/src/generators/generator/schema.json
+++ b/packages/plugin/src/generators/generator/schema.json
@@ -58,6 +58,11 @@
       "default": false,
       "description": "Do not format files with prettier.",
       "x-priority": "internal"
+    },
+    "nameAndDirectoryFormat": {
+      "description": "Whether to generate the generator in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
+      "type": "string",
+      "enum": ["as-provided", "derived"]
     }
   },
   "required": ["name"],

--- a/packages/plugin/src/generators/migration/schema.json
+++ b/packages/plugin/src/generators/migration/schema.json
@@ -56,6 +56,11 @@
       "type": "boolean",
       "default": false,
       "description": "Do not eslint configuration for plugin json files."
+    },
+    "nameAndDirectoryFormat": {
+      "description": "Whether to generate the migration in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
+      "type": "string",
+      "enum": ["as-provided", "derived"]
     }
   },
   "required": ["packageVersion"],


### PR DESCRIPTION
…ecutor,migration generators

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

nameAndDirectoryFormat is not an option on generator, migration, and executor generators.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

nameAndDirectoryFormat is an option on generator, migration, and executor generators.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
