### PR TITLE
chore(testing): address flakiness of cypress e2e test when using --port=cypress-auto

### DIFF
--- a/e2e/cypress/src/cypress.test.ts
+++ b/e2e/cypress/src/cypress.test.ts
@@ -158,10 +158,6 @@ describe('env vars', () => {
   it(
     'should run e2e in parallel',
     async () => {
-      // ensure ports are free before running tests
-      await killPort(4200);
-      await killPort(4201);
-
       const ngAppName = uniq('ng-app');
       runCLI(
         `generate @nx/angular:app ${ngAppName} --e2eTestRunner=cypress --linter=eslint --no-interactive`
@@ -171,13 +167,7 @@ describe('env vars', () => {
         const results = runCLI(
           `run-many --target=e2e --parallel=2 --port=cypress-auto --output-style=stream`
         );
-        expect(results).toContain('Using port 4200');
-        expect(results).toContain('Using port 4201');
         expect(results).toContain('Successfully ran target e2e for 2 projects');
-        checkFilesDoNotExist(
-          `node_modules/@nx/cypress/src/executors/cypress/4200.txt`,
-          `node_modules/@nx/cypress/src/executors/cypress/4201.txt`
-        );
       }
     },
     TEN_MINS_MS


### PR DESCRIPTION
Since the test is passing `--port=cypres-auto`, it could be ports other than `4200` and `4201`. We only really care about the two tests being run and passing, so checking `Successfully ran target e2e for 2 projects` is enough.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
