### PR TITLE
docs(core): add nx console troubshooting guide

### DIFF
--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -2345,6 +2345,14 @@
                 "isExternal": false,
                 "children": [],
                 "disableCollapsible": false
+              },
+              {
+                "name": "Troubleshooting",
+                "path": "/recipes/nx-console/console-troubleshooting",
+                "id": "console-troubleshooting",
+                "isExternal": false,
+                "children": [],
+                "disableCollapsible": false
               }
             ],
             "disableCollapsible": false
@@ -4063,6 +4071,14 @@
             "isExternal": false,
             "children": [],
             "disableCollapsible": false
+          },
+          {
+            "name": "Troubleshooting",
+            "path": "/recipes/nx-console/console-troubleshooting",
+            "id": "console-troubleshooting",
+            "isExternal": false,
+            "children": [],
+            "disableCollapsible": false
           }
         ],
         "disableCollapsible": false
@@ -4111,6 +4127,14 @@
         "name": "Keyboard Shortcuts",
         "path": "/recipes/nx-console/console-shortcuts",
         "id": "console-shortcuts",
+        "isExternal": false,
+        "children": [],
+        "disableCollapsible": false
+      },
+      {
+        "name": "Troubleshooting",
+        "path": "/recipes/nx-console/console-troubleshooting",
+        "id": "console-troubleshooting",
         "isExternal": false,
         "children": [],
         "disableCollapsible": false

--- a/docs/generated/manifests/nx.json
+++ b/docs/generated/manifests/nx.json
@@ -2923,6 +2923,16 @@
             "isExternal": false,
             "path": "/recipes/nx-console/console-shortcuts",
             "tags": ["integrate-with-editors"]
+          },
+          {
+            "id": "console-troubleshooting",
+            "name": "Troubleshooting",
+            "description": "",
+            "file": "shared/recipes/console-troubleshooting",
+            "itemList": [],
+            "isExternal": false,
+            "path": "/recipes/nx-console/console-troubleshooting",
+            "tags": ["integrate-with-editors"]
           }
         ],
         "isExternal": false,
@@ -5067,6 +5077,16 @@
         "isExternal": false,
         "path": "/recipes/nx-console/console-shortcuts",
         "tags": ["integrate-with-editors"]
+      },
+      {
+        "id": "console-troubleshooting",
+        "name": "Troubleshooting",
+        "description": "",
+        "file": "shared/recipes/console-troubleshooting",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/recipes/nx-console/console-troubleshooting",
+        "tags": ["integrate-with-editors"]
       }
     ],
     "isExternal": false,
@@ -5131,6 +5151,16 @@
     "itemList": [],
     "isExternal": false,
     "path": "/recipes/nx-console/console-shortcuts",
+    "tags": ["integrate-with-editors"]
+  },
+  "/recipes/nx-console/console-troubleshooting": {
+    "id": "console-troubleshooting",
+    "name": "Troubleshooting",
+    "description": "",
+    "file": "shared/recipes/console-troubleshooting",
+    "itemList": [],
+    "isExternal": false,
+    "path": "/recipes/nx-console/console-troubleshooting",
     "tags": ["integrate-with-editors"]
   },
   "/recipes/other": {

--- a/docs/generated/manifests/tags.json
+++ b/docs/generated/manifests/tags.json
@@ -412,6 +412,13 @@
       "id": "console-shortcuts",
       "name": "Keyboard Shortcuts",
       "path": "/recipes/nx-console/console-shortcuts"
+    },
+    {
+      "description": "",
+      "file": "shared/recipes/console-troubleshooting",
+      "id": "console-troubleshooting",
+      "name": "Troubleshooting",
+      "path": "/recipes/nx-console/console-troubleshooting"
     }
   ],
   "use-task-executors": [

--- a/docs/map.json
+++ b/docs/map.json
@@ -1131,6 +1131,12 @@
                   "id": "console-shortcuts",
                   "tags": ["integrate-with-editors"],
                   "file": "shared/recipes/console-shortcuts"
+                },
+                {
+                  "name": "Troubleshooting",
+                  "id": "console-troubleshooting",
+                  "tags": ["integrate-with-editors"],
+                  "file": "shared/recipes/console-troubleshooting"
                 }
               ]
             },

--- a/docs/shared/recipes/console-troubleshooting.md
+++ b/docs/shared/recipes/console-troubleshooting.md
@@ -1,0 +1,17 @@
+# Nx Console Troubleshooting
+
+## VSCode + nvm Issues
+
+VSCode loads a version of Node when it starts. It can use versions set via [`nvm`](https://github.com/nvm-sh/nvm) but there's some caveats.
+
+- If you've installed Node outside of `nvm` (for example using their installer or `brew` on Mac), VSCode will always use that version. You can check by running `nvm list` and looking for a `system` alias. To enable VSCode to pick up your `nvm` version, make sure to uninstall it.
+- VSCode will load the `default` alias from `nvm` at startup. You can set it by running `nvm alias default [version]`. To make sure VSCode can load the correct value needs to be set in your OS' default terminal. Setting it in a VSCode-integrated terminal won't persist after it's closed. Similarly, setting it in a third-party app like iTerm won't influence VSCode by default.
+- VSCode only loads the `default` version when the app is first started. This means that in order to change it, you need to close all VSCode windows and restart the app - running `Reload Window` won't work.
+- If you work with lots of different Node versions, there are various VSCode extensions available to dynamically run `nvm use` whenever you open a new integrated terminal. Search for `nvm`.
+- You can set a static version by using a launch configuration with `runtimeVersion` set. Refer to [this guide](https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_multi-version-support).
+
+We try to make noticing discrepancies easier by showing you the currently loaded Node version on startup. You can disable this in the Nx Console settings.
+
+## JetBrains WSL Support
+
+The Node interpreter under Languages & Frameworks > Node.js needs to be configured to use the Node executable within the WSL distribution. You can read more on the [official Jetbrains docs](https://www.jetbrains.com/help/webstorm/how-to-use-wsl-development-environment-in-product.html#ws_wsl_node_interpreter_configure).

--- a/docs/shared/recipes/console-troubleshooting.md
+++ b/docs/shared/recipes/console-troubleshooting.md
@@ -2,10 +2,10 @@
 
 ## VSCode + nvm Issues
 
-VSCode loads a version of Node when it starts. It can use versions set via [`nvm`](https://github.com/nvm-sh/nvm) but there's some caveats.
+VSCode loads a version of Node when it starts. It can use versions set via [`nvm`](https://github.com/nvm-sh/nvm) but there are some caveats.
 
-- If you've installed Node outside of `nvm` (for example using their installer or `brew` on Mac), VSCode will always use that version. You can check by running `nvm list` and looking for a `system` alias. To enable VSCode to pick up your `nvm` version, make sure to uninstall it.
-- VSCode will load the `default` alias from `nvm` at startup. You can set it by running `nvm alias default [version]`. To make sure VSCode can load the correct value needs to be set in your OS' default terminal. Setting it in a VSCode-integrated terminal won't persist after it's closed. Similarly, setting it in a third-party app like iTerm won't influence VSCode by default.
+- If you've installed Node outside of `nvm` (for example using the Node installer or `brew` on Mac), VSCode will always use that version. You can check by running `nvm list` and looking for a `system` alias. To enable VSCode to pick up your `nvm` version, make sure to uninstall the version of Node that was installed outside of `nvm`.
+- VSCode will load the `default` alias from `nvm` at startup. You can set it by running `nvm alias default [version]`. The `default` alias needs to be set in your OS' default terminal for VSCode to pick it up. Setting it in a VSCode-integrated terminal won't persist after it's closed. Similarly, setting it in a third-party app like iTerm won't influence VSCode by default.
 - VSCode only loads the `default` version when the app is first started. This means that in order to change it, you need to close all VSCode windows and restart the app - running `Reload Window` won't work.
 - If you work with lots of different Node versions, there are various VSCode extensions available to dynamically run `nvm use` whenever you open a new integrated terminal. Search for `nvm`.
 - You can set a static version by using a launch configuration with `runtimeVersion` set. Refer to [this guide](https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_multi-version-support).

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -190,6 +190,7 @@
       - [Add Dependency Command](/recipes/nx-console/console-add-dependency-command)
       - [Project Pane](/recipes/nx-console/console-project-pane)
       - [Keyboard Shortcuts](/recipes/nx-console/console-shortcuts)
+      - [Troubleshooting](/recipes/nx-console/console-troubleshooting)
     - [Other](/recipes/other)
       - [Rescope Packages from @nrwl to @nx](/recipes/other/rescope)
   - [Showcase](/showcase)


### PR DESCRIPTION
This PR adds a troubleshooting guide for Nx Console to nx.dev.
We've been having a lot of issues submitted about VSCode + nvm so it's good to have a place to point folks to and also one they might find through google.
This will also be linked to from an Nx Console feature I'm building to make it even more discoverable.

![image](https://github.com/nrwl/nx/assets/34165455/6d9bbd13-cc32-4519-b36a-1e1274650753)
