### PR TITLE
chore(core): remove deprecated re-export

### DIFF
--- a/packages/nx/src/utils/register.ts
+++ b/packages/nx/src/utils/register.ts
@@ -1,2 +1,0 @@
-// TODO(v17): remove this re-export
-export * from '../plugins/js/utils/register';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`registerTsProject` is exported from `nx/src/utils/register`;

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`registerTsProject` is not exported from `nx/src/utils/register`; This is private API so you probably shouldn't import this.. but it is also available at `@nx/js/src/internal`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
