### PR TITLE
fix(react): Error when invalid path is provided to federate-module generator

### DIFF
--- a/docs/generated/packages/react/generators/federate-module.json
+++ b/docs/generated/packages/react/generators/federate-module.json
@@ -25,7 +25,7 @@
       },
       "path": {
         "type": "string",
-        "description": "The path to locate the federated module.",
+        "description": "The path to locate the federated module. This path should be relative to the workspace root and the file should exist.",
         "x-prompt": "What is the path to the module to be federated?"
       },
       "remote": {

--- a/packages/angular/src/generators/federate-module/federate-module.ts
+++ b/packages/angular/src/generators/federate-module/federate-module.ts
@@ -15,7 +15,7 @@ import {
 
 export async function federateModuleGenerator(tree: Tree, schema: Schema) {
   if (!tree.exists(schema.path)) {
-    throw new Error(stripIndents`The "path" provided does not exist. Please verify the path is correct and pointing to a file that exists in the workspace.
+    throw new Error(stripIndents`The "path" provided  does not exist. Please verify the path is correct and pointing to a file that exists in the workspace.
     
     Path: ${schema.path}`);
   }

--- a/packages/react/src/generators/federate-module/federate-module.spec.ts
+++ b/packages/react/src/generators/federate-module/federate-module.spec.ts
@@ -17,6 +17,7 @@ describe('federate-module', () => {
 
   beforeAll(() => {
     tree = createTreeWithEmptyWorkspace();
+    tree.write('my-remote/src/my-federated-module.ts', ''); // Ensure that the file exists
   });
   describe('no remote', () => {
     it('should generate a remote and e2e', async () => {
@@ -45,6 +46,17 @@ describe('federate-module', () => {
       expect(
         tsconfig.compilerOptions.paths['my-remote/my-federated-module']
       ).toEqual(['my-remote/src/my-federated-module.ts']);
+    });
+
+    it('should error when invalid path is provided', async () => {
+      await federateModuleGenerator(tree, {
+        ...schema,
+        path: 'invalid/path',
+      }).catch((e) => {
+        expect(e.message).toContain(
+          'The "path" provided  does not exist. Please verify the path is correct and pointing to a file that exists in the workspace.'
+        );
+      });
     });
   });
 

--- a/packages/react/src/generators/federate-module/federate-module.ts
+++ b/packages/react/src/generators/federate-module/federate-module.ts
@@ -5,6 +5,7 @@ import {
   logger,
   readJson,
   runTasksInSerial,
+  stripIndents,
 } from '@nx/devkit';
 import { Schema } from './schema';
 
@@ -14,6 +15,12 @@ import { determineProjectNameAndRootOptions } from '@nx/devkit/src/generators/pr
 import { addTsConfigPath, getRootTsConfigPathInTree } from '@nx/js';
 
 export async function federateModuleGenerator(tree: Tree, schema: Schema) {
+  // Check if the file exists
+  if (!tree.exists(schema.path)) {
+    throw new Error(stripIndents`The "path" provided  does not exist. Please verify the path is correct and pointing to a file that exists in the workspace.
+    
+    Path: ${schema.path}`);
+  }
   const tasks: GeneratorCallback[] = [];
   // Check remote exists
   const remote = checkRemoteExists(tree, schema.remote);

--- a/packages/react/src/generators/federate-module/schema.json
+++ b/packages/react/src/generators/federate-module/schema.json
@@ -25,7 +25,7 @@
     },
     "path": {
       "type": "string",
-      "description": "The path to locate the federated module.",
+      "description": "The path to locate the federated module. This path should be relative to the workspace root and the file should exist.",
       "x-prompt": "What is the path to the module to be federated?"
     },
     "remote": {


### PR DESCRIPTION
We should ensure that when the user provides `--path` to the `federate-module` generator the file already exists.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We allow any path to be provided.
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Only files that currently exists.
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
