### PR TITLE
 fix(core): fix rm defaultCollection migration

### DIFF
--- a/packages/nx/src/migrations/update-17-0-0/rm-default-collection-npm-scope.spec.ts
+++ b/packages/nx/src/migrations/update-17-0-0/rm-default-collection-npm-scope.spec.ts
@@ -43,6 +43,14 @@ describe('rm-default-collection-npm-scope migration', () => {
       await update(tree);
       expect(readJson(tree, 'nx.json').cli).not.toBeDefined();
     });
+
+    it('should work if cli is not defined', async () => {
+      updateJson(tree, 'nx.json', (j) => {
+        delete j.cli;
+        return j;
+      });
+      await update(tree);
+    });
   });
 
   describe('without nx.json', () => {

--- a/packages/nx/src/migrations/update-17-0-0/rm-default-collection-npm-scope.ts
+++ b/packages/nx/src/migrations/update-17-0-0/rm-default-collection-npm-scope.ts
@@ -13,10 +13,12 @@ export default async function update(tree: Tree) {
 
   const nxJson = readNxJson(tree);
 
-  delete nxJson.cli?.['defaultCollection'];
+  if (nxJson.cli) {
+    delete nxJson.cli?.['defaultCollection'];
 
-  if (Object.keys(nxJson.cli).length < 1) {
-    delete nxJson.cli;
+    if (Object.keys(nxJson.cli).length < 1) {
+      delete nxJson.cli;
+    }
   }
 
   warnNpmScopeHasChanged(tree, nxJson);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The migration for removing `defaultCollection` fails when `nx.json` does not have a `cli` property defined.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The migration for removing `defaultCollection` succeeds when `nx.json` does not have a `cli` property defined.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
