### PR TITLE
fix(rollup): use workspace rootDir while compiling TS files

### DIFF
--- a/packages/rollup/src/executors/rollup/rollup.impl.ts
+++ b/packages/rollup/src/executors/rollup/rollup.impl.ts
@@ -306,7 +306,7 @@ function createTsCompilerOptions(
 ) {
   const compilerOptionPaths = computeCompilerOptionsPaths(config, dependencies);
   const compilerOptions = {
-    rootDir: options.projectRoot,
+    rootDir: config.options.rootDir,
     allowJs: options.allowJs,
     declaration: true,
     paths: compilerOptionPaths,


### PR DESCRIPTION
Fixes #11289

Tested this approach on real project using [pnpm's patch mechanism](https://pnpm.io/cli/patch)
