### PR TITLE
fix(js): use workspace rootDir while compiling TS files

### DIFF
--- a/packages/workspace/src/utilities/typescript/compilation.ts
+++ b/packages/workspace/src/utilities/typescript/compilation.ts
@@ -145,7 +145,7 @@ function getNormalizedTsConfig(options: TypeScriptCompilationOptions) {
   const tsConfig = readTsConfig(options.tsConfig);
   tsConfig.options.outDir = options.outputPath;
   tsConfig.options.noEmitOnError = true;
-  tsConfig.options.rootDir = options.rootDir;
+  tsConfig.options.rootDir = '.';
   if (tsConfig.options.incremental && !tsConfig.options.tsBuildInfoFile) {
     tsConfig.options.tsBuildInfoFile = joinPathFragments(
       options.outputPath,


### PR DESCRIPTION
Fixes #11583

Tested this approach for some time already on real project using [pnpm's patch mechanism](https://pnpm.io/cli/patch)
