### PR TITLE
feat(react-native): run pod commands with bundler

### DIFF
--- a/docs/generated/packages/react-native/executors/pod-install.json
+++ b/docs/generated/packages/react-native/executors/pod-install.json
@@ -25,6 +25,11 @@
         "description": "Disallow any changes to the Podfile or the Podfile.lock during installation.",
         "type": "boolean",
         "default": false
+      },
+      "useBundler": {
+        "description": "Run cocoapods within a Bundler environment, i.e. with the `bundle exec pod install` command",
+        "type": "boolean",
+        "default": false
       }
     },
     "required": ["buildFolder"],

--- a/packages/react-native/src/executors/pod-install/schema.d.ts
+++ b/packages/react-native/src/executors/pod-install/schema.d.ts
@@ -2,4 +2,5 @@ export interface ReactNativePodInstallOptions {
   buildFolder: string; // default is './build'
   repoUpdate: boolean; // default is false
   deployment: boolean; // default is false
+  useBundler: boolean; // default is false
 }

--- a/packages/react-native/src/executors/pod-install/schema.json
+++ b/packages/react-native/src/executors/pod-install/schema.json
@@ -22,6 +22,11 @@
       "description": "Disallow any changes to the Podfile or the Podfile.lock during installation.",
       "type": "boolean",
       "default": false
+    },
+    "useBundler": {
+      "description": "Run cocoapods within a Bundler environment, i.e. with the `bundle exec pod install` command",
+      "type": "boolean",
+      "default": false
     }
   },
   "required": ["buildFolder"]

--- a/packages/react-native/src/utils/pod-install-task.ts
+++ b/packages/react-native/src/utils/pod-install-task.ts
@@ -28,10 +28,12 @@ export function runPodInstall(
     buildFolder?: string;
     repoUpdate?: boolean;
     deployment?: boolean;
+    useBundler?: boolean;
   } = {
     buildFolder: './build',
     repoUpdate: false,
     deployment: false,
+    useBundler: false,
   }
 ): GeneratorCallback {
   return () => {
@@ -57,10 +59,12 @@ export function podInstall(
     buildFolder?: string;
     repoUpdate?: boolean;
     deployment?: boolean;
+    useBundler?: boolean;
   } = {
     buildFolder: './build',
     repoUpdate: false,
     deployment: false,
+    useBundler: false,
   }
 ) {
   try {
@@ -70,15 +74,15 @@ export function podInstall(
         stdio: 'inherit',
       });
     }
-    execSync(
-      `pod install ${options.repoUpdate ? '--repo-update' : ''} ${
-        options.deployment ? '--deployment' : ''
-      }`,
-      {
-        cwd: iosDirectory,
-        stdio: 'inherit',
-      }
-    );
+    const podCommand = [
+      options.useBundler ? 'bundle exec pod install' : 'pod install',
+      options.repoUpdate ? '--repo-update' : '',
+      options.deployment ? '--deployment' : '',
+    ].join(' ');
+    execSync(podCommand, {
+      cwd: iosDirectory,
+      stdio: 'inherit',
+    });
   } catch (e) {
     logger.error(podInstallErrorMessage);
     throw e;


### PR DESCRIPTION
closed #19698

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
`pod install` command is run with the local installed version of cocoapods. This could lead to dependency misalignment or inconsistencies.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Allow the possibility to handle the cocoapods version by Gem and run the `pod install` command with `bundle exec` to ensure everyone in a team use the same package versions.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #19698
