### PR TITLE
fix(js): update esbuild version

### DIFF
--- a/packages/js/migrations.json
+++ b/packages/js/migrations.json
@@ -96,6 +96,15 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "17.0.0": {
+      "version": "17.0.0-rc.2",
+      "packages": {
+        "esbuild": {
+          "version": "^0.19.2",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/js/src/utils/versions.ts
+++ b/packages/js/src/utils/versions.ts
@@ -1,6 +1,6 @@
 export const nxVersion = require('../../package.json').version;
 
-export const esbuildVersion = '^0.17.17';
+export const esbuildVersion = '^0.19.2';
 export const prettierVersion = '^2.6.2';
 export const swcCliVersion = '~0.1.62';
 export const swcCoreVersion = '~1.3.85';


### PR DESCRIPTION
## Current Behavior
[Esbuild version installed by js](https://github.com/nrwl/nx/blob/b9e671c11d77e2c47880f0cf60bde64c5d2aa449/packages/js/src/utils/versions.ts#L3) generator does not match [esbuild version used on Nx repo](https://github.com/nrwl/nx/blob/master/package.json#L167). This causes issues with mismatch versions on install.

## Expected Behavior
match two versions. update version on js generator, and add migration too.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #19270
