### PR TITLE
fix(nx-cloud): fix nx connect throwing if run twice

### DIFF
--- a/packages/nx/src/utils/nx-cloud-utils.ts
+++ b/packages/nx/src/utils/nx-cloud-utils.ts
@@ -24,7 +24,7 @@ export function getNxCloudToken(nxJson: NxJsonConfiguration): string {
   );
 
   if (!cloudRunner && !nxJson.nxCloudAccessToken)
-    throw new Error('nx-cloud runner not find in nx.json');
+    throw new Error('nx-cloud runner not found in nx.json');
 
-  return cloudRunner.options.accessToken ?? nxJson.nxCloudAccessToken;
+  return cloudRunner?.options.accessToken ?? nxJson.nxCloudAccessToken;
 }


### PR DESCRIPTION
repro is pretty simple - run `nx connect` twice
![image](https://github.com/nrwl/nx/assets/34165455/1c7ddae3-b1b8-454b-8a42-6aada6836b03)
