### PR TITLE
fix(core): check nxjson cli exists before looking for keys

### DIFF
--- a/packages/nx/src/migrations/update-17-0-0/rm-default-collection-npm-scope.ts
+++ b/packages/nx/src/migrations/update-17-0-0/rm-default-collection-npm-scope.ts
@@ -15,7 +15,7 @@ export default async function update(tree: Tree) {
 
   delete nxJson.cli?.['defaultCollection'];
 
-  if (Object.keys(nxJson.cli).length < 1) {
+  if (nxJson?.cli && Object.keys(nxJson.cli).length < 1) {
     delete nxJson.cli;
   }
 


### PR DESCRIPTION
## Current Behavior

```
nx migrate next
```
and 

```
nx migrate --run-migrations
```
gets error:
```
 >  NX   Running migrations from 'migrations.json'


 >  NX   Failed to run rm-default-collection-npm-scope from nx. This workspace is NOT up to date!


 >  NX   Cannot convert undefined or null to object
```

## Expected Behavior
Check `nxJson.cli` exists before checking keys.


