### PR TITLE
fix(angular): federate-module should support as-provided for new remotes

### DIFF
--- a/docs/generated/packages/angular/generators/federate-module.json
+++ b/docs/generated/packages/angular/generators/federate-module.json
@@ -9,7 +9,7 @@
     "description": "Create a federated module, which is exposed by a remote and can be subsequently loaded by a host.",
     "examples": [
       {
-        "command": "nx g federate-module MyModule --path=./src/component/my-cmp.ts --remote=my-remote-app",
+        "command": "nx g federate-module MyModule --path=./src/component/my-cmp.ts --remote=my-remote-app --remoteDirectory=apps/my-remote-app",
         "description": "Create a federated module from my-remote-app, that exposes my-cmp from ./src/component/my-cmp.ts as MyModule."
       }
     ],
@@ -32,6 +32,10 @@
         "type": "string",
         "description": "The name of the remote.",
         "x-prompt": "What is/should the remote be named?"
+      },
+      "remoteDirectory": {
+        "description": "The directory of the new remote application if one needs to be created.",
+        "type": "string"
       },
       "projectNameAndRootFormat": {
         "description": "Whether to generate the project name and root directory as provided (`as-provided`) or generate them composing their values and taking the configured layout into account (`derived`).",

--- a/docs/generated/packages/react/generators/federate-module.json
+++ b/docs/generated/packages/react/generators/federate-module.json
@@ -9,7 +9,7 @@
     "description": "Create a federated module, which can be loaded by a remote host.",
     "examples": [
       {
-        "command": "nx g federate-module MyModule --path=./src/component/my-cmp.ts --remote=my-remote-app",
+        "command": "nx g federate-module MyModule --path=./src/component/my-cmp.ts --remote=my-remote-app --remoteDirectory=apps/my-remote-app",
         "description": "Create a federated module from my-remote-app, that exposes my-cmp from ./src/component/my-cmp.ts as MyModule."
       }
     ],
@@ -33,6 +33,10 @@
         "description": "The name of the remote.",
         "x-prompt": "What is/should the remote be named?"
       },
+      "remoteDirectory": {
+        "description": "The directory of the new remote application if one needs to be created.",
+        "type": "string"
+      },
       "projectNameAndRootFormat": {
         "description": "Whether to generate the project name and root directory as provided (`as-provided`) or generate them composing their values and taking the configured layout into account (`derived`).",
         "type": "string",
@@ -41,40 +45,8 @@
       "style": {
         "description": "The file extension to be used for style files.",
         "type": "string",
-        "default": "css",
-        "alias": "s",
-        "x-prompt": {
-          "message": "Which stylesheet format would you like to use?",
-          "type": "list",
-          "items": [
-            { "value": "css", "label": "CSS" },
-            {
-              "value": "scss",
-              "label": "SASS(.scss)       [ http://sass-lang.com                     ]"
-            },
-            {
-              "value": "less",
-              "label": "LESS              [ http://lesscss.org                       ]"
-            },
-            {
-              "value": "styled-components",
-              "label": "styled-components [ https://styled-components.com            ]"
-            },
-            {
-              "value": "@emotion/styled",
-              "label": "emotion           [ https://emotion.sh                       ]"
-            },
-            {
-              "value": "styled-jsx",
-              "label": "styled-jsx        [ https://www.npmjs.com/package/styled-jsx ]"
-            },
-            {
-              "value": "styl",
-              "label": "DEPRECATD: Stylus(.styl) [ http://stylus-lang.com            ]"
-            },
-            { "value": "none", "label": "None" }
-          ]
-        }
+        "default": "none",
+        "alias": "s"
       },
       "linter": {
         "description": "The tool to use for running lint checks.",

--- a/packages/angular/src/generators/federate-module/schema.d.ts
+++ b/packages/angular/src/generators/federate-module/schema.d.ts
@@ -5,6 +5,7 @@ export interface Schema {
   name: string;
   path: string;
   remote: string;
+  remoteDirectory?: string;
   host?: string;
   projectNameAndRootFormat?: ProjectNameAndRootFormat;
   unitTestRunner?: UnitTestRunner;

--- a/packages/angular/src/generators/federate-module/schema.json
+++ b/packages/angular/src/generators/federate-module/schema.json
@@ -6,7 +6,7 @@
   "description": "Create a federated module, which is exposed by a remote and can be subsequently loaded by a host.",
   "examples": [
     {
-      "command": "nx g federate-module MyModule --path=./src/component/my-cmp.ts --remote=my-remote-app",
+      "command": "nx g federate-module MyModule --path=./src/component/my-cmp.ts --remote=my-remote-app --remoteDirectory=apps/my-remote-app",
       "description": "Create a federated module from my-remote-app, that exposes my-cmp from ./src/component/my-cmp.ts as MyModule."
     }
   ],
@@ -32,6 +32,10 @@
       "type": "string",
       "description": "The name of the remote.",
       "x-prompt": "What is/should the remote be named?"
+    },
+    "remoteDirectory": {
+      "description": "The directory of the new remote application if one needs to be created.",
+      "type": "string"
     },
     "projectNameAndRootFormat": {
       "description": "Whether to generate the project name and root directory as provided (`as-provided`) or generate them composing their values and taking the configured layout into account (`derived`).",

--- a/packages/react/src/generators/federate-module/schema.d.ts
+++ b/packages/react/src/generators/federate-module/schema.d.ts
@@ -2,6 +2,7 @@ export interface Schema {
   name: string;
   path: string;
   remote: string;
+  remoteDirectory?: string;
   projectNameAndRootFormat?: ProjectNameAndRootFormat;
   e2eTestRunner?: 'cypress' | 'none';
   host?: string;

--- a/packages/react/src/generators/federate-module/schema.json
+++ b/packages/react/src/generators/federate-module/schema.json
@@ -6,7 +6,7 @@
   "description": "Create a federated module, which can be loaded by a remote host.",
   "examples": [
     {
-      "command": "nx g federate-module MyModule --path=./src/component/my-cmp.ts --remote=my-remote-app",
+      "command": "nx g federate-module MyModule --path=./src/component/my-cmp.ts --remote=my-remote-app --remoteDirectory=apps/my-remote-app",
       "description": "Create a federated module from my-remote-app, that exposes my-cmp from ./src/component/my-cmp.ts as MyModule."
     }
   ],
@@ -33,6 +33,10 @@
       "description": "The name of the remote.",
       "x-prompt": "What is/should the remote be named?"
     },
+    "remoteDirectory": {
+      "description": "The directory of the new remote application if one needs to be created.",
+      "type": "string"
+    },
     "projectNameAndRootFormat": {
       "description": "Whether to generate the project name and root directory as provided (`as-provided`) or generate them composing their values and taking the configured layout into account (`derived`).",
       "type": "string",
@@ -41,46 +45,8 @@
     "style": {
       "description": "The file extension to be used for style files.",
       "type": "string",
-      "default": "css",
-      "alias": "s",
-      "x-prompt": {
-        "message": "Which stylesheet format would you like to use?",
-        "type": "list",
-        "items": [
-          {
-            "value": "css",
-            "label": "CSS"
-          },
-          {
-            "value": "scss",
-            "label": "SASS(.scss)       [ http://sass-lang.com                     ]"
-          },
-          {
-            "value": "less",
-            "label": "LESS              [ http://lesscss.org                       ]"
-          },
-          {
-            "value": "styled-components",
-            "label": "styled-components [ https://styled-components.com            ]"
-          },
-          {
-            "value": "@emotion/styled",
-            "label": "emotion           [ https://emotion.sh                       ]"
-          },
-          {
-            "value": "styled-jsx",
-            "label": "styled-jsx        [ https://www.npmjs.com/package/styled-jsx ]"
-          },
-          {
-            "value": "styl",
-            "label": "DEPRECATD: Stylus(.styl) [ http://stylus-lang.com            ]"
-          },
-          {
-            "value": "none",
-            "label": "None"
-          }
-        ]
-      }
+      "default": "none",
+      "alias": "s"
     },
     "linter": {
       "description": "The tool to use for running lint checks.",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When using the federate-module generator, there is no way to specify where the remote project will be generated when using as-provided


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
There should be a --remoteDirectory flag to specify where the remote application should be created

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
