### PR TITLE
docs(linter): use correct plugin name in migrating-to-flat-eslint.md

### DIFF
--- a/docs/shared/recipes/tips-n-tricks/migrating-to-flat-eslint.md
+++ b/docs/shared/recipes/tips-n-tricks/migrating-to-flat-eslint.md
@@ -163,7 +163,7 @@ Since version 16.8.0, Nx supports the usage of flat config in the [@nx/lint:esli
 To convert workspace ESLint configurations from the default `.eslintrc.json` to the new flat config you need to run:
 
 ```shell
- nx g @nx/eslint:convert-to-flat-config
+ nx g @nx/linter:convert-to-flat-config
 ```
 
 The generator will go through all the projects and convert their configurations to the new format. It will also convert the base `.eslintrc.json` and `.eslintignore`.


### PR DESCRIPTION
the command in the docs used `@nx/eslint` as plugin name instead of `@nx/linter`

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

n.a.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

n.a.