### PR TITLE
fix(storybook): update to patch 7.5.1 webpackStatsJson fix

### DIFF
--- a/e2e/storybook-angular/src/storybook-angular.test.ts
+++ b/e2e/storybook-angular/src/storybook-angular.test.ts
@@ -27,9 +27,7 @@ describe('Storybook executors for Angular', () => {
   describe('serve and build storybook', () => {
     afterAll(() => killPorts());
 
-    // TODO(katerina) TODO(jack): This is currently failing because @storybook/angular:start-storybook has a bad schema. Once it's fixed we need to re-enable this test.
-    // See: https://github.com/storybookjs/storybook/issues/24512
-    xit('should serve an Angular based Storybook setup', async () => {
+    it('should serve an Angular based Storybook setup', async () => {
       const p = await runCommandUntil(
         `run ${angularStorybookLib}:storybook`,
         (output) => {

--- a/packages/storybook/migrations.json
+++ b/packages/storybook/migrations.json
@@ -50,6 +50,115 @@
     }
   },
   "packageJsonUpdates": {
+    "17.0.0": {
+      "version": "17.0.0-rc.3",
+      "packages": {
+        "@storybook/test-runner": {
+          "version": "^0.13.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/core-server": {
+          "version": "^7.5.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/angular": {
+          "version": "^7.5.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/react": {
+          "version": "^7.5.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/react-vite": {
+          "version": "^7.5.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/react-webpack5": {
+          "version": "^7.5.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/web-components-vite": {
+          "version": "^7.5.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/web-components-webpack5": {
+          "version": "^7.5.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/addon-a11y": {
+          "version": "^7.5.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/addon-actions": {
+          "version": "^7.5.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/addon-backgrounds": {
+          "version": "^7.5.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/addon-controls": {
+          "version": "^7.5.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/addon-docs": {
+          "version": "^7.5.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/addon-essentials": {
+          "version": "^7.5.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/addon-interactions": {
+          "version": "^7.5.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/addon-mdx-gfm": {
+          "version": "^7.5.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/addon-highlight": {
+          "version": "^7.5.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/addon-jest": {
+          "version": "^7.5.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/addon-links": {
+          "version": "^7.5.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/addon-measure": {
+          "version": "^7.5.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/addon-outline": {
+          "version": "^7.5.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/addon-storyshots": {
+          "version": "^7.5.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/addon-storyshots-puppeteer": {
+          "version": "^7.5.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/addon-storysource": {
+          "version": "^7.5.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/addon-toolbars": {
+          "version": "^7.5.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/addon-viewport": {
+          "version": "^7.5.1",
+          "alwaysAddToPackageJson": false
+        }
+      }
+    },
     "16.7.0": {
       "version": "16.7.0-beta.3",
       "packages": {

--- a/packages/storybook/src/utils/versions.ts
+++ b/packages/storybook/src/utils/versions.ts
@@ -7,7 +7,7 @@ export const storybookJestVersion = '~0.1.0';
 export const litVersion = '^2.6.1';
 export const tsNodeVersion = '10.9.1';
 
-export const storybookVersion = '^7.2.1';
+export const storybookVersion = '^7.5.1';
 export const reactVersion = '^18.2.0';
 export const viteVersion = '~4.3.9';
 


### PR DESCRIPTION
Once this (https://github.com/storybookjs/storybook/pull/24499) is released, we can merge this PR.

This fixes the `webpackStatsJson` issue.

Related:
* https://github.com/nrwl/nx/issues/19723
* https://github.com/nrwl/nx/issues/19734
* https://github.com/storybookjs/storybook/issues/24512
* https://github.com/storybookjs/storybook/pull/24494

Update: `7.5.1` is released! 

