### PR TITLE
fix(react): Update error message for invalid remote name

### DIFF
--- a/packages/angular/src/utils/mf/utils.ts
+++ b/packages/angular/src/utils/mf/utils.ts
@@ -48,7 +48,14 @@ export function getFunctionDeterminateRemoteUrl(isServer: boolean = false) {
   const remoteEntry = isServer ? 'server/remoteEntry.js' : 'remoteEntry.mjs';
 
   return function (remote: string) {
-    const remoteConfiguration = readCachedProjectConfiguration(remote);
+    let remoteConfiguration = null;
+    try {
+      remoteConfiguration = readCachedProjectConfiguration(remote);
+    } catch (e) {
+      throw new Error(
+        `Cannot find remote "${remote}". Check that the remote name is correct in your module federation config file.\n`
+      );
+    }
     const serveTarget = remoteConfiguration?.targets?.[target];
 
     if (!serveTarget) {

--- a/packages/nx/src/project-graph/project-graph.ts
+++ b/packages/nx/src/project-graph/project-graph.ts
@@ -50,7 +50,11 @@ export function readCachedProjectConfiguration(
 ): ProjectConfiguration {
   const graph = readCachedProjectGraph();
   const node = graph.nodes[projectName];
-  return node.data;
+  try {
+    return node.data;
+  } catch (e) {
+    throw new Error(`Cannot find project: '${projectName}' in your workspace.`);
+  }
 }
 
 /**

--- a/packages/react/src/module-federation/utils.ts
+++ b/packages/react/src/module-federation/utils.ts
@@ -21,7 +21,14 @@ export function getFunctionDeterminateRemoteUrl(isServer: boolean = false) {
   const remoteEntry = isServer ? 'server/remoteEntry.js' : 'remoteEntry.js';
 
   return function (remote: string) {
-    const remoteConfiguration = readCachedProjectConfiguration(remote);
+    let remoteConfiguration = null;
+    try {
+      remoteConfiguration = readCachedProjectConfiguration(remote);
+    } catch (e) {
+      throw new Error(
+        `Cannot find remote: "${remote}". Check that the remote name is correct in your module federation config file.\n`
+      );
+    }
     const serveTarget = remoteConfiguration?.targets?.[target];
 
     if (!serveTarget) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently, when you have an invalid remote you only get this error.

```shell
 >  NX   Cannot read properties of undefined (reading 'data')


TypeError: Cannot read properties of undefined (reading 'data')
    at readCachedProjectConfiguration (/private/tmp/projects/react-mfe/node_modules/nx/src/project-graph/project-graph.js:47:17)
    at /private/tmp/projects/react-mfe/node_modules/@nx/react/src/module-federation/utils.js:11:88
    at handleStringRemote (/private/tmp/projects/react-mfe/node_modules/@nx/webpack/src/utils/module-federation/remotes.js:45:30)
    at mapRemotes (/private/tmp/projects/react-mfe/node_modules/@nx/webpack/src/utils/module-federation/remotes.js:20:37)
    at getModuleFederationConfig (/private/tmp/projects/react-mfe/node_modules/@nx/react/src/module-federation/utils.js:62:25)
    at withModuleFederation (/private/tmp/projects/react-mfe/node_modules/@nx/react/src/module-federation/with-module-federation.js:11:112)
    at Object.<anonymous> (/private/tmp/projects/react-mfe/home/webpack.config.js:15:3)
    at Module._compile (node:internal/modules/cjs/loader:1254:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Object.require.extensions.<computed> [as .js] (/private/tmp/projects/react-mfe/node_modules/ts-node/src/index.ts:1608:43)
```
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Have a better error message.
```shell
Cannot find project "remoteDoesNotExists". Check that the name is correct in your module-federation config file.
```
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
