### PR TITLE
fix(misc): create-nx-workspace should support --preset=custom@tag

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -275,7 +275,7 @@ async function normalizeArgsMiddleware(
   });
 
   try {
-    let thirdPartyPreset: string | null;
+    let thirdPartyPreset: { preset: string; version?: string } | null;
 
     // Node options
     let docker: boolean;
@@ -293,7 +293,8 @@ async function normalizeArgsMiddleware(
 
     if (thirdPartyPreset) {
       Object.assign(argv, {
-        preset: thirdPartyPreset,
+        preset: thirdPartyPreset.preset,
+        presetVersion: thirdPartyPreset.version,
         appName: '',
         style: '',
       });

--- a/packages/create-nx-workspace/src/create-preset.ts
+++ b/packages/create-nx-workspace/src/create-preset.ts
@@ -9,7 +9,7 @@ import { spawnAndWait } from './utils/child-process-utils';
 import { unparse } from './utils/unparse';
 
 export async function createPreset<T extends CreateWorkspaceOptions>(
-  preset: string,
+  { preset }: { preset: string },
   parsedArgs: T,
   packageManager: PackageManager,
   directory: string

--- a/packages/create-nx-workspace/src/utils/preset/get-third-party-preset.ts
+++ b/packages/create-nx-workspace/src/utils/preset/get-third-party-preset.ts
@@ -9,15 +9,17 @@ import { isKnownPreset } from './preset';
  */
 export async function getThirdPartyPreset(
   preset?: string
-): Promise<string | null> {
+): Promise<{ preset: string; version?: string } | null> {
   if (preset && !isKnownPreset(preset)) {
     // extract the package name from the preset
-    const packageName = preset.match(/.+@/)
-      ? preset[0] + preset.substring(1).split('@')[0]
-      : preset;
+    const atIndex = preset.indexOf('@', 1);
+    const [packageName, version] =
+      atIndex > 0
+        ? [preset.slice(0, atIndex), preset.slice(atIndex + 1)]
+        : [preset];
     const validateResult = validateNpmPackage(packageName);
     if (validateResult.validForNewPackages) {
-      return Promise.resolve(packageName);
+      return Promise.resolve({ preset: packageName, version });
     } else {
       //! Error here
       output.error({


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
You can run `npx create-nx-workspace@next` to test builtin presets on the next version.
`nx new`'s preset argument can accept `--preset preset@version` syntax

You can't test custom preset beta versions with `npx create-nx-workspace --preset custom@next`.

NOTE: Currently you can do: `npx create-nx-workspace --preset custom --presetVersion next`, but that still feels a little weird to me.

## Expected Behavior
You can test custom preset beta versions with `npx create-nx-workspace --preset custom@next`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
