### PR TITLE
docs(core): add git instruction to fetch new remote 

### DIFF
--- a/docs/shared/migration/preserving-git-histories.md
+++ b/docs/shared/migration/preserving-git-histories.md
@@ -16,6 +16,12 @@ To start we'll add a remote repository url for where the standalone app is locat
 git remote add my-standalone-app <repository url>
 ```
 
+Now we must fetch the branches from the new remote
+
+```shell
+git fetch my-standalone-app
+```
+
 Assuming that our main branch on this repo is called 'master', then we'll run
 
 ```shell


### PR DESCRIPTION
Following the existing instructions:

```shell
git remote add my-standalone-app
git merge my-standalone-app/master
```

you would get:

```shell
Not something we can merge
```

We need to fetch the remote branches first before we can merge it.

```shell
git remote add my-standalone-app
git fetch my-standalone-app
git merge my-standalone-app/master
```
