### PR TITLE
fix(linter): check filePath existence first

### DIFF
--- a/packages/eslint-plugin/src/utils/ast-utils.ts
+++ b/packages/eslint-plugin/src/utils/ast-utils.ts
@@ -110,7 +110,18 @@ function hasMemberExport(exportedMember, filePath) {
 }
 
 export function getRelativeImportPath(exportedMember, filePath, basePath) {
-  if (lstatSync(filePath).isDirectory()) {
+  const status = lstatSync(filePath, {
+    throwIfNoEntry: false,
+  });
+  if (!status /*not existed, but probably not full file with an extension*/) {
+    // try to find an extension that exists
+    const ext = ['.ts', '.tsx', '.js', '.jsx'].find((ext) =>
+      lstatSync(filePath + ext, { throwIfNoEntry: false })
+    );
+    if (ext) {
+      filePath += ext;
+    }
+  } else if (status.isDirectory()) {
     const file = readdirSync(filePath).find((file) =>
       /^index\.[jt]sx?$/.exec(file)
     );
@@ -118,18 +129,6 @@ export function getRelativeImportPath(exportedMember, filePath, basePath) {
       filePath = joinPathFragments(filePath, file);
     } else {
       return;
-    }
-  } else if (
-    !lstatSync(filePath, {
-      throwIfNoEntry: false,
-    }) /*not folder, but probably not full file with an extension either*/
-  ) {
-    // try to find an extension that exists
-    const ext = ['.ts', '.tsx', '.js', '.jsx'].find((ext) =>
-      lstatSync(filePath + ext, { throwIfNoEntry: false })
-    );
-    if (ext) {
-      filePath += ext;
     }
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
crash if a file path does not exist

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
no crash

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #19748
