### PR TITLE
docs(vue): include vue plugin when generating documentation

### DIFF
--- a/scripts/documentation/package-schemas/package-metadata.ts
+++ b/scripts/documentation/package-schemas/package-metadata.ts
@@ -121,9 +121,6 @@ export function findPackageMetadataList(
     .map((folderPath: string): PackageData => {
       const folderName = folderPath.substring(packagesDir.length + 1);
 
-      // TODO(v17): Remove this once @nx/vue is published
-      if (folderName === 'vue') return null;
-
       const relativeFolderPath = folderPath.replace(absoluteRoot, '');
       const packageJson = readJsonSync(
         join(folderPath, 'package.json'),


### PR DESCRIPTION
@nx/vue @17.0.0 is published now so it can be included when building the docs

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
vue plugin docs are not published

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

vue plugin docs to be published

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
n.a.