### PR TITLE
fix(vue): do not generate component in lib by default

### DIFF
--- a/packages/vue/src/generators/library/schema.json
+++ b/packages/vue/src/generators/library/schema.json
@@ -98,7 +98,7 @@
     "component": {
       "type": "boolean",
       "description": "Generate a default component.",
-      "default": true
+      "default": false
     },
     "js": {
       "type": "boolean",


### PR DESCRIPTION
Just like Angular, Vue libraries might not need a vue component in them. They could be a directive, service, etc.

So just like Angular, we should not generate a component
