### PR TITLE
fix(vue): drop vue jest dependency

### DIFF
--- a/packages/vue/.eslintrc.json
+++ b/packages/vue/.eslintrc.json
@@ -33,6 +33,7 @@
               "nx",
               "typescript",
               "@nx/cypress",
+              "@nx/jest",
               "@nx/playwright",
               "@nx/storybook"
             ]

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -31,7 +31,6 @@
     "minimatch": "3.0.5",
     "tslib": "^2.3.0",
     "@nx/devkit": "file:../devkit",
-    "@nx/jest": "file:../jest",
     "@nx/js": "file:../js",
     "@nx/eslint": "file:../eslint",
     "@nx/vite": "file:../vite",


### PR DESCRIPTION
`@nx/vue` should not depend on `@nx/jest` since we're using it through `ensurePackage`