### PR TITLE
fix(vite): prevent vite:build copying package.json when generatePackageJson false

### DIFF
--- a/e2e/vite/src/vite.test.ts
+++ b/e2e/vite/src/vite.test.ts
@@ -117,6 +117,29 @@ describe('Vite Plugin', () => {
         });
         rmDist();
       }, 200_000);
+
+      it('should build application without copying exisiting package json when generatePackageJson=false', async () => {
+        createFile(
+          `apps/${myApp}/package.json`,
+          JSON.stringify({
+            name: 'my-existing-app',
+            version: '1.0.1',
+            scripts: {
+              start: 'node server.js',
+            },
+          })
+        );
+        runCLI(`build ${myApp} --generatePackageJson=false`);
+        expect(readFile(`dist/apps/${myApp}/index.html`)).toBeDefined();
+        const fileArray = listFiles(`dist/apps/${myApp}/assets`);
+        const mainBundle = fileArray.find((file) => file.endsWith('.js'));
+        expect(
+          readFile(`dist/apps/${myApp}/assets/${mainBundle}`)
+        ).toBeDefined();
+
+        expect(fileExists(`dist/apps/${myApp}/package.json`)).toBe(false);
+        rmDist();
+      }, 200_000);
     });
 
     100_000;

--- a/packages/vite/src/executors/build/build.impl.ts
+++ b/packages/vite/src/executors/build/build.impl.ts
@@ -142,6 +142,7 @@ export async function* viteBuildExecutor(
   }
   // For buildable libs, copy package.json if it exists.
   else if (
+    options.generatePackageJson !== false &&
     !existsSync(distPackageJson) &&
     existsSync(libraryPackageJson) &&
     rootPackageJson !== libraryPackageJson


### PR DESCRIPTION
closed #19758

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When generatePackageJson is set to false, vite:build copies package.json to output directory.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
No package.json is generated in the dist folder

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #19758 
