### PR TITLE
feat(core): use static_vcruntime to avoid msvcrt dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2610,6 +2610,7 @@ dependencies = [
  "serde",
  "serde_json",
  "static_assertions",
+ "static_vcruntime",
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_dep_graph",
@@ -3869,6 +3870,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "static_vcruntime"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "954e3e877803def9dc46075bf4060147c55cd70db97873077232eae0269dc89b"
 
 [[package]]
 name = "string-width"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3873,9 +3873,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "static_vcruntime"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "954e3e877803def9dc46075bf4060147c55cd70db97873077232eae0269dc89b"
+checksum = "ff7589a1859b09232522bb9edf076ca7fcf14ded96685d3fa629db73023ffbb7"
 
 [[package]]
 name = "string-width"

--- a/packages/nx/Cargo.toml
+++ b/packages/nx/Cargo.toml
@@ -109,6 +109,7 @@ crate-type = ['cdylib']
 
 [build-dependencies]
 napi-build = '2.1.3'
+static_vcruntime = '2.0'
 
 [dev-dependencies]
 assert_fs = "1.0.10"

--- a/packages/nx/Cargo.toml
+++ b/packages/nx/Cargo.toml
@@ -109,7 +109,7 @@ crate-type = ['cdylib']
 
 [build-dependencies]
 napi-build = '2.1.3'
-static_vcruntime = '2.0'
+static_vcruntime = '3.0'
 
 [dev-dependencies]
 assert_fs = "1.0.10"

--- a/packages/nx/build.rs
+++ b/packages/nx/build.rs
@@ -1,6 +1,7 @@
 extern crate napi_build;
 
 fn main() {
+    static_vcruntime::metabuild();
     napi_build::setup();
 
     // Embed Windows resource metadata to establish binary legitimacy


### PR DESCRIPTION
Closes #19779

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When targeting Windows the resulting binary (nx.dll) dynamically links against Microsoft Visual C++ runtime (msvcrt140.dll). This means nx won't be able to run on Windows systems without this runtime installed.

## Expected Behavior
I'd like to avoid this dependency by linking the runtime statically into the nx binary. (This is also how e.g. cargo.exe for Windows is built.)

## Related Issue(s)

Fixes #19779
