### PR TITLE
feat(vite): allow passing path to custom tsconfig file when skipTypeCheck is false

### DIFF
--- a/docs/generated/packages/vite/executors/build.json
+++ b/docs/generated/packages/vite/executors/build.json
@@ -26,6 +26,12 @@
         "description": "Skip type-checking via TypeScript. Skipping type-checking speeds up the build but type errors are not caught.",
         "default": false
       },
+      "tsConfig": {
+        "type": "string",
+        "description": "The path to custom tsconfig file for type-checking when skipTypeCheck is false. Required when tsconfig file is not at the projectRoot level.",
+        "x-completion-type": "file",
+        "x-completion-glob": "tsconfig.*.json"
+      },
       "configFile": {
         "type": "string",
         "description": "The name of the Vite.js configuration file.",

--- a/packages/vite/src/executors/build/build.impl.ts
+++ b/packages/vite/src/executors/build/build.impl.ts
@@ -83,7 +83,7 @@ export async function* viteBuildExecutor(
     await validateTypes({
       workspaceRoot: context.root,
       projectRoot: projectRoot,
-      tsconfig: getProjectTsConfigPath(projectRoot),
+      tsconfig: options.tsConfig ?? getProjectTsConfigPath(projectRoot),
     });
   }
 

--- a/packages/vite/src/executors/build/schema.d.ts
+++ b/packages/vite/src/executors/build/schema.d.ts
@@ -6,4 +6,5 @@ export interface ViteBuildExecutorOptions {
   watch?: boolean;
   generatePackageJson?: boolean;
   includeDevDependenciesInPackageJson?: boolean;
+  tsConfig?: string;
 }

--- a/packages/vite/src/executors/build/schema.json
+++ b/packages/vite/src/executors/build/schema.json
@@ -28,6 +28,12 @@
       "description": "Skip type-checking via TypeScript. Skipping type-checking speeds up the build but type errors are not caught.",
       "default": false
     },
+    "tsConfig": {
+      "type": "string",
+      "description": "The path to custom tsconfig file for type-checking when skipTypeCheck is false. Required when tsconfig file is not at the projectRoot level.",
+      "x-completion-type": "file",
+      "x-completion-glob": "tsconfig.*.json"
+    },
     "configFile": {
       "type": "string",
       "description": "The name of the Vite.js configuration file.",


### PR DESCRIPTION
When `skipTypeCheck` is `false` and no tsconfig file exists in projectRoot, it returns undefined which causes `join(opts.workspaceRoot, opts.tsconfig)` in `validateTypes` to fail with `The "path" argument must be of type string. Received undefined`.
Allow user to pass custom tsconfig file location which can be in parent/child directory of projectRoot

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
If tsconfig does not exist is projectRoot it fails with `The "path" argument must be of type string. Received undefined`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Allow user to pass custom tsconfig file, so that vite build does not fail and type checking works.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
