### PR TITLE
feat(core): add --data for nx show projects command

### DIFF
--- a/docs/generated/cli/show.md
+++ b/docs/generated/cli/show.md
@@ -109,6 +109,12 @@ Type: `string`
 
 Base of the current branch (usually main)
 
+##### data
+
+Type: `string`
+
+Show extra project data in output
+
 ##### exclude
 
 Type: `string`

--- a/docs/generated/packages/nx/documents/show.md
+++ b/docs/generated/packages/nx/documents/show.md
@@ -109,6 +109,12 @@ Type: `string`
 
 Base of the current branch (usually main)
 
+##### data
+
+Type: `string`
+
+Show extra project data in output
+
 ##### exclude
 
 Type: `string`

--- a/packages/nx/src/command-line/show/command-object.ts
+++ b/packages/nx/src/command-line/show/command-object.ts
@@ -17,6 +17,7 @@ export type ShowProjectsOptions = NxShowArgs & {
   type: ProjectGraphProjectNode['type'];
   projects: string[];
   withTarget: string[];
+  data: string[];
 };
 
 export type ShowProjectOptions = NxShowArgs & {
@@ -75,6 +76,11 @@ const showProjectsCommand: CommandModule<NxShowArgs, ShowProjectsOptions> = {
         type: 'string',
         alias: ['t'],
         description: 'Show only projects that have a specific target',
+        coerce: parseCSV,
+      })
+      .option('data', {
+        type: 'string',
+        description: 'Show extra project data in output',
         coerce: parseCSV,
       })
       .option('type', {

--- a/packages/nx/src/command-line/show/show.spec.ts
+++ b/packages/nx/src/command-line/show/show.spec.ts
@@ -1,0 +1,111 @@
+import { readNxJson } from '../../config/nx-json';
+import { ProjectGraph } from '../../config/project-graph';
+import { createProjectGraphAsync } from '../../project-graph/project-graph';
+import { ShowProjectsOptions } from './command-object';
+import { showProjectsHandler } from './show';
+
+jest.mock('../../project-graph/project-graph');
+jest.mock('../../config/nx-json');
+
+describe('showProjectsHandler', () => {
+  let mockGraph: ProjectGraph;
+  const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  const processExitSpy = jest
+    .spyOn(process, 'exit')
+    .mockImplementation((code?: number) => ({} as never));
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockGraph = {
+      nodes: {
+        project1: {
+          type: 'app',
+          name: 'project1',
+          data: {
+            root: '',
+            description: 'Mock description for project1',
+            sourceRoot: 'mock/root/project1',
+            projectType: 'application',
+          },
+        },
+        project2: {
+          type: 'lib',
+          name: 'project2',
+          data: {
+            root: '',
+            description: 'Mock description for project2',
+            sourceRoot: 'mock/root/project2',
+            projectType: 'library',
+          },
+        },
+        project3: {
+          type: 'lib',
+          name: 'project3',
+          data: {
+            root: '',
+          },
+        },
+      },
+      dependencies: {},
+    };
+
+    (createProjectGraphAsync as jest.Mock).mockResolvedValueOnce(mockGraph);
+    (readNxJson as jest.Mock).mockReturnValueOnce({
+      npmScope: 'test',
+      projects: {},
+      tasksRunnerOptions: {
+        default: {
+          runner: 'test-runner',
+          options: {},
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    processExitSpy.mockRestore();
+  });
+
+  it('should log all projects when no args are provided', async () => {
+    await showProjectsHandler({} as ShowProjectsOptions);
+
+    expect(consoleLogSpy).toHaveBeenCalledTimes(3);
+    expect(consoleLogSpy).toHaveBeenNthCalledWith(1, 'project1');
+    expect(consoleLogSpy).toHaveBeenNthCalledWith(2, 'project2');
+    expect(consoleLogSpy).toHaveBeenNthCalledWith(3, 'project3');
+    expect(processExitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('should log project data attributes when --data arg is provided', async () => {
+    await showProjectsHandler({
+      data: ['description', 'sourceRoot', 'projectType'],
+    } as ShowProjectsOptions);
+
+    expect(consoleLogSpy).toHaveBeenCalledWith('project1');
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      '\tdescription "Mock description for project1"'
+    );
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      '\tsourceRoot  "mock/root/project1"'
+    );
+    expect(consoleLogSpy).toHaveBeenCalledWith('\tprojectType "application"');
+
+    expect(consoleLogSpy).toHaveBeenCalledWith('project2');
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      '\tdescription "Mock description for project2"'
+    );
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      '\tsourceRoot  "mock/root/project2"'
+    );
+    expect(consoleLogSpy).toHaveBeenCalledWith('\tprojectType "library"');
+
+    expect(consoleLogSpy).toHaveBeenCalledWith('project3');
+    expect(consoleLogSpy).toHaveBeenCalledWith('\tdescription ""');
+    expect(consoleLogSpy).toHaveBeenCalledWith('\tsourceRoot  ""');
+    expect(consoleLogSpy).toHaveBeenCalledWith('\tprojectType "library"');
+
+    expect(processExitSpy).toHaveBeenCalledWith(0);
+  });
+});

--- a/packages/nx/src/command-line/show/show.ts
+++ b/packages/nx/src/command-line/show/show.ts
@@ -76,6 +76,20 @@ export async function showProjectsHandler(
   } else {
     for (const project of selectedProjects) {
       console.log(project);
+
+      if (!args?.data) {
+        continue;
+      }
+
+      const maxAttrLength =
+        args.data.reduce((max, attr) => Math.max(max, attr.length), 0) || 0;
+
+      for (let attr of args.data) {
+        const attrValue = graph.nodes[project]?.data?.[attr] || '';
+        console.log(
+          `\t${attr.padEnd(maxAttrLength)} ${JSON.stringify(attrValue)}`
+        );
+      }
     }
   }
   process.exit(0);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The `nx show projects` command with no args will log all project names to the console:
```
$ nx show projects
project1
project2
project3
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Additional project data is logged for attributes passed in with `--data` arg:

```
$ nx show projects --data description,sourceRoot,projectType
project1
	description "Mock description for project1"
	sourceRoot  "mock/root/project1"
	projectType "application"
project2
	description "Mock description for project2"
	sourceRoot  "mock/root/project2"
	projectType "library"
project3
	description ""
	sourceRoot  ""
	projectType "library"
```

Thoughts:
- Quickly viewing descriptions for all projects in the repo could be useful for onboarding new team members _(is there another way to do this, perhaps?)_
- The `--data targets`/object value formatting could be cleaner or potentially disallowed...  

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
