### PR TITLE
fix(core): generate should handle multiselect shorthand

### DIFF
--- a/packages/nx/src/utils/params.spec.ts
+++ b/packages/nx/src/utils/params.spec.ts
@@ -1743,6 +1743,44 @@ describe('params', () => {
       ]);
     });
 
+    it('should use a multiselect if type is array and x-prompt uses shorthand', () => {
+      const prompts = getPromptsForSchema(
+        {},
+        {
+          properties: {
+            pets: {
+              type: 'array',
+              'x-prompt': 'What kind of pets do you have?',
+              items: {
+                enum: ['cat', 'dog', 'fish'],
+              },
+            },
+          },
+        },
+        {
+          version: 2,
+          projects: {},
+        }
+      );
+
+      expect(prompts).toMatchInlineSnapshot(`
+        [
+          {
+            "choices": [
+              "cat",
+              "dog",
+              "fish",
+            ],
+            "limit": 10,
+            "message": "What kind of pets do you have?",
+            "name": "pets",
+            "type": "multiselect",
+            "validate": [Function],
+          },
+        ]
+      `);
+    });
+
     describe('Project prompts', () => {
       it('should use an autocomplete prompt for a property named project', () => {
         const prompts = getPromptsForSchema(

--- a/packages/nx/src/utils/params.ts
+++ b/packages/nx/src/utils/params.ts
@@ -785,10 +785,23 @@ export function getPromptsForSchema(
       // Normalize x-prompt
       if (typeof v['x-prompt'] === 'string') {
         const message = v['x-prompt'];
-        v['x-prompt'] = {
-          type: v.type === 'boolean' ? 'confirm' : 'input',
-          message,
-        };
+        if (v.type === 'boolean') {
+          v['x-prompt'] = {
+            type: 'confirm',
+            message,
+          };
+        } else if (v.type === 'array' && v.items?.enum) {
+          v['x-prompt'] = {
+            type: 'multiselect',
+            items: v.items.enum,
+            message,
+          };
+        } else {
+          v['x-prompt'] = {
+            type: 'input',
+            message,
+          };
+        }
       }
 
       question.message = v['x-prompt'].message;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Some angular devkit schematics use a shorthand for multiselects inside of schema.json that looks something like this:

```json
"propertyName": {
      "type": "array",
      "description": "Specifies which type of guard to create.",
      "items": {
        "enum": ["CanActivate", "CanActivateChild", "CanDeactivate", "CanMatch"],
        "type": "string"
      },
      "default": ["CanActivate"],
      "x-prompt": "Which type of guard would you like to create?"
    }
```

Currently, this is parsed as a string input

## Expected Behavior
This renders a multiselect.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #19142
