### PR TITLE
fix(core): negated paths should be considered by prefix migration

### DIFF
--- a/packages/nx/src/migrations/update-15-0-0/prefix-outputs.spec.ts
+++ b/packages/nx/src/migrations/update-15-0-0/prefix-outputs.spec.ts
@@ -116,6 +116,34 @@ describe('15.0.0 migration (prefix-outputs)', () => {
 
     await prefixOutputs(tree);
   });
+
+  it('should handle negated outputs', async () => {
+    const nxJson = readNxJson(tree);
+    updateNxJson(tree, {
+      ...nxJson,
+      targetDefaults: {
+        build: {
+          outputs: ['!dist', '{projectRoot}/build', '{options.outputPath}'],
+        },
+      },
+    });
+
+    await prefixOutputs(tree);
+
+    const updated = readNxJson(tree);
+
+    expect(updated.targetDefaults).toMatchInlineSnapshot(`
+      {
+        "build": {
+          "outputs": [
+            "!{workspaceRoot}/dist",
+            "{projectRoot}/build",
+            "{options.outputPath}",
+          ],
+        },
+      }
+    `);
+  });
 });
 
 describe('15.0.0 migration (prefix-outputs) (v1)', () => {

--- a/packages/nx/src/migrations/update-15-0-0/prefix-outputs.ts
+++ b/packages/nx/src/migrations/update-15-0-0/prefix-outputs.ts
@@ -64,12 +64,11 @@ export default async function (tree: Tree) {
       if (!target.outputs) {
         continue;
       }
-
-      target.outputs = target.outputs.map((output) => {
-        return /^{[\s\S]+}/.test(output)
-          ? output
-          : joinPathFragments('{workspaceRoot}', output);
-      });
+      try {
+        validateOutputs(target.outputs);
+      } catch (e: any) {
+        target.outputs = transformLegacyOutputs('{projectRoot}', e);
+      }
     }
 
     updateNxJson(tree, nxJson);

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -107,7 +107,7 @@ export function validateOutputs(outputs: string[]) {
   const invalidOutputs = new Set<string>();
 
   for (const output of outputs) {
-    if (!/^{[\s\S]+}/.test(output)) {
+    if (!/^!?{[\s\S]+}/.test(output)) {
       invalidOutputs.add(output);
     }
   }
@@ -125,14 +125,21 @@ export function transformLegacyOutputs(
       return output;
     }
 
-    const relativePath = isRelativePath(output)
+    let [isNegated, outputPath] = output.startsWith('!')
+      ? [true, output.substring(1)]
+      : [false, output];
+
+    const relativePath = isRelativePath(outputPath)
       ? output
-      : relative(projectRoot, output);
+      : relative(projectRoot, outputPath);
 
     const isWithinProject = !relativePath.startsWith('..');
-    return joinPathFragments(
-      isWithinProject ? '{projectRoot}' : '{workspaceRoot}',
-      isWithinProject ? relativePath : output
+    return (
+      (isNegated ? '!' : '') +
+      joinPathFragments(
+        isWithinProject ? '{projectRoot}' : '{workspaceRoot}',
+        isWithinProject ? relativePath : outputPath
+      )
     );
   });
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The migration to prefix outputs doesn't take into account negations in the path.

## Expected Behavior
The migration to prefix outputs takes negations into account.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
