### PR TITLE
fix(core): await output drain before exiting show

### DIFF
--- a/packages/nx/src/command-line/show/show.ts
+++ b/packages/nx/src/command-line/show/show.ts
@@ -1,3 +1,4 @@
+import { output } from '../../utils/output';
 import { NxJsonConfiguration, readNxJson } from '../../config/nx-json';
 import {
   ProjectGraph,
@@ -78,6 +79,7 @@ export async function showProjectsHandler(
       console.log(project);
     }
   }
+  await output.drain();
   process.exit(0);
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Show may exit before writing all output to stdout when it is piped

## Expected Behavior
Show waits for output to drain before exiting.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #19095
