### PR TITLE
fix(core): ensure require.resolve('nx') resolves correctly

### DIFF
--- a/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -27,7 +27,8 @@ export function executeModuleFederationDevServerBuilder(
   schema: Schema,
   context: import('@angular-devkit/architect').BuilderContext
 ): ReturnType<typeof executeWebpackDevServerBuilder | any> {
-  const nxBin = require.resolve('nx');
+  // Force Node to resolve to look for the nx binary that is inside node_modules
+  const nxBin = require.resolve('nx/bin/nx');
   const { ...options } = schema;
   const projectGraph = readCachedProjectGraph();
   const { projects: workspaceProjects } =

--- a/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -40,7 +40,8 @@ export default async function* moduleFederationDevServer(
   options: ModuleFederationDevServerOptions,
   context: ExecutorContext
 ): AsyncIterableIterator<{ success: boolean; baseUrl?: string }> {
-  const nxBin = require.resolve('nx');
+  // Force Node to resolve to look for the nx binary that is inside node_modules
+  const nxBin = require.resolve('nx/bin/nx');
   const currIter = options.static
     ? fileServerExecutor(
         {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When you create a plugin that calls our internal executor for example `require.resolve('nx')` resolves to `{workspaceRoot}/nx.json`

This is because tsconfig-paths uses `require.extensions` which includes `.json`
```ts
    interface RequireExtensions extends Dict<(m: Module, filename: string) => any> {
        '.js': (m: Module, filename: string) => any;
        '.json': (m: Module, filename: string) => any;
        '.node': (m: Module, filename: string) => any;
    }
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`require.resolve('nx')` should resolve to nx binary. For example located in `node_modules/nx/bin/nx.js`
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
Filed an issue: https://github.com/dividab/tsconfig-paths/issues/255

fixes: #19782 