### PR TITLE
fix(core): change the order of watch ignores so that nxignore is the last one added

### DIFF
--- a/packages/nx/src/native/watch/utils.rs
+++ b/packages/nx/src/native/watch/utils.rs
@@ -15,14 +15,20 @@ pub(super) fn get_ignore_files<T: AsRef<str>>(root: T) -> Vec<IgnoreFile> {
 
     let node_folder = PathBuf::from(root).join("node_modules");
     walker.filter_entry(move |entry| !entry.path().starts_with(&node_folder));
-    walker
+    let mut ignores = walker
         .build()
         .flatten()
         .filter(|result| {
             result.path().ends_with(".nxignore") || result.path().ends_with(".gitignore")
         })
-        .map(|result| {
-            let path: PathBuf = result.path().into();
+        .map(|result| result.path().into())
+        .collect::<Vec<PathBuf>>();
+
+    ignores.sort();
+
+    ignores
+        .into_iter()
+        .map(|path| {
             let parent: PathBuf = path.parent().unwrap_or(&path).into();
             IgnoreFile {
                 path,

--- a/packages/nx/src/native/watch/watch_config.rs
+++ b/packages/nx/src/native/watch/watch_config.rs
@@ -28,7 +28,7 @@ pub(super) async fn create_runtime(
         .map_err(anyhow::Error::from)?;
 
     filter
-        .add_globs(&additional_globs, Some(&origin.into()))
+        .add_globs(additional_globs, Some(&origin.into()))
         .map_err(anyhow::Error::from)?;
 
     let mut runtime = RuntimeConfig::default();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`.nxignore` is added before `.gitignore` while building out the watcher ignores

## Expected Behavior
`.nxignore` is always the last file to be added to the ignore lists so that allowed items are in proper order

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #19172
