### PR TITLE
feat(angular): remove usage of cypressProjectGenerator from ng-add generator

### DIFF
--- a/packages/angular/src/generators/ng-add/migrators/projects/__snapshots__/e2e.migrator.spec.ts.snap
+++ b/packages/angular/src/generators/ng-add/migrators/projects/__snapshots__/e2e.migrator.spec.ts.snap
@@ -14,11 +14,11 @@ export default defineConfig({
 `;
 
 exports[`e2e migrator cypress with project root at "" cypress version >=10 should create a cypress.config.ts file when it does not exist 1`] = `
-"import { defineConfig } from 'cypress';
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+"import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { defineConfig } from 'cypress';
 
 export default defineConfig({
-  e2e: nxE2EPreset(__dirname)
+  e2e: nxE2EPreset(__filename, { cypressDir: 'src' })
 });
 "
 `;
@@ -90,11 +90,11 @@ export default defineConfig({
 `;
 
 exports[`e2e migrator cypress with project root at "projects/app1" cypress version >=10 should create a cypress.config.ts file when it does not exist 1`] = `
-"import { defineConfig } from 'cypress';
-import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+"import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+import { defineConfig } from 'cypress';
 
 export default defineConfig({
-  e2e: nxE2EPreset(__dirname)
+  e2e: nxE2EPreset(__filename, { cypressDir: 'src' })
 });
 "
 `;

--- a/packages/angular/src/generators/ng-add/migrators/projects/e2e.migrator.ts
+++ b/packages/angular/src/generators/ng-add/migrators/projects/e2e.migrator.ts
@@ -1,4 +1,4 @@
-import { cypressProjectGenerator } from '@nx/cypress';
+import { configurationGenerator } from '@nx/cypress';
 import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
 import { installedCypressVersion } from '@nx/cypress/src/utils/cypress-version';
 import type {
@@ -9,11 +9,9 @@ import type {
 import {
   addProjectConfiguration,
   joinPathFragments,
-  names,
   offsetFromRoot,
   readJson,
   readProjectConfiguration,
-  removeProjectConfiguration,
   stripIndents,
   updateJson,
   updateProjectConfiguration,
@@ -337,12 +335,20 @@ export class E2eMigrator extends ProjectMigrator<SupportedTargets> {
   private async migrateCypressE2eProject(): Promise<void> {
     const oldCypressConfigFilePath = this.getOldCypressConfigFilePath();
 
-    // TODO(v18): This needs to be removed before v18 since the generator is going away.
-    await cypressProjectGenerator(this.tree, {
-      name: this.project.name,
-      project: this.appName,
+    addProjectConfiguration(this.tree, this.project.name, {
+      projectType: 'application',
+      root: this.project.newRoot,
+      sourceRoot: this.project.newSourceRoot,
+      targets: {},
+      tags: [],
+      implicitDependencies: [this.appName],
+    });
+    await configurationGenerator(this.tree, {
+      project: this.project.name,
       linter: this.isProjectUsingEsLint ? Linter.EsLint : Linter.None,
       skipFormat: true,
+      // any target would do, we replace it later with the target existing in the project being migrated
+      devServerTarget: `${this.appName}:serve`,
     });
 
     const cypressConfigFilePath = this.updateOrCreateCypressConfigFile(
@@ -388,48 +394,15 @@ export class E2eMigrator extends ProjectMigrator<SupportedTargets> {
   }
 
   private updateCypressProjectConfiguration(cypressConfigPath: string): void {
-    /**
-     * The `cypressProjectGenerator` function normalizes the project name. The
-     * migration keeps the names for existing projects as-is to avoid any
-     * confusion. The e2e project is technically new, but it's associated
-     * to an existing application, so we keep it familiar.
-     */
-    const generatedProjectName = names(this.project.name).fileName;
-    if (this.project.name !== generatedProjectName) {
-      // If the names are different, we "rename" the newly added project.
-      this.projectConfig = readProjectConfiguration(
-        this.tree,
-        generatedProjectName
-      );
-
-      this.projectConfig.root = this.project.newRoot;
-      this.projectConfig.sourceRoot = this.project.newSourceRoot;
-      removeProjectConfiguration(this.tree, generatedProjectName);
-      addProjectConfiguration(
-        this.tree,
-        this.project.name,
-        { ...this.projectConfig },
-        true
-      );
-    } else {
-      this.projectConfig = readProjectConfiguration(
-        this.tree,
-        this.project.name
-      );
-    }
+    this.projectConfig = readProjectConfiguration(this.tree, this.project.name);
 
     if (this.isProjectUsingEsLint) {
       // the generated cypress project always generates a "lint" target,
       // in case the app was using a different name for it, we use it
-      const lintTarget = this.projectConfig.targets.lint;
       if (this.lintTargetName && this.lintTargetName !== 'lint') {
         this.projectConfig.targets[this.lintTargetName] =
           this.projectConfig.targets.lint;
       }
-      lintTarget.options.lintFilePatterns =
-        lintTarget.options.lintFilePatterns.map((pattern) =>
-          pattern.replace(`apps/${generatedProjectName}`, this.project.newRoot)
-        );
     }
 
     [this.targetNames.e2e, 'cypress-run', 'cypress-open'].forEach((target) => {

--- a/packages/cypress/src/generators/configuration/configuration.ts
+++ b/packages/cypress/src/generators/configuration/configuration.ts
@@ -118,6 +118,7 @@ async function addFiles(tree: Tree, options: NormalizedSchema) {
     ext: options.js ? 'js' : 'ts',
     offsetFromRoot: offsetFromRoot(projectConfig.root),
     offsetFromProjectRoot,
+    projectRoot: projectConfig.root,
     tsConfigPath: hasTsConfig
       ? `${offsetFromProjectRoot}/tsconfig.json`
       : getRelativePathToRootTsConfig(tree, projectConfig.root),


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `@nx/cypress:cypress-project` is being consumed internally by the `@nx/angular:ng-add` generator even though is deprecated.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `@nx/angular:ng-add` generator shouldn't use the `@nx/cypress:cypress-project` generator.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #19390 
