### PR TITLE
fix(vite): throw informative error if no vitest config exists

### DIFF
--- a/packages/vite/src/executors/test/vitest.impl.ts
+++ b/packages/vite/src/executors/test/vitest.impl.ts
@@ -130,6 +130,18 @@ async function getSettings(
     ? options.config // config is expected to be from the workspace root
     : findViteConfig(joinPathFragments(context.root, projectRoot));
 
+  if (!viteConfigPath) {
+    throw new Error(
+      stripIndents`
+      Unable to load test config from config file ${viteConfigPath}.
+      
+      Please make sure that vitest is configured correctly, 
+      or use the @nx/vite:vitest generator to configure it for you.
+      You can read more here: https://nx.dev/nx-api/vite/generators/vitest
+      `
+    );
+  }
+
   const resolvedProjectRoot = resolve(workspaceRoot, projectRoot);
   const resolvedViteConfigPath = resolve(
     workspaceRoot,

--- a/packages/vite/src/utils/options-utils.ts
+++ b/packages/vite/src/utils/options-utils.ts
@@ -155,8 +155,13 @@ export function getViteBuildOptions(
   const projectRoot =
     context.projectsConfigurations.projects[context.projectName].root;
 
+  const outputPath = joinPathFragments(
+    'dist',
+    projectRoot != '.' ? projectRoot : context.projectName
+  );
+
   return {
-    outDir: relative(projectRoot, options.outputPath),
+    outDir: relative(projectRoot, options.outputPath ?? outputPath),
     emptyOutDir: options.emptyOutDir,
     reportCompressedSize: true,
     cssCodeSplit: options.cssCodeSplit,


### PR DESCRIPTION

## Current Behavior

If `vite.config.ts` does not exist, unhelpful error is thrown.

## Expected Behavior

Throw helpful error if vite.config.ts does not exist.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18481
