### PR TITLE
docs(core): link tutorials from package docs

### DIFF
--- a/docs/generated/packages/angular/documents/overview.md
+++ b/docs/generated/packages/angular/documents/overview.md
@@ -101,7 +101,8 @@ nx g @nx/angular:service my-service
 
 ## More Documentation
 
-- [Angular Nx Tutorial](/getting-started/tutorials/angular-monorepo-tutorial)
+- [Angular Standalone Tutorial](/getting-started/tutorials/angular-standalone-tutorial)
+- [Angular Monorepo Tutorial](/getting-started/tutorials/angular-monorepo-tutorial)
 - [Migrating from the Angular CLI](/recipes/angular/migration/angular)
 - [Setup Module Federation with Angular and Nx](/concepts/module-federation/faster-builds-with-module-federation)
 - [Upgrading an AngularJS application to Angular](/recipes/angular/migration/angularjs)

--- a/docs/generated/packages/angular/documents/overview.md
+++ b/docs/generated/packages/angular/documents/overview.md
@@ -33,6 +33,10 @@ yarn add -D @nx/angular
 npm install -D @nx/angular
 ```
 
+{% callout type="note" title="Angular Tutorials" %}
+For a full tutorial experience, follow the [Angular Standalone Tutorial](/getting-started/tutorials/angular-standalone-tutorial) or the [Angular Monorepo Tutorial](/getting-started/tutorials/angular-monorepo-tutorial)
+{% /callout %}
+
 ## Using the Angular Plugin
 
 ### Generating an application

--- a/docs/generated/packages/react/documents/overview.md
+++ b/docs/generated/packages/react/documents/overview.md
@@ -24,6 +24,10 @@ npm install -D @nx/react
 yarn add -D @nx/react
 ```
 
+{% callout type="note" title="React Tutorials" %}
+For a full tutorial experience, follow the [React Standalone Tutorial](/getting-started/tutorials/react-standalone-tutorial) or the [React Monorepo Tutorial](/getting-started/tutorials/react-monorepo-tutorial)
+{% /callout %}
+
 ### Creating Applications and Libraries
 
 You can add a new application with the following:

--- a/docs/generated/packages/react/documents/overview.md
+++ b/docs/generated/packages/react/documents/overview.md
@@ -128,6 +128,8 @@ The library in `dist` is publishable to npm or a private registry.
 
 ## More Documentation
 
+- [React Standalone Tutorial](/getting-started/tutorials/react-standalone-tutorial)
+- [React Monorepo Tutorial](/getting-started/tutorials/react-monorepo-tutorial)
 - [Using Cypress](/nx-api/cypress)
 - [Using Jest](/nx-api/jest)
 - [Using Storybook](/recipes/storybook/overview-react)

--- a/docs/generated/packages/vue/documents/overview.md
+++ b/docs/generated/packages/vue/documents/overview.md
@@ -15,6 +15,10 @@ You can create a new workspace that uses Vue with one of the following commands:
 npx create-nx-workspace@latest --preset=vue
 ```
 
+{% callout type="note" title="Vue Standalone Tutorial" %}
+For a full tutorial experience, follow the [Vue Standalone Tutorial](/getting-started/tutorials/vue-standalone-tutorial)
+{% /callout %}
+
 ## Add Vue to an existing workspace
 
 There are a number of ways to use Vue in your existing workspace.

--- a/docs/generated/packages/vue/documents/overview.md
+++ b/docs/generated/packages/vue/documents/overview.md
@@ -62,3 +62,7 @@ To generate a Vue library, run the following:
 ```shell
 nx g @nx/vue:lib my-lib
 ```
+
+## More Documentation
+
+- [Vue Standalone Tutorial](/getting-started/tutorials/vue-standalone-tutorial)

--- a/docs/shared/packages/angular/angular-plugin.md
+++ b/docs/shared/packages/angular/angular-plugin.md
@@ -101,7 +101,8 @@ nx g @nx/angular:service my-service
 
 ## More Documentation
 
-- [Angular Nx Tutorial](/getting-started/tutorials/angular-monorepo-tutorial)
+- [Angular Standalone Tutorial](/getting-started/tutorials/angular-standalone-tutorial)
+- [Angular Monorepo Tutorial](/getting-started/tutorials/angular-monorepo-tutorial)
 - [Migrating from the Angular CLI](/recipes/angular/migration/angular)
 - [Setup Module Federation with Angular and Nx](/concepts/module-federation/faster-builds-with-module-federation)
 - [Upgrading an AngularJS application to Angular](/recipes/angular/migration/angularjs)

--- a/docs/shared/packages/angular/angular-plugin.md
+++ b/docs/shared/packages/angular/angular-plugin.md
@@ -33,6 +33,10 @@ yarn add -D @nx/angular
 npm install -D @nx/angular
 ```
 
+{% callout type="note" title="Angular Tutorials" %}
+For a full tutorial experience, follow the [Angular Standalone Tutorial](/getting-started/tutorials/angular-standalone-tutorial) or the [Angular Monorepo Tutorial](/getting-started/tutorials/angular-monorepo-tutorial)
+{% /callout %}
+
 ## Using the Angular Plugin
 
 ### Generating an application

--- a/docs/shared/packages/react/react-plugin.md
+++ b/docs/shared/packages/react/react-plugin.md
@@ -24,6 +24,10 @@ npm install -D @nx/react
 yarn add -D @nx/react
 ```
 
+{% callout type="note" title="React Tutorials" %}
+For a full tutorial experience, follow the [React Standalone Tutorial](/getting-started/tutorials/react-standalone-tutorial) or the [React Monorepo Tutorial](/getting-started/tutorials/react-monorepo-tutorial)
+{% /callout %}
+
 ### Creating Applications and Libraries
 
 You can add a new application with the following:

--- a/docs/shared/packages/react/react-plugin.md
+++ b/docs/shared/packages/react/react-plugin.md
@@ -128,6 +128,8 @@ The library in `dist` is publishable to npm or a private registry.
 
 ## More Documentation
 
+- [React Standalone Tutorial](/getting-started/tutorials/react-standalone-tutorial)
+- [React Monorepo Tutorial](/getting-started/tutorials/react-monorepo-tutorial)
 - [Using Cypress](/nx-api/cypress)
 - [Using Jest](/nx-api/jest)
 - [Using Storybook](/recipes/storybook/overview-react)

--- a/docs/shared/packages/vue/vue-plugin.md
+++ b/docs/shared/packages/vue/vue-plugin.md
@@ -15,6 +15,10 @@ You can create a new workspace that uses Vue with one of the following commands:
 npx create-nx-workspace@latest --preset=vue
 ```
 
+{% callout type="note" title="Vue Standalone Tutorial" %}
+For a full tutorial experience, follow the [Vue Standalone Tutorial](/getting-started/tutorials/vue-standalone-tutorial)
+{% /callout %}
+
 ## Add Vue to an existing workspace
 
 There are a number of ways to use Vue in your existing workspace.

--- a/docs/shared/packages/vue/vue-plugin.md
+++ b/docs/shared/packages/vue/vue-plugin.md
@@ -62,3 +62,7 @@ To generate a Vue library, run the following:
 ```shell
 nx g @nx/vue:lib my-lib
 ```
+
+## More Documentation
+
+- [Vue Standalone Tutorial](/getting-started/tutorials/vue-standalone-tutorial)

--- a/docs/shared/recipes/troubleshoot-cache-misses.md
+++ b/docs/shared/recipes/troubleshoot-cache-misses.md
@@ -8,7 +8,7 @@ Problem: A task is being executed when you expect it to be replayed from the cac
 
    - Check the `inputs` and `namedInputs` defined in the project configuration and root `nx.json`. The `inputs` control whether a task will execute or replay from cache.
    - Check to see if there is an output file that is not being captured by the `outputs` for the task. The `outputs` property only controls what files are replayed from the cache, it doesn't dictate whether the cache is replayed, but an unaccounted output file could be modifying one of the inputs of the task.
-   - To check your input glob patterns file-by-file, you can get a list of all the files associated with each project by running: `nx graph --file=output.json`
+   - To check your input glob patterns file-by-file, you can get a list of all the files associated with each project by running `nx graph --file=output.json` or by clicking on a task in the task graph in the `nx graph` visualization.
 
 1. Use the Nx Cloud troubleshooting tools
    - Make sure your repo is [connected to Nx Cloud](/core-features/cache-task-results#distributed-computation-caching)


### PR DESCRIPTION
- Link to tutorials from package API docs
- Add note to troubleshoot cache miss recipe about viewing inputs in the graph visualization