### PR TITLE
fix(nextjs): Custom server should work on fresh applications

### DIFF
--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -239,7 +239,7 @@ function withNx(
 
       const userWebpackConfig = nextConfig.webpack;
 
-      const { createWebpackConfig } = require('../src/utils/config');
+      const { createWebpackConfig } = require('@nx/next/src/utils/config');
       nextConfig.webpack = (a, b) =>
         createWebpackConfig(
           workspaceRoot,

--- a/packages/next/src/generators/custom-server/custom-server.ts
+++ b/packages/next/src/generators/custom-server/custom-server.ts
@@ -81,7 +81,7 @@ export async function customServerGenerator(
 
   project.targets['serve-custom-server'] = {
     executor: '@nx/js:node',
-    defaultConfiguration: 'development',
+    defaultConfiguration: 'production',
     options: {
       buildTarget: `${options.project}:build-custom-server`,
     },


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

If you create a fresh next.js app with a custom-server. 
Running the custom-server does not work even if you provide the correct production build.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Running custom-server target on fresh apps should work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #18263
