### PR TITLE
fix(bundling): fix regression with --thirdParty option for esbuild

### DIFF
--- a/e2e/esbuild/src/esbuild.test.ts
+++ b/e2e/esbuild/src/esbuild.test.ts
@@ -156,6 +156,13 @@ describe('EsBuild Plugin', () => {
     // Bundle only child lib
     runCLI(`build ${parentLib} --third-party=false`);
 
+    expect(
+      readJson(`dist/libs/${parentLib}/package.json`).dependencies
+    ).toEqual({
+      // Don't care about the versions, just that they exist
+      rambda: expect.any(String),
+      lodash: expect.any(String),
+    });
     runResult = runCommand(`node dist/libs/${parentLib}/index.cjs`);
     expect(runResult).toMatch(/Hello world/);
     expect(runResult).toMatch(/Hello from child lib/);

--- a/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
+++ b/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
@@ -87,6 +87,10 @@ export async function* esbuildExecutor(
       generateLockfile: true,
       outputFileExtensionForCjs: getOutExtension('cjs', options),
       excludeLibsInPackageJson: !options.thirdParty,
+      // TODO(jack): Remove the need to pass updateBuildableProjectDepsInPackageJson option when overrideDependencies or extraDependencies are passed.
+      // Add this back to fix a regression.
+      // See: https://github.com/nrwl/nx/issues/19773
+      updateBuildableProjectDepsInPackageJson: externalDependencies.length > 0,
     };
 
     // If we're bundling third-party packages, then any extra deps from external should be the only deps in package.json


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Passing `thirdParty: false` is not working, and bundling npm packages into bundle.

## Expected Behavior
Passing `thirdParty: false` should work.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #19773
