### PR TITLE
fix(nx-dev): don't show minor on main version section

### DIFF
--- a/nx-dev/nx-dev/pages/changelog.tsx
+++ b/nx-dev/nx-dev/pages/changelog.tsx
@@ -267,7 +267,7 @@ export default function Changelog(props: ChangeLogProps): JSX.Element {
                         className="inline-flex h-4 w-4"
                         aria-hidden="true"
                       />{' '}
-                      v{changelog.version}
+                      v{changelog.version.split('.').slice(0, 2).join('.')}
                     </a>
                     <a aria-hidden="true" href={`#${changelog.version}`}>
                       <LinkIcon className="ml-2 mb-1 inline h-5 w-5 opacity-0 group-hover:opacity-100" />


### PR DESCRIPTION
It is weird to show the patch version on the main version links as the patch version are a subsection of it. This PR removes the patch
![Screenshot 2023-10-24 at 23 35 42](https://github.com/nrwl/nx/assets/542458/9b9ecf2e-ae59-42bd-85de-1d1741cc60f6)

