### PR TITLE
fix(angular): only append workspace root if it does not exist for buildable libs #19807

### DIFF
--- a/packages/angular/src/builders/utilities/webpack.ts
+++ b/packages/angular/src/builders/utilities/webpack.ts
@@ -11,7 +11,9 @@ export async function mergeCustomWebpackConfig(
 ) {
   const customWebpackConfiguration = resolveCustomWebpackConfig(
     pathToWebpackConfig,
-    join(workspaceRoot, options.tsConfig)
+    options.tsConfig.startsWith(workspaceRoot)
+      ? options.tsConfig
+      : join(workspaceRoot, options.tsConfig)
   );
   // The extra Webpack configuration file can also export a Promise, for instance:
   // `module.exports = new Promise(...)`. If it exports a single object, but not a Promise,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When creating a tmp tsconfig file for buildable libs, we already have a fully qualified path, however, if a custom webpack config is used, we prepend an additional workspaceRoot to the path causing an invalid path. 


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The path to the tsconfig should always be valid

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #19807
