### PR TITLE
docs(core): Using --directory=libs/is-odd instead of --directory=packages/is-odd

### DIFF
--- a/docs/shared/npm-tutorial/integrated.md
+++ b/docs/shared/npm-tutorial/integrated.md
@@ -19,11 +19,11 @@ The file structure should look like this:
 
 ```treeview
 myorg/
-├── packages/
-├── tools/
-├── nx.json
-├── package.json
 ├── README.md
+├── node_modules
+├── nx.json
+├── package-lock.json
+├── package.json
 └── tsconfig.base.json
 ```
 
@@ -33,7 +33,7 @@ Nx comes with generators that can help with scaffolding applications. Run this g
 
 ```shell
 npx nx generate @nx/js:library is-even \
---directory=libs/is-even \
+--directory=packages/is-even \
 --publishable \
 --importPath=@myorg/is-even
 ```
@@ -107,7 +107,7 @@ To illustrate that, let's create another package `is-odd`. We can again run the 
 
 ```shell
 npx nx generate @nx/js:library is-odd \
---directory=libs/is-odd \
+--directory=packages/is-odd \
 --publishable \
 --importPath=@myorg/is-odd
 ```


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Using --directory=libs/is-odd instead of --directory=packages/is-odd

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We need to use the parameter --directory=packages/is-odd

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
