### PR TITLE
feat(angular): switch generation defaults to use standalone by default

### DIFF
--- a/docs/generated/cli/create-nx-workspace.md
+++ b/docs/generated/cli/create-nx-workspace.md
@@ -145,6 +145,8 @@ Customizes the initial content of your workspace. Default presets include: ["app
 
 Type: `boolean`
 
+Default: `true`
+
 Add a routing setup for an Angular app
 
 ### skipGit
@@ -158,6 +160,8 @@ Skip initializing a git repository
 ### standaloneApi
 
 Type: `boolean`
+
+Default: `true`
 
 Use Standalone Components if generating an Angular app
 

--- a/docs/generated/packages/angular/generators/application.json
+++ b/docs/generated/packages/angular/generators/application.json
@@ -153,6 +153,7 @@
       "standalone": {
         "description": "Generate an application that is setup to use standalone components.",
         "type": "boolean",
+        "default": true,
         "x-priority": "important"
       },
       "rootProject": {

--- a/docs/generated/packages/angular/generators/component.json
+++ b/docs/generated/packages/angular/generators/component.json
@@ -60,7 +60,7 @@
       "standalone": {
         "description": "Whether the generated component is standalone.",
         "type": "boolean",
-        "default": false,
+        "default": true,
         "x-priority": "important"
       },
       "viewEncapsulation": {

--- a/docs/generated/packages/angular/generators/directive.json
+++ b/docs/generated/packages/angular/generators/directive.json
@@ -61,7 +61,7 @@
       "standalone": {
         "description": "Whether the generated directive is standalone.",
         "type": "boolean",
-        "default": false
+        "default": true
       },
       "flat": {
         "type": "boolean",

--- a/docs/generated/packages/angular/generators/federate-module.json
+++ b/docs/generated/packages/angular/generators/federate-module.json
@@ -69,7 +69,7 @@
       "standalone": {
         "description": "Whether to generate the remote application with standalone components if it needs to be created.",
         "type": "boolean",
-        "default": false
+        "default": true
       },
       "host": {
         "type": "string",

--- a/docs/generated/packages/angular/generators/host.json
+++ b/docs/generated/packages/angular/generators/host.json
@@ -163,7 +163,7 @@
       "standalone": {
         "type": "boolean",
         "description": "Whether to generate a host application that uses standalone components.",
-        "default": false
+        "default": true
       },
       "ssr": {
         "description": "Whether to configure SSR for the host application",

--- a/docs/generated/packages/angular/generators/library.json
+++ b/docs/generated/packages/angular/generators/library.json
@@ -142,7 +142,7 @@
       "standalone": {
         "type": "boolean",
         "description": "Generate a library that uses a standalone component instead of a module as the entry point.",
-        "default": false
+        "default": true
       },
       "displayBlock": {
         "description": "Specifies if the component generated style will contain `:host { display: block; }`. Disclaimer: This option is only valid when `--standalone` is set to `true`.",

--- a/docs/generated/packages/angular/generators/pipe.json
+++ b/docs/generated/packages/angular/generators/pipe.json
@@ -53,7 +53,7 @@
       "standalone": {
         "description": "Whether the generated pipe is standalone.",
         "type": "boolean",
-        "default": false
+        "default": true
       },
       "module": {
         "type": "string",

--- a/docs/generated/packages/angular/generators/remote.json
+++ b/docs/generated/packages/angular/generators/remote.json
@@ -157,7 +157,7 @@
       "standalone": {
         "description": "Whether to generate a remote application with standalone components.",
         "type": "boolean",
-        "default": false
+        "default": true
       },
       "ssr": {
         "description": "Whether to configure SSR for the remote application to be consumed by a host application using SSR.",

--- a/docs/generated/packages/angular/generators/setup-mf.json
+++ b/docs/generated/packages/angular/generators/setup-mf.json
@@ -72,7 +72,7 @@
       "standalone": {
         "type": "boolean",
         "description": "Whether the application is a standalone application.",
-        "default": false
+        "default": true
       },
       "typescriptConfiguration": {
         "type": "boolean",

--- a/docs/generated/packages/nx/documents/create-nx-workspace.md
+++ b/docs/generated/packages/nx/documents/create-nx-workspace.md
@@ -145,6 +145,8 @@ Customizes the initial content of your workspace. Default presets include: ["app
 
 Type: `boolean`
 
+Default: `true`
+
 Add a routing setup for an Angular app
 
 ### skipGit
@@ -158,6 +160,8 @@ Skip initializing a git repository
 ### standaloneApi
 
 Type: `boolean`
+
+Default: `true`
 
 Use Standalone Components if generating an Angular app
 

--- a/e2e/angular-core/src/module-federation.test.ts
+++ b/e2e/angular-core/src/module-federation.test.ts
@@ -37,11 +37,11 @@ describe('Angular Module Federation', () => {
 
     // generate host app
     runCLI(
-      `generate @nx/angular:host ${hostApp} --style=css --project-name-and-root-format=as-provided --no-interactive`
+      `generate @nx/angular:host ${hostApp} --style=css --no-standalone --project-name-and-root-format=as-provided --no-interactive`
     );
     // generate remote app
     runCLI(
-      `generate @nx/angular:remote ${remoteApp1} --host=${hostApp} --port=${remotePort} --style=css --project-name-and-root-format=as-provided --no-interactive`
+      `generate @nx/angular:remote ${remoteApp1} --host=${hostApp} --port=${remotePort} --style=css --no-standalone --project-name-and-root-format=as-provided --no-interactive`
     );
 
     // check files are generated without the layout directory ("apps/")
@@ -56,7 +56,7 @@ describe('Angular Module Federation', () => {
 
     // generate a shared lib with a seconary entry point
     runCLI(
-      `generate @nx/angular:library ${sharedLib} --buildable --project-name-and-root-format=as-provided --no-interactive`
+      `generate @nx/angular:library ${sharedLib} --buildable --no-standalone --project-name-and-root-format=as-provided --no-interactive`
     );
     runCLI(
       `generate @nx/angular:library-secondary-entry-point --library=${sharedLib} --name=${secondaryEntry} --no-interactive`
@@ -260,11 +260,11 @@ describe('Angular Module Federation', () => {
 
     // generate host app
     runCLI(
-      `generate @nx/angular:host ${hostApp} --project-name-and-root-format=derived --no-interactive`
+      `generate @nx/angular:host ${hostApp} --no-standalone --project-name-and-root-format=derived --no-interactive`
     );
     // generate remote app
     runCLI(
-      `generate @nx/angular:remote ${remoteApp} --host=${hostApp} --port=${remotePort} --project-name-and-root-format=derived --no-interactive`
+      `generate @nx/angular:remote ${remoteApp} --host=${hostApp} --port=${remotePort} --no-standalone --project-name-and-root-format=derived --no-interactive`
     );
 
     // check files are generated with the layout directory ("apps/")
@@ -344,7 +344,8 @@ describe('Angular Module Federation', () => {
 
       @Component({
         selector: 'proj-root',
-        template: \`<div class="host">{{title}}</div>\`
+        template: \`<div class="host">{{title}}</div>\`,
+        standalone: true
       })
       export class AppComponent {
         title = \`shell is \${isEven(2) ? 'even' : 'odd'}\`;
@@ -421,7 +422,8 @@ describe('Angular Module Federation', () => {
 
       @Component({
         selector: 'proj-${remote}-entry',
-        template: \`<div class="childremote">{{title}}</div>\`
+        template: \`<div class="childremote">{{title}}</div>\`,
+        standalone: true
       })
       export class RemoteEntryComponent {
         title = \`shell is \${isEven(2) ? 'even' : 'odd'}\`;
@@ -437,7 +439,8 @@ describe('Angular Module Federation', () => {
         name: '${remote}',
         remotes: ['${childRemote}'],
         exposes: {
-          './Module': '${remote}/src/app/remote-entry/entry.module.ts',
+          './Routes': '${remote}/src/app/remote-entry/entry.routes.ts',
+          './Module': '${remote}/src/app/remote-entry/entry.component.ts',
         },
       };
 

--- a/e2e/angular-core/src/projects.test.ts
+++ b/e2e/angular-core/src/projects.test.ts
@@ -28,10 +28,10 @@ describe('Angular Projects', () => {
   beforeAll(() => {
     proj = newProject();
     runCLI(
-      `generate @nx/angular:app ${app1} --project-name-and-root-format=as-provided --no-interactive`
+      `generate @nx/angular:app ${app1} --no-standalone --project-name-and-root-format=as-provided --no-interactive`
     );
     runCLI(
-      `generate @nx/angular:lib ${lib1} --add-module-spec --project-name-and-root-format=as-provided --no-interactive`
+      `generate @nx/angular:lib ${lib1} --no-standalone --add-module-spec --project-name-and-root-format=as-provided --no-interactive`
     );
     app1DefaultModule = readFile(`${app1}/src/app/app.module.ts`);
     app1DefaultComponentTemplate = readFile(
@@ -52,7 +52,7 @@ describe('Angular Projects', () => {
   it('should successfully generate apps and libs and work correctly', async () => {
     const standaloneApp = uniq('standalone-app');
     runCLI(
-      `generate @nx/angular:app ${standaloneApp} --directory=my-dir/${standaloneApp} --standalone=true --project-name-and-root-format=as-provided --no-interactive`
+      `generate @nx/angular:app ${standaloneApp} --directory=my-dir/${standaloneApp} --project-name-and-root-format=as-provided --no-interactive`
     );
 
     const esbuildApp = uniq('esbuild-app');
@@ -201,17 +201,17 @@ describe('Angular Projects', () => {
     // ARRANGE
     const esbuildApp = uniq('esbuild-app');
     runCLI(
-      `generate @nx/angular:app ${esbuildApp} --bundler=esbuild --project-name-and-root-format=as-provided --no-interactive`
+      `generate @nx/angular:app ${esbuildApp} --bundler=esbuild --no-standalone --project-name-and-root-format=as-provided --no-interactive`
     );
 
     const buildableLib = uniq('buildlib1');
     const buildableChildLib = uniq('buildlib2');
 
     runCLI(
-      `generate @nx/angular:library ${buildableLib} --buildable=true --project-name-and-root-format=as-provided --no-interactive`
+      `generate @nx/angular:library ${buildableLib} --buildable=true --no-standalone --project-name-and-root-format=as-provided --no-interactive`
     );
     runCLI(
-      `generate @nx/angular:library ${buildableChildLib} --buildable=true --project-name-and-root-format=as-provided --no-interactive`
+      `generate @nx/angular:library ${buildableChildLib} --buildable=true --no-standalone --project-name-and-root-format=as-provided --no-interactive`
     );
 
     // update the app module to include a ref to the buildable lib
@@ -332,14 +332,14 @@ describe('Angular Projects', () => {
     const entryPoint = uniq('entrypoint');
 
     runCLI(
-      `generate @nx/angular:lib ${lib} --publishable --importPath=@${proj}/${lib} --project-name-and-root-format=as-provided --no-interactive`
+      `generate @nx/angular:lib ${lib} --publishable --importPath=@${proj}/${lib} --no-standalone --project-name-and-root-format=as-provided --no-interactive`
     );
     runCLI(
       `generate @nx/angular:secondary-entry-point --name=${entryPoint} --library=${lib} --no-interactive`
     );
 
     runCLI(
-      `generate @nx/angular:library ${childLib} --publishable=true --importPath=@${proj}/${childLib} --project-name-and-root-format=as-provided --no-interactive`
+      `generate @nx/angular:library ${childLib} --publishable=true --importPath=@${proj}/${childLib} --no-standalone --project-name-and-root-format=as-provided --no-interactive`
     );
     runCLI(
       `generate @nx/angular:secondary-entry-point --name=sub --library=${childLib} --no-interactive`
@@ -375,7 +375,7 @@ describe('Angular Projects', () => {
     const libName = uniq('lib1');
 
     runCLI(
-      `generate @nx/angular:app ${appName} --project-name-and-root-format=derived --no-interactive`
+      `generate @nx/angular:app ${appName} --no-standalone --project-name-and-root-format=derived --no-interactive`
     );
 
     // check files are generated with the layout directory ("apps/")
@@ -391,7 +391,7 @@ describe('Angular Projects', () => {
     );
 
     runCLI(
-      `generate @nx/angular:lib ${libName} --buildable --project-name-and-root-format=derived`
+      `generate @nx/angular:lib ${libName} --no-standalone --buildable --project-name-and-root-format=derived`
     );
 
     // check files are generated with the layout directory ("libs/")
@@ -416,12 +416,12 @@ describe('Angular Projects', () => {
     // assert scoped project names are not supported when --project-name-and-root-format=derived
     expect(() =>
       runCLI(
-        `generate @nx/angular:lib ${libName} --buildable --project-name-and-root-format=derived`
+        `generate @nx/angular:lib ${libName} --buildable --no-standalone --project-name-and-root-format=derived`
       )
     ).toThrow();
 
     runCLI(
-      `generate @nx/angular:lib ${libName} --buildable --project-name-and-root-format=as-provided`
+      `generate @nx/angular:lib ${libName} --buildable --no-standalone --project-name-and-root-format=as-provided`
     );
 
     // check files are generated without the layout directory ("libs/") and

--- a/e2e/angular-extensions/src/misc.test.ts
+++ b/e2e/angular-extensions/src/misc.test.ts
@@ -50,7 +50,8 @@ describe('Move Angular Project', () => {
     expect(moveOutput).toContain(
       `CREATE ${newPath}/src/app/app.component.html`
     );
-    expect(moveOutput).toContain(`CREATE ${newPath}/src/app/app.module.ts`);
+    expect(moveOutput).toContain(`CREATE ${newPath}/src/app/app.component.ts`);
+    expect(moveOutput).toContain(`CREATE ${newPath}/src/app/app.config.ts`);
     expect(moveOutput).toContain(`CREATE ${newPath}/src/assets/.gitkeep`);
   });
 
@@ -98,7 +99,7 @@ describe('Move Angular Project', () => {
     const lib1 = uniq('mylib');
     const lib2 = uniq('mylib');
     runCLI(
-      `generate @nx/angular:lib ${lib1} --project-name-and-root-format=as-provided --no-interactive`
+      `generate @nx/angular:lib ${lib1} --no-standalone --project-name-and-root-format=as-provided --no-interactive`
     );
 
     /**
@@ -106,7 +107,7 @@ describe('Move Angular Project', () => {
      */
 
     runCLI(
-      `generate @nx/angular:lib ${lib2} --project-name-and-root-format=as-provided --no-interactive`
+      `generate @nx/angular:lib ${lib2} --no-standalone --project-name-and-root-format=as-provided --no-interactive`
     );
 
     updateFile(
@@ -154,7 +155,7 @@ describe('Move Angular Project', () => {
     const lib1 = uniq('mylib');
     const lib2 = uniq('mylib');
     runCLI(
-      `generate @nx/angular:lib ${lib1} --project-name-and-root-format=derived --no-interactive`
+      `generate @nx/angular:lib ${lib1} --no-standalone --project-name-and-root-format=derived --no-interactive`
     );
 
     /**
@@ -162,7 +163,7 @@ describe('Move Angular Project', () => {
      */
 
     runCLI(
-      `generate @nx/angular:lib ${lib2} --project-name-and-root-format=derived --no-interactive`
+      `generate @nx/angular:lib ${lib2} --no-standalone --project-name-and-root-format=derived --no-interactive`
     );
 
     updateFile(

--- a/e2e/angular-extensions/src/ngrx.test.ts
+++ b/e2e/angular-extensions/src/ngrx.test.ts
@@ -21,7 +21,7 @@ describe('Angular Package', () => {
     it('should work', async () => {
       const myapp = uniq('myapp');
       runCLI(
-        `generate @nx/angular:app ${myapp} --project-name-and-root-format=as-provided --no-interactive`
+        `generate @nx/angular:app ${myapp} --no-standalone --project-name-and-root-format=as-provided --no-interactive`
       );
 
       // Generate root ngrx state management
@@ -37,7 +37,7 @@ describe('Angular Package', () => {
       const mylib = uniq('mylib');
       // Generate feature library and ngrx state within that library
       runCLI(
-        `g @nx/angular:lib ${mylib} --prefix=fl --project-name-and-root-format=as-provided`
+        `g @nx/angular:lib ${mylib} --prefix=fl --no-standalone --project-name-and-root-format=as-provided`
       );
       runCLI(
         `generate @nx/angular:ngrx flights --parent=${mylib}/src/lib/${mylib}.module.ts --facade`
@@ -54,7 +54,7 @@ describe('Angular Package', () => {
     it('should work with creators', async () => {
       const myapp = uniq('myapp');
       runCLI(
-        `generate @nx/angular:app ${myapp} --routing --project-name-and-root-format=as-provided --no-interactive`
+        `generate @nx/angular:app ${myapp} --routing --no-standalone --project-name-and-root-format=as-provided --no-interactive`
       );
 
       // Generate root ngrx state management
@@ -72,7 +72,7 @@ describe('Angular Package', () => {
       const mylib = uniq('mylib');
       // Generate feature library and ngrx state within that library
       runCLI(
-        `g @nx/angular:lib ${mylib} --prefix=fl --project-name-and-root-format=as-provided`
+        `g @nx/angular:lib ${mylib} --prefix=fl --no-standalone --project-name-and-root-format=as-provided`
       );
 
       const flags = `--facade --barrels`;
@@ -91,7 +91,7 @@ describe('Angular Package', () => {
     it('should work with creators using --module', async () => {
       const myapp = uniq('myapp');
       runCLI(
-        `generate @nx/angular:app ${myapp} --routing --project-name-and-root-format=as-provided --no-interactive`
+        `generate @nx/angular:app ${myapp} --routing --no-standalone --project-name-and-root-format=as-provided --no-interactive`
       );
 
       // Generate root ngrx state management
@@ -109,7 +109,7 @@ describe('Angular Package', () => {
       const mylib = uniq('mylib');
       // Generate feature library and ngrx state within that library
       runCLI(
-        `g @nx/angular:lib ${mylib} --prefix=fl --project-name-and-root-format=as-provided`
+        `g @nx/angular:lib ${mylib} --prefix=fl --no-standalone --project-name-and-root-format=as-provided`
       );
 
       const flags = `--facade --barrels`;

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -57,7 +57,6 @@
     "tslib": "^2.3.0",
     "webpack": "^5.80.0",
     "webpack-merge": "^5.8.0",
-    "enquirer": "^2.3.6",
     "@nx/devkit": "file:../devkit",
     "@nx/cypress": "file:../cypress",
     "@nx/jest": "file:../jest",

--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -907,6 +907,20 @@ exports[`app --strict should enable strict type checking: e2e tsconfig.json 1`] 
 }
 `;
 
+exports[`app angular v15 support should import "ApplicationConfig" from "@angular/platform-browser" 1`] = `
+"import { ApplicationConfig } from '@angular/platform-browser';
+import {
+  provideRouter,
+  withEnabledBlockingInitialNavigation,
+} from '@angular/router';
+import { appRoutes } from './app.routes';
+
+export const appConfig: ApplicationConfig = {
+  providers: [provideRouter(appRoutes, withEnabledBlockingInitialNavigation())],
+};
+"
+`;
+
 exports[`app at the root should accept numbers in the path 1`] = `"src/9-websites/my-app"`;
 
 exports[`app nested should create project configs 1`] = `

--- a/packages/angular/src/generators/application/application.ts
+++ b/packages/angular/src/generators/application/application.ts
@@ -22,7 +22,6 @@ import {
   updateEditorTsConfig,
 } from './lib';
 import type { Schema } from './schema';
-import { prompt } from 'enquirer';
 
 export async function applicationGenerator(
   tree: Tree,
@@ -38,17 +37,6 @@ export async function applicationGeneratorInternal(
   tree: Tree,
   schema: Partial<Schema>
 ): Promise<GeneratorCallback> {
-  if (
-    schema.standalone === undefined &&
-    process.env.NX_INTERACTIVE === 'true'
-  ) {
-    schema.standalone = await prompt({
-      name: 'standalone-components',
-      message: 'Would you like to use Standalone Components?',
-      type: 'confirm',
-    }).then((a) => a['standalone-components']);
-  }
-
   const options = await normalizeOptions(tree, schema);
   const rootOffset = offsetFromRoot(options.appProjectRoot);
 

--- a/packages/angular/src/generators/application/lib/create-project.ts
+++ b/packages/angular/src/generators/application/lib/create-project.ts
@@ -1,11 +1,9 @@
 import type { Tree } from '@nx/devkit';
 import { addProjectConfiguration } from '@nx/devkit';
 import type { AngularProjectConfiguration } from '../../../utils/types';
-import { getInstalledAngularVersionInfo } from '../../utils/version-utils';
 import type { NormalizedSchema } from './normalized-schema';
 
 export function createProject(tree: Tree, options: NormalizedSchema) {
-  const installedAngularInfo = getInstalledAngularVersionInfo(tree);
   const buildExecutor =
     options.bundler === 'webpack'
       ? '@angular-devkit/build-angular:browser'

--- a/packages/angular/src/generators/application/lib/normalize-options.ts
+++ b/packages/angular/src/generators/application/lib/normalize-options.ts
@@ -52,6 +52,7 @@ export async function normalizeOptions(
     linter: Linter.EsLint,
     strict: true,
     bundler: options.bundler ?? 'webpack',
+    standalone: true,
     ...options,
     prefix,
     name: appProjectName,

--- a/packages/angular/src/generators/application/schema.json
+++ b/packages/angular/src/generators/application/schema.json
@@ -156,6 +156,7 @@
     "standalone": {
       "description": "Generate an application that is setup to use standalone components.",
       "type": "boolean",
+      "default": true,
       "x-priority": "important"
     },
     "rootProject": {

--- a/packages/angular/src/generators/component/component.spec.ts
+++ b/packages/angular/src/generators/component/component.spec.ts
@@ -1,9 +1,4 @@
-import {
-  addProjectConfiguration,
-  stripIndents,
-  updateJson,
-  writeJson,
-} from '@nx/devkit';
+import { addProjectConfiguration, writeJson } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { componentGenerator } from './component';
 
@@ -33,6 +28,7 @@ describe('component Generator', () => {
     await componentGenerator(tree, {
       name: 'example',
       project: 'lib1',
+      standalone: false,
     });
 
     // ASSERT
@@ -79,6 +75,7 @@ describe('component Generator', () => {
       name: 'example',
       project: 'lib1',
       skipTests: true,
+      standalone: false,
     });
 
     // ASSERT
@@ -113,6 +110,7 @@ describe('component Generator', () => {
       name: 'example',
       project: 'lib1',
       inlineTemplate: true,
+      standalone: false,
     });
 
     // ASSERT
@@ -150,6 +148,7 @@ describe('component Generator', () => {
       name: 'example',
       project: 'lib1',
       inlineStyle: true,
+      standalone: false,
     });
 
     // ASSERT
@@ -187,6 +186,7 @@ describe('component Generator', () => {
       name: 'example',
       project: 'lib1',
       style: 'none',
+      standalone: false,
     });
 
     // ASSERT
@@ -232,6 +232,7 @@ describe('component Generator', () => {
       name: 'example',
       project: 'lib1',
       export: true,
+      standalone: false,
     });
 
     // ASSERT
@@ -270,7 +271,6 @@ describe('component Generator', () => {
     await componentGenerator(tree, {
       name: 'example',
       project: 'lib1',
-      standalone: true,
       export: true,
     });
 
@@ -314,6 +314,7 @@ describe('component Generator', () => {
       name: 'example',
       project: 'lib1',
       export: false,
+      standalone: false,
     });
 
     // ASSERT
@@ -354,7 +355,6 @@ describe('component Generator', () => {
     await componentGenerator(tree, {
       name: 'example',
       project: 'lib1',
-      standalone: true,
       export: false,
     });
 
@@ -397,6 +397,7 @@ describe('component Generator', () => {
       name: 'example',
       project: 'lib1',
       skipImport: true,
+      standalone: false,
     });
 
     // ASSERT
@@ -437,6 +438,7 @@ describe('component Generator', () => {
       name: 'example',
       project: 'lib1',
       export: true,
+      standalone: false,
     });
 
     // ASSERT
@@ -476,6 +478,7 @@ describe('component Generator', () => {
       name: 'example',
       project: 'lib1',
       export: true,
+      standalone: false,
     });
 
     // ASSERT
@@ -511,6 +514,7 @@ describe('component Generator', () => {
         project: 'lib1',
         flat: true,
         export: true,
+        standalone: false,
       });
 
       // ASSERT
@@ -551,6 +555,7 @@ describe('component Generator', () => {
         project: 'lib1',
         flat: true,
         export: false,
+        standalone: false,
       });
 
       // ASSERT
@@ -595,6 +600,7 @@ describe('component Generator', () => {
         project: 'lib1',
         path: 'libs/lib1/src/lib/mycomp',
         export: true,
+        standalone: false,
       });
 
       // ASSERT
@@ -638,6 +644,7 @@ describe('component Generator', () => {
           project: 'lib1',
           path: 'apps/app1/src/mycomp',
           export: false,
+          standalone: false,
         })
       ).rejects.toThrow();
     });
@@ -683,6 +690,7 @@ describe('component Generator', () => {
           project: 'lib1',
           module,
           export: true,
+          standalone: false,
         });
 
         // ASSERT
@@ -723,6 +731,7 @@ describe('component Generator', () => {
         project: 'shared-ui',
         export: true,
         flat: false,
+        standalone: false,
       });
 
       // ASSERT
@@ -771,6 +780,7 @@ describe('component Generator', () => {
         project: 'lib1',
         module: 'not-exported',
         export: true,
+        standalone: false,
       });
 
       // ASSERT
@@ -808,6 +818,7 @@ describe('component Generator', () => {
           project: 'lib1',
           path: 'libs/lib1/src/lib',
           module: 'not-found',
+          standalone: false,
         })
       ).rejects.toThrow();
     });
@@ -849,6 +860,7 @@ describe('component Generator', () => {
           name: 'example',
           project: 'lib1',
           path: 'libs/lib1/src/lib',
+          standalone: false,
         })
       ).rejects.toThrow();
     });
@@ -902,6 +914,7 @@ describe('component Generator', () => {
         project: 'lib1',
         path: 'libs/lib1/secondary/src/lib',
         export: true,
+        standalone: false,
       });
 
       // ASSERT
@@ -961,6 +974,7 @@ describe('component Generator', () => {
         name: 'example',
         project: 'lib1',
         export: true,
+        standalone: false,
       });
 
       // ASSERT

--- a/packages/angular/src/generators/component/lib/normalize-options.ts
+++ b/packages/angular/src/generators/component/lib/normalize-options.ts
@@ -46,6 +46,7 @@ export async function normalizeOptions(
     projectName,
     changeDetection: options.changeDetection ?? 'Default',
     style: options.style ?? 'css',
+    standalone: options.standalone ?? true,
     directory,
     fileName,
     filePath,

--- a/packages/angular/src/generators/component/schema.json
+++ b/packages/angular/src/generators/component/schema.json
@@ -62,7 +62,7 @@
     "standalone": {
       "description": "Whether the generated component is standalone.",
       "type": "boolean",
-      "default": false,
+      "default": true,
       "x-priority": "important"
     },
     "viewEncapsulation": {

--- a/packages/angular/src/generators/directive/__snapshots__/directive.spec.ts.snap
+++ b/packages/angular/src/generators/directive/__snapshots__/directive.spec.ts.snap
@@ -1,30 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`directive generator should export the directive correctly when flat=false and path is nested deeper 1`] = `
-"import { Directive } from '@angular/core';
-
-@Directive({
-  selector: '[projTest]',
-})
-export class TestDirective {
-  constructor() {}
-}
-"
-`;
-
-exports[`directive generator should export the directive correctly when flat=false and path is nested deeper 2`] = `
-"import { TestDirective } from './test.directive';
-
-describe('TestDirective', () => {
-  it('should create an instance', () => {
-    const directive = new TestDirective();
-    expect(directive).toBeTruthy();
-  });
-});
-"
-`;
-
-exports[`directive generator should export the directive correctly when flat=false and path is nested deeper 3`] = `
+exports[`directive generator --no-standalone should export the directive correctly when flat=false and path is nested deeper 1`] = `
 "import { NgModule } from '@angular/core';
 import { TestDirective } from './my-directives/test/test.directive';
 @NgModule({
@@ -36,7 +12,7 @@ export class TestModule {}
 "
 `;
 
-exports[`directive generator should generate a directive with test files and attach to the NgModule automatically 1`] = `
+exports[`directive generator --no-standalone should generate a directive with test files and attach to the NgModule automatically 1`] = `
 "import { Directive } from '@angular/core';
 
 @Directive({
@@ -48,7 +24,7 @@ export class TestDirective {
 "
 `;
 
-exports[`directive generator should generate a directive with test files and attach to the NgModule automatically 2`] = `
+exports[`directive generator --no-standalone should generate a directive with test files and attach to the NgModule automatically 2`] = `
 "import { TestDirective } from './test.directive';
 
 describe('TestDirective', () => {
@@ -60,7 +36,7 @@ describe('TestDirective', () => {
 "
 `;
 
-exports[`directive generator should generate a directive with test files and attach to the NgModule automatically 3`] = `
+exports[`directive generator --no-standalone should generate a directive with test files and attach to the NgModule automatically 3`] = `
 "import { NgModule } from '@angular/core';
 import { TestDirective } from './test.directive';
 @NgModule({
@@ -72,7 +48,7 @@ export class TestModule {}
 "
 `;
 
-exports[`directive generator should import the directive correctly when flat=false 1`] = `
+exports[`directive generator --no-standalone should import the directive correctly when flat=false 1`] = `
 "import { Directive } from '@angular/core';
 
 @Directive({
@@ -84,7 +60,7 @@ export class TestDirective {
 "
 `;
 
-exports[`directive generator should import the directive correctly when flat=false 2`] = `
+exports[`directive generator --no-standalone should import the directive correctly when flat=false 2`] = `
 "import { TestDirective } from './test.directive';
 
 describe('TestDirective', () => {
@@ -96,7 +72,7 @@ describe('TestDirective', () => {
 "
 `;
 
-exports[`directive generator should import the directive correctly when flat=false 3`] = `
+exports[`directive generator --no-standalone should import the directive correctly when flat=false 3`] = `
 "import { NgModule } from '@angular/core';
 import { TestDirective } from './test/test.directive';
 @NgModule({
@@ -108,7 +84,7 @@ export class TestModule {}
 "
 `;
 
-exports[`directive generator should import the directive correctly when flat=false and path is nested deeper 1`] = `
+exports[`directive generator --no-standalone should import the directive correctly when flat=false and path is nested deeper 1`] = `
 "import { Directive } from '@angular/core';
 
 @Directive({
@@ -120,7 +96,7 @@ export class TestDirective {
 "
 `;
 
-exports[`directive generator should import the directive correctly when flat=false and path is nested deeper 2`] = `
+exports[`directive generator --no-standalone should import the directive correctly when flat=false and path is nested deeper 2`] = `
 "import { TestDirective } from './test.directive';
 
 describe('TestDirective', () => {
@@ -132,7 +108,7 @@ describe('TestDirective', () => {
 "
 `;
 
-exports[`directive generator should import the directive correctly when flat=false and path is nested deeper 3`] = `
+exports[`directive generator --no-standalone should import the directive correctly when flat=false and path is nested deeper 3`] = `
 "import { NgModule } from '@angular/core';
 import { TestDirective } from './my-directives/test/test.directive';
 @NgModule({
@@ -144,66 +120,7 @@ export class TestModule {}
 "
 `;
 
-exports[`directive generator should not generate test file when skipTests=true 1`] = `
-"import { Directive } from '@angular/core';
-
-@Directive({
-  selector: '[projTest]',
-})
-export class TestDirective {
-  constructor() {}
-}
-"
-`;
-
-exports[`directive generator should not generate test file when skipTests=true 2`] = `
-"import { NgModule } from '@angular/core';
-import { TestDirective } from './my-directives/test/test.directive';
-@NgModule({
-  imports: [],
-  declarations: [TestDirective],
-  exports: [],
-})
-export class TestModule {}
-"
-`;
-
-exports[`directive generator should not import the directive when skipImport=true 1`] = `
-"import { Directive } from '@angular/core';
-
-@Directive({
-  selector: '[projTest]',
-})
-export class TestDirective {
-  constructor() {}
-}
-"
-`;
-
-exports[`directive generator should not import the directive when skipImport=true 2`] = `
-"import { TestDirective } from './test.directive';
-
-describe('TestDirective', () => {
-  it('should create an instance', () => {
-    const directive = new TestDirective();
-    expect(directive).toBeTruthy();
-  });
-});
-"
-`;
-
-exports[`directive generator should not import the directive when skipImport=true 3`] = `
-"import { NgModule } from '@angular/core';
-@NgModule({
-  imports: [],
-  declarations: [],
-  exports: [],
-})
-export class TestModule {}
-"
-`;
-
-exports[`directive generator should not import the directive when standalone=true 1`] = `
+exports[`directive generator should generate correctly 1`] = `
 "import { Directive } from '@angular/core';
 
 @Directive({
@@ -216,7 +133,7 @@ export class TestDirective {
 "
 `;
 
-exports[`directive generator should not import the directive when standalone=true 2`] = `
+exports[`directive generator should generate correctly 2`] = `
 "import { TestDirective } from './test.directive';
 
 describe('TestDirective', () => {
@@ -225,16 +142,5 @@ describe('TestDirective', () => {
     expect(directive).toBeTruthy();
   });
 });
-"
-`;
-
-exports[`directive generator should not import the directive when standalone=true 3`] = `
-"import { NgModule } from '@angular/core';
-@NgModule({
-  imports: [],
-  declarations: [],
-  exports: [],
-})
-export class TestModule {}
 "
 `;

--- a/packages/angular/src/generators/directive/directive.spec.ts
+++ b/packages/angular/src/generators/directive/directive.spec.ts
@@ -14,22 +14,9 @@ describe('directive generator', () => {
       sourceRoot: 'test/src',
       projectType: 'application',
     });
-
-    tree.write(
-      'test/src/app/test.module.ts',
-      `import {NgModule} from "@angular/core";
-    @NgModule({
-      imports: [],
-      declarations: [],
-      exports: []
-    })
-    export class TestModule {}`
-    );
   });
 
-  it('should generate a directive with test files and attach to the NgModule automatically', async () => {
-    // ARRANGE
-
+  it('should generate correctly', async () => {
     // ACT
     await generateDirectiveWithDefaultOptions(tree);
 
@@ -40,107 +27,19 @@ describe('directive generator', () => {
     expect(
       tree.read('test/src/app/test.directive.spec.ts', 'utf-8')
     ).toMatchSnapshot();
-    expect(tree.read('test/src/app/test.module.ts', 'utf-8')).toMatchSnapshot();
   });
 
-  it('should import the directive correctly when flat=false', async () => {
+  it('should not import the directive into an existing module', async () => {
     // ARRANGE
+    addModule(tree);
 
     // ACT
-    await generateDirectiveWithDefaultOptions(tree, { flat: false });
+    await generateDirectiveWithDefaultOptions(tree);
 
     // ASSERT
-    expect(
-      tree.read('test/src/app/test/test.directive.ts', 'utf-8')
-    ).toMatchSnapshot();
-    expect(
-      tree.read('test/src/app/test/test.directive.spec.ts', 'utf-8')
-    ).toMatchSnapshot();
-    expect(tree.read('test/src/app/test.module.ts', 'utf-8')).toMatchSnapshot();
-  });
-
-  it('should not import the directive when standalone=true', async () => {
-    // ARRANGE
-
-    // ACT
-    await generateDirectiveWithDefaultOptions(tree, { standalone: true });
-
-    // ASSERT
-    expect(
-      tree.read('test/src/app/test.directive.ts', 'utf-8')
-    ).toMatchSnapshot();
-    expect(
-      tree.read('test/src/app/test.directive.spec.ts', 'utf-8')
-    ).toMatchSnapshot();
-    expect(tree.read('test/src/app/test.module.ts', 'utf-8')).toMatchSnapshot();
-  });
-
-  it('should import the directive correctly when flat=false and path is nested deeper', async () => {
-    // ARRANGE
-
-    // ACT
-    await generateDirectiveWithDefaultOptions(tree, {
-      flat: false,
-      path: 'test/src/app/my-directives',
-    });
-
-    // ASSERT
-    expect(
-      tree.read('test/src/app/my-directives/test/test.directive.ts', 'utf-8')
-    ).toMatchSnapshot();
-    expect(
-      tree.read(
-        'test/src/app/my-directives/test/test.directive.spec.ts',
-        'utf-8'
-      )
-    ).toMatchSnapshot();
-    expect(tree.read('test/src/app/test.module.ts', 'utf-8')).toMatchSnapshot();
-  });
-
-  it('should export the directive correctly when flat=false and path is nested deeper', async () => {
-    // ARRANGE
-
-    // ACT
-    await generateDirectiveWithDefaultOptions(tree, {
-      flat: false,
-      path: 'test/src/app/my-directives',
-      export: true,
-    });
-
-    // ASSERT
-    expect(
-      tree.read('test/src/app/my-directives/test/test.directive.ts', 'utf-8')
-    ).toMatchSnapshot();
-    expect(
-      tree.read(
-        'test/src/app/my-directives/test/test.directive.spec.ts',
-        'utf-8'
-      )
-    ).toMatchSnapshot();
-    expect(tree.read('test/src/app/test.module.ts', 'utf-8')).toMatchSnapshot();
-  });
-
-  it('should not import the directive when skipImport=true', async () => {
-    // ARRANGE
-
-    // ACT
-    await generateDirectiveWithDefaultOptions(tree, {
-      flat: false,
-      path: 'test/src/app/my-directives',
-      skipImport: true,
-    });
-
-    // ASSERT
-    expect(
-      tree.read('test/src/app/my-directives/test/test.directive.ts', 'utf-8')
-    ).toMatchSnapshot();
-    expect(
-      tree.read(
-        'test/src/app/my-directives/test/test.directive.spec.ts',
-        'utf-8'
-      )
-    ).toMatchSnapshot();
-    expect(tree.read('test/src/app/test.module.ts', 'utf-8')).toMatchSnapshot();
+    expect(tree.read('test/src/app/test.module.ts', 'utf-8')).not.toContain(
+      'TestDirective'
+    );
   });
 
   it('should not generate test file when skipTests=true', async () => {
@@ -155,14 +54,127 @@ describe('directive generator', () => {
 
     // ASSERT
     expect(
-      tree.read('test/src/app/my-directives/test/test.directive.ts', 'utf-8')
-    ).toMatchSnapshot();
-    expect(
       tree.exists('test/src/app/my-directives/test/test.directive.spec.ts')
     ).toBeFalsy();
-    expect(tree.read('test/src/app/test.module.ts', 'utf-8')).toMatchSnapshot();
+  });
+
+  describe('--no-standalone', () => {
+    beforeEach(() => {
+      addModule(tree);
+    });
+
+    it('should generate a directive with test files and attach to the NgModule automatically', async () => {
+      // ARRANGE
+
+      // ACT
+      await generateDirectiveWithDefaultOptions(tree, { standalone: false });
+
+      // ASSERT
+      expect(
+        tree.read('test/src/app/test.directive.ts', 'utf-8')
+      ).toMatchSnapshot();
+      expect(
+        tree.read('test/src/app/test.directive.spec.ts', 'utf-8')
+      ).toMatchSnapshot();
+      expect(
+        tree.read('test/src/app/test.module.ts', 'utf-8')
+      ).toMatchSnapshot();
+    });
+
+    it('should import the directive correctly when flat=false', async () => {
+      // ARRANGE
+
+      // ACT
+      await generateDirectiveWithDefaultOptions(tree, {
+        flat: false,
+        standalone: false,
+      });
+
+      // ASSERT
+      expect(
+        tree.read('test/src/app/test/test.directive.ts', 'utf-8')
+      ).toMatchSnapshot();
+      expect(
+        tree.read('test/src/app/test/test.directive.spec.ts', 'utf-8')
+      ).toMatchSnapshot();
+      expect(
+        tree.read('test/src/app/test.module.ts', 'utf-8')
+      ).toMatchSnapshot();
+    });
+
+    it('should import the directive correctly when flat=false and path is nested deeper', async () => {
+      // ARRANGE
+
+      // ACT
+      await generateDirectiveWithDefaultOptions(tree, {
+        flat: false,
+        path: 'test/src/app/my-directives',
+        standalone: false,
+      });
+
+      // ASSERT
+      expect(
+        tree.read('test/src/app/my-directives/test/test.directive.ts', 'utf-8')
+      ).toMatchSnapshot();
+      expect(
+        tree.read(
+          'test/src/app/my-directives/test/test.directive.spec.ts',
+          'utf-8'
+        )
+      ).toMatchSnapshot();
+      expect(
+        tree.read('test/src/app/test.module.ts', 'utf-8')
+      ).toMatchSnapshot();
+    });
+
+    it('should export the directive correctly when flat=false and path is nested deeper', async () => {
+      // ARRANGE
+
+      // ACT
+      await generateDirectiveWithDefaultOptions(tree, {
+        flat: false,
+        path: 'test/src/app/my-directives',
+        export: true,
+        standalone: false,
+      });
+
+      // ASSERT
+      expect(
+        tree.read('test/src/app/test.module.ts', 'utf-8')
+      ).toMatchSnapshot();
+    });
+
+    it('should not import the directive when skipImport=true', async () => {
+      // ARRANGE
+
+      // ACT
+      await generateDirectiveWithDefaultOptions(tree, {
+        flat: false,
+        path: 'test/src/app/my-directives',
+        skipImport: true,
+        standalone: false,
+      });
+
+      // ASSERT
+      expect(tree.read('test/src/app/test.module.ts', 'utf-8')).not.toContain(
+        'TestDirective'
+      );
+    });
   });
 });
+
+function addModule(tree: Tree) {
+  tree.write(
+    'test/src/app/test.module.ts',
+    `import {NgModule} from "@angular/core";
+  @NgModule({
+    imports: [],
+    declarations: [],
+    exports: []
+  })
+  export class TestModule {}`
+  );
+}
 
 async function generateDirectiveWithDefaultOptions(
   tree: Tree,

--- a/packages/angular/src/generators/directive/lib/normalize-options.ts
+++ b/packages/angular/src/generators/directive/lib/normalize-options.ts
@@ -48,5 +48,6 @@ export async function normalizeOptions(
     filePath,
     symbolName,
     selector,
+    standalone: options.standalone ?? true,
   };
 }

--- a/packages/angular/src/generators/directive/schema.json
+++ b/packages/angular/src/generators/directive/schema.json
@@ -68,7 +68,7 @@
     "standalone": {
       "description": "Whether the generated directive is standalone.",
       "type": "boolean",
-      "default": false
+      "default": true
     },
     "flat": {
       "type": "boolean",

--- a/packages/angular/src/generators/federate-module/federate-module.ts
+++ b/packages/angular/src/generators/federate-module/federate-module.ts
@@ -19,6 +19,9 @@ export async function federateModuleGenerator(tree: Tree, schema: Schema) {
     
     Path: ${schema.path}`);
   }
+
+  schema.standalone = schema.standalone ?? true;
+
   const { tasks, projectRoot, remoteName } = await addRemote(tree, schema);
 
   addFileToRemoteTsconfig(tree, remoteName, schema.path);

--- a/packages/angular/src/generators/federate-module/schema.json
+++ b/packages/angular/src/generators/federate-module/schema.json
@@ -69,7 +69,7 @@
     "standalone": {
       "description": "Whether to generate the remote application with standalone components if it needs to be created.",
       "type": "boolean",
-      "default": false
+      "default": true
     },
     "host": {
       "type": "string",

--- a/packages/angular/src/generators/host/__snapshots__/host.spec.ts.snap
+++ b/packages/angular/src/generators/host/__snapshots__/host.spec.ts.snap
@@ -868,8 +868,9 @@ describe('AppComponent', () => {
         RouterTestingModule.withRoutes([
           { path: '', component: NxWelcomeComponent },
         ]),
+        AppComponent,
+        NxWelcomeComponent,
       ],
-      declarations: [AppComponent, NxWelcomeComponent],
     }).compileComponents();
   });
 
@@ -912,8 +913,9 @@ describe('AppComponent', () => {
         RouterTestingModule.withRoutes([
           { path: '', component: NxWelcomeComponent },
         ]),
+        AppComponent,
+        NxWelcomeComponent,
       ],
-      declarations: [AppComponent, NxWelcomeComponent],
     }).compileComponents();
   });
 

--- a/packages/angular/src/generators/host/host.spec.ts
+++ b/packages/angular/src/generators/host/host.spec.ts
@@ -1,4 +1,3 @@
-import { stripIndents, updateJson } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import {
   getProjects,
@@ -19,6 +18,7 @@ describe('Host App Generator', () => {
     await generateTestHostApplication(tree, {
       name: 'test',
       typescriptConfiguration: false,
+      standalone: false,
     });
 
     // ASSERT
@@ -32,6 +32,7 @@ describe('Host App Generator', () => {
     await generateTestHostApplication(tree, {
       name: 'test',
       typescriptConfiguration: true,
+      standalone: false,
     });
 
     // ASSERT
@@ -45,6 +46,7 @@ describe('Host App Generator', () => {
     await generateTestRemoteApplication(tree, {
       name: 'remote',
       typescriptConfiguration: false,
+      standalone: false,
     });
 
     // ACT
@@ -52,6 +54,7 @@ describe('Host App Generator', () => {
       name: 'test',
       remotes: ['remote'],
       typescriptConfiguration: false,
+      standalone: false,
     });
 
     // ASSERT
@@ -65,6 +68,7 @@ describe('Host App Generator', () => {
     await generateTestRemoteApplication(tree, {
       name: 'remote',
       typescriptConfiguration: true,
+      standalone: false,
     });
 
     // ACT
@@ -72,6 +76,7 @@ describe('Host App Generator', () => {
       name: 'test',
       remotes: ['remote'],
       typescriptConfiguration: true,
+      standalone: false,
     });
 
     // ASSERT
@@ -89,6 +94,7 @@ describe('Host App Generator', () => {
       name: 'host-app',
       remotes: ['remote1', 'remote2'],
       typescriptConfiguration: false,
+      standalone: false,
     });
 
     // ASSERT
@@ -119,6 +125,7 @@ describe('Host App Generator', () => {
       name: 'host-app',
       remotes: ['remote1', 'remote2'],
       typescriptConfiguration: true,
+      standalone: false,
     });
 
     // ASSERT
@@ -145,6 +152,7 @@ describe('Host App Generator', () => {
     await generateTestRemoteApplication(tree, {
       name: 'remote1',
       typescriptConfiguration: false,
+      standalone: false,
     });
 
     // ACT
@@ -152,6 +160,7 @@ describe('Host App Generator', () => {
       name: 'host-app',
       remotes: ['remote1', 'remote2', 'remote3'],
       typescriptConfiguration: false,
+      standalone: false,
     });
 
     // ASSERT
@@ -169,6 +178,7 @@ describe('Host App Generator', () => {
     await generateTestRemoteApplication(tree, {
       name: 'remote1',
       typescriptConfiguration: true,
+      standalone: false,
     });
 
     // ACT
@@ -176,6 +186,7 @@ describe('Host App Generator', () => {
       name: 'host-app',
       remotes: ['remote1', 'remote2', 'remote3'],
       typescriptConfiguration: true,
+      standalone: false,
     });
 
     // ASSERT
@@ -193,6 +204,7 @@ describe('Host App Generator', () => {
     await generateTestRemoteApplication(tree, {
       name: 'remote1',
       typescriptConfiguration: false,
+      standalone: false,
     });
 
     // ACT
@@ -201,6 +213,7 @@ describe('Host App Generator', () => {
       directory: 'foo/host-app',
       remotes: ['remote1', 'remote2', 'remote3'],
       typescriptConfiguration: false,
+      standalone: false,
     });
 
     // ASSERT
@@ -218,6 +231,7 @@ describe('Host App Generator', () => {
     await generateTestRemoteApplication(tree, {
       name: 'remote1',
       typescriptConfiguration: true,
+      standalone: false,
     });
 
     // ACT
@@ -226,6 +240,7 @@ describe('Host App Generator', () => {
       directory: 'foo/host-app',
       remotes: ['remote1', 'remote2', 'remote3'],
       typescriptConfiguration: true,
+      standalone: false,
     });
 
     // ASSERT
@@ -245,7 +260,6 @@ describe('Host App Generator', () => {
     await generateTestHostApplication(tree, {
       name: 'host',
       remotes: ['remote1'],
-      standalone: true,
     });
 
     // ASSERT
@@ -264,7 +278,6 @@ describe('Host App Generator', () => {
     await generateTestHostApplication(tree, {
       name: 'host',
       remotes: ['remote1'],
-      standalone: true,
     });
 
     // ASSERT
@@ -282,7 +295,6 @@ describe('Host App Generator', () => {
       name: 'dashboard',
       remotes: ['remote1'],
       directory: 'test/dashboard',
-      standalone: true,
     });
 
     // ASSERT
@@ -300,6 +312,7 @@ describe('Host App Generator', () => {
       name: 'dashboard',
       remotes: ['remote1'],
       e2eTestRunner: E2eTestRunner.None,
+      standalone: false,
     });
 
     // ASSERT
@@ -318,6 +331,7 @@ describe('Host App Generator', () => {
         name: 'test',
         ssr: true,
         typescriptConfiguration: false,
+        standalone: false,
       });
 
       // ASSERT
@@ -353,6 +367,7 @@ describe('Host App Generator', () => {
         name: 'test',
         ssr: true,
         typescriptConfiguration: true,
+        standalone: false,
       });
 
       // ASSERT
@@ -386,7 +401,6 @@ describe('Host App Generator', () => {
       // ACT
       await generateTestHostApplication(tree, {
         name: 'test',
-        standalone: true,
         ssr: true,
         typescriptConfiguration: false,
       });
@@ -426,7 +440,6 @@ describe('Host App Generator', () => {
       // ACT
       await generateTestHostApplication(tree, {
         name: 'test',
-        standalone: true,
         ssr: true,
         typescriptConfiguration: true,
       });
@@ -468,6 +481,7 @@ describe('Host App Generator', () => {
         name: 'remote1',
         projectNameAndRootFormat: 'derived',
         typescriptConfiguration: false,
+        standalone: false,
       });
 
       // ACT
@@ -476,6 +490,7 @@ describe('Host App Generator', () => {
         remotes: ['remote1', 'remote2', 'remote3'],
         projectNameAndRootFormat: 'derived',
         typescriptConfiguration: false,
+        standalone: false,
       });
 
       // ASSERT
@@ -494,6 +509,7 @@ describe('Host App Generator', () => {
         name: 'remote1',
         projectNameAndRootFormat: 'derived',
         typescriptConfiguration: false,
+        standalone: false,
       });
 
       // ACT
@@ -503,6 +519,7 @@ describe('Host App Generator', () => {
         remotes: ['remote1', 'remote2', 'remote3'],
         projectNameAndRootFormat: 'derived',
         typescriptConfiguration: false,
+        standalone: false,
       });
 
       // ASSERT
@@ -520,6 +537,7 @@ describe('Host App Generator', () => {
         name: 'remote1',
         projectNameAndRootFormat: 'derived',
         typescriptConfiguration: true,
+        standalone: false,
       });
 
       // ACT
@@ -529,6 +547,7 @@ describe('Host App Generator', () => {
         remotes: ['remote1', 'remote2', 'remote3'],
         projectNameAndRootFormat: 'derived',
         typescriptConfiguration: true,
+        standalone: false,
       });
 
       // ASSERT

--- a/packages/angular/src/generators/host/host.ts
+++ b/packages/angular/src/generators/host/host.ts
@@ -22,6 +22,7 @@ export async function host(tree: Tree, options: Schema) {
 
 export async function hostInternal(tree: Tree, schema: Schema) {
   const { typescriptConfiguration = true, ...options }: Schema = schema;
+  options.standalone = options.standalone ?? true;
 
   const projects = getProjects(tree);
 
@@ -50,7 +51,7 @@ export async function hostInternal(tree: Tree, schema: Schema) {
 
   const appInstallTask = await applicationGenerator(tree, {
     ...options,
-    standalone: options.standalone ?? false,
+    standalone: options.standalone,
     routing: true,
     port: 4200,
     skipFormat: true,
@@ -71,6 +72,7 @@ export async function hostInternal(tree: Tree, schema: Schema) {
     e2eProjectName: skipE2E ? undefined : `${hostProjectName}-e2e`,
     prefix: options.prefix,
     typescriptConfiguration,
+    standalone: options.standalone,
   });
 
   let installTasks = [appInstallTask];

--- a/packages/angular/src/generators/host/schema.json
+++ b/packages/angular/src/generators/host/schema.json
@@ -166,7 +166,7 @@
     "standalone": {
       "type": "boolean",
       "description": "Whether to generate a host application that uses standalone components.",
-      "default": false
+      "default": true
     },
     "ssr": {
       "description": "Whether to configure SSR for the host application",

--- a/packages/angular/src/generators/library/lib/normalize-options.ts
+++ b/packages/angular/src/generators/library/lib/normalize-options.ts
@@ -11,6 +11,7 @@ export async function normalizeOptions(
   host: Tree,
   schema: Schema
 ): Promise<NormalizedSchema> {
+  schema.standalone = schema.standalone ?? true;
   // Create a schema with populated default values
   const options: Schema = {
     buildable: false,

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -41,6 +41,7 @@ describe('lib', () => {
       unitTestRunner: UnitTestRunner.Jest,
       simpleName: false,
       strict: true,
+      standalone: false,
       ...opts,
     });
   }

--- a/packages/angular/src/generators/library/schema.json
+++ b/packages/angular/src/generators/library/schema.json
@@ -142,7 +142,7 @@
     "standalone": {
       "type": "boolean",
       "description": "Generate a library that uses a standalone component instead of a module as the entry point.",
-      "default": false
+      "default": true
     },
     "displayBlock": {
       "description": "Specifies if the component generated style will contain `:host { display: block; }`. Disclaimer: This option is only valid when `--standalone` is set to `true`.",

--- a/packages/angular/src/generators/move/move.spec.ts
+++ b/packages/angular/src/generators/move/move.spec.ts
@@ -39,6 +39,7 @@ describe('@nx/angular:move', () => {
       simpleName: true,
       skipFormat: false,
       unitTestRunner: UnitTestRunner.Jest,
+      standalone: false,
     });
 
     jest
@@ -335,6 +336,7 @@ describe('@nx/angular:move', () => {
         simpleName: true,
         skipFormat: false,
         unitTestRunner: UnitTestRunner.Jest,
+        standalone: false,
       });
       addProjectToGraph('my-lib');
 
@@ -355,7 +357,11 @@ describe('@nx/angular:move', () => {
   });
 
   it('should move project correctly when --project-name-and-root-format=derived', async () => {
-    await generateTestLibrary(tree, { name: 'mylib2', buildable: true });
+    await generateTestLibrary(tree, {
+      name: 'mylib2',
+      buildable: true,
+      standalone: false,
+    });
     addProjectToGraph('mylib2');
 
     await angularMoveGenerator(tree, {

--- a/packages/angular/src/generators/ngrx/ngrx.spec.ts
+++ b/packages/angular/src/generators/ngrx/ngrx.spec.ts
@@ -637,7 +637,7 @@ describe('ngrx', () => {
     beforeEach(async () => {
       jest.clearAllMocks();
       tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-      await generateTestApplication(tree, { name: 'myapp' });
+      await generateTestApplication(tree, { name: 'myapp', standalone: false });
       devkit.updateJson(tree, 'package.json', (json) => ({
         ...json,
         dependencies: {
@@ -679,7 +679,7 @@ describe('ngrx', () => {
   describe('rxjs v6 support', () => {
     beforeEach(async () => {
       tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-      await generateTestApplication(tree, { name: 'myapp' });
+      await generateTestApplication(tree, { name: 'myapp', standalone: false });
       devkit.updateJson(tree, 'package.json', (json) => ({
         ...json,
         dependencies: {

--- a/packages/angular/src/generators/pipe/__snapshots__/pipe.spec.ts.snap
+++ b/packages/angular/src/generators/pipe/__snapshots__/pipe.spec.ts.snap
@@ -1,32 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`pipe generator should export the pipe correctly when flat=false and path is nested deeper 1`] = `
-"import { Pipe, PipeTransform } from '@angular/core';
-
-@Pipe({
-  name: 'test',
-})
-export class TestPipe implements PipeTransform {
-  transform(value: unknown, ...args: unknown[]): unknown {
-    return null;
-  }
-}
-"
-`;
-
-exports[`pipe generator should export the pipe correctly when flat=false and path is nested deeper 2`] = `
-"import { TestPipe } from './test.pipe';
-
-describe('TestPipe', () => {
-  it('create an instance', () => {
-    const pipe = new TestPipe();
-    expect(pipe).toBeTruthy();
-  });
-});
-"
-`;
-
-exports[`pipe generator should export the pipe correctly when flat=false and path is nested deeper 3`] = `
+exports[`pipe generator --no-standalone should export the pipe correctly when flat=false and path is nested deeper 1`] = `
 "import { NgModule } from '@angular/core';
 import { TestPipe } from './my-pipes/test/test.pipe';
 @NgModule({
@@ -38,7 +12,7 @@ export class TestModule {}
 "
 `;
 
-exports[`pipe generator should generate a pipe with test files and attach to the NgModule automatically 1`] = `
+exports[`pipe generator --no-standalone should generate a pipe with test files and attach to the NgModule automatically 1`] = `
 "import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
@@ -52,7 +26,7 @@ export class TestPipe implements PipeTransform {
 "
 `;
 
-exports[`pipe generator should generate a pipe with test files and attach to the NgModule automatically 2`] = `
+exports[`pipe generator --no-standalone should generate a pipe with test files and attach to the NgModule automatically 2`] = `
 "import { TestPipe } from './test.pipe';
 
 describe('TestPipe', () => {
@@ -64,7 +38,7 @@ describe('TestPipe', () => {
 "
 `;
 
-exports[`pipe generator should generate a pipe with test files and attach to the NgModule automatically 3`] = `
+exports[`pipe generator --no-standalone should generate a pipe with test files and attach to the NgModule automatically 3`] = `
 "import { NgModule } from '@angular/core';
 import { TestPipe } from './test.pipe';
 @NgModule({
@@ -76,7 +50,7 @@ export class TestModule {}
 "
 `;
 
-exports[`pipe generator should import the pipe correctly when flat=false 1`] = `
+exports[`pipe generator --no-standalone should import the pipe correctly when flat=false 1`] = `
 "import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
@@ -90,7 +64,7 @@ export class TestPipe implements PipeTransform {
 "
 `;
 
-exports[`pipe generator should import the pipe correctly when flat=false 2`] = `
+exports[`pipe generator --no-standalone should import the pipe correctly when flat=false 2`] = `
 "import { TestPipe } from './test.pipe';
 
 describe('TestPipe', () => {
@@ -102,7 +76,7 @@ describe('TestPipe', () => {
 "
 `;
 
-exports[`pipe generator should import the pipe correctly when flat=false 3`] = `
+exports[`pipe generator --no-standalone should import the pipe correctly when flat=false 3`] = `
 "import { NgModule } from '@angular/core';
 import { TestPipe } from './test/test.pipe';
 @NgModule({
@@ -114,7 +88,7 @@ export class TestModule {}
 "
 `;
 
-exports[`pipe generator should import the pipe correctly when flat=false and path is nested deeper 1`] = `
+exports[`pipe generator --no-standalone should import the pipe correctly when flat=false and path is nested deeper 1`] = `
 "import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
@@ -128,7 +102,7 @@ export class TestPipe implements PipeTransform {
 "
 `;
 
-exports[`pipe generator should import the pipe correctly when flat=false and path is nested deeper 2`] = `
+exports[`pipe generator --no-standalone should import the pipe correctly when flat=false and path is nested deeper 2`] = `
 "import { TestPipe } from './test.pipe';
 
 describe('TestPipe', () => {
@@ -140,7 +114,7 @@ describe('TestPipe', () => {
 "
 `;
 
-exports[`pipe generator should import the pipe correctly when flat=false and path is nested deeper 3`] = `
+exports[`pipe generator --no-standalone should import the pipe correctly when flat=false and path is nested deeper 3`] = `
 "import { NgModule } from '@angular/core';
 import { TestPipe } from './my-pipes/test/test.pipe';
 @NgModule({
@@ -152,70 +126,7 @@ export class TestModule {}
 "
 `;
 
-exports[`pipe generator should not generate test file when skipTests=true 1`] = `
-"import { Pipe, PipeTransform } from '@angular/core';
-
-@Pipe({
-  name: 'test',
-})
-export class TestPipe implements PipeTransform {
-  transform(value: unknown, ...args: unknown[]): unknown {
-    return null;
-  }
-}
-"
-`;
-
-exports[`pipe generator should not generate test file when skipTests=true 2`] = `
-"import { NgModule } from '@angular/core';
-import { TestPipe } from './my-pipes/test/test.pipe';
-@NgModule({
-  imports: [],
-  declarations: [TestPipe],
-  exports: [],
-})
-export class TestModule {}
-"
-`;
-
-exports[`pipe generator should not import the pipe when skipImport=true 1`] = `
-"import { Pipe, PipeTransform } from '@angular/core';
-
-@Pipe({
-  name: 'test',
-})
-export class TestPipe implements PipeTransform {
-  transform(value: unknown, ...args: unknown[]): unknown {
-    return null;
-  }
-}
-"
-`;
-
-exports[`pipe generator should not import the pipe when skipImport=true 2`] = `
-"import { TestPipe } from './test.pipe';
-
-describe('TestPipe', () => {
-  it('create an instance', () => {
-    const pipe = new TestPipe();
-    expect(pipe).toBeTruthy();
-  });
-});
-"
-`;
-
-exports[`pipe generator should not import the pipe when skipImport=true 3`] = `
-"import { NgModule } from '@angular/core';
-@NgModule({
-  imports: [],
-  declarations: [],
-  exports: [],
-})
-export class TestModule {}
-"
-`;
-
-exports[`pipe generator should not import the pipe when standalone=true 1`] = `
+exports[`pipe generator should generate correctly 1`] = `
 "import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
@@ -230,7 +141,7 @@ export class TestPipe implements PipeTransform {
 "
 `;
 
-exports[`pipe generator should not import the pipe when standalone=true 2`] = `
+exports[`pipe generator should generate correctly 2`] = `
 "import { TestPipe } from './test.pipe';
 
 describe('TestPipe', () => {
@@ -239,16 +150,5 @@ describe('TestPipe', () => {
     expect(pipe).toBeTruthy();
   });
 });
-"
-`;
-
-exports[`pipe generator should not import the pipe when standalone=true 3`] = `
-"import { NgModule } from '@angular/core';
-@NgModule({
-  imports: [],
-  declarations: [],
-  exports: [],
-})
-export class TestModule {}
 "
 `;

--- a/packages/angular/src/generators/pipe/lib/normalize-options.ts
+++ b/packages/angular/src/generators/pipe/lib/normalize-options.ts
@@ -36,5 +36,6 @@ export async function normalizeOptions(
     fileName,
     filePath,
     symbolName,
+    standalone: options.standalone ?? true,
   };
 }

--- a/packages/angular/src/generators/pipe/pipe.spec.ts
+++ b/packages/angular/src/generators/pipe/pipe.spec.ts
@@ -14,22 +14,9 @@ describe('pipe generator', () => {
       sourceRoot: 'test/src',
       projectType: 'application',
     });
-
-    tree.write(
-      'test/src/app/test.module.ts',
-      `import {NgModule} from "@angular/core";
-    @NgModule({
-      imports: [],
-      declarations: [],
-      exports: []
-    })
-    export class TestModule {}`
-    );
   });
 
-  it('should generate a pipe with test files and attach to the NgModule automatically', async () => {
-    // ARRANGE
-
+  it('should generate correctly', async () => {
     // ACT
     await generatePipeWithDefaultOptions(tree);
 
@@ -38,101 +25,22 @@ describe('pipe generator', () => {
     expect(
       tree.read('test/src/app/test.pipe.spec.ts', 'utf-8')
     ).toMatchSnapshot();
-    expect(tree.read('test/src/app/test.module.ts', 'utf-8')).toMatchSnapshot();
   });
 
-  it('should import the pipe correctly when flat=false', async () => {
+  it('should not import the pipe into an existing module', async () => {
     // ARRANGE
-
-    // ACT
-    await generatePipeWithDefaultOptions(tree, { flat: false });
-
-    // ASSERT
-    expect(
-      tree.read('test/src/app/test/test.pipe.ts', 'utf-8')
-    ).toMatchSnapshot();
-    expect(
-      tree.read('test/src/app/test/test.pipe.spec.ts', 'utf-8')
-    ).toMatchSnapshot();
-    expect(tree.read('test/src/app/test.module.ts', 'utf-8')).toMatchSnapshot();
-  });
-
-  it('should not import the pipe when standalone=true', async () => {
-    // ARRANGE
+    addModule(tree);
 
     // ACT
     await generatePipeWithDefaultOptions(tree, { standalone: true });
 
     // ASSERT
-    expect(tree.read('test/src/app/test.pipe.ts', 'utf-8')).toMatchSnapshot();
-    expect(
-      tree.read('test/src/app/test.pipe.spec.ts', 'utf-8')
-    ).toMatchSnapshot();
-    expect(tree.read('test/src/app/test.module.ts', 'utf-8')).toMatchSnapshot();
-  });
-
-  it('should import the pipe correctly when flat=false and path is nested deeper', async () => {
-    // ARRANGE
-
-    // ACT
-    await generatePipeWithDefaultOptions(tree, {
-      flat: false,
-      path: 'test/src/app/my-pipes',
-    });
-
-    // ASSERT
-    expect(
-      tree.read('test/src/app/my-pipes/test/test.pipe.ts', 'utf-8')
-    ).toMatchSnapshot();
-    expect(
-      tree.read('test/src/app/my-pipes/test/test.pipe.spec.ts', 'utf-8')
-    ).toMatchSnapshot();
-    expect(tree.read('test/src/app/test.module.ts', 'utf-8')).toMatchSnapshot();
-  });
-
-  it('should export the pipe correctly when flat=false and path is nested deeper', async () => {
-    // ARRANGE
-
-    // ACT
-    await generatePipeWithDefaultOptions(tree, {
-      flat: false,
-      path: 'test/src/app/my-pipes',
-      export: true,
-    });
-
-    // ASSERT
-    expect(
-      tree.read('test/src/app/my-pipes/test/test.pipe.ts', 'utf-8')
-    ).toMatchSnapshot();
-    expect(
-      tree.read('test/src/app/my-pipes/test/test.pipe.spec.ts', 'utf-8')
-    ).toMatchSnapshot();
-    expect(tree.read('test/src/app/test.module.ts', 'utf-8')).toMatchSnapshot();
-  });
-
-  it('should not import the pipe when skipImport=true', async () => {
-    // ARRANGE
-
-    // ACT
-    await generatePipeWithDefaultOptions(tree, {
-      flat: false,
-      path: 'test/src/app/my-pipes',
-      skipImport: true,
-    });
-
-    // ASSERT
-    expect(
-      tree.read('test/src/app/my-pipes/test/test.pipe.ts', 'utf-8')
-    ).toMatchSnapshot();
-    expect(
-      tree.read('test/src/app/my-pipes/test/test.pipe.spec.ts', 'utf-8')
-    ).toMatchSnapshot();
-    expect(tree.read('test/src/app/test.module.ts', 'utf-8')).toMatchSnapshot();
+    expect(tree.read('test/src/app/test.module.ts', 'utf-8')).not.toContain(
+      'TestPipe'
+    );
   });
 
   it('should not generate test file when skipTests=true', async () => {
-    // ARRANGE
-
     // ACT
     await generatePipeWithDefaultOptions(tree, {
       flat: false,
@@ -142,14 +50,122 @@ describe('pipe generator', () => {
 
     // ASSERT
     expect(
-      tree.read('test/src/app/my-pipes/test/test.pipe.ts', 'utf-8')
-    ).toMatchSnapshot();
-    expect(
       tree.exists('test/src/app/my-pipes/test/test.pipe.spec.ts')
     ).toBeFalsy();
-    expect(tree.read('test/src/app/test.module.ts', 'utf-8')).toMatchSnapshot();
+  });
+
+  describe('--no-standalone', () => {
+    beforeEach(() => {
+      addModule(tree);
+    });
+
+    it('should generate a pipe with test files and attach to the NgModule automatically', async () => {
+      // ARRANGE
+
+      // ACT
+      await generatePipeWithDefaultOptions(tree, { standalone: false });
+
+      // ASSERT
+      expect(tree.read('test/src/app/test.pipe.ts', 'utf-8')).toMatchSnapshot();
+      expect(
+        tree.read('test/src/app/test.pipe.spec.ts', 'utf-8')
+      ).toMatchSnapshot();
+      expect(
+        tree.read('test/src/app/test.module.ts', 'utf-8')
+      ).toMatchSnapshot();
+    });
+
+    it('should import the pipe correctly when flat=false', async () => {
+      // ARRANGE
+
+      // ACT
+      await generatePipeWithDefaultOptions(tree, {
+        flat: false,
+        standalone: false,
+      });
+
+      // ASSERT
+      expect(
+        tree.read('test/src/app/test/test.pipe.ts', 'utf-8')
+      ).toMatchSnapshot();
+      expect(
+        tree.read('test/src/app/test/test.pipe.spec.ts', 'utf-8')
+      ).toMatchSnapshot();
+      expect(
+        tree.read('test/src/app/test.module.ts', 'utf-8')
+      ).toMatchSnapshot();
+    });
+
+    it('should import the pipe correctly when flat=false and path is nested deeper', async () => {
+      // ARRANGE
+
+      // ACT
+      await generatePipeWithDefaultOptions(tree, {
+        flat: false,
+        path: 'test/src/app/my-pipes',
+        standalone: false,
+      });
+
+      // ASSERT
+      expect(
+        tree.read('test/src/app/my-pipes/test/test.pipe.ts', 'utf-8')
+      ).toMatchSnapshot();
+      expect(
+        tree.read('test/src/app/my-pipes/test/test.pipe.spec.ts', 'utf-8')
+      ).toMatchSnapshot();
+      expect(
+        tree.read('test/src/app/test.module.ts', 'utf-8')
+      ).toMatchSnapshot();
+    });
+
+    it('should export the pipe correctly when flat=false and path is nested deeper', async () => {
+      // ARRANGE
+
+      // ACT
+      await generatePipeWithDefaultOptions(tree, {
+        flat: false,
+        path: 'test/src/app/my-pipes',
+        export: true,
+        standalone: false,
+      });
+
+      // ASSERT
+      expect(
+        tree.read('test/src/app/test.module.ts', 'utf-8')
+      ).toMatchSnapshot();
+    });
+
+    it('should not import the pipe when skipImport=true', async () => {
+      // ARRANGE
+
+      // ACT
+      await generatePipeWithDefaultOptions(tree, {
+        flat: false,
+        path: 'test/src/app/my-pipes',
+        skipImport: true,
+        standalone: false,
+      });
+
+      // ASSERT
+      expect(tree.read('test/src/app/test.module.ts', 'utf-8')).not.toContain(
+        'TestPipe'
+      );
+    });
   });
 });
+
+function addModule(tree: Tree) {
+  tree.write(
+    'test/src/app/test.module.ts',
+    `import {NgModule} from "@angular/core";
+    @NgModule({
+      imports: [],
+      declarations: [],
+      exports: []
+    })
+    export class TestModule {}`
+  );
+}
 
 async function generatePipeWithDefaultOptions(
   tree: Tree,

--- a/packages/angular/src/generators/pipe/schema.json
+++ b/packages/angular/src/generators/pipe/schema.json
@@ -55,7 +55,7 @@
     "standalone": {
       "description": "Whether the generated pipe is standalone.",
       "type": "boolean",
-      "default": false
+      "default": true
     },
     "module": {
       "type": "string",

--- a/packages/angular/src/generators/remote/remote.spec.ts
+++ b/packages/angular/src/generators/remote/remote.spec.ts
@@ -22,6 +22,7 @@ describe('MF Remote App Generator', () => {
       name: 'test',
       port: 4201,
       typescriptConfiguration: false,
+      standalone: false,
     });
 
     // ASSERT
@@ -41,6 +42,7 @@ describe('MF Remote App Generator', () => {
       name: 'test',
       port: 4201,
       typescriptConfiguration: true,
+      standalone: false,
     });
 
     // ASSERT
@@ -54,6 +56,7 @@ describe('MF Remote App Generator', () => {
     await generateTestHostApplication(tree, {
       name: 'host',
       typescriptConfiguration: false,
+      standalone: false,
     });
 
     // ACT
@@ -61,6 +64,7 @@ describe('MF Remote App Generator', () => {
       name: 'test',
       host: 'host',
       typescriptConfiguration: false,
+      standalone: false,
     });
 
     // ASSERT
@@ -75,6 +79,7 @@ describe('MF Remote App Generator', () => {
     await generateTestHostApplication(tree, {
       name: 'host',
       typescriptConfiguration: true,
+      standalone: false,
     });
 
     // ACT
@@ -82,6 +87,7 @@ describe('MF Remote App Generator', () => {
       name: 'test',
       host: 'host',
       typescriptConfiguration: true,
+      standalone: false,
     });
 
     // ASSERT
@@ -98,6 +104,7 @@ describe('MF Remote App Generator', () => {
       await generateTestRemoteApplication(tree, {
         name: 'test',
         host: 'host',
+        standalone: false,
       });
     } catch (error) {
       // ASSERT
@@ -113,11 +120,13 @@ describe('MF Remote App Generator', () => {
     await generateTestRemoteApplication(tree, {
       name: 'existing',
       port: 4201,
+      standalone: false,
     });
 
     // ACT
     await generateTestRemoteApplication(tree, {
       name: 'test',
+      standalone: false,
     });
 
     // ASSERT
@@ -132,6 +141,7 @@ describe('MF Remote App Generator', () => {
     // ACT
     await generateTestRemoteApplication(tree, {
       name: 'test',
+      standalone: false,
     });
 
     // ASSERT
@@ -147,6 +157,7 @@ describe('MF Remote App Generator', () => {
     await generateTestRemoteApplication(tree, {
       name: 'test',
       port: 4201,
+      standalone: false,
     });
 
     // ASSERT
@@ -161,7 +172,6 @@ describe('MF Remote App Generator', () => {
     // ACT
     await generateTestRemoteApplication(tree, {
       name: 'test',
-      standalone: true,
       typescriptConfiguration: false,
     });
 
@@ -195,7 +205,6 @@ describe('MF Remote App Generator', () => {
     // ACT
     await generateTestRemoteApplication(tree, {
       name: 'test',
-      standalone: true,
       typescriptConfiguration: true,
     });
 
@@ -226,6 +235,7 @@ describe('MF Remote App Generator', () => {
     await generateTestRemoteApplication(tree, {
       name: 'remote1',
       e2eTestRunner: E2eTestRunner.None,
+      standalone: false,
     });
 
     // ASSERT
@@ -241,6 +251,7 @@ describe('MF Remote App Generator', () => {
     await generateTestRemoteApplication(tree, {
       name: 'test',
       inlineTemplate: true,
+      standalone: false,
     });
 
     // ASSERT
@@ -264,7 +275,6 @@ describe('MF Remote App Generator', () => {
     // ACT
     await generateTestRemoteApplication(tree, {
       name: 'test',
-      standalone: true,
     });
 
     // ASSERT
@@ -286,6 +296,7 @@ describe('MF Remote App Generator', () => {
         name: 'test',
         ssr: true,
         typescriptConfiguration: false,
+        standalone: false,
       });
 
       // ASSERT
@@ -333,6 +344,7 @@ describe('MF Remote App Generator', () => {
         name: 'test',
         ssr: true,
         typescriptConfiguration: true,
+        standalone: false,
       });
 
       // ASSERT
@@ -381,6 +393,7 @@ describe('MF Remote App Generator', () => {
         port: 4201,
         projectNameAndRootFormat: 'derived',
         typescriptConfiguration: false,
+        standalone: false,
       });
 
       expect(tree.exists('apps/test/webpack.config.js')).toBe(true);
@@ -396,6 +409,7 @@ describe('MF Remote App Generator', () => {
         directory: 'shared',
         projectNameAndRootFormat: 'derived',
         typescriptConfiguration: false,
+        standalone: false,
       });
 
       expect(tree.exists('apps/shared/test/webpack.config.js')).toBe(true);

--- a/packages/angular/src/generators/remote/remote.ts
+++ b/packages/angular/src/generators/remote/remote.ts
@@ -22,6 +22,7 @@ export async function remote(tree: Tree, options: Schema) {
 
 export async function remoteInternal(tree: Tree, schema: Schema) {
   const { typescriptConfiguration = true, ...options }: Schema = schema;
+  options.standalone = options.standalone ?? true;
 
   const projects = getProjects(tree);
   if (options.host && !projects.has(options.host)) {
@@ -44,7 +45,7 @@ export async function remoteInternal(tree: Tree, schema: Schema) {
 
   const appInstallTask = await applicationGenerator(tree, {
     ...options,
-    standalone: options.standalone ?? false,
+    standalone: options.standalone,
     routing: true,
     port,
     skipFormat: true,

--- a/packages/angular/src/generators/remote/schema.json
+++ b/packages/angular/src/generators/remote/schema.json
@@ -160,7 +160,7 @@
     "standalone": {
       "description": "Whether to generate a remote application with standalone components.",
       "type": "boolean",
-      "default": false
+      "default": true
     },
     "ssr": {
       "description": "Whether to configure SSR for the remote application to be consumed by a host application using SSR.",

--- a/packages/angular/src/generators/scam-directive/lib/convert-directive-to-scam.spec.ts
+++ b/packages/angular/src/generators/scam-directive/lib/convert-directive-to-scam.spec.ts
@@ -19,6 +19,7 @@ describe('convertDirectiveToScam', () => {
       skipImport: true,
       export: false,
       flat: false,
+      standalone: false,
     });
 
     // ACT
@@ -75,6 +76,7 @@ describe('convertDirectiveToScam', () => {
       skipImport: true,
       export: false,
       flat: false,
+      standalone: false,
     });
 
     // ACT
@@ -125,6 +127,7 @@ describe('convertDirectiveToScam', () => {
       skipImport: true,
       export: false,
       flat: true,
+      standalone: false,
     });
 
     // ACT
@@ -181,6 +184,7 @@ describe('convertDirectiveToScam', () => {
       skipImport: true,
       export: false,
       flat: true,
+      standalone: false,
     });
 
     // ACT
@@ -232,6 +236,7 @@ describe('convertDirectiveToScam', () => {
       export: false,
       flat: false,
       path: 'apps/app1/src/app/random',
+      standalone: false,
     });
 
     // ACT
@@ -289,6 +294,7 @@ describe('convertDirectiveToScam', () => {
       export: false,
       flat: true,
       path: 'apps/app1/src/app/random',
+      standalone: false,
     });
 
     // ACT

--- a/packages/angular/src/generators/scam-pipe/lib/convert-pipe-to-scam.spec.ts
+++ b/packages/angular/src/generators/scam-pipe/lib/convert-pipe-to-scam.spec.ts
@@ -19,6 +19,7 @@ describe('convertPipeToScam', () => {
       skipImport: true,
       export: false,
       flat: false,
+      standalone: false,
     });
 
     // ACT
@@ -127,6 +128,7 @@ describe('convertPipeToScam', () => {
       skipImport: true,
       export: false,
       flat: true,
+      standalone: false,
     });
 
     // ACT
@@ -182,6 +184,7 @@ describe('convertPipeToScam', () => {
       skipImport: true,
       export: false,
       flat: true,
+      standalone: false,
     });
 
     // ACT
@@ -233,6 +236,7 @@ describe('convertPipeToScam', () => {
       export: false,
       flat: false,
       path: 'apps/app1/src/app/random',
+      standalone: false,
     });
 
     // ACT
@@ -292,6 +296,7 @@ describe('convertPipeToScam', () => {
       export: false,
       flat: true,
       path: 'apps/app1/src/app/random',
+      standalone: false,
     });
 
     // ACT

--- a/packages/angular/src/generators/scam/lib/convert-component-to-scam.spec.ts
+++ b/packages/angular/src/generators/scam/lib/convert-component-to-scam.spec.ts
@@ -18,6 +18,7 @@ describe('convertComponentToScam', () => {
       project: 'app1',
       skipImport: true,
       export: false,
+      standalone: false,
     });
 
     // ACT
@@ -72,6 +73,7 @@ describe('convertComponentToScam', () => {
       project: 'app1',
       skipImport: true,
       export: false,
+      standalone: false,
     });
 
     // ACT
@@ -121,6 +123,7 @@ describe('convertComponentToScam', () => {
       skipImport: true,
       export: false,
       flat: true,
+      standalone: false,
     });
 
     // ACT
@@ -177,6 +180,7 @@ describe('convertComponentToScam', () => {
       skipImport: true,
       export: false,
       flat: true,
+      standalone: false,
     });
 
     // ACT
@@ -228,6 +232,7 @@ describe('convertComponentToScam', () => {
       export: false,
       flat: true,
       type: 'random',
+      standalone: false,
     });
 
     // ACT
@@ -286,6 +291,7 @@ describe('convertComponentToScam', () => {
       export: false,
       flat: true,
       type: 'random',
+      standalone: false,
     });
 
     // ACT
@@ -338,6 +344,7 @@ describe('convertComponentToScam', () => {
       export: false,
       flat: false,
       path: 'apps/app1/src/app/random',
+      standalone: false,
     });
 
     // ACT
@@ -395,6 +402,7 @@ describe('convertComponentToScam', () => {
       export: false,
       flat: true,
       path: 'apps/app1/src/app/random',
+      standalone: false,
     });
 
     // ACT

--- a/packages/angular/src/generators/setup-mf/lib/normalize-options.ts
+++ b/packages/angular/src/generators/setup-mf/lib/normalize-options.ts
@@ -11,5 +11,6 @@ export function normalizeOptions(
     typescriptConfiguration: options.typescriptConfiguration ?? true,
     federationType: options.federationType ?? 'static',
     prefix: options.prefix ?? getProjectPrefix(tree, options.appName),
+    standalone: options.standalone ?? true,
   };
 }

--- a/packages/angular/src/generators/setup-mf/schema.json
+++ b/packages/angular/src/generators/setup-mf/schema.json
@@ -72,7 +72,7 @@
     "standalone": {
       "type": "boolean",
       "description": "Whether the application is a standalone application.",
-      "default": false
+      "default": true
     },
     "typescriptConfiguration": {
       "type": "boolean",

--- a/packages/angular/src/generators/setup-mf/setup-mf.spec.ts
+++ b/packages/angular/src/generators/setup-mf/setup-mf.spec.ts
@@ -11,10 +11,12 @@ describe('Init MF', () => {
     await generateTestApplication(tree, {
       name: 'app1',
       routing: true,
+      standalone: false,
     });
     await generateTestApplication(tree, {
       name: 'remote1',
       routing: true,
+      standalone: false,
     });
   });
 
@@ -29,6 +31,7 @@ describe('Init MF', () => {
         appName: app,
         mfType: type,
         typescriptConfiguration: false,
+        standalone: false,
       });
 
       // ASSERT
@@ -58,6 +61,7 @@ describe('Init MF', () => {
         appName: app,
         mfType: type,
         typescriptConfiguration: true,
+        standalone: false,
       });
 
       // ASSERT
@@ -89,6 +93,7 @@ describe('Init MF', () => {
       await setupMf(tree, {
         appName: app,
         mfType: type,
+        standalone: false,
       });
 
       // ASSERT
@@ -113,6 +118,7 @@ describe('Init MF', () => {
       await setupMf(tree, {
         appName: app,
         mfType: type,
+        standalone: false,
       });
 
       // ASSERT
@@ -136,6 +142,7 @@ describe('Init MF', () => {
         appName: app,
         mfType: type,
         typescriptConfiguration: false,
+        standalone: false,
       });
 
       // ASSERT
@@ -164,6 +171,7 @@ describe('Init MF', () => {
         appName: app,
         mfType: type,
         typescriptConfiguration: true,
+        standalone: false,
       });
 
       // ASSERT
@@ -187,6 +195,7 @@ describe('Init MF', () => {
       appName: 'app1',
       mfType: 'host',
       federationType: 'dynamic',
+      standalone: false,
     });
 
     // ASSERT
@@ -201,6 +210,7 @@ describe('Init MF', () => {
       appName: 'remote1',
       mfType: 'remote',
       prefix: 'my-org',
+      standalone: false,
     });
 
     // ASSERT
@@ -214,7 +224,11 @@ describe('Init MF', () => {
 
   it('should generate the remote entry component correctly when prefix is not provided', async () => {
     // ACT
-    await setupMf(tree, { appName: 'remote1', mfType: 'remote' });
+    await setupMf(tree, {
+      appName: 'remote1',
+      mfType: 'remote',
+      standalone: false,
+    });
 
     // ASSERT
     expect(
@@ -229,6 +243,7 @@ describe('Init MF', () => {
       mfType: 'host',
       remotes: ['remote1'],
       typescriptConfiguration: false,
+      standalone: false,
     });
 
     // ASSERT
@@ -247,6 +262,7 @@ describe('Init MF', () => {
       mfType: 'host',
       remotes: ['remote1'],
       typescriptConfiguration: true,
+      standalone: false,
     });
 
     // ASSERT
@@ -264,6 +280,7 @@ describe('Init MF', () => {
       appName: 'app1',
       mfType: 'host',
       typescriptConfiguration: false,
+      standalone: false,
     });
 
     // ACT
@@ -272,6 +289,7 @@ describe('Init MF', () => {
       mfType: 'remote',
       host: 'app1',
       typescriptConfiguration: false,
+      standalone: false,
     });
 
     // ASSERT
@@ -285,6 +303,7 @@ describe('Init MF', () => {
       appName: 'app1',
       mfType: 'host',
       typescriptConfiguration: true,
+      standalone: false,
     });
 
     // ACT
@@ -293,6 +312,7 @@ describe('Init MF', () => {
       mfType: 'remote',
       host: 'app1',
       typescriptConfiguration: true,
+      standalone: false,
     });
 
     // ASSERT
@@ -304,12 +324,14 @@ describe('Init MF', () => {
     // ARRANGE
     await generateTestApplication(tree, {
       name: 'remote2',
+      standalone: false,
     });
 
     await setupMf(tree, {
       appName: 'app1',
       mfType: 'host',
       typescriptConfiguration: false,
+      standalone: false,
     });
 
     await setupMf(tree, {
@@ -318,6 +340,7 @@ describe('Init MF', () => {
       host: 'app1',
       port: 4201,
       typescriptConfiguration: false,
+      standalone: false,
     });
 
     // ACT
@@ -327,6 +350,7 @@ describe('Init MF', () => {
       host: 'app1',
       port: 4202,
       typescriptConfiguration: false,
+      standalone: false,
     });
 
     // ASSERT
@@ -338,12 +362,14 @@ describe('Init MF', () => {
     // ARRANGE
     await generateTestApplication(tree, {
       name: 'remote2',
+      standalone: false,
     });
 
     await setupMf(tree, {
       appName: 'app1',
       mfType: 'host',
       typescriptConfiguration: true,
+      standalone: false,
     });
 
     await setupMf(tree, {
@@ -352,6 +378,7 @@ describe('Init MF', () => {
       host: 'app1',
       port: 4201,
       typescriptConfiguration: true,
+      standalone: false,
     });
 
     // ACT
@@ -361,6 +388,7 @@ describe('Init MF', () => {
       host: 'app1',
       port: 4202,
       typescriptConfiguration: true,
+      standalone: false,
     });
 
     // ASSERT
@@ -373,12 +401,14 @@ describe('Init MF', () => {
     await generateTestApplication(tree, {
       name: 'remote2',
       routing: true,
+      standalone: false,
     });
 
     await setupMf(tree, {
       appName: 'app1',
       mfType: 'host',
       routing: true,
+      standalone: false,
     });
 
     await setupMf(tree, {
@@ -387,6 +417,7 @@ describe('Init MF', () => {
       host: 'app1',
       port: 4201,
       routing: true,
+      standalone: false,
     });
 
     // ACT
@@ -396,6 +427,7 @@ describe('Init MF', () => {
       host: 'app1',
       port: 4202,
       routing: true,
+      standalone: false,
     });
 
     // ASSERT
@@ -408,6 +440,7 @@ describe('Init MF', () => {
     await generateTestApplication(tree, {
       name: 'test-app',
       routing: true,
+      standalone: false,
     });
 
     // ACT
@@ -416,6 +449,7 @@ describe('Init MF', () => {
       mfType: 'host',
       routing: true,
       e2eProjectName: 'test-app-e2e',
+      standalone: false,
     });
 
     // ASSERT
@@ -437,6 +471,7 @@ describe('Init MF', () => {
         routing: true,
         federationType: 'dynamic',
         typescriptConfiguration: false,
+        standalone: false,
       });
 
       // ASSERT
@@ -457,6 +492,7 @@ describe('Init MF', () => {
         routing: true,
         federationType: 'dynamic',
         typescriptConfiguration: true,
+        standalone: false,
       });
 
       // ASSERT
@@ -478,6 +514,7 @@ describe('Init MF', () => {
       routing: true,
       federationType: 'dynamic',
       typescriptConfiguration: false,
+      standalone: false,
     });
 
     // ACT
@@ -488,6 +525,7 @@ describe('Init MF', () => {
       host: 'app1',
       routing: true,
       typescriptConfiguration: false,
+      standalone: false,
     });
 
     // ASSERT
@@ -510,6 +548,7 @@ describe('Init MF', () => {
       routing: true,
       federationType: 'dynamic',
       typescriptConfiguration: true,
+      standalone: false,
     });
 
     // ACT
@@ -520,6 +559,7 @@ describe('Init MF', () => {
       host: 'app1',
       routing: true,
       typescriptConfiguration: true,
+      standalone: false,
     });
 
     // ASSERT

--- a/packages/angular/src/generators/setup-ssr/setup-ssr.spec.ts
+++ b/packages/angular/src/generators/setup-ssr/setup-ssr.spec.ts
@@ -19,6 +19,7 @@ describe('setupSSR', () => {
 
     await generateTestApplication(tree, {
       name: 'app1',
+      standalone: false,
     });
 
     // ACT
@@ -145,7 +146,6 @@ describe('setupSSR', () => {
 
     await generateTestApplication(tree, {
       name: 'app1',
-      standalone: true,
     });
 
     // ACT
@@ -219,6 +219,7 @@ describe('setupSSR', () => {
 
     await generateTestApplication(tree, {
       name: 'app1',
+      standalone: false,
     });
 
     // ACT
@@ -257,7 +258,6 @@ describe('setupSSR', () => {
 
     await generateTestApplication(tree, {
       name: 'app1',
-      standalone: true,
     });
 
     // ACT
@@ -305,6 +305,7 @@ describe('setupSSR', () => {
 
       await generateTestApplication(tree, {
         name: 'app1',
+        standalone: false,
       });
 
       updateJson(tree, 'package.json', (json) => ({
@@ -340,6 +341,7 @@ describe('setupSSR', () => {
 
       await generateTestApplication(tree, {
         name: 'app1',
+        standalone: false,
       });
 
       // ACT
@@ -374,6 +376,7 @@ describe('setupSSR', () => {
       const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
       await generateTestApplication(tree, {
         name: 'app1',
+        standalone: false,
       });
       updateJson(tree, 'package.json', (json) => ({
         ...json,

--- a/packages/angular/src/generators/utils/testing.ts
+++ b/packages/angular/src/generators/utils/testing.ts
@@ -72,11 +72,13 @@ export async function createStorybookTestWorkspaceForLib(
     skipFormat: false,
     unitTestRunner: UnitTestRunner.Jest,
     projectNameAndRootFormat: 'as-provided',
+    standalone: false,
   });
 
   await componentGenerator(tree, {
     name: 'test-button',
     project: libName,
+    standalone: false,
   });
 
   tree.write(
@@ -121,6 +123,7 @@ export class TestButtonComponent {
     project: libName,
     path: `${libName}/src/lib/barrel`,
     module: 'barrel',
+    standalone: false,
   });
 
   tree.write(
@@ -152,6 +155,7 @@ export class BarrelModule {}`
     project: libName,
     path: `${libName}/src/lib/variable-declare`,
     module: 'variable-declare',
+    standalone: false,
   });
 
   await componentGenerator(tree, {
@@ -159,6 +163,7 @@ export class BarrelModule {}`
     project: libName,
     path: `${libName}/src/lib/variable-declare`,
     module: 'variable-declare',
+    standalone: false,
   });
 
   tree.write(
@@ -192,6 +197,7 @@ export class VariableDeclareModule {}`
     project: libName,
     path: `${libName}/src/lib/variable-spread-declare`,
     module: 'variable-spread-declare',
+    standalone: false,
   });
 
   await componentGenerator(tree, {
@@ -199,6 +205,7 @@ export class VariableDeclareModule {}`
     project: libName,
     path: `${libName}/src/lib/variable-spread-declare`,
     module: 'variable-spread-declare',
+    standalone: false,
   });
 
   await componentGenerator(tree, {
@@ -206,6 +213,7 @@ export class VariableDeclareModule {}`
     project: libName,
     path: `${libName}/src/lib/variable-spread-declare`,
     module: 'variable-spread-declare',
+    standalone: false,
   });
 
   tree.write(
@@ -239,6 +247,7 @@ export class VariableSpreadDeclareModule {}`
     project: libName,
     path: `${libName}/src/lib/static-member-declarations`,
     module: 'static-member-declarations',
+    standalone: false,
   });
 
   await componentGenerator(tree, {
@@ -246,6 +255,7 @@ export class VariableSpreadDeclareModule {}`
     project: libName,
     path: `${libName}/src/lib/static-member-declarations`,
     module: 'static-member-declarations',
+    standalone: false,
   });
 
   tree.write(
@@ -277,11 +287,13 @@ export class StaticMemberDeclarationsModule {
     project: libName,
     module: 'nested',
     path: `${libName}/src/lib/nested`,
+    standalone: false,
   });
 
   await componentGenerator(tree, {
     name: 'test-other',
     project: libName,
+    standalone: false,
   });
 
   return tree;

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -143,10 +143,12 @@ export const commandsObject: yargs.Argv<Arguments> = yargs
           .option('standaloneApi', {
             describe: chalk.dim`Use Standalone Components if generating an Angular app`,
             type: 'boolean',
+            default: true,
           })
           .option('routing', {
             describe: chalk.dim`Add a routing setup for an Angular app`,
             type: 'boolean',
+            default: true,
           })
           .option('bundler', {
             describe: chalk.dim`Bundler to be used to build the app`,
@@ -680,9 +682,9 @@ async function determineAngularOptions(
   let preset: Preset;
   let style: string;
   let appName: string;
-  let standaloneApi: boolean;
   let e2eTestRunner: undefined | 'none' | 'cypress' | 'playwright' = undefined;
 
+  const standaloneApi = parsedArgs.standaloneApi;
   const routing = parsedArgs.routing;
 
   if (parsedArgs.preset && parsedArgs.preset !== Preset.Angular) {
@@ -734,29 +736,6 @@ async function determineAngularOptions(
   }
 
   e2eTestRunner = await determineE2eTestRunner(parsedArgs);
-
-  if (parsedArgs.standaloneApi !== undefined) {
-    standaloneApi = parsedArgs.standaloneApi;
-  } else {
-    const reply = await enquirer.prompt<{ standaloneApi: 'Yes' | 'No' }>([
-      {
-        name: 'standaloneApi',
-        message:
-          'Would you like to use Standalone Components in your application?',
-        type: 'autocomplete',
-        choices: [
-          {
-            name: 'No',
-          },
-          {
-            name: 'Yes',
-          },
-        ],
-        initial: 'No' as any,
-      },
-    ]);
-    standaloneApi = reply.standaloneApi === 'Yes';
-  }
 
   return { preset, style, appName, standaloneApi, routing, e2eTestRunner };
 }


### PR DESCRIPTION
- Updates CNW to use the Angular Standalone API by default for the default application.
- Updates generators to use the Angular Standalone API by default.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
