### PR TITLE
fix(js): should respect vitest test environment

### DIFF
--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -1359,4 +1359,32 @@ describe('lib', () => {
       expect(tree.exists('web/my-lib/src/lib/my-lib.ts')).toBeTruthy();
     });
   });
+
+  describe('--testEnvironment', () => {
+    it('should generate a vite config with testEnvironment set to node', async () => {
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        name: 'my-node-lib',
+        unitTestRunner: 'vitest',
+        testEnvironment: 'node',
+      });
+
+      const content = tree.read('my-node-lib/vite.config.ts', 'utf-8');
+
+      expect(content).toContain(`environment: 'node'`);
+    });
+
+    it('should generate a vite config with testEnvironment set to jsdom by default', async () => {
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        name: 'my-jsdom-lib',
+        unitTestRunner: 'vitest',
+        testEnvironment: undefined,
+      });
+
+      const content = tree.read('my-jsdom-lib/vite.config.ts', 'utf-8');
+
+      expect(content).toContain(`environment: 'jsdom'`);
+    });
+  });
 });

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -99,6 +99,7 @@ export async function libraryGeneratorInternal(
         project: options.name,
         includeLib: true,
         includeVitest: options.unitTestRunner === 'vitest',
+        testEnvironment: options.testEnvironment,
       },
       false
     );
@@ -136,6 +137,7 @@ export async function libraryGeneratorInternal(
         project: options.name,
         includeLib: false,
         includeVitest: true,
+        testEnvironment: options.testEnvironment,
       },
       true
     );

--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -805,7 +805,7 @@ function handleViteConfigFileExists(
     cache: {
       dir: `${offsetFromRoot}node_modules/.vitest`,
     },
-    environment: 'jsdom',
+    environment: options.testEnvironment ?? 'jsdom',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
   };
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When you generate a library configured with vitest as the unit test the `testEnvironment` is always set to `jsdom`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

We should use the testEnvironment supplied.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #19853
