### PR TITLE
fix(js): fix typescript analysis for imports in objects in arrays

### DIFF
--- a/packages/nx/src/native/plugins/js/ts_import_locators.rs
+++ b/packages/nx/src/native/plugins/js/ts_import_locators.rs
@@ -14,7 +14,9 @@ use swc_common::{BytePos, SourceMap, Spanned};
 use swc_ecma_ast::EsVersion::EsNext;
 use swc_ecma_parser::error::Error;
 use swc_ecma_parser::lexer::Lexer;
-use swc_ecma_parser::token::Keyword::{Class, Default_, Export, Function, Import};
+use swc_ecma_parser::token::Keyword::{
+    Catch, Class, Default_, Export, Finally, Function, Import, Try,
+};
 use swc_ecma_parser::token::Word::{Ident, Keyword};
 use swc_ecma_parser::token::{BinOpToken, Token, TokenAndSpan};
 use swc_ecma_parser::{Syntax, Tokens, TsConfig};
@@ -43,6 +45,7 @@ enum BlockType {
     Object,
     ObjectType,
     ArrowFunction,
+    TryCatchFinally,
 }
 
 fn is_identifier(token: &Token) -> bool {
@@ -55,6 +58,7 @@ struct State<'a> {
     pub previous_token: Option<TokenAndSpan>,
     pub import_type: ImportType,
     open_brace_count: i128,
+    open_bracket_count: i128,
     blocks_stack: Vec<BlockType>,
     next_block_type: BlockType,
 }
@@ -66,6 +70,7 @@ impl<'a> State<'a> {
             current_token: None,
             previous_token: None,
             open_brace_count: 0,
+            open_bracket_count: 0,
             blocks_stack: vec![],
             next_block_type: BlockType::Block,
             import_type: ImportType::Dynamic,
@@ -106,11 +111,19 @@ impl<'a> State<'a> {
                     // The block has closed so remove it from the block stack
                     self.blocks_stack.pop();
                 }
+                Token::LBracket => {
+                    self.open_bracket_count += 1;
+                }
+                Token::RBracket => {
+                    self.open_bracket_count -= 1;
+                }
                 _ => {}
             }
 
             // Keep track of when we are in an object declaration because colons mean different things
             let in_object_declaration = self.blocks_stack.contains(&BlockType::Object);
+            // Keep track of when we are in an array declaration because commas mean different things
+            let in_array_declaration = self.open_bracket_count > 0;
 
             let new_line = self.lexer.had_line_break_before_last();
 
@@ -141,6 +154,13 @@ impl<'a> State<'a> {
                     Keyword(keyword) if *keyword == Class => {
                         self.next_block_type = BlockType::Class;
                     }
+
+                    // If a try/catch/finally keyword appears, the next open brace will start a function block
+                    Keyword(keyword)
+                        if *keyword == Try || *keyword == Catch || *keyword == Finally =>
+                    {
+                        self.next_block_type = BlockType::TryCatchFinally;
+                    }
                     _ => {}
                 },
                 Token::AssignOp(_) => {
@@ -165,6 +185,25 @@ impl<'a> State<'a> {
                                 self.next_block_type = BlockType::ArrowFunction;
                             }
                         }
+                    }
+                }
+                // When an array opens, the next brace will be an object
+                // Matches [{ }]
+                Token::LBracket => {
+                    if let Some(t) = &self.previous_token {
+                        match t.token {
+                            Token::Colon => {
+                                self.next_block_type = BlockType::ObjectType;
+                            }
+                            _ => {
+                                self.next_block_type = BlockType::Object;
+                            }
+                        }
+                    }
+                }
+                Token::Comma => {
+                    if in_array_declaration {
+                        self.next_block_type = BlockType::Object;
                     }
                 }
                 Token::BinOp(op) => match op {
@@ -407,9 +446,15 @@ fn find_specifier_in_require(state: &mut State) -> Option<(String, ImportType)> 
             Token::LParen |
             // Matches things like require.resolve
             Token::Dot |
+            Token::Comma |
+            Token::LBrace |
+            Token::RBrace |
+            Token::LBracket |
+            Token::RBracket |
+            Token::Colon |
             Token::Word(Ident(_)) => {}
             // This could be a string literal
-            Token::Str { value, .. } => {
+            Token::Str { value, .. } if import.is_none() => {
                 import = Some(value.to_string());
             }
 
@@ -434,6 +479,8 @@ fn find_specifier_in_require(state: &mut State) -> Option<(String, ImportType)> 
                     return None;
                 }
             }
+            // If we found an import, definitely wait for the RParen so it gets added
+            _ if import.is_some() => {}
             // Anything else means this is not a require of a string literal
             _ => {
                 return None;
@@ -560,7 +607,7 @@ fn process_file(
 
     let code_is_not_ignored = |(specifier, pos): (String, BytePos)| {
         let line_with_code = cm.lookup_line(pos).expect("All code is on a line");
-        if lines_with_nx_ignore_comments.contains(&(line_with_code - 1)) {
+        if line_with_code > 0 && lines_with_nx_ignore_comments.contains(&(line_with_code - 1)) {
             None
         } else {
             Some(specifier)
@@ -618,8 +665,13 @@ fn find_imports(
 #[cfg(test)]
 mod find_imports {
     use super::*;
+    use crate::native::utils::glob::build_glob_set;
+    use crate::native::utils::path::Normalize;
+    use crate::native::walker::nx_walker;
     use assert_fs::prelude::*;
     use assert_fs::TempDir;
+    use std::env;
+    use std::path::PathBuf;
     use swc_common::comments::NoopComments;
 
     #[test]
@@ -820,7 +872,7 @@ import 'a4'; import 'a5';
         .unwrap();
 
         let result = results.get(0).unwrap();
-        let ast_results: ImportResult = find_imports_with_ast(test_file_path);
+        let ast_results: ImportResult = find_imports_with_ast(test_file_path).unwrap();
 
         assert_eq!(
             result.static_import_expressions,
@@ -977,6 +1029,20 @@ import('./dynamic-import.vue')
       }
       const a = 1;
       export class App {}
+
+
+      const a: [{ a: typeof import('static-import-in-array-type-in-object')}] = [];
+
+      const a = [{ a: import('dynamic-import-in-object-in-array')}];
+
+      const a = { a: [import('dynamic-import-in-array-in-object')]};
+
+      const routes = [
+        {},
+        {
+            lazy: () => import('dynamic-import-lazy-route')
+        }
+      ]
                 "#,
             )
             .unwrap();
@@ -990,7 +1056,7 @@ import('./dynamic-import.vue')
         .unwrap();
 
         let result = results.get(0).unwrap();
-        let ast_results: ImportResult = find_imports_with_ast(test_file_path);
+        let ast_results: ImportResult = find_imports_with_ast(test_file_path).unwrap();
 
         assert_eq!(
             result.static_import_expressions,
@@ -1048,7 +1114,7 @@ import('./dynamic-import.vue')
         .unwrap();
 
         let result = results.get(0).unwrap();
-        let ast_results: ImportResult = find_imports_with_ast(test_file_path);
+        let ast_results: ImportResult = find_imports_with_ast(test_file_path).unwrap();
 
         assert_eq!(
             result.static_import_expressions,
@@ -1087,7 +1153,7 @@ import('./dynamic-import.vue')
         .unwrap();
 
         let result = results.get(0).unwrap();
-        let ast_results: ImportResult = find_imports_with_ast(test_file_path);
+        let ast_results: ImportResult = find_imports_with_ast(test_file_path).unwrap();
 
         assert_eq!(
             result.static_import_expressions,
@@ -1135,7 +1201,7 @@ import('./dynamic-import.vue')
         .unwrap();
 
         let result = results.get(0).unwrap();
-        let ast_results: ImportResult = find_imports_with_ast(test_file_path);
+        let ast_results: ImportResult = find_imports_with_ast(test_file_path).unwrap();
 
         assert_eq!(
             result.static_import_expressions,
@@ -1220,7 +1286,7 @@ import('./dynamic-import.vue')
         .unwrap();
 
         let result = results.get(0).unwrap();
-        let ast_results: ImportResult = find_imports_with_ast(test_file_path);
+        let ast_results: ImportResult = find_imports_with_ast(test_file_path).unwrap();
 
         assert_eq!(
             result.static_import_expressions,
@@ -1272,7 +1338,7 @@ import('./dynamic-import.vue')
         .unwrap();
 
         let result = results.get(0).unwrap();
-        let ast_results: ImportResult = find_imports_with_ast(test_file_path);
+        let ast_results: ImportResult = find_imports_with_ast(test_file_path).unwrap();
 
         assert_eq!(
             result.static_import_expressions,
@@ -1284,8 +1350,60 @@ import('./dynamic-import.vue')
         );
     }
 
+    #[test]
+    #[ignore]
+    fn should_find_imports_properly_for_all_files_in_nx_repo() {
+        let current_dir = env::current_dir().unwrap();
+
+        let mut ancestors = current_dir.ancestors();
+
+        ancestors.next();
+        ancestors.next();
+        let root = PathBuf::from(ancestors.next().unwrap());
+
+        let files = nx_walker(root.clone(), move |receiver| {
+            let mut files = vec![];
+            let glob = build_glob_set(&["**/*.[jt]s"]).unwrap();
+            for (path, _) in receiver {
+                if glob.is_match(&path) {
+                    files.push(root.join(path).to_normalized_string());
+                }
+            }
+            files
+        });
+
+        let results: HashMap<_, _> =
+            find_imports(HashMap::from([(String::from("nx"), files.clone())]))
+                .unwrap()
+                .into_iter()
+                .map(|import_result| (import_result.file.clone(), import_result))
+                .collect();
+
+        let ast_results: HashMap<_, _> = files
+            .into_iter()
+            .filter_map(|p| find_imports_with_ast(p).ok())
+            .map(|import_result| (import_result.file.clone(), import_result))
+            .collect();
+
+        for (path, import_result) in results {
+            let ast_result = ast_results.get(&path);
+
+            if let Some(ast_result) = ast_result {
+                dbg!(&path, &import_result, &ast_result);
+                assert_eq!(
+                    import_result.static_import_expressions,
+                    ast_result.static_import_expressions
+                );
+                assert_eq!(
+                    import_result.dynamic_import_expressions,
+                    ast_result.dynamic_import_expressions
+                );
+            }
+        }
+    }
+
     // This function finds imports with the ast which verifies that the imports we find are the same as the ones typescript finds
-    fn find_imports_with_ast(file_path: String) -> ImportResult {
+    fn find_imports_with_ast(file_path: String) -> anyhow::Result<ImportResult> {
         let cm = Arc::<SourceMap>::default()
             .load_file(Path::new(file_path.as_str()))
             .unwrap();
@@ -1306,7 +1424,7 @@ import('./dynamic-import.vue')
             None,
             &mut errs,
         )
-        .unwrap();
+        .map_err(|_| anyhow::anyhow!("Failed to create ast"))?;
 
         let comments = NoopComments;
         let deps = swc_ecma_dep_graph::analyze_dependencies(&module, &comments);
@@ -1333,11 +1451,11 @@ import('./dynamic-import.vue')
                 static_import_expressions.push(dep.specifier.to_string());
             }
         }
-        ImportResult {
+        Ok(ImportResult {
             source_project: String::from("source"),
             file: file_path,
             static_import_expressions,
             dynamic_import_expressions,
-        }
+        })
     }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When imports are in an object in an array (popular when defining routes), the imports were determined to be `Static` even though they should be `Dynamic`:
```ts
      const routes = [
        {},
        {
            lazy: () => import('dynamic-import-lazy-route')
        }
      ]
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When imports are in an object in an array (popular when defining routes), the imports are determined to be `Dynamic`:
```ts
      const routes = [
        {},
        {
            lazy: () => import('dynamic-import-lazy-route')
        }
      ]
```

![image](https://github.com/nrwl/nx/assets/8104246/18090bfb-38ee-4d13-9f30-06a73e866ebd)


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
