### PR TITLE
fix(vue): use default coverageProvider in @nx/vue:library generator when adding vitest

### DIFF
--- a/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -101,7 +101,7 @@ exports[`lib should add vue, vite and vitest to package.json 1`] = `
     "@typescript-eslint/eslint-plugin": "^6.9.1",
     "@typescript-eslint/parser": "^6.9.1",
     "@vitejs/plugin-vue": "^4.3.1",
-    "@vitest/coverage-c8": "~0.32.0",
+    "@vitest/coverage-v8": "~0.32.0",
     "@vitest/ui": "~0.32.0",
     "@vue/eslint-config-prettier": "7.1.0",
     "@vue/eslint-config-typescript": "^11.0.3",

--- a/packages/vue/src/generators/library/lib/add-vite.ts
+++ b/packages/vue/src/generators/library/lib/add-vite.ts
@@ -53,6 +53,7 @@ export async function addVite(
     const vitestTask = await vitestGenerator(tree, {
       uiFramework: 'none',
       project: options.name,
+      coverageProvider: 'v8',
       inSourceTests: options.inSourceTests,
       skipFormat: true,
       testEnvironment: 'jsdom',

--- a/packages/vue/src/generators/library/lib/add-vite.ts
+++ b/packages/vue/src/generators/library/lib/add-vite.ts
@@ -53,7 +53,6 @@ export async function addVite(
     const vitestTask = await vitestGenerator(tree, {
       uiFramework: 'none',
       project: options.name,
-      coverageProvider: 'c8',
       inSourceTests: options.inSourceTests,
       skipFormat: true,
       testEnvironment: 'jsdom',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When generating a library with @nx/vue, invokes the vitestGenerator with `coverageProvider: 'c8'`.
c8 has been deprecated. The new default is v8 (which is already used in @nx/vite:vitest)


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
c8 shouldn't be used as coverageProvider. Instead use the default from @nx/vite:vitest

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

n.a.