### PR TITLE
feat(core): track what config file a target was created by

### DIFF
--- a/docs/generated/devkit/TargetConfiguration.md
+++ b/docs/generated/devkit/TargetConfiguration.md
@@ -15,6 +15,7 @@ Target's configuration
 - [cache](../../devkit/documents/TargetConfiguration#cache): boolean
 - [command](../../devkit/documents/TargetConfiguration#command): string
 - [configurations](../../devkit/documents/TargetConfiguration#configurations): Object
+- [createdBy](../../devkit/documents/TargetConfiguration#createdby): string
 - [defaultConfiguration](../../devkit/documents/TargetConfiguration#defaultconfiguration): string
 - [dependsOn](../../devkit/documents/TargetConfiguration#dependson): (string | TargetDependencyConfig)[]
 - [executor](../../devkit/documents/TargetConfiguration#executor): string
@@ -49,6 +50,14 @@ Sets of options
 #### Index signature
 
 ▪ [config: `string`]: `any`
+
+---
+
+### createdBy
+
+• `Optional` **createdBy**: `string`
+
+The configuration file that lead to a given target being created. E.g. project.json or cypress.config.ts.
 
 ---
 

--- a/packages/nx/src/config/workspace-json-project-json.ts
+++ b/packages/nx/src/config/workspace-json-project-json.ts
@@ -186,4 +186,9 @@ export interface TargetConfiguration<T = any> {
    * Determines if Nx is able to cache a given target.
    */
   cache?: boolean;
+
+  /**
+   * The configuration file that lead to a given target being created. E.g. project.json or cypress.config.ts.
+   */
+  createdBy?: string;
 }

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -90,6 +90,12 @@ export function buildProjectsConfigurationsFromProjectPathsAndPlugins(
           });
         for (const node in projectNodes) {
           projectNodes[node].name ??= node;
+          for (const target in projectNodes[node].targets) {
+            projectNodes[node].targets[target] = {
+              ...projectNodes[node].targets[target],
+              createdBy: file,
+            };
+          }
           mergeProjectConfigurationIntoRootMap(
             projectRootMap,
             projectNodes[node]


### PR DESCRIPTION
adds a `createdBy` property to `TargetConfiguration` that can be consumed by nx console or nx show to tell folks why a target is there.

- It only track the latest file that made a modification to a target. 
I *assume* that most cases will be `1 file -> n targets` and rarely will a target be modified by different files. Either way, the last plugin/file always takes precedence in configuring the target and this matches that. 
- We could let plugin authors handle setting this property themselves but I think it's more consistent & transparent if we do it outside of `createNodes`
- We might want something similar on `ProjectConfiguration`. However, `n files -> 1 project` is the norm there. I'm not sure how we would display this information nicely yet - so for now I'm sticking with `TargetConfiguration`.