### PR TITLE
fix(vue): do not add @vue/tsconfig dependency

### DIFF
--- a/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -120,7 +120,6 @@ exports[`lib should add vue, vite and vitest to package.json 1`] = `
     "@vue/eslint-config-prettier": "7.1.0",
     "@vue/eslint-config-typescript": "^11.0.3",
     "@vue/test-utils": "^2.4.1",
-    "@vue/tsconfig": "^0.4.0",
     "eslint": "~8.48.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-vue": "^9.16.1",

--- a/packages/vue/src/utils/ensure-dependencies.ts
+++ b/packages/vue/src/utils/ensure-dependencies.ts
@@ -10,7 +10,6 @@ import {
   vueRouterVersion,
   vueTestUtilsVersion,
   vueTscVersion,
-  vueTsconfigVersion,
 } from './versions';
 
 export type EnsureDependenciesOptions = {
@@ -24,7 +23,6 @@ export function ensureDependencies(
 ): GeneratorCallback {
   const dependencies: Record<string, string> = {};
   const devDependencies: Record<string, string> = {
-    '@vue/tsconfig': vueTsconfigVersion,
     '@vue/test-utils': vueTestUtilsVersion,
     '@vitejs/plugin-vue': vitePluginVueVersion,
     'vue-tsc': vueTscVersion,

--- a/packages/vue/src/utils/versions.ts
+++ b/packages/vue/src/utils/versions.ts
@@ -5,9 +5,6 @@ export const vueVersion = '^3.3.4';
 export const vueTscVersion = '^1.8.8';
 export const vueRouterVersion = '^4.2.4';
 
-// build deps
-export const vueTsconfigVersion = '^0.4.0';
-
 // test deps
 export const vueTestUtilsVersion = '^2.4.1';
 export const vitePluginVueVersion = '^4.5.0';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

@nx/vue:init generator adds a dev dependency for @vue/tsconfig but this package is never used.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

do not install @vue/tsconfig when it's not used

## Related Issue(s)
n.a.
