### PR TITLE
feat(devkit): add method to get project json projects

### DIFF
--- a/docs/generated/devkit/README.md
+++ b/docs/generated/devkit/README.md
@@ -115,6 +115,7 @@ It only uses language primitives and immutable objects
 - [getOutputsForTargetAndConfiguration](../../devkit/documents/getOutputsForTargetAndConfiguration)
 - [getPackageManagerCommand](../../devkit/documents/getPackageManagerCommand)
 - [getPackageManagerVersion](../../devkit/documents/getPackageManagerVersion)
+- [getProjectJsonProjects](../../devkit/documents/getProjectJsonProjects)
 - [getProjects](../../devkit/documents/getProjects)
 - [getWorkspaceLayout](../../devkit/documents/getWorkspaceLayout)
 - [glob](../../devkit/documents/glob)

--- a/docs/generated/devkit/getProjectJsonProjects.md
+++ b/docs/generated/devkit/getProjectJsonProjects.md
@@ -1,0 +1,13 @@
+# Function: getProjectJsonProjects
+
+▸ **getProjectJsonProjects**(`tree`): `Map`<`string`, [`ProjectConfiguration`](../../devkit/documents/ProjectConfiguration)\>
+
+#### Parameters
+
+| Name   | Type                                  |
+| :----- | :------------------------------------ |
+| `tree` | [`Tree`](../../devkit/documents/Tree) |
+
+#### Returns
+
+`Map`<`string`, [`ProjectConfiguration`](../../devkit/documents/ProjectConfiguration)\>

--- a/docs/generated/devkit/getProjects.md
+++ b/docs/generated/devkit/getProjects.md
@@ -15,3 +15,7 @@ Use [readProjectConfiguration](../../devkit/documents/readProjectConfiguration) 
 #### Returns
 
 `Map`<`string`, [`ProjectConfiguration`](../../devkit/documents/ProjectConfiguration)\>
+
+**`Deprecated`**
+
+This method will be removed in Nx v18. It's usefulness is a bit hampered from including non-project.json projects which are not updateable. It also has never been truly accurate, and projects that are identified which do not contain a project.json or package.json file have never been returned. Use a combination of [getProjectJsonProjects](../../devkit/documents/getProjectJsonProjects) and [glob](../../devkit/documents/glob) instead to find the projects you wish to update.

--- a/docs/generated/packages/devkit/documents/nx_devkit.md
+++ b/docs/generated/packages/devkit/documents/nx_devkit.md
@@ -115,6 +115,7 @@ It only uses language primitives and immutable objects
 - [getOutputsForTargetAndConfiguration](../../devkit/documents/getOutputsForTargetAndConfiguration)
 - [getPackageManagerCommand](../../devkit/documents/getPackageManagerCommand)
 - [getPackageManagerVersion](../../devkit/documents/getPackageManagerVersion)
+- [getProjectJsonProjects](../../devkit/documents/getProjectJsonProjects)
 - [getProjects](../../devkit/documents/getProjects)
 - [getWorkspaceLayout](../../devkit/documents/getWorkspaceLayout)
 - [glob](../../devkit/documents/glob)

--- a/packages/nx/src/devkit-exports.ts
+++ b/packages/nx/src/devkit-exports.ts
@@ -116,6 +116,7 @@ export {
   removeProjectConfiguration,
   updateProjectConfiguration,
   getProjects,
+  getProjectJsonProjects,
 } from './generators/utils/project-configuration';
 
 /**

--- a/packages/nx/src/generators/utils/project-configuration.spec.ts
+++ b/packages/nx/src/generators/utils/project-configuration.spec.ts
@@ -8,6 +8,7 @@ import { readJson, writeJson } from '../utils/json';
 import {
   addProjectConfiguration,
   getProjects,
+  getProjectJsonProjects,
   readProjectConfiguration,
   removeProjectConfiguration,
   updateProjectConfiguration,
@@ -175,7 +176,7 @@ describe('project configuration', () => {
       writeJson<PackageJson>(tree, 'package.json', {
         name: '@testing/root',
         version: '0.0.1',
-        workspaces: ['*/**/package.json'],
+        workspaces: ['**/package.json'],
       });
     });
 
@@ -205,6 +206,27 @@ describe('project configuration', () => {
         name: 'proj',
         root: 'proj',
       });
+    });
+  });
+
+  describe('getProjectJsonProjects', () => {
+    it('should not find package.json based projects', () => {
+      writeJson<PackageJson>(tree, 'package.json', {
+        name: '@testing/root',
+        version: '0.0.1',
+        workspaces: ['**/package.json'],
+      });
+      writeJson<PackageJson>(tree, 'proj/package.json', {
+        name: 'proj',
+        version: '0.0.1',
+      });
+      writeJson<ProjectConfiguration>(tree, 'other/project.json', {
+        name: 'other',
+        root: 'other',
+      });
+      const projects = getProjectJsonProjects(tree);
+      expect(projects.size).toEqual(1);
+      expect(projects.has('other')).toEqual(true);
     });
   });
 });

--- a/packages/nx/src/migrations/update-15-0-0/prefix-outputs.spec.ts
+++ b/packages/nx/src/migrations/update-15-0-0/prefix-outputs.spec.ts
@@ -6,7 +6,7 @@ import {
   readProjectConfiguration,
   updateNxJson,
 } from '../../generators/utils/project-configuration';
-import { readJson, writeJson } from '../../generators/utils/json';
+import { readJson, updateJson, writeJson } from '../../generators/utils/json';
 import prefixOutputs from './prefix-outputs';
 import { validateOutputs } from '../../tasks-runner/utils';
 
@@ -83,6 +83,10 @@ describe('15.0.0 migration (prefix-outputs)', () => {
   });
 
   it('should migrate package.json projects', async () => {
+    updateJson(tree, 'package.json', (j) => {
+      j.workspaces = ['proj'];
+      return j;
+    });
     writeJson(tree, 'proj/package.json', {
       name: 'proj',
       scripts: {

--- a/packages/nx/src/native/tests/watcher.spec.ts
+++ b/packages/nx/src/native/tests/watcher.spec.ts
@@ -147,7 +147,7 @@ describe('watcher', () => {
     wait().then(() => {
       temp.appendFile('.env.local', 'hello');
     });
-  });
+  }, 60_000);
 });
 
 function wait(timeout = 500) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`getProjects` returns all projects, even those which can't be updated. This makes writing migrations and generators which modify configuration a bit harder.

## Expected Behavior
`getProjectJsonProjects` returns only project.json projects

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
