### PR TITLE
fix(react): Update types version so that there is no mismatch when using yarn

### DIFF
--- a/packages/react/src/utils/versions.ts
+++ b/packages/react/src/utils/versions.ts
@@ -8,8 +8,8 @@ export const reactDomVersion = '18.2.0';
 export const reactIsVersion = '18.2.0';
 export const swcLoaderVersion = '0.1.15';
 export const babelLoaderVersion = '^9.1.2';
-export const typesReactVersion = '18.2.24';
-export const typesReactDomVersion = '18.2.9';
+export const typesReactVersion = '18.2.33';
+export const typesReactDomVersion = '18.2.14';
 export const typesReactIsVersion = '18.2.2';
 
 export const typesNodeVersion = '18.14.2';


### PR DESCRIPTION
When using `yarn` to create a react app with `style-components` selected it resolves mismatching of types
```shell
├─┬ @testing-library/react@14.0.0
│ └─┬ @types/react-dom@18.2.14
│   └── @types/react@18.2.33
├─┬ @types/react-dom@18.2.9
│ └── @types/react@18.2.33
├─┬ @types/react-is@18.2.2
│ └── @types/react@18.2.33
├── @types/react@18.2.24
└─┬ @types/styled-components@5.1.26
  ├─┬ @types/hoist-non-react-statics@3.3.4
  │ └── @types/react@18.2.33
  └── @types/react@18.2.33
```

Which would make running `nx build` result in a error.

Updating the types to the latest `patch` version should resolve this mismatch issue.