### PR TITLE
fix(vue): dont require project when generating component

### DIFF
--- a/docs/generated/packages/vue/generators/component.json
+++ b/docs/generated/packages/vue/generators/component.json
@@ -108,7 +108,7 @@
         "x-prompt": "What unit test runner should be used?"
       }
     },
-    "required": ["name", "project"],
+    "required": ["name"],
     "presets": []
   },
   "aliases": ["c"],

--- a/packages/vue/src/generators/component/schema.json
+++ b/packages/vue/src/generators/component/schema.json
@@ -110,5 +110,5 @@
       "x-prompt": "What unit test runner should be used?"
     }
   },
-  "required": ["name", "project"]
+  "required": ["name"]
 }


### PR DESCRIPTION
Don't throw when passing directory and not project when generating component
