### PR TITLE
fix(angular): extract remotes from manifest correctly #19880

### DIFF
--- a/packages/webpack/src/utils/module-federation/get-remotes-for-host.ts
+++ b/packages/webpack/src/utils/module-federation/get-remotes-for-host.ts
@@ -35,7 +35,7 @@ function extractRemoteProjectsFromConfig(
             typeof key === 'string' && typeof parsedManifest[key] === 'string'
         )
       ) {
-        remotes.push(Object.keys(parsedManifest));
+        remotes.push(...Object.keys(parsedManifest));
       }
     }
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When extracting remotes from manifest, we use Object.keys, which returns the array. However, we push this full array into another array, instead of spreading it.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Spread the Object.keys array to add each remote extracted individually

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #19880
