### PR TITLE
fix(angular): support scoped remote names for federation

### DIFF
--- a/packages/angular/src/utils/mf/utils.ts
+++ b/packages/angular/src/utils/mf/utils.ts
@@ -89,15 +89,18 @@ export async function getModuleFederationConfig(
     projectGraph = await createProjectGraphAsync();
   }
 
-  if (!projectGraph.nodes[mfConfig.name]?.data) {
+  const NPM_SCOPE_REGEX = /^@(\w|\w-\w)+\/(?!\/)/;
+  const mfConfigName = mfConfig.name.replace(NPM_SCOPE_REGEX, '');
+
+  if (!projectGraph.nodes[mfConfigName]?.data) {
     throw Error(
-      `Cannot find project "${mfConfig.name}". Check that the name is correct in module-federation.config.js`
+      `Cannot find project "${mfConfigName}". Check that the name is correct in module-federation.config.js`
     );
   }
 
   const dependencies = getDependentPackagesForProject(
     projectGraph,
-    mfConfig.name
+    mfConfigName
   );
 
   if (mfConfig.shared) {
@@ -131,9 +134,7 @@ export async function getModuleFederationConfig(
   });
 
   const sharedDependencies = {
-    ...sharedLibraries.getLibraries(
-      projectGraph.nodes[mfConfig.name].data.root
-    ),
+    ...sharedLibraries.getLibraries(projectGraph.nodes[mfConfigName].data.root),
     ...npmPackages,
   };
 

--- a/packages/webpack/src/utils/module-federation/get-remotes-for-host.ts
+++ b/packages/webpack/src/utils/module-federation/get-remotes-for-host.ts
@@ -16,7 +16,7 @@ function extractRemoteProjectsFromConfig(
   config: ModuleFederationConfig,
   pathToManifestFile?: string
 ) {
-  const remotes = [];
+  let remotes = [];
   if (pathToManifestFile && existsSync(pathToManifestFile)) {
     const moduleFederationManifestJson = readFileSync(
       pathToManifestFile,
@@ -42,6 +42,8 @@ function extractRemoteProjectsFromConfig(
   const staticRemotes =
     config.remotes?.map((r) => (Array.isArray(r) ? r[0] : r)) ?? [];
   remotes.push(...staticRemotes);
+  const NPM_SCOPE_REGEX = /^@(\w|\w-\w)+\/(?!\/)/;
+  remotes = remotes.map((r) => r.replace(NPM_SCOPE_REGEX, ''));
   return remotes;
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We currently error if someone tries to use a remote name such as '@scope/remote'

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should not error if someone tries to use a remote name with this

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
