### PR TITLE
feat(angular): rename browserTarget to buildTarget in dev-server executors

### DIFF
--- a/docs/generated/packages/angular/executors/module-federation-dev-server.json
+++ b/docs/generated/packages/angular/executors/module-federation-dev-server.json
@@ -9,12 +9,18 @@
     "description": "The module-federation-dev-server executor is reserved exclusively for use with host Module Federation applications. It allows the user to specify which remote applications should be served with the host.",
     "type": "object",
     "presets": [
-      { "name": "Using a Different Port", "keys": ["browserTarget", "port"] }
+      { "name": "Using a Different Port", "keys": ["buildTarget", "port"] }
     ],
     "properties": {
       "browserTarget": {
         "type": "string",
-        "description": "A browser builder target to serve in the format of `project:target[:configuration]`. You can also pass in more than one configuration name as a comma-separated list. Example: `project:target:production,staging`.",
+        "description": "A browser builder target to serve in the format of `project:target[:configuration]`.",
+        "pattern": "^[^:\\s]+:[^:\\s]+(:[^\\s]+)?$",
+        "x-deprecated": "Use 'buildTarget' instead. It will be removed in Nx v18."
+      },
+      "buildTarget": {
+        "type": "string",
+        "description": "A build builder target to serve in the format of `project:target[:configuration]`.",
         "pattern": "^[^:\\s]+:[^:\\s]+(:[^\\s]+)?$"
       },
       "port": {
@@ -125,8 +131,11 @@
       }
     },
     "additionalProperties": false,
-    "required": ["browserTarget"],
-    "examplesFile": "## Examples\n\n{% tabs %}\n\n{% tab label=\"Basic Usage\" %}\nThe Module Federation Dev Server will serve a host application and find the remote applications associated with the host and serve them statically also.  \nSee an example set up of it below:\n\n```json\n{\n  \"serve\": {\n    \"executor\": \"@nx/angular:module-federation-dev-server\",\n    \"configurations\": {\n      \"production\": {\n        \"browserTarget\": \"host:build:production\"\n      },\n      \"development\": {\n        \"browserTarget\": \"host:build:development\"\n      }\n    },\n    \"defaultConfiguration\": \"development\",\n    \"options\": {\n      \"port\": 4200,\n      \"publicHost\": \"http://localhost:4200\"\n    }\n  }\n}\n```\n\n{% /tab %}\n\n{% tab label=\"Serve host with remotes that can be live reloaded\" %}\nThe Module Federation Dev Server will serve a host application and find the remote applications associated with the host and serve a set selection with live reloading enabled also.  \nSee an example set up of it below:\n\n```json\n{\n  \"serve-with-hmr-remotes\": {\n    \"executor\": \"@nx/angular:module-federation-dev-server\",\n    \"configurations\": {\n      \"production\": {\n        \"browserTarget\": \"host:build:production\"\n      },\n      \"development\": {\n        \"browserTarget\": \"host:build:development\"\n      }\n    },\n    \"defaultConfiguration\": \"development\",\n    \"options\": {\n      \"port\": 4200,\n      \"publicHost\": \"http://localhost:4200\",\n      \"devRemotes\": [\"remote1\", \"remote2\"]\n    }\n  }\n}\n```\n\n{% /tab %}\n\n{% /tabs %}\n"
+    "anyOf": [
+      { "required": ["buildTarget"] },
+      { "required": ["browserTarget"] }
+    ],
+    "examplesFile": "## Examples\n\n{% tabs %}\n\n{% tab label=\"Basic Usage\" %}\nThe Module Federation Dev Server will serve a host application and find the remote applications associated with the host and serve them statically also.  \nSee an example set up of it below:\n\n```json\n{\n  \"serve\": {\n    \"executor\": \"@nx/angular:module-federation-dev-server\",\n    \"configurations\": {\n      \"production\": {\n        \"buildTarget\": \"host:build:production\"\n      },\n      \"development\": {\n        \"buildTarget\": \"host:build:development\"\n      }\n    },\n    \"defaultConfiguration\": \"development\",\n    \"options\": {\n      \"port\": 4200,\n      \"publicHost\": \"http://localhost:4200\"\n    }\n  }\n}\n```\n\n{% /tab %}\n\n{% tab label=\"Serve host with remotes that can be live reloaded\" %}\nThe Module Federation Dev Server will serve a host application and find the remote applications associated with the host and serve a set selection with live reloading enabled also.  \nSee an example set up of it below:\n\n```json\n{\n  \"serve-with-hmr-remotes\": {\n    \"executor\": \"@nx/angular:module-federation-dev-server\",\n    \"configurations\": {\n      \"production\": {\n        \"buildTarget\": \"host:build:production\"\n      },\n      \"development\": {\n        \"buildTarget\": \"host:build:development\"\n      }\n    },\n    \"defaultConfiguration\": \"development\",\n    \"options\": {\n      \"port\": 4200,\n      \"publicHost\": \"http://localhost:4200\",\n      \"devRemotes\": [\"remote1\", \"remote2\"]\n    }\n  }\n}\n```\n\n{% /tab %}\n\n{% /tabs %}\n"
   },
   "description": "The module-federation-dev-server executor is reserved exclusively for use with host Module Federation applications. It allows the user to specify which remote applications should be served with the host.",
   "aliases": [],

--- a/docs/generated/packages/angular/executors/webpack-dev-server.json
+++ b/docs/generated/packages/angular/executors/webpack-dev-server.json
@@ -7,15 +7,21 @@
     "$schema": "http://json-schema.org/draft-07/schema",
     "title": "Schema for Webpack Dev Server",
     "description": "The webpack-dev-server executor is very similar to the standard dev server builder provided by the Angular Devkit. It is usually used in tandem with `@nx/angular:webpack-browser` when your Angular application uses a custom webpack configuration.",
-    "examplesFile": "##### Seving an application with a custom webpack configuration\n\nThis executor should be used along with `@nx/angular:webpack-browser` to serve an application using a custom webpack configuration.\n\nYour `project.json` file should contain a `build` and `serve` target that matches the following:\n\n```json\n\"build\": {\n    \"executor\": \"@nx/angular:webpack-browser\",\n    \"options\": {\n        ...\n        \"customWebpackConfig\": {\n          \"path\": \"apps/appName/webpack.config.js\"\n        }\n    }\n},\n\"serve\": {\n    \"executor\": \"@nx/angular:webpack-dev-server\",\n    \"configurations\": {\n        \"production\": {\n            \"browserTarget\": \"appName:build:production\"\n        },\n        \"development\": {\n            \"browserTarget\": \"appName:build:development\"\n        }\n    },\n    \"defaultConfiguration\": \"development\",\n}\n```\n",
+    "examplesFile": "##### Seving an application with a custom webpack configuration\n\nThis executor should be used along with `@nx/angular:webpack-browser` to serve an application using a custom webpack configuration.\n\nYour `project.json` file should contain a `build` and `serve` target that matches the following:\n\n```json\n\"build\": {\n    \"executor\": \"@nx/angular:webpack-browser\",\n    \"options\": {\n        ...\n        \"customWebpackConfig\": {\n          \"path\": \"apps/appName/webpack.config.js\"\n        }\n    }\n},\n\"serve\": {\n    \"executor\": \"@nx/angular:webpack-dev-server\",\n    \"configurations\": {\n        \"production\": {\n            \"buildTarget\": \"appName:build:production\"\n        },\n        \"development\": {\n            \"buildTarget\": \"appName:build:development\"\n        }\n    },\n    \"defaultConfiguration\": \"development\",\n}\n```\n",
     "type": "object",
     "presets": [
-      { "name": "Using a Different Port", "keys": ["browserTarget", "port"] }
+      { "name": "Using a Different Port", "keys": ["buildTarget", "port"] }
     ],
     "properties": {
       "browserTarget": {
         "type": "string",
-        "description": "A browser builder target to serve in the format of `project:target[:configuration]`. You can also pass in more than one configuration name as a comma-separated list. Example: `project:target:production,staging`.",
+        "description": "A browser builder target to serve in the format of `project:target[:configuration]`. Ignored if `buildTarget` is set.",
+        "pattern": "^[^:\\s]+:[^:\\s]+(:[^\\s]+)?$",
+        "x-deprecated": "Use 'buildTarget' instead. It will be removed in Nx v18."
+      },
+      "buildTarget": {
+        "type": "string",
+        "description": "A build builder target to serve in the format of `project:target[:configuration]`.",
         "pattern": "^[^:\\s]+:[^:\\s]+(:[^\\s]+)?$"
       },
       "port": {
@@ -106,7 +112,10 @@
       }
     },
     "additionalProperties": false,
-    "required": ["browserTarget"]
+    "anyOf": [
+      { "required": ["buildTarget"] },
+      { "required": ["browserTarget"] }
+    ]
   },
   "description": "The `webpack-dev-server` executor is very similar to the standard `dev-server` builder provided by the Angular Devkit. It is usually used in tandem with `@nrwl/angular:webpack-browser` when your Angular application uses a custom webpack configuration.",
   "aliases": [],

--- a/packages/angular/docs/module-federation-dev-server-examples.md
+++ b/packages/angular/docs/module-federation-dev-server-examples.md
@@ -12,10 +12,10 @@ See an example set up of it below:
     "executor": "@nx/angular:module-federation-dev-server",
     "configurations": {
       "production": {
-        "browserTarget": "host:build:production"
+        "buildTarget": "host:build:production"
       },
       "development": {
-        "browserTarget": "host:build:development"
+        "buildTarget": "host:build:development"
       }
     },
     "defaultConfiguration": "development",
@@ -39,10 +39,10 @@ See an example set up of it below:
     "executor": "@nx/angular:module-federation-dev-server",
     "configurations": {
       "production": {
-        "browserTarget": "host:build:production"
+        "buildTarget": "host:build:production"
       },
       "development": {
-        "browserTarget": "host:build:development"
+        "buildTarget": "host:build:development"
       }
     },
     "defaultConfiguration": "development",

--- a/packages/angular/docs/webpack-dev-server-examples.md
+++ b/packages/angular/docs/webpack-dev-server-examples.md
@@ -18,10 +18,10 @@ Your `project.json` file should contain a `build` and `serve` target that matche
     "executor": "@nx/angular:webpack-dev-server",
     "configurations": {
         "production": {
-            "browserTarget": "appName:build:production"
+            "buildTarget": "appName:build:production"
         },
         "development": {
-            "browserTarget": "appName:build:development"
+            "buildTarget": "appName:build:development"
         }
     },
     "defaultConfiguration": "development",

--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -287,6 +287,15 @@
       },
       "description": "Update the @angular/cli package version to ~17.0.0-rc.2.",
       "factory": "./src/migrations/update-17-2-0/update-angular-cli"
+    },
+    "rename-browser-target-to-build-target": {
+      "cli": "nx",
+      "version": "17.2.0-beta.0",
+      "requires": {
+        "@angular/core": ">=17.0.0-rc.1"
+      },
+      "description": "Rename 'browserTarget' to 'buildTarget'.",
+      "factory": "./src/migrations/update-17-2-0/browser-target-to-build-target"
     }
   },
   "packageJsonUpdates": {

--- a/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -1,27 +1,28 @@
-import type { Schema } from './schema';
 import {
   logger,
   readCachedProjectGraph,
   readNxJson,
   workspaceRoot,
 } from '@nx/devkit';
-import { scheduleTarget } from 'nx/src/adapter/ngcli-adapter';
-import { executeWebpackDevServerBuilder } from '../webpack-dev-server/webpack-dev-server.impl';
-import { readProjectsConfigurationFromProjectGraph } from 'nx/src/project-graph/project-graph';
-import { getExecutorInformation } from 'nx/src/command-line/run/executor-utils';
-import {
-  getDynamicRemotes,
-  getStaticRemotes,
-  validateDevRemotes,
-} from '../utilities/module-federation';
-import { existsSync } from 'fs';
-import { extname, join } from 'path';
 import {
   getModuleFederationConfig,
   getRemotes,
 } from '@nx/webpack/src/utils/module-federation';
 import { fork } from 'child_process';
+import { existsSync } from 'fs';
+import { scheduleTarget } from 'nx/src/adapter/ngcli-adapter';
+import { getExecutorInformation } from 'nx/src/command-line/run/executor-utils';
+import { readProjectsConfigurationFromProjectGraph } from 'nx/src/project-graph/project-graph';
+import { extname, join } from 'path';
 import { combineLatest, concatMap, from, switchMap } from 'rxjs';
+import { validateDevRemotes } from '../utilities/module-federation';
+import { executeWebpackDevServerBuilder } from '../webpack-dev-server/webpack-dev-server.impl';
+import type {
+  NormalizedSchema,
+  Schema,
+  SchemaWithBrowserTarget,
+  SchemaWithBuildTarget,
+} from './schema';
 
 export function executeModuleFederationDevServerBuilder(
   schema: Schema,
@@ -29,7 +30,7 @@ export function executeModuleFederationDevServerBuilder(
 ): ReturnType<typeof executeWebpackDevServerBuilder | any> {
   // Force Node to resolve to look for the nx binary that is inside node_modules
   const nxBin = require.resolve('nx/bin/nx');
-  const { ...options } = schema;
+  const options = normalizeOptions(schema);
   const projectGraph = readCachedProjectGraph();
   const { projects: workspaceProjects } =
     readProjectsConfigurationFromProjectGraph(projectGraph);
@@ -44,7 +45,7 @@ export function executeModuleFederationDevServerBuilder(
           port: options.port,
           host: options.host,
           ssl: options.ssl,
-          buildTarget: options.browserTarget,
+          buildTarget: options.buildTarget,
           parallel: false,
           spa: false,
           withDeps: false,
@@ -226,3 +227,21 @@ export function executeModuleFederationDevServerBuilder(
 export default require('@angular-devkit/architect').createBuilder(
   executeModuleFederationDevServerBuilder
 );
+
+function normalizeOptions(schema: Schema): NormalizedSchema {
+  let buildTarget = (schema as SchemaWithBuildTarget).buildTarget;
+  if ((schema as SchemaWithBrowserTarget).browserTarget) {
+    buildTarget ??= (schema as SchemaWithBrowserTarget).browserTarget;
+    delete (schema as SchemaWithBrowserTarget).browserTarget;
+  }
+
+  return {
+    ...schema,
+    buildTarget,
+    host: schema.host ?? 'localhost',
+    port: schema.port ?? 4200,
+    liveReload: schema.liveReload ?? true,
+    open: schema.open ?? false,
+    ssl: schema.ssl ?? false,
+  };
+}

--- a/packages/angular/src/builders/module-federation-dev-server/schema.d.ts
+++ b/packages/angular/src/builders/module-federation-dev-server/schema.d.ts
@@ -1,15 +1,14 @@
-export interface Schema {
-  browserTarget: string;
-  port: number;
-  host: string;
+interface BaseSchema {
+  port?: number;
+  host?: string;
   proxyConfig?: string;
-  ssl: boolean;
+  ssl?: boolean;
   sslKey?: string;
   sslCert?: string;
   headers?: Record<string, string>;
-  open: boolean;
+  open?: boolean;
   verbose?: boolean;
-  liveReload: boolean;
+  liveReload?: boolean;
   publicHost?: string;
   allowedHosts?: string[];
   servePath?: string;
@@ -23,3 +22,19 @@ export interface Schema {
   static?: boolean;
   isInitialHost?: boolean;
 }
+
+export type SchemaWithBrowserTarget = BaseSchema & {
+  browserTarget: string;
+};
+
+export type SchemaWithBuildTarget = BaseSchema & {
+  buildTarget: string;
+};
+
+export type Schema = SchemaWithBrowserTarget | SchemaWithBuildTarget;
+
+export type NormalizedSchema = SchemaWithBuildTarget & {
+  liveReload: boolean;
+  open: boolean;
+  ssl: boolean;
+};

--- a/packages/angular/src/builders/module-federation-dev-server/schema.json
+++ b/packages/angular/src/builders/module-federation-dev-server/schema.json
@@ -8,13 +8,19 @@
   "presets": [
     {
       "name": "Using a Different Port",
-      "keys": ["browserTarget", "port"]
+      "keys": ["buildTarget", "port"]
     }
   ],
   "properties": {
     "browserTarget": {
       "type": "string",
-      "description": "A browser builder target to serve in the format of `project:target[:configuration]`. You can also pass in more than one configuration name as a comma-separated list. Example: `project:target:production,staging`.",
+      "description": "A browser builder target to serve in the format of `project:target[:configuration]`.",
+      "pattern": "^[^:\\s]+:[^:\\s]+(:[^\\s]+)?$",
+      "x-deprecated": "Use 'buildTarget' instead. It will be removed in Nx v18."
+    },
+    "buildTarget": {
+      "type": "string",
+      "description": "A build builder target to serve in the format of `project:target[:configuration]`.",
       "pattern": "^[^:\\s]+:[^:\\s]+(:[^\\s]+)?$"
     },
     "port": {
@@ -135,6 +141,6 @@
     }
   },
   "additionalProperties": false,
-  "required": ["browserTarget"],
+  "anyOf": [{ "required": ["buildTarget"] }, { "required": ["browserTarget"] }],
   "examplesFile": "../../../docs/module-federation-dev-server-examples.md"
 }

--- a/packages/angular/src/builders/webpack-dev-server/lib/normalize-options.ts
+++ b/packages/angular/src/builders/webpack-dev-server/lib/normalize-options.ts
@@ -1,12 +1,24 @@
-import type { Schema } from '../schema';
+import type {
+  NormalizedSchema,
+  Schema,
+  SchemaWithBrowserTarget,
+  SchemaWithBuildTarget,
+} from '../schema';
 
-export function normalizeOptions(schema: Schema): Schema {
+export function normalizeOptions(schema: Schema): NormalizedSchema {
+  let buildTarget = (schema as SchemaWithBuildTarget).buildTarget;
+  if ((schema as SchemaWithBrowserTarget).browserTarget) {
+    buildTarget ??= (schema as SchemaWithBrowserTarget).browserTarget;
+    delete (schema as SchemaWithBrowserTarget).browserTarget;
+  }
+
   return {
-    host: 'localhost',
-    port: 4200,
-    liveReload: true,
-    open: false,
-    ssl: false,
     ...schema,
+    buildTarget,
+    host: schema.host ?? 'localhost',
+    port: schema.port ?? 4200,
+    liveReload: schema.liveReload ?? true,
+    open: schema.open ?? false,
+    ssl: schema.ssl ?? false,
   };
 }

--- a/packages/angular/src/builders/webpack-dev-server/schema.d.ts
+++ b/packages/angular/src/builders/webpack-dev-server/schema.d.ts
@@ -1,15 +1,14 @@
-export interface Schema {
-  browserTarget: string;
-  port: number;
-  host: string;
+interface BaseSchema {
+  port?: number;
+  host?: string;
   proxyConfig?: string;
-  ssl: boolean;
+  ssl?: boolean;
   sslKey?: string;
   sslCert?: string;
   headers?: Record<string, string>;
-  open: boolean;
+  open?: boolean;
   verbose?: boolean;
-  liveReload: boolean;
+  liveReload?: boolean;
   publicHost?: string;
   allowedHosts?: string[];
   servePath?: string;
@@ -19,3 +18,19 @@ export interface Schema {
   poll?: number;
   buildLibsFromSource?: boolean;
 }
+
+export type SchemaWithBrowserTarget = BaseSchema & {
+  browserTarget: string;
+};
+
+export type SchemaWithBuildTarget = BaseSchema & {
+  buildTarget: string;
+};
+
+export type Schema = SchemaWithBrowserTarget | SchemaWithBuildTarget;
+
+export type NormalizedSchema = SchemaWithBuildTarget & {
+  liveReload: boolean;
+  open: boolean;
+  ssl: boolean;
+};

--- a/packages/angular/src/builders/webpack-dev-server/schema.json
+++ b/packages/angular/src/builders/webpack-dev-server/schema.json
@@ -9,13 +9,19 @@
   "presets": [
     {
       "name": "Using a Different Port",
-      "keys": ["browserTarget", "port"]
+      "keys": ["buildTarget", "port"]
     }
   ],
   "properties": {
     "browserTarget": {
       "type": "string",
-      "description": "A browser builder target to serve in the format of `project:target[:configuration]`. You can also pass in more than one configuration name as a comma-separated list. Example: `project:target:production,staging`.",
+      "description": "A browser builder target to serve in the format of `project:target[:configuration]`. Ignored if `buildTarget` is set.",
+      "pattern": "^[^:\\s]+:[^:\\s]+(:[^\\s]+)?$",
+      "x-deprecated": "Use 'buildTarget' instead. It will be removed in Nx v18."
+    },
+    "buildTarget": {
+      "type": "string",
+      "description": "A build builder target to serve in the format of `project:target[:configuration]`.",
       "pattern": "^[^:\\s]+:[^:\\s]+(:[^\\s]+)?$"
     },
     "port": {
@@ -112,5 +118,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["browserTarget"]
+  "anyOf": [{ "required": ["buildTarget"] }, { "required": ["browserTarget"] }]
 }

--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -268,7 +268,7 @@ exports[`app --project-name-and-root-format=derived should generate correctly wh
     "extract-i18n": {
       "executor": "@angular-devkit/build-angular:extract-i18n",
       "options": {
-        "browserTarget": "my-dir-my-app:build",
+        "buildTarget": "my-dir-my-app:build",
       },
     },
     "lint": {
@@ -286,10 +286,10 @@ exports[`app --project-name-and-root-format=derived should generate correctly wh
     "serve": {
       "configurations": {
         "development": {
-          "browserTarget": "my-dir-my-app:build:development",
+          "buildTarget": "my-dir-my-app:build:development",
         },
         "production": {
-          "browserTarget": "my-dir-my-app:build:production",
+          "buildTarget": "my-dir-my-app:build:production",
         },
       },
       "defaultConfiguration": "development",
@@ -512,7 +512,7 @@ exports[`app --project-name-and-root-format=derived should generate correctly wh
     "extract-i18n": {
       "executor": "@angular-devkit/build-angular:extract-i18n",
       "options": {
-        "browserTarget": "my-app:build",
+        "buildTarget": "my-app:build",
       },
     },
     "lint": {
@@ -530,10 +530,10 @@ exports[`app --project-name-and-root-format=derived should generate correctly wh
     "serve": {
       "configurations": {
         "development": {
-          "browserTarget": "my-app:build:development",
+          "buildTarget": "my-app:build:development",
         },
         "production": {
-          "browserTarget": "my-app:build:production",
+          "buildTarget": "my-app:build:production",
         },
       },
       "defaultConfiguration": "development",
@@ -985,7 +985,7 @@ exports[`app nested should create project configs 1`] = `
     "extract-i18n": {
       "executor": "@angular-devkit/build-angular:extract-i18n",
       "options": {
-        "browserTarget": "my-app:build",
+        "buildTarget": "my-app:build",
       },
     },
     "lint": {
@@ -1003,10 +1003,10 @@ exports[`app nested should create project configs 1`] = `
     "serve": {
       "configurations": {
         "development": {
-          "browserTarget": "my-app:build:development",
+          "buildTarget": "my-app:build:development",
         },
         "production": {
-          "browserTarget": "my-app:build:production",
+          "buildTarget": "my-app:build:production",
         },
       },
       "defaultConfiguration": "development",
@@ -1143,7 +1143,7 @@ exports[`app not nested should create project configs 1`] = `
     "extract-i18n": {
       "executor": "@angular-devkit/build-angular:extract-i18n",
       "options": {
-        "browserTarget": "my-app:build",
+        "buildTarget": "my-app:build",
       },
     },
     "lint": {
@@ -1161,10 +1161,10 @@ exports[`app not nested should create project configs 1`] = `
     "serve": {
       "configurations": {
         "development": {
-          "browserTarget": "my-app:build:development",
+          "buildTarget": "my-app:build:development",
         },
         "production": {
-          "browserTarget": "my-app:build:production",
+          "buildTarget": "my-app:build:production",
         },
       },
       "defaultConfiguration": "development",

--- a/packages/angular/src/generators/application/lib/create-project.ts
+++ b/packages/angular/src/generators/application/lib/create-project.ts
@@ -1,6 +1,7 @@
 import type { Tree } from '@nx/devkit';
 import { addProjectConfiguration } from '@nx/devkit';
 import type { AngularProjectConfiguration } from '../../../utils/types';
+import { getInstalledAngularVersionInfo } from '../../utils/version-utils';
 import type { NormalizedSchema } from './normalized-schema';
 
 export function createProject(tree: Tree, options: NormalizedSchema) {
@@ -8,6 +9,10 @@ export function createProject(tree: Tree, options: NormalizedSchema) {
     options.bundler === 'webpack'
       ? '@angular-devkit/build-angular:browser'
       : '@angular-devkit/build-angular:browser-esbuild';
+
+  const { major } = getInstalledAngularVersionInfo(tree);
+  const buildTargetOptionName = major >= 17 ? 'buildTarget' : 'browserTarget';
+
   const project: AngularProjectConfiguration = {
     name: options.name,
     projectType: 'application',
@@ -73,10 +78,10 @@ export function createProject(tree: Tree, options: NormalizedSchema) {
           : undefined,
         configurations: {
           production: {
-            browserTarget: `${options.name}:build:production`,
+            [buildTargetOptionName]: `${options.name}:build:production`,
           },
           development: {
-            browserTarget: `${options.name}:build:development`,
+            [buildTargetOptionName]: `${options.name}:build:development`,
           },
         },
         defaultConfiguration: 'development',
@@ -84,7 +89,7 @@ export function createProject(tree: Tree, options: NormalizedSchema) {
       'extract-i18n': {
         executor: '@angular-devkit/build-angular:extract-i18n',
         options: {
-          browserTarget: `${options.name}:build`,
+          [buildTargetOptionName]: `${options.name}:build`,
         },
       },
     },

--- a/packages/angular/src/migrations/update-14-8-0/rename-webpack-server.spec.ts
+++ b/packages/angular/src/migrations/update-14-8-0/rename-webpack-server.spec.ts
@@ -14,6 +14,11 @@ describe('renameWebpackServer', () => {
 
     updateJson(tree, 'apps/remote/project.json', (json) => {
       json.targets.serve.executor = '@nrwl/angular:webpack-server';
+      // Nx 14.x.x generates apps with browserTarget
+      json.targets.serve.configurations = {
+        development: { browserTarget: 'remote:build:development' },
+        production: { browserTarget: 'remote:build:production' },
+      };
       return json;
     });
 

--- a/packages/angular/src/migrations/update-17-2-0/browser-target-to-build-target.spec.ts
+++ b/packages/angular/src/migrations/update-17-2-0/browser-target-to-build-target.spec.ts
@@ -1,0 +1,159 @@
+import {
+  addProjectConfiguration,
+  readJson,
+  readProjectConfiguration,
+  updateJson,
+  type NxJsonConfiguration,
+  type Tree,
+} from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration, { executors } from './browser-target-to-build-target';
+
+describe('browser-target-to-build-target migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it.each(executors)(
+    'should rename "browserTarget" option from target using the "%s" executor',
+    async (executor) => {
+      addProjectConfiguration(tree, 'app1', {
+        root: 'apps/app1',
+        targets: {
+          serve: {
+            executor,
+            options: { browserTarget: 'app1:serve' },
+            configurations: {
+              development: { browserTarget: 'app1:serve:development' },
+              production: { browserTarget: 'app1:serve:production' },
+            },
+          },
+        },
+      });
+
+      await migration(tree);
+
+      const project = readProjectConfiguration(tree, 'app1');
+      expect(project.targets.serve.options.browserTarget).toBeUndefined();
+      expect(project.targets.serve.options.buildTarget).toBe('app1:serve');
+      expect(
+        project.targets.serve.configurations.development.browserTarget
+      ).toBeUndefined();
+      expect(project.targets.serve.configurations.development.buildTarget).toBe(
+        'app1:serve:development'
+      );
+      expect(
+        project.targets.serve.configurations.production.browserTarget
+      ).toBeUndefined();
+      expect(project.targets.serve.configurations.production.buildTarget).toBe(
+        'app1:serve:production'
+      );
+    }
+  );
+
+  it('should not rename "browserTarget" from target not using the relevant executors', async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      targets: {
+        serve: {
+          executor: '@org/awesome-plugin:executor',
+          options: { browserTarget: 'app1:serve' },
+          configurations: {
+            development: { browserTarget: 'app1:serve:development' },
+            production: { browserTarget: 'app1:serve:production' },
+          },
+        },
+      },
+    });
+
+    await migration(tree);
+
+    const project = readProjectConfiguration(tree, 'app1');
+    expect(project.targets.serve.options.browserTarget).toBe('app1:serve');
+    expect(project.targets.serve.configurations.development.browserTarget).toBe(
+      'app1:serve:development'
+    );
+    expect(project.targets.serve.configurations.production.browserTarget).toBe(
+      'app1:serve:production'
+    );
+  });
+
+  it.each(executors)(
+    'should rename "browserTarget" option in nx.json target defaults for a target with the "%s" executor',
+    async (executor) => {
+      updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+        json.targetDefaults ??= {};
+        json.targetDefaults.serve = {
+          executor,
+          options: { browserTarget: '{projectName}:serve' },
+          configurations: {
+            development: { browserTarget: '{projectName}:serve:development' },
+            production: { browserTarget: '{projectName}:serve:production' },
+          },
+        };
+        return json;
+      });
+
+      await migration(tree);
+
+      const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+      expect(nxJson.targetDefaults.serve.options.browserTarget).toBeUndefined();
+      expect(nxJson.targetDefaults.serve.options.buildTarget).toBe(
+        '{projectName}:serve'
+      );
+      expect(
+        nxJson.targetDefaults.serve.configurations.development.browserTarget
+      ).toBeUndefined();
+      expect(
+        nxJson.targetDefaults.serve.configurations.development.buildTarget
+      ).toBe('{projectName}:serve:development');
+      expect(
+        nxJson.targetDefaults.serve.configurations.production.browserTarget
+      ).toBeUndefined();
+      expect(
+        nxJson.targetDefaults.serve.configurations.production.buildTarget
+      ).toBe('{projectName}:serve:production');
+    }
+  );
+
+  it.each(executors)(
+    'should rename "browserTarget" option in nx.json target defaults for the "%s" executor',
+    async (executor) => {
+      updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+        json.targetDefaults ??= {};
+        json.targetDefaults[executor] = {
+          options: { browserTarget: '{projectName}:serve' },
+          configurations: {
+            development: { browserTarget: '{projectName}:serve:development' },
+            production: { browserTarget: '{projectName}:serve:production' },
+          },
+        };
+        return json;
+      });
+
+      await migration(tree);
+
+      const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+      expect(
+        nxJson.targetDefaults[executor].options.browserTarget
+      ).toBeUndefined();
+      expect(nxJson.targetDefaults[executor].options.buildTarget).toBe(
+        '{projectName}:serve'
+      );
+      expect(
+        nxJson.targetDefaults[executor].configurations.development.browserTarget
+      ).toBeUndefined();
+      expect(
+        nxJson.targetDefaults[executor].configurations.development.buildTarget
+      ).toBe('{projectName}:serve:development');
+      expect(
+        nxJson.targetDefaults[executor].configurations.production.browserTarget
+      ).toBeUndefined();
+      expect(
+        nxJson.targetDefaults[executor].configurations.production.buildTarget
+      ).toBe('{projectName}:serve:production');
+    }
+  );
+});

--- a/packages/angular/src/migrations/update-17-2-0/browser-target-to-build-target.ts
+++ b/packages/angular/src/migrations/update-17-2-0/browser-target-to-build-target.ts
@@ -1,0 +1,75 @@
+import {
+  formatFiles,
+  readJson,
+  readProjectConfiguration,
+  updateProjectConfiguration,
+  writeJson,
+  type NxJsonConfiguration,
+  type Tree,
+} from '@nx/devkit';
+import { forEachExecutorOptions } from '@nx/devkit/src/generators/executor-options-utils';
+
+export const executors = [
+  '@angular-devkit/build-angular:dev-server',
+  '@angular-devkit/build-angular:extract-i18n',
+  '@nx/angular:module-federation-dev-server',
+  '@nx/angular:webpack-dev-server',
+];
+
+export default async function (tree: Tree) {
+  executors.forEach((executor) => {
+    // update options from project configs
+    forEachExecutorOptions<{
+      browserTarget?: string;
+      buildTarget?: string;
+    }>(tree, executor, (_, project, target, configuration) => {
+      const projectConfiguration = readProjectConfiguration(tree, project);
+      const config = configuration
+        ? projectConfiguration.targets[target].configurations[configuration]
+        : projectConfiguration.targets[target].options;
+
+      updateConfig(config);
+
+      updateProjectConfiguration(tree, project, projectConfiguration);
+    });
+
+    // update options from nx.json target defaults
+    const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+    if (!nxJson.targetDefaults) {
+      return;
+    }
+
+    for (const [targetOrExecutor, targetConfig] of Object.entries(
+      nxJson.targetDefaults
+    )) {
+      if (
+        !executors.includes(targetOrExecutor) &&
+        !executors.includes(targetConfig.executor)
+      ) {
+        continue;
+      }
+
+      if (targetConfig.options) {
+        updateConfig(targetConfig.options);
+      }
+
+      Object.values(targetConfig.configurations ?? {}).forEach((config) => {
+        updateConfig(config);
+      });
+    }
+
+    writeJson(tree, 'nx.json', nxJson);
+  });
+
+  await formatFiles(tree);
+}
+
+function updateConfig(config: {
+  browserTarget?: string;
+  buildTarget?: string;
+}): void {
+  if (config.browserTarget) {
+    config.buildTarget ??= config.browserTarget;
+    delete config.browserTarget;
+  }
+}

--- a/packages/angular/src/migrations/update-17-2-0/browser-target-to-build-target.ts
+++ b/packages/angular/src/migrations/update-17-2-0/browser-target-to-build-target.ts
@@ -1,10 +1,9 @@
 import {
   formatFiles,
-  readJson,
+  readNxJson,
   readProjectConfiguration,
+  updateNxJson,
   updateProjectConfiguration,
-  writeJson,
-  type NxJsonConfiguration,
   type Tree,
 } from '@nx/devkit';
 import { forEachExecutorOptions } from '@nx/devkit/src/generators/executor-options-utils';
@@ -34,7 +33,7 @@ export default async function (tree: Tree) {
     });
 
     // update options from nx.json target defaults
-    const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+    const nxJson = readNxJson(tree);
     if (!nxJson.targetDefaults) {
       return;
     }
@@ -58,7 +57,7 @@ export default async function (tree: Tree) {
       });
     }
 
-    writeJson(tree, 'nx.json', nxJson);
+    updateNxJson(tree, nxJson);
   });
 
   await formatFiles(tree);


### PR DESCRIPTION
Deprecates the `browserTarget` option (deprecated in Angular v17) in favor of `buildTarget`.

Our executors will only expose the `buildTarget` option in Nx v18 and they internally normalize the option according to the Angular version (Nx v18 will still support versions of Angular expecting "browserTarget"). That way, we have a unified single option for our executors public APIs, while we ensure that it works with the versions of Angular we support.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
