### PR TITLE
feat(node): Allow none for @nx/node linter option

### DIFF
--- a/docs/generated/packages/node/generators/library.json
+++ b/docs/generated/packages/node/generators/library.json
@@ -41,7 +41,7 @@
       "linter": {
         "description": "The tool to use for running lint checks.",
         "type": "string",
-        "enum": ["eslint"],
+        "enum": ["eslint", "none"],
         "default": "eslint"
       },
       "unitTestRunner": {

--- a/packages/node/src/generators/library/schema.json
+++ b/packages/node/src/generators/library/schema.json
@@ -41,7 +41,7 @@
     "linter": {
       "description": "The tool to use for running lint checks.",
       "type": "string",
-      "enum": ["eslint"],
+      "enum": ["eslint", "none"],
       "default": "eslint"
     },
     "unitTestRunner": {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Eslint is required to be installed when generating a node library

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
There should be the option to skip using eslint in favor of other linters. The default however stays as eslint for a sane default.
