### PR TITLE
cleanup(angular): increase expected app bundle size threshold in e2e test

### DIFF
--- a/e2e/angular-core/src/projects.test.ts
+++ b/e2e/angular-core/src/projects.test.ts
@@ -97,7 +97,7 @@ describe('Angular Projects', () => {
     console.log(
       `The current es2015 bundle size is ${es2015BundleSize / 1000} KB`
     );
-    expect(es2015BundleSize).toBeLessThanOrEqual(210000);
+    expect(es2015BundleSize).toBeLessThanOrEqual(220000);
 
     // check unit tests
     runCLI(


### PR DESCRIPTION
Increase the expected bundle size threshold in e2e test. There's a slight increase in the bundle size with the new `application` builder (at least for the non-standalone default-generated app we use in the test). I confirmed this by comparing two Angular CLI apps generated with the latest and next versions.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
