### PR TITLE
fix(angular): allow numbers following a dash in application prefix

### DIFF
--- a/packages/angular/src/generators/utils/project.ts
+++ b/packages/angular/src/generators/utils/project.ts
@@ -10,14 +10,14 @@ export function normalizeNewProjectPrefix(
 ): string {
   // Prefix needs to be a valid html selector, if npmScope it's not valid, we don't default
   // to it and let it fall through to the Angular schematic to handle it
-  // https://github.com/angular/angular-cli/blob/1c634cd327e5a850553b258aa2d5e6a6b2c75c65/packages/schematics/angular/component/index.ts#L130
+  // https://github.com/angular/angular-cli/blob/aa9f0528f174e856a4923cb24861fdf6e6f96b48/packages/schematics/angular/component/index.ts#L64
   const htmlSelectorRegex =
-    /^[a-zA-Z][.0-9a-zA-Z]*(:?-[a-zA-Z][.0-9a-zA-Z]*)*$/;
+    /^[a-zA-Z][.0-9a-zA-Z]*((:?-[0-9]+)*|(:?-[a-zA-Z][.0-9a-zA-Z]*(:?-[0-9]+)*)*)$/;
 
   if (prefix) {
     if (!htmlSelectorRegex.test(prefix)) {
       throw new Error(
-        'The provided "prefix" is invalid. The prefix must start with a letter, and must contain only alphanumeric characters or dashes. When adding a dash the segment after the dash must also start with a letter.'
+        'The provided "prefix" is invalid. The prefix must start with a letter, and must contain only alphanumeric characters or dashes.'
       );
     }
 
@@ -33,7 +33,7 @@ There are two options that can be followed to resolve this issue:
 
 If you encountered this error when creating a new Nx Workspace, the workspace name or "npmScope" is invalid to use as the selector prefix for the application being generated.
 
-Valid selector prefixes must start with a letter, and must contain only alphanumeric characters or dashes. When adding a dash the segment after the dash must also start with a letter.`);
+Valid selector prefixes must start with a letter, and must contain only alphanumeric characters or dashes.`);
   }
 
   return npmScope || fallbackPrefix;


### PR DESCRIPTION
For reference: https://github.com/angular/angular-cli/commit/c5827d412f821727bbb8c6f885b35b717d607a82#diff-21e22640a309b86842754f526a37c110b6fefd87a11f0bec50f5921035489783

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
