### PR TITLE
feat(core): merge target configurations from plugin results

### DIFF
--- a/packages/nx/src/project-graph/utils/normalize-project-nodes.ts
+++ b/packages/nx/src/project-graph/utils/normalize-project-nodes.ts
@@ -114,7 +114,7 @@ export function normalizeProjectTargets(
     );
 
     if (defaults) {
-      targets[target] = mergeTargetConfigurations(project, target, defaults);
+      targets[target] = mergeTargetConfigurations(targets[target], defaults);
     }
 
     targets[target].options = resolveNxTokensInOptions(

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -9,451 +9,547 @@ import {
   readTargetDefaultsForTarget,
 } from './project-configuration-utils';
 
-describe('target defaults', () => {
-  const targetDefaults = {
-    'nx:run-commands': {
-      options: {
-        key: 'default-value-for-executor',
+describe('project-configuration-utils', () => {
+  describe('target defaults', () => {
+    const targetDefaults = {
+      'nx:run-commands': {
+        options: {
+          key: 'default-value-for-executor',
+        },
       },
-    },
-    build: {
-      options: {
-        key: 'default-value-for-targetname',
-      },
-    },
-  };
-
-  it('should prefer executor key', () => {
-    expect(
-      readTargetDefaultsForTarget(
-        'other-target',
-        targetDefaults,
-        'nx:run-commands'
-      ).options['key']
-    ).toEqual('default-value-for-executor');
-  });
-
-  it('should fallback to target key', () => {
-    expect(
-      readTargetDefaultsForTarget('build', targetDefaults, 'other-executor')
-        .options['key']
-    ).toEqual('default-value-for-targetname');
-  });
-
-  it('should return undefined if not found', () => {
-    expect(
-      readTargetDefaultsForTarget(
-        'other-target',
-        targetDefaults,
-        'other-executor'
-      )
-    ).toBeNull();
-  });
-
-  describe('options', () => {
-    it('should merge if executor matches', () => {
-      expect(
-        mergeTargetConfigurations(
-          {
-            root: '.',
-            targets: {
-              build: {
-                executor: 'target',
-                options: {
-                  a: 'project-value-a',
-                },
-              },
-            },
-          },
-          'build',
-          {
-            executor: 'target',
-            options: {
-              a: 'default-value-a',
-              b: 'default-value-b',
-            },
-          }
-        ).options
-      ).toEqual({ a: 'project-value-a', b: 'default-value-b' });
-    });
-
-    it('should merge if executor is only provided on the project', () => {
-      expect(
-        mergeTargetConfigurations(
-          {
-            root: '.',
-            targets: {
-              build: {
-                executor: 'target',
-                options: {
-                  a: 'project-value',
-                },
-              },
-            },
-          },
-          'build',
-          {
-            options: {
-              a: 'default-value',
-              b: 'default-value',
-            },
-          }
-        ).options
-      ).toEqual({ a: 'project-value', b: 'default-value' });
-    });
-
-    it('should merge if executor is only provided in the defaults', () => {
-      expect(
-        mergeTargetConfigurations(
-          {
-            root: '.',
-            targets: {
-              build: {
-                options: {
-                  a: 'project-value',
-                },
-              },
-            },
-          },
-          'build',
-          {
-            executor: 'target',
-            options: {
-              a: 'default-value',
-              b: 'default-value',
-            },
-          }
-        ).options
-      ).toEqual({ a: 'project-value', b: 'default-value' });
-    });
-
-    it('should not merge if executor is different', () => {
-      expect(
-        mergeTargetConfigurations(
-          {
-            root: '',
-            targets: {
-              build: {
-                executor: 'other',
-                options: {
-                  a: 'project-value',
-                },
-              },
-            },
-          },
-          'build',
-          {
-            executor: 'default-executor',
-            options: {
-              b: 'default-value',
-            },
-          }
-        ).options
-      ).toEqual({ a: 'project-value' });
-    });
-  });
-
-  describe('configurations', () => {
-    const projectConfigurations: TargetConfiguration['configurations'] = {
-      dev: {
-        foo: 'project-value-foo',
-      },
-      prod: {
-        bar: 'project-value-bar',
+      build: {
+        options: {
+          key: 'default-value-for-targetname',
+        },
       },
     };
 
-    const defaultConfigurations: TargetConfiguration['configurations'] = {
-      dev: {
-        foo: 'default-value-foo',
-        other: 'default-value-other',
-      },
-      baz: {
-        x: 'default-value-x',
-      },
-    };
-
-    const merged: TargetConfiguration['configurations'] = {
-      dev: {
-        foo: projectConfigurations.dev.foo,
-        other: defaultConfigurations.dev.other,
-      },
-      prod: { bar: projectConfigurations.prod.bar },
-      baz: { x: defaultConfigurations.baz.x },
-    };
-
-    it('should merge configurations if executor matches', () => {
+    it('should prefer executor key', () => {
       expect(
-        mergeTargetConfigurations(
-          {
-            root: '.',
-            targets: {
-              build: {
-                executor: 'target',
-                configurations: projectConfigurations,
-              },
-            },
-          },
-          'build',
-          {
-            executor: 'target',
-            configurations: defaultConfigurations,
-          }
-        ).configurations
-      ).toEqual(merged);
+        readTargetDefaultsForTarget(
+          'other-target',
+          targetDefaults,
+          'nx:run-commands'
+        ).options['key']
+      ).toEqual('default-value-for-executor');
     });
 
-    it('should merge if executor is only provided on the project', () => {
+    it('should fallback to target key', () => {
       expect(
-        mergeTargetConfigurations(
-          {
-            root: '.',
-            targets: {
-              build: {
-                executor: 'target',
-                configurations: projectConfigurations,
-              },
-            },
-          },
-          'build',
-          {
-            configurations: defaultConfigurations,
-          }
-        ).configurations
-      ).toEqual(merged);
+        readTargetDefaultsForTarget('build', targetDefaults, 'other-executor')
+          .options['key']
+      ).toEqual('default-value-for-targetname');
     });
 
-    it('should merge if executor is only provided in the defaults', () => {
+    it('should return undefined if not found', () => {
       expect(
-        mergeTargetConfigurations(
-          {
-            root: '.',
-            targets: {
-              build: {
-                configurations: projectConfigurations,
-              },
-            },
-          },
-          'build',
-          {
-            executor: 'target',
-            configurations: defaultConfigurations,
-          }
-        ).configurations
-      ).toEqual(merged);
+        readTargetDefaultsForTarget(
+          'other-target',
+          targetDefaults,
+          'other-executor'
+        )
+      ).toBeNull();
     });
 
-    it('should not merge if executor doesnt match', () => {
-      expect(
-        mergeTargetConfigurations(
-          {
-            root: '',
-            targets: {
-              build: {
-                executor: 'other',
-                configurations: projectConfigurations,
+    describe('options', () => {
+      it('should merge if executor matches', () => {
+        expect(
+          mergeTargetConfigurations(
+            {
+              executor: 'target',
+              options: {
+                a: 'project-value-a',
               },
             },
-          },
-          'build',
-          {
-            executor: 'target',
-            configurations: defaultConfigurations,
-          }
-        ).configurations
-      ).toEqual(projectConfigurations);
+            {
+              executor: 'target',
+              options: {
+                a: 'default-value-a',
+                b: 'default-value-b',
+              },
+            }
+          ).options
+        ).toEqual({ a: 'project-value-a', b: 'default-value-b' });
+      });
+
+      it('should merge if executor is only provided on the project', () => {
+        expect(
+          mergeTargetConfigurations(
+            {
+              executor: 'target',
+              options: {
+                a: 'project-value',
+              },
+            },
+            {
+              options: {
+                a: 'default-value',
+                b: 'default-value',
+              },
+            }
+          ).options
+        ).toEqual({ a: 'project-value', b: 'default-value' });
+      });
+
+      it('should merge if executor is only provided in the defaults', () => {
+        expect(
+          mergeTargetConfigurations(
+            {
+              options: {
+                a: 'project-value',
+              },
+            },
+            {
+              executor: 'target',
+              options: {
+                a: 'default-value',
+                b: 'default-value',
+              },
+            }
+          ).options
+        ).toEqual({ a: 'project-value', b: 'default-value' });
+      });
+
+      it('should not merge if executor is different', () => {
+        expect(
+          mergeTargetConfigurations(
+            {
+              executor: 'other',
+              options: {
+                a: 'project-value',
+              },
+            },
+            {
+              executor: 'default-executor',
+              options: {
+                b: 'default-value',
+              },
+            }
+          ).options
+        ).toEqual({ a: 'project-value' });
+      });
+    });
+
+    describe('configurations', () => {
+      const projectConfigurations: TargetConfiguration['configurations'] = {
+        dev: {
+          foo: 'project-value-foo',
+        },
+        prod: {
+          bar: 'project-value-bar',
+        },
+      };
+
+      const defaultConfigurations: TargetConfiguration['configurations'] = {
+        dev: {
+          foo: 'default-value-foo',
+          other: 'default-value-other',
+        },
+        baz: {
+          x: 'default-value-x',
+        },
+      };
+
+      const merged: TargetConfiguration['configurations'] = {
+        dev: {
+          foo: projectConfigurations.dev.foo,
+          other: defaultConfigurations.dev.other,
+        },
+        prod: { bar: projectConfigurations.prod.bar },
+        baz: { x: defaultConfigurations.baz.x },
+      };
+
+      it('should merge configurations if executor matches', () => {
+        expect(
+          mergeTargetConfigurations(
+            {
+              executor: 'target',
+              configurations: projectConfigurations,
+            },
+            {
+              executor: 'target',
+              configurations: defaultConfigurations,
+            }
+          ).configurations
+        ).toEqual(merged);
+      });
+
+      it('should merge if executor is only provided on the project', () => {
+        expect(
+          mergeTargetConfigurations(
+            {
+              executor: 'target',
+              configurations: projectConfigurations,
+            },
+            {
+              configurations: defaultConfigurations,
+            }
+          ).configurations
+        ).toEqual(merged);
+      });
+
+      it('should merge if executor is only provided in the defaults', () => {
+        expect(
+          mergeTargetConfigurations(
+            {
+              configurations: projectConfigurations,
+            },
+            {
+              executor: 'target',
+              configurations: defaultConfigurations,
+            }
+          ).configurations
+        ).toEqual(merged);
+      });
+
+      it('should not merge if executor doesnt match', () => {
+        expect(
+          mergeTargetConfigurations(
+            {
+              executor: 'other',
+              configurations: projectConfigurations,
+            },
+            {
+              executor: 'target',
+              configurations: defaultConfigurations,
+            }
+          ).configurations
+        ).toEqual(projectConfigurations);
+      });
+    });
+
+    describe('defaultConfiguration', () => {
+      const projectDefaultConfiguration: TargetConfiguration['defaultConfiguration'] =
+        'dev';
+      const defaultDefaultConfiguration: TargetConfiguration['defaultConfiguration'] =
+        'prod';
+
+      const merged: TargetConfiguration['defaultConfiguration'] =
+        projectDefaultConfiguration;
+
+      it('should merge defaultConfiguration if executor matches', () => {
+        expect(
+          mergeTargetConfigurations(
+            {
+              executor: 'target',
+              defaultConfiguration: projectDefaultConfiguration,
+            },
+            {
+              executor: 'target',
+              defaultConfiguration: defaultDefaultConfiguration,
+            }
+          ).defaultConfiguration
+        ).toEqual(merged);
+      });
+
+      it('should merge if executor is only provided on the project', () => {
+        expect(
+          mergeTargetConfigurations(
+            {
+              executor: 'target',
+              defaultConfiguration: projectDefaultConfiguration,
+            },
+            {
+              defaultConfiguration: defaultDefaultConfiguration,
+            }
+          ).defaultConfiguration
+        ).toEqual(merged);
+      });
+
+      it('should merge if executor is only provided in the defaults', () => {
+        expect(
+          mergeTargetConfigurations(
+            {
+              defaultConfiguration: projectDefaultConfiguration,
+            },
+            {
+              executor: 'target',
+              defaultConfiguration: defaultDefaultConfiguration,
+            }
+          ).defaultConfiguration
+        ).toEqual(merged);
+      });
+
+      it('should not merge if executor doesnt match', () => {
+        expect(
+          mergeTargetConfigurations(
+            {
+              executor: 'other',
+              defaultConfiguration: projectDefaultConfiguration,
+            },
+            {
+              executor: 'target',
+              defaultConfiguration: defaultDefaultConfiguration,
+            }
+          ).defaultConfiguration
+        ).toEqual(projectDefaultConfiguration);
+      });
     });
   });
 
-  describe('defaultConfiguration', () => {
-    const projectDefaultConfiguration: TargetConfiguration['defaultConfiguration'] =
-      'dev';
-    const defaultDefaultConfiguration: TargetConfiguration['defaultConfiguration'] =
-      'prod';
-
-    const merged: TargetConfiguration['defaultConfiguration'] =
-      projectDefaultConfiguration;
-
-    it('should merge defaultConfiguration if executor matches', () => {
-      expect(
-        mergeTargetConfigurations(
-          {
-            root: '.',
-            targets: {
-              build: {
-                executor: 'target',
-                defaultConfiguration: projectDefaultConfiguration,
-              },
+  describe('mergeProjectConfigurationIntoRootMap', () => {
+    it('should merge targets from different configurations', () => {
+      const rootMap = new RootMapBuilder()
+        .addProject({
+          root: 'libs/lib-a',
+          name: 'lib-a',
+          targets: {
+            echo: {
+              command: 'echo lib-a',
             },
           },
-          'build',
-          {
-            executor: 'target',
-            defaultConfiguration: defaultDefaultConfiguration,
-          }
-        ).defaultConfiguration
-      ).toEqual(merged);
-    });
-
-    it('should merge if executor is only provided on the project', () => {
-      expect(
-        mergeTargetConfigurations(
-          {
-            root: '.',
-            targets: {
-              build: {
-                executor: 'target',
-                defaultConfiguration: projectDefaultConfiguration,
-              },
-            },
-          },
-          'build',
-          {
-            defaultConfiguration: defaultDefaultConfiguration,
-          }
-        ).defaultConfiguration
-      ).toEqual(merged);
-    });
-
-    it('should merge if executor is only provided in the defaults', () => {
-      expect(
-        mergeTargetConfigurations(
-          {
-            root: '.',
-            targets: {
-              build: {
-                defaultConfiguration: projectDefaultConfiguration,
-              },
-            },
-          },
-          'build',
-          {
-            executor: 'target',
-            defaultConfiguration: defaultDefaultConfiguration,
-          }
-        ).defaultConfiguration
-      ).toEqual(merged);
-    });
-
-    it('should not merge if executor doesnt match', () => {
-      expect(
-        mergeTargetConfigurations(
-          {
-            root: '',
-            targets: {
-              build: {
-                executor: 'other',
-                defaultConfiguration: projectDefaultConfiguration,
-              },
-            },
-          },
-          'build',
-          {
-            executor: 'target',
-            defaultConfiguration: defaultDefaultConfiguration,
-          }
-        ).defaultConfiguration
-      ).toEqual(projectDefaultConfiguration);
-    });
-  });
-});
-
-describe('mergeProjectConfigurationIntoRootMap', () => {
-  it('should merge targets from different configurations', () => {
-    const rootMap = new RootMapBuilder()
-      .addProject({
+        })
+        .getRootMap();
+      mergeProjectConfigurationIntoRootMap(rootMap, {
         root: 'libs/lib-a',
         name: 'lib-a',
         targets: {
-          echo: {
-            command: 'echo lib-a',
+          build: {
+            command: 'tsc',
           },
         },
-      })
-      .getRootMap();
-    mergeProjectConfigurationIntoRootMap(rootMap, {
-      root: 'libs/lib-a',
-      name: 'lib-a',
-      targets: {
-        build: {
-          command: 'tsc',
-        },
-      },
-    });
-    expect(rootMap.get('libs/lib-a')).toMatchInlineSnapshot(`
-      {
-        "name": "lib-a",
-        "root": "libs/lib-a",
-        "targets": {
-          "build": {
-            "command": "tsc",
-          },
-          "echo": {
-            "command": "echo lib-a",
-          },
-        },
-      }
-    `);
-  });
-});
-
-describe('readProjectsConfigurationsFromRootMap', () => {
-  it('should error if multiple roots point to the same project', () => {
-    const rootMap = new RootMapBuilder()
-      .addProject({
-        name: 'lib',
-        root: 'apps/lib-a',
-      })
-      .addProject({
-        name: 'lib',
-        root: 'apps/lib-b',
-      })
-      .getRootMap();
-
-    expect(() => {
-      readProjectConfigurationsFromRootMap(rootMap);
-    }).toThrowErrorMatchingInlineSnapshot(`
-      "The following projects are defined in multiple locations:
-      - lib: 
-        - apps/lib-a
-        - apps/lib-b
-
-      To fix this, set a unique name for each project in a project.json inside the project's root. If the project does not currently have a project.json, you can create one that contains only a name."
-    `);
-  });
-
-  it('should read root map into standard projects configurations form', () => {
-    const rootMap = new RootMapBuilder()
-      .addProject({
-        name: 'lib-a',
-        root: 'libs/a',
-      })
-      .addProject({
-        name: 'lib-b',
-        root: 'libs/b',
-      })
-      .addProject({
-        name: 'lib-shared-b',
-        root: 'libs/shared/b',
-      })
-      .getRootMap();
-    expect(readProjectConfigurationsFromRootMap(rootMap))
-      .toMatchInlineSnapshot(`
-      {
-        "lib-a": {
+      });
+      expect(rootMap.get('libs/lib-a')).toMatchInlineSnapshot(`
+        {
           "name": "lib-a",
-          "root": "libs/a",
+          "root": "libs/lib-a",
+          "targets": {
+            "build": {
+              "command": "tsc",
+            },
+            "echo": {
+              "command": "echo lib-a",
+            },
+          },
+        }
+      `);
+    });
+
+    // Target configuration merging is tested more thoroughly in mergeTargetConfigurations
+    it('should merge target configurations of compatible target declarations', () => {
+      const existingTargetConfiguration = {
+        command: 'already present',
+      };
+      const shouldMergeConfigurationA = {
+        executor: 'build',
+        options: {
+          a: 1,
+          b: {
+            c: 2,
+          },
         },
-        "lib-b": {
-          "name": "lib-b",
-          "root": "libs/b",
+        configurations: {
+          dev: {
+            foo: 'bar',
+          },
+          prod: {
+            optimize: true,
+          },
         },
-        "lib-shared-b": {
-          "name": "lib-shared-b",
-          "root": "libs/shared/b",
+      };
+      const shouldMergeConfigurationB = {
+        executor: 'build',
+        options: {
+          d: 3,
+          b: {
+            c: 2,
+          },
         },
-      }
-    `);
+        configurations: {
+          prod: {
+            foo: 'baz',
+          },
+        },
+      };
+      const shouldntMergeConfigurationA = {
+        executor: 'build',
+        options: {
+          a: 1,
+        },
+      };
+      const shouldntMergeConfigurationB = {
+        executor: 'test',
+        options: {
+          test: 1,
+        },
+      };
+      const newTargetConfiguration = {
+        executor: 'echo',
+        options: {
+          echo: 'echo',
+        },
+      };
+
+      const rootMap = new RootMapBuilder()
+        .addProject({
+          root: 'libs/lib-a',
+          name: 'lib-a',
+          targets: {
+            existingTarget: existingTargetConfiguration,
+            shouldMerge: shouldMergeConfigurationA,
+            shouldntMerge: shouldntMergeConfigurationA,
+          },
+        })
+        .getRootMap();
+      mergeProjectConfigurationIntoRootMap(rootMap, {
+        root: 'libs/lib-a',
+        name: 'lib-a',
+        targets: {
+          shouldMerge: shouldMergeConfigurationB,
+          shouldntMerge: shouldntMergeConfigurationB,
+          newTarget: newTargetConfiguration,
+        },
+      });
+      const merged = rootMap.get('libs/lib-a');
+      expect(merged.targets['existingTarget']).toEqual(
+        existingTargetConfiguration
+      );
+      expect(merged.targets['shouldMerge']).toMatchInlineSnapshot(`
+        {
+          "configurations": {
+            "dev": {
+              "foo": "bar",
+            },
+            "prod": {
+              "foo": "baz",
+              "optimize": true,
+            },
+          },
+          "executor": "build",
+          "options": {
+            "a": 1,
+            "b": {
+              "c": 2,
+            },
+            "d": 3,
+          },
+        }
+      `);
+      expect(merged.targets['shouldntMerge']).toEqual(
+        shouldntMergeConfigurationB
+      );
+      expect(merged.targets['newTarget']).toEqual(newTargetConfiguration);
+    });
+
+    it('should concatenate tags', () => {
+      const rootMap = new RootMapBuilder()
+        .addProject({
+          root: 'libs/lib-a',
+          name: 'lib-a',
+          tags: ['a', 'b'],
+          implicitDependencies: ['lib-b'],
+        })
+        .getRootMap();
+      mergeProjectConfigurationIntoRootMap(rootMap, {
+        root: 'libs/lib-a',
+        name: 'lib-a',
+        tags: ['b', 'c'],
+        implicitDependencies: ['lib-c', '!lib-b'],
+      });
+      expect(rootMap.get('libs/lib-a').tags).toEqual(['a', 'b', 'c']);
+      expect(rootMap.get('libs/lib-a').implicitDependencies).toEqual([
+        'lib-b',
+        'lib-c',
+        '!lib-b',
+      ]);
+    });
+
+    it('should merge generator options', () => {
+      const rootMap = new RootMapBuilder()
+        .addProject({
+          root: 'libs/lib-a',
+          name: 'lib-a',
+          generators: {
+            '@nx/angular:component': {
+              style: 'scss',
+            },
+          },
+        })
+        .getRootMap();
+      mergeProjectConfigurationIntoRootMap(rootMap, {
+        root: 'libs/lib-a',
+        name: 'lib-a',
+        generators: {
+          '@nx/angular:component': {
+            flat: true,
+          },
+          '@nx/angular:service': {
+            spec: false,
+          },
+        },
+      });
+      expect(rootMap.get('libs/lib-a').generators).toMatchInlineSnapshot(`
+        {
+          "@nx/angular:component": {
+            "flat": true,
+            "style": "scss",
+          },
+          "@nx/angular:service": {
+            "spec": false,
+          },
+        }
+      `);
+    });
+  });
+
+  describe('readProjectsConfigurationsFromRootMap', () => {
+    it('should error if multiple roots point to the same project', () => {
+      const rootMap = new RootMapBuilder()
+        .addProject({
+          name: 'lib',
+          root: 'apps/lib-a',
+        })
+        .addProject({
+          name: 'lib',
+          root: 'apps/lib-b',
+        })
+        .getRootMap();
+
+      expect(() => {
+        readProjectConfigurationsFromRootMap(rootMap);
+      }).toThrowErrorMatchingInlineSnapshot(`
+        "The following projects are defined in multiple locations:
+        - lib: 
+          - apps/lib-a
+          - apps/lib-b
+
+        To fix this, set a unique name for each project in a project.json inside the project's root. If the project does not currently have a project.json, you can create one that contains only a name."
+      `);
+    });
+
+    it('should read root map into standard projects configurations form', () => {
+      const rootMap = new RootMapBuilder()
+        .addProject({
+          name: 'lib-a',
+          root: 'libs/a',
+        })
+        .addProject({
+          name: 'lib-b',
+          root: 'libs/b',
+        })
+        .addProject({
+          name: 'lib-shared-b',
+          root: 'libs/shared/b',
+        })
+        .getRootMap();
+      expect(readProjectConfigurationsFromRootMap(rootMap))
+        .toMatchInlineSnapshot(`
+        {
+          "lib-a": {
+            "name": "lib-a",
+            "root": "libs/a",
+          },
+          "lib-b": {
+            "name": "lib-b",
+            "root": "libs/b",
+          },
+          "lib-shared-b": {
+            "name": "lib-shared-b",
+            "root": "libs/shared/b",
+          },
+        }
+      `);
+    });
   });
 });
 

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -33,8 +33,8 @@ export function mergeProjectConfigurationIntoRootMap(
 
   // The next blocks handle properties that should be themselves merged (e.g. targets, tags, and implicit dependencies)
   if (project.tags && matchingProject.tags) {
-    updatedProjectConfiguration.tags = matchingProject.tags.concat(
-      project.tags
+    updatedProjectConfiguration.tags = Array.from(
+      new Set(matchingProject.tags.concat(project.tags))
     );
   }
 
@@ -44,10 +44,17 @@ export function mergeProjectConfigurationIntoRootMap(
   }
 
   if (project.generators && matchingProject.generators) {
-    updatedProjectConfiguration.generators = {
-      ...matchingProject.generators,
-      ...project.generators,
-    };
+    // Start with generators config in new project.
+    updatedProjectConfiguration.generators = { ...project.generators };
+
+    // For each generator that was already defined, shallow merge the options.
+    // Project contains the new info, so it has higher priority.
+    for (const generator in matchingProject.generators) {
+      updatedProjectConfiguration.generators[generator] = {
+        ...matchingProject.generators[generator],
+        ...project.generators[generator],
+      };
+    }
   }
 
   if (project.targets && matchingProject.targets) {
@@ -55,6 +62,17 @@ export function mergeProjectConfigurationIntoRootMap(
       ...matchingProject.targets,
       ...project.targets,
     };
+    for (const target in matchingProject.targets) {
+      if (target in matchingProject.targets && target in project.targets) {
+        // If the target is defined in both places, merge the options
+        // Project contains the new info, so it has higher priority.
+        // Options from matchingProject are used as defaults.
+        updatedProjectConfiguration.targets[target] = mergeTargetConfigurations(
+          project.targets[target],
+          matchingProject.targets[target]
+        );
+      }
+    }
   }
 
   projectRootMap.set(
@@ -144,43 +162,51 @@ export function readProjectConfigurationsFromRootMap(
   return projects;
 }
 
+/**
+ * Merges two configurations for a target.
+ *
+ * Most properties from `target` will overwrite any properties from `baseTarget`.
+ * Options and configurations are treated differently - they are merged together if the executor definition is compatible.
+ *
+ * @param target The configuration for the target with higher priority
+ * @param baseTarget The configuration for the target that should be overwritten.
+ * @returns A merged target configuration
+ */
 export function mergeTargetConfigurations(
-  projectConfiguration: ProjectConfiguration,
-  target: string,
-  targetDefaults: TargetDefaults[string]
+  target: TargetConfiguration,
+  baseTarget: TargetConfiguration
 ): TargetConfiguration {
-  const targetConfiguration = projectConfiguration.targets?.[target];
-
-  if (!targetConfiguration) {
-    throw new Error(
-      `Attempted to merge targetDefaults for ${projectConfiguration.name}.${target}, which doesn't exist.`
-    );
-  }
-
   const {
     configurations: defaultConfigurations,
     options: defaultOptions,
     ...defaults
-  } = targetDefaults;
+  } = baseTarget;
   const result = {
     ...defaults,
-    ...targetConfiguration,
+    ...target,
   };
 
   // Target is "compatible", e.g. executor is defined only once or is the same
   // in both places. This means that it is likely safe to merge options
-  if (
-    !targetDefaults.executor ||
-    !targetConfiguration.executor ||
-    targetDefaults.executor === targetConfiguration.executor
-  ) {
-    result.options = { ...defaultOptions, ...targetConfiguration?.options };
+  if (isCompatibleTarget(defaults, target)) {
+    result.options = { ...defaultOptions, ...target?.options };
     result.configurations = mergeConfigurations(
       defaultConfigurations,
-      targetConfiguration.configurations
+      target.configurations
     );
   }
   return result as TargetConfiguration;
+}
+
+/**
+ * Checks if targets options are compatible - used when merging configurations
+ * to avoid merging options for @nx/js:tsc into something like @nx/webpack:webpack.
+ *
+ * If the executors are both specified and don't match, the options aren't considered
+ * "compatible" and shouldn't be merged.
+ */
+function isCompatibleTarget(a: TargetConfiguration, b: TargetConfiguration) {
+  return !a.executor || !b.executor || a.executor === b.executor;
 }
 
 function mergeConfigurations<T extends Object>(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
If multiple plugins identify the same target on the same project, whichever plugin identified the target last "wins", in that it completely overwrites the already present target.

Since `project.json` is implemented as a plugin, this means the configuration inside `project.json` overwrites the full target block that was identified by any plugin.

## Expected Behavior
If the already identified target, and the newly found target are "compatible (either only 1 specifies executor, or the executor matches), then we can merge the target configurations.

This enables overwriting 1 or 2 properties in the `project.json`, while inference takes care of the rest.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
