### PR TITLE
feat(angular): generate applications with the esbuild-based application builder

### DIFF
--- a/docs/generated/packages/angular/generators/application.json
+++ b/docs/generated/packages/angular/generators/application.json
@@ -169,10 +169,12 @@
         "default": false
       },
       "bundler": {
-        "description": "Bundler to use to build the application.",
+        "description": "Bundler to use to build the application. _Note: The `esbuild` bundler is only considered stable from Angular v17._",
         "type": "string",
         "enum": ["webpack", "esbuild"],
-        "default": "webpack"
+        "default": "esbuild",
+        "x-prompt": "Which bundler do you want to use to build the application?",
+        "x-priority": "important"
       }
     },
     "additionalProperties": false,

--- a/e2e/angular-core/src/module-federation.test.ts
+++ b/e2e/angular-core/src/module-federation.test.ts
@@ -157,10 +157,10 @@ describe('Angular Module Federation', () => {
 
     // generate apps
     runCLI(
-      `generate @nx/angular:application ${app1} --routing --project-name-and-root-format=as-provided --no-interactive`
+      `generate @nx/angular:application ${app1} --routing --bundler=webpack --project-name-and-root-format=as-provided --no-interactive`
     );
     runCLI(
-      `generate @nx/angular:application ${app2} --project-name-and-root-format=as-provided --no-interactive`
+      `generate @nx/angular:application ${app2} --bundler=webpack --project-name-and-root-format=as-provided --no-interactive`
     );
 
     // convert apps

--- a/e2e/angular-core/src/projects.test.ts
+++ b/e2e/angular-core/src/projects.test.ts
@@ -28,7 +28,7 @@ describe('Angular Projects', () => {
   beforeAll(() => {
     proj = newProject();
     runCLI(
-      `generate @nx/angular:app ${app1} --no-standalone --project-name-and-root-format=as-provided --no-interactive`
+      `generate @nx/angular:app ${app1} --no-standalone --bundler=webpack --project-name-and-root-format=as-provided --no-interactive`
     );
     runCLI(
       `generate @nx/angular:lib ${lib1} --no-standalone --add-module-spec --project-name-and-root-format=as-provided --no-interactive`
@@ -52,7 +52,7 @@ describe('Angular Projects', () => {
   it('should successfully generate apps and libs and work correctly', async () => {
     const standaloneApp = uniq('standalone-app');
     runCLI(
-      `generate @nx/angular:app ${standaloneApp} --directory=my-dir/${standaloneApp} --project-name-and-root-format=as-provided --no-interactive`
+      `generate @nx/angular:app ${standaloneApp} --directory=my-dir/${standaloneApp} --bundler=webpack --project-name-and-root-format=as-provided --no-interactive`
     );
 
     const esbuildApp = uniq('esbuild-app');
@@ -90,7 +90,7 @@ describe('Angular Projects', () => {
     );
     checkFilesExist(`dist/${app1}/main.js`);
     checkFilesExist(`dist/my-dir/${standaloneApp}/main.js`);
-    checkFilesExist(`dist/my-dir/${esbuildApp}/main.js`);
+    checkFilesExist(`dist/my-dir/${esbuildApp}/browser/main.js`);
     // This is a loose requirement because there are a lot of
     // influences external from this project that affect this.
     const es2015BundleSize = getSize(tmpProjPath(`dist/${app1}/main.js`));
@@ -299,6 +299,9 @@ describe('Angular Projects', () => {
       config.targets.build.executor = '@nx/angular:browser-esbuild';
       config.targets.build.options = {
         ...config.targets.build.options,
+        outputPath: `dist/${esbuildApp}`,
+        main: config.targets.build.options.browser,
+        browser: undefined,
         buildLibsFromSource: false,
       };
       return config;

--- a/e2e/angular-extensions/src/cypress-component-tests.test.ts
+++ b/e2e/angular-extensions/src/cypress-component-tests.test.ts
@@ -130,7 +130,7 @@ describe('Angular Cypress Component Tests', () => {
 
 function createApp(appName: string) {
   runCLI(
-    `generate @nx/angular:app ${appName} --project-name-and-root-format=as-provided --no-interactive`
+    `generate @nx/angular:app ${appName} --bundler=webpack --project-name-and-root-format=as-provided --no-interactive`
   );
   runCLI(
     `generate @nx/angular:component fancy-component --project=${appName} --no-interactive`

--- a/e2e/angular-extensions/src/ngrx.test.ts
+++ b/e2e/angular-extensions/src/ngrx.test.ts
@@ -43,7 +43,7 @@ describe('Angular Package', () => {
         `generate @nx/angular:ngrx flights --parent=${mylib}/src/lib/${mylib}.module.ts --facade`
       );
 
-      expect(runCLI(`build ${myapp}`)).toMatch(/main\.[a-z0-9]+\.js/);
+      expect(runCLI(`build ${myapp}`)).toMatch(/main-[a-zA-Z0-9]+\.js/);
       expectTestsPass(await runCLIAsync(`test ${myapp} --no-watch`));
       // TODO: remove this condition
       if (getSelectedPackageManager() !== 'pnpm') {
@@ -80,7 +80,7 @@ describe('Angular Package', () => {
         `generate @nx/angular:ngrx flights --parent=${mylib}/src/lib/${mylib}.module.ts ${flags}`
       );
 
-      expect(runCLI(`build ${myapp}`)).toMatch(/main\.[a-z0-9]+\.js/);
+      expect(runCLI(`build ${myapp}`)).toMatch(/main-[a-zA-Z0-9]+\.js/);
       expectTestsPass(await runCLIAsync(`test ${myapp} --no-watch`));
       // TODO: remove this condition
       if (getSelectedPackageManager() !== 'pnpm') {
@@ -117,7 +117,7 @@ describe('Angular Package', () => {
         `generate @nx/angular:ngrx flights --module=${mylib}/src/lib/${mylib}.module.ts ${flags}`
       );
 
-      expect(runCLI(`build ${myapp}`)).toMatch(/main\.[a-z0-9]+\.js/);
+      expect(runCLI(`build ${myapp}`)).toMatch(/main-[a-zA-Z0-9]+\.js/);
       expectTestsPass(await runCLIAsync(`test ${myapp} --no-watch`));
       // TODO: remove this condition
       if (getSelectedPackageManager() !== 'pnpm') {

--- a/e2e/cypress/src/cypress.test.ts
+++ b/e2e/cypress/src/cypress.test.ts
@@ -187,7 +187,9 @@ async function testCtAndE2eInProject(
 ) {
   let appName = uniq(`${projectType}-cy-app`);
   runCLI(
-    `generate @nx/${projectType}:app ${appName} --e2eTestRunner=none --no-interactive`
+    `generate @nx/${projectType}:app ${appName} --e2eTestRunner=none --no-interactive ${
+      projectType === 'angular' ? '--bundler=webpack' : ''
+    }`
   );
   runCLI(
     `generate @nx/${projectType}:component btn --project=${appName} --no-interactive`

--- a/e2e/workspace-create/src/create-nx-workspace.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace.test.ts
@@ -32,6 +32,7 @@ describe('create-nx-workspace', () => {
       standaloneApi: false,
       routing: false,
       e2eTestRunner: 'none',
+      bundler: 'webpack',
     });
 
     checkFilesExist('package.json');
@@ -52,6 +53,7 @@ describe('create-nx-workspace', () => {
       standaloneApi: true,
       routing: true,
       e2eTestRunner: 'none',
+      bundler: 'webpack',
     });
 
     checkFilesExist('package.json');
@@ -144,6 +146,7 @@ describe('create-nx-workspace', () => {
       standaloneApi: false,
       routing: true,
       e2eTestRunner: 'none',
+      bundler: 'webpack',
     });
     expectCodeIsFormatted();
   });
@@ -163,6 +166,7 @@ describe('create-nx-workspace', () => {
         standaloneApi: false,
         routing: false,
         e2eTestRunner: 'none',
+        bundler: 'webpack',
       })
     ).toThrow();
   });

--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -219,12 +219,9 @@ exports[`app --project-name-and-root-format=derived should generate correctly wh
     "build": {
       "configurations": {
         "development": {
-          "buildOptimizer": false,
           "extractLicenses": false,
-          "namedChunks": true,
           "optimization": false,
           "sourceMap": true,
-          "vendorChunk": true,
         },
         "production": {
           "budgets": [
@@ -243,14 +240,14 @@ exports[`app --project-name-and-root-format=derived should generate correctly wh
         },
       },
       "defaultConfiguration": "production",
-      "executor": "@angular-devkit/build-angular:browser",
+      "executor": "@angular-devkit/build-angular:application",
       "options": {
         "assets": [
           "apps/my-dir/my-app/src/favicon.ico",
           "apps/my-dir/my-app/src/assets",
         ],
+        "browser": "apps/my-dir/my-app/src/main.ts",
         "index": "apps/my-dir/my-app/src/index.html",
-        "main": "apps/my-dir/my-app/src/main.ts",
         "outputPath": "dist/apps/my-dir/my-app",
         "polyfills": [
           "zone.js",
@@ -463,12 +460,9 @@ exports[`app --project-name-and-root-format=derived should generate correctly wh
     "build": {
       "configurations": {
         "development": {
-          "buildOptimizer": false,
           "extractLicenses": false,
-          "namedChunks": true,
           "optimization": false,
           "sourceMap": true,
-          "vendorChunk": true,
         },
         "production": {
           "budgets": [
@@ -487,14 +481,14 @@ exports[`app --project-name-and-root-format=derived should generate correctly wh
         },
       },
       "defaultConfiguration": "production",
-      "executor": "@angular-devkit/build-angular:browser",
+      "executor": "@angular-devkit/build-angular:application",
       "options": {
         "assets": [
           "apps/my-app/src/favicon.ico",
           "apps/my-app/src/assets",
         ],
+        "browser": "apps/my-app/src/main.ts",
         "index": "apps/my-app/src/index.html",
-        "main": "apps/my-app/src/main.ts",
         "outputPath": "dist/apps/my-app",
         "polyfills": [
           "zone.js",
@@ -936,12 +930,9 @@ exports[`app nested should create project configs 1`] = `
     "build": {
       "configurations": {
         "development": {
-          "buildOptimizer": false,
           "extractLicenses": false,
-          "namedChunks": true,
           "optimization": false,
           "sourceMap": true,
-          "vendorChunk": true,
         },
         "production": {
           "budgets": [
@@ -960,14 +951,14 @@ exports[`app nested should create project configs 1`] = `
         },
       },
       "defaultConfiguration": "production",
-      "executor": "@angular-devkit/build-angular:browser",
+      "executor": "@angular-devkit/build-angular:application",
       "options": {
         "assets": [
           "my-dir/my-app/src/favicon.ico",
           "my-dir/my-app/src/assets",
         ],
+        "browser": "my-dir/my-app/src/main.ts",
         "index": "my-dir/my-app/src/index.html",
-        "main": "my-dir/my-app/src/main.ts",
         "outputPath": "dist/my-dir/my-app",
         "polyfills": [
           "zone.js",
@@ -1094,12 +1085,9 @@ exports[`app not nested should create project configs 1`] = `
     "build": {
       "configurations": {
         "development": {
-          "buildOptimizer": false,
           "extractLicenses": false,
-          "namedChunks": true,
           "optimization": false,
           "sourceMap": true,
-          "vendorChunk": true,
         },
         "production": {
           "budgets": [
@@ -1118,14 +1106,14 @@ exports[`app not nested should create project configs 1`] = `
         },
       },
       "defaultConfiguration": "production",
-      "executor": "@angular-devkit/build-angular:browser",
+      "executor": "@angular-devkit/build-angular:application",
       "options": {
         "assets": [
           "my-app/src/favicon.ico",
           "my-app/src/assets",
         ],
+        "browser": "my-app/src/main.ts",
         "index": "my-app/src/index.html",
-        "main": "my-app/src/main.ts",
         "outputPath": "dist/my-app",
         "polyfills": [
           "zone.js",

--- a/packages/angular/src/generators/application/lib/normalize-options.ts
+++ b/packages/angular/src/generators/application/lib/normalize-options.ts
@@ -51,14 +51,15 @@ export async function normalizeOptions(
     e2eTestRunner: E2eTestRunner.Cypress,
     linter: Linter.EsLint,
     strict: true,
-    bundler: options.bundler ?? 'webpack',
     standalone: true,
     ...options,
     prefix,
     name: appProjectName,
     appProjectRoot,
+    appProjectSourceRoot: `${appProjectRoot}/src`,
     e2eProjectRoot,
     e2eProjectName,
     parsedTags,
+    bundler: options.bundler ?? 'esbuild',
   };
 }

--- a/packages/angular/src/generators/application/lib/normalized-schema.ts
+++ b/packages/angular/src/generators/application/lib/normalized-schema.ts
@@ -8,6 +8,7 @@ export interface NormalizedSchema extends Schema {
   e2eTestRunner: E2eTestRunner;
   prefix: string;
   appProjectRoot: string;
+  appProjectSourceRoot: string;
   e2eProjectName: string;
   e2eProjectRoot: string;
   parsedTags: string[];

--- a/packages/angular/src/generators/application/schema.json
+++ b/packages/angular/src/generators/application/schema.json
@@ -172,10 +172,12 @@
       "default": false
     },
     "bundler": {
-      "description": "Bundler to use to build the application.",
+      "description": "Bundler to use to build the application. _Note: The `esbuild` bundler is only considered stable from Angular v17._",
       "type": "string",
       "enum": ["webpack", "esbuild"],
-      "default": "webpack"
+      "default": "esbuild",
+      "x-prompt": "Which bundler do you want to use to build the application?",
+      "x-priority": "important"
     }
   },
   "additionalProperties": false,

--- a/packages/angular/src/generators/cypress-component-configuration/cypress-component-configuration.spec.ts
+++ b/packages/angular/src/generators/cypress-component-configuration/cypress-component-configuration.spec.ts
@@ -221,6 +221,7 @@ describe('Cypress Component Testing Configuration', () => {
     it('should use own project config', async () => {
       await generateTestApplication(tree, {
         name: 'fancy-app',
+        bundler: 'webpack',
       });
       await componentGenerator(tree, {
         name: 'fancy-cmp',
@@ -259,6 +260,7 @@ describe('Cypress Component Testing Configuration', () => {
     it('should use the project graph to find the correct project config', async () => {
       await generateTestApplication(tree, {
         name: 'fancy-app',
+        bundler: 'webpack',
       });
       await generateTestLibrary(tree, {
         name: 'fancy-lib',

--- a/packages/angular/src/generators/host/host.ts
+++ b/packages/angular/src/generators/host/host.ts
@@ -55,6 +55,7 @@ export async function hostInternal(tree: Tree, schema: Schema) {
     routing: true,
     port: 4200,
     skipFormat: true,
+    bundler: 'webpack',
   });
 
   const skipE2E =

--- a/packages/angular/src/generators/ngrx-root-store/lib/normalize-options.ts
+++ b/packages/angular/src/generators/ngrx-root-store/lib/normalize-options.ts
@@ -35,7 +35,8 @@ export function normalizeOptions(
     project.sourceRoot,
     'app/app.config.ts'
   );
-  const appMainPath = project.targets.build.options.main;
+  const appMainPath =
+    project.targets.build.options.main ?? project.targets.build.options.browser;
 
   /** If NgModule App
    * -> Use App Module

--- a/packages/angular/src/generators/remote/remote.ts
+++ b/packages/angular/src/generators/remote/remote.ts
@@ -49,6 +49,7 @@ export async function remoteInternal(tree: Tree, schema: Schema) {
     routing: true,
     port,
     skipFormat: true,
+    bundler: 'webpack',
   });
 
   const skipE2E =

--- a/packages/angular/src/generators/setup-ssr/setup-ssr.spec.ts
+++ b/packages/angular/src/generators/setup-ssr/setup-ssr.spec.ts
@@ -20,6 +20,7 @@ describe('setupSSR', () => {
     await generateTestApplication(tree, {
       name: 'app1',
       standalone: false,
+      bundler: 'webpack',
     });
 
     // ACT
@@ -118,6 +119,7 @@ describe('setupSSR', () => {
 
     await generateTestApplication(tree, {
       name: 'app1',
+      bundler: 'webpack',
     });
 
     tree.write('app1/src/environments/environment.ts', '');
@@ -146,6 +148,7 @@ describe('setupSSR', () => {
 
     await generateTestApplication(tree, {
       name: 'app1',
+      bundler: 'webpack',
     });
 
     // ACT

--- a/packages/angular/src/migrations/update-15-2-0/update-typescript-target.spec.ts
+++ b/packages/angular/src/migrations/update-15-2-0/update-typescript-target.spec.ts
@@ -16,11 +16,13 @@ describe('Migration to update target and add useDefineForClassFields', () => {
     tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
     await generateTestApplication(tree, {
       name: 'test',
+      bundler: 'webpack',
       projectNameAndRootFormat: 'derived',
     });
     await generateTestApplication(tree, {
       name: 'karma',
       unitTestRunner: UnitTestRunner.None,
+      bundler: 'webpack',
       projectNameAndRootFormat: 'derived',
     });
 

--- a/packages/angular/src/utils/nx-devkit/ast-utils.ts
+++ b/packages/angular/src/utils/nx-devkit/ast-utils.ts
@@ -678,7 +678,9 @@ function getListOfRoutes(
 
 export function isNgStandaloneApp(tree: Tree, projectName: string) {
   const project = readProjectConfiguration(tree, projectName);
-  const mainFile = project.targets?.build?.options?.main;
+  const mainFile =
+    project.targets?.build?.options?.main ??
+    project.targets?.build?.options?.browser;
 
   if (project.projectType !== 'application' || !mainFile) {
     return false;
@@ -873,7 +875,8 @@ export function readBootstrapInfo(
 
   let mainPath;
   try {
-    mainPath = config.targets.build.options.main;
+    mainPath =
+      config.targets.build.options.main ?? config.targets.build.options.browser;
   } catch (e) {
     throw new Error('Main file cannot be located');
   }

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -60,6 +60,7 @@ interface AngularArguments extends BaseArguments {
   routing: boolean;
   standaloneApi: boolean;
   e2eTestRunner: 'none' | 'cypress' | 'playwright';
+  bundler: 'webpack' | 'esbuild';
 }
 
 interface VueArguments extends BaseArguments {
@@ -679,6 +680,7 @@ async function determineAngularOptions(
   let style: string;
   let appName: string;
   let e2eTestRunner: undefined | 'none' | 'cypress' | 'playwright' = undefined;
+  let bundler: undefined | 'webpack' | 'esbuild' = undefined;
 
   const standaloneApi = parsedArgs.standaloneApi;
   const routing = parsedArgs.routing;
@@ -701,6 +703,30 @@ async function determineAngularOptions(
       preset = Preset.AngularMonorepo;
       appName = await determineAppName(parsedArgs);
     }
+  }
+
+  if (parsedArgs.bundler) {
+    bundler = parsedArgs.bundler;
+  } else {
+    const reply = await enquirer.prompt<{ bundler: 'esbuild' | 'webpack' }>([
+      {
+        name: 'bundler',
+        message: `Which bundler would you like to use?`,
+        type: 'autocomplete',
+        choices: [
+          {
+            name: 'esbuild',
+            message: 'esbuild [ https://esbuild.github.io/ ]',
+          },
+          {
+            name: 'webpack',
+            message: 'Webpack [ https://webpack.js.org/ ]',
+          },
+        ],
+        initial: 'esbuild' as any,
+      },
+    ]);
+    bundler = reply.bundler;
   }
 
   if (parsedArgs.style) {
@@ -733,7 +759,15 @@ async function determineAngularOptions(
 
   e2eTestRunner = await determineE2eTestRunner(parsedArgs);
 
-  return { preset, style, appName, standaloneApi, routing, e2eTestRunner };
+  return {
+    preset,
+    style,
+    appName,
+    standaloneApi,
+    routing,
+    e2eTestRunner,
+    bundler,
+  };
 }
 
 async function determineNodeOptions(

--- a/packages/cypress/src/executors/cypress/cypress.impl.ts
+++ b/packages/cypress/src/executors/cypress/cypress.impl.ts
@@ -204,7 +204,8 @@ If the port is in use, try using a different port value or passing --port='cypre
   for await (const output of await runExecutor<{
     success: boolean;
     baseUrl?: string;
-    info?: { port: number; baseUrl?: string };
+    port?: string;
+    info?: { port?: number; baseUrl?: string };
   }>(parsedDevServerTarget, overrides, context)) {
     if (!output.success && !opts.watch)
       throw new Error('Could not compile application files');
@@ -212,9 +213,9 @@ If the port is in use, try using a different port value or passing --port='cypre
       !opts.baseUrl &&
       !output.baseUrl &&
       !output.info?.baseUrl &&
-      output.info?.port
+      (output.port || output.info?.port)
     ) {
-      output.baseUrl = `http://localhost:${output.info.port}`;
+      output.baseUrl = `http://localhost:${output.port ?? output.info?.port}`;
     }
     yield {
       baseUrl: opts.baseUrl || output.baseUrl || output.info?.baseUrl,

--- a/packages/workspace/src/generators/preset/preset.ts
+++ b/packages/workspace/src/generators/preset/preset.ts
@@ -31,6 +31,7 @@ async function createPreset(tree: Tree, options: Schema) {
       standalone: options.standaloneApi,
       routing: options.routing,
       e2eTestRunner: options.e2eTestRunner ?? 'cypress',
+      bundler: options.bundler,
     });
   } else if (options.preset === Preset.AngularStandalone) {
     const {


### PR DESCRIPTION
- Add prompt to CNW for `--bundler` for Angular applications.
- Update Angular app generator to default to `esbuild` for the bundler.
- Generate build target for apps with the `@angular-devkit/build-angular:application` builder instead of the `@angular-devkit/build-angular:browser-esbuild`.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
