### PR TITLE
fix: remove `@` character from templates for compat with Angular cont…

### DIFF
--- a/packages/angular/src/generators/application/files/standalone-components/src/app/nx-welcome.component.ts__tpl__
+++ b/packages/angular/src/generators/application/files/standalone-components/src/app/nx-welcome.component.ts__tpl__
@@ -745,9 +745,9 @@ import { CommonModule } from '@angular/common';
               Add UI library
             </summary>
             <pre><span># Generate UI lib</span>
-nx g @nx/angular:lib ui
+nx g &#64;nx/angular:lib ui
 <span># Add a component</span>
-nx g @nx/angular:component button --project ui</pre>
+nx g &#64;nx/angular:component button --project ui</pre>
           </details>
           <details>
             <summary>


### PR DESCRIPTION
…rol flow

This fixes `error NG5002: Incomplete block "nx". If you meant to write the @ character, you should use the "&#64;" HTML entity instead.` error on freshly generated Angular apps with routing.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
