### PR TITLE
feat(linter): Support no fail on empty lint run

### DIFF
--- a/docs/generated/packages/eslint/executors/lint.json
+++ b/docs/generated/packages/eslint/executors/lint.json
@@ -133,6 +133,11 @@
         "type": "string",
         "description": "The equivalent of the `--print-config` flag on the ESLint CLI.",
         "x-completion-type": "file"
+      },
+      "errorOnUnmatchedPattern": {
+        "type": "boolean",
+        "description": "When set to false, equivalent of the `--no-error-on-unmatched-pattern` flag on the ESLint CLI.",
+        "default": true
       }
     },
     "required": ["lintFilePatterns"],

--- a/packages/eslint/src/executors/lint/lint.impl.spec.ts
+++ b/packages/eslint/src/executors/lint/lint.impl.spec.ts
@@ -70,6 +70,7 @@ function createValidRunBuilderOptions(
     resolvePluginsRelativeTo: null,
     reportUnusedDisableDirectives: null,
     printConfig: null,
+    errorOnUnmatchedPattern: true,
     ...additionalOptions,
   };
 }
@@ -209,6 +210,34 @@ describe('Linter Builder', () => {
     await expect(result).rejects.toThrow(
       `All files matching the following patterns are ignored:\n- 'includedFile1'\n\nPlease check your '.eslintignore' file.`
     );
+    mockIsPathIgnored.mockReturnValue(Promise.resolve(false));
+  });
+
+  it('should not throw if no reports generated and errorOnUnmatchedPattern is false', async () => {
+    mockReports = [];
+    setupMocks();
+    const result = lintExecutor(
+      createValidRunBuilderOptions({
+        lintFilePatterns: ['includedFile1'],
+        errorOnUnmatchedPattern: false,
+      }),
+      mockContext
+    );
+    await expect(result).resolves.not.toThrow();
+  });
+
+  it('should not throw if pattern excluded and errorOnUnmatchedPattern is false', async () => {
+    mockReports = [];
+    setupMocks();
+    mockIsPathIgnored.mockReturnValue(Promise.resolve(true));
+    const result = lintExecutor(
+      createValidRunBuilderOptions({
+        lintFilePatterns: ['includedFile1'],
+        errorOnUnmatchedPattern: false,
+      }),
+      mockContext
+    );
+    await expect(result).resolves.not.toThrow();
     mockIsPathIgnored.mockReturnValue(Promise.resolve(false));
   });
 

--- a/packages/eslint/src/executors/lint/lint.impl.ts
+++ b/packages/eslint/src/executors/lint/lint.impl.ts
@@ -39,7 +39,8 @@ export default async function run(
     ? joinPathFragments(options.cacheLocation, projectName)
     : undefined;
 
-  const { printConfig, ...normalizedOptions } = options;
+  const { printConfig, errorOnUnmatchedPattern, ...normalizedOptions } =
+    options;
 
   /**
    * Until ESLint v9 is released and the new so called flat config is the default
@@ -119,7 +120,7 @@ Please see https://nx.dev/guides/eslint for full guidance on how to resolve this
     throw err;
   }
 
-  if (lintResults.length === 0) {
+  if (lintResults.length === 0 && errorOnUnmatchedPattern) {
     const ignoredPatterns = (
       await Promise.all(
         normalizedOptions.lintFilePatterns.map(async (pattern) =>

--- a/packages/eslint/src/executors/lint/schema.d.ts
+++ b/packages/eslint/src/executors/lint/schema.d.ts
@@ -21,6 +21,7 @@ export interface Schema extends JsonObject {
   resolvePluginsRelativeTo: string | null;
   reportUnusedDisableDirectives: Linter.StringSeverity | null;
   printConfig?: string | null;
+  errorOnUnmatchedPattern?: boolean;
 }
 
 type Formatter =

--- a/packages/eslint/src/executors/lint/schema.json
+++ b/packages/eslint/src/executors/lint/schema.json
@@ -137,6 +137,11 @@
       "type": "string",
       "description": "The equivalent of the `--print-config` flag on the ESLint CLI.",
       "x-completion-type": "file"
+    },
+    "errorOnUnmatchedPattern": {
+      "type": "boolean",
+      "description": "When set to false, equivalent of the `--no-error-on-unmatched-pattern` flag on the ESLint CLI.",
+      "default": true
     }
   },
   "required": ["lintFilePatterns"],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
@nx/eslint:lint fails when no files are found to lint

## Expected Behavior
@nx/eslint:lint optionally succeeds when no files are found to lint

## Related Issue(s)
#19953 

Fixes #19953 
