### PR TITLE
fix(devkit): formatFiles should support prettier 3

### DIFF
--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -16,7 +16,10 @@ sortObjectByKeys =
 export async function formatFiles(tree: Tree): Promise<void> {
   let prettier: typeof Prettier;
   try {
-    prettier = await import('prettier');
+    // tsc doesn't like dynamic imports.
+    prettier = await new Function(`return import('prettier');`)().then((m) =>
+      m.default ? m.default : m
+    );
   } catch {}
 
   sortTsConfig(tree);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
There are some cases where prettier v3 support is lacking. A notable issue still occurs in tests that use formatFiles, as jest complains about the ESM. The error you get tells you how to get around it, but is still enough of a reason to not migrate folks automatically imho.

## Expected Behavior
formatFiles still works after migrating to prettier 3

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
