### PR TITLE
fix(misc): create-nx-workspace should not log undefined for preset deprecation

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -240,7 +240,6 @@ function normalizeAndWarnOnDeprecatedPreset(
   return async (args: yargs.Arguments<Arguments>): Promise<void> => {
     if (!args.preset) return;
     if (deprecatedPresets[args.preset]) {
-      args.preset = deprecatedPresets[args.preset] as Preset;
       output.addVerticalSeparator();
       output.note({
         title: `The "${args.preset}" preset is deprecated.`,
@@ -252,6 +251,7 @@ function normalizeAndWarnOnDeprecatedPreset(
           }" preset instead.`,
         ],
       });
+      args.preset = deprecatedPresets[args.preset] as Preset;
     }
   };
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We normalize deprecated preset names, and then log a deprecation message. The message fails to find the preset in deprecatedPresets, since we've already normalized the name.

## Expected Behavior
We log the message, and then normalize the preset, s.t. the message lookup is accurate.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
