### PR TITLE
feat(testing): move test config more into nx.json targetDefaults

### DIFF
--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -302,16 +302,9 @@ exports[`app --project-name-and-root-format=derived should generate correctly wh
       },
     },
     "test": {
-      "configurations": {
-        "ci": {
-          "ci": true,
-          "codeCoverage": true,
-        },
-      },
       "executor": "@nx/jest:jest",
       "options": {
         "jestConfig": "apps/my-dir/my-app/jest.config.ts",
-        "passWithNoTests": true,
       },
       "outputs": [
         "{workspaceRoot}/coverage/{projectRoot}",
@@ -546,16 +539,9 @@ exports[`app --project-name-and-root-format=derived should generate correctly wh
       },
     },
     "test": {
-      "configurations": {
-        "ci": {
-          "ci": true,
-          "codeCoverage": true,
-        },
-      },
       "executor": "@nx/jest:jest",
       "options": {
         "jestConfig": "apps/my-app/jest.config.ts",
-        "passWithNoTests": true,
       },
       "outputs": [
         "{workspaceRoot}/coverage/{projectRoot}",
@@ -1005,16 +991,9 @@ exports[`app nested should create project configs 1`] = `
       },
     },
     "test": {
-      "configurations": {
-        "ci": {
-          "ci": true,
-          "codeCoverage": true,
-        },
-      },
       "executor": "@nx/jest:jest",
       "options": {
         "jestConfig": "my-dir/my-app/jest.config.ts",
-        "passWithNoTests": true,
       },
       "outputs": [
         "{workspaceRoot}/coverage/{projectRoot}",
@@ -1163,16 +1142,9 @@ exports[`app not nested should create project configs 1`] = `
       },
     },
     "test": {
-      "configurations": {
-        "ci": {
-          "ci": true,
-          "codeCoverage": true,
-        },
-      },
       "executor": "@nx/jest:jest",
       "options": {
         "jestConfig": "my-app/jest.config.ts",
-        "passWithNoTests": true,
       },
       "outputs": [
         "{workspaceRoot}/coverage/{projectRoot}",

--- a/packages/angular/src/generators/ng-add/migrators/projects/app.migrator.spec.ts
+++ b/packages/angular/src/generators/ng-add/migrators/projects/app.migrator.spec.ts
@@ -1624,7 +1624,6 @@ describe('app migrator', () => {
       ).toStrictEqual([
         'build',
         'lint',
-        'test',
         'e2e',
         'myCustomTest',
         'myCustomLint',
@@ -1657,7 +1656,7 @@ describe('app migrator', () => {
       const { targetDefaults } = readNxJson(tree);
       expect(
         Object.keys(targetDefaults).filter((f) => targetDefaults[f].cache)
-      ).toStrictEqual(['build', 'lint', 'test', 'e2e', 'myCustomTest']);
+      ).toStrictEqual(['build', 'lint', 'e2e', 'myCustomTest']);
     });
   });
 });

--- a/packages/angular/src/generators/ng-add/migrators/projects/lib.migrator.spec.ts
+++ b/packages/angular/src/generators/ng-add/migrators/projects/lib.migrator.spec.ts
@@ -1280,7 +1280,6 @@ describe('lib migrator', () => {
       ).toStrictEqual([
         'build',
         'lint',
-        'test',
         'e2e',
         'myCustomBuild',
         'myCustomTest',
@@ -1307,7 +1306,7 @@ describe('lib migrator', () => {
       const { targetDefaults } = readNxJson(tree);
       expect(
         Object.keys(targetDefaults).filter((f) => targetDefaults[f].cache)
-      ).toStrictEqual(['build', 'lint', 'test', 'e2e', 'myCustomTest']);
+      ).toStrictEqual(['build', 'lint', 'e2e', 'myCustomTest']);
     });
   });
 });

--- a/packages/eslint/src/generators/workspace-rules-project/workspace-rules-project.spec.ts
+++ b/packages/eslint/src/generators/workspace-rules-project/workspace-rules-project.spec.ts
@@ -81,16 +81,9 @@ describe('@nx/eslint:workspace-rules-project', () => {
         "sourceRoot": "tools/eslint-rules",
         "targets": {
           "test": {
-            "configurations": {
-              "ci": {
-                "ci": true,
-                "codeCoverage": true,
-              },
-            },
             "executor": "@nx/jest:jest",
             "options": {
               "jestConfig": "tools/eslint-rules/jest.config.ts",
-              "passWithNoTests": true,
             },
             "outputs": [
               "{workspaceRoot}/coverage/{projectRoot}",

--- a/packages/jest/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/jest/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -114,16 +114,9 @@ export default {
 
 exports[`jestProject should use jest.config.js in project config with --js flag 1`] = `
 {
-  "configurations": {
-    "ci": {
-      "ci": true,
-      "codeCoverage": true,
-    },
-  },
   "executor": "@nx/jest:jest",
   "options": {
     "jestConfig": "libs/lib1/jest.config.js",
-    "passWithNoTests": true,
   },
   "outputs": [
     "{workspaceRoot}/coverage/{projectRoot}",

--- a/packages/jest/src/generators/configuration/configuration.spec.ts
+++ b/packages/jest/src/generators/configuration/configuration.spec.ts
@@ -84,13 +84,6 @@ describe('jestProject', () => {
       outputs: ['{workspaceRoot}/coverage/{projectRoot}'],
       options: {
         jestConfig: 'libs/lib1/jest.config.ts',
-        passWithNoTests: true,
-      },
-      configurations: {
-        ci: {
-          ci: true,
-          codeCoverage: true,
-        },
       },
     });
   });

--- a/packages/jest/src/generators/configuration/lib/update-workspace.ts
+++ b/packages/jest/src/generators/configuration/lib/update-workspace.ts
@@ -28,13 +28,6 @@ export function updateWorkspace(
         normalizePath(projectConfig.root),
         `jest.config.${options.js ? 'js' : 'ts'}`
       ),
-      passWithNoTests: true,
-    },
-    configurations: {
-      ci: {
-        ci: true,
-        codeCoverage: true,
-      },
     },
   };
 

--- a/packages/jest/src/generators/init/init.spec.ts
+++ b/packages/jest/src/generators/init/init.spec.ts
@@ -79,17 +79,26 @@ export default {
 
     const productionFileSet = readJson<NxJsonConfiguration>(tree, 'nx.json')
       .namedInputs.production;
-    const testDefaults = readJson<NxJsonConfiguration>(tree, 'nx.json')
-      .targetDefaults.test;
+    const jestDefaults = readJson<NxJsonConfiguration>(tree, 'nx.json')
+      .targetDefaults['@nx/jest:jest'];
     expect(productionFileSet).toContain(
       '!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)'
     );
     expect(productionFileSet).toContain('!{projectRoot}/tsconfig.spec.json');
     expect(productionFileSet).toContain('!{projectRoot}/jest.config.[jt]s');
     expect(productionFileSet).toContain('!{projectRoot}/src/test-setup.[jt]s');
-    expect(testDefaults).toEqual({
+    expect(jestDefaults).toEqual({
       cache: true,
       inputs: ['default', '^production', '{workspaceRoot}/jest.preset.js'],
+      options: {
+        passWithNoTests: true,
+      },
+      configurations: {
+        ci: {
+          ci: true,
+          codeCoverage: true,
+        },
+      },
     });
   });
 

--- a/packages/nest/src/generators/library/library.spec.ts
+++ b/packages/nest/src/generators/library/library.spec.ts
@@ -34,13 +34,6 @@ describe('lib', () => {
         outputs: [`{workspaceRoot}/coverage/{projectRoot}`],
         options: {
           jestConfig: `my-lib/jest.config.ts`,
-          passWithNoTests: true,
-        },
-        configurations: {
-          ci: {
-            ci: true,
-            codeCoverage: true,
-          },
         },
       });
     });

--- a/packages/node/src/generators/library/library.spec.ts
+++ b/packages/node/src/generators/library/library.spec.ts
@@ -40,13 +40,6 @@ describe('lib', () => {
         outputs: ['{workspaceRoot}/coverage/{projectRoot}'],
         options: {
           jestConfig: 'my-lib/jest.config.ts',
-          passWithNoTests: true,
-        },
-        configurations: {
-          ci: {
-            ci: true,
-            codeCoverage: true,
-          },
         },
       });
       expect(

--- a/packages/nx/src/generators/testing-utils/create-tree-with-empty-workspace.ts
+++ b/packages/nx/src/generators/testing-utils/create-tree-with-empty-workspace.ts
@@ -43,9 +43,6 @@ function addCommonFiles(tree: Tree, addAppsAndLibsFolders: boolean): Tree {
         lint: {
           cache: true,
         },
-        test: {
-          cache: true,
-        },
         e2e: {
           cache: true,
         },

--- a/packages/plugin/src/generators/e2e-project/e2e.spec.ts
+++ b/packages/plugin/src/generators/e2e-project/e2e.spec.ts
@@ -119,19 +119,12 @@ describe('NxPlugin e2e-project Generator', () => {
     expect(project.targets.e2e).toBeTruthy();
     expect(project.targets.e2e).toMatchInlineSnapshot(`
       {
-        "configurations": {
-          "ci": {
-            "ci": true,
-            "codeCoverage": true,
-          },
-        },
         "dependsOn": [
           "^build",
         ],
         "executor": "@nx/jest:jest",
         "options": {
           "jestConfig": "apps/my-plugin-e2e/jest.config.ts",
-          "passWithNoTests": true,
           "runInBand": true,
         },
         "outputs": [

--- a/packages/plugin/src/generators/e2e-project/e2e.ts
+++ b/packages/plugin/src/generators/e2e-project/e2e.ts
@@ -148,7 +148,6 @@ async function addJest(host: Tree, options: NormalizedSchema) {
       ...testTarget.options,
       runInBand: true,
     },
-    configurations: testTarget.configurations,
   };
 
   // remove the jest build target

--- a/packages/plugin/src/generators/plugin/plugin.spec.ts
+++ b/packages/plugin/src/generators/plugin/plugin.spec.ts
@@ -83,13 +83,6 @@ describe('NxPlugin Plugin Generator', () => {
       outputs: ['{workspaceRoot}/coverage/{projectRoot}'],
       options: {
         jestConfig: 'libs/my-plugin/jest.config.ts',
-        passWithNoTests: true,
-      },
-      configurations: {
-        ci: {
-          ci: true,
-          codeCoverage: true,
-        },
       },
     });
   });

--- a/packages/react-native/src/generators/library/library.spec.ts
+++ b/packages/react-native/src/generators/library/library.spec.ts
@@ -296,16 +296,9 @@ describe('lib', () => {
       const projectConfiguration = readProjectConfiguration(appTree, 'my-lib');
       expect(projectConfiguration.targets.test).toMatchInlineSnapshot(`
         {
-          "configurations": {
-            "ci": {
-              "ci": true,
-              "codeCoverage": true,
-            },
-          },
           "executor": "@nx/jest:jest",
           "options": {
             "jestConfig": "my-lib/jest.config.ts",
-            "passWithNoTests": true,
           },
           "outputs": [
             "{workspaceRoot}/coverage/{projectRoot}",

--- a/packages/storybook/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/storybook/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -72,16 +72,9 @@ exports[`@nx/storybook:configuration for Storybook v7 basic functionalities shou
       },
     },
     "test": {
-      "configurations": {
-        "ci": {
-          "ci": true,
-          "codeCoverage": true,
-        },
-      },
       "executor": "@nx/jest:jest",
       "options": {
         "jestConfig": "test-ui-lib/jest.config.ts",
-        "passWithNoTests": true,
       },
       "outputs": [
         "{workspaceRoot}/coverage/{projectRoot}",

--- a/packages/storybook/src/migrations/update-16-5-0/__snapshots__/move-storybook-tsconfig.spec.ts.snap
+++ b/packages/storybook/src/migrations/update-16-5-0/__snapshots__/move-storybook-tsconfig.spec.ts.snap
@@ -121,9 +121,6 @@ exports[`Ignore @nx/react/plugins/storybook in Storybook eslint plugin should up
     "lint": {
       "cache": true,
     },
-    "test": {
-      "cache": true,
-    },
   },
 }
 `;

--- a/packages/vite/src/generators/init/init.spec.ts
+++ b/packages/vite/src/generators/init/init.spec.ts
@@ -80,7 +80,9 @@ describe('@nx/vite:init', () => {
 
       const productionNamedInputs = readJson(tree, 'nx.json').namedInputs
         .production;
-      const testDefaults = readJson(tree, 'nx.json').targetDefaults.test;
+      const vitestDefaults = readJson(tree, 'nx.json').targetDefaults[
+        '@nx/vite:vitest'
+      ];
 
       expect(productionNamedInputs).toContain(
         '!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)'
@@ -88,7 +90,7 @@ describe('@nx/vite:init', () => {
       expect(productionNamedInputs).toContain(
         '!{projectRoot}/tsconfig.spec.json'
       );
-      expect(testDefaults).toEqual({
+      expect(vitestDefaults).toEqual({
         cache: true,
         inputs: ['default', '^production'],
       });

--- a/packages/vite/src/generators/init/init.ts
+++ b/packages/vite/src/generators/init/init.ts
@@ -93,8 +93,9 @@ export function createVitestConfig(tree: Tree) {
   }
 
   nxJson.targetDefaults ??= {};
-  nxJson.targetDefaults.test ??= {};
-  nxJson.targetDefaults.test.inputs ??= [
+  nxJson.targetDefaults['@nx/vite:vitest'] ??= {};
+  nxJson.targetDefaults['@nx/vite:vitest'].cache ??= true;
+  nxJson.targetDefaults['@nx/vite:vitest'].inputs ??= [
     'default',
     productionFileSet ? '^production' : '^default',
   ];

--- a/packages/workspace/src/generators/new/__snapshots__/new.spec.ts.snap
+++ b/packages/workspace/src/generators/new/__snapshots__/new.spec.ts.snap
@@ -46,9 +46,6 @@ exports[`new should generate an empty nx.json 1`] = `
     "lint": {
       "cache": true,
     },
-    "test": {
-      "cache": true,
-    },
   },
 }
 `;

--- a/packages/workspace/src/generators/new/generate-workspace-files.spec.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.spec.ts
@@ -117,9 +117,6 @@ describe('@nx/workspace:generateWorkspaceFiles', () => {
           "lint": {
             "cache": true,
           },
-          "test": {
-            "cache": true,
-          },
         },
       }
     `);
@@ -164,9 +161,6 @@ describe('@nx/workspace:generateWorkspaceFiles', () => {
             "cache": true,
           },
           "lint": {
-            "cache": true,
-          },
-          "test": {
             "cache": true,
           },
         },
@@ -232,9 +226,6 @@ describe('@nx/workspace:generateWorkspaceFiles', () => {
             "cache": true,
           },
           "lint": {
-            "cache": true,
-          },
-          "test": {
             "cache": true,
           },
         },

--- a/packages/workspace/src/generators/new/generate-workspace-files.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.ts
@@ -75,9 +75,6 @@ function createNxJson(
       lint: {
         cache: true,
       },
-      test: {
-        cache: true,
-      },
       e2e: {
         cache: true,
       },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`jest` targets have a lot of the same options added to them in `project.json`

`test` target defaults are all added to `nx.json` defaults under `test` which leads to some weird cases when both `vitest` and `jest` are used when `jest.preset.js` will be an input for `vitest` tasks.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Common `jest` options are added to `nx.json` under `targetDefaults` so the options are not added to `project.json`.

Target defaults for test executors are added under the executor so `@nx/jest:jest` settings are separate from `@nx/vite:vitest` settings.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
