### PR TITLE
chore(js): fix flaky assets test

### DIFF
--- a/packages/js/src/utils/assets/copy-assets-handler.spec.ts
+++ b/packages/js/src/utils/assets/copy-assets-handler.spec.ts
@@ -118,70 +118,54 @@ describe('AssetInputOutputHandler', () => {
     deletedMockedWatchedFile(path.join(projectDir, 'docs/test1.md'));
     deletedMockedWatchedFile(path.join(projectDir, 'docs/test2.md'));
 
-    expect(callback.mock.calls).toEqual([
-      [
-        [
-          {
-            type: 'create',
-            src: path.join(rootDir, 'LICENSE'),
-            dest: path.join(rootDir, 'dist/mylib/LICENSE'),
-          },
-        ],
-      ],
-      [
-        [
-          {
-            type: 'create',
-            src: path.join(rootDir, 'mylib/README.md'),
-            dest: path.join(rootDir, 'dist/mylib/README.md'),
-          },
-        ],
-      ],
-      [
-        [
-          {
-            type: 'create',
-            src: path.join(rootDir, 'mylib/docs/test1.md'),
-            dest: path.join(rootDir, 'dist/mylib/docs/test1.md'),
-          },
-        ],
-      ],
-      [
-        [
-          {
-            type: 'create',
-            src: path.join(rootDir, 'mylib/docs/test2.md'),
-            dest: path.join(rootDir, 'dist/mylib/docs/test2.md'),
-          },
-        ],
-      ],
-      [
-        [
-          {
-            type: 'update',
-            src: path.join(rootDir, 'mylib/docs/test1.md'),
-            dest: path.join(rootDir, 'dist/mylib/docs/test1.md'),
-          },
-        ],
-      ],
-      [
-        [
-          {
-            type: 'delete',
-            src: path.join(rootDir, 'mylib/docs/test1.md'),
-            dest: path.join(rootDir, 'dist/mylib/docs/test1.md'),
-          },
-        ],
-      ],
-      [
-        [
-          {
-            type: 'delete',
-            src: path.join(rootDir, 'mylib/docs/test2.md'),
-            dest: path.join(rootDir, 'dist/mylib/docs/test2.md'),
-          },
-        ],
-      ],
+    expect(callback).toHaveBeenCalledWith([
+      {
+        type: 'create',
+        src: path.join(rootDir, 'LICENSE'),
+        dest: path.join(rootDir, 'dist/mylib/LICENSE'),
+      },
+    ]);
+    expect(callback).toHaveBeenCalledWith([
+      {
+        type: 'create',
+        src: path.join(rootDir, 'mylib/README.md'),
+        dest: path.join(rootDir, 'dist/mylib/README.md'),
+      },
+    ]);
+    expect(callback).toHaveBeenCalledWith([
+      {
+        type: 'create',
+        src: path.join(rootDir, 'mylib/docs/test1.md'),
+        dest: path.join(rootDir, 'dist/mylib/docs/test1.md'),
+      },
+    ]);
+    expect(callback).toHaveBeenCalledWith([
+      {
+        type: 'create',
+        src: path.join(rootDir, 'mylib/docs/test2.md'),
+        dest: path.join(rootDir, 'dist/mylib/docs/test2.md'),
+      },
+    ]);
+    expect(callback).toHaveBeenCalledWith([
+      {
+        type: 'update',
+        src: path.join(rootDir, 'mylib/docs/test1.md'),
+        dest: path.join(rootDir, 'dist/mylib/docs/test1.md'),
+      },
+    ]);
+    expect(callback).toHaveBeenCalledWith([
+      {
+        type: 'delete',
+        src: path.join(rootDir, 'mylib/docs/test1.md'),
+        dest: path.join(rootDir, 'dist/mylib/docs/test1.md'),
+      },
+    ]);
+    expect(callback).toHaveBeenCalledWith([
+      {
+        type: 'delete',
+        src: path.join(rootDir, 'mylib/docs/test2.md'),
+        dest: path.join(rootDir, 'dist/mylib/docs/test2.md'),
+      },
     ]);
 
     dispose();
@@ -202,39 +186,31 @@ describe('AssetInputOutputHandler', () => {
 
     await sut.processAllAssetsOnce();
 
-    expect(callback.mock.calls).toEqual([
-      [
-        [
-          {
-            type: 'create',
-            src: path.join(rootDir, 'LICENSE'),
-            dest: path.join(rootDir, 'dist/mylib/LICENSE'),
-          },
-        ],
-      ],
-      [
-        [
-          {
-            type: 'create',
-            src: path.join(rootDir, 'mylib/README.md'),
-            dest: path.join(rootDir, 'dist/mylib/README.md'),
-          },
-        ],
-      ],
-      [
-        [
-          {
-            type: 'create',
-            src: path.join(rootDir, 'mylib/docs/test1.md'),
-            dest: path.join(rootDir, 'dist/mylib/docs/test1.md'),
-          },
-          {
-            type: 'create',
-            src: path.join(rootDir, 'mylib/docs/test2.md'),
-            dest: path.join(rootDir, 'dist/mylib/docs/test2.md'),
-          },
-        ],
-      ],
+    expect(callback).toHaveBeenCalledWith([
+      {
+        type: 'create',
+        src: path.join(rootDir, 'LICENSE'),
+        dest: path.join(rootDir, 'dist/mylib/LICENSE'),
+      },
+    ]);
+    expect(callback).toHaveBeenCalledWith([
+      {
+        type: 'create',
+        src: path.join(rootDir, 'mylib/README.md'),
+        dest: path.join(rootDir, 'dist/mylib/README.md'),
+      },
+    ]);
+    expect(callback).toHaveBeenCalledWith([
+      {
+        type: 'create',
+        src: path.join(rootDir, 'mylib/docs/test1.md'),
+        dest: path.join(rootDir, 'dist/mylib/docs/test1.md'),
+      },
+      {
+        type: 'create',
+        src: path.join(rootDir, 'mylib/docs/test2.md'),
+        dest: path.join(rootDir, 'dist/mylib/docs/test2.md'),
+      },
     ]);
   });
 });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

This assets handler test has been flaky.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The test no longer worries about the order in which the callback was called. It just worries that it was indeed called with the changed assets.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
