### PR TITLE
fix(core): ensure project order in graph is deterministic

### DIFF
--- a/packages/nx/src/project-graph/utils/normalize-project-nodes.ts
+++ b/packages/nx/src/project-graph/utils/normalize-project-nodes.ts
@@ -23,7 +23,10 @@ export async function normalizeProjectNodes(
   nxJson: NxJsonConfiguration
 ) {
   const toAdd = [];
-  const projects = Object.keys(ctx.projects);
+  // Sorting projects by name to make sure that the order of projects in the graph is deterministic.
+  // This is important to ensure that expanded properties referencing projects (e.g. implicit dependencies)
+  // are also deterministic, and thus don't cause the calculated project configuration hash to shift.
+  const projects = Object.keys(ctx.projects).sort();
 
   // Used for expanding implicit dependencies (e.g. `@proj/*` or `tag:foo`)
   const partialProjectGraphNodes = projects.reduce((graph, project) => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The hash of the project configuration can change every run when using implicit dependencies configurations that contain glob patterns.

## Expected Behavior
The project configuration hash is stable when the implicit dependencies have not changed. This is a pretty major issue, and a **_better_** fix would likely be to figure out why the order isn't deterministic to begin with, but it would be a larger PR and isn't obvious after looking over the code for a bit. I think the glob results are being processed in a different order when creating the graph nodes, and thats a lot harder to fix than just sorting the normalized array when we hash tasks.

## Related Issue(s)

Fixes #19820
