### PR TITLE
feat(vite): Use app/lib tsconfig for buildable paths resolution

### DIFF
--- a/packages/vite/src/utils/executor-utils.ts
+++ b/packages/vite/src/utils/executor-utils.ts
@@ -1,5 +1,5 @@
 import { printDiagnostics, runTypeCheck } from '@nx/js';
-import { join, resolve } from 'path';
+import { join } from 'path';
 import { ViteBuildExecutorOptions } from '../executors/build/schema';
 import { ExecutorContext } from '@nx/devkit';
 import { ViteDevServerExecutorOptions } from '../executors/dev-server/schema';
@@ -7,6 +7,7 @@ import {
   calculateProjectBuildableDependencies,
   createTmpTsConfig,
 } from '@nx/js/src/utils/buildable-libs-utils';
+import { getProjectTsConfigPath } from './options-utils';
 
 export async function validateTypes(opts: {
   workspaceRoot: string;
@@ -31,7 +32,7 @@ export function createBuildableTsConfig(
   options: ViteBuildExecutorOptions | ViteDevServerExecutorOptions,
   context: ExecutorContext
 ) {
-  const tsConfig = resolve(projectRoot, 'tsconfig.json');
+  const tsConfig = getProjectTsConfigPath(projectRoot);
   options['buildLibsFromSource'] ??= true;
 
   if (!options['buildLibsFromSource']) {
@@ -45,7 +46,14 @@ export function createBuildableTsConfig(
       context.targetName === 'serve' ? 'build' : context.targetName,
       context.configurationName
     );
-    // this tsconfig is used via the vite ts paths plugin
-    createTmpTsConfig(tsConfig, context.root, projectRoot, dependencies);
+    // This tsconfig is used via the Vite ts paths plugin.
+    // It can be also used by other user-defined Vite plugins (e.g. for creating type declaration files).
+    const tmpTsConfigPath = createTmpTsConfig(
+      tsConfig,
+      context.root,
+      projectRoot,
+      dependencies
+    );
+    process.env.NX_TSCONFIG_PATH = tmpTsConfigPath;
   }
 }


### PR DESCRIPTION
This change uses actual project TypeScript config - i.e. `tsconfig.app.json` or `tsconfig.lib.json` - to generate temporary `tsconfig` file when building with `"buildLibsFromSource": false` option.

This is needed when users would want to use the generated `tsconfig` in their Vite configuration - e.g. for generating type declarations.

Also exposed the generated `tsconfig` via `NX_TSCONFIG_PATH` env variable. This way users trying to use the generated config don't have to know & depend on specific path which feels like an internal implementation detail.

So now user can use `vite-plugin-dts` or `@rollup/plugin-typescript` to generate type declarations during build:

```
export default defineConfig({
  plugins: [
    nxViteTsPaths(),
    {
      ...typescript({
        tsconfig: process.env.NX_TSCONFIG_PATH ?? join(__dirname, 'tsconfig.lib.json'),
        noForceEmit: true,
      }),
      apply: 'build',
    },
  ],
})
```

## Current Behavior
Generated temporary `tsconfig` file is based on project `tsconfig.json` file which is shared in typical NX setups for tests & build. And as such it is missing some options that are relevant only for build - e.g. `emitDeclarationOnly`.