### PR TITLE
fix(detox): Update jest transform to point to correct tsconfig

### DIFF
--- a/packages/detox/src/generators/application/files/app/jest.config.json.template
+++ b/packages/detox/src/generators/application/files/app/jest.config.json.template
@@ -12,5 +12,12 @@
   "reporters": ["detox/runners/jest/reporter"],
   "testEnvironment": "detox/runners/jest/testEnvironment",
   "verbose": true,
-  "setupFilesAfterEnv": ["<rootDir>/test-setup.ts"]
+  "setupFilesAfterEnv": ["<rootDir>/test-setup.ts"],
+      "transform": {
+    "^.+\\.(ts|js|html)$": [
+      "ts-jest",
+      { "tsconfig": "<rootDir>/tsconfig.e2e.json" }
+    ]
+  }
+  
 }


### PR DESCRIPTION
We generate `tsconfig.e2e.json` for detox. However, `jest.preset` has `tsconfig.spec.json` for the transform prop.
So we need to override this for detox.

closes: #19976
