### PR TITLE
feat(module-federation): use nx run-many to build static remotes in parallel

### DIFF
--- a/docs/generated/packages/angular/executors/module-federation-dev-server.json
+++ b/docs/generated/packages/angular/executors/module-federation-dev-server.json
@@ -122,6 +122,10 @@
         "description": "Whether the host that is running this executor is the first in the project tree to do so.",
         "default": true,
         "x-priority": "internal"
+      },
+      "parallel": {
+        "type": "number",
+        "description": "Max number of parallel processes for building static remotes"
       }
     },
     "additionalProperties": false,

--- a/docs/generated/packages/react/executors/module-federation-dev-server.json
+++ b/docs/generated/packages/react/executors/module-federation-dev-server.json
@@ -100,6 +100,10 @@
         "description": "Whether the host that is running this executor is the first in the project tree to do so.",
         "default": true,
         "x-priority": "internal"
+      },
+      "parallel": {
+        "type": "number",
+        "description": "Max number of parallel processes for building static remotes"
       }
     },
     "presets": []

--- a/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -142,7 +142,10 @@ export function executeModuleFederationDevServerBuilder(
       }
     );
     staticProcess.stdout.on('data', (data) => {
-      if (data.toString().includes('Successfully ran target build')) {
+      const ANSII_CODE_REGEX =
+        /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
+      const stdoutString = data.toString().replace(ANSII_CODE_REGEX, '');
+      if (stdoutString.includes('Successfully ran target build')) {
         staticProcess.stdout.removeAllListeners('data');
         logger.info(`NX Built ${remotes.staticRemotes.length} static remotes`);
         res();

--- a/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -121,26 +121,20 @@ export function executeModuleFederationDevServerBuilder(
     pathToManifestFile
   );
 
-  let isCollectingStaticRemoteOutput = true;
-
-  for (const app of remotes.staticRemotes) {
-    const remoteProjectServeTarget =
-      projectGraph.nodes[app].data.targets['serve-static'];
-    const isUsingModuleFederationDevServerExecutor =
-      remoteProjectServeTarget.executor.includes(
-        'module-federation-dev-server'
-      );
-    let outWithErr: null | string[] = [];
+  const staticRemoteBuildPromise = new Promise<void>((res) => {
+    logger.info(
+      `NX Building ${remotes.staticRemotes.length} static remotes...`
+    );
     const staticProcess = fork(
       nxBin,
       [
-        'run',
-        `${app}:serve-static${
-          context.target.configuration ? `:${context.target.configuration}` : ''
-        }`,
-        ...(isUsingModuleFederationDevServerExecutor
-          ? [`--isInitialHost=false`]
+        'run-many',
+        `--target=build`,
+        `--projects=${remotes.staticRemotes.join(',')}`,
+        ...(context.target.configuration
+          ? [`--configuration=${context.target.configuration}`]
           : []),
+        ...(options.parallel ? [`--parallel=${options.parallel}`] : []),
       ],
       {
         cwd: context.workspaceRoot,
@@ -148,79 +142,128 @@ export function executeModuleFederationDevServerBuilder(
       }
     );
     staticProcess.stdout.on('data', (data) => {
-      if (isCollectingStaticRemoteOutput) {
-        outWithErr.push(data.toString());
-      } else {
-        outWithErr = null;
+      if (data.toString().includes('Successfully ran target build')) {
         staticProcess.stdout.removeAllListeners('data');
+        logger.info(`NX Built ${remotes.staticRemotes.length} static remotes`);
+        res();
       }
     });
     staticProcess.stderr.on('data', (data) => logger.info(data.toString()));
     staticProcess.on('exit', (code) => {
       if (code !== 0) {
-        logger.info(outWithErr.join(''));
-        throw new Error(`Remote failed to start. See above for errors.`);
+        throw new Error(`Remotes failed to build. See above for errors.`);
       }
     });
     process.on('SIGTERM', () => staticProcess.kill('SIGTERM'));
     process.on('exit', () => staticProcess.kill('SIGTERM'));
-  }
+  });
 
-  const devRemotes$ = [];
-  for (const app of remotes.devRemotes) {
-    if (!workspaceProjects[app].targets?.['serve']) {
-      throw new Error(`Could not find "serve" target in "${app}" project.`);
-    } else if (!workspaceProjects[app].targets?.['serve'].executor) {
-      throw new Error(
-        `Could not find executor for "serve" target in "${app}" project.`
-      );
-    }
+  return from(staticRemoteBuildPromise).pipe(
+    concatMap(() => {
+      let isCollectingStaticRemoteOutput = true;
 
-    const runOptions: { verbose?: boolean; isInitialHost?: boolean } = {};
-    const [collection, executor] =
-      workspaceProjects[app].targets['serve'].executor.split(':');
-    const isUsingModuleFederationDevServerExecutor = executor.includes(
-      'module-federation-dev-server'
-    );
-    const { schema } = getExecutorInformation(
-      collection,
-      executor,
-      workspaceRoot
-    );
-    if (
-      (options.verbose && schema.additionalProperties) ||
-      'verbose' in schema.properties
-    ) {
-      runOptions.verbose = options.verbose;
-    }
-
-    if (isUsingModuleFederationDevServerExecutor) {
-      runOptions.isInitialHost = false;
-    }
-
-    const serve$ = scheduleTarget(
-      context.workspaceRoot,
-      {
-        project: app,
-        target: 'serve',
-        configuration: context.target.configuration,
-        runOptions,
-      },
-      options.verbose
-    ).then((obs) => {
-      obs.toPromise().catch((err) => {
-        throw new Error(
-          `Remote '${app}' failed to serve correctly due to the following: \r\n${err.toString()}`
+      for (const app of remotes.staticRemotes) {
+        const remoteProjectServeTarget =
+          projectGraph.nodes[app].data.targets['serve-static'];
+        const isUsingModuleFederationDevServerExecutor =
+          remoteProjectServeTarget.executor.includes(
+            'module-federation-dev-server'
+          );
+        let outWithErr: null | string[] = [];
+        const staticProcess = fork(
+          nxBin,
+          [
+            'run',
+            `${app}:serve-static${
+              context.target.configuration
+                ? `:${context.target.configuration}`
+                : ''
+            }`,
+            ...(isUsingModuleFederationDevServerExecutor
+              ? [`--isInitialHost=false`]
+              : []),
+          ],
+          {
+            cwd: context.workspaceRoot,
+            stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+          }
         );
-      });
-    });
+        staticProcess.stdout.on('data', (data) => {
+          if (isCollectingStaticRemoteOutput) {
+            outWithErr.push(data.toString());
+          } else {
+            outWithErr = null;
+            staticProcess.stdout.removeAllListeners('data');
+          }
+        });
+        staticProcess.stderr.on('data', (data) => logger.info(data.toString()));
+        staticProcess.on('exit', (code) => {
+          if (code !== 0) {
+            logger.info(outWithErr.join(''));
+            throw new Error(`Remote failed to start. See above for errors.`);
+          }
+        });
+        process.on('SIGTERM', () => staticProcess.kill('SIGTERM'));
+        process.on('exit', () => staticProcess.kill('SIGTERM'));
+      }
 
-    devRemotes$.push(serve$);
-  }
+      const devRemotes$ = [];
+      for (const app of remotes.devRemotes) {
+        if (!workspaceProjects[app].targets?.['serve']) {
+          throw new Error(`Could not find "serve" target in "${app}" project.`);
+        } else if (!workspaceProjects[app].targets?.['serve'].executor) {
+          throw new Error(
+            `Could not find executor for "serve" target in "${app}" project.`
+          );
+        }
 
-  return devRemotes$.length > 0
-    ? combineLatest([...devRemotes$]).pipe(concatMap(() => currExecutor))
-    : currExecutor;
+        const runOptions: { verbose?: boolean; isInitialHost?: boolean } = {};
+        const [collection, executor] =
+          workspaceProjects[app].targets['serve'].executor.split(':');
+        const isUsingModuleFederationDevServerExecutor = executor.includes(
+          'module-federation-dev-server'
+        );
+        const { schema } = getExecutorInformation(
+          collection,
+          executor,
+          workspaceRoot
+        );
+        if (
+          (options.verbose && schema.additionalProperties) ||
+          'verbose' in schema.properties
+        ) {
+          runOptions.verbose = options.verbose;
+        }
+
+        if (isUsingModuleFederationDevServerExecutor) {
+          runOptions.isInitialHost = false;
+        }
+
+        const serve$ = scheduleTarget(
+          context.workspaceRoot,
+          {
+            project: app,
+            target: 'serve',
+            configuration: context.target.configuration,
+            runOptions,
+          },
+          options.verbose
+        ).then((obs) => {
+          obs.toPromise().catch((err) => {
+            throw new Error(
+              `Remote '${app}' failed to serve correctly due to the following: \r\n${err.toString()}`
+            );
+          });
+        });
+
+        devRemotes$.push(serve$);
+      }
+
+      return devRemotes$.length > 0
+        ? combineLatest([...devRemotes$]).pipe(concatMap(() => currExecutor))
+        : currExecutor;
+    })
+  );
 }
 
 export default require('@angular-devkit/architect').createBuilder(

--- a/packages/angular/src/builders/module-federation-dev-server/schema.d.ts
+++ b/packages/angular/src/builders/module-federation-dev-server/schema.d.ts
@@ -22,4 +22,5 @@ export interface Schema {
   pathToManifestFile?: string;
   static?: boolean;
   isInitialHost?: boolean;
+  parallel?: number;
 }

--- a/packages/angular/src/builders/module-federation-dev-server/schema.json
+++ b/packages/angular/src/builders/module-federation-dev-server/schema.json
@@ -132,6 +132,10 @@
       "description": "Whether the host that is running this executor is the first in the project tree to do so.",
       "default": true,
       "x-priority": "internal"
+    },
+    "parallel": {
+      "type": "number",
+      "description": "Max number of parallel processes for building static remotes"
     }
   },
   "additionalProperties": false,

--- a/packages/react/src/executors/module-federation-dev-server/schema.json
+++ b/packages/react/src/executors/module-federation-dev-server/schema.json
@@ -101,6 +101,10 @@
       "description": "Whether the host that is running this executor is the first in the project tree to do so.",
       "default": true,
       "x-priority": "internal"
+    },
+    "parallel": {
+      "type": "number",
+      "description": "Max number of parallel processes for building static remotes"
     }
   }
 }


### PR DESCRIPTION
- feat(angular): use nx run-many to build remotes in parallel
- feat(react): use nx run-many to build remotes in parallel

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We currently spin up a new forked process for every build of a static remote. This impacts resources and memory consumption when there are a lot of remotes in the workspace.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should use nx run-many instead to manage parallel builds of static remotes allowing for users to find the perfect number of parallel processes that they can use to build static remotes locally.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
