### PR TITLE
fix(js): filtering of local dependencies when running `nx release version`

### DIFF
--- a/packages/js/src/generators/release-version/release-version.ts
+++ b/packages/js/src/generators/release-version/release-version.ts
@@ -270,13 +270,10 @@ To fix this you will either need to add a package.json file at that location, or
       );
 
       const dependentProjects = Object.values(localPackageDependencies)
-        .filter((localPackageDependencies) => {
-          return localPackageDependencies.some(
-            (localPackageDependency) =>
-              localPackageDependency.target === project.name
-          );
-        })
-        .flat();
+        .flat()
+        .filter((localPackageDependency) => {
+          return localPackageDependency.target === project.name;
+        });
 
       if (dependentProjects.length > 0) {
         log(


### PR DESCRIPTION
This closes #19990 by moving the `filter` onto the flat list of local dependencies instead of requiring just one of the local dependencies to match the `target`.

## Current Behavior
If just one local dependent project / dependency match the `target` all dependents would be included as `dependentProjects` resulting in the behaviour outlined in #19990.

## Expected Behavior
The `dependentProjects` include only dependent projects / local dependencies that are actually relevant for a particular `project`, resulting in the expected `package.json` when running `nx release version`.

## Related Issue(s)
Fixes #19990
