### PR TITLE
fix(js): handle empty objects for migration to remove deprecated buil…

### DIFF
--- a/packages/js/src/migrations/update-17-0-0/remove-deprecated-build-options.spec.ts
+++ b/packages/js/src/migrations/update-17-0-0/remove-deprecated-build-options.spec.ts
@@ -53,6 +53,17 @@ describe('remove-deprecated-build-options', () => {
     await expect(migration(tree)).resolves.not.toThrow();
   });
 
+  it('should work if a target is an empty object', async () => {
+    addProjectConfiguration(tree, 'proj', {
+      root: 'proj',
+      targets: {
+        build: {},
+      },
+    });
+
+    await expect(migration(tree)).resolves.not.toThrow();
+  });
+
   it('should not update community executors', async () => {
     addProjectConfiguration(tree, 'proj', {
       root: 'proj',

--- a/packages/js/src/migrations/update-17-0-0/remove-deprecated-build-options.ts
+++ b/packages/js/src/migrations/update-17-0-0/remove-deprecated-build-options.ts
@@ -19,7 +19,8 @@ export default async function (tree: Tree) {
 
     for (const target of Object.values(projectConfig.targets)) {
       if (
-        target.executor.startsWith('@nx/') &&
+        target.executor?.startsWith('@nx/') &&
+        target.options &&
         ('buildableProjectDepsInPackageJsonType' in target.options ||
           'updateBuildableProjectDepsInPackageJson' in target.options)
       ) {


### PR DESCRIPTION
…d options

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The migration breaks when there's an empty object as a target like in the nx repo

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The migration does not break when there's an empty object as a target like in the nx repo

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
