### PR TITLE
fix(linter): fix update to using module node16

### DIFF
--- a/packages/eslint-plugin/src/configs/react-base.ts
+++ b/packages/eslint-plugin/src/configs/react-base.ts
@@ -8,7 +8,7 @@
  * This configuration is intended to be combined with other configs from this
  * package.
  */
-import * as restrictedGlobals from 'confusing-browser-globals';
+import restrictedGlobals from 'confusing-browser-globals';
 
 /**
  * Rule set originally adapted from:

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "moduleResolution": "node16",
+    "module": "node16",
     "types": ["node", "jest"]
   },
   "include": [],

--- a/packages/eslint-plugin/tsconfig.lib.json
+++ b/packages/eslint-plugin/tsconfig.lib.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "commonjs",
     "outDir": "../../dist/out-tsc",
     "declaration": true,
     "types": ["node"]

--- a/packages/eslint-plugin/tsconfig.spec.json
+++ b/packages/eslint-plugin/tsconfig.spec.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "module": "commonjs",
     "types": ["jest", "node"]
   },
   "include": [

--- a/packages/eslint/src/generators/workspace-rules-project/__snapshots__/workspace-rules-project.spec.ts.snap
+++ b/packages/eslint/src/generators/workspace-rules-project/__snapshots__/workspace-rules-project.spec.ts.snap
@@ -36,7 +36,7 @@ exports[`@nx/eslint:workspace-rules-project should generate the required files 2
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "moduleResolution": "node16",
-    "module": "commonjs"
+    "module": "node16"
   },
   "files": [],
   "include": [],
@@ -70,7 +70,6 @@ exports[`@nx/eslint:workspace-rules-project should generate the required files 4
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "module": "commonjs",
     "types": ["jest", "node"]
   },
   "include": ["jest.config.ts", "**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]

--- a/packages/eslint/src/generators/workspace-rules-project/files/tsconfig.json__tmpl__
+++ b/packages/eslint/src/generators/workspace-rules-project/files/tsconfig.json__tmpl__
@@ -2,7 +2,7 @@
   "extends": "<%= rootTsConfigPath %>",
   "compilerOptions": {
     "moduleResolution": "node16",
-    "module": "commonjs"
+    "module": "node16"
   },
   "files": [],
   "include": [],

--- a/packages/eslint/src/generators/workspace-rules-project/workspace-rules-project.ts
+++ b/packages/eslint/src/generators/workspace-rules-project/workspace-rules-project.ts
@@ -87,6 +87,8 @@ export async function lintWorkspaceRulesProjectGenerator(
     tree,
     join(workspaceLintPluginDir, 'tsconfig.spec.json'),
     (json) => {
+      delete json.compilerOptions?.module;
+
       if (json.include) {
         json.include = json.include.map((v) => {
           if (v.startsWith('src/**')) {

--- a/packages/eslint/src/migrations/update-17-1-0/__snapshots__/update-typescript-eslint.spec.ts.snap
+++ b/packages/eslint/src/migrations/update-17-1-0/__snapshots__/update-typescript-eslint.spec.ts.snap
@@ -59,9 +59,34 @@ export const rule = ESLintUtils.RuleCreator(() => __filename)({
 exports[`update-typescript-eslint migration should update the tsconfig.json 1`] = `
 "{
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "node16",
     "moduleResolution": "node16"
   }
+}
+"
+`;
+
+exports[`update-typescript-eslint migration should update the tsconfig.json 2`] = `
+"{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "**/*_spec.ts",
+    "**/*_test.ts",
+    "**/*.spec.tsx",
+    "**/*.test.tsx",
+    "**/*.spec.js",
+    "**/*.test.js",
+    "**/*.spec.jsx",
+    "**/*.test.jsx",
+    "**/*.d.ts",
+    "jest.config.ts"
+  ]
 }
 "
 `;

--- a/packages/eslint/src/migrations/update-17-1-0/update-typescript-eslint.spec.ts
+++ b/packages/eslint/src/migrations/update-17-1-0/update-typescript-eslint.spec.ts
@@ -14,6 +14,28 @@ describe('update-typescript-eslint migration', () => {
         module: 'commonjs',
       },
     });
+    writeJson(tree, 'tools/eslint-rules/tsconfig.spec.json', {
+      extends: './tsconfig.json',
+      compilerOptions: {
+        outDir: '../../dist/out-tsc',
+        module: 'commonjs',
+        types: ['jest', 'node'],
+      },
+      include: [
+        '**/*.spec.ts',
+        '**/*.test.ts',
+        '**/*_spec.ts',
+        '**/*_test.ts',
+        '**/*.spec.tsx',
+        '**/*.test.tsx',
+        '**/*.spec.js',
+        '**/*.test.js',
+        '**/*.spec.jsx',
+        '**/*.test.jsx',
+        '**/*.d.ts',
+        'jest.config.ts',
+      ],
+    });
 
     tree.write(
       'tools/eslint-rules/jest.config.ts',
@@ -81,6 +103,9 @@ export const rule = ESLintUtils.RuleCreator(() => __filename)({
 
     expect(
       tree.read('tools/eslint-rules/tsconfig.json', 'utf-8')
+    ).toMatchSnapshot();
+    expect(
+      tree.read('tools/eslint-rules/tsconfig.spec.json', 'utf-8')
     ).toMatchSnapshot();
   });
 

--- a/packages/eslint/src/migrations/update-17-1-0/update-typescript-eslint.ts
+++ b/packages/eslint/src/migrations/update-17-1-0/update-typescript-eslint.ts
@@ -34,13 +34,22 @@ function updateJestConfig(tree: Tree) {
   }
 }
 
-function updateTsConfig(tree: Tree) {
+function updateTsConfigs(tree: Tree) {
   const tsConfigPath = 'tools/eslint-rules/tsconfig.json';
   if (tree.exists(tsConfigPath)) {
     updateJson(tree, tsConfigPath, (tsConfig) => {
       tsConfig.compilerOptions ??= {};
       tsConfig.compilerOptions.moduleResolution = 'node16';
+      tsConfig.compilerOptions.module = 'node16';
       return tsConfig;
+    });
+  }
+  const tsConfigSpec = 'tools/eslint-rules/tsconfig.spec.json';
+  if (tree.exists(tsConfigSpec)) {
+    updateJson(tree, tsConfigSpec, (tsConfigSpec) => {
+      delete tsConfigSpec.compilerOptions?.module;
+      delete tsConfigSpec.compilerOptions?.moduleResolution;
+      return tsConfigSpec;
     });
   }
 }
@@ -91,7 +100,7 @@ function updateRecommended(tree: Tree) {
 
 export default async function update(tree: Tree) {
   updateJestConfig(tree);
-  updateTsConfig(tree);
+  updateTsConfigs(tree);
   updateRecommended(tree);
 
   await formatFiles(tree);

--- a/tools/eslint-rules/tsconfig.json
+++ b/tools/eslint-rules/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "moduleResolution": "node16",
-    "module": "commonjs"
+    "module": "node16"
   },
   "files": [],
   "include": [],

--- a/tools/eslint-rules/tsconfig.spec.json
+++ b/tools/eslint-rules/tsconfig.spec.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "module": "commonjs",
     "types": ["jest", "node"]
   },
   "include": ["**/*.test.ts", "**/*.spec.ts", "**/*.d.ts", "jest.config.ts"]


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The migration for adding "module": "node16" is broken because `moduleResolution` does not match with `module`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`module` should match with `moduleResolution` and the migration is adjusted.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
