### PR TITLE
feat(module-federation): use single file-server for static remotes

### DIFF
--- a/docs/generated/packages/angular/executors/module-federation-dev-server.json
+++ b/docs/generated/packages/angular/executors/module-federation-dev-server.json
@@ -132,6 +132,10 @@
       "parallel": {
         "type": "number",
         "description": "Max number of parallel processes for building static remotes"
+      },
+      "staticRemotesPort": {
+        "type": "number",
+        "description": "The port at which to serve the file-server for the static remotes."
       }
     },
     "additionalProperties": false,

--- a/docs/generated/packages/react/executors/module-federation-dev-server.json
+++ b/docs/generated/packages/react/executors/module-federation-dev-server.json
@@ -104,6 +104,10 @@
       "parallel": {
         "type": "number",
         "description": "Max number of parallel processes for building static remotes"
+      },
+      "staticRemotesPort": {
+        "type": "number",
+        "description": "The port at which to serve the file-server for the static remotes."
       }
     },
     "presets": []

--- a/docs/generated/packages/web/executors/file-server.json
+++ b/docs/generated/packages/web/executors/file-server.json
@@ -90,6 +90,12 @@
         "type": "number",
         "description": "Set cache time (in seconds) for cache-control max-age header. To disable caching, use -1. Caching defaults to disabled.",
         "default": -1
+      },
+      "skipInitialRun": {
+        "type": "boolean",
+        "description": "Skip the initial run of the build target.",
+        "default": false,
+        "x-priority": "internal"
       }
     },
     "additionalProperties": false,

--- a/docs/generated/packages/web/executors/file-server.json
+++ b/docs/generated/packages/web/executors/file-server.json
@@ -90,16 +90,9 @@
         "type": "number",
         "description": "Set cache time (in seconds) for cache-control max-age header. To disable caching, use -1. Caching defaults to disabled.",
         "default": -1
-      },
-      "skipInitialRun": {
-        "type": "boolean",
-        "description": "Skip the initial run of the build target.",
-        "default": false,
-        "x-priority": "internal"
       }
     },
     "additionalProperties": false,
-    "required": ["buildTarget"],
     "presets": []
   },
   "description": "Serve a web application from a folder.",

--- a/e2e/angular-core/src/module-federation.test.ts
+++ b/e2e/angular-core/src/module-federation.test.ts
@@ -316,6 +316,8 @@ describe('Angular Module Federation', () => {
     const module = uniq('module');
     const host = uniq('host');
 
+    const hostPort = 4200;
+
     runCLI(
       `generate @nx/angular:host ${host} --remotes=${remote} --no-interactive --projectNameAndRootFormat=as-provided`
     );
@@ -383,7 +385,7 @@ describe('Angular Module Federation', () => {
         `e2e ${host}-e2e --no-watch --verbose`,
         (output) => output.includes('All specs passed!')
       );
-      await killProcessAndPorts(hostE2eResults.pid);
+      await killProcessAndPorts(hostE2eResults.pid, hostPort, hostPort + 1);
     }
   }, 500_000);
 
@@ -393,6 +395,7 @@ describe('Angular Module Federation', () => {
     const childRemote = uniq('childremote');
     const module = uniq('module');
     const host = uniq('host');
+    const hostPort = 4200;
 
     runCLI(
       `generate @nx/angular:host ${host} --remotes=${remote} --no-interactive --projectNameAndRootFormat=as-provided`
@@ -478,7 +481,7 @@ describe('Angular Module Federation', () => {
         `e2e ${host}-e2e --no-watch --verbose`,
         (output) => output.includes('All specs passed!')
       );
-      await killProcessAndPorts(hostE2eResults.pid);
+      await killProcessAndPorts(hostE2eResults.pid, hostPort, hostPort + 1);
     }
   }, 500_000);
 });

--- a/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -1,28 +1,235 @@
-import {
-  logger,
-  readCachedProjectGraph,
-  readNxJson,
-  workspaceRoot,
-} from '@nx/devkit';
-import {
-  getModuleFederationConfig,
-  getRemotes,
-} from '@nx/webpack/src/utils/module-federation';
-import { fork } from 'child_process';
-import { existsSync } from 'fs';
-import { scheduleTarget } from 'nx/src/adapter/ngcli-adapter';
-import { getExecutorInformation } from 'nx/src/command-line/run/executor-utils';
-import { readProjectsConfigurationFromProjectGraph } from 'nx/src/project-graph/project-graph';
-import { extname, join } from 'path';
-import { combineLatest, concatMap, from, switchMap } from 'rxjs';
-import { validateDevRemotes } from '../utilities/module-federation';
-import { executeWebpackDevServerBuilder } from '../webpack-dev-server/webpack-dev-server.impl';
 import type {
   NormalizedSchema,
   Schema,
   SchemaWithBrowserTarget,
   SchemaWithBuildTarget,
 } from './schema';
+import {
+  logger,
+  type ProjectConfiguration,
+  type ProjectGraph,
+  readCachedProjectGraph,
+  readNxJson,
+  workspaceRoot,
+} from '@nx/devkit';
+import { scheduleTarget } from 'nx/src/adapter/ngcli-adapter';
+import { executeWebpackDevServerBuilder } from '../webpack-dev-server/webpack-dev-server.impl';
+import { readProjectsConfigurationFromProjectGraph } from 'nx/src/project-graph/project-graph';
+import { getExecutorInformation } from 'nx/src/command-line/run/executor-utils';
+import { validateDevRemotes } from '../utilities/module-federation';
+import { existsSync } from 'fs';
+import { dirname, extname, join } from 'path';
+import {
+  getModuleFederationConfig,
+  getRemotes,
+} from '@nx/webpack/src/utils/module-federation';
+import { fork } from 'child_process';
+import { combineLatest, concatMap, from, switchMap } from 'rxjs';
+import { cpSync } from 'fs';
+
+function buildStaticRemotes(
+  remotes: {
+    remotePorts: any[];
+    staticRemotes: string[];
+    devRemotes: string[];
+  },
+  nxBin,
+  context: import('@angular-devkit/architect').BuilderContext,
+  options: Schema
+) {
+  const staticRemoteBuildPromise = new Promise<void>((res) => {
+    logger.info(
+      `NX Building ${remotes.staticRemotes.length} static remotes...`
+    );
+    const staticProcess = fork(
+      nxBin,
+      [
+        'run-many',
+        `--target=build`,
+        `--projects=${remotes.staticRemotes.join(',')}`,
+        ...(context.target.configuration
+          ? [`--configuration=${context.target.configuration}`]
+          : []),
+        ...(options.parallel ? [`--parallel=${options.parallel}`] : []),
+      ],
+      {
+        cwd: context.workspaceRoot,
+        stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+      }
+    );
+    staticProcess.stdout.on('data', (data) => {
+      const ANSII_CODE_REGEX =
+        /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
+      const stdoutString = data.toString().replace(ANSII_CODE_REGEX, '');
+      if (stdoutString.includes('Successfully ran target build')) {
+        staticProcess.stdout.removeAllListeners('data');
+        logger.info(`NX Built ${remotes.staticRemotes.length} static remotes`);
+        res();
+      }
+    });
+    staticProcess.stderr.on('data', (data) => logger.info(data.toString()));
+    staticProcess.on('exit', (code) => {
+      if (code !== 0) {
+        throw new Error(`Remotes failed to build. See above for errors.`);
+      }
+    });
+    process.on('SIGTERM', () => staticProcess.kill('SIGTERM'));
+    process.on('exit', () => staticProcess.kill('SIGTERM'));
+  });
+  return staticRemoteBuildPromise;
+}
+
+function startStaticRemotesFileServer(
+  remotes: {
+    remotePorts: any[];
+    staticRemotes: string[];
+    devRemotes: string[];
+  },
+  projectGraph: ProjectGraph,
+  options: Schema,
+  context: import('@angular-devkit/architect').BuilderContext
+) {
+  const mappedLocationOfRemotes: Record<string, string> = {};
+  let shouldMoveToCommonLocation = false;
+  let commonOutputDirectory: string;
+
+  for (const app of remotes.staticRemotes) {
+    const outputPath =
+      projectGraph.nodes[app].data.targets['build'].options.outputPath;
+    const directoryOfOutputPath = dirname(outputPath);
+
+    if (!commonOutputDirectory) {
+      commonOutputDirectory = directoryOfOutputPath;
+    } else if (commonOutputDirectory !== directoryOfOutputPath) {
+      shouldMoveToCommonLocation = true;
+    }
+
+    mappedLocationOfRemotes[app] = `http${options.ssl ? 's' : ''}://${
+      options.host
+    }:${options.staticRemotesPort}/${app}`;
+  }
+
+  process.env.NX_MF_DEV_SERVER_STATIC_REMOTES = JSON.stringify(
+    mappedLocationOfRemotes
+  );
+
+  if (shouldMoveToCommonLocation) {
+    commonOutputDirectory = join(workspaceRoot, 'tmp/static-remotes');
+    for (const app of remotes.staticRemotes) {
+      const outputPath =
+        projectGraph.nodes[app].data.targets['build'].options.outputPath;
+      cpSync(outputPath, commonOutputDirectory, {
+        force: true,
+        recursive: true,
+      });
+    }
+  }
+
+  const staticRemotesIter$ = from(
+    import('@nx/web/src/executors/file-server/file-server.impl')
+  ).pipe(
+    switchMap((fileServerExecutor) =>
+      fileServerExecutor.default(
+        {
+          skipInitialRun: true,
+          cors: true,
+          watch: false,
+          staticFilePath: commonOutputDirectory,
+          buildTarget: '',
+          parallel: false,
+          spa: false,
+          withDeps: false,
+          host: options.host,
+          port: options.staticRemotesPort,
+          ssl: options.ssl,
+          sslCert: options.sslCert,
+          sslKey: options.sslKey,
+        },
+        {
+          projectGraph,
+          root: context.workspaceRoot,
+          target:
+            projectGraph.nodes[context.target.project].data.targets[
+              context.target.target
+            ],
+          targetName: context.target.target,
+          projectName: context.target.project,
+          configurationName: context.target.configuration,
+          cwd: context.currentDirectory,
+          isVerbose: options.verbose,
+          projectsConfigurations:
+            readProjectsConfigurationFromProjectGraph(projectGraph),
+          nxJsonConfiguration: readNxJson(),
+        }
+      )
+    )
+  );
+  return staticRemotesIter$;
+}
+
+function startDevRemotes(
+  remotes: {
+    remotePorts: any[];
+    staticRemotes: string[];
+    devRemotes: string[];
+  },
+  workspaceProjects: Record<string, ProjectConfiguration>,
+  options: Schema,
+  context: import('@angular-devkit/architect').BuilderContext
+) {
+  const devRemotes$ = [];
+  for (const app of remotes.devRemotes) {
+    if (!workspaceProjects[app].targets?.['serve']) {
+      throw new Error(`Could not find "serve" target in "${app}" project.`);
+    } else if (!workspaceProjects[app].targets?.['serve'].executor) {
+      throw new Error(
+        `Could not find executor for "serve" target in "${app}" project.`
+      );
+    }
+
+    const runOptions: { verbose?: boolean; isInitialHost?: boolean } = {};
+    const [collection, executor] =
+      workspaceProjects[app].targets['serve'].executor.split(':');
+    const isUsingModuleFederationDevServerExecutor = executor.includes(
+      'module-federation-dev-server'
+    );
+    const { schema } = getExecutorInformation(
+      collection,
+      executor,
+      workspaceRoot
+    );
+    if (
+      (options.verbose && schema.additionalProperties) ||
+      'verbose' in schema.properties
+    ) {
+      runOptions.verbose = options.verbose;
+    }
+
+    if (isUsingModuleFederationDevServerExecutor) {
+      runOptions.isInitialHost = false;
+    }
+
+    const serve$ = scheduleTarget(
+      context.workspaceRoot,
+      {
+        project: app,
+        target: 'serve',
+        configuration: context.target.configuration,
+        runOptions,
+      },
+      options.verbose
+    ).then((obs) => {
+      obs.toPromise().catch((err) => {
+        throw new Error(
+          `Remote '${app}' failed to serve correctly due to the following: \r\n${err.toString()}`
+        );
+      });
+    });
+
+    devRemotes$.push(serve$);
+  }
+  return devRemotes$;
+}
 
 export function executeModuleFederationDevServerBuilder(
   schema: Schema,
@@ -31,6 +238,8 @@ export function executeModuleFederationDevServerBuilder(
   // Force Node to resolve to look for the nx binary that is inside node_modules
   const nxBin = require.resolve('nx/bin/nx');
   const options = normalizeOptions(schema);
+  options.staticRemotesPort ??= options.port + 1;
+
   const projectGraph = readCachedProjectGraph();
   const { projects: workspaceProjects } =
     readProjectsConfigurationFromProjectGraph(projectGraph);
@@ -122,150 +331,34 @@ export function executeModuleFederationDevServerBuilder(
     pathToManifestFile
   );
 
-  const staticRemoteBuildPromise = new Promise<void>((res) => {
-    logger.info(
-      `NX Building ${remotes.staticRemotes.length} static remotes...`
-    );
-    const staticProcess = fork(
-      nxBin,
-      [
-        'run-many',
-        `--target=build`,
-        `--projects=${remotes.staticRemotes.join(',')}`,
-        ...(context.target.configuration
-          ? [`--configuration=${context.target.configuration}`]
-          : []),
-        ...(options.parallel ? [`--parallel=${options.parallel}`] : []),
-      ],
-      {
-        cwd: context.workspaceRoot,
-        stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
-      }
-    );
-    staticProcess.stdout.on('data', (data) => {
-      const ANSII_CODE_REGEX =
-        /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
-      const stdoutString = data.toString().replace(ANSII_CODE_REGEX, '');
-      if (stdoutString.includes('Successfully ran target build')) {
-        staticProcess.stdout.removeAllListeners('data');
-        logger.info(`NX Built ${remotes.staticRemotes.length} static remotes`);
-        res();
-      }
-    });
-    staticProcess.stderr.on('data', (data) => logger.info(data.toString()));
-    staticProcess.on('exit', (code) => {
-      if (code !== 0) {
-        throw new Error(`Remotes failed to build. See above for errors.`);
-      }
-    });
-    process.on('SIGTERM', () => staticProcess.kill('SIGTERM'));
-    process.on('exit', () => staticProcess.kill('SIGTERM'));
-  });
+  const staticRemoteBuildPromise = buildStaticRemotes(
+    remotes,
+    nxBin,
+    context,
+    options
+  );
 
   return from(staticRemoteBuildPromise).pipe(
     concatMap(() => {
-      let isCollectingStaticRemoteOutput = true;
+      const staticRemotesIter$ = startStaticRemotesFileServer(
+        remotes,
+        projectGraph,
+        options,
+        context
+      );
 
-      for (const app of remotes.staticRemotes) {
-        const remoteProjectServeTarget =
-          projectGraph.nodes[app].data.targets['serve-static'];
-        const isUsingModuleFederationDevServerExecutor =
-          remoteProjectServeTarget.executor.includes(
-            'module-federation-dev-server'
-          );
-        let outWithErr: null | string[] = [];
-        const staticProcess = fork(
-          nxBin,
-          [
-            'run',
-            `${app}:serve-static${
-              context.target.configuration
-                ? `:${context.target.configuration}`
-                : ''
-            }`,
-            ...(isUsingModuleFederationDevServerExecutor
-              ? [`--isInitialHost=false`]
-              : []),
-          ],
-          {
-            cwd: context.workspaceRoot,
-            stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
-          }
-        );
-        staticProcess.stdout.on('data', (data) => {
-          if (isCollectingStaticRemoteOutput) {
-            outWithErr.push(data.toString());
-          } else {
-            outWithErr = null;
-            staticProcess.stdout.removeAllListeners('data');
-          }
-        });
-        staticProcess.stderr.on('data', (data) => logger.info(data.toString()));
-        staticProcess.on('exit', (code) => {
-          if (code !== 0) {
-            logger.info(outWithErr.join(''));
-            throw new Error(`Remote failed to start. See above for errors.`);
-          }
-        });
-        process.on('SIGTERM', () => staticProcess.kill('SIGTERM'));
-        process.on('exit', () => staticProcess.kill('SIGTERM'));
-      }
-
-      const devRemotes$ = [];
-      for (const app of remotes.devRemotes) {
-        if (!workspaceProjects[app].targets?.['serve']) {
-          throw new Error(`Could not find "serve" target in "${app}" project.`);
-        } else if (!workspaceProjects[app].targets?.['serve'].executor) {
-          throw new Error(
-            `Could not find executor for "serve" target in "${app}" project.`
-          );
-        }
-
-        const runOptions: { verbose?: boolean; isInitialHost?: boolean } = {};
-        const [collection, executor] =
-          workspaceProjects[app].targets['serve'].executor.split(':');
-        const isUsingModuleFederationDevServerExecutor = executor.includes(
-          'module-federation-dev-server'
-        );
-        const { schema } = getExecutorInformation(
-          collection,
-          executor,
-          workspaceRoot
-        );
-        if (
-          (options.verbose && schema.additionalProperties) ||
-          'verbose' in schema.properties
-        ) {
-          runOptions.verbose = options.verbose;
-        }
-
-        if (isUsingModuleFederationDevServerExecutor) {
-          runOptions.isInitialHost = false;
-        }
-
-        const serve$ = scheduleTarget(
-          context.workspaceRoot,
-          {
-            project: app,
-            target: 'serve',
-            configuration: context.target.configuration,
-            runOptions,
-          },
-          options.verbose
-        ).then((obs) => {
-          obs.toPromise().catch((err) => {
-            throw new Error(
-              `Remote '${app}' failed to serve correctly due to the following: \r\n${err.toString()}`
-            );
-          });
-        });
-
-        devRemotes$.push(serve$);
-      }
+      const devRemotes$ = startDevRemotes(
+        remotes,
+        workspaceProjects,
+        options,
+        context
+      );
 
       return devRemotes$.length > 0
-        ? combineLatest([...devRemotes$]).pipe(concatMap(() => currExecutor))
-        : currExecutor;
+        ? combineLatest([...devRemotes$, staticRemotesIter$]).pipe(
+            concatMap(() => currExecutor)
+          )
+        : from(staticRemotesIter$).pipe(concatMap(() => currExecutor));
     })
   );
 }

--- a/packages/angular/src/builders/module-federation-dev-server/schema.d.ts
+++ b/packages/angular/src/builders/module-federation-dev-server/schema.d.ts
@@ -22,6 +22,7 @@ interface BaseSchema {
   static?: boolean;
   isInitialHost?: boolean;
   parallel?: number;
+  staticRemotesPort?: number;
 }
 
 export type SchemaWithBrowserTarget = BaseSchema & {

--- a/packages/angular/src/builders/module-federation-dev-server/schema.json
+++ b/packages/angular/src/builders/module-federation-dev-server/schema.json
@@ -142,6 +142,10 @@
     "parallel": {
       "type": "number",
       "description": "Max number of parallel processes for building static remotes"
+    },
+    "staticRemotesPort": {
+      "type": "number",
+      "description": "The port at which to serve the file-server for the static remotes."
     }
   },
   "additionalProperties": false,

--- a/packages/angular/src/utils/mf/utils.ts
+++ b/packages/angular/src/utils/mf/utils.ts
@@ -48,6 +48,14 @@ export function getFunctionDeterminateRemoteUrl(isServer: boolean = false) {
   const remoteEntry = isServer ? 'server/remoteEntry.js' : 'remoteEntry.mjs';
 
   return function (remote: string) {
+    const mappedStaticRemotesFromEnv = process.env
+      .NX_MF_DEV_SERVER_STATIC_REMOTES
+      ? JSON.parse(process.env.NX_MF_DEV_SERVER_STATIC_REMOTES)
+      : undefined;
+    if (mappedStaticRemotesFromEnv && mappedStaticRemotesFromEnv[remote]) {
+      return `${mappedStaticRemotesFromEnv[remote]}/${remoteEntry}`;
+    }
+
     let remoteConfiguration = null;
     try {
       remoteConfiguration = readCachedProjectConfiguration(remote);

--- a/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -4,6 +4,7 @@ import {
   parseTargetString,
   readTargetOptions,
   runExecutor,
+  workspaceRoot,
 } from '@nx/devkit';
 import devServerExecutor from '@nx/webpack/src/executors/dev-server/dev-server.impl';
 import fileServerExecutor from '@nx/web/src/executors/file-server/file-server.impl';
@@ -18,6 +19,8 @@ import {
 } from '@nx/devkit/src/utils/async-iterable';
 import { waitForPortOpen } from '@nx/web/src/utils/wait-for-port-open';
 import { fork } from 'child_process';
+import { dirname, join } from 'path';
+import { cpSync } from 'fs';
 
 type ModuleFederationDevServerOptions = WebDevServerOptions & {
   devRemotes?: string[];
@@ -25,6 +28,7 @@ type ModuleFederationDevServerOptions = WebDevServerOptions & {
   static?: boolean;
   isInitialHost?: boolean;
   parallel?: number;
+  staticRemotesPort?: number;
 };
 
 function getBuildOptions(buildTarget: string, context: ExecutorContext) {
@@ -37,10 +41,164 @@ function getBuildOptions(buildTarget: string, context: ExecutorContext) {
   };
 }
 
+function startStaticRemotesFileServer(
+  remotes: {
+    remotePorts: any[];
+    staticRemotes: string[];
+    devRemotes: string[];
+  },
+  context: ExecutorContext,
+  options: ModuleFederationDevServerOptions
+) {
+  const mappedLocationOfRemotes: Record<string, string> = {};
+  let shouldMoveToCommonLocation = false;
+  let commonOutputDirectory: string;
+  for (const app of remotes.staticRemotes) {
+    const outputPath =
+      context.projectGraph.nodes[app].data.targets['build'].options.outputPath;
+    const directoryOfOutputPath = dirname(outputPath);
+
+    if (!commonOutputDirectory) {
+      commonOutputDirectory = directoryOfOutputPath;
+    } else if (commonOutputDirectory !== directoryOfOutputPath) {
+      shouldMoveToCommonLocation = true;
+    }
+
+    mappedLocationOfRemotes[app] = `http${options.ssl ? 's' : ''}://${
+      options.host
+    }:${options.staticRemotesPort}/${app}`;
+  }
+
+  process.env.NX_MF_DEV_SERVER_STATIC_REMOTES = JSON.stringify(
+    mappedLocationOfRemotes
+  );
+
+  if (shouldMoveToCommonLocation) {
+    commonOutputDirectory = join(workspaceRoot, 'tmp/static-remotes');
+    for (const app of remotes.staticRemotes) {
+      const outputPath =
+        context.projectGraph.nodes[app].data.targets['build'].options
+          .outputPath;
+      cpSync(outputPath, commonOutputDirectory, {
+        force: true,
+        recursive: true,
+      });
+    }
+  }
+
+  const staticRemotesIter = fileServerExecutor(
+    {
+      skipInitialRun: true,
+      cors: true,
+      watch: false,
+      staticFilePath: commonOutputDirectory,
+      buildTarget: '',
+      parallel: false,
+      spa: false,
+      withDeps: false,
+      host: options.host,
+      port: options.staticRemotesPort,
+      ssl: options.ssl,
+      sslCert: options.sslCert,
+      sslKey: options.sslKey,
+    },
+    context
+  );
+  return staticRemotesIter;
+}
+
+async function startDevRemotes(
+  remotes: {
+    remotePorts: any[];
+    staticRemotes: string[];
+    devRemotes: string[];
+  },
+  context: ExecutorContext
+) {
+  const devRemoteIters: AsyncIterable<{ success: boolean }>[] = [];
+
+  for (const app of remotes.devRemotes) {
+    const remoteProjectServeTarget =
+      context.projectGraph.nodes[app].data.targets['serve'];
+    const isUsingModuleFederationDevServerExecutor =
+      remoteProjectServeTarget.executor.includes(
+        'module-federation-dev-server'
+      );
+
+    devRemoteIters.push(
+      await runExecutor(
+        {
+          project: app,
+          target: 'serve',
+          configuration: context.configurationName,
+        },
+        {
+          watch: true,
+          ...(isUsingModuleFederationDevServerExecutor
+            ? { isInitialHost: false }
+            : {}),
+        },
+        context
+      )
+    );
+  }
+  return devRemoteIters;
+}
+
+async function buildStaticRemotes(
+  remotes: {
+    remotePorts: any[];
+    staticRemotes: string[];
+    devRemotes: string[];
+  },
+  nxBin,
+  context: ExecutorContext,
+  options: ModuleFederationDevServerOptions
+) {
+  logger.info(`NX Building ${remotes.staticRemotes.length} static remotes...`);
+  await new Promise<void>((res) => {
+    const staticProcess = fork(
+      nxBin,
+      [
+        'run-many',
+        `--target=build`,
+        `--projects=${remotes.staticRemotes.join(',')}`,
+        ...(context.configurationName
+          ? [`--configuration=${context.configurationName}`]
+          : []),
+        ...(options.parallel ? [`--parallel=${options.parallel}`] : []),
+      ],
+      {
+        cwd: context.root,
+        stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+      }
+    );
+    staticProcess.stdout.on('data', (data) => {
+      const ANSII_CODE_REGEX =
+        /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
+      const stdoutString = data.toString().replace(ANSII_CODE_REGEX, '');
+      if (stdoutString.includes('Successfully ran target build')) {
+        staticProcess.stdout.removeAllListeners('data');
+        logger.info(`NX Built ${remotes.staticRemotes.length} static remotes`);
+        res();
+      }
+    });
+    staticProcess.stderr.on('data', (data) => logger.info(data.toString()));
+    staticProcess.on('exit', (code) => {
+      if (code !== 0) {
+        throw new Error(`Remote failed to start. See above for errors.`);
+      }
+    });
+    process.on('SIGTERM', () => staticProcess.kill('SIGTERM'));
+    process.on('exit', () => staticProcess.kill('SIGTERM'));
+  });
+}
+
 export default async function* moduleFederationDevServer(
   options: ModuleFederationDevServerOptions,
   context: ExecutorContext
 ): AsyncIterableIterator<{ success: boolean; baseUrl?: string }> {
+  options.staticRemotesPort ??= options.port + 1;
   // Force Node to resolve to look for the nx binary that is inside node_modules
   const nxBin = require.resolve('nx/bin/nx');
   const currIter = options.static
@@ -81,117 +239,19 @@ export default async function* moduleFederationDevServer(
     }
   );
 
-  logger.info(`NX Building ${remotes.staticRemotes.length} static remotes...`);
-  await new Promise<void>((res) => {
-    const staticProcess = fork(
-      nxBin,
-      [
-        'run-many',
-        `--target=build`,
-        `--projects=${remotes.staticRemotes.join(',')}`,
-        ...(context.configurationName
-          ? [`--configuration=${context.configurationName}`]
-          : []),
-        ...(options.parallel ? [`--parallel=${options.parallel}`] : []),
-      ],
-      {
-        cwd: context.root,
-        stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
-      }
-    );
-    staticProcess.stdout.on('data', (data) => {
-      const ANSII_CODE_REGEX =
-        /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
-      const stdoutString = data.toString().replace(ANSII_CODE_REGEX, '');
-      if (stdoutString.includes('Successfully ran target build')) {
-        staticProcess.stdout.removeAllListeners('data');
-        logger.info(`NX Built ${remotes.staticRemotes.length} static remotes`);
-        res();
-      }
-    });
-    staticProcess.stderr.on('data', (data) => logger.info(data.toString()));
-    staticProcess.on('exit', (code) => {
-      if (code !== 0) {
-        throw new Error(`Remote failed to start. See above for errors.`);
-      }
-    });
-    process.on('SIGTERM', () => staticProcess.kill('SIGTERM'));
-    process.on('exit', () => staticProcess.kill('SIGTERM'));
-  });
+  await buildStaticRemotes(remotes, nxBin, context, options);
 
-  let isCollectingStaticRemoteOutput = true;
-  const devRemoteIters: AsyncIterable<{ success: boolean }>[] = [];
+  const devRemoteIters = await startDevRemotes(remotes, context);
 
-  for (const app of remotes.devRemotes) {
-    const remoteProjectServeTarget =
-      context.projectGraph.nodes[app].data.targets['serve'];
-    const isUsingModuleFederationDevServerExecutor =
-      remoteProjectServeTarget.executor.includes(
-        'module-federation-dev-server'
-      );
-
-    devRemoteIters.push(
-      await runExecutor(
-        {
-          project: app,
-          target: 'serve',
-          configuration: context.configurationName,
-        },
-        {
-          watch: true,
-          ...(isUsingModuleFederationDevServerExecutor
-            ? { isInitialHost: false }
-            : {}),
-        },
-        context
-      )
-    );
-  }
-  for (const app of remotes.staticRemotes) {
-    const remoteProjectServeTarget =
-      context.projectGraph.nodes[app].data.targets['serve-static'];
-    const isUsingModuleFederationDevServerExecutor =
-      remoteProjectServeTarget.executor.includes(
-        'module-federation-dev-server'
-      );
-    let outWithErr: null | string[] = [];
-    const staticProcess = fork(
-      nxBin,
-      [
-        'run',
-        `${app}:serve-static${
-          context.configurationName ? `:${context.configurationName}` : ''
-        }`,
-        ...(isUsingModuleFederationDevServerExecutor
-          ? [`--isInitialHost=false`]
-          : []),
-      ],
-      {
-        cwd: context.root,
-        stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
-      }
-    );
-    staticProcess.stdout.on('data', (data) => {
-      if (isCollectingStaticRemoteOutput) {
-        outWithErr.push(data.toString());
-      } else {
-        outWithErr = null;
-        staticProcess.stdout.removeAllListeners('data');
-      }
-    });
-    staticProcess.stderr.on('data', (data) => logger.info(data.toString()));
-    staticProcess.on('exit', (code) => {
-      if (code !== 0) {
-        logger.info(outWithErr.join(''));
-        throw new Error(`Remote failed to start. See above for errors.`);
-      }
-    });
-    process.on('SIGTERM', () => staticProcess.kill('SIGTERM'));
-    process.on('exit', () => staticProcess.kill('SIGTERM'));
-  }
+  const staticRemotesIter = startStaticRemotesFileServer(
+    remotes,
+    context,
+    options
+  );
 
   return yield* combineAsyncIterables(
     currIter,
+    staticRemotesIter,
     ...devRemoteIters,
     createAsyncIterable<{ success: true; baseUrl: string }>(
       async ({ next, done }) => {
@@ -204,18 +264,11 @@ export default async function* moduleFederationDevServer(
           return;
         }
         try {
-          await Promise.all(
-            remotes.remotePorts.map((port) =>
-              // Allow 20 minutes for each remote to start, which is plenty of time but we can tweak it later if needed.
-              // Most remotes should start in under 1 minute.
-              waitForPortOpen(port, {
-                retries: 480,
-                retryDelay: 2500,
-                host: 'localhost',
-              })
-            )
-          );
-          isCollectingStaticRemoteOutput = false;
+          await waitForPortOpen(options.staticRemotesPort, {
+            retries: 480,
+            retryDelay: 2500,
+            host: 'localhost',
+          });
           logger.info(
             `NX All remotes started, server ready at http://localhost:${options.port}`
           );

--- a/packages/react/src/executors/module-federation-dev-server/schema.json
+++ b/packages/react/src/executors/module-federation-dev-server/schema.json
@@ -105,6 +105,10 @@
     "parallel": {
       "type": "number",
       "description": "Max number of parallel processes for building static remotes"
+    },
+    "staticRemotesPort": {
+      "type": "number",
+      "description": "The port at which to serve the file-server for the static remotes."
     }
   }
 }

--- a/packages/react/src/module-federation/utils.ts
+++ b/packages/react/src/module-federation/utils.ts
@@ -21,6 +21,14 @@ export function getFunctionDeterminateRemoteUrl(isServer: boolean = false) {
   const remoteEntry = isServer ? 'server/remoteEntry.js' : 'remoteEntry.js';
 
   return function (remote: string) {
+    const mappedStaticRemotesFromEnv = process.env
+      .NX_MF_DEV_SERVER_STATIC_REMOTES
+      ? JSON.parse(process.env.NX_MF_DEV_SERVER_STATIC_REMOTES)
+      : undefined;
+    if (mappedStaticRemotesFromEnv && mappedStaticRemotesFromEnv[remote]) {
+      return `${mappedStaticRemotesFromEnv[remote]}/${remoteEntry}`;
+    }
+
     let remoteConfiguration = null;
     try {
       remoteConfiguration = readCachedProjectConfiguration(remote);

--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -140,8 +140,10 @@ export default async function* fileServerExecutor(
     disposeWatch = await createFileWatcher(context.projectName, run);
   }
 
-  // perform initial run
-  run();
+  if (!options.skipInitialRun) {
+    // perform initial run
+    run();
+  }
 
   const outputPath = getBuildTargetOutputPath(options, context);
 

--- a/packages/web/src/executors/file-server/schema.d.ts
+++ b/packages/web/src/executors/file-server/schema.d.ts
@@ -5,7 +5,7 @@ export interface Schema {
   sslKey?: string;
   sslCert?: string;
   proxyUrl?: string;
-  buildTarget: string;
+  buildTarget?: string;
   parallel: boolean;
   maxParallel?: number;
   withDeps: boolean;
@@ -17,5 +17,4 @@ export interface Schema {
   gzip?: boolean;
   brotli?: boolean;
   cacheSeconds?: number;
-  skipInitialRun?: boolean;
 }

--- a/packages/web/src/executors/file-server/schema.d.ts
+++ b/packages/web/src/executors/file-server/schema.d.ts
@@ -17,4 +17,5 @@ export interface Schema {
   gzip?: boolean;
   brotli?: boolean;
   cacheSeconds?: number;
+  skipInitialRun?: boolean;
 }

--- a/packages/web/src/executors/file-server/schema.json
+++ b/packages/web/src/executors/file-server/schema.json
@@ -92,14 +92,7 @@
       "type": "number",
       "description": "Set cache time (in seconds) for cache-control max-age header. To disable caching, use -1. Caching defaults to disabled.",
       "default": -1
-    },
-    "skipInitialRun": {
-      "type": "boolean",
-      "description": "Skip the initial run of the build target.",
-      "default": false,
-      "x-priority": "internal"
     }
   },
-  "additionalProperties": false,
-  "required": ["buildTarget"]
+  "additionalProperties": false
 }

--- a/packages/web/src/executors/file-server/schema.json
+++ b/packages/web/src/executors/file-server/schema.json
@@ -92,6 +92,12 @@
       "type": "number",
       "description": "Set cache time (in seconds) for cache-control max-age header. To disable caching, use -1. Caching defaults to disabled.",
       "default": -1
+    },
+    "skipInitialRun": {
+      "type": "boolean",
+      "description": "Skip the initial run of the build target.",
+      "default": false,
+      "x-priority": "internal"
     }
   },
   "additionalProperties": false,

--- a/packages/webpack/src/utils/module-federation/get-remotes-for-host.ts
+++ b/packages/webpack/src/utils/module-federation/get-remotes-for-host.ts
@@ -114,7 +114,7 @@ export function getRemotes(
 
   const staticRemotes = knownRemotes.filter((r) => !devServeApps.has(r));
   const devServeRemotes = knownRemotes.filter((r) => devServeApps.has(r));
-  const remotePorts = knownRemotes.map(
+  const remotePorts = devServeRemotes.map(
     (r) => context.projectGraph.nodes[r].data.targets['serve'].options.port
   );
 


### PR DESCRIPTION
- feat(angular): use a single file server for static remotes
- feat(module-federation): ensure static remote file server doesn't conflict with dev remote port

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We currently spin up a forked process for every static remote to run a file-server for the remote.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We should use a single file-server for all the remotes



## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
