### PR TITLE
fix(linter): migrate custom ignorePath to flat config

### DIFF
--- a/packages/eslint/src/generators/convert-to-flat-config/__snapshots__/generator.spec.ts.snap
+++ b/packages/eslint/src/generators/convert-to-flat-config/__snapshots__/generator.spec.ts.snap
@@ -135,7 +135,7 @@ module.exports = [
 "
 `;
 
-exports[`convert-to-flat-config generator should add global gitignores 1`] = `
+exports[`convert-to-flat-config generator should add global eslintignores 1`] = `
 "const { FlatCompat } = require('@eslint/eslintrc');
 const nxEslintPlugin = require('@nx/eslint-plugin');
 const js = require('@eslint/js');
@@ -313,6 +313,33 @@ module.exports = [
     files: ['**/*.js', '**/*.jsx'],
     rules: {},
   })),
+];
+"
+`;
+
+exports[`convert-to-flat-config generator should handle custom eslintignores 1`] = `
+"const baseConfig = require('../../eslint.config.js');
+module.exports = [
+  ...baseConfig,
+  {
+    files: [
+      'libs/test-lib/**/*.ts',
+      'libs/test-lib/**/*.tsx',
+      'libs/test-lib/**/*.js',
+      'libs/test-lib/**/*.jsx',
+    ],
+    rules: {},
+  },
+  {
+    files: ['libs/test-lib/**/*.ts', 'libs/test-lib/**/*.tsx'],
+    rules: {},
+  },
+  {
+    files: ['libs/test-lib/**/*.js', 'libs/test-lib/**/*.jsx'],
+    rules: {},
+  },
+  { ignores: ['libs/test-lib/ignore/me'] },
+  { ignores: ['libs/test-lib/ignore/me/as/well'] },
 ];
 "
 `;

--- a/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.spec.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.spec.ts
@@ -62,7 +62,8 @@ describe('convertEslintJsonToFlatConfig', () => {
       tree,
       '',
       '.eslintrc.json',
-      'eslint.config.js'
+      'eslint.config.js',
+      ['.eslintignore']
     );
 
     expect(tree.read('eslint.config.js', 'utf-8')).toMatchInlineSnapshot(`
@@ -119,7 +120,6 @@ describe('convertEslintJsonToFlatConfig', () => {
     `);
 
     expect(tree.exists('.eslintrc.json')).toBeFalsy();
-    expect(tree.exists('.eslintignore')).toBeFalsy();
   });
 
   it('should convert project configs', async () => {
@@ -174,7 +174,8 @@ describe('convertEslintJsonToFlatConfig', () => {
       tree,
       'mylib',
       '.eslintrc.json',
-      'eslint.config.js'
+      'eslint.config.js',
+      ['mylib/.eslintignore']
     );
 
     expect(tree.read('mylib/eslint.config.js', 'utf-8')).toMatchInlineSnapshot(`
@@ -229,6 +230,5 @@ describe('convertEslintJsonToFlatConfig', () => {
     `);
 
     expect(tree.exists('mylib/.eslintrc.json')).toBeFalsy();
-    expect(tree.exists('mylib/.eslintignore')).toBeFalsy();
   });
 });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
- Flat config converter does not respect `ignorePath` 
- Flat config converter removes ignore file during the conversion of the config, which can lead to issues if some other project references the same ignore file.

## Expected Behavior
- Flat config converter should respect `ignorePath` and clean it up after the conversion
- Converter should remove ignore files only once all the projects have been converted

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
