### PR TITLE
fix(linter): do not expect project to have flat eslint config

### DIFF
--- a/packages/eslint/src/executors/lint/lint.impl.spec.ts
+++ b/packages/eslint/src/executors/lint/lint.impl.spec.ts
@@ -683,7 +683,7 @@ Please see https://nx.dev/guides/eslint for full guidance on how to resolve this
     jest.spyOn(fs, 'existsSync').mockReturnValue(true);
     await lintExecutor(createValidRunBuilderOptions(), mockContext);
     expect(mockResolveAndInstantiateESLint).toHaveBeenCalledWith(
-      'apps/proj/eslint.config.js',
+      undefined,
       {
         lintFilePatterns: [],
         eslintConfig: null,

--- a/packages/eslint/src/executors/lint/lint.impl.ts
+++ b/packages/eslint/src/executors/lint/lint.impl.ts
@@ -51,12 +51,6 @@ export default async function run(
     joinPathFragments(workspaceRoot, 'eslint.config.js')
   );
 
-  if (!eslintConfigPath && hasFlatConfig) {
-    const projectRoot =
-      context.projectsConfigurations.projects[context.projectName].root;
-    eslintConfigPath = joinPathFragments(projectRoot, 'eslint.config.js');
-  }
-
   const { eslint, ESLint } = await resolveAndInstantiateESLint(
     eslintConfigPath,
     normalizedOptions,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
We expect that each project has `eslint.config.js` when in flat config.

## Expected Behavior
Project can use root `eslint.config.js`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
