### PR TITLE
fix(repo): update `devcontainer.json` to use latest Node LTS (20.x.x)…

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,26 +3,28 @@
 {
   "name": "NxDevContainer",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "mcr.microsoft.com/devcontainers/typescript-node:0-18",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:20-bullseye",
   "features": {
     "ghcr.io/devcontainers/features/rust:1": {}
   },
-
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // 4211 = nx graph port
   "forwardPorts": [4211],
-
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "pnpm install",
+  "postCreateCommand": "./.devcontainer/postCreateCommand.sh",
+  // Configure tool-specific properties.
   "customizations": {
     "vscode": {
-      "extensions": ["nrwl.angular-console"]
+      "extensions": [
+        "nrwl.angular-console",
+        "firsttris.vscode-jest-runner",
+        "eamodio.gitlens"
+      ],
+      "settings": {
+        "debug.javascript.autoAttachFilter": "onlyWithFlag" // workaround for that issue: https://github.com/microsoft/vscode-js-debug/issues/374#issuecomment-622239998
+      }
     }
   }
-
-  // Configure tool-specific properties.
-  // "customizations": {},
-
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
   // "remoteUser": "root"
 }

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Update the underlying (Debian) OS, to make sure we have the latest security patches and libraries like 'GLIBC' 
+sudo apt-get update  && sudo apt-get -y upgrade
+
+# Update pnpm
+#npm install -g pnpm
+
+# Install dependencies
+pnpm install --frozen-lockfile
+

--- a/.prettierignore
+++ b/.prettierignore
@@ -36,3 +36,5 @@ graph/client/src/assets/generated-task-graphs
 CODEOWNERS
 
 /.nx/cache
+
+.pnpm-store


### PR DESCRIPTION
… and improved initial setup

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
As reported and  discussed in the Nx Champion discord channel,  right now, running a command lke `nx test js` within Nx repo **opened inside a DevContainer**,  fails with the following error:

```
 Test suite failed to run

    /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /workspaces/nx/packages/nx/src/native/nx.linux-x64-gnu.node)

      180 |           try {
      181 |             if (localFileExisted) {
    > 182 |               nativeBinding = require('./nx.linux-x64-gnu.node')
          |                               ^
      183 |             } else {
      184 |               nativeBinding = require('@nx/nx-linux-x64-gnu')
      185 |             }

      at CompileFunctionRuntime._loadModule (../../node_modules/.pnpm/jest-runtime@29.5.0/node_modules/jest-runtime/build/index.js:1009:29)
      at Object.<anonymous> (../nx/src/native/index.js:182:31)
      at Object.<anonymous> (../nx/src/hasher/task-hasher.ts:23:1)
      at Object.<anonymous> (../nx/src/hasher/hash-task.ts:4:1)
      at Object.<anonymous> (../nx/src/tasks-runner/task-orchestrator.ts:20:1)
      at Object.<anonymous> (../nx/src/tasks-runner/default-tasks-runner.ts:2:1)
      at Object.<anonymous> (../nx/src/devkit-exports.ts:223:1)
      at Object.<anonymous> (../devkit/index.ts:15:1)
      at Object.<anonymous> (src/generators/release-version/utils/resolve-local-package-dependencies.spec.ts:1:1)
```

This was due to **outdated native libraires** (here `GLIBC`)  in the underlying (Debian) OS of the base Docker Image
used by the `devcontainer` (https://hub.docker.com/_/microsoft-devcontainers-typescript-node)


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Opening Nx repo within a devcontainer should work fine as it was initially.

This PR:  
- Updated the Node version to latest LTS (20.x.x)
- Automated the udpate of the OS, to prevent aforementioned issue and include security patches
- Use `--frozen-lockfile` when post installing npm dependencies, 
- Improved other settings in the `devcontainer` (default extensions installed, some settings)
