### PR TITLE
feat(module-federation): Add react support for  dynamic federation

### DIFF
--- a/docs/generated/packages/react/generators/host.json
+++ b/docs/generated/packages/react/generators/host.json
@@ -68,6 +68,11 @@
         "enum": ["eslint"],
         "default": "eslint"
       },
+      "dynamic": {
+        "type": "boolean",
+        "description": "Should the host application use dynamic federation?",
+        "default": false
+      },
       "skipFormat": {
         "description": "Skip formatting files.",
         "type": "boolean",

--- a/docs/generated/packages/react/generators/remote.json
+++ b/docs/generated/packages/react/generators/remote.json
@@ -28,6 +28,12 @@
         "type": "string",
         "enum": ["as-provided", "derived"]
       },
+      "dynamic": {
+        "type": "boolean",
+        "description": "Should the host application use dynamic federation?",
+        "default": false,
+        "x-priority": "internal"
+      },
       "style": {
         "description": "The file extension to be used for style files.",
         "type": "string",

--- a/packages/react/mf/dynamic-federation.ts
+++ b/packages/react/mf/dynamic-federation.ts
@@ -1,0 +1,105 @@
+export type ResolveRemoteUrlFunction = (
+  remoteName: string
+) => string | Promise<string>;
+
+declare const window: {
+  [key: string]: any;
+};
+
+declare const document: {
+  head: {
+    appendChild: (script: HTMLScriptElement) => void;
+  };
+  createElement: (type: 'script') => any;
+};
+
+declare const __webpack_init_sharing__: (scope: 'default') => Promise<void>;
+declare const __webpack_share_scopes__: { default: unknown };
+let remoteUrlDefinitions: Record<string, string>;
+let resolveRemoteUrl: ResolveRemoteUrlFunction;
+const remoteModuleMap = new Map<string, unknown>();
+const remoteContainerMap = new Map<string, unknown>();
+let initialSharingScopeCreated = false;
+
+export function setRemoteUrlResolver(
+  _resolveRemoteUrl: ResolveRemoteUrlFunction
+) {
+  resolveRemoteUrl = _resolveRemoteUrl;
+}
+
+export function setRemoteDefinitions(definitions: Record<string, string>) {
+  remoteUrlDefinitions = definitions;
+}
+
+export async function loadRemoteModule(remoteName: string, moduleName: string) {
+  const remoteModuleKey = `${remoteName}:${moduleName}`;
+  if (remoteModuleMap.has(remoteModuleKey)) {
+    return remoteModuleMap.get(remoteModuleKey);
+  }
+
+  const container = remoteContainerMap.has(remoteName)
+    ? remoteContainerMap.get(remoteName)
+    : await loadRemoteContainer(remoteName);
+
+  const factory = await container.get(moduleName);
+  const Module = factory();
+
+  remoteModuleMap.set(remoteModuleKey, Module);
+
+  return Module;
+}
+
+const fetchRemoteModule = (url: string, remoteName: string): Promise<any> => {
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = url;
+    script.type = 'text/javascript';
+    script.async = true;
+    script.onload = () => {
+      const proxy = {
+        get: (request) => window[remoteName].get(request),
+        init: (arg) => {
+          try {
+            window[remoteName].init(arg);
+          } catch (e) {
+            console.error(`Failed to initialize remote ${remoteName}`, e);
+            reject(e);
+          }
+        },
+      };
+      resolve(proxy);
+    };
+    script.onerror = () => reject(new Error(`Remote ${remoteName} not found`));
+    document.head.appendChild(script);
+  });
+};
+
+async function loadRemoteContainer(remoteName: string) {
+  if (!resolveRemoteUrl && !remoteUrlDefinitions) {
+    throw new Error(
+      'Call setRemoteDefinitions or setRemoteUrlResolver to allow Dynamic Federation to find the remote apps correctly.'
+    );
+  }
+
+  if (!initialSharingScopeCreated) {
+    initialSharingScopeCreated = true;
+    await __webpack_init_sharing__('default');
+  }
+
+  const remoteUrl = remoteUrlDefinitions
+    ? remoteUrlDefinitions[remoteName]
+    : await resolveRemoteUrl(remoteName);
+
+  let containerUrl = remoteUrl;
+  if (!remoteUrl.endsWith('.mjs') && !remoteUrl.endsWith('.js')) {
+    containerUrl = `${remoteUrl}${
+      remoteUrl.endsWith('/') ? '' : '/'
+    }remoteEntry.js`;
+  }
+
+  const container = await fetchRemoteModule(containerUrl, remoteName);
+  await container.init(__webpack_share_scopes__.default);
+
+  remoteContainerMap.set(remoteName, container);
+  return container;
+}

--- a/packages/react/mf/index.ts
+++ b/packages/react/mf/index.ts
@@ -1,0 +1,5 @@
+export {
+  loadRemoteModule,
+  setRemoteDefinitions,
+  setRemoteUrlResolver,
+} from './dynamic-federation';

--- a/packages/react/src/generators/host/files/common/src/app/__fileName__.tsx__tmpl__
+++ b/packages/react/src/generators/host/files/common/src/app/__fileName__.tsx__tmpl__
@@ -3,12 +3,20 @@ import * as React from 'react';
 import NxWelcome from "./nx-welcome";
 <% } %>
 import { Link, Route, Routes } from 'react-router-dom';
+<% if (dynamic) { %>
+import { loadRemoteModule } from '@nx/react/mf';
+<% } %>
 
 <% if (remotes.length > 0) { %>
 <% remotes.forEach(function(r) { %>
+<% if (dynamic) { %>
+ const <%= r.className %> = React.lazy(() => loadRemoteModule('<%= r.fileName %>', './Module'))
+<% } else  { %>
  const <%= r.className %> = React.lazy(() => import('<%= r.fileName %>/Module'));
+<% } %>
  <% }); %>
 <% } %>
+
 export function App() {
   return (
     <React.Suspense fallback={null}>

--- a/packages/react/src/generators/host/files/module-federation-ssr-ts/module-federation.server.config.ts__tmpl__
+++ b/packages/react/src/generators/host/files/module-federation-ssr-ts/module-federation.server.config.ts__tmpl__
@@ -3,8 +3,11 @@ import { ModuleFederationConfig } from '@nx/webpack';
 const config: ModuleFederationConfig = {
     name: '<%= projectName %>',
     remotes: [
-    <% remotes.forEach(function(r) {%> "<%= r.fileName %>", <% }); %>
-    ],
+      <% if (static) { 
+         remotes.forEach(function(r) { %> "<%= r.fileName %>", <% }); 
+       }
+    %>
+  ],
 };
 
 export default config;

--- a/packages/react/src/generators/host/files/module-federation-ssr/module-federation.server.config.js__tmpl__
+++ b/packages/react/src/generators/host/files/module-federation-ssr/module-federation.server.config.js__tmpl__
@@ -6,8 +6,11 @@
 const moduleFederationConfig = {
     name: '<%= projectName %>',
     remotes: [
-    <% remotes.forEach(function(r) {%> "<%= r.fileName %>", <% }); %>
-    ],
+       <% if (static) { 
+         remotes.forEach(function(r) { %> "<%= r.fileName %>", <% }); 
+       }
+    %>
+  ],
 };
 
 module.exports = moduleFederationConfig;

--- a/packages/react/src/generators/host/files/module-federation-ts/module-federation.config.ts__tmpl__
+++ b/packages/react/src/generators/host/files/module-federation-ts/module-federation.config.ts__tmpl__
@@ -3,8 +3,11 @@ import { ModuleFederationConfig } from '@nx/webpack';
 const config: ModuleFederationConfig = {
     name: '<%= projectName %>',
     remotes: [
-        <% remotes.forEach(function(r) {%> "<%= r.fileName %>", <% }); %>
-],
+            <% if (static) { 
+         remotes.forEach(function(r) { %> "<%= r.fileName %>", <% }); 
+       }
+    %>
+  ],
 };
 
 export default config;

--- a/packages/react/src/generators/host/files/module-federation-ts/src/main.ts__tmpl__
+++ b/packages/react/src/generators/host/files/module-federation-ts/src/main.ts__tmpl__
@@ -1,1 +1,10 @@
-import('./bootstrap');
+<% if (dynamic) { %>
+    import { setRemoteDefinitions } from '@nx/react/mf';
+
+    fetch('/assets/module-federation.manifest.json')
+    .then((res) => res.json())
+    .then(definitions => setRemoteDefinitions(definitions))
+    .then(() =>  import('./bootstrap').catch(err => console.error(err)));
+<% } else { %>
+    import('./bootstrap').catch(err => console.error(err));
+<% } %>

--- a/packages/react/src/generators/host/files/module-federation/module-federation.config.js__tmpl__
+++ b/packages/react/src/generators/host/files/module-federation/module-federation.config.js__tmpl__
@@ -1,6 +1,9 @@
 module.exports = {
   name: '<%= projectName %>',
   remotes: [
-  <% remotes.forEach(function(r) {%> "<%= r.fileName %>", <% }); %>
+    <% if (static) { 
+         remotes.forEach(function(r) { %> "<%= r.fileName %>", <% }); 
+       }
+    %>
   ],
 };

--- a/packages/react/src/generators/host/files/module-federation/src/main.ts__tmpl__
+++ b/packages/react/src/generators/host/files/module-federation/src/main.ts__tmpl__
@@ -1,1 +1,10 @@
-import('./bootstrap');
+<% if (dynamic) { %>
+    import { setRemoteDefinitions } from '@nx/react/mf';
+
+    fetch('/assets/module-federation.manifest.json')
+    .then((res) => res.json())
+    .then(definitions => setRemoteDefinitions(definitions))
+    .then(() =>  import('./bootstrap').catch(err => console.error(err)));
+<% } else { %>
+    import('./bootstrap').catch(err => console.error(err));
+<% } %>

--- a/packages/react/src/generators/host/host.ts
+++ b/packages/react/src/generators/host/host.ts
@@ -39,6 +39,7 @@ export async function hostGeneratorInternal(
   const options: NormalizedSchema = {
     ...(await normalizeOptions<Schema>(host, schema, '@nx/react:host')),
     typescriptConfiguration: schema.typescriptConfiguration ?? true,
+    dynamic: schema.dynamic ?? false,
   };
 
   const initTask = await applicationGenerator(host, {
@@ -71,6 +72,8 @@ export async function hostGeneratorInternal(
         skipFormat: true,
         projectNameAndRootFormat: options.projectNameAndRootFormat,
         typescriptConfiguration: options.typescriptConfiguration,
+        dynamic: options.dynamic,
+        host: options.name,
       });
       tasks.push(remoteTask);
       remotePort++;

--- a/packages/react/src/generators/host/lib/setup-ssr-for-host.ts
+++ b/packages/react/src/generators/host/lib/setup-ssr-for-host.ts
@@ -33,6 +33,7 @@ export async function setupSsrForHost(
     project.root,
     {
       ...options,
+      static: !options?.dynamic,
       remotes: defaultRemoteManifest.map(({ name, port }) => {
         return {
           ...names(name),

--- a/packages/react/src/generators/host/schema.d.ts
+++ b/packages/react/src/generators/host/schema.d.ts
@@ -25,6 +25,7 @@ export interface Schema {
   unitTestRunner: 'jest' | 'vitest' | 'none';
   minimal?: boolean;
   typescriptConfiguration?: boolean;
+  dynamic?: boolean;
 }
 
 export interface NormalizedSchema extends Schema {

--- a/packages/react/src/generators/host/schema.json
+++ b/packages/react/src/generators/host/schema.json
@@ -74,6 +74,11 @@
       "enum": ["eslint"],
       "default": "eslint"
     },
+    "dynamic": {
+      "type": "boolean",
+      "description": "Should the host application use dynamic federation?",
+      "default": false
+    },
     "skipFormat": {
       "description": "Skip formatting files.",
       "type": "boolean",

--- a/packages/react/src/generators/remote/__snapshots__/remote.spec.ts.snap
+++ b/packages/react/src/generators/remote/__snapshots__/remote.spec.ts.snap
@@ -28,6 +28,7 @@ exports[`remote generator should create the remote with the correct config files
 exports[`remote generator should create the remote with the correct config files 3`] = `
 "module.exports = {
   name: 'test',
+
   exposes: {
     './Module': './src/remote-entry.ts',
   },
@@ -65,6 +66,7 @@ exports[`remote generator should create the remote with the correct config files
 
 const config: ModuleFederationConfig = {
   name: 'test',
+
   exposes: {
     './Module': './src/remote-entry.ts',
   },

--- a/packages/react/src/generators/remote/files/module-federation-ts/module-federation.config.ts__tmpl__
+++ b/packages/react/src/generators/remote/files/module-federation-ts/module-federation.config.ts__tmpl__
@@ -2,6 +2,9 @@ import {ModuleFederationConfig} from '@nx/webpack';
 
 const config: ModuleFederationConfig = {
     name: '<%= projectName %>',
+    <% if (dynamic) { %>
+   library: { type: 'var', name: '<%= projectName %>'},
+   <% } %>
     exposes: {
         './Module': './src/remote-entry.ts',
     },

--- a/packages/react/src/generators/remote/files/module-federation/module-federation.config.js__tmpl__
+++ b/packages/react/src/generators/remote/files/module-federation/module-federation.config.js__tmpl__
@@ -1,5 +1,8 @@
 module.exports = {
    name: '<%= projectName %>',
+   <% if (dynamic) { %>
+   library: { type: 'var', name: '<%= projectName %>'},
+   <% } %>
    exposes: {
      './Module': './src/remote-entry.ts',
    },

--- a/packages/react/src/generators/remote/lib/add-remote-to-dynamic-host.ts
+++ b/packages/react/src/generators/remote/lib/add-remote-to-dynamic-host.ts
@@ -1,0 +1,17 @@
+import { Tree } from '@nx/devkit';
+
+export function addRemoteToDynamicHost(
+  tree: Tree,
+  remoteName: string,
+  remotePort: number,
+  pathToMfManifest: string
+) {
+  const current = tree.read(pathToMfManifest, 'utf8');
+  tree.write(
+    pathToMfManifest,
+    JSON.stringify({
+      ...JSON.parse(current),
+      [remoteName]: `http://localhost:${remotePort}`,
+    })
+  );
+}

--- a/packages/react/src/generators/remote/remote.ts
+++ b/packages/react/src/generators/remote/remote.ts
@@ -20,6 +20,7 @@ import { Schema } from './schema';
 import setupSsrGenerator from '../setup-ssr/setup-ssr';
 import { setupSsrForRemote } from './lib/setup-ssr-for-remote';
 import { setupTspathForRemote } from './lib/setup-tspath-for-remote';
+import { addRemoteToDynamicHost } from './lib/add-remote-to-dynamic-host';
 
 export function addModuleFederationFiles(
   host: Tree,
@@ -72,6 +73,7 @@ export async function remoteGeneratorInternal(host: Tree, schema: Schema) {
   const options: NormalizedSchema<Schema> = {
     ...(await normalizeOptions<Schema>(host, schema, '@nx/react:remote')),
     typescriptConfiguration: schema.typescriptConfiguration ?? false,
+    dynamic: schema.dynamic ?? false,
   };
   const initAppTask = await applicationGenerator(host, {
     ...options,
@@ -118,6 +120,20 @@ export async function remoteGeneratorInternal(host: Tree, schema: Schema) {
       `webpack.server.config.${options.typescriptConfiguration ? 'ts' : 'js'}`
     );
     updateProjectConfiguration(host, options.projectName, projectConfig);
+  }
+
+  if (options.host && options.dynamic) {
+    const hostConfig = readProjectConfiguration(host, schema.host);
+    const pathToMFManifest = joinPathFragments(
+      hostConfig.sourceRoot,
+      'assets/module-federation.manifest.json'
+    );
+    addRemoteToDynamicHost(
+      host,
+      options.name,
+      options.devServerPort,
+      pathToMFManifest
+    );
   }
 
   if (!options.skipFormat) {

--- a/packages/react/src/generators/remote/schema.d.ts
+++ b/packages/react/src/generators/remote/schema.d.ts
@@ -26,6 +26,7 @@ export interface Schema {
   tags?: string;
   unitTestRunner: 'jest' | 'vitest' | 'none';
   typescriptConfiguration?: boolean;
+  dynamic?: boolean;
 }
 
 export interface NormalizedSchema extends ApplicationNormalizedSchema {

--- a/packages/react/src/generators/remote/schema.json
+++ b/packages/react/src/generators/remote/schema.json
@@ -28,6 +28,12 @@
       "type": "string",
       "enum": ["as-provided", "derived"]
     },
+    "dynamic": {
+      "type": "boolean",
+      "description": "Should the host application use dynamic federation?",
+      "default": false,
+      "x-priority": "internal"
+    },
     "style": {
       "description": "The file extension to be used for style files.",
       "type": "string",

--- a/packages/react/src/rules/update-module-federation-project.ts
+++ b/packages/react/src/rules/update-module-federation-project.ts
@@ -1,6 +1,7 @@
 import {
   addDependenciesToPackageJson,
   GeneratorCallback,
+  joinPathFragments,
   readProjectConfiguration,
   Tree,
   updateProjectConfiguration,
@@ -14,6 +15,7 @@ export function updateModuleFederationProject(
     appProjectRoot: string;
     devServerPort?: number;
     typescriptConfiguration?: boolean;
+    dynamic?: boolean;
   }
 ): GeneratorCallback {
   const projectConfig = readProjectConfiguration(host, options.projectName);
@@ -32,6 +34,19 @@ export function updateModuleFederationProject(
       options.typescriptConfiguration ? 'ts' : 'js'
     }`,
   };
+
+  // If host should be configured to use dynamic federation
+  if (options.dynamic) {
+    const pathToProdWebpackConfig = joinPathFragments(
+      projectConfig.root,
+      `webpack.prod.config.${options.typescriptConfiguration ? 'ts' : 'js'}`
+    );
+    if (host.exists(pathToProdWebpackConfig)) {
+      host.delete(pathToProdWebpackConfig);
+    }
+
+    delete projectConfig.targets.build.configurations.production?.webpackConfig;
+  }
 
   projectConfig.targets.serve.executor =
     '@nx/react:module-federation-dev-server';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Currently, we only support static federation or promise based modules.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
With this change, you will be able to load remotes via a manifest file (`module-federation.manifest.json`).

The host generator has been updated to behave similarly to `@nx/angular` that has the `--dynamic` flag.

```shell
nx generate @nx/react:host acme --remotes=nx --dynamic=true  --styles=css
```
This configures the host to dynamically load remotes via the manifest file.