### PR TITLE
fix(angular): stub performance.mark in jest test setup file

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -296,6 +296,15 @@
       },
       "description": "Rename 'browserTarget' to 'buildTarget'.",
       "factory": "./src/migrations/update-17-1-0/browser-target-to-build-target"
+    },
+    "stub-performance-mark-in-jest-test-setup": {
+      "cli": "nx",
+      "version": "17.1.0-beta.1",
+      "requires": {
+        "@angular/core": ">=17.0.0-rc.1"
+      },
+      "description": "Stubs out 'performance.mark' in the Jest test setup file.",
+      "factory": "./src/migrations/update-17-1-0/stub-performance-mark-in-jest-test-setup"
     }
   },
   "packageJsonUpdates": {

--- a/packages/angular/src/generators/library/library.ts
+++ b/packages/angular/src/generators/library/library.ts
@@ -14,6 +14,7 @@ import addLintingGenerator from '../add-linting/add-linting';
 import setupTailwindGenerator from '../setup-tailwind/setup-tailwind';
 import {
   addDependenciesToPackageJsonIfDontExist,
+  getInstalledAngularVersionInfo,
   versions,
 } from '../utils/version-utils';
 import { addBuildableLibrariesPostCssDependencies } from '../utils/dependencies';
@@ -140,6 +141,7 @@ async function addUnitTestRunner(
       'src',
       'test-setup.ts'
     );
+    const { major: angularMajorVersion } = getInstalledAngularVersionInfo(host);
     if (options.strict && host.exists(setupFile)) {
       const contents = host.read(setupFile, 'utf-8');
       host.write(
@@ -151,7 +153,17 @@ globalThis.ngJest = {
     errorOnUnknownProperties: true,
   },
 };
-${contents}`
+${contents}${
+          angularMajorVersion >= 17
+            ? `
+/**
+* Angular uses performance.mark() which is not supported by jsdom. Stub it out
+* to avoid errors.
+*/
+global.performance.mark = jest.fn();
+`
+            : ''
+        }`
       );
     }
   }

--- a/packages/angular/src/migrations/update-17-1-0/stub-performance-mark-in-jest-test-setup.spec.ts
+++ b/packages/angular/src/migrations/update-17-1-0/stub-performance-mark-in-jest-test-setup.spec.ts
@@ -1,0 +1,255 @@
+import {
+  addProjectConfiguration,
+  type ProjectConfiguration,
+  type ProjectGraph,
+  type Tree,
+} from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration from './stub-performance-mark-in-jest-test-setup';
+
+let projectGraph: ProjectGraph;
+jest.mock('@nx/devkit', () => ({
+  ...jest.requireActual('@nx/devkit'),
+  createProjectGraphAsync: () => Promise.resolve(projectGraph),
+}));
+
+describe('stub-performance-mark-in-jest-test-setup migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should add a stub for "performance.mark" for angular projects', async () => {
+    addProject(
+      tree,
+      'app1',
+      {
+        name: 'app1',
+        root: 'apps/app1',
+        targets: {
+          test: {
+            executor: '@nx/jest:jest',
+            options: { jestConfig: 'apps/app1/jest.config.ts' },
+          },
+        },
+      },
+      ['npm:@angular/core']
+    );
+    tree.write('apps/app1/jest.config.ts', jestConfigContents);
+    tree.write('apps/app1/src/test-setup.ts', setupFileContents);
+
+    await migration(tree);
+
+    expect(tree.read('apps/app1/src/test-setup.ts', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
+      globalThis.ngJest = {
+        testEnvironmentOptions: {
+          errorOnUnknownElements: true,
+          errorOnUnknownProperties: true,
+        },
+      };
+      import 'jest-preset-angular/setup-jest';
+
+      /**
+       * Angular uses performance.mark() which is not supported by jsdom. Stub it out
+       * to avoid errors.
+       */
+      global.performance.mark = jest.fn();
+      "
+    `);
+  });
+
+  it('should add a stub for "performance.mark" when using a custom setup file', async () => {
+    addProject(
+      tree,
+      'app1',
+      {
+        name: 'app1',
+        root: 'apps/app1',
+        targets: {
+          test: {
+            executor: '@nx/jest:jest',
+            options: { jestConfig: 'apps/app1/jest.config.ts' },
+          },
+        },
+      },
+      ['npm:@angular/core']
+    );
+    tree.write(
+      'apps/app1/jest.config.ts',
+      jestConfigContents.replace(
+        `['<rootDir>/src/test-setup.ts']`,
+        `['<rootDir>/src/custom-test-setup-file.ts']`
+      )
+    );
+    tree.write('apps/app1/src/custom-test-setup-file.ts', setupFileContents);
+
+    await migration(tree);
+
+    expect(tree.exists('apps/app1/src/test-setup.ts')).toBe(false);
+    expect(tree.read('apps/app1/src/custom-test-setup-file.ts', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
+      globalThis.ngJest = {
+        testEnvironmentOptions: {
+          errorOnUnknownElements: true,
+          errorOnUnknownProperties: true,
+        },
+      };
+      import 'jest-preset-angular/setup-jest';
+
+      /**
+       * Angular uses performance.mark() which is not supported by jsdom. Stub it out
+       * to avoid errors.
+       */
+      global.performance.mark = jest.fn();
+      "
+    `);
+  });
+
+  it('should handle when there is no setup file and not throw', async () => {
+    addProject(
+      tree,
+      'app1',
+      {
+        name: 'app1',
+        root: 'apps/app1',
+        targets: {
+          test: {
+            executor: '@nx/jest:jest',
+            options: { jestConfig: 'apps/app1/jest.config.ts' },
+          },
+        },
+      },
+      ['npm:@angular/core']
+    );
+    tree.write(
+      'apps/app1/jest.config.ts',
+      jestConfigContents.replace(
+        `setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],`,
+        ''
+      )
+    );
+
+    await expect(migration(tree)).resolves.not.toThrow();
+  });
+
+  it('should not add a stub for "performance.mark" for non-angular projects', async () => {
+    addProject(
+      tree,
+      'app1',
+      {
+        name: 'app1',
+        root: 'apps/app1',
+        targets: {
+          test: {
+            executor: '@nx/jest:jest',
+            options: { jestConfig: 'apps/app1/jest.config.ts' },
+          },
+        },
+      },
+      []
+    );
+    tree.write('apps/app1/jest.config.ts', jestConfigContents);
+    tree.write('apps/app1/src/test-setup.ts', setupFileContents);
+
+    await migration(tree);
+
+    expect(tree.read('apps/app1/src/test-setup.ts', 'utf-8')).not.toContain(
+      'global.performance.mark = jest.fn();'
+    );
+  });
+
+  it('should not add a stub for "performance.mark" when it is already being accessed', async () => {
+    addProject(
+      tree,
+      'app1',
+      {
+        name: 'app1',
+        root: 'apps/app1',
+        targets: {
+          test: {
+            executor: '@nx/jest:jest',
+            options: { jestConfig: 'apps/app1/jest.config.ts' },
+          },
+        },
+      },
+      []
+    );
+    tree.write('apps/app1/jest.config.ts', jestConfigContents);
+    tree.write(
+      'apps/app1/src/test-setup.ts',
+      `${setupFileContents}
+global.performance.mark = require('perf_hooks').performance.mark;`
+    );
+
+    await migration(tree);
+
+    expect(tree.read('apps/app1/src/test-setup.ts', 'utf-8')).not.toContain(
+      'global.performance.mark = jest.fn();'
+    );
+  });
+});
+
+function addProject(
+  tree: Tree,
+  projectName: string,
+  config: ProjectConfiguration,
+  dependencies: string[]
+): void {
+  projectGraph = {
+    dependencies: {
+      [projectName]: dependencies.map((d) => ({
+        source: projectName,
+        target: d,
+        type: 'static',
+      })),
+    },
+    nodes: {
+      [projectName]: { data: config, name: projectName, type: 'app' },
+    },
+  };
+  addProjectConfiguration(tree, projectName, config);
+}
+
+const jestConfigContents = `
+/* eslint-disable */
+export default {
+  displayName: 'foo',
+  preset: './jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  coverageDirectory: './coverage/foo',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+  testMatch: [
+    '<rootDir>/src/**/__tests__/**/*.[jt]s?(x)',
+    '<rootDir>/src/**/*(*.)@(spec|test).[jt]s?(x)',
+  ],
+};
+`;
+
+const setupFileContents = `
+// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
+globalThis.ngJest = {
+  testEnvironmentOptions: {
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true,
+  },
+};
+import 'jest-preset-angular/setup-jest';
+`;

--- a/packages/angular/src/migrations/update-17-1-0/stub-performance-mark-in-jest-test-setup.ts
+++ b/packages/angular/src/migrations/update-17-1-0/stub-performance-mark-in-jest-test-setup.ts
@@ -1,0 +1,103 @@
+import { createProjectGraphAsync, formatFiles, type Tree } from '@nx/devkit';
+import { forEachExecutorOptionsInGraph } from '@nx/devkit/src/generators/executor-options-utils';
+import type { JestExecutorOptions } from '@nx/jest/src/executors/jest/schema';
+import { tsquery } from '@phenomnomnominal/tsquery';
+import { dirname } from 'path';
+import * as ts from 'typescript';
+import { getProjectsFilteredByDependencies } from '../utils/projects';
+
+export default async function (tree: Tree): Promise<void> {
+  const angularProjects = await getProjectsFilteredByDependencies(tree, [
+    'npm:@angular/core',
+  ]);
+  const jestConfigFiles = new Set<string>();
+
+  const projectGraph = await createProjectGraphAsync();
+  forEachExecutorOptionsInGraph<JestExecutorOptions>(
+    projectGraph,
+    '@nx/jest:jest',
+    (options, projectName) => {
+      const projectConfig = angularProjects.find(
+        ({ project }) => projectName === project.name
+      );
+      if (!projectConfig) {
+        return;
+      }
+
+      if (options.jestConfig && tree.exists(options.jestConfig)) {
+        jestConfigFiles.add(options.jestConfig);
+      }
+    }
+  );
+
+  const setupFilePaths: string[] = [];
+  for (const jestConfigFile of jestConfigFiles) {
+    const projectSetupFilePaths = getSetupFilePaths(tree, jestConfigFile);
+    setupFilePaths.push(...projectSetupFilePaths);
+  }
+
+  for (const setupFilePath of setupFilePaths) {
+    if (!tree.exists(setupFilePath)) {
+      continue;
+    }
+
+    updateSetupFileWithPerformanceMarkStub(tree, setupFilePath);
+  }
+
+  await formatFiles(tree);
+}
+
+function getSetupFilePaths(tree: Tree, jestConfigFile: string): string[] {
+  const config = tree.read(jestConfigFile, 'utf-8');
+  const TS_QUERY_JEST_CONFIG_PREFIX =
+    ':matches(ExportAssignment, BinaryExpression:has(Identifier[name="module"]):has(Identifier[name="exports"]))';
+  const setupFilePathNodes = tsquery.query<ts.StringLiteral>(
+    config,
+    `${TS_QUERY_JEST_CONFIG_PREFIX} > ObjectLiteralExpression PropertyAssignment:has(Identifier[name="setupFilesAfterEnv"]) > ArrayLiteralExpression StringLiteral`
+  );
+
+  const rootDir = dirname(jestConfigFile);
+  const setupFilePaths = setupFilePathNodes.map((node) =>
+    node.text.replace('<rootDir>', rootDir)
+  );
+
+  return setupFilePaths;
+}
+
+function updateSetupFileWithPerformanceMarkStub(
+  tree: Tree,
+  setupFilePath: string
+) {
+  const setupFile = tree.read(setupFilePath, 'utf-8');
+  const setupFileSource = ts.createSourceFile(
+    setupFilePath,
+    setupFile,
+    ts.ScriptTarget.Latest
+  );
+
+  const TS_QUERY_PERFORMANCE_MARK_ACCESS =
+    'PropertyAccessExpression:has(Identifier[name=performance]):has(Identifier[name=mark])';
+  const TS_QUERY_PERFORMANCE_MARK_ASSIGNMENT =
+    'PropertyAccessExpression:has(Identifier[name=performance]) + EqualsToken + ObjectLiteralExpression:has(PropertyAssignment Identifier[name=mark])';
+
+  const performanceMarkNodes = tsquery.query(
+    setupFileSource,
+    `:matches(${TS_QUERY_PERFORMANCE_MARK_ACCESS}, ${TS_QUERY_PERFORMANCE_MARK_ASSIGNMENT})`
+  );
+
+  // there is already some access to performance.mark, so we assume it was handled already
+  if (performanceMarkNodes.length) {
+    return;
+  }
+
+  tree.write(
+    setupFilePath,
+    `${setupFile}
+/**
+ * Angular uses performance.mark() which is not supported by jsdom. Stub it out
+ * to avoid errors.
+ */
+global.performance.mark = jest.fn();
+`
+  );
+}


### PR DESCRIPTION
Add a stub for `performance.mark`, which is now internally used by Angular, and it's not supported by `jsdom` (Jest test environment) out of the box.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
