### PR TITLE
feat(nx-dev): limit ai chat query length

### DIFF
--- a/nx-dev/feature-ai/src/lib/prompt.tsx
+++ b/nx-dev/feature-ai/src/lib/prompt.tsx
@@ -121,6 +121,7 @@ export function Prompt({
           onChange={onInputChange}
           id="query-prompt"
           name="query"
+          maxLength={500}
           disabled={isGenerating}
           className="block w-full p-0 resize-none bg-transparent text-sm placeholder-slate-500 pl-2 py-[1.3rem] focus-within:outline-none focus:placeholder-slate-400 dark:focus:placeholder-slate-300 dark:text-white focus:outline-none focus:ring-0 border-none disabled:cursor-not-allowed"
           placeholder="How does caching work?"

--- a/nx-dev/nx-dev/pages/api/query-ai-handler.ts
+++ b/nx-dev/nx-dev/pages/api/query-ai-handler.ts
@@ -27,9 +27,9 @@ const supabaseUrl = process.env['NX_NEXT_PUBLIC_SUPABASE_URL'];
 const supabaseServiceKey = process.env['NX_SUPABASE_SERVICE_ROLE_KEY'];
 const openAiKey = process.env['NX_OPENAI_KEY'];
 const tokenCountLimit =
-  parseInt(process.env['NX_TOKEN_COUNT_LIMIT'] ?? '2500') > 0
-    ? parseInt(process.env['NX_TOKEN_COUNT_LIMIT'] ?? '2500')
-    : 2500;
+  parseInt(process.env['NX_TOKEN_COUNT_LIMIT'] ?? '500') > 0
+    ? parseInt(process.env['NX_TOKEN_COUNT_LIMIT'] ?? '500')
+    : 500;
 
 export const config = {
   runtime: 'edge',


### PR DESCRIPTION
Limits the ai chat query in two ways:
- Limits the user input to 500 characters
- Limits the added context from previous answers to 500 tokens per answer (down from 2500)