### PR TITLE
feat(angular): block router initial navigation only for ssr when opting-out of hydration

### DIFF
--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -9,10 +9,7 @@ import { appRoutes } from './app.routes';
 
 @NgModule({
   declarations: [AppComponent],
-  imports: [
-    BrowserModule,
-    RouterModule.forRoot(appRoutes, { initialNavigation: 'enabledBlocking' }),
-  ],
+  imports: [BrowserModule, RouterModule.forRoot(appRoutes)],
   providers: [],
   bootstrap: [AppComponent],
 })
@@ -687,14 +684,11 @@ bootstrapApplication(AppComponent, appConfig).catch((err) =>
 
 exports[`app --standalone should generate a standalone app correctly with routing 2`] = `
 "import { ApplicationConfig } from '@angular/core';
-import {
-  provideRouter,
-  withEnabledBlockingInitialNavigation,
-} from '@angular/router';
+import { provideRouter } from '@angular/router';
 import { appRoutes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideRouter(appRoutes, withEnabledBlockingInitialNavigation())],
+  providers: [provideRouter(appRoutes)],
 };
 "
 `;
@@ -889,14 +883,11 @@ exports[`app --strict should enable strict type checking: e2e tsconfig.json 1`] 
 
 exports[`app angular v15 support should import "ApplicationConfig" from "@angular/platform-browser" 1`] = `
 "import { ApplicationConfig } from '@angular/platform-browser';
-import {
-  provideRouter,
-  withEnabledBlockingInitialNavigation,
-} from '@angular/router';
+import { provideRouter } from '@angular/router';
 import { appRoutes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideRouter(appRoutes, withEnabledBlockingInitialNavigation())],
+  providers: [provideRouter(appRoutes)],
 };
 "
 `;

--- a/packages/angular/src/generators/application/files/ng-module/src/app/app.module.ts__tpl__
+++ b/packages/angular/src/generators/application/files/ng-module/src/app/app.module.ts__tpl__
@@ -9,7 +9,7 @@ import { NxWelcomeComponent } from './nx-welcome.component';<% } %>
   declarations: [AppComponent<% if(!minimal) { %>, NxWelcomeComponent<% } %>],
   imports: [
     BrowserModule,<% if(routing) { %>
-    RouterModule.forRoot(appRoutes, { initialNavigation: 'enabledBlocking' }),<% } %>
+    RouterModule.forRoot(appRoutes),<% } %>
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/packages/angular/src/generators/application/files/standalone-components/src/app/app.config.ts__tpl__
+++ b/packages/angular/src/generators/application/files/standalone-components/src/app/app.config.ts__tpl__
@@ -1,7 +1,7 @@
 import { ApplicationConfig } from <% if (installedAngularInfo.major >= 16) { %>'@angular/core';<% } else { %>'@angular/platform-browser';<% } %><% if (routing) { %>
-import { provideRouter, withEnabledBlockingInitialNavigation } from '@angular/router';
+import { provideRouter } from '@angular/router';
 import { appRoutes } from './app.routes';<% } %>
 
 export const appConfig: ApplicationConfig = {
-  providers: [<% if (routing) { %>provideRouter(appRoutes, withEnabledBlockingInitialNavigation()) <% } %>]
+  providers: [<% if (routing) { %>provideRouter(appRoutes) <% } %>]
 };

--- a/packages/angular/src/generators/ngrx-root-store/__snapshots__/ngrx-root-store.spec.ts.snap
+++ b/packages/angular/src/generators/ngrx-root-store/__snapshots__/ngrx-root-store.spec.ts.snap
@@ -18,7 +18,7 @@ import { UsersFacade } from './+state/users.facade';
   declarations: [AppComponent, NxWelcomeComponent],
   imports: [
     BrowserModule,
-    RouterModule.forRoot(appRoutes, { initialNavigation: 'enabledBlocking' }),
+    RouterModule.forRoot(appRoutes),
     StoreModule.forRoot(
       {},
       {
@@ -89,7 +89,7 @@ import { UsersEffects } from './+state/users.effects';
   declarations: [AppComponent, NxWelcomeComponent],
   imports: [
     BrowserModule,
-    RouterModule.forRoot(appRoutes, { initialNavigation: 'enabledBlocking' }),
+    RouterModule.forRoot(appRoutes),
     StoreModule.forRoot(
       {},
       {
@@ -372,7 +372,7 @@ import { StoreRouterConnectingModule } from '@ngrx/router-store';
   declarations: [AppComponent, NxWelcomeComponent],
   imports: [
     BrowserModule,
-    RouterModule.forRoot(appRoutes, { initialNavigation: 'enabledBlocking' }),
+    RouterModule.forRoot(appRoutes),
     StoreModule.forRoot(
       {},
       {
@@ -409,7 +409,7 @@ import { StoreDevtoolsModule } from '@ngrx/store-devtools';
   declarations: [AppComponent, NxWelcomeComponent],
   imports: [
     BrowserModule,
-    RouterModule.forRoot(appRoutes, { initialNavigation: 'enabledBlocking' }),
+    RouterModule.forRoot(appRoutes),
     StoreModule.forRoot(
       {},
       {
@@ -433,10 +433,7 @@ export class AppModule {}
 
 exports[`NgRxRootStoreGenerator Standalone APIs should add a facade when --facade=true 1`] = `
 "import { ApplicationConfig } from '@angular/core';
-import {
-  provideRouter,
-  withEnabledBlockingInitialNavigation,
-} from '@angular/router';
+import { provideRouter } from '@angular/router';
 import { appRoutes } from './app.routes';
 import { provideStore, provideState } from '@ngrx/store';
 import { provideEffects } from '@ngrx/effects';
@@ -451,7 +448,7 @@ export const appConfig: ApplicationConfig = {
     UsersFacade,
     provideEffects(),
     provideStore(),
-    provideRouter(appRoutes, withEnabledBlockingInitialNavigation()),
+    provideRouter(appRoutes),
   ],
 };
 "
@@ -490,10 +487,7 @@ export class UsersFacade {
 
 exports[`NgRxRootStoreGenerator Standalone APIs should add a root module and root state when --minimal=false 1`] = `
 "import { ApplicationConfig } from '@angular/core';
-import {
-  provideRouter,
-  withEnabledBlockingInitialNavigation,
-} from '@angular/router';
+import { provideRouter } from '@angular/router';
 import { appRoutes } from './app.routes';
 import { provideStore, provideState } from '@ngrx/store';
 import { provideEffects } from '@ngrx/effects';
@@ -506,7 +500,7 @@ export const appConfig: ApplicationConfig = {
     provideState(fromUsers.USERS_FEATURE_KEY, fromUsers.usersReducer),
     provideEffects(),
     provideStore(),
-    provideRouter(appRoutes, withEnabledBlockingInitialNavigation()),
+    provideRouter(appRoutes),
   ],
 };
 "
@@ -759,30 +753,20 @@ describe('Users Selectors', () => {
 
 exports[`NgRxRootStoreGenerator Standalone APIs should add an empty root module when --minimal=true 1`] = `
 "import { ApplicationConfig } from '@angular/core';
-import {
-  provideRouter,
-  withEnabledBlockingInitialNavigation,
-} from '@angular/router';
+import { provideRouter } from '@angular/router';
 import { appRoutes } from './app.routes';
 import { provideStore } from '@ngrx/store';
 import { provideEffects } from '@ngrx/effects';
 
 export const appConfig: ApplicationConfig = {
-  providers: [
-    provideEffects(),
-    provideStore(),
-    provideRouter(appRoutes, withEnabledBlockingInitialNavigation()),
-  ],
+  providers: [provideEffects(), provideStore(), provideRouter(appRoutes)],
 };
 "
 `;
 
 exports[`NgRxRootStoreGenerator Standalone APIs should instrument the store devtools when "addDevTools: true" 1`] = `
 "import { ApplicationConfig, isDevMode } from '@angular/core';
-import {
-  provideRouter,
-  withEnabledBlockingInitialNavigation,
-} from '@angular/router';
+import { provideRouter } from '@angular/router';
 import { appRoutes } from './app.routes';
 import { provideStore } from '@ngrx/store';
 import { provideEffects } from '@ngrx/effects';
@@ -793,7 +777,7 @@ export const appConfig: ApplicationConfig = {
     provideStoreDevtools({ logOnly: !isDevMode() }),
     provideEffects(),
     provideStore(),
-    provideRouter(appRoutes, withEnabledBlockingInitialNavigation()),
+    provideRouter(appRoutes),
   ],
 };
 "

--- a/packages/angular/src/generators/ngrx/__snapshots__/ngrx.spec.ts.snap
+++ b/packages/angular/src/generators/ngrx/__snapshots__/ngrx.spec.ts.snap
@@ -669,10 +669,7 @@ bootstrapApplication(AppComponent, appConfig).catch((err) =>
 
 exports[`ngrx Standalone APIs should add a root module with feature module when minimal is set to false 2`] = `
 "import { ApplicationConfig } from '@angular/core';
-import {
-  provideRouter,
-  withEnabledBlockingInitialNavigation,
-} from '@angular/router';
+import { provideRouter } from '@angular/router';
 import { appRoutes } from './app.routes';
 import { provideStore, provideState } from '@ngrx/store';
 import { provideEffects } from '@ngrx/effects';
@@ -685,7 +682,7 @@ export const appConfig: ApplicationConfig = {
     provideState(fromUsers.USERS_FEATURE_KEY, fromUsers.usersReducer),
     provideEffects(),
     provideStore(),
-    provideRouter(appRoutes, withEnabledBlockingInitialNavigation()),
+    provideRouter(appRoutes),
   ],
 };
 "
@@ -704,20 +701,13 @@ bootstrapApplication(AppComponent, appConfig).catch((err) =>
 
 exports[`ngrx Standalone APIs should add an empty provideStore when minimal and root are set to true 2`] = `
 "import { ApplicationConfig } from '@angular/core';
-import {
-  provideRouter,
-  withEnabledBlockingInitialNavigation,
-} from '@angular/router';
+import { provideRouter } from '@angular/router';
 import { appRoutes } from './app.routes';
 import { provideStore, provideState } from '@ngrx/store';
 import { provideEffects } from '@ngrx/effects';
 
 export const appConfig: ApplicationConfig = {
-  providers: [
-    provideEffects(),
-    provideStore(),
-    provideRouter(appRoutes, withEnabledBlockingInitialNavigation()),
-  ],
+  providers: [provideEffects(), provideStore(), provideRouter(appRoutes)],
 };
 "
 `;
@@ -735,10 +725,7 @@ bootstrapApplication(AppComponent, appConfig).catch((err) =>
 
 exports[`ngrx Standalone APIs should add facade provider when facade is true 2`] = `
 "import { ApplicationConfig } from '@angular/core';
-import {
-  provideRouter,
-  withEnabledBlockingInitialNavigation,
-} from '@angular/router';
+import { provideRouter } from '@angular/router';
 import { appRoutes } from './app.routes';
 import { provideStore, provideState } from '@ngrx/store';
 import { provideEffects } from '@ngrx/effects';
@@ -753,7 +740,7 @@ export const appConfig: ApplicationConfig = {
     provideEffects(),
     provideStore(),
     UsersFacade,
-    provideRouter(appRoutes, withEnabledBlockingInitialNavigation()),
+    provideRouter(appRoutes),
   ],
 };
 "

--- a/packages/angular/src/generators/setup-ssr/lib/index.ts
+++ b/packages/angular/src/generators/setup-ssr/lib/index.ts
@@ -4,3 +4,4 @@ export * from './update-app-module';
 export * from './update-project-config';
 export * from './validate-options';
 export * from './add-hydration';
+export * from './set-router-initial-navigation';

--- a/packages/angular/src/generators/setup-ssr/lib/set-router-initial-navigation.spec.ts
+++ b/packages/angular/src/generators/setup-ssr/lib/set-router-initial-navigation.spec.ts
@@ -1,0 +1,138 @@
+import { addProjectConfiguration, type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { setRouterInitialNavigation } from './set-router-initial-navigation';
+
+describe('setRouterInitialNavigation', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+    addProjectConfiguration(tree, 'app1', { root: 'apps/app1' });
+  });
+
+  describe('standalone', () => {
+    it('should import and set "withEnabledBlockingInitialNavigation"', () => {
+      tree.write(
+        'apps/app1/src/app.config.ts',
+        `import { ApplicationConfig } from '@angular/platform-browser';
+import { provideRouter } from '@angular/router';
+import { appRoutes } from './app.routes';
+
+export const appConfig: ApplicationConfig = {
+  providers: [provideRouter(appRoutes)],
+};
+`
+      );
+
+      setRouterInitialNavigation(tree, {
+        project: 'app1',
+        standalone: true,
+      });
+
+      expect(tree.read('apps/app1/src/app.config.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { ApplicationConfig } from '@angular/platform-browser';
+        import { provideRouter, withEnabledBlockingInitialNavigation } from '@angular/router';
+        import { appRoutes } from './app.routes';
+
+        export const appConfig: ApplicationConfig = {
+          providers: [provideRouter(appRoutes, withEnabledBlockingInitialNavigation())],
+        };
+        "
+      `);
+    });
+
+    it('should remove "withDisabledInitialNavigation"', () => {
+      tree.write(
+        'apps/app1/src/app.config.ts',
+        `import { ApplicationConfig } from '@angular/platform-browser';
+import {
+  provideRouter,
+  withDisabledInitialNavigation,
+} from '@angular/router';
+import { appRoutes } from './app.routes';
+
+export const appConfig: ApplicationConfig = {
+  providers: [provideRouter(
+    appRoutes,
+    withDisabledInitialNavigation(),
+  )],
+};
+`
+      );
+
+      setRouterInitialNavigation(tree, {
+        project: 'app1',
+        standalone: true,
+      });
+
+      expect(tree.read('apps/app1/src/app.config.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { ApplicationConfig } from '@angular/platform-browser';
+        import {
+          provideRouter,
+           withEnabledBlockingInitialNavigation,
+        } from '@angular/router';
+        import { appRoutes } from './app.routes';
+
+        export const appConfig: ApplicationConfig = {
+          providers: [provideRouter(appRoutes, withEnabledBlockingInitialNavigation())],
+        };
+        "
+      `);
+    });
+  });
+
+  describe('NgModule', () => {
+    it(`should set "initialNavigation: 'enabledBlocking'"`, () => {
+      tree.write(
+        'apps/app1/src/app.module.ts',
+        `import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { RouterModule } from '@angular/router';
+import { AppComponent } from './app.component';
+import { appRoutes } from './app.routes';
+import { NxWelcomeComponent } from './nx-welcome.component';
+
+@NgModule({
+  declarations: [AppComponent, NxWelcomeComponent],
+  imports: [
+    BrowserModule.withServerTransition({ appId: 'serverApp' }),
+    RouterModule.forRoot(appRoutes),
+  ],
+  providers: [],
+  bootstrap: [AppComponent],
+})
+export class AppModule {}
+`
+      );
+
+      setRouterInitialNavigation(tree, {
+        project: 'app1',
+        standalone: false,
+      });
+
+      expect(tree.read('apps/app1/src/app.module.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { NgModule } from '@angular/core';
+        import { BrowserModule } from '@angular/platform-browser';
+        import { RouterModule } from '@angular/router';
+        import { AppComponent } from './app.component';
+        import { appRoutes } from './app.routes';
+        import { NxWelcomeComponent } from './nx-welcome.component';
+
+        @NgModule({
+          declarations: [AppComponent, NxWelcomeComponent],
+          imports: [
+            BrowserModule.withServerTransition({ appId: 'serverApp' }),
+            RouterModule.forRoot(appRoutes, { initialNavigation: "enabledBlocking" }),
+          ],
+          providers: [],
+          bootstrap: [AppComponent],
+        })
+        export class AppModule {}
+        "
+      `);
+    });
+  });
+});

--- a/packages/angular/src/generators/setup-ssr/lib/set-router-initial-navigation.ts
+++ b/packages/angular/src/generators/setup-ssr/lib/set-router-initial-navigation.ts
@@ -1,0 +1,242 @@
+import {
+  readProjectConfiguration,
+  visitNotIgnoredFiles,
+  type Tree,
+} from '@nx/devkit';
+import { insertImport } from '@nx/js';
+import { tsquery } from '@phenomnomnominal/tsquery';
+import type {
+  CallExpression,
+  ImportSpecifier,
+  ObjectLiteralElementLike,
+  ObjectLiteralExpression,
+  Printer,
+  SourceFile,
+} from 'typescript';
+import {
+  EmitHint,
+  createPrinter,
+  factory,
+  isCallExpression,
+  isIdentifier,
+  isPropertyAssignment,
+} from 'typescript';
+import type { Schema } from '../schema';
+
+export function setRouterInitialNavigation(tree: Tree, options: Schema): void {
+  const printer = createPrinter();
+  const project = readProjectConfiguration(tree, options.project);
+
+  visitNotIgnoredFiles(tree, project.root, (filePath) => {
+    // we are only interested in .ts files
+    if (!filePath.endsWith('.ts')) {
+      return;
+    }
+
+    if (options.standalone) {
+      processFileWithStandaloneSetup(tree, filePath, printer);
+    } else {
+      processFileWithNgModuleSetup(tree, filePath, printer);
+    }
+  });
+}
+
+function processFileWithStandaloneSetup(
+  tree: Tree,
+  filePath: string,
+  printer: Printer
+) {
+  let content = tree.read(filePath, 'utf-8');
+  let sourceFile = tsquery.ast(content);
+
+  const provideRouterCallExpression =
+    getProvideRouterCallExpression(sourceFile);
+  if (!provideRouterCallExpression) {
+    return;
+  }
+
+  if (
+    provideRouterCallExpression.arguments.some(
+      (arg) =>
+        isCallExpression(arg) &&
+        isIdentifier(arg.expression) &&
+        arg.expression.text === 'withEnabledBlockingInitialNavigation'
+    )
+  ) {
+    return;
+  }
+
+  const updatedProvideRouterCallExpression = printer.printNode(
+    EmitHint.Unspecified,
+    updateProvideRouterCallExpression(provideRouterCallExpression),
+    sourceFile
+  );
+
+  content = `${content.slice(
+    0,
+    provideRouterCallExpression.getStart()
+  )}${updatedProvideRouterCallExpression}${content.slice(
+    provideRouterCallExpression.getEnd()
+  )}`;
+
+  tree.write(filePath, content);
+
+  sourceFile = tsquery.ast(content);
+  sourceFile = insertImport(
+    tree,
+    sourceFile,
+    filePath,
+    'withEnabledBlockingInitialNavigation',
+    '@angular/router'
+  );
+
+  const withDisabledInitialNavigationImportNode = tsquery<ImportSpecifier>(
+    sourceFile,
+    'ImportDeclaration ImportSpecifier:has(Identifier[name=withDisabledInitialNavigation])'
+  )[0];
+  if (!withDisabledInitialNavigationImportNode) {
+    return;
+  }
+
+  const hasTrailingComma =
+    withDisabledInitialNavigationImportNode.parent.elements.hasTrailingComma;
+
+  content = tree.read(filePath, 'utf-8');
+  tree.write(
+    filePath,
+    `${content.slice(
+      0,
+      withDisabledInitialNavigationImportNode.getStart()
+    )}${content.slice(
+      withDisabledInitialNavigationImportNode.getEnd() +
+        (hasTrailingComma ? 1 : 0)
+    )}`
+  );
+}
+
+function updateProvideRouterCallExpression(
+  node: CallExpression
+): CallExpression {
+  const filteredArgs = node.arguments.filter(
+    (arg) =>
+      !(
+        isCallExpression(arg) &&
+        isIdentifier(arg.expression) &&
+        arg.expression.text === 'withDisabledInitialNavigation'
+      )
+  );
+
+  const initialNavigationFeatureArg = factory.createCallExpression(
+    factory.createIdentifier('withEnabledBlockingInitialNavigation'),
+    [],
+    []
+  );
+
+  return factory.updateCallExpression(
+    node,
+    node.expression,
+    node.typeArguments,
+    [...filteredArgs, initialNavigationFeatureArg]
+  );
+}
+
+function processFileWithNgModuleSetup(
+  tree: Tree,
+  filePath: string,
+  printer: Printer
+) {
+  const content = tree.read(filePath, 'utf-8');
+  const sourceFile = tsquery.ast(content);
+
+  const routerModuleForRootCallExpression =
+    getRouterModuleForRootCallExpression(sourceFile);
+  if (!routerModuleForRootCallExpression) {
+    return;
+  }
+
+  const updatedRouterModuleForRootCallExpression = printer.printNode(
+    EmitHint.Unspecified,
+    updateRouterModuleForRootCallExpression(routerModuleForRootCallExpression),
+    sourceFile
+  );
+
+  tree.write(
+    filePath,
+    `${content.slice(
+      0,
+      routerModuleForRootCallExpression.getStart()
+    )}${updatedRouterModuleForRootCallExpression}${content.slice(
+      routerModuleForRootCallExpression.getEnd()
+    )}`
+  );
+}
+
+function updateRouterModuleForRootCallExpression(
+  node: CallExpression
+): CallExpression {
+  const existingOptions = node.arguments[1] as
+    | ObjectLiteralExpression
+    | undefined;
+
+  const existingProperties = existingOptions?.properties
+    ? factory.createNodeArray(
+        existingOptions.properties.filter(
+          (exp) =>
+            !(
+              isPropertyAssignment(exp) &&
+              isIdentifier(exp.name) &&
+              exp.name.text === 'initialNavigation'
+            )
+        )
+      )
+    : factory.createNodeArray<ObjectLiteralElementLike>();
+
+  const enabledLiteral = factory.createStringLiteral('enabledBlocking');
+  const initialNavigationProperty = factory.createPropertyAssignment(
+    'initialNavigation',
+    enabledLiteral
+  );
+
+  const routerOptions = existingOptions
+    ? factory.updateObjectLiteralExpression(
+        existingOptions,
+        factory.createNodeArray([
+          ...existingProperties,
+          initialNavigationProperty,
+        ])
+      )
+    : factory.createObjectLiteralExpression(
+        factory.createNodeArray([initialNavigationProperty])
+      );
+  const args = [node.arguments[0], routerOptions];
+
+  return factory.createCallExpression(
+    node.expression,
+    node.typeArguments,
+    args
+  );
+}
+
+function getProvideRouterCallExpression(
+  sourceFile: SourceFile
+): CallExpression | null {
+  const routerModuleForRootCalls = tsquery(
+    sourceFile,
+    'PropertyAssignment:has(Identifier[name=providers]) > ArrayLiteralExpression CallExpression:has(Identifier[name=provideRouter])',
+    { visitAllChildren: true }
+  ) as CallExpression[];
+
+  return routerModuleForRootCalls.length ? routerModuleForRootCalls[0] : null;
+}
+
+function getRouterModuleForRootCallExpression(
+  sourceFile: SourceFile
+): CallExpression | null {
+  const routerModuleForRootCalls = tsquery(
+    sourceFile,
+    'Decorator > CallExpression:has(Identifier[name=NgModule]) PropertyAssignment:has(Identifier[name=imports]) > ArrayLiteralExpression CallExpression:has(Identifier[name=forRoot])',
+    { visitAllChildren: true }
+  ) as CallExpression[];
+
+  return routerModuleForRootCalls.length ? routerModuleForRootCalls[0] : null;
+}

--- a/packages/angular/src/generators/setup-ssr/setup-ssr.ts
+++ b/packages/angular/src/generators/setup-ssr/setup-ssr.ts
@@ -5,6 +5,7 @@ import {
   installPackagesTask,
 } from '@nx/devkit';
 import {
+  getInstalledAngularVersionInfo,
   getInstalledPackageVersionInfo,
   versions,
 } from '../utils/version-utils';
@@ -12,6 +13,7 @@ import {
   addHydration,
   generateSSRFiles,
   normalizeOptions,
+  setRouterInitialNavigation,
   updateAppModule,
   updateProjectConfig,
   validateOptions,
@@ -31,6 +33,11 @@ export async function setupSsr(tree: Tree, schema: Schema) {
 
   if (options.hydration) {
     addHydration(tree, options);
+  }
+
+  const { major: angularMajorVersion } = getInstalledAngularVersionInfo(tree);
+  if (angularMajorVersion < 17 || !options.hydration) {
+    setRouterInitialNavigation(tree, options);
   }
 
   const pkgVersions = versions(tree);


### PR DESCRIPTION
- Stop generating all apps with `initialNavigation: 'enabledBlocking'` (NgModule) or `withEnabledBlockingInitialNavigation` (standalone)
- Set the above only when setting up ssr and if using Angular v17, when opting out of hydration

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
