### PR TITLE
chore(nx-dev): do not publish docs for patches

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -235,7 +235,8 @@ jobs:
           npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
           pnpm nx-release --local=false $GITHUB_REF_NAME
       - name: Trigger Docs Release
-        if: ${{ !github.event.release.prerelease }}
+        # Publish docs only on a full release and when publishing the latest version
+        if: ${{ !github.event.release.prerelease && github.ref_name ==='master' }}
         run: |
           # We force recreate the branch in order to always be up to date and avoid merge conflicts within the automated workflow
           git branch -f website

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -236,7 +236,7 @@ jobs:
           pnpm nx-release --local=false $GITHUB_REF_NAME
       - name: Trigger Docs Release
         # Publish docs only on a full release and when publishing the latest version
-        if: ${{ !github.event.release.prerelease && github.ref_name ==='master' }}
+        if: ${{ !github.event.release.prerelease && github.event.release.target_commitish == 'master' }}
         run: |
           # We force recreate the branch in order to always be up to date and avoid merge conflicts within the automated workflow
           git branch -f website


### PR DESCRIPTION
Do not publish docs if we're releasing a patch for an older version of Nx.