### PR TITLE
chore(core): split package.json scripts from project.json plugin

### DIFF
--- a/packages/nx/src/plugins/project-json/build-nodes/package-json-next-to-project-json.spec.ts
+++ b/packages/nx/src/plugins/project-json/build-nodes/package-json-next-to-project-json.spec.ts
@@ -1,0 +1,74 @@
+import * as memfs from 'memfs';
+
+import '../../../internal-testing-utils/mock-fs';
+
+import { CreatePackageJsonProjectsNextToProjectJson } from './package-json-next-to-project-json';
+import {
+  CreateNodesContext,
+  CreateNodesFunction,
+} from '../../../utils/nx-plugin';
+const { createNodes } = CreatePackageJsonProjectsNextToProjectJson;
+
+describe('nx project.json plugin', () => {
+  let context: CreateNodesContext;
+  let createNodesFunction: CreateNodesFunction;
+
+  beforeEach(() => {
+    context = {
+      nxJsonConfiguration: {},
+      workspaceRoot: '/root',
+    };
+    createNodesFunction = createNodes[1];
+  });
+
+  it('should build projects from project.json', () => {
+    memfs.vol.fromJSON(
+      {
+        'packages/lib-a/project.json': JSON.stringify({
+          name: 'lib-a',
+          targets: {
+            build: {
+              executor: 'nx:run-commands',
+              options: {},
+            },
+          },
+        }),
+        'packages/lib-a/package.json': JSON.stringify({
+          name: 'lib-a',
+          scripts: {
+            test: 'jest',
+          },
+        }),
+      },
+      '/root'
+    );
+
+    expect(
+      createNodesFunction('packages/lib-a/project.json', undefined, context)
+    ).toMatchInlineSnapshot(`
+      {
+        "projects": {
+          "lib-a": {
+            "name": "lib-a",
+            "root": "packages/lib-a",
+            "targets": {
+              "nx-release-publish": {
+                "dependsOn": [
+                  "^nx-release-publish",
+                ],
+                "executor": "@nx/js:release-publish",
+                "options": {},
+              },
+              "test": {
+                "executor": "nx:run-script",
+                "options": {
+                  "script": "test",
+                },
+              },
+            },
+          },
+        },
+      }
+    `);
+  });
+});

--- a/packages/nx/src/plugins/project-json/build-nodes/package-json-next-to-project-json.ts
+++ b/packages/nx/src/plugins/project-json/build-nodes/package-json-next-to-project-json.ts
@@ -1,0 +1,58 @@
+import { dirname, join } from 'path';
+import { existsSync } from 'fs';
+import { NxPluginV2 } from '../../../utils/nx-plugin';
+import { readJsonFile } from '../../../utils/fileutils';
+import { ProjectConfiguration } from '../../../config/workspace-json-project-json';
+import {
+  PackageJson,
+  readTargetsFromPackageJson,
+} from '../../../utils/package-json';
+
+// TODO: Remove this one day, this should not need to be done.
+
+export const CreatePackageJsonProjectsNextToProjectJson: NxPluginV2 = {
+  name: 'nx-core-build-package-json-nodes-next-to-project-json-nodes',
+  createNodes: [
+    '{project.json,**/project.json}',
+    (file, _, { workspaceRoot }) => {
+      const project = createProjectFromPackageJsonNextToProjectJson(
+        file,
+        workspaceRoot
+      );
+
+      return project
+        ? {
+            projects: {
+              [project.name]: project,
+            },
+          }
+        : {};
+    },
+  ],
+};
+
+function createProjectFromPackageJsonNextToProjectJson(
+  projectJsonPath: string,
+  workspaceRoot: string
+): ProjectConfiguration | null {
+  const root = dirname(projectJsonPath);
+  const packageJsonPath = join(workspaceRoot, root, 'package.json');
+  if (!existsSync(packageJsonPath)) {
+    return null;
+  }
+  try {
+    const packageJson: PackageJson = readJsonFile(packageJsonPath);
+
+    let { nx, name } = packageJson;
+
+    return {
+      ...nx,
+      name,
+      root,
+      targets: readTargetsFromPackageJson(packageJson),
+    } as ProjectConfiguration;
+  } catch (e) {
+    console.log(e);
+    return null;
+  }
+}

--- a/packages/nx/src/plugins/project-json/build-nodes/project-json.spec.ts
+++ b/packages/nx/src/plugins/project-json/build-nodes/project-json.spec.ts
@@ -2,22 +2,9 @@ import * as memfs from 'memfs';
 
 import '../../../internal-testing-utils/mock-fs';
 
-import { PackageJson } from '../../../utils/package-json';
-
-import {
-  CreateProjectJsonProjectsPlugin,
-  mergeNpmScriptsWithTargets,
-} from './project-json';
+import { CreateProjectJsonProjectsPlugin } from './project-json';
 import { CreateNodesContext } from '../../../utils/nx-plugin';
 const { createNodes } = CreateProjectJsonProjectsPlugin;
-
-const defaultReleasePublishTarget = {
-  'nx-release-publish': {
-    dependsOn: ['^nx-release-publish'],
-    executor: '@nx/js:release-publish',
-    options: {},
-  },
-};
 
 describe('nx project.json plugin', () => {
   let context: CreateNodesContext;
@@ -42,13 +29,6 @@ describe('nx project.json plugin', () => {
               executor: 'nx:run-commands',
               options: {},
             },
-          },
-        }),
-        'packages/lib-a/package.json': JSON.stringify({
-          name: 'lib-a',
-          scripts: {
-            build: 'should not see me',
-            test: 'jest',
           },
         }),
       },
@@ -81,183 +61,10 @@ describe('nx project.json plugin', () => {
                 "executor": "nx:run-commands",
                 "options": {},
               },
-              "nx-release-publish": {
-                "dependsOn": [
-                  "^nx-release-publish",
-                ],
-                "executor": "@nx/js:release-publish",
-                "options": {},
-              },
-              "test": {
-                "executor": "nx:run-script",
-                "options": {
-                  "script": "test",
-                },
-              },
             },
           },
         },
       }
     `);
-  });
-
-  describe('mergeNpmScriptsWithTargets', () => {
-    const packageJson: PackageJson = {
-      name: 'my-app',
-      version: '0.0.0',
-      scripts: {
-        build: 'echo 1',
-      },
-    };
-
-    const packageJsonBuildTarget = {
-      executor: 'nx:run-script',
-      options: {
-        script: 'build',
-      },
-    };
-
-    it('should prefer project.json targets', () => {
-      const projectJsonTargets = {
-        build: {
-          executor: 'nx:run-commands',
-          options: {
-            command: 'echo 2',
-          },
-        },
-      };
-
-      const result = mergeNpmScriptsWithTargets(
-        packageJson,
-        projectJsonTargets
-      );
-      expect(result).toEqual({
-        ...projectJsonTargets,
-        ...defaultReleasePublishTarget,
-      });
-    });
-
-    it('should provide targets from project.json and package.json', () => {
-      const projectJsonTargets = {
-        clean: {
-          executor: 'nx:run-commands',
-          options: {
-            command: 'echo 2',
-          },
-        },
-      };
-
-      const result = mergeNpmScriptsWithTargets(
-        packageJson,
-        projectJsonTargets
-      );
-      expect(result).toEqual({
-        ...projectJsonTargets,
-        build: packageJsonBuildTarget,
-        ...defaultReleasePublishTarget,
-      });
-    });
-
-    it('should contain extended options from nx property in package.json', () => {
-      const result = mergeNpmScriptsWithTargets(
-        {
-          name: 'my-other-app',
-          version: '',
-          scripts: {
-            build: 'echo 1',
-          },
-          nx: {
-            targets: {
-              build: {
-                outputs: ['custom'],
-              },
-            },
-          },
-        },
-        null
-      );
-      expect(result).toEqual({
-        build: { ...packageJsonBuildTarget, outputs: ['custom'] },
-        ...defaultReleasePublishTarget,
-      });
-    });
-
-    it('should work when project.json targets is null', () => {
-      const result = mergeNpmScriptsWithTargets(packageJson, null);
-
-      expect(result).toEqual({
-        build: {
-          executor: 'nx:run-script',
-          options: {
-            script: 'build',
-          },
-        },
-        ...defaultReleasePublishTarget,
-      });
-    });
-
-    it("should work when project root is ''", () => {
-      const result = mergeNpmScriptsWithTargets(
-        {
-          name: 'my-app',
-          version: '',
-          scripts: {
-            test: 'echo testing',
-          },
-        },
-        {
-          build: {
-            executor: 'nx:run-commands',
-            options: { command: 'echo hi' },
-          },
-        }
-      );
-
-      expect(result).toEqual({
-        build: {
-          executor: 'nx:run-commands',
-          options: { command: 'echo hi' },
-        },
-        test: {
-          executor: 'nx:run-script',
-          options: { script: 'test' },
-        },
-        ...defaultReleasePublishTarget,
-      });
-    });
-
-    it('should ignore scripts that are not in includedScripts', () => {
-      const result = mergeNpmScriptsWithTargets(
-        {
-          name: 'included-scripts-test',
-          version: '',
-          scripts: {
-            test: 'echo testing',
-            fail: 'exit 1',
-          },
-          nx: {
-            includedScripts: ['test'],
-          },
-        },
-        {
-          build: {
-            executor: 'nx:run-commands',
-            options: { command: 'echo hi' },
-          },
-        }
-      );
-
-      expect(result).toEqual({
-        build: {
-          executor: 'nx:run-commands',
-          options: { command: 'echo hi' },
-        },
-        test: {
-          executor: 'nx:run-script',
-          options: { script: 'test' },
-        },
-        ...defaultReleasePublishTarget,
-      });
-    });
   });
 });

--- a/packages/nx/src/plugins/project-json/build-nodes/project-json.ts
+++ b/packages/nx/src/plugins/project-json/build-nodes/project-json.ts
@@ -1,17 +1,9 @@
 import { dirname, join } from 'node:path';
-import { existsSync } from 'node:fs';
 
-import {
-  ProjectConfiguration,
-  TargetConfiguration,
-} from '../../../config/workspace-json-project-json';
+import { ProjectConfiguration } from '../../../config/workspace-json-project-json';
 import { toProjectName } from '../../../config/workspaces';
 import { readJsonFile } from '../../../utils/fileutils';
 import { NxPluginV2 } from '../../../utils/nx-plugin';
-import {
-  PackageJson,
-  readTargetsFromPackageJson,
-} from '../../../utils/package-json';
 
 export const CreateProjectJsonProjectsPlugin: NxPluginV2 = {
   name: 'nx-core-build-project-json-nodes',
@@ -21,7 +13,6 @@ export const CreateProjectJsonProjectsPlugin: NxPluginV2 = {
       const root = context.workspaceRoot;
       const json = readJsonFile<ProjectConfiguration>(join(root, file));
       const project = buildProjectFromProjectJson(json, file);
-      mergePackageJsonConfigurationWithProjectJson(project, root);
       return {
         projects: {
           [project.name]: project,
@@ -40,47 +31,4 @@ export function buildProjectFromProjectJson(
     root: dirname(path),
     ...json,
   };
-}
-
-export function mergePackageJsonConfigurationWithProjectJson(
-  p: ProjectConfiguration,
-  root: string
-) {
-  if (existsSync(join(root, p.root, 'package.json'))) {
-    try {
-      const packageJson: PackageJson = readJsonFile(
-        join(root, p.root, 'package.json')
-      );
-
-      p.targets = mergeNpmScriptsWithTargets(packageJson, p.targets);
-
-      const { nx } = packageJson;
-
-      if (nx?.tags) {
-        p.tags = [...(p.tags || []), ...nx.tags];
-      }
-      if (nx?.implicitDependencies) {
-        p.implicitDependencies = [
-          ...(p.implicitDependencies || []),
-          ...nx.implicitDependencies,
-        ];
-      }
-      if (nx?.namedInputs) {
-        p.namedInputs = { ...(p.namedInputs || {}), ...nx.namedInputs };
-      }
-    } catch (e) {
-      // ignore json parser errors
-    }
-  }
-}
-
-export function mergeNpmScriptsWithTargets(
-  packageJson: PackageJson,
-  targets: Record<string, TargetConfiguration>
-): Record<string, TargetConfiguration> {
-  try {
-    return { ...readTargetsFromPackageJson(packageJson), ...(targets || {}) };
-  } catch (e) {
-    return targets;
-  }
 }

--- a/packages/nx/src/utils/nx-plugin.ts
+++ b/packages/nx/src/utils/nx-plugin.ts
@@ -41,6 +41,7 @@ import {
 import { getNxPackageJsonWorkspacesPlugin } from '../../plugins/package-json-workspaces';
 import { CreateProjectJsonProjectsPlugin } from '../plugins/project-json/build-nodes/project-json';
 import { FileMapCache } from '../project-graph/nx-deps-cache';
+import { CreatePackageJsonProjectsNextToProjectJson } from '../plugins/project-json/build-nodes/package-json-next-to-project-json';
 
 /**
  * Context for {@link CreateNodesFunction}
@@ -286,11 +287,6 @@ export async function loadNxPlugins(
 ): Promise<LoadedNxPlugin[]> {
   const result: LoadedNxPlugin[] = [...(await getDefaultPlugins(root))];
 
-  // TODO: These should be specified in nx.json
-  // Temporarily load js as if it were a plugin which is built into nx
-  // In the future, this will be optional and need to be specified in nx.json
-  result.push();
-
   plugins ??= [];
   for (const plugin of plugins) {
     result.push(await loadNxPluginAsync(plugin, paths, root));
@@ -514,7 +510,10 @@ function readPluginMainFromProjectConfiguration(
 }
 
 async function getDefaultPlugins(root: string): Promise<LoadedNxPlugin[]> {
-  const plugins: NxPluginV2[] = [await import('../plugins/js')];
+  const plugins: NxPluginV2[] = [
+    CreatePackageJsonProjectsNextToProjectJson,
+    await import('../plugins/js'),
+  ];
 
   if (shouldMergeAngularProjects(root, false)) {
     plugins.push(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`package.json` targets which are created because they are next to `project.json` targets override targets from plugins.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`package.json` targets which are created because they are next to `project.json` are added separately earlier on in the merge process so targets from plugins will override them.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
