### PR TITLE
chore(repo): fix create-nx-plugin e2e test

### DIFF
--- a/e2e/workspace-create/src/create-nx-plugin.test.ts
+++ b/e2e/workspace-create/src/create-nx-plugin.test.ts
@@ -64,7 +64,7 @@ describe('create-nx-plugin', () => {
     checkFilesExist(
       `dist/packages/${pluginName}/package.json`,
       `dist/packages/${pluginName}/generators.json`,
-      `packages/${pluginName}-e2e/tests/${pluginName}.spec.ts`
+      `packages/${pluginName}-e2e/src/${pluginName}.spec.ts`
     );
 
     runCLI(`build create-${pluginName}-package`);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

E2e tests are created under `e2e/src` but they are checked at `e2e/tests`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Test checks E2e tests are created under `e2e/src`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
