### PR TITLE
fix(core): ensure plugin testing uses correct pm for install

### DIFF
--- a/packages/plugin/src/utils/testing-utils/async-commands.ts
+++ b/packages/plugin/src/utils/testing-utils/async-commands.ts
@@ -1,6 +1,6 @@
 import { exec } from 'child_process';
 import { tmpProjPath } from './paths';
-import { getPackageManagerCommand } from '@nx/devkit';
+import { detectPackageManager, getPackageManagerCommand } from '@nx/devkit';
 import { fileExists } from './utils';
 
 /**
@@ -43,8 +43,9 @@ export function runNxCommandAsync(
     silenceError: false,
   }
 ): Promise<{ stdout: string; stderr: string }> {
+  const cwd = opts.cwd ?? tmpProjPath();
   if (fileExists(tmpProjPath('package.json'))) {
-    const pmc = getPackageManagerCommand();
+    const pmc = getPackageManagerCommand(detectPackageManager(cwd));
     return runCommandAsync(`${pmc.exec} nx ${command}`, opts);
   } else if (process.platform === 'win32') {
     return runCommandAsync(`./nx.bat %${command}`, opts);

--- a/packages/plugin/src/utils/testing-utils/commands.ts
+++ b/packages/plugin/src/utils/testing-utils/commands.ts
@@ -1,6 +1,6 @@
 import { ExecOptions, execSync } from 'child_process';
 import { tmpProjPath } from './paths';
-import { getPackageManagerCommand } from '@nx/devkit';
+import { detectPackageManager, getPackageManagerCommand } from '@nx/devkit';
 import { fileExists } from './utils';
 
 /**
@@ -17,12 +17,13 @@ export function runNxCommand(
   }
 ): string {
   function _runNxCommand(c) {
+    const cwd = opts.cwd ?? tmpProjPath();
     const execSyncOptions: ExecOptions = {
-      cwd: opts.cwd ?? tmpProjPath(),
+      cwd,
       env: { ...process.env, ...opts.env },
     };
     if (fileExists(tmpProjPath('package.json'))) {
-      const pmc = getPackageManagerCommand();
+      const pmc = getPackageManagerCommand(detectPackageManager(cwd));
       return execSync(`${pmc.exec} nx ${command}`, execSyncOptions);
     } else if (process.platform === 'win32') {
       return execSync(`./nx.bat %${command}`, execSyncOptions);

--- a/packages/plugin/src/utils/testing-utils/nx-project.ts
+++ b/packages/plugin/src/utils/testing-utils/nx-project.ts
@@ -1,4 +1,4 @@
-import { workspaceRoot } from '@nx/devkit';
+import { detectPackageManager, workspaceRoot } from '@nx/devkit';
 import {
   getPackageManagerCommand,
   readJsonFile,
@@ -50,9 +50,10 @@ export function uniq(prefix: string) {
  * @param silent silent output from the install
  */
 export function runPackageManagerInstall(silent: boolean = true) {
-  const pmc = getPackageManagerCommand();
+  const cwd = tmpProjPath();
+  const pmc = getPackageManagerCommand(detectPackageManager(cwd));
   const install = execSync(pmc.install, {
-    cwd: tmpProjPath(),
+    cwd,
     ...(silent ? { stdio: ['ignore', 'ignore', 'ignore'] } : {}),
   });
   return install ? install.toString() : '';


### PR DESCRIPTION
When running tests in a temp folder where a workspace has been generated with different package manager than the root one, the `ensureNxPackage` and `newNxProject` will fail.

The `runNxNewCommand` always generates workspace with `npm` which might not be matching the root package manager. The failure has been detected on `nx-react-workspace` with Yarn v4

## Current Behavior
`runPackageManagerInstall` will use the package manager detected from the root of the repo regardless what package manager is set in the folder where we are running the command.

## Expected Behavior
`runPackageManagerInstall` should detect the package manager from the folder where it's being run.
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
