### PR TITLE
docs(angular): update nx and angular version compat matrix with angular v17

### DIFF
--- a/docs/generated/packages/angular/documents/angular-nx-version-matrix.md
+++ b/docs/generated/packages/angular/documents/angular-nx-version-matrix.md
@@ -12,22 +12,23 @@ Below is a reference table that matches versions of Angular to the version of Nx
 
 We provide a recommended version, and it is usually the latest minor version of Nx in the range provided because there will have been bug fixes added since the first release in the range.
 
-| Angular Version | **Nx Version _(recommended)_** | Nx Version _(range)_                    |
-| --------------- | ------------------------------ | --------------------------------------- |
-| ~16.2.0         | **latest**                     | 16.7.0 <= latest                        |
-| ~16.1.0         | **latest**                     | 16.4.0 <= latest                        |
-| ~16.0.0         | **latest**                     | 16.1.0 <= latest                        |
-| ~15.2.0         | **latest**                     | 15.8.0 <= latest                        |
-| ~15.1.0         | **latest**                     | 15.5.0 <= latest                        |
-| ~15.0.0         | **latest**                     | 15.2.0 <= 15.4.8 \|\| 15.7.0 <= latest  |
-| ~14.2.0         | **latest**                     | 14.6.0 <= 15.1.1 \|\| 15.7.0 <= latest  |
-| ~14.1.0         | **latest**                     | 14.5.0 <= 14.5.10 \|\| 15.7.0 <= latest |
-| ~14.0.0         | **latest**                     | 14.2.1 <= 14.4.3 \|\| 15.7.0 <= latest  |
-| ^13.0.0         | **14.1.9**                     | 13.2.0 <= 14.1.9                        |
-| ^12.0.0         | **13.1.4**                     | 12.3.0 <= 13.1.4                        |
-| ^11.0.0         | **12.2.0**                     | 11.0.0 <= 12.2.0                        |
-| ^10.0.0         | **10.4.15**                    | 9.7.0 <= 10.4.15                        |
-| ^9.0.0          | **9.6.0**                      | 8.12.4 <= 9.6.0                         |
-| ^8.0.0          | **8.12.2**                     | 8.7.0 <= 8.12.2                         |
+| Angular Version | **Nx Version _(recommended)_** | Nx Version _(range)_                   |
+| --------------- | ------------------------------ | -------------------------------------- |
+| ~17.0.0         | **latest**                     | 17.1.0 <= latest                       |
+| ~16.2.0         | **latest**                     | 16.7.0 <= latest                       |
+| ~16.1.0         | **latest**                     | 16.4.0 <= latest                       |
+| ~16.0.0         | **latest**                     | 16.1.0 <= latest                       |
+| ~15.2.0         | **latest**                     | 15.8.0 <= latest                       |
+| ~15.1.0         | **latest**                     | 15.5.0 <= latest                       |
+| ~15.0.0         | **latest**                     | 15.2.0 <= 15.4.8 \|\| 15.7.0 <= latest |
+| ~14.2.0         | **~17.0.0**                    | 14.6.0 <= 15.1.1 \|\| 15.7.0 < 17.1.0  |
+| ~14.1.0         | **~17.0.0**                    | 14.5.0 <= 14.5.10 \|\| 15.7.0 < 17.1.0 |
+| ~14.0.0         | **~17.0.0**                    | 14.2.1 <= 14.4.3 \|\| 15.7.0 < 17.1.0  |
+| ^13.0.0         | **14.1.9**                     | 13.2.0 <= 14.1.9                       |
+| ^12.0.0         | **13.1.4**                     | 12.3.0 <= 13.1.4                       |
+| ^11.0.0         | **12.2.0**                     | 11.0.0 <= 12.2.0                       |
+| ^10.0.0         | **10.4.15**                    | 9.7.0 <= 10.4.15                       |
+| ^9.0.0          | **9.6.0**                      | 8.12.4 <= 9.6.0                        |
+| ^8.0.0          | **8.12.2**                     | 8.7.0 <= 8.12.2                        |
 
 Additionally, you can check the supported versions of Node and Typescript for the version of Angular you are using in the [Angular docs](https://angular.io/guide/versions#actively-supported-versions).

--- a/docs/shared/packages/angular/angular-nx-version-matrix.md
+++ b/docs/shared/packages/angular/angular-nx-version-matrix.md
@@ -12,22 +12,23 @@ Below is a reference table that matches versions of Angular to the version of Nx
 
 We provide a recommended version, and it is usually the latest minor version of Nx in the range provided because there will have been bug fixes added since the first release in the range.
 
-| Angular Version | **Nx Version _(recommended)_** | Nx Version _(range)_                    |
-| --------------- | ------------------------------ | --------------------------------------- |
-| ~16.2.0         | **latest**                     | 16.7.0 <= latest                        |
-| ~16.1.0         | **latest**                     | 16.4.0 <= latest                        |
-| ~16.0.0         | **latest**                     | 16.1.0 <= latest                        |
-| ~15.2.0         | **latest**                     | 15.8.0 <= latest                        |
-| ~15.1.0         | **latest**                     | 15.5.0 <= latest                        |
-| ~15.0.0         | **latest**                     | 15.2.0 <= 15.4.8 \|\| 15.7.0 <= latest  |
-| ~14.2.0         | **latest**                     | 14.6.0 <= 15.1.1 \|\| 15.7.0 <= latest  |
-| ~14.1.0         | **latest**                     | 14.5.0 <= 14.5.10 \|\| 15.7.0 <= latest |
-| ~14.0.0         | **latest**                     | 14.2.1 <= 14.4.3 \|\| 15.7.0 <= latest  |
-| ^13.0.0         | **14.1.9**                     | 13.2.0 <= 14.1.9                        |
-| ^12.0.0         | **13.1.4**                     | 12.3.0 <= 13.1.4                        |
-| ^11.0.0         | **12.2.0**                     | 11.0.0 <= 12.2.0                        |
-| ^10.0.0         | **10.4.15**                    | 9.7.0 <= 10.4.15                        |
-| ^9.0.0          | **9.6.0**                      | 8.12.4 <= 9.6.0                         |
-| ^8.0.0          | **8.12.2**                     | 8.7.0 <= 8.12.2                         |
+| Angular Version | **Nx Version _(recommended)_** | Nx Version _(range)_                   |
+| --------------- | ------------------------------ | -------------------------------------- |
+| ~17.0.0         | **latest**                     | 17.1.0 <= latest                       |
+| ~16.2.0         | **latest**                     | 16.7.0 <= latest                       |
+| ~16.1.0         | **latest**                     | 16.4.0 <= latest                       |
+| ~16.0.0         | **latest**                     | 16.1.0 <= latest                       |
+| ~15.2.0         | **latest**                     | 15.8.0 <= latest                       |
+| ~15.1.0         | **latest**                     | 15.5.0 <= latest                       |
+| ~15.0.0         | **latest**                     | 15.2.0 <= 15.4.8 \|\| 15.7.0 <= latest |
+| ~14.2.0         | **~17.0.0**                    | 14.6.0 <= 15.1.1 \|\| 15.7.0 < 17.1.0  |
+| ~14.1.0         | **~17.0.0**                    | 14.5.0 <= 14.5.10 \|\| 15.7.0 < 17.1.0 |
+| ~14.0.0         | **~17.0.0**                    | 14.2.1 <= 14.4.3 \|\| 15.7.0 < 17.1.0  |
+| ^13.0.0         | **14.1.9**                     | 13.2.0 <= 14.1.9                       |
+| ^12.0.0         | **13.1.4**                     | 12.3.0 <= 13.1.4                       |
+| ^11.0.0         | **12.2.0**                     | 11.0.0 <= 12.2.0                       |
+| ^10.0.0         | **10.4.15**                    | 9.7.0 <= 10.4.15                       |
+| ^9.0.0          | **9.6.0**                      | 8.12.4 <= 9.6.0                        |
+| ^8.0.0          | **8.12.2**                     | 8.7.0 <= 8.12.2                        |
 
 Additionally, you can check the supported versions of Node and Typescript for the version of Angular you are using in the [Angular docs](https://angular.io/guide/versions#actively-supported-versions).


### PR DESCRIPTION
~~This is blocked until the [support for Angular v17](https://github.com/nrwl/nx/pull/19689) is released.~~

Updated doc: https://nx-dev-git-fork-leosvelperez-docs-update-nx-ng-versions-nrwl.vercel.app/nx-api/angular/documents/angular-nx-version-matrix

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The Nx and Angular version compatibility matrix does not contain information about Angular v17.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The Nx and Angular version compatibility matrix should display information about Angular v17.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
