### PR TITLE
fix(nextjs): re-enable storybook test

### DIFF
--- a/packages/storybook/migrations.json
+++ b/packages/storybook/migrations.json
@@ -50,6 +50,19 @@
     }
   },
   "packageJsonUpdates": {
+    "17.1.0-beta.4": {
+      "version": "17.1.0-beta.4",
+      "packages": {
+        "@storybook/testing-library": {
+          "version": "^0.2.2",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/jest": {
+          "version": "^0.2.3",
+          "alwaysAddToPackageJson": false
+        }
+      }
+    },
     "17.1.0": {
       "version": "17.1.0-beta.3",
       "packages": {

--- a/packages/storybook/src/utils/versions.ts
+++ b/packages/storybook/src/utils/versions.ts
@@ -2,8 +2,8 @@ export const nxVersion = require('../../package.json').version;
 export const storybookReactNativeVersion = '^6.5.3';
 export const reactNativeStorybookLoader = '^2.0.5';
 export const storybookTestRunnerVersion = '^0.13.0';
-export const storybookTestingLibraryVersion = '~0.2.0';
-export const storybookJestVersion = '~0.1.0';
+export const storybookTestingLibraryVersion = '^0.2.2';
+export const storybookJestVersion = '^0.2.3';
 export const litVersion = '^2.6.1';
 export const tsNodeVersion = '10.9.1';
 


### PR DESCRIPTION
related: https://github.com/nrwl/nx/pull/19661

The `e2e-next-extensions` suite fails for Storybook+Next with the following error:

```
 >  NX   Storybook failed to load the following preset: @storybook/nextjs/preset.
```

On normal (non-CI) environments, it works fine (`nx build-storybook my-nest-app` works fine).

I noticed that when I opened the project that was generated by the E2E test, and ran `nx build-storybook` there, the same issue appeared. Once I installed the dependencies again (`npm i`), the error went away. There must be an issue with the first install in the e2e tests. So, calling `npm i` again fixes the issue on e2e, too.