### PR TITLE
feat(core): add --pretty flag for 'nx show --json'

### DIFF
--- a/docs/generated/cli/show.md
+++ b/docs/generated/cli/show.md
@@ -79,6 +79,12 @@ Type: `boolean`
 
 Output JSON
 
+### pretty
+
+Type: `boolean`
+
+Pretty print JSON output
+
 ### version
 
 Type: `boolean`

--- a/docs/generated/packages/nx/documents/show.md
+++ b/docs/generated/packages/nx/documents/show.md
@@ -79,6 +79,12 @@ Type: `boolean`
 
 Output JSON
 
+### pretty
+
+Type: `boolean`
+
+Pretty print JSON output
+
 ### version
 
 Type: `boolean`

--- a/packages/nx/src/command-line/show/command-object.ts
+++ b/packages/nx/src/command-line/show/command-object.ts
@@ -1,9 +1,10 @@
 import type { ProjectGraphProjectNode } from '../../config/project-graph';
-import { CommandModule, showHelp } from 'yargs';
+import { boolean, CommandModule, showHelp } from 'yargs';
 import { parseCSV, withAffectedOptions } from '../yargs-utils/shared-options';
 
 export interface NxShowArgs {
   json?: boolean;
+  pretty?: boolean;
 }
 
 export type ShowProjectsOptions = NxShowArgs & {
@@ -37,6 +38,11 @@ export const yargsShowCommand: CommandModule<
       .option('json', {
         type: 'boolean',
         description: 'Output JSON',
+      })
+      .option('pretty', {
+        type: 'boolean',
+        description: 'Pretty print JSON output',
+        implies: 'json',
       })
       .example(
         '$0 show projects',

--- a/packages/nx/src/command-line/show/show.ts
+++ b/packages/nx/src/command-line/show/show.ts
@@ -73,7 +73,11 @@ export async function showProjectsHandler(
   }
 
   if (args.json) {
-    console.log(JSON.stringify(Array.from(selectedProjects)));
+    if (args.pretty) {
+      console.dir(selectedProjects, { depth: null, colors: true });
+    } else {
+      console.log(JSON.stringify(Array.from(selectedProjects)));
+    }
   } else {
     for (const project of selectedProjects) {
       console.log(project);
@@ -93,7 +97,11 @@ export async function showProjectHandler(
     process.exit(1);
   }
   if (args.json) {
-    console.log(JSON.stringify(node.data));
+    if (args.pretty) {
+      console.dir(node.data, { depth: 10, colors: true });
+    } else {
+      console.log(JSON.stringify(node.data));
+    }
   } else {
     const chalk = require('chalk') as typeof import('chalk');
     const logIfExists = (label, key: keyof typeof node['data']) => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Users who used `--json` with `nx show project` aren't able to read it easily since we no longer format the output

## Expected Behavior
There is a `--pretty` flag that indents options as well as highlights values

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
