### PR TITLE
feat(core): extglob to standard glob parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,6 +1352,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "nom",
  "once_cell",
  "parking_lot",
  "rayon",

--- a/packages/nx/Cargo.toml
+++ b/packages/nx/Cargo.toml
@@ -21,6 +21,7 @@ napi = { version = '2.12.6', default-features = false, features = [
     'tokio_rt',
 ] }
 napi-derive = '2.9.3'
+nom = '7.1.3'
 regex = "1.9.1"
 rayon = "1.7.0"
 thiserror = "1.0.40"

--- a/packages/nx/src/native/cache/expand_outputs.rs
+++ b/packages/nx/src/native/cache/expand_outputs.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crate::native::utils::glob::build_glob_set;
+use crate::native::glob::build_glob_set;
 use crate::native::utils::path::Normalize;
 use crate::native::walker::nx_walker_sync;
 

--- a/packages/nx/src/native/glob/glob_group.rs
+++ b/packages/nx/src/native/glob/glob_group.rs
@@ -1,0 +1,46 @@
+use std::borrow::Cow;
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug, PartialEq)]
+pub enum GlobGroup<'a> {
+    // *(a|b|c)
+    ZeroOrMore(Cow<'a, str>),
+    // ?(a|b|c)
+    ZeroOrOne(Cow<'a, str>),
+    // +(a|b|c)
+    OneOrMore(Cow<'a, str>),
+    // @(a|b|c)
+    ExactOne(Cow<'a, str>),
+    // !(a|b|c)
+    Negated(Cow<'a, str>),
+    NegatedFileName(Cow<'a, str>),
+    NonSpecialGroup(Cow<'a, str>),
+    NonSpecial(Cow<'a, str>),
+}
+
+impl<'a> Display for GlobGroup<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GlobGroup::ZeroOrMore(s)
+            | GlobGroup::ZeroOrOne(s)
+            | GlobGroup::OneOrMore(s)
+            | GlobGroup::ExactOne(s)
+            | GlobGroup::NonSpecialGroup(s)
+            | GlobGroup::Negated(s) => {
+                if s.contains(',') {
+                    write!(f, "{{{}}}", s)
+                } else {
+                    write!(f, "{}", s)
+                }
+            }
+            GlobGroup::NegatedFileName(s) => {
+                if s.contains(',') {
+                    write!(f, "{{{}}}.", s)
+                } else {
+                    write!(f, "{}.", s)
+                }
+            }
+            GlobGroup::NonSpecial(s) => write!(f, "{}", s),
+        }
+    }
+}

--- a/packages/nx/src/native/glob/glob_parser.rs
+++ b/packages/nx/src/native/glob/glob_parser.rs
@@ -1,0 +1,276 @@
+use crate::native::glob::glob_group::GlobGroup;
+use nom::branch::alt;
+use nom::bytes::complete::{is_not, tag, take_till, take_until, take_while};
+use nom::combinator::{eof, map, map_parser};
+use nom::error::{context, convert_error, VerboseError};
+use nom::multi::{many_till, separated_list0};
+use nom::sequence::{preceded, terminated};
+use nom::{Finish, IResult};
+use std::borrow::Cow;
+
+fn simple_group(input: &str) -> IResult<&str, GlobGroup, VerboseError<&str>> {
+    context(
+        "simple_group",
+        map(preceded(tag("("), group), GlobGroup::NonSpecialGroup),
+    )(input)
+}
+
+fn zero_or_more_group(input: &str) -> IResult<&str, GlobGroup, VerboseError<&str>> {
+    context(
+        "zero_or_more_group",
+        map(preceded(tag("*("), group), GlobGroup::ZeroOrMore),
+    )(input)
+}
+
+fn zero_or_one_group(input: &str) -> IResult<&str, GlobGroup, VerboseError<&str>> {
+    context(
+        "zero_or_one_group",
+        map(preceded(tag("?("), group), GlobGroup::ZeroOrOne),
+    )(input)
+}
+
+fn one_or_more_group(input: &str) -> IResult<&str, GlobGroup, VerboseError<&str>> {
+    context(
+        "one_or_more_group",
+        map(preceded(tag("+("), group), GlobGroup::OneOrMore),
+    )(input)
+}
+
+fn exact_one_group(input: &str) -> IResult<&str, GlobGroup, VerboseError<&str>> {
+    context(
+        "exact_one_group",
+        map(preceded(tag("@("), group), GlobGroup::ExactOne),
+    )(input)
+}
+
+fn negated_group(input: &str) -> IResult<&str, GlobGroup, VerboseError<&str>> {
+    context(
+        "negated_group",
+        map(preceded(tag("!("), group), GlobGroup::Negated),
+    )(input)
+}
+
+fn negated_file_group(input: &str) -> IResult<&str, GlobGroup, VerboseError<&str>> {
+    context("negated_file_group", |input| {
+        let (input, result) = preceded(tag("!("), group)(input)?;
+        let (input, _) = tag(".")(input)?;
+        Ok((input, GlobGroup::NegatedFileName(result)))
+    })(input)
+}
+
+fn non_special_character(input: &str) -> IResult<&str, GlobGroup, VerboseError<&str>> {
+    context(
+        "non_special_character",
+        map(
+            alt((
+                take_while(|c| c != '?' && c != '+' && c != '@' && c != '!' && c != '('),
+                is_not("*("),
+            )),
+            |i: &str| GlobGroup::NonSpecial(i.into()),
+        ),
+    )(input)
+}
+
+fn group(input: &str) -> IResult<&str, Cow<str>, VerboseError<&str>> {
+    context(
+        "group",
+        map_parser(terminated(take_until(")"), tag(")")), separated_group_items),
+    )(input)
+}
+
+fn separated_group_items(input: &str) -> IResult<&str, Cow<str>, VerboseError<&str>> {
+    map(
+        separated_list0(
+            alt((tag("|"), tag(","))),
+            take_while(|c| c != '|' && c != ','),
+        ),
+        |items: Vec<&str>| {
+            if items.len() == 1 {
+                Cow::from(items[0])
+            } else {
+                Cow::from(items.join(","))
+            }
+        },
+    )(input)
+}
+
+fn parse_segment(input: &str) -> IResult<&str, Vec<GlobGroup>, VerboseError<&str>> {
+    context(
+        "parse_segment",
+        many_till(
+            context(
+                "glob_group",
+                alt((
+                    simple_group,
+                    zero_or_more_group,
+                    zero_or_one_group,
+                    one_or_more_group,
+                    exact_one_group,
+                    negated_file_group,
+                    negated_group,
+                    non_special_character,
+                )),
+            ),
+            eof,
+        ),
+    )(input)
+    .map(|(i, (groups, _))| (i, groups))
+}
+
+fn separated_segments(input: &str) -> IResult<&str, Vec<Vec<GlobGroup>>, VerboseError<&str>> {
+    separated_list0(tag("/"), map_parser(take_till(|c| c == '/'), parse_segment))(input)
+}
+
+// match on !test/, but not !(test)/
+fn negated_glob(input: &str) -> (&str, bool) {
+    let (tagged_input, _) = match tag::<_, _, VerboseError<&str>>("!")(input) {
+        Ok(result) => result,
+        Err(_) => return (input, false),
+    };
+
+    match tag::<_, _, VerboseError<&str>>("(")(tagged_input) {
+        Ok(_) => (input, false),
+        Err(_) => (tagged_input, true),
+    }
+}
+
+pub fn parse_glob(input: &str) -> anyhow::Result<(bool, Vec<Vec<GlobGroup>>)> {
+    let (input, negated) = negated_glob(input);
+    let result = separated_segments(input).finish();
+    if let Ok((_, result)) = result {
+        Ok((negated, result))
+    } else {
+        Err(anyhow::anyhow!(
+            "{}",
+            convert_error(input, result.err().unwrap())
+        ))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::native::glob::glob_group::GlobGroup;
+    use crate::native::glob::glob_parser::parse_glob;
+
+    #[test]
+    fn should_parse_globs() {
+        let result = parse_glob("a/b/c").unwrap();
+        assert_eq!(
+            result,
+            (
+                false,
+                vec![
+                    vec![GlobGroup::NonSpecial("a".into())],
+                    vec![GlobGroup::NonSpecial("b".into())],
+                    vec![GlobGroup::NonSpecial("c".into())]
+                ]
+            )
+        );
+
+        let result = parse_glob("a/*.ts").unwrap();
+        assert_eq!(
+            result,
+            (
+                false,
+                vec![
+                    vec![GlobGroup::NonSpecial("a".into())],
+                    vec![GlobGroup::NonSpecial("*.ts".into())]
+                ]
+            )
+        );
+
+        let result = parse_glob("a/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)").unwrap();
+        assert_eq!(
+            result,
+            (
+                false,
+                vec![
+                    vec![GlobGroup::NonSpecial("a".into())],
+                    vec![GlobGroup::NonSpecial("**".into()),],
+                    vec![
+                        GlobGroup::ZeroOrOne("*.".into()),
+                        GlobGroup::OneOrMore("spec,test".into()),
+                        GlobGroup::NonSpecial(".[jt]s".into()),
+                        GlobGroup::ZeroOrOne("x".into()),
+                        GlobGroup::ZeroOrOne(".snap".into())
+                    ]
+                ]
+            )
+        );
+
+        let result = parse_glob("!(e2e|test)/*.ts").unwrap();
+        assert_eq!(
+            result,
+            (
+                false,
+                vec![
+                    vec![GlobGroup::Negated("e2e,test".into())],
+                    vec![GlobGroup::NonSpecial("*.ts".into())]
+                ]
+            )
+        );
+
+        let result = parse_glob("**/*.(js|ts)").unwrap();
+        assert_eq!(
+            result,
+            (
+                false,
+                vec![
+                    vec![GlobGroup::NonSpecial("**".into())],
+                    vec![
+                        GlobGroup::NonSpecial("*.".into()),
+                        GlobGroup::NonSpecialGroup("js,ts".into())
+                    ]
+                ]
+            )
+        );
+
+        let result = parse_glob("**/!(README).[jt]s!(x)").unwrap();
+        assert_eq!(
+            result,
+            (
+                false,
+                vec![
+                    vec![GlobGroup::NonSpecial("**".into())],
+                    vec![
+                        GlobGroup::NegatedFileName("README".into()),
+                        GlobGroup::NonSpecial("[jt]s".into()),
+                        GlobGroup::Negated("x".into())
+                    ]
+                ]
+            )
+        );
+
+        let result = parse_glob("!test/!(README).[jt]s!(x)").unwrap();
+        assert_eq!(
+            result,
+            (
+                true,
+                vec![
+                    vec![GlobGroup::NonSpecial("test".into())],
+                    vec![
+                        GlobGroup::NegatedFileName("README".into()),
+                        GlobGroup::NonSpecial("[jt]s".into()),
+                        GlobGroup::Negated("x".into())
+                    ]
+                ]
+            )
+        );
+
+        let result = parse_glob("!(test)/!(README).[jt]s!(x)").unwrap();
+        assert_eq!(
+            result,
+            (
+                false,
+                vec![
+                    vec![GlobGroup::Negated("test".into())],
+                    vec![
+                        GlobGroup::NegatedFileName("README".into()),
+                        GlobGroup::NonSpecial("[jt]s".into()),
+                        GlobGroup::Negated("x".into())
+                    ]
+                ]
+            )
+        );
+    }
+}

--- a/packages/nx/src/native/glob/glob_transform.rs
+++ b/packages/nx/src/native/glob/glob_transform.rs
@@ -1,0 +1,187 @@
+use crate::native::glob::glob_group::GlobGroup;
+use crate::native::glob::glob_parser::parse_glob;
+use itertools::Itertools;
+use std::collections::HashSet;
+
+#[derive(Debug)]
+enum GlobType {
+    Negative(String),
+    Positive(String),
+}
+
+pub fn convert_glob(glob: &str) -> anyhow::Result<Vec<String>> {
+    let (negated, parsed) = parse_glob(glob)?;
+    let mut built_segments: Vec<Vec<GlobType>> = Vec::new();
+    for (index, glob_segment) in parsed.iter().enumerate() {
+        let is_last = index == parsed.len() - 1;
+        built_segments.push(build_segment("", glob_segment, is_last, false));
+    }
+
+    let mut globs = built_segments
+        .iter()
+        .multi_cartesian_product()
+        .map(|product| {
+            let mut negative = false;
+            let mut full_path = false;
+            let mut path = String::from("");
+            for (index, glob) in product.iter().enumerate() {
+                full_path = index == product.len() - 1;
+                match glob {
+                    GlobType::Negative(s) if index != product.len() - 1 => {
+                        path.push_str(&format!("{}/", s));
+                        negative = true;
+                        break;
+                    }
+                    GlobType::Negative(s) => {
+                        path.push_str(&format!("{}/", s));
+                        negative = true;
+                    }
+                    GlobType::Positive(s) => {
+                        path.push_str(&format!("{}/", s));
+                    }
+                }
+            }
+
+            let modified_path = if full_path {
+                &path[..path.len() - 1]
+            } else {
+                &path
+            };
+
+            if negative || negated {
+                format!("!{}", modified_path)
+            } else {
+                modified_path.to_owned()
+            }
+        })
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    globs.sort();
+    Ok(globs)
+}
+
+fn build_segment(
+    existing: &str,
+    group: &[GlobGroup],
+    is_last_segment: bool,
+    is_negative: bool,
+) -> Vec<GlobType> {
+    if let Some(glob_part) = group.iter().next() {
+        let built_glob = format!("{}{}", existing, glob_part);
+        match glob_part {
+            GlobGroup::ZeroOrMore(_) | GlobGroup::ZeroOrOne(_) => {
+                let existing = if !is_last_segment { "*" } else { existing };
+                let off_group = build_segment(existing, &group[1..], is_last_segment, is_negative);
+                let on_group =
+                    build_segment(&built_glob, &group[1..], is_last_segment, is_negative);
+                off_group.into_iter().chain(on_group).collect::<Vec<_>>()
+            }
+            GlobGroup::Negated(_) => {
+                let existing = if !is_last_segment { "*" } else { existing };
+                let off_group = build_segment(existing, &group[1..], is_last_segment, is_negative);
+                let on_group = build_segment(&built_glob, &group[1..], is_last_segment, true);
+                off_group.into_iter().chain(on_group).collect::<Vec<_>>()
+            }
+            GlobGroup::NegatedFileName(_) => {
+                let off_group = build_segment("*.", &group[1..], is_last_segment, is_negative);
+                let on_group = build_segment(&built_glob, &group[1..], is_last_segment, true);
+                off_group.into_iter().chain(on_group).collect::<Vec<_>>()
+            }
+            GlobGroup::OneOrMore(_)
+            | GlobGroup::ExactOne(_)
+            | GlobGroup::NonSpecial(_)
+            | GlobGroup::NonSpecialGroup(_) => {
+                build_segment(&built_glob, &group[1..], is_last_segment, is_negative)
+            }
+        }
+    } else if is_negative {
+        vec![GlobType::Negative(existing.to_string())]
+    } else {
+        vec![GlobType::Positive(existing.to_string())]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::convert_glob;
+
+    #[test]
+    fn convert_globs_full_convert() {
+        let full_convert =
+            convert_glob("dist/!(cache|cache2)/**/!(README|LICENSE).(js|ts)").unwrap();
+        assert_eq!(
+            full_convert,
+            [
+                "!dist/*/**/{README,LICENSE}.{js,ts}",
+                "!dist/{cache,cache2}/",
+                "dist/*/**/*.{js,ts}",
+            ]
+        );
+    }
+
+    #[test]
+    fn convert_globs_no_dirs() {
+        let no_dirs = convert_glob("dist/**/!(README|LICENSE).(js|ts)").unwrap();
+        assert_eq!(
+            no_dirs,
+            ["!dist/**/{README,LICENSE}.{js,ts}", "dist/**/*.{js,ts}",]
+        );
+    }
+
+    #[test]
+    fn convert_globs_no_files() {
+        let no_files = convert_glob("dist/!(cache|cache2)/**/*.(js|ts)").unwrap();
+        assert_eq!(no_files, ["!dist/{cache,cache2}/", "dist/*/**/*.{js,ts}",]);
+    }
+
+    #[test]
+    fn convert_globs_no_extensions() {
+        let no_extensions = convert_glob("dist/!(cache|cache2)/**/*.js").unwrap();
+        assert_eq!(no_extensions, ["!dist/{cache,cache2}/", "dist/*/**/*.js",]);
+    }
+
+    #[test]
+    fn convert_globs_no_patterns() {
+        let no_patterns = convert_glob("dist/**/*.js").unwrap();
+        assert_eq!(no_patterns, ["dist/**/*.js",]);
+    }
+
+    #[test]
+    fn convert_globs_single_negative() {
+        let negative_single_dir = convert_glob("packages/!(package-a)*").unwrap();
+        assert_eq!(negative_single_dir, ["!packages/package-a*", "packages/*"]);
+    }
+
+    #[test]
+    fn test_transforming_globs() {
+        let globs = convert_glob("!(test|e2e)/?(*.)+(spec|test).[jt]s!(x)?(.snap)").unwrap();
+        assert_eq!(
+            globs,
+            vec![
+                "!*/*.{spec,test}.[jt]sx",
+                "!*/*.{spec,test}.[jt]sx.snap",
+                "!*/{spec,test}.[jt]sx",
+                "!*/{spec,test}.[jt]sx.snap",
+                "!{test,e2e}/",
+                "*/*.{spec,test}.[jt]s",
+                "*/*.{spec,test}.[jt]s.snap",
+                "*/{spec,test}.[jt]s",
+                "*/{spec,test}.[jt]s.snap"
+            ]
+        );
+
+        let globs = convert_glob("**/!(package-a)*").unwrap();
+        assert_eq!(globs, vec!["!**/package-a*", "**/*"]);
+
+        let globs = convert_glob("dist/!(cache|cache2)/**/!(README|LICENSE).(js|ts)").unwrap();
+        assert_eq!(
+            globs,
+            [
+                "!dist/*/**/{README,LICENSE}.{js,ts}",
+                "!dist/{cache,cache2}/",
+                "dist/*/**/*.{js,ts}"
+            ]
+        );
+    }
+}

--- a/packages/nx/src/native/mod.rs
+++ b/packages/nx/src/native/mod.rs
@@ -1,4 +1,5 @@
 pub mod cache;
+pub mod glob;
 pub mod hasher;
 mod logger;
 pub mod plugins;

--- a/packages/nx/src/native/plugins/js/ts_import_locators.rs
+++ b/packages/nx/src/native/plugins/js/ts_import_locators.rs
@@ -665,7 +665,7 @@ fn find_imports(
 #[cfg(test)]
 mod find_imports {
     use super::*;
-    use crate::native::utils::glob::build_glob_set;
+    use crate::native::glob::build_glob_set;
     use crate::native::utils::path::Normalize;
     use crate::native::walker::nx_walker;
     use assert_fs::prelude::*;

--- a/packages/nx/src/native/utils/find_matching_projects.rs
+++ b/packages/nx/src/native/utils/find_matching_projects.rs
@@ -1,5 +1,5 @@
+use crate::native::glob::{build_glob_set, NxGlobSet};
 use crate::native::project_graph::types::{Project, ProjectGraph};
-use crate::native::utils::glob::{build_glob_set, NxGlobSet};
 use hashbrown::HashSet;
 use std::collections::HashMap;
 
@@ -212,7 +212,7 @@ fn add_matching_projects_by_tag<'a>(
             .get(*project_name)
             .and_then(|p| p.tags.as_ref())
             .map(|tags| tags.iter().map(|tag| tag.as_str()).collect::<Vec<_>>());
-        let Some(tags) =  project_tags else {
+        let Some(tags) = project_tags else {
             continue;
         };
 

--- a/packages/nx/src/native/utils/mod.rs
+++ b/packages/nx/src/native/utils/mod.rs
@@ -1,5 +1,4 @@
 mod find_matching_projects;
-pub mod glob;
 pub mod path;
 
 pub use find_matching_projects::*;

--- a/packages/nx/src/native/walker.rs
+++ b/packages/nx/src/native/walker.rs
@@ -5,7 +5,7 @@ use std::thread::available_parallelism;
 use crossbeam_channel::{unbounded, Receiver};
 use ignore::WalkBuilder;
 
-use crate::native::utils::glob::build_glob_set;
+use crate::native::glob::build_glob_set;
 
 use walkdir::WalkDir;
 

--- a/packages/nx/src/native/workspace/config_files.rs
+++ b/packages/nx/src/native/workspace/config_files.rs
@@ -1,4 +1,4 @@
-use crate::native::utils::glob::build_glob_set;
+use crate::native::glob::build_glob_set;
 use crate::native::utils::path::Normalize;
 use crate::native::workspace::types::ConfigurationParserResult;
 
@@ -12,7 +12,7 @@ pub(super) fn glob_files(
     files: Option<&[(PathBuf, String)]>,
 ) -> napi::Result<Vec<String>, WorkspaceErrors> {
     let Some(files) = files else {
-        return Ok(Default::default())
+        return Ok(Default::default());
     };
 
     let globs =
@@ -33,8 +33,7 @@ pub(super) fn get_project_configurations<ConfigurationParser>(
 where
     ConfigurationParser: Fn(Vec<String>) -> napi::Result<ConfigurationParserResult>,
 {
-    let config_paths =
-        glob_files(globs, files).map_err(anyhow::Error::from)?;
+    let config_paths = glob_files(globs, files).map_err(anyhow::Error::from)?;
 
     parse_configurations(config_paths)
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Current native glob implementation has a naive approach to handle extglobs. Where it only handles negated groups (`!()`) using regex

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The extglob is now parsed and we are able to handle `@()`, `!()`, `?()`, `+()`, `*()` patterns. Although, there are still some limitations:
* `*(a|b|c)` && `?(a|b|c)` behave the same
* `+(a|b|c)` && `@(a|b|c)` behave the same

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
