### PR TITLE
feat(core): add exports to package.json of package

### DIFF
--- a/tools/workspace-plugin/src/generators/create-nodes-plugin/__snapshots__/generator.spec.ts.snap
+++ b/tools/workspace-plugin/src/generators/create-nodes-plugin/__snapshots__/generator.spec.ts.snap
@@ -1,5 +1,59 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`create-nodes-plugin/generator generator should add the plugin path to package.json exports 1`] = `
+"{
+  "name": "@nx/eslint",
+  "version": "0.0.1",
+  "private": false,
+  "description": "Some description",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nrwl/nx.git",
+    "directory": "packages/eslint"
+  },
+  "keywords": [
+    "Monorepo",
+    "eslint",
+    "Web",
+    "CLI"
+  ],
+  "main": "./index",
+  "typings": "./index.d.ts",
+  "author": "Victor Savkin",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/nrwl/nx/issues"
+  },
+  "homepage": "https://nx.dev",
+  "generators": "./generators.json",
+  "executors": "./executors.json",
+  "ng-update": {
+    "requirements": {},
+    "migrations": "./migrations.json"
+  },
+  "dependencies": {
+    "@nx/devkit": "file:../devkit"
+  },
+  "peerDependencies": {},
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./package.json": "./package.json",
+    "./migrations.json": "./migrations.json",
+    "./generators.json": "./generators.json",
+    "./executors.json": "./executors.json",
+    "./executors": "./executors.js",
+    "./src/executors/*/schema.json": "./src/executors/*/schema.json",
+    "./src/executors/*.impl": "./src/executors/*.impl.js",
+    "./src/executors/*/compat": "./src/executors/*/compat.js",
+    "./plugin": "./plugin.js"
+  }
+}
+"
+`;
+
 exports[`create-nodes-plugin/generator generator should run successfully 1`] = `
 "import {
   CreateNodes,

--- a/tools/workspace-plugin/src/generators/create-nodes-plugin/generator.spec.ts
+++ b/tools/workspace-plugin/src/generators/create-nodes-plugin/generator.spec.ts
@@ -17,14 +17,13 @@ describe('create-nodes-plugin/generator generator', () => {
       },
     });
 
-    writeJson(tree, 'packages/eslint/package.json', {});
-
     jest.spyOn(process, 'cwd').mockReturnValue('/virtual/packages/eslint');
 
     setCwd('packages/eslint');
   });
 
   it('should run successfully', async () => {
+    writeJson(tree, 'packages/eslint/package.json', {});
     await generatorGenerator(tree);
     expect(
       tree.read('packages/eslint/src/plugins/plugin.ts').toString()
@@ -38,6 +37,57 @@ describe('create-nodes-plugin/generator generator', () => {
           'packages/eslint/src/migrations/update-17-2-0/add-eslint-plugin.ts'
         )
         .toString()
+    ).toMatchSnapshot();
+  });
+
+  it('should add the plugin path to package.json exports', async () => {
+    writeJson(tree, 'packages/eslint/package.json', {
+      name: '@nx/eslint',
+      version: '0.0.1',
+      private: false,
+      description: 'Some description',
+      repository: {
+        type: 'git',
+        url: 'https://github.com/nrwl/nx.git',
+        directory: 'packages/eslint',
+      },
+      keywords: ['Monorepo', 'eslint', 'Web', 'CLI'],
+      main: './index',
+      typings: './index.d.ts',
+      author: 'Victor Savkin',
+      license: 'MIT',
+      bugs: {
+        url: 'https://github.com/nrwl/nx/issues',
+      },
+      homepage: 'https://nx.dev',
+      generators: './generators.json',
+      executors: './executors.json',
+      'ng-update': {
+        requirements: {},
+        migrations: './migrations.json',
+      },
+      dependencies: {
+        '@nx/devkit': 'file:../devkit',
+      },
+      peerDependencies: {},
+      publishConfig: {
+        access: 'public',
+      },
+      exports: {
+        '.': './index.js',
+        './package.json': './package.json',
+        './migrations.json': './migrations.json',
+        './generators.json': './generators.json',
+        './executors.json': './executors.json',
+        './executors': './executors.js',
+        './src/executors/*/schema.json': './src/executors/*/schema.json',
+        './src/executors/*.impl': './src/executors/*.impl.js',
+        './src/executors/*/compat': './src/executors/*/compat.js',
+      },
+    });
+    await generatorGenerator(tree);
+    expect(
+      tree.read('packages/eslint/package.json', 'utf-8')
     ).toMatchSnapshot();
   });
 });

--- a/tools/workspace-plugin/src/generators/create-nodes-plugin/generator.ts
+++ b/tools/workspace-plugin/src/generators/create-nodes-plugin/generator.ts
@@ -1,4 +1,11 @@
-import { formatFiles, generateFiles, names, Tree } from '@nx/devkit';
+import {
+  formatFiles,
+  generateFiles,
+  joinPathFragments,
+  names,
+  Tree,
+  updateJson,
+} from '@nx/devkit';
 import { basename, join, relative } from 'path';
 import migrationGenerator from '@nx/plugin/src/generators/migration/migration';
 
@@ -20,6 +27,17 @@ export async function generatorGenerator(tree: Tree) {
     className,
     propertyName,
   });
+
+  updateJson(
+    tree,
+    joinPathFragments(relative(tree.root, cwd), 'package.json'),
+    (json) => {
+      if (json['exports']) {
+        json['exports']['./plugin'] = './plugin.js';
+      }
+      return json;
+    }
+  );
 
   await formatFiles(tree);
 }


### PR DESCRIPTION
## Current behaviour

If a project has `exports` defined in its `package.json` (eg. https://github.com/nrwl/nx/blob/master/packages/vite/package.json#L46), then if we don't add the `plugin.js` path into the exports array, an error shows up when trying to use the plugin:

```
 >  NX   Package subpath './plugin' is not defined by "exports" in /Users/fileas/Projects/nrwl/test-nx-workspaces/pcv3-zero/node_modules/@nx/vite/package.json
```

## Expected behaviour

The generator should add the plugin path into the exports array/