### PR TITLE
fix(react): component generator should work without sourceRoot

### DIFF
--- a/packages/react/src/generators/component/component.spec.ts
+++ b/packages/react/src/generators/component/component.spec.ts
@@ -1,5 +1,11 @@
 import { installedCypressVersion } from '@nx/cypress/src/utils/cypress-version';
-import { logger, readJson, Tree } from '@nx/devkit';
+import {
+  logger,
+  readJson,
+  readProjectConfiguration,
+  Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { createApp, createLib } from '../../utils/testing-generators';
 import { componentGenerator } from './component';
@@ -133,6 +139,22 @@ describe('component', () => {
         name: 'hello',
         style: 'css',
         project: 'my-app',
+        export: true,
+      });
+
+      const indexContent = appTree.read('my-lib/src/index.ts', 'utf-8');
+
+      expect(indexContent).not.toMatch(/lib\/hello/);
+    });
+
+    it('should work for projects without sourceRoot', async () => {
+      const projectConfig = readProjectConfiguration(appTree, 'my-lib');
+      delete projectConfig.sourceRoot;
+      updateProjectConfiguration(appTree, 'my-lib', projectConfig);
+
+      await componentGenerator(appTree, {
+        name: 'my-lib/src/lib/hello',
+        style: 'css',
         export: true,
       });
 

--- a/packages/react/src/generators/component/lib/normalize-options.ts
+++ b/packages/react/src/generators/component/lib/normalize-options.ts
@@ -36,7 +36,11 @@ export async function normalizeOptions(
 
   const { className } = names(name);
 
-  const { sourceRoot: projectSourceRoot, projectType } = project;
+  const {
+    sourceRoot: projectSourceRoot,
+    root: projectRoot,
+    projectType,
+  } = project;
 
   const styledModule = /^(css|scss|less|none)$/.test(options.style)
     ? null
@@ -62,6 +66,6 @@ export async function normalizeOptions(
     className,
     fileName,
     filePath,
-    projectSourceRoot,
+    projectSourceRoot: projectSourceRoot ?? projectRoot,
   };
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
If a project does not have source root, generator fails.

## Expected Behavior
Component generator should use project root is source root is not found.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
