### PR TITLE
fix(nx-cloud): fallback to nx-cloud bin if enterprise is outdated and…

### DIFF
--- a/packages/nx/bin/nx-cloud.ts
+++ b/packages/nx/bin/nx-cloud.ts
@@ -44,6 +44,11 @@ async function invokeCommandWithNxCloudClient(options: CloudTaskRunnerOptions) {
     const body = ['Cannot run commands from the `nx-cloud` CLI.'];
 
     if (e instanceof NxCloudEnterpriseOutdatedError) {
+      try {
+        // TODO: Remove this when all enterprise customers have updated.
+        // Try requiring the bin from the `nx-cloud` package.
+        return require('nx-cloud/bin/nx-cloud');
+      } catch {}
       body.push(
         'If you are an Nx Enterprise customer, please reach out to your assigned Developer Productivity Engineer.',
         'If you are NOT an Nx Enterprise customer but are seeing this message, please reach out to cloud-support@nrwl.io.'


### PR DESCRIPTION
… migrate properly

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When Nx Enterprise customers update, there's a chance that the bin from `nx` overrides the bin from the `nx-cloud` package.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When running `nx-cloud` commands fails due to the NxEnterprise instance being out of date, it tries to fallback to the `nx-cloud` bin which has a built in version of the commands.

In addition, `useLightClient` is set to true if during the migration, it is unable to verify the Nx Cloud client.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
