### PR TITLE
feat(core): change the signature of createNodes to return a project root map instead of project name map

### DIFF
--- a/docs/generated/devkit/CreateNodesFunction.md
+++ b/docs/generated/devkit/CreateNodesFunction.md
@@ -1,6 +1,6 @@
 # Type alias: CreateNodesFunction<T\>
 
-Ƭ **CreateNodesFunction**<`T`\>: (`projectConfigurationFile`: `string`, `options`: `T` \| `undefined`, `context`: [`CreateNodesContext`](../../devkit/documents/CreateNodesContext)) => { `externalNodes?`: `Record`<`string`, [`ProjectGraphExternalNode`](../../devkit/documents/ProjectGraphExternalNode)\> ; `projects?`: `Record`<`string`, [`ProjectConfiguration`](../../devkit/documents/ProjectConfiguration)\> }
+Ƭ **CreateNodesFunction**<`T`\>: (`projectConfigurationFile`: `string`, `options`: `T` \| `undefined`, `context`: [`CreateNodesContext`](../../devkit/documents/CreateNodesContext)) => { `externalNodes?`: `Record`<`string`, [`ProjectGraphExternalNode`](../../devkit/documents/ProjectGraphExternalNode)\> ; `projects?`: `Record`<`string`, `Optional`<[`ProjectConfiguration`](../../devkit/documents/ProjectConfiguration), `"root"`\>\> }
 
 #### Type parameters
 
@@ -27,7 +27,7 @@ Used for creating nodes for the [ProjectGraph](../../devkit/documents/ProjectGra
 
 `Object`
 
-| Name             | Type                                                                                               |
-| :--------------- | :------------------------------------------------------------------------------------------------- |
-| `externalNodes?` | `Record`<`string`, [`ProjectGraphExternalNode`](../../devkit/documents/ProjectGraphExternalNode)\> |
-| `projects?`      | `Record`<`string`, [`ProjectConfiguration`](../../devkit/documents/ProjectConfiguration)\>         |
+| Name             | Type                                                                                                              | Description                                                                                                |
+| :--------------- | :---------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------- |
+| `externalNodes?` | `Record`<`string`, [`ProjectGraphExternalNode`](../../devkit/documents/ProjectGraphExternalNode)\>                | A map of external node name -> external node. External nodes do not have a root, so the key is their name. |
+| `projects?`      | `Record`<`string`, `Optional`<[`ProjectConfiguration`](../../devkit/documents/ProjectConfiguration), `"root"`\>\> | A map of project root -> project configuration                                                             |

--- a/docs/shared/recipes/plugins/project-graph-plugins.md
+++ b/docs/shared/recipes/plugins/project-graph-plugins.md
@@ -60,15 +60,11 @@ export const createNodes: CreateNodes = [
   '**/project.json',
   (projectConfigurationFile: string, opts, context: CreateNodesContext) => {
     const projectConfiguration = readJson(projectConfigurationFile);
-    const projectRoot = dirname(projectConfigurationFile);
-    const projectName = projectConfiguration.name;
+    const root = dirname(projectConfigurationFile);
 
     return {
       projects: {
-        [projectName]: {
-          ...projectConfiguration,
-          root: projectRoot,
-        },
+        [root]: projectConfiguration,
       },
     };
   },
@@ -244,12 +240,10 @@ export const createNodes: CreateNodes<MyPluginOptions> = [
   '**/project.json',
   (fileName, opts, ctx) => {
     const root = dirname(fileName);
-    const name = basename(fileName);
 
     return {
       projects: {
-        [name]: {
-          root,
+        [root]: {
           tags: opts.tagName ? [opts.tagName] : [],
         },
       },

--- a/e2e/plugin/src/nx-plugin.fixtures.ts
+++ b/e2e/plugin/src/nx-plugin.fixtures.ts
@@ -37,8 +37,9 @@ export const createNodes: CreateNodes<PluginOptions> = [
 
         return {
             projects: {
-                [name]: {
+                [root]: {
                     root,
+                    name,
                     targets: {
                         build: {
                             executor: "nx:run-commands",

--- a/packages/nx/plugins/package-json-workspaces.spec.ts
+++ b/packages/nx/plugins/package-json-workspaces.spec.ts
@@ -40,7 +40,7 @@ describe('nx package.json workspaces plugin', () => {
       .toMatchInlineSnapshot(`
       {
         "projects": {
-          "root": {
+          ".": {
             "name": "root",
             "projectType": "library",
             "root": ".",
@@ -68,7 +68,7 @@ describe('nx package.json workspaces plugin', () => {
       .toMatchInlineSnapshot(`
       {
         "projects": {
-          "lib-a": {
+          "packages/lib-a": {
             "name": "lib-a",
             "projectType": "library",
             "root": "packages/lib-a",
@@ -96,7 +96,7 @@ describe('nx package.json workspaces plugin', () => {
       .toMatchInlineSnapshot(`
       {
         "projects": {
-          "lib-b": {
+          "packages/lib-b": {
             "implicitDependencies": [
               "lib-a",
             ],

--- a/packages/nx/plugins/package-json-workspaces.ts
+++ b/packages/nx/plugins/package-json-workspaces.ts
@@ -30,13 +30,14 @@ export function getNxPackageJsonWorkspacesPlugin(root: string): NxPluginV2 {
 
 export function createNodeFromPackageJson(pkgJsonPath: string, root: string) {
   const json: PackageJson = readJsonFile(join(root, pkgJsonPath));
+  const project = buildProjectConfigurationFromPackageJson(
+    json,
+    pkgJsonPath,
+    readNxJson(root)
+  );
   return {
     projects: {
-      [json.name]: buildProjectConfigurationFromPackageJson(
-        json,
-        pkgJsonPath,
-        readNxJson(root)
-      ),
+      [project.root]: project,
     },
   };
 }

--- a/packages/nx/src/plugins/project-json/build-nodes/project-json.spec.ts
+++ b/packages/nx/src/plugins/project-json/build-nodes/project-json.spec.ts
@@ -39,7 +39,7 @@ describe('nx project.json plugin', () => {
       .toMatchInlineSnapshot(`
       {
         "projects": {
-          "root": {
+          ".": {
             "name": "root",
             "root": ".",
             "targets": {
@@ -53,7 +53,7 @@ describe('nx project.json plugin', () => {
       .toMatchInlineSnapshot(`
       {
         "projects": {
-          "lib-a": {
+          "packages/lib-a": {
             "name": "lib-a",
             "root": "packages/lib-a",
             "targets": {

--- a/packages/nx/src/plugins/project-json/build-nodes/project-json.ts
+++ b/packages/nx/src/plugins/project-json/build-nodes/project-json.ts
@@ -9,13 +9,14 @@ export const CreateProjectJsonProjectsPlugin: NxPluginV2 = {
   name: 'nx-core-build-project-json-nodes',
   createNodes: [
     '{project.json,**/project.json}',
-    (file, _, context) => {
-      const root = context.workspaceRoot;
-      const json = readJsonFile<ProjectConfiguration>(join(root, file));
+    (file, _, { workspaceRoot }) => {
+      const json = readJsonFile<ProjectConfiguration>(
+        join(workspaceRoot, file)
+      );
       const project = buildProjectFromProjectJson(json, file);
       return {
         projects: {
-          [project.name]: project,
+          [project.root]: project,
         },
       };
     },

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -114,11 +114,19 @@ export function buildProjectsConfigurationsFromProjectPathsAndPlugins(
             workspaceRoot: root,
           });
         for (const node in projectNodes) {
-          projectNodes[node].name ??= node;
-          mergeProjectConfigurationIntoRootMap(
-            projectRootMap,
-            projectNodes[node]
-          );
+          mergeProjectConfigurationIntoRootMap(projectRootMap, {
+            // If root is specified in config, that will overwrite this.
+            // Specifying it here though allows plugins to return something like
+            // {
+            //   projects: {
+            //     [root]: { targets: buildTargetsFromFile(f) }
+            //   }
+            // }
+            // Otherwise, the root would have to be specified in the config as well
+            // which would be a bit redundant.
+            root: node,
+            ...projectNodes[node],
+          });
         }
         Object.assign(externalNodes, pluginExternalNodes);
       }

--- a/tools/workspace-plugin/src/generators/create-nodes-plugin/__snapshots__/generator.spec.ts.snap
+++ b/tools/workspace-plugin/src/generators/create-nodes-plugin/__snapshots__/generator.spec.ts.snap
@@ -88,11 +88,10 @@ export const createNodes: CreateNodes<EslintPluginOptions> = [
     }
 
     options = normalizeOptions(options);
-    const projectName = basename(projectRoot);
 
     return {
       projects: {
-        [projectName]: {
+        [projectRoot]: {
           root: projectRoot,
           projectType: 'library',
           targets: buildEslintTargets(

--- a/tools/workspace-plugin/src/generators/create-nodes-plugin/files/src/plugins/plugin.ts.template
+++ b/tools/workspace-plugin/src/generators/create-nodes-plugin/files/src/plugins/plugin.ts.template
@@ -31,11 +31,10 @@ export const createNodes: CreateNodes<<%= className %>PluginOptions> = [
     }
 
     options = normalizeOptions(options);
-    const projectName = basename(projectRoot);
 
     return {
       projects: {
-        [projectName]: {
+        [projectRoot]: {
           root: projectRoot,
           projectType: 'library',
           targets: build<%= className %>Targets(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
CreateNodes returns an object containing a map of project name -> project, this is a bit awkward to use when you know that there is another thing providing that info later on. It feels bad to register a target and have to come up with a placeholder name that you know will be overridden.

## Expected Behavior
The project root is **_required_** anyways, to merge infos together, so use it as the key to the map

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
