### PR TITLE
fix(core): always load nxignore last for highest priority

### DIFF
--- a/packages/nx/src/native/tests/watcher.spec.ts
+++ b/packages/nx/src/native/tests/watcher.spec.ts
@@ -27,10 +27,13 @@ describe('watcher', () => {
     temp.cleanup();
   });
 
-  it('should trigger the callback for files that are not ignored', (done) => {
-    watcher = new Watcher(temp.tempDir);
-    watcher.watch((error, paths) => {
-      expect(paths).toMatchInlineSnapshot(`
+  it('should trigger the callback for files that are not ignored', async () => {
+    return new Promise<void>(async (done) => {
+      await wait();
+
+      watcher = new Watcher(temp.tempDir);
+      watcher.watch((error, paths) => {
+        expect(paths).toMatchInlineSnapshot(`
         [
           {
             "path": "app1/main.html",
@@ -38,21 +41,25 @@ describe('watcher', () => {
           },
         ]
       `);
-      done();
-    });
+        done();
+      });
 
-    wait().then(() => {
+      await wait();
       temp.createFileSync('node_modules/my-file.json', JSON.stringify({}));
+      await wait();
       temp.createFileSync('app2/main.css', JSON.stringify({}));
+      await wait();
       temp.createFileSync('app1/main.html', JSON.stringify({}));
     });
-  });
+  }, 10000);
 
-  it('should trigger the callback when files are updated', (done) => {
-    watcher = new Watcher(temp.tempDir);
+  it('should trigger the callback when files are updated', async () => {
+    return new Promise<void>(async (done) => {
+      await wait();
+      watcher = new Watcher(temp.tempDir);
 
-    watcher.watch((err, paths) => {
-      expect(paths).toMatchInlineSnapshot(`
+      watcher.watch((err, paths) => {
+        expect(paths).toMatchInlineSnapshot(`
         [
           {
             "path": "app1/main.js",
@@ -60,46 +67,51 @@ describe('watcher', () => {
           },
         ]
       `);
-      done();
-    });
+        done();
+      });
 
-    wait(1000).then(() => {
+      await wait();
       // nxignored file should not trigger a callback
       temp.appendFile('app2/main.js', 'update');
+      await wait();
       temp.appendFile('app1/main.js', 'update');
     });
-  });
+  }, 10000);
 
-  it('should watch file renames', (done) => {
-    watcher = new Watcher(temp.tempDir);
+  it('should watch file renames', async () => {
+    return new Promise<void>(async (done) => {
+      await wait();
+      watcher = new Watcher(temp.tempDir);
 
-    watcher.watch((err, paths) => {
-      expect(paths.length).toBe(2);
-      expect(paths.find((p) => p.type === 'create')).toMatchInlineSnapshot(`
+      watcher.watch((err, paths) => {
+        expect(paths.length).toBe(2);
+        expect(paths.find((p) => p.type === 'create')).toMatchInlineSnapshot(`
         {
           "path": "app1/rename.js",
           "type": "create",
         }
       `);
-      expect(paths.find((p) => p.type === 'delete')).toMatchInlineSnapshot(`
+        expect(paths.find((p) => p.type === 'delete')).toMatchInlineSnapshot(`
         {
           "path": "app1/main.js",
           "type": "delete",
         }
       `);
-      done();
-    });
+        done();
+      });
 
-    wait().then(() => {
+      await wait();
       temp.renameFile('app1/main.js', 'app1/rename.js');
     });
-  });
+  }, 10000);
 
-  it('should trigger on deletes', (done) => {
-    watcher = new Watcher(temp.tempDir);
+  it('should trigger on deletes', async () => {
+    return new Promise<void>(async (done) => {
+      await wait();
+      watcher = new Watcher(temp.tempDir);
 
-    watcher.watch((err, paths) => {
-      expect(paths).toMatchInlineSnapshot(`
+      watcher.watch((err, paths) => {
+        expect(paths).toMatchInlineSnapshot(`
         [
           {
             "path": "app1/main.js",
@@ -107,19 +119,22 @@ describe('watcher', () => {
           },
         ]
       `);
-      done();
-    });
+        done();
+      });
 
-    wait().then(() => {
+      await wait();
       temp.removeFileSync('app1/main.js');
     });
-  });
+  }, 10000);
 
-  it('should ignore nested gitignores', (done) => {
-    watcher = new Watcher(temp.tempDir);
+  it('should ignore nested gitignores', async () => {
+    return new Promise<void>(async (done) => {
+      await wait();
 
-    watcher.watch((err, paths) => {
-      expect(paths).toMatchInlineSnapshot(`
+      watcher = new Watcher(temp.tempDir);
+
+      watcher.watch((err, paths) => {
+        expect(paths).toMatchInlineSnapshot(`
         [
           {
             "path": "boo.txt",
@@ -127,30 +142,33 @@ describe('watcher', () => {
           },
         ]
       `);
-      done();
-    });
+        done();
+      });
 
-    wait().then(() => {
+      await wait();
       // should not be triggered
       temp.createFileSync('nested-ignore/hello1.txt', '');
+      await wait();
       temp.createFileSync('boo.txt', '');
     });
-  });
+  }, 10000);
 
-  it('should include files that are negated in nxignore but are ignored in gitignore', (done) => {
-    watcher = new Watcher(temp.tempDir);
-    watcher.watch((err, paths) => {
-      expect(paths.some(({ path }) => path === '.env.local')).toBeTruthy();
-      done();
-    });
+  it('should include files that are negated in nxignore but are ignored in gitignore', async () => {
+    return new Promise<void>(async (done) => {
+      await wait();
+      watcher = new Watcher(temp.tempDir);
+      watcher.watch((err, paths) => {
+        expect(paths.some(({ path }) => path === '.env.local')).toBeTruthy();
+        done();
+      });
 
-    wait().then(() => {
+      await wait(2000);
       temp.appendFile('.env.local', 'hello');
     });
-  });
+  }, 15000);
 });
 
-function wait(timeout = 500) {
+function wait(timeout = 1000) {
   return new Promise<void>((res) => {
     setTimeout(() => {
       res();

--- a/packages/nx/src/native/watch/utils.rs
+++ b/packages/nx/src/native/watch/utils.rs
@@ -1,10 +1,11 @@
 use ignore::WalkBuilder;
 use ignore_files::IgnoreFile;
+use std::path::Path;
 use std::{fs, path::PathBuf};
 use tracing::trace;
 use watchexec_events::{Event, Tag};
 
-pub(super) fn get_ignore_files<T: AsRef<str>>(root: T) -> Vec<IgnoreFile> {
+pub(super) fn get_ignore_files<T: AsRef<str>>(root: T) -> (Vec<IgnoreFile>, Option<IgnoreFile>) {
     let root = root.as_ref();
 
     let mut walker = WalkBuilder::new(root);
@@ -13,20 +14,12 @@ pub(super) fn get_ignore_files<T: AsRef<str>>(root: T) -> Vec<IgnoreFile> {
 
     let node_folder = PathBuf::from(root).join("node_modules");
     walker.filter_entry(move |entry| !entry.path().starts_with(&node_folder));
-    let mut ignores = walker
+    let gitignore_files = walker
         .build()
         .flatten()
-        .filter(|result| {
-            result.path().ends_with(".nxignore") || result.path().ends_with(".gitignore")
-        })
-        .map(|result| result.path().into())
-        .collect::<Vec<PathBuf>>();
-
-    ignores.sort();
-
-    ignores
-        .into_iter()
-        .map(|path| {
+        .filter(|result| result.path().ends_with(".gitignore"))
+        .map(|result| {
+            let path: PathBuf = result.path().into();
             let parent: PathBuf = path.parent().unwrap_or(&path).into();
             IgnoreFile {
                 path,
@@ -34,7 +27,21 @@ pub(super) fn get_ignore_files<T: AsRef<str>>(root: T) -> Vec<IgnoreFile> {
                 applies_to: None,
             }
         })
-        .collect()
+        .collect();
+    (gitignore_files, get_nx_ignore(root))
+}
+
+fn get_nx_ignore<P: AsRef<Path>>(origin: P) -> Option<IgnoreFile> {
+    let nx_ignore_path = PathBuf::from(origin.as_ref()).join(".nxignore");
+    if nx_ignore_path.exists() {
+        Some(IgnoreFile {
+            path: nx_ignore_path,
+            applies_in: Some(origin.as_ref().into()),
+            applies_to: None,
+        })
+    } else {
+        None
+    }
 }
 
 // /// Get only the root level folders to watch.


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
when loading ignore files, the underlying framework uses async mechanisms to read these files. Even if we pass the files in a set order, the async nature would be `FutureUnordered`. This causes the nxignore to sometimes be loaded before gitignore, where we always want it to be loaded last. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The nxignore file is added after all other ignore files have been read and loaded.
* Also added bonus of stabilizing the watcher unit tests

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
