### PR TITLE
fix(misc): add missing migration to bump typescript version to v5.2

### DIFF
--- a/packages/js/migrations.json
+++ b/packages/js/migrations.json
@@ -111,6 +111,18 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "17.1.0": {
+      "version": "17.1.0-beta.4",
+      "x-prompt": "Do you want to update to TypeScript v5.2?",
+      "requires": {
+        "typescript": ">=5.1.0 <5.2.0"
+      },
+      "packages": {
+        "typescript": {
+          "version": "~5.2.2"
+        }
+      }
     }
   }
 }

--- a/packages/workspace/migrations.json
+++ b/packages/workspace/migrations.json
@@ -61,6 +61,18 @@
           "version": "~5.1.3"
         }
       }
+    },
+    "17.1.0": {
+      "version": "17.1.0-beta.4",
+      "x-prompt": "Do you want to update to TypeScript v5.2?",
+      "requires": {
+        "typescript": ">=5.1.0 <5.2.0"
+      },
+      "packages": {
+        "typescript": {
+          "version": "~5.2.2"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The migration to bump the TypeScript version to v5.2 is missing.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

There should be a migration to bump the TypeScript version to v5.2.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
