### PR TITLE
feat(core): don't clear NX_BASE or NX_HEAD

### DIFF
--- a/packages/nx/src/tasks-runner/task-env.ts
+++ b/packages/nx/src/tasks-runner/task-env.ts
@@ -57,8 +57,7 @@ export function getEnvVariablesForTask(
     delete res.NX_STREAM_OUTPUT;
     delete res.NX_PREFIX_OUTPUT;
   }
-  delete res.NX_BASE;
-  delete res.NX_HEAD;
+  // we don't reset NX_BASE or NX_HEAD because those are set by the user and should be preserved
   delete res.NX_SET_CLI;
   return res;
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

When I try to access the `NX_BASE` environment variable that I set in CI from a local executor it returns `undefined`

## Expected Behavior

I can access the `NX_BASE` value that I set in CI within a local executor

## Related Issue(s)

The behavior was added in https://github.com/nrwl/nx/pull/10523 however it is unclear why it was necessary. As far as I can tell Nx does not write to these environment variables. The nearby comment says that they are being reset in case Nx is called within Nx however I precisely do not want them reset so that I can call Nx within Nx and re-use the same base and head

This is tangentially related to this [discord question](https://discord.com/channels/1143497901675401286/1143501349653327882/threads/1171564165991780453)
