### PR TITLE
fix(core): always ignore ".git/", "node_modules" and ".nx/" directories even when `use_ignore` is set to false for the watcher

### DIFF
--- a/packages/nx/src/daemon/server/watcher.ts
+++ b/packages/nx/src/daemon/server/watcher.ts
@@ -69,12 +69,6 @@ export async function watchOutputFiles(cb: FileWatcherCallback) {
       return cb(err, null);
     }
 
-    events = events.filter((event) => {
-      return (
-        !event.path.startsWith('.git') && !event.path.includes('node_modules')
-      );
-    });
-
     if (events.length !== 0) {
       cb(null, events);
     }

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -128,7 +128,10 @@ export class Watcher {
   origin: string
   /**
    * Creates a new Watcher instance.
-   * If `useIgnore` is set to false, no ignores will be used, even when `additionalGlobs` is set
+   * Will always ignore the following directories:
+   * * .git/
+   * * node_modules/
+   * * .nx/
    */
   constructor(origin: string, additionalGlobs?: Array<string> | undefined | null, useIgnore?: boolean | undefined | null)
   watch(callback: (err: string | null, events: WatchEvent[]) => void): void

--- a/packages/nx/src/native/watch/utils.rs
+++ b/packages/nx/src/native/watch/utils.rs
@@ -5,33 +5,40 @@ use std::{fs, path::PathBuf};
 use tracing::trace;
 use watchexec_events::{Event, Tag};
 
-pub(super) fn get_ignore_files<T: AsRef<str>>(root: T) -> (Vec<IgnoreFile>, Option<IgnoreFile>) {
+pub(super) fn get_ignore_files<T: AsRef<str>>(
+    use_ignore: bool,
+    root: T,
+) -> Option<Vec<IgnoreFile>> {
     let root = root.as_ref();
+    if use_ignore {
+        let mut walker = WalkBuilder::new(root);
+        walker.hidden(false);
+        walker.git_ignore(false);
 
-    let mut walker = WalkBuilder::new(root);
-    walker.hidden(false);
-    walker.git_ignore(false);
-
-    let node_folder = PathBuf::from(root).join("node_modules");
-    walker.filter_entry(move |entry| !entry.path().starts_with(&node_folder));
-    let gitignore_files = walker
-        .build()
-        .flatten()
-        .filter(|result| result.path().ends_with(".gitignore"))
-        .map(|result| {
-            let path: PathBuf = result.path().into();
-            let parent: PathBuf = path.parent().unwrap_or(&path).into();
-            IgnoreFile {
-                path,
-                applies_in: Some(parent),
-                applies_to: None,
-            }
-        })
-        .collect();
-    (gitignore_files, get_nx_ignore(root))
+        let node_folder = PathBuf::from(root).join("node_modules");
+        walker.filter_entry(move |entry| !entry.path().starts_with(&node_folder));
+        Some(
+            walker
+                .build()
+                .flatten()
+                .filter(|result| result.path().ends_with(".gitignore"))
+                .map(|result| {
+                    let path: PathBuf = result.path().into();
+                    let parent: PathBuf = path.parent().unwrap_or(&path).into();
+                    IgnoreFile {
+                        path,
+                        applies_in: Some(parent),
+                        applies_to: None,
+                    }
+                })
+                .collect(),
+        )
+    } else {
+        None
+    }
 }
 
-fn get_nx_ignore<P: AsRef<Path>>(origin: P) -> Option<IgnoreFile> {
+pub(super) fn get_nx_ignore<P: AsRef<Path>>(origin: P) -> Option<IgnoreFile> {
     let nx_ignore_path = PathBuf::from(origin.as_ref()).join(".nxignore");
     if nx_ignore_path.exists() {
         Some(IgnoreFile {
@@ -43,23 +50,6 @@ fn get_nx_ignore<P: AsRef<Path>>(origin: P) -> Option<IgnoreFile> {
         None
     }
 }
-
-// /// Get only the root level folders to watch.
-// /// These will not include git ignored folders
-// pub(super) fn get_watch_directories<T: AsRef<str>>(root: T) -> Vec<PathBuf> {
-//     let root = root.as_ref();
-//
-//     let mut walker = WalkBuilder::new(root);
-//     walker.hidden(false);
-//     walker.max_depth(Some(1));
-//     walker.filter_entry(|entry| entry.path().is_dir());
-//
-//     walker
-//         .build()
-//         .flatten()
-//         .map(|result| result.path().into())
-//         .collect()
-// }
 
 pub(super) fn transform_event(watch_event: &Event) -> Option<Event> {
     if cfg!(linux) {

--- a/packages/nx/src/native/watch/watch_config.rs
+++ b/packages/nx/src/native/watch/watch_config.rs
@@ -1,21 +1,20 @@
-use crate::native::watch::utils::get_ignore_files;
-use crate::native::watch::watch_filterer::WatchFilterer;
-use ignore_files::IgnoreFilter;
 use std::sync::Arc;
+
+use ignore_files::IgnoreFilter;
 use tracing::trace;
 use watchexec::config::RuntimeConfig;
 use watchexec_filterer_ignore::IgnoreFilterer;
+
+use crate::native::watch::utils::{get_ignore_files, get_nx_ignore};
+use crate::native::watch::watch_filterer::WatchFilterer;
 
 pub(super) async fn create_runtime(
     origin: &str,
     additional_globs: &[&str],
     use_ignore: bool,
 ) -> napi::Result<RuntimeConfig> {
-    let (ignore_files, nx_ignore_file) = if use_ignore {
-        get_ignore_files(origin)
-    } else {
-        (vec![], None)
-    };
+    let ignore_files = get_ignore_files(use_ignore, origin);
+    let nx_ignore_file = get_nx_ignore(origin);
 
     trace!(
         ?use_ignore,
@@ -23,9 +22,13 @@ pub(super) async fn create_runtime(
         ?ignore_files,
         "Using these ignore files for the watcher"
     );
-    let mut filter = IgnoreFilter::new(origin, &ignore_files)
-        .await
-        .map_err(anyhow::Error::from)?;
+    let mut filter = if let Some(ignore_files) = ignore_files {
+        IgnoreFilter::new(origin, &ignore_files)
+            .await
+            .map_err(anyhow::Error::from)?
+    } else {
+        IgnoreFilter::empty(origin)
+    };
 
     filter
         .add_globs(additional_globs, Some(&origin.into()))

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -33,7 +33,10 @@ pub struct Watcher {
 #[napi]
 impl Watcher {
     /// Creates a new Watcher instance.
-    /// If `useIgnore` is set to false, no ignores will be used, even when `additionalGlobs` is set
+    /// Will always ignore the following directories:
+    /// * .git/
+    /// * node_modules/
+    /// * .nx/
     #[napi(constructor)]
     pub fn new(
         origin: String,
@@ -43,15 +46,15 @@ impl Watcher {
         let watch_exec = Watchexec::new(InitConfig::default(), RuntimeConfig::default())
             .map_err(anyhow::Error::from)?;
 
-        let mut globs = additional_globs.unwrap_or_default();
-
-        // always ignore the .git  and node_modules folder
-        globs.push(".git/".into());
-        globs.push("node_modules/".into());
+        // always have these globs come before the additional globs
+        let mut globs = vec![".git/".into(), "node_modules/".into(), ".nx/".into()];
+        if let Some(additional_globs) = additional_globs {
+            globs.extend(additional_globs);
+        }
 
         Ok(Watcher {
             origin: if cfg!(window) {
-                origin.replace("/", "\\")
+                origin.replace('/', "\\")
             } else {
                 origin
             },
@@ -94,7 +97,7 @@ impl Watcher {
         let origin = self.origin.clone();
         let watch_exec = self.watch_exec.clone();
         let additional_globs = self.additional_globs.clone();
-        let use_ignore = self.use_ignore.clone();
+        let use_ignore = self.use_ignore;
         let start = async move {
             let mut runtime = watch_config::create_runtime(
                 &origin,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Setting up a watcher to not use ignore files (for daemon output watching) did not apply default ignores of ".git/", "node_modules" or ".nx/" directories. This causes the daemon watcher to go into a loop if there were files being written to one of these directories (especially node_modules or .nx folders because of the daemon.log or other nx cached files)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The watcher is properly configured to set an empty IgnoreFile in the root, and the then additional_globs and nxignore will always be applied. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
