### PR TITLE
feat(nx-dev): call to action button

### DIFF
--- a/docs/nx-cloud/intro/nx-cloud-workflows.md
+++ b/docs/nx-cloud/intro/nx-cloud-workflows.md
@@ -5,6 +5,8 @@ src="https://www.youtube.com/embed/JG1FWfZFByM"
 title="Introducing Nx Cloud Workflows"
 width="100%" /%}
 
+{% call-to-action title="Sign Up for Early Access" icon="nxcloud" description="Experience Nx Cloud Workflows for yourself" url="https://cloud.nx.app/workflows-early-access" /%}
+
 ## Powerful CI Capabilities Optimized for Nx monorepos
 
 Just like Nx and Nx Cloud, Nx Cloud Workflows enables you to offload tedious technical tasks so that you can focus on more mission-critical tasks. With a traditional CI platform, you are responsible for telling the CI platform exactly what commands to execute in which environments and what to do with the artifacts. Nx Cloud by itself can automate parallelizing tasks and sharing build artifacts across machines, but you still have to create agent machines on your CI platform.

--- a/nx-dev/ui-markdoc/src/index.ts
+++ b/nx-dev/ui-markdoc/src/index.ts
@@ -17,6 +17,8 @@ import { CustomLink } from './lib/nodes/link.component';
 import { link } from './lib/nodes/link.schema';
 import { Callout } from './lib/tags/callout.component';
 import { callout } from './lib/tags/callout.schema';
+import { CallToAction } from './lib/tags/call-to-action.component';
+import { callToAction } from './lib/tags/call-to-action.schema';
 import { Card, Cards, LinkCard } from './lib/tags/cards.component';
 import { card, cards, linkCard } from './lib/tags/cards.schema';
 import { GithubRepository } from './lib/tags/github-repository.component';
@@ -66,6 +68,7 @@ export const getMarkdocCustomConfig = (
     },
     tags: {
       callout,
+      'call-to-action': callToAction,
       card,
       cards,
       'link-card': linkCard,
@@ -90,6 +93,7 @@ export const getMarkdocCustomConfig = (
   },
   components: {
     Callout,
+    CallToAction,
     Card,
     Cards,
     LinkCard,

--- a/nx-dev/ui-markdoc/src/lib/tags/call-to-action.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/call-to-action.component.tsx
@@ -1,0 +1,41 @@
+import { ChevronRightIcon } from '@heroicons/react/24/outline';
+import { frameworkIcons } from '../icons';
+
+export function CallToAction({
+  url,
+  title,
+  description,
+  icon = 'nx',
+}: {
+  url: string;
+  title: string;
+  description?: string;
+  icon?: string;
+}): JSX.Element {
+  return (
+    <div className="not-prose group relative my-12 mx-auto flex w-full max-w-md items-center gap-3 overflow-hidden rounded-lg bg-slate-50 shadow-md transition hover:text-white dark:bg-slate-800/60">
+      <div className="absolute inset-0 z-0 w-2 bg-blue-500 transition-all duration-150 group-hover:w-full dark:bg-sky-500"></div>
+      <div className="w-2 bg-blue-500 dark:bg-sky-500"></div>
+
+      <div className="z-10 flex flex-grow items-center py-3">
+        <div className="h-10 w-10">{icon && frameworkIcons[icon]?.image}</div>
+
+        <div className="mx-3">
+          <p>
+            {title}
+            <a
+              href={url}
+              target="_blank"
+              rel="noreferrer"
+              className="block text-sm font-medium opacity-80"
+            >
+              <span className="absolute inset-0" aria-hidden="true"></span>
+              {description || ''}
+            </a>
+          </p>
+        </div>
+      </div>
+      <ChevronRightIcon className="mr-4 h-6 w-6 transition-all group-hover:translate-x-3" />
+    </div>
+  );
+}

--- a/nx-dev/ui-markdoc/src/lib/tags/call-to-action.schema.ts
+++ b/nx-dev/ui-markdoc/src/lib/tags/call-to-action.schema.ts
@@ -1,0 +1,29 @@
+import { Schema } from '@markdoc/markdoc';
+
+export const callToAction: Schema = {
+  // 'Display content in a large button.',
+  render: 'CallToAction',
+  attributes: {
+    url: {
+      // 'The url to link to',
+      type: 'String',
+      required: true,
+    },
+    title: {
+      // 'Title of the call to action',
+      type: 'String',
+      required: true,
+    },
+    description: {
+      // 'Description of the call to action.  Defaults to an empty string',
+      type: 'String',
+      required: false,
+    },
+    icon: {
+      // 'Icon displayed to the left of the call to actions.  Defaults to the Nx icon',
+      // Choose from the list in nx-dev/ui-markdoc/src/lib/icons.tsx
+      type: 'String',
+      required: false,
+    },
+  },
+};


### PR DESCRIPTION
- Adds a call to action button to be used on docs pages - styled the same as the existing github repository links
  - Customizable icon, title, description and url
- Uses the call to action on the Nx Cloud Workflows page

![Screenshot 2023-11-08 at 11 19 14 AM](https://github.com/nrwl/nx/assets/861504/e0f78cce-6391-48d7-83b0-39dca99925c9)
