### PR TITLE
fix(misc): update nx-welcome templates with as-provided generator paths

### DIFF
--- a/packages/angular/src/generators/application/files/ng-module/src/app/nx-welcome.component.ts__tpl__
+++ b/packages/angular/src/generators/application/files/ng-module/src/app/nx-welcome.component.ts__tpl__
@@ -744,7 +744,7 @@ import { Component, ViewEncapsulation } from '@angular/core';
             <pre><span># Generate UI lib</span>
 nx g &#64;nx/angular:lib ui
 <span># Add a component</span>
-nx g &#64;nx/angular:component button --project ui</pre>
+nx g &#64;nx/angular:component ui/src/lib/button</pre>
           </details>
           <details>
             <summary>

--- a/packages/angular/src/generators/application/files/standalone-components/src/app/nx-welcome.component.ts__tpl__
+++ b/packages/angular/src/generators/application/files/standalone-components/src/app/nx-welcome.component.ts__tpl__
@@ -747,7 +747,7 @@ import { CommonModule } from '@angular/common';
             <pre><span># Generate UI lib</span>
 nx g &#64;nx/angular:lib ui
 <span># Add a component</span>
-nx g &#64;nx/angular:component button --project ui</pre>
+nx g &#64;nx/angular:component ui/src/lib/button</pre>
           </details>
           <details>
             <summary>

--- a/packages/expo/src/generators/application/files/src/app/App.tsx.template
+++ b/packages/expo/src/generators/application/files/src/app/App.tsx.template
@@ -472,7 +472,7 @@ export const App = () => {
                   @nx/expo:component \
                 </Text>
                 <Text style={[styles.textXS, styles.monospace]}>
-                  button --project ui
+                  ui/src/lib/button
                 </Text>
               </View>
               <View style={styles.listItem}>

--- a/packages/next/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/next/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -385,7 +385,7 @@ export default async function Index() {
                 <span># Generate UI lib</span>
                 nx g @nx/next:library ui
                 <span># Add a component</span>
-                nx g @nx/next:component button --project=ui
+                nx g @nx/next:component ui/src/lib/button
               </pre>
             </details>
             <details>

--- a/packages/next/src/generators/application/lib/create-application-files.helpers.ts
+++ b/packages/next/src/generators/application/lib/create-application-files.helpers.ts
@@ -358,7 +358,7 @@ export function createAppJsx(name: string) {
               <span># Generate UI lib</span>
               nx g @nx/next:library ui
               <span># Add a component</span>
-              nx g @nx/next:component button --project=ui
+              nx g @nx/next:component ui/src/lib/button
             </pre>
           </details>
           <details>

--- a/packages/nuxt/src/generators/application/files/src/components/NxWelcome.vue__tmpl__
+++ b/packages/nuxt/src/generators/application/files/src/components/NxWelcome.vue__tmpl__
@@ -379,9 +379,9 @@ defineProps<{
           </summary>
           <pre>
             <span># Generate UI lib</span>
-            nx g @nx/react:lib ui
+            nx g @nx/vue:lib ui
             <span># Add a component</span>
-            nx g @nx/react:component button --project ui
+            nx g @nx/vue:component ui/src/lib/button
           </pre>
         </details>
         <details>

--- a/packages/react-native/src/generators/application/files/app/src/app/App.tsx.template
+++ b/packages/react-native/src/generators/application/files/app/src/app/App.tsx.template
@@ -472,7 +472,7 @@ export const App = () => {
                   @nx/react-native:component \
                 </Text>
                 <Text style={[styles.textXS, styles.monospace]}>
-                  button --project ui
+                  ui/src/lib/button
                 </Text>
               </View>
               <View style={styles.listItem}>

--- a/packages/react/src/generators/application/files/nx-welcome/src/app/nx-welcome.tsx
+++ b/packages/react/src/generators/application/files/nx-welcome/src/app/nx-welcome.tsx
@@ -792,7 +792,7 @@ export function NxWelcome({ title }: { title: string }) {
                 <span># Generate UI lib</span>
                 nx g @nx/react:lib ui
                 <span># Add a component</span>
-                nx g @nx/react:component button --project ui
+                nx g @nx/react:component ui/src/lib/button
               </pre>
             </details>
             <details>

--- a/packages/vue/src/generators/application/files/common/src/app/NxWelcome.vue.template
+++ b/packages/vue/src/generators/application/files/common/src/app/NxWelcome.vue.template
@@ -372,9 +372,9 @@ defineProps<{
           </summary>
           <pre>
             <span># Generate UI lib</span>
-            nx g @nx/react:lib ui
+            nx g @nx/vue:lib ui
             <span># Add a component</span>
-            nx g @nx/react:component button --project ui
+            nx g @nx/vue:component ui/src/lib/button
           </pre>
         </details>
         <details>

--- a/packages/web/src/generators/application/files/app-vite/src/app/app.element.ts__tmpl__
+++ b/packages/web/src/generators/application/files/app-vite/src/app/app.element.ts__tmpl__
@@ -336,7 +336,7 @@ export class AppElement extends HTMLElement {
 nx g @nx/angular:lib ui
 
 <span># Add a component</span>
-nx g @nx/angular:component button --project ui</pre>
+nx g @nx/angular:component ui/src/lib/button</pre>
           </details>
           <details>
             <summary>

--- a/packages/web/src/generators/application/files/app-webpack/src/app/app.element.ts__tmpl__
+++ b/packages/web/src/generators/application/files/app-webpack/src/app/app.element.ts__tmpl__
@@ -336,7 +336,7 @@ export class AppElement extends HTMLElement {
 nx g @nx/angular:lib ui
 
 <span># Add a component</span>
-nx g @nx/angular:component button --project ui</pre>
+nx g @nx/angular:component ui/src/lib/button</pre>
           </details>
           <details>
             <summary>


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The default template in application generators still recommends generating a component using the deprecated `--project` option.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The default template in application generators recommends generating a component providing the full path.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
