### PR TITLE
fix(core): create nodes plugin fixes

### DIFF
--- a/packages/devkit/src/utils/replace-project-configuration-with-plugin.ts
+++ b/packages/devkit/src/utils/replace-project-configuration-with-plugin.ts
@@ -54,7 +54,7 @@ export function replaceProjectConfigurationsWithPlugin<T = unknown>(
       for (const [targetName, targetConfig] of Object.entries(node.targets)) {
         const targetFromProjectConfig = projectConfig.targets[targetName];
 
-        if (targetFromProjectConfig.executor !== targetConfig.executor) {
+        if (targetFromProjectConfig?.executor !== targetConfig.executor) {
           continue;
         }
 

--- a/tools/workspace-plugin/src/generators/create-nodes-plugin/__snapshots__/generator.spec.ts.snap
+++ b/tools/workspace-plugin/src/generators/create-nodes-plugin/__snapshots__/generator.spec.ts.snap
@@ -79,7 +79,7 @@ export const createNodes: CreateNodes<EslintPluginOptions> = [
     const projectRoot = dirname(configFilePath);
 
     // Do not create a project if package.json and project.json isn't there.
-    const siblingFiles = readdirSync(projectRoot);
+    const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));
     if (
       !siblingFiles.includes('package.json') &&
       !siblingFiles.includes('project.json')

--- a/tools/workspace-plugin/src/generators/create-nodes-plugin/files/src/plugins/plugin.ts.template
+++ b/tools/workspace-plugin/src/generators/create-nodes-plugin/files/src/plugins/plugin.ts.template
@@ -22,7 +22,7 @@ export const createNodes: CreateNodes<<%= className %>PluginOptions> = [
     const projectRoot = dirname(configFilePath);
 
     // Do not create a project if package.json and project.json isn't there.
-    const siblingFiles = readdirSync(projectRoot);
+    const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));
     if (
       !siblingFiles.includes('package.json') &&
       !siblingFiles.includes('project.json')


### PR DESCRIPTION
1. `const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot))`, `context.workspaceRoot` needed for using `tempFs` at least. And I guess more robust in any case?
2. `targetFromProjectConfig?.executor`: maybe a project does not have the defined target? so a project has `vite.config.ts` but does not have `serve` target. it would fail.