### PR TITLE
docs(angular): update angular tutorials for v17

### DIFF
--- a/docs/shared/angular-standalone-tutorial/angular-standalone.md
+++ b/docs/shared/angular-standalone-tutorial/angular-standalone.md
@@ -36,19 +36,19 @@ title="Tutorial: Standalone Angular Application"
 Create a new Angular application with the following command:
 
 ```{% command="npx create-nx-workspace@latest myngapp --preset=angular-standalone" path="~" %}
+✔ Which bundler would you like to use? · esbuild
 ✔ Default stylesheet format · css
+✔ Do you want to enable Server-Side Rendering (SSR) and Static Site Generation (SSG/Prerendering)? · No
 ✔ Test runner to use for end to end (E2E) tests · cypress
-✔ Would you like to use Standalone Components in your application? · Yes
-✔ Would you like to add routing? · Yes
 ✔ Enable distributed caching to make your CI faster · Yes
 ```
 
 You get asked a few questions that help Nx preconfigure your new Angular application. These include
 
-- Angular specific questions, such as whether you want to have the router set up for you, whether to use the Angular Standalone API and which stylesheet format to use
+- Angular specific questions, such as which bundler to use, whether to enable server-side rendering and which stylesheet format to use
 - General Nx questions, such as whether to enable distributed caching with Nx Cloud. Nx comes with built-in [local caching](/core-features/cache-task-results). If you want to benefit from this cache in CI, you can enable [distributed caching](/nx-cloud/features/remote-cache) which will set up [Nx Cloud](https://nx.app). This is also a prerequisite for enabling [distributed task execution](/nx-cloud/features/distribute-task-execution).
 
-For the sake of this tutorial, let's respond to all the questions with "yes".
+For the sake of this tutorial, let's respond to all the questions with the default response.
 
 The `create-nx-workspace` command generates the following structure:
 
@@ -144,11 +144,11 @@ All targets, such as `serve`, `build`, `test` or your custom ones, are defined i
   "name": "myngapp",
   ...
   "targets": {
-    "serve": { ... },
     "build": { ... },
-    "preview": { ... },
-    "test": { ... },
+    "serve": { ... },
+    "extract-i18n": { ... },
     "lint": { ... },
+    "test": { ... },
     "serve-static": { ... },
   },
 }

--- a/docs/shared/angular-tutorial/angular-monorepo.md
+++ b/docs/shared/angular-tutorial/angular-monorepo.md
@@ -55,10 +55,10 @@ Create a new Angular monorepo with the following command:
  >  NX   Let's create a new workspace [https://nx.dev/getting-started/intro]
 
 ✔ Application name · angular-store
+✔ Which bundler would you like to use? · esbuild
 ✔ Default stylesheet format · css
+✔ Do you want to enable Server-Side Rendering (SSR) and Static Site Generation (SSG/Prerendering)? · No
 ✔ Test runner to use for end to end (E2E) tests · cypress
-✔ Would you like to use Standalone Components in your application? · Yes
-✔ Would you like to add routing? · Yes
 ✔ Enable distributed caching to make your CI faster · Yes
 ```
 
@@ -132,11 +132,11 @@ All targets, such as `serve`, `build`, `test` or your custom ones, are defined i
   "name": "angular-store",
   ...
   "targets": {
-    "serve": { ... },
     "build": { ... },
-    "preview": { ... },
-    "test": { ... },
+    "serve": { ... },
+    "extract-i18n": { ... },
     "lint": { ... },
+    "test": { ... },
     "serve-static": { ... },
   },
 }


### PR DESCRIPTION
Updates Angular tutorials to remove references to `--routing` and `--standalone`.
Adds prompts for bundler and ssr.

Do not merge until 17.1.0 is released