### PR TITLE
fix(core): drop file lock after its used

### DIFF
--- a/packages/nx/bin/post-install.ts
+++ b/packages/nx/bin/post-install.ts
@@ -8,9 +8,11 @@ import { verifyOrUpdateNxCloudClient } from '../src/nx-cloud/update-manager';
 import { getCloudOptions } from '../src/nx-cloud/utilities/get-cloud-options';
 import { isNxCloudUsed } from '../src/utils/nx-cloud-utils';
 import { readNxJson } from '../src/config/nx-json';
+import { setupWorkspaceContext } from '../src/utils/workspace-context';
 
 (async () => {
   try {
+    setupWorkspaceContext(workspaceRoot);
     if (isMainNxPackage() && fileExists(join(workspaceRoot, 'nx.json'))) {
       const b = new Date();
       assertSupportedPlatform();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When something uses `WorkspaceContext.getFiles` within another `WorkspaceContext` call, the lock doesn't get unlocked and the inner call will never complete.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The lock is dropped after it is read. And other calls can use it.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
