### PR TITLE
cleanup(core): create root map in js and send to rust instead of full…

### DIFF
--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -103,15 +103,9 @@ export const enum WorkspaceErrors {
   ParseError = 'ParseError',
   Generic = 'Generic'
 }
-export interface ConfigurationParserResult {
-  projectNodes: Record<string, object>
-  externalNodes: Record<string, object>
-}
 export interface NxWorkspaceFiles {
   projectFileMap: Record<string, Array<FileData>>
   globalFiles: Array<FileData>
-  projectConfigurations: Record<string, object>
-  externalNodes: Record<string, object>
 }
 export class ImportResult {
   file: string
@@ -140,9 +134,9 @@ export class Watcher {
 export class WorkspaceContext {
   workspaceRoot: string
   constructor(workspaceRoot: string)
-  getWorkspaceFiles(globs: Array<string>, parseConfigurations: (arg0: Array<string>) => ConfigurationParserResult): NxWorkspaceFiles
+  getWorkspaceFiles(globs: Array<string>, parseConfigurations: (arg0: Array<string>) => Record<string, string>): NxWorkspaceFiles
   glob(globs: Array<string>): Array<string>
-  getProjectConfigurations(globs: Array<string>, parseConfigurations: (arg0: Array<string>) => ConfigurationParserResult): ConfigurationParserResult
+  getProjectConfigurations(globs: Array<string>, parseConfigurations: (arg0: Array<string>) => Record<string, string>): Record<string, string>
   incrementalUpdate(updatedFiles: Array<string>, deletedFiles: Array<string>): Record<string, string>
   allFileData(): Array<FileData>
 }

--- a/packages/nx/src/native/tests/workspace_files.spec.ts
+++ b/packages/nx/src/native/tests/workspace_files.spec.ts
@@ -10,15 +10,9 @@ describe('workspace files', () => {
       const res = {};
       for (const filename of filenames) {
         const json = readJsonFile(join(tempDir, filename));
-        res[json.name] = {
-          ...json,
-          root: dirname(filename),
-        };
+        res[dirname(filename)] = json.name;
       }
-      return {
-        projectNodes: res,
-        externalNodes: {},
-      };
+      return res;
     };
   }
 
@@ -57,14 +51,9 @@ describe('workspace files', () => {
     let globs = ['project.json', '**/project.json', 'libs/*/package.json'];
 
     const context = new WorkspaceContext(fs.tempDir);
-    let { projectFileMap, projectConfigurations, globalFiles } =
-      context.getWorkspaceFiles(
-        globs,
-        createParseConfigurationsFunction(fs.tempDir)
-      );
-
-    let sortedConfigs = Object.values(projectConfigurations).sort((a, b) =>
-      a['name'].localeCompare(b['name'])
+    let { projectFileMap, globalFiles } = context.getWorkspaceFiles(
+      globs,
+      createParseConfigurationsFunction(fs.tempDir)
     );
 
     expect(projectFileMap).toMatchInlineSnapshot(`
@@ -120,30 +109,6 @@ describe('workspace files', () => {
           },
         ],
       }
-    `);
-    expect(sortedConfigs).toMatchInlineSnapshot(`
-      [
-        {
-          "name": "nested-project",
-          "root": "libs/nested/project",
-        },
-        {
-          "name": "package-project",
-          "root": "libs/package-project",
-        },
-        {
-          "name": "project1",
-          "root": "libs/project1",
-        },
-        {
-          "name": "project2",
-          "root": "libs/project2",
-        },
-        {
-          "name": "project3",
-          "root": "libs/project3",
-        },
-      ]
     `);
     expect(globalFiles).toMatchInlineSnapshot(`
       [
@@ -213,57 +178,6 @@ describe('workspace files', () => {
         },
       ]
     `);
-  });
-
-  it('should dedupe configuration files', async () => {
-    const fs = new TempFs('workspace-files');
-    const nxJson: NxJsonConfiguration = {};
-    await fs.createFiles({
-      './nx.json': JSON.stringify(nxJson),
-      './package.json': JSON.stringify({
-        name: 'repo-name',
-        version: '0.0.0',
-        dependencies: {},
-      }),
-      './project.json': JSON.stringify({
-        name: 'repo-name',
-      }),
-      './libs/project1/project.json': JSON.stringify({
-        name: 'project1',
-      }),
-      './libs/project1/package.json': JSON.stringify({
-        name: 'project1',
-      }),
-      './libs/project1/index.js': '',
-    });
-
-    const context = new WorkspaceContext(fs.tempDir);
-    let globs = ['project.json', '**/project.json', '**/package.json'];
-
-    let nodes = context.getProjectConfigurations(globs, (filenames) => {
-      const res = {};
-      for (const filename of filenames) {
-        const json = readJsonFile(join(fs.tempDir, filename));
-        res[json.name] = {
-          ...json,
-          root: dirname(filename),
-        };
-      }
-      return {
-        externalNodes: {},
-        projectNodes: res,
-      };
-    });
-    expect(nodes.projectNodes).toEqual({
-      project1: {
-        name: 'project1',
-        root: 'libs/project1',
-      },
-      'repo-name': expect.objectContaining({
-        name: 'repo-name',
-        root: '.',
-      }),
-    });
   });
 
   // describe('errors', () => {

--- a/packages/nx/src/native/workspace/config_files.rs
+++ b/packages/nx/src/native/workspace/config_files.rs
@@ -1,6 +1,6 @@
 use crate::native::utils::glob::build_glob_set;
 use crate::native::utils::path::Normalize;
-use crate::native::workspace::types::ConfigurationParserResult;
+use std::collections::HashMap;
 
 use crate::native::workspace::errors::{InternalWorkspaceErrors, WorkspaceErrors};
 use rayon::prelude::*;
@@ -12,7 +12,7 @@ pub(super) fn glob_files(
     files: Option<&[(PathBuf, String)]>,
 ) -> napi::Result<Vec<String>, WorkspaceErrors> {
     let Some(files) = files else {
-        return Ok(Default::default())
+        return Ok(Default::default());
     };
 
     let globs =
@@ -29,12 +29,11 @@ pub(super) fn get_project_configurations<ConfigurationParser>(
     globs: Vec<String>,
     files: Option<&[(PathBuf, String)]>,
     parse_configurations: ConfigurationParser,
-) -> napi::Result<ConfigurationParserResult>
+) -> napi::Result<HashMap<String, String>>
 where
-    ConfigurationParser: Fn(Vec<String>) -> napi::Result<ConfigurationParserResult>,
+    ConfigurationParser: Fn(Vec<String>) -> napi::Result<HashMap<String, String>>,
 {
-    let config_paths =
-        glob_files(globs, files).map_err(anyhow::Error::from)?;
+    let config_paths = glob_files(globs, files).map_err(anyhow::Error::from)?;
 
     parse_configurations(config_paths)
 }

--- a/packages/nx/src/native/workspace/context.rs
+++ b/packages/nx/src/native/workspace/context.rs
@@ -18,8 +18,6 @@ use crate::native::workspace::errors::WorkspaceErrors;
 use crate::native::workspace::workspace_files::NxWorkspaceFiles;
 use crate::native::workspace::{config_files, workspace_files};
 
-use crate::native::workspace::types::ConfigurationParserResult;
-
 #[napi]
 pub struct WorkspaceContext {
     pub workspace_root: String,
@@ -70,7 +68,7 @@ impl FilesWorker {
     pub fn get_files(&self) -> Option<MutexGuard<'_, RawMutex, Files>> {
         let Some(files_sync) = &self.0 else {
             trace!("there were no files because the workspace root did not exist");
-            return None
+            return None;
         };
 
         let (files_lock, cvar) = &files_sync.deref();
@@ -93,7 +91,7 @@ impl FilesWorker {
     ) -> HashMap<String, String> {
         let Some(files_sync) = &self.0 else {
             trace!("there were no files because the workspace root did not exist");
-           return HashMap::new();
+            return HashMap::new();
         };
 
         let (files_lock, _) = &files_sync.deref();
@@ -108,8 +106,8 @@ impl FilesWorker {
             .par_iter()
             .filter_map(|path| {
                 let full_path = workspace_root_path.join(path);
-                let Ok( content ) = std::fs::read(full_path) else {
-                    trace!( "could not read file: ?full_path");
+                let Ok(content) = std::fs::read(full_path) else {
+                    trace!("could not read file: ?full_path");
                     return None;
                 };
                 Some((path.to_string(), xxh3::xxh3_64(&content).to_string()))
@@ -153,7 +151,7 @@ impl WorkspaceContext {
         parse_configurations: ConfigurationParser,
     ) -> napi::Result<NxWorkspaceFiles, WorkspaceErrors>
     where
-        ConfigurationParser: Fn(Vec<String>) -> napi::Result<ConfigurationParserResult>,
+        ConfigurationParser: Fn(Vec<String>) -> napi::Result<HashMap<String, String>>,
     {
         workspace_files::get_files(
             globs,
@@ -166,10 +164,7 @@ impl WorkspaceContext {
     }
 
     #[napi]
-    pub fn glob(
-        &self,
-        globs: Vec<String>,
-    ) -> napi::Result<Vec<String>, WorkspaceErrors> {
+    pub fn glob(&self, globs: Vec<String>) -> napi::Result<Vec<String>, WorkspaceErrors> {
         config_files::glob_files(
             globs,
             self.files_worker
@@ -184,9 +179,9 @@ impl WorkspaceContext {
         &self,
         globs: Vec<String>,
         parse_configurations: ConfigurationParser,
-    ) -> napi::Result<ConfigurationParserResult>
+    ) -> napi::Result<HashMap<String, String>>
     where
-        ConfigurationParser: Fn(Vec<String>) -> napi::Result<ConfigurationParserResult>,
+        ConfigurationParser: Fn(Vec<String>) -> napi::Result<HashMap<String, String>>,
     {
         config_files::get_project_configurations(
             globs,

--- a/packages/nx/src/native/workspace/types.rs
+++ b/packages/nx/src/native/workspace/types.rs
@@ -1,15 +1,5 @@
-use std::collections::HashMap;
-
-use napi::JsObject;
-
 #[derive(Debug, Eq, PartialEq)]
 pub enum FileLocation {
     Global,
     Project(String),
-}
-
-#[napi(object)]
-pub struct ConfigurationParserResult {
-    pub project_nodes: HashMap<String, JsObject>,
-    pub external_nodes: HashMap<String, JsObject>,
 }

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -96,6 +96,7 @@ export function buildProjectsConfigurationsFromProjectPathsAndPlugins(
 ): {
   projects: Record<string, ProjectConfiguration>;
   externalNodes: Record<string, ProjectGraphExternalNode>;
+  rootMap: Record<string, string>;
 } {
   const projectRootMap: Map<string, ProjectConfiguration> = new Map();
   const externalNodes: Record<string, ProjectGraphExternalNode> = {};
@@ -133,9 +134,12 @@ export function buildProjectsConfigurationsFromProjectPathsAndPlugins(
     }
   }
 
+  const rootMap = createRootMap(projectRootMap);
+
   return {
     projects: readProjectConfigurationsFromRootMap(projectRootMap),
     externalNodes,
+    rootMap,
   };
 }
 
@@ -289,4 +293,11 @@ export function readTargetDefaultsForTarget(
     // If the executor is not defined, the only key we have is the target name.
     return targetDefaults?.[targetName];
   }
+}
+function createRootMap(projectRootMap: Map<string, ProjectConfiguration>) {
+  const map: Record<string, string> = {};
+  for (const [projectRoot, { name: projectName }] of projectRootMap) {
+    map[projectRoot] = projectName;
+  }
+  return map;
 }

--- a/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
+++ b/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
@@ -60,25 +60,26 @@ export async function retrieveWorkspaceFiles(
   );
 
   performance.mark('get-workspace-files:start');
+  let projects: Record<string, ProjectConfiguration>;
+  let externalNodes: Record<string, ProjectGraphExternalNode>;
 
-  const { projectConfigurations, projectFileMap, globalFiles, externalNodes } =
-    getNxWorkspaceFilesFromContext(
-      workspaceRoot,
-      globs,
-      (configs: string[]) => {
-        const projectConfigurations = createProjectConfigurations(
-          workspaceRoot,
-          nxJson,
-          configs,
-          plugins
-        );
+  const { projectFileMap, globalFiles } = getNxWorkspaceFilesFromContext(
+    workspaceRoot,
+    globs,
+    (configs: string[]) => {
+      const projectConfigurations = createProjectConfigurations(
+        workspaceRoot,
+        nxJson,
+        configs,
+        plugins
+      );
 
-        return {
-          projectNodes: projectConfigurations.projects,
-          externalNodes: projectConfigurations.externalNodes,
-        };
-      }
-    ) as NxWorkspaceFiles;
+      projects = projectConfigurations.projects;
+
+      externalNodes = projectConfigurations.externalNodes;
+      return projectConfigurations.rootMap;
+    }
+  ) as NxWorkspaceFiles;
   performance.mark('get-workspace-files:end');
   performance.measure(
     'get-workspace-files',
@@ -94,9 +95,9 @@ export async function retrieveWorkspaceFiles(
     },
     projectConfigurations: {
       version: 2,
-      projects: projectConfigurations,
+      projects,
     } as ProjectsConfigurations,
-    externalNodes: externalNodes as Record<string, ProjectGraphExternalNode>,
+    externalNodes,
   };
 }
 
@@ -176,26 +177,30 @@ function _retrieveProjectConfigurations(
   externalNodes: Record<string, ProjectGraphExternalNode>;
   projectNodes: Record<string, ProjectConfiguration>;
 } {
-  return getProjectConfigurationsFromContext(
+  let result: {
+    externalNodes: Record<string, ProjectGraphExternalNode>;
+    projectNodes: Record<string, ProjectConfiguration>;
+  };
+  getProjectConfigurationsFromContext(
     workspaceRoot,
     globs,
     (configs: string[]) => {
-      const projectConfigurations = createProjectConfigurations(
+      const { projects, externalNodes, rootMap } = createProjectConfigurations(
         workspaceRoot,
         nxJson,
         configs,
         plugins
       );
 
-      return {
-        projectNodes: projectConfigurations.projects,
-        externalNodes: projectConfigurations.externalNodes,
+      result = {
+        projectNodes: projects,
+        externalNodes: externalNodes,
       };
+
+      return rootMap;
     }
-  ) as {
-    externalNodes: Record<string, ProjectGraphExternalNode>;
-    projectNodes: Record<string, ProjectConfiguration>;
-  };
+  );
+  return result;
 }
 
 export async function retrieveProjectConfigurationPaths(
@@ -232,24 +237,28 @@ export function retrieveProjectConfigurationsWithoutPluginInference(
     return projectsWithoutPluginCache.get(cacheKey);
   }
 
-  const projectConfigurations = getProjectConfigurationsFromContext(
+  let projects: Record<string, ProjectConfiguration>;
+  getProjectConfigurationsFromContext(
     root,
     projectGlobPatterns,
     (configs: string[]) => {
-      const { projects } = createProjectConfigurations(root, nxJson, configs, [
-        { plugin: getNxPackageJsonWorkspacesPlugin(root) },
-        { plugin: CreateProjectJsonProjectsPlugin },
-      ]);
-      return {
-        projectNodes: projects,
-        externalNodes: {},
-      };
+      const projectConfigurations = createProjectConfigurations(
+        root,
+        nxJson,
+        configs,
+        [
+          { plugin: getNxPackageJsonWorkspacesPlugin(root) },
+          { plugin: CreateProjectJsonProjectsPlugin },
+        ]
+      );
+      projects = projectConfigurations.projects;
+      return projectConfigurations.rootMap;
     }
-  ).projectNodes as Record<string, ProjectConfiguration>;
+  );
 
-  projectsWithoutPluginCache.set(cacheKey, projectConfigurations);
+  projectsWithoutPluginCache.set(cacheKey, projects);
 
-  return projectConfigurations;
+  return projects;
 }
 
 function buildAllWorkspaceFiles(
@@ -279,10 +288,11 @@ export function createProjectConfigurations(
 ): {
   projects: Record<string, ProjectConfiguration>;
   externalNodes: Record<string, ProjectGraphExternalNode>;
+  rootMap: Record<string, string>;
 } {
   performance.mark('build-project-configs:start');
 
-  const { projects, externalNodes } =
+  const { projects, externalNodes, rootMap } =
     buildProjectsConfigurationsFromProjectPathsAndPlugins(
       nxJson,
       configFiles,
@@ -302,6 +312,7 @@ export function createProjectConfigurations(
   return {
     projects: projectConfigurations,
     externalNodes,
+    rootMap,
   };
 }
 

--- a/packages/nx/src/utils/workspace-context.ts
+++ b/packages/nx/src/utils/workspace-context.ts
@@ -1,4 +1,4 @@
-import type { ConfigurationParserResult, WorkspaceContext } from '../native';
+import type { WorkspaceContext } from '../native';
 import { performance } from 'perf_hooks';
 
 let workspaceContext: WorkspaceContext | undefined;
@@ -19,7 +19,7 @@ export function setupWorkspaceContext(workspaceRoot: string) {
 export function getNxWorkspaceFilesFromContext(
   workspaceRoot: string,
   globs: string[],
-  parseConfigurations: (files: string[]) => ConfigurationParserResult
+  parseConfigurations: (files: string[]) => Record<string, string>
 ) {
   ensureContextAvailable(workspaceRoot);
   return workspaceContext.getWorkspaceFiles(globs, parseConfigurations);
@@ -36,7 +36,7 @@ export function globWithWorkspaceContext(
 export function getProjectConfigurationsFromContext(
   workspaceRoot: string,
   globs: string[],
-  parseConfigurations: (files: string[]) => ConfigurationParserResult
+  parseConfigurations: (files: string[]) => Record<string, string>
 ) {
   ensureContextAvailable(workspaceRoot);
   return workspaceContext.getProjectConfigurations(globs, parseConfigurations);


### PR DESCRIPTION
… project configs

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Rust only needs to get a project root map to create the project file map but currently, the whole project configuration map is sent.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Js only sends Rust the project root map which means we don't need to serialize the bulk of data that's in the project configuration map.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
