### PR TITLE
chore(core): nx plugin submission @routineless/nx-aws-cdk

### DIFF
--- a/community/approved-plugins.json
+++ b/community/approved-plugins.json
@@ -40,6 +40,11 @@
     "url": "https://github.com/berenddeboer/nx-plugins/tree/main/packages/nx-aws-cdk"
   },
   {
+    "name": "@routineless/nx-aws-cdk",
+    "description": "Nx plugin to generate and manage aws cdk app and lambdas.",
+    "url": "https://github.com/KozelAnatoliy/routineless/tree/main/packages/nx-aws-cdk"
+  },
+  {
     "name": "@berenddeboer/nx-sst",
     "description": "Nx plugin to generate an SST stack and execute all SST commands.",
     "url": "https://github.com/berenddeboer/nx-plugins/tree/main/packages/nx-sst"


### PR DESCRIPTION
<!-- 
_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

# Community Plugin Submission

Thanks for submitting your Nx Plugin to our community plugins list. Make sure to follow these steps to ensure that your PR is approved in a timely manner.

## Plugin Requirements

Before you submit your plugin to be listed in our registry, it needs to meet the following requirements:
- Run some kind of automated e2e tests in your repository
- Include `@nx/devkit` as a `dependency` in the plugin's `package.json`
- List a `repository.url` in the plugin's `package.json`

i.e.

```
{
  "repository": {
    "type": "git",
    "url": "https://github.com/nrwl/nx.git",
    "directory": "packages/web"
  }
}
```

Note: We reserve the right to remove unmaintained plugins from the registry.  If the plugins become maintained again, they can be resubmitted to the registry.

## Steps to Submit Your Plugin
- Use the following commit message template: `chore(core): nx plugin submission [PLUGIN_NAME]`
- Update the `community/approved-plugins.json` file with a new entry for your plugin that includes `name`, `url`, `description`:

Example:

```json
// community/approved-plugins.json

[{
    "name": "@community/plugin",
    "url": "https://github.com/community/plugin",
    "description": "This plugin provides the following capabilities."
}]
```

Once merged, your plugin will be available when running the `nx list` command, and will also be available in the Plugin Registry on [nx.dev](https://nx.dev/plugin-registry)
-->

# Community Plugin Submission

## @routineless/nx-aws-cdk

This plugin is focused on simplifying aws cdk applications development, testing and deployment. In order to manage infrastructure it uses cdk and cdklocal for local mode. This plugin has preset, cdk-application and lambda generator. It also has executors for cdk application and localstack executor that is used by cdk in local mode. It supports provisioning of all cdk commands and has extended support for watch mode compared to basic cdk. Main advantage is simplicity of configuring multiple environments and automatic detection of local mode and environment setup for it.

Lambda generator simplifies initial lambda lib setup and can add it to existing cdk application if needed. It has preconfigured target to bundle lambda runtime code. In serverless aws application there might be a lot of lambda functions and generating new app becomes handy. 