### PR TITLE
fix(webpack): maintain entry arrays that are accessed from within composePlugins()

### DIFF
--- a/e2e/webpack/src/webpack.test.ts
+++ b/e2e/webpack/src/webpack.test.ts
@@ -135,4 +135,31 @@ module.exports = composePlugins(withNx(), (config) => {
     let output = runCommand(`node dist/${appName}/main.js`);
     expect(output).toMatch(/Hello/);
   }, 500_000);
+
+  // Issue: https://github.com/nrwl/nx/issues/20179
+  it('should allow main/styles entries to be spread within composePlugins() function (#20179)', () => {
+    const appName = uniq('app');
+    runCLI(`generate @nx/web:app ${appName} --bundler webpack`);
+    updateFile(`apps/${appName}/src/main.ts`, `console.log('Hello');\n`);
+
+    updateFile(
+      `apps/${appName}/webpack.config.js`,
+      `
+        const { composePlugins, withNx, withWeb } = require('@nx/webpack');
+        module.exports = composePlugins(withNx(), withWeb(), (config) => {
+          return {
+            ...config,
+            entry: {
+              main: [...config.entry.main],
+              styles: [...config.entry.styles],
+            }
+          };
+        });
+      `
+    );
+
+    expect(() => {
+      runCLI(`build ${appName} --outputHashing none`);
+    }).not.toThrow();
+  });
 });

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
@@ -30,7 +30,15 @@ const mainFields = ['module', 'main'];
 
 export function applyBaseConfig(
   options: NormalizedNxWebpackPluginOptions,
-  config: Partial<WebpackOptionsNormalized | Configuration> = {}
+  config: Partial<WebpackOptionsNormalized | Configuration> = {},
+  {
+    useNormalizedEntry,
+  }: {
+    // webpack.Configuration allows arrays to be set on a single entry
+    // webpack then normalizes them to { import: "..." } objects
+    // This option allows use to preserve existing composePlugins behavior where entry.main is an array.
+    useNormalizedEntry?: boolean;
+  } = {}
 ): void {
   const plugins: WebpackPluginInstance[] = [
     new NxTsconfigPathsWebpackPlugin(options),
@@ -85,7 +93,11 @@ export function applyBaseConfig(
 
   config.entry ??= {};
   entries.forEach((entry) => {
-    config.entry[entry.name] = { import: entry.import };
+    if (useNormalizedEntry) {
+      config.entry[entry.name] = { import: entry.import };
+    } else {
+      config.entry[entry.name] = entry.import;
+    }
   });
 
   if (options.progress) {

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-web-config.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-web-config.ts
@@ -25,7 +25,15 @@ import MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 export function applyWebConfig(
   options: NormalizedNxWebpackPluginOptions,
-  config: Partial<WebpackOptionsNormalized | Configuration> = {}
+  config: Partial<WebpackOptionsNormalized | Configuration> = {},
+  {
+    useNormalizedEntry,
+  }: {
+    // webpack.Configuration allows arrays to be set on a single entry
+    // webpack then normalizes them to { import: "..." } objects
+    // This option allows use to preserve existing composePlugins behavior where entry.main is an array.
+    useNormalizedEntry?: boolean;
+  } = {}
 ): void {
   const plugins: WebpackPluginInstance[] = [];
 
@@ -70,7 +78,7 @@ export function applyWebConfig(
     );
   }
 
-  const entry: { [key: string]: { import: string[] } } = {};
+  const entries: { [key: string]: { import: string[] } } = {};
   const globalStylePaths: string[] = [];
 
   // Determine hashing format.
@@ -97,10 +105,10 @@ export function applyWebConfig(
     normalizeExtraEntryPoints(options.styles, 'styles').forEach((style) => {
       const resolvedPath = path.resolve(options.root, style.input);
       // Add style entry points.
-      if (entry[style.bundleName]) {
-        entry[style.bundleName].import.push(resolvedPath);
+      if (entries[style.bundleName]) {
+        entries[style.bundleName].import.push(resolvedPath);
       } else {
-        entry[style.bundleName] = { import: [resolvedPath] };
+        entries[style.bundleName] = { import: [resolvedPath] };
       }
 
       // Add global css paths.
@@ -315,7 +323,13 @@ export function applyWebConfig(
   if (Array.isArray(config.entry))
     throw new Error('Entry array is not supported. Use an object.');
 
-  config.entry = { ...config.entry, ...entry };
+  Object.entries(entries).forEach(([entryName, entryData]) => {
+    if (useNormalizedEntry) {
+      config.entry[entryName] = { import: entryData.import };
+    } else {
+      config.entry[entryName] = entryData.import;
+    }
+  });
 
   config.optimization = {
     ...config.optimization,

--- a/packages/webpack/src/plugins/nx-webpack-plugin/nx-webpack-plugin.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/nx-webpack-plugin.ts
@@ -39,14 +39,18 @@ export class NxWebpackPlugin {
       deleteOutputDir(this.options.root, this.options.outputPath);
     }
 
-    applyBaseConfig(this.options, compiler.options);
+    applyBaseConfig(this.options, compiler.options, {
+      useNormalizedEntry: true,
+    });
 
     if (compiler.options.target) {
       this.options.target = compiler.options.target;
     }
 
     if (this.options.target === 'web' || this.options.target === 'webworker') {
-      applyWebConfig(this.options, compiler.options);
+      applyWebConfig(this.options, compiler.options, {
+        useNormalizedEntry: true,
+      });
     }
   }
 


### PR DESCRIPTION
Previously, when using `composePlugins()`, the `config.entry` values are arrays such as `{ main: ['main.ts'] }`. However, since refactoring to support `NxWebpackPlugin` (to be documented soon), any customization that uses the value as an iterable will fail (e.g. `{ main: ['webpack/hot/poll?100', ...config.entry.main] }`.

This PR fixes the value to be an array again so we remain backwards compatible with existing usages of `composePlugins()`.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20179
