### PR TITLE
feat(testing): distribute cypress tests for ci

### DIFF
--- a/docs/generated/packages/nx/executors/noop.json
+++ b/docs/generated/packages/nx/executors/noop.json
@@ -9,7 +9,7 @@
     "cli": "nx",
     "outputCapture": "pipe",
     "properties": {},
-    "additionalProperties": false,
+    "additionalProperties": true,
     "presets": []
   },
   "description": "An executor that does nothing",

--- a/packages/cypress/plugin.ts
+++ b/packages/cypress/plugin.ts
@@ -1,1 +1,1 @@
-export { createNodes } from './src/plugins/plugin';
+export { createNodes, createDependencies } from './src/plugins/plugin';

--- a/packages/cypress/src/migrations/update-17-2-0/add-nx-cypress-plugin.spec.ts
+++ b/packages/cypress/src/migrations/update-17-2-0/add-nx-cypress-plugin.spec.ts
@@ -52,7 +52,9 @@ describe('add-nx-cypress-plugin migration', () => {
           },
           ciDevServerTarget: 'my-app:serve-static',
         },
-        e2e: {},
+        e2e: {
+          specPattern: '**/*.cy.ts',
+        },
       })
     );
     updateProjectConfiguration(tree, 'e2e', {
@@ -77,7 +79,13 @@ describe('add-nx-cypress-plugin migration', () => {
 
     await update(tree);
 
-    expect(readProjectConfiguration(tree, 'e2e').targets.e2e).toBeUndefined();
+    expect(readProjectConfiguration(tree, 'e2e').targets.e2e).toEqual({
+      configurations: {
+        ci: {
+          devServerTarget: 'my-app:serve-static',
+        },
+      },
+    });
   });
 
   it('should not the e2e target when it uses a different executor', async () => {
@@ -119,7 +127,9 @@ describe('add-nx-cypress-plugin migration', () => {
           },
           ciDevServerTarget: 'my-app:serve-static',
         },
-        e2e: {},
+        e2e: {
+          specPattern: '**/*.cy.ts',
+        },
       })
     );
     updateProjectConfiguration(tree, 'e2e', {
@@ -148,6 +158,11 @@ describe('add-nx-cypress-plugin migration', () => {
     expect(readProjectConfiguration(tree, 'e2e').targets.e2e).toEqual({
       options: {
         watch: false,
+      },
+      configurations: {
+        ci: {
+          devServerTarget: 'my-app:serve-static',
+        },
       },
     });
   });

--- a/packages/devkit/src/utils/calculate-hash-for-create-nodes.ts
+++ b/packages/devkit/src/utils/calculate-hash-for-create-nodes.ts
@@ -1,0 +1,17 @@
+import type { CreateNodesContext } from 'nx/src/devkit-exports';
+import { requireNx } from '../../nx';
+import { join } from 'path';
+const { hashWithWorkspaceContext, hashArray, hashObject } = requireNx();
+
+export function calculateHashForCreateNodes(
+  projectRoot: string,
+  options: object,
+  context: CreateNodesContext
+): string {
+  return hashArray([
+    hashWithWorkspaceContext(context.workspaceRoot, [
+      join(projectRoot, '**/*'),
+    ]),
+    hashObject(options),
+  ]);
+}

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -15,6 +15,7 @@ export { stripIndent } from './utils/logger';
 export { readModulePackageJson } from './utils/package-json';
 export { splitByColons } from './utils/split-target';
 export { hashObject } from './hasher/file-hasher';
+export { hashWithWorkspaceContext } from './utils/workspace-context';
 export {
   createProjectRootMappingsFromProjectConfigurations,
   findProjectForPath,

--- a/packages/nx/src/executors/noop/schema.json
+++ b/packages/nx/src/executors/noop/schema.json
@@ -6,5 +6,5 @@
   "cli": "nx",
   "outputCapture": "pipe",
   "properties": {},
-  "additionalProperties": false
+  "additionalProperties": true
 }

--- a/packages/nx/src/native/hasher.rs
+++ b/packages/nx/src/native/hasher.rs
@@ -3,11 +3,15 @@ use crate::native::walker::nx_walker;
 use std::collections::HashMap;
 use xxhash_rust::xxh3;
 
+pub fn hash(content: &[u8]) -> String {
+    xxh3::xxh3_64(content).to_string()
+}
+
 #[napi]
 pub fn hash_array(input: Vec<String>) -> String {
     let joined = input.join(",");
     let content = joined.as_bytes();
-    xxh3::xxh3_64(content).to_string()
+    hash(content)
 }
 
 #[napi]
@@ -16,7 +20,7 @@ pub fn hash_file(file: String) -> Option<String> {
         return None;
     };
 
-    Some(xxh3::xxh3_64(&content).to_string())
+    Some(hash(&content))
 }
 
 #[napi]

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -135,7 +135,8 @@ export class WorkspaceContext {
   workspaceRoot: string
   constructor(workspaceRoot: string)
   getWorkspaceFiles(globs: Array<string>, parseConfigurations: (arg0: Array<string>) => Promise<Record<string, string>>): Promise<NxWorkspaceFiles>
-  glob(globs: Array<string>): Array<string>
+  glob(globs: Array<string>, exclude?: Array<string> | undefined | null): Array<string>
+  hashFilesMatchingGlob(globs: Array<string>, exclude?: Array<string> | undefined | null): string
   getProjectConfigurations(globs: Array<string>, parseConfigurations: (arg0: Array<string>) => Promise<Record<string, string>>): Promise<Record<string, string>>
   incrementalUpdate(updatedFiles: Array<string>, deletedFiles: Array<string>): Record<string, string>
   allFileData(): Array<FileData>

--- a/packages/nx/src/native/workspace/config_files.rs
+++ b/packages/nx/src/native/workspace/config_files.rs
@@ -1,40 +1,48 @@
 use crate::native::glob::build_glob_set;
 use crate::native::utils::path::Normalize;
-use std::collections::HashMap;
 use napi::bindgen_prelude::Promise;
+use std::collections::HashMap;
 
-use crate::native::workspace::errors::{InternalWorkspaceErrors, WorkspaceErrors};
 use rayon::prelude::*;
 use std::path::PathBuf;
 
 /// Get workspace config files based on provided globs
 pub(super) fn glob_files(
+    files: &[(PathBuf, String)],
     globs: Vec<String>,
-    files: Option<&[(PathBuf, String)]>,
-) -> napi::Result<Vec<String>, WorkspaceErrors> {
-    let Some(files) = files else {
-        return Ok(Default::default());
-    };
+    exclude: Option<Vec<String>>,
+) -> napi::Result<impl ParallelIterator<Item = &(PathBuf, String)>> {
+    let globs = build_glob_set(&globs)?;
 
-    let globs =
-        build_glob_set(&globs).map_err(|err| InternalWorkspaceErrors::Generic(err.to_string()))?;
-    Ok(files
-        .par_iter()
-        .map(|file| file.0.to_normalized_string())
-        .filter(|path| globs.is_match(path))
-        .collect())
+    let exclude_glob_set = exclude
+        .map(|exclude| build_glob_set(&exclude))
+        .transpose()?;
+
+    Ok(files.par_iter().filter(move |file| {
+        let path = file.0.to_normalized_string();
+        let is_match = globs.is_match(&path);
+
+        if !is_match {
+            return is_match;
+        }
+
+        exclude_glob_set
+            .as_ref()
+            .map(|exclude_glob_set| exclude_glob_set.is_match(&path))
+            .unwrap_or(is_match)
+    }))
 }
 
 /// Get workspace config files based on provided globs
 pub(super) fn get_project_configurations<ConfigurationParser>(
     globs: Vec<String>,
-    files: Option<&[(PathBuf, String)]>,
+    files: &[(PathBuf, String)],
     parse_configurations: ConfigurationParser,
 ) -> napi::Result<Promise<HashMap<String, String>>>
 where
     ConfigurationParser: Fn(Vec<String>) -> napi::Result<Promise<HashMap<String, String>>>,
 {
-    let config_paths = glob_files(globs, files).map_err(anyhow::Error::from)?;
+    let files = glob_files(files, globs, None).map_err(anyhow::Error::from)?;
 
-    parse_configurations(config_paths)
+    parse_configurations(files.map(|file| file.0.to_normalized_string()).collect())
 }

--- a/packages/nx/src/native/workspace/context.rs
+++ b/packages/nx/src/native/workspace/context.rs
@@ -1,21 +1,19 @@
 use crate::native::logger::enable_logger;
 use std::collections::HashMap;
 
+use crate::native::hasher::hash;
 use crate::native::types::FileData;
 use crate::native::utils::path::Normalize;
 use napi::bindgen_prelude::*;
-use parking_lot::lock_api::MutexGuard;
-use parking_lot::{Condvar, Mutex, RawMutex};
+use parking_lot::{Condvar, Mutex};
 use rayon::prelude::*;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::thread;
 use tracing::{trace, warn};
-use xxhash_rust::xxh3;
 
 use crate::native::walker::nx_walker;
-use crate::native::workspace::errors::WorkspaceErrors;
 use crate::native::workspace::{config_files, workspace_files};
 
 #[napi]
@@ -27,7 +25,6 @@ pub struct WorkspaceContext {
 
 type Files = Vec<(PathBuf, String)>;
 struct FilesWorker(Option<Arc<(Mutex<Files>, Condvar)>>);
-
 impl FilesWorker {
     fn gather_files(workspace_root: &Path) -> Self {
         if !workspace_root.exists() {
@@ -49,7 +46,7 @@ impl FilesWorker {
             let files = nx_walker(workspace_root, |rec| {
                 let mut file_hashes: Vec<(PathBuf, String)> = vec![];
                 for (path, content) in rec {
-                    file_hashes.push((path, xxh3::xxh3_64(&content).to_string()));
+                    file_hashes.push((path, hash(&content)));
                 }
                 file_hashes
             });
@@ -65,26 +62,25 @@ impl FilesWorker {
         FilesWorker(Some(files_lock))
     }
 
-    pub fn get_files(&self) -> Option<Vec<(PathBuf, String)>> {
-        let Some(files_sync) = &self.0 else {
-            trace!("there were no files because the workspace root did not exist");
-            return None;
-        };
+    pub fn get_files(&self) -> Vec<(PathBuf, String)> {
+        if let Some(files_sync) = &self.0 {
+            let (files_lock, cvar) = files_sync.deref();
+            trace!("locking files");
+            let mut files = files_lock.lock();
+            let files_len = files.len();
+            if files_len == 0 {
+                trace!("waiting for files");
+                cvar.wait(&mut files);
+            }
 
-        let (files_lock, cvar) = &files_sync.deref();
-        trace!("locking files");
-        let mut files = files_lock.lock();
-        let files_len = files.len();
-        if files_len == 0 {
-            trace!("waiting for files");
-            cvar.wait(&mut files);
+            let cloned_files = files.clone();
+            drop(files);
+
+            trace!("files are available");
+            cloned_files
+        } else {
+            vec![]
         }
-
-        let cloned_files = files.clone();
-        drop(files);
-
-        trace!("files are available");
-        Some(cloned_files)
     }
 
     pub fn update_files(
@@ -114,7 +110,7 @@ impl FilesWorker {
                     trace!("could not read file: ?full_path");
                     return None;
                 };
-                Some((path.to_string(), xxh3::xxh3_64(&content).to_string()))
+                Some((path.to_string(), hash(&content)))
             })
             .collect();
 
@@ -158,18 +154,39 @@ impl WorkspaceContext {
     where
         ConfigurationParser: Fn(Vec<String>) -> napi::Result<Promise<HashMap<String, String>>>,
     {
-        workspace_files::get_files(
-            env,
-            globs,
-            parse_configurations,
-            self.files_worker.get_files().as_deref(),
-        )
-        .map_err(anyhow::Error::from)
+        let files = self.files_worker.get_files();
+        workspace_files::get_files(env, globs, parse_configurations, &files)
+            .map_err(anyhow::Error::from)
     }
 
     #[napi]
-    pub fn glob(&self, globs: Vec<String>) -> napi::Result<Vec<String>, WorkspaceErrors> {
-        config_files::glob_files(globs, self.files_worker.get_files().as_deref())
+    pub fn glob(
+        &self,
+        globs: Vec<String>,
+        exclude: Option<Vec<String>>,
+    ) -> napi::Result<Vec<String>> {
+        let files = self.files_worker.get_files();
+
+        let globbed_files = config_files::glob_files(&files, globs, exclude)?;
+        Ok(globbed_files
+            .map(|file| file.0.to_normalized_string())
+            .collect())
+    }
+
+    #[napi]
+    pub fn hash_files_matching_glob(
+        &self,
+        globs: Vec<String>,
+        exclude: Option<Vec<String>>,
+    ) -> napi::Result<String> {
+        let files = self.files_worker.get_files();
+        let globbed_files = config_files::glob_files(&files, globs, exclude)?;
+        Ok(hash(
+            &globbed_files
+                .map(|file| file.1.as_bytes())
+                .collect::<Vec<_>>()
+                .concat(),
+        ))
     }
 
     #[napi(ts_return_type = "Promise<Record<string, string>>")]
@@ -182,11 +199,11 @@ impl WorkspaceContext {
     where
         ConfigurationParser: Fn(Vec<String>) -> napi::Result<Promise<HashMap<String, String>>>,
     {
-        let promise = config_files::get_project_configurations(
-            globs,
-            self.files_worker.get_files().as_deref(),
-            parse_configurations,
-        )?;
+        let files = self.files_worker.get_files();
+
+        let promise =
+            config_files::get_project_configurations(globs, &files, parse_configurations)?;
+
         env.spawn_future(async move {
             let result = promise.await?;
             Ok(result)
@@ -205,16 +222,14 @@ impl WorkspaceContext {
 
     #[napi]
     pub fn all_file_data(&self) -> Vec<FileData> {
-        self.files_worker
-            .get_files()
-            .map_or_else(Vec::new, |files| {
-                files
-                    .iter()
-                    .map(|(path, content)| FileData {
-                        file: path.to_normalized_string(),
-                        hash: content.clone(),
-                    })
-                    .collect()
+        let files = self.files_worker.get_files();
+
+        files
+            .iter()
+            .map(|(path, content)| FileData {
+                file: path.to_normalized_string(),
+                hash: content.clone(),
             })
+            .collect()
     }
 }

--- a/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
+++ b/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
@@ -274,8 +274,6 @@ export async function createProjectConfigurations(
       workspaceRoot
     );
 
-  let projectConfigurations = projects;
-
   performance.mark('build-project-configs:end');
   performance.measure(
     'build-project-configs',
@@ -284,7 +282,7 @@ export async function createProjectConfigurations(
   );
 
   return {
-    projects: projectConfigurations,
+    projects,
     externalNodes,
     rootMap,
   };

--- a/packages/nx/src/utils/workspace-context.ts
+++ b/packages/nx/src/utils/workspace-context.ts
@@ -27,10 +27,20 @@ export function getNxWorkspaceFilesFromContext(
 
 export function globWithWorkspaceContext(
   workspaceRoot: string,
-  globs: string[]
+  globs: string[],
+  exclude?: string[]
 ) {
   ensureContextAvailable(workspaceRoot);
-  return workspaceContext.glob(globs);
+  return workspaceContext.glob(globs, exclude);
+}
+
+export function hashWithWorkspaceContext(
+  workspaceRoot: string,
+  globs: string[],
+  exclude?: string[]
+) {
+  ensureContextAvailable(workspaceRoot);
+  return workspaceContext.hashFilesMatchingGlob(globs, exclude);
 }
 
 export function getProjectConfigurationsFromContext(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Cypress projects are run as a suite in CI.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Cypress tasks are configured for each each spec file and then linked by a parent task. The task to run is the parent task, called `e2e-ci` by default.
![graph (12)](https://github.com/nrwl/nx/assets/8104246/eaa02073-134a-4002-9dcd-4529146e4a6a)

What this allows Nx to do is run these tasks in parallel distributed across multiple machines via DTE.

Ultimately, this means that cypress suites are run across multiple machines in less time AND each spec file is cached independently.

This PR also contains other changes too

Cypress changes

1. A cache is added to the node construction so that it doesn't need to run unless something in the project changes. This isn't bullet proof but should help a lot for the performance issues. This might need to be tweaked further after testing.

Devkit

1. There is a new internal function in devkit which allows other plugins to easily hash a project's files so that they too can cache their target construction.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
