### PR TITLE
fix(testing): target defaults migration should not throw if workspace contains inferred projects

### DIFF
--- a/packages/jest/src/migrations/update-17-1-0/move-options-to-target-defaults.spec.ts
+++ b/packages/jest/src/migrations/update-17-1-0/move-options-to-target-defaults.spec.ts
@@ -559,4 +559,46 @@ describe('move-options-to-target-defaults migration', () => {
       },
     });
   });
+
+  it("should't error if a project is present in the graph but not using project.json", async () => {
+    projectGraph.nodes['csproj'] = {
+      name: 'csproj',
+      type: 'lib',
+      data: {
+        root: 'csproj',
+        targets: {
+          build: {
+            command: 'echo HELLO',
+          },
+        },
+      },
+    };
+    addProjectConfiguration(tree, 'proj1', {
+      root: 'proj1',
+      targets: {
+        test: {
+          executor: '@nx/jest:jest',
+          options: {
+            jestConfig: 'jest.config.js',
+            passWithNoTests: true,
+          },
+          configurations: {
+            ci: {
+              ci: true,
+              codeCoverage: true,
+            },
+          },
+        },
+      },
+    });
+    updateNxJson(tree, {
+      targetDefaults: {
+        build: {
+          inputs: ['default', '^production'],
+        },
+      },
+    });
+    const promise = update(tree);
+    await expect(promise).resolves.not.toThrow();
+  });
 });

--- a/packages/jest/src/migrations/update-17-1-0/move-options-to-target-defaults.ts
+++ b/packages/jest/src/migrations/update-17-1-0/move-options-to-target-defaults.ts
@@ -174,7 +174,7 @@ function isTargetDefaultUsed(
           targetName,
           targetDefaults,
           // It might seem like we should use the graph here too but we don't want to pass an executor which was processed in the graph
-          projectMap.get(p.name).targets?.[targetName]?.executor
+          projectMap.get(p.name)?.targets?.[targetName]?.executor
         ) === targetDefault
       ) {
         return true;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The jest target defaults migration compares projects in the graph with projects in the tree. There are cases where projects will be present in the graph, but not the tree, and in these cases the migration throws.

## Expected Behavior
The migration continues successfully if some projects are not in the tree.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
