### PR TITLE
feat(core): added the ability to split command property into an array in nx:run-commands executor

### DIFF
--- a/docs/generated/packages/nx/executors/run-commands.json
+++ b/docs/generated/packages/nx/executors/run-commands.json
@@ -76,6 +76,18 @@
         "x-priority": "important"
       },
       "command": {
+        "oneOf": [
+          {
+            "type": "array",
+            "description": "Command to run in child process, but divided into parts.",
+            "items": { "type": "string" },
+            "x-priority": "important"
+          },
+          {
+            "type": "string",
+            "description": "Command to run in child process."
+          }
+        ],
         "type": "string",
         "description": "Command to run in child process.",
         "x-priority": "important"

--- a/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
@@ -234,6 +234,42 @@ describe('Run Commands', () => {
     expect(readFile(f)).toEqual('1212');
   });
 
+  it('should run the command, but divided into paths', async () => {
+    const f = fileSync().name;
+    const result = await runCommands(
+      {
+        command: [`echo 1 >> ${f}`, '&&', `echo 2 >> ${f}`],
+        parallel: false,
+
+        __unparsed__: [],
+      },
+      context
+    );
+    expect(result).toEqual(expect.objectContaining({ success: true }));
+    expect(readFile(f)).toEqual('12');
+  });
+
+  it('should run the command, but divided into several paths', async () => {
+    const f = fileSync().name;
+    const result = await runCommands(
+      {
+        command: [
+          `echo 1 >> ${f}  `,
+          `&&`,
+          `echo 2 >> ${f}`,
+          ';',
+          `echo 34 >> ${f}`,
+        ],
+        parallel: false,
+
+        __unparsed__: [],
+      },
+      context
+    );
+    expect(result).toEqual(expect.objectContaining({ success: true }));
+    expect(readFile(f)).toEqual('1234');
+  });
+
   it('should run commands in parallel', async () => {
     const f = fileSync().name;
     const result = await runCommands(

--- a/packages/nx/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.ts
@@ -42,7 +42,7 @@ export type Json = {
 };
 
 export interface RunCommandsOptions extends Json {
-  command?: string;
+  command?: string | string[];
   commands?: (
     | {
         command: string;
@@ -237,7 +237,13 @@ function normalizeOptions(
   }
 
   if (options.command) {
-    options.commands = [{ command: options.command }];
+    options.commands = [
+      {
+        command: Array.isArray(options.command)
+          ? options.command.join(' ')
+          : options.command,
+      },
+    ];
     options.parallel = options.readyWhenStatus?.length > 0;
   } else {
     options.commands = options.commands.map((c) =>

--- a/packages/nx/src/executors/run-commands/schema.json
+++ b/packages/nx/src/executors/run-commands/schema.json
@@ -84,6 +84,20 @@
       "x-priority": "important"
     },
     "command": {
+      "oneOf": [
+        {
+          "type": "array",
+          "description": "Command to run in child process, but divided into parts.",
+          "items": {
+            "type": "string"
+          },
+          "x-priority": "important"
+        },
+        {
+          "type": "string",
+          "description": "Command to run in child process."
+        }
+      ],
       "type": "string",
       "description": "Command to run in child process.",
       "x-priority": "important"


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

In projects, you can often find teams that are too long. Example here:

```json
 "run:dev": {
    "executor": "nx:run-commands",
    "options": {
      "command": "docker compose -f .docker/compose/docker-compose.services.yml -f .docker/compose/docker-compose.dev.yml --project-directory . up -d"
    },
    "dependsOn": ["update:dev"]
  }
```
## Expected Behavior

Implemented splitting of the 'command' parameter, added the ability to pass it as an array to avoid such *huge* strings:

```json
"run:dev": {
    "executor": "nx:run-commands",
    "options": {
      "command": [
	"docker compose -f",
        ".docker/compose/docker-compose.services.yml -f",
	".docker/compose/docker-compose.dev.yml",
	"--project-directory . up -d"
      ]
    },
    "dependsOn": ["update:dev"]
  },
```
Added a couple of tests and changed schema.json to 'run-commands' executor.
