### PR TITLE
fix(angular): update jest-preset-angular fixing an issue with component single string styles and styleUrl props

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -1489,6 +1489,22 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "17.1.2-jest": {
+      "version": "17.1.2-beta.0",
+      "requires": {
+        "@angular-devkit/build-angular": ">=13.0.0 <18.0.0",
+        "@angular/compiler-cli": ">=13.0.0 <18.0.0",
+        "@angular/core": ">=13.0.0 <18.0.0",
+        "@angular/platform-browser-dynamic": ">=13.0.0 <18.0.0",
+        "jest": "^29.0.0"
+      },
+      "packages": {
+        "jest-preset-angular": {
+          "version": "~13.1.4",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/angular/src/utils/versions.ts
+++ b/packages/angular/src/utils/versions.ts
@@ -24,7 +24,7 @@ export const postcssUrlVersion = '~10.1.3';
 export const autoprefixerVersion = '^10.4.0';
 export const tsNodeVersion = '10.9.1';
 
-export const jestPresetAngularVersion = '~13.1.3';
+export const jestPresetAngularVersion = '~13.1.4';
 export const typesNodeVersion = '16.11.7';
 export const jasmineMarblesVersion = '^0.9.2';
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Workspaces using version `13.1.3` of `jest-preset-angular` will throw an error when running tests over components using a single string for the `styles` property or the new `styleUrl` property (Angular v17).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Testing a component using a single string for the `styles` property or the new `styleUrl` property should work correctly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
