### PR TITLE
fix(angular): fix misc issues with migration replacing the nguniversal usages

### DIFF
--- a/packages/angular/src/migrations/update-17-1-0/replace-nguniversal-engines.spec.ts
+++ b/packages/angular/src/migrations/update-17-1-0/replace-nguniversal-engines.spec.ts
@@ -60,7 +60,9 @@ describe('replace-nguniversal-engines migration', () => {
     };
     projectGraph = {
       dependencies: {
-        app1: [{ source: 'app1', target: 'npm:@angular/core', type: 'static' }],
+        app1: [
+          { source: 'app1', target: 'npm:@nguniversal/common', type: 'static' },
+        ],
       },
       nodes: { app1: { data: project, name: 'app1', type: 'app' } },
     };
@@ -214,6 +216,20 @@ if (moduleFilename === __filename || moduleFilename.includes('iisnode')) {
     expect(tree.exists('src/express.tokens.ts')).toBe(true);
   });
 
+  it('should import tokens file correctly in nested paths', async () => {
+    const filePath = 'src/nested/folder/home/home.component.ts';
+    tree.write(
+      filePath,
+      `import { RESPONSE } from '@nguniversal/express-engine/tokens';`
+    );
+
+    await migration(tree);
+
+    expect(tree.read(filePath, 'utf-8')).toContain(
+      `import { RESPONSE } from '../../../express.tokens';`
+    );
+  });
+
   it('should not create tokens file when "@nguniversal/express-engine/tokens" is not used', async () => {
     await migration(tree);
 
@@ -223,5 +239,14 @@ if (moduleFilename === __filename || moduleFilename.includes('iisnode')) {
       `import { REQUEST, RESPONSE } from './src/express.tokens';`
     );
     expect(tree.exists('src/express.tokens.ts')).toBe(false);
+  });
+
+  it('should not process non-TypeScript files', async () => {
+    const content = `import { ngExpressEngine } from '@nguniversal/express-engine';`;
+    tree.write('src/foo.txt', content);
+
+    await migration(tree);
+
+    expect(tree.read('src/foo.txt', 'utf-8')).toBe(content);
   });
 });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `replace-nguniversal-engines` migration:

- Doesn't process targets using `@nx/angular:webpack-server`
- Process and update non-TypeScript files
- Generates wrong import paths for nested files

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `replace-nguniversal-engines` migration should:

- Process targets using `@nx/angular:webpack-server`
- Only process TypeScript files
- Generate the correct import paths for all files

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20162 
