### PR TITLE
feat(angular): support application builder for cypress component testing

### DIFF
--- a/packages/angular/plugins/component-testing.ts
+++ b/packages/angular/plugins/component-testing.ts
@@ -73,7 +73,7 @@ ${e.stack ? e.stack : e}`
   const buildTarget = getBuildableTarget(ctContext);
 
   if (!buildTarget.project && !graph.nodes?.[buildTarget.project]?.data) {
-    throw new Error(stripIndents`Unable to find project configuration for build target. 
+    throw new Error(stripIndents`Unable to find project configuration for build target.
     Project Name? ${buildTarget.project}
     Has project config? ${!!graph.nodes?.[buildTarget.project]?.data}`);
   }
@@ -295,8 +295,8 @@ Note: this may fail, setting the correct 'sourceRoot' for ${buildContext.project
 }
 
 function withSchemaDefaults(options: any): BrowserBuilderSchema {
-  if (!options.main) {
-    throw new Error('Missing executor options "main"');
+  if (!options.main && !options.browser) {
+    throw new Error('Missing executor options "main" and "browser"');
   }
   if (!options.index) {
     throw new Error('Missing executor options "index"');
@@ -322,6 +322,7 @@ function withSchemaDefaults(options: any): BrowserBuilderSchema {
   options.outputHashing ??= 'none';
   options.progress ??= true;
   options.scripts ??= [];
+  options.main = options.main ??= options.browser;
 
   return options;
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Using the Application Builder as the executor the "component-test" target fails using cypress because the `main` property in the `options`-object was renamed to `browser`.

## Expected Behavior
Use the `browser` property when the `main` property is missing.

See: https://angular.io/guide/esbuild#using-the-application-builder