### PR TITLE
fix(linter): fix runtime error caused by incorrect chalk import

### DIFF
--- a/packages/eslint-plugin/src/utils/project-graph-utils.ts
+++ b/packages/eslint-plugin/src/utils/project-graph-utils.ts
@@ -4,7 +4,7 @@ import {
   readCachedProjectGraph,
 } from '@nx/devkit';
 import { isTerminalRun } from './runtime-lint-utils';
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 import {
   createProjectRootMappings,
   ProjectRootMappings,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When the project graph is not available in CI an error is thrown:

```
TypeError: Error while loading rule '@nx/enforce-module-boundaries': Cannot read properties of undefined (reading 'keyword')
Occurred while linting /home/runner/work/clickup_frontend/clickup_frontend/libs/rich-editor/content-assistant/src/lib/generate-by-prompt-template/generate-by-prompt-template-state.ts
    at ensureGlobalProjectGraph (/home/runner/work/clickup_frontend/clickup_frontend/node_modules/.pnpm/@nx+eslint-plugin@17.1.1_@types+node@18.11.9_@typescript-eslint+parser@6.10.0_eslint-config-p_3dqjsp2nk5zwpqpottk4p3quji/node_modules/@nx/eslint-plugin/src/utils/project-graph-utils.js:35:51)
    at readProjectGraph (/home/runner/work/clickup_frontend/clickup_frontend/node_modules/.pnpm/@nx+eslint-plugin@17.1.1_@types+node@18.11.9_@typescript-eslint+parser@6.10.0_eslint-config-p_3dqjsp2nk5zwpqpottk4p3quji/node_modules/@nx/eslint-plugin/src/utils/project-graph-utils.js:46:5)
    at create (/home/runner/work/clickup_frontend/clickup_frontend/node_modules/.pnpm/@nx+eslint-plugin@17.1.1_@types+node@18.11.9_@typescript-eslint+parser@6.10.0_eslint-config-p_3dqjsp2nk5zwpqpottk4p3quji/node_modules/@nx/eslint-plugin/src/rules/enforce-module-boundaries.js:133:1[37](https://github.com/time-loop/clickup_frontend/actions/runs/6852408090/job/18630875776?pr=40850#step:11:38))
    at Object.create (/home/runner/work/clickup_frontend/clickup_frontend/node_modules/.pnpm/@typescript-eslint+utils@6.10.0_eslint@8.46.0_typescript@5.1.3/node_modules/@typescript-eslint/utils/src/eslint-utils/RuleCreator.ts:102:14)
    at createRuleListeners (/home/runner/work/clickup_frontend/clickup_frontend/node_modules/.pnpm/eslint@8.46.0/node_modules/eslint/lib/linter/linter.js:870:21)
    at /home/runner/work/clickup_frontend/clickup_frontend/node_modules/.pnpm/eslint@8.46.0/node_modules/eslint/lib/linter/linter.js:10[40](https://github.com/time-loop/clickup_frontend/actions/runs/6852408090/job/18630875776?pr=40850#step:11:41):110
    at Array.forEach (<anonymous>)
    at runRules (/home/runner/work/clickup_frontend/clickup_frontend/node_modules/.pnpm/eslint@8.46.0/node_modules/eslint/lib/linter/linter.js:977:34)
    at Linter._verifyWithoutProcessors (/home/runner/work/clickup_frontend/clickup_frontend/node_modules/.pnpm/eslint@8.[46](https://github.com/time-loop/clickup_frontend/actions/runs/6852408090/job/18630875776?pr=40850#step:11:47).0/node_modules/eslint/lib/linter/linter.js:1330:31)
    at Linter._verifyWithoutProcessors (/home/runner/work/clickup_frontend/clickup_frontend/node_modules/.pnpm/eslint-plugin-eslint-comments@3.2.0_eslint@8.46.0/node_modules/eslint-plugin-eslint-comments/lib/utils/patch.js:166:36)
```

This was caused by https://github.com/nrwl/nx/pull/20004 which changed the semantics of how the wildcard import of `chalk` behaves to behave like native ESM interop - as chalk v4 is commonjs then it can only be imported as the default import and not as a wildcard.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

No error is thrown any more

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

I could not find any related issues.
