### PR TITLE
fix(angular): serve host app with --skipRemotes='*'

### DIFF
--- a/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -56,6 +56,7 @@ function buildStaticRemotes(
       [
         'run-many',
         `--target=build`,
+        `--all=false`,
         `--projects=${remotes.staticRemotes.join(',')}`,
         ...(context.target.configuration
           ? [`--configuration=${context.target.configuration}`]


### PR DESCRIPTION
set `--all=false` for static remotes building in `module-federation-dev-server`

## Current Behavior
When I run command `nx serve web-app --skipRemotes='*'` serve failed because I don't have remotes to build. `run-many` exit with code not 0

## Expected Behavior
When I run command `nx serve web-app --skipRemotes='*'` no remotes builded and only host served