### PR TITLE
fix(react): import SupportedStyles type from correct path

### DIFF
--- a/packages/react/src/generators/host/schema.d.ts
+++ b/packages/react/src/generators/host/schema.d.ts
@@ -1,6 +1,6 @@
 import type { ProjectNameAndRootFormat } from '@nx/devkit/src/generators/project-name-and-root-utils';
 import type { Linter } from '@nx/eslint';
-import type { SupportedStyles } from '../../../typings';
+import type { SupportedStyles } from '../../../typings/style';
 
 export interface Schema {
   classComponent?: boolean;

--- a/packages/react/src/generators/remote/schema.d.ts
+++ b/packages/react/src/generators/remote/schema.d.ts
@@ -1,6 +1,6 @@
 import type { ProjectNameAndRootFormat } from '@nx/devkit/src/generators/project-name-and-root-utils';
 import type { Linter } from '@nx/eslint';
-import type { SupportedStyles } from '../../../typings';
+import type { SupportedStyles } from '../../../typings/style';
 import type { NormalizedSchema as ApplicationNormalizedSchema } from '../application/schema';
 
 export interface Schema {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Having incorrect import path for `SupportedStyles` type. There's no `packages/react/typings/index.d.ts` barrel file that would reexport style types.

## Expected Behavior
tsc doesn't throw error when typechecking schema