### PR TITLE
fix(core): better support for expanded glob pattern

### DIFF
--- a/packages/nx/src/native/glob/glob_group.rs
+++ b/packages/nx/src/native/glob/glob_group.rs
@@ -13,7 +13,10 @@ pub enum GlobGroup<'a> {
     ExactOne(Cow<'a, str>),
     // !(a|b|c)
     Negated(Cow<'a, str>),
+    // !(a|b|c).js
     NegatedFileName(Cow<'a, str>),
+    // !(a|b|c)*
+    NegatedWildcard(Cow<'a, str>),
     NonSpecialGroup(Cow<'a, str>),
     NonSpecial(Cow<'a, str>),
 }
@@ -38,6 +41,13 @@ impl<'a> Display for GlobGroup<'a> {
                     write!(f, "{{{}}}.", s)
                 } else {
                     write!(f, "{}.", s)
+                }
+            }
+            GlobGroup::NegatedWildcard(s) => {
+                if s.contains(',') {
+                    write!(f, "{{{}}}*", s)
+                } else {
+                    write!(f, "{}*", s)
                 }
             }
             GlobGroup::NonSpecial(s) => write!(f, "{}", s),

--- a/packages/nx/src/native/glob/glob_transform.rs
+++ b/packages/nx/src/native/glob/glob_transform.rs
@@ -88,6 +88,11 @@ fn build_segment(
                 let on_group = build_segment(&built_glob, &group[1..], is_last_segment, true);
                 off_group.into_iter().chain(on_group).collect::<Vec<_>>()
             }
+            GlobGroup::NegatedWildcard(_) => {
+                let off_group = build_segment("*", &group[1..], is_last_segment, is_negative);
+                let on_group = build_segment(&built_glob, &group[1..], is_last_segment, true);
+                off_group.into_iter().chain(on_group).collect::<Vec<_>>()
+            }
             GlobGroup::OneOrMore(_)
             | GlobGroup::ExactOne(_)
             | GlobGroup::NonSpecial(_)
@@ -151,6 +156,15 @@ mod test {
     fn convert_globs_single_negative() {
         let negative_single_dir = convert_glob("packages/!(package-a)*").unwrap();
         assert_eq!(negative_single_dir, ["!packages/package-a*", "packages/*"]);
+    }
+
+    #[test]
+    fn convert_globs_single_negative_wildcard_directory() {
+        let negative_single_dir = convert_glob("packages/!(package-a)*/package.json").unwrap();
+        assert_eq!(
+            negative_single_dir,
+            ["!packages/package-a*/", "packages/*/package.json"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Glob that are in the brace expansion pattern: 
examples:     
* `{yarn.lock,package-lock.json}`
* `{packages/!(package-a)*/package.json,packages/*/package.json}`

We don't properly expand them to their own separate globs. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Expanded glob patterns are treated as separated globs. If a pattern contains `{}` within a segment we do not expand them. Only when `{}` wraps the WHOLE pattern.

Expanded:
* `{yarn.lock,package-lock.json}`
* `{packages/!(package-a)*/package.json,packages/*/package.json}`

Not expanded:
* `package/file.{js,ts}`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
