### PR TITLE
feat(web): add verbose logging to waitForPortOpen function

### DIFF
--- a/packages/web/src/utils/wait-for-port-open.ts
+++ b/packages/web/src/utils/wait-for-port-open.ts
@@ -1,10 +1,12 @@
+import { logger } from '@nx/devkit';
 import * as net from 'net';
 
 export function waitForPortOpen(
   port: number,
   options: { host?: string; retries?: number; retryDelay?: number } = {}
 ): Promise<void> {
-  const allowedErrorCodes = ['ECONNREFUSED', 'ECONNRESET'];
+  const host = options.host ?? '127.0.0.1';
+  const allowedErrorCodes = ['ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT'];
 
   return new Promise((resolve, reject) => {
     const checkPort = (retries = options.retries ?? 120) => {
@@ -23,6 +25,11 @@ export function waitForPortOpen(
 
       client.once('error', (err) => {
         if (retries === 0 || !allowedErrorCodes.includes(err['code'])) {
+          if (process.env['NX_VERBOSE_LOGGING'] === 'true') {
+            logger.info(
+              `Error connecting on ${host}:${port}: ${err['code'] || err}`
+            );
+          }
           cleanupClient();
           reject(err);
         } else {
@@ -32,7 +39,10 @@ export function waitForPortOpen(
 
       // Node will use IPv6 if it is available, but this can cause issues if the server is only listening on IPv4.
       // Hard-coding to look on 127.0.0.1 to avoid using the IPv6 loopback address "::1".
-      client.connect({ port, host: options.host ?? '127.0.0.1' });
+      if (process.env['NX_VERBOSE_LOGGING'] === 'true') {
+        logger.info(`Connecting on ${host}:${port}`);
+      }
+      client.connect({ port, host });
     };
 
     checkPort();


### PR DESCRIPTION
When we call `waitForPortOpen` in our executors (e.g. React/Angular module federation executors), the timeout could be triggered by an error code other than what we expect (`ECONNREFUSED`, `ECONNRESET`). This change allows easier debugging when the timeout occurs unexpectedly.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
