### PR TITLE
chore(repo): stop agents after macos

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,6 +161,10 @@ jobs:
           command: |
             pnpm nx affected -t e2e-macos --parallel=1 --base=$NX_BASE --head=$NX_HEAD
           no_output_timeout: 45m
+      - run:
+          name: Close CI group
+          command: |
+            pnpm nx-cloud stop-all-agents
 
 # -------------------------
 #        WORKFLOWS(JOBS)

--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -7,7 +7,7 @@ launch-templates:
       GIT_COMMITTER_EMAIL: test@test.com
       GIT_COMMITTER_NAME: Test
       NX_E2E_CI_CACHE_KEY: e2e-circleci-linux
-      NX_VERBOSE_LOGGING: 'false'
+      NX_VERBOSE_LOGGING: 'true'
       NX_PERF_LOGGING: 'false'
       NX_NATIVE_LOGGING: 'false'
       SELECTED_PM: 'pnpm'


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

No verbose logging on agents making it hard to debug stuff.

Macos doesn't stop agents which causes jobs to remain in progress

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

verbose logging on agents making it hard to debug stuff.

Macos stops agents so jobs do not remain in progress

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
