### PR TITLE
docs(nx-dev): fix incorrect link to medium instead of dev.to

### DIFF
--- a/nx-dev/nx-dev/pages/blog/index.tsx
+++ b/nx-dev/nx-dev/pages/blog/index.tsx
@@ -106,7 +106,7 @@ export default function Blog(): JSX.Element {
                     We're on Dev.to, too!
                   </h4>
                   <a
-                    href="https://blog.nrwl.io"
+                    href="https://dev.to/nx"
                     rel="noreferrer"
                     target="_blank"
                     title="Nrwl Blog"


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
link for dev.to was to medium. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
instead should link to dev.to where content isn't paywalled bc medium is being silly

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
