### PR TITLE
fix(angular): display template error when cache is disabled in ng-packagr executors

### DIFF
--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ngc/compile-source-files.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ngc/compile-source-files.ts
@@ -100,9 +100,10 @@ export async function compileSourceFiles(
       );
     cache.oldNgtscProgram = angularProgram;
   } else {
-    // When not in watch mode, the startup cost of the incremental analysis can be avoided by
-    // using an abstract builder that only wraps a TypeScript program.
-    builder = ts.createAbstractBuilder(typeScriptProgram, tsCompilerHost);
+    builder = ts.createEmitAndSemanticDiagnosticsBuilderProgram(
+      typeScriptProgram,
+      tsCompilerHost
+    );
   }
 
   // Update semantic diagnostics cache

--- a/packages/angular/src/executors/package/ng-packagr-adjustments/ngc/compile-source-files.ts
+++ b/packages/angular/src/executors/package/ng-packagr-adjustments/ngc/compile-source-files.ts
@@ -113,9 +113,10 @@ export async function compileSourceFiles(
       );
     cache.oldNgtscProgram = angularProgram;
   } else {
-    // When not in watch mode, the startup cost of the incremental analysis can be avoided by
-    // using an abstract builder that only wraps a TypeScript program.
-    builder = ts.createAbstractBuilder(typeScriptProgram, tsCompilerHost);
+    builder = ts.createEmitAndSemanticDiagnosticsBuilderProgram(
+      typeScriptProgram,
+      tsCompilerHost
+    );
   }
 
   // Update semantic diagnostics cache


### PR DESCRIPTION
https://github.com/ng-packagr/ng-packagr/commit/0698929aa8583204d4b6a203824c0af27770f0eb

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
