### PR TITLE
fix(module-federation): single file server should use project name for directory

### DIFF
--- a/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -109,7 +109,10 @@ function startStaticRemotesFileServer(
 
     if (!commonOutputDirectory) {
       commonOutputDirectory = directoryOfOutputPath;
-    } else if (commonOutputDirectory !== directoryOfOutputPath) {
+    } else if (
+      commonOutputDirectory !== directoryOfOutputPath ||
+      !outputPath.endsWith(app)
+    ) {
       shouldMoveToCommonLocation = true;
     }
   }
@@ -119,18 +122,10 @@ function startStaticRemotesFileServer(
     for (const app of remotes.staticRemotes) {
       const outputPath =
         projectGraph.nodes[app].data.targets['build'].options.outputPath;
-      const outputPathParts = outputPath.split('/');
-      cpSync(
-        outputPath,
-        join(
-          commonOutputDirectory,
-          outputPathParts[outputPathParts.length - 1]
-        ),
-        {
-          force: true,
-          recursive: true,
-        }
-      );
+      cpSync(outputPath, join(commonOutputDirectory, app), {
+        force: true,
+        recursive: true,
+      });
     }
   }
 

--- a/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -59,7 +59,10 @@ function startStaticRemotesFileServer(
 
     if (!commonOutputDirectory) {
       commonOutputDirectory = directoryOfOutputPath;
-    } else if (commonOutputDirectory !== directoryOfOutputPath) {
+    } else if (
+      commonOutputDirectory !== directoryOfOutputPath ||
+      !outputPath.endsWith(app)
+    ) {
       shouldMoveToCommonLocation = true;
     }
   }
@@ -70,7 +73,7 @@ function startStaticRemotesFileServer(
       const outputPath =
         context.projectGraph.nodes[app].data.targets['build'].options
           .outputPath;
-      cpSync(outputPath, commonOutputDirectory, {
+      cpSync(outputPath, join(commonOutputDirectory, app), {
         force: true,
         recursive: true,
       });


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
If a remote has a project name that !== the directory it is output to, single file server will serve the files from a location that the host is not expecting


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
If the remote has a different project name to the directory it is output from, the output should be placed in a correct folder and served correctly such that the host can find it.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
