### PR TITLE
fix(webpack): set isolatedConfig to true by default

### DIFF
--- a/docs/generated/packages/webpack/executors/webpack.json
+++ b/docs/generated/packages/webpack/executors/webpack.json
@@ -334,7 +334,7 @@
       "isolatedConfig": {
         "type": "boolean",
         "description": "Do not apply Nx webpack plugins automatically. Plugins need to be applied in the project's webpack.config.js file (e.g. withNx, withReact, etc.).",
-        "default": false
+        "default": true
       },
       "extractLicenses": {
         "type": "boolean",

--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -42,7 +42,7 @@ describe('app', () => {
 
       expect(projects.get('my-app').root).toEqual('my-app');
       expect(projects.get('my-app-e2e').root).toEqual('my-app-e2e');
-    });
+    }, 60_000);
 
     it('should add vite types to tsconfigs', async () => {
       await applicationGenerator(appTree, {
@@ -388,7 +388,6 @@ describe('app', () => {
       scripts: [],
       styles: ['my-app/src/styles.css'],
       tsConfig: 'my-app/tsconfig.app.json',
-      isolatedConfig: true,
       webpackConfig: 'my-app/webpack.config.js',
     });
     expect(targetConfig.build.configurations.production).toEqual({

--- a/packages/react/src/generators/application/lib/add-project.ts
+++ b/packages/react/src/generators/application/lib/add-project.ts
@@ -67,7 +67,6 @@ function createBuildTarget(options: NormalizedSchema): TargetConfiguration {
               ),
             ],
       scripts: [],
-      isolatedConfig: true,
       webpackConfig: joinPathFragments(
         options.appProjectRoot,
         'webpack.config.js'

--- a/packages/web/src/generators/application/application.spec.ts
+++ b/packages/web/src/generators/application/application.spec.ts
@@ -35,7 +35,7 @@ describe('app', () => {
       expect(readProjectConfiguration(tree, 'my-app-e2e').root).toEqual(
         'my-app-e2e'
       );
-    }, 35000);
+    }, 60_000);
 
     it('should update tags and implicit dependencies', async () => {
       await applicationGenerator(tree, {
@@ -53,7 +53,7 @@ describe('app', () => {
           implicitDependencies: ['my-app'],
         },
       });
-    });
+    }, 60_000);
 
     it('should generate files', async () => {
       await applicationGenerator(tree, {
@@ -225,7 +225,7 @@ describe('app', () => {
       expect(readProjectConfiguration(tree, 'my-app-e2e').root).toEqual(
         'my-dir/my-app-e2e'
       );
-    }, 35000);
+    }, 60_000);
 
     it('should update tags and implicit dependencies', async () => {
       await applicationGenerator(tree, {
@@ -358,6 +358,7 @@ describe('app', () => {
     expect(targets.build.executor).toEqual('@nx/webpack:webpack');
     expect(targets.build.outputs).toEqual(['{options.outputPath}']);
     expect(targets.build.options).toEqual({
+      target: 'web',
       compiler: 'babel',
       assets: ['my-app/src/favicon.ico', 'my-app/src/assets'],
       index: 'my-app/src/index.html',

--- a/packages/web/src/generators/application/application.ts
+++ b/packages/web/src/generators/application/application.ts
@@ -76,6 +76,7 @@ async function setupBundler(tree: Tree, options: NormalizedSchema) {
       typeof import('@nx/webpack')
     >('@nx/webpack', nxVersion);
     await configurationGenerator(tree, {
+      target: 'web',
       project: options.projectName,
       main,
       tsConfig,

--- a/packages/webpack/src/executors/webpack/schema.json
+++ b/packages/webpack/src/executors/webpack/schema.json
@@ -255,7 +255,7 @@
     "isolatedConfig": {
       "type": "boolean",
       "description": "Do not apply Nx webpack plugins automatically. Plugins need to be applied in the project's webpack.config.js file (e.g. withNx, withReact, etc.).",
-      "default": false
+      "default": true
     },
     "extractLicenses": {
       "type": "boolean",


### PR DESCRIPTION
This PR fixes an issue with deprecating `isolatedConfig`, but we still set it in our generators.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
