### PR TITLE
fix(module-federation): host with no remotes should not build remote apps

### DIFF
--- a/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/angular/src/builders/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -37,6 +37,9 @@ function buildStaticRemotes(
   context: import('@angular-devkit/architect').BuilderContext,
   options: Schema
 ) {
+  if (!remotes.staticRemotes.length) {
+    return Promise.resolve();
+  }
   const mappedLocationOfRemotes: Record<string, string> = {};
   for (const app of remotes.staticRemotes) {
     mappedLocationOfRemotes[app] = `http${options.ssl ? 's' : ''}://${

--- a/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -144,6 +144,9 @@ async function buildStaticRemotes(
   context: ExecutorContext,
   options: ModuleFederationDevServerOptions
 ) {
+  if (!remotes.staticRemotes.length) {
+    return;
+  }
   logger.info(`NX Building ${remotes.staticRemotes.length} static remotes...`);
   const mappedLocationOfRemotes: Record<string, string> = {};
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When a host has no remotes, it is attempting to build any project that has a build target

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
If the host has no remotes, it should not attempt to build other projects unless required as a buildable lib dependency

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20200
