### PR TITLE
fix(misc): fix project-name-and-root-utils type imports in schemas

### DIFF
--- a/packages/next/src/generators/library/schema.d.ts
+++ b/packages/next/src/generators/library/schema.d.ts
@@ -1,4 +1,4 @@
-import type { ProjectNameAndRootFormat } from '@nx/devkit/src/generators/project-name-directory-utils';
+import type { ProjectNameAndRootFormat } from '@nx/devkit/src/generators/project-name-and-root-utils';
 import type { Linter } from '@nx/eslint';
 import type { SupportedStyles } from '@nx/react';
 

--- a/packages/plugin/src/generators/create-package/schema.d.ts
+++ b/packages/plugin/src/generators/create-package/schema.d.ts
@@ -1,4 +1,4 @@
-import type { ProjectNameAndRootFormat } from '@nx/devkit/src/generators/project-name-directory-utils';
+import type { ProjectNameAndRootFormat } from '@nx/devkit/src/generators/project-name-and-root-utils';
 import type { Linter } from '@nx/eslint';
 
 export interface CreatePackageSchema {

--- a/packages/plugin/src/generators/e2e-project/schema.d.ts
+++ b/packages/plugin/src/generators/e2e-project/schema.d.ts
@@ -1,4 +1,4 @@
-import type { ProjectNameAndRootFormat } from '@nx/devkit/src/generators/project-name-directory-utils';
+import type { ProjectNameAndRootFormat } from '@nx/devkit/src/generators/project-name-and-root-utils';
 import type { Linter } from '@nx/eslint';
 
 export interface Schema {

--- a/packages/plugin/src/generators/plugin/schema.d.ts
+++ b/packages/plugin/src/generators/plugin/schema.d.ts
@@ -1,4 +1,4 @@
-import type { ProjectNameAndRootFormat } from '@nx/devkit/src/generators/project-name-directory-utils';
+import type { ProjectNameAndRootFormat } from '@nx/devkit/src/generators/project-name-and-root-utils';
 import type { Linter } from '@nx/eslint';
 
 export interface Schema {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Some schemas were left with an old and now invalid import path to `@nx/devkit/src/generators/project-name-and-directory-utils`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Schemas should import from `@nx/devkit/src/generators/project-name-and-root-utils`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20266 
