### PR TITLE
fix(angular): generate component with as-provided format when generating a library

### DIFF
--- a/packages/angular/src/generators/library/lib/add-standalone-component.ts
+++ b/packages/angular/src/generators/library/lib/add-standalone-component.ts
@@ -1,8 +1,8 @@
-import { Tree } from 'nx/src/generators/tree';
-import { NormalizedSchema } from './normalized-schema';
-import componentGenerator from '../../component/component';
-import { addLoadChildren } from './add-load-children';
+import { joinPathFragments, type Tree } from '@nx/devkit';
+import { componentGenerator } from '../../component/component';
 import { addChildren } from './add-children';
+import { addLoadChildren } from './add-load-children';
+import type { NormalizedSchema } from './normalized-schema';
 
 export async function addStandaloneComponent(
   tree: Tree,
@@ -11,10 +11,15 @@ export async function addStandaloneComponent(
   await componentGenerator(tree, {
     ...componentOptions,
     name: componentOptions.name,
+    directory: joinPathFragments(
+      libraryOptions.projectRoot,
+      'src',
+      'lib',
+      componentOptions.flat ? '' : componentOptions.name
+    ),
+    nameAndDirectoryFormat: 'as-provided',
     standalone: true,
     export: true,
-    project: libraryOptions.name,
-    flat: componentOptions.flat,
     skipFormat: true,
   });
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When generating a library, the component generator is invoked with the default & deprecated `derived` format.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Internal calls to other generators should be done using the `as-provided` format.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20304 
