### PR TITLE
fix(misc): @nx/web:file-server should not error on destructuring null

### DIFF
--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -97,12 +97,12 @@ function createFileWatcher(
       includeGlobalWorkspaceFiles: true,
       includeDependentProjects: true,
     },
-    async (error, { changedFiles }) => {
+    async (error, val) => {
       if (error === 'closed') {
         throw new Error('Watch error: Daemon closed the connection');
       } else if (error) {
         throw new Error(`Watch error: ${error?.message ?? 'Unknown'}`);
-      } else if (changedFiles.length > 0) {
+      } else if (val?.changedFiles.length > 0) {
         changeHandler();
       }
     }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
The daemon watcher sometimes returns an error, and when doing so the second arg is null. This results in an error:

```
TypeError: Cannot destructure property 'changedFiles' of 'object null' as it is null.
    at /Users/dnichols2/Documents/Repos/webplatform.ui/node_modules/@nx/web/src/executors/file-server/file-server.impl.js:81:24
    at Socket.<anonymous> (/Users/dnichols2/Documents/Repos/webplatform.ui/node_modules/nx/src/daemon/client/client.js:121:17)
    at Socket.emit (node:events:517:28)
    at Pipe.<anonymous> (node:net:350:12)
```

## Expected Behavior

There is not an error on the restructuring logic, preserving the original error message.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
