### PR TITLE
cleanup(core): separate retrieve project configurations and retrieve workspace files

### DIFF
--- a/packages/devkit/src/utils/convert-nx-executor.ts
+++ b/packages/devkit/src/utils/convert-nx-executor.ts
@@ -32,7 +32,7 @@ export function convertNxExecutor(executor: Executor) {
               projects: await retrieveProjectConfigurationsWithAngularProjects(
                 builderContext.workspaceRoot,
                 nxJsonConfiguration
-              ).then((p) => p.projects),
+              ).then((p) => (p as any).projectNodes ?? p.projects),
             }
           : // TODO(v18): remove retrieveProjectConfigurations. This is to be backwards compatible with Nx 16.5 and below.
             (workspaces as any).readProjectsConfigurations({

--- a/packages/devkit/src/utils/convert-nx-executor.ts
+++ b/packages/devkit/src/utils/convert-nx-executor.ts
@@ -32,7 +32,7 @@ export function convertNxExecutor(executor: Executor) {
               projects: await retrieveProjectConfigurationsWithAngularProjects(
                 builderContext.workspaceRoot,
                 nxJsonConfiguration
-              ).then((p) => p.projectNodes),
+              ).then((p) => p.projects),
             }
           : // TODO(v18): remove retrieveProjectConfigurations. This is to be backwards compatible with Nx 16.5 and below.
             (workspaces as any).readProjectsConfigurations({

--- a/packages/nx/src/config/workspaces.spec.ts
+++ b/packages/nx/src/config/workspaces.spec.ts
@@ -60,13 +60,13 @@ describe('Workspaces', () => {
         }),
       });
 
-      const { projectNodes } = await withEnvironmentVariables(
+      const { projects } = await withEnvironmentVariables(
         {
           NX_WORKSPACE_ROOT: fs.tempDir,
         },
         () => retrieveProjectConfigurations(fs.tempDir, readNxJson(fs.tempDir))
       );
-      expect(projectNodes['my-package']).toEqual({
+      expect(projects['my-package']).toEqual({
         name: 'my-package',
         root: 'packages/my-package',
         sourceRoot: 'packages/my-package',

--- a/packages/nx/src/executors/utils/convert-nx-executor.ts
+++ b/packages/nx/src/executors/utils/convert-nx-executor.ts
@@ -24,7 +24,7 @@ export function convertNxExecutor(executor: Executor) {
             builderContext.workspaceRoot,
             nxJsonConfiguration
           )
-        ).projectNodes,
+        ).projects,
       };
       const context: ExecutorContext = {
         root: builderContext.workspaceRoot,

--- a/packages/nx/src/hasher/native-task-hasher-impl.spec.ts
+++ b/packages/nx/src/hasher/native-task-hasher-impl.spec.ts
@@ -77,16 +77,21 @@ describe('native task hasher', () => {
   });
 
   it('should create a task hash', async () => {
-    const workspaceFiles = await retrieveWorkspaceFiles(tempFs.tempDir, nxJson);
+    const workspaceFiles = await retrieveWorkspaceFiles(tempFs.tempDir, {
+      'libs/parent': 'parent',
+      'libs/unrelated': 'unrelated',
+      'libs/tagged': 'tagged',
+    });
     const builder = new ProjectGraphBuilder(
       undefined,
       workspaceFiles.fileMap.projectFileMap
     );
+
     builder.addNode({
       name: 'parent',
       type: 'lib',
       data: {
-        root: 'parent',
+        root: 'libs/parent',
         targets: {
           build: {
             executor: 'nx:run-commands',
@@ -149,9 +154,9 @@ describe('native task hasher', () => {
             "AllExternalDependencies": "3244421341483603138",
             "env:NONEXISTENTENV": "3244421341483603138",
             "env:TESTENV": "11441948532827618368",
-            "parent:ProjectConfiguration": "15828052557461792163",
+            "parent:ProjectConfiguration": "4131510303084753861",
             "parent:TsConfig": "2264969541778889434",
-            "parent:{projectRoot}/**/*": "3244421341483603138",
+            "parent:{projectRoot}/**/*": "15295586939211629225",
             "runtime:echo runtime123": "29846575039086708",
             "tagged:ProjectConfiguration": "1604492097835699503",
             "tagged:TsConfig": "2264969541778889434",
@@ -163,17 +168,17 @@ describe('native task hasher', () => {
             "{workspaceRoot}/.nxignore": "3244421341483603138",
             "{workspaceRoot}/nx.json": "5219582320960288192",
           },
-          "value": "2902224107680327789",
+          "value": "6332317845632665670",
         },
       ]
     `);
   });
 
   it('should hash tasks where the project has dependencies', async () => {
-    console.log('read first', await tempFs.readFile('nx.json'));
-    const workspaceFiles = await retrieveWorkspaceFiles(tempFs.tempDir, nxJson);
-    console.dir(workspaceFiles.allWorkspaceFiles);
-    console.log('read second', await tempFs.readFile('nx.json'));
+    const workspaceFiles = await retrieveWorkspaceFiles(tempFs.tempDir, {
+      'libs/parent': 'parent',
+      'libs/child': 'child',
+    });
     const builder = new ProjectGraphBuilder(
       undefined,
       workspaceFiles.fileMap.projectFileMap
@@ -243,10 +248,10 @@ describe('native task hasher', () => {
     } as any;
     tempFs.writeFile('nx.json', JSON.stringify(nxJsonModified));
 
-    const workspaceFiles = await retrieveWorkspaceFiles(
-      tempFs.tempDir,
-      nxJsonModified
-    );
+    const workspaceFiles = await retrieveWorkspaceFiles(tempFs.tempDir, {
+      'libs/parent': 'parent',
+      'libs/child': 'child',
+    });
 
     let builder = new ProjectGraphBuilder(
       undefined,
@@ -323,7 +328,9 @@ describe('native task hasher', () => {
       },
     };
     tempFs.writeFile('nx.json', JSON.stringify(nxJson));
-    const workspaceFiles = await retrieveWorkspaceFiles(tempFs.tempDir, nxJson);
+    const workspaceFiles = await retrieveWorkspaceFiles(tempFs.tempDir, {
+      'libs/parent': 'parent',
+    });
     let builder = new ProjectGraphBuilder(
       undefined,
       workspaceFiles.fileMap.projectFileMap
@@ -403,7 +410,10 @@ describe('native task hasher', () => {
       },
     };
     tempFs.writeFile('nx.json', JSON.stringify(nxJson));
-    const workspaceFiles = await retrieveWorkspaceFiles(tempFs.tempDir, nxJson);
+    const workspaceFiles = await retrieveWorkspaceFiles(tempFs.tempDir, {
+      'libs/parent': 'parent',
+      'libs/child': 'child',
+    });
     const builder = new ProjectGraphBuilder(
       undefined,
       workspaceFiles.fileMap.projectFileMap
@@ -486,7 +496,9 @@ describe('native task hasher', () => {
   });
 
   it('should be able to include only a part of the base tsconfig', async () => {
-    let workspaceFiles = await retrieveWorkspaceFiles(tempFs.tempDir, nxJson);
+    let workspaceFiles = await retrieveWorkspaceFiles(tempFs.tempDir, {
+      'libs/parent': 'parent',
+    });
     const builder = new ProjectGraphBuilder(
       undefined,
       workspaceFiles.fileMap.projectFileMap
@@ -539,7 +551,10 @@ describe('native task hasher', () => {
   });
 
   it('should hash tasks where the project graph has circular dependencies', async () => {
-    const workspaceFiles = await retrieveWorkspaceFiles(tempFs.tempDir, nxJson);
+    const workspaceFiles = await retrieveWorkspaceFiles(tempFs.tempDir, {
+      'libs/parent': 'parent',
+      'libs/child': 'child',
+    });
     const builder = new ProjectGraphBuilder(
       undefined,
       workspaceFiles.fileMap.projectFileMap

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -171,10 +171,9 @@ export class Watcher {
 export class WorkspaceContext {
   workspaceRoot: string
   constructor(workspaceRoot: string)
-  getWorkspaceFiles(globs: Array<string>, parseConfigurations: (arg0: Array<string>) => Promise<Record<string, string>>): Promise<NxWorkspaceFiles>
+  getWorkspaceFiles(projectRootMap: Record<string, string>): NxWorkspaceFiles
   glob(globs: Array<string>, exclude?: Array<string> | undefined | null): Array<string>
   hashFilesMatchingGlob(globs: Array<string>, exclude?: Array<string> | undefined | null): string
-  getProjectConfigurations(globs: Array<string>, parseConfigurations: (arg0: Array<string>) => Promise<Record<string, string>>): Promise<Record<string, string>>
   incrementalUpdate(updatedFiles: Array<string>, deletedFiles: Array<string>): Record<string, string>
   updateProjectFiles(projectRootMappings: ProjectRootMappings, projectFiles: ExternalObject<ProjectFiles>, globalFiles: ExternalObject<Array<FileData>>, updatedFiles: Record<string, string>, deletedFiles: Array<string>): UpdatedWorkspaceFiles
   allFileData(): Array<FileData>

--- a/packages/nx/src/native/tests/workspace_files.spec.ts
+++ b/packages/nx/src/native/tests/workspace_files.spec.ts
@@ -48,12 +48,16 @@ describe('workspace files', () => {
       './libs/package-project/index.js': '',
       './nested/non-project/file.txt': '',
     });
-    let globs = ['project.json', '**/project.json', 'libs/*/package.json'];
 
     const context = new WorkspaceContext(fs.tempDir);
     let { projectFileMap, globalFiles } = await context.getWorkspaceFiles(
-      globs,
-      createParseConfigurationsFunction(fs.tempDir)
+      {
+        'libs/project1': 'project1',
+        'libs/project2': 'project2',
+        'libs/project3': 'project3',
+        'libs/nested/project': 'nested-project',
+        'libs/package-project': 'package-project'
+      }
     );
 
     expect(projectFileMap).toMatchInlineSnapshot(`
@@ -147,10 +151,10 @@ describe('workspace files', () => {
 
     const context = new WorkspaceContext(fs.tempDir);
 
-    const globs = ['project.json', '**/project.json', '**/package.json'];
     const { globalFiles, projectFileMap } = await context.getWorkspaceFiles(
-      globs,
-      createParseConfigurationsFunction(fs.tempDir)
+      {
+        '.': 'repo-name'
+      }
     );
 
     expect(globalFiles).toEqual([]);

--- a/packages/nx/src/native/workspace/config_files.rs
+++ b/packages/nx/src/native/workspace/config_files.rs
@@ -1,6 +1,3 @@
-use std::collections::HashMap;
-
-use napi::bindgen_prelude::Promise;
 use rayon::prelude::*;
 
 use crate::native::glob::build_glob_set;
@@ -31,18 +28,4 @@ pub(super) fn glob_files(
             .map(|exclude_glob_set| exclude_glob_set.is_match(path))
             .unwrap_or(is_match)
     }))
-}
-
-/// Get workspace config files based on provided globs
-pub(super) fn get_project_configurations<ConfigurationParser>(
-    globs: Vec<String>,
-    files: &[FileData],
-    parse_configurations: ConfigurationParser,
-) -> napi::Result<Promise<HashMap<String, String>>>
-where
-    ConfigurationParser: Fn(Vec<String>) -> napi::Result<Promise<HashMap<String, String>>>,
-{
-    let files = glob_files(files, globs, None).map_err(anyhow::Error::from)?;
-
-    parse_configurations(files.map(|file| file.file.to_owned()).collect())
 }

--- a/packages/nx/src/native/workspace/context.rs
+++ b/packages/nx/src/native/workspace/context.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 
 use crate::native::hasher::hash;
 use crate::native::utils::Normalize;
-use napi::bindgen_prelude::*;
 use rayon::prelude::*;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
@@ -20,7 +19,7 @@ use crate::native::walker::nx_walker;
 use crate::native::workspace::types::{
     FileMap, NxWorkspaceFilesExternals, ProjectFiles, UpdatedWorkspaceFiles,
 };
-use crate::native::workspace::{config_files, workspace_files};
+use crate::native::workspace::{config_files, workspace_files, types::NxWorkspaceFiles};
 
 #[napi]
 pub struct WorkspaceContext {
@@ -157,17 +156,13 @@ impl WorkspaceContext {
         }
     }
 
-    #[napi(ts_return_type = "Promise<NxWorkspaceFiles>")]
-    pub fn get_workspace_files<ConfigurationParser>(
+    #[napi]
+    pub fn get_workspace_files(
         &self,
-        env: Env,
-        globs: Vec<String>,
-        parse_configurations: ConfigurationParser,
-    ) -> anyhow::Result<Option<Object>>
-    where
-        ConfigurationParser: Fn(Vec<String>) -> napi::Result<Promise<HashMap<String, String>>>,
+        project_root_map: HashMap<String, String>,
+    ) -> anyhow::Result<NxWorkspaceFiles>
     {
-        workspace_files::get_files(env, globs, parse_configurations, self.all_file_data())
+        workspace_files::get_files(project_root_map, self.all_file_data())
             .map_err(anyhow::Error::from)
     }
 
@@ -196,27 +191,6 @@ impl WorkspaceContext {
                 .collect::<Vec<_>>()
                 .concat(),
         ))
-    }
-
-    #[napi(ts_return_type = "Promise<Record<string, string>>")]
-    pub fn get_project_configurations<ConfigurationParser>(
-        &self,
-        env: Env,
-        globs: Vec<String>,
-        parse_configurations: ConfigurationParser,
-    ) -> napi::Result<Object>
-    where
-        ConfigurationParser: Fn(Vec<String>) -> napi::Result<Promise<HashMap<String, String>>>,
-    {
-        let promise = config_files::get_project_configurations(
-            globs,
-            &self.all_file_data(),
-            parse_configurations,
-        )?;
-        env.spawn_future(async move {
-            let result = promise.await?;
-            Ok(result)
-        })
     }
 
     #[napi]

--- a/packages/nx/src/native/workspace/workspace_files.rs
+++ b/packages/nx/src/native/workspace/workspace_files.rs
@@ -1,97 +1,79 @@
-use napi::bindgen_prelude::{Object, Promise};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use napi::bindgen_prelude::External;
-use napi::Env;
 use rayon::prelude::*;
 use tracing::trace;
 
 use crate::native::types::FileData;
-use crate::native::workspace::config_files;
 use crate::native::workspace::types::{FileLocation, NxWorkspaceFiles, NxWorkspaceFilesExternals};
 
-pub(super) fn get_files<ConfigurationParser>(
-    env: Env,
-    globs: Vec<String>,
-    parse_configurations: ConfigurationParser,
+pub(super) fn get_files(
+    project_root_map: HashMap<String, String>,
     files: Vec<FileData>,
-) -> napi::Result<Option<Object>>
-where
-    ConfigurationParser: Fn(Vec<String>) -> napi::Result<Promise<HashMap<String, String>>>,
-{
+) -> napi::Result<NxWorkspaceFiles> {
     if files.is_empty() {
         return Ok(Default::default());
     };
 
-    trace!("{globs:?}");
-    let promise = config_files::get_project_configurations(globs, &files, parse_configurations)?;
+    let root_map = transform_root_map(project_root_map);
 
-    let result = env.spawn_future(async move {
-        let parsed_graph_nodes = promise.await?;
+    trace!(?root_map);
 
-        let root_map = transform_root_map(parsed_graph_nodes);
+    let file_locations = files
+        .par_iter()
+        .cloned()
+        .map(|file_data| {
+            let file_path = PathBuf::from(&file_data.file);
+            let mut parent = file_path.parent().unwrap_or_else(|| Path::new("."));
 
-        trace!(?root_map);
-
-        let file_locations = files
-            .par_iter()
-            .cloned()
-            .map(|file_data| {
-                let file_path = PathBuf::from(&file_data.file);
-                let mut parent = file_path.parent().unwrap_or_else(|| Path::new("."));
-
-                while root_map.get(parent).is_none() && parent != Path::new(".") {
-                    parent = parent.parent().unwrap_or_else(|| Path::new("."));
-                }
-
-                match root_map.get(parent) {
-                    Some(project_name) => (FileLocation::Project(project_name.into()), file_data),
-                    None => (FileLocation::Global, file_data),
-                }
-            })
-            .collect::<Vec<(FileLocation, FileData)>>();
-
-        let mut project_file_map: HashMap<String, Vec<FileData>> = HashMap::with_capacity(
-            file_locations
-                .iter()
-                .filter(|&f| f.0 != FileLocation::Global)
-                .count(),
-        );
-        let mut global_files: Vec<FileData> = Vec::with_capacity(
-            file_locations
-                .iter()
-                .filter(|&f| f.0 == FileLocation::Global)
-                .count(),
-        );
-        for (file_location, file_data) in file_locations {
-            match file_location {
-                FileLocation::Global => global_files.push(file_data),
-                FileLocation::Project(project_name) => {
-                    match project_file_map.get_mut(&project_name) {
-                        None => {
-                            project_file_map.insert(project_name.clone(), vec![file_data]);
-                        }
-                        Some(project_files) => project_files.push(file_data),
-                    }
-                }
+            while root_map.get(parent).is_none() && parent != Path::new(".") {
+                parent = parent.parent().unwrap_or_else(|| Path::new("."));
             }
-        }
 
-        let project_files_external = External::new(project_file_map.clone());
-        let global_files_external = External::new(global_files.clone());
-        let all_workspace_files = External::new(files);
-        Ok(NxWorkspaceFiles {
-            project_file_map,
-            global_files,
-            external_references: Some(NxWorkspaceFilesExternals {
-                project_files: project_files_external,
-                global_files: global_files_external,
-                all_workspace_files,
-            }),
+            match root_map.get(parent) {
+                Some(project_name) => (FileLocation::Project(project_name.into()), file_data),
+                None => (FileLocation::Global, file_data),
+            }
         })
-    })?;
-    Ok(Some(result))
+        .collect::<Vec<(FileLocation, FileData)>>();
+
+    let mut project_file_map: HashMap<String, Vec<FileData>> = HashMap::with_capacity(
+        file_locations
+            .iter()
+            .filter(|&f| f.0 != FileLocation::Global)
+            .count(),
+    );
+    let mut global_files: Vec<FileData> = Vec::with_capacity(
+        file_locations
+            .iter()
+            .filter(|&f| f.0 == FileLocation::Global)
+            .count(),
+    );
+    for (file_location, file_data) in file_locations {
+        match file_location {
+            FileLocation::Global => global_files.push(file_data),
+            FileLocation::Project(project_name) => match project_file_map.get_mut(&project_name) {
+                None => {
+                    project_file_map.insert(project_name.clone(), vec![file_data]);
+                }
+                Some(project_files) => project_files.push(file_data),
+            },
+        }
+    }
+
+    let project_files_external = External::new(project_file_map.clone());
+    let global_files_external = External::new(global_files.clone());
+    let all_workspace_files = External::new(files);
+    Ok(NxWorkspaceFiles {
+        project_file_map,
+        global_files,
+        external_references: Some(NxWorkspaceFilesExternals {
+            project_files: project_files_external,
+            global_files: global_files_external,
+            all_workspace_files,
+        }),
+    })
 }
 
 fn transform_root_map(root_map: HashMap<String, String>) -> hashbrown::HashMap<PathBuf, String> {

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-project-dependencies.spec.ts
@@ -3,7 +3,11 @@ const tempFs = new TempFs('explicit-project-deps');
 
 import { ProjectGraphBuilder } from '../../../../project-graph/project-graph-builder';
 import { buildExplicitTypeScriptDependencies } from './explicit-project-dependencies';
-import { retrieveWorkspaceFiles } from '../../../../project-graph/utils/retrieve-workspace-files';
+import {
+  retrieveProjectConfigurationPaths,
+  retrieveProjectConfigurations,
+  retrieveWorkspaceFiles,
+} from '../../../../project-graph/utils/retrieve-workspace-files';
 import { CreateDependenciesContext } from '../../../../utils/nx-plugin';
 import { setupWorkspaceContext } from '../../../../utils/workspace-context';
 
@@ -560,14 +564,19 @@ async function createContext(
 
   setupWorkspaceContext(tempFs.tempDir);
 
-  const { fileMap, projectConfigurations } = await retrieveWorkspaceFiles(
+  const { projects, projectRootMap } = await retrieveProjectConfigurations(
     tempFs.tempDir,
     nxJson
   );
 
+  const { fileMap } = await retrieveWorkspaceFiles(
+    tempFs.tempDir,
+    projectRootMap
+  );
+
   return {
     externalNodes: builder.getUpdatedProjectGraph().externalNodes,
-    projects: projectConfigurations.projects,
+    projects: projects,
     nxJsonConfiguration: nxJson,
     filesToProcess: fileMap,
     fileMap: fileMap,

--- a/packages/nx/src/project-graph/project-graph.ts
+++ b/packages/nx/src/project-graph/project-graph.ts
@@ -12,7 +12,10 @@ import { daemonClient } from '../daemon/client/client';
 import { fileExists } from '../utils/fileutils';
 import { workspaceRoot } from '../utils/workspace-root';
 import { performance } from 'perf_hooks';
-import { retrieveWorkspaceFiles } from './utils/retrieve-workspace-files';
+import {
+  retrieveProjectConfigurations,
+  retrieveWorkspaceFiles,
+} from './utils/retrieve-workspace-files';
 import { readNxJson } from '../config/nx-json';
 import { unregisterPluginTSTranspiler } from '../utils/nx-plugin';
 import { writeSourceMaps } from '../utils/source-maps';
@@ -78,19 +81,16 @@ export function readProjectsConfigurationFromProjectGraph(
 export async function buildProjectGraphWithoutDaemon() {
   const nxJson = readNxJson();
 
-  const {
-    allWorkspaceFiles,
-    fileMap,
-    projectConfigurations,
-    externalNodes,
-    sourceMaps,
-    rustReferences,
-  } = await retrieveWorkspaceFiles(workspaceRoot, nxJson);
+  const { projects, externalNodes, sourceMaps, projectRootMap } =
+    await retrieveProjectConfigurations(workspaceRoot, nxJson);
+
+  const { allWorkspaceFiles, fileMap, rustReferences } =
+    await retrieveWorkspaceFiles(workspaceRoot, projectRootMap);
 
   const cacheEnabled = process.env.NX_CACHE_PROJECT_GRAPH !== 'false';
   const projectGraph = (
     await buildProjectGraphUsingProjectFileMap(
-      projectConfigurations.projects,
+      projects,
       externalNodes,
       fileMap,
       allWorkspaceFiles,

--- a/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
+++ b/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
@@ -24,9 +24,8 @@ import {
 } from '../../utils/nx-plugin';
 import { CreateProjectJsonProjectsPlugin } from '../../plugins/project-json/build-nodes/project-json';
 import {
-  getNxWorkspaceFilesFromContext,
-  getProjectConfigurationsFromContext,
   globWithWorkspaceContext,
+  getNxWorkspaceFilesFromContext,
 } from '../../utils/workspace-context';
 import { buildAllWorkspaceFiles } from './build-all-workspace-files';
 
@@ -38,15 +37,9 @@ import { buildAllWorkspaceFiles } from './build-all-workspace-files';
  */
 export async function retrieveWorkspaceFiles(
   workspaceRoot: string,
-  nxJson: NxJsonConfiguration
+  projectRootMap: Record<string, string>
 ) {
   performance.mark('native-file-deps:start');
-  const plugins = await loadNxPlugins(
-    nxJson?.plugins ?? [],
-    getNxRequirePaths(workspaceRoot),
-    workspaceRoot
-  );
-  let globs = configurationGlobs(plugins);
   performance.mark('native-file-deps:end');
   performance.measure(
     'native-file-deps',
@@ -55,29 +48,9 @@ export async function retrieveWorkspaceFiles(
   );
 
   performance.mark('get-workspace-files:start');
-  let projects: Record<string, ProjectConfiguration>;
-  let externalNodes: Record<string, ProjectGraphExternalNode>;
-  let sourceMaps: ConfigurationSourceMaps;
 
   const { projectFileMap, globalFiles, externalReferences } =
-    (await getNxWorkspaceFilesFromContext(
-      workspaceRoot,
-      globs,
-      async (configs: string[]) => {
-        const projectConfigurations = await createProjectConfigurations(
-          workspaceRoot,
-          nxJson,
-          configs,
-          plugins
-        );
-
-        projects = projectConfigurations.projects;
-        sourceMaps = projectConfigurations.sourceMaps;
-
-        externalNodes = projectConfigurations.externalNodes;
-        return projectConfigurations.rootMap;
-      }
-    )) as NxWorkspaceFiles;
+    getNxWorkspaceFilesFromContext(workspaceRoot, projectRootMap);
   performance.mark('get-workspace-files:end');
   performance.measure(
     'get-workspace-files',
@@ -91,12 +64,6 @@ export async function retrieveWorkspaceFiles(
       projectFileMap,
       nonProjectFiles: globalFiles,
     },
-    projectConfigurations: {
-      version: 2,
-      projects,
-    } as ProjectsConfigurations,
-    externalNodes,
-    sourceMaps,
     rustReferences: externalReferences,
   };
 }
@@ -110,29 +77,20 @@ export async function retrieveWorkspaceFiles(
 export async function retrieveProjectConfigurations(
   workspaceRoot: string,
   nxJson: NxJsonConfiguration
-): Promise<{
-  externalNodes: Record<string, ProjectGraphExternalNode>;
-  projectNodes: Record<string, ProjectConfiguration>;
-  sourceMaps: ConfigurationSourceMaps;
-}> {
+): Promise<RetrievedGraphNodes> {
   const plugins = await loadNxPlugins(
     nxJson?.plugins ?? [],
     getNxRequirePaths(workspaceRoot),
     workspaceRoot
   );
 
-  const globs = configurationGlobs(plugins);
-  return _retrieveProjectConfigurations(workspaceRoot, nxJson, plugins, globs);
+  return _retrieveProjectConfigurations(workspaceRoot, nxJson, plugins);
 }
 
 export async function retrieveProjectConfigurationsWithAngularProjects(
   workspaceRoot: string,
   nxJson: NxJsonConfiguration
-): Promise<{
-  externalNodes: Record<string, ProjectGraphExternalNode>;
-  projectNodes: Record<string, ProjectConfiguration>;
-  sourceMaps: ConfigurationSourceMaps;
-}> {
+): Promise<RetrievedGraphNodes> {
   const plugins = await loadNxPlugins(
     nxJson?.plugins ?? [],
     getNxRequirePaths(workspaceRoot),
@@ -146,46 +104,30 @@ export async function retrieveProjectConfigurationsWithAngularProjects(
     plugins.push({ plugin: NxAngularJsonPlugin });
   }
 
-  const globs = configurationGlobs(plugins);
-  return _retrieveProjectConfigurations(workspaceRoot, nxJson, plugins, globs);
+  return _retrieveProjectConfigurations(workspaceRoot, nxJson, plugins);
 }
+
+export type RetrievedGraphNodes = {
+  externalNodes: Record<string, ProjectGraphExternalNode>;
+  projects: Record<string, ProjectConfiguration>;
+  sourceMaps: ConfigurationSourceMaps;
+  projectRootMap: Record<string, string>;
+};
 
 function _retrieveProjectConfigurations(
   workspaceRoot: string,
   nxJson: NxJsonConfiguration,
-  plugins: LoadedNxPlugin[],
-  globs: string[]
-): Promise<{
-  externalNodes: Record<string, ProjectGraphExternalNode>;
-  projectNodes: Record<string, ProjectConfiguration>;
-  sourceMaps: ConfigurationSourceMaps;
-}> {
-  let result: {
-    externalNodes: Record<string, ProjectGraphExternalNode>;
-    projectNodes: Record<string, ProjectConfiguration>;
-    sourceMaps: ConfigurationSourceMaps;
-  };
-  return getProjectConfigurationsFromContext(
+  plugins: LoadedNxPlugin[]
+): Promise<RetrievedGraphNodes> {
+  const globPatterns = configurationGlobs(plugins);
+  const projectFiles = globWithWorkspaceContext(workspaceRoot, globPatterns);
+
+  return createProjectConfigurations(
     workspaceRoot,
-    globs,
-    async (configs: string[]) => {
-      const { projects, externalNodes, rootMap, sourceMaps } =
-        await createProjectConfigurations(
-          workspaceRoot,
-          nxJson,
-          configs,
-          plugins
-        );
-
-      result = {
-        projectNodes: projects,
-        externalNodes: externalNodes,
-        sourceMaps,
-      };
-
-      return rootMap;
-    }
-  ).then(() => result);
+    nxJson,
+    projectFiles,
+    plugins
+  );
 }
 
 export function retrieveProjectConfigurationPaths(
@@ -214,23 +156,15 @@ export async function retrieveProjectConfigurationsWithoutPluginInference(
     return projectsWithoutPluginCache.get(cacheKey);
   }
 
-  let projects: Record<string, ProjectConfiguration>;
-  await getProjectConfigurationsFromContext(
+  const projectFiles = globWithWorkspaceContext(root, projectGlobPatterns);
+  const { projects } = await createProjectConfigurations(
     root,
-    projectGlobPatterns,
-    async (configs: string[]) => {
-      const projectConfigurations = await createProjectConfigurations(
-        root,
-        nxJson,
-        configs,
-        [
-          { plugin: getNxPackageJsonWorkspacesPlugin(root) },
-          { plugin: CreateProjectJsonProjectsPlugin },
-        ]
-      );
-      projects = projectConfigurations.projects;
-      return projectConfigurations.rootMap;
-    }
+    nxJson,
+    projectFiles,
+    [
+      { plugin: getNxPackageJsonWorkspacesPlugin(root) },
+      { plugin: CreateProjectJsonProjectsPlugin },
+    ]
   );
 
   projectsWithoutPluginCache.set(cacheKey, projects);
@@ -243,12 +177,7 @@ export async function createProjectConfigurations(
   nxJson: NxJsonConfiguration,
   configFiles: string[],
   plugins: LoadedNxPlugin[]
-): Promise<{
-  projects: Record<string, ProjectConfiguration>;
-  externalNodes: Record<string, ProjectGraphExternalNode>;
-  rootMap: Record<string, string>;
-  sourceMaps: ConfigurationSourceMaps;
-}> {
+): Promise<RetrievedGraphNodes> {
   performance.mark('build-project-configs:start');
 
   const { projects, externalNodes, rootMap, sourceMaps } =
@@ -269,7 +198,7 @@ export async function createProjectConfigurations(
   return {
     projects,
     externalNodes,
-    rootMap,
+    projectRootMap: rootMap,
     sourceMaps,
   };
 }

--- a/packages/nx/src/utils/workspace-context.ts
+++ b/packages/nx/src/utils/workspace-context.ts
@@ -19,11 +19,10 @@ export function setupWorkspaceContext(workspaceRoot: string) {
 
 export function getNxWorkspaceFilesFromContext(
   workspaceRoot: string,
-  globs: string[],
-  parseConfigurations: (files: string[]) => Promise<Record<string, string>>
+  projectRootMap: Record<string, string>
 ) {
   ensureContextAvailable(workspaceRoot);
-  return workspaceContext.getWorkspaceFiles(globs, parseConfigurations);
+  return workspaceContext.getWorkspaceFiles(projectRootMap);
 }
 
 export function globWithWorkspaceContext(
@@ -42,15 +41,6 @@ export function hashWithWorkspaceContext(
 ) {
   ensureContextAvailable(workspaceRoot);
   return workspaceContext.hashFilesMatchingGlob(globs, exclude);
-}
-
-export function getProjectConfigurationsFromContext(
-  workspaceRoot: string,
-  globs: string[],
-  parseConfigurations: (files: string[]) => Promise<Record<string, string>>
-) {
-  ensureContextAvailable(workspaceRoot);
-  return workspaceContext.getProjectConfigurations(globs, parseConfigurations);
 }
 
 export function updateFilesInContext(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
There are two distinct operations that are a bit intermingled that have to happen at around the same time. The mingling made sense initially, but has led to some issues and made things a bit more confusing in the codebase.

The two operations are: `retrieveWorkspaceFiles` and `getProjectConfigurations`. The confusion begins with the fact that `retrieveWorkspaceFiles` and `getProjectConfigurations` both return project nodes. If you need project nodes, which should you use?

While this was a bit confusing, it wasn't really an issue. After making createNodes async though, and doing more testing and digging with it, some issues were found:

- The types of promise values were lost between rust + typescript. We got around this by telling napi-rs what type to use, but it was a magic string that could have easily been forgotten

- Further, when incrementally updating the project graph **_both_** were being used, causing `createNodes` to occasionally be called twice.

- The `getProjectConfigurations` rust method was mostly obsolete. It's entire job was to glob files on the rust side, and then return the result of a TS callback that ran on the results. However, we already exposed a function to glob via rust, and there's no real reason to call the callback on the rust side.

## Expected Behavior

By separating out the 2 methods, we are able to remove the `getProjectConfigurations` method from the rust side, and avoid **_ever_** passing the JS callback into rust. Instead, we pass the project root map which was always calculated on the typescript side of things. This means the JS promises go away, and we get our type safety back. It also clearly divides the responsibility of retrieveWorkspaceFiles away from creating projects configurations, and allows for further cleanup.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
