### PR TITLE
feat(devkit): improving error handeling read target options

### DIFF
--- a/packages/devkit/src/executors/read-target-options.ts
+++ b/packages/devkit/src/executors/read-target-options.ts
@@ -43,27 +43,27 @@ export function readTargetOptions<T = any>(
   const [nodeModule, executorName] = targetConfiguration.executor.split(':');
   const { schema } = getExecutorInformation
     ? getExecutorInformation(
-      nodeModule,
-      executorName,
-      context.root,
-      context.projectsConfigurations?.projects ?? context.workspace.projects
-    )
+        nodeModule,
+        executorName,
+        context.root,
+        context.projectsConfigurations?.projects ?? context.workspace.projects
+      )
     : // TODO(v18): remove readExecutor. This is to be backwards compatible with Nx 16.5 and below.
-    (ws as any).readExecutor(nodeModule, executorName);
+      (ws as any).readExecutor(nodeModule, executorName);
 
   const defaultProject = calculateDefaultProjectName
     ? calculateDefaultProjectName(
-      context.cwd,
-      context.root,
-      { version: 2, projects: context.projectsConfigurations.projects },
-      context.nxJsonConfiguration
-    )
+        context.cwd,
+        context.root,
+        { version: 2, projects: context.projectsConfigurations.projects },
+        context.nxJsonConfiguration
+      )
     : // TODO(v18): remove calculateDefaultProjectName. This is to be backwards compatible with Nx 16.5 and below.
-    (ws as any).calculateDefaultProjectName(
-      context.cwd,
-      { version: 2, projects: context.projectsConfigurations.projects },
-      context.nxJsonConfiguration
-    );
+      (ws as any).calculateDefaultProjectName(
+        context.cwd,
+        { version: 2, projects: context.projectsConfigurations.projects },
+        context.nxJsonConfiguration
+      );
 
   return combineOptionsForExecutor(
     {},

--- a/packages/devkit/src/executors/read-target-options.ts
+++ b/packages/devkit/src/executors/read-target-options.ts
@@ -34,32 +34,36 @@ export function readTargetOptions<T = any>(
 
   const targetConfiguration = projectConfiguration.targets[target];
 
+  if (!targetConfiguration) {
+    throw new Error(`Unable to find target ${target} for project ${project}`);
+  }
+
   // TODO(v18): remove Workspaces.
   const ws = new Workspaces(context.root);
   const [nodeModule, executorName] = targetConfiguration.executor.split(':');
   const { schema } = getExecutorInformation
     ? getExecutorInformation(
-        nodeModule,
-        executorName,
-        context.root,
-        context.projectsConfigurations?.projects ?? context.workspace.projects
-      )
+      nodeModule,
+      executorName,
+      context.root,
+      context.projectsConfigurations?.projects ?? context.workspace.projects
+    )
     : // TODO(v18): remove readExecutor. This is to be backwards compatible with Nx 16.5 and below.
-      (ws as any).readExecutor(nodeModule, executorName);
+    (ws as any).readExecutor(nodeModule, executorName);
 
   const defaultProject = calculateDefaultProjectName
     ? calculateDefaultProjectName(
-        context.cwd,
-        context.root,
-        { version: 2, projects: context.projectsConfigurations.projects },
-        context.nxJsonConfiguration
-      )
+      context.cwd,
+      context.root,
+      { version: 2, projects: context.projectsConfigurations.projects },
+      context.nxJsonConfiguration
+    )
     : // TODO(v18): remove calculateDefaultProjectName. This is to be backwards compatible with Nx 16.5 and below.
-      (ws as any).calculateDefaultProjectName(
-        context.cwd,
-        { version: 2, projects: context.projectsConfigurations.projects },
-        context.nxJsonConfiguration
-      );
+    (ws as any).calculateDefaultProjectName(
+      context.cwd,
+      { version: 2, projects: context.projectsConfigurations.projects },
+      context.nxJsonConfiguration
+    );
 
   return combineOptionsForExecutor(
     {},


### PR DESCRIPTION
Catching a wrong target given in the project.json for component testing.

closed #20251

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When running a Cypress component test with a wrong target it will error with an unclear error:
```
TypeError: Cannot read properties of undefined (reading 'executor')
    at readTargetOptions (/[PATH TO]/node_modules/@nx/devkit/src/executors/read-target-options.js:24:60)
    etc...
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
With this fix, it should catch when the `executor` is not found and throw a clear error saying that the target is not found on the project. This makes it clearer what the error is about


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20251


(This is a re-opening of [This PR](https://github.com/nrwl/nx/pull/20271) since something went wring formatting and it closed it)