### PR TITLE
fix(next): avoid overriding of environment PORT if its not specified in options

### DIFF
--- a/packages/next/src/executors/server/custom-server.impl.ts
+++ b/packages/next/src/executors/server/custom-server.impl.ts
@@ -14,8 +14,15 @@ export default async function* serveExecutor(
     ? 'development'
     : 'production';
 
+  let { port } = options;
+  if(!port && process.env.PORT) {
+    port = parseInt(process.env.PORT, 10);
+  }
+
   // Setting port that the custom server should use.
-  (process.env as any).PORT = options.port;
+  if(port) {
+    (process.env as any).PORT = `${options.port}`;
+  }
 
   const projectRoot = context.projectGraph.nodes[context.projectName].data.root;
 
@@ -30,7 +37,12 @@ async function* runCustomServer(
   process.env.NX_NEXT_DIR = root;
   process.env.NX_NEXT_PUBLIC_DIR = join(root, 'public');
 
-  const baseUrl = `http://${options.hostname || 'localhost'}:${options.port}`;
+  let { port } = options;
+  if(!port && process.env.PORT) {
+    port = parseInt(process.env.PORT, 10);
+  }
+
+  const baseUrl = `http://${options.hostname || 'localhost'}:${port}`;
 
   const customServerBuild = await runExecutor(
     parseTargetString(options.customServerTarget, context),

--- a/packages/next/src/executors/server/server.impl.ts
+++ b/packages/next/src/executors/server/server.impl.ts
@@ -29,7 +29,7 @@ export default async function* serveExecutor(
   );
   const projectRoot = context.workspace.projects[context.projectName].root;
 
-  const { port, keepAliveTimeout, hostname } = options;
+  const { keepAliveTimeout, hostname } = options;
 
   // This is required for the default custom server to work. See the @nx/next:app generator.
   process.env.NX_NEXT_DIR = projectRoot;
@@ -42,7 +42,14 @@ export default async function* serveExecutor(
     : 'production';
 
   // Setting port that the custom server should use.
-  process.env.PORT = `${options.port}`;
+  let { port } = options;
+  if(!port && process.env.PORT) {
+    port = parseInt(process.env.PORT, 10);
+  }
+
+  if(port) {
+    process.env.PORT = `${port}`;
+  }
 
   const args = createCliOptions({ port, hostname });
 


### PR DESCRIPTION
This PR fixes an issue with empty port overwriting environment PORT variable (cannot provide PORT from environment with any solution, nor nx, nor next)

## Current Behavior

## Expected Behavior

## Related Issue(s)

Fixes #
