### PR TITLE
feat(testing): allow cypress preset to execute a command for a web server

### DIFF
--- a/packages/angular/src/generators/application/lib/add-e2e.ts
+++ b/packages/angular/src/generators/application/lib/add-e2e.ts
@@ -32,6 +32,7 @@ export async function addE2e(tree: Tree, options: NormalizedSchema) {
       skipPackageJson: options.skipPackageJson,
       skipFormat: true,
       devServerTarget: `${options.name}:serve:development`,
+      baseUrl: 'http://localhost:4200',
       rootProject: options.rootProject,
     });
   } else if (options.e2eTestRunner === 'playwright') {

--- a/packages/angular/src/generators/ng-add/migrators/projects/__snapshots__/e2e.migrator.spec.ts.snap
+++ b/packages/angular/src/generators/ng-add/migrators/projects/__snapshots__/e2e.migrator.spec.ts.snap
@@ -19,7 +19,10 @@ exports[`e2e migrator cypress with project root at "" cypress version >=10 shoul
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
-  e2e: { ...nxE2EPreset(__filename, { cypressDir: 'src' }) },
+  e2e: {
+    ...nxE2EPreset(__filename, { cypressDir: 'src' }),
+    baseUrl: 'http://localhost:4200',
+  },
 });
 "
 `;
@@ -96,7 +99,10 @@ exports[`e2e migrator cypress with project root at "projects/app1" cypress versi
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
-  e2e: { ...nxE2EPreset(__filename, { cypressDir: 'src' }) },
+  e2e: {
+    ...nxE2EPreset(__filename, { cypressDir: 'src' }),
+    baseUrl: 'http://localhost:4200',
+  },
 });
 "
 `;

--- a/packages/angular/src/generators/ng-add/migrators/projects/e2e.migrator.ts
+++ b/packages/angular/src/generators/ng-add/migrators/projects/e2e.migrator.ts
@@ -348,6 +348,7 @@ export class E2eMigrator extends ProjectMigrator<SupportedTargets> {
       skipFormat: true,
       // any target would do, we replace it later with the target existing in the project being migrated
       devServerTarget: `${this.appName}:serve`,
+      baseUrl: 'http://localhost:4200',
     });
 
     const cypressConfigFilePath = this.updateOrCreateCypressConfigFile(

--- a/packages/cypress/plugins/cypress-preset.ts
+++ b/packages/cypress/plugins/cypress-preset.ts
@@ -1,14 +1,11 @@
-import {
-  createProjectGraphAsync,
-  parseTargetString,
-  workspaceRoot,
-} from '@nx/devkit';
+import { workspaceRoot } from '@nx/devkit';
 import { dirname, join, relative } from 'path';
 import { lstatSync } from 'fs';
 
 import vitePreprocessor from '../src/plugins/preprocessor-vite';
-import { createExecutorContext } from '../src/utils/ct-helpers';
-import { startDevServer } from '../src/utils/start-dev-server';
+import { exec } from 'child_process';
+import { request as httpRequest } from 'http';
+import { request as httpsRequest } from 'https';
 
 interface BaseCypressPreset {
   videosFolder: string;
@@ -57,6 +54,18 @@ export function nxBaseCypressPreset(
   };
 }
 
+function startWebServer(webServerCommand: string) {
+  const serverProcess = exec(webServerCommand, {
+    cwd: workspaceRoot,
+  });
+  serverProcess.stdout.pipe(process.stdout);
+  serverProcess.stderr.pipe(process.stderr);
+
+  return () => {
+    serverProcess.kill();
+  };
+}
+
 /**
  * nx E2E Preset for Cypress
  * @description
@@ -84,54 +93,118 @@ export function nxE2EPreset(
     specPattern: `${basePath}/**/*.cy.{js,jsx,ts,tsx}`,
     fixturesFolder: `${basePath}/fixtures`,
     env: {
-      devServerTargets: options?.devServerTargets,
-      devServerTargetOptions: {},
-      ciDevServerTarget: options?.ciDevServerTarget,
+      webServerCommand: options?.webServerCommands?.default,
+      webServerCommands: options?.webServerCommands,
+      ciWebServerCommand: options?.ciWebServerCommand,
     },
     async setupNodeEvents(on, config) {
       if (options?.bundler === 'vite') {
         on('file:preprocessor', vitePreprocessor());
       }
-      if (!config.env.devServerTargets) {
+      if (!config.env.webServerCommands) {
         return;
       }
-      const devServerTarget =
-        config.env.devServerTarget ?? config.env.devServerTargets['default'];
+      const webServerCommand = config.env.webServerCommand;
 
-      if (!devServerTarget) {
+      if (!webServerCommand) {
         return;
       }
-      if (!config.baseUrl && devServerTarget) {
-        const graph = await createProjectGraphAsync();
-        const target = parseTargetString(devServerTarget, graph);
-        const context = createExecutorContext(
-          graph,
-          graph.nodes[target.project].data?.targets,
-          target.project,
-          target.target,
-          target.configuration
-        );
-
-        const devServer = startDevServer(
-          {
-            devServerTarget,
-            ...config.env.devServerTargetOptions,
-          },
-          context
-        );
-        on('after:run', () => {
-          devServer.return();
-        });
-        const devServerValue = (await devServer.next()).value;
-        if (!devServerValue) {
-          return;
+      if (config.baseUrl && webServerCommand) {
+        if (await isServerUp(config.baseUrl)) {
+          if (
+            options?.webServerConfig?.reuseExistingServer === undefined
+              ? true
+              : options.webServerConfig.reuseExistingServer
+          ) {
+            console.log(
+              `Reusing the server already running on ${config.baseUrl}`
+            );
+            return;
+          } else {
+            throw new Error(
+              `Web server is already running at ${config.baseUrl}`
+            );
+          }
         }
-        return { ...config, baseUrl: devServerValue.baseUrl };
+        const killWebServer = startWebServer(webServerCommand);
+
+        on('after:run', () => {
+          killWebServer();
+        });
+        await waitForServer(config.baseUrl, options.webServerConfig);
       }
     },
   };
 
   return baseConfig;
+}
+
+function waitForServer(
+  url: string,
+  webServerConfig: WebServerConfig
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let pollTimeout: NodeJS.Timeout | null;
+    const { protocol } = new URL(url);
+
+    const timeoutDuration = webServerConfig?.timeout ?? 5 * 1000;
+    const timeout = setTimeout(() => {
+      clearTimeout(pollTimeout);
+      reject(
+        new Error(
+          `Web server failed to start in ${timeoutDuration}ms. This can be configured in cypress.config.ts.`
+        )
+      );
+    }, timeoutDuration);
+
+    const makeRequest = protocol === 'https:' ? httpsRequest : httpRequest;
+
+    function pollForServer() {
+      const request = makeRequest(url, () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+
+      request.on('error', () => {
+        pollTimeout = setTimeout(pollForServer, 100);
+      });
+
+      // Don't forget to end the request
+      request.end();
+    }
+
+    pollForServer();
+  });
+}
+
+function isServerUp(url: string) {
+  const { protocol } = new URL(url);
+  const makeRequest = protocol === 'https:' ? httpsRequest : httpRequest;
+
+  return new Promise((resolve) => {
+    const request = makeRequest(url, () => {
+      resolve(true);
+    });
+
+    request.on('error', () => {
+      resolve(false);
+    });
+
+    // Don't forget to end the request
+    request.end();
+  });
+}
+
+export interface WebServerConfig {
+  /**
+   * Timeout to wait for the webserver to start listening
+   */
+  timeout?: number;
+  /**
+   * Reuse an existing web server if it exists
+   * If this is false, an error will be thrown if the server is already running
+   */
+  reuseExistingServer?: boolean;
 }
 
 export type NxCypressE2EPresetOptions = {
@@ -143,6 +216,7 @@ export type NxCypressE2EPresetOptions = {
    **/
   cypressDir?: string;
 
-  devServerTargets?: Record<string, string>;
-  ciDevServerTarget?: string;
+  webServerCommands?: Record<string, string>;
+  ciWebServerCommand?: string;
+  webServerConfig?: WebServerConfig;
 };

--- a/packages/cypress/src/executors/cypress/cypress.impl.ts
+++ b/packages/cypress/src/executors/cypress/cypress.impl.ts
@@ -170,10 +170,6 @@ async function runCypress(
     options.browser = opts.browser;
   }
 
-  options.env = {
-    devServerTarget: opts.devServerTarget,
-  };
-
   if (opts.env) {
     options.env = {
       ...options.env,

--- a/packages/cypress/src/generators/configuration/configuration.spec.ts
+++ b/packages/cypress/src/generators/configuration/configuration.spec.ts
@@ -34,7 +34,7 @@ describe('Cypress e2e configuration', () => {
       mockedInstalledCypressVersion.mockReturnValue(10);
     });
 
-    it('should add dev server targets to the cypress config when the @nx/cypress/plugin is present', async () => {
+    it('should add web server commands to the cypress config when the @nx/cypress/plugin is present', async () => {
       process.env.NX_PCV3 = 'true';
       await cypressInitGenerator(tree, {});
 
@@ -42,6 +42,7 @@ describe('Cypress e2e configuration', () => {
 
       await cypressE2EConfigurationGenerator(tree, {
         project: 'my-app',
+        baseUrl: 'http://localhost:4200',
       });
       expect(tree.read('apps/my-app/cypress.config.ts', 'utf-8'))
         .toMatchInlineSnapshot(`
@@ -53,12 +54,13 @@ describe('Cypress e2e configuration', () => {
           e2e: {
             ...nxE2EPreset(__filename, {
               cypressDir: 'src',
-              devServerTargets: {
-                default: 'my-app:serve',
-                production: 'my-app:serve:production',
+              webServerCommands: {
+                default: 'nx run my-app:serve',
+                production: 'nx run my-app:serve:production',
               },
-              ciDevServerTarget: 'my-app:serve-static',
+              ciWebServerCommand: 'nx run my-app:serve-static',
             }),
+            baseUrl: 'http://localhost:4200',
           },
         });
         "
@@ -188,9 +190,20 @@ describe('Cypress e2e configuration', () => {
         baseUrl: 'http://localhost:4200',
       });
       assertCypressFiles(tree, 'apps/my-app/src');
-      expect(
-        readProjectConfiguration(tree, 'my-app').targets.e2e.options.baseUrl
-      ).toEqual('http://localhost:4200');
+      expect(tree.read('apps/my-app/cypress.config.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+
+        import { defineConfig } from 'cypress';
+
+        export default defineConfig({
+          e2e: {
+            ...nxE2EPreset(__filename, { cypressDir: 'src' }),
+            baseUrl: 'http://localhost:4200',
+          },
+        });
+        "
+      `);
     });
 
     it('should not overwrite existing e2e target', async () => {

--- a/packages/cypress/src/generators/configuration/configuration.ts
+++ b/packages/cypress/src/generators/configuration/configuration.ts
@@ -164,14 +164,14 @@ async function addFiles(
     });
 
     const cyFile = joinPathFragments(projectConfig.root, 'cypress.config.ts');
-    let devServerTargets: Record<string, string>;
+    let webServerCommands: Record<string, string>;
 
     let ciDevServerTarget: string;
 
-    if (hasPlugin && !options.baseUrl && options.devServerTarget) {
-      devServerTargets = {};
+    if (hasPlugin && options.devServerTarget) {
+      webServerCommands = {};
 
-      devServerTargets.default = options.devServerTarget;
+      webServerCommands.default = 'nx run ' + options.devServerTarget;
       const parsedTarget = parseTargetString(
         options.devServerTarget,
         projectGraph
@@ -188,11 +188,11 @@ async function addFiles(
           'production'
         ]
       ) {
-        devServerTargets.production = `${parsedTarget.project}:${parsedTarget.target}:production`;
+        webServerCommands.production = `nx run ${parsedTarget.project}:${parsedTarget.target}:production`;
       }
       // Add ci/static e2e target if serve target is found
       if (devServerProjectConfig.targets?.['serve-static']) {
-        ciDevServerTarget = `${parsedTarget.project}:serve-static`;
+        ciDevServerTarget = `nx run ${parsedTarget.project}:serve-static`;
       }
     }
     const updatedCyConfig = await addDefaultE2EConfig(
@@ -200,8 +200,8 @@ async function addFiles(
       {
         cypressDir: options.directory,
         bundler: options.bundler === 'vite' ? 'vite' : undefined,
-        devServerTargets,
-        ciDevServerTarget: ciDevServerTarget,
+        webServerCommands,
+        ciWebServerCommand: ciDevServerTarget,
       },
       options.baseUrl
     );
@@ -245,12 +245,7 @@ function addTarget(tree: Tree, opts: NormalizedSchema) {
       testingType: 'e2e',
     },
   };
-  if (opts.baseUrl) {
-    projectConfig.targets.e2e.options = {
-      ...projectConfig.targets.e2e.options,
-      baseUrl: opts.baseUrl,
-    };
-  } else if (opts.devServerTarget) {
+  if (opts.devServerTarget) {
     const parsedTarget = parseTargetString(opts.devServerTarget);
 
     projectConfig.targets.e2e.options = {
@@ -282,6 +277,11 @@ function addTarget(tree: Tree, opts: NormalizedSchema) {
         devServerTarget: `${parsedTarget.project}:serve-static`,
       };
     }
+  } else if (opts.baseUrl) {
+    projectConfig.targets.e2e.options = {
+      ...projectConfig.targets.e2e.options,
+      baseUrl: opts.baseUrl,
+    };
   }
 
   updateProjectConfiguration(tree, opts.project, projectConfig);

--- a/packages/cypress/src/plugins/plugin.spec.ts
+++ b/packages/cypress/src/plugins/plugin.spec.ts
@@ -38,9 +38,9 @@ describe('@nx/cypress/plugin', () => {
       defineConfig({
         e2e: {
           env: {
-            devServerTargets: {
-              default: 'my-app:serve',
-              production: 'my-app:serve:production',
+            webServerCommands: {
+              default: 'nx run my-app:serve',
+              production: 'nx run my-app:serve:production',
             },
           },
           videosFolder: './dist/videos',
@@ -67,7 +67,7 @@ describe('@nx/cypress/plugin', () => {
                 "command": "cypress run --config-file cypress.config.js --e2e",
                 "configurations": {
                   "production": {
-                    "command": "cypress run --config-file cypress.config.js --e2e --env.devServerTarget my-app:serve:production",
+                    "command": "cypress run --config-file cypress.config.js --e2e --env webServerCommand="nx run my-app:serve:production"",
                   },
                 },
                 "inputs": [
@@ -156,11 +156,11 @@ describe('@nx/cypress/plugin', () => {
           videosFolder: './dist/videos',
           screenshotsFolder: './dist/screenshots',
           env: {
-            devServerTargets: {
+            webServerCommands: {
               default: 'my-app:serve',
               production: 'my-app:serve:production',
             },
-            ciDevServerTarget: 'my-app:serve-static',
+            ciWebServerCommand: 'my-app:serve-static',
           },
         },
       })
@@ -184,7 +184,7 @@ describe('@nx/cypress/plugin', () => {
                 "command": "cypress run --config-file cypress.config.js --e2e",
                 "configurations": {
                   "production": {
-                    "command": "cypress run --config-file cypress.config.js --e2e --env.devServerTarget my-app:serve:production",
+                    "command": "cypress run --config-file cypress.config.js --e2e --env webServerCommand="my-app:serve:production"",
                   },
                 },
                 "inputs": [
@@ -230,7 +230,7 @@ describe('@nx/cypress/plugin', () => {
               },
               "e2e-ci--test.cy.ts": {
                 "cache": true,
-                "command": "cypress run --config-file cypress.config.js --e2e --env.devServerTarget my-app:serve-static --spec test.cy.ts",
+                "command": "cypress run --config-file cypress.config.js --e2e --env webServerCommand="my-app:serve-static" --spec test.cy.ts",
                 "inputs": [
                   "default",
                   "^production",
@@ -240,6 +240,9 @@ describe('@nx/cypress/plugin', () => {
                     ],
                   },
                 ],
+                "options": {
+                  "cwd": ".",
+                },
                 "outputs": [
                   "{projectRoot}/dist/videos",
                   "{projectRoot}/dist/screenshots",

--- a/packages/cypress/src/plugins/plugin.ts
+++ b/packages/cypress/src/plugins/plugin.ts
@@ -2,6 +2,7 @@ import {
   CreateDependencies,
   CreateNodes,
   CreateNodesContext,
+  detectPackageManager,
   NxJsonConfiguration,
   readJsonFile,
   TargetConfiguration,
@@ -10,7 +11,7 @@ import {
 import { dirname, extname, join, relative } from 'path';
 import { registerTsProject } from '@nx/js/src/internal';
 
-import { getRootTsConfigPath } from '@nx/js';
+import { getLockFileName, getRootTsConfigPath } from '@nx/js';
 
 import { CypressExecutorOptions } from '../executors/cypress/cypress.impl';
 import { readTargetDefaultsForTarget } from 'nx/src/project-graph/utils/project-configuration-utils';
@@ -70,7 +71,9 @@ export const createNodes: CreateNodes<CypressPluginOptions> = [
       return {};
     }
 
-    const hash = calculateHashForCreateNodes(projectRoot, options, context);
+    const hash = calculateHashForCreateNodes(projectRoot, options, context, [
+      getLockFileName(detectPackageManager(context.workspaceRoot)),
+    ]);
 
     const targets = targetsCache[hash]
       ? targetsCache[hash]
@@ -149,7 +152,8 @@ function buildCypressTargets(
     ...cypressConfig.e2e?.env,
   };
 
-  const devServerTargets: Record<string, string> = cypressEnv?.devServerTargets;
+  const webServerCommands: Record<string, string> =
+    cypressEnv?.webServerCommands;
 
   const relativeConfigPath = relative(projectRoot, configFilePath);
 
@@ -187,23 +191,23 @@ function buildCypressTargets(
       );
     }
 
-    if (devServerTargets?.default) {
-      delete devServerTargets.default;
+    if (webServerCommands?.default) {
+      delete webServerCommands.default;
     }
 
-    if (Object.keys(devServerTargets ?? {}).length > 0) {
+    if (Object.keys(webServerCommands ?? {}).length > 0) {
       targets[options.targetName].configurations ??= {};
-      for (const [configuration, devServerTarget] of Object.entries(
-        devServerTargets ?? {}
+      for (const [configuration, webServerCommand] of Object.entries(
+        webServerCommands ?? {}
       )) {
         targets[options.targetName].configurations[configuration] = {
-          command: `cypress run --config-file ${relativeConfigPath} --e2e --env.devServerTarget ${devServerTarget}`,
+          command: `cypress run --config-file ${relativeConfigPath} --e2e --env webServerCommand="${webServerCommand}"`,
         };
       }
     }
 
-    const ciDevServerTarget: string = cypressEnv?.ciDevServerTarget;
-    if (ciDevServerTarget) {
+    const ciWebServerCommand: string = cypressEnv?.ciWebServerCommand;
+    if (ciWebServerCommand) {
       const specPatterns = Array.isArray(cypressConfig.e2e.specPattern)
         ? cypressConfig.e2e.specPattern.map((p) => join(projectRoot, p))
         : [join(projectRoot, cypressConfig.e2e.specPattern)];
@@ -230,7 +234,10 @@ function buildCypressTargets(
           outputs,
           inputs,
           cache: true,
-          command: `cypress run --config-file ${relativeConfigPath} --e2e --env.devServerTarget ${ciDevServerTarget} --spec ${relativeSpecFilePath}`,
+          command: `cypress run --config-file ${relativeConfigPath} --e2e --env webServerCommand="${ciWebServerCommand}" --spec ${relativeSpecFilePath}`,
+          options: {
+            cwd: projectRoot,
+          },
         };
         dependsOn.push({
           target: targetName,

--- a/packages/cypress/src/utils/config.spec.ts
+++ b/packages/cypress/src/utils/config.spec.ts
@@ -156,11 +156,11 @@ export default defineConfig({
 `,
       {
         cypressDir: 'cypress',
-        devServerTargets: {
+        webServerCommands: {
           default: 'my-app:serve',
           production: 'my-app:serve:production',
         },
-        ciDevServerTarget: 'my-app:serve-static',
+        ciWebServerCommand: 'my-app:serve-static',
       },
       undefined
     );
@@ -171,7 +171,7 @@ export default defineConfig({
       import { nxComponentTestingPreset } from '@nx/angular/plugins/component-testing';
 
       export default defineConfig({
-        e2e: { ...nxE2EPreset(__filename, {"cypressDir":"cypress","devServerTargets":{"default":"my-app:serve","production":"my-app:serve:production"},"ciDevServerTarget":"my-app:serve-static"}) }
+        e2e: { ...nxE2EPreset(__filename, {"cypressDir":"cypress","webServerCommands":{"default":"my-app:serve","production":"my-app:serve:production"},"ciWebServerCommand":"my-app:serve-static"}) }
       });
       "
     `);

--- a/packages/devkit/src/utils/calculate-hash-for-create-nodes.ts
+++ b/packages/devkit/src/utils/calculate-hash-for-create-nodes.ts
@@ -6,11 +6,13 @@ const { hashWithWorkspaceContext, hashArray, hashObject } = requireNx();
 export function calculateHashForCreateNodes(
   projectRoot: string,
   options: object,
-  context: CreateNodesContext
+  context: CreateNodesContext,
+  additionalGlobs: string[] = []
 ): string {
   return hashArray([
     hashWithWorkspaceContext(context.workspaceRoot, [
       join(projectRoot, '**/*'),
+      ...additionalGlobs,
     ]),
     hashObject(options),
   ]);

--- a/packages/next/src/generators/application/lib/add-e2e.ts
+++ b/packages/next/src/generators/application/lib/add-e2e.ts
@@ -29,6 +29,7 @@ export async function addE2e(host: Tree, options: NormalizedSchema) {
       directory: 'src',
       skipFormat: true,
       devServerTarget: `${options.projectName}:serve`,
+      baseUrl: 'http://localhost:4200',
       jsx: true,
     });
   } else if (options.e2eTestRunner === 'playwright') {

--- a/packages/nuxt/src/generators/application/lib/add-e2e.ts
+++ b/packages/nuxt/src/generators/application/lib/add-e2e.ts
@@ -30,6 +30,7 @@ export async function addE2e(host: Tree, options: NormalizedSchema) {
       bundler: 'vite',
       skipFormat: true,
       devServerTarget: `${options.projectName}:serve`,
+      baseUrl: 'http://localhost:4200',
       jsx: true,
     });
   } else if (options.e2eTestRunner === 'playwright') {

--- a/packages/react/src/generators/application/lib/add-e2e.ts
+++ b/packages/react/src/generators/application/lib/add-e2e.ts
@@ -42,6 +42,7 @@ export async function addE2e(
         bundler: options.bundler === 'rspack' ? 'webpack' : options.bundler,
         skipFormat: true,
         devServerTarget: `${options.projectName}:serve`,
+        baseUrl: 'http://localhost:4200',
         jsx: true,
         rootProject: options.rootProject,
       });

--- a/packages/vue/src/generators/application/lib/add-e2e.ts
+++ b/packages/vue/src/generators/application/lib/add-e2e.ts
@@ -39,6 +39,7 @@ export async function addE2e(
         bundler: 'vite',
         skipFormat: true,
         devServerTarget: `${options.projectName}:serve`,
+        baseUrl: 'http://localhost:4200',
         jsx: true,
       });
     }

--- a/packages/web/src/generators/application/application.ts
+++ b/packages/web/src/generators/application/application.ts
@@ -296,6 +296,7 @@ export async function applicationGeneratorInternal(host: Tree, schema: Schema) {
       ...options,
       project: options.e2eProjectName,
       devServerTarget: `${options.projectName}:serve`,
+      baseUrl: 'http://localhost:4200',
       directory: 'src',
       skipFormat: true,
     });

--- a/packages/workspace/src/generators/move/move.spec.ts
+++ b/packages/workspace/src/generators/move/move.spec.ts
@@ -214,7 +214,10 @@ describe('move', () => {
       import { defineConfig } from 'cypress';
 
       export default defineConfig({
-        e2e: { ...nxE2EPreset(__filename, { cypressDir: 'src' }) },
+        e2e: {
+          ...nxE2EPreset(__filename, { cypressDir: 'src' }),
+          baseUrl: 'http://localhost:4200',
+        },
       });
       "
     `);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Cypress preset executes an executor for a target. This limits it to being used for nx targets. Also, executors are run directly without ensuring its task dependencies have been run.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Cypress preset executes a command. This allows it to be used for any command. Now if it's an nx command, the task dependencies will be run.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
