### PR TITLE
fix(core): add env variable to skip sorting of the tsconfig.base.json paths

### DIFF
--- a/docs/shared/reference/environment-variables.md
+++ b/docs/shared/reference/environment-variables.md
@@ -26,6 +26,7 @@ The following environment variables are ones that you can set to change the beha
 | NX_PREFER_TS_NODE                | boolean | If set to `true`, Nx will use ts-node for local execution of plugins even if `@swc-node/register` is installed.                                                                                                                        |
 | NX_IGNORE_CYCLES                 | boolean | If set to `true`, Nx will ignore errors created by a task graph circular dependency. Can be overriden on the command line with `--nxIgnoreCycles`                                                                                      |
 | NX_BATCH_MODE                    | boolean | If set to `true`, Nx will run task(s) in batches for executors which support batches.                                                                                                                                                  |
+| NX_FORMAT_SKIP_TSCONFIG          | boolean | If set to `true`, Nx will not sort the paths in the tsconfig.base.json file when doing its formatting.                                                                                                                                 |
 
 Nx will set the following environment variables so they can be accessible within the process even outside of executors and generators.
 

--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -68,6 +68,9 @@ export async function formatFiles(tree: Tree): Promise<void> {
 }
 
 function sortTsConfig(tree: Tree) {
+  if (process.env.NX_FORMAT_SKIP_TSCONFIG === 'true') {
+    return;
+  }
   try {
     const tsConfigPath = getRootTsConfigPath(tree);
     if (!tsConfigPath) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
There are certain libraries that rely on the order of the paths in the tsconfig.base.json. When migrating or running generators, we call `formatFiles` to format all files, and this always sorts the paths in the tsconfig.base.json

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
 running migrations or generators with `NX_FORMAT_SKIP_TSCONFIG` should not sort or touch the tsconfig.base.json file. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20190
