### PR TITLE
fix(core): fix performance regression from using projects for loading…

### DIFF
--- a/packages/nx/src/utils/nx-plugin.ts
+++ b/packages/nx/src/utils/nx-plugin.ts
@@ -254,11 +254,21 @@ export async function loadNxPlugins(
     { plugin: CreatePackageJsonProjectsNextToProjectJson },
   ];
 
-  // When loading plugins for `createNodes`, we don't know what projects exist yet.
-  projects ??= await retrieveProjectConfigurationsWithoutPluginInference(root);
-
   plugins ??= [];
 
+  // When loading plugins for `createNodes`, we don't know what projects exist yet.
+  // Try resolving plugins
+  for (const plugin of plugins) {
+    try {
+      require.resolve(typeof plugin === 'string' ? plugin : plugin.plugin);
+    } catch {
+      // If a plugin cannot be resolved, we will need projects to resolve it
+      projects ??= await retrieveProjectConfigurationsWithoutPluginInference(
+        root
+      );
+      break;
+    }
+  }
   for (const plugin of plugins) {
     result.push(await loadNxPluginAsync(plugin, paths, projects, root));
   }


### PR DESCRIPTION
… plugins

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

We always load projects to resolve plugins.. even when there are no plugins... or all plugins are resolvable without projects.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

We only load projects if there are plugins which are not able to be resolved without projects

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
