### PR TITLE
fix(testing): set TS_NODE_PROJECT before running Jest so j.config.ts file transpile using the root tsconfig file

### DIFF
--- a/packages/jest/src/executors/jest/jest.impl.ts
+++ b/packages/jest/src/executors/jest/jest.impl.ts
@@ -15,6 +15,8 @@ import {
 import { getSummary } from './summary';
 import { readFileSync } from 'fs';
 import type { BatchResults } from 'nx/src/tasks-runner/batch/batch-messages';
+import { getRootTsConfigPath } from '@nx/js';
+
 process.env.NODE_ENV ??= 'test';
 
 export async function jestExecutor(
@@ -22,6 +24,7 @@ export async function jestExecutor(
   context: ExecutorContext
 ): Promise<{ success: boolean }> {
   const config = await jestConfigParser(options, context);
+  process.env['TS_NODE_PROJECT'] ??= getRootTsConfigPath();
 
   const { results } = await runCLI(config, [options.jestConfig]);
 


### PR DESCRIPTION
This PR addresses an issue with `jest.config.ts` file, where custom options in `tsconfig.base.json` file are not used. For example, if `resolveJsonModules: true`  is used.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
`tsconfig.base.json` is not used when transpiling `jest.config.ts` file.

## Expected Behavior
`tsconfig.base.json` is used when transpiling `jest.config.ts` file.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
