### PR TITLE
fix(linter): standalone e2e should not extend root config

### DIFF
--- a/packages/eslint/src/generators/lint-project/lint-project.spec.ts
+++ b/packages/eslint/src/generators/lint-project/lint-project.spec.ts
@@ -9,6 +9,7 @@ import {
 import { Linter } from '../utils/linter';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { lintProjectGenerator } from './lint-project';
+import { eslintVersion } from '../../utils/versions';
 
 describe('@nx/eslint:lint-project', () => {
   let tree: Tree;
@@ -220,5 +221,32 @@ describe('@nx/eslint:lint-project', () => {
     expect(readJson(tree, 'nx.json').pluginsConfig['@nx/js']).toEqual({
       analyzeSourceFiles: true,
     });
+  });
+
+  it('should extend root config', async () => {
+    await lintProjectGenerator(tree, {
+      ...defaultOptions,
+      linter: Linter.EsLint,
+      eslintFilePatterns: ['libs/test-lib/**/*.ts'],
+      project: 'test-lib',
+      setParserOptionsProject: false,
+    });
+
+    const eslintConfig = readJson(tree, 'libs/test-lib/.eslintrc.json');
+    expect(eslintConfig.extends).toBeDefined();
+  });
+
+  it('should not extend root config if rootProject is set', async () => {
+    await lintProjectGenerator(tree, {
+      ...defaultOptions,
+      linter: Linter.EsLint,
+      eslintFilePatterns: ['libs/test-lib/**/*.ts'],
+      project: 'test-lib',
+      setParserOptionsProject: false,
+      rootProject: true,
+    });
+
+    const eslintConfig = readJson(tree, 'libs/test-lib/.eslintrc.json');
+    expect(eslintConfig.extends).toBeUndefined();
   });
 });

--- a/packages/eslint/src/generators/lint-project/lint-project.ts
+++ b/packages/eslint/src/generators/lint-project/lint-project.ts
@@ -113,7 +113,8 @@ export async function lintProjectGenerator(
     createEsLintConfiguration(
       tree,
       projectConfig,
-      options.setParserOptionsProject
+      options.setParserOptionsProject,
+      options.rootProject
     );
   }
 
@@ -142,11 +143,13 @@ export async function lintProjectGenerator(
 function createEsLintConfiguration(
   tree: Tree,
   projectConfig: ProjectConfiguration,
-  setParserOptionsProject: boolean
+  setParserOptionsProject: boolean,
+  rootProject: boolean
 ) {
-  const eslintConfig = findEslintFile(tree);
-  const pathToRootConfig = eslintConfig
-    ? `${offsetFromRoot(projectConfig.root)}${eslintConfig}`
+  // we are only extending root for non-standalone projects or their complementary e2e apps
+  const extendedRootConfig = rootProject ? undefined : findEslintFile(tree);
+  const pathToRootConfig = extendedRootConfig
+    ? `${offsetFromRoot(projectConfig.root)}${extendedRootConfig}`
     : undefined;
   const addDependencyChecks = isBuildableLibraryProject(projectConfig);
 
@@ -201,7 +204,7 @@ function createEsLintConfiguration(
     const isCompatNeeded = addDependencyChecks;
     const nodes = [];
     const importMap = new Map();
-    if (eslintConfig) {
+    if (extendedRootConfig) {
       importMap.set(pathToRootConfig, 'baseConfig');
       nodes.push(generateSpreadElement('baseConfig'));
     }
@@ -213,7 +216,7 @@ function createEsLintConfiguration(
     tree.write(join(projectConfig.root, 'eslint.config.js'), content);
   } else {
     writeJson(tree, join(projectConfig.root, `.eslintrc.json`), {
-      extends: eslintConfig ? [pathToRootConfig] : undefined,
+      extends: extendedRootConfig ? [pathToRootConfig] : undefined,
       // Include project files to be linted since the global one excludes all files.
       ignorePatterns: ['!**/*'],
       overrides,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Due to a bug, accompanying e2e project gets generated with eslint config extending the root one.

## Expected Behavior
The accompanying e2e project's eslint config for standalone apps should not extends the root config before the migration.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
