### PR TITLE
chore(testing): disable flaky watch e2e in esbuild

### DIFF
--- a/e2e/esbuild/src/esbuild.test.ts
+++ b/e2e/esbuild/src/esbuild.test.ts
@@ -94,27 +94,28 @@ describe('EsBuild Plugin', () => {
     `
     );
 
+    // TODO: Investigate why these assertions are flaky in CI
     /* Test that watch mode copies assets on start, and again on update.
      */
-    updateFile(`libs/${myPkg}/assets/a.md`, 'initial a');
-    const watchProcess = await runCommandUntil(
-      `build ${myPkg} --watch`,
-      (output) => {
-        return output.includes('watching for changes');
-      }
-    );
-    readFile(`dist/libs/${myPkg}/assets/a.md`).includes('initial a');
-    updateFile(`libs/${myPkg}/assets/a.md`, 'updated a');
-    await expect(
-      waitUntil(
-        () => readFile(`dist/libs/${myPkg}/assets/a.md`).includes('updated a'),
-        {
-          timeout: 20_000,
-          ms: 500,
-        }
-      )
-    ).resolves.not.toThrow();
-    watchProcess.kill();
+    // updateFile(`libs/${myPkg}/assets/a.md`, 'initial a');
+    // const watchProcess = await runCommandUntil(
+    //   `build ${myPkg} --watch`,
+    //   (output) => {
+    //     return output.includes('watching for changes');
+    //   }
+    // );
+    // readFile(`dist/libs/${myPkg}/assets/a.md`).includes('initial a');
+    // updateFile(`libs/${myPkg}/assets/a.md`, 'updated a');
+    // await expect(
+    //   waitUntil(
+    //     () => readFile(`dist/libs/${myPkg}/assets/a.md`).includes('updated a'),
+    //     {
+    //       timeout: 20_000,
+    //       ms: 500,
+    //     }
+    //   )
+    // ).resolves.not.toThrow();
+    // watchProcess.kill();
   }, 300_000);
 
   it('should support bundling everything or only workspace libs', async () => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
