### PR TITLE
chore(repo): bump jest timeout to mitigate against flaky unit tests

### DIFF
--- a/jest.preset.js
+++ b/jest.preset.js
@@ -2,7 +2,7 @@ const nxPreset = require('@nx/jest/preset').default;
 
 module.exports = {
   ...nxPreset,
-  testTimeout: 30000,
+  testTimeout: 35000,
   testMatch: ['**/+(*.)+(spec|test).+(ts|js)?(x)'],
   transform: {
     '^.+\\.(ts|js|html)$': 'ts-jest',


### PR DESCRIPTION
Some of the unit tests seem to be flaky due to machines being slower than expected. This PR changes the default jest timeout from 30s to 35s, which seems to be enough to make most tests pass.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
