### PR TITLE
chore(repo): disable freebsd support for beta releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -158,9 +158,11 @@ jobs:
      timeout-minutes: 45
      steps:
        - uses: actions/checkout@v3
+         if: ${{ !contains(github.ref, '-') }}
        - name: Build
          id: build
-         uses: cross-platform-actions/action@v0.21.0
+         if: ${{ !contains(github.ref, '-') }}
+         uses: cross-platform-actions/action@v0.21.1
          env:
            DEBUG: napi:*
            RUSTUP_IO_THREADS: 1
@@ -197,9 +199,10 @@ jobs:
              rm -rf node_modules
              rm -rf dist
              echo "KILL ALL NODE PROCESSES"
-             killall node
+             killall node || true
              echo "COMPLETE"
        - name: Upload artifact
+         if: ${{ !contains(github.ref, '-') }}
          uses: actions/upload-artifact@v3
          with:
            name: bindings-freebsd


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

FreeBSD fails literally 80% of the time and it's hampering productivity.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Non-stable versions will not have support for FreeBSD. Stable versions will still have support for FreeBSD

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
