### PR TITLE
docs(nextjs): fix plugin docs for Sentry

### DIFF
--- a/docs/shared/packages/next/next-config-setup.md
+++ b/docs/shared/packages/next/next-config-setup.md
@@ -125,7 +125,8 @@ module.exports = async (phase, context) => {
 
   // If you have plugins that has to be added after Nx you can do that here.
   // For example, Sentry needs to be added last.
-  updatedConfig = require('@sentry/nextjs')(updatedConfig, { silent: true });
+  const { withSentryConfig } = require('@sentry/nextjs');
+  updatedConfig = withSentryConfig(updatedConfig);
 
   return updatedConfig;
 };


### PR DESCRIPTION
update and fix #19338 to rebase to latest master + update commit msg
(wasn't able to force push to that PR, maybe author disabled contributing commits)