### PR TITLE
fix(react): remote url port depends on serve target

### DIFF
--- a/packages/react/src/generators/remote/lib/setup-ssr-for-remote.ts
+++ b/packages/react/src/generators/remote/lib/setup-ssr-for-remote.ts
@@ -43,7 +43,7 @@ export async function setupSsrForRemote(
   const serverOutputPath =
     serverOptions?.outputPath ??
     joinPathFragments(originalOutputPath, 'server');
-  const serverOutputName = serverOptions?.outputName ?? 'main.js';
+  const serverOutputName = serverOptions?.outputFileName ?? 'main.js';
   project.targets['serve-static'] = {
     dependsOn: ['build', 'server'],
     executor: 'nx:run-commands',

--- a/packages/react/src/module-federation/utils.ts
+++ b/packages/react/src/module-federation/utils.ts
@@ -17,7 +17,7 @@ import {
 import { readCachedProjectConfiguration } from 'nx/src/project-graph/project-graph';
 
 export function getFunctionDeterminateRemoteUrl(isServer: boolean = false) {
-  const target = isServer ? 'serve-server' : 'serve';
+  const target = 'serve';
   const remoteEntry = isServer ? 'server/remoteEntry.js' : 'remoteEntry.js';
 
   return function (remote: string) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
with multiple remotes, the remote url always return port 4201

when serve with ssr, it runs serve target on the remote rather than 'serve-server' : https://github.com/nrwl/nx/blob/0df8293c912ba5a87dfda30be2b463ceef1294d0/packages/react/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts#L130

so the port of the remote url should be taken on the serve target options

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
