### PR TITLE
fix(module-federation): fix static remote port determination

### DIFF
--- a/packages/angular/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/angular/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -125,6 +125,8 @@ export default async function* moduleFederationDevServerExecutor(
         context.projectGraph.nodes[r].data.targets['serve'].options.port;
       if (remotePort >= portToUse) {
         return remotePort + 1;
+      } else {
+        return portToUse;
       }
     }, options.staticRemotesPort);
   }

--- a/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -253,6 +253,8 @@ export default async function* moduleFederationDevServer(
         context.projectGraph.nodes[r].data.targets['serve'].options.port;
       if (remotePort >= portToUse) {
         return remotePort + 1;
+      } else {
+        return portToUse;
       }
     }, options.staticRemotesPort);
   }


### PR DESCRIPTION
## Current Behavior
If a staticRemotesPort is not passed in to the module federation dev server and a remote's port is less than the default staticRemotesPort, undefined is return and module federation dev server fails to start

## Expected Behavior
Module federation dev server starts with a calculated staticRemotesPort if it is not passed

