### PR TITLE
fix(core): handle local plugin executors when trying to hash targets

### DIFF
--- a/packages/nx/src/native/tasks/hash_planner.rs
+++ b/packages/nx/src/native/tasks/hash_planner.rs
@@ -138,9 +138,13 @@ impl HashPlanner {
                 .split(':')
                 .next()
                 .expect("Executors should always have a ':'");
-            let existing_package =
+            let Some(existing_package) =
                 find_external_dependency_node_name(executor_package, &external_nodes_keys)
-                    .unwrap_or(executor_package);
+            else {
+                // this usually happens because the executor was a local plugin.
+                // todo)) @Cammisuli: we need to gather the project's inputs and its dep inputs similar to how we do it in `self_and_deps_inputs`
+                return Ok(None);
+            };
             Ok(Some(vec![HashInstruction::External(
                 existing_package.to_string(),
             )]))

--- a/packages/nx/src/native/tasks/task_hasher.rs
+++ b/packages/nx/src/native/tasks/task_hasher.rs
@@ -82,8 +82,8 @@ impl TaskHasher {
         hash_plans: External<HashMap<String, Vec<HashInstruction>>>,
         js_env: HashMap<String, String>,
     ) -> anyhow::Result<NapiDashMap<String, HashDetails>> {
-        debug!("{:?}", hash_plans.as_ref());
-        trace!("hash_plans: {}", hash_plans.len());
+        debug!("hashing plans {:?}", hash_plans.as_ref());
+        trace!("plan length: {}", hash_plans.len());
         trace!("all workspace files: {}", self.all_workspace_files.len());
         trace!("project_file_map: {}", self.project_file_map.len());
 
@@ -103,7 +103,7 @@ impl TaskHasher {
 
         let hashes: NapiDashMap<String, HashDetails> = NapiDashMap::new();
 
-        let _ = hash_plans
+        hash_plans
             .iter()
             .flat_map(|(task_id, instructions)| {
                 instructions
@@ -133,7 +133,7 @@ impl TaskHasher {
 
                 entry.details.insert(hash_detail.0, hash_detail.1);
                 Ok::<(), anyhow::Error>(())
-            });
+            })?;
 
         hashes.iter_mut().for_each(|mut h| {
             let hash_details = h.value_mut();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When there's a local plugin thats used as an executor, we incorrectly mark it as a "External" dep in the hash planner

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Local plugin executors are skipped. We will handle this better in the future where we can gather the inputs of the local plugin and set all the instructions properly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
