### PR TITLE
feat(core): add env parameter to run-commands

### DIFF
--- a/docs/generated/packages/nx/executors/run-commands.json
+++ b/docs/generated/packages/nx/executors/run-commands.json
@@ -107,6 +107,11 @@
         "type": "string",
         "description": "Current working directory of the commands. If it's not specified the commands will run in the workspace root, if a relative path is specified the commands will run in that path relative to the workspace root and if it's an absolute path the commands will run in that path."
       },
+      "env": {
+        "type": "object",
+        "description": "Environment variables that will be made available to the commands.",
+        "additionalProperties": { "type": "string" }
+      },
       "__unparsed__": {
         "hidden": true,
         "type": "array",

--- a/docs/generated/packages/nx/executors/run-commands.json
+++ b/docs/generated/packages/nx/executors/run-commands.json
@@ -109,7 +109,7 @@
       },
       "env": {
         "type": "object",
-        "description": "Environment variables that will be made available to the commands.",
+        "description": "Environment variables that will be made available to the commands. This property has priority over the `.env` files.",
         "additionalProperties": { "type": "string" }
       },
       "__unparsed__": {

--- a/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
@@ -402,6 +402,11 @@ describe('Run Commands', () => {
   });
 
   describe('env', () => {
+    afterAll(() => {
+      delete process.env.MY_ENV_VAR;
+      unlinkSync('.env');
+    });
+
     it('should add the env to the command', async () => {
       const root = dirSync().name;
       const f = fileSync().name;
@@ -423,6 +428,29 @@ describe('Run Commands', () => {
 
       expect(result).toEqual(expect.objectContaining({ success: true }));
       expect(readFile(f)).toEqual('my-value');
+    });
+    it('should prioritize env setting over local dotenv files', async () => {
+      writeFileSync('.env', 'MY_ENV_VAR=from-dotenv');
+      const root = dirSync().name;
+      const f = fileSync().name;
+      const result = await runCommands(
+        {
+          commands: [
+            {
+              command: `echo "$MY_ENV_VAR" >> ${f}`,
+            },
+          ],
+          env: {
+            MY_ENV_VAR: 'from-options',
+          },
+          parallel: true,
+          __unparsed__: [],
+        },
+        { root } as any
+      );
+
+      expect(result).toEqual(expect.objectContaining({ success: true }));
+      expect(readFile(f)).toEqual('from-options');
     });
   });
 

--- a/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
@@ -401,6 +401,31 @@ describe('Run Commands', () => {
     });
   });
 
+  describe('env', () => {
+    it('should add the env to the command', async () => {
+      const root = dirSync().name;
+      const f = fileSync().name;
+      const result = await runCommands(
+        {
+          commands: [
+            {
+              command: `echo "$MY_ENV_VAR" >> ${f}`,
+            },
+          ],
+          env: {
+            MY_ENV_VAR: 'my-value',
+          },
+          parallel: true,
+          __unparsed__: [],
+        },
+        { root } as any
+      );
+
+      expect(result).toEqual(expect.objectContaining({ success: true }));
+      expect(readFile(f)).toEqual('my-value');
+    });
+  });
+
   describe('dotenv', () => {
     beforeAll(() => {
       writeFileSync('.env', 'NRWL_SITE=https://nrwl.io/');

--- a/packages/nx/src/executors/run-commands/schema.json
+++ b/packages/nx/src/executors/run-commands/schema.json
@@ -115,6 +115,13 @@
       "type": "string",
       "description": "Current working directory of the commands. If it's not specified the commands will run in the workspace root, if a relative path is specified the commands will run in that path relative to the workspace root and if it's an absolute path the commands will run in that path."
     },
+    "env": {
+      "type": "object",
+      "description": "Environment variables that will be made available to the commands.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
     "__unparsed__": {
       "hidden": true,
       "type": "array",

--- a/packages/nx/src/executors/run-commands/schema.json
+++ b/packages/nx/src/executors/run-commands/schema.json
@@ -117,7 +117,7 @@
     },
     "env": {
       "type": "object",
-      "description": "Environment variables that will be made available to the commands.",
+      "description": "Environment variables that will be made available to the commands. This property has priority over the `.env` files.",
       "additionalProperties": {
         "type": "string"
       }


### PR DESCRIPTION
This PR adds `env` field to `run-commands` executor.

This modification is necessary for supporting `eslint` in v3 config

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
