### PR TITLE
fix(core): programmatic release API should throw on error

### DIFF
--- a/packages/nx/src/command-line/release/command-object.ts
+++ b/packages/nx/src/command-line/release/command-object.ts
@@ -144,7 +144,7 @@ const versionCommand: CommandModule<NxReleaseArgs, VersionOptions> = {
     ),
   handler: (args) =>
     import('./version')
-      .then((m) => m.releaseVersion(args))
+      .then((m) => m.releaseVersionCLIHandler(args))
       .then((versionDataOrExitCode) => {
         if (typeof versionDataOrExitCode === 'number') {
           return process.exit(versionDataOrExitCode);
@@ -201,7 +201,9 @@ const changelogCommand: CommandModule<NxReleaseArgs, ChangelogOptions> = {
         })
     ),
   handler: async (args) => {
-    const status = await (await import('./changelog')).releaseChangelog(args);
+    const status = await (
+      await import('./changelog')
+    ).releaseChangelogCLIHandler(args);
     process.exit(status);
   },
 };
@@ -227,7 +229,7 @@ const publishCommand: CommandModule<NxReleaseArgs, PublishOptions> = {
       }),
   handler: (args) =>
     import('./publish').then((m) =>
-      m.releasePublish(coerceParallelOption(withOverrides(args, 2)))
+      m.releasePublishCLIHandler(coerceParallelOption(withOverrides(args, 2)))
     ),
 };
 

--- a/packages/nx/src/command-line/release/config/config.spec.ts
+++ b/packages/nx/src/command-line/release/config/config.spec.ts
@@ -977,6 +977,98 @@ describe('createNxReleaseConfig()', () => {
         }
       `);
     });
+
+    it('should respect top level releaseTagPatterns for fixed groups without explicit settings of their own', async () => {
+      const res = await createNxReleaseConfig(projectGraph, {
+        releaseTagPattern: '{version}',
+        groups: {
+          npm: {
+            projects: ['nx'],
+            version: {
+              generatorOptions: {
+                currentVersionResolver: 'git-tag',
+                specifierSource: 'conventional-commits',
+              },
+            },
+            changelog: true,
+          },
+        },
+      });
+      expect(res).toMatchInlineSnapshot(`
+        {
+          "error": null,
+          "nxReleaseConfig": {
+            "changelog": {
+              "git": {
+                "commit": false,
+                "commitArgs": "",
+                "commitMessage": "",
+                "tag": false,
+                "tagArgs": "",
+                "tagMessage": "",
+              },
+              "projectChangelogs": false,
+              "workspaceChangelog": {
+                "createRelease": false,
+                "entryWhenNoChanges": "This was a version bump only, there were no code changes.",
+                "file": "{workspaceRoot}/CHANGELOG.md",
+                "renderOptions": {
+                  "includeAuthors": true,
+                },
+                "renderer": "nx/changelog-renderer",
+              },
+            },
+            "git": {
+              "commit": false,
+              "commitArgs": "",
+              "commitMessage": "",
+              "tag": false,
+              "tagArgs": "",
+              "tagMessage": "",
+            },
+            "groups": {
+              "npm": {
+                "changelog": {
+                  "createRelease": false,
+                  "entryWhenNoChanges": "This was a version bump only for {projectName} to align it with other projects, there were no code changes.",
+                  "file": "{projectRoot}/CHANGELOG.md",
+                  "renderOptions": {
+                    "includeAuthors": true,
+                  },
+                  "renderer": "nx/changelog-renderer",
+                },
+                "projects": [
+                  "nx",
+                ],
+                "projectsRelationship": "fixed",
+                "releaseTagPattern": "{version}",
+                "version": {
+                  "generator": "@nx/js:release-version",
+                  "generatorOptions": {
+                    "currentVersionResolver": "git-tag",
+                    "specifierSource": "conventional-commits",
+                  },
+                },
+              },
+            },
+            "projectsRelationship": "fixed",
+            "releaseTagPattern": "{version}",
+            "version": {
+              "generator": "@nx/js:release-version",
+              "generatorOptions": {},
+              "git": {
+                "commit": false,
+                "commitArgs": "",
+                "commitMessage": "",
+                "tag": false,
+                "tagArgs": "",
+                "tagMessage": "",
+              },
+            },
+          },
+        }
+      `);
+    });
   });
 
   describe('user config -> top level changelog', () => {

--- a/packages/nx/src/command-line/release/config/config.ts
+++ b/packages/nx/src/command-line/release/config/config.ts
@@ -354,7 +354,7 @@ export async function createNxReleaseConfig(
         // The appropriate group default releaseTagPattern is dependent upon the projectRelationships
         (projectsRelationship === 'independent'
           ? defaultIndependentReleaseTagPattern
-          : defaultFixedReleaseTagPattern),
+          : userConfig.releaseTagPattern || defaultFixedReleaseTagPattern),
     };
 
     releaseGroups[releaseGroupName] = deepMergeDefaults([groupDefaults], {

--- a/packages/nx/src/command-line/release/publish.ts
+++ b/packages/nx/src/command-line/release/publish.ts
@@ -19,9 +19,13 @@ import {
 } from './config/config';
 import { filterReleaseGroups } from './config/filter-release-groups';
 
+export const releasePublishCLIHandler = (args: PublishOptions) =>
+  releasePublish(args);
+
 /**
  * NOTE: This function is also exported for programmatic usage and forms part of the public API
- * of Nx.
+ * of Nx. We intentionally do not wrap the implementation with handleErrors because users need
+ * to have control over their own error handling when using the API.
  */
 export async function releasePublish(args: PublishOptions): Promise<void> {
   /**


### PR DESCRIPTION
**NOTE TO REVIEWERS: The diff looks bigger than it is because removing `handeErrors` causes indentation changes, best to view with whitespace hidden: https://github.com/nrwl/nx/pull/20448/files?diff=unified&w=1**

---

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The functions were originally written as CLI command handlers and still behave too much like that when it comes to error handling. Consumers of the programmatic API do not get to use try/catch how they would expect to and do not get access to the raw errors.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Consumers of the programmatic API can use try/catch how they would expect to and get full access to the raw errors thrown by the command implementations.

---

- NOTE: Additionally fixed one config issue I found
