### PR TITLE
fix(core): remove v8-compile-cache

### DIFF
--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -53,25 +53,6 @@ function main() {
     process.env.NX_DAEMON = 'false';
     require('nx/src/command-line/nx-commands').commandsObject.argv;
   } else {
-    // v8-compile-cache doesn't support ESM. Attempting to import ESM
-    // with it enabled results in an error that reads "Invalid host options".
-    //
-    // Angular CLI, and prettier both use ESM so we need to disable it in these cases.
-    if (
-      workspace &&
-      workspace.type === 'nx' &&
-      ![
-        'format',
-        'format:check',
-        'format:write',
-        'g',
-        'generate',
-        'release',
-      ].some((cmd) => process.argv[2] === cmd)
-    ) {
-      require('v8-compile-cache');
-    }
-
     if (!daemonClient.enabled() && workspace !== null) {
       setupWorkspaceContext(workspace.dir);
     }

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -63,7 +63,6 @@
     "tmp": "~0.2.1",
     "tsconfig-paths": "^4.1.2",
     "tslib": "^2.3.0",
-    "v8-compile-cache": "2.3.0",
     "yargs": "^17.6.2",
     "yargs-parser": "21.1.1",
     "node-machine-id": "1.1.12"


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`v8-compile-cache` causes issues when ESM modules are loaded.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`v8-compile-cache` is removed.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
