### PR TITLE
fix(core): fix handling of globs with {,.snap}

### DIFF
--- a/packages/nx/src/native/glob.rs
+++ b/packages/nx/src/native/glob.rs
@@ -92,7 +92,8 @@ pub(crate) fn build_glob_set<S: AsRef<str> + Debug>(globs: &[S]) -> anyhow::Resu
         .iter()
         .flat_map(|s| potential_glob_split(s.as_ref()))
         .map(|glob| {
-            if glob.contains('!') || glob.contains('|') || glob.contains('(') {
+            if glob.contains('!') || glob.contains('|') || glob.contains('(') || glob.contains("{,")
+            {
                 convert_glob(glob)
             } else {
                 Ok(vec![glob.to_string()])
@@ -226,6 +227,13 @@ mod test {
         assert!(!glob_set.is_match("dist/file.js"));
         assert!(!glob_set.is_match("dist/cache/"));
         assert!(!glob_set.is_match("dist/main/"));
+
+        let glob_set = build_glob_set(&["**/*.spec.ts{,.snap}"]).unwrap();
+        // matches
+        assert!(glob_set.is_match("src/file.spec.ts"));
+        assert!(glob_set.is_match("src/file.spec.ts.snap"));
+        // no matches
+        assert!(!glob_set.is_match("src/file.ts"));
     }
 
     #[test]


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Inputs such as this:
```
{projectRoot}/**/*.spec.ts{,.snap}
```

cause an error:

```
 >  NX   error parsing glob 'libs/nx-packages/client-bundle/**/*.spec.ts{': unclosed alternate group; missing '}' (maybe escape '{' with '[{]'?)


Error: error parsing glob 'libs/nx-packages/client-bundle/**/*.spec.ts{': unclosed alternate group; missing '}' (maybe escape '{' with '[{]'?)
    at NativeTaskHasherImpl.hashTasks (/home/vsts/work/1/s/node_modules/nx/src/hasher/native-task-hasher-impl.js:31:36)
    at InProcessTaskHasher.hashTasks (/home/vsts/work/1/s/node_modules/nx/src/hasher/task-hasher.js:53:50)
    at hashTasksThatDoNotDependOnOutputsOfOtherTasks (/home/vsts/work/1/s/node_modules/nx/src/hasher/hash-task.js:25:33)
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Globs like the above are handled properly.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
