### PR TITLE
fix(core): handle filesets with commas

### DIFF
--- a/packages/nx/src/native/tasks/hash_planner.rs
+++ b/packages/nx/src/native/tasks/hash_planner.rs
@@ -387,7 +387,10 @@ fn find_external_dependency_node_name<'a>(
 
 fn project_file_set_inputs(project_name: &str, file_sets: Vec<&str>) -> Vec<HashInstruction> {
     vec![
-        HashInstruction::ProjectFileSet(project_name.to_string(), file_sets.join(",")),
+        HashInstruction::ProjectFileSet(
+            project_name.to_string(),
+            file_sets.iter().map(|f| f.to_string()).collect(),
+        ),
         HashInstruction::ProjectConfiguration(project_name.to_string()),
         HashInstruction::TsConfiguration(project_name.to_string()),
     ]

--- a/packages/nx/src/native/tasks/hashers/hash_project_files.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_project_files.rs
@@ -9,7 +9,7 @@ use crate::native::types::FileData;
 pub fn hash_project_files(
     project_name: &str,
     project_root: &str,
-    file_sets: &str,
+    file_sets: &[String],
     project_file_map: &HashMap<String, Vec<FileData>>,
 ) -> Result<String> {
     let collected_files = collect_files(project_name, project_root, file_sets, project_file_map)?;
@@ -24,11 +24,11 @@ pub fn hash_project_files(
 fn collect_files<'a>(
     project_name: &str,
     project_root: &str,
-    file_sets: &str,
+    file_sets: &[String],
     project_file_map: &'a HashMap<String, Vec<FileData>>,
 ) -> Result<Vec<&'a FileData>> {
     let globs = file_sets
-        .split(',')
+        .iter()
         .map(|f| f.replace("{projectRoot}", project_root))
         .collect::<Vec<_>>();
     let now = std::time::Instant::now();
@@ -59,7 +59,10 @@ mod tests {
     fn test_collect_files() {
         let proj_name = "test_project";
         let proj_root = "test/root";
-        let file_sets = "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap),{projectRoot}/**/*";
+        let file_sets = &[
+            "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)".to_string(),
+            "{projectRoot}/**/*".to_string(),
+        ];
         let mut file_map = HashMap::new();
         let tsfile_1 = FileData {
             file: "test/root/test1.ts".into(),
@@ -94,7 +97,7 @@ mod tests {
         let result = collect_files(
             proj_name,
             proj_root,
-            "!{projectRoot}/**/*.spec.ts",
+            &["!{projectRoot}/**/*.spec.ts".into()],
             &file_map,
         )
         .unwrap();
@@ -112,7 +115,10 @@ mod tests {
     fn should_hash_deterministically() {
         let proj_name = "test_project";
         let proj_root = "test/root";
-        let file_sets = "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap),{projectRoot}/**/*";
+        let file_sets = &[
+            "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)".to_string(),
+            "{projectRoot}/**/*".to_string(),
+        ];
         let mut file_map = HashMap::new();
         let file_data1 = FileData {
             file: "test/root/test1.ts".into(),

--- a/packages/nx/src/native/tasks/task_hasher.rs
+++ b/packages/nx/src/native/tasks/task_hasher.rs
@@ -190,7 +190,7 @@ impl TaskHasher {
                 trace!(parent: &span, "hash_env: {:?}", now.elapsed());
                 hashed_env
             }
-            HashInstruction::ProjectFileSet(project_name, file_set) => {
+            HashInstruction::ProjectFileSet(project_name, file_sets) => {
                 let project = self
                     .project_graph
                     .nodes
@@ -199,7 +199,7 @@ impl TaskHasher {
                 let hashed_project_files = hash_project_files(
                     project_name,
                     &project.root,
-                    file_set,
+                    file_sets,
                     &self.project_file_map,
                 )?;
                 trace!(parent: &span, "hash_project_files: {:?}", now.elapsed());

--- a/packages/nx/src/native/tasks/types.rs
+++ b/packages/nx/src/native/tasks/types.rs
@@ -35,7 +35,7 @@ pub enum HashInstruction {
     WorkspaceFileSet(String),
     Runtime(String),
     Environment(String),
-    ProjectFileSet(String, String),
+    ProjectFileSet(String, Vec<String>),
     ProjectConfiguration(String),
     TsConfiguration(String),
     TaskOutput(String, Vec<String>),
@@ -71,7 +71,7 @@ impl fmt::Display for HashInstruction {
             match self {
                 HashInstruction::AllExternalDependencies => "AllExternalDependencies".to_string(),
                 HashInstruction::ProjectFileSet(project_name, file_set) => {
-                    format!("{project_name}:{file_set}")
+                    format!("{project_name}:{}", file_set.join(","))
                 }
                 HashInstruction::WorkspaceFileSet(file_set) => file_set.to_string(),
                 HashInstruction::Runtime(runtime) => format!("runtime:{}", runtime),


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Inputs such as `{projectRoot}/**/*.spec.ts{,.snap}` are split incorrectly.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Filesets are passed as a Vec of string, so they don't need to be joined and splitted.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
