### PR TITLE
fix(core): update changelog schema

### DIFF
--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -146,8 +146,7 @@
                     "$ref": "#/definitions/NxReleaseChangelogConfiguration"
                   },
                   {
-                    "type": "boolean",
-                    "enum": [false]
+                    "type": "boolean"
                   }
                 ]
               },
@@ -167,8 +166,7 @@
                   "$ref": "#/definitions/NxReleaseChangelogConfiguration"
                 },
                 {
-                  "type": "boolean",
-                  "enum": [false]
+                  "type": "boolean"
                 }
               ]
             },
@@ -178,8 +176,7 @@
                   "$ref": "#/definitions/NxReleaseChangelogConfiguration"
                 },
                 {
-                  "type": "boolean",
-                  "enum": [false]
+                  "type": "boolean"
                 }
               ]
             }


### PR DESCRIPTION
Was accidentally missed when allowing `true` shorthand so users get an erroneous warning in nx.json if they use it right now