### PR TITLE
fix(webpack): Fixed libraryTarget option not being set for node targets

### DIFF
--- a/e2e/node/src/node-webpack.test.ts
+++ b/e2e/node/src/node-webpack.test.ts
@@ -52,7 +52,7 @@ describe('Node Applications + webpack', () => {
 
     await runCLIAsync(`build ${app} --optimization`);
     const optimizedContent = readFile(`dist/apps/${app}/main.js`);
-    expect(optimizedContent).toContain('console.log("foo bar")');
+    expect(optimizedContent).toContain('console.log("foo "+"bar")');
 
     // Test that serve can re-run dependency builds.
     const lib = uniq('nodelib');

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
@@ -95,6 +95,11 @@ function applyNxIndependentConfig(
 
   config.output = {
     ...config.output,
+    libraryTarget:
+      (config as Configuration).output?.libraryTarget ??
+      options.target === 'node'
+        ? 'commonjs'
+        : undefined,
     path:
       config.output?.path ??
       (options.outputPath


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When #19984 got merged it changed the implementation of Webpack.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
For node projects to compile like they always did.

## Related Issue(s)
Fixes #20349
Fixes TriPSs/nx-extend#182
