### PR TITLE
fix(misc): add args to command in run-commands before unparsed args

### DIFF
--- a/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
@@ -180,6 +180,29 @@ describe('Run Commands', () => {
       ).toEqual('echo one -a=b');
     });
 
+    it('should add all args when forwardAllArgs is true', () => {
+      expect(
+        interpolateArgsIntoCommand(
+          'echo',
+          { args: '--additional-arg', __unparsed__: [] } as any,
+          true
+        )
+      ).toEqual('echo --additional-arg');
+    });
+
+    it('should add all args and unparsed args when forwardAllArgs is true', () => {
+      expect(
+        interpolateArgsIntoCommand(
+          'echo',
+          {
+            args: '--additional-arg',
+            __unparsed__: ['--additional-unparsed-arg'],
+          } as any,
+          true
+        )
+      ).toEqual('echo --additional-arg --additional-unparsed-arg');
+    });
+
     it("shouldn't add literal `undefined` if arg is not provided", () => {
       expect(
         interpolateArgsIntoCommand(

--- a/packages/nx/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.ts
@@ -296,7 +296,10 @@ function processEnv(color: boolean, cwd: string, env: Record<string, string>) {
 
 export function interpolateArgsIntoCommand(
   command: string,
-  opts: Pick<NormalizedRunCommandsOptions, 'parsedArgs' | '__unparsed__'>,
+  opts: Pick<
+    NormalizedRunCommandsOptions,
+    'args' | 'parsedArgs' | '__unparsed__'
+  >,
   forwardAllArgs: boolean
 ) {
   if (command.indexOf('{args.') > -1) {
@@ -305,7 +308,7 @@ export function interpolateArgsIntoCommand(
       opts.parsedArgs[group] !== undefined ? opts.parsedArgs[group] : ''
     );
   } else if (forwardAllArgs) {
-    return `${command}${
+    return `${command}${opts.args ? ' ' + opts.args : ''}${
       opts.__unparsed__.length > 0 ? ' ' + opts.__unparsed__.join(' ') : ''
     }`;
   } else {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When `run-commands` is configured like the following:

```
{
  command: 'echo',
  options: {
    'args': 'Hello World'
  }
}
```

The resulting command which is run does not have the args.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When `run-commands` is configured like the following:

```
{
  command: 'echo',
  options: {
    'args': 'Hello World'
  }
}
```

The resulting command which is run does have the args.

The user can still pass additional args after that as well

`nx echo Jason` when the config is:

```
{
  command: 'echo',
  options: {
    args: 'Hello'
  }
}
```

Will run `echo Hello Jason`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
