### PR TITLE
feat(web): support buildTarget that excludes project name

### DIFF
--- a/e2e/web/src/file-server.test.ts
+++ b/e2e/web/src/file-server.test.ts
@@ -25,6 +25,8 @@ describe('file-server', () => {
     setMaxWorkers(join('apps', appName, 'project.json'));
     updateJson(join('apps', appName, 'project.json'), (config) => {
       config.targets['serve'].executor = '@nx/web:file-server';
+      // Check that buildTarget can exclude project name (e.g. build vs proj:build).
+      config.targets['serve'].options.buildTarget = 'build';
       return config;
     });
 

--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -52,8 +52,16 @@ function getHttpServerArgs(options: Schema) {
   return args;
 }
 
-function getBuildTargetCommand(options: Schema) {
-  const cmd = ['nx', 'run', options.buildTarget];
+function getBuildTargetCommand(options: Schema, context: ExecutorContext) {
+  const target = parseTargetString(options.buildTarget, context);
+  const cmd = ['nx', 'run'];
+
+  if (target.configuration) {
+    cmd.push(`${target.project}:${target.target}:${target.configuration}`);
+  } else {
+    cmd.push(`${target.project}:${target.target}`);
+  }
+
   if (options.parallel) {
     cmd.push(`--parallel`);
   }
@@ -131,7 +139,7 @@ export default async function* fileServerExecutor(
       if (!running) {
         running = true;
         try {
-          const args = getBuildTargetCommand(options);
+          const args = getBuildTargetCommand(options, context);
           execFileSync(pmCmd, args, {
             stdio: [0, 1, 2],
           });


### PR DESCRIPTION
This PR allows use to define `file-server` target as follows:

```json5
executor: "@nx/web:file-server",
options: {
  buildTarget: 'build'
}
```
Previously, we had to provide the project name like `<proj>:build` or else this executor won't work.

## Current Behavior
Project name is required

## Expected Behavior
Project name is optional

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
