### PR TITLE
fix(web): file-server falls back to outputs if outputPath is not preset

### DIFF
--- a/e2e/web/src/file-server.test.ts
+++ b/e2e/web/src/file-server.test.ts
@@ -7,6 +7,7 @@ import {
   runCommandUntil,
   setMaxWorkers,
   uniq,
+  updateFile,
   updateJson,
 } from '@nx/e2e/utils';
 import { join } from 'path';
@@ -34,6 +35,55 @@ describe('file-server', () => {
       `serve ${appName} --port=${port}`,
       (output) => {
         return output.indexOf(`localhost:${port}`) > -1;
+      }
+    );
+
+    try {
+      await promisifiedTreeKill(p.pid, 'SIGKILL');
+      await killPorts(port);
+    } catch {
+      // ignore
+    }
+  }, 300_000);
+
+  it('should read from directory from outputs if outputPath is not specified', async () => {
+    const appName = uniq('app');
+    const port = 4301;
+
+    runCLI(`generate @nx/web:app ${appName} --no-interactive`);
+    setMaxWorkers(join('apps', appName, 'project.json'));
+    // Used to copy index.html rather than the normal webpack build.
+    updateFile(
+      `copy-index.js`,
+      `
+      const fs = require('node:fs');
+      const path = require('node:path');
+      fs.mkdirSync(path.join(__dirname, 'dist/foobar'), { recursive: true });
+      fs.copyFileSync(
+        path.join(__dirname, 'apps/${appName}/src/index.html'),
+        path.join(__dirname, 'dist/foobar/index.html')
+      );
+    `
+    );
+    updateJson(join('apps', appName, 'project.json'), (config) => {
+      // Point to same path as output.path in webpack config.
+      config.targets['build'] = {
+        command: `node copy-index.js`,
+        outputs: [`{workspaceRoot}/dist/foobar`],
+      };
+      config.targets['serve'].executor = '@nx/web:file-server';
+      // Check that buildTarget can exclude project name (e.g. build vs proj:build).
+      config.targets['serve'].options.buildTarget = 'build';
+      return config;
+    });
+
+    const p = await runCommandUntil(
+      `serve ${appName} --port=${port}`,
+      (output) => {
+        return (
+          output.indexOf(`localhost:${port}`) > -1 &&
+          output.indexOf(`dist/foobar`) > -1
+        );
       }
     );
 


### PR DESCRIPTION
This PR fixes an issue where not defining `outputPath` for a target causes file-server to fail.
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
