### PR TITLE
fix(core): use `target_os = "linux"` instead of just `linux` for watch events

### DIFF
--- a/e2e/nx-misc/src/watch.test.ts
+++ b/e2e/nx-misc/src/watch.test.ts
@@ -7,10 +7,15 @@ import {
   getStrippedEnvironmentVariables,
   updateJson,
   isVerboseE2ERun,
+  readFile,
 } from '@nx/e2e/utils';
 import { spawn } from 'child_process';
 import { join } from 'path';
-import { writeFileSync } from 'fs';
+import { writeFileSync, mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+
+let cacheDirectory = mkdtempSync(join(tmpdir(), 'daemon'));
+console.log('cache directory', cacheDirectory);
 
 async function writeFileForWatcher(path: string, content: string) {
   const e2ePath = join(tmpProjPath(), path);
@@ -33,11 +38,17 @@ describe('Nx Watch', () => {
       env: {
         NX_DAEMON: 'true',
         NX_NATIVE_LOGGING: 'nx',
+        NX_PROJECT_GRAPH_CACHE_DIRECTORY: cacheDirectory,
       },
     });
   });
 
   afterEach(() => {
+    if (process.env.NX_E2E_OUTPUT_DAEMON_LOGS === 'true') {
+      let daemonLog = readFile(join(cacheDirectory, 'd/daemon.log'));
+      const testName = expect.getState().currentTestName;
+      console.log(`${testName} daemon log: \n${daemonLog}`);
+    }
     runCLI('reset');
   });
 

--- a/packages/nx/src/native/watch/utils.rs
+++ b/packages/nx/src/native/watch/utils.rs
@@ -52,7 +52,7 @@ pub(super) fn get_nx_ignore<P: AsRef<Path>>(origin: P) -> Option<IgnoreFile> {
 }
 
 pub(super) fn transform_event(watch_event: &Event) -> Option<Event> {
-    if cfg!(linux) {
+    if cfg!(target_os = "linux") {
         let tags = watch_event
             .tags
             .clone()


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We were using an incorrect `cfg!(linux)` macro to do some conditional compilation for linux. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Use the correct `cfg!(target_os = "linux")` macro argument. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20406
