### PR TITLE
fix(core): unloading expanded envs

### DIFF
--- a/packages/nx/src/tasks-runner/task-env.ts
+++ b/packages/nx/src/tasks-runner/task-env.ts
@@ -187,7 +187,8 @@ function loadDotEnvFilesForTask(
 function unloadDotEnvFiles(environmentVariables: NodeJS.ProcessEnv) {
   const unloadDotEnvFile = (filename: string) => {
     let parsedDotEnvFile: NodeJS.ProcessEnv = {};
-    loadDotEnvFile({ path: filename, processEnv: parsedDotEnvFile });
+    const myEnv = loadDotEnvFile({ path: filename, processEnv: parsedDotEnvFile });
+    parsedDotEnvFile = { ...expand(myEnv).parsed };
     Object.keys(parsedDotEnvFile).forEach((envVarKey) => {
       if (environmentVariables[envVarKey] === parsedDotEnvFile[envVarKey]) {
         delete environmentVariables[envVarKey];


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When an env is expandable, it is not being unloaded before loading a task environment variables. Hence the initial value (from `bin/nx.ts`) is kept, and overwrites are not beings used when running the task.
This is because the `unloadDotEnvFiles()` function is comparing expanded variables with non expanded variables.

## Expected Behavior
Every `.env`, `.env.local` and `.local.env` should be unloaded before loading the appropriate envs for a task.

## Related Issue(s)
