### PR TITLE
fix(js): update minimum supported typescript version by js plugin

### DIFF
--- a/packages/js/src/generators/init/init.spec.ts
+++ b/packages/js/src/generators/init/init.spec.ts
@@ -105,14 +105,14 @@ describe('js init generator', () => {
 
   it('should not overwrite installed typescript version when is a supported version', async () => {
     updateJson(tree, 'package.json', (json) => {
-      json.devDependencies = { ...json.devDependencies, typescript: '~4.7.0' };
+      json.devDependencies = { ...json.devDependencies, typescript: '~4.8.2' };
       return json;
     });
 
     await init(tree, {});
 
     const packageJson = readJson(tree, 'package.json');
-    expect(packageJson.devDependencies['typescript']).toBe('~4.7.0');
+    expect(packageJson.devDependencies['typescript']).toBe('~4.8.2');
     expect(packageJson.devDependencies['typescript']).not.toBe(
       typescriptVersion
     );

--- a/packages/js/src/utils/versions.ts
+++ b/packages/js/src/utils/versions.ts
@@ -17,4 +17,4 @@ export const typescriptVersion = '~5.2.2';
  * that's supported by the lowest Angular supported version, e.g.
  * `npm view @angular/compiler-cli@14.0.0 peerDependencies.typescript`
  */
-export const supportedTypescriptVersions = '>=4.6.2';
+export const supportedTypescriptVersions = '>=4.8.2';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The minimum supported TypeScript version is still using the minimum supported version by Angular v14, which is already unsupported.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The minimum supported TypeScript version should be the minimum supported version by Angular v15, which is the lowest Angular version supported.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
