### PR TITLE
fix(nextjs): When running dev server .next folder should be in source

### DIFF
--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -147,8 +147,10 @@ function withNx(
   context: WithNxContext = getWithNxContext()
 ): NextConfigFn {
   return async (phase: string) => {
-    const { PHASE_PRODUCTION_SERVER } = await import('next/constants');
-    if (phase === PHASE_PRODUCTION_SERVER) {
+    const { PHASE_PRODUCTION_SERVER, PHASE_DEVELOPMENT_SERVER } = await import(
+      'next/constants'
+    );
+    if ([PHASE_PRODUCTION_SERVER, PHASE_DEVELOPMENT_SERVER].includes(phase)) {
       // If we are running an already built production server, just return the configuration.
       // NOTE: Avoid any `require(...)` or `import(...)` statements here. Development dependencies are not available at production runtime.
       const { nx, ...validNextConfig } = _nextConfig;


### PR DESCRIPTION
closes: #19365

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Running `nx serve acme --turbo --configuration=development` throws an error when loading the page.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Running `nx serve acme --turbo --configuration=development`. Should not throw an error.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
