### PR TITLE
fix(linter): support adding plugin at a later stage

### DIFF
--- a/packages/eslint/src/generators/init/init.spec.ts
+++ b/packages/eslint/src/generators/init/init.spec.ts
@@ -5,9 +5,15 @@ import { lintInitGenerator } from './init';
 
 describe('@nx/eslint:init', () => {
   let tree: Tree;
+  let envV3: string | undefined;
 
   beforeEach(() => {
+    envV3 = process.env.NX_PCV3;
     tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  });
+
+  afterEach(() => {
+    process.env.NX_PCV3 = envV3;
   });
 
   it('should generate the global eslint config', async () => {

--- a/packages/eslint/src/generators/init/init.spec.ts
+++ b/packages/eslint/src/generators/init/init.spec.ts
@@ -97,4 +97,31 @@ describe('@nx/eslint:init', () => {
       ]
     `);
   });
+
+  it('should add @nx/eslint/plugin in subsequent step', async () => {
+    updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+      json.namedInputs ??= {};
+      json.namedInputs.production = ['default'];
+      return json;
+    });
+
+    await lintInitGenerator(tree, {});
+    expect(
+      readJson<NxJsonConfiguration>(tree, 'nx.json').plugins
+    ).not.toBeDefined();
+
+    process.env.NX_PCV3 = 'true';
+    await lintInitGenerator(tree, {});
+    expect(readJson<NxJsonConfiguration>(tree, 'nx.json').plugins)
+      .toMatchInlineSnapshot(`
+      [
+        {
+          "options": {
+            "targetName": "lint",
+          },
+          "plugin": "@nx/eslint/plugin",
+        },
+      ]
+    `);
+  });
 });

--- a/packages/eslint/src/generators/init/init.ts
+++ b/packages/eslint/src/generators/init/init.ts
@@ -18,6 +18,7 @@ import { Linter } from '../utils/linter';
 import { findEslintFile } from '../utils/eslint-file';
 import { getGlobalEsLintConfiguration } from './global-eslint-config';
 import { EslintPluginOptions } from '../../plugins/plugin';
+import { hasEslintPlugin } from '../utils/plugin';
 
 export interface LinterInitOptions {
   linter?: Linter;
@@ -94,7 +95,16 @@ function updateVSCodeExtensions(tree: Tree) {
  * Initializes ESLint configuration in a workspace and adds necessary dependencies.
  */
 function initEsLint(tree: Tree, options: LinterInitOptions): GeneratorCallback {
-  if (findEslintFile(tree)) {
+  const addPlugins = process.env.NX_PCV3 === 'true';
+  const hasPlugin = hasEslintPlugin(tree);
+  const rootEslintFile = findEslintFile(tree);
+
+  if (rootEslintFile && addPlugins && !hasPlugin) {
+    addPlugin(tree);
+    return () => {};
+  }
+
+  if (rootEslintFile) {
     return () => {};
   }
 
@@ -111,7 +121,6 @@ function initEsLint(tree: Tree, options: LinterInitOptions): GeneratorCallback {
 
   updateProductionFileset(tree);
 
-  const addPlugins = process.env.NX_PCV3 === 'true';
   if (addPlugins) {
     addPlugin(tree);
   } else {

--- a/packages/eslint/src/generators/lint-project/lint-project.ts
+++ b/packages/eslint/src/generators/lint-project/lint-project.ts
@@ -35,6 +35,7 @@ import {
   baseEsLintConfigFile,
   baseEsLintFlatConfigFile,
 } from '../../utils/config-file';
+import { hasEslintPlugin } from '../utils/plugin';
 
 interface LintProjectOptions {
   project: string;
@@ -73,12 +74,7 @@ export async function lintProjectGenerator(
     lintFilePatterns.push(`{projectRoot}/package.json`);
   }
 
-  const nxJson = readNxJson(tree);
-  const hasPlugin = nxJson.plugins?.some((p) =>
-    typeof p === 'string'
-      ? p === '@nx/eslint/plugin'
-      : p.plugin === '@nx/eslint/plugin'
-  );
+  const hasPlugin = hasEslintPlugin(tree);
   if (hasPlugin) {
     if (
       lintFilePatterns &&

--- a/packages/eslint/src/generators/utils/plugin.ts
+++ b/packages/eslint/src/generators/utils/plugin.ts
@@ -1,0 +1,10 @@
+import { Tree, readNxJson } from '@nx/devkit';
+
+export function hasEslintPlugin(tree: Tree): boolean {
+  const nxJson = readNxJson(tree);
+  return nxJson.plugins?.some((p) =>
+    typeof p === 'string'
+      ? p === '@nx/eslint/plugin'
+      : p.plugin === '@nx/eslint/plugin'
+  );
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Eslint Init generator can add plugin instead of target defaults only on a fresh workspace, where eslint hasn't been initialized yet. Calling one of the eslint generators at the later point with `NX_PCV3` flag yields not result, since we bale out immediately upon finding root config.

## Expected Behavior
If plugin was not set up in nx.json it should be added at any point by calling generators with `NX_PCV3` flag

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
