### PR TITLE
docs(core): redirect ci to intro page

### DIFF
--- a/nx-dev/nx-dev/redirect-rules.js
+++ b/nx-dev/nx-dev/redirect-rules.js
@@ -452,6 +452,7 @@ const nxCloudUrls = {
   '/nx-cloud/account/encryption': '/ci/recipes/security/encryption',
   '/nx-cloud/concepts/encryption': '/ci/recipes/security/encryption',
   '/nx-cloud/features/nx-cloud-workflows': '/ci/concepts/nx-agents',
+  '/ci': '/ci/intro/ci-with-nx',
   '/nx-cloud/:path*': '/ci/:path*',
 };
 


### PR DESCRIPTION
Redirects `nx.dev/ci` to `nx.dev/ci/intro/ci-with-nx`