### PR TITLE
feat(storybook): nodes plugin

### DIFF
--- a/packages/react/src/generators/storybook-configuration/configuration.ts
+++ b/packages/react/src/generators/storybook-configuration/configuration.ts
@@ -3,6 +3,7 @@ import storiesGenerator from '../stories/stories';
 import {
   ensurePackage,
   formatFiles,
+  joinPathFragments,
   readProjectConfiguration,
   Tree,
 } from '@nx/devkit';
@@ -44,8 +45,7 @@ export async function storybookConfigurationGenerator(
   const projectConfig = readProjectConfiguration(host, schema.project);
 
   if (
-    projectConfig.targets['build']?.executor === '@nx/webpack:webpack' ||
-    projectConfig.targets['build']?.executor === '@nrwl/webpack:webpack' ||
+    findWebpackConfig(host, projectConfig.root) ||
     projectConfig.targets['build']?.executor === '@nx/rollup:rollup' ||
     projectConfig.targets['build']?.executor === '@nrwl/rollup:rollup'
   ) {
@@ -75,3 +75,20 @@ export async function storybookConfigurationGenerator(
 }
 
 export default storybookConfigurationGenerator;
+
+export function findWebpackConfig(
+  tree: Tree,
+  projectRoot: string
+): string | undefined {
+  const allowsExt = ['js', 'mjs', 'ts', 'cjs', 'mts', 'cts'];
+
+  for (const ext of allowsExt) {
+    const webpackConfigPath = joinPathFragments(
+      projectRoot,
+      `webpack.config.${ext}`
+    );
+    if (tree.exists(webpackConfigPath)) {
+      return webpackConfigPath;
+    }
+  }
+}

--- a/packages/remix/src/generators/storybook-configuration/__snapshots__/storybook-configuration.impl.spec.ts.snap
+++ b/packages/remix/src/generators/storybook-configuration/__snapshots__/storybook-configuration.impl.spec.ts.snap
@@ -3,21 +3,17 @@
 exports[`Storybook Configuration it should create a storybook configuration and use react-vite framework with testing framework jest 1`] = `
 "import type { StorybookConfig } from '@storybook/react-vite';
 
-import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
-import { mergeConfig } from 'vite';
-
 const config: StorybookConfig = {
   stories: ['../src/lib/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
   addons: ['@storybook/addon-essentials', '@storybook/addon-interactions'],
   framework: {
     name: '@storybook/react-vite',
-    options: {},
+    options: {
+      builder: {
+        viteConfigPath: 'libs/storybook-test/vite.config.ts',
+      },
+    },
   },
-
-  viteFinal: async (config) =>
-    mergeConfig(config, {
-      plugins: [nxViteTsPaths()],
-    }),
 };
 
 export default config;
@@ -31,21 +27,17 @@ export default config;
 exports[`Storybook Configuration it should create a storybook configuration and use react-vite framework with testing framework none 1`] = `
 "import type { StorybookConfig } from '@storybook/react-vite';
 
-import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
-import { mergeConfig } from 'vite';
-
 const config: StorybookConfig = {
   stories: ['../src/lib/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
   addons: ['@storybook/addon-essentials', '@storybook/addon-interactions'],
   framework: {
     name: '@storybook/react-vite',
-    options: {},
+    options: {
+      builder: {
+        viteConfigPath: 'libs/storybook-test/vite.config.ts',
+      },
+    },
   },
-
-  viteFinal: async (config) =>
-    mergeConfig(config, {
-      plugins: [nxViteTsPaths()],
-    }),
 };
 
 export default config;
@@ -59,21 +51,17 @@ export default config;
 exports[`Storybook Configuration it should create a storybook configuration and use react-vite framework with testing framework vitest 1`] = `
 "import type { StorybookConfig } from '@storybook/react-vite';
 
-import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
-import { mergeConfig } from 'vite';
-
 const config: StorybookConfig = {
   stories: ['../src/lib/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
   addons: ['@storybook/addon-essentials', '@storybook/addon-interactions'],
   framework: {
     name: '@storybook/react-vite',
-    options: {},
+    options: {
+      builder: {
+        viteConfigPath: 'libs/storybook-test/vite.config.ts',
+      },
+    },
   },
-
-  viteFinal: async (config) =>
-    mergeConfig(config, {
-      plugins: [nxViteTsPaths()],
-    }),
 };
 
 export default config;

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -30,11 +30,11 @@
     "migrations": "./migrations.json"
   },
   "dependencies": {
+    "@nx/devkit": "file:../devkit",
     "@phenomnomnominal/tsquery": "~5.0.1",
     "semver": "7.5.3",
     "tslib": "^2.3.0",
     "@nx/cypress": "file:../cypress",
-    "@nx/devkit": "file:../devkit",
     "@nx/js": "file:../js",
     "@nx/eslint": "file:../eslint"
   },

--- a/packages/storybook/plugin.ts
+++ b/packages/storybook/plugin.ts
@@ -1,0 +1,5 @@
+export {
+  createNodes,
+  StorybookPluginOptions,
+  createDependencies,
+} from './src/plugins/plugin';

--- a/packages/storybook/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/storybook/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -173,7 +173,7 @@ const config: StorybookConfig = {
     name: '@storybook/react-vite',
     options: {
       builder: {
-        viteConfigPath: 'apps/main-vite-ts/vite.config.custom.ts',
+        viteConfigPath: 'apps/main-vite-ts/vite.config.ts',
       },
     },
   },
@@ -323,7 +323,7 @@ const config: StorybookConfig = {
     name: '@storybook/web-components-vite',
     options: {
       builder: {
-        viteConfigPath: 'apps/wv1/vite.config.custom.ts',
+        viteConfigPath: 'apps/wv1/vite.config.ts',
       },
     },
   },

--- a/packages/storybook/src/generators/configuration/configuration.spec.ts
+++ b/packages/storybook/src/generators/configuration/configuration.spec.ts
@@ -253,12 +253,10 @@ describe('@nx/storybook:configuration for Storybook v7', () => {
 
       tree.write('libs/react-vite/vite.config.ts', 'export default {}');
       tree.write('apps/main-vite/vite.config.ts', 'export default {}');
-      tree.write(
-        'apps/main-vite-ts/vite.config.custom.ts',
-        'export default {}'
-      );
+      tree.write('apps/main-vite-ts/vite.config.ts', 'export default {}');
       tree.write('apps/reapp/vite.config.ts', 'export default {}');
-      tree.write('apps/wv1/vite.config.custom.ts', 'export default {}');
+      tree.write('apps/wv1/vite.config.ts', 'export default {}');
+      tree.write('apps/nextapp/next.config.js', 'export default {}');
 
       await configurationGenerator(tree, {
         project: 'reapp',

--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -3,6 +3,7 @@ import {
   formatFiles,
   GeneratorCallback,
   logger,
+  readNxJson,
   readProjectConfiguration,
   runTasksInSerial,
   Tree,
@@ -13,18 +14,19 @@ import { StorybookConfigureSchema } from './schema';
 import { initGenerator } from '../init/init';
 
 import {
-  addAngularStorybookTask,
+  addAngularStorybookTarget,
   addBuildStorybookToCacheableOperations,
   addStaticTarget,
-  addStorybookTask,
+  addStorybookTarget,
   addStorybookToNamedInputs,
   configureTsProjectConfig,
   configureTsSolutionConfig,
   createProjectStorybookDir,
   createStorybookTsconfigFile,
   editTsconfigBaseJson,
+  findNextConfig,
+  findViteConfig,
   getE2EProjectName,
-  getViteConfigFilePath,
   projectIsRootProjectInStandaloneWorkspace,
   updateLintConfig,
 } from './lib/util-functions';
@@ -37,6 +39,7 @@ import {
 import {
   coreJsVersion,
   nxVersion,
+  storybookVersion,
   tsLibVersion,
   tsNodeVersion,
 } from '../../utils/versions';
@@ -58,20 +61,12 @@ export async function configurationGenerator(
     tree,
     schema.project
   );
-  const { nextBuildTarget, compiler, viteBuildTarget } =
-    findStorybookAndBuildTargetsAndCompiler(targets);
+  const { compiler } = findStorybookAndBuildTargetsAndCompiler(targets);
 
-  let viteConfigFilePath: string | undefined;
+  const viteConfigFilePath = findViteConfig(tree, root);
+  const nextConfigFilePath = findNextConfig(tree, root);
 
-  if (viteBuildTarget) {
-    viteConfigFilePath = getViteConfigFilePath(
-      tree,
-      root,
-      targets[viteBuildTarget]?.options?.configFile
-    );
-  }
-
-  if (viteBuildTarget) {
+  if (viteConfigFilePath) {
     if (schema.uiFramework === '@storybook/react-webpack5') {
       logger.info(
         `Your project ${schema.project} uses Vite as a bundler.
@@ -88,7 +83,7 @@ export async function configurationGenerator(
     }
   }
 
-  if (nextBuildTarget) {
+  if (nextConfigFilePath) {
     schema.uiFramework = '@storybook/nextjs';
   }
 
@@ -98,10 +93,19 @@ export async function configurationGenerator(
   });
   tasks.push(initTask);
 
-  const mainDir =
-    !!nextBuildTarget && projectType === 'application' ? 'components' : 'src';
+  const nxJson = readNxJson(tree);
+  const hasPlugin = nxJson.plugins?.some((p) =>
+    typeof p === 'string'
+      ? p === '@nx/storybook/plugin'
+      : p.plugin === '@nx/storybook/plugin'
+  );
 
-  const usesVite = !!viteBuildTarget || schema.uiFramework.endsWith('-vite');
+  const mainDir =
+    !!nextConfigFilePath && projectType === 'application'
+      ? 'components'
+      : 'src';
+
+  const usesVite = !!viteConfigFilePath || schema.uiFramework.endsWith('-vite');
 
   createProjectStorybookDir(
     tree,
@@ -114,7 +118,7 @@ export async function configurationGenerator(
     projectIsRootProjectInStandaloneWorkspace(root),
     schema.interactionTests,
     mainDir,
-    !!nextBuildTarget,
+    !!nextConfigFilePath,
     compiler === 'swc',
     usesVite,
     viteConfigFilePath
@@ -137,19 +141,24 @@ export async function configurationGenerator(
   addBuildStorybookToCacheableOperations(tree);
   addStorybookToNamedInputs(tree);
 
-  if (schema.uiFramework === '@storybook/angular') {
-    addAngularStorybookTask(tree, schema.project, schema.interactionTests);
-  } else {
-    addStorybookTask(
-      tree,
-      schema.project,
-      schema.uiFramework,
-      schema.interactionTests
-    );
-  }
+  let devDeps = {};
 
-  if (schema.configureStaticServe) {
-    addStaticTarget(tree, schema);
+  if (!hasPlugin) {
+    if (schema.uiFramework === '@storybook/angular') {
+      addAngularStorybookTarget(tree, schema.project, schema.interactionTests);
+    } else {
+      addStorybookTarget(
+        tree,
+        schema.project,
+        schema.uiFramework,
+        schema.interactionTests
+      );
+    }
+    if (schema.configureStaticServe) {
+      addStaticTarget(tree, schema);
+    }
+  } else {
+    devDeps['storybook'] = storybookVersion;
   }
 
   // TODO(katerina): Nx 18 -> remove Cypress
@@ -174,8 +183,6 @@ export async function configurationGenerator(
       );
     }
   }
-
-  let devDeps = {};
 
   if (schema.tsConfiguration) {
     devDeps['ts-node'] = tsNodeVersion;
@@ -203,10 +210,7 @@ export async function configurationGenerator(
     devDeps['core-js'] = coreJsVersion;
   }
 
-  if (
-    schema.uiFramework.endsWith('-vite') &&
-    (!viteBuildTarget || !viteConfigFilePath)
-  ) {
+  if (schema.uiFramework.endsWith('-vite') && !viteConfigFilePath) {
     // This means that the user has selected a Vite framework
     // but the project does not have Vite configuration.
     // We need to install the @nx/vite plugin in order to be able to use

--- a/packages/storybook/src/generators/configuration/lib/util-functions.ts
+++ b/packages/storybook/src/generators/configuration/lib/util-functions.ts
@@ -33,7 +33,7 @@ import { useFlatConfig } from '@nx/eslint/src/utils/flat-config';
 
 const DEFAULT_PORT = 4400;
 
-export function addStorybookTask(
+export function addStorybookTarget(
   tree: Tree,
   projectName: string,
   uiFramework: UiFramework,
@@ -82,7 +82,7 @@ export function addStorybookTask(
   updateProjectConfiguration(tree, projectName, projectConfig);
 }
 
-export function addAngularStorybookTask(
+export function addAngularStorybookTarget(
   tree: Tree,
   projectName: string,
   interactionTests: boolean
@@ -696,18 +696,32 @@ export async function getE2EProjectName(
   return e2eProject;
 }
 
-export function getViteConfigFilePath(
+export function findViteConfig(
   tree: Tree,
-  projectRoot: string,
-  configFile?: string
+  projectRoot: string
 ): string | undefined {
-  return configFile && tree.exists(configFile)
-    ? configFile
-    : tree.exists(joinPathFragments(`${projectRoot}/vite.config.ts`))
-    ? joinPathFragments(`${projectRoot}/vite.config.ts`)
-    : tree.exists(joinPathFragments(`${projectRoot}/vite.config.js`))
-    ? joinPathFragments(`${projectRoot}/vite.config.js`)
-    : undefined;
+  const allowsExt = ['js', 'mjs', 'ts', 'cjs', 'mts', 'cts'];
+
+  for (const ext of allowsExt) {
+    const viteConfigPath = joinPathFragments(projectRoot, `vite.config.${ext}`);
+    if (tree.exists(viteConfigPath)) {
+      return viteConfigPath;
+    }
+  }
+}
+
+export function findNextConfig(
+  tree: Tree,
+  projectRoot: string
+): string | undefined {
+  const allowsExt = ['js', 'mjs', 'cjs'];
+
+  for (const ext of allowsExt) {
+    const nextConfigPath = joinPathFragments(projectRoot, `next.config.${ext}`);
+    if (tree.exists(nextConfigPath)) {
+      return nextConfigPath;
+    }
+  }
 }
 
 export function renameAndMoveOldTsConfig(

--- a/packages/storybook/src/generators/init/init.ts
+++ b/packages/storybook/src/generators/init/init.ts
@@ -21,6 +21,7 @@ import {
 } from '../../utils/versions';
 import { Schema } from './schema';
 import {
+  addPlugin,
   getInstalledStorybookVersion,
   storybookMajorVersion,
 } from '../../utils/utilities';
@@ -59,6 +60,10 @@ function checkDependenciesInstalled(host: Tree, schema: Schema) {
     !packageJson.devDependencies['react-dom']
   ) {
     dependencies['react-dom'] = reactVersion;
+  }
+
+  if (process.env.NX_PCV3 === 'true') {
+    devDependencies['storybook'] = storybook7VersionToInstall;
   }
 
   devDependencies['@storybook/core-server'] = storybook7VersionToInstall;
@@ -204,6 +209,10 @@ export async function initGenerator(tree: Tree, schema: Schema) {
   moveToDevDependencies(tree);
   editRootTsConfig(tree);
   addCacheableOperation(tree);
+  const addPlugins = process.env.NX_PCV3 === 'true';
+  if (addPlugins) {
+    addPlugin(tree);
+  }
   return runTasksInSerial(...tasks);
 }
 

--- a/packages/storybook/src/plugins/plugin.spec.ts
+++ b/packages/storybook/src/plugins/plugin.spec.ts
@@ -1,0 +1,167 @@
+import { CreateNodesContext } from '@nx/devkit';
+
+import { createNodes } from './plugin';
+import { TempFs } from '@nx/devkit/internal-testing-utils';
+
+describe('@nx/storybook/plugin', () => {
+  let createNodesFunction = createNodes[1];
+  let context: CreateNodesContext;
+  let tempFs = new TempFs('test');
+
+  beforeEach(async () => {
+    context = {
+      nxJsonConfiguration: {
+        namedInputs: {
+          default: ['{projectRoot}/**/*'],
+          production: ['!{projectRoot}/**/*.spec.ts'],
+        },
+      },
+      workspaceRoot: tempFs.tempDir,
+    };
+    tempFs.createFileSync(
+      'my-app/project.json',
+      JSON.stringify({ name: 'my-app' })
+    );
+    tempFs.createFileSync(
+      'my-ng-app/project.json',
+      JSON.stringify({ name: 'my-ng-app' })
+    );
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    tempFs = new TempFs('test');
+  });
+
+  it('should create nodes', () => {
+    tempFs.createFileSync(
+      'my-app/.storybook/main.ts',
+      `import type { StorybookConfig } from '@storybook/react-vite';
+
+      import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+      import { mergeConfig } from 'vite';
+      
+      const config: StorybookConfig = {
+        stories: ['../src/app/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
+        addons: ['@storybook/addon-essentials', '@storybook/addon-interactions'],
+        framework: {
+          name: '@storybook/react-vite',
+          options: {},
+        },
+      
+        viteFinal: async (config) =>
+          mergeConfig(config, {
+            plugins: [nxViteTsPaths()],
+          }),
+      };
+      
+      export default config;`
+    );
+    const nodes = createNodesFunction(
+      'my-app/.storybook/main.ts',
+      {
+        buildStorybookTargetName: 'build-storybook',
+        staticStorybookTargetName: 'static-storybook',
+        serveStorybookTargetName: 'serve-storybook',
+        testStorybookTargetName: 'test-storybook',
+      },
+      context
+    );
+
+    expect(nodes?.['projects']?.['my-app']?.targets).toBeDefined();
+    expect(
+      nodes?.['projects']?.['my-app']?.targets?.['build-storybook']
+    ).toMatchObject({
+      command:
+        'storybook build --config-dir my-app/.storybook --output-dir dist/storybook/my-app',
+      cache: true,
+      outputs: ['{workspaceRoot}/dist/storybook/{projectRoot}'],
+      inputs: [
+        'production',
+        '^production',
+        { externalDependencies: ['storybook', '@storybook/test-runner'] },
+      ],
+    });
+
+    expect(
+      nodes?.['projects']?.['my-app']?.targets?.['storybook']
+    ).toMatchObject({
+      command: 'storybook dev --config-dir my-app/.storybook',
+    });
+    expect(
+      nodes?.['projects']?.['my-app']?.targets?.['test-storybook']
+    ).toMatchObject({
+      command: 'test-storybook --config-dir my-app/.storybook',
+    });
+  });
+
+  it('should create angular nodes', () => {
+    tempFs.createFileSync(
+      'my-ng-app/.storybook/main.ts',
+      `import type { StorybookConfig } from '@storybook/angular';
+
+      const config: StorybookConfig = {
+        stories: ['../src/app/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
+        addons: ['@storybook/addon-essentials', '@storybook/addon-interactions'],
+        framework: {
+          name: '@storybook/angular',
+          options: {},
+        },
+      };
+      
+      export default config;`
+    );
+    const nodes = createNodesFunction(
+      'my-ng-app/.storybook/main.ts',
+      {
+        buildStorybookTargetName: 'build-storybook',
+        staticStorybookTargetName: 'static-storybook',
+        serveStorybookTargetName: 'serve-storybook',
+        testStorybookTargetName: 'test-storybook',
+      },
+      context
+    );
+
+    expect(nodes?.['projects']?.['my-ng-app']?.targets).toBeDefined();
+    expect(
+      nodes?.['projects']?.['my-ng-app']?.targets?.['build-storybook']
+    ).toMatchObject({
+      executor: '@storybook/angular:build-storybook',
+      options: {
+        outputDir: 'dist/storybook/my-ng-app',
+        configDir: 'my-ng-app/.storybook',
+        browserTarget: 'my-ng-app:build-storybook',
+        compodoc: false,
+      },
+      cache: true,
+      outputs: ['{workspaceRoot}/dist/storybook/{projectRoot}'],
+      inputs: [
+        'production',
+        '^production',
+        {
+          externalDependencies: [
+            'storybook',
+            '@storybook/angular',
+            '@storybook/test-runner',
+          ],
+        },
+      ],
+    });
+
+    expect(
+      nodes?.['projects']?.['my-ng-app']?.targets?.['storybook']
+    ).toMatchObject({
+      executor: '@storybook/angular:start-storybook',
+      options: {
+        browserTarget: 'my-ng-app:build-storybook',
+        configDir: 'my-ng-app/.storybook',
+        compodoc: false,
+      },
+    });
+    expect(
+      nodes?.['projects']?.['my-ng-app']?.targets?.['test-storybook']
+    ).toMatchObject({
+      command: 'test-storybook --config-dir my-ng-app/.storybook',
+    });
+  });
+});

--- a/packages/storybook/src/plugins/plugin.ts
+++ b/packages/storybook/src/plugins/plugin.ts
@@ -1,0 +1,375 @@
+import {
+  CreateDependencies,
+  CreateNodes,
+  CreateNodesContext,
+  TargetConfiguration,
+  detectPackageManager,
+  joinPathFragments,
+  parseJson,
+  readJsonFile,
+  workspaceRoot,
+  writeJsonFile,
+} from '@nx/devkit';
+import { dirname, isAbsolute, join, relative } from 'path';
+import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
+import { projectGraphCacheDirectory } from 'nx/src/utils/cache-directory';
+import { getLockFileName } from '@nx/js';
+import { tsquery } from '@phenomnomnominal/tsquery';
+
+export interface StorybookPluginOptions {
+  buildStorybookTargetName?: string;
+  serveStorybookTargetName?: string;
+  staticStorybookTargetName?: string;
+  testStorybookTargetName?: string;
+}
+
+const cachePath = join(projectGraphCacheDirectory, 'storybook.hash');
+const targetsCache = existsSync(cachePath) ? readTargetsCache() : {};
+
+const calculatedTargets: Record<
+  string,
+  Record<string, TargetConfiguration>
+> = {};
+
+function readTargetsCache(): Record<
+  string,
+  Record<string, TargetConfiguration>
+> {
+  return readJsonFile(cachePath);
+}
+
+function writeTargetsToCache(
+  targets: Record<string, Record<string, TargetConfiguration>>
+) {
+  writeJsonFile(cachePath, targets);
+}
+
+export const createDependencies: CreateDependencies = () => {
+  writeTargetsToCache(calculatedTargets);
+  return [];
+};
+
+export const createNodes: CreateNodes<StorybookPluginOptions> = [
+  '**/.storybook/main.{js,ts,mjs,mts,cjs,cts}',
+  (configFilePath, options, context) => {
+    let projectRoot = '';
+    if (configFilePath.includes('/.storybook')) {
+      projectRoot = dirname(configFilePath).replace('/.storybook', '');
+    } else {
+      projectRoot = dirname(configFilePath).replace('.storybook', '');
+    }
+
+    if (projectRoot === '') {
+      projectRoot = '.';
+    }
+    // Do not create a project if package.json and project.json isn't there.
+    const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));
+    if (
+      !siblingFiles.includes('package.json') &&
+      !siblingFiles.includes('project.json')
+    ) {
+      return {};
+    }
+
+    options = normalizeOptions(options);
+    const hash = calculateHashForCreateNodes(projectRoot, options, context, [
+      getLockFileName(detectPackageManager(context.workspaceRoot)),
+    ]);
+
+    const projectName = buildProjectName(projectRoot, context.workspaceRoot);
+
+    const targets = targetsCache[hash]
+      ? targetsCache[hash]
+      : buildStorybookTargets(
+          configFilePath,
+          projectRoot,
+          options,
+          context,
+          projectName
+        );
+
+    calculatedTargets[hash] = targets;
+
+    const result = {
+      projects: {
+        [projectRoot]: {
+          root: projectRoot,
+          targets,
+        },
+      },
+    };
+    // For root projects, the name is not inferred from root package.json, so we need to manually set it.
+    // TODO(jack): We should handle this in core and remove this workaround.
+    if (projectRoot === '.') {
+      result.projects[projectRoot]['name'] = projectName;
+    }
+
+    return result;
+  },
+];
+
+function buildStorybookTargets(
+  configFilePath: string,
+  projectRoot: string,
+  options: StorybookPluginOptions,
+  context: CreateNodesContext,
+  projectName: string
+) {
+  const buildOutputs = getOutputs(projectRoot);
+
+  const namedInputs = getNamedInputs(projectRoot, context);
+
+  const storybookFramework = getStorybookConfig(configFilePath, context);
+
+  const frameworkIsAngular = storybookFramework === "'@storybook/angular'";
+
+  const targets: Record<string, TargetConfiguration> = {};
+
+  targets[options.buildStorybookTargetName] = buildTarget(
+    namedInputs,
+    buildOutputs,
+    configFilePath,
+    projectRoot,
+    frameworkIsAngular,
+    projectName
+  );
+
+  targets[options.serveStorybookTargetName] = serveTarget(
+    configFilePath,
+    frameworkIsAngular,
+    projectName
+  );
+
+  targets[options.testStorybookTargetName] = testTarget(configFilePath);
+
+  targets[options.staticStorybookTargetName] = serveStaticTarget(
+    options,
+    projectRoot
+  );
+
+  return targets;
+}
+
+function buildTarget(
+  namedInputs: {
+    [inputName: string]: any[];
+  },
+  outputs: string[],
+  configFilePath: string,
+  projectRoot: string,
+  frameworkIsAngular: boolean,
+  projectName: string
+) {
+  const outputDir = joinPathFragments('dist/storybook', projectRoot);
+
+  let targetConfig: TargetConfiguration;
+
+  if (frameworkIsAngular) {
+    targetConfig = {
+      executor: '@storybook/angular:build-storybook',
+      options: {
+        outputDir: `${outputDir}`,
+        configDir: `${dirname(configFilePath)}`,
+        browserTarget: `${projectName}:build-storybook`,
+        compodoc: false,
+      },
+      cache: true,
+      outputs,
+      inputs: [
+        ...('production' in namedInputs
+          ? ['production', '^production']
+          : ['default', '^default']),
+        {
+          externalDependencies: [
+            'storybook',
+            '@storybook/angular',
+            '@storybook/test-runner',
+          ],
+        },
+      ],
+    };
+  } else {
+    targetConfig = {
+      command: `storybook build --config-dir ${dirname(
+        configFilePath
+      )} --output-dir ${outputDir}`,
+      cache: true,
+      outputs,
+      inputs: [
+        ...('production' in namedInputs
+          ? ['production', '^production']
+          : ['default', '^default']),
+        {
+          externalDependencies: ['storybook', '@storybook/test-runner'],
+        },
+      ],
+    };
+  }
+
+  return targetConfig;
+}
+
+function serveTarget(
+  configFilePath: string,
+  frameworkIsAngular: boolean,
+  projectName: string
+) {
+  if (frameworkIsAngular) {
+    return {
+      executor: '@storybook/angular:start-storybook',
+      options: {
+        configDir: `${dirname(configFilePath)}`,
+        browserTarget: `${projectName}:build-storybook`,
+        compodoc: false,
+      },
+    };
+  } else {
+    return {
+      command: `storybook dev --config-dir ${dirname(configFilePath)}`,
+    };
+  }
+}
+
+function testTarget(configFilePath: string) {
+  const targetConfig: TargetConfiguration = {
+    command: `test-storybook --config-dir ${dirname(configFilePath)}`,
+    inputs: [
+      {
+        externalDependencies: ['storybook', '@storybook/test-runner'],
+      },
+    ],
+  };
+
+  return targetConfig;
+}
+
+function serveStaticTarget(
+  options: StorybookPluginOptions,
+  projectRoot: string
+) {
+  const targetConfig: TargetConfiguration = {
+    executor: '@nx/web:file-server',
+    options: {
+      buildTarget: `${options.buildStorybookTargetName}`,
+      // TODO(katerina): need to read the output from CLI args
+      staticFilePath: joinPathFragments('dist/storybook', projectRoot),
+    },
+  };
+
+  return targetConfig;
+}
+
+function getStorybookConfig(
+  configFilePath: string,
+  context: CreateNodesContext
+): string {
+  const resolvedPath = join(context.workspaceRoot, configFilePath);
+  const mainTsJs = readFileSync(resolvedPath, 'utf-8');
+  const importDeclarations = tsquery.query(
+    mainTsJs,
+    'ImportDeclaration:has(ImportSpecifier:has([text="StorybookConfig"]))'
+  )?.[0];
+
+  const storybookConfigImportPackage = tsquery.query(
+    importDeclarations,
+    'StringLiteral'
+  )?.[0];
+
+  let frameworkName: string | undefined;
+
+  if (storybookConfigImportPackage?.getText() === `'@storybook/core-common'`) {
+    const frameworkPropertyAssignment = tsquery.query(
+      mainTsJs,
+      `PropertyAssignment:has(Identifier:has([text="framework"]))`
+    )?.[0];
+
+    if (!frameworkPropertyAssignment) {
+      return;
+    }
+
+    const propertyAssignments = tsquery.query(
+      frameworkPropertyAssignment,
+      `PropertyAssignment:has(Identifier:has([text="name"]))`
+    );
+
+    const namePropertyAssignment = propertyAssignments?.find((expression) => {
+      return expression.getText().startsWith('name');
+    });
+
+    if (!namePropertyAssignment) {
+      const storybookConfigImportPackage = tsquery.query(
+        frameworkPropertyAssignment,
+        'StringLiteral'
+      )?.[0];
+      frameworkName = storybookConfigImportPackage?.getText();
+    } else {
+      frameworkName = tsquery
+        .query(namePropertyAssignment, `StringLiteral`)?.[0]
+        ?.getText();
+    }
+  } else {
+    frameworkName = storybookConfigImportPackage?.getText();
+  }
+  return frameworkName;
+}
+
+function getOutputs(_projectRoot: string): string[] {
+  // TODO(katerina): need to read the output from CLI args
+  // const outputPath = <output path as read from CLI>;
+
+  const normalizedOutputPath = normalizeOutputPath(undefined, _projectRoot);
+
+  const outputs = [normalizedOutputPath];
+
+  return outputs;
+}
+
+function normalizeOutputPath(
+  outputPath: string | undefined,
+  projectRoot: string
+): string | undefined {
+  if (!outputPath) {
+    if (projectRoot === '.') {
+      return `{projectRoot}/dist/storybook`;
+    } else {
+      return `{workspaceRoot}/dist/storybook/{projectRoot}`;
+    }
+  } else {
+    if (isAbsolute(outputPath)) {
+      return `{workspaceRoot}/${relative(workspaceRoot, outputPath)}`;
+    } else {
+      if (outputPath.startsWith('..')) {
+        return join('{workspaceRoot}', join(projectRoot, outputPath));
+      } else {
+        return join('{projectRoot}', outputPath);
+      }
+    }
+  }
+}
+
+function normalizeOptions(
+  options: StorybookPluginOptions
+): StorybookPluginOptions {
+  options ??= {};
+  options.buildStorybookTargetName = 'build-storybook';
+  options.serveStorybookTargetName = 'storybook';
+  options.testStorybookTargetName = 'test-storybook';
+  options.staticStorybookTargetName = 'static-storybook';
+  return options;
+}
+
+function buildProjectName(projectRoot: string, workspaceRoot: string): string {
+  const packageJsonPath = join(workspaceRoot, projectRoot, 'package.json');
+  const projectJsonPath = join(workspaceRoot, projectRoot, 'project.json');
+  let name: string;
+  if (existsSync(projectJsonPath)) {
+    const projectJson = parseJson(readFileSync(projectJsonPath, 'utf-8'));
+    name = projectJson.name;
+  } else if (existsSync(packageJsonPath)) {
+    const packageJson = parseJson(readFileSync(packageJsonPath, 'utf-8'));
+    name = packageJson.name;
+  }
+  return name ?? projectRoot;
+}

--- a/packages/storybook/src/utils/utilities.ts
+++ b/packages/storybook/src/utils/utilities.ts
@@ -1,4 +1,9 @@
-import { TargetConfiguration, Tree } from '@nx/devkit';
+import {
+  TargetConfiguration,
+  Tree,
+  readNxJson,
+  updateNxJson,
+} from '@nx/devkit';
 import { CompilerOptions } from 'typescript';
 import { statSync } from 'fs';
 import { findNodes } from '@nx/js';
@@ -270,4 +275,30 @@ export function pleaseUpgrade(): string {
     Here is a guide on how to upgrade:
     https://nx.dev/nx-api/storybook/generators/migrate-7
     `;
+}
+
+export function addPlugin(tree: Tree) {
+  const nxJson = readNxJson(tree);
+  nxJson.plugins ??= [];
+
+  for (const plugin of nxJson.plugins) {
+    if (
+      typeof plugin === 'string'
+        ? plugin === '@nx/storybook/plugin'
+        : plugin.plugin === '@nx/storybook/plugin'
+    ) {
+      return;
+    }
+  }
+
+  nxJson.plugins.push({
+    plugin: '@nx/storybook/plugin',
+    options: {
+      buildStorybookTargetName: 'build-storybook',
+      serveStorybookTargetName: 'storybook',
+      testStorybookTargetName: 'test-storybook',
+      staticStorybookTargetName: 'static-storybook',
+    },
+  });
+  updateNxJson(tree, nxJson);
 }

--- a/packages/vite/src/plugins/plugin.spec.ts
+++ b/packages/vite/src/plugins/plugin.spec.ts
@@ -66,7 +66,6 @@ describe('@nx/vite/plugin', () => {
     });
   });
 
-  // some issue wiht the tempfs
   describe('not root project', () => {
     const tempFs = new TempFs('test');
     beforeEach(() => {


### PR DESCRIPTION
A plugin (`@nx/storybook/plugin`) which will add Storybook targets/projects to the Nx project graph. This allows you to run Storybook for projects that have a `.storybook/main.ts` file without creating a `project.json` file.

## To-do's

- [x] READ CONFIG AND SEE IF IT'S ANGULAR - USE ANGULAR EXECUTORS IF IT IS
- [x] Figure out what to do with being unable to read outputs and port from config
- [x] Figure out what to do with being unable to set outputs and port in config
- [x] figure out why it looks for name
- [x] don't add targets if `NX_PCV3` is true
- [x] Test it thoroughly
- [x] Figure out how to specify `@storybook/nextjs` as framework (if no executor is present in project.json) (use graph??)
- [x] Make angular work - right now it does not find targets: Needs this to work: https://github.com/nrwl/nx/pull/21019

## How it works

On `@nx/storybook:init` this is added in the `nx.json`:
```
...
plugins: [
  {
    plugin: '@nx/storybook/plugin',
    options: {
      buildStorybookTargetName = 'build-storybook',
      serveStorybookTargetName = 'storybook',
      testStorybookTargetName = 'test-storybook',
      staticStorybookTargetName = 'static-storybook'
    },
  },
  ...
]
```
so that you can run `nx storybook my-app`, `nx build-storybook my-app` etc, without manually defining these targets in your projects' `project.json`.

The plugin generates these targets with bare minimum (no extra) options configuration. Any options you need for your Storybook app, you can pass through the CLI as normal.
