### PR TITLE
fix(release): only early exit when no changelog changes if expecting commit

### DIFF
--- a/packages/nx/src/command-line/release/changelog.ts
+++ b/packages/nx/src/command-line/release/changelog.ts
@@ -333,20 +333,20 @@ async function applyChangesAndExit(
 ) {
   let latestCommit = toSHA;
 
-  const changes = tree.listChanges();
-  // This could happen we using conventional commits, for example
-  if (!changes.length) {
-    output.warn({
-      title: `No changes detected for changelogs`,
-      bodyLines: [
-        `No changes were detected for any changelog files, so no changelog entries will be generated.`,
-      ],
-    });
-    return 0;
-  }
-
   // Generate a new commit for the changes, if configured to do so
   if (args.gitCommit ?? nxReleaseConfig.changelog.git.commit) {
+    const changes = tree.listChanges();
+    // This could happen we using conventional commits, for example
+    if (!changes.length) {
+      output.warn({
+        title: `No changes detected for changelogs`,
+        bodyLines: [
+          `No changes were detected for any changelog files, so no changelog entries will be generated.`,
+        ],
+      });
+      return 0;
+    }
+
     await commitChanges(
       changes.map((f) => f.path),
       !!args.dryRun,


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Changelog command will always exit early if there are no changes ready to be flushed to disk from the tree

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Changelog command will only exit early when there are no changes ready to be flushed to disk from the tree when a commit is expected to be made

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
