### PR TITLE
chore(js): fixing output based on test runner selection

### DIFF
--- a/packages/js/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/js/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -1,5 +1,88 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`lib --bundler=vite should add build and test targets with vite and vitest 1`] = `
+"# my-lib
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run \`nx build my-lib\` to build the library.
+
+## Running unit tests
+
+Run \`nx test my-lib\` to execute the unit tests via [Vitest](https://vitest.dev/).
+"
+`;
+
+exports[`lib --bundler=vite should add build and test targets with vite and vitest 2`] = `
+"{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../dist/out-tsc",
+    "declaration": true,
+    "types": ["node", "vite/client"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["vite.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}
+"
+`;
+
+exports[`lib --bundler=vite should respect unitTestRunner if passed 1`] = `
+"# my-lib
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run \`nx build my-lib\` to build the library.
+"
+`;
+
+exports[`lib --bundler=vite should respect unitTestRunner if passed 2`] = `
+"{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../dist/out-tsc",
+    "declaration": true,
+    "types": ["node", "vite/client"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}
+"
+`;
+
+exports[`lib --bundler=vite should respect unitTestRunner if passed 3`] = `
+"# my-lib
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run \`nx build my-lib\` to build the library.
+
+## Running unit tests
+
+Run \`nx test my-lib\` to execute the unit tests via [Jest](https://jestjs.io).
+"
+`;
+
+exports[`lib --bundler=vite should respect unitTestRunner if passed 4`] = `
+"{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../dist/out-tsc",
+    "declaration": true,
+    "types": ["node", "vite/client"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}
+"
+`;
+
 exports[`lib --unit-test-runner jest should generate test configuration with swc and js 1`] = `
 "/* eslint-disable */
 const { readFileSync } = require('fs');

--- a/packages/js/src/generators/library/files/lib/README.md
+++ b/packages/js/src/generators/library/files/lib/README.md
@@ -14,6 +14,5 @@ Run `<%= cliCommand %> build <%= name %>` to build the library.
 
 ## Running unit tests
 
-Run `<%= cliCommand %> test <%= name %>` to execute the unit tests via [Jest](https://jestjs.io).
-
+Run `<%= cliCommand %> test <%= name %>` to execute the unit tests via <% if(unitTestRunner === 'jest') { %>[Jest](https://jestjs.io)<% } else { %>[Vitest](https://vitest.dev/)<% } %>.
 <% } %>

--- a/packages/js/src/generators/library/files/lib/tsconfig.lib.json__tmpl__
+++ b/packages/js/src/generators/library/files/lib/tsconfig.lib.json__tmpl__
@@ -6,5 +6,8 @@
     "types": ["node"]
   },
   "include": ["src/**/*.ts"<% if (js) { %>, "src/**/*.js"<% } %>],
-  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"<% if (js) { %>, "src/**/*.spec.js", "src/**/*.test.js"<% } %>]
+  "exclude": [
+    <% if (hasUnitTestRunner && unitTestRunner === 'jest') { %>"jest.config.ts", 
+    <% } else if (hasUnitTestRunner) { %>"vite.config.ts", 
+    <% } %>"src/**/*.spec.ts", "src/**/*.test.ts"<% if (js) { %>, "src/**/*.spec.js", "src/**/*.test.js"<% } %>]
 }

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -1181,6 +1181,8 @@ describe('lib', () => {
         executor: '@nx/vite:test',
       });
       expect(tree.exists('my-lib/vite.config.ts')).toBeTruthy();
+      expect(tree.read('my-lib/README.md', 'utf-8')).toMatchSnapshot();
+      expect(tree.read('my-lib/tsconfig.lib.json', 'utf-8')).toMatchSnapshot();
       expect(readJson(tree, 'my-lib/.eslintrc.json').overrides).toContainEqual({
         files: ['*.json'],
         parser: 'jsonc-eslint-parser',
@@ -1211,6 +1213,10 @@ describe('lib', () => {
         });
 
         const project = readProjectConfiguration(tree, 'my-lib');
+        expect(tree.read('my-lib/README.md', 'utf-8')).toMatchSnapshot();
+        expect(
+          tree.read('my-lib/tsconfig.lib.json', 'utf-8')
+        ).toMatchSnapshot();
         expect(project.targets.test?.executor).toEqual(executor);
       }
     );


### PR DESCRIPTION
## Current Behavior
Jest is hardcoded regardless of test runner that is selected in the generator

## Expected Behavior
generated output should reflect the selected options for accuracy and consistency

## Related Issue(s)

Fixes #20571
