### PR TITLE
feat(core): targets inferred from plugins override targetDefaults

### DIFF
--- a/packages/cypress/src/plugins/plugin.spec.ts
+++ b/packages/cypress/src/plugins/plugin.spec.ts
@@ -19,6 +19,13 @@ describe('@nx/cypress/plugin', () => {
     });
     context = {
       nxJsonConfiguration: {
+        // These defaults should be overridden by plugin
+        targetDefaults: {
+          e2e: {
+            cache: false,
+            inputs: ['foo', '^foo'],
+          },
+        },
         namedInputs: {
           default: ['{projectRoot}/**/*'],
           production: ['!{projectRoot}/**/*.spec.ts'],

--- a/packages/eslint/src/plugins/plugin.spec.ts
+++ b/packages/eslint/src/plugins/plugin.spec.ts
@@ -17,6 +17,13 @@ describe('@nx/eslint/plugin', () => {
   beforeEach(async () => {
     context = {
       nxJsonConfiguration: {
+        // These defaults should be overridden by plugin
+        targetDefaults: {
+          lint: {
+            cache: false,
+            inputs: ['foo', '^foo'],
+          },
+        },
         namedInputs: {
           default: ['{projectRoot}/**/*'],
           production: ['!{projectRoot}/**/*.spec.ts'],

--- a/packages/eslint/src/plugins/plugin.ts
+++ b/packages/eslint/src/plugins/plugin.ts
@@ -4,7 +4,6 @@ import {
   TargetConfiguration,
 } from '@nx/devkit';
 import { dirname, join } from 'path';
-import { readTargetDefaultsForTarget } from 'nx/src/project-graph/utils/project-configuration-utils';
 import { readdirSync } from 'fs';
 import { combineGlobPatterns } from 'nx/src/utils/globs';
 import {
@@ -103,12 +102,6 @@ function buildEslintTargets(
   options: EslintPluginOptions,
   context: CreateNodesContext
 ) {
-  const targetDefaults = readTargetDefaultsForTarget(
-    options.targetName,
-    context.nxJsonConfiguration.targetDefaults,
-    '@nx/eslint:lint'
-  );
-
   const isRootProject = projectRoot === '.';
 
   const targets: Record<string, TargetConfiguration> = {};
@@ -127,8 +120,8 @@ function buildEslintTargets(
 
   targets[options.targetName] = {
     ...baseTargetConfig,
-    cache: targetDefaults?.cache ?? true,
-    inputs: targetDefaults?.inputs ?? [
+    cache: true,
+    inputs: [
       'default',
       ...eslintConfigs.map((config) => `{workspaceRoot}/${config}`),
       '{workspaceRoot}/tools/eslint-rules/**/*',

--- a/packages/nuxt/src/plugins/plugin.spec.ts
+++ b/packages/nuxt/src/plugins/plugin.spec.ts
@@ -29,6 +29,13 @@ describe('@nx/nuxt/plugin', () => {
     beforeEach(async () => {
       context = {
         nxJsonConfiguration: {
+          // These defaults should be overridden by plugin
+          targetDefaults: {
+            build: {
+              cache: false,
+              inputs: ['foo', '^foo'],
+            },
+          },
           namedInputs: {
             default: ['{projectRoot}/**/*'],
             production: ['!{projectRoot}/**/*.spec.ts'],

--- a/packages/vite/src/plugins/plugin.spec.ts
+++ b/packages/vite/src/plugins/plugin.spec.ts
@@ -19,6 +19,13 @@ describe('@nx/vite/plugin', () => {
     beforeEach(async () => {
       context = {
         nxJsonConfiguration: {
+          // These defaults should be overridden by plugin
+          targetDefaults: {
+            build: {
+              cache: false,
+              inputs: ['foo', '^foo'],
+            },
+          },
           namedInputs: {
             default: ['{projectRoot}/**/*'],
             production: ['!{projectRoot}/**/*.spec.ts'],

--- a/packages/webpack/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/webpack/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`@nx/webpack/plugin should create nodes 1`] = `
+{
+  "projects": {
+    "my-app": {
+      "projectType": "application",
+      "targets": {
+        "build-something": {
+          "cache": true,
+          "command": "webpack -c webpack.config.js --node-env=production",
+          "inputs": [
+            "default",
+            "^production",
+            {
+              "externalDependencies": [
+                "webpack-cli",
+              ],
+            },
+          ],
+          "options": {
+            "cwd": "my-app",
+          },
+          "outputs": [
+            "dist/foo",
+          ],
+        },
+        "my-serve": {
+          "command": "webpack serve -c webpack.config.js --node-env=development",
+          "options": {
+            "cwd": "my-app",
+          },
+        },
+        "preview-site": {
+          "command": "webpack serve -c webpack.config.js --node-env=production",
+          "options": {
+            "cwd": "my-app",
+          },
+        },
+        "serve-static": {
+          "executor": "@nx/web:file-server",
+          "options": {
+            "buildTarget": "build-something",
+          },
+        },
+      },
+    },
+  },
+}
+`;

--- a/packages/webpack/src/plugins/plugin.spec.ts
+++ b/packages/webpack/src/plugins/plugin.spec.ts
@@ -1,0 +1,60 @@
+import { CreateNodesContext } from '@nx/devkit';
+import { createNodes } from './plugin';
+import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
+import { join } from 'path';
+
+describe('@nx/webpack/plugin', () => {
+  let createNodesFunction = createNodes[1];
+  let context: CreateNodesContext;
+  let tempFs: TempFs;
+
+  beforeEach(() => {
+    tempFs = new TempFs('webpack-plugin');
+
+    context = {
+      nxJsonConfiguration: {
+        namedInputs: {
+          default: ['{projectRoot}/**/*'],
+          production: ['!{projectRoot}/**/*.spec.ts'],
+        },
+      },
+      workspaceRoot: tempFs.tempDir,
+    };
+
+    tempFs.createFileSync(
+      'my-app/project.json',
+      JSON.stringify({ name: 'my-app' })
+    );
+    tempFs.createFileSync('my-app/webpack.config.js', '');
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('should create nodes', async () => {
+    mockWebpackConfig({
+      output: {
+        path: 'dist/foo',
+      },
+    });
+    const nodes = await createNodesFunction(
+      'my-app/webpack.config.js',
+      {
+        buildTargetName: 'build-something',
+        serveTargetName: 'my-serve',
+        previewTargetName: 'preview-site',
+        serveStaticTargetName: 'serve-static',
+      },
+      context
+    );
+
+    expect(nodes).toMatchSnapshot();
+  });
+
+  function mockWebpackConfig(config: any) {
+    jest.mock(join(tempFs.tempDir, 'my-app/webpack.config.js'), () => config, {
+      virtual: true,
+    });
+  }
+});

--- a/packages/webpack/src/plugins/plugin.ts
+++ b/packages/webpack/src/plugins/plugin.ts
@@ -10,7 +10,6 @@ import {
 } from '@nx/devkit';
 import { basename, dirname, isAbsolute, join, relative } from 'path';
 import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
-import { readTargetDefaultsForTarget } from 'nx/src/project-graph/utils/project-configuration-utils';
 import { WebpackExecutorOptions } from '../executors/webpack/schema';
 import { WebDevServerOptions } from '../executors/dev-server/schema';
 import { existsSync, readdirSync } from 'fs';
@@ -124,22 +123,9 @@ async function createWebpackTargets(
 
   targets[options.buildTargetName] = {
     command: `webpack -c ${configBasename} --node-env=production`,
-    options: {
-      cwd: projectRoot,
-    },
-  };
-
-  const buildTargetDefaults = readTargetDefaultsForTarget(
-    options.buildTargetName,
-    context.nxJsonConfiguration.targetDefaults
-  );
-
-  if (buildTargetDefaults?.cache === undefined) {
-    targets[options.buildTargetName].cache = true;
-  }
-
-  if (buildTargetDefaults?.inputs === undefined) {
-    targets[options.buildTargetName].inputs =
+    options: { cwd: projectRoot },
+    cache: true,
+    inputs:
       'production' in namedInputs
         ? [
             'default',
@@ -154,12 +140,9 @@ async function createWebpackTargets(
             {
               externalDependencies: ['webpack-cli'],
             },
-          ];
-  }
-
-  if (buildTargetDefaults?.outputs === undefined) {
-    targets[options.buildTargetName].outputs = [outputPath];
-  }
+          ],
+    outputs: [outputPath],
+  };
 
   targets[options.serveTargetName] = {
     command: `webpack serve -c ${configBasename} --node-env=development`,


### PR DESCRIPTION
As discussed, the targets inferred by Nx plugins will completely override `targetDefaults` inside `nx.json`. If users want to override any settings, they need to add an entry to `project.json` instead.

In the future, we will no longer generate `nx.json` with `targetDefaults`, so the only two places to check are plugins and `project.json`.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
