### PR TITLE
fix(repo): fix release script to look for new node auth token

### DIFF
--- a/scripts/nx-release.ts
+++ b/scripts/nx-release.ts
@@ -36,7 +36,7 @@ const LARGE_BUFFER = 1024 * 1000000;
   });
 
   // Expected to run as part of the Github `publish` workflow
-  if (!options.local && process.env.NPM_TOKEN) {
+  if (!options.local && process.env.NODE_AUTH_TOKEN) {
     // Delete all .node files that were built during the previous steps
     // Always run before the artifacts step because we still need the .node files for native-packages
     execSync('find ./build -name "*.node" -delete', {
@@ -65,7 +65,7 @@ const LARGE_BUFFER = 1024 * 1000000;
   };
 
   // Intended for creating a github release which triggers the publishing workflow
-  if (!options.local && !process.env.NPM_TOKEN) {
+  if (!options.local && !process.env.NODE_AUTH_TOKEN) {
     // For this important use-case it makes sense to always have full logs
     isVerboseLogging = true;
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The environment variable for running the publish workflow in github actions changed to `NODE_AUTH_TOKEN` but the release script was still looking for `NPM_TOKEN`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The release script looks for `NODE_AUTH_TOKEN`

https://github.com/nrwl/nx/actions/runs/7105681620
