### PR TITLE
fix(core): sort project file map and global files

### DIFF
--- a/packages/nx/src/native/workspace/workspace_files.rs
+++ b/packages/nx/src/native/workspace/workspace_files.rs
@@ -62,6 +62,11 @@ pub(super) fn get_files(
         }
     }
 
+    global_files.par_sort();
+    for (_, project_files) in project_file_map.iter_mut() {
+        project_files.par_sort();
+    }
+
     let project_files_external = External::new(project_file_map.clone());
     let global_files_external = External::new(global_files.clone());
     let all_workspace_files = External::new(files);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The project file map is not sorted after we parallelized processing. When threads finish in a different order, the final array of project files could potentially be inserted into the vec in order of who finished first. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The project file map files are sorted, along with the global files after all processing is done. This ensures that the project file map is deterministic.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
