### PR TITLE
fix(testing): recalculate cypress targets when cypress config changes

### DIFF
--- a/packages/cypress/src/plugins/plugin.ts
+++ b/packages/cypress/src/plugins/plugin.ts
@@ -263,15 +263,15 @@ function getCypressConfig(
     if (tsConfigPath) {
       const unregisterTsProject = registerTsProject(tsConfigPath);
       try {
-        module = require(resolvedPath);
+        module = load(resolvedPath);
       } finally {
         unregisterTsProject();
       }
     } else {
-      module = require(resolvedPath);
+      module = load(resolvedPath);
     }
   } else {
-    module = require(resolvedPath);
+    module = load(resolvedPath);
   }
   return module.default ?? module;
 }
@@ -296,4 +296,19 @@ function getInputs(
       externalDependencies: ['cypress'],
     },
   ];
+}
+
+/**
+ * Load the module after ensuring that the require cache is cleared.
+ */
+function load(path: string): any {
+  // Clear cache if the path is in the cache
+  if (require.cache[path]) {
+    for (const k of Object.keys(require.cache)) {
+      delete require.cache[k];
+    }
+  }
+
+  // Then require
+  return require(path);
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

When the daemon is enabled, the cypress config is loaded from the `require` cache which means changing the `cypress.config.ts` doesn't change the project config.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `require` cache is cleared before loading the `cypress.config.ts` to ensure that changes are picked up.

I tried to use `import()` which has a separate cache but had a lot of issues loading `.ts` files with `import()`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
