### PR TITLE
docs(core): fix home page link

### DIFF
--- a/docs/shared/recipes/storybook/storybook-composition-setup.md
+++ b/docs/shared/recipes/storybook/storybook-composition-setup.md
@@ -140,7 +140,7 @@ export default config;
 
 ### Optional: use `run-commands` and create a `storybook-composition` target
 
-If you want to take advantage of the [`run-commands`](https://nx.dev/api/nx/executors/run-commands) functionality of Nx, you can create a custom target that will invoke the `run-parallel` command for your "composed" Storybook instances.
+If you want to take advantage of the [`run-commands`](/nx-api/nx/executors/run-commands) functionality of Nx, you can create a custom target that will invoke the `run-parallel` command for your "composed" Storybook instances.
 
 The objective is to end up with a new target in your `main-host`'s `project.json` file (`apps/main-host/project.json`) that looks like this:
 

--- a/nx-dev/ui-common/src/lib/header.tsx
+++ b/nx-dev/ui-common/src/lib/header.tsx
@@ -30,7 +30,7 @@ export function Header(): JSX.Element {
       name: 'Distributed cache & task execution',
       description:
         'Executes tasks remotely on different agents in parallel. Enable remote cache in one command.',
-      href: '/core-features/distribute-task-execution',
+      href: '/ci/features/distribute-task-execution',
     },
     {
       name: 'Recipes',


### PR DESCRIPTION
Fixes a couple links
- A storybook recipe was pointing to an old version of an api page
- The `Distributed cache & task execution` link was pointing to an old url that had a redirect created, but the redirect was not being applied because the link is a next/link, not a normal \<a\> tag.

Unfortunately, if you use an \<a\> tag, there's a flash of white while the page reloads (for dark theme users).  So the best fix was to make the url be correct instead of changing to an \<a\> tag.