### PR TITLE
feat(react): treat window and var library types the same

### DIFF
--- a/packages/react/src/module-federation/with-module-federation.ts
+++ b/packages/react/src/module-federation/with-module-federation.ts
@@ -3,6 +3,8 @@ import { getModuleFederationConfig } from './utils';
 import type { AsyncNxComposableWebpackPlugin } from '@nx/webpack';
 import ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
 
+const isVarOrWindow = (libType?: string) => libType === 'var' || libType === 'window';
+
 /**
  * @param {ModuleFederationConfig} options
  * @return {Promise<AsyncNxComposableWebpackPlugin>}
@@ -17,7 +19,7 @@ export async function withModuleFederation(
     config.output.uniqueName = options.name;
     config.output.publicPath = 'auto';
 
-    if (options.library?.type === 'var') {
+    if (isVarOrWindow(options.library?.type)) {
       config.output.scriptType = 'text/javascript';
     }
 
@@ -27,7 +29,7 @@ export async function withModuleFederation(
 
     config.experiments = {
       ...config.experiments,
-      outputModule: !(options.library?.type === 'var'),
+      outputModule: !isVarOrWindow(options.library?.type),
     };
 
     config.plugins.push(
@@ -46,7 +48,7 @@ export async function withModuleFederation(
          *  { appX: 'appX@http://localhost:3001/remoteEntry.js' }
          *  { appY: 'appY@http://localhost:3002/remoteEntry.js' }
          */
-        ...(options.library?.type === 'var' ? { remoteType: 'script' } : {}),
+        ...(isVarOrWindow(options.library?.type) ? { remoteType: 'script' } : {}),
       }),
       sharedLibraries.getReplacementPlugin()
     );

--- a/packages/react/src/module-federation/with-module-federation.ts
+++ b/packages/react/src/module-federation/with-module-federation.ts
@@ -3,7 +3,8 @@ import { getModuleFederationConfig } from './utils';
 import type { AsyncNxComposableWebpackPlugin } from '@nx/webpack';
 import ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
 
-const isVarOrWindow = (libType?: string) => libType === 'var' || libType === 'window';
+const isVarOrWindow = (libType?: string) =>
+  libType === 'var' || libType === 'window';
 
 /**
  * @param {ModuleFederationConfig} options
@@ -14,12 +15,13 @@ export async function withModuleFederation(
 ): Promise<AsyncNxComposableWebpackPlugin> {
   const { sharedDependencies, sharedLibraries, mappedRemotes } =
     await getModuleFederationConfig(options);
+  const isGlobal = isVarOrWindow(options.library?.type);
 
   return (config, ctx) => {
     config.output.uniqueName = options.name;
     config.output.publicPath = 'auto';
 
-    if (isVarOrWindow(options.library?.type)) {
+    if (isGlobal) {
       config.output.scriptType = 'text/javascript';
     }
 
@@ -29,7 +31,7 @@ export async function withModuleFederation(
 
     config.experiments = {
       ...config.experiments,
-      outputModule: !isVarOrWindow(options.library?.type),
+      outputModule: !isGlobal,
     };
 
     config.plugins.push(
@@ -48,7 +50,7 @@ export async function withModuleFederation(
          *  { appX: 'appX@http://localhost:3001/remoteEntry.js' }
          *  { appY: 'appY@http://localhost:3002/remoteEntry.js' }
          */
-        ...(isVarOrWindow(options.library?.type) ? { remoteType: 'script' } : {}),
+        ...(isGlobal ? { remoteType: 'script' } : {}),
       }),
       sharedLibraries.getReplacementPlugin()
     );


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
If user specifies 'var' as library output type in the module federation config then the ModuleFederationPlugin options are slightly different. These same changes could also apply to the 'window' library type.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Both window and var library types will add the container to the global scope so they both can be accessed like `window[containerName]`, but the window library type ensures the container is attached to the global scope for both module and non module script types.
