### PR TITLE
fix(release): do not update dependents when they already use "*"

### DIFF
--- a/packages/js/src/generators/release-version/release-version.spec.ts
+++ b/packages/js/src/generators/release-version/release-version.spec.ts
@@ -419,6 +419,98 @@ To fix this you will either need to add a package.json file at that location, or
         `);
       });
 
+      it(`should not update dependents when they are using version "*"`, async () => {
+        projectGraph = createWorkspaceWithPackageDependencies(tree, {
+          'my-lib': {
+            projectRoot: 'libs/my-lib',
+            packageName: 'my-lib',
+            version: '0.0.1',
+            packageJsonPath: 'libs/my-lib/package.json',
+            localDependencies: [],
+          },
+          'project-with-dependency-on-my-pkg': {
+            projectRoot: 'libs/project-with-dependency-on-my-pkg',
+            packageName: 'project-with-dependency-on-my-pkg',
+            version: '0.0.1',
+            packageJsonPath:
+              'libs/project-with-dependency-on-my-pkg/package.json',
+            localDependencies: [
+              {
+                projectName: 'my-lib',
+                dependencyCollection: 'dependencies',
+                version: '*',
+              },
+            ],
+          },
+          'project-with-devDependency-on-my-pkg': {
+            projectRoot: 'libs/project-with-devDependency-on-my-pkg',
+            packageName: 'project-with-devDependency-on-my-pkg',
+            version: '0.0.1',
+            packageJsonPath:
+              'libs/project-with-devDependency-on-my-pkg/package.json',
+            localDependencies: [
+              {
+                projectName: 'my-lib',
+                dependencyCollection: 'devDependencies',
+                version: '*',
+              },
+            ],
+          },
+        });
+
+        expect(readJson(tree, 'libs/my-lib/package.json').version).toEqual(
+          '0.0.1'
+        );
+        expect(
+          readJson(tree, 'libs/project-with-dependency-on-my-pkg/package.json')
+            .version
+        ).toEqual('0.0.1');
+
+        await releaseVersionGenerator(tree, {
+          projects: Object.values(projectGraph.nodes), // version all projects
+          projectGraph,
+          specifier: '4.5.6', // user CLI specifier override set, no prompting should occur
+          currentVersionResolver: 'disk',
+          specifierSource: 'prompt',
+          releaseGroup: createReleaseGroup('independent'),
+        });
+
+        expect(readJson(tree, 'libs/my-lib/package.json'))
+          .toMatchInlineSnapshot(`
+          {
+            "name": "my-lib",
+            "version": "4.5.6",
+          }
+        `);
+
+        expect(
+          readJson(tree, 'libs/project-with-dependency-on-my-pkg/package.json')
+        ).toMatchInlineSnapshot(`
+          {
+            "dependencies": {
+              "my-lib": "*",
+            },
+            "name": "project-with-dependency-on-my-pkg",
+            "version": "4.5.6",
+          }
+        `);
+
+        expect(
+          readJson(
+            tree,
+            'libs/project-with-devDependency-on-my-pkg/package.json'
+          )
+        ).toMatchInlineSnapshot(`
+          {
+            "devDependencies": {
+              "my-lib": "*",
+            },
+            "name": "project-with-devDependency-on-my-pkg",
+            "version": "4.5.6",
+          }
+        `);
+      });
+
       it(`should update dependents even when filtering to a subset of projects which do not include those dependents`, async () => {
         expect(readJson(tree, 'libs/my-lib/package.json').version).toEqual(
           '0.0.1'

--- a/packages/js/src/generators/release-version/release-version.ts
+++ b/packages/js/src/generators/release-version/release-version.ts
@@ -372,6 +372,12 @@ To fix this you will either need to add a package.json file at that location, or
             'package.json'
           ),
           (json) => {
+            // Do not update "*" as it already matches all possible versions including the new one
+            if (
+              json[dependentProject.dependencyCollection][packageName] === '*'
+            ) {
+              return json;
+            }
             json[dependentProject.dependencyCollection][packageName] =
               newVersion;
             return json;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`nx release version` always updates the package.json of dependents, even if they are referencing the package version using "*"

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`nx release version` will only update the package.json of dependents when the version is not "*"

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
