### PR TITLE
feat(bundling): bump rollup-plugin-typescript2 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -259,7 +259,7 @@
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-postcss": "^4.0.1",
-    "rollup-plugin-typescript2": "0.34.1",
+    "rollup-plugin-typescript2": "0.36.0",
     "rxjs": "^7.8.0",
     "sass": "1.55.0",
     "sass-loader": "^12.2.0",

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -42,7 +42,7 @@
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-postcss": "^4.0.1",
-    "rollup-plugin-typescript2": "0.34.1",
+    "rollup-plugin-typescript2": "0.36.0",
     "rxjs": "^7.8.0",
     "tslib": "^2.3.0",
     "@nx/devkit": "file:../devkit",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -845,8 +845,8 @@ devDependencies:
     specifier: ^4.0.1
     version: 4.0.2(postcss@8.4.19)(ts-node@10.9.1)
   rollup-plugin-typescript2:
-    specifier: 0.34.1
-    version: 0.34.1(rollup@2.79.0)(typescript@5.3.3)
+    specifier: 0.36.0
+    version: 0.36.0(rollup@2.79.0)(typescript@5.3.3)
   rxjs:
     specifier: ^7.8.0
     version: 7.8.1
@@ -28718,8 +28718,8 @@ packages:
       - ts-node
     dev: true
 
-  /rollup-plugin-typescript2@0.34.1(rollup@2.79.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-P4cHLtGikESmqi1CA+tdMDUv8WbQV48mzPYt77TSTOPJpERyZ9TXdDgjSDix8Fkqce6soYz3+fa4lrC93IEkcw==}
+  /rollup-plugin-typescript2@0.36.0(rollup@2.79.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-NB2CSQDxSe9+Oe2ahZbf+B4bh7pHwjV5L+RSYpCu7Q5ROuN94F9b6ioWwKfz3ueL3KTtmX4o2MUH2cgHDIEUsw==}
     peerDependencies:
       rollup: '>=1.26.3'
       typescript: '>=2.4.0'
@@ -28728,8 +28728,8 @@ packages:
       find-cache-dir: 3.3.2
       fs-extra: 10.1.0
       rollup: 2.79.0
-      semver: 7.5.3
-      tslib: 2.5.0
+      semver: 7.5.4
+      tslib: 2.6.2
       typescript: 5.3.3
     dev: true
 


### PR DESCRIPTION
## Reproduction
1. Create workspace
```
npx create-nx-workspace@17.1.3 --preset=npm --workspaceType=package-based --nxCloud=false bug-demo

cd bug-demo
```

2. Create a library 
```
nx g @nx/js:lib maskito --unitTestRunner=none --bundler=tsc --directory=packages/maskito
```

3. Install `libphonenumber-js`
```
npm i libphonenumber-js
```

4. Use `libphonenumber-js` inside `bug-demo/packages/maskito/src/index.ts`:
```ts
import {MetadataJson} from 'libphonenumber-js/core';

export const debug: MetadataJson | null = null;
```

Run `nx build maskito` => Build is successful ✅

5. Install `@nx/rollup`
```
npm i @nx/rollup@17.1.3 -D
```

6. Change executor of the library
```
nx g @nx/rollup:configuration --project=maskito --skipValidation
```

7. Run 
```
nx build maskito
```

It throws error ❌
```
> nx run maskito:build:production

Bundling maskito...
Error during bundle: Error: Unexpected token (Note that you need plugins to import files that are not JavaScript)
Bundle failed: maskito
```


## How to check it ?
1. Use the reproduction above
2. Add these lines to root `package.json`
```json
    "overrides": {
        "rollup-plugin-typescript2": "0.35.0"
    },
```
3. Run again `npm i`
4. Run `nx build maskito`

Build is successful ✅

## Related Issue(s)
* https://github.com/ezolenko/rollup-plugin-typescript2/issues/446
