### PR TITLE
chore(repo): add `rollup` to `allowedScopes` for `commit-lint.js`

### DIFF
--- a/scripts/commitizen.js
+++ b/scripts/commitizen.js
@@ -22,6 +22,7 @@ const scopes = [
   { value: 'expo',          name: 'expo:            anything Expo specific' },
   { value: 'release',       name: 'release:         anything related to nx release' },
   { value: 'repo',          name: 'repo:            anything related to managing the repo itself' },
+  { value: 'rollup',        name: 'rollup:          anything Rollup specific' },
   { value: 'storybook',     name: 'storybook:       anything Storybook specific' },
   { value: 'testing',       name: 'testing:         anything testing specific (e.g. jest or cypress)' },
   { value: 'vite',          name: 'vite:            anything Vite specific' },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
See this PR:
* https://github.com/nrwl/nx/pull/20609

Its commit message contains `rollup`-scope.
But `commit-lint.js` fails with error:
```
> @nx/nx-source@ check-commit /home/circleci/repo
> node ./scripts/commit-lint.js

🐟🐟🐟 Validating git commit message 🐟🐟🐟
[Error]: Oh no! 😦 Your commit message: 
-------------------------------------------------------------------
commit e419cc9ce795494af006fa68c17401cba977c05b
Author: Nikita Barsukov <nikita.s.barsukov@gmail.com>
Date:   Wed Dec 6 17:37:57 2023 +0300

    fix(rollup): add support for `*.d.cts` / `*.d.mts` file types
-------------------------------------------------------------------

 👉️ Does not follow the commit message convention specified in the CONTRIBUTING.MD file.

type(scope): subject 
 BLANK LINE 
 body


possible types: feat|fix|docs|cleanup|chore
possible scopes: angular|core|bundling|detox|devkit|express|graph|js|linter|misc|nest|nextjs|node|nuxt|nx-cloud|nx-plugin|nx-dev|react|react-native|expo|release|repo|storybook|testing|vite|vue|web|webpack|module-federation (if unsure use "core")

EXAMPLE: 
feat(nx): add an option to generate lazy-loadable modules
```

## Expected Behavior
Lint passes because there is package `rollup`:
https://github.com/nrwl/nx/tree/master/packages/rollup

