### PR TITLE
fix(core): add 'dependsOn' property in when inferring build targets via plugins

### DIFF
--- a/packages/nuxt/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/nuxt/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -9,6 +9,9 @@ exports[`@nx/nuxt/plugin not root project should create nodes 1`] = `
         "build-something": {
           "cache": true,
           "command": "nuxi build",
+          "dependsOn": [
+            "^build-something",
+          ],
           "inputs": [
             "default",
             "^production",
@@ -66,6 +69,9 @@ exports[`@nx/nuxt/plugin root project should create nodes 1`] = `
         "build": {
           "cache": true,
           "command": "nuxi build",
+          "dependsOn": [
+            "^build",
+          ],
           "inputs": [
             "default",
             "^production",

--- a/packages/nuxt/src/plugins/plugin.ts
+++ b/packages/nuxt/src/plugins/plugin.ts
@@ -101,6 +101,7 @@ async function buildNuxtTargets(
   const targets: Record<string, TargetConfiguration> = {};
 
   targets[options.buildTargetName] = buildTarget(
+    options.buildTargetName,
     namedInputs,
     buildOutputs,
     projectRoot
@@ -118,6 +119,7 @@ async function buildNuxtTargets(
 }
 
 function buildTarget(
+  buildTargetName: string,
   namedInputs: {
     [inputName: string]: any[];
   },
@@ -128,6 +130,7 @@ function buildTarget(
     command: `nuxi build`,
     options: { cwd: projectRoot },
     cache: true,
+    dependsOn: [`^${buildTargetName}`],
     inputs: [
       ...('production' in namedInputs
         ? ['default', '^production']

--- a/packages/vite/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/vite/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -9,6 +9,9 @@ exports[`@nx/vite/plugin not root project should create nodes 1`] = `
         "build-something": {
           "cache": true,
           "command": "vite build",
+          "dependsOn": [
+            "^build-something",
+          ],
           "inputs": [
             "production",
             "^production",
@@ -77,6 +80,9 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
         "build": {
           "cache": true,
           "command": "vite build",
+          "dependsOn": [
+            "^build",
+          ],
           "inputs": [
             "production",
             "^production",

--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -110,6 +110,7 @@ async function buildViteTargets(
   const targets: Record<string, TargetConfiguration> = {};
 
   targets[options.buildTargetName] = await buildTarget(
+    options.buildTargetName,
     namedInputs,
     buildOutputs,
     projectRoot
@@ -131,6 +132,7 @@ async function buildViteTargets(
 }
 
 async function buildTarget(
+  buildTargetName: string,
   namedInputs: {
     [inputName: string]: any[];
   },
@@ -141,6 +143,7 @@ async function buildTarget(
     command: `vite build`,
     options: { cwd: joinPathFragments(projectRoot) },
     cache: true,
+    dependsOn: [`^${buildTargetName}`],
     inputs: [
       ...('production' in namedInputs
         ? ['production', '^production']

--- a/packages/webpack/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/webpack/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -9,6 +9,9 @@ exports[`@nx/webpack/plugin should create nodes 1`] = `
         "build-something": {
           "cache": true,
           "command": "webpack -c webpack.config.js --node-env=production",
+          "dependsOn": [
+            "^build-something",
+          ],
           "inputs": [
             "default",
             "^production",

--- a/packages/webpack/src/plugins/plugin.ts
+++ b/packages/webpack/src/plugins/plugin.ts
@@ -125,6 +125,7 @@ async function createWebpackTargets(
     command: `webpack -c ${configBasename} --node-env=production`,
     options: { cwd: projectRoot },
     cache: true,
+    dependsOn: [`^${options.buildTargetName}`],
     inputs:
       'production' in namedInputs
         ? [


### PR DESCRIPTION
This PR ensures that `build` targets have `dependsOn: ['^build']` set by default, since `targetDefaults` may not be providing the defaults.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
