### PR TITLE
fix(nextjs): apply transpilation fixes and other webpack config when running dev-server

### DIFF
--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -150,7 +150,7 @@ function withNx(
     const { PHASE_PRODUCTION_SERVER, PHASE_DEVELOPMENT_SERVER } = await import(
       'next/constants'
     );
-    if ([PHASE_PRODUCTION_SERVER, PHASE_DEVELOPMENT_SERVER].includes(phase)) {
+    if (PHASE_PRODUCTION_SERVER === phase) {
       // If we are running an already built production server, just return the configuration.
       // NOTE: Avoid any `require(...)` or `import(...)` statements here. Development dependencies are not available at production runtime.
       const { nx, ...validNextConfig } = _nextConfig;
@@ -233,10 +233,14 @@ function withNx(
         const outputDir = `${offsetFromRoot(projectDirectory)}${
           options.outputPath
         }`;
-        nextConfig.distDir =
-          nextConfig.distDir && nextConfig.distDir !== '.next'
-            ? joinPathFragments(outputDir, nextConfig.distDir)
-            : joinPathFragments(outputDir, '.next');
+        // If running dev-server, we should keep `.next` inside project directory since Turbopack expects this.
+        // See: https://github.com/nrwl/nx/issues/19365
+        if (phase !== PHASE_DEVELOPMENT_SERVER) {
+          nextConfig.distDir =
+            nextConfig.distDir && nextConfig.distDir !== '.next'
+              ? joinPathFragments(outputDir, nextConfig.distDir)
+              : joinPathFragments(outputDir, '.next');
+        }
       }
 
       const userWebpackConfig = nextConfig.webpack;


### PR DESCRIPTION
Next.js' webpack build treat workspace libs as third-party packages, and bypass transpilation for them. We need to make all of the same webpack config changes during dev-server as we do for build.

This PR moves the Turbopack fix lower in the withNx function, so all of the previous webpack config are still added.

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
