### PR TITLE
fix(testing): add webServerCommands/ciWebServerCommands option for cy…

### DIFF
--- a/packages/cypress/src/generators/configuration/configuration.spec.ts
+++ b/packages/cypress/src/generators/configuration/configuration.spec.ts
@@ -43,6 +43,11 @@ describe('Cypress e2e configuration', () => {
       await cypressE2EConfigurationGenerator(tree, {
         project: 'my-app',
         baseUrl: 'http://localhost:4200',
+        webServerCommands: {
+          default: 'nx run my-app:serve',
+          production: 'nx run my-app:serve:production',
+        },
+        ciWebServerCommand: 'nx run my-app:serve-static',
       });
       expect(tree.read('apps/my-app/cypress.config.ts', 'utf-8'))
         .toMatchInlineSnapshot(`

--- a/packages/cypress/src/generators/configuration/configuration.ts
+++ b/packages/cypress/src/generators/configuration/configuration.ts
@@ -40,6 +40,9 @@ export interface CypressE2EConfigSchema {
   port?: number | 'cypress-auto';
   jsx?: boolean;
   rootProject?: boolean;
+
+  webServerCommands?: Record<string, string>;
+  ciWebServerCommand?: string;
 }
 
 type NormalizedSchema = ReturnType<typeof normalizeOptions>;
@@ -166,9 +169,12 @@ async function addFiles(
     const cyFile = joinPathFragments(projectConfig.root, 'cypress.config.ts');
     let webServerCommands: Record<string, string>;
 
-    let ciDevServerTarget: string;
+    let ciWebServerCommand: string;
 
-    if (hasPlugin && options.devServerTarget) {
+    if (hasPlugin && options.webServerCommands && options.ciWebServerCommand) {
+      webServerCommands = options.webServerCommands;
+      ciWebServerCommand = options.ciWebServerCommand;
+    } else if (hasPlugin && options.devServerTarget) {
       webServerCommands = {};
 
       webServerCommands.default = 'nx run ' + options.devServerTarget;
@@ -192,7 +198,7 @@ async function addFiles(
       }
       // Add ci/static e2e target if serve target is found
       if (devServerProjectConfig.targets?.['serve-static']) {
-        ciDevServerTarget = `nx run ${parsedTarget.project}:serve-static`;
+        ciWebServerCommand = `nx run ${parsedTarget.project}:serve-static`;
       }
     }
     const updatedCyConfig = await addDefaultE2EConfig(
@@ -201,7 +207,7 @@ async function addFiles(
         cypressDir: options.directory,
         bundler: options.bundler === 'vite' ? 'vite' : undefined,
         webServerCommands,
-        ciWebServerCommand: ciDevServerTarget,
+        ciWebServerCommand: ciWebServerCommand,
       },
       options.baseUrl
     );

--- a/packages/react/src/generators/application/lib/add-e2e.ts
+++ b/packages/react/src/generators/application/lib/add-e2e.ts
@@ -18,10 +18,10 @@ export async function addE2e(
 ): Promise<GeneratorCallback> {
   switch (options.e2eTestRunner) {
     case 'cypress': {
-      if (
-        (options.bundler === 'webpack' && !hasWebpackPlugin(tree)) ||
-        (options.bundler === 'vite' && !hasVitePlugin(tree))
-      ) {
+      const hasNxBuildPlugin =
+        (options.bundler === 'webpack' && hasWebpackPlugin(tree)) ||
+        (options.bundler === 'vite' && hasVitePlugin(tree));
+      if (!hasNxBuildPlugin) {
         webStaticServeGenerator(tree, {
           buildTarget: `${options.projectName}:build`,
           targetName: 'serve-static',
@@ -52,6 +52,15 @@ export async function addE2e(
         baseUrl: 'http://localhost:4200',
         jsx: true,
         rootProject: options.rootProject,
+        webServerCommands: hasNxBuildPlugin
+          ? {
+              default: `nx run ${options.projectName}:serve`,
+              production: `nx run ${options.projectName}:preview`,
+            }
+          : undefined,
+        ciWebServerCommand: hasNxBuildPlugin
+          ? `nx run ${options.projectName}:serve-static`
+          : undefined,
       });
     }
     case 'playwright': {


### PR DESCRIPTION
…press configuration

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The cypress generator looks at the project configuration in the tree to determine if a `serve` and `serve-static` target exist. For PCv3, the tree doesn't have the project configuration.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

There is an option which is used over looking at the project configuration in the tree. Apps should pass this in.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
