### PR TITLE
fix(webpack): ensure webpack config is always at the latest version when running in the daemon

### DIFF
--- a/packages/webpack/src/plugins/plugin.ts
+++ b/packages/webpack/src/plugins/plugin.ts
@@ -109,7 +109,8 @@ async function createWebpackTargets(
   const namedInputs = getNamedInputs(projectRoot, context);
   const webpackConfig = resolveUserDefinedWebpackConfig(
     join(context.workspaceRoot, configFilePath),
-    getRootTsConfigPath()
+    getRootTsConfigPath(),
+    true
   );
   const webpackOptions = await readWebpackOptions(webpackConfig);
 

--- a/packages/webpack/src/utils/webpack/resolve-user-defined-webpack-config.ts
+++ b/packages/webpack/src/utils/webpack/resolve-user-defined-webpack-config.ts
@@ -2,8 +2,20 @@ import { registerTsProject } from '@nx/js/src/internal';
 
 export function resolveUserDefinedWebpackConfig(
   path: string,
-  tsConfig: string
+  tsConfig: string,
+  /** Skip require cache and return latest content */
+  reload = false
 ) {
+  if (reload) {
+    // Clear cache if the path is in the cache
+    if (require.cache[path]) {
+      // Clear all entries because config may import other modules
+      for (const k of Object.keys(require.cache)) {
+        delete require.cache[k];
+      }
+    }
+  }
+
   // Don't transpile non-TS files. This prevents workspaces libs from being registered via tsconfig-paths.
   // There's an issue here with Nx workspace where loading plugins from source (via tsconfig-paths) can lead to errors.
   if (!/\.(ts|mts|cts)$/.test(path)) {


### PR DESCRIPTION
Same as https://github.com/nrwl/nx/pull/20593

Clear the require cache when the config has previously been loaded.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
