### PR TITLE
fix(react): skip adding comma to config when adding remote to host if…

### DIFF
--- a/packages/react/src/module-federation/ast-utils.spec.ts
+++ b/packages/react/src/module-federation/ast-utils.spec.ts
@@ -89,6 +89,41 @@ describe('addRemoteToConfig', () => {
 
     expect(result).toEqual(sourceCode);
   });
+
+  it('should not add comma if the existing array has a trailing comma', async () => {
+    const sourceCode = stripIndents`
+      module.exports = {
+        name: 'shell',
+        remotes: [
+          'app1',
+          'app2',
+        ]
+      };
+    `;
+
+    const source = ts.createSourceFile(
+      '/module-federation.config.js',
+      sourceCode,
+      ts.ScriptTarget.Latest,
+      true
+    );
+
+    const result = applyChangesToString(
+      sourceCode,
+      addRemoteToConfig(source, 'new-app')
+    );
+
+    expect(result).toEqual(stripIndents`
+      module.exports = {
+        name: 'shell',
+        remotes: [
+          'app1',
+          'app2',
+          'new-app',
+        ]
+      };
+    `);
+  });
 });
 
 describe('addRemoteDefinition', () => {

--- a/packages/react/src/module-federation/ast-utils.ts
+++ b/packages/react/src/module-federation/ast-utils.ts
@@ -37,7 +37,7 @@ export function addRemoteToConfig(
     const lastElement =
       arrayExpression.elements[arrayExpression.elements.length - 1];
     return [
-      lastElement
+      lastElement && !arrayExpression.elements.hasTrailingComma
         ? {
             type: ChangeType.Insert,
             index: lastElement.end,


### PR DESCRIPTION
… last remote has a trailing comma

When adding a remote to a host's config, check if the last remotes array has a trailing comma. If it does, skip adding a comma in front of the new remote.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

Let's say I have a React host application with at least one remote defined in the project's module federation configuration file which looks something like the following.

```ts
import { ModuleFederationConfig } from '@nx/webpack';

const config: ModuleFederationConfig = {
  name: 'host',
  remotes: [
    'app-1',
  ],
};

export default config;
```

ℹ️ Notice the trailing comma after `'app-1'`

If I use the `@nx/react:remote` generator to create a new remote – e.g. `nx g remote app-2 --host host` – it will update my host's module federation configuration to the following.

```ts
import { ModuleFederationConfig } from '@nx/webpack';

const config: ModuleFederationConfig = {
  name: 'host',
  remotes: ['app-1', , 'app-2'],
};

export default config;
```

## Expected Behavior

I would expect the generator to take trailing commas into account and update my module federation configuration to something like the following.

```ts
import { ModuleFederationConfig } from '@nx/webpack';

const config: ModuleFederationConfig = {
  name: 'host',
  remotes: [
    'app-1',
    'app-2',
  ],
};

export default config;
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
