### PR TITLE
feat(vue): add nuxt as cnw vue framework

### DIFF
--- a/docs/generated/cli/create-nx-workspace.md
+++ b/docs/generated/cli/create-nx-workspace.md
@@ -139,7 +139,7 @@ Package manager to use
 
 Type: `string`
 
-Customizes the initial content of your workspace. Default presets include: ["apps", "empty", "core", "npm", "ts", "web-components", "angular-monorepo", "angular-standalone", "react-monorepo", "react-standalone", "vue-monorepo", "vue-standalone", "next", "nextjs-standalone", "react-native", "expo", "nest", "express", "react", "angular", "node-standalone", "node-monorepo", "ts-standalone"]. To build your own see https://nx.dev/extending-nx/recipes/create-preset
+Customizes the initial content of your workspace. Default presets include: ["apps", "empty", "core", "npm", "ts", "web-components", "angular-monorepo", "angular-standalone", "react-monorepo", "react-standalone", "vue-monorepo", "vue-standalone", "nuxt", "nuxt-standalone", "next", "nextjs-standalone", "react-native", "expo", "nest", "express", "react", "angular", "node-standalone", "node-monorepo", "ts-standalone"]. To build your own see https://nx.dev/extending-nx/recipes/create-preset
 
 ### routing
 

--- a/docs/generated/packages/nx/documents/create-nx-workspace.md
+++ b/docs/generated/packages/nx/documents/create-nx-workspace.md
@@ -139,7 +139,7 @@ Package manager to use
 
 Type: `string`
 
-Customizes the initial content of your workspace. Default presets include: ["apps", "empty", "core", "npm", "ts", "web-components", "angular-monorepo", "angular-standalone", "react-monorepo", "react-standalone", "vue-monorepo", "vue-standalone", "next", "nextjs-standalone", "react-native", "expo", "nest", "express", "react", "angular", "node-standalone", "node-monorepo", "ts-standalone"]. To build your own see https://nx.dev/extending-nx/recipes/create-preset
+Customizes the initial content of your workspace. Default presets include: ["apps", "empty", "core", "npm", "ts", "web-components", "angular-monorepo", "angular-standalone", "react-monorepo", "react-standalone", "vue-monorepo", "vue-standalone", "nuxt", "nuxt-standalone", "next", "nextjs-standalone", "react-native", "expo", "nest", "express", "react", "angular", "node-standalone", "node-monorepo", "ts-standalone"]. To build your own see https://nx.dev/extending-nx/recipes/create-preset
 
 ### routing
 

--- a/e2e/utils/create-project-utils.ts
+++ b/e2e/utils/create-project-utils.ts
@@ -152,6 +152,7 @@ export function runCreateWorkspace(
     nextAppDir,
     e2eTestRunner,
     ssr,
+    framework,
   }: {
     preset: string;
     appName?: string;
@@ -169,6 +170,7 @@ export function runCreateWorkspace(
     nextAppDir?: boolean;
     e2eTestRunner?: 'cypress' | 'playwright' | 'jest' | 'detox' | 'none';
     ssr?: boolean;
+    framework?: string;
   }
 ) {
   projName = name;
@@ -216,6 +218,10 @@ export function runCreateWorkspace(
 
   if (e2eTestRunner) {
     command += ` --e2eTestRunner=${e2eTestRunner}`;
+  }
+
+  if (framework) {
+    command += ` --framework=${framework}`;
   }
 
   if (extraArgs) {

--- a/e2e/workspace-create/src/create-nx-workspace.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace.test.ts
@@ -448,11 +448,43 @@ describe('create-nx-workspace', () => {
     expectCodeIsFormatted();
   });
 
-  it('should be able to create an vue monorepo', () => {
+  it('should be able to create a vue monorepo', () => {
     const wsName = uniq('vue');
     const appName = uniq('app');
     runCreateWorkspace(wsName, {
       preset: 'vue-monorepo',
+      appName,
+      style: 'css',
+      packageManager,
+      e2eTestRunner: 'none',
+    });
+    expectCodeIsFormatted();
+  });
+
+  it('should create a workspace with a single nuxt app at the root', () => {
+    const wsName = uniq('nuxt');
+
+    runCreateWorkspace(wsName, {
+      preset: 'nuxt-standalone',
+      appName: wsName,
+      style: 'css',
+      packageManager,
+      e2eTestRunner: 'none',
+    });
+
+    checkFilesExist('package.json');
+    checkFilesExist('project.json');
+    checkFilesExist('nuxt.config.ts');
+    checkFilesExist('src/app.vue');
+    checkFilesExist('src/pages/index.vue');
+    expectCodeIsFormatted();
+  });
+
+  it('should be able to create a nuxt monorepo', () => {
+    const wsName = uniq('nuxt');
+    const appName = uniq('app');
+    runCreateWorkspace(wsName, {
+      preset: 'nuxt',
       appName,
       style: 'css',
       packageManager,


### PR DESCRIPTION
Just like for React we have the `framework` option for `Nextjs`, add the `framework` option for Vue to choose between `none` and `nuxt` when creating a new workspace.

```
npx create-nx-workspace my-org

 >  NX   Let's create a new workspace [https://nx.dev/getting-started/intro]

✔ Which stack do you want to use? · vue
? What framework would you like to use? …
None               I only want vue.
Nuxt       [  https://nuxt.com/  ]
```

![Screenshot 2023-12-07 at 4 44 05 PM](https://github.com/nrwl/nx/assets/6603745/709800a4-bb1a-407b-8fc9-23485968c489)



