### PR TITLE
fix(webpack): correctly handle user defined webpack config

### DIFF
--- a/packages/webpack/src/executors/webpack/webpack.impl.ts
+++ b/packages/webpack/src/executors/webpack/webpack.impl.ts
@@ -56,7 +56,10 @@ async function getWebpackConfigs(
     ? {}
     : composePlugins(withNx(options), withWeb(options));
 
-  if (isNxWebpackComposablePlugin(userDefinedWebpackConfig)) {
+  if (
+    isNxWebpackComposablePlugin(userDefinedWebpackConfig) ||
+    typeof userDefinedWebpackConfig === 'function'
+  ) {
     // Old behavior, call the Nx-specific webpack config function that user exports
     return await userDefinedWebpackConfig(config, {
       options,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

A regression was introduced in https://github.com/nrwl/nx/pull/20243 (released under [17.2.0-beta.9](https://github.com/nrwl/nx/releases/tag/17.2.0-beta.9)) in the `@nx/webpack` executor where a user-defined webpack config can be unresolved causing the executor to fail with the following error: 

```
WARNING in configuration
The 'mode' option has not been set, webpack will fallback to 'production' for this value.
Set 'mode' option to 'development' or 'production' to enable defaults for each environment.
You can also set it to 'none' to disable any default behavior. Learn more: https://webpack.js.org/configuration/mode/

ERROR in main
Module not found: Error: Can't resolve './src' in '/xxx/xxx/xxx/repo'
```

Here's what our custom webpack config looks like:

```js
// webpack.config.js
module.exports = async (config, { options, context }) => {
    return merge(config, { /* ... */ });
};
```

## Expected Behavior

When I locally patch the `@nx/webpack` package with my following modifications the config gets correctly resolved and the executor runs successfully again.

## Related Issue(s)

N/A
