### PR TITLE
fix(core): add projects argument to graph command

### DIFF
--- a/packages/nx/src/command-line/yargs-utils/shared-options.ts
+++ b/packages/nx/src/command-line/yargs-utils/shared-options.ts
@@ -260,8 +260,11 @@ export function withDepGraphOptions(yargs: Argv) {
     .option('view', {
       describe: 'Choose whether to view the projects or task graph',
       type: 'string',
-      default: 'projects',
       choices: ['projects', 'tasks'],
+    })
+    .option('projects', {
+      describe: 'The projects to show in the project graph',
+      coerce: parseCSV,
     })
     .option('targets', {
       describe: 'The target to show tasks for in the task graph',
@@ -301,6 +304,23 @@ export function withDepGraphOptions(yargs: Argv) {
       describe: 'Open the project graph in the browser.',
       type: 'boolean',
       default: true,
+    })
+    .middleware((args) => {
+      if (!args.view) {
+        if (args.targets) {
+          args.view = 'tasks';
+        } else {
+          args.view = 'projects';
+        }
+      }
+
+      if (args.projects && !args.targets) {
+        args.focus = args.projects[0];
+      }
+
+      if (args.focus) {
+        args.projects = [args.focus];
+      }
     });
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
There is no way to output a json file with tasks without specifying a project while using the `nx graph` command.

I.E `nx graph --projects project --task build --file=stdout` would not give task graph information

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The projects argument is added to `nx graph` so that we can properly output the task graph with the `--file` argument. 

so `nx graph --projects project --task build --file=stdout` will output the project graph, and the task graph. This would be extremely helpful for debugging task issues. 

BUT WAIT THERES MORE:
* There is also the added bonus of mapping `--projects` to `--focus` so that we can open the proper view in the graph without using the `--file` argument
* Specifying `--tasks` will now default the view to the task view

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
