### PR TITLE
docs(angular): use `@nx/angular:dev-server` instead of legacy `@nx/angular:webpack-dev-server`

### DIFF
--- a/docs/shared/guides/module-federation/dynamic-mfe-angular.md
+++ b/docs/shared/guides/module-federation/dynamic-mfe-angular.md
@@ -99,7 +99,7 @@ For both applications, the generator did the following:
 - Moved the code that is normally in `main.ts` to `bootstrap.ts`
 - Changed `main.ts` to dynamically import `bootstrap.ts` _(this is required for the Module Federation to correct load versions of shared libraries)_
 - Updated the `build` target in the `project.json` to use the `@nx/angular:webpack-browser` executor _(this is required as it supports passing a custom Webpack configuration to the Angular compiler)_
-- Updated the `serve` target to use `@nx/angular:webpack-dev-server` _(this is required as we first need Webpack to build the application with our custom Webpack configuration)_
+- Updated the `serve` target to use `@nx/angular:dev-server` _(this is required as we first need Webpack to build the application with our custom Webpack configuration)_
 
 The key differences reside within the configuration of the Module Federation Plugin within each application's `module-federation.config.js`.
 

--- a/docs/shared/guides/use-environment-variables-in-angular.md
+++ b/docs/shared/guides/use-environment-variables-in-angular.md
@@ -54,7 +54,7 @@ Next, update the `build` and `serve` targets (in `project.json` or `angular.json
   },
   "serve": {
     // NOTE: use dev-server that supports custom webpack config.
-    "executor": "@nx/angular:webpack-dev-server"
+    "executor": "@nx/angular:dev-server"
     // snip
   }
 }


### PR DESCRIPTION
## Expected Behavior
https://github.com/nrwl/nx/blob/be821aa15e0320276e2c0b5ea59fbae1eec3780a/packages/angular/migrations.json#L330

## Related Issue(s)
* https://github.com/nrwl/nx/pull/20311