### PR TITLE
feat(core): add task plans to `--graph=file.json` argument

### DIFF
--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -344,7 +344,12 @@ export async function generateGraph(
     if (args.file === 'stdout') {
       console.log(
         JSON.stringify(
-          await createJsonOutput(prunedGraph, args.projects, args.targets),
+          await createJsonOutput(
+            prunedGraph,
+            rawGraph,
+            args.projects,
+            args.targets
+          ),
           null,
           2
         )
@@ -406,6 +411,7 @@ export async function generateGraph(
       ensureDirSync(dirname(fullFilePath));
 
       const json = await createJsonOutput(
+        prunedGraph,
         rawGraph,
         args.projects,
         args.targets
@@ -1034,12 +1040,13 @@ interface GraphJsonResponse {
 }
 
 async function createJsonOutput(
-  graph: ProjectGraph,
+  prunedGraph: ProjectGraph,
+  rawGraph: ProjectGraph,
   projects: string[],
   targets?: string[]
 ): Promise<GraphJsonResponse> {
   const response: GraphJsonResponse = {
-    graph,
+    graph: prunedGraph,
   };
 
   if (targets?.length) {
@@ -1050,7 +1057,7 @@ async function createJsonOutput(
     );
 
     const taskGraph = createTaskGraph(
-      graph,
+      rawGraph,
       defaultDependencyConfigs,
       projects,
       targets,
@@ -1058,7 +1065,7 @@ async function createJsonOutput(
       {}
     );
 
-    const hasher = createTaskHasher(graph, readNxJson());
+    const hasher = createTaskHasher(rawGraph, readNxJson());
     let tasks = Object.values(taskGraph.tasks);
     const hashes = await hasher.hashTasks(tasks, taskGraph);
     response.tasks = taskGraph;

--- a/packages/nx/src/hasher/create-task-hasher.ts
+++ b/packages/nx/src/hasher/create-task-hasher.ts
@@ -1,0 +1,29 @@
+import { NxJsonConfiguration } from '../config/nx-json';
+import { ProjectGraph } from '../config/project-graph';
+import { daemonClient } from '../daemon/client/client';
+import { getFileMap } from '../project-graph/build-project-graph';
+import {
+  DaemonBasedTaskHasher,
+  InProcessTaskHasher,
+  TaskHasher,
+} from './task-hasher';
+
+export function createTaskHasher(
+  projectGraph: ProjectGraph,
+  nxJson: NxJsonConfiguration,
+  runnerOptions?: any
+): TaskHasher {
+  if (daemonClient.enabled()) {
+    return new DaemonBasedTaskHasher(daemonClient, runnerOptions);
+  } else {
+    const { fileMap, allWorkspaceFiles, rustReferences } = getFileMap();
+    return new InProcessTaskHasher(
+      fileMap?.projectFileMap,
+      allWorkspaceFiles,
+      projectGraph,
+      nxJson,
+      rustReferences,
+      runnerOptions
+    );
+  }
+}

--- a/packages/nx/src/hasher/task-hasher.ts
+++ b/packages/nx/src/hasher/task-hasher.ts
@@ -168,7 +168,7 @@ export class InProcessTaskHasher implements TaskHasher {
           this.projectGraph,
           {
             selectivelyHashTsConfig:
-              this.options.selectivelyHashTsConfig ?? false,
+              this.options?.selectivelyHashTsConfig ?? false,
           }
         )
       : new NativeTaskHasherImpl(
@@ -178,7 +178,7 @@ export class InProcessTaskHasher implements TaskHasher {
           this.externalRustReferences,
           {
             selectivelyHashTsConfig:
-              this.options.selectivelyHashTsConfig ?? false,
+              this.options?.selectivelyHashTsConfig ?? false,
           }
         );
   }

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -34,6 +34,7 @@ import { daemonClient } from '../daemon/client/client';
 import { StoreRunInformationLifeCycle } from './life-cycles/store-run-information-life-cycle';
 import { getFileMap } from '../project-graph/build-project-graph';
 import { performance } from 'perf_hooks';
+import { createTaskHasher } from '../hasher/create-task-hasher';
 
 async function getTerminalOutputLifeCycle(
   initiatingProject: string,
@@ -233,20 +234,7 @@ export async function invokeTasksRunner({
 
   const { tasksRunner, runnerOptions } = getRunner(nxArgs, nxJson);
 
-  let hasher: TaskHasher;
-  if (daemonClient.enabled()) {
-    hasher = new DaemonBasedTaskHasher(daemonClient, runnerOptions);
-  } else {
-    const { fileMap, allWorkspaceFiles, rustReferences } = getFileMap();
-    hasher = new InProcessTaskHasher(
-      fileMap?.projectFileMap,
-      allWorkspaceFiles,
-      projectGraph,
-      nxJson,
-      rustReferences,
-      runnerOptions
-    );
-  }
+  let hasher = createTaskHasher(projectGraph, nxJson, runnerOptions);
 
   // this is used for two reasons: to fetch all remote cache hits AND
   // to submit everything that is known in advance to Nx Cloud to run in


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
doing `nx run project:target --graph=output.json` does not give information about the task plans

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
doing `nx run project:target --graph=output.json` gives information about the task plans. This is going to be useful for debugging between the old task hasher and the new one

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
