### PR TITLE
fix(core): check compilerOptions exists before deleting it

### DIFF
--- a/packages/nx/src/hasher/native-task-hasher-impl.ts
+++ b/packages/nx/src/hasher/native-task-hasher-impl.ts
@@ -4,16 +4,15 @@ import { Task, TaskGraph } from '../config/task-graph';
 import {
   ExternalObject,
   FileData,
-  HashPlanner,
   HasherOptions,
-  ProjectGraph as NativeProjectGraph,
-  transferProjectGraph,
-  TaskHasher,
+  HashPlanner,
   NxWorkspaceFilesExternals,
+  ProjectGraph as NativeProjectGraph,
+  TaskHasher,
+  transferProjectGraph,
 } from '../native';
 import { transformProjectGraphForRust } from '../native/transform-objects';
 import { PartialHash, TaskHasherImpl } from './task-hasher';
-import { readJson } from '../generators/utils/json';
 import { readJsonFile } from '../utils/fileutils';
 import { getRootTsConfigPath } from '../plugins/js/utils/typescript';
 
@@ -46,7 +45,9 @@ export class NativeTaskHasherImpl implements TaskHasherImpl {
     if (rootTsConfigPath) {
       tsconfig = readJsonFile(getRootTsConfigPath());
       paths = tsconfig.compilerOptions?.paths ?? {};
-      delete tsconfig.compilerOptions.paths;
+      if (tsconfig.compilerOptions?.paths) {
+        delete tsconfig.compilerOptions.paths;
+      }
     }
 
     this.planner = new HashPlanner(nxJson, this.projectGraphRef);


### PR DESCRIPTION
This PR fixes an issue with daemon when tsconfig is missing compilerOptions.

See: https://github.com/jaysoo/nx-issue-daemon

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
