### PR TITLE
fix(js): allow inlined libs without imports

### DIFF
--- a/e2e/js/src/js-inlining.test.ts
+++ b/e2e/js/src/js-inlining.test.ts
@@ -148,4 +148,25 @@ describe('inlining', () => {
     );
     expect(childFileContent).toContain(`${grandChild}/src`);
   }, 240_000);
+
+  it('should allow inlining to be enabled without imports', async () => {
+    const parent = uniq('parent');
+    runCLI(`generate @nx/js:lib ${parent} --no-interactive`);
+
+    updateFile(`libs/${parent}/src/lib/${parent}.ts`, () => {
+      return `
+          export function ${parent}() {
+            console.log('hello');
+          }
+        `;
+    });
+
+    // 1. external is set to all
+    execSync(`rm -rf dist`);
+    runCLI(`build ${parent} --external=all`);
+
+    // 1. external is set to none
+    execSync(`rm -rf dist`);
+    runCLI(`build ${parent} --external=none`);
+  }, 240_000);
 });

--- a/packages/js/src/utils/inline.ts
+++ b/packages/js/src/utils/inline.ts
@@ -278,10 +278,12 @@ function updateImports(
   destOutputPath: string,
   inlinedDepsDestOutputRecord: Record<string, string>
 ) {
+  const pathAliases = Object.keys(inlinedDepsDestOutputRecord);
+  if (pathAliases.length == 0) {
+    return;
+  }
   const importRegex = new RegExp(
-    Object.keys(inlinedDepsDestOutputRecord)
-      .map((pathAlias) => `["'](${pathAlias})["']`)
-      .join('|'),
+    pathAliases.map((pathAlias) => `["'](${pathAlias})["']`).join('|'),
     'g'
   );
   recursiveUpdateImport(


### PR DESCRIPTION
Our team has been working on some internal projects that typically get built with inlined libs. We came up with a generator to create our projects with presets including `external`, but since they're new projects they haven't imported any libs (yet!).

## Current Behavior

When the `external` option for the `@nx/js:tsc` executor is set to `all` or `none` but the project doesn't import any libs, the build fails.

```shell
nx run example-app:build

Compiling TypeScript files for project "example-app"...
Done compiling TypeScript files for project "example-app".
node:internal/errors:496
    ErrorCaptureStackTrace(err);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "to" argument must be of type string. Received undefined
    at new NodeError (node:internal/errors:405:5)
    at validateString (node:internal/validators:162:11)
    at relative (node:path:1191:5)
    at /Users/zbristow/projects/node_modules/@nx/js/src/utils/inline.js:182:60
    at String.replace (<anonymous>)
    at recursiveUpdateImport (/Users/zbristow/projects/node_modules/@nx/js/src/utils/inline.js:177:48)
    at recursiveUpdateImport (/Users/zbristow/projects/node_modules/@nx/js/src/utils/inline.js:188:13)
    at updateImports (/Users/zbristow/projects/node_modules/@nx/js/src/utils/inline.js:167:5)
    at postProcessInlinedDependencies (/Users/zbristow/projects/node_modules/@nx/js/src/utils/inline.js:54:5)
    at /Users/zbristow/projects/node_modules/@nx/js/src/executors/tsc/tsc.impl.js:73:53 {
  code: 'ERR_INVALID_ARG_TYPE'
}

Node.js v18.18.0

 ———

 >  NX   Ran target build for project example-app (4s)

    ✖    1/1 failed
    ✔    0/1 succeeded [0 read from cache]
```

## Expected Behavior

Build the project successfully.
