### PR TITLE
fix(core): hash files properly by reading the whole file

### DIFF
--- a/packages/nx/src/native/hasher.rs
+++ b/packages/nx/src/native/hasher.rs
@@ -1,6 +1,6 @@
-use std::fs::File;
-use std::io::{BufRead, BufReader};
+use std::io::BufRead;
 use std::path::Path;
+
 use tracing::trace;
 use xxhash_rust::xxh3;
 
@@ -23,23 +23,17 @@ pub fn hash_file(file: String) -> Option<String> {
 #[inline]
 pub fn hash_file_path<P: AsRef<Path>>(path: P) -> Option<String> {
     let path = path.as_ref();
-    let Ok(file) = File::open(path) else {
-        trace!("could not open file: {path:?}");
+    let Ok(content) = std::fs::read(path) else {
+        trace!("Failed to read file: {:?}", path);
         return None;
     };
 
-    let mut buffer = BufReader::new(file);
-    let Ok(content) = buffer.fill_buf() else {
-        trace!("could not read file: {path:?}");
-        return None;
-    };
-
-    Some(hash(content))
+    Some(hash(&content))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::native::hasher::hash_file;
     use assert_fs::prelude::*;
     use assert_fs::TempDir;
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The whole file was not being read for hashing all files for the first time on init. They were being read properly when they were hashed when they were updated.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Hashing of files always reads the whole file.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
