### PR TITLE
fix(core): publish next versions of Nx with support for FreeBSD

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -162,10 +162,10 @@ jobs:
      timeout-minutes: 45
      steps:
        - uses: actions/checkout@v4
-         if: ${{ !contains(github.ref, '-') && github.event_name != 'schedule' }}
+         if: ${{ github.event_name != 'schedule' }}
        - name: Build
          id: build
-         if: ${{ !contains(github.ref, '-') && github.event_name != 'schedule' }}
+         if: ${{ github.event_name != 'schedule' }}
          uses: cross-platform-actions/action@v0.21.1
          env:
            DEBUG: napi:*
@@ -206,7 +206,7 @@ jobs:
              killall node || true
              echo "COMPLETE"
        - name: Upload artifact
-         if: ${{ !contains(github.ref, '-') && github.event_name != 'schedule' }}
+         if: ${{ github.event_name != 'schedule' }}
          uses: actions/upload-artifact@v3
          with:
            name: bindings-freebsd


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The `next` versions (`alpha`, `beta`, `rc`) do not have support for FreeBSD because it was too flaky... however we use the `next` versions for this repo... which means we can't use them to publish `stable` versions of Nx. :facepalm: 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The `next` versions (`alpha`, `beta`, `rc`) have support for FreeBSD again. `canary` versions still will not have support for FreeBSD because the pipeline would be too flaky at the moment for it to be consistently successful.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
