### PR TITLE
chore(node): decrease e2e times

### DIFF
--- a/e2e/node/src/node-esbuild.test.ts
+++ b/e2e/node/src/node-esbuild.test.ts
@@ -6,20 +6,21 @@ import {
   promisifiedTreeKill,
   readFile,
   runCLI,
-  runCLIAsync,
   runCommandUntil,
   setMaxWorkers,
-  tmpProjPath,
   uniq,
   updateFile,
 } from '@nx/e2e/utils';
-import { execSync } from 'child_process';
 import { join } from 'path';
 
 describe('Node Applications + esbuild', () => {
-  beforeEach(() => newProject());
+  beforeAll(() =>
+    newProject({
+      packages: ['@nx/node'],
+    })
+  );
 
-  afterEach(() => cleanupProject());
+  afterAll(() => cleanupProject());
 
   it('should generate an app using esbuild', async () => {
     const app = uniq('nodeapp');

--- a/e2e/node/src/node-server.test.ts
+++ b/e2e/node/src/node-server.test.ts
@@ -17,11 +17,13 @@ import { join } from 'path';
 
 describe('Node Applications + webpack', () => {
   let proj: string;
-  beforeEach(() => {
-    proj = newProject();
+  beforeAll(() => {
+    proj = newProject({
+      packages: ['@nx/node'],
+    });
   });
 
-  afterEach(() => cleanupProject());
+  afterAll(() => cleanupProject());
 
   function addLibImport(appName: string, libName: string, importPath?: string) {
     const content = readFile(`apps/${appName}/src/main.ts`);

--- a/e2e/node/src/node-webpack.test.ts
+++ b/e2e/node/src/node-webpack.test.ts
@@ -17,9 +17,13 @@ import { execSync } from 'child_process';
 import { join } from 'path';
 
 describe('Node Applications + webpack', () => {
-  beforeEach(() => newProject());
+  beforeAll(() =>
+    newProject({
+      packages: ['@nx/node'],
+    })
+  );
 
-  afterEach(() => cleanupProject());
+  afterAll(() => cleanupProject());
 
   it('should generate an app using webpack', async () => {
     const app = uniq('nodeapp');

--- a/e2e/utils/create-project-utils.ts
+++ b/e2e/utils/create-project-utils.ts
@@ -21,6 +21,7 @@ import { angularCliVersion as defaultAngularCliVersion } from '@nx/workspace/src
 import { dump } from '@zkochan/js-yaml';
 import { execSync, ExecSyncOptions } from 'child_process';
 
+import { performance, PerformanceMeasure } from 'perf_hooks';
 import { logError, logInfo } from './log-utils';
 import {
   getPackageManagerCommand,
@@ -28,12 +29,40 @@ import {
   RunCmdOpts,
   runCommand,
 } from './command-utils';
-import { NxJsonConfiguration, output } from '@nx/devkit';
+import { output } from '@nx/devkit';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { resetWorkspaceContext } from 'nx/src/utils/workspace-context';
 
 let projName: string;
+
+// TODO(jack): we should tag the projects (e.g. tags: ['package']) and filter from that rather than hard-code packages.
+const nxPackages = [
+  `@nx/angular`,
+  `@nx/eslint-plugin`,
+  `@nx/express`,
+  `@nx/esbuild`,
+  `@nx/jest`,
+  `@nx/js`,
+  `@nx/eslint`,
+  `@nx/nest`,
+  `@nx/next`,
+  `@nx/node`,
+  `@nx/nuxt`,
+  `@nx/plugin`,
+  `@nx/playwright`,
+  `@nx/rollup`,
+  `@nx/react`,
+  `@nx/storybook`,
+  `@nx/vue`,
+  `@nx/vite`,
+  `@nx/web`,
+  `@nx/webpack`,
+  `@nx/react-native`,
+  `@nx/expo`,
+] as const;
+
+type NxPackage = typeof nxPackages[number];
 
 /**
  * Sets up a new project in the temporary project path
@@ -43,15 +72,34 @@ export function newProject({
   name = uniq('proj'),
   packageManager = getSelectedPackageManager(),
   unsetProjectNameAndRootFormat = true,
+  packages,
+}: {
+  name?: string;
+  packageManager?: 'npm' | 'yarn' | 'pnpm';
+  unsetProjectNameAndRootFormat?: boolean;
+  readonly packages?: Array<NxPackage>;
 } = {}): string {
+  const newProjectStart = performance.mark('new-project:start');
   try {
     const projScope = 'proj';
 
+    let createNxWorkspaceMeasure: PerformanceMeasure;
+    let packageInstallMeasure: PerformanceMeasure;
+
     if (!directoryExists(tmpBackupProjPath())) {
+      const createNxWorkspaceStart = performance.mark(
+        'create-nx-workspace:start'
+      );
       runCreateWorkspace(projScope, {
         preset: 'apps',
         packageManager,
       });
+      const createNxWorkspaceEnd = performance.mark('create-nx-workspace:end');
+      createNxWorkspaceMeasure = performance.measure(
+        'create-nx-workspace',
+        createNxWorkspaceStart.name,
+        createNxWorkspaceEnd.name
+      );
 
       if (unsetProjectNameAndRootFormat) {
         console.warn(
@@ -69,33 +117,19 @@ export function newProject({
         );
       }
 
-      // TODO(jack): we should tag the projects (e.g. tags: ['package']) and filter from that rather than hard-code packages.
-      const packages = [
-        `@nx/angular`,
-        `@nx/eslint-plugin`,
-        `@nx/express`,
-        `@nx/esbuild`,
-        `@nx/jest`,
-        `@nx/js`,
-        `@nx/eslint`,
-        `@nx/nest`,
-        `@nx/next`,
-        `@nx/node`,
-        `@nx/nuxt`,
-        `@nx/plugin`,
-        `@nx/playwright`,
-        `@nx/rollup`,
-        `@nx/react`,
-        `@nx/storybook`,
-        `@nx/vue`,
-        `@nx/vite`,
-        `@nx/web`,
-        `@nx/webpack`,
-        `@nx/react-native`,
-        `@nx/expo`,
-      ];
-      packageInstall(packages.join(` `), projScope);
-
+      if (!packages) {
+        console.warn(
+          'ATTENTION: All packages are installed into the new workspace. To make this test faster, please pass the subset of packages that this test needs by passing a packages array in the options'
+        );
+      }
+      const packageInstallStart = performance.mark('packageInstall:start');
+      packageInstall((packages ?? nxPackages).join(` `), projScope);
+      const packageInstallEnd = performance.mark('packageInstall:end');
+      packageInstallMeasure = performance.measure(
+        'packageInstall',
+        packageInstallStart.name,
+        packageInstallEnd.name
+      );
       // stop the daemon
       execSync(`${getPackageManagerCommand().runNx} reset`, {
         cwd: `${e2eCwd}/proj`,
@@ -105,17 +139,53 @@ export function newProject({
       moveSync(`${e2eCwd}/proj`, `${tmpBackupProjPath()}`);
     }
     projName = name;
-    copySync(`${tmpBackupProjPath()}`, `${tmpProjPath()}`);
-    if (isVerbose()) {
-      logInfo(`NX`, `E2E created a project: ${tmpProjPath()}`);
-    }
 
+    const projectDirectory = tmpProjPath();
+    copySync(`${tmpBackupProjPath()}`, `${projectDirectory}`);
+
+    // TODO: What is this for?
     if (packageManager === 'pnpm') {
       execSync(getPackageManagerCommand().install, {
-        cwd: tmpProjPath(),
+        cwd: projectDirectory,
         stdio: 'pipe',
         env: { CI: 'true', ...process.env },
         encoding: 'utf-8',
+      });
+    }
+
+    const newProjectEnd = performance.mark('new-project:end');
+    const perfMeasure = performance.measure(
+      'newProject',
+      newProjectStart.name,
+      newProjectEnd.name
+    );
+
+    if (isVerbose()) {
+      logInfo(
+        `NX`,
+        `E2E created a project: ${projectDirectory} in ${
+          perfMeasure.duration / 1000
+        } seconds
+${
+  createNxWorkspaceMeasure
+    ? `create-nx-workspace: ${
+        createNxWorkspaceMeasure.duration / 1000
+      } seconds\n`
+    : ''
+}${
+          packageInstallMeasure
+            ? `packageInstall: ${
+                packageInstallMeasure.duration / 1000
+              } seconds\n`
+            : ''
+        }`
+      );
+    }
+
+    if (process.env.NX_E2E_EDITOR) {
+      const editor = process.env.NX_E2E_EDITOR;
+      execSync(`${editor} ${projectDirectory}`, {
+        stdio: 'inherit',
       });
     }
     return projScope;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

https://staging.nx.app/runs/qLbKKji3E7/task/e2e-node%3Ae2e

When we create new workspaces in e2e tests, every single package is installed.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

I made the Node e2e tests go from 30 minutes to 8 minutes :smile:

https://staging.nx.app/runs/c2BBFGVuvq/task/e2e-node%3Ae2e

I added a new `packages` option for the `newProject` function to allow for you to specify exactly which Nx plugins you want to install.

```ts
newProject({
  packages: ['@nx/node']
});
```

Currently, we install every single @nx package in a new workspace before tests run. This takes a long time and the tests probably only need a few of the packages.

This along with making sure not too many workspaces are created during the tests should make the e2e tests much faster.

There will be a warning in the e2e logs if the packages option is not passed which means all packages are installed. Please pass the packages to get rid of the warnings.

### Bonus

You can set `NX_E2E_EDITOR` to open the workspace in the editor of your choice.

Example:

`NX_E2E_EDITOR=code nx e2e e2e-cypress`

Be careful if too many workspaces are created.. a lot of editors will open... but you should probably try to refactor the tests so not as many workspaces are opened.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
