### PR TITLE
fix(webpack): fixed `isolatedConfig: false` option not composing plugins

### DIFF
--- a/packages/webpack/src/executors/webpack/webpack.impl.ts
+++ b/packages/webpack/src/executors/webpack/webpack.impl.ts
@@ -23,7 +23,7 @@ import type {
 } from './schema';
 import { normalizeOptions } from './lib/normalize-options';
 import {
-  composePlugins,
+  composePluginsSync,
   isNxWebpackComposablePlugin,
 } from '../../utils/config';
 import { withNx } from '../../utils/with-nx';
@@ -54,7 +54,9 @@ async function getWebpackConfigs(
 
   const config = options.isolatedConfig
     ? {}
-    : composePlugins(withNx(options), withWeb(options));
+    : (options.target === 'web'
+        ? composePluginsSync(withNx(options), withWeb(options))
+        : withNx(options))({}, { options, context });
 
   if (isNxWebpackComposablePlugin(userDefinedWebpackConfig)) {
     // Old behavior, call the Nx-specific webpack config function that user exports


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
When compiling a node project that has `isolatedConfig` set to `false` and does not provide an webpack config this error is thrown:

```
 >  NX   Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.

    - configuration has an unknown property 'nxWebpackComposablePlugin'. These properties are valid:
      object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, extends?, externals?, externalsPresets?, externalsType?, ignoreWarnings?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
      -> Options object as provided by the user.
      For typos: please correct them.
      For loader options: webpack >= v2.0.0 no longer allows custom properties in configuration.
        Loaders should be updated to allow passing options via loader options in module.rules.
        Until loaders are updated one can use the LoaderOptionsPlugin to pass these options to the loader:
        plugins: [
          new webpack.LoaderOptionsPlugin({
            // test: /\.xxx$/, // may apply this only for some modules
            options: {
              nxWebpackComposablePlugin: …
            }
          })
        ]
   Pass --verbose to see the stacktrace.
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
For the default plugins to be added correctly

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
