### PR TITLE
fix(react): webpack backwards compat for `@nx/react/plugin/webpack`

### DIFF
--- a/packages/react/plugins/webpack.ts
+++ b/packages/react/plugins/webpack.ts
@@ -1,16 +1,6 @@
+import { composePlugins, withNx } from '@nx/webpack';
 import { withReact } from './with-react';
 
-// Support existing default exports as well as new named export.
-const legacyExport: any = withReact();
-legacyExport.withReact = withReact;
+const plugin = composePlugins(withNx(), withReact());
 
-/** @deprecated use `import { withReact } from '@nx/react'` */
-// This is here for backward compatibility if anyone imports {getWebpackConfig} directly.
-// TODO(jack): Remove in Nx 16
-const getWebpackConfig = withReact();
-
-legacyExport.getWebpackConfig = getWebpackConfig;
-
-module.exports = legacyExport;
-
-export { getWebpackConfig };
+module.exports = plugin;


### PR DESCRIPTION
Now that our Webpack executor supports standard Webpack configuration files, we need to check if the exported function is a standard Webpack function `(env, args) -> config` or Nx-specific funtion `(config, nxContext) -> config`. To be treated as an Nx-specific function, it needs to be called with `composePlugins`, otherwise `@nx/webpack:webpack` executor will pass the function to Webpack as a standard config.

This means that legacy setup with this in `project.json`...

```json5
build: {
  options: { 
    //...
    webpackConfig: '@nx/react/plugins/webpack'
  }
}
```

...will no longer build since `@nx/react/plugin/webpack` does not run through `composePlugins`.

## Current Behavior
Build is broken

## Expected Behavior
Build works

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20669

## Notes
Also removes `getWebpackConfig` function that we deprecated in Nx 14 and was supposed to remove in Nx 16.
