### PR TITLE
fix(webpack): migrate projects without webpackConfig to use webpack.config.js

### DIFF
--- a/packages/webpack/migrations.json
+++ b/packages/webpack/migrations.json
@@ -29,6 +29,12 @@
       "version": "16.0.0-beta.1",
       "description": "Replace @nrwl/webpack with @nx/webpack",
       "implementation": "./src/migrations/update-16-0-0-add-nx-packages/update-16-0-0-add-nx-packages"
+    },
+    "update-17-2-1-webpack-config-setup": {
+      "cli": "nx",
+      "version": "17.2.1-beta.0",
+      "description": "Add webpack.config.js file when webpackConfig is not defined",
+      "implementation": "./src/migrations/update-17-2-1/webpack-config-setup"
     }
   },
   "packageJsonUpdates": {

--- a/packages/webpack/src/migrations/update-17-2-1/webpack-config-setup.spec.ts
+++ b/packages/webpack/src/migrations/update-17-2-1/webpack-config-setup.spec.ts
@@ -1,0 +1,82 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { addProjectConfiguration, Tree } from '@nx/devkit';
+import webpackConfigSetup from './webpack-config-setup';
+
+describe('17.2.1 migration (setup webpack.config file)', () => {
+  let tree: Tree;
+
+  beforeEach(async () => {
+    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  });
+
+  it('should create webpack.config.js for projects that did not set webpackConfig', async () => {
+    addProjectConfiguration(tree, 'myapp', {
+      root: 'apps/myapp',
+      targets: {
+        build: {
+          executor: '@nrwl/webpack:webpack',
+          options: {},
+        },
+      },
+    });
+
+    await webpackConfigSetup(tree);
+
+    expect(tree.read('apps/myapp/webpack.config.js', 'utf-8'))
+      .toEqual(`const { composePlugins, withNx } = require('@nx/webpack');
+
+// Nx plugins for webpack.
+module.exports = composePlugins(withNx(), (config) => {
+  // Note: This was added by an Nx migration. Webpack builds are required to have a corresponding Webpack config file.
+  // See: https://nx.dev/recipes/webpack/webpack-config-setup
+  return config;
+});
+`);
+  });
+
+  it('should not create webpack.config.js when webpackConfig is already set', async () => {
+    tree.write(
+      `apps/myapp/webpack.config.js`,
+      `
+      module.exports = { /* CUSTOM */ };
+    `
+    );
+    addProjectConfiguration(tree, 'myapp', {
+      root: 'apps/myapp',
+      targets: {
+        build: {
+          executor: '@nrwl/webpack:webpack',
+          options: {
+            webpackConfig: 'apps/myapp/webpack.config.js',
+          },
+        },
+      },
+    });
+
+    await webpackConfigSetup(tree);
+
+    expect(tree.read('apps/myapp/webpack.config.js', 'utf-8')).toContain(
+      '/* CUSTOM */'
+    );
+  });
+
+  it('should not create webpack.config.js when isolatedConfig is set to false', async () => {
+    addProjectConfiguration(tree, 'myapp', {
+      root: 'apps/myapp',
+      targets: {
+        build: {
+          executor: '@nrwl/webpack:webpack',
+          options: {
+            // Technically this is not possible, since isolatedConfig without webpackConfig does not work
+            // Handling this edge-case anyway
+            isolatedConfig: false,
+          },
+        },
+      },
+    });
+
+    await webpackConfigSetup(tree);
+
+    expect(tree.exists('apps/myapp/webpack.config.js')).toBeFalsy();
+  });
+});

--- a/packages/webpack/src/migrations/update-17-2-1/webpack-config-setup.ts
+++ b/packages/webpack/src/migrations/update-17-2-1/webpack-config-setup.ts
@@ -1,0 +1,48 @@
+import {
+  formatFiles,
+  readProjectConfiguration,
+  Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+import { forEachExecutorOptions } from '@nx/devkit/src/generators/executor-options-utils';
+import { WebpackExecutorOptions } from '../../executors/webpack/schema';
+
+export default async function (tree: Tree) {
+  forEachExecutorOptions<WebpackExecutorOptions>(
+    tree,
+    '@nrwl/webpack:webpack',
+    (
+      options: WebpackExecutorOptions,
+      projectName,
+      targetName,
+      configurationName
+    ) => {
+      // Only handle webpack config for default configuration
+      if (configurationName) return;
+
+      const projectConfiguration = readProjectConfiguration(tree, projectName);
+
+      if (!options.webpackConfig && options.isolatedConfig !== false) {
+        options.webpackConfig = `${projectConfiguration.root}/webpack.config.js`;
+        tree.write(
+          options.webpackConfig,
+          `
+        const { composePlugins, withNx } = require('@nx/webpack');
+
+        // Nx plugins for webpack.
+        module.exports = composePlugins(withNx(), (config) => {
+          // Note: This was added by an Nx migration. Webpack builds are required to have a corresponding Webpack config file.
+          // See: https://nx.dev/recipes/webpack/webpack-config-setup
+          return config;
+        });
+        `
+        );
+
+        projectConfiguration.targets[targetName].options = options;
+        updateProjectConfiguration(tree, projectName, projectConfiguration);
+      }
+    }
+  );
+
+  await formatFiles(tree);
+}


### PR DESCRIPTION
For projects that did not define `webpackConfig`, and instead relied on non-isolated webpack builds (i.e. `@nx/webpack:webpack` provides plugin and other configs), this PR adds a migration to create an explicit `webpack.config.js` and set `webpackConfig`.


Non-isolated webpack builds will not longer be supported in Nx 18.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20671 
