### PR TITLE
fix(webpack): add standardWebpackConfigFunction option when users opts for a standard config function

### DIFF
--- a/docs/generated/packages/webpack/executors/webpack.json
+++ b/docs/generated/packages/webpack/executors/webpack.json
@@ -313,6 +313,11 @@
         "default": true,
         "x-deprecated": "Automatic configuration of Webpack is deprecated in favor of an explicit 'webpack.config.js' file. This option will be removed in Nx 18. See https://nx.dev/recipes/webpack/webpack-config-setup."
       },
+      "standardWebpackConfigFunction": {
+        "type": "boolean",
+        "description": "Set to true if the webpack config exports a standard webpack function, not an Nx-specific one. See: https://webpack.js.org/configuration/configuration-types/#exporting-a-function",
+        "default": false
+      },
       "extractLicenses": {
         "type": "boolean",
         "description": "Extract all licenses in a separate file, in the case of production builds only."

--- a/packages/webpack/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/webpack/src/executors/dev-server/dev-server.impl.ts
@@ -81,7 +81,11 @@ export async function* devServerExecutor(
 
     // Only add the dev server option if user is composable plugin.
     // Otherwise, user should define `devServer` option directly in their webpack config.
-    if (isNxWebpackComposablePlugin(userDefinedWebpackConfig)) {
+    if (
+      typeof userDefinedWebpackConfig === 'function' &&
+      isNxWebpackComposablePlugin(userDefinedWebpackConfig) &&
+      !buildOptions.standardWebpackConfigFunction
+    ) {
       config = await userDefinedWebpackConfig(
         { devServer },
         {

--- a/packages/webpack/src/executors/webpack/schema.d.ts
+++ b/packages/webpack/src/executors/webpack/schema.d.ts
@@ -50,6 +50,7 @@ export interface WebpackExecutorOptions {
   // TODO(v18): Remove this option
   /** @deprecated set webpackConfig and provide an explicit webpack.config.js file (See: https://nx.dev/recipes/webpack/webpack-config-setup) */
   isolatedConfig?: boolean;
+  standardWebpackConfigFunction?: boolean;
   main?: string;
   memoryLimit?: number;
   namedChunks?: boolean;

--- a/packages/webpack/src/executors/webpack/schema.json
+++ b/packages/webpack/src/executors/webpack/schema.json
@@ -237,6 +237,11 @@
       "default": true,
       "x-deprecated": "Automatic configuration of Webpack is deprecated in favor of an explicit 'webpack.config.js' file. This option will be removed in Nx 18. See https://nx.dev/recipes/webpack/webpack-config-setup."
     },
+    "standardWebpackConfigFunction": {
+      "type": "boolean",
+      "description": "Set to true if the webpack config exports a standard webpack function, not an Nx-specific one. See: https://webpack.js.org/configuration/configuration-types/#exporting-a-function",
+      "default": false
+    },
     "extractLicenses": {
       "type": "boolean",
       "description": "Extract all licenses in a separate file, in the case of production builds only."

--- a/packages/webpack/src/executors/webpack/webpack.impl.ts
+++ b/packages/webpack/src/executors/webpack/webpack.impl.ts
@@ -56,7 +56,11 @@ async function getWebpackConfigs(
     ? {}
     : composePlugins(withNx(options), withWeb(options));
 
-  if (isNxWebpackComposablePlugin(userDefinedWebpackConfig)) {
+  if (
+    typeof userDefinedWebpackConfig === 'function' &&
+    isNxWebpackComposablePlugin(userDefinedWebpackConfig) &&
+    !options.standardWebpackConfigFunction
+  ) {
     // Old behavior, call the Nx-specific webpack config function that user exports
     return await userDefinedWebpackConfig(config, {
       options,


### PR DESCRIPTION
This PR fixes an issue when we added support for standard [webpack function as config](webpack.js.org/configuration/configuration-types/#exporting-a-function).

Any existing projects that doesn't call `composePlugins` on the top-level export will now be treated as a standard function, which will fail the build.

The fix is to add a new option `standardWebpackConfigFunction`, so users have to opt into this setting. There should not be an effect on PCv3 since those projects do not run through our executor anyway, this new option is for the specific case of PCv3 + `@nx/webpack:webpack`.

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
