### PR TITLE
fix(core): show warning if workspaceRoot starts with !

### DIFF
--- a/packages/nx/src/native/tasks/hashers/hash_workspace_files.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_workspace_files.rs
@@ -2,24 +2,25 @@ use std::sync::Arc;
 
 use anyhow::*;
 use dashmap::DashMap;
-use tracing::trace;
+use tracing::{trace, warn};
 
-use crate::native::glob::build_glob_set;
 use crate::native::types::FileData;
+use crate::native::{glob::build_glob_set, hasher::hash};
 
 pub fn hash_workspace_files(
     workspace_file_set: &str,
     all_workspace_files: &[FileData],
     cache: Arc<DashMap<String, String>>,
 ) -> Result<String> {
-    let file_set = workspace_file_set
-        .strip_prefix("{workspaceRoot}/")
-        .ok_or_else(|| {
-            anyhow!(
-                "{workspace_file_set} does not start with {}",
-                "{workspaceRoot}/"
-            )
-        })?;
+    let file_set = workspace_file_set.strip_prefix("{workspaceRoot}/");
+
+    let Some(file_set) = file_set else {
+        warn!(
+            "{workspace_file_set} does not start with {}. This will throw an error in Nx 18.",
+            "{workspaceRoot}/"
+        );
+        return Ok(hash(b""));
+    };
 
     if let Some(cache_results) = cache.get(file_set) {
         return Ok(cache_results.clone());
@@ -50,9 +51,10 @@ mod test {
     use std::sync::Arc;
 
     #[test]
-    fn test_hash_workspace_files_error() {
-        let result = hash_workspace_files("packages/{package}", &[], Arc::new(DashMap::new()));
-        assert!(result.is_err());
+    fn invalid_workspace_input_is_just_empty_hash() {
+        let result =
+            hash_workspace_files("packages/{package}", &[], Arc::new(DashMap::new())).unwrap();
+        assert_eq!(result, hash(b""));
     }
 
     #[test]


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When a input starts with a `!{workspaceRoot}`, Nx will throw an error. The node task hasher did not throw an error, but instead mistakenly tried to find a non-existent file, which resulted in the final hash for this being an  empty string. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`!{workspaceRoot}` will not throw an error, but show a warning instead. This will be changed to throw an error with Nx 18. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20677
