### PR TITLE
fix(vite): pass `watch` option from CLI to test executor

### DIFF
--- a/packages/vite/src/executors/test/lib/utils.ts
+++ b/packages/vite/src/executors/test/lib/utils.ts
@@ -79,10 +79,9 @@ export async function getExtraArgs(
   const schema = await import('../schema.json');
   const extraArgs: Record<string, any> = {};
   for (const key of Object.keys(options)) {
-    if (!schema.properties[key]) {
+    if (!schema.properties[key] || key === 'watch') {
       extraArgs[key] = options[key];
     }
   }
-
   return extraArgs;
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

```
nx test --watch
# vitest executor won't run in watch mode
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

vitest executor should run in watch mode

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20706
