### PR TITLE
fix(linter): move should migrate all eslint configs

### DIFF
--- a/packages/eslint/src/generators/utils/eslint-file.ts
+++ b/packages/eslint/src/generators/utils/eslint-file.ts
@@ -3,10 +3,10 @@ import {
   names,
   offsetFromRoot,
   readJson,
-  Tree,
   updateJson,
 } from '@nx/devkit';
-import { Linter } from 'eslint';
+import type { Tree } from '@nx/devkit';
+import type { Linter } from 'eslint';
 import { useFlatConfig } from '../../utils/flat-config';
 import {
   addBlockToFlatConfigExport,

--- a/packages/workspace/src/generators/convert-to-monorepo/convert-to-monorepo.spec.ts
+++ b/packages/workspace/src/generators/convert-to-monorepo/convert-to-monorepo.spec.ts
@@ -167,7 +167,6 @@ describe('monorepo generator', () => {
 
     // Extracted base config files
     expect(tree.exists('tsconfig.base.json')).toBeTruthy();
-    expect(tree.exists('.eslintrc.base.json')).toBeTruthy();
     expect(tree.exists('jest.config.ts')).toBeTruthy();
   });
 });

--- a/packages/workspace/src/generators/convert-to-monorepo/convert-to-monorepo.spec.ts
+++ b/packages/workspace/src/generators/convert-to-monorepo/convert-to-monorepo.spec.ts
@@ -74,7 +74,6 @@ describe('monorepo generator', () => {
 
     // Extracted base config files
     expect(tree.exists('tsconfig.base.json')).toBeTruthy();
-    expect(tree.exists('.eslintrc.base.json')).toBeTruthy();
   });
 
   it('should respect nested libraries', async () => {
@@ -140,7 +139,6 @@ describe('monorepo generator', () => {
 
     // Extracted base config files
     expect(tree.exists('tsconfig.base.json')).toBeTruthy();
-    expect(tree.exists('.eslintrc.base.json')).toBeTruthy();
     expect(tree.exists('jest.config.ts')).toBeTruthy();
   });
 

--- a/packages/workspace/src/generators/convert-to-monorepo/convert-to-monorepo.ts
+++ b/packages/workspace/src/generators/convert-to-monorepo/convert-to-monorepo.ts
@@ -19,9 +19,13 @@ export async function monorepoGenerator(tree: Tree, options: {}) {
 
   // Need to determine libs vs packages directory base on the type of root project.
   for (const [, project] of projects) {
-    if (project.root === '.') rootProject = project;
-    projectsToMove.unshift(project); // move the root project 1st
+    if (project.root === '.') {
+      rootProject = project;
+    } else {
+      projectsToMove.push(project);
+    }
   }
+  projectsToMove.unshift(rootProject); // move the root project 1st
 
   // Currently, Nx only handles apps+libs or packages. You cannot mix and match them.
   // If the standalone project is an app (React, Angular, etc), then use apps+libs.

--- a/packages/workspace/src/generators/move/lib/extract-base-configs.ts
+++ b/packages/workspace/src/generators/move/lib/extract-base-configs.ts
@@ -1,4 +1,9 @@
-import { joinPathFragments, ProjectConfiguration, Tree } from '@nx/devkit';
+import {
+  getProjects,
+  joinPathFragments,
+  ProjectConfiguration,
+  Tree,
+} from '@nx/devkit';
 
 export function maybeExtractTsConfigBase(tree: Tree): void {
   let extractTsConfigBase: any;
@@ -22,27 +27,19 @@ export async function maybeExtractJestConfigBase(tree: Tree): Promise<void> {
   await jestInitGenerator(tree, {});
 }
 
-export function maybeExtractEslintConfigIfRootProject(
+export function maybeMigrateEslintConfigIfRootProject(
   tree: Tree,
   rootProject: ProjectConfiguration
 ): void {
-  if (rootProject.root !== '.') return;
-  if (tree.exists('.eslintrc.base.json')) return;
-  let migrateConfigToMonorepoStyle: any;
-  try {
-    migrateConfigToMonorepoStyle = require('@nx/' +
-      'eslint/src/generators/init/init-migration').migrateConfigToMonorepoStyle;
-  } catch {
-    // eslint not installed
-  }
-  // Only need to handle migrating the root rootProject.
-  // If other libs/apps exist, then this migration is already done by `@nx/eslint:lint-rootProject` generator.
-  migrateConfigToMonorepoStyle?.(
-    [rootProject],
+  const { migrateConfigToMonorepoStyle } = require('@nx/' +
+    'eslint/src/generators/init/init-migration');
+  migrateConfigToMonorepoStyle(
+    getProjects(tree),
     tree,
     tree.exists(joinPathFragments(rootProject.root, 'jest.config.ts')) ||
       tree.exists(joinPathFragments(rootProject.root, 'jest.config.js'))
       ? 'jest'
-      : 'none'
+      : 'none',
+    true
   );
 }

--- a/packages/workspace/src/generators/move/lib/extract-base-configs.ts
+++ b/packages/workspace/src/generators/move/lib/extract-base-configs.ts
@@ -31,15 +31,19 @@ export function maybeMigrateEslintConfigIfRootProject(
   tree: Tree,
   rootProject: ProjectConfiguration
 ): void {
-  const { migrateConfigToMonorepoStyle } = require('@nx/' +
-    'eslint/src/generators/init/init-migration');
-  migrateConfigToMonorepoStyle(
-    getProjects(tree),
+  let migrateConfigToMonorepoStyle: any;
+  try {
+    migrateConfigToMonorepoStyle = require('@nx/' +
+      'eslint/src/generators/init/init-migration').migrateConfigToMonorepoStyle;
+  } catch {
+    // eslint not installed
+  }
+  migrateConfigToMonorepoStyle?.(
+    Array.from(getProjects(tree).values()),
     tree,
     tree.exists(joinPathFragments(rootProject.root, 'jest.config.ts')) ||
       tree.exists(joinPathFragments(rootProject.root, 'jest.config.js'))
       ? 'jest'
-      : 'none',
-    true
+      : 'none'
   );
 }

--- a/packages/workspace/src/generators/move/move.spec.ts
+++ b/packages/workspace/src/generators/move/move.spec.ts
@@ -244,6 +244,63 @@ describe('move', () => {
     `);
   });
 
+  it('should correctly move standalone repos that have migrated eslint config', async () => {
+    // Test that these are not moved
+    tree.write('.gitignore', '');
+    tree.write('README.md', '');
+
+    await applicationGenerator(tree, {
+      name: 'react-app',
+      rootProject: true,
+      unitTestRunner: 'jest',
+      e2eTestRunner: 'cypress',
+      linter: 'eslint',
+      style: 'css',
+      projectNameAndRootFormat: 'as-provided',
+    });
+    await libraryGenerator(tree, {
+      name: 'my-lib',
+      bundler: 'tsc',
+      buildable: true,
+      unitTestRunner: 'jest',
+      linter: 'eslint',
+      directory: 'my-lib',
+      projectNameAndRootFormat: 'as-provided',
+    });
+    // assess the correct starting position
+    expect(tree.exists('.eslintrc.base.json')).toBeTruthy();
+    expect(readJson(tree, '.eslintrc.json').plugins).not.toBeDefined();
+    expect(readJson(tree, '.eslintrc.json').extends).toEqual([
+      'plugin:@nx/react',
+      './.eslintrc.base.json',
+    ]);
+    expect(readJson(tree, 'e2e/.eslintrc.json').plugins).not.toBeDefined();
+    expect(readJson(tree, 'e2e/.eslintrc.json').extends).toEqual([
+      'plugin:cypress/recommended',
+      '../.eslintrc.base.json',
+    ]);
+
+    await moveGenerator(tree, {
+      projectName: 'react-app',
+      updateImportPath: false,
+      destination: 'apps/react-app',
+      projectNameAndRootFormat: 'as-provided',
+    });
+
+    // expect both eslint configs to have been changed
+    expect(tree.exists('.eslintrc.json')).toBeTruthy();
+    expect(tree.exists('.eslintrc.base.json')).toBeFalsy();
+
+    expect(readJson(tree, 'apps/react-app/.eslintrc.json').extends).toEqual([
+      'plugin:@nx/react',
+      '../../.eslintrc.json',
+    ]);
+    expect(readJson(tree, 'e2e/.eslintrc.json').extends).toEqual([
+      'plugin:cypress/recommended',
+      '../.eslintrc.json',
+    ]);
+  });
+
   it('should move project correctly when --project-name-and-root-format=derived', async () => {
     await libraryGenerator(tree, {
       name: 'my-lib',

--- a/packages/workspace/src/generators/move/move.ts
+++ b/packages/workspace/src/generators/move/move.ts
@@ -21,7 +21,7 @@ import { updateProjectRootFiles } from './lib/update-project-root-files';
 import { updateReadme } from './lib/update-readme';
 import { updateStorybookConfig } from './lib/update-storybook-config';
 import {
-  maybeExtractEslintConfigIfRootProject,
+  maybeMigrateEslintConfigIfRootProject,
   maybeExtractJestConfigBase,
   maybeExtractTsConfigBase,
 } from './lib/extract-base-configs';
@@ -42,7 +42,6 @@ export async function moveGeneratorInternal(tree: Tree, rawSchema: Schema) {
   if (projectConfig.root === '.') {
     maybeExtractTsConfigBase(tree);
     await maybeExtractJestConfigBase(tree);
-    maybeExtractEslintConfigIfRootProject(tree, projectConfig);
     // Reload config since it has been updated after extracting base configs
     projectConfig = readProjectConfiguration(tree, rawSchema.projectName);
   }
@@ -61,6 +60,11 @@ export async function moveGeneratorInternal(tree: Tree, rawSchema: Schema) {
   updateBuildTargets(tree, schema);
   updateDefaultProject(tree, schema);
   updateImplicitDependencies(tree, schema);
+
+  if (projectConfig.root === '.') {
+    // we want to migrate eslint config once the root project files are moved
+    maybeMigrateEslintConfigIfRootProject(tree, projectConfig);
+  }
 
   await runAngularPlugin(tree, schema);
 


### PR DESCRIPTION


## Current Behavior
The `move` generator incorrectly migrates root project, leaving other project's in the standalone mode.

## Expected Behavior
The `move` generator should update eslint configs of other projects as well when migrating root project.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
