### PR TITLE
chore(angular): use packages property to reduce install times

### DIFF
--- a/e2e/angular-core/src/config.test.ts
+++ b/e2e/angular-core/src/config.test.ts
@@ -12,7 +12,7 @@ describe('angular.json v1 config', () => {
   const app1 = uniq('app1');
 
   beforeAll(() => {
-    newProject();
+    newProject({ packages: ['@nx/angular'] });
     runCLI(
       `generate @nx/angular:app ${app1} --project-name-and-root-format=as-provided --no-interactive`
     );

--- a/e2e/angular-core/src/module-federation.test.ts
+++ b/e2e/angular-core/src/module-federation.test.ts
@@ -18,7 +18,7 @@ describe('Angular Module Federation', () => {
   let oldVerboseLoggingValue: string;
 
   beforeAll(() => {
-    proj = newProject();
+    proj = newProject({ packages: ['@nx/angular'] });
     oldVerboseLoggingValue = process.env.NX_E2E_VERBOSE_LOGGING;
     process.env.NX_E2E_VERBOSE_LOGGING = 'true';
   });

--- a/e2e/angular-core/src/projects.test.ts
+++ b/e2e/angular-core/src/projects.test.ts
@@ -30,7 +30,7 @@ describe('Angular Projects', () => {
   let esbuildAppDefaultProjectConfig: string;
 
   beforeAll(() => {
-    proj = newProject();
+    proj = newProject({ packages: ['@nx/angular'] });
     runCLI(
       `generate @nx/angular:app ${app1} --no-standalone --bundler=webpack --project-name-and-root-format=as-provided --no-interactive`
     );

--- a/e2e/angular-extensions/src/cypress-component-tests.test.ts
+++ b/e2e/angular-extensions/src/cypress-component-tests.test.ts
@@ -21,7 +21,10 @@ describe('Angular Cypress Component Tests', () => {
   const buildableLibName = uniq('cy-angular-buildable-lib');
 
   beforeAll(async () => {
-    projectName = newProject({ name: uniq('cy-ng') });
+    projectName = newProject({
+      name: uniq('cy-ng'),
+      packages: ['@nx/angular'],
+    });
 
     createApp(appName);
 
@@ -359,6 +362,7 @@ describe(InputStandaloneComponent.name, () => {
 `
   );
 }
+
 function useBuildableLibInLib(
   projectName: string,
   buildableLibName: string,

--- a/e2e/angular-extensions/src/misc.test.ts
+++ b/e2e/angular-extensions/src/misc.test.ts
@@ -16,7 +16,7 @@ describe('Move Angular Project', () => {
   let newPath: string;
 
   beforeAll(() => {
-    proj = newProject();
+    proj = newProject({ packages: ['@nx/angular'] });
     app1 = uniq('app1');
     app2 = uniq('app2');
     newPath = `subfolder/${app2}`;

--- a/e2e/angular-extensions/src/ngrx.test.ts
+++ b/e2e/angular-extensions/src/ngrx.test.ts
@@ -12,7 +12,7 @@ import {
 describe('Angular Package', () => {
   describe('ngrx', () => {
     beforeAll(() => {
-      newProject();
+      newProject({ packages: ['@nx/angular'] });
     });
     afterAll(() => {
       cleanupProject();

--- a/e2e/angular-extensions/src/tailwind.test.ts
+++ b/e2e/angular-extensions/src/tailwind.test.ts
@@ -116,7 +116,7 @@ describe('Tailwind support', () => {
   };
 
   beforeAll(() => {
-    project = newProject();
+    project = newProject({ packages: ['@nx/angular'] });
 
     // Create tailwind config in the workspace root
     createWorkspaceTailwindConfigFile();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Our e2es install all nx packages when creating a workspace.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Only install @nx/angular and let that package install the deps it needs to.
This should also give a truer representation of whether our package is installing optional dependencies for tooling correctly

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
