### PR TITLE
fix(core): correctly move project and target strings

### DIFF
--- a/packages/workspace/src/generators/move/lib/__snapshots__/create-project-configuration-in-new-destination.spec.ts.snap
+++ b/packages/workspace/src/generators/move/lib/__snapshots__/create-project-configuration-in-new-destination.spec.ts.snap
@@ -1,0 +1,200 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`moveProjectConfiguration should rename the project 1`] = `
+{
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "implicitDependencies": [
+    "my-other-lib",
+  ],
+  "name": "subfolder-my-destination",
+  "projectType": "application",
+  "root": "apps/subfolder/my-destination",
+  "sourceRoot": "apps/subfolder/my-destination/src",
+  "tags": [
+    "type:ui",
+  ],
+  "targets": {
+    "build": {
+      "configurations": {
+        "production": {
+          "aot": true,
+          "budgets": [
+            {
+              "maximumError": "5mb",
+              "maximumWarning": "2mb",
+              "type": "initial",
+            },
+            {
+              "maximumError": "10kb",
+              "maximumWarning": "6kb",
+              "type": "anyComponentStyle",
+            },
+          ],
+          "buildOptimizer": true,
+          "extractCss": true,
+          "extractLicenses": true,
+          "fileReplacements": [
+            {
+              "replace": "apps/subfolder/my-destination/src/environments/environment.ts",
+              "with": "apps/subfolder/my-destination/src/environments/environment.prod.ts",
+            },
+          ],
+          "namedChunks": false,
+          "optimization": true,
+          "outputHashing": "all",
+          "sourceMap": false,
+          "vendorChunk": false,
+        },
+      },
+      "executor": "@angular-devkit/build-angular:browser",
+      "options": {
+        "aot": false,
+        "assets": [
+          "apps/subfolder/my-destination/src/favicon.ico",
+          "apps/subfolder/my-destination/src/assets",
+        ],
+        "index": "apps/subfolder/my-destination/src/index.html",
+        "main": "apps/subfolder/my-destination/src/main.ts",
+        "outputPath": "dist/apps/subfolder/my-destination",
+        "polyfills": "apps/subfolder/my-destination/src/polyfills.ts",
+        "scripts": [],
+        "styles": [
+          "apps/subfolder/my-destination/src/styles.scss",
+        ],
+        "tsConfig": "apps/subfolder/my-destination/tsconfig.app.json",
+      },
+    },
+    "extract-i18n": {
+      "executor": "@angular-devkit/build-angular:extract-i18n",
+      "options": {
+        "browserTarget": "my-source:build",
+      },
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+    },
+    "serve": {
+      "configurations": {
+        "production": {
+          "browserTarget": "my-source:build:production",
+        },
+      },
+      "executor": "@angular-devkit/build-angular:dev-server",
+      "options": {
+        "browserTarget": "my-source:build",
+      },
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "options": {
+        "jestConfig": "apps/subfolder/my-destination/jest.config.js",
+        "setupFile": "apps/subfolder/my-destination/src/test-setup.ts",
+        "tsConfig": "apps/subfolder/my-destination/tsconfig.spec.json",
+      },
+    },
+  },
+}
+`;
+
+exports[`moveProjectConfiguration should rename the project correctly except for build targets 1`] = `
+{
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "implicitDependencies": [],
+  "name": "subfolder-my-destination",
+  "projectType": "application",
+  "root": "apps/subfolder/my-destination",
+  "sourceRoot": "apps/subfolder/my-destination/src",
+  "tags": [],
+  "targets": {
+    "build": {
+      "cache": true,
+      "configurations": {
+        "development": {
+          "mode": "development",
+        },
+        "production": {
+          "mode": "production",
+        },
+      },
+      "defaultConfiguration": "production",
+      "dependsOn": [
+        "^build",
+      ],
+      "executor": "@nx/vite:build",
+      "inputs": [
+        "production",
+        "^production",
+      ],
+      "options": {
+        "outputPath": "dist/apps/subfolder/my-destination",
+      },
+      "outputs": [
+        "{options.outputPath}",
+      ],
+    },
+    "lint": {
+      "cache": true,
+      "configurations": {},
+      "executor": "@nx/eslint:lint",
+      "inputs": [
+        "default",
+        "{workspaceRoot}/.eslintrc.json",
+        "{workspaceRoot}/.eslintignore",
+        "{workspaceRoot}/eslint.config.js",
+      ],
+      "options": {},
+      "outputs": [
+        "{options.outputFile}",
+      ],
+    },
+    "preview": {
+      "configurations": {
+        "development": {
+          "buildTarget": "my-flat-source:build:development",
+        },
+        "production": {
+          "buildTarget": "my-flat-source:build:production",
+        },
+      },
+      "defaultConfiguration": "development",
+      "executor": "@nx/vite:preview-server",
+      "options": {
+        "buildTarget": "my-flat-source:build",
+      },
+    },
+    "serve": {
+      "configurations": {
+        "development": {
+          "buildTarget": "my-flat-source:build:development",
+          "hmr": true,
+        },
+        "production": {
+          "buildTarget": "my-flat-source:build:production",
+          "hmr": false,
+        },
+      },
+      "defaultConfiguration": "development",
+      "executor": "@nx/vite:dev-server",
+      "options": {
+        "buildTarget": "my-flat-source:build:development",
+        "hmr": true,
+      },
+    },
+    "test": {
+      "cache": true,
+      "configurations": {},
+      "executor": "@nx/vite:test",
+      "inputs": [
+        "default",
+        "^production",
+      ],
+      "options": {
+        "reportsDirectory": "../coverage/apps/subfolder/my-destination",
+      },
+      "outputs": [
+        "{options.reportsDirectory}",
+      ],
+    },
+  },
+}
+`;

--- a/packages/workspace/src/generators/move/lib/create-project-configuration-in-new-destination.spec.ts
+++ b/packages/workspace/src/generators/move/lib/create-project-configuration-in-new-destination.spec.ts
@@ -11,6 +11,7 @@ import { createProjectConfigurationInNewDestination } from './create-project-con
 describe('moveProjectConfiguration', () => {
   let tree: Tree;
   let projectConfig: ProjectConfiguration;
+  let projectConfigFlat: ProjectConfiguration;
   let schema: NormalizedSchema;
 
   const setupWorkspace = (version: 1 | 2 = 1) => {
@@ -138,7 +139,80 @@ describe('moveProjectConfiguration', () => {
       },
     });
 
+    addProjectConfiguration(tree, 'my-flat-source', {
+      root: 'my-flat-source',
+      name: 'my-flat-source',
+      sourceRoot: 'my-flat-source/src',
+      projectType: 'application',
+      targets: {
+        build: {
+          cache: true,
+          dependsOn: ['^build'],
+          inputs: ['production', '^production'],
+          executor: '@nx/vite:build',
+          outputs: ['{options.outputPath}'],
+          defaultConfiguration: 'production',
+          options: { outputPath: 'dist/my-flat-source' },
+          configurations: {
+            development: { mode: 'development' },
+            production: { mode: 'production' },
+          },
+        },
+        serve: {
+          executor: '@nx/vite:dev-server',
+          defaultConfiguration: 'development',
+          options: {
+            buildTarget: 'my-flat-source:build:development',
+            hmr: true,
+          },
+          configurations: {
+            development: {
+              buildTarget: 'my-flat-source:build:development',
+              hmr: true,
+            },
+            production: {
+              buildTarget: 'my-flat-source:build:production',
+              hmr: false,
+            },
+          },
+        },
+        preview: {
+          executor: '@nx/vite:preview-server',
+          defaultConfiguration: 'development',
+          options: { buildTarget: 'my-flat-source:build' },
+          configurations: {
+            development: { buildTarget: 'my-flat-source:build:development' },
+            production: { buildTarget: 'my-flat-source:build:production' },
+          },
+        },
+        test: {
+          cache: true,
+          inputs: ['default', '^production'],
+          executor: '@nx/vite:test',
+          outputs: ['{options.reportsDirectory}'],
+          options: { reportsDirectory: '../coverage/my-flat-source' },
+          configurations: {},
+        },
+        lint: {
+          cache: true,
+          inputs: [
+            'default',
+            '{workspaceRoot}/.eslintrc.json',
+            '{workspaceRoot}/.eslintignore',
+            '{workspaceRoot}/eslint.config.js',
+          ],
+          executor: '@nx/eslint:lint',
+          outputs: ['{options.outputFile}'],
+          options: {},
+          configurations: {},
+        },
+      },
+      tags: [],
+      implicitDependencies: [],
+    });
+
     projectConfig = readProjectConfiguration(tree, 'my-source');
+    projectConfigFlat = readProjectConfiguration(tree, 'my-flat-source');
   };
 
   it('should rename the project', async () => {
@@ -148,7 +222,28 @@ describe('moveProjectConfiguration', () => {
 
     expect(
       readProjectConfiguration(tree, 'subfolder-my-destination')
-    ).toBeDefined();
+    ).toMatchSnapshot();
+  });
+
+  it('should rename the project correctly except for build targets', async () => {
+    setupWorkspace();
+
+    createProjectConfigurationInNewDestination(
+      tree,
+      { ...schema, projectName: 'my-flat-source' },
+      projectConfigFlat
+    );
+
+    const projectConfigFlatDestination = readProjectConfiguration(
+      tree,
+      'subfolder-my-destination'
+    );
+
+    expect(
+      projectConfigFlatDestination.targets['preview'].options.buildTarget
+    ).toBe('my-flat-source:build');
+
+    expect(projectConfigFlatDestination).toMatchSnapshot();
   });
 
   it('should update paths in only the intended project', async () => {

--- a/packages/workspace/src/generators/move/lib/create-project-configuration-in-new-destination.ts
+++ b/packages/workspace/src/generators/move/lib/create-project-configuration-in-new-destination.ts
@@ -14,7 +14,7 @@ export function createProjectConfigurationInNewDestination(
   projectConfig.name = schema.newProjectName;
   const isRootProject = projectConfig.root === '.';
 
-  // Subtle bug if project name === path, where the updated name was being overrideen.
+  // Subtle bug if project name === path, where the updated name was being overridden.
   const { name, ...rest } = projectConfig;
 
   // replace old root path with new one
@@ -35,8 +35,14 @@ export function createProjectConfigurationInNewDestination(
       `"${schema.relativeToRootDestination}/src/$2"`
     );
   } else {
+    // There's another issue if project name === path, where the target
+    // string (my-app:build:production) was being replaced
+    // and resulting in my-destination/my-new-name:build:production
+
+    // Change anything but target strings (my-app:build:production).
+    // Target string are going to be updated in the updateBuildTargets function
     newProjectString = newProjectString.replace(
-      new RegExp(projectConfig.root, 'g'),
+      new RegExp(projectConfig.root + '(?!:)', 'g'),
       schema.relativeToRootDestination
     );
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
There's an issue with the `move` generator if `projectName === path`, where the target string (`my-app:build:production`) was being replaced and resulting in `my-destination/my-new-name:build:production` because of:

```
    newProjectString = newProjectString.replace(
      new RegExp(projectConfig.root, 'g'),
      schema.relativeToRootDestination
    );
```

## Expected Behavior

Target string should be `new-name:build:production` instead of `new-path:build:production`.
So we need to safeguard for this, and first replace the name in target strings and then replace any paths.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #19493
