### PR TITLE
fix(webpack): fix check for standardWebpackConfigFunction

### DIFF
--- a/packages/webpack/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/webpack/src/executors/dev-server/dev-server.impl.ts
@@ -83,8 +83,8 @@ export async function* devServerExecutor(
     // Otherwise, user should define `devServer` option directly in their webpack config.
     if (
       typeof userDefinedWebpackConfig === 'function' &&
-      isNxWebpackComposablePlugin(userDefinedWebpackConfig) &&
-      !buildOptions.standardWebpackConfigFunction
+      (isNxWebpackComposablePlugin(userDefinedWebpackConfig) ||
+        !buildOptions.standardWebpackConfigFunction)
     ) {
       config = await userDefinedWebpackConfig(
         { devServer },

--- a/packages/webpack/src/executors/webpack/webpack.impl.ts
+++ b/packages/webpack/src/executors/webpack/webpack.impl.ts
@@ -60,8 +60,8 @@ async function getWebpackConfigs(
 
   if (
     typeof userDefinedWebpackConfig === 'function' &&
-    isNxWebpackComposablePlugin(userDefinedWebpackConfig) &&
-    !options.standardWebpackConfigFunction
+    (isNxWebpackComposablePlugin(userDefinedWebpackConfig) ||
+      !options.standardWebpackConfigFunction)
   ) {
     // Old behavior, call the Nx-specific webpack config function that user exports
     return await userDefinedWebpackConfig(config, {


### PR DESCRIPTION
The previous logic isn't correct, this PR fixes it. 

When `standardWebpackConfigFunction` isn't set to `true` (falsy by default), it should always treat the webpack config function as our composable version. 

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
