### PR TITLE
fix(vite): allow vitest to be v1

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -38,7 +38,7 @@
   },
   "peerDependencies": {
     "vite": "^5.0.0",
-    "vitest": ">=0.34.6 <1.0.0"
+    "vitest": ">=0.34.6"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Allow vitest v1, until we also merge this: https://github.com/nrwl/nx/pull/20747