### PR TITLE
docs(core): show default values for boolean options in executor schema explorer

### DIFF
--- a/nx-dev/feature-package-schema-viewer/src/lib/examples.ts
+++ b/nx-dev/feature-package-schema-viewer/src/lib/examples.ts
@@ -275,7 +275,7 @@ function generateJsonExampleForHelper(
       return inferExample(
         schema,
         (x) => typeof x === 'boolean',
-        () => Example.of(true)
+        () => Example.of(schema.default ?? true)
       );
     } else if (type === 'integer' || type === 'number') {
       return inferExample(


### PR DESCRIPTION
This PR updates the schema explorer so default values (if present) will be shown rather than the hardcoded `true`.

<img width="1104" alt="Screenshot 2023-12-14 at 8 50 25 AM" src="https://github.com/nrwl/nx/assets/53559/5ce38faf-145d-46b4-baa7-08824b637c01">

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20683
