### PR TITLE
fix(nx-dev): typo on the homepage

### DIFF
--- a/nx-dev/ui-home/src/lib/extensible-and-integrated/plugins-tab.tsx
+++ b/nx-dev/ui-home/src/lib/extensible-and-integrated/plugins-tab.tsx
@@ -345,7 +345,7 @@ export function PluginsTab(): JSX.Element {
                     title="Official plugins are maintained by the Nx Team"
                     className="absolute bottom-3 right-4 rounded-full border border-slate-200 bg-slate-50 px-3 py-0.5 text-xs font-medium capitalize dark:border-slate-700 dark:bg-slate-800"
                   >
-                    Official
+                    Nx Team
                   </span>
                 ) : (
                   <span


### PR DESCRIPTION
Plugins should be labeled as `Nx Team` instead of `Official`