### PR TITLE
fix(nextjs): Page generator should work out of the box

### DIFF
--- a/packages/next/src/generators/page/page.ts
+++ b/packages/next/src/generators/page/page.ts
@@ -27,6 +27,7 @@ export async function pageGeneratorInternal(host: Tree, schema: Schema) {
   const options = await normalizeOptions(host, schema);
   const componentTask = await reactComponentGenerator(host, {
     ...options,
+    isNextPage: true,
     nameAndDirectoryFormat: 'as-provided', // already determined the directory so use as is
     export: false,
     classComponent: false,

--- a/packages/react/src/generators/component/files/__fileName__.tsx__tmpl__
+++ b/packages/react/src/generators/component/files/__fileName__.tsx__tmpl__
@@ -32,13 +32,30 @@ const Styled<%= className %> = styled.div`
   color: pink;
 `;
 <% }%>
-<% if (classComponent) { %>
-export class <%= className %> extends Component<<%= className %>Props> {
-  override render() {
+<% if(!isNextPage) { %>
+  <% if (classComponent) { %>
+  export class <%= className %> extends Component<<%= className %>Props> {
+    override render() {
+      return (
+        <<%= wrapper %><%- extras %>>
+          <%= styledModule === 'styled-jsx' ? `<style jsx>{\`div { color: pink; }\`}</style>` : `` %>
+          <p>Welcome to <%= className %>!</p>
+          <% if (routing) { %>
+            <ul>
+              <li><Link to="/"><%= name %> root</Link></li>
+            </ul>
+            <Route path="/" element={<div>This is the <%= name %> root route.</div>} />
+          <% } %>
+        </<%= wrapper %>>
+      );
+    }
+  }
+  <% } else { %>
+  export function <%= className %>(props: <%= className %>Props) {
     return (
       <<%= wrapper %><%- extras %>>
-        <%= styledModule === 'styled-jsx' ? `<style jsx>{\`div { color: pink; }\`}</style>` : `` %>
-        <p>Welcome to <%= className %>!</p>
+        <% if (styledModule === 'styled-jsx') { %><style jsx>{`div { color: pink; }`}</style><% } %>
+        <h1>Welcome to <%= className %>!</h1>
         <% if (routing) { %>
           <ul>
             <li><Link to="/"><%= name %> root</Link></li>
@@ -47,25 +64,25 @@ export class <%= className %> extends Component<<%= className %>Props> {
         <% } %>
       </<%= wrapper %>>
     );
-  }
-}
-<% } else { %>
-export function <%= className %>(props: <%= className %>Props) {
-  return (
-    <<%= wrapper %><%- extras %>>
-      <% if (styledModule === 'styled-jsx') { %><style jsx>{`div { color: pink; }`}</style><% } %>
-      <h1>Welcome to <%= className %>!</h1>
-      <% if (routing) { %>
-        <ul>
-          <li><Link to="/"><%= name %> root</Link></li>
-        </ul>
-        <Route path="/" element={<div>This is the <%= name %> root route.</div>} />
-      <% } %>
-    </<%= wrapper %>>
-  );
-};
-<% } %>
+  };
+  <% } %>
 
-export default <%= className %>;
+  export default <%= className %>;
+<% } else { %>
+  export default function <%= className %>(props: <%= className %>Props) {
+    return (
+      <<%= wrapper %><%- extras %>>
+        <% if (styledModule === 'styled-jsx') { %><style jsx>{`div { color: pink; }`}</style><% } %>
+        <h1>Welcome to <%= className %>!</h1>
+        <% if (routing) { %>
+          <ul>
+            <li><Link to="/"><%= name %> root</Link></li>
+          </ul>
+          <Route path="/" element={<div>This is the <%= name %> root route.</div>} />
+        <% } %>
+      </<%= wrapper %>>
+    );
+  };
+<% } %>
 
 <% if (inSourceTests === true) { %> <%- inSourceVitestTests %> <% } %>

--- a/packages/react/src/generators/component/lib/normalize-options.ts
+++ b/packages/react/src/generators/component/lib/normalize-options.ts
@@ -57,6 +57,9 @@ export async function normalizeOptions(
   options.globalCss = options.globalCss ?? false;
   options.inSourceTests = options.inSourceTests ?? false;
 
+  //TODO (nicholas): Remove when Next page generator is removed
+  options.isNextPage = options.isNextPage ?? false;
+
   return {
     ...options,
     projectName,

--- a/packages/react/src/generators/component/schema.d.ts
+++ b/packages/react/src/generators/component/schema.d.ts
@@ -33,6 +33,8 @@ export interface Schema {
   // Used by other wrapping generators to preserve previous behavior
   // e.g. @nx/next:component
   derivedDirectory?: string;
+  // Used by Next.js to determine how React should generate the page
+  isNextPage?: boolean;
 }
 
 export interface NormalizedSchema extends Schema {


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Currently, when you run the page generator and then run build immediately after you would get something similar to
```shell
app/home/page.tsx
Type error: Page "app/home/page.tsx" does not match the required types of a Next.js Page.
  "Home" is not a valid Page export field.
Error occurred while trying to run the build command
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

It should build without errors if no modification has been made.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20106
