### PR TITLE
fix(release): changelog renderer should prefer breaking change explanation text

### DIFF
--- a/e2e/release/src/release.test.ts
+++ b/e2e/release/src/release.test.ts
@@ -120,6 +120,7 @@ describe('nx release', () => {
       dependencyRelationshipLogMatch.length !== 1
     ) {
       // From JamesHenry: explicit error to assist troubleshooting NXC-143
+      // Update: after seeing this error in the wild, it somehow seems to be not finding the dependency relationship sometimes
       throw new Error(
         `
 Error: Expected to find exactly one dependency relationship log line.
@@ -128,7 +129,10 @@ If you are seeing this message then you have been impacted by some currently und
 
 Please report the full nx release version command output below to the Nx team:
 
-${versionOutput}`
+${{
+  versionOutput,
+  pkg2Contents: readFile(`${pkg2}/package.json`),
+}}`
       );
     }
     expect(dependencyRelationshipLogMatch.length).toEqual(1);

--- a/packages/nx/changelog-renderer/index.spec.ts
+++ b/packages/nx/changelog-renderer/index.spec.ts
@@ -539,4 +539,125 @@ describe('defaultChangelogRenderer()', () => {
       expect(markdown).toMatchInlineSnapshot(`""`);
     });
   });
+
+  describe('breaking changes', () => {
+    it('should work for breaking changes with just the ! and no explanation', async () => {
+      const breakingChangeCommitWithExplanation: GitCommit = {
+        // ! after the type, no BREAKING CHANGE: in the body
+        message: 'feat(WebSocketSubject)!: no longer extends `Subject`.',
+        shortHash: '54f2f6ed1',
+        author: {
+          name: 'James Henry',
+          email: 'jh@example.com',
+        },
+        body:
+          'M\tpackages/rxjs/src/internal/observable/dom/WebSocketSubject.ts\n' +
+          '"',
+        authors: [
+          {
+            name: 'James Henry',
+            email: 'jh@example.com',
+          },
+        ],
+        description: 'no longer extends `Subject`.',
+        type: 'feat',
+        scope: 'WebSocketSubject',
+        references: [{ value: '54f2f6ed1', type: 'hash' }],
+        isBreaking: true,
+        revertedHashes: [],
+        affectedFiles: [
+          'packages/rxjs/src/internal/observable/dom/WebSocketSubject.ts',
+        ],
+      };
+
+      const markdown = await defaultChangelogRenderer({
+        projectGraph,
+        commits: [breakingChangeCommitWithExplanation],
+        releaseVersion: 'v1.1.0',
+        project: null,
+        entryWhenNoChanges: false,
+        changelogRenderOptions: {
+          includeAuthors: true,
+        },
+      });
+
+      expect(markdown).toMatchInlineSnapshot(`
+        "## v1.1.0
+
+
+        ### 🚀 Features
+
+        - ⚠️  **WebSocketSubject:** no longer extends \`Subject\`.
+
+        #### ⚠️  Breaking Changes
+
+        - ⚠️  **WebSocketSubject:** no longer extends \`Subject\`.
+
+        ### ❤️  Thank You
+
+        - James Henry"
+      `);
+    });
+
+    it('should extract the explanation of a breaking change and render it preferentially', async () => {
+      const breakingChangeCommitWithExplanation: GitCommit = {
+        // No ! after the type, but BREAKING CHANGE: in the body
+        message: 'feat(WebSocketSubject): no longer extends `Subject`.',
+        shortHash: '54f2f6ed1',
+        author: {
+          name: 'James Henry',
+          email: 'jh@example.com',
+        },
+        body:
+          'BREAKING CHANGE: `WebSocketSubject` is no longer `instanceof Subject`. Check for `instanceof WebSocketSubject` instead.\n' +
+          '"\n' +
+          '\n' +
+          'M\tpackages/rxjs/src/internal/observable/dom/WebSocketSubject.ts\n' +
+          '"',
+        authors: [
+          {
+            name: 'James Henry',
+            email: 'jh@example.com',
+          },
+        ],
+        description: 'no longer extends `Subject`.',
+        type: 'feat',
+        scope: 'WebSocketSubject',
+        references: [{ value: '54f2f6ed1', type: 'hash' }],
+        isBreaking: true,
+        revertedHashes: [],
+        affectedFiles: [
+          'packages/rxjs/src/internal/observable/dom/WebSocketSubject.ts',
+        ],
+      };
+
+      const markdown = await defaultChangelogRenderer({
+        projectGraph,
+        commits: [breakingChangeCommitWithExplanation],
+        releaseVersion: 'v1.1.0',
+        project: null,
+        entryWhenNoChanges: false,
+        changelogRenderOptions: {
+          includeAuthors: true,
+        },
+      });
+
+      expect(markdown).toMatchInlineSnapshot(`
+        "## v1.1.0
+
+
+        ### 🚀 Features
+
+        - ⚠️  **WebSocketSubject:** no longer extends \`Subject\`.
+
+        #### ⚠️  Breaking Changes
+
+        - **WebSocketSubject:** \`WebSocketSubject\` is no longer \`instanceof Subject\`. Check for \`instanceof WebSocketSubject\` instead.
+
+        ### ❤️  Thank You
+
+        - James Henry"
+      `);
+    });
+  });
 });

--- a/packages/nx/src/command-line/release/utils/git.ts
+++ b/packages/nx/src/command-line/release/utils/git.ts
@@ -285,7 +285,8 @@ export function parseGitCommit(commit: RawGitCommit): GitCommit | null {
 
   const scope = match.groups.scope || '';
 
-  const isBreaking = Boolean(match.groups.breaking);
+  const isBreaking =
+    Boolean(match.groups.breaking) || commit.body.includes('BREAKING CHANGE:');
   let description = match.groups.description;
 
   // Extract references from message


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

We always repeat the breaking change commit message and do not recognize breaking changes without the `!` being present.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

We recognize breaking changes with only `BREAKING CHANGE:` present (in accordance with the spec https://www.conventionalcommits.org/en/v1.0.0/), and we preferentially render the explanation text after `BREAKING CHANGE:` in the relevant section of the changelog. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
