### PR TITLE
fix(core): normalize version prefix to avoid "v" twice

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -207,8 +207,11 @@ export const commandsObject: yargs.Argv<Arguments> = yargs
   ) as yargs.Argv<Arguments>;
 
 async function main(parsedArgs: yargs.Arguments<Arguments>) {
+  
+  const normalizedNxVersion = normalizePrefixNxVersion(nxVersion)
+  
   output.log({
-    title: `Creating your v${nxVersion} workspace.`,
+    title: `Creating your ${normalizedNxVersion} workspace.`,
     bodyLines: [
       'To make sure the command works reliably in all environments, and that the preset is applied correctly,',
       `Nx will run "${parsedArgs.packageManager} install" several times. Please wait.`,
@@ -240,6 +243,10 @@ async function main(parsedArgs: yargs.Arguments<Arguments>) {
       title: `Successfully applied preset: ${parsedArgs.preset}`,
     });
   }
+}
+
+function normalizePrefixNxVersion(nxVersion: string) {
+  return nxVersion.startsWith('v') ? nxVersion : `v${nxVersion}`
 }
 
 function normalizeAndWarnOnDeprecatedPreset(


### PR DESCRIPTION
Since the new version has the v prefix, it was duplicated in the message when a workspace is being created
Like this: " >  NX   Creating your vv17.2.5 workspace."

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
