### PR TITLE
fix(release): ensure leading v is stripped from provided semver version

### DIFF
--- a/packages/js/src/generators/release-version/release-version.spec.ts
+++ b/packages/js/src/generators/release-version/release-version.spec.ts
@@ -494,6 +494,50 @@ To fix this you will either need to add a package.json file at that location, or
       });
     });
   });
+
+  describe('leading v in version', () => {
+    it(`should strip a leading v from the provided specifier`, async () => {
+      expect(readJson(tree, 'libs/my-lib/package.json').version).toEqual(
+        '0.0.1'
+      );
+      await releaseVersionGenerator(tree, {
+        projects: Object.values(projectGraph.nodes), // version all projects
+        projectGraph,
+        specifier: 'v8.8.8',
+        currentVersionResolver: 'disk',
+        releaseGroup: createReleaseGroup('fixed'),
+      });
+      expect(readJson(tree, 'libs/my-lib/package.json')).toMatchInlineSnapshot(`
+        {
+          "name": "my-lib",
+          "version": "8.8.8",
+        }
+      `);
+
+      expect(
+        readJson(tree, 'libs/project-with-dependency-on-my-pkg/package.json')
+      ).toMatchInlineSnapshot(`
+        {
+          "dependencies": {
+            "my-lib": "8.8.8",
+          },
+          "name": "project-with-dependency-on-my-pkg",
+          "version": "8.8.8",
+        }
+      `);
+      expect(
+        readJson(tree, 'libs/project-with-devDependency-on-my-pkg/package.json')
+      ).toMatchInlineSnapshot(`
+        {
+          "devDependencies": {
+            "my-lib": "8.8.8",
+          },
+          "name": "project-with-devDependency-on-my-pkg",
+          "version": "8.8.8",
+        }
+      `);
+    });
+  });
 });
 
 function createReleaseGroup(

--- a/packages/js/src/generators/release-version/release-version.ts
+++ b/packages/js/src/generators/release-version/release-version.ts
@@ -37,10 +37,14 @@ export async function releaseVersionGenerator(
     const versionData: VersionData = {};
 
     // If the user provided a specifier, validate that it is valid semver or a relative semver keyword
-    if (options.specifier && !isValidSemverSpecifier(options.specifier)) {
-      throw new Error(
-        `The given version specifier "${options.specifier}" is not valid. You provide an exact version or a valid semver keyword such as "major", "minor", "patch", etc.`
-      );
+    if (options.specifier) {
+      if (!isValidSemverSpecifier(options.specifier)) {
+        throw new Error(
+          `The given version specifier "${options.specifier}" is not valid. You provide an exact version or a valid semver keyword such as "major", "minor", "patch", etc.`
+        );
+      }
+      // The node semver library classes a leading `v` as valid, but we want to ensure it is not present in the final version
+      options.specifier = options.specifier.replace(/^v/, '');
     }
 
     const projects = options.projects;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`v17.2.5` was accidentally published (with a leading `v`) and it turns out that the node semver package feels the leading v is valid and therefore we happily stamped the full `v17.2.5` out into our package.json files.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Now even if such an accidental publish were to happen, the leading `v` would always be stripped before applying it.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
