### PR TITLE
fix(node): E2E test port conflicts

### DIFF
--- a/e2e/node/src/node-server.test.ts
+++ b/e2e/node/src/node-server.test.ts
@@ -154,12 +154,14 @@ describe('Node Applications + webpack', () => {
   it('should support waitUntilTargets for serve target', async () => {
     const nodeApp1 = uniq('nodeapp1');
     const nodeApp2 = uniq('nodeapp2');
+
+    // Set ports to avoid conflicts with other tests that might run in parallel
     runCLI(
-      `generate @nx/node:app ${nodeApp1} --framework=none --no-interactive`
+      `generate @nx/node:app ${nodeApp1} --framework=none --no-interactive --port=4444`
     );
     setMaxWorkers(join('apps', nodeApp1, 'project.json'));
     runCLI(
-      `generate @nx/node:app ${nodeApp2} --framework=none --no-interactive`
+      `generate @nx/node:app ${nodeApp2} --framework=none --no-interactive --port=4445`
     );
     setMaxWorkers(join('apps', nodeApp2, 'project.json'));
     updateJson(join('apps', nodeApp1, 'project.json'), (config) => {


### PR DESCRIPTION
Fixes this issue: https://staging.nx.app/runs/7BPr6czXMd/task/e2e-node%3Ae2e

Since the e2e tests are usually `async` there is a possibility that two tests using the same environment variable (in this case _port_) can conflict while running.
