### PR TITLE
feat(nextjs): Add support for experimental-https when running dev server

### DIFF
--- a/docs/generated/packages/next/executors/server.json
+++ b/docs/generated/packages/next/executors/server.json
@@ -55,6 +55,10 @@
       "turbo": {
         "type": "boolean",
         "description": "Activate the incremental bundler for Next.js, which is implemented in Rust. Please note, this feature is exclusively available in development mode."
+      },
+      "experimentalHttps": {
+        "type": "boolean",
+        "description": "Enable HTTPS support for the Next.js development server."
       }
     },
     "required": ["buildTarget"],

--- a/packages/next/src/executors/server/schema.json
+++ b/packages/next/src/executors/server/schema.json
@@ -52,6 +52,10 @@
     "turbo": {
       "type": "boolean",
       "description": "Activate the incremental bundler for Next.js, which is implemented in Rust. Please note, this feature is exclusively available in development mode."
+    },
+    "experimentalHttps": {
+      "type": "boolean",
+      "description": "Enable HTTPS support for the Next.js development server."
     }
   },
   "required": ["buildTarget"],

--- a/packages/next/src/executors/server/server.impl.ts
+++ b/packages/next/src/executors/server/server.impl.ts
@@ -55,11 +55,13 @@ export default async function* serveExecutor(
 
   const mode = options.dev ? 'dev' : 'start';
   const turbo = options.turbo && options.dev ? '--turbo' : '';
+  const experimentalHttps =
+    options.experimentalHttps && options.dev ? '--experimental-https' : '';
   const nextBin = require.resolve('next/dist/bin/next');
 
   yield* createAsyncIterable<{ success: boolean; baseUrl: string }>(
     async ({ done, next, error }) => {
-      const server = fork(nextBin, [mode, ...args, turbo], {
+      const server = fork(nextBin, [mode, ...args, turbo, experimentalHttps], {
         cwd: options.dev ? projectRoot : nextDir,
         stdio: 'inherit',
       });

--- a/packages/next/src/utils/types.ts
+++ b/packages/next/src/utils/types.ts
@@ -52,6 +52,7 @@ export interface NextServeBuilderOptions {
   buildLibsFromSource?: boolean;
   keepAliveTimeout?: number;
   turbo?: boolean;
+  experimentalHttps?: boolean;
 }
 
 export interface NextExportBuilderOptions {


### PR DESCRIPTION
Adds support for `--experiemental-https` when running dev server similar to `--turbo`.

This change was missed when Next.js 13.5 got released https://nextjs.org/blog/next-13-5

closes: #19952

