### PR TITLE
fix(vite): dist and coverage paths for root projects

### DIFF
--- a/packages/nuxt/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/nuxt/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -109,7 +109,7 @@ exports[`@nx/nuxt/plugin root project should create nodes 1`] = `
             "cwd": ".",
           },
           "outputs": [
-            "{workspaceRoot}/coverage/{projectRoot}",
+            "{projectRoot}/coverage",
           ],
         },
       },

--- a/packages/nuxt/src/plugins/plugin.ts
+++ b/packages/nuxt/src/plugins/plugin.ts
@@ -232,11 +232,11 @@ function getOutputs(
   buildOutputs: string[];
   testOutputs: string[];
 } {
-  const reportsDirectory =
-    normalizeOutputPath(
-      viteConfig?.['test']?.coverage?.reportsDirectory,
-      projectRoot
-    ) ?? '{workspaceRoot}/coverage/{projectRoot}';
+  const reportsDirectory = normalizeOutputPath(
+    viteConfig?.['test']?.coverage?.reportsDirectory,
+    projectRoot,
+    'coverage'
+  );
 
   let nuxtBuildDir = nuxtConfig?.buildDir;
   if (nuxtConfig?.buildDir && basename(nuxtConfig?.buildDir) === '.nuxt') {
@@ -248,7 +248,7 @@ function getOutputs(
     );
   }
   const buildOutputPath =
-    normalizeOutputPath(nuxtBuildDir, projectRoot) ??
+    normalizeOutputPath(nuxtBuildDir, projectRoot, 'dist') ??
     '{workspaceRoot}/dist/{projectRoot}';
 
   return {
@@ -259,16 +259,24 @@ function getOutputs(
 
 function normalizeOutputPath(
   outputPath: string | undefined,
-  projectRoot: string
+  projectRoot: string,
+  path: 'coverage' | 'dist'
 ): string | undefined {
-  if (!outputPath) return undefined;
-  if (isAbsolute(outputPath)) {
-    return `{workspaceRoot}/${relative(workspaceRoot, outputPath)}`;
-  } else {
-    if (outputPath.startsWith('..')) {
-      return join('{workspaceRoot}', join(projectRoot, outputPath));
+  if (!outputPath) {
+    if (projectRoot === '.') {
+      return `{projectRoot}/${path}`;
     } else {
-      return outputPath;
+      return `{workspaceRoot}/${path}/{projectRoot}`;
+    }
+  } else {
+    if (isAbsolute(outputPath)) {
+      return `{workspaceRoot}/${relative(workspaceRoot, outputPath)}`;
+    } else {
+      if (outputPath.startsWith('..')) {
+        return join('{workspaceRoot}', join(projectRoot, outputPath));
+      } else {
+        return join('{projectRoot}', outputPath);
+      }
     }
   }
 }

--- a/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
+++ b/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
@@ -1128,7 +1128,7 @@ export default defineConfig({
 
     reporters: ['default'],
     coverage: {
-      reportsDirectory: './coverage/.',
+      reportsDirectory: './coverage/test',
       provider: 'v8',
     },
   },

--- a/packages/vite/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/vite/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -96,7 +96,7 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
             "cwd": ".",
           },
           "outputs": [
-            "{workspaceRoot}/dist/{projectRoot}",
+            "{projectRoot}/dist",
           ],
         },
         "preview": {
@@ -133,7 +133,7 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
             "cwd": ".",
           },
           "outputs": [
-            "{workspaceRoot}/coverage/{projectRoot}",
+            "{projectRoot}/coverage",
           ],
         },
       },

--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -221,13 +221,17 @@ function getOutputs(
 } {
   const { build, test } = viteConfig;
 
-  const buildOutputPath =
-    normalizeOutputPath(build?.outDir, projectRoot) ??
-    '{workspaceRoot}/dist/{projectRoot}';
+  const buildOutputPath = normalizeOutputPath(
+    build?.outDir,
+    projectRoot,
+    'dist'
+  );
 
-  const reportsDirectoryPath =
-    normalizeOutputPath(test?.coverage?.reportsDirectory, projectRoot) ??
-    '{workspaceRoot}/coverage/{projectRoot}';
+  const reportsDirectoryPath = normalizeOutputPath(
+    test?.coverage?.reportsDirectory,
+    projectRoot,
+    'coverage'
+  );
 
   return {
     buildOutputs: [buildOutputPath],
@@ -237,16 +241,24 @@ function getOutputs(
 
 function normalizeOutputPath(
   outputPath: string | undefined,
-  projectRoot: string
+  projectRoot: string,
+  path: 'coverage' | 'dist'
 ): string | undefined {
-  if (!outputPath) return undefined;
-  if (isAbsolute(outputPath)) {
-    return `{workspaceRoot}/${relative(workspaceRoot, outputPath)}`;
-  } else {
-    if (outputPath.startsWith('..')) {
-      return join('{workspaceRoot}', join(projectRoot, outputPath));
+  if (!outputPath) {
+    if (projectRoot === '.') {
+      return `{projectRoot}/${path}`;
     } else {
-      return outputPath;
+      return `{workspaceRoot}/${path}/{projectRoot}`;
+    }
+  } else {
+    if (isAbsolute(outputPath)) {
+      return `{workspaceRoot}/${relative(workspaceRoot, outputPath)}`;
+    } else {
+      if (outputPath.startsWith('..')) {
+        return join('{workspaceRoot}', join(projectRoot, outputPath));
+      } else {
+        return join('{projectRoot}', outputPath);
+      }
     }
   }
 }

--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -496,6 +496,11 @@ export function createOrEditViteConfig(
     ? `${projectRoot}/vitest.config.ts`
     : `${projectRoot}/vite.config.ts`;
 
+  const buildOutDir =
+    projectRoot === '.'
+      ? `./dist/${options.project}`
+      : `${offsetFromRoot(projectRoot)}dist/${projectRoot}`;
+
   const buildOption = onlyVitest
     ? ''
     : options.includeLib
@@ -503,7 +508,7 @@ export function createOrEditViteConfig(
       // Configuration for building your library.
       // See: https://vitejs.dev/guide/build.html#library-mode
       build: {
-        outDir: '${offsetFromRoot(projectRoot)}dist/${projectRoot}',
+        outDir: '${buildOutDir}',
         reportCompressedSize: true,
         commonjsOptions: {
           transformMixedEsModules: true,
@@ -524,7 +529,7 @@ export function createOrEditViteConfig(
       },`
     : `
     build: {
-      outDir: '${offsetFromRoot(projectRoot)}dist/${projectRoot}',
+      outDir: '${buildOutDir}',
       reportCompressedSize: true,
       commonjsOptions: {
         transformMixedEsModules: true,
@@ -553,6 +558,11 @@ export function createOrEditViteConfig(
     );
   }
 
+  const reportsDirectory =
+    projectRoot === '.'
+      ? `./coverage/${options.project}`
+      : `${offsetFromRoot(projectRoot)}coverage/${projectRoot}`;
+
   const testOption = options.includeVitest
     ? `test: {
     globals: true,
@@ -568,7 +578,7 @@ export function createOrEditViteConfig(
     }
     reporters: ['default'],
     coverage: {
-      reportsDirectory: '${offsetFromRoot(projectRoot)}coverage/${projectRoot}',
+      reportsDirectory: '${reportsDirectory}',
       provider: ${
         options.coverageProvider ? `'${options.coverageProvider}'` : `'v8'`
       },
@@ -618,12 +628,13 @@ export function createOrEditViteConfig(
       viteConfigPath,
       options,
       buildOption,
+      buildOutDir,
       imports,
       plugins,
       testOption,
+      reportsDirectory,
       cacheDir,
       offsetFromRoot(projectRoot),
-      projectRoot,
       projectAlreadyHasViteTargets
     );
     return;
@@ -788,12 +799,13 @@ function handleViteConfigFileExists(
   viteConfigPath: string,
   options: ViteConfigFileOptions,
   buildOption: string,
+  buildOutDir: string,
   imports: string[],
   plugins: string[],
   testOption: string,
+  reportsDirectory: string,
   cacheDir: string,
   offsetFromRoot: string,
-  projectRoot: string,
   projectAlreadyHasViteTargets?: TargetFlags
 ) {
   if (
@@ -820,14 +832,14 @@ function handleViteConfigFileExists(
         rollupOptions: {
           external: options.rollupOptionsExternal ?? [],
         },
-        outDir: `${offsetFromRoot}dist/${projectRoot}`,
+        outDir: buildOutDir,
         reportCompressedSize: true,
         commonjsOptions: {
           transformMixedEsModules: true,
         },
       }
     : {
-        outDir: `${offsetFromRoot}dist/${projectRoot}`,
+        outDir: buildOutDir,
         reportCompressedSize: true,
         commonjsOptions: {
           transformMixedEsModules: true,
@@ -843,7 +855,7 @@ function handleViteConfigFileExists(
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     reporters: ['default'],
     coverage: {
-      reportsDirectory: `${offsetFromRoot}coverage/${projectRoot}`,
+      reportsDirectory: reportsDirectory,
       provider: `${options.coverageProvider ?? 'v8'}`,
     },
   };


### PR DESCRIPTION
Account for root projects when setting build and coverage output paths.
