### PR TITLE
fix(angular): fix standalone eslint config generation

### DIFF
--- a/e2e/eslint/src/linter.test.ts
+++ b/e2e/eslint/src/linter.test.ts
@@ -687,11 +687,12 @@ describe('Linter', () => {
       let e2eEslint = readJson('e2e/.eslintrc.json');
 
       // should have plugin extends
-      expect(appEslint.overrides[0].extends).toBeDefined();
-      expect(appEslint.overrides[1].extends).toBeDefined();
-      expect(
-        e2eEslint.overrides.some((override) => override.extends)
-      ).toBeTruthy();
+      let appOverrides = JSON.stringify(appEslint.overrides);
+      expect(appOverrides).toContain('plugin:@nx/javascript');
+      expect(appOverrides).toContain('plugin:@nx/typescript');
+      let e2eOverrides = JSON.stringify(e2eEslint.overrides);
+      expect(e2eOverrides).toContain('plugin:@nx/javascript');
+      expect(e2eOverrides).toContain('plugin:@nx/typescript');
 
       runCLI(`generate @nx/js:lib ${mylib} --unitTestRunner=jest`);
       verifySuccessfulMigratedSetup(myapp, mylib);
@@ -700,11 +701,12 @@ describe('Linter', () => {
       e2eEslint = readJson('e2e/.eslintrc.json');
 
       // should have no plugin extends
-      expect(appEslint.overrides[0].extends).toBeUndefined();
-      expect(appEslint.overrides[1].extends).toBeUndefined();
-      expect(
-        e2eEslint.overrides.some((override) => override.extends)
-      ).toBeFalsy();
+      appOverrides = JSON.stringify(appEslint.overrides);
+      expect(appOverrides).not.toContain('plugin:@nx/javascript');
+      expect(appOverrides).not.toContain('plugin:@nx/typescript');
+      e2eOverrides = JSON.stringify(e2eEslint.overrides);
+      expect(e2eOverrides).not.toContain('plugin:@nx/javascript');
+      expect(e2eOverrides).not.toContain('plugin:@nx/typescript');
     });
 
     it('(Angular standalone) should set root project config to app and e2e app and migrate when another lib is added', () => {
@@ -720,10 +722,10 @@ describe('Linter', () => {
       let e2eEslint = readJson('e2e/.eslintrc.json');
 
       // should have plugin extends
-      expect(appEslint.overrides[1].extends).toBeDefined();
-      expect(
-        e2eEslint.overrides.some((override) => override.extends)
-      ).toBeTruthy();
+      let appOverrides = JSON.stringify(appEslint.overrides);
+      expect(appOverrides).toContain('plugin:@nx/typescript');
+      let e2eOverrides = JSON.stringify(e2eEslint.overrides);
+      expect(e2eOverrides).toContain('plugin:@nx/typescript');
 
       runCLI(`generate @nx/js:lib ${mylib} --no-interactive`);
       verifySuccessfulMigratedSetup(myapp, mylib);
@@ -732,12 +734,10 @@ describe('Linter', () => {
       e2eEslint = readJson('e2e/.eslintrc.json');
 
       // should have no plugin extends
-      expect(appEslint.overrides[1].extends).toEqual([
-        'plugin:@nx/angular-template',
-      ]);
-      expect(
-        e2eEslint.overrides.some((override) => override.extends)
-      ).toBeFalsy();
+      appOverrides = JSON.stringify(appEslint.overrides);
+      expect(appOverrides).not.toContain('plugin:@nx/typescript');
+      e2eOverrides = JSON.stringify(e2eEslint.overrides);
+      expect(e2eOverrides).not.toContain('plugin:@nx/typescript');
     });
 
     it('(Node standalone) should set root project config to app and e2e app and migrate when another lib is added', async () => {
@@ -754,9 +754,12 @@ describe('Linter', () => {
       let e2eEslint = readJson('e2e/.eslintrc.json');
 
       // should have plugin extends
-      expect(appEslint.overrides[0].extends).toBeDefined();
-      expect(appEslint.overrides[1].extends).toBeDefined();
-      expect(e2eEslint.overrides[0].extends).toBeDefined();
+      let appOverrides = JSON.stringify(appEslint.overrides);
+      expect(appOverrides).toContain('plugin:@nx/javascript');
+      expect(appOverrides).toContain('plugin:@nx/typescript');
+      let e2eOverrides = JSON.stringify(e2eEslint.overrides);
+      expect(e2eOverrides).toContain('plugin:@nx/javascript');
+      expect(e2eOverrides).toContain('plugin:@nx/typescript');
 
       runCLI(`generate @nx/js:lib ${mylib} --no-interactive`);
       verifySuccessfulMigratedSetup(myapp, mylib);
@@ -765,9 +768,13 @@ describe('Linter', () => {
       e2eEslint = readJson('e2e/.eslintrc.json');
 
       // should have no plugin extends
-      expect(appEslint.overrides[0].extends).toBeUndefined();
-      expect(appEslint.overrides[1].extends).toBeUndefined();
-      expect(e2eEslint.overrides[0].extends).toBeUndefined();
+      // should have no plugin extends
+      appOverrides = JSON.stringify(appEslint.overrides);
+      expect(appOverrides).not.toContain('plugin:@nx/javascript');
+      expect(appOverrides).not.toContain('plugin:@nx/typescript');
+      e2eOverrides = JSON.stringify(e2eEslint.overrides);
+      expect(e2eOverrides).not.toContain('plugin:@nx/javascript');
+      expect(e2eOverrides).not.toContain('plugin:@nx/typescript');
     });
   });
 

--- a/packages/angular/src/generators/add-linting/add-linting.ts
+++ b/packages/angular/src/generators/add-linting/add-linting.ts
@@ -15,6 +15,10 @@ import {
   replaceOverridesInLintConfig,
 } from '@nx/eslint/src/generators/utils/eslint-file';
 import { camelize, dasherize } from '@nx/devkit/src/utils/string-utils';
+import {
+  javaScriptOverride,
+  typeScriptOverride,
+} from '@nx/eslint/src/generators/init/global-eslint-config';
 
 export async function addLintingGenerator(
   tree: Tree,
@@ -43,6 +47,7 @@ export async function addLintingGenerator(
       .includes(`${options.projectRoot}/tsconfig.*?.json`);
 
     replaceOverridesInLintConfig(tree, options.projectRoot, [
+      ...(rootProject ? [typeScriptOverride, javaScriptOverride] : []),
       {
         files: ['*.ts'],
         ...(hasParserOptions


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Angular standalone app generates eslint config without base `@nx/typescript` and `@nx/javascript` rule sets.

## Expected Behavior
Every standalone app should add base `@nx/typescript` and `@nx/javascript` rule sets.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
