### PR TITLE
feat(eslint): make init generator public

### DIFF
--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -7262,6 +7262,14 @@
             "name": "generators",
             "children": [
               {
+                "id": "init",
+                "path": "/nx-api/eslint/generators/init",
+                "name": "init",
+                "children": [],
+                "isExternal": false,
+                "disableCollapsible": false
+              },
+              {
                 "id": "workspace-rules-project",
                 "path": "/nx-api/eslint/generators/workspace-rules-project",
                 "name": "workspace-rules-project",

--- a/docs/generated/manifests/nx-api.json
+++ b/docs/generated/manifests/nx-api.json
@@ -691,6 +691,15 @@
       }
     },
     "generators": {
+      "/nx-api/eslint/generators/init": {
+        "description": "Set up the ESLint plugin.",
+        "file": "generated/packages/eslint/generators/init.json",
+        "hidden": true,
+        "name": "init",
+        "originalFilePath": "/packages/eslint/src/generators/init/schema.json",
+        "path": "/nx-api/eslint/generators/init",
+        "type": "generator"
+      },
       "/nx-api/eslint/generators/workspace-rules-project": {
         "description": "Create the Workspace Lint Rules Project.",
         "file": "generated/packages/eslint/generators/workspace-rules-project.json",

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -680,6 +680,15 @@
     ],
     "generators": [
       {
+        "description": "Set up the ESLint plugin.",
+        "file": "generated/packages/eslint/generators/init.json",
+        "hidden": true,
+        "name": "init",
+        "originalFilePath": "/packages/eslint/src/generators/init/schema.json",
+        "path": "eslint/generators/init",
+        "type": "generator"
+      },
+      {
         "description": "Create the Workspace Lint Rules Project.",
         "file": "generated/packages/eslint/generators/workspace-rules-project.json",
         "hidden": true,

--- a/docs/generated/packages/eslint/generators/init.json
+++ b/docs/generated/packages/eslint/generators/init.json
@@ -1,0 +1,21 @@
+{
+  "name": "init",
+  "factory": "./src/generators/init/init#lintInitGenerator",
+  "schema": {
+    "$schema": "http://json-schema.org/schema",
+    "cli": "nx",
+    "$id": "NxESLintInit",
+    "title": "Initialize ESLint Plugin",
+    "description": "Set up the ESLint plugin.",
+    "type": "object",
+    "properties": {},
+    "required": [],
+    "presets": []
+  },
+  "description": "Set up the ESLint plugin.",
+  "hidden": true,
+  "implementation": "/packages/eslint/src/generators/init/init#lintInitGenerator.ts",
+  "aliases": [],
+  "path": "/packages/eslint/src/generators/init/schema.json",
+  "type": "generator"
+}

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -405,6 +405,7 @@
     - [executors](/nx-api/eslint/executors)
       - [lint](/nx-api/eslint/executors/lint)
     - [generators](/nx-api/eslint/generators)
+      - [init](/nx-api/eslint/generators/init)
       - [workspace-rules-project](/nx-api/eslint/generators/workspace-rules-project)
       - [workspace-rule](/nx-api/eslint/generators/workspace-rule)
       - [convert-to-flat-config](/nx-api/eslint/generators/convert-to-flat-config)

--- a/packages/eslint/generators.json
+++ b/packages/eslint/generators.json
@@ -2,6 +2,12 @@
   "name": "nx/eslint",
   "version": "0.1",
   "generators": {
+    "init": {
+      "factory": "./src/generators/init/init#lintInitGenerator",
+      "schema": "./src/generators/init/schema.json",
+      "description": "Set up the ESLint plugin.",
+      "hidden": true
+    },
     "workspace-rules-project": {
       "factory": "./src/generators/workspace-rules-project/workspace-rules-project#lintWorkspaceRulesProjectGenerator",
       "schema": "./src/generators/workspace-rules-project/schema.json",

--- a/packages/eslint/src/generators/init/schema.json
+++ b/packages/eslint/src/generators/init/schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "$id": "NxESLintInit",
+  "title": "Initialize ESLint Plugin",
+  "description": "Set up the ESLint plugin.",
+  "type": "object",
+  "properties": {},
+  "required": []
+}


### PR DESCRIPTION
We need to call `nx g @nx/eslint:init` for PCv3 so this PR makes it public.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
