### PR TITLE
fix(nextjs): correct inferred outputs for root Next.js projects

### DIFF
--- a/packages/next/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/next/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -1,5 +1,101 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`@nx/next/plugin integrated projects should create nodes 1`] = `Promise {}`;
+exports[`@nx/next/plugin integrated projects should create nodes 1`] = `
+{
+  "projects": {
+    "my-app": {
+      "root": "my-app",
+      "targets": {
+        "my-build": {
+          "cache": true,
+          "command": "next build",
+          "dependsOn": [
+            "^build",
+          ],
+          "inputs": [
+            "default",
+            "^production",
+            {
+              "externalDependencies": [
+                "next",
+              ],
+            },
+          ],
+          "options": {
+            "cwd": "my-app",
+          },
+          "outputs": [
+            "{workspaceRoot}/my-app/.next",
+            "{workspaceRoot}/my-app/.next/!(cache)",
+          ],
+        },
+        "my-serve": {
+          "command": "next dev",
+          "options": {
+            "cwd": "my-app",
+          },
+        },
+        "my-start": {
+          "command": "next start",
+          "dependsOn": [
+            "my-build",
+          ],
+          "options": {
+            "cwd": "my-app",
+          },
+        },
+      },
+    },
+  },
+}
+`;
 
-exports[`@nx/next/plugin root projects should create nodes 1`] = `Promise {}`;
+exports[`@nx/next/plugin root projects should create nodes 1`] = `
+{
+  "projects": {
+    ".": {
+      "root": ".",
+      "targets": {
+        "build": {
+          "cache": true,
+          "command": "next build",
+          "dependsOn": [
+            "^build",
+          ],
+          "inputs": [
+            "default",
+            "^production",
+            {
+              "externalDependencies": [
+                "next",
+              ],
+            },
+          ],
+          "options": {
+            "cwd": ".",
+          },
+          "outputs": [
+            "{projectRoot}/.next",
+            "{projectRoot}/.next/!(cache)",
+          ],
+        },
+        "dev": {
+          "command": "next dev",
+          "options": {
+            "cwd": ".",
+          },
+        },
+        "start": {
+          "command": "next start",
+          "dependsOn": [
+            "build",
+          ],
+          "options": {
+            "cwd": ".",
+          },
+        },
+      },
+    },
+  },
+}
+`;

--- a/packages/next/src/plugins/plugin.spec.ts
+++ b/packages/next/src/plugins/plugin.spec.ts
@@ -25,10 +25,10 @@ describe('@nx/next/plugin', () => {
       jest.resetModules();
     });
 
-    it('should create nodes', () => {
+    it('should create nodes', async () => {
       const nextConfigPath = 'next.config.js';
       mockNextConfig(nextConfigPath, {});
-      const nodes = createNodesFunction(
+      const nodes = await createNodesFunction(
         nextConfigPath,
         {
           buildTargetName: 'build',
@@ -65,9 +65,9 @@ describe('@nx/next/plugin', () => {
       jest.resetModules();
     });
 
-    it('should create nodes', () => {
+    it('should create nodes', async () => {
       mockNextConfig('my-app/next.config.js', {});
-      const nodes = createNodesFunction(
+      const nodes = await createNodesFunction(
         'my-app/next.config.js',
         {
           buildTargetName: 'my-build',

--- a/packages/next/src/plugins/plugin.ts
+++ b/packages/next/src/plugins/plugin.ts
@@ -2,10 +2,10 @@ import {
   CreateDependencies,
   CreateNodes,
   CreateNodesContext,
-  NxJsonConfiguration,
-  TargetConfiguration,
   detectPackageManager,
+  NxJsonConfiguration,
   readJsonFile,
+  TargetConfiguration,
   writeJsonFile,
 } from '@nx/devkit';
 import { dirname, join } from 'path';
@@ -170,7 +170,12 @@ async function getOutputs(projectRoot, nextConfig) {
     // If nextConfig is an object, directly use its 'distDir' property.
     dir = nextConfig.distDir;
   }
-  return `{workspaceRoot}/${projectRoot}/${dir}`;
+
+  if (projectRoot === '.') {
+    return `{projectRoot}/${dir}`;
+  } else {
+    return `{workspaceRoot}/${projectRoot}/${dir}`;
+  }
 }
 
 function getNextConfig(


### PR DESCRIPTION
The current value (i.e. `{workspaceRoot}/./.next`) does not work and nothing gets cached. Also updates unit tests to properly await promises so we get correct snapshots.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
