### PR TITLE
chore(repo): update nightly node version matrix

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -26,13 +26,10 @@ jobs:
         node_version:
           - 20
           - 18
-          - 16
         exclude:
-          # run just node v18 on macos
+          # run just node v20 on macos
           - os: macos-latest
             node_version: 20
-          - os: macos-latest
-            node_version: 16
 
     name: Cache install (${{ matrix.os }}, node v${{ matrix.node_version }})
     steps:
@@ -102,7 +99,6 @@ jobs:
         node_version:
           - 20
           - 18
-          - 16
         package_manager:
           - npm
           - yarn
@@ -214,109 +210,57 @@ jobs:
           - os: ubuntu-latest
             project: e2e-expo
           # exclude non-CNW/Lerna tests from non-LTS node versions
-          - node_version: 16
+          - node_version: 18
             project: e2e-angular-core
-          - node_version: 16
+          - node_version: 18
             project: e2e-angular-extensions
-          - node_version: 16
+          - node_version: 18
             project: e2e-angular-module-federation
-          - node_version: 16
+          - node_version: 18
             project: e2e-cypress
-          - node_version: 16
+          - node_version: 18
             project: e2e-detox
-          - node_version: 16
+          - node_version: 18
             project: e2e-esbuild
-          - node_version: 16
+          - node_version: 18
             project: e2e-expo
-          - node_version: 16
+          - node_version: 18
             project: e2e-jest
-          - node_version: 16
+          - node_version: 18
             project: e2e-js
-          - node_version: 16
+          - node_version: 18
             project: e2e-eslint
-          - node_version: 16
+          - node_version: 18
             project: e2e-next
-          - node_version: 16
+          - node_version: 18
             project: e2e-node
-          - node_version: 16
+          - node_version: 18
             project: e2e-nx-init
-          - node_version: 16
+          - node_version: 18
             project: e2e-nx-misc
-          - node_version: 16
+          - node_version: 18
             project: e2e-nx-plugin
-          - node_version: 16
+          - node_version: 18
             project: e2e-lerna-smoke-tests
-          - node_version: 16
+          - node_version: 18
             project: e2e-react-core
-          - node_version: 16
+          - node_version: 18
             project: e2e-react-module-federation
-          - node_version: 16
+          - node_version: 18
             project: e2e-react-extensions
-          - node_version: 16
+          - node_version: 18
             project: e2e-react-native
-          - node_version: 16
+          - node_version: 18
             project: e2e-web
-          - node_version: 16
+          - node_version: 18
             project: e2e-rollup
-          - node_version: 16
+          - node_version: 18
             project: e2e-storybook
-          - node_version: 16
+          - node_version: 18
             project: e2e-storybook-angular
-          - node_version: 16
+          - node_version: 18
             project: e2e-vite
-          - node_version: 16
-            project: e2e-webpack
-          - node_version: 20
-            project: e2e-angular-core
-          - node_version: 20
-            project: e2e-angular-extensions
-          - node_version: 20
-            project: e2e-angular-module-federation
-          - node_version: 20
-            project: e2e-cypress
-          - node_version: 20
-            project: e2e-detox
-          - node_version: 20
-            project: e2e-esbuild
-          - node_version: 20
-            project: e2e-expo
-          - node_version: 20
-            project: e2e-jest
-          - node_version: 20
-            project: e2e-js
-          - node_version: 20
-            project: e2e-eslint
-          - node_version: 20
-            project: e2e-next
-          - node_version: 20
-            project: e2e-node
-          - node_version: 20
-            project: e2e-nx-init
-          - node_version: 20
-            project: e2e-nx-misc
-          - node_version: 20
-            project: e2e-nx-plugin
-          - node_version: 20
-            project: e2e-lerna-smoke-tests
-          - node_version: 20
-            project: e2e-react-core
-          - node_version: 20
-            project: e2e-react-module-federation
-          - node_version: 20
-            project: e2e-react-extensions
-          - node_version: 20
-            project: e2e-react-native
-          - node_version: 20
-            project: e2e-web
-          - node_version: 20
-            project: e2e-rollup
-          - node_version: 20
-            project: e2e-storybook
-          - node_version: 20
-            project: e2e-storybook-angular
-          - node_version: 20
-            project: e2e-vite
-          - node_version: 20
+          - node_version: 18
             project: e2e-webpack
           # run just npm v18 on macos
           - os: macos-latest
@@ -324,9 +268,7 @@ jobs:
           - os: macos-latest
             package_manager: pnpm
           - os: macos-latest
-            node_version: 16
-          - os: macos-latest
-            node_version: 20
+            node_version: 18
       fail-fast: false
 
     name: ${{ matrix.os_name }}/${{ matrix.package_manager }}/${{ matrix.node_version }} ${{ join(matrix.project) }}

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -23,7 +23,6 @@ jobs:
         node_version:
           - 20
           - 18
-          - 16
 
     name: Cache install (node v${{ matrix.node_version }})
     steps:
@@ -75,7 +74,6 @@ jobs:
         node_version:
           - 20
           - 18
-          - 16
         package_manager:
           - npm
         project:
@@ -159,97 +157,51 @@ jobs:
             codeowners: 'S04SYHYKGNP'
         exclude:
           # exclude non-CNW/Lerna tests from non-LTS node versions
-          - node_version: 16
+          - node_version: 18
             project: e2e-angular-core
-          - node_version: 16
+          - node_version: 18
             project: e2e-angular-extensions
-          - node_version: 16
+          - node_version: 18
             project: e2e-angular-module-federation
-          - node_version: 16
+          - node_version: 18
             project: e2e-cypress
-          - node_version: 16
+          - node_version: 18
             project: e2e-esbuild
-          - node_version: 16
+          - node_version: 18
             project: e2e-jest
-          - node_version: 16
+          - node_version: 18
             project: e2e-js
-          - node_version: 16
+          - node_version: 18
             project: e2e-eslint
-          - node_version: 16
+          - node_version: 18
             project: e2e-next
-          - node_version: 16
+          - node_version: 18
             project: e2e-node
-          - node_version: 16
+          - node_version: 18
             project: e2e-nx-init
-          - node_version: 16
+          - node_version: 18
             project: e2e-nx-misc
-          - node_version: 16
+          - node_version: 18
             project: e2e-plugin
-          - node_version: 16
+          - node_version: 18
             project: e2e-lerna-smoke-tests
-          - node_version: 16
+          - node_version: 18
             project: e2e-react-core
-          - node_version: 16
+          - node_version: 18
             project: e2e-react-module-federation
-          - node_version: 16
+          - node_version: 18
             project: e2e-react-extensions
-          - node_version: 16
+          - node_version: 18
             project: e2e-web
-          - node_version: 16
+          - node_version: 18
             project: e2e-rollup
-          - node_version: 16
+          - node_version: 18
             project: e2e-storybook
-          - node_version: 16
+          - node_version: 18
             project: e2e-storybook-angular
-          - node_version: 16
+          - node_version: 18
             project: e2e-vite
-          - node_version: 16
-            project: e2e-webpack
-          - node_version: 20
-            project: e2e-angular-core
-          - node_version: 20
-            project: e2e-angular-extensions
-          - node_version: 20
-            project: e2e-angular-module-federation
-          - node_version: 20
-            project: e2e-cypress
-          - node_version: 20
-            project: e2e-esbuild
-          - node_version: 20
-            project: e2e-jest
-          - node_version: 20
-            project: e2e-js
-          - node_version: 20
-            project: e2e-eslint
-          - node_version: 20
-            project: e2e-next
-          - node_version: 20
-            project: e2e-node
-          - node_version: 20
-            project: e2e-nx-init
-          - node_version: 20
-            project: e2e-nx-misc
-          - node_version: 20
-            project: e2e-plugin
-          - node_version: 20
-            project: e2e-lerna-smoke-tests
-          - node_version: 20
-            project: e2e-react-core
-          - node_version: 20
-            project: e2e-react-module-federation
-          - node_version: 20
-            project: e2e-react-extensions
-          - node_version: 20
-            project: e2e-web
-          - node_version: 20
-            project: e2e-rollup
-          - node_version: 20
-            project: e2e-storybook
-          - node_version: 20
-            project: e2e-storybook-angular
-          - node_version: 20
-            project: e2e-vite
-          - node_version: 20
+          - node_version: 18
             project: e2e-webpack
       fail-fast: false
 


### PR DESCRIPTION
Update nightly matrix checks:
- Remove Node v16
- Switch all tests to run on v20 as default

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
