### PR TITLE
fix(repo): add missing packages to nightly

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -114,26 +114,32 @@ jobs:
           - e2e-cypress
           - e2e-detox
           - e2e-esbuild
+          - e2e-eslint
           - e2e-expo
           - e2e-jest
           - e2e-js
           - e2e-lerna-smoke-tests
-          - e2e-eslint
-          - e2e-next
+          - e2e-next-core
+          - e2e-next-extensions
           - e2e-node
+          - e2e-nuxt
           - e2e-nx-init
           - e2e-nx-misc
-          - e2e-nx-plugin
           - e2e-nx-run
+          - e2e-playwright
+          - e2e-plugin
           - e2e-react-core
           - e2e-react-module-federation
           - e2e-react-extensions
           - e2e-react-native
-          - e2e-web
+          - e2e-release
+          - e2e-remix
           - e2e-rollup
           - e2e-storybook
           - e2e-storybook-angular
           - e2e-vite
+          - e2e-vue
+          - e2e-web
           - e2e-webpack
           - e2e-workspace-create
           - e2e-workspace-create-npm

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -84,24 +84,30 @@ jobs:
           - e2e-angular-module-federation
           - e2e-cypress
           - e2e-esbuild
+          - e2e-eslint
           - e2e-jest
           - e2e-js
           - e2e-lerna-smoke-tests
-          - e2e-eslint
-          - e2e-next
+          - e2e-next-core
+          - e2e-next-extensions
           - e2e-node
+          - e2e-nuxt
           - e2e-nx-init
           - e2e-nx-misc
-          - e2e-plugin
           - e2e-nx-run
+          - e2e-playwright
+          - e2e-plugin
           - e2e-react-core
           - e2e-react-module-federation
           - e2e-react-extensions
-          - e2e-web
+          - e2e-release
+          - e2e-remix
           - e2e-rollup
           - e2e-storybook
           - e2e-storybook-angular
           - e2e-vite
+          - e2e-vue
+          - e2e-web
           - e2e-webpack
           - e2e-workspace-create
           - e2e-workspace-create-npm


### PR DESCRIPTION
This PR adds missing packages to the nightly matrix:
- Splitting of `next` to `next-core` and `next-extensions`
- Fixes `plugin` rename
- Nuxt
- Remix
- Playwright
- Release
- Vue

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
