### PR TITLE
fix(linter): only update overrides when applicable

### DIFF
--- a/packages/eslint/src/generators/utils/eslint-file.ts
+++ b/packages/eslint/src/generators/utils/eslint-file.ts
@@ -226,6 +226,13 @@ export function updateOverrideInLintConfig(
     tree.write(fileName, content);
   } else {
     const fileName = joinPathFragments(root, '.eslintrc.json');
+    if (!tree.exists(fileName)) {
+      return;
+    }
+    const existingJson = readJson(tree, fileName);
+    if (!existingJson.overrides || !existingJson.overrides.some(lookup)) {
+      return;
+    }
     updateJson(tree, fileName, (json: Linter.Config) => {
       const index = json.overrides.findIndex(lookup);
       if (index !== -1) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

The latest `@nx/next` migration can fail when a project does not have a `.eslintrc.json` file, and if that file exists but does not have overrides. Even in the case it does have those things, it will always patch the file which results in the loss of comments to all files.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The logic will only patch the file if it exists, has overrides, and one of the overrides matches the expected pattern.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
