### PR TITLE
fix(nextjs): update migration to handle projects without eslintrc

### DIFF
--- a/packages/next/src/migrations/update-17-2-7/remove-eslint-rules-patch.spec.ts
+++ b/packages/next/src/migrations/update-17-2-7/remove-eslint-rules-patch.spec.ts
@@ -1,14 +1,23 @@
-import { Tree, addProjectConfiguration, writeJson } from '@nx/devkit';
+import { addProjectConfiguration, readJson, Tree, writeJson } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from 'nx/src/devkit-testing-exports';
 
 import update from './remove-eslint-rules-patch';
-import { readJson } from '@nx/devkit';
 
 describe('update-nx-next-dependency', () => {
   let tree: Tree;
 
   beforeEach(() => {
     tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should handle projects without eslintrc file', async () => {
+    tree.write('.eslintrc.json', '{}');
+
+    addProjectConfiguration(tree, 'my-pkg', {
+      root: 'packages/my-pkg',
+    });
+
+    await expect(update(tree)).resolves.not.toThrow();
   });
 
   it('should remove @next/next/no-html-link-for-pages in json configs', async () => {

--- a/packages/next/src/migrations/update-17-2-7/remove-eslint-rules-patch.ts
+++ b/packages/next/src/migrations/update-17-2-7/remove-eslint-rules-patch.ts
@@ -1,9 +1,13 @@
-import { Tree, formatFiles, getProjects } from '@nx/devkit';
-import { updateOverrideInLintConfig } from '@nx/eslint/src/generators/utils/eslint-file';
+import { formatFiles, getProjects, Tree } from '@nx/devkit';
+import {
+  isEslintConfigSupported,
+  updateOverrideInLintConfig,
+} from '@nx/eslint/src/generators/utils/eslint-file';
 
 export default async function update(tree: Tree) {
   const projects = getProjects(tree);
   projects.forEach((project) => {
+    if (!isEslintConfigSupported(tree, project.root)) return;
     updateOverrideInLintConfig(
       tree,
       project.root,


### PR DESCRIPTION
The migration added to 17.2.7 is failing on missing eslintrc files. This PR adds a check before attempting migration.

## Current Behavior
Migration fails

## Expected Behavior
Migration works

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20920
