### PR TITLE
fix(nextjs): Playwright should work with workspace libs

### DIFF
--- a/e2e/next-extensions/src/next-playwright.test.ts
+++ b/e2e/next-extensions/src/next-playwright.test.ts
@@ -1,0 +1,63 @@
+import {
+  runCLI,
+  runE2ETests,
+  cleanupProject,
+  newProject,
+  uniq,
+  updateFile,
+} from '@nx/e2e/utils';
+
+describe('Next Playwright e2e tests', () => {
+  let projectName;
+  const appName = uniq('pw-next-app');
+  const usedInAppLibName = uniq('pw-next-lib');
+
+  beforeAll(async () => {
+    projectName = newProject({
+      name: uniq('pw-next'),
+      packages: ['@nx/next'],
+    });
+    runCLI(
+      `generate @nx/next:app ${appName} --e2eTestRunner=playwright --projectNameAndRootFormat=as-provided --no-interactive`
+    );
+  });
+
+  afterAll(() => cleanupProject());
+
+  it('should execute e2e tests using playwright', () => {
+    if (runE2ETests()) {
+      const result = runCLI(`e2e ${appName}-e2e --no-watch --verbose`);
+      expect(result).toContain(
+        `Successfully ran target e2e for project ${appName}-e2e`
+      );
+    }
+  });
+
+  it('should execute e2e tests using playwright with a library used in the app', () => {
+    runCLI(
+      `generate @nx/js:library ${usedInAppLibName} --unitTestRunner=none --importPath=@mylib --projectNameAndRootFormat=as-provided --no-interactive`
+    );
+
+    updateFile(
+      `${appName}-e2e/src/example.spec.ts`,
+      `
+      import { test, expect } from '@playwright/test';
+      import * as mylib from '@mylib'
+  
+      test('has title', async ({ page }) => {
+        await page.goto('/');
+  
+        // Expect h1 to contain a substring.
+        expect(await page.locator('h1').innerText()).toContain('Welcome');
+      });
+      `
+    );
+
+    if (runE2ETests()) {
+      const result = runCLI(`e2e ${appName}-e2e --no-watch --verbose`);
+      expect(result).toContain(
+        `Successfully ran target e2e for project ${appName}-e2e`
+      );
+    }
+  });
+});

--- a/e2e/react-extensions/src/playwright.test.ts
+++ b/e2e/react-extensions/src/playwright.test.ts
@@ -1,0 +1,63 @@
+import {
+  runCLI,
+  runE2ETests,
+  cleanupProject,
+  newProject,
+  uniq,
+  updateFile,
+} from '@nx/e2e/utils';
+
+describe('React Playwright e2e tests', () => {
+  let projectName;
+  const appName = uniq('pw-react-app');
+  const usedInAppLibName = uniq('pw-react-lib');
+
+  beforeAll(async () => {
+    projectName = newProject({
+      name: uniq('pw-react'),
+      packages: ['@nx/react'],
+    });
+    runCLI(
+      `generate @nx/react:app ${appName} --e2eTestRunner=playwright --projectNameAndRootFormat=as-provided --no-interactive`
+    );
+  });
+
+  afterAll(() => cleanupProject());
+
+  it('should execute e2e tests using playwright', () => {
+    if (runE2ETests()) {
+      const result = runCLI(`e2e ${appName}-e2e --no-watch --verbose`);
+      expect(result).toContain(
+        `Successfully ran target e2e for project ${appName}-e2e`
+      );
+    }
+  });
+
+  it('should execute e2e tests using playwright with a library used in the app', () => {
+    runCLI(
+      `generate @nx/js:library ${usedInAppLibName} --unitTestRunner=none --importPath=@mylib --projectNameAndRootFormat=as-provided --no-interactive`
+    );
+
+    updateFile(
+      `${appName}-e2e/src/example.spec.ts`,
+      `
+    import { test, expect } from '@playwright/test';
+    import * as mylib from '@mylib'
+
+    test('has title', async ({ page }) => {
+      await page.goto('/');
+
+      // Expect h1 to contain a substring.
+      expect(await page.locator('h1').innerText()).toContain('Welcome');
+    });
+    `
+    );
+
+    if (runE2ETests()) {
+      const result = runCLI(`e2e ${appName}-e2e --no-watch --verbose`);
+      expect(result).toContain(
+        `Successfully ran target e2e for project ${appName}-e2e`
+      );
+    }
+  });
+});


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Currently when you generate a next / react application and you need to import a workspace library, it would fail. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Importing workspace libraries should work out of the box (OOTB)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
closes: #20901
