### PR TITLE
fix(nextjs): Missing deps for image and css optimization

### DIFF
--- a/packages/next/src/executors/build/lib/update-package-json.ts
+++ b/packages/next/src/executors/build/lib/update-package-json.ts
@@ -15,7 +15,16 @@ export function updatePackageJson(
   packageJson.dependencies ??= {};
 
   // These are always required for a production Next.js app to run.
-  const requiredPackages = ['react', 'react-dom', 'next', 'typescript'];
+  // sharp is for next/image https://nextjs.org/docs/messages/sharp-missing-in-production
+  // critters is required for experimental optimizing CSS
+  const requiredPackages = [
+    'react',
+    'react-dom',
+    'next',
+    'typescript',
+    'sharp',
+    'critters',
+  ];
   for (const pkg of requiredPackages) {
     const externalNode = context.projectGraph.externalNodes[`npm:${pkg}`];
     if (externalNode) {


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When you use `next/image` for optimization or enable `experimental.cssOptimization` from your next config
after installing `sharp` or `critters` respectively they are not added to the production build `package.json`
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

These packages should be added to the production build `package.json`
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20866
