### PR TITLE
fix(angular): add named export for moduleFederationDevServerExecutor

### DIFF
--- a/packages/angular/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/angular/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -28,7 +28,7 @@ import { validateDevRemotes } from '../../builders/utilities/module-federation';
 import { extname, join } from 'path';
 import { existsSync } from 'fs';
 
-export default async function* moduleFederationDevServerExecutor(
+export async function* moduleFederationDevServerExecutor(
   schema: Schema,
   context: ExecutorContext
 ) {
@@ -198,3 +198,5 @@ export default async function* moduleFederationDevServerExecutor(
     )
   );
 }
+
+export default moduleFederationDevServerExecutor;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
I can't import `moduleFederationDevServerExecutor` from `@nx/angular/executors` because `moduleFederationDevServerExecutor` is exported as `default`

## Expected Behavior
I can import `moduleFederationDevServerExecutor` from `@nx/angular/executors`
```ts
import { moduleFederationDevServerExecutor } from '@nx/angular/executors';
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
