### PR TITLE
feat(vite): recognize all vite.config file extensions

### DIFF
--- a/packages/nuxt/src/plugins/plugin.ts
+++ b/packages/nuxt/src/plugins/plugin.ts
@@ -49,7 +49,7 @@ export interface NuxtPluginOptions {
 }
 
 export const createNodes: CreateNodes<NuxtPluginOptions> = [
-  '**/nuxt.config.{js,ts}',
+  '**/nuxt.config.{js,ts,mjs,mts,cjs,cts}',
   async (configFilePath, options, context) => {
     const projectRoot = dirname(configFilePath);
     // Do not create a project if package.json and project.json isn't there.

--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -52,7 +52,7 @@ export const createDependencies: CreateDependencies = () => {
 };
 
 export const createNodes: CreateNodes<VitePluginOptions> = [
-  '**/{vite,vitest}.config.{js,ts}',
+  '**/{vite,vitest}.config.{js,ts,mjs,mts,cjs,cts}',
   async (configFilePath, options, context) => {
     const projectRoot = dirname(configFilePath);
     // Do not create a project if package.json and project.json isn't there.


### PR DESCRIPTION
For `@nx/vite/plugin`, recognize the following extensions for vite.config files: 'js', 'mjs', 'ts', 'cjs', 'mts', 'cts' 