### PR TITLE
feat(core): add the "add" cli command

### DIFF
--- a/docs/generated/cli/add.md
+++ b/docs/generated/cli/add.md
@@ -47,7 +47,7 @@ Show help
 
 Type: `string`
 
-The package name and optional version (e.g. `@nx/react` or `@nx/react@latest`) to install and initialize
+The package name and optional version (e.g. `@nx/react` or `@nx/react@latest`) to install and initialize. If the version is not specified it will install the same version as the `nx` package for Nx core plugins or the latest version for other packages
 
 ### verbose
 

--- a/docs/generated/cli/add.md
+++ b/docs/generated/cli/add.md
@@ -17,10 +17,16 @@ Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`
 
 ### Examples
 
-Install the latest version of the `@nx/react` package and run its `@nx/react:init` generator:
+Install the `@nx/react` package matching the installed version of the `nx` package and run its `@nx/react:init` generator:
 
 ```shell
  nx add @nx/react
+```
+
+Install the latest version of the `non-core-nx-plugin` package and run its `non-core-nx-plugin:init` generator if available:
+
+```shell
+ nx add non-core-nx-plugin
 ```
 
 Install version `17.0.0` of the `@nx/react` package and run its `@nx/react:init` generator:

--- a/docs/generated/cli/add.md
+++ b/docs/generated/cli/add.md
@@ -23,7 +23,7 @@ Install the latest version of the `@nx/react` package and run its `@nx/react:ini
  nx add @nx/react
 ```
 
-Install the version `17.0.0` of the `@nx/react` package and run its `@nx/react:init` generator:
+Install version `17.0.0` of the `@nx/react` package and run its `@nx/react:init` generator:
 
 ```shell
  nx add @nx/react@17.0.0
@@ -41,7 +41,13 @@ Show help
 
 Type: `string`
 
-The name of an installed plugin to query
+The package name and optional version (e.g. `@nx/react` or `@nx/react@latest`) to install and initialize
+
+### verbose
+
+Type: `boolean`
+
+Prints additional information about the commands (e.g., stack traces)
 
 ### version
 

--- a/docs/generated/cli/add.md
+++ b/docs/generated/cli/add.md
@@ -1,0 +1,50 @@
+---
+title: 'add - CLI command'
+description: 'Install a plugin and initialize it.'
+---
+
+# add
+
+Install a plugin and initialize it.
+
+## Usage
+
+```shell
+nx add <packageSpecifier>
+```
+
+Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpm nx`.
+
+### Examples
+
+Install the latest version of the `@nx/react` package and run its `@nx/react:init` generator:
+
+```shell
+ nx add @nx/react
+```
+
+Install the version `17.0.0` of the `@nx/react` package and run its `@nx/react:init` generator:
+
+```shell
+ nx add @nx/react@17.0.0
+```
+
+## Options
+
+### help
+
+Type: `boolean`
+
+Show help
+
+### packageSpecifier
+
+Type: `string`
+
+The name of an installed plugin to query
+
+### version
+
+Type: `boolean`
+
+Show version number

--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -8332,6 +8332,14 @@
                 "isExternal": false,
                 "children": [],
                 "disableCollapsible": false
+              },
+              {
+                "name": "add",
+                "path": "/nx-api/nx/documents/add",
+                "id": "add",
+                "isExternal": false,
+                "children": [],
+                "disableCollapsible": false
               }
             ],
             "isExternal": false,

--- a/docs/generated/manifests/nx-api.json
+++ b/docs/generated/manifests/nx-api.json
@@ -1832,6 +1832,17 @@
         "path": "/nx-api/nx/documents/release",
         "tags": [],
         "originalFilePath": "generated/cli/release"
+      },
+      "/nx-api/nx/documents/add": {
+        "id": "add",
+        "name": "add",
+        "description": "The core Nx plugin contains the core functionality of Nx like the project graph, nx commands and task orchestration.",
+        "file": "generated/packages/nx/documents/add",
+        "itemList": [],
+        "isExternal": false,
+        "path": "/nx-api/nx/documents/add",
+        "tags": [],
+        "originalFilePath": "generated/cli/add"
       }
     },
     "root": "/packages/nx",

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -1812,6 +1812,17 @@
         "path": "nx/documents/release",
         "tags": [],
         "originalFilePath": "generated/cli/release"
+      },
+      {
+        "id": "add",
+        "name": "add",
+        "description": "The core Nx plugin contains the core functionality of Nx like the project graph, nx commands and task orchestration.",
+        "file": "generated/packages/nx/documents/add",
+        "itemList": [],
+        "isExternal": false,
+        "path": "nx/documents/add",
+        "tags": [],
+        "originalFilePath": "generated/cli/add"
       }
     ],
     "executors": [

--- a/docs/generated/packages/nx/documents/add.md
+++ b/docs/generated/packages/nx/documents/add.md
@@ -47,7 +47,7 @@ Show help
 
 Type: `string`
 
-The package name and optional version (e.g. `@nx/react` or `@nx/react@latest`) to install and initialize
+The package name and optional version (e.g. `@nx/react` or `@nx/react@latest`) to install and initialize. If the version is not specified it will install the same version as the `nx` package for Nx core plugins or the latest version for other packages
 
 ### verbose
 

--- a/docs/generated/packages/nx/documents/add.md
+++ b/docs/generated/packages/nx/documents/add.md
@@ -17,10 +17,16 @@ Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`
 
 ### Examples
 
-Install the latest version of the `@nx/react` package and run its `@nx/react:init` generator:
+Install the `@nx/react` package matching the installed version of the `nx` package and run its `@nx/react:init` generator:
 
 ```shell
  nx add @nx/react
+```
+
+Install the latest version of the `non-core-nx-plugin` package and run its `non-core-nx-plugin:init` generator if available:
+
+```shell
+ nx add non-core-nx-plugin
 ```
 
 Install version `17.0.0` of the `@nx/react` package and run its `@nx/react:init` generator:

--- a/docs/generated/packages/nx/documents/add.md
+++ b/docs/generated/packages/nx/documents/add.md
@@ -23,7 +23,7 @@ Install the latest version of the `@nx/react` package and run its `@nx/react:ini
  nx add @nx/react
 ```
 
-Install the version `17.0.0` of the `@nx/react` package and run its `@nx/react:init` generator:
+Install version `17.0.0` of the `@nx/react` package and run its `@nx/react:init` generator:
 
 ```shell
  nx add @nx/react@17.0.0
@@ -41,7 +41,13 @@ Show help
 
 Type: `string`
 
-The name of an installed plugin to query
+The package name and optional version (e.g. `@nx/react` or `@nx/react@latest`) to install and initialize
+
+### verbose
+
+Type: `boolean`
+
+Prints additional information about the commands (e.g., stack traces)
 
 ### version
 

--- a/docs/generated/packages/nx/documents/add.md
+++ b/docs/generated/packages/nx/documents/add.md
@@ -1,0 +1,50 @@
+---
+title: 'add - CLI command'
+description: 'Install a plugin and initialize it.'
+---
+
+# add
+
+Install a plugin and initialize it.
+
+## Usage
+
+```shell
+nx add <packageSpecifier>
+```
+
+Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`, `yarn nx`, or `pnpm nx`.
+
+### Examples
+
+Install the latest version of the `@nx/react` package and run its `@nx/react:init` generator:
+
+```shell
+ nx add @nx/react
+```
+
+Install the version `17.0.0` of the `@nx/react` package and run its `@nx/react:init` generator:
+
+```shell
+ nx add @nx/react@17.0.0
+```
+
+## Options
+
+### help
+
+Type: `boolean`
+
+Show help
+
+### packageSpecifier
+
+Type: `string`
+
+The name of an installed plugin to query
+
+### version
+
+Type: `boolean`
+
+Show version number

--- a/docs/map.json
+++ b/docs/map.json
@@ -2065,6 +2065,11 @@
               "name": "release",
               "id": "release",
               "file": "generated/cli/release"
+            },
+            {
+              "name": "add",
+              "id": "add",
+              "file": "generated/cli/add"
             }
           ]
         },

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -539,6 +539,7 @@
       - [show](/nx-api/nx/documents/show)
       - [view-logs](/nx-api/nx/documents/view-logs)
       - [release](/nx-api/nx/documents/release)
+      - [add](/nx-api/nx/documents/add)
     - [executors](/nx-api/nx/executors)
       - [noop](/nx-api/nx/executors/noop)
       - [run-commands](/nx-api/nx/executors/run-commands)

--- a/packages/nx/bin/init-local.ts
+++ b/packages/nx/bin/init-local.ts
@@ -1,7 +1,5 @@
 import { performance } from 'perf_hooks';
-import { execSync } from 'child_process';
 
-import { getPackageManagerCommand } from '../src/utils/package-manager';
 import { commandsObject } from '../src/command-line/nx-commands';
 import { WorkspaceTypeAndRoot } from '../src/utils/find-workspace-root';
 import { stripIndents } from '../src/utils/strip-indents';
@@ -144,14 +142,7 @@ function isKnownCommand(command: string) {
 
 function shouldDelegateToAngularCLI() {
   const command = process.argv[2];
-  const commands = [
-    'add',
-    'analytics',
-    'config',
-    'doc',
-    'update',
-    'completion',
-  ];
+  const commands = ['analytics', 'config', 'doc', 'update', 'completion'];
   return commands.indexOf(command) > -1;
 }
 
@@ -177,30 +168,6 @@ function handleAngularCLIFallbacks(workspace: WorkspaceTypeAndRoot) {
       `Running "ng update" can still be useful in some dev workflows, so we aren't planning to remove it.`
     );
     console.log(`If you need to use it, run "FORCE_NG_UPDATE=true ng update".`);
-  } else if (process.argv[2] === 'add') {
-    console.log('Ng add is not natively supported by Nx');
-    const pkg = process.argv[2] === 'add' ? process.argv[3] : process.argv[4];
-    if (!pkg) {
-      process.exit(1);
-    }
-
-    const pm = getPackageManagerCommand();
-    const cmd = `${pm.add} ${pkg} && ${pm.exec} nx g ${pkg}:ng-add`;
-    console.log(`Instead, we recommend running \`${cmd}\``);
-
-    import('enquirer').then((x) =>
-      x
-        .prompt<{ c: boolean }>({
-          name: 'c',
-          type: 'confirm',
-          message: 'Run this command?',
-        })
-        .then(({ c }) => {
-          if (c) {
-            execSync(cmd, { stdio: 'inherit' });
-          }
-        })
-    );
   } else if (process.argv[2] === 'completion') {
     if (!process.argv[3]) {
       console.log(`"ng completion" is not natively supported by Nx.

--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -85,7 +85,7 @@
     },
     "17.3.0-update-nx-wrapper": {
       "cli": "nx",
-      "version": "17.3.0-beta.5",
+      "version": "17.3.0-beta.6",
       "description": "Updates the nx wrapper.",
       "implementation": "./src/migrations/update-17-3-0/update-nxw"
     }

--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -82,6 +82,12 @@
       "version": "17.3.0-beta.3",
       "description": "Explicitly opt-out of git operations in nx release",
       "implementation": "./src/migrations/update-17-3-0/nx-release-git-operations-explicit-opt-out"
+    },
+    "17.3.0-update-nx-wrapper": {
+      "cli": "nx",
+      "version": "17.3.0-beta.4",
+      "description": "Updates the nx wrapper.",
+      "implementation": "./src/migrations/update-17-3-0/update-nxw"
     }
   }
 }

--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -85,7 +85,7 @@
     },
     "17.3.0-update-nx-wrapper": {
       "cli": "nx",
-      "version": "17.3.0-beta.4",
+      "version": "17.3.0-beta.5",
       "description": "Updates the nx wrapper.",
       "implementation": "./src/migrations/update-17-3-0/update-nxw"
     }

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -64,7 +64,8 @@
     "tslib": "^2.3.0",
     "yargs": "^17.6.2",
     "yargs-parser": "21.1.1",
-    "node-machine-id": "1.1.12"
+    "node-machine-id": "1.1.12",
+    "ora": "5.3.0"
   },
   "peerDependencies": {
     "@swc-node/register": "^1.6.7",

--- a/packages/nx/src/command-line/add/add.ts
+++ b/packages/nx/src/command-line/add/add.ts
@@ -8,21 +8,29 @@ import {
   getPackageManagerCommand,
   type PackageManagerCommands,
 } from '../../utils/package-manager';
+import { handleErrors } from '../../utils/params';
 import { getPluginCapabilities } from '../../utils/plugins';
 import { workspaceRoot } from '../../utils/workspace-root';
 import type { AddOptions } from './command-object';
 
-export async function addHandler(args: AddOptions): Promise<void> {
-  output.addNewline();
+export function addHandler(args: AddOptions): Promise<void> {
+  if (args.verbose) {
+    process.env.NX_VERBOSE_LOGGING = 'true';
+  }
+  const isVerbose = process.env.NX_VERBOSE_LOGGING === 'true';
 
-  const pmc = getPackageManagerCommand();
-  const [pkgName, version] = parsePackageSpecifier(args.packageSpecifier);
+  return handleErrors(isVerbose, async () => {
+    output.addNewline();
 
-  await installPackage(pkgName, version, pmc);
-  await initializePlugin(pkgName, pmc);
+    const pmc = getPackageManagerCommand();
+    const [pkgName, version] = parsePackageSpecifier(args.packageSpecifier);
 
-  output.success({
-    title: `Package ${pkgName} added successfully.`,
+    await installPackage(pkgName, version, pmc);
+    await initializePlugin(pkgName, pmc);
+
+    output.success({
+      title: `Package ${pkgName} added successfully.`,
+    });
   });
 }
 

--- a/packages/nx/src/command-line/add/add.ts
+++ b/packages/nx/src/command-line/add/add.ts
@@ -1,0 +1,131 @@
+import { exec } from 'child_process';
+import * as ora from 'ora';
+import { isAngularPluginInstalled } from '../../adapter/angular-json';
+import type { GeneratorsJsonEntry } from '../../config/misc-interfaces';
+import { logger } from '../../utils/logger';
+import { output } from '../../utils/output';
+import {
+  getPackageManagerCommand,
+  type PackageManagerCommands,
+} from '../../utils/package-manager';
+import { getPluginCapabilities } from '../../utils/plugins';
+import { workspaceRoot } from '../../utils/workspace-root';
+import type { AddOptions } from './command-object';
+
+export async function addHandler(args: AddOptions): Promise<void> {
+  output.addNewline();
+
+  const pmc = getPackageManagerCommand();
+  const [pkgName, version] = parsePackageSpecifier(args.packageSpecifier);
+
+  await installPackage(pkgName, version, pmc);
+  await initializePlugin(pkgName, pmc);
+
+  output.success({
+    title: `Package ${pkgName} added successfully.`,
+  });
+}
+
+async function installPackage(
+  pkgName: string,
+  version: string,
+  packageManagerCommands: PackageManagerCommands
+): Promise<void> {
+  const spinner = ora(`Installing ${pkgName}@${version}...`);
+  spinner.start();
+
+  await new Promise<void>((resolve) =>
+    exec(
+      `${packageManagerCommands.addDev} ${pkgName}@${version}`,
+      (error, stdout) => {
+        if (error) {
+          spinner.fail();
+          output.addNewline();
+          logger.log(stdout);
+          process.exit(1);
+        }
+
+        return resolve();
+      }
+    )
+  );
+
+  spinner.succeed();
+}
+
+async function initializePlugin(
+  pkgName: string,
+  packageManagerCommands: PackageManagerCommands
+): Promise<void> {
+  const capabilities = await getPluginCapabilities(workspaceRoot, pkgName, {});
+  const generators = capabilities?.generators;
+  if (!generators) {
+    output.log({
+      title: `No generators found in ${pkgName}. Skipping initialization.`,
+    });
+    return;
+  }
+
+  const initGenerator = findInitGenerator(generators);
+  if (!initGenerator) {
+    output.log({
+      title: `No "init" generator found in ${pkgName}. Skipping initialization.`,
+    });
+    return;
+  }
+
+  const spinner = ora(`Initializing ${pkgName}...`);
+  spinner.start();
+
+  await new Promise<void>((resolve) =>
+    exec(
+      `${packageManagerCommands.exec} nx g ${pkgName}:${initGenerator}`,
+      (error, stdout) => {
+        if (error) {
+          spinner.fail();
+          output.addNewline();
+          logger.log(stdout);
+          process.exit(1);
+        }
+
+        return resolve();
+      }
+    )
+  );
+
+  spinner.succeed();
+}
+
+function findInitGenerator(
+  generators: Record<string, GeneratorsJsonEntry>
+): string | undefined {
+  if (generators['init']) {
+    return 'init';
+  }
+
+  const angularPluginInstalled = isAngularPluginInstalled();
+  if (angularPluginInstalled && generators['ng-add']) {
+    return 'ng-add';
+  }
+
+  return Object.keys(generators).find(
+    (name) =>
+      generators[name].aliases?.includes('init') ||
+      (angularPluginInstalled && generators[name].aliases?.includes('ng-add'))
+  );
+}
+
+function parsePackageSpecifier(
+  packageSpecifier: string
+): [pkgName: string, version: string] {
+  const i = packageSpecifier.lastIndexOf('@');
+
+  if (i <= 0) {
+    return [packageSpecifier, 'latest'];
+  }
+
+  const pkgName = packageSpecifier.substring(0, i);
+  const version = packageSpecifier.substring(i + 1);
+
+  return [pkgName, version];
+}

--- a/packages/nx/src/command-line/add/command-object.ts
+++ b/packages/nx/src/command-line/add/command-object.ts
@@ -1,0 +1,28 @@
+import { CommandModule } from 'yargs';
+
+export interface AddOptions {
+  packageSpecifier: string;
+}
+
+export const yargsAddCommand: CommandModule<
+  Record<string, unknown>,
+  AddOptions
+> = {
+  command: 'add <packageSpecifier>',
+  describe: 'Install a plugin and initialize it.',
+  builder: (yargs) =>
+    yargs
+      .positional('packageSpecifier', {
+        type: 'string',
+        description: 'The name of an installed plugin to query',
+      })
+      .example(
+        '$0 add @nx/react',
+        'Install the latest version of the `@nx/react` package and run its `@nx/react:init` generator'
+      )
+      .example(
+        '$0 add @nx/react@17.0.0',
+        'Install the version `17.0.0` of the `@nx/react` package and run its `@nx/react:init` generator'
+      ),
+  handler: (args) => import('./add').then((m) => m.addHandler(args)),
+};

--- a/packages/nx/src/command-line/add/command-object.ts
+++ b/packages/nx/src/command-line/add/command-object.ts
@@ -2,6 +2,7 @@ import { CommandModule } from 'yargs';
 
 export interface AddOptions {
   packageSpecifier: string;
+  verbose?: boolean;
 }
 
 export const yargsAddCommand: CommandModule<
@@ -14,7 +15,13 @@ export const yargsAddCommand: CommandModule<
     yargs
       .positional('packageSpecifier', {
         type: 'string',
-        description: 'The name of an installed plugin to query',
+        description:
+          'The package name and optional version (e.g. `@nx/react` or `@nx/react@latest`) to install and initialize',
+      })
+      .option('verbose', {
+        type: 'boolean',
+        description:
+          'Prints additional information about the commands (e.g., stack traces)',
       })
       .example(
         '$0 add @nx/react',
@@ -22,7 +29,7 @@ export const yargsAddCommand: CommandModule<
       )
       .example(
         '$0 add @nx/react@17.0.0',
-        'Install the version `17.0.0` of the `@nx/react` package and run its `@nx/react:init` generator'
-      ),
+        'Install version `17.0.0` of the `@nx/react` package and run its `@nx/react:init` generator'
+      ) as any,
   handler: (args) => import('./add').then((m) => m.addHandler(args)),
 };

--- a/packages/nx/src/command-line/add/command-object.ts
+++ b/packages/nx/src/command-line/add/command-object.ts
@@ -16,7 +16,7 @@ export const yargsAddCommand: CommandModule<
       .positional('packageSpecifier', {
         type: 'string',
         description:
-          'The package name and optional version (e.g. `@nx/react` or `@nx/react@latest`) to install and initialize',
+          'The package name and optional version (e.g. `@nx/react` or `@nx/react@latest`) to install and initialize. If the version is not specified it will install the same version as the `nx` package for Nx core plugins or the latest version for other packages',
       })
       .option('verbose', {
         type: 'boolean',
@@ -26,6 +26,10 @@ export const yargsAddCommand: CommandModule<
       .example(
         '$0 add @nx/react',
         'Install the latest version of the `@nx/react` package and run its `@nx/react:init` generator'
+      )
+      .example(
+        '$0 add non-core-nx-plugin',
+        'Install the latest version of the `non-core-nx-plugin` package and run its `non-core-nx-plugin:init` generator if available'
       )
       .example(
         '$0 add @nx/react@17.0.0',

--- a/packages/nx/src/command-line/examples.ts
+++ b/packages/nx/src/command-line/examples.ts
@@ -389,4 +389,16 @@ export const examples: Record<string, Example[]> = {
         'Watch all projects (including newly created projects) in the workspace',
     },
   ],
+  add: [
+    {
+      command: 'add @nx/react',
+      description:
+        'Install the latest version of the `@nx/react` package and run its `@nx/react:init` generator',
+    },
+    {
+      command: 'add @nx/react@17.0.0',
+      description:
+        'Install the version `17.0.0` of the `@nx/react` package and run its `@nx/react:init` generator',
+    },
+  ],
 };

--- a/packages/nx/src/command-line/examples.ts
+++ b/packages/nx/src/command-line/examples.ts
@@ -398,7 +398,7 @@ export const examples: Record<string, Example[]> = {
     {
       command: 'add @nx/react@17.0.0',
       description:
-        'Install the version `17.0.0` of the `@nx/react` package and run its `@nx/react:init` generator',
+        'Install version `17.0.0` of the `@nx/react` package and run its `@nx/react:init` generator',
     },
   ],
 };

--- a/packages/nx/src/command-line/examples.ts
+++ b/packages/nx/src/command-line/examples.ts
@@ -393,7 +393,12 @@ export const examples: Record<string, Example[]> = {
     {
       command: 'add @nx/react',
       description:
-        'Install the latest version of the `@nx/react` package and run its `@nx/react:init` generator',
+        'Install the `@nx/react` package matching the installed version of the `nx` package and run its `@nx/react:init` generator',
+    },
+    {
+      command: 'add non-core-nx-plugin',
+      description:
+        'Install the latest version of the `non-core-nx-plugin` package and run its `non-core-nx-plugin:init` generator if available',
     },
     {
       command: 'add @nx/react@17.0.0',

--- a/packages/nx/src/command-line/init/implementation/dot-nx/nxw.ts
+++ b/packages/nx/src/command-line/init/implementation/dot-nx/nxw.ts
@@ -78,7 +78,7 @@ function performInstallation(
   fs.writeFileSync(
     installationPath,
     JSON.stringify({
-      ...currentInstallation,
+      name: 'nx-installation',
       devDependencies: {
         nx: nxJson.installation.version,
         ...nxJson.installation.plugins,

--- a/packages/nx/src/command-line/init/implementation/dot-nx/nxw.ts
+++ b/packages/nx/src/command-line/init/implementation/dot-nx/nxw.ts
@@ -1,6 +1,6 @@
 // This file should be committed to your repository! It wraps Nx and ensures
 // that your local installation matches nx.json.
-// See: https://nx.dev/more-concepts/nx-and-the-wrapper for more info.
+// See: https://nx.dev/recipes/installation/install-non-javascript for more info.
 //
 //# The contents of this file are executed before packages are installed.
 //# As such, we should not import anything from nx, other @nrwl packages,

--- a/packages/nx/src/command-line/init/implementation/dot-nx/nxw.ts
+++ b/packages/nx/src/command-line/init/implementation/dot-nx/nxw.ts
@@ -17,10 +17,17 @@ import type { PackageJson } from '../../../../utils/package-json';
 const installationPath = path.join(__dirname, 'installation', 'package.json');
 
 function matchesCurrentNxInstall(
+  currentInstallation: PackageJson,
   nxJsonInstallation: NxJsonConfiguration['installation']
 ) {
+  if (
+    !currentInstallation.devDependencies ||
+    !Object.keys(currentInstallation.devDependencies).length
+  ) {
+    return false;
+  }
+
   try {
-    const currentInstallation: PackageJson = require(installationPath);
     if (
       currentInstallation.devDependencies['nx'] !==
         nxJsonInstallation.version ||
@@ -52,37 +59,70 @@ function ensureDir(p: string) {
   }
 }
 
+function getCurrentInstallation(): PackageJson {
+  try {
+    return require(installationPath);
+  } catch {
+    return {
+      name: 'nx-installation',
+      version: '0.0.0',
+      devDependencies: {},
+    };
+  }
+}
+
+function performInstallation(
+  currentInstallation: PackageJson,
+  nxJson: NxJsonConfiguration
+) {
+  fs.writeFileSync(
+    installationPath,
+    JSON.stringify({
+      ...currentInstallation,
+      devDependencies: {
+        nx: nxJson.installation.version,
+        ...nxJson.installation.plugins,
+      },
+    })
+  );
+
+  try {
+    cp.execSync('npm i', {
+      cwd: path.dirname(installationPath),
+      stdio: 'inherit',
+    });
+  } catch (e) {
+    // revert possible changes to the current installation
+    fs.writeFileSync(installationPath, JSON.stringify(currentInstallation));
+    // rethrow
+    throw e;
+  }
+}
+
 function ensureUpToDateInstallation() {
   const nxJsonPath = path.join(__dirname, '..', 'nx.json');
-
   let nxJson: NxJsonConfiguration;
 
   try {
     nxJson = require(nxJsonPath);
+    if (!nxJson.installation) {
+      console.error(
+        '[NX]: The "installation" entry in the "nx.json" file is required when running the nx wrapper. See https://nx.dev/recipes/installation/install-non-javascript'
+      );
+      process.exit(1);
+    }
   } catch {
     console.error(
-      '[NX]: nx.json is required when running the nx wrapper. See https://nx.dev/more-concepts/nx-and-the-wrapper'
+      '[NX]: The "nx.json" file is required when running the nx wrapper. See https://nx.dev/recipes/installation/install-non-javascript'
     );
     process.exit(1);
   }
 
   try {
     ensureDir(path.join(__dirname, 'installation'));
-    if (!matchesCurrentNxInstall(nxJson.installation)) {
-      fs.writeFileSync(
-        installationPath,
-        JSON.stringify({
-          name: 'nx-installation',
-          devDependencies: {
-            nx: nxJson.installation.version,
-            ...nxJson.installation.plugins,
-          },
-        })
-      );
-      cp.execSync('npm i', {
-        cwd: path.dirname(installationPath),
-        stdio: 'inherit',
-      });
+    const currentInstallation = getCurrentInstallation();
+    if (!matchesCurrentNxInstall(currentInstallation, nxJson.installation)) {
+      performInstallation(currentInstallation, nxJson);
     }
   } catch (e: unknown) {
     const messageLines = [

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -37,6 +37,7 @@ import { yargsShowCommand } from './show/command-object';
 import { yargsWatchCommand } from './watch/command-object';
 import { yargsResetCommand } from './reset/command-object';
 import { yargsReleaseCommand } from './release/command-object';
+import { yargsAddCommand } from './add/command-object';
 
 // Ensure that the output takes up the available width of the terminal.
 yargs.wrap(yargs.terminalWidth());
@@ -56,6 +57,7 @@ export const commandsObject = yargs
   .parserConfiguration(parserConfiguration)
   .usage(chalk.bold('Smart Monorepos · Fast CI'))
   .demandCommand(1, '')
+  .command(yargsAddCommand)
   .command(yargsAffectedBuildCommand)
   .command(yargsAffectedCommand)
   .command(yargsAffectedE2ECommand)

--- a/packages/nx/src/migrations/update-17-3-0/update-nxw.ts
+++ b/packages/nx/src/migrations/update-17-3-0/update-nxw.ts
@@ -1,4 +1,4 @@
-import { Tree } from '../../generators/tree';
+import type { Tree } from '../../generators/tree';
 import { updateNxw } from '../../utils/update-nxw';
 
 export default async function (tree: Tree) {

--- a/packages/nx/src/utils/update-nxw.ts
+++ b/packages/nx/src/utils/update-nxw.ts
@@ -1,0 +1,13 @@
+import {
+  getNxWrapperContents,
+  nxWrapperPath,
+} from '../command-line/init/implementation/dot-nx/add-nx-scripts';
+import type { Tree } from '../generators/tree';
+import { normalizePath } from '../utils/path';
+
+export function updateNxw(tree: Tree) {
+  const wrapperPath = normalizePath(nxWrapperPath());
+  if (tree.exists(wrapperPath)) {
+    tree.write(wrapperPath, getNxWrapperContents());
+  }
+}


### PR DESCRIPTION
Adds a new command for installing and initializing a package: `add`.

Initialization is done by invoking the `<package>:init` generator. If the `@nx/angular` plugin is installed, it will also look for an `ng-add` generator if the `init` generator is not found.

Examples usage:

Install the `@nx/react` package matching the currently installed `nx` version (for non-core nx plugins, it will install their latest version) and run its `@nx/react:init` generator:

```shell
 nx add @nx/react
```

Install the version `17.0.0` of the `@nx/react` package and run its `@nx/react:init` generator:

```shell
 nx add @nx/react@17.0.0
```

If the package being added doesn't contain an `init` generator (or `ng-add` in Angular workspaces), it will safely handle it by only installing the package and logging a message stating there's nothing to initialize.

Docs: https://nx-dev-git-fork-leosvelperez-core-add-command-nrwl.vercel.app/nx-api/nx/documents/add

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
