### PR TITLE
fix(core): handle "." project roots properly for hashing

### DIFF
--- a/packages/nx/src/native/hasher.rs
+++ b/packages/nx/src/native/hasher.rs
@@ -1,4 +1,3 @@
-use std::io::BufRead;
 use std::path::Path;
 
 use tracing::trace;

--- a/packages/nx/src/native/project_graph/utils.rs
+++ b/packages/nx/src/native/project_graph/utils.rs
@@ -8,25 +8,22 @@ pub type ProjectRootMappings = HashMap<String, String>;
 pub fn create_project_root_mappings(nodes: &HashMap<String, Project>) -> ProjectRootMappings {
     let mut project_root_mappings = HashMap::new();
     for (project_name, node) in nodes {
-        project_root_mappings.insert(
-            node.root.clone(),
-            normalize_project_root(project_name.clone()),
-        );
+        project_root_mappings.insert(node.root.clone(), normalize_project_root(project_name));
     }
     project_root_mappings
 }
 
-pub fn normalize_project_root(root: String) -> String {
+pub fn normalize_project_root(root: &str) -> String {
     let root = if root.is_empty() {
         ".".to_string()
     } else {
-        root
+        root.to_owned()
     };
     if root.ends_with('/') {
         root.strip_suffix('/')
             .expect("'/' already checked to exist")
             .to_string()
     } else {
-        root
+        root.to_owned()
     }
 }

--- a/packages/nx/src/native/project_graph/utils/find_project_for_path.rs
+++ b/packages/nx/src/native/project_graph/utils/find_project_for_path.rs
@@ -1,4 +1,4 @@
-use crate::native::project_graph::utils::ProjectRootMappings;
+use crate::native::project_graph::utils::{normalize_project_root, ProjectRootMappings};
 use std::path::Path;
 
 pub fn find_project_for_path<P: AsRef<Path>>(
@@ -19,7 +19,9 @@ pub fn find_project_for_path<P: AsRef<Path>>(
     }
 
     if let Some(current_path_str) = current_path.to_str() {
-        match project_root_map.get(current_path_str) {
+        let normalized_project_path = normalize_project_root(current_path_str);
+
+        match project_root_map.get(&normalized_project_path) {
             Some(s) => Some(s),
             None => None,
         }
@@ -67,6 +69,15 @@ mod test {
                     named_inputs: None,
                 },
             ),
+            (
+                "standalone".into(),
+                Project {
+                    tags: None,
+                    targets: Default::default(),
+                    root: ".".into(),
+                    named_inputs: None,
+                },
+            ),
         ]));
 
         assert_eq!(
@@ -81,5 +92,9 @@ mod test {
             find_project_for_path("apps/demo-app/src/subdir/blah", &project_root_mapping),
             Some("demo-app")
         );
+        assert_eq!(
+            find_project_for_path("src/standalone", &project_root_mapping),
+            Some("standalone")
+        )
     }
 }

--- a/packages/nx/src/native/tasks/task_hasher.rs
+++ b/packages/nx/src/native/tasks/task_hasher.rs
@@ -201,6 +201,7 @@ impl TaskHasher {
                     &project.root,
                     file_sets,
                     &self.project_file_map,
+                    &self.workspace_root,
                 )?;
                 trace!(parent: &span, "hash_project_files: {:?}", now.elapsed());
                 hashed_project_files

--- a/packages/nx/src/native/tasks/task_hasher.rs
+++ b/packages/nx/src/native/tasks/task_hasher.rs
@@ -201,7 +201,6 @@ impl TaskHasher {
                     &project.root,
                     file_sets,
                     &self.project_file_map,
-                    &self.workspace_root,
                 )?;
                 trace!(parent: &span, "hash_project_files: {:?}", now.elapsed());
                 hashed_project_files


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
When a project root is `"."` we cannot find the correct files to hash because we replace `{projectRoot}` with ".", so `{projectRoot}/**/*` becomes `./**/*`. This fails glob matching because the matcher needs to be relative to the project files in the project file map. 

There is also a case where we fail to update the project file map when the daemon is running because we cannot find a project a project with "." as the key.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Standalone projects roots that are `"."` are properly handled when looking to update/read from the project file map. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20927
Fixes #20969