### PR TITLE
cleanup(web): kill process and open port in e2e test case

### DIFF
--- a/e2e/web/src/web-webpack.test.ts
+++ b/e2e/web/src/web-webpack.test.ts
@@ -1,5 +1,6 @@
 import {
   cleanupProject,
+  killProcessAndPorts,
   newProject,
   runCLI,
   runCommandUntil,
@@ -19,8 +20,13 @@ describe('Web Components Applications with bundler set as webpack', () => {
     );
     setMaxWorkers(join('apps', appName, 'project.json'));
 
-    await runCommandUntil(`serve ${appName} --port=5000 --ssl`, (output) => {
-      return output.includes('listening at https://localhost:5000');
-    });
+    const childProcess = await runCommandUntil(
+      `serve ${appName} --port=5000 --ssl`,
+      (output) => {
+        return output.includes('listening at https://localhost:5000');
+      }
+    );
+
+    await killProcessAndPorts(childProcess.pid, 5000);
   }, 300_000);
 });


### PR DESCRIPTION
Kills an open port in an e2e test case. This causes another test suite in `e2e-node` that uses the same port to fail if run in the same agent.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
