### PR TITLE
fix(webpack): correctly handle data URIs with escaped quotes in style…

### DIFF
--- a/packages/webpack/src/utils/webpack/plugins/postcss-cli-resources.ts
+++ b/packages/webpack/src/utils/webpack/plugins/postcss-cli-resources.ts
@@ -152,7 +152,7 @@ export function PostcssCliResources(options: PostcssCliResourcesOptions) {
       return Promise.all(
         urlDeclarations.map(async (decl) => {
           const value = decl.value;
-          const urlRegex = /url\(\s*(?:"([^"]+)"|'([^']+)'|(.+?))\s*\)/g;
+          const urlRegex = /url(?:\(\s*['"]?)(.*?)(?:['"]?\s*\))/g;
           const segments: string[] = [];
           let match;
           let lastIndex = 0;
@@ -162,7 +162,7 @@ export function PostcssCliResources(options: PostcssCliResourcesOptions) {
           const context =
             (inputFile && path.dirname(inputFile)) || loader.context;
           while ((match = urlRegex.exec(value))) {
-            const originalUrl = match[1] || match[2] || match[3];
+            const originalUrl = match[1];
             let processedUrl;
             try {
               processedUrl = await process(originalUrl, context, resourceCache);


### PR DESCRIPTION
This is just a copy of the fix already done in the angular-cli repository: https://github.com/angular/angular-cli/pull/23691

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Double quoted url() in css arguments are parsed incorrectly
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Double quoted url() in css arguments are parsed correctly
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
No issue in repo, fixes same copied code as described in angular-cli repository https://github.com/angular/angular-cli/issues/23680
