### PR TITLE
fix(web): fix webpack + playwright config issues

### DIFF
--- a/packages/playwright/src/generators/configuration/configuration.ts
+++ b/packages/playwright/src/generators/configuration/configuration.ts
@@ -52,20 +52,20 @@ export async function configurationGenerator(
       `${projectConfig.root}/tsconfig.json`,
       JSON.stringify(
         {
-          extends: '${getRelativePathToRootTsConfig(tree, projectConfig.root)}',
+          extends: getRelativePathToRootTsConfig(tree, projectConfig.root),
           compilerOptions: {
             allowJs: true,
-            outDir: '${offsetFromProjectRoot}dist/out-tsc',
+            outDir: `${offsetFromProjectRoot}dist/out-tsc`,
             module: 'commonjs',
             sourceMap: false,
           },
           include: [
             '**/*.ts',
             '**/*.js',
-            '${offsetFromProjectRoot}playwright.config.ts',
-            '${offsetFromProjectRoot}**/*.spec.ts',
-            '${offsetFromProjectRoot}**/*.spec.js',
-            '${offsetFromProjectRoot}**/*.d.ts',
+            `${offsetFromProjectRoot}playwright.config.ts`,
+            `${offsetFromProjectRoot}**/*.spec.ts`,
+            `${offsetFromProjectRoot}**/*.spec.js`,
+            `${offsetFromProjectRoot}**/*.d.ts`,
           ],
         },
         null,

--- a/packages/webpack/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/webpack/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`@nx/webpack/plugin should create nodes 1`] = `
       "targets": {
         "build-something": {
           "cache": true,
-          "command": "webpack -c webpack.config.js --node-env=production",
+          "command": "webpack-cli -c webpack.config.js --node-env=production",
           "dependsOn": [
             "^build-something",
           ],
@@ -29,13 +29,13 @@ exports[`@nx/webpack/plugin should create nodes 1`] = `
           ],
         },
         "my-serve": {
-          "command": "webpack serve -c webpack.config.js --node-env=development",
+          "command": "webpack-cli serve -c webpack.config.js --node-env=development",
           "options": {
             "cwd": "my-app",
           },
         },
         "preview-site": {
-          "command": "webpack serve -c webpack.config.js --node-env=production",
+          "command": "webpack-cli serve -c webpack.config.js --node-env=production",
           "options": {
             "cwd": "my-app",
           },

--- a/packages/webpack/src/plugins/nx-webpack-plugin/nx-webpack-plugin.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/nx-webpack-plugin.ts
@@ -22,8 +22,8 @@ export class NxWebpackPlugin {
   private readonly options: NormalizedNxWebpackPluginOptions;
 
   constructor(options: NxWebpackPluginOptions = {}) {
-    // If we're not in an Nx task, we're building inferred targets, so skip normalizing build options.
-    if (process.env['NX_TASK_TARGET_PROJECT']) {
+    // If we're building inferred targets, skip normalizing build options.
+    if (!global.NX_GRAPH_CREATION) {
       this.options = normalizeOptions(options);
     }
   }

--- a/packages/webpack/src/plugins/plugin.ts
+++ b/packages/webpack/src/plugins/plugin.ts
@@ -107,11 +107,15 @@ async function createWebpackTargets(
   >
 > {
   const namedInputs = getNamedInputs(projectRoot, context);
+
+  global.NX_GRAPH_CREATION = true;
   const webpackConfig = resolveUserDefinedWebpackConfig(
     join(context.workspaceRoot, configFilePath),
     getRootTsConfigPath(),
     true
   );
+  delete global.NX_GRAPH_CREATION;
+
   const webpackOptions = await readWebpackOptions(webpackConfig);
 
   const outputPath =
@@ -123,7 +127,7 @@ async function createWebpackTargets(
   const configBasename = basename(configFilePath);
 
   targets[options.buildTargetName] = {
-    command: `webpack -c ${configBasename} --node-env=production`,
+    command: `webpack-cli -c ${configBasename} --node-env=production`,
     options: { cwd: projectRoot },
     cache: true,
     dependsOn: [`^${options.buildTargetName}`],
@@ -147,14 +151,14 @@ async function createWebpackTargets(
   };
 
   targets[options.serveTargetName] = {
-    command: `webpack serve -c ${configBasename} --node-env=development`,
+    command: `webpack-cli serve -c ${configBasename} --node-env=development`,
     options: {
       cwd: projectRoot,
     },
   };
 
   targets[options.previewTargetName] = {
-    command: `webpack serve -c ${configBasename} --node-env=production`,
+    command: `webpack-cli serve -c ${configBasename} --node-env=production`,
     options: {
       cwd: projectRoot,
     },


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

There are several issues with a new PCv3 workspace with React + Webpack + Playwright and running `CI=true nx e2e e2e`

1. The `NxWebpackPlugin` wasn't able to normalize options correctly and threw an error during project graph creation.
2. The command for webpack targets seem to be wrong? it says `webpack` is not a command.
3. The `tsconfig.json` in Playwright projects is stringify'd incorrectly.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

1. The graph plugin for `@nx/webpack` will set an explicit global variable to allow the `NxWebpackPlugin` to properly detect if it is being executed within a graph creation context.
2. The command is `webpack-cli`
3. `tsconfig.json` is serialized correctly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
