### PR TITLE
chore(repo): simplify nx release config

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -26,6 +26,11 @@
     ]
   },
   "release": {
+    "projects": [
+      "packages/*",
+      "packages/nx/native-packages/*",
+      "packages-legacy/*"
+    ],
     "releaseTagPattern": "{version}",
     "changelog": {
       "workspaceChangelog": {
@@ -33,19 +38,10 @@
         "file": false
       }
     },
-    "groups": {
-      "npm": {
-        "projects": [
-          "packages/*",
-          "packages/nx/native-packages/*",
-          "packages-legacy/*"
-        ],
-        "version": {
-          "generatorOptions": {
-            "packageRoot": "build/packages/{projectName}",
-            "currentVersionResolver": "registry"
-          }
-        }
+    "version": {
+      "generatorOptions": {
+        "packageRoot": "build/packages/{projectName}",
+        "currentVersionResolver": "registry"
       }
     }
   },


### PR DESCRIPTION
We've supported not needing a group for the simple case for a while. People use the nx repo as a reference so we should make it as concise/easy to understand as possible