### PR TITLE
fix(misc): ignore .nx/cache when running nx init in an angular cli project

### DIFF
--- a/packages/nx/src/command-line/init/implementation/angular/index.ts
+++ b/packages/nx/src/command-line/init/implementation/angular/index.ts
@@ -11,6 +11,7 @@ import {
   initCloud,
   printFinalMessage,
   runInstall,
+  updateGitIgnore,
 } from '../utils';
 import { setupIntegratedWorkspace } from './integrated-workspace';
 import { getLegacyMigrationFunctionIfApplicable } from './legacy-angular-versions';
@@ -147,6 +148,8 @@ async function setupWorkspace(
   cacheableOperations: string[],
   isIntegratedMigration: boolean
 ): Promise<void> {
+  updateGitIgnore(repoRoot);
+
   if (isIntegratedMigration) {
     setupIntegratedWorkspace();
   } else {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Running `nx init` on an Angular CLI project doesn't add the `.nx/cache` entry to `.gitignore`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Running `nx init` on an Angular CLI project should add the `.nx/cache` entry to `.gitignore`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
