### PR TITLE
fix(nextjs): Add support for mjs next config file

### DIFF
--- a/e2e/next-core/src/next-pcv3.test.ts
+++ b/e2e/next-core/src/next-pcv3.test.ts
@@ -8,6 +8,8 @@ import {
   directoryExists,
   readJson,
   updateFile,
+  removeFile,
+  createFile,
 } from 'e2e/utils';
 
 describe('@nx/next/plugin', () => {
@@ -49,6 +51,24 @@ describe('@nx/next/plugin', () => {
     // check build output for PCV3 artifacts (e.g. .next directory) are inside the project directory
     directoryExists(`${appName}/.next`);
 
+    expect(result).toContain(
+      `Successfully ran target build for project ${appName}`
+    );
+  }, 200_000);
+
+  it('should build the app with .mjs config file', async () => {
+    createFile(
+      `${appName}/next.config.mjs`,
+      `
+      export default {
+        reactStrictMode: true,
+      };
+      `
+    );
+
+    removeFile(`${appName}/next.config.js`);
+
+    const result = runCLI(`build ${appName}`);
     expect(result).toContain(
       `Successfully ran target build for project ${appName}`
     );

--- a/packages/next/src/plugins/plugin.ts
+++ b/packages/next/src/plugins/plugin.ts
@@ -8,7 +8,7 @@ import {
   TargetConfiguration,
   writeJsonFile,
 } from '@nx/devkit';
-import { dirname, join } from 'path';
+import { dirname, extname, join } from 'path';
 
 import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
 import { existsSync, readdirSync } from 'fs';
@@ -51,9 +51,8 @@ export const createDependencies: CreateDependencies = () => {
   return [];
 };
 
-// TODO(nicholas): Add support for .mjs files
 export const createNodes: CreateNodes<NextPluginOptions> = [
-  '**/next.config.{js, cjs}',
+  '**/next.config.{js,cjs,mjs}',
   async (configFilePath, options, context) => {
     const projectRoot = dirname(configFilePath);
 
@@ -95,7 +94,7 @@ async function buildNextTargets(
   options: NextPluginOptions,
   context: CreateNodesContext
 ) {
-  const nextConfig = getNextConfig(nextConfigPath, context);
+  const nextConfig = await getNextConfig(nextConfigPath, context);
   const namedInputs = getNamedInputs(projectRoot, context);
 
   const targets: Record<string, TargetConfiguration> = {};
@@ -178,13 +177,18 @@ async function getOutputs(projectRoot, nextConfig) {
   }
 }
 
-function getNextConfig(
+async function getNextConfig(
   configFilePath: string,
   context: CreateNodesContext
 ): Promise<any> {
   const resolvedPath = join(context.workspaceRoot, configFilePath);
 
-  const module = load(resolvedPath);
+  let module;
+  if (extname(configFilePath) === '.mjs') {
+    module = await loadEsmModule(resolvedPath);
+  } else {
+    module = load(resolvedPath);
+  }
   return module.default ?? module;
 }
 
@@ -209,17 +213,35 @@ function getInputs(
   ];
 }
 
+const packageInstallationDirectories = ['node_modules', '.yarn'];
 /**
  * Load the module after ensuring that the require cache is cleared.
  */
 function load(path: string): any {
   // Clear cache if the path is in the cache
   if (require.cache[path]) {
-    for (const k of Object.keys(require.cache)) {
-      delete require.cache[k];
+    for (const key of Object.keys(require.cache)) {
+      if (!packageInstallationDirectories.some((dir) => key.includes(dir))) {
+        delete require.cache[key];
+      }
     }
   }
 
   // Then require
   return require(path);
+}
+
+/**
+ * Lazily compiled dynamic import loader function.
+ */
+let dynamicLoad: (<T>(modulePath: string | URL) => Promise<T>) | undefined;
+
+export function loadEsmModule<T>(modulePath: string | URL): Promise<T> {
+  const modulePathWithCacheBust = `${modulePath}?version=${Date.now()}`;
+  dynamicLoad ??= new Function(
+    'modulePath',
+    `return import(modulePath);`
+  ) as Exclude<typeof dynamicLoad, undefined>;
+
+  return dynamicLoad(modulePathWithCacheBust);
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

Currently, PCV3 with Next.js only supports `.js` and `.cjs` next config files. 
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

With this change we now also support `.mjs` next config file.
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
