### PR TITLE
fix(angular): support scheduling inferred angular cli builder targets

### DIFF
--- a/packages/nx/src/adapter/ngcli-adapter.ts
+++ b/packages/nx/src/adapter/ngcli-adapter.ts
@@ -75,7 +75,7 @@ export async function createBuilderContext(
   context: ExecutorContext
 ) {
   require('./compat');
-  const fsHost = new NxScopedHost(context.root);
+  const fsHost = new NxScopedHostForBuilders(context.root);
   // the top level import is not patched because it is imported before the
   // patching happens so we require it here to use the patched version below
   const { workspaces } = require('@angular-devkit/core');
@@ -199,7 +199,7 @@ export async function scheduleTarget(
   const { Architect } = require('@angular-devkit/architect');
 
   const logger = getLogger(verbose);
-  const fsHost = new NxScopedHost(root);
+  const fsHost = new NxScopedHostForBuilders(root);
   const { workspace } = await workspaces.readWorkspace(
     'angular.json',
     workspaces.createWorkspaceHost(fsHost)
@@ -430,7 +430,7 @@ export class NxScopedHost extends virtualFs.ScopedHost<any> {
     }
   }
 
-  private readMergedWorkspaceConfiguration() {
+  protected readMergedWorkspaceConfiguration() {
     return zip(
       from(createProjectGraphAsync()),
       this.readExistingAngularJson(),
@@ -598,7 +598,7 @@ export class NxScopedHost extends virtualFs.ScopedHost<any> {
     return this.readJson('angular.json');
   }
 
-  private readJson<T = any>(path: string): Observable<T> {
+  protected readJson<T = any>(path: string): Observable<T> {
     return super
       .exists(path as any)
       .pipe(
@@ -610,6 +610,39 @@ export class NxScopedHost extends virtualFs.ScopedHost<any> {
             : of(null)
         )
       );
+  }
+}
+
+/**
+ * Host used by Angular CLI builders. It reads the project configurations from
+ * the project graph to access the expanded targets.
+ */
+export class NxScopedHostForBuilders extends NxScopedHost {
+  protected readMergedWorkspaceConfiguration() {
+    return zip(
+      from(createProjectGraphAsync()),
+      this.readExistingAngularJson(),
+      this.readJson<NxJsonConfiguration>('nx.json')
+    ).pipe(
+      map(([graph, angularJson, nxJson]) => {
+        const workspaceConfig = (angularJson || { projects: {} }) as any;
+        workspaceConfig.cli ??= nxJson.cli;
+        workspaceConfig.schematics ??= nxJson.generators;
+
+        for (const projectName of Object.keys(graph.nodes)) {
+          workspaceConfig.projects[projectName] ??= {
+            ...graph.nodes[projectName].data,
+          };
+        }
+
+        return workspaceConfig;
+      }),
+      catchError((err) => {
+        console.log('Unable to read angular.json');
+        console.log(err);
+        process.exit(1);
+      })
+    );
   }
 }
 
@@ -628,6 +661,10 @@ export function arrayBufferToString(buffer: any) {
   return result;
 }
 
+/**
+ * Host used by Angular CLI schematics. It reads the project configurations from
+ * the project configuration files.
+ */
 export class NxScopeHostUsedForWrappedSchematics extends NxScopedHost {
   constructor(root: string, private readonly host: Tree) {
     super(root);

--- a/packages/nx/src/adapter/ngcli-adapter.ts
+++ b/packages/nx/src/adapter/ngcli-adapter.ts
@@ -398,7 +398,7 @@ async function runSchematic(
       })
       .toPromise();
   } catch (e) {
-    console.log(e);
+    console.error(e);
     throw e;
   }
   if (!record.error) {
@@ -470,8 +470,8 @@ export class NxScopedHost extends virtualFs.ScopedHost<any> {
         );
       }),
       catchError((err) => {
-        console.log('Unable to read angular.json');
-        console.log(err);
+        console.error('Unable to read angular.json');
+        console.error(err);
         process.exit(1);
       })
     );
@@ -638,8 +638,8 @@ export class NxScopedHostForBuilders extends NxScopedHost {
         return workspaceConfig;
       }),
       catchError((err) => {
-        console.log('Unable to read angular.json');
-        console.log(err);
+        console.error('Unable to read angular.json');
+        console.error(err);
         process.exit(1);
       })
     );


### PR DESCRIPTION
Update the Angular CLI adapter layer to support scheduling targets that are inferred. The adapter layer is updated so the host used by Angular CLI builders reads the project configurations from the project graph. This way, it can access the expanded targets.

The host used by Angular CLI schematics remains untouched and reads the project configurations from the `project.json` files. This way, Angular CLI schematics only process/modify what's in the actual configuration files.

This is needed to unblock https://github.com/nrwl/nx/pull/20562.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
