### PR TITLE
cleanup(core): rewrite text reference to nx console 'run' button

### DIFF
--- a/packages/devkit/src/utils/package-json.ts
+++ b/packages/devkit/src/utils/package-json.ts
@@ -457,7 +457,7 @@ export function ensurePackage<T extends any = any>(
 
   if (process.env.NX_DRY_RUN && process.env.NX_DRY_RUN !== 'false') {
     throw new Error(
-      'NOTE: This generator does not support --dry-run. If you are running this in Nx Console, it should execute fine once you hit the "Run" button.\n'
+      'NOTE: This generator does not support --dry-run. If you are running this in Nx Console, it should execute fine once you hit the "Generate" button.\n'
     );
   }
 


### PR DESCRIPTION
![image](https://github.com/nrwl/nx/assets/34165455/c5cbc302-7619-4d4d-9ec3-80ca9abde2a0)
this 'run' button is now called 'generate'