### PR TITLE
docs(core): update readme to avoid branch name already exist error

### DIFF
--- a/docs/nx-cloud/tutorial/github-actions.md
+++ b/docs/nx-cloud/tutorial/github-actions.md
@@ -284,7 +284,9 @@ jobs:
             ~/.cache/Cypress # needed for the Cypress binary
           key: ${{ steps.cache-dependencies-restore.outputs.cache-primary-key }}
       - uses: nrwl/nx-set-shas@v3
+      - name: Track branch
       # This line is needed for nx affected to work when CI is running on a PR
+      if: github.event_name == 'pull_request'
       - run: git branch --track main origin/main
       - run: pnpm nx affected -t lint,test,build --parallel=3 --configuration=ci
       - run: pnpm nx affected -t e2e --parallel=1


### PR DESCRIPTION
This PR updates the readme. It adds a command to skip branch tracking when we are PR is merged to main.

## Current Behavior
![CleanShot 2024-01-05 at 10  10 59](https://github.com/nrwl/nx/assets/53527664/350927a1-339a-4e30-b26c-5617f5e00c53)


## Expected Behavior
![CleanShot 2024-01-05 at 10  11 33](https://github.com/nrwl/nx/assets/53527664/a8b54037-26cd-456c-a208-b3f21f0c65e8)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->


