### PR TITLE
fix(core): handle invalid group glob groups

### DIFF
--- a/docs/shared/recipes/running-tasks/customizing-inputs.md
+++ b/docs/shared/recipes/running-tasks/customizing-inputs.md
@@ -172,7 +172,7 @@ Here's how we could define that, starting from our default situation:
 {
   "namedInputs": {
     "default": ["{projectRoot}/**/*"],
-    "production": ["default", "!{projectRoot}/**/?(*.)+spec.ts"]
+    "production": ["default", "!{projectRoot}/**/?(*.)+(spec|test).ts"]
   },
   "targetDefaults": {
     "build": {

--- a/packages/nx/src/hasher/native-task-hasher-impl.spec.ts
+++ b/packages/nx/src/hasher/native-task-hasher-impl.spec.ts
@@ -4,6 +4,7 @@ import { NxJsonConfiguration } from '../config/nx-json';
 import { createTaskGraph } from '../tasks-runner/create-task-graph';
 import { NativeTaskHasherImpl } from './native-task-hasher-impl';
 import { ProjectGraphBuilder } from '../project-graph/project-graph-builder';
+import { testOnlyTransferFileMap } from '../native';
 
 describe('native task hasher', () => {
   let tempFs: TempFs;
@@ -653,4 +654,41 @@ describe('native task hasher', () => {
       }
     `);
   });
+
+  /**
+   * commented out to show how to debug issues with hashing
+   *
+   *
+   *
+   * gather the project graph + task graph with `nx run project:target --graph=graph.json`
+   * gather the file-map.json from `.nx/cache/file-map.json`
+   * gather the nx.json file
+   */
+  // it('should test client workspaces', async () => {
+  //   let nxJson = require('nx.json');
+  //   let graphs = require('graph.json');
+  //   let projectGraph = graphs.graph;
+  //   let taskGraph = graphs.tasks;
+  //
+  //   let files = require('file-map.json');
+  //   let projectFiles = files.fileMap.projectFileMap;
+  //   let nonProjectFiles = files.fileMap.nonProjectFiles;
+  //
+  //   let transferred = testOnlyTransferFileMap(projectFiles, nonProjectFiles);
+  //
+  //   let hasher = new NativeTaskHasherImpl(
+  //     '',
+  //     nxJson,
+  //     projectGraph,
+  //     transferred,
+  //     { selectivelyHashTsConfig: false }
+  //   );
+  //
+  //   const hashes = await hasher.hashTasks(
+  //     Object.values(taskGraph.tasks),
+  //     taskGraph,
+  //     {}
+  //   );
+  //   console.dir(hashes, { depth: null });
+  // });
 });

--- a/packages/nx/src/native/glob.rs
+++ b/packages/nx/src/native/glob.rs
@@ -359,4 +359,20 @@ mod test {
         assert!(glob_set.is_match("packages/package-c/package.json"));
         assert!(!glob_set.is_match("packages/package-a/package.json"));
     }
+
+    #[test]
+    fn should_handle_invalid_group_globs() {
+        let glob_set = build_glob_set(&[
+            "libs/**/*",
+            "!libs/**/?(*.)+spec.ts?(.snap)",
+            "!libs/tsconfig.spec.json",
+            "!libs/jest.config.ts",
+            "!libs/.eslintrc.json",
+            "!libs/**/test-setup.ts",
+        ])
+        .unwrap();
+
+        assert!(glob_set.is_match("libs/src/index.ts"));
+        assert!(!glob_set.is_match("libs/src/index.spec.ts"));
+    }
 }

--- a/packages/nx/src/native/glob/glob_transform.rs
+++ b/packages/nx/src/native/glob/glob_transform.rs
@@ -198,4 +198,39 @@ mod test {
             ]
         );
     }
+
+    #[test]
+    fn should_convert_globs_with_invalid_groups() {
+        let globs = convert_glob("libs/**/?(*.)+spec.ts?(.snap)").unwrap();
+        assert_eq!(
+            globs,
+            [
+                "libs/**/*.spec.ts",
+                "libs/**/*.spec.ts.snap",
+                "libs/**/spec.ts",
+                "libs/**/spec.ts.snap"
+            ]
+        );
+
+        let globs = convert_glob("libs/**/?(*.)@spec.ts?(.snap)").unwrap();
+        assert_eq!(
+            globs,
+            [
+                "libs/**/*.spec.ts",
+                "libs/**/*.spec.ts.snap",
+                "libs/**/spec.ts",
+                "libs/**/spec.ts.snap"
+            ]
+        );
+        let globs = convert_glob("libs/**/?(*.)?spec.ts?(.snap)").unwrap();
+        assert_eq!(
+            globs,
+            [
+                "libs/**/*.spec.ts",
+                "libs/**/*.spec.ts.snap",
+                "libs/**/spec.ts",
+                "libs/**/spec.ts.snap"
+            ]
+        );
+    }
 }

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -139,6 +139,7 @@ export interface FileMap {
   projectFileMap: ProjectFiles
   nonProjectFiles: Array<FileData>
 }
+export function testOnlyTransferFileMap(projectFiles: Record<string, Array<FileData>>, nonProjectFiles: Array<FileData>): NxWorkspaceFilesExternals
 export class ImportResult {
   file: string
   sourceProject: string

--- a/packages/nx/src/native/index.js
+++ b/packages/nx/src/native/index.js
@@ -246,7 +246,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { expandOutputs, getFilesForOutputs, remove, copy, hashArray, hashFile, ImportResult, findImports, transferProjectGraph, HashPlanner, TaskHasher, EventType, Watcher, WorkspaceContext, WorkspaceErrors } = nativeBinding
+const { expandOutputs, getFilesForOutputs, remove, copy, hashArray, hashFile, ImportResult, findImports, transferProjectGraph, HashPlanner, TaskHasher, EventType, Watcher, WorkspaceContext, WorkspaceErrors, testOnlyTransferFileMap } = nativeBinding
 
 module.exports.expandOutputs = expandOutputs
 module.exports.getFilesForOutputs = getFilesForOutputs
@@ -263,3 +263,4 @@ module.exports.EventType = EventType
 module.exports.Watcher = Watcher
 module.exports.WorkspaceContext = WorkspaceContext
 module.exports.WorkspaceErrors = WorkspaceErrors
+module.exports.testOnlyTransferFileMap = testOnlyTransferFileMap

--- a/packages/nx/src/native/logger/mod.rs
+++ b/packages/nx/src/native/logger/mod.rs
@@ -81,6 +81,13 @@ where
     }
 }
 
+/// Enable logging for the native module
+/// You can set log levels and different logs by setting the `NX_NATIVE_LOGGING` environment variable
+/// Examples:
+/// - `NX_NATIVE_LOGGING=trace|warn|debug|error|info` - enable all logs for all crates and modules
+/// - `NX_NATIVE_LOGGING=nx=trace` - enable all logs for the `nx` (this) crate
+/// - `NX_NATIVE_LOGGING=nx::native::tasks::hashers::hash_project_files=trace` - enable all logs for the `hash_project_files` module
+/// - `NX_NATIVE_LOGGING=[{project_name=project}]` - enable logs that contain the project in its span
 pub(crate) fn enable_logger() {
     let env_filter =
         EnvFilter::try_from_env("NX_NATIVE_LOGGING").unwrap_or_else(|_| EnvFilter::new("ERROR"));

--- a/packages/nx/src/native/project_graph/transfer_project_graph.rs
+++ b/packages/nx/src/native/project_graph/transfer_project_graph.rs
@@ -1,5 +1,6 @@
-use crate::native::project_graph::types::ProjectGraph;
 use napi::bindgen_prelude::External;
+
+use crate::native::project_graph::types::ProjectGraph;
 
 #[napi]
 /// Transfer the project graph from the JS world to the Rust world, so that we can pass the project graph via memory quicker
@@ -7,3 +8,4 @@ use napi::bindgen_prelude::External;
 pub fn transfer_project_graph(project_graph: ProjectGraph) -> External<ProjectGraph> {
     External::new(project_graph)
 }
+

--- a/packages/nx/src/native/workspace/context.rs
+++ b/packages/nx/src/native/workspace/context.rs
@@ -2,7 +2,7 @@ use napi::bindgen_prelude::External;
 use std::collections::HashMap;
 
 use crate::native::hasher::hash;
-use crate::native::utils::{Normalize, path::get_child_files};
+use crate::native::utils::{path::get_child_files, Normalize};
 use rayon::prelude::*;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
@@ -302,7 +302,6 @@ impl WorkspaceContext {
 
     #[napi]
     pub fn get_files_in_directory(&self, directory: String) -> Vec<String> {
-        get_child_files(&directory, self.files_worker
-            .get_files())
+        get_child_files(&directory, self.files_worker.get_files())
     }
 }

--- a/packages/nx/src/native/workspace/mod.rs
+++ b/packages/nx/src/native/workspace/mod.rs
@@ -1,3 +1,8 @@
+use crate::native::types::FileData;
+use crate::native::workspace::types::NxWorkspaceFilesExternals;
+use napi::bindgen_prelude::External;
+use std::collections::HashMap;
+
 pub mod config_files;
 pub mod context;
 mod errors;
@@ -5,3 +10,21 @@ mod files_archive;
 mod files_hashing;
 pub mod types;
 pub mod workspace_files;
+
+#[napi]
+// should only be used in tests to transfer the file map from the JS world to the Rust world
+pub fn __test_only_transfer_file_map(
+    project_files: HashMap<String, Vec<FileData>>,
+    non_project_files: Vec<FileData>,
+) -> NxWorkspaceFilesExternals {
+    let all_workspace_files = project_files
+        .iter()
+        .flat_map(|(_, files)| files.clone())
+        .chain(non_project_files.clone())
+        .collect::<Vec<FileData>>();
+    NxWorkspaceFilesExternals {
+        project_files: External::new(project_files),
+        global_files: External::new(non_project_files),
+        all_workspace_files: External::new(all_workspace_files),
+    }
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Inputs that contain invalid groups will fail glob parsing
Example:
`libs/?snap.ts`

## Expected Behavior
Handle invalid groups by consuming the special character if they are not followed immediately with a `(`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
