### PR TITLE
fix(js): allow inlineable dependency to be added to externals

### DIFF
--- a/packages/js/src/utils/inline.ts
+++ b/packages/js/src/utils/inline.ts
@@ -309,7 +309,8 @@ function recursiveUpdateImport(
       const updatedContent = fileContent.replace(importRegex, (matched) => {
         const result = matched.replace(/['"]/g, '');
         // If a match is the same as the rootParentDir, we're checking its own files so we return the matched as in no changes.
-        if (result === rootParentDir) return matched;
+        if (result === rootParentDir || !inlinedDepsDestOutputRecord[result])
+          return matched;
         const importPath = `"${relative(
           dirPath,
           inlinedDepsDestOutputRecord[result]


### PR DESCRIPTION
This PR fixes an issue when `external` is used with tsc/swc in combination with deprecated inline feature.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20016
