### PR TITLE
feat(misc): install @nx/web if static-serve is setup as target

### DIFF
--- a/packages/remix/src/generators/application/application.impl.ts
+++ b/packages/remix/src/generators/application/application.impl.ts
@@ -34,6 +34,7 @@ import {
   updateUnitTestConfig,
 } from './lib';
 import { NxRemixGeneratorSchema } from './schema';
+import { nxVersion } from '@nx/vite';
 
 export default async function (tree: Tree, _options: NxRemixGeneratorSchema) {
   const options = await normalizeOptions(tree, _options);
@@ -271,11 +272,7 @@ function addFileServerTarget(
   options: NormalizedSchema,
   targetName: string
 ) {
-  addDependenciesToPackageJson(
-    tree,
-    {},
-    { '@nx/web': getPackageVersion(tree, 'nx') }
-  );
+  addDependenciesToPackageJson(tree, {}, { '@nx/web': nxVersion });
 
   const projectConfig = readProjectConfiguration(tree, options.projectName);
   projectConfig.targets[targetName] = {

--- a/packages/storybook/src/generators/init/__snapshots__/init.spec.ts.snap
+++ b/packages/storybook/src/generators/init/__snapshots__/init.spec.ts.snap
@@ -11,6 +11,7 @@ exports[`@nx/storybook:init dependencies for package.json should add angular rel
     "@angular/forms": "*",
     "@nx/js": "0.0.1",
     "@nx/storybook": "0.0.1",
+    "@nx/web": "0.0.1",
     "@storybook/addon-essentials": "7.5.3",
     "@storybook/angular": "7.5.3",
     "@storybook/core-server": "7.5.3",

--- a/packages/storybook/src/generators/init/init.spec.ts
+++ b/packages/storybook/src/generators/init/init.spec.ts
@@ -433,6 +433,7 @@ describe('@nx/storybook:init', () => {
       expect(Object.keys(packageJson.devDependencies)).toEqual([
         '@nx/js',
         '@nx/storybook',
+        '@nx/web',
         '@storybook/addon-essentials',
         '@storybook/core-server',
         '@swc-node/register',

--- a/packages/storybook/src/generators/init/init.ts
+++ b/packages/storybook/src/generators/init/init.ts
@@ -37,6 +37,10 @@ function checkDependenciesInstalled(host: Tree, schema: Schema) {
   // base deps
   devDependencies['@nx/storybook'] = nxVersion;
 
+  // for @nx/web:file-server
+  // TODO: remove when we figure out another solution
+  devDependencies['@nx/web'] = nxVersion;
+
   let storybook7VersionToInstall = storybookVersion;
   if (
     storybookMajorVersion() >= 7 &&

--- a/packages/vite/src/generators/init/__snapshots__/init.spec.ts.snap
+++ b/packages/vite/src/generators/init/__snapshots__/init.spec.ts.snap
@@ -8,6 +8,7 @@ exports[`@nx/vite:init dependencies for package.json should add vite packages an
   "devDependencies": {
     "@nx/js": "0.0.1",
     "@nx/vite": "0.0.1",
+    "@nx/web": "0.0.1",
     "@swc-node/register": "~1.6.7",
     "@swc/core": "~1.3.85",
     "@vitejs/plugin-react": "^4.2.0",
@@ -29,6 +30,7 @@ exports[`@nx/vite:init dependencies for package.json should support --testEnviro
     "@edge-runtime/vm": "~3.0.2",
     "@nx/js": "0.0.1",
     "@nx/vite": "0.0.1",
+    "@nx/web": "0.0.1",
     "@swc-node/register": "~1.6.7",
     "@swc/core": "~1.3.85",
     "@vitest/ui": "^1.0.4",
@@ -47,6 +49,7 @@ exports[`@nx/vite:init dependencies for package.json should support --testEnviro
   "devDependencies": {
     "@nx/js": "0.0.1",
     "@nx/vite": "0.0.1",
+    "@nx/web": "0.0.1",
     "@swc-node/register": "~1.6.7",
     "@swc/core": "~1.3.85",
     "@vitest/ui": "^1.0.4",
@@ -66,6 +69,7 @@ exports[`@nx/vite:init dependencies for package.json should support --testEnviro
   "devDependencies": {
     "@nx/js": "0.0.1",
     "@nx/vite": "0.0.1",
+    "@nx/web": "0.0.1",
     "@swc-node/register": "~1.6.7",
     "@swc/core": "~1.3.85",
     "@vitest/ui": "^1.0.4",

--- a/packages/vite/src/generators/init/lib/utils.ts
+++ b/packages/vite/src/generators/init/lib/utils.ts
@@ -37,6 +37,10 @@ export function checkDependenciesInstalled(
   devDependencies['vitest'] = vitestVersion;
   devDependencies['@vitest/ui'] = vitestVersion;
 
+  // for @nx/web:file-server
+  // TODO: remove when we figure out another solution
+  devDependencies['@nx/web'] = nxVersion;
+
   if (schema.testEnvironment === 'jsdom') {
     devDependencies['jsdom'] = jsdomVersion;
   } else if (schema.testEnvironment === 'happy-dom') {

--- a/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/vue/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -108,6 +108,7 @@ exports[`lib should add vue, vite and vitest to package.json 1`] = `
     "@nx/rollup": "0.0.1",
     "@nx/vite": "0.0.1",
     "@nx/vue": "0.0.1",
+    "@nx/web": "0.0.1",
     "@swc-node/register": "~1.6.7",
     "@swc/core": "~1.3.85",
     "@typescript-eslint/eslint-plugin": "^6.13.2",

--- a/packages/webpack/src/generators/init/init.pcv3.spec.ts
+++ b/packages/webpack/src/generators/init/init.pcv3.spec.ts
@@ -27,6 +27,7 @@ describe('webpackInitGenerator (PCv3)', () => {
         '@swc/helpers': expect.any(String),
       },
       devDependencies: {
+        '@nx/web': expect.any(String),
         '@nx/webpack': expect.any(String),
         '@swc/cli': expect.any(String),
         '@swc/core': expect.any(String),

--- a/packages/webpack/src/generators/init/init.spec.ts
+++ b/packages/webpack/src/generators/init/init.spec.ts
@@ -20,6 +20,7 @@ describe('webpackInitGenerator', () => {
         '@swc/helpers': expect.any(String),
       },
       devDependencies: {
+        '@nx/web': expect.any(String),
         '@nx/webpack': expect.any(String),
         '@swc/cli': expect.any(String),
         '@swc/core': expect.any(String),
@@ -36,6 +37,7 @@ describe('webpackInitGenerator', () => {
       name: expect.any(String),
       dependencies: {},
       devDependencies: {
+        '@nx/web': expect.any(String),
         '@nx/webpack': expect.any(String),
         tslib: expect.any(String),
       },

--- a/packages/webpack/src/generators/init/init.ts
+++ b/packages/webpack/src/generators/init/init.ts
@@ -27,6 +27,9 @@ export async function webpackInitGenerator(tree: Tree, schema: Schema) {
   const tasks: GeneratorCallback[] = [];
   const devDependencies = {
     '@nx/webpack': nxVersion,
+    // for @nx/web:file-server
+    // TODO: remove when we figure out another solution
+    '@nx/web': nxVersion,
   };
 
   if (shouldAddPlugin) {

--- a/packages/webpack/src/migrations/update-15-6-3/webpack-config-setup.spec.ts
+++ b/packages/webpack/src/migrations/update-15-6-3/webpack-config-setup.spec.ts
@@ -51,7 +51,7 @@ describe('15.6.3 migration (setup webpack.config file)', () => {
         },
       },
     });
-    tree.write('apps/app3/webpack.config.js', 'some content');
+    tree.write('apps/app3/webpack.config.js', `console.log("some content");`);
 
     addProjectConfiguration(tree, 'app4', {
       root: 'apps/app4',
@@ -64,22 +64,29 @@ describe('15.6.3 migration (setup webpack.config file)', () => {
         },
       },
     });
-    tree.write('some/random/path/webpack.something.ts', 'some content');
+    tree.write(
+      'some/random/path/webpack.something.ts',
+      `console.log("some content");`
+    );
 
     await webpackConfigSetup(tree);
 
     expect(tree.read('apps/app3/webpack.config.js', 'utf-8')).toMatchSnapshot();
-    expect(
-      tree.read('apps/app3/webpack.config.old.js', 'utf-8')
-    ).toMatchInlineSnapshot(`"some content"`);
+    expect(tree.read('apps/app3/webpack.config.old.js', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "console.log('some content');
+      "
+    `);
 
     expect(
       tree.read('some/random/path/webpack.something.ts', 'utf-8')
     ).toMatchSnapshot();
 
-    expect(
-      tree.read('some/random/path/webpack.something.old.ts', 'utf-8')
-    ).toMatchInlineSnapshot(`"some content"`);
+    expect(tree.read('some/random/path/webpack.something.old.ts', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "console.log('some content');
+      "
+    `);
   });
 
   it('should update the project configuration - executor options', async () => {
@@ -114,7 +121,7 @@ describe('15.6.3 migration (setup webpack.config file)', () => {
       },
     });
 
-    tree.write('apps/app3/webpack.config.js', 'some content');
+    tree.write('apps/app3/webpack.config.js', `console.log("some content");`);
 
     addProjectConfiguration(tree, 'app4', {
       root: 'apps/app4',
@@ -127,7 +134,10 @@ describe('15.6.3 migration (setup webpack.config file)', () => {
         },
       },
     });
-    tree.write('some/random/path/webpack.something.ts', 'some content');
+    tree.write(
+      'some/random/path/webpack.something.ts',
+      `console.log("some content");`
+    );
 
     await webpackConfigSetup(tree);
 


### PR DESCRIPTION
Waiting for another PR before merging

`static-serve` uses `@nx/web:file-server` executor, so we should install `@nx/web` when generating such a target.