### PR TITLE
feat(core): remove prompt from nx connect command

### DIFF
--- a/docs/generated/cli/connect.md
+++ b/docs/generated/cli/connect.md
@@ -23,14 +23,6 @@ Type: `boolean`
 
 Show help
 
-### interactive
-
-Type: `boolean`
-
-Default: `true`
-
-Prompt for confirmation
-
 ### version
 
 Type: `boolean`

--- a/docs/generated/packages/nx/documents/connect-to-nx-cloud.md
+++ b/docs/generated/packages/nx/documents/connect-to-nx-cloud.md
@@ -23,14 +23,6 @@ Type: `boolean`
 
 Show help
 
-### interactive
-
-Type: `boolean`
-
-Default: `true`
-
-Prompt for confirmation
-
 ### version
 
 Type: `boolean`

--- a/docs/nx-cloud/tutorial/circle.md
+++ b/docs/nx-cloud/tutorial/circle.md
@@ -313,7 +313,6 @@ Merge your PR into the `main` branch when you're ready to move to the next secti
 Reducing the number of tasks to run via [affected commands](/ci/features/affected) (as seen in the previous section) is helpful, but might not be enough. By default [Nx caches the results of tasks](/core-features/cache-task-results) on your local machine. But CI and local developer machines are still performing the same tasks on the same code - wasting time and money. The [Nx Cloud remote cache](/ci/features/remote-cache) can eliminate that waste for you.
 
 ```{% command="pnpm nx connect" %}
-✔ Enable distributed caching to make your CI faster · Yes
 $ nx g nx:connect-to-nx-cloud --quiet --no-interactive
 
  >  NX   Distributed caching via Nx Cloud has been enabled

--- a/docs/nx-cloud/tutorial/github-actions.md
+++ b/docs/nx-cloud/tutorial/github-actions.md
@@ -314,7 +314,6 @@ Merge your PR into the `main` branch when you're ready to move to the next secti
 Reducing the number of tasks to run via [affected commands](/ci/features/affected) (as seen in the previous section) is helpful, but might not be enough. By default [Nx caches the results of tasks](/core-features/cache-task-results) on your local machine. But CI and local developer machines are still performing the same tasks on the same code - wasting time and money. The [Nx Cloud remote cache](/ci/features/remote-cache) can eliminate that waste for you.
 
 ```{% command="pnpm nx connect" %}
-✔ Enable distributed caching to make your CI faster · Yes
 
  >  NX   Distributed caching via Nx Cloud has been enabled
 

--- a/packages/nx/src/command-line/connect/command-object.ts
+++ b/packages/nx/src/command-line/connect/command-object.ts
@@ -1,24 +1,13 @@
 import { CommandModule } from 'yargs';
 import { linkToNxDevAndExamples } from '../yargs-utils/documentation';
-import type { ConnectToNxCloudOptions } from './connect-to-nx-cloud';
 
-export const yargsConnectCommand: CommandModule<{}, ConnectToNxCloudOptions> = {
+export const yargsConnectCommand: CommandModule = {
   command: 'connect',
   aliases: ['connect-to-nx-cloud'],
   describe: `Connect workspace to Nx Cloud`,
-  builder: (yargs) =>
-    linkToNxDevAndExamples(
-      yargs.option('interactive', {
-        type: 'boolean',
-        description: 'Prompt for confirmation',
-        default: true,
-      }),
-      'connect-to-nx-cloud'
-    ),
-  handler: async (options) => {
-    await (
-      await import('./connect-to-nx-cloud')
-    ).connectToNxCloudCommand(options);
+  builder: (yargs) => linkToNxDevAndExamples(yargs, 'connect-to-nx-cloud'),
+  handler: async () => {
+    await (await import('./connect-to-nx-cloud')).connectToNxCloudCommand();
     process.exit(0);
   },
 };

--- a/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/connect/connect-to-nx-cloud.ts
@@ -42,15 +42,7 @@ export async function connectToNxCloudIfExplicitlyAsked(
   }
 }
 
-export interface ConnectToNxCloudOptions {
-  interactive: boolean;
-  promptOverride?: string;
-}
-
-export async function connectToNxCloudCommand({
-  promptOverride,
-  interactive,
-}: ConnectToNxCloudOptions): Promise<boolean> {
+export async function connectToNxCloudCommand(): Promise<boolean> {
   const nxJson = readNxJson();
   if (isNxCloudUsed(nxJson)) {
     output.log({
@@ -68,15 +60,13 @@ export async function connectToNxCloudCommand({
     return false;
   }
 
-  const res = interactive ? await connectToNxCloudPrompt(promptOverride) : true;
-  if (!res) return false;
   runNxSync(`g nx:connect-to-nx-cloud --quiet --no-interactive`, {
     stdio: [0, 1, 2],
   });
   return true;
 }
 
-async function connectToNxCloudPrompt(prompt?: string) {
+export async function connectToNxCloudPrompt(prompt?: string) {
   return await (
     await import('enquirer')
   )

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -49,6 +49,7 @@ import {
 import { handleErrors } from '../../utils/params';
 import {
   connectToNxCloudCommand,
+  connectToNxCloudPrompt,
   onlyDefaultRunnerIsUsed,
 } from '../connect/connect-to-nx-cloud';
 import { output } from '../../utils/output';
@@ -1222,10 +1223,10 @@ async function generateMigrationsJsonAndUpdatePackageJson(
         !isCI() &&
         !isNxCloudUsed(originalNxJson)
       ) {
-        const useCloud = await connectToNxCloudCommand({
-          promptOverride: messages.getPromptMessage('nxCloudMigration'),
-          interactive: true,
-        });
+        const setNxCloud = await connectToNxCloudPrompt(
+          messages.getPromptMessage('nxCloudMigration')
+        );
+        const useCloud = setNxCloud ? await connectToNxCloudCommand() : false;
         await recordStat({
           command: 'migrate',
           nxVersion,


### PR DESCRIPTION
### Remove interactivity from the `nx connect`

At the moment connect is used in three scenarios:
- During the CNW
- During the migration to next major version of Nx
- Explicitly by calling `nx connect`

The `create nx workspace` is using custom prompt and then calls `connect` with `interactive: false` anyway, so this PR does not change that.
The migration will still use the prompt as before, but now calling it explicitly before running `connect`
The `nx connect` is intentional command so there’s no need to bug user with additional layer of confirmation. We want to remove any obstacle that might “help” them not set up cloud.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
