### PR TITLE
feat(remix): add createNodes support for target inference

### DIFF
--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -37,5 +37,9 @@
   "peerDependencies": {},
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./plugin": "./plugin.js"
   }
 }

--- a/packages/remix/plugin.ts
+++ b/packages/remix/plugin.ts
@@ -1,0 +1,5 @@
+export {
+  createNodes,
+  createDependencies,
+  RemixPluginOptions,
+} from './src/plugins/plugin';

--- a/packages/remix/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/remix/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -1,0 +1,111 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`@nx/remix/plugin non-root project should create nodes 1`] = `
+{
+  "projects": {
+    "my-app": {
+      "root": "my-app",
+      "targets": {
+        "build": {
+          "cache": true,
+          "dependsOn": [
+            "^build",
+          ],
+          "executor": "@nx/remix:build",
+          "inputs": [
+            "production",
+            "^production",
+          ],
+          "options": {
+            "outputPath": "{workspaceRoot}/dist",
+          },
+          "outputs": [
+            "{options.outputPath}",
+          ],
+        },
+        "serve": {
+          "executor": "@nx/remix:serve",
+          "options": {
+            "command": "npx remix-serve build/index.js",
+          },
+        },
+        "start": {
+          "command": "npx remix-serve build/index.js",
+          "dependsOn": [
+            "build",
+          ],
+          "options": {
+            "cwd": "my-app",
+          },
+        },
+        "tsc": {
+          "cache": true,
+          "command": "tsc",
+          "inputs": [
+            "production",
+            "^production",
+          ],
+          "options": {
+            "cwd": "my-app",
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`@nx/remix/plugin root project should create nodes 1`] = `
+{
+  "projects": {
+    ".": {
+      "root": ".",
+      "targets": {
+        "build": {
+          "cache": true,
+          "dependsOn": [
+            "^build",
+          ],
+          "executor": "@nx/remix:build",
+          "inputs": [
+            "production",
+            "^production",
+          ],
+          "options": {
+            "outputPath": "{workspaceRoot}/dist",
+          },
+          "outputs": [
+            "{options.outputPath}",
+          ],
+        },
+        "serve": {
+          "executor": "@nx/remix:serve",
+          "options": {
+            "command": "npx remix-serve build/index.js",
+          },
+        },
+        "start": {
+          "command": "npx remix-serve build/index.js",
+          "dependsOn": [
+            "build",
+          ],
+          "options": {
+            "cwd": ".",
+          },
+        },
+        "typecheck": {
+          "cache": true,
+          "command": "tsc",
+          "inputs": [
+            "production",
+            "^production",
+          ],
+          "options": {
+            "cwd": ".",
+          },
+        },
+      },
+    },
+  },
+}
+`;

--- a/packages/remix/src/plugins/plugin.spec.ts
+++ b/packages/remix/src/plugins/plugin.spec.ts
@@ -1,0 +1,137 @@
+import { type CreateNodesContext, joinPathFragments } from '@nx/devkit';
+import { createNodes } from './plugin';
+import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
+
+describe('@nx/remix/plugin', () => {
+  let createNodesFunction = createNodes[1];
+  let context: CreateNodesContext;
+  let cwd = process.cwd();
+
+  describe('root project', () => {
+    const tempFs = new TempFs('test');
+
+    beforeEach(() => {
+      context = {
+        nxJsonConfiguration: {
+          targetDefaults: {
+            build: {
+              cache: false,
+              inputs: ['foo', '^foo'],
+            },
+            serve: {
+              command: 'npm run serve',
+            },
+            start: {
+              command: 'npm run start',
+            },
+            typecheck: {
+              command: 'tsc',
+            },
+          },
+          namedInputs: {
+            default: ['{projectRoot}/**/*'],
+            production: ['!{projectRoot}/**/*.spec.ts'],
+          },
+        },
+        workspaceRoot: tempFs.tempDir,
+      };
+      tempFs.createFileSync(
+        'package.json',
+        JSON.stringify('{name: "my-app", type: "module"}')
+      );
+      tempFs.createFileSync(
+        'remix.config.cjs',
+        `/**
+ * @type {import('@remix-run/dev').AppConfig}
+ */
+module.exports = {
+  ignoredRouteFiles: ['**/.*'],
+  watchPaths: () => require('@nx/remix').createWatchPaths(__dirname),
+};
+`
+      );
+      process.chdir(tempFs.tempDir);
+    });
+
+    afterEach(() => {
+      jest.resetModules();
+      tempFs.cleanup();
+      process.chdir(cwd);
+    });
+
+    it('should create nodes', async () => {
+      // ACT
+      const nodes = await createNodesFunction(
+        'remix.config.cjs',
+        {
+          buildTargetName: 'build',
+          serveTargetName: 'serve',
+          startTargetName: 'start',
+          typecheckTargetName: 'typecheck',
+        },
+        context
+      );
+
+      // ASSERT
+      expect(nodes).toMatchSnapshot();
+    });
+  });
+
+  describe('non-root project', () => {
+    const tempFs = new TempFs('test');
+
+    beforeEach(() => {
+      context = {
+        nxJsonConfiguration: {
+          namedInputs: {
+            default: ['{projectRoot}/**/*'],
+            production: ['!{projectRoot}/**/*.spec.ts'],
+          },
+        },
+        workspaceRoot: tempFs.tempDir,
+      };
+
+      tempFs.createFileSync(
+        'my-app/project.json',
+        JSON.stringify({ name: 'my-app' })
+      );
+
+      tempFs.createFileSync(
+        'my-app/remix.config.cjs',
+        `/**
+ * @type {import('@remix-run/dev').AppConfig}
+ */
+module.exports = {
+  ignoredRouteFiles: ['**/.*'],
+  watchPaths: () => require('@nx/remix').createWatchPaths(__dirname),
+};
+`
+      );
+
+      process.chdir(tempFs.tempDir);
+    });
+
+    afterEach(() => {
+      jest.resetModules();
+      tempFs.cleanup();
+      process.chdir(cwd);
+    });
+
+    it('should create nodes', async () => {
+      // ACT
+      const nodes = await createNodesFunction(
+        'my-app/remix.config.cjs',
+        {
+          buildTargetName: 'build',
+          serveTargetName: 'serve',
+          startTargetName: 'start',
+          typecheckTargetName: 'tsc',
+        },
+        context
+      );
+
+      // ASSERT
+      expect(nodes).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/remix/src/plugins/plugin.ts
+++ b/packages/remix/src/plugins/plugin.ts
@@ -1,0 +1,211 @@
+import { projectGraphCacheDirectory } from 'nx/src/utils/cache-directory';
+import {
+  type CreateDependencies,
+  type CreateNodes,
+  type CreateNodesContext,
+  type TargetConfiguration,
+  detectPackageManager,
+  readJsonFile,
+  writeJsonFile,
+} from '@nx/devkit';
+import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
+import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
+import { getLockFileName, getRootTsConfigPath } from '@nx/js';
+import { registerTsProject } from '@nx/js/src/internal';
+import { type AppConfig } from '@remix-run/dev';
+import { join, dirname } from 'path';
+import { existsSync, readdirSync } from 'fs';
+
+const cachePath = join(projectGraphCacheDirectory, 'remix.hash');
+const targetsCache = existsSync(cachePath) ? readTargetsCache() : {};
+const calculatedTargets: Record<
+  string,
+  Record<string, TargetConfiguration>
+> = {};
+
+function readTargetsCache(): Record<
+  string,
+  Record<string, TargetConfiguration>
+> {
+  return readJsonFile(cachePath);
+}
+
+function writeTargetsToCache(
+  targets: Record<string, Record<string, TargetConfiguration>>
+) {
+  writeJsonFile(cachePath, targets);
+}
+
+export const createDependencies: CreateDependencies = () => {
+  writeTargetsToCache(calculatedTargets);
+  return [];
+};
+
+export interface RemixPluginOptions {
+  buildTargetName?: string;
+  serveTargetName?: string;
+  startTargetName?: string;
+  typecheckTargetName?: string;
+}
+
+export const createNodes: CreateNodes<RemixPluginOptions> = [
+  '**/remix.config.{js,cjs,mjs}',
+  async (configFilePath, options, context) => {
+    const projectRoot = dirname(configFilePath);
+    const fullyQualifiedProjectRoot = join(context.workspaceRoot, projectRoot);
+    // Do not create a project if package.json and project.json isn't there
+    const siblingFiles = readdirSync(fullyQualifiedProjectRoot);
+    if (
+      !siblingFiles.includes('package.json') &&
+      !siblingFiles.includes('project.json')
+    ) {
+      return {};
+    }
+
+    options = normalizeOptions(options);
+
+    const hash = calculateHashForCreateNodes(projectRoot, options, context, [
+      getLockFileName(detectPackageManager(context.workspaceRoot)),
+    ]);
+    const targets = targetsCache[hash]
+      ? targetsCache[hash]
+      : await buildRemixTargets(configFilePath, projectRoot, options, context);
+
+    calculatedTargets[hash] = targets;
+
+    return {
+      projects: {
+        [projectRoot]: {
+          root: projectRoot,
+          targets,
+        },
+      },
+    };
+  },
+];
+
+async function buildRemixTargets(
+  configFilePath: string,
+  projectRoot: string,
+  options: RemixPluginOptions,
+  context: CreateNodesContext
+) {
+  const namedInputs = getNamedInputs(projectRoot, context);
+  const serverBuildPath = await getServerBuildPath(
+    configFilePath,
+    context.workspaceRoot
+  );
+
+  const targets: Record<string, TargetConfiguration> = {};
+  targets[options.buildTargetName] = buildTarget(
+    options.buildTargetName,
+    namedInputs
+  );
+  targets[options.serveTargetName] = serveTarget(serverBuildPath);
+  targets[options.startTargetName] = startTarget(
+    projectRoot,
+    serverBuildPath,
+    options.buildTargetName
+  );
+  targets[options.typecheckTargetName] = typecheckTarget(
+    projectRoot,
+    namedInputs
+  );
+
+  return targets;
+}
+
+function buildTarget(
+  buildTargetName: string,
+  namedInputs: { [inputName: string]: any[] }
+): TargetConfiguration {
+  return {
+    cache: true,
+    dependsOn: [`^${buildTargetName}`],
+    inputs: [
+      ...('production' in namedInputs
+        ? ['production', '^production']
+        : ['default', '^default']),
+    ],
+    outputs: ['{options.outputPath}'],
+    executor: '@nx/remix:build',
+    options: {
+      outputPath: '{workspaceRoot}/dist',
+    },
+  };
+}
+
+function serveTarget(serverBuildPath: string): TargetConfiguration {
+  return {
+    executor: '@nx/remix:serve',
+    options: {
+      command: `npx remix-serve ${serverBuildPath}`,
+    },
+  };
+}
+
+function startTarget(
+  projectRoot: string,
+  serverBuildPath: string,
+  buildTargetName: string
+): TargetConfiguration {
+  return {
+    dependsOn: [buildTargetName],
+    command: `npx remix-serve ${serverBuildPath}`,
+    options: {
+      cwd: projectRoot,
+    },
+  };
+}
+
+function typecheckTarget(
+  projectRoot: string,
+  namedInputs: { [inputName: string]: any[] }
+): TargetConfiguration {
+  return {
+    cache: true,
+    inputs: [
+      ...('production' in namedInputs
+        ? ['production', '^production']
+        : ['default', '^default']),
+    ],
+    command: 'tsc',
+    options: {
+      cwd: projectRoot,
+    },
+  };
+}
+
+async function getServerBuildPath(
+  configFilePath: string,
+  workspaceRoot: string
+): Promise<string> {
+  const configPath = join(workspaceRoot, configFilePath);
+  let appConfig: AppConfig = {};
+  try {
+    let appConfigModule: any;
+    try {
+      appConfigModule = await Function(`return import("${configPath}")`)();
+    } catch {
+      appConfigModule = require(configPath);
+    }
+
+    appConfig = appConfigModule?.default || appConfigModule;
+  } catch (error) {
+    throw new Error(
+      `Error loading Remix config at ${configFilePath}\n${String(error)}`
+    );
+  }
+
+  return appConfig.serverBuildPath ?? 'build/index.js';
+}
+
+function normalizeOptions(options: RemixPluginOptions) {
+  options ??= {};
+  options.buildTargetName ??= 'build';
+  options.serveTargetName ??= 'serve';
+  options.startTargetName ??= 'start';
+  options.typecheckTargetName ??= 'typecheck';
+
+  return options;
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Remix can only be used with `project.json` files that define the required targets.


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Add `@nx/remix/plugin` to allow for inferring targets for projects where we find a `remix.config` file.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
