### PR TITLE
fix(vite): do not add test target if test is not defined

### DIFF
--- a/packages/vite/src/plugins/__snapshots__/plugin-with-test.spec.ts.snap
+++ b/packages/vite/src/plugins/__snapshots__/plugin-with-test.spec.ts.snap
@@ -1,0 +1,72 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`@nx/vite/plugin with test node root project should create nodes - with test too 1`] = `
+{
+  "projects": {
+    ".": {
+      "root": ".",
+      "targets": {
+        "build": {
+          "cache": true,
+          "command": "vite build",
+          "dependsOn": [
+            "^build",
+          ],
+          "inputs": [
+            "production",
+            "^production",
+            {
+              "externalDependencies": [
+                "vite",
+              ],
+            },
+          ],
+          "options": {
+            "cwd": ".",
+          },
+          "outputs": [
+            "{projectRoot}/dist",
+          ],
+        },
+        "preview": {
+          "command": "vite preview",
+          "options": {
+            "cwd": ".",
+          },
+        },
+        "serve": {
+          "command": "vite serve",
+          "options": {
+            "cwd": ".",
+          },
+        },
+        "serve-static": {
+          "executor": "@nx/web:file-server",
+          "options": {
+            "buildTarget": "build",
+          },
+        },
+        "test": {
+          "cache": true,
+          "command": "vitest run",
+          "inputs": [
+            "default",
+            "^production",
+            {
+              "externalDependencies": [
+                "vitest",
+              ],
+            },
+          ],
+          "options": {
+            "cwd": ".",
+          },
+          "outputs": [
+            "{projectRoot}/coverage",
+          ],
+        },
+      },
+    },
+  },
+}
+`;

--- a/packages/vite/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/vite/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -46,25 +46,6 @@ exports[`@nx/vite/plugin not root project should create nodes 1`] = `
             "buildTarget": "build-something",
           },
         },
-        "vitest": {
-          "cache": true,
-          "command": "vitest run",
-          "inputs": [
-            "default",
-            "^production",
-            {
-              "externalDependencies": [
-                "vitest",
-              ],
-            },
-          ],
-          "options": {
-            "cwd": "my-app",
-          },
-          "outputs": [
-            "{workspaceRoot}/coverage/{projectRoot}",
-          ],
-        },
       },
     },
   },
@@ -116,25 +97,6 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
           "options": {
             "buildTarget": "build",
           },
-        },
-        "test": {
-          "cache": true,
-          "command": "vitest run",
-          "inputs": [
-            "default",
-            "^production",
-            {
-              "externalDependencies": [
-                "vitest",
-              ],
-            },
-          ],
-          "options": {
-            "cwd": ".",
-          },
-          "outputs": [
-            "{projectRoot}/coverage",
-          ],
         },
       },
     },

--- a/packages/vite/src/plugins/plugin-with-test.spec.ts
+++ b/packages/vite/src/plugins/plugin-with-test.spec.ts
@@ -1,12 +1,15 @@
 import { CreateNodesContext } from '@nx/devkit';
 import { createNodes } from './plugin';
-import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 
 jest.mock('vite', () => ({
   loadConfigFromFile: jest.fn().mockImplementation(() => {
     return Promise.resolve({
       path: 'vite.config.ts',
-      config: {},
+      config: {
+        test: {
+          some: 'option',
+        },
+      },
       dependencies: [],
     });
   }),
@@ -16,13 +19,17 @@ jest.mock('../utils/executor-utils', () => ({
   loadViteDynamicImport: jest.fn().mockResolvedValue({
     loadConfigFromFile: jest.fn().mockResolvedValue({
       path: 'vite.config.ts',
-      config: {},
+      config: {
+        test: {
+          some: 'option',
+        },
+      },
       dependencies: [],
     }),
   }),
 }));
 
-describe('@nx/vite/plugin', () => {
+describe('@nx/vite/plugin with test node', () => {
   let createNodesFunction = createNodes[1];
   let context: CreateNodesContext;
   describe('root project', () => {
@@ -49,7 +56,7 @@ describe('@nx/vite/plugin', () => {
       jest.resetModules();
     });
 
-    it('should create nodes', async () => {
+    it('should create nodes - with test too', async () => {
       const nodes = await createNodesFunction(
         'vite.config.ts',
         {
@@ -57,47 +64,6 @@ describe('@nx/vite/plugin', () => {
           serveTargetName: 'serve',
           previewTargetName: 'preview',
           testTargetName: 'test',
-          serveStaticTargetName: 'serve-static',
-        },
-        context
-      );
-
-      expect(nodes).toMatchSnapshot();
-    });
-  });
-
-  describe('not root project', () => {
-    const tempFs = new TempFs('test');
-    beforeEach(() => {
-      context = {
-        nxJsonConfiguration: {
-          namedInputs: {
-            default: ['{projectRoot}/**/*'],
-            production: ['!{projectRoot}/**/*.spec.ts'],
-          },
-        },
-        workspaceRoot: tempFs.tempDir,
-      };
-
-      tempFs.createFileSync(
-        'my-app/project.json',
-        JSON.stringify({ name: 'my-app' })
-      );
-      tempFs.createFileSync('my-app/vite.config.ts', '');
-    });
-
-    afterEach(() => {
-      jest.resetModules();
-    });
-
-    it('should create nodes', async () => {
-      const nodes = await createNodesFunction(
-        'my-app/vite.config.ts',
-        {
-          buildTargetName: 'build-something',
-          serveTargetName: 'my-serve',
-          previewTargetName: 'preview-site',
-          testTargetName: 'vitest',
           serveStaticTargetName: 'serve-static',
         },
         context


### PR DESCRIPTION
* if test is present add test target
* if only test definition is present, then we cannot assume that we only need test target
* if only vitest.config is there, then only add test target
* if test is not present, do not add test target