### PR TITLE
fix(vite): replaceFile and fileReplacement fixes

### DIFF
--- a/docs/generated/packages/vite/executors/build.json
+++ b/docs/generated/packages/vite/executors/build.json
@@ -32,28 +32,6 @@
         "x-completion-type": "file",
         "x-completion-glob": "vite.config.@(js|ts)"
       },
-      "fileReplacements": {
-        "description": "Replace files with other files in the build.",
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "replace": {
-              "type": "string",
-              "description": "The file to be replaced.",
-              "x-completion-type": "file"
-            },
-            "with": {
-              "type": "string",
-              "description": "The file to replace with.",
-              "x-completion-type": "file"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["replace", "with"]
-        },
-        "default": []
-      },
       "watch": {
         "description": "Enable re-building when files change.",
         "oneOf": [{ "type": "boolean" }, { "type": "object" }],

--- a/docs/shared/packages/vite/configure-vite.md
+++ b/docs/shared/packages/vite/configure-vite.md
@@ -216,3 +216,28 @@ export default defineConfig({
 ```
 
 In that config file, you can configure Vite as you would normally do. For more information, see the [Vite.js documentation](https://vitejs.dev/config/).
+
+## Set up file replacements
+
+You can use the `replaceFiles()` plugin (`@nx/vite/plugins/rollup-replace-files.plugin`) to replace files in your build. You can import the plugin from `@nx/vite/plugins/rollup-replace-files.plugin`. And you can set it up like this:
+
+```ts {% fileName="apps/my-app/vite.config.ts" %}
+...
+import { replaceFiles } from '@nx/vite/plugins/rollup-replace-files.plugin';
+
+export default defineConfig({
+  ...
+
+  plugins: [
+    ...
+    replaceFiles([
+      {
+        replace: 'apps/my-app/src/environments/environment.ts',
+        with: 'apps/my-app/src/environments/environment.prod.ts',
+      },
+    ]),
+  ],
+
+  ...
+});
+```

--- a/packages/vite/plugins/rollup-replace-files.plugin.ts
+++ b/packages/vite/plugins/rollup-replace-files.plugin.ts
@@ -5,7 +5,7 @@
  * @param {FileReplacement[]} replacements
  * @return {({name: "rollup-plugin-replace-files", enforce: "pre" | "post" | undefined, Promise<resolveId>})}
  */
-export default function replaceFiles(replacements: FileReplacement[]): {
+export function replaceFiles(replacements: FileReplacement[]): {
   name: string;
   enforce: 'pre' | 'post' | undefined;
   resolveId(

--- a/packages/vite/src/executors/build/schema.d.ts
+++ b/packages/vite/src/executors/build/schema.d.ts
@@ -1,11 +1,9 @@
-import type { FileReplacement } from '../../plugins/rollup-replace-files.plugin';
 export interface ViteBuildExecutorOptions {
   outputPath?: string;
+  buildLibsFromSource?: boolean;
   skipTypeCheck?: boolean;
   configFile?: string;
-  fileReplacements?: FileReplacement[];
   watch?: boolean;
   generatePackageJson?: boolean;
   includeDevDependenciesInPackageJson?: boolean;
-  buildLibsFromSource?: boolean;
 }

--- a/packages/vite/src/executors/build/schema.json
+++ b/packages/vite/src/executors/build/schema.json
@@ -34,28 +34,6 @@
       "x-completion-type": "file",
       "x-completion-glob": "vite.config.@(js|ts)"
     },
-    "fileReplacements": {
-      "description": "Replace files with other files in the build.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "replace": {
-            "type": "string",
-            "description": "The file to be replaced.",
-            "x-completion-type": "file"
-          },
-          "with": {
-            "type": "string",
-            "description": "The file to replace with.",
-            "x-completion-type": "file"
-          }
-        },
-        "additionalProperties": false,
-        "required": ["replace", "with"]
-      },
-      "default": []
-    },
     "watch": {
       "description": "Enable re-building when files change.",
       "oneOf": [

--- a/packages/vite/src/migrations/update-17-2-0/update-vite-config.ts
+++ b/packages/vite/src/migrations/update-17-2-0/update-vite-config.ts
@@ -39,10 +39,10 @@ export default async function updateBuildDir(tree: Tree) {
 
       configContents = updateTestConfig(configContents, projectConfig, config);
 
-      if (options.fileReplacements?.length > 0) {
+      if (options['fileReplacements']?.length > 0) {
         configContents = addFileReplacements(
           configContents,
-          options.fileReplacements,
+          options['fileReplacements'],
           config
         );
       }

--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -212,9 +212,6 @@ export function addOrChangeBuildTarget(
   project.targets ??= {};
 
   if (project.targets[target]) {
-    buildOptions.fileReplacements =
-      project.targets[target].options?.fileReplacements;
-
     if (project.targets[target].executor === '@nxext/vite:build') {
       buildOptions['base'] = project.targets[target].options?.baseHref;
       buildOptions['sourcemap'] = project.targets[target].options?.sourcemaps;


### PR DESCRIPTION
* Remove `default` from `replaceFiles` plugin export.
* Remove `fileReplacements` from `build` schema, since it's not supported there any more
* Add documentation about how to set up file replacements for vite

Fixes #21065 #20918
