### PR TITLE
feat(release): enable git operations by default

### DIFF
--- a/docs/generated/cli/release.md
+++ b/docs/generated/cli/release.md
@@ -161,13 +161,11 @@ Type: `string`
 
 Exact version or semver keyword to apply to the selected release group.
 
-##### stageChanges
+##### stage-changes
 
 Type: `boolean`
 
-Default: `false`
-
-Whether or not to stage the changes made by this command, irrespective of the git config in nx.json related to automated commits. Useful when combining this command with changelog generation.
+Whether or not to stage the changes made by this command. Useful when combining this command with changelog generation.
 
 ##### version
 

--- a/docs/generated/packages/nx/documents/release.md
+++ b/docs/generated/packages/nx/documents/release.md
@@ -161,13 +161,11 @@ Type: `string`
 
 Exact version or semver keyword to apply to the selected release group.
 
-##### stageChanges
+##### stage-changes
 
 Type: `boolean`
 
-Default: `false`
-
-Whether or not to stage the changes made by this command, irrespective of the git config in nx.json related to automated commits. Useful when combining this command with changelog generation.
+Whether or not to stage the changes made by this command. Useful when combining this command with changelog generation.
 
 ##### version
 

--- a/docs/shared/core-features/manage-releases.md
+++ b/docs/shared/core-features/manage-releases.md
@@ -105,8 +105,6 @@ import * as yargs from 'yargs';
 
   const { workspaceVersion, projectsVersionData } = await releaseVersion({
     specifier: options.version,
-    // stage package.json updates to be committed later by the changelog command
-    stageChanges: true,
     dryRun: options.dryRun,
     verbose: options.verbose,
   });

--- a/e2e/release/src/independent-projects.test.ts
+++ b/e2e/release/src/independent-projects.test.ts
@@ -125,6 +125,9 @@ describe('nx release - independent projects', () => {
         "scripts": {
 
 
+        >  NX   Staging changed files with git
+
+
       `);
 
       const versionPkg2Output = runCLI(
@@ -132,26 +135,29 @@ describe('nx release - independent projects', () => {
       );
       expect(versionPkg2Output).toMatchInlineSnapshot(`
 
-          >  NX   Your filter "{project-name}" matched the following projects:
+        >  NX   Your filter "{project-name}" matched the following projects:
 
-          - {project-name}
-
-
-          >  NX   Running release version for project: {project-name}
-
-          {project-name} 🔍 Reading data for package "@proj/{project-name}" from {project-name}/package.json
-          {project-name} 📄 Resolved the current version as 0.0.0 from {project-name}/package.json
-          {project-name} 📄 Using the provided version specifier "999.9.9-package.2".
-          {project-name} ✍️  New version 999.9.9-package.2 written to {project-name}/package.json
+        - {project-name}
 
 
-          "name": "@proj/{project-name}",
-          -   "version": "0.0.0",
-          +   "version": "999.9.9-package.2",
-          "scripts": {
+        >  NX   Running release version for project: {project-name}
 
-          }
-          +
+        {project-name} 🔍 Reading data for package "@proj/{project-name}" from {project-name}/package.json
+        {project-name} 📄 Resolved the current version as 0.0.0 from {project-name}/package.json
+        {project-name} 📄 Using the provided version specifier "999.9.9-package.2".
+        {project-name} ✍️  New version 999.9.9-package.2 written to {project-name}/package.json
+
+
+        "name": "@proj/{project-name}",
+        -   "version": "0.0.0",
+        +   "version": "999.9.9-package.2",
+        "scripts": {
+
+        }
+        +
+
+
+        >  NX   Staging changed files with git
 
 
       `);
@@ -188,6 +194,9 @@ describe('nx release - independent projects', () => {
         -     "@proj/{project-name}": "0.0.0"
         +     "@proj/{project-name}": "999.9.9-package.3"
         }
+
+
+        >  NX   Staging changed files with git
 
 
       `);
@@ -653,7 +662,7 @@ describe('nx release - independent projects', () => {
   });
 
   describe('release command', () => {
-    beforeEach(() => {
+    it('should allow versioning projects independently', async () => {
       updateJson('nx.json', () => {
         return {
           release: {
@@ -670,9 +679,10 @@ describe('nx release - independent projects', () => {
           },
         };
       });
-    });
 
-    it('should allow versioning projects independently', async () => {
+      runCommand(`git add .`);
+      runCommand(`git commit -m "chore: initial commit"`);
+
       runCommand(`git tag ${pkg1}@v1.2.0`);
       runCommand(`git tag ${pkg2}@v1.4.0`);
       runCommand(`git tag ${pkg3}@v1.6.0`);
@@ -727,6 +737,9 @@ describe('nx release - independent projects', () => {
           },
         };
       });
+
+      runCommand(`git add .`);
+      runCommand(`git commit -m "chore: initial commit"`);
 
       runCommand(`git tag ${pkg1}@v1.3.0`);
       runCommand(`git tag ${pkg2}@v1.5.0`);

--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -76,6 +76,12 @@
       "version": "17.0.0-rc.1",
       "description": "Migration for v17.0.0-rc.1",
       "implementation": "./src/migrations/update-17-0-0/rm-default-collection-npm-scope"
+    },
+    "17.3.0-nx-release-git-operations-explicit-opt-out": {
+      "cli": "nx",
+      "version": "17.3.0-beta.3",
+      "description": "Explicitly opt-out of git operations in nx release",
+      "implementation": "./src/migrations/update-17-3-0/nx-release-git-operations-explicit-opt-out"
     }
   }
 }

--- a/packages/nx/src/command-line/release/changelog.ts
+++ b/packages/nx/src/command-line/release/changelog.ts
@@ -140,14 +140,14 @@ export async function releaseChangelog(
 
   const tree = new FsTree(workspaceRoot, args.verbose);
 
-  const userCommitMessage: string | undefined =
+  const commitMessage: string | undefined =
     args.gitCommitMessage || nxReleaseConfig.changelog.git.commitMessage;
 
   const commitMessageValues: string[] = createCommitMessageValues(
     releaseGroups,
     releaseGroupToFilteredProjects,
     projectsVersionData,
-    userCommitMessage
+    commitMessage
   );
 
   // Resolve any git tags as early as possible so that we can hard error in case of any duplicates before reaching the actual git command

--- a/packages/nx/src/command-line/release/command-object.ts
+++ b/packages/nx/src/command-line/release/command-object.ts
@@ -183,11 +183,10 @@ const versionCommand: CommandModule<NxReleaseArgs, VersionOptions> = {
             'The optional prerelease identifier to apply to the version, in the case that specifier has been set to prerelease.',
           default: '',
         })
-        .option('stageChanges', {
+        .option('stage-changes', {
           type: 'boolean',
           describe:
-            'Whether or not to stage the changes made by this command, irrespective of the git config in nx.json related to automated commits. Useful when combining this command with changelog generation.',
-          default: false,
+            'Whether or not to stage the changes made by this command. Useful when combining this command with changelog generation.',
         })
     ),
   handler: (args) =>

--- a/packages/nx/src/command-line/release/config/config.spec.ts
+++ b/packages/nx/src/command-line/release/config/config.spec.ts
@@ -54,7 +54,7 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -75,7 +75,7 @@ describe('createNxReleaseConfig()', () => {
             "git": {
               "commit": false,
               "commitArgs": "",
-              "commitMessage": "",
+              "commitMessage": "chore(release): publish {version}",
               "tag": false,
               "tagArgs": "",
               "tagMessage": "",
@@ -104,7 +104,8 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
+                "stageChanges": true,
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -124,7 +125,7 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -145,7 +146,7 @@ describe('createNxReleaseConfig()', () => {
             "git": {
               "commit": false,
               "commitArgs": "",
-              "commitMessage": "",
+              "commitMessage": "chore(release): publish {version}",
               "tag": false,
               "tagArgs": "",
               "tagMessage": "",
@@ -174,7 +175,8 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
+                "stageChanges": true,
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -197,7 +199,7 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -218,7 +220,7 @@ describe('createNxReleaseConfig()', () => {
             "git": {
               "commit": false,
               "commitArgs": "",
-              "commitMessage": "",
+              "commitMessage": "chore(release): publish {version}",
               "tag": false,
               "tagArgs": "",
               "tagMessage": "",
@@ -247,7 +249,8 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
+                "stageChanges": true,
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -286,7 +289,7 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -307,7 +310,7 @@ describe('createNxReleaseConfig()', () => {
             "git": {
               "commit": false,
               "commitArgs": "",
-              "commitMessage": "",
+              "commitMessage": "chore(release): publish {version}",
               "tag": false,
               "tagArgs": "",
               "tagMessage": "",
@@ -336,7 +339,8 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
+                "stageChanges": true,
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -365,7 +369,7 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -386,7 +390,7 @@ describe('createNxReleaseConfig()', () => {
             "git": {
               "commit": false,
               "commitArgs": "",
-              "commitMessage": "",
+              "commitMessage": "chore(release): publish {version}",
               "tag": false,
               "tagArgs": "",
               "tagMessage": "",
@@ -413,7 +417,8 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
+                "stageChanges": true,
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -440,7 +445,7 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -461,7 +466,7 @@ describe('createNxReleaseConfig()', () => {
             "git": {
               "commit": false,
               "commitArgs": "",
-              "commitMessage": "",
+              "commitMessage": "chore(release): publish {version}",
               "tag": false,
               "tagArgs": "",
               "tagMessage": "",
@@ -489,7 +494,8 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
+                "stageChanges": true,
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -528,7 +534,7 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -549,7 +555,7 @@ describe('createNxReleaseConfig()', () => {
             "git": {
               "commit": false,
               "commitArgs": "",
-              "commitMessage": "",
+              "commitMessage": "chore(release): publish {version}",
               "tag": false,
               "tagArgs": "",
               "tagMessage": "",
@@ -590,7 +596,8 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
+                "stageChanges": true,
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -618,7 +625,7 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -639,7 +646,7 @@ describe('createNxReleaseConfig()', () => {
             "git": {
               "commit": false,
               "commitArgs": "",
-              "commitMessage": "",
+              "commitMessage": "chore(release): publish {version}",
               "tag": false,
               "tagArgs": "",
               "tagMessage": "",
@@ -676,7 +683,8 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
+                "stageChanges": true,
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -706,7 +714,7 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -727,7 +735,7 @@ describe('createNxReleaseConfig()', () => {
             "git": {
               "commit": false,
               "commitArgs": "",
-              "commitMessage": "",
+              "commitMessage": "chore(release): publish {version}",
               "tag": false,
               "tagArgs": "",
               "tagMessage": "",
@@ -760,7 +768,8 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
+                "stageChanges": true,
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -786,7 +795,7 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": true,
                 "commitArgs": "--no-verify",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -807,7 +816,7 @@ describe('createNxReleaseConfig()', () => {
             "git": {
               "commit": true,
               "commitArgs": "--no-verify",
-              "commitMessage": "",
+              "commitMessage": "chore(release): publish {version}",
               "tag": false,
               "tagArgs": "",
               "tagMessage": "",
@@ -836,7 +845,8 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": true,
                 "commitArgs": "--no-verify",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
+                "stageChanges": true,
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -868,7 +878,7 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -889,7 +899,7 @@ describe('createNxReleaseConfig()', () => {
             "git": {
               "commit": false,
               "commitArgs": "",
-              "commitMessage": "",
+              "commitMessage": "chore(release): publish {version}",
               "tag": false,
               "tagArgs": "",
               "tagMessage": "",
@@ -918,7 +928,8 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": true,
                 "commitArgs": "--no-verify",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
+                "stageChanges": true,
                 "tag": true,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -963,7 +974,7 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -984,7 +995,7 @@ describe('createNxReleaseConfig()', () => {
             "git": {
               "commit": false,
               "commitArgs": "",
-              "commitMessage": "",
+              "commitMessage": "chore(release): publish {version}",
               "tag": false,
               "tagArgs": "",
               "tagMessage": "",
@@ -1011,7 +1022,8 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
+                "stageChanges": true,
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -1036,7 +1048,7 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -1057,7 +1069,7 @@ describe('createNxReleaseConfig()', () => {
             "git": {
               "commit": false,
               "commitArgs": "",
-              "commitMessage": "",
+              "commitMessage": "chore(release): publish {version}",
               "tag": false,
               "tagArgs": "",
               "tagMessage": "",
@@ -1086,7 +1098,8 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
+                "stageChanges": true,
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -1121,7 +1134,7 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -1142,7 +1155,7 @@ describe('createNxReleaseConfig()', () => {
             "git": {
               "commit": false,
               "commitArgs": "",
-              "commitMessage": "",
+              "commitMessage": "chore(release): publish {version}",
               "tag": false,
               "tagArgs": "",
               "tagMessage": "",
@@ -1182,7 +1195,8 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
+                "stageChanges": true,
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -1210,7 +1224,7 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -1221,7 +1235,7 @@ describe('createNxReleaseConfig()', () => {
             "git": {
               "commit": false,
               "commitArgs": "",
-              "commitMessage": "",
+              "commitMessage": "chore(release): publish {version}",
               "tag": false,
               "tagArgs": "",
               "tagMessage": "",
@@ -1250,7 +1264,8 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
+                "stageChanges": true,
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -1286,7 +1301,7 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -1317,7 +1332,7 @@ describe('createNxReleaseConfig()', () => {
             "git": {
               "commit": false,
               "commitArgs": "",
-              "commitMessage": "",
+              "commitMessage": "chore(release): publish {version}",
               "tag": false,
               "tagArgs": "",
               "tagMessage": "",
@@ -1356,7 +1371,8 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
+                "stageChanges": true,
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -1382,7 +1398,7 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -1413,7 +1429,7 @@ describe('createNxReleaseConfig()', () => {
             "git": {
               "commit": false,
               "commitArgs": "",
-              "commitMessage": "",
+              "commitMessage": "chore(release): publish {version}",
               "tag": false,
               "tagArgs": "",
               "tagMessage": "",
@@ -1452,7 +1468,8 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
+                "stageChanges": true,
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -1506,7 +1523,7 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -1537,7 +1554,7 @@ describe('createNxReleaseConfig()', () => {
             "git": {
               "commit": false,
               "commitArgs": "",
-              "commitMessage": "",
+              "commitMessage": "chore(release): publish {version}",
               "tag": false,
               "tagArgs": "",
               "tagMessage": "",
@@ -1608,7 +1625,8 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
+                "stageChanges": true,
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -1649,7 +1667,7 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -1680,7 +1698,7 @@ describe('createNxReleaseConfig()', () => {
             "git": {
               "commit": false,
               "commitArgs": "",
-              "commitMessage": "",
+              "commitMessage": "chore(release): publish {version}",
               "tag": false,
               "tagArgs": "",
               "tagMessage": "",
@@ -1739,7 +1757,8 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
+                "stageChanges": true,
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -2034,7 +2053,7 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",
@@ -2055,7 +2074,7 @@ describe('createNxReleaseConfig()', () => {
             "git": {
               "commit": false,
               "commitArgs": "",
-              "commitMessage": "",
+              "commitMessage": "chore(release): publish {version}",
               "tag": false,
               "tagArgs": "",
               "tagMessage": "",
@@ -2095,7 +2114,8 @@ describe('createNxReleaseConfig()', () => {
               "git": {
                 "commit": false,
                 "commitArgs": "",
-                "commitMessage": "",
+                "commitMessage": "chore(release): publish {version}",
+                "stageChanges": true,
                 "tag": false,
                 "tagArgs": "",
                 "tagMessage": "",

--- a/packages/nx/src/command-line/release/config/config.ts
+++ b/packages/nx/src/command-line/release/config/config.ts
@@ -99,11 +99,20 @@ export async function createNxReleaseConfig(
 
   const gitDefaults = {
     commit: false,
-    commitMessage: '',
+    commitMessage: 'chore(release): publish {version}',
     commitArgs: '',
     tag: false,
     tagMessage: '',
     tagArgs: '',
+  };
+  const versionGitDefaults: NxReleaseConfig['version']['git'] = {
+    ...gitDefaults,
+    stageChanges: true,
+  };
+  const changelogGitDefaults = {
+    ...gitDefaults,
+    commit: true,
+    tag: true,
   };
 
   const defaultFixedReleaseTagPattern = 'v{version}';
@@ -117,12 +126,12 @@ export async function createNxReleaseConfig(
     projectsRelationship: workspaceProjectsRelationship,
     git: gitDefaults,
     version: {
-      git: gitDefaults,
+      git: versionGitDefaults,
       generator: '@nx/js:release-version',
       generatorOptions: {},
     },
     changelog: {
-      git: gitDefaults,
+      git: changelogGitDefaults,
       workspaceChangelog: {
         createRelease: false,
         entryWhenNoChanges:

--- a/packages/nx/src/command-line/release/config/filter-release-groups.spec.ts
+++ b/packages/nx/src/command-line/release/config/filter-release-groups.spec.ts
@@ -12,10 +12,10 @@ describe('filterReleaseGroups()', () => {
       groups: {},
       changelog: {
         git: {
-          commit: false,
+          commit: true,
           commitMessage: '',
           commitArgs: '',
-          tag: false,
+          tag: true,
           tagMessage: '',
           tagArgs: '',
         },
@@ -26,6 +26,7 @@ describe('filterReleaseGroups()', () => {
         generator: '',
         generatorOptions: {},
         git: {
+          stageChanges: true,
           commit: false,
           commitMessage: '',
           commitArgs: '',

--- a/packages/nx/src/command-line/release/release.ts
+++ b/packages/nx/src/command-line/release/release.ts
@@ -56,8 +56,11 @@ export async function release(
 
   const versionResult: NxReleaseVersionResult = await releaseVersion({
     ...args,
-    // if enabled, committing and tagging will be handled by the changelog
-    // command, so we should only stage the changes in the version command
+    // We should stage the changes in the version command only if
+    // the changelog command will actually be committing the files.
+    // Since git.commit defaults to true for the changelog command, we
+    // only need to disable staging if git.commit is explicitly set to false.
+    stageChanges: nxReleaseConfig.git?.commit ?? true,
     gitCommit: false,
     gitTag: false,
   });

--- a/packages/nx/src/command-line/release/release.ts
+++ b/packages/nx/src/command-line/release/release.ts
@@ -58,7 +58,6 @@ export async function release(
     ...args,
     // if enabled, committing and tagging will be handled by the changelog
     // command, so we should only stage the changes in the version command
-    stageChanges: nxReleaseConfig.git?.commit,
     gitCommit: false,
     gitTag: false,
   });

--- a/packages/nx/src/command-line/release/utils/shared.ts
+++ b/packages/nx/src/command-line/release/utils/shared.ts
@@ -76,12 +76,9 @@ export function createCommitMessageValues(
   releaseGroups: ReleaseGroupWithName[],
   releaseGroupToFilteredProjects: Map<ReleaseGroupWithName, Set<string>>,
   versionData: VersionData,
-  userCommitMessage?: string
+  commitMessage: string
 ): string[] {
-  const defaultCommitMessage = `chore(release): publish {version}`;
-  const commitMessageValues = userCommitMessage
-    ? [userCommitMessage]
-    : [defaultCommitMessage];
+  const commitMessageValues = [commitMessage];
 
   if (releaseGroups.length === 0) {
     return commitMessageValues;
@@ -115,7 +112,7 @@ export function createCommitMessageValues(
   if (
     releaseGroups.length === 1 &&
     releaseGroups[0].projectsRelationship === 'independent' &&
-    userCommitMessage?.includes('{projectName}')
+    commitMessage?.includes('{projectName}')
   ) {
     const releaseGroup = releaseGroups[0];
     const releaseGroupProjectNames = Array.from(

--- a/packages/nx/src/command-line/release/utils/shared.ts
+++ b/packages/nx/src/command-line/release/utils/shared.ts
@@ -112,7 +112,7 @@ export function createCommitMessageValues(
   if (
     releaseGroups.length === 1 &&
     releaseGroups[0].projectsRelationship === 'independent' &&
-    commitMessage?.includes('{projectName}')
+    commitMessage.includes('{projectName}')
   ) {
     const releaseGroup = releaseGroups[0];
     const releaseGroupProjectNames = Array.from(

--- a/packages/nx/src/command-line/release/version.ts
+++ b/packages/nx/src/command-line/release/version.ts
@@ -180,15 +180,6 @@ export async function releaseVersion(
       };
     }
 
-    if (args.stageChanges ?? nxReleaseConfig.version.git.stageChanges) {
-      output.logSingleLine(`Staging changed files with git`);
-      await gitAdd({
-        changedFiles,
-        dryRun: args.dryRun,
-        verbose: args.verbose,
-      });
-    }
-
     if (args.gitCommit ?? nxReleaseConfig.version.git.commit) {
       await commitChanges(
         tree.listChanges().map((f) => f.path),
@@ -202,6 +193,13 @@ export async function releaseVersion(
         ),
         args.gitCommitArgs || nxReleaseConfig.version.git.commitArgs
       );
+    } else if (args.stageChanges ?? nxReleaseConfig.version.git.stageChanges) {
+      output.logSingleLine(`Staging changed files with git`);
+      await gitAdd({
+        changedFiles,
+        dryRun: args.dryRun,
+        verbose: args.verbose,
+      });
     }
 
     if (args.gitTag ?? nxReleaseConfig.version.git.tag) {
@@ -292,15 +290,6 @@ export async function releaseVersion(
     };
   }
 
-  if (args.stageChanges ?? nxReleaseConfig.version.git.stageChanges) {
-    output.logSingleLine(`Staging changed files with git`);
-    await gitAdd({
-      changedFiles,
-      dryRun: args.dryRun,
-      verbose: args.verbose,
-    });
-  }
-
   if (args.gitCommit ?? nxReleaseConfig.version.git.commit) {
     await commitChanges(
       changedFiles,
@@ -314,6 +303,13 @@ export async function releaseVersion(
       ),
       args.gitCommitArgs || nxReleaseConfig.version.git.commitArgs
     );
+  } else if (args.stageChanges ?? nxReleaseConfig.version.git.stageChanges) {
+    output.logSingleLine(`Staging changed files with git`);
+    await gitAdd({
+      changedFiles,
+      dryRun: args.dryRun,
+      verbose: args.verbose,
+    });
   }
 
   if (args.gitTag ?? nxReleaseConfig.version.git.tag) {

--- a/packages/nx/src/command-line/release/version.ts
+++ b/packages/nx/src/command-line/release/version.ts
@@ -120,7 +120,7 @@ export async function releaseVersion(
   const tree = new FsTree(workspaceRoot, args.verbose);
 
   const versionData: VersionData = {};
-  const userCommitMessage: string | undefined =
+  const commitMessage: string | undefined =
     args.gitCommitMessage || nxReleaseConfig.version.git.commitMessage;
 
   if (args.projects?.length) {
@@ -180,10 +180,8 @@ export async function releaseVersion(
       };
     }
 
-    if (args.stageChanges) {
-      output.logSingleLine(
-        `Staging changed files with git because --stage-changes was set`
-      );
+    if (args.stageChanges ?? nxReleaseConfig.version.git.stageChanges) {
+      output.logSingleLine(`Staging changed files with git`);
       await gitAdd({
         changedFiles,
         dryRun: args.dryRun,
@@ -200,7 +198,7 @@ export async function releaseVersion(
           releaseGroups,
           releaseGroupToFilteredProjects,
           versionData,
-          userCommitMessage
+          commitMessage
         ),
         args.gitCommitArgs || nxReleaseConfig.version.git.commitArgs
       );
@@ -294,10 +292,8 @@ export async function releaseVersion(
     };
   }
 
-  if (args.stageChanges) {
-    output.logSingleLine(
-      `Staging changed files with git because --stage-changes was set`
-    );
+  if (args.stageChanges ?? nxReleaseConfig.version.git.stageChanges) {
+    output.logSingleLine(`Staging changed files with git`);
     await gitAdd({
       changedFiles,
       dryRun: args.dryRun,
@@ -314,7 +310,7 @@ export async function releaseVersion(
         releaseGroups,
         releaseGroupToFilteredProjects,
         versionData,
-        userCommitMessage
+        commitMessage
       ),
       args.gitCommitArgs || nxReleaseConfig.version.git.commitArgs
     );

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -219,7 +219,12 @@ interface NxReleaseConfiguration {
     /**
      * Enable or override configuration for git operations as part of the version subcommand
      */
-    git?: NxReleaseGitConfiguration;
+    git?: NxReleaseGitConfiguration & {
+      /**
+       * Whether or not to stage the changes made by this command. Useful when combining the version command with changelog generation.
+       */
+      stageChanges?: boolean;
+    };
   };
   /**
    * Optionally override the git/release tag pattern to use. This field is the source of truth

--- a/packages/nx/src/migrations/update-17-3-0/nx-release-git-operations-explicit-opt-out.spec.ts
+++ b/packages/nx/src/migrations/update-17-3-0/nx-release-git-operations-explicit-opt-out.spec.ts
@@ -1,0 +1,306 @@
+import { NxJsonConfiguration } from '../../config/nx-json';
+import { createTree } from '../../generators/testing-utils/create-tree';
+import { createTreeWithEmptyWorkspace } from '../../generators/testing-utils/create-tree-with-empty-workspace';
+import { readJson, writeJson } from '../../generators/utils/json';
+import nxReleaseGitOperationsExplicitOptOut from './nx-release-git-operations-explicit-opt-out';
+
+describe('nxReleaseGitOperationsExplicitOptOut', () => {
+  let tree;
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should not error if nx.json is not present', () => {
+    nxReleaseGitOperationsExplicitOptOut(createTree());
+  });
+
+  it('should do nothing if release is not configured', () => {
+    writeJson(tree, 'nx.json', {});
+
+    nxReleaseGitOperationsExplicitOptOut(tree);
+
+    const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+    expect(nxJson.release).toBeUndefined();
+  });
+
+  it('should set commit and tag to false if changelog.git.commit is not defined', () => {
+    writeJson(tree, 'nx.json', {
+      release: {
+        version: {
+          git: {
+            // override properties in version.git should be ignored
+            commit: true,
+            tag: true,
+          },
+        },
+      },
+    });
+
+    nxReleaseGitOperationsExplicitOptOut(tree);
+
+    const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+    expect(nxJson.release).toEqual({
+      git: {
+        commit: false,
+        tag: false,
+      },
+      version: {
+        git: {
+          commit: true,
+          tag: true,
+        },
+      },
+    });
+  });
+
+  it('should not set commit and tag to false if changelog.git.commit is not defined but global git config is defined', () => {
+    writeJson(tree, 'nx.json', {
+      release: {
+        git: {
+          commit: false,
+          tag: true,
+        },
+        version: {
+          git: {
+            // override properties in version.git should be ignored
+            commit: true,
+            tag: true,
+          },
+        },
+      },
+    });
+
+    nxReleaseGitOperationsExplicitOptOut(tree);
+
+    const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+    expect(nxJson.release).toEqual({
+      git: {
+        commit: false,
+        tag: true,
+      },
+      version: {
+        git: {
+          commit: true,
+          tag: true,
+        },
+      },
+    });
+  });
+
+  describe('consolidation', () => {
+    it('should consolidate version.git and changelog.git if they both exist and have matching true values', () => {
+      writeJson<NxJsonConfiguration>(tree, 'nx.json', {
+        release: {
+          git: {
+            commit: false,
+            tag: false,
+          },
+          version: {
+            git: {
+              commit: true,
+              tag: true,
+            },
+          },
+          changelog: {
+            git: {
+              commit: true,
+              tag: true,
+            },
+          },
+        },
+      });
+
+      nxReleaseGitOperationsExplicitOptOut(tree);
+
+      const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+      expect(nxJson.release).toEqual({
+        git: {
+          commit: true,
+          tag: true,
+        },
+      });
+    });
+
+    it('should consolidate version.git and changelog.git if they both exist and have matching false values', () => {
+      writeJson<NxJsonConfiguration>(tree, 'nx.json', {
+        release: {
+          git: {
+            commit: true,
+            tag: true,
+          },
+          version: {
+            git: {
+              commit: false,
+              tag: false,
+            },
+          },
+          changelog: {
+            git: {
+              commit: false,
+              tag: false,
+            },
+          },
+        },
+      });
+
+      nxReleaseGitOperationsExplicitOptOut(tree);
+
+      const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+      expect(nxJson.release).toEqual({
+        git: {
+          commit: false,
+          tag: false,
+        },
+      });
+    });
+
+    it('should consolidate commit property but not change other properties', () => {
+      writeJson<NxJsonConfiguration>(tree, 'nx.json', {
+        release: {
+          version: {
+            git: {
+              commit: true,
+              tag: false,
+              commitMessage: 'Version commit message',
+            },
+          },
+          changelog: {
+            git: {
+              commit: true,
+              tag: true,
+              tagMessage: 'Version tag message',
+            },
+          },
+        },
+      });
+
+      nxReleaseGitOperationsExplicitOptOut(tree);
+
+      const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+      expect(nxJson.release).toEqual({
+        git: {
+          commit: true,
+        },
+        version: {
+          git: {
+            tag: false,
+            commitMessage: 'Version commit message',
+          },
+        },
+        changelog: {
+          git: {
+            tag: true,
+            tagMessage: 'Version tag message',
+          },
+        },
+      });
+    });
+
+    it('should consolidate tag property but not change other properties', () => {
+      writeJson<NxJsonConfiguration>(tree, 'nx.json', {
+        release: {
+          version: {
+            git: {
+              commit: false,
+              tag: true,
+              commitMessage: 'Version commit message',
+            },
+          },
+          changelog: {
+            git: {
+              commit: true,
+              tag: true,
+              tagMessage: 'Version tag message',
+            },
+          },
+        },
+      });
+
+      nxReleaseGitOperationsExplicitOptOut(tree);
+
+      const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+      expect(nxJson.release).toEqual({
+        git: {
+          tag: true,
+        },
+        version: {
+          git: {
+            commit: false,
+            commitMessage: 'Version commit message',
+          },
+        },
+        changelog: {
+          git: {
+            commit: true,
+            tagMessage: 'Version tag message',
+          },
+        },
+      });
+    });
+
+    it('should remove empty version and changelog properties', () => {
+      writeJson<NxJsonConfiguration>(tree, 'nx.json', {
+        release: {
+          git: {
+            commit: true,
+            tag: true,
+          },
+          version: {
+            git: {},
+          },
+          changelog: {
+            git: {},
+          },
+        },
+      });
+
+      nxReleaseGitOperationsExplicitOptOut(tree);
+
+      const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+      expect(nxJson.release).toEqual({
+        git: {
+          commit: true,
+          tag: true,
+        },
+      });
+    });
+
+    it('should remove empty global git property', () => {
+      writeJson<NxJsonConfiguration>(tree, 'nx.json', {
+        release: {
+          git: {},
+          version: {
+            git: {
+              commit: false,
+              tag: false,
+            },
+          },
+          changelog: {
+            git: {
+              commit: true,
+              tag: true,
+            },
+          },
+        },
+      });
+
+      nxReleaseGitOperationsExplicitOptOut(tree);
+
+      const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+      expect(nxJson.release).toEqual({
+        version: {
+          git: {
+            commit: false,
+            tag: false,
+          },
+        },
+        changelog: {
+          git: {
+            commit: true,
+            tag: true,
+          },
+        },
+      });
+    });
+  });
+});

--- a/packages/nx/src/migrations/update-17-3-0/nx-release-git-operations-explicit-opt-out.spec.ts
+++ b/packages/nx/src/migrations/update-17-3-0/nx-release-git-operations-explicit-opt-out.spec.ts
@@ -87,6 +87,112 @@ describe('nxReleaseGitOperationsExplicitOptOut', () => {
     });
   });
 
+  describe('stageChanges', () => {
+    it('should set version.stageChanges to false if committing is not explicitly enabled', () => {
+      writeJson(tree, 'nx.json', {
+        release: {},
+      });
+
+      nxReleaseGitOperationsExplicitOptOut(tree);
+
+      const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+      expect(nxJson.release).toEqual({
+        git: {
+          commit: false,
+          tag: false,
+        },
+        version: {
+          git: {
+            stageChanges: false,
+          },
+        },
+      });
+    });
+
+    it('should not set version.stageChanges if committing is enabled globally', () => {
+      writeJson(tree, 'nx.json', {
+        release: {
+          git: {
+            commit: true,
+            tag: false,
+          },
+        },
+      });
+
+      nxReleaseGitOperationsExplicitOptOut(tree);
+
+      const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+      expect(nxJson.release).toEqual({
+        git: {
+          commit: true,
+          tag: false,
+        },
+      });
+    });
+
+    it('should not set version.stageChanges if committing is enabled in version', () => {
+      writeJson(tree, 'nx.json', {
+        release: {
+          git: {
+            commit: false,
+            tag: false,
+          },
+          version: {
+            git: {
+              commit: true,
+            },
+          },
+        },
+      });
+
+      nxReleaseGitOperationsExplicitOptOut(tree);
+
+      const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+      expect(nxJson.release).toEqual({
+        git: {
+          commit: false,
+          tag: false,
+        },
+        version: {
+          git: {
+            commit: true,
+          },
+        },
+      });
+    });
+
+    it('should not set version.stageChanges if committing is enabled in changelog', () => {
+      writeJson(tree, 'nx.json', {
+        release: {
+          git: {
+            commit: false,
+            tag: false,
+          },
+          changelog: {
+            git: {
+              commit: true,
+            },
+          },
+        },
+      });
+
+      nxReleaseGitOperationsExplicitOptOut(tree);
+
+      const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+      expect(nxJson.release).toEqual({
+        git: {
+          commit: false,
+          tag: false,
+        },
+        changelog: {
+          git: {
+            commit: true,
+          },
+        },
+      });
+    });
+  });
+
   describe('consolidation', () => {
     it('should consolidate version.git and changelog.git if they both exist and have matching true values', () => {
       writeJson<NxJsonConfiguration>(tree, 'nx.json', {
@@ -150,6 +256,11 @@ describe('nxReleaseGitOperationsExplicitOptOut', () => {
         git: {
           commit: false,
           tag: false,
+        },
+        version: {
+          git: {
+            stageChanges: false,
+          },
         },
       });
     });

--- a/packages/nx/src/migrations/update-17-3-0/nx-release-git-operations-explicit-opt-out.ts
+++ b/packages/nx/src/migrations/update-17-3-0/nx-release-git-operations-explicit-opt-out.ts
@@ -48,6 +48,21 @@ export default function nxReleaseGitOperationsExplicitOptOut(tree: Tree) {
       delete nxJson.release.changelog.git.tag;
     }
 
+    // Opt out of staging changes in version if committing is not configured
+    if (
+      !nxJson.release.git.commit &&
+      !nxJson.release.version?.git?.commit &&
+      !nxJson.release.changelog?.git?.commit
+    ) {
+      nxJson.release.version = {
+        ...nxJson.release.version,
+        git: {
+          ...nxJson.release.version?.git,
+          stageChanges: false,
+        },
+      };
+    }
+
     // Ensure that we don't leave any empty object properties in their config
     removeIfEmpty(nxJson.release.version, 'git');
     removeIfEmpty(nxJson.release.changelog, 'git');

--- a/packages/nx/src/migrations/update-17-3-0/nx-release-git-operations-explicit-opt-out.ts
+++ b/packages/nx/src/migrations/update-17-3-0/nx-release-git-operations-explicit-opt-out.ts
@@ -29,27 +29,12 @@ export default function nxReleaseGitOperationsExplicitOptOut(tree: Tree) {
       nxJson.release.git.tag = false;
     }
 
-    // Consolidate version.git and changelog.git if they have matching values
+    // Opt out of staging changes in version only if using
+    // granular git config AND if committing is not enabled.
+    // We don't want to add granular git config if it doesn't already exist,
+    // because the nx release meta command is incompatible with it.
     if (
-      nxJson.release.version?.git?.commit !== undefined &&
-      nxJson.release.version?.git?.commit ===
-        nxJson.release.changelog?.git?.commit
-    ) {
-      nxJson.release.git.commit = nxJson.release.version.git.commit;
-      delete nxJson.release.version.git.commit;
-      delete nxJson.release.changelog.git.commit;
-    }
-    if (
-      nxJson.release.version?.git?.tag !== undefined &&
-      nxJson.release.version?.git?.tag === nxJson.release.changelog?.git?.tag
-    ) {
-      nxJson.release.git.tag = nxJson.release.version.git.tag;
-      delete nxJson.release.version.git.tag;
-      delete nxJson.release.changelog.git.tag;
-    }
-
-    // Opt out of staging changes in version if committing is not configured
-    if (
+      (nxJson.release.version?.git || nxJson.release.changelog?.git) &&
       !nxJson.release.git.commit &&
       !nxJson.release.version?.git?.commit &&
       !nxJson.release.changelog?.git?.commit
@@ -64,21 +49,10 @@ export default function nxReleaseGitOperationsExplicitOptOut(tree: Tree) {
     }
 
     // Ensure that we don't leave any empty object properties in their config
-    removeIfEmpty(nxJson.release.version, 'git');
-    removeIfEmpty(nxJson.release.changelog, 'git');
-    removeIfEmpty(nxJson.release, 'version');
-    removeIfEmpty(nxJson.release, 'changelog');
-    removeIfEmpty(nxJson.release, 'git');
+    if (Object.keys(nxJson.release.git).length === 0) {
+      delete nxJson.release.git;
+    }
 
     return nxJson;
   });
-}
-
-function removeIfEmpty(obj: unknown, key: string) {
-  if (!obj) {
-    return;
-  }
-  if (obj[key] && Object.keys(obj[key]).length === 0) {
-    delete obj[key];
-  }
 }

--- a/packages/nx/src/migrations/update-17-3-0/nx-release-git-operations-explicit-opt-out.ts
+++ b/packages/nx/src/migrations/update-17-3-0/nx-release-git-operations-explicit-opt-out.ts
@@ -1,0 +1,69 @@
+import { NxJsonConfiguration } from '../../config/nx-json';
+import { Tree } from '../../generators/tree';
+import { updateJson } from '../../generators/utils/json';
+
+export default function nxReleaseGitOperationsExplicitOptOut(tree: Tree) {
+  if (!tree.exists('nx.json')) {
+    return;
+  }
+
+  updateJson<NxJsonConfiguration>(tree, 'nx.json', (nxJson) => {
+    if (!nxJson.release) {
+      return nxJson;
+    }
+
+    nxJson.release.git = nxJson.release.git ?? {};
+
+    // Explicitly opt out of git operations if not defined
+    // to preserve the old behavior
+    if (
+      nxJson.release.git.commit === undefined &&
+      nxJson.release.changelog?.git?.commit === undefined
+    ) {
+      nxJson.release.git.commit = false;
+    }
+    if (
+      nxJson.release.git.tag === undefined &&
+      nxJson.release.changelog?.git?.tag === undefined
+    ) {
+      nxJson.release.git.tag = false;
+    }
+
+    // Consolidate version.git and changelog.git if they have matching values
+    if (
+      nxJson.release.version?.git?.commit !== undefined &&
+      nxJson.release.version?.git?.commit ===
+        nxJson.release.changelog?.git?.commit
+    ) {
+      nxJson.release.git.commit = nxJson.release.version.git.commit;
+      delete nxJson.release.version.git.commit;
+      delete nxJson.release.changelog.git.commit;
+    }
+    if (
+      nxJson.release.version?.git?.tag !== undefined &&
+      nxJson.release.version?.git?.tag === nxJson.release.changelog?.git?.tag
+    ) {
+      nxJson.release.git.tag = nxJson.release.version.git.tag;
+      delete nxJson.release.version.git.tag;
+      delete nxJson.release.changelog.git.tag;
+    }
+
+    // Ensure that we don't leave any empty object properties in their config
+    removeIfEmpty(nxJson.release.version, 'git');
+    removeIfEmpty(nxJson.release.changelog, 'git');
+    removeIfEmpty(nxJson.release, 'version');
+    removeIfEmpty(nxJson.release, 'changelog');
+    removeIfEmpty(nxJson.release, 'git');
+
+    return nxJson;
+  });
+}
+
+function removeIfEmpty(obj: unknown, key: string) {
+  if (!obj) {
+    return;
+  }
+  if (obj[key] && Object.keys(obj[key]).length === 0) {
+    delete obj[key];
+  }
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
- `nx release version` will not stage changes unless the `--stageChanges` argument is passed
- There is no way to enable staging changes on the version command via config
- `nx release changelog` will not commit and tag unless explicitly enabled in config or via cli args
- `nx release` will not commit and tag unless explicitly enabled in config or via cli args

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
- `nx release version` stages changes by default, which can be overridden in config or with `--no-stage-changes`
- `nx release changelog` commits and tags by default, unless overridden
- `nx release` commits and tags by default, unless overridden