### PR TITLE
docs(core): improve run commands in parallel section

### DIFF
--- a/docs/shared/monorepo-ci-github-actions.md
+++ b/docs/shared/monorepo-ci-github-actions.md
@@ -174,7 +174,7 @@ jobs:
           }
 
           # list of commands to be run on main has env flag NX_CLOUD_DISTRIBUTED_EXECUTION set to false
-          NX_CLOUD_DISTRIBUTED_EXECUTION=false npx nx-cloud record -- run_command "npx nx format:check"
+          run_command "NX_CLOUD_DISTRIBUTED_EXECUTION=false npx nx-cloud record -- npx nx format:check"
 
           # list of commands to be run on agents
           run_command "npx nx affected -t lint,test,build --parallel=3"
@@ -186,7 +186,7 @@ jobs:
             fi
           done
 
-          exit 0 # exist with success status if a all processes complete successfully
+          exit 0 # exits with success status if a all processes complete successfully
 
   agents:
     name: Agent ${{ matrix.agent }}

--- a/docs/shared/monorepo-ci-github-actions.md
+++ b/docs/shared/monorepo-ci-github-actions.md
@@ -163,22 +163,30 @@ jobs:
 
       - name: Run commands in parallel
         run: |
+          # initialize an array to store process IDs (PIDs)
           pids=()
+
+          # function to run commands and store the PID
+          function run_command() {
+            local command=$1
+            $command &  # run the command in the background
+            pids+=($!)  # store the PID of the background process
+          }
+
           # list of commands to be run on main has env flag NX_CLOUD_DISTRIBUTED_EXECUTION set to false
-          NX_CLOUD_DISTRIBUTED_EXECUTION=false npx nx-cloud record -- npx nx format:check & pids+=($!)
+          NX_CLOUD_DISTRIBUTED_EXECUTION=false npx nx-cloud record -- run_command "npx nx format:check"
 
           # list of commands to be run on agents
-          npx nx affected -t lint,test,build --parallel=3 & 
-          pids+=($!)
+          run_command "npx nx affected -t lint,test,build --parallel=3"
 
-          # run all commands in parallel and bail if one of them fails
+          # wait for all background processes to finish
           for pid in ${pids[*]}; do
             if ! wait $pid; then
-              exit 1
+              exit 1  # exit with an error status if any process fails
             fi
           done
 
-          exit 0
+          exit 0 # exist with success status if a all processes complete successfully
 
   agents:
     name: Agent ${{ matrix.agent }}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

Execution of background processes involves the repetitive task of storing PIDs and running commands in the background.

## Expected Behavior

Improved doc section about running background processes in parallel, this can be useful if we want to run multiple commands with different arguments, for instance:

```bash
run_command "npx nx affected -t lint,test --parallel=3"
run_command "npx nx affected -t build --parallel=1"
```

If you like this change I can also raise a PR to modify the actual `circleci/config.yml`.