### PR TITLE
chore(repo): use prebuilt base image tag for nx agent

### DIFF
--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -1,6 +1,7 @@
 launch-templates:
   linux-medium:
     resource-class: 'docker_linux_amd64/medium+'
+    image: 'ubuntu22.04-node20.9-withDind-v1'
     env:
       GIT_AUTHOR_EMAIL: test@test.com
       GIT_AUTHOR_NAME: Test


### PR DESCRIPTION
Uses the new pre-built Nx Agents built images:

https://linear.app/nxdev/issue/INF-540/create-default-executor-images-and-allow-users-to-provide-their-own