### PR TITLE
feat(core): add target defaults in configuration generators rather th…

### DIFF
--- a/packages/angular/src/generators/application/lib/create-project.ts
+++ b/packages/angular/src/generators/application/lib/create-project.ts
@@ -1,8 +1,8 @@
-import type { Tree } from '@nx/devkit';
-import { addProjectConfiguration } from '@nx/devkit';
+import { addProjectConfiguration, Tree } from '@nx/devkit';
 import type { AngularProjectConfiguration } from '../../../utils/types';
 import { getInstalledAngularVersionInfo } from '../../utils/version-utils';
 import type { NormalizedSchema } from './normalized-schema';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/add-build-target-defaults';
 
 export function createProject(tree: Tree, options: NormalizedSchema) {
   const { major: angularMajorVersion } = getInstalledAngularVersionInfo(tree);
@@ -19,6 +19,8 @@ export function createProject(tree: Tree, options: NormalizedSchema) {
     angularMajorVersion >= 17 && options.bundler === 'esbuild'
       ? 'browser'
       : 'main';
+
+  addBuildTargetDefaults(tree, buildExecutor);
 
   let budgets = undefined;
   if (options.bundler === 'webpack' || angularMajorVersion >= 17) {

--- a/packages/devkit/src/generators/add-build-target-defaults.ts
+++ b/packages/devkit/src/generators/add-build-target-defaults.ts
@@ -1,0 +1,22 @@
+import type { Tree } from 'nx/src/devkit-exports';
+import { requireNx } from '../../nx';
+
+const { readNxJson, updateNxJson } = requireNx();
+
+export function addBuildTargetDefaults(
+  tree: Tree,
+  executorName: string,
+  buildTargetName = 'build'
+): void {
+  const nxJson = readNxJson(tree);
+  nxJson.targetDefaults ??= {};
+  nxJson.targetDefaults[executorName] ??= {
+    cache: true,
+    dependsOn: [`^${buildTargetName}`],
+    inputs:
+      nxJson.namedInputs && 'production' in nxJson.namedInputs
+        ? ['production', '^production']
+        : ['default', '^default'],
+  };
+  updateNxJson(tree, nxJson);
+}

--- a/packages/esbuild/src/generators/configuration/configuration.ts
+++ b/packages/esbuild/src/generators/configuration/configuration.ts
@@ -1,8 +1,8 @@
-import type { Tree } from '@nx/devkit';
 import {
   formatFiles,
   joinPathFragments,
   readProjectConfiguration,
+  Tree,
   updateProjectConfiguration,
   writeJson,
 } from '@nx/devkit';
@@ -12,6 +12,7 @@ import { getImportPath } from '@nx/js/src/utils/get-import-path';
 import { esbuildInitGenerator } from '../init/init';
 import { EsBuildExecutorOptions } from '../../executors/esbuild/schema';
 import { EsBuildProjectSchema } from './schema';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/add-build-target-defaults';
 
 export async function configurationGenerator(
   tree: Tree,
@@ -39,6 +40,7 @@ function checkForTargetConflicts(tree: Tree, options: EsBuildProjectSchema) {
 }
 
 function addBuildTarget(tree: Tree, options: EsBuildProjectSchema) {
+  addBuildTargetDefaults(tree, '@nx/esbuild:esbuild', options.buildTarget);
   const project = readProjectConfiguration(tree, options.project);
   const packageJsonPath = joinPathFragments(project.root, 'package.json');
 

--- a/packages/expo/src/generators/application/lib/add-project.ts
+++ b/packages/expo/src/generators/application/lib/add-project.ts
@@ -9,10 +9,15 @@ import {
 
 import { hasExpoPlugin } from '../../../utils/has-expo-plugin';
 import { NormalizedSchema } from './normalize-options';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/add-build-target-defaults';
 
 export function addProject(host: Tree, options: NormalizedSchema) {
   const nxJson = readNxJson(host);
   const hasPlugin = hasExpoPlugin(host);
+
+  if (!hasPlugin) {
+    addBuildTargetDefaults(host, '@nx/expo:build');
+  }
 
   const projectConfiguration: ProjectConfiguration = {
     root: options.appProjectRoot,

--- a/packages/expo/src/generators/library/library.ts
+++ b/packages/expo/src/generators/library/library.ts
@@ -32,6 +32,7 @@ import { NormalizedSchema, normalizeOptions } from './lib/normalize-options';
 import { Schema } from './schema';
 import { ensureDependencies } from '../../utils/ensure-dependencies';
 import { initRootBabelConfig } from '../../utils/init-root-babel-config';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/add-build-target-defaults';
 
 export async function expoLibraryGenerator(
   host: Tree,
@@ -143,6 +144,8 @@ async function addProject(
   });
 
   const external = ['react/jsx-runtime', 'react-native', 'react', 'react-dom'];
+
+  addBuildTargetDefaults(host, '@nx/rollup:rollup');
 
   project.targets.build = {
     executor: '@nx/rollup:rollup',

--- a/packages/js/src/generators/setup-build/generator.ts
+++ b/packages/js/src/generators/setup-build/generator.ts
@@ -12,6 +12,7 @@ import { addSwcConfig } from '../../utils/swc/add-swc-config';
 import { addSwcDependencies } from '../../utils/swc/add-swc-dependencies';
 import { nxVersion } from '../../utils/versions';
 import { SetupBuildGeneratorSchema } from './schema';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/add-build-target-defaults';
 
 export async function setupBuildGenerator(
   tree: Tree,
@@ -122,6 +123,8 @@ export async function setupBuildGenerator(
       break;
     }
     case 'tsc': {
+      addBuildTargetDefaults(tree, '@nx/js:tsc');
+
       const outputPath = joinPathFragments('dist', project.root);
       project.targets[buildTarget] = {
         executor: `@nx/js:tsc`,
@@ -137,6 +140,8 @@ export async function setupBuildGenerator(
       break;
     }
     case 'swc': {
+      addBuildTargetDefaults(tree, '@nx/js:swc');
+
       const outputPath = joinPathFragments('dist', project.root);
       project.targets[buildTarget] = {
         executor: `@nx/js:swc`,

--- a/packages/next/src/generators/application/lib/add-project.ts
+++ b/packages/next/src/generators/application/lib/add-project.ts
@@ -5,6 +5,7 @@ import {
   readNxJson,
   Tree,
 } from '@nx/devkit';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/add-build-target-defaults';
 
 export function addProject(host: Tree, options: NormalizedSchema) {
   const targets: Record<string, any> = {};
@@ -20,6 +21,8 @@ export function addProject(host: Tree, options: NormalizedSchema) {
   );
 
   if (!hasPlugin) {
+    addBuildTargetDefaults(host, '@nx/next:build');
+
     targets.build = {
       executor: '@nx/next:build',
       outputs: ['{options.outputPath}'],

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -47,6 +47,7 @@ import { initGenerator } from '../init/init';
 import { setupDockerGenerator } from '../setup-docker/setup-docker';
 import { Schema } from './schema';
 import { hasWebpackPlugin } from '../../utils/has-webpack-plugin';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/add-build-target-defaults';
 
 export interface NormalizedSchema extends Schema {
   appProjectRoot: string;
@@ -160,9 +161,11 @@ function addProject(tree: Tree, options: NormalizedSchema) {
   };
 
   if (options.bundler === 'esbuild') {
+    addBuildTargetDefaults(tree, '@nx/esbuild:esbuild');
     project.targets.build = getEsBuildConfig(project, options);
   } else if (options.bundler === 'webpack') {
     if (!hasWebpackPlugin(tree)) {
+      addBuildTargetDefaults(tree, `@nx/webpack:webpack`);
       project.targets.build = getWebpackBuildConfig(project, options);
     }
   }

--- a/packages/node/src/generators/library/library.ts
+++ b/packages/node/src/generators/library/library.ts
@@ -21,6 +21,7 @@ import { join } from 'path';
 import { tslibVersion, typesNodeVersion } from '../../utils/versions';
 import { initGenerator } from '../init/init';
 import { Schema } from './schema';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/add-build-target-defaults';
 
 export interface NormalizedSchema extends Schema {
   fileName: string;
@@ -164,6 +165,7 @@ function updateProject(tree: Tree, options: NormalizedSchema) {
   const rootProject = options.projectRoot === '.' || options.projectRoot === '';
 
   project.targets = project.targets || {};
+  addBuildTargetDefaults(tree, `@nx/js:${options.compiler}`);
   project.targets.build = {
     executor: `@nx/js:${options.compiler}`,
     outputs: ['{options.outputPath}'],

--- a/packages/remix/src/generators/application/application.impl.ts
+++ b/packages/remix/src/generators/application/application.impl.ts
@@ -37,6 +37,7 @@ import { NxRemixGeneratorSchema } from './schema';
 import { updateDependencies } from '../utils/update-dependencies';
 import initGenerator from '../init/init';
 import { initGenerator as jsInitGenerator } from '@nx/js';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/add-build-target-defaults';
 
 export default async function (tree: Tree, _options: NxRemixGeneratorSchema) {
   const options = await normalizeOptions(tree, _options);
@@ -44,6 +45,8 @@ export default async function (tree: Tree, _options: NxRemixGeneratorSchema) {
     await initGenerator(tree, { skipFormat: true }),
     await jsInitGenerator(tree, { skipFormat: true }),
   ];
+
+  addBuildTargetDefaults(tree, '@nx/remix:build');
 
   addProjectConfiguration(tree, options.projectName, {
     root: options.projectRoot,

--- a/packages/rollup/src/generators/configuration/configuration.ts
+++ b/packages/rollup/src/generators/configuration/configuration.ts
@@ -1,8 +1,9 @@
-import type { GeneratorCallback, Tree } from '@nx/devkit';
 import {
   formatFiles,
   joinPathFragments,
   readProjectConfiguration,
+  Tree,
+  GeneratorCallback,
   runTasksInSerial,
   updateProjectConfiguration,
   writeJson,
@@ -12,6 +13,7 @@ import { getImportPath } from '@nx/js/src/utils/get-import-path';
 import { rollupInitGenerator } from '../init/init';
 import { RollupExecutorOptions } from '../../executors/rollup/schema';
 import { RollupProjectSchema } from './schema';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/add-build-target-defaults';
 import { ensureDependencies } from '../../utils/ensure-dependencies';
 
 export async function configurationGenerator(
@@ -46,6 +48,7 @@ function checkForTargetConflicts(tree: Tree, options: RollupProjectSchema) {
 }
 
 function addBuildTarget(tree: Tree, options: RollupProjectSchema) {
+  addBuildTargetDefaults(tree, '@nx/rollup:rollup', options.buildTarget);
   const project = readProjectConfiguration(tree, options.project);
   const packageJsonPath = joinPathFragments(project.root, 'package.json');
 

--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -20,6 +20,7 @@ import {
   addStaticTarget,
   addStorybookTarget,
   addStorybookToNamedInputs,
+  addStorybookToTargetDefaults,
   configureTsProjectConfig,
   configureTsSolutionConfig,
   createProjectStorybookDir,
@@ -153,6 +154,9 @@ export async function configurationGenerator(
 
   addBuildStorybookToCacheableOperations(tree);
   addStorybookToNamedInputs(tree);
+  if (!hasPlugin) {
+    addStorybookToTargetDefaults(tree);
+  }
 
   let devDeps = {};
 

--- a/packages/storybook/src/generators/configuration/lib/util-functions.ts
+++ b/packages/storybook/src/generators/configuration/lib/util-functions.ts
@@ -481,45 +481,53 @@ export function addStorybookToNamedInputs(tree: Tree) {
       }
     }
 
-    nxJson.targetDefaults ??= {};
-    nxJson.targetDefaults['build-storybook'] ??= {};
-    nxJson.targetDefaults['build-storybook'].inputs ??= [
-      'default',
-      hasProductionFileset ? '^production' : '^default',
-    ];
-
-    if (
-      !nxJson.targetDefaults['build-storybook'].inputs.includes(
-        '{projectRoot}/.storybook/**/*'
-      )
-    ) {
-      nxJson.targetDefaults['build-storybook'].inputs.push(
-        '{projectRoot}/.storybook/**/*'
-      );
-    }
-
-    // Delete the !{projectRoot}/.storybook/**/* glob from build-storybook
-    // because we want to rebuild Storybook if the .storybook folder changes
-    const index = nxJson.targetDefaults['build-storybook'].inputs.indexOf(
-      '!{projectRoot}/.storybook/**/*'
-    );
-
-    if (index !== -1) {
-      nxJson.targetDefaults['build-storybook'].inputs.splice(index, 1);
-    }
-
-    if (
-      !nxJson.targetDefaults['build-storybook'].inputs.includes(
-        '{projectRoot}/tsconfig.storybook.json'
-      )
-    ) {
-      nxJson.targetDefaults['build-storybook'].inputs.push(
-        '{projectRoot}/tsconfig.storybook.json'
-      );
-    }
-
     updateNxJson(tree, nxJson);
   }
+}
+
+export function addStorybookToTargetDefaults(tree: Tree) {
+  const nxJson = readNxJson(tree);
+
+  nxJson.targetDefaults ??= {};
+  nxJson.targetDefaults['build-storybook'] ??= {};
+  nxJson.targetDefaults['build-storybook'].inputs ??= [
+    'default',
+    nxJson.namedInputs && 'production' in nxJson.namedInputs
+      ? '^production'
+      : '^default',
+  ];
+
+  if (
+    !nxJson.targetDefaults['build-storybook'].inputs.includes(
+      '{projectRoot}/.storybook/**/*'
+    )
+  ) {
+    nxJson.targetDefaults['build-storybook'].inputs.push(
+      '{projectRoot}/.storybook/**/*'
+    );
+  }
+
+  // Delete the !{projectRoot}/.storybook/**/* glob from build-storybook
+  // because we want to rebuild Storybook if the .storybook folder changes
+  const index = nxJson.targetDefaults['build-storybook'].inputs.indexOf(
+    '!{projectRoot}/.storybook/**/*'
+  );
+
+  if (index !== -1) {
+    nxJson.targetDefaults['build-storybook'].inputs.splice(index, 1);
+  }
+
+  if (
+    !nxJson.targetDefaults['build-storybook'].inputs.includes(
+      '{projectRoot}/tsconfig.storybook.json'
+    )
+  ) {
+    nxJson.targetDefaults['build-storybook'].inputs.push(
+      '{projectRoot}/tsconfig.storybook.json'
+    );
+  }
+
+  updateNxJson(tree, nxJson);
 }
 
 export function createProjectStorybookDir(

--- a/packages/storybook/src/generators/init/init.ts
+++ b/packages/storybook/src/generators/init/init.ts
@@ -78,10 +78,10 @@ function moveToDevDependencies(tree: Tree): GeneratorCallback {
 }
 
 export async function initGenerator(tree: Tree, schema: Schema) {
-  addCacheableOperation(tree);
-
   if (process.env.NX_PCV3 === 'true') {
     addPlugin(tree);
+  } else {
+    addCacheableOperation(tree);
   }
 
   const tasks: GeneratorCallback[] = [];

--- a/packages/storybook/src/migrations/update-16-5-0/move-storybook-tsconfig.ts
+++ b/packages/storybook/src/migrations/update-16-5-0/move-storybook-tsconfig.ts
@@ -2,6 +2,7 @@ import { getProjects, joinPathFragments, Tree, formatFiles } from '@nx/devkit';
 import { forEachExecutorOptions } from '@nx/devkit/src/generators/executor-options-utils';
 import {
   addStorybookToNamedInputs,
+  addStorybookToTargetDefaults,
   renameAndMoveOldTsConfig,
 } from '../../generators/configuration/lib/util-functions';
 
@@ -26,5 +27,6 @@ export default async function (tree: Tree) {
   );
 
   addStorybookToNamedInputs(tree);
+  addStorybookToTargetDefaults(tree);
   await formatFiles(tree);
 }

--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -15,6 +15,7 @@ import { VitePreviewServerExecutorOptions } from '../executors/preview-server/sc
 import { VitestExecutorOptions } from '../executors/test/schema';
 import { ViteConfigurationGeneratorSchema } from '../generators/configuration/schema';
 import { ensureViteConfigIsCorrect } from './vite-config-edit-utils';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/add-build-target-defaults';
 
 export type Target = 'build' | 'serve' | 'test' | 'preview';
 export type TargetFlags = Partial<Record<Target, boolean>>;
@@ -200,6 +201,7 @@ export function addOrChangeBuildTarget(
   options: ViteConfigurationGeneratorSchema,
   target: string
 ) {
+  addBuildTargetDefaults(tree, '@nx/vite:build');
   const project = readProjectConfiguration(tree, options.project);
 
   const buildOptions: ViteBuildExecutorOptions = {

--- a/packages/web/src/generators/application/application.ts
+++ b/packages/web/src/generators/application/application.ts
@@ -36,6 +36,7 @@ import { webInitGenerator } from '../init/init';
 import { Schema } from './schema';
 import { getNpmScope } from '@nx/js/src/utils/package-json/get-npm-scope';
 import { hasWebpackPlugin } from '../../utils/has-webpack-plugin';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/add-build-target-defaults';
 
 interface NormalizedSchema extends Schema {
   projectName: string;
@@ -175,6 +176,7 @@ async function setupBundler(tree: Tree, options: NormalizedSchema) {
     // TODO(jack): Flush this out... no bundler should be possible for web but the experience isn't holistic due to missing features (e.g. writing index.html).
   } else if (options.bundler === 'none') {
     const project = readProjectConfiguration(tree, options.projectName);
+    addBuildTargetDefaults(tree, `@nx/js:${options.compiler}`);
     project.targets.build = {
       executor: `@nx/js:${options.compiler}`,
       outputs: ['{options.outputPath}'],

--- a/packages/webpack/src/generators/configuration/configuration.ts
+++ b/packages/webpack/src/generators/configuration/configuration.ts
@@ -1,8 +1,8 @@
-import type { Tree } from '@nx/devkit';
 import {
   formatFiles,
   joinPathFragments,
   readProjectConfiguration,
+  Tree,
   updateProjectConfiguration,
   writeJson,
 } from '@nx/devkit';
@@ -11,6 +11,7 @@ import { webpackInitGenerator } from '../init/init';
 import { ConfigurationGeneratorSchema } from './schema';
 import { WebpackExecutorOptions } from '../../executors/webpack/schema';
 import { hasPlugin } from '../../utils/has-plugin';
+import { addBuildTargetDefaults } from '@nx/devkit/src/generators/add-build-target-defaults';
 
 export async function configurationGenerator(
   tree: Tree,
@@ -142,6 +143,8 @@ module.exports = composePlugins(withNx(), (config) => {
 }
 
 function addBuildTarget(tree: Tree, options: ConfigurationGeneratorSchema) {
+  addBuildTargetDefaults(tree, '@nx/webpack:webpack');
+
   const project = readProjectConfiguration(tree, options.project);
   const buildOptions: WebpackExecutorOptions = {
     target: options.target,

--- a/packages/workspace/src/generators/new/files-root-app/package.json__tmpl__
+++ b/packages/workspace/src/generators/new/files-root-app/package.json__tmpl__
@@ -10,5 +10,8 @@
   "devDependencies": {
     "@nx/workspace": "<%= nxVersion %>",
     "nx": "<%= nxVersion %>"
+  },
+  "nx": {
+    "includedScripts": []
   }
 }

--- a/packages/workspace/src/generators/new/generate-workspace-files.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.ts
@@ -67,15 +67,18 @@ function createNxJson(
     affected: {
       defaultBase,
     },
-    targetDefaults: {
-      build: {
-        cache: true,
-        dependsOn: ['^build'],
-      },
-      lint: {
-        cache: true,
-      },
-    },
+    targetDefaults:
+      process.env.NX_PCV3 !== 'true'
+        ? {
+            build: {
+              cache: true,
+              dependsOn: ['^build'],
+            },
+            lint: {
+              cache: true,
+            },
+          }
+        : undefined,
   };
 
   if (defaultBase === 'main') {
@@ -87,7 +90,9 @@ function createNxJson(
       production: ['default'],
       sharedGlobals: [],
     };
-    nxJson.targetDefaults.build.inputs = ['production', '^production'];
+    if (process.env.NX_PCV3 !== 'true') {
+      nxJson.targetDefaults.build.inputs = ['production', '^production'];
+    }
   }
 
   writeJson<NxJsonConfiguration>(tree, join(directory, 'nx.json'), nxJson);


### PR DESCRIPTION
…an workspace

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

`targetDefaults` for build are generated for every single workspace.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`targetDefaults` for 'build' are too general for every single workspace.

Each plugin should define targetDefaults when it defines its targets for a project.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
