### PR TITLE
fix(remix): legacy package pointing to incorrect readme

### DIFF
--- a/packages-legacy/remix/project.json
+++ b/packages-legacy/remix/project.json
@@ -6,7 +6,7 @@
   "targets": {
     "build": {
       "outputs": ["{workspaceRoot}/build/packages/{projectName}/README.md"],
-      "command": "node ./scripts/copy-readme.js react-legacy"
+      "command": "node ./scripts/copy-readme.js remix-legacy"
     },
     "build-base": {
       "executor": "@nrwl/js:tsc",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The remix-legacy package has invalid build config, where it is pointing to an incorrect project to copy the readme
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
It should point to the correct project

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
