### PR TITLE
fix(remix): import of config file should invalidate cache

### DIFF
--- a/packages/remix/src/plugins/plugin.ts
+++ b/packages/remix/src/plugins/plugin.ts
@@ -185,7 +185,9 @@ async function getServerBuildPath(
   try {
     let appConfigModule: any;
     try {
-      appConfigModule = await Function(`return import("${configPath}")`)();
+      appConfigModule = await Function(
+        `return import("${configPath}?t=${Date.now()}")`
+      )();
     } catch {
       appConfigModule = require(configPath);
     }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We do not invalidate the import cache when importing config file with `@nx/remix/plugin`

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Use a querystring to ensure import cache is invalidated

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
