### PR TITLE
feat(devkit): add a flag to keep existing versions when calling addDependenciesToPackageJson

### DIFF
--- a/docs/generated/devkit/addDependenciesToPackageJson.md
+++ b/docs/generated/devkit/addDependenciesToPackageJson.md
@@ -1,6 +1,6 @@
 # Function: addDependenciesToPackageJson
 
-▸ **addDependenciesToPackageJson**(`tree`, `dependencies`, `devDependencies`, `packageJsonPath?`): [`GeneratorCallback`](../../devkit/documents/GeneratorCallback)
+▸ **addDependenciesToPackageJson**(`tree`, `dependencies`, `devDependencies`, `packageJsonPath?`, `keepExistingVersions?`): [`GeneratorCallback`](../../devkit/documents/GeneratorCallback)
 
 Add Dependencies and Dev Dependencies to package.json
 
@@ -14,12 +14,13 @@ This will **add** `react` and `jest` to the dependencies and devDependencies sec
 
 #### Parameters
 
-| Name               | Type                                  | Description                                                             |
-| :----------------- | :------------------------------------ | :---------------------------------------------------------------------- |
-| `tree`             | [`Tree`](../../devkit/documents/Tree) | Tree representing file system to modify                                 |
-| `dependencies`     | `Record`\<`string`, `string`\>        | Dependencies to be added to the dependencies section of package.json    |
-| `devDependencies`  | `Record`\<`string`, `string`\>        | Dependencies to be added to the devDependencies section of package.json |
-| `packageJsonPath?` | `string`                              | Path to package.json                                                    |
+| Name                    | Type                                  | Description                                                                 |
+| :---------------------- | :------------------------------------ | :-------------------------------------------------------------------------- |
+| `tree`                  | [`Tree`](../../devkit/documents/Tree) | Tree representing file system to modify                                     |
+| `dependencies`          | `Record`\<`string`, `string`\>        | Dependencies to be added to the dependencies section of package.json        |
+| `devDependencies`       | `Record`\<`string`, `string`\>        | Dependencies to be added to the devDependencies section of package.json     |
+| `packageJsonPath?`      | `string`                              | Path to package.json                                                        |
+| `keepExistingVersions?` | `boolean`                             | If true, prevents existing dependencies from being bumped to newer versions |
 
 #### Returns
 

--- a/packages/devkit/src/utils/package-json.spec.ts
+++ b/packages/devkit/src/utils/package-json.spec.ts
@@ -446,6 +446,29 @@ describe('addDependenciesToPackageJson', () => {
     });
     expect(installTask).toBeDefined();
   });
+
+  it('should allow existing versions to be kept', () => {
+    writeJson(tree, 'package.json', {
+      dependencies: {
+        foo: '1.0.0',
+      },
+    });
+
+    addDependenciesToPackageJson(
+      tree,
+      {
+        foo: '2.0.0',
+      },
+      {},
+      undefined,
+      true
+    );
+
+    const result = readJson(tree, 'package.json');
+    expect(result.dependencies).toEqual({
+      foo: '1.0.0',
+    });
+  });
 });
 
 describe('ensurePackage', () => {

--- a/packages/workspace/src/generators/convert-to-monorepo/convert-to-monorepo.spec.ts
+++ b/packages/workspace/src/generators/convert-to-monorepo/convert-to-monorepo.spec.ts
@@ -129,6 +129,6 @@ describe('monorepo generator', () => {
 
     // Extracted base config files
     expect(tree.exists('tsconfig.base.json')).toBeTruthy();
-    expect(tree.exists('jest.config.ts')).toBeTruthy();
+    expect(tree.exists('jest.preset.js')).toBeTruthy();
   });
 });

--- a/packages/workspace/src/generators/move/lib/move-project-files.ts
+++ b/packages/workspace/src/generators/move/lib/move-project-files.ts
@@ -25,7 +25,7 @@ export function moveProjectFiles(
     '.babelrc',
     '.eslintrc.json',
     'eslint.config.js',
-    /^jest\.config\.(app|lib)\.[jt]s$/,
+    /^jest\.config\.((app|lib)\.)?[jt]s$/,
     'vite.config.ts',
     /^webpack.*\.js$/,
     'index.html', // Vite


### PR DESCRIPTION
This PR adds a flag to `addDependenciesToPackageJson` function in devkit to prevent versions from being bumped. This will be used in init generators since using `nx init` and `nx add` should not bump versions and risk breaking existing projects.

**Example:**

If existing `package.json` already has `next@13.4.0`, then calling this function:
```ts
addDependenciesToPackageJson(
  tree,
  {
    next: '~14.0.0'
  {},
  undefined,
  true // keepExistingVersions
);
```

Will leave `next` at existing version of `13.4.0`.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Notes

- There was discussion on converting the args to accept an options object, but this will break existing usages with signature `addDependenciesToPackageJson(tree, {...}, {...}, customPackageJsonPath)`, unless we do function overrides.