### PR TITLE
fix(graph): e2es require sourceMapUrl and remove deprecated tests

### DIFF
--- a/graph/client-e2e/src/e2e/dev-task-graph.cy.ts
+++ b/graph/client-e2e/src/e2e/dev-task-graph.cy.ts
@@ -198,6 +198,7 @@ describe('dev mode - task graph', () => {
           // Load the fixture data and find the property based on the query parameter
 
           const expandedInputs = nxExamplesTaskInputs[taskId];
+          console.log(expandedInputs);
 
           // Reply with the selected property
           req.reply({

--- a/graph/client-e2e/src/e2e/release-static-app.cy.ts
+++ b/graph/client-e2e/src/e2e/release-static-app.cy.ts
@@ -58,57 +58,6 @@ describe('release static-mode app', () => {
         });
       });
     });
-
-    ['depGraphService', 'projectGraphService'].forEach((serviceName) => {
-      describe(`deprecated api - ${serviceName}`, () => {
-        it('should focus project', () => {
-          cy.window().then((window) => {
-            window.externalApi[serviceName].send({
-              type: 'focusProject',
-              projectName: 'cart',
-            });
-            checkFocusedProject(nxExamplesJson, 'cart');
-          });
-        });
-
-        it('should select all projects', () => {
-          cy.window().then((window) => {
-            window.externalApi[serviceName].send({ type: 'selectAll' });
-            checkSelectAll(nxExamplesJson);
-          });
-        });
-
-        it('should select a project', () => {
-          cy.window().then((window) => {
-            window.externalApi[serviceName].send({
-              type: 'selectProject',
-              projectName: 'cart',
-            });
-            checkSelectedProject('cart');
-          });
-        });
-
-        it('should deselect a project', () => {
-          cy.window().then((window) => {
-            window.externalApi[serviceName].send({
-              type: 'selectProject',
-              projectName: 'cart',
-            });
-            window.externalApi[serviceName].send({
-              type: 'selectProject',
-              projectName: 'cart-e2e',
-            });
-            window.externalApi[serviceName].send({
-              type: 'deselectProject',
-              projectName: 'cart',
-            });
-
-            checkSelectedProject('cart-e2e');
-            checkDeselectedProject('cart');
-          });
-        });
-      });
-    });
   });
 });
 

--- a/graph/client-e2e/src/support/app.po.ts
+++ b/graph/client-e2e/src/support/app.po.ts
@@ -49,7 +49,7 @@ export const getSelectTargetDropdown = () =>
 export const openTooltipForNode = (nodeId: string) =>
   cy.window().then((window) => {
     // @ts-ignore - we will access private methods only in this e2e test
-    const pos = window.externalApi.graphService.renderGraph.cy
+    const pos = window.externalApi._graphService.renderGraph.cy
       .$(nodeId)
       .renderedPosition();
     cy.get('#cytoscape-graph').click(pos.x, pos.y);

--- a/graph/client/src/assets/dev-e2e/environment.js
+++ b/graph/client/src/assets/dev-e2e/environment.js
@@ -13,6 +13,7 @@ window.appConfig = {
       projectGraphUrl: 'assets/project-graphs/e2e.json',
       taskGraphUrl: 'assets/task-graphs/e2e.json',
       taskInputsUrl: 'assets/task-inputs/e2e.json',
+      sourceMapsUrl: 'assets/source-maps/e2e.json',
     },
     {
       id: 'affected',
@@ -20,6 +21,7 @@ window.appConfig = {
       projectGraphUrl: 'assets/project-graphs/affected.json',
       taskGraphUrl: 'assets/task-graphs/affected.json',
       taskInputsUrl: 'assets/task-inputs/affected.json',
+      sourceMapsUrl: 'assets/source-maps/e2e-affected.json',
     },
   ],
   defaultWorkspaceId: 'e2e',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
E2Es were failing because of missing sourceMapUrl in config and deprecated tests looking for removed services

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
E2Es pass

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
