### PR TITLE
docs(nx-dev): fix ci format record command

### DIFF
--- a/docs/shared/monorepo-ci-azure.md
+++ b/docs/shared/monorepo-ci-azure.md
@@ -50,7 +50,7 @@ jobs:
       # Required for nx affected if we're on a branch
       - script: git branch --track main origin/main
       - script: npm ci
-      - script: npx nx format:check --base=$(BASE_SHA)
+      - script: npx nx-cloud record -- nx format:check --base=$(BASE_SHA)
       - script: npx nx affected --base=$(BASE_SHA) -t lint,test,build --parallel=3 --configuration=ci
 ```
 
@@ -164,7 +164,7 @@ jobs:
       - script: git branch --track main origin/main
       - script: npm ci
       - script: npx nx-cloud start-ci-run --stop-agents-after="build"
-      - script: npx nx-cloud record -- npx nx format:check --base=$(BASE_SHA) --head=$(HEAD_SHA)
+      - script: npx nx-cloud record -- nx format:check --base=$(BASE_SHA) --head=$(HEAD_SHA)
       - script: npx nx affected --base=$(BASE_SHA) --head=$(HEAD_SHA) -t lint,test,build --parallel=2 --configuration=ci
 ```
 

--- a/docs/shared/monorepo-ci-bitbucket-pipelines.md
+++ b/docs/shared/monorepo-ci-bitbucket-pipelines.md
@@ -17,7 +17,7 @@ pipelines:
             - node
           script:
             - npm ci
-            - npx nx format:check
+            - npx nx-cloud record -- nx format:check
             - npx nx affected -t lint,test,build --base=origin/master --head=HEAD --configuration=ci
 
   branches:
@@ -28,7 +28,7 @@ pipelines:
             - node
           script:
             - npm ci
-            - npx nx format:check
+            - npx nx-cloud record -- nx format:check
             - npx nx affected -t lint,test,build --base=HEAD~1 --configuration=ci
 ```
 
@@ -71,7 +71,7 @@ pipelines:
 
                 - npm ci
                 - npx nx-cloud start-ci-run --stop-agents-after="build" --agent-count=3
-                - npx nx-cloud record -- npx nx format:check
+                - npx nx-cloud record -- nx format:check
                 - npx nx affected --target=lint,test,build --parallel=2
           - step: *agent
           - step: *agent

--- a/docs/shared/monorepo-ci-circle-ci.md
+++ b/docs/shared/monorepo-ci-circle-ci.md
@@ -19,7 +19,7 @@ jobs:
       - run: npm ci
       - nx/set-shas
 
-      - run: npx nx format:check
+      - run: npx nx-cloud record -- nx format:check
       - run: npx nx affected --base=$NX_BASE --head=$NX_HEAD -t lint,test,build --parallel=3 --configuration=ci
 workflows:
   build:
@@ -67,7 +67,7 @@ jobs:
       # Tell Nx Cloud to use DTE and stop agents when the build tasks are done
       - run: npx nx-cloud start-ci-run --stop-agents-after=build
       # Send logs to Nx Cloud for any CLI command
-      - run: npx nx-cloud record -- npx nx format:check
+      - run: npx nx-cloud record -- nx format:check
       # Lint, test and build on agent jobs everything affected by a change
       - run: npx nx affected --base=$NX_BASE --head=$NX_HEAD -t lint,test,build --parallel=2 --configuration=ci
   agent:

--- a/docs/shared/monorepo-ci-github-actions.md
+++ b/docs/shared/monorepo-ci-github-actions.md
@@ -37,7 +37,7 @@ jobs:
       # This line is needed for nx affected to work when CI is running on a PR
       - run: git branch --track main origin/main
 
-      - run: npx nx format:check
+      - run: npx nx-cloud record -- nx format:check
       - run: npx nx affected -t lint,test,build --parallel=3
 ```
 
@@ -76,7 +76,7 @@ jobs:
     with:
       number-of-agents: 3
       parallel-commands: |
-        npx nx-cloud record -- npx nx format:check
+        npx nx-cloud record -- nx format:check
       parallel-commands-on-agents: |
         npx nx affected -t lint,test,build --parallel=2
 
@@ -189,7 +189,7 @@ jobs:
           }
 
           # list of commands to be run on main has env flag NX_CLOUD_DISTRIBUTED_EXECUTION set to false
-          run_command "NX_CLOUD_DISTRIBUTED_EXECUTION=false npx nx-cloud record -- npx nx format:check"
+          run_command "NX_CLOUD_DISTRIBUTED_EXECUTION=false npx nx-cloud record -- nx format:check"
 
           # list of commands to be run on agents
           run_command "npx nx affected -t lint,test,build --parallel=3"

--- a/docs/shared/monorepo-ci-gitlab.md
+++ b/docs/shared/monorepo-ci-gitlab.md
@@ -10,6 +10,7 @@ Below is an example of an GitLab setup that runs on a single job, building and t
 image: node:18
 
 stages:
+  - lint
   - test
   - build
 
@@ -36,7 +37,7 @@ format-check:
   stage: test
   extends: .distributed
   script:
-    - npx nx format:check --base=$NX_BASE --head=$NX_HEAD
+    - npx nx-cloud record -- nx format:check --base=$NX_BASE --head=$NX_HEAD
 
 lint:
   stage: test
@@ -112,7 +113,7 @@ nx-dte:
   extends: .base-pipeline
   script:
     - yarn nx-cloud start-ci-run --stop-agents-after=build
-    - yarn nx-cloud record -- yarn nx format:check --base=$NX_BASE --head=$NX_HEAD
+    - yarn nx-cloud record -- nx format:check --base=$NX_BASE --head=$NX_HEAD
     - yarn nx affected --base=$NX_BASE --head=$NX_HEAD -t lint,test,build --parallel=2
 
 # Create as many agents as you want

--- a/docs/shared/monorepo-ci-jenkins.md
+++ b/docs/shared/monorepo-ci-jenkins.md
@@ -22,10 +22,8 @@ pipeline {
                     agent any
                     steps {
                         sh "npm ci"
-                        sh "npx nx format:check"
-                        sh "npx nx affected --base=HEAD~1 -t lint --parallel=3"
-                        sh "npx nx affected --base=HEAD~1 -t test --parallel=3"
-                        sh "npx nx affected --base=HEAD~1 -t build --parallel=3"
+                        sh "npx nx-cloud record -- nx format:check"
+                        sh "npx nx affected --base=HEAD~1 -t lint,test,build --parallel=3"
                     }
                 }
                 stage('PR') {
@@ -35,10 +33,8 @@ pipeline {
                     agent any
                     steps {
                         sh "npm ci"
-                        sh "npx nx format:check"
-                        sh "npx nx affected --base origin/${env.CHANGE_TARGET} -t lint --parallel=3"
-                        sh "npx nx affected --base origin/${env.CHANGE_TARGET} -t test --parallel=3 --configuration=ci"
-                        sh "npx nx affected --base origin/${env.CHANGE_TARGET} -t build --parallel=3"
+                        sh "npx nx-cloud record -- nx format:check"
+                        sh "npx nx affected --base origin/${env.CHANGE_TARGET} -t lint,test,build --parallel=3"
                     }
                 }
             }
@@ -74,7 +70,7 @@ pipeline {
                     steps {
                         sh "npm ci"
                         sh "npx nx-cloud start-ci-run --stop-agents-after='build'"
-                        sh "npx nx format:check"
+                        sh "npx nx-cloud record -- nx format:check"
                         sh "npx nx affected --base=HEAD~1 -t lint --parallel=3 & npx nx affected --base=HEAD~1 -t test --parallel=3 --configuration=ci & npx nx affected --base=HEAD~1 -t build --parallel=3"
                     }
                 }
@@ -86,7 +82,7 @@ pipeline {
                     steps {
                         sh "npm ci"
                         sh "npx nx-cloud start-ci-run --stop-agents-after='build'"
-                        sh "npx nx format:check"
+                        sh "npx nx-cloud record -- nx format:check"
                         sh "npx nx affected --base origin/${env.CHANGE_TARGET} -t lint --parallel=2 & npx nx affected --base origin/${env.CHANGE_TARGET} -t test --parallel=2 --configuration=ci & npx nx affected --base origin/${env.CHANGE_TARGET} -t build --parallel=2"
                     }
                 }


### PR DESCRIPTION
Current CI workflows reference the `nx format:check` command without the recommended `nx-cloud record` prefix.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
