### PR TITLE
fix(nx-dev): align button sizes on hero

### DIFF
--- a/nx-dev/ui-home/src/lib/hero.tsx
+++ b/nx-dev/ui-home/src/lib/hero.tsx
@@ -161,7 +161,7 @@ export function Hero(): JSX.Element {
             >
               <button
                 title="Create an Nx workspace"
-                className="group relative flex w-full items-center rounded-lg border border-slate-200 bg-white py-3 px-2 sm:px-6 text-sm sm:text-lg font-semibold leading-6 transition hover:bg-slate-100 focus:ring-2 focus:ring-offset-2 focus:ring-offset-white dark:border-slate-700 dark:bg-slate-800 dark:text-white dark:hover:bg-slate-700 sm:w-auto"
+                className="group relative flex w-full items-center rounded-lg border border-slate-200 bg-white py-2 px-2 sm:px-6 text-sm sm:text-lg font-semibold leading-6 transition hover:bg-slate-100 focus:ring-2 focus:ring-offset-2 focus:ring-offset-white dark:border-slate-700 dark:bg-slate-800 dark:text-white dark:hover:bg-slate-700 sm:w-auto"
               >
                 <span className="absolute top-1 right-1 flex opacity-0 transition-opacity group-hover:opacity-100">
                   {copied ? (


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
![Screenshot 2024-01-16 at 14 10 47](https://github.com/nrwl/nx/assets/881612/2cb43979-cf0a-4db0-910c-bd9ed2465d42)

## Expected Behavior
Get started link and create-nx-workspace button do not have the same size
<!-- This is the behavior we should expect with the changes in this PR -->
![Screenshot 2024-01-16 at 14 10 22](https://github.com/nrwl/nx/assets/881612/acf9f538-7f8d-4b1e-8aa0-991a1581b2b8)


## Related Issue(s)
Get started link and create-nx-workspace button **have** the same size
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
