### PR TITLE
fix(storybook): handle output-dir properly for outputs

### DIFF
--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -66,7 +66,9 @@ export async function configurationGenerator(
   );
   const { compiler } = findStorybookAndBuildTargetsAndCompiler(targets);
 
-  const viteConfigFilePath = findViteConfig(tree, root);
+  const viteConfig = findViteConfig(tree, root);
+  const viteConfigFilePath = viteConfig?.fullConfigPath;
+  const viteConfigFileName = viteConfig?.viteConfigFileName;
   const nextConfigFilePath = findNextConfig(tree, root);
 
   if (viteConfigFilePath) {
@@ -130,7 +132,9 @@ export async function configurationGenerator(
     !!nextConfigFilePath,
     compiler === 'swc',
     usesVite,
-    viteConfigFilePath
+    viteConfigFilePath,
+    hasPlugin,
+    viteConfigFileName
   );
 
   if (schema.uiFramework !== '@storybook/angular') {

--- a/packages/storybook/src/generators/configuration/lib/util-functions.ts
+++ b/packages/storybook/src/generators/configuration/lib/util-functions.ts
@@ -536,7 +536,9 @@ export function createProjectStorybookDir(
   isNextJs?: boolean,
   usesSwc?: boolean,
   usesVite?: boolean,
-  viteConfigFilePath?: string
+  viteConfigFilePath?: string,
+  hasPlugin?: boolean,
+  viteConfigFileName?: string
 ) {
   let projectDirectory =
     projectType === 'application'
@@ -579,6 +581,8 @@ export function createProjectStorybookDir(
     usesVite,
     isRootProject: projectIsRootProjectInStandaloneWorkspace,
     viteConfigFilePath,
+    hasPlugin,
+    viteConfigFileName,
   });
 
   if (js) {
@@ -699,13 +703,19 @@ export async function getE2EProjectName(
 export function findViteConfig(
   tree: Tree,
   projectRoot: string
-): string | undefined {
+): {
+  fullConfigPath: string | undefined;
+  viteConfigFileName: string | undefined;
+} {
   const allowsExt = ['js', 'mjs', 'ts', 'cjs', 'mts', 'cts'];
 
   for (const ext of allowsExt) {
     const viteConfigPath = joinPathFragments(projectRoot, `vite.config.${ext}`);
     if (tree.exists(viteConfigPath)) {
-      return viteConfigPath;
+      return {
+        fullConfigPath: viteConfigPath,
+        viteConfigFileName: `vite.config.${ext}`,
+      };
     }
   }
 }

--- a/packages/storybook/src/generators/configuration/project-files-ts/.storybook/main.ts__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files-ts/.storybook/main.ts__tmpl__
@@ -14,7 +14,11 @@ const config: StorybookConfig = {
   framework: {
     name: '<%= uiFramework %>',
     options: {
-      <% if (usesVite && viteConfigFilePath) { %>
+      <% if (usesVite && viteConfigFilePath && hasPlugin) { %>
+      builder: {
+        viteConfigPath: '<%= viteConfigFileName %>',
+      },
+      <% } %><% if (usesVite && viteConfigFilePath && !hasPlugin) { %>
       builder: {
         viteConfigPath: '<%= viteConfigFilePath %>',
       },

--- a/packages/storybook/src/generators/configuration/project-files/.storybook/main.js__tmpl__
+++ b/packages/storybook/src/generators/configuration/project-files/.storybook/main.js__tmpl__
@@ -13,7 +13,12 @@ const config = {
   framework: {
     name: '<%= uiFramework %>',
     options: {
-      <% if (usesVite && viteConfigFilePath) { %>
+     <% if (usesVite && viteConfigFilePath && hasPlugin) { %>
+      builder: {
+        viteConfigPath: '<%= viteConfigFileName %>',
+      },
+      <% } %>
+      <% if (usesVite && viteConfigFilePath && !hasPlugin) { %>
       builder: {
         viteConfigPath: '<%= viteConfigFilePath %>',
       },

--- a/packages/storybook/src/plugins/plugin.spec.ts
+++ b/packages/storybook/src/plugins/plugin.spec.ts
@@ -72,10 +72,17 @@ describe('@nx/storybook/plugin', () => {
     expect(
       nodes?.['projects']?.['my-app']?.targets?.['build-storybook']
     ).toMatchObject({
-      command:
-        'storybook build --config-dir my-app/.storybook --output-dir dist/storybook/my-app',
+      command: 'storybook build',
+      options: {
+        cwd: 'my-app',
+      },
       cache: true,
-      outputs: ['{workspaceRoot}/dist/storybook/{projectRoot}'],
+      outputs: [
+        '{workspaceRoot}/{projectRoot}/static-storybook',
+        '{options.output-dir}',
+        '{options.outputDir}',
+        '{options.o}',
+      ],
       inputs: [
         'production',
         '^production',
@@ -86,12 +93,12 @@ describe('@nx/storybook/plugin', () => {
     expect(
       nodes?.['projects']?.['my-app']?.targets?.['storybook']
     ).toMatchObject({
-      command: 'storybook dev --config-dir my-app/.storybook',
+      command: 'storybook dev',
     });
     expect(
       nodes?.['projects']?.['my-app']?.targets?.['test-storybook']
     ).toMatchObject({
-      command: 'test-storybook --config-dir my-app/.storybook',
+      command: 'test-storybook',
     });
   });
 
@@ -128,13 +135,18 @@ describe('@nx/storybook/plugin', () => {
     ).toMatchObject({
       executor: '@storybook/angular:build-storybook',
       options: {
-        outputDir: 'dist/storybook/my-ng-app',
+        outputDir: 'my-ng-app/static-storybook',
         configDir: 'my-ng-app/.storybook',
         browserTarget: 'my-ng-app:build-storybook',
         compodoc: false,
       },
       cache: true,
-      outputs: ['{workspaceRoot}/dist/storybook/{projectRoot}'],
+      outputs: [
+        '{workspaceRoot}/{projectRoot}/static-storybook',
+        '{options.output-dir}',
+        '{options.outputDir}',
+        '{options.o}',
+      ],
       inputs: [
         'production',
         '^production',
@@ -161,7 +173,7 @@ describe('@nx/storybook/plugin', () => {
     expect(
       nodes?.['projects']?.['my-ng-app']?.targets?.['test-storybook']
     ).toMatchObject({
-      command: 'test-storybook --config-dir my-ng-app/.storybook',
+      command: 'test-storybook',
     });
   });
 });


### PR DESCRIPTION
Do not hard-code output dir for Storybook. Take into account CLI argument, or just use the default (`static-storybook`).

Also, change the way the `storybook` command is ran. Run it from the root of each project.
