### PR TITLE
fix(nx-dev): table of contents with code

### DIFF
--- a/nx-dev/feature-doc-viewer/src/lib/table-of-contents.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/table-of-contents.tsx
@@ -14,7 +14,16 @@ export function collectHeadings(
 ): Heading[] {
   if (node) {
     if (node.name && node.name === 'Heading') {
-      const title = node.children[0];
+      function childToString(child: any) {
+        if (typeof child === 'string') {
+          return child;
+        }
+        if (child.children) {
+          return child.children.map(childToString).join(' ');
+        }
+        return '';
+      }
+      const title = node.children.map(childToString).join(' ');
 
       if (typeof title === 'string') {
         sections.push({


### PR DESCRIPTION
Fix table of contents when headings include code