### PR TITLE
feat(graph): show open config button in graph web

### DIFF
--- a/graph/client/src/app/ui-tooltips/graph-tooltip-display.tsx
+++ b/graph/client/src/app/ui-tooltips/graph-tooltip-display.tsx
@@ -8,34 +8,60 @@ import {
 } from '@nx/graph/ui-tooltips';
 import { ProjectNodeActions } from './project-node-actions';
 import { TaskNodeActions } from './task-node-actions';
+import { useEnvironmentConfig, useRouteConstructor } from '@nx/graph/shared';
+import { useNavigate } from 'react-router-dom';
 
 const tooltipService = getTooltipService();
 
 export function TooltipDisplay() {
+  const environment = useEnvironmentConfig()?.environment;
+  const navigate = useNavigate();
+  const routeConstructor = useRouteConstructor();
+
   const currentTooltip = useSyncExternalStore(
     (callback) => tooltipService.subscribe(callback),
     () => tooltipService.currentTooltip
   );
+
   let tooltipToRender;
   if (currentTooltip) {
-    switch (currentTooltip.type) {
-      case 'projectNode':
-        tooltipToRender = (
-          <ProjectNodeToolTip {...currentTooltip.props}>
-            <ProjectNodeActions {...currentTooltip.props} />
-          </ProjectNodeToolTip>
-        );
-        break;
-      case 'projectEdge':
-        tooltipToRender = <ProjectEdgeNodeTooltip {...currentTooltip.props} />;
-        break;
-      case 'taskNode':
-        tooltipToRender = (
-          <TaskNodeTooltip {...currentTooltip.props}>
-            <TaskNodeActions {...currentTooltip.props} />
-          </TaskNodeTooltip>
-        );
-        break;
+    if (currentTooltip.type === 'projectNode') {
+      const onConfigClick = (() => {
+        if (currentTooltip.props.openConfigCallback) {
+          return currentTooltip.props.openConfigCallback;
+        }
+
+        if (environment !== 'nx-console') {
+          return () => {
+            navigate(
+              routeConstructor(
+                {
+                  pathname: `/project-details/${currentTooltip.props.id}`,
+                },
+                false
+              )
+            );
+          };
+        }
+      })();
+
+      tooltipToRender = (
+        <ProjectNodeToolTip
+          {...currentTooltip.props}
+          openConfigCallback={onConfigClick}
+          isNxConsole={environment === 'nx-console'}
+        >
+          <ProjectNodeActions {...currentTooltip.props} />
+        </ProjectNodeToolTip>
+      );
+    } else if (currentTooltip.type === 'projectEdge') {
+      tooltipToRender = <ProjectEdgeNodeTooltip {...currentTooltip.props} />;
+    } else if (currentTooltip.type === 'taskNode') {
+      tooltipToRender = (
+        <TaskNodeTooltip {...currentTooltip.props}>
+          <TaskNodeActions {...currentTooltip.props} />
+        </TaskNodeTooltip>
+      );
     }
   }
 

--- a/graph/client/src/app/ui-tooltips/graph-tooltip-display.tsx
+++ b/graph/client/src/app/ui-tooltips/graph-tooltip-display.tsx
@@ -27,10 +27,6 @@ export function TooltipDisplay() {
   if (currentTooltip) {
     if (currentTooltip.type === 'projectNode') {
       const onConfigClick = (() => {
-        if (currentTooltip.props.openConfigCallback) {
-          return currentTooltip.props.openConfigCallback;
-        }
-
         if (environment !== 'nx-console') {
           return () => {
             navigate(
@@ -42,6 +38,14 @@ export function TooltipDisplay() {
               )
             );
           };
+        } else {
+          return () =>
+            this.externalApiService.postEvent({
+              type: 'open-project-config',
+              payload: {
+                projectName: currentTooltip.props.id,
+              },
+            });
         }
       })();
 
@@ -57,8 +61,38 @@ export function TooltipDisplay() {
     } else if (currentTooltip.type === 'projectEdge') {
       tooltipToRender = <ProjectEdgeNodeTooltip {...currentTooltip.props} />;
     } else if (currentTooltip.type === 'taskNode') {
+      const onConfigClick = (() => {
+        const [projectName, targetName] = currentTooltip.props.id.split(':');
+        if (environment !== 'nx-console') {
+          return () => {
+            navigate(
+              routeConstructor(
+                {
+                  pathname: `/project-details/${projectName}`,
+                  search: `expanded=${targetName}`,
+                },
+                false
+              )
+            );
+          };
+        } else {
+          return () =>
+            this.externalApiService.postEvent({
+              type: 'open-project-config',
+              payload: {
+                projectName,
+                targetName,
+              },
+            });
+        }
+      })();
+
       tooltipToRender = (
-        <TaskNodeTooltip {...currentTooltip.props}>
+        <TaskNodeTooltip
+          {...currentTooltip.props}
+          openConfigCallback={onConfigClick}
+          isNxConsole={environment === 'nx-console'}
+        >
           <TaskNodeActions {...currentTooltip.props} />
         </TaskNodeTooltip>
       );

--- a/graph/ui-graph/src/lib/tooltip-service.ts
+++ b/graph/ui-graph/src/lib/tooltip-service.ts
@@ -23,22 +23,11 @@ export class GraphTooltipService {
           this.hideAll();
           break;
         case 'ProjectNodeClick':
-          const openConfigCallback =
-            graph.renderMode === 'nx-console'
-              ? () =>
-                  this.externalApiService.postEvent({
-                    type: 'open-project-config',
-                    payload: {
-                      projectName: event.data.id,
-                    },
-                  })
-              : undefined;
           this.openProjectNodeToolTip(event.ref, {
             id: event.data.id,
             tags: event.data.tags,
             type: event.data.type,
             description: event.data.description,
-            openConfigCallback,
           });
           break;
         case 'TaskNodeClick':

--- a/graph/ui-tooltips/src/lib/project-node-tooltip.tsx
+++ b/graph/ui-tooltips/src/lib/project-node-tooltip.tsx
@@ -1,6 +1,6 @@
 import {
   PencilSquareIcon,
-  ArrowTopRightOnSquareIcon,
+  DocumentMagnifyingGlassIcon,
 } from '@heroicons/react/24/outline';
 import { Tag } from '@nx/graph/ui-components';
 import { ReactNode } from 'react';
@@ -45,7 +45,7 @@ export function ProjectNodeToolTip({
           {isNxConsole ? (
             <PencilSquareIcon className="h-5 w-5" />
           ) : (
-            <ArrowTopRightOnSquareIcon className="h-5 w-5" />
+            <DocumentMagnifyingGlassIcon className="h-5 w-5" />
           )}
         </button>
       </h4>

--- a/graph/ui-tooltips/src/lib/project-node-tooltip.tsx
+++ b/graph/ui-tooltips/src/lib/project-node-tooltip.tsx
@@ -1,6 +1,10 @@
-import { PencilSquareIcon } from '@heroicons/react/24/outline';
+import {
+  PencilSquareIcon,
+  ArrowTopRightOnSquareIcon,
+} from '@heroicons/react/24/outline';
 import { Tag } from '@nx/graph/ui-components';
 import { ReactNode } from 'react';
+import { useEnvironmentConfig } from '@nx/graph/shared';
 
 export interface ProjectNodeToolTipProps {
   type: 'app' | 'lib' | 'e2e';
@@ -8,6 +12,7 @@ export interface ProjectNodeToolTipProps {
   tags: string[];
   description?: string;
   openConfigCallback?: () => void;
+  isNxConsole?: boolean;
 
   children?: ReactNode | ReactNode[];
 }
@@ -19,6 +24,7 @@ export function ProjectNodeToolTip({
   children,
   description,
   openConfigCallback,
+  isNxConsole,
 }: ProjectNodeToolTipProps) {
   return (
     <div className="text-sm text-slate-700 dark:text-slate-400">
@@ -27,15 +33,21 @@ export function ProjectNodeToolTip({
           <Tag className="mr-3">{type}</Tag>
           <span className="font-mono">{id}</span>
         </div>
-        {openConfigCallback ? (
-          <button
-            className=" flex items-center rounded-md border-slate-300 bg-white p-1 font-medium text-slate-500 shadow-sm ring-1 transition hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-400 dark:ring-slate-600 hover:dark:bg-slate-700"
-            title="Edit project.json in editor"
-            onClick={openConfigCallback}
-          >
+        <button
+          className=" flex items-center rounded-md border-slate-300 bg-white p-1 font-medium text-slate-500 shadow-sm ring-1 transition hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-400 dark:ring-slate-600 hover:dark:bg-slate-700"
+          title={
+            isNxConsole
+              ? 'Open project details in editor'
+              : 'Open project details'
+          }
+          onClick={openConfigCallback}
+        >
+          {isNxConsole ? (
             <PencilSquareIcon className="h-5 w-5" />
-          </button>
-        ) : undefined}
+          ) : (
+            <ArrowTopRightOnSquareIcon className="h-5 w-5" />
+          )}
+        </button>
       </h4>
       {tags.length > 0 ? (
         <p className="my-2">

--- a/graph/ui-tooltips/src/lib/task-node-tooltip.tsx
+++ b/graph/ui-tooltips/src/lib/task-node-tooltip.tsx
@@ -1,4 +1,8 @@
-import { PlayIcon } from '@heroicons/react/24/outline';
+import {
+  DocumentMagnifyingGlassIcon,
+  PencilSquareIcon,
+  PlayIcon,
+} from '@heroicons/react/24/outline';
 import { Tag } from '@nx/graph/ui-components';
 import { ReactNode } from 'react';
 
@@ -8,6 +12,8 @@ export interface TaskNodeTooltipProps {
   runTaskCallback?: () => void;
   description?: string;
   inputs?: Record<string, string[]>;
+  isNxConsole?: boolean;
+  openConfigCallback?: () => void;
 
   children?: ReactNode | ReactNode[];
 }
@@ -17,14 +23,33 @@ export function TaskNodeTooltip({
   executor,
   description,
   runTaskCallback: runTargetCallback,
+  isNxConsole,
+  openConfigCallback,
   children,
 }: TaskNodeTooltipProps) {
   return (
     <div className="text-sm text-slate-700 dark:text-slate-400">
       <h4 className="flex justify-between items-center gap-4 mb-3">
-        <div className="flex items-center">
-          <Tag className="mr-3">{executor}</Tag>
-          <span className="font-mono">{id}</span>
+        <div className="flex grow items-center justify-between">
+          <div className="flex items-center">
+            <Tag className="mr-3">{executor}</Tag>
+            <span className="font-mono">{id}</span>
+          </div>
+          <button
+            className=" flex items-center rounded-md border-slate-300 bg-white p-1 font-medium text-slate-500 shadow-sm ring-1 transition hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-400 dark:ring-slate-600 hover:dark:bg-slate-700"
+            title={
+              isNxConsole
+                ? 'Open project details in editor'
+                : 'Open project details'
+            }
+            onClick={openConfigCallback}
+          >
+            {isNxConsole ? (
+              <PencilSquareIcon className="h-5 w-5" />
+            ) : (
+              <DocumentMagnifyingGlassIcon className="h-5 w-5" />
+            )}
+          </button>
         </div>
         {runTargetCallback ? (
           <button

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -108,6 +108,7 @@
       "@nx/storybook": ["packages/storybook"],
       "@nx/storybook/*": ["packages/storybook/*"],
       "@nx/typedoc-theme": ["typedoc-theme/src/index.ts"],
+      "@nx/ui-theme": ["graph/ui-theme/src/index.ts"],
       "@nx/vite": ["packages/vite"],
       "@nx/vite/*": ["packages/vite/*"],
       "@nx/vue": ["packages/vue"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -108,7 +108,6 @@
       "@nx/storybook": ["packages/storybook"],
       "@nx/storybook/*": ["packages/storybook/*"],
       "@nx/typedoc-theme": ["typedoc-theme/src/index.ts"],
-      "@nx/ui-theme": ["graph/ui-theme/src/index.ts"],
       "@nx/vite": ["packages/vite"],
       "@nx/vite/*": ["packages/vite/*"],
       "@nx/vue": ["packages/vue"],


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
The button on the graph node tooltip to open the project details does not appear when viewing the graph in web view

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The button in the graph node tooltip should show in graph web and route to the project-details view

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
