### PR TITLE
docs(nx-dev): hiding community partners link for now

### DIFF
--- a/nx-dev/nx-dev/pages/launch-nx.tsx
+++ b/nx-dev/nx-dev/pages/launch-nx.tsx
@@ -179,12 +179,12 @@ export default function ConfPage(): JSX.Element {
                 >
                   Launch Conf
                 </Link>
-                <Link
-                  href="#community-partners"
-                  className="cursor-pointer bg-white/40 py-8 transition hover:bg-white dark:bg-slate-800/60 dark:hover:bg-slate-800"
-                >
-                  Community Partners
-                </Link>
+                {/*<Link*/}
+                {/*  href="#community-partners"*/}
+                {/*  className="cursor-pointer bg-white/40 py-8 transition hover:bg-white dark:bg-slate-800/60 dark:hover:bg-slate-800"*/}
+                {/*>*/}
+                {/*  Community Partners*/}
+                {/*</Link>*/}
               </div>
             </div>
           </div>


### PR DESCRIPTION

## Current Behavior
Community Partners link goes nowhere

## Expected Behavior
Community Partners link is hidden


