### PR TITLE
feat(release): support conventionalCommits shorthand for version config

### DIFF
--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -542,6 +542,11 @@
     "NxReleaseVersionConfiguration": {
       "type": "object",
       "properties": {
+        "conventionalCommits": {
+          "type": "boolean",
+          "description": "Shorthand for enabling the current version of projects to be resolved from git tags, and the next version to be determined by analyzing commit messages according to the Conventional Commits specification.",
+          "default": false
+        },
         "generator": {
           "type": "string"
         },

--- a/packages/nx/src/command-line/release/config/config.spec.ts
+++ b/packages/nx/src/command-line/release/config/config.spec.ts
@@ -91,6 +91,7 @@ describe('createNxReleaseConfig()', () => {
                 "projectsRelationship": "fixed",
                 "releaseTagPattern": "v{version}",
                 "version": {
+                  "conventionalCommits": false,
                   "generator": "@nx/js:release-version",
                   "generatorOptions": {},
                 },
@@ -99,6 +100,7 @@ describe('createNxReleaseConfig()', () => {
             "projectsRelationship": "fixed",
             "releaseTagPattern": "v{version}",
             "version": {
+              "conventionalCommits": false,
               "generator": "@nx/js:release-version",
               "generatorOptions": {},
               "git": {
@@ -162,6 +164,7 @@ describe('createNxReleaseConfig()', () => {
                 "projectsRelationship": "fixed",
                 "releaseTagPattern": "v{version}",
                 "version": {
+                  "conventionalCommits": false,
                   "generator": "@nx/js:release-version",
                   "generatorOptions": {},
                 },
@@ -170,6 +173,7 @@ describe('createNxReleaseConfig()', () => {
             "projectsRelationship": "fixed",
             "releaseTagPattern": "v{version}",
             "version": {
+              "conventionalCommits": false,
               "generator": "@nx/js:release-version",
               "generatorOptions": {},
               "git": {
@@ -236,6 +240,7 @@ describe('createNxReleaseConfig()', () => {
                 "projectsRelationship": "fixed",
                 "releaseTagPattern": "v{version}",
                 "version": {
+                  "conventionalCommits": false,
                   "generator": "@nx/js:release-version",
                   "generatorOptions": {},
                 },
@@ -244,6 +249,7 @@ describe('createNxReleaseConfig()', () => {
             "projectsRelationship": "fixed",
             "releaseTagPattern": "v{version}",
             "version": {
+              "conventionalCommits": false,
               "generator": "@nx/js:release-version",
               "generatorOptions": {},
               "git": {
@@ -326,6 +332,7 @@ describe('createNxReleaseConfig()', () => {
                 "projectsRelationship": "fixed",
                 "releaseTagPattern": "v{version}",
                 "version": {
+                  "conventionalCommits": false,
                   "generator": "@nx/js:release-version",
                   "generatorOptions": {},
                 },
@@ -334,6 +341,7 @@ describe('createNxReleaseConfig()', () => {
             "projectsRelationship": "fixed",
             "releaseTagPattern": "v{version}",
             "version": {
+              "conventionalCommits": false,
               "generator": "@nx/js:release-version",
               "generatorOptions": {},
               "git": {
@@ -404,6 +412,7 @@ describe('createNxReleaseConfig()', () => {
                 "projectsRelationship": "fixed",
                 "releaseTagPattern": "v{version}",
                 "version": {
+                  "conventionalCommits": false,
                   "generator": "@nx/js:release-version",
                   "generatorOptions": {},
                 },
@@ -412,6 +421,7 @@ describe('createNxReleaseConfig()', () => {
             "projectsRelationship": "fixed",
             "releaseTagPattern": "v{version}",
             "version": {
+              "conventionalCommits": false,
               "generator": "@nx/js:release-version",
               "generatorOptions": {},
               "git": {
@@ -481,6 +491,7 @@ describe('createNxReleaseConfig()', () => {
                 "projectsRelationship": "fixed",
                 "releaseTagPattern": "v{version}",
                 "version": {
+                  "conventionalCommits": false,
                   "generator": "@nx/js:release-version",
                   "generatorOptions": {},
                 },
@@ -489,6 +500,7 @@ describe('createNxReleaseConfig()', () => {
             "projectsRelationship": "fixed",
             "releaseTagPattern": "v{version}",
             "version": {
+              "conventionalCommits": false,
               "generator": "@nx/js:release-version",
               "generatorOptions": {},
               "git": {
@@ -569,6 +581,7 @@ describe('createNxReleaseConfig()', () => {
                 "projectsRelationship": "fixed",
                 "releaseTagPattern": "v{version}",
                 "version": {
+                  "conventionalCommits": false,
                   "generator": "@custom/generator",
                   "generatorOptions": {
                     "optionsOverride": "something",
@@ -583,6 +596,7 @@ describe('createNxReleaseConfig()', () => {
                 "projectsRelationship": "fixed",
                 "releaseTagPattern": "v{version}",
                 "version": {
+                  "conventionalCommits": false,
                   "generator": "@custom/generator-alternative",
                   "generatorOptions": {},
                 },
@@ -591,6 +605,7 @@ describe('createNxReleaseConfig()', () => {
             "projectsRelationship": "fixed",
             "releaseTagPattern": "v{version}",
             "version": {
+              "conventionalCommits": false,
               "generator": "@nx/js:release-version",
               "generatorOptions": {},
               "git": {
@@ -670,6 +685,7 @@ describe('createNxReleaseConfig()', () => {
                 "projectsRelationship": "fixed",
                 "releaseTagPattern": "v{version}",
                 "version": {
+                  "conventionalCommits": false,
                   "generator": "@nx/js:release-version",
                   "generatorOptions": {},
                 },
@@ -678,6 +694,7 @@ describe('createNxReleaseConfig()', () => {
             "projectsRelationship": "fixed",
             "releaseTagPattern": "v{version}",
             "version": {
+              "conventionalCommits": false,
               "generator": "@nx/js:release-version",
               "generatorOptions": {},
               "git": {
@@ -751,6 +768,7 @@ describe('createNxReleaseConfig()', () => {
                 "projectsRelationship": "fixed",
                 "releaseTagPattern": "v{version}",
                 "version": {
+                  "conventionalCommits": false,
                   "generator": "@nx/js:release-version",
                   "generatorOptions": {
                     "foo": "bar",
@@ -761,6 +779,7 @@ describe('createNxReleaseConfig()', () => {
             "projectsRelationship": "fixed",
             "releaseTagPattern": "v{version}",
             "version": {
+              "conventionalCommits": false,
               "generator": "@nx/js:release-version",
               "generatorOptions": {
                 "foo": "bar",
@@ -832,6 +851,7 @@ describe('createNxReleaseConfig()', () => {
                 "projectsRelationship": "fixed",
                 "releaseTagPattern": "v{version}",
                 "version": {
+                  "conventionalCommits": false,
                   "generator": "@nx/js:release-version",
                   "generatorOptions": {},
                 },
@@ -840,6 +860,7 @@ describe('createNxReleaseConfig()', () => {
             "projectsRelationship": "fixed",
             "releaseTagPattern": "v{version}",
             "version": {
+              "conventionalCommits": false,
               "generator": "@nx/js:release-version",
               "generatorOptions": {},
               "git": {
@@ -915,6 +936,7 @@ describe('createNxReleaseConfig()', () => {
                 "projectsRelationship": "fixed",
                 "releaseTagPattern": "v{version}",
                 "version": {
+                  "conventionalCommits": false,
                   "generator": "@nx/js:release-version",
                   "generatorOptions": {},
                 },
@@ -923,6 +945,7 @@ describe('createNxReleaseConfig()', () => {
             "projectsRelationship": "fixed",
             "releaseTagPattern": "v{version}",
             "version": {
+              "conventionalCommits": false,
               "generator": "@nx/js:release-version",
               "generatorOptions": {},
               "git": {
@@ -1009,6 +1032,7 @@ describe('createNxReleaseConfig()', () => {
                 "projectsRelationship": "fixed",
                 "releaseTagPattern": "v{version}",
                 "version": {
+                  "conventionalCommits": false,
                   "generator": "@nx/js:release-version",
                   "generatorOptions": {},
                 },
@@ -1017,6 +1041,7 @@ describe('createNxReleaseConfig()', () => {
             "projectsRelationship": "fixed",
             "releaseTagPattern": "v{version}",
             "version": {
+              "conventionalCommits": false,
               "generator": "@nx/js:release-version",
               "generatorOptions": {},
               "git": {
@@ -1085,6 +1110,7 @@ describe('createNxReleaseConfig()', () => {
                 "projectsRelationship": "fixed",
                 "releaseTagPattern": "{projectName}__{version}",
                 "version": {
+                  "conventionalCommits": false,
                   "generator": "@nx/js:release-version",
                   "generatorOptions": {},
                 },
@@ -1093,6 +1119,7 @@ describe('createNxReleaseConfig()', () => {
             "projectsRelationship": "fixed",
             "releaseTagPattern": "{projectName}__{version}",
             "version": {
+              "conventionalCommits": false,
               "generator": "@nx/js:release-version",
               "generatorOptions": {},
               "git": {
@@ -1179,6 +1206,7 @@ describe('createNxReleaseConfig()', () => {
                 "projectsRelationship": "fixed",
                 "releaseTagPattern": "{version}",
                 "version": {
+                  "conventionalCommits": false,
                   "generator": "@nx/js:release-version",
                   "generatorOptions": {
                     "currentVersionResolver": "git-tag",
@@ -1190,6 +1218,7 @@ describe('createNxReleaseConfig()', () => {
             "projectsRelationship": "fixed",
             "releaseTagPattern": "{version}",
             "version": {
+              "conventionalCommits": false,
               "generator": "@nx/js:release-version",
               "generatorOptions": {},
               "git": {
@@ -1251,6 +1280,7 @@ describe('createNxReleaseConfig()', () => {
                 "projectsRelationship": "fixed",
                 "releaseTagPattern": "v{version}",
                 "version": {
+                  "conventionalCommits": false,
                   "generator": "@nx/js:release-version",
                   "generatorOptions": {},
                 },
@@ -1259,6 +1289,7 @@ describe('createNxReleaseConfig()', () => {
             "projectsRelationship": "fixed",
             "releaseTagPattern": "v{version}",
             "version": {
+              "conventionalCommits": false,
               "generator": "@nx/js:release-version",
               "generatorOptions": {},
               "git": {
@@ -1358,6 +1389,7 @@ describe('createNxReleaseConfig()', () => {
                 "projectsRelationship": "fixed",
                 "releaseTagPattern": "v{version}",
                 "version": {
+                  "conventionalCommits": false,
                   "generator": "@nx/js:release-version",
                   "generatorOptions": {},
                 },
@@ -1366,6 +1398,7 @@ describe('createNxReleaseConfig()', () => {
             "projectsRelationship": "fixed",
             "releaseTagPattern": "v{version}",
             "version": {
+              "conventionalCommits": false,
               "generator": "@nx/js:release-version",
               "generatorOptions": {},
               "git": {
@@ -1455,6 +1488,7 @@ describe('createNxReleaseConfig()', () => {
                 "projectsRelationship": "fixed",
                 "releaseTagPattern": "v{version}",
                 "version": {
+                  "conventionalCommits": false,
                   "generator": "@nx/js:release-version",
                   "generatorOptions": {},
                 },
@@ -1463,6 +1497,7 @@ describe('createNxReleaseConfig()', () => {
             "projectsRelationship": "fixed",
             "releaseTagPattern": "v{version}",
             "version": {
+              "conventionalCommits": false,
               "generator": "@nx/js:release-version",
               "generatorOptions": {},
               "git": {
@@ -1532,6 +1567,7 @@ describe('createNxReleaseConfig()', () => {
                 "projectsRelationship": "fixed",
                 "releaseTagPattern": "v{version}",
                 "version": {
+                  "conventionalCommits": false,
                   "generator": "@nx/js:release-version",
                   "generatorOptions": {},
                 },
@@ -1540,6 +1576,7 @@ describe('createNxReleaseConfig()', () => {
             "projectsRelationship": "fixed",
             "releaseTagPattern": "v{version}",
             "version": {
+              "conventionalCommits": false,
               "generator": "@nx/js:release-version",
               "generatorOptions": {},
               "git": {
@@ -1655,6 +1692,7 @@ describe('createNxReleaseConfig()', () => {
                 "projectsRelationship": "fixed",
                 "releaseTagPattern": "v{version}",
                 "version": {
+                  "conventionalCommits": false,
                   "generator": "@nx/js:release-version",
                   "generatorOptions": {},
                 },
@@ -1667,6 +1705,7 @@ describe('createNxReleaseConfig()', () => {
                 "projectsRelationship": "fixed",
                 "releaseTagPattern": "v{version}",
                 "version": {
+                  "conventionalCommits": false,
                   "generator": "@nx/js:release-version",
                   "generatorOptions": {},
                 },
@@ -1689,6 +1728,7 @@ describe('createNxReleaseConfig()', () => {
                 "projectsRelationship": "fixed",
                 "releaseTagPattern": "v{version}",
                 "version": {
+                  "conventionalCommits": false,
                   "generator": "@nx/js:release-version",
                   "generatorOptions": {},
                 },
@@ -1697,6 +1737,7 @@ describe('createNxReleaseConfig()', () => {
             "projectsRelationship": "fixed",
             "releaseTagPattern": "v{version}",
             "version": {
+              "conventionalCommits": false,
               "generator": "@nx/js:release-version",
               "generatorOptions": {},
               "git": {
@@ -1799,6 +1840,7 @@ describe('createNxReleaseConfig()', () => {
                 "projectsRelationship": "fixed",
                 "releaseTagPattern": "v{version}",
                 "version": {
+                  "conventionalCommits": false,
                   "generator": "@nx/js:release-version",
                   "generatorOptions": {},
                 },
@@ -1821,6 +1863,7 @@ describe('createNxReleaseConfig()', () => {
                 "projectsRelationship": "fixed",
                 "releaseTagPattern": "{projectName}-{version}",
                 "version": {
+                  "conventionalCommits": false,
                   "generator": "@nx/js:release-version",
                   "generatorOptions": {},
                 },
@@ -1829,6 +1872,7 @@ describe('createNxReleaseConfig()', () => {
             "projectsRelationship": "fixed",
             "releaseTagPattern": "v{version}",
             "version": {
+              "conventionalCommits": false,
               "generator": "@nx/js:release-version",
               "generatorOptions": {},
               "git": {
@@ -2165,6 +2209,7 @@ describe('createNxReleaseConfig()', () => {
                 "projectsRelationship": "independent",
                 "releaseTagPattern": "{projectName}@{version}",
                 "version": {
+                  "conventionalCommits": false,
                   "generator": "@nx/js:release-version",
                   "generatorOptions": {},
                 },
@@ -2178,6 +2223,7 @@ describe('createNxReleaseConfig()', () => {
                 "projectsRelationship": "fixed",
                 "releaseTagPattern": "v{version}",
                 "version": {
+                  "conventionalCommits": false,
                   "generator": "@nx/js:release-version",
                   "generatorOptions": {},
                 },
@@ -2186,6 +2232,7 @@ describe('createNxReleaseConfig()', () => {
             "projectsRelationship": "independent",
             "releaseTagPattern": "{projectName}@{version}",
             "version": {
+              "conventionalCommits": false,
               "generator": "@nx/js:release-version",
               "generatorOptions": {},
               "git": {
@@ -2199,6 +2246,306 @@ describe('createNxReleaseConfig()', () => {
               },
             },
           },
+        }
+      `);
+    });
+  });
+
+  describe('version.conventionalCommits shorthand', () => {
+    it('should update appropriate default values for generatorOptions when applied at the root', async () => {
+      const res = await createNxReleaseConfig(projectGraph, {
+        version: {
+          conventionalCommits: true,
+        },
+      });
+      expect(res).toMatchInlineSnapshot(`
+        {
+          "error": null,
+          "nxReleaseConfig": {
+            "changelog": {
+              "git": {
+                "commit": true,
+                "commitArgs": "",
+                "commitMessage": "chore(release): publish {version}",
+                "tag": true,
+                "tagArgs": "",
+                "tagMessage": "",
+              },
+              "projectChangelogs": false,
+              "workspaceChangelog": {
+                "createRelease": false,
+                "entryWhenNoChanges": "This was a version bump only, there were no code changes.",
+                "file": "{workspaceRoot}/CHANGELOG.md",
+                "renderOptions": {
+                  "authors": true,
+                  "commitReferences": true,
+                  "versionTitleDate": true,
+                },
+                "renderer": "nx/changelog-renderer",
+              },
+            },
+            "git": {
+              "commit": false,
+              "commitArgs": "",
+              "commitMessage": "chore(release): publish {version}",
+              "tag": false,
+              "tagArgs": "",
+              "tagMessage": "",
+            },
+            "groups": {
+              "__default__": {
+                "changelog": false,
+                "projects": [
+                  "lib-a",
+                  "lib-b",
+                  "nx",
+                ],
+                "projectsRelationship": "fixed",
+                "releaseTagPattern": "v{version}",
+                "version": {
+                  "conventionalCommits": true,
+                  "generator": "@nx/js:release-version",
+                  "generatorOptions": {
+                    "currentVersionResolver": "git-tag",
+                    "specifierSource": "conventional-commits",
+                  },
+                },
+              },
+            },
+            "projectsRelationship": "fixed",
+            "releaseTagPattern": "v{version}",
+            "version": {
+              "conventionalCommits": true,
+              "generator": "@nx/js:release-version",
+              "generatorOptions": {
+                "currentVersionResolver": "git-tag",
+                "specifierSource": "conventional-commits",
+              },
+              "git": {
+                "commit": false,
+                "commitArgs": "",
+                "commitMessage": "chore(release): publish {version}",
+                "stageChanges": true,
+                "tag": false,
+                "tagArgs": "",
+                "tagMessage": "",
+              },
+            },
+          },
+        }
+      `);
+    });
+
+    it('should be possible to override at the group level and produce the appropriate default generatorOptions', async () => {
+      const res = await createNxReleaseConfig(projectGraph, {
+        version: {
+          conventionalCommits: true,
+        },
+        groups: {
+          'group-1': {
+            projects: 'nx',
+            version: {
+              conventionalCommits: false,
+            },
+          },
+        },
+      });
+      expect(res).toMatchInlineSnapshot(`
+        {
+          "error": null,
+          "nxReleaseConfig": {
+            "changelog": {
+              "git": {
+                "commit": true,
+                "commitArgs": "",
+                "commitMessage": "chore(release): publish {version}",
+                "tag": true,
+                "tagArgs": "",
+                "tagMessage": "",
+              },
+              "projectChangelogs": false,
+              "workspaceChangelog": {
+                "createRelease": false,
+                "entryWhenNoChanges": "This was a version bump only, there were no code changes.",
+                "file": "{workspaceRoot}/CHANGELOG.md",
+                "renderOptions": {
+                  "authors": true,
+                  "commitReferences": true,
+                  "versionTitleDate": true,
+                },
+                "renderer": "nx/changelog-renderer",
+              },
+            },
+            "git": {
+              "commit": false,
+              "commitArgs": "",
+              "commitMessage": "chore(release): publish {version}",
+              "tag": false,
+              "tagArgs": "",
+              "tagMessage": "",
+            },
+            "groups": {
+              "group-1": {
+                "changelog": false,
+                "projects": [
+                  "nx",
+                ],
+                "projectsRelationship": "fixed",
+                "releaseTagPattern": "v{version}",
+                "version": {
+                  "conventionalCommits": false,
+                  "generator": "@nx/js:release-version",
+                  "generatorOptions": {},
+                },
+              },
+            },
+            "projectsRelationship": "fixed",
+            "releaseTagPattern": "v{version}",
+            "version": {
+              "conventionalCommits": true,
+              "generator": "@nx/js:release-version",
+              "generatorOptions": {
+                "currentVersionResolver": "git-tag",
+                "specifierSource": "conventional-commits",
+              },
+              "git": {
+                "commit": false,
+                "commitArgs": "",
+                "commitMessage": "chore(release): publish {version}",
+                "stageChanges": true,
+                "tag": false,
+                "tagArgs": "",
+                "tagMessage": "",
+              },
+            },
+          },
+        }
+      `);
+    });
+
+    it('should not error if the shorthand is combined with unrelated generatorOptions', async () => {
+      const res = await createNxReleaseConfig(projectGraph, {
+        version: {
+          conventionalCommits: true,
+          generatorOptions: {
+            someUnrelatedOption: 'foobar',
+          },
+        },
+      });
+      expect(res).toMatchInlineSnapshot(`
+        {
+          "error": null,
+          "nxReleaseConfig": {
+            "changelog": {
+              "git": {
+                "commit": true,
+                "commitArgs": "",
+                "commitMessage": "chore(release): publish {version}",
+                "tag": true,
+                "tagArgs": "",
+                "tagMessage": "",
+              },
+              "projectChangelogs": false,
+              "workspaceChangelog": {
+                "createRelease": false,
+                "entryWhenNoChanges": "This was a version bump only, there were no code changes.",
+                "file": "{workspaceRoot}/CHANGELOG.md",
+                "renderOptions": {
+                  "authors": true,
+                  "commitReferences": true,
+                  "versionTitleDate": true,
+                },
+                "renderer": "nx/changelog-renderer",
+              },
+            },
+            "git": {
+              "commit": false,
+              "commitArgs": "",
+              "commitMessage": "chore(release): publish {version}",
+              "tag": false,
+              "tagArgs": "",
+              "tagMessage": "",
+            },
+            "groups": {
+              "__default__": {
+                "changelog": false,
+                "projects": [
+                  "lib-a",
+                  "lib-b",
+                  "nx",
+                ],
+                "projectsRelationship": "fixed",
+                "releaseTagPattern": "v{version}",
+                "version": {
+                  "conventionalCommits": true,
+                  "generator": "@nx/js:release-version",
+                  "generatorOptions": {
+                    "currentVersionResolver": "git-tag",
+                    "someUnrelatedOption": "foobar",
+                    "specifierSource": "conventional-commits",
+                  },
+                },
+              },
+            },
+            "projectsRelationship": "fixed",
+            "releaseTagPattern": "v{version}",
+            "version": {
+              "conventionalCommits": true,
+              "generator": "@nx/js:release-version",
+              "generatorOptions": {
+                "currentVersionResolver": "git-tag",
+                "someUnrelatedOption": "foobar",
+                "specifierSource": "conventional-commits",
+              },
+              "git": {
+                "commit": false,
+                "commitArgs": "",
+                "commitMessage": "chore(release): publish {version}",
+                "stageChanges": true,
+                "tag": false,
+                "tagArgs": "",
+                "tagMessage": "",
+              },
+            },
+          },
+        }
+      `);
+    });
+
+    it('should error if the shorthand is combined with related generatorOptions', async () => {
+      const res1 = await createNxReleaseConfig(projectGraph, {
+        version: {
+          conventionalCommits: true,
+          generatorOptions: {
+            specifierSource: 'prompt',
+          },
+        },
+      });
+      expect(res1).toMatchInlineSnapshot(`
+        {
+          "error": {
+            "code": "CONVENTIONAL_COMMITS_SHORTHAND_MIXED_WITH_OVERLAPPING_GENERATOR_OPTIONS",
+            "data": {},
+          },
+          "nxReleaseConfig": null,
+        }
+      `);
+
+      const res2 = await createNxReleaseConfig(projectGraph, {
+        version: {
+          conventionalCommits: true,
+          generatorOptions: {
+            currentVersionResolver: 'registry',
+          },
+        },
+      });
+      expect(res2).toMatchInlineSnapshot(`
+        {
+          "error": {
+            "code": "CONVENTIONAL_COMMITS_SHORTHAND_MIXED_WITH_OVERLAPPING_GENERATOR_OPTIONS",
+            "data": {},
+          },
+          "nxReleaseConfig": null,
         }
       `);
     });

--- a/packages/nx/src/command-line/release/config/config.spec.ts
+++ b/packages/nx/src/command-line/release/config/config.spec.ts
@@ -2252,6 +2252,178 @@ describe('createNxReleaseConfig()', () => {
   });
 
   describe('version.conventionalCommits shorthand', () => {
+    it('should be implicitly false and not interfere with its long-form equivalent generatorOptions when not explicitly set', async () => {
+      const res1 = await createNxReleaseConfig(projectGraph, {
+        version: {
+          generatorOptions: {
+            currentVersionResolver: 'git-tag',
+            specifierSource: 'conventional-commits',
+          },
+        },
+      });
+      expect(res1).toMatchInlineSnapshot(`
+        {
+          "error": null,
+          "nxReleaseConfig": {
+            "changelog": {
+              "git": {
+                "commit": true,
+                "commitArgs": "",
+                "commitMessage": "chore(release): publish {version}",
+                "tag": true,
+                "tagArgs": "",
+                "tagMessage": "",
+              },
+              "projectChangelogs": false,
+              "workspaceChangelog": {
+                "createRelease": false,
+                "entryWhenNoChanges": "This was a version bump only, there were no code changes.",
+                "file": "{workspaceRoot}/CHANGELOG.md",
+                "renderOptions": {
+                  "authors": true,
+                  "commitReferences": true,
+                  "versionTitleDate": true,
+                },
+                "renderer": "nx/changelog-renderer",
+              },
+            },
+            "git": {
+              "commit": false,
+              "commitArgs": "",
+              "commitMessage": "chore(release): publish {version}",
+              "tag": false,
+              "tagArgs": "",
+              "tagMessage": "",
+            },
+            "groups": {
+              "__default__": {
+                "changelog": false,
+                "projects": [
+                  "lib-a",
+                  "lib-b",
+                  "nx",
+                ],
+                "projectsRelationship": "fixed",
+                "releaseTagPattern": "v{version}",
+                "version": {
+                  "conventionalCommits": false,
+                  "generator": "@nx/js:release-version",
+                  "generatorOptions": {
+                    "currentVersionResolver": "git-tag",
+                    "specifierSource": "conventional-commits",
+                  },
+                },
+              },
+            },
+            "projectsRelationship": "fixed",
+            "releaseTagPattern": "v{version}",
+            "version": {
+              "conventionalCommits": false,
+              "generator": "@nx/js:release-version",
+              "generatorOptions": {
+                "currentVersionResolver": "git-tag",
+                "specifierSource": "conventional-commits",
+              },
+              "git": {
+                "commit": false,
+                "commitArgs": "",
+                "commitMessage": "chore(release): publish {version}",
+                "stageChanges": true,
+                "tag": false,
+                "tagArgs": "",
+                "tagMessage": "",
+              },
+            },
+          },
+        }
+      `);
+
+      const res2 = await createNxReleaseConfig(projectGraph, {
+        version: {
+          generatorOptions: {
+            currentVersionResolver: 'registry',
+            specifierSource: 'prompt',
+          },
+        },
+      });
+      expect(res2).toMatchInlineSnapshot(`
+        {
+          "error": null,
+          "nxReleaseConfig": {
+            "changelog": {
+              "git": {
+                "commit": true,
+                "commitArgs": "",
+                "commitMessage": "chore(release): publish {version}",
+                "tag": true,
+                "tagArgs": "",
+                "tagMessage": "",
+              },
+              "projectChangelogs": false,
+              "workspaceChangelog": {
+                "createRelease": false,
+                "entryWhenNoChanges": "This was a version bump only, there were no code changes.",
+                "file": "{workspaceRoot}/CHANGELOG.md",
+                "renderOptions": {
+                  "authors": true,
+                  "commitReferences": true,
+                  "versionTitleDate": true,
+                },
+                "renderer": "nx/changelog-renderer",
+              },
+            },
+            "git": {
+              "commit": false,
+              "commitArgs": "",
+              "commitMessage": "chore(release): publish {version}",
+              "tag": false,
+              "tagArgs": "",
+              "tagMessage": "",
+            },
+            "groups": {
+              "__default__": {
+                "changelog": false,
+                "projects": [
+                  "lib-a",
+                  "lib-b",
+                  "nx",
+                ],
+                "projectsRelationship": "fixed",
+                "releaseTagPattern": "v{version}",
+                "version": {
+                  "conventionalCommits": false,
+                  "generator": "@nx/js:release-version",
+                  "generatorOptions": {
+                    "currentVersionResolver": "registry",
+                    "specifierSource": "prompt",
+                  },
+                },
+              },
+            },
+            "projectsRelationship": "fixed",
+            "releaseTagPattern": "v{version}",
+            "version": {
+              "conventionalCommits": false,
+              "generator": "@nx/js:release-version",
+              "generatorOptions": {
+                "currentVersionResolver": "registry",
+                "specifierSource": "prompt",
+              },
+              "git": {
+                "commit": false,
+                "commitArgs": "",
+                "commitMessage": "chore(release): publish {version}",
+                "stageChanges": true,
+                "tag": false,
+                "tagArgs": "",
+                "tagMessage": "",
+              },
+            },
+          },
+        }
+      `);
+    });
+
     it('should update appropriate default values for generatorOptions when applied at the root', async () => {
       const res = await createNxReleaseConfig(projectGraph, {
         version: {

--- a/packages/nx/src/command-line/release/config/config.ts
+++ b/packages/nx/src/command-line/release/config/config.ts
@@ -73,7 +73,8 @@ export interface CreateNxReleaseConfigError {
     | 'RELEASE_GROUP_MATCHES_NO_PROJECTS'
     | 'RELEASE_GROUP_RELEASE_TAG_PATTERN_VERSION_PLACEHOLDER_MISSING_OR_EXCESSIVE'
     | 'PROJECT_MATCHES_MULTIPLE_GROUPS'
-    | 'PROJECTS_MISSING_TARGET';
+    | 'PROJECTS_MISSING_TARGET'
+    | 'CONVENTIONAL_COMMITS_SHORTHAND_MIXED_WITH_OVERLAPPING_GENERATOR_OPTIONS';
   data: Record<string, string | string[]>;
 }
 
@@ -91,6 +92,16 @@ export async function createNxReleaseConfig(
     return {
       error: {
         code: 'PROJECTS_AND_GROUPS_DEFINED',
+        data: {},
+      },
+      nxReleaseConfig: null,
+    };
+  }
+
+  if (hasInvalidConventionalCommitsConfig(userConfig)) {
+    return {
+      error: {
+        code: 'CONVENTIONAL_COMMITS_SHORTHAND_MIXED_WITH_OVERLAPPING_GENERATOR_OPTIONS',
         data: {},
       },
       nxReleaseConfig: null,
@@ -121,14 +132,22 @@ export async function createNxReleaseConfig(
   const workspaceProjectsRelationship =
     userConfig.projectsRelationship || 'fixed';
 
+  const defaultGeneratorOptions = userConfig.version?.conventionalCommits
+    ? {
+        currentVersionResolver: 'git-tag',
+        specifierSource: 'conventional-commits',
+      }
+    : {};
+
   const WORKSPACE_DEFAULTS: Omit<NxReleaseConfig, 'groups'> = {
     // By default all projects in all groups are released together
     projectsRelationship: workspaceProjectsRelationship,
     git: gitDefaults,
     version: {
       git: versionGitDefaults,
+      conventionalCommits: userConfig.version?.conventionalCommits || false,
       generator: '@nx/js:release-version',
-      generatorOptions: {},
+      generatorOptions: defaultGeneratorOptions,
     },
     changelog: {
       git: changelogGitDefaults,
@@ -174,6 +193,7 @@ export async function createNxReleaseConfig(
   const GROUP_DEFAULTS: Omit<NxReleaseConfig['groups'][string], 'projects'> = {
     projectsRelationship: groupProjectsRelationship,
     version: {
+      conventionalCommits: false,
       generator: '@nx/js:release-version',
       generatorOptions: {},
     },
@@ -390,11 +410,26 @@ export async function createNxReleaseConfig(
           : userConfig.releaseTagPattern || defaultFixedReleaseTagPattern),
     };
 
-    releaseGroups[releaseGroupName] = deepMergeDefaults([groupDefaults], {
+    const finalReleaseGroup = deepMergeDefaults([groupDefaults], {
       ...releaseGroup,
       // Ensure that the resolved project names take priority over the original user config (which could have contained unresolved globs etc)
       projects: matchingProjects,
     });
+
+    // Apply conventionalCommits shorthand to the final group if explicitly configured in the original group
+    if (releaseGroup.version?.conventionalCommits === true) {
+      finalReleaseGroup.version.generatorOptions = {
+        ...finalReleaseGroup.version.generatorOptions,
+        currentVersionResolver: 'git-tag',
+        specifierSource: 'conventional-commits',
+      };
+    }
+    if (releaseGroup.version?.conventionalCommits === false) {
+      delete finalReleaseGroup.version.generatorOptions.currentVersionResolver;
+      delete finalReleaseGroup.version.generatorOptions.specifierSource;
+    }
+
+    releaseGroups[releaseGroupName] = finalReleaseGroup;
   }
 
   return {
@@ -477,6 +512,17 @@ export async function handleNxReleaseConfigError(
         ]);
         output.error({
           title: `Release group "${error.data.releaseGroupName}" has an invalid releaseTagPattern. Please ensure the pattern contains exactly one instance of the "{version}" placeholder`,
+          bodyLines: [nxJsonMessage],
+        });
+      }
+      break;
+    case 'CONVENTIONAL_COMMITS_SHORTHAND_MIXED_WITH_OVERLAPPING_GENERATOR_OPTIONS':
+      {
+        const nxJsonMessage = await resolveNxJsonConfigErrorMessage([
+          'release',
+        ]);
+        output.error({
+          title: `You have configured both the shorthand "version.conventionalCommits" and one or more of the related "version.generatorOptions" that it sets for you. Please use one or the other:`,
           bodyLines: [nxJsonMessage],
         });
       }
@@ -599,4 +645,34 @@ function deepMergeDefaults<T>(
   }
 
   return result as DeepRequired<T>;
+}
+
+/**
+ * We want to prevent users from setting both the conventionalCommits shorthand and any of the related
+ * generatorOptions at the same time, since it is at best redundant, and at worst invalid.
+ */
+function hasInvalidConventionalCommitsConfig(
+  userConfig: NxJsonConfiguration['release']
+): boolean {
+  // at the root
+  if (
+    userConfig.version?.conventionalCommits === true &&
+    (userConfig.version?.generatorOptions?.currentVersionResolver ||
+      userConfig.version?.generatorOptions?.specifierSource)
+  ) {
+    return true;
+  }
+  // within any groups
+  if (userConfig.groups) {
+    for (const group of Object.values(userConfig.groups)) {
+      if (
+        group.version?.conventionalCommits === true &&
+        (group.version?.generatorOptions?.currentVersionResolver ||
+          group.version?.generatorOptions?.specifierSource)
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
 }

--- a/packages/nx/src/command-line/release/config/config.ts
+++ b/packages/nx/src/command-line/release/config/config.ts
@@ -262,6 +262,19 @@ export async function createNxReleaseConfig(
   const rootVersionWithoutGit = { ...rootVersionConfig };
   delete rootVersionWithoutGit.git;
 
+  // Apply conventionalCommits shorthand to the final group defaults if explicitly configured in the original user config
+  if (userConfig.version?.conventionalCommits === true) {
+    rootVersionWithoutGit.generatorOptions = {
+      ...rootVersionWithoutGit.generatorOptions,
+      currentVersionResolver: 'git-tag',
+      specifierSource: 'conventional-commits',
+    };
+  }
+  if (userConfig.version?.conventionalCommits === false) {
+    delete rootVersionWithoutGit.generatorOptions.currentVersionResolver;
+    delete rootVersionWithoutGit.generatorOptions.specifierSource;
+  }
+
   const groups: NxReleaseConfig['groups'] =
     userConfig.groups && Object.keys(userConfig.groups).length
       ? ensureProjectsConfigIsArray(userConfig.groups)
@@ -424,7 +437,10 @@ export async function createNxReleaseConfig(
         specifierSource: 'conventional-commits',
       };
     }
-    if (releaseGroup.version?.conventionalCommits === false) {
+    if (
+      releaseGroup.version?.conventionalCommits === false &&
+      releaseGroupName !== IMPLICIT_DEFAULT_RELEASE_GROUP
+    ) {
       delete finalReleaseGroup.version.generatorOptions.currentVersionResolver;
       delete finalReleaseGroup.version.generatorOptions.specifierSource;
     }

--- a/packages/nx/src/command-line/release/config/filter-release-groups.spec.ts
+++ b/packages/nx/src/command-line/release/config/filter-release-groups.spec.ts
@@ -23,6 +23,7 @@ describe('filterReleaseGroups()', () => {
         projectChangelogs: false,
       },
       version: {
+        conventionalCommits: false,
         generator: '',
         generatorOptions: {},
         git: {
@@ -91,6 +92,7 @@ describe('filterReleaseGroups()', () => {
           projects: ['lib-a'],
           changelog: false,
           version: {
+            conventionalCommits: false,
             generator: '',
             generatorOptions: {},
           },
@@ -117,6 +119,7 @@ describe('filterReleaseGroups()', () => {
           projects: ['lib-a'],
           changelog: false,
           version: {
+            conventionalCommits: false,
             generator: '',
             generatorOptions: {},
           },
@@ -127,6 +130,7 @@ describe('filterReleaseGroups()', () => {
           projects: ['lib-b'],
           changelog: false,
           version: {
+            conventionalCommits: false,
             generator: '',
             generatorOptions: {},
           },
@@ -147,6 +151,7 @@ describe('filterReleaseGroups()', () => {
             "projectsRelationship": "fixed",
             "releaseTagPattern": "",
             "version": {
+              "conventionalCommits": false,
               "generator": "",
               "generatorOptions": {},
             },
@@ -160,6 +165,7 @@ describe('filterReleaseGroups()', () => {
             "projectsRelationship": "fixed",
             "releaseTagPattern": "",
             "version": {
+              "conventionalCommits": false,
               "generator": "",
               "generatorOptions": {},
             },
@@ -177,6 +183,7 @@ describe('filterReleaseGroups()', () => {
             "projectsRelationship": "fixed",
             "releaseTagPattern": "",
             "version": {
+              "conventionalCommits": false,
               "generator": "",
               "generatorOptions": {},
             },
@@ -192,6 +199,7 @@ describe('filterReleaseGroups()', () => {
             "projectsRelationship": "fixed",
             "releaseTagPattern": "",
             "version": {
+              "conventionalCommits": false,
               "generator": "",
               "generatorOptions": {},
             },
@@ -209,6 +217,7 @@ describe('filterReleaseGroups()', () => {
           projects: ['lib-a', 'lib-a'],
           changelog: false,
           version: {
+            conventionalCommits: false,
             generator: '',
             generatorOptions: {},
           },
@@ -234,6 +243,7 @@ describe('filterReleaseGroups()', () => {
           projects: ['lib-a'],
           changelog: false,
           version: {
+            conventionalCommits: false,
             generator: '',
             generatorOptions: {},
           },
@@ -244,6 +254,7 @@ describe('filterReleaseGroups()', () => {
           projects: ['lib-b'],
           changelog: false,
           version: {
+            conventionalCommits: false,
             generator: '',
             generatorOptions: {},
           },
@@ -270,6 +281,7 @@ describe('filterReleaseGroups()', () => {
           projects: ['lib-a'],
           changelog: false,
           version: {
+            conventionalCommits: false,
             generator: '',
             generatorOptions: {},
           },
@@ -280,6 +292,7 @@ describe('filterReleaseGroups()', () => {
           projects: ['lib-b'],
           changelog: false,
           version: {
+            conventionalCommits: false,
             generator: '',
             generatorOptions: {},
           },
@@ -300,6 +313,7 @@ describe('filterReleaseGroups()', () => {
             "projectsRelationship": "independent",
             "releaseTagPattern": "",
             "version": {
+              "conventionalCommits": false,
               "generator": "",
               "generatorOptions": {},
             },
@@ -317,6 +331,7 @@ describe('filterReleaseGroups()', () => {
             "projectsRelationship": "independent",
             "releaseTagPattern": "",
             "version": {
+              "conventionalCommits": false,
               "generator": "",
               "generatorOptions": {},
             },
@@ -350,6 +365,7 @@ describe('filterReleaseGroups()', () => {
           projects: ['lib-a'],
           changelog: false,
           version: {
+            conventionalCommits: false,
             generator: '',
             generatorOptions: {},
           },
@@ -360,6 +376,7 @@ describe('filterReleaseGroups()', () => {
           projects: ['lib-b'],
           changelog: false,
           version: {
+            conventionalCommits: false,
             generator: '',
             generatorOptions: {},
           },
@@ -380,6 +397,7 @@ describe('filterReleaseGroups()', () => {
             "projectsRelationship": "fixed",
             "releaseTagPattern": "",
             "version": {
+              "conventionalCommits": false,
               "generator": "",
               "generatorOptions": {},
             },
@@ -397,6 +415,7 @@ describe('filterReleaseGroups()', () => {
             "projectsRelationship": "fixed",
             "releaseTagPattern": "",
             "version": {
+              "conventionalCommits": false,
               "generator": "",
               "generatorOptions": {},
             },

--- a/packages/nx/src/command-line/release/utils/shared.spec.ts
+++ b/packages/nx/src/command-line/release/utils/shared.spec.ts
@@ -11,6 +11,7 @@ describe('shared', () => {
             projectsRelationship: 'independent',
             projects: ['foo'], // single project, will get flattened in the final commit message
             version: {
+              conventionalCommits: false,
               generator: '@nx/js:version',
               generatorOptions: {},
             },
@@ -22,6 +23,7 @@ describe('shared', () => {
             projectsRelationship: 'fixed',
             projects: ['bar', 'baz'],
             version: {
+              conventionalCommits: false,
               generator: '@nx/js:version',
               generatorOptions: {},
             },
@@ -82,6 +84,7 @@ describe('shared', () => {
               'node',
             ],
             version: {
+              conventionalCommits: true,
               generator: '@nx/js:release-version',
               generatorOptions: {
                 specifierSource: 'conventional-commits',

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -57,6 +57,17 @@ interface NxInstallationConfiguration {
 interface NxReleaseVersionConfiguration {
   generator?: string;
   generatorOptions?: Record<string, unknown>;
+  /**
+   * Enabling support for parsing semver bumps via conventional commits and reading the current version from
+   * git tags is so common that we have a first class shorthand for it, which is false by default.
+   *
+   * Setting this to true is the same as adding the following to version.generatorOptions:
+   * - currentVersionResolver: "git-tag"
+   * - specifierSource: "conventional-commits"
+   *
+   * If the user attempts to mix and match these options with the shorthand, we will provide a helpful error.
+   */
+  conventionalCommits?: boolean;
 }
 
 /**


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

In the very common case of enabling conventional commits based versioning the following two options within nested config are required:

```json
"release": {
  "version": {
    "generatorOptions": {
      "specifierSource": "conventional-commits",
      "currentVersionResolver": "git-tag"
    }
  }
}
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

In the very common case of enabling conventional commits based versioning the following readable shorthand is available:

```json
"release": {
  "version": {
    "conventionalCommits": true
  }
}
```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
