### PR TITLE
feat(core): forward stdin to commands started via rust

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -16,7 +16,7 @@ packages/jest/src/schematics/**/files/**/*.json
 packages/nx/src/plugins/js/lock-file/__fixtures__/**/*.*
 packages/**/schematics/**/files/**/*.html
 packages/**/generators/**/files/**/*.html
-packages/nx/src/native/
+packages/nx/src/native/**/*.rs
 nx-dev/nx-dev/.next/
 nx-dev/nx-dev/public/documentation
 graph/client/src/assets/environment.js

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.4.1",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "ctor"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,17 +1210,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libredox"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
-dependencies = [
- "bitflags 2.4.1",
- "libc",
- "redox_syscall 0.4.1",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,12 +1521,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "numtoa"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
-
-[[package]]
 name = "nx"
 version = "0.1.0"
 dependencies = [
@@ -1520,6 +1528,7 @@ dependencies = [
  "assert_fs",
  "colored",
  "crossbeam-channel",
+ "crossterm",
  "dashmap",
  "dunce",
  "fs_extra",
@@ -1543,7 +1552,6 @@ dependencies = [
  "swc_ecma_dep_graph",
  "swc_ecma_parser",
  "swc_ecma_visit",
- "termion",
  "thiserror",
  "tokio",
  "tracing",
@@ -1865,12 +1873,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_termios"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
-
-[[package]]
 name = "regex"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2102,6 +2104,27 @@ name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -2404,18 +2427,6 @@ dependencies = [
  "redox_syscall 0.3.5",
  "rustix",
  "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "termion"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "417813675a504dfbbf21bfde32c03e5bf9f2413999962b479023c02848c1c7a5"
-dependencies = [
- "libc",
- "libredox",
- "numtoa",
- "redox_termios",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1185,6 +1185,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+ "redox_syscall 0.4.1",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1496,6 +1507,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "numtoa"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+
+[[package]]
 name = "nx"
 version = "0.1.0"
 dependencies = [
@@ -1526,7 +1543,7 @@ dependencies = [
  "swc_ecma_dep_graph",
  "swc_ecma_parser",
  "swc_ecma_visit",
- "term_size",
+ "termion",
  "thiserror",
  "tokio",
  "tracing",
@@ -1846,6 +1863,12 @@ checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
+
+[[package]]
+name = "redox_termios"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
 
 [[package]]
 name = "regex"
@@ -2384,13 +2407,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "term_size"
-version = "0.3.2"
+name = "termion"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
+checksum = "417813675a504dfbbf21bfde32c03e5bf9f2413999962b479023c02848c1c7a5"
 dependencies = [
  "libc",
- "winapi",
+ "libredox",
+ "numtoa",
+ "redox_termios",
 ]
 
 [[package]]

--- a/packages/nx/Cargo.toml
+++ b/packages/nx/Cargo.toml
@@ -42,8 +42,7 @@ swc_common = "0.31.16"
 swc_ecma_parser = { version = "0.137.1", features = ["typescript"] }
 swc_ecma_visit = "0.93.0"
 swc_ecma_ast = "0.107.0"
-termion = "3.0.0"
-
+crossterm = "0.27.0"
 
 [lib]
 crate-type = ['cdylib']

--- a/packages/nx/Cargo.toml
+++ b/packages/nx/Cargo.toml
@@ -42,7 +42,8 @@ swc_common = "0.31.16"
 swc_ecma_parser = { version = "0.137.1", features = ["typescript"] }
 swc_ecma_visit = "0.93.0"
 swc_ecma_ast = "0.107.0"
-term_size = "0.3.2"
+termion = "3.0.0"
+
 
 [lib]
 crate-type = ['cdylib']

--- a/packages/nx/src/command-line/affected/affected.ts
+++ b/packages/nx/src/command-line/affected/affected.ts
@@ -114,8 +114,6 @@ export async function affected(
             extraTargetDependencies,
             { excludeTaskDependencies: false, loadDotEnvFiles: true }
           );
-          // fix for https://github.com/nrwl/nx/issues/1666
-          if (process.stdin['unref']) (process.stdin as any).unref();
           process.exit(status);
         }
         break;

--- a/packages/nx/src/command-line/release/publish.ts
+++ b/packages/nx/src/command-line/release/publish.ts
@@ -177,8 +177,6 @@ async function runPublishOnProjects(
     );
 
     if (status !== 0) {
-      // fix for https://github.com/nrwl/nx/issues/1666
-      if (process.stdin['unref']) (process.stdin as any).unref();
       process.exit(status);
     }
   }

--- a/packages/nx/src/command-line/run-many/run-many.ts
+++ b/packages/nx/src/command-line/run-many/run-many.ts
@@ -75,8 +75,6 @@ export async function runMany(
       extraTargetDependencies,
       extraOptions
     );
-    // fix for https://github.com/nrwl/nx/issues/1666
-    if (process.stdin['unref']) (process.stdin as any).unref();
     process.exit(status);
   }
 }

--- a/packages/nx/src/command-line/run/run-one.ts
+++ b/packages/nx/src/command-line/run/run-one.ts
@@ -89,8 +89,6 @@ export async function runOne(
       extraTargetDependencies,
       extraOptions
     );
-    // fix for https://github.com/nrwl/nx/issues/1666
-    if (process.stdin['unref']) (process.stdin as any).unref();
     process.exit(status);
   }
 }

--- a/packages/nx/src/native/command.rs
+++ b/packages/nx/src/native/command.rs
@@ -129,7 +129,7 @@ pub fn run_command(
 
     let (w, h) = terminal::size().unwrap_or((80, 24));
     let pair = pty_system.openpty(PtySize {
-        rows: r,
+        rows: h,
         cols: w,
         pixel_width: 0,
         pixel_height: 0,

--- a/packages/nx/src/native/tests/command.spec.ts
+++ b/packages/nx/src/native/tests/command.spec.ts
@@ -1,3 +1,4 @@
+import { checkUnknownRules } from 'ajv/dist/compile/util';
 import { PseudoTtyProcess } from '../../utils/child-process';
 import { runCommand } from '../index';
 
@@ -26,23 +27,26 @@ describe('runCommand', () => {
   it('should subscribe to output', (done) => {
     const childProcess = runCommand('echo "hello world"', process.cwd());
 
-    childProcess.onOutput((output) => {
-      expect(output.trim()).toEqual('hello world');
+    let output = '';
+    childProcess.onOutput((chunk) => {
+      output += chunk;
     });
-
+    
     childProcess.onExit(() => {
+      expect(output.trim()).toEqual('hello world');
       done();
     });
   });
 
   it('should be tty', (done) => {
     const childProcess = runCommand('node -p "process.stdout.isTTY"');
+    let output = '';
     childProcess.onOutput((out) => {
-      let output = JSON.stringify(out.trim());
+      output += out.trim();
       // check to make sure that we have ansi sequence characters only available in tty terminals
-      expect(output).toMatchInlineSnapshot(`""\\u001b[33mtrue\\u001b[39m""`);
     });
     childProcess.onExit((_) => {
+      expect(JSON.stringify(output)).toMatchInlineSnapshot(`""\\u001b[33mtrue\\u001b[39m""`);
       done();
     });
   });

--- a/packages/nx/src/native/tests/command.spec.ts
+++ b/packages/nx/src/native/tests/command.spec.ts
@@ -10,13 +10,17 @@ describe('runCommand', () => {
   });
   it('should kill a running command', () => {
     const childProcess = new PseudoTtyProcess(
-      runCommand('sleep 3 && echo "hello world" > file.txt', process.cwd())
+      runCommand(
+        'sleep 3 && echo "hello world" > file.txt',
+        process.cwd()
+      )
     );
     childProcess.onExit((exit_code) => {
       expect(exit_code).not.toEqual(0);
     });
     childProcess.kill();
     expect(childProcess.isAlive).toEqual(false);
+
   }, 1000);
 
   it('should subscribe to output', (done) => {
@@ -36,7 +40,7 @@ describe('runCommand', () => {
     childProcess.onOutput((out) => {
       let output = JSON.stringify(out.trim());
       // check to make sure that we have ansi sequence characters only available in tty terminals
-      expect(output).toMatchInlineSnapshot(`""""`);
+      expect(output).toMatchInlineSnapshot(`""\\u001b[33mtrue\\u001b[39m""`);
     });
     childProcess.onExit((_) => {
       done();

--- a/packages/nx/src/native/tests/command.spec.ts
+++ b/packages/nx/src/native/tests/command.spec.ts
@@ -1,4 +1,3 @@
-import { checkUnknownRules } from 'ajv/dist/compile/util';
 import { PseudoTtyProcess } from '../../utils/child-process';
 import { runCommand } from '../index';
 
@@ -11,17 +10,13 @@ describe('runCommand', () => {
   });
   it('should kill a running command', () => {
     const childProcess = new PseudoTtyProcess(
-      runCommand(
-        'sleep 3 && echo "hello world" > file.txt',
-        process.cwd()
-      )
+      runCommand('sleep 3 && echo "hello world" > file.txt', process.cwd())
     );
     childProcess.onExit((exit_code) => {
       expect(exit_code).not.toEqual(0);
     });
     childProcess.kill();
     expect(childProcess.isAlive).toEqual(false);
-
   }, 1000);
 
   it('should subscribe to output', (done) => {
@@ -31,7 +26,7 @@ describe('runCommand', () => {
     childProcess.onOutput((chunk) => {
       output += chunk;
     });
-    
+
     childProcess.onExit(() => {
       expect(output.trim()).toEqual('hello world');
       done();
@@ -46,7 +41,9 @@ describe('runCommand', () => {
       // check to make sure that we have ansi sequence characters only available in tty terminals
     });
     childProcess.onExit((_) => {
-      expect(JSON.stringify(output)).toMatchInlineSnapshot(`""\\u001b[33mtrue\\u001b[39m""`);
+      expect(JSON.stringify(output)).toMatchInlineSnapshot(
+        `""\\u001b[33mtrue\\u001b[39m""`
+      );
       done();
     });
   });

--- a/packages/nx/src/native/tests/command.spec.ts
+++ b/packages/nx/src/native/tests/command.spec.ts
@@ -10,17 +10,13 @@ describe('runCommand', () => {
   });
   it('should kill a running command', () => {
     const childProcess = new PseudoTtyProcess(
-      runCommand(
-        'sleep 3 && echo "hello world" > file.txt',
-        process.cwd()
-      )
+      runCommand('sleep 3 && echo "hello world" > file.txt', process.cwd())
     );
     childProcess.onExit((exit_code) => {
       expect(exit_code).not.toEqual(0);
     });
     childProcess.kill();
     expect(childProcess.isAlive).toEqual(false);
-
   }, 1000);
 
   it('should subscribe to output', (done) => {
@@ -40,7 +36,7 @@ describe('runCommand', () => {
     childProcess.onOutput((out) => {
       let output = JSON.stringify(out.trim());
       // check to make sure that we have ansi sequence characters only available in tty terminals
-      expect(output).toMatchInlineSnapshot(`""\\u001b[33mtrue\\u001b[39m""`);
+      expect(output).toMatchInlineSnapshot(`""""`);
     });
     childProcess.onExit((_) => {
       done();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Commands ran via rust do not have any access to user input

## Expected Behavior
Commands ran via rust receive stdin

## Related Issue(s)
This removes the fix for https://github.com/nrwl/nx/issues/1666 - we believe the issue should no longer be relevant and it was causing the command runner to hang on MacOS - if it recurs, we will look into reapplying some version of the fix.

Fixes #8269
