### PR TITLE
docs(core): fix typo

### DIFF
--- a/docs/shared/concepts/how-project-graph-is-built.md
+++ b/docs/shared/concepts/how-project-graph-is-built.md
@@ -1,6 +1,6 @@
 # How the Project Graph is Built
 
-Nx creates a graph of all the dependencies between projects in your workspace using two sources of information:
+Nx creates a graph of all the dependencies between projects in your workspace using three sources of information:
 
 1. Package dependencies defined in the `package.json` file for each project.
 


### PR DESCRIPTION
Found a typo in the docs and fixed it. It said two sources of info but listed three.