### PR TITLE
fix(linter): fix import of chalk for reporting

### DIFF
--- a/packages/eslint-plugin/src/utils/project-graph-utils.ts
+++ b/packages/eslint-plugin/src/utils/project-graph-utils.ts
@@ -4,7 +4,7 @@ import {
   readCachedProjectGraph,
 } from '@nx/devkit';
 import { isTerminalRun } from './runtime-lint-utils';
-import * as chalk from 'chalk';
+import chalk = require('chalk');
 import {
   createProjectRootMappings,
   ProjectRootMappings,


### PR DESCRIPTION
Depending on the import type, the chalk instance will look differently and the `reset` function might not be available.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #20752
