### PR TITLE
feat(graph): add tooltips to project details view

### DIFF
--- a/graph/project-details/src/lib/project-details.tsx
+++ b/graph/project-details/src/lib/project-details.tsx
@@ -13,6 +13,8 @@ import {
   useRouteConstructor,
 } from '@nx/graph/shared';
 import { TargetConfigurationDetails } from './target/target-configuration-details';
+import { PropertyInfoTooltip, Tooltip } from '@nx/graph/ui-tooltips';
+import { TooltipTriggerText } from './target/ui/tooltip-trigger-text';
 
 export interface ProjectDetailsProps {
   project: ProjectGraphProjectNode;
@@ -77,7 +79,16 @@ export function ProjectDetails({
         </div>
       </header>
       <div>
-        <h2 className="text-3xl mb-2">Targets</h2>
+        <h2 className="text-3xl mb-4">
+          <Tooltip
+            openAction="hover"
+            content={(<PropertyInfoTooltip type="targets" />) as any}
+          >
+            <span>
+              <TooltipTriggerText>Targets</TooltipTriggerText>
+            </span>
+          </Tooltip>
+        </h2>
         <ul>
           {Object.entries(projectData.targets ?? {}).map(
             ([targetName, target]) => {

--- a/graph/project-details/src/lib/target/source-info.tsx
+++ b/graph/project-details/src/lib/target/source-info.tsx
@@ -1,7 +1,34 @@
-export function SourceInfo(props: { data: Array<string> }) {
+import { SourcemapInfoToolTip, Tooltip } from '@nx/graph/ui-tooltips';
+import { InformationCircleIcon } from '@heroicons/react/24/outline';
+
+export function SourceInfo(props: {
+  data: Array<string>;
+  propertyKey: string;
+}) {
   return (
-    <span className="italic text-gray-500">
-      Created by {props.data[1]} from {props.data[0]}
+    <span className="inline-flex items-center gap-2">
+      <Tooltip
+        openAction="hover"
+        strategy="fixed"
+        placement="top-start"
+        showTooltipArrow={false}
+        content={
+          (
+            <SourcemapInfoToolTip
+              propertyKey={props.propertyKey}
+              plugin={props.data[1]}
+              file={props.data[0]}
+            />
+          ) as any
+        }
+      >
+        {/*<span className="italic text-gray-500">*/}
+        {/*  <InformationCircleIcon className="w-3 h-3" />*/}
+        {/*</span>*/}
+        <span className="italic text-gray-500">
+          Created by {props.data[1]} from {props.data[0]}
+        </span>
+      </Tooltip>
     </span>
   );
 }

--- a/graph/project-details/src/lib/target/source-info.tsx
+++ b/graph/project-details/src/lib/target/source-info.tsx
@@ -5,6 +5,9 @@ export function SourceInfo(props: {
   data: Array<string>;
   propertyKey: string;
 }) {
+  // Target property key is in the form `target.${targetName}`
+  // Every other property within in the target has the form `target.${targetName}.${propertyName}
+  const isTarget = props.propertyKey.split('.').length === 2;
   return (
     <span className="inline-flex items-center gap-2">
       <Tooltip
@@ -26,7 +29,7 @@ export function SourceInfo(props: {
         {/*  <InformationCircleIcon className="w-3 h-3" />*/}
         {/*</span>*/}
         <span className="italic text-gray-500">
-          Created by {props.data[1]} from {props.data[0]}
+          {isTarget ? 'Created' : 'Set'} by {props.data[1]} from {props.data[0]}
         </span>
       </Tooltip>
     </span>

--- a/graph/project-details/src/lib/target/target-configuration-details.tsx
+++ b/graph/project-details/src/lib/target/target-configuration-details.tsx
@@ -22,6 +22,8 @@ import { FadingCollapsible } from './fading-collapsible';
 import { TargetConfigurationProperty } from './target-configuration-property';
 import { selectSourceInfo } from './target-configuration-details.util';
 import { CopyToClipboard } from './copy-to-clipboard';
+import { PropertyInfoTooltip, Tooltip } from '@nx/graph/ui-tooltips';
+import { TooltipTriggerText } from './ui/tooltip-trigger-text';
 
 /* eslint-disable-next-line */
 export interface TargetProps {
@@ -40,7 +42,7 @@ export function TargetConfigurationDetails({
   const environment = useEnvironmentConfig()?.environment;
   const externalApiService = getExternalApiService();
   const navigate = useNavigate();
-  const routeContructor = useRouteConstructor();
+  const routeConstructor = useRouteConstructor();
   const [searchParams, setSearchParams] = useSearchParams();
   const [collapsed, setCollapsed] = useState(true);
 
@@ -120,7 +122,7 @@ export function TargetConfigurationDetails({
       });
     } else {
       navigate(
-        routeContructor(
+        routeConstructor(
           {
             pathname: `/tasks/${encodeURIComponent(targetName)}`,
             search: `?projects=${encodeURIComponent(projectName)}`,
@@ -187,9 +189,15 @@ export function TargetConfigurationDetails({
               }}
             />
             {targetConfiguration.cache && (
-              <span className="rounded-full inline-block text-xs bg-sky-500 dark:bg-sky-800 px-2 text-slate-50 mr-2">
-                Cacheable
-              </span>
+              <Tooltip
+                openAction="hover"
+                strategy="fixed"
+                content={(<PropertyInfoTooltip type="cacheable" />) as any}
+              >
+                <span className="rounded-full inline-block text-xs bg-sky-500 dark:bg-sky-800 px-2 text-slate-50 mr-2">
+                  Cacheable
+                </span>
+              </Tooltip>
             )}
             {environment === 'nx-console' && (
               <PlayIcon
@@ -229,9 +237,9 @@ export function TargetConfigurationDetails({
       {!collapsed && (
         <div className="p-4 text-base">
           <div className="mb-4 group">
-            <h4 className="font-bold">
+            <h4 className="mb-4">
               {singleCommand ? (
-                <>
+                <span className="font-bold">
                   Command
                   <span className="hidden group-hover:inline ml-2 mb-1">
                     <CopyToClipboard
@@ -240,9 +248,16 @@ export function TargetConfigurationDetails({
                       }
                     />
                   </span>
-                </>
+                </span>
               ) : (
-                'Executor'
+                <Tooltip
+                  openAction="hover"
+                  content={(<PropertyInfoTooltip type="executors" />) as any}
+                >
+                  <span className="font-bold">
+                    <TooltipTriggerText>Executor</TooltipTriggerText>
+                  </span>
+                </Tooltip>
               )}
             </h4>
             <p className="pl-5">
@@ -265,8 +280,15 @@ export function TargetConfigurationDetails({
 
           {targetConfiguration.inputs && (
             <div className="group">
-              <h4 className="font-bold">
-                Inputs
+              <h4 className="mb-4">
+                <Tooltip
+                  openAction="hover"
+                  content={(<PropertyInfoTooltip type="inputs" />) as any}
+                >
+                  <span className="font-bold">
+                    <TooltipTriggerText>Inputs</TooltipTriggerText>
+                  </span>
+                </Tooltip>
                 <span className="hidden group-hover:inline ml-2 mb-1">
                   <CopyToClipboard
                     onCopy={() =>
@@ -300,8 +322,15 @@ export function TargetConfigurationDetails({
           )}
           {targetConfiguration.outputs && (
             <div className="group">
-              <h4 className="font-bold">
-                Outputs
+              <h4 className="mb-4">
+                <Tooltip
+                  openAction="hover"
+                  content={(<PropertyInfoTooltip type="outputs" />) as any}
+                >
+                  <span className="font-bold">
+                    <TooltipTriggerText>Outputs</TooltipTriggerText>
+                  </span>
+                </Tooltip>
                 <span className="hidden group-hover:inline ml-2 mb-1">
                   <CopyToClipboard
                     onCopy={() =>
@@ -337,8 +366,15 @@ export function TargetConfigurationDetails({
           )}
           {targetConfiguration.dependsOn && (
             <div className="group">
-              <h4 className="font-bold">
-                Depends On
+              <h4 className="mb-4">
+                <Tooltip
+                  openAction="hover"
+                  content={(<PropertyInfoTooltip type="dependsOn" />) as any}
+                >
+                  <span className="font-bold">
+                    <TooltipTriggerText>Depends On</TooltipTriggerText>
+                  </span>
+                </Tooltip>
                 <span className="hidden group-hover:inline ml-2 mb-1">
                   <CopyToClipboard
                     onCopy={() =>
@@ -374,7 +410,16 @@ export function TargetConfigurationDetails({
 
           {shouldRenderOptions ? (
             <>
-              <h4 className="font-bold mb-2">Options</h4>
+              <h4 className="mb-4">
+                <Tooltip
+                  openAction="hover"
+                  content={(<PropertyInfoTooltip type="options" />) as any}
+                >
+                  <span className="font-bold">
+                    <TooltipTriggerText>Options</TooltipTriggerText>
+                  </span>
+                </Tooltip>
+              </h4>
               <div className="mb-4">
                 <FadingCollapsible>
                   <JsonCodeBlock
@@ -400,11 +445,20 @@ export function TargetConfigurationDetails({
 
           {shouldRenderConfigurations ? (
             <>
-              <h4 className="font-bold py-2">
-                Configurations{' '}
+              <h4 className="py-2 mb-4">
+                <Tooltip
+                  openAction="hover"
+                  content={
+                    (<PropertyInfoTooltip type="configurations" />) as any
+                  }
+                >
+                  <span className="font-bold">
+                    <TooltipTriggerText>Configurations</TooltipTriggerText>
+                  </span>
+                </Tooltip>{' '}
                 {targetConfiguration.defaultConfiguration && (
                   <span
-                    className="ml-3 rounded-full inline-block text-xs bg-sky-500 px-2 text-slate-50  mr-6"
+                    className="ml-3 font-bold rounded-full inline-block text-xs bg-sky-500 px-2 text-slate-50  mr-6"
                     title="Default Configuration"
                   >
                     {targetConfiguration.defaultConfiguration}

--- a/graph/project-details/src/lib/target/target-configuration-details.tsx
+++ b/graph/project-details/src/lib/target/target-configuration-details.tsx
@@ -22,7 +22,11 @@ import { FadingCollapsible } from './fading-collapsible';
 import { TargetConfigurationProperty } from './target-configuration-property';
 import { selectSourceInfo } from './target-configuration-details.util';
 import { CopyToClipboard } from './copy-to-clipboard';
-import { PropertyInfoTooltip, Tooltip } from '@nx/graph/ui-tooltips';
+import {
+  PropertyInfoTooltip,
+  SourcemapInfoToolTip,
+  Tooltip,
+} from '@nx/graph/ui-tooltips';
 import { TooltipTriggerText } from './ui/tooltip-trigger-text';
 
 /* eslint-disable-next-line */
@@ -217,8 +221,11 @@ export function TargetConfigurationDetails({
         </div>
         {!collapsed && (
           <div className="flex items-center text-sm mt-2">
-            <span className="flex-1">
-              <SourceInfo data={sourceMap[`targets.${targetName}`]} />
+            <span className="flex-1 flex items-center">
+              <SourceInfo
+                data={sourceMap[`targets.${targetName}`]}
+                propertyKey={`targets.${targetName}`}
+              />
             </span>
             <code className="ml-4 bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300 font-mono px-2 py-1 rounded">
               nx run {projectName}:{targetName}
@@ -310,7 +317,10 @@ export function TargetConfigurationDetails({
                       <TargetConfigurationProperty data={input}>
                         {sourceInfo && (
                           <span className="hidden group-hover/line:inline pl-4">
-                            <SourceInfo data={sourceInfo} />
+                            <SourceInfo
+                              data={sourceInfo}
+                              propertyKey={`targets.${targetName}.inputs`}
+                            />
                           </span>
                         )}
                       </TargetConfigurationProperty>
@@ -354,7 +364,10 @@ export function TargetConfigurationDetails({
                       <TargetConfigurationProperty data={output}>
                         {sourceInfo && (
                           <span className="hidden group-hover/line:inline pl-4">
-                            <SourceInfo data={sourceInfo} />
+                            <SourceInfo
+                              data={sourceInfo}
+                              propertyKey={`targets.${targetName}.outputs`}
+                            />
                           </span>
                         )}
                       </TargetConfigurationProperty>
@@ -397,8 +410,13 @@ export function TargetConfigurationDetails({
                   return (
                     <li className="group/line overflow-hidden whitespace-nowrap">
                       <TargetConfigurationProperty data={dep}>
-                        <span className="hidden group-hover/line:inline pl-4">
-                          {sourceInfo && <SourceInfo data={sourceInfo} />}
+                        <span className="hidden group-hover/line:inline pl-4 h-6">
+                          {sourceInfo && (
+                            <SourceInfo
+                              data={sourceInfo}
+                              propertyKey={`targets.${targetName}.dependsOn`}
+                            />
+                          )}
                         </span>
                       </TargetConfigurationProperty>
                     </li>
@@ -431,7 +449,10 @@ export function TargetConfigurationDetails({
                       );
                       return sourceInfo ? (
                         <span className="pl-4">
-                          <SourceInfo data={sourceInfo} />
+                          <SourceInfo
+                            data={sourceInfo}
+                            propertyKey={`targets.${targetName}.options.${propertyName}`}
+                          />
                         </span>
                       ) : null;
                     }}
@@ -475,7 +496,10 @@ export function TargetConfigurationDetails({
                     );
                     return sourceInfo ? (
                       <span className="pl-4">
-                        <SourceInfo data={sourceInfo} />{' '}
+                        <SourceInfo
+                          data={sourceInfo}
+                          propertyKey={`targets.${targetName}.configurations.${propertyName}`}
+                        />{' '}
                       </span>
                     ) : null;
                   }}

--- a/graph/project-details/src/lib/target/target-configuration-details.tsx
+++ b/graph/project-details/src/lib/target/target-configuration-details.tsx
@@ -28,6 +28,7 @@ import {
   Tooltip,
 } from '@nx/graph/ui-tooltips';
 import { TooltipTriggerText } from './ui/tooltip-trigger-text';
+import { ExternalLink } from '@nx/graph/ui-tooltips';
 
 /* eslint-disable-next-line */
 export interface TargetProps {
@@ -269,14 +270,13 @@ export function TargetConfigurationDetails({
             </h4>
             <p className="pl-5">
               {executorLink ? (
-                <a
-                  className="underline"
+                <ExternalLink
                   href={executorLink ?? 'https://nx.dev/nx-api'}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  {singleCommand ? singleCommand : targetConfiguration.executor}
-                </a>
+                  text={
+                    singleCommand ? singleCommand : targetConfiguration.executor
+                  }
+                  title="View Documentation"
+                />
               ) : singleCommand ? (
                 singleCommand
               ) : (

--- a/graph/project-details/src/lib/target/ui/tooltip-trigger-text.tsx
+++ b/graph/project-details/src/lib/target/ui/tooltip-trigger-text.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+
+export function TooltipTriggerText({
+  children,
+}: {
+  children: string | ReactNode;
+}) {
+  return (
+    <span className="underline underline-offset-8 decoration-2 decoration-dotted decoration-slate-700/50 dark:decoration-slate-400/50">
+      {children}
+    </span>
+  );
+}

--- a/graph/ui-tooltips/src/index.ts
+++ b/graph/ui-tooltips/src/index.ts
@@ -3,3 +3,5 @@ export * from './lib/project-edge-tooltip';
 export * from './lib/project-node-tooltip';
 export * from './lib/task-node-tooltip';
 export * from './lib/tooltip-button';
+export * from './lib/property-info-tooltip';
+export * from './lib/sourcemap-info-tooltip';

--- a/graph/ui-tooltips/src/index.ts
+++ b/graph/ui-tooltips/src/index.ts
@@ -5,3 +5,4 @@ export * from './lib/task-node-tooltip';
 export * from './lib/tooltip-button';
 export * from './lib/property-info-tooltip';
 export * from './lib/sourcemap-info-tooltip';
+export * from './lib/external-link';

--- a/graph/ui-tooltips/src/lib/external-link.tsx
+++ b/graph/ui-tooltips/src/lib/external-link.tsx
@@ -1,9 +1,18 @@
 import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
 
-export function ExternalLink({ text, href }: { text: string; href: string }) {
+export function ExternalLink({
+  text,
+  href,
+  title,
+}: {
+  text: string;
+  href: string;
+  title?: string;
+}) {
   return (
     <a
       href={href}
+      title={title}
       className="text-slate-500 dark:text-slate-300 hover:underline inline-flex items-center gap-2"
       target="_blank"
     >

--- a/graph/ui-tooltips/src/lib/external-link.tsx
+++ b/graph/ui-tooltips/src/lib/external-link.tsx
@@ -1,0 +1,13 @@
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
+
+export function ExternalLink({ text, href }: { text: string; href: string }) {
+  return (
+    <a
+      href={href}
+      className="text-slate-500 dark:text-slate-300 hover:underline inline-flex items-center gap-2"
+      target="_blank"
+    >
+      {text} <ArrowTopRightOnSquareIcon className="w-4 h-4 inline" />
+    </a>
+  );
+}

--- a/graph/ui-tooltips/src/lib/property-info-tooltip.stories.tsx
+++ b/graph/ui-tooltips/src/lib/property-info-tooltip.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+  PropertyInfoTooltipProps,
+  PropertyInfoTooltip,
+} from './property-info-tooltip';
+import { Tooltip } from './tooltip';
+
+const meta: Meta<typeof PropertyInfoTooltip> = {
+  component: PropertyInfoTooltip,
+  title: 'Tooltips/PropertyInfoToolTip',
+};
+
+export default meta;
+type Story = StoryObj<typeof PropertyInfoTooltip>;
+
+export const Primary: Story = {
+  render: (args) => (
+    <div className="flex w-full justify-center">
+      <Tooltip open={true} content={(<PropertyInfoTooltip {...args} />) as any}>
+        <p>Internal Reference</p>
+      </Tooltip>
+    </div>
+  ),
+  args: {
+    type: 'inputs',
+  } as PropertyInfoTooltipProps,
+};

--- a/graph/ui-tooltips/src/lib/property-info-tooltip.tsx
+++ b/graph/ui-tooltips/src/lib/property-info-tooltip.tsx
@@ -12,6 +12,7 @@ type PropertyInfoTooltipType =
 
 type PropertyInfoTooltipTypeOptions = {
   docsUrl: string;
+  docsLinkText?: string;
   heading: string;
   description: string;
 };
@@ -25,50 +26,52 @@ const PROPERTY_INFO_TOOLTIP_TYPE_OPTIONS: Record<
 > = {
   targets: {
     docsUrl: 'https://nx.dev/core-features/run-tasks#define-tasks',
+    docsLinkText: 'Learn more about running tasks',
     heading: 'Target',
     description:
-      'A Target is the definition of an action taken on a project (e.g. build). It defines how an action should be performed which Nx will then use when invoking the task.',
+      'A Target is the definition of a task for a project. These can be run in many different ways.',
   },
   executors: {
     docsUrl: 'https://nx.dev/concepts/executors-and-configurations',
     heading: 'Executors',
     description:
-      "Executors are pre-packaged node scripts that can be used to run tasks in a consistent way.\nIn order to use an executor, you need to install the plugin that contains the executor and then configure the executor in the project's project.json file.",
+      'Executors define what happens when a task is run.\nCheck the documentation of the executor below to learn more about what it does.',
   },
   cacheable: {
     docsUrl: 'https://nx.dev/concepts/how-caching-works',
-    heading: 'Cacheable Target',
+    docsLinkText: 'Learn more about Caching',
+    heading: 'Caching',
     description:
-      'Marking a target as cacheable tells Nx to store the computation hash for the task after the task has run.\nBefore subsequent runs of the target Nx will recalculate the computation hash. If the hash matches an existing computation hash, Nx retrieves the computation and replays it. This includes restoring files.',
+      'This task will be cached by Nx. When the Inputs have not changed the Outputs will be restored from the cache.',
   },
   inputs: {
     docsUrl: 'https://nx.dev/recipes/running-tasks/customizing-inputs',
     heading: 'Inputs',
-    description: `Inputs configure what goes into the calculation of a hash for the task.\nThis affects when things can be pulled from cache/replay.`,
+    description: `Inputs are used by the task to produce Outputs. Inputs are used to determine when the Outputs of a task can be restored from the cache.`,
   },
   outputs: {
     docsUrl: 'https://nx.dev/reference/project-configuration#outputs',
     heading: 'Outputs',
     description:
-      'Targets may define outputs to tell Nx where the target is going to create file artifacts that Nx should cache. ',
+      'Outputs are the results of a task. Outputs are restored from the cache when the Inputs are the same as a previous run.',
   },
   dependsOn: {
     docsUrl: 'https://nx.dev/concepts/task-pipeline-configuration',
+    docsLinkText: 'Learn more about creating dependencies between tasks',
     heading: 'Depends On',
     description:
-      'The dependsOn property allows a target to define other tasks that must be completed before the target can run.\nThese could be tasks from other projects in the monorepo or tasks from the same project.',
+      'This is a list of other tasks which must be completed before running this task.',
+  },
+  options: {
+    docsUrl: 'https://nx.dev/concepts/executors-and-configurations',
+    heading: 'Options',
+    description: 'Options modify the behaviour of the task.',
   },
   configurations: {
     docsUrl: 'https://nx.dev/concepts/executors-and-configurations',
     heading: 'Configurations',
     description:
-      'The configurations property provides extra sets of values that will be merged into the options map when the task is run by Nx.',
-  },
-  options: {
-    docsUrl: 'https://nx.dev/concepts/executors-and-configurations',
-    heading: 'Options',
-    description:
-      'Options are used to provide arguments allowing for the modification of the behaviour of the executor.',
+      'Configurations are sets of Options to allow a Target to be used in different scenarios.',
   },
 };
 
@@ -79,7 +82,6 @@ export function PropertyInfoTooltip({ type }: PropertyInfoTooltipProps) {
     <div className="text-sm text-slate-700 dark:text-slate-400 max-w-lg">
       <h4 className="flex justify-between items-center border-b text-base">
         <span className="font-mono">{propertyInfo.heading}</span>
-        <span className="text-sm text-gray-500 italic">Nx Graph Insights</span>
       </h4>
       <div className="flex flex-col font-mono border-b py-2">
         <p className="flex grow items-center gap-2 whitespace-pre-wrap">
@@ -89,7 +91,10 @@ export function PropertyInfoTooltip({ type }: PropertyInfoTooltipProps) {
       <div className="flex py-2">
         <p className="pr-4 flex items-center">
           <ExternalLink
-            text={`View ${propertyInfo.heading} Documentation`}
+            text={
+              propertyInfo.docsLinkText ??
+              `Learn more about ${propertyInfo.heading}`
+            }
             href={propertyInfo.docsUrl}
           />
         </p>

--- a/graph/ui-tooltips/src/lib/property-info-tooltip.tsx
+++ b/graph/ui-tooltips/src/lib/property-info-tooltip.tsx
@@ -1,0 +1,99 @@
+import { ExternalLink } from './external-link';
+
+type PropertyInfoTooltipType =
+  | 'targets'
+  | 'executors'
+  | 'cacheable'
+  | 'inputs'
+  | 'outputs'
+  | 'dependsOn'
+  | 'options'
+  | 'configurations';
+
+type PropertyInfoTooltipTypeOptions = {
+  docsUrl: string;
+  heading: string;
+  description: string;
+};
+export interface PropertyInfoTooltipProps {
+  type: PropertyInfoTooltipType;
+}
+
+const PROPERTY_INFO_TOOLTIP_TYPE_OPTIONS: Record<
+  PropertyInfoTooltipType,
+  PropertyInfoTooltipTypeOptions
+> = {
+  targets: {
+    docsUrl: 'https://nx.dev/core-features/run-tasks#define-tasks',
+    heading: 'Target',
+    description:
+      'A Target is the definition of an action taken on a project (e.g. build). It defines how an action should be performed which Nx will then use when invoking the task.',
+  },
+  executors: {
+    docsUrl: 'https://nx.dev/concepts/executors-and-configurations',
+    heading: 'Executors',
+    description:
+      "Executors are pre-packaged node scripts that can be used to run tasks in a consistent way.\nIn order to use an executor, you need to install the plugin that contains the executor and then configure the executor in the project's project.json file.",
+  },
+  cacheable: {
+    docsUrl: 'https://nx.dev/concepts/how-caching-works',
+    heading: 'Cacheable Target',
+    description:
+      'Marking a target as cacheable tells Nx to store the computation hash for the task after the task has run.\nBefore subsequent runs of the target Nx will recalculate the computation hash. If the hash matches an existing computation hash, Nx retrieves the computation and replays it. This includes restoring files.',
+  },
+  inputs: {
+    docsUrl: 'https://nx.dev/recipes/running-tasks/customizing-inputs',
+    heading: 'Inputs',
+    description: `Inputs configure what goes into the calculation of a hash for the task.\nThis affects when things can be pulled from cache/replay.`,
+  },
+  outputs: {
+    docsUrl: 'https://nx.dev/reference/project-configuration#outputs',
+    heading: 'Outputs',
+    description:
+      'Targets may define outputs to tell Nx where the target is going to create file artifacts that Nx should cache. ',
+  },
+  dependsOn: {
+    docsUrl: 'https://nx.dev/concepts/task-pipeline-configuration',
+    heading: 'Depends On',
+    description:
+      'The dependsOn property allows a target to define other tasks that must be completed before the target can run.\nThese could be tasks from other projects in the monorepo or tasks from the same project.',
+  },
+  configurations: {
+    docsUrl: 'https://nx.dev/concepts/executors-and-configurations',
+    heading: 'Configurations',
+    description:
+      'The configurations property provides extra sets of values that will be merged into the options map when the task is run by Nx.',
+  },
+  options: {
+    docsUrl: 'https://nx.dev/concepts/executors-and-configurations',
+    heading: 'Options',
+    description:
+      'Options are used to provide arguments allowing for the modification of the behaviour of the executor.',
+  },
+};
+
+export function PropertyInfoTooltip({ type }: PropertyInfoTooltipProps) {
+  const propertyInfo = PROPERTY_INFO_TOOLTIP_TYPE_OPTIONS[type];
+
+  return (
+    <div className="text-sm text-slate-700 dark:text-slate-400 max-w-lg">
+      <h4 className="flex justify-between items-center border-b text-base">
+        <span className="font-mono">{propertyInfo.heading}</span>
+        <span className="text-sm text-gray-500 italic">Nx Graph Insights</span>
+      </h4>
+      <div className="flex flex-col font-mono border-b py-2">
+        <p className="flex grow items-center gap-2 whitespace-pre-wrap">
+          {propertyInfo.description}
+        </p>
+      </div>
+      <div className="flex py-2">
+        <p className="pr-4 flex items-center">
+          <ExternalLink
+            text={`View ${propertyInfo.heading} Documentation`}
+            href={propertyInfo.docsUrl}
+          />
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/graph/ui-tooltips/src/lib/sourcemap-info-tooltip.stories.tsx
+++ b/graph/ui-tooltips/src/lib/sourcemap-info-tooltip.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+  SourcemapInfoToolTipProps,
+  SourcemapInfoToolTip,
+} from './sourcemap-info-tooltip';
+import { Tooltip } from './tooltip';
+
+const meta: Meta<typeof SourcemapInfoToolTip> = {
+  component: SourcemapInfoToolTip,
+  title: 'Tooltips/SourcemapInfoToolTip',
+};
+
+export default meta;
+type Story = StoryObj<typeof SourcemapInfoToolTip>;
+
+export const Primary: Story = {
+  render: (args) => (
+    <div className="flex w-full justify-center">
+      <Tooltip
+        open={true}
+        content={(<SourcemapInfoToolTip {...args} />) as any}
+      >
+        <p>Internal Reference</p>
+      </Tooltip>
+    </div>
+  ),
+  args: {
+    propertyKey: 'targets.build.command',
+    plugin: 'nx-core-build-project-json-nodes',
+    file: 'tools/eslint-rules/project.json',
+  } as SourcemapInfoToolTipProps,
+};

--- a/graph/ui-tooltips/src/lib/sourcemap-info-tooltip.tsx
+++ b/graph/ui-tooltips/src/lib/sourcemap-info-tooltip.tsx
@@ -14,44 +14,39 @@ export function SourcemapInfoToolTip({
   file,
   children,
 }: SourcemapInfoToolTipProps) {
+  // Target property key is in the form `target.${targetName}`
+  // Every other property within in the target has the form `target.${targetName}.${propertyName}
+  const isTarget = propertyKey.split('.').length === 2;
+
   const docsUrlSlug: string | undefined = plugin.startsWith('@nx/')
     ? plugin.replace('@nx/', '').split('/')[0]
     : undefined;
 
   return (
     <div className="text-sm text-slate-700 dark:text-slate-400 max-w-md sm:max-w-full">
-      <h4 className="flex justify-between items-center border-b text-base gap-4">
-        <span className="font-mono">{propertyKey}</span>
-        <span className="text-sm text-gray-500 italic">Nx Graph Insights</span>
-      </h4>
       <div className="flex flex-col font-mono border-b py-2">
         <p className="flex grow items-center gap-2">
-          <span className="font-bold">Created by:</span>
+          <span className="font-bold">{isTarget ? 'Created' : 'Set'} by:</span>
           <span className="inline-flex grow justify-between items-center">
-            {plugin}
+            {docsUrlSlug ? (
+              <ExternalLink
+                text={plugin}
+                href={`https://nx.dev/nx-api/${docsUrlSlug}`}
+              />
+            ) : (
+              `${plugin}`
+            )}
           </span>
         </p>
         <p>
-          <span className="font-bold">Created from:</span> {file}
+          <span className="font-bold">From:</span> {file}
         </p>
       </div>
       <div className="flex py-2">
-        {docsUrlSlug && (
-          <p className="border-r pr-4 flex items-center">
-            <ExternalLink
-              text={`View @nx/${docsUrlSlug} Docs`}
-              href={`https://nx.dev/nx-api/${docsUrlSlug}`}
-            />
-          </p>
-        )}
-        <p className={`${docsUrlSlug && 'pl-4'} flex flex-col gap-1`}>
+        <p className={`flex flex-col gap-1`}>
           <ExternalLink
-            text="What are Inferred Tasks?"
+            text="Learn more about how projects are configured"
             href="https://nx.dev/concepts/inferred-tasks"
-          />
-          <ExternalLink
-            text="What are Project Graph Plugins?"
-            href="https://nx.dev/extending-nx/recipes/project-graph-plugins"
           />
         </p>
       </div>

--- a/graph/ui-tooltips/src/lib/sourcemap-info-tooltip.tsx
+++ b/graph/ui-tooltips/src/lib/sourcemap-info-tooltip.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from 'react';
-import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
+import { ExternalLink } from './external-link';
 
 export interface SourcemapInfoToolTipProps {
   propertyKey: string;
@@ -56,17 +56,5 @@ export function SourcemapInfoToolTip({
         </p>
       </div>
     </div>
-  );
-}
-
-function ExternalLink({ text, href }: { text: string; href: string }) {
-  return (
-    <a
-      href={href}
-      className="text-slate-500 dark:text-slate-300 hover:underline inline-flex items-center gap-2"
-      target="_blank"
-    >
-      {text} <ArrowTopRightOnSquareIcon className="w-4 h-4 inline" />
-    </a>
   );
 }

--- a/graph/ui-tooltips/src/lib/sourcemap-info-tooltip.tsx
+++ b/graph/ui-tooltips/src/lib/sourcemap-info-tooltip.tsx
@@ -1,0 +1,72 @@
+import { type ReactNode } from 'react';
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
+
+export interface SourcemapInfoToolTipProps {
+  propertyKey: string;
+  plugin: string;
+  file: string;
+  children?: ReactNode | ReactNode[];
+}
+
+export function SourcemapInfoToolTip({
+  propertyKey,
+  plugin,
+  file,
+  children,
+}: SourcemapInfoToolTipProps) {
+  const docsUrlSlug: string | undefined = plugin.startsWith('@nx/')
+    ? plugin.replace('@nx/', '').split('/')[0]
+    : undefined;
+
+  return (
+    <div className="text-sm text-slate-700 dark:text-slate-400">
+      <h4 className="flex justify-between items-center border-b text-base">
+        <span className="font-mono">{propertyKey}</span>
+        <span className="text-sm text-gray-500 italic">Nx Graph Insights</span>
+      </h4>
+      <div className="flex flex-col font-mono border-b py-2">
+        <p className="flex grow items-center gap-2">
+          <span className="font-bold">Created by:</span>
+          <span className="inline-flex grow justify-between items-center">
+            {plugin}
+          </span>
+        </p>
+        <p>
+          <span className="font-bold">Created from:</span> {file}
+        </p>
+      </div>
+      <div className="flex py-2">
+        {docsUrlSlug && (
+          <p className="border-r pr-4 flex items-center">
+            <ExternalLink
+              text={`View @nx/${docsUrlSlug} Docs`}
+              href={`https://nx.dev/nx-api/${docsUrlSlug}`}
+            />
+          </p>
+        )}
+        <p className={`${docsUrlSlug && 'pl-4'} flex flex-col gap-1`}>
+          <ExternalLink
+            text="What are Inferred Tasks?"
+            href="https://nx.dev/concepts/inferred-tasks"
+          />
+          <ExternalLink
+            text="What are Project Graph Plugins?"
+            href="https://nx.dev/extending-nx/recipes/project-graph-plugins"
+          />
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function ExternalLink({ text, href }: { text: string; href: string }) {
+  return (
+    <a
+      href={href}
+      className="text-slate-500 dark:text-slate-300 hover:underline inline-flex items-center gap-2"
+      target="_blank"
+    >
+      {text} <ArrowTopRightOnSquareIcon className="w-4 h-4 inline" />
+    </a>
+  );
+}

--- a/graph/ui-tooltips/src/lib/sourcemap-info-tooltip.tsx
+++ b/graph/ui-tooltips/src/lib/sourcemap-info-tooltip.tsx
@@ -19,8 +19,8 @@ export function SourcemapInfoToolTip({
     : undefined;
 
   return (
-    <div className="text-sm text-slate-700 dark:text-slate-400">
-      <h4 className="flex justify-between items-center border-b text-base">
+    <div className="text-sm text-slate-700 dark:text-slate-400 max-w-md sm:max-w-full">
+      <h4 className="flex justify-between items-center border-b text-base gap-4">
         <span className="font-mono">{propertyKey}</span>
         <span className="text-sm text-gray-500 italic">Nx Graph Insights</span>
       </h4>

--- a/graph/ui-tooltips/src/lib/tooltip.tsx
+++ b/graph/ui-tooltips/src/lib/tooltip.tsx
@@ -99,7 +99,7 @@ export function Tooltip({
   });
   const hover = useHover(context, {
     enabled: openAction === 'hover',
-    delay: { open: 0, close: 500 },
+    delay: { open: 0, close: 150 },
     handleClose: safePolygon({ buffer }),
   });
   const role = useRole(context, { role: 'tooltip' });

--- a/graph/ui-tooltips/src/lib/tooltip.tsx
+++ b/graph/ui-tooltips/src/lib/tooltip.tsx
@@ -35,6 +35,8 @@ export type TooltipProps = HTMLAttributes<HTMLDivElement> & {
   placement?: Placement;
   reference?: ReferenceType;
   openAction?: 'click' | 'hover' | 'manual';
+  buffer?: number;
+  showTooltipArrow?: boolean;
   strategy?: 'absolute' | 'fixed';
 };
 
@@ -46,6 +48,8 @@ export function Tooltip({
   reference: externalReference,
   openAction = 'click',
   strategy = 'absolute',
+  buffer = 0,
+  showTooltipArrow = true,
 }: TooltipProps) {
   const [isOpen, setIsOpen] = useState(open);
   const arrowRef = useRef(null);
@@ -95,7 +99,8 @@ export function Tooltip({
   });
   const hover = useHover(context, {
     enabled: openAction === 'hover',
-    handleClose: safePolygon({ restMs: 5 }),
+    delay: { open: 0, close: 500 },
+    handleClose: safePolygon({ buffer }),
   });
   const role = useRole(context, { role: 'tooltip' });
 
@@ -121,24 +126,26 @@ export function Tooltip({
           ref={refs.setFloating}
           style={{
             position: appliedStrategy,
-            top: y ?? 0,
+            top: showTooltipArrow ? y : y + 8 ?? 0,
             left: x ?? 0,
             width: 'max-content',
           }}
           className="z-10 min-w-[250px] rounded-md border border-slate-500"
           {...getFloatingProps()}
         >
-          <div
-            style={{
-              left: arrowX != null ? `${arrowX}px` : '',
-              top: arrowY != null ? `${arrowY}px` : '',
-              right: '',
-              bottom: '',
-              [staticSide]: '-4px',
-            }}
-            className="absolute -z-10 h-4 w-4 rotate-45 bg-slate-500"
-            ref={arrowRef}
-          ></div>
+          {showTooltipArrow && (
+            <div
+              style={{
+                left: arrowX != null ? `${arrowX}px` : '',
+                top: arrowY != null ? `${arrowY}px` : '',
+                right: '',
+                bottom: '',
+                [staticSide]: '-4px',
+              }}
+              className="absolute -z-10 h-4 w-4 rotate-45 bg-slate-500"
+              ref={arrowRef}
+            ></div>
+          )}
           <div className="select-text rounded-md bg-white p-3 dark:bg-slate-900 dark:text-slate-400">
             {content}
           </div>

--- a/graph/ui-tooltips/src/lib/tooltip.tsx
+++ b/graph/ui-tooltips/src/lib/tooltip.tsx
@@ -25,6 +25,7 @@ import {
   useDismiss,
   useHover,
   useRole,
+  safePolygon,
 } from '@floating-ui/react';
 
 export type TooltipProps = HTMLAttributes<HTMLDivElement> & {
@@ -92,7 +93,10 @@ export function Tooltip({
     outsidePress: true,
     outsidePressEvent: 'mousedown',
   });
-  const hover = useHover(context, { enabled: openAction === 'hover' });
+  const hover = useHover(context, {
+    enabled: openAction === 'hover',
+    handleClose: safePolygon({ restMs: 5 }),
+  });
   const role = useRole(context, { role: 'tooltip' });
 
   const { getReferenceProps, getFloatingProps } = useInteractions([

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@babel/runtime": "^7.22.6",
     "@eslint/eslintrc": "^2.1.1",
     "@eslint/js": "^8.48.0",
-    "@floating-ui/react": "0.19.2",
+    "@floating-ui/react": "0.26.6",
     "@jest/reporters": "^29.4.1",
     "@jest/test-result": "^29.4.1",
     "@jest/types": "^29.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 overrides:
   minimist: ^1.2.6
   underscore: ^1.12.1
@@ -212,8 +216,8 @@ devDependencies:
     specifier: ^8.48.0
     version: 8.48.0
   '@floating-ui/react':
-    specifier: 0.19.2
-    version: 0.19.2(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0)
+    specifier: 0.26.6
+    version: 0.26.6(react-dom@18.2.0)(react@18.2.0)
   '@jest/reporters':
     specifier: ^29.4.1
     version: 29.5.0
@@ -243,7 +247,7 @@ devDependencies:
     version: 9.1.6(@nestjs/common@9.1.6)(@nestjs/core@9.1.6)
   '@nestjs/schematics':
     specifier: ^9.1.0
-    version: 9.1.0(chokidar@3.5.3)(typescript@4.9.4)
+    version: 9.1.0(typescript@5.2.2)
   '@nestjs/swagger':
     specifier: ^6.0.0
     version: 6.1.3(@nestjs/common@9.1.6)(@nestjs/core@9.1.6)(reflect-metadata@0.1.14)
@@ -585,7 +589,7 @@ devDependencies:
     version: 2.14.0(eslint@8.48.0)
   eslint-plugin-import:
     specifier: 2.27.5
-    version: 2.27.5(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.5.2)(eslint@8.48.0)
+    version: 2.27.5(@typescript-eslint/parser@6.18.1)(eslint@8.48.0)
   eslint-plugin-jsx-a11y:
     specifier: 6.7.1
     version: 6.7.1(eslint@8.48.0)
@@ -5425,20 +5429,16 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
-  /@floating-ui/core@1.2.1:
-    resolution: {integrity: sha512-LSqwPZkK3rYfD7GKoIeExXOyYx6Q1O4iqZWwIehDNuv3Dv425FIAE8PRwtAx1imEolFTHgBEcoFHm9MDnYgPCg==}
-    dev: true
-
   /@floating-ui/core@1.4.1:
     resolution: {integrity: sha512-jk3WqquEJRlcyu7997NtR5PibI+y5bi+LS3hPmguVClypenMsCY3CBa3LAQnozRCtCrYWSEtAdiskpamuJRFOQ==}
     dependencies:
       '@floating-ui/utils': 0.1.1
     dev: true
 
-  /@floating-ui/dom@1.2.1:
-    resolution: {integrity: sha512-Rt45SmRiV8eU+xXSB9t0uMYiQ/ZWGE/jumse2o3i5RGlyvcbqOF4q+1qBnzLE2kZ5JGhq0iMkcGXUKbFe7MpTA==}
+  /@floating-ui/core@1.5.3:
+    resolution: {integrity: sha512-O0WKDOo0yhJuugCx6trZQj5jVJ9yR0ystG2JaNAemYUWce+pmM6WUEFIibnWyEJKdrDxhm75NoSRME35FNaM/Q==}
     dependencies:
-      '@floating-ui/core': 1.2.1
+      '@floating-ui/utils': 0.2.1
     dev: true
 
   /@floating-ui/dom@1.5.1:
@@ -5448,15 +5448,11 @@ packages:
       '@floating-ui/utils': 0.1.1
     dev: true
 
-  /@floating-ui/react-dom@1.3.0(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-htwHm67Ji5E/pROEAr7f8IKFShuiCKHwUC/UY4vC3I5jiSvGFAYnSYiZO5MlGmads+QqvUkR9ANHEguGrDv72g==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
+  /@floating-ui/dom@1.5.4:
+    resolution: {integrity: sha512-jByEsHIY+eEdCjnTVu+E3ephzTOzkQ8hgUfGwos+bg7NlH33Zc5uO+QHz1mrQUOgIKKDD1RtS201P9NvAfq3XQ==}
     dependencies:
-      '@floating-ui/dom': 1.2.1
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      '@floating-ui/core': 1.5.3
+      '@floating-ui/utils': 0.2.1
     dev: true
 
   /@floating-ui/react-dom@2.0.1(react-dom@18.2.0)(react@18.2.0):
@@ -5470,23 +5466,36 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: true
 
-  /@floating-ui/react@0.19.2(@types/react@18.2.33)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-JyNk4A0Ezirq8FlXECvRtQOX/iBe5Ize0W/pLkrZjfHW9GUV7Xnq6zm6fyZuQzaHHqEnVizmvlA96e1/CkZv+w==}
+  /@floating-ui/react-dom@2.0.6(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-IB8aCRFxr8nFkdYZgH+Otd9EVQPJoynxeFRGTB8voPoZMRWo8XjYuCRgpI1btvuKY69XMiLnW+ym7zoBHM90Rw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
-      '@floating-ui/react-dom': 1.3.0(react-dom@18.2.0)(react@18.2.0)
-      aria-hidden: 1.2.2(@types/react@18.2.33)(react@18.2.0)
+      '@floating-ui/dom': 1.5.4
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: true
+
+  /@floating-ui/react@0.26.6(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-FFDAuSlRwb8CY4/VvYio/wwk/0339B257yRpKwNOjcHWNYL/fgjl1KUvT3K6ZZ4WDbBWYc7Km4ITMuPZrS8omg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      '@floating-ui/react-dom': 2.0.6(react-dom@18.2.0)(react@18.2.0)
+      '@floating-ui/utils': 0.2.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tabbable: 6.0.1
-    transitivePeerDependencies:
-      - '@types/react'
     dev: true
 
   /@floating-ui/utils@0.1.1:
     resolution: {integrity: sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw==}
+    dev: true
+
+  /@floating-ui/utils@0.2.1:
+    resolution: {integrity: sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==}
     dev: true
 
   /@gar/promisify@1.1.3:
@@ -6362,6 +6371,20 @@ packages:
       jsonc-parser: 3.2.0
       pluralize: 8.0.0
       typescript: 4.9.4
+    transitivePeerDependencies:
+      - chokidar
+    dev: true
+
+  /@nestjs/schematics@9.1.0(typescript@5.2.2):
+    resolution: {integrity: sha512-/7CyMTnPJSK9/xD9CkCqwuHPOlHVlLC2RDnbdCJ7mIO07SdbBbY14msTqtYW9VRQtsjZPLh1GTChf7ryJUImwA==}
+    peerDependencies:
+      typescript: '>=4.3.5'
+    dependencies:
+      '@angular-devkit/core': 15.2.4(chokidar@3.5.3)
+      '@angular-devkit/schematics': 15.2.4(chokidar@3.5.3)
+      jsonc-parser: 3.2.0
+      pluralize: 8.0.0
+      typescript: 5.2.2
     transitivePeerDependencies:
       - chokidar
     dev: true
@@ -12090,7 +12113,7 @@ packages:
       lodash: 4.17.21
       mlly: 1.4.2
       outdent: 0.8.0
-      vite: 4.5.0(@types/node@18.19.8)(less@4.2.0)(sass@1.69.5)(stylus@0.59.0)(terser@5.24.0)
+      vite: 4.5.0(@types/node@18.19.8)(less@4.1.3)(sass@1.55.0)(stylus@0.59.0)
       vite-node: 0.28.5(@types/node@18.19.8)(less@4.1.3)(sass@1.55.0)(stylus@0.59.0)
     transitivePeerDependencies:
       - '@types/node'
@@ -16814,6 +16837,35 @@ packages:
       - supports-color
     dev: true
 
+  /eslint-module-utils@2.7.4(@typescript-eslint/parser@6.18.1)(eslint-import-resolver-node@0.3.9)(eslint@8.48.0):
+    resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 6.18.1(eslint@8.48.0)(typescript@5.2.2)
+      debug: 3.2.7(supports-color@8.1.1)
+      eslint: 8.48.0
+      eslint-import-resolver-node: 0.3.9
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /eslint-plugin-cypress@2.14.0(eslint@8.48.0):
     resolution: {integrity: sha512-eW6tv7iIg7xujleAJX4Ujm649Bf5jweqa4ObPEIuueYRyLZt7qXGWhCY/n4bfeFW/j6nQZwbIBHKZt6EKcL/cg==}
     peerDependencies:
@@ -16842,6 +16894,39 @@ packages:
       eslint: 8.48.0
       eslint-import-resolver-node: 0.3.9
       eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.2)(eslint@8.48.0)
+      has: 1.0.3
+      is-core-module: 2.13.0
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.values: 1.1.6
+      resolve: 1.22.8
+      semver: 6.3.1
+      tsconfig-paths: 3.14.1
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+    dev: true
+
+  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@6.18.1)(eslint@8.48.0):
+    resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 6.18.1(eslint@8.48.0)(typescript@5.2.2)
+      array-includes: 3.1.6
+      array.prototype.flat: 1.3.1
+      array.prototype.flatmap: 1.3.1
+      debug: 3.2.7(supports-color@8.1.1)
+      doctrine: 2.1.0
+      eslint: 8.48.0
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.7.4(@typescript-eslint/parser@6.18.1)(eslint-import-resolver-node@0.3.9)(eslint@8.48.0)
       has: 1.0.3
       is-core-module: 2.13.0
       is-glob: 4.0.3
@@ -29584,7 +29669,7 @@ packages:
       picocolors: 1.0.0
       source-map: 0.6.1
       source-map-support: 0.5.21
-      vite: 4.5.0(@types/node@18.19.8)(less@4.2.0)(sass@1.69.5)(stylus@0.59.0)(terser@5.24.0)
+      vite: 4.5.0(@types/node@18.19.8)(less@4.1.3)(sass@1.55.0)(stylus@0.59.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -29615,6 +29700,45 @@ packages:
       - sugarss
       - supports-color
       - terser
+    dev: true
+
+  /vite@4.5.0(@types/node@18.19.8)(less@4.1.3)(sass@1.55.0)(stylus@0.59.0):
+    resolution: {integrity: sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 18.19.8
+      esbuild: 0.18.17
+      less: 4.1.3
+      postcss: 8.4.32
+      rollup: 3.28.0
+      sass: 1.55.0
+      stylus: 0.59.0
+    optionalDependencies:
+      fsevents: 2.3.3
     dev: true
 
   /vite@4.5.0(@types/node@18.19.8)(less@4.2.0)(sass@1.69.5)(stylus@0.59.0)(terser@5.24.0):
@@ -30713,7 +30837,3 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
- feat(graph): design tooltip for sourcemaps
- feat(graph): add property info tooltip
- feat(graph): wire up property info tooltip to project details view

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We do not show additional information via tooltips.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We use tooltips to show additional relevant information when the user hovers over certain fields within the project details view.

There are two types of tooltips to be added.

1. Sourcemap Info Tooltips
2. Property Info Tooltips

The Property Info Tooltips are displayed when the field names are hovered (such as Target, Options, Depends On etc).

The Sourcemap Info Tooltips will be displayed when the sourcemap is hovered.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
