### PR TITLE
feat(misc): update minimatch version used across packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -225,7 +225,7 @@
     "metro-config": "0.76.8",
     "metro-resolver": "0.76.8",
     "mini-css-extract-plugin": "~2.4.7",
-    "minimatch": "3.0.5",
+    "minimatch": "9.0.3",
     "next-sitemap": "^3.1.10",
     "ng-packagr": "~17.0.0",
     "node-fetch": "^2.6.7",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -52,7 +52,7 @@
     "find-cache-dir": "^3.3.2",
     "ignore": "^5.0.4",
     "magic-string": "~0.30.2",
-    "minimatch": "3.0.5",
+    "minimatch": "9.0.3",
     "semver": "7.5.3",
     "tslib": "^2.3.0",
     "webpack": "^5.80.0",

--- a/packages/angular/src/generators/stories/stories.ts
+++ b/packages/angular/src/generators/stories/stories.ts
@@ -20,7 +20,7 @@ import { getProjectEntryPoints } from '../utils/storybook-ast/entry-point';
 import { getE2EProject } from './lib/get-e2e-project';
 import { getModuleFilePaths } from '../utils/storybook-ast/module-info';
 import type { StoriesGeneratorOptions } from './schema';
-import minimatch = require('minimatch');
+import { minimatch } from 'minimatch';
 import { nxVersion } from '../../utils/versions';
 
 export async function angularStoriesGenerator(

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -42,7 +42,7 @@
     "jest-config": "^29.4.1",
     "jest-resolve": "^29.4.1",
     "jest-util": "^29.4.1",
-    "minimatch": "3.0.5",
+    "minimatch": "9.0.3",
     "resolve.exports": "1.1.0",
     "tslib": "^2.3.0",
     "@nx/devkit": "file:../devkit",

--- a/packages/jest/src/plugins/plugin.ts
+++ b/packages/jest/src/plugins/plugin.ts
@@ -18,7 +18,7 @@ import { projectGraphCacheDirectory } from 'nx/src/utils/cache-directory';
 import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
 import { getGlobPatternsFromPackageManagerWorkspaces } from 'nx/plugins/package-json-workspaces';
 import { combineGlobPatterns } from 'nx/src/utils/globs';
-import * as minimatch from 'minimatch';
+import { minimatch } from 'minimatch';
 
 export interface JestPluginOptions {
   targetName?: string;

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -52,7 +52,7 @@
     "tsconfig-paths": "^4.1.2",
     "ignore": "^5.0.4",
     "js-tokens": "^4.0.0",
-    "minimatch": "3.0.5",
+    "minimatch": "9.0.3",
     "ora": "5.3.0",
     "semver": "7.5.3",
     "source-map-support": "0.5.19",

--- a/packages/js/src/utils/assets/copy-assets-handler.ts
+++ b/packages/js/src/utils/assets/copy-assets-handler.ts
@@ -1,4 +1,4 @@
-import * as minimatch from 'minimatch';
+import { minimatch } from 'minimatch';
 import * as path from 'path';
 import * as fse from 'fs-extra';
 import ignore from 'ignore';

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -52,7 +52,7 @@
     "js-yaml": "4.1.0",
     "jsonc-parser": "3.2.0",
     "lines-and-columns": "~2.0.3",
-    "minimatch": "3.0.5",
+    "minimatch": "9.0.3",
     "npm-run-path": "^4.0.1",
     "open": "^8.4.0",
     "semver": "7.5.3",

--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -2,7 +2,7 @@ import { createHash } from 'crypto';
 import { existsSync, readFileSync, statSync, writeFileSync } from 'fs';
 import { copySync, ensureDirSync } from 'fs-extra';
 import * as http from 'http';
-import * as minimatch from 'minimatch';
+import { minimatch } from 'minimatch';
 import { URL } from 'node:url';
 import * as open from 'open';
 import {

--- a/packages/nx/src/generators/utils/glob.spec.ts
+++ b/packages/nx/src/generators/utils/glob.spec.ts
@@ -38,7 +38,7 @@ describe('glob', () => {
     tree.write('3.txt', '3');
     fs.writeFile('4.md', '4');
 
-    const withTree = glob(tree, ['*.txt']).sort();
+    const withTree = glob(tree, ['**/*.txt']).sort();
 
     expect(withTree).toMatchInlineSnapshot(`
       [

--- a/packages/nx/src/generators/utils/glob.ts
+++ b/packages/nx/src/generators/utils/glob.ts
@@ -1,9 +1,7 @@
+import { minimatch } from 'minimatch';
 import { Tree } from '../tree';
 import { combineGlobPatterns } from '../../utils/globs';
-import { workspaceRoot } from '../../utils/workspace-root';
 import { globWithWorkspaceContext } from '../../utils/workspace-context';
-
-import minimatch = require('minimatch');
 
 /**
  * Performs a tree-aware glob search on the files in a workspace. Able to find newly

--- a/packages/nx/src/generators/utils/project-configuration.ts
+++ b/packages/nx/src/generators/utils/project-configuration.ts
@@ -1,3 +1,4 @@
+import { minimatch } from 'minimatch';
 import { basename, join, relative } from 'path';
 
 import {
@@ -23,8 +24,6 @@ import { readJson, writeJson } from './json';
 import { readNxJson } from './nx-json';
 
 import type { Tree } from '../tree';
-
-import minimatch = require('minimatch');
 
 export { readNxJson, updateNxJson } from './nx-json';
 

--- a/packages/nx/src/hasher/node-task-hasher-impl.ts
+++ b/packages/nx/src/hasher/node-task-hasher-impl.ts
@@ -10,7 +10,7 @@ import { Task, TaskGraph } from '../config/task-graph';
 import { hashArray, hashObject } from './file-hasher';
 import { getOutputsForTargetAndConfiguration } from '../tasks-runner/utils';
 import { workspaceRoot } from '../utils/workspace-root';
-import * as minimatch from 'minimatch';
+import { minimatch } from 'minimatch';
 import { join } from 'path';
 import { hashFile } from '../native';
 import { findAllProjectNodeDependencies } from '../utils/project-graph-utils';

--- a/packages/nx/src/hasher/task-hasher.ts
+++ b/packages/nx/src/hasher/task-hasher.ts
@@ -10,7 +10,7 @@ import { DaemonClient } from '../daemon/client/client';
 import { hashArray } from './file-hasher';
 import { NodeTaskHasherImpl } from './node-task-hasher-impl';
 import { InputDefinition } from '../config/workspace-json-project-json';
-import * as minimatch from 'minimatch';
+import { minimatch } from 'minimatch';
 import { NativeTaskHasherImpl } from './native-task-hasher-impl';
 import { workspaceRoot } from '../utils/workspace-root';
 import { NxWorkspaceFilesExternals } from '../native';

--- a/packages/nx/src/project-graph/affected/locators/project-glob-changes.ts
+++ b/packages/nx/src/project-graph/affected/locators/project-glob-changes.ts
@@ -1,5 +1,5 @@
 import { TouchedProjectLocator } from '../affected-project-graph-models';
-import minimatch = require('minimatch');
+import { minimatch } from 'minimatch';
 import { workspaceRoot } from '../../../utils/workspace-root';
 import { getNxRequirePaths } from '../../../utils/installation-directory';
 import { join } from 'path';

--- a/packages/nx/src/project-graph/affected/locators/workspace-projects.ts
+++ b/packages/nx/src/project-graph/affected/locators/workspace-projects.ts
@@ -1,4 +1,4 @@
-import * as minimatch from 'minimatch';
+import { minimatch } from 'minimatch';
 import { TouchedProjectLocator } from '../affected-project-graph-models';
 import { NxJsonConfiguration } from '../../../config/nx-json';
 import {

--- a/packages/nx/src/project-graph/file-utils.ts
+++ b/packages/nx/src/project-graph/file-utils.ts
@@ -24,7 +24,7 @@ import {
 } from './utils/project-configuration-utils';
 import { NxJsonConfiguration } from '../config/nx-json';
 import { getDefaultPluginsSync } from '../utils/nx-plugin.deprecated';
-import minimatch = require('minimatch');
+import { minimatch } from 'minimatch';
 import { CreateNodesResult } from '../devkit-exports';
 import { CreatePackageJsonProjectsNextToProjectJson } from '../plugins/project-json/build-nodes/package-json-next-to-project-json';
 import { LoadedNxPlugin } from '../utils/nx-plugin';

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -10,7 +10,7 @@ import { CreateNodesResult, LoadedNxPlugin } from '../../utils/nx-plugin';
 import { readJsonFile } from '../../utils/fileutils';
 import { workspaceRoot } from '../../utils/workspace-root';
 
-import minimatch = require('minimatch');
+import { minimatch } from 'minimatch';
 import { join } from 'path';
 
 export type SourceInformation = [string, string];

--- a/packages/nx/src/utils/find-matching-projects.spec.ts
+++ b/packages/nx/src/utils/find-matching-projects.spec.ts
@@ -3,7 +3,7 @@ import {
   getMatchingStringsWithCache,
 } from './find-matching-projects';
 import type { ProjectGraphProjectNode } from '../config/project-graph';
-import minimatch = require('minimatch');
+import { minimatch } from 'minimatch';
 
 describe('findMatchingProjects', () => {
   let projectGraph: Record<string, ProjectGraphProjectNode> = {

--- a/packages/nx/src/utils/find-matching-projects.ts
+++ b/packages/nx/src/utils/find-matching-projects.ts
@@ -1,4 +1,4 @@
-import minimatch = require('minimatch');
+import { minimatch } from 'minimatch';
 import type { ProjectGraphProjectNode } from '../config/project-graph';
 
 const validPatternTypes = [

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -36,7 +36,7 @@
     "@nx/eslint": "file:../eslint",
     "@nx/js": "file:../js",
     "tslib": "^2.3.0",
-    "minimatch": "3.0.5"
+    "minimatch": "9.0.3"
   },
   "peerDependencies": {
     "@playwright/test": "^1.36.0"

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -16,7 +16,7 @@ import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash
 
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { getFilesInDirectoryUsingContext } from 'nx/src/utils/workspace-context';
-import minimatch = require('minimatch');
+import { minimatch } from 'minimatch';
 import { loadPlaywrightConfig } from '../utils/load-config-file';
 import { projectGraphCacheDirectory } from 'nx/src/utils/cache-directory';
 import { getLockFileName } from '@nx/js';

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -32,7 +32,7 @@
     "ignore": "^5.0.4",
     "metro-config": "~0.76.8",
     "metro-resolver": "~0.76.8",
-    "minimatch": "3.0.5",
+    "minimatch": "9.0.3",
     "node-fetch": "^2.6.7",
     "tsconfig-paths": "^4.1.2",
     "tslib": "^2.3.0",

--- a/packages/react-native/src/generators/stories/stories.ts
+++ b/packages/react-native/src/generators/stories/stories.ts
@@ -12,7 +12,7 @@ import {
   containsComponentDeclaration,
   projectRootPath,
 } from '@nx/react/src/generators/stories/stories';
-import minimatch = require('minimatch');
+import { minimatch } from 'minimatch';
 import { nxVersion } from '../../utils/versions';
 
 export async function createAllStories(

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -35,7 +35,7 @@
     "@svgr/webpack": "^8.0.1",
     "chalk": "^4.1.0",
     "file-loader": "^6.2.0",
-    "minimatch": "3.0.5",
+    "minimatch": "9.0.3",
     "tslib": "^2.3.0",
     "@nx/devkit": "file:../devkit",
     "@nx/js": "file:../js",

--- a/packages/react/src/generators/stories/stories.ts
+++ b/packages/react/src/generators/stories/stories.ts
@@ -18,7 +18,7 @@ import {
   visitNotIgnoredFiles,
 } from '@nx/devkit';
 import { basename, join } from 'path';
-import minimatch = require('minimatch');
+import { minimatch } from 'minimatch';
 import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
 import { nxVersion } from '../../utils/versions';
 

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -28,7 +28,7 @@
     "migrations": "./migrations.json"
   },
   "dependencies": {
-    "minimatch": "3.0.5",
+    "minimatch": "9.0.3",
     "tslib": "^2.3.0",
     "@nx/devkit": "file:../devkit",
     "@nx/js": "file:../js",

--- a/packages/vue/src/generators/stories/stories.ts
+++ b/packages/vue/src/generators/stories/stories.ts
@@ -13,7 +13,7 @@ import {
 import { basename, join } from 'path';
 import { nxVersion } from '../../utils/versions';
 import { createComponentStories } from './lib/component-story';
-import minimatch = require('minimatch');
+import { minimatch } from 'minimatch';
 
 export interface StorybookStoriesSchema {
   project: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -750,8 +750,8 @@ devDependencies:
     specifier: ~2.4.7
     version: 2.4.7(webpack@5.88.0)
   minimatch:
-    specifier: 3.0.5
-    version: 3.0.5
+    specifier: 9.0.3
+    version: 9.0.3
   next-sitemap:
     specifier: ^3.1.10
     version: 3.1.29(@next/env@14.0.4)(next@13.3.4)
@@ -5516,7 +5516,7 @@ packages:
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
       debug: 4.3.4(supports-color@5.5.0)
-      minimatch: 3.0.5
+      minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -17738,7 +17738,7 @@ packages:
       deepmerge: 4.3.1
       fs-extra: 10.1.0
       memfs: 3.5.0
-      minimatch: 3.0.5
+      minimatch: 3.1.2
       node-abort-controller: 3.0.1
       schema-utils: 3.2.0
       semver: 7.5.3
@@ -17761,7 +17761,7 @@ packages:
       deepmerge: 4.3.1
       fs-extra: 10.1.0
       memfs: 3.5.0
-      minimatch: 3.0.5
+      minimatch: 3.1.2
       node-abort-controller: 3.1.1
       schema-utils: 3.2.0
       semver: 7.5.3
@@ -18223,7 +18223,7 @@ packages:
     dependencies:
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.0.5
+      minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
     dev: true
@@ -18244,7 +18244,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.0.5
+      minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
     dev: true
@@ -19748,7 +19748,7 @@ packages:
       async: 3.2.4
       chalk: 4.1.2
       filelist: 1.0.4
-      minimatch: 3.0.5
+      minimatch: 3.1.2
     dev: true
 
   /jasmine-core@2.99.1:
@@ -22580,7 +22580,7 @@ packages:
       array-differ: 3.0.0
       array-union: 2.1.0
       arrify: 2.0.1
-      minimatch: 3.0.5
+      minimatch: 3.1.2
     dev: true
 
   /mute-stream@0.0.8:
@@ -22798,7 +22798,7 @@ packages:
     resolution: {integrity: sha512-tmPX422rYgofd4epzrNoOXiE8XFZYOcCq1vD7MAXCDO+O+zndlA2ztdKKMa+EeuBG5tHETpr4ml4RGgpqDCCAg==}
     engines: {node: '>= 0.10.5'}
     dependencies:
-      minimatch: 3.0.5
+      minimatch: 3.1.2
     dev: true
 
   /node-domexception@1.0.0:
@@ -26366,7 +26366,7 @@ packages:
     engines: {node: '>= 0.8.0'}
     dependencies:
       debug: 2.6.9
-      minimatch: 3.0.5
+      minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -28228,7 +28228,7 @@ packages:
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 7.1.4
-      minimatch: 3.0.5
+      minimatch: 3.1.2
     dev: true
 
   /text-extensions@1.9.0:


### PR DESCRIPTION
Bumps the minimatch version used across packages to get several fixes made in the latest versions.

With this, we specifically address an issue with the tree-aware glob search helper where globstart matching (`**`) was not matching zero path portions (e.g. `**/*.txt` would match `a/foo.txt` but not `foo.txt`).

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
